### PR TITLE
Refine sprite and bitplane latch timing

### DIFF
--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -49,6 +49,9 @@ that plane-0 fetch reaches Denise instead of sampling stale shifter contents.
 That gate is placed in the bitplane/DIW coordinate domain, not the normal
 Copper/register-write output domain, because it follows the fetch slot that
 loads BPL1DAT.
+Once that first DMA word is visible, the renderer samples the enabled
+bitplanes from the complete latched word; it does not expose the first word
+plane-by-plane according to each plane's individual DMA slot.
 If a manual BPL1DAT write starts a word before that DMA load point, replay
 stops the manual word where the DMA word replaces Denise's shifter.
 BPLCON1-delayed samples at the left edge of a contiguous bitplane-DMA block

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3227,13 +3227,6 @@ fn manual_sprite_lines_from_events_with_visible_line0(
     include_latched_sprite_state: bool,
 ) -> Vec<Vec<SpriteLine>> {
     let mut regs = BeamSpriteState::from_render_state(initial_state, held);
-    if !include_latched_sprite_state {
-        for sprite in 0..8 {
-            if held[sprite].is_none() {
-                regs.spr_armed[sprite] = false;
-            }
-        }
-    }
     let visible_end = visible_line0 + rows as i32;
     let mut next_beam: [(i32, usize); 8] = std::array::from_fn(|sprite| {
         if include_latched_sprite_state || held[sprite].is_some() {
@@ -3291,10 +3284,15 @@ fn manual_sprite_lines_from_events_with_visible_line0(
             && (off - 0x140) & 0x0006 == 0
             && event.hpos < SPRITE_DMA_PAIR_CAPTURE_HPOS[sprite / 2]
         {
-            regs.spr_armed[sprite] = false;
+            if regs.direct_data_armed[sprite] {
+                regs.spr_armed[sprite] = false;
+            }
             regs.direct_data_armed[sprite] = false;
         }
         regs.apply_write(off, event.value);
+        if (event.vpos as i32) < visible_line0 && matches!((off - 0x140) & 0x0006, 0x4 | 0x6) {
+            regs.direct_data_armed[sprite] = false;
+        }
         next_beam[sprite] = event_beam;
     }
 
@@ -4429,10 +4427,10 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         visible_line0,
     );
     let event_started = Instant::now();
-    // Seed replay from beam-timed SPRx writes, not frame-start data latches.
-    // The SPRxDATA latch can persist across frames, but by itself it does not
-    // tell us whether the sprite vertical comparators are active this field.
-    // DMA-established held sprites seed through `input.held_sprites` instead.
+    // Seed replay spans from beam-timed SPRx writes or DMA-established held
+    // sprites. SPRxDATA latches remain armed across the frame boundary, but
+    // they do not emit by themselves when captured DMA is the primary source;
+    // a later SPRxPOS write can still reuse that latch after the DMA slot.
     let mut manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
         &state,
         render_events,
@@ -9406,28 +9404,69 @@ mod tests {
     }
 
     #[test]
-    fn manual_sprite_position_write_does_not_seed_from_frame_start_data_latch() {
+    fn pre_dma_position_write_preserves_armed_latch_for_later_position_write() {
         let mut initial_state = blank_state();
-        let (old_pos, ctl) = sprite_control_words(
-            PAL_VISIBLE_LINE0 as u16,
-            PAL_VISIBLE_LINE0 as u16 + 1,
-            DIW_HSTART_FB0 as u16,
-        );
-        let (new_pos, _) = sprite_control_words(
-            PAL_VISIBLE_LINE0 as u16,
-            PAL_VISIBLE_LINE0 as u16 + 1,
-            (DIW_HSTART_FB0 + 16) as u16,
-        );
+        let beam_y = PAL_VISIBLE_LINE0;
+        let (old_pos, ctl) =
+            sprite_control_words(beam_y as u16, beam_y as u16 + 1, DIW_HSTART_FB0 as u16);
+        let pre_dma_hstart = (DIW_HSTART_FB0 + 16) as u16;
+        let (pre_dma_pos, _) =
+            sprite_control_words(beam_y as u16, beam_y as u16 + 1, pre_dma_hstart);
+        let post_dma_hstart = (DIW_HSTART_FB0 + 32) as u16;
+        let (post_dma_pos, _) =
+            sprite_control_words(beam_y as u16, beam_y as u16 + 1, post_dma_hstart);
         initial_state.sprpos[0] = old_pos;
         initial_state.sprctl[0] = ctl;
-        initial_state.sprdata[0] = 0xFFFF;
+        initial_state.sprdata[0] = 0x8000;
+        initial_state.spr_armed[0] = true;
+
+        let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+            &initial_state,
+            &[
+                cpu_event(
+                    beam_y as u32,
+                    SPRITE_DMA_PAIR_CAPTURE_HPOS[0] - 1,
+                    0x140,
+                    pre_dma_pos,
+                ),
+                cpu_event(
+                    beam_y as u32,
+                    SPRITE_DMA_PAIR_CAPTURE_HPOS[0] + 1,
+                    0x140,
+                    post_dma_pos,
+                ),
+            ],
+            &[None; 8],
+            PAL_VISIBLE_LINE0,
+            FB_HEIGHT,
+            false,
+        );
+
+        assert!(manual_sprite_lines[0].iter().any(|line| {
+            line.beam_y == beam_y
+                && line.hstart == i32::from(post_dma_hstart)
+                && line.data == 0x8000
+        }));
+    }
+
+    #[test]
+    fn post_dma_position_write_reuses_armed_frame_start_data_latch() {
+        let mut initial_state = blank_state();
+        let beam_y = PAL_VISIBLE_LINE0;
+        let (old_pos, ctl) =
+            sprite_control_words(beam_y as u16, beam_y as u16 + 1, DIW_HSTART_FB0 as u16);
+        let reused_hstart = (DIW_HSTART_FB0 + 32) as u16;
+        let (new_pos, _) = sprite_control_words(beam_y as u16, beam_y as u16 + 1, reused_hstart);
+        initial_state.sprpos[0] = old_pos;
+        initial_state.sprctl[0] = ctl;
+        initial_state.sprdata[0] = 0x8000;
         initial_state.spr_armed[0] = true;
 
         let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
             &initial_state,
             &[cpu_event(
-                PAL_VISIBLE_LINE0 as u32,
-                COPPER_WAIT_HPOS_FB0 as u32,
+                beam_y as u32,
+                SPRITE_DMA_PAIR_CAPTURE_HPOS[0] + 1,
                 0x140,
                 new_pos,
             )],
@@ -9437,7 +9476,64 @@ mod tests {
             false,
         );
 
-        assert!(manual_sprite_lines[0].is_empty());
+        assert!(manual_sprite_lines[0].iter().any(|line| {
+            line.beam_y == beam_y && line.hstart == i32::from(reused_hstart) && line.data == 0x8000
+        }));
+    }
+
+    #[test]
+    fn offscreen_pre_dma_position_write_preserves_armed_latch_for_same_line_retime() {
+        let mut initial_state = blank_state();
+        let beam_y = 99;
+        initial_state.sprpos[3] = 0x5020;
+        initial_state.sprctl[3] = 0x0602;
+        initial_state.sprdata[3] = 0xE92D;
+        initial_state.sprdatb[3] = 0x16FF;
+        initial_state.spr_armed[3] = true;
+
+        let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+            &initial_state,
+            &[
+                cpu_event(beam_y as u32, 8, 0x158, 0x5020),
+                cpu_event(beam_y as u32, 64, 0x158, 0x503C),
+            ],
+            &[None; 8],
+            PAL_VISIBLE_LINE0,
+            FB_HEIGHT,
+            false,
+        );
+
+        assert!(manual_sprite_lines[3].iter().any(|line| {
+            line.beam_y == beam_y
+                && line.hstart == 0x78
+                && line.data == 0xE92D
+                && line.datb == 0x16FF
+        }));
+    }
+
+    #[test]
+    fn pre_visible_data_write_seeds_latch_without_direct_output_guard() {
+        let mut initial_state = blank_state();
+        initial_state.sprpos[3] = 0x5020;
+
+        let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+            &initial_state,
+            &[
+                cpu_event(0, 78, 0x15A, 0x0602),
+                cpu_event(0, 110, 0x15E, 0x16FF),
+                cpu_event(0, 142, 0x15C, 0xE92D),
+                cpu_event(99, 8, 0x158, 0x5020),
+                cpu_event(99, 64, 0x158, 0x503C),
+            ],
+            &[None; 8],
+            PAL_VISIBLE_LINE0,
+            FB_HEIGHT,
+            false,
+        );
+
+        assert!(manual_sprite_lines[3].iter().any(|line| {
+            line.beam_y == 99 && line.hstart == 0x78 && line.data == 0xE92D && line.datb == 0x16FF
+        }));
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1082,7 +1082,6 @@ struct DenisePlannedPlayfieldLine<'a> {
     plane_words: &'a [Vec<u16>],
     fetched_pixels: usize,
     carry_words: [Option<u16>; 8],
-    first_word_plane_start_x: [usize; 8],
 }
 
 impl<'a> DenisePlannedPlayfieldLine<'a> {
@@ -1100,17 +1099,11 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             plane_words,
             fetched_pixels,
             carry_words: [None; 8],
-            first_word_plane_start_x: [0; 8],
         }
     }
 
     fn with_carry_words(mut self, carry_words: [Option<u16>; 8]) -> Self {
         self.carry_words = carry_words;
-        self
-    }
-
-    fn with_first_word_plane_start_x(mut self, start_x: [usize; 8]) -> Self {
-        self.first_word_plane_start_x = start_x;
         self
     }
 
@@ -1165,17 +1158,9 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
                 active = true;
                 continue;
             }
-            if fetch_x < 16 && fetch_x < self.first_word_plane_start_x[plane] {
-                active = true;
-                let carry_offset = self.first_word_plane_start_x[plane] - fetch_x;
-                if carry_offset <= 16 {
-                    let bit = carry_offset - 1;
-                    if self.carry_words[plane].is_some_and(|word| word & (1 << bit) != 0) {
-                        idx |= 1 << plane;
-                    }
-                }
-                continue;
-            }
+            // The DMA fetch slots decide which word reaches Denise, but the
+            // display shifter sees that word as a complete latched sample.
+            // Do not expose the first word plane-by-plane at a late DDF edge.
             if fetch_x >= self.fetched_pixels {
                 continue;
             }
@@ -2767,51 +2752,6 @@ fn bitplane_dma_output_start_x(
                 .find_map(|(hpos, plane)| (plane == 0).then_some(hpos))
         })
         .map(bitplane_fetch_framebuffer_x)
-}
-
-fn first_word_plane_start_x(
-    base_control: ControlState,
-    control_segments: &[ControlSegment],
-    display_start_x: usize,
-    words_per_row: usize,
-    dma_planes: usize,
-) -> [usize; 8] {
-    if dma_planes == 0 || words_per_row == 0 {
-        return [0; 8];
-    }
-    let mut display_control = base_control;
-    for segment in control_segments {
-        if segment.x <= display_start_x {
-            display_control = segment.control;
-        }
-    }
-    let pixel_repeat = display_control.framebuffer_pixel_repeat();
-    let native_per_pixel = display_control.native_samples_per_framebuffer_pixel();
-    let fetch_start_native_x =
-        display_control.fetch_start_native_x(display_control.diw_h_start(), pixel_repeat);
-    if fetch_start_native_x == 0 {
-        return [0; 8];
-    }
-    let native_x_offset =
-        display_control.native_x_offset(display_control.diw_h_start(), pixel_repeat);
-    let framebuffer_x_to_fetch_x = |x: usize| -> usize {
-        let output_native_x = x
-            .saturating_sub(display_start_x)
-            .saturating_div(pixel_repeat)
-            .saturating_mul(native_per_pixel);
-        output_native_x
-            .saturating_sub(fetch_start_native_x)
-            .saturating_add(native_x_offset)
-    };
-
-    let mut start_x = [0; 8];
-    let plan = line_fetch_plan_for_word(base_control, control_segments, 0, dma_planes);
-    for (hpos, plane) in plan.iter() {
-        if plane < start_x.len() {
-            start_x[plane] = framebuffer_x_to_fetch_x(bitplane_fetch_framebuffer_x(hpos));
-        }
-    }
-    start_x
 }
 
 fn bitplane_carry_words_for_line(
@@ -4854,13 +4794,6 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 dma_output_start_x,
                 previous_playfield_tail_words,
             );
-            let first_word_plane_start_x = first_word_plane_start_x(
-                base_controls[y],
-                row_control_segments,
-                x_start,
-                words_per_row,
-                dma_planes.min(nplanes),
-            );
             let line_plan = DenisePlannedPlayfieldLine::new(
                 y,
                 x_start,
@@ -4868,8 +4801,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 &row_words[..nplanes],
                 fetched_pixels,
             )
-            .with_carry_words(carry_words)
-            .with_first_word_plane_start_x(first_word_plane_start_x);
+            .with_carry_words(carry_words);
             let bpl_output_start_x = dma_output_start_x.unwrap_or(0);
             dma_output_start_x_by_line[y] = dma_output_start_x;
             last_playfield_line = Some(y);
@@ -8193,24 +8125,15 @@ mod tests {
     }
 
     #[test]
-    fn late_ddf_waits_for_each_planes_first_fetch_slot() {
+    fn late_ddf_first_word_samples_all_planes_together() {
         let control = ControlState {
-            bplcon0: 0x1000,
+            bplcon0: 0x4000,
             ..ControlState::default()
         };
-        let plane_words = [vec![0x0800]];
-        let mut carry_words = [None; 8];
-        carry_words[0] = Some(0x0001);
-        let mut first_word_plane_start_x = [0; 8];
-        first_word_plane_start_x[0] = 4;
+        let plane_words = [vec![0x4000], vec![0x4000], vec![0x4000], vec![0x4000]];
+        let line = DenisePlannedPlayfieldLine::new(0, 0, 64, &plane_words, 16);
 
-        let line = DenisePlannedPlayfieldLine::new(0, 0, 64, &plane_words, 16)
-            .with_carry_words(carry_words)
-            .with_first_word_plane_start_x(first_word_plane_start_x);
-
-        assert_eq!(line.sample(control, 2).idx, 0);
-        assert_eq!(line.sample(control, 3).idx, 1);
-        assert_eq!(line.sample(control, 4).idx, 1);
+        assert_eq!(line.sample(control, 1).idx, 0x0F);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve sprite data latches across manual sprite retiming so pointer/data replay does not clone edge fragments
- sample late-DDF first bitplane words as complete Denise latches instead of exposing individual plane fetch slots
- document the late-DDF latch rule and add focused bitplane coverage

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --locked late_ddf_first_word_samples_all_planes_together
- rendered the reported save-state frames and smoke-checked the prior regression points