### PR TITLE
Map host right Ctrl to Right Amiga key

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -27,8 +27,10 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 
 Host modifiers that are passed through to the emulated keyboard map onto
 the Amiga keyboard: Alt becomes Amiga Alt, Cmd/Super becomes the left/right
-Amiga keys, and Ctrl becomes Amiga Ctrl, so `Ctrl+Amiga+Amiga` is typed
-naturally.
+Amiga keys, and left Ctrl becomes Amiga Ctrl, so `Ctrl+Amiga+Amiga` is
+typed naturally. The Amiga keyboard has no right Ctrl, so host right Ctrl
+also acts as the right Amiga key -- handy on PC/laptop keyboards that lack
+a right Super/Win key.
 
 All other keys are sent to the emulated machine through the real path: a
 bit-timed keyboard-MCU model clocks each transition into CIA-A's serial

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7540,11 +7540,16 @@ fn host_to_amiga_rawkey(code: KeyCode) -> Option<u8> {
         ShiftLeft => 0x60,
         ShiftRight => 0x61,
         CapsLock => 0x62,
-        ControlLeft | ControlRight => 0x63,
+        // The Amiga keyboard has a single Ctrl key (left side); there is no
+        // right Ctrl. Map host ControlLeft to it. Host ControlRight has no
+        // Amiga counterpart, so alias it to Right Amiga ($67) alongside
+        // SuperRight -- many PC/laptop keyboards lack a right Super/Win key,
+        // leaving Right Amiga otherwise unreachable.
+        ControlLeft => 0x63,
         AltLeft => 0x64,
         AltRight => 0x65,
         SuperLeft => 0x66,
-        SuperRight => 0x67,
+        SuperRight | ControlRight => 0x67,
         // Arrows
         ArrowUp => 0x4C,
         ArrowDown => 0x4D,
@@ -7738,11 +7743,13 @@ mod tests {
     #[test]
     fn host_mapping_includes_amiga_modifiers() {
         assert_eq!(host_to_amiga_rawkey(KeyCode::ControlLeft), Some(0x63));
-        assert_eq!(host_to_amiga_rawkey(KeyCode::ControlRight), Some(0x63));
         assert_eq!(host_to_amiga_rawkey(KeyCode::AltLeft), Some(0x64));
         assert_eq!(host_to_amiga_rawkey(KeyCode::AltRight), Some(0x65));
         assert_eq!(host_to_amiga_rawkey(KeyCode::SuperLeft), Some(0x66));
         assert_eq!(host_to_amiga_rawkey(KeyCode::SuperRight), Some(0x67));
+        // The Amiga has no right Ctrl, so host ControlRight doubles as a
+        // Right Amiga ($67) alias for keyboards without a right Super key.
+        assert_eq!(host_to_amiga_rawkey(KeyCode::ControlRight), Some(0x67));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #65. On hosts without a right Super/Win key (most PC and laptop keyboards), the Right Amiga key was unreachable, blocking menu shortcuts and the `Ctrl+Amiga+Amiga` keyboard reset.

The Amiga keyboard has a single Ctrl key (left side, rawkey `$63`) and two Amiga keys (`$66`/`$67`). There is no right Ctrl on real hardware, so host `ControlRight` previously mapped redundantly to Amiga Ctrl. This aliases host `ControlRight` to Right Amiga (`$67`) alongside `SuperRight`; `ControlLeft` keeps Amiga Ctrl. It mirrors the physical Amiga layout, where the right side of the keyboard carries Right Amiga, not Ctrl.

This is the mapping proposed by @codewiz in the issue.

## Effect on existing hosts

- **Mac:** no practical change. Right Amiga is still reached via right Cmd (`SuperRight`), and Mac keyboards have only a left Ctrl, so the changed row rarely triggers. Left Ctrl still gives Amiga Ctrl.
- **Linux/Windows laptops:** right Ctrl now reaches Right Amiga, which was previously impossible.

## Changes

- `src/video/window.rs`: `host_to_amiga_rawkey` mapping + updated unit test `host_mapping_includes_amiga_modifiers`.
- `docs/guide/ui.md`: documented that host right Ctrl acts as Right Amiga.

## Testing

- `cargo test host_mapping_includes_amiga_modifiers` passes.
- `cargo clippy` and `cargo fmt --check` clean.