### PR TITLE
Handle side-specific host modifier events

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -344,6 +344,10 @@ const OSD_TEXT: u32 = rgba(236, 236, 232);
 const OSD_SHADOW: u32 = rgba(0, 0, 0);
 const OSD_BG: u32 = rgba(10, 10, 12);
 const RECORD_DOT: u32 = rgba(229, 56, 48);
+const AMIGA_RAWKEY_LEFT_SHIFT: u8 = 0x60;
+const AMIGA_RAWKEY_RIGHT_SHIFT: u8 = 0x61;
+const AMIGA_RAWKEY_LEFT_ALT: u8 = 0x64;
+const AMIGA_RAWKEY_RIGHT_ALT: u8 = 0x65;
 
 fn host_shortcut_modifier_pressed(modifiers: ModifiersState) -> bool {
     if cfg!(target_os = "macos") {
@@ -418,6 +422,34 @@ use winit::event::{
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{KeyCode, ModifiersState, PhysicalKey};
 use winit::window::{CursorGrabMode, Icon, Window, WindowAttributes, WindowId};
+
+fn rawkey_index(rawkey: u8) -> usize {
+    (rawkey & 0x7F) as usize
+}
+
+fn rawkey_is_held(held_rawkeys: &[bool; 128], rawkey: u8) -> bool {
+    held_rawkeys[rawkey_index(rawkey)]
+}
+
+fn rawkey_transition_is_duplicate(held_rawkeys: &[bool; 128], rawkey: u8, pressed: bool) -> bool {
+    rawkey_is_held(held_rawkeys, rawkey) == pressed
+}
+
+fn repeated_main_key_should_drop(
+    held_rawkeys: &[bool; 128],
+    code: KeyCode,
+    state: ElementState,
+    repeat: bool,
+    ui_accepts_repeat: bool,
+) -> bool {
+    if !repeat || state != ElementState::Pressed || ui_accepts_repeat {
+        return false;
+    }
+    match host_to_amiga_rawkey(code) {
+        Some(rawkey) => rawkey_is_held(held_rawkeys, rawkey),
+        None => true,
+    }
+}
 
 pub struct App {
     emu: Emulator,
@@ -1178,7 +1210,7 @@ impl ApplicationHandler for App {
                     },
                 ..
             } => {
-                if repeat && !self.ui_key_accepts_repeat(None, code) {
+                if self.should_drop_repeated_main_key(code, state, repeat) {
                     return;
                 }
                 match (code, state) {
@@ -1272,7 +1304,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::ModifiersChanged(modifiers) => {
-                self.modifiers = modifiers.state();
+                self.update_host_modifiers(modifiers.state());
             }
             WindowEvent::CursorMoved { position, .. } => {
                 let previous_cursor_pos = self.cursor_pos;
@@ -4622,6 +4654,21 @@ impl App {
             )
     }
 
+    fn should_drop_repeated_main_key(
+        &self,
+        code: KeyCode,
+        state: ElementState,
+        repeat: bool,
+    ) -> bool {
+        repeated_main_key_should_drop(
+            &self.held_rawkeys,
+            code,
+            state,
+            repeat,
+            self.ui_key_accepts_repeat(None, code),
+        )
+    }
+
     fn activate_analyzer_pick_at(&mut self, kind: ToolPanelKind, pos: (i32, i32)) -> bool {
         if kind != ToolPanelKind::FrameAnalyzer {
             return false;
@@ -4665,7 +4712,7 @@ impl App {
                 }
             }
             WindowEvent::ModifiersChanged(modifiers) => {
-                self.modifiers = modifiers.state();
+                self.update_host_modifiers(modifiers.state());
             }
             WindowEvent::CursorMoved { position, .. } => {
                 let previous = self.tool_window(kind).and_then(|tool| tool.cursor_pos);
@@ -6879,8 +6926,29 @@ impl App {
         }
     }
 
+    fn update_host_modifiers(&mut self, modifiers: ModifiersState) {
+        self.modifiers = modifiers;
+        if !modifiers.shift_key() {
+            self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_LEFT_SHIFT);
+            self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_RIGHT_SHIFT);
+        }
+        if !modifiers.alt_key() {
+            self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_LEFT_ALT);
+            self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_RIGHT_ALT);
+        }
+    }
+
+    fn release_amiga_rawkey_if_held(&mut self, rawkey: u8) {
+        if rawkey_is_held(&self.held_rawkeys, rawkey) {
+            self.handle_amiga_key_event(rawkey, false);
+        }
+    }
+
     fn handle_amiga_key_event(&mut self, rawkey: u8, pressed: bool) {
-        let idx = (rawkey & 0x7F) as usize;
+        if rawkey_transition_is_duplicate(&self.held_rawkeys, rawkey, pressed) {
+            return;
+        }
+        let idx = rawkey_index(rawkey);
         self.held_rawkeys[idx] = pressed;
 
         // Ctrl+Amiga+Amiga is no longer consumed host-side: the chord
@@ -7786,16 +7854,18 @@ mod tests {
         host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_mode_uses_keyboard,
         joystick_toggle_rect, keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv,
         paint_test_screen, parse_amiga_key, pause_button_rect, power_button_rect,
-        present_row_sample, presentation_source_y_offset, reboot_button_rect, rgba,
+        present_row_sample, presentation_source_y_offset, rawkey_is_held,
+        rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
         shot_button_rect, should_render_emulated_frame, standard_window_top_row,
         status_with_latched_fdd_track, take_integral_mouse_delta, texture_height, texture_width,
         tv_source_h_bounds, tv_standard_h_shift, volume_percent_from_pos, volume_slider_track_rect,
         BarControl, DriveBar, JoystickInputMode, KeyboardJoystickHeld, KeyboardJoystickKey,
-        MediaBar, StatusBarView, ToolPanelKind, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY,
-        CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON,
-        HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON,
-        PRESENT_HEIGHT, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG,
-        TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
+        MediaBar, StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT,
+        AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED,
+        CD_BODY, CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF,
+        FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF,
+        POWER_LED_ON, PRESENT_HEIGHT, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS,
+        STATUS_BG, TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
     };
     use crate::audio::{AudioSink, NullSink};
     use crate::bus::FrontPanelStatus;
@@ -7804,6 +7874,7 @@ mod tests {
     use std::cell::RefCell;
     use std::path::PathBuf;
     use std::rc::Rc;
+    use winit::event::ElementState;
     use winit::keyboard::{KeyCode, ModifiersState};
 
     /// A typical session: DF0 connected with a disk in, no CD drive.
@@ -7850,6 +7921,102 @@ mod tests {
         // The Amiga has no right Ctrl, so host ControlRight doubles as a
         // Right Amiga ($67) alias for keyboards without a right Super key.
         assert_eq!(host_to_amiga_rawkey(KeyCode::ControlRight), Some(0x67));
+    }
+
+    #[test]
+    fn host_repeat_filter_accepts_unheld_amiga_qualifier_press() {
+        let mut held = [false; 128];
+
+        assert!(!repeated_main_key_should_drop(
+            &held,
+            KeyCode::ShiftRight,
+            ElementState::Pressed,
+            true,
+            false
+        ));
+
+        held[AMIGA_RAWKEY_RIGHT_SHIFT as usize] = true;
+        assert!(repeated_main_key_should_drop(
+            &held,
+            KeyCode::ShiftRight,
+            ElementState::Pressed,
+            true,
+            false
+        ));
+
+        assert!(repeated_main_key_should_drop(
+            &held,
+            KeyCode::F12,
+            ElementState::Pressed,
+            true,
+            false
+        ));
+        assert!(!repeated_main_key_should_drop(
+            &held,
+            KeyCode::ShiftRight,
+            ElementState::Pressed,
+            false,
+            false
+        ));
+        assert!(!repeated_main_key_should_drop(
+            &held,
+            KeyCode::ArrowRight,
+            ElementState::Pressed,
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn amiga_qualifier_transitions_ignore_duplicate_host_events() {
+        let mut held = [false; 128];
+
+        assert!(rawkey_transition_is_duplicate(
+            &held,
+            AMIGA_RAWKEY_LEFT_SHIFT,
+            false
+        ));
+        assert!(!rawkey_transition_is_duplicate(
+            &held,
+            AMIGA_RAWKEY_LEFT_SHIFT,
+            true
+        ));
+
+        held[AMIGA_RAWKEY_LEFT_SHIFT as usize] = true;
+        assert!(rawkey_transition_is_duplicate(
+            &held,
+            AMIGA_RAWKEY_LEFT_SHIFT,
+            true
+        ));
+        assert!(!rawkey_transition_is_duplicate(
+            &held,
+            AMIGA_RAWKEY_LEFT_SHIFT,
+            false
+        ));
+    }
+
+    #[test]
+    fn aggregate_modifier_release_clears_held_amiga_qualifiers() {
+        let mut app = test_app();
+        for rawkey in [
+            AMIGA_RAWKEY_LEFT_SHIFT,
+            AMIGA_RAWKEY_RIGHT_SHIFT,
+            AMIGA_RAWKEY_LEFT_ALT,
+            AMIGA_RAWKEY_RIGHT_ALT,
+        ] {
+            app.handle_amiga_key_event(rawkey, true);
+            assert!(rawkey_is_held(&app.held_rawkeys, rawkey));
+        }
+
+        app.update_host_modifiers(ModifiersState::SHIFT);
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT));
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_ALT));
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
+
+        app.update_host_modifiers(ModifiersState::empty());
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT));
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -462,6 +462,10 @@ fn raw_device_qualifier_rawkey(code: KeyCode) -> Option<u8> {
     }
 }
 
+fn raw_device_qualifier_family_held(held_rawkeys: &[bool; 128], left: u8, right: u8) -> bool {
+    rawkey_is_held(held_rawkeys, left) || rawkey_is_held(held_rawkeys, right)
+}
+
 pub struct App {
     emu: Emulator,
     fb: Vec<u32>,
@@ -527,6 +531,7 @@ pub struct App {
     record_input_path: Option<PathBuf>,
     modifiers: ModifiersState,
     held_rawkeys: [bool; 128],
+    raw_device_held_rawkeys: [bool; 128],
     main_window_focused: bool,
     cursor_pos: Option<(i32, i32)>,
     last_display_cursor_pos: Option<(i32, i32)>,
@@ -820,6 +825,7 @@ impl App {
             record_input_path: record_input,
             modifiers: ModifiersState::empty(),
             held_rawkeys: [false; 128],
+            raw_device_held_rawkeys: [false; 128],
             main_window_focused: false,
             cursor_pos: None,
             last_display_cursor_pos: None,
@@ -4698,6 +4704,7 @@ impl App {
         };
 
         let pressed = event.state == ElementState::Pressed;
+        self.raw_device_held_rawkeys[rawkey_index(rawkey)] = pressed;
         if pressed && (!self.main_window_focused || self.modal_ui_active()) {
             return;
         }
@@ -6966,11 +6973,23 @@ impl App {
 
     fn update_host_modifiers(&mut self, modifiers: ModifiersState) {
         self.modifiers = modifiers;
-        if !modifiers.shift_key() {
+        if !modifiers.shift_key()
+            && !raw_device_qualifier_family_held(
+                &self.raw_device_held_rawkeys,
+                AMIGA_RAWKEY_LEFT_SHIFT,
+                AMIGA_RAWKEY_RIGHT_SHIFT,
+            )
+        {
             self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_LEFT_SHIFT);
             self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_RIGHT_SHIFT);
         }
-        if !modifiers.alt_key() {
+        if !modifiers.alt_key()
+            && !raw_device_qualifier_family_held(
+                &self.raw_device_held_rawkeys,
+                AMIGA_RAWKEY_LEFT_ALT,
+                AMIGA_RAWKEY_RIGHT_ALT,
+            )
+        {
             self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_LEFT_ALT);
             self.release_amiga_rawkey_if_held(AMIGA_RAWKEY_RIGHT_ALT);
         }
@@ -7892,19 +7911,19 @@ mod tests {
         host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_mode_uses_keyboard,
         joystick_toggle_rect, keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv,
         paint_test_screen, parse_amiga_key, pause_button_rect, power_button_rect,
-        present_row_sample, presentation_source_y_offset, raw_device_qualifier_rawkey,
-        rawkey_is_held, rawkey_transition_is_duplicate, reboot_button_rect,
-        repeated_main_key_should_drop, rgba, shot_button_rect, should_render_emulated_frame,
-        standard_window_top_row, status_with_latched_fdd_track, take_integral_mouse_delta,
-        texture_height, texture_width, tv_source_h_bounds, tv_standard_h_shift,
-        volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, JoystickInputMode,
-        KeyboardJoystickHeld, KeyboardJoystickKey, MediaBar, StatusBarView, ToolPanelKind,
-        AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
-        AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF,
-        CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF,
-        HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON, PRESENT_HEIGHT,
-        STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-        TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
+        present_row_sample, presentation_source_y_offset, raw_device_qualifier_family_held,
+        raw_device_qualifier_rawkey, rawkey_is_held, rawkey_transition_is_duplicate,
+        reboot_button_rect, repeated_main_key_should_drop, rgba, shot_button_rect,
+        should_render_emulated_frame, standard_window_top_row, status_with_latched_fdd_track,
+        take_integral_mouse_delta, texture_height, texture_width, tv_source_h_bounds,
+        tv_standard_h_shift, volume_percent_from_pos, volume_slider_track_rect, BarControl,
+        DriveBar, JoystickInputMode, KeyboardJoystickHeld, KeyboardJoystickKey, MediaBar,
+        StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT,
+        AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED,
+        CD_BODY, CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF,
+        FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF,
+        POWER_LED_ON, PRESENT_HEIGHT, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS,
+        STATUS_BG, TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
     };
     use crate::audio::{AudioSink, NullSink};
     use crate::bus::FrontPanelStatus;
@@ -8029,6 +8048,31 @@ mod tests {
     }
 
     #[test]
+    fn raw_device_qualifier_family_reports_physical_side_state() {
+        let mut held = [false; 128];
+        assert!(!raw_device_qualifier_family_held(
+            &held,
+            AMIGA_RAWKEY_LEFT_ALT,
+            AMIGA_RAWKEY_RIGHT_ALT
+        ));
+
+        held[AMIGA_RAWKEY_LEFT_ALT as usize] = true;
+        assert!(raw_device_qualifier_family_held(
+            &held,
+            AMIGA_RAWKEY_LEFT_ALT,
+            AMIGA_RAWKEY_RIGHT_ALT
+        ));
+
+        held[AMIGA_RAWKEY_LEFT_ALT as usize] = false;
+        held[AMIGA_RAWKEY_RIGHT_ALT as usize] = true;
+        assert!(raw_device_qualifier_family_held(
+            &held,
+            AMIGA_RAWKEY_LEFT_ALT,
+            AMIGA_RAWKEY_RIGHT_ALT
+        ));
+    }
+
+    #[test]
     fn amiga_qualifier_transitions_ignore_duplicate_host_events() {
         let mut held = [false; 128];
 
@@ -8078,6 +8122,36 @@ mod tests {
         app.update_host_modifiers(ModifiersState::empty());
         assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT));
         assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
+    }
+
+    #[test]
+    fn raw_device_alt_hold_blocks_altgr_aggregate_cleanup() {
+        let mut app = test_app();
+        app.main_window_focused = true;
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::AltLeft),
+            state: ElementState::Pressed,
+        });
+        app.update_host_modifiers(ModifiersState::ALT);
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_ALT));
+
+        app.update_host_modifiers(ModifiersState::empty());
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_ALT));
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::AltRight),
+            state: ElementState::Pressed,
+        });
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_ALT));
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::AltLeft),
+            state: ElementState::Released,
+        });
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_ALT));
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -417,7 +417,8 @@ use std::time::Instant;
 use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
 use winit::event::{
-    DeviceEvent, DeviceId, ElementState, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent,
+    DeviceEvent, DeviceId, ElementState, KeyEvent, MouseButton, MouseScrollDelta, RawKeyEvent,
+    WindowEvent,
 };
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{KeyCode, ModifiersState, PhysicalKey};
@@ -448,6 +449,16 @@ fn repeated_main_key_should_drop(
     match host_to_amiga_rawkey(code) {
         Some(rawkey) => rawkey_is_held(held_rawkeys, rawkey),
         None => true,
+    }
+}
+
+fn raw_device_qualifier_rawkey(code: KeyCode) -> Option<u8> {
+    match code {
+        KeyCode::ShiftLeft => Some(AMIGA_RAWKEY_LEFT_SHIFT),
+        KeyCode::ShiftRight => Some(AMIGA_RAWKEY_RIGHT_SHIFT),
+        KeyCode::AltLeft => Some(AMIGA_RAWKEY_LEFT_ALT),
+        KeyCode::AltRight => Some(AMIGA_RAWKEY_RIGHT_ALT),
+        _ => None,
     }
 }
 
@@ -516,6 +527,7 @@ pub struct App {
     record_input_path: Option<PathBuf>,
     modifiers: ModifiersState,
     held_rawkeys: [bool; 128],
+    main_window_focused: bool,
     cursor_pos: Option<(i32, i32)>,
     last_display_cursor_pos: Option<(i32, i32)>,
     /// Most recent raw host cursor position (physical pixels) from the last
@@ -808,6 +820,7 @@ impl App {
             record_input_path: record_input,
             modifiers: ModifiersState::empty(),
             held_rawkeys: [false; 128],
+            main_window_focused: false,
             cursor_pos: None,
             last_display_cursor_pos: None,
             last_cursor_phys: None,
@@ -1350,10 +1363,13 @@ impl ApplicationHandler for App {
                     self.request_redraw();
                 }
             }
-            WindowEvent::Focused(false) => {
-                self.volume_dragging = false;
-                self.analyzer_dragging = false;
-                self.set_mouse_captured(false);
+            WindowEvent::Focused(focused) => {
+                self.main_window_focused = focused;
+                if !focused {
+                    self.volume_dragging = false;
+                    self.analyzer_dragging = false;
+                    self.set_mouse_captured(false);
+                }
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 let pressed = state == ElementState::Pressed;
@@ -1535,10 +1551,14 @@ impl ApplicationHandler for App {
         _device_id: DeviceId,
         event: DeviceEvent,
     ) {
-        if let DeviceEvent::MouseMotion { delta } = event {
-            if self.mouse_captured {
-                self.add_host_mouse_delta(delta.0, delta.1);
+        match event {
+            DeviceEvent::MouseMotion { delta } => {
+                if self.mouse_captured {
+                    self.add_host_mouse_delta(delta.0, delta.1);
+                }
             }
+            DeviceEvent::Key(event) => self.handle_raw_device_key_event(event),
+            _ => {}
         }
     }
 
@@ -4667,6 +4687,24 @@ impl App {
             repeat,
             self.ui_key_accepts_repeat(None, code),
         )
+    }
+
+    fn handle_raw_device_key_event(&mut self, event: RawKeyEvent) {
+        let PhysicalKey::Code(code) = event.physical_key else {
+            return;
+        };
+        let Some(rawkey) = raw_device_qualifier_rawkey(code) else {
+            return;
+        };
+
+        let pressed = event.state == ElementState::Pressed;
+        if pressed && (!self.main_window_focused || self.modal_ui_active()) {
+            return;
+        }
+        if self.handle_keyboard_joystick_key(code, pressed) {
+            return;
+        }
+        self.handle_amiga_key_event(rawkey, pressed);
     }
 
     fn activate_analyzer_pick_at(&mut self, kind: ToolPanelKind, pos: (i32, i32)) -> bool {
@@ -7854,18 +7892,19 @@ mod tests {
         host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_mode_uses_keyboard,
         joystick_toggle_rect, keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv,
         paint_test_screen, parse_amiga_key, pause_button_rect, power_button_rect,
-        present_row_sample, presentation_source_y_offset, rawkey_is_held,
-        rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
-        shot_button_rect, should_render_emulated_frame, standard_window_top_row,
-        status_with_latched_fdd_track, take_integral_mouse_delta, texture_height, texture_width,
-        tv_source_h_bounds, tv_standard_h_shift, volume_percent_from_pos, volume_slider_track_rect,
-        BarControl, DriveBar, JoystickInputMode, KeyboardJoystickHeld, KeyboardJoystickKey,
-        MediaBar, StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT,
-        AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED,
-        CD_BODY, CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF,
-        FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF,
-        POWER_LED_ON, PRESENT_HEIGHT, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS,
-        STATUS_BG, TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
+        present_row_sample, presentation_source_y_offset, raw_device_qualifier_rawkey,
+        rawkey_is_held, rawkey_transition_is_duplicate, reboot_button_rect,
+        repeated_main_key_should_drop, rgba, shot_button_rect, should_render_emulated_frame,
+        standard_window_top_row, status_with_latched_fdd_track, take_integral_mouse_delta,
+        texture_height, texture_width, tv_source_h_bounds, tv_standard_h_shift,
+        volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, JoystickInputMode,
+        KeyboardJoystickHeld, KeyboardJoystickKey, MediaBar, StatusBarView, ToolPanelKind,
+        AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
+        AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF,
+        CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF,
+        HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON, PRESENT_HEIGHT,
+        STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
+        TRACK_SEGMENT_ON, VOLUME_FILL, VOLUME_GLYPH_X,
     };
     use crate::audio::{AudioSink, NullSink};
     use crate::bus::FrontPanelStatus;
@@ -7874,8 +7913,8 @@ mod tests {
     use std::cell::RefCell;
     use std::path::PathBuf;
     use std::rc::Rc;
-    use winit::event::ElementState;
-    use winit::keyboard::{KeyCode, ModifiersState};
+    use winit::event::{ElementState, RawKeyEvent};
+    use winit::keyboard::{KeyCode, ModifiersState, PhysicalKey};
 
     /// A typical session: DF0 connected with a disk in, no CD drive.
     fn single_drive_media() -> MediaBar {
@@ -7968,6 +8007,28 @@ mod tests {
     }
 
     #[test]
+    fn raw_device_qualifier_filter_is_limited_to_amiga_modifier_lines() {
+        assert_eq!(
+            raw_device_qualifier_rawkey(KeyCode::ShiftLeft),
+            Some(AMIGA_RAWKEY_LEFT_SHIFT)
+        );
+        assert_eq!(
+            raw_device_qualifier_rawkey(KeyCode::ShiftRight),
+            Some(AMIGA_RAWKEY_RIGHT_SHIFT)
+        );
+        assert_eq!(
+            raw_device_qualifier_rawkey(KeyCode::AltLeft),
+            Some(AMIGA_RAWKEY_LEFT_ALT)
+        );
+        assert_eq!(
+            raw_device_qualifier_rawkey(KeyCode::AltRight),
+            Some(AMIGA_RAWKEY_RIGHT_ALT)
+        );
+        assert_eq!(raw_device_qualifier_rawkey(KeyCode::KeyS), None);
+        assert_eq!(raw_device_qualifier_rawkey(KeyCode::ArrowRight), None);
+    }
+
+    #[test]
     fn amiga_qualifier_transitions_ignore_duplicate_host_events() {
         let mut held = [false; 128];
 
@@ -8017,6 +8078,58 @@ mod tests {
         app.update_host_modifiers(ModifiersState::empty());
         assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT));
         assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
+    }
+
+    #[test]
+    fn raw_device_release_clears_one_side_while_aggregate_modifier_remains() {
+        let mut app = test_app();
+        app.main_window_focused = true;
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::ShiftLeft),
+            state: ElementState::Pressed,
+        });
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::ShiftRight),
+            state: ElementState::Pressed,
+        });
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT));
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::ShiftLeft),
+            state: ElementState::Released,
+        });
+        app.update_host_modifiers(ModifiersState::SHIFT);
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT));
+        assert!(rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::ShiftRight),
+            state: ElementState::Released,
+        });
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_SHIFT));
+    }
+
+    #[test]
+    fn raw_device_alt_right_respects_keyboard_joystick_ownership() {
+        let mut app = test_app();
+        app.main_window_focused = true;
+        app.set_joystick_input_mode(JoystickInputMode::Keyboard);
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::AltRight),
+            state: ElementState::Pressed,
+        });
+        assert!(app.keyboard_joy_held.fire_right_alt);
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
+
+        app.handle_raw_device_key_event(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::AltRight),
+            state: ElementState::Released,
+        });
+        assert!(!app.keyboard_joy_held.fire_right_alt);
+        assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- accept a repeated host key press when the mapped Amiga rawkey is not already held, covering Win32/winit side-specific Shift/Alt modifier press events
- deduplicate Amiga rawkey transitions before they enter the keyboard MCU
- consume raw device key events for host left/right Shift and Alt so one Amiga qualifier can be released while the opposite side remains held
- track raw device held state for qualifier families so aggregate modifier cleanup does not clear held Amiga Alt lines during Windows AltGr-style Right Alt modifier changes
- keep raw qualifier presses gated by window focus/modal UI, while allowing releases to clear held Amiga rawkeys; preserve keyboard joystick ownership of Right Alt

## Verification
- cargo test raw_device
- cargo test qualifier
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features --locked -- -D warnings

## Windows test build
Latest successful Windows workflow for commit `f5e65013b0375077215ff329d293788006c092ad`:
- https://github.com/LinuxJedi/Copperline/actions/runs/28469896587
- artifact: `copperline-windows`
- package inside artifact: `Copperline-0.9.0-win-x64.zip`
- artifact digest: `sha256:60f03608bf8193846ee31f04081ae9841866214bde097efbe4e9665d41d1646e`
- package SHA-256: `3856933ca22815587f19c9ddd8ad178f2ce04ff33e1ee329d61318c58419f604`
- 

Fixes #56 