### PR TITLE
Add chip-bus frame analyzer tool window

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ against real hardware.
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
   (ADF / ADZ / DMS, read-only SCP), Gayle IDE, A2091 SCSI, and CDTV/CD32 CD.
-- **Tooling**: an in-window debugger, remote GDB support, deterministic save
-  states, input recording/replay, and headless screenshot/frame-dump capture
-  -- the deterministic core makes every replay byte-identical.
+- **Tooling**: an in-window debugger, an interactive chip-bus frame
+  analyzer, remote GDB support, deterministic save states, input
+  recording/replay, and headless screenshot/frame-dump capture -- the
+  deterministic core makes every replay byte-identical.
 
 ## Requirements
 
@@ -140,8 +141,8 @@ Essential shortcuts use `Cmd` on macOS and `Alt` on Linux/Windows:
 closes an open menu/window), `Cmd+S` / `Alt+S` saves a screenshot, and
 `Cmd+B` / `Alt+B` opens the debugger. `Cmd+J` / `Alt+J` cycles joystick
 input between automatic selection, keyboard emulation, and gamepad-only.
-The status bar, pop-up menu, overlay windows (debugger, gamepad
-calibration, save/load state, input recording), and the full shortcut list
+The status bar, pop-up menu, tool windows (debugger and frame analyzer),
+overlay panels, save/load state, input recording, and the full shortcut list
 are documented in the
 [user guide](docs/guide/ui.md).
 

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -2,7 +2,8 @@
 
 Press `Cmd+B` on macOS or `Alt+B` on Linux/Windows (or pick **Debugger**
 from the status-bar menu) to pause the machine and open the debugger
-window. Closing it restores the pause state from before it opened.
+tool window alongside the emulated display. Closing it restores the pause
+state from before it opened.
 Everything the debugger shows comes from
 side-effect-free peeks -- inspecting memory or registers never disturbs the
 emulated machine -- and stepping drives the same cycle-exact core as normal
@@ -88,3 +89,36 @@ exactly as the live core would.
 **Frame** is the tool for raster work: combined with the Chipset and Copper
 tabs it lets you single-step a Copper effect one frame at a time and watch
 the register state the beam will replay.
+
+## Frame Analyzer pane
+
+Pick **Frame Analyzer...** from the status-bar menu to pause the machine and
+open the chip-bus frame analyzer in a separate tool window, leaving the
+normal emulated display visible in the main window. The analyzer shows the
+whole captured Agnus beam frame, not just the TV-presented display. The trace
+includes vertical and horizontal overscan, blanking, and the visible display
+window.
+
+The main heatmap is indexed by beam position: X is `hpos` colour clocks and Y
+is `vpos` lines. Each cell records the chip-bus owner for that colour clock:
+refresh, bitplane, sprite, disk, audio, Copper, blitter, CPU, or idle. The
+white outline marks the framebuffer display area that Copperline captured for
+presentation. Register-write markers show CPU, Copper, and interrupt-time
+custom-register writes at their beam positions.
+
+Click the heatmap to select a beam slot. The lower strip expands that selected
+scanline, so horizontal DMA contention in overscan is easier to inspect. The
+right-hand counters summarize total colour clocks per owner, the percentage
+of busy-blitter time that the blitter actually received, and which owners
+consumed cycles while the blitter was waiting.
+
+The pane has the same transport rhythm as the debugger:
+
+| Control | Key | Effect |
+|---|---|---|
+| Run / Pause | `R` | Resume or pause while continuing to collect frame traces |
+| Frame | `F` | Run exactly one frame and show the completed trace |
+
+Opening the pane starts a partial trace immediately; pressing **Frame**
+captures a clean full frame. Closing it restores the run/pause state selected
+inside the pane and disables the tracing hot path.

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -20,7 +20,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+G` | `Alt+G` | Capture / release the host mouse (clicking the display also captures) |
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
 | `Cmd+J` | `Alt+J` | Cycle joystick input mode: auto, keyboard, gamepad |
-| `Esc` | `Esc` | Close an open menu or overlay window; otherwise passed through to the Amiga |
+| `Esc` | `Esc` | Close an open menu, tool window, or overlay panel; otherwise passed through to the Amiga |
 | `Ctrl+Amiga+Amiga` | `Ctrl+Amiga+Amiga` | Keyboard reset (warm reboot) |
 
 Host modifiers that are passed through to the emulated keyboard map onto
@@ -61,7 +61,7 @@ The status bar (44 pixels below the display) holds, left to right:
   powered; power cold-boots (clears RAM) or powers off back to the test
   screen; reboot is a warm reset.
 
-## Menu and overlay windows
+## Menu, tool windows, and overlay panels
 
 ```{figure} ../images/ui-preview-menu.png
 :alt: The pop-up menu
@@ -70,12 +70,18 @@ The status bar (44 pixels below the display) holds, left to right:
 The pop-up menu opened from the status bar.
 ```
 
-The menu opens overlay windows drawn over the display. While one is open,
-key presses and display clicks stay in the window instead of reaching the
-Amiga; `Esc` closes it.
+The menu opens debugger-style tool windows and smaller overlay panels. Tool
+windows are separate native windows so the emulated display remains visible;
+overlay panels are drawn over the display. While either kind is open, key
+presses and display clicks stay in the UI instead of reaching the Amiga;
+`Esc` closes it.
 
+- **Frame Analyzer...**: pauses the machine and opens a separate diagnostic
+  window showing which chip-bus owner had each Agnus colour clock across
+  the captured frame, including overscan and blanking; see
+  [](../debugger/window.md#frame-analyzer-pane).
 - **Debugger** (also `Cmd+B` on macOS or `Alt+B` on Linux/Windows):
-  pauses the machine and opens the five-tab debugger; see
+  pauses the machine and opens the five-tab debugger in a tool window; see
   [](../debugger/window).
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Joystick Input** (also `Cmd+J` / `Alt+J`): cycles between automatic
@@ -194,8 +200,9 @@ file format and what exactly is (and is not) captured are specified in
 
 The mouse lives on port 1 and feeds the JOY0DAT counters. Click the display
 (or press `Cmd+G` on macOS or `Alt+G` on Linux/Windows) to capture the host
-mouse; the same shortcut releases it. While an overlay window is open, host
-cursor motion is not fed to the emulated mouse.
+mouse; the same shortcut releases it. While an overlay panel is open, host
+cursor motion is not fed to the emulated mouse. Tool windows likewise keep
+the debugger or analyzer interaction separate from Amiga mouse input.
 
 A USB gamepad drives the emulated port-2 digital joystick: directions
 through JOY1DAT, fire through /FIR1, and a second button through

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,8 @@ running in Copperline.
 - [](zorro) -- describing additional Zorro II/III expansion boards in
   TOML metadata files.
 - [](debugger/window), [](debugger/headless), and [](debugger/gdb) -- the
-  interactive debugger window, environment-driven headless debugger, and
-  remote GDB frontend.
+  interactive debugger window, chip-bus frame analyzer, environment-driven
+  headless debugger, and remote GDB frontend.
 - [](internals/architecture) -- how the emulator works inside, for
   contributors.
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -56,8 +56,8 @@ src/
     beam.rs         # beam-position event index for the renderer
     bitplane.rs     # event replay + planar->RGBA renderer
     deinterlace.rs  # motion-adaptive deinterlacer
-    window.rs       # winit ApplicationHandler + render worker + pixels surface + status bar
-    ui.rs           # pop-up menu + overlay windows (debugger etc.)
+    window.rs       # winit ApplicationHandler + render worker + main/tool pixels surfaces + status bar
+    ui.rs           # pop-up menu, overlay panels, and debugger/analyzer panel drawing
     font.rs         # 8x8 overlay font
 vendor/m68k/        # vendored m68k CPU core
 tests/              # ignored integration tests (need local ROM assets)

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -218,9 +218,10 @@ framebuffer):
   is still recentred, while a display that genuinely fetches bitplane data into
   the overscan border is left exactly as rendered.
 
-`ui.rs` implements the status bar widgets, the pop-up menu, and the
-overlay windows (About, Shortcuts, Calibration, Debugger) drawn over the
-display with the 8x8 `font.rs` glyphs. `COPPERLINE_UI_PREVIEW=1 cargo test
+`ui.rs` implements the status bar widgets, the pop-up menu, the smaller
+overlay panels (About, Shortcuts, Calibration), and the shared debugger/tool
+panel drawing used by the native debugger and frame-analyzer windows. The UI
+uses the 8x8 `font.rs` glyphs. `COPPERLINE_UI_PREVIEW=1 cargo test
 panels_render_into_their_rects` renders every panel into
 `target/ui-preview-*.png` -- the screenshots in this documentation come
 from there -- and the `test_app()` fixture drives the debugger window

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -725,6 +725,12 @@ pub struct Bus {
     dbg_slotmap: Vec<Vec<u8>>,
     dbg_slotmap_on: bool,
     dbg_slotmap_dumped: bool,
+    #[serde(skip)]
+    frame_analyzer_enabled: bool,
+    #[serde(skip)]
+    current_frame_bus_trace: FrameBusTrace,
+    #[serde(skip)]
+    last_frame_bus_trace: Option<FrameBusTrace>,
     /// Debugger-window custom-register watch offsets ($000-$1FE, word
     /// aligned), mirrored from the CPU machine's InteractiveBreaks, and
     /// the first pending hit since the debugger last polled. Recorded in
@@ -935,9 +941,12 @@ pub enum ChipBusOwner {
     Idle,
 }
 
-const CHIP_BUS_OWNER_NAMES: [&str; 9] = [
+pub const CHIP_BUS_OWNER_NAMES: [&str; 9] = [
     "refresh", "bitplane", "sprite", "disk", "audio", "copper", "blitter", "cpu", "idle",
 ];
+
+pub const FRAME_ANALYZER_MAX_VPOS: usize = MAX_VISIBLE_LINES;
+pub const FRAME_ANALYZER_MAX_HPOS: usize = 512;
 
 // Single-char codes for the COPPERLINE_DIAG_SLOTMAP per-color-clock owner map,
 // chosen to line up with vAmiga's DMA-Debugger slot colours for visual diffing.
@@ -968,6 +977,141 @@ impl ChipBusOwner {
             ChipBusOwner::Cpu => 7,
             ChipBusOwner::Idle => 8,
         }
+    }
+}
+
+/// Per-frame chip-bus ownership trace for the interactive frame analyzer.
+///
+/// One byte records the owner for one Agnus colour clock at `(vpos, hpos)`.
+/// It is deliberately compact because it is filled from the bus-arbitration
+/// hot path while the analyzer is open.
+#[derive(Clone, Debug)]
+pub struct FrameBusTrace {
+    pub frame: u64,
+    pub seconds: f64,
+    pub rows: usize,
+    pub cols: usize,
+    pub line_cck: u32,
+    pub visible_start_vpos: u32,
+    pub visible_lines: usize,
+    pub display_hpos_start: u32,
+    pub display_hpos_end: u32,
+    pub owner_cck: [u64; 9],
+    pub blitter_busy_cck: u64,
+    pub blitter_starve_cck: [u64; 9],
+    pub partial: bool,
+    owners: Vec<u8>,
+}
+
+impl Default for FrameBusTrace {
+    fn default() -> Self {
+        Self {
+            frame: 0,
+            seconds: 0.0,
+            rows: 0,
+            cols: 0,
+            line_cck: COLORCLOCKS_PER_LINE,
+            visible_start_vpos: RENDER_VISIBLE_START_VPOS,
+            visible_lines: RENDER_VISIBLE_LINES,
+            display_hpos_start: RENDER_COPPER_WAIT_HPOS_FB0,
+            display_hpos_end: RENDER_COPPER_WAIT_HPOS_FB0 + (RENDER_FRAMEBUFFER_WIDTH as u32 / 4),
+            owner_cck: [0; 9],
+            blitter_busy_cck: 0,
+            blitter_starve_cck: [0; 9],
+            partial: false,
+            owners: Vec::new(),
+        }
+    }
+}
+
+impl FrameBusTrace {
+    fn reset_for_frame(
+        &mut self,
+        frame: u64,
+        seconds: f64,
+        frame_lines: u32,
+        line_cck: u32,
+        visible_start_vpos: u32,
+        visible_lines: usize,
+        partial: bool,
+    ) {
+        self.frame = frame;
+        self.seconds = seconds;
+        self.rows = (frame_lines as usize).clamp(1, FRAME_ANALYZER_MAX_VPOS);
+        self.cols = (line_cck as usize).clamp(1, FRAME_ANALYZER_MAX_HPOS);
+        self.line_cck = line_cck;
+        self.visible_start_vpos = visible_start_vpos;
+        self.visible_lines = visible_lines.min(FRAME_ANALYZER_MAX_VPOS);
+        self.display_hpos_start = RENDER_COPPER_WAIT_HPOS_FB0;
+        self.display_hpos_end = (RENDER_COPPER_WAIT_HPOS_FB0
+            + (RENDER_FRAMEBUFFER_WIDTH as u32 / 4))
+            .min(self.cols as u32);
+        self.owner_cck = [0; 9];
+        self.blitter_busy_cck = 0;
+        self.blitter_starve_cck = [0; 9];
+        self.partial = partial;
+        self.owners.resize(self.rows * self.cols, b'.');
+        self.owners.fill(b'.');
+    }
+
+    fn finish_window(&mut self, visible_start_vpos: u32, visible_lines: usize) {
+        self.visible_start_vpos = visible_start_vpos.min(self.rows.saturating_sub(1) as u32);
+        self.visible_lines = visible_lines.min(self.rows);
+    }
+
+    fn clear(&mut self) {
+        self.rows = 0;
+        self.cols = 0;
+        self.owners.clear();
+        self.owner_cck = [0; 9];
+        self.blitter_busy_cck = 0;
+        self.blitter_starve_cck = [0; 9];
+        self.partial = false;
+    }
+
+    fn record(&mut self, vpos: u32, hpos: u32, cck: u32, owner: ChipBusOwner, blitter_busy: bool) {
+        if self.rows == 0 || self.cols == 0 {
+            return;
+        }
+        let v = vpos as usize;
+        let h = hpos as usize;
+        if v >= self.rows || h >= self.cols {
+            return;
+        }
+        let idx = owner.accounting_index();
+        self.owner_cck[idx] = self.owner_cck[idx].saturating_add(u64::from(cck));
+        if blitter_busy {
+            self.blitter_busy_cck = self.blitter_busy_cck.saturating_add(u64::from(cck));
+            if !matches!(owner, ChipBusOwner::Blitter) {
+                self.blitter_starve_cck[idx] =
+                    self.blitter_starve_cck[idx].saturating_add(u64::from(cck));
+            }
+        }
+        let code = chip_bus_owner_code(owner);
+        let row = &mut self.owners[v * self.cols..(v + 1) * self.cols];
+        let end = (h + cck as usize).min(self.cols);
+        for slot in row.iter_mut().take(end).skip(h) {
+            *slot = code;
+        }
+    }
+
+    pub fn owner_code_at(&self, vpos: usize, hpos: usize) -> u8 {
+        if vpos >= self.rows || hpos >= self.cols {
+            return b'.';
+        }
+        self.owners[vpos * self.cols + hpos]
+    }
+
+    pub fn owner_row(&self, vpos: usize) -> Option<&[u8]> {
+        if vpos >= self.rows || self.cols == 0 {
+            return None;
+        }
+        let start = vpos * self.cols;
+        Some(&self.owners[start..start + self.cols])
+    }
+
+    pub fn has_samples(&self) -> bool {
+        self.owner_cck.iter().any(|&v| v != 0)
     }
 }
 
@@ -1630,6 +1774,9 @@ impl Bus {
             dbg_slotmap: Vec::new(),
             dbg_slotmap_on: crate::envcfg::flag("COPPERLINE_DIAG_SLOTMAP"),
             dbg_slotmap_dumped: false,
+            frame_analyzer_enabled: false,
+            current_frame_bus_trace: FrameBusTrace::default(),
+            last_frame_bus_trace: None,
             ui_reg_watches: Vec::new(),
             ui_reg_hit: None,
             blitter_slowdown_cpu_misses: 0,
@@ -1920,6 +2067,8 @@ impl Bus {
         self.last_frame_geometry = FrameGeometry::standard(RENDER_VISIBLE_START_VPOS, false);
         self.lazy_collision_vpos = RENDER_VISIBLE_START_VPOS;
         self.lazy_collision_hpos = RENDER_COPPER_WAIT_HPOS_FB0;
+        self.current_frame_bus_trace.clear();
+        self.last_frame_bus_trace = None;
         self.cpu_bus_arbitration_enabled = false;
         self.blitter_slowdown_cpu_misses = 0;
         self.slice_bus_advanced_cck = 0;
@@ -2049,6 +2198,8 @@ impl Bus {
         self.current_frame_sprite_dma_observed = false;
         self.last_frame_sprite_dma_observed = false;
         self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
+        self.current_frame_bus_trace.clear();
+        self.last_frame_bus_trace = None;
     }
 
     pub fn emulated_seconds(&self) -> f64 {
@@ -3084,6 +3235,30 @@ impl Bus {
         } else {
             self.current_frame_geometry
         }
+    }
+
+    pub fn set_frame_analyzer_enabled(&mut self, enabled: bool) {
+        if self.frame_analyzer_enabled == enabled {
+            return;
+        }
+        self.frame_analyzer_enabled = enabled;
+        if enabled {
+            self.reset_current_frame_bus_trace(true);
+        } else {
+            self.current_frame_bus_trace.clear();
+            self.last_frame_bus_trace = None;
+        }
+    }
+
+    pub fn frame_bus_trace(&self) -> Option<&FrameBusTrace> {
+        self.last_frame_bus_trace
+            .as_ref()
+            .filter(|trace| trace.has_samples())
+            .or_else(|| {
+                self.current_frame_bus_trace
+                    .has_samples()
+                    .then_some(&self.current_frame_bus_trace)
+            })
     }
 
     pub fn current_render_events(&self) -> &[BeamRegisterWrite] {
@@ -4629,6 +4804,15 @@ impl Bus {
                     *slot = code;
                 }
             }
+        }
+        if self.frame_analyzer_enabled {
+            self.current_frame_bus_trace.record(
+                self.agnus.vpos,
+                hpos,
+                cck,
+                owner,
+                self.blitter.busy,
+            );
         }
         // The Copper was already stepped above (or is held without fetching at
         // the end-of-line lockout); only drive the other owners here.
@@ -6268,6 +6452,36 @@ impl Bus {
         self.bus_accounting.reset_frame();
     }
 
+    fn reset_current_frame_bus_trace(&mut self, partial: bool) {
+        if !self.frame_analyzer_enabled {
+            return;
+        }
+        self.current_frame_bus_trace.reset_for_frame(
+            self.emulated_frames,
+            self.emulated_seconds(),
+            self.agnus.current_frame_lines(),
+            self.agnus.current_line_cck(),
+            self.current_frame_visible_start_vpos,
+            self.current_frame_geometry.visible_lines,
+            partial,
+        );
+    }
+
+    fn finish_frame_bus_trace(&mut self) {
+        if !self.frame_analyzer_enabled {
+            self.current_frame_bus_trace.clear();
+            self.last_frame_bus_trace = None;
+            return;
+        }
+        self.current_frame_bus_trace.finish_window(
+            self.current_frame_visible_start_vpos,
+            self.current_frame_geometry.visible_lines,
+        );
+        if self.current_frame_bus_trace.has_samples() {
+            self.last_frame_bus_trace = Some(self.current_frame_bus_trace.clone());
+        }
+    }
+
     fn begin_new_beam_frame(&mut self) {
         if crate::envcfg::flag("COPPERLINE_DIAG_DISPLAY") {
             let lines: Vec<usize> = self
@@ -6488,6 +6702,7 @@ impl Bus {
         }
         self.accumulate_live_collisions_to_frame_end();
         self.log_bus_accounting_frame();
+        self.finish_frame_bus_trace();
         self.last_frame_render_base = Some(self.current_frame_render_base);
         self.last_frame_visible_start_vpos = self.current_frame_visible_start_vpos;
         self.last_frame_geometry = self.current_frame_geometry;
@@ -6568,6 +6783,7 @@ impl Bus {
         }
         self.pending_copper_frame_start = Some(self.agnus.cop1lc);
         self.copper.stop();
+        self.reset_current_frame_bus_trace(false);
     }
 
     pub(crate) fn record_cpu_chip_ram_write(&mut self, offset: usize, size: usize, value: u32) {
@@ -10050,13 +10266,13 @@ mod tests {
         live_sprite_playfield_collision_bits_in_range, live_sprite_sprite_collision_bits,
         visible_start_vpos_for_diw, BeamChipRamWrite, BeamRegisterWrite, BeamWriteSource, Bus,
         CapturedBitplaneRow, CapturedSpriteLine, ChipBusOwner, CpuBusAccessKind, DeviceClock,
-        DisplaySpriteControl, DisplaySpriteDmaState, DisplaySpriteLineData, LiveCollisionControl,
-        LiveCollisionLineReplay, LiveSpriteCollisionSource, RenderRegisterSnapshot,
-        BLITTER_SLOWDOWN_CPU_MISS_LIMIT, BLTCON1_DOFF, BPLCON0_ECSENA, BPLCON3_BRDSPRT,
-        BPLCON3_SPRES_HIRES, COPPER_BUS_LOCKOUT_HPOS, DENISE_HPOS_LAG_CCK, DMACON_AUD_MASK,
-        DMACON_BLTEN, DMACON_BLTPRI, DMACON_BPLEN, DMACON_SPREN, RENDER_COPPER_WAIT_HPOS_FB0,
-        RENDER_DIW_HSTART_FB0, RENDER_MIN_OVERSCAN_START_VPOS, RENDER_VISIBLE_LINES,
-        RENDER_VISIBLE_START_VPOS, SPRITE_DMA_PAIR_CAPTURE_HPOS,
+        DisplaySpriteControl, DisplaySpriteDmaState, DisplaySpriteLineData, FrameBusTrace,
+        LiveCollisionControl, LiveCollisionLineReplay, LiveSpriteCollisionSource,
+        RenderRegisterSnapshot, BLITTER_SLOWDOWN_CPU_MISS_LIMIT, BLTCON1_DOFF, BPLCON0_ECSENA,
+        BPLCON3_BRDSPRT, BPLCON3_SPRES_HIRES, COPPER_BUS_LOCKOUT_HPOS, DENISE_HPOS_LAG_CCK,
+        DMACON_AUD_MASK, DMACON_BLTEN, DMACON_BLTPRI, DMACON_BPLEN, DMACON_SPREN,
+        RENDER_COPPER_WAIT_HPOS_FB0, RENDER_DIW_HSTART_FB0, RENDER_MIN_OVERSCAN_START_VPOS,
+        RENDER_VISIBLE_LINES, RENDER_VISIBLE_START_VPOS, SPRITE_DMA_PAIR_CAPTURE_HPOS,
     };
     use crate::audio::AudioSink;
     use crate::chipset::agnus::{
@@ -10087,6 +10303,49 @@ mod tests {
     const STANDARD_VISIBLE_X0: usize = ((STANDARD_DIW_HSTART - RENDER_DIW_HSTART_FB0) * 2) as usize;
     const RENDER_COLOR_WRITE_HPOS_FB0: u32 = 0x34;
     static BUS_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn frame_analyzer_records_owner_spans_and_blitter_wait_cck() {
+        let mut trace = FrameBusTrace::default();
+        trace.reset_for_frame(7, 0.140, 4, 16, 1, 2, false);
+
+        trace.record(1, 2, 3, ChipBusOwner::Bitplane, false);
+        trace.record(1, 5, 2, ChipBusOwner::Copper, true);
+        trace.record(1, 7, 2, ChipBusOwner::Blitter, true);
+        trace.record(8, 0, 4, ChipBusOwner::Cpu, true);
+        trace.finish_window(2, 1);
+
+        assert_eq!(trace.frame, 7);
+        assert_eq!(trace.rows, 4);
+        assert_eq!(trace.cols, 16);
+        assert_eq!(trace.visible_start_vpos, 2);
+        assert_eq!(trace.visible_lines, 1);
+        assert!(trace.has_samples());
+
+        let row = trace.owner_row(1).expect("recorded beam row");
+        assert_eq!(row[1], b'.');
+        assert_eq!(&row[2..5], &[b'B'; 3]);
+        assert_eq!(&row[5..7], &[b'C'; 2]);
+        assert_eq!(&row[7..9], &[b'L'; 2]);
+        assert_eq!(trace.owner_code_at(3, 0), b'.');
+
+        assert_eq!(
+            trace.owner_cck[ChipBusOwner::Bitplane.accounting_index()],
+            3
+        );
+        assert_eq!(trace.owner_cck[ChipBusOwner::Copper.accounting_index()], 2);
+        assert_eq!(trace.owner_cck[ChipBusOwner::Blitter.accounting_index()], 2);
+        assert_eq!(trace.owner_cck[ChipBusOwner::Cpu.accounting_index()], 0);
+        assert_eq!(trace.blitter_busy_cck, 4);
+        assert_eq!(
+            trace.blitter_starve_cck[ChipBusOwner::Copper.accounting_index()],
+            2
+        );
+        assert_eq!(
+            trace.blitter_starve_cck[ChipBusOwner::Blitter.accounting_index()],
+            0
+        );
+    }
 
     #[test]
     fn bitplane_slot_plan_key_ignores_denise_only_bplcon0_bits() {

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -51,6 +51,7 @@ const MENU_PAD: usize = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MenuItem {
+    FrameAnalyzer,
     About,
     Shortcuts,
     Calibration,
@@ -64,7 +65,8 @@ pub enum MenuItem {
     LoadRom,
 }
 
-pub const MENU_ITEMS: [MenuItem; 11] = [
+pub const MENU_ITEMS: [MenuItem; 12] = [
+    MenuItem::FrameAnalyzer,
     MenuItem::Debugger,
     MenuItem::Calibration,
     MenuItem::JoystickInput,
@@ -86,6 +88,7 @@ fn menu_item_label(
     joystick_input_mode: JoystickInputMode,
 ) -> String {
     match item {
+        MenuItem::FrameAnalyzer => "Frame Analyzer...".to_string(),
         MenuItem::About => "About...".to_string(),
         MenuItem::Shortcuts => "Keyboard Shortcuts...".to_string(),
         MenuItem::Calibration => "Calibrate Gamepad...".to_string(),
@@ -201,12 +204,34 @@ impl Default for DebuggerPanel {
     }
 }
 
+/// Interactive state of the frame analyzer pane.
+pub struct FrameAnalyzerPanel {
+    pub selected_vpos: u16,
+    pub selected_hpos: u16,
+}
+
+impl FrameAnalyzerPanel {
+    pub fn new() -> Self {
+        Self {
+            selected_vpos: 0x2C,
+            selected_hpos: 0x28,
+        }
+    }
+}
+
+impl Default for FrameAnalyzerPanel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// An open overlay sub-window.
 pub enum Panel {
     About,
     Shortcuts,
     Calibration(crate::gamepad::CalibrationSession),
     Debugger(DebuggerPanel),
+    FrameAnalyzer(FrameAnalyzerPanel),
 }
 
 /// Menu/panel state owned by the window.
@@ -233,42 +258,57 @@ impl UiState {
             }
             return menu_rect().contains(pos).then_some(UiControl::PanelBody);
         }
-        let panel = self.panel.as_ref()?;
-        let rect = panel_rect(panel);
-        if close_button_rect(rect).contains(pos) {
-            return Some(UiControl::PanelClose);
-        }
-        match panel {
-            Panel::Calibration(session) => {
-                for (control, button_rect) in cal_button_rects(rect) {
-                    if button_rect.contains(pos) && cal_button_enabled(control, session) {
-                        return Some(control);
-                    }
+        self.panel
+            .as_ref()
+            .and_then(|panel| panel_control_at(panel, pos))
+    }
+}
+
+pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
+    let rect = panel_rect(panel);
+    if close_button_rect(rect).contains(pos) {
+        return Some(UiControl::PanelClose);
+    }
+    match panel {
+        Panel::Calibration(session) => {
+            for (control, button_rect) in cal_button_rects(rect) {
+                if button_rect.contains(pos) && cal_button_enabled(control, session) {
+                    return Some(control);
                 }
             }
-            Panel::Debugger(panel) => {
-                for (index, tab) in DEBUG_TABS.iter().enumerate() {
-                    if debug_tab_rect(rect, index).contains(pos) {
-                        return Some(UiControl::DebugTab(*tab));
-                    }
+        }
+        Panel::Debugger(panel) => {
+            for (index, tab) in DEBUG_TABS.iter().enumerate() {
+                if debug_tab_rect(rect, index).contains(pos) {
+                    return Some(UiControl::DebugTab(*tab));
                 }
-                for (control, button_rect) in debug_button_rects(rect) {
+            }
+            for (control, button_rect) in debug_button_rects(rect) {
+                if button_rect.contains(pos) {
+                    return Some(control);
+                }
+            }
+            if panel.tab == DebugTab::Break {
+                for (control, button_rect) in break_tab_button_rects(rect) {
                     if button_rect.contains(pos) {
                         return Some(control);
                     }
                 }
-                if panel.tab == DebugTab::Break {
-                    for (control, button_rect) in break_tab_button_rects(rect) {
-                        if button_rect.contains(pos) {
-                            return Some(control);
-                        }
-                    }
+            }
+        }
+        Panel::FrameAnalyzer(_) => {
+            if let Some(control) = analyzer_pick_control(rect, pos) {
+                return Some(control);
+            }
+            for (control, button_rect) in analyzer_button_rects(rect) {
+                if button_rect.contains(pos) {
+                    return Some(control);
                 }
             }
-            Panel::About | Panel::Shortcuts => {}
         }
-        rect.contains(pos).then_some(UiControl::PanelBody)
+        Panel::About | Panel::Shortcuts => {}
     }
+    rect.contains(pos).then_some(UiControl::PanelBody)
 }
 
 /// A clickable UI control, used for hit-testing and hover highlights.
@@ -306,6 +346,17 @@ pub enum UiControl {
     DebugRegToggle,
     /// Break tab: remove all breakpoints and watchpoints.
     DebugBreaksClear,
+    /// Frame analyzer: run/pause the machine while keeping the pane open.
+    AnalyzerRun,
+    /// Frame analyzer: step/capture one complete Agnus frame.
+    AnalyzerFrame,
+    /// Frame analyzer: select a slot. Coordinates are normalized to 0..1023
+    /// so window.rs can map them through the current trace dimensions.
+    AnalyzerPick {
+        x: u16,
+        y: u16,
+        scanline: bool,
+    },
 }
 
 fn panel_dims(panel: &Panel) -> (usize, usize) {
@@ -314,6 +365,7 @@ fn panel_dims(panel: &Panel) -> (usize, usize) {
         Panel::Shortcuts => (600, 352),
         Panel::Calibration(_) => (620, 372),
         Panel::Debugger(_) => (684, 520),
+        Panel::FrameAnalyzer(_) => (700, 526),
     }
 }
 
@@ -323,6 +375,7 @@ fn panel_title(panel: &Panel) -> &'static str {
         Panel::Shortcuts => "Keyboard Shortcuts",
         Panel::Calibration(_) => "Gamepad Calibration",
         Panel::Debugger(_) => "Debugger",
+        Panel::FrameAnalyzer(_) => "Frame Analyzer",
     }
 }
 
@@ -438,6 +491,69 @@ fn break_tab_button_rects(rect: Rect) -> [(UiControl, Rect); 4] {
     ]
 }
 
+fn analyzer_raster_rect(rect: Rect) -> Rect {
+    Rect {
+        x: rect.x + 10,
+        y: rect.y + TITLE_H + 44,
+        w: 448,
+        h: 246,
+    }
+}
+
+fn analyzer_scanline_rect(rect: Rect) -> Rect {
+    Rect {
+        x: rect.x + 10,
+        y: rect.y + TITLE_H + 336,
+        w: 512,
+        h: 34,
+    }
+}
+
+fn analyzer_button_rects(rect: Rect) -> [(UiControl, Rect); 2] {
+    let y = rect.y + rect.h - DEBUG_BUTTON_H - 6;
+    [
+        (
+            UiControl::AnalyzerRun,
+            Rect {
+                x: rect.x + 8,
+                y,
+                w: 70,
+                h: DEBUG_BUTTON_H,
+            },
+        ),
+        (
+            UiControl::AnalyzerFrame,
+            Rect {
+                x: rect.x + 84,
+                y,
+                w: 76,
+                h: DEBUG_BUTTON_H,
+            },
+        ),
+    ]
+}
+
+fn analyzer_pick_control(rect: Rect, pos: (i32, i32)) -> Option<UiControl> {
+    for (pick_rect, scanline) in [
+        (analyzer_raster_rect(rect), false),
+        (analyzer_scanline_rect(rect), true),
+    ] {
+        if !pick_rect.contains(pos) {
+            continue;
+        }
+        let x = (pos.0 - pick_rect.x as i32).max(0) as usize;
+        let y = (pos.1 - pick_rect.y as i32).max(0) as usize;
+        let nx = ((x * 1023) / pick_rect.w.max(1)).min(1023) as u16;
+        let ny = ((y * 1023) / pick_rect.h.max(1)).min(1023) as u16;
+        return Some(UiControl::AnalyzerPick {
+            x: nx,
+            y: ny,
+            scanline,
+        });
+    }
+    None
+}
+
 /// Bytes shown per Memory-tab page (16 rows of 16).
 pub const MEM_PAGE_BYTES: u32 = 256;
 
@@ -495,11 +611,63 @@ pub struct DebuggerView {
     pub lines: Vec<DbgLine>,
 }
 
+pub struct AnalyzerMarker {
+    pub vpos: u16,
+    pub hpos: u16,
+    pub label: String,
+}
+
+pub struct AnalyzerTraceView {
+    pub frame: u64,
+    pub seconds: f64,
+    pub rows: usize,
+    pub cols: usize,
+    pub line_cck: u32,
+    pub visible_start_vpos: u32,
+    pub visible_lines: usize,
+    pub display_hpos_start: u32,
+    pub display_hpos_end: u32,
+    pub owner_cck: [u64; 9],
+    pub blitter_busy_cck: u64,
+    pub blitter_starve_cck: [u64; 9],
+    pub partial: bool,
+    pub selected_vpos: usize,
+    pub selected_hpos: usize,
+    pub selected_owner: &'static str,
+    pub selected_owner_code: u8,
+    pub owners: Vec<u8>,
+    pub markers: Vec<AnalyzerMarker>,
+}
+
+impl AnalyzerTraceView {
+    fn owner_code_at(&self, vpos: usize, hpos: usize) -> u8 {
+        if vpos >= self.rows || hpos >= self.cols {
+            return b'.';
+        }
+        self.owners[vpos * self.cols + hpos]
+    }
+
+    fn owner_row(&self, vpos: usize) -> Option<&[u8]> {
+        if vpos >= self.rows || self.cols == 0 {
+            return None;
+        }
+        let start = vpos * self.cols;
+        Some(&self.owners[start..start + self.cols])
+    }
+}
+
+pub struct FrameAnalyzerView {
+    pub running: bool,
+    pub status: String,
+    pub trace: Option<AnalyzerTraceView>,
+}
+
 pub enum PanelViewData {
     About(AboutView),
     Shortcuts,
     Calibration(CalibrationView),
     Debugger(DebuggerView),
+    FrameAnalyzer(Box<FrameAnalyzerView>),
 }
 
 // ---------------------------------------------------------------------------
@@ -996,6 +1164,552 @@ fn draw_debugger(
     }
 }
 
+fn owner_color(code: u8) -> u32 {
+    match code {
+        b'R' => rgba(68, 180, 190),
+        b'B' => rgba(64, 118, 230),
+        b'S' => rgba(212, 84, 220),
+        b'D' => rgba(190, 122, 54),
+        b'A' => rgba(72, 190, 96),
+        b'C' => rgba(238, 206, 72),
+        b'L' => rgba(222, 78, 76),
+        b'P' => rgba(230, 232, 224),
+        _ => rgba(20, 22, 26),
+    }
+}
+
+fn owner_name_for_code(code: u8) -> &'static str {
+    match code {
+        b'R' => "refresh",
+        b'B' => "bitplane",
+        b'S' => "sprite",
+        b'D' => "disk",
+        b'A' => "audio",
+        b'C' => "copper",
+        b'L' => "blitter",
+        b'P' => "cpu",
+        _ => "idle",
+    }
+}
+
+fn draw_outline(frame: &mut [u8], rect: Rect, color: u32, scale: usize) {
+    if rect.w == 0 || rect.h == 0 {
+        return;
+    }
+    fill_rect(
+        frame,
+        scale_rect(
+            Rect {
+                x: rect.x,
+                y: rect.y,
+                w: rect.w,
+                h: 1,
+            },
+            scale,
+        ),
+        color,
+        scale,
+    );
+    fill_rect(
+        frame,
+        scale_rect(
+            Rect {
+                x: rect.x,
+                y: rect.y + rect.h.saturating_sub(1),
+                w: rect.w,
+                h: 1,
+            },
+            scale,
+        ),
+        color,
+        scale,
+    );
+    fill_rect(
+        frame,
+        scale_rect(
+            Rect {
+                x: rect.x,
+                y: rect.y,
+                w: 1,
+                h: rect.h,
+            },
+            scale,
+        ),
+        color,
+        scale,
+    );
+    fill_rect(
+        frame,
+        scale_rect(
+            Rect {
+                x: rect.x + rect.w.saturating_sub(1),
+                y: rect.y,
+                w: 1,
+                h: rect.h,
+            },
+            scale,
+        ),
+        color,
+        scale,
+    );
+}
+
+fn trace_x(rect: Rect, hpos: usize, cols: usize) -> usize {
+    rect.x + (hpos.min(cols.saturating_sub(1)) * rect.w / cols.max(1))
+}
+
+fn trace_y(rect: Rect, vpos: usize, rows: usize) -> usize {
+    rect.y + (vpos.min(rows.saturating_sub(1)) * rect.h / rows.max(1))
+}
+
+fn draw_owner_heatmap(frame: &mut [u8], rect: Rect, trace: &AnalyzerTraceView, scale: usize) {
+    fill_rect(frame, scale_rect(rect, scale), rgba(10, 12, 14), scale);
+    for y in 0..rect.h {
+        let vpos = y * trace.rows / rect.h.max(1);
+        for x in 0..rect.w {
+            let hpos = x * trace.cols / rect.w.max(1);
+            let color = owner_color(trace.owner_code_at(vpos, hpos));
+            fill_rect(
+                frame,
+                scale_rect(
+                    Rect {
+                        x: rect.x + x,
+                        y: rect.y + y,
+                        w: 1,
+                        h: 1,
+                    },
+                    scale,
+                ),
+                color,
+                scale,
+            );
+        }
+    }
+
+    let visible_top = trace_y(rect, trace.visible_start_vpos as usize, trace.rows);
+    let visible_bottom = trace_y(
+        rect,
+        (trace.visible_start_vpos as usize)
+            .saturating_add(trace.visible_lines)
+            .min(trace.rows.saturating_sub(1)),
+        trace.rows,
+    )
+    .max(visible_top + 1);
+    let display_left = trace_x(rect, trace.display_hpos_start as usize, trace.cols);
+    let display_right =
+        trace_x(rect, trace.display_hpos_end as usize, trace.cols).max(display_left + 1);
+    draw_outline(
+        frame,
+        Rect {
+            x: display_left,
+            y: visible_top,
+            w: display_right.saturating_sub(display_left).max(1),
+            h: visible_bottom.saturating_sub(visible_top).max(1),
+        },
+        rgba(238, 238, 232),
+        scale,
+    );
+
+    for marker in trace.markers.iter().take(80) {
+        let x = trace_x(rect, marker.hpos as usize, trace.cols);
+        let y = trace_y(rect, marker.vpos as usize, trace.rows);
+        fill_rect(
+            frame,
+            scale_rect(
+                Rect {
+                    x: x.saturating_sub(1),
+                    y,
+                    w: 3,
+                    h: 1,
+                },
+                scale,
+            ),
+            PANEL_TEXT_ACCENT,
+            scale,
+        );
+        fill_rect(
+            frame,
+            scale_rect(
+                Rect {
+                    x,
+                    y: y.saturating_sub(1),
+                    w: 1,
+                    h: 3,
+                },
+                scale,
+            ),
+            PANEL_TEXT_ACCENT,
+            scale,
+        );
+    }
+
+    let sx = trace_x(rect, trace.selected_hpos, trace.cols);
+    let sy = trace_y(rect, trace.selected_vpos, trace.rows);
+    draw_outline(
+        frame,
+        Rect {
+            x: sx.saturating_sub(3),
+            y: sy.saturating_sub(3),
+            w: 7,
+            h: 7,
+        },
+        PANEL_TEXT_HILIGHT,
+        scale,
+    );
+    draw_outline(frame, rect, BUTTON_EDGE_LIGHT, scale);
+}
+
+fn draw_scanline_strip(frame: &mut [u8], rect: Rect, trace: &AnalyzerTraceView, scale: usize) {
+    fill_rect(frame, scale_rect(rect, scale), rgba(10, 12, 14), scale);
+    if let Some(row) = trace.owner_row(trace.selected_vpos) {
+        for x in 0..rect.w {
+            let hpos = x * trace.cols / rect.w.max(1);
+            let color = owner_color(row[hpos.min(row.len().saturating_sub(1))]);
+            fill_rect(
+                frame,
+                scale_rect(
+                    Rect {
+                        x: rect.x + x,
+                        y: rect.y + 8,
+                        w: 1,
+                        h: rect.h.saturating_sub(14),
+                    },
+                    scale,
+                ),
+                color,
+                scale,
+            );
+        }
+    }
+    let sx = trace_x(rect, trace.selected_hpos, trace.cols);
+    fill_rect(
+        frame,
+        scale_rect(
+            Rect {
+                x: sx,
+                y: rect.y,
+                w: 1,
+                h: rect.h,
+            },
+            scale,
+        ),
+        PANEL_TEXT_HILIGHT,
+        scale,
+    );
+    draw_outline(frame, rect, BUTTON_EDGE_LIGHT, scale);
+}
+
+fn draw_owner_counters(
+    frame: &mut [u8],
+    x: usize,
+    mut y: usize,
+    trace: &AnalyzerTraceView,
+    scale: usize,
+) {
+    let total: u64 = trace.owner_cck.iter().sum();
+    draw_panel_text(frame, x, y, "Owner cck", PANEL_TEXT_HILIGHT, 1, scale);
+    y += 12;
+    for (idx, name) in crate::bus::CHIP_BUS_OWNER_NAMES.iter().enumerate() {
+        let cck = trace.owner_cck[idx];
+        if cck == 0 {
+            continue;
+        }
+        let pct = if total == 0 {
+            0.0
+        } else {
+            cck as f64 * 100.0 / total as f64
+        };
+        let code = match idx {
+            0 => b'R',
+            1 => b'B',
+            2 => b'S',
+            3 => b'D',
+            4 => b'A',
+            5 => b'C',
+            6 => b'L',
+            7 => b'P',
+            _ => b'.',
+        };
+        fill_rect(
+            frame,
+            scale_rect(
+                Rect {
+                    x,
+                    y: y + 2,
+                    w: 8,
+                    h: 8,
+                },
+                scale,
+            ),
+            owner_color(code),
+            scale,
+        );
+        draw_panel_text(
+            frame,
+            x + 14,
+            y,
+            &format!("{name:<8} {cck:>5} {pct:>4.1}%"),
+            PANEL_TEXT,
+            1,
+            scale,
+        );
+        y += 12;
+    }
+    if trace.blitter_busy_cck != 0 {
+        y += 4;
+        let blit_grant = trace.owner_cck[6];
+        let pct = blit_grant as f64 * 100.0 / trace.blitter_busy_cck as f64;
+        draw_panel_text(
+            frame,
+            x,
+            y,
+            &format!("blitter grant {pct:>4.1}%"),
+            PANEL_TEXT_ACCENT,
+            1,
+            scale,
+        );
+        y += 12;
+        let total_starve: u64 = trace.blitter_starve_cck.iter().sum();
+        draw_panel_text(
+            frame,
+            x,
+            y,
+            &format!("blitter wait {total_starve:>5}"),
+            PANEL_TEXT_ACCENT,
+            1,
+            scale,
+        );
+        y += 12;
+        for (idx, name) in crate::bus::CHIP_BUS_OWNER_NAMES.iter().enumerate() {
+            let cck = trace.blitter_starve_cck[idx];
+            if cck == 0 {
+                continue;
+            }
+            draw_panel_text(
+                frame,
+                x,
+                y,
+                &format!("{name:<8} {cck:>5}"),
+                PANEL_TEXT_DIM,
+                1,
+                scale,
+            );
+            y += 12;
+        }
+    }
+}
+
+fn draw_frame_analyzer(
+    frame: &mut [u8],
+    rect: Rect,
+    _panel: &FrameAnalyzerPanel,
+    view: &FrameAnalyzerView,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    let status_w = view.status.chars().count() * font::GLYPH_W;
+    draw_panel_text(
+        frame,
+        rect.x + rect.w - TITLE_H - 8 - status_w.min(rect.w.saturating_sub(TITLE_H + 16)),
+        rect.y + (TITLE_H - 8) / 2,
+        &view.status,
+        PANEL_TITLE_TEXT,
+        1,
+        scale,
+    );
+
+    let Some(trace) = &view.trace else {
+        let mut y = rect.y + TITLE_H + 36;
+        for line in [
+            "No chip-bus trace captured yet.",
+            "Press Frame to record one full Agnus frame, or Run to collect live frames.",
+            "The analyzer records hpos/vpos ownership, including overscan and blanking.",
+        ] {
+            draw_panel_text(frame, rect.x + 24, y, line, PANEL_TEXT, 1, scale);
+            y += 16;
+        }
+        for (control, button_rect) in analyzer_button_rects(rect) {
+            let label = match control {
+                UiControl::AnalyzerRun if view.running => "Pause",
+                UiControl::AnalyzerRun => "Run",
+                _ => "Frame",
+            };
+            draw_text_button(
+                frame,
+                button_rect,
+                label,
+                true,
+                hover == Some(control),
+                scale,
+            );
+        }
+        return;
+    };
+
+    let header = format!(
+        "frame {}  {:.3}s  {} lines x {} cck{}{}",
+        trace.frame,
+        trace.seconds,
+        trace.rows,
+        trace.line_cck,
+        if trace.cols as u32 != trace.line_cck {
+            " sampled"
+        } else {
+            ""
+        },
+        if trace.partial { "  partial" } else { "" }
+    );
+    draw_panel_text(
+        frame,
+        rect.x + 10,
+        rect.y + TITLE_H + 10,
+        &header,
+        PANEL_TEXT,
+        1,
+        scale,
+    );
+    draw_panel_text(
+        frame,
+        rect.x + 10,
+        rect.y + TITLE_H + 24,
+        "full raster: x=hpos colour clocks, y=vpos beam lines; white box is captured display",
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+
+    let raster = analyzer_raster_rect(rect);
+    draw_owner_heatmap(frame, raster, trace, scale);
+    let counters_x = raster.x + raster.w + 16;
+    draw_owner_counters(frame, counters_x, raster.y, trace, scale);
+
+    let selected = format!(
+        "selected v={:03} h={:03}  owner={} ({})",
+        trace.selected_vpos,
+        trace.selected_hpos,
+        trace.selected_owner,
+        trace.selected_owner_code as char
+    );
+    draw_panel_text(
+        frame,
+        rect.x + 10,
+        raster.y + raster.h + 10,
+        &selected,
+        PANEL_TEXT_HILIGHT,
+        1,
+        scale,
+    );
+    if let Some(marker) = trace.markers.iter().find(|m| {
+        usize::from(m.vpos) == trace.selected_vpos && usize::from(m.hpos) == trace.selected_hpos
+    }) {
+        draw_panel_text(
+            frame,
+            rect.x + 10,
+            raster.y + raster.h + 22,
+            &marker.label,
+            PANEL_TEXT_ACCENT,
+            1,
+            scale,
+        );
+    }
+
+    let scanline = analyzer_scanline_rect(rect);
+    draw_panel_text(
+        frame,
+        scanline.x,
+        scanline.y - 14,
+        "selected scanline",
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+    draw_scanline_strip(frame, scanline, trace, scale);
+
+    let mut y = scanline.y + scanline.h + 14;
+    draw_panel_text(frame, rect.x + 10, y, "Legend", PANEL_TEXT_DIM, 1, scale);
+    let mut x = rect.x + 66;
+    for code in [b'R', b'B', b'S', b'D', b'A', b'C', b'L', b'P', b'.'] {
+        fill_rect(
+            frame,
+            scale_rect(
+                Rect {
+                    x,
+                    y: y + 2,
+                    w: 8,
+                    h: 8,
+                },
+                scale,
+            ),
+            owner_color(code),
+            scale,
+        );
+        draw_panel_text(
+            frame,
+            x + 12,
+            y,
+            owner_name_for_code(code),
+            PANEL_TEXT,
+            1,
+            scale,
+        );
+        x += if code == b'.' { 54 } else { 82 };
+    }
+    y += 18;
+    let marker_text = format!("register markers shown: {}", trace.markers.len().min(80));
+    draw_panel_text(
+        frame,
+        rect.x + 10,
+        y,
+        &marker_text,
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+
+    for (control, button_rect) in analyzer_button_rects(rect) {
+        let label = match control {
+            UiControl::AnalyzerRun if view.running => "Pause",
+            UiControl::AnalyzerRun => "Run",
+            _ => "Frame",
+        };
+        draw_text_button(
+            frame,
+            button_rect,
+            label,
+            true,
+            hover == Some(control),
+            scale,
+        );
+    }
+}
+
+pub fn draw_panel_layer(
+    frame: &mut [u8],
+    texture_scale: usize,
+    panel: &Panel,
+    hover: Option<UiControl>,
+    data: Option<&PanelViewData>,
+) {
+    draw_panel_chrome(frame, panel, hover, texture_scale);
+    let rect = panel_rect(panel);
+    match (panel, data) {
+        (Panel::About, Some(PanelViewData::About(view))) => {
+            draw_about(frame, rect, view, texture_scale)
+        }
+        (Panel::Shortcuts, _) => draw_shortcuts(frame, rect, texture_scale),
+        (Panel::Calibration(session), Some(PanelViewData::Calibration(view))) => {
+            draw_calibration(frame, rect, view, hover, session, texture_scale)
+        }
+        (Panel::Debugger(panel_state), Some(PanelViewData::Debugger(view))) => {
+            draw_debugger(frame, rect, panel_state, view, hover, texture_scale)
+        }
+        (Panel::FrameAnalyzer(panel_state), Some(PanelViewData::FrameAnalyzer(view))) => {
+            draw_frame_analyzer(frame, rect, panel_state, view, hover, texture_scale)
+        }
+        _ => {}
+    }
+}
+
 /// Draw the whole UI layer: pop-up menu and/or the open panel. Drawn after
 /// the status bar and OSD so it sits on top of everything.
 pub fn draw(
@@ -1010,21 +1724,7 @@ pub fn draw(
     joystick_input_mode: JoystickInputMode,
 ) {
     if let Some(panel) = &ui.panel {
-        draw_panel_chrome(frame, panel, hover, texture_scale);
-        let rect = panel_rect(panel);
-        match (panel, data) {
-            (Panel::About, Some(PanelViewData::About(view))) => {
-                draw_about(frame, rect, view, texture_scale)
-            }
-            (Panel::Shortcuts, _) => draw_shortcuts(frame, rect, texture_scale),
-            (Panel::Calibration(session), Some(PanelViewData::Calibration(view))) => {
-                draw_calibration(frame, rect, view, hover, session, texture_scale)
-            }
-            (Panel::Debugger(panel_state), Some(PanelViewData::Debugger(view))) => {
-                draw_debugger(frame, rect, panel_state, view, hover, texture_scale)
-            }
-            _ => {}
-        }
+        draw_panel_layer(frame, texture_scale, panel, hover, data);
     }
     if ui.menu_open {
         draw_menu(
@@ -1161,8 +1861,11 @@ mod tests {
         };
         let first = menu_item_rect(0);
         let pos = (first.x as i32 + 4, first.y as i32 + 4);
-        assert_eq!(ui.control_at(pos), Some(UiControl::MenuItem(MENU_ITEMS[0])));
-        let joystick = menu_item_rect(2);
+        assert_eq!(
+            ui.control_at(pos),
+            Some(UiControl::MenuItem(MenuItem::FrameAnalyzer))
+        );
+        let joystick = menu_item_rect(3);
         let pos = (joystick.x as i32 + 4, joystick.y as i32 + 4);
         assert_eq!(
             ui.control_at(pos),
@@ -1170,6 +1873,42 @@ mod tests {
         );
         // Outside the menu: nothing (the click closes the menu).
         assert_eq!(ui.control_at((0, 0)), None);
+    }
+
+    #[test]
+    fn frame_analyzer_controls_hit_test() {
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::FrameAnalyzer(FrameAnalyzerPanel::new())),
+        };
+        let rect = panel_rect(ui.panel.as_ref().unwrap());
+        let raster = analyzer_raster_rect(rect);
+        assert_eq!(
+            ui.control_at((raster.x as i32 + raster.w as i32 / 2, raster.y as i32 + 2)),
+            Some(UiControl::AnalyzerPick {
+                x: 511,
+                y: 8,
+                scanline: false,
+            })
+        );
+        let scanline = analyzer_scanline_rect(rect);
+        assert_eq!(
+            ui.control_at((
+                scanline.x as i32 + scanline.w as i32 / 2,
+                scanline.y as i32 + 2
+            )),
+            Some(UiControl::AnalyzerPick {
+                x: 511,
+                y: 60,
+                scanline: true,
+            })
+        );
+        let (control, button) = analyzer_button_rects(rect)[1];
+        assert_eq!(control, UiControl::AnalyzerFrame);
+        assert_eq!(
+            ui.control_at((button.x as i32 + 2, button.y as i32 + 2)),
+            Some(UiControl::AnalyzerFrame)
+        );
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -434,6 +434,7 @@ pub struct App {
     present_fb: Vec<u32>,
     present_rows: usize,
     render: Option<Render>,
+    tool_window: Option<ToolWindow>,
     render_worker: Option<RenderWorker>,
     render_recycle_fb: Vec<u32>,
     cpu_halted: bool,
@@ -530,6 +531,9 @@ pub struct App {
     /// Host pause state before the debugger forced a pause, restored when
     /// the debugger window closes (unless Run was used inside it).
     paused_before_debugger: bool,
+    /// Host pause state before the frame analyzer forced a pause, restored
+    /// when the analyzer pane closes unless Run was used inside it.
+    paused_before_analyzer: bool,
     /// The reason for the last interactive breakpoint/watchpoint stop,
     /// shown on the debugger's Break tab until execution resumes.
     last_debug_stop: Option<String>,
@@ -588,6 +592,13 @@ struct Render {
     window: Arc<Window>,
     pixels: Pixels<'static>,
     texture_scale: usize,
+}
+
+struct ToolWindow {
+    window: Arc<Window>,
+    pixels: Pixels<'static>,
+    texture_scale: usize,
+    cursor_pos: Option<(i32, i32)>,
 }
 
 struct RenderJob {
@@ -710,6 +721,7 @@ impl App {
             present_fb: vec![0u32; FB_WIDTH * OUT_HEIGHT],
             present_rows: OUT_HEIGHT,
             render: None,
+            tool_window: None,
             render_worker,
             render_recycle_fb: Vec::new(),
             cpu_halted: false,
@@ -761,6 +773,7 @@ impl App {
             ui: UiState::default(),
             about_machine_lines,
             paused_before_debugger: false,
+            paused_before_analyzer: false,
             last_debug_stop: None,
             recorder: None,
             record_fb: Vec::new(),
@@ -954,13 +967,7 @@ impl ApplicationHandler for App {
         #[cfg(target_os = "macos")]
         set_macos_dock_icon();
         let inner = window.inner_size();
-        let surface = SurfaceTexture::new(inner.width.max(1), inner.height.max(1), window.clone());
         let texture_scale = texture_scale_for_window(&window);
-        let builder = PixelsBuilder::new(
-            texture_width(texture_scale) as u32,
-            texture_height(texture_scale) as u32,
-            surface,
-        );
         // On Linux, restrict wgpu to the Vulkan backend. wgpu's GL fallback
         // initializes its EGL instance without a display handle (pixels uses
         // InstanceDescriptor::new_without_display_handle), so EGL drops to the
@@ -974,14 +981,7 @@ impl ApplicationHandler for App {
         // Other platforms keep wgpu's default backend set (Metal on macOS,
         // DX12/Vulkan on Windows). cfg!() (not #[cfg]) keeps the Linux branch
         // type-checked on every host.
-        let builder = if cfg!(target_os = "linux") {
-            builder.wgpu_backend(
-                pixels::wgpu::Backends::from_env().unwrap_or(pixels::wgpu::Backends::VULKAN),
-            )
-        } else {
-            builder
-        };
-        let mut pixels = match builder.build() {
+        let pixels = match build_pixels_for_window(window.clone(), texture_scale) {
             Ok(p) => p,
             Err(e) => {
                 error!("pixels init failed: {e}");
@@ -997,12 +997,6 @@ impl ApplicationHandler for App {
                 return;
             }
         };
-        // Scale the display continuously with the window (preserving the
-        // 4:3 presentation aspect, letterboxing as needed) instead of the
-        // default pixel-perfect mode, which only steps at whole integer
-        // multiples and otherwise leaves a fixed-size image in a growing
-        // black border.
-        pixels.set_scaling_mode(ScalingMode::Fill);
         info!(
             "window + pixels surface ready ({}x{}, texture {}x{})",
             inner.width,
@@ -1132,9 +1126,20 @@ impl ApplicationHandler for App {
     fn window_event(
         &mut self,
         event_loop: &ActiveEventLoop,
-        _window_id: WindowId,
+        window_id: WindowId,
         event: WindowEvent,
     ) {
+        if Some(window_id) == self.tool_window_id() {
+            self.handle_tool_window_event(event_loop, event);
+            return;
+        }
+        if self
+            .render
+            .as_ref()
+            .is_some_and(|render| render.window.id() != window_id)
+        {
+            return;
+        }
         match event {
             WindowEvent::CloseRequested => {
                 event_loop.exit();
@@ -1192,7 +1197,8 @@ impl ApplicationHandler for App {
                     (KeyCode::KeyB, ElementState::Pressed)
                         if host_shortcut_modifier_pressed(self.modifiers) =>
                     {
-                        self.toggle_debugger()
+                        self.toggle_debugger();
+                        self.ensure_tool_window_for_current_panel(event_loop);
                     }
                     (KeyCode::KeyJ, ElementState::Pressed)
                         if host_shortcut_modifier_pressed(self.modifiers) =>
@@ -1260,7 +1266,7 @@ impl ApplicationHandler for App {
                 }
                 let layout = bar_layout(&self.media_bar());
                 if bar_hover_changed(&layout, previous_cursor_pos, self.cursor_pos)
-                    || ui_hover_changed(&self.ui, previous_cursor_pos, self.cursor_pos)
+                    || self.main_ui_hover_changed(previous_cursor_pos, self.cursor_pos)
                 {
                     self.request_redraw();
                 }
@@ -1287,8 +1293,11 @@ impl ApplicationHandler for App {
                 }
                 if pressed && !self.mouse_captured && self.ui.active() {
                     if button == MouseButton::Left {
-                        if let Some(control) = self.cursor_pos.and_then(|p| self.ui.control_at(p)) {
+                        if let Some(control) =
+                            self.cursor_pos.and_then(|p| self.main_ui_control_at(p))
+                        {
                             self.activate_ui_control(control);
+                            self.ensure_tool_window_for_current_panel(event_loop);
                             return;
                         }
                     }
@@ -1383,11 +1392,16 @@ impl ApplicationHandler for App {
                     hover,
                 };
                 let osd = self.active_osd_text();
-                let ui_hover = self.cursor_pos.and_then(|p| self.ui.control_at(p));
-                let ui_data = self.build_panel_view_data();
+                let ui_hover = self.cursor_pos.and_then(|p| self.main_ui_control_at(p));
                 let warp = !self.emu.paced();
                 let recording = self.recorder.is_some();
                 let input_recording = self.input_recorder.is_some();
+                let panel_in_tool_window = self.tool_window.is_some();
+                let ui_data = if panel_in_tool_window {
+                    None
+                } else {
+                    self.build_panel_view_data()
+                };
                 if let Some(r) = self.render.as_mut() {
                     let frame = r.pixels.frame_mut();
                     copy_present_frame(&self.present_fb, self.present_rows, frame, r.texture_scale);
@@ -1400,17 +1414,35 @@ impl ApplicationHandler for App {
                     if let Some(text) = &osd {
                         draw_osd(frame, text, r.texture_scale);
                     }
-                    ui::draw(
-                        frame,
-                        r.texture_scale,
-                        &self.ui,
-                        ui_hover,
-                        ui_data.as_ref(),
-                        warp,
-                        recording,
-                        input_recording,
-                        self.joystick_input_mode,
-                    );
+                    if panel_in_tool_window {
+                        let main_ui = UiState {
+                            menu_open: self.ui.menu_open,
+                            panel: None,
+                        };
+                        ui::draw(
+                            frame,
+                            r.texture_scale,
+                            &main_ui,
+                            ui_hover,
+                            None,
+                            warp,
+                            recording,
+                            input_recording,
+                            self.joystick_input_mode,
+                        );
+                    } else {
+                        ui::draw(
+                            frame,
+                            r.texture_scale,
+                            &self.ui,
+                            ui_hover,
+                            ui_data.as_ref(),
+                            warp,
+                            recording,
+                            input_recording,
+                            self.joystick_input_mode,
+                        );
+                    }
                     if let Err(e) = r.pixels.render() {
                         error!("pixels.render: {e}");
                     }
@@ -1494,6 +1526,7 @@ impl ApplicationHandler for App {
             // A breakpoint/watchpoint hit pauses the machine and brings
             // the debugger window up with the reason.
             self.surface_debug_stop();
+            self.ensure_tool_window_for_current_panel(event_loop);
         }
         let now = Instant::now();
         // While powered off, leave the parked test screen in place; the
@@ -1509,9 +1542,7 @@ impl ApplicationHandler for App {
         // as fast as the host allows. Emulated state is identical either way.
         let headless_capture = self.auto_shot.is_some() || self.frame_dump.is_some();
         if rendered && !headless_capture {
-            if let Some(r) = self.render.as_ref() {
-                r.window.request_redraw();
-            }
+            self.request_redraw();
         }
 
         if self.dump_frame_if_due(now, event_loop) {
@@ -2040,6 +2071,29 @@ fn texture_scale_for_window(window: &Window) -> usize {
     (window.scale_factor().round() as usize).clamp(1, MAX_TEXTURE_SCALE)
 }
 
+fn build_pixels_for_window(
+    window: Arc<Window>,
+    texture_scale: usize,
+) -> std::result::Result<Pixels<'static>, pixels::Error> {
+    let inner = window.inner_size();
+    let surface = SurfaceTexture::new(inner.width.max(1), inner.height.max(1), window);
+    let builder = PixelsBuilder::new(
+        texture_width(texture_scale) as u32,
+        texture_height(texture_scale) as u32,
+        surface,
+    );
+    let builder = if cfg!(target_os = "linux") {
+        builder.wgpu_backend(
+            pixels::wgpu::Backends::from_env().unwrap_or(pixels::wgpu::Backends::VULKAN),
+        )
+    } else {
+        builder
+    };
+    let mut pixels = builder.build()?;
+    pixels.set_scaling_mode(ScalingMode::Fill);
+    Ok(pixels)
+}
+
 pub(super) fn texture_width(scale: usize) -> usize {
     FB_WIDTH * scale
 }
@@ -2094,6 +2148,20 @@ fn volume_scroll_steps(delta: MouseScrollDelta) -> Option<i16> {
         Some(-1)
     } else {
         None
+    }
+}
+
+fn owner_name_from_code(code: u8) -> &'static str {
+    match code {
+        b'R' => "refresh",
+        b'B' => "bitplane",
+        b'S' => "sprite",
+        b'D' => "disk",
+        b'A' => "audio",
+        b'C' => "copper",
+        b'L' => "blitter",
+        b'P' => "cpu",
+        _ => "idle",
     }
 }
 
@@ -2724,15 +2792,6 @@ fn bar_hover_changed(
 ) -> bool {
     previous.and_then(|pos| control_at(pos, layout))
         != current.and_then(|pos| control_at(pos, layout))
-}
-
-fn ui_hover_changed(
-    ui: &UiState,
-    previous: Option<(i32, i32)>,
-    current: Option<(i32, i32)>,
-) -> bool {
-    ui.active()
-        && previous.and_then(|pos| ui.control_at(pos)) != current.and_then(|pos| ui.control_at(pos))
 }
 
 fn draw_fdd_track_counter(frame: &mut [u8], track: Option<u8>, texture_scale: usize) {
@@ -4214,6 +4273,136 @@ impl App {
         MediaBar { drives, cd }
     }
 
+    fn main_ui_control_at(&self, pos: (i32, i32)) -> Option<UiControl> {
+        if self.tool_window.is_some() && !self.ui.menu_open {
+            return None;
+        }
+        self.ui.control_at(pos)
+    }
+
+    fn main_ui_hover_changed(
+        &self,
+        previous: Option<(i32, i32)>,
+        current: Option<(i32, i32)>,
+    ) -> bool {
+        previous.and_then(|pos| self.main_ui_control_at(pos))
+            != current.and_then(|pos| self.main_ui_control_at(pos))
+    }
+
+    fn tool_panel_control_at(&self, pos: (i32, i32)) -> Option<UiControl> {
+        self.ui
+            .panel
+            .as_ref()
+            .and_then(|panel| ui::panel_control_at(panel, pos))
+    }
+
+    fn tool_hover_changed(
+        &self,
+        previous: Option<(i32, i32)>,
+        current: Option<(i32, i32)>,
+    ) -> bool {
+        previous.and_then(|pos| self.tool_panel_control_at(pos))
+            != current.and_then(|pos| self.tool_panel_control_at(pos))
+    }
+
+    fn tool_window_id(&self) -> Option<WindowId> {
+        self.tool_window.as_ref().map(|tool| tool.window.id())
+    }
+
+    fn handle_tool_window_event(&mut self, event_loop: &ActiveEventLoop, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => self.close_panel(),
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        state,
+                        physical_key: PhysicalKey::Code(code),
+                        repeat,
+                        ..
+                    },
+                ..
+            } => {
+                if repeat || state != ElementState::Pressed {
+                    return;
+                }
+                if code == KeyCode::KeyQ && host_shortcut_modifier_pressed(self.modifiers) {
+                    event_loop.exit();
+                } else if !self.ui_handle_key(code) {
+                    self.request_redraw();
+                }
+            }
+            WindowEvent::ModifiersChanged(modifiers) => {
+                self.modifiers = modifiers.state();
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                let previous = self.tool_window.as_ref().and_then(|tool| tool.cursor_pos);
+                let pos = self.tool_window.as_ref().and_then(|tool| {
+                    cursor_texture_position(&tool.pixels, position, tool.texture_scale)
+                });
+                if let Some(tool) = self.tool_window.as_mut() {
+                    tool.cursor_pos = pos;
+                }
+                if self.tool_hover_changed(previous, pos) {
+                    self.request_redraw();
+                }
+            }
+            WindowEvent::CursorLeft { .. } => {
+                let previous = self.tool_window.as_ref().and_then(|tool| tool.cursor_pos);
+                if let Some(tool) = self.tool_window.as_mut() {
+                    tool.cursor_pos = None;
+                }
+                if self.tool_hover_changed(previous, None) {
+                    self.request_redraw();
+                }
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if state != ElementState::Pressed || button != MouseButton::Left {
+                    return;
+                }
+                let control = self
+                    .tool_window
+                    .as_ref()
+                    .and_then(|tool| tool.cursor_pos)
+                    .and_then(|pos| self.tool_panel_control_at(pos));
+                if let Some(control) = control {
+                    self.activate_ui_control(control);
+                    self.ensure_tool_window_for_current_panel(event_loop);
+                }
+            }
+            WindowEvent::Resized(size) => {
+                if let Some(tool) = self.tool_window.as_mut() {
+                    let _ = tool
+                        .pixels
+                        .resize_surface(size.width.max(1), size.height.max(1));
+                }
+                self.request_redraw();
+            }
+            WindowEvent::RedrawRequested => self.draw_tool_window(),
+            _ => {}
+        }
+    }
+
+    fn draw_tool_window(&mut self) {
+        let Some(panel) = self.ui.panel.as_ref() else {
+            self.tool_window = None;
+            return;
+        };
+        let ui_data = self.build_panel_view_data();
+        let hover = self
+            .tool_window
+            .as_ref()
+            .and_then(|tool| tool.cursor_pos)
+            .and_then(|pos| ui::panel_control_at(panel, pos));
+        if let Some(tool) = self.tool_window.as_mut() {
+            let frame = tool.pixels.frame_mut();
+            frame.fill(0);
+            ui::draw_panel_layer(frame, tool.texture_scale, panel, hover, ui_data.as_ref());
+            if let Err(e) = tool.pixels.render() {
+                error!("tool pixels.render: {e}");
+            }
+        }
+    }
+
     /// Run the action behind a clicked status-bar control (volume is
     /// handled separately because it starts a drag).
     fn activate_bar_control(&mut self, control: BarControl) {
@@ -4241,6 +4430,7 @@ impl App {
             UiControl::MenuItem(item) => {
                 self.ui.menu_open = false;
                 match item {
+                    ui::MenuItem::FrameAnalyzer => self.open_frame_analyzer(),
                     ui::MenuItem::About => self.ui.panel = Some(Panel::About),
                     ui::MenuItem::Shortcuts => self.ui.panel = Some(Panel::Shortcuts),
                     ui::MenuItem::Calibration => {
@@ -4291,6 +4481,11 @@ impl App {
                 self.emu.machine.ui_breaks_clear();
                 self.last_debug_stop = None;
                 self.show_osd("Cleared all breakpoints and watchpoints");
+            }
+            UiControl::AnalyzerRun => self.frame_analyzer_toggle_run(),
+            UiControl::AnalyzerFrame => self.frame_analyzer_step_frame(),
+            UiControl::AnalyzerPick { x, y, scanline } => {
+                self.frame_analyzer_select(x, y, scanline)
             }
         }
         self.request_redraw();
@@ -4358,6 +4553,17 @@ impl App {
                 }
             }
         }
+        if matches!(self.ui.panel, Some(Panel::FrameAnalyzer(_))) {
+            let control = match code {
+                KeyCode::KeyF => Some(UiControl::AnalyzerFrame),
+                KeyCode::KeyR => Some(UiControl::AnalyzerRun),
+                _ => None,
+            };
+            if let Some(control) = control {
+                self.activate_ui_control(control);
+                return true;
+            }
+        }
         false
     }
 
@@ -4375,6 +4581,9 @@ impl App {
 
     fn open_debugger(&mut self) {
         if !matches!(self.ui.panel, Some(Panel::Debugger(_))) {
+            if matches!(self.ui.panel, Some(Panel::FrameAnalyzer(_))) {
+                self.emu.bus_mut().set_frame_analyzer_enabled(false);
+            }
             // The debugger shortcut can arrive while the mouse is captured;
             // release it so the window's controls are reachable.
             self.set_mouse_captured(false);
@@ -4399,6 +4608,121 @@ impl App {
         }
     }
 
+    fn tool_window_title(panel: &Panel) -> &'static str {
+        match panel {
+            Panel::Debugger(_) => "Copperline Debugger",
+            Panel::FrameAnalyzer(_) => "Copperline Frame Analyzer",
+            Panel::About => "Copperline About",
+            Panel::Shortcuts => "Copperline Keyboard Shortcuts",
+            Panel::Calibration(_) => "Copperline Gamepad Calibration",
+        }
+    }
+
+    fn panel_prefers_tool_window(panel: &Panel) -> bool {
+        matches!(panel, Panel::Debugger(_) | Panel::FrameAnalyzer(_))
+    }
+
+    fn ensure_tool_window_for_current_panel(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(panel) = self.ui.panel.as_ref() else {
+            return;
+        };
+        if !Self::panel_prefers_tool_window(panel) {
+            return;
+        }
+        let title = Self::tool_window_title(panel);
+        if let Some(tool) = self.tool_window.as_ref() {
+            tool.window.set_title(title);
+            tool.window.request_redraw();
+            return;
+        }
+
+        let size = LogicalSize::new(FB_WIDTH as f64, WINDOW_PRESENT_HEIGHT as f64);
+        let attrs = WindowAttributes::default()
+            .with_title(title)
+            .with_window_icon(copperline_window_icon())
+            .with_inner_size(size)
+            .with_min_inner_size(LogicalSize::new(
+                FB_WIDTH as f64 / 2.0,
+                WINDOW_PRESENT_HEIGHT as f64 / 2.0,
+            ));
+        let window = match event_loop.create_window(attrs) {
+            Ok(w) => Arc::new(w),
+            Err(e) => {
+                warn!("create tool window failed: {e}");
+                return;
+            }
+        };
+        let texture_scale = texture_scale_for_window(&window);
+        let pixels = match build_pixels_for_window(window.clone(), texture_scale) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("tool window pixels init failed: {e}");
+                return;
+            }
+        };
+        info!(
+            "tool window ready: {title} (texture {}x{})",
+            texture_width(texture_scale),
+            texture_height(texture_scale)
+        );
+        self.tool_window = Some(ToolWindow {
+            window,
+            pixels,
+            texture_scale,
+            cursor_pos: None,
+        });
+        self.request_redraw();
+    }
+
+    fn open_frame_analyzer(&mut self) {
+        if !matches!(self.ui.panel, Some(Panel::FrameAnalyzer(_))) {
+            self.set_mouse_captured(false);
+            self.paused_before_analyzer = self.paused;
+            self.paused = true;
+            self.sync_live_audio_suspension();
+            self.emu.bus_mut().set_frame_analyzer_enabled(true);
+            self.ui.panel = Some(Panel::FrameAnalyzer(ui::FrameAnalyzerPanel::new()));
+            self.resize_for_active_panel();
+        }
+    }
+
+    fn frame_analyzer_toggle_run(&mut self) {
+        self.paused = !self.paused;
+        self.paused_before_analyzer = self.paused;
+        self.sync_live_audio_suspension();
+        if !self.paused {
+            self.emu.bus_mut().set_frame_analyzer_enabled(true);
+        }
+    }
+
+    fn frame_analyzer_step_frame(&mut self) {
+        self.emu.bus_mut().set_frame_analyzer_enabled(true);
+        self.debugger_step_frame();
+    }
+
+    fn frame_analyzer_select(&mut self, x: u16, y: u16, scanline: bool) {
+        let Some(trace) = self.emu.bus().frame_bus_trace() else {
+            return;
+        };
+        let hpos = (usize::from(x) * trace.cols / 1024).min(trace.cols.saturating_sub(1));
+        let vpos = if scanline {
+            self.ui
+                .panel
+                .as_ref()
+                .and_then(|panel| match panel {
+                    Panel::FrameAnalyzer(panel) => Some(panel.selected_vpos as usize),
+                    _ => None,
+                })
+                .unwrap_or(trace.visible_start_vpos as usize)
+        } else {
+            (usize::from(y) * trace.rows / 1024).min(trace.rows.saturating_sub(1))
+        };
+        if let Some(Panel::FrameAnalyzer(panel)) = self.ui.panel.as_mut() {
+            panel.selected_hpos = hpos.min(u16::MAX as usize) as u16;
+            panel.selected_vpos = vpos.min(u16::MAX as usize) as u16;
+        }
+    }
+
     /// Close the open panel. Closing the debugger restores the pause state
     /// from before it opened (as updated by Run/Pause used inside it).
     fn close_panel(&mut self) {
@@ -4407,7 +4731,14 @@ impl App {
             self.last_debug_stop = None;
             self.sync_live_audio_suspension();
         }
+        if matches!(self.ui.panel, Some(Panel::FrameAnalyzer(_))) {
+            self.paused = self.paused_before_analyzer;
+            self.emu.bus_mut().set_frame_analyzer_enabled(false);
+            self.sync_live_audio_suspension();
+        }
         self.ui.panel = None;
+        self.tool_window = None;
+        self.resize_for_active_panel();
         self.request_redraw();
     }
 
@@ -4891,6 +5222,84 @@ impl App {
             Panel::Debugger(panel) => {
                 Some(ui::PanelViewData::Debugger(self.build_debugger_view(panel)))
             }
+            Panel::FrameAnalyzer(panel) => Some(ui::PanelViewData::FrameAnalyzer(Box::new(
+                self.build_frame_analyzer_view(panel),
+            ))),
+        }
+    }
+
+    fn build_frame_analyzer_view(&self, panel: &ui::FrameAnalyzerPanel) -> ui::FrameAnalyzerView {
+        let bus = self.emu.bus();
+        let status = format!(
+            "{} frame {} {:.2}s",
+            if self.paused { "paused" } else { "running" },
+            bus.emulated_frames(),
+            bus.emulated_seconds()
+        );
+        let Some(trace) = bus.frame_bus_trace() else {
+            return ui::FrameAnalyzerView {
+                running: !self.paused,
+                status,
+                trace: None,
+            };
+        };
+        let selected_vpos = usize::from(panel.selected_vpos).min(trace.rows.saturating_sub(1));
+        let selected_hpos = usize::from(panel.selected_hpos).min(trace.cols.saturating_sub(1));
+        let selected_owner_code = trace.owner_code_at(selected_vpos, selected_hpos);
+        let selected_owner = owner_name_from_code(selected_owner_code);
+        let mut owners = Vec::with_capacity(trace.rows * trace.cols);
+        for vpos in 0..trace.rows {
+            if let Some(row) = trace.owner_row(vpos) {
+                owners.extend_from_slice(row);
+            }
+        }
+        let markers = bus
+            .frame_render_events()
+            .iter()
+            .take(240)
+            .map(|event| {
+                let off = event.offset & 0x01FE;
+                ui::AnalyzerMarker {
+                    vpos: event.vpos.min(u32::from(u16::MAX)) as u16,
+                    hpos: event.hpos.min(u32::from(u16::MAX)) as u16,
+                    label: format!(
+                        "{} v={:03} h={:03} ${off:03X}={:04X}",
+                        match event.source {
+                            BeamWriteSource::Cpu => "cpu",
+                            BeamWriteSource::CpuCopperIrq => "irq",
+                            BeamWriteSource::Copper => "copper",
+                        },
+                        event.vpos,
+                        event.hpos,
+                        event.value,
+                    ),
+                }
+            })
+            .collect();
+        ui::FrameAnalyzerView {
+            running: !self.paused,
+            status,
+            trace: Some(ui::AnalyzerTraceView {
+                frame: trace.frame,
+                seconds: trace.seconds,
+                rows: trace.rows,
+                cols: trace.cols,
+                line_cck: trace.line_cck,
+                visible_start_vpos: trace.visible_start_vpos,
+                visible_lines: trace.visible_lines,
+                display_hpos_start: trace.display_hpos_start,
+                display_hpos_end: trace.display_hpos_end,
+                owner_cck: trace.owner_cck,
+                blitter_busy_cck: trace.blitter_busy_cck,
+                blitter_starve_cck: trace.blitter_starve_cck,
+                partial: trace.partial,
+                selected_vpos,
+                selected_hpos,
+                selected_owner,
+                selected_owner_code,
+                owners,
+                markers,
+            }),
         }
     }
 
@@ -5311,9 +5720,20 @@ impl App {
         self.emu.set_live_audio_suspended(suspended);
     }
 
+    fn resize_for_active_panel(&self) {
+        let Some(window) = self.render.as_ref().map(|r| r.window.clone()) else {
+            return;
+        };
+        let size = LogicalSize::new(FB_WIDTH as f64, WINDOW_PRESENT_HEIGHT as f64);
+        let _ = window.request_inner_size(size);
+    }
+
     fn request_redraw(&self) {
         if let Some(render) = self.render.as_ref() {
             render.window.request_redraw();
+        }
+        if let Some(tool) = self.tool_window.as_ref() {
+            tool.window.request_redraw();
         }
     }
 


### PR DESCRIPTION
## Summary
- add a transient per-frame Agnus chip-bus ownership trace for the interactive Frame Analyzer
- render the analyzer with full-raster heatmap, selected scanline strip, owner counters, register markers, and blitter wait accounting
- move debugger/analyzer panels into native tool windows so the main emulated display remains visible
- document the new tool-window workflow and analyzer controls

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo build --release
- git diff --check