### PR TITLE
Performance and audio fixes: lazy collision scans, config-screen state-load audio

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -69,6 +69,13 @@ pub trait AudioSink {
     fn runtime_status(&self) -> AudioRuntimeStatus {
         AudioRuntimeStatus::default()
     }
+    /// True only for the no-op sink that discards every sample (`NullSink`).
+    /// The configuration screen runs on a silent placeholder machine using this
+    /// sink; loading a state over that machine detects it here so the restored
+    /// machine can be given a real host output instead of staying silent.
+    fn is_null_sink(&self) -> bool {
+        false
+    }
 }
 
 pub fn audio_profile_enabled() -> bool {
@@ -85,6 +92,9 @@ pub struct NullSink;
 impl AudioSink for NullSink {
     fn push(&mut self, _left: f32, _right: f32) {}
     fn flush(&mut self) {}
+    fn is_null_sink(&self) -> bool {
+        true
+    }
 }
 
 // -----------------------------------------------------------------

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -729,6 +729,19 @@ pub struct Bus {
     last_frame_geometry: FrameGeometry,
     lazy_collision_vpos: u32,
     lazy_collision_hpos: u32,
+    /// Sticky gate for the per-frame collision accumulation. Collision results
+    /// are observable only through a CLXDAT read ($DFF00E); software that never
+    /// reads CLXDAT cannot tell whether the latch was maintained. The full-frame
+    /// collision scan in `begin_new_beam_frame` (`accumulate_live_collisions_to_
+    /// frame_end`) is ~37% of emulation time on a busy demo, so skip it entirely
+    /// until the first CLXDAT read. From that read onward this stays true and the
+    /// per-frame flush runs exactly as before, so any software that actually uses
+    /// collisions is bit-identical. Not serialized: a restored state restarts in
+    /// the skipping state and re-arms on the next CLXDAT read (the latch carries
+    /// the current frame's collisions, which is all real collision code relies
+    /// on; cross-frame historical-OR of an unread latch is not meaningful).
+    #[serde(skip)]
+    collision_tracking_active: bool,
     cpu_bus_arbitration_enabled: bool,
     cpu_granted_chip_slots: u64,
     cpu_missed_chip_slots: u64,
@@ -1810,6 +1823,7 @@ impl Bus {
             last_frame_geometry: FrameGeometry::standard(RENDER_VISIBLE_START_VPOS, false),
             lazy_collision_vpos: RENDER_VISIBLE_START_VPOS,
             lazy_collision_hpos: RENDER_COPPER_WAIT_HPOS_FB0,
+            collision_tracking_active: false,
             cpu_bus_arbitration_enabled: false,
             cpu_clock_carry: 0,
             cpu_clocks_per_cck: 2,
@@ -2120,6 +2134,7 @@ impl Bus {
         self.last_frame_geometry = FrameGeometry::standard(RENDER_VISIBLE_START_VPOS, false);
         self.lazy_collision_vpos = RENDER_VISIBLE_START_VPOS;
         self.lazy_collision_hpos = RENDER_COPPER_WAIT_HPOS_FB0;
+        self.collision_tracking_active = false;
         self.current_frame_bus_trace.clear();
         self.last_frame_bus_trace = None;
         self.cpu_bus_arbitration_enabled = false;
@@ -3739,6 +3754,9 @@ impl Bus {
             0x00A => self.input.joy0dat(), // JOY0DAT (mouse port 1 counters)
             0x00C => self.input.joy1dat(), // JOY1DAT (mouse port 2 counters)
             0x00E => {
+                // Software is observing collisions: arm the per-frame flush from
+                // now on so the latch is maintained exactly as hardware does.
+                self.collision_tracking_active = true;
                 self.accumulate_live_collisions_until_current_beam();
                 self.denise.read_clxdat()
             } // CLXDAT
@@ -6809,7 +6827,12 @@ impl Bus {
                 );
             }
         }
-        self.accumulate_live_collisions_to_frame_end();
+        // Only maintain the collision latch across the frame boundary once
+        // software has shown it reads CLXDAT. Until then the full-frame scan is
+        // unobservable work; see `collision_tracking_active`.
+        if self.collision_tracking_active {
+            self.accumulate_live_collisions_to_frame_end();
+        }
         self.log_bus_accounting_frame();
         self.finish_frame_bus_trace();
         let promote_render_frame = !self.current_frame_render_blocked;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5584,6 +5584,14 @@ impl App {
                     path.display(),
                     outcome.summary
                 );
+                // The pre-boot configuration screen runs on a placeholder
+                // machine with a silent NullSink (see build_placeholder_machine);
+                // a state loaded over it would keep that null sink and play no
+                // audio. Detect that case before powering on and give the
+                // restored machine a live host output below, mirroring the
+                // launcher's Run path. A machine that already has a real sink
+                // (any normal running session) is left untouched.
+                let restoring_over_placeholder = self.restoring_over_placeholder();
                 self.powered_on = true;
                 self.cpu_halted = false;
                 // Force a fresh presentation: the restored frame counter
@@ -5592,6 +5600,9 @@ impl App {
                 if matches!(self.ui.panel, Some(Panel::Launcher(_))) {
                     self.ui.panel = None;
                     self.resize_for_active_panel();
+                }
+                if restoring_over_placeholder {
+                    self.install_live_audio_after_placeholder_load();
                 }
                 if outcome.reconfigured {
                     // The state was built on a different machine; the host
@@ -6605,6 +6616,37 @@ impl App {
 
     fn suspend_live_audio_for_host_io(&mut self) {
         self.emu.set_live_audio_suspended(true);
+    }
+
+    /// Whether a state is being loaded over the pre-boot placeholder machine
+    /// that hosts the configuration screen: powered off, the launcher panel
+    /// open, and the silent NullSink still installed. Only then does a load need
+    /// to install a real audio output; every normal running session already has
+    /// one. Evaluate this before powering on / dismissing the launcher.
+    fn restoring_over_placeholder(&self) -> bool {
+        !self.powered_on
+            && matches!(self.ui.panel, Some(Panel::Launcher(_)))
+            && self.emu.bus().paula.audio.is_null_sink()
+    }
+
+    /// Replace the placeholder machine's silent NullSink with a live host audio
+    /// output after a save state is loaded over the configuration screen. This
+    /// mirrors the launcher Run path (`launcher_run`): the configuration screen
+    /// itself stays silent, but a machine started from it -- by Run or by a state
+    /// load -- gets real sound. On audio-init failure the state stays loaded and
+    /// the machine simply runs without sound, exactly as a failed Run does.
+    fn install_live_audio_after_placeholder_load(&mut self) {
+        match CpalSink::new(crate::priority::requested(false)) {
+            Ok(sink) => {
+                self.emu.bus_mut().paula.audio = Box::new(sink);
+                // Apply the current suspension state to the freshly installed
+                // stream (it should be live now: powered on and not paused).
+                self.sync_live_audio_suspension();
+            }
+            Err(e) => {
+                warn!("audio init after state load failed; continuing without sound: {e:#}");
+            }
+        }
     }
 
     fn finish_host_io_pause(&mut self) {
@@ -8903,6 +8945,79 @@ mod tests {
         app.suspend_live_audio_for_host_io();
         app.finish_host_io_pause();
         assert_eq!(states.borrow().last(), Some(&true));
+    }
+
+    #[test]
+    fn restoring_over_placeholder_detected_only_for_the_silent_config_screen() {
+        // The exact configuration-screen placeholder: powered off, launcher
+        // open, NullSink installed (as build_placeholder_machine produces).
+        let mut app = test_app();
+        app.power_off();
+        app.open_launcher();
+        assert!(
+            app.restoring_over_placeholder(),
+            "powered-off launcher with a null sink is the placeholder"
+        );
+
+        // A live (non-null) sink behind the launcher is a real running session
+        // re-opening the config screen: its audio must not be torn out.
+        let states = Rc::new(RefCell::new(Vec::new()));
+        let mut live = test_app_with_audio(Box::new(SuspensionSink {
+            states: Rc::clone(&states),
+        }));
+        live.power_off();
+        live.open_launcher();
+        assert!(
+            !live.restoring_over_placeholder(),
+            "a real audio sink behind the launcher is not the placeholder"
+        );
+
+        // A null sink but powered on, or with no launcher open, is not the
+        // pre-boot placeholder either.
+        let mut powered = test_app();
+        powered.open_launcher();
+        assert!(powered.powered_on);
+        assert!(!powered.restoring_over_placeholder());
+
+        let mut no_launcher = test_app();
+        no_launcher.power_off();
+        assert!(no_launcher.ui.panel.is_none());
+        assert!(!no_launcher.restoring_over_placeholder());
+    }
+
+    #[test]
+    fn state_load_over_running_session_keeps_its_live_audio_sink() {
+        // Re-opening the config screen over a running machine and loading a
+        // state must not replace the live audio sink (the regression guard for
+        // the placeholder-upgrade path). Uses a probe sink so no real audio
+        // device is touched.
+        let path = std::env::temp_dir().join(format!(
+            "copperline-running-state-load-{}.clstate",
+            std::process::id()
+        ));
+        let states = Rc::new(RefCell::new(Vec::new()));
+        let mut app = test_app_with_audio(Box::new(SuspensionSink {
+            states: Rc::clone(&states),
+        }));
+        app.emu.save_state(&path).expect("save test state");
+        app.open_launcher();
+        assert!(app.powered_on);
+        assert!(!app.restoring_over_placeholder());
+
+        assert!(app.load_state_from_path(&path));
+
+        // The probe sink is still the installed one: a suspension toggle still
+        // reaches it. (A replacement CpalSink would have dropped the probe.)
+        states.borrow_mut().clear();
+        app.suspend_live_audio_for_host_io();
+        app.finish_host_io_pause();
+        assert_eq!(
+            states.borrow().as_slice(),
+            &[true, false],
+            "live audio sink should survive a state load over a running session"
+        );
+
+        let _ = std::fs::remove_file(&path);
     }
 
     /// End-to-end recording through the app: start, run emulated frames


### PR DESCRIPTION
Two independent fixes, each in its own commit.

## 1. Gate per-frame collision accumulation on CLXDAT observation

`begin_new_beam_frame` ran a full-frame collision scan
(`accumulate_live_collisions_to_frame_end`) **every frame**, defeating the
existing lazy-collision machinery. Collision results are observable only through
a `CLXDAT` read (`$DFF00E`), so for software that never reads `CLXDAT` (most
demos) the scan is pure waste — ~37% of emulation time on a busy demo, scanning
tens of millions of pixels per second.

A sticky gate (`collision_tracking_active`) skips the per-frame flush until the
first `CLXDAT` read, then stays armed so any collision-using software is
**bit-identical** to before. The read path already accumulates up to the current
beam, so the first read after arming returns the current frame's collisions
correctly. The field is `#[serde(skip)]` so existing save states still load.

This is the behaviour the ignored `assert_noaudio_ham_performance` test already
expects (`collisions calls=0` for a HAM demo that doesn't read `CLXDAT`) — the
lazy machinery was in place and this was the missing piece.

**Impact:** ~30% wall-time reduction on the affected demo (≈60 → 85+ fps
unthrottled), which resolves audio stutters on slower (Intel) hosts where the
core was overrunning the frame budget.

**Verification:** all `clxdat`/collision unit tests pass; dumped frames are
byte-identical baseline vs patched (two different demos).

## 2. Restore live audio when loading a state over the config screen

The machine-configuration screen runs on the placeholder machine
(`build_placeholder_machine`), which is wired with a silent `NullSink`. Loading
a save state restores in place and `adopt_host_resources` swaps the existing
sink into the restored machine, so a state loaded over the config screen
inherits the placeholder's `NullSink` and plays no sound. The launcher's Run
path avoids this by building a fresh machine with a real `CpalSink`; the
load-state path never did.

`restoring_over_placeholder()` detects the exact case (powered off + launcher
open + `NullSink`) and installs a live `CpalSink` after the load, mirroring Run.
Every normal session (running `CpalSink`, `--noaudio`, `--audio-wav`) fails the
gate and is left untouched.

**Verification:** 1175 unit tests pass (2 added — gate coverage for all four
conditions, plus a regression guard that a live sink is never torn out by a load
over a running session).