### PR TITLE
Fix late display DMA and sprite replay timing

### DIFF
--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -49,6 +49,9 @@ timing).
 
 Sprite DMA retains its latched POS/CTL descriptor independently from the
 SPRxPT registers while a sprite data stream is active or waiting for VSTART.
+Standard PAL/NTSC hard vertical blank inhibits sprite DMA at the top of the
+field, so descriptor fetches are not replayed until PAL line $19 or NTSC line
+$14.
 If software rewrites SPRxPT on a later beam line while that descriptor is
 still pending, the retained POS/CTL stays latched and the new SPRxPT value
 retargets the descriptor's post-control data stream. A same-line rewrite

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -187,14 +187,16 @@ migration machinery; old states are simply invalidated.
 
 ## Snapshot point and atomicity
 
-The app-level contract is that states are taken between emulated frames:
-the window event loop and the headless timers both act only after
-`step_frame` returns, and `--save-state-after` fires at the first frame
-boundary past its deadline. Strictly, the serialized surface is complete
-enough that any inter-instruction point round-trips (the unit test saves
-mid-frame after arbitrary `step_slice` counts); the frame boundary is
-kept as the documented contract because it is what the calling code
-guarantees and it keeps presentation state trivially rebuildable.
+The app-level contract is that states are taken at presentation-quantum
+boundaries: the window event loop and the headless timers both act only
+after `step_frame` returns, and `--save-state-after` fires at the first
+quantum past its deadline. A quantum can land inside an emulated field, so
+the serialized surface must round-trip any inter-instruction point (the
+unit test saves mid-frame after arbitrary `step_slice` counts). When a load
+resumes anywhere other than the start of a field, the hardware state
+continues exactly from that beam position, but the renderer marks that
+partly reconstructed field non-presentable and waits for the next complete
+field before updating screenshots, frame dumps, or the window.
 
 `savestate::save` takes `&M68kMachine` and does not mutate emulated
 state. `savestate::load` parses fully before applying, then moves host

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -81,10 +81,14 @@ are detailed under [](#cpu-contention) below.
 ### Sprite DMA control rewrites
 
 Sprite DMA fetches POS/CTL at the fixed pair slots, then data words for
-the active line. Software can still rewrite SPRxPOS/SPRxCTL while a
-descriptor is pending or before a later pair slot to reposition an already
-active sprite on that scanline. Those writes update the live horizontal and
-vertical comparators, but they do not restart the sprite data stream: the
+the active line. Standard hard vertical blank suppresses those fetches until
+PAL line $19 or NTSC line $14, so frame-start SPRxPT writes made before that
+boundary still name a memory descriptor rather than retargeting a descriptor
+that could not yet have been fetched. Software can still rewrite
+SPRxPOS/SPRxCTL while a descriptor is pending or before a later pair slot to
+reposition an already active sprite on that scanline. Those writes update the
+live horizontal and vertical comparators, but they do not restart the sprite
+data stream: the
 data pointer stays with the descriptor that armed the sprite, and active
 row offsets remain relative to that descriptor. Copperline therefore keeps
 a runtime-only data-origin VSTART alongside the live comparator VSTART,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -717,6 +717,8 @@ pub struct Bus {
     current_frame_sprite_dma_observed: bool,
     last_frame_sprite_dma_observed: bool,
     current_frame_display_snapshot_taken: bool,
+    #[serde(skip)]
+    current_frame_render_blocked: bool,
     current_frame_visible_start_vpos: u32,
     last_frame_visible_start_vpos: u32,
     /// Display geometry latched at the frame wrap (standard fixed canvas
@@ -1799,6 +1801,7 @@ impl Bus {
             current_frame_sprite_dma_observed: false,
             last_frame_sprite_dma_observed: false,
             current_frame_display_snapshot_taken: false,
+            current_frame_render_blocked: false,
             current_frame_visible_start_vpos: RENDER_VISIBLE_START_VPOS,
             last_frame_visible_start_vpos: RENDER_VISIBLE_START_VPOS,
             current_frame_geometry: FrameGeometry::standard(RENDER_VISIBLE_START_VPOS, false),
@@ -2108,6 +2111,7 @@ impl Bus {
         self.current_frame_sprite_dma_observed = false;
         self.last_frame_sprite_dma_observed = false;
         self.current_frame_display_snapshot_taken = false;
+        self.current_frame_render_blocked = false;
         self.current_frame_visible_start_vpos = RENDER_VISIBLE_START_VPOS;
         self.last_frame_visible_start_vpos = RENDER_VISIBLE_START_VPOS;
         self.current_frame_geometry = FrameGeometry::standard(RENDER_VISIBLE_START_VPOS, false);
@@ -2256,6 +2260,8 @@ impl Bus {
         self.last_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
         self.current_frame_sprite_dma_observed = false;
         self.last_frame_sprite_dma_observed = false;
+        self.current_frame_render_blocked = self.agnus.vpos != 0 || self.agnus.hpos != 0;
+        self.sprite_dma_frame_start_ptr = self.display_dma_sprpt;
         self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
         self.current_frame_bus_trace.clear();
         self.last_frame_bus_trace = None;
@@ -3297,6 +3303,10 @@ impl Bus {
     pub fn frame_render_base(&self) -> RenderRegisterSnapshot {
         self.last_frame_render_base
             .unwrap_or(self.current_frame_render_base)
+    }
+
+    pub fn frame_render_available(&self) -> bool {
+        self.last_frame_render_base.is_some()
     }
 
     pub fn frame_visible_start_vpos(&self) -> u32 {
@@ -6800,10 +6810,17 @@ impl Bus {
         self.accumulate_live_collisions_to_frame_end();
         self.log_bus_accounting_frame();
         self.finish_frame_bus_trace();
-        self.last_frame_render_base = Some(self.current_frame_render_base);
-        self.last_frame_visible_start_vpos = self.current_frame_visible_start_vpos;
-        self.last_frame_geometry = self.current_frame_geometry;
-        self.last_frame_render_events = std::mem::take(&mut self.current_frame_render_events);
+        let promote_render_frame = !self.current_frame_render_blocked;
+        if promote_render_frame {
+            self.last_frame_render_base = Some(self.current_frame_render_base);
+            self.last_frame_visible_start_vpos = self.current_frame_visible_start_vpos;
+            self.last_frame_geometry = self.current_frame_geometry;
+            self.last_frame_render_events = std::mem::take(&mut self.current_frame_render_events);
+        } else {
+            self.last_frame_render_base = None;
+            self.last_frame_render_events.clear();
+            self.current_frame_render_events.clear();
+        }
         self.current_frame_collision_events.clear();
         self.current_frame_collision_control_events.clear();
         self.current_frame_collision_bpldat_events.clear();
@@ -6811,12 +6828,19 @@ impl Bus {
         self.current_frame_collision_control_index = None;
         self.current_frame_collision_bpldat_index = None;
         self.current_frame_collision_sprite_index = None;
-        self.last_frame_chip_ram_writes = std::mem::take(&mut self.current_frame_chip_ram_writes);
-        self.last_frame_beam_top_palette = self.current_frame_beam_top_palette;
-        self.last_frame_beam_top_palette_end = self.beam_top_palette;
-        self.last_frame_beam_bottom_palette = self.beam_bottom_palette;
-        self.last_frame_beam_bottom_palette_valid = self.beam_bottom_palette_valid;
-        self.last_frame_beam_bottom_palette_events = self.beam_bottom_palette_events.clone();
+        if promote_render_frame {
+            self.last_frame_chip_ram_writes =
+                std::mem::take(&mut self.current_frame_chip_ram_writes);
+            self.last_frame_beam_top_palette = self.current_frame_beam_top_palette;
+            self.last_frame_beam_top_palette_end = self.beam_top_palette;
+            self.last_frame_beam_bottom_palette = self.beam_bottom_palette;
+            self.last_frame_beam_bottom_palette_valid = self.beam_bottom_palette_valid;
+            self.last_frame_beam_bottom_palette_events = self.beam_bottom_palette_events.clone();
+        } else {
+            self.last_frame_chip_ram_writes.clear();
+            self.current_frame_chip_ram_writes.clear();
+            self.last_frame_beam_bottom_palette_events.clear();
+        }
         // Promote the just-finished frame's chip-RAM snapshot to `last` by
         // swapping buffers instead of copying 2 MB. `capture_current_frame_
         // display_start` already filled `current_frame_chip_ram` for any frame
@@ -6824,31 +6848,55 @@ impl Bus {
         // recycle the old `last` buffer as the next `current`. A frame that
         // never displayed (no capture taken) has no meaningful snapshot, so
         // fall back to a live copy for the renderer's blank/border output.
-        if self.current_frame_display_snapshot_taken
+        if promote_render_frame
+            && self.current_frame_display_snapshot_taken
             && self.current_frame_chip_ram.len() == self.mem.chip_ram.len()
         {
             std::mem::swap(
                 &mut self.last_frame_chip_ram,
                 &mut self.current_frame_chip_ram,
             );
-        } else {
+        } else if promote_render_frame {
             self.last_frame_chip_ram.clear();
             self.last_frame_chip_ram
                 .extend_from_slice(&self.mem.chip_ram);
+        } else {
+            self.last_frame_chip_ram.clear();
         }
-        self.last_frame_bitplane_rows = std::mem::replace(
+        let current_bitplane_rows = std::mem::replace(
             &mut self.current_frame_bitplane_rows,
             empty_captured_bitplane_rows(),
         );
-        self.last_frame_sprite_lines = std::mem::take(&mut self.current_frame_sprite_lines);
-        self.last_frame_held_sprites = std::mem::take(&mut self.current_frame_held_sprites);
+        self.last_frame_bitplane_rows = if promote_render_frame {
+            current_bitplane_rows
+        } else {
+            empty_captured_bitplane_rows()
+        };
+        self.last_frame_sprite_lines = if promote_render_frame {
+            std::mem::take(&mut self.current_frame_sprite_lines)
+        } else {
+            self.current_frame_sprite_lines.clear();
+            Vec::new()
+        };
+        self.last_frame_held_sprites = if promote_render_frame {
+            std::mem::take(&mut self.current_frame_held_sprites)
+        } else {
+            self.current_frame_held_sprites = [None; 8];
+            [None; 8]
+        };
         clear_captured_sprite_lines_by_y(&mut self.current_frame_sprite_lines_by_y);
         self.current_frame_sprite_collision_sources = empty_sprite_collision_sources();
-        self.last_frame_sprite_display_enable_x_by_y = std::mem::replace(
+        let current_sprite_display_enable_x_by_y = std::mem::replace(
             &mut self.current_frame_sprite_display_enable_x_by_y,
             empty_sprite_display_enable_x_by_y(),
         );
-        self.last_frame_sprite_dma_observed = self.current_frame_sprite_dma_observed;
+        self.last_frame_sprite_display_enable_x_by_y = if promote_render_frame {
+            current_sprite_display_enable_x_by_y
+        } else {
+            empty_sprite_display_enable_x_by_y()
+        };
+        self.last_frame_sprite_dma_observed =
+            promote_render_frame && self.current_frame_sprite_dma_observed;
         self.current_frame_sprite_dma_observed = false;
         // The next frame's snapshot is taken lazily at its display start
         // (`capture_current_frame_display_start`), which clears and refills
@@ -6858,6 +6906,7 @@ impl Bus {
         self.current_frame_chip_ram.clear();
         self.current_frame_beam_top_palette = self.beam_top_palette;
         self.current_frame_display_snapshot_taken = false;
+        self.current_frame_render_blocked = false;
         self.current_frame_visible_start_vpos = RENDER_VISIBLE_START_VPOS;
         self.current_frame_render_base = self.capture_render_snapshot();
         // Carry each sprite channel's DMA pointer across the frame boundary the
@@ -6922,9 +6971,11 @@ impl Bus {
             .extend_from_slice(&self.mem.chip_ram);
         self.current_frame_beam_top_palette = self.beam_top_palette;
         self.current_frame_display_snapshot_taken = true;
-        self.advance_display_dma_for_clipped_rows();
-        self.advance_sprite_dma_to_visible_start();
-        self.capture_held_sprites_for_visible_window();
+        if !self.current_frame_render_blocked {
+            self.advance_display_dma_for_clipped_rows();
+            self.advance_sprite_dma_to_visible_start();
+            self.capture_held_sprites_for_visible_window();
+        }
     }
 
     /// After the offscreen sprite-DMA replay, snapshot any sprite that has
@@ -6993,9 +7044,17 @@ impl Bus {
         }
         let state = self.display_dma_sprite_state[sprite];
         if let Some(control) = state.control {
+            let pending_descriptor_not_loaded = state.control_loaded_vpos >= vpos as i32
+                || vpos < self.current_frame_visible_start_vpos
+                || (state.control_loaded_vpos == unset_sprite_control_loaded_vpos()
+                    && (vpos as i32) < control.vstart);
             if !state.data_dma_active
                 && !control.data_origin_is_register_stream()
-                && state.control_loaded_vpos == vpos as i32
+                // The descriptor must have loaded earlier in this field before
+                // SPRxPT can retarget its data stream. Equal/later, pre-visible
+                // replay reloads, or an unknown save-state value before VSTART
+                // restart POS/CTL.
+                && pending_descriptor_not_loaded
             {
                 self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState::default();
                 return;
@@ -7029,7 +7088,27 @@ impl Bus {
         // display area and the channel's descriptor fetch slot for this line
         // has already passed. Frame-start/top-border SPRxPT reloads are normal
         // descriptor setup and must not resurrect stale armed register data.
+        if !display_window_contains_vpos(
+            self.denise.diwstrt,
+            self.denise.diwstop,
+            self.effective_diwhigh(),
+            vpos,
+        ) {
+            return false;
+        }
+
+        let beam_y = vpos as i32;
+        let vstart =
+            sprite_vstart_from_words(self.denise.sprpos[sprite], self.denise.sprctl[sprite]);
+        let raw_vstop = sprite_vstop_from_ctl(self.denise.sprctl[sprite]);
+        let vstop = if raw_vstop < vstart {
+            self.agnus.current_frame_lines() as i32
+        } else {
+            raw_vstop
+        };
         vpos >= self.current_frame_visible_start_vpos
+            && beam_y >= vstart
+            && beam_y < vstop
             && hpos >= SPRITE_DMA_PAIR_CAPTURE_HPOS[sprite / 2]
     }
 
@@ -15337,10 +15416,58 @@ mod tests {
     }
 
     #[test]
+    fn armed_pointer_reload_before_vstart_fetches_descriptor_words() {
+        let mut bus = empty_bus();
+        let sprite_ptr = 0x0200usize;
+        let (pos, ctl) = sprite_control_words(0x40, 0x42, 0x0101);
+        write_chip_word(&mut bus, sprite_ptr, pos);
+        write_chip_word(&mut bus, sprite_ptr + 2, ctl);
+        write_chip_word(&mut bus, sprite_ptr + 4, 0xAAAA);
+        write_chip_word(&mut bus, sprite_ptr + 6, 0xBBBB);
+
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.denise.diwstrt = (0x2C << 8) | 0x0081;
+        bus.denise.diwstop = (0x80 << 8) | 0x00C1;
+        bus.denise.sprpos[0] = pos;
+        bus.denise.sprctl[0] = ctl;
+        bus.denise.spr_armed[0] = true;
+        bus.display_dma_sprite_state[0] = DisplaySpriteDmaState {
+            control: Some(DisplaySpriteControl {
+                vstart: 0x40,
+                vstop: 0x42,
+                hstart: 0x0101,
+                hsub_70ns: false,
+                data_vstart: 0x40,
+                data_base: 0x0100,
+                next_ptr: 0x0108,
+                attached: false,
+            }),
+            control_loaded_vpos: super::unset_sprite_control_loaded_vpos(),
+            ..DisplaySpriteDmaState::default()
+        };
+
+        bus.agnus.vpos = 0x24;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0];
+        let _ =
+            bus.write_custom_word_from(0x120, (sprite_ptr >> 16) as u16, BeamWriteSource::Copper);
+        let _ = bus.write_custom_word_from(0x122, sprite_ptr as u16, BeamWriteSource::Copper);
+
+        bus.agnus.vpos = 0x40;
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].hstart, 0x0101);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+    }
+
+    #[test]
     fn after_slot_armed_sprite_pointer_write_seeds_dma_data_stream() {
         let mut bus = empty_bus();
         let data_ptr = 0x0300usize;
-        let (pos, ctl) = sprite_control_words(0x00, 0x00, 0x0101);
+        let (pos, ctl) = sprite_control_words(0x40, 0x44, 0x0101);
         write_chip_word(&mut bus, data_ptr, 0xAAAA);
         write_chip_word(&mut bus, data_ptr + 2, 0xBBBB);
 
@@ -15940,6 +16067,7 @@ mod tests {
         bus.reset_transient_video_after_state_load();
 
         assert!(bus.last_frame_render_base.is_none());
+        assert!(!bus.current_frame_render_blocked);
         assert!(bus.last_frame_render_events.is_empty());
         assert_eq!(bus.current_frame_chip_ram, bus.mem.chip_ram);
         assert!(bus.last_frame_chip_ram.is_empty());
@@ -15956,6 +16084,77 @@ mod tests {
             assert!(!state.data_dma_active);
             assert!(state.last_line.is_none());
         }
+    }
+
+    #[test]
+    fn state_load_after_display_start_suppresses_partial_render_frame() {
+        let mut bus = empty_bus();
+        bus.agnus.vpos = RENDER_VISIBLE_START_VPOS + 20;
+        bus.current_frame_render_base = RenderRegisterSnapshot {
+            bplcon0: 0x1200,
+            ..RenderRegisterSnapshot::default()
+        };
+        bus.current_frame_render_events.push(BeamRegisterWrite {
+            vpos: RENDER_VISIBLE_START_VPOS + 20,
+            hpos: 0x40,
+            offset: 0x180,
+            value: 0x0FFF,
+            source: BeamWriteSource::Copper,
+        });
+        bus.current_frame_bitplane_rows[0] = Some(CapturedBitplaneRow {
+            nplanes: 1,
+            words_per_row: 1,
+            planes: std::array::from_fn(|_| vec![0xFFFF]),
+        });
+        bus.current_frame_sprite_lines.push(CapturedSpriteLine {
+            sprite: 0,
+            hstart: 0x80,
+            hsub_70ns: false,
+            beam_y: RENDER_VISIBLE_START_VPOS as i32 + 20,
+            data: 0x1111,
+            datb: 0x2222,
+            data_ext: [0; 3],
+            datb_ext: [0; 3],
+            width_words: 1,
+            attached: false,
+        });
+
+        bus.reset_transient_video_after_state_load();
+        assert!(bus.current_frame_render_blocked);
+
+        bus.current_frame_render_events.push(BeamRegisterWrite {
+            vpos: RENDER_VISIBLE_START_VPOS + 21,
+            hpos: 0x40,
+            offset: 0x180,
+            value: 0x00F0,
+            source: BeamWriteSource::Copper,
+        });
+        bus.current_frame_bitplane_rows[0] = Some(CapturedBitplaneRow {
+            nplanes: 1,
+            words_per_row: 1,
+            planes: std::array::from_fn(|_| vec![0xAAAA]),
+        });
+        bus.current_frame_sprite_lines.push(CapturedSpriteLine {
+            sprite: 1,
+            hstart: 0x90,
+            hsub_70ns: false,
+            beam_y: RENDER_VISIBLE_START_VPOS as i32 + 21,
+            data: 0x3333,
+            datb: 0x4444,
+            data_ext: [0; 3],
+            datb_ext: [0; 3],
+            width_words: 1,
+            attached: false,
+        });
+
+        bus.begin_new_beam_frame();
+
+        assert!(!bus.frame_render_available());
+        assert!(!bus.current_frame_render_blocked);
+        assert!(bus.last_frame_render_base.is_none());
+        assert!(bus.last_frame_render_events.is_empty());
+        assert!(bus.last_frame_bitplane_rows.iter().all(Option::is_none));
+        assert!(bus.last_frame_sprite_lines.is_empty());
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -225,6 +225,8 @@ const COPPER_BUS_LOCKOUT_HPOS: u32 = 0x00E1;
 const COPER_CPU_IRQ_DELAY_CCK: u32 = 2;
 const RENDER_VISIBLE_START_VPOS: u32 = 0x2C;
 const RENDER_MIN_OVERSCAN_START_VPOS: u32 = 0x1C;
+const PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS: u32 = 0x19;
+const NTSC_SPRITE_DMA_FIRST_ACTIVE_VPOS: u32 = 0x14;
 const RENDER_VISIBLE_LINES: usize = FB_HEIGHT;
 const RENDER_FRAMEBUFFER_WIDTH: i32 = FB_WIDTH as i32;
 // Capture-side twin of `bitplane::DIW_HSTART_FB0`; held 8 colour clocks (16
@@ -7045,15 +7047,13 @@ impl Bus {
         let state = self.display_dma_sprite_state[sprite];
         if let Some(control) = state.control {
             let pending_descriptor_not_loaded = state.control_loaded_vpos >= vpos as i32
-                || vpos < self.current_frame_visible_start_vpos
                 || (state.control_loaded_vpos == unset_sprite_control_loaded_vpos()
                     && (vpos as i32) < control.vstart);
             if !state.data_dma_active
                 && !control.data_origin_is_register_stream()
                 // The descriptor must have loaded earlier in this field before
-                // SPRxPT can retarget its data stream. Equal/later, pre-visible
-                // replay reloads, or an unknown save-state value before VSTART
-                // restart POS/CTL.
+                // SPRxPT can retarget its data stream. Equal/later loads or an
+                // unknown save-state value before VSTART restart POS/CTL.
                 && pending_descriptor_not_loaded
             {
                 self.display_dma_sprite_state[sprite] = DisplaySpriteDmaState::default();
@@ -7543,6 +7543,9 @@ impl Bus {
                 if dmacon & (DMACON_DMAEN | DMACON_SPREN) != (DMACON_DMAEN | DMACON_SPREN) {
                     continue;
                 }
+                if self.sprite_dma_inhibited_by_vertical_blank_at(vpos) {
+                    continue;
+                }
                 for sprite in pair * 2..pair * 2 + 2 {
                     if sprite_dma_disabled_by_bitplane_ddf(
                         sprite,
@@ -7604,12 +7607,19 @@ impl Bus {
         }
     }
 
+    fn sprite_dma_inhibited_by_vertical_blank_at(&self, vpos: u32) -> bool {
+        vpos < sprite_dma_first_active_vpos(self.agnus.video_standard())
+    }
+
     fn capture_sprite_dma_words_if_due(&mut self, vpos: u32, old_hpos: u32, new_hpos: u32) {
         // No sprite DMA pair slot lies in [old_hpos, new_hpos): nothing below
         // can run (the per-pair loop checks the same window), so skip the
         // sprite-state scan on the vast majority of beam advances.
         if old_hpos > SPRITE_DMA_PAIR_CAPTURE_HPOS[3] || new_hpos <= SPRITE_DMA_PAIR_CAPTURE_HPOS[0]
         {
+            return;
+        }
+        if self.sprite_dma_inhibited_by_vertical_blank_at(vpos) {
             return;
         }
         let sprite_dma_enabled =
@@ -8741,6 +8751,16 @@ fn copper_frame_start_vpos(_video_standard: VideoStandard) -> u32 {
     // lines, collapsing the CPU's pre-display work margin. Restarting at line 0
     // restores the margin real hardware gives before early display DMA fetches.
     0
+}
+
+fn sprite_dma_first_active_vpos(video_standard: VideoStandard) -> u32 {
+    // Hard vertical blank inhibits sprite DMA near the top of a standard
+    // field. The first line after that blank is one line earlier than bitplane
+    // DMA: PAL line $19 and NTSC line $14.
+    match video_standard {
+        VideoStandard::Pal => PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS,
+        VideoStandard::Ntsc => NTSC_SPRITE_DMA_FIRST_ACTIVE_VPOS,
+    }
 }
 
 fn next_chip_bus_quantum_at(hpos: u32, line_cck: u32) -> u32 {
@@ -10655,8 +10675,9 @@ mod tests {
         RenderRegisterSnapshot, BLITTER_SLOWDOWN_CPU_MISS_LIMIT, BLTCON1_DOFF, BPLCON0_ECSENA,
         BPLCON3_BRDSPRT, BPLCON3_SPRES_HIRES, COPPER_BUS_LOCKOUT_HPOS, DENISE_HPOS_LAG_CCK,
         DMACON_AUD_MASK, DMACON_BLTEN, DMACON_BLTPRI, DMACON_BPLEN, DMACON_SPREN,
-        RENDER_COPPER_WAIT_HPOS_FB0, RENDER_DIW_HSTART_FB0, RENDER_MIN_OVERSCAN_START_VPOS,
-        RENDER_VISIBLE_LINES, RENDER_VISIBLE_START_VPOS, SPRITE_DMA_PAIR_CAPTURE_HPOS,
+        PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS, RENDER_COPPER_WAIT_HPOS_FB0, RENDER_DIW_HSTART_FB0,
+        RENDER_MIN_OVERSCAN_START_VPOS, RENDER_VISIBLE_LINES, RENDER_VISIBLE_START_VPOS,
+        SPRITE_DMA_PAIR_CAPTURE_HPOS,
     };
     use crate::audio::AudioSink;
     use crate::chipset::agnus::{
@@ -15279,6 +15300,95 @@ mod tests {
         assert_eq!(lines[0].sprite, 0);
         assert_eq!(lines[0].beam_y, 0x2C);
         assert_eq!(lines[0].hstart, 0x00A1);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+    }
+
+    #[test]
+    fn vertical_blank_sprite_pointer_write_reloads_descriptor_in_offscreen_replay() {
+        let mut bus = empty_bus();
+        let old_ptr = 0x0100usize;
+        let new_ptr = 0x0200usize;
+        let (old_pos, old_ctl) = sprite_control_words(0x2C, 0x30, 0x0083);
+        let (new_pos, new_ctl) = sprite_control_words(0x2C, 0x30, 0x00A1);
+        write_chip_word(&mut bus, old_ptr, old_pos);
+        write_chip_word(&mut bus, old_ptr + 2, old_ctl);
+        write_chip_word(&mut bus, old_ptr + 4, 0x1111);
+        write_chip_word(&mut bus, old_ptr + 6, 0x2222);
+        write_chip_word(&mut bus, new_ptr, new_pos);
+        write_chip_word(&mut bus, new_ptr + 2, new_ctl);
+        write_chip_word(&mut bus, new_ptr + 4, 0xAAAA);
+        write_chip_word(&mut bus, new_ptr + 6, 0xBBBB);
+
+        bus.current_frame_render_base.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.sprite_dma_frame_start_ptr[0] = old_ptr as u32;
+        bus.current_frame_render_events.push(BeamRegisterWrite {
+            vpos: PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS - 1,
+            hpos: 0,
+            offset: 0x120,
+            value: (new_ptr >> 16) as u16,
+            source: BeamWriteSource::Copper,
+        });
+        bus.current_frame_render_events.push(BeamRegisterWrite {
+            vpos: PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS - 1,
+            hpos: 0x0A,
+            offset: 0x122,
+            value: new_ptr as u16,
+            source: BeamWriteSource::Copper,
+        });
+
+        bus.agnus.vpos = RENDER_VISIBLE_START_VPOS;
+        bus.capture_current_frame_display_start();
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].hstart, 0x00A1);
+        assert_eq!(lines[0].data, 0xAAAA);
+        assert_eq!(lines[0].datb, 0xBBBB);
+    }
+
+    #[test]
+    fn post_vertical_blank_sprite_pointer_write_retargets_pending_descriptor() {
+        let mut bus = empty_bus();
+        let descriptor_ptr = 0x0100usize;
+        let data_ptr = 0x0200usize;
+        let (pos, ctl) = sprite_control_words(0x2C, 0x30, 0x0083);
+        write_chip_word(&mut bus, descriptor_ptr, pos);
+        write_chip_word(&mut bus, descriptor_ptr + 2, ctl);
+        write_chip_word(&mut bus, descriptor_ptr + 4, 0x1111);
+        write_chip_word(&mut bus, descriptor_ptr + 6, 0x2222);
+        write_chip_word(&mut bus, data_ptr, 0xAAAA);
+        write_chip_word(&mut bus, data_ptr + 2, 0xBBBB);
+
+        bus.current_frame_render_base.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_SPREN;
+        bus.sprite_dma_frame_start_ptr[0] = descriptor_ptr as u32;
+        bus.current_frame_render_events.push(BeamRegisterWrite {
+            vpos: PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS + 11,
+            hpos: SPRITE_DMA_PAIR_CAPTURE_HPOS[0],
+            offset: 0x120,
+            value: (data_ptr >> 16) as u16,
+            source: BeamWriteSource::Copper,
+        });
+        bus.current_frame_render_events.push(BeamRegisterWrite {
+            vpos: PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS + 11,
+            hpos: SPRITE_DMA_PAIR_CAPTURE_HPOS[0] + 2,
+            offset: 0x122,
+            value: data_ptr as u16,
+            source: BeamWriteSource::Copper,
+        });
+
+        bus.agnus.vpos = RENDER_VISIBLE_START_VPOS;
+        bus.capture_current_frame_display_start();
+        bus.agnus.hpos = SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1;
+        bus.advance_chipset(2);
+
+        let lines = bus.frame_captured_sprite_lines();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].hstart, 0x0083);
         assert_eq!(lines[0].data, 0xAAAA);
         assert_eq!(lines[0].datb, 0xBBBB);
     }

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1082,6 +1082,7 @@ struct DenisePlannedPlayfieldLine<'a> {
     plane_words: &'a [Vec<u16>],
     fetched_pixels: usize,
     carry_words: [Option<u16>; 8],
+    first_word_plane_start_x: [usize; 8],
 }
 
 impl<'a> DenisePlannedPlayfieldLine<'a> {
@@ -1099,11 +1100,17 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             plane_words,
             fetched_pixels,
             carry_words: [None; 8],
+            first_word_plane_start_x: [0; 8],
         }
     }
 
     fn with_carry_words(mut self, carry_words: [Option<u16>; 8]) -> Self {
         self.carry_words = carry_words;
+        self
+    }
+
+    fn with_first_word_plane_start_x(mut self, start_x: [usize; 8]) -> Self {
+        self.first_word_plane_start_x = start_x;
         self
     }
 
@@ -1156,6 +1163,17 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             let fetch_x = native_x - delay;
             if fetch_x < min_fetch_x {
                 active = true;
+                continue;
+            }
+            if fetch_x < 16 && fetch_x < self.first_word_plane_start_x[plane] {
+                active = true;
+                let carry_offset = self.first_word_plane_start_x[plane] - fetch_x;
+                if carry_offset <= 16 {
+                    let bit = carry_offset - 1;
+                    if self.carry_words[plane].is_some_and(|word| word & (1 << bit) != 0) {
+                        idx |= 1 << plane;
+                    }
+                }
                 continue;
             }
             if fetch_x >= self.fetched_pixels {
@@ -2749,6 +2767,51 @@ fn bitplane_dma_output_start_x(
                 .find_map(|(hpos, plane)| (plane == 0).then_some(hpos))
         })
         .map(bitplane_fetch_framebuffer_x)
+}
+
+fn first_word_plane_start_x(
+    base_control: ControlState,
+    control_segments: &[ControlSegment],
+    display_start_x: usize,
+    words_per_row: usize,
+    dma_planes: usize,
+) -> [usize; 8] {
+    if dma_planes == 0 || words_per_row == 0 {
+        return [0; 8];
+    }
+    let mut display_control = base_control;
+    for segment in control_segments {
+        if segment.x <= display_start_x {
+            display_control = segment.control;
+        }
+    }
+    let pixel_repeat = display_control.framebuffer_pixel_repeat();
+    let native_per_pixel = display_control.native_samples_per_framebuffer_pixel();
+    let fetch_start_native_x =
+        display_control.fetch_start_native_x(display_control.diw_h_start(), pixel_repeat);
+    if fetch_start_native_x == 0 {
+        return [0; 8];
+    }
+    let native_x_offset =
+        display_control.native_x_offset(display_control.diw_h_start(), pixel_repeat);
+    let framebuffer_x_to_fetch_x = |x: usize| -> usize {
+        let output_native_x = x
+            .saturating_sub(display_start_x)
+            .saturating_div(pixel_repeat)
+            .saturating_mul(native_per_pixel);
+        output_native_x
+            .saturating_sub(fetch_start_native_x)
+            .saturating_add(native_x_offset)
+    };
+
+    let mut start_x = [0; 8];
+    let plan = line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes);
+    for (hpos, plane) in plan.iter() {
+        if plane < start_x.len() {
+            start_x[plane] = framebuffer_x_to_fetch_x(bitplane_fetch_framebuffer_x(hpos));
+        }
+    }
+    start_x
 }
 
 fn bitplane_carry_words_for_line(
@@ -4793,6 +4856,13 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 dma_output_start_x,
                 previous_playfield_tail_words,
             );
+            let first_word_plane_start_x = first_word_plane_start_x(
+                base_controls[y],
+                row_control_segments,
+                x_start,
+                words_per_row,
+                dma_planes.min(nplanes),
+            );
             let line_plan = DenisePlannedPlayfieldLine::new(
                 y,
                 x_start,
@@ -4800,7 +4870,8 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 &row_words[..nplanes],
                 fetched_pixels,
             )
-            .with_carry_words(carry_words);
+            .with_carry_words(carry_words)
+            .with_first_word_plane_start_x(first_word_plane_start_x);
             let bpl_output_start_x = dma_output_start_x.unwrap_or(0);
             dma_output_start_x_by_line[y] = dma_output_start_x;
             last_playfield_line = Some(y);
@@ -8121,6 +8192,27 @@ mod tests {
             ),
             first_word_x
         );
+    }
+
+    #[test]
+    fn late_ddf_waits_for_each_planes_first_fetch_slot() {
+        let control = ControlState {
+            bplcon0: 0x1000,
+            ..ControlState::default()
+        };
+        let plane_words = [vec![0x0800]];
+        let mut carry_words = [None; 8];
+        carry_words[0] = Some(0x0001);
+        let mut first_word_plane_start_x = [0; 8];
+        first_word_plane_start_x[0] = 4;
+
+        let line = DenisePlannedPlayfieldLine::new(0, 0, 64, &plane_words, 16)
+            .with_carry_words(carry_words)
+            .with_first_word_plane_start_x(first_word_plane_start_x);
+
+        assert_eq!(line.sample(control, 2).idx, 0);
+        assert_eq!(line.sample(control, 3).idx, 1);
+        assert_eq!(line.sample(control, 4).idx, 1);
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -2742,9 +2742,13 @@ fn bitplane_dma_output_start_x(
     if display_control.fetch_start_native_x(display_control.diw_h_start(), pixel_repeat) == 0 {
         return Some(display_start_x);
     }
-    line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes)
-        .iter()
-        .find_map(|(hpos, plane)| (plane == 0).then_some(bitplane_fetch_framebuffer_x(hpos)))
+    let plan = line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes);
+    plan.word_fetch_hpos
+        .or_else(|| {
+            plan.iter()
+                .find_map(|(hpos, plane)| (plane == 0).then_some(hpos))
+        })
+        .map(bitplane_fetch_framebuffer_x)
 }
 
 fn bitplane_carry_words_for_line(
@@ -8064,7 +8068,7 @@ mod tests {
     }
 
     #[test]
-    fn late_ddf_bitplane_output_waits_for_first_bpl1dat_fetch() {
+    fn late_ddf_bitplane_output_starts_at_first_word_fetch() {
         let standard_ddf = ControlState {
             dmacon: DMACON_DMAEN | DMACON_BPLEN,
             bplcon0: 0x1000,
@@ -8094,6 +8098,11 @@ mod tests {
             ..standard_ddf
         };
         let inset_words = inset_ddf.words_per_row(native_frame_width_for_control(inset_ddf));
+        let first_word_x = bitplane_fetch_framebuffer_x(
+            line_fetch_plan_for_word(inset_ddf, &[], 0, inset_ddf.dma_planes())
+                .word_fetch_hpos
+                .unwrap(),
+        );
         let first_bpl1dat_x =
             bitplane_fetch_framebuffer_x(bitplane_fetch_hpos_for_plane(inset_ddf, 0, 0));
 
@@ -8101,6 +8110,7 @@ mod tests {
             inset_ddf.fetch_start_native_x(inset_ddf.diw_h_start(), 2),
             0
         );
+        assert!(first_word_x < first_bpl1dat_x);
         assert_eq!(
             bitplane_output_start_x(
                 inset_ddf,
@@ -8109,7 +8119,7 @@ mod tests {
                 inset_words,
                 inset_ddf.dma_planes(),
             ),
-            first_bpl1dat_x
+            first_word_x
         );
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1741,7 +1741,12 @@ impl ApplicationHandler for App {
         }
         if let Some((secs, path)) = self.auto_shot.take() {
             if self.emu.bus().emulated_seconds() >= secs as f64 {
+                let emulated_frame = self.emu.bus().emulated_frames();
                 self.finish_render_for_current_frame();
+                if self.last_rendered_emulated_frame != Some(emulated_frame) {
+                    self.auto_shot = Some((secs, path));
+                    return;
+                }
                 self.save_screenshot(&path);
                 self.emu.report_stats();
                 self.emu.bus().poll_stats.dump_top("at screenshot");
@@ -6745,6 +6750,9 @@ impl App {
             return false;
         }
         self.finish_render_for_current_frame();
+        if self.last_rendered_emulated_frame != Some(emulated_frame) {
+            return false;
+        }
 
         let Some(state) = self.frame_dump.as_mut() else {
             return false;
@@ -6968,6 +6976,9 @@ impl App {
         if !self.powered_on {
             return false;
         }
+        if !self.emu.bus().frame_render_available() {
+            return false;
+        }
         let target = self.emu.bus().emulated_frames();
         let mut rendered = self.render_emulated_frame_if_needed();
         while self.render_worker.is_some() && self.last_rendered_emulated_frame != Some(target) {
@@ -6977,6 +6988,9 @@ impl App {
     }
 
     fn render_emulated_frame_if_needed(&mut self) -> bool {
+        if !self.emu.bus().frame_render_available() {
+            return false;
+        }
         if self.render_worker.is_some() {
             return self.render_emulated_frame_threaded();
         }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8856,19 +8856,44 @@ mod tests {
             "copperline-app-recording-{}.avi",
             std::process::id()
         ));
-        app.start_recording_to(path.clone());
-        assert!(app.recorder.is_some(), "recorder should be active");
-
-        let frames_to_record = 5;
-        for _ in 0..frames_to_record {
+        for warmup_step in 0..4 {
             app.emu.step_frame().expect("step frame");
             let rendered = if app.render_worker.is_some() {
                 app.finish_render_for_current_frame()
             } else {
                 app.render_emulated_frame_if_needed()
             };
-            assert!(rendered, "each step quantum should complete a frame");
+            if rendered {
+                break;
+            }
+            assert!(
+                warmup_step < 3,
+                "fixture should produce an initial renderable frame"
+            );
+        }
+
+        app.start_recording_to(path.clone());
+        assert!(app.recorder.is_some(), "recorder should be active");
+
+        let frames_to_record = 5;
+        let mut rendered_frames = 0;
+        let mut step_quanta = 0;
+        while rendered_frames < frames_to_record {
+            app.emu.step_frame().expect("step frame");
+            let rendered = if app.render_worker.is_some() {
+                app.finish_render_for_current_frame()
+            } else {
+                app.render_emulated_frame_if_needed()
+            };
             app.capture_recorder_output(rendered);
+            if rendered {
+                rendered_frames += 1;
+            }
+            step_quanta += 1;
+            assert!(
+                step_quanta <= frames_to_record * 2,
+                "fixture should keep producing renderable frames"
+            );
         }
         app.stop_recording();
         assert!(app.recorder.is_none());


### PR DESCRIPTION
## Summary
- start late bitplane output from the first fetched word group instead of the nominal DDF start
- suppress partial restored-frame rendering until a completed display DMA frame is available
- model standard hard-vblank sprite DMA inhibition so early SPRxPT writes seed descriptors while later pre-visible writes can still retarget pending descriptor data

## Verification
- cargo fmt --check
- git diff --check
- cargo test --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo build --release --locked
- headless frame dumps for the reported copperline save-state regressions