### PR TITLE
Add keyboard joystick input mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ positional argument, or point at a config file:
 Essential shortcuts use `Cmd` on macOS and `Alt` on Linux/Windows:
 `Cmd+Q` / `Alt+Q` closes the window, `Esc` passes through to the Amiga (or
 closes an open menu/window), `Cmd+S` / `Alt+S` saves a screenshot, and
-`Cmd+B` / `Alt+B` opens the debugger. The status bar, pop-up menu, overlay
-windows (debugger, gamepad calibration, save/load state, input recording),
-and the full shortcut list are documented in the
+`Cmd+B` / `Alt+B` opens the debugger. `Cmd+J` / `Alt+J` cycles joystick
+input between automatic selection, keyboard emulation, and gamepad-only.
+The status bar, pop-up menu, overlay windows (debugger, gamepad
+calibration, save/load state, input recording), and the full shortcut list
+are documented in the
 [user guide](docs/guide/ui.md).
 
 ## Configuration
@@ -186,7 +188,7 @@ release needs resolved first. Release steps for every channel are in
 | Denise BPLCON / COLORxx | Stored and replayed by beam position. |
 | Bitplane renderer | OCS lo-res or hi-res; reads chip RAM via BPLxPT; honours modulos and beam-timed BPLCON1 scroll; EHB, HAM, dual playfield, and CLXDAT collisions. Completed frames render on a worker thread by default; `COPPERLINE_THREADED_RENDER=0` forces synchronous rendering. |
 | Display window | winit 0.30 + pixels 0.17 surface; 716x285 framebuffer presented at 4:3 (716x537) plus a 44-pixel status bar with power/disk controls. |
-| Keyboard / mouse / gamepad | Host keyboard/mouse mapped to Amiga input paths; key down and key up events go through CIA-A SDR/ICR with acknowledge + KDAT handshake backpressure and keyboard-MCU pacing; mouse deltas feed JOY0DAT; `Cmd+G` on macOS or `Alt+G` on Linux/Windows toggles host mouse capture; a USB gamepad (gilrs) drives the port-2 digital joystick (JOY1DAT directions, /FIR1 fire, POT1Y button 2); Ctrl+Ami+Ami resets. |
+| Keyboard / mouse / gamepad | Host keyboard/mouse mapped to Amiga input paths; key down and key up events go through CIA-A SDR/ICR with acknowledge + KDAT handshake backpressure and keyboard-MCU pacing; mouse deltas feed JOY0DAT; `Cmd+G` on macOS or `Alt+G` on Linux/Windows toggles host mouse capture; a USB gamepad (gilrs) or keyboard joystick emulation drives the port-2 digital joystick (JOY1DAT directions, /FIR1 fire, POT1Y button 2); Ctrl+Ami+Ami resets. |
 | OCS sprites | 8 DMA/manual 16-pixel sprites, attached sprites, composited over bitplanes with playfield priority. |
 | Chip bus arbitration | Per-colour-clock OCS slot ownership for refresh, display DMA, sprites, disk, audio, Copper, blitter, and CPU chip/custom accesses, with CPU wait states. |
 | ECS | ECS Agnus revisions (8372A/8375) and ECS Denise (8373): up to 2M chip RAM, DIWHIGH, BEAMCON0, SuperHires, ECS blitter (BLTSIZV/BLTSIZH), programmable geometry. |

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -19,6 +19,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+D` | `Alt+D` | Swap to the next disk in a drive's configured playlist |
 | `Cmd+G` | `Alt+G` | Capture / release the host mouse (clicking the display also captures) |
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
+| `Cmd+J` | `Alt+J` | Cycle joystick input mode: auto, keyboard, gamepad |
 | `Esc` | `Esc` | Close an open menu or overlay window; otherwise passed through to the Amiga |
 | `Ctrl+Amiga+Amiga` | `Ctrl+Amiga+Amiga` | Keyboard reset (warm reboot) |
 
@@ -77,6 +78,8 @@ Amiga; `Esc` closes it.
   pauses the machine and opens the five-tab debugger; see
   [](../debugger/window).
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
+- **Joystick Input** (also `Cmd+J` / `Alt+J`): cycles between automatic
+  selection, keyboard joystick emulation, and gamepad-only mode.
 - **Warp Speed**: runs the emulator unpaced, as fast as the host allows.
   Toggling back re-anchors real-time pacing cleanly.
 - **Record Video** (also `Cmd+R` / `Alt+R`): starts a video-with-audio
@@ -199,6 +202,24 @@ through JOY1DAT, fire through /FIR1, and a second button through
 POT1Y/POTGOR. On a CD32 machine the pad speaks the CD32 serial button
 protocol instead, including the red/blue/green/yellow and transport
 buttons. Mouse and gamepad coexist because they use different ports.
+
+If no calibrated gamepad is connected, Copperline can emulate the port-2
+joystick from the host keyboard. The default joystick input mode is
+**auto**: a calibrated USB gamepad is used when present, otherwise the
+keyboard mapping is active. Use the menu's **Joystick Input** item, or
+`Cmd+J` on macOS / `Alt+J` on Linux and Windows, to cycle through:
+
+- **auto**: gamepad when available, keyboard fallback otherwise.
+- **keyboard**: always use the keyboard mapping and ignore live gamepad
+  polling.
+- **gamepad**: use only a calibrated gamepad; keyboard keys pass through
+  to the Amiga keyboard.
+
+Keyboard joystick mode uses the FS-UAE-compatible mapping: cursor keys for
+directions, and Right Ctrl or Right Alt for fire. For CD32 pad buttons,
+`C` is red/fire, `X` is blue, `D` is green, `S` is yellow, Return is
+play/pause, `Z` is rewind, and `A` is forward. While keyboard joystick mode
+owns these keys, they are not sent to the Amiga keyboard.
 
 ## Gamepad calibration
 

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -126,6 +126,26 @@ feed the JOY0DAT quadrature counters. Gamepads are read through raw
 [](../guide/ui); on CD32 machines the pad output is serialized through
 the CD32 pad protocol instead of the plain digital joystick lines.
 
+The window layer has one host-source policy for the emulated port-2
+joystick/CD32 pad: auto, keyboard, or gamepad. Auto is the default. It
+polls the calibrated gamepad first and, when no usable pad state is
+available, resolves the keyboard joystick state instead. Keyboard mode
+skips gamepad polling for port-2 input; gamepad mode disables keyboard
+joystick capture so the mapped keys take the normal Amiga keyboard path.
+All three sources ultimately call the same `InputState::set_joystick_port2`
+and `set_cd32_buttons_port2` helpers, so JOY1DAT, /FIR1, POT1Y/POTGOR, and
+the CD32 serial bits remain hardware-derived.
+
+Keyboard joystick emulation is deliberately a host input source, not a
+guest-keyboard behaviour. When active, the winit key handler consumes the
+mapped host keys before rawkey translation: cursor keys drive directions,
+Right Ctrl/Right Alt drive fire, and the CD32 extras are C/X/D/S/Return/Z/A.
+Each alias is tracked independently before resolving to a single joystick
+state, so releasing one fire alias does not clear fire while another alias
+is still held. Releases for keys already captured as joystick controls are
+also swallowed if the source mode changes before key-up, preventing stray
+Amiga rawkey releases.
+
 ## Audio output (`audio.rs`)
 
 `AudioSink` abstracts the host boundary: a cpal live sink, a WAV-file sink

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -9,8 +9,8 @@
 //! (register snapshots, disassembly text) the panels render.
 
 use super::window::{
-    draw_rect_bevel, fill_rect, fill_rect_blend, rgba, scale_rect, Rect, BUTTON_EDGE_DARK,
-    BUTTON_EDGE_LIGHT, BUTTON_FACE, BUTTON_FACE_HOVER,
+    draw_rect_bevel, fill_rect, fill_rect_blend, rgba, scale_rect, JoystickInputMode, Rect,
+    BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE, BUTTON_FACE_HOVER,
 };
 use super::{font, FB_WIDTH, HOST_SHORTCUT_MODIFIER_LABEL, PRESENT_HEIGHT};
 
@@ -55,6 +55,7 @@ pub enum MenuItem {
     Shortcuts,
     Calibration,
     Debugger,
+    JoystickInput,
     Warp,
     Record,
     RecordInput,
@@ -63,9 +64,10 @@ pub enum MenuItem {
     LoadRom,
 }
 
-pub const MENU_ITEMS: [MenuItem; 10] = [
+pub const MENU_ITEMS: [MenuItem; 11] = [
     MenuItem::Debugger,
     MenuItem::Calibration,
+    MenuItem::JoystickInput,
     MenuItem::Warp,
     MenuItem::Record,
     MenuItem::RecordInput,
@@ -81,21 +83,23 @@ fn menu_item_label(
     warp: bool,
     recording: bool,
     input_recording: bool,
-) -> &'static str {
+    joystick_input_mode: JoystickInputMode,
+) -> String {
     match item {
-        MenuItem::About => "About...",
-        MenuItem::Shortcuts => "Keyboard Shortcuts...",
-        MenuItem::Calibration => "Calibrate Gamepad...",
-        MenuItem::Debugger => "Debugger...",
-        MenuItem::Warp if warp => "Warp Speed      [on]",
-        MenuItem::Warp => "Warp Speed     [off]",
-        MenuItem::Record if recording => "Stop Video Recording",
-        MenuItem::Record => "Record Video",
-        MenuItem::RecordInput if input_recording => "Stop Input Recording",
-        MenuItem::RecordInput => "Record Input",
-        MenuItem::SaveState => "Save State",
-        MenuItem::LoadState => "Load State...",
-        MenuItem::LoadRom => "Load Kickstart ROM...",
+        MenuItem::About => "About...".to_string(),
+        MenuItem::Shortcuts => "Keyboard Shortcuts...".to_string(),
+        MenuItem::Calibration => "Calibrate Gamepad...".to_string(),
+        MenuItem::Debugger => "Debugger...".to_string(),
+        MenuItem::JoystickInput => format!("Joystick Input  [{}]", joystick_input_mode.label()),
+        MenuItem::Warp if warp => "Warp Speed      [on]".to_string(),
+        MenuItem::Warp => "Warp Speed     [off]".to_string(),
+        MenuItem::Record if recording => "Stop Video Recording".to_string(),
+        MenuItem::Record => "Record Video".to_string(),
+        MenuItem::RecordInput if input_recording => "Stop Input Recording".to_string(),
+        MenuItem::RecordInput => "Record Input".to_string(),
+        MenuItem::SaveState => "Save State".to_string(),
+        MenuItem::LoadState => "Load State...".to_string(),
+        MenuItem::LoadRom => "Load Kickstart ROM...".to_string(),
     }
 }
 
@@ -638,6 +642,7 @@ fn draw_menu(
     warp: bool,
     recording: bool,
     input_recording: bool,
+    joystick_input_mode: JoystickInputMode,
     scale: usize,
 ) {
     let rect = menu_rect();
@@ -659,7 +664,7 @@ fn draw_menu(
             frame,
             item_rect.x + 8,
             item_rect.y + (MENU_ITEM_H - 16) / 2,
-            menu_item_label(*item, warp, recording, input_recording),
+            &menu_item_label(*item, warp, recording, input_recording, joystick_input_mode),
             fg,
             2,
             scale,
@@ -742,7 +747,7 @@ fn draw_about(frame: &mut [u8], rect: Rect, view: &AboutView, scale: usize) {
     }
 }
 
-const SHORTCUT_ROWS: [(&str, &str, bool); 11] = [
+const SHORTCUT_ROWS: [(&str, &str, bool); 12] = [
     ("Q", "Quit", true),
     ("S", "Save screenshot", true),
     ("R", "Record video on/off", true),
@@ -752,6 +757,7 @@ const SHORTCUT_ROWS: [(&str, &str, bool); 11] = [
     ("D", "Swap queued disk", true),
     ("G", "Capture mouse", true),
     ("B", "Debugger", true),
+    ("J", "Joystick input mode", true),
     ("Esc", "Close menu/window", false),
     ("Ctrl+Ami+Ami", "Keyboard reset", false),
 ];
@@ -997,6 +1003,7 @@ pub fn draw(
     warp: bool,
     recording: bool,
     input_recording: bool,
+    joystick_input_mode: JoystickInputMode,
 ) {
     if let Some(panel) = &ui.panel {
         draw_panel_chrome(frame, panel, hover, texture_scale);
@@ -1022,6 +1029,7 @@ pub fn draw(
             warp,
             recording,
             input_recording,
+            joystick_input_mode,
             texture_scale,
         );
     }
@@ -1150,6 +1158,12 @@ mod tests {
         let first = menu_item_rect(0);
         let pos = (first.x as i32 + 4, first.y as i32 + 4);
         assert_eq!(ui.control_at(pos), Some(UiControl::MenuItem(MENU_ITEMS[0])));
+        let joystick = menu_item_rect(2);
+        let pos = (joystick.x as i32 + 4, joystick.y as i32 + 4);
+        assert_eq!(
+            ui.control_at(pos),
+            Some(UiControl::MenuItem(MenuItem::JoystickInput))
+        );
         // Outside the menu: nothing (the click closes the menu).
         assert_eq!(ui.control_at((0, 0)), None);
     }
@@ -1304,7 +1318,17 @@ mod tests {
             menu_open: true,
             panel: None,
         };
-        draw(&mut frame, scale, &ui, None, None, true, false, false);
+        draw(
+            &mut frame,
+            scale,
+            &ui,
+            None,
+            None,
+            true,
+            false,
+            false,
+            JoystickInputMode::Auto,
+        );
         let menu = menu_rect();
         let probe = ((menu.y + MENU_PAD + 2) * w + menu.x + 4) * 4;
         assert_eq!(&frame[probe..probe + 4], &MENU_BG.to_le_bytes());
@@ -1334,6 +1358,7 @@ mod tests {
             false,
             false,
             false,
+            JoystickInputMode::Auto,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "about");
@@ -1352,6 +1377,7 @@ mod tests {
             false,
             false,
             false,
+            JoystickInputMode::Auto,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "shortcuts");
@@ -1387,6 +1413,7 @@ mod tests {
             false,
             false,
             false,
+            JoystickInputMode::Auto,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "calibration");
@@ -1429,6 +1456,7 @@ mod tests {
             false,
             false,
             false,
+            JoystickInputMode::Auto,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "debugger");
@@ -1468,6 +1496,7 @@ mod tests {
             false,
             false,
             false,
+            JoystickInputMode::Auto,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "debugger-break");

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -60,6 +60,161 @@ impl JoyButtonKind {
     }
 }
 
+/// Host input source for the emulated port-2 joystick/CD32 pad. Auto keeps
+/// a calibrated physical pad in charge when one is present and otherwise
+/// falls back to keyboard joystick emulation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoystickInputMode {
+    Auto,
+    Gamepad,
+    Keyboard,
+}
+
+impl JoystickInputMode {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Auto => Self::Keyboard,
+            Self::Keyboard => Self::Gamepad,
+            Self::Gamepad => Self::Auto,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Gamepad => "gamepad",
+            Self::Keyboard => "keyboard",
+        }
+    }
+}
+
+impl Default for JoystickInputMode {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyboardJoystickKey {
+    Up,
+    Down,
+    Left,
+    Right,
+    FireRightCtrl,
+    FireRightAlt,
+    Red,
+    Blue,
+    Green,
+    Yellow,
+    Play,
+    Rewind,
+    Forward,
+}
+
+/// Host keys currently held for keyboard joystick emulation. Fire has
+/// multiple aliases, so this tracks individual keys and resolves them to
+/// one port state when applied.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct KeyboardJoystickHeld {
+    up: bool,
+    down: bool,
+    left: bool,
+    right: bool,
+    fire_right_ctrl: bool,
+    fire_right_alt: bool,
+    red: bool,
+    blue: bool,
+    green: bool,
+    yellow: bool,
+    play: bool,
+    rwd: bool,
+    ffw: bool,
+}
+
+impl KeyboardJoystickHeld {
+    fn set(&mut self, key: KeyboardJoystickKey, held: bool) {
+        match key {
+            KeyboardJoystickKey::Up => self.up = held,
+            KeyboardJoystickKey::Down => self.down = held,
+            KeyboardJoystickKey::Left => self.left = held,
+            KeyboardJoystickKey::Right => self.right = held,
+            KeyboardJoystickKey::FireRightCtrl => self.fire_right_ctrl = held,
+            KeyboardJoystickKey::FireRightAlt => self.fire_right_alt = held,
+            KeyboardJoystickKey::Red => self.red = held,
+            KeyboardJoystickKey::Blue => self.blue = held,
+            KeyboardJoystickKey::Green => self.green = held,
+            KeyboardJoystickKey::Yellow => self.yellow = held,
+            KeyboardJoystickKey::Play => self.play = held,
+            KeyboardJoystickKey::Rewind => self.rwd = held,
+            KeyboardJoystickKey::Forward => self.ffw = held,
+        }
+    }
+
+    fn is_set(&self, key: KeyboardJoystickKey) -> bool {
+        match key {
+            KeyboardJoystickKey::Up => self.up,
+            KeyboardJoystickKey::Down => self.down,
+            KeyboardJoystickKey::Left => self.left,
+            KeyboardJoystickKey::Right => self.right,
+            KeyboardJoystickKey::FireRightCtrl => self.fire_right_ctrl,
+            KeyboardJoystickKey::FireRightAlt => self.fire_right_alt,
+            KeyboardJoystickKey::Red => self.red,
+            KeyboardJoystickKey::Blue => self.blue,
+            KeyboardJoystickKey::Green => self.green,
+            KeyboardJoystickKey::Yellow => self.yellow,
+            KeyboardJoystickKey::Play => self.play,
+            KeyboardJoystickKey::Rewind => self.rwd,
+            KeyboardJoystickKey::Forward => self.ffw,
+        }
+    }
+
+    fn joystick_state(&self) -> crate::gamepad::JoystickState {
+        crate::gamepad::JoystickState {
+            up: self.up,
+            down: self.down,
+            left: self.left,
+            right: self.right,
+            fire: self.fire_right_ctrl || self.fire_right_alt || self.red,
+            button2: self.blue,
+            green: self.green,
+            yellow: self.yellow,
+            play: self.play,
+            rwd: self.rwd,
+            ffw: self.ffw,
+        }
+    }
+}
+
+/// FS-UAE-compatible keyboard joystick/gamepad emulation:
+/// cursor keys for directions; Right Ctrl/Right Alt for fire; CD32 extras
+/// on C/X/D/S/Return/Z/A.
+fn keyboard_joystick_key_for(code: KeyCode) -> Option<KeyboardJoystickKey> {
+    Some(match code {
+        KeyCode::ArrowUp => KeyboardJoystickKey::Up,
+        KeyCode::ArrowDown => KeyboardJoystickKey::Down,
+        KeyCode::ArrowLeft => KeyboardJoystickKey::Left,
+        KeyCode::ArrowRight => KeyboardJoystickKey::Right,
+        KeyCode::ControlRight => KeyboardJoystickKey::FireRightCtrl,
+        KeyCode::AltRight => KeyboardJoystickKey::FireRightAlt,
+        KeyCode::KeyC => KeyboardJoystickKey::Red,
+        KeyCode::KeyX => KeyboardJoystickKey::Blue,
+        KeyCode::KeyD => KeyboardJoystickKey::Green,
+        KeyCode::KeyS => KeyboardJoystickKey::Yellow,
+        KeyCode::Enter | KeyCode::NumpadEnter => KeyboardJoystickKey::Play,
+        KeyCode::KeyZ => KeyboardJoystickKey::Rewind,
+        KeyCode::KeyA => KeyboardJoystickKey::Forward,
+        _ => return None,
+    })
+}
+
+fn joystick_mode_uses_keyboard(mode: JoystickInputMode, gamepad_active: bool) -> bool {
+    match mode {
+        JoystickInputMode::Keyboard => true,
+        JoystickInputMode::Auto => !gamepad_active,
+        JoystickInputMode::Gamepad => false,
+    }
+}
+
 /// The port-2 controls currently held by `--joy-after` scripting.
 #[derive(Debug, Default, Clone, Copy)]
 struct AutoJoyHeld {
@@ -356,6 +511,14 @@ pub struct App {
     /// input backend is available (e.g. headless CI) or the pad is not yet
     /// calibrated.
     gamepad: crate::gamepad::GamepadReader,
+    /// Host source policy for the emulated port-2 joystick/CD32 pad.
+    joystick_input_mode: JoystickInputMode,
+    /// Whether the last normal input poll resolved a calibrated physical
+    /// gamepad. Auto mode uses this to decide whether mapped keyboard keys
+    /// should be consumed as joystick controls.
+    last_gamepad_active: bool,
+    /// Mapped host keys currently held for keyboard joystick emulation.
+    keyboard_joy_held: KeyboardJoystickHeld,
     /// Pop-up menu and overlay sub-window (about/debugger/calibration)
     /// state. While a panel is open it consumes pointer and key input.
     ui: UiState,
@@ -589,6 +752,9 @@ impl App {
             hcenter: hcenter_enabled(),
             overscan,
             gamepad: crate::gamepad::GamepadReader::new(),
+            joystick_input_mode: JoystickInputMode::default(),
+            last_gamepad_active: false,
+            keyboard_joy_held: KeyboardJoystickHeld::default(),
             ui: UiState::default(),
             about_machine_lines,
             paused_before_debugger: false,
@@ -598,29 +764,95 @@ impl App {
         }
     }
 
-    /// Poll the calibrated gamepad and drive the emulated port-2 joystick.
-    /// Called once per scheduler quantum; with no pad (or an uncalibrated
-    /// one), port 2 stays a mouse unless --joy-after scripting is active.
-    fn pump_gamepad(&mut self) {
-        let state = self.gamepad.poll();
-        match state {
-            Some(s) => {
-                let input = &mut self.emu.bus_mut().input;
-                input.set_joystick_port2(s.up, s.down, s.left, s.right, s.fire, s.button2);
-                input.set_cd32_buttons_port2(s.play, s.rwd, s.ffw, s.green, s.yellow);
-            }
+    /// Poll the active host joystick source and drive the emulated port-2
+    /// joystick. Called once per scheduler quantum. In Auto mode, a
+    /// calibrated gamepad wins; otherwise the keyboard mapping supplies a
+    /// joystick so port 2 remains usable without a physical controller.
+    fn pump_joystick_input(&mut self) {
+        let gamepad_state = match self.joystick_input_mode {
+            JoystickInputMode::Keyboard => None,
+            JoystickInputMode::Auto | JoystickInputMode::Gamepad => self.gamepad.poll(),
+        };
+        self.last_gamepad_active = gamepad_state.is_some();
+
+        match gamepad_state {
+            Some(state) => self.apply_joystick_state(state),
             // No physical pad but --joy-after scripting has fired: keep
             // asserting the scripted state so it survives this release
             // path and drives the upcoming scheduler quantum.
             None if self.auto_joy_engaged => self.apply_auto_joy_state(),
-            // Pad gone/uncalibrated: release everything so nothing sticks.
+            None if self.keyboard_joystick_enabled() => self.apply_keyboard_joystick_state(),
+            // Pad gone/uncalibrated and keyboard fallback disabled: release
+            // everything so nothing sticks.
             None if self.emu.bus().input.joystick_port2 => {
-                let input = &mut self.emu.bus_mut().input;
-                input.set_joystick_port2(false, false, false, false, false, false);
-                input.set_cd32_buttons_port2(false, false, false, false, false);
+                self.release_port2_joystick();
             }
             None => {}
         }
+    }
+
+    fn keyboard_joystick_enabled(&self) -> bool {
+        joystick_mode_uses_keyboard(self.joystick_input_mode, self.last_gamepad_active)
+    }
+
+    fn apply_joystick_state(&mut self, state: crate::gamepad::JoystickState) {
+        let input = &mut self.emu.bus_mut().input;
+        input.set_joystick_port2(
+            state.up,
+            state.down,
+            state.left,
+            state.right,
+            state.fire,
+            state.button2,
+        );
+        input.set_cd32_buttons_port2(state.play, state.rwd, state.ffw, state.green, state.yellow);
+    }
+
+    fn apply_keyboard_joystick_state(&mut self) {
+        self.apply_joystick_state(self.keyboard_joy_held.joystick_state());
+    }
+
+    fn release_port2_joystick(&mut self) {
+        let input = &mut self.emu.bus_mut().input;
+        input.set_joystick_port2(false, false, false, false, false, false);
+        input.set_cd32_buttons_port2(false, false, false, false, false);
+    }
+
+    fn cycle_joystick_input_mode(&mut self) {
+        self.set_joystick_input_mode(self.joystick_input_mode.next());
+    }
+
+    fn set_joystick_input_mode(&mut self, mode: JoystickInputMode) {
+        if self.joystick_input_mode == mode {
+            return;
+        }
+        self.joystick_input_mode = mode;
+        if mode == JoystickInputMode::Keyboard {
+            self.last_gamepad_active = false;
+        }
+        if !matches!(self.ui.panel, Some(Panel::Calibration(_))) {
+            self.pump_joystick_input();
+        }
+        info!("joystick input mode: {}", mode.label());
+        self.show_osd(format!("Joystick input: {}", mode.label()));
+    }
+
+    /// Consume a mapped host key as joystick input when keyboard joystick
+    /// emulation is active. Releases for previously consumed mapped keys
+    /// are also swallowed, even if a gamepad has taken over meanwhile.
+    fn handle_keyboard_joystick_key(&mut self, code: KeyCode, pressed: bool) -> bool {
+        let Some(key) = keyboard_joystick_key_for(code) else {
+            return false;
+        };
+        let was_held = self.keyboard_joy_held.is_set(key);
+        if !self.keyboard_joystick_enabled() && !was_held {
+            return false;
+        }
+        self.keyboard_joy_held.set(key, pressed);
+        if self.keyboard_joystick_enabled() {
+            self.apply_keyboard_joystick_state();
+        }
+        true
     }
 
     /// Drive the emulated port-2 joystick/CD32 pad from the --joy-after
@@ -930,6 +1162,11 @@ impl ApplicationHandler for App {
                     {
                         self.toggle_debugger()
                     }
+                    (KeyCode::KeyJ, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers) =>
+                    {
+                        self.cycle_joystick_input_mode()
+                    }
                     (KeyCode::KeyR, ElementState::Pressed)
                         if host_shortcut_modifier_pressed(self.modifiers)
                             && self.modifiers.shift_key() =>
@@ -950,6 +1187,9 @@ impl ApplicationHandler for App {
                         // into the emulated machine. Releases still pass so
                         // a key held across opening a panel is not stuck.
                         if pressed && self.ui.panel.is_some() {
+                            return;
+                        }
+                        if self.handle_keyboard_joystick_key(other, pressed) {
                             return;
                         }
                         if let Some(rawkey) = host_to_amiga_rawkey(other) {
@@ -1137,6 +1377,7 @@ impl ApplicationHandler for App {
                         warp,
                         recording,
                         input_recording,
+                        self.joystick_input_mode,
                     );
                     if let Err(e) = r.pixels.render() {
                         error!("pixels.render: {e}");
@@ -1207,7 +1448,7 @@ impl ApplicationHandler for App {
                 std::thread::sleep(std::time::Duration::from_millis(5));
             }
         } else {
-            self.pump_gamepad();
+            self.pump_joystick_input();
         }
         // Run one scheduler quantum. Rebuild the host framebuffer only
         // when Agnus has crossed into a new frame; the expensive renderer
@@ -1285,7 +1526,7 @@ impl ApplicationHandler for App {
             true
         });
         // Fire any scheduled --joy-after events into the port-2
-        // joystick/CD32-pad state, then assert the held set (pump_gamepad
+        // joystick/CD32-pad state, then assert the held set (input polling
         // re-applies it every quantum while scripting is engaged).
         let mut joy_changed = false;
         let held = &mut self.auto_joy_held;
@@ -3975,6 +4216,7 @@ impl App {
                             Some(Panel::Calibration(crate::gamepad::CalibrationSession::new()));
                     }
                     ui::MenuItem::Debugger => self.open_debugger(),
+                    ui::MenuItem::JoystickInput => self.cycle_joystick_input_mode(),
                     ui::MenuItem::Warp => self.toggle_warp(),
                     ui::MenuItem::Record => self.toggle_recording(),
                     ui::MenuItem::RecordInput => self.toggle_input_recording(),
@@ -5874,17 +6116,19 @@ mod tests {
         bar_layout, bitplane, center_present_frame_for_visible_start,
         center_present_frame_horizontally, control_at, copperline_icon_image,
         copperline_logo_image, copy_present_frame, draw_status_bar, fdd_track_counter_rect,
-        fdd_track_digit_rect, host_shortcut_modifier_pressed, host_to_amiga_rawkey, led_row_rect,
+        fdd_track_digit_rect, host_shortcut_modifier_pressed, host_to_amiga_rawkey,
+        joystick_mode_uses_keyboard, keyboard_joystick_key_for, led_row_rect,
         mask_present_frame_to_tv, paint_test_screen, parse_amiga_key, pause_button_rect,
         power_button_rect, present_row_sample, presentation_source_y_offset, reboot_button_rect,
         rgba, shot_button_rect, should_render_emulated_frame, standard_window_top_row,
         status_with_latched_fdd_track, take_integral_mouse_delta, texture_height, texture_width,
-        volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, MediaBar,
-        StatusBarView, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON,
-        DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
-        POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON, PRESENT_HEIGHT,
-        STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-        TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
+        volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, JoystickInputMode,
+        KeyboardJoystickHeld, KeyboardJoystickKey, MediaBar, StatusBarView, BUTTON_GLYPH,
+        BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW,
+        DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF,
+        POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON, PRESENT_HEIGHT, STANDARD_PAL_VISIBLE_LINES,
+        STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON,
+        VOLUME_FILL, VOLUME_GLYPH_X,
     };
     use crate::audio::{AudioSink, NullSink};
     use crate::bus::FrontPanelStatus;
@@ -5934,6 +6178,98 @@ mod tests {
         assert_eq!(host_to_amiga_rawkey(KeyCode::AltRight), Some(0x65));
         assert_eq!(host_to_amiga_rawkey(KeyCode::SuperLeft), Some(0x66));
         assert_eq!(host_to_amiga_rawkey(KeyCode::SuperRight), Some(0x67));
+    }
+
+    #[test]
+    fn keyboard_joystick_mapping_matches_fsuae_controls() {
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::ArrowUp),
+            Some(KeyboardJoystickKey::Up)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::ArrowDown),
+            Some(KeyboardJoystickKey::Down)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::ArrowLeft),
+            Some(KeyboardJoystickKey::Left)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::ArrowRight),
+            Some(KeyboardJoystickKey::Right)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::ControlRight),
+            Some(KeyboardJoystickKey::FireRightCtrl)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::AltRight),
+            Some(KeyboardJoystickKey::FireRightAlt)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::KeyC),
+            Some(KeyboardJoystickKey::Red)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::KeyX),
+            Some(KeyboardJoystickKey::Blue)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::KeyD),
+            Some(KeyboardJoystickKey::Green)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::KeyS),
+            Some(KeyboardJoystickKey::Yellow)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::Enter),
+            Some(KeyboardJoystickKey::Play)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::KeyZ),
+            Some(KeyboardJoystickKey::Rewind)
+        );
+        assert_eq!(
+            keyboard_joystick_key_for(KeyCode::KeyA),
+            Some(KeyboardJoystickKey::Forward)
+        );
+        assert_eq!(keyboard_joystick_key_for(KeyCode::ControlLeft), None);
+    }
+
+    #[test]
+    fn keyboard_joystick_fire_aliases_release_independently() {
+        let mut held = KeyboardJoystickHeld::default();
+        held.set(KeyboardJoystickKey::FireRightCtrl, true);
+        held.set(KeyboardJoystickKey::Red, true);
+        assert!(held.joystick_state().fire);
+
+        held.set(KeyboardJoystickKey::FireRightCtrl, false);
+        assert!(held.joystick_state().fire);
+
+        held.set(KeyboardJoystickKey::Red, false);
+        assert!(!held.joystick_state().fire);
+    }
+
+    #[test]
+    fn joystick_input_mode_policy_uses_keyboard_as_auto_fallback() {
+        assert_eq!(JoystickInputMode::Auto.next(), JoystickInputMode::Keyboard);
+        assert_eq!(
+            JoystickInputMode::Keyboard.next(),
+            JoystickInputMode::Gamepad
+        );
+        assert_eq!(JoystickInputMode::Gamepad.next(), JoystickInputMode::Auto);
+
+        assert!(joystick_mode_uses_keyboard(JoystickInputMode::Auto, false));
+        assert!(!joystick_mode_uses_keyboard(JoystickInputMode::Auto, true));
+        assert!(joystick_mode_uses_keyboard(
+            JoystickInputMode::Keyboard,
+            true
+        ));
+        assert!(!joystick_mode_uses_keyboard(
+            JoystickInputMode::Gamepad,
+            false
+        ));
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -63,8 +63,9 @@ impl JoyButtonKind {
 /// Host input source for the emulated port-2 joystick/CD32 pad. Auto keeps
 /// a calibrated physical pad in charge when one is present and otherwise
 /// falls back to keyboard joystick emulation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum JoystickInputMode {
+    #[default]
     Auto,
     Gamepad,
     Keyboard,
@@ -85,12 +86,6 @@ impl JoystickInputMode {
             Self::Gamepad => "gamepad",
             Self::Keyboard => "keyboard",
         }
-    }
-}
-
-impl Default for JoystickInputMode {
-    fn default() -> Self {
-        Self::Auto
     }
 }
 


### PR DESCRIPTION
## Summary
- add Auto/Keyboard/Gamepad source policy for the emulated port-2 joystick/CD32 pad
- add FS-UAE-compatible keyboard joystick mapping plus Cmd/Alt+J and a menu switch
- document the user-facing mapping and the internals input path

## Tests
- cargo test keyboard_joystick
- cargo test joystick_input_mode_policy_uses_keyboard_as_auto_fallback
- cargo test menu_sits_above_the_status_bar_and_hit_tests_items
- cargo test panels_render_into_their_rects
- git diff --check