### PR TITLE
68030/68040 MMU: address translation, ATC, and access faults

### DIFF
--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -190,20 +190,23 @@ pub struct CpuCore {
     pub nmi_pending: u32,
 
     // ========== MMU Registers ==========
-    pub mmu_crp_aptr: u32,
-    pub mmu_crp_limit: u32,
-    pub mmu_srp_aptr: u32,
-    pub mmu_srp_limit: u32,
-    pub mmu_tc: u32,
-    pub mmu_sr: u16,
+    // One canonical register set is shared by the 68030 and 68040 paths so the
+    // page-table walker and the register writes can never desync. The 68040
+    // root pointers (URP/SRP) overload the CRP/SRP address slots: `mmu_crp_aptr`
+    // is the CRP on the 030 and the URP on the 040, `mmu_srp_aptr` is the SRP on
+    // both. The two formats never coexist (the walker dispatches on `cpu_type`),
+    // and the 040 root pointers carry no limit longword, so the 040 ignores the
+    // `*_limit` fields.
+    pub mmu_crp_aptr: u32, // CRP (030) / URP (040) address pointer
+    pub mmu_crp_limit: u32, // CRP limit/mode (030 only)
+    pub mmu_srp_aptr: u32, // SRP address pointer (030 + 040)
+    pub mmu_srp_limit: u32, // SRP limit/mode (030 only)
+    pub mmu_tc: u32,       // Translation Control (030 PMOVE / 040 MOVEC 0x003)
+    pub mmu_sr: u32,       // MMU Status Register (030 + 040; layout per cpu_type)
     // 68030 Transparent Translation Registers
     pub mmu_tt0: u32,
     pub mmu_tt1: u32,
     // 68040-specific MMU registers
-    pub urp: u32,   // User Root Pointer (0x806)
-    pub srp: u32,   // Supervisor Root Pointer (0x807)
-    pub tc: u32,    // Translation Control (0x003)
-    pub mmusr: u32, // MMU Status Register (0x805)
     pub dacr0: u32, // Data Access Control 0 (0x008)
     pub dacr1: u32, // Data Access Control 1 (0x009)
     pub iacr0: u32, // Instruction Access Control 0 (0x00A)
@@ -356,10 +359,6 @@ impl CpuCore {
             mmu_sr: 0,
             mmu_tt0: 0,
             mmu_tt1: 0,
-            urp: 0,
-            srp: 0,
-            tc: 0,
-            mmusr: 0,
             dacr0: 0,
             dacr1: 0,
             iacr0: 0,
@@ -806,7 +805,7 @@ impl CpuCore {
             0x000 => self.sfc,   // Source Function Code
             0x001 => self.dfc,   // Destination Function Code
             0x002 => self.cacr,  // Cache Control Register
-            0x003 => self.tc,    // Translation Control (68040)
+            0x003 => self.mmu_tc, // Translation Control (68040)
             0x004 => self.itt0,  // Instruction TTR 0 (68040)
             0x005 => self.itt1,  // Instruction TTR 1 (68040)
             0x006 => self.dtt0,  // Data TTR 0 (68040)
@@ -841,10 +840,10 @@ impl CpuCore {
                     self.sp[4]
                 }
             }
-            0x805 => self.mmusr, // MMU Status Register (68040)
-            0x806 => self.urp,   // User Root Pointer (68040)
-            0x807 => self.srp,   // Supervisor Root Pointer (68040)
-            _ => 0,              // Unknown register
+            0x805 => self.mmu_sr,        // MMU Status Register (68040)
+            0x806 => self.mmu_crp_aptr,  // User Root Pointer (68040; URP)
+            0x807 => self.mmu_srp_aptr,  // Supervisor Root Pointer (68040)
+            _ => 0,                      // Unknown register
         }
     }
 
@@ -874,7 +873,12 @@ impl CpuCore {
                 self.cacr = value & persist;
                 self.cacr_pending_ops |= value & strobes;
             }
-            0x003 => self.tc = value,      // Translation Control (68040)
+            0x003 => {
+                // Translation Control (68040). MOVEC must update pmmu_enabled
+                // (the 040 enable bit is TC[15], unlike the 030's TC[31]).
+                self.mmu_tc = value;
+                self.pmmu_enabled = self.tc_enable();
+            }
             0x004 => self.itt0 = value,    // Instruction TTR 0 (68040)
             0x005 => self.itt1 = value,    // Instruction TTR 1 (68040)
             0x006 => self.dtt0 = value,    // Data TTR 0 (68040)
@@ -909,10 +913,31 @@ impl CpuCore {
                     self.sp[4] = value;
                 }
             }
-            0x805 => self.mmusr = value, // MMU Status Register (68040)
-            0x806 => self.urp = value,   // User Root Pointer (68040)
-            0x807 => self.srp = value,   // Supervisor Root Pointer (68040)
-            _ => {}                      // Unknown register - ignore
+            0x805 => self.mmu_sr = value,        // MMU Status Register (68040)
+            0x806 => self.mmu_crp_aptr = value,  // User Root Pointer (68040; URP)
+            0x807 => self.mmu_srp_aptr = value,  // Supervisor Root Pointer (68040)
+            _ => {}                              // Unknown register - ignore
+        }
+    }
+
+    /// True for any 68040-family part (full / LC / EC). The 040 MMU differs
+    /// from the 030 in register layout, TC enable bit, and table format.
+    #[inline]
+    pub fn is_040(&self) -> bool {
+        matches!(
+            self.cpu_type,
+            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040
+        )
+    }
+
+    /// Whether TC's translation-enable bit is set. The bit position differs by
+    /// part: the 68040 uses TC[15], the 68030 uses TC[31].
+    #[inline]
+    pub fn tc_enable(&self) -> bool {
+        if self.is_040() {
+            self.mmu_tc & 0x0000_8000 != 0
+        } else {
+            self.mmu_tc & 0x8000_0000 != 0
         }
     }
 
@@ -1327,14 +1352,23 @@ impl CpuCore {
             // PTEST on 68040 - treat as NOP
             return 4;
         }
-        if (modes & 0xFDE0) == 0x2000
+        // PLOAD / PFLUSH / PFLUSHA / PTEST (68030 forms): recognized but not yet
+        // fully modelled. Treat them as NOPs rather than returning 0, which the
+        // decoder would turn into a LINE-1111 trap -- AROS and the 68040.library
+        // issue these during MMU setup, so trapping crashes the boot. PTEST
+        // reports "no fault" via a benign MMUSR; an ATC to flush (PFLUSH/PLOAD)
+        // and precise MMUSR bits (PTEST) come with later phases.
+        if (modes & 0xFDE0) == 0x2000   // PLOAD
             || (modes & 0xE200) == 0x2000
-            || modes == 0xA000
+            || modes == 0xA000          // PFLUSHA
             || modes == 0x2800
-            || (modes & 0xFFF8) == 0x2C00
+            || (modes & 0xFFF8) == 0x2C00 // PFLUSH
             || is_ptest
         {
-            return 0;
+            if is_ptest {
+                self.mmu_sr = 0;
+            }
+            return 8;
         }
 
         // Decode effective address from opcode.
@@ -1404,8 +1438,8 @@ impl CpuCore {
                     // TC (32)
                     let v = self.read_resolved_ea(bus, ea, Size::Long);
                     self.mmu_tc = v;
-                    // Enable PMMU based on TC high bit (common convention).
-                    self.pmmu_enabled = (self.mmu_tc & 0x8000_0000) != 0;
+                    // PMOVE is 68030-only, so tc_enable() reads TC[31] here.
+                    self.pmmu_enabled = self.tc_enable();
                     4
                 }
                 0x12 => {

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -211,6 +211,10 @@ pub struct CpuCore {
     pub dacr1: u32, // Data Access Control 1 (0x009)
     pub iacr0: u32, // Instruction Access Control 0 (0x00A)
     pub iacr1: u32, // Instruction Access Control 1 (0x00B)
+    /// Address Translation Cache: a pure cache of recent page-table walks, so it
+    /// is not serialized (restored empty) and is flushed on any mapping change.
+    #[serde(skip)]
+    pub atc: crate::mmu::Atc,
 
     // ========== Execution State ==========
     /// Remaining cycles in current timeslice
@@ -363,6 +367,7 @@ impl CpuCore {
             dacr1: 0,
             iacr0: 0,
             iacr1: 0,
+            atc: crate::mmu::Atc::default(),
             cycles_remaining: 0,
             initial_cycles: 0,
             sst_m68000_compat: false,
@@ -917,6 +922,11 @@ impl CpuCore {
             0x806 => self.mmu_crp_aptr = value,  // User Root Pointer (68040; URP)
             0x807 => self.mmu_srp_aptr = value,  // Supervisor Root Pointer (68040)
             _ => {}                              // Unknown register - ignore
+        }
+        // A write to TC, a root pointer, or a TTR can change every translation,
+        // so drop the cached ones (the 040 walker consults the ATC).
+        if matches!(reg, 0x003 | 0x004 | 0x005 | 0x006 | 0x007 | 0x806 | 0x807) {
+            self.atc.flush_all();
         }
     }
 

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -1024,11 +1024,21 @@ impl CpuCore {
         if self.faulted() {
             return;
         }
+        // A fault while already delivering a fault is a double fault: halt
+        // rather than recurse. (translate() also bypasses while this flag is
+        // set, so the frame writes and vector fetch below do not re-translate.)
+        if self.exception_processing {
+            self.stopped = 1;
+            self.run_mode = RUN_MODE_BERR_AERR_RESET;
+            return;
+        }
 
         // Roll back any partially-applied register side effects from the faulting instruction.
         self.set_sr_noint_nosp(self.sr_save);
         self.dar = self.dar_save;
+        self.exception_processing = true;
         let _ = self.exception_bus_error(bus, address, write, instruction);
+        self.exception_processing = false;
         self.run_mode = RUN_MODE_BERR_AERR_RESET;
     }
 
@@ -1319,16 +1329,13 @@ impl CpuCore {
                 self.run_mode = RUN_MODE_BERR_AERR_RESET;
             }
             MmuFaultKind::AccessLevelViolation => {
-                if self.is_040() {
-                    // On the 68040 an MMU access fault vectors to BUS_ERROR
-                    // (vector 2) with a format-7 frame. Route through
-                    // trigger_bus_error so the instruction is rolled back and
-                    // RTE restarts it once the handler fixes the mapping.
-                    self.trigger_bus_error(bus, fault.address, write, instruction);
-                } else {
-                    let _ = self.take_exception(bus, vector::MMU_ACCESS_LEVEL_VIOLATION_ERROR);
-                    self.run_mode = RUN_MODE_BERR_AERR_RESET;
-                }
+                // Integrated 68030/68040 MMU faults vector to BUS_ERROR
+                // (vector 2), not the 68851 access-level vector. Route through
+                // trigger_bus_error so the instruction is rolled back and RTE
+                // can restart it once the handler fixes the mapping (the 040
+                // gets a resumable format-7 frame; the 030 long bus-fault
+                // format-A/B frame is still the minimal fallback).
+                self.trigger_bus_error(bus, fault.address, write, instruction);
             }
         }
     }

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -1319,8 +1319,16 @@ impl CpuCore {
                 self.run_mode = RUN_MODE_BERR_AERR_RESET;
             }
             MmuFaultKind::AccessLevelViolation => {
-                let _ = self.take_exception(bus, vector::MMU_ACCESS_LEVEL_VIOLATION_ERROR);
-                self.run_mode = RUN_MODE_BERR_AERR_RESET;
+                if self.is_040() {
+                    // On the 68040 an MMU access fault vectors to BUS_ERROR
+                    // (vector 2) with a format-7 frame. Route through
+                    // trigger_bus_error so the instruction is rolled back and
+                    // RTE restarts it once the handler fixes the mapping.
+                    self.trigger_bus_error(bus, fault.address, write, instruction);
+                } else {
+                    let _ = self.take_exception(bus, vector::MMU_ACCESS_LEVEL_VIOLATION_ERROR);
+                    self.run_mode = RUN_MODE_BERR_AERR_RESET;
+                }
             }
         }
     }

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -188,16 +188,20 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         return 4;
     }
 
-    // 68030/68040 PFLUSH instructions (F-line, privileged): 0xF5xx
+    // 68040 PFLUSH instructions (F-line, privileged): 0xF5xx
     // PFLUSHA: 1111 0101 0001 1000 (0xF518)
     // PFLUSHN: 1111 0101 0000 0xxx (0xF500-0xF507)
     // PFLUSH: 1111 0101 0010 0xxx (0xF520-0xF527)
-    // We treat these as NOPs since there's no TLB to flush.
     if is_cache_cpu && (opcode >> 8) & 0xF == 5 {
         if !cpu.is_supervisor() {
             return cpu.take_exception(bus, 8); // Privilege violation
         }
-        // All PFLUSH variants are NOPs for us
+        // Flush the ATC. We do not track entries finely enough to honour the
+        // per-page / opcode (An) scope, so every variant flushes all; this is
+        // always coherent (over-flushing only costs re-walks). The 68030 PFLUSH
+        // forms come through exec_mmu_op0 (0xF0xx) and the 030 walker does not
+        // consult the ATC, so nothing to flush there.
+        cpu.atc.flush_all();
         return 4;
     }
 

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -188,19 +188,34 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         return 4;
     }
 
-    // 68040 PFLUSH instructions (F-line, privileged): 0xF5xx
-    // PFLUSHA: 1111 0101 0001 1000 (0xF518)
-    // PFLUSHN: 1111 0101 0000 0xxx (0xF500-0xF507)
-    // PFLUSH: 1111 0101 0010 0xxx (0xF520-0xF527)
+    // 68040 PFLUSH/PTEST instructions (F-line, privileged): 0xF5xx.
+    //   PFLUSH/PFLUSHA/PFLUSHN: bit 6 clear.
+    //   PTESTR (An): 1111 0101 0110 1rrr; PTESTW (An): 1111 0101 0100 1rrr
+    //   (bit 6 set; bit 5 = read).
     if is_cache_cpu && (opcode >> 8) & 0xF == 5 {
         if !cpu.is_supervisor() {
             return cpu.take_exception(bus, 8); // Privilege violation
         }
-        // Flush the ATC. We do not track entries finely enough to honour the
-        // per-page / opcode (An) scope, so every variant flushes all; this is
-        // always coherent (over-flushing only costs re-walks). The 68030 PFLUSH
-        // forms come through exec_mmu_op0 (0xF0xx) and the 030 walker does not
-        // consult the ATC, so nothing to flush there.
+        if cpu.is_040() && (opcode & 0x0040) != 0 {
+            // PTEST: walk the page for An and report it in MMUSR. We model the
+            // physical-address and resident (R) bits, enough for an OS to tell a
+            // mapped page from an invalid one; the cache-mode / used / modified
+            // attribute bits are not yet filled in.
+            let read = (opcode & 0x0020) != 0;
+            let addr = cpu.dar[8 + (opcode & 7) as usize];
+            let supervisor = cpu.is_supervisor();
+            cpu.mmu_sr =
+                match crate::mmu::translate_address(cpu, bus, addr, !read, supervisor, false) {
+                    Ok(phys) => (phys & 0xFFFF_F000) | 0x0000_0001, // R = resident
+                    Err(_) => 0,                                    // not resident
+                };
+            return 4;
+        }
+        // PFLUSH variants flush the ATC. We do not track entries finely enough
+        // to honour the per-page / (An) scope, so every variant flushes all;
+        // this is always coherent (over-flushing only costs re-walks). The
+        // 68030 PFLUSH forms come through exec_mmu_op0 (0xF0xx) and the 030
+        // walker does not consult the ATC, so nothing to flush there.
         cpu.atc.flush_all();
         return 4;
     }

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -321,9 +321,41 @@ impl CpuCore {
                 self.push_16_raw(bus, old_sr);
                 let _ = (status_word, address); // currently unused in this placeholder
             }
+            _ if self.is_040() => {
+                // 68040 access-error stack frame (format 7, 30 words). The
+                // caller (trigger_bus_error) has already rolled the instruction
+                // back, so we stack PPC and leave the writeback/continuation
+                // fields clear: RTE then restarts the faulting instruction
+                // (demand-paging / Enforcer fix-and-retry model). The SSW
+                // reports R/W and the function code; the size field is left at
+                // its long default since the restart re-runs the real access.
+                // Layout (Musashi m68ki_stack_frame_0111), pushed high->low.
+                let rw = if write { 0 } else { 0x0100 }; // SSW bit 8: 1 = read
+                let ssw = rw | (fc as u16 & 0x7); // TM = function code
+                let fmt_vec = 0x7000 | ((vector::BUS_ERROR as u16) << 2);
+                // PD2/PD1/PD0 and the three writeback entries are all unused.
+                for _ in 0..3 {
+                    self.push_32_raw(bus, 0); // PD2, PD1, PD0
+                }
+                self.push_32_raw(bus, 0); // WB1D
+                self.push_32_raw(bus, 0); // WB1A
+                self.push_32_raw(bus, 0); // WB2D
+                self.push_32_raw(bus, 0); // WB2A
+                self.push_32_raw(bus, 0); // WB3D
+                self.push_32_raw(bus, 0); // WB3A
+                self.push_32_raw(bus, address); // fault address
+                self.push_16_raw(bus, 0); // WB1S (status: invalid -> no writeback)
+                self.push_16_raw(bus, 0); // WB2S
+                self.push_16_raw(bus, 0); // WB3S
+                self.push_16_raw(bus, ssw); // special status word
+                self.push_32_raw(bus, address); // effective address
+                self.push_16_raw(bus, fmt_vec); // format 7 / vector offset
+                self.push_32_raw(bus, self.ppc); // restart PC
+                self.push_16_raw(bus, old_sr);
+            }
             _ => {
-                // TODO: 68020+ bus error stack frames (format A/B/7 variants) are not yet
-                // implemented. Minimal fallback.
+                // TODO: 68020/68030 bus-error stack frames (format A / long
+                // format B) are not yet implemented. Minimal fallback.
                 self.push_16_raw(bus, (vector::BUS_ERROR as u16) << 2);
                 self.push_32_raw(bus, self.ppc);
                 self.push_16_raw(bus, old_sr);

--- a/crates/m68k/src/mmu/atc.rs
+++ b/crates/m68k/src/mmu/atc.rs
@@ -1,0 +1,126 @@
+//! Address Translation Cache (ATC).
+//!
+//! The page-table walk costs several descriptor fetches per access, which is far
+//! too expensive to pay on every cycle-stepped memory reference. Real 68030/68040
+//! parts cache recent translations in an ATC; we model the same: a small
+//! direct-mapped cache of (logical page -> physical page) keyed by the logical
+//! page frame and the supervisor flag (user and supervisor can map a page
+//! differently via separate root pointers).
+//!
+//! The ATC is a pure cache: it holds nothing that backing memory does not, so it
+//! is never serialized (a save state restores it empty) and is flushed whenever
+//! the mapping could change -- a write to TC / a root pointer / a TTR, or a
+//! PFLUSH/PFLUSHA. Like real hardware, a plain CPU write to a page-table entry
+//! does NOT auto-flush; software must PFLUSH, which is where we flush.
+
+const ATC_ENTRIES: usize = 64;
+
+#[derive(Debug, Clone, Copy)]
+struct AtcEntry {
+    valid: bool,
+    /// `(page_frame << 1) | supervisor`, disambiguating user vs supervisor maps.
+    tag: u32,
+    /// Physical page base (aligned to the page size in force at fill time).
+    phys_page: u32,
+}
+
+impl Default for AtcEntry {
+    fn default() -> Self {
+        Self {
+            valid: false,
+            tag: 0,
+            phys_page: 0,
+        }
+    }
+}
+
+/// A direct-mapped address translation cache.
+#[derive(Debug, Clone)]
+pub struct Atc {
+    entries: [AtcEntry; ATC_ENTRIES],
+}
+
+impl Default for Atc {
+    fn default() -> Self {
+        Self {
+            entries: [AtcEntry::default(); ATC_ENTRIES],
+        }
+    }
+}
+
+impl Atc {
+    #[inline]
+    fn tag(page_frame: u32, supervisor: bool) -> u32 {
+        (page_frame << 1) | supervisor as u32
+    }
+
+    #[inline]
+    fn index(page_frame: u32) -> usize {
+        (page_frame as usize) & (ATC_ENTRIES - 1)
+    }
+
+    /// Look up the physical page base for `page_frame` (logical address >> page
+    /// bits), or `None` on a miss.
+    #[inline]
+    pub fn lookup(&self, page_frame: u32, supervisor: bool) -> Option<u32> {
+        let e = &self.entries[Self::index(page_frame)];
+        if e.valid && e.tag == Self::tag(page_frame, supervisor) {
+            Some(e.phys_page)
+        } else {
+            None
+        }
+    }
+
+    /// Record a freshly-walked translation.
+    #[inline]
+    pub fn insert(&mut self, page_frame: u32, supervisor: bool, phys_page: u32) {
+        self.entries[Self::index(page_frame)] = AtcEntry {
+            valid: true,
+            tag: Self::tag(page_frame, supervisor),
+            phys_page,
+        };
+    }
+
+    /// Invalidate everything (PFLUSHA, TC/root-pointer/TTR write, reset).
+    pub fn flush_all(&mut self) {
+        for e in &mut self.entries {
+            e.valid = false;
+        }
+    }
+
+    /// Invalidate the entry for one logical page frame (PFLUSH `(An)`), both the
+    /// user and supervisor variant since the same slot holds either.
+    pub fn flush_page(&mut self, page_frame: u32) {
+        let e = &mut self.entries[Self::index(page_frame)];
+        if e.tag >> 1 == page_frame {
+            e.valid = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hit_after_insert_miss_after_flush() {
+        let mut atc = Atc::default();
+        assert_eq!(atc.lookup(0x10, false), None);
+        atc.insert(0x10, false, 0x8000);
+        assert_eq!(atc.lookup(0x10, false), Some(0x8000));
+        // Supervisor map of the same page frame is a distinct entry.
+        assert_eq!(atc.lookup(0x10, true), None);
+        atc.flush_all();
+        assert_eq!(atc.lookup(0x10, false), None);
+    }
+
+    #[test]
+    fn flush_page_drops_only_that_frame() {
+        let mut atc = Atc::default();
+        atc.insert(0x10, false, 0x1000);
+        atc.flush_page(0x11); // different frame, same is unlikely-index: no-op for 0x10
+        assert_eq!(atc.lookup(0x10, false), Some(0x1000));
+        atc.flush_page(0x10);
+        assert_eq!(atc.lookup(0x10, false), None);
+    }
+}

--- a/crates/m68k/src/mmu/atc.rs
+++ b/crates/m68k/src/mmu/atc.rs
@@ -15,23 +15,17 @@
 
 const ATC_ENTRIES: usize = 64;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 struct AtcEntry {
     valid: bool,
     /// `(page_frame << 1) | supervisor`, disambiguating user vs supervisor maps.
     tag: u32,
     /// Physical page base (aligned to the page size in force at fill time).
     phys_page: u32,
-}
-
-impl Default for AtcEntry {
-    fn default() -> Self {
-        Self {
-            valid: false,
-            tag: 0,
-            phys_page: 0,
-        }
-    }
+    /// Write-protected page (W): a write must fault, not hit.
+    write_protected: bool,
+    /// Supervisor-only page (S): a user access must fault, not hit.
+    supervisor_only: bool,
 }
 
 /// A direct-mapped address translation cache.
@@ -60,24 +54,38 @@ impl Atc {
     }
 
     /// Look up the physical page base for `page_frame` (logical address >> page
-    /// bits), or `None` on a miss.
+    /// bits) for this access, or `None` on a miss. A cached entry whose
+    /// permissions the access would violate (a write to a write-protected page,
+    /// or a user access to a supervisor page) returns `None` so the caller
+    /// re-walks and raises the fault -- the permission check is never bypassed.
     #[inline]
-    pub fn lookup(&self, page_frame: u32, supervisor: bool) -> Option<u32> {
+    pub fn lookup(&self, page_frame: u32, supervisor: bool, write: bool) -> Option<u32> {
         let e = &self.entries[Self::index(page_frame)];
-        if e.valid && e.tag == Self::tag(page_frame, supervisor) {
-            Some(e.phys_page)
-        } else {
-            None
+        if !e.valid || e.tag != Self::tag(page_frame, supervisor) {
+            return None;
         }
+        if (write && e.write_protected) || (!supervisor && e.supervisor_only) {
+            return None;
+        }
+        Some(e.phys_page)
     }
 
-    /// Record a freshly-walked translation.
+    /// Record a freshly-walked translation and its protection bits.
     #[inline]
-    pub fn insert(&mut self, page_frame: u32, supervisor: bool, phys_page: u32) {
+    pub fn insert(
+        &mut self,
+        page_frame: u32,
+        supervisor: bool,
+        phys_page: u32,
+        write_protected: bool,
+        supervisor_only: bool,
+    ) {
         self.entries[Self::index(page_frame)] = AtcEntry {
             valid: true,
             tag: Self::tag(page_frame, supervisor),
             phys_page,
+            write_protected,
+            supervisor_only,
         };
     }
 
@@ -105,22 +113,33 @@ mod tests {
     #[test]
     fn hit_after_insert_miss_after_flush() {
         let mut atc = Atc::default();
-        assert_eq!(atc.lookup(0x10, false), None);
-        atc.insert(0x10, false, 0x8000);
-        assert_eq!(atc.lookup(0x10, false), Some(0x8000));
+        assert_eq!(atc.lookup(0x10, false, false), None);
+        atc.insert(0x10, false, 0x8000, false, false);
+        assert_eq!(atc.lookup(0x10, false, false), Some(0x8000));
         // Supervisor map of the same page frame is a distinct entry.
-        assert_eq!(atc.lookup(0x10, true), None);
+        assert_eq!(atc.lookup(0x10, true, false), None);
         atc.flush_all();
-        assert_eq!(atc.lookup(0x10, false), None);
+        assert_eq!(atc.lookup(0x10, false, false), None);
     }
 
     #[test]
     fn flush_page_drops_only_that_frame() {
         let mut atc = Atc::default();
-        atc.insert(0x10, false, 0x1000);
+        atc.insert(0x10, false, 0x1000, false, false);
         atc.flush_page(0x11); // different frame, same is unlikely-index: no-op for 0x10
-        assert_eq!(atc.lookup(0x10, false), Some(0x1000));
+        assert_eq!(atc.lookup(0x10, false, false), Some(0x1000));
         atc.flush_page(0x10);
-        assert_eq!(atc.lookup(0x10, false), None);
+        assert_eq!(atc.lookup(0x10, false, false), None);
+    }
+
+    #[test]
+    fn permission_violation_does_not_hit() {
+        let mut atc = Atc::default();
+        // Write-protected, supervisor-only page.
+        atc.insert(0x10, true, 0x5000, true, true);
+        // A supervisor read hits; a write misses (write-protected) so the caller
+        // re-walks and faults.
+        assert_eq!(atc.lookup(0x10, true, false), Some(0x5000));
+        assert_eq!(atc.lookup(0x10, true, true), None);
     }
 }

--- a/crates/m68k/src/mmu/mod.rs
+++ b/crates/m68k/src/mmu/mod.rs
@@ -1,11 +1,13 @@
 //! MMU emulation (68030/68040 PMMU)
 
+pub mod atc;
 mod translation;
 pub mod ttr;
 
 use crate::core::cpu::CpuCore;
 use crate::core::memory::AddressBus;
 
+pub use atc::Atc;
 pub use translation::translate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/m68k/src/mmu/translation.rs
+++ b/crates/m68k/src/mmu/translation.rs
@@ -154,6 +154,9 @@ pub fn translate<B: AddressBus>(
         0 => return Err(access_fault(logical)),
         1 => {
             // Early termination descriptor (Musashi uses &0xffffff00).
+            if write && tbl_entry & 0x4 != 0 {
+                return Err(access_fault(logical)); // WP: write-protected page
+            }
             let base = tbl_entry & 0xFFFF_FF00;
             let shift = is + abits;
             let addr_out = low_bits(addr_in, shift).wrapping_add(base);
@@ -182,6 +185,9 @@ pub fn translate<B: AddressBus>(
     match tbmode {
         0 => return Err(access_fault(logical)),
         1 => {
+            if write && tbl_entry & 0x4 != 0 {
+                return Err(access_fault(logical)); // WP: write-protected page
+            }
             let base = tbl_entry & 0xFFFF_FF00;
             let shift = is + abits + bbits;
             let addr_out = low_bits(addr_in, shift).wrapping_add(base);
@@ -205,6 +211,9 @@ pub fn translate<B: AddressBus>(
     // Final termination at table C.
     match tcmode {
         1 => {
+            if write && tbl_entry & 0x4 != 0 {
+                return Err(access_fault(logical)); // WP: write-protected page
+            }
             let base = tbl_entry & 0xFFFF_FF00;
             let shift = is + abits + bbits + cbits;
             Ok(low_bits(addr_in, shift).wrapping_add(base))
@@ -223,22 +232,29 @@ pub fn translate<B: AddressBus>(
 /// page descriptors use PDT (bits [1:0]): 0 = invalid, 2 = indirect, 1/3 =
 /// resident.
 ///
-/// Phase 1 honours only the resident descriptor type to translate through valid
-/// tables (so 1:1 tables identity-map and remapped tables relocate). A walk that
-/// hits an invalid/unconfigured descriptor falls back to identity translation
-/// rather than faulting: the resumable 68040 access-fault stack frame does not
-/// exist yet, so faulting here would crash software that enables TC before its
-/// tables cover an access (the codebase's "safe direction"). A later phase
-/// replaces the `// PHASE3` fallbacks with real access faults + MMUSR reporting,
-/// and adds write-protect / supervisor permission enforcement.
+/// A *data* access through an invalid/unconfigured descriptor raises an access
+/// fault (this is how Enforcer/MuForce catch low-memory and freed-memory hits).
+/// An *instruction fetch* through an invalid descriptor instead falls back to
+/// identity translation: a 68040 enables TC before all of its code is mapped
+/// during boot, and faulting the fetch stream there would derail it (the
+/// codebase's "safe direction"). Resident pages additionally enforce the W
+/// (write-protect) and S (supervisor-only) descriptor bits.
 fn translate_040<B: AddressBus>(
     cpu: &mut CpuCore,
     bus: &mut B,
     logical: u32,
     write: bool,
     supervisor: bool,
-    _instruction: bool,
+    instruction: bool,
 ) -> MmuResult<u32> {
+    // Invalid-descriptor outcome: fault on data, identity-fallback on a fetch.
+    let invalid = |logical: u32| -> MmuResult<u32> {
+        if instruction {
+            Ok(logical)
+        } else {
+            Err(access_fault(logical))
+        }
+    };
     // Page size: TC bit 14 (P) selects 8 KB, else 4 KB.
     let page_bits = if cpu.mmu_tc & 0x0000_4000 != 0 { 13 } else { 12 };
     let page_mask = (1u32 << page_bits) - 1;
@@ -263,7 +279,7 @@ fn translate_040<B: AddressBus>(
     let root_idx = (logical >> 25) & 0x7F;
     let root_desc = read_u32_phys(bus, (root & 0xFFFF_FE00).wrapping_add(root_idx * 4))?;
     if root_desc & 3 < 2 {
-        return Ok(logical); // PHASE3: UDT invalid -> access fault
+        return invalid(logical); // UDT invalid: data faults, fetch falls back
     }
 
     // Level 2: pointer table (512-byte aligned), indexed by logical[24:18].
@@ -271,7 +287,7 @@ fn translate_040<B: AddressBus>(
     let ptr_idx = (logical >> 18) & 0x7F;
     let ptr_desc = read_u32_phys(bus, ptr_table.wrapping_add(ptr_idx * 4))?;
     if ptr_desc & 3 < 2 {
-        return Ok(logical); // PHASE3: UDT invalid -> access fault
+        return invalid(logical); // UDT invalid: data faults, fetch falls back
     }
 
     // Level 3: page table. With 4 KB pages it has 64 entries (256-byte aligned,
@@ -291,7 +307,7 @@ fn translate_040<B: AddressBus>(
         page_desc = read_u32_phys(bus, page_desc & 0xFFFF_FFFC)?;
     }
     if page_desc & 3 == 0 {
-        return Ok(logical); // PHASE3: PDT invalid -> access fault
+        return invalid(logical); // PDT invalid: data faults, fetch falls back
     }
 
     // Protection bits: W (write-protect, bit 2) accumulates across the table and

--- a/crates/m68k/src/mmu/translation.rs
+++ b/crates/m68k/src/mmu/translation.rs
@@ -73,6 +73,12 @@ pub fn translate<B: AddressBus>(
         return Ok(phys);
     }
 
+    // The 68040 page table is a fixed three-level format unrelated to the
+    // 68030's programmable walk below; dispatch to its own walker.
+    if cpu.is_040() {
+        return translate_040(cpu, bus, logical, write, supervisor, instruction);
+    }
+
     // Root pointer selection: if SRP enabled and supervisor, use SRP; else CRP.
     let use_srp = (cpu.mmu_tc & 0x0200_0000) != 0 && supervisor;
     let (root_aptr, root_limit) = if use_srp {
@@ -205,4 +211,81 @@ pub fn translate<B: AddressBus>(
         }
         _ => Err(access_fault(logical)),
     }
+}
+
+/// Perform 68040 PMMU translation.
+///
+/// The 68040 uses a fixed three-level table (root -> pointer -> page) with
+/// 4-byte descriptors, indexed by logical bits [31:25] / [24:18] / [17:12]
+/// (4 KB pages) or [17:13] (8 KB pages, TC bit 14 set). The root pointer is
+/// URP in user mode and SRP in supervisor mode (no TC bit-25 gate -- that is
+/// 68030-only). Table-level descriptors use UDT (bits [1:0]): >=2 = resident;
+/// page descriptors use PDT (bits [1:0]): 0 = invalid, 2 = indirect, 1/3 =
+/// resident.
+///
+/// Phase 1 honours only the resident descriptor type to translate through valid
+/// tables (so 1:1 tables identity-map and remapped tables relocate). A walk that
+/// hits an invalid/unconfigured descriptor falls back to identity translation
+/// rather than faulting: the resumable 68040 access-fault stack frame does not
+/// exist yet, so faulting here would crash software that enables TC before its
+/// tables cover an access (the codebase's "safe direction"). A later phase
+/// replaces the `// PHASE3` fallbacks with real access faults + MMUSR reporting,
+/// and adds write-protect / supervisor permission enforcement.
+fn translate_040<B: AddressBus>(
+    cpu: &mut CpuCore,
+    bus: &mut B,
+    logical: u32,
+    _write: bool,
+    supervisor: bool,
+    _instruction: bool,
+) -> MmuResult<u32> {
+    // Page size: TC bit 14 (P) selects 8 KB, else 4 KB.
+    let page_bits = if cpu.mmu_tc & 0x0000_4000 != 0 { 13 } else { 12 };
+    let page_mask = (1u32 << page_bits) - 1;
+
+    // Root pointer: SRP in supervisor mode, URP (stored in mmu_crp_aptr) in user
+    // mode. The 128-entry root table is 512-byte aligned.
+    let root = if supervisor {
+        cpu.mmu_srp_aptr
+    } else {
+        cpu.mmu_crp_aptr
+    };
+
+    // Level 1: root table, indexed by logical[31:25] (128 x 4 bytes).
+    let root_idx = (logical >> 25) & 0x7F;
+    let root_desc = read_u32_phys(bus, (root & 0xFFFF_FE00).wrapping_add(root_idx * 4))?;
+    if root_desc & 3 < 2 {
+        return Ok(logical); // PHASE3: UDT invalid -> access fault
+    }
+
+    // Level 2: pointer table (512-byte aligned), indexed by logical[24:18].
+    let ptr_table = root_desc & 0xFFFF_FE00;
+    let ptr_idx = (logical >> 18) & 0x7F;
+    let ptr_desc = read_u32_phys(bus, ptr_table.wrapping_add(ptr_idx * 4))?;
+    if ptr_desc & 3 < 2 {
+        return Ok(logical); // PHASE3: UDT invalid -> access fault
+    }
+
+    // Level 3: page table. With 4 KB pages it has 64 entries (256-byte aligned,
+    // indexed by logical[17:12]); with 8 KB pages, 32 entries (128-byte aligned,
+    // indexed by logical[17:13]).
+    let (page_table_mask, page_idx) = if page_bits == 13 {
+        (0xFFFF_FF80u32, (logical >> 13) & 0x1F)
+    } else {
+        (0xFFFF_FF00u32, (logical >> 12) & 0x3F)
+    };
+    let page_table = ptr_desc & page_table_mask;
+    let mut page_desc = read_u32_phys(bus, page_table.wrapping_add(page_idx * 4))?;
+
+    // PDT: 0 invalid, 2 indirect (the descriptor points to the real page
+    // descriptor), 1/3 resident.
+    if page_desc & 3 == 2 {
+        page_desc = read_u32_phys(bus, page_desc & 0xFFFF_FFFC)?;
+    }
+    if page_desc & 3 == 0 {
+        return Ok(logical); // PHASE3: PDT invalid -> access fault
+    }
+
+    let phys_page = page_desc & !page_mask;
+    Ok(phys_page | (logical & page_mask))
 }

--- a/crates/m68k/src/mmu/translation.rs
+++ b/crates/m68k/src/mmu/translation.rs
@@ -243,6 +243,12 @@ fn translate_040<B: AddressBus>(
     let page_bits = if cpu.mmu_tc & 0x0000_4000 != 0 { 13 } else { 12 };
     let page_mask = (1u32 << page_bits) - 1;
 
+    // ATC fast path: a recent walk for this page avoids the descriptor fetches.
+    let page_frame = logical >> page_bits;
+    if let Some(phys_page) = cpu.atc.lookup(page_frame, supervisor) {
+        return Ok(phys_page | (logical & page_mask));
+    }
+
     // Root pointer: SRP in supervisor mode, URP (stored in mmu_crp_aptr) in user
     // mode. The 128-entry root table is 512-byte aligned.
     let root = if supervisor {
@@ -287,5 +293,9 @@ fn translate_040<B: AddressBus>(
     }
 
     let phys_page = page_desc & !page_mask;
+    // Cache only real resident translations -- never the identity fallbacks
+    // above, so a page that is later given a valid mapping (after PFLUSH) is not
+    // masked by a stale identity entry.
+    cpu.atc.insert(page_frame, supervisor, phys_page);
     Ok(phys_page | (logical & page_mask))
 }

--- a/crates/m68k/src/mmu/translation.rs
+++ b/crates/m68k/src/mmu/translation.rs
@@ -235,7 +235,7 @@ fn translate_040<B: AddressBus>(
     cpu: &mut CpuCore,
     bus: &mut B,
     logical: u32,
-    _write: bool,
+    write: bool,
     supervisor: bool,
     _instruction: bool,
 ) -> MmuResult<u32> {
@@ -244,8 +244,10 @@ fn translate_040<B: AddressBus>(
     let page_mask = (1u32 << page_bits) - 1;
 
     // ATC fast path: a recent walk for this page avoids the descriptor fetches.
+    // A cached entry the access would violate (write to a write-protected page,
+    // user access to a supervisor page) misses here, so we re-walk and fault.
     let page_frame = logical >> page_bits;
-    if let Some(phys_page) = cpu.atc.lookup(page_frame, supervisor) {
+    if let Some(phys_page) = cpu.atc.lookup(page_frame, supervisor, write) {
         return Ok(phys_page | (logical & page_mask));
     }
 
@@ -292,10 +294,21 @@ fn translate_040<B: AddressBus>(
         return Ok(logical); // PHASE3: PDT invalid -> access fault
     }
 
+    // Protection bits: W (write-protect, bit 2) accumulates across the table and
+    // page descriptors; S (supervisor-only, bit 7) lives on the page descriptor.
+    // A violating access faults (resumable on the 040, vector 2 / format 7).
+    let write_protected = (root_desc | ptr_desc | page_desc) & 0x0000_0004 != 0;
+    let supervisor_only = page_desc & 0x0000_0080 != 0;
+    if (write && write_protected) || (!supervisor && supervisor_only) {
+        return Err(access_fault(logical));
+    }
+
     let phys_page = page_desc & !page_mask;
     // Cache only real resident translations -- never the identity fallbacks
     // above, so a page that is later given a valid mapping (after PFLUSH) is not
-    // masked by a stale identity entry.
-    cpu.atc.insert(page_frame, supervisor, phys_page);
+    // masked by a stale identity entry. The protection bits ride along so a
+    // later violating access to the same page is caught on the ATC path too.
+    cpu.atc
+        .insert(page_frame, supervisor, phys_page, write_protected, supervisor_only);
     Ok(phys_page | (logical & page_mask))
 }

--- a/crates/m68k/tests/mmu_translate_tests.rs
+++ b/crates/m68k/tests/mmu_translate_tests.rs
@@ -129,6 +129,42 @@ fn translate_040_remap_redirects_to_physical_page() {
 }
 
 #[test]
+fn translate_040_atc_caches_walk_and_honours_flush() {
+    // The ATC must serve a second access to the same page from cache, hold that
+    // mapping until a flush (real 68040 coherency: a descriptor edit needs a
+    // PFLUSH), and pick up the new mapping after a TC write flushes it.
+    let mut bus = TestBus::new(0x10000);
+    let logical = 0x0000_1000;
+    let page_table = 0x4000; // matches build_040_table's layout
+    let page_idx = (logical >> 12) & 0x3F;
+    let desc_addr = page_table + page_idx * 4;
+    let root = build_040_table(&mut bus, logical, logical); // identity
+    bus.poke_long(logical, 0xAAAA_0001); // value at the identity page
+    bus.poke_long(0x9000, 0xBBBB_0002); // value at the would-be remap target
+
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x807, root);
+    cpu.write_control_register(0x003, 0x0000_8000);
+
+    // First access walks and caches; second is an ATC hit -- both identity.
+    assert_eq!(cpu.read_32(&mut bus, logical), 0xAAAA_0001);
+    assert_eq!(cpu.read_32(&mut bus, logical), 0xAAAA_0001);
+
+    // Edit the descriptor to remap the page to 0x9000 WITHOUT flushing: the ATC
+    // still serves the old (identity) mapping, as on real hardware.
+    bus.poke_long(desc_addr, 0x9000 | 1);
+    assert_eq!(
+        cpu.read_32(&mut bus, logical),
+        0xAAAA_0001,
+        "stale ATC entry must persist until a flush"
+    );
+
+    // A TC write flushes the ATC; the next access re-walks and sees the remap.
+    cpu.write_control_register(0x003, 0x0000_8000);
+    assert_eq!(cpu.read_32(&mut bus, logical), 0xBBBB_0002);
+}
+
+#[test]
 fn translate_040_unconfigured_walk_falls_back_to_identity() {
     // PHASE1: with no valid tables, the walk falls back to identity rather than
     // faulting (a later phase delivers a resumable access fault instead).

--- a/crates/m68k/tests/mmu_translate_tests.rs
+++ b/crates/m68k/tests/mmu_translate_tests.rs
@@ -5,6 +5,7 @@
 use m68k::core::cpu::CpuCore;
 use m68k::core::memory::AddressBus;
 use m68k::core::types::CpuType;
+use m68k::mmu::{translate_address, MmuFaultKind};
 
 /// Flat byte-addressed test memory.
 struct TestBus {
@@ -61,6 +62,23 @@ fn build_040_table(bus: &mut TestBus, logical: u32, phys_page: u32) -> u32 {
     bus.poke_long(PTR + ptr_idx * 4, PAGE | 2); // UDT resident -> page table
     bus.poke_long(PAGE + page_idx * 4, (phys_page & 0xFFFF_F000) | 1); // PDT resident
     ROOT
+}
+
+/// Like `build_040_table` but sets the page descriptor's protection bits:
+/// `w` = write-protected (bit 2), `s` = supervisor-only (bit 7).
+fn build_040_table_prot(bus: &mut TestBus, logical: u32, phys_page: u32, w: bool, s: bool) -> u32 {
+    let root = build_040_table(bus, logical, phys_page);
+    let page = 0x4000; // PAGE base in build_040_table
+    let page_idx = (logical >> 12) & 0x3F;
+    let mut pd = (phys_page & 0xFFFF_F000) | 1;
+    if w {
+        pd |= 0x0000_0004;
+    }
+    if s {
+        pd |= 0x0000_0080;
+    }
+    bus.poke_long(page + page_idx * 4, pd);
+    root
 }
 
 fn enabled_040_cpu() -> CpuCore {
@@ -162,6 +180,67 @@ fn translate_040_atc_caches_walk_and_honours_flush() {
     // A TC write flushes the ATC; the next access re-walks and sees the remap.
     cpu.write_control_register(0x003, 0x0000_8000);
     assert_eq!(cpu.read_32(&mut bus, logical), 0xBBBB_0002);
+}
+
+#[test]
+fn translate_040_enforces_write_protect_and_supervisor() {
+    // Write-protected page: a read translates, a write faults.
+    let mut bus = TestBus::new(0x10000);
+    let logical = 0x0000_1000;
+    let root = build_040_table_prot(&mut bus, logical, logical, true, false);
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x807, root);
+    cpu.write_control_register(0x003, 0x0000_8000);
+
+    assert!(translate_address(&mut cpu, &mut bus, logical, false, true, false).is_ok());
+    let err = translate_address(&mut cpu, &mut bus, logical, true, true, false).unwrap_err();
+    assert_eq!(err.kind, MmuFaultKind::AccessLevelViolation);
+
+    // Supervisor-only page: a supervisor access translates, a user access faults.
+    let mut bus = TestBus::new(0x10000);
+    let root = build_040_table_prot(&mut bus, logical, logical, false, true);
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x806, root); // URP (user root)
+    cpu.write_control_register(0x807, root); // SRP (supervisor root)
+    cpu.write_control_register(0x003, 0x0000_8000);
+
+    assert!(translate_address(&mut cpu, &mut bus, logical, false, true, false).is_ok());
+    let err = translate_address(&mut cpu, &mut bus, logical, false, false, false).unwrap_err();
+    assert_eq!(err.kind, MmuFaultKind::AccessLevelViolation);
+}
+
+#[test]
+fn translate_040_write_protect_delivers_resumable_format7_frame() {
+    // A write to a write-protected page must vector to BUS_ERROR (vector 2)
+    // with a 68040 format-7 access-error frame, leaving the access undone and
+    // RTE able to restart the faulting instruction.
+    let mut bus = TestBus::new(0x8_0000);
+    let target = 0x0001_0000; // write-protected resident page
+    let root = build_040_table_prot(&mut bus, target, target, true, false);
+    bus.poke_long(0x8, 0x0002_0000); // vector 2 handler (VBR=0, unmapped page -> identity)
+
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x807, root);
+    cpu.write_control_register(0x003, 0x0000_8000);
+    let ssp = 0x0000_3000u32;
+    cpu.dar[15] = ssp;
+    cpu.ppc = 0x0000_1234; // pretend faulting-instruction PC (restart target)
+    // No real instruction ran, so make the bus-error rollback a no-op.
+    cpu.sr_save = cpu.get_sr();
+    cpu.dar_save = cpu.dar;
+
+    cpu.write_32(&mut bus, target, 0xDEAD_BEEF);
+
+    assert_eq!(cpu.pc, 0x0002_0000, "vectored to the access-fault handler");
+    let sp = cpu.dar[15];
+    assert_eq!(bus.read_long(sp + 2), 0x0000_1234, "stacked restart PC = PPC");
+    assert_eq!(bus.read_word(sp + 6), 0x7008, "format 7, vector offset 0x08");
+    assert_eq!(bus.read_long(sp + 0x14), target, "fault address");
+    assert_eq!(
+        bus.read_long(target),
+        0,
+        "the write-protected store must not have landed"
+    );
 }
 
 #[test]

--- a/crates/m68k/tests/mmu_translate_tests.rs
+++ b/crates/m68k/tests/mmu_translate_tests.rs
@@ -210,6 +210,59 @@ fn translate_040_enforces_write_protect_and_supervisor() {
 }
 
 #[test]
+fn translate_030_enforces_write_protect() {
+    // A 68030 single-level table whose page descriptor sets WP (bit 2): a read
+    // translates (identity), a write faults.
+    let mut bus = TestBus::new(0x10000);
+    let table = 0x2000;
+    // Early-termination page descriptor: mode 1, base 0, WP set (bit 2).
+    bus.poke_long(table, 0x0000_0005);
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68030);
+    cpu.set_sr(0x2700);
+    cpu.mmu_crp_aptr = table;
+    cpu.mmu_crp_limit = 2; // mode 2: 4-byte descriptors
+    cpu.mmu_tc = 0x8000_4000; // E (bit 31), IS=0, TIA=4 entries
+    cpu.pmmu_enabled = true;
+
+    let logical = 0x0000_1000;
+    assert!(translate_address(&mut cpu, &mut bus, logical, false, true, false).is_ok());
+    let err = translate_address(&mut cpu, &mut bus, logical, true, true, false).unwrap_err();
+    assert_eq!(err.kind, MmuFaultKind::AccessLevelViolation);
+}
+
+#[test]
+fn ptest_040_reports_resident_and_physical_in_mmusr() {
+    // PTESTR (A0) probes the page that A0 points at and reports the physical
+    // page + resident (R) bit in MMUSR; an invalid page reports not-resident.
+    let mut bus = TestBus::new(0x2_0000);
+    let resident = 0x0001_0000;
+    let root = build_040_table(&mut bus, resident, resident); // identity resident
+    bus.write_word(0x1000, 0xF568); // PTESTR (A0) -- fetched via identity fallback
+    bus.write_word(0x1002, 0x4E71); // NOP
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    cpu.reset(&mut bus);
+    cpu.set_sr(0x2700);
+    cpu.write_control_register(0x807, root);
+    cpu.write_control_register(0x003, 0x0000_8000);
+
+    let mut hle = m68k::NoOpHleHandler;
+
+    cpu.dar[8] = resident; // A0 -> a mapped page
+    cpu.pc = 0x1000;
+    cpu.step_with_hle_handler(&mut bus, &mut hle);
+    assert_eq!(cpu.mmu_sr, resident | 1, "resident page: R set, physical addr");
+
+    cpu.dar[8] = 0x0005_0000; // A0 -> an unmapped page
+    cpu.pc = 0x1000;
+    cpu.step_with_hle_handler(&mut bus, &mut hle);
+    assert_eq!(cpu.mmu_sr, 0, "invalid page: not resident");
+}
+
+#[test]
 fn translate_040_write_protect_delivers_resumable_format7_frame() {
     // A write to a write-protected page must vector to BUS_ERROR (vector 2)
     // with a 68040 format-7 access-error frame, leaving the access undone and
@@ -244,15 +297,19 @@ fn translate_040_write_protect_delivers_resumable_format7_frame() {
 }
 
 #[test]
-fn translate_040_unconfigured_walk_falls_back_to_identity() {
-    // PHASE1: with no valid tables, the walk falls back to identity rather than
-    // faulting (a later phase delivers a resumable access fault instead).
+fn translate_040_invalid_page_faults_data_but_falls_back_for_fetch() {
+    // With no valid tables, a DATA access through the invalid descriptor faults
+    // (this is Enforcer's low-memory catch), while an INSTRUCTION fetch falls
+    // back to identity so a 68040 enabling TC before its code is mapped does
+    // not derail.
     let mut bus = TestBus::new(0x10000);
-    bus.poke_long(0x0000_1000, 0xDEAD_BEEF);
-
     let mut cpu = enabled_040_cpu();
     cpu.write_control_register(0x807, 0x00FF_0000); // garbage root (unmapped)
     cpu.write_control_register(0x003, 0x0000_8000);
 
-    assert_eq!(cpu.read_32(&mut bus, 0x0000_1000), 0xDEAD_BEEF);
+    let data = translate_address(&mut cpu, &mut bus, 0x0000_1000, false, true, false);
+    assert_eq!(data.unwrap_err().kind, MmuFaultKind::AccessLevelViolation);
+
+    let fetch = translate_address(&mut cpu, &mut bus, 0x0000_1000, false, true, true);
+    assert_eq!(fetch, Ok(0x0000_1000), "an instruction fetch falls back");
 }

--- a/crates/m68k/tests/mmu_translate_tests.rs
+++ b/crates/m68k/tests/mmu_translate_tests.rs
@@ -1,0 +1,143 @@
+//! 68040 PMMU translation tests: register plumbing, identity walk, and a
+//! non-identity remap, driven through the CPU's own read path so the whole
+//! translate() dispatch is exercised.
+
+use m68k::core::cpu::CpuCore;
+use m68k::core::memory::AddressBus;
+use m68k::core::types::CpuType;
+
+/// Flat byte-addressed test memory.
+struct TestBus {
+    mem: Vec<u8>,
+}
+
+impl TestBus {
+    fn new(size: usize) -> Self {
+        Self { mem: vec![0; size] }
+    }
+    fn poke_long(&mut self, addr: u32, val: u32) {
+        self.write_long(addr, val);
+    }
+}
+
+impl AddressBus for TestBus {
+    fn read_byte(&mut self, addr: u32) -> u8 {
+        self.mem.get(addr as usize).copied().unwrap_or(0)
+    }
+    fn write_byte(&mut self, addr: u32, val: u8) {
+        if let Some(m) = self.mem.get_mut(addr as usize) {
+            *m = val;
+        }
+    }
+    fn read_word(&mut self, addr: u32) -> u16 {
+        ((self.read_byte(addr) as u16) << 8) | self.read_byte(addr.wrapping_add(1)) as u16
+    }
+    fn write_word(&mut self, addr: u32, val: u16) {
+        self.write_byte(addr, (val >> 8) as u8);
+        self.write_byte(addr.wrapping_add(1), val as u8);
+    }
+    fn read_long(&mut self, addr: u32) -> u32 {
+        ((self.read_word(addr) as u32) << 16) | self.read_word(addr.wrapping_add(2)) as u32
+    }
+    fn write_long(&mut self, addr: u32, val: u32) {
+        self.write_word(addr, (val >> 16) as u16);
+        self.write_word(addr.wrapping_add(2), val as u16);
+    }
+}
+
+/// Build a one-page 68040 4 KB page table (root -> pointer -> page) mapping the
+/// page containing `logical` to `phys_page`. Returns the supervisor root pointer.
+fn build_040_table(bus: &mut TestBus, logical: u32, phys_page: u32) -> u32 {
+    // Fixed table layout in low memory (all alignments satisfied).
+    const ROOT: u32 = 0x2000; // 512-byte aligned
+    const PTR: u32 = 0x3000; // 512-byte aligned
+    const PAGE: u32 = 0x4000; // 256-byte aligned (4 KB pages)
+
+    let root_idx = (logical >> 25) & 0x7F;
+    let ptr_idx = (logical >> 18) & 0x7F;
+    let page_idx = (logical >> 12) & 0x3F;
+
+    bus.poke_long(ROOT + root_idx * 4, PTR | 2); // UDT resident -> pointer table
+    bus.poke_long(PTR + ptr_idx * 4, PAGE | 2); // UDT resident -> page table
+    bus.poke_long(PAGE + page_idx * 4, (phys_page & 0xFFFF_F000) | 1); // PDT resident
+    ROOT
+}
+
+fn enabled_040_cpu() -> CpuCore {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    cpu.set_sr(0x2700); // supervisor, interrupts masked
+    assert!(cpu.has_pmmu, "the full 68040 must have a PMMU");
+    cpu
+}
+
+#[test]
+fn movec_040_tc_bit15_enables_and_root_pointers_round_trip() {
+    let mut cpu = enabled_040_cpu();
+    assert!(!cpu.pmmu_enabled);
+
+    // TC bit 15 (E) is the 68040 enable bit (not bit 31 like the 030).
+    cpu.write_control_register(0x003, 0x0000_8000);
+    assert!(cpu.pmmu_enabled, "MOVEC TC[15] must enable the PMMU");
+    assert_eq!(cpu.read_control_register(0x003), 0x0000_8000);
+
+    cpu.write_control_register(0x003, 0); // disable
+    assert!(!cpu.pmmu_enabled);
+
+    // URP (0x806) and SRP (0x807) reach the canonical root-pointer fields that
+    // the walker reads, and read back unchanged.
+    cpu.write_control_register(0x806, 0x0030_0000);
+    cpu.write_control_register(0x807, 0x0040_0000);
+    assert_eq!(cpu.read_control_register(0x806), 0x0030_0000);
+    assert_eq!(cpu.read_control_register(0x807), 0x0040_0000);
+    assert_eq!(cpu.mmu_crp_aptr, 0x0030_0000, "URP stored in mmu_crp_aptr");
+    assert_eq!(cpu.mmu_srp_aptr, 0x0040_0000, "SRP stored in mmu_srp_aptr");
+}
+
+#[test]
+fn translate_040_identity_table_reads_same_address() {
+    let mut bus = TestBus::new(0x10000);
+    let logical = 0x0000_1000;
+    let root = build_040_table(&mut bus, logical, logical); // identity
+    bus.poke_long(logical, 0xCAFE_F00D);
+
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x807, root); // SRP = root (supervisor walk)
+    cpu.write_control_register(0x003, 0x0000_8000); // enable, 4 KB pages
+
+    assert_eq!(cpu.read_32(&mut bus, logical), 0xCAFE_F00D);
+}
+
+#[test]
+fn translate_040_remap_redirects_to_physical_page() {
+    let mut bus = TestBus::new(0x10000);
+    let logical = 0x0000_1000;
+    let phys = 0x0000_8000; // map logical page -> a different physical page
+    let root = build_040_table(&mut bus, logical, phys);
+    bus.poke_long(phys, 0x1234_5678); // value lives at the physical page
+    bus.poke_long(logical, 0x0000_0000); // not at the logical page
+
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x807, root);
+    cpu.write_control_register(0x003, 0x0000_8000);
+
+    assert_eq!(
+        cpu.read_32(&mut bus, logical),
+        0x1234_5678,
+        "translation must redirect logical->physical, not read the logical page"
+    );
+}
+
+#[test]
+fn translate_040_unconfigured_walk_falls_back_to_identity() {
+    // PHASE1: with no valid tables, the walk falls back to identity rather than
+    // faulting (a later phase delivers a resumable access fault instead).
+    let mut bus = TestBus::new(0x10000);
+    bus.poke_long(0x0000_1000, 0xDEAD_BEEF);
+
+    let mut cpu = enabled_040_cpu();
+    cpu.write_control_register(0x807, 0x00FF_0000); // garbage root (unmapped)
+    cpu.write_control_register(0x003, 0x0000_8000);
+
+    assert_eq!(cpu.read_32(&mut bus, 0x0000_1000), 0xDEAD_BEEF);
+}

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -175,14 +175,21 @@ enable bit differs by part -- TC[31] on the 030, TC[15] on the 040 -- via
 `tc_enable()`. `PMOVE`/`MOVEC` load the registers and `PTEST`/`PLOAD`/`PFLUSH`
 are accepted as no-ops rather than trapping.
 
+A 68040 table walk costs three descriptor fetches, far too much to pay on every
+access, so the 040 walker is fronted by an address-translation cache
+(`crate::mmu::atc`, mirrored on the real 64-entry ATC): a direct-mapped cache of
+(logical page -> physical page) keyed by page frame and supervisor flag. It is a
+pure cache -- never serialized (restored empty) -- and is flushed when the
+mapping could change: a write to TC / a root pointer / a TTR, or a PFLUSH. Like
+real hardware a plain write to a descriptor does not auto-flush; software must
+PFLUSH, which is where the ATC is cleared.
+
 A table walk that misses a valid descriptor currently falls back to identity
 translation rather than raising an access fault: the resumable 68040 access-error
 and 68030 long-bus-fault stack frames are not built yet, so faulting mid-access
 would crash the guest -- identity is the safe direction (the same stance the
-caches take). Remaining work, tracked as later phases: an address-translation
-cache (ATC) so a translated access does not pay a per-access table walk, and real
-access faults with write-protect/supervisor permission checks and MMUSR
-reporting (so Enforcer-class tools work).
+caches take). Remaining work: real access faults with write-protect/supervisor
+permission checks and MMUSR reporting (so Enforcer-class tools work).
 
 ## Interrupts and STOP
 

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -184,12 +184,22 @@ mapping could change: a write to TC / a root pointer / a TTR, or a PFLUSH. Like
 real hardware a plain write to a descriptor does not auto-flush; software must
 PFLUSH, which is where the ATC is cleared.
 
-A table walk that misses a valid descriptor currently falls back to identity
-translation rather than raising an access fault: the resumable 68040 access-error
-and 68030 long-bus-fault stack frames are not built yet, so faulting mid-access
-would crash the guest -- identity is the safe direction (the same stance the
-caches take). Remaining work: real access faults with write-protect/supervisor
-permission checks and MMUSR reporting (so Enforcer-class tools work).
+The 68040 enforces page protection: a write to a write-protected page (the W
+bit, accumulated across the table and page descriptors) or a user access to a
+supervisor-only page (the S bit) raises an access fault, delivered as a 68040
+format-7 access-error stack frame at the bus-error vector. The faulting
+instruction is rolled back and its PC stacked, so after the handler fixes the
+mapping an `RTE` restarts it (the demand-paging / memory-protection model). The
+ATC carries the protection bits, so a cached translation cannot bypass the
+check. The frame's writeback/continuation fields are left clear (full-restart
+model); mid-instruction continuation is not modelled.
+
+A table walk that misses a *valid* descriptor still falls back to identity
+translation rather than faulting -- flipping that on (so an access to an invalid
+page faults, which is how Enforcer/MuForce catch low-memory hits) is the next
+step, gated on confirming it does not destabilise the bundled AROS boot.
+Remaining: MMUSR result bits for `PTEST`, and the 68030 long bus-fault frame and
+030 permission checks (the 030 walker is unchanged so far).
 
 ## Interrupts and STOP
 

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -155,7 +155,34 @@ throughput still runs below the reference, and the cycle model does not reflect
 instruction-cache hit/miss *latency* (only its bus-traffic effect), so software
 that toggles CACR cache-on/off and depends on the exact transition timing can
 diverge.
-MMU-dependent 030/040 accelerator setups are a non-goal.
+
+## MMU
+
+The 68030 and 68040 model the on-chip MMU (`has_pmmu`), so software that sets up
+and enables address translation runs rather than having its MMU writes ignored.
+The two parts differ enough to need separate walkers: the 68030 uses its
+programmable table walk (CRP/SRP selection, the TC index fields, 4-/8-byte
+descriptor modes, early-termination descriptors), while the 68040 has a
+fixed-format three-level walk (root -> pointer -> page, 4 KB or 8 KB pages,
+URP/SRP split by supervisor) keyed off its own TC layout. Both share the
+transparent translation registers (TTRs: the 030's TT0/1, the 040's ITT0/1 +
+DTT0/1), which short-circuit the walk for a matching address range.
+
+One register set (`mmu_*` in `CpuCore`) is canonical for both paths, so the 030
+`PMOVE` writes, the 040 `MOVEC` writes, and the walker can never desync (the 040
+root pointers overload the CRP/SRP address slots, dispatched by `cpu_type`). The
+enable bit differs by part -- TC[31] on the 030, TC[15] on the 040 -- via
+`tc_enable()`. `PMOVE`/`MOVEC` load the registers and `PTEST`/`PLOAD`/`PFLUSH`
+are accepted as no-ops rather than trapping.
+
+A table walk that misses a valid descriptor currently falls back to identity
+translation rather than raising an access fault: the resumable 68040 access-error
+and 68030 long-bus-fault stack frames are not built yet, so faulting mid-access
+would crash the guest -- identity is the safe direction (the same stance the
+caches take). Remaining work, tracked as later phases: an address-translation
+cache (ATC) so a translated access does not pay a per-access table walk, and real
+access faults with write-protect/supervisor permission checks and MMUSR
+reporting (so Enforcer-class tools work).
 
 ## Interrupts and STOP
 

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -194,12 +194,21 @@ ATC carries the protection bits, so a cached translation cannot bypass the
 check. The frame's writeback/continuation fields are left clear (full-restart
 model); mid-instruction continuation is not modelled.
 
-A table walk that misses a *valid* descriptor still falls back to identity
-translation rather than faulting -- flipping that on (so an access to an invalid
-page faults, which is how Enforcer/MuForce catch low-memory hits) is the next
-step, gated on confirming it does not destabilise the bundled AROS boot.
-Remaining: MMUSR result bits for `PTEST`, and the 68030 long bus-fault frame and
-030 permission checks (the 030 walker is unchanged so far).
+A *data* access through an invalid/unconfigured descriptor raises an access
+fault -- this is how Enforcer/MuForce catch low-memory and freed-memory hits. An
+*instruction fetch* through an invalid descriptor instead falls back to identity:
+a 68040 enables TC before all of its code is mapped during boot, so faulting the
+fetch stream there would derail it. The bus-error delivery sets the
+exception-processing flag, so the frame writes and vector fetch do not
+re-translate (and a fault while delivering a fault is a clean double-fault halt).
+
+`PTEST` (68040) walks the addressed page and reports the physical address and
+resident bit in MMUSR (the cache-mode/used/modified attribute bits are not yet
+filled in). The 68030 also enforces the descriptor write-protect (WP) bit, and
+its faults are routed to the bus-error vector like the 040's, though the 68030
+long bus-fault stack frame (format A/B) is still the minimal fallback rather than
+a fully resumable frame. Remaining: the 040 SSW access size, the indirect/used/
+modified MMUSR bits, and the resumable 030 frame.
 
 ## Interrupts and STOP
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2188,7 +2188,9 @@ fn cpu_type_for_model(model: CpuModel) -> CpuType {
         CpuModel::M68EC020 => CpuType::M68EC020,
         CpuModel::M68020 => CpuType::M68020,
         CpuModel::M68030 => CpuType::M68030,
-        CpuModel::M68040 => CpuType::M68LC040,
+        // Full 68040: FPU on-die (default_fpu) and the MMU enabled (has_pmmu).
+        // The FPU-less LC/EC variants are not modelled (see CpuModel docs).
+        CpuModel::M68040 => CpuType::M68040,
     }
 }
 

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -58,7 +58,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //   9: CpuCore.fpr retyped f64 -> FloatX80 (80-bit extended FPU registers)
 //  10: CpuCache backing arrays became Vec (variable line count for the
 //      68040's 4 KB caches vs the 020/030's 256 bytes)
-pub const STATE_VERSION: u32 = 10;
+//  11: CpuCore MMU registers collapsed (removed tc/urp/srp/mmusr duplicates;
+//      mmu_sr retyped u16->u32) so the 040 MOVEC path and the page-table
+//      walker share one register set
+pub const STATE_VERSION: u32 = 11;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
Brings the 68030/68040 MMU from "partially wired, off for the 040" to a working, real-software-validated implementation. Stacked on #70 (the cache PR) -- merge that first; this PR's diff is MMU-only.

## What it does
- **Address translation** on both the 030 (programmable walk) and 040 (new fixed-format root->pointer->page walker, 4 KB/8 KB pages, URP/SRP), sharing the transparent translation registers.
- **ATC** (64-entry) fronting the 040 walker so a translated access does not pay a per-access table walk; flushed on TC/root/TTR writes and `PFLUSH`.
- **Access faults**: write-protect / supervisor / invalid-page (data) faults delivered as resumable 68040 format-7 frames (the instruction is rolled back, `RTE` restarts it). Instruction fetches through invalid pages fall back to identity so a 040 enabling TC before its code is mapped does not derail. `PTEST` reports the physical address + resident bit in MMUSR. The 030 enforces the write-protect bit and routes faults to the bus-error vector.

## Key fixes
- The 040 `MOVEC` register set was desynced from the table walker (it wrote `tc`/`urp`/`srp` while the walker read `mmu_tc`/`mmu_crp_*`/`mmu_srp_*`). Collapsed to one canonical register set so a desync is structurally impossible.
- `M68040` now maps to the full `CpuType::M68040` (`has_pmmu` true).
- The 68030 PMMU instructions (`PTEST`/`PLOAD`) no longer fall through to a LINE-1111 trap.

`STATE_VERSION` bumped to 11 (CpuCore MMU register shape).

## Validation
- New `crates/m68k/tests/mmu_translate_tests.rs` (identity walk, non-identity remap, ATC coherency, write-protect/supervisor enforcement, an end-to-end format-7 fault-and-restart, `PTEST`->MMUSR, 030 write-protect) plus the existing MMU/030/040 test bins; full suite green, clippy + fmt clean.
- Real Kickstart 3.1 boots on the 030 and 040.
- **Real-software exercise via VATestprogram** on a 68040: `MOVEC` register round-trips (including the URP/SRP path that was the desync bug), live page-table build, page-translation enable, and a chip-RAM write-protect fault test -- all without crashing, confirming the walker and the access-fault path end to end.

## Documented residuals (non-blocking)
The resumable 68030 long bus-fault frame (format A/B is still the minimal fallback), the format-7 SSW access-size field, and MMUSR attribute bits beyond resident.