### PR TITLE
Add configurable initial joystick input mode

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -230,6 +230,22 @@ floppy_sounds = true
 floppy_sounds_volume = 100
 
 
+# Host input preferences.
+# [input]
+
+# Initial source for the emulated port-2 joystick / CD32 pad:
+#   "auto"     (default) a calibrated USB gamepad drives port 2 when present,
+#              otherwise the keyboard-joystick mapping (cursor keys + fire keys)
+#              takes over so port 2 stays usable without a controller.
+#   "gamepad"  only a physical pad drives port 2; the keyboard passes straight
+#              through to the Amiga (Shell, editor, Workbench). With no pad
+#              connected there is simply no port-2 input -- ideal for
+#              keyboard-driven setup of an AmigaOS environment.
+#   "keyboard" always use the keyboard-joystick mapping.
+# Cmd+J / Alt+J still cycles this live; --joystick MODE overrides it per run.
+# joystick = "auto"
+
+
 # Optional floppy drives. DF0 is always connected; set [floppy] drives
 # to wire empty external mechanisms as well (1-4 total drives). Missing
 # [floppy.dfN] tables mean no disk in that drive. Supported images:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,6 +44,7 @@ range checks as the equivalent TOML fields:
 | `--fast SIZE` | `[memory] fast` | `0`, `1M`, `4M`, `8M`, ... |
 | `--slow SIZE` | `[memory] slow` | `0`, up to `512K` |
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
+| `--joystick MODE` | `[input] joystick` | `auto`, `keyboard`, `gamepad` |
 
 For example, to boot a stock A1200 profile but with 8 MB of fast RAM and a
 faster CPU, with no config file at all:
@@ -314,6 +315,30 @@ floppy_sounds_volume = 100  # 0-100, relative to Paula's output
 The drive sounds are generated from scratch: motor hum with spin-up/down,
 head-step clicks for seeks and the empty-drive poll, and faint read/write
 hiss during disk DMA.
+
+## `[input]`
+
+```toml
+[input]
+joystick = "auto"   # "auto" (default), "keyboard", or "gamepad"
+```
+
+Selects the initial host source for the emulated port-2 joystick / CD32 pad:
+
+- `auto` -- a calibrated USB gamepad drives port 2 when one is present;
+  otherwise the keyboard-joystick mapping (cursor keys plus the fire keys)
+  takes over so port 2 stays usable without a controller.
+- `gamepad` -- only a physical pad drives port 2. The keyboard is left to
+  the Amiga, so it passes straight through to a Shell, an editor, or
+  Workbench. With no pad connected there is simply no port-2 input. Handy
+  when running an AmigaOS environment for hands-on, keyboard-driven setup.
+- `keyboard` -- always use the keyboard-joystick mapping, even when a pad is
+  connected.
+
+This only sets the starting mode. `Cmd+J` / `Alt+J` (and the menu's
+**Joystick Input** item, or the launcher's *A/V & Emu* tab) still cycle it
+live without changing the config. `--joystick MODE` overrides this for a
+single run.
 
 ## `[floppy]` and `[floppy.df0]` .. `[floppy.df3]`
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -162,7 +162,7 @@ The layout is:
   *Hard Disk* (IDE master/slave and the A2091 SCSI ROM and units), *CD* (image,
   insert delay, CD32 NVRAM), *Zorro* (extra autoconfig boards by metadata file),
   and *A/V & Emu* (overscan, phosphor, floppy sounds and volume, power-on,
-  pacing, realtime priority, warp speed).
+  pacing, realtime priority, warp speed, joystick input mode).
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
   buttons flip a toggle, and the **Browse** and **Clear** buttons set or remove
   a file path through a native file dialog. A setting that does not apply to the
@@ -284,10 +284,13 @@ protocol instead, including the red/blue/green/yellow and transport
 buttons. Mouse and gamepad coexist because they use different ports.
 
 If no calibrated gamepad is connected, Copperline can emulate the port-2
-joystick from the host keyboard. The default joystick input mode is
-**auto**: a calibrated USB gamepad is used when present, otherwise the
-keyboard mapping is active. Use the menu's **Joystick Input** item, or
-`Cmd+J` on macOS / `Alt+J` on Linux and Windows, to cycle through:
+joystick from the host keyboard. The joystick input mode starts at **auto**
+(a calibrated USB gamepad is used when present, otherwise the keyboard
+mapping is active); set a different starting mode with `[input] joystick` in
+the config (or `--joystick MODE`, or the launcher's *A/V & Emu* tab) when you
+want the keyboard left to the Amiga for interactive setup. Use the menu's
+**Joystick Input** item, or `Cmd+J` on macOS / `Alt+J` on Linux and Windows,
+to cycle through:
 
 - **auto**: gamepad when available, keyboard fallback otherwise.
 - **keyboard**: always use the keyboard mapping and ignore live gamepad

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,11 @@ pub struct Config {
     /// decay that fuses field-rate dither and interlace flicker on a
     /// real CRT.
     pub phosphor: f32,
+    /// Initial host input source for the emulated port-2 joystick/CD32 pad
+    /// (`[input] joystick` / `--joystick`). Defaults to [`JoystickInputMode::Auto`];
+    /// the runtime `Cmd+J` / `Alt+J` toggle (and the menu's Joystick Input item)
+    /// changes it live without affecting this start-up value.
+    pub joystick_input_mode: JoystickInputMode,
 }
 
 /// How much of the overscan field the window presents. The
@@ -156,6 +161,43 @@ pub enum Overscan {
     /// behind the bezel, and so does this mode. The default.
     #[default]
     Tv,
+}
+
+/// Host input source for the emulated port-2 joystick/CD32 pad. `Auto` keeps a
+/// calibrated physical gamepad in charge when one is present and otherwise
+/// falls back to keyboard joystick emulation. `Gamepad` uses only a physical
+/// pad, so the keyboard passes straight through to the Amiga (and with no pad
+/// connected there is simply no port-2 input). `Keyboard` always uses the
+/// keyboard-joystick mapping. Set the initial mode with `[input] joystick`
+/// (or `--joystick`); `Cmd+J` / `Alt+J` still cycles it at runtime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum JoystickInputMode {
+    #[default]
+    Auto,
+    Gamepad,
+    Keyboard,
+}
+
+impl JoystickInputMode {
+    /// Cycle order for the runtime toggle and the launcher stepper:
+    /// auto -> keyboard -> gamepad -> auto.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Auto => Self::Keyboard,
+            Self::Keyboard => Self::Gamepad,
+            Self::Gamepad => Self::Auto,
+        }
+    }
+
+    /// Short label for menus, the on-screen flash, and the config string
+    /// (round-trips through [`parse_joystick_input_mode`]).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Gamepad => "gamepad",
+            Self::Keyboard => "keyboard",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -694,6 +736,7 @@ impl Default for Config {
             floppy_playlists: std::array::from_fn(|_| Vec::new()),
             overscan: Overscan::Tv,
             phosphor: 0.0,
+            joystick_input_mode: JoystickInputMode::Auto,
         }
     }
 }
@@ -809,6 +852,9 @@ pub struct ConfigOverrides {
     pub fast: Option<String>,
     pub slow: Option<String>,
     pub floppy_drives: Option<u8>,
+    /// Initial joystick input mode (`--joystick`): "auto", "keyboard", or
+    /// "gamepad". Validated by the same parser as `[input] joystick`.
+    pub joystick: Option<String>,
 }
 
 impl ConfigOverrides {
@@ -823,6 +869,7 @@ impl ConfigOverrides {
             && self.fast.is_none()
             && self.slow.is_none()
             && self.floppy_drives.is_none()
+            && self.joystick.is_none()
     }
 
     /// Inject the set overrides into the raw config, replacing the values
@@ -854,6 +901,9 @@ impl ConfigOverrides {
         }
         if let Some(drives) = self.floppy_drives {
             raw.floppy.drives = Some(drives);
+        }
+        if let Some(joystick) = &self.joystick {
+            raw.input.joystick = Some(joystick.clone());
         }
     }
 }
@@ -905,6 +955,8 @@ pub(crate) struct RawConfig {
     pub(crate) floppy: RawFloppy,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) display: RawDisplay,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) input: RawInput,
     /// `[[zorro]]` board entries, configured in file order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) zorro: Vec<RawZorroBoard>,
@@ -929,6 +981,17 @@ pub(crate) struct RawDisplay {
     /// CRT phosphor persistence fraction, 0.0 (off, default) to 0.95.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) phosphor: Option<f32>,
+}
+
+/// `[input]` host-input preferences. Currently just the initial joystick input
+/// mode; `Cmd+J` / `Alt+J` still cycles it live.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawInput {
+    /// Initial joystick input source: "auto" (default), "keyboard", or
+    /// "gamepad".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) joystick: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -1282,6 +1345,10 @@ impl TryFrom<RawConfig> for Config {
             Some(p) if (0.0..=0.95).contains(&p) => p,
             Some(p) => bail!("[display] phosphor must be between 0.0 and 0.95, got {p}"),
         };
+        let joystick_input_mode = match raw.input.joystick.as_deref() {
+            None => defaults.joystick_input_mode,
+            Some(s) => parse_joystick_input_mode(s)?,
+        };
 
         let ide = IdeConfig {
             master: raw.ide.master.map(PathBuf::from),
@@ -1426,6 +1493,7 @@ impl TryFrom<RawConfig> for Config {
             floppy_playlists,
             overscan,
             phosphor,
+            joystick_input_mode,
         })
     }
 }
@@ -1435,6 +1503,18 @@ pub(crate) fn parse_overscan(s: &str) -> Result<Overscan> {
         "full" => Ok(Overscan::Full),
         "tv" => Ok(Overscan::Tv),
         other => bail!("[display] overscan must be \"full\" or \"tv\", got \"{other}\""),
+    }
+}
+
+pub(crate) fn parse_joystick_input_mode(s: &str) -> Result<JoystickInputMode> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "auto" => Ok(JoystickInputMode::Auto),
+        "keyboard" | "kbd" | "key" => Ok(JoystickInputMode::Keyboard),
+        "gamepad" | "pad" | "joystick" | "joy" => Ok(JoystickInputMode::Gamepad),
+        _ => Err(anyhow!(
+            "unknown [input] joystick {:?}: expected \"auto\", \"keyboard\", or \"gamepad\"",
+            s
+        )),
     }
 }
 
@@ -2072,6 +2152,49 @@ mod tests {
             assert_eq!(cfg.emulation.warp_speed, expected, "for {text:?}");
         }
         assert!(parse_config("[emulation]\nwarp_speed = \"32x\"\n").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn joystick_input_mode_defaults_to_auto() -> Result<()> {
+        // No [input] section: the port-2 source starts in Auto, regardless of
+        // the machine profile (it is a host-input preference, not hardware).
+        assert_eq!(
+            parse_config("")?.joystick_input_mode,
+            JoystickInputMode::Auto
+        );
+        assert_eq!(
+            parse_config("[machine]\nprofile = \"A1200\"\n")?.joystick_input_mode,
+            JoystickInputMode::Auto
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn joystick_input_mode_parses_and_rejects_garbage() -> Result<()> {
+        for (text, expected) in [
+            ("auto", JoystickInputMode::Auto),
+            ("keyboard", JoystickInputMode::Keyboard),
+            ("gamepad", JoystickInputMode::Gamepad),
+            ("GAMEPAD", JoystickInputMode::Gamepad),
+        ] {
+            let cfg = parse_config(&format!("[input]\njoystick = {text:?}\n"))?;
+            assert_eq!(cfg.joystick_input_mode, expected, "for {text:?}");
+        }
+        assert!(parse_config("[input]\njoystick = \"mouse\"\n").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn joystick_cli_override_sets_initial_mode() -> Result<()> {
+        let overrides = ConfigOverrides {
+            joystick: Some("gamepad".to_string()),
+            ..ConfigOverrides::default()
+        };
+        assert_eq!(
+            load_overrides(&overrides)?.joystick_input_mode,
+            JoystickInputMode::Gamepad
+        );
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,11 @@ where
                     .ok_or_else(|| anyhow!("--floppy-drives requires COUNT (1-4)"))?;
                 overrides.floppy_drives = Some(parse_floppy_drive_count(&value)?);
             }
+            "--joystick" => {
+                overrides.joystick = Some(args.next().ok_or_else(|| {
+                    anyhow!("--joystick requires a mode (auto/keyboard/gamepad)")
+                })?);
+            }
             "--click-after" => {
                 let secs: f32 = args
                     .next()
@@ -655,6 +660,8 @@ fn print_help() {
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
          --floppy-drives COUNT          wired floppy drives, 1-4 (DF0 plus externals)\n  \
+         --joystick MODE                initial joystick input: auto, keyboard, or gamepad\n  \
+         \x20                            (gamepad lets the keyboard pass through to the Amiga)\n  \
          \x20                            (--model/--cpu/etc. override the config file or defaults)\n  \
          --screenshot-after SECS PATH   save a PNG to PATH after SECS emulated seconds, then exit\n  \
          --save-state-after SECS PATH   write a save state to PATH after SECS emulated seconds,\n  \
@@ -1052,6 +1059,7 @@ fn main() -> Result<()> {
         resolve_overscan(cfg.overscan),
         resolve_phosphor(cfg.phosphor),
         cfg.emulation.warp_speed,
+        cfg.joystick_input_mode,
         about_machine_lines(&cfg),
         raw_cfg,
     );
@@ -1307,6 +1315,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         resolve_overscan(config::Overscan::Tv),
         resolve_phosphor(0.0),
         config::WarpSpeed::default(),
+        config::JoystickInputMode::default(),
         vec!["Configure a machine, then press Run.".to_string()],
         raw_cfg,
     );

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -22,8 +22,8 @@
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
-    format_size, machine_profile_defaults, Chipset, Config, CpuModel, MachineModel, Overscan,
-    PacingBudget, RawConfig, RawFloppyDrive, RawZorroBoard, WarpSpeed,
+    format_size, machine_profile_defaults, Chipset, Config, CpuModel, JoystickInputMode,
+    MachineModel, Overscan, PacingBudget, RawConfig, RawFloppyDrive, RawZorroBoard, WarpSpeed,
 };
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
 use anyhow::Result;
@@ -261,6 +261,7 @@ pub enum LauncherField {
     PacingBudget,
     RealtimePriority,
     Warp,
+    Joystick,
 }
 
 /// How a row's value is edited, and therefore which widget the panel draws.
@@ -346,7 +347,7 @@ const CD_ROWS: [Row; 3] = [
     row(F::CdInsertDelay, "Insert delay", Cycle),
     row(F::Cd32Nvram, "CD32 NVRAM", PathRow),
 ];
-const AV_EMULATION_ROWS: [Row; 8] = [
+const AV_EMULATION_ROWS: [Row; 9] = [
     row(F::Overscan, "Overscan", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
     row(F::FloppySounds, "Floppy sounds", Toggle),
@@ -355,6 +356,7 @@ const AV_EMULATION_ROWS: [Row; 8] = [
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::RealtimePriority, "Realtime priority", Toggle),
     row(F::Warp, "Warp speed", Cycle),
+    row(F::Joystick, "Joystick input", Cycle),
 ];
 
 /// The rows shown on a tab, top to bottom. The `Zorro` tab has no rows: it is
@@ -442,6 +444,12 @@ const WARPS: [WarpSpeed; 5] = [
     WarpSpeed::X16,
     WarpSpeed::Max,
 ];
+// Cycle order matches the runtime Cmd+J toggle (auto -> keyboard -> gamepad).
+const JOYSTICK_MODES: [JoystickInputMode; 3] = [
+    JoystickInputMode::Auto,
+    JoystickInputMode::Keyboard,
+    JoystickInputMode::Gamepad,
+];
 
 /// A fully-typed, editable mirror of a configurable machine. See the module
 /// docs for how it round-trips through [`RawConfig`].
@@ -498,6 +506,7 @@ pub struct MachineSetup {
     pacing_budget: PacingBudget,
     realtime_priority: bool,
     warp: WarpSpeed,
+    joystick_input_mode: JoystickInputMode,
     // Extra Zorro boards (metadata path + plugin config schema/overrides)
     zorro_boards: Vec<ZorroBoardSetup>,
 }
@@ -564,6 +573,7 @@ impl MachineSetup {
             pacing_budget: cfg.emulation.pacing_budget,
             realtime_priority: cfg.emulation.realtime_priority,
             warp: cfg.emulation.warp_speed,
+            joystick_input_mode: cfg.joystick_input_mode,
             zorro_boards: raw
                 .zorro
                 .iter()
@@ -717,6 +727,9 @@ impl MachineSetup {
         if self.warp != base.emulation.warp_speed {
             raw.emulation.warp_speed = Some(self.warp.label().to_ascii_lowercase());
         }
+        if self.joystick_input_mode != base.joystick_input_mode {
+            raw.input.joystick = Some(self.joystick_input_mode.label().to_string());
+        }
         // Zorro boards: emit the metadata path plus any per-board overrides
         // (typed per the option schema), only when the user changed something.
         raw.zorro = self
@@ -808,6 +821,7 @@ impl MachineSetup {
         self.pacing_budget = base.emulation.pacing_budget;
         self.realtime_priority = base.emulation.realtime_priority;
         self.warp = base.emulation.warp_speed;
+        self.joystick_input_mode = base.joystick_input_mode;
         if !self.has_gayle() {
             self.ide_master = None;
             self.ide_slave = None;
@@ -952,6 +966,11 @@ impl MachineSetup {
                 PacingBudget::Instructions => "Instructions".to_string(),
             },
             F::Warp => self.warp.label().to_string(),
+            F::Joystick => match self.joystick_input_mode {
+                JoystickInputMode::Auto => "Auto".to_string(),
+                JoystickInputMode::Keyboard => "Keyboard".to_string(),
+                JoystickInputMode::Gamepad => "Gamepad".to_string(),
+            },
             // Path fields: the file name, or a placeholder.
             F::Rom => self.path_label(field, "(bundled AROS)"),
             _ if rows_contains_kind(field, RowKind::Path) => self.path_label(field, "(none)"),
@@ -1019,6 +1038,10 @@ impl MachineSetup {
                 self.pacing_budget = cycle_slice(&PACINGS, self.pacing_budget, forward)
             }
             F::Warp => self.warp = cycle_slice(&WARPS, self.warp, forward),
+            F::Joystick => {
+                self.joystick_input_mode =
+                    cycle_slice(&JOYSTICK_MODES, self.joystick_input_mode, forward)
+            }
             _ => {}
         }
     }
@@ -1588,6 +1611,28 @@ mod tests {
         assert_eq!(raw.chipset.agnus.as_deref(), Some("OCS"));
         let back = MachineSetup::from_raw(&raw).unwrap();
         assert_eq!(back.agnus, Some(AgnusRevision::Ocs));
+    }
+
+    #[test]
+    fn joystick_input_mode_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        // Default is Auto, which emits no [input] section.
+        assert_eq!(s.joystick_input_mode, JoystickInputMode::Auto);
+        assert!(s.to_raw().input.joystick.is_none());
+        // Cycle order matches the runtime toggle: auto -> keyboard -> gamepad.
+        s.cycle(LauncherField::Joystick, true);
+        assert_eq!(s.joystick_input_mode, JoystickInputMode::Keyboard);
+        s.cycle(LauncherField::Joystick, true);
+        assert_eq!(s.joystick_input_mode, JoystickInputMode::Gamepad);
+        let raw = s.to_raw();
+        assert_eq!(raw.input.joystick.as_deref(), Some("gamepad"));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.joystick_input_mode, JoystickInputMode::Gamepad);
+        // Switching machine profile resets it to the Auto default.
+        let mut s = MachineSetup::default();
+        s.cycle(LauncherField::Joystick, true);
+        s.select_model(Some(MachineModel::A1200));
+        assert_eq!(s.joystick_input_mode, JoystickInputMode::Auto);
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -64,34 +64,11 @@ impl JoyButtonKind {
     }
 }
 
-/// Host input source for the emulated port-2 joystick/CD32 pad. Auto keeps
-/// a calibrated physical pad in charge when one is present and otherwise
-/// falls back to keyboard joystick emulation.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum JoystickInputMode {
-    #[default]
-    Auto,
-    Gamepad,
-    Keyboard,
-}
-
-impl JoystickInputMode {
-    pub fn next(self) -> Self {
-        match self {
-            Self::Auto => Self::Keyboard,
-            Self::Keyboard => Self::Gamepad,
-            Self::Gamepad => Self::Auto,
-        }
-    }
-
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Auto => "auto",
-            Self::Gamepad => "gamepad",
-            Self::Keyboard => "keyboard",
-        }
-    }
-}
+// The host input source for the emulated port-2 joystick/CD32 pad is a
+// configurable value, so it lives with the other config enums; re-exported
+// here because the window/menu/ui code refers to it as
+// `crate::video::window::JoystickInputMode`.
+pub use crate::config::JoystickInputMode;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KeyboardJoystickKey {
@@ -739,6 +716,7 @@ impl App {
         overscan: Overscan,
         phosphor: f32,
         warp_speed: WarpSpeed,
+        joystick_input_mode: JoystickInputMode,
         about_machine_lines: Vec<String>,
         machine_config: RawConfig,
     ) -> Self {
@@ -809,7 +787,7 @@ impl App {
             hcenter: hcenter_enabled(),
             overscan,
             gamepad: crate::gamepad::GamepadReader::new(),
-            joystick_input_mode: JoystickInputMode::default(),
+            joystick_input_mode,
             warp_speed,
             last_gamepad_active: false,
             keyboard_joy_held: KeyboardJoystickHeld::default(),
@@ -5427,6 +5405,11 @@ impl App {
         self.disk_playlist_index = [0; 4];
         self.overscan = crate::resolve_overscan(cfg.overscan);
         self.warp_speed = cfg.emulation.warp_speed;
+        // Reset the host joystick source to the new machine's configured
+        // start-up mode (a previous live Cmd+J toggle does not carry over).
+        self.joystick_input_mode = cfg.joystick_input_mode;
+        self.last_gamepad_active = false;
+        self.keyboard_joy_held = KeyboardJoystickHeld::default();
         self.about_machine_lines = crate::about_machine_lines(cfg);
         self.deinterlacer = Deinterlacer::with_phosphor(crate::resolve_phosphor(cfg.phosphor));
         self.ui.menu_open = false;
@@ -8795,6 +8778,7 @@ mod tests {
             crate::config::Overscan::Full,
             0.0,
             crate::config::WarpSpeed::Max,
+            crate::config::JoystickInputMode::Auto,
             vec!["Machine: test".to_string()],
             crate::config::RawConfig::default(),
         )


### PR DESCRIPTION
Closes #46.

## Summary

The initial port-2 joystick input mode was hardcoded to `Auto`. In `Auto` with no gamepad connected, the keyboard-joystick fallback consumes the cursor and fire keys, which is awkward during interactive setup (typing in a Shell, an editor, or driving Workbench). The only way to pick another mode was the runtime `Cmd+J` / `Alt+J` cycle, which had to be redone every launch.

This makes the starting mode configurable. `Cmd+J` / `Alt+J` still cycle it live; this only sets the initial value.

## Changes

- **Config**: `[input] joystick = "auto" | "keyboard" | "gamepad"` (new `RawInput` section + `parse_joystick_input_mode`). `JoystickInputMode` moves to `config.rs` alongside the other configurable enums (`Overscan`, `WarpSpeed`, ...) and is re-exported from `video::window`, so existing references keep working. `Config` carries `joystick_input_mode` (default `Auto`; a host preference, not a per-profile machine characteristic).
- **CLI**: `--joystick MODE` override, validated by the same parser as the TOML key, plus a help-text entry.
- **Machine configuration GUI**: a "Joystick input" row on the *A/V & Emu* tab, cycling Auto -> Keyboard -> Gamepad (matching the runtime toggle), round-tripping through `RawConfig` and resetting to Auto on profile change.
- **Window**: `App::new` takes the mode instead of hardcoding `default()`; the launcher's Run path resets the live mode to the new machine's configured value.
- **Docs / example**: `docs/guide/configuration.md` (CLI table + new `[input]` section), `docs/guide/ui.md` (launcher tab list + Mouse/joystick note), and a commented `[input]` block in `copperline.example.toml`.

`gamepad` mode is the one wanted for keyboard-driven setup: only a physical pad drives port 2, so the keyboard passes straight through to the Amiga, and with no pad connected there is simply no port-2 input.

## Testing

- `cargo build --release`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.
- Full unit suite: 1182 passed, 0 failed.
- New tests: config parse/default/CLI-override and a launcher round-trip.
- Smoke-tested: `--joystick gamepad` boots; `--joystick bogus` errors clearly; `--help` lists the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)