### PR TITLE
Add adjustable warp-speed output frame skip

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -44,6 +44,15 @@ pacing_budget = "cycles"
 # one run (set it to 0/false/off to force it off).
 # realtime_priority = false
 
+# Default speed of Warp Speed (turbo) mode. The window presents with vsync,
+# so emulating one frame per presented frame would pin warp to the host
+# monitor's refresh rate. This is an output frame skip: warp retires this
+# many emulated frames per presented frame, making warp roughly the limit
+# times the refresh rate (host CPU permitting). One of "2x", "4x", "8x",
+# "16x", or "max" (default; run flat out, still presenting at vsync). Adjust
+# it live from the Warp Limit menu item or Cmd+Shift+W / Alt+Shift+W.
+# warp_speed = "max"
+
 
 [cpu]
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -119,6 +119,7 @@ clock works.
 power_on = true            # false = start powered off at the test screen
 pacing_budget = "cycles"   # "cycles" (hardware-accurate) or "instructions"
 realtime_priority = false  # true = raise the pacer/audio thread priority
+warp_speed = "max"         # turbo limit: "2x", "4x", "8x", "16x", or "max"
 ```
 
 The deterministic cycle-driven core is the only emulation timing. It is
@@ -153,6 +154,15 @@ carried no information.)
   `COPPERLINE_REALTIME_PRIORITY` overrides this for one run; set it to
   `0`/`false`/`off` to force it off, or to any other value (or leave it empty)
   to force it on.
+- `warp_speed` sets the default speed of Warp Speed (turbo) mode. The window
+  presents with vsync, so emulating one frame per presented frame would pin
+  warp to the host monitor's refresh rate. This option is an output frame
+  skip -- `"2x"`, `"4x"`, `"8x"`, `"16x"`, or `"max"` (default) -- so warp
+  retires that many emulated frames per presented frame, making warp roughly
+  the limit times the refresh rate (host CPU permitting). `"max"` runs flat
+  out and still presents at vsync. Adjust it live from the **Warp Limit**
+  menu item or `Cmd+Shift+W` / `Alt+Shift+W` (see [The window and its
+  controls](ui.md)).
 
 ## `[cpu]`
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -20,6 +20,8 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+G` | `Alt+G` | Capture / release the host mouse (clicking the display also captures) |
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
 | `Cmd+J` | `Alt+J` | Cycle joystick input mode: auto, keyboard, gamepad |
+| `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |
+| `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Esc` | `Esc` | Close an open menu, tool window, or overlay panel; otherwise passed through to the Amiga |
 | `Ctrl+Amiga+Amiga` | `Ctrl+Amiga+Amiga` | Keyboard reset (warm reboot) |
 
@@ -87,8 +89,17 @@ tool window or overlay.
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Joystick Input** (also `Cmd+J` / `Alt+J`): cycles between automatic
   selection, keyboard joystick emulation, and gamepad-only mode.
-- **Warp Speed**: runs the emulator unpaced, as fast as the host allows.
-  Toggling back re-anchors real-time pacing cleanly.
+- **Warp Speed** (also `Cmd+W` / `Alt+W`): runs the emulator unpaced for
+  fast-forward. Toggling back re-anchors real-time pacing cleanly.
+- **Warp Limit** (also `Cmd+Shift+W` / `Alt+Shift+W`): cycles how fast warp
+  runs. Because the window presents with vsync, emulating one frame per
+  presented frame would cap warp at the host monitor's refresh rate (about
+  1.2x for 50 Hz PAL on a 60 Hz display). The limit sets an output frame
+  skip -- 2x, 4x, 8x, 16x, or **Max** -- so warp retires that many emulated
+  frames per presented frame, making the effective speed roughly the limit
+  times the refresh rate (host CPU permitting). `Max` runs flat out and
+  still presents at vsync. The default is set by `[emulation] warp_speed`
+  (see [Configuration](configuration.md)).
 - **Record Video** (also `Cmd+R` / `Alt+R`): starts a video-with-audio
   recording; the same item (or shortcut again) stops it. See below.
 - **Record Input** (also `Cmd+Shift+R` / `Alt+Shift+R`): records every

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,6 +168,10 @@ pub struct Emulation {
     /// [`crate::priority`]. The `COPPERLINE_REALTIME_PRIORITY` env var
     /// overrides this for one run.
     pub realtime_priority: bool,
+    /// How fast the UI "Warp Speed" (turbo) mode runs when engaged, expressed
+    /// as an output frame-skip level. See [`WarpSpeed`]. Adjustable at runtime
+    /// from the Emulator menu and the keyboard.
+    pub warp_speed: WarpSpeed,
 }
 
 /// Real-mode pacing budget model.
@@ -187,6 +191,90 @@ pub enum PacingBudget {
     /// mixes that average more than the assumed flat cost. Opt in via
     /// `pacing_budget = "instructions"` or `COPPERLINE_REAL_PACING_BUDGET=instructions`.
     Instructions,
+}
+
+/// Hard upper bound on emulated frames per presented frame in `WarpSpeed::Max`,
+/// so a host that emulates faster than it presents cannot spin the event loop
+/// arbitrarily long between input polls. `Max` is normally bounded first by its
+/// wall-clock budget (see `WarpSpeed::time_budget_ms`); this cap only matters
+/// when the host is fast enough to retire this many frames inside that budget.
+pub const WARP_MAX_FRAME_CAP: usize = 1024;
+
+/// Wall-clock budget (milliseconds) for one presented frame in `WarpSpeed::Max`.
+/// The event loop emulates frames back-to-back until this much host time has
+/// elapsed, then presents one frame at vsync. Kept under a 60 Hz refresh
+/// interval (16.6 ms) so input is still polled and a frame still presented every
+/// host refresh while the core runs flat out.
+pub const WARP_MAX_BUDGET_MS: u64 = 12;
+
+/// How fast the UI "Warp Speed" (turbo) mode runs when engaged.
+///
+/// Presentation is gated to the host monitor's refresh rate (the wgpu surface
+/// presents with vsync), so emulating exactly one frame per presented frame
+/// caps warp at the monitor rate -- about 1.2x for a 50 Hz PAL machine on a
+/// 60 Hz display. To decouple emulation speed from the monitor, warp emulates
+/// several frames per *presented* frame (output frame skip): the intermediate
+/// frames are computed but never rendered or presented, so the effective speed
+/// is the level times the refresh rate, host CPU permitting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WarpSpeed {
+    /// Two emulated frames per presented frame.
+    X2,
+    /// Four emulated frames per presented frame.
+    X4,
+    /// Eight emulated frames per presented frame.
+    X8,
+    /// Sixteen emulated frames per presented frame.
+    X16,
+    /// As many frames as fit in `WARP_MAX_BUDGET_MS` of host time per presented
+    /// frame (bounded by `WARP_MAX_FRAME_CAP`): run flat out, present at vsync.
+    #[default]
+    Max,
+}
+
+impl WarpSpeed {
+    /// Cycle to the next level for the menu/keyboard "cycle" control:
+    /// 2x -> 4x -> 8x -> 16x -> Max -> 2x.
+    pub fn next(self) -> Self {
+        match self {
+            Self::X2 => Self::X4,
+            Self::X4 => Self::X8,
+            Self::X8 => Self::X16,
+            Self::X16 => Self::Max,
+            Self::Max => Self::X2,
+        }
+    }
+
+    /// Short label for menus and the on-screen status flash.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::X2 => "2x",
+            Self::X4 => "4x",
+            Self::X8 => "8x",
+            Self::X16 => "16x",
+            Self::Max => "Max",
+        }
+    }
+
+    /// Maximum emulated frames to retire per presented frame while warping.
+    pub fn frame_cap(self) -> usize {
+        match self {
+            Self::X2 => 2,
+            Self::X4 => 4,
+            Self::X8 => 8,
+            Self::X16 => 16,
+            Self::Max => WARP_MAX_FRAME_CAP,
+        }
+    }
+
+    /// Wall-clock budget (milliseconds) per presented frame, or `None` for the
+    /// fixed levels, which simply retire `frame_cap` frames then present.
+    pub fn time_budget_ms(self) -> Option<u64> {
+        match self {
+            Self::Max => Some(WARP_MAX_BUDGET_MS),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -523,6 +611,7 @@ impl Default for Config {
                 power_on: true,
                 pacing_budget: PacingBudget::Cycles,
                 realtime_priority: false,
+                warp_speed: WarpSpeed::default(),
             },
             chip_ram_bytes: 512 * 1024,
             fast_ram_bytes: 0,
@@ -820,6 +909,8 @@ struct RawEmulation {
     /// Best-effort realtime-like thread priority for the pacer and audio
     /// threads (default false). See `src/priority.rs`.
     realtime_priority: Option<bool>,
+    /// UI warp/turbo speed: "2x", "4x", "8x", "16x", or "max" (default).
+    warp_speed: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -968,6 +1059,10 @@ impl TryFrom<RawConfig> for Config {
                 .emulation
                 .realtime_priority
                 .unwrap_or(defaults.emulation.realtime_priority),
+            warp_speed: match raw.emulation.warp_speed.as_deref() {
+                None => defaults.emulation.warp_speed,
+                Some(s) => parse_warp_speed(s)?,
+            },
         };
         let chip_ram_bytes = match raw.memory.chip.as_deref() {
             None => defaults.chip_ram_bytes,
@@ -1147,6 +1242,20 @@ fn parse_pacing_budget(s: &str) -> Result<PacingBudget> {
         "instructions" | "retired-instructions" => Ok(PacingBudget::Instructions),
         _ => Err(anyhow!(
             "unknown emulation pacing_budget {:?}: expected \"cycles\" or \"instructions\"",
+            s
+        )),
+    }
+}
+
+fn parse_warp_speed(s: &str) -> Result<WarpSpeed> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "2x" | "2" => Ok(WarpSpeed::X2),
+        "4x" | "4" => Ok(WarpSpeed::X4),
+        "8x" | "8" => Ok(WarpSpeed::X8),
+        "16x" | "16" => Ok(WarpSpeed::X16),
+        "max" | "unlimited" => Ok(WarpSpeed::Max),
+        _ => Err(anyhow!(
+            "unknown emulation warp_speed {:?}: expected \"2x\", \"4x\", \"8x\", \"16x\", or \"max\"",
             s
         )),
     }
@@ -1599,7 +1708,47 @@ mod tests {
         let cfg = parse_config("")?;
         assert!(cfg.emulation.power_on);
         assert_eq!(cfg.emulation.pacing_budget, PacingBudget::Cycles);
+        assert_eq!(cfg.emulation.warp_speed, WarpSpeed::Max);
         Ok(())
+    }
+
+    #[test]
+    fn warp_speed_parses_levels_and_rejects_garbage() -> Result<()> {
+        for (text, expected) in [
+            ("2x", WarpSpeed::X2),
+            ("4x", WarpSpeed::X4),
+            ("8x", WarpSpeed::X8),
+            ("16x", WarpSpeed::X16),
+            ("max", WarpSpeed::Max),
+            ("MAX", WarpSpeed::Max),
+        ] {
+            let cfg = parse_config(&format!("[emulation]\nwarp_speed = {text:?}\n"))?;
+            assert_eq!(cfg.emulation.warp_speed, expected, "for {text:?}");
+        }
+        assert!(parse_config("[emulation]\nwarp_speed = \"32x\"\n").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn warp_speed_cycle_wraps_through_levels() {
+        // The menu/keyboard "cycle" control walks 2x -> 4x -> 8x -> 16x ->
+        // Max and back to 2x.
+        let order = [
+            WarpSpeed::X2,
+            WarpSpeed::X4,
+            WarpSpeed::X8,
+            WarpSpeed::X16,
+            WarpSpeed::Max,
+        ];
+        for window in order.windows(2) {
+            assert_eq!(window[0].next(), window[1]);
+        }
+        assert_eq!(WarpSpeed::Max.next(), WarpSpeed::X2);
+        // Fixed levels retire exactly their multiplier in frames; Max is
+        // bounded by a wall-clock budget rather than a small fixed count.
+        assert_eq!(WarpSpeed::X8.frame_cap(), 8);
+        assert!(WarpSpeed::X8.time_budget_ms().is_none());
+        assert_eq!(WarpSpeed::Max.time_budget_ms(), Some(WARP_MAX_BUDGET_MS));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1158,6 +1158,7 @@ fn main() -> Result<()> {
         disk_write_protected,
         resolve_overscan(cfg.overscan),
         resolve_phosphor(cfg.phosphor),
+        cfg.emulation.warp_speed,
         about_machine_lines(&cfg),
     );
 

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -13,6 +13,7 @@ use super::window::{
     BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE, BUTTON_FACE_HOVER,
 };
 use super::{font, FB_WIDTH, HOST_SHORTCUT_MODIFIER_LABEL, PRESENT_HEIGHT};
+use crate::config::WarpSpeed;
 
 // ---------------------------------------------------------------------------
 // Palette
@@ -58,6 +59,7 @@ pub enum MenuItem {
     Debugger,
     JoystickInput,
     Warp,
+    WarpLimit,
     Record,
     RecordInput,
     SaveState,
@@ -65,12 +67,13 @@ pub enum MenuItem {
     LoadRom,
 }
 
-pub const MENU_ITEMS: [MenuItem; 12] = [
+pub const MENU_ITEMS: [MenuItem; 13] = [
     MenuItem::FrameAnalyzer,
     MenuItem::Debugger,
     MenuItem::Calibration,
     MenuItem::JoystickInput,
     MenuItem::Warp,
+    MenuItem::WarpLimit,
     MenuItem::Record,
     MenuItem::RecordInput,
     MenuItem::SaveState,
@@ -83,6 +86,7 @@ pub const MENU_ITEMS: [MenuItem; 12] = [
 fn menu_item_label(
     item: MenuItem,
     warp: bool,
+    warp_speed: WarpSpeed,
     recording: bool,
     input_recording: bool,
     joystick_input_mode: JoystickInputMode,
@@ -96,6 +100,9 @@ fn menu_item_label(
         MenuItem::JoystickInput => format!("Joystick Input  [{}]", joystick_input_mode.label()),
         MenuItem::Warp if warp => "Warp Speed      [on]".to_string(),
         MenuItem::Warp => "Warp Speed     [off]".to_string(),
+        // Right-pad so the closing bracket stays put as the value width
+        // changes (2x/8x vs 16x/Max), aligning with the Warp Speed row above.
+        MenuItem::WarpLimit => format!("Warp Limit     {:>5}", format!("[{}]", warp_speed.label())),
         MenuItem::Record if recording => "Stop Video Recording".to_string(),
         MenuItem::Record => "Record Video".to_string(),
         MenuItem::RecordInput if input_recording => "Stop Input Recording".to_string(),
@@ -364,7 +371,7 @@ pub enum UiControl {
 fn panel_dims(panel: &Panel) -> (usize, usize) {
     match panel {
         Panel::About => (560, 380),
-        Panel::Shortcuts => (600, 352),
+        Panel::Shortcuts => (600, 396),
         Panel::Calibration(_) => (620, 372),
         Panel::Debugger(_) => (684, 520),
         Panel::FrameAnalyzer(_) => (700, 526),
@@ -813,6 +820,7 @@ fn draw_menu(
     frame: &mut [u8],
     hover: Option<UiControl>,
     warp: bool,
+    warp_speed: WarpSpeed,
     recording: bool,
     input_recording: bool,
     joystick_input_mode: JoystickInputMode,
@@ -837,7 +845,14 @@ fn draw_menu(
             frame,
             item_rect.x + 8,
             item_rect.y + (MENU_ITEM_H - 16) / 2,
-            &menu_item_label(*item, warp, recording, input_recording, joystick_input_mode),
+            &menu_item_label(
+                *item,
+                warp,
+                warp_speed,
+                recording,
+                input_recording,
+                joystick_input_mode,
+            ),
             fg,
             2,
             scale,
@@ -920,7 +935,7 @@ fn draw_about(frame: &mut [u8], rect: Rect, view: &AboutView, scale: usize) {
     }
 }
 
-const SHORTCUT_ROWS: [(&str, &str, bool); 12] = [
+const SHORTCUT_ROWS: [(&str, &str, bool); 14] = [
     ("Q", "Quit", true),
     ("S", "Save screenshot", true),
     ("R", "Record video on/off", true),
@@ -931,6 +946,8 @@ const SHORTCUT_ROWS: [(&str, &str, bool); 12] = [
     ("G", "Capture mouse", true),
     ("B", "Debugger", true),
     ("J", "Joystick input mode", true),
+    ("W", "Warp speed on/off", true),
+    ("Shift+W", "Warp limit (2x..Max)", true),
     ("Esc", "Close menu/window", false),
     ("Ctrl+Ami+Ami", "Keyboard reset", false),
 ];
@@ -1797,6 +1814,7 @@ pub fn draw(
     hover: Option<UiControl>,
     data: Option<&PanelViewData>,
     warp: bool,
+    warp_speed: WarpSpeed,
     recording: bool,
     input_recording: bool,
     joystick_input_mode: JoystickInputMode,
@@ -1809,6 +1827,7 @@ pub fn draw(
             frame,
             hover,
             warp,
+            warp_speed,
             recording,
             input_recording,
             joystick_input_mode,
@@ -2204,6 +2223,7 @@ mod tests {
             None,
             None,
             true,
+            WarpSpeed::Max,
             false,
             false,
             JoystickInputMode::Auto,
@@ -2235,6 +2255,7 @@ mod tests {
             None,
             Some(&data),
             false,
+            WarpSpeed::Max,
             false,
             false,
             JoystickInputMode::Auto,
@@ -2254,6 +2275,7 @@ mod tests {
             None,
             Some(&PanelViewData::Shortcuts),
             false,
+            WarpSpeed::Max,
             false,
             false,
             JoystickInputMode::Auto,
@@ -2290,6 +2312,7 @@ mod tests {
             Some(UiControl::CalCancel),
             Some(&data),
             false,
+            WarpSpeed::Max,
             false,
             false,
             JoystickInputMode::Auto,
@@ -2333,6 +2356,7 @@ mod tests {
             Some(UiControl::DebugStep),
             Some(&data),
             false,
+            WarpSpeed::Max,
             false,
             false,
             JoystickInputMode::Auto,
@@ -2373,6 +2397,7 @@ mod tests {
             Some(UiControl::DebugRegToggle),
             Some(&data),
             false,
+            WarpSpeed::Max,
             false,
             false,
             JoystickInputMode::Auto,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::bus::{
     BeamWriteSource, FrontPanelStatus, RenderRegisterSnapshot, VideoRenderFrameTiming,
 };
-use crate::config::Overscan;
+use crate::config::{Overscan, WarpSpeed};
 use crate::emulator::Emulator;
 use crate::screenshot;
 
@@ -523,6 +523,11 @@ pub struct App {
     gamepad: crate::gamepad::GamepadReader,
     /// Host source policy for the emulated port-2 joystick/CD32 pad.
     joystick_input_mode: JoystickInputMode,
+    /// Output frame-skip level for warp/turbo mode: how many emulated frames
+    /// are retired per presented frame while warp is engaged. Presentation is
+    /// vsync-gated, so this is what decouples warp speed from the host monitor
+    /// refresh rate. Adjustable from the Emulator menu and the keyboard.
+    warp_speed: WarpSpeed,
     /// Whether the last normal input poll resolved a calibrated physical
     /// gamepad. Auto mode uses this to decide whether mapped keyboard keys
     /// should be consumed as joystick controls.
@@ -715,6 +720,7 @@ impl App {
         disk_write_protected: [bool; 4],
         overscan: Overscan,
         phosphor: f32,
+        warp_speed: WarpSpeed,
         about_machine_lines: Vec<String>,
     ) -> Self {
         // Headless capture runs drive themselves off emulated time, so a
@@ -785,6 +791,7 @@ impl App {
             overscan,
             gamepad: crate::gamepad::GamepadReader::new(),
             joystick_input_mode: JoystickInputMode::default(),
+            warp_speed,
             last_gamepad_active: false,
             keyboard_joy_held: KeyboardJoystickHeld::default(),
             ui: UiState::default(),
@@ -1233,6 +1240,17 @@ impl ApplicationHandler for App {
                     {
                         self.toggle_recording()
                     }
+                    (KeyCode::KeyW, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers)
+                            && self.modifiers.shift_key() =>
+                    {
+                        self.cycle_warp_speed()
+                    }
+                    (KeyCode::KeyW, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers) =>
+                    {
+                        self.toggle_warp()
+                    }
                     (other, state) => {
                         let pressed = state == ElementState::Pressed;
                         if pressed && self.ui_handle_key(other) {
@@ -1421,6 +1439,7 @@ impl ApplicationHandler for App {
                 let osd = self.active_osd_text();
                 let ui_hover = self.cursor_pos.and_then(|p| self.main_ui_control_at(p));
                 let warp = !self.emu.paced();
+                let warp_speed = self.warp_speed;
                 let recording = self.recorder.is_some();
                 let input_recording = self.input_recorder.is_some();
                 let ui_data = self.build_panel_view_data();
@@ -1443,6 +1462,7 @@ impl ApplicationHandler for App {
                         ui_hover,
                         ui_data.as_ref(),
                         warp,
+                        warp_speed,
                         recording,
                         input_recording,
                         self.joystick_input_mode,
@@ -1518,18 +1538,50 @@ impl ApplicationHandler for App {
         } else {
             self.pump_joystick_input();
         }
+        // Headless capture (screenshot/frame-dump) builds the framebuffer for
+        // the saved PNG but presents nothing: it already runs unthrottled at one
+        // frame per loop (request_redraw is skipped below), and every captured
+        // frame must be rendered, so warp's output frame-skip burst must not
+        // apply there.
+        let headless_capture = self.auto_shot.is_some() || self.frame_dump.is_some();
         // Run one scheduler quantum. Rebuild the host framebuffer only
         // when Agnus has crossed into a new frame; the expensive renderer
         // reconstructs a completed hardware frame, not an instruction slice.
         if running {
-            if let Err(e) = self.emu.step_frame() {
-                error!("emulator step halted: {e:?}");
-                self.cpu_halted = true;
-                self.sync_live_audio_suspension();
+            // Presentation is vsync-gated, so emulating exactly one frame per
+            // presented frame would cap warp at the host monitor refresh rate
+            // (about 1.2x for 50 Hz PAL on a 60 Hz display). In warp, retire
+            // several frames per presented frame (output frame skip): only the
+            // last frame of the burst is rendered and presented, so the
+            // effective speed is the warp level times the refresh rate, host
+            // CPU permitting. Real-time pacing and headless capture stay at one
+            // frame per loop.
+            let (frame_cap, time_budget) = self.warp_burst_plan(headless_capture);
+            let burst_start = Instant::now();
+            let mut frames_done = 0usize;
+            loop {
+                if let Err(e) = self.emu.step_frame() {
+                    error!("emulator step halted: {e:?}");
+                    self.cpu_halted = true;
+                    self.sync_live_audio_suspension();
+                    break;
+                }
+                frames_done += 1;
+                // A breakpoint/watchpoint hit pauses the machine and brings
+                // the debugger window up with the reason; end the burst so the
+                // stop surfaces at the frame where it happened.
+                if self.surface_debug_stop() {
+                    break;
+                }
+                if frames_done >= frame_cap {
+                    break;
+                }
+                if let Some(budget) = time_budget {
+                    if burst_start.elapsed() >= budget {
+                        break;
+                    }
+                }
             }
-            // A breakpoint/watchpoint hit pauses the machine and brings
-            // the debugger window up with the reason.
-            self.surface_debug_stop();
             self.ensure_tool_windows_for_open_panels(event_loop);
         }
         let now = Instant::now();
@@ -1540,11 +1592,10 @@ impl ApplicationHandler for App {
             rendered |= self.finish_render_for_current_frame();
         }
         self.capture_recorder_output(rendered);
-        // Headless capture (screenshot/frame-dump) builds the framebuffer
-        // for the saved PNG but never needs to present to the window;
-        // skipping request_redraw avoids the vsync gate so the run advances
-        // as fast as the host allows. Emulated state is identical either way.
-        let headless_capture = self.auto_shot.is_some() || self.frame_dump.is_some();
+        // Skipping request_redraw for headless capture avoids the vsync gate so
+        // the run advances as fast as the host allows; emulated state is
+        // identical either way. (`headless_capture` was resolved above, before
+        // the step, to decide the warp burst.)
         if rendered && !headless_capture {
             self.request_redraw();
         }
@@ -4544,6 +4595,7 @@ impl App {
                     ui::MenuItem::Debugger => self.open_debugger(),
                     ui::MenuItem::JoystickInput => self.cycle_joystick_input_mode(),
                     ui::MenuItem::Warp => self.toggle_warp(),
+                    ui::MenuItem::WarpLimit => self.cycle_warp_speed(),
                     ui::MenuItem::Record => self.toggle_recording(),
                     ui::MenuItem::RecordInput => self.toggle_input_recording(),
                     ui::MenuItem::SaveState => self.save_state_interactive(),
@@ -5018,12 +5070,47 @@ impl App {
         let warp = self.emu.paced();
         self.emu.set_paced(!warp);
         if warp {
-            info!("warp speed on (emulation unpaced)");
-            self.show_osd("Warp speed on");
+            let limit = self.warp_speed.label();
+            info!("warp speed on (emulation unpaced, limit {limit})");
+            self.show_osd(format!("Warp speed on ({limit})"));
         } else {
             info!("warp speed off (real-time pacing)");
             self.show_osd("Warp speed off");
         }
+    }
+
+    /// How many emulated frames to retire before presenting the next frame, and
+    /// an optional wall-clock budget that bounds that burst. Warp's output frame
+    /// skip applies only while warp is engaged and not doing headless capture;
+    /// real-time pacing and headless capture both run one frame per presented
+    /// frame. The `Max` level returns a budget so the burst presents at vsync
+    /// rather than spinning to its frame cap.
+    fn warp_burst_plan(&self, headless_capture: bool) -> (usize, Option<std::time::Duration>) {
+        if self.emu.paced() || headless_capture {
+            return (1, None);
+        }
+        (
+            self.warp_speed.frame_cap(),
+            self.warp_speed
+                .time_budget_ms()
+                .map(std::time::Duration::from_millis),
+        )
+    }
+
+    /// Cycle the warp/turbo output frame-skip level (2x -> 4x -> 8x -> 16x ->
+    /// Max). Takes effect immediately when warp is engaged; otherwise it just
+    /// arms the level the next warp toggle will use.
+    fn cycle_warp_speed(&mut self) {
+        self.warp_speed = self.warp_speed.next();
+        let limit = self.warp_speed.label();
+        info!("warp limit: {limit}");
+        let active = !self.emu.paced();
+        if active {
+            self.show_osd(format!("Warp limit: {limit}"));
+        } else {
+            self.show_osd(format!("Warp limit: {limit} (warp off)"));
+        }
+        self.request_redraw();
     }
 
     /// Interactive shortcut / menu state save: write the whole
@@ -6885,6 +6972,7 @@ mod tests {
     };
     use crate::audio::{AudioSink, NullSink};
     use crate::bus::FrontPanelStatus;
+    use crate::config::WarpSpeed;
     use crate::video::{FB_HEIGHT, FB_PIXELS, FB_WIDTH};
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -7057,6 +7145,43 @@ mod tests {
         assert!(should_render_emulated_frame(None, 0));
         assert!(!should_render_emulated_frame(Some(12), 12));
         assert!(should_render_emulated_frame(Some(12), 13));
+    }
+
+    #[test]
+    fn warp_burst_decouples_emulation_from_the_vsync_present() {
+        let mut app = test_app();
+        // test_app builds an unpaced (warp) emulator. Default warp level is
+        // Max: retire many frames per presented frame, bounded by a wall-clock
+        // budget so the loop still presents at vsync.
+        app.warp_speed = WarpSpeed::Max;
+        let (cap, budget) = app.warp_burst_plan(false);
+        assert!(cap > 1, "warp Max must skip output frames, got cap {cap}");
+        assert!(budget.is_some(), "Max bounds the burst by wall-clock time");
+
+        // A fixed level retires exactly its multiplier in frames, with no time
+        // bound -- predictable speed = level x refresh rate.
+        app.warp_speed = WarpSpeed::X4;
+        assert_eq!(app.warp_burst_plan(false), (4, None));
+
+        // Headless capture renders every frame, so the burst must not engage
+        // even though the core is unpaced.
+        assert_eq!(app.warp_burst_plan(true), (1, None));
+
+        // Real-time pacing presents one frame per loop regardless of level.
+        app.emu.set_paced(true);
+        assert_eq!(app.warp_burst_plan(false), (1, None));
+    }
+
+    #[test]
+    fn cycle_warp_speed_walks_the_levels() {
+        let mut app = test_app();
+        app.warp_speed = WarpSpeed::X8;
+        app.cycle_warp_speed();
+        assert_eq!(app.warp_speed, WarpSpeed::X16);
+        app.cycle_warp_speed();
+        assert_eq!(app.warp_speed, WarpSpeed::Max);
+        app.cycle_warp_speed();
+        assert_eq!(app.warp_speed, WarpSpeed::X2);
     }
 
     #[test]
@@ -8044,6 +8169,7 @@ mod tests {
             [true; 4],
             crate::config::Overscan::Full,
             0.0,
+            crate::config::WarpSpeed::Max,
             vec!["Machine: test".to_string()],
         )
     }


### PR DESCRIPTION
## Problem

Warp/turbo mode was locked to the host monitor refresh rate. The window presents with vsync (`pixels` defaults to `PresentMode::Fifo`), and the event loop emulated exactly one frame per presented frame, so warp could never exceed `refresh / amiga_fps` -- about **1.2x** for 50 Hz PAL on a 60 Hz display. The existing inline comment at `window.rs` already noted the vsync gate.

## Fix: output frame skip

In warp, the loop now retires several emulated frames per *presented* frame; only the last frame of the burst is rendered and presented, so the effective speed is roughly `level x refresh`, host CPU permitting. Real-time pacing and headless capture (screenshot / frame dump) are unaffected -- both stay at one frame per presented frame, and every captured frame is still rendered.

Levels are **2x / 4x / 8x / 16x / Max**:

- Fixed levels retire exactly their multiplier in frames (predictable speed).
- `Max` runs flat out, bounded by a ~12 ms wall-clock budget per present (capped at 1024 frames as a safety) so the loop still polls input and presents at vsync instead of spinning.

The live audio ring buffer is fixed-capacity and drops on overrun, so `Max` cannot grow memory or hang -- it just drops fast-forwarded audio, as expected.

## Controls

- New **Warp Limit** menu item that cycles the level and shows it (e.g. `Warp Limit [8x]`).
- `Cmd+Shift+W` / `Alt+Shift+W` cycles the limit (OSD flash).
- `Cmd+W` / `Alt+W` now toggles Warp Speed (previously menu-only).
- Default via `[emulation] warp_speed` (`"2x".."16x"` or `"max"`, default `"max"`).

## Tests / checks

- `cargo build --release`, `cargo clippy --all-targets`, `cargo fmt --check` -- all clean.
- Full unit suite: **1091 passed**, 0 failed, including 4 new tests (`WarpSpeed` parse/cycle, `warp_burst_plan`, `cycle_warp_speed`).
- Re-rendered the menu and Shortcuts UI previews and eyeballed layout.
- End-to-end: `warp_speed = "8x"` parses and runs headless; `"32x"` fails with `expected "2x", "4x", "8x", "16x", or "max"`.

Docs updated: `docs/guide/ui.md` (shortcuts table + menu), `docs/guide/configuration.md` (`[emulation]`), and `copperline.example.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)