### PR TITLE
Add macOS DMG release builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,85 @@
+name: macOS
+
+# Builds the macOS disk image (a universal Copperline.app in a .dmg) and
+# uploads it as a workflow artifact on every qualifying change, and attaches it
+# to the GitHub Release when a v* tag is pushed. The main CI already builds and
+# tests on macOS; this workflow only adds the packaging path, so it is scoped to
+# the code and packaging surface that affects the bundle.
+#
+# The image is intentionally unsigned (no Developer ID, no notarization), so it
+# trips Gatekeeper on first launch; the bundled README.txt documents the
+# right-click-Open workaround.
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "src/**"
+      - "vendor/**"
+      - "assets/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".cargo/**"
+      - "packaging/macos/**"
+      - ".github/workflows/macos.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "vendor/**"
+      - "assets/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".cargo/**"
+      - "packaging/macos/**"
+      - ".github/workflows/macos.yml"
+  # Manual rebuild. Use this to attach a dmg to a release whose tag predates
+  # this workflow (the v* tag tree has no macos.yml, so a tag push cannot
+  # trigger it): run it against a branch with the source parity you want and set
+  # release_tag to push the built dmg onto that existing release.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to attach the dmg to (e.g. v0.7.0). Leave blank to only upload a workflow artifact."
+        required: false
+        default: ""
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build macOS dmg
+    runs-on: macos-latest
+    # Needed only by the release-attach step on v* tags.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Both Apple architectures so build-dmg.sh can lipo a universal binary.
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+      - name: Build dmg
+        run: packaging/macos/build-dmg.sh
+      - name: Locate artifact
+        id: artifact
+        run: echo "path=$(ls Copperline-*-macos-universal.dmg | head -n1)" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: copperline-macos
+          path: ${{ steps.artifact.outputs.path }}
+          if-no-files-found: error
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.artifact.outputs.path }}
+      - name: Attach to existing release (manual run)
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # --clobber so a re-run replaces the asset instead of failing on a
+        # name clash.
+        run: gh release upload "${{ inputs.release_tag }}" "${{ steps.artifact.outputs.path }}" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ copperline-video-*.avi
 /AppDir
 /.appimage-tools
 /*.AppImage
+
+# macOS disk image build artifact (packaging/macos/build-dmg.sh); the .app
+# bundle stages under /target, already ignored above.
+/*.dmg

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -129,6 +129,28 @@ first. To build one by hand on a Windows host:
 packaging/windows/build-zip.ps1
 ```
 
+## macOS disk image
+
+The prebuilt macOS download is a disk image (`packaging/macos/`): a
+drag-to-Applications `Copperline.app` wrapped in a `.dmg`. The `macOS` workflow
+builds it on `macos-latest` and, on a `v*` tag, attaches
+`Copperline-X.Y.Z-macos-universal.dmg` to the GitHub Release automatically.
+Homebrew (above) remains the build-from-source channel; the disk image is the
+no-compiler alternative.
+
+The app bundle is a universal binary (the workflow builds both
+`aarch64-apple-darwin` and `x86_64-apple-darwin` and `lipo`-joins them), so one
+download runs natively on Apple Silicon and Intel. The bundled AROS ROM lives in
+`Contents/Resources/aros`, which `romsearch.rs` probes, so it runs out of the
+box. The image is ad-hoc signed (required for the arm64 slice to launch) but is
+intentionally NOT Developer ID signed or notarized, so first launch trips
+Gatekeeper; the right-click-Open workaround is in the image's `README.txt`. To
+build one by hand on a macOS host:
+
+```sh
+./packaging/macos/build-dmg.sh
+```
+
 ## Crate packaging
 
 `cargo package --no-verify --offline` can be used to inspect the source

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -30,6 +30,16 @@ override to click through, unlike a downloaded prebuilt app. Use
 `brew install --HEAD copperline` to build the latest `main` instead of the
 most recent tagged release, then run `copperline` from the terminal.
 
+For a no-compiler install, download `Copperline-X.Y.Z-macos-universal.dmg`
+from the [releases page](https://github.com/LinuxJedi/Copperline/releases),
+open it, and drag `Copperline.app` onto the Applications shortcut. The app is a
+universal binary that runs natively on Apple Silicon and Intel, and bundles the
+AROS boot ROM, so it runs out of the box. The image is not code-signed or
+notarized, so on first launch Gatekeeper refuses to open it; right-click (or
+Control-click) the app and choose **Open**, then confirm. macOS remembers the
+choice. If it still refuses, clear the download quarantine with
+`xattr -dr com.apple.quarantine /Applications/Copperline.app`.
+
 ## Installing on Linux
 
 Two channels are provided.

--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Copperline</string>
+  <key>CFBundleExecutable</key>
+  <string>copperline</string>
+  <key>CFBundleIconFile</key>
+  <string>copperline.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>dev.copperline.Copperline</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Copperline</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>@VERSION@</string>
+  <key>CFBundleVersion</key>
+  <string>@VERSION@</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.games</string>
+  <!-- The universal binary's arm64 slice requires macOS 11 (Big Sur); the
+       x86_64 slice runs further back, but LSMinimumSystemVersion governs the
+       whole bundle, so it is set to the higher floor. -->
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copperline is licensed under GPL-3.0-or-later.</string>
+</dict>
+</plist>

--- a/packaging/macos/README.txt
+++ b/packaging/macos/README.txt
@@ -1,0 +1,42 @@
+Copperline - macOS disk image
+==============================
+
+Copperline is a cycle-driven Amiga emulator (OCS/ECS/AGA).
+
+Installing
+----------
+Drag Copperline.app onto the Applications shortcut in this window, then launch
+it from Applications or Launchpad. The app is a universal binary and runs
+natively on both Apple Silicon and Intel Macs.
+
+First launch (unsigned app)
+---------------------------
+This build is not code-signed or notarized, so on first launch macOS Gatekeeper
+will refuse to open it ("Copperline cannot be opened because the developer
+cannot be verified", or "is damaged" on Apple Silicon). This is expected for an
+unsigned download. To run it anyway, right-click (or Control-click)
+Copperline.app and choose Open, then confirm Open in the dialog. macOS
+remembers the choice, so subsequent launches open normally.
+
+If right-click Open still refuses, clear the download quarantine from a terminal:
+
+    xattr -dr com.apple.quarantine /Applications/Copperline.app
+
+Boot ROM
+--------
+With no ROM of your own, Copperline boots the bundled AROS open-source
+Kickstart replacement, stored inside the app at
+Copperline.app/Contents/Resources/aros. AROS is freely redistributable; see the
+LICENSE next to the ROM. To use a real Kickstart instead, point a config file
+at it, or load it at runtime from the menu (Load Kickstart ROM...).
+
+Configuration
+-------------
+copperline.example.toml is a starting point. Copy it, edit the paths to your
+own Kickstart ROM and disk/hard-disk images, and launch from a terminal with:
+
+    /Applications/Copperline.app/Contents/MacOS/copperline --config your-config.toml
+
+Run that binary with --help for the full command-line surface.
+
+Copperline is licensed under GPL-3.0-or-later; see LICENSE.txt.

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build a Copperline macOS disk image: a drag-to-Applications Copperline.app
+# wrapped in a .dmg. Run from a macOS host (or CI); see
+# .github/workflows/macos.yml.
+#
+# What it does:
+#   1. Builds the release binary for both Apple architectures with the pinned
+#      dependency graph and lipo-joins them into one universal binary, so a
+#      single download runs natively on Apple Silicon and Intel.
+#   2. Stages a Copperline.app bundle: the universal binary in Contents/MacOS,
+#      the icon and AROS ROM in Contents/Resources. romsearch.rs probes a
+#      bundle's Contents/Resources/aros first, so the bundled AROS ROM is found
+#      with no configuration.
+#   3. Ad-hoc code-signs the bundle. lipo strips the per-slice signatures Rust
+#      attaches on macOS, and an unsigned arm64 binary will not launch on Apple
+#      Silicon at all, so a signature is mandatory even when it is ad-hoc.
+#   4. Lays out a .dmg with the app and an Applications symlink, named
+#      Copperline-<version>-macos-universal.dmg to mirror the
+#      AppImage/Windows/Homebrew version naming so release assets are
+#      self-describing.
+#
+# This build is intentionally NOT signed with a Developer ID or notarized, so
+# first launch trips Gatekeeper; packaging/macos/README.txt (shipped in the
+# image) explains the right-click-Open workaround.
+#
+# Override knobs (env):
+#   MACOS_UNIVERSAL=0   build only the host architecture (faster local builds)
+#   OUTPUT=<path>       final .dmg file name
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+cd "$repo_root"
+
+version="$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)"
+app_name="Copperline.app"
+stage="$repo_root/target/macos-dmg"
+app="$stage/$app_name"
+output="${OUTPUT:-$repo_root/Copperline-$version-macos-universal.dmg}"
+
+# Architectures to build. Default is universal (both); MACOS_UNIVERSAL=0 builds
+# only the host arch for a faster local turnaround.
+if [ "${MACOS_UNIVERSAL:-1}" = "0" ]; then
+  case "$(uname -m)" in
+    arm64) targets=(aarch64-apple-darwin) ;;
+    *) targets=(x86_64-apple-darwin) ;;
+  esac
+else
+  targets=(aarch64-apple-darwin x86_64-apple-darwin)
+fi
+
+echo "==> Building release binary (${targets[*]})"
+for target in "${targets[@]}"; do
+  # Idempotent; ensures hand-builds on a fresh checkout have the cross target.
+  if command -v rustup >/dev/null 2>&1; then
+    rustup target add "$target" >/dev/null
+  fi
+  cargo build --release --locked --target "$target"
+done
+
+echo "==> Staging $app_name"
+rm -rf "$stage"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources/aros"
+
+# Universal binary from the per-arch builds (a single-arch lipo is a no-op copy).
+bins=()
+for target in "${targets[@]}"; do
+  bins+=("target/$target/release/copperline")
+done
+lipo -create -output "$app/Contents/MacOS/copperline" "${bins[@]}"
+
+# Info.plist with the version substituted in; plutil -lint catches a botched
+# substitution before the bundle ships.
+sed "s/@VERSION@/$version/g" "$here/Info.plist.in" > "$app/Contents/Info.plist"
+plutil -lint "$app/Contents/Info.plist" >/dev/null
+
+# Classic four-character package signature; harmless but expected by some tools.
+printf 'APPL????' > "$app/Contents/PkgInfo"
+
+cp "assets/brand/copperline.icns" "$app/Contents/Resources/copperline.icns"
+
+# Bundled AROS open-source Kickstart replacement (the default boot ROM).
+# romsearch.rs resolves Contents/Resources/aros relative to the executable.
+# Ship the license/readme/acknowledgements next to the ROM halves as
+# redistribution requires.
+for f in \
+  aros-amiga-m68k-rom.bin \
+  aros-amiga-m68k-ext.bin \
+  LICENSE \
+  README.md \
+  ACKNOWLEDGEMENTS; do
+  cp "assets/aros/$f" "$app/Contents/Resources/aros/$f"
+done
+
+echo "==> Ad-hoc signing $app_name"
+# --deep so the nested executable is signed too; "-" selects the ad-hoc
+# identity (no Developer ID needed). This is what lets the universal binary
+# launch on Apple Silicon; it does not satisfy notarization, so downloads are
+# still Gatekeeper-quarantined (see README.txt).
+codesign --force --deep --sign - "$app"
+
+echo "==> Laying out disk image contents"
+# Top-level docs alongside the app, mirroring the Windows zip: an Applications
+# shortcut for drag-installs, the README's Gatekeeper note, a starter config,
+# and the Copperline license that must accompany the binary.
+ln -s /Applications "$stage/Applications"
+cp "$here/README.txt" "$stage/README.txt"
+cp "copperline.example.toml" "$stage/copperline.example.toml"
+cp "LICENSE" "$stage/LICENSE.txt"
+
+echo "==> Building $(basename "$output")"
+rm -f "$output"
+hdiutil create \
+  -volname "Copperline $version" \
+  -srcfolder "$stage" \
+  -fs HFS+ \
+  -format UDZO \
+  -ov \
+  "$output" >/dev/null
+
+echo "==> Built $output"


### PR DESCRIPTION
Closes #32.

Auto-generates an unsigned macOS disk image as a release asset, mirroring the Windows zip and Linux AppImage packaging paths.

## What this adds

- **`packaging/macos/build-dmg.sh`** - builds a release binary for both `aarch64-apple-darwin` and `x86_64-apple-darwin`, `lipo`-joins them into one **universal** binary, stages `Copperline.app`, ad-hoc code-signs it, and wraps it in `Copperline-<version>-macos-universal.dmg` with a drag-to-Applications layout. `MACOS_UNIVERSAL=0` builds host-arch only for faster local iteration.
- **`packaging/macos/Info.plist.in`** - bundle metadata template (`@VERSION@` substituted at build, validated with `plutil -lint`).
- **`packaging/macos/README.txt`** - ships inside the DMG; documents the unsigned-app Gatekeeper right-click-Open / `xattr` workaround.
- **`.github/workflows/macos.yml`** - runs on `macos-latest`, uploads a workflow artifact on every qualifying change, attaches the DMG to the GitHub Release on a `v*` tag, and has a `workflow_dispatch` back-fill input (same shape as `windows.yml`).
- **`.gitignore`** - ignores the repo-root `/*.dmg` output (matching the existing `/*.AppImage` rule).
- **`RELEASE.md`** + **`docs/guide/getting-started.md`** - document the new download channel and the Gatekeeper note.

No source changes were needed: `romsearch.rs` already probes a bundle's `Contents/Resources/aros/`, so the bundled AROS boot ROM is found with no configuration.

## Unsigned, by design

The image is ad-hoc signed (required for the arm64 slice to launch on Apple Silicon) but intentionally **not** Developer ID signed or notarized, so first launch trips Gatekeeper. The bundled `README.txt` and the docs explain the right-click-Open workaround.

## Verification (ran the real CI path locally)

- Universal binary confirmed: `lipo -info` reports `x86_64 arm64`.
- `codesign --verify` passes; `Signature=adhoc`, identifier `dev.copperline.Copperline`.
- DMG mounts as volume `Copperline 0.7.0` with `Copperline.app` + `Applications` symlink + README/example config/LICENSE.
- The bundled binary, launched from a neutral working directory, loaded AROS from `Contents/Resources/aros/` and ran 20 emulated seconds cleanly; its screenshot is **byte-identical (same md5)** to the plain dev build, so packaging changes nothing about emulation.
- `bash -n`, `shellcheck`, YAML parse, and an ASCII-only scan all pass.

## Note on the current tag

A `v*` tag whose tree predates `macos.yml` will not trigger it, so to back-fill the DMG onto the existing `v0.7.0` release, use the workflow's **Run workflow** button with `release_tag: v0.7.0`. Future tags trigger automatically. This is documented in `RELEASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)