### PR TITLE
Do not require a ROM file if --load-state argument provided

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -948,7 +948,9 @@ fn main() -> Result<()> {
     }
 
     let mut cfg = cfg.with_rom_override(cli.rom_path.clone());
-    resolve_bundled_rom(&mut cfg)?;
+    if cli.load_state.is_none() {
+        resolve_bundled_rom(&mut cfg)?;
+    }
     let disk_insert_after = resolve_disk_insert_after(&mut cfg, cli.disk_insert_after)?;
 
     info!(


### PR DESCRIPTION
...because the ROM is included in the state file