### PR TITLE
Add remote GDB debugger frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,16 @@ jobs:
           path: docs/_build/exports/copperline.pdf
           if-no-files-found: ignore
 
+  gdb-remote:
+    name: GDB remote protocol tests
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: RSP unit tests
+        run: cargo test --locked gdbstub
+
   diagrom-smoke:
     name: DiagROM boot smoke
     needs: build-test

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ against real hardware.
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
   (ADF / ADZ / DMS, read-only SCP), Gayle IDE, A2091 SCSI, and CDTV/CD32 CD.
-- **Tooling**: an in-window debugger, deterministic save states, input
-  recording/replay, and headless screenshot/frame-dump capture -- the
-  deterministic core makes every replay byte-identical.
+- **Tooling**: an in-window debugger, remote GDB support, deterministic save
+  states, input recording/replay, and headless screenshot/frame-dump capture
+  -- the deterministic core makes every replay byte-identical.
 
 ## Requirements
 
@@ -178,11 +178,11 @@ images, validation rules, and audio options -- is in the
 ## Documentation
 
 User and developer documentation -- getting started, the UI and shortcuts,
-headless capture, save states, input recording, both debuggers, the
-configuration reference, and the internals (timing model, chipset, CPU,
-video pipeline) -- is published at [copperline.dev](https://copperline.dev/)
-and lives under `docs/` as a [MyST](https://mystmd.org/) project you can also
-build locally:
+headless capture, save states, input recording, the debugger frontends
+(window, headless, and remote GDB), the configuration reference, and the
+internals (timing model, chipset, CPU, video pipeline) -- is published at
+[copperline.dev](https://copperline.dev/) and lives under `docs/` as a
+[MyST](https://mystmd.org/) project you can also build locally:
 
 ```sh
 npm install -g mystmd

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -1,0 +1,113 @@
+# Remote GDB
+
+Copperline can run as a headless GDB remote target:
+
+```sh
+./target/release/copperline --config copperline.example.toml --noaudio --gdb :2345
+```
+
+Port-only forms (`2345` or `:2345`) bind to `127.0.0.1`. Use an explicit
+address such as `0.0.0.0:2345` only on a trusted network: the remote
+protocol can read and write guest RAM and can resume the emulated machine.
+
+Connect from GDB with the 68k architecture selected:
+
+```gdb
+(gdb) set architecture m68k
+(gdb) target remote :2345
+```
+
+The target starts paused at reset. The stub implements the normal all-stop
+remote packets for register access, RAM reads/writes, hardware-style PC
+breakpoints, memory watchpoints, single-step, continue, Ctrl-C interrupt,
+and GDB reverse execution (`reverse-step` / `reverse-continue`).
+
+## CPU and Memory
+
+GDB sees the core 68000 register set as `d0`-`d7`, `a0`-`a6`, `sp`, `ps`,
+and `pc`. Register writes go through Copperline's CPU wrapper so SR stack
+banking and interrupt state stay coherent.
+
+Generic GDB memory packets are intentionally conservative:
+
+- Reads use a side-effect-free CPU-visible RAM/ROM view, including the boot
+  ROM overlay.
+- Writes modify RAM-backed regions only: chip RAM, trapdoor slow RAM, and
+  configured RAM expansion boards.
+- Writes to ROM, overlay ROM, custom chips, CIA, RTC, IDE, SCSI, CD, and
+  other device windows are ignored by `M` packets.
+
+Use `monitor write-reg` for deliberate custom-chip writes.
+
+## Custom Chips
+
+Use GDB's `monitor` command for Amiga-specific state:
+
+```gdb
+(gdb) monitor status
+(gdb) monitor beam
+(gdb) monitor custom
+(gdb) monitor reg DMACON
+(gdb) monitor reg DFF100
+(gdb) monitor write-reg COLOR00 00f
+```
+
+Custom-register inspection is side-effect-free. It reads Copperline's
+internal Agnus/Denise/Paula/blitter latches rather than executing a real CPU
+read from `$DFFxxx`, so it will not acknowledge interrupts, clear latches, or
+advance collision/audio state. `write-reg` is different: it routes a word
+write through the normal custom-register write path and therefore has real
+hardware effects.
+
+Register names match the debugger window (`DMACON`, `BPLCON0`, `COLOR00`,
+`AUD0VOL`, and so on). Numeric offsets (`96`) and full custom addresses
+(`DFF096`) are also accepted.
+
+## Copper
+
+The Copper list can be dumped from the live list pointer, the current Copper
+PC, or an explicit chip-RAM address:
+
+```gdb
+(gdb) monitor copper
+(gdb) monitor copper pc 20
+(gdb) monitor copper 00c01000 80
+```
+
+Counts are hexadecimal, matching GDB's packet syntax and Copperline's other
+debugger address inputs.
+
+## Reverse Debugging
+
+`--gdb` arms the same snapshot-ring reverse debugger used by the window and
+headless reverse watchpoint. GDB commands map as follows:
+
+| GDB command | Copperline operation |
+|---|---|
+| `reverse-step` | reconstruct the previous instruction boundary |
+| `reverse-continue` | run backward to the previous GDB PC breakpoint |
+| `monitor last-writer ADDR` | find the last instruction that changed the watched word |
+
+Reverse history uses `COPPERLINE_DBG_RR_BUDGET_MB` and
+`COPPERLINE_DBG_RR_INTERVAL`, with the same tradeoff as the other frontends:
+more memory and more frequent snapshots make reverse operations faster.
+
+For byte-identical replay, keep the usual determinism requirements from
+[](reverse): set `COPPERLINE_RTC_FIXED_SECS` when guest RTC reads matter, and
+avoid externally mutating hard-drive/CD images during a debug session.
+
+## Monitor Commands
+
+| Command | Effect |
+|---|---|
+| `help` | list monitor commands |
+| `status` | CPU PC/SR, frame, beam, instruction position, reverse status |
+| `beam` | beam/frame/colour-clock position |
+| `custom` | compact custom-chip state dump |
+| `reg NAME\|OFFSET` | side-effect-free custom-register latch read |
+| `write-reg NAME\|OFFSET VALUE` | real custom-register word write |
+| `watch-reg NAME\|OFFSET` | stop on CPU or Copper writes to the custom register |
+| `unwatch-reg NAME\|OFFSET` | remove one custom-register watch |
+| `clear-reg-watches` | remove all custom-register watches |
+| `copper [auto\|pc\|ADDR] [COUNT]` | disassemble Copper instructions |
+| `last-writer ADDR` | reverse-search the last write to a word |

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,8 +44,9 @@ running in Copperline.
   dumps, scripted input, and WAV capture.
 - [](zorro) -- describing additional Zorro II/III expansion boards in
   TOML metadata files.
-- [](debugger/window) and [](debugger/headless) -- the interactive
-  debugger window and the environment-driven headless debugger.
+- [](debugger/window), [](debugger/headless), and [](debugger/gdb) -- the
+  interactive debugger window, environment-driven headless debugger, and
+  remote GDB frontend.
 - [](internals/architecture) -- how the emulator works inside, for
   contributors.
 

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -27,6 +27,7 @@ project:
         - file: debugger/window.md
         - file: debugger/headless.md
         - file: debugger/reverse.md
+        - file: debugger/gdb.md
     - title: Internals
       children:
         - file: internals/architecture.md
@@ -51,6 +52,7 @@ project:
         - debugger/window.md
         - debugger/headless.md
         - debugger/reverse.md
+        - debugger/gdb.md
         - internals/architecture.md
         - internals/timing.md
         - internals/chipset.md
@@ -62,4 +64,5 @@ project:
 site:
   template: book-theme
   options:
+    favicon: ../assets/brand/copperline.ico
     hide_authors: true

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -6131,6 +6131,45 @@ impl Bus {
         )
     }
 
+    /// Side-effect-free debugger view of a custom-register word.
+    ///
+    /// This is intentionally not the CPU-visible custom bus read path:
+    /// inspecting state from GDB or the in-window debugger must not acknowledge
+    /// interrupts, advance collision latches, flush audio, or return an
+    /// undriven-bus value for write-only registers whose internal latch is
+    /// useful to inspect.
+    pub fn debug_custom_word(&self, off: u16) -> Option<u16> {
+        let off = off & 0x1FE;
+        let value = match off {
+            0x002 => {
+                let mut r = self.agnus.dmacon & 0x07FF;
+                if self.blitter.busy {
+                    r |= 1 << 14;
+                }
+                if self.blitter.bzero {
+                    r |= 1 << 13;
+                }
+                r
+            }
+            0x004 => self.agnus.read_vposr(),
+            0x006 => self.agnus.read_vhposr(),
+            0x010 => self.paula.adkcon,
+            0x01C => self.paula.intena,
+            0x01E => self.cpu_visible_intreq(),
+            0x080 => ((self.agnus.cop1lc >> 16) & 0x001F) as u16,
+            0x082 => (self.agnus.cop1lc & 0xFFFE) as u16,
+            0x084 => ((self.agnus.cop2lc >> 16) & 0x001F) as u16,
+            0x086 => (self.agnus.cop2lc & 0xFFFE) as u16,
+            0x096 => self.agnus.dmacon,
+            0x09A => self.paula.intena,
+            0x09C => self.cpu_visible_intreq(),
+            0x09E => self.paula.adkcon,
+            audio @ 0x0A0..=0x0DF => self.paula.peek_audio_reg_latch(audio - 0x0A0)?,
+            other => self.custom_byte_write_latch(other)?,
+        };
+        Some(value)
+    }
+
     /// Read a 16-bit big-endian word from whichever RAM/ROM region maps
     /// `addr` (chip, fast, slow, or ROM), for the debugger's memory dumps.
     /// Returns 0 for unmapped addresses.

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -1080,7 +1080,6 @@ impl Paula {
         0
     }
 
-    #[cfg(test)]
     pub fn peek_audio_reg_latch(&self, reg_off: u16) -> Option<u16> {
         let ch_idx = (reg_off / 0x10) as usize;
         if ch_idx >= 4 {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1009,6 +1009,54 @@ impl M68kMachine {
         self.cpu.d(reg)
     }
 
+    /// Return one GDB-style core register: D0-D7, A0-A7, SR, PC.
+    pub fn debug_register(&self, reg: usize) -> Option<u32> {
+        match reg {
+            0..=7 => Some(self.cpu.d(reg)),
+            8..=15 => Some(self.cpu.a(reg - 8)),
+            16 => Some(u32::from(self.cpu.get_sr())),
+            17 => Some(self.cpu.pc),
+            _ => None,
+        }
+    }
+
+    /// Set one GDB-style core register: D0-D7, A0-A7, SR, PC.
+    pub fn debug_set_register(&mut self, reg: usize, value: u32) -> bool {
+        match reg {
+            0..=7 => self.cpu.set_d(reg, value),
+            8..=15 => self.cpu.set_a(reg - 8, value),
+            16 => self.cpu.set_sr(value as u16),
+            17 => self.cpu.pc = value & self.bus.address_mask,
+            _ => return false,
+        }
+        true
+    }
+
+    /// Side-effect-free CPU-visible memory read for remote debuggers. This
+    /// respects the current address width and boot ROM overlay, but does not
+    /// access device registers or charge bus time.
+    pub fn debug_read_memory(&self, addr: u32, len: usize) -> Vec<u8> {
+        (0..len)
+            .map(|idx| self.bus.peek_byte(addr.wrapping_add(idx as u32)))
+            .collect()
+    }
+
+    /// Side-effect-free CPU-visible memory write for remote debuggers. Only
+    /// RAM-backed regions are mutated; ROM, overlay ROM, and device windows are
+    /// ignored. Returns the number of bytes actually written.
+    pub fn debug_write_memory(&mut self, addr: u32, bytes: &[u8]) -> usize {
+        let mut written = 0usize;
+        for (idx, byte) in bytes.iter().enumerate() {
+            if self
+                .bus
+                .debug_write_byte(addr.wrapping_add(idx as u32), *byte)
+            {
+                written += 1;
+            }
+        }
+        written
+    }
+
     pub fn cpu_type(&self) -> CpuType {
         self.cpu.cpu_type
     }
@@ -1462,6 +1510,38 @@ impl CpuBus {
             return self.bus.mem.extended_rom[off];
         }
         0xFF
+    }
+
+    fn debug_write_byte(&mut self, address: u32, value: u8) -> bool {
+        let addr = self.mask(address);
+        if self.overlay_rom_offset(addr, 1).is_some() {
+            return false;
+        }
+        if let Some(off) = region_offset(self.bus.mem.chip_ram.len(), CHIP_RAM_BASE, addr, 1) {
+            self.bus.mem.chip_ram[off] = value;
+            self.invalidate_debug_write(addr, 1);
+            return true;
+        }
+        if let Some((board, off)) = self.bus.mem.zorro.region_at(addr, 1) {
+            self.bus.mem.zorro.board_ram_mut(board)[off] = value;
+            self.invalidate_debug_write(addr, 1);
+            return true;
+        }
+        if let Some(off) = region_offset(self.bus.mem.slow_ram.len(), SLOW_RAM_BASE, addr, 1) {
+            self.bus.mem.slow_ram[off] = value;
+            self.invalidate_debug_write(addr, 1);
+            return true;
+        }
+        false
+    }
+
+    fn invalidate_debug_write(&mut self, addr: u32, size: usize) {
+        if let Some(cache) = self.icache.as_deref_mut() {
+            cache.invalidate_write(addr, size);
+        }
+        if let Some(cache) = self.dcache.as_deref_mut() {
+            cache.invalidate_write(addr, size);
+        }
     }
 
     /// Word-granular bus cycles for a CPU access of `size` bytes (the 68000

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -590,6 +590,16 @@ impl Emulator {
         self.tt_ring.as_ref()
     }
 
+    /// Capture an initial reverse-debug anchor if reverse mode is armed but no
+    /// snapshot has been retained yet. Remote debuggers call this when a GDB
+    /// session starts so early reverse-step operations can replay from reset.
+    pub fn debug_ensure_time_travel_anchor(&mut self) -> Result<()> {
+        if self.tt_ring.as_ref().is_some_and(|ring| !ring.is_empty()) {
+            return Ok(());
+        }
+        self.tt_capture_if_due()
+    }
+
     /// Record an input action at the current position for deterministic
     /// reverse replay. No-op unless reverse mode is armed; the live forward
     /// application is unchanged and still done by the caller.
@@ -780,8 +790,19 @@ impl Emulator {
     /// may exist before the oldest snapshot. (Watch-based reverse-continue is
     /// not yet modelled; breakpoints only.)
     pub fn tt_reverse_continue(&mut self) -> Result<crate::timetravel::ReverseOutcome<u64>> {
-        use crate::timetravel::ReverseOutcome;
         let breakpoints = self.machine.ui_breaks().breakpoints.clone();
+        self.tt_reverse_continue_to(&breakpoints)
+    }
+
+    /// Run backward to the previous PC breakpoint in `breakpoints`. This is
+    /// the same operation as `tt_reverse_continue`, but takes an explicit
+    /// breakpoint list so remote debugger frontends can keep their protocol
+    /// breakpoints independent from the in-window debugger state.
+    pub fn tt_reverse_continue_to(
+        &mut self,
+        breakpoints: &[u32],
+    ) -> Result<crate::timetravel::ReverseOutcome<u64>> {
+        use crate::timetravel::ReverseOutcome;
         if breakpoints.is_empty() {
             return Ok(ReverseOutcome::NotFound);
         }
@@ -799,7 +820,7 @@ impl Emulator {
                 self.tt_ring.as_ref().and_then(|r| r.oldest_pos()) == Some(anchor.0);
             self.restore_blob(&anchor.1, anchor.0)?;
             self.tt_begin_replay_input(anchor.0);
-            if let Some(pos) = self.tt_scan_breakpoint(&breakpoints, interval_end)? {
+            if let Some(pos) = self.tt_scan_breakpoint(breakpoints, interval_end)? {
                 self.tt_restore_to(pos)?;
                 return Ok(ReverseOutcome::Found(pos));
             }
@@ -1063,6 +1084,28 @@ impl Emulator {
         for _ in 0..count {
             self.execute_cpu_slice(1)?;
             self.machine.refresh_irq_line();
+        }
+        Ok(())
+    }
+
+    /// Execute one debugger-controlled step using the same STOP/idle handling
+    /// as the real-time loop. The caller owns `cpu_idle` across repeated calls
+    /// so a CPU halted in STOP can advance devices to the next wake-up event
+    /// without spinning on zero-instruction slices.
+    pub fn debug_step_for_gdb(&mut self, cpu_idle: &mut bool) -> Result<()> {
+        if self.stats.started_at.is_none() {
+            self.stats.started_at = Some(std::time::Instant::now());
+        }
+        let frame_before = self.bus().emulated_frames();
+        self.run_one_step(cpu_idle, INSTRUCTIONS_PER_REALTIME_SLICE)?;
+        let frame_after = self.bus().emulated_frames();
+        if frame_after != frame_before {
+            self.stats.frames = self
+                .stats
+                .frames
+                .saturating_add(frame_after.saturating_sub(frame_before));
+            self.tt_capture_if_due()?;
+            self.tt_poll_reverse_watch()?;
         }
         Ok(())
     }

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -1,0 +1,842 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Remote GDB protocol frontend for Copperline.
+//!
+//! This is a host debugger transport, not an emulated Amiga device. Generic
+//! GDB memory packets inspect and modify CPU-visible RAM without touching
+//! memory-mapped devices; Amiga custom-chip state is exposed through `monitor`
+//! commands so inspection remains side-effect-free.
+
+use crate::debugger::{custom_reg_name, UI_ADDR_MASK};
+use crate::emulator::Emulator;
+use crate::timetravel::ReverseOutcome;
+use anyhow::{anyhow, Context, Result};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+const TARGET_XML: &str = r#"<?xml version="1.0"?>
+<target>
+  <architecture>m68k</architecture>
+  <feature name="org.gnu.gdb.m68k.core">
+    <reg name="d0" bitsize="32" regnum="0"/>
+    <reg name="d1" bitsize="32" regnum="1"/>
+    <reg name="d2" bitsize="32" regnum="2"/>
+    <reg name="d3" bitsize="32" regnum="3"/>
+    <reg name="d4" bitsize="32" regnum="4"/>
+    <reg name="d5" bitsize="32" regnum="5"/>
+    <reg name="d6" bitsize="32" regnum="6"/>
+    <reg name="d7" bitsize="32" regnum="7"/>
+    <reg name="a0" bitsize="32" regnum="8"/>
+    <reg name="a1" bitsize="32" regnum="9"/>
+    <reg name="a2" bitsize="32" regnum="10"/>
+    <reg name="a3" bitsize="32" regnum="11"/>
+    <reg name="a4" bitsize="32" regnum="12"/>
+    <reg name="a5" bitsize="32" regnum="13"/>
+    <reg name="a6" bitsize="32" regnum="14"/>
+    <reg name="sp" bitsize="32" regnum="15" type="data_ptr"/>
+    <reg name="ps" bitsize="32" regnum="16"/>
+    <reg name="pc" bitsize="32" regnum="17" type="code_ptr"/>
+  </feature>
+</target>
+"#;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    pub listen: String,
+    pub reverse_budget_mb: usize,
+    pub reverse_interval_frames: u64,
+}
+
+impl Config {
+    pub fn new(listen: String) -> Self {
+        Self {
+            listen,
+            reverse_budget_mb: crate::envcfg::var("COPPERLINE_DBG_RR_BUDGET_MB")
+                .and_then(|s| s.trim().parse::<usize>().ok())
+                .unwrap_or(crate::debugger::RR_DEFAULT_BUDGET_MB),
+            reverse_interval_frames: crate::envcfg::var("COPPERLINE_DBG_RR_INTERVAL")
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .unwrap_or(crate::debugger::RR_DEFAULT_INTERVAL_FRAMES),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Watchpoint {
+    addr: u32,
+    len: usize,
+    last: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StopReason {
+    Attached,
+    Step,
+    Breakpoint,
+    Watchpoint(u32),
+    RegisterWatch,
+    Reverse,
+    Interrupted,
+}
+
+pub fn run(mut emu: Emulator, config: Config) -> Result<()> {
+    let bind = normalize_listen_addr(&config.listen)?;
+    let listener = TcpListener::bind(&bind).with_context(|| format!("binding GDB stub {bind}"))?;
+    log::info!("gdb: listening on {bind}");
+    let (stream, peer) = listener.accept().context("accepting GDB connection")?;
+    log::info!("gdb: connection from {peer}");
+    stream.set_nodelay(true).ok();
+
+    emu.set_paced(false);
+    emu.enable_time_travel(config.reverse_budget_mb, config.reverse_interval_frames);
+    emu.debug_ensure_time_travel_anchor()?;
+
+    Session::new(emu, stream).run()
+}
+
+fn normalize_listen_addr(input: &str) -> Result<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("--gdb requires ADDR, :PORT, or PORT"));
+    }
+    if trimmed.starts_with(':') {
+        return Ok(format!("127.0.0.1{trimmed}"));
+    }
+    if trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(format!("127.0.0.1:{trimmed}"));
+    }
+    Ok(trimmed.to_string())
+}
+
+struct Session {
+    emu: Emulator,
+    stream: TcpStream,
+    no_ack: bool,
+    breakpoints: Vec<u32>,
+    watchpoints: Vec<Watchpoint>,
+    reg_watches: Vec<u16>,
+    stop: StopReason,
+    cpu_idle: bool,
+}
+
+impl Session {
+    fn new(emu: Emulator, stream: TcpStream) -> Self {
+        Self {
+            emu,
+            stream,
+            no_ack: false,
+            breakpoints: Vec::new(),
+            watchpoints: Vec::new(),
+            reg_watches: Vec::new(),
+            stop: StopReason::Attached,
+            cpu_idle: false,
+        }
+    }
+
+    fn run(&mut self) -> Result<()> {
+        loop {
+            let Some(packet) = self.read_packet()? else {
+                return Ok(());
+            };
+            if packet == "QStartNoAckMode" {
+                self.send_packet("OK")?;
+                self.no_ack = true;
+                continue;
+            }
+            match self.handle_packet(&packet)? {
+                PacketOutcome::Reply(reply) => self.send_packet(&reply)?,
+                PacketOutcome::Disconnect => {
+                    self.send_packet("OK")?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn handle_packet(&mut self, packet: &str) -> Result<PacketOutcome> {
+        let reply = match packet {
+            "!" => "OK".to_string(),
+            "?" => self.stop_reply(),
+            "g" => self.read_all_registers(),
+            "qC" => "QC1".to_string(),
+            "qAttached" | "qAttached:1" => "1".to_string(),
+            "qfThreadInfo" => "m1".to_string(),
+            "qsThreadInfo" => "l".to_string(),
+            "vCont?" => "vCont;c;s".to_string(),
+            "D" | "D;1" => return Ok(PacketOutcome::Disconnect),
+            "k" => return Ok(PacketOutcome::Disconnect),
+            _ if packet.starts_with("qSupported") => {
+                "PacketSize=4000;QStartNoAckMode+;qXfer:features:read+;hwbreak+;ReverseStep+;ReverseContinue+".to_string()
+            }
+            _ if packet.starts_with("qXfer:features:read:target.xml:") => {
+                self.read_target_xml(packet)?
+            }
+            _ if packet.starts_with("qRcmd,") => {
+                let command = String::from_utf8(hex_decode(&packet[6..])?)
+                    .context("decoding monitor command")?;
+                let output = self.handle_monitor(command.trim())?;
+                self.send_console(&output)?;
+                "OK".to_string()
+            }
+            _ if packet.starts_with('H') => "OK".to_string(),
+            _ if packet.starts_with('T') => "OK".to_string(),
+            _ if packet.starts_with('p') => self.read_register(&packet[1..])?,
+            _ if packet.starts_with('P') => self.write_register(&packet[1..])?,
+            _ if packet.starts_with('m') => self.read_memory(&packet[1..])?,
+            _ if packet.starts_with('M') => self.write_memory(&packet[1..])?,
+            _ if packet.starts_with("Z0,") || packet.starts_with("Z1,") => {
+                self.add_breakpoint(packet)?
+            }
+            _ if packet.starts_with("z0,") || packet.starts_with("z1,") => {
+                self.remove_breakpoint(packet)?
+            }
+            _ if packet.starts_with("Z2,") || packet.starts_with("Z3,") || packet.starts_with("Z4,") => {
+                self.add_watchpoint(packet)?
+            }
+            _ if packet.starts_with("z2,") || packet.starts_with("z3,") || packet.starts_with("z4,") => {
+                self.remove_watchpoint(packet)?
+            }
+            _ if packet == "s" || packet.starts_with("s") => {
+                if let Some(addr) = packet.strip_prefix('s').filter(|s| !s.is_empty()) {
+                    let pc = parse_hex_u32(addr)?;
+                    self.emu.machine.debug_set_register(17, pc);
+                }
+                self.step_forward()?
+            }
+            _ if packet == "c" || packet.starts_with("c") => {
+                if let Some(addr) = packet.strip_prefix('c').filter(|s| !s.is_empty()) {
+                    let pc = parse_hex_u32(addr)?;
+                    self.emu.machine.debug_set_register(17, pc);
+                }
+                self.continue_forward()?
+            }
+            _ if packet.starts_with("vCont;c") => self.continue_forward()?,
+            _ if packet.starts_with("vCont;s") => self.step_forward()?,
+            "bs" => self.reverse_step()?,
+            "bc" => self.reverse_continue()?,
+            _ => String::new(),
+        };
+        Ok(PacketOutcome::Reply(reply))
+    }
+
+    fn read_packet(&mut self) -> Result<Option<String>> {
+        let mut byte = [0u8; 1];
+        loop {
+            match self.stream.read_exact(&mut byte) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(e) => return Err(e).context("reading GDB packet"),
+            }
+            match byte[0] {
+                b'+' | b'-' => continue,
+                b'$' => break,
+                0x03 => {
+                    self.stop = StopReason::Interrupted;
+                    return Ok(Some("?".to_string()));
+                }
+                _ => continue,
+            }
+        }
+
+        let mut payload = Vec::new();
+        loop {
+            self.stream
+                .read_exact(&mut byte)
+                .context("reading GDB packet payload")?;
+            if byte[0] == b'#' {
+                break;
+            }
+            payload.push(byte[0]);
+        }
+        let mut sum_bytes = [0u8; 2];
+        self.stream
+            .read_exact(&mut sum_bytes)
+            .context("reading GDB packet checksum")?;
+        let expected = parse_hex_byte(sum_bytes[0], sum_bytes[1])?;
+        let actual = checksum(&payload);
+        if expected != actual {
+            if !self.no_ack {
+                self.stream.write_all(b"-").ok();
+            }
+            return self.read_packet();
+        }
+        if !self.no_ack {
+            self.stream.write_all(b"+").ok();
+        }
+        String::from_utf8(payload)
+            .map(Some)
+            .context("GDB packet is not UTF-8")
+    }
+
+    fn send_packet(&mut self, payload: &str) -> Result<()> {
+        let sum = checksum(payload.as_bytes());
+        write!(self.stream, "${payload}#{sum:02x}").context("sending GDB packet")?;
+        self.stream.flush().ok();
+        Ok(())
+    }
+
+    fn send_console(&mut self, output: &str) -> Result<()> {
+        for line in output.as_bytes().chunks(200) {
+            self.send_packet(&format!("O{}", hex_encode(line)))?;
+        }
+        Ok(())
+    }
+
+    fn stop_reply(&self) -> String {
+        match &self.stop {
+            StopReason::Watchpoint(addr) => format!("T05watch:{addr:x};thread:1;"),
+            StopReason::RegisterWatch => "T05thread:1;".to_string(),
+            StopReason::Breakpoint => "T05hwbreak:;thread:1;".to_string(),
+            _ => "T05thread:1;".to_string(),
+        }
+    }
+
+    fn read_all_registers(&self) -> String {
+        let mut out = String::with_capacity(18 * 8);
+        for reg in 0..18 {
+            let value = self.emu.machine.debug_register(reg).unwrap_or(0);
+            out.push_str(&format!("{value:08x}"));
+        }
+        out
+    }
+
+    fn read_register(&self, reg: &str) -> Result<String> {
+        let reg = parse_hex_usize(reg)?;
+        Ok(match self.emu.machine.debug_register(reg) {
+            Some(value) => format!("{value:08x}"),
+            None => "E00".to_string(),
+        })
+    }
+
+    fn write_register(&mut self, payload: &str) -> Result<String> {
+        let Some((reg_s, value_s)) = payload.split_once('=') else {
+            return Ok("E01".to_string());
+        };
+        let reg = parse_hex_usize(reg_s)?;
+        let bytes = hex_decode(value_s)?;
+        let mut value = 0u32;
+        for byte in bytes.iter().take(4) {
+            value = (value << 8) | u32::from(*byte);
+        }
+        Ok(if self.emu.machine.debug_set_register(reg, value) {
+            self.emu.machine.refresh_irq_line();
+            "OK".to_string()
+        } else {
+            "E00".to_string()
+        })
+    }
+
+    fn read_memory(&self, payload: &str) -> Result<String> {
+        let Some((addr_s, len_s)) = payload.split_once(',') else {
+            return Ok("E01".to_string());
+        };
+        let addr = parse_hex_u32(addr_s)?;
+        let len = parse_hex_usize(len_s)?;
+        Ok(hex_encode(&self.emu.machine.debug_read_memory(addr, len)))
+    }
+
+    fn write_memory(&mut self, payload: &str) -> Result<String> {
+        let Some((range, data_s)) = payload.split_once(':') else {
+            return Ok("E01".to_string());
+        };
+        let Some((addr_s, len_s)) = range.split_once(',') else {
+            return Ok("E01".to_string());
+        };
+        let addr = parse_hex_u32(addr_s)?;
+        let len = parse_hex_usize(len_s)?;
+        let data = hex_decode(data_s)?;
+        if data.len() != len {
+            return Ok("E02".to_string());
+        }
+        let written = self.emu.machine.debug_write_memory(addr, &data);
+        self.refresh_watchpoints();
+        Ok(if written == len {
+            "OK".to_string()
+        } else {
+            "E03".to_string()
+        })
+    }
+
+    fn add_breakpoint(&mut self, packet: &str) -> Result<String> {
+        let (addr, _) = parse_z_packet(packet)?;
+        let addr = addr & UI_ADDR_MASK;
+        if !self.breakpoints.contains(&addr) {
+            self.breakpoints.push(addr);
+        }
+        Ok("OK".to_string())
+    }
+
+    fn remove_breakpoint(&mut self, packet: &str) -> Result<String> {
+        let (addr, _) = parse_z_packet(packet)?;
+        let addr = addr & UI_ADDR_MASK;
+        self.breakpoints.retain(|&candidate| candidate != addr);
+        Ok("OK".to_string())
+    }
+
+    fn add_watchpoint(&mut self, packet: &str) -> Result<String> {
+        let (addr, len) = parse_z_packet(packet)?;
+        let len = len.max(1);
+        let last = self.emu.machine.debug_read_memory(addr, len);
+        if let Some(existing) = self
+            .watchpoints
+            .iter_mut()
+            .find(|w| w.addr == addr && w.len == len)
+        {
+            existing.last = last;
+        } else {
+            self.watchpoints.push(Watchpoint { addr, len, last });
+        }
+        Ok("OK".to_string())
+    }
+
+    fn remove_watchpoint(&mut self, packet: &str) -> Result<String> {
+        let (addr, len) = parse_z_packet(packet)?;
+        self.watchpoints
+            .retain(|watch| watch.addr != addr || watch.len != len.max(1));
+        Ok("OK".to_string())
+    }
+
+    fn step_forward(&mut self) -> Result<String> {
+        self.stop = StopReason::Step;
+        self.emu.debug_step_for_gdb(&mut self.cpu_idle)?;
+        if let Some(stop) = self.check_stop()? {
+            self.stop = stop;
+        }
+        Ok(self.stop_reply())
+    }
+
+    fn continue_forward(&mut self) -> Result<String> {
+        loop {
+            self.emu.debug_step_for_gdb(&mut self.cpu_idle)?;
+            if let Some(stop) = self.check_stop()? {
+                self.stop = stop;
+                return Ok(self.stop_reply());
+            }
+            if self.poll_interrupt()? {
+                self.stop = StopReason::Interrupted;
+                return Ok(self.stop_reply());
+            }
+        }
+    }
+
+    fn reverse_step(&mut self) -> Result<String> {
+        match self.emu.tt_reverse_step(1)? {
+            ReverseOutcome::Found(_) => {
+                self.cpu_idle = false;
+                self.refresh_watchpoints();
+                self.stop = StopReason::Reverse;
+                Ok(self.stop_reply())
+            }
+            ReverseOutcome::NotFound | ReverseOutcome::BeyondHistory => Ok("E01".to_string()),
+        }
+    }
+
+    fn reverse_continue(&mut self) -> Result<String> {
+        match self.emu.tt_reverse_continue_to(&self.breakpoints)? {
+            ReverseOutcome::Found(_) => {
+                self.cpu_idle = false;
+                self.refresh_watchpoints();
+                self.stop = StopReason::Breakpoint;
+                Ok(self.stop_reply())
+            }
+            ReverseOutcome::NotFound | ReverseOutcome::BeyondHistory => Ok("E01".to_string()),
+        }
+    }
+
+    fn check_stop(&mut self) -> Result<Option<StopReason>> {
+        if self.emu.bus_mut().take_ui_reg_hit().is_some() {
+            return Ok(Some(StopReason::RegisterWatch));
+        }
+        let pc = self.emu.machine.pc() & UI_ADDR_MASK;
+        if self.breakpoints.contains(&pc) {
+            return Ok(Some(StopReason::Breakpoint));
+        }
+        for watch in &mut self.watchpoints {
+            let cur = self.emu.machine.debug_read_memory(watch.addr, watch.len);
+            if cur != watch.last {
+                watch.last = cur;
+                return Ok(Some(StopReason::Watchpoint(watch.addr)));
+            }
+        }
+        Ok(None)
+    }
+
+    fn refresh_watchpoints(&mut self) {
+        for watch in &mut self.watchpoints {
+            watch.last = self.emu.machine.debug_read_memory(watch.addr, watch.len);
+        }
+    }
+
+    fn poll_interrupt(&mut self) -> Result<bool> {
+        self.stream
+            .set_nonblocking(true)
+            .context("setting GDB stream nonblocking")?;
+        let mut byte = [0u8; 1];
+        let result = match self.stream.peek(&mut byte) {
+            Ok(1) if byte[0] == 0x03 => {
+                let _ = self.stream.read(&mut byte);
+                Ok(true)
+            }
+            Ok(_) => Ok(false),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(false),
+            Err(e) => Err(e).context("polling GDB interrupt"),
+        };
+        self.stream
+            .set_nonblocking(false)
+            .context("restoring GDB stream blocking mode")?;
+        result
+    }
+
+    fn read_target_xml(&self, packet: &str) -> Result<String> {
+        let Some((_, range)) = packet.rsplit_once(':') else {
+            return Ok("E01".to_string());
+        };
+        let Some((offset_s, len_s)) = range.split_once(',') else {
+            return Ok("E01".to_string());
+        };
+        let offset = parse_hex_usize(offset_s)?;
+        let len = parse_hex_usize(len_s)?;
+        let bytes = TARGET_XML.as_bytes();
+        if offset >= bytes.len() {
+            return Ok("l".to_string());
+        }
+        let end = offset.saturating_add(len).min(bytes.len());
+        let prefix = if end == bytes.len() { 'l' } else { 'm' };
+        let chunk = std::str::from_utf8(&bytes[offset..end]).expect("target XML is UTF-8");
+        Ok(format!("{prefix}{chunk}"))
+    }
+
+    fn handle_monitor(&mut self, command: &str) -> Result<String> {
+        let mut parts = command.split_whitespace();
+        let Some(cmd) = parts.next() else {
+            return Ok(monitor_help());
+        };
+        match cmd {
+            "help" => Ok(monitor_help()),
+            "status" => Ok(self.monitor_status()),
+            "beam" => Ok(format!(
+                "beam vpos={} hpos={} frame={} cck={} pos={}\n",
+                self.emu.bus().agnus.vpos,
+                self.emu.bus().agnus.hpos,
+                self.emu.bus().emulated_frames(),
+                self.emu.bus().emulated_cck(),
+                self.emu.retired_instructions()
+            )),
+            "custom" => Ok(self.monitor_custom()),
+            "reg" => {
+                let Some(name) = parts.next() else {
+                    return Ok("usage: monitor reg NAME|OFFSET\n".to_string());
+                };
+                let Some(off) = parse_custom_reg(name) else {
+                    return Ok(format!("unknown custom register {name}\n"));
+                };
+                Ok(self.monitor_reg(off))
+            }
+            "write-reg" => {
+                let Some(name) = parts.next() else {
+                    return Ok("usage: monitor write-reg NAME|OFFSET VALUE\n".to_string());
+                };
+                let Some(value_s) = parts.next() else {
+                    return Ok("usage: monitor write-reg NAME|OFFSET VALUE\n".to_string());
+                };
+                let Some(off) = parse_custom_reg(name) else {
+                    return Ok(format!("unknown custom register {name}\n"));
+                };
+                let value = parse_hex_u16(value_s)?;
+                let irq = self
+                    .emu
+                    .bus_mut()
+                    .custom_write(u64::from(off), 2, u64::from(value));
+                if irq {
+                    self.emu.machine.refresh_irq_line();
+                }
+                Ok(format!(
+                    "{} ${off:03X} <- ${value:04X}\n",
+                    custom_reg_name(off)
+                ))
+            }
+            "watch-reg" => {
+                let Some(name) = parts.next() else {
+                    return Ok("usage: monitor watch-reg NAME|OFFSET\n".to_string());
+                };
+                let Some(off) = parse_custom_reg(name) else {
+                    return Ok(format!("unknown custom register {name}\n"));
+                };
+                if !self.reg_watches.contains(&off) {
+                    self.reg_watches.push(off);
+                    self.emu.bus_mut().set_ui_reg_watches(&self.reg_watches);
+                }
+                Ok(format!("watching {} ${off:03X}\n", custom_reg_name(off)))
+            }
+            "unwatch-reg" => {
+                let Some(name) = parts.next() else {
+                    return Ok("usage: monitor unwatch-reg NAME|OFFSET\n".to_string());
+                };
+                let Some(off) = parse_custom_reg(name) else {
+                    return Ok(format!("unknown custom register {name}\n"));
+                };
+                self.reg_watches.retain(|&candidate| candidate != off);
+                self.emu.bus_mut().set_ui_reg_watches(&self.reg_watches);
+                Ok(format!(
+                    "not watching {} ${off:03X}\n",
+                    custom_reg_name(off)
+                ))
+            }
+            "clear-reg-watches" => {
+                self.reg_watches.clear();
+                self.emu.bus_mut().set_ui_reg_watches(&[]);
+                Ok("cleared custom-register watches\n".to_string())
+            }
+            "copper" => self.monitor_copper(parts.collect()),
+            "last-writer" => {
+                let Some(addr_s) = parts.next() else {
+                    return Ok("usage: monitor last-writer ADDR\n".to_string());
+                };
+                let addr = parse_hex_u32(addr_s)? & !1;
+                let before = self.emu.retired_instructions();
+                match self.emu.tt_last_writer(addr, before)? {
+                    ReverseOutcome::Found(rec) => {
+                        self.cpu_idle = false;
+                        self.refresh_watchpoints();
+                        Ok(format!(
+                            "last writer ${:06X}: {:04X}->{:04X} pc=${:08X} pos={} frame={} cck={}\n",
+                            rec.addr, rec.old, rec.new, rec.pc, rec.pos, rec.frame, rec.cck
+                        ))
+                    }
+                    ReverseOutcome::NotFound => Ok(format!(
+                        "no write to ${addr:06X} found in retained history\n"
+                    )),
+                    ReverseOutcome::BeyondHistory => Ok(format!(
+                        "last write to ${addr:06X} predates retained history\n"
+                    )),
+                }
+            }
+            _ => Ok(format!("unknown monitor command {cmd}\n{}", monitor_help())),
+        }
+    }
+
+    fn monitor_status(&self) -> String {
+        format!(
+            "pc=${:08X} sr=${:04X} frame={} beam=({}, {}) pos={} reverse={}\n",
+            self.emu.machine.pc(),
+            self.emu.machine.sr(),
+            self.emu.bus().emulated_frames(),
+            self.emu.bus().agnus.vpos,
+            self.emu.bus().agnus.hpos,
+            self.emu.retired_instructions(),
+            if self.emu.time_travel_enabled() {
+                "armed"
+            } else {
+                "off"
+            }
+        )
+    }
+
+    fn monitor_custom(&self) -> String {
+        let bus = self.emu.bus();
+        let mut out = String::new();
+        out.push_str(&format!(
+            "beam vpos={} hpos={} frame={}\n",
+            bus.agnus.vpos,
+            bus.agnus.hpos,
+            bus.emulated_frames()
+        ));
+        out.push_str(&format!("{}\n", bus.debug_display_state()));
+        for off in [
+            0x002, 0x004, 0x006, 0x010, 0x01C, 0x01E, 0x080, 0x082, 0x084, 0x086, 0x096, 0x09A,
+            0x09C, 0x09E, 0x100, 0x102, 0x104, 0x106, 0x108, 0x10A, 0x1FC,
+        ] {
+            if let Some(value) = bus.debug_custom_word(off) {
+                out.push_str(&format!(
+                    "{:<8} ${off:03X} = ${value:04X}\n",
+                    custom_reg_name(off)
+                ));
+            }
+        }
+        out
+    }
+
+    fn monitor_reg(&self, off: u16) -> String {
+        match self.emu.bus().debug_custom_word(off) {
+            Some(value) => format!("{} ${off:03X} = ${value:04X}\n", custom_reg_name(off)),
+            None => format!("{} ${off:03X}: no debug latch\n", custom_reg_name(off)),
+        }
+    }
+
+    fn monitor_copper(&self, args: Vec<&str>) -> Result<String> {
+        let bus = self.emu.bus();
+        let start = match args.first().copied() {
+            None | Some("auto") => bus.agnus.cop1lc,
+            Some("pc") => bus.copper.pc(),
+            Some(addr) => parse_hex_u32(addr)?,
+        };
+        let count = match args.get(1).copied() {
+            Some(count) => parse_hex_usize(count)?,
+            None => 64,
+        };
+        let mut out = format!(
+            "COP1LC ${:06X} COP2LC ${:06X} COPPC ${:06X} ({})\n",
+            bus.agnus.cop1lc,
+            bus.agnus.cop2lc,
+            bus.copper.pc(),
+            if bus.copper.is_running() {
+                "running"
+            } else {
+                "stopped"
+            }
+        );
+        for (addr, text) in
+            crate::disasm::dump_copper_list(|addr| self.emu.bus().peek_word_any(addr), start, count)
+        {
+            out.push_str(&format!("{addr:06X}  {text}\n"));
+        }
+        Ok(out)
+    }
+}
+
+enum PacketOutcome {
+    Reply(String),
+    Disconnect,
+}
+
+fn monitor_help() -> String {
+    "monitor commands:\n\
+     help\n\
+     status | beam | custom\n\
+     reg NAME|OFFSET\n\
+     write-reg NAME|OFFSET VALUE\n\
+     watch-reg NAME|OFFSET | unwatch-reg NAME|OFFSET | clear-reg-watches\n\
+     copper [auto|pc|ADDR] [COUNT]\n\
+     last-writer ADDR\n"
+        .to_string()
+}
+
+fn parse_z_packet(packet: &str) -> Result<(u32, usize)> {
+    let mut fields = packet.split(',');
+    let _kind = fields.next();
+    let addr = fields
+        .next()
+        .ok_or_else(|| anyhow!("missing Z/z address"))?;
+    let kind = fields
+        .next()
+        .ok_or_else(|| anyhow!("missing Z/z kind"))?
+        .split(';')
+        .next()
+        .unwrap_or("1");
+    Ok((parse_hex_u32(addr)?, parse_hex_usize(kind)?))
+}
+
+fn parse_custom_reg(input: &str) -> Option<u16> {
+    if let Ok(value) = parse_hex_u32(input) {
+        return Some(custom_offset_from_value(value));
+    }
+    let needle = input.trim().to_ascii_uppercase();
+    (0..=0x1FEu16)
+        .step_by(2)
+        .find(|&off| custom_reg_name(off).to_ascii_uppercase() == needle)
+}
+
+fn custom_offset_from_value(value: u32) -> u16 {
+    if (0x00DF_F000..=0x00DF_FFFF).contains(&value) {
+        (value - 0x00DF_F000) as u16 & 0x1FE
+    } else {
+        value as u16 & 0x1FE
+    }
+}
+
+fn parse_hex_u16(input: &str) -> Result<u16> {
+    let value = parse_hex_u32(input)?;
+    Ok(value as u16)
+}
+
+fn parse_hex_u32(input: &str) -> Result<u32> {
+    let trimmed = input
+        .trim()
+        .trim_start_matches('$')
+        .trim_start_matches("0x")
+        .trim_start_matches("0X");
+    u32::from_str_radix(trimmed, 16).with_context(|| format!("invalid hex value {input:?}"))
+}
+
+fn parse_hex_usize(input: &str) -> Result<usize> {
+    let value = parse_hex_u32(input)?;
+    Ok(value as usize)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn hex_decode(input: &str) -> Result<Vec<u8>> {
+    let bytes = input.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return Err(anyhow!("hex string has odd length"));
+    }
+    bytes
+        .chunks(2)
+        .map(|pair| parse_hex_byte(pair[0], pair[1]))
+        .collect()
+}
+
+fn parse_hex_byte(hi: u8, lo: u8) -> Result<u8> {
+    let hi = hex_nibble(hi)?;
+    let lo = hex_nibble(lo)?;
+    Ok((hi << 4) | lo)
+}
+
+fn hex_nibble(byte: u8) -> Result<u8> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(anyhow!("invalid hex digit {:?}", byte as char)),
+    }
+}
+
+fn checksum(bytes: &[u8]) -> u8 {
+    bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listen_addr_defaults_to_loopback_for_port_forms() -> Result<()> {
+        assert_eq!(normalize_listen_addr(":2345")?, "127.0.0.1:2345");
+        assert_eq!(normalize_listen_addr("2345")?, "127.0.0.1:2345");
+        assert_eq!(normalize_listen_addr("0.0.0.0:2345")?, "0.0.0.0:2345");
+        Ok(())
+    }
+
+    #[test]
+    fn hex_round_trip_and_checksum_match_rsp_framing() -> Result<()> {
+        let data = b"m1000,10";
+        assert_eq!(hex_decode(&hex_encode(data))?, data);
+        assert_eq!(checksum(data), 0xbb);
+        Ok(())
+    }
+
+    #[test]
+    fn custom_register_parser_accepts_names_offsets_and_addresses() {
+        assert_eq!(parse_custom_reg("DMACON"), Some(0x096));
+        assert_eq!(parse_custom_reg("dff096"), Some(0x096));
+        assert_eq!(parse_custom_reg("$96"), Some(0x096));
+        assert_eq!(parse_custom_reg("COLOR00"), Some(0x180));
+        assert_eq!(parse_custom_reg("notareg"), None);
+    }
+
+    #[test]
+    fn target_xml_chunk_uses_rsp_more_and_last_prefixes() -> Result<()> {
+        let mut bytes = TARGET_XML.as_bytes();
+        let first = &bytes[..16];
+        assert_eq!(first[0], b'<');
+        bytes = &bytes[bytes.len() - 8..];
+        assert!(!bytes.is_empty());
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod envcfg;
 mod floppy;
 mod gamepad;
 mod gayle;
+mod gdbstub;
 mod harddrive;
 mod inputrec;
 mod inputsched;
@@ -77,6 +78,9 @@ pub struct CliArgs {
     /// `--benchmark-until SECS`: run frames directly, without opening a
     /// window, until the absolute emulated-time target is reached.
     pub benchmark_until: Option<f32>,
+    /// `--gdb ADDR`: run a headless GDB remote-protocol server on ADDR,
+    /// `:PORT`, or `PORT`, pausing at reset until the debugger resumes.
+    pub gdb: Option<gdbstub::Config>,
     /// Dump consecutive rendered frames after an emulated-time delay. This
     /// is intended for debugging flicker and frame-to-frame palette
     /// changes that a single screenshot cannot show.
@@ -243,6 +247,7 @@ where
     let mut save_state_after: Option<(f32, PathBuf)> = None;
     let mut load_state: Option<PathBuf> = None;
     let mut benchmark_until: Option<f32> = None;
+    let mut gdb: Option<gdbstub::Config> = None;
     let mut dump_dir: Option<PathBuf> = None;
     let mut dump_start_secs: f32 = 0.0;
     let mut dump_count: Option<u32> = None;
@@ -497,6 +502,12 @@ where
                 }
                 benchmark_until = Some(secs);
             }
+            "--gdb" | "--gdb-listen" => {
+                let listen = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--gdb requires ADDR, :PORT, or PORT"))?;
+                gdb = Some(gdbstub::Config::new(listen));
+            }
             "--dump-frames" => {
                 let path = args
                     .next()
@@ -574,7 +585,7 @@ where
             "--profile-live-audio and --noaudio are mutually exclusive"
         ));
     }
-    if benchmark_until.is_some() && !explicit_audio_live && audio_wav.is_none() {
+    if (benchmark_until.is_some() || gdb.is_some()) && !explicit_audio_live && audio_wav.is_none() {
         audio_live = false;
     }
     let frame_dump = match (dump_dir, dump_count) {
@@ -599,6 +610,7 @@ where
         save_state_after,
         load_state,
         benchmark_until,
+        gdb,
         frame_dump,
         press_after,
         click_after,
@@ -639,6 +651,8 @@ fn print_help() {
          \x20                            its emulated timeline\n  \
          --benchmark-until SECS         run frames with no window until absolute emulated\n  \
          \x20                            time SECS, report counters, then exit\n  \
+         --gdb ADDR                     run a headless GDB remote server on ADDR,\n  \
+         \x20                            :PORT, or PORT; port-only forms bind 127.0.0.1\n  \
          --dump-frames DIR              dump consecutive PNG frames into DIR, then exit\n  \
          --dump-start SECS              start frame dumping after SECS seconds (default: 0)\n  \
          --dump-count COUNT             number of frames to dump with --dump-frames\n  \
@@ -774,6 +788,48 @@ fn validate_benchmark_args(cli: &CliArgs) -> Result<()> {
     Ok(())
 }
 
+fn validate_gdb_args(cli: &CliArgs) -> Result<()> {
+    if cli.gdb.is_none() {
+        return Ok(());
+    }
+
+    if cli.benchmark_until.is_some() {
+        return Err(anyhow!("--gdb cannot be combined with --benchmark-until"));
+    }
+    if cli.screenshot_after.is_some() {
+        return Err(anyhow!("--gdb cannot be combined with --screenshot-after"));
+    }
+    if cli.save_state_after.is_some() {
+        return Err(anyhow!("--gdb cannot be combined with --save-state-after"));
+    }
+    if cli.frame_dump.is_some() {
+        return Err(anyhow!("--gdb cannot be combined with --dump-frames"));
+    }
+    if cli.live_audio_profile_secs.is_some() {
+        return Err(anyhow!(
+            "--gdb cannot be combined with --profile-live-audio"
+        ));
+    }
+    if !cli.press_after.is_empty()
+        || !cli.click_after.is_empty()
+        || !cli.joy_after.is_empty()
+        || !cli.mouse_after.is_empty()
+    {
+        return Err(anyhow!(
+            "--gdb cannot be combined with scheduled input events"
+        ));
+    }
+    if cli.record_input.is_some() {
+        return Err(anyhow!("--gdb cannot be combined with --record-input"));
+    }
+    if !cli.disk_insert_after.is_empty() {
+        return Err(anyhow!(
+            "--gdb cannot be combined with scheduled disk inserts"
+        ));
+    }
+    Ok(())
+}
+
 fn run_headless_benchmark(mut emu: Emulator, target_secs: f32) -> Result<()> {
     emu.set_paced(false);
     emu.reset_stats();
@@ -833,6 +889,7 @@ fn main() -> Result<()> {
 
     let cli = parse_args()?;
     validate_benchmark_args(&cli)?;
+    validate_gdb_args(&cli)?;
     if cli.calibrate_gamepad {
         return gamepad::run_calibration();
     }
@@ -1000,8 +1057,10 @@ fn main() -> Result<()> {
     // Headless capture runs (screenshot / frame dump) advance the
     // deterministic core unthrottled; the interactive window paces to
     // wall-clock time. The emulated result is identical either way.
-    let headless_capture =
-        cli.screenshot_after.is_some() || cli.frame_dump.is_some() || cli.benchmark_until.is_some();
+    let headless_capture = cli.screenshot_after.is_some()
+        || cli.frame_dump.is_some()
+        || cli.benchmark_until.is_some()
+        || cli.gdb.is_some();
     let paced = !headless_capture;
     info!("emulation timing: deterministic core, paced={paced}");
     let cpu_clocks_per_cck = crate::config::clocks_per_cck_for_mhz(cfg.cpu_clock_mhz);
@@ -1041,6 +1100,9 @@ fn main() -> Result<()> {
     }
     if let Some(target_secs) = cli.benchmark_until {
         return run_headless_benchmark(emu, target_secs);
+    }
+    if let Some(gdb) = cli.gdb {
+        return gdbstub::run(emu, gdb);
     }
     let disk_write_protected = std::array::from_fn(|idx| {
         cfg.floppy.drives[idx]
@@ -1466,6 +1528,36 @@ mod tests {
             "/tmp/x",
         ])?;
         let err = validate_benchmark_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--screenshot-after"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
+    fn gdb_mode_parses_and_defaults_to_null_audio() -> Result<()> {
+        let args = parse(&["--gdb", ":2345"])?;
+        assert_eq!(
+            args.gdb,
+            Some(crate::gdbstub::Config::new(":2345".to_string()))
+        );
+        assert!(!args.audio_live);
+        validate_gdb_args(&args)?;
+        Ok(())
+    }
+
+    #[test]
+    fn gdb_mode_rejects_window_scheduled_work() -> Result<()> {
+        let args = parse(&["--gdb", ":2345", "--press-after", "1.0", "ctrl"])?;
+        let err = validate_gdb_args(&args).unwrap_err();
+        assert!(err.to_string().contains("scheduled input"), "{err:#}");
+
+        let args = parse(&[
+            "--gdb",
+            ":2345",
+            "--screenshot-after",
+            "1.0",
+            "/tmp/gdb.png",
+        ])?;
+        let err = validate_gdb_args(&args).unwrap_err();
         assert!(err.to_string().contains("--screenshot-after"), "{err:#}");
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add a headless GDB RSP frontend with 68k register access, RAM memory packets, breakpoints/watchpoints, and monitor commands for custom-chip state and Copper lists
- wire GDB mode into the CLI and existing reverse-debug snapshot ring for reverse-step, reverse-continue, and last-writer queries
- document the workflow and add a focused CI job for RSP unit tests

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --locked
- cargo build --release --locked
- myst build --html