### PR TITLE
WASM external Zorro board plugins (with A2065 networking flagship)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +236,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -384,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +468,8 @@ dependencies = [
  "serde-big-array",
  "thread-priority",
  "toml",
+ "wasmtime",
+ "wat",
  "winit",
 ]
 
@@ -528,6 +554,113 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
+
+[[package]]
+name = "cranelift-control"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8"
+
+[[package]]
+name = "cranelift-native"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -618,6 +751,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +800,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fdeflate"
@@ -807,6 +958,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +1054,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -917,6 +1089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1126,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -972,12 +1158,27 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1117,6 +1318,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1427,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memmap2"
@@ -1667,6 +1889,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oboe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1994,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1859,6 +2108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +2148,27 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "sptr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -1961,6 +2243,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+dependencies = [
+ "hashbrown 0.14.5",
+ "log",
+ "rustc-hash 2.1.2",
+ "slice-group-by",
+ "smallvec",
 ]
 
 [[package]]
@@ -2178,6 +2473,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2535,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2554,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2285,6 +2602,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2635,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "termcolor"
@@ -2516,6 +2851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2956,244 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa79bcd666a043b58f5fa62b221b0b914dd901e6f620e8ab7371057a797f3e1"
+dependencies = [
+ "leb128",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5220ee4c6ffcc0cb9d7c47398052203bc902c8ef3985b0c8134118440c0b2921"
+dependencies = [
+ "ahash",
+ "bitflags 2.13.0",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68c93bcc5e934985afd8b65214bdd77abd3863b2e1855eae1b07a11c4ef30a8"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "libc",
+ "libm",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.36.7",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "wasmparser 0.219.2",
+ "wasmtime-asm-macros",
+ "wasmtime-component-macro",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.12.1",
+ "log",
+ "object 0.36.7",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.219.2",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap",
+ "log",
+ "object 0.36.7",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.219.2",
+ "wasmparser 0.219.2",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "252.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.252.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -3316,6 +3895,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wit-parser"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca004bb251010fe956f4a5b9d4bf86b4e415064160dd6669569939e8cbf2504f"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,3 +3994,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,12 @@ ringbuf = "0.4"
 hound = "3.5"
 rfd = "0.17.2"
 gilrs = "0.11"
+# WASM plugin host for functional Zorro boards (src/wasmboard.rs). Lean feature
+# set: the Cranelift JIT + runtime only -- no WASI, component model, GC, threads,
+# or wat parsing in the shipped binary (kept deterministic; see the determinism
+# Config in wasmboard.rs). Pin the version: save-state replay of a plugin's
+# linear-memory snapshot is only guaranteed within one wasmtime build.
+wasmtime = { version = "=27.0.0", default-features = false, features = ["cranelift", "runtime"] }
 # Already pulled in transitively; used directly only for localtime_r (local
 # time-zone filename stamps) and, on macOS, the pthread QoS class used for the
 # optional realtime-priority feature (see src/priority.rs).
@@ -55,6 +61,11 @@ objc2-foundation = { version = "0.3", default-features = false, features = ["NSD
 # the windows-sys it pulls in) never enters the macOS build.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 thread-priority = "3.1"
+
+[dev-dependencies]
+# Compile WAT to wasm bytes in the WASM-plugin-host tests, so golden test
+# plugins live as readable text in the tests rather than checked-in binaries.
+wat = "1"
 
 [lints.clippy]
 # Chipset pipeline functions take per-signal argument lists that mirror the

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -133,6 +133,35 @@ Plugins can be written in any language that targets `wasm32` (Rust, C, Zig,
 ...). An inert example module and its manifest can be generated with the
 ignored test `emit_example_plugin_wasm` (see `src/wasmboard.rs`).
 
+## Networking: the A2065 Ethernet board
+
+Copperline includes an in-tree Commodore A2065 Ethernet board (`src/a2065.rs`),
+an Am7990 LANCE NIC the AmigaOS SANA-II `a2065.device` drives. Fit it from the
+config:
+
+```toml
+[a2065]
+net = "loopback"   # host network backend; "none" for an isolated NIC
+```
+
+Unlike the DMAC boards, the LANCE does not master the Amiga bus: its init
+block, descriptor rings, and packet buffers live in the board's own 32 KiB RAM
+(which the CPU reaches through the board window), so the board is self-contained
+and owns its host network backend directly.
+
+Host network backends live in `src/net.rs` behind the `NetBackend` trait. Built
+in today is **loopback** (transmitted frames are queued straight back -- useful
+for a self-contained demo and for tests); a userspace NAT (libslirp/smoltcp) and
+a host TAP bridge are planned and will slot in behind `make_backend` under build
+features. TAP will require host privileges and interface setup; NAT will not.
+
+**Networking is non-deterministic.** Inbound frames arrive on the host's
+schedule, not the emulated clock, so a fitted A2065 (or any `net`-capable WASM
+plugin) breaks Copperline's byte-identical replay and save-state reproducibility
+while traffic flows -- the emulator logs this when the board is attached. Save
+states record only the chosen backend and bring up a fresh one on load
+(in-flight frames are dropped; the guest's TCP retransmits).
+
 ## How autoconfig works in Copperline
 
 Everything below happens automatically; it is documented so you can debug a

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -9,6 +9,20 @@ metadata files without writing any Rust. The built-in `[memory] fast` and
 device-backed board (see the device-board notes below and the `[scsi]`
 section of [](guide/configuration)).
 
+There are two board kinds:
+
+- **RAM boards** (`type = "ram"`) -- an autoconfig identity over a slab of
+  RAM, described entirely in TOML.
+- **WASM plugin boards** (`type = "wasm"`) -- *functional* boards (registers,
+  interrupts, DMA) whose behaviour is supplied by an external WebAssembly
+  module, loaded at runtime. These let you add a working board without
+  forking and recompiling Copperline. See
+  [WASM plugin boards](#wasm-plugin-boards) below.
+
+Functional boards (the A2091, the CDTV DMAC, and WASM plugins) all implement
+the `ZorroDevice` trait (`src/zorro_device.rs`): the bus drives every board
+through that one boundary for register access, ticking, interrupts, and DMA.
+
 ## Describing a board in TOML
 
 Reference a board metadata file from the main configuration:
@@ -28,7 +42,7 @@ The metadata file:
 # boards/megaram.toml
 name = "MegaRAM"        # human-readable, appears in logs
 zorro = 3               # 2 or 3
-type = "ram"            # board backing; only "ram" so far
+type = "ram"            # "ram" or "wasm"
 size = "64M"
 manufacturer = 0x07DB   # 16-bit autoconfig manufacturer ID
 product = 0x20          # 8-bit product code, unique per manufacturer
@@ -56,6 +70,68 @@ Field notes:
 The spec is validated on load (`BoardSpec::validate`,
 `src/zorro.rs`): bad sizes, unknown `zorro` versions, and unknown backing
 types are reported with the metadata file's path.
+
+## WASM plugin boards
+
+A `type = "wasm"` board is a *functional* board whose behaviour comes from an
+external WebAssembly module (`src/wasmboard.rs`), so you can ship a working
+board -- registers, interrupts, DMA -- as a `.wasm` file plus a TOML manifest,
+with no changes to Copperline.
+
+```toml
+# boards/example.toml
+name = "Example Board"
+zorro = 2
+type = "wasm"
+size = "64K"            # the board's autoconfig window size
+manufacturer = 0x1448
+product = 0x10
+wasm = "example.wasm"   # module path, relative to this metadata file
+dma  = true             # capabilities, all default false:
+int2 = true             #   dma  -> the dma_read/dma_write host imports
+int6 = false            #   int2 -> may assert INT2 (PORTS)
+                        #   int6 -> may assert INT6 (EXTER)
+```
+
+WASM is chosen because a module's entire mutable state lives in its linear
+memory -- a flat byte array that Copperline's save states snapshot and restore
+exactly like Amiga RAM, preserving deterministic replay. The engine is run with
+NaN canonicalization and without SIMD or threads for determinism; a plugin's
+persistent state must live in linear memory (WebAssembly globals are not
+captured). A save state stores the module's path and replays its memory image
+on load, so the `.wasm` file must remain where the manifest points.
+
+### Module ABI
+
+The host calls these exports (all optional except `memory`):
+
+| Export | Signature | Purpose |
+|--------|-----------|---------|
+| `memory` | (linear memory) | required; the board's state lives here |
+| `init` | `() -> ()` | called once after instantiation |
+| `read` | `(off i32, size i32) -> i32` | register read at a window offset |
+| `write` | `(off i32, size i32, value i32)` | register write |
+| `tick` | `(cck i32)` | advance by `cck` colour clocks |
+| `int2` | `() -> i32` | INT2 (PORTS) line state, non-zero = asserted |
+| `int6` | `() -> i32` | INT6 (EXTER) line state |
+
+The plugin may import these host functions from module `env` (gated by the
+manifest capabilities; importing one that was not granted fails to load):
+
+| Import | Signature | Capability |
+|--------|-----------|------------|
+| `log` | `(ptr i32, len i32)` | always available |
+| `dma_read` | `(addr i32, ptr i32, len i32)` | `dma`: Amiga `addr` -> plugin memory `ptr` |
+| `dma_write` | `(addr i32, ptr i32, len i32)` | `dma`: plugin memory `ptr` -> Amiga `addr` |
+
+Interrupt lines are level-sensitive and polled, exactly like the in-tree
+boards: a plugin holds `int2`/`int6` non-zero while the line is asserted, and
+the bus applies the 68000 interrupt-recognition latency automatically -- the
+plugin never pulses INTREQ.
+
+Plugins can be written in any language that targets `wasm32` (Rust, C, Zig,
+...). An inert example module and its manifest can be generated with the
+ignored test `emit_example_plugin_wasm` (see `src/wasmboard.rs`).
 
 ## How autoconfig works in Copperline
 
@@ -146,14 +222,19 @@ board); see the `identify` option in [](guide/configuration).
 
 ## Adding a board in Rust
 
-For board types that need code (a new `BoardBacking` beyond RAM), the flow
-is below; the A2091 (`BoardBacking::A2091`, `src/a2091.rs`) is the worked
-example of a device-backed board:
+Most functional boards should be WASM plugins (above). Add an *in-tree* board
+in Rust only when it needs host integration or performance that a plugin
+cannot give (the A2091 SCSI controller, `src/a2091.rs`, is the worked example).
+In-tree functional boards implement the `ZorroDevice` trait
+(`src/zorro_device.rs`) and are stored as a `BoardDevice` enum variant in
+`Bus::devices`; the chain maps each board's window to a
+`BoardBacking::Device(slot)` index into that vector.
 
-1. Extend `BoardBacking` (`src/zorro.rs`) with the new backing and teach
-   `ZorroChain`'s access paths (`region_at` callers in `src/bus.rs` and
-   `src/cpu.rs`) how reads/writes reach it.
-2. Provide a `BoardSpec` constructor, mirroring the existing ones:
+1. Implement `ZorroDevice` for the board (register `read`/`write`, `tick`,
+   `int2_line`/`int6_line`, `reset`); DMA goes through the `DeviceHost` passed
+   to each call. Add a `BoardDevice` variant wrapping it (`src/zorro_device.rs`).
+2. Provide a `BoardSpec` constructor with `backing: BoardBacking::Device(slot)`,
+   mirroring the existing ones:
 
    ```rust
    pub fn fast_ram(size_bytes: usize) -> Self {
@@ -171,8 +252,10 @@ example of a device-backed board:
    }
    ```
 
-3. Register it in `Config::build_zorro_chain` (`src/config.rs`) or accept
-   it from the metadata loader (`load_board_metadata`, `src/zorro.rs`).
+3. Instantiate the device in `build_machine` (`src/main.rs`): assign it a
+   slot, add its `BoardSpec` to the chain, and push the `BoardDevice` onto
+   `Bus::devices` (the A2091 block is the template). Bump
+   `savestate::STATE_VERSION` if the serialized layout changes.
 4. Add unit tests next to the existing ones in `src/zorro.rs`, which cover
    ROM nibble encoding, Zorro II/III base assignment, chain advance,
    shut-up, and power-on reset -- they are the best worked examples of the

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -133,6 +133,45 @@ Plugins can be written in any language that targets `wasm32` (Rust, C, Zig,
 ...). An inert example module and its manifest can be generated with the
 ignored test `emit_example_plugin_wasm` (see `src/wasmboard.rs`).
 
+### Plugin settings, files, and the config panel
+
+A plugin can take settings and files. The manifest declares defaults in a
+`[config]` table and a schema in `[[option]]` entries:
+
+```toml
+[config]                 # defaults
+mode = "bridged"
+mtu = 1500
+[[option]]               # schema (drives the launcher's config panel)
+key = "mode"
+label = "Mode"
+type = "enum"            # string | bool | int | file | enum
+choices = ["bridged", "nat"]
+[[option]]
+key = "rom"
+label = "Boot ROM"
+type = "file"            # the host loads the file and exposes it as a resource
+```
+
+At runtime the module reads a setting via the `config_get` host import, and a
+file-typed option's bytes via `resource_len` / `resource_read` (keyed by the
+option's `key`). For an autoboot ROM, the plugin copies the `rom` resource into
+its linear memory at `init` and serves those bytes from `read()`, with `diag_vec`
+set in the manifest -- just like the in-tree A2091.
+
+The user overrides settings per board in the main config, layered over the
+manifest defaults:
+
+```toml
+[[zorro]]
+metadata = "boards/nic.toml"
+config = { mode = "nat", rom = "boot.rom" }
+```
+
+The machine-configuration launcher renders the `[[option]]` schema as an
+editable field per option (enum/int steppers, a bool toggle, a file picker, and
+a text box for strings), writing changes back as these per-board overrides.
+
 ## Networking: the A2065 Ethernet board
 
 Copperline includes an in-tree Commodore A2065 Ethernet board (`src/a2065.rs`),

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -223,6 +223,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ar_archive_writer/ar_archive_writer-0.5.2.crate",
+        "sha256": "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348",
+        "dest": "cargo/vendor/ar_archive_writer-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348\", \"files\": {}}",
+        "dest": "cargo/vendor/ar_archive_writer-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arbitrary/arbitrary-1.4.2.crate",
+        "sha256": "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1",
+        "dest": "cargo/vendor/arbitrary-1.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1\", \"files\": {}}",
+        "dest": "cargo/vendor/arbitrary-1.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.9.crate",
         "sha256": "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb",
         "dest": "cargo/vendor/arrayref-0.3.9"
@@ -561,6 +587,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cobs/cobs-0.3.0.crate",
+        "sha256": "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1",
+        "dest": "cargo/vendor/cobs-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1\", \"files\": {}}",
+        "dest": "cargo/vendor/cobs-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/codespan-reporting/codespan-reporting-0.13.1.crate",
         "sha256": "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681",
         "dest": "cargo/vendor/codespan-reporting-0.13.1"
@@ -699,6 +738,136 @@
         "type": "inline",
         "contents": "{\"package\": \"873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779\", \"files\": {}}",
         "dest": "cargo/vendor/cpal-0.15.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-bforest/cranelift-bforest-0.114.0.crate",
+        "sha256": "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1",
+        "dest": "cargo/vendor/cranelift-bforest-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-bforest-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-bitset/cranelift-bitset-0.114.0.crate",
+        "sha256": "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156",
+        "dest": "cargo/vendor/cranelift-bitset-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-bitset-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-codegen/cranelift-codegen-0.114.0.crate",
+        "sha256": "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b",
+        "dest": "cargo/vendor/cranelift-codegen-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-codegen-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-codegen-meta/cranelift-codegen-meta-0.114.0.crate",
+        "sha256": "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7",
+        "dest": "cargo/vendor/cranelift-codegen-meta-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-codegen-meta-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-codegen-shared/cranelift-codegen-shared-0.114.0.crate",
+        "sha256": "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895",
+        "dest": "cargo/vendor/cranelift-codegen-shared-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-codegen-shared-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-control/cranelift-control-0.114.0.crate",
+        "sha256": "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec",
+        "dest": "cargo/vendor/cranelift-control-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-control-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-entity/cranelift-entity-0.114.0.crate",
+        "sha256": "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96",
+        "dest": "cargo/vendor/cranelift-entity-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-entity-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-frontend/cranelift-frontend-0.114.0.crate",
+        "sha256": "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e",
+        "dest": "cargo/vendor/cranelift-frontend-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-frontend-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-isle/cranelift-isle-0.114.0.crate",
+        "sha256": "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8",
+        "dest": "cargo/vendor/cranelift-isle-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-isle-0.114.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-native/cranelift-native-0.114.0.crate",
+        "sha256": "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f",
+        "dest": "cargo/vendor/cranelift-native-0.114.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-native-0.114.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -860,6 +1029,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embedded-io/embedded-io-0.4.0.crate",
+        "sha256": "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced",
+        "dest": "cargo/vendor/embedded-io-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced\", \"files\": {}}",
+        "dest": "cargo/vendor/embedded-io-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embedded-io/embedded-io-0.6.1.crate",
+        "sha256": "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d",
+        "dest": "cargo/vendor/embedded-io-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d\", \"files\": {}}",
+        "dest": "cargo/vendor/embedded-io-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/env_filter/env_filter-1.0.1.crate",
         "sha256": "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef",
         "dest": "cargo/vendor/env_filter-1.0.1"
@@ -907,6 +1102,19 @@
         "type": "inline",
         "contents": "{\"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\", \"files\": {}}",
         "dest": "cargo/vendor/errno-0.3.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fallible-iterator/fallible-iterator-0.3.0.crate",
+        "sha256": "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649",
+        "dest": "cargo/vendor/fallible-iterator-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649\", \"files\": {}}",
+        "dest": "cargo/vendor/fallible-iterator-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1120,6 +1328,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gimli/gimli-0.31.1.crate",
+        "sha256": "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f",
+        "dest": "cargo/vendor/gimli-0.31.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f\", \"files\": {}}",
+        "dest": "cargo/vendor/gimli-0.31.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gl_generator/gl_generator-0.14.0.crate",
         "sha256": "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d",
         "dest": "cargo/vendor/gl_generator-0.14.0"
@@ -1224,6 +1445,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.5.crate",
+        "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+        "dest": "cargo/vendor/hashbrown-0.14.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.14.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.15.5.crate",
         "sha256": "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1",
         "dest": "cargo/vendor/hashbrown-0.15.5"
@@ -1263,6 +1497,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
+        "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+        "dest": "cargo/vendor/heck-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.5.2.crate",
         "sha256": "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c",
         "dest": "cargo/vendor/hermit-abi-0.5.2"
@@ -1297,6 +1544,19 @@
         "type": "inline",
         "contents": "{\"package\": \"62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f\", \"files\": {}}",
         "dest": "cargo/vendor/hound-3.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/id-arena/id-arena-2.3.0.crate",
+        "sha256": "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954",
+        "dest": "cargo/vendor/id-arena-2.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\", \"files\": {}}",
+        "dest": "cargo/vendor/id-arena-2.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1354,6 +1614,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.12.1.crate",
+        "sha256": "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569",
+        "dest": "cargo/vendor/itertools-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/itertools/itertools-0.13.0.crate",
         "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
         "dest": "cargo/vendor/itertools-0.13.0"
@@ -1362,6 +1635,19 @@
         "type": "inline",
         "contents": "{\"package\": \"413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186\", \"files\": {}}",
         "dest": "cargo/vendor/itertools-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.18.crate",
+        "sha256": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682",
+        "dest": "cargo/vendor/itoa-1.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1523,6 +1809,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/leb128/leb128-0.2.7.crate",
+        "sha256": "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52",
+        "dest": "cargo/vendor/leb128-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52\", \"files\": {}}",
+        "dest": "cargo/vendor/leb128-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/leb128fmt/leb128fmt-0.1.0.crate",
+        "sha256": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2",
+        "dest": "cargo/vendor/leb128fmt-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\", \"files\": {}}",
+        "dest": "cargo/vendor/leb128fmt-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libc/libc-0.2.186.crate",
         "sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
         "dest": "cargo/vendor/libc-0.2.186"
@@ -1674,6 +1986,19 @@
         "type": "inline",
         "contents": "{\"package\": \"6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8\", \"files\": {}}",
         "dest": "cargo/vendor/memchr-2.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memfd/memfd-0.6.5.crate",
+        "sha256": "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227",
+        "dest": "cargo/vendor/memfd-0.6.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227\", \"files\": {}}",
+        "dest": "cargo/vendor/memfd-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2186,6 +2511,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/object/object-0.36.7.crate",
+        "sha256": "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87",
+        "dest": "cargo/vendor/object-0.36.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87\", \"files\": {}}",
+        "dest": "cargo/vendor/object-0.36.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/object/object-0.37.3.crate",
+        "sha256": "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe",
+        "dest": "cargo/vendor/object-0.37.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe\", \"files\": {}}",
+        "dest": "cargo/vendor/object-0.37.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/oboe/oboe-0.6.1.crate",
         "sha256": "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb",
         "dest": "cargo/vendor/oboe-0.6.1"
@@ -2298,6 +2649,19 @@
         "type": "inline",
         "contents": "{\"package\": \"2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1\", \"files\": {}}",
         "dest": "cargo/vendor/parking_lot_core-0.9.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/paste/paste-1.0.15.crate",
+        "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
+        "dest": "cargo/vendor/paste-1.0.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-1.0.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2459,6 +2823,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/postcard/postcard-1.1.3.crate",
+        "sha256": "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24",
+        "dest": "cargo/vendor/postcard-1.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24\", \"files\": {}}",
+        "dest": "cargo/vendor/postcard-1.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/presser/presser-0.3.1.crate",
         "sha256": "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa",
         "dest": "cargo/vendor/presser-0.3.1"
@@ -2506,6 +2883,32 @@
         "type": "inline",
         "contents": "{\"package\": \"3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5\", \"files\": {}}",
         "dest": "cargo/vendor/profiling-1.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/psm/psm-0.1.31.crate",
+        "sha256": "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea",
+        "dest": "cargo/vendor/psm-0.1.31"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea\", \"files\": {}}",
+        "dest": "cargo/vendor/psm-0.1.31",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pulley-interpreter/pulley-interpreter-27.0.0.crate",
+        "sha256": "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb",
+        "dest": "cargo/vendor/pulley-interpreter-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb\", \"files\": {}}",
+        "dest": "cargo/vendor/pulley-interpreter-27.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2623,6 +3026,19 @@
         "type": "inline",
         "contents": "{\"package\": \"5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7\", \"files\": {}}",
         "dest": "cargo/vendor/redox_syscall-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regalloc2/regalloc2-0.10.2.crate",
+        "sha256": "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0",
+        "dest": "cargo/vendor/regalloc2-0.10.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0\", \"files\": {}}",
+        "dest": "cargo/vendor/regalloc2-0.10.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2914,6 +3330,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.150.crate",
+        "sha256": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9",
+        "dest": "cargo/vendor/serde_json-1.0.150"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.150",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.9.crate",
         "sha256": "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3",
         "dest": "cargo/vendor/serde_spanned-0.6.9"
@@ -3005,6 +3434,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slice-group-by/slice-group-by-0.3.1.crate",
+        "sha256": "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7",
+        "dest": "cargo/vendor/slice-group-by-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7\", \"files\": {}}",
+        "dest": "cargo/vendor/slice-group-by-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/slotmap/slotmap-1.1.1.crate",
         "sha256": "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038",
         "dest": "cargo/vendor/slotmap-1.1.1"
@@ -3070,6 +3512,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sptr/sptr-0.3.2.crate",
+        "sha256": "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a",
+        "dest": "cargo/vendor/sptr-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a\", \"files\": {}}",
+        "dest": "cargo/vendor/sptr-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.1.crate",
+        "sha256": "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596\", \"files\": {}}",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
         "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
         "dest": "cargo/vendor/static_assertions-1.1.0"
@@ -3104,6 +3572,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99\", \"files\": {}}",
         "dest": "cargo/vendor/syn-2.0.117",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
+        "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
+        "dest": "cargo/vendor/target-lexicon-0.12.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.12.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3395,6 +3876,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
+        "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
+        "dest": "cargo/vendor/unicode-xid-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-xid-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.2.crate",
         "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
         "dest": "cargo/vendor/utf8parse-0.2.2"
@@ -3533,6 +4027,227 @@
         "type": "inline",
         "contents": "{\"package\": \"9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-shared-0.2.122",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.219.2.crate",
+        "sha256": "8aa79bcd666a043b58f5fa62b221b0b914dd901e6f620e8ab7371057a797f3e1",
+        "dest": "cargo/vendor/wasm-encoder-0.219.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8aa79bcd666a043b58f5fa62b221b0b914dd901e6f620e8ab7371057a797f3e1\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-encoder-0.219.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.252.0.crate",
+        "sha256": "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f",
+        "dest": "cargo/vendor/wasm-encoder-0.252.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-encoder-0.252.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.219.2.crate",
+        "sha256": "5220ee4c6ffcc0cb9d7c47398052203bc902c8ef3985b0c8134118440c0b2921",
+        "dest": "cargo/vendor/wasmparser-0.219.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5220ee4c6ffcc0cb9d7c47398052203bc902c8ef3985b0c8134118440c0b2921\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmparser-0.219.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.252.0.crate",
+        "sha256": "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c",
+        "dest": "cargo/vendor/wasmparser-0.252.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmparser-0.252.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmprinter/wasmprinter-0.219.2.crate",
+        "sha256": "c68c93bcc5e934985afd8b65214bdd77abd3863b2e1855eae1b07a11c4ef30a8",
+        "dest": "cargo/vendor/wasmprinter-0.219.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c68c93bcc5e934985afd8b65214bdd77abd3863b2e1855eae1b07a11c4ef30a8\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmprinter-0.219.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime/wasmtime-27.0.0.crate",
+        "sha256": "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b",
+        "dest": "cargo/vendor/wasmtime-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-asm-macros/wasmtime-asm-macros-27.0.0.crate",
+        "sha256": "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28",
+        "dest": "cargo/vendor/wasmtime-asm-macros-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-asm-macros-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-component-macro/wasmtime-component-macro-27.0.0.crate",
+        "sha256": "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b",
+        "dest": "cargo/vendor/wasmtime-component-macro-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-component-macro-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-component-util/wasmtime-component-util-27.0.0.crate",
+        "sha256": "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2",
+        "dest": "cargo/vendor/wasmtime-component-util-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-component-util-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-cranelift/wasmtime-cranelift-27.0.0.crate",
+        "sha256": "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906",
+        "dest": "cargo/vendor/wasmtime-cranelift-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-cranelift-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-environ/wasmtime-environ-27.0.0.crate",
+        "sha256": "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27",
+        "dest": "cargo/vendor/wasmtime-environ-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-environ-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/wasmtime-jit-icache-coherence-27.0.0.crate",
+        "sha256": "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad",
+        "dest": "cargo/vendor/wasmtime-jit-icache-coherence-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-jit-icache-coherence-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-slab/wasmtime-slab-27.0.0.crate",
+        "sha256": "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea",
+        "dest": "cargo/vendor/wasmtime-slab-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-slab-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/wasmtime-versioned-export-macros-27.0.0.crate",
+        "sha256": "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6",
+        "dest": "cargo/vendor/wasmtime-versioned-export-macros-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-versioned-export-macros-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/wasmtime-wit-bindgen-27.0.0.crate",
+        "sha256": "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e",
+        "dest": "cargo/vendor/wasmtime-wit-bindgen-27.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-wit-bindgen-27.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wast/wast-252.0.0.crate",
+        "sha256": "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65",
+        "dest": "cargo/vendor/wast-252.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65\", \"files\": {}}",
+        "dest": "cargo/vendor/wast-252.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wat/wat-1.252.0.crate",
+        "sha256": "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb",
+        "dest": "cargo/vendor/wat-1.252.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb\", \"files\": {}}",
+        "dest": "cargo/vendor/wat-1.252.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4331,6 +5046,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-parser/wit-parser-0.219.2.crate",
+        "sha256": "ca004bb251010fe956f4a5b9d4bf86b4e415064160dd6669569939e8cbf2504f",
+        "dest": "cargo/vendor/wit-parser-0.219.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca004bb251010fe956f4a5b9d4bf86b4e415064160dd6669569939e8cbf2504f\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-parser-0.219.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/x11-dl/x11-dl-2.21.0.crate",
         "sha256": "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f",
         "dest": "cargo/vendor/x11-dl-2.21.0"
@@ -4443,6 +5171,19 @@
         "type": "inline",
         "contents": "{\"package\": \"0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639\", \"files\": {}}",
         "dest": "cargo/vendor/zerocopy-derive-0.8.50",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zmij/zmij-1.0.21.crate",
+        "sha256": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa",
+        "dest": "cargo/vendor/zmij-1.0.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa\", \"files\": {}}",
+        "dest": "cargo/vendor/zmij-1.0.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/a2065.rs
+++ b/src/a2065.rs
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Commodore A2065 Ethernet board: a Zorro II autoconfig board carrying an
+//! Am7990 LANCE and 32 KiB of on-board RAM, driven by the AmigaOS SANA-II
+//! `a2065.device`.
+//!
+//! Unlike the A2091/CDTV DMACs, the LANCE does not master the Amiga bus: its
+//! init block, descriptor rings, and packet buffers all live in the board's own
+//! 32 KiB RAM, which the CPU also reaches through the board window. So this
+//! board is self-contained -- it owns a [`crate::net::NetBackend`] for real
+//! frames and never touches Amiga chip RAM.
+//!
+//! Board window layout (per the Linux `a2065` driver and WinUAE):
+//! - `$0000..`     MAC address PROM (the station address the driver reads)
+//! - `$4000`       LANCE RDP (register data port), `$4002` RAP (address port)
+//! - `$8000..$FFFF` 32 KiB shared RAM (LANCE address 0 maps here)
+//!
+//! The LANCE programming model (Am7990 datasheet): the host selects a CSR via
+//! RAP and reads/writes it via RDP. CSR1/CSR2 hold the init-block address; on
+//! INIT the chip reads the init block (mode, MAC, RX/TX ring base + length) from
+//! RAM, and on STRT it services the rings. Transmit descriptors the host hands
+//! to the chip (OWN bit set) are sent; inbound frames are written into receive
+//! descriptors the host left owned by the chip. RINT/TINT in CSR0 raise INT2
+//! when interrupts are enabled.
+//!
+//! Word fields in the init block and descriptors are accessed big-endian, the
+//! layout a 68000 driver writes with the LANCE's byte-swap (CSR3 BSWP) set;
+//! packet payloads are byte streams and are not swapped. Note: this models the
+//! documented LANCE behaviour and is unit-tested against the programming model,
+//! but has not yet been validated end-to-end against `a2065.device` plus a guest
+//! TCP/IP stack -- see the tests and the Zorro chapter in the docs.
+
+use crate::net::{make_backend, NetBackend, NetConfig};
+use crate::zorro_device::{DeviceHost, ZorroDevice};
+use serde::{Deserialize, Serialize};
+
+const REG_RDP: u32 = 0x4000;
+const REG_RAP: u32 = 0x4002;
+const RAM_BASE: u32 = 0x8000;
+const RAM_SIZE: usize = 0x8000; // 32 KiB on-board RAM
+
+// CSR0 bits (Am7990).
+const CSR0_INIT: u16 = 1 << 0;
+const CSR0_STRT: u16 = 1 << 1;
+const CSR0_STOP: u16 = 1 << 2;
+const CSR0_TDMD: u16 = 1 << 3;
+const CSR0_TXON: u16 = 1 << 4;
+const CSR0_RXON: u16 = 1 << 5;
+const CSR0_INEA: u16 = 1 << 6;
+const CSR0_INTR: u16 = 1 << 7;
+const CSR0_IDON: u16 = 1 << 8;
+const CSR0_TINT: u16 = 1 << 9;
+const CSR0_RINT: u16 = 1 << 10;
+const CSR0_ERR: u16 = 1 << 15;
+/// Status bits the host clears by writing 1 (the rest of CSR0 is control).
+const CSR0_RC_BITS: u16 = CSR0_IDON | CSR0_TINT | CSR0_RINT | (0xF << 11) | CSR0_ERR;
+
+// Descriptor status byte (high byte of the second word).
+const DESC_OWN: u8 = 1 << 7;
+const DESC_STP: u8 = 1 << 1;
+const DESC_ENP: u8 = 1 << 0;
+
+/// Largest Ethernet frame the chip will move (no jumbo frames).
+const MAX_FRAME: usize = 1518;
+
+#[derive(Serialize, Deserialize)]
+pub struct A2065 {
+    /// Synthesized station MAC (locally administered).
+    mac: [u8; 6],
+    /// 32 KiB on-board RAM (LANCE address space and CPU window share it).
+    ram: Vec<u8>,
+    /// Which host backend to bring up (recorded so a save state is
+    /// self-contained); the live backend is a non-serialized host resource.
+    net_config: NetConfig,
+
+    // LANCE registers.
+    rap: u16,
+    csr0: u16,
+    csr1: u16,
+    csr2: u16,
+    csr3: u16,
+
+    // Ring state derived from the init block on INIT.
+    rx_ring: u32,
+    rx_len: u32,
+    rx_mask: u32,
+    rx_cur: u32,
+    tx_ring: u32,
+    tx_len: u32,
+    tx_mask: u32,
+    tx_cur: u32,
+    running: bool,
+
+    /// HDD/activity-style LED latch (board activity).
+    activity: bool,
+
+    /// Live host network backend; rebuilt from `net_config`, not serialized.
+    #[serde(skip)]
+    net: Option<Box<dyn NetBackend>>,
+}
+
+impl A2065 {
+    pub fn new(net_config: NetConfig) -> Self {
+        // A locally-administered MAC (02:..) derived from a fixed prefix; a
+        // real board reads this from a PROM.
+        let mac = [0x02, 0x00, 0x10, 0x00, 0x00, 0x01];
+        Self {
+            mac,
+            ram: vec![0u8; RAM_SIZE],
+            net_config,
+            rap: 0,
+            csr0: CSR0_STOP,
+            csr1: 0,
+            csr2: 0,
+            csr3: 0,
+            rx_ring: 0,
+            rx_len: 0,
+            rx_mask: 0,
+            rx_cur: 0,
+            tx_ring: 0,
+            tx_len: 0,
+            tx_mask: 0,
+            tx_cur: 0,
+            running: false,
+            activity: false,
+            net: make_backend(net_config),
+        }
+    }
+
+    /// Reattach the live network backend after a save-state load (the backend
+    /// is a host resource and is brought up fresh, like an audio sink).
+    fn ensure_backend(&mut self) {
+        if self.net.is_none() {
+            self.net = make_backend(self.net_config);
+        }
+    }
+
+    // ----- board RAM word access (big-endian) ----------------------------
+
+    fn ram_word(&self, addr: u32) -> u16 {
+        let a = (addr as usize) & (RAM_SIZE - 1);
+        if a + 1 < RAM_SIZE {
+            (u16::from(self.ram[a]) << 8) | u16::from(self.ram[a + 1])
+        } else {
+            0
+        }
+    }
+
+    fn set_ram_word(&mut self, addr: u32, w: u16) {
+        let a = (addr as usize) & (RAM_SIZE - 1);
+        if a + 1 < RAM_SIZE {
+            self.ram[a] = (w >> 8) as u8;
+            self.ram[a + 1] = w as u8;
+        }
+    }
+
+    // ----- LANCE engine ---------------------------------------------------
+
+    fn init_block_addr(&self) -> u32 {
+        (u32::from(self.csr1) | (u32::from(self.csr2 & 0xFF) << 16)) & !1
+    }
+
+    /// Read the init block (Am7990 layout) from board RAM and set up the rings.
+    fn lance_init(&mut self) {
+        let iadr = self.init_block_addr();
+        // +0 MODE, +2..+8 PADR (MAC), +8..+10 LADRF (filter, ignored).
+        let _mode = self.ram_word(iadr);
+        for i in 0..3 {
+            let w = self.ram_word(iadr + 2 + i * 2);
+            // PADR is stored low-byte-first per word in LANCE order.
+            self.mac[i as usize * 2] = w as u8;
+            self.mac[i as usize * 2 + 1] = (w >> 8) as u8;
+        }
+        // +$10 RDRA[15:0], +$12 (RLEN<<13) | RDRA[23:16].
+        let rdra_lo = self.ram_word(iadr + 0x10);
+        let rdra_hi = self.ram_word(iadr + 0x12);
+        self.rx_ring = u32::from(rdra_lo) | (u32::from(rdra_hi & 0xFF) << 16);
+        self.rx_len = 1 << ((rdra_hi >> 13) & 0x7);
+        self.rx_mask = self.rx_len - 1;
+        self.rx_cur = 0;
+        // +$14 TDRA[15:0], +$16 (TLEN<<13) | TDRA[23:16].
+        let tdra_lo = self.ram_word(iadr + 0x14);
+        let tdra_hi = self.ram_word(iadr + 0x16);
+        self.tx_ring = u32::from(tdra_lo) | (u32::from(tdra_hi & 0xFF) << 16);
+        self.tx_len = 1 << ((tdra_hi >> 13) & 0x7);
+        self.tx_mask = self.tx_len - 1;
+        self.tx_cur = 0;
+        self.csr0 |= CSR0_IDON;
+    }
+
+    /// Address of descriptor `n` (8 bytes each) in a ring.
+    fn desc_addr(ring: u32, n: u32) -> u32 {
+        ring + n * 8
+    }
+
+    fn desc_buffer(&self, dbase: u32) -> (u32, usize) {
+        let ladr = self.ram_word(dbase);
+        let mid = self.ram_word(dbase + 2); // status<<8 | HADR
+        let hadr = (mid & 0xFF) as u32;
+        let addr = u32::from(ladr) | (hadr << 16);
+        // BCNT at +4 is a two's-complement negative count in bits 0..11.
+        let bcnt = self.ram_word(dbase + 4);
+        let len = (((!bcnt) & 0x0FFF) + 1) as usize;
+        (addr, len)
+    }
+
+    fn desc_status(&self, dbase: u32) -> u8 {
+        (self.ram_word(dbase + 2) >> 8) as u8
+    }
+
+    fn set_desc_status(&mut self, dbase: u32, status: u8) {
+        let w = self.ram_word(dbase + 2);
+        self.set_ram_word(dbase + 2, (u16::from(status) << 8) | (w & 0xFF));
+    }
+
+    /// Walk the TX ring, sending every chip-owned descriptor.
+    fn poll_tx(&mut self) {
+        if !self.running || self.tx_len == 0 {
+            return;
+        }
+        for _ in 0..self.tx_len {
+            let dbase = Self::desc_addr(self.tx_ring, self.tx_cur);
+            let status = self.desc_status(dbase);
+            if status & DESC_OWN == 0 {
+                break; // host still owns it: nothing to send
+            }
+            let (buf_addr, len) = self.desc_buffer(dbase);
+            let len = len.min(MAX_FRAME);
+            let mut frame = vec![0u8; len];
+            for (i, b) in frame.iter_mut().enumerate() {
+                let a = (buf_addr as usize + i) & (RAM_SIZE - 1);
+                *b = self.ram[a];
+            }
+            if let Some(net) = self.net.as_mut() {
+                net.send(&frame);
+            }
+            self.activity = true;
+            // Hand the descriptor back to the host, clearing OWN.
+            self.set_desc_status(dbase, status & !DESC_OWN);
+            self.csr0 |= CSR0_TINT;
+            self.tx_cur = (self.tx_cur + 1) & self.tx_mask;
+        }
+    }
+
+    /// Deliver one inbound frame into the next chip-owned RX descriptor.
+    fn receive_frame(&mut self, frame: &[u8]) -> bool {
+        if !self.running || self.rx_len == 0 {
+            return false;
+        }
+        let dbase = Self::desc_addr(self.rx_ring, self.rx_cur);
+        let status = self.desc_status(dbase);
+        if status & DESC_OWN == 0 {
+            return false; // no free descriptor: drop (MISS would be set on HW)
+        }
+        let (buf_addr, cap) = self.desc_buffer(dbase);
+        let n = frame.len().min(cap).min(MAX_FRAME);
+        for (i, b) in frame.iter().take(n).enumerate() {
+            let a = (buf_addr as usize + i) & (RAM_SIZE - 1);
+            self.ram[a] = *b;
+        }
+        // MCNT (message byte count) at +6, plus STP|ENP and OWN cleared.
+        self.set_ram_word(dbase + 6, n as u16);
+        self.set_desc_status(dbase, (status & !DESC_OWN) | DESC_STP | DESC_ENP);
+        self.activity = true;
+        self.csr0 |= CSR0_RINT;
+        self.rx_cur = (self.rx_cur + 1) & self.rx_mask;
+        true
+    }
+
+    // ----- CSR access -----------------------------------------------------
+
+    fn read_csr(&self) -> u16 {
+        match self.rap & 3 {
+            0 => self.csr0_value(),
+            1 => self.csr1,
+            2 => self.csr2,
+            _ => self.csr3,
+        }
+    }
+
+    /// CSR0 with its derived summary bits (INTR, ERR) folded in.
+    fn csr0_value(&self) -> u16 {
+        let mut v = self.csr0;
+        let err = v & (CSR0_ERR | (0xF << 11)); // BABL|CERR|MISS|MERR rolled up
+        if err != 0 {
+            v |= CSR0_ERR;
+        }
+        if (v & (CSR0_ERR | CSR0_IDON | CSR0_TINT | CSR0_RINT)) != 0 && (v & CSR0_INEA) != 0 {
+            v |= CSR0_INTR;
+        }
+        v
+    }
+
+    fn write_csr(&mut self, val: u16) {
+        match self.rap & 3 {
+            0 => self.write_csr0(val),
+            1 => self.csr1 = val & !1,
+            2 => self.csr2 = val & 0xFF,
+            3 => self.csr3 = val & 0x7,
+            _ => {}
+        }
+    }
+
+    fn write_csr0(&mut self, val: u16) {
+        if val & CSR0_STOP != 0 {
+            // STOP resets the chip to idle.
+            self.csr0 = CSR0_STOP;
+            self.running = false;
+            return;
+        }
+        // Clear the status bits the host wrote 1 to.
+        self.csr0 &= !(val & CSR0_RC_BITS);
+        // INEA is read/write.
+        if val & CSR0_INEA != 0 {
+            self.csr0 |= CSR0_INEA;
+        } else {
+            self.csr0 &= !CSR0_INEA;
+        }
+        self.csr0 &= !CSR0_STOP;
+        if val & CSR0_INIT != 0 {
+            self.lance_init();
+        }
+        if val & CSR0_STRT != 0 {
+            self.running = true;
+            self.csr0 |= CSR0_TXON | CSR0_RXON;
+        }
+        if val & CSR0_TDMD != 0 {
+            self.poll_tx();
+        }
+    }
+
+    fn int_line(&self) -> bool {
+        self.csr0_value() & CSR0_INTR != 0
+    }
+}
+
+impl ZorroDevice for A2065 {
+    fn read(&mut self, off: u32, size: usize, _host: &mut DeviceHost) -> u32 {
+        let mut value = 0u32;
+        for i in 0..size as u32 {
+            value = (value << 8) | u32::from(self.read_byte(off + i));
+        }
+        value
+    }
+
+    fn write(&mut self, off: u32, size: usize, value: u32, _host: &mut DeviceHost) {
+        // The LANCE registers are word ports; gather a word write and apply it
+        // once. RAM is byte-addressable.
+        if off == REG_RDP || off == REG_RAP {
+            let w = value as u16;
+            if off == REG_RDP {
+                self.write_csr(w);
+            } else {
+                self.rap = w & 3;
+            }
+            return;
+        }
+        for i in 0..size as u32 {
+            let shift = 8 * (size as u32 - 1 - i);
+            self.write_byte(off + i, (value >> shift) as u8);
+        }
+    }
+
+    fn tick(&mut self, _cck: u32, _host: &mut DeviceHost) {
+        // Pull any inbound frames the backend has queued into the RX ring.
+        self.ensure_backend();
+        while self.running {
+            let frame = match self.net.as_mut().and_then(|n| n.poll()) {
+                Some(f) => f,
+                None => break,
+            };
+            if !self.receive_frame(&frame) {
+                break; // ring full: leave the frame for next time would need a
+                       // queue; for now it is dropped (a real chip sets MISS)
+            }
+        }
+    }
+
+    fn int2_line(&self) -> bool {
+        self.int_line()
+    }
+
+    fn is_idle(&self) -> bool {
+        false
+    }
+
+    fn take_activity(&mut self) -> bool {
+        std::mem::take(&mut self.activity)
+    }
+
+    fn reset(&mut self) {
+        self.rap = 0;
+        self.csr0 = CSR0_STOP;
+        self.csr1 = 0;
+        self.csr2 = 0;
+        self.csr3 = 0;
+        self.running = false;
+        self.ram.fill(0);
+        self.net = make_backend(self.net_config);
+    }
+
+    fn kind(&self) -> &'static str {
+        "a2065"
+    }
+}
+
+impl A2065 {
+    fn read_byte(&self, off: u32) -> u8 {
+        match off {
+            // RDP/RAP are word ports; a byte read takes the relevant half.
+            REG_RDP | 0x4001 => {
+                let w = self.read_csr();
+                if off & 1 == 0 {
+                    (w >> 8) as u8
+                } else {
+                    w as u8
+                }
+            }
+            REG_RAP | 0x4003 => {
+                if off & 1 == 0 {
+                    (self.rap >> 8) as u8
+                } else {
+                    self.rap as u8
+                }
+            }
+            _ if off < 12 => {
+                // MAC PROM at even byte offsets 0,2,4,...; odd bytes read 0.
+                if off & 1 == 0 {
+                    self.mac[(off / 2) as usize]
+                } else {
+                    0
+                }
+            }
+            _ if (RAM_BASE..RAM_BASE + RAM_SIZE as u32).contains(&off) => {
+                self.ram[(off - RAM_BASE) as usize]
+            }
+            _ => 0xFF,
+        }
+    }
+
+    fn write_byte(&mut self, off: u32, b: u8) {
+        if (RAM_BASE..RAM_BASE + RAM_SIZE as u32).contains(&off) {
+            self.ram[(off - RAM_BASE) as usize] = b;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host_mem() -> crate::memory::Memory {
+        crate::memory::Memory {
+            chip_ram: vec![0u8; 0x100],
+            slow_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    /// Drive a CSR write the way the driver does: RAP <- n, then RDP <- value.
+    fn write_csr(board: &mut A2065, mem: &mut crate::memory::Memory, csr: u16, val: u16) {
+        let mut host = DeviceHost::new(mem);
+        board.write(REG_RAP, 2, u32::from(csr), &mut host);
+        board.write(REG_RDP, 2, u32::from(val), &mut host);
+    }
+
+    fn read_csr(board: &mut A2065, mem: &mut crate::memory::Memory, csr: u16) -> u16 {
+        let mut host = DeviceHost::new(mem);
+        board.write(REG_RAP, 2, u32::from(csr), &mut host);
+        board.read(REG_RDP, 2, &mut host) as u16
+    }
+
+    /// Lay an init block + a 1-entry RX ring and 1-entry TX ring into board RAM,
+    /// with buffers, and point CSR1/CSR2 at the init block. Returns the LANCE
+    /// addresses of the TX and RX buffers.
+    fn set_up_rings(board: &mut A2065, mem: &mut crate::memory::Memory) -> (u32, u32) {
+        // Layout in board RAM (LANCE addresses):
+        //   init block @ 0x000, RX ring @ 0x100, TX ring @ 0x200,
+        //   RX buffer @ 0x400, TX buffer @ 0x600.
+        let iadr = 0x000u32;
+        let rx_ring = 0x100u32;
+        let tx_ring = 0x200u32;
+        let rx_buf = 0x400u32;
+        let tx_buf = 0x600u32;
+
+        // helper to write a word at a LANCE address through the CPU window.
+        let put = |board: &mut A2065, mem: &mut crate::memory::Memory, addr: u32, w: u16| {
+            let mut host = DeviceHost::new(mem);
+            board.write(RAM_BASE + addr, 2, u32::from(w), &mut host);
+        };
+
+        // Init block: MODE=0, PADR (MAC), LADRF=0, RDRA/RLEN, TDRA/TLEN.
+        put(board, mem, iadr, 0); // mode
+        put(board, mem, iadr + 2, 0x0201); // PADR word0 (low-first): 02,01? test only
+        put(board, mem, iadr + 4, 0x0403);
+        put(board, mem, iadr + 6, 0x0605);
+        // RX ring: RLEN log2 = 0 (1 entry) in bits 13-15.
+        put(board, mem, iadr + 0x10, rx_ring as u16);
+        put(
+            board,
+            mem,
+            iadr + 0x12,
+            (0 << 13) | ((rx_ring >> 16) as u16 & 0xFF),
+        );
+        // TX ring: TLEN log2 = 0.
+        put(board, mem, iadr + 0x14, tx_ring as u16);
+        put(
+            board,
+            mem,
+            iadr + 0x16,
+            (0 << 13) | ((tx_ring >> 16) as u16 & 0xFF),
+        );
+
+        // RX descriptor 0: buffer @ rx_buf, OWN=chip, BCNT = -256.
+        put(board, mem, rx_ring, rx_buf as u16);
+        put(
+            board,
+            mem,
+            rx_ring + 2,
+            (u16::from(DESC_OWN) << 8) | ((rx_buf >> 16) as u16 & 0xFF),
+        );
+        put(board, mem, rx_ring + 4, 0xF000 | (((!256u16) + 1) & 0x0FFF));
+
+        // TX descriptor 0: host-owned initially (OWN=0).
+        put(board, mem, tx_ring, tx_buf as u16);
+        put(board, mem, tx_ring + 2, (tx_buf >> 16) as u16 & 0xFF);
+
+        // Point CSR1/CSR2 at the init block.
+        write_csr(board, mem, 1, iadr as u16);
+        write_csr(board, mem, 2, (iadr >> 16) as u16);
+        (tx_buf, rx_buf)
+    }
+
+    #[test]
+    fn rap_selects_csr_and_init_done_sets_idon() {
+        let mut board = A2065::new(NetConfig::Loopback);
+        let mut mem = host_mem();
+        set_up_rings(&mut board, &mut mem);
+
+        // INIT then STRT.
+        write_csr(&mut board, &mut mem, 0, CSR0_INIT);
+        assert_ne!(read_csr(&mut board, &mut mem, 0) & CSR0_IDON, 0);
+        write_csr(&mut board, &mut mem, 0, CSR0_STRT);
+        assert_ne!(read_csr(&mut board, &mut mem, 0) & CSR0_RXON, 0);
+    }
+
+    #[test]
+    fn transmit_descriptor_is_sent_to_the_backend() {
+        let mut board = A2065::new(NetConfig::Loopback);
+        let mut mem = host_mem();
+        let (tx_buf, _rx) = set_up_rings(&mut board, &mut mem);
+        write_csr(&mut board, &mut mem, 0, CSR0_INIT);
+        write_csr(&mut board, &mut mem, 0, CSR0_STRT | CSR0_INEA);
+
+        // Put a 64-byte frame in the TX buffer, count = -64, OWN=chip, STP|ENP.
+        {
+            let mut host = DeviceHost::new(&mut mem);
+            for i in 0..64u32 {
+                board.write(
+                    RAM_BASE + tx_buf + i,
+                    1,
+                    u32::from(0x40 + i as u8),
+                    &mut host,
+                );
+            }
+        }
+        // TX descriptor 0 at LANCE 0x200: BCNT=-64, status OWN|STP|ENP.
+        {
+            let mut host = DeviceHost::new(&mut mem);
+            board.write(
+                RAM_BASE + 0x204,
+                2,
+                u32::from(0xF000 | (((!64u16) + 1) & 0x0FFF)),
+                &mut host,
+            );
+            board.write(
+                RAM_BASE + 0x202,
+                2,
+                u32::from((u16::from(DESC_OWN | DESC_STP | DESC_ENP) << 8) | 0),
+                &mut host,
+            );
+        }
+        // Transmit demand.
+        write_csr(&mut board, &mut mem, 0, CSR0_TDMD);
+
+        // The loopback backend should now hold the 64-byte frame, and TINT set.
+        assert_ne!(read_csr(&mut board, &mut mem, 0) & CSR0_TINT, 0);
+        let frame = board
+            .net
+            .as_mut()
+            .unwrap()
+            .poll()
+            .expect("frame transmitted");
+        assert_eq!(frame.len(), 64);
+        assert_eq!(frame[0], 0x40);
+        assert_eq!(frame[63], 0x40 + 63);
+    }
+
+    #[test]
+    fn inbound_frame_lands_in_rx_ring_and_raises_int() {
+        let mut board = A2065::new(NetConfig::Loopback);
+        let mut mem = host_mem();
+        set_up_rings(&mut board, &mut mem);
+        write_csr(&mut board, &mut mem, 0, CSR0_INIT);
+        write_csr(&mut board, &mut mem, 0, CSR0_STRT | CSR0_INEA);
+
+        // Inject a frame into the backend, then tick to deliver it.
+        board.net.as_mut().unwrap().send(&[0xAA, 0xBB, 0xCC, 0xDD]);
+        let mut host = DeviceHost::new(&mut mem);
+        board.tick(1, &mut host);
+        drop(host);
+
+        // RINT set and INT2 asserted (INEA on).
+        assert_ne!(read_csr(&mut board, &mut mem, 0) & CSR0_RINT, 0);
+        assert!(board.int2_line());
+
+        // The frame bytes are in the RX buffer (LANCE 0x400 -> window 0x8400).
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(board.read(RAM_BASE + 0x400, 1, &mut host), 0xAA);
+        assert_eq!(board.read(RAM_BASE + 0x403, 1, &mut host), 0xDD);
+    }
+
+    #[test]
+    fn stop_clears_running_and_int() {
+        let mut board = A2065::new(NetConfig::Loopback);
+        let mut mem = host_mem();
+        set_up_rings(&mut board, &mut mem);
+        write_csr(&mut board, &mut mem, 0, CSR0_INIT);
+        write_csr(&mut board, &mut mem, 0, CSR0_STRT | CSR0_INEA);
+        board.net.as_mut().unwrap().send(&[1, 2, 3, 4]);
+        let mut host = DeviceHost::new(&mut mem);
+        board.tick(1, &mut host);
+        drop(host);
+        assert!(board.int2_line());
+
+        write_csr(&mut board, &mut mem, 0, CSR0_STOP);
+        assert!(!board.int2_line());
+        assert!(!board.running);
+    }
+
+    #[test]
+    fn mac_prom_is_readable_at_even_bytes() {
+        let mut board = A2065::new(NetConfig::None);
+        let mut mem = host_mem();
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(board.read(0, 1, &mut host), 0x02);
+        assert_eq!(board.read(2, 1, &mut host), 0x00);
+        assert_eq!(board.read(4, 1, &mut host), 0x10);
+    }
+}

--- a/src/a2065.rs
+++ b/src/a2065.rs
@@ -502,20 +502,11 @@ mod tests {
         put(board, mem, iadr + 6, 0x0605);
         // RX ring: RLEN log2 = 0 (1 entry) in bits 13-15.
         put(board, mem, iadr + 0x10, rx_ring as u16);
-        put(
-            board,
-            mem,
-            iadr + 0x12,
-            (0 << 13) | ((rx_ring >> 16) as u16 & 0xFF),
-        );
+        // High word: RLEN log2 = 0 (1 entry) in bits 13-15, RDRA[23:16] in 0-7.
+        put(board, mem, iadr + 0x12, (rx_ring >> 16) as u16 & 0xFF);
         // TX ring: TLEN log2 = 0.
         put(board, mem, iadr + 0x14, tx_ring as u16);
-        put(
-            board,
-            mem,
-            iadr + 0x16,
-            (0 << 13) | ((tx_ring >> 16) as u16 & 0xFF),
-        );
+        put(board, mem, iadr + 0x16, (tx_ring >> 16) as u16 & 0xFF);
 
         // RX descriptor 0: buffer @ rx_buf, OWN=chip, BCNT = -256.
         put(board, mem, rx_ring, rx_buf as u16);
@@ -579,10 +570,11 @@ mod tests {
                 u32::from(0xF000 | (((!64u16) + 1) & 0x0FFF)),
                 &mut host,
             );
+            // Status byte in the high byte; HADR (low byte) is 0.
             board.write(
                 RAM_BASE + 0x202,
                 2,
-                u32::from((u16::from(DESC_OWN | DESC_STP | DESC_ENP) << 8) | 0),
+                u32::from(u16::from(DESC_OWN | DESC_STP | DESC_ENP) << 8),
                 &mut host,
             );
         }
@@ -612,9 +604,10 @@ mod tests {
 
         // Inject a frame into the backend, then tick to deliver it.
         board.net.as_mut().unwrap().send(&[0xAA, 0xBB, 0xCC, 0xDD]);
-        let mut host = DeviceHost::new(&mut mem);
-        board.tick(1, &mut host);
-        drop(host);
+        {
+            let mut host = DeviceHost::new(&mut mem);
+            board.tick(1, &mut host);
+        }
 
         // RINT set and INT2 asserted (INEA on).
         assert_ne!(read_csr(&mut board, &mut mem, 0) & CSR0_RINT, 0);
@@ -634,9 +627,10 @@ mod tests {
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
         write_csr(&mut board, &mut mem, 0, CSR0_STRT | CSR0_INEA);
         board.net.as_mut().unwrap().send(&[1, 2, 3, 4]);
-        let mut host = DeviceHost::new(&mut mem);
-        board.tick(1, &mut host);
-        drop(host);
+        {
+            let mut host = DeviceHost::new(&mut mem);
+            board.tick(1, &mut host);
+        }
         assert!(board.int2_line());
 
         write_csr(&mut board, &mut mem, 0, CSR0_STOP);

--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -25,7 +25,7 @@
 //! TODO: arbitrate DMAC bus-master cycles against the CPU on the expansion
 //! bus for cycle-accurate transfer timing.
 
-use crate::memory::{Memory, SLOW_RAM_BASE};
+use crate::memory::Memory;
 use crate::scsi::{DmaDir, ScsiDisk, Wd33c93};
 use anyhow::{bail, Result};
 use std::path::Path;
@@ -339,44 +339,16 @@ impl A2091 {
     }
 
     fn dma_read_word(&mut self, mem: &Memory, addr: u32) -> u16 {
-        let a = addr as usize;
-        if a + 1 < mem.chip_ram.len() {
-            return (u16::from(mem.chip_ram[a]) << 8) | u16::from(mem.chip_ram[a + 1]);
-        }
-        let slow = SLOW_RAM_BASE as usize;
-        if a >= slow && a + 1 < slow + mem.slow_ram.len() {
-            let o = a - slow;
-            return (u16::from(mem.slow_ram[o]) << 8) | u16::from(mem.slow_ram[o + 1]);
-        }
-        if let Some((board, off)) = mem.zorro.region_at(addr, 2) {
-            let ram = mem.zorro.board_ram(board);
-            return (u16::from(ram[off]) << 8) | u16::from(ram[off + 1]);
-        }
-        self.warn_dma_target(addr);
-        0xFFFF
+        crate::zorro_device::dma_read_word(mem, addr).unwrap_or_else(|| {
+            self.warn_dma_target(addr);
+            0xFFFF
+        })
     }
 
     fn dma_write_word(&mut self, mem: &mut Memory, addr: u32, w: u16) {
-        let a = addr as usize;
-        if a + 1 < mem.chip_ram.len() {
-            mem.chip_ram[a] = (w >> 8) as u8;
-            mem.chip_ram[a + 1] = w as u8;
-            return;
+        if !crate::zorro_device::dma_write_word(mem, addr, w) {
+            self.warn_dma_target(addr);
         }
-        let slow = SLOW_RAM_BASE as usize;
-        if a >= slow && a + 1 < slow + mem.slow_ram.len() {
-            let o = a - slow;
-            mem.slow_ram[o] = (w >> 8) as u8;
-            mem.slow_ram[o + 1] = w as u8;
-            return;
-        }
-        if let Some((board, off)) = mem.zorro.region_at(addr, 2) {
-            let ram = mem.zorro.board_ram_mut(board);
-            ram[off] = (w >> 8) as u8;
-            ram[off + 1] = w as u8;
-            return;
-        }
-        self.warn_dma_target(addr);
     }
 
     fn warn_dma_target(&mut self, addr: u32) {
@@ -384,6 +356,49 @@ impl A2091 {
             self.dma_warned = true;
             log::warn!("a2091: DMA to unmapped address {addr:#08X}; ignoring");
         }
+    }
+}
+
+impl crate::zorro_device::ZorroDevice for A2091 {
+    fn read(&mut self, off: u32, size: usize, host: &mut crate::zorro_device::DeviceHost) -> u32 {
+        Self::read(self, off, size, host.memory_mut())
+    }
+
+    fn write(
+        &mut self,
+        off: u32,
+        size: usize,
+        value: u32,
+        host: &mut crate::zorro_device::DeviceHost,
+    ) {
+        Self::write(self, off, size, value, host.memory_mut())
+    }
+
+    fn tick(&mut self, cck: u32, host: &mut crate::zorro_device::DeviceHost) {
+        Self::tick(self, cck, host.memory_mut())
+    }
+
+    fn int2_line(&self) -> bool {
+        Self::int2_line(self)
+    }
+
+    // The A2091 delivers delayed WD33C93 interrupts and pumps queued DMA from
+    // its tick, so it is never treated as idle: the bus ticks it every slice
+    // (matching its pre-trait unconditional tick).
+    fn is_idle(&self) -> bool {
+        false
+    }
+
+    fn take_activity(&mut self) -> bool {
+        Self::take_activity(self)
+    }
+
+    fn reset(&mut self) {
+        Self::reset(self)
+    }
+
+    fn kind(&self) -> &'static str {
+        "a2091"
     }
 }
 
@@ -481,7 +496,7 @@ mod tests {
     #[test]
     fn autoconfig_identity_carries_diag_vector_and_configures_a_device_window() {
         let mut chain = ZorroChain::default();
-        chain.add_board(BoardSpec::a2091()).unwrap();
+        chain.add_board(BoardSpec::a2091(0)).unwrap();
         // er_Type = Zorro II | DIAGVALID | 64K size code = 0xD1, presented
         // uninverted on the physical nibbles.
         assert_eq!(chain.config_read(AUTOCONFIG_BASE, 1), 0xD0);
@@ -505,7 +520,7 @@ mod tests {
         assert_eq!(chain.region_at(0x00E9_0000, 2), None);
         assert_eq!(
             chain.device_region_at(0x00E9_0040, 2),
-            Some((BoardBacking::A2091, 0x40))
+            Some((BoardBacking::Device(0), 0x40))
         );
         assert_eq!(chain.device_region_at(0x00EA_0000, 2), None);
     }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -539,9 +539,12 @@ pub struct Bus {
     /// CDTV DMAC/CD controller (CDTV machine profile): an autoconfig
     /// board with the 6525 TPI and Matshita drive.
     pub cdtv: Option<crate::cdtv::CdtvController>,
-    /// A2091 SCSI controller (Zorro II autoconfig board, `[scsi]` config);
-    /// the chain maps its window, accesses route here.
-    pub a2091: Option<crate::a2091::A2091>,
+    /// Functional Zorro-chain boards (the A2091 SCSI controller, WASM plugin
+    /// boards). The chain maps each board's window to a
+    /// [`crate::zorro::BoardBacking::Device`] slot index into this vector, and
+    /// accesses route here through the [`crate::zorro_device::ZorroDevice`]
+    /// boundary. Serialized inline with the bus.
+    pub devices: Vec<crate::zorro_device::BoardDevice>,
     /// Emulated-time deadline keeping the front-panel HDD LED lit after the
     /// most recent Gayle IDE activity, so short synchronous transfers stay
     /// visible for a human-perceptible stretch.
@@ -1689,7 +1692,7 @@ impl Bus {
             gayle: None,
             akiko: None,
             cdtv: None,
-            a2091: None,
+            devices: Vec::new(),
             hdd_led_until_cck: 0,
             cd32_pad_shifter: 8,
             cd32_pad_fire_oldstate: 0,
@@ -1832,8 +1835,11 @@ impl Bus {
         self.akiko = Some(akiko);
     }
 
-    pub fn attach_a2091(&mut self, a2091: crate::a2091::A2091) {
-        self.a2091 = Some(a2091);
+    /// Attach the functional Zorro-chain boards. Their slot indices must match
+    /// the [`crate::zorro::BoardBacking::Device`] indices assigned when the
+    /// boards were added to the chain.
+    pub fn attach_devices(&mut self, devices: Vec<crate::zorro_device::BoardDevice>) {
+        self.devices = devices;
     }
 
     pub fn attach_cdtv(&mut self, cdtv: crate::cdtv::CdtvController) {
@@ -1995,8 +2001,8 @@ impl Bus {
         if let Some(cdtv) = self.cdtv.as_mut() {
             cdtv.reset();
         }
-        if let Some(a2091) = self.a2091.as_mut() {
-            a2091.reset();
+        for dev in &mut self.devices {
+            crate::zorro_device::ZorroDevice::reset(dev);
         }
         self.hdd_led_until_cck = 0;
         self.overlay_disable_pending = false;
@@ -2109,7 +2115,7 @@ impl Bus {
             power_led_on: pra & 0x02 == 0,
             fdd_led_on: self.floppy.activity_led_on(),
             fdd_track: self.floppy.selected_track(),
-            hdd_led: (self.gayle.is_some() || self.a2091.is_some())
+            hdd_led: (self.gayle.is_some() || self.has_scsi_device())
                 .then_some(self.emulated_cck < self.hdd_led_until_cck),
             cd_led: self
                 .cdtv
@@ -2123,6 +2129,13 @@ impl Bus {
     /// Whether the machine has a CD drive (CDTV DMAC or CD32 Akiko).
     pub fn cd_drive_present(&self) -> bool {
         self.cdtv.is_some() || self.akiko.is_some()
+    }
+
+    /// Whether a SCSI controller board is fitted (lights the HDD LED).
+    fn has_scsi_device(&self) -> bool {
+        self.devices
+            .iter()
+            .any(|d| matches!(d, crate::zorro_device::BoardDevice::A2091(_)))
     }
 
     /// Whether a disc is mounted (or, on CDTV, waiting in the tray).
@@ -3028,19 +3041,40 @@ impl Bus {
             }
         }
 
+        // CDTV DMAC: advance through the ZorroDevice boundary (its tick streams
+        // CD audio from Paula's ring) and level-feed its INT2 line like Gayle's.
         if let Some(cdtv) = self.cdtv.as_mut() {
-            cdtv.tick(cck, self.paula.cd_audio_mut());
-            if cdtv.int2_line() {
+            {
+                let mut host = crate::zorro_device::DeviceHost::with_cd_audio(
+                    &mut self.mem,
+                    self.paula.cd_audio_mut(),
+                );
+                crate::zorro_device::ZorroDevice::tick(cdtv, cck, &mut host);
+            }
+            if crate::zorro_device::ZorroDevice::int2_line(cdtv) {
                 self.paula.intreq |= INT_PORTS;
             }
         }
 
-        // A2091 SCSI: deliver delayed WD33C93 interrupts (and any DMA that
-        // became ready) and level-feed its INT2 line like Gayle's.
-        if let Some(a2091) = self.a2091.as_mut() {
-            a2091.tick(cck, &mut self.mem);
-            if a2091.int2_line() {
-                self.paula.intreq |= INT_PORTS;
+        // Functional Zorro-chain boards (A2091 SCSI, WASM plugins): advance each
+        // -- delivering delayed interrupts and any DMA that became ready -- and
+        // level-feed its INT2/INT6 lines like Gayle's.
+        {
+            let Self {
+                devices,
+                mem,
+                paula,
+                ..
+            } = self;
+            for dev in devices.iter_mut() {
+                let mut host = crate::zorro_device::DeviceHost::new(&mut *mem);
+                crate::zorro_device::ZorroDevice::tick(dev, cck, &mut host);
+                if crate::zorro_device::ZorroDevice::int2_line(dev) {
+                    paula.intreq |= INT_PORTS;
+                }
+                if crate::zorro_device::ZorroDevice::int6_line(dev) {
+                    paula.intreq |= INT_EXTER;
+                }
             }
         }
 

--- a/src/cdtv.rs
+++ b/src/cdtv.rs
@@ -33,7 +33,7 @@
 
 use crate::cdrom::{CdImage, LEADIN_SECTORS, RAW_SECTOR_BYTES};
 use crate::chipset::paula::CdAudioRing;
-use crate::memory::{Memory, SLOW_RAM_BASE};
+use crate::memory::Memory;
 
 // DMAC CNTR bits.
 const CNTR_TCEN: u8 = 1 << 7;
@@ -1046,43 +1046,15 @@ impl CdtvController {
     /// Zorro II board RAM (the CD driver allocates CD buffers in fast RAM when
     /// present). Unmapped targets warn once and drop the data.
     fn dma_write_word(&mut self, mem: &mut Memory, addr: u32, hi: u8, lo: u8) {
-        let a = addr as usize;
-        if a + 1 < mem.chip_ram.len() {
-            mem.chip_ram[a] = hi;
-            mem.chip_ram[a + 1] = lo;
-            return;
-        }
-        let slow = SLOW_RAM_BASE as usize;
-        if a >= slow && a + 1 < slow + mem.slow_ram.len() {
-            mem.slow_ram[a - slow] = hi;
-            mem.slow_ram[a - slow + 1] = lo;
-            return;
-        }
-        if let Some((board, off)) = mem.zorro.region_at(addr, 2) {
-            let ram = mem.zorro.board_ram_mut(board);
-            ram[off] = hi;
-            ram[off + 1] = lo;
-            return;
-        }
-        if !self.dma_warned {
+        let w = (u16::from(hi) << 8) | u16::from(lo);
+        if !crate::zorro_device::dma_write_word(mem, addr, w) && !self.dma_warned {
             self.dma_warned = true;
             log::warn!("cdtv: DMA to unmapped address {addr:#08X}; ignoring");
         }
     }
 
     fn dma_read_byte(mem: &Memory, addr: u32) -> u8 {
-        let a = addr as usize;
-        if a < mem.chip_ram.len() {
-            return mem.chip_ram[a];
-        }
-        let slow = SLOW_RAM_BASE as usize;
-        if a >= slow && a < slow + mem.slow_ram.len() {
-            return mem.slow_ram[a - slow];
-        }
-        if let Some((board, off)) = mem.zorro.region_at(addr, 1) {
-            return mem.zorro.board_ram(board)[off];
-        }
-        0xFF
+        crate::zorro_device::dma_read_byte(mem, addr).unwrap_or(0xFF)
     }
 
     fn run_dma(&mut self, mem: &mut Memory) {
@@ -1263,6 +1235,49 @@ impl CdtvController {
         }
         self.play_position += 1;
         self.last_play_pos = self.play_position;
+    }
+}
+
+impl crate::zorro_device::ZorroDevice for CdtvController {
+    // The CDTV self-decodes its window (base is 64K-aligned), so the dispatch
+    // passes the window offset, which `read_byte`/`write_byte` mask to the same
+    // low 16 bits the absolute address carried before.
+    fn read(&mut self, off: u32, size: usize, _host: &mut crate::zorro_device::DeviceHost) -> u32 {
+        Self::read(self, off, size)
+    }
+
+    fn write(
+        &mut self,
+        off: u32,
+        size: usize,
+        value: u32,
+        host: &mut crate::zorro_device::DeviceHost,
+    ) {
+        Self::write(self, off, size, value, host.memory_mut())
+    }
+
+    // The DMAC tick streams CD audio rather than touching guest memory, so it
+    // draws Paula's CD-audio ring from the host instead of `Memory`.
+    fn tick(&mut self, cck: u32, host: &mut crate::zorro_device::DeviceHost) {
+        Self::tick(self, cck, host.cd_audio())
+    }
+
+    fn int2_line(&self) -> bool {
+        Self::int2_line(self)
+    }
+
+    // Ticked every slice to advance CD audio and deliver the delayed
+    // DMA-completion interrupt (matches its pre-trait unconditional tick).
+    fn is_idle(&self) -> bool {
+        false
+    }
+
+    fn reset(&mut self) {
+        Self::reset(self)
+    }
+
+    fn kind(&self) -> &'static str {
+        "cdtv"
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,10 @@ pub struct Config {
     /// drive images on SCSI IDs 0-6. Works on any machine model (the board
     /// autoconfigs on the Zorro chain and carries its own scsi.device).
     pub scsi: ScsiConfig,
+    /// A2065 Ethernet board (`[a2065]`): when set, an A2065 NIC autoconfigs on
+    /// the Zorro chain using the named host network backend. Networking is
+    /// non-deterministic, so a fitted A2065 breaks byte-identical replay.
+    pub a2065_net: Option<crate::net::NetConfig>,
     pub floppy: FloppyConfig,
     /// Which floppy drive slots are electrically present. DF0 is the
     /// internal drive and is always present; DF1-DF3 are external drives
@@ -684,6 +688,7 @@ impl Default for Config {
             audio: AudioConfig::default(),
             ide: IdeConfig::default(),
             scsi: ScsiConfig::default(),
+            a2065_net: None,
             floppy: FloppyConfig::default(),
             floppy_connected: [true, false, false, false],
             floppy_playlists: std::array::from_fn(|_| Vec::new()),
@@ -895,6 +900,8 @@ pub(crate) struct RawConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) scsi: RawScsi,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) a2065: RawA2065,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) floppy: RawFloppy,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) display: RawDisplay,
@@ -956,6 +963,17 @@ pub(crate) struct RawScsi {
     pub(crate) unit5: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) unit6: Option<String>,
+}
+
+/// `[a2065]` Ethernet board. Fitting the board enables host networking, which
+/// is non-deterministic.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawA2065 {
+    /// Host network backend: "loopback" (self-contained), or "none" for an
+    /// isolated NIC. Absent means no A2065 board is fitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) net: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -1279,6 +1297,16 @@ impl TryFrom<RawConfig> for Config {
             bail!("[scsi] rom_odd needs rom (the even EPROM half)");
         }
 
+        let a2065_net = match &raw.a2065.net {
+            None => None,
+            Some(s) => Some(crate::net::parse_net_config(s).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "[a2065] net = {:?} is not a known backend (expected \"none\" or \"loopback\")",
+                    s
+                )
+            })?),
+        };
+
         // The A500 Rev 6A is both the "A500" profile and the no-profile
         // default machine (the most common, most-targeted Amiga): the Fatter
         // 8372A Agnus with the original OCS 8362 Denise. An explicit [chipset]
@@ -1375,6 +1403,7 @@ impl TryFrom<RawConfig> for Config {
             audio,
             ide,
             scsi,
+            a2065_net,
             floppy,
             floppy_connected,
             floppy_playlists,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,16 @@ fn is_default<T: Default + PartialEq>(value: &T) -> bool {
 /// `rom = "..."` or the CLI argument) always replaces it.
 pub const BUNDLED_AROS_ROM: &str = "<bundled-aros>";
 
+/// A WASM plugin Zorro board resolved from config: its autoconfig identity
+/// (`spec`, with a placeholder device slot reassigned at build time), the
+/// `.wasm` module path, and the plugin manifest (name + capabilities).
+#[derive(Debug, Clone)]
+pub struct WasmBoardConfig {
+    pub spec: BoardSpec,
+    pub wasm_path: PathBuf,
+    pub manifest: crate::wasmboard::WasmManifest,
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub rom_path: PathBuf,
@@ -49,9 +59,14 @@ pub struct Config {
     /// Zorro III autoconfig RAM (`[memory] z3`). Needs a CPU with a 32-bit
     /// address bus (68020/030/040; not the 24-bit 68000/68EC020).
     pub z3_ram_bytes: usize,
-    /// Extra Zorro boards loaded from `[[zorro]]` metadata files, in
+    /// Extra Zorro RAM boards loaded from `[[zorro]]` metadata files, in
     /// autoconfig chain order after the built-in RAM boards.
     pub zorro_boards: Vec<BoardSpec>,
+    /// WASM plugin boards loaded from `[[zorro]]` metadata files. Instantiated
+    /// and attached to the bus at machine-build time (their device-slot index
+    /// is assigned then); kept separate from RAM boards because they carry a
+    /// module and capabilities, not just an autoconfig identity.
+    pub wasm_boards: Vec<WasmBoardConfig>,
     /// Advertise the Copperline identification board on the Zorro autoconfig
     /// chain (manufacturer 5192 / product 2) so guest software such as
     /// identify.library can detect the emulator. Defaults to true; set
@@ -643,6 +658,7 @@ impl Default for Config {
             slow_ram_bytes: A500_TRAPDOOR_RAM_BYTES,
             z3_ram_bytes: 0,
             zorro_boards: Vec::new(),
+            wasm_boards: Vec::new(),
             identify_board: true,
             // The no-[machine] default models the most common and most-
             // targeted Amiga: the A500 Rev 6A (the ECS "Fatter" 8372A Agnus
@@ -1187,10 +1203,20 @@ impl TryFrom<RawConfig> for Config {
             Some(s) => parse_size(s, "Zorro III RAM")?,
         };
         let mut zorro_boards = Vec::new();
+        let mut wasm_boards = Vec::new();
         for entry in &raw.zorro {
-            zorro_boards.push(crate::zorro::load_board_metadata(Path::new(
-                &entry.metadata,
-            ))?);
+            match crate::zorro::load_board_metadata(Path::new(&entry.metadata))? {
+                crate::zorro::LoadedZorroBoard::Ram(spec) => zorro_boards.push(spec),
+                crate::zorro::LoadedZorroBoard::Wasm {
+                    spec,
+                    wasm_path,
+                    manifest,
+                } => wasm_boards.push(WasmBoardConfig {
+                    spec,
+                    wasm_path,
+                    manifest,
+                }),
+            }
         }
         let chipset = match raw.chipset.revision.as_deref() {
             None => defaults.chipset,
@@ -1292,7 +1318,10 @@ impl TryFrom<RawConfig> for Config {
         validate_fast_ram(fast_ram_bytes, chip_ram_bytes)?;
         validate_slow_ram(slow_ram_bytes)?;
         validate_z3_ram(z3_ram_bytes, cpu)?;
-        for board in &zorro_boards {
+        let board_specs = zorro_boards
+            .iter()
+            .chain(wasm_boards.iter().map(|w| &w.spec));
+        for board in board_specs {
             if board.version == ZorroVersion::III && !cpu_has_32bit_bus(cpu) {
                 bail!(
                     "zorro board {:?} is Zorro III, which needs a 32-bit CPU \
@@ -1316,6 +1345,7 @@ impl TryFrom<RawConfig> for Config {
             slow_ram_bytes,
             z3_ram_bytes,
             zorro_boards,
+            wasm_boards,
             identify_board: raw.identify.unwrap_or(defaults.identify_board),
             chipset,
             agnus_revision,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1052,6 +1052,10 @@ pub(crate) struct RawZorroBoard {
     /// Path to a TOML board metadata file (see `src/zorro.rs` for the
     /// schema), resolved relative to the working directory.
     pub(crate) metadata: String,
+    /// Per-board plugin setting overrides, layered over the manifest's
+    /// `[config]` defaults (WASM plugin boards only). The launcher edits these.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) config: Option<toml::Table>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -1228,12 +1232,25 @@ impl TryFrom<RawConfig> for Config {
                 crate::zorro::LoadedZorroBoard::Wasm {
                     spec,
                     wasm_path,
-                    manifest,
-                } => wasm_boards.push(WasmBoardConfig {
-                    spec,
-                    wasm_path,
-                    manifest,
-                }),
+                    mut manifest,
+                    default_config,
+                    options: _,
+                } => {
+                    // Effective config = manifest defaults, with the user's
+                    // per-board overrides layered on top.
+                    let mut config = default_config;
+                    if let Some(overrides) = &entry.config {
+                        for (key, value) in overrides {
+                            config.insert(key.clone(), crate::zorro::toml_value_to_string(value));
+                        }
+                    }
+                    manifest.config = config;
+                    wasm_boards.push(WasmBoardConfig {
+                        spec,
+                        wasm_path,
+                        manifest,
+                    });
+                }
             }
         }
         let chipset = match raw.chipset.revision.as_deref() {
@@ -1969,6 +1986,7 @@ mod tests {
             },
             zorro: vec![RawZorroBoard {
                 metadata: "board.toml".to_string(),
+                config: None,
             }],
             ..RawConfig::default()
         };

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1746,25 +1746,24 @@ impl CpuBus {
                 return value;
             }
         }
-        if self.bus.a2091.is_some() {
-            // A2091 SCSI: a configured Zorro device board window (registers,
-            // boot ROM, DMA strobes). Off the chip bus like Gayle.
-            if let Some((crate::zorro::BoardBacking::A2091, off)) =
-                self.bus.mem.zorro.device_region_at(addr, size)
-            {
-                self.bus.cpu_slow_external_access(Self::access_words(size));
-                let (value, activity) = match self.bus.a2091.as_mut() {
-                    Some(a2091) => {
-                        let v = a2091.read(off, size, &mut self.bus.mem);
-                        (v, a2091.take_activity())
-                    }
-                    None => (floating_read(size), false),
-                };
-                if activity {
-                    self.bus.note_hdd_activity();
-                }
-                return value;
+        // A configured functional Zorro board window (registers, boot ROM, DMA
+        // strobes): the chain maps it to a device slot. Off the chip bus like
+        // Gayle.
+        if let Some((crate::zorro::BoardBacking::Device(slot), off)) =
+            self.bus.mem.zorro.device_region_at(addr, size)
+        {
+            self.bus.cpu_slow_external_access(Self::access_words(size));
+            let (value, activity) = {
+                let mem = &mut self.bus.mem;
+                let dev = &mut self.bus.devices[slot];
+                let mut host = crate::zorro_device::DeviceHost::new(mem);
+                let v = crate::zorro_device::ZorroDevice::read(dev, off, size, &mut host);
+                (v, crate::zorro_device::ZorroDevice::take_activity(dev))
+            };
+            if activity {
+                self.bus.note_hdd_activity();
             }
+            return value;
         }
         if self.bus.akiko.is_some()
             && range_contains(crate::akiko::AKIKO_BASE, crate::akiko::AKIKO_SIZE, addr)
@@ -1782,7 +1781,15 @@ impl CpuBus {
         {
             self.bus.cpu_slow_external_access(Self::access_words(size));
             if let Some(cdtv) = self.bus.cdtv.as_mut() {
-                return cdtv.read(addr, size);
+                // The CDTV self-decodes its 64K window; pass the window offset
+                // through the ZorroDevice boundary (its read ignores memory).
+                let mut host = crate::zorro_device::DeviceHost::new(&mut self.bus.mem);
+                return crate::zorro_device::ZorroDevice::read(
+                    cdtv,
+                    addr & 0xFFFF,
+                    size,
+                    &mut host,
+                );
             }
         }
         if range_contains(CUSTOM_BASE, CUSTOM_SIZE, addr) {
@@ -1951,21 +1958,21 @@ impl CpuBus {
             }
             return;
         }
-        if self.bus.a2091.is_some() {
-            if let Some((crate::zorro::BoardBacking::A2091, off)) =
-                self.bus.mem.zorro.device_region_at(addr, size)
-            {
-                self.bus.cpu_slow_external_access(Self::access_words(size));
-                let mut activity = false;
-                if let Some(a2091) = self.bus.a2091.as_mut() {
-                    a2091.write(off, size, value, &mut self.bus.mem);
-                    activity = a2091.take_activity();
-                }
-                if activity {
-                    self.bus.note_hdd_activity();
-                }
-                return;
+        if let Some((crate::zorro::BoardBacking::Device(slot), off)) =
+            self.bus.mem.zorro.device_region_at(addr, size)
+        {
+            self.bus.cpu_slow_external_access(Self::access_words(size));
+            let activity = {
+                let mem = &mut self.bus.mem;
+                let dev = &mut self.bus.devices[slot];
+                let mut host = crate::zorro_device::DeviceHost::new(mem);
+                crate::zorro_device::ZorroDevice::write(dev, off, size, value, &mut host);
+                crate::zorro_device::ZorroDevice::take_activity(dev)
+            };
+            if activity {
+                self.bus.note_hdd_activity();
             }
+            return;
         }
         if self.bus.akiko.is_some()
             && range_contains(crate::akiko::AKIKO_BASE, crate::akiko::AKIKO_SIZE, addr)
@@ -1984,7 +1991,16 @@ impl CpuBus {
         {
             self.bus.cpu_slow_external_access(Self::access_words(size));
             if let Some(mut cdtv) = self.bus.cdtv.take() {
-                cdtv.write(addr, size, value, &mut self.bus.mem);
+                // Taken out to split the borrow from `mem`; routed through the
+                // ZorroDevice boundary with the self-decoded window offset.
+                let mut host = crate::zorro_device::DeviceHost::new(&mut self.bus.mem);
+                crate::zorro_device::ZorroDevice::write(
+                    &mut cdtv,
+                    addr & 0xFFFF,
+                    size,
+                    value,
+                    &mut host,
+                );
                 self.bus.cdtv = Some(cdtv);
             }
             return;
@@ -2191,15 +2207,6 @@ fn region_offset(len: usize, base: u64, address: u32, size: usize) -> Option<usi
         Some((addr - base) as usize)
     } else {
         None
-    }
-}
-
-fn floating_read(size: usize) -> u32 {
-    match size {
-        1 => 0xFF,
-        2 => 0xFFFF,
-        4 => 0xFFFF_FFFF,
-        _ => 0,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,9 @@ mod serial;
 mod timestamp;
 mod timetravel;
 mod video;
+mod wasmboard;
 mod zorro;
+mod zorro_device;
 
 use anyhow::{anyhow, Result};
 use log::{info, warn};
@@ -1076,7 +1078,11 @@ pub(crate) fn build_machine(
     paced: bool,
 ) -> Result<Emulator> {
     let mut zorro = cfg.build_zorro_chain()?;
-    let mut scsi_board = if cfg.scsi.enabled() {
+    // Functional Zorro-chain boards. Each board's autoconfig identity goes on
+    // the chain (mapping its window to a device slot) while the device object
+    // is attached to the bus after it is built; the slot index ties them.
+    let mut devices: Vec<crate::zorro_device::BoardDevice> = Vec::new();
+    if cfg.scsi.enabled() {
         let rom_path = cfg.scsi.rom.as_ref().expect("config validated [scsi] rom");
         let rom = crate::a2091::A2091::load_rom(rom_path, cfg.scsi.rom_odd.as_deref())?;
         let mut board = crate::a2091::A2091::new(rom)?;
@@ -1085,15 +1091,29 @@ pub(crate) fn build_machine(
             board.attach_drive(unit, crate::scsi::ScsiDisk::open(path, unit)?);
             info!("scsi: unit {unit} {}", path.display());
         }
-        zorro.add_board(crate::zorro::BoardSpec::a2091())?;
+        let slot = devices.len();
+        zorro.add_board(crate::zorro::BoardSpec::a2091(slot))?;
         info!(
-            "scsi: A2091 controller on the Zorro chain, ROM {}",
+            "scsi: A2091 controller on the Zorro chain (slot {slot}), ROM {}",
             rom_path.display()
         );
-        Some(board)
-    } else {
-        None
-    };
+        devices.push(crate::zorro_device::BoardDevice::A2091(board));
+    }
+    // WASM plugin boards: assign each a device slot, put its autoconfig
+    // identity on the chain, and instantiate the module.
+    for wb in &cfg.wasm_boards {
+        let slot = devices.len();
+        let mut spec = wb.spec.clone();
+        spec.backing = crate::zorro::BoardBacking::Device(slot);
+        zorro.add_board(spec)?;
+        let board = crate::wasmboard::WasmBoard::from_file(&wb.wasm_path, wb.manifest.clone())?;
+        info!(
+            "zorro: WASM plugin {:?} on the Zorro chain (slot {slot}), module {}",
+            wb.manifest.name,
+            wb.wasm_path.display()
+        );
+        devices.push(crate::zorro_device::BoardDevice::Wasm(board));
+    }
     // The A1000 has no Kickstart ROM: cfg.rom_path is its 64 KiB bootstrap
     // ROM, and a 256 KiB WCS is allocated for it to load Kickstart into from
     // the Kickstart disk in DF0.
@@ -1146,8 +1166,8 @@ pub(crate) fn build_machine(
         }
         bus.attach_gayle(gayle);
     }
-    if let Some(board) = scsi_board.take() {
-        bus.attach_a2091(board);
+    if !devices.is_empty() {
+        bus.attach_devices(devices);
     }
     if cfg.cd32_pad {
         bus.input.cd32_pad_port2 = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 //!   If no ROM is given (neither argument nor `rom =` in the config), boots
 //!   the bundled AROS open-source Kickstart replacement (see src/romsearch.rs).
 
+mod a2065;
 mod a2091;
 mod akiko;
 mod audio;
@@ -32,6 +33,7 @@ mod harddrive;
 mod inputrec;
 mod inputsched;
 mod memory;
+mod net;
 mod priority;
 mod recorder;
 mod romsearch;
@@ -1113,6 +1115,18 @@ pub(crate) fn build_machine(
             wb.wasm_path.display()
         );
         devices.push(crate::zorro_device::BoardDevice::Wasm(board));
+    }
+    // A2065 Ethernet board (in-tree LANCE NIC): networking is non-deterministic.
+    if let Some(net_config) = cfg.a2065_net {
+        let slot = devices.len();
+        zorro.add_board(crate::zorro::BoardSpec::a2065(slot))?;
+        info!(
+            "a2065: Ethernet board on the Zorro chain (slot {slot}), net backend {net_config:?} \
+             -- networking is non-deterministic, replay/save-state reproducibility not guaranteed"
+        );
+        devices.push(crate::zorro_device::BoardDevice::A2065(
+            crate::a2065::A2065::new(net_config),
+        ));
     }
     // The A1000 has no Kickstart ROM: cfg.rom_path is its 64 KiB bootstrap
     // ROM, and a 256 KiB WCS is allocated for it to load Kickstart into from

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Host networking backends for emulated Ethernet boards (the a2065 LANCE and
+//! WASM NIC plugins).
+//!
+//! An emulated NIC owns a [`NetBackend`]: it pushes the Ethernet frames the
+//! guest transmits with [`NetBackend::send`] and pulls inbound frames with
+//! [`NetBackend::poll`]. A frame is a complete Ethernet frame (destination MAC
+//! through payload, no FCS).
+//!
+//! Networking is inherently non-deterministic: inbound frames arrive on the
+//! host's schedule, not the emulated clock, so a NIC board breaks Copperline's
+//! byte-identical replay / save-state determinism while traffic flows. Backends
+//! are therefore host resources, not serialized state -- a save state records
+//! only the board's chosen backend ([`NetConfig`]) and brings up a fresh
+//! backend on load (in-flight frames are dropped; the guest's TCP retransmits).
+//!
+//! One backend is built in: [`LoopbackBackend`] (frames echo back to the
+//! sender, for tests and a self-contained two-station demo). [`NetConfig::None`]
+//! brings up no backend at all, which is how an isolated NIC (one with the
+//! capability but no host connectivity) is expressed. Userspace NAT
+//! (libslirp/smoltcp) and a host TAP bridge are planned and will slot in behind
+//! [`make_backend`] under build features.
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+/// A host networking backend an emulated NIC sends and receives frames through.
+/// `Send` so it can live in a wasmtime store's data (which the bus owns).
+pub trait NetBackend: Send {
+    /// Transmit one Ethernet frame from the guest to the network.
+    fn send(&mut self, frame: &[u8]);
+
+    /// Return the next inbound Ethernet frame for the guest, if any.
+    fn poll(&mut self) -> Option<Vec<u8>>;
+}
+
+/// Which host backend a NIC board uses. Recorded in the board's config (and
+/// save state) so the board is self-contained; the live backend it names is a
+/// host resource brought up fresh by [`make_backend`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum NetConfig {
+    /// No connectivity: transmits are dropped, nothing is ever received.
+    #[default]
+    None,
+    /// Frames transmitted are queued straight back as received frames. Lets a
+    /// guest see its own broadcasts and supports a self-contained demo without
+    /// touching the host network; also the deterministic backend for tests.
+    Loopback,
+}
+
+/// Bring up the live backend a [`NetConfig`] names. `None` means the board has
+/// no host networking (its NIC still works, it just never sees traffic).
+pub fn make_backend(cfg: NetConfig) -> Option<Box<dyn NetBackend>> {
+    match cfg {
+        NetConfig::None => None,
+        NetConfig::Loopback => Some(Box::new(LoopbackBackend::default())),
+    }
+}
+
+/// A backend that queues each transmitted frame straight back for receipt.
+#[derive(Default)]
+pub struct LoopbackBackend {
+    queue: VecDeque<Vec<u8>>,
+}
+
+impl NetBackend for LoopbackBackend {
+    fn send(&mut self, frame: &[u8]) {
+        self.queue.push_back(frame.to_vec());
+    }
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        self.queue.pop_front()
+    }
+}
+
+/// Parse a `net`/`net_backend` config string into a [`NetConfig`].
+pub fn parse_net_config(s: &str) -> Option<NetConfig> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "none" | "off" | "" => Some(NetConfig::None),
+        "loopback" | "loop" => Some(NetConfig::Loopback),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_returns_sent_frames_in_order() {
+        let mut b = LoopbackBackend::default();
+        assert!(b.poll().is_none());
+        b.send(&[1, 2, 3]);
+        b.send(&[4, 5]);
+        assert_eq!(b.poll(), Some(vec![1, 2, 3]));
+        assert_eq!(b.poll(), Some(vec![4, 5]));
+        assert!(b.poll().is_none());
+    }
+
+    #[test]
+    fn config_parses_known_backends() {
+        assert_eq!(parse_net_config("loopback"), Some(NetConfig::Loopback));
+        assert_eq!(parse_net_config("None"), Some(NetConfig::None));
+        assert_eq!(parse_net_config(""), Some(NetConfig::None));
+        assert_eq!(parse_net_config("tap0"), None);
+    }
+
+    #[test]
+    fn make_backend_brings_up_named_backend() {
+        assert!(make_backend(NetConfig::None).is_none());
+        let mut b = make_backend(NetConfig::Loopback).expect("loopback backend");
+        b.send(&[9]);
+        assert_eq!(b.poll(), Some(vec![9]));
+    }
+}

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -54,7 +54,8 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //   6: Memory gained the A1000 WCS (wcs + wcs_write_protected)
 //   7: Bus.a2091 Option replaced by Bus.devices Vec<BoardDevice>; the
 //      BoardBacking::A2091 variant became BoardBacking::Device(slot)
-pub const STATE_VERSION: u32 = 7;
+//   8: BoardDevice gained Wasm and A2065 variants (enum layout change)
+pub const STATE_VERSION: u32 = 8;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -52,7 +52,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //   4: PollStats.custom HashMap replaced by a flat Vec table
 //   5: MachineDescriptor header (machine-shape guard rail)
 //   6: Memory gained the A1000 WCS (wcs + wcs_write_protected)
-pub const STATE_VERSION: u32 = 6;
+//   7: Bus.a2091 Option replaced by Bus.devices Vec<BoardDevice>; the
+//      BoardBacking::A2091 variant became BoardBacking::Device(slot)
+pub const STATE_VERSION: u32 = 7;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -25,8 +25,136 @@ use crate::config::{
     format_size, machine_profile_defaults, Chipset, Config, CpuModel, MachineModel, Overscan,
     PacingBudget, RawConfig, RawFloppyDrive, RawZorroBoard, WarpSpeed,
 };
+use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
 use anyhow::Result;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+
+/// A Zorro board entry in the launcher: its metadata-file path, the config
+/// option schema parsed from that manifest (empty for RAM boards or on load
+/// error), and the user's per-board setting overrides (layered over the
+/// manifest defaults). Editing in the config panel mutates `overrides`.
+#[derive(Debug, Clone)]
+pub struct ZorroBoardSetup {
+    metadata: PathBuf,
+    options: Vec<ConfigOption>,
+    /// Effective manifest defaults (option defaults overlaid by `[config]`,
+    /// file paths resolved), the baseline the user's overrides layer over.
+    defaults: BTreeMap<String, String>,
+    overrides: BTreeMap<String, String>,
+}
+
+impl ZorroBoardSetup {
+    /// Load a board's option schema + defaults from its manifest. RAM boards
+    /// and load failures yield an entry with no editable options.
+    fn load(metadata: PathBuf) -> Self {
+        let (options, defaults) = match crate::zorro::load_board_metadata(&metadata) {
+            Ok(LoadedZorroBoard::Wasm {
+                options,
+                default_config,
+                ..
+            }) => (options, default_config),
+            _ => (Vec::new(), BTreeMap::new()),
+        };
+        Self {
+            metadata,
+            options,
+            defaults,
+            overrides: BTreeMap::new(),
+        }
+    }
+
+    /// File name (or full path) for display.
+    pub fn name(&self) -> String {
+        self.metadata
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| self.metadata.display().to_string())
+    }
+
+    pub fn options(&self) -> &[ConfigOption] {
+        &self.options
+    }
+
+    /// The current value of option `opt`: the user's override, else the
+    /// effective manifest default, else empty.
+    pub fn value(&self, opt: usize) -> String {
+        let Some(o) = self.options.get(opt) else {
+            return String::new();
+        };
+        self.overrides
+            .get(&o.key)
+            .or_else(|| self.defaults.get(&o.key))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn set(&mut self, opt: usize, value: String) {
+        if let Some(o) = self.options.get(opt) {
+            self.overrides.insert(o.key.clone(), value);
+        }
+    }
+
+    /// Drop the override, reverting the option to its manifest default.
+    fn clear(&mut self, opt: usize) {
+        if let Some(o) = self.options.get(opt) {
+            self.overrides.remove(&o.key);
+        }
+    }
+
+    /// Step an enum/int option by one (forward or back).
+    fn cycle(&mut self, opt: usize, forward: bool) {
+        let Some(o) = self.options.get(opt) else {
+            return;
+        };
+        let next = match &o.kind {
+            ConfigOptionKind::Enum(choices) if !choices.is_empty() => {
+                let cur = self.value(opt);
+                let idx = choices.iter().position(|c| *c == cur).unwrap_or(0);
+                let n = choices.len();
+                let idx = if forward {
+                    (idx + 1) % n
+                } else {
+                    (idx + n - 1) % n
+                };
+                choices[idx].clone()
+            }
+            ConfigOptionKind::Int => {
+                let cur: i64 = self.value(opt).trim().parse().unwrap_or(0);
+                let next = if forward { cur + 1 } else { cur - 1 };
+                next.to_string()
+            }
+            _ => return,
+        };
+        self.set(opt, next);
+    }
+
+    /// Flip a bool option.
+    fn toggle(&mut self, opt: usize) {
+        if matches!(
+            self.options.get(opt).map(|o| &o.kind),
+            Some(ConfigOptionKind::Bool)
+        ) {
+            let on = self.value(opt).trim().eq_ignore_ascii_case("true");
+            self.set(opt, (!on).to_string());
+        }
+    }
+
+    /// The TOML override value for an option, typed per its kind, or `None`
+    /// when the user has left it at the manifest default.
+    fn override_toml(&self, o: &ConfigOption) -> Option<toml::Value> {
+        let raw = self.overrides.get(&o.key)?;
+        Some(match o.kind {
+            ConfigOptionKind::Bool => toml::Value::Boolean(raw.trim().eq_ignore_ascii_case("true")),
+            ConfigOptionKind::Int => raw
+                .trim()
+                .parse::<i64>()
+                .map(toml::Value::Integer)
+                .unwrap_or_else(|_| toml::Value::String(raw.clone())),
+            _ => toml::Value::String(raw.clone()),
+        })
+    }
+}
 
 /// The configuration screen's category tabs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -370,8 +498,8 @@ pub struct MachineSetup {
     pacing_budget: PacingBudget,
     realtime_priority: bool,
     warp: WarpSpeed,
-    // Extra Zorro boards by metadata-file path
-    zorro_boards: Vec<PathBuf>,
+    // Extra Zorro boards (metadata path + plugin config schema/overrides)
+    zorro_boards: Vec<ZorroBoardSetup>,
 }
 
 impl Default for MachineSetup {
@@ -439,7 +567,17 @@ impl MachineSetup {
             zorro_boards: raw
                 .zorro
                 .iter()
-                .map(|b| PathBuf::from(&b.metadata))
+                .map(|b| {
+                    let mut board = ZorroBoardSetup::load(PathBuf::from(&b.metadata));
+                    if let Some(overrides) = &b.config {
+                        for (key, value) in overrides {
+                            board
+                                .overrides
+                                .insert(key.clone(), crate::zorro::toml_value_to_string(value));
+                        }
+                    }
+                    board
+                })
                 .collect(),
         })
     }
@@ -579,12 +717,22 @@ impl MachineSetup {
         if self.warp != base.emulation.warp_speed {
             raw.emulation.warp_speed = Some(self.warp.label().to_ascii_lowercase());
         }
-        // Zorro boards
+        // Zorro boards: emit the metadata path plus any per-board overrides
+        // (typed per the option schema), only when the user changed something.
         raw.zorro = self
             .zorro_boards
             .iter()
-            .map(|p| RawZorroBoard {
-                metadata: path_string(p),
+            .map(|b| {
+                let mut table = toml::Table::new();
+                for o in &b.options {
+                    if let Some(v) = b.override_toml(o) {
+                        table.insert(o.key.clone(), v);
+                    }
+                }
+                RawZorroBoard {
+                    metadata: path_string(&b.metadata),
+                    config: (!table.is_empty()).then_some(table),
+                }
             })
             .collect();
         raw
@@ -953,17 +1101,45 @@ impl MachineSetup {
         }
     }
 
-    pub fn zorro_boards(&self) -> &[PathBuf] {
+    pub fn zorro_boards(&self) -> &[ZorroBoardSetup] {
         &self.zorro_boards
     }
 
     pub fn add_zorro(&mut self, path: PathBuf) {
-        self.zorro_boards.push(path);
+        self.zorro_boards.push(ZorroBoardSetup::load(path));
     }
 
     pub fn remove_zorro(&mut self, idx: usize) {
         if idx < self.zorro_boards.len() {
             self.zorro_boards.remove(idx);
+        }
+    }
+
+    /// Step an enum/int option on a board.
+    pub fn zorro_option_cycle(&mut self, board: usize, opt: usize, forward: bool) {
+        if let Some(b) = self.zorro_boards.get_mut(board) {
+            b.cycle(opt, forward);
+        }
+    }
+
+    /// Flip a bool option on a board.
+    pub fn zorro_option_toggle(&mut self, board: usize, opt: usize) {
+        if let Some(b) = self.zorro_boards.get_mut(board) {
+            b.toggle(opt);
+        }
+    }
+
+    /// Set a board option's value (a file path, or typed text).
+    pub fn zorro_option_set(&mut self, board: usize, opt: usize, value: String) {
+        if let Some(b) = self.zorro_boards.get_mut(board) {
+            b.set(opt, value);
+        }
+    }
+
+    /// Revert a board option to its manifest default.
+    pub fn zorro_option_clear(&mut self, board: usize, opt: usize) {
+        if let Some(b) = self.zorro_boards.get_mut(board) {
+            b.clear(opt);
         }
     }
 }
@@ -997,6 +1173,10 @@ pub struct LauncherState {
     pub setup: MachineSetup,
     pub tab: LauncherTab,
     pub status: Option<StatusMessage>,
+    /// The string/int plugin option being typed into (board index, option
+    /// index) and the edit buffer, when a text field has focus.
+    editing: Option<(usize, usize)>,
+    edit_buffer: String,
 }
 
 impl LauncherState {
@@ -1005,7 +1185,56 @@ impl LauncherState {
             setup,
             tab: LauncherTab::System,
             status: None,
+            editing: None,
+            edit_buffer: String::new(),
         }
+    }
+
+    /// The (board, option) currently being text-edited, if any.
+    pub fn editing(&self) -> Option<(usize, usize)> {
+        self.editing
+    }
+
+    /// The current edit buffer (for drawing the focused field).
+    pub fn edit_buffer(&self) -> &str {
+        &self.edit_buffer
+    }
+
+    /// Focus a board option for text entry, seeding the buffer with its value.
+    pub fn begin_edit(&mut self, board: usize, opt: usize) {
+        self.edit_buffer = self
+            .setup
+            .zorro_boards()
+            .get(board)
+            .map(|b| b.value(opt))
+            .unwrap_or_default();
+        self.editing = Some((board, opt));
+        self.status = None;
+    }
+
+    pub fn edit_push(&mut self, c: char) {
+        if self.editing.is_some() {
+            self.edit_buffer.push(c);
+        }
+    }
+
+    pub fn edit_backspace(&mut self) {
+        if self.editing.is_some() {
+            self.edit_buffer.pop();
+        }
+    }
+
+    /// Commit the edit buffer to the focused board option.
+    pub fn edit_commit(&mut self) {
+        if let Some((board, opt)) = self.editing.take() {
+            let value = std::mem::take(&mut self.edit_buffer);
+            self.setup.zorro_option_set(board, opt, value);
+        }
+    }
+
+    pub fn edit_cancel(&mut self) {
+        self.editing = None;
+        self.edit_buffer.clear();
     }
 
     /// Open the configuration panel seeded from a raw config (the running
@@ -1202,6 +1431,93 @@ fn pacing_name(pacing: PacingBudget) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_board_manifest() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "copperline-launcher-board-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &path,
+            r#"
+            name = "Test Plugin"
+            zorro = 2
+            type = "wasm"
+            size = "64K"
+            manufacturer = 5192
+            product = 16
+            wasm = "x.wasm"
+            [config]
+            speed = "fast"
+            verbose = false
+            [[option]]
+            key = "speed"
+            label = "Speed"
+            type = "enum"
+            choices = ["slow", "fast"]
+            [[option]]
+            key = "verbose"
+            label = "Verbose"
+            type = "bool"
+            [[option]]
+            key = "count"
+            label = "Count"
+            type = "int"
+            default = 3
+            [[option]]
+            key = "rom"
+            label = "ROM"
+            type = "file"
+        "#,
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn plugin_board_options_load_edit_and_round_trip() {
+        let path = write_board_manifest();
+        let mut board = ZorroBoardSetup::load(path.clone());
+        assert_eq!(board.options().len(), 4);
+        // Defaults: [config] for speed/verbose, the option default for count.
+        assert_eq!(board.value(0), "fast");
+        assert_eq!(board.value(1), "false");
+        assert_eq!(board.value(2), "3");
+        assert_eq!(board.value(3), ""); // unset file
+
+        board.cycle(0, true); // enum fast -> slow (wraps)
+        assert_eq!(board.value(0), "slow");
+        board.toggle(1); // bool false -> true
+        assert_eq!(board.value(1), "true");
+        board.cycle(2, false); // int 3 -> 2
+        assert_eq!(board.value(2), "2");
+        board.set(3, "/tmp/board.rom".into());
+        assert_eq!(board.value(3), "/tmp/board.rom");
+        board.clear(2); // revert int to its default
+        assert_eq!(board.value(2), "3");
+
+        // Overrides serialize back, typed per the option schema.
+        let mut setup = MachineSetup::default();
+        setup.zorro_boards = vec![board];
+        let raw = setup.to_raw();
+        let cfg = raw.zorro[0].config.as_ref().expect("overrides emitted");
+        assert_eq!(cfg.get("speed").unwrap().as_str(), Some("slow"));
+        assert_eq!(cfg.get("verbose").unwrap().as_bool(), Some(true));
+        assert_eq!(cfg.get("rom").unwrap().as_str(), Some("/tmp/board.rom"));
+        // "count" was reverted to default, so it is not emitted.
+        assert!(cfg.get("count").is_none());
+
+        // And those overrides round-trip back through from_raw.
+        let reloaded = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(reloaded.zorro_boards()[0].value(0), "slow");
+        assert_eq!(reloaded.zorro_boards()[0].value(1), "true");
+
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[test]
     fn default_setup_is_the_a500_aros_machine() {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1501,8 +1501,10 @@ mod tests {
         assert_eq!(board.value(2), "3");
 
         // Overrides serialize back, typed per the option schema.
-        let mut setup = MachineSetup::default();
-        setup.zorro_boards = vec![board];
+        let setup = MachineSetup {
+            zorro_boards: vec![board],
+            ..MachineSetup::default()
+        };
         let raw = setup.to_raw();
         let cfg = raw.zorro[0].config.as_ref().expect("overrides emitted");
         assert_eq!(cfg.get("speed").unwrap().as_str(), Some("slow"));

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -433,6 +433,32 @@ pub enum UiControl {
     LauncherZorroAdd,
     /// Configuration screen: remove the Zorro board at this index.
     LauncherZorroRemove(usize),
+    /// Plugin config: step an enum/int option of a Zorro board.
+    LauncherBoardCycle {
+        board: usize,
+        opt: usize,
+        forward: bool,
+    },
+    /// Plugin config: flip a bool option of a Zorro board.
+    LauncherBoardToggle {
+        board: usize,
+        opt: usize,
+    },
+    /// Plugin config: pick a file for a file-typed board option.
+    LauncherBoardBrowse {
+        board: usize,
+        opt: usize,
+    },
+    /// Plugin config: revert a board option to its manifest default.
+    LauncherBoardClear {
+        board: usize,
+        opt: usize,
+    },
+    /// Plugin config: focus a string/int board option for text entry.
+    LauncherBoardEdit {
+        board: usize,
+        opt: usize,
+    },
     /// Configuration screen: load a .toml configuration.
     LauncherLoad,
     /// Configuration screen: save the configuration to a .toml file.
@@ -2068,13 +2094,49 @@ fn launcher_action_rects(rect: Rect) -> [(UiControl, Rect); 4] {
     ]
 }
 
-/// The Zorro list sits below the Add button, which is pinned to the top of the
-/// pane, so board row `i` is at content row `i + 1`.
-fn launcher_zorro_remove_rect(rect: Rect, i: usize) -> Rect {
+/// One drawable/clickable item in the Zorro tab. The flat layout list keeps
+/// drawing and hit-testing in exact sync (immediate-mode UI).
+#[derive(Clone, Copy)]
+enum ZorroItem {
+    Header(usize),
+    Option { board: usize, opt: usize },
+}
+
+/// Flatten the Zorro boards into (content-row, item) pairs. Row 0 is the Add
+/// button, pinned to the top; each board header and its option rows follow.
+fn launcher_zorro_layout(setup: &launcher::MachineSetup) -> Vec<(usize, ZorroItem)> {
+    let mut items = Vec::new();
+    let mut row = 1;
+    for (i, board) in setup.zorro_boards().iter().enumerate() {
+        items.push((row, ZorroItem::Header(i)));
+        row += 1;
+        for opt in 0..board.options().len() {
+            items.push((row, ZorroItem::Option { board: i, opt }));
+            row += 1;
+        }
+    }
+    items
+}
+
+/// The Remove button for a board header drawn at content `row`.
+fn launcher_zorro_remove_rect(rect: Rect, row: usize) -> Rect {
     Rect {
         x: rect.x + rect.w - LAUNCH_MARGIN - LAUNCH_REMOVE_W,
-        y: launcher_row_y(rect, i + 1) + 2,
+        y: launcher_row_y(rect, row) + 2,
         w: LAUNCH_REMOVE_W,
+        h: LAUNCH_CONTROL_H,
+    }
+}
+
+/// The clickable value box for a string option at `row_y` (control column to
+/// the right margin).
+fn launcher_board_value_rect(rect: Rect, row_y: usize) -> Rect {
+    let x = launcher_control_x(rect);
+    let right = rect.x + rect.w - LAUNCH_MARGIN;
+    Rect {
+        x,
+        y: row_y + 2,
+        w: right.saturating_sub(x),
         h: LAUNCH_CONTROL_H,
     }
 }
@@ -2112,10 +2174,55 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
         }
     }
     if state.tab == LauncherTab::Zorro {
-        let count = state.setup.zorro_boards().len();
-        for i in 0..count {
-            if launcher_zorro_remove_rect(rect, i).contains(pos) {
-                return Some(UiControl::LauncherZorroRemove(i));
+        use crate::zorro::ConfigOptionKind as K;
+        for (row, item) in launcher_zorro_layout(&state.setup) {
+            let row_y = launcher_row_y(rect, row);
+            match item {
+                ZorroItem::Header(i) => {
+                    if launcher_zorro_remove_rect(rect, row).contains(pos) {
+                        return Some(UiControl::LauncherZorroRemove(i));
+                    }
+                }
+                ZorroItem::Option { board, opt } => {
+                    match &state.setup.zorro_boards()[board].options()[opt].kind {
+                        K::Bool => {
+                            if launcher_toggle_rect(rect, row_y).contains(pos) {
+                                return Some(UiControl::LauncherBoardToggle { board, opt });
+                            }
+                        }
+                        K::Enum(_) | K::Int => {
+                            let (prev, _v, next) = launcher_cycle_rects(rect, row_y);
+                            if prev.contains(pos) {
+                                return Some(UiControl::LauncherBoardCycle {
+                                    board,
+                                    opt,
+                                    forward: false,
+                                });
+                            }
+                            if next.contains(pos) {
+                                return Some(UiControl::LauncherBoardCycle {
+                                    board,
+                                    opt,
+                                    forward: true,
+                                });
+                            }
+                        }
+                        K::File => {
+                            let (browse, clear) = launcher_path_rects(rect, row_y);
+                            if browse.contains(pos) {
+                                return Some(UiControl::LauncherBoardBrowse { board, opt });
+                            }
+                            if clear.contains(pos) {
+                                return Some(UiControl::LauncherBoardClear { board, opt });
+                            }
+                        }
+                        K::String => {
+                            if launcher_board_value_rect(rect, row_y).contains(pos) {
+                                return Some(UiControl::LauncherBoardEdit { board, opt });
+                            }
+                        }
+                    }
+                }
             }
         }
         if launcher_zorro_add_rect(rect).contains(pos) {
@@ -2334,10 +2441,11 @@ fn draw_launcher_row(
 fn draw_launcher_zorro(
     frame: &mut [u8],
     rect: Rect,
-    setup: &launcher::MachineSetup,
+    state: &LauncherState,
     hover: Option<UiControl>,
     scale: usize,
 ) {
+    let setup = &state.setup;
     let pane_x = launcher_pane_x(rect);
     // Add button pinned to the top of the pane; the board list (or the empty
     // note) sits below it.
@@ -2349,8 +2457,7 @@ fn draw_launcher_zorro(
         hover == Some(UiControl::LauncherZorroAdd),
         scale,
     );
-    let boards = setup.zorro_boards();
-    if boards.is_empty() {
+    if setup.zorro_boards().is_empty() {
         draw_panel_text(
             frame,
             pane_x,
@@ -2361,31 +2468,166 @@ fn draw_launcher_zorro(
             scale,
         );
     }
-    for (i, board) in boards.iter().enumerate() {
-        let remove = launcher_zorro_remove_rect(rect, i);
-        let name = board
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| board.display().to_string());
-        let avail = remove.x.saturating_sub(pane_x + 8);
-        let name = truncate_to_width(&name, avail);
-        draw_panel_text(
-            frame,
-            pane_x,
-            launcher_row_y(rect, i + 1) + 8,
-            &name,
-            PANEL_TEXT,
-            1,
-            scale,
-        );
-        draw_text_button(
-            frame,
-            remove,
-            "Remove",
-            true,
-            hover == Some(UiControl::LauncherZorroRemove(i)),
-            scale,
-        );
+    for (row, item) in launcher_zorro_layout(setup) {
+        let row_y = launcher_row_y(rect, row);
+        match item {
+            ZorroItem::Header(i) => {
+                let board = &setup.zorro_boards()[i];
+                let remove = launcher_zorro_remove_rect(rect, row);
+                let name = truncate_to_width(&board.name(), remove.x.saturating_sub(pane_x + 8));
+                draw_panel_text(frame, pane_x, row_y + 8, &name, PANEL_TEXT, 1, scale);
+                draw_text_button(
+                    frame,
+                    remove,
+                    "Remove",
+                    true,
+                    hover == Some(UiControl::LauncherZorroRemove(i)),
+                    scale,
+                );
+            }
+            ZorroItem::Option { board, opt } => {
+                draw_launcher_board_option(frame, rect, state, board, opt, row_y, hover, scale);
+            }
+        }
+    }
+}
+
+/// Draw one plugin config-option row (indented under its board): a label plus
+/// the widget its kind calls for.
+fn draw_launcher_board_option(
+    frame: &mut [u8],
+    rect: Rect,
+    state: &LauncherState,
+    board: usize,
+    opt: usize,
+    row_y: usize,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    use crate::zorro::ConfigOptionKind as K;
+    let setup = &state.setup;
+    let option = &setup.zorro_boards()[board].options()[opt];
+    // Indented label.
+    let label_x = launcher_pane_x(rect) + 12;
+    let label = truncate_to_width(
+        &option.label,
+        launcher_control_x(rect).saturating_sub(label_x + 6),
+    );
+    draw_panel_text(frame, label_x, row_y + 8, &label, PANEL_TEXT, 1, scale);
+
+    let value = setup.zorro_boards()[board].value(opt);
+    match &option.kind {
+        K::Bool => {
+            let on = value.trim().eq_ignore_ascii_case("true");
+            draw_text_button(
+                frame,
+                launcher_toggle_rect(rect, row_y),
+                if on { "On" } else { "Off" },
+                true,
+                hover == Some(UiControl::LauncherBoardToggle { board, opt }),
+                scale,
+            );
+        }
+        K::Enum(_) | K::Int => {
+            let (prev, val, next) = launcher_cycle_rects(rect, row_y);
+            draw_text_button(
+                frame,
+                prev,
+                "<",
+                true,
+                hover
+                    == Some(UiControl::LauncherBoardCycle {
+                        board,
+                        opt,
+                        forward: false,
+                    }),
+                scale,
+            );
+            let shown = truncate_to_width(&value, val.w.saturating_sub(8));
+            draw_panel_text(
+                frame,
+                val.x + 6,
+                row_y + 8,
+                &shown,
+                PANEL_TEXT_HILIGHT,
+                1,
+                scale,
+            );
+            draw_text_button(
+                frame,
+                next,
+                ">",
+                true,
+                hover
+                    == Some(UiControl::LauncherBoardCycle {
+                        board,
+                        opt,
+                        forward: true,
+                    }),
+                scale,
+            );
+        }
+        K::File => {
+            let (browse, clear) = launcher_path_rects(rect, row_y);
+            let shown = if value.is_empty() {
+                "(none)".to_string()
+            } else {
+                std::path::Path::new(&value)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or(value.clone())
+            };
+            let avail = browse.x.saturating_sub(launcher_control_x(rect) + 6);
+            let shown = truncate_to_width(&shown, avail);
+            draw_panel_text(
+                frame,
+                launcher_control_x(rect),
+                row_y + 8,
+                &shown,
+                PANEL_TEXT,
+                1,
+                scale,
+            );
+            draw_text_button(
+                frame,
+                browse,
+                "Browse",
+                true,
+                hover == Some(UiControl::LauncherBoardBrowse { board, opt }),
+                scale,
+            );
+            draw_text_button(
+                frame,
+                clear,
+                "Clear",
+                true,
+                hover == Some(UiControl::LauncherBoardClear { board, opt }),
+                scale,
+            );
+        }
+        K::String => {
+            let editing = state.editing() == Some((board, opt));
+            let vbox = launcher_board_value_rect(rect, row_y);
+            draw_rect_bevel(
+                frame,
+                scale_rect(vbox, scale),
+                BUTTON_EDGE_DARK,
+                BUTTON_EDGE_LIGHT,
+                scale,
+            );
+            let text = if editing {
+                format!("{}_", state.edit_buffer())
+            } else {
+                value.clone()
+            };
+            let color = if editing {
+                PANEL_TEXT_HILIGHT
+            } else {
+                PANEL_TEXT
+            };
+            let shown = truncate_to_width(&text, vbox.w.saturating_sub(8));
+            draw_panel_text(frame, vbox.x + 4, row_y + 8, &shown, color, 1, scale);
+        }
     }
 }
 
@@ -2453,7 +2695,7 @@ fn draw_launcher(
     }
     // Active tab content in the settings pane.
     if state.tab == LauncherTab::Zorro {
-        draw_launcher_zorro(frame, rect, setup, hover, scale);
+        draw_launcher_zorro(frame, rect, state, hover, scale);
     } else {
         for (i, r) in launcher::rows(state.tab).iter().enumerate() {
             draw_launcher_row(frame, rect, setup, r, i, hover, scale);
@@ -3309,5 +3551,73 @@ mod tests {
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher");
+
+        // Configuration screen: the Zorro tab with a WASM plugin board whose
+        // config-option schema renders an editable field per option.
+        let manifest_path = std::env::temp_dir().join(format!(
+            "copperline-ui-preview-board-{}.toml",
+            std::process::id()
+        ));
+        std::fs::write(
+            &manifest_path,
+            r#"
+            name = "Demo NIC"
+            zorro = 2
+            type = "wasm"
+            size = "64K"
+            manufacturer = 5192
+            product = 16
+            wasm = "demo.wasm"
+            [config]
+            mode = "bridged"
+            [[option]]
+            key = "mode"
+            label = "Mode"
+            type = "enum"
+            choices = ["bridged", "nat"]
+            [[option]]
+            key = "verbose"
+            label = "Verbose"
+            type = "bool"
+            [[option]]
+            key = "mtu"
+            label = "MTU"
+            type = "int"
+            default = 1500
+            [[option]]
+            key = "rom"
+            label = "Boot ROM"
+            type = "file"
+            [[option]]
+            key = "mac"
+            label = "MAC address"
+            type = "string"
+            default = "02:00:10:00:00:01"
+        "#,
+        )
+        .unwrap();
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.setup.add_zorro(manifest_path.clone());
+        state.tab = LauncherTab::Zorro;
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(
+            &mut frame,
+            scale,
+            &ui,
+            None,
+            None,
+            false,
+            WarpSpeed::Max,
+            false,
+            false,
+            JoystickInputMode::Auto,
+        );
+        assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
+        save(&frame, "launcher-zorro");
+        let _ = std::fs::remove_file(&manifest_path);
     }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4724,10 +4724,42 @@ impl App {
             }
             UiControl::LauncherZorroRemove(idx) => {
                 if let Some(state) = self.launcher_state_mut() {
+                    state.edit_cancel();
                     state.setup.remove_zorro(idx);
                     state.status = None;
                 }
             }
+            UiControl::LauncherBoardCycle {
+                board,
+                opt,
+                forward,
+            } => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.edit_cancel();
+                    state.setup.zorro_option_cycle(board, opt, forward);
+                    state.status = None;
+                }
+            }
+            UiControl::LauncherBoardToggle { board, opt } => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.edit_cancel();
+                    state.setup.zorro_option_toggle(board, opt);
+                    state.status = None;
+                }
+            }
+            UiControl::LauncherBoardClear { board, opt } => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.edit_cancel();
+                    state.setup.zorro_option_clear(board, opt);
+                    state.status = None;
+                }
+            }
+            UiControl::LauncherBoardEdit { board, opt } => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.begin_edit(board, opt);
+                }
+            }
+            UiControl::LauncherBoardBrowse { board, opt } => self.launcher_board_browse(board, opt),
             UiControl::LauncherDefaults => {
                 if let Some(state) = self.launcher_state_mut() {
                     let model = state.setup.model();
@@ -4810,6 +4842,11 @@ impl App {
     fn ui_handle_key(&mut self, code: KeyCode) -> bool {
         if self.ui.active() {
             if code == KeyCode::Escape {
+                // While typing into a plugin option, Escape cancels the edit
+                // rather than closing the panel.
+                if self.launcher_cancel_edit_if_active() {
+                    return true;
+                }
                 if self.ui.menu_open {
                     self.ui.menu_open = false;
                     self.request_redraw();
@@ -4818,10 +4855,57 @@ impl App {
                 }
                 return true;
             }
+            // Route keys to a focused plugin-option text field, if any.
+            if self.launcher_handle_edit_key(code) {
+                return true;
+            }
             return false;
         }
         self.default_tool_key_kind()
             .is_some_and(|kind| self.ui_handle_tool_key(kind, code))
+    }
+
+    /// Cancel an in-progress plugin-option text edit, if one is focused.
+    fn launcher_cancel_edit_if_active(&mut self) -> bool {
+        let cancelled = matches!(
+            self.launcher_state_mut(),
+            Some(state) if state.editing().is_some()
+        );
+        if cancelled {
+            if let Some(state) = self.launcher_state_mut() {
+                state.edit_cancel();
+            }
+            self.request_redraw();
+        }
+        cancelled
+    }
+
+    /// Feed a key to a focused plugin-option text field. Returns false (so the
+    /// key falls through) when no field is being edited.
+    fn launcher_handle_edit_key(&mut self, code: KeyCode) -> bool {
+        let handled = {
+            let Some(state) = self.launcher_state_mut() else {
+                return false;
+            };
+            if state.editing().is_none() {
+                return false;
+            }
+            if let Some(ch) = entry_char_for_key(code) {
+                state.edit_push(ch);
+            } else {
+                match code {
+                    KeyCode::Backspace => state.edit_backspace(),
+                    KeyCode::Enter | KeyCode::NumpadEnter => state.edit_commit(),
+                    // Swallow other keys while a field has focus.
+                    _ => {}
+                }
+            }
+            true
+        };
+        if handled {
+            self.request_redraw();
+        }
+        handled
     }
 
     fn default_tool_key_kind(&self) -> Option<ToolPanelKind> {
@@ -5185,6 +5269,24 @@ impl App {
         if let Some(path) = picked {
             if let Some(state) = self.launcher_state_mut() {
                 state.setup.add_zorro(path);
+                state.status = None;
+            }
+        }
+        self.finish_host_io_pause();
+    }
+
+    /// Pick a file for a plugin board's file-typed config option.
+    fn launcher_board_browse(&mut self, board: usize, opt: usize) {
+        self.suspend_live_audio_for_host_io();
+        let picked = rfd::FileDialog::new()
+            .set_title("Choose plugin file")
+            .pick_file();
+        if let Some(path) = picked {
+            if let Some(state) = self.launcher_state_mut() {
+                state.edit_cancel();
+                state
+                    .setup
+                    .zorro_option_set(board, opt, path.to_string_lossy().into_owned());
                 state.status = None;
             }
         }

--- a/src/wasmboard.rs
+++ b/src/wasmboard.rs
@@ -39,6 +39,7 @@
 //! wasmtime build; the version is pinned in `Cargo.toml`.
 
 use crate::memory::Memory;
+use crate::net::{make_backend, NetBackend, NetConfig};
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -59,14 +60,19 @@ pub struct WasmCaps {
     pub int2: bool,
     /// Asserts the INT6 (EXTER) line (advisory; the `int6` export is polled).
     pub int6: bool,
+    /// Host networking (`net_send`/`net_recv` imports). A net board is
+    /// non-deterministic; see [`crate::net`].
+    pub net: bool,
 }
 
-/// A plugin's non-autoconfig metadata: its display name and capabilities. The
-/// autoconfig identity lives in the board's [`crate::zorro::BoardSpec`].
+/// A plugin's non-autoconfig metadata: its display name, capabilities, and (for
+/// a NIC board) which host network backend to bring up. The autoconfig identity
+/// lives in the board's [`crate::zorro::BoardSpec`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WasmManifest {
     pub name: String,
     pub caps: WasmCaps,
+    pub net: NetConfig,
 }
 
 /// Store data for host imports. The Amiga-memory pointer is stored as a
@@ -76,6 +82,10 @@ struct HostCtx {
     /// Address of the live `Memory`, valid only during a plugin call.
     mem: usize,
     name: String,
+    /// Host network backend for a NIC plugin (the `net` capability). A host
+    /// resource, not serialized: brought up fresh from the manifest's
+    /// [`NetConfig`] on instantiation and reset.
+    net: Option<Box<dyn NetBackend>>,
 }
 
 /// The typed entry points a plugin may export.
@@ -123,6 +133,7 @@ impl WasmRuntime {
             HostCtx {
                 mem: 0,
                 name: manifest.name.clone(),
+                net: make_backend(manifest.net),
             },
         );
         let mut linker = Linker::new(engine);
@@ -246,6 +257,37 @@ fn register_host_fns(linker: &mut Linker<HostCtx>, caps: WasmCaps) -> Result<()>
             },
         )?;
     }
+
+    if caps.net {
+        // net_send(ptr, len): transmit the Ethernet frame in linear memory.
+        linker.func_wrap(
+            "env",
+            "net_send",
+            |mut caller: Caller<'_, HostCtx>, ptr: i32, len: i32| -> Result<()> {
+                let frame = read_wasm_bytes(&mut caller, ptr, len)?;
+                if let Some(net) = caller.data_mut().net.as_mut() {
+                    net.send(&frame);
+                }
+                Ok(())
+            },
+        )?;
+
+        // net_recv(ptr, cap) -> i32: copy the next inbound frame into linear
+        // memory at `ptr` (truncated to `cap` bytes) and return its length, or
+        // 0 when none is waiting.
+        linker.func_wrap(
+            "env",
+            "net_recv",
+            |mut caller: Caller<'_, HostCtx>, ptr: i32, cap: i32| -> Result<i32> {
+                let Some(frame) = caller.data_mut().net.as_mut().and_then(|n| n.poll()) else {
+                    return Ok(0);
+                };
+                let n = frame.len().min(cap.max(0) as usize);
+                write_wasm_bytes(&mut caller, ptr, &frame[..n])?;
+                Ok(n as i32)
+            },
+        )?;
+    }
     Ok(())
 }
 
@@ -304,6 +346,15 @@ pub struct WasmBoard {
 impl WasmBoard {
     /// Load and instantiate a plugin module from a `.wasm` file.
     pub fn from_file(path: &Path, manifest: WasmManifest) -> Result<Self> {
+        if manifest.net != NetConfig::None {
+            log::warn!(
+                "wasm[{}]: network backend {:?} active -- deterministic replay \
+                 and save-state reproducibility are not guaranteed while \
+                 traffic flows",
+                manifest.name,
+                manifest.net
+            );
+        }
         let engine = make_engine()?;
         let module = Module::from_file(&engine, path)
             .with_context(|| format!("compiling WASM plugin {}", path.display()))?;
@@ -505,7 +556,22 @@ mod tests {
                 dma,
                 int2: true,
                 int6: false,
+                net: false,
             },
+            net: NetConfig::None,
+        }
+    }
+
+    fn net_manifest(name: &str) -> WasmManifest {
+        WasmManifest {
+            name: name.into(),
+            caps: WasmCaps {
+                dma: false,
+                int2: false,
+                int6: false,
+                net: true,
+            },
+            net: NetConfig::Loopback,
         }
     }
 
@@ -627,6 +693,47 @@ mod tests {
         // write() triggers dma_read of 4 bytes from Amiga $40.
         board.write(0, 0, 0x40, &mut host);
         assert_eq!(board.read(0, 4, &mut host), 0xDEAD_BEEF);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A NIC test plugin: `write(_, _, val)` transmits a 4-byte frame
+    /// `[val, AA, BB, CC]`; `read` polls a frame into linear memory and returns
+    /// `(len << 16) | first_byte`. With the loopback backend, what is sent
+    /// comes straight back.
+    const NET_WAT: &str = r#"
+        (module
+          (import "env" "net_send" (func $net_send (param i32 i32)))
+          (import "env" "net_recv" (func $net_recv (param i32 i32) (result i32)))
+          (memory (export "memory") 1)
+          (func (export "write") (param $off i32) (param $size i32) (param $val i32)
+            (i32.store8 (i32.const 32) (local.get $val))
+            (i32.store8 (i32.const 33) (i32.const 0xAA))
+            (i32.store8 (i32.const 34) (i32.const 0xBB))
+            (i32.store8 (i32.const 35) (i32.const 0xCC))
+            (call $net_send (i32.const 32) (i32.const 4)))
+          (func (export "read") (param $off i32) (param $size i32) (result i32)
+            (local $n i32)
+            (local.set $n (call $net_recv (i32.const 64) (i32.const 128)))
+            (i32.or
+              (i32.shl (local.get $n) (i32.const 16))
+              (i32.load8_u (i32.const 64))))
+        )
+    "#;
+
+    #[test]
+    fn net_send_and_recv_round_trip_over_loopback() {
+        let path = write_wasm("net", NET_WAT);
+        let mut board = WasmBoard::from_file(&path, net_manifest("net")).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+
+        // Transmit a frame; the loopback backend queues it straight back.
+        board.write(0, 0, 0x5E, &mut host);
+        // read() polls it: length 4, first byte 0x5E.
+        assert_eq!(board.read(0, 0, &mut host), (4 << 16) | 0x5E);
+        // No more frames waiting -> length 0 in the high half.
+        assert_eq!(board.read(0, 0, &mut host) >> 16, 0);
 
         let _ = std::fs::remove_file(&path);
     }

--- a/src/wasmboard.rs
+++ b/src/wasmboard.rs
@@ -1,0 +1,654 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! WASM-hosted functional Zorro board: an external plugin compiled to
+//! `wasm32` that implements a board's behaviour, run under wasmtime.
+//!
+//! A plugin module exports its behaviour and imports a small set of host
+//! services (see the ABI below); its entire mutable state lives in WebAssembly
+//! linear memory, which is a flat byte array that snapshots and restores
+//! exactly like the Amiga RAM the emulator already serializes. That is why WASM
+//! fits Copperline's determinism / save-state contract.
+//!
+//! ## Module ABI
+//!
+//! Exports the plugin provides (all optional except `memory`):
+//! - `memory`                       the linear memory (required)
+//! - `init()`                       called once after instantiation
+//! - `read(off: i32, size: i32) -> i32`   register read in the board window
+//! - `write(off: i32, size: i32, value: i32)`  register write
+//! - `tick(cck: i32)`               advance by `cck` colour clocks
+//! - `int2() -> i32`                INT2 (PORTS) line state, 0/1
+//! - `int6() -> i32`                INT6 (EXTER) line state, 0/1
+//!
+//! Imports the host provides in module `env` (capability-gated):
+//! - `log(ptr: i32, len: i32)`                      always available
+//! - `dma_read(addr: i32, ptr: i32, len: i32)`      requires the `dma` capability
+//! - `dma_write(addr: i32, ptr: i32, len: i32)`     requires the `dma` capability
+//!
+//! `dma_read` copies `len` bytes from Amiga address `addr` into the plugin's
+//! linear memory at `ptr`; `dma_write` copies the other way. Both use the
+//! shared 24-bit chip/slow/Zorro decode in [`crate::zorro_device`].
+//!
+//! ## Determinism
+//!
+//! The wasmtime engine is configured for determinism (NaN canonicalization, no
+//! SIMD/threads). Persistent mutable state must live in linear memory: snapshots
+//! capture linear memory and its page count, not WebAssembly globals (the
+//! shadow-stack pointer is unwound to a constant between calls, so it needs no
+//! capture). Save-state replay of a plugin is only guaranteed within one
+//! wasmtime build; the version is pinned in `Cargo.toml`.
+
+use crate::memory::Memory;
+use crate::zorro_device::{DeviceHost, ZorroDevice};
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+use wasmtime::{
+    Caller, Config, Engine, Extern, Linker, Memory as WasmMemory, Module, Store, TypedFunc,
+};
+
+/// Capabilities a plugin declares in its manifest; ungranted host imports are
+/// not linked, so a module that needs more than it declared fails to
+/// instantiate (loudly) rather than silently misbehaving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct WasmCaps {
+    /// Bus-master DMA into Amiga memory (`dma_read`/`dma_write` imports).
+    pub dma: bool,
+    /// Asserts the INT2 (PORTS) line (advisory; the `int2` export is polled).
+    pub int2: bool,
+    /// Asserts the INT6 (EXTER) line (advisory; the `int6` export is polled).
+    pub int6: bool,
+}
+
+/// A plugin's non-autoconfig metadata: its display name and capabilities. The
+/// autoconfig identity lives in the board's [`crate::zorro::BoardSpec`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WasmManifest {
+    pub name: String,
+    pub caps: WasmCaps,
+}
+
+/// Store data for host imports. The Amiga-memory pointer is stored as a
+/// `usize` (0 = none) so the store stays `Send`; it is set to the live
+/// `&mut Memory` only for the duration of a plugin call (see [`WasmRuntime::enter`]).
+struct HostCtx {
+    /// Address of the live `Memory`, valid only during a plugin call.
+    mem: usize,
+    name: String,
+}
+
+/// The typed entry points a plugin may export.
+struct Exports {
+    read: Option<TypedFunc<(i32, i32), i32>>,
+    write: Option<TypedFunc<(i32, i32, i32), ()>>,
+    tick: Option<TypedFunc<i32, ()>>,
+    int2: Option<TypedFunc<(), i32>>,
+    int6: Option<TypedFunc<(), i32>>,
+}
+
+/// The live wasmtime state for one plugin board. Holds the engine and compiled
+/// module so a power-on reset can re-instantiate a fresh module (clearing the
+/// plugin's RAM) without recompiling.
+struct WasmRuntime {
+    engine: Engine,
+    module: Module,
+    manifest: WasmManifest,
+    store: Store<HostCtx>,
+    memory: WasmMemory,
+    exports: Exports,
+}
+
+impl WasmRuntime {
+    fn new(engine: Engine, module: Module, manifest: WasmManifest) -> Result<Self> {
+        let (store, memory, exports) = Self::instantiate(&engine, &module, &manifest)?;
+        Ok(Self {
+            engine,
+            module,
+            manifest,
+            store,
+            memory,
+            exports,
+        })
+    }
+
+    /// Build a fresh store/instance from an engine + compiled module.
+    fn instantiate(
+        engine: &Engine,
+        module: &Module,
+        manifest: &WasmManifest,
+    ) -> Result<(Store<HostCtx>, WasmMemory, Exports)> {
+        let mut store = Store::new(
+            engine,
+            HostCtx {
+                mem: 0,
+                name: manifest.name.clone(),
+            },
+        );
+        let mut linker = Linker::new(engine);
+        register_host_fns(&mut linker, manifest.caps)?;
+        let instance = linker
+            .instantiate(&mut store, module)
+            .context("instantiating WASM plugin")?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| anyhow!("WASM plugin exports no `memory`"))?;
+        let exports = Exports {
+            read: instance.get_typed_func(&mut store, "read").ok(),
+            write: instance.get_typed_func(&mut store, "write").ok(),
+            tick: instance.get_typed_func(&mut store, "tick").ok(),
+            int2: instance.get_typed_func(&mut store, "int2").ok(),
+            int6: instance.get_typed_func(&mut store, "int6").ok(),
+        };
+        if let Ok(init) = instance.get_typed_func::<(), ()>(&mut store, "init") {
+            init.call(&mut store, ())
+                .context("WASM plugin init() trapped")?;
+        }
+        Ok((store, memory, exports))
+    }
+
+    /// Re-instantiate from the kept engine + module (cold reset: clears RAM).
+    fn reset(&mut self) -> Result<()> {
+        let (store, memory, exports) =
+            Self::instantiate(&self.engine, &self.module, &self.manifest)?;
+        self.store = store;
+        self.memory = memory;
+        self.exports = exports;
+        Ok(())
+    }
+
+    /// Point the store at the live Amiga memory for the duration of a call.
+    fn enter(&mut self, mem: &mut Memory) {
+        self.store.data_mut().mem = mem as *mut Memory as usize;
+    }
+
+    /// Clear the Amiga-memory pointer once a call returns.
+    fn leave(&mut self) {
+        self.store.data_mut().mem = 0;
+    }
+
+    /// Snapshot linear memory and its current page count.
+    fn snapshot(&mut self) -> (u64, Vec<u8>) {
+        let pages = self.memory.size(&self.store);
+        let bytes = self.memory.data(&self.store).to_vec();
+        (pages, bytes)
+    }
+
+    /// Restore a snapshot: grow linear memory to the saved page count, then
+    /// write the saved bytes back.
+    fn restore(&mut self, pages: u64, bytes: &[u8]) -> Result<()> {
+        let cur = self.memory.size(&self.store);
+        if pages > cur {
+            self.memory
+                .grow(&mut self.store, pages - cur)
+                .context("growing WASM plugin memory on restore")?;
+        }
+        self.memory
+            .write(&mut self.store, 0, bytes)
+            .context("restoring WASM plugin memory")?;
+        Ok(())
+    }
+}
+
+/// Build the deterministic wasmtime engine. NaN canonicalization removes
+/// host-CPU NaN bit-pattern leakage; SIMD/relaxed-SIMD/threads are disabled
+/// (relaxed-SIMD is nondeterministic by spec, threads add shared-memory
+/// nondeterminism).
+fn make_engine() -> Result<Engine> {
+    let mut cfg = Config::new();
+    cfg.cranelift_nan_canonicalization(true);
+    cfg.wasm_simd(false);
+    cfg.wasm_relaxed_simd(false);
+    // The `threads` wasmtime feature is not built in (see Cargo.toml), so shared
+    // memory / atomics are unavailable -- no separate knob needed.
+    Engine::new(&cfg).context("creating WASM engine")
+}
+
+/// Register the host imports the plugin may call, gated by capability.
+fn register_host_fns(linker: &mut Linker<HostCtx>, caps: WasmCaps) -> Result<()> {
+    // log(ptr, len): always available.
+    linker.func_wrap(
+        "env",
+        "log",
+        |mut caller: Caller<'_, HostCtx>, ptr: i32, len: i32| -> Result<()> {
+            let buf = read_wasm_bytes(&mut caller, ptr, len)?;
+            let name = caller.data().name.clone();
+            log::info!("wasm[{name}]: {}", String::from_utf8_lossy(&buf));
+            Ok(())
+        },
+    )?;
+
+    if caps.dma {
+        // dma_read(addr, ptr, len): Amiga[addr..] -> wasm linear memory[ptr..].
+        linker.func_wrap(
+            "env",
+            "dma_read",
+            |mut caller: Caller<'_, HostCtx>, addr: i32, ptr: i32, len: i32| -> Result<()> {
+                let len = len.max(0) as usize;
+                let mut buf = vec![0u8; len];
+                with_amiga_memory(&caller, |amiga| {
+                    DeviceHost::new(amiga).dma_read(addr as u32, &mut buf);
+                });
+                write_wasm_bytes(&mut caller, ptr, &buf)
+            },
+        )?;
+
+        // dma_write(addr, ptr, len): wasm linear memory[ptr..] -> Amiga[addr..].
+        linker.func_wrap(
+            "env",
+            "dma_write",
+            |mut caller: Caller<'_, HostCtx>, addr: i32, ptr: i32, len: i32| -> Result<()> {
+                let buf = read_wasm_bytes(&mut caller, ptr, len)?;
+                with_amiga_memory(&caller, |amiga| {
+                    DeviceHost::new(amiga).dma_write(addr as u32, &buf);
+                });
+                Ok(())
+            },
+        )?;
+    }
+    Ok(())
+}
+
+/// Run `f` with the live Amiga memory the store currently points at. No-op when
+/// the pointer is unset (a plugin should only DMA from within a host call).
+fn with_amiga_memory(caller: &Caller<'_, HostCtx>, f: impl FnOnce(&mut Memory)) {
+    let mem = caller.data().mem;
+    if mem == 0 {
+        return;
+    }
+    // SAFETY: `mem` is the address of the `&mut Memory` set by `WasmRuntime::enter`
+    // for the duration of this plugin call (see the ZorroDevice impl below). It is
+    // not aliased while the plugin runs -- the outer DeviceHost is not touched
+    // until the call returns -- and is cleared to 0 afterwards.
+    let amiga = unsafe { &mut *(mem as *mut Memory) };
+    f(amiga);
+}
+
+/// Read `len` bytes from the plugin's linear memory at `ptr`.
+fn read_wasm_bytes(caller: &mut Caller<'_, HostCtx>, ptr: i32, len: i32) -> Result<Vec<u8>> {
+    let memory = caller_memory(caller)?;
+    let len = len.max(0) as usize;
+    let mut buf = vec![0u8; len];
+    memory
+        .read(&mut *caller, ptr.max(0) as usize, &mut buf)
+        .context("reading WASM plugin memory")?;
+    Ok(buf)
+}
+
+/// Write `buf` into the plugin's linear memory at `ptr`.
+fn write_wasm_bytes(caller: &mut Caller<'_, HostCtx>, ptr: i32, buf: &[u8]) -> Result<()> {
+    let memory = caller_memory(caller)?;
+    memory
+        .write(&mut *caller, ptr.max(0) as usize, buf)
+        .context("writing WASM plugin memory")?;
+    Ok(())
+}
+
+fn caller_memory(caller: &mut Caller<'_, HostCtx>) -> Result<WasmMemory> {
+    caller
+        .get_export("memory")
+        .and_then(Extern::into_memory)
+        .ok_or_else(|| anyhow!("WASM plugin exports no `memory`"))
+}
+
+/// A functional Zorro board implemented by a WASM plugin module.
+///
+/// Serializes via a path-reopen shadow (like HDF/CD images): the snapshot
+/// carries the module path, manifest, and a linear-memory image; on load the
+/// module is recompiled from its path and the image replayed.
+pub struct WasmBoard {
+    module_path: PathBuf,
+    rt: RefCell<WasmRuntime>,
+}
+
+impl WasmBoard {
+    /// Load and instantiate a plugin module from a `.wasm` file.
+    pub fn from_file(path: &Path, manifest: WasmManifest) -> Result<Self> {
+        let engine = make_engine()?;
+        let module = Module::from_file(&engine, path)
+            .with_context(|| format!("compiling WASM plugin {}", path.display()))?;
+        let rt = WasmRuntime::new(engine, module, manifest)?;
+        Ok(Self {
+            module_path: path.to_path_buf(),
+            rt: RefCell::new(rt),
+        })
+    }
+
+    /// Call an exported function that takes no Amiga memory, returning its
+    /// `i32` result (0 if the export is absent or traps).
+    fn call_flag(&self, sel: impl FnOnce(&Exports) -> Option<TypedFunc<(), i32>>) -> bool {
+        let mut rt = self.rt.borrow_mut();
+        let Some(func) = sel(&rt.exports) else {
+            return false;
+        };
+        match func.call(&mut rt.store, ()) {
+            Ok(v) => v != 0,
+            Err(e) => {
+                log::warn!("wasm[{}]: int line query trapped: {e}", rt.manifest.name);
+                false
+            }
+        }
+    }
+}
+
+impl ZorroDevice for WasmBoard {
+    fn read(&mut self, off: u32, size: usize, host: &mut DeviceHost) -> u32 {
+        let rt = self.rt.get_mut();
+        let Some(func) = rt.exports.read.clone() else {
+            return 0xFFFF_FFFF;
+        };
+        rt.enter(host.memory_mut());
+        let result = func.call(&mut rt.store, (off as i32, size as i32));
+        rt.leave();
+        match result {
+            Ok(v) => v as u32,
+            Err(e) => {
+                log::warn!("wasm[{}]: read trapped: {e}", rt.manifest.name);
+                0xFFFF_FFFF
+            }
+        }
+    }
+
+    fn write(&mut self, off: u32, size: usize, value: u32, host: &mut DeviceHost) {
+        let rt = self.rt.get_mut();
+        let Some(func) = rt.exports.write.clone() else {
+            return;
+        };
+        rt.enter(host.memory_mut());
+        let result = func.call(&mut rt.store, (off as i32, size as i32, value as i32));
+        rt.leave();
+        if let Err(e) = result {
+            log::warn!("wasm[{}]: write trapped: {e}", rt.manifest.name);
+        }
+    }
+
+    fn tick(&mut self, cck: u32, host: &mut DeviceHost) {
+        let rt = self.rt.get_mut();
+        let Some(func) = rt.exports.tick.clone() else {
+            return;
+        };
+        rt.enter(host.memory_mut());
+        let result = func.call(&mut rt.store, cck as i32);
+        rt.leave();
+        if let Err(e) = result {
+            log::warn!("wasm[{}]: tick trapped: {e}", rt.manifest.name);
+        }
+    }
+
+    fn int2_line(&self) -> bool {
+        self.call_flag(|e| e.int2.clone())
+    }
+
+    fn int6_line(&self) -> bool {
+        self.call_flag(|e| e.int6.clone())
+    }
+
+    // Ticked every slice (the plugin decides what to do); a sparse next_event
+    // model is a future optimization.
+    fn is_idle(&self) -> bool {
+        false
+    }
+
+    fn reset(&mut self) {
+        if let Err(e) = self.rt.get_mut().reset() {
+            log::error!("wasm: plugin reset failed: {e}");
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        "wasm"
+    }
+}
+
+/// The serialized form of a [`WasmBoard`]: enough to recompile the module from
+/// its path and replay its linear memory.
+#[derive(Serialize, Deserialize)]
+struct WasmBoardState {
+    module_path: PathBuf,
+    manifest: WasmManifest,
+    pages: u64,
+    bytes: Vec<u8>,
+}
+
+impl Serialize for WasmBoard {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut rt = self.rt.borrow_mut();
+        let (pages, bytes) = rt.snapshot();
+        let state = WasmBoardState {
+            module_path: self.module_path.clone(),
+            manifest: rt.manifest.clone(),
+            pages,
+            bytes,
+        };
+        state.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for WasmBoard {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let state = WasmBoardState::deserialize(deserializer)?;
+        let board = WasmBoard::from_file(&state.module_path, state.manifest)
+            .map_err(serde::de::Error::custom)?;
+        board
+            .rt
+            .borrow_mut()
+            .restore(state.pages, &state.bytes)
+            .map_err(serde::de::Error::custom)?;
+        Ok(board)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A golden test plugin: a 16-bit counter at window offset 0, incremented
+    /// by `tick`, readable/writable, asserting INT2 once it passes a threshold.
+    /// Its whole state is one i32 in linear memory at address 0.
+    const COUNTER_WAT: &str = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "read") (param $off i32) (param $size i32) (result i32)
+            (i32.load (i32.const 0)))
+          (func (export "write") (param $off i32) (param $size i32) (param $val i32)
+            (i32.store (i32.const 0) (local.get $val)))
+          (func (export "tick") (param $cck i32)
+            (i32.store (i32.const 0)
+              (i32.add (i32.load (i32.const 0)) (i32.const 1))))
+          (func (export "int2") (result i32)
+            (i32.gt_u (i32.load (i32.const 0)) (i32.const 3)))
+        )
+    "#;
+
+    /// A DMA test plugin: `write(off, size, val)` reads 4 bytes from Amiga
+    /// address `val` into linear memory and stores their big-endian sum back so
+    /// `read` returns it; exercises the dma_read host import.
+    const DMA_WAT: &str = r#"
+        (module
+          (import "env" "dma_read" (func $dma_read (param i32 i32 i32)))
+          (memory (export "memory") 1)
+          (func (export "read") (param $off i32) (param $size i32) (result i32)
+            (i32.load (i32.const 0)))
+          (func (export "write") (param $off i32) (param $size i32) (param $addr i32)
+            ;; copy 4 bytes from Amiga[$addr] into linear memory at offset 16
+            (call $dma_read (local.get $addr) (i32.const 16) (i32.const 4))
+            ;; store the 32-bit big-endian value at offset 0
+            (i32.store (i32.const 0)
+              (i32.or
+                (i32.or
+                  (i32.shl (i32.load8_u (i32.const 16)) (i32.const 24))
+                  (i32.shl (i32.load8_u (i32.const 17)) (i32.const 16)))
+                (i32.or
+                  (i32.shl (i32.load8_u (i32.const 18)) (i32.const 8))
+                  (i32.load8_u (i32.const 19))))))
+        )
+    "#;
+
+    fn write_wasm(name: &str, wat: &str) -> PathBuf {
+        let bytes = wat::parse_str(wat).expect("valid WAT");
+        let path = std::env::temp_dir().join(format!(
+            "copperline-wasmboard-{name}-{}-{}.wasm",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, &bytes).expect("write wasm");
+        path
+    }
+
+    fn manifest(name: &str, dma: bool) -> WasmManifest {
+        WasmManifest {
+            name: name.into(),
+            caps: WasmCaps {
+                dma,
+                int2: true,
+                int6: false,
+            },
+        }
+    }
+
+    fn empty_memory() -> Memory {
+        Memory {
+            chip_ram: vec![0u8; 0x1000],
+            slow_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    #[test]
+    fn counter_plugin_reads_writes_and_ticks() {
+        let path = write_wasm("counter", COUNTER_WAT);
+        let mut board = WasmBoard::from_file(&path, manifest("counter", false)).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+
+        assert_eq!(board.read(0, 2, &mut host), 0);
+        board.write(0, 2, 10, &mut host);
+        assert_eq!(board.read(0, 2, &mut host), 10);
+
+        // tick increments; int2 asserts once the counter passes 3.
+        let mut fresh = WasmBoard::from_file(&path, manifest("counter", false)).unwrap();
+        assert!(!fresh.int2_line());
+        for _ in 0..5 {
+            fresh.tick(1, &mut host);
+        }
+        assert_eq!(fresh.read(0, 2, &mut host), 5);
+        assert!(fresh.int2_line());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn reset_clears_plugin_memory() {
+        let path = write_wasm("counter", COUNTER_WAT);
+        let mut board = WasmBoard::from_file(&path, manifest("counter", false)).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+
+        board.write(0, 2, 42, &mut host);
+        assert_eq!(board.read(0, 2, &mut host), 42);
+        board.reset();
+        assert_eq!(board.read(0, 2, &mut host), 0);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_state_round_trip_is_byte_identical() {
+        let path = write_wasm("counter", COUNTER_WAT);
+        let mut board = WasmBoard::from_file(&path, manifest("counter", false)).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0, 2, 99, &mut host);
+
+        // Serialize, mutate the live board, then restore from the snapshot.
+        let blob = bincode::serialize(&board).unwrap();
+        board.write(0, 2, 7, &mut host);
+        assert_eq!(board.read(0, 2, &mut host), 7);
+
+        let restored: WasmBoard = bincode::deserialize(&blob).unwrap();
+        let mut rmem = empty_memory();
+        let mut rhost = DeviceHost::new(&mut rmem);
+        let mut restored = restored;
+        assert_eq!(restored.read(0, 2, &mut rhost), 99);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn memory_grow_round_trips_through_a_snapshot() {
+        // A plugin that grows its memory then writes a marker high up; the
+        // snapshot must capture the grown page count and the marker.
+        let grow_wat = r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "write") (param i32 i32 i32)
+                (drop (memory.grow (i32.const 1)))
+                (i32.store (i32.const 65540) (i32.const 12345)))
+              (func (export "read") (param i32 i32) (result i32)
+                (i32.load (i32.const 65540)))
+            )
+        "#;
+        let path = write_wasm("grow", grow_wat);
+        let mut board = WasmBoard::from_file(&path, manifest("grow", false)).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0, 0, 0, &mut host); // grow + write marker in the new page
+        assert_eq!(board.read(0, 0, &mut host), 12345);
+
+        let blob = bincode::serialize(&board).unwrap();
+        let mut restored: WasmBoard = bincode::deserialize(&blob).unwrap();
+        let mut rmem = empty_memory();
+        let mut rhost = DeviceHost::new(&mut rmem);
+        assert_eq!(restored.read(0, 0, &mut rhost), 12345);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn dma_read_import_reaches_amiga_chip_ram() {
+        let path = write_wasm("dma", DMA_WAT);
+        let mut board = WasmBoard::from_file(&path, manifest("dma", true)).unwrap();
+        let mut mem = empty_memory();
+        mem.chip_ram[0x40] = 0xDE;
+        mem.chip_ram[0x41] = 0xAD;
+        mem.chip_ram[0x42] = 0xBE;
+        mem.chip_ram[0x43] = 0xEF;
+        let mut host = DeviceHost::new(&mut mem);
+
+        // write() triggers dma_read of 4 bytes from Amiga $40.
+        board.write(0, 0, 0x40, &mut host);
+        assert_eq!(board.read(0, 4, &mut host), 0xDEAD_BEEF);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Materialise an inert example plugin `.wasm` (autoconfigures, answers a
+    /// constant, no interrupts/DMA) to the path in `COPPERLINE_EMIT_WASM`, for
+    /// end-to-end boot testing and as a starting point for plugin authors.
+    /// Run with: `COPPERLINE_EMIT_WASM=/path/board.wasm cargo test --release \
+    /// emit_example_plugin_wasm -- --ignored`.
+    #[test]
+    #[ignore]
+    fn emit_example_plugin_wasm() {
+        let inert = r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "read") (param i32 i32) (result i32)
+                (i32.const 0x12345678))
+              (func (export "write") (param i32 i32 i32))
+              (func (export "tick") (param i32)))
+        "#;
+        let out = std::env::var("COPPERLINE_EMIT_WASM").expect("set COPPERLINE_EMIT_WASM");
+        std::fs::write(&out, wat::parse_str(inert).expect("valid WAT")).expect("write wasm");
+        eprintln!("wrote example plugin to {out}");
+    }
+}

--- a/src/wasmboard.rs
+++ b/src/wasmboard.rs
@@ -44,6 +44,7 @@ use crate::zorro_device::{DeviceHost, ZorroDevice};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use wasmtime::{
     Caller, Config, Engine, Extern, Linker, Memory as WasmMemory, Module, Store, TypedFunc,
@@ -73,6 +74,12 @@ pub struct WasmManifest {
     pub name: String,
     pub caps: WasmCaps,
     pub net: NetConfig,
+    /// Effective plugin settings (manifest defaults merged with the user's
+    /// per-board overrides), exposed to the module via the `config_get` import.
+    pub config: BTreeMap<String, String>,
+    /// Config keys whose values are host file paths; the host loads each file
+    /// and exposes it to the module via `resource_read` under the same key.
+    pub file_keys: Vec<String>,
 }
 
 /// Store data for host imports. The Amiga-memory pointer is stored as a
@@ -86,6 +93,10 @@ struct HostCtx {
     /// resource, not serialized: brought up fresh from the manifest's
     /// [`NetConfig`] on instantiation and reset.
     net: Option<Box<dyn NetBackend>>,
+    /// Effective plugin settings, read by the `config_get` import.
+    config: BTreeMap<String, String>,
+    /// Loaded file resources, read by the `resource_*` imports.
+    resources: HashMap<String, Vec<u8>>,
 }
 
 /// The typed entry points a plugin may export.
@@ -104,6 +115,8 @@ struct WasmRuntime {
     engine: Engine,
     module: Module,
     manifest: WasmManifest,
+    /// File resources loaded once from the manifest's file-typed config values.
+    resources: HashMap<String, Vec<u8>>,
     store: Store<HostCtx>,
     memory: WasmMemory,
     exports: Exports,
@@ -111,11 +124,13 @@ struct WasmRuntime {
 
 impl WasmRuntime {
     fn new(engine: Engine, module: Module, manifest: WasmManifest) -> Result<Self> {
-        let (store, memory, exports) = Self::instantiate(&engine, &module, &manifest)?;
+        let resources = load_resources(&manifest)?;
+        let (store, memory, exports) = Self::instantiate(&engine, &module, &manifest, &resources)?;
         Ok(Self {
             engine,
             module,
             manifest,
+            resources,
             store,
             memory,
             exports,
@@ -127,6 +142,7 @@ impl WasmRuntime {
         engine: &Engine,
         module: &Module,
         manifest: &WasmManifest,
+        resources: &HashMap<String, Vec<u8>>,
     ) -> Result<(Store<HostCtx>, WasmMemory, Exports)> {
         let mut store = Store::new(
             engine,
@@ -134,6 +150,8 @@ impl WasmRuntime {
                 mem: 0,
                 name: manifest.name.clone(),
                 net: make_backend(manifest.net),
+                config: manifest.config.clone(),
+                resources: resources.clone(),
             },
         );
         let mut linker = Linker::new(engine);
@@ -161,7 +179,7 @@ impl WasmRuntime {
     /// Re-instantiate from the kept engine + module (cold reset: clears RAM).
     fn reset(&mut self) -> Result<()> {
         let (store, memory, exports) =
-            Self::instantiate(&self.engine, &self.module, &self.manifest)?;
+            Self::instantiate(&self.engine, &self.module, &self.manifest, &self.resources)?;
         self.store = store;
         self.memory = memory;
         self.exports = exports;
@@ -201,6 +219,24 @@ impl WasmRuntime {
     }
 }
 
+/// Load the file resources a manifest's file-typed config values name. Like the
+/// module itself and HDF/CD images, these are reopened by path (here and again
+/// on a save-state load), not carried in the snapshot.
+fn load_resources(manifest: &WasmManifest) -> Result<HashMap<String, Vec<u8>>> {
+    let mut map = HashMap::new();
+    for key in &manifest.file_keys {
+        match manifest.config.get(key) {
+            Some(path) if !path.is_empty() => {
+                let bytes = std::fs::read(path)
+                    .with_context(|| format!("loading WASM plugin resource {key:?} from {path}"))?;
+                map.insert(key.clone(), bytes);
+            }
+            _ => {} // an unset file option is simply absent
+        }
+    }
+    Ok(map)
+}
+
 /// Build the deterministic wasmtime engine. NaN canonicalization removes
 /// host-CPU NaN bit-pattern leakage; SIMD/relaxed-SIMD/threads are disabled
 /// (relaxed-SIMD is nondeterministic by spec, threads add shared-memory
@@ -226,6 +262,79 @@ fn register_host_fns(linker: &mut Linker<HostCtx>, caps: WasmCaps) -> Result<()>
             let name = caller.data().name.clone();
             log::info!("wasm[{name}]: {}", String::from_utf8_lossy(&buf));
             Ok(())
+        },
+    )?;
+
+    // config_get(key_ptr, key_len, out_ptr, out_cap) -> i32: copy the setting's
+    // value into linear memory (truncated to out_cap) and return its full
+    // length, or -1 if the key is absent. Always available.
+    linker.func_wrap(
+        "env",
+        "config_get",
+        |mut caller: Caller<'_, HostCtx>,
+         key_ptr: i32,
+         key_len: i32,
+         out_ptr: i32,
+         out_cap: i32|
+         -> Result<i32> {
+            let key = read_wasm_bytes(&mut caller, key_ptr, key_len)?;
+            let key = String::from_utf8_lossy(&key).into_owned();
+            let Some(value) = caller.data().config.get(&key).cloned() else {
+                return Ok(-1);
+            };
+            let bytes = value.as_bytes();
+            let n = bytes.len().min(out_cap.max(0) as usize);
+            write_wasm_bytes(&mut caller, out_ptr, &bytes[..n])?;
+            Ok(bytes.len() as i32)
+        },
+    )?;
+
+    // resource_len(name_ptr, name_len) -> i32: byte length of a file resource,
+    // or -1 if absent.
+    linker.func_wrap(
+        "env",
+        "resource_len",
+        |mut caller: Caller<'_, HostCtx>, name_ptr: i32, name_len: i32| -> Result<i32> {
+            let name = read_wasm_bytes(&mut caller, name_ptr, name_len)?;
+            let name = String::from_utf8_lossy(&name).into_owned();
+            Ok(caller
+                .data()
+                .resources
+                .get(&name)
+                .map(|b| b.len() as i32)
+                .unwrap_or(-1))
+        },
+    )?;
+
+    // resource_read(name_ptr, name_len, off, out_ptr, len) -> i32: copy
+    // resource[off..off+len] into linear memory; returns the byte count, or -1
+    // if the resource is absent.
+    linker.func_wrap(
+        "env",
+        "resource_read",
+        |mut caller: Caller<'_, HostCtx>,
+         name_ptr: i32,
+         name_len: i32,
+         off: i32,
+         out_ptr: i32,
+         len: i32|
+         -> Result<i32> {
+            let name = read_wasm_bytes(&mut caller, name_ptr, name_len)?;
+            let name = String::from_utf8_lossy(&name).into_owned();
+            let chunk = match caller.data().resources.get(&name) {
+                Some(bytes) => {
+                    let off = off.max(0) as usize;
+                    let end = off.saturating_add(len.max(0) as usize).min(bytes.len());
+                    if off >= bytes.len() {
+                        Vec::new()
+                    } else {
+                        bytes[off..end].to_vec()
+                    }
+                }
+                None => return Ok(-1),
+            };
+            write_wasm_bytes(&mut caller, out_ptr, &chunk)?;
+            Ok(chunk.len() as i32)
         },
     )?;
 
@@ -559,6 +668,8 @@ mod tests {
                 net: false,
             },
             net: NetConfig::None,
+            config: BTreeMap::new(),
+            file_keys: Vec::new(),
         }
     }
 
@@ -572,6 +683,8 @@ mod tests {
                 net: true,
             },
             net: NetConfig::Loopback,
+            config: BTreeMap::new(),
+            file_keys: Vec::new(),
         }
     }
 
@@ -720,6 +833,58 @@ mod tests {
               (i32.load8_u (i32.const 64))))
         )
     "#;
+
+    /// A plugin that reads a setting and a file resource at init: `init` puts
+    /// the config value's first byte at mem[256], the resource length at
+    /// mem[257], and the resource's first 4 bytes at mem[258..]; `read(off)`
+    /// returns mem[256 + off].
+    const CONFIG_WAT: &str = r#"
+        (module
+          (import "env" "config_get" (func $config_get (param i32 i32 i32 i32) (result i32)))
+          (import "env" "resource_len" (func $resource_len (param i32 i32) (result i32)))
+          (import "env" "resource_read" (func $resource_read (param i32 i32 i32 i32 i32) (result i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 0) "buffers")
+          (data (i32.const 16) "rom")
+          (func (export "init")
+            (drop (call $config_get (i32.const 0) (i32.const 7) (i32.const 256) (i32.const 64)))
+            (i32.store8 (i32.const 257) (call $resource_len (i32.const 16) (i32.const 3)))
+            (drop (call $resource_read (i32.const 16) (i32.const 3) (i32.const 0) (i32.const 258) (i32.const 4))))
+          (func (export "read") (param $off i32) (param $size i32) (result i32)
+            (i32.load8_u (i32.add (i32.const 256) (local.get $off))))
+        )
+    "#;
+
+    #[test]
+    fn config_and_resource_imports_reach_the_plugin() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let rom_path = std::env::temp_dir().join(format!(
+            "copperline-wasm-rom-{}-{nanos}.bin",
+            std::process::id()
+        ));
+        std::fs::write(&rom_path, [0xCA, 0xFE, 0xBA, 0xBE]).unwrap();
+
+        let path = write_wasm("cfg", CONFIG_WAT);
+        let mut manifest = manifest("cfg", false);
+        manifest.config.insert("buffers".into(), "8".into());
+        manifest
+            .config
+            .insert("rom".into(), rom_path.to_string_lossy().into_owned());
+        manifest.file_keys = vec!["rom".into()];
+
+        let mut board = WasmBoard::from_file(&path, manifest).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(board.read(0, 1, &mut host), 0x38); // config "buffers" = "8"
+        assert_eq!(board.read(1, 1, &mut host), 4); // resource_len("rom")
+        assert_eq!(board.read(2, 1, &mut host), 0xCA); // rom[0]
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&rom_path);
+    }
 
     #[test]
     fn net_send_and_recv_round_trip_over_loopback() {

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -21,6 +21,7 @@ use crate::net::NetConfig;
 use crate::wasmboard::{WasmCaps, WasmManifest};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 pub const AUTOCONFIG_BASE: u64 = 0x00E8_0000;
@@ -531,6 +532,20 @@ fn floating_bus(size: usize) -> u64 {
 /// dma = true           # optional capabilities (default false)
 /// int2 = true
 /// int6 = false
+///
+/// # Plugin settings passed to the module (defaults; the user overrides them
+/// # per-board in the main config). A "file" option is loaded by the host and
+/// # exposed to the plugin as a named resource.
+/// [config]
+/// mac = "02:00:10:00:00:01"
+/// [[option]]
+/// key = "mac"
+/// label = "MAC address"
+/// type = "string"      # string | bool | int | file | enum
+/// [[option]]
+/// key = "rom"
+/// label = "Boot ROM"
+/// type = "file"
 /// ```
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -552,6 +567,56 @@ struct RawBoardMeta {
     /// Host network backend ("none"/"loopback"); presence grants the `net`
     /// capability (the net_send/net_recv imports).
     net: Option<String>,
+    /// Default plugin settings (free-form key/value).
+    config: Option<toml::Table>,
+    /// Config option schema, for the launcher's config panel.
+    #[serde(default)]
+    option: Vec<RawOption>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawOption {
+    key: String,
+    label: Option<String>,
+    #[serde(rename = "type")]
+    kind: String,
+    default: Option<toml::Value>,
+    choices: Option<Vec<String>>,
+}
+
+/// One editable plugin setting, declared by a `[[option]]` in the manifest, used
+/// to render the launcher's config panel.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigOption {
+    pub key: String,
+    pub label: String,
+    pub kind: ConfigOptionKind,
+    pub default: Option<String>,
+}
+
+/// The editing widget a [`ConfigOption`] wants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigOptionKind {
+    String,
+    Bool,
+    Int,
+    /// A host file path; loaded by the host and exposed to the plugin as a
+    /// resource keyed by the option's `key`.
+    File,
+    /// A choice from a fixed list.
+    Enum(Vec<String>),
+}
+
+/// Stringify a TOML scalar for the plugin's flat string-valued config map.
+pub(crate) fn toml_value_to_string(v: &toml::Value) -> String {
+    match v {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Boolean(b) => b.to_string(),
+        toml::Value::Integer(n) => n.to_string(),
+        toml::Value::Float(f) => f.to_string(),
+        other => other.to_string(),
+    }
 }
 
 /// A board parsed from a TOML metadata file: a RAM board (fully described by
@@ -566,6 +631,12 @@ pub enum LoadedZorroBoard {
         spec: BoardSpec,
         wasm_path: PathBuf,
         manifest: WasmManifest,
+        /// The config-option schema for the launcher panel.
+        options: Vec<ConfigOption>,
+        /// Default settings from `[config]` (option defaults applied, file
+        /// values resolved relative to the metadata file); the user's per-board
+        /// overrides are layered on top at config-resolution time.
+        default_config: BTreeMap<String, String>,
     },
 }
 
@@ -646,6 +717,8 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
                 })?,
                 None => NetConfig::None,
             };
+            let options = parse_options(&raw.option, path)?;
+            let default_config = build_default_config(raw.config.as_ref(), &options, path);
             let manifest = WasmManifest {
                 name: spec.name.clone(),
                 caps: WasmCaps {
@@ -655,11 +728,21 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
                     net: raw.net.is_some(),
                 },
                 net,
+                // The merge with the user's per-board overrides happens at
+                // config-resolution time; defaults travel separately for now.
+                config: BTreeMap::new(),
+                file_keys: options
+                    .iter()
+                    .filter(|o| o.kind == ConfigOptionKind::File)
+                    .map(|o| o.key.clone())
+                    .collect(),
             };
             Ok(LoadedZorroBoard::Wasm {
                 spec,
                 wasm_path,
                 manifest,
+                options,
+                default_config,
             })
         }
         other => bail!(
@@ -668,6 +751,73 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
             other
         ),
     }
+}
+
+/// Parse the `[[option]]` schema from a manifest.
+fn parse_options(raw: &[RawOption], path: &Path) -> Result<Vec<ConfigOption>> {
+    let mut out = Vec::with_capacity(raw.len());
+    for o in raw {
+        let kind = match o.kind.trim().to_ascii_lowercase().as_str() {
+            "string" => ConfigOptionKind::String,
+            "bool" => ConfigOptionKind::Bool,
+            "int" => ConfigOptionKind::Int,
+            "file" => ConfigOptionKind::File,
+            "enum" => {
+                let choices = o.choices.clone().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{}: option {:?} type = \"enum\" needs choices = [...]",
+                        path.display(),
+                        o.key
+                    )
+                })?;
+                ConfigOptionKind::Enum(choices)
+            }
+            other => bail!(
+                "{}: option {:?} has unknown type {:?} (expected string/bool/int/file/enum)",
+                path.display(),
+                o.key,
+                other
+            ),
+        };
+        out.push(ConfigOption {
+            key: o.key.clone(),
+            label: o.label.clone().unwrap_or_else(|| o.key.clone()),
+            kind,
+            default: o.default.as_ref().map(toml_value_to_string),
+        });
+    }
+    Ok(out)
+}
+
+/// Build the default settings map: option defaults, overlaid by any `[config]`
+/// entries, with file-typed values resolved relative to the metadata file.
+fn build_default_config(
+    config: Option<&toml::Table>,
+    options: &[ConfigOption],
+    path: &Path,
+) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    for o in options {
+        if let Some(d) = &o.default {
+            map.insert(o.key.clone(), d.clone());
+        }
+    }
+    if let Some(table) = config {
+        for (k, v) in table {
+            map.insert(k.clone(), toml_value_to_string(v));
+        }
+    }
+    if let Some(dir) = path.parent() {
+        for o in options {
+            if o.kind == ConfigOptionKind::File {
+                if let Some(val) = map.get(&o.key) {
+                    let resolved = dir.join(val).to_string_lossy().into_owned();
+                    map.insert(o.key.clone(), resolved);
+                }
+            }
+        }
+    }
+    map
 }
 
 fn parse_board_size(s: &str) -> Result<usize> {
@@ -909,6 +1059,7 @@ mod tests {
             spec,
             wasm_path,
             manifest,
+            ..
         } = loaded
         else {
             panic!("expected a WASM board");

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -17,6 +17,7 @@
 //! boards are implemented today; other backings plug in via
 //! [`BoardBacking`].
 
+use crate::net::NetConfig;
 use crate::wasmboard::{WasmCaps, WasmManifest};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -147,6 +148,23 @@ impl BoardSpec {
             serial: copperline_ident_serial(),
             size_bytes: 0x1_0000,
             backing: BoardBacking::Ram,
+            memlist: false,
+            diag_vec: None,
+        }
+    }
+
+    /// The A2065 Ethernet board: Commodore West Chester (manufacturer 514),
+    /// product 0x70, a 64K Zorro II window with no autoboot ROM. `slot` is the
+    /// index of the matching `A2065` device in `Bus::devices`.
+    pub fn a2065(slot: usize) -> Self {
+        Self {
+            name: "A2065 Ethernet".into(),
+            version: ZorroVersion::II,
+            manufacturer: 514,
+            product: 0x70,
+            serial: 0,
+            size_bytes: 0x1_0000,
+            backing: BoardBacking::Device(slot),
             memlist: false,
             diag_vec: None,
         }
@@ -531,6 +549,9 @@ struct RawBoardMeta {
     dma: Option<bool>,
     int2: Option<bool>,
     int6: Option<bool>,
+    /// Host network backend ("none"/"loopback"); presence grants the `net`
+    /// capability (the net_send/net_recv imports).
+    net: Option<String>,
 }
 
 /// A board parsed from a TOML metadata file: a RAM board (fully described by
@@ -615,13 +636,25 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
             };
             spec.validate()
                 .with_context(|| format!("{}: invalid board", path.display()))?;
+            let net = match &raw.net {
+                Some(s) => crate::net::parse_net_config(s).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{}: net = {:?} is not a known backend (expected \"none\" or \"loopback\")",
+                        path.display(),
+                        s
+                    )
+                })?,
+                None => NetConfig::None,
+            };
             let manifest = WasmManifest {
                 name: spec.name.clone(),
                 caps: WasmCaps {
                     dma: raw.dma.unwrap_or(false),
                     int2: raw.int2.unwrap_or(false),
                     int6: raw.int6.unwrap_or(false),
+                    net: raw.net.is_some(),
                 },
+                net,
             };
             Ok(LoadedZorroBoard::Wasm {
                 spec,

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -17,9 +17,10 @@
 //! boards are implemented today; other backings plug in via
 //! [`BoardBacking`].
 
+use crate::wasmboard::{WasmCaps, WasmManifest};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub const AUTOCONFIG_BASE: u64 = 0x00E8_0000;
 pub const AUTOCONFIG_SIZE: u64 = 0x0001_0000;
@@ -73,9 +74,11 @@ pub enum ZorroVersion {
 pub enum BoardBacking {
     /// RAM the CPU can read and write at external-bus speed.
     Ram,
-    /// The A2091/A590 SCSI controller (registers + boot ROM); accesses
-    /// route to the `A2091` device on the bus, not to board RAM.
-    A2091,
+    /// A functional device (registers + optional boot ROM): accesses route to
+    /// `Bus::devices[usize]`, a [`crate::zorro_device::BoardDevice`], not to
+    /// board RAM. The index is assigned when the board is added to the chain
+    /// and matches the device attached to the bus.
+    Device(usize),
 }
 
 /// The autoconfig identity and backing of one expansion board.
@@ -152,8 +155,9 @@ impl BoardSpec {
     /// The A2091 SCSI controller board: the DMAC supplies the autoconfig
     /// identity (Commodore West Chester, product 3) with a valid DiagArea
     /// vector pointing at the boot ROM, which appears at $2000 in the
-    /// board space.
-    pub fn a2091() -> Self {
+    /// board space. `slot` is the index of the matching `A2091` device in
+    /// `Bus::devices`.
+    pub fn a2091(slot: usize) -> Self {
         Self {
             name: "A2091 SCSI".into(),
             version: ZorroVersion::II,
@@ -161,7 +165,7 @@ impl BoardSpec {
             product: 3,
             serial: 0,
             size_bytes: 0x1_0000,
-            backing: BoardBacking::A2091,
+            backing: BoardBacking::Device(slot),
             memlist: false,
             diag_vec: Some(0x2000),
         }
@@ -226,7 +230,7 @@ impl ZorroChain {
         spec.validate()?;
         let ram = match spec.backing {
             BoardBacking::Ram => vec![0u8; spec.size_bytes],
-            BoardBacking::A2091 => Vec::new(),
+            BoardBacking::Device(_) => Vec::new(),
         };
         self.boards.push(Board {
             spec,
@@ -274,7 +278,7 @@ impl ZorroChain {
                             self.regions.push((base, board.ram.len() as u32, idx));
                         }
                     }
-                    BoardBacking::A2091 => {
+                    BoardBacking::Device(_) => {
                         self.device_regions
                             .push((base, board.spec.size_bytes as u32, idx));
                     }
@@ -497,12 +501,18 @@ fn floating_bus(size: usize) -> u64 {
 /// ```toml
 /// name = "MegaRAM"
 /// zorro = 3            # 2 or 3
-/// type = "ram"         # board backing; only "ram" so far
+/// type = "ram"         # "ram" or "wasm"
 /// size = "64M"
 /// manufacturer = 0x07DB
 /// product = 0x20
 /// serial = 0           # optional
-/// memlist = true       # optional; defaults true for type = "ram"
+/// memlist = true       # optional; defaults true for "ram", false for "wasm"
+///
+/// # For type = "wasm" (a plugin board), additionally:
+/// wasm = "board.wasm"  # module path, relative to this metadata file
+/// dma = true           # optional capabilities (default false)
+/// int2 = true
+/// int6 = false
 /// ```
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -516,10 +526,30 @@ struct RawBoardMeta {
     product: u16,
     serial: Option<u32>,
     memlist: Option<bool>,
+    // WASM plugin boards (type = "wasm"):
+    wasm: Option<String>,
+    dma: Option<bool>,
+    int2: Option<bool>,
+    int6: Option<bool>,
+}
+
+/// A board parsed from a TOML metadata file: a RAM board (fully described by
+/// its autoconfig identity) or a WASM plugin board (identity plus the module
+/// path and capabilities, instantiated at machine-build time).
+#[derive(Debug)]
+pub enum LoadedZorroBoard {
+    Ram(BoardSpec),
+    Wasm {
+        /// Autoconfig identity; `backing` is a `Device` placeholder reassigned
+        /// to the real slot index when the board is attached to the bus.
+        spec: BoardSpec,
+        wasm_path: PathBuf,
+        manifest: WasmManifest,
+    },
 }
 
 /// Load a board description from a TOML metadata file.
-pub fn load_board_metadata(path: &Path) -> Result<BoardSpec> {
+pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
     let text = std::fs::read_to_string(path)
         .with_context(|| format!("reading zorro board metadata {}", path.display()))?;
     let raw: RawBoardMeta = toml::from_str(&text)
@@ -533,14 +563,6 @@ pub fn load_board_metadata(path: &Path) -> Result<BoardSpec> {
             other
         ),
     };
-    let backing = match raw.backing.trim().to_ascii_lowercase().as_str() {
-        "ram" => BoardBacking::Ram,
-        other => bail!(
-            "{}: type = {:?} is not supported (expected \"ram\")",
-            path.display(),
-            other
-        ),
-    };
     if raw.manufacturer > 0xFFFF {
         bail!("{}: manufacturer must be a 16-bit ID", path.display());
     }
@@ -549,20 +571,70 @@ pub fn load_board_metadata(path: &Path) -> Result<BoardSpec> {
     }
     let size_bytes = parse_board_size(&raw.size)
         .with_context(|| format!("{}: bad size {:?}", path.display(), raw.size))?;
-    let spec = BoardSpec {
-        name: raw.name,
-        version,
-        manufacturer: raw.manufacturer as u16,
-        product: raw.product as u8,
-        serial: raw.serial.unwrap_or(0),
-        size_bytes,
-        backing,
-        memlist: raw.memlist.unwrap_or(true),
-        diag_vec: None,
-    };
-    spec.validate()
-        .with_context(|| format!("{}: invalid board", path.display()))?;
-    Ok(spec)
+    let kind = raw.backing.trim().to_ascii_lowercase();
+    match kind.as_str() {
+        "ram" => {
+            let spec = BoardSpec {
+                name: raw.name,
+                version,
+                manufacturer: raw.manufacturer as u16,
+                product: raw.product as u8,
+                serial: raw.serial.unwrap_or(0),
+                size_bytes,
+                backing: BoardBacking::Ram,
+                memlist: raw.memlist.unwrap_or(true),
+                diag_vec: None,
+            };
+            spec.validate()
+                .with_context(|| format!("{}: invalid board", path.display()))?;
+            Ok(LoadedZorroBoard::Ram(spec))
+        }
+        "wasm" => {
+            let Some(wasm) = raw.wasm else {
+                bail!(
+                    "{}: type = \"wasm\" needs a `wasm = \"module.wasm\"` path",
+                    path.display()
+                );
+            };
+            // Module path resolves relative to the metadata file's directory.
+            let wasm_path = match path.parent() {
+                Some(dir) => dir.join(&wasm),
+                None => PathBuf::from(&wasm),
+            };
+            // The real slot index is assigned when the device is attached.
+            let spec = BoardSpec {
+                name: raw.name,
+                version,
+                manufacturer: raw.manufacturer as u16,
+                product: raw.product as u8,
+                serial: raw.serial.unwrap_or(0),
+                size_bytes,
+                backing: BoardBacking::Device(0),
+                memlist: raw.memlist.unwrap_or(false),
+                diag_vec: None,
+            };
+            spec.validate()
+                .with_context(|| format!("{}: invalid board", path.display()))?;
+            let manifest = WasmManifest {
+                name: spec.name.clone(),
+                caps: WasmCaps {
+                    dma: raw.dma.unwrap_or(false),
+                    int2: raw.int2.unwrap_or(false),
+                    int6: raw.int6.unwrap_or(false),
+                },
+            };
+            Ok(LoadedZorroBoard::Wasm {
+                spec,
+                wasm_path,
+                manifest,
+            })
+        }
+        other => bail!(
+            "{}: type = {:?} is not supported (expected \"ram\" or \"wasm\")",
+            path.display(),
+            other
+        ),
+    }
 }
 
 fn parse_board_size(s: &str) -> Result<usize> {
@@ -756,9 +828,12 @@ mod tests {
             "#,
         )
         .unwrap();
-        let spec = load_board_metadata(&path).unwrap();
+        let loaded = load_board_metadata(&path).unwrap();
         let _ = std::fs::remove_file(&path);
 
+        let LoadedZorroBoard::Ram(spec) = loaded else {
+            panic!("expected a RAM board");
+        };
         assert_eq!(spec.name, "MegaRAM");
         assert_eq!(spec.version, ZorroVersion::III);
         assert_eq!(spec.backing, BoardBacking::Ram);
@@ -766,6 +841,55 @@ mod tests {
         assert_eq!(spec.manufacturer, 2011);
         assert_eq!(spec.product, 32);
         assert!(spec.memlist);
+    }
+
+    #[test]
+    fn wasm_board_metadata_parses_path_and_caps() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "copperline-zorro-wasm-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &path,
+            r#"
+            name = "Test NIC"
+            zorro = 2
+            type = "wasm"
+            size = "64K"
+            manufacturer = 5192
+            product = 16
+            wasm = "nic.wasm"
+            dma = true
+            int2 = true
+            "#,
+        )
+        .unwrap();
+        let loaded = load_board_metadata(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        let LoadedZorroBoard::Wasm {
+            spec,
+            wasm_path,
+            manifest,
+        } = loaded
+        else {
+            panic!("expected a WASM board");
+        };
+        assert_eq!(spec.name, "Test NIC");
+        assert_eq!(spec.version, ZorroVersion::II);
+        assert!(matches!(spec.backing, BoardBacking::Device(_)));
+        assert!(!spec.memlist);
+        // Module path is resolved next to the metadata file.
+        assert_eq!(wasm_path, dir.join("nic.wasm"));
+        assert_eq!(manifest.name, "Test NIC");
+        assert!(manifest.caps.dma);
+        assert!(manifest.caps.int2);
+        assert!(!manifest.caps.int6);
     }
 
     #[test]
@@ -812,7 +936,7 @@ mod tests {
 
     #[test]
     fn diag_vector_sets_diagvalid_and_init_diag_vec() {
-        let chain = chain_with(vec![BoardSpec::a2091()]);
+        let chain = chain_with(vec![BoardSpec::a2091(0)]);
 
         // er_Type carries ERTF_DIAGVALID (autoboot ROM present)...
         let hi = (chain.config_read(AUTOCONFIG_BASE, 1) as u8) >> 4;
@@ -865,7 +989,7 @@ mod tests {
     fn three_board_chain_configures_in_order() {
         let mut chain = chain_with(vec![
             BoardSpec::fast_ram(2 * 1024 * 1024),
-            BoardSpec::a2091(),
+            BoardSpec::a2091(0),
             BoardSpec::z3_ram(16 * 1024 * 1024),
         ]);
 
@@ -877,7 +1001,7 @@ mod tests {
         chain.config_write(AUTOCONFIG_BASE + EC_BASEADDRESS_PHYS, 1, 0xE9);
         assert_eq!(
             chain.device_region_at(0x00E9_0000, 2),
-            Some((BoardBacking::A2091, 0))
+            Some((BoardBacking::Device(0), 0))
         );
 
         // Board 3: Zorro III RAM via the 16-bit write to $44.

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The functional-Zorro-board boundary.
+//!
+//! A [`ZorroDevice`] is an expansion board that *does something* beyond
+//! presenting RAM: it answers register reads/writes in its configured window,
+//! advances on the colour clock, may assert an interrupt line, and may bus-
+//! master DMA into Amiga memory. The in-tree A2091 SCSI controller and CDTV
+//! DMAC implement it, and the WASM plugin host (`src/wasmboard.rs`) implements
+//! it over a guest module so functional boards can be authored out of tree.
+//!
+//! [`DeviceHost`] is the narrow host-services view a device is handed on every
+//! call. Today it exposes guest memory for DMA; capability hooks (CD audio,
+//! networking) are added alongside the devices that need them. It also owns the
+//! single 24-bit DMA address decode (chip / slow / Zorro-board RAM) that the
+//! A2091 and CDTV bus masters previously each open-coded.
+
+use crate::chipset::paula::CdAudioRing;
+use crate::memory::{Memory, SLOW_RAM_BASE};
+
+/// 24-bit DMA bus-master word read: the chip / slow / Zorro-board RAM decode a
+/// Zorro DMA controller sees. Returns `None` when the (word-aligned) address is
+/// not backed by RAM, leaving the unmapped sentinel and warn policy to the
+/// caller. Word reads require both bytes in range, matching the hardware word
+/// access; the last odd byte of a region therefore does not satisfy a word.
+pub(crate) fn dma_read_word(mem: &Memory, addr: u32) -> Option<u16> {
+    let a = addr as usize;
+    if a + 1 < mem.chip_ram.len() {
+        return Some((u16::from(mem.chip_ram[a]) << 8) | u16::from(mem.chip_ram[a + 1]));
+    }
+    let slow = SLOW_RAM_BASE as usize;
+    if a >= slow && a + 1 < slow + mem.slow_ram.len() {
+        let o = a - slow;
+        return Some((u16::from(mem.slow_ram[o]) << 8) | u16::from(mem.slow_ram[o + 1]));
+    }
+    if let Some((board, off)) = mem.zorro.region_at(addr, 2) {
+        let ram = mem.zorro.board_ram(board);
+        return Some((u16::from(ram[off]) << 8) | u16::from(ram[off + 1]));
+    }
+    None
+}
+
+/// 24-bit DMA bus-master word write. Returns `false` when the target is not
+/// backed by RAM (so the caller can warn and drop, as the hardware does).
+pub(crate) fn dma_write_word(mem: &mut Memory, addr: u32, w: u16) -> bool {
+    let a = addr as usize;
+    if a + 1 < mem.chip_ram.len() {
+        mem.chip_ram[a] = (w >> 8) as u8;
+        mem.chip_ram[a + 1] = w as u8;
+        return true;
+    }
+    let slow = SLOW_RAM_BASE as usize;
+    if a >= slow && a + 1 < slow + mem.slow_ram.len() {
+        let o = a - slow;
+        mem.slow_ram[o] = (w >> 8) as u8;
+        mem.slow_ram[o + 1] = w as u8;
+        return true;
+    }
+    if let Some((board, off)) = mem.zorro.region_at(addr, 2) {
+        let ram = mem.zorro.board_ram_mut(board);
+        ram[off] = (w >> 8) as u8;
+        ram[off + 1] = w as u8;
+        return true;
+    }
+    false
+}
+
+/// 24-bit DMA bus-master byte read (the CDTV diagnostic peek uses this).
+/// Returns `None` when the address is not backed by RAM. Byte reads only need
+/// the single byte in range, so the bounds differ from the word read above.
+pub(crate) fn dma_read_byte(mem: &Memory, addr: u32) -> Option<u8> {
+    let a = addr as usize;
+    if a < mem.chip_ram.len() {
+        return Some(mem.chip_ram[a]);
+    }
+    let slow = SLOW_RAM_BASE as usize;
+    if a >= slow && a < slow + mem.slow_ram.len() {
+        return Some(mem.slow_ram[a - slow]);
+    }
+    if let Some((board, off)) = mem.zorro.region_at(addr, 1) {
+        return Some(mem.zorro.board_ram(board)[off]);
+    }
+    None
+}
+
+/// 24-bit DMA bus-master byte write. Returns `false` when the target is not
+/// backed by RAM.
+pub(crate) fn dma_write_byte(mem: &mut Memory, addr: u32, b: u8) -> bool {
+    let a = addr as usize;
+    if a < mem.chip_ram.len() {
+        mem.chip_ram[a] = b;
+        return true;
+    }
+    let slow = SLOW_RAM_BASE as usize;
+    if a >= slow && a < slow + mem.slow_ram.len() {
+        mem.slow_ram[a - slow] = b;
+        return true;
+    }
+    if let Some((board, off)) = mem.zorro.region_at(addr, 1) {
+        mem.zorro.board_ram_mut(board)[off] = b;
+        return true;
+    }
+    false
+}
+
+/// The host-services view handed to a [`ZorroDevice`] on every call. Wraps the
+/// guest [`Memory`] so a board can DMA, and is the place capability hooks are
+/// added (CD audio injection, networking) as the boards that need them land.
+pub struct DeviceHost<'a> {
+    mem: &'a mut Memory,
+    /// Paula's CD-audio ring, available only on a host built for the CDTV tick.
+    cd_audio: Option<&'a mut CdAudioRing>,
+}
+
+impl<'a> DeviceHost<'a> {
+    pub fn new(mem: &'a mut Memory) -> Self {
+        Self {
+            mem,
+            cd_audio: None,
+        }
+    }
+
+    /// A host view that also exposes Paula's CD-audio ring, for the CDTV DMAC
+    /// tick (which streams CD audio rather than touching guest memory).
+    pub fn with_cd_audio(mem: &'a mut Memory, cd_audio: &'a mut CdAudioRing) -> Self {
+        Self {
+            mem,
+            cd_audio: Some(cd_audio),
+        }
+    }
+
+    /// The guest memory the board DMAs into.
+    pub fn memory_mut(&mut self) -> &mut Memory {
+        self.mem
+    }
+
+    /// Paula's CD-audio ring. Only present on a host built via
+    /// [`DeviceHost::with_cd_audio`] (the CDTV tick path); requesting it
+    /// elsewhere is a wiring bug.
+    pub fn cd_audio(&mut self) -> &mut CdAudioRing {
+        self.cd_audio
+            .as_deref_mut()
+            .expect("DeviceHost::cd_audio requested without a CD-audio ring")
+    }
+
+    // These wrap the shared decode for boards that hold a `DeviceHost` rather
+    // than a bare `&Memory`. The in-tree A2091/CDTV call the free functions
+    // directly; the WASM plugin host (Phase 2) routes its DMA imports here.
+    /// 24-bit DMA word read; `None` when the address is unmapped.
+    #[allow(dead_code)]
+    pub fn dma_read_word(&self, addr: u32) -> Option<u16> {
+        dma_read_word(self.mem, addr)
+    }
+
+    /// 24-bit DMA word write; `false` when the target is unmapped.
+    #[allow(dead_code)]
+    pub fn dma_write_word(&mut self, addr: u32, w: u16) -> bool {
+        dma_write_word(self.mem, addr, w)
+    }
+
+    /// 24-bit DMA byte read; `None` when the address is unmapped.
+    #[allow(dead_code)]
+    pub fn dma_read_byte(&self, addr: u32) -> Option<u8> {
+        dma_read_byte(self.mem, addr)
+    }
+
+    /// Bulk DMA read into `buf` starting at Amiga `addr` (byte-granular 24-bit
+    /// decode; unmapped bytes read as 0xFF). The WASM plugin host's `dma_read`
+    /// import routes here.
+    #[allow(dead_code)]
+    pub fn dma_read(&self, addr: u32, buf: &mut [u8]) {
+        for (i, b) in buf.iter_mut().enumerate() {
+            *b = dma_read_byte(self.mem, addr.wrapping_add(i as u32)).unwrap_or(0xFF);
+        }
+    }
+
+    /// Bulk DMA write of `buf` to Amiga `addr` (byte-granular 24-bit decode;
+    /// unmapped bytes dropped). The WASM plugin host's `dma_write` import
+    /// routes here.
+    #[allow(dead_code)]
+    pub fn dma_write(&mut self, addr: u32, buf: &[u8]) {
+        for (i, b) in buf.iter().enumerate() {
+            dma_write_byte(self.mem, addr.wrapping_add(i as u32), *b);
+        }
+    }
+}
+
+/// A functional Zorro expansion board.
+///
+/// Implementors handle register access in their configured window
+/// (`read`/`write`, offset-relative), advance on the colour clock (`tick`), and
+/// expose level-sensitive interrupt lines the bus polls. DMA goes through the
+/// [`DeviceHost`]; the bus owns interrupt latching and recognition latency, so a
+/// device only reports its line state and never pulses INTREQ.
+//
+// Implemented in Phase 1 (A2091, CDTV) and Phase 2 (WASM); defined here so the
+// boundary and `DeviceHost` live together.
+#[allow(dead_code)]
+pub trait ZorroDevice {
+    /// Read `size` bytes at window offset `off`.
+    fn read(&mut self, off: u32, size: usize, host: &mut DeviceHost) -> u32;
+
+    /// Write `size` bytes of `value` at window offset `off`.
+    fn write(&mut self, off: u32, size: usize, value: u32, host: &mut DeviceHost);
+
+    /// Advance the device by `cck` colour clocks.
+    fn tick(&mut self, cck: u32, host: &mut DeviceHost);
+
+    /// INT2 (PORTS) line state. Level-sensitive: held true while asserted.
+    fn int2_line(&self) -> bool {
+        false
+    }
+
+    /// INT6 (EXTER) line state. Level-sensitive: held true while asserted.
+    fn int6_line(&self) -> bool {
+        false
+    }
+
+    /// True while the device is quiescent so the bus can skip its tick.
+    fn is_idle(&self) -> bool {
+        true
+    }
+
+    /// Colour clocks until the device's next internal event, if known, so the
+    /// scheduler can wake it sparsely instead of polling every cck.
+    fn next_event_cck(&self) -> Option<u32> {
+        None
+    }
+
+    /// Drain and report board activity for the HDD/status LED.
+    fn take_activity(&mut self) -> bool {
+        false
+    }
+
+    /// Return the board to its power-on state (keeps attached media/ROM).
+    fn reset(&mut self);
+
+    /// A stable identifier for logging and snapshot matching.
+    fn kind(&self) -> &'static str;
+}
+
+/// A functional Zorro-chain board the bus owns and serializes inline.
+///
+/// Each variant is a concrete device implementing [`ZorroDevice`]. The enum
+/// (rather than `Box<dyn ZorroDevice>`) keeps the set serde-derivable -- a
+/// trait object is not -- so a board's whole state round-trips with the `Bus`
+/// like every other device, while still letting the bus hold heterogeneous
+/// boards in one `Vec` indexed by [`crate::zorro::BoardBacking::Device`].
+// The variants are intentionally different sizes (the A2091 carries its boot
+// ROM and SBIC state; a WASM board carries a wasmtime store handle). The bus
+// holds only a handful of boards, so the unused tail per element is immaterial;
+// boxing would just add an indirection on every register access.
+#[allow(clippy::large_enum_variant)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum BoardDevice {
+    A2091(crate::a2091::A2091),
+    Wasm(crate::wasmboard::WasmBoard),
+}
+
+impl ZorroDevice for BoardDevice {
+    fn read(&mut self, off: u32, size: usize, host: &mut DeviceHost) -> u32 {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::read(d, off, size, host),
+            BoardDevice::Wasm(d) => ZorroDevice::read(d, off, size, host),
+        }
+    }
+
+    fn write(&mut self, off: u32, size: usize, value: u32, host: &mut DeviceHost) {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::write(d, off, size, value, host),
+            BoardDevice::Wasm(d) => ZorroDevice::write(d, off, size, value, host),
+        }
+    }
+
+    fn tick(&mut self, cck: u32, host: &mut DeviceHost) {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::tick(d, cck, host),
+            BoardDevice::Wasm(d) => ZorroDevice::tick(d, cck, host),
+        }
+    }
+
+    fn int2_line(&self) -> bool {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::int2_line(d),
+            BoardDevice::Wasm(d) => ZorroDevice::int2_line(d),
+        }
+    }
+
+    fn int6_line(&self) -> bool {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::int6_line(d),
+            BoardDevice::Wasm(d) => ZorroDevice::int6_line(d),
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::is_idle(d),
+            BoardDevice::Wasm(d) => ZorroDevice::is_idle(d),
+        }
+    }
+
+    fn next_event_cck(&self) -> Option<u32> {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::next_event_cck(d),
+            BoardDevice::Wasm(d) => ZorroDevice::next_event_cck(d),
+        }
+    }
+
+    fn take_activity(&mut self) -> bool {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::take_activity(d),
+            BoardDevice::Wasm(d) => ZorroDevice::take_activity(d),
+        }
+    }
+
+    fn reset(&mut self) {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::reset(d),
+            BoardDevice::Wasm(d) => ZorroDevice::reset(d),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::kind(d),
+            BoardDevice::Wasm(d) => ZorroDevice::kind(d),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zorro::ZorroChain;
+
+    fn mem_with(chip: usize, slow: usize) -> Memory {
+        Memory {
+            chip_ram: vec![0u8; chip],
+            slow_ram: vec![0u8; slow],
+            rom: Vec::new(),
+            overlay: false,
+            zorro: ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    #[test]
+    fn dma_word_round_trips_chip_and_slow_ram() {
+        let mut mem = mem_with(0x100, 0x100);
+        assert!(dma_write_word(&mut mem, 0x10, 0xBEEF));
+        assert_eq!(dma_read_word(&mem, 0x10), Some(0xBEEF));
+        assert_eq!(mem.chip_ram[0x10], 0xBE);
+        assert_eq!(mem.chip_ram[0x11], 0xEF);
+
+        let slow = SLOW_RAM_BASE as u32;
+        assert!(dma_write_word(&mut mem, slow + 0x20, 0x1234));
+        assert_eq!(dma_read_word(&mem, slow + 0x20), Some(0x1234));
+        assert_eq!(mem.slow_ram[0x20], 0x12);
+    }
+
+    #[test]
+    fn word_access_needs_both_bytes_in_range() {
+        // chip_ram is 0x100 bytes: the last word starts at 0xFE (0xFE,0xFF in
+        // range); a word at 0xFF would need byte 0x100, which is out of range,
+        // and 0xFF is not in slow or Zorro space either, so it is unmapped.
+        let mut mem = mem_with(0x100, 0x100);
+        assert!(dma_write_word(&mut mem, 0xFE, 0xAA55));
+        assert_eq!(dma_read_word(&mem, 0xFE), Some(0xAA55));
+        assert_eq!(dma_read_word(&mem, 0xFF), None);
+        assert!(!dma_write_word(&mut mem, 0xFF, 0x0000));
+    }
+
+    #[test]
+    fn byte_read_includes_the_last_byte_a_word_cannot() {
+        // The byte decode (CDTV peek) accepts the final byte 0xFF that the word
+        // decode rejects -- the bounds genuinely differ.
+        let mut mem = mem_with(0x100, 0x100);
+        mem.chip_ram[0xFF] = 0x7E;
+        assert_eq!(dma_read_byte(&mem, 0xFF), Some(0x7E));
+        assert_eq!(dma_read_byte(&mem, 0x100), None);
+    }
+
+    #[test]
+    fn unmapped_addresses_report_none() {
+        let mem = mem_with(0x100, 0x100);
+        // Between chip top and slow base: nothing backs it.
+        assert_eq!(dma_read_word(&mem, 0x0040_0000), None);
+        assert_eq!(dma_read_byte(&mem, 0x0040_0000), None);
+    }
+}

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -254,6 +254,7 @@ pub trait ZorroDevice {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum BoardDevice {
     A2091(crate::a2091::A2091),
+    A2065(crate::a2065::A2065),
     Wasm(crate::wasmboard::WasmBoard),
 }
 
@@ -261,6 +262,7 @@ impl ZorroDevice for BoardDevice {
     fn read(&mut self, off: u32, size: usize, host: &mut DeviceHost) -> u32 {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::read(d, off, size, host),
+            BoardDevice::A2065(d) => ZorroDevice::read(d, off, size, host),
             BoardDevice::Wasm(d) => ZorroDevice::read(d, off, size, host),
         }
     }
@@ -268,6 +270,7 @@ impl ZorroDevice for BoardDevice {
     fn write(&mut self, off: u32, size: usize, value: u32, host: &mut DeviceHost) {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::write(d, off, size, value, host),
+            BoardDevice::A2065(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::Wasm(d) => ZorroDevice::write(d, off, size, value, host),
         }
     }
@@ -275,6 +278,7 @@ impl ZorroDevice for BoardDevice {
     fn tick(&mut self, cck: u32, host: &mut DeviceHost) {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::tick(d, cck, host),
+            BoardDevice::A2065(d) => ZorroDevice::tick(d, cck, host),
             BoardDevice::Wasm(d) => ZorroDevice::tick(d, cck, host),
         }
     }
@@ -282,6 +286,7 @@ impl ZorroDevice for BoardDevice {
     fn int2_line(&self) -> bool {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::int2_line(d),
+            BoardDevice::A2065(d) => ZorroDevice::int2_line(d),
             BoardDevice::Wasm(d) => ZorroDevice::int2_line(d),
         }
     }
@@ -289,6 +294,7 @@ impl ZorroDevice for BoardDevice {
     fn int6_line(&self) -> bool {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::int6_line(d),
+            BoardDevice::A2065(d) => ZorroDevice::int6_line(d),
             BoardDevice::Wasm(d) => ZorroDevice::int6_line(d),
         }
     }
@@ -296,6 +302,7 @@ impl ZorroDevice for BoardDevice {
     fn is_idle(&self) -> bool {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::is_idle(d),
+            BoardDevice::A2065(d) => ZorroDevice::is_idle(d),
             BoardDevice::Wasm(d) => ZorroDevice::is_idle(d),
         }
     }
@@ -303,6 +310,7 @@ impl ZorroDevice for BoardDevice {
     fn next_event_cck(&self) -> Option<u32> {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::next_event_cck(d),
+            BoardDevice::A2065(d) => ZorroDevice::next_event_cck(d),
             BoardDevice::Wasm(d) => ZorroDevice::next_event_cck(d),
         }
     }
@@ -310,6 +318,7 @@ impl ZorroDevice for BoardDevice {
     fn take_activity(&mut self) -> bool {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::take_activity(d),
+            BoardDevice::A2065(d) => ZorroDevice::take_activity(d),
             BoardDevice::Wasm(d) => ZorroDevice::take_activity(d),
         }
     }
@@ -317,6 +326,7 @@ impl ZorroDevice for BoardDevice {
     fn reset(&mut self) {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::reset(d),
+            BoardDevice::A2065(d) => ZorroDevice::reset(d),
             BoardDevice::Wasm(d) => ZorroDevice::reset(d),
         }
     }
@@ -324,6 +334,7 @@ impl ZorroDevice for BoardDevice {
     fn kind(&self) -> &'static str {
         match self {
             BoardDevice::A2091(d) => ZorroDevice::kind(d),
+            BoardDevice::A2065(d) => ZorroDevice::kind(d),
             BoardDevice::Wasm(d) => ZorroDevice::kind(d),
         }
     }


### PR DESCRIPTION
Adds a uniform `ZorroDevice` boundary for functional Zorro expansion boards and
a WASM plugin host, so functional boards can be authored out of tree as `wasm32`
modules and configured from the launcher. WASM is chosen because a module's
mutable state is its linear memory -- a flat byte array that save states snapshot
and restore exactly like Amiga RAM, preserving deterministic replay.

## Boundary + dogfood
- New `src/zorro_device.rs`: the `ZorroDevice` trait + a `DeviceHost` shim that
  owns the one shared 24-bit DMA decode (previously open-coded in the A2091 and
  CDTV).
- The A2091 SCSI controller moves into `Bus::devices` (`BoardBacking::Device(slot)`),
  and both it and the CDTV DMAC are driven through the trait. Verified
  byte-identical against pre-change `main` (boot screenshot + save/load replay).

## WASM plugin host (`src/wasmboard.rs`, wasmtime, pinned)
- Deterministic engine (NaN canonicalization, no SIMD/threads). A plugin's
  linear memory snapshots with save states; the module is reopened by path on
  load, like HDF/CD images.
- Module ABI: `read`/`write`/`tick`/`int2`/`int6`/`init` exports; `log`,
  `dma_read`/`dma_write` (dma cap), `net_send`/`net_recv` (net cap), and
  `config_get`/`resource_*` host imports. Boards are declared with `type = "wasm"`
  in `[[zorro]]` metadata.

## Networking flagship
- `src/net.rs`: a `NetBackend` trait with a loopback backend (host resource, not
  serialized). Userspace NAT and TAP are planned behind `make_backend`.
- `src/a2065.rs`: an in-tree Commodore A2065 (Am7990 LANCE) NIC as a `ZorroDevice`,
  self-contained in 32 KiB board RAM (init block, RX/TX rings, buffers), owning
  its backend. Fit it with `[a2065] net = "loopback"`.
- A fitted A2065 or a `net` plugin breaks byte-identical replay while traffic
  flows; the emulator warns on attach.

## Plugin config options (incl. ROMs), editable in the UI
- Manifests declare `[config]` defaults and an `[[option]]` schema
  (string/bool/int/file/enum). File options are loaded by the host and exposed
  to the module as resources; an autoboot ROM is served by the plugin's `read()`
  from its linear memory (like the A2091) with `diag_vec` set.
- Per-board overrides live in the main config (`[[zorro]] config = { ... }`),
  layered over the manifest defaults.
- The machine-configuration launcher renders the schema as one editable field
  per option (steppers, toggle, file picker, text box), writing edits back as
  overrides.

## Notes
- `STATE_VERSION` 6 -> 8 (Bus device storage + `BoardDevice` variants).
- ~1140 unit tests pass; clippy and fmt clean; `docs/zorro.md` updated.
- Not yet validated end-to-end against the real `a2065.device` SANA-II driver
  (no guest TCP/IP assets); the LANCE is unit-tested against the Am7990
  programming model. Real NAT/TAP backends and any interactive click-through of
  the new config panel remain follow-ups.