### PR TITLE
Expand machine profiles: A500 Rev 6A default, A500OCS, A500+ 8375, A1000

### DIFF
--- a/a1000.example.toml
+++ b/a1000.example.toml
@@ -1,0 +1,19 @@
+# Amiga 1000 (the original Amiga, 1985).
+#
+# The A1000 has no Kickstart ROM. Instead a 64 KiB bootstrap ROM (the
+# "Amiga ROM Bootstrap") loads Kickstart from the Kickstart disk in DF0 into
+# 256 KiB of writable control store (WCS) at $FC0000, write-protects it, and
+# runs it -- exactly as the real machine does. So `rom` here is the bootstrap
+# ROM, and the Kickstart disk goes in DF0.
+#
+# Defaults to the 256 KiB stock chip RAM (set chip = "512K" for the common
+# front expansion). Leave the Kickstart disk in DF0 and the bootstrap loads it
+# on power-up; once Kickstart is up it asks for a Workbench disk.
+
+rom = "Amiga 1000 ROM Bootstrap (1985)(Commodore)(A1000)[!].rom"
+
+[machine]
+profile = "A1000"
+
+[floppy.df0]
+path = "Kickstart-Disk v1.1 r32.34 (1986)(Commodore)(A1000)(PAL).adf"

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -84,11 +84,15 @@ model = "68000"
 
 # Optional machine profile: a validated bundle of chipset revisions, CPU,
 # memory sizes, RTC presence, and gate array. Explicit [cpu]/[chipset]/
-# [memory] sections still override the profile defaults. Without this
-# section the A500-like defaults apply (512 KiB chip plus 512 KiB
-# trapdoor slow RAM).
+# [memory] sections still override the profile defaults. The "A500" profile
+# models a Rev 6A board: the ECS "Fatter" 8372A Agnus (1 MiB chip reach plus
+# the software PAL/NTSC switch) with the original OCS 8362 Denise, 512 KiB
+# chip + 512 KiB trapdoor slow RAM (fit up to 1 MiB chip with chip = "1M").
+# Without any [machine] section the default machine is that same Rev 6A
+# A500 (ECS 8372A Agnus, OCS 8362 Denise, 512 KiB chip + 512 KiB trapdoor
+# slow RAM) -- the most common and most-targeted Amiga.
 # [machine]
-# profile = "A600"      # A500 | A500Plus | A600 | A1200 | CDTV | CD32
+# profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | CDTV | CD32
 # rtc = true            # $DC0000 RTC fitted (base A600 shipped without)
 
 
@@ -176,8 +180,11 @@ slow = "512K"
 # are implemented (remaining edge-case gaps are noted in
 # docs/internals/chipset.md). The preset picks matching chips:
 # OCS = OCS Agnus + OCS Denise, ECS = ECS Agnus (8372A, or 8375 with
-# >1M chip RAM) + ECS Denise 8373, AGA = Alice + Lisa.
-revision = "OCS"
+# >1M chip RAM) + ECS Denise 8373, AGA = Alice + Lisa. Omit it to take the
+# machine's real chips (the default and the A500 profile are a Rev 6A:
+# 8372A Agnus + OCS Denise). Setting it is an override that wins over the
+# profile -- e.g. revision = "OCS" forces a plain 8371/8362 machine.
+# revision = "OCS"
 
 # Optional per-chip overrides on top of the preset, for mixed machines
 # that really shipped (e.g. a late A500: ECS Agnus + OCS Denise).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -35,7 +35,7 @@ range checks as the equivalent TOML fields:
 
 | Flag | Overrides | Accepts |
 |---|---|---|
-| `--model NAME` | `[machine] profile` | `A500`, `A500Plus`, `A600`, `A1200`, `CDTV`, `CD32` |
+| `--model NAME` | `[machine] profile` | `A1000`, `A500`, `A500OCS`, `A500Plus`, `A600`, `A1200`, `CDTV`, `CD32` |
 | `--chipset NAME` | `[chipset] revision` | `OCS`, `ECS`, `AGA` |
 | `--cpu MODEL` | `[cpu] model` | `68000`, `68EC020`, `68020`, `68030`, `68040` |
 | `--cpu-clock MHZ` | `[cpu] clock_mhz` | a number of MHz |
@@ -88,7 +88,7 @@ missing.
 
 ```toml
 [machine]
-profile = "A1200" # A500, A500Plus (A500+), A600, A1200, CDTV, CD32
+profile = "A1200" # A1000, A500, A500OCS, A500Plus (A500+), A600, A1200, CDTV, CD32
 rtc = true        # whether the $DC0000 battery RTC is fitted
 ```
 
@@ -96,13 +96,18 @@ A machine profile bundles the chipset, CPU, memory, gate array, and
 peripheral defaults of a real machine. The key is `profile` (the deprecated
 `model` alias still parses) so it never collides with `[cpu] model`. Explicit `[cpu]`, `[chipset]`, and
 `[memory]` sections override individual profile defaults. Without a
-`[machine]` section you get A500-like defaults (OCS, 68000, 512K chip RAM,
-512K trapdoor slow RAM).
+`[machine]` section you get the A500 Rev 6A default (the same as the `A500`
+profile: ECS 8372A Agnus, OCS 8362 Denise, 68000, 512K chip RAM, 512K
+trapdoor slow RAM) -- the most common and most-targeted Amiga. An explicit
+`[chipset] revision` overrides the per-machine chips, so `revision = "OCS"`
+gives a plain 8371/8362 OCS machine.
 
 | Profile | Chipset | CPU | Chip RAM | Slow RAM | Extras |
 |---|---|---|---|---|---|
-| `A500` | OCS | 68000 @ 7.09 MHz | 512K | 512K | -- |
-| `A500Plus` | ECS (8372A Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | -- |
+| `A1000` | OCS (8361/8367 Agnus, OCS Denise) | 68000 @ 7.09 MHz | 256K | 0 | WCS, boot ROM + Kickstart disk |
+| `A500` | Rev 6A: ECS 8372A Agnus, OCS 8362 Denise | 68000 @ 7.09 MHz | 512K (up to 1M) | 512K | -- |
+| `A500OCS` | OCS (8371 Fat Agnus, OCS Denise) | 68000 @ 7.09 MHz | 512K | 512K | early A500 / A2000 |
+| `A500Plus` | ECS (8375 Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | RTC |
 | `A600` | ECS (8375 Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | Gayle IDE, RTC |
 | `A1200` | AGA (Alice/Lisa) | 68EC020 @ 14.18 MHz | 2M | 0 | Gayle IDE, RTC |
 | `CDTV` | ECS | 68000 @ 7.09 MHz | 1M | 0 | DMAC CD controller, 256K extended ROM |
@@ -110,7 +115,26 @@ peripheral defaults of a real machine. The key is `profile` (the deprecated
 
 `rtc` exists because some machines shipped both ways: the base A600 had no
 RTC while the A600HD did. The default keeps it fitted so the Workbench
-clock works.
+clock works. The A500+ has an OKI RTC soldered to the motherboard, so its
+profile fits one; the A1000 has none.
+
+The `A1000` profile models the original Amiga, which has no Kickstart ROM.
+Its `rom` is instead the 64K bootstrap ROM ("Amiga ROM Bootstrap"); on
+power-up the bootstrap loads Kickstart from the Kickstart disk in DF0 into
+256K of writable control store (WCS) at `$FC0000`, write-protects it, and runs
+it -- exactly as the real machine does. So an A1000 config names the bootstrap
+ROM as `rom` and puts the Kickstart disk in `[floppy.df0]`; leave it in and the
+machine boots to Kickstart (which then asks for a Workbench disk). See the
+ready-made `a1000.example.toml`.
+
+The `A500` profile models the common Rev 6A board: the ECS "Fatter" 8372A
+Agnus (a 1 MiB chip-RAM reach and the software-selectable PAL/NTSC switch via
+`BEAMCON0`) paired with the original OCS 8362 Denise. It is therefore an
+Agnus-only ECS upgrade, not a full-ECS machine -- the OCS Denise means no
+superhires or `BRDRBLNK`, exactly as on the real board. Chip RAM defaults to
+the stock 512K but accepts up to 1M (`[memory] chip = "1M"`); more than 1M is
+rejected because the 8372A cannot address it. Booting with no `[machine]`
+section instead gives a plain OCS A500-like machine (8371 Agnus, OCS Denise).
 
 ## `[emulation]`
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -117,12 +117,14 @@ cargo test --release -- --ignored   # integration tests (need local ROMs/disks)
 
 With no arguments, Copperline looks for `./copperline.toml` in the current
 directory. If it is not present, built-in defaults are used: a 68000 at
-~7.09 MHz with 512 KiB chip RAM, OCS, PAL, and the bundled AROS ROM (when no
+~7.09 MHz with 512 KiB chip RAM, PAL, and the bundled AROS ROM (when no
 ROM is named, Copperline locates the AROS image that ships with it -- see
-[](configuration#top-level)). The default machine is a 1 MB A500: 512 KiB
-chip RAM plus 512 KiB of trapdoor slow RAM, matching the memory expansion
-many OCS demos expect. Use `--slow 0` or `[memory] slow = "0"` for a bare
-512 KiB A500.
+[](configuration#top-level)). The default machine is the A500 Rev 6A -- the
+most common and most-targeted Amiga: the ECS "Fatter" 8372A Agnus (1 MiB
+chip reach plus the software PAL/NTSC switch) with the original OCS 8362
+Denise, 512 KiB chip RAM plus 512 KiB of trapdoor slow RAM. Use `--slow 0`
+or `[memory] slow = "0"` for a bare 512 KiB machine, or `[chipset] revision
+= "OCS"` for a plain 8371/8362 OCS A500.
 
 You can boot your own ROM with a positional argument, or point at a specific
 config file:

--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -446,6 +446,8 @@ mod tests {
             zorro: ZorroChain::default(),
             extended_rom: Vec::new(),
             extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
         }
     }
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2085,6 +2085,10 @@ impl Bus {
         self.bitplane_bplcon0_delay = None;
         self.bitplane_ddfstart_miss = None;
         self.mem.overlay = true;
+        // A 68000 RESET returns the A1000 WCS latch to boot mode (boot ROM at
+        // $F80000, WCS writable) without clearing the WCS, so the boot ROM can
+        // re-run the Kickstart it already loaded instead of reading the disk.
+        self.mem.wcs_write_protected = false;
         self.floppy.reset_external_drives();
         self.floppy.write_prb(0xFF);
     }
@@ -3434,12 +3438,17 @@ impl Bus {
             _ => {}
         }
         if reg == REG_PRA || reg == REG_DDRA {
-            // CIA-A PRA bit 1 is /LED. On post-A1000 Amigas this line
-            // also controls the optional analogue audio low-pass filter:
-            // low = LED bright + filter enabled, high = LED dim/off +
-            // filter bypassed.
-            let pra = self.cia_a.read(REG_PRA);
-            self.paula.set_led_filter_enabled(pra & 0x02 == 0);
+            // CIA-A PRA bit 1 is /LED. On post-A1000 Amigas this line also
+            // switches the analogue audio low-pass filter: low = LED bright +
+            // filter engaged, high = LED dim/off + filter bypassed. The A1000
+            // does not have that circuit -- its filter is fixed and the LED is
+            // not on this line -- so the LED never switches the filter there.
+            // The A1000 is the machine with a WCS fitted at $FC0000.
+            let is_a1000 = !self.mem.wcs.is_empty();
+            if !is_a1000 {
+                let pra = self.cia_a.read(REG_PRA);
+                self.paula.set_led_filter_enabled(pra & 0x02 == 0);
+            }
             self.cd32_pad_cia_clock();
         }
         eff
@@ -10503,6 +10512,8 @@ mod tests {
                 zorro: crate::zorro::ZorroChain::default(),
                 extended_rom: Vec::new(),
                 extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
             },
             Paula::new(Box::new(NoopSerial), Box::new(NoopAudio)),
             FloppyController::default(),
@@ -10520,6 +10531,8 @@ mod tests {
                 zorro: crate::zorro::ZorroChain::default(),
                 extended_rom: Vec::new(),
                 extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
             },
             Paula::new(
                 Box::new(NoopSerial),
@@ -17934,6 +17947,32 @@ mod tests {
 
         let _ = bus.cia_a_write(pra, 1, 0xC1);
         assert!(bus.front_panel_status().power_led_on);
+    }
+
+    #[test]
+    fn a1000_led_line_does_not_switch_the_audio_filter() {
+        use crate::chipset::cia::REG_DDRA;
+        let ddra = (REG_DDRA as u64) << 8;
+        let pra = (REG_PRA as u64) << 8;
+
+        // A post-A1000 machine: CIA-A PRA bit 1 (/LED) switches the analogue
+        // audio low-pass filter. Drive bits 0 (/OVL, kept high) and 1 as
+        // outputs, then toggle /LED. The filter starts engaged.
+        let mut normal = empty_bus();
+        assert!(normal.paula.led_filter_enabled());
+        let _ = normal.cia_a_write(ddra, 1, 0x03);
+        let _ = normal.cia_a_write(pra, 1, 0x03); // /LED high -> filter bypassed
+        assert!(!normal.paula.led_filter_enabled());
+        let _ = normal.cia_a_write(pra, 1, 0x01); // /LED low -> filter engaged
+        assert!(normal.paula.led_filter_enabled());
+
+        // The A1000 (identified by its WCS) lacks that circuit: its fixed
+        // filter stays engaged no matter what the LED line does.
+        let mut a1000 = empty_bus();
+        a1000.mem.wcs = vec![0u8; crate::memory::WCS_SIZE];
+        let _ = a1000.cia_a_write(ddra, 1, 0x03);
+        let _ = a1000.cia_a_write(pra, 1, 0x03); // /LED high: no effect on the filter
+        assert!(a1000.paula.led_filter_enabled());
     }
 
     #[test]

--- a/src/cdtv.rs
+++ b/src/cdtv.rs
@@ -1333,6 +1333,8 @@ mod tests {
             zorro: crate::zorro::ZorroChain::default(),
             extended_rom: Vec::new(),
             extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
         }
     }
 

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -586,6 +586,11 @@ impl Paula {
         self.led_filter_enabled = enabled;
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn led_filter_enabled(&self) -> bool {
+        self.led_filter_enabled
+    }
+
     pub fn set_output_volume_percent(&mut self, percent: u8) {
         self.output_volume = f32::from(percent.min(100)) / 100.0;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -389,11 +389,17 @@ pub enum Chipset {
 /// clock, memory sizes, RTC presence, and gate array. Explicit `[cpu]`/
 /// `[chipset]`/`[memory]` sections override the profile defaults where
 /// compatible; the profile owns what those sections cannot express (Gayle,
-/// RTC presence). With no `[machine]` section the defaults are A500-like:
-/// OCS, 68000, 512 KiB chip RAM, and 512 KiB trapdoor slow RAM.
+/// RTC presence). With no `[machine]` section the defaults match the `A500`
+/// profile: the A500 Rev 6A (ECS 8372A Agnus, OCS 8362 Denise, 68000,
+/// 512 KiB chip RAM, and 512 KiB trapdoor slow RAM).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MachineModel {
+    /// A500 Rev 6A: the ECS "Fatter" 8372A Agnus (1 MiB chip reach, software
+    /// PAL/NTSC switch) with the original OCS 8362 Denise.
     A500,
+    /// Early A500 (Rev 3/5), equivalent to an A2000: the 512 KiB OCS "Fat
+    /// Agnus" (8370/8371) with OCS 8362 Denise.
+    A500Ocs,
     A500Plus,
     A600,
     A1200,
@@ -405,6 +411,13 @@ pub enum MachineModel {
     /// 512 KiB extended ROM at $E00000. Enables Akiko and the CD32 CD-ROM
     /// path.
     Cd32,
+    /// A1000: the original Amiga. OCS 8361/8367 Agnus + OCS 8362 Denise, and
+    /// no Kickstart ROM -- the `rom` is the 64 KiB bootstrap ROM, which loads
+    /// Kickstart from the Kickstart disk in DF0 into 256 KiB of writable
+    /// control store (WCS) at $FC0000 and then write-protects it. 256 KiB
+    /// stock chip RAM, no trapdoor slow RAM, no RTC. (Added last so the
+    /// serialized discriminants of the other models do not shift.)
+    A1000,
 }
 
 /// Identity of a ROM image: its length and a CRC-32 of its bytes. Enough to
@@ -619,8 +632,12 @@ impl Default for Config {
             z3_ram_bytes: 0,
             zorro_boards: Vec::new(),
             identify_board: true,
-            chipset: Chipset::Ocs,
-            agnus_revision: AgnusRevision::Ocs,
+            // The no-[machine] default models the most common and most-
+            // targeted Amiga: the A500 Rev 6A (the ECS "Fatter" 8372A Agnus
+            // with the original OCS 8362 Denise). Selecting `[chipset]
+            // revision` or a different `[machine] profile` opts out.
+            chipset: Chipset::Ecs,
+            agnus_revision: AgnusRevision::Ecs8372Rev4,
             denise_revision: DeniseRevision::Ocs,
             machine: None,
             gate_array: GateArray::None,
@@ -1147,17 +1164,37 @@ impl TryFrom<RawConfig> for Config {
             bail!("[scsi] rom_odd needs rom (the even EPROM half)");
         }
 
+        // The A500 Rev 6A is both the "A500" profile and the no-profile
+        // default machine (the most common, most-targeted Amiga): the Fatter
+        // 8372A Agnus with the original OCS 8362 Denise. An explicit [chipset]
+        // revision is an intentional override, so it re-derives the chips from
+        // the generic preset instead -- e.g. revision = "OCS" forces a plain
+        // 8371/8362 machine even under profile = "A500". cfg.machine, the gate
+        // array, and the descriptor machine id are unaffected.
+        let a500_default =
+            raw.chipset.revision.is_none() && matches!(machine, None | Some(MachineModel::A500));
         let agnus_revision = match raw.chipset.agnus.as_deref() {
-            // The A600 board carries the 2 MB-capable 8375 regardless of
-            // fitted chip RAM; other machines pick by preset + RAM size
-            // (the A1200's AGA preset resolves to Alice).
             None => match machine {
-                Some(MachineModel::A600) => AgnusRevision::Ecs8375,
+                // The A500+ (Rev 8A) and A600 boards have the 2 MB "Super Fat"
+                // 8375 soldered on, regardless of preset or fitted chip RAM.
+                Some(MachineModel::A500Plus | MachineModel::A600) => AgnusRevision::Ecs8375,
+                // The A500 Rev 6A / default machine has the 1 MB 8372A. Pinning
+                // it keeps the authentic 1 MiB chip-RAM ceiling, so fitting
+                // more is rejected by validate_chip_ram rather than silently
+                // promoted to an 8375.
+                _ if a500_default => AgnusRevision::Ecs8372Rev4,
+                // Everything else -- the A1200's AGA preset (Alice) or an
+                // explicit revision preset -- picks by preset + fitted chip RAM.
                 _ => default_agnus_revision(chipset, chip_ram_bytes),
             },
             Some(s) => parse_agnus_revision(s)?,
         };
         let denise_revision = match raw.chipset.denise.as_deref() {
+            // The A500 Rev 6A / default machine pairs its ECS Agnus with the
+            // original 8362 OCS Denise (no superhires/BRDRBLNK). Every other
+            // machine, and any explicit revision preset, takes the Denise that
+            // matches its preset.
+            None if a500_default => DeniseRevision::Ocs,
             None => default_denise_revision(chipset),
             Some(s) => parse_denise_revision(s)?,
         };
@@ -1292,14 +1329,16 @@ fn parse_chipset(s: &str) -> Result<Chipset> {
 fn parse_machine_model(s: &str) -> Result<MachineModel> {
     let norm = s.trim().to_ascii_uppercase().replace(['_', '-', ' '], "");
     match norm.as_str() {
+        "A1000" => Ok(MachineModel::A1000),
         "A500" => Ok(MachineModel::A500),
+        "A500OCS" => Ok(MachineModel::A500Ocs),
         "A500PLUS" | "A500+" => Ok(MachineModel::A500Plus),
         "A600" => Ok(MachineModel::A600),
         "A1200" => Ok(MachineModel::A1200),
         "CDTV" => Ok(MachineModel::Cdtv),
         "CD32" => Ok(MachineModel::Cd32),
         _ => Err(anyhow!(
-            "unknown machine model {:?}: expected A500 / A500Plus / A600 / A1200 / CDTV / CD32",
+            "unknown machine model {:?}: expected A1000 / A500 / A500OCS / A500Plus / A600 / A1200 / CDTV / CD32",
             s
         )),
     }
@@ -1313,10 +1352,34 @@ fn machine_profile_defaults(model: MachineModel) -> Config {
         ..Config::default()
     };
     match model {
-        // The common expanded OCS A500: 512 KiB chip plus 512 KiB trapdoor
-        // slow RAM. A bare 512 KiB machine is still available with
-        // `[memory] slow = "0"` or `--slow 0`.
-        MachineModel::A500 => {}
+        // The A500 Rev 6A board: the ECS "Fatter" 8372A Agnus (1 MiB chip
+        // reach plus the software PAL/NTSC switch) paired with the original
+        // OCS 8362 Denise, and the common 512 KiB chip + 512 KiB trapdoor
+        // slow RAM. The 8372A makes up to 1 MiB chip RAM possible (chip =
+        // "1M" / --chip 1M); the Denise stays OCS, so this is an Agnus-only
+        // ECS machine, not a full-ECS A500+. The 8372A/8362 pairing is pinned
+        // in the agnus/denise derivation below. A bare 512 KiB machine is
+        // still available with `[memory] slow = "0"` or `--slow 0`.
+        MachineModel::A500 => {
+            d.chipset = Chipset::Ecs;
+        }
+        // The original Amiga: OCS 8361/8367 Agnus + OCS 8362 Denise, 256 KiB
+        // stock chip RAM, no trapdoor slow RAM, no RTC. The `rom` is the
+        // 64 KiB bootstrap ROM and the Kickstart disk goes in DF0; the boot
+        // ROM loads it into the WCS at $FC0000 (see Memory::load_a1000).
+        MachineModel::A1000 => {
+            d.chipset = Chipset::Ocs;
+            d.chip_ram_bytes = 256 * 1024;
+            d.slow_ram_bytes = 0;
+            d.rtc_present = false;
+        }
+        // The early A500 (Rev 3/5) / A2000: the 512 KiB OCS "Fat Agnus"
+        // (8370/8371) and OCS 8362 Denise, with the same 512 KiB chip +
+        // 512 KiB trapdoor slow RAM. This is the pre-Rev-6A machine the
+        // default used to be; `revision = "OCS"` gives the same chips.
+        MachineModel::A500Ocs => {
+            d.chipset = Chipset::Ocs;
+        }
         MachineModel::A500Plus => {
             d.chipset = Chipset::Ecs;
             d.chip_ram_bytes = 1024 * 1024;
@@ -1824,9 +1887,15 @@ mod tests {
 
     #[test]
     fn machine_profiles_supply_defaults_and_keep_overrides() -> Result<()> {
-        // No [machine] section: A500-like defaults, no gate array, RTC fitted.
+        // No [machine] section: the default machine is the A500 Rev 6A
+        // (ECS 8372A Agnus + OCS 8362 Denise), no gate array, RTC fitted,
+        // stock 512K chip + 512K trapdoor slow RAM. cfg.machine stays None --
+        // the profile id only changes with an explicit [machine] profile.
         let cfg = parse_config("")?;
         assert_eq!(cfg.machine, None);
+        assert_eq!(cfg.chipset, Chipset::Ecs);
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ecs8372Rev4);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ocs);
         assert_eq!(cfg.gate_array, GateArray::None);
         assert_eq!(cfg.chip_ram_bytes, 512 * 1024);
         assert_eq!(cfg.slow_ram_bytes, 512 * 1024);
@@ -1839,7 +1908,11 @@ mod tests {
             "#,
         )?;
         assert_eq!(cfg.machine, Some(MachineModel::A500));
-        assert_eq!(cfg.chipset, Chipset::Ocs);
+        // Rev 6A board: ECS Agnus (the 1 MiB 8372A) with the original OCS
+        // Denise, stock 512 KiB chip + 512 KiB trapdoor slow RAM.
+        assert_eq!(cfg.chipset, Chipset::Ecs);
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ecs8372Rev4);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ocs);
         assert_eq!(cfg.chip_ram_bytes, 512 * 1024);
         assert_eq!(cfg.slow_ram_bytes, 512 * 1024);
 
@@ -1892,8 +1965,13 @@ mod tests {
         assert_eq!(cfg.chipset, Chipset::Ecs);
         assert_eq!(cfg.chip_ram_bytes, 1024 * 1024);
         assert_eq!(cfg.slow_ram_bytes, 0);
-        assert_eq!(cfg.agnus_revision, AgnusRevision::Ecs8372Rev4);
+        // The A500+ (Rev 8A) board carries the 2 MB-capable 8375, like the
+        // A600, even though it ships with 1 MB chip RAM fitted.
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ecs8375);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ecs8373);
         assert_eq!(cfg.gate_array, GateArray::None);
+        // The A500+ has an OKI RTC soldered to the motherboard.
+        assert!(cfg.rtc_present);
 
         let cfg = parse_config(
             r#"
@@ -1915,6 +1993,108 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("unknown machine model"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
+    fn a500_rev6a_agnus_allows_up_to_1mb_chip() -> Result<()> {
+        // The Fatter 8372A reaches 1 MiB, so the 1 MiB chip-RAM mod is a
+        // valid A500 configuration and still carries the 8372A (not the
+        // 2 MiB 8375) alongside the OCS Denise.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A500"
+            [memory]
+            chip = "1M"
+            slow = "0"
+            "#,
+        )?;
+        assert_eq!(cfg.chip_ram_bytes, 1024 * 1024);
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ecs8372Rev4);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ocs);
+
+        // 2 MiB chip exceeds the 8372A's 1 MiB address reach: rejected
+        // rather than silently promoted to a 2 MiB 8375.
+        let err = parse_config(
+            r#"
+            [machine]
+            profile = "A500"
+            [memory]
+            chip = "2M"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Agnus address reach"), "{err:#}");
+
+        // An explicit [chipset] revision overrides the profile's board chips:
+        // profile = "A500" + revision = "OCS" is a plain 8371/8362 OCS
+        // machine, not the Fatter-Agnus Rev 6A.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A500"
+            [chipset]
+            revision = "OCS"
+            "#,
+        )?;
+        assert_eq!(cfg.chipset, Chipset::Ocs);
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ocs);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ocs);
+        Ok(())
+    }
+
+    #[test]
+    fn a500ocs_profile_is_a_plain_512k_ocs_machine() -> Result<()> {
+        // The early A500 (Rev 3/5) / A2000: 8370/8371 Fat Agnus + OCS Denise,
+        // 512 KiB chip + 512 KiB trapdoor slow RAM, no gate array.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A500OCS"
+            "#,
+        )?;
+        assert_eq!(cfg.machine, Some(MachineModel::A500Ocs));
+        assert_eq!(cfg.chipset, Chipset::Ocs);
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ocs);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ocs);
+        assert_eq!(cfg.chip_ram_bytes, 512 * 1024);
+        assert_eq!(cfg.slow_ram_bytes, 512 * 1024);
+        assert_eq!(cfg.gate_array, GateArray::None);
+
+        // The OCS Fat Agnus tops out at 512 KiB chip RAM.
+        let err = parse_config(
+            r#"
+            [machine]
+            profile = "A500OCS"
+            [memory]
+            chip = "1M"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("chipset maximum"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
+    fn a1000_profile_is_an_ocs_machine_with_wcs_defaults() -> Result<()> {
+        // The original Amiga: OCS 8361/8367 Agnus + OCS 8362 Denise, 256 KiB
+        // stock chip RAM, no slow RAM, no RTC, no gate array. The `rom` is the
+        // 64 KiB bootstrap ROM (loaded by Memory::load_a1000, not here).
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A1000"
+            "#,
+        )?;
+        assert_eq!(cfg.machine, Some(MachineModel::A1000));
+        assert_eq!(cfg.chipset, Chipset::Ocs);
+        assert_eq!(cfg.agnus_revision, AgnusRevision::Ocs);
+        assert_eq!(cfg.denise_revision, DeniseRevision::Ocs);
+        assert_eq!(cfg.chip_ram_bytes, 256 * 1024);
+        assert_eq!(cfg.slow_ram_bytes, 0);
+        assert!(!cfg.rtc_present);
+        assert_eq!(cfg.gate_array, GateArray::None);
         Ok(())
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -6,7 +6,9 @@ use crate::bus::{Bus, CpuBusAccessKind};
 use crate::chipset::cia::CiaSideEffect;
 use crate::chipset::paula::{pending_ipl, INT_MASTER};
 use crate::config::CpuModel;
-use crate::memory::{AUTOCONFIG_BASE, AUTOCONFIG_SIZE, CHIP_RAM_BASE, ROM_BASE, SLOW_RAM_BASE};
+use crate::memory::{
+    AUTOCONFIG_BASE, AUTOCONFIG_SIZE, CHIP_RAM_BASE, ROM_BASE, SLOW_RAM_BASE, WCS_BASE,
+};
 use anyhow::{anyhow, Result};
 use log::{debug, trace};
 use m68k::{AddressBus, CpuCore, CpuType, NoOpHleHandler, StepResult};
@@ -1518,6 +1520,9 @@ impl CpuBus {
         if let Some(off) = region_offset(self.bus.mem.rom.len(), ROM_BASE, addr, 1) {
             return self.bus.mem.rom[off];
         }
+        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, 1) {
+            return self.bus.mem.wcs[off];
+        }
         if let Some(off) = region_offset(
             self.bus.mem.extended_rom.len(),
             self.bus.mem.extended_rom_base,
@@ -1692,6 +1697,12 @@ impl CpuBus {
             self.bus.cpu_external_access(Self::access_words(size));
             return read_be(&self.bus.mem.rom, off, size);
         }
+        // A1000 WCS at $FC0000 (empty -> no match on other machines): the
+        // 256 KiB writable control store the boot ROM loads Kickstart into.
+        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, size) {
+            self.bus.cpu_external_access(Self::access_words(size));
+            return read_be(&self.bus.mem.wcs, off, size);
+        }
         if let Some(off) = region_offset(
             self.bus.mem.extended_rom.len(),
             self.bus.mem.extended_rom_base,
@@ -1855,6 +1866,21 @@ impl CpuBus {
         }
         if region_offset(self.bus.mem.rom.len(), ROM_BASE, addr, size).is_some() {
             self.bus.cpu_external_access(Self::access_words(size));
+            // A1000: a CPU write anywhere in the boot-ROM window ($F80000-
+            // $FBFFFF) flips the latch to write-protect the WCS. The boot code
+            // does this once the Kickstart image is in place at $FC0000.
+            if !self.bus.mem.wcs.is_empty() {
+                self.bus.mem.wcs_write_protected = true;
+            }
+            return;
+        }
+        // A1000 WCS at $FC0000: writable until the boot ROM locks the latch.
+        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, size) {
+            self.bus.cpu_external_access(Self::access_words(size));
+            if !self.bus.mem.wcs_write_protected {
+                write_be(&mut self.bus.mem.wcs, off, size, value);
+                self.dbg_note_memw(addr, size);
+            }
             return;
         }
         if region_offset(
@@ -2253,6 +2279,8 @@ mod tests {
                 zorro,
                 extended_rom: Vec::new(),
                 extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
             },
             Paula::new(Box::new(StdoutSink::new()), Box::new(NullSink)),
             FloppyController::default(),
@@ -2486,6 +2514,8 @@ mod tests {
                     zorro: ZorroChain::default(),
                     extended_rom: Vec::new(),
                     extended_rom_base: 0,
+                    wcs: Vec::new(),
+                    wcs_write_protected: false,
                 },
                 Paula::new(Box::new(StdoutSink::new()), Box::new(NullSink)),
                 FloppyController::default(),

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1948,6 +1948,8 @@ mod tests {
                 zorro: crate::zorro::ZorroChain::default(),
                 extended_rom: Vec::new(),
                 extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
             },
             crate::chipset::paula::Paula::new(Box::new(crate::serial::NullSerialSink), audio),
             crate::floppy::FloppyController::default(),
@@ -2000,6 +2002,8 @@ mod tests {
                 zorro: crate::zorro::ZorroChain::default(),
                 extended_rom: Vec::new(),
                 extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
             },
             crate::chipset::paula::Paula::new(
                 Box::new(crate::serial::NullSerialSink),

--- a/src/main.rs
+++ b/src/main.rs
@@ -979,7 +979,14 @@ fn main() -> Result<()> {
     } else {
         None
     };
-    let mut mem = Memory::load(&cfg.rom_path, cfg.chip_ram_bytes, cfg.slow_ram_bytes, zorro)?;
+    // The A1000 has no Kickstart ROM: cfg.rom_path is its 64 KiB bootstrap
+    // ROM, and a 256 KiB WCS is allocated for it to load Kickstart into from
+    // the Kickstart disk in DF0.
+    let mut mem = if cfg.machine == Some(crate::config::MachineModel::A1000) {
+        Memory::load_a1000(&cfg.rom_path, cfg.chip_ram_bytes, cfg.slow_ram_bytes, zorro)?
+    } else {
+        Memory::load(&cfg.rom_path, cfg.chip_ram_bytes, cfg.slow_ram_bytes, zorro)?
+    };
     if let Some(path) = &cfg.extended_rom_path {
         let image = std::fs::read(path)
             .map_err(|e| anyhow!("reading extended ROM {}: {e}", path.display()))?;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -18,6 +18,15 @@ pub const CHIP_RAM_BASE: u64 = 0x0000_0000;
 #[cfg_attr(not(test), allow(dead_code))]
 pub const FAST_RAM_BASE: u64 = 0x0020_0000;
 pub const SLOW_RAM_BASE: u64 = 0x00C0_0000;
+/// Amiga 1000 WCS / WOM: 256 KiB of writable control store at $FC0000 that
+/// the boot ROM loads Kickstart into and then write-protects. The 256 KiB
+/// boot-ROM window ($F80000-$FBFFFF) sits immediately below it, so a boot
+/// ROM echoed to this size and mapped at ROM_BASE ends exactly at WCS_BASE.
+pub const WCS_BASE: u64 = 0x00FC_0000;
+pub const WCS_SIZE: usize = 256 * 1024;
+/// The A1000 bootstrap ROM is 64 KiB; the address latch echoes it across the
+/// 256 KiB $F80000-$FBFFFF window.
+pub const A1000_BOOT_ROM_SIZE: usize = 64 * 1024;
 pub use crate::zorro::{AUTOCONFIG_BASE, AUTOCONFIG_SIZE};
 
 /// Normalise a boot-ROM image to the full 512 KiB ROM window. A 512 KiB
@@ -44,6 +53,26 @@ pub fn normalize_boot_rom(rom: Vec<u8>) -> Result<Vec<u8>> {
     }
 }
 
+/// Normalise an Amiga 1000 bootstrap ROM (the 64 KiB "Amiga ROM Bootstrap"
+/// that loads Kickstart from the Kickstart disk into the WCS). On real
+/// hardware the address latch echoes the 64 KiB part across the whole 256 KiB
+/// $F80000-$FBFFFF boot-ROM window; echoing it here lets the standard ROM
+/// decode at ROM_BASE cover that window, leaving $FC0000-$FFFFFF for the WCS.
+pub fn normalize_a1000_boot_rom(rom: Vec<u8>) -> Result<Vec<u8>> {
+    if rom.len() != A1000_BOOT_ROM_SIZE {
+        anyhow::bail!(
+            "A1000 boot ROM is {} bytes; expected {} (64 KiB)",
+            rom.len(),
+            A1000_BOOT_ROM_SIZE
+        );
+    }
+    let mut full = Vec::with_capacity(WCS_SIZE);
+    while full.len() < WCS_SIZE {
+        full.extend_from_slice(&rom);
+    }
+    Ok(full)
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Memory {
     pub chip_ram: Vec<u8>,
@@ -56,6 +85,14 @@ pub struct Memory {
     /// no extended ROM is fitted.
     pub extended_rom: Vec<u8>,
     pub extended_rom_base: u64,
+    /// Amiga 1000 WCS / WOM at $FC0000 (256 KiB writable control store the
+    /// boot ROM loads Kickstart into). Empty on every other machine, which is
+    /// how the address decode tells an A1000 apart.
+    pub wcs: Vec<u8>,
+    /// A1000 WCS write-protect latch. A 68000 RESET clears it (WCS writable,
+    /// boot ROM mapped at $F80000); a CPU write anywhere in $F80000-$FBFFFF
+    /// sets it, after which the boot code runs the Kickstart it loaded.
+    pub wcs_write_protected: bool,
 }
 
 impl Memory {
@@ -72,17 +109,55 @@ impl Memory {
         let rom = std::fs::read(rom_path)
             .with_context(|| format!("reading ROM {}", rom_path.display()))?;
         let rom = normalize_boot_rom(rom)?;
-        let chip_ram = vec![0u8; chip_ram_bytes];
-        let slow_ram = vec![0u8; slow_ram_bytes];
-        Ok(Self {
-            chip_ram,
-            slow_ram,
+        Ok(Self::with_rom(
+            rom,
+            chip_ram_bytes,
+            slow_ram_bytes,
+            zorro,
+            Vec::new(),
+        ))
+    }
+
+    /// Load an Amiga 1000: the `rom_path` is the 64 KiB bootstrap ROM (echoed
+    /// across the $F80000 boot-ROM window), and a 256 KiB WCS is allocated at
+    /// $FC0000 for the boot ROM to load Kickstart into from the Kickstart disk.
+    pub fn load_a1000(
+        rom_path: &Path,
+        chip_ram_bytes: usize,
+        slow_ram_bytes: usize,
+        zorro: ZorroChain,
+    ) -> Result<Self> {
+        let rom = std::fs::read(rom_path)
+            .with_context(|| format!("reading A1000 boot ROM {}", rom_path.display()))?;
+        let rom = normalize_a1000_boot_rom(rom)?;
+        let wcs = vec![0u8; WCS_SIZE];
+        Ok(Self::with_rom(
+            rom,
+            chip_ram_bytes,
+            slow_ram_bytes,
+            zorro,
+            wcs,
+        ))
+    }
+
+    fn with_rom(
+        rom: Vec<u8>,
+        chip_ram_bytes: usize,
+        slow_ram_bytes: usize,
+        zorro: ZorroChain,
+        wcs: Vec<u8>,
+    ) -> Self {
+        Self {
+            chip_ram: vec![0u8; chip_ram_bytes],
+            slow_ram: vec![0u8; slow_ram_bytes],
             rom,
             overlay: true,
             zorro,
             extended_rom: Vec::new(),
             extended_rom_base: 0,
-        })
+            wcs,
+            wcs_write_protected: false,
+        }
     }
 
     /// Attach an extended ROM image: 512 KiB maps at $E00000 (CD32),
@@ -116,6 +191,11 @@ impl Memory {
     pub fn power_on_reset(&mut self) {
         self.chip_ram.fill(0);
         self.slow_ram.fill(0);
+        // Cold boot loses the WCS contents and returns the latch to boot mode
+        // (WCS writable), so the A1000 reloads Kickstart from disk. A warm
+        // (keyboard) reset preserves the WCS, as the real machine does.
+        self.wcs.fill(0);
+        self.wcs_write_protected = false;
         self.overlay = true;
         self.zorro.power_on_reset();
     }
@@ -150,5 +230,20 @@ mod tests {
         assert!(normalize_boot_rom(vec![0u8; 1024]).is_err());
         assert!(normalize_boot_rom(vec![0u8; ROM_SIZE + 1]).is_err());
         assert!(normalize_boot_rom(Vec::new()).is_err());
+    }
+
+    #[test]
+    fn a1000_boot_rom_echoes_64k_across_the_256k_window() {
+        // The 64 KiB A1000 bootstrap ROM is echoed four times to fill the
+        // 256 KiB $F80000-$FBFFFF window, so the standard ROM decode covers it.
+        let boot: Vec<u8> = (0..A1000_BOOT_ROM_SIZE).map(|i| i as u8).collect();
+        let out = normalize_a1000_boot_rom(boot.clone()).unwrap();
+        assert_eq!(out.len(), WCS_SIZE);
+        for chunk in out.chunks(A1000_BOOT_ROM_SIZE) {
+            assert_eq!(chunk, &boot[..]);
+        }
+        // Only the 64 KiB part is accepted (a 256/512 KiB Kickstart is not it).
+        assert!(normalize_a1000_boot_rom(vec![0u8; ROM_SIZE]).is_err());
+        assert!(normalize_a1000_boot_rom(vec![0u8; 32 * 1024]).is_err());
     }
 }

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -51,7 +51,8 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //   3: keyboard MCU clock-based handshake timing (state shape change)
 //   4: PollStats.custom HashMap replaced by a flat Vec table
 //   5: MachineDescriptor header (machine-shape guard rail)
-pub const STATE_VERSION: u32 = 5;
+//   6: Memory gained the A1000 WCS (wcs + wcs_write_protected)
+pub const STATE_VERSION: u32 = 6;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {
@@ -149,6 +150,8 @@ mod tests {
                 zorro: ZorroChain::default(),
                 extended_rom: Vec::new(),
                 extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
             },
             Paula::new(Box::new(NullSerialSink), Box::new(NullSink)),
             FloppyController::default(),

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8303,6 +8303,8 @@ mod tests {
             zorro: crate::zorro::ZorroChain::default(),
             extended_rom: Vec::new(),
             extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
         };
         let bus = crate::bus::Bus::new(
             mem,


### PR DESCRIPTION
## Summary

Expands the modeled Amiga line and makes the default machine the most common one. Everything is hardware-derived (no title/ROM/filename branches). 1107 unit tests pass; clippy and fmt clean.

## Changes

### Default machine and `A500` -> Rev 6A
The no-`[machine]` default and the `A500` profile now model the A500 Rev 6A: the ECS "Fatter" 8372A Agnus (1 MiB chip reach plus the software PAL/NTSC switch via `BEAMCON0`) paired with the original OCS 8362 Denise. An explicit `[chipset] revision` still wins, so `revision = "OCS"` yields a plain 8371/8362 machine even under `profile = "A500"`. Chip RAM can be fitted up to the 8372A's 1 MiB ceiling.

### `A500Plus` / `A600` -> 8375
Both now carry the 2 MiB "Super Fat" 8375 (the A500+ board shipped it; it previously resolved to the 8372A).

### New `A500OCS` profile
The early A500 / A2000: 8370/8371 Fat Agnus + OCS Denise, 512 KiB chip + 512 KiB trapdoor slow RAM. (Also reachable via `[chipset] revision = "OCS"`.)

### New `A1000` profile + WCS
The original Amiga has no Kickstart ROM. Its `rom` is the 64 KiB bootstrap ROM, which loads Kickstart from the Kickstart disk in DF0 into 256 KiB of writable control store (WCS) at `$FC0000` and then write-protects it via the `$F80000` latch. The boot ROM is echoed across `$F80000-$FBFFFF` and overlaid at `$0` at reset; the bootstrap reads the disk through the normal Paula disk DMA. Boots Kickstart 1.1 to the insert-Workbench prompt. `a1000.example.toml` is a ready-made config. `STATE_VERSION` -> 6 for the new `Memory` fields.

### A1000 audio filter
The A1000 lacks the circuit tying CIA-A PRA bit 1 (`/LED`) to the audio low-pass filter, so the LED no longer switches the filter on that machine (its fixed filter stays engaged).

### Docs
A500+ soldered OKI RTC noted; the configuration tables, `--model` list, and example TOML updated for all new/changed profiles.

## Testing
- 1107 unit tests pass (added coverage for each profile, the WCS boot-ROM normalizer, the explicit-`revision`-wins precedence, and the A1000 LED-filter behavior).
- `cargo clippy` clean, `cargo fmt --check` clean.
- Headless boots verified: A1000 reaches the Kickstart 1.1 insert-Workbench screen; A500/A500OCS/A500Plus/A600/A1200 all configure correctly; a normal KS1.3 boot still renders the insert-disk screen (no regression).
