### PR TITLE
Zipped floppy image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ against real hardware.
   with an optional 68881/68882 FPU (default-on for the 68040).
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
-  (ADF / ADZ / DMS, read-only SCP), Gayle IDE, A2091 SCSI, and CDTV/CD32 CD.
+  (ADF / ADZ / ZIP / DMS, read-only SCP), Gayle IDE, A2091 SCSI, and CDTV/CD32
+  CD.
 - **Tooling**: an in-window debugger, an interactive chip-bus frame
   analyzer, remote GDB support, deterministic save states, input
   recording/replay, and headless screenshot/frame-dump capture -- the

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -249,8 +249,9 @@ floppy_sounds_volume = 100
 # Optional floppy drives. DF0 is always connected; set [floppy] drives
 # to wire empty external mechanisms as well (1-4 total drives). Missing
 # [floppy.dfN] tables mean no disk in that drive. Supported images:
-# DD ADF (901120 bytes), ADZ/gzip, DMS, UAE extended ADF, and read-only
-# SCP flux captures. DMS/gzip/SCP are always treated as write-protected.
+# DD ADF (901120 bytes), ADZ/gzip, single file ZIP archives, DMS, UAE extended
+# ADF, and read-only SCP flux captures. DMS/gzip/SCP are always treated as
+# write-protected.
 #
 # [floppy]
 # drives = 2

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -361,10 +361,10 @@ also connects that drive automatically, so existing configs that name
 `[floppy.df1]` .. `[floppy.df3]` keep working.
 
 Supported image formats: standard 901120-byte DD ADF, gzip-compressed
-images (ADZ), DMS archives, UAE extended ADF, and read-only SCP flux
-images. DMS, gzip, and SCP images are decoded at load time and always
-treated as write-protected; set `write_protected = false` on a plain ADF to
-allow write-through updates to the image file.
+images (ADZ), single file ZIP archives, DMS archives, UAE extended ADF, and
+read-only SCP flux images. DMS, gzip, and SCP images are decoded at load time
+and always treated as write-protected; set `write_protected = false` on a plain
+ADF to allow write-through updates to the image file.
 
 A `paths` playlist lets multi-disk software that only drives DF0: run
 without a second drive: the first entry is the boot disk and the disk-swap

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -169,8 +169,8 @@ rom = "KICK13.ROM"
 path = "MyGame.adf"
 ```
 
-Copperline accepts plain ADF images, gzip-compressed images, DMS archives,
-UAE extended ADFs, and read-only SCP flux images.
+Copperline accepts plain ADF images, gzip-compressed images, single file ZIP
+archives, DMS archives, UAE extended ADFs, and read-only SCP flux images.
 
 ## Example configuration
 

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -195,8 +195,8 @@ DSKDAT, and DMA into chip RAM behave as Paula documents. Non-WORDSYNC read
 DMA drains Paula's recovered 16-bit disk word phase even when DSKLEN is
 armed between disk-word boundaries; WORDSYNC is the explicit mode that
 realigns framing to a matched sync word before transfer. Supported image
-formats: ADF (read/write), gzip ADZ, DMS (decompressed by `dms.rs`), UAE
-extended ADF, and read-only SCP flux images.
+formats: ADF (read/write), gzip ADZ, single file ZIP, DMS (decompressed by
+ `dms.rs`), UAE extended ADF, and read-only SCP flux images.
 
 Standard ADF and AmigaDOS tracks are synthesized as one PAL-sized
 revolution: 11 sectors occupy 5984 MFM words, and the generated revolution

--- a/src/config.rs
+++ b/src/config.rs
@@ -2095,6 +2095,7 @@ fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
         )
     })?;
     if sig[..2] == [0x1F, 0x8B]
+        || sig[..4] == [0x50, 0x4b, 0x03, 0x04]
         || &sig[..3] == b"SCP"
         || &sig[..4] == b"DMS!"
         || &sig == b"UAE-1ADF"
@@ -2104,7 +2105,8 @@ fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
     }
 
     bail!(
-        "floppy.df{} image {} is {} bytes, expected {} bytes (standard DD ADF), gzip-compressed supported image, UAE extended ADF, SCP, or DMS",
+        "floppy.df{} image {} is {} bytes, expected {} bytes (standard DD ADF),
+        gzip-compressed supported image, UAE extended ADF, SCP, DMS or single file ZIP",
         idx,
         path.display(),
         meta.len(),

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -11,9 +11,10 @@ use crate::chipset::paula::PAULA_CLOCK_HZ;
 use crate::config::{FloppyConfig, FloppyDriveConfig};
 use crate::dms;
 use anyhow::{bail, ensure, Context, Result};
-use flate2::read::GzDecoder;
+use flate2::read::{DeflateDecoder, GzDecoder};
+use flate2::CrcReader;
 use log::{debug, warn};
-use std::io::Read;
+use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 
 pub const CYLINDERS: usize = 80;
@@ -93,6 +94,7 @@ const UAE_EXT2_SIGNATURE: &[u8; 8] = b"UAE-1ADF";
 const IPF_SIGNATURE: &[u8; 4] = b"CAPS";
 const SCP_SIGNATURE: &[u8; 3] = b"SCP";
 const GZIP_SIGNATURE: &[u8; 2] = &[0x1F, 0x8B];
+const ZIP_SIGNATURE: &[u8; 4] = &[0x50, 0x4b, 0x03, 0x04];
 const STANDARD_EXTERNAL_DRIVE_ID: u32 = 0xFFFF_FFFF;
 const SCP_TRACK_TABLE_OFFSET: usize = 0x10;
 const SCP_EXTENDED_TRACK_TABLE_OFFSET: usize = 0x80;
@@ -1775,6 +1777,9 @@ impl FloppyImage {
         let (data, write_protected, legacy_extended_adf) = if packed.starts_with(GZIP_SIGNATURE) {
             let unpacked = decode_gzip_floppy_image(&packed)?;
             decode_floppy_payload(unpacked, true, &config.path)?
+        } else if packed.starts_with(ZIP_SIGNATURE) {
+            let unpacked = decode_zip_floppy_image(&packed)?;
+            decode_floppy_payload(unpacked, true, &config.path)?
         } else {
             decode_floppy_payload(packed, config.write_protected, &config.path)?
         };
@@ -1910,6 +1915,72 @@ fn decode_gzip_floppy_image(data: &[u8]) -> Result<Vec<u8>> {
         .read_to_end(&mut unpacked)
         .context("decompressing gzip-compressed floppy image")?;
     Ok(unpacked)
+}
+
+fn decode_zip_floppy_image(data: &[u8]) -> Result<Vec<u8>> {
+    ensure!(data.starts_with(ZIP_SIGNATURE), "missing zip signature");
+    let mut cursor = Cursor::new(data);
+    let mut u16buf = [0u8; 2];
+    let mut u32buf = [0u8; 4];
+
+    // Skip to compression method (at offset 8 in local file header)
+    cursor.set_position(8);
+    cursor.read_exact(&mut u16buf)?;
+    let compression = u16::from_le_bytes(u16buf);
+
+    // Skip to CRC-32 (at offset 14 in local file header)
+    cursor.set_position(14);
+    cursor.read_exact(&mut u32buf)?;
+    let expected_crc = u32::from_le_bytes(u32buf);
+
+    // Skip to uncompressed size (at offset 22 in local file header)
+    cursor.set_position(22);
+    cursor.read_exact(&mut u32buf)?;
+    let uncomp_size = u32::from_le_bytes(u32buf);
+    ensure!(
+        uncomp_size as usize == ADF_SIZE,
+        "invalid ADF file size in ZIP archive"
+    );
+
+    // Skip to file name length and extra field length
+    cursor.set_position(26);
+    cursor.read_exact(&mut u16buf)?;
+    let file_name_length = u16::from_le_bytes(u16buf);
+    cursor.read_exact(&mut u16buf)?;
+    let extra_field_length = u16::from_le_bytes(u16buf);
+
+    // Skip the file name and extra field to reach the compressed data
+    cursor.set_position((30 + file_name_length + extra_field_length) as u64);
+
+    let mut decompressed = vec![0; ADF_SIZE];
+
+    let calculated_crc = match compression {
+        8 => {
+            // Deflate compression
+            let mut decode_reader = CrcReader::new(DeflateDecoder::new(cursor));
+            decode_reader
+                .read_exact(&mut decompressed)
+                .context("deflating zipped floppy image")?;
+            decode_reader.crc().sum()
+        }
+        0 => {
+            // No compression
+            let mut reader = CrcReader::new(cursor);
+            reader
+                .read_exact(&mut decompressed)
+                .context("unarchiving zipped floppy image")?;
+            reader.crc().sum()
+        }
+        n => {
+            bail!("Unsupported compression method in zip archive: {n}");
+        }
+    };
+    // Verify CRC32
+    if calculated_crc != expected_crc {
+        bail!("checksum error in zip archive: expected: {expected_crc} != calculated: {calculated_crc}");
+    }
+
+    Ok(decompressed)
 }
 
 fn decode_uae_extended_adf(data: &[u8]) -> Result<FloppyImageData> {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5437,9 +5437,10 @@ impl App {
             LauncherField::Df0Image
             | LauncherField::Df1Image
             | LauncherField::Df2Image
-            | LauncherField::Df3Image => {
-                dialog.add_filter("Floppy images", &["adf", "adz", "dms", "scp", "gz", "ipf"])
-            }
+            | LauncherField::Df3Image => dialog.add_filter(
+                "Floppy images",
+                &["adf", "adz", "dms", "scp", "gz", "ipf", "zip"],
+            ),
             LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "bin"]),
             LauncherField::Cd32Nvram => dialog.add_filter("NVRAM images", &["bin", "nv", "sav"]),
             _ => dialog.add_filter("Hard disk images", &["hdf", "img", "bin"]),
@@ -6663,7 +6664,10 @@ impl App {
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
             .set_title(format!("Load DF{drive_idx} disk image(s)"))
-            .add_filter("Amiga disk images", &["adf", "adz", "dms", "scp", "gz"])
+            .add_filter(
+                "Amiga disk images",
+                &["adf", "adz", "dms", "scp", "gz", "zip"],
+            )
             .pick_files();
 
         // The modal file dialog blocks this (the main/emulation) thread, so


### PR DESCRIPTION
This change adds support for ADF-images in zip files. Many collections, like TOSEC, use that format, so it makes sense to support it. The implementation is quite simple: Only the local file header is parsed, not the central directory. Only the first file of the ZIP-archive is used, which is usually sufficient.