### PR TITLE
Make joystick input mode explicit with a status-bar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ config file:
 Essential shortcuts use `Cmd` on macOS and `Alt` on Linux/Windows:
 `Cmd+Q` / `Alt+Q` closes the window, `Esc` passes through to the Amiga (or
 closes an open menu/window), `Cmd+S` / `Alt+S` saves a screenshot, and
-`Cmd+B` / `Alt+B` opens the debugger. `Cmd+J` / `Alt+J` cycles joystick
-input between automatic selection, keyboard emulation, and gamepad-only.
+`Cmd+B` / `Alt+B` opens the debugger. `Cmd+J` / `Alt+J` (or the status-bar
+icon) toggles joystick input between gamepad-only and keyboard emulation.
 The status bar, pop-up menu, tool windows (debugger and frame analyzer),
 overlay panels, save/load state, input recording, and the full shortcut list
 are documented in the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,7 +44,7 @@ range checks as the equivalent TOML fields:
 | `--fast SIZE` | `[memory] fast` | `0`, `1M`, `4M`, `8M`, ... |
 | `--slow SIZE` | `[memory] slow` | `0`, up to `512K` |
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
-| `--joystick MODE` | `[input] joystick` | `auto`, `keyboard`, `gamepad` |
+| `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 
 For example, to boot a stock A1200 profile but with 8 MB of fast RAM and a
 faster CPU, with no config file at all:
@@ -320,25 +320,26 @@ hiss during disk DMA.
 
 ```toml
 [input]
-joystick = "auto"   # "auto" (default), "keyboard", or "gamepad"
+joystick = "gamepad"   # "gamepad" (default) or "keyboard"
 ```
 
-Selects the initial host source for the emulated port-2 joystick / CD32 pad:
+Selects the initial host source for the emulated port-2 joystick / CD32 pad.
+There are two explicit modes, so the active source is always visible rather
+than depending on whether a pad happens to be connected:
 
-- `auto` -- a calibrated USB gamepad drives port 2 when one is present;
-  otherwise the keyboard-joystick mapping (cursor keys plus the fire keys)
-  takes over so port 2 stays usable without a controller.
-- `gamepad` -- only a physical pad drives port 2. The keyboard is left to
-  the Amiga, so it passes straight through to a Shell, an editor, or
-  Workbench. With no pad connected there is simply no port-2 input. Handy
-  when running an AmigaOS environment for hands-on, keyboard-driven setup.
-- `keyboard` -- always use the keyboard-joystick mapping, even when a pad is
-  connected.
+- `gamepad` (the default) -- only a physical pad drives port 2. The keyboard
+  is left to the Amiga, so it passes straight through to a Shell, an editor,
+  or Workbench, and no keys are unexpectedly captured as joystick input. With
+  no pad connected there is simply no port-2 input.
+- `keyboard` -- use the keyboard-joystick mapping (cursor keys plus the fire
+  keys), so port 2 stays usable without a controller.
 
-This only sets the starting mode. `Cmd+J` / `Alt+J` (and the menu's
-**Joystick Input** item, or the launcher's *A/V & Emu* tab) still cycle it
-live without changing the config. `--joystick MODE` overrides this for a
-single run.
+This only sets the starting mode. The status-bar toggle (the gamepad /
+keyboard icon next to the volume control), `Cmd+J` / `Alt+J`, the menu's
+**Joystick Input** item, and the launcher's *A/V & Emu* tab all flip it live
+without changing the config. `--joystick MODE` overrides this for a single
+run. (`auto` is still accepted here as a backward-compatibility alias for
+`gamepad`; the old auto-detect mode has been removed.)
 
 ## `[floppy]` and `[floppy.df0]` .. `[floppy.df3]`
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -19,7 +19,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+D` | `Alt+D` | Swap to the next disk in a drive's configured playlist |
 | `Cmd+G` | `Alt+G` | Capture / release the host mouse (clicking the display also captures) |
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
-| `Cmd+J` | `Alt+J` | Cycle joystick input mode: auto, keyboard, gamepad |
+| `Cmd+J` | `Alt+J` | Toggle joystick input mode: gamepad / keyboard (also the status-bar icon) |
 | `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |
 | `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Esc` | `Esc` | Close an open menu, tool window, or overlay panel; otherwise passed through to the Amiga |
@@ -58,6 +58,10 @@ The status bar (44 pixels below the display) holds, left to right:
 - **Camera button**: saves a screenshot (same as `Cmd+S` on macOS or
   `Alt+S` on Linux/Windows).
 - **Hamburger menu button**: opens the pop-up menu (below).
+- **Joystick toggle** (just left of the volume control): a gamepad or
+  keyboard icon showing which source drives the port-2 joystick. Click it to
+  flip between gamepad-only and keyboard joystick emulation; see
+  [](#mouse-and-joystick).
 - **Volume slider**: drag, or scroll the mouse wheel over it for 5% steps.
 - **Pause / power / reboot buttons.** Pause freezes emulation while staying
   powered; power cold-boots (clears RAM) or powers off back to the test
@@ -90,8 +94,8 @@ tool window or overlay.
   pauses the machine and opens the five-tab debugger in a tool window; see
   [](../debugger/window).
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
-- **Joystick Input** (also `Cmd+J` / `Alt+J`): cycles between automatic
-  selection, keyboard joystick emulation, and gamepad-only mode.
+- **Joystick Input** (also `Cmd+J` / `Alt+J`, or the status-bar icon):
+  toggles between gamepad-only and keyboard joystick emulation.
 - **Warp Speed** (also `Cmd+W` / `Alt+W`): runs the emulator unpaced for
   fast-forward. Toggling back re-anchors real-time pacing cleanly.
 - **Warp Limit** (also `Cmd+Shift+W` / `Alt+Shift+W`): cycles how fast warp
@@ -286,20 +290,21 @@ POT1Y/POTGOR. On a CD32 machine the pad speaks the CD32 serial button
 protocol instead, including the red/blue/green/yellow and transport
 buttons. Mouse and gamepad coexist because they use different ports.
 
-If no calibrated gamepad is connected, Copperline can emulate the port-2
-joystick from the host keyboard. The joystick input mode starts at **auto**
-(a calibrated USB gamepad is used when present, otherwise the keyboard
-mapping is active); set a different starting mode with `[input] joystick` in
-the config (or `--joystick MODE`, or the launcher's *A/V & Emu* tab) when you
-want the keyboard left to the Amiga for interactive setup. Use the menu's
-**Joystick Input** item, or `Cmd+J` on macOS / `Alt+J` on Linux and Windows,
-to cycle through:
+Copperline can also emulate the port-2 joystick from the host keyboard.
+There are two explicit input modes, and the active one is always shown by the
+gamepad / keyboard icon in the status bar (next to the volume control), so a
+"my keys aren't working" surprise can be spotted and fixed at a glance:
 
-- **auto**: gamepad when available, keyboard fallback otherwise.
-- **keyboard**: always use the keyboard mapping and ignore live gamepad
-  polling.
-- **gamepad**: use only a calibrated gamepad; keyboard keys pass through
-  to the Amiga keyboard.
+- **gamepad** (the default): use only a calibrated gamepad; every keyboard
+  key passes through to the Amiga. With no pad connected there is no port-2
+  input. This is the no-surprise mode for interactive AmigaOS setup.
+- **keyboard**: use the keyboard-joystick mapping so port 2 works without a
+  controller.
+
+Click the status-bar icon to flip between them; the menu's **Joystick Input**
+item and `Cmd+J` on macOS / `Alt+J` on Linux and Windows do the same. Set the
+starting mode with `[input] joystick` in the config (or `--joystick MODE`, or
+the launcher's *A/V & Emu* tab).
 
 Keyboard joystick mode uses the FS-UAE-compatible mapping: cursor keys for
 directions, and Right Ctrl or Right Alt for fire. For CD32 pad buttons,

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,9 +139,10 @@ pub struct Config {
     /// real CRT.
     pub phosphor: f32,
     /// Initial host input source for the emulated port-2 joystick/CD32 pad
-    /// (`[input] joystick` / `--joystick`). Defaults to [`JoystickInputMode::Auto`];
-    /// the runtime `Cmd+J` / `Alt+J` toggle (and the menu's Joystick Input item)
-    /// changes it live without affecting this start-up value.
+    /// (`[input] joystick` / `--joystick`). Defaults to
+    /// [`JoystickInputMode::Gamepad`]; the runtime status-bar toggle, `Cmd+J` /
+    /// `Alt+J`, and the menu's Joystick Input item flip it live without
+    /// affecting this start-up value.
     pub joystick_input_mode: JoystickInputMode,
 }
 
@@ -163,29 +164,27 @@ pub enum Overscan {
     Tv,
 }
 
-/// Host input source for the emulated port-2 joystick/CD32 pad. `Auto` keeps a
-/// calibrated physical gamepad in charge when one is present and otherwise
-/// falls back to keyboard joystick emulation. `Gamepad` uses only a physical
-/// pad, so the keyboard passes straight through to the Amiga (and with no pad
-/// connected there is simply no port-2 input). `Keyboard` always uses the
-/// keyboard-joystick mapping. Set the initial mode with `[input] joystick`
-/// (or `--joystick`); `Cmd+J` / `Alt+J` still cycles it at runtime.
+/// Host input source for the emulated port-2 joystick/CD32 pad. `Gamepad` (the
+/// default) uses only a physical pad, so the keyboard passes straight through to
+/// the Amiga (and with no pad connected there is simply no port-2 input).
+/// `Keyboard` always uses the keyboard-joystick mapping, capturing the arrow
+/// keys and fire keys. There are deliberately only these two explicit modes: the
+/// status-bar toggle and `Cmd+J` / `Alt+J` flip between them, so the active mode
+/// is always visible rather than depending on hidden gamepad-presence state. Set
+/// the start-up mode with `[input] joystick` (or `--joystick`).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum JoystickInputMode {
     #[default]
-    Auto,
     Gamepad,
     Keyboard,
 }
 
 impl JoystickInputMode {
-    /// Cycle order for the runtime toggle and the launcher stepper:
-    /// auto -> keyboard -> gamepad -> auto.
+    /// Flip the two-state toggle (status bar, `Cmd+J`/`Alt+J`, launcher stepper).
     pub fn next(self) -> Self {
         match self {
-            Self::Auto => Self::Keyboard,
+            Self::Gamepad => Self::Keyboard,
             Self::Keyboard => Self::Gamepad,
-            Self::Gamepad => Self::Auto,
         }
     }
 
@@ -193,7 +192,6 @@ impl JoystickInputMode {
     /// (round-trips through [`parse_joystick_input_mode`]).
     pub fn label(self) -> &'static str {
         match self {
-            Self::Auto => "auto",
             Self::Gamepad => "gamepad",
             Self::Keyboard => "keyboard",
         }
@@ -747,7 +745,7 @@ impl Default for Config {
             floppy_playlists: std::array::from_fn(|_| Vec::new()),
             overscan: Overscan::Tv,
             phosphor: 0.0,
-            joystick_input_mode: JoystickInputMode::Auto,
+            joystick_input_mode: JoystickInputMode::Gamepad,
         }
     }
 }
@@ -863,8 +861,9 @@ pub struct ConfigOverrides {
     pub fast: Option<String>,
     pub slow: Option<String>,
     pub floppy_drives: Option<u8>,
-    /// Initial joystick input mode (`--joystick`): "auto", "keyboard", or
-    /// "gamepad". Validated by the same parser as `[input] joystick`.
+    /// Initial joystick input mode (`--joystick`): "gamepad" or "keyboard"
+    /// ("auto" still accepted as a compatibility alias). Validated by the same
+    /// parser as `[input] joystick`.
     pub joystick: Option<String>,
 }
 
@@ -995,12 +994,13 @@ pub(crate) struct RawDisplay {
 }
 
 /// `[input]` host-input preferences. Currently just the initial joystick input
-/// mode; `Cmd+J` / `Alt+J` still cycles it live.
+/// mode; the status-bar toggle and `Cmd+J` / `Alt+J` flip it live.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawInput {
-    /// Initial joystick input source: "auto" (default), "keyboard", or
-    /// "gamepad".
+    /// Initial joystick input source: "gamepad" (default) or "keyboard".
+    /// ("auto" is still accepted for backward compatibility and maps to
+    /// "gamepad".)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) joystick: Option<String>,
 }
@@ -1637,11 +1637,13 @@ pub(crate) fn parse_overscan(s: &str) -> Result<Overscan> {
 
 pub(crate) fn parse_joystick_input_mode(s: &str) -> Result<JoystickInputMode> {
     match s.trim().to_ascii_lowercase().as_str() {
-        "auto" => Ok(JoystickInputMode::Auto),
+        // "auto" is retained as a backward-compatibility alias for older configs
+        // and `--joystick auto`; the auto-detect mode was removed in favour of
+        // the two explicit, always-visible modes, so it now maps to the default.
+        "auto" | "gamepad" | "pad" | "joystick" | "joy" => Ok(JoystickInputMode::Gamepad),
         "keyboard" | "kbd" | "key" => Ok(JoystickInputMode::Keyboard),
-        "gamepad" | "pad" | "joystick" | "joy" => Ok(JoystickInputMode::Gamepad),
         _ => Err(anyhow!(
-            "unknown [input] joystick {:?}: expected \"auto\", \"keyboard\", or \"gamepad\"",
+            "unknown [input] joystick {:?}: expected \"gamepad\" or \"keyboard\"",
             s
         )),
     }
@@ -2285,16 +2287,18 @@ mod tests {
     }
 
     #[test]
-    fn joystick_input_mode_defaults_to_auto() -> Result<()> {
-        // No [input] section: the port-2 source starts in Auto, regardless of
-        // the machine profile (it is a host-input preference, not hardware).
+    fn joystick_input_mode_defaults_to_gamepad() -> Result<()> {
+        // No [input] section: the port-2 source starts in Gamepad, regardless
+        // of the machine profile (it is a host-input preference, not hardware).
+        // Gamepad is the no-surprise default: with no pad the keyboard reaches
+        // the Amiga normally instead of being captured as joystick input.
         assert_eq!(
             parse_config("")?.joystick_input_mode,
-            JoystickInputMode::Auto
+            JoystickInputMode::Gamepad
         );
         assert_eq!(
             parse_config("[machine]\nprofile = \"A1200\"\n")?.joystick_input_mode,
-            JoystickInputMode::Auto
+            JoystickInputMode::Gamepad
         );
         Ok(())
     }
@@ -2302,7 +2306,8 @@ mod tests {
     #[test]
     fn joystick_input_mode_parses_and_rejects_garbage() -> Result<()> {
         for (text, expected) in [
-            ("auto", JoystickInputMode::Auto),
+            // "auto" is a backward-compatibility alias mapping to the default.
+            ("auto", JoystickInputMode::Gamepad),
             ("keyboard", JoystickInputMode::Keyboard),
             ("gamepad", JoystickInputMode::Gamepad),
             ("GAMEPAD", JoystickInputMode::Gamepad),

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,9 +337,10 @@ where
                 overrides.floppy_drives = Some(parse_floppy_drive_count(&value)?);
             }
             "--joystick" => {
-                overrides.joystick = Some(args.next().ok_or_else(|| {
-                    anyhow!("--joystick requires a mode (auto/keyboard/gamepad)")
-                })?);
+                overrides.joystick = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--joystick requires a mode (gamepad/keyboard)"))?,
+                );
             }
             "--click-after" => {
                 let secs: f32 = args
@@ -660,7 +661,7 @@ fn print_help() {
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
          --floppy-drives COUNT          wired floppy drives, 1-4 (DF0 plus externals)\n  \
-         --joystick MODE                initial joystick input: auto, keyboard, or gamepad\n  \
+         --joystick MODE                initial joystick input: gamepad or keyboard\n  \
          \x20                            (gamepad lets the keyboard pass through to the Amiga)\n  \
          \x20                            (--model/--cpu/etc. override the config file or defaults)\n  \
          --screenshot-after SECS PATH   save a PNG to PATH after SECS emulated seconds, then exit\n  \

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -448,12 +448,9 @@ const WARPS: [WarpSpeed; 5] = [
     WarpSpeed::X16,
     WarpSpeed::Max,
 ];
-// Cycle order matches the runtime Cmd+J toggle (auto -> keyboard -> gamepad).
-const JOYSTICK_MODES: [JoystickInputMode; 3] = [
-    JoystickInputMode::Auto,
-    JoystickInputMode::Keyboard,
-    JoystickInputMode::Gamepad,
-];
+// The stepper flips the two explicit modes, matching the runtime toggle.
+const JOYSTICK_MODES: [JoystickInputMode; 2] =
+    [JoystickInputMode::Gamepad, JoystickInputMode::Keyboard];
 
 /// A fully-typed, editable mirror of a configurable machine. See the module
 /// docs for how it round-trips through [`RawConfig`].
@@ -1061,7 +1058,6 @@ impl MachineSetup {
             },
             F::Warp => self.warp.label().to_string(),
             F::Joystick => match self.joystick_input_mode {
-                JoystickInputMode::Auto => "Auto".to_string(),
                 JoystickInputMode::Keyboard => "Keyboard".to_string(),
                 JoystickInputMode::Gamepad => "Gamepad".to_string(),
             },
@@ -1752,23 +1748,23 @@ mod tests {
     #[test]
     fn joystick_input_mode_round_trips_through_raw() {
         let mut s = MachineSetup::default();
-        // Default is Auto, which emits no [input] section.
-        assert_eq!(s.joystick_input_mode, JoystickInputMode::Auto);
+        // Default is Gamepad, which emits no [input] section.
+        assert_eq!(s.joystick_input_mode, JoystickInputMode::Gamepad);
         assert!(s.to_raw().input.joystick.is_none());
-        // Cycle order matches the runtime toggle: auto -> keyboard -> gamepad.
+        // The stepper flips between the two explicit modes.
         s.cycle(LauncherField::Joystick, true);
         assert_eq!(s.joystick_input_mode, JoystickInputMode::Keyboard);
+        let raw = s.to_raw();
+        assert_eq!(raw.input.joystick.as_deref(), Some("keyboard"));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.joystick_input_mode, JoystickInputMode::Keyboard);
         s.cycle(LauncherField::Joystick, true);
         assert_eq!(s.joystick_input_mode, JoystickInputMode::Gamepad);
-        let raw = s.to_raw();
-        assert_eq!(raw.input.joystick.as_deref(), Some("gamepad"));
-        let back = MachineSetup::from_raw(&raw).unwrap();
-        assert_eq!(back.joystick_input_mode, JoystickInputMode::Gamepad);
-        // Switching machine profile resets it to the Auto default.
+        // Switching machine profile resets it to the Gamepad default.
         let mut s = MachineSetup::default();
         s.cycle(LauncherField::Joystick, true);
         s.select_model(Some(MachineModel::A1200));
-        assert_eq!(s.joystick_input_mode, JoystickInputMode::Auto);
+        assert_eq!(s.joystick_input_mode, JoystickInputMode::Gamepad);
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -3111,11 +3111,7 @@ mod tests {
         // must end before the popup's right edge or the trailing "..." clips.
         let menu = menu_rect();
         let limit = menu.x + menu.w;
-        let modes = [
-            JoystickInputMode::Auto,
-            JoystickInputMode::Keyboard,
-            JoystickInputMode::Gamepad,
-        ];
+        let modes = [JoystickInputMode::Gamepad, JoystickInputMode::Keyboard];
         let speeds = [WarpSpeed::X2, WarpSpeed::X8, WarpSpeed::X16, WarpSpeed::Max];
         for item in MENU_ITEMS {
             for warp in [false, true] {
@@ -3482,7 +3478,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         let menu = menu_rect();
         let probe = ((menu.y + MENU_PAD + 2) * w + menu.x + 4) * 4;
@@ -3514,7 +3510,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "about");
@@ -3534,7 +3530,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "shortcuts");
@@ -3571,7 +3567,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "calibration");
@@ -3615,7 +3611,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "debugger");
@@ -3656,7 +3652,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "debugger-break");
@@ -3683,7 +3679,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher");
@@ -3750,7 +3746,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher-zorro");
@@ -3784,7 +3780,7 @@ mod tests {
             WarpSpeed::Max,
             false,
             false,
-            JoystickInputMode::Auto,
+            JoystickInputMode::Gamepad,
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher-storage");

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -183,12 +183,11 @@ fn keyboard_joystick_key_for(code: KeyCode) -> Option<KeyboardJoystickKey> {
     })
 }
 
-fn joystick_mode_uses_keyboard(mode: JoystickInputMode, gamepad_active: bool) -> bool {
-    match mode {
-        JoystickInputMode::Keyboard => true,
-        JoystickInputMode::Auto => !gamepad_active,
-        JoystickInputMode::Gamepad => false,
-    }
+/// Whether the active mode routes the keyboard joystick mapping to port 2. With
+/// only the two explicit modes this is a direct read of the mode -- `Keyboard`
+/// captures the arrow/fire keys, `Gamepad` lets every key reach the Amiga.
+fn joystick_mode_uses_keyboard(mode: JoystickInputMode) -> bool {
+    matches!(mode, JoystickInputMode::Keyboard)
 }
 
 /// The port-2 controls currently held by `--joy-after` scripting.
@@ -275,6 +274,13 @@ const VOLUME_SLIDER_H: usize = 8;
 const VOLUME_KNOB_W: usize = 8;
 const VOLUME_KNOB_H: usize = 16;
 const VOLUME_GLYPH_X: usize = VOLUME_SLIDER_X - 16;
+// Joystick input-source toggle: a compact icon button just left of the volume
+// glyph, in the otherwise-free slot before the right-hand control cluster. The
+// widest media layout (four floppies plus a CD) ends at x=372, so a 22px button
+// here clears both the media controls and the speaker glyph; this is verified by
+// `joystick_toggle_clears_worst_case_media`.
+const JOY_TOGGLE_W: usize = 22;
+const JOY_TOGGLE_X: usize = VOLUME_GLYPH_X - 2 - JOY_TOGGLE_W;
 const STANDARD_PAL_VISIBLE_WIDTH: usize = 320 * 2;
 const STANDARD_PAL_VISIBLE_LINES: usize = 256;
 const STANDARD_PAL_VISIBLE_START_VPOS: u32 = 0x2C;
@@ -519,10 +525,6 @@ pub struct App {
     /// vsync-gated, so this is what decouples warp speed from the host monitor
     /// refresh rate. Adjustable from the Emulator menu and the keyboard.
     warp_speed: WarpSpeed,
-    /// Whether the last normal input poll resolved a calibrated physical
-    /// gamepad. Auto mode uses this to decide whether mapped keyboard keys
-    /// should be consumed as joystick controls.
-    last_gamepad_active: bool,
     /// Mapped host keys currently held for keyboard joystick emulation.
     keyboard_joy_held: KeyboardJoystickHeld,
     /// Pop-up menu and main-window overlay state. Debugger and frame
@@ -789,7 +791,6 @@ impl App {
             gamepad: crate::gamepad::GamepadReader::new(),
             joystick_input_mode,
             warp_speed,
-            last_gamepad_active: false,
             keyboard_joy_held: KeyboardJoystickHeld::default(),
             ui: UiState::default(),
             about_machine_lines,
@@ -803,15 +804,14 @@ impl App {
     }
 
     /// Poll the active host joystick source and drive the emulated port-2
-    /// joystick. Called once per scheduler quantum. In Auto mode, a
-    /// calibrated gamepad wins; otherwise the keyboard mapping supplies a
-    /// joystick so port 2 remains usable without a physical controller.
+    /// joystick. Called once per scheduler quantum. In Gamepad mode a calibrated
+    /// physical pad drives the port; in Keyboard mode the keyboard mapping does,
+    /// so port 2 stays usable without a physical controller.
     fn pump_joystick_input(&mut self) {
         let gamepad_state = match self.joystick_input_mode {
             JoystickInputMode::Keyboard => None,
-            JoystickInputMode::Auto | JoystickInputMode::Gamepad => self.gamepad.poll(),
+            JoystickInputMode::Gamepad => self.gamepad.poll(),
         };
-        self.last_gamepad_active = gamepad_state.is_some();
 
         match gamepad_state {
             Some(state) => self.apply_joystick_state(state),
@@ -830,7 +830,7 @@ impl App {
     }
 
     fn keyboard_joystick_enabled(&self) -> bool {
-        joystick_mode_uses_keyboard(self.joystick_input_mode, self.last_gamepad_active)
+        joystick_mode_uses_keyboard(self.joystick_input_mode)
     }
 
     fn apply_joystick_state(&mut self, state: crate::gamepad::JoystickState) {
@@ -865,9 +865,6 @@ impl App {
             return;
         }
         self.joystick_input_mode = mode;
-        if mode == JoystickInputMode::Keyboard {
-            self.last_gamepad_active = false;
-        }
         if !matches!(self.ui.panel, Some(Panel::Calibration(_))) {
             self.pump_joystick_input();
         }
@@ -1432,6 +1429,7 @@ impl ApplicationHandler for App {
                     powered_on: self.powered_on,
                     paused: self.paused,
                     media,
+                    joystick_input_mode: self.joystick_input_mode,
                     hover,
                 };
                 let osd = self.active_osd_text();
@@ -2476,6 +2474,13 @@ fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_scale: usize)
             texture_scale,
         );
     }
+    draw_joystick_button(
+        frame,
+        scale_rect(joystick_toggle_rect(), texture_scale),
+        view.joystick_input_mode,
+        hover == Some(BarControl::Joystick),
+        texture_scale,
+    );
     draw_volume_control(frame, status.output_volume_percent, texture_scale);
     draw_menu_button(
         frame,
@@ -2536,6 +2541,8 @@ struct StatusBarView {
     powered_on: bool,
     paused: bool,
     media: MediaBar,
+    /// Active host joystick source, shown by the status-bar toggle icon.
+    joystick_input_mode: JoystickInputMode,
     hover: Option<BarControl>,
 }
 
@@ -2547,6 +2554,7 @@ enum BarControl {
     Reboot,
     Screenshot,
     Menu,
+    Joystick,
     Volume,
     DriveLoad(usize),
     DriveSwap(usize),
@@ -2667,6 +2675,9 @@ fn control_at(pos: (i32, i32), layout: &BarLayout) -> Option<BarControl> {
     }
     if reboot_button_rect().contains(pos) {
         return Some(BarControl::Reboot);
+    }
+    if joystick_toggle_rect().contains(pos) {
+        return Some(BarControl::Joystick);
     }
     if volume_control_hit_rect().contains(pos) {
         return Some(BarControl::Volume);
@@ -2799,6 +2810,15 @@ fn volume_control_hit_rect() -> Rect {
         x: VOLUME_SLIDER_X - 8,
         y: PRESENT_HEIGHT + STATUS_CONTROL_Y,
         w: VOLUME_SLIDER_W + 16,
+        h: STATUS_CONTROL_H,
+    }
+}
+
+fn joystick_toggle_rect() -> Rect {
+    Rect {
+        x: JOY_TOGGLE_X,
+        y: PRESENT_HEIGHT + STATUS_CONTROL_Y,
+        w: JOY_TOGGLE_W,
         h: STATUS_CONTROL_H,
     }
 }
@@ -3634,6 +3654,81 @@ fn draw_pause_button(
     } else {
         draw_pause_glyph(frame, cx, cy, BUTTON_GLYPH, texture_scale);
     }
+}
+
+/// Joystick input-source toggle: shows the device currently driving the
+/// emulated port-2 joystick (a gamepad in `Gamepad` mode, a keyboard in
+/// `Keyboard` mode). Clicking it flips between the two, so the active source is
+/// always visible rather than hidden behind a key combination.
+fn draw_joystick_button(
+    frame: &mut [u8],
+    rect: Rect,
+    mode: JoystickInputMode,
+    hover: bool,
+    texture_scale: usize,
+) {
+    draw_button_base(frame, rect, hover, texture_scale);
+    match mode {
+        JoystickInputMode::Gamepad => draw_gamepad_glyph(frame, rect, texture_scale),
+        JoystickInputMode::Keyboard => draw_keyboard_glyph(frame, rect, texture_scale),
+    }
+}
+
+/// A small gamepad: a rounded green body with a recessed d-pad on the left and
+/// two action buttons on the right.
+fn draw_gamepad_glyph(frame: &mut [u8], rect: Rect, texture_scale: usize) {
+    let s = texture_scale;
+    let mut cell = |x: usize, y: usize, w: usize, h: usize, color: u32| {
+        fill_rect(
+            frame,
+            Rect {
+                x: rect.x + x * s,
+                y: rect.y + y * s,
+                w: w * s,
+                h: h * s,
+            },
+            color,
+            texture_scale,
+        );
+    };
+    // Body and the two grip bumps.
+    cell(4, 8, 14, 8, BUTTON_GLYPH);
+    cell(3, 13, 3, 3, BUTTON_GLYPH);
+    cell(16, 13, 3, 3, BUTTON_GLYPH);
+    // D-pad cross, cut into the body on the left.
+    cell(7, 9, 2, 5, BUTTON_EDGE_DARK);
+    cell(5, 11, 6, 2, BUTTON_EDGE_DARK);
+    // Two action buttons on the right.
+    cell(13, 10, 2, 2, BUTTON_EDGE_DARK);
+    cell(15, 12, 2, 2, BUTTON_EDGE_DARK);
+}
+
+/// A small keyboard: a recessed dark case holding two rows of green keys and a
+/// space bar.
+fn draw_keyboard_glyph(frame: &mut [u8], rect: Rect, texture_scale: usize) {
+    let s = texture_scale;
+    let mut cell = |x: usize, y: usize, w: usize, h: usize, color: u32| {
+        fill_rect(
+            frame,
+            Rect {
+                x: rect.x + x * s,
+                y: rect.y + y * s,
+                w: w * s,
+                h: h * s,
+            },
+            color,
+            texture_scale,
+        );
+    };
+    // Case.
+    cell(3, 6, 16, 11, BUTTON_EDGE_DARK);
+    // Two rows of keys.
+    for &kx in &[5, 8, 11, 14] {
+        cell(kx, 8, 2, 2, BUTTON_GLYPH);
+        cell(kx, 11, 2, 2, BUTTON_GLYPH);
+    }
+    // Space bar.
+    cell(7, 14, 8, 2, BUTTON_GLYPH);
 }
 
 /// The pause symbol: two short vertical bars flanking the centre.
@@ -4586,6 +4681,10 @@ impl App {
             BarControl::DriveEject(idx) => self.eject_drive_disk(idx),
             BarControl::CdLoad => self.load_cd_from_dialog(),
             BarControl::CdEject => self.eject_cd(),
+            BarControl::Joystick => {
+                self.cycle_joystick_input_mode();
+                self.request_redraw();
+            }
             BarControl::Volume => {}
         }
     }
@@ -5425,7 +5524,6 @@ impl App {
         // Reset the host joystick source to the new machine's configured
         // start-up mode (a previous live Cmd+J toggle does not carry over).
         self.joystick_input_mode = cfg.joystick_input_mode;
-        self.last_gamepad_active = false;
         self.keyboard_joy_held = KeyboardJoystickHeld::default();
         self.about_machine_lines = crate::about_machine_lines(cfg);
         self.deinterlacer = Deinterlacer::with_phosphor(crate::resolve_phosphor(cfg.phosphor));
@@ -7579,18 +7677,18 @@ mod tests {
         control_at, copperline_icon_image, copperline_logo_image, copy_present_frame,
         draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect,
         host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_mode_uses_keyboard,
-        keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv, paint_test_screen,
-        parse_amiga_key, pause_button_rect, power_button_rect, present_row_sample,
-        presentation_source_y_offset, reboot_button_rect, rgba, shot_button_rect,
-        should_render_emulated_frame, standard_window_top_row, status_with_latched_fdd_track,
-        take_integral_mouse_delta, texture_height, texture_width, tv_source_h_bounds,
-        tv_standard_h_shift, volume_percent_from_pos, volume_slider_track_rect, BarControl,
-        DriveBar, JoystickInputMode, KeyboardJoystickHeld, KeyboardJoystickKey, MediaBar,
-        StatusBarView, ToolPanelKind, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF,
-        CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF,
-        HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON, PRESENT_HEIGHT,
-        STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-        TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
+        joystick_toggle_rect, keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv,
+        paint_test_screen, parse_amiga_key, pause_button_rect, power_button_rect,
+        present_row_sample, presentation_source_y_offset, reboot_button_rect, rgba,
+        shot_button_rect, should_render_emulated_frame, standard_window_top_row,
+        status_with_latched_fdd_track, take_integral_mouse_delta, texture_height, texture_width,
+        tv_source_h_bounds, tv_standard_h_shift, volume_percent_from_pos, volume_slider_track_rect,
+        BarControl, DriveBar, JoystickInputMode, KeyboardJoystickHeld, KeyboardJoystickKey,
+        MediaBar, StatusBarView, ToolPanelKind, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY,
+        CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON,
+        HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON,
+        PRESENT_HEIGHT, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG,
+        TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
     };
     use crate::audio::{AudioSink, NullSink};
     use crate::bus::FrontPanelStatus;
@@ -7630,6 +7728,7 @@ mod tests {
             powered_on,
             paused,
             media: single_drive_media(),
+            joystick_input_mode: JoystickInputMode::Gamepad,
             hover: None,
         }
     }
@@ -7716,24 +7815,69 @@ mod tests {
     }
 
     #[test]
-    fn joystick_input_mode_policy_uses_keyboard_as_auto_fallback() {
-        assert_eq!(JoystickInputMode::Auto.next(), JoystickInputMode::Keyboard);
+    fn joystick_input_mode_toggles_between_two_explicit_modes() {
+        // The toggle flips directly between the two modes; there is no hidden
+        // auto-detect state, so the keyboard mapping is engaged exactly when
+        // (and only when) the mode is Keyboard.
+        assert_eq!(
+            JoystickInputMode::Gamepad.next(),
+            JoystickInputMode::Keyboard
+        );
         assert_eq!(
             JoystickInputMode::Keyboard.next(),
             JoystickInputMode::Gamepad
         );
-        assert_eq!(JoystickInputMode::Gamepad.next(), JoystickInputMode::Auto);
 
-        assert!(joystick_mode_uses_keyboard(JoystickInputMode::Auto, false));
-        assert!(!joystick_mode_uses_keyboard(JoystickInputMode::Auto, true));
-        assert!(joystick_mode_uses_keyboard(
-            JoystickInputMode::Keyboard,
-            true
-        ));
-        assert!(!joystick_mode_uses_keyboard(
-            JoystickInputMode::Gamepad,
-            false
-        ));
+        assert!(joystick_mode_uses_keyboard(JoystickInputMode::Keyboard));
+        assert!(!joystick_mode_uses_keyboard(JoystickInputMode::Gamepad));
+    }
+
+    #[test]
+    fn joystick_toggle_clears_worst_case_media() {
+        // The toggle sits at a fixed x just left of the volume glyph. The
+        // widest media layout (four floppies plus a CD) must not reach it, and
+        // it must stay left of the volume control's hit area.
+        let toggle = joystick_toggle_rect();
+        let layout = bar_layout(&media(4, Some(true)));
+        let media_right = layout
+            .cd_eject
+            .into_iter()
+            .chain(layout.drive_eject.into_iter().flatten())
+            .map(|r| r.x + r.w)
+            .max()
+            .unwrap();
+        assert!(
+            media_right <= toggle.x,
+            "media right edge {media_right} overlaps joystick toggle at {}",
+            toggle.x
+        );
+        assert!(toggle.x + toggle.w <= VOLUME_GLYPH_X);
+    }
+
+    #[test]
+    fn joystick_toggle_is_hit_tested_and_draws_each_mode() {
+        let layout = bar_layout(&single_drive_media());
+        let toggle = joystick_toggle_rect();
+        let center = (
+            (toggle.x + toggle.w / 2) as i32,
+            (toggle.y + toggle.h / 2) as i32,
+        );
+        assert_eq!(control_at(center, &layout), Some(BarControl::Joystick));
+
+        // Each mode lights the green glyph somewhere in the button (gamepad
+        // body vs. keyboard keys), so the two states are visually distinct.
+        let scale = 1;
+        for mode in [JoystickInputMode::Gamepad, JoystickInputMode::Keyboard] {
+            let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+            let mut v = view(FrontPanelStatus::default(), true, false);
+            v.joystick_input_mode = mode;
+            draw_status_bar(&mut frame, &v, scale);
+            let lit = (toggle.y..toggle.y + toggle.h).any(|y| {
+                (toggle.x..toggle.x + toggle.w)
+                    .any(|x| pixel(&frame, x, y, scale) == BUTTON_GLYPH.to_le_bytes())
+            });
+            assert!(lit, "joystick toggle drew no glyph for {mode:?}");
+        }
     }
 
     #[test]
@@ -8240,6 +8384,7 @@ mod tests {
             powered_on: true,
             paused: false,
             media: bar,
+            joystick_input_mode: JoystickInputMode::Gamepad,
             hover: None,
         };
         draw_status_bar(&mut frame, &v, scale);
@@ -8795,7 +8940,7 @@ mod tests {
             crate::config::Overscan::Full,
             0.0,
             crate::config::WarpSpeed::Max,
-            crate::config::JoystickInputMode::Auto,
+            crate::config::JoystickInputMode::Gamepad,
             vec!["Machine: test".to_string()],
             crate::config::RawConfig::default(),
         )


### PR DESCRIPTION
## Summary

Fixes #60 ("keyboard doesn't work"). The reported problem was the joystick **Auto** mode: with no calibrated gamepad connected, Auto silently captured the cursor keys and Right Ctrl / Right Alt as port-2 joystick input, so those keys stopped reaching the Amiga -- with nothing on screen to explain why.

This replaces the three modes (Auto / Gamepad / Keyboard) with two explicit ones, and surfaces the active mode in the status bar so it can never be a hidden surprise.

## Changes

- **Removed Auto.** `JoystickInputMode` is now `Gamepad` (default) and `Keyboard`.
  - **Gamepad (default)** is the no-surprise mode: only a physical pad drives port 2, so every keyboard key passes straight through to the Amiga. With no pad connected there is simply no port-2 input -- nothing is captured.
  - **Keyboard** is the FS-UAE keyboard-joystick mapping, unchanged.
- **`auto` kept as a compat alias.** The `[input] joystick` config key and `--joystick` still accept `"auto"`, mapping it to `Gamepad`, so existing configs and command lines keep working.
- **Status-bar toggle.** A gamepad / keyboard icon sits just left of the volume control, showing the active source; clicking it flips the mode. The active mode is now always visible.
- **Everything kept in sync.** `Cmd+J` / `Alt+J`, the menu's *Joystick Input* item, and the launcher's *A/V & Emu* stepper are all two-state now. The toggle is runtime-only -- config still sets the start-up default.
- **Docs** (`configuration.md`, `ui.md`, `README.md`) updated for the two modes, the new default, and the status-bar icon.

## Testing

- `cargo build --release`, `cargo clippy`, `cargo fmt --check` all clean.
- `cargo test --release`: 1196 passed, 0 failed.
- New tests: two-state toggle behaviour, status-bar hit-testing + per-mode glyph drawing, and a layout-clearance test proving the toggle clears even the widest media layout (four floppies plus a CD) and stays left of the volume control.
- Visually confirmed both icons render distinctly via the real `draw_status_bar` path.