### PR TITLE
video: require Vulkan for presentation on Linux

### DIFF
--- a/.github/workflows/linux-present.yml
+++ b/.github/workflows/linux-present.yml
@@ -38,14 +38,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies
         # Build: ALSA (cpal) + udev (gilrs). Runtime: software Vulkan (Mesa
-        # lavapipe) + a virtual X server. CI runners have no GPU, so lavapipe
-        # is the only ICD present.
+        # lavapipe) + a virtual X server, plus the X11/xkb client libraries
+        # winit dlopens at startup (libxkbcommon-x11 in particular, which the
+        # runner image does not ship). CI runners have no GPU, so lavapipe is
+        # the only ICD present. Keep this list in sync with
+        # packaging/test-linux-vulkan/Dockerfile.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libasound2-dev libudev-dev \
             mesa-vulkan-drivers vulkan-tools \
-            xvfb xauth
+            xvfb xauth \
+            libxkbcommon0 libxkbcommon-x11-0 \
+            libx11-6 libx11-xcb1 libxcb1 \
+            libxcursor1 libxi6 libxrandr2 libxrender1 \
+            libwayland-client0
       - name: Show Vulkan driver
         run: vulkaninfo --summary | head -n 25
       - name: Build

--- a/.github/workflows/linux-present.yml
+++ b/.github/workflows/linux-present.yml
@@ -1,0 +1,61 @@
+name: Linux present
+
+# Verifies Copperline's presentation path initializes and renders a frame on
+# Linux using software Vulkan (Mesa lavapipe) under a headless X server. Guards
+# the "Vulkan required on Linux" policy in src/video/window.rs: wgpu's GL
+# fallback drops to an unusable surfaceless EGL platform, so a Vulkan adapter
+# (hardware or lavapipe) must be reachable for the window surface to come up.
+# GitHub runners have no GPU, so this exercises the lavapipe path -- the same
+# one a Vulkan-less host uses after installing a software ICD. The local
+# equivalent for an Apple Silicon dev host is packaging/test-linux-vulkan/.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/video/**"
+      - "vendor/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/linux-present.yml"
+  pull_request:
+    paths:
+      - "src/video/**"
+      - "vendor/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/linux-present.yml"
+
+concurrency:
+  group: linux-present-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  present-smoke:
+    name: Vulkan present smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        # Build: ALSA (cpal) + udev (gilrs). Runtime: software Vulkan (Mesa
+        # lavapipe) + a virtual X server. CI runners have no GPU, so lavapipe
+        # is the only ICD present.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libasound2-dev libudev-dev \
+            mesa-vulkan-drivers vulkan-tools \
+            xvfb xauth
+      - name: Show Vulkan driver
+        run: vulkaninfo --summary | head -n 25
+      - name: Build
+        run: cargo build --release --locked --bin copperline
+      - name: Headless screenshot (exercises Vulkan present init)
+        # A hidden window + present surface are still created in screenshot
+        # mode, so a non-empty PNG proves the wgpu instance/adapter/surface
+        # came up on Vulkan. Boots the bundled AROS ROM, so no assets needed.
+        run: |
+          xvfb-run -a -s "-screen 0 1280x720x24" \
+            ./target/release/copperline --noaudio --screenshot-after 3 /tmp/present.png
+          test -s /tmp/present.png
+          echo "present path OK ($(stat -c %s /tmp/present.png) bytes)"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ against real hardware.
 - Fedora build dependencies: `sudo dnf install alsa-lib-devel systemd-devel`.
 - No SDL2 dependency. Developed and tested on **macOS**; the Linux and
   Windows paths are expected to work but are currently untested.
+- **Linux requires a Vulkan driver.** The display is presented with wgpu via
+  the Vulkan backend; the OpenGL fallback is not usable (see "Linux: Vulkan
+  required" below). Any GPU from roughly Intel Skylake / 2015 onward has a
+  hardware Vulkan driver. Older hardware (or a headless/VM host) can use the
+  software lavapipe ICD: `vulkan-swrast` on Arch, `mesa-vulkan-drivers` on
+  Debian/Ubuntu/Fedora. macOS (Metal) and Windows (DX12) are unaffected.
 
 ## Install (macOS, Homebrew)
 
@@ -83,6 +89,33 @@ Or grab the single-file `Copperline-*.AppImage` from the
 [releases page](https://github.com/LinuxJedi/Copperline/releases),
 `chmod +x` it and run. Both bundle the AROS boot ROM. Packaging sources are in
 `packaging/`.
+
+### Linux: Vulkan required
+
+On Linux the display is presented through wgpu's **Vulkan** backend. The
+OpenGL fallback is deliberately disabled: wgpu creates its EGL instance
+without a display handle, so it silently selects Mesa's "surfaceless"
+platform, which cannot be paired with an on-screen window. The symptom on a
+Vulkan-less machine is the window flashing open and then exiting with:
+
+```
+ERROR copperline::video::window] pixels init failed: No suitable `wgpu::Adapter` found.
+```
+
+If you hit this, install a Vulkan driver:
+
+- Hardware Vulkan (recommended): any GPU from roughly Intel Skylake / 2015
+  onward ships one. Update your `mesa`/GPU driver package.
+- Software fallback (older hardware, headless, or a VM) -- the lavapipe ICD:
+  - Arch: `sudo pacman -S vulkan-swrast`
+  - Debian/Ubuntu: `sudo apt install mesa-vulkan-drivers`
+  - Fedora: `sudo dnf install mesa-vulkan-drivers`
+
+Copperline does all rendering on the CPU and only asks the GPU to blit one
+framebuffer per frame, so software Vulkan (lavapipe) is perfectly adequate.
+The Flatpak runtime already includes lavapipe, so the Flatpak works without
+any extra package. Setting `WGPU_BACKEND` overrides the backend selection if
+you need to force a specific one for debugging.
 
 ## Build and run
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,6 +6,8 @@
 - macOS, Linux, or Windows. There is no SDL2 dependency: video uses
   `winit` + `pixels`, audio uses `cpal`, and gamepads use the pure-Rust
   `gilrs` crate.
+- A GPU backend for presentation: Metal on macOS, DX12 on Windows, and
+  **Vulkan on Linux** (see [](#vulkan-is-required-on-linux)).
 - Fedora build dependencies: `sudo dnf install alsa-lib-devel systemd-devel`.
 - A boot ROM. Copperline ships with the [AROS](http://www.aros.org/)
   open-source Kickstart replacement and boots it by default, so it runs out
@@ -52,6 +54,32 @@ chmod +x Copperline-*.AppImage
 
 Both bundle the AROS boot ROM, so they run out of the box. Packaging sources
 live in `packaging/flatpak/` and `packaging/appimage/`.
+
+### Vulkan is required on Linux
+
+The display is presented through wgpu's Vulkan backend. The OpenGL fallback
+is disabled because wgpu initializes its EGL instance without a display
+handle and silently selects Mesa's "surfaceless" platform, which cannot be
+paired with an on-screen window; adapter selection then fails. The symptom is
+the window flashing open and immediately exiting with:
+
+```
+ERROR copperline::video::window] pixels init failed: No suitable `wgpu::Adapter` found.
+```
+
+The fix is to provide a Vulkan driver. Any GPU from roughly Intel Skylake /
+2015 onward ships a hardware Vulkan driver in `mesa`. Older hardware, a
+headless host, or a VM can use the software lavapipe ICD instead:
+
+- Arch: `sudo pacman -S vulkan-swrast`
+- Debian/Ubuntu: `sudo apt install mesa-vulkan-drivers`
+- Fedora: `sudo dnf install mesa-vulkan-drivers`
+
+Copperline renders entirely on the CPU and only asks the GPU to blit one
+framebuffer per frame, so software Vulkan is perfectly adequate. The Flatpak
+runtime already includes lavapipe, so the Flatpak needs no extra package.
+`WGPU_BACKEND` overrides backend selection if you need to force one for
+debugging.
 
 ## Building
 

--- a/packaging/test-linux-vulkan/Dockerfile
+++ b/packaging/test-linux-vulkan/Dockerfile
@@ -1,0 +1,36 @@
+# Headless Linux GPU smoke test for Copperline's presentation path.
+#
+# Recreates what a Vulkan-less / software-GPU Linux host looks like: software
+# Vulkan (Mesa lavapipe) plus a virtual X server (Xvfb), with no hardware GPU.
+# Used to verify that the Vulkan present path initializes and renders a frame
+# headlessly, which guards the "Vulkan required on Linux" policy in window.rs.
+# See packaging/test-linux-vulkan/run-smoke.sh for the actual checks.
+#
+# Build from the repo root:
+#   docker build -t copperline-linux-test -f packaging/test-linux-vulkan/Dockerfile .
+# Or just use packaging/test-linux-vulkan/run.sh, which also wires up caches.
+FROM rust:bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      pkg-config \
+      libasound2-dev \
+      libudev-dev \
+      xvfb \
+      xauth \
+      libvulkan1 \
+      mesa-vulkan-drivers \
+      vulkan-tools \
+      libxkbcommon0 \
+      libxkbcommon-x11-0 \
+      libx11-6 \
+      libx11-xcb1 \
+      libxcb1 \
+      libxcursor1 \
+      libxi6 \
+      libxrandr2 \
+      libxrender1 \
+      libwayland-client0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+ENTRYPOINT ["bash", "packaging/test-linux-vulkan/run-smoke.sh"]

--- a/packaging/test-linux-vulkan/run-smoke.sh
+++ b/packaging/test-linux-vulkan/run-smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build Copperline inside the Linux test container and verify the presentation
+# path initializes headlessly on software Vulkan (Mesa lavapipe).
+#
+# Runs inside the image from packaging/test-linux-vulkan/Dockerfile. The repo
+# is bind-mounted at /src and CARGO_TARGET_DIR points at a cache volume, so the
+# host's (macOS) target/ is never touched. Mirrors the environment of a host
+# without a hardware Vulkan driver: lavapipe is the only ICD present.
+set -euo pipefail
+
+echo "==> Vulkan ICDs visible to the loader:"
+if ! vulkaninfo --summary 2>/dev/null | sed -n '1,25p'; then
+  echo "ERROR: no usable Vulkan driver in the container" >&2
+  exit 1
+fi
+
+echo
+echo "==> Building release binary (Linux, in-container target dir)"
+cargo build --release --locked --bin copperline
+
+bin="${CARGO_TARGET_DIR:-target}/release/copperline"
+out="/tmp/copperline-smoke.png"
+rm -f "$out"
+
+echo
+echo "==> Headless screenshot under Xvfb (exercises the Vulkan present init)"
+# A hidden window + present surface are still created in screenshot mode, so a
+# successful PNG proves the wgpu instance/adapter/surface came up on Vulkan.
+xvfb-run -a -s "-screen 0 1280x720x24" \
+  "$bin" --noaudio --screenshot-after 3 "$out"
+
+if [ -s "$out" ]; then
+  echo
+  echo "PASS: present path initialized and rendered ($(stat -c %s "$out") bytes) -> $out"
+else
+  echo "FAIL: no screenshot produced; the present surface did not initialize" >&2
+  exit 1
+fi

--- a/packaging/test-linux-vulkan/run.sh
+++ b/packaging/test-linux-vulkan/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the Linux test image and run the headless Vulkan present smoke test in
+# a container. Safe from an Apple Silicon (or any) Mac host: the container runs
+# as the host's native platform (linux/arm64 on Apple Silicon) and exercises
+# the same wgpu code path as an x86_64 Linux host -- the surfaceless-GL bug the
+# Vulkan policy avoids is hardware- and architecture-independent.
+#
+#   packaging/test-linux-vulkan/run.sh
+#
+# The first run builds the image and the release binary (slow); cargo's
+# registry and a Linux-only target dir are kept in named Docker volumes so
+# repeat runs are fast and the host's target/ is never clobbered.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+cd "$repo_root"
+
+img=copperline-linux-test
+
+echo "==> Building test image ($img)"
+docker build -t "$img" -f packaging/test-linux-vulkan/Dockerfile .
+
+echo "==> Running smoke test"
+docker run --rm \
+  -v "$repo_root":/src \
+  -v copperline-lin-target:/lin-target \
+  -v copperline-cargo-registry:/usr/local/cargo/registry \
+  -e CARGO_TARGET_DIR=/lin-target \
+  "$img"

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -399,7 +399,7 @@ pub struct DiskInsertSpec {
 
 use anyhow::{anyhow, Result};
 use log::{error, info, warn};
-use pixels::{Pixels, ScalingMode, SurfaceTexture};
+use pixels::{Pixels, PixelsBuilder, ScalingMode, SurfaceTexture};
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::{
@@ -951,14 +951,43 @@ impl ApplicationHandler for App {
         let inner = window.inner_size();
         let surface = SurfaceTexture::new(inner.width.max(1), inner.height.max(1), window.clone());
         let texture_scale = texture_scale_for_window(&window);
-        let mut pixels = match Pixels::new(
+        let builder = PixelsBuilder::new(
             texture_width(texture_scale) as u32,
             texture_height(texture_scale) as u32,
             surface,
-        ) {
+        );
+        // On Linux, restrict wgpu to the Vulkan backend. wgpu's GL fallback
+        // initializes its EGL instance without a display handle (pixels uses
+        // InstanceDescriptor::new_without_display_handle), so EGL drops to the
+        // Mesa "surfaceless" platform, which is not compatible with an on-screen
+        // window surface -- adapter selection then fails with "No suitable
+        // wgpu::Adapter found" on any machine that lacks a hardware Vulkan
+        // driver. Vulkan does not need the display handle at instance creation,
+        // so it works; GPUs without a hardware Vulkan driver (pre-Skylake Intel
+        // and other pre-2015 parts) can fall back to the software lavapipe ICD.
+        // An explicit WGPU_BACKEND override is still honoured for debugging.
+        // Other platforms keep wgpu's default backend set (Metal on macOS,
+        // DX12/Vulkan on Windows). cfg!() (not #[cfg]) keeps the Linux branch
+        // type-checked on every host.
+        let builder = if cfg!(target_os = "linux") {
+            builder.wgpu_backend(
+                pixels::wgpu::Backends::from_env().unwrap_or(pixels::wgpu::Backends::VULKAN),
+            )
+        } else {
+            builder
+        };
+        let mut pixels = match builder.build() {
             Ok(p) => p,
             Err(e) => {
                 error!("pixels init failed: {e}");
+                if cfg!(target_os = "linux") {
+                    error!(
+                        "Copperline requires a Vulkan driver on Linux. Update your GPU \
+                         drivers, or install a software Vulkan ICD (lavapipe): \
+                         'vulkan-swrast' on Arch, 'mesa-vulkan-drivers' on Debian/Ubuntu, \
+                         'mesa-vulkan-drivers' (or 'vulkan-loader') on Fedora."
+                    );
+                }
                 event_loop.exit();
                 return;
             }


### PR DESCRIPTION
On Linux the display is now presented exclusively through wgpu's Vulkan backend. wgpu's GL/EGL fallback creates its instance without a display handle (pixels uses InstanceDescriptor::new_without_display_handle), so EGL selects Mesa's surfaceless platform, whose adapter is not compatible with the on-screen window surface. The result was "No suitable wgpu::Adapter found" and an immediate exit on any Linux host lacking a hardware Vulkan driver, for example pre-Skylake Intel such as the HD 5000 (Haswell).

Vulkan does not need the display handle at instance creation, so it works. Hosts without a hardware Vulkan driver can use the software lavapipe ICD; Copperline renders on the CPU and only blits one framebuffer per frame, so software Vulkan is adequate. The selection is gated with cfg!(target_os = "linux") so it still type-checks elsewhere; macOS (Metal) and Windows (DX12) are unchanged, and WGPU_BACKEND still overrides it.

Adds an actionable error message naming lavapipe, README and getting-started docs, a Dockerised lavapipe + Xvfb smoke test under packaging/test-linux-vulkan/, and a native-ubuntu CI mirror in .github/workflows/linux-present.yml.