### PR TITLE
Allow overriding hard-drive volume names

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -402,6 +402,19 @@ exit. Note that the stock A1200/A600 Kickstart `scsi.device` only probes
 the IDE master; a slave drive needs a guest OS or driver that supports
 two units (e.g. Kickstart 3.1.4).
 
+To override the volume name (instead of inheriting the directory name),
+give the drive as a table with `path` and `name`:
+
+```toml
+[ide]
+master = { path = "/host/Games", name = "Games" }
+# slave = "scratch.hdf"        # the bare-string form still works
+```
+
+The name sets the FFS volume label of a directory mount; AmigaDOS volume
+names hold up to 30 characters and cannot contain `:` or `/`. It has no
+effect on a raw HDF, which carries its own label inside the image.
+
 The drive responds to ATA IDENTIFY with the Gayle byte order real hardware
 uses, so both Kickstart 3.1 variants boot from it. An HDD activity LED
 appears in the status bar on IDE machines.
@@ -437,7 +450,9 @@ vector at `$2000`).
 Each `unitN` accepts everything `[ide]` paths do: RDB images, bare
 partition hardfiles (a synthesized RDB advertises a bootable `DHn`
 partition, named after the SCSI ID), and host directories built into
-in-memory FFS volumes. The HDD activity LED covers SCSI traffic too.
+in-memory FFS volumes -- including the `{ path = "...", name = "..." }`
+table form that overrides a directory mount's volume name. The HDD
+activity LED covers SCSI traffic too.
 
 ## `[cd]` -- CDTV and CD32
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -165,10 +165,13 @@ The layout is:
   pacing, realtime priority, warp speed, joystick input mode).
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
   buttons flip a toggle, and the **Browse** and **Clear** buttons set or remove
-  a file path through a native file dialog. A setting that does not apply to the
-  chosen machine is greyed and shows why in place of its control -- "needs
-  32-bit CPU" for Zorro III RAM, "needs 68020+" for the FPU, "needs A600/A1200"
-  for IDE.
+  a file path through a native file dialog. On the *Hard Disk* tab, once an IDE
+  or SCSI drive has an image a small editable box appears next to **Browse**:
+  click it and type to set the volume name for a directory mount (left blank, a
+  directory mount inherits the host directory's name; the box has no effect on a
+  raw HDF). A setting that does not apply to the chosen machine is greyed and
+  shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM,
+  "needs 68020+" for the FPU, "needs A600/A1200" for IDE.
 - **Action bar** (bottom). **Load...** and **Save...** read and write a `.toml`
   config
   through a file dialog (Save writes a minimal file, only the settings that

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -70,7 +70,9 @@ cycles are not yet arbitrated against the CPU (TODO in `a2091.rs`).
 Both IDE and SCSI drives share the `harddrive.rs` sector backend: raw
 HDF images, bare partition hardfiles wrapped in a synthesized RDB
 (bootable `DHn` named after the unit), and host directories built into
-in-memory FFS volumes by `dirfs.rs`. The SCSI-2 target layer in
+in-memory FFS volumes by `dirfs.rs` (whose volume label defaults to the
+directory name, or a `name` override configured on the drive). The
+SCSI-2 target layer in
 `scsi.rs` answers INQUIRY, MODE SENSE pages 3/4, READ CAPACITY,
 READ/WRITE(6)/(10), REQUEST SENSE, and the no-op housekeeping commands,
 with sense state kept per target.

--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -469,7 +469,7 @@ mod tests {
     fn board_with_disk(sectors: u64) -> (A2091, PathBuf) {
         let mut board = A2091::new(fake_rom()).unwrap();
         let path = temp_image(sectors);
-        board.attach_drive(0, crate::scsi::ScsiDisk::open(&path, 0).unwrap());
+        board.attach_drive(0, crate::scsi::ScsiDisk::open(&path, 0, None).unwrap());
         (board, path)
     }
 
@@ -564,7 +564,7 @@ mod tests {
         std::fs::write(&path, &img).unwrap();
         let (mut board2, _) = (board, ());
         // Reopen the drive so the new image content is seen.
-        board2.attach_drive(0, crate::scsi::ScsiDisk::open(&path, 0).unwrap());
+        board2.attach_drive(0, crate::scsi::ScsiDisk::open(&path, 0, None).unwrap());
         let mut board = board2;
         let mut mem = test_memory();
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -19757,7 +19757,7 @@ mod tests {
 
         let mut bus = empty_bus();
         let mut gayle = Gayle::new(0xD0);
-        gayle.attach_drive(0, IdeDrive::open(&image, 0).unwrap());
+        gayle.attach_drive(0, IdeDrive::open(&image, 0, None).unwrap());
         bus.attach_gayle(gayle);
 
         // Enable the IDE interrupt at $DAA000 and issue a READ SECTORS via

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,10 +200,21 @@ impl JoystickInputMode {
     }
 }
 
+/// A configured hard-drive image: the host path plus an optional volume-name
+/// override. The override only changes a host *directory* mounted as an
+/// in-memory FFS volume -- it sets the FFS volume label instead of deriving it
+/// from the directory name. A raw HDF carries its own label inside the image
+/// and ignores the override.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriveImage {
+    pub path: PathBuf,
+    pub volume_name: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IdeConfig {
-    pub master: Option<PathBuf>,
-    pub slave: Option<PathBuf>,
+    pub master: Option<DriveImage>,
+    pub slave: Option<DriveImage>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -214,7 +225,7 @@ pub struct ScsiConfig {
     /// Odd-byte EPROM half for split dumps.
     pub rom_odd: Option<PathBuf>,
     /// Drive images by SCSI ID (0-6; ID 7 is the controller).
-    pub units: [Option<PathBuf>; 7],
+    pub units: [Option<DriveImage>; 7],
 }
 
 impl ScsiConfig {
@@ -994,13 +1005,105 @@ pub(crate) struct RawInput {
     pub(crate) joystick: Option<String>,
 }
 
+/// A drive image entry in `[ide]`/`[scsi]`. Accepts either a bare path string
+/// (`master = "disk.hdf"`) or a table carrying an explicit volume-name override
+/// (`master = { path = "games/", name = "Games" }`). It serializes back to the
+/// bare string when no name is set, so existing minimal configs round-trip
+/// unchanged.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RawDrive {
+    pub(crate) path: String,
+    pub(crate) name: Option<String>,
+}
+
+impl RawDrive {
+    pub(crate) fn from_path(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            name: None,
+        }
+    }
+}
+
+impl Serialize for RawDrive {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.name {
+            // No override: a plain string keeps saved configs minimal.
+            None => serializer.serialize_str(&self.path),
+            Some(name) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("path", &self.path)?;
+                map.serialize_entry("name", name)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RawDrive {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct DriveVisitor;
+        impl<'de> serde::de::Visitor<'de> for DriveVisitor {
+            type Value = RawDrive;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a drive image path, or a table with `path` and optional `name`")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> std::result::Result<RawDrive, E> {
+                Ok(RawDrive::from_path(v))
+            }
+            fn visit_string<E: serde::de::Error>(
+                self,
+                v: String,
+            ) -> std::result::Result<RawDrive, E> {
+                Ok(RawDrive::from_path(v))
+            }
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<RawDrive, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut path: Option<String> = None;
+                let mut name: Option<String> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "path" => {
+                            if path.is_some() {
+                                return Err(serde::de::Error::duplicate_field("path"));
+                            }
+                            path = Some(map.next_value()?);
+                        }
+                        "name" => {
+                            if name.is_some() {
+                                return Err(serde::de::Error::duplicate_field("name"));
+                            }
+                            name = Some(map.next_value()?);
+                        }
+                        other => {
+                            return Err(serde::de::Error::unknown_field(other, &["path", "name"]));
+                        }
+                    }
+                }
+                let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
+                Ok(RawDrive { path, name })
+            }
+        }
+        deserializer.deserialize_any(DriveVisitor)
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawIde {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) master: Option<String>,
+    pub(crate) master: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) slave: Option<String>,
+    pub(crate) slave: Option<RawDrive>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -1013,19 +1116,19 @@ pub(crate) struct RawScsi {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rom_odd: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit0: Option<String>,
+    pub(crate) unit0: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit1: Option<String>,
+    pub(crate) unit1: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit2: Option<String>,
+    pub(crate) unit2: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit3: Option<String>,
+    pub(crate) unit3: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit4: Option<String>,
+    pub(crate) unit4: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit5: Option<String>,
+    pub(crate) unit5: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit6: Option<String>,
+    pub(crate) unit6: Option<RawDrive>,
 }
 
 /// `[a2065]` Ethernet board. Fitting the board enables host networking, which
@@ -1199,6 +1302,32 @@ pub(crate) struct RawFloppyDrive {
     pub(crate) write_protected: Option<bool>,
 }
 
+/// Convert a parsed `[ide]`/`[scsi]` drive entry into a `DriveImage`,
+/// validating any volume-name override. An empty/whitespace name is treated as
+/// no override; AmigaDOS volume names cannot contain ':' or '/' and the FFS
+/// root block stores at most 30 characters.
+fn drive_image(raw: RawDrive) -> Result<DriveImage> {
+    let volume_name = match raw.name {
+        None => None,
+        Some(name) => {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                None
+            } else if trimmed.contains([':', '/']) {
+                bail!("drive name {name:?} must not contain ':' or '/'");
+            } else if trimmed.chars().count() > 30 {
+                bail!("drive name {name:?} is too long (AmigaDOS volume names hold 30 characters)");
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+    };
+    Ok(DriveImage {
+        path: PathBuf::from(raw.path),
+        volume_name,
+    })
+}
+
 impl TryFrom<RawConfig> for Config {
     type Error = anyhow::Error;
 
@@ -1351,8 +1480,8 @@ impl TryFrom<RawConfig> for Config {
         };
 
         let ide = IdeConfig {
-            master: raw.ide.master.map(PathBuf::from),
-            slave: raw.ide.slave.map(PathBuf::from),
+            master: raw.ide.master.map(drive_image).transpose()?,
+            slave: raw.ide.slave.map(drive_image).transpose()?,
         };
         if (ide.master.is_some() || ide.slave.is_some()) && defaults.gate_array == GateArray::None {
             bail!("[ide] images need a Gayle machine: set [machine] profile = \"A600\" (or A1200)");
@@ -1362,13 +1491,13 @@ impl TryFrom<RawConfig> for Config {
             rom: raw.scsi.rom.map(PathBuf::from),
             rom_odd: raw.scsi.rom_odd.map(PathBuf::from),
             units: [
-                raw.scsi.unit0.map(PathBuf::from),
-                raw.scsi.unit1.map(PathBuf::from),
-                raw.scsi.unit2.map(PathBuf::from),
-                raw.scsi.unit3.map(PathBuf::from),
-                raw.scsi.unit4.map(PathBuf::from),
-                raw.scsi.unit5.map(PathBuf::from),
-                raw.scsi.unit6.map(PathBuf::from),
+                raw.scsi.unit0.map(drive_image).transpose()?,
+                raw.scsi.unit1.map(drive_image).transpose()?,
+                raw.scsi.unit2.map(drive_image).transpose()?,
+                raw.scsi.unit3.map(drive_image).transpose()?,
+                raw.scsi.unit4.map(drive_image).transpose()?,
+                raw.scsi.unit5.map(drive_image).transpose()?,
+                raw.scsi.unit6.map(drive_image).transpose()?,
             ],
         };
         if scsi.enabled() && scsi.rom.is_none() {
@@ -2051,7 +2180,7 @@ mod tests {
                 denise: None,
             },
             ide: RawIde {
-                master: Some("hd0.hdf".to_string()),
+                master: Some(RawDrive::from_path("hd0.hdf")),
                 slave: None,
             },
             floppy: RawFloppy {
@@ -2549,7 +2678,10 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert_eq!(cfg.ide.master.as_deref(), Some(Path::new("disk.hdf")));
+        assert_eq!(
+            cfg.ide.master.as_ref().map(|d| d.path.as_path()),
+            Some(Path::new("disk.hdf"))
+        );
         assert_eq!(cfg.ide.slave, None);
     }
 
@@ -2832,11 +2964,14 @@ mod tests {
         assert!(cfg.scsi.enabled());
         assert_eq!(cfg.scsi.rom.as_deref(), Some(Path::new("a2091.rom")));
         assert_eq!(
-            cfg.scsi.units[0].as_deref(),
+            cfg.scsi.units[0].as_ref().map(|d| d.path.as_path()),
             Some(Path::new("workbench.hdf"))
         );
         assert!(cfg.scsi.units[1].is_none());
-        assert_eq!(cfg.scsi.units[3].as_deref(), Some(Path::new("data.hdf")));
+        assert_eq!(
+            cfg.scsi.units[3].as_ref().map(|d| d.path.as_path()),
+            Some(Path::new("data.hdf"))
+        );
 
         // Drives without the boot ROM cannot work: the ROM carries the
         // scsi.device driver.
@@ -2862,6 +2997,131 @@ mod tests {
         )?;
         assert!(cfg.scsi.enabled());
         Ok(())
+    }
+
+    #[test]
+    fn drive_entries_accept_a_volume_name_override() -> Result<()> {
+        // IDE and SCSI drives take either a bare path or a table carrying an
+        // explicit volume name; the bare form leaves the name unset.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = { path = "games/", name = "Games" }
+            slave = "data.hdf"
+            "#,
+        )?;
+        let master = cfg.ide.master.as_ref().expect("master configured");
+        assert_eq!(master.path, Path::new("games/"));
+        assert_eq!(master.volume_name.as_deref(), Some("Games"));
+        let slave = cfg.ide.slave.as_ref().expect("slave configured");
+        assert_eq!(slave.path, Path::new("data.hdf"));
+        assert_eq!(slave.volume_name, None);
+
+        let cfg = parse_config(
+            r#"
+            [scsi]
+            rom = "a2091.rom"
+            unit0 = { path = "work/", name = "Work Disk" }
+            "#,
+        )?;
+        let unit0 = cfg.scsi.units[0].as_ref().expect("unit0 configured");
+        assert_eq!(unit0.volume_name.as_deref(), Some("Work Disk"));
+        Ok(())
+    }
+
+    #[test]
+    fn drive_name_override_is_validated() {
+        // A ':' or '/' is illegal in an AmigaDOS volume name.
+        let err = parse_config(
+            r#"
+            [scsi]
+            rom = "a2091.rom"
+            unit0 = { path = "work/", name = "Bad:Name" }
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("must not contain"), "{err:#}");
+
+        // Over the 30-character FFS volume-label limit.
+        let err = parse_config(&format!(
+            r#"
+            [scsi]
+            rom = "a2091.rom"
+            unit0 = {{ path = "work/", name = "{}" }}
+            "#,
+            "X".repeat(31)
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("too long"), "{err:#}");
+
+        // A blank name is treated as no override (not an error).
+        let cfg = parse_config(
+            r#"
+            [scsi]
+            rom = "a2091.rom"
+            unit0 = { path = "work/", name = "  " }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.scsi.units[0].as_ref().unwrap().volume_name, None);
+
+        // An unknown key in the table form is rejected.
+        let err = parse_config(
+            r#"
+            [scsi]
+            rom = "a2091.rom"
+            unit0 = { path = "work/", label = "Work" }
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("label"), "{err:#}");
+    }
+
+    #[test]
+    fn mixed_named_and_bare_drives_round_trip_through_saved_toml() {
+        // A named drive serializes as a sub-table; a bare sibling must not be
+        // swallowed by it (TOML requires scalar keys before sub-tables). Save
+        // the whole config the way the panel does and parse it back.
+        let raw = RawConfig {
+            scsi: RawScsi {
+                rom: Some("a2091.rom".to_string()),
+                unit0: Some(RawDrive {
+                    path: "work/".to_string(),
+                    name: Some("Work".to_string()),
+                }),
+                unit1: Some(RawDrive::from_path("data.hdf")),
+                ..RawScsi::default()
+            },
+            ..RawConfig::default()
+        };
+        let text = raw.to_toml_string().unwrap();
+        let back: RawConfig = toml::from_str(&text).unwrap();
+        assert_eq!(raw, back, "round-trip mismatch; TOML was:\n{text}");
+    }
+
+    #[test]
+    fn drive_entry_round_trips_through_toml() {
+        // No name: serializes back to the bare string form.
+        let bare = RawIde {
+            master: Some(RawDrive::from_path("disk.hdf")),
+            slave: None,
+        };
+        let text = toml::to_string(&bare).unwrap();
+        assert!(text.contains(r#"master = "disk.hdf""#), "{text}");
+
+        // With a name: serializes to the inline table and parses back.
+        let named = RawIde {
+            master: Some(RawDrive {
+                path: "games/".to_string(),
+                name: Some("Games".to_string()),
+            }),
+            slave: None,
+        };
+        let text = toml::to_string(&named).unwrap();
+        let parsed: RawIde = toml::from_str(&text).unwrap();
+        assert_eq!(parsed, named);
     }
 
     #[test]

--- a/src/gayle.rs
+++ b/src/gayle.rs
@@ -92,9 +92,16 @@ impl IdeDrive {
     /// Open an IDE unit (0 = master, 1 = slave; this picks the DHn device
     /// name a synthesized RDB advertises). The path may be a raw HDF image
     /// file, or a host directory, which is built into an in-memory FFS
-    /// volume at open time.
-    pub fn open(path: &Path, unit: usize) -> anyhow::Result<Self> {
-        let disk = HardDriveImage::open(path, &format!("DH{unit}"), "ide", "COPPERLINE IDE DISK")?;
+    /// volume at open time; `volume_name` labels that volume (directory
+    /// mounts only).
+    pub fn open(path: &Path, unit: usize, volume_name: Option<&str>) -> anyhow::Result<Self> {
+        let disk = HardDriveImage::open(
+            path,
+            &format!("DH{unit}"),
+            "ide",
+            "COPPERLINE IDE DISK",
+            volume_name,
+        )?;
         // The classic Amiga HDF geometry: 16 surfaces, 32 sectors per track
         // (what HDToolBox/RDB tooling defaults to), so the CHS the host
         // computes from an RDB's physical-drive block agrees with what the
@@ -906,7 +913,7 @@ mod tests {
     fn gayle_with_drive(sectors: u64) -> (Gayle, PathBuf) {
         let path = temp_image(sectors);
         let mut gayle = Gayle::new(0xD0);
-        gayle.attach_drive(0, IdeDrive::open(&path, 0).unwrap());
+        gayle.attach_drive(0, IdeDrive::open(&path, 0, None).unwrap());
         (gayle, path)
     }
 
@@ -955,7 +962,7 @@ mod tests {
         data[SECTOR_SIZE] = 0xA5; // marker in partition sector 1
         std::fs::write(&path, &data).unwrap();
 
-        let mut drive = IdeDrive::open(&path, 0).unwrap();
+        let mut drive = IdeDrive::open(&path, 0, None).unwrap();
         // One synthesized RDB cylinder plus the partition cylinder.
         assert_eq!(drive.disk.total_sectors(), 2 * u64::from(CYL_SECTORS));
 
@@ -1011,7 +1018,7 @@ mod tests {
         let mut data = std::fs::read(&path).unwrap();
         data[..4].copy_from_slice(b"RDSK");
         std::fs::write(&path, &data).unwrap();
-        let mut drive = IdeDrive::open(&path, 0).unwrap();
+        let mut drive = IdeDrive::open(&path, 0, None).unwrap();
         assert_eq!(drive.disk.total_sectors(), u64::from(CYL_SECTORS));
         let mut sector = [0u8; SECTOR_SIZE];
         drive.disk.read_sector(0, &mut sector).unwrap();
@@ -1026,7 +1033,7 @@ mod tests {
         let mut data = std::fs::read(&path).unwrap();
         data[..4].copy_from_slice(b"DOS\x00");
         std::fs::write(&path, &data).unwrap();
-        let err = match IdeDrive::open(&path, 0) {
+        let err = match IdeDrive::open(&path, 0, None) {
             Ok(_) => panic!("expected open to fail"),
             Err(e) => e.to_string(),
         };

--- a/src/harddrive.rs
+++ b/src/harddrive.rs
@@ -213,27 +213,38 @@ impl HardDriveImage {
     /// "DH0") a synthesized RDB advertises; `bus_name` ("ide"/"scsi") tags
     /// log messages; `disk_label` fills the RDSK vendor/product identity.
     /// The path may be a raw HDF image file, or a host directory, which is
-    /// built into an in-memory FFS volume at open time.
+    /// built into an in-memory FFS volume at open time. `volume_override`
+    /// names that FFS volume; when `None` the directory name is used. It has
+    /// no effect on a raw HDF, which carries its own label inside the image.
     pub fn open(
         path: &Path,
         device_name: &str,
         bus_name: &'static str,
         disk_label: &str,
+        volume_override: Option<&str>,
     ) -> anyhow::Result<Self> {
         let mut backing = if path.is_dir() {
-            let volume = path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_default();
+            let volume = volume_override.map(str::to_string).unwrap_or_else(|| {
+                path.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+            });
             let image = crate::dirfs::build_ffs_image(path, &volume)?;
             log::warn!(
-                "{bus_name}: {} mounted as an in-memory volume built from the directory; \
-                 guest writes to it are NOT written back to the host and are lost \
+                "{bus_name}: {} mounted as an in-memory volume \"{volume}\" built from the \
+                 directory; guest writes to it are NOT written back to the host and are lost \
                  at exit",
                 path.display()
             );
             Backing::Memory(image)
         } else {
+            if volume_override.is_some() {
+                log::warn!(
+                    "{bus_name}: {} is a raw HDF image; the configured drive name is ignored \
+                     (the volume label lives inside the image)",
+                    path.display()
+                );
+            }
             Backing::File(
                 OpenOptions::new()
                     .read(true)
@@ -426,7 +437,7 @@ mod tests {
         let mut bytes = vec![0u8; 64 * SECTOR_SIZE];
         bytes[5 * SECTOR_SIZE..5 * SECTOR_SIZE + 4].copy_from_slice(b"MARK");
         let path = temp_image("serde.hdf", &bytes);
-        let mut original = HardDriveImage::open(&path, "DH0", "ide", "TEST DISK").unwrap();
+        let mut original = HardDriveImage::open(&path, "DH0", "ide", "TEST DISK", None).unwrap();
 
         let encoded = bincode::serialize(&original).unwrap();
         let mut restored: HardDriveImage = bincode::deserialize(&encoded).unwrap();
@@ -450,10 +461,62 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// Read every sector of an image and return the FFS volume label found in
+    /// its root block (block type 2 / secondary type 1). The directory mount
+    /// prepends a synthesized RDB, so the root block is not at a fixed LBA;
+    /// scan for it instead.
+    fn volume_label(disk: &mut HardDriveImage) -> String {
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        for lba in 0..disk.total_sectors() {
+            disk.read_sector(lba, &mut sector).unwrap();
+            let be32 = |off: usize| u32::from_be_bytes(sector[off..off + 4].try_into().unwrap());
+            if be32(0) == 2 && be32(SECTOR_SIZE - 4) == 1 {
+                let name_base = SECTOR_SIZE - 80;
+                let len = sector[name_base] as usize;
+                return String::from_utf8_lossy(&sector[name_base + 1..name_base + 1 + len])
+                    .into_owned();
+            }
+        }
+        panic!("no FFS root block found");
+    }
+
+    /// A uniquely-named parent temp dir holding a short-named child directory
+    /// (returned) with one file. The child's name is short enough that the
+    /// 30-character FFS volume-label limit does not truncate it.
+    fn temp_mount_dir(child: &str) -> (PathBuf, PathBuf) {
+        static UNIQUE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = UNIQUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let parent = std::env::temp_dir().join(format!(
+            "copperline-harddrive-dir-{}-{unique}",
+            std::process::id()
+        ));
+        let mount = parent.join(child);
+        std::fs::create_dir_all(&mount).unwrap();
+        std::fs::write(mount.join("hello.txt"), b"hi\n").unwrap();
+        (parent, mount)
+    }
+
+    #[test]
+    fn directory_mount_uses_the_directory_name_as_the_volume_label() {
+        let (parent, mount) = temp_mount_dir("Games");
+        let mut disk = HardDriveImage::open(&mount, "DH0", "ide", "TEST DISK", None).unwrap();
+        assert_eq!(volume_label(&mut disk), "Games");
+        let _ = std::fs::remove_dir_all(&parent);
+    }
+
+    #[test]
+    fn directory_mount_volume_override_sets_the_label() {
+        let (parent, mount) = temp_mount_dir("Games");
+        let mut disk =
+            HardDriveImage::open(&mount, "DH0", "ide", "TEST DISK", Some("Workbench")).unwrap();
+        assert_eq!(volume_label(&mut disk), "Workbench");
+        let _ = std::fs::remove_dir_all(&parent);
+    }
+
     #[test]
     fn serde_errors_when_backing_file_is_missing() {
         let path = temp_image("gone.hdf", &vec![0u8; 8 * SECTOR_SIZE]);
-        let original = HardDriveImage::open(&path, "DH0", "ide", "TEST DISK").unwrap();
+        let original = HardDriveImage::open(&path, "DH0", "ide", "TEST DISK", None).unwrap();
         let encoded = bincode::serialize(&original).unwrap();
         let _ = std::fs::remove_file(&path);
         let Err(err) = bincode::deserialize::<HardDriveImage>(&encoded) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1098,10 +1098,13 @@ pub(crate) fn build_machine(
         let rom_path = cfg.scsi.rom.as_ref().expect("config validated [scsi] rom");
         let rom = crate::a2091::A2091::load_rom(rom_path, cfg.scsi.rom_odd.as_deref())?;
         let mut board = crate::a2091::A2091::new(rom)?;
-        for (unit, path) in cfg.scsi.units.iter().enumerate() {
-            let Some(path) = path else { continue };
-            board.attach_drive(unit, crate::scsi::ScsiDisk::open(path, unit)?);
-            info!("scsi: unit {unit} {}", path.display());
+        for (unit, drive) in cfg.scsi.units.iter().enumerate() {
+            let Some(drive) = drive else { continue };
+            board.attach_drive(
+                unit,
+                crate::scsi::ScsiDisk::open(&drive.path, unit, drive.volume_name.as_deref())?,
+            );
+            info!("scsi: unit {unit} {}", drive.path.display());
         }
         let slot = devices.len();
         zorro.add_board(crate::zorro::BoardSpec::a2091(slot))?;
@@ -1180,13 +1183,19 @@ pub(crate) fn build_machine(
     bus.set_rtc_present(cfg.rtc_present);
     if let Some(id) = cfg.gate_array.gayle_id() {
         let mut gayle = crate::gayle::Gayle::new(id);
-        if let Some(path) = &cfg.ide.master {
-            gayle.attach_drive(0, crate::gayle::IdeDrive::open(path, 0)?);
-            info!("ide: master {}", path.display());
+        if let Some(drive) = &cfg.ide.master {
+            gayle.attach_drive(
+                0,
+                crate::gayle::IdeDrive::open(&drive.path, 0, drive.volume_name.as_deref())?,
+            );
+            info!("ide: master {}", drive.path.display());
         }
-        if let Some(path) = &cfg.ide.slave {
-            gayle.attach_drive(1, crate::gayle::IdeDrive::open(path, 1)?);
-            info!("ide: slave {}", path.display());
+        if let Some(drive) = &cfg.ide.slave {
+            gayle.attach_drive(
+                1,
+                crate::gayle::IdeDrive::open(&drive.path, 1, drive.volume_name.as_deref())?,
+            );
+            info!("ide: slave {}", drive.path.display());
         }
         bus.attach_gayle(gayle);
     }

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -155,10 +155,16 @@ pub struct ScsiDisk {
 impl ScsiDisk {
     /// Open a SCSI unit. `unit` is the SCSI ID, which picks the DHn device
     /// name a synthesized RDB advertises (so a bare hardfile on unit 0
-    /// boots as DH0 exactly as it would on the IDE bus).
-    pub fn open(path: &Path, unit: usize) -> anyhow::Result<Self> {
-        let disk =
-            HardDriveImage::open(path, &format!("DH{unit}"), "scsi", "COPPERLINE SCSI DISK")?;
+    /// boots as DH0 exactly as it would on the IDE bus). `volume_name`
+    /// labels a directory mounted as an in-memory FFS volume.
+    pub fn open(path: &Path, unit: usize, volume_name: Option<&str>) -> anyhow::Result<Self> {
+        let disk = HardDriveImage::open(
+            path,
+            &format!("DH{unit}"),
+            "scsi",
+            "COPPERLINE SCSI DISK",
+            volume_name,
+        )?;
         Ok(Self {
             disk,
             sense: [0u8; SENSE_LEN],
@@ -1230,7 +1236,7 @@ mod tests {
     fn chip_with_disk(sectors: u64) -> (Wd33c93, PathBuf) {
         let path = temp_image(sectors);
         let mut wd = Wd33c93::new();
-        wd.attach_target(0, ScsiDisk::open(&path, 0).unwrap());
+        wd.attach_target(0, ScsiDisk::open(&path, 0, None).unwrap());
         (wd, path)
     }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -23,7 +23,8 @@ use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
     format_size, machine_profile_defaults, Chipset, Config, CpuModel, JoystickInputMode,
-    MachineModel, Overscan, PacingBudget, RawConfig, RawFloppyDrive, RawZorroBoard, WarpSpeed,
+    MachineModel, Overscan, PacingBudget, RawConfig, RawDrive, RawFloppyDrive, RawZorroBoard,
+    WarpSpeed,
 };
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
 use anyhow::Result;
@@ -273,6 +274,9 @@ pub enum RowKind {
     Toggle,
     /// A file path with Browse/Clear buttons.
     Path,
+    /// A hard-drive image: a path with Browse/Clear, plus an editable
+    /// volume-name field (used when the image is a host directory).
+    Drive,
 }
 
 /// One settings row: a label, the field it edits, and how to edit it.
@@ -288,7 +292,7 @@ const fn row(field: LauncherField, label: &'static str, kind: RowKind) -> Row {
 }
 
 use LauncherField as F;
-use RowKind::{Cycle, Toggle};
+use RowKind::{Cycle, Drive, Toggle};
 // `RowKind::Path` is written out below so it does not collide with the
 // `std::path::Path` import.
 use RowKind::Path as PathRow;
@@ -330,17 +334,17 @@ const FLOPPY_ROWS: [Row; 9] = [
     row(F::Df3WriteProtect, "DF3 write-protect", Toggle),
 ];
 const STORAGE_ROWS: [Row; 11] = [
-    row(F::IdeMaster, "IDE master", PathRow),
-    row(F::IdeSlave, "IDE slave", PathRow),
+    row(F::IdeMaster, "IDE master", Drive),
+    row(F::IdeSlave, "IDE slave", Drive),
     row(F::ScsiRom, "SCSI boot ROM", PathRow),
     row(F::ScsiRomOdd, "SCSI ROM (odd)", PathRow),
-    row(F::ScsiUnit0, "SCSI unit 0", PathRow),
-    row(F::ScsiUnit1, "SCSI unit 1", PathRow),
-    row(F::ScsiUnit2, "SCSI unit 2", PathRow),
-    row(F::ScsiUnit3, "SCSI unit 3", PathRow),
-    row(F::ScsiUnit4, "SCSI unit 4", PathRow),
-    row(F::ScsiUnit5, "SCSI unit 5", PathRow),
-    row(F::ScsiUnit6, "SCSI unit 6", PathRow),
+    row(F::ScsiUnit0, "SCSI unit 0", Drive),
+    row(F::ScsiUnit1, "SCSI unit 1", Drive),
+    row(F::ScsiUnit2, "SCSI unit 2", Drive),
+    row(F::ScsiUnit3, "SCSI unit 3", Drive),
+    row(F::ScsiUnit4, "SCSI unit 4", Drive),
+    row(F::ScsiUnit5, "SCSI unit 5", Drive),
+    row(F::ScsiUnit6, "SCSI unit 6", Drive),
 ];
 const CD_ROWS: [Row; 3] = [
     row(F::CdImage, "CD image", PathRow),
@@ -487,12 +491,16 @@ pub struct MachineSetup {
     /// image is a one-element list.
     df_playlists: [Vec<PathBuf>; 4],
     df_write_protected: [bool; 4],
-    // Hard disk
+    // Hard disk. Each drive's optional volume-name override (directory mounts
+    // only) sits in the matching `*_name` slot, paralleling the path slot.
     ide_master: Option<PathBuf>,
+    ide_master_name: Option<String>,
     ide_slave: Option<PathBuf>,
+    ide_slave_name: Option<String>,
     scsi_rom: Option<PathBuf>,
     scsi_rom_odd: Option<PathBuf>,
     scsi_units: [Option<PathBuf>; 7],
+    scsi_unit_names: [Option<String>; 7],
     // CD
     cd_image: Option<PathBuf>,
     cd_insert_delay: f64,
@@ -555,11 +563,18 @@ impl MachineSetup {
             floppy_drives: raw.floppy.drives.unwrap_or(connected).clamp(1, 4),
             df_playlists: cfg.floppy_playlists.clone(),
             df_write_protected,
-            ide_master: cfg.ide.master.clone(),
-            ide_slave: cfg.ide.slave.clone(),
+            ide_master: cfg.ide.master.as_ref().map(|d| d.path.clone()),
+            ide_master_name: cfg.ide.master.as_ref().and_then(|d| d.volume_name.clone()),
+            ide_slave: cfg.ide.slave.as_ref().map(|d| d.path.clone()),
+            ide_slave_name: cfg.ide.slave.as_ref().and_then(|d| d.volume_name.clone()),
             scsi_rom: cfg.scsi.rom.clone(),
             scsi_rom_odd: cfg.scsi.rom_odd.clone(),
-            scsi_units: cfg.scsi.units.clone(),
+            scsi_units: std::array::from_fn(|i| cfg.scsi.units[i].as_ref().map(|d| d.path.clone())),
+            scsi_unit_names: std::array::from_fn(|i| {
+                cfg.scsi.units[i]
+                    .as_ref()
+                    .and_then(|d| d.volume_name.clone())
+            }),
             cd_image: cfg.cd_image_path.clone(),
             cd_insert_delay: cfg.cd_insert_delay_secs,
             // Use the raw NVRAM path: Config defaults it to "cd32-nvram.bin"
@@ -685,17 +700,38 @@ impl MachineSetup {
         raw.floppy.df2 = self.floppy_drive_raw(2);
         raw.floppy.df3 = self.floppy_drive_raw(3);
         // Hard disk
-        raw.ide.master = self.ide_master.as_deref().map(path_string);
-        raw.ide.slave = self.ide_slave.as_deref().map(path_string);
+        raw.ide.master = drive_raw(self.ide_master.as_deref(), self.ide_master_name.as_deref());
+        raw.ide.slave = drive_raw(self.ide_slave.as_deref(), self.ide_slave_name.as_deref());
         raw.scsi.rom = self.scsi_rom.as_deref().map(path_string);
         raw.scsi.rom_odd = self.scsi_rom_odd.as_deref().map(path_string);
-        raw.scsi.unit0 = self.scsi_units[0].as_deref().map(path_string);
-        raw.scsi.unit1 = self.scsi_units[1].as_deref().map(path_string);
-        raw.scsi.unit2 = self.scsi_units[2].as_deref().map(path_string);
-        raw.scsi.unit3 = self.scsi_units[3].as_deref().map(path_string);
-        raw.scsi.unit4 = self.scsi_units[4].as_deref().map(path_string);
-        raw.scsi.unit5 = self.scsi_units[5].as_deref().map(path_string);
-        raw.scsi.unit6 = self.scsi_units[6].as_deref().map(path_string);
+        raw.scsi.unit0 = drive_raw(
+            self.scsi_units[0].as_deref(),
+            self.scsi_unit_names[0].as_deref(),
+        );
+        raw.scsi.unit1 = drive_raw(
+            self.scsi_units[1].as_deref(),
+            self.scsi_unit_names[1].as_deref(),
+        );
+        raw.scsi.unit2 = drive_raw(
+            self.scsi_units[2].as_deref(),
+            self.scsi_unit_names[2].as_deref(),
+        );
+        raw.scsi.unit3 = drive_raw(
+            self.scsi_units[3].as_deref(),
+            self.scsi_unit_names[3].as_deref(),
+        );
+        raw.scsi.unit4 = drive_raw(
+            self.scsi_units[4].as_deref(),
+            self.scsi_unit_names[4].as_deref(),
+        );
+        raw.scsi.unit5 = drive_raw(
+            self.scsi_units[5].as_deref(),
+            self.scsi_unit_names[5].as_deref(),
+        );
+        raw.scsi.unit6 = drive_raw(
+            self.scsi_units[6].as_deref(),
+            self.scsi_unit_names[6].as_deref(),
+        );
         // CD
         raw.cd.image = self.cd_image.as_deref().map(path_string);
         if self.cd_insert_delay != 0.0 {
@@ -824,7 +860,9 @@ impl MachineSetup {
         self.joystick_input_mode = base.joystick_input_mode;
         if !self.has_gayle() {
             self.ide_master = None;
+            self.ide_master_name = None;
             self.ide_slave = None;
+            self.ide_slave_name = None;
         }
         if !self.has_cd() {
             self.cd_image = None;
@@ -921,6 +959,62 @@ impl MachineSetup {
         }
     }
 
+    /// Whether `field` is a hard-drive image that can carry a volume-name
+    /// override (IDE/SCSI drives, but not the SCSI boot ROM or CD/ROM paths).
+    pub fn is_drive_field(field: LauncherField) -> bool {
+        matches!(
+            field,
+            F::IdeMaster
+                | F::IdeSlave
+                | F::ScsiUnit0
+                | F::ScsiUnit1
+                | F::ScsiUnit2
+                | F::ScsiUnit3
+                | F::ScsiUnit4
+                | F::ScsiUnit5
+                | F::ScsiUnit6
+        )
+    }
+
+    /// The volume-name override for a drive field, if set.
+    pub fn drive_name(&self, field: LauncherField) -> Option<&str> {
+        let name = match field {
+            F::IdeMaster => &self.ide_master_name,
+            F::IdeSlave => &self.ide_slave_name,
+            F::ScsiUnit0 => &self.scsi_unit_names[0],
+            F::ScsiUnit1 => &self.scsi_unit_names[1],
+            F::ScsiUnit2 => &self.scsi_unit_names[2],
+            F::ScsiUnit3 => &self.scsi_unit_names[3],
+            F::ScsiUnit4 => &self.scsi_unit_names[4],
+            F::ScsiUnit5 => &self.scsi_unit_names[5],
+            F::ScsiUnit6 => &self.scsi_unit_names[6],
+            _ => return None,
+        };
+        name.as_deref()
+    }
+
+    /// Set (or, with a blank string, clear) a drive field's volume-name
+    /// override. A name without a configured image is meaningless, so it is
+    /// dropped when the field has no path.
+    pub fn set_drive_name(&mut self, field: LauncherField, name: String) {
+        let trimmed = name.trim();
+        let value =
+            (!trimmed.is_empty() && self.path(field).is_some()).then(|| trimmed.to_string());
+        let slot = match field {
+            F::IdeMaster => &mut self.ide_master_name,
+            F::IdeSlave => &mut self.ide_slave_name,
+            F::ScsiUnit0 => &mut self.scsi_unit_names[0],
+            F::ScsiUnit1 => &mut self.scsi_unit_names[1],
+            F::ScsiUnit2 => &mut self.scsi_unit_names[2],
+            F::ScsiUnit3 => &mut self.scsi_unit_names[3],
+            F::ScsiUnit4 => &mut self.scsi_unit_names[4],
+            F::ScsiUnit5 => &mut self.scsi_unit_names[5],
+            F::ScsiUnit6 => &mut self.scsi_unit_names[6],
+            _ => return,
+        };
+        *slot = value;
+    }
+
     /// The value text shown on a row (the current enum/size/number; the file
     /// name or a placeholder for paths; On/Off for toggles).
     pub fn value_label(&self, field: LauncherField) -> String {
@@ -971,9 +1065,13 @@ impl MachineSetup {
                 JoystickInputMode::Keyboard => "Keyboard".to_string(),
                 JoystickInputMode::Gamepad => "Gamepad".to_string(),
             },
-            // Path fields: the file name, or a placeholder.
+            // Path/drive fields: the file name, or a placeholder.
             F::Rom => self.path_label(field, "(bundled AROS)"),
-            _ if rows_contains_kind(field, RowKind::Path) => self.path_label(field, "(none)"),
+            _ if rows_contains_kind(field, RowKind::Path)
+                || rows_contains_kind(field, RowKind::Drive) =>
+            {
+                self.path_label(field, "(none)")
+            }
             // Toggles
             _ => {
                 if self.toggle_value(field) {
@@ -1122,6 +1220,10 @@ impl MachineSetup {
             F::Cd32Nvram => self.cd32_nvram = None,
             _ => {}
         }
+        // A drive's volume name is meaningless once its image is gone.
+        if Self::is_drive_field(field) {
+            self.set_drive_name(field, String::new());
+        }
     }
 
     pub fn zorro_boards(&self) -> &[ZorroBoardSetup] {
@@ -1190,15 +1292,24 @@ impl StatusMessage {
     }
 }
 
+/// A text field that has keyboard focus in the configuration panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditTarget {
+    /// A Zorro plugin board's string option (board index, option index).
+    BoardOption { board: usize, opt: usize },
+    /// A hard-drive volume-name override.
+    DriveName(LauncherField),
+}
+
 /// The full interactive state of the open configuration panel.
 #[derive(Debug, Clone)]
 pub struct LauncherState {
     pub setup: MachineSetup,
     pub tab: LauncherTab,
     pub status: Option<StatusMessage>,
-    /// The string/int plugin option being typed into (board index, option
-    /// index) and the edit buffer, when a text field has focus.
-    editing: Option<(usize, usize)>,
+    /// The text field being typed into, and the edit buffer, when one has
+    /// focus (a plugin string option or a drive volume name).
+    editing: Option<EditTarget>,
     edit_buffer: String,
 }
 
@@ -1213,8 +1324,8 @@ impl LauncherState {
         }
     }
 
-    /// The (board, option) currently being text-edited, if any.
-    pub fn editing(&self) -> Option<(usize, usize)> {
+    /// The text field currently being edited, if any.
+    pub fn editing(&self) -> Option<EditTarget> {
         self.editing
     }
 
@@ -1224,14 +1335,21 @@ impl LauncherState {
     }
 
     /// Focus a board option for text entry, seeding the buffer with its value.
-    pub fn begin_edit(&mut self, board: usize, opt: usize) {
+    pub fn begin_edit_board(&mut self, board: usize, opt: usize) {
         self.edit_buffer = self
             .setup
             .zorro_boards()
             .get(board)
             .map(|b| b.value(opt))
             .unwrap_or_default();
-        self.editing = Some((board, opt));
+        self.editing = Some(EditTarget::BoardOption { board, opt });
+        self.status = None;
+    }
+
+    /// Focus a drive's volume-name field, seeding the buffer with its value.
+    pub fn begin_edit_drive_name(&mut self, field: LauncherField) {
+        self.edit_buffer = self.setup.drive_name(field).unwrap_or_default().to_string();
+        self.editing = Some(EditTarget::DriveName(field));
         self.status = None;
     }
 
@@ -1247,11 +1365,16 @@ impl LauncherState {
         }
     }
 
-    /// Commit the edit buffer to the focused board option.
+    /// Commit the edit buffer to the focused field.
     pub fn edit_commit(&mut self) {
-        if let Some((board, opt)) = self.editing.take() {
+        if let Some(target) = self.editing.take() {
             let value = std::mem::take(&mut self.edit_buffer);
-            self.setup.zorro_option_set(board, opt, value);
+            match target {
+                EditTarget::BoardOption { board, opt } => {
+                    self.setup.zorro_option_set(board, opt, value);
+                }
+                EditTarget::DriveName(field) => self.setup.set_drive_name(field, value),
+            }
         }
     }
 
@@ -1284,6 +1407,19 @@ fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
 
 fn path_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
+}
+
+/// Build a `[ide]`/`[scsi]` drive entry from an editable path + optional
+/// volume-name override. A blank name emits the bare path string so saved
+/// configs stay minimal.
+fn drive_raw(path: Option<&Path>, name: Option<&str>) -> Option<RawDrive> {
+    path.map(|p| RawDrive {
+        path: path_string(p),
+        name: name
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+    })
 }
 
 fn cycle_slice<T: Copy + PartialEq>(items: &[T], current: T, forward: bool) -> T {
@@ -1656,6 +1792,57 @@ mod tests {
         assert_eq!(
             raw.floppy.df1.as_ref().and_then(|d| d.path.as_deref()),
             Some("/disks/b.adf")
+        );
+    }
+
+    #[test]
+    fn drive_volume_name_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        s.select_model(Some(MachineModel::A1200)); // Gayle, so IDE applies.
+        s.set_path(LauncherField::IdeMaster, PathBuf::from("/host/games"));
+        s.set_drive_name(LauncherField::IdeMaster, "Games".to_string());
+        assert_eq!(s.drive_name(LauncherField::IdeMaster), Some("Games"));
+
+        let raw = s.to_raw();
+        let master = raw.ide.master.as_ref().expect("master emitted");
+        assert_eq!(master.path, "/host/games");
+        assert_eq!(master.name.as_deref(), Some("Games"));
+
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.drive_name(LauncherField::IdeMaster), Some("Games"));
+    }
+
+    #[test]
+    fn drive_volume_name_without_an_image_is_dropped() {
+        let mut s = MachineSetup::default();
+        s.select_model(Some(MachineModel::A1200));
+        // No image set: a name has nothing to label.
+        s.set_drive_name(LauncherField::IdeMaster, "Orphan".to_string());
+        assert_eq!(s.drive_name(LauncherField::IdeMaster), None);
+
+        // With an image the name sticks, then clearing the image drops it too.
+        s.set_path(LauncherField::IdeMaster, PathBuf::from("/host/games"));
+        s.set_drive_name(LauncherField::IdeMaster, "Games".to_string());
+        assert_eq!(s.drive_name(LauncherField::IdeMaster), Some("Games"));
+        s.clear_path(LauncherField::IdeMaster);
+        assert_eq!(s.drive_name(LauncherField::IdeMaster), None);
+    }
+
+    #[test]
+    fn editing_a_drive_name_commits_to_the_setup() {
+        let mut setup = MachineSetup::default();
+        setup.select_model(Some(MachineModel::A1200));
+        setup.set_path(LauncherField::ScsiUnit0, PathBuf::from("/host/work"));
+        let mut state = LauncherState::new(setup);
+        state.begin_edit_drive_name(LauncherField::ScsiUnit0);
+        for ch in "WORK".chars() {
+            state.edit_push(ch);
+        }
+        state.edit_commit();
+        assert_eq!(state.editing(), None);
+        assert_eq!(
+            state.setup.drive_name(LauncherField::ScsiUnit0),
+            Some("WORK")
         );
     }
 }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -8,7 +8,7 @@
 //! `window.rs` routes events to it and builds the per-frame view data
 //! (register snapshots, disassembly text) the panels render.
 
-use super::launcher::{self, LauncherField, LauncherState, LauncherTab, RowKind};
+use super::launcher::{self, EditTarget, LauncherField, LauncherState, LauncherTab, RowKind};
 use super::window::{
     draw_rect_bevel, fill_rect, fill_rect_blend, rgba, scale_rect, JoystickInputMode, Rect,
     BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE, BUTTON_FACE_HOVER,
@@ -436,6 +436,8 @@ pub enum UiControl {
     LauncherBrowse(LauncherField),
     /// Configuration screen: clear a path field.
     LauncherClear(LauncherField),
+    /// Configuration screen: focus a drive's volume-name field for text entry.
+    LauncherDriveNameEdit(LauncherField),
     /// Configuration screen: add a Zorro metadata board file.
     LauncherZorroAdd,
     /// Configuration screen: remove the Zorro board at this index.
@@ -1944,6 +1946,8 @@ const LAUNCH_ACTION_W: usize = 84;
 const LAUNCH_ACTION_H: usize = 22;
 const LAUNCH_BROWSE_W: usize = 66;
 const LAUNCH_CLEAR_W: usize = 54;
+/// Width of the editable volume-name box on a drive row.
+const LAUNCH_NAME_W: usize = 96;
 const LAUNCH_REMOVE_W: usize = 70;
 const LAUNCH_CONTROL_H: usize = 20;
 
@@ -2065,6 +2069,18 @@ fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
         h: LAUNCH_CONTROL_H,
     };
     (browse, clear)
+}
+
+/// The editable volume-name box on a drive row: it sits just left of the
+/// Browse button, with the path text filling the space before it.
+fn launcher_drive_name_rect(rect: Rect, row_y: usize) -> Rect {
+    let (browse, _clear) = launcher_path_rects(rect, row_y);
+    Rect {
+        x: browse.x.saturating_sub(6 + LAUNCH_NAME_W),
+        y: browse.y,
+        w: LAUNCH_NAME_W,
+        h: LAUNCH_CONTROL_H,
+    }
 }
 
 fn launcher_action_rects(rect: Rect) -> [(UiControl, Rect); 4] {
@@ -2271,6 +2287,21 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         return Some(UiControl::LauncherClear(r.field));
                     }
                 }
+                RowKind::Drive => {
+                    let (browse, clear) = launcher_path_rects(rect, row_y);
+                    if browse.contains(pos) {
+                        return Some(UiControl::LauncherBrowse(r.field));
+                    }
+                    if clear.contains(pos) {
+                        return Some(UiControl::LauncherClear(r.field));
+                    }
+                    // The volume name only matters once an image is chosen.
+                    if state.setup.path(r.field).is_some()
+                        && launcher_drive_name_rect(rect, row_y).contains(pos)
+                    {
+                        return Some(UiControl::LauncherDriveNameEdit(r.field));
+                    }
+                }
             }
         }
     }
@@ -2336,12 +2367,13 @@ fn draw_launcher_chip(
 fn draw_launcher_row(
     frame: &mut [u8],
     rect: Rect,
-    setup: &launcher::MachineSetup,
+    state: &LauncherState,
     r: &launcher::Row,
     i: usize,
     hover: Option<UiControl>,
     scale: usize,
 ) {
+    let setup = &state.setup;
     let row_y = launcher_row_y(rect, i);
     let reason = setup.disabled_reason(r.field);
     let label_color = if reason.is_none() {
@@ -2425,6 +2457,62 @@ fn draw_launcher_row(
             let avail = browse.x.saturating_sub(value_x + 8);
             let text = truncate_to_width(&setup.value_label(r.field), avail);
             draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
+            draw_text_button(
+                frame,
+                browse,
+                "Browse",
+                true,
+                hover == Some(UiControl::LauncherBrowse(r.field)),
+                scale,
+            );
+            draw_text_button(
+                frame,
+                clear,
+                "Clear",
+                true,
+                hover == Some(UiControl::LauncherClear(r.field)),
+                scale,
+            );
+        }
+        RowKind::Drive => {
+            let (browse, clear) = launcher_path_rects(rect, row_y);
+            let value_x = launcher_control_x(rect);
+            // The volume-name box only appears once an image is chosen (a name
+            // has nothing to label otherwise); until then the row reads like a
+            // plain path row and the path text fills the full width.
+            let has_image = setup.path(r.field).is_some();
+            let name_box = launcher_drive_name_rect(rect, row_y);
+            let text_right = if has_image { name_box.x } else { browse.x };
+            let avail = text_right.saturating_sub(value_x + 8);
+            let text = truncate_to_width(&setup.value_label(r.field), avail);
+            draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
+            if has_image {
+                draw_rect_bevel(
+                    frame,
+                    scale_rect(name_box, scale),
+                    BUTTON_EDGE_DARK,
+                    BUTTON_EDGE_LIGHT,
+                    scale,
+                );
+                let editing = state.editing() == Some(EditTarget::DriveName(r.field));
+                let (label, color) = if editing {
+                    (format!("{}_", state.edit_buffer()), PANEL_TEXT_HILIGHT)
+                } else if let Some(name) = setup.drive_name(r.field) {
+                    (name.to_string(), PANEL_TEXT)
+                } else {
+                    ("(volume)".to_string(), PANEL_TEXT_DIM)
+                };
+                let shown = truncate_to_width(&label, name_box.w.saturating_sub(8));
+                draw_panel_text(
+                    frame,
+                    name_box.x + 4,
+                    name_box.y + 6,
+                    &shown,
+                    color,
+                    1,
+                    scale,
+                );
+            }
             draw_text_button(
                 frame,
                 browse,
@@ -2613,7 +2701,7 @@ fn draw_launcher_board_option(
             );
         }
         K::String => {
-            let editing = state.editing() == Some((board, opt));
+            let editing = state.editing() == Some(EditTarget::BoardOption { board, opt });
             let vbox = launcher_board_value_rect(rect, row_y);
             draw_rect_bevel(
                 frame,
@@ -2705,7 +2793,7 @@ fn draw_launcher(
         draw_launcher_zorro(frame, rect, state, hover, scale);
     } else {
         for (i, r) in launcher::rows(state.tab).iter().enumerate() {
-            draw_launcher_row(frame, rect, setup, r, i, hover, scale);
+            draw_launcher_row(frame, rect, state, r, i, hover, scale);
         }
     }
     // Status / error line.
@@ -3667,5 +3755,38 @@ mod tests {
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher-zorro");
         let _ = std::fs::remove_file(&manifest_path);
+
+        // Configuration screen: the Storage tab on an A1200, with an IDE
+        // master mounted from a host directory and given a volume-name
+        // override (the editable box beside Browse).
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.setup.select_model(Some(MachineModel::A1200));
+        state.setup.set_path(
+            LauncherField::IdeMaster,
+            std::path::PathBuf::from("/host/games"),
+        );
+        state
+            .setup
+            .set_drive_name(LauncherField::IdeMaster, "Games".to_string());
+        state.tab = LauncherTab::Storage;
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(
+            &mut frame,
+            scale,
+            &ui,
+            None,
+            None,
+            false,
+            WarpSpeed::Max,
+            false,
+            false,
+            JoystickInputMode::Auto,
+        );
+        assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
+        save(&frame, "launcher-storage");
     }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4710,8 +4710,14 @@ impl App {
             }
             UiControl::LauncherClear(field) => {
                 if let Some(state) = self.launcher_state_mut() {
+                    state.edit_cancel();
                     state.setup.clear_path(field);
                     state.status = None;
+                }
+            }
+            UiControl::LauncherDriveNameEdit(field) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.begin_edit_drive_name(field);
                 }
             }
             UiControl::LauncherZorroRemove(idx) => {
@@ -4748,7 +4754,7 @@ impl App {
             }
             UiControl::LauncherBoardEdit { board, opt } => {
                 if let Some(state) = self.launcher_state_mut() {
-                    state.begin_edit(board, opt);
+                    state.begin_edit_board(board, opt);
                 }
             }
             UiControl::LauncherBoardBrowse { board, opt } => self.launcher_board_browse(board, opt),
@@ -5245,6 +5251,9 @@ impl App {
         let picked = dialog.pick_file();
         if let Some(path) = picked {
             if let Some(state) = self.launcher_state_mut() {
+                // A pending volume-name edit (on this or another drive row)
+                // would otherwise be left visually focused after the dialog.
+                state.edit_cancel();
                 state.setup.set_path(field, path);
                 state.status = None;
             }
@@ -5315,6 +5324,10 @@ impl App {
     }
 
     fn launcher_save(&mut self) {
+        // Capture a name/option typed but not yet committed with Enter.
+        if let Some(state) = self.launcher_state_mut() {
+            state.edit_commit();
+        }
         let toml = match self.launcher_state().map(|s| s.setup.to_toml()) {
             Some(Ok(text)) => text,
             Some(Err(e)) => {
@@ -5351,6 +5364,10 @@ impl App {
     /// AROS resolution, audio-device and machine-construction errors all stay
     /// in the panel as a status line; only success swaps the live machine.
     fn launcher_run(&mut self) {
+        // Capture a name/option typed but not yet committed with Enter.
+        if let Some(state) = self.launcher_state_mut() {
+            state.edit_commit();
+        }
         let mut cfg = match self.launcher_state().map(|s| s.setup.build_config()) {
             Some(Ok(cfg)) => cfg,
             Some(Err(e)) => {


### PR DESCRIPTION
Closes #50.

## What

When a host directory is mounted as an IDE/SCSI hard drive (the directory-as-HDD feature), the in-memory FFS volume took its label from the host directory name with no way to change it. This adds a way to override that volume name, both in the config file and in the GUI configuration screen.

## Config

IDE/SCSI drive entries now accept either the existing bare path string or a table carrying an explicit volume name:

```toml
[ide]
master = { path = "/host/Games", name = "Games" }
slave  = "scratch.hdf"          # bare-string form unchanged

[scsi]
rom   = "a2091.rom"
unit0 = { path = "/host/Work", name = "Work" }
```

- The name sets the **FFS volume label** of a directory mount.
- It is validated: no `:` or `/`, at most 30 characters (the AmigaDOS limit); a blank name is treated as no override.
- It is **ignored for a raw HDF**, which carries its own label inside the image (a warning is logged if one is set).
- Existing configs round-trip unchanged: an entry with no name still serializes back to the bare string.

The override threads from `IdeConfig`/`ScsiConfig` (new `DriveImage { path, volume_name }`) through `HardDriveImage::open` into `dirfs::build_ffs_image`.

## GUI

On the **Hard Disk** tab, once a drive has an image an editable volume-name box appears beside **Browse**; click it and type to set the name (left blank, a directory mount inherits the host directory name). The panel's text-edit focus was generalized from a Zorro-board-option tuple to an `EditTarget` enum so it can also target a drive name. A typed-but-not-Entered name is committed on Save/Run.


## Tests

- Table-form parsing for IDE and SCSI, plus name validation (`:`/`/`, length, blank, unknown key).
- TOML round-trip including the scalar-before-subtable sibling ordering case.
- The directory-mount FFS label decoded back from the built image, both default (directory name) and overridden.
- The launcher drive-name model (round-trip, drop-without-image, edit-commit).

`cargo test` (1194 pass), `cargo clippy`, and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
