### PR TITLE
homebrew: update formula to v0.2.0

### DIFF
--- a/Formula/copperline.rb
+++ b/Formula/copperline.rb
@@ -19,8 +19,8 @@
 class Copperline < Formula
   desc "Cycle-driven Amiga emulator (OCS/ECS/AGA) written in Rust"
   homepage "https://copperline.dev/"
-  url "https://github.com/LinuxJedi/Copperline/archive/refs/tags/v0.1.0.tar.gz"
-  sha256 "45d375f3cb499e006c7a4e9998ec13a6fdb2489aacdb727468b221a91cc530bd"
+  url "https://github.com/LinuxJedi/Copperline/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "861307f8d947d64ecf028e10872f79eba960c0362921e3e46f557b9929aa5c9d"
   license "GPL-3.0-or-later"
   head "https://github.com/LinuxJedi/Copperline.git", branch: "main"
 


### PR DESCRIPTION
Updates the Homebrew tap formula to the v0.2.0 release.

- `url` -> `v0.2.0.tar.gz`
- `sha256` -> `861307f8d947d64ecf028e10872f79eba960c0362921e3e46f557b9929aa5c9d` (computed from the published tag tarball)

The `Homebrew formula` workflow's `brew audit --strict --online` verifies the tarball is reachable and the checksum matches, so CI is the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)