### PR TITLE
Debugger: step-over/step-out, memory & register poke, conditional breakpoints

### DIFF
--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -104,6 +104,8 @@ avoid externally mutating hard-drive/CD images during a debug session.
 | `status` | CPU PC/SR, frame, beam, instruction position, reverse status |
 | `beam` | beam/frame/colour-clock position |
 | `custom` | compact custom-chip state dump |
+| `stepover` | step over a BSR/JSR/TRAP call (single step otherwise) |
+| `finish` | run until the current subroutine returns to its caller |
 | `reg NAME\|OFFSET` | side-effect-free custom-register latch read |
 | `write-reg NAME\|OFFSET VALUE` | real custom-register word write |
 | `watch-reg NAME\|OFFSET` | stop on CPU or Copper writes to the custom register |

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -67,26 +67,63 @@ On the Break tab, type an address into the `$` box and toggle any of:
 **Clear all** removes everything. Breakpoints and watchpoints stay armed
 when the window is closed: a hit pauses the machine, reopens the debugger
 on the Break tab with the reason highlighted, and shows it as an on-screen
-message.
+message. A breakpoint also shows as a `*` next to its line in the CPU
+tab's disassembly.
+
+### Conditional and counted breakpoints
+
+The Break box accepts more than a bare address:
+
+```
+ADDR [LHS OP RHS] [IGN N]
+```
+
+- **Condition** `LHS OP RHS` -- the breakpoint only stops when it holds.
+  Operands are registers (`D0`-`D7`, `A0`-`A7`, `PC`, `SR`), a memory word
+  `M<hex>` (e.g. `MC00002`), or a bare hex immediate. A register name wins
+  over hex, so write an immediate that looks like a register with a leading
+  zero (`0D0`). Operators are `EQ NE LT GT LE GE` and `AND` (a bit test:
+  true when `LHS & RHS` is non-zero).
+- **Ignore count** `IGN N` -- skip the first `N` (hex) qualifying hits, then
+  stop on the next one. The Break list shows the running `ign hits/N`.
+
+Examples: `C033C2 D0 EQ 5` stops at `$C033C2` only when `D0` is 5;
+`40 MC00002 AND 4000 IGN A` stops at `$40` once the word at `$C00002` has
+bit `$4000` set, after ten earlier qualifying passes.
 
 ## Transport controls
 
 | Control | Key | Effect |
 |---|---|---|
 | Run / Pause | `R` | Resume or pause the machine |
-| Step | `S` | Execute exactly one instruction |
+| Step | `S` | Execute exactly one instruction (into calls) |
+| Step Over | `O` | Run a BSR/JSR/TRAP callee to completion, stopping after the call |
+| Step Out | `U` | Run until the current subroutine returns to its caller |
 | Frame | `F` | Run to the next video frame and re-render the display |
 | Run to `$` | -- | Run until the PC reaches the address in the box |
 | &lt; Frame | -- | Step one video frame *backward* |
 | &lt; Step | -- | Step one instruction *backward* (see [](reverse)) |
 | &lt; Run | -- | Run *backward* to the previous breakpoint hit |
 
-The `R`/`S`/`F` keys work whenever the hex box is unfocused (while it is
-focused they are hex input). **Run to $** is bounded by a 2M-instruction
-budget so a never-reached address cannot wedge the UI; if the budget runs
-out, the debugger says so and stays paused. If the CPU is sitting in a
-`STOP`, stepping fast-forwards device time to the interrupt that wakes it,
-exactly as the live core would.
+The `R`/`S`/`O`/`U`/`F` keys work whenever the box is unfocused (while it is
+focused they are text input). **Run to $**, **Step Over**, and **Step Out**
+are bounded by an instruction budget so a never-returning call or
+never-reached address cannot wedge the UI; if the budget runs out, the
+debugger stays paused. Step Out detects the return by the stack pointer
+rising past its value at entry, so nested calls and interrupt handlers do
+not end it early. If the CPU is sitting in a `STOP`, stepping fast-forwards
+device time to the interrupt that wakes it, exactly as the live core would.
+
+## Editing memory and registers
+
+While paused you can patch state live from the `$` box and the **Poke** /
+**Set Reg** button (the second transport row, on the Memory and CPU tabs):
+
+- On the **Memory** tab, type `ADDR VALUE` (two hex words) and click
+  **Poke** to write a 16-bit word. ROM and device windows are left
+  untouched, exactly like the GDB memory-write path.
+- On the **CPU** tab, type `REG VALUE` (e.g. `D0 1234`, `PC F80000`; `SP`
+  aliases `A7`) and click **Set Reg**.
 
 **Frame** is the tool for raster work: combined with the Chipset and Copper
 tabs it lets you single-step a Copper effect one frame at a time and watch

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1078,9 +1078,26 @@ impl M68kMachine {
         &self.ui_breaks
     }
 
-    /// Toggle a PC breakpoint. Returns true when the breakpoint is now set.
-    pub fn ui_toggle_breakpoint(&mut self, addr: u32) -> bool {
-        self.ui_breaks.toggle_breakpoint(addr)
+    /// Toggle a PC breakpoint carrying an optional condition and ignore count.
+    /// Returns true when the breakpoint is now set.
+    pub fn ui_set_breakpoint(
+        &mut self,
+        addr: u32,
+        cond: Option<crate::debugger::BreakCond>,
+        ignore: u32,
+    ) -> bool {
+        self.ui_breaks.toggle_breakpoint_full(addr, cond, ignore)
+    }
+
+    /// Evaluate the breakpoint gate at `pc` against live register/memory state.
+    /// Disjoint field borrows let the breakpoint set update its hit counter
+    /// while reading the CPU core and bus.
+    fn ui_breakpoint_stops(&mut self, pc: u32) -> bool {
+        let ctx = MachineBreakContext {
+            cpu: &self.cpu,
+            bus: &self.bus.bus,
+        };
+        self.ui_breaks.breakpoint_stops(pc, &ctx)
     }
 
     /// Toggle a word watchpoint at `addr` (word-aligned), baselining it on
@@ -1149,7 +1166,7 @@ impl M68kMachine {
     fn ui_check_breaks_after_step(&mut self) {
         use crate::debugger::DebugStop;
         let pc = self.cpu.pc & crate::debugger::UI_ADDR_MASK;
-        if self.ui_breaks.is_breakpoint(pc) {
+        if self.ui_breakpoint_stops(pc) {
             self.ui_stop = Some(DebugStop::Breakpoint { pc });
             return;
         }
@@ -1216,7 +1233,7 @@ impl M68kMachine {
                 // stop before the handler's first instruction executes.
                 if self.ui_breaks.armed() {
                     let pc = self.cpu.pc & crate::debugger::UI_ADDR_MASK;
-                    if self.ui_breaks.is_breakpoint(pc) {
+                    if self.ui_breakpoint_stops(pc) {
                         self.ui_stop = Some(crate::debugger::DebugStop::Breakpoint { pc });
                         break;
                     }
@@ -2066,6 +2083,32 @@ impl AddressBus for CpuBus {
 
     fn reset_devices(&mut self) {
         self.bus.reset_custom_chips_from_cpu_reset();
+    }
+}
+
+/// Adapts the live CPU core and bus to the [`BreakContext`] a breakpoint
+/// condition reads. Borrows the `cpu` and `bus` fields disjointly from the
+/// breakpoint set so the gate can update hit counters while evaluating.
+struct MachineBreakContext<'a> {
+    cpu: &'a CpuCore,
+    bus: &'a crate::bus::Bus,
+}
+
+impl crate::debugger::BreakContext for MachineBreakContext<'_> {
+    fn data(&self, n: usize) -> u32 {
+        self.cpu.d(n)
+    }
+    fn addr_reg(&self, n: usize) -> u32 {
+        self.cpu.a(n)
+    }
+    fn pc(&self) -> u32 {
+        self.cpu.pc
+    }
+    fn sr(&self) -> u32 {
+        u32::from(self.cpu.get_sr())
+    }
+    fn mem_word(&self, addr: u32) -> u16 {
+        self.bus.peek_word_any(addr)
     }
 }
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -273,12 +273,132 @@ pub fn custom_reg_name(off: u16) -> String {
     fixed.to_string()
 }
 
+/// One operand in a breakpoint condition: a register, an immediate, or a
+/// 16-bit memory word. Memory and immediates are written in hex; the memory
+/// form is `M<hex>` (e.g. `MC00002`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CondOperand {
+    Data(usize),
+    Addr(usize),
+    Pc,
+    Sr,
+    Imm(u32),
+    Mem(u32),
+}
+
+/// Comparison used in a breakpoint condition. `And` is a bit test: it is true
+/// when `lhs & rhs` is non-zero, handy for checking flag/register bits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CondOp {
+    Eq,
+    Ne,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+    And,
+}
+
+/// A breakpoint condition: `lhs op rhs`, evaluated against live CPU/memory
+/// state through [`BreakContext`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BreakCond {
+    pub lhs: CondOperand,
+    pub op: CondOp,
+    pub rhs: CondOperand,
+}
+
+/// Live CPU/memory state a [`BreakCond`] reads. Implemented over the running
+/// machine at the breakpoint gate, kept as a trait so the condition logic and
+/// its tests stay independent of the CPU core type.
+pub trait BreakContext {
+    fn data(&self, n: usize) -> u32;
+    fn addr_reg(&self, n: usize) -> u32;
+    fn pc(&self) -> u32;
+    fn sr(&self) -> u32;
+    fn mem_word(&self, addr: u32) -> u16;
+}
+
+impl CondOperand {
+    fn value(self, ctx: &dyn BreakContext) -> u32 {
+        match self {
+            CondOperand::Data(n) => ctx.data(n),
+            CondOperand::Addr(n) => ctx.addr_reg(n),
+            CondOperand::Pc => ctx.pc(),
+            CondOperand::Sr => ctx.sr(),
+            CondOperand::Imm(v) => v,
+            CondOperand::Mem(a) => u32::from(ctx.mem_word(a)),
+        }
+    }
+
+    fn describe(self) -> String {
+        match self {
+            CondOperand::Data(n) => format!("D{n}"),
+            CondOperand::Addr(n) => format!("A{n}"),
+            CondOperand::Pc => "PC".to_string(),
+            CondOperand::Sr => "SR".to_string(),
+            CondOperand::Imm(v) => format!("${v:X}"),
+            CondOperand::Mem(a) => format!("M{a:X}"),
+        }
+    }
+}
+
+impl CondOp {
+    pub fn mnemonic(self) -> &'static str {
+        match self {
+            CondOp::Eq => "EQ",
+            CondOp::Ne => "NE",
+            CondOp::Lt => "LT",
+            CondOp::Gt => "GT",
+            CondOp::Le => "LE",
+            CondOp::Ge => "GE",
+            CondOp::And => "AND",
+        }
+    }
+}
+
+impl BreakCond {
+    pub fn eval(&self, ctx: &dyn BreakContext) -> bool {
+        let l = self.lhs.value(ctx);
+        let r = self.rhs.value(ctx);
+        match self.op {
+            CondOp::Eq => l == r,
+            CondOp::Ne => l != r,
+            CondOp::Lt => l < r,
+            CondOp::Gt => l > r,
+            CondOp::Le => l <= r,
+            CondOp::Ge => l >= r,
+            CondOp::And => (l & r) != 0,
+        }
+    }
+
+    pub fn describe(&self) -> String {
+        format!(
+            "{} {} {}",
+            self.lhs.describe(),
+            self.op.mnemonic(),
+            self.rhs.describe()
+        )
+    }
+}
+
+/// One interactive PC breakpoint: an address, an optional condition that must
+/// hold for it to fire, and an ignore count (skip this many qualifying hits
+/// before stopping).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Breakpoint {
+    pub addr: u32,
+    pub cond: Option<BreakCond>,
+    pub ignore: u32,
+    pub hits: u32,
+}
+
 /// The debugger window's breakpoint/watchpoint set. Owned by the CPU
 /// machine so it stays armed while the window is closed; `armed` is the
 /// single per-instruction gate the hot loop checks.
 #[derive(Default)]
 pub struct InteractiveBreaks {
-    pub breakpoints: Vec<u32>,
+    pub breakpoints: Vec<Breakpoint>,
     pub watches: Vec<UiWatch>,
     /// Watched custom-register word offsets into $DFF000 ($000-$1FE).
     /// Hits are recorded by the bus's custom-register write path (which
@@ -299,26 +419,61 @@ impl InteractiveBreaks {
             && self.reg_watches.is_empty());
     }
 
+    /// Whether any breakpoint is set at `pc`, ignoring its condition. Used for
+    /// display (marking the address) and the reverse-debug scan.
     pub fn is_breakpoint(&self, pc: u32) -> bool {
-        self.breakpoints.contains(&pc)
+        let pc = pc & UI_ADDR_MASK;
+        self.breakpoints.iter().any(|bp| bp.addr == pc)
     }
 
-    /// Add the breakpoint, or remove it when already set. Returns true
-    /// when the breakpoint is now set.
-    pub fn toggle_breakpoint(&mut self, addr: u32) -> bool {
+    /// Add a breakpoint with an optional condition and ignore count, or remove
+    /// the breakpoint at `addr` when one already exists. Returns true when the
+    /// breakpoint is now set.
+    pub fn toggle_breakpoint_full(
+        &mut self,
+        addr: u32,
+        cond: Option<BreakCond>,
+        ignore: u32,
+    ) -> bool {
         let addr = addr & UI_ADDR_MASK;
-        let added = match self.breakpoints.iter().position(|&pc| pc == addr) {
+        let added = match self.breakpoints.iter().position(|bp| bp.addr == addr) {
             Some(pos) => {
                 self.breakpoints.remove(pos);
                 false
             }
             None => {
-                self.breakpoints.push(addr);
+                self.breakpoints.push(Breakpoint {
+                    addr,
+                    cond,
+                    ignore,
+                    hits: 0,
+                });
                 true
             }
         };
         self.rearm();
         added
+    }
+
+    /// Decide whether reaching `pc` should stop. A breakpoint stops when its
+    /// address matches, its condition (if any) holds against `ctx`, and its
+    /// ignore count has been exhausted -- each qualifying hit before that is
+    /// counted and skipped.
+    pub fn breakpoint_stops(&mut self, pc: u32, ctx: &dyn BreakContext) -> bool {
+        let pc = pc & UI_ADDR_MASK;
+        let Some(bp) = self.breakpoints.iter_mut().find(|bp| bp.addr == pc) else {
+            return false;
+        };
+        if let Some(cond) = &bp.cond {
+            if !cond.eval(ctx) {
+                return false;
+            }
+        }
+        if bp.hits < bp.ignore {
+            bp.hits = bp.hits.saturating_add(1);
+            return false;
+        }
+        true
     }
 
     /// Add a word watch at `addr` (recording `current` as its baseline),
@@ -640,14 +795,99 @@ mod tests {
         assert!(!breaks.armed());
 
         // Adding masks the address to the 68000 bus width.
-        assert!(breaks.toggle_breakpoint(0xFFC0_33C2));
+        assert!(breaks.toggle_breakpoint_full(0xFFC0_33C2, None, 0));
         assert!(breaks.armed());
         assert!(breaks.is_breakpoint(0x00C0_33C2));
 
         // Toggling the same (masked) address removes it and disarms.
-        assert!(!breaks.toggle_breakpoint(0x00C0_33C2));
+        assert!(!breaks.toggle_breakpoint_full(0x00C0_33C2, None, 0));
         assert!(!breaks.armed());
         assert!(!breaks.is_breakpoint(0x00C0_33C2));
+    }
+
+    /// Fixed register/memory snapshot for exercising condition evaluation.
+    #[derive(Default)]
+    struct FakeCtx {
+        data: [u32; 8],
+        addr: [u32; 8],
+        pc: u32,
+        sr: u32,
+        mem: std::collections::HashMap<u32, u16>,
+    }
+
+    impl BreakContext for FakeCtx {
+        fn data(&self, n: usize) -> u32 {
+            self.data[n]
+        }
+        fn addr_reg(&self, n: usize) -> u32 {
+            self.addr[n]
+        }
+        fn pc(&self) -> u32 {
+            self.pc
+        }
+        fn sr(&self) -> u32 {
+            self.sr
+        }
+        fn mem_word(&self, addr: u32) -> u16 {
+            self.mem.get(&addr).copied().unwrap_or(0)
+        }
+    }
+
+    #[test]
+    fn conditional_breakpoint_stops_only_when_condition_holds() {
+        let mut breaks = InteractiveBreaks::default();
+        breaks.toggle_breakpoint_full(
+            0x1000,
+            Some(BreakCond {
+                lhs: CondOperand::Data(0),
+                op: CondOp::Eq,
+                rhs: CondOperand::Imm(5),
+            }),
+            0,
+        );
+        let mut ctx = FakeCtx::default();
+
+        // Address matches but the condition is false: no stop.
+        ctx.data[0] = 4;
+        assert!(!breaks.breakpoint_stops(0x1000, &ctx));
+        // A different address never stops regardless of the condition.
+        ctx.data[0] = 5;
+        assert!(!breaks.breakpoint_stops(0x2000, &ctx));
+        // Address matches and the condition holds: stop.
+        assert!(breaks.breakpoint_stops(0x1000, &ctx));
+    }
+
+    #[test]
+    fn ignore_count_skips_the_first_qualifying_hits() {
+        let mut breaks = InteractiveBreaks::default();
+        // Stop on the 4th qualifying hit (ignore the first 3).
+        breaks.toggle_breakpoint_full(0x1000, None, 3);
+        let ctx = FakeCtx::default();
+        assert!(!breaks.breakpoint_stops(0x1000, &ctx));
+        assert!(!breaks.breakpoint_stops(0x1000, &ctx));
+        assert!(!breaks.breakpoint_stops(0x1000, &ctx));
+        assert!(breaks.breakpoint_stops(0x1000, &ctx));
+        // And it keeps stopping afterwards.
+        assert!(breaks.breakpoint_stops(0x1000, &ctx));
+    }
+
+    #[test]
+    fn bit_test_condition_uses_memory_word() {
+        let mut breaks = InteractiveBreaks::default();
+        breaks.toggle_breakpoint_full(
+            0x40,
+            Some(BreakCond {
+                lhs: CondOperand::Mem(0xDFF002),
+                op: CondOp::And,
+                rhs: CondOperand::Imm(0x4000),
+            }),
+            0,
+        );
+        let mut ctx = FakeCtx::default();
+        ctx.mem.insert(0xDFF002, 0x0000);
+        assert!(!breaks.breakpoint_stops(0x40, &ctx));
+        ctx.mem.insert(0xDFF002, 0x4000);
+        assert!(breaks.breakpoint_stops(0x40, &ctx));
     }
 
     #[test]
@@ -665,7 +905,7 @@ mod tests {
         assert!(!breaks.toggle_reg_watch(0x097));
         assert!(breaks.reg_watches.is_empty());
         assert!(breaks.armed()); // memory watch still set
-        breaks.toggle_breakpoint(0x100);
+        breaks.toggle_breakpoint_full(0x100, None, 0);
         breaks.clear();
         assert!(!breaks.armed());
         assert!(breaks.breakpoints.is_empty());

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -804,7 +804,15 @@ impl Emulator {
     /// may exist before the oldest snapshot. (Watch-based reverse-continue is
     /// not yet modelled; breakpoints only.)
     pub fn tt_reverse_continue(&mut self) -> Result<crate::timetravel::ReverseOutcome<u64>> {
-        let breakpoints = self.machine.ui_breaks().breakpoints.clone();
+        // Reverse-continue honours breakpoint addresses only (conditions are
+        // not replayed), so collect the bare addresses.
+        let breakpoints: Vec<u32> = self
+            .machine
+            .ui_breaks()
+            .breakpoints
+            .iter()
+            .map(|bp| bp.addr)
+            .collect();
         self.tt_reverse_continue_to(&breakpoints)
     }
 
@@ -2029,6 +2037,34 @@ mod tests {
         emu.debug_step_over(10_000).unwrap(); // MOVEQ is not a call: single step
         assert_eq!(emu.machine.pc(), 0x00F8_0014);
         assert_eq!(emu.machine.d(0), 1);
+    }
+
+    #[test]
+    fn conditional_breakpoint_fires_during_execution() {
+        use crate::debugger::{BreakCond, CondOp, CondOperand};
+        let mut emu = emulator_with_call_program();
+        // Break at the subroutine entry only when D1 == 0 (true on first
+        // entry; the callee sets D1=2 afterwards).
+        emu.machine.ui_set_breakpoint(
+            0x00F8_0020,
+            Some(BreakCond {
+                lhs: CondOperand::Data(1),
+                op: CondOp::Eq,
+                rhs: CondOperand::Imm(0),
+            }),
+            0,
+        );
+        let mut stopped = false;
+        for _ in 0..32 {
+            emu.debug_step_instructions(1).unwrap();
+            if emu.machine.ui_debug_stop_pending() {
+                stopped = true;
+                break;
+            }
+        }
+        assert!(stopped, "conditional breakpoint did not fire");
+        assert_eq!(emu.machine.pc(), 0x00F8_0020);
+        assert!(emu.machine.take_ui_debug_stop().is_some());
     }
 
     #[test]

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -345,6 +345,20 @@ fn real_target_instructions_per_second(cpu_cycles_per_instruction: f64) -> f64 {
     PAL_68000_CLOCK_HZ / cpu_cycles_per_instruction
 }
 
+/// True when the opword is a call that, once its callee returns, resumes at the
+/// following instruction: BSR (`0x61xx`), JSR (`0x4E80..=0x4EBF`), or TRAP #n
+/// (`0x4E40..=0x4E4F`). Step-over runs to the instruction after one of these.
+fn instruction_returns_inline(op: u16) -> bool {
+    (op & 0xFF00) == 0x6100 || (op & 0xFFC0) == 0x4E80 || (op & 0xFFF0) == 0x4E40
+}
+
+/// True when the opword returns from a subroutine or exception: RTE (`0x4E73`),
+/// RTD (`0x4E74`), RTS (`0x4E75`), or RTR (`0x4E77`). Step-out watches for one
+/// of these lifting the stack pointer past the entry frame.
+fn instruction_is_return(op: u16) -> bool {
+    matches!(op, 0x4E73 | 0x4E74 | 0x4E75 | 0x4E77)
+}
+
 #[derive(Default)]
 pub struct EmuStats {
     pub frames: u64,
@@ -1110,32 +1124,39 @@ impl Emulator {
         Ok(())
     }
 
+    /// Execute one instruction with the same STOP/idle fast-forward handling as
+    /// the real-time loop: a CPU halted in STOP makes no progress under a
+    /// single-instruction slice, so advance devices to the next event and let
+    /// the wake-up interrupt fire. Shared by the run-to / step-over / step-out
+    /// helpers so they all step a STOPped CPU forward instead of spinning.
+    fn debug_step_one_with_idle(&mut self) -> Result<()> {
+        let run = self.execute_cpu_slice(1)?;
+        self.machine.refresh_irq_line();
+        if run.cpu_stopped {
+            let chunk = self.idle_fast_forward_chunk(INSTRUCTIONS_PER_REALTIME_SLICE);
+            let run = self.execute_cpu_slice(chunk)?;
+            let accounting = real_slice_accounting(
+                &run,
+                chunk,
+                self.cpu_cycles_per_instruction,
+                self.real_pacing_budget_mode,
+            );
+            if run.cpu_stopped {
+                let idle_cck = accounting.slice_cck.saturating_sub(run.bus_advanced_cck);
+                self.bus_mut().advance_devices(idle_cck);
+            }
+            self.machine.refresh_irq_line();
+        }
+        Ok(())
+    }
+
     /// Run until the CPU reaches `target_pc` (masked to the bus width), up
     /// to `max_instructions`. Returns true when the target was hit.
     pub fn debug_run_to_pc(&mut self, target_pc: u32, max_instructions: usize) -> Result<bool> {
         const PC_MASK: u32 = 0x00FF_FFFF;
         let target = target_pc & PC_MASK;
         for _ in 0..max_instructions {
-            let run = self.execute_cpu_slice(1)?;
-            self.machine.refresh_irq_line();
-            if run.cpu_stopped {
-                // A stopped CPU makes no progress under single-instruction
-                // slices; advance devices to the next event so the wake-up
-                // interrupt can fire, mirroring step_real's fast-forward.
-                let chunk = self.idle_fast_forward_chunk(INSTRUCTIONS_PER_REALTIME_SLICE);
-                let run = self.execute_cpu_slice(chunk)?;
-                let accounting = real_slice_accounting(
-                    &run,
-                    chunk,
-                    self.cpu_cycles_per_instruction,
-                    self.real_pacing_budget_mode,
-                );
-                if run.cpu_stopped {
-                    let idle_cck = accounting.slice_cck.saturating_sub(run.bus_advanced_cck);
-                    self.bus_mut().advance_devices(idle_cck);
-                }
-                self.machine.refresh_irq_line();
-            }
+            self.debug_step_one_with_idle()?;
             if self.machine.pc() & PC_MASK == target {
                 return Ok(true);
             }
@@ -1146,6 +1167,47 @@ impl Emulator {
             }
         }
         Ok(false)
+    }
+
+    /// Step over the instruction at PC. When it is a call that returns to the
+    /// following instruction (BSR/JSR/TRAP), run until that return address (or
+    /// an earlier breakpoint/watch hit, or the `max_instructions` budget if the
+    /// call never returns); otherwise this is a plain single step.
+    pub fn debug_step_over(&mut self, max_instructions: usize) -> Result<()> {
+        let pc = self.machine.pc();
+        let op = self.machine.bus().peek_word_any(pc);
+        if !instruction_returns_inline(op) {
+            return self.debug_step_instructions(1);
+        }
+        let cpu_type = self.machine.cpu_type();
+        let len = {
+            let bus = self.machine.bus();
+            crate::disasm::disassemble(|a| bus.peek_word_any(a), pc, cpu_type).1
+        };
+        self.debug_run_to_pc(pc.wrapping_add(len), max_instructions)?;
+        Ok(())
+    }
+
+    /// Run until the current subroutine returns to its caller, up to
+    /// `max_instructions`. The return is detected by the stack pointer rising
+    /// above its value at entry right after a return instruction (RTS/RTR/RTE/
+    /// RTD): nested calls and interrupt handlers push below the entry frame and
+    /// pop back to it, so only this frame's own return lifts the SP past entry.
+    /// An earlier breakpoint/watch hit also ends the run.
+    pub fn debug_step_out(&mut self, max_instructions: usize) -> Result<()> {
+        let start_sp = self.machine.a(7);
+        for _ in 0..max_instructions {
+            let op = self.machine.bus().peek_word_any(self.machine.pc());
+            let is_return = instruction_is_return(op);
+            self.debug_step_one_with_idle()?;
+            if is_return && self.machine.a(7) > start_sp {
+                return Ok(());
+            }
+            if self.machine.ui_debug_stop_pending() {
+                return Ok(());
+            }
+        }
+        Ok(())
     }
 
     pub fn step_frame(&mut self) -> Result<()> {
@@ -1891,6 +1953,93 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    /// Build an emulator whose reset vector runs a tiny program in ROM:
+    ///
+    /// ```text
+    /// F80010  BSR.S  $F80020   ; call the subroutine
+    /// F80012  MOVEQ  #1,D0     ; return lands here (step-over stops before it)
+    /// F80014  BRA.S  *         ; halt
+    /// F80020  MOVEQ  #2,D1     ; subroutine body
+    /// F80022  RTS
+    /// ```
+    ///
+    /// SSP resets to $4000 (chip RAM), so BSR/RTS push and pop the return
+    /// address through real memory. The reset vectors live in chip RAM (overlay
+    /// is off, so the CPU reads them from address 0 at reset).
+    fn emulator_with_call_program() -> super::Emulator {
+        let mut rom = vec![0u8; crate::memory::ROM_SIZE];
+        let put = |mem: &mut [u8], off: usize, word: u16| {
+            mem[off..off + 2].copy_from_slice(&word.to_be_bytes());
+        };
+        put(&mut rom, 0x10, 0x610E); // BSR.S $F80020
+        put(&mut rom, 0x12, 0x7001); // MOVEQ #1,D0
+        put(&mut rom, 0x14, 0x60FE); // BRA.S *
+        put(&mut rom, 0x20, 0x7202); // MOVEQ #2,D1
+        put(&mut rom, 0x22, 0x4E75); // RTS
+
+        let mut chip_ram = vec![0u8; 512 * 1024];
+        chip_ram[0..4].copy_from_slice(&0x0000_4000u32.to_be_bytes()); // reset SSP
+        chip_ram[4..8].copy_from_slice(&0x00F8_0010u32.to_be_bytes()); // reset PC
+
+        let bus = crate::bus::Bus::new(
+            crate::memory::Memory {
+                chip_ram,
+                slow_ram: Vec::new(),
+                rom,
+                overlay: false,
+                zorro: crate::zorro::ZorroChain::default(),
+                extended_rom: Vec::new(),
+                extended_rom_base: 0,
+            },
+            crate::chipset::paula::Paula::new(
+                Box::new(crate::serial::NullSerialSink),
+                Box::new(crate::audio::NullSink),
+            ),
+            crate::floppy::FloppyController::default(),
+        );
+        super::Emulator::new(
+            bus,
+            crate::config::CpuModel::M68000,
+            false,
+            crate::config::PacingBudget::Cycles,
+            2,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn step_over_runs_the_callee_and_stops_after_the_call() {
+        let mut emu = emulator_with_call_program();
+        assert_eq!(emu.machine.pc(), 0x00F8_0010);
+        emu.debug_step_over(10_000).unwrap();
+        // The subroutine ran to completion (D1=2) and we stopped at the
+        // instruction after the BSR, before it executed (D0 still 0).
+        assert_eq!(emu.machine.pc(), 0x00F8_0012);
+        assert_eq!(emu.machine.d(1), 2);
+        assert_eq!(emu.machine.d(0), 0);
+    }
+
+    #[test]
+    fn step_over_a_non_call_is_a_plain_single_step() {
+        let mut emu = emulator_with_call_program();
+        emu.debug_step_over(10_000).unwrap(); // over the BSR -> at $F80012
+        emu.debug_step_over(10_000).unwrap(); // MOVEQ is not a call: single step
+        assert_eq!(emu.machine.pc(), 0x00F8_0014);
+        assert_eq!(emu.machine.d(0), 1);
+    }
+
+    #[test]
+    fn step_out_returns_to_the_caller() {
+        let mut emu = emulator_with_call_program();
+        emu.debug_step_instructions(1).unwrap(); // execute the BSR -> inside callee
+        assert_eq!(emu.machine.pc(), 0x00F8_0020);
+        emu.debug_step_out(10_000).unwrap();
+        // Returned to the instruction after the call; the callee body ran.
+        assert_eq!(emu.machine.pc(), 0x00F8_0012);
+        assert_eq!(emu.machine.d(1), 2);
     }
 
     #[test]

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -14,6 +14,10 @@ use anyhow::{anyhow, Context, Result};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 
+/// Instruction budget for the `monitor stepover` / `monitor finish` helpers, so
+/// a call or subroutine that never returns cannot wedge the debug server.
+const MONITOR_STEP_BUDGET: usize = 5_000_000;
+
 const TARGET_XML: &str = r#"<?xml version="1.0"?>
 <target>
   <architecture>m68k</architecture>
@@ -523,6 +527,21 @@ impl Session {
                 self.emu.retired_instructions()
             )),
             "custom" => Ok(self.monitor_custom()),
+            "stepover" => {
+                // Step over a BSR/JSR/TRAP call (single step otherwise),
+                // bounded so a call that never returns cannot hang the server.
+                self.cpu_idle = false;
+                self.emu.debug_step_over(MONITOR_STEP_BUDGET)?;
+                self.refresh_watchpoints();
+                Ok(format!("pc=${:08X}\n", self.emu.machine.pc()))
+            }
+            "finish" => {
+                // Run until the current subroutine returns to its caller.
+                self.cpu_idle = false;
+                self.emu.debug_step_out(MONITOR_STEP_BUDGET)?;
+                self.refresh_watchpoints();
+                Ok(format!("pc=${:08X}\n", self.emu.machine.pc()))
+            }
             "reg" => {
                 let Some(name) = parts.next() else {
                     return Ok("usage: monitor reg NAME|OFFSET\n".to_string());
@@ -703,6 +722,7 @@ fn monitor_help() -> String {
     "monitor commands:\n\
      help\n\
      status | beam | custom\n\
+     stepover | finish\n\
      reg NAME|OFFSET\n\
      write-reg NAME|OFFSET VALUE\n\
      watch-reg NAME|OFFSET | unwatch-reg NAME|OFFSET | clear-reg-watches\n\

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -190,15 +190,45 @@ impl DebuggerPanel {
         }
     }
 
-    /// The typed address, when the entry holds valid hex.
+    /// The typed address: the first whitespace-separated token parsed as hex.
+    /// (Poke uses a second token; the address consumers only need the first.)
     pub fn entry_addr(&self) -> Option<u32> {
-        parse_hex_u32(&self.entry)
+        parse_hex_u32(self.entry.split_whitespace().next()?)
+    }
+
+    /// Memory poke target: two hex tokens "ADDR VALUE", as an even address and
+    /// the 16-bit word to write there.
+    pub fn poke_target(&self) -> Option<(u32, u16)> {
+        let mut tokens = self.entry.split_whitespace();
+        let addr = parse_hex_u32(tokens.next()?)?;
+        let value = parse_hex_u32(tokens.next()?)?;
+        Some((addr & !1, value as u16))
+    }
+
+    /// Register poke target: a register name then a hex value, e.g. "D0 1234"
+    /// or "PC F80000". Returns the GDB-style register index and the value.
+    pub fn reg_poke(&self) -> Option<(usize, u32)> {
+        let mut tokens = self.entry.split_whitespace();
+        let reg = parse_reg_name(tokens.next()?)?;
+        let value = parse_hex_u32(tokens.next()?)?;
+        Some((reg, value))
     }
 
     pub fn push_entry_char(&mut self, ch: char) {
-        if self.entry.len() < 8 && ch.is_ascii_hexdigit() {
-            self.entry.push(ch.to_ascii_uppercase());
+        // Hex for addresses and values, plus space and the non-hex letters in
+        // register names (P/S/R) so the box can hold "ADDR VALUE" or
+        // "REG VALUE" for poke. A leading or doubled space is dropped so the
+        // two tokens stay clean.
+        let allowed = ch.is_ascii_hexdigit()
+            || ch == ' '
+            || matches!(ch.to_ascii_uppercase(), 'P' | 'S' | 'R');
+        if !allowed || self.entry.len() >= 20 {
+            return;
         }
+        if ch == ' ' && (self.entry.is_empty() || self.entry.ends_with(' ')) {
+            return;
+        }
+        self.entry.push(ch.to_ascii_uppercase());
     }
 
     pub fn backspace_entry(&mut self) {
@@ -351,6 +381,9 @@ pub enum UiControl {
     DebugMemPrev,
     DebugMemNext,
     DebugEntry,
+    /// Poke: on the Memory tab write a word from the entry box's "ADDR VALUE";
+    /// on the CPU tab set a register from "REG VALUE".
+    DebugPoke,
     /// Break tab: toggle a PC breakpoint at the entry address.
     DebugBreakToggle,
     /// Break tab: toggle a memory word watchpoint at the entry address.
@@ -456,7 +489,7 @@ fn debug_tab_rect(rect: Rect, index: usize) -> Rect {
     }
 }
 
-fn debug_button_rects(rect: Rect) -> [(UiControl, Rect); 12] {
+fn debug_button_rects(rect: Rect) -> [(UiControl, Rect); 13] {
     let y = rect.y + rect.h - DEBUG_BUTTON_H - 6;
     // Step Over / Step Out share a second transport row just above the main
     // one; the main row is already full edge to edge.
@@ -488,6 +521,8 @@ fn debug_button_rects(rect: Rect) -> [(UiControl, Rect); 12] {
         // Forward step-over / step-out on the second row.
         (UiControl::DebugStepOver, button2(8, 90)),
         (UiControl::DebugStepOut, button2(102, 84)),
+        // Poke (Memory tab) / Set Reg (CPU tab), on the second row.
+        (UiControl::DebugPoke, button2(200, 90)),
     ]
 }
 
@@ -1178,6 +1213,13 @@ fn draw_debugger(
                     UiControl::DebugReverseRun => "< Run",
                     UiControl::DebugMemPrev => "<",
                     UiControl::DebugMemNext => ">",
+                    UiControl::DebugPoke => {
+                        if panel.tab == DebugTab::Cpu {
+                            "Set Reg"
+                        } else {
+                            "Poke"
+                        }
+                    }
                     _ => "",
                 };
                 let enabled = match control {
@@ -1185,6 +1227,11 @@ fn draw_debugger(
                         panel.tab == DebugTab::Memory
                     }
                     UiControl::DebugRunTo => panel.entry_addr().is_some(),
+                    UiControl::DebugPoke => match panel.tab {
+                        DebugTab::Memory => panel.poke_target().is_some(),
+                        DebugTab::Cpu => panel.reg_poke().is_some(),
+                        _ => false,
+                    },
                     UiControl::DebugReverseStep
                     | UiControl::DebugReverseFrame
                     | UiControl::DebugReverseRun => view.reverse_available,
@@ -1868,6 +1915,29 @@ pub fn parse_hex_u32(s: &str) -> Option<u32> {
     u32::from_str_radix(s, 16).ok()
 }
 
+/// Parse a 68000 register name into the GDB-style index used by
+/// `debug_set_register`: D0-D7 -> 0-7, A0-A7 -> 8-15, SR -> 16, PC -> 17,
+/// with SP an alias for A7.
+fn parse_reg_name(token: &str) -> Option<usize> {
+    let token = token.to_ascii_uppercase();
+    match token.as_str() {
+        "PC" => return Some(17),
+        "SR" => return Some(16),
+        "SP" => return Some(15),
+        _ => {}
+    }
+    if token.len() < 2 {
+        return None;
+    }
+    let (kind, idx) = token.split_at(1);
+    let n: usize = idx.parse().ok()?;
+    match kind {
+        "D" if n <= 7 => Some(n),
+        "A" if n <= 7 => Some(8 + n),
+        _ => None,
+    }
+}
+
 const DMACON_BITS: [(u16, &str); 15] = [
     (1 << 14, "BBUSY"),
     (1 << 13, "BZERO"),
@@ -2086,11 +2156,11 @@ mod tests {
         assert_eq!(panel.entry_addr(), Some(0xC003C));
         panel.backspace_entry();
         assert_eq!(panel.entry, "C003");
-        // Capped at 8 hex digits.
-        for _ in 0..12 {
+        // Capped at the entry length (room for an "ADDR VALUE" poke).
+        for _ in 0..30 {
             panel.push_entry_char('F');
         }
-        assert_eq!(panel.entry.len(), 8);
+        assert_eq!(panel.entry.len(), 20);
     }
 
     #[test]
@@ -2124,6 +2194,44 @@ mod tests {
         assert_eq!(parse_hex_u32("C00000"), Some(0xC00000));
         assert_eq!(parse_hex_u32(""), None);
         assert_eq!(parse_hex_u32("xyz"), None);
+    }
+
+    #[test]
+    fn entry_box_parses_address_and_poke_tokens() {
+        let mut panel = DebuggerPanel::new();
+        // The entry only accepts hex, space, and the P/S/R register letters.
+        for ch in "C00000 DEAD".chars() {
+            panel.push_entry_char(ch);
+        }
+        assert_eq!(panel.entry, "C00000 DEAD");
+        // The address consumers see just the first token.
+        assert_eq!(panel.entry_addr(), Some(0xC00000));
+        // Memory poke takes both tokens; the address is forced even.
+        assert_eq!(panel.poke_target(), Some((0xC00000, 0xDEAD)));
+
+        // Leading/doubled spaces are dropped, and disallowed characters
+        // (e.g. 'G', 'X') never make it in.
+        let mut panel = DebuggerPanel::new();
+        for ch in " GD0 X12Z34".chars() {
+            panel.push_entry_char(ch);
+        }
+        assert_eq!(panel.entry, "D0 1234");
+        assert_eq!(panel.reg_poke(), Some((0, 0x1234)));
+    }
+
+    #[test]
+    fn register_names_map_to_gdb_indices() {
+        assert_eq!(parse_reg_name("D0"), Some(0));
+        assert_eq!(parse_reg_name("d7"), Some(7));
+        assert_eq!(parse_reg_name("A0"), Some(8));
+        assert_eq!(parse_reg_name("A7"), Some(15));
+        assert_eq!(parse_reg_name("SP"), Some(15));
+        assert_eq!(parse_reg_name("SR"), Some(16));
+        assert_eq!(parse_reg_name("PC"), Some(17));
+        assert_eq!(parse_reg_name("D8"), None);
+        assert_eq!(parse_reg_name("A8"), None);
+        assert_eq!(parse_reg_name("Z0"), None);
+        assert_eq!(parse_reg_name(""), None);
     }
 
     /// Render each panel and the menu into a presentation-sized frame.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -334,6 +334,11 @@ pub enum UiControl {
     DebugTab(DebugTab),
     DebugRun,
     DebugStep,
+    /// Step over a call: run the callee to completion, stopping at the
+    /// instruction after a BSR/JSR/TRAP (a plain single step otherwise).
+    DebugStepOver,
+    /// Step out: run until the current subroutine returns to its caller.
+    DebugStepOut,
     DebugStepFrame,
     DebugRunTo,
     /// Reverse-debug: step one instruction backward (reconstructed from the
@@ -451,11 +456,20 @@ fn debug_tab_rect(rect: Rect, index: usize) -> Rect {
     }
 }
 
-fn debug_button_rects(rect: Rect) -> [(UiControl, Rect); 10] {
+fn debug_button_rects(rect: Rect) -> [(UiControl, Rect); 12] {
     let y = rect.y + rect.h - DEBUG_BUTTON_H - 6;
+    // Step Over / Step Out share a second transport row just above the main
+    // one; the main row is already full edge to edge.
+    let y2 = rect.y + rect.h - 2 * DEBUG_BUTTON_H - 10;
     let button = |x: usize, w: usize| Rect {
         x: rect.x + x,
         y,
+        w,
+        h: DEBUG_BUTTON_H,
+    };
+    let button2 = |x: usize, w: usize| Rect {
+        x: rect.x + x,
+        y: y2,
         w,
         h: DEBUG_BUTTON_H,
     };
@@ -471,6 +485,9 @@ fn debug_button_rects(rect: Rect) -> [(UiControl, Rect); 10] {
         (UiControl::DebugReverseFrame, button(466, 76)),
         (UiControl::DebugReverseStep, button(546, 66)),
         (UiControl::DebugReverseRun, button(616, 60)),
+        // Forward step-over / step-out on the second row.
+        (UiControl::DebugStepOver, button2(8, 90)),
+        (UiControl::DebugStepOut, button2(102, 84)),
     ]
 }
 
@@ -976,7 +993,7 @@ fn draw_shortcuts(frame: &mut [u8], rect: Rect, scale: usize) {
     for line in [
         "Shortcuts: Cmd on macOS, Alt on Linux/Windows",
         "Amiga modifiers: Alt, Cmd/Super=Amiga, Ctrl",
-        "In the debugger: S step, F frame, R run/pause",
+        "In the debugger: S step, O over, U out, F frame, R run/pause",
     ] {
         draw_panel_text(frame, rect.x + 24, y, line, PANEL_TEXT_DIM, 1, scale);
         y += 12;
@@ -1101,9 +1118,10 @@ fn draw_debugger(
             );
         }
     }
-    // Content lines.
+    // Content lines. Two transport rows sit at the bottom now (the main row
+    // plus the Step Over/Out row), so the text area ends above both.
     let content_top = debug_content_top(rect);
-    let content_bottom = rect.y + rect.h - DEBUG_BUTTON_H - 12;
+    let content_bottom = rect.y + rect.h - 2 * DEBUG_BUTTON_H - 16;
     let pitch = 10;
     let max_lines = content_bottom.saturating_sub(content_top) / pitch;
     for (index, line) in view.lines.iter().take(max_lines).enumerate() {
@@ -1151,6 +1169,8 @@ fn draw_debugger(
                         }
                     }
                     UiControl::DebugStep => "Step",
+                    UiControl::DebugStepOver => "Step Over",
+                    UiControl::DebugStepOut => "Step Out",
                     UiControl::DebugStepFrame => "Frame",
                     UiControl::DebugRunTo => "Run to $",
                     UiControl::DebugReverseStep => "< Step",

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -14,6 +14,7 @@ use super::window::{
 };
 use super::{font, FB_WIDTH, HOST_SHORTCUT_MODIFIER_LABEL, PRESENT_HEIGHT};
 use crate::config::WarpSpeed;
+use crate::debugger::{BreakCond, CondOp, CondOperand};
 
 // ---------------------------------------------------------------------------
 // Palette
@@ -215,14 +216,11 @@ impl DebuggerPanel {
     }
 
     pub fn push_entry_char(&mut self, ch: char) {
-        // Hex for addresses and values, plus space and the non-hex letters in
-        // register names (P/S/R) so the box can hold "ADDR VALUE" or
-        // "REG VALUE" for poke. A leading or doubled space is dropped so the
-        // two tokens stay clean.
-        let allowed = ch.is_ascii_hexdigit()
-            || ch == ' '
-            || matches!(ch.to_ascii_uppercase(), 'P' | 'S' | 'R');
-        if !allowed || self.entry.len() >= 20 {
+        // Alphanumerics and spaces: hex for addresses/values, letters for
+        // register names (Dn/An/PC/SR), memory operands (M<hex>), and the
+        // breakpoint-condition mnemonics (EQ/NE/LT/GT/LE/GE/AND/IGN). A leading
+        // or doubled space is dropped so the tokens stay clean.
+        if (!ch.is_ascii_alphanumeric() && ch != ' ') || self.entry.len() >= 40 {
             return;
         }
         if ch == ' ' && (self.entry.is_empty() || self.entry.ends_with(' ')) {
@@ -1938,6 +1936,65 @@ fn parse_reg_name(token: &str) -> Option<usize> {
     }
 }
 
+/// Parse a breakpoint spec from the entry box: "ADDR [LHS OP RHS] [IGN N]".
+/// Returns the address, an optional condition, and an ignore count. The
+/// condition is three whitespace tokens (operand, mnemonic, operand); the
+/// optional trailing "IGN N" gives a hex ignore count.
+pub fn parse_break_spec(entry: &str) -> Option<(u32, Option<BreakCond>, u32)> {
+    let mut tokens = entry.split_whitespace();
+    let addr = parse_hex_u32(tokens.next()?)?;
+    let rest: Vec<&str> = tokens.collect();
+    // Split off a trailing "IGN N" clause if present.
+    let (cond_tokens, ignore) = match rest.iter().position(|t| t.eq_ignore_ascii_case("IGN")) {
+        Some(i) => {
+            let count = parse_hex_u32(rest.get(i + 1)?)?;
+            (&rest[..i], count)
+        }
+        None => (&rest[..], 0),
+    };
+    let cond = match cond_tokens {
+        [] => None,
+        [lhs, op, rhs] => Some(BreakCond {
+            lhs: parse_cond_operand(lhs)?,
+            op: parse_cond_op(op)?,
+            rhs: parse_cond_operand(rhs)?,
+        }),
+        _ => return None,
+    };
+    Some((addr, cond, ignore))
+}
+
+/// Parse a condition operand: a register name, `M<hex>` for a memory word, or a
+/// bare hex immediate. Register names win over hex (so `D0` is the register,
+/// not `$D0`); write an immediate with a leading zero (`0D0`) to disambiguate.
+fn parse_cond_operand(token: &str) -> Option<CondOperand> {
+    if let Some(reg) = parse_reg_name(token) {
+        return Some(match reg {
+            0..=7 => CondOperand::Data(reg),
+            8..=15 => CondOperand::Addr(reg - 8),
+            16 => CondOperand::Sr,
+            _ => CondOperand::Pc,
+        });
+    }
+    if let Some(hex) = token.strip_prefix('M').or_else(|| token.strip_prefix('m')) {
+        return Some(CondOperand::Mem(parse_hex_u32(hex)?));
+    }
+    Some(CondOperand::Imm(parse_hex_u32(token)?))
+}
+
+fn parse_cond_op(token: &str) -> Option<CondOp> {
+    Some(match token.to_ascii_uppercase().as_str() {
+        "EQ" => CondOp::Eq,
+        "NE" => CondOp::Ne,
+        "LT" => CondOp::Lt,
+        "GT" => CondOp::Gt,
+        "LE" => CondOp::Le,
+        "GE" => CondOp::Ge,
+        "AND" => CondOp::And,
+        _ => return None,
+    })
+}
+
 const DMACON_BITS: [(u16, &str); 15] = [
     (1 << 14, "BBUSY"),
     (1 << 13, "BZERO"),
@@ -2149,18 +2206,22 @@ mod tests {
         assert_eq!(ui.control_at(pos), Some(UiControl::PanelBody));
 
         let mut panel = DebuggerPanel::new();
-        for ch in ['c', '0', '0', 'z', '3', 'C'] {
+        for ch in ['c', '0', '0', '3', 'C'] {
             panel.push_entry_char(ch);
         }
         assert_eq!(panel.entry, "C003C");
         assert_eq!(panel.entry_addr(), Some(0xC003C));
+        // Punctuation is rejected (letters/digits/space are kept for spec
+        // mnemonics).
+        panel.push_entry_char('!');
+        assert_eq!(panel.entry, "C003C");
         panel.backspace_entry();
         assert_eq!(panel.entry, "C003");
-        // Capped at the entry length (room for an "ADDR VALUE" poke).
-        for _ in 0..30 {
+        // Capped at the entry length (room for a conditional breakpoint spec).
+        for _ in 0..50 {
             panel.push_entry_char('F');
         }
-        assert_eq!(panel.entry.len(), 20);
+        assert_eq!(panel.entry.len(), 40);
     }
 
     #[test]
@@ -2209,14 +2270,54 @@ mod tests {
         // Memory poke takes both tokens; the address is forced even.
         assert_eq!(panel.poke_target(), Some((0xC00000, 0xDEAD)));
 
-        // Leading/doubled spaces are dropped, and disallowed characters
-        // (e.g. 'G', 'X') never make it in.
+        // Leading/doubled spaces are collapsed, and punctuation never makes it
+        // in (letters are allowed now, for register names and condition
+        // mnemonics).
         let mut panel = DebuggerPanel::new();
-        for ch in " GD0 X12Z34".chars() {
+        for ch in "  D0  1234!".chars() {
             panel.push_entry_char(ch);
         }
         assert_eq!(panel.entry, "D0 1234");
         assert_eq!(panel.reg_poke(), Some((0, 0x1234)));
+    }
+
+    #[test]
+    fn break_spec_parses_address_condition_and_ignore() {
+        // Bare address: plain breakpoint.
+        assert_eq!(parse_break_spec("C033C2"), Some((0xC033C2, None, 0)));
+
+        // Address plus a register/immediate condition.
+        let (addr, cond, ignore) = parse_break_spec("C033C2 D0 EQ 5").unwrap();
+        assert_eq!(addr, 0xC033C2);
+        assert_eq!(ignore, 0);
+        assert_eq!(
+            cond,
+            Some(BreakCond {
+                lhs: CondOperand::Data(0),
+                op: CondOp::Eq,
+                rhs: CondOperand::Imm(5),
+            })
+        );
+
+        // Memory operand, bit-test op, and a trailing ignore count.
+        let (_, cond, ignore) = parse_break_spec("40 MC00002 AND 4000 IGN A").unwrap();
+        assert_eq!(ignore, 0xA);
+        assert_eq!(
+            cond,
+            Some(BreakCond {
+                lhs: CondOperand::Mem(0xC00002),
+                op: CondOp::And,
+                rhs: CondOperand::Imm(0x4000),
+            })
+        );
+
+        // Ignore count with no condition.
+        assert_eq!(parse_break_spec("1234 IGN 3"), Some((0x1234, None, 3)));
+
+        // Malformed condition and bad address are rejected.
+        assert!(parse_break_spec("C033C2 D0 EQ").is_none());
+        assert!(parse_break_spec("C033C2 D0 XX 5").is_none());
+        assert!(parse_break_spec("xyz").is_none());
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5537,17 +5537,32 @@ impl App {
         true
     }
 
-    /// Toggle a PC breakpoint at the entry-box address.
+    /// Toggle a PC breakpoint from the entry box. The entry may carry an
+    /// optional condition and ignore count: "ADDR [LHS OP RHS] [IGN N]".
     fn debugger_toggle_breakpoint(&mut self) {
-        let Some(addr) = self.debugger_entry_addr("Break") else {
+        let spec = self
+            .debugger_panel
+            .as_ref()
+            .and_then(|panel| ui::parse_break_spec(&panel.entry));
+        let Some((addr, cond, ignore)) = spec else {
+            self.show_osd("Break: ADDR [LHS OP RHS] [IGN N] e.g. C033C2 D0 EQ 5");
             return;
         };
-        let set = self.emu.machine.ui_toggle_breakpoint(addr);
-        self.show_osd(format!(
+        let set = self.emu.machine.ui_set_breakpoint(addr, cond, ignore);
+        let mut msg = format!(
             "Breakpoint ${:06X} {}",
             addr & 0x00FF_FFFF,
             if set { "set" } else { "removed" }
-        ));
+        );
+        if set {
+            if let Some(cond) = &cond {
+                msg.push_str(&format!(" when {}", cond.describe()));
+            }
+            if ignore > 0 {
+                msg.push_str(&format!(" ign {ignore}"));
+            }
+        }
+        self.show_osd(msg);
     }
 
     /// Toggle a memory word watchpoint at the entry-box address.
@@ -5813,10 +5828,13 @@ impl App {
                         "Disassembly pinned at ${origin:06X} (empty box + Enter follows PC)"
                     )));
                 }
+                let breaks = machine.ui_breaks();
                 let mut addr = panel.disasm_addr.unwrap_or(pc) & !1;
                 for _ in 0..24 {
                     let (text, len) = crate::disasm::disassemble(read, addr, machine.cpu_type());
-                    let line = format!("{addr:08X}  {text}");
+                    // A leading bullet marks a line that carries a breakpoint.
+                    let marker = if breaks.is_breakpoint(addr) { "*" } else { " " };
+                    let line = format!("{marker}{addr:08X}  {text}");
                     lines.push(if addr == pc {
                         ui::DbgLine::hilit(line)
                     } else {
@@ -5952,14 +5970,27 @@ impl App {
                 lines.push(ui::DbgLine::plain(
                     "Reg takes a custom-register offset (96) or address (DFF096).",
                 ));
+                lines.push(ui::DbgLine::plain(
+                    "Break cond: ADDR [LHS OP RHS] [IGN N]  e.g. C033C2 D0 EQ 5",
+                ));
+                lines.push(ui::DbgLine::plain(
+                    "  ops EQ NE LT GT LE GE AND; operand Dn An PC SR Mhex hex",
+                ));
                 lines.push(ui::DbgLine::plain(""));
                 let breaks = self.emu.machine.ui_breaks();
                 lines.push(ui::DbgLine::plain("Breakpoints:"));
                 if breaks.breakpoints.is_empty() {
                     lines.push(ui::DbgLine::plain("  (none)"));
                 }
-                for pc in &breaks.breakpoints {
-                    lines.push(ui::DbgLine::plain(format!("  ${pc:06X}")));
+                for bp in &breaks.breakpoints {
+                    let mut text = format!("  ${:06X}", bp.addr);
+                    if let Some(cond) = &bp.cond {
+                        text.push_str(&format!("  {}", cond.describe()));
+                    }
+                    if bp.ignore > 0 {
+                        text.push_str(&format!("  ign {}/{}", bp.hits, bp.ignore));
+                    }
+                    lines.push(ui::DbgLine::plain(text));
                 }
                 lines.push(ui::DbgLine::plain(""));
                 lines.push(ui::DbgLine::plain("Watchpoints (word, stop on change):"));
@@ -6783,9 +6814,9 @@ fn take_integral_mouse_delta(value: &mut f64) -> i32 {
 }
 
 /// Hex digit for a key, for the debugger's address entry box.
-/// Map a key to the character it types into the debugger entry box: hex digits,
-/// plus Space and P/S/R so the box can hold "ADDR VALUE" / "REG VALUE" for poke
-/// (`push_entry_char` filters anything it should not accept).
+/// Map a key to the character it types into the debugger entry box: digits, all
+/// letters (for register names and the EQ/NE/.../AND/IGN condition mnemonics and
+/// M<hex> memory operands), and Space. `push_entry_char` filters and uppercases.
 fn entry_char_for_key(code: KeyCode) -> Option<char> {
     use KeyCode::*;
     Some(match code {
@@ -6805,10 +6836,26 @@ fn entry_char_for_key(code: KeyCode) -> Option<char> {
         KeyD => 'D',
         KeyE => 'E',
         KeyF => 'F',
-        // Extra register-name letters (PC/SR/SP) and the token separator.
+        KeyG => 'G',
+        KeyH => 'H',
+        KeyI => 'I',
+        KeyJ => 'J',
+        KeyK => 'K',
+        KeyL => 'L',
+        KeyM => 'M',
+        KeyN => 'N',
+        KeyO => 'O',
         KeyP => 'P',
-        KeyS => 'S',
+        KeyQ => 'Q',
         KeyR => 'R',
+        KeyS => 'S',
+        KeyT => 'T',
+        KeyU => 'U',
+        KeyV => 'V',
+        KeyW => 'W',
+        KeyX => 'X',
+        KeyY => 'Y',
+        KeyZ => 'Z',
         Space => ' ',
         _ => return None,
     })
@@ -8828,7 +8875,8 @@ mod tests {
             Some(panel) => {
                 assert_eq!(panel.disasm_addr, Some(0xFC0010));
                 let view = app.build_debugger_view(panel);
-                assert!(view.lines.iter().any(|l| l.text.starts_with("00FC0010")));
+                // Each disasm line carries a one-char breakpoint marker prefix.
+                assert!(view.lines.iter().any(|l| l.text.contains("00FC0010")));
             }
             _ => panic!("debugger panel should be open"),
         }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4618,6 +4618,10 @@ impl App {
             }
             UiControl::DebugRun => self.activate_tool_control(ToolPanelKind::Debugger, control),
             UiControl::DebugStep => self.activate_tool_control(ToolPanelKind::Debugger, control),
+            UiControl::DebugStepOver => {
+                self.activate_tool_control(ToolPanelKind::Debugger, control)
+            }
+            UiControl::DebugStepOut => self.activate_tool_control(ToolPanelKind::Debugger, control),
             UiControl::DebugStepFrame => {
                 self.activate_tool_control(ToolPanelKind::Debugger, control)
             }
@@ -4676,6 +4680,8 @@ impl App {
             }
             (ToolPanelKind::Debugger, UiControl::DebugRun) => self.debugger_toggle_run(),
             (ToolPanelKind::Debugger, UiControl::DebugStep) => self.debugger_step(),
+            (ToolPanelKind::Debugger, UiControl::DebugStepOver) => self.debugger_step_over(),
+            (ToolPanelKind::Debugger, UiControl::DebugStepOut) => self.debugger_step_out(),
             (ToolPanelKind::Debugger, UiControl::DebugStepFrame) => self.debugger_step_frame(),
             (ToolPanelKind::Debugger, UiControl::DebugRunTo) => self.debugger_run_to(),
             (ToolPanelKind::Debugger, UiControl::DebugReverseStep) => self.debugger_reverse_step(),
@@ -4800,6 +4806,8 @@ impl App {
         }
         let control = match code {
             KeyCode::KeyS => Some(UiControl::DebugStep),
+            KeyCode::KeyO => Some(UiControl::DebugStepOver),
+            KeyCode::KeyU => Some(UiControl::DebugStepOut),
             KeyCode::KeyF => Some(UiControl::DebugStepFrame),
             KeyCode::KeyR => Some(UiControl::DebugRun),
             _ => None,
@@ -5348,6 +5356,39 @@ impl App {
             self.sync_live_audio_suspension();
         }
         self.surface_debug_stop();
+    }
+
+    /// Step over a subroutine call while paused: run a BSR/JSR/TRAP callee to
+    /// completion and stop at the following instruction (a plain single step
+    /// otherwise). Bounded so a call that never returns cannot wedge the UI.
+    fn debugger_step_over(&mut self) {
+        const STEP_OVER_BUDGET: usize = 5_000_000;
+        self.paused = true;
+        self.sync_live_audio_suspension();
+        self.last_debug_stop = None;
+        if let Err(e) = self.emu.debug_step_over(STEP_OVER_BUDGET) {
+            error!("debugger step-over halted: {e:?}");
+            self.cpu_halted = true;
+            self.sync_live_audio_suspension();
+        }
+        self.surface_debug_stop();
+        self.finish_render_for_current_frame();
+    }
+
+    /// Step out of the current subroutine while paused: run until it returns to
+    /// its caller. Bounded so a routine that never returns cannot wedge the UI.
+    fn debugger_step_out(&mut self) {
+        const STEP_OUT_BUDGET: usize = 5_000_000;
+        self.paused = true;
+        self.sync_live_audio_suspension();
+        self.last_debug_stop = None;
+        if let Err(e) = self.emu.debug_step_out(STEP_OUT_BUDGET) {
+            error!("debugger step-out halted: {e:?}");
+            self.cpu_halted = true;
+            self.sync_live_audio_suspension();
+        }
+        self.surface_debug_stop();
+        self.finish_render_for_current_frame();
     }
 
     /// Run one whole video frame while paused, refreshing the display so

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -368,6 +368,18 @@ fn host_shortcut_modifier_pressed(modifiers: ModifiersState) -> bool {
     }
 }
 
+/// Display name for a GDB-style register index (see `debug_set_register`):
+/// D0-D7, A0-A7, SR, PC.
+fn gdb_reg_label(reg: usize) -> String {
+    match reg {
+        0..=7 => format!("D{reg}"),
+        8..=15 => format!("A{}", reg - 8),
+        16 => "SR".to_string(),
+        17 => "PC".to_string(),
+        _ => format!("r{reg}"),
+    }
+}
+
 fn window_title_mouse_captured() -> String {
     format!("{WINDOW_TITLE} - Mouse captured ({HOST_SHORTCUT_MODIFIER_LABEL}+G releases)")
 }
@@ -4637,6 +4649,7 @@ impl App {
             }
             UiControl::DebugMemPrev => self.activate_tool_control(ToolPanelKind::Debugger, control),
             UiControl::DebugMemNext => self.activate_tool_control(ToolPanelKind::Debugger, control),
+            UiControl::DebugPoke => self.activate_tool_control(ToolPanelKind::Debugger, control),
             UiControl::DebugEntry => {
                 if let Some(panel) = self.debugger_panel.as_mut() {
                     panel.entry_active = true;
@@ -4693,6 +4706,7 @@ impl App {
             }
             (ToolPanelKind::Debugger, UiControl::DebugMemPrev) => self.debugger_mem_page(-1),
             (ToolPanelKind::Debugger, UiControl::DebugMemNext) => self.debugger_mem_page(1),
+            (ToolPanelKind::Debugger, UiControl::DebugPoke) => self.debugger_poke(),
             (ToolPanelKind::Debugger, UiControl::DebugEntry) => {
                 if let Some(panel) = self.debugger_panel.as_mut() {
                     panel.entry_active = true;
@@ -4771,7 +4785,7 @@ impl App {
             return false;
         };
         if panel.entry_active {
-            if let Some(ch) = hex_char_for_key(code) {
+            if let Some(ch) = entry_char_for_key(code) {
                 panel.push_entry_char(ch);
                 self.request_redraw();
                 return true;
@@ -5585,6 +5599,54 @@ impl App {
                     panel.mem_addr.wrapping_add(delta)
                 } & 0x00FF_FFF0;
             }
+        }
+    }
+
+    /// Write the entry box's value live while paused: a memory word from
+    /// "ADDR VALUE" on the Memory tab, or a register from "REG VALUE" on the
+    /// CPU tab. The panel borrow is resolved into a plain action first so the
+    /// emulator can then be borrowed mutably to perform the write.
+    fn debugger_poke(&mut self) {
+        enum Poke {
+            Mem(u32, u16),
+            Reg(usize, u32),
+            MemHelp,
+            RegHelp,
+            None,
+        }
+        let action = match self.debugger_panel.as_ref() {
+            Some(panel) => match panel.tab {
+                ui::DebugTab::Memory => match panel.poke_target() {
+                    Some((addr, value)) => Poke::Mem(addr, value),
+                    None => Poke::MemHelp,
+                },
+                ui::DebugTab::Cpu => match panel.reg_poke() {
+                    Some((reg, value)) => Poke::Reg(reg, value),
+                    None => Poke::RegHelp,
+                },
+                _ => Poke::None,
+            },
+            None => Poke::None,
+        };
+        match action {
+            Poke::Mem(addr, value) => {
+                let written = self
+                    .emu
+                    .machine
+                    .debug_write_memory(addr, &value.to_be_bytes());
+                if written == 2 {
+                    self.show_osd(format!("Poked ${value:04X} -> ${addr:06X}"));
+                } else {
+                    self.show_osd(format!("${addr:06X} is not writable RAM"));
+                }
+            }
+            Poke::Reg(reg, value) => {
+                self.emu.machine.debug_set_register(reg, value);
+                self.show_osd(format!("{} <- ${value:X}", gdb_reg_label(reg)));
+            }
+            Poke::MemHelp => self.show_osd("Poke: type \"ADDR VALUE\" (hex) first"),
+            Poke::RegHelp => self.show_osd("Set Reg: type \"REG VALUE\" e.g. D0 1234"),
+            Poke::None => {}
         }
     }
 
@@ -6721,7 +6783,10 @@ fn take_integral_mouse_delta(value: &mut f64) -> i32 {
 }
 
 /// Hex digit for a key, for the debugger's address entry box.
-fn hex_char_for_key(code: KeyCode) -> Option<char> {
+/// Map a key to the character it types into the debugger entry box: hex digits,
+/// plus Space and P/S/R so the box can hold "ADDR VALUE" / "REG VALUE" for poke
+/// (`push_entry_char` filters anything it should not accept).
+fn entry_char_for_key(code: KeyCode) -> Option<char> {
     use KeyCode::*;
     Some(match code {
         Digit0 | Numpad0 => '0',
@@ -6740,6 +6805,11 @@ fn hex_char_for_key(code: KeyCode) -> Option<char> {
         KeyD => 'D',
         KeyE => 'E',
         KeyF => 'F',
+        // Extra register-name letters (PC/SR/SP) and the token separator.
+        KeyP => 'P',
+        KeyS => 'S',
+        KeyR => 'R',
+        Space => ' ',
         _ => return None,
     })
 }
@@ -8772,14 +8842,46 @@ mod tests {
             _ => panic!("debugger panel should be open"),
         }
 
-        // While the entry box is focused, S is a hex digit candidate, not
-        // a transport key: it must not step (S is not hex, so it is just
-        // swallowed by the modal panel).
+        // While the entry box is focused, S types the register-name letter
+        // 'S' (for SR/SP) into the box instead of stepping.
         if let Some(panel) = app.debugger_panel.as_mut() {
             panel.entry_active = true;
+            panel.entry.clear();
         }
         let pc_before = app.emu.machine.pc();
-        assert!(!app.ui_handle_key(KeyCode::KeyS));
+        assert!(app.ui_handle_key(KeyCode::KeyS));
         assert_eq!(app.emu.machine.pc(), pc_before);
+        assert_eq!(
+            app.debugger_panel.as_ref().map(|p| p.entry.as_str()),
+            Some("S")
+        );
+    }
+
+    #[test]
+    fn debugger_poke_writes_memory_and_registers() {
+        let mut app = test_app();
+        app.open_debugger();
+        // Map chip RAM at $0 so the low test address is writable RAM, not the
+        // boot ROM overlay.
+        app.emu.machine.disable_overlay();
+
+        // Memory tab: "ADDR VALUE" writes a word into chip RAM.
+        if let Some(panel) = app.debugger_panel.as_mut() {
+            panel.tab = super::ui::DebugTab::Memory;
+            panel.entry = "2000 BEEF".to_string();
+        }
+        app.debugger_poke();
+        assert_eq!(
+            app.emu.machine.debug_read_memory(0x2000, 2),
+            vec![0xBE, 0xEF]
+        );
+
+        // CPU tab: "REG VALUE" sets a register.
+        if let Some(panel) = app.debugger_panel.as_mut() {
+            panel.tab = super::ui::DebugTab::Cpu;
+            panel.entry = "D3 12345678".to_string();
+        }
+        app.debugger_poke();
+        assert_eq!(app.emu.machine.d(3), 0x1234_5678);
     }
 }


### PR DESCRIPTION
A survey of the codebase put the debugger's biggest gaps next to where every accuracy fix in the history starts. This PR closes three of them, as three commits.

## 1. Step-over / step-out
Single-instruction stepping was the only forward granularity. Two new emulator primitives, built on the existing run-to / single-step machinery (sharing a new STOP/idle helper so a halted CPU advances instead of spinning):

- **Step Over** runs a `BSR`/`JSR`/`TRAP` callee to completion and stops at the following instruction (a plain single step otherwise).
- **Step Out** runs until the current subroutine returns, detected by the stack pointer rising past its entry value right after a return (`RTS`/`RTR`/`RTE`/`RTD`) -- so nested calls and interrupt handlers, which push below the entry frame and pop back to it, do not end it early.

Both are bounded by an instruction budget and stop early on a breakpoint/watch hit. Exposed as a **Step Over / Step Out** button row and the `O` / `U` keys, and over GDB as `monitor stepover` / `monitor finish`.

## 2. Interactive memory & register poke
The Memory and CPU tabs were read-only; patching state live meant the GDB stub. The shared `$` box now also accepts a space and the register letters, so it holds two tokens, and a context button on the transport's second row acts on the current tab:

- **Memory** tab **Poke**: `ADDR VALUE` writes a 16-bit word (ROM/device windows are left untouched, like GDB `M`).
- **CPU** tab **Set Reg**: `REG VALUE` sets `D0`-`D7`/`A0`-`A7`/`PC`/`SR` (`SP` aliases `A7`).

The button is disabled until the entry parses, so it is self-documenting.

## 3. Conditional & counted breakpoints
Breakpoints were unconditional. They now carry an optional condition and ignore count, parsed from the Break box as `ADDR [LHS OP RHS] [IGN N]`:

- Operands: registers (`D0`-`D7`/`A0`-`A7`/`PC`/`SR`), a memory word `M<hex>`, or a hex immediate (a register name wins over hex).
- Operators: `EQ NE LT GT LE GE` and `AND` (bit test).
- `IGN N` skips the first `N` qualifying hits; the list shows the running `ign hits/N`.

The all-letters/digits mnemonic syntax keeps the box typeable without shifted symbols. Conditions evaluate at the breakpoint gate against live register/memory state through a `BreakContext` trait (disjoint field borrows let the breakpoint set bump its hit counter while reading the CPU/bus). Breakpoints are also marked with a `*` in the CPU-tab disassembly.

## Tests / checks
- `cargo build --release`, `cargo clippy --all-targets`, `cargo fmt --check` -- all clean.
- Full suite **1102 passed**, including new unit tests for step-over/out, poke parsing/writing, register-name mapping, condition parsing and evaluation (with a mock context), ignore-count countdown, and an end-to-end test that a conditional breakpoint fires during execution.
- Re-rendered the debugger UI previews to verify the new button rows and layout.

Docs updated: `docs/debugger/window.md` (transport, conditional breakpoints, poke) and `docs/debugger/gdb.md` (new monitor commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)