### PR TITLE
Fix sprite DMA and display-edge replay timing

### DIFF
--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -29,13 +29,15 @@ to the 8-CCK fetch-unit count: $34/$D4 fetches 21 words, $28/$D4 fetches
 rather than moving DDFSTRT down to an absolute grid. In
 lo-res, the plane-order slots for a wide unit are packed into the unit's
 first eight CCKs; the remaining CCKs are free for other bus users. If a
-bitplane fetch block occupies sprite 7's late DMA slot at $30, sprite 7 DMA
-is blocked for that line; the condition is derived from the fetch-block
-sequence, not from a single DDFSTRT value. SANITY Roots II's AGA 256-colour
-effects are regression examples for both sides of this: the hi-res FMODE=3
-pictures need raw-DDFSTRT unit rounding to preserve their 40-word rows, and
-the lo-res FMODE=3 landscape needs packed first-eight CCK plane slots
-instead of spreading those slots across the 32-CCK unit.
+bitplane fetch block that started before sprite 7's late DMA slot is still
+active at $30, sprite 7 DMA is blocked for that line; a DDFSTRT value of
+$30 itself matches on the following odd cycle and does not steal the already
+decided sprite slot. The condition is derived from the fetch-block sequence,
+not from a single DDFSTRT value. SANITY Roots II's AGA 256-colour effects are
+regression examples for both sides of this: the hi-res FMODE=3 pictures need
+raw-DDFSTRT unit rounding to preserve their 40-word rows, and the lo-res
+FMODE=3 landscape needs packed first-eight CCK plane slots instead of
+spreading those slots across the 32-CCK unit.
 
 Agnus revisions are modelled independently of Denise (machines shipped
 mixed): OCS (8370/8371), ECS 8372A (1M chip RAM reach), ECS 8375 (2M), and

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -48,17 +48,21 @@ sprite fetch quanta (FMODE=0 stays byte-identical to the OCS/ECS slot
 timing).
 
 Sprite DMA retains its latched POS/CTL descriptor independently from the
-SPRxPT registers while a sprite data stream is active. If software rewrites
-SPRxPT while the retained descriptor is still waiting for VSTART, the current
-stream is discarded and the next sprite DMA slot fetches a descriptor from
-the new address; otherwise descriptor words can be mistaken for sprite data.
+SPRxPT registers while a sprite data stream is active or waiting for VSTART.
+If software rewrites SPRxPT on a later beam line while that descriptor is
+still pending, the retained POS/CTL stays latched and the new SPRxPT value
+retargets the descriptor's post-control data stream. A same-line rewrite
+after the descriptor fetch is treated as a descriptor restart for the next
+sprite DMA slot; otherwise freshly loaded descriptor words would be mistaken
+for sprite data.
 Software can also write SPRxPOS/SPRxCTL directly and let sprite DMA fetch
 data from the current SPRxPT stream; in that case SPRxPT names the first
 data word pair, not a memory descriptor. A save-state load clears
 Copperline's transient Agnus descriptor latch, so this register-stream case
 is reconstructed from Denise's retained armed state, SPRxPOS/SPRxCTL, and
-the next beam-ordered SPRxPT low-word write. If a DMA descriptor has already
-been retained and is still waiting for VSTART, later SPRxPOS/SPRxCTL writes
+an after-slot SPRxPT low-word write in the rendered display area. If a DMA
+descriptor has already been retained and is still waiting for VSTART, later
+SPRxPOS/SPRxCTL writes
 update the live comparators but keep the descriptor's post-control data
 origin. The frame-start replay path mirrors this by replaying off-screen
 DMACON and SPRxPT writes in beam order before rendering the visible field.

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -58,6 +58,17 @@ update the live comparators but keep the descriptor's post-control data
 origin. The frame-start replay path mirrors this by replaying off-screen
 DMACON and SPRxPT writes in beam order before rendering the visible field.
 
+SPRxPT advances through sprite DMA and is not snapped back to the last value
+the Copper/CPU wrote at the top of the next field. A channel that has read its
+terminating descriptor leaves SPRxPT parked at the DMA frontier past the
+consumed list, so the next field's replay is seeded from that frontier rather
+than the stale descriptor address. Programs must reload SPRxPT every field
+(normally from the Copper) to keep a sprite displayed; this is what prevents a
+reused sprite descriptor buffer that software overwrites between fields from
+being re-armed from its previous, now-overwritten address before the Copper's
+reload lands. A channel still mid-descriptor at field end keeps the written
+pointer so an active reused sprite is not skipped past its data.
+
 Sprite descriptors whose decoded VSTART equals VSTOP idle the current
 sprite stream until software rearms it or the next field fetches again;
 the following words are not scanned as another descriptor. This is distinct

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -54,11 +54,17 @@ stream is discarded and the next sprite DMA slot fetches a descriptor from
 the new address; otherwise descriptor words can be mistaken for sprite data.
 Software can also write SPRxPOS/SPRxCTL directly and let sprite DMA fetch
 data from the current SPRxPT stream; in that case SPRxPT names the first
-data word pair, not a memory descriptor. If a DMA descriptor has already
+data word pair, not a memory descriptor. A save-state load clears
+Copperline's transient Agnus descriptor latch, so this register-stream case
+is reconstructed from Denise's retained armed state, SPRxPOS/SPRxCTL, and
+the next beam-ordered SPRxPT low-word write. If a DMA descriptor has already
 been retained and is still waiting for VSTART, later SPRxPOS/SPRxCTL writes
 update the live comparators but keep the descriptor's post-control data
 origin. The frame-start replay path mirrors this by replaying off-screen
 DMACON and SPRxPT writes in beam order before rendering the visible field.
+Enabled sprite slots that fetch no sprite data are not treated as observed
+sprite DMA; otherwise empty DMA slots would suppress valid register/manual
+sprite replay for that frame.
 
 SPRxPT advances through sprite DMA and is not snapped back to the last value
 the Copper/CPU wrote at the top of the next field. A channel that has read its

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -204,11 +204,11 @@ RAM, custom registers, and beam event journal stay intact, while Agnus
 rebuilds sprite control/data latches from the restored pointer context under
 the current descriptor rules. Register-armed sprite streams whose transient
 descriptor latch was not serialized are reconstructed from Denise's retained
-SPRxPOS/SPRxCTL/data-armed state and the next SPRxPT low-word write, so the
-first complete field after load follows the same data-stream rule as a live
-run. On success the window forces power on, clears any CPU halt latch, and
-invalidates `last_rendered_emulated_frame` so the next presentation
-re-renders from the restored Bus.
+SPRxPOS/SPRxCTL/data-armed state and the next after-slot SPRxPT low-word
+write in the rendered field, so the first complete field after load follows
+the same data-stream rule as a live run. On success the window forces power
+on, clears any CPU halt latch, and invalidates `last_rendered_emulated_frame`
+so the next presentation re-renders from the restored Bus.
 
 ## Verification
 

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -202,9 +202,13 @@ resources across, resets any queued live-audio presentation frames from the
 old timeline, and clears transient video capture buffers. The restored guest
 RAM, custom registers, and beam event journal stay intact, while Agnus
 rebuilds sprite control/data latches from the restored pointer context under
-the current descriptor rules. On success the window forces power on, clears
-any CPU halt latch, and invalidates `last_rendered_emulated_frame` so the
-next presentation re-renders from the restored Bus.
+the current descriptor rules. Register-armed sprite streams whose transient
+descriptor latch was not serialized are reconstructed from Denise's retained
+SPRxPOS/SPRxCTL/data-armed state and the next SPRxPT low-word write, so the
+first complete field after load follows the same data-stream rule as a live
+run. On success the window forces power on, clears any CPU halt latch, and
+invalidates `last_rendered_emulated_frame` so the next presentation
+re-renders from the restored Bus.
 
 ## Verification
 

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -98,14 +98,19 @@ serialize it if mid-line sprite-DMA resume accuracy is tightened. Tests:
 Beam-timed SPRxPOS writes are replayed in Denise's horizontal-comparator
 domain, seven colour clocks ahead of the normal register-output position.
 This matters for manual sprite reuse with sprite DMA disabled: Copper lists
-can write consecutive SPRxPOS values whose HSTARTs exactly abut, while later
-SPRxDATA/SPRxDATB writes still take effect only from their ordinary beam
-position. A same-line POS write also does not truncate a manual sprite word
-that has already started shifting; it re-arms a later compare while the
-active word completes. Tests:
+can write consecutive SPRxPOS values whose HSTARTs exactly abut. SPRxDATA
+and SPRxDATB writes update Denise's data latches at their ordinary beam
+position, but the sprite serializer copies those latches only when the
+horizontal comparator fires. A same-line DATA/DATB write after that compare
+therefore waits for a later compare or scanline instead of replacing the
+word already shifting. Same-line POS/CTL writes also do not truncate a
+manual sprite word that has already started shifting; they re-arm a later
+compare while the active word completes. Tests:
 `manual_sprite_position_write_before_hstart_uses_sprite_compare_domain`,
 `manual_sprite_position_writes_use_denise_compare_lag`,
-`manual_sprite_position_write_does_not_truncate_started_word`.
+`manual_sprite_position_write_does_not_truncate_started_word`,
+`manual_sprite_data_write_after_compare_waits_for_next_scanline`,
+`sprite_register_data_write_after_compare_preserves_dma_latch_on_same_beam_line`.
 
 ## The Copper
 
@@ -141,22 +146,22 @@ shared by the live bus path and the blitter-deadline predictor's cloned
 simulation, so prediction and execution cannot drift apart.
 
 For the low-res renderer, a same-line `COLORxx` write at beam `hpos`
-starts affecting pixels at `(hpos - $34) * 4` (`COLOR_WRITE_HPOS_FB0` in
+starts affecting pixels at `(hpos - $35) * 4` (`COLOR_WRITE_HPOS_FB0` in
 `src/video/bitplane.rs`); beam-timed placement is anchored at
 `COPPER_WAIT_HPOS_FB0` ($28), and bitplane-control writes add the
 fetch-to-display pipeline offset (`BITPLANE_CONTROL_PIPELINE_FB`). This
-anchor keeps a copper colour change aligned with the bitplane pixels it
-recolours: Denise (and MiniMig, which adds a one-lores-pixel bitplane delay
-"for alignment of bitplane data and copper colour change") emits the new
-colour in the same beam slot as those pixels. OCS Denise (8362) and ECS
-Denise (8373) share this timing; the only OCS/ECS colour-path difference is
-the OCS 12-bit value mask. (AGA Lisa delays colour changes by one hires
-pixel relative to OCS/ECS per WinUAE; that sub-colour-clock offset is not
-yet modelled.) AGA BPLCON4's sprite palette-base byte uses Lisa's earlier
-sprite colour-lookup path at `(hpos - $36) * 4`
-(`SPRITE_PALETTE_CONTROL_HPOS_FB0`). Tests:
+models COLORxx on Denise's final palette/output phase, one lores pixel
+ahead of writes that feed delayed shifter/control paths. OCS Denise (8362)
+and ECS Denise (8373) share this timing; the only OCS/ECS colour-path
+difference is the OCS 12-bit value mask. (AGA Lisa delays colour changes by
+one hires pixel relative to OCS/ECS per WinUAE; that sub-colour-clock offset
+is not yet modelled.) AGA BPLCON4's sprite palette-base byte uses Lisa's
+earlier sprite colour-lookup path at `(hpos - $36) * 4`
+(`SPRITE_PALETTE_CONTROL_HPOS_FB0`), one lores pixel ahead of ordinary
+COLORxx replay. Tests:
 `copper_move_writes_visible_registers_on_second_dma_slot`,
-`copper_move_spends_four_color_clocks_leaving_alternate_cycles_free`.
+`copper_move_spends_four_color_clocks_leaving_alternate_cycles_free`,
+`color_register_writes_use_final_output_position`.
 
 ### WAIT/SKIP edge cases
 

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -89,11 +89,16 @@ data pointer stays with the descriptor that armed the sprite, and active
 row offsets remain relative to that descriptor. Copperline therefore keeps
 a runtime-only data-origin VSTART alongside the live comparator VSTART,
 preserving it across active POS/CTL rewrites while still using the
-rewritten HSTART for the line. The runtime origin is skipped in save states
-to preserve the fixed bincode layout; future save-state versioning should
-serialize it if mid-line sprite-DMA resume accuracy is tightened. Tests:
+rewritten HSTART for the line. Directly armed register sprites use the same
+runtime origin marker when SPRxPT is refreshed as a data stream instead of a
+memory descriptor. The runtime origin is skipped in save states to preserve
+the fixed bincode layout; after load, retained Denise armed state and the
+next SPRxPT low-word write reconstruct this case for subsequent full frames.
+Future save-state versioning should serialize it if mid-line sprite-DMA
+resume accuracy is tightened. Tests:
 `pending_sprite_control_rewrite_preserves_descriptor_data_origin`,
-`active_sprite_control_rewrite_preserves_descriptor_data_origin`.
+`active_sprite_control_rewrite_preserves_descriptor_data_origin`,
+`armed_register_sprite_pointer_write_seeds_dma_data_stream`.
 
 Beam-timed SPRxPOS writes are replayed in Denise's horizontal-comparator
 domain, seven colour clocks ahead of the normal register-output position.

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -89,16 +89,21 @@ data pointer stays with the descriptor that armed the sprite, and active
 row offsets remain relative to that descriptor. Copperline therefore keeps
 a runtime-only data-origin VSTART alongside the live comparator VSTART,
 preserving it across active POS/CTL rewrites while still using the
-rewritten HSTART for the line. Directly armed register sprites use the same
-runtime origin marker when SPRxPT is refreshed as a data stream instead of a
+rewritten HSTART for the line. SPRxPT rewrites on a later beam line while a
+descriptor is still pending retarget that descriptor's data stream; same-line
+rewrites after the descriptor fetch restart from a memory descriptor on the
+next sprite slot. Directly armed register sprites use the same runtime origin
+marker when an after-slot SPRxPT write refreshes a data stream instead of a
 memory descriptor. The runtime origin is skipped in save states to preserve
 the fixed bincode layout; after load, retained Denise armed state and the
-next SPRxPT low-word write reconstruct this case for subsequent full frames.
+next after-slot SPRxPT low-word write reconstruct this case for subsequent
+full frames.
 Future save-state versioning should serialize it if mid-line sprite-DMA
 resume accuracy is tightened. Tests:
 `pending_sprite_control_rewrite_preserves_descriptor_data_origin`,
 `active_sprite_control_rewrite_preserves_descriptor_data_origin`,
-`armed_register_sprite_pointer_write_seeds_dma_data_stream`.
+`pending_descriptor_sprite_pointer_write_retargets_data_stream`,
+`after_slot_armed_sprite_pointer_write_seeds_dma_data_stream`.
 
 Beam-timed SPRxPOS writes are replayed in Denise's horizontal-comparator
 domain, seven colour clocks ahead of the normal register-output position.

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -63,18 +63,20 @@ when those two x positions differ, then applies the full BPLCON4 value on
 the normal control segment.
 
 Manual and held-sprite replay has a smaller split of its own. SPRxDATA and
-SPRxDATB writes affect only later pixels in the normal register-output
-domain, and SPRxCTL still disarms output at that point. SPRxPOS writes,
-however, re-arm the sprite horizontal comparator: if the write occurs before
-the newly programmed HSTART, the sprite can still begin at that HSTART. The
+SPRxDATB writes update Denise's data latches in the normal register-output
+domain, but the sprite serializer copies those latches only when the
+horizontal comparator fires. A DATA/DATB write after that compare is for a
+later compare or scanline, not the word already shifting. SPRxPOS writes
+re-arm the sprite horizontal comparator: if the write occurs before the
+newly programmed HSTART, the sprite can still begin at that HSTART. The
 replay clips those position intervals in the sprite-comparator domain
 (seven CCK ahead of the normal register-output position) so adjacent manual
 sprite words can abut at their HSTARTs and staggered even/odd attached-pair
 position writes do not create artificial half-pair strips. Once a manual
-sprite word has started shifting, a later same-line SPRxPOS write can arm a
-future compare but does not truncate that active word. A POS write that
-lands exactly on the HSTART compare boundary is on the already-started side
-of that rule.
+sprite word has started shifting, later same-line POS/CTL writes can arm a
+future compare but do not truncate that active word. A POS write that lands
+exactly on the HSTART compare boundary is on the already-started side of
+that rule.
 
 When sprite DMA was observed for the frame, captured DMA lines are the
 authoritative data source for DMA-fetched spans. Manual replay is seeded by

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -41,6 +41,11 @@ push a standard-width DIW past the completed early-DDF row at the right edge.
 When DDFSTRT is late enough that DIW opens before DMA has delivered the
 first BPL1DAT word for the row, playfield output remains border-colour until
 that plane-0 fetch reaches Denise instead of sampling stale shifter contents.
+If a manual BPL1DAT write starts a word before that DMA load point, replay
+stops the manual word where the DMA word replaces Denise's shifter.
+BPLCON1-delayed samples at the left edge of a contiguous bitplane-DMA block
+come from the previous line's shifter tail; block-start lines still blank that
+scroll-in because there is no carried playfield data.
 A BPLCON1 write whose normal register position is already at or beyond DIW's
 right edge is not pulled left into the current line's bitplane-scroll domain;
 it updates following lines without retapping the visible HAM tail of the

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -50,8 +50,10 @@ loads BPL1DAT.
 If a manual BPL1DAT write starts a word before that DMA load point, replay
 stops the manual word where the DMA word replaces Denise's shifter.
 BPLCON1-delayed samples at the left edge of a contiguous bitplane-DMA block
-come from the previous line's shifter tail; block-start lines still blank that
-scroll-in because there is no carried playfield data.
+come from the previous line's shifter tail when current-line DMA is already
+feeding Denise at the display edge. Block-start lines, and lines whose output
+is held until a delayed first BPL1DAT load, blank that scroll-in because no
+current-line shifter data has reached the visible gate yet.
 A BPLCON1 write whose normal register position is already at or beyond DIW's
 right edge is not pulled left into the current line's bitplane-scroll domain;
 it updates following lines without retapping the visible HAM tail of the

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -38,9 +38,15 @@ pre-advances that hidden sample before painting the DIW edge. Single-word
 lo-res fetches that start before the standard `$38` DDF slot expose complete
 16-pixel groups; the standard one-sample phase bias is trimmed when it would
 push a standard-width DIW past the completed early-DDF row at the right edge.
+Late single-word lo-res DDF keeps the standard DIW `$81` one-sample phase;
+the renderer must not subtract an extra sample just to align the clipped
+start to a fetch-unit boundary.
 When DDFSTRT is late enough that DIW opens before DMA has delivered the
 first BPL1DAT word for the row, playfield output remains border-colour until
 that plane-0 fetch reaches Denise instead of sampling stale shifter contents.
+That gate is placed in the bitplane/DIW coordinate domain, not the normal
+Copper/register-write output domain, because it follows the fetch slot that
+loads BPL1DAT.
 If a manual BPL1DAT write starts a word before that DMA load point, replay
 stops the manual word where the DMA word replaces Denise's shifter.
 BPLCON1-delayed samples at the left edge of a contiguous bitplane-DMA block

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -38,6 +38,9 @@ pre-advances that hidden sample before painting the DIW edge. Single-word
 lo-res fetches that start before the standard `$38` DDF slot expose complete
 16-pixel groups; the standard one-sample phase bias is trimmed when it would
 push a standard-width DIW past the completed early-DDF row at the right edge.
+When DDFSTRT is late enough that DIW opens before DMA has delivered the
+first BPL1DAT word for the row, playfield output remains border-colour until
+that plane-0 fetch reaches Denise instead of sampling stale shifter contents.
 A BPLCON1 write whose normal register position is already at or beyond DIW's
 right edge is not pulled left into the current line's bitplane-scroll domain;
 it updates following lines without retapping the visible HAM tail of the

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -30,14 +30,16 @@ pipeline carries 24-bit colour end to end; OCS/ECS paths keep their exact
 12-bit maths and expand by nibble), composited with the eight sprites
 under playfield priority, and CLXDAT collisions are accumulated.
 For DMA-fetched HAM playfields, the display window gates framebuffer output
-and collision recording, but it does not rewind the HAM component history:
-fetched native samples that sit just before DIW, or inside a closed portion
-of DIW, still advance the HAM hold colour. Standard lo-res DDF timing starts
-the first visible output one native sample into the fetched stream, so replay
-pre-advances that hidden sample before painting the DIW edge. Single-word
-lo-res fetches that start before the standard `$38` DDF slot expose complete
-16-pixel groups; the standard one-sample phase bias is trimmed when it would
-push a standard-width DIW past the completed early-DDF row at the right edge.
+and collision recording, but the low-res Denise phase can still seed the HAM
+component history just before DIW: standard `$38` DDF timing starts the first
+visible output one native sample into the fetched stream, so replay
+pre-advances that hidden sample before painting the DIW edge. Extra fetch
+groups from an earlier DDFSTRT are not decoded into the HAM hold colour before
+DIW opens; they are fetched by Agnus, but the first visible HAM history is
+bounded to the display-phase samples. Single-word lo-res fetches that start
+before the standard `$38` DDF slot expose complete 16-pixel groups; the
+standard one-sample phase bias is trimmed when it would push a standard-width
+DIW past the completed early-DDF row at the right edge.
 Late single-word lo-res DDF keeps the standard DIW `$81` one-sample phase;
 the renderer must not subtract an extra sample just to align the clipped
 start to a fetch-unit boundary.
@@ -53,7 +55,10 @@ BPLCON1-delayed samples at the left edge of a contiguous bitplane-DMA block
 come from the previous line's shifter tail when current-line DMA is already
 feeding Denise at the display edge. Block-start lines, and lines whose output
 is held until a delayed first BPL1DAT load, blank that scroll-in because no
-current-line shifter data has reached the visible gate yet.
+current-line shifter data has reached the visible gate yet. AGA's extended
+BPLCON1 delays can exceed one 16-bit shifter word; replay does not reuse the
+single cached line-tail word for those wider delays, so the extra leading gap
+stays background until current-line samples reach Lisa.
 A BPLCON1 write whose normal register position is already at or beyond DIW's
 right edge is not pulled left into the current line's bitplane-scroll domain;
 it updates following lines without retapping the visible HAM tail of the
@@ -103,7 +108,10 @@ write after the sprite DMA slot can re-arm the horizontal comparator and
 reuse the line data DMA already loaded, so the renderer seeds those POS-only
 reuse spans from the captured DMA line. Sprites whose data was established
 by DMA before SPREN was cleared are carried separately as held sprites and
-can still be repositioned by later SPRxPOS/CTL writes.
+can still be repositioned by later SPRxPOS/CTL writes. Merely enabling
+sprite DMA and crossing an empty sprite pair slot is not enough to make
+captured DMA authoritative; the frame must contain actual fetched or held
+sprite data.
 
 The mapping from beam coordinates to framebuffer x is anchored by
 constants that encode the hardware's fetch-to-display pipeline delays --

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -10484,17 +10484,10 @@ mod tests {
 
     const STANDARD_DIW_HSTART: i32 = 0x81;
     const STANDARD_VISIBLE_X0: usize = ((STANDARD_DIW_HSTART - RENDER_DIW_HSTART_FB0) * 2) as usize;
-    // STOP. If you are here because some scene's colours or copper-driven
-    // picture look horizontally shifted and you are tempted to nudge this
-    // value (or `COLOR_WRITE_HPOS_FB0` in src/video/bitplane.rs, which this
-    // mirrors): you are almost certainly wrong. This anchor is the Denise
-    // COLORxx output phase, calibrated so copper/CPU colour writes line up
-    // with the bitplane pixels they recolour (OCS == ECS; verified against
-    // MiniMig, MiSTer Minimig-AGA, WinUAE and vAmiga). We have moved it "to
-    // fix" a scene several times and every time had to move it back, because
-    // the real bug was elsewhere (bitplane fetch/DDF alignment, sprite arming,
-    // etc.). Find the actual cause; do not retune this number.
-    const RENDER_COLOR_WRITE_HPOS_FB0: u32 = 0x34;
+    // Mirrors `COLOR_WRITE_HPOS_FB0` in src/video/bitplane.rs. COLORxx writes
+    // reach Denise's final palette/output phase one lores pixel ahead of
+    // writes that feed delayed shifter/control paths.
+    const RENDER_COLOR_WRITE_HPOS_FB0: u32 = 0x35;
     static BUS_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -15908,6 +15908,41 @@ mod tests {
     }
 
     #[test]
+    fn sprite_dma_capture_keeps_sprite_seven_when_ddfstrt_matches_sprite_slot() {
+        let mut bus = empty_bus();
+        let (pos, ctl) = sprite_control_words(0x2C, 0x2D, 0x0083);
+        let sprite6_ptr = 0x0200usize;
+        let sprite7_ptr = 0x0300usize;
+        for ptr in [sprite6_ptr, sprite7_ptr] {
+            write_chip_word(&mut bus, ptr, pos);
+            write_chip_word(&mut bus, ptr + 2, ctl);
+            write_chip_word(&mut bus, ptr + 8, 0);
+            write_chip_word(&mut bus, ptr + 10, 0);
+        }
+        write_chip_word(&mut bus, sprite6_ptr + 4, 0x6666);
+        write_chip_word(&mut bus, sprite6_ptr + 6, 0x7777);
+        write_chip_word(&mut bus, sprite7_ptr + 4, 0x8888);
+        write_chip_word(&mut bus, sprite7_ptr + 6, 0x9999);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN | DMACON_SPREN;
+        bus.agnus.vpos = 0x2C;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[3] - 1;
+        bus.denise.bplcon0 = 0x3000;
+        bus.denise.ddfstrt = 0x0030;
+        bus.denise.ddfstop = 0x0038;
+        bus.denise.sprpt[6] = sprite6_ptr as u32;
+        bus.denise.sprpt[7] = sprite7_ptr as u32;
+        bus.display_dma_sprpt[6] = sprite6_ptr as u32;
+        bus.display_dma_sprpt[7] = sprite7_ptr as u32;
+
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert!(lines.iter().any(|line| line.sprite == 6));
+        assert!(lines.iter().any(|line| line.sprite == 7));
+    }
+
+    #[test]
     fn sprite_dma_capture_repeats_last_fetched_line_after_dma_disable_until_vstop() {
         let mut bus = empty_bus();
         let sprite_ptr = 0x0100usize;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -207,6 +207,11 @@ fn diag_sprcap() -> Option<&'static str> {
     V.get_or_init(|| crate::envcfg::var("COPPERLINE_DIAG_SPRCAP"))
         .as_deref()
 }
+
+fn diag_sprcap_matches(want: &str, beam_y: i32) -> bool {
+    let want = want.trim();
+    want == "all" || want.parse::<i32>().ok() == Some(beam_y)
+}
 const CPU_COPPER_BOTTOM_PALETTE_MIN_VPOS: u32 = 0xC0;
 #[cfg(test)]
 const DMACON_AUD_MASK: u16 = 0x000F;
@@ -297,6 +302,12 @@ struct DisplaySpriteDmaState {
     terminated: bool,
     data_dma_active: bool,
     last_line: Option<DisplaySpriteLineData>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpriteControlRegisterWrite {
+    Pos,
+    Ctl,
 }
 
 #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
@@ -4704,11 +4715,17 @@ impl Bus {
                     match reg {
                         0x0 => {
                             self.denise.sprpos[idx] = val;
-                            self.latch_display_sprite_dma_control_from_registers(idx);
+                            self.latch_display_sprite_dma_control_from_registers(
+                                idx,
+                                SpriteControlRegisterWrite::Pos,
+                            );
                         }
                         0x2 => {
                             self.denise.write_sprctl(idx, val);
-                            self.latch_display_sprite_dma_control_from_registers(idx);
+                            self.latch_display_sprite_dma_control_from_registers(
+                                idx,
+                                SpriteControlRegisterWrite::Ctl,
+                            );
                         }
                         0x4 => self.denise.write_sprdata(idx, val),
                         0x6 => self.denise.write_sprdatb(idx, val),
@@ -6951,7 +6968,11 @@ impl Bus {
         self.retarget_display_sprite_dma_pointer_at(sprite, vpos, hpos);
     }
 
-    fn latch_display_sprite_dma_control_from_registers(&mut self, sprite: usize) {
+    fn latch_display_sprite_dma_control_from_registers(
+        &mut self,
+        sprite: usize,
+        write: SpriteControlRegisterWrite,
+    ) {
         if sprite >= 8 {
             return;
         }
@@ -6962,6 +6983,7 @@ impl Bus {
             self.agnus.vpos,
             self.agnus.hpos,
             self.agnus.dmacon,
+            write,
         );
     }
 
@@ -6973,9 +6995,36 @@ impl Bus {
         vpos: u32,
         hpos: u32,
         dmacon: u16,
+        write: SpriteControlRegisterWrite,
     ) {
         if sprite >= 8 {
             return;
+        }
+
+        let mut state = self.display_dma_sprite_state[sprite];
+        let previous_control = state.control;
+        let beam_y = vpos as i32;
+
+        if matches!(write, SpriteControlRegisterWrite::Pos)
+            && state.data_dma_active
+            && previous_control
+                .map(|previous| beam_y < previous.vstop)
+                .unwrap_or(false)
+        {
+            if let Some(mut control) = previous_control {
+                // SPRxPOS retimes the horizontal comparator, but it does not
+                // re-fetch POS/CTL or cancel an already-enabled sprite DMA
+                // stream. Keep the DMA descriptor's stop/data origin latched;
+                // the HSTART low bit still comes from the previously latched
+                // CTL word.
+                control.hstart = (((pos & 0x00FF) << 1) as i32) | (control.hstart & 1);
+                state.control = Some(control);
+                state.next_ptr = Some(control.next_ptr);
+                state.terminated = false;
+                state.data_dma_active = true;
+                self.display_dma_sprite_state[sprite] = state;
+                return;
+            }
         }
 
         let vstart = sprite_vstart_from_words(pos, ctl);
@@ -7012,9 +7061,6 @@ impl Bus {
             attached: ctl & 0x0080 != 0,
         };
 
-        let mut state = self.display_dma_sprite_state[sprite];
-        let previous_control = state.control;
-        let beam_y = vpos as i32;
         let in_window = beam_y >= control.vstart && beam_y < control.vstop;
         let sprite_dma_enabled =
             dmacon & (DMACON_DMAEN | DMACON_SPREN) == (DMACON_DMAEN | DMACON_SPREN);
@@ -7421,12 +7467,11 @@ impl Bus {
                     // lines on that beam line (frame, channel, position, words,
                     // and the chip-RAM descriptor/data addresses they fetched).
                     if let Some(want) = diag_sprcap() {
-                        if want.trim() == "all"
-                            || want.trim().parse::<i32>().ok() == Some(line.beam_y)
-                        {
+                        if diag_sprcap_matches(want, line.beam_y) {
                             let st = &self.display_dma_sprite_state[sprite];
+                            let ctl = st.control;
                             log::info!(
-                                "sprcap f={} s{} y={} hstart={} hsub={} att={} w={} A={:04X} {:04X?} B={:04X} {:04X?} data_base={:06X} next={:06X?}",
+                                "sprcap f={} s{} y={} hstart={} hsub={} att={} w={} A={:04X} {:04X?} B={:04X} {:04X?} ctl=({},{},{},{:06X}) data_base={:06X} next={:06X?}",
                                 self.emulated_frames,
                                 line.sprite,
                                 line.beam_y,
@@ -7438,6 +7483,10 @@ impl Bus {
                                 line.data_ext,
                                 line.datb,
                                 line.datb_ext,
+                                ctl.map(|c| c.vstart).unwrap_or(-1),
+                                ctl.map(|c| c.vstop).unwrap_or(-1),
+                                ctl.map(|c| c.effective_data_vstart()).unwrap_or(-1),
+                                ctl.map(|c| c.next_ptr).unwrap_or(0),
                                 st.control.map(|c| c.data_base).unwrap_or(0),
                                 st.next_ptr
                             );
@@ -7481,6 +7530,7 @@ impl Bus {
         let mut state = self.display_dma_sprite_state[sprite];
         let mut descriptor_can_match_current_vstart =
             state.control.is_some() || state.next_ptr.is_none();
+        let mut descriptor_loaded_after_stop_this_line = false;
 
         let mut visited_descriptor_ptrs = HashSet::new();
         loop {
@@ -7496,6 +7546,7 @@ impl Bus {
                     state.data_dma_active = false;
                     state.last_line = None;
                     descriptor_can_match_current_vstart = false;
+                    descriptor_loaded_after_stop_this_line = true;
                 } else if !state.data_dma_active {
                     if beam_y == control.vstart {
                         state.data_dma_active = true;
@@ -7624,7 +7675,7 @@ impl Bus {
             } else {
                 height as u32
             };
-            let control = DisplaySpriteControl {
+            let mut control = DisplaySpriteControl {
                 vstart,
                 vstop,
                 hstart: sprite_hstart_from_words(pos, ctl),
@@ -7634,11 +7685,56 @@ impl Bus {
                 next_ptr: ptr.wrapping_add(data_lines.saturating_mul(4 * quantum)) & ram_mask & !1,
                 attached: ctl & 0x0080 != 0,
             };
+            let defer_start_until_next_line =
+                descriptor_loaded_after_stop_this_line && beam_y == control.vstart;
+            if defer_start_until_next_line {
+                control.data_vstart = beam_y + 1;
+                let remaining_height = (control.vstop - control.data_vstart).max(0) as u32;
+                let remaining_data_lines = if sprite_scan_doubled(self.agnus.fmode()) {
+                    remaining_height.div_ceil(2)
+                } else {
+                    remaining_height
+                };
+                control.next_ptr = control
+                    .data_base
+                    .wrapping_add(remaining_data_lines.saturating_mul(4 * quantum))
+                    & ram_mask
+                    & !1;
+            }
+            if let Some(want) = diag_sprcap() {
+                if diag_sprcap_matches(want, beam_y) {
+                    log::info!(
+                        "sprdesc f={} s{} y={} ptr={:06X} pos={:04X} ctl={:04X} vstart={} vstop={} raw_vstop={} hstart={} att={} data_base={:06X} data_vstart={} next={:06X} can_match={} start_now={} defer_start={}",
+                        self.emulated_frames,
+                        sprite,
+                        beam_y,
+                        descriptor_ptr,
+                        pos,
+                        ctl,
+                        control.vstart,
+                        control.vstop,
+                        raw_vstop,
+                        control.hstart,
+                        u8::from(control.attached),
+                        control.data_base,
+                        control.data_vstart,
+                        control.next_ptr,
+                        u8::from(descriptor_can_match_current_vstart),
+                        u8::from(beam_y == control.vstart && descriptor_can_match_current_vstart),
+                        u8::from(defer_start_until_next_line),
+                    );
+                }
+            }
 
             state.control = Some(control);
             state.data_dma_active = false;
             state.last_line = None;
             if beam_y < control.vstart {
+                self.display_dma_sprite_state[sprite] = state;
+                return None;
+            }
+            if defer_start_until_next_line {
+                state.data_dma_active = true;
                 self.display_dma_sprite_state[sprite] = state;
                 return None;
             }
@@ -7866,7 +7962,7 @@ impl Bus {
                 let block_display_planes = block_mode.display_planes();
                 for plane in 0..block_dma_planes.min(8) {
                     if plane == 0 {
-                        self.record_sprite_display_enable_for_bitplane_dma(vpos, block_bplcon0);
+                        self.record_sprite_display_enable_for_bitplane_dma(vpos);
                     }
                     for w in 0..quantum.min(words_per_row - word_base) {
                         let word_idx = word_base + w;
@@ -7921,7 +8017,7 @@ impl Bus {
                         continue;
                     }
                     if plane == 0 {
-                        self.record_sprite_display_enable_for_bitplane_dma(vpos, block_bplcon0);
+                        self.record_sprite_display_enable_for_bitplane_dma(vpos);
                     }
                     for w in 0..quantum.min(words_per_row - word_base) {
                         let word_idx = word_base + w;
@@ -8132,7 +8228,7 @@ impl Bus {
         self.record_sprite_display_enable_x(fb_y, x);
     }
 
-    fn record_sprite_display_enable_for_bitplane_dma(&mut self, vpos: u32, bplcon0: u16) {
+    fn record_sprite_display_enable_for_bitplane_dma(&mut self, vpos: u32) {
         let Some(fb_y) = visible_framebuffer_y(
             vpos,
             self.current_frame_visible_start_vpos,
@@ -8145,21 +8241,7 @@ impl Bus {
             self.denise.diwstop,
             self.effective_diwhigh(),
         );
-        let pixel_repeat = if bitplane_hires(bplcon0) || bitplane_shres(bplcon0) {
-            1
-        } else {
-            2
-        };
-        let native_samples_per_pixel = if bitplane_shres(bplcon0) { 2 } else { 1 };
-        let fetch_start_native_x = live_fetch_start_native_x(
-            self.agnus.revision(),
-            bplcon0,
-            self.denise.diwstrt,
-            self.effective_diwhigh(),
-            self.denise.ddfstrt,
-        );
-        let skipped_pixels = fetch_start_native_x.div_ceil(native_samples_per_pixel) * pixel_repeat;
-        let x = window_x_start.max(0) as usize + skipped_pixels;
+        let x = window_x_start.max(0) as usize;
         self.record_sprite_display_enable_x(fb_y, x);
     }
 
@@ -9432,9 +9514,9 @@ fn live_sprite_visible_x_range_for_control(
     if beam_y < 0 {
         return None;
     }
-    // A manual BPL1DAT write records `display_enable_x` for this scanline;
-    // that is enough to make OCS/ECS sprites active vertically, while DIW
-    // still clips the horizontal span.
+    // Bitplane DMA records DIW's left edge here; a manual BPL1DAT write records
+    // its beam position. Either path can make OCS/ECS sprites active vertically,
+    // while DIW still clips the horizontal span.
     let (window_x_start, window_x_stop) =
         live_display_window_x(control.diwstrt, control.diwstop, control.diwhigh);
     let x_start = x_start.max(display_enable_x).max(window_x_start);
@@ -9462,8 +9544,8 @@ fn live_sprite_pixel_inside_display_window(
         return false;
     }
     // See `live_sprite_visible_x_range_for_control`: display_enable_x carries
-    // the per-line BPL1DAT/DMA latch, so do not apply a separate DIW vertical
-    // test here.
+    // the per-line manual-BPL1DAT/DMA gate, so do not apply a separate DIW
+    // vertical test here.
     live_display_window_contains_x(
         control.diwstrt,
         control.diwstop,
@@ -13592,7 +13674,7 @@ mod tests {
     }
 
     #[test]
-    fn bitplane_dma_bpl1dat_fetch_sets_sprite_display_enable_at_playfield_origin() {
+    fn bitplane_dma_sets_sprite_display_enable_at_display_window_start() {
         let mut bus = empty_bus();
         bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
         bus.agnus.vpos = RENDER_VISIBLE_START_VPOS;
@@ -13611,6 +13693,29 @@ mod tests {
         assert_eq!(
             bus.frame_sprite_display_enable_x_by_y()[0],
             Some(((0x81 - RENDER_DIW_HSTART_FB0) * 2) as usize)
+        );
+    }
+
+    #[test]
+    fn late_bitplane_fetch_does_not_delay_sprite_display_inside_diw() {
+        let mut bus = empty_bus();
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+        bus.agnus.vpos = RENDER_VISIBLE_START_VPOS;
+        bus.agnus.hpos = 0x50;
+        bus.denise.diwstrt = 0x2C91;
+        bus.denise.diwstop = 0x2CC1;
+        bus.denise.ddfstrt = 0x0050;
+        bus.denise.ddfstop = 0x0050;
+        bus.denise.bplcon0 = 0x3200;
+        bus.denise.bplpt[0] = 0x0100;
+        bus.display_dma_bplpt[0] = 0x0100;
+        write_chip_word(&mut bus, 0x0100, 0x4000);
+
+        bus.advance_chipset(8);
+
+        assert_eq!(
+            bus.frame_sprite_display_enable_x_by_y()[0],
+            Some(((0x91 - RENDER_DIW_HSTART_FB0) * 2) as usize)
         );
     }
 
@@ -15386,6 +15491,58 @@ mod tests {
     }
 
     #[test]
+    fn active_sprite_pos_write_retimes_hstart_without_clearing_dma_stream() {
+        let mut bus = empty_bus();
+        let sprite_ptr = 0x0100usize;
+        let (pos, ctl) = sprite_control_words(0x2C, 0x30, 0x0083);
+        write_chip_word(&mut bus, sprite_ptr, pos);
+        write_chip_word(&mut bus, sprite_ptr + 2, ctl);
+        write_chip_word(&mut bus, sprite_ptr + 4, 0x1111);
+        write_chip_word(&mut bus, sprite_ptr + 6, 0x2222);
+        write_chip_word(&mut bus, sprite_ptr + 8, 0x3333);
+        write_chip_word(&mut bus, sprite_ptr + 10, 0x4444);
+        write_chip_word(&mut bus, sprite_ptr + 12, 0x5555);
+        write_chip_word(&mut bus, sprite_ptr + 14, 0x6666);
+        write_chip_word(&mut bus, sprite_ptr + 16, 0);
+        write_chip_word(&mut bus, sprite_ptr + 18, 0);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.denise.sprpt[0] = sprite_ptr as u32;
+        bus.display_dma_sprpt[0] = sprite_ptr as u32;
+        bus.agnus.vpos = 0x2C;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        // Rewriting SPRxPOS while DMA is already enabled changes the horizontal
+        // comparator. It must not recompute the active descriptor from the
+        // software-visible SPRxCTL value, which may not be the DMA-fetched CTL.
+        let moved_pos = ((0x00A1 >> 1) & 0x00FF) as u16;
+        bus.agnus.vpos = 0x2D;
+        bus.agnus.hpos = 0;
+        assert!(!bus.write_custom_word_from(0x140, moved_pos, BeamWriteSource::Copper));
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        bus.agnus.vpos = 0x2E;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let words: Vec<(i32, i32, u16, u16)> = bus
+            .frame_captured_sprite_lines()
+            .iter()
+            .map(|line| (line.beam_y, line.hstart, line.data, line.datb))
+            .collect();
+        assert_eq!(
+            words,
+            vec![
+                (0x2C, 0x0083, 0x1111, 0x2222),
+                (0x2D, 0x00A1, 0x3333, 0x4444),
+                (0x2E, 0x00A1, 0x5555, 0x6666),
+            ]
+        );
+    }
+
+    #[test]
     fn finished_sprite_channel_carries_dma_frontier_across_frame_boundary() {
         // Real Agnus advances SPRxPT through sprite DMA. A channel that has read
         // its terminating descriptor leaves the pointer parked at the DMA
@@ -15869,6 +16026,55 @@ mod tests {
         assert!(!lines
             .iter()
             .any(|line| line.sprite == 0 && line.beam_y == 0x2D));
+    }
+
+    #[test]
+    fn sprite_dma_chained_descriptor_with_same_vstart_arms_after_control_fetch_line() {
+        let mut bus = empty_bus();
+        let sprite_ptr = 0x0100usize;
+        let (first_pos, first_ctl) = sprite_control_words(0x2C, 0x2D, 0x0083);
+        let (same_line_pos, same_line_ctl) = sprite_control_words(0x2D, 0x30, 0x0091);
+        let (later_pos, later_ctl) = sprite_control_words(0x31, 0x32, 0x00A1);
+        write_chip_word(&mut bus, sprite_ptr, first_pos);
+        write_chip_word(&mut bus, sprite_ptr + 2, first_ctl);
+        write_chip_word(&mut bus, sprite_ptr + 4, 0x1111);
+        write_chip_word(&mut bus, sprite_ptr + 6, 0x2222);
+        write_chip_word(&mut bus, sprite_ptr + 8, same_line_pos);
+        write_chip_word(&mut bus, sprite_ptr + 10, same_line_ctl);
+        write_chip_word(&mut bus, sprite_ptr + 12, 0x3333);
+        write_chip_word(&mut bus, sprite_ptr + 14, 0x4444);
+        write_chip_word(&mut bus, sprite_ptr + 16, 0x5555);
+        write_chip_word(&mut bus, sprite_ptr + 18, 0x6666);
+        write_chip_word(&mut bus, sprite_ptr + 20, later_pos);
+        write_chip_word(&mut bus, sprite_ptr + 22, later_ctl);
+        write_chip_word(&mut bus, sprite_ptr + 24, 0x7777);
+        write_chip_word(&mut bus, sprite_ptr + 26, 0x8888);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.denise.sprpt[0] = sprite_ptr as u32;
+        bus.display_dma_sprpt[0] = sprite_ptr as u32;
+
+        for vpos in 0x2C..=0x31u32 {
+            bus.agnus.vpos = vpos;
+            bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+            bus.advance_chipset(2);
+        }
+
+        let words: Vec<(i32, i32, u16, u16)> = bus
+            .frame_captured_sprite_lines()
+            .iter()
+            .filter(|line| line.sprite == 0)
+            .map(|line| (line.beam_y, line.hstart, line.data, line.datb))
+            .collect();
+        assert_eq!(
+            words,
+            vec![
+                (0x2C, 0x0083, 0x1111, 0x2222),
+                (0x2E, 0x0091, 0x3333, 0x4444),
+                (0x2F, 0x0091, 0x5555, 0x6666),
+                (0x31, 0x00A1, 0x7777, 0x8888),
+            ]
+        );
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -298,10 +298,16 @@ pub struct HeldSpriteLine {
 #[derive(Clone, Copy, Debug, Default, serde::Serialize, serde::Deserialize)]
 struct DisplaySpriteDmaState {
     control: Option<DisplaySpriteControl>,
+    #[serde(skip, default = "unset_sprite_control_loaded_vpos")]
+    control_loaded_vpos: i32,
     next_ptr: Option<u32>,
     terminated: bool,
     data_dma_active: bool,
     last_line: Option<DisplaySpriteLineData>,
+}
+
+fn unset_sprite_control_loaded_vpos() -> i32 {
+    i32::MIN
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -6987,23 +6993,44 @@ impl Bus {
         }
         let state = self.display_dma_sprite_state[sprite];
         if let Some(control) = state.control {
-            if !state.data_dma_active && !control.data_origin_is_register_stream() {
+            if !state.data_dma_active
+                && !control.data_origin_is_register_stream()
+                && state.control_loaded_vpos == vpos as i32
+            {
                 self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState::default();
                 return;
             }
-        } else if self.denise.spr_armed[sprite]
-            && dmacon & (DMACON_DMAEN | DMACON_SPREN) == (DMACON_DMAEN | DMACON_SPREN)
+        } else if self
+            .armed_sprite_pointer_write_can_seed_register_data_stream(sprite, vpos, hpos, dmacon)
         {
-            // The transient Agnus descriptor latch is not always available to
-            // this replay path (notably after save-state load), but Denise
-            // still exposes an armed sprite word plus the retained POS/CTL
-            // comparators. If software refreshes SPRxPT for that still-armed
-            // stream, the pointer names data words rather than a fresh POS/CTL
-            // descriptor.
             self.latch_display_sprite_register_data_stream_at(sprite, vpos, hpos);
             return;
         }
         self.retarget_display_sprite_dma_pointer_at(sprite, vpos, hpos);
+    }
+
+    fn armed_sprite_pointer_write_can_seed_register_data_stream(
+        &self,
+        sprite: usize,
+        vpos: u32,
+        hpos: u32,
+        dmacon: u16,
+    ) -> bool {
+        if !self.denise.spr_armed[sprite]
+            || dmacon & (DMACON_DMAEN | DMACON_SPREN) != (DMACON_DMAEN | DMACON_SPREN)
+        {
+            return false;
+        }
+
+        // The transient Agnus descriptor latch is not always available to this
+        // replay path (notably after save-state load), but Denise may still
+        // expose an armed sprite word plus retained POS/CTL comparators. Only
+        // use that as a data-stream fallback once the beam is in the rendered
+        // display area and the channel's descriptor fetch slot for this line
+        // has already passed. Frame-start/top-border SPRxPT reloads are normal
+        // descriptor setup and must not resurrect stale armed register data.
+        vpos >= self.current_frame_visible_start_vpos
+            && hpos >= SPRITE_DMA_PAIR_CAPTURE_HPOS[sprite / 2]
     }
 
     fn latch_display_sprite_register_data_stream_at(
@@ -7049,6 +7076,7 @@ impl Bus {
         };
         self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState {
             control: Some(control),
+            control_loaded_vpos: stream_start,
             next_ptr: Some(control.next_ptr),
             terminated: false,
             data_dma_active: false,
@@ -7187,6 +7215,7 @@ impl Bus {
         }
 
         state.control = Some(control);
+        state.control_loaded_vpos = beam_y;
         state.next_ptr = Some(control.next_ptr);
         state.terminated = false;
         state.data_dma_active =
@@ -7819,6 +7848,7 @@ impl Bus {
             }
 
             state.control = Some(control);
+            state.control_loaded_vpos = beam_y;
             state.data_dma_active = false;
             state.last_line = None;
             if beam_y < control.vstart {
@@ -15259,7 +15289,55 @@ mod tests {
     }
 
     #[test]
-    fn armed_register_sprite_pointer_write_seeds_dma_data_stream() {
+    fn pending_descriptor_sprite_pointer_write_retargets_data_stream() {
+        let mut bus = empty_bus();
+        let old_ptr = 0x0200usize;
+        let new_data_ptr = 0x0300usize;
+        let (pos, ctl) = sprite_control_words(0x60, 0x62, 0x0101);
+        write_chip_word(&mut bus, old_ptr, pos);
+        write_chip_word(&mut bus, old_ptr + 2, ctl);
+        write_chip_word(&mut bus, old_ptr + 4, 0x1111);
+        write_chip_word(&mut bus, old_ptr + 6, 0x2222);
+        write_chip_word(&mut bus, new_data_ptr, 0xAAAA);
+        write_chip_word(&mut bus, new_data_ptr + 2, 0xBBBB);
+        write_chip_word(&mut bus, new_data_ptr + 4, 0xCCCC);
+        write_chip_word(&mut bus, new_data_ptr + 6, 0xDDDD);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.denise.sprpt[0] = old_ptr as u32;
+        bus.display_dma_sprpt[0] = old_ptr as u32;
+
+        bus.agnus.vpos = 0x2C;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+        let pending = bus.display_dma_sprite_state[0];
+        assert_eq!(pending.control.map(|control| control.vstart), Some(0x60));
+        assert!(!pending.data_dma_active);
+
+        bus.agnus.vpos = 0x30;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0];
+        let _ =
+            bus.write_custom_word_from(0x120, (new_data_ptr >> 16) as u16, BeamWriteSource::Copper);
+        let _ = bus.write_custom_word_from(0x122, new_data_ptr as u16, BeamWriteSource::Copper);
+
+        bus.agnus.vpos = 0x60;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+        bus.agnus.vpos = 0x61;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].hstart, 0x0101);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+        assert_eq!(lines[1].data, 0xCCCC);
+        assert_eq!(lines[1].datb, 0xDDDD);
+    }
+
+    #[test]
+    fn after_slot_armed_sprite_pointer_write_seeds_dma_data_stream() {
         let mut bus = empty_bus();
         let data_ptr = 0x0300usize;
         let (pos, ctl) = sprite_control_words(0x00, 0x00, 0x0101);
@@ -15268,20 +15346,21 @@ mod tests {
 
         bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
         bus.agnus.vpos = 0x40;
-        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 4;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0];
         bus.denise.sprpos[0] = pos;
         bus.denise.sprctl[0] = ctl;
         bus.denise.spr_armed[0] = true;
 
         let _ = bus.write_custom_word_from(0x120, (data_ptr >> 16) as u16, BeamWriteSource::Copper);
         let _ = bus.write_custom_word_from(0x122, data_ptr as u16, BeamWriteSource::Copper);
+        bus.agnus.vpos = 0x41;
         bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
         bus.advance_chipset(2);
 
         let lines = bus.frame_captured_sprite_lines();
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].hstart, 0x0101);
-        assert_eq!(lines[0].beam_y, 0x40);
+        assert_eq!(lines[0].beam_y, 0x41);
         assert_eq!(lines[0].data, 0xAAAA);
         assert_eq!(lines[0].datb, 0xBBBB);
     }
@@ -15719,6 +15798,7 @@ mod tests {
         bus.denise.sprpt[0] = 0x0005_F0BC;
         bus.display_dma_sprite_state[0] = DisplaySpriteDmaState {
             control: None,
+            control_loaded_vpos: super::unset_sprite_control_loaded_vpos(),
             next_ptr: Some(frontier0),
             terminated: true,
             data_dma_active: false,
@@ -15740,6 +15820,7 @@ mod tests {
                 next_ptr: 0x0200,
                 attached: false,
             }),
+            control_loaded_vpos: 0x20,
             next_ptr: Some(0x0200),
             terminated: false,
             data_dma_active: true,
@@ -15839,6 +15920,7 @@ mod tests {
                 next_ptr: 0x0200,
                 attached: false,
             }),
+            control_loaded_vpos: 0x20,
             next_ptr: Some(0x0200),
             terminated: false,
             data_dma_active: true,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -773,6 +773,19 @@ pub struct Bus {
     blitter_trace: Option<std::fs::File>,
     display_dma_bplpt: [u32; 8],
     display_dma_sprpt: [u32; 8],
+    /// Per-sprite SPRxPT value to seed the next frame's sprite-DMA replay with.
+    /// Real Agnus advances SPRxPT through sprite DMA and does not snap it back to
+    /// the last Copper/CPU write at the top of a field: once a channel has read
+    /// its terminating descriptor its pointer sits past the consumed list. We
+    /// model that by carrying the finished channel's DMA frontier across the
+    /// frame boundary instead of re-seeding from `denise.sprpt` (the stale last
+    /// write), so a sprite descriptor buffer that software rewrites every field
+    /// is not re-armed from its previous, now-overwritten address before the
+    /// Copper reloads SPRxPT. Transient render state, rebuilt each frame (and
+    /// re-derived after a state load), so it is excluded from the serialized
+    /// layout.
+    #[serde(skip)]
+    sprite_dma_frame_start_ptr: [u32; 8],
     // Derived from sprite DMA descriptor/control fetches. Kept in the bincode
     // layout for compatibility, then reset after a state load so stale decoded
     // latches are rebuilt from the restored pointer context.
@@ -1796,6 +1809,7 @@ impl Bus {
             blitter_trace,
             display_dma_bplpt: [0; 8],
             display_dma_sprpt: [0; 8],
+            sprite_dma_frame_start_ptr: [0; 8],
             display_dma_sprite_state: [DisplaySpriteDmaState::default(); 8],
             display_dma_clipped_rows_advanced: false,
             bitplane_dmacon_delay: None,
@@ -2085,6 +2099,7 @@ impl Bus {
         self.emulated_frames = 0;
         self.display_dma_bplpt = [0; 8];
         self.display_dma_sprpt = [0; 8];
+        self.sprite_dma_frame_start_ptr = [0; 8];
         self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
         self.display_dma_clipped_rows_advanced = false;
         self.bitplane_dmacon_delay = None;
@@ -6812,6 +6827,22 @@ impl Bus {
         self.current_frame_display_snapshot_taken = false;
         self.current_frame_visible_start_vpos = RENDER_VISIBLE_START_VPOS;
         self.current_frame_render_base = self.capture_render_snapshot();
+        // Carry each sprite channel's DMA pointer across the frame boundary the
+        // way real Agnus does. A channel that finished the field (read its
+        // terminating descriptor, so `control` is cleared) leaves SPRxPT parked
+        // past the consumed list at its DMA frontier; it does NOT snap back to
+        // the last value the Copper/CPU wrote into `denise.sprpt`. Seed the next
+        // frame's replay from that frontier so a reused descriptor buffer that
+        // software rewrites every field is not re-armed from its previous,
+        // now-overwritten address before the Copper reloads SPRxPT. Channels
+        // still mid-descriptor at frame end keep the written pointer.
+        for sprite in 0..8 {
+            let state = &self.display_dma_sprite_state[sprite];
+            self.sprite_dma_frame_start_ptr[sprite] = match (state.control, state.next_ptr) {
+                (None, Some(frontier)) => frontier,
+                _ => self.denise.sprpt[sprite],
+            };
+        }
         self.current_frame_collision_may_have_dual_playfield =
             self.current_frame_render_base.bplcon0 & 0x0400 != 0;
         self.display_dma_bplpt = self.denise.bplpt;
@@ -7228,7 +7259,11 @@ impl Bus {
         // span and run the sprite fetch only on lines where SPREN was actually
         // enabled, rather than sampling registers at the visible start.
         let base = self.current_frame_render_base;
-        self.display_dma_sprpt = base.sprpt;
+        // Seed from the previous field's carried SPRxPT frontier rather than the
+        // last Copper/CPU write captured in `base.sprpt`. See
+        // `sprite_dma_frame_start_ptr` for why finished channels must not snap
+        // back to their stale descriptor address.
+        self.display_dma_sprpt = self.sprite_dma_frame_start_ptr;
         self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
         let mut dmacon = base.dmacon;
         let writes: Vec<(u32, u32, u16, u16)> = self
@@ -15281,9 +15316,9 @@ mod tests {
         write_chip_word(&mut bus, sprite_ptr + 18, 0);
 
         bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
-        // The offscreen sprite-DMA replay seeds from the frame-start DMACON
-        // and SPRxPT snapshot (and replays $096/$120..$13F writes across the
-        // span); mirror what begin_new_beam_frame records so SPREN and the
+        // The offscreen sprite-DMA replay seeds from the frame-start DMACON and
+        // the carried SPRxPT frontier (and replays $096/$120..$13F writes across
+        // the span); mirror what begin_new_beam_frame records so SPREN and the
         // sprite pointer are live for the offscreen lines this sprite starts on.
         bus.current_frame_render_base.dmacon = DMACON_DMAEN | DMACON_SPREN;
         bus.current_frame_render_base.sprpt[0] = sprite_ptr as u32;
@@ -15291,6 +15326,7 @@ mod tests {
         bus.agnus.hpos = 0;
         bus.denise.sprpt[0] = sprite_ptr as u32;
         bus.display_dma_sprpt[0] = sprite_ptr as u32;
+        bus.sprite_dma_frame_start_ptr[0] = sprite_ptr as u32;
 
         bus.capture_current_frame_display_start();
         bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
@@ -15327,6 +15363,7 @@ mod tests {
         bus.agnus.hpos = 0;
         bus.denise.sprpt[0] = sprite_ptr as u32;
         bus.display_dma_sprpt[0] = sprite_ptr as u32;
+        bus.sprite_dma_frame_start_ptr[0] = sprite_ptr as u32;
 
         bus.capture_current_frame_display_start();
 
@@ -15346,6 +15383,71 @@ mod tests {
         assert_eq!(lines[0].hstart, 0x00A1);
         assert_eq!(lines[0].data, 0x1111);
         assert_eq!(lines[0].datb, 0x2222);
+    }
+
+    #[test]
+    fn finished_sprite_channel_carries_dma_frontier_across_frame_boundary() {
+        // Real Agnus advances SPRxPT through sprite DMA. A channel that has read
+        // its terminating descriptor leaves the pointer parked at the DMA
+        // frontier past the consumed list; it does NOT snap back to the last
+        // value the Copper/CPU wrote into SPRxPT. begin_new_beam_frame must seed
+        // the next frame's sprite-DMA replay from that frontier for a finished
+        // channel (so a reused descriptor buffer that software overwrites every
+        // field is not re-armed from its stale address before the Copper reloads
+        // SPRxPT), and from the written pointer for a channel still mid-field.
+        let mut bus = empty_bus();
+
+        // Channel 0 finished the field: its control comparator is cleared and the
+        // DMA frontier sits at the terminating descriptor. denise.sprpt still
+        // holds the now-overwritten descriptor address the Copper wrote earlier.
+        let frontier0 = 0x0005_F3E4u32;
+        bus.denise.sprpt[0] = 0x0005_F0BC;
+        bus.display_dma_sprite_state[0] = DisplaySpriteDmaState {
+            control: None,
+            next_ptr: Some(frontier0),
+            terminated: true,
+            data_dma_active: false,
+            last_line: None,
+        };
+
+        // Channel 1 is still mid-descriptor at frame end: keep the written
+        // pointer so an active reused sprite is not skipped past its data.
+        let written1 = 0x0006_0000u32;
+        bus.denise.sprpt[1] = written1;
+        bus.display_dma_sprite_state[1] = DisplaySpriteDmaState {
+            control: Some(DisplaySpriteControl {
+                vstart: 0x20,
+                vstop: 0x40,
+                hstart: 0x80,
+                hsub_70ns: false,
+                data_vstart: 0x20,
+                data_base: 0x0100,
+                next_ptr: 0x0200,
+                attached: false,
+            }),
+            next_ptr: Some(0x0200),
+            terminated: false,
+            data_dma_active: true,
+            last_line: None,
+        };
+
+        // Channel 2 was never set up this field: fall back to the written pointer.
+        bus.denise.sprpt[2] = 0x0007_0000;
+
+        bus.begin_new_beam_frame();
+
+        assert_eq!(
+            bus.sprite_dma_frame_start_ptr[0], frontier0,
+            "finished channel must carry the DMA frontier, not the stale written pointer"
+        );
+        assert_eq!(
+            bus.sprite_dma_frame_start_ptr[1], written1,
+            "channel still mid-descriptor keeps the written SPRxPT"
+        );
+        assert_eq!(
+            bus.sprite_dma_frame_start_ptr[2], 0x0007_0000,
+            "channel with no descriptor falls back to the written SPRxPT"
+        );
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -465,13 +465,23 @@ fn unset_sprite_data_vstart() -> i32 {
     i32::MIN
 }
 
+fn register_sprite_data_vstart() -> i32 {
+    i32::MIN + 1
+}
+
 impl DisplaySpriteControl {
     fn effective_data_vstart(self) -> i32 {
-        if self.data_vstart == unset_sprite_data_vstart() {
+        if self.data_vstart == unset_sprite_data_vstart()
+            || self.data_vstart == register_sprite_data_vstart()
+        {
             self.vstart
         } else {
             self.data_vstart
         }
+    }
+
+    fn data_origin_is_register_stream(self) -> bool {
+        self.data_vstart == register_sprite_data_vstart()
     }
 }
 
@@ -6957,15 +6967,93 @@ impl Bus {
     }
 
     fn apply_display_sprite_pointer_low_write_at(&mut self, sprite: usize, vpos: u32, hpos: u32) {
+        self.apply_display_sprite_pointer_low_write_at_with_dmacon(
+            sprite,
+            vpos,
+            hpos,
+            self.agnus.dmacon,
+        );
+    }
+
+    fn apply_display_sprite_pointer_low_write_at_with_dmacon(
+        &mut self,
+        sprite: usize,
+        vpos: u32,
+        hpos: u32,
+        dmacon: u16,
+    ) {
         if sprite >= 8 {
             return;
         }
         let state = self.display_dma_sprite_state[sprite];
-        if state.control.is_some() && !state.data_dma_active {
-            self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState::default();
+        if let Some(control) = state.control {
+            if !state.data_dma_active && !control.data_origin_is_register_stream() {
+                self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState::default();
+                return;
+            }
+        } else if self.denise.spr_armed[sprite]
+            && dmacon & (DMACON_DMAEN | DMACON_SPREN) == (DMACON_DMAEN | DMACON_SPREN)
+        {
+            // The transient Agnus descriptor latch is not always available to
+            // this replay path (notably after save-state load), but Denise
+            // still exposes an armed sprite word plus the retained POS/CTL
+            // comparators. If software refreshes SPRxPT for that still-armed
+            // stream, the pointer names data words rather than a fresh POS/CTL
+            // descriptor.
+            self.latch_display_sprite_register_data_stream_at(sprite, vpos, hpos);
             return;
         }
         self.retarget_display_sprite_dma_pointer_at(sprite, vpos, hpos);
+    }
+
+    fn latch_display_sprite_register_data_stream_at(
+        &mut self,
+        sprite: usize,
+        vpos: u32,
+        hpos: u32,
+    ) {
+        let frame_lines = self.agnus.current_frame_lines() as i32;
+        let beam_y = vpos as i32;
+        if beam_y >= frame_lines {
+            return;
+        }
+        let fetch_slot = SPRITE_DMA_PAIR_CAPTURE_HPOS[sprite / 2];
+        let stream_start = if hpos >= fetch_slot {
+            beam_y.saturating_add(1)
+        } else {
+            beam_y
+        };
+        if stream_start >= frame_lines {
+            return;
+        }
+
+        let quantum = sprite_fetch_quantum(self.agnus.fmode());
+        let line_bytes = 4 * quantum;
+        let data_lines = (frame_lines - stream_start).max(0) as u32;
+        let data_base = self.display_dma_sprpt[sprite] & self.chip_dma_mask & !1;
+        let control = DisplaySpriteControl {
+            vstart: stream_start,
+            vstop: frame_lines,
+            hstart: sprite_hstart_from_words(
+                self.denise.sprpos[sprite],
+                self.denise.sprctl[sprite],
+            ),
+            hsub_70ns: bitplane_shres(self.denise.bplcon0)
+                && sprite_hsub_70ns_from_ctl(self.denise.sprctl[sprite]),
+            data_vstart: register_sprite_data_vstart(),
+            data_base,
+            next_ptr: data_base.wrapping_add(data_lines.saturating_mul(line_bytes))
+                & self.chip_dma_mask
+                & !1,
+            attached: self.denise.sprctl[sprite] & 0x0080 != 0,
+        };
+        self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState {
+            control: Some(control),
+            next_ptr: Some(control.next_ptr),
+            terminated: false,
+            data_dma_active: false,
+            last_line: None,
+        };
     }
 
     fn latch_display_sprite_dma_control_from_registers(
@@ -7053,7 +7141,7 @@ impl Bus {
             vstop,
             hstart: sprite_hstart_from_words(pos, ctl),
             hsub_70ns: bitplane_shres(self.denise.bplcon0) && sprite_hsub_70ns_from_ctl(ctl),
-            data_vstart: vstart,
+            data_vstart: register_sprite_data_vstart(),
             data_base,
             next_ptr: data_base.wrapping_add(data_lines.saturating_mul(line_bytes))
                 & self.chip_dma_mask
@@ -7088,6 +7176,7 @@ impl Bus {
             if let Some(previous_control) = previous_control {
                 // A pending descriptor has already consumed POS/CTL; direct
                 // control writes retime the comparators, not the data stream.
+                control.data_vstart = previous_control.data_vstart;
                 control.data_base = previous_control.data_base;
                 control.next_ptr = control
                     .data_base
@@ -7144,7 +7233,11 @@ impl Bus {
         let ptr = self.display_dma_sprpt[sprite] & self.chip_dma_mask & !1;
         control.data_base =
             ptr.wrapping_sub(line.saturating_mul(line_bytes)) & self.chip_dma_mask & !1;
-        control.data_vstart = control.vstart;
+        control.data_vstart = if control.data_origin_is_register_stream() {
+            register_sprite_data_vstart()
+        } else {
+            control.vstart
+        };
         let height = (control.vstop - control.vstart).max(0) as u32;
         let data_lines = if sprite_scan_doubled(self.agnus.fmode()) {
             height.div_ceil(2)
@@ -7399,7 +7492,7 @@ impl Bus {
         } else {
             let cur = self.display_dma_sprpt[idx];
             self.display_dma_sprpt[idx] = (cur & 0x00FF_0000) | (value as u32 & 0xFFFE);
-            self.apply_display_sprite_pointer_low_write_at(idx, vpos, hpos);
+            self.apply_display_sprite_pointer_low_write_at_with_dmacon(idx, vpos, hpos, *dmacon);
         }
     }
 
@@ -7441,7 +7534,6 @@ impl Bus {
             }
             if sprite_dma_enabled {
                 pair_slots += 1;
-                self.current_frame_sprite_dma_observed = true;
             }
             let mut captured_line = false;
             for sprite in pair * 2..pair * 2 + 2 {
@@ -15122,6 +15214,79 @@ mod tests {
     }
 
     #[test]
+    fn pending_register_control_sprite_pointer_write_retargets_data_stream() {
+        let mut bus = empty_bus();
+        let old_data_ptr = 0x0200usize;
+        let new_data_ptr = 0x0300usize;
+        let (pos, ctl) = sprite_control_words(0x40, 0x42, 0x0101);
+        write_chip_word(&mut bus, old_data_ptr, 0x1111);
+        write_chip_word(&mut bus, old_data_ptr + 2, 0x2222);
+        write_chip_word(&mut bus, new_data_ptr, 0xAAAA);
+        write_chip_word(&mut bus, new_data_ptr + 2, 0xBBBB);
+        write_chip_word(&mut bus, new_data_ptr + 4, 0xCCCC);
+        write_chip_word(&mut bus, new_data_ptr + 6, 0xDDDD);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.display_dma_sprpt[0] = old_data_ptr as u32;
+        bus.denise.sprpt[0] = old_data_ptr as u32;
+
+        bus.agnus.vpos = 0x20;
+        bus.agnus.hpos = 0;
+        assert!(!bus.write_custom_word_from(0x140, pos, BeamWriteSource::Copper));
+        assert!(!bus.write_custom_word_from(0x142, ctl, BeamWriteSource::Copper));
+
+        bus.agnus.vpos = 0x24;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0];
+        let _ =
+            bus.write_custom_word_from(0x120, (new_data_ptr >> 16) as u16, BeamWriteSource::Copper);
+        let _ = bus.write_custom_word_from(0x122, new_data_ptr as u16, BeamWriteSource::Copper);
+
+        bus.agnus.vpos = 0x40;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+        bus.agnus.vpos = 0x41;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].hstart, 0x0101);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+        assert_eq!(lines[1].hstart, 0x0101);
+        assert_eq!(lines[1].data, 0xCCCC);
+        assert_eq!(lines[1].datb, 0xDDDD);
+    }
+
+    #[test]
+    fn armed_register_sprite_pointer_write_seeds_dma_data_stream() {
+        let mut bus = empty_bus();
+        let data_ptr = 0x0300usize;
+        let (pos, ctl) = sprite_control_words(0x00, 0x00, 0x0101);
+        write_chip_word(&mut bus, data_ptr, 0xAAAA);
+        write_chip_word(&mut bus, data_ptr + 2, 0xBBBB);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.agnus.vpos = 0x40;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 4;
+        bus.denise.sprpos[0] = pos;
+        bus.denise.sprctl[0] = ctl;
+        bus.denise.spr_armed[0] = true;
+
+        let _ = bus.write_custom_word_from(0x120, (data_ptr >> 16) as u16, BeamWriteSource::Copper);
+        let _ = bus.write_custom_word_from(0x122, data_ptr as u16, BeamWriteSource::Copper);
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].hstart, 0x0101);
+        assert_eq!(lines[0].beam_y, 0x40);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+    }
+
+    #[test]
     fn active_sprite_control_rewrite_preserves_descriptor_data_origin() {
         let mut bus = empty_bus();
         let sprite_ptr = 0x0100usize;
@@ -15870,6 +16035,66 @@ mod tests {
         let sprite6 = lines.iter().find(|line| line.sprite == 6).unwrap();
         assert_eq!(sprite0.data, 0x1111);
         assert_eq!(sprite6.data, 0xBBBB);
+    }
+
+    #[test]
+    fn sprite_pointer_write_at_pair_slot_seeds_next_line_descriptor_fetch() {
+        let mut bus = empty_bus();
+        let old_ptr = 0x0100usize;
+        let new_ptr = 0x0200usize;
+        let (old_pos, old_ctl) = sprite_control_words(0x40, 0x44, 0x0083);
+        let (new_pos, new_ctl) = sprite_control_words(0x40, 0x44, 0x00C1);
+
+        write_chip_word(&mut bus, old_ptr, old_pos);
+        write_chip_word(&mut bus, old_ptr + 2, old_ctl);
+        write_chip_word(&mut bus, old_ptr + 4, 0x1111);
+        write_chip_word(&mut bus, old_ptr + 6, 0x2222);
+        write_chip_word(&mut bus, new_ptr, new_pos);
+        write_chip_word(&mut bus, new_ptr + 2, new_ctl);
+        write_chip_word(&mut bus, new_ptr + 4, 0xAAAA);
+        write_chip_word(&mut bus, new_ptr + 6, 0xBBBB);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.denise.sprpt[0] = old_ptr as u32;
+        bus.display_dma_sprpt[0] = old_ptr as u32;
+
+        bus.agnus.vpos = 0x24;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(1);
+        let _ = bus.write_custom_word_from(0x120, (new_ptr >> 16) as u16, BeamWriteSource::Copper);
+        let _ = bus.write_custom_word_from(0x122, new_ptr as u16, BeamWriteSource::Copper);
+
+        let state = bus.display_dma_sprite_state[0];
+        assert!(
+            state.control.is_none(),
+            "same-slot pointer write should discard the descriptor fetched before the write"
+        );
+
+        bus.agnus.vpos = 0x40;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].hstart, 0x00C1);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+    }
+
+    #[test]
+    fn empty_sprite_dma_slot_does_not_mark_frame_dma_observed() {
+        let mut bus = empty_bus();
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.agnus.vpos = RENDER_VISIBLE_START_VPOS;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+
+        bus.advance_chipset(2);
+
+        assert!(bus.frame_captured_sprite_lines().is_empty());
+        assert!(
+            !bus.frame_sprite_dma_observed(),
+            "enabled sprite slots without fetched sprite data must not suppress register/manual sprites"
+        );
     }
 
     #[test]

--- a/src/chipset/agnus.rs
+++ b/src/chipset/agnus.rs
@@ -517,7 +517,7 @@ pub fn sprite_dma_disabled_by_bitplane_ddf(
     let blocks = bitplane_fetch_blocks(u32::from(ddfstop) - ddfstart, unit) as u32;
     let last_block_start = ddfstart + blocks.saturating_sub(1) * unit;
     let sprite7_block_start = 0x0030;
-    ddfstart <= sprite7_block_start
+    ddfstart < sprite7_block_start
         && last_block_start >= sprite7_block_start
         && (sprite7_block_start - ddfstart).is_multiple_of(unit)
 }
@@ -1591,13 +1591,23 @@ mod tests {
 
     #[test]
     fn early_bitplane_ddfstart_disables_only_sprite_seven_dma() {
-        assert!(sprite_dma_disabled_by_bitplane_ddf(
+        assert!(!sprite_dma_disabled_by_bitplane_ddf(
             7,
             AgnusRevision::Ocs,
             0x1000,
             0,
             DMACON_DMAEN | DMACON_BPLEN,
             0x0030,
+            0x0038,
+            false,
+        ));
+        assert!(sprite_dma_disabled_by_bitplane_ddf(
+            7,
+            AgnusRevision::Ocs,
+            0x1000,
+            0,
+            DMACON_DMAEN | DMACON_BPLEN,
+            0x0028,
             0x0038,
             false,
         ));

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -23,6 +23,7 @@ use crate::chipset::denise::{
     Palette, COLOR_RGB_MASK, COLOR_TRANSPARENCY_BIT,
 };
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -921,6 +922,7 @@ struct ControlSegment {
 #[derive(Clone, Copy)]
 struct ManualBplSegment {
     line: usize,
+    hpos: u32,
     x: i32,
     planes: [u16; 8],
     palette: Palette,
@@ -2149,6 +2151,7 @@ fn apply_render_events_and_collect_display_plan_events_with_visible_line0(
         if off == 0x110 && (0..base_palettes.len() as i32).contains(&visible_line) {
             manual_bpl_segments.push(ManualBplSegment {
                 line,
+                hpos: event.hpos,
                 x: beam_to_framebuffer_x_unclamped(event.hpos),
                 planes: state.bpldat,
                 palette,
@@ -2785,6 +2788,121 @@ fn apply_bitplane_data_write(bpldat: &mut [u16; 8], off: u16, val: u16) {
     }
 }
 
+fn seed_manual_bpl_segments_from_latches(
+    segments: &mut [ManualBplSegment],
+    frame_start_bpldat: [u16; 8],
+    render_events: &[BeamRegisterWrite],
+    base_controls: &[ControlState],
+    control_segments: &[Vec<ControlSegment>],
+    captured_bitplane_rows: &[Option<CapturedBitplaneRow>],
+    visible_line0: i32,
+) {
+    if segments.is_empty() {
+        return;
+    }
+
+    let mut segment_indices_by_beam: HashMap<(usize, u32), Vec<usize>> = HashMap::new();
+    for (idx, segment) in segments.iter().enumerate() {
+        segment_indices_by_beam
+            .entry((segment.line, segment.hpos))
+            .or_default()
+            .push(idx);
+    }
+    for indices in segment_indices_by_beam.values_mut() {
+        indices.reverse();
+    }
+
+    let rows = base_controls.len().min(control_segments.len());
+    let mut bpldat = frame_start_bpldat;
+    let mut event_idx = 0usize;
+
+    for line in 0..rows {
+        let beam_y_i = visible_line0 + line as i32;
+        if beam_y_i < 0 {
+            continue;
+        }
+        let beam_y = beam_y_i as u32;
+        while let Some(event) = render_events.get(event_idx) {
+            if event.vpos >= beam_y {
+                break;
+            }
+            apply_bitplane_data_write(&mut bpldat, event.offset & 0x01FE, event.value);
+            event_idx += 1;
+        }
+
+        let row_control_segments = &control_segments[line];
+        let words_per_row = line_words_per_row(base_controls[line], row_control_segments);
+        let dma_planes = line_max_dma_planes(base_controls[line], row_control_segments);
+        let mut fetches = Vec::new();
+        if dma_planes != 0 && line_has_valid_ddf_window(base_controls[line], row_control_segments) {
+            if let Some(captured) = captured_bitplane_rows.get(line).and_then(Option::as_ref) {
+                let fetch_plans = line_fetch_plans_for_line(
+                    base_controls[line],
+                    row_control_segments,
+                    words_per_row,
+                    dma_planes,
+                );
+                for (word_idx, plan) in fetch_plans
+                    .iter()
+                    .enumerate()
+                    .take(words_per_row.min(captured.words_per_row))
+                {
+                    for (hpos, plane) in plan.iter() {
+                        if plane < dma_planes.min(8)
+                            && plane < captured.nplanes
+                            && word_idx < captured.planes[plane].len()
+                        {
+                            fetches.push((hpos, plane, word_idx));
+                        }
+                    }
+                }
+                fetches.sort_unstable();
+            }
+        }
+
+        let mut fetch_idx = 0usize;
+        loop {
+            let next_event_hpos = render_events
+                .get(event_idx)
+                .and_then(|event| (event.vpos == beam_y).then_some(event.hpos));
+            let next_fetch = fetches.get(fetch_idx).copied();
+            match (next_event_hpos, next_fetch) {
+                (Some(event_hpos), Some((fetch_hpos, plane, word_idx)))
+                    if fetch_hpos < event_hpos =>
+                {
+                    bpldat[plane] = captured_bitplane_rows[line]
+                        .as_ref()
+                        .and_then(|row| row.planes[plane].get(word_idx).copied())
+                        .unwrap_or(0);
+                    fetch_idx += 1;
+                }
+                (Some(_), _) => {
+                    let event = render_events[event_idx];
+                    let off = event.offset & 0x01FE;
+                    apply_bitplane_data_write(&mut bpldat, off, event.value);
+                    if off == 0x110 {
+                        if let Some(indices) = segment_indices_by_beam.get_mut(&(line, event.hpos))
+                        {
+                            if let Some(segment_idx) = indices.pop() {
+                                segments[segment_idx].planes = bpldat;
+                            }
+                        }
+                    }
+                    event_idx += 1;
+                }
+                (None, Some((_fetch_hpos, plane, word_idx))) => {
+                    bpldat[plane] = captured_bitplane_rows[line]
+                        .as_ref()
+                        .and_then(|row| row.planes[plane].get(word_idx).copied())
+                        .unwrap_or(0);
+                    fetch_idx += 1;
+                }
+                (None, None) => break,
+            }
+        }
+    }
+}
+
 struct TimedChipRam<'a> {
     ram: Cow<'a, [u8]>,
     writes: &'a [BeamChipRamWrite],
@@ -2959,6 +3077,13 @@ fn manual_sprite_lines_from_events_with_visible_line0(
     include_latched_sprite_state: bool,
 ) -> Vec<Vec<SpriteLine>> {
     let mut regs = BeamSpriteState::from_render_state(initial_state, held);
+    if !include_latched_sprite_state {
+        for sprite in 0..8 {
+            if held[sprite].is_none() {
+                regs.spr_armed[sprite] = false;
+            }
+        }
+    }
     let visible_end = visible_line0 + rows as i32;
     let mut next_beam: [(i32, usize); 8] = std::array::from_fn(|sprite| {
         if include_latched_sprite_state || held[sprite].is_some() {
@@ -3016,6 +3141,14 @@ fn manual_sprite_lines_from_events_with_visible_line0(
             flush_mode,
             &mut lines,
         );
+        if !include_latched_sprite_state
+            && held[sprite].is_none()
+            && (off - 0x140) & 0x0006 == 0
+            && event.hpos < SPRITE_DMA_PAIR_CAPTURE_HPOS[sprite / 2]
+        {
+            regs.spr_armed[sprite] = false;
+            regs.direct_data_armed[sprite] = false;
+        }
         regs.apply_write(off, event.value);
         next_beam[sprite] = event_beam;
     }
@@ -3146,11 +3279,8 @@ fn merge_dma_seeded_manual_sprite_lines(
         if seeded.is_empty() {
             continue;
         }
-        let mut seeded_beams: Vec<i32> = seeded.iter().map(|line| line.beam_y).collect();
-        seeded_beams.sort_unstable();
-        seeded_beams.dedup();
         let target = &mut manual_lines[sprite];
-        target.retain(|line| seeded_beams.binary_search(&line.beam_y).is_err());
+        clip_sprite_lines_around_register_lines(seeded, target);
         target.append(seeded);
         target.sort_by_key(|line| (line.beam_y, line.x_start, line.x_stop));
     }
@@ -4607,6 +4737,15 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
     );
 
     let manual_bpl_started = Instant::now();
+    seed_manual_bpl_segments_from_latches(
+        &mut manual_bpl_segments,
+        frame_start_bpldat,
+        render_events,
+        &base_controls,
+        &control_segments,
+        captured_bitplane_rows,
+        visible_line0,
+    );
     render_timing.manual_bpl_segments = manual_bpl_segments.len() as u64;
     render_manual_bpl_segments_with_visible_line0(
         &manual_bpl_segments,
@@ -6149,11 +6288,10 @@ fn sprite_pixel_inside_display_window(
     if x < enable_x {
         return false;
     }
-    // OCS/ECS Denise starts sprite display for this scanline after the first
-    // BPL1DAT load, whether that load came from bitplane DMA or a manual
-    // copper/CPU write. DIW still clips horizontally, but a manual BPL1DAT
-    // write can make sprites visible on lines where the vertical bitplane
-    // window is closed.
+    // OCS/ECS Denise clips normal sprites to the horizontal display window.
+    // Bitplane DMA opens that gate at DIW's left edge even when DDFSTRT delays
+    // the first playfield word; a manual BPL1DAT write can still open it on a
+    // scanline where the vertical bitplane window is closed.
     let (x_start, x_stop) = control.display_window_x();
     x >= x_start && x < x_stop
 }
@@ -8895,6 +9033,41 @@ mod tests {
     }
 
     #[test]
+    fn manual_sprite_position_write_does_not_seed_from_frame_start_data_latch() {
+        let mut initial_state = blank_state();
+        let (old_pos, ctl) = sprite_control_words(
+            PAL_VISIBLE_LINE0 as u16,
+            PAL_VISIBLE_LINE0 as u16 + 1,
+            DIW_HSTART_FB0 as u16,
+        );
+        let (new_pos, _) = sprite_control_words(
+            PAL_VISIBLE_LINE0 as u16,
+            PAL_VISIBLE_LINE0 as u16 + 1,
+            (DIW_HSTART_FB0 + 16) as u16,
+        );
+        initial_state.sprpos[0] = old_pos;
+        initial_state.sprctl[0] = ctl;
+        initial_state.sprdata[0] = 0xFFFF;
+        initial_state.spr_armed[0] = true;
+
+        let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+            &initial_state,
+            &[cpu_event(
+                PAL_VISIBLE_LINE0 as u32,
+                COPPER_WAIT_HPOS_FB0 as u32,
+                0x140,
+                new_pos,
+            )],
+            &[None; 8],
+            PAL_VISIBLE_LINE0,
+            FB_HEIGHT,
+            false,
+        );
+
+        assert!(manual_sprite_lines[0].is_empty());
+    }
+
+    #[test]
     fn manual_sprite_replay_starts_from_beam_timed_data_write() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
@@ -8922,6 +9095,92 @@ mod tests {
         assert!(manual_sprite_lines[0]
             .iter()
             .any(|line| line.beam_y == PAL_VISIBLE_LINE0));
+    }
+
+    #[test]
+    fn early_line_position_write_does_not_reuse_previous_manual_sprite_data() {
+        let mut initial_state = blank_state();
+        let beam_y = PAL_VISIBLE_LINE0;
+        let (pos, ctl) =
+            sprite_control_words(beam_y as u16, beam_y as u16 + 4, DIW_HSTART_FB0 as u16);
+        initial_state.sprpos[0] = pos;
+        initial_state.sprctl[0] = ctl;
+
+        let (next_pos, _) = sprite_control_words(
+            (beam_y + 1) as u16,
+            (beam_y + 2) as u16,
+            (DIW_HSTART_FB0 + 32) as u16,
+        );
+        let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+            &initial_state,
+            &[
+                cpu_event(beam_y as u32, COPPER_WAIT_HPOS_FB0 as u32, 0x144, 0xFFFF),
+                cpu_event((beam_y + 1) as u32, 4, 0x140, next_pos),
+            ],
+            &[None; 8],
+            PAL_VISIBLE_LINE0,
+            FB_HEIGHT,
+            false,
+        );
+
+        assert!(manual_sprite_lines[0]
+            .iter()
+            .any(|line| line.beam_y == beam_y && line.data == 0xFFFF));
+        assert!(manual_sprite_lines[0]
+            .iter()
+            .all(|line| line.beam_y != beam_y + 1));
+    }
+
+    #[test]
+    fn dma_seeded_sprite_reuse_keeps_later_register_data_on_same_line() {
+        let beam_y = PAL_VISIBLE_LINE0;
+        let mut manual_lines = vec![Vec::new(); 8];
+        manual_lines[0].push(SpriteLine {
+            hstart: DIW_HSTART_FB0 + 96,
+            hsub_70ns: false,
+            beam_y,
+            data: 0xFFFF,
+            datb: 0,
+            data_ext: [0; 3],
+            datb_ext: [0; 3],
+            width_words: 1,
+            attached: false,
+            x_start: 208,
+            x_stop: FB_WIDTH,
+        });
+
+        let mut dma_seeded = vec![Vec::new(); 8];
+        dma_seeded[0].push(SpriteLine {
+            hstart: DIW_HSTART_FB0 + 96,
+            hsub_70ns: false,
+            beam_y,
+            data: 0x8000,
+            datb: 0,
+            data_ext: [0; 3],
+            datb_ext: [0; 3],
+            width_words: 1,
+            attached: false,
+            x_start: 112,
+            x_stop: 240,
+        });
+
+        merge_dma_seeded_manual_sprite_lines(&mut manual_lines, dma_seeded);
+
+        assert!(manual_lines[0].iter().any(|line| {
+            line.beam_y == beam_y
+                && line.data == 0xFFFF
+                && line.x_start == 208
+                && line.x_stop == FB_WIDTH
+        }));
+        assert!(manual_lines[0].iter().any(|line| {
+            line.beam_y == beam_y
+                && line.data == 0x8000
+                && line.x_start == 112
+                && line.x_stop == 208
+        }));
+        assert!(manual_lines[0]
+            .iter()
+            .all(|line| line.data != 0x8000 || line.x_stop <= 208));
     }
 
     #[test]
@@ -11484,6 +11743,7 @@ mod tests {
         planes[0] = 0x8000;
         let segments = [ManualBplSegment {
             line: 0,
+            hpos: 0,
             x: 0,
             planes,
             palette,
@@ -11527,6 +11787,7 @@ mod tests {
         planes[0] = 0x4000;
         let segments = [ManualBplSegment {
             line: 0,
+            hpos: 0,
             x: 0,
             planes,
             palette,
@@ -11573,6 +11834,7 @@ mod tests {
         planes[0] = 0x8000;
         let segments = [ManualBplSegment {
             line: 0,
+            hpos: 0,
             x: 0,
             planes,
             palette,
@@ -11993,6 +12255,51 @@ mod tests {
                 "word {word_idx}"
             );
         }
+    }
+
+    #[test]
+    fn manual_bpl1dat_snapshots_dma_updated_bpldat_latches() {
+        let mut state = RenderState {
+            dmacon: DMACON_DMAEN | DMACON_BPLEN,
+            bplcon0: 0x3000,
+            ddfstrt: 0x0038,
+            ddfstop: 0x0038,
+            ..blank_state()
+        };
+        state.bpldat[1] = 0x4000;
+        let base_control = ControlState::from_render_state(&state);
+        let base_controls = [base_control; FB_HEIGHT];
+        let control_segments = vec![Vec::new(); FB_HEIGHT];
+        let hpos = 0x0040;
+        let mut segments = [ManualBplSegment {
+            line: 0,
+            hpos,
+            x: beam_to_framebuffer_x_unclamped(hpos),
+            planes: [0; 8],
+            palette: state.palette,
+        }];
+        let mut captured_rows = vec![None; FB_HEIGHT];
+        let mut planes: [Vec<u16>; 8] = std::array::from_fn(|_| vec![0]);
+        planes[1][0] = 0x8000;
+        captured_rows[0] = Some(CapturedBitplaneRow {
+            nplanes: 3,
+            words_per_row: 1,
+            planes,
+        });
+        let events = [beam_event(PAL_VISIBLE_LINE0 as u32, hpos, 0x0110, 0x0000)];
+
+        seed_manual_bpl_segments_from_latches(
+            &mut segments,
+            state.bpldat,
+            &events,
+            &base_controls,
+            &control_segments,
+            &captured_rows,
+            PAL_VISIBLE_LINE0,
+        );
+
+        assert_eq!(segments[0].planes[0], 0x0000);
+        assert_eq!(segments[0].planes[1], 0x8000);
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -2735,6 +2735,19 @@ fn bitplane_dma_output_start_x(
         .find_map(|(hpos, plane)| (plane == 0).then_some(bitplane_fetch_framebuffer_x(hpos)))
 }
 
+fn bitplane_carry_words_for_line(
+    block_start: bool,
+    display_start_x: usize,
+    dma_output_start_x: Option<usize>,
+    previous_playfield_tail_words: [Option<u16>; 8],
+) -> [Option<u16>; 8] {
+    if block_start || dma_output_start_x.is_some_and(|start| start > display_start_x) {
+        [None; 8]
+    } else {
+        previous_playfield_tail_words
+    }
+}
+
 #[cfg(test)]
 fn line_fetch_hpos_for_word(
     base_control: ControlState,
@@ -4746,11 +4759,19 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 }
             }
             let block_start = last_playfield_line != Some(y.wrapping_sub(1));
-            let carry_words = if block_start {
-                [None; 8]
-            } else {
-                previous_playfield_tail_words
-            };
+            let dma_output_start_x = bitplane_dma_output_start_x(
+                base_controls[y],
+                row_control_segments,
+                x_start,
+                words_per_row,
+                dma_planes.min(nplanes),
+            );
+            let carry_words = bitplane_carry_words_for_line(
+                block_start,
+                x_start,
+                dma_output_start_x,
+                previous_playfield_tail_words,
+            );
             let line_plan = DenisePlannedPlayfieldLine::new(
                 y,
                 x_start,
@@ -4759,13 +4780,6 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 fetched_pixels,
             )
             .with_carry_words(carry_words);
-            let dma_output_start_x = bitplane_dma_output_start_x(
-                base_controls[y],
-                row_control_segments,
-                x_start,
-                words_per_row,
-                dma_planes.min(nplanes),
-            );
             let bpl_output_start_x = dma_output_start_x.unwrap_or(0);
             dma_output_start_x_by_line[y] = dma_output_start_x;
             last_playfield_line = Some(y);
@@ -7255,6 +7269,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn present_h_shift_for_leaves_narrow_late_fetch_untouched() {
+        // A normal DIW can be used around a tiny one-word late-DDF object. The
+        // fetched object must stay in beam position; presentation centring must
+        // not copy its right edge into the deep-left overscan border.
+        assert_eq!(
+            present_h_shift_for(&ocs_snapshot(0x3481, 0x24D1, 0x0050, 0x0058)),
+            0
+        );
+    }
+
     fn put_word(ram: &mut [u8], pc: usize, word: u16) {
         ram[pc..pc + 2].copy_from_slice(&word.to_be_bytes());
     }
@@ -8151,6 +8176,25 @@ mod tests {
         assert_eq!(with_carry.sample(control, 0).idx, 1);
         assert_eq!(with_carry.sample(control, 1).idx, 0);
         assert_eq!(with_carry.sample(control, 3).idx, 1);
+    }
+
+    #[test]
+    fn bplcon1_delay_drops_carry_when_first_bpl1dat_is_late() {
+        let mut previous_tail = [None; 8];
+        previous_tail[0] = Some(0x0001);
+
+        assert_eq!(
+            bitplane_carry_words_for_line(false, 64, Some(64), previous_tail),
+            previous_tail
+        );
+        assert_eq!(
+            bitplane_carry_words_for_line(false, 64, Some(158), previous_tail),
+            [None; 8]
+        );
+        assert_eq!(
+            bitplane_carry_words_for_line(true, 64, Some(64), previous_tail),
+            [None; 8]
+        );
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -58,26 +58,24 @@ const DIW_HSTART_FETCH_REFERENCE_HIRES: i32 = 0x83;
 // and bitplane pixels still register against each other after widening.
 const COPPER_WAIT_HPOS_FB0: i32 = 0x28;
 /// COLORxx writes feed Denise's final colour-selection/output path. Denise
-/// keeps copper/CPU colour-register changes phase-aligned with the bitplane
-/// serializer output: a colour write and the bitplane pixels it recolours reach
-/// the DAC together. (MiniMig models this explicitly with a one-lores-pixel
-/// bitplane delay added "for alignment of bitplane data and copper colour
-/// change"; WinUAE applies colour changes in the same beam slot as the
-/// bitplane pixels.) OCS Denise (8362) and ECS Denise (8373) share this timing
-/// exactly -- the only OCS/ECS colour-path difference is the OCS 12-bit value
-/// mask -- so this anchor is revision-independent across OCS/ECS.
+/// applies copper/CPU colour-register changes in the palette/output phase,
+/// ahead of register writes that feed the bitplane shifter. This anchor keeps
+/// COLORxx changes one lores pixel ahead of the generic beam/write domain,
+/// matching vAmiga's model where COLORxx is recorded at the current output
+/// pixel while BPLCON/DDF/sprite data paths carry explicit pixel delays. OCS
+/// Denise (8362) and ECS Denise (8373) share this timing exactly -- the only
+/// OCS/ECS colour-path difference is the OCS 12-bit value mask -- so this
+/// anchor is revision-independent across OCS/ECS.
 ///
 /// TODO: AGA Lisa delays colour changes by one hires pixel relative to
 /// OCS/ECS (WinUAE: "AGA color changes are 1 hires pixel delayed"). That
 /// sub-colour-clock offset is not yet modelled here.
 ///
 /// STOP before retuning this. If a scene's colours or copper-driven picture
-/// look horizontally shifted, the cause is almost never this anchor -- it has
-/// been moved "to fix" demos several times and always had to be moved back
-/// (the real bug was bitplane fetch/DDF alignment, sprite arming, etc.). This
-/// value keeps copper colour writes aligned with the bitplane pixels they
-/// recolour and is the same on OCS and ECS; leave it at 0x34.
-const COLOR_WRITE_HPOS_FB0: i32 = 0x34;
+/// look horizontally shifted, the cause is usually bitplane fetch/DDF
+/// alignment, sprite arming, or a missed write-domain delay, not this final
+/// colour-output anchor.
+const COLOR_WRITE_HPOS_FB0: i32 = 0x35;
 /// AGA BPLCON4's low sprite-palette byte follows Lisa's sprite colour lookup
 /// path, which reaches sprite output earlier than ordinary COLORxx palette
 /// writes. Keep it separate from COLOR replay so copper palette gradients stay
@@ -1629,6 +1627,7 @@ impl BeamSpriteState {
         let held = self.held[sprite];
         let hstart = sprite_hstart(pos, ctl);
         let hsub_70ns = sprite_hsub_70ns(ctl);
+        let base_x = sprite_nominal_base_framebuffer_x(pos, ctl);
         // A held sprite was already active when SPREN was cleared. With no
         // sprite DMA slot running, the DMA descriptor's stop comparator cannot
         // retire the latched data; later SPRxPOS writes simply reposition it.
@@ -1646,6 +1645,13 @@ impl BeamSpriteState {
                 x_start,
                 x_stop,
             });
+        }
+        // SPRxDATA/SPRxDATB writes update Denise's data latches, but the
+        // serializer only copies those latches when the horizontal sprite
+        // comparator fires. A write after that compare is for a later compare,
+        // not the remaining pixels of the current word.
+        if x_start as i32 > base_x {
+            return None;
         }
         if !self.direct_data_armed[sprite] {
             let vstart = sprite_vstart(pos, ctl);
@@ -3128,17 +3134,12 @@ fn manual_sprite_lines_from_events_with_visible_line0(
             visible_line0,
             rows,
         );
-        let flush_mode = if (off - 0x140) & 0x0006 == 0 {
-            ManualSpriteFlushMode::PreserveStartedOutput
-        } else {
-            ManualSpriteFlushMode::ClipAtEnd
-        };
         flush_manual_sprite_lines(
             sprite,
             &regs,
             next_beam[sprite],
             event_beam,
-            flush_mode,
+            ManualSpriteFlushMode::PreserveStartedOutput,
             &mut lines,
         );
         if !include_latched_sprite_state
@@ -3360,7 +3361,7 @@ fn flush_manual_sprite_lines(
         if mode == ManualSpriteFlushMode::PreserveStartedOutput && beam_y == end_line {
             let pos = regs.sprpos[sprite];
             let ctl = regs.sprctl[sprite];
-            let base_x = (sprite_hstart(pos, ctl) - DIW_HSTART_FB0) * 2;
+            let base_x = sprite_nominal_base_framebuffer_x(pos, ctl);
             if x_stop as i32 >= base_x {
                 x_stop = FB_WIDTH;
             }
@@ -6261,6 +6262,10 @@ fn sprite_base_framebuffer_x(
     base_x + i32::from(hsub_70ns && control.shres())
 }
 
+fn sprite_nominal_base_framebuffer_x(pos: u16, ctl: u16) -> i32 {
+    (sprite_hstart(pos, ctl) - DIW_HSTART_FB0) * 2 + i32::from(sprite_hsub_70ns(ctl))
+}
+
 fn sprite_display_enable_x_for_y(
     sprite_display_enable_x_by_y: &[Option<usize>],
     y: usize,
@@ -7567,7 +7572,7 @@ mod tests {
         );
         assert_eq!(
             beam_to_framebuffer_x_unclamped(COLOR_WRITE_HPOS_FB0 as u32),
-            48
+            52
         );
         assert_eq!(
             sprite_palette_control_framebuffer_x(SPRITE_PALETTE_CONTROL_HPOS_FB0 as u32),
@@ -9480,7 +9485,7 @@ mod tests {
     }
 
     #[test]
-    fn manual_sprite_data_writes_affect_only_later_pixels_on_same_line() {
+    fn manual_sprite_data_write_after_compare_waits_for_next_scanline() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
             PAL_VISIBLE_LINE0 as u16,
@@ -9498,7 +9503,12 @@ mod tests {
             0xA000,
         )];
         let manual_sprite_lines = manual_sprite_lines_from_events(&initial_state, &events);
-        assert_eq!(manual_sprite_lines[0][0].x_start, 4);
+        assert!(manual_sprite_lines[0]
+            .iter()
+            .all(|line| line.beam_y != PAL_VISIBLE_LINE0));
+        assert!(manual_sprite_lines[0]
+            .iter()
+            .any(|line| line.beam_y == PAL_VISIBLE_LINE0 + 1 && line.x_start == 0));
 
         let base_controls = [ControlState::from_render_state(&initial_state); FB_HEIGHT];
         let mut render_state = initial_state;
@@ -9534,11 +9544,12 @@ mod tests {
         );
 
         assert_eq!(fb[0], rgb12_to_rgba8(0));
-        assert_eq!(fb[4], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[4], rgb12_to_rgba8(0));
+        assert_eq!(fb[FB_WIDTH], rgb12_to_rgba8(0x0F00));
     }
 
     #[test]
-    fn manual_sprite_data_arms_before_datb_updates_later_pixels() {
+    fn manual_sprite_datb_write_after_compare_waits_for_next_scanline() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
             PAL_VISIBLE_LINE0 as u16,
@@ -9601,11 +9612,12 @@ mod tests {
         );
 
         assert_eq!(fb[0], rgb12_to_rgba8(0x0F00));
-        assert_eq!(fb[4], rgb12_to_rgba8(0x00F0));
+        assert_eq!(fb[4], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[FB_WIDTH], rgb12_to_rgba8(0x00F0));
     }
 
     #[test]
-    fn manual_sprite_control_write_disarms_output_until_data_write() {
+    fn manual_sprite_control_write_after_compare_preserves_loaded_word() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
             PAL_VISIBLE_LINE0 as u16,
@@ -9670,9 +9682,10 @@ mod tests {
 
         assert_eq!(fb[0], rgb12_to_rgba8(0x0F00));
         assert_eq!(fb[7], rgb12_to_rgba8(0x0F00));
-        assert_eq!(fb[8], rgb12_to_rgba8(0));
-        assert_eq!(fb[15], rgb12_to_rgba8(0));
+        assert_eq!(fb[8], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[15], rgb12_to_rgba8(0x0F00));
         assert_eq!(fb[16], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[32], rgb12_to_rgba8(0));
     }
 
     #[test]
@@ -9743,7 +9756,7 @@ mod tests {
     }
 
     #[test]
-    fn attached_manual_sprite_writes_replay_later_odd_data_bits() {
+    fn attached_manual_sprite_data_after_compare_waits_for_next_scanline() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
             PAL_VISIBLE_LINE0 as u16,
@@ -9813,11 +9826,11 @@ mod tests {
         );
 
         assert_eq!(fb[0], rgb12_to_rgba8(0x0F00));
-        assert_eq!(fb[4], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[4], rgb12_to_rgba8(0));
     }
 
     #[test]
-    fn attached_manual_sprite_writes_preserve_even_pixels_before_odd_arms() {
+    fn attached_manual_sprite_data_after_compare_preserves_loaded_even_pixels() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
             PAL_VISIBLE_LINE0 as u16,
@@ -9875,7 +9888,7 @@ mod tests {
         );
 
         assert_eq!(fb[0], rgb12_to_rgba8(0x0F00));
-        assert_eq!(fb[4], rgb12_to_rgba8(0x00F0));
+        assert_eq!(fb[4], rgb12_to_rgba8(0x0F00));
     }
 
     #[test]
@@ -10519,7 +10532,7 @@ mod tests {
     }
 
     #[test]
-    fn sprite_register_data_write_replaces_dma_latch_on_same_beam_line() {
+    fn sprite_register_data_write_after_compare_preserves_dma_latch_on_same_beam_line() {
         let mut state = blank_state();
         let (pos, ctl) = sprite_control_words(
             PAL_VISIBLE_LINE0 as u16,
@@ -10584,8 +10597,9 @@ mod tests {
 
         assert_eq!(fb[0], rgb12_to_rgba8(0x0F00));
         assert_eq!(fb[7], rgb12_to_rgba8(0x0F00));
-        assert_eq!(fb[8], rgb12_to_rgba8(0));
-        assert_eq!(fb[31], rgb12_to_rgba8(0));
+        assert_eq!(fb[8], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[31], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[32], rgb12_to_rgba8(0));
     }
 
     #[test]
@@ -11944,7 +11958,7 @@ mod tests {
 
         let line = (0x50 - 0x2C) as usize;
         let sprite_x = sprite_palette_control_framebuffer_x(hpos);
-        assert_eq!(sprite_x, color_write_framebuffer_x(hpos).saturating_sub(8));
+        assert_eq!(sprite_x, color_write_framebuffer_x(hpos).saturating_sub(4));
         let beam_x = beam_to_framebuffer_x_unclamped(hpos) as usize;
         assert!(sprite_x < beam_x);
         assert_eq!(control_segments[line].len(), 2);

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -81,11 +81,12 @@ const COLOR_WRITE_HPOS_FB0: i32 = 0x35;
 /// writes. Keep it separate from COLOR replay so copper palette gradients stay
 /// in the Denise palette-output phase on OCS/ECS.
 const SPRITE_PALETTE_CONTROL_HPOS_FB0: i32 = 0x36;
-/// SPRxPOS writes update the Denise horizontal comparator seven CCK ahead of
-/// the normal register/output beam domain. Manual sprite replays use this
-/// earlier domain so adjacent position writes can abut at their programmed
-/// HSTARTs.
-const SPRITE_POSITION_WRITE_PIPELINE_CCK: u32 = 7;
+/// SPRxPOS and SPRxDATx writes feed Denise's sprite comparator/latches seven
+/// CCK ahead of the normal register/output beam domain. Manual sprite replays
+/// use this earlier domain so adjacent position writes can abut at their
+/// programmed HSTARTs, and data writes that beat the comparator load the same
+/// scanline.
+const SPRITE_REGISTER_WRITE_PIPELINE_CCK: u32 = 7;
 /// Framebuffer-x offset between the copper/register coordinate
 /// ([`COPPER_WAIT_HPOS_FB0`], used to place beam-timed register writes) and the
 /// bitplane/DIW coordinate ([`DIW_HSTART_FB0`], used to place fetched bitplane
@@ -3301,6 +3302,10 @@ fn manual_sprite_event_beam_for_sprite_write(
         // domain delays attached pairs whose even/odd position writes are
         // staggered by the Copper.
         0x0 => manual_sprite_position_event_beam(vpos, hpos, visible_line0, rows),
+        // SPRxDATA/SPRxDATB update the latches copied by Denise's horizontal
+        // sprite comparator. If the write reaches that path before the
+        // comparator fires, the new data belongs to the current scanline.
+        0x4 | 0x6 => manual_sprite_data_event_beam(vpos, hpos, visible_line0, rows),
         _ => manual_sprite_event_beam(vpos, hpos, visible_line0, rows),
     }
 }
@@ -3336,9 +3341,31 @@ fn manual_sprite_position_event_beam(
     (vpos, x)
 }
 
+fn manual_sprite_data_event_beam(
+    vpos: u32,
+    hpos: u32,
+    visible_line0: i32,
+    rows: usize,
+) -> (i32, usize) {
+    let visible_end = visible_line0 + rows as i32;
+    let vpos = vpos as i32;
+    if vpos < visible_line0 {
+        return (visible_line0, 0);
+    }
+    if vpos >= visible_end {
+        return (visible_end, 0);
+    }
+    let x = sprite_data_write_framebuffer_x(hpos);
+    (vpos, x)
+}
+
 fn sprite_position_write_framebuffer_x(hpos: u32) -> usize {
-    let hpos = hpos.saturating_sub(SPRITE_POSITION_WRITE_PIPELINE_CCK);
+    let hpos = hpos.saturating_sub(SPRITE_REGISTER_WRITE_PIPELINE_CCK);
     ((hpos as i32 * 2 - DIW_HSTART_FB0) * 2).clamp(0, FB_WIDTH as i32) as usize
+}
+
+fn sprite_data_write_framebuffer_x(hpos: u32) -> usize {
+    sprite_position_write_framebuffer_x(hpos)
 }
 
 fn flush_manual_sprite_lines(
@@ -9457,7 +9484,7 @@ mod tests {
         initial_state.sprdata[0] = 0xFFFF;
         initial_state.spr_armed[0] = true;
 
-        let boundary_hpos = u32::from(first_hstart / 2) + SPRITE_POSITION_WRITE_PIPELINE_CCK;
+        let boundary_hpos = u32::from(first_hstart / 2) + SPRITE_REGISTER_WRITE_PIPELINE_CCK;
         let manual_sprite_lines = manual_sprite_lines_from_events(
             &initial_state,
             &[
@@ -9485,6 +9512,107 @@ mod tests {
     }
 
     #[test]
+    fn manual_sprite_data_write_before_compare_uses_sprite_compare_domain() {
+        let mut initial_state = blank_state();
+        let beam_y = PAL_VISIBLE_LINE0;
+        let hstart = 240;
+        let (pos, ctl) = sprite_control_words(beam_y as u16, beam_y as u16 + 1, hstart);
+        initial_state.sprpos[2] = pos;
+        initial_state.sprctl[2] = ctl;
+        initial_state.palette.write_ocs(25, 0x0F00);
+
+        let event_hpos = 116;
+        let data_x = sprite_data_write_framebuffer_x(event_hpos);
+        let colour_output_x = beam_to_framebuffer_x_unclamped(event_hpos) as usize;
+        let base_x = sprite_nominal_base_framebuffer_x(pos, ctl) as usize;
+        assert!(data_x < base_x);
+        assert!(colour_output_x > base_x);
+
+        let manual_sprite_lines = manual_sprite_lines_from_events(
+            &initial_state,
+            &[cpu_event(beam_y as u32, event_hpos, 0x154, 0x8000)],
+        );
+
+        let line = manual_sprite_lines[2]
+            .iter()
+            .find(|line| line.beam_y == beam_y)
+            .expect("data write before the comparator affects the current scanline");
+        assert_eq!(line.x_start, data_x);
+        assert_eq!(line.data, 0x8000);
+        assert_eq!(
+            sprite_line_pixel_bits_at(
+                line,
+                base_x as i32,
+                ControlState::from_render_state(&initial_state),
+                &[],
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn attached_manual_sprite_data_write_before_compare_uses_sprite_compare_domain() {
+        let mut initial_state = blank_state();
+        let beam_y = PAL_VISIBLE_LINE0;
+        let hstart = 240;
+        let (pos, ctl) = sprite_control_words(beam_y as u16, beam_y as u16 + 1, hstart);
+        initial_state.sprpos[0] = pos;
+        initial_state.sprctl[0] = ctl;
+        initial_state.sprpos[1] = pos;
+        initial_state.sprctl[1] = ctl | 0x0080;
+        initial_state.palette.write_ocs(20, 0x0F00);
+
+        let event_hpos = 116;
+        let data_x = sprite_data_write_framebuffer_x(event_hpos);
+        let colour_output_x = beam_to_framebuffer_x_unclamped(event_hpos) as usize;
+        let base_x = sprite_nominal_base_framebuffer_x(pos, ctl) as usize;
+        assert!(data_x < base_x);
+        assert!(colour_output_x > base_x);
+
+        let events = [
+            cpu_event(beam_y as u32, event_hpos, 0x144, 0),
+            cpu_event(beam_y as u32, event_hpos, 0x14C, 0x8000),
+        ];
+        let manual_sprite_lines = manual_sprite_lines_from_events(&initial_state, &events);
+
+        let base_controls = [ControlState::from_render_state(&initial_state); FB_HEIGHT];
+        let mut render_state = initial_state;
+        apply_move(&mut render_state, 0x144, 0);
+        apply_move(&mut render_state, 0x14C, 0x8000);
+        let ram = vec![0u8; 512 * 1024];
+        let base_palettes = [render_state.palette; FB_HEIGHT];
+        let palette_segments = vec![Vec::new(); FB_HEIGHT];
+        let control_segments = vec![Vec::new(); FB_HEIGHT];
+        let playfield_mask = vec![0u8; FB_PIXELS];
+        let mut collision_pixels = vec![CollisionPixel::default(); FB_PIXELS];
+        let mut fb = vec![rgb12_to_rgba8(0); FB_PIXELS];
+
+        render_sprites_with_manual_lines(
+            &render_state,
+            &ram,
+            &mut fb,
+            SpriteClip {
+                x_start: 0,
+                x_stop: FB_WIDTH,
+                y_start: 0,
+                y_stop: FB_HEIGHT,
+            },
+            &base_palettes,
+            &palette_segments,
+            &base_controls,
+            &control_segments,
+            &playfield_mask,
+            &mut collision_pixels,
+            sprite_pointer_refreshes_from_mask([false; 8]),
+            &[],
+            false,
+            Some(&manual_sprite_lines),
+        );
+
+        assert_eq!(fb[base_x], rgb12_to_rgba8(0x0F00));
+    }
+
+    #[test]
     fn manual_sprite_data_write_after_compare_waits_for_next_scanline() {
         let mut initial_state = blank_state();
         let (pos, ctl) = sprite_control_words(
@@ -9496,9 +9624,12 @@ mod tests {
         initial_state.sprctl[0] = ctl;
         initial_state.palette.write_ocs(17, 0x0F00);
 
+        let after_compare_hpos =
+            (DIW_HSTART_FB0 as u32 / 2) + SPRITE_REGISTER_WRITE_PIPELINE_CCK + 2;
+        assert!(sprite_data_write_framebuffer_x(after_compare_hpos) > 0);
         let events = [cpu_event(
             PAL_VISIBLE_LINE0 as u32,
-            (COPPER_WAIT_HPOS_FB0 + 1) as u32,
+            after_compare_hpos,
             0x144,
             0xA000,
         )];
@@ -9561,6 +9692,9 @@ mod tests {
         initial_state.palette.write_ocs(17, 0x0F00);
         initial_state.palette.write_ocs(19, 0x00F0);
 
+        let after_compare_hpos =
+            (DIW_HSTART_FB0 as u32 / 2) + SPRITE_REGISTER_WRITE_PIPELINE_CCK + 2;
+        assert!(sprite_data_write_framebuffer_x(after_compare_hpos) > 0);
         let events = [
             cpu_event(
                 PAL_VISIBLE_LINE0 as u32,
@@ -9568,12 +9702,7 @@ mod tests {
                 0x144,
                 0xFFFF,
             ),
-            cpu_event(
-                PAL_VISIBLE_LINE0 as u32,
-                (COPPER_WAIT_HPOS_FB0 + 1) as u32,
-                0x146,
-                0xFFFF,
-            ),
+            cpu_event(PAL_VISIBLE_LINE0 as u32, after_compare_hpos, 0x146, 0xFFFF),
         ];
         let manual_sprite_lines = manual_sprite_lines_from_events(&initial_state, &events);
 
@@ -9769,6 +9898,9 @@ mod tests {
         initial_state.sprctl[1] = ctl | 0x0080;
         initial_state.palette.write_ocs(20, 0x0F00);
 
+        let after_compare_hpos =
+            (DIW_HSTART_FB0 as u32 / 2) + SPRITE_REGISTER_WRITE_PIPELINE_CCK + 2;
+        assert!(sprite_data_write_framebuffer_x(after_compare_hpos) > 0);
         let events = [
             cpu_event(
                 PAL_VISIBLE_LINE0 as u32,
@@ -9782,12 +9914,7 @@ mod tests {
                 0x14C,
                 0x8000,
             ),
-            cpu_event(
-                PAL_VISIBLE_LINE0 as u32,
-                (COPPER_WAIT_HPOS_FB0 + 1) as u32,
-                0x14C,
-                0x2000,
-            ),
+            cpu_event(PAL_VISIBLE_LINE0 as u32, after_compare_hpos, 0x14C, 0x2000),
         ];
         let manual_sprite_lines = manual_sprite_lines_from_events(&initial_state, &events);
 
@@ -9846,9 +9973,12 @@ mod tests {
         initial_state.palette.write_ocs(17, 0x0F00);
         initial_state.palette.write_ocs(21, 0x00F0);
 
+        let after_compare_hpos =
+            (DIW_HSTART_FB0 as u32 / 2) + SPRITE_REGISTER_WRITE_PIPELINE_CCK + 2;
+        assert!(sprite_data_write_framebuffer_x(after_compare_hpos) > 0);
         let events = [cpu_event(
             PAL_VISIBLE_LINE0 as u32,
-            (COPPER_WAIT_HPOS_FB0 + 1) as u32,
+            after_compare_hpos,
             0x14C,
             0x2000,
         )];
@@ -10563,11 +10693,14 @@ mod tests {
             datb_ext: [0; 3],
             width_words: 1,
         }];
+        let after_compare_hpos =
+            (DIW_HSTART_FB0 as u32 / 2) + SPRITE_REGISTER_WRITE_PIPELINE_CCK + 2;
+        assert!(sprite_data_write_framebuffer_x(after_compare_hpos) > 0);
         let manual_sprite_lines = manual_sprite_lines_from_events(
             &state,
             &[beam_event(
                 PAL_VISIBLE_LINE0 as u32,
-                (COPPER_WAIT_HPOS_FB0 + 2) as u32,
+                after_compare_hpos,
                 0x0144,
                 0x0000,
             )],

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -894,18 +894,6 @@ impl ControlState {
                 // lo-res phase bias must not push a standard-width DIW one sample
                 // past that completed early-DDF row at the right edge.
                 origin_shift -= 1;
-            } else if ddf > standard_ddf && origin_shift < 0 && display_native_shift == 1 {
-                // Mirror of the above for a standard-width DIW whose DDFSTRT is
-                // *late*: the picture is positioned in whole fetch gulps, but the
-                // standard one-sample lo-res phase bias (DIWSTRT $81 vs the $80
-                // fetch reference, i.e. display_native_shift == 1) lands the
-                // clipped-sample count one off the gulp grid -- clipping the
-                // first cell column and orphaning a partial column at the right
-                // edge (e.g. a copper-fed bitplane mosaic fetched with DDFSTRT
-                // $48 in a standard DIW). Non-standard windows carry their own
-                // phase and are positioned by display_native_shift directly, so
-                // gate this on the standard +1 bias only.
-                origin_shift -= 1;
             }
         }
         origin_shift
@@ -2744,8 +2732,7 @@ fn bitplane_dma_output_start_x(
     }
     line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes)
         .iter()
-        .find_map(|(hpos, plane)| (plane == 0).then_some(beam_to_framebuffer_x_unclamped(hpos)))
-        .map(|x| x.clamp(0, FB_WIDTH as i32) as usize)
+        .find_map(|(hpos, plane)| (plane == 0).then_some(bitplane_fetch_framebuffer_x(hpos)))
 }
 
 #[cfg(test)]
@@ -2826,6 +2813,10 @@ fn beam_event_at_or_before_beam(event: &BeamRegisterWrite, vpos: u32, hpos: u32)
 
 fn bitplane_fetch_hpos(control: ControlState, word_idx: usize) -> u32 {
     bitplane_fetch_hpos_for_plane(control, word_idx, 0)
+}
+
+fn bitplane_fetch_framebuffer_x(hpos: u32) -> usize {
+    ((hpos as i32 * 2 - DIW_HSTART_FB0) * 2).clamp(0, FB_WIDTH as i32) as usize
 }
 
 fn apply_bitplane_pointer_write(ptrs: &mut [u32; 8], off: u16, val: u16) {
@@ -8047,6 +8038,18 @@ mod tests {
         };
         assert_eq!(inset_fetch.fetch_start_native_x(false, 2), 14);
         assert_eq!(inset_fetch.native_x_offset(false, 2), 0);
+
+        let late_fetch_standard_window = RenderState {
+            bplcon0: 0,
+            diwstrt: ((PAL_VISIBLE_LINE0 as u16) << 8) | 0x0081,
+            ddfstrt: 0x0048,
+            ..blank_state()
+        };
+        assert_eq!(
+            late_fetch_standard_window.fetch_start_native_x(false, 2),
+            31
+        );
+        assert_eq!(late_fetch_standard_window.native_x_offset(false, 2), 0);
     }
 
     #[test]
@@ -8081,8 +8084,7 @@ mod tests {
         };
         let inset_words = inset_ddf.words_per_row(native_frame_width_for_control(inset_ddf));
         let first_bpl1dat_x =
-            beam_to_framebuffer_x_unclamped(bitplane_fetch_hpos_for_plane(inset_ddf, 0, 0))
-                .clamp(0, FB_WIDTH as i32) as usize;
+            bitplane_fetch_framebuffer_x(bitplane_fetch_hpos_for_plane(inset_ddf, 0, 0));
 
         assert_ne!(
             inset_ddf.fetch_start_native_x(inset_ddf.diw_h_start(), 2),

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1081,6 +1081,7 @@ struct DenisePlannedPlayfieldLine<'a> {
     x_stop: usize,
     plane_words: &'a [Vec<u16>],
     fetched_pixels: usize,
+    carry_words: [Option<u16>; 8],
 }
 
 impl<'a> DenisePlannedPlayfieldLine<'a> {
@@ -1097,7 +1098,13 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             x_stop,
             plane_words,
             fetched_pixels,
+            carry_words: [None; 8],
         }
+    }
+
+    fn with_carry_words(mut self, carry_words: [Option<u16>; 8]) -> Self {
+        self.carry_words = carry_words;
+        self
     }
 
     #[cfg(test)]
@@ -1135,6 +1142,15 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             let delay = delays[plane];
             if native_x < delay {
                 active = true;
+                let carry_offset = delay - native_x;
+                if carry_offset <= 16 {
+                    if let Some(word) = self.carry_words.get(plane).copied().flatten() {
+                        let bit = carry_offset - 1;
+                        if word & (1 << bit) != 0 {
+                            idx |= 1 << plane;
+                        }
+                    }
+                }
                 continue;
             }
             let fetch_x = native_x - delay;
@@ -2688,6 +2704,7 @@ fn line_fetch_plans_for_line(
     plans
 }
 
+#[cfg(test)]
 fn bitplane_output_start_x(
     base_control: ControlState,
     control_segments: &[ControlSegment],
@@ -2695,8 +2712,25 @@ fn bitplane_output_start_x(
     words_per_row: usize,
     dma_planes: usize,
 ) -> usize {
+    bitplane_dma_output_start_x(
+        base_control,
+        control_segments,
+        display_start_x,
+        words_per_row,
+        dma_planes,
+    )
+    .unwrap_or(0)
+}
+
+fn bitplane_dma_output_start_x(
+    base_control: ControlState,
+    control_segments: &[ControlSegment],
+    display_start_x: usize,
+    words_per_row: usize,
+    dma_planes: usize,
+) -> Option<usize> {
     if dma_planes == 0 || words_per_row == 0 {
-        return 0;
+        return None;
     }
     let mut display_control = base_control;
     for segment in control_segments {
@@ -2706,13 +2740,12 @@ fn bitplane_output_start_x(
     }
     let pixel_repeat = display_control.framebuffer_pixel_repeat();
     if display_control.fetch_start_native_x(display_control.diw_h_start(), pixel_repeat) == 0 {
-        return 0;
+        return Some(display_start_x);
     }
     line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes)
         .iter()
         .find_map(|(hpos, plane)| (plane == 0).then_some(beam_to_framebuffer_x_unclamped(hpos)))
         .map(|x| x.clamp(0, FB_WIDTH as i32) as usize)
-        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -4401,6 +4434,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
     let mut playfield_mask = vec![0u8; FB_WIDTH * rows];
     let mut collision_pixels = vec![CollisionPixel::default(); FB_WIDTH * rows];
     let mut clxdat = 0u16;
+    let mut dma_output_start_x_by_line = vec![None; rows];
 
     let background_started = Instant::now();
     fill_background_with_visible_line0(
@@ -4512,6 +4546,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         // predecessor was border (no carried-over shifter data) can suppress
         // the BPLCON1 scroll pulling its leading pre-fetch words into view.
         let mut last_playfield_line: Option<usize> = None;
+        let mut previous_playfield_tail_words: [Option<u16>; 8] = [None; 8];
         for y in 0..rows {
             let row_control_segments = &control_segments[y];
             let Some((x_start, x_stop)) = line_display_window_bounds(
@@ -4719,21 +4754,29 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                     }
                 }
             }
+            let block_start = last_playfield_line != Some(y.wrapping_sub(1));
+            let carry_words = if block_start {
+                [None; 8]
+            } else {
+                previous_playfield_tail_words
+            };
             let line_plan = DenisePlannedPlayfieldLine::new(
                 y,
                 x_start,
                 x_stop,
                 &row_words[..nplanes],
                 fetched_pixels,
-            );
-            let bpl_output_start_x = bitplane_output_start_x(
+            )
+            .with_carry_words(carry_words);
+            let dma_output_start_x = bitplane_dma_output_start_x(
                 base_controls[y],
                 row_control_segments,
                 x_start,
                 words_per_row,
                 dma_planes.min(nplanes),
             );
-            let block_start = last_playfield_line != Some(y.wrapping_sub(1));
+            let bpl_output_start_x = dma_output_start_x.unwrap_or(0);
+            dma_output_start_x_by_line[y] = dma_output_start_x;
             last_playfield_line = Some(y);
             render_planned_playfield_line(
                 &line_plan,
@@ -4758,6 +4801,11 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 let m = control.modulo_for_plane(p, beam_y as i32);
                 ptrs[p] = ((ptrs[p] as i64).wrapping_add(m as i64) as u32) & ram_mask;
             }
+            previous_playfield_tail_words = std::array::from_fn(|plane| {
+                (plane < nplanes)
+                    .then(|| row_words[plane].last().copied())
+                    .flatten()
+            });
         }
         if let (Some(planes), Some(index)) = (export_planes.as_ref(), export_index.as_ref()) {
             let frame = input.emulated_frames;
@@ -4820,6 +4868,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         &palette_segments,
         &base_controls,
         &control_segments,
+        &dma_output_start_x_by_line,
         visible_line0,
         input.emulated_seconds,
         input.emulated_frames,
@@ -5362,6 +5411,7 @@ fn render_manual_bpl_segments(
     base_controls: &[ControlState],
     control_segments: &[Vec<ControlSegment>],
 ) {
+    let dma_output_start_x_by_line = vec![None; base_controls.len()];
     render_manual_bpl_segments_with_visible_line0(
         segments,
         fb,
@@ -5372,6 +5422,7 @@ fn render_manual_bpl_segments(
         palette_segments,
         base_controls,
         control_segments,
+        &dma_output_start_x_by_line,
         PAL_VISIBLE_LINE0,
         0.0,
         0,
@@ -5389,6 +5440,7 @@ fn render_manual_bpl_segments_with_visible_line0(
     palette_segments: &[Vec<PaletteSegment>],
     base_controls: &[ControlState],
     control_segments: &[Vec<ControlSegment>],
+    dma_output_start_x_by_line: &[Option<usize>],
     visible_line0: i32,
     emulated_seconds: f64,
     emulated_frames: u64,
@@ -5424,6 +5476,7 @@ fn render_manual_bpl_segments_with_visible_line0(
             palette_segments,
             base_controls,
             control_segments,
+            dma_output_start_x_by_line,
             &mut ham_color,
             &mut ham_select,
             &mut ham_select_pixels,
@@ -5482,6 +5535,7 @@ fn draw_manual_bpl_word(
     palette_segments: &[Vec<PaletteSegment>],
     base_controls: &[ControlState],
     control_segments: &[Vec<ControlSegment>],
+    dma_output_start_x_by_line: &[Option<usize>],
     ham_color: &mut u32,
     ham_select: &mut u8,
     ham_select_pixels: &mut [u8],
@@ -5495,6 +5549,11 @@ fn draw_manual_bpl_word(
     const MAX_MANUAL_BPL_NATIVE_SAMPLES: usize = MANUAL_BPL_WORD_BITS + MAX_BPLCON1_DELAY;
 
     let shifter = DeniseManualBitplaneShifter::new(seg.planes, MANUAL_BPL_WORD_BITS);
+    let dma_output_start_x = dma_output_start_x_by_line
+        .get(seg.line)
+        .copied()
+        .flatten()
+        .filter(|&x| seg.x < x as i32);
     let mut x_cursor = seg.x;
     let mut native_idx = 0usize;
     while native_idx < MAX_MANUAL_BPL_NATIVE_SAMPLES {
@@ -5530,6 +5589,9 @@ fn draw_manual_bpl_word(
                 return false;
             }
             let x = x as usize;
+            if dma_output_start_x.is_some_and(|dma_x| x >= dma_x) {
+                return false;
+            }
             let pixel_control =
                 control_at_x(base_controls[seg.line], &control_segments[seg.line], x);
             let (window_x_start, window_x_stop) = pixel_control.display_window_x();
@@ -5574,6 +5636,9 @@ fn draw_manual_bpl_word(
                 continue;
             }
             let x = x as usize;
+            if dma_output_start_x.is_some_and(|dma_x| x >= dma_x) {
+                continue;
+            }
             let pixel_control =
                 control_at_x(base_controls[seg.line], &control_segments[seg.line], x);
             let (window_x_start, window_x_stop) = pixel_control.display_window_x();
@@ -8006,7 +8071,7 @@ mod tests {
                 standard_words,
                 standard_ddf.dma_planes(),
             ),
-            0
+            standard_ddf.display_window_x().0
         );
 
         let inset_ddf = ControlState {
@@ -8055,6 +8120,35 @@ mod tests {
             }),
             8
         );
+    }
+
+    #[test]
+    fn bplcon1_delay_uses_previous_line_shifter_tail_when_contiguous() {
+        let control = ControlState {
+            bplcon0: 0x1000,
+            bplcon1: 3,
+            ..ControlState::default()
+        };
+        let plane_words = [vec![0x8000]];
+        let no_carry = DenisePlannedPlayfieldLine::new(0, 0, 32, &plane_words, 16);
+
+        assert_eq!(
+            no_carry.sample(control, 0),
+            DeniseBitplaneSample {
+                idx: 0,
+                nplanes: 1,
+                active: true,
+            }
+        );
+
+        let mut carry_words = [None; 8];
+        carry_words[0] = Some(0x0004);
+        let with_carry = DenisePlannedPlayfieldLine::new(0, 0, 32, &plane_words, 16)
+            .with_carry_words(carry_words);
+
+        assert_eq!(with_carry.sample(control, 0).idx, 1);
+        assert_eq!(with_carry.sample(control, 1).idx, 0);
+        assert_eq!(with_carry.sample(control, 3).idx, 1);
     }
 
     #[test]
@@ -12544,6 +12638,67 @@ mod tests {
 
         assert_eq!(segments[0].planes[0], 0x0000);
         assert_eq!(segments[0].planes[1], 0x8000);
+    }
+
+    #[test]
+    fn manual_bpl1dat_before_dma_output_stops_at_dma_shifter_load() {
+        let mut palette = Palette::new();
+        palette.write_ocs(1, 0x0F00);
+        let control = ControlState {
+            dmacon: DMACON_DMAEN | DMACON_BPLEN,
+            bplcon0: 0x1000,
+            diwstrt: ((PAL_VISIBLE_LINE0 as u16) << 8) | STANDARD_DIW_HSTART as u16,
+            diwstop: (((PAL_VISIBLE_LINE0 + 1) as u16) << 8) | STANDARD_DIW_HSTOP as u16,
+            ddfstrt: 0x0050,
+            ddfstop: 0x00D0,
+            ..ControlState::default()
+        };
+        let base_palettes = [palette; FB_HEIGHT];
+        let palette_segments = vec![Vec::new(); FB_HEIGHT];
+        let base_controls = [control; FB_HEIGHT];
+        let control_segments = vec![Vec::new(); FB_HEIGHT];
+        let dma_output_x = bitplane_dma_output_start_x(
+            control,
+            &[],
+            control.display_window_x().0,
+            control.words_per_row(native_frame_width_for_control(control)),
+            control.dma_planes(),
+        )
+        .unwrap();
+        let mut fb = vec![rgb12_to_rgba8(0x000F); FB_PIXELS];
+        let mut playfield_mask = vec![0u8; FB_PIXELS];
+        let mut collision_pixels = vec![CollisionPixel::default(); FB_PIXELS];
+        let mut clxdat = 0u16;
+        let mut planes = [0u16; 8];
+        planes[0] = 0xFFFF;
+        let segments = [ManualBplSegment {
+            line: 0,
+            hpos: 0,
+            x: dma_output_x as i32 - 8,
+            planes,
+            palette,
+        }];
+        let mut dma_output_start_x_by_line = vec![None; FB_HEIGHT];
+        dma_output_start_x_by_line[0] = Some(dma_output_x);
+
+        render_manual_bpl_segments_with_visible_line0(
+            &segments,
+            &mut fb,
+            &mut playfield_mask,
+            &mut collision_pixels,
+            &mut clxdat,
+            &base_palettes,
+            &palette_segments,
+            &base_controls,
+            &control_segments,
+            &dma_output_start_x_by_line,
+            PAL_VISIBLE_LINE0,
+            0.0,
+            0,
+        );
+
+        assert_eq!(fb[dma_output_x - 2], rgb12_to_rgba8(0x0F00));
+        assert_eq!(fb[dma_output_x], rgb12_to_rgba8(0x000F));
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -824,6 +824,18 @@ impl ControlState {
             .max(0) as usize
     }
 
+    fn ham_history_start_native_x(
+        &self,
+        diw_h_start: u16,
+        pixel_repeat: usize,
+        native_x_offset: usize,
+    ) -> usize {
+        let display_phase_native =
+            ((diw_h_start as i32 - self.fetch_reference()) * 2) / pixel_repeat as i32;
+        let visible_phase = display_phase_native.max(0) as usize;
+        native_x_offset.saturating_sub(visible_phase.min(native_x_offset))
+    }
+
     fn fetch_origin_native_shift(&self, diw_h_start: u16, pixel_repeat: usize) -> i32 {
         let display_native_shift =
             ((diw_h_start as i32 - self.fetch_reference()) * 2) / pixel_repeat as i32;
@@ -1130,8 +1142,8 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             let delay = delays[plane];
             if native_x < delay {
                 active = true;
-                let carry_offset = delay - native_x;
-                if carry_offset <= 16 {
+                if delay <= 16 {
+                    let carry_offset = delay - native_x;
                     if let Some(word) = self.carry_words.get(plane).copied().flatten() {
                         let bit = carry_offset - 1;
                         if word & (1 << bit) != 0 {
@@ -3691,6 +3703,12 @@ fn maybe_log_frame_state(
         ymin,
         ymax,
     );
+    log::info!(
+        "  sprpos={:04X?} sprctl={:04X?} sprarmed={:?}",
+        state.sprpos,
+        state.sprctl,
+        state.spr_armed,
+    );
 }
 
 #[derive(Clone, Copy)]
@@ -4409,7 +4427,6 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         &mut manual_bpl_segments,
         visible_line0,
     );
-    backfill_left_overscan_background(&mut base_palettes, &mut palette_segments);
     render_timing.event_nanos = event_started.elapsed().as_nanos();
     render_timing.events = render_events.len() as u64;
     render_timing.control_segments = control_segments
@@ -5156,6 +5173,15 @@ fn render_planned_playfield_line(
         let nplanes = sample_control.nplanes().min(plan.plane_words.len());
         let delays = std::array::from_fn(|plane| sample_control.scroll_for_plane(plane));
         let ham_mode = sample_control.hold_and_modify();
+        let ham_history_start_native_x = if ham_mode {
+            pixel_control.ham_history_start_native_x(
+                pixel_diw_h_start,
+                pixel_repeat,
+                native_x_offset,
+            )
+        } else {
+            0
+        };
 
         let collision_dual = pixel_control.dual_playfield();
         let collision_key_now = (
@@ -5197,6 +5223,8 @@ fn render_planned_playfield_line(
                         && pixel_x < win_x_stop
                 });
             if ham_mode {
+                next_ham_native_x =
+                    next_ham_native_x.max(ham_history_start_native_x.min(plan.fetched_pixels));
                 let preroll_stop = native_x.min(plan.fetched_pixels);
                 while next_ham_native_x < preroll_stop {
                     let skipped =
@@ -6613,48 +6641,6 @@ fn effective_ddf_window(
     let start = start.max(hard_start);
     let stop = stop.min(hard_stop);
     (stop >= start).then_some((start, stop))
-}
-
-/// Backfill the left overscan border's background colour (COLOR00) on lines
-/// where the Copper establishes it *within* the overscan.
-///
-/// A Copper-driven horizontal gradient parks on a per-line WAIT and writes its
-/// first COLOR00 a few color clocks into the line, timed so the colour is ready
-/// at the playfield's left edge. The columns to the left of that first write sit
-/// in the overscan border (left of [`STANDARD_VISIBLE_X0`]) and would otherwise
-/// fall back to the previous line's final gradient colour -- a stale,
-/// brighter-or-darker vertical strip at the far left. A real PAL display crops
-/// this overscan; since the framebuffer keeps the full overscan field, adopt the
-/// colour the Copper sets within the overscan so the gradient reads continuously
-/// to the left edge instead of showing the cross-line carry. Lines whose first
-/// background change lands at or beyond the standard visible edge are untouched,
-/// so no in-picture pixel changes.
-fn backfill_left_overscan_background(
-    base_palettes: &mut [Palette],
-    palette_segments: &mut [Vec<PaletteSegment>],
-) {
-    for (base, segments) in base_palettes.iter_mut().zip(palette_segments.iter_mut()) {
-        // Only act when the background colour is established within the overscan
-        // (the gradient's first COLOR00 write lands left of the visible edge).
-        if segments
-            .first()
-            .is_none_or(|first| first.x >= STANDARD_VISIBLE_X0)
-        {
-            continue;
-        }
-        // The COLOR00 the Copper has set by the time the beam reaches the visible
-        // edge -- the gradient's entry colour for this line.
-        let entry_color = palette_at_x(*base, segments, STANDARD_VISIBLE_X0 - 1)[0];
-        base.write_entry(0, false, entry_color);
-        for seg in segments.iter_mut() {
-            if seg.x >= STANDARD_VISIBLE_X0 {
-                break;
-            }
-            if seg.entry == 0 && !seg.loct {
-                seg.value = entry_color;
-            }
-        }
-    }
 }
 
 fn palette_at_x(mut palette: Palette, segments: &[PaletteSegment], x: usize) -> Palette {
@@ -8176,6 +8162,29 @@ mod tests {
         assert_eq!(with_carry.sample(control, 0).idx, 1);
         assert_eq!(with_carry.sample(control, 1).idx, 0);
         assert_eq!(with_carry.sample(control, 3).idx, 1);
+    }
+
+    #[test]
+    fn aga_extended_bplcon1_delay_does_not_reuse_single_word_line_tail() {
+        let control = ControlState {
+            agnus_revision: AgnusRevision::AgaAlice,
+            bplcon0: BPLCON0_ECSENA | 0x1000,
+            bplcon1: 0x0800,
+            fmode: 0x0003,
+            ..ControlState::default()
+        };
+        assert_eq!(control.scroll_for_plane(0), 32);
+
+        let plane_words = [vec![0x8000, 0x0000, 0x0000]];
+        let mut carry_words = [None; 8];
+        carry_words[0] = Some(0xFFFF);
+        let line = DenisePlannedPlayfieldLine::new(0, 0, 64, &plane_words, 48)
+            .with_carry_words(carry_words);
+
+        assert_eq!(line.sample(control, 15).idx, 0);
+        assert_eq!(line.sample(control, 16).idx, 0);
+        assert_eq!(line.sample(control, 31).idx, 0);
+        assert_eq!(line.sample(control, 32).idx, 1);
     }
 
     #[test]
@@ -11613,6 +11622,52 @@ mod tests {
     }
 
     #[test]
+    fn planned_ham_dma_ignores_extra_early_ddf_history_before_diw() {
+        let mut row_words = vec![vec![0; 2]; 6];
+        row_words[0][0] |= 0x8000; // native x 0: direct palette entry 1
+        row_words[4][0] |= 0x0001; // native x 15: HAM blue := 0
+        row_words[4][1] |= 0x8000; // native x 16: HAM blue := 0
+        let line_plan = DenisePlannedPlayfieldLine::new(0, 64, 66, &row_words, 32);
+        let mut control = visible_lowres_control(0x6800);
+        control.diwstrt = ((PAL_VISIBLE_LINE0 as u16) << 8) | STANDARD_DIW_HSTART as u16;
+        control.diwstop =
+            (((PAL_VISIBLE_LINE0 + 1) as u16) << 8) | (STANDARD_DIW_HSTART as u16 + 1);
+        control.ddfstrt = 0x0030;
+        control.ddfstop = 0x00D0;
+        let mut palette = Palette::new();
+        palette.write_ocs(1, 0x0123);
+        let mut fb = vec![0; FB_PIXELS];
+        let mut playfield_mask = vec![0; FB_PIXELS];
+        let mut collision_pixels = vec![CollisionPixel::default(); FB_PIXELS];
+        let mut clxdat = 0;
+
+        render_planned_playfield_line(
+            &line_plan,
+            &mut fb,
+            &mut playfield_mask,
+            &mut collision_pixels,
+            &mut clxdat,
+            palette,
+            &[],
+            0,
+            control,
+            &[],
+            0,
+            control.bplcon1,
+            false,
+            0,
+            PAL_VISIBLE_LINE0,
+            0.0,
+            0,
+        );
+
+        assert_eq!(control.native_x_offset(control.diw_h_start(), 2), 16);
+        assert_eq!(fb[64], rgb12_to_rgba8(0x0000));
+        assert_eq!(fb[65], rgb12_to_rgba8(0x0000));
+        assert_eq!(&playfield_mask[64..66], &[0x02, 0x02]);
+    }
+
+    #[test]
     fn bplcon1_write_at_diw_right_edge_does_not_retap_current_ham_line() {
         let mut row_words = vec![vec![0; 1]; 6];
         row_words[0][0] |= 0x4000; // native x 1: direct palette entry 1
@@ -12270,6 +12325,55 @@ mod tests {
         assert_eq!(palette_segments[border_line][0].entry, 0);
         assert_eq!(palette_segments[border_line][0].value, 0x0103);
         assert_eq!(base_palettes[border_line + 1][0], 0x0103);
+    }
+
+    #[test]
+    fn color00_overscan_write_does_not_backfill_row_start() {
+        let mut state = blank_state();
+        state.palette.write_ocs(0, 0x0000);
+        state.diwstrt = ((PAL_VISIBLE_LINE0 as u16) << 8) | STANDARD_DIW_HSTART as u16;
+        state.diwstop = (((PAL_VISIBLE_LINE0 + 1) as u16) << 8) | STANDARD_DIW_HSTOP as u16;
+        let mut base_palettes = [state.palette; FB_HEIGHT];
+        let mut palette_segments = vec![Vec::new(); FB_HEIGHT];
+        let mut base_controls = [ControlState::from_render_state(&state); FB_HEIGHT];
+        let mut control_segments = vec![Vec::new(); FB_HEIGHT];
+        let mut manual_bpl_segments = Vec::new();
+        let beam_y = PAL_VISIBLE_LINE0 as u32;
+        let events = [
+            beam_event(beam_y, 68, 0x0180, 0x087A),
+            beam_event(beam_y, 76, 0x0180, 0x0000),
+        ];
+
+        apply_render_events(
+            &mut state,
+            &events,
+            &mut base_palettes,
+            &mut palette_segments,
+            &mut base_controls,
+            &mut control_segments,
+            &mut manual_bpl_segments,
+        );
+
+        assert_eq!(palette_segments[0][0].x, 60);
+        assert_eq!(palette_segments[0][0].value, 0x087A);
+        assert_eq!(palette_segments[0][1].x, 92);
+        assert_eq!(palette_segments[0][1].value, 0x0000);
+        assert_eq!(base_palettes[0][0], 0x0000);
+
+        let mut fb = vec![0; FB_PIXELS];
+        fill_background(
+            &mut fb,
+            &base_palettes,
+            &palette_segments,
+            &base_controls,
+            &control_segments,
+        );
+
+        assert_eq!(fb[0], rgb12_to_rgba8(0x0000));
+        assert_eq!(fb[59], rgb12_to_rgba8(0x0000));
+        assert_eq!(fb[60], rgb12_to_rgba8(0x087A));
+        assert_eq!(fb[91], rgb12_to_rgba8(0x087A));
+        assert_eq!(fb[92], rgb12_to_rgba8(0x0000));
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -2688,6 +2688,33 @@ fn line_fetch_plans_for_line(
     plans
 }
 
+fn bitplane_output_start_x(
+    base_control: ControlState,
+    control_segments: &[ControlSegment],
+    display_start_x: usize,
+    words_per_row: usize,
+    dma_planes: usize,
+) -> usize {
+    if dma_planes == 0 || words_per_row == 0 {
+        return 0;
+    }
+    let mut display_control = base_control;
+    for segment in control_segments {
+        if segment.x <= display_start_x {
+            display_control = segment.control;
+        }
+    }
+    let pixel_repeat = display_control.framebuffer_pixel_repeat();
+    if display_control.fetch_start_native_x(display_control.diw_h_start(), pixel_repeat) == 0 {
+        return 0;
+    }
+    line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes)
+        .iter()
+        .find_map(|(hpos, plane)| (plane == 0).then_some(beam_to_framebuffer_x_unclamped(hpos)))
+        .map(|x| x.clamp(0, FB_WIDTH as i32) as usize)
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 fn line_fetch_hpos_for_word(
     base_control: ControlState,
@@ -4699,6 +4726,13 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 &row_words[..nplanes],
                 fetched_pixels,
             );
+            let bpl_output_start_x = bitplane_output_start_x(
+                base_controls[y],
+                row_control_segments,
+                x_start,
+                words_per_row,
+                dma_planes.min(nplanes),
+            );
             let block_start = last_playfield_line != Some(y.wrapping_sub(1));
             last_playfield_line = Some(y);
             render_planned_playfield_line(
@@ -4715,6 +4749,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 control_segment_idx,
                 base_controls[y].bplcon1,
                 block_start,
+                bpl_output_start_x,
                 visible_line0,
                 input.emulated_seconds,
                 input.emulated_frames,
@@ -4965,6 +5000,7 @@ fn render_planned_playfield_line(
     mut control_segment_idx: usize,
     base_scroll_bplcon1: u16,
     suppress_prefetch_scroll_fill: bool,
+    bpl_output_start_x: usize,
     visible_line0: i32,
     emulated_seconds: f64,
     emulated_frames: u64,
@@ -5101,7 +5137,10 @@ fn render_planned_playfield_line(
             let visible_sample = line_visible
                 && (0..pixel_repeat).any(|dx| {
                     let pixel_x = x + dx;
-                    pixel_x < plan.x_stop && pixel_x >= win_x_start && pixel_x < win_x_stop
+                    pixel_x < plan.x_stop
+                        && pixel_x >= bpl_output_start_x
+                        && pixel_x >= win_x_start
+                        && pixel_x < win_x_stop
                 });
             if ham_mode {
                 let preroll_stop = native_x.min(plan.fetched_pixels);
@@ -7943,6 +7982,57 @@ mod tests {
         };
         assert_eq!(inset_fetch.fetch_start_native_x(false, 2), 14);
         assert_eq!(inset_fetch.native_x_offset(false, 2), 0);
+    }
+
+    #[test]
+    fn late_ddf_bitplane_output_waits_for_first_bpl1dat_fetch() {
+        let standard_ddf = ControlState {
+            dmacon: DMACON_DMAEN | DMACON_BPLEN,
+            bplcon0: 0x1000,
+            diwstrt: ((PAL_VISIBLE_LINE0 as u16) << 8) | STANDARD_DIW_HSTART as u16,
+            diwstop: (((PAL_VISIBLE_LINE0 + 1) as u16) << 8) | STANDARD_DIW_HSTOP as u16,
+            ddfstrt: 0x0038,
+            ddfstop: 0x00D0,
+            ..ControlState::default()
+        };
+        let standard_words =
+            standard_ddf.words_per_row(native_frame_width_for_control(standard_ddf));
+
+        assert_eq!(
+            bitplane_output_start_x(
+                standard_ddf,
+                &[],
+                standard_ddf.display_window_x().0,
+                standard_words,
+                standard_ddf.dma_planes(),
+            ),
+            0
+        );
+
+        let inset_ddf = ControlState {
+            ddfstrt: 0x0050,
+            ddfstop: 0x00D0,
+            ..standard_ddf
+        };
+        let inset_words = inset_ddf.words_per_row(native_frame_width_for_control(inset_ddf));
+        let first_bpl1dat_x =
+            beam_to_framebuffer_x_unclamped(bitplane_fetch_hpos_for_plane(inset_ddf, 0, 0))
+                .clamp(0, FB_WIDTH as i32) as usize;
+
+        assert_ne!(
+            inset_ddf.fetch_start_native_x(inset_ddf.diw_h_start(), 2),
+            0
+        );
+        assert_eq!(
+            bitplane_output_start_x(
+                inset_ddf,
+                &[],
+                inset_ddf.display_window_x().0,
+                inset_words,
+                inset_ddf.dma_planes(),
+            ),
+            first_bpl1dat_x
+        );
     }
 
     #[test]
@@ -11325,6 +11415,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,
@@ -11369,6 +11460,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,
@@ -11417,6 +11509,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,
@@ -11454,6 +11547,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,
@@ -11491,6 +11585,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,
@@ -11528,6 +11623,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,
@@ -11561,6 +11657,7 @@ mod tests {
             0,
             control.bplcon1,
             false,
+            0,
             PAL_VISIBLE_LINE0,
             0.0,
             0,

--- a/tests/vamiga_ts.rs
+++ b/tests/vamiga_ts.rs
@@ -154,7 +154,10 @@ fn run_case(
         .into());
     }
 
-    assert_png_dimensions(&png_path, 640, 480)?;
+    // Copperline presents at the fixed multisync geometry (716x537) rather than
+    // the old 640x480 framebuffer; a screenshot that is any other size means the
+    // presentation path changed shape.
+    assert_png_dimensions(&png_path, 716, 537)?;
     if let Some(baseline_root) = baseline_root {
         let mut expected = baseline_root.join(&case.rel_path);
         expected.set_extension("png");


### PR DESCRIPTION
## Summary
- model sprite DMA pointer/frontier carry across frame boundaries and avoid treating empty enabled sprite slots as observed DMA
- preserve latched sprite descriptor/data origins across POS/CTL and SPRxPT rewrites, including pending descriptor retargets before VSTART
- document the sprite timing, save-state reconstruction, and display-edge replay behavior covered by this branch

## Verification
- cargo build --release --locked
- cargo test --locked
- cargo fmt --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- visual save-state checks for the Copperline, bin-gen-x, Desire-Hamazing, and AGA regression scenes