### PR TITLE
Fix TurboTomato: float unmapped reads + ECS DIWHIGH revert

### DIFF
--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -44,6 +44,17 @@ cannot change at runtime (see [](../internals/architecture)).
   is active, with key registers on each line. Capped at 200,000 lines per
   run as a flood guard.
 
+`COPPERLINE_DBG_TRACE_FULL=1`
+: Like `TRACE`, but each line is a fixed-width, all-hex record of the entire
+  register file (`D0`-`D7`/`A0`-`A7`) and the CCR, prefixed `ft`. Intended for
+  diffing Copperline's instruction stream against a reference 68000 (e.g.
+  vAmiga) to isolate a mis-emulated instruction. Implies `TRACE`.
+
+`COPPERLINE_DBG_TRACE_LO=ADDR` / `COPPERLINE_DBG_TRACE_HI=ADDR`
+: Restrict the trace to instructions whose PC is in `[LO, HI]`. This isolates a
+  single routine (e.g. a depacker loop) and, by excluding interrupt handlers,
+  yields a contiguous deterministic stream that lines up across emulators.
+
 `COPPERLINE_DBG_RAMDUMP=ADDR:LEN:FILE`
 : One-shot memory dump the first time the debugger activates: LEN bytes
   from hex address ADDR are written to FILE, read through the CPU's own

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -125,6 +125,17 @@ The CPU-visible memory map:
 MMIO stubs cover every "gap" region DiagROM probes during fast-RAM
 detection, so probing software sees bus-like behaviour everywhere.
 
+A CPU read of an address no region claims floats to the last value the
+chip data bus carried (`Bus.data_bus`, fed by the live display and audio
+DMA fetches), as on real Agnus-arbitrated hardware -- not a fixed all-ones
+pattern; on a blank screen that value is 0. The constant matters: software
+that chases a pointer off into unmapped space (e.g. a filesystem walking a
+corrupted buffer-cache chain) can loop forever on a fixed value, where the
+ever-changing floating value lets the chase wander to a zero terminator as
+on silicon. Device windows that decode their own floating bus keep their
+own values -- e.g. the A2091 board's unpopulated XT-interface bytes read
+`$FF` from its own model, not the chip data bus.
+
 ## Determinism and the host boundary
 
 The core's only inputs are the config, the loaded images, and the
@@ -135,6 +146,12 @@ scheduling only. This is what makes `--screenshot-after` runs exactly
 reproducible, lets the headless debugger replay a failure
 deterministically, and makes [save states](savestate) exact: a restored
 run is byte-identical to one that was never interrupted.
+
+The one host-clock value that reaches emulated state is the battery RTC: a
+guest that reads it (`$DC0000`) sees the host date and time, so RTC reads
+are not reproducible across wall-clock runs. `COPPERLINE_RTC_FIXED_SECS=`
+*unix-seconds* pins the clock to a fixed value, which is what makes
+differential traces against another emulator line up.
 
 ### Input scripting and recording (`inputrec.rs`)
 

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -80,6 +80,13 @@ HAM8, the BPLCON4 BPLAM pixel-index XOR mask, and the OSPRM/ESPRM sprite
 palette banks. Denise state is not rendered live -- writes become beam
 events that the [video pipeline](video) replays.
 
+The ECS DIWHIGH high bits only stay in force until the next DIWSTRT or
+DIWSTOP write, which re-arms the OCS-implicit high bits derived from the
+low DIWSTRT/DIWSTOP values. Software that programmed a wide window through
+DIWHIGH and then touches DIWSTRT/DIWSTOP falls back to the implicit
+window, so the replay must drop the stale DIWHIGH on those writes rather
+than hold it.
+
 ## CIA (`cia.rs`)
 
 A small 8520 model used for both CIAs: I/O ports, the

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -580,6 +580,13 @@ pub struct Bus {
     pending_device_tick: AgnusTick,
     audio_pending_cck: u32,
     last_chip_bus_owner: ChipBusOwner,
+    /// Last 16-bit value driven on the chip data bus by a real access (display/
+    /// audio/sprite DMA, or a mapped CPU read). CPU reads of unmapped addresses
+    /// float to this, like the Agnus-arbitrated chip bus on real hardware, which
+    /// is dominated by display DMA (often 0 on a blank screen) -- not a fixed
+    /// all-ones pattern. Transient; re-established by DMA after a state load.
+    #[serde(skip)]
+    pub(crate) data_bus: u16,
     device_clock: DeviceClock,
     emulated_cck: u64,
     emulated_frames: u64,
@@ -1455,6 +1462,7 @@ impl Bus {
             pending_device_tick: AgnusTick::default(),
             audio_pending_cck: 0,
             last_chip_bus_owner: ChipBusOwner::Idle,
+            data_bus: 0,
             device_clock: DeviceClock::default(),
             emulated_cck: 0,
             emulated_frames: 0,
@@ -4890,6 +4898,7 @@ impl Bus {
             return;
         };
         let word = self.read_chip_word_for_audio_dma(request.address);
+        self.data_bus = word;
         let irq = self.paula.grant_audio_dma(channel, word);
         self.paula.latch_interrupt_sources(irq);
     }
@@ -6743,6 +6752,7 @@ impl Bus {
                         let word_idx = word_base + w;
                         let addr = self.display_dma_bplpt[plane] & addr_mask;
                         let fetched = read_chip_word_wrapping(&self.mem.chip_ram, addr);
+                        self.data_bus = fetched;
                         if self.capture_bitplane_fetch_word(
                             fb_y,
                             display_planes,
@@ -6793,6 +6803,7 @@ impl Bus {
                         let word_idx = word_base + w;
                         let addr = self.display_dma_bplpt[plane] & addr_mask;
                         let fetched = read_chip_word_wrapping(&self.mem.chip_ram, addr);
+                        self.data_bus = fetched;
                         if self.capture_bitplane_fetch_word(
                             fb_y,
                             block_display_planes,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -393,28 +393,64 @@ impl M68kMachine {
         self.maybe_dump_ram(secs);
         let pc = self.cpu.pc;
 
-        if self.dbg.as_ref().is_some_and(|d| d.trace) {
+        if let Some((trace_full, lo, hi)) = self
+            .dbg
+            .as_ref()
+            .filter(|d| d.trace)
+            .map(|d| (d.trace_full, d.trace_lo, d.trace_hi))
+        {
+            let in_window = pc >= lo && pc <= hi;
             let trace_lines = self.dbg.as_ref().map(|d| d.trace_lines).unwrap_or(0);
-            if trace_lines < DEBUG_TRACE_LINE_CAP {
+            if in_window && trace_lines < DEBUG_TRACE_LINE_CAP {
                 let bus = &self.bus.bus;
                 let (text, _len) = crate::disasm::disassemble(
                     |addr| bus.peek_word_any(addr),
                     pc,
                     self.cpu.cpu_type,
                 );
-                log::info!(
-                    "dbg trace t={secs:.5} pc={pc:#010X} {text:<30} \
-                     d0={:#X} d1={:#X} d2={:#X} d7={:#X} a0={:#X} a1={:#X} a2={:#X} a4={:#X} a7={:#X}",
-                    self.cpu.d(0),
-                    self.cpu.d(1),
-                    self.cpu.d(2),
-                    self.cpu.d(7),
-                    self.cpu.a(0),
-                    self.cpu.a(1),
-                    self.cpu.a(2),
-                    self.cpu.a(4),
-                    self.cpu.a(7),
-                );
+                if trace_full {
+                    // COPPERLINE_DBG_TRACE_FULL: a fixed-width, all-hex record of
+                    // the full register file and CCR, for line-by-line diffing
+                    // against a reference 68000 trace. `op` is the raw opcode word.
+                    let op = self.bus.bus.peek_word_any(pc);
+                    let d: Vec<String> = (0..8).map(|i| format!("{:08X}", self.cpu.d(i))).collect();
+                    let a: Vec<String> = (0..8).map(|i| format!("{:08X}", self.cpu.a(i))).collect();
+                    log::info!(
+                        "ft pc={pc:06X} op={op:04X} ccr={:02X} \
+                         d={} {} {} {} {} {} {} {} a={} {} {} {} {} {} {} {} | {text}",
+                        self.cpu.get_ccr(),
+                        d[0],
+                        d[1],
+                        d[2],
+                        d[3],
+                        d[4],
+                        d[5],
+                        d[6],
+                        d[7],
+                        a[0],
+                        a[1],
+                        a[2],
+                        a[3],
+                        a[4],
+                        a[5],
+                        a[6],
+                        a[7],
+                    );
+                } else {
+                    log::info!(
+                        "dbg trace t={secs:.5} pc={pc:#010X} {text:<30} \
+                         d0={:#X} d1={:#X} d2={:#X} d7={:#X} a0={:#X} a1={:#X} a2={:#X} a4={:#X} a7={:#X}",
+                        self.cpu.d(0),
+                        self.cpu.d(1),
+                        self.cpu.d(2),
+                        self.cpu.d(7),
+                        self.cpu.a(0),
+                        self.cpu.a(1),
+                        self.cpu.a(2),
+                        self.cpu.a(4),
+                        self.cpu.a(7),
+                    );
+                }
                 if let Some(d) = self.dbg.as_mut() {
                     d.trace_lines += 1;
                 }
@@ -1630,7 +1666,17 @@ impl CpuBus {
             log::info!("float rd {addr:#08X}");
         }
         self.bus.cpu_slow_external_access(1);
-        floating_read(size)
+        // Undriven (unmapped) read: float to the last value the chip data bus
+        // carried (display/audio DMA), as on the Agnus-arbitrated chip bus --
+        // not a fixed all-ones pattern. `size` is always 1 here (size>1 recurses
+        // to byte reads); a 68000 byte read takes the high data-bus byte at even
+        // addresses, the low byte at odd.
+        let data_bus = self.bus.data_bus;
+        if addr & 1 == 0 {
+            u32::from(data_bus >> 8)
+        } else {
+            u32::from(data_bus & 0xFF)
+        }
     }
 
     fn write_sized(&mut self, address: u32, size: usize, value: u32) {
@@ -2516,7 +2562,13 @@ mod tests {
     }
 
     #[test]
-    fn unmapped_cpu_reads_float_high() {
+    fn unmapped_cpu_reads_float_to_chip_data_bus() {
+        // An unmapped CPU read does not return a fixed all-ones pattern; it
+        // floats to the last value the Agnus-arbitrated chip data bus carried
+        // (display/audio DMA), exactly as on real hardware. Returning a constant
+        // can close pathological pointer-chase loops (a program walking a
+        // corrupted list off into unmapped space) that terminate on real silicon
+        // because the floating value keeps changing.
         let mut bus = CpuBus {
             bus: test_bus(reset_rom(0, 0)),
             address_mask: ADDRESS_MASK_24BIT,
@@ -2526,10 +2578,17 @@ mod tests {
             dcache: None,
         };
         let addr = SLOW_RAM_BASE as u32 + 64 * 1024;
-        bus.write_long(addr, 0);
-        assert_eq!(bus.read_byte(addr), 0xFF);
-        assert_eq!(bus.read_word(addr), 0xFFFF);
-        assert_eq!(bus.read_long(addr), 0xFFFF_FFFF);
+        // With nothing yet driven, the bus rests at 0.
+        bus.write_long(addr, 0x1234_5678);
+        assert_eq!(bus.read_long(addr), 0);
+        // Once a real access latches a value, undriven reads float to it; a
+        // 68000 byte read takes the high data-bus byte at even addresses and the
+        // low byte at odd.
+        bus.bus.data_bus = 0xA53C;
+        assert_eq!(bus.read_byte(addr), 0xA5);
+        assert_eq!(bus.read_byte(addr + 1), 0x3C);
+        assert_eq!(bus.read_word(addr), 0xA53C);
+        assert_eq!(bus.read_long(addr), 0xA53C_A53C);
     }
 
     #[test]

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -18,6 +18,13 @@
 //! COPPERLINE_DBG_DUMP    = comma-separated "ADDR:WORDS" memory
 //!                      regions hexdumped on every hit      e.g. "C09580:4"
 //! COPPERLINE_DBG_TRACE   = set to log every executed instruction in the window
+//! COPPERLINE_DBG_TRACE_FULL = like TRACE, but each line is a fixed-width all-hex
+//!                      record of the whole register file (D0-D7/A0-A7) and CCR,
+//!                      for diffing against a reference 68000 (e.g. vAmiga). Implies
+//!                      TRACE. Format: "ft pc=.. op=.. ccr=.. d=.. a=.. | <disasm>"
+//! COPPERLINE_DBG_TRACE_LO/HI = only trace instructions with LO <= pc <= HI, to
+//!                      isolate one routine (e.g. a depacker loop) from the rest
+//!                      of the system     e.g. LO="DE488" HI="DE578"
 //! COPPERLINE_DBG_AFTER   = emulated seconds before which the debugger is inert
 //! COPPERLINE_DBG_UNTIL   = emulated seconds after which the debugger is inert
 //! COPPERLINE_DBG_MAXHITS = stop reporting after this many hits (default 200)
@@ -369,6 +376,15 @@ pub struct Debugger {
     /// `(addr, words)` regions hexdumped (as 16-bit words) on each hit.
     pub dumps: Vec<(u32, u32)>,
     pub trace: bool,
+    /// COPPERLINE_DBG_TRACE_FULL: emit every CPU register (D0-D7/A0-A7) plus the
+    /// CCR flags on each traced instruction, for differential comparison against
+    /// a reference 68000 (vAmiga). Implies `trace`.
+    pub trace_full: bool,
+    /// COPPERLINE_DBG_TRACE_LO/HI: when set, only trace instructions whose PC is
+    /// in `[lo, hi]`. Keeps a focused routine (e.g. a depacker loop) out of the
+    /// noise of the rest of the system. `lo`=0/`hi`=u32::MAX means no filter.
+    pub trace_lo: u32,
+    pub trace_hi: u32,
     pub after_secs: f64,
     pub until_secs: f64,
     pub max_hits: u64,
@@ -392,7 +408,10 @@ impl Debugger {
     pub fn from_env() -> Option<Self> {
         let breakpoints = parse_addr_list("COPPERLINE_DBG_BREAK");
         let watches = parse_watch_list("COPPERLINE_DBG_WATCH");
-        let trace = crate::envcfg::flag("COPPERLINE_DBG_TRACE");
+        let trace_full = crate::envcfg::flag("COPPERLINE_DBG_TRACE_FULL");
+        let trace = trace_full || crate::envcfg::flag("COPPERLINE_DBG_TRACE");
+        let trace_lo = parse_hex_var("COPPERLINE_DBG_TRACE_LO").unwrap_or(0);
+        let trace_hi = parse_hex_var("COPPERLINE_DBG_TRACE_HI").unwrap_or(u32::MAX);
         let copper_dump = parse_copper_dump("COPPERLINE_DBG_COPPER");
         let ram_dump = parse_ram_dump("COPPERLINE_DBG_RAMDUMP");
         if breakpoints.is_empty()
@@ -412,6 +431,9 @@ impl Debugger {
             watches,
             dumps,
             trace,
+            trace_full,
+            trace_lo,
+            trace_hi,
             after_secs: parse_f64("COPPERLINE_DBG_AFTER").unwrap_or(0.0),
             until_secs: parse_f64("COPPERLINE_DBG_UNTIL").unwrap_or(f64::INFINITY),
             max_hits: parse_u64("COPPERLINE_DBG_MAXHITS").unwrap_or(200),
@@ -481,6 +503,10 @@ fn parse_addr_list(var: &str) -> Vec<u32> {
     crate::envcfg::var(var)
         .map(|v| v.split(',').filter_map(parse_hex).collect())
         .unwrap_or_default()
+}
+
+fn parse_hex_var(var: &str) -> Option<u32> {
+    crate::envcfg::var(var).and_then(|v| parse_hex(v.trim()))
 }
 
 fn parse_watch_list(var: &str) -> Vec<Watch> {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -93,6 +93,15 @@ impl Msm6242Rtc {
         if let Some(time) = self.test_time {
             return RtcDateTime::from_system_time(time);
         }
+        // COPPERLINE_RTC_FIXED_SECS pins the clock to a fixed Unix-seconds
+        // value, making RTC reads deterministic across runs (otherwise the
+        // host wall-clock differs run-to-run, which pollutes differential
+        // traces with spurious timestamp divergences).
+        if let Some(secs) = crate::envcfg::var("COPPERLINE_RTC_FIXED_SECS")
+            .and_then(|s| s.trim().parse::<u64>().ok())
+        {
+            return RtcDateTime::from_unix_seconds(secs);
+        }
         RtcDateTime::from_system_time(SystemTime::now())
     }
 

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -2349,8 +2349,19 @@ fn apply_move(state: &mut RenderState, off: u16, val: u16) {
             state.clxcon2 = 0;
         }
         0x10E => state.clxcon2 = val & 0x0FFF,
-        0x08E => state.diwstrt = val,
-        0x090 => state.diwstop = val,
+        // Writing DIWSTRT/DIWSTOP re-arms the OCS-implicit high bits: an ECS
+        // DIWHIGH value only applies until the next DIWSTRT/DIWSTOP write (the
+        // Agnus side clears its diwhigh_written flag here for the same reason).
+        // Without this, a stale DIWHIGH (e.g. $00FF, pushing V-start off-screen)
+        // keeps the display window empty even after the window is reprogrammed.
+        0x08E => {
+            state.diwstrt = val;
+            state.diwhigh = DiwHigh::ocs_implicit();
+        }
+        0x090 => {
+            state.diwstop = val;
+            state.diwhigh = DiwHigh::ocs_implicit();
+        }
         0x1E4 => state.diwhigh = DiwHigh::ecs_explicit(val),
         0x092 => state.ddfstrt = val,
         0x094 => state.ddfstop = val,
@@ -5802,6 +5813,24 @@ mod tests {
         assert_eq!(state.diw_h_start(), 0x00FC);
         assert_eq!(state.diw_v_stop(), 0x007F);
         assert_eq!(state.diw_h_stop(), 0x0001);
+    }
+
+    #[test]
+    fn display_window_diwstrt_diwstop_write_reverts_diwhigh_to_implicit() {
+        // An ECS DIWHIGH value only applies until the next DIWSTRT/DIWSTOP
+        // write, which re-arms the OCS-implicit high bits. A stale DIWHIGH
+        // must not keep shrinking the window after it is reprogrammed --
+        // TurboTomato's ECS title rendered black because $00FF stayed latched
+        // and pushed the vertical window start off-screen.
+        let mut state = blank_state();
+        apply_move(&mut state, 0x1E4, 0x00FF);
+        assert_eq!(state.diwhigh, DiwHigh::ecs_explicit(0x00FF));
+        apply_move(&mut state, 0x08E, 0x2C81);
+        assert_eq!(state.diwhigh, DiwHigh::ocs_implicit());
+
+        apply_move(&mut state, 0x1E4, 0x00FF);
+        apply_move(&mut state, 0x090, 0x2CC1);
+        assert_eq!(state.diwhigh, DiwHigh::ocs_implicit());
     }
 
     #[test]


### PR DESCRIPTION
Fixes the TurboTomato (KS2.05 / A500+, 2 MB) disk hanging before its
title screen, in two independent parts. With both, the game reaches its
title on both OCS and ECS Denise.

## 1. Float unmapped CPU reads to the chip data bus

Unmapped/undriven CPU reads returned a fixed all-ones pattern. Real
Agnus-arbitrated hardware floats an undriven read to the last value
driven on the chip bus -- dominated by display/audio DMA, often 0 on a
blank screen -- which keeps changing every access. A constant can close
a pathological pointer-chase loop: a program that walks a corrupted
linked list off into unmapped space loops forever, where real hardware
wanders and quickly hits a terminator.

Adds a 16-bit chip data-bus latch (`Bus.data_bus`), fed from the live
bitplane and audio DMA fetches; unmapped CPU reads now float to it. The
latch is serde-skipped (transient, rebuilt by DMA), so no STATE_VERSION
bump.

The game over-draws an in-game bitmap and corrupts a FastFileSystem
buffer-cache hash link; the filesystem's later chain walk ran off into
unmapped memory and looped forever on the all-ones value. KS2.05 still
boots (memory sizing relies on unmapped reads not matching the written
pattern), State of the Art renders; the float-high unit test is updated
to the data-bus model.

Also adds debug tooling used to diagnose this: `COPPERLINE_DBG_TRACE_FULL`
(full register + CCR instruction trace) with `COPPERLINE_DBG_TRACE_LO/HI`
PC filtering, and `COPPERLINE_RTC_FIXED_SECS` for a deterministic RTC.

## 2. ECS: DIWSTRT/DIWSTOP write reverts DIWHIGH to OCS-implicit (renderer)

On ECS the explicit DIWHIGH display-window high bits only apply until the
next DIWSTRT/DIWSTOP write, which re-arms the OCS-implicit high bits. The
Agnus side already models this; the replay renderer's `apply_move()`
latched `DiwHigh::EcsExplicit` on a DIWHIGH write and never reverted it.

A program that writes DIWHIGH once (e.g. `$00FF`) and later reprograms
the window via DIWSTRT/DIWSTOP kept the stale high bits, pushing the
vertical window start off-screen -- the renderer produced an empty
(black) display while the beam counters stayed correct. TurboTomato's
ECS-Denise title rendered pure black for this reason. OCS Denise is
unaffected (it ignores DIWHIGH writes). Includes a renderer regression
test.

## Verification
- TurboTomato reaches its title on OCS and ECS Denise.
- KS2.05 boots; State of the Art renders.
- 977 unit tests pass; `cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)