### PR TITLE
Model the 68040 on-chip caches

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -72,14 +72,16 @@ model = "68000"
 # RAM stay chip-bus bound.
 # clock_mhz = 14.0
 
-# Model the on-chip caches (CACR-controlled, cleared through MOVEC like
-# real silicon). Off by default: the calibrated 020 timing assumes no
-# cache model, so enabling them makes chip-RAM-resident code faster.
-# icache needs a 68020/68EC020/68030; dcache needs a 68030 (and only
-# caches expansion RAM/ROM -- chip and slow RAM are cache-inhibited
-# because DMA writes them, as on real Amigas).
-# icache = true
-# dcache = true
+# Model the on-chip caches (a hit serves with no chip-bus cycle, as on
+# real silicon, so cached code stops contending with DMA). On by default
+# for the CPUs that have them, since AmigaOS enables them at boot: the
+# instruction cache on the 68020/68EC020/68030/68040 (256 bytes on the
+# 020/030, 4 KB on the 040) and the data cache on the 68030/68040. The
+# data cache only covers expansion RAM/ROM -- chip and slow RAM are
+# cache-inhibited because DMA writes them, as on real Amigas. Set false
+# to force a CPU to run cacheless (e.g. for the uncalibrated baseline).
+# icache = false
+# dcache = false
 
 
 # Optional machine profile: a validated bundle of chipset revisions, CPU,

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -221,8 +221,8 @@ pub struct CpuCore {
 }
 
 // CACR bit assignments (68020/68030). The 68040 redefines CACR (IE/DE
-// enables only, with CINV/CPUSH instructions doing invalidation) and is
-// not cache-modeled here.
+// enables only, with CINV/CPUSH instructions doing invalidation); its bits
+// are below (CACR_040_*).
 /// Enable instruction cache.
 pub const CACR_EI: u32 = 1 << 0;
 /// Freeze instruction cache (hits served, misses do not allocate).
@@ -245,6 +245,15 @@ pub const CACR_CD: u32 = 1 << 11;
 pub const CACR_DBE: u32 = 1 << 12;
 /// Write allocate (68030; stored, the host model is write-through).
 pub const CACR_WA: u32 = 1 << 13;
+
+// CACR bit assignments (68040). The 68040 CACR has only two defined bits -
+// the cache enables - and no freeze/clear strobes: invalidation is done with
+// the CINV/CPUSH instructions instead (see decode.rs). All other bits are
+// reserved and read back as zero.
+/// Enable instruction cache (68040).
+pub const CACR_040_IE: u32 = 1 << 15;
+/// Enable data cache (68040).
+pub const CACR_040_DE: u32 = 1 << 31;
 
 impl Default for CpuCore {
     fn default() -> Self {
@@ -856,9 +865,11 @@ impl CpuCore {
                         CACR_EI | CACR_FI | CACR_IBE | CACR_ED | CACR_FD | CACR_DBE | CACR_WA,
                         CACR_CEI | CACR_CI | CACR_CED | CACR_CD,
                     ),
-                    // 68040 CACR has a different layout (IE/DE) and uses
-                    // CINV/CPUSH for invalidation; store it untouched.
-                    _ => (0xFFFF_FFFF, 0),
+                    // 68040 CACR defines only the two cache-enable bits and
+                    // has no clear strobes - invalidation is done with the
+                    // CINV/CPUSH instructions (see decode.rs). Reserved bits
+                    // read back as zero.
+                    _ => (CACR_040_IE | CACR_040_DE, 0),
                 };
                 self.cacr = value & persist;
                 self.cacr_pending_ops |= value & strobes;

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -148,10 +148,17 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         return cpu.exec_move16(bus, opcode);
     }
 
-    // 68030/68040 Cache Instructions: CINV and CPUSH (F-line, privileged)
-    // CINVA/CPUSHA: 1111 0100 x1x1 1000 (0xF418, 0xF438, 0xF458, 0xF478, etc.)
-    // CINV/CPUSH line/page: 1111 010x xxxx xaaa
-    // We treat these as NOPs since there's no cache to invalidate/push.
+    // 68040 Cache Instructions: CINV and CPUSH (F-line, privileged).
+    //   1111 0100 cc o ss aaa   cc = caches (01 data, 10 instr, 11 both),
+    //                           o = 0 CINV / 1 CPUSH, ss = scope, aaa = An.
+    // The host cache model is functional + write-through, so a push has no
+    // dirty data to write back and CPUSH collapses to CINV; we also do not
+    // track lines finely enough to honour the line/page scope, so every
+    // variant clears the whole indicated cache(s). Over-clearing only costs a
+    // few refills and is always coherent (the safe direction). The clears are
+    // surfaced to the host via cacr_pending_ops, the same channel the 68030
+    // CACR clear strobes use. The 68030 has no CINV/CPUSH (it invalidates
+    // through CACR), so these stay NOPs there.
     let is_cache_cpu = matches!(
         cpu.cpu_type,
         CpuType::M68EC030
@@ -165,7 +172,19 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         if !cpu.is_supervisor() {
             return cpu.take_exception(bus, 8); // Privilege violation
         }
-        // All CINV/CPUSH variants are NOPs for us
+        let is_68040 = matches!(
+            cpu.cpu_type,
+            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040
+        );
+        if is_68040 {
+            let caches = (opcode >> 6) & 0b11;
+            if caches & 0b01 != 0 {
+                cpu.cacr_pending_ops |= super::cpu::CACR_CD; // clear data cache
+            }
+            if caches & 0b10 != 0 {
+                cpu.cacr_pending_ops |= super::cpu::CACR_CI; // clear instruction cache
+            }
+        }
         return 4;
     }
 

--- a/crates/m68k/src/lib.rs
+++ b/crates/m68k/src/lib.rs
@@ -11,6 +11,9 @@ pub mod mmu;
 
 // Re-export commonly used types from core
 pub use core::cpu::CpuCore;
-pub use core::cpu::{CACR_CD, CACR_CED, CACR_CEI, CACR_CI, CACR_ED, CACR_EI, CACR_FD, CACR_FI};
+pub use core::cpu::{
+    CACR_040_DE, CACR_040_IE, CACR_CD, CACR_CED, CACR_CEI, CACR_CI, CACR_ED, CACR_EI, CACR_FD,
+    CACR_FI,
+};
 pub use core::memory::AddressBus;
 pub use core::types::{CpuType, HleHandler, NoOpHleHandler, Size, StepResult};

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -197,8 +197,8 @@ carried no information.)
 [cpu]
 model = "68000"     # 68000, 68EC020, 68020, 68030, 68040
 clock_mhz = 14.0    # optional; defaults to the model's stock speed
-# icache = false    # 020/030 instruction-cache model (on by default for them)
-# dcache = false    # 030 data-cache model (on by default for the 030)
+# icache = false    # instruction-cache model (on by default: 020/030/040)
+# dcache = false    # data-cache model (on by default: 030/040)
 # fpu = true        # fit a 68881/68882 (68020/68030; needs the coprocessor
 #                   # interface, so not valid on a 68000). The full 68040's
 #                   # on-die FPU is enabled by default.
@@ -212,14 +212,15 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
   stay chip-bus bound, so overclocking speeds up only what a real
   accelerator would speed up.
 - `icache`/`dcache` model the on-chip caches and default **on** for the
-  silicon that has them (instruction cache on the 020/68EC020/030, data cache
-  on the 030 only), matching real hardware where AmigaOS enables them via
-  CACR. Set either to `false` to opt out. This is not cosmetic: 020/030 code
-  that loops out of chip RAM otherwise contends with bitplane DMA on every
-  instruction fetch and can run at roughly half speed, which is why an AGA
-  demo's music or animation may pace correctly only with the cache modelled.
-  The data cache caches expansion RAM/ROM only, since chip and slow RAM are
-  DMA-visible and cache-inhibited as on real Amigas.
+  silicon that has them (instruction cache on the 020/68EC020/030/040, data
+  cache on the 030/040), matching real hardware where AmigaOS enables them via
+  CACR. The cache is sized to the CPU: 256 bytes on the 020/030, 4 KB on the
+  040. Set either to `false` to opt out. This is not cosmetic: code that loops
+  out of chip RAM otherwise contends with bitplane DMA on every instruction
+  fetch and can run at roughly half speed, which is why an AGA demo's music or
+  animation may pace correctly only with the cache modelled. The data cache
+  caches expansion RAM/ROM only, since chip and slow RAM are DMA-visible and
+  cache-inhibited as on real Amigas.
 
 ## `[memory]`
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -16,7 +16,7 @@ src/
   debugger.rs       # env-driven headless debugger
   disasm.rs         # 68000 + Copper-list disassemblers
   cpu.rs            # m68k core wrapper and CPU-visible bus adapter
-  cache.rs          # 68020/030 on-chip instruction/data cache model
+  cache.rs          # 68020/030/040 on-chip instruction/data cache model
   bus.rs            # shared RAM, ROM, chipset, CIA, RTC, and I/O state
   memory.rs         # chip/slow RAM, ROM, extended ROM containers
   romsearch.rs      # locate the bundled AROS default boot ROM

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -67,26 +67,42 @@ fall-through) and
 ## Caches
 
 The on-chip caches are silicon, so they are modelled by default on the parts
-that have them: the instruction cache on the 68020/68EC020/68030 and the data
-cache on the 68030 (`CpuModel::has_instruction_cache`/`has_data_cache`).
-CACR/CAAR are always stored; software (AmigaOS at boot) enables and clears the
-cache through CACR exactly as on hardware. A cache hit costs no bus cycle, so
-a cached instruction fetch does not contend with chip-bus DMA -- which is the
-point: 020/030 code looping out of chip RAM otherwise pays a bitplane-DMA
-arbitration stall on every fetch and runs at roughly half speed, drifting an
-AGA demo's interrupt-driven music or animation to half its intended rate. The
-data cache only covers expansion RAM/ROM because chip and slow RAM are
-DMA-visible and cache-inhibited, as on real machines. A 68000/68010 models no
-cache. `[cpu] icache = false`/`dcache = false` opt a 020/030 back out; with no
-cache modelled, the cache-control instructions are no-ops and self-modifying
-code always executes fresh bytes (the safe direction).
+that have them: the instruction cache on the 68020/68EC020/68030/68040 and the
+data cache on the 68030/68040 (`CpuModel::has_instruction_cache`/
+`has_data_cache`). CACR (and CAAR on the 020/030) are always stored; software
+(AmigaOS at boot) enables and clears the cache exactly as on hardware. A cache
+hit costs no bus cycle, so a cached instruction fetch does not contend with
+chip-bus DMA -- which is the point: 020/030/040 code looping out of chip RAM
+otherwise pays a bitplane-DMA arbitration stall on every fetch and runs at
+roughly half speed, drifting an AGA demo's interrupt-driven music or animation
+to half its intended rate. The data cache only covers expansion RAM/ROM
+because chip and slow RAM are DMA-visible and cache-inhibited, as on real
+machines. A 68000/68010 models no cache. `[cpu] icache = false`/`dcache =
+false` opt a cached CPU back out; with no cache modelled, the cache-control
+instructions are no-ops and self-modifying code always executes fresh bytes
+(the safe direction).
+
+Each cache is a power-of-two array of direct-mapped longword entries
+(`src/cache.rs`): 64 entries (256 bytes) on the 020/030 -- the exact 68020
+instruction-cache geometry -- and 1024 (4 KB) on the 68040. The larger 040
+capacity is the part that matters here: a chip-RAM loop bigger than 256 bytes
+stays resident on a 040 where it would thrash a 020. The 040's 4-way
+set-associative, 16-byte-line, copyback organisation is deliberately not
+modelled, and need not be -- copyback is unobservable because the data cache
+only covers expansion RAM, which is not DMA-visible, so write-back versus
+write-through cannot be told apart. The 040 also redefines CACR (only the IE/DE
+enable bits, no freeze or clear strobes) and moves invalidation to the
+CINV/CPUSH instructions; the model maps a CINV/CPUSH to a whole-cache clear of
+the indicated cache(s) -- over-clearing line/page scopes, which is always
+coherent (a push has no dirty data to write back in a write-through model).
 
 The instruction cache does not snoop writes (authentic 68020 behaviour), so a
 line stays valid until DMA or the CPU rewrites its backing memory, or software
-clears it via CACR. Restoring a save state that predates cache modelling (or
-was captured with the cache disabled) re-establishes the model's cache cold
-and re-derives its enable bits from the restored CACR, so the machine keeps
-the cache its CPU has rather than silently running cacheless after a load.
+clears it (via CACR on the 020/030, via CINV/CPUSH on the 040). Restoring a
+save state that predates cache modelling (or was captured with the cache
+disabled) re-establishes the model's cache cold and re-derives its enable bits
+from the restored CACR, so the machine keeps the cache its CPU has rather than
+silently running cacheless after a load.
 
 ## 68020+ timing
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,65 +1,84 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! 68020/68030 on-chip cache model (functional + bus-traffic accurate).
+//! 68020/68030/68040 on-chip cache model (functional + bus-traffic accurate).
 //!
-//! Both caches are modeled as 64 direct-mapped longword entries (256
-//! bytes), which is the exact 68020 instruction cache geometry; the
-//! 68030's 16x4-longword line organisation collapses to the same thing
-//! once burst fills are ignored (we do not model burst timing; IBE/DBE
-//! are stored but inert).
+//! Each cache is a power-of-two number of direct-mapped longword entries. The
+//! 68020/68030 use 64 entries (256 bytes), the exact 68020 instruction-cache
+//! geometry; the 68030's 16x4-longword line organisation collapses to the same
+//! thing once burst fills are ignored. The 68040's 4 KB caches are 1024
+//! entries: the larger capacity is what matters here (a chip-RAM loop bigger
+//! than 256 bytes stays resident on a 040 where it would thrash a 020). The
+//! 040's 4-way set-associative, 16-byte-line, copyback organisation is not
+//! modelled, and need not be: copyback is invisible because the data cache only
+//! covers expansion RAM, which is not DMA-visible, so write-back versus
+//! write-through is unobservable. We do not model burst timing (IBE/DBE are
+//! stored but inert on the 030).
 //!
-//! A hit serves the access with no bus cycle, which is the real effect
-//! that matters on an Amiga: cached fetches stop competing with DMA for
-//! the chip bus. Like the real silicon, the instruction cache does NOT
-//! snoop writes - self-modifying code must clear it through CACR, and
-//! DMA (blitter/copper/disk) never invalidates it. The data cache is
-//! write-through; a write that hits invalidates the entry (the next
-//! read refills it), which is always coherent and only marginally
+//! A hit serves the access with no bus cycle, which is the real effect that
+//! matters on an Amiga: cached fetches stop competing with DMA for the chip
+//! bus. Like the real silicon, the instruction cache does NOT snoop writes -
+//! self-modifying code must clear it (through CACR on the 020/030, through
+//! CINV/CPUSH on the 040), and DMA (blitter/copper/disk) never invalidates it.
+//! The data cache is write-through; a write that hits invalidates the entry
+//! (the next read refills it), which is always coherent and only marginally
 //! pessimistic versus update-on-hit.
 //!
-//! Cache emulation is opt-in (`[cpu] icache` / `dcache`): the default
-//! 68020 timing calibration (vendor scale_cycles_for_cpu_type plus the
-//! AGA fetch latch) was made without it, so enabling the caches makes
-//! chip-RAM code faster than that baseline.
+//! The caches are modelled by default on the CPUs that have them (AmigaOS
+//! turns them on through CACR at boot); `[cpu] icache = false` / `dcache =
+//! false` force them off. The 020+ chip-bus timing is calibrated against an
+//! A1200 with the cache on, since that is the A1200 default.
 
-const LINES: usize = 64;
+/// Longword entries for the 256-byte 68020/68030 caches.
+pub const LINES_020: usize = 64;
+/// Longword entries for the 4 KB 68040 caches.
+pub const LINES_040: usize = 1024;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LongwordCache {
-    #[serde(with = "serde_big_array::BigArray")]
-    tags: [u32; LINES],
-    #[serde(with = "serde_big_array::BigArray")]
-    valid: [bool; LINES],
-    #[serde(with = "serde_big_array::BigArray")]
-    data: [u32; LINES],
+    tags: Vec<u32>,
+    valid: Vec<bool>,
+    data: Vec<u32>,
+    /// `lines - 1`; `lines` is a power of two. `index = (addr >> 2) & index_mask`.
+    index_mask: u32,
+    /// Right-shift that drops the byte-offset and index bits, leaving the tag.
+    tag_shift: u32,
 }
 
 impl Default for LongwordCache {
     fn default() -> Self {
-        Self {
-            tags: [0; LINES],
-            valid: [false; LINES],
-            data: [0; LINES],
-        }
+        Self::new(LINES_020)
     }
 }
 
 impl LongwordCache {
-    #[inline]
-    fn index(addr: u32) -> usize {
-        ((addr >> 2) as usize) & (LINES - 1)
+    /// `lines` must be a power of two.
+    pub fn new(lines: usize) -> Self {
+        debug_assert!(lines.is_power_of_two(), "cache line count must be 2^n");
+        Self {
+            tags: vec![0; lines],
+            valid: vec![false; lines],
+            data: vec![0; lines],
+            index_mask: (lines as u32) - 1,
+            // Two byte-offset bits below the index, then log2(lines) index bits.
+            tag_shift: 2 + lines.trailing_zeros(),
+        }
     }
 
     #[inline]
-    fn tag(addr: u32) -> u32 {
-        addr >> 8
+    fn index(&self, addr: u32) -> usize {
+        ((addr >> 2) & self.index_mask) as usize
+    }
+
+    #[inline]
+    fn tag(&self, addr: u32) -> u32 {
+        addr >> self.tag_shift
     }
 
     /// Look up the aligned longword containing `addr`.
     #[inline]
     pub fn lookup(&self, addr: u32) -> Option<u32> {
-        let idx = Self::index(addr);
-        if self.valid[idx] && self.tags[idx] == Self::tag(addr) {
+        let idx = self.index(addr);
+        if self.valid[idx] && self.tags[idx] == self.tag(addr) {
             Some(self.data[idx])
         } else {
             None
@@ -69,8 +88,8 @@ impl LongwordCache {
     /// Fill the entry for the aligned longword containing `addr`.
     #[inline]
     pub fn fill(&mut self, addr: u32, longword: u32) {
-        let idx = Self::index(addr);
-        self.tags[idx] = Self::tag(addr);
+        let idx = self.index(addr);
+        self.tags[idx] = self.tag(addr);
         self.valid[idx] = true;
         self.data[idx] = longword;
     }
@@ -79,29 +98,46 @@ impl LongwordCache {
     /// data-cache write-through hits).
     #[inline]
     pub fn invalidate_entry(&mut self, addr: u32) {
-        let idx = Self::index(addr);
-        if self.tags[idx] == Self::tag(addr) {
+        let idx = self.index(addr);
+        if self.tags[idx] == self.tag(addr) {
             self.valid[idx] = false;
         }
     }
 
-    /// Invalidate everything (CACR clear-cache, reset).
+    /// Invalidate everything (CACR clear-cache, CINV/CPUSH, reset).
     pub fn invalidate_all(&mut self) {
-        self.valid = [false; LINES];
+        self.valid.fill(false);
     }
 }
 
 /// One cache (instruction or data) plus its CACR-controlled state.
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CpuCache {
     cache: LongwordCache,
-    /// CACR enable bit (EI/ED).
+    /// CACR enable bit (EI/ED on 020/030, IE/DE on 040).
     pub enabled: bool,
     /// CACR freeze bit (FI/FD): hits are served, misses do not allocate.
+    /// Always false on the 040, which has no freeze bit.
     pub frozen: bool,
 }
 
+impl Default for CpuCache {
+    fn default() -> Self {
+        Self::new(LINES_020)
+    }
+}
+
 impl CpuCache {
+    /// A disabled cache with `lines` longword entries (a power of two):
+    /// `LINES_020` for the 020/030, `LINES_040` for the 040.
+    pub fn new(lines: usize) -> Self {
+        Self {
+            cache: LongwordCache::new(lines),
+            enabled: false,
+            frozen: false,
+        }
+    }
+
     /// Serve a `size`-byte read at `addr` from the cache, if every
     /// longword it touches is resident. `size` must be 1, 2, or 4.
     pub fn read(&self, addr: u32, size: usize) -> Option<u32> {
@@ -167,9 +203,10 @@ impl CpuCache {
         }
     }
 
-    /// CACR clear-entry strobe: drop the line indexed by CAAR.
+    /// CACR clear-entry strobe: drop the line indexed by CAAR (020/030 only;
+    /// the 040 has no per-entry CACR strobe).
     pub fn clear_entry_by_index(&mut self, caar: u32) {
-        let idx = LongwordCache::index(caar);
+        let idx = self.cache.index(caar);
         self.cache.valid[idx] = false;
     }
 
@@ -239,6 +276,33 @@ mod tests {
         c.fill_after_miss(0x1100, 4, |_| 2);
         assert_eq!(c.read(0x1100, 4), Some(2));
         assert_eq!(c.read(0x1000, 4), None);
+    }
+
+    #[test]
+    fn larger_cache_avoids_a_conflict_the_small_one_evicts() {
+        // 0x1000 and 0x1100 land on the same line index in the 256-byte
+        // (64-line) 020/030 cache - bits [2..8) match - so the second fill
+        // evicts the first. In the 4 KB (1024-line) 040 cache the index spans
+        // bits [2..12), so they map to different lines and both stay resident.
+        // This is the capacity difference that keeps a >256-byte chip-RAM loop
+        // cached on a 040 where it would thrash a 020.
+        let mut small = CpuCache::new(LINES_020);
+        small.enabled = true;
+        small.fill_after_miss(0x1000, 4, |_| 1);
+        small.fill_after_miss(0x1100, 4, |_| 2);
+        assert_eq!(small.read(0x1100, 4), Some(2));
+        assert_eq!(
+            small.read(0x1000, 4),
+            None,
+            "small cache evicts on conflict"
+        );
+
+        let mut big = CpuCache::new(LINES_040);
+        big.enabled = true;
+        big.fill_after_miss(0x1000, 4, |_| 1);
+        big.fill_after_miss(0x1100, 4, |_| 2);
+        assert_eq!(big.read(0x1000, 4), Some(1), "large cache keeps both");
+        assert_eq!(big.read(0x1100, 4), Some(2));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -428,22 +428,22 @@ impl CpuModel {
     }
 
     /// Whether this model has the on-chip instruction cache Copperline models.
-    /// The 68020/68EC020/68030 all ship a 256-byte direct-mapped instruction
-    /// cache; AmigaOS enables it (CACR.EI) at boot. Real A1200/A4000 software
-    /// (demos especially) leans on it: code looping out of chip RAM otherwise
-    /// contends with bitplane DMA on every fetch and runs roughly half-speed.
-    /// The 68040 caches exist but are not modelled here, so it reports false.
+    /// The 68020/68EC020/68030 ship a 256-byte direct-mapped instruction cache
+    /// and the 68040 a 4 KB one; AmigaOS enables it (CACR) at boot. Real
+    /// A1200/A4000 software (demos especially) leans on it: code looping out of
+    /// chip RAM otherwise contends with bitplane DMA on every fetch and runs
+    /// roughly half-speed.
     pub fn has_instruction_cache(self) -> bool {
         matches!(
             self,
-            CpuModel::M68EC020 | CpuModel::M68020 | CpuModel::M68030
+            CpuModel::M68EC020 | CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040
         )
     }
 
-    /// Whether this model has the on-chip data cache Copperline models. Only
-    /// the 68030 has one (the 020 has none; the 040's is not modelled).
+    /// Whether this model has the on-chip data cache Copperline models. The
+    /// 68030 (256 bytes) and 68040 (4 KB) have one; the 020 has none.
     pub fn has_data_cache(self) -> bool {
-        self == CpuModel::M68030
+        matches!(self, CpuModel::M68030 | CpuModel::M68040)
     }
 }
 
@@ -1362,19 +1362,17 @@ impl TryFrom<RawConfig> for Config {
             .icache
             .unwrap_or_else(|| cpu.has_instruction_cache());
         let cpu_dcache = raw.cpu.dcache.unwrap_or_else(|| cpu.has_data_cache());
-        if cpu_icache
-            && !matches!(
-                cpu,
-                CpuModel::M68EC020 | CpuModel::M68020 | CpuModel::M68030
-            )
-        {
+        if cpu_icache && !cpu.has_instruction_cache() {
             bail!(
-                "[cpu] icache = true needs a 68020/68EC020/68030 (the 68000 has \
-                 no cache; the 68040 cache is not modelled)"
+                "[cpu] icache = true needs a 68020/68EC020/68030/68040 \
+                 (the 68000 has no instruction cache)"
             );
         }
-        if cpu_dcache && cpu != CpuModel::M68030 {
-            bail!("[cpu] dcache = true needs a 68030 (the 68020 has no data cache)");
+        if cpu_dcache && !cpu.has_data_cache() {
+            bail!(
+                "[cpu] dcache = true needs a 68030 or 68040 \
+                 (the 68000/68020 have no data cache)"
+            );
         }
         if let Some(speed) = raw.emulation.speed.as_deref() {
             log::warn!(
@@ -2880,6 +2878,9 @@ mod tests {
         let cfg = parse_config("[cpu]\nmodel = \"68020\"")?;
         assert!(cfg.cpu_icache && !cfg.cpu_dcache);
         let cfg = parse_config("[cpu]\nmodel = \"68030\"")?;
+        assert!(cfg.cpu_icache && cfg.cpu_dcache);
+        // A 68040 gets both its (4 KB) caches by default.
+        let cfg = parse_config("[cpu]\nmodel = \"68040\"")?;
         assert!(cfg.cpu_icache && cfg.cpu_dcache);
 
         // A plain 68000 has neither.

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1360,14 +1360,16 @@ impl M68kMachine {
         cck
     }
 
-    /// Install the 68020/030 cache models. These default on for CPUs that have
-    /// them (see `CpuModel::has_instruction_cache`/`has_data_cache`), matching
-    /// real silicon where AmigaOS enables the cache via CACR; `[cpu] icache =
-    /// false`/`dcache = false` opt out. With both false, CACR writes are
-    /// tracked but have no effect.
+    /// Install the 68020/030/040 cache models. These default on for CPUs that
+    /// have them (see `CpuModel::has_instruction_cache`/`has_data_cache`),
+    /// matching real silicon where AmigaOS enables the cache via CACR; `[cpu]
+    /// icache = false`/`dcache = false` opt out. With both false, CACR writes
+    /// are tracked but have no effect. The cache is sized for the CPU: 256
+    /// bytes (64 longwords) on the 020/030, 4 KB (1024) on the 040.
     pub fn set_cache_emulation(&mut self, icache: bool, dcache: bool) {
-        self.bus.icache = icache.then(Box::default);
-        self.bus.dcache = dcache.then(Box::default);
+        let lines = cache_lines_for_cpu_type(self.cpu.cpu_type);
+        self.bus.icache = icache.then(|| Box::new(crate::cache::CpuCache::new(lines)));
+        self.bus.dcache = dcache.then(|| Box::new(crate::cache::CpuCache::new(lines)));
         self.last_cacr = 0;
         self.apply_cacr_updates();
         if icache || dcache {
@@ -1383,7 +1385,10 @@ impl M68kMachine {
     /// strobes. Called after every instruction; a single compare when
     /// nothing changed.
     fn apply_cacr_updates(&mut self) {
-        use m68k::{CACR_CD, CACR_CED, CACR_CEI, CACR_CI, CACR_ED, CACR_EI, CACR_FD, CACR_FI};
+        use m68k::{
+            CACR_040_DE, CACR_040_IE, CACR_CD, CACR_CED, CACR_CEI, CACR_CI, CACR_ED, CACR_EI,
+            CACR_FD, CACR_FI,
+        };
         let ops = std::mem::take(&mut self.cpu.cacr_pending_ops);
         let cacr = self.cpu.cacr;
         if ops == 0 && cacr == self.last_cacr {
@@ -1391,6 +1396,29 @@ impl M68kMachine {
         }
         self.last_cacr = cacr;
         let caar = self.cpu.caar;
+        // The 68040 CACR uses different enable bits (IE/DE) and has no freeze
+        // or CACR clear strobes - invalidation arrives through CINV/CPUSH,
+        // which decode.rs surfaces as the CACR_CI/CACR_CD pending ops below.
+        if matches!(
+            self.cpu.cpu_type,
+            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040
+        ) {
+            if let Some(icache) = self.bus.icache.as_deref_mut() {
+                icache.enabled = cacr & CACR_040_IE != 0;
+                icache.frozen = false;
+                if ops & CACR_CI != 0 {
+                    icache.clear_all();
+                }
+            }
+            if let Some(dcache) = self.bus.dcache.as_deref_mut() {
+                dcache.enabled = cacr & CACR_040_DE != 0;
+                dcache.frozen = false;
+                if ops & CACR_CD != 0 {
+                    dcache.clear_all();
+                }
+            }
+            return;
+        }
         if let Some(icache) = self.bus.icache.as_deref_mut() {
             icache.enabled = cacr & CACR_EI != 0;
             icache.frozen = cacr & CACR_FI != 0;
@@ -2164,6 +2192,15 @@ fn cpu_type_for_model(model: CpuModel) -> CpuType {
     }
 }
 
+/// Longword entries in each on-chip cache for this CPU: the 040's caches are
+/// 4 KB (1024 longwords), the 020/030's 256 bytes (64). See `crate::cache`.
+fn cache_lines_for_cpu_type(cpu_type: CpuType) -> usize {
+    match cpu_type {
+        CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040 => crate::cache::LINES_040,
+        _ => crate::cache::LINES_020,
+    }
+}
+
 fn address_mask_for_model(model: CpuModel) -> u32 {
     match model {
         CpuModel::M68000 | CpuModel::M68EC020 => ADDRESS_MASK_24BIT,
@@ -2676,6 +2713,68 @@ mod tests {
         assert_eq!(slice.instructions, 8);
         assert_eq!(machine.d(2), 1, "CACR CI must flush the stale entry");
         Ok(())
+    }
+
+    #[test]
+    fn icache_68040_enabled_by_ie_and_flushed_by_cinv() -> Result<()> {
+        // The 68040 CACR enables the instruction cache through IE (bit 15),
+        // and CINV/CPUSH - not a CACR strobe - invalidates it. Self-modifying
+        // code therefore runs the stale cached opcode until a CINV.
+        //
+        //   $100: 203C 0000 8000  move.l #$8000,d0        (CACR.IE)
+        //   $106: 4E7B 0002        movec d0,cacr           (icache on)
+        //   $10A: 4E71             nop                     (cached on first run)
+        //   $10C: 31FC 5282 010A   move.w #$5282,($10A).w  (patch -> addq.l #1,d2)
+        //   $112: F498             cinva (instruction)     (clear icache)  [B only]
+        //   ...:  4EF8 010A        jmp ($10A).w
+        let prologue: [u16; 9] = [
+            0x203C, 0x0000, 0x8000, 0x4E7B, 0x0002, 0x4E71, 0x31FC, 0x5282, 0x010A,
+        ];
+
+        // A: no CINV. The patched write does not snoop the icache, so the
+        // revisit hits the stale NOP and d2 stays 0.
+        let mut program_a = prologue.to_vec();
+        program_a.extend_from_slice(&[0x4EF8, 0x010A]); // jmp ($10A).w
+        let mut machine = M68kMachine::new(
+            test_bus(reset_rom(0x0007_FFFE, 0x0000_0100)),
+            CpuModel::M68040,
+            false,
+        )?;
+        machine.set_cache_emulation(true, false);
+        write_program(machine.bus_mut(), 0x100, &program_a);
+        let slice = machine.step_slice(6)?;
+        assert_eq!(slice.instructions, 6);
+        assert_eq!(machine.d(2), 0, "stale cached NOP must run without a CINV");
+
+        // B: CINVA before the jump flushes the icache, so the revisit misses
+        // and refetches the patched ADDQ.
+        let mut program_b = prologue.to_vec();
+        program_b.extend_from_slice(&[0xF498, 0x4EF8, 0x010A]); // cinva (instr); jmp
+        let mut machine = M68kMachine::new(
+            test_bus(reset_rom(0x0007_FFFE, 0x0000_0100)),
+            CpuModel::M68040,
+            false,
+        )?;
+        machine.set_cache_emulation(true, false);
+        write_program(machine.bus_mut(), 0x100, &program_b);
+        let slice = machine.step_slice(7)?;
+        assert_eq!(slice.instructions, 7);
+        assert_eq!(machine.d(2), 1, "CINVA must flush the stale icache entry");
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_040_caches_are_4kb() {
+        // The 040 installs the larger 4 KB (1024-longword) caches; the 020/030
+        // get the 256-byte (64) ones.
+        assert_eq!(
+            cache_lines_for_cpu_type(CpuType::M68LC040),
+            crate::cache::LINES_040
+        );
+        assert_eq!(
+            cache_lines_for_cpu_type(CpuType::M68020),
+            crate::cache::LINES_020
+        );
     }
 
     #[test]

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -56,7 +56,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      BoardBacking::A2091 variant became BoardBacking::Device(slot)
 //   8: BoardDevice gained Wasm and A2065 variants (enum layout change)
 //   9: CpuCore.fpr retyped f64 -> FloatX80 (80-bit extended FPU registers)
-pub const STATE_VERSION: u32 = 9;
+//  10: CpuCache backing arrays became Vec (variable line count for the
+//      68040's 4 KB caches vs the 020/030's 256 bytes)
+pub const STATE_VERSION: u32 = 10;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -891,14 +891,11 @@ impl MachineSetup {
         let reason = |applicable: bool, why: &'static str| (!applicable).then_some(why);
         match field {
             F::Fpu => reason(self.cpu != CpuModel::M68000, "needs 68020+"),
-            F::Icache => reason(
-                matches!(
-                    self.cpu,
-                    CpuModel::M68EC020 | CpuModel::M68020 | CpuModel::M68030
-                ),
-                "needs 68020/030",
-            ),
-            F::Dcache => reason(self.cpu == CpuModel::M68030, "needs 68030"),
+            // Gate on the model's actual cache capability so the launcher tracks
+            // CpuModel rather than a second hand-maintained list (the 040 has
+            // both caches; only the 68000 has neither).
+            F::Icache => reason(self.cpu.has_instruction_cache(), "needs 68020+"),
+            F::Dcache => reason(self.cpu.has_data_cache(), "needs 68030/040"),
             F::Z3Ram => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
             F::IdeMaster | F::IdeSlave => reason(self.has_gayle(), "needs A600/A1200"),
             F::CdImage | F::CdInsertDelay => reason(self.has_cd(), "needs CDTV/CD32"),
@@ -1699,6 +1696,33 @@ mod tests {
         let toml = s.to_toml().unwrap();
         assert!(toml.trim().is_empty(), "expected empty TOML, got:\n{toml}");
         assert!(s.build_config().is_ok());
+    }
+
+    #[test]
+    fn launcher_exposes_both_cache_toggles_for_the_68040() {
+        let mut s = MachineSetup::default();
+        // Step the CPU selector along to the 68040.
+        for _ in 0..CPUS.len() {
+            if s.cpu == CpuModel::M68040 {
+                break;
+            }
+            s.cycle(LauncherField::Cpu, true);
+        }
+        assert_eq!(s.cpu, CpuModel::M68040, "cycled to the 68040");
+        // The 040 has both caches, so neither toggle is greyed and both default
+        // on (like the 030) when the part is selected.
+        assert_eq!(s.disabled_reason(LauncherField::Icache), None);
+        assert_eq!(s.disabled_reason(LauncherField::Dcache), None);
+        assert!(s.toggle_value(LauncherField::Icache));
+        assert!(s.toggle_value(LauncherField::Dcache));
+
+        // The 68000 has neither; the 68EC020 has only the instruction cache.
+        s.cpu = CpuModel::M68000;
+        assert!(s.disabled_reason(LauncherField::Icache).is_some());
+        assert!(s.disabled_reason(LauncherField::Dcache).is_some());
+        s.cpu = CpuModel::M68EC020;
+        assert_eq!(s.disabled_reason(LauncherField::Icache), None);
+        assert!(s.disabled_reason(LauncherField::Dcache).is_some());
     }
 
     #[test]


### PR DESCRIPTION
The 68040 reported no caches, so AGA code looping out of chip RAM contended with bitplane DMA on every fetch (the half-speed problem the 020/030 cache model already solves). This extends that model to the 040.

## Changes
- `CpuModel::has_instruction_cache`/`has_data_cache` include the 68040; config no longer rejects `[cpu] icache/dcache` on it; both default on like the 020/030.
- The cache is sized to the CPU: `src/cache.rs` is now `Vec`-backed with a runtime power-of-two line count -- 64 longwords (256 bytes) on the 020/030, 1024 (4 KB) on the 040. The larger 040 capacity is the fidelity that matters (a chip-RAM loop bigger than 256 bytes stays resident on a 040). Copyback / 4-way / 16-byte lines are not modelled and need not be -- copyback is unobservable because the data cache only covers expansion RAM, which is not DMA-visible.
- The 040 CACR (IE bit 15 / DE bit 31, no freeze, no clear strobes) is handled via `CACR_040_IE`/`CACR_040_DE`, an `apply_cacr_updates` 040 branch, and `CINV`/`CPUSH` (decode.rs) clearing the whole indicated cache(s). The 68030 keeps `CINV`/`CPUSH` as NOPs.
- The launcher exposes both cache toggles for the 040 (gated on `has_*_cache` rather than a hand-maintained model list).

`STATE_VERSION` bumped to 10 for the cache struct shape change. New tests cover the larger-cache capacity win, an end-to-end 040 `CACR.IE` enable + `CINVA` flush, and the launcher gating. Full suite green; clippy + fmt clean.