### PR TITLE
Allow Copper lists at chip RAM address zero

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -11404,6 +11404,28 @@ mod tests {
     }
 
     #[test]
+    fn copper_can_fetch_list_from_chip_ram_base() {
+        let mut bus = empty_bus();
+        for (pc, word) in [
+            (0x0000, 0x0180),
+            (0x0002, 0x00F0),
+            (0x0004, 0xFFFF),
+            (0x0006, 0xFFFE),
+        ] {
+            write_chip_word(&mut bus, pc, word);
+        }
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_COPEN;
+        bus.agnus.hpos = 0x20;
+        assert!(!bus.custom_write(0x080, 2, 0x0000));
+        assert!(!bus.custom_write(0x082, 2, 0x0000));
+        assert!(!bus.custom_write(0x088, 2, 0xFFFF));
+        bus.advance_chipset(6);
+
+        assert_eq!(bus.denise.palette[0], 0x00F0);
+    }
+
+    #[test]
     fn copper_interrupt_wait_fires_coper_at_programmed_line() {
         let mut bus = empty_bus();
         let cop1 = 0x0100usize;

--- a/src/chipset/copper.rs
+++ b/src/chipset/copper.rs
@@ -345,11 +345,7 @@ impl Copper {
         self.pc = address & !1;
         self.pending_first = None;
         self.skip_next_move = false;
-        self.state = if self.pc == 0 {
-            CopperState::Stopped
-        } else {
-            CopperState::Running
-        };
+        self.state = CopperState::Running;
     }
 
     pub fn stop(&mut self) {
@@ -863,23 +859,20 @@ mod tests {
     #[test]
     fn dma_fetches_one_instruction_word_per_slot() {
         let mut copper = Copper::new();
-        let chip_ram = [0x00, 0x00, 0x01, 0x80, 0x0A, 0xBC, 0xFF, 0xFF, 0xFF, 0xFE];
+        let chip_ram = [0x01, 0x80, 0x0A, 0xBC, 0x01, 0x82, 0x04, 0x56];
         copper.jump(0);
-        assert_eq!(copper.fetch_decode(&chip_ram), CopperFetch::Idle);
-
-        copper.jump(2);
         assert_eq!(
             copper.fetch_decode(&chip_ram),
             CopperFetch::FirstWord {
-                pc: 2,
+                pc: 0,
                 word: 0x0180
             }
         );
-        assert_eq!(copper.pc(), 4);
+        assert_eq!(copper.pc(), 2);
         assert_eq!(
             copper.fetch_decode(&chip_ram),
             CopperFetch::Instruction {
-                pc: 2,
+                pc: 0,
                 first: 0x0180,
                 second: 0x0ABC,
                 instruction: CopperInstruction::Move {
@@ -888,7 +881,30 @@ mod tests {
                 }
             }
         );
+        assert_eq!(copper.pc(), 4);
+
+        copper.jump(4);
+        assert_eq!(
+            copper.fetch_decode(&chip_ram),
+            CopperFetch::FirstWord {
+                pc: 4,
+                word: 0x0182
+            }
+        );
         assert_eq!(copper.pc(), 6);
+        assert_eq!(
+            copper.fetch_decode(&chip_ram),
+            CopperFetch::Instruction {
+                pc: 4,
+                first: 0x0182,
+                second: 0x0456,
+                instruction: CopperInstruction::Move {
+                    register: 0x0182,
+                    value: 0x0456
+                }
+            }
+        );
+        assert_eq!(copper.pc(), 8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat COP1LC=0 as a valid Agnus copper-list address instead of a stopped sentinel.
- Cover chip-RAM base copper fetch in the copper unit test and bus-level COPJMP1 regression.

Fixes #28

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features --locked -- -D warnings
- release repro screenshot: /tmp/copperline-issue28-fixed-8s.png shows the green/blue split