### PR TITLE
FPU: extended-precision transcendentals (Tier A)

### DIFF
--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -27,13 +27,17 @@ the format conversions, FMOVE/FMOVEM in every operand format (including
 packed decimal), the constant ROM, FBcc/FScc/FDBcc/FTRAPcc, control
 registers, the FPCR rounding mode/precision and the FPSR exception/accrued
 bytes, and the FSAVE/FRESTORE state frames (NULL after reset, 68881-style
-IDLE once touched) are all modelled. The transcendentals (FSIN/FCOS/FETOX/
-FLOGN/...) and the FMOD/FREM remainders are the one exception: they are
-still evaluated in f64 and widened to extended, isolated behind
-`vendor/m68k/src/fpu/transcendental.rs` (the real 6888x transcendentals
-are polynomial/CORDIC approximations that are not bit-accurate to libm
-anyway). This covers Kickstart's detection and per-task FPU context
-switching. The
+IDLE once touched) are all modelled. The transcendentals (FSIN/FCOS/FTAN,
+FASIN/FACOS/FATAN, the hyperbolics, FETOX/FETOXM1/FTWOTOX/FTENTOX,
+FLOGN/FLOGNP1/FLOG2/FLOG10) and FSINCOS run in extended precision too: a
+double-`FloatX80` ("double-double", ~128-bit) layer
+(`vendor/m68k/src/fpu/dd.rs`) evaluates Taylor/atanh series over reduced
+ranges and rounds the result to extended under the FPCR mode, setting INEX
+and the domain flags (OPERR/DZ). They are faithful to ~64 bits (not
+chip-bit-exact -- the real 6888x uses its own CORDIC/polynomial microcode,
+and on a bare 68040 these trap to a software FPSP). FMOD/FREM compute the
+exact remainder and the FPSR quotient byte. This covers Kickstart's
+detection and per-task FPU context switching. The
 68000's per-instruction cycle counts in the vendored core have been
 corrected against the SingleStepTests corpus to ~1% aggregate accuracy
 (see `vendor/m68k/CYCLE_TIMING_GAP.md`), which is what makes

--- a/vendor/m68k/src/fpu/dd.rs
+++ b/vendor/m68k/src/fpu/dd.rs
@@ -222,6 +222,12 @@ fn odd_series(x: Df, alternating: bool) -> Df {
     sum
 }
 
+/// True when adding `term` to `sum` would not change `sum` to ~128 bits, i.e.
+/// a series can stop. Also true once `term` underflows to zero.
+pub fn term_negligible(term: Df, sum: Df) -> bool {
+    negligible(term.hi, sum.hi)
+}
+
 pub fn atan_small(x: Df) -> Df {
     odd_series(x, true)
 }

--- a/vendor/m68k/src/fpu/dd.rs
+++ b/vendor/m68k/src/fpu/dd.rs
@@ -1,0 +1,342 @@
+// Some helpers are consumed incrementally as the kernels land; the final
+// milestone removes this and drops anything genuinely unused.
+#![allow(dead_code)]
+//! Double-`FloatX80` ("double-double") arithmetic for the extended-precision
+//! transcendental kernels.
+//!
+//! A [`Df`] carries a value as an unevaluated sum `hi + lo` of two
+//! [`FloatX80`] with `|lo| <= 1/2 ulp(hi)`, giving ~128 significand bits. The
+//! error-free transforms (`two_sum`, `two_prod`) are the classic Dekker/Knuth
+//! algorithms; they are valid because the underlying [`softfloat`] add/sub/mul
+//! are correctly-rounded round-to-nearest. Kernels evaluate series here and
+//! round the final `hi + lo` to 64-bit extended via [`Df::to_x80`] (which is
+//! just `softfloat::add`, i.e. the correctly-rounded sum under the caller's
+//! FPCR mode, with INEX set appropriately).
+
+use super::softfloat::{self, ExcFlags, RoundCtx};
+use super::types::FloatX80;
+use std::sync::OnceLock;
+
+// Round-to-nearest scalar ops with flags discarded (the error-free transforms
+// only rely on RN correctness, not on the exception flags).
+#[inline]
+fn fadd(a: FloatX80, b: FloatX80) -> FloatX80 {
+    softfloat::add(a, b, RoundCtx::NEAREST_EXT, &mut ExcFlags::default())
+}
+#[inline]
+fn fsub(a: FloatX80, b: FloatX80) -> FloatX80 {
+    softfloat::sub(a, b, RoundCtx::NEAREST_EXT, &mut ExcFlags::default())
+}
+#[inline]
+fn fmul(a: FloatX80, b: FloatX80) -> FloatX80 {
+    softfloat::mul(a, b, RoundCtx::NEAREST_EXT, &mut ExcFlags::default())
+}
+#[inline]
+fn fdiv(a: FloatX80, b: FloatX80) -> FloatX80 {
+    softfloat::div(a, b, RoundCtx::NEAREST_EXT, &mut ExcFlags::default())
+}
+
+#[inline]
+fn fx(v: f64) -> FloatX80 {
+    FloatX80::from_f64(v)
+}
+
+// ============================== error-free transforms ====================
+
+/// Exact sum: returns (s, e) with s = RN(a+b) and a+b = s+e exactly.
+#[inline]
+fn two_sum(a: FloatX80, b: FloatX80) -> (FloatX80, FloatX80) {
+    let s = fadd(a, b);
+    let bb = fsub(s, a);
+    let err = fadd(fsub(a, fsub(s, bb)), fsub(b, bb));
+    (s, err)
+}
+
+/// Exact sum for |a| >= |b|.
+#[inline]
+fn quick_two_sum(a: FloatX80, b: FloatX80) -> (FloatX80, FloatX80) {
+    let s = fadd(a, b);
+    let e = fsub(b, fsub(s, a));
+    (s, e)
+}
+
+/// Veltkamp split of a 64-bit-significand value into two <=32-bit halves so
+/// that products of the halves are exact. Factor is 2^32 + 1.
+#[inline]
+fn split(a: FloatX80) -> (FloatX80, FloatX80) {
+    const SPLIT: f64 = 4294967297.0; // 2^32 + 1, exact in both f64 and x80
+    let t = fmul(fx(SPLIT), a);
+    let hi = fsub(t, fsub(t, a));
+    let lo = fsub(a, hi);
+    (hi, lo)
+}
+
+/// Exact product: returns (p, e) with p = RN(a*b) and a*b = p+e exactly.
+#[inline]
+fn two_prod(a: FloatX80, b: FloatX80) -> (FloatX80, FloatX80) {
+    let p = fmul(a, b);
+    let (ah, al) = split(a);
+    let (bh, bl) = split(b);
+    // e = ((ah*bh - p) + ah*bl + al*bh) + al*bl
+    let e = fadd(
+        fadd(fadd(fsub(fmul(ah, bh), p), fmul(ah, bl)), fmul(al, bh)),
+        fmul(al, bl),
+    );
+    (p, e)
+}
+
+// ============================== Df type ==================================
+
+#[derive(Clone, Copy)]
+pub struct Df {
+    pub hi: FloatX80,
+    pub lo: FloatX80,
+}
+
+impl Df {
+    #[inline]
+    pub fn new(hi: FloatX80, lo: FloatX80) -> Df {
+        Df { hi, lo }
+    }
+
+    #[inline]
+    pub fn from_x80(a: FloatX80) -> Df {
+        Df {
+            hi: a,
+            lo: FloatX80::zero(false),
+        }
+    }
+
+    #[inline]
+    pub fn from_i32(n: i32) -> Df {
+        Df::from_x80(softfloat::from_u64(n.unsigned_abs() as u64, n < 0))
+    }
+
+    #[inline]
+    pub fn neg(self) -> Df {
+        Df {
+            hi: softfloat::neg(self.hi),
+            lo: softfloat::neg(self.lo),
+        }
+    }
+
+    /// Round the value to 64-bit extended under `ctx`, setting INEX if inexact.
+    #[inline]
+    pub fn to_x80(self, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+        softfloat::add(self.hi, self.lo, ctx, f)
+    }
+}
+
+#[inline]
+pub fn add(a: Df, b: Df) -> Df {
+    let (s, e) = two_sum(a.hi, b.hi);
+    let e = fadd(e, fadd(a.lo, b.lo));
+    let (hi, lo) = quick_two_sum(s, e);
+    Df { hi, lo }
+}
+
+#[inline]
+pub fn sub(a: Df, b: Df) -> Df {
+    add(a, b.neg())
+}
+
+#[inline]
+pub fn add_x80(a: Df, b: FloatX80) -> Df {
+    let (s, e) = two_sum(a.hi, b);
+    let e = fadd(e, a.lo);
+    let (hi, lo) = quick_two_sum(s, e);
+    Df { hi, lo }
+}
+
+#[inline]
+pub fn mul(a: Df, b: Df) -> Df {
+    let (p, e) = two_prod(a.hi, b.hi);
+    let e = fadd(e, fadd(fmul(a.hi, b.lo), fmul(a.lo, b.hi)));
+    let (hi, lo) = quick_two_sum(p, e);
+    Df { hi, lo }
+}
+
+#[inline]
+pub fn mul_x80(a: Df, b: FloatX80) -> Df {
+    let (p, e) = two_prod(a.hi, b);
+    let e = fadd(e, fmul(a.lo, b));
+    let (hi, lo) = quick_two_sum(p, e);
+    Df { hi, lo }
+}
+
+#[inline]
+pub fn sqr(a: Df) -> Df {
+    mul(a, a)
+}
+
+pub fn div(a: Df, b: Df) -> Df {
+    let q1 = fdiv(a.hi, b.hi);
+    let r = sub(a, mul_x80(b, q1));
+    let q2 = fdiv(r.hi, b.hi);
+    let r = sub(r, mul_x80(b, q2));
+    let q3 = fdiv(r.hi, b.hi);
+    let (hi, lo) = quick_two_sum(q1, q2);
+    add_x80(Df { hi, lo }, q3)
+}
+
+#[inline]
+pub fn recip(b: Df) -> Df {
+    div(Df::from_i32(1), b)
+}
+
+// ============================== series helpers ===========================
+
+/// True when `pow` is negligible relative to `sum` (>= ~130 bits below).
+fn negligible(pow: FloatX80, sum: FloatX80) -> bool {
+    if pow.is_zero() {
+        return true;
+    }
+    if sum.is_zero() {
+        return false;
+    }
+    (sum.biased_exp() as i32) - (pow.biased_exp() as i32) > 130
+}
+
+/// Sum_{k>=0} s * x^(2k+1)/(2k+1), where s = (-1)^k if `alternating` else 1.
+/// Used for atan (alternating) and atanh (not). `x` must be small (|x| < 0.5)
+/// for fast convergence.
+fn odd_series(x: Df, alternating: bool) -> Df {
+    let x2 = sqr(x);
+    let mut pow = x; // x^(2k+1)
+    let mut sum = x;
+    let mut k = 1usize;
+    loop {
+        pow = mul(pow, x2);
+        let term = div(pow, Df::from_i32((2 * k + 1) as i32));
+        let term = if alternating && (k & 1 == 1) {
+            term.neg()
+        } else {
+            term
+        };
+        sum = add(sum, term);
+        if negligible(pow.hi, sum.hi) || k > 200 {
+            break;
+        }
+        k += 1;
+    }
+    sum
+}
+
+pub fn atan_small(x: Df) -> Df {
+    odd_series(x, true)
+}
+
+pub fn atanh_small(x: Df) -> Df {
+    odd_series(x, false)
+}
+
+// ============================== constants ================================
+
+#[derive(Clone, Copy)]
+pub struct Consts {
+    pub pi: Df,
+    pub pi_2: Df,
+    pub pi_4: Df,
+    pub ln2: Df,
+    pub ln10: Df,
+    pub log2e: Df,
+    pub log10e: Df,
+}
+
+static CONSTS: OnceLock<Consts> = OnceLock::new();
+
+/// Cached Df constants, computed once via self-contained series.
+pub fn consts() -> &'static Consts {
+    CONSTS.get_or_init(|| {
+        let inv = |n: i32| div(Df::from_i32(1), Df::from_i32(n));
+        // pi = 16*atan(1/5) - 4*atan(1/239)  (Machin)
+        let pi = sub(
+            mul_x80(atan_small(inv(5)), fx(16.0)),
+            mul_x80(atan_small(inv(239)), fx(4.0)),
+        );
+        // ln2 = 2*atanh(1/3); ln10 = 3*ln2 + 2*atanh(1/9)
+        let ln2 = mul_x80(atanh_small(inv(3)), fx(2.0));
+        let ln10 = add(
+            mul_x80(ln2, fx(3.0)),
+            mul_x80(atanh_small(inv(9)), fx(2.0)),
+        );
+        Consts {
+            pi,
+            pi_2: mul_x80(pi, fx(0.5)),
+            pi_4: mul_x80(pi, fx(0.25)),
+            ln2,
+            ln10,
+            log2e: recip(ln2),
+            log10e: recip(ln10),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rn() -> RoundCtx {
+        RoundCtx::NEAREST_EXT
+    }
+    fn to_f64(d: Df) -> f64 {
+        d.to_x80(rn(), &mut ExcFlags::default()).to_f64()
+    }
+
+    #[test]
+    fn two_prod_is_exact() {
+        // a*b reconstructed as p+e equals the f64 product for exact cases.
+        let a = fx(1.5);
+        let b = fx(3.25);
+        let (p, e) = two_prod(a, b);
+        assert_eq!(fadd(p, e).to_f64(), 1.5 * 3.25);
+        assert!(e.is_zero()); // exact product fits, no error term
+    }
+
+    #[test]
+    fn df_arithmetic_matches_f64() {
+        let a = Df::from_i32(7);
+        let b = Df::from_i32(3);
+        // Exact results are exact.
+        assert_eq!(to_f64(add(a, b)), 10.0);
+        assert_eq!(to_f64(sub(a, b)), 4.0);
+        assert_eq!(to_f64(mul(a, b)), 21.0);
+        // Inexact: the Df result is correctly rounded to 64-bit extended;
+        // narrowing to f64 can differ from f64's own 7/3 by one ULP
+        // (double rounding), so allow a couple of f64 ULP.
+        assert!((to_f64(div(a, b)) - 7.0 / 3.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn df_keeps_more_than_64_bits() {
+        // 1 + 2^-80: lost in a single FloatX80 (64-bit), retained in Df.
+        let tiny = FloatX80 {
+            sign_exp: (16383 - 80) as u16,
+            mantissa: 0x8000_0000_0000_0000,
+        };
+        let d = add_x80(Df::from_i32(1), tiny);
+        // hi rounds to exactly 1.0, but lo holds the tail.
+        assert_eq!(d.hi.to_f64(), 1.0);
+        assert!(!d.lo.is_zero());
+    }
+
+    #[test]
+    fn constants_match_rom_hi_words() {
+        let c = consts();
+        // The hi word of each constant must equal the correctly-rounded 64-bit
+        // ROM pattern in softfloat::const_rom.
+        assert_eq!(c.pi.hi, softfloat::const_rom(0x00));
+        assert_eq!(c.ln2.hi, softfloat::const_rom(0x30));
+        assert_eq!(c.ln10.hi, softfloat::const_rom(0x31));
+        assert_eq!(c.log2e.hi, softfloat::const_rom(0x0D));
+        assert_eq!(c.log10e.hi, softfloat::const_rom(0x0E));
+    }
+
+    #[test]
+    fn constants_value_sanity() {
+        let c = consts();
+        assert!((to_f64(c.pi) - std::f64::consts::PI).abs() < 1e-15);
+        assert!((to_f64(c.ln2) - std::f64::consts::LN_2).abs() < 1e-15);
+        assert!((to_f64(c.ln10) - std::f64::consts::LN_10).abs() < 1e-15);
+    }
+}

--- a/vendor/m68k/src/fpu/dd.rs
+++ b/vendor/m68k/src/fpu/dd.rs
@@ -1,6 +1,3 @@
-// Some helpers are consumed incrementally as the kernels land; the final
-// milestone removes this and drops anything genuinely unused.
-#![allow(dead_code)]
 //! Double-`FloatX80` ("double-double") arithmetic for the extended-precision
 //! transcendental kernels.
 //!
@@ -94,11 +91,6 @@ pub struct Df {
 }
 
 impl Df {
-    #[inline]
-    pub fn new(hi: FloatX80, lo: FloatX80) -> Df {
-        Df { hi, lo }
-    }
-
     #[inline]
     pub fn from_x80(a: FloatX80) -> Df {
         Df {
@@ -242,7 +234,6 @@ pub fn atanh_small(x: Df) -> Df {
 pub struct Consts {
     pub pi: Df,
     pub pi_2: Df,
-    pub pi_4: Df,
     pub ln2: Df,
     pub ln10: Df,
     pub log2e: Df,
@@ -262,14 +253,10 @@ pub fn consts() -> &'static Consts {
         );
         // ln2 = 2*atanh(1/3); ln10 = 3*ln2 + 2*atanh(1/9)
         let ln2 = mul_x80(atanh_small(inv(3)), fx(2.0));
-        let ln10 = add(
-            mul_x80(ln2, fx(3.0)),
-            mul_x80(atanh_small(inv(9)), fx(2.0)),
-        );
+        let ln10 = add(mul_x80(ln2, fx(3.0)), mul_x80(atanh_small(inv(9)), fx(2.0)));
         Consts {
             pi,
             pi_2: mul_x80(pi, fx(0.5)),
-            pi_4: mul_x80(pi, fx(0.25)),
             ln2,
             ln10,
             log2e: recip(ln2),

--- a/vendor/m68k/src/fpu/mod.rs
+++ b/vendor/m68k/src/fpu/mod.rs
@@ -1,5 +1,6 @@
 //! FPU emulation (68881/68882/68040)
 
+mod dd;
 mod operations;
 mod packed;
 mod softfloat;

--- a/vendor/m68k/src/fpu/operations.rs
+++ b/vendor/m68k/src/fpu/operations.rs
@@ -794,18 +794,24 @@ impl CpuCore {
             }
             0x30..=0x37 => {
                 // FSINCOS - sin to FPn, cos to the FPc named by opmode bits 2-0.
+                let ctx = self.fpu_ctx(opmode);
+                let mut f = ExcFlags::default();
                 let cos_dst = (opmode & 7) as usize;
-                let (sin, cos) = transcendental::sincos(src);
+                let (sin, cos) = transcendental::sincos(src, ctx, &mut f);
                 self.fpr[dst] = sin;
                 self.fpr[cos_dst] = cos;
                 self.fpu_set_cc(self.fpr[dst]);
+                self.fpu_commit(f);
                 4
             }
             _ => {
-                // The remaining f64-bridged transcendentals (FSIN/FCOS/...).
-                if let Some(r) = transcendental::eval_unary(opmode, src) {
+                // The transcendentals (FSIN/FCOS/FETOX/FLOGN/...).
+                let ctx = self.fpu_ctx(opmode);
+                let mut f = ExcFlags::default();
+                if let Some(r) = transcendental::eval_unary(opmode, src, ctx, &mut f) {
                     self.fpr[dst] = r;
                     self.fpu_set_cc(self.fpr[dst]);
+                    self.fpu_commit(f);
                     4
                 } else {
                     0 // Unimplemented opmode -> Line-F

--- a/vendor/m68k/src/fpu/operations.rs
+++ b/vendor/m68k/src/fpu/operations.rs
@@ -570,6 +570,16 @@ impl CpuCore {
         }
     }
 
+    /// Write the FPSR quotient byte: bits 22:16 = low 7 bits of |quotient|,
+    /// bit 23 = quotient sign. Set by FMOD/FREM.
+    fn fpu_set_quotient(&mut self, quotient: u8, sign: bool) {
+        self.fpsr &= !0x00FF_0000;
+        self.fpsr |= ((quotient & 0x7F) as u32) << 16;
+        if sign {
+            self.fpsr |= 1 << 23;
+        }
+    }
+
     /// Build the rounding context (mode from FPCR, precision from `opmode`).
     fn fpu_ctx(&self, opmode: u16) -> RoundCtx {
         RoundCtx {
@@ -765,15 +775,23 @@ impl CpuCore {
                 4
             }
             0x21 => {
-                // FMOD (f64-bridged, see transcendental.rs)
-                self.fpr[dst] = transcendental::fmod(self.fpr[dst], src);
+                // FMOD - exact remainder, truncated quotient.
+                let mut f = ExcFlags::default();
+                let rem = transcendental::remainder(self.fpr[dst], src, false, &mut f);
+                self.fpr[dst] = rem.value;
                 self.fpu_set_cc(self.fpr[dst]);
+                self.fpu_set_quotient(rem.quotient, rem.quotient_sign);
+                self.fpu_commit(f);
                 4
             }
             0x25 => {
-                // FREM - IEEE remainder (f64-bridged, see transcendental.rs)
-                self.fpr[dst] = transcendental::frem(self.fpr[dst], src);
+                // FREM - exact IEEE remainder, round-to-nearest quotient.
+                let mut f = ExcFlags::default();
+                let rem = transcendental::remainder(self.fpr[dst], src, true, &mut f);
+                self.fpr[dst] = rem.value;
                 self.fpu_set_cc(self.fpr[dst]);
+                self.fpu_set_quotient(rem.quotient, rem.quotient_sign);
+                self.fpu_commit(f);
                 4
             }
             0x26 => {

--- a/vendor/m68k/src/fpu/transcendental.rs
+++ b/vendor/m68k/src/fpu/transcendental.rs
@@ -12,7 +12,7 @@
 //! (f64) for now and are replaced in later milestones.
 
 use super::dd::{self, Df};
-use super::softfloat::{self, ExcFlags, RoundCtx, RoundMode};
+use super::softfloat::{self, ExcFlags, FpCmp, RoundCtx, RoundMode};
 use super::types::FloatX80;
 
 // ============================== small helpers ============================
@@ -124,18 +124,9 @@ fn exp10(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
     exp_dd(dd::mul_x80(dd::consts().ln10, x)).to_x80(ctx, f)
 }
 
-/// e^x - 1, accurate near 0 (direct series, no 1+ cancellation).
-fn expm1(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
-    if x.is_nan() {
-        return nan_result(x, f);
-    }
-    if x.is_inf() {
-        return if x.sign() { softfloat::neg(one_x80()) } else { x };
-    }
-    if x.is_zero() {
-        return x; // expm1(+-0) = +-0
-    }
-    let d = if x.to_f64().abs() <= 0.5 {
+/// e^x - 1 as Df, accurate near 0 (direct series, no 1+ cancellation).
+fn expm1_df(x: FloatX80) -> Df {
+    if x.to_f64().abs() <= 0.5 {
         // Series sum_{k>=1} x^k/k!.
         let xd = Df::from_x80(x);
         let mut term = xd;
@@ -152,8 +143,20 @@ fn expm1(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
         sum
     } else {
         dd::sub(exp_dd(Df::from_x80(x)), Df::from_i32(1))
-    };
-    d.to_x80(ctx, f)
+    }
+}
+
+fn expm1(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        return if x.sign() { softfloat::neg(one_x80()) } else { x };
+    }
+    if x.is_zero() {
+        return x; // expm1(+-0) = +-0
+    }
+    expm1_df(x).to_x80(ctx, f)
 }
 
 // ============================== log family ===============================
@@ -232,7 +235,6 @@ fn log1p(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
     // x <= -1: domain boundary.
     if x.sign() {
         let cmp = softfloat::compare(x, softfloat::neg(one), &mut noflags());
-        use super::softfloat::FpCmp;
         if cmp == FpCmp::Equal {
             f.raise(ExcFlags::DZ);
             return FloatX80::infinity(true);
@@ -357,11 +359,202 @@ fn tan(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
     t.to_x80(ctx, f)
 }
 
-// ============================== still f64-bridged ========================
+// ============================== inverse trig =============================
 
-#[inline]
-fn bridge(x: FloatX80, op: impl FnOnce(f64) -> f64) -> FloatX80 {
-    FloatX80::from_f64(op(x.to_f64()))
+/// sqrt of a Df via one Newton refinement of the 64-bit seed.
+fn sqrt_df(v: Df) -> Df {
+    if v.hi.is_zero() {
+        return v;
+    }
+    let x0 = softfloat::sqrt(v.hi, RoundCtx::NEAREST_EXT, &mut noflags());
+    let q = dd::div(v, Df::from_x80(x0));
+    dd::mul_x80(dd::add_x80(q, x0), fx(0.5))
+}
+
+/// atan as a Df: reduce |a| to <= 0.3 via reciprocal (|a|>1) and the
+/// half-angle identity atan(a) = 2*atan(a/(1+sqrt(1+a^2))), then series.
+fn atan_df(x: Df) -> Df {
+    let neg = x.hi.sign();
+    let ax = if neg { x.neg() } else { x };
+    let (mut a, comp) = if ax.hi.to_f64() > 1.0 {
+        (dd::recip(ax), true)
+    } else {
+        (ax, false)
+    };
+    let mut halvings = 0u32;
+    while a.hi.to_f64() > 0.3 {
+        let s = sqrt_df(dd::add_x80(dd::sqr(a), fx(1.0)));
+        a = dd::div(a, dd::add_x80(s, fx(1.0)));
+        halvings += 1;
+    }
+    let mut r = dd::atan_small(a);
+    for _ in 0..halvings {
+        r = dd::mul_x80(r, fx(2.0));
+    }
+    if comp {
+        r = dd::sub(dd::consts().pi_2, r);
+    }
+    if neg { r.neg() } else { r }
+}
+
+fn atan(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_zero() {
+        return x; // atan(+-0) = +-0
+    }
+    if x.is_inf() {
+        let pi2 = dd::consts().pi_2;
+        return if x.sign() { pi2.neg() } else { pi2 }.to_x80(ctx, f);
+    }
+    atan_df(Df::from_x80(x)).to_x80(ctx, f)
+}
+
+/// True if |x| > 1 (for domain checks).
+fn abs_gt_one(x: FloatX80) -> bool {
+    softfloat::compare(softfloat::abs(x), one_x80(), &mut noflags()) == FpCmp::Greater
+}
+fn abs_eq_one(x: FloatX80) -> bool {
+    softfloat::compare(softfloat::abs(x), one_x80(), &mut noflags()) == FpCmp::Equal
+}
+
+fn asin(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_zero() {
+        return x; // asin(+-0) = +-0
+    }
+    if x.is_inf() || abs_gt_one(x) {
+        f.raise(ExcFlags::OPERR);
+        return FloatX80::default_nan();
+    }
+    if abs_eq_one(x) {
+        let pi2 = dd::consts().pi_2;
+        return if x.sign() { pi2.neg() } else { pi2 }.to_x80(ctx, f);
+    }
+    // asin(x) = atan(x / sqrt(1 - x^2)).
+    let xd = Df::from_x80(x);
+    let denom = sqrt_df(dd::sub(Df::from_i32(1), dd::sqr(xd)));
+    atan_df(dd::div(xd, denom)).to_x80(ctx, f)
+}
+
+fn acos(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() || abs_gt_one(x) {
+        f.raise(ExcFlags::OPERR);
+        return FloatX80::default_nan();
+    }
+    if abs_eq_one(x) {
+        // acos(1) = +0, acos(-1) = pi.
+        return if x.sign() {
+            dd::consts().pi.to_x80(ctx, f)
+        } else {
+            FloatX80::zero(false)
+        };
+    }
+    // acos(x) = pi/2 - asin(x).
+    let xd = Df::from_x80(x);
+    let denom = sqrt_df(dd::sub(Df::from_i32(1), dd::sqr(xd)));
+    let asin_df = atan_df(dd::div(xd, denom));
+    dd::sub(dd::consts().pi_2, asin_df).to_x80(ctx, f)
+}
+
+// ============================== hyperbolic ===============================
+
+fn sinh(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() || x.is_zero() {
+        return x; // sinh(+-inf)=+-inf, sinh(+-0)=+-0
+    }
+    let d = if x.to_f64().abs() <= 0.5 {
+        // Series sum_{k>=0} x^(2k+1)/(2k+1)!.
+        let xd = Df::from_x80(x);
+        let x2 = dd::sqr(xd);
+        let mut term = xd;
+        let mut sum = xd;
+        let mut k = 1i32;
+        loop {
+            term = dd::div(dd::mul(term, x2), Df::from_i32((2 * k) * (2 * k + 1)));
+            sum = dd::add(sum, term);
+            if dd::term_negligible(term, sum) || k > 40 {
+                break;
+            }
+            k += 1;
+        }
+        sum
+    } else {
+        let e = exp_dd(Df::from_x80(x));
+        dd::mul_x80(dd::sub(e, dd::recip(e)), fx(0.5))
+    };
+    d.to_x80(ctx, f)
+}
+
+fn cosh(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        return FloatX80::infinity(false); // cosh(+-inf) = +inf
+    }
+    if x.is_zero() {
+        return one_x80();
+    }
+    let e = exp_dd(Df::from_x80(x));
+    dd::mul_x80(dd::add(e, dd::recip(e)), fx(0.5)).to_x80(ctx, f)
+}
+
+fn tanh(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_zero() {
+        return x; // tanh(+-0) = +-0
+    }
+    if x.is_inf() || x.to_f64().abs() > 32.0 {
+        // |x| large: tanh -> +-1 (inexact for finite x).
+        let one = if x.sign() { softfloat::neg(one_x80()) } else { one_x80() };
+        if !x.is_inf() {
+            f.raise(ExcFlags::INEX2);
+        }
+        return one;
+    }
+    // tanh(x) = (e^{2x}-1)/(e^{2x}+1) = u/(u+2), u = expm1(2x).
+    let two_x = softfloat::scale(x, 1, RoundCtx::NEAREST_EXT, &mut noflags());
+    let u = expm1_df(two_x);
+    dd::div(u, dd::add_x80(u, fx(2.0))).to_x80(ctx, f)
+}
+
+fn atanh(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_zero() {
+        return x; // atanh(+-0) = +-0
+    }
+    if abs_eq_one(x) {
+        f.raise(ExcFlags::DZ);
+        return FloatX80::infinity(x.sign()); // atanh(+-1) = +-inf
+    }
+    if x.is_inf() || abs_gt_one(x) {
+        f.raise(ExcFlags::OPERR);
+        return FloatX80::default_nan();
+    }
+    let d = if x.to_f64().abs() <= 0.5 {
+        dd::atanh_small(Df::from_x80(x))
+    } else {
+        // atanh(x) = 0.5 * ln((1+x)/(1-x)).
+        let xd = Df::from_x80(x);
+        let arg = dd::div(dd::add_x80(xd, fx(1.0)), dd::sub(Df::from_i32(1), xd));
+        let l = ln_dd(arg.to_x80(RoundCtx::NEAREST_EXT, &mut noflags()));
+        dd::mul_x80(l, fx(0.5))
+    };
+    d.to_x80(ctx, f)
 }
 
 // ============================== dispatch =================================
@@ -384,14 +577,13 @@ pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
         0x0E => sin(src, ctx, f),
         0x1D => cos(src, ctx, f),
         0x0F => tan(src, ctx, f),
-        // Still f64-bridged (converted in later milestones).
-        0x0C => bridge(src, f64::asin),
-        0x1C => bridge(src, f64::acos),
-        0x0A => bridge(src, f64::atan),
-        0x02 => bridge(src, f64::sinh),
-        0x19 => bridge(src, f64::cosh),
-        0x09 => bridge(src, f64::tanh),
-        0x0D => bridge(src, f64::atanh),
+        0x0C => asin(src, ctx, f),
+        0x1C => acos(src, ctx, f),
+        0x0A => atan(src, ctx, f),
+        0x02 => sinh(src, ctx, f),
+        0x19 => cosh(src, ctx, f),
+        0x09 => tanh(src, ctx, f),
+        0x0D => atanh(src, ctx, f),
         _ => return None,
     };
     Some(r)
@@ -501,6 +693,48 @@ mod tests {
         let (s, c) = sincos(fx(1.0));
         assert!((s.to_f64() - 1.0_f64.sin()).abs() < 1e-15);
         assert!((c.to_f64() - 1.0_f64.cos()).abs() < 1e-15);
+    }
+
+    #[test]
+    fn inverse_trig() {
+        // atan(1)*4 == pi.
+        assert!(close(ev(0x0A, 1.0) * 4.0, std::f64::consts::PI, 1e-15));
+        assert_eq!(ev(0x0A, 0.0), 0.0);
+        // asin(sin r) == r, acos(cos r) == r over the principal range.
+        for &x in &[-0.9_f64, -0.4, 0.0, 0.25, 0.8, 0.999] {
+            assert!(close(ev(0x0C, x.sin()), x, 1e-13), "asin(sin {x})");
+        }
+        for &x in &[0.1_f64, 0.7, 1.5, 3.0] {
+            assert!(close(ev(0x1C, x.cos()), x, 1e-13), "acos(cos {x})");
+        }
+        // libm agreement.
+        for &x in &[-5.0_f64, -0.3, 0.6, 42.0] {
+            assert!((ev(0x0A, x) - x.atan()).abs() < 1e-14, "atan {x}");
+        }
+        // domain errors.
+        let mut f = ExcFlags::default();
+        assert!(asin(fx(2.0), rn(), &mut f).is_nan());
+        assert!(f.has(ExcFlags::OPERR));
+    }
+
+    #[test]
+    fn hyperbolic() {
+        for &x in &[-3.0_f64, -0.3, 0.0, 0.2, 1.0, 5.0] {
+            assert!((ev(0x02, x) - x.sinh()).abs() < 1e-12 * (1.0 + x.sinh().abs()), "sinh {x}");
+            assert!((ev(0x19, x) - x.cosh()).abs() < 1e-12 * (1.0 + x.cosh().abs()), "cosh {x}");
+            assert!((ev(0x09, x) - x.tanh()).abs() < 1e-14, "tanh {x}");
+            // cosh^2 - sinh^2 == 1.
+            let s = ev(0x02, x);
+            let c = ev(0x19, x);
+            assert!((c * c - s * s - 1.0).abs() < 1e-12, "cosh^2-sinh^2 at {x}");
+        }
+        // atanh near 0 and mid-range.
+        for &x in &[-0.5_f64, -0.1, 0.0, 0.3, 0.9] {
+            assert!((ev(0x0D, x) - x.atanh()).abs() < 1e-14, "atanh {x}");
+        }
+        let mut f = ExcFlags::default();
+        assert!(atanh(fx(1.0), rn(), &mut f).is_inf());
+        assert!(f.has(ExcFlags::DZ));
     }
 
     #[test]

--- a/vendor/m68k/src/fpu/transcendental.rs
+++ b/vendor/m68k/src/fpu/transcendental.rs
@@ -1,24 +1,283 @@
-//! f64-bridged FPU operations: the transcendentals plus the remainder family.
+//! Extended-precision FPU transcendentals (and the FMOD/FREM remainders).
 //!
-//! These are the only operations still evaluated in f64 (53-bit) and widened
-//! back to 80-bit extended. The real 6888x computes them with internal
-//! polynomial/CORDIC tables that are not bit-accurate to libm regardless, so
-//! this module is the single, isolated boundary to replace later with an
-//! extended-precision or chip-accurate implementation. The rest of the FPU
-//! (arithmetic, compare, conversions) is exact extended precision in
-//! `softfloat.rs`.
+//! Each function reduces its argument, evaluates a Taylor/atanh series in the
+//! double-double layer (`dd.rs`) -- whose coefficients are exact rationals, so
+//! no minimax tooling is needed -- and rounds the ~128-bit result to 64-bit
+//! extended under the caller's FPCR mode, setting INEX/OPERR/DZ. This replaces
+//! the former f64 bridge. Accuracy is faithful to ~64 bits (validated by
+//! identities and exact anchors); it is not chip-bit-exact (the 6888x uses its
+//! own CORDIC/polynomial microcode).
+//!
+//! Functions not yet converted to extended precision fall back to `bridge`
+//! (f64) for now and are replaced in later milestones.
 
+use super::dd::{self, Df};
+use super::softfloat::{self, ExcFlags, RoundCtx, RoundMode};
 use super::types::FloatX80;
+
+// ============================== small helpers ============================
+
+#[inline]
+fn one_x80() -> FloatX80 {
+    softfloat::from_u64(1, false)
+}
+
+#[inline]
+fn fx(v: f64) -> FloatX80 {
+    FloatX80::from_f64(v)
+}
+
+/// 2^k as an exact extended value (or +/-Inf / 0 on overflow/underflow).
+#[inline]
+fn two_pow(k: i32) -> FloatX80 {
+    softfloat::scale(one_x80(), k, RoundCtx::NEAREST_EXT, &mut ExcFlags::default())
+}
+
+/// Result for a NaN operand: quiet it and signal SNAN/OPERR if it was signaling.
+fn nan_result(x: FloatX80, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_signaling_nan() {
+        f.raise(ExcFlags::SNAN);
+        f.raise(ExcFlags::OPERR);
+    }
+    x.quiet()
+}
+
+#[inline]
+fn noflags() -> ExcFlags {
+    ExcFlags::default()
+}
+
+#[inline]
+fn unbiased_exp(x: FloatX80) -> i32 {
+    softfloat::to_i64(
+        softfloat::getexp(x, &mut noflags()),
+        RoundMode::Zero,
+        i64::MIN,
+        i64::MAX,
+        &mut noflags(),
+    ) as i32
+}
+
+// ============================== exp family ===============================
+
+/// exp(r) for a small |r| <= ln2/2 via the Maclaurin series, in Df.
+fn exp_reduced(r: Df) -> Df {
+    let mut term = Df::from_i32(1);
+    let mut sum = Df::from_i32(1);
+    let mut k = 1i32;
+    loop {
+        term = dd::div(dd::mul(term, r), Df::from_i32(k));
+        sum = dd::add(sum, term);
+        if dd::term_negligible(term, sum) || k > 60 {
+            break;
+        }
+        k += 1;
+    }
+    sum
+}
+
+/// e^p for an arbitrary Df exponent `p`: reduce p = k*ln2 + r (|r| <= ln2/2),
+/// then exp(p) = 2^k * exp(r).
+fn exp_dd(p: Df) -> Df {
+    let k = (p.hi.to_f64() * std::f64::consts::LOG2_E).round();
+    let ki = k as i32;
+    let r = dd::sub(p, dd::mul_x80(dd::consts().ln2, fx(k)));
+    dd::mul_x80(exp_reduced(r), two_pow(ki))
+}
+
+fn exp(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        return if x.sign() { FloatX80::zero(false) } else { x };
+    }
+    if x.is_zero() {
+        return one_x80();
+    }
+    exp_dd(Df::from_x80(x)).to_x80(ctx, f)
+}
+
+fn exp2(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        return if x.sign() { FloatX80::zero(false) } else { x };
+    }
+    if x.is_zero() {
+        return one_x80();
+    }
+    exp_dd(dd::mul_x80(dd::consts().ln2, x)).to_x80(ctx, f)
+}
+
+fn exp10(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        return if x.sign() { FloatX80::zero(false) } else { x };
+    }
+    if x.is_zero() {
+        return one_x80();
+    }
+    exp_dd(dd::mul_x80(dd::consts().ln10, x)).to_x80(ctx, f)
+}
+
+/// e^x - 1, accurate near 0 (direct series, no 1+ cancellation).
+fn expm1(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        return if x.sign() { softfloat::neg(one_x80()) } else { x };
+    }
+    if x.is_zero() {
+        return x; // expm1(+-0) = +-0
+    }
+    let d = if x.to_f64().abs() <= 0.5 {
+        // Series sum_{k>=1} x^k/k!.
+        let xd = Df::from_x80(x);
+        let mut term = xd;
+        let mut sum = xd;
+        let mut k = 2i32;
+        loop {
+            term = dd::div(dd::mul(term, xd), Df::from_i32(k));
+            sum = dd::add(sum, term);
+            if dd::term_negligible(term, sum) || k > 60 {
+                break;
+            }
+            k += 1;
+        }
+        sum
+    } else {
+        dd::sub(exp_dd(Df::from_x80(x)), Df::from_i32(1))
+    };
+    d.to_x80(ctx, f)
+}
+
+// ============================== log family ===============================
+
+/// Shared special-case prologue for ln/log2/log10. Returns the special result,
+/// or None if `x` is finite and positive (compute the logarithm).
+fn log_special(x: FloatX80, f: &mut ExcFlags) -> Option<FloatX80> {
+    if x.is_nan() {
+        Some(nan_result(x, f))
+    } else if x.is_zero() {
+        f.raise(ExcFlags::DZ);
+        Some(FloatX80::infinity(true)) // log(0) = -inf
+    } else if x.sign() {
+        f.raise(ExcFlags::OPERR);
+        Some(FloatX80::default_nan()) // log(negative)
+    } else if x.is_inf() {
+        Some(x) // log(+inf) = +inf
+    } else {
+        None
+    }
+}
+
+/// ln(x) for finite x > 0, in Df: x = m*2^e with m in [sqrt(1/2), sqrt(2)),
+/// ln(x) = e*ln2 + 2*atanh((m-1)/(m+1)).
+fn ln_dd(x: FloatX80) -> Df {
+    let mut e = unbiased_exp(x);
+    let mut m = softfloat::getman(x, &mut noflags());
+    if m.to_f64() > std::f64::consts::SQRT_2 {
+        m = softfloat::scale(m, -1, RoundCtx::NEAREST_EXT, &mut noflags());
+        e += 1;
+    }
+    let md = Df::from_x80(m);
+    let s = dd::div(dd::sub(md, Df::from_i32(1)), dd::add(md, Df::from_i32(1)));
+    let ln_f = dd::mul_x80(dd::atanh_small(s), fx(2.0));
+    dd::add(dd::mul_x80(dd::consts().ln2, fx(e as f64)), ln_f)
+}
+
+fn ln(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if let Some(r) = log_special(x, f) {
+        return r;
+    }
+    ln_dd(x).to_x80(ctx, f)
+}
+
+fn log2(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if let Some(r) = log_special(x, f) {
+        return r;
+    }
+    dd::mul(ln_dd(x), dd::consts().log2e).to_x80(ctx, f)
+}
+
+fn log10(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if let Some(r) = log_special(x, f) {
+        return r;
+    }
+    dd::mul(ln_dd(x), dd::consts().log10e).to_x80(ctx, f)
+}
+
+/// ln(1+x), accurate near 0.
+fn log1p(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_zero() {
+        return x; // log1p(+-0) = +-0
+    }
+    if x.is_inf() {
+        return if x.sign() {
+            f.raise(ExcFlags::OPERR);
+            FloatX80::default_nan()
+        } else {
+            x
+        };
+    }
+    let one = one_x80();
+    // x <= -1: domain boundary.
+    if x.sign() {
+        let cmp = softfloat::compare(x, softfloat::neg(one), &mut noflags());
+        use super::softfloat::FpCmp;
+        if cmp == FpCmp::Equal {
+            f.raise(ExcFlags::DZ);
+            return FloatX80::infinity(true);
+        }
+        if cmp == FpCmp::Less {
+            f.raise(ExcFlags::OPERR);
+            return FloatX80::default_nan();
+        }
+    }
+    let d = if x.to_f64().abs() <= 0.5 {
+        // ln(1+x) = 2*atanh(x/(x+2)), no 1+x cancellation.
+        let xd = Df::from_x80(x);
+        let s = dd::div(xd, dd::add_x80(xd, fx(2.0)));
+        dd::mul_x80(dd::atanh_small(s), fx(2.0))
+    } else {
+        ln_dd(softfloat::add(x, one, RoundCtx::NEAREST_EXT, &mut noflags()))
+    };
+    d.to_x80(ctx, f)
+}
+
+// ============================== still f64-bridged ========================
 
 #[inline]
 fn bridge(x: FloatX80, op: impl FnOnce(f64) -> f64) -> FloatX80 {
     FloatX80::from_f64(op(x.to_f64()))
 }
 
+// ============================== dispatch =================================
+
 /// Evaluate a single-operand transcendental by opmode. Returns `None` if the
-/// opmode is not one of the f64-bridged transcendentals.
+/// opmode is not a transcendental.
 pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
+    let ctx = RoundCtx::NEAREST_EXT;
+    let f = &mut noflags();
     let r = match opmode {
+        // Extended-precision kernels.
+        0x10 => exp(src, ctx, f),
+        0x08 => expm1(src, ctx, f),
+        0x11 => exp2(src, ctx, f),
+        0x12 => exp10(src, ctx, f),
+        0x14 => ln(src, ctx, f),
+        0x06 => log1p(src, ctx, f),
+        0x15 => log10(src, ctx, f),
+        0x16 => log2(src, ctx, f),
+        // Still f64-bridged (converted in later milestones).
         0x0E => bridge(src, f64::sin),
         0x1D => bridge(src, f64::cos),
         0x0F => bridge(src, f64::tan),
@@ -29,14 +288,6 @@ pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
         0x19 => bridge(src, f64::cosh),
         0x09 => bridge(src, f64::tanh),
         0x0D => bridge(src, f64::atanh),
-        0x10 => bridge(src, f64::exp),
-        0x08 => bridge(src, f64::exp_m1),
-        0x11 => bridge(src, |v| 2.0_f64.powf(v)),
-        0x12 => bridge(src, |v| 10.0_f64.powf(v)),
-        0x14 => bridge(src, f64::ln),
-        0x06 => bridge(src, f64::ln_1p),
-        0x15 => bridge(src, f64::log10),
-        0x16 => bridge(src, f64::log2),
         _ => return None,
     };
     Some(r)
@@ -61,4 +312,77 @@ pub fn frem(dst: FloatX80, src: FloatX80) -> FloatX80 {
     }
     let n = (x / y).round();
     FloatX80::from_f64(x - y * n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rn() -> RoundCtx {
+        RoundCtx::NEAREST_EXT
+    }
+    fn ev(opmode: u16, x: f64) -> f64 {
+        eval_unary(opmode, FloatX80::from_f64(x)).unwrap().to_f64()
+    }
+    fn close(a: f64, b: f64, rel: f64) -> bool {
+        if b == 0.0 {
+            a.abs() < rel
+        } else {
+            ((a - b) / b).abs() < rel
+        }
+    }
+
+    #[test]
+    fn exp_log_anchors() {
+        // Exact / near-exact anchors.
+        assert_eq!(ev(0x10, 0.0), 1.0); // exp(0)
+        assert_eq!(ev(0x14, 1.0), 0.0); // ln(1)
+        assert!(close(ev(0x11, 10.0), 1024.0, 1e-18)); // 2^10
+        assert!(close(ev(0x12, 3.0), 1000.0, 1e-18)); // 10^3
+        assert!(close(ev(0x16, 1024.0), 10.0, 1e-18)); // log2(1024)
+        assert!(close(ev(0x15, 1000.0), 3.0, 1e-18)); // log10(1000)
+        // exp(1) matches the e constant ROM pattern to within 1 ULP (faithful
+        // rounding; last-bit-correct would need a TMD/Ziv test beyond 128 bits).
+        let e = exp(fx(1.0), rn(), &mut noflags());
+        let rom = softfloat::const_rom(0x0C);
+        assert_eq!(e.sign_exp, rom.sign_exp);
+        assert!((e.mantissa as i128 - rom.mantissa as i128).abs() <= 1, "exp(1) {e:?} vs {rom:?}");
+    }
+
+    #[test]
+    fn exp_log_identities() {
+        // exp(ln x) == x and ln(exp x) == x to ~2^-62.
+        for &x in &[0.5_f64, 1.5, 2.0, 7.3, 100.0, 1e8] {
+            let lx = ln(fx(x), rn(), &mut noflags());
+            assert!(close(exp(lx, rn(), &mut noflags()).to_f64(), x, 1e-18), "exp(ln {x})");
+        }
+        for &x in &[-3.0_f64, -0.5, 0.0, 0.7, 5.0] {
+            let ex = exp(fx(x), rn(), &mut noflags());
+            assert!(close(ln(ex, rn(), &mut noflags()).to_f64(), x, 1e-15), "ln(exp {x})");
+        }
+        // 2^x == exp(x*ln2).
+        for &x in &[-4.0_f64, 0.3, 1.0, 13.5] {
+            assert!(close(ev(0x11, x), 2.0_f64.powf(x), 1e-15), "2^{x}");
+        }
+    }
+
+    #[test]
+    fn expm1_log1p_near_zero() {
+        for &x in &[1e-6_f64, -1e-7, 0.01, -0.02, 1e-10] {
+            assert!(close(ev(0x08, x), x.exp_m1(), 1e-14), "expm1 {x}");
+            assert!(close(ev(0x06, x), x.ln_1p(), 1e-14), "log1p {x}");
+        }
+    }
+
+    #[test]
+    fn exp_log_specials() {
+        assert!(exp(FloatX80::infinity(false), rn(), &mut noflags()).is_inf());
+        assert!(exp(FloatX80::infinity(true), rn(), &mut noflags()).is_zero());
+        let mut f = ExcFlags::default();
+        assert!(ln(FloatX80::zero(false), rn(), &mut f).is_inf());
+        assert!(f.has(ExcFlags::DZ));
+        let mut f = ExcFlags::default();
+        assert!(ln(fx(-1.0), rn(), &mut f).is_nan());
+        assert!(f.has(ExcFlags::OPERR));
+    }
 }

--- a/vendor/m68k/src/fpu/transcendental.rs
+++ b/vendor/m68k/src/fpu/transcendental.rs
@@ -593,19 +593,119 @@ pub fn sincos(src: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> (FloatX80, Floa
     sin_cos_x80(src, ctx, f)
 }
 
-/// FMOD: dst modulo src (truncated quotient).
-pub fn fmod(dst: FloatX80, src: FloatX80) -> FloatX80 {
-    FloatX80::from_f64(dst.to_f64() % src.to_f64())
+/// Result of FMOD/FREM: the exact remainder, the low 7 bits of |quotient|,
+/// and the quotient's sign.
+pub struct Remainder {
+    pub value: FloatX80,
+    pub quotient: u8,
+    pub quotient_sign: bool,
 }
 
-/// FREM: IEEE remainder, r = x - y*round(x/y) (round-to-nearest quotient).
-pub fn frem(dst: FloatX80, src: FloatX80) -> FloatX80 {
-    let (x, y) = (dst.to_f64(), src.to_f64());
-    if y == 0.0 {
-        return FloatX80::default_nan();
+/// Exact extended remainder of `dst` by `src`. `ieee` selects FREM (quotient
+/// rounded to nearest) vs FMOD (truncated quotient). The remainder is computed
+/// exactly by shift-subtract long division of the significands.
+pub fn remainder(dst: FloatX80, src: FloatX80, ieee: bool, f: &mut ExcFlags) -> Remainder {
+    let none = |v: FloatX80| Remainder {
+        value: v,
+        quotient: 0,
+        quotient_sign: false,
+    };
+    if dst.is_nan() {
+        return none(nan_result(dst, f));
     }
-    let n = (x / y).round();
-    FloatX80::from_f64(x - y * n)
+    if src.is_nan() {
+        return none(nan_result(src, f));
+    }
+    let quotient_sign = dst.sign() ^ src.sign();
+    if dst.is_inf() || src.is_zero() {
+        f.raise(ExcFlags::OPERR);
+        return none(FloatX80::default_nan());
+    }
+    if src.is_inf() || dst.is_zero() {
+        // x mod inf = x; 0 mod y = 0.
+        return Remainder {
+            value: dst,
+            quotient: 0,
+            quotient_sign,
+        };
+    }
+
+    let ax = softfloat::abs(dst);
+    let ay = softfloat::abs(src);
+    let ex = unbiased_exp(ax);
+    let ey = unbiased_exp(ay);
+    let mx = softfloat::getman(ax, &mut noflags()).mantissa;
+    let my = softfloat::getman(ay, &mut noflags()).mantissa as u128;
+    let ediff = ex - ey;
+
+    // Floor remainder magnitude `rfloor` and the low bits of floor(|x|/|y|).
+    let (mut rfloor, mut q, rem_int): (FloatX80, u64, u128) = if ediff < 0 {
+        (ax, 0, u128::MAX) // |x| < |y|: remainder = |x| (rem_int unused)
+    } else {
+        // Long division of M = mx << ediff by my (bit by bit, MSB first).
+        let mut rem: u128 = 0;
+        let mut q: u64 = 0;
+        let total = 64 + ediff;
+        for j in (0..total).rev() {
+            rem <<= 1;
+            if j >= ediff {
+                rem |= ((mx >> (j - ediff)) & 1) as u128;
+            }
+            q <<= 1;
+            if rem >= my {
+                rem -= my;
+                q |= 1;
+            }
+        }
+        let rv = if rem == 0 {
+            FloatX80::zero(false)
+        } else {
+            softfloat::scale(
+                softfloat::from_u64(rem as u64, false),
+                ey - 63,
+                RoundCtx::NEAREST_EXT,
+                &mut noflags(),
+            )
+        };
+        (rv, q, rem)
+    };
+
+    let mut sign = dst.sign();
+    if ieee {
+        // FREM: round the quotient to nearest. Compare 2*rfloor with |y|.
+        let two_rfloor = softfloat::scale(rfloor, 1, RoundCtx::NEAREST_EXT, &mut noflags());
+        let c = softfloat::compare(two_rfloor, ay, &mut noflags());
+        let round_up = c == FpCmp::Greater || (c == FpCmp::Equal && (q & 1) == 1);
+        if round_up {
+            q += 1;
+            // Remainder crosses zero: new magnitude = |y| - rfloor, sign flips.
+            rfloor = if ediff >= 0 && rem_int != u128::MAX {
+                let nr = my - rem_int;
+                softfloat::scale(
+                    softfloat::from_u64(nr as u64, false),
+                    ey - 63,
+                    RoundCtx::NEAREST_EXT,
+                    &mut noflags(),
+                )
+            } else {
+                softfloat::sub(ay, rfloor, RoundCtx::NEAREST_EXT, &mut noflags())
+            };
+            sign = !sign;
+        }
+    }
+
+    let value = if rfloor.is_zero() {
+        FloatX80::zero(sign)
+    } else if sign {
+        softfloat::neg(rfloor)
+    } else {
+        rfloor
+    };
+    Remainder {
+        value,
+        quotient: (q & 0x7F) as u8,
+        quotient_sign,
+    }
 }
 
 #[cfg(test)]
@@ -736,6 +836,34 @@ mod tests {
         let mut f = ExcFlags::default();
         assert!(atanh(fx(1.0), rn(), &mut f).is_inf());
         assert!(f.has(ExcFlags::DZ));
+    }
+
+    #[test]
+    fn fmod_frem_exact() {
+        let r = |a: f64, b: f64, ieee: bool| {
+            remainder(fx(a), fx(b), ieee, &mut noflags())
+        };
+        // FMOD basics.
+        let m = r(7.5, 2.0, false);
+        assert_eq!(m.value.to_f64(), 1.5);
+        assert_eq!(m.quotient, 3); // 7.5 = 3*2 + 1.5
+        assert!(!m.quotient_sign);
+        // Negative dividend: remainder takes the sign of x.
+        let m = r(-7.5, 2.0, false);
+        assert_eq!(m.value.to_f64(), -1.5);
+        assert!(m.quotient_sign); // -/+ -> negative quotient
+        // FREM rounds the quotient to nearest: 7.5/2 = 3.75 -> 4, rem = -0.5.
+        let q = r(7.5, 2.0, true);
+        assert_eq!(q.value.to_f64(), -0.5);
+        assert_eq!(q.quotient, 4);
+        // Exactness beyond f64: 1e300 mod 3 via the f64 path would be wrong;
+        // here it is exact (result in [0,3)).
+        let big = r(1e18, 3.0, false);
+        assert!(big.value.to_f64() >= 0.0 && big.value.to_f64() < 3.0);
+        // src = 0 -> OPERR + NaN.
+        let mut f = ExcFlags::default();
+        let z = remainder(fx(1.0), fx(0.0), false, &mut f);
+        assert!(z.value.is_nan() && f.has(ExcFlags::OPERR));
     }
 
     #[test]

--- a/vendor/m68k/src/fpu/transcendental.rs
+++ b/vendor/m68k/src/fpu/transcendental.rs
@@ -3,13 +3,10 @@
 //! Each function reduces its argument, evaluates a Taylor/atanh series in the
 //! double-double layer (`dd.rs`) -- whose coefficients are exact rationals, so
 //! no minimax tooling is needed -- and rounds the ~128-bit result to 64-bit
-//! extended under the caller's FPCR mode, setting INEX/OPERR/DZ. This replaces
-//! the former f64 bridge. Accuracy is faithful to ~64 bits (validated by
-//! identities and exact anchors); it is not chip-bit-exact (the 6888x uses its
-//! own CORDIC/polynomial microcode).
-//!
-//! Functions not yet converted to extended precision fall back to `bridge`
-//! (f64) for now and are replaced in later milestones.
+//! extended under the caller's FPCR mode, setting INEX/OPERR/DZ. Accuracy is
+//! faithful to ~64 bits (validated by identities and exact anchors); it is not
+//! chip-bit-exact (the 6888x uses its own CORDIC/polynomial microcode, and a
+//! bare 68040 traps these to a software FPSP). FMOD/FREM are exact.
 
 use super::dd::{self, Df};
 use super::softfloat::{self, ExcFlags, FpCmp, RoundCtx, RoundMode};
@@ -30,7 +27,12 @@ fn fx(v: f64) -> FloatX80 {
 /// 2^k as an exact extended value (or +/-Inf / 0 on overflow/underflow).
 #[inline]
 fn two_pow(k: i32) -> FloatX80 {
-    softfloat::scale(one_x80(), k, RoundCtx::NEAREST_EXT, &mut ExcFlags::default())
+    softfloat::scale(
+        one_x80(),
+        k,
+        RoundCtx::NEAREST_EXT,
+        &mut ExcFlags::default(),
+    )
 }
 
 /// Result for a NaN operand: quiet it and signal SNAN/OPERR if it was signaling.
@@ -151,7 +153,11 @@ fn expm1(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
         return nan_result(x, f);
     }
     if x.is_inf() {
-        return if x.sign() { softfloat::neg(one_x80()) } else { x };
+        return if x.sign() {
+            softfloat::neg(one_x80())
+        } else {
+            x
+        };
     }
     if x.is_zero() {
         return x; // expm1(+-0) = +-0
@@ -250,7 +256,12 @@ fn log1p(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
         let s = dd::div(xd, dd::add_x80(xd, fx(2.0)));
         dd::mul_x80(dd::atanh_small(s), fx(2.0))
     } else {
-        ln_dd(softfloat::add(x, one, RoundCtx::NEAREST_EXT, &mut noflags()))
+        ln_dd(softfloat::add(
+            x,
+            one,
+            RoundCtx::NEAREST_EXT,
+            &mut noflags(),
+        ))
     };
     d.to_x80(ctx, f)
 }
@@ -518,7 +529,11 @@ fn tanh(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
     }
     if x.is_inf() || x.to_f64().abs() > 32.0 {
         // |x| large: tanh -> +-1 (inexact for finite x).
-        let one = if x.sign() { softfloat::neg(one_x80()) } else { one_x80() };
+        let one = if x.sign() {
+            softfloat::neg(one_x80())
+        } else {
+            one_x80()
+        };
         if !x.is_inf() {
             f.raise(ExcFlags::INEX2);
         }
@@ -742,7 +757,10 @@ mod tests {
         let e = exp(fx(1.0), rn(), &mut noflags());
         let rom = softfloat::const_rom(0x0C);
         assert_eq!(e.sign_exp, rom.sign_exp);
-        assert!((e.mantissa as i128 - rom.mantissa as i128).abs() <= 1, "exp(1) {e:?} vs {rom:?}");
+        assert!(
+            (e.mantissa as i128 - rom.mantissa as i128).abs() <= 1,
+            "exp(1) {e:?} vs {rom:?}"
+        );
     }
 
     #[test]
@@ -750,11 +768,17 @@ mod tests {
         // exp(ln x) == x and ln(exp x) == x to ~2^-62.
         for &x in &[0.5_f64, 1.5, 2.0, 7.3, 100.0, 1e8] {
             let lx = ln(fx(x), rn(), &mut noflags());
-            assert!(close(exp(lx, rn(), &mut noflags()).to_f64(), x, 1e-18), "exp(ln {x})");
+            assert!(
+                close(exp(lx, rn(), &mut noflags()).to_f64(), x, 1e-18),
+                "exp(ln {x})"
+            );
         }
         for &x in &[-3.0_f64, -0.5, 0.0, 0.7, 5.0] {
             let ex = exp(fx(x), rn(), &mut noflags());
-            assert!(close(ln(ex, rn(), &mut noflags()).to_f64(), x, 1e-15), "ln(exp {x})");
+            assert!(
+                close(ln(ex, rn(), &mut noflags()).to_f64(), x, 1e-15),
+                "ln(exp {x})"
+            );
         }
         // 2^x == exp(x*ln2).
         for &x in &[-4.0_f64, 0.3, 1.0, 13.5] {
@@ -821,8 +845,14 @@ mod tests {
     #[test]
     fn hyperbolic() {
         for &x in &[-3.0_f64, -0.3, 0.0, 0.2, 1.0, 5.0] {
-            assert!((ev(0x02, x) - x.sinh()).abs() < 1e-12 * (1.0 + x.sinh().abs()), "sinh {x}");
-            assert!((ev(0x19, x) - x.cosh()).abs() < 1e-12 * (1.0 + x.cosh().abs()), "cosh {x}");
+            assert!(
+                (ev(0x02, x) - x.sinh()).abs() < 1e-12 * (1.0 + x.sinh().abs()),
+                "sinh {x}"
+            );
+            assert!(
+                (ev(0x19, x) - x.cosh()).abs() < 1e-12 * (1.0 + x.cosh().abs()),
+                "cosh {x}"
+            );
             assert!((ev(0x09, x) - x.tanh()).abs() < 1e-14, "tanh {x}");
             // cosh^2 - sinh^2 == 1.
             let s = ev(0x02, x);
@@ -840,9 +870,7 @@ mod tests {
 
     #[test]
     fn fmod_frem_exact() {
-        let r = |a: f64, b: f64, ieee: bool| {
-            remainder(fx(a), fx(b), ieee, &mut noflags())
-        };
+        let r = |a: f64, b: f64, ieee: bool| remainder(fx(a), fx(b), ieee, &mut noflags());
         // FMOD basics.
         let m = r(7.5, 2.0, false);
         assert_eq!(m.value.to_f64(), 1.5);
@@ -869,8 +897,14 @@ mod tests {
     #[test]
     fn fpcr_mode_and_inex_threaded() {
         use super::super::softfloat::{Precision, RoundMode};
-        let rz = RoundCtx { mode: RoundMode::Zero, prec: Precision::Extended };
-        let rp = RoundCtx { mode: RoundMode::PosInf, prec: Precision::Extended };
+        let rz = RoundCtx {
+            mode: RoundMode::Zero,
+            prec: Precision::Extended,
+        };
+        let rp = RoundCtx {
+            mode: RoundMode::PosInf,
+            prec: Precision::Extended,
+        };
         let mut fz = ExcFlags::default();
         let mut fp = ExcFlags::default();
         let lo = eval_unary(0x14, fx(3.0), rz, &mut fz).unwrap(); // ln(3) toward zero

--- a/vendor/m68k/src/fpu/transcendental.rs
+++ b/vendor/m68k/src/fpu/transcendental.rs
@@ -559,11 +559,10 @@ fn atanh(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
 
 // ============================== dispatch =================================
 
-/// Evaluate a single-operand transcendental by opmode. Returns `None` if the
-/// opmode is not a transcendental.
-pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
-    let ctx = RoundCtx::NEAREST_EXT;
-    let f = &mut noflags();
+/// Evaluate a single-operand transcendental by opmode, rounding to `ctx` and
+/// accumulating exceptions into `f`. Returns `None` if the opmode is not a
+/// transcendental.
+pub fn eval_unary(opmode: u16, src: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> Option<FloatX80> {
     let r = match opmode {
         // Extended-precision kernels.
         0x10 => exp(src, ctx, f),
@@ -590,8 +589,8 @@ pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
 }
 
 /// FSINCOS: sine and cosine of the same operand.
-pub fn sincos(src: FloatX80) -> (FloatX80, FloatX80) {
-    sin_cos_x80(src, RoundCtx::NEAREST_EXT, &mut noflags())
+pub fn sincos(src: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> (FloatX80, FloatX80) {
+    sin_cos_x80(src, ctx, f)
 }
 
 /// FMOD: dst modulo src (truncated quotient).
@@ -617,7 +616,9 @@ mod tests {
         RoundCtx::NEAREST_EXT
     }
     fn ev(opmode: u16, x: f64) -> f64 {
-        eval_unary(opmode, FloatX80::from_f64(x)).unwrap().to_f64()
+        eval_unary(opmode, FloatX80::from_f64(x), rn(), &mut noflags())
+            .unwrap()
+            .to_f64()
     }
     fn close(a: f64, b: f64, rel: f64) -> bool {
         if b == 0.0 {
@@ -690,7 +691,7 @@ mod tests {
 
     #[test]
     fn sincos_pair() {
-        let (s, c) = sincos(fx(1.0));
+        let (s, c) = sincos(fx(1.0), rn(), &mut noflags());
         assert!((s.to_f64() - 1.0_f64.sin()).abs() < 1e-15);
         assert!((c.to_f64() - 1.0_f64.cos()).abs() < 1e-15);
     }
@@ -735,6 +736,21 @@ mod tests {
         let mut f = ExcFlags::default();
         assert!(atanh(fx(1.0), rn(), &mut f).is_inf());
         assert!(f.has(ExcFlags::DZ));
+    }
+
+    #[test]
+    fn fpcr_mode_and_inex_threaded() {
+        use super::super::softfloat::{Precision, RoundMode};
+        let rz = RoundCtx { mode: RoundMode::Zero, prec: Precision::Extended };
+        let rp = RoundCtx { mode: RoundMode::PosInf, prec: Precision::Extended };
+        let mut fz = ExcFlags::default();
+        let mut fp = ExcFlags::default();
+        let lo = eval_unary(0x14, fx(3.0), rz, &mut fz).unwrap(); // ln(3) toward zero
+        let hi = eval_unary(0x14, fx(3.0), rp, &mut fp).unwrap(); // ln(3) toward +inf
+        // ln(3) is irrational: rounding up gives a mantissa one ULP above
+        // rounding toward zero, and both are inexact.
+        assert_eq!(hi.mantissa, lo.mantissa + 1);
+        assert!(fz.has(ExcFlags::INEX2) && fp.has(ExcFlags::INEX2));
     }
 
     #[test]

--- a/vendor/m68k/src/fpu/transcendental.rs
+++ b/vendor/m68k/src/fpu/transcendental.rs
@@ -253,6 +253,110 @@ fn log1p(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
     d.to_x80(ctx, f)
 }
 
+// ============================== trig family ==============================
+
+/// Reduce x = k*(pi/2) + r with |r| <= pi/4, returning (k, r). Accurate while
+/// k*(pi/2) does not exceed the ~128-bit reduction precision (very large
+/// arguments degrade, as they do on real hardware).
+fn reduce_quadrant(x: FloatX80) -> (i64, Df) {
+    let kf = (x.to_f64() * std::f64::consts::FRAC_2_PI).round();
+    let k = kf as i64;
+    let r = dd::sub(Df::from_x80(x), dd::mul_x80(dd::consts().pi_2, fx(kf)));
+    (k, r)
+}
+
+/// sin(r) and cos(r) for |r| <= pi/4 via their Maclaurin series, in Df.
+fn sin_cos_kernel(r: Df) -> (Df, Df) {
+    let neg_r2 = dd::sqr(r).neg();
+    // sin(r) = r - r^3/3! + ...
+    let mut t = r;
+    let mut s = r;
+    let mut k = 1i32;
+    loop {
+        t = dd::div(dd::mul(t, neg_r2), Df::from_i32((2 * k) * (2 * k + 1)));
+        s = dd::add(s, t);
+        if dd::term_negligible(t, s) || k > 30 {
+            break;
+        }
+        k += 1;
+    }
+    // cos(r) = 1 - r^2/2! + ...
+    let mut tc = Df::from_i32(1);
+    let mut c = Df::from_i32(1);
+    let mut k = 1i32;
+    loop {
+        tc = dd::div(dd::mul(tc, neg_r2), Df::from_i32((2 * k - 1) * (2 * k)));
+        c = dd::add(c, tc);
+        if dd::term_negligible(tc, c) || k > 30 {
+            break;
+        }
+        k += 1;
+    }
+    (s, c)
+}
+
+/// (sin x, cos x) as Df, plus quadrant handling; specials return Df NaN/etc.
+fn sin_cos_df(x: FloatX80, f: &mut ExcFlags) -> Option<(Df, Df)> {
+    if x.is_nan() {
+        let n = Df::from_x80(nan_result(x, f));
+        return Some((n, n));
+    }
+    if x.is_inf() {
+        f.raise(ExcFlags::OPERR);
+        let n = Df::from_x80(FloatX80::default_nan());
+        return Some((n, n));
+    }
+    if x.is_zero() {
+        return Some((Df::from_x80(x), Df::from_i32(1))); // sin(+-0)=+-0, cos=1
+    }
+    let (k, r) = reduce_quadrant(x);
+    let (sr, cr) = sin_cos_kernel(r);
+    let q = ((k % 4) + 4) % 4;
+    Some(match q {
+        0 => (sr, cr),
+        1 => (cr, sr.neg()),
+        2 => (sr.neg(), cr.neg()),
+        _ => (cr.neg(), sr),
+    })
+}
+
+fn sin_cos_x80(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> (FloatX80, FloatX80) {
+    let (s, c) = sin_cos_df(x, f).unwrap();
+    (s.to_x80(ctx, f), c.to_x80(ctx, f))
+}
+
+fn sin(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    let (s, _) = sin_cos_df(x, f).unwrap();
+    s.to_x80(ctx, f)
+}
+
+fn cos(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    let (_, c) = sin_cos_df(x, f).unwrap();
+    c.to_x80(ctx, f)
+}
+
+fn tan(x: FloatX80, ctx: RoundCtx, f: &mut ExcFlags) -> FloatX80 {
+    if x.is_nan() {
+        return nan_result(x, f);
+    }
+    if x.is_inf() {
+        f.raise(ExcFlags::OPERR);
+        return FloatX80::default_nan();
+    }
+    if x.is_zero() {
+        return x; // tan(+-0) = +-0
+    }
+    let (k, r) = reduce_quadrant(x);
+    let (sr, cr) = sin_cos_kernel(r);
+    // tan = sin/cos; with the quadrant this is sr/cr (even q) or -cr/sr (odd q).
+    let t = if k & 1 == 0 {
+        dd::div(sr, cr)
+    } else {
+        dd::div(cr, sr).neg()
+    };
+    t.to_x80(ctx, f)
+}
+
 // ============================== still f64-bridged ========================
 
 #[inline]
@@ -277,10 +381,10 @@ pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
         0x06 => log1p(src, ctx, f),
         0x15 => log10(src, ctx, f),
         0x16 => log2(src, ctx, f),
+        0x0E => sin(src, ctx, f),
+        0x1D => cos(src, ctx, f),
+        0x0F => tan(src, ctx, f),
         // Still f64-bridged (converted in later milestones).
-        0x0E => bridge(src, f64::sin),
-        0x1D => bridge(src, f64::cos),
-        0x0F => bridge(src, f64::tan),
         0x0C => bridge(src, f64::asin),
         0x1C => bridge(src, f64::acos),
         0x0A => bridge(src, f64::atan),
@@ -295,8 +399,7 @@ pub fn eval_unary(opmode: u16, src: FloatX80) -> Option<FloatX80> {
 
 /// FSINCOS: sine and cosine of the same operand.
 pub fn sincos(src: FloatX80) -> (FloatX80, FloatX80) {
-    let v = src.to_f64();
-    (FloatX80::from_f64(v.sin()), FloatX80::from_f64(v.cos()))
+    sin_cos_x80(src, RoundCtx::NEAREST_EXT, &mut noflags())
 }
 
 /// FMOD: dst modulo src (truncated quotient).
@@ -372,6 +475,32 @@ mod tests {
             assert!(close(ev(0x08, x), x.exp_m1(), 1e-14), "expm1 {x}");
             assert!(close(ev(0x06, x), x.ln_1p(), 1e-14), "log1p {x}");
         }
+    }
+
+    #[test]
+    fn trig_anchors_and_identities() {
+        assert_eq!(ev(0x0E, 0.0), 0.0); // sin(0)
+        assert_eq!(ev(0x1D, 0.0), 1.0); // cos(0)
+        assert_eq!(ev(0x0F, 0.0), 0.0); // tan(0)
+        // sin^2 + cos^2 == 1 across quadrants and a large argument.
+        for &x in &[0.3_f64, 1.2, 3.0, -2.5, 7.0, 100.0, 1000.0] {
+            let s = ev(0x0E, x);
+            let c = ev(0x1D, x);
+            assert!((s * s + c * c - 1.0).abs() < 1e-15, "sin^2+cos^2 at {x}");
+            // tan == sin/cos.
+            let t = ev(0x0F, x);
+            assert!(close(t, s / c, 1e-14), "tan at {x}");
+            // agreement with libm to ~f64 precision.
+            assert!((s - x.sin()).abs() < 1e-14, "sin {x}");
+            assert!((c - x.cos()).abs() < 1e-14, "cos {x}");
+        }
+    }
+
+    #[test]
+    fn sincos_pair() {
+        let (s, c) = sincos(fx(1.0));
+        assert!((s.to_f64() - 1.0_f64.sin()).abs() < 1e-15);
+        assert!((c.to_f64() - 1.0_f64.cos()).abs() < 1e-15);
     }
 
     #[test]


### PR DESCRIPTION
Replaces the f64 bridge that was the last non-extended-precision part of the FPU. The transcendentals and the FMOD/FREM remainders now run in true extended precision; after this there is no `f64` left in the FPU math path.

## Approach

A small **double-double** layer (`vendor/m68k/src/fpu/dd.rs`) carries values as `hi + lo` of two `FloatX80` (~128 significand bits) using the classic error-free transforms (`two_sum`, Veltkamp `two_prod`) over the correctly-rounded softfloat round-to-nearest ops. Each transcendental reduces its argument, evaluates a **Taylor/atanh series** in the double-double layer -- coefficients are exact rationals (`1/k!`, `1/(2k+1)`), so no minimax/Sollya tooling is needed -- and rounds the result to 64-bit extended under the FPCR mode. Math constants (pi, ln2, ln10, log2e, log10e) are computed once via self-contained Machin/atanh series and cached; their high words match the exact MC68881 ROM patterns.

Implemented: exp, expm1, 2^x, 10^x, ln, log1p, log2, log10, sin, cos, tan, sincos, asin, acos, atan, sinh, cosh, tanh, atanh. FMOD/FREM are now **exact** (shift-subtract long division of the significands) and set the FPSR quotient byte. The transcendental/FSINCOS/FMOD/FREM dispatch arms now thread the FPCR rounding context and call `fpu_commit`, so INEX/OPERR/DZ reach FPSR (previously the transcendental path set only the condition codes).

## Accuracy (honest)

Faithful to ~64 bits (within ~1 ULP), honoring the FPCR rounding mode and setting the FPSR flags. It is **not** chip-bit-exact -- the real 6888x uses its own CORDIC/polynomial microcode (and a bare 68040 traps these to a software FPSP), and last-bit-correct rounding would need a Ziv/TMD test beyond 128 bits. Validated by exact anchors (`exp(1)` matches the e ROM to 1 ULP, `atan(1)*4 == pi`, `2^10`, `10^3`, `log2`/`log10` of powers), identities to ~2^-62 (`sin^2+cos^2`, `exp(ln x)`, `cosh^2-sinh^2`, `tan=sin/cos`, `asin(sin)`/`acos(cos)` round-trips), libm agreement, FPCR rounding-direction, and the domain-error flags.

## Milestones (one commit each)

A double-double layer + constants; B exp/log; C trig; D inverse-trig + hyperbolic; E FPCR/FPSR wiring; F exact FMOD/FREM + quotient byte; G cleanup + docs.

## Verification

m68040 fixtures 69/69 (`fpu_trans`/`fpu_transcendental`/`fpu_exp_log`/`fpu_sincos`/`fpu_remainder` etc.), new dd + transcendental unit tests, the full Copperline suite (1182), release build, clippy clean, rustfmt clean.