### PR TITLE
Add Windows distribution: portable zip + CI/release workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# Static-link the MSVC C runtime on Windows so the release binary and the
+# packaged zip (packaging/windows/build-zip.ps1) run without the Visual C++
+# Redistributable installed. Scoped to the MSVC target, so the macOS and Linux
+# builds are unaffected.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,86 @@
+name: Windows
+
+# Builds the portable Windows zip and uploads it as a workflow artifact on
+# every qualifying change, and attaches it to the GitHub Release when a v* tag
+# is pushed. Building the zip also doubles as the Windows build check: there is
+# no other Windows coverage (the main CI runs on macOS), so the code-path
+# triggers below run the full release build on pull requests too.
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "src/**"
+      - "vendor/**"
+      - "assets/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".cargo/**"
+      - "packaging/windows/**"
+      - ".github/workflows/windows.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "vendor/**"
+      - "assets/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".cargo/**"
+      - "packaging/windows/**"
+      - ".github/workflows/windows.yml"
+  # Manual rebuild. Use this to attach a zip to a release whose tag predates
+  # this workflow (the v* tag tree has no windows.yml, so a tag push cannot
+  # trigger it): run it against a branch that has the source parity you want
+  # (for v0.2.0, main is identical to the tag bar the Homebrew bump) and set
+  # release_tag to push the built zip onto that existing release.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to attach the zip to (e.g. v0.2.0). Leave blank to only upload a workflow artifact."
+        required: false
+        default: ""
+
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Windows zip
+    runs-on: windows-latest
+    # Needed only by the release-attach step on v* tags.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release zip
+        shell: pwsh
+        run: packaging/windows/build-zip.ps1
+      - name: Locate artifact
+        id: artifact
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem Copperline-*-win-x64.zip | Select-Object -First 1
+          "path=$($zip.Name)" >> $env:GITHUB_OUTPUT
+      - uses: actions/upload-artifact@v4
+        with:
+          name: copperline-windows
+          path: ${{ steps.artifact.outputs.path }}
+          if-no-files-found: error
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.artifact.outputs.path }}
+      - name: Attach to existing release (manual run)
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        # --clobber so a re-run replaces the asset instead of failing on a
+        # name clash.
+        run: gh release upload "${{ inputs.release_tag }}" "${{ steps.artifact.outputs.path }}" --clobber

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,6 +96,23 @@ build one by hand on a Linux host:
 ./packaging/appimage/build-appimage.sh
 ```
 
+## Windows
+
+Windows distribution is a portable zip (`packaging/windows/`). The `Windows`
+workflow builds it on `windows-latest` and, on a `v*` tag, attaches
+`Copperline-X.Y.Z-win-x64.zip` to the GitHub Release automatically. The same
+workflow runs the full release build on pull requests that touch the code, so
+it doubles as the Windows build check (the main CI runs on macOS only).
+
+The zip is self-contained: the MSVC C runtime is linked statically (see
+`.cargo/config.toml`) so it needs no Visual C++ Redistributable, and the
+bundled AROS ROM sits in a sibling `aros\` folder that `romsearch.rs` probes
+first. To build one by hand on a Windows host:
+
+```pwsh
+packaging/windows/build-zip.ps1
+```
+
 ## Crate packaging
 
 `cargo package --no-verify --offline` can be used to inspect the source

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -1,0 +1,33 @@
+Copperline - portable Windows build
+====================================
+
+Copperline is a cycle-driven Amiga emulator (OCS/ECS/AGA).
+
+Running
+-------
+This is a portable build: no installation is required. Unzip it anywhere and
+run copperline.exe. It needs no administrator rights and no Visual C++
+Redistributable (the C runtime is linked statically into the executable).
+
+On first launch Windows SmartScreen may show "Windows protected your PC"
+because the executable is not code-signed. Click "More info", then
+"Run anyway" to start it.
+
+Boot ROM
+--------
+With no ROM of your own, Copperline boots the bundled AROS open-source
+Kickstart replacement, found in the aros\ folder next to the executable. AROS
+is freely redistributable; see aros\LICENSE. To use a real Kickstart instead,
+point a config file at it, or load it at runtime from the menu
+(Load Kickstart ROM...).
+
+Configuration
+-------------
+copperline.example.toml is a starting point. Copy it, edit the paths to your
+own Kickstart ROM and disk/hard-disk images, and launch with:
+
+    copperline.exe --config your-config.toml
+
+Run "copperline.exe --help" for the full command-line surface.
+
+Copperline is licensed under GPL-3.0-or-later; see LICENSE.txt.

--- a/packaging/windows/build-zip.ps1
+++ b/packaging/windows/build-zip.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+# Build a Copperline Windows release zip: a portable, no-install bundle that
+# runs without administrator rights. Run on a Windows host (or CI); see
+# .github/workflows/windows.yml.
+#
+# What it does:
+#   1. Builds the release binary for x86_64-pc-windows-msvc with the pinned
+#      dependency graph. The CRT is statically linked (see .cargo/config.toml),
+#      so the bundle needs no Visual C++ Redistributable.
+#   2. Stages a folder holding copperline.exe with a sibling aros\ directory,
+#      which is the first location romsearch.rs probes, so the bundled AROS
+#      ROM is found with no configuration.
+#   3. Zips the folder into Copperline-<version>-win-x64.zip, mirroring the
+#      AppImage/Homebrew version naming so release assets are self-describing.
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $here "..\..")).Path
+Set-Location $repoRoot
+
+$target = "x86_64-pc-windows-msvc"
+
+# Version from Cargo.toml, matching the AppImage/Homebrew naming convention.
+$version = (Select-String -Path "Cargo.toml" -Pattern '^version\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+$stageName = "Copperline-$version-win-x64"
+$stage = Join-Path $repoRoot $stageName
+$zipPath = Join-Path $repoRoot "$stageName.zip"
+
+Write-Host "==> Building release binary ($target)"
+cargo build --release --locked --target $target
+if ($LASTEXITCODE -ne 0) { throw "cargo build failed" }
+
+Write-Host "==> Staging $stageName"
+if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+$arosDir = Join-Path $stage "aros"
+New-Item -ItemType Directory -Force -Path $arosDir | Out-Null
+
+Copy-Item "target\$target\release\copperline.exe" (Join-Path $stage "copperline.exe")
+
+# Bundled AROS open-source Kickstart replacement (the default boot ROM).
+# romsearch.rs probes a sibling aros\ next to the executable first. Ship the
+# license/readme/acknowledgements next to the ROM halves as redistribution
+# requires.
+foreach ($f in @(
+    "aros-amiga-m68k-rom.bin",
+    "aros-amiga-m68k-ext.bin",
+    "LICENSE",
+    "README.md",
+    "ACKNOWLEDGEMENTS")) {
+    Copy-Item "assets\aros\$f" (Join-Path $arosDir $f)
+}
+
+# Top-level docs and an example config to get users started.
+Copy-Item "copperline.example.toml" $stage
+Copy-Item "LICENSE" (Join-Path $stage "LICENSE.txt")
+Copy-Item "packaging\windows\README.txt" (Join-Path $stage "README.txt")
+
+Write-Host "==> Zipping $zipPath"
+if (Test-Path $zipPath) { Remove-Item -Force $zipPath }
+Compress-Archive -Path $stage -DestinationPath $zipPath -CompressionLevel Optimal
+
+Write-Host "==> Built $stageName.zip"


### PR DESCRIPTION
Ships Windows as a portable, no-install zip, mirroring the existing AppImage channel.

## What's here
- **`packaging/windows/build-zip.ps1`** - builds the release binary for `x86_64-pc-windows-msvc` and stages `copperline.exe` with a sibling `aros/` folder (the first location `romsearch.rs` probes, so the bundled AROS ROM is found with no configuration), plus `copperline.example.toml`, the license, and a bundled `README.txt` covering the SmartScreen prompt and supplying your own Kickstart.
- **`.cargo/config.toml`** - statically links the MSVC CRT, scoped to the MSVC target so macOS/Linux builds are unaffected, so the zip needs no Visual C++ Redistributable.
- **`.github/workflows/windows.yml`** - builds the zip on every code-path change (doubling as the Windows build check, since the main CI runs on macOS), uploads it as an artifact, and attaches it to the GitHub Release on a `v*` tag.
- **`RELEASE.md`** - documents the Windows channel.

## Back-filling the 0.2.0 release
The `v0.2.0` tag predates this workflow, so a tag push can't trigger it. The `workflow_dispatch` trigger handles this: after merge, run **Windows** against `main` with `release_tag = v0.2.0`. `main`'s source is identical to the tag (only the Homebrew bump sits in between, which doesn't touch the binary), so the rebuilt zip is faithful to the release.

## Notes
- The binary is unsigned, so first launch shows a SmartScreen prompt; the bundled `README.txt` explains it. Code signing can be added later.
- YAML validated; the actual Windows build is first exercised by this PR's CI run.