### PR TITLE
Code cleanup pass: robustness fixes, dedup, and hot-path tidy-ups

### DIFF
--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -32,7 +32,7 @@
 //! CD-DA sectors into the host mixer ring (44.1 kHz, the mixer's native
 //! rate) and sends the drive's start/end notification packets.
 
-use crate::cdrom::{CdImage, DATA_SECTOR_BYTES, LEADIN_SECTORS};
+use crate::cdrom::{to_bcd, CdImage, DATA_SECTOR_BYTES, LEADIN_SECTORS};
 use crate::chipset::paula::CdAudioRing;
 
 pub const AKIKO_BASE: u32 = 0x00B8_0000;
@@ -88,10 +88,6 @@ fn get_long_byte(value: u32, offset: u32) -> u8 {
 fn put_long_byte(value: &mut u32, offset: u32, byte: u8) {
     let shift = 8 * (3 - offset);
     *value = (*value & !(0xFF << shift)) | (u32::from(byte) << shift);
-}
-
-fn to_bcd(v: u8) -> u8 {
-    ((v / 10) << 4) | (v % 10)
 }
 
 fn from_bcd(v: u8) -> u32 {
@@ -1216,7 +1212,21 @@ impl Akiko {
         let Some(disc) = self.disc.as_mut() else {
             return;
         };
-        // Use the highest available slot (Lotus Trilogy depends on it).
+        // Akiko has no per-sector destination register: the driver arms a
+        // 16-bit mask (PBX) of available 4 KB buffers and the engine
+        // consumes one buffer per incoming sector, clearing its bit. Fill
+        // order is the highest armed buffer first (priority-encode from
+        // bit 15). This ordering is empirical, not from a datasheet:
+        // WinUAE observes it on real CD32 silicon (its own comment cites
+        // the same regression title as this file's tests), but the only
+        // independent reverse-engineering (MAME) instead maps the buffer
+        // to (lba - lba_start) & 0x0F, i.e. sector-ordinal order gated by
+        // the arm mask -- not highest-bit-first. No HDL/datasheet ground
+        // truth exists to settle it (see docs/internals for chip-model
+        // cross-checking method). Keep highest-bit-first since WinUAE is
+        // the more hardware-validated CD32 reference, but treat this as a
+        // model, not confirmed hardware.
+        // TODO: verify buffer-fill order against real Akiko silicon.
         let slot = (15 - self.pbx.leading_zeros().saturating_sub(16)) & 15;
         let slot = if self.pbx & (1 << slot) != 0 {
             slot
@@ -1249,13 +1259,9 @@ impl Akiko {
         raw[3] = (self.sector_counter & 31) as u8;
 
         let base = self.addressdata + slot * 4096;
-        for (i, byte) in raw.iter().enumerate() {
-            chip_put_byte(chip_ram, base + i as u32, *byte);
-        }
+        chip_put_bytes(chip_ram, base, &raw);
         // Clear the slot's subcode area.
-        for i in 0..73 * 2 {
-            chip_put_byte(chip_ram, base + 0xC00 + i, 0);
-        }
+        chip_put_bytes(chip_ram, base + 0xC00, &[0u8; 73 * 2]);
         self.pbx &= !(1 << slot);
         self.intreq |= CDINT_PBX;
 
@@ -1263,13 +1269,11 @@ impl Akiko {
             // Sector-synchronous subcode delivery: zeroed payload with
             // the hardware's end markers.
             self.subcodeoffset = if self.subcodeoffset >= 128 { 0 } else { 128 };
-            for i in 0..96 {
-                chip_put_byte(
-                    chip_ram,
-                    self.subcode_address + u32::from(self.subcodeoffset) + i,
-                    0,
-                );
-            }
+            chip_put_bytes(
+                chip_ram,
+                self.subcode_address + u32::from(self.subcodeoffset),
+                &[0u8; 96],
+            );
             let tail = self.subcode_address + u32::from(self.subcodeoffset) + 96;
             chip_put_byte(chip_ram, tail, 0xFF);
             chip_put_byte(chip_ram, tail + 1, 0xFF);
@@ -1346,6 +1350,25 @@ fn chip_put_byte(chip_ram: &mut [u8], addr: u32, value: u8) {
         return;
     }
     chip_ram[(addr as usize) & (len - 1)] = value;
+}
+
+/// Like `chip_put_byte` but for a contiguous run: a single `copy_from_slice`
+/// in the common (non-wrapping) case instead of one masked store per byte,
+/// used for sector/subcode DMA where `bytes` can be a couple of KB.
+fn chip_put_bytes(chip_ram: &mut [u8], addr: u32, bytes: &[u8]) {
+    let len = chip_ram.len();
+    if len == 0 || bytes.is_empty() {
+        return;
+    }
+    let start = (addr as usize) & (len - 1);
+    let end = start + bytes.len();
+    if end <= len {
+        chip_ram[start..end].copy_from_slice(bytes);
+    } else {
+        let first_len = len - start;
+        chip_ram[start..].copy_from_slice(&bytes[..first_len]);
+        chip_put_bytes(chip_ram, 0, &bytes[first_len..]);
+    }
 }
 
 fn build_toc(disc: &CdImage) -> Vec<TocEntry> {
@@ -1828,6 +1851,9 @@ mod tests {
 
     #[test]
     fn data_read_command_dmas_sectors_into_pbx_slots() {
+        // Regression example: Lotus Trilogy's CD32 loader arms multiple
+        // PBX slots ahead of the data and depends on them filling highest
+        // slot first (see the comment on `run_sector_read`).
         let mut ring = CdAudioRing::default();
         let mut chip = vec![0u8; 256 * 1024];
         let mut akiko = Akiko::new();

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5,9 +5,8 @@
 //! typed read/write methods for memory-mapped devices.
 
 use crate::chipset::agnus::{
-    ddf_hard_bounds, sprite_dma_disabled_by_bitplane_ddf, Agnus, AgnusRevision, AgnusTick,
-    VideoStandard, BEAMCON0_DUAL, BEAMCON0_HARDDIS, COLORCLOCKS_PER_LINE,
-    NTSC_LONG_COLORCLOCKS_PER_LINE,
+    sprite_dma_disabled_by_bitplane_ddf, Agnus, AgnusRevision, AgnusTick, VideoStandard,
+    BEAMCON0_DUAL, BEAMCON0_HARDDIS, COLORCLOCKS_PER_LINE, NTSC_LONG_COLORCLOCKS_PER_LINE,
 };
 use crate::chipset::blitter::Blitter;
 use crate::chipset::cia::{
@@ -28,7 +27,6 @@ use crate::memory::Memory;
 use crate::rtc::Msm6242Rtc;
 use crate::video::{beam::BeamEventIndex, FrameGeometry, FB_HEIGHT, FB_WIDTH, MAX_VISIBLE_LINES};
 use log::trace;
-use std::collections::HashSet;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
@@ -259,7 +257,6 @@ const CLXDAT_SPRITE_PLAYFIELD_MASK: u16 = 0x01FE;
 const CLXDAT_SPRITE_SPRITE_MASK: u16 = 0x7E00;
 const BITPLANE_DDF_HARD_START: u16 = 0x0018;
 const BITPLANE_DDF_HARD_STOP: u16 = 0x00D8;
-const OCS_LORES_BPL_SEQUENCE: [usize; 8] = [8, 4, 6, 2, 7, 3, 5, 1];
 const SPRITE_DMA_PAIR_CAPTURE_HPOS: [u32; 4] = [0x018, 0x020, 0x028, 0x030];
 const NANOS_PER_SECOND: u128 = 1_000_000_000;
 const VIDEO_FETCH_TIMING_SAMPLE_RATE: u128 = 128;
@@ -1867,6 +1864,10 @@ impl Bus {
             dbg_ext_cck_x100: external_access_cck_x100_setting(),
         };
         bus.configure_chip_dma_masks();
+        // Re-derive the per-frame capture buffers from the same helper the
+        // reset paths use, rather than trusting the struct literal above to
+        // stay in lockstep with it by hand.
+        bus.reset_frame_capture_buffers();
         bus
     }
 
@@ -2039,6 +2040,48 @@ impl Bus {
         self.keyboard.next_event_cck()
     }
 
+    /// Reset the per-frame render/capture buffers to their empty starting
+    /// state. Shared by a real hardware reset (`reset_for_keyboard_reset`)
+    /// and the state-load path (`reset_transient_video_after_state_load`)
+    /// for exactly the fields those two callers already reset to
+    /// identical values, so a new capture-buffer field only has to be
+    /// listed here once instead of drifting between the two copies.
+    ///
+    /// Deliberately NOT included: `current_frame_render_blocked` and
+    /// `sprite_dma_frame_start_ptr` (the two callers legitimately disagree
+    /// on their value -- a state load derives them from the just-restored
+    /// beam/pointer state instead of zeroing them), and the fields only
+    /// `reset_for_keyboard_reset` touches (palettes, collision tracking,
+    /// frame geometry, DMA pointers/delays) because those are either
+    /// power-on-only resets or are themselves part of the serialized save
+    /// state and must not be clobbered after a state load.
+    fn reset_frame_capture_buffers(&mut self) {
+        self.last_frame_render_base = None;
+        self.last_frame_render_events.clear();
+        self.last_frame_beam_bottom_palette_events.clear();
+        self.current_frame_chip_ram.clear();
+        self.current_frame_chip_ram
+            .extend_from_slice(&self.mem.chip_ram);
+        self.last_frame_chip_ram.clear();
+        self.current_frame_chip_ram_writes.clear();
+        self.last_frame_chip_ram_writes.clear();
+        self.current_frame_bitplane_rows = empty_captured_bitplane_rows();
+        self.last_frame_bitplane_rows = empty_captured_bitplane_rows();
+        self.current_frame_sprite_lines.clear();
+        clear_captured_sprite_lines_by_y(&mut self.current_frame_sprite_lines_by_y);
+        self.current_frame_sprite_collision_sources = empty_sprite_collision_sources();
+        self.last_frame_sprite_lines.clear();
+        self.current_frame_held_sprites = [None; 8];
+        self.last_frame_held_sprites = [None; 8];
+        self.current_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
+        self.last_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
+        self.current_frame_sprite_dma_observed = false;
+        self.last_frame_sprite_dma_observed = false;
+        self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
+        self.current_frame_bus_trace.clear();
+        self.last_frame_bus_trace = None;
+    }
+
     pub fn reset_for_keyboard_reset(&mut self) {
         let video_standard = self.agnus.video_standard();
         let agnus_revision = self.agnus.revision();
@@ -2089,7 +2132,6 @@ impl Bus {
         self.cpu_palette_target_writes = 0;
         self.cpu_palette_target_beam = None;
         self.current_frame_render_base = RenderRegisterSnapshot::default();
-        self.last_frame_render_base = None;
         self.current_frame_render_events.clear();
         self.current_frame_collision_events.clear();
         self.current_frame_collision_control_events.clear();
@@ -2099,33 +2141,14 @@ impl Bus {
         self.current_frame_collision_bpldat_index = None;
         self.current_frame_collision_sprite_index = None;
         self.current_frame_collision_may_have_dual_playfield = false;
-        self.last_frame_render_events.clear();
         self.beam_bottom_palette_events.clear();
         self.pending_beam_bottom_palette_events.clear();
-        self.last_frame_beam_bottom_palette_events.clear();
         self.current_frame_beam_top_palette = self.beam_top_palette;
         self.last_frame_beam_top_palette = Palette::new();
         self.last_frame_beam_top_palette_end = Palette::new();
         self.last_frame_beam_bottom_palette = Palette::new();
         self.last_frame_beam_bottom_palette_valid = false;
-        self.current_frame_chip_ram.clear();
-        self.current_frame_chip_ram
-            .extend_from_slice(&self.mem.chip_ram);
-        self.last_frame_chip_ram.clear();
-        self.current_frame_chip_ram_writes.clear();
-        self.last_frame_chip_ram_writes.clear();
-        self.current_frame_bitplane_rows = empty_captured_bitplane_rows();
-        self.last_frame_bitplane_rows = empty_captured_bitplane_rows();
-        self.current_frame_sprite_lines.clear();
-        clear_captured_sprite_lines_by_y(&mut self.current_frame_sprite_lines_by_y);
-        self.current_frame_sprite_collision_sources = empty_sprite_collision_sources();
-        self.last_frame_sprite_lines.clear();
-        self.current_frame_held_sprites = [None; 8];
-        self.last_frame_held_sprites = [None; 8];
-        self.current_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
-        self.last_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
-        self.current_frame_sprite_dma_observed = false;
-        self.last_frame_sprite_dma_observed = false;
+        self.reset_frame_capture_buffers();
         self.current_frame_display_snapshot_taken = false;
         self.current_frame_render_blocked = false;
         self.current_frame_visible_start_vpos = RENDER_VISIBLE_START_VPOS;
@@ -2135,8 +2158,6 @@ impl Bus {
         self.lazy_collision_vpos = RENDER_VISIBLE_START_VPOS;
         self.lazy_collision_hpos = RENDER_COPPER_WAIT_HPOS_FB0;
         self.collision_tracking_active = false;
-        self.current_frame_bus_trace.clear();
-        self.last_frame_bus_trace = None;
         self.cpu_bus_arbitration_enabled = false;
         self.blitter_slowdown_cpu_misses = 0;
         self.slice_bus_advanced_cck = 0;
@@ -2148,7 +2169,6 @@ impl Bus {
         self.display_dma_bplpt = [0; 8];
         self.display_dma_sprpt = [0; 8];
         self.sprite_dma_frame_start_ptr = [0; 8];
-        self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
         self.display_dma_clipped_rows_advanced = false;
         self.bitplane_dmacon_delay = None;
         self.bitplane_bplcon0_delay = None;
@@ -2256,32 +2276,9 @@ impl Bus {
     }
 
     pub(crate) fn reset_transient_video_after_state_load(&mut self) {
-        self.last_frame_render_base = None;
-        self.last_frame_render_events.clear();
-        self.last_frame_beam_bottom_palette_events.clear();
-        self.current_frame_chip_ram.clear();
-        self.current_frame_chip_ram
-            .extend_from_slice(&self.mem.chip_ram);
-        self.last_frame_chip_ram.clear();
-        self.current_frame_chip_ram_writes.clear();
-        self.last_frame_chip_ram_writes.clear();
-        self.current_frame_bitplane_rows = empty_captured_bitplane_rows();
-        self.last_frame_bitplane_rows = empty_captured_bitplane_rows();
-        self.current_frame_sprite_lines.clear();
-        self.last_frame_sprite_lines.clear();
-        clear_captured_sprite_lines_by_y(&mut self.current_frame_sprite_lines_by_y);
-        self.current_frame_sprite_collision_sources = empty_sprite_collision_sources();
-        self.current_frame_held_sprites = [None; 8];
-        self.last_frame_held_sprites = [None; 8];
-        self.current_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
-        self.last_frame_sprite_display_enable_x_by_y = empty_sprite_display_enable_x_by_y();
-        self.current_frame_sprite_dma_observed = false;
-        self.last_frame_sprite_dma_observed = false;
+        self.reset_frame_capture_buffers();
         self.current_frame_render_blocked = self.agnus.vpos != 0 || self.agnus.hpos != 0;
         self.sprite_dma_frame_start_ptr = self.display_dma_sprpt;
-        self.display_dma_sprite_state = [DisplaySpriteDmaState::default(); 8];
-        self.current_frame_bus_trace.clear();
-        self.last_frame_bus_trace = None;
     }
 
     pub fn emulated_seconds(&self) -> f64 {
@@ -3535,10 +3532,10 @@ impl Bus {
         if self.cia_a.irq_line_asserted() {
             self.paula.intreq |= INT_PORTS;
         }
-        match eff {
-            CiaSideEffect::KeyboardHandshakeStart => self.keyboard.amiga_kdat_edge(true),
-            CiaSideEffect::KeyboardHandshakeEnd => self.keyboard.amiga_kdat_edge(false),
-            _ => {}
+        match eff.keyboard_handshake {
+            Some(true) => self.keyboard.amiga_kdat_edge(true),
+            Some(false) => self.keyboard.amiga_kdat_edge(false),
+            None => {}
         }
         if reg == REG_PRA || reg == REG_DDRA {
             // CIA-A PRA bit 1 is /LED. On post-A1000 Amigas this line also
@@ -6609,7 +6606,12 @@ impl Bus {
         }
     }
 
-    fn begin_new_beam_frame(&mut self) {
+    /// The `COPPERLINE_DIAG_*` frame-start dumps (bpl-dma summary, slotmap
+    /// dump, copper-list length walk, BUF0/sprite snapshots), split out of
+    /// `begin_new_beam_frame` so that function's real frame-boundary
+    /// bookkeeping is reviewable on its own instead of interleaved with
+    /// ~200 lines of opt-in diagnostic logging.
+    fn diag_log_frame_start(&mut self) {
         if crate::envcfg::flag("COPPERLINE_DIAG_DISPLAY") {
             let lines: Vec<usize> = self
                 .dbg_bpl_cck
@@ -6827,6 +6829,10 @@ impl Bus {
                 );
             }
         }
+    }
+
+    fn begin_new_beam_frame(&mut self) {
+        self.diag_log_frame_start();
         // Only maintain the collision latch across the frame boundary once
         // software has shown it reads CLXDAT. Until then the full-frame scan is
         // unobservable work; see `collision_tracking_active`.
@@ -7765,7 +7771,15 @@ impl Bus {
             state.control.is_some() || state.next_ptr.is_none();
         let mut descriptor_loaded_after_stop_this_line = false;
 
-        let mut visited_descriptor_ptrs = HashSet::new();
+        // Loop-detection scratch for the descriptor chain below. A plain
+        // Vec with a linear `contains` check is used instead of a HashSet:
+        // chains are almost always 1-2 descriptors long in practice (this
+        // runs per active sprite per DMA-pair capture point per scanline),
+        // so a linear scan avoids both the heap allocation pattern and the
+        // hashing overhead a HashSet would pay for such a tiny set, while
+        // keeping the exact same "any previously-visited pointer" cycle
+        // check (not just a fixed lookback window).
+        let mut visited_descriptor_ptrs: Vec<u32> = Vec::new();
         loop {
             if state.terminated {
                 self.display_dma_sprite_state[sprite] = state;
@@ -7849,13 +7863,14 @@ impl Bus {
 
             let descriptor_ptr =
                 state.next_ptr.unwrap_or(self.display_dma_sprpt[sprite]) & ram_mask & !1;
-            if !visited_descriptor_ptrs.insert(descriptor_ptr) {
+            if visited_descriptor_ptrs.contains(&descriptor_ptr) {
                 state.terminated = true;
                 state.data_dma_active = false;
                 state.last_line = None;
                 self.display_dma_sprite_state[sprite] = state;
                 return None;
             }
+            visited_descriptor_ptrs.push(descriptor_ptr);
 
             // AGA wide fetches also widen the control-word slots: POS is the
             // first word of the first fetch, CTL the first word of the second.
@@ -8698,29 +8713,28 @@ fn bitplane_words_per_row(
     words.max(1)
 }
 
+// These fetch-mode helpers used to be independently-maintained twins of
+// the agnus.rs functions of the same name/shape; they now delegate to the
+// single agnus.rs implementation (kept as thin wrappers here so none of
+// this file's many call sites had to change).
 fn bitplane_shres(bplcon0: u16) -> bool {
-    bplcon0 & BPLCON0_SHRES != 0
+    crate::chipset::agnus::bitplane_shres(bplcon0)
 }
 
 fn bitplane_hires(bplcon0: u16) -> bool {
-    bplcon0 & 0x8000 != 0 && !bitplane_shres(bplcon0)
+    crate::chipset::agnus::bitplane_hires(bplcon0)
 }
 
-// Capture-side twins of the agnus fetch-mode helpers (see agnus.rs).
 fn bitplane_fetch_quantum(fmode: u16) -> u32 {
-    match fmode & 0x0003 {
-        0 => 1,
-        3 => 4,
-        _ => 2,
-    }
+    crate::chipset::agnus::bitplane_fetch_quantum(fmode)
 }
 
 fn bitplane_fetch_period(bplcon0: u16, fmode: u16) -> u32 {
-    bitplane_fetch_cck_per_word(bplcon0) * bitplane_fetch_quantum(fmode)
+    crate::chipset::agnus::bitplane_fetch_period(bplcon0, fmode)
 }
 
 fn bitplane_fetch_unit(bplcon0: u16, fmode: u16) -> u32 {
-    bitplane_fetch_period(bplcon0, fmode).max(8)
+    crate::chipset::agnus::bitplane_fetch_unit(bplcon0, fmode)
 }
 
 fn plane_mask_for_count(nplanes: usize) -> u16 {
@@ -8750,13 +8764,7 @@ fn sprite_fetch_quantum(fmode: u16) -> u32 {
 }
 
 fn bitplane_fetch_cck_per_word(bplcon0: u16) -> u32 {
-    if bitplane_shres(bplcon0) {
-        2
-    } else if bitplane_hires(bplcon0) {
-        4
-    } else {
-        8
-    }
+    crate::chipset::agnus::bitplane_fetch_cck_per_word(bplcon0)
 }
 
 fn chip_dma_addr_mask(chip_ram_len: usize) -> u32 {
@@ -8794,22 +8802,8 @@ fn effective_ddf_hpos(revision: AgnusRevision, bplcon0: u16, raw: u16) -> u16 {
     effective_ddf_start_hpos_raw(revision, bplcon0, raw)
 }
 
-fn ddf_register_mask(revision: AgnusRevision) -> u16 {
-    if matches!(revision, AgnusRevision::Ocs) {
-        0x00FC
-    } else {
-        0x00FE
-    }
-}
-
 fn effective_ddf_start_hpos_raw(revision: AgnusRevision, bplcon0: u16, raw: u16) -> u16 {
-    let _ = bplcon0;
-    raw & ddf_register_mask(revision)
-}
-
-fn effective_ddf_stop_hpos(revision: AgnusRevision, bplcon0: u16, raw: u16) -> u16 {
-    let _ = bplcon0;
-    raw & ddf_register_mask(revision)
+    crate::chipset::agnus::effective_bitplane_ddf_start_hpos(revision, bplcon0, raw)
 }
 
 fn effective_ddf_start_hpos(revision: AgnusRevision, bplcon0: u16, raw: u16) -> u16 {
@@ -8828,30 +8822,13 @@ fn effective_ddf_window(
     ddfstop: u16,
     harddis: bool,
 ) -> Option<(u16, u16)> {
-    let (hard_start, hard_stop) = ddf_hard_bounds(harddis);
-    let start = effective_ddf_start_hpos_raw(revision, bplcon0, ddfstrt);
-    let mut stop = effective_ddf_stop_hpos(revision, bplcon0, ddfstop);
-    if start == 0 || start > hard_stop {
-        return None;
-    }
-    if matches!(revision, AgnusRevision::Ocs) && stop == start {
-        stop = hard_stop;
-    }
-    let start = start.max(hard_start);
-    let stop = stop.min(hard_stop);
-    (stop >= start).then_some((start, stop))
+    crate::chipset::agnus::effective_bitplane_ddf_window(
+        revision, bplcon0, ddfstrt, ddfstop, harddis,
+    )
 }
 
 fn bitplane_fetch_order(bplcon0: u16, plane: usize) -> u32 {
-    if bitplane_hires(bplcon0) || bitplane_shres(bplcon0) {
-        return plane as u32;
-    }
-
-    let plane_num = plane + 1;
-    OCS_LORES_BPL_SEQUENCE
-        .iter()
-        .position(|&candidate| candidate == plane_num)
-        .unwrap_or(7) as u32
+    crate::chipset::agnus::bitplane_fetch_order(bplcon0, plane)
 }
 
 fn read_chip_word_wrapping(ram: &[u8], addr: u32) -> u16 {

--- a/src/cdrom.rs
+++ b/src/cdrom.rs
@@ -260,7 +260,19 @@ impl CdImage {
                 let region_end_sector = match file_tracks.get(j + 1) {
                     Some(next) => next.index0.unwrap_or_else(|| next.index1.unwrap()),
                     None => {
-                        let remaining = file_len - byte_offset;
+                        // Earlier tracks' INDEX values come straight from
+                        // the (untrusted) cue sheet; a corrupt/crafted one
+                        // can claim more bytes than the file actually has,
+                        // which would underflow this subtraction.
+                        let Some(remaining) = file_len.checked_sub(byte_offset) else {
+                            bail!(
+                                "{}: track {} starts {} bytes past the end of {}",
+                                cue_path.display(),
+                                track.number,
+                                byte_offset.saturating_sub(file_len),
+                                file_names[file_index],
+                            );
+                        };
                         if !remaining.is_multiple_of(track.kind.sector_bytes() as u64) {
                             bail!(
                                 "{}: track {} does not end on a sector boundary",
@@ -451,7 +463,7 @@ impl CdImage {
     }
 }
 
-fn to_bcd(v: u8) -> u8 {
+pub(crate) fn to_bcd(v: u8) -> u8 {
     ((v / 10) << 4) | (v % 10)
 }
 
@@ -659,6 +671,37 @@ mod tests {
         let _ = std::fs::remove_file(&bin1);
         let _ = std::fs::remove_file(&bin2);
         let _ = std::fs::remove_file(&bin3);
+    }
+
+    #[test]
+    fn track_index_claiming_more_than_the_file_holds_is_rejected_not_a_panic() {
+        // Track 1's INDEX 01 (used as track 2's region start, i.e. track
+        // 1's region end) claims a sector far beyond what the shared file
+        // actually contains. That inflates `byte_offset` past `file_len`
+        // by the time the last track computes its remaining-bytes span,
+        // which must be rejected as a malformed cue sheet instead of
+        // underflowing the subtraction.
+        let cue = temp_path("overrun.cue");
+        let bin = temp_path("overrun.bin");
+        write_file(&bin, &vec![0u8; 2 * RAW_SECTOR_BYTES]);
+        std::fs::write(
+            &cue,
+            format!(
+                concat!(
+                    "FILE \"{}\" BINARY\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n",
+                    "  TRACK 02 AUDIO\n    INDEX 01 00:10:00\n",
+                ),
+                bin.file_name().unwrap().to_string_lossy(),
+            ),
+        )
+        .unwrap();
+        let err = CdImage::load(&cue).expect_err("overrunning cue sheet must be rejected");
+        assert!(
+            err.to_string().contains("past the end of"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_file(&cue);
+        let _ = std::fs::remove_file(&bin);
     }
 
     #[test]

--- a/src/cdtv.rs
+++ b/src/cdtv.rs
@@ -31,7 +31,7 @@
 //! Akiko. Subcode payload delivery (CD+G) is not implemented: SCOR
 //! pulses with the motor on, but SBCP never presents data.
 
-use crate::cdrom::{CdImage, LEADIN_SECTORS, RAW_SECTOR_BYTES};
+use crate::cdrom::{to_bcd, CdImage, LEADIN_SECTORS, RAW_SECTOR_BYTES};
 use crate::chipset::paula::CdAudioRing;
 use crate::memory::Memory;
 
@@ -61,10 +61,6 @@ const AUDIO_STATUS_NO_STATUS: u8 = 0x15;
 const CCK_PER_LINE: u32 = 227;
 /// Colour clocks per 1/75th second (one single-speed CD frame).
 const CCK_PER_CD_FRAME: u32 = crate::chipset::paula::PAULA_CLOCK_HZ / 75;
-
-fn to_bcd(v: u8) -> u8 {
-    ((v / 10) << 4) | (v % 10)
-}
 
 fn lsn_to_msf(lsn: u32) -> u32 {
     let msf = lsn + LEADIN_SECTORS;

--- a/src/chipset/agnus.rs
+++ b/src/chipset/agnus.rs
@@ -55,7 +55,6 @@ pub fn ddf_hard_bounds(harddis: bool) -> (u16, u16) {
 }
 const DEFAULT_HTOTAL: u16 = (COLORCLOCKS_PER_LINE - 1) as u16;
 
-#[cfg_attr(not(test), allow(dead_code))]
 const OCS_LORES_BPL_SEQUENCE: [usize; 8] = [8, 4, 6, 2, 7, 3, 5, 1];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -412,15 +411,15 @@ pub fn anchor_bitplane_fetch_start(start: u16, unit: u32) -> u16 {
     start
 }
 
-fn bitplane_shres(bplcon0: u16) -> bool {
+pub(crate) fn bitplane_shres(bplcon0: u16) -> bool {
     bplcon0 & 0x0040 != 0
 }
 
-fn bitplane_hires(bplcon0: u16) -> bool {
+pub(crate) fn bitplane_hires(bplcon0: u16) -> bool {
     bplcon0 & 0x8000 != 0 && !bitplane_shres(bplcon0)
 }
 
-fn bitplane_fetch_cck_per_word(bplcon0: u16) -> u32 {
+pub(crate) fn bitplane_fetch_cck_per_word(bplcon0: u16) -> u32 {
     if bitplane_shres(bplcon0) {
         2
     } else if bitplane_hires(bplcon0) {
@@ -440,7 +439,7 @@ pub fn bitplane_fetch_quantum(fmode: u16) -> u32 {
 }
 
 /// Colour clocks between successive fetches of one plane.
-fn bitplane_fetch_period(bplcon0: u16, fmode: u16) -> u32 {
+pub(crate) fn bitplane_fetch_period(bplcon0: u16, fmode: u16) -> u32 {
     bitplane_fetch_cck_per_word(bplcon0) * bitplane_fetch_quantum(fmode)
 }
 
@@ -448,11 +447,11 @@ fn bitplane_fetch_period(bplcon0: u16, fmode: u16) -> u32 {
 /// completes a whole unit. 8 cck at FMODE=0 (the classic block), growing
 /// with the fetch width when the per-plane period exceeds it (lores 16/32,
 /// hires 16 at FMODE=3).
-fn bitplane_fetch_unit(bplcon0: u16, fmode: u16) -> u32 {
+pub(crate) fn bitplane_fetch_unit(bplcon0: u16, fmode: u16) -> u32 {
     bitplane_fetch_period(bplcon0, fmode).max(8)
 }
 
-fn ddf_register_mask(revision: AgnusRevision) -> u16 {
+pub(crate) fn ddf_register_mask(revision: AgnusRevision) -> u16 {
     if matches!(revision, AgnusRevision::Ocs) {
         0x00FC
     } else {
@@ -577,8 +576,7 @@ fn bitplane_dma_fetch_timings(
     timings
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
-fn bitplane_fetch_order(bplcon0: u16, plane: usize) -> u32 {
+pub(crate) fn bitplane_fetch_order(bplcon0: u16, plane: usize) -> u32 {
     if bitplane_hires(bplcon0) || bitplane_shres(bplcon0) {
         return plane as u32;
     }

--- a/src/chipset/blitter.rs
+++ b/src/chipset/blitter.rs
@@ -33,6 +33,13 @@ const BLTCON1_FCI: u16 = 1 << 2;
 const BLTCON1_DESC: u16 = 1 << 1;
 const BLTCON1_SING: u16 = 1 << 1;
 const BLTCON1_LINE: u16 = 1 << 0;
+// Bits 4/3/2 are reinterpreted in line mode (BLTCON1.LINEMODE=1) as the
+// octant-decode fields documented on the line-draw function below (SUD,
+// SUL, AUL), the same bit positions EFE/IFE/FCI use in normal mode -- the
+// same overloading this file already names twice for bit 1 (DESC/SING).
+const BLTCON1_SUD: u16 = BLTCON1_EFE;
+const BLTCON1_SUL: u16 = BLTCON1_IFE;
+const BLTCON1_AUL: u16 = BLTCON1_FCI;
 const CHIP_DMA_ADDR_MASK: u32 = 0x001F_FFFF;
 const CHIP_DMA_HIGH_MASK: u32 = 0x001F_0000;
 
@@ -1556,14 +1563,14 @@ fn line_step_sometimes(
     cpt: &mut u32,
     one_dot: &mut bool,
 ) -> i32 {
-    if bltcon1 & 0x0010 != 0 {
-        if bltcon1 & 0x0008 != 0 {
+    if bltcon1 & BLTCON1_SUD != 0 {
+        if bltcon1 & BLTCON1_SUL != 0 {
             line_step_y(-1, bplmod, cpt, one_dot);
         } else {
             line_step_y(1, bplmod, cpt, one_dot);
         }
         ash
-    } else if bltcon1 & 0x0008 != 0 {
+    } else if bltcon1 & BLTCON1_SUL != 0 {
         line_step_x(ash, -1, cpt)
     } else {
         line_step_x(ash, 1, cpt)
@@ -1571,14 +1578,14 @@ fn line_step_sometimes(
 }
 
 fn line_step_always(bltcon1: u16, ash: i32, bplmod: i32, cpt: &mut u32, one_dot: &mut bool) -> i32 {
-    if bltcon1 & 0x0010 != 0 {
-        if bltcon1 & 0x0004 != 0 {
+    if bltcon1 & BLTCON1_SUD != 0 {
+        if bltcon1 & BLTCON1_AUL != 0 {
             line_step_x(ash, -1, cpt)
         } else {
             line_step_x(ash, 1, cpt)
         }
     } else {
-        if bltcon1 & 0x0004 != 0 {
+        if bltcon1 & BLTCON1_AUL != 0 {
             line_step_y(-1, bplmod, cpt, one_dot);
         } else {
             line_step_y(1, bplmod, cpt, one_dot);
@@ -1635,6 +1642,128 @@ fn apply_fill(d: u16, fill_state: &mut u16, ife: bool, efe: bool) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Run the same blit configuration through both the synchronous
+    /// reference implementation (`execute`, what most tests in this file
+    /// use for readability) and the scheduled per-DMA-slot pipeline
+    /// production actually runs, and assert they leave RAM and BZERO
+    /// identical. The two are independently-maintained code paths for the
+    /// same hardware math; without a direct cross-check, a bug introduced
+    /// in only one of them is invisible to every test that only exercises
+    /// the other. That's exactly how the double-advanced-A-shifter bug
+    /// documented below (`scheduled_disabled_a_window_mask_shifts_once_per_word`)
+    /// slipped through: every existing test drove `execute`, so nothing
+    /// caught the scheduled path computing the A channel twice per word.
+    fn assert_scheduled_matches_synchronous(
+        ram_size: usize,
+        bltsize: u16,
+        configure: impl Fn(&mut Blitter),
+        seed_ram: impl Fn(&mut [u8]),
+    ) {
+        let mut sync_ram = vec![0u8; ram_size];
+        seed_ram(&mut sync_ram);
+        let mut sync_b = Blitter::new();
+        configure(&mut sync_b);
+        sync_b.execute(bltsize, &mut sync_ram);
+
+        let mut sched_ram = vec![0u8; ram_size];
+        seed_ram(&mut sched_ram);
+        let mut sched_b = Blitter::new();
+        configure(&mut sched_b);
+        let snapshot = sched_ram.clone();
+        sched_b.start_scheduled(bltsize, &snapshot);
+        while !sched_b.tick_scheduled_slot(&mut sched_ram) {}
+
+        assert_eq!(
+            sched_ram, sync_ram,
+            "scheduled vs synchronous blit RAM diverged"
+        );
+        assert_eq!(sched_b.bzero, sync_b.bzero, "BZERO diverged");
+    }
+
+    #[test]
+    fn scheduled_matches_synchronous_for_normal_copy_with_shift() {
+        assert_scheduled_matches_synchronous(
+            256,
+            (1u16 << 6) | 2,
+            |b| {
+                b.bltcon0 = (4 << 12) | 0x09F0; // ASH=4, USEA|USED, D=A
+                b.bltcon1 = 0;
+                b.bltafwm = 0xFFFF;
+                b.bltalwm = 0xFFFF;
+                b.bltapt = 0x10;
+                b.bltdpt = 0x20;
+            },
+            |ram| {
+                ram[0x10] = 0xF0;
+                ram[0x11] = 0x00;
+                ram[0x12] = 0x0F;
+                ram[0x13] = 0xFF;
+            },
+        );
+    }
+
+    #[test]
+    fn scheduled_matches_synchronous_for_normal_copy_with_masks() {
+        assert_scheduled_matches_synchronous(
+            256,
+            (1u16 << 6) | 2,
+            |b| {
+                b.bltcon0 = 0x09F0;
+                b.bltcon1 = 0x0000;
+                b.bltafwm = 0x00FF;
+                b.bltalwm = 0xFF00;
+                b.bltapt = 0x10;
+                b.bltdpt = 0x20;
+            },
+            |ram| {
+                ram[0x10] = 0xAA;
+                ram[0x11] = 0xBB;
+                ram[0x12] = 0xCC;
+                ram[0x13] = 0xDD;
+            },
+        );
+    }
+
+    #[test]
+    fn scheduled_matches_synchronous_for_descending_area_fill() {
+        assert_scheduled_matches_synchronous(
+            64,
+            (1u16 << 6) | 1,
+            |b| {
+                b.bltcon0 = BLTCON0_USE_A | BLTCON0_USE_D | 0x00F0;
+                b.bltcon1 = BLTCON1_DESC | BLTCON1_IFE;
+                b.bltafwm = 0xFFFF;
+                b.bltalwm = 0xFFFF;
+                b.bltapt = 0x10;
+                b.bltdpt = 0x20;
+            },
+            |ram| write_word(ram, 0x10, 0x0022),
+        );
+    }
+
+    #[test]
+    fn scheduled_matches_synchronous_for_diagonal_line() {
+        assert_scheduled_matches_synchronous(
+            1024,
+            (16u16 << 6) | 2,
+            |b| {
+                b.bltcon0 = 0x0BCA; // ASH=0, USEA|USEC|USED, minterm $CA
+                b.bltcon1 = BLTCON1_LINE; // octant 0 (SUD=0 SUL=0 AUL=0)
+                b.bltafwm = 0xFFFF;
+                b.bltalwm = 0xFFFF;
+                b.bltadat = 0x8000;
+                b.bltbdat = 0xFFFF;
+                b.bltcpt = 0;
+                b.bltdpt = 0;
+                b.bltcmod = 32;
+                b.bltamod = 0;
+                b.bltbmod = 30;
+                b.bltapt = 0;
+            },
+            |_ram| {},
+        );
+    }
 
     /// A->D copy with the source pre-loaded into chip RAM. BLTCON0 =
     /// `0x09F0` (USE A + USE D + minterm $F0 == D := A), no shift, no
@@ -2548,7 +2677,7 @@ mod tests {
         let mut ram = vec![0u8; 128];
         let mut b = Blitter::new();
         b.bltcon0 = (14 << 12) | BLTCON0_USE_C | 0x00AA; // Minterm C.
-        b.bltcon1 = (2 << 12) | BLTCON1_LINE | 0x0010;
+        b.bltcon1 = (2 << 12) | BLTCON1_LINE | BLTCON1_SUD;
         b.bltcpt = 0;
         b.bltdpt = 0;
         b.bltcmod = 32;
@@ -2569,7 +2698,7 @@ mod tests {
         let mut ram = vec![0u8; 1024];
         let mut b = Blitter::new();
         b.bltcon0 = 0x0BCA;
-        b.bltcon1 = BLTCON1_LINE | BLTCON1_SIGN | BLTCON1_SING | 0x0010;
+        b.bltcon1 = BLTCON1_LINE | BLTCON1_SIGN | BLTCON1_SING | BLTCON1_SUD;
         b.bltafwm = 0xFFFF;
         b.bltalwm = 0xFFFF;
         b.bltadat = 0x8000;

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -521,21 +521,22 @@ impl Cia {
             _ => {}
         }
 
+        let mut effect = CiaSideEffect::default();
         if self.which == Which::A && matches!(reg, REG_PRA | REG_DDRA) {
             let now_no_overlay = self.cia_a_no_overlay_line();
             if !prev_no_overlay && now_no_overlay {
-                return CiaSideEffect::DisableOverlay;
+                effect.disable_overlay = true;
             }
         }
-        if started_timer {
-            CiaSideEffect::TimerStarted
-        } else if keyboard_handshake_start {
-            CiaSideEffect::KeyboardHandshakeStart
+        effect.timer_started = started_timer;
+        effect.keyboard_handshake = if keyboard_handshake_start {
+            Some(true)
         } else if keyboard_handshake_end {
-            CiaSideEffect::KeyboardHandshakeEnd
+            Some(false)
         } else {
-            CiaSideEffect::None
-        }
+            None
+        };
+        effect
     }
 
     /// Advance both timers by `ticks` (CIA PHI2 cycles = CPU/10).
@@ -817,28 +818,29 @@ impl TimerBInputMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CiaSideEffect {
-    None,
+/// Side effects from a single `Cia::write`. These are independent flags,
+/// not an exclusive choice: one CRA byte write can both start a timer
+/// (bit 0) and toggle SPMODE (bit 6) in the same write, and both must be
+/// reported or the keyboard handshake edge is silently dropped whenever
+/// it coincides with a timer start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CiaSideEffect {
     /// CIA-A /OVL was driven low: stop overlaying the ROM at $0 and
     /// switch to chip RAM there.
-    DisableOverlay,
+    pub disable_overlay: bool,
     /// CRA/CRB bit 0 transitioned 0 -> 1: a timer just started. The
     /// emulator preempts the current instruction slice so the next
     /// slice's dynamic cap (computed from `next_underflow_ticks`)
     /// takes effect for the new run, instead of leaving the slice
     /// to run all the way to its larger default size while the CPU
     /// tight-polls ICR/timer counts.
-    TimerStarted,
-    /// CIA-A CRA.SPMODE went 0 -> 1: serial output mode drives the SP
-    /// (KDAT) line low, which the keyboard MCU sees as the start of the
-    /// post-byte handshake pulse.
-    KeyboardHandshakeStart,
-    /// CIA-A CRA.SPMODE went 1 -> 0: SP (KDAT) released. The keyboard
-    /// MCU measures the pulse between Start and End and accepts any
-    /// deliberate handshake (it samples the line within microseconds;
-    /// only a zero-width double-write is ignored).
-    KeyboardHandshakeEnd,
+    pub timer_started: bool,
+    /// CIA-A CRA.SPMODE transitioned: `Some(true)` on 0 -> 1 (serial
+    /// output mode drives the SP/KDAT line low, which the keyboard MCU
+    /// sees as the start of the post-byte handshake pulse), `Some(false)`
+    /// on 1 -> 0 (SP released; the MCU measures the pulse between start
+    /// and end and accepts any deliberate handshake).
+    pub keyboard_handshake: Option<bool>,
 }
 
 /// Map a raw 24-bit Amiga bus address into a CIA register index using
@@ -873,13 +875,25 @@ mod tests {
         let mut cia = Cia::new(Which::A);
 
         assert_eq!(
-            cia.write(REG_CRA, CRA_SPMODE),
-            CiaSideEffect::KeyboardHandshakeStart
+            cia.write(REG_CRA, CRA_SPMODE).keyboard_handshake,
+            Some(true)
         );
         // Rewriting the same mode is not an edge.
-        assert_eq!(cia.write(REG_CRA, CRA_SPMODE), CiaSideEffect::None);
-        assert_eq!(cia.write(REG_CRA, 0), CiaSideEffect::KeyboardHandshakeEnd);
-        assert_eq!(cia.write(REG_CRA, 0), CiaSideEffect::None);
+        assert_eq!(cia.write(REG_CRA, CRA_SPMODE).keyboard_handshake, None);
+        assert_eq!(cia.write(REG_CRA, 0).keyboard_handshake, Some(false));
+        assert_eq!(cia.write(REG_CRA, 0).keyboard_handshake, None);
+    }
+
+    #[test]
+    fn cia_a_cra_write_reports_timer_start_and_keyboard_edge_together() {
+        // A single CRA byte can flip both START (bit 0) and SPMODE (bit 6)
+        // at once. Both side effects must be reported, or the keyboard MCU
+        // edge is silently dropped whenever it coincides with a timer
+        // start (this previously collapsed to TimerStarted only).
+        let mut cia = Cia::new(Which::A);
+        let effect = cia.write(REG_CRA, CRA_SPMODE | 0x01);
+        assert!(effect.timer_started);
+        assert_eq!(effect.keyboard_handshake, Some(true));
     }
 
     #[test]
@@ -1189,8 +1203,8 @@ mod tests {
     fn cia_a_driving_ovl_low_releases_reset_overlay() {
         let mut cia = Cia::new(Which::A);
 
-        assert_eq!(cia.write(REG_DDRA, 0x03), CiaSideEffect::None);
-        assert_eq!(cia.write(REG_PRA, 0x02), CiaSideEffect::DisableOverlay);
+        assert_eq!(cia.write(REG_DDRA, 0x03), CiaSideEffect::default());
+        assert!(cia.write(REG_PRA, 0x02).disable_overlay);
         assert_eq!(cia.read(REG_PRA) & 0x01, 0);
     }
 

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -415,6 +415,11 @@ pub struct Paula {
     pub potgo: u16,
 
     chans: [AudChannel; 4],
+    // Scratch buffer for `advance_audio_channels_inner`'s modulation events,
+    // reused across calls instead of allocating fresh each time modulation
+    // fires: not logical machine state, so it is not part of the save state.
+    #[serde(skip)]
+    mod_events_scratch: Vec<AudioModEvent>,
     serial_tx_buffer: Option<u16>,
     serial_tx_shift: Option<SerialTxShift>,
     serial_rx_shift: Option<SerialRxShift>,
@@ -473,6 +478,7 @@ impl Paula {
                 AudChannel::new(),
                 AudChannel::new(),
             ],
+            mod_events_scratch: Vec::new(),
             serial_tx_buffer: None,
             serial_tx_shift: None,
             serial_rx_shift: None,
@@ -1315,7 +1321,11 @@ impl Paula {
 
     fn advance_audio_channels_inner<const MODULATE: bool>(&mut self, cck: u32) -> u16 {
         let mut irq_bits = 0;
-        let mut mod_events = MODULATE.then(Vec::new);
+        // Reuse the scratch buffer instead of allocating a fresh Vec (and
+        // freeing it again) on every call that has modulation enabled.
+        if MODULATE {
+            self.mod_events_scratch.clear();
+        }
         let ptr_mask = self.dma_ptr_mask();
         for ch_idx in 0..4 {
             let source_modulates = MODULATE && self.channel_drives_audio_modulation(ch_idx);
@@ -1384,27 +1394,21 @@ impl Paula {
                     if ch.phase == 0 {
                         ch.current = ch.word_hi;
                         if source_modulates {
-                            if let Some(mod_events) = mod_events.as_mut() {
-                                mod_events.push(AudioModEvent {
-                                    source: ch_idx,
-                                    word: ((ch.word_hi as u8 as u16) << 8)
-                                        | ch.word_lo as u8 as u16,
-                                    word_start: true,
-                                });
-                            }
+                            self.mod_events_scratch.push(AudioModEvent {
+                                source: ch_idx,
+                                word: ((ch.word_hi as u8 as u16) << 8) | ch.word_lo as u8 as u16,
+                                word_start: true,
+                            });
                         }
                         ch.phase = 1;
                     } else {
                         ch.current = ch.word_lo;
                         if source_modulates {
-                            if let Some(mod_events) = mod_events.as_mut() {
-                                mod_events.push(AudioModEvent {
-                                    source: ch_idx,
-                                    word: ((ch.word_hi as u8 as u16) << 8)
-                                        | ch.word_lo as u8 as u16,
-                                    word_start: false,
-                                });
-                            }
+                            self.mod_events_scratch.push(AudioModEvent {
+                                source: ch_idx,
+                                word: ((ch.word_hi as u8 as u16) << 8) | ch.word_lo as u8 as u16,
+                                word_start: false,
+                            });
                         }
                         ch.phase = 0;
                         // Whole 16-bit word consumed: promote the word the
@@ -1423,8 +1427,14 @@ impl Paula {
                 }
             }
         }
-        if let Some(mod_events) = mod_events {
-            self.apply_audio_modulation(&mod_events);
+        if MODULATE && !self.mod_events_scratch.is_empty() {
+            // Move the buffer out so `apply_audio_modulation` (which needs
+            // &mut self to update the modulated channels) isn't aliased
+            // against an immutable borrow of it, then move it back so its
+            // allocation survives for the next call.
+            let events = std::mem::take(&mut self.mod_events_scratch);
+            self.apply_audio_modulation(&events);
+            self.mod_events_scratch = events;
         }
         irq_bits
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3,7 +3,6 @@
 //! M68K CPU wrapper and CPU-visible Amiga bus adapter.
 
 use crate::bus::{Bus, CpuBusAccessKind};
-use crate::chipset::cia::CiaSideEffect;
 use crate::chipset::paula::{pending_ipl, INT_MASTER};
 use crate::config::CpuModel;
 use crate::memory::{
@@ -1502,9 +1501,58 @@ impl M68kMachine {
     }
 }
 
+/// Which plain-memory region a CPU-visible address falls in, and the byte
+/// offset into that region's backing store. Shared by every access path
+/// (peek/debug-write for the debugger, and the real uncached read/write)
+/// so the plain-memory part of the address map -- overlay ROM, chip RAM,
+/// Zorro RAM, slow RAM, ROM, WCS, extended ROM -- is only decoded in one
+/// place. I/O regions (CIA, RTC, Gayle, custom chips, Zorro devices,
+/// autoconfig) are not plain memory and stay in `read_sized_uncached` /
+/// `write_sized`, which only reach them once this classifier returns
+/// `None`.
+enum PlainMemRegion {
+    OverlayRom(usize),
+    ChipRam(usize),
+    ZorroRam(usize, usize),
+    SlowRam(usize),
+    Rom(usize),
+    Wcs(usize),
+    ExtendedRom(usize),
+}
+
 impl CpuBus {
     fn mask(&self, address: u32) -> u32 {
         address & self.address_mask
+    }
+
+    fn classify_plain_memory(&self, addr: u32, size: usize) -> Option<PlainMemRegion> {
+        if let Some(off) = self.overlay_rom_offset(addr, size) {
+            return Some(PlainMemRegion::OverlayRom(off));
+        }
+        if let Some(off) = region_offset(self.bus.mem.chip_ram.len(), CHIP_RAM_BASE, addr, size) {
+            return Some(PlainMemRegion::ChipRam(off));
+        }
+        if let Some((board, off)) = self.bus.mem.zorro.region_at(addr, size) {
+            return Some(PlainMemRegion::ZorroRam(board, off));
+        }
+        if let Some(off) = region_offset(self.bus.mem.slow_ram.len(), SLOW_RAM_BASE, addr, size) {
+            return Some(PlainMemRegion::SlowRam(off));
+        }
+        if let Some(off) = region_offset(self.bus.mem.rom.len(), ROM_BASE, addr, size) {
+            return Some(PlainMemRegion::Rom(off));
+        }
+        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, size) {
+            return Some(PlainMemRegion::Wcs(off));
+        }
+        if let Some(off) = region_offset(
+            self.bus.mem.extended_rom.len(),
+            self.bus.mem.extended_rom_base,
+            addr,
+            size,
+        ) {
+            return Some(PlainMemRegion::ExtendedRom(off));
+        }
+        None
     }
 
     fn peek_word(&self, address: u32) -> u16 {
@@ -1533,56 +1581,40 @@ impl CpuBus {
 
     fn peek_byte(&self, address: u32) -> u8 {
         let addr = self.mask(address);
-        if let Some(off) = self.overlay_rom_offset(addr, 1) {
-            return self.bus.mem.rom[off];
+        match self.classify_plain_memory(addr, 1) {
+            Some(PlainMemRegion::OverlayRom(off) | PlainMemRegion::Rom(off)) => {
+                self.bus.mem.rom[off]
+            }
+            Some(PlainMemRegion::ChipRam(off)) => self.bus.mem.chip_ram[off],
+            Some(PlainMemRegion::ZorroRam(board, off)) => self.bus.mem.zorro.board_ram(board)[off],
+            Some(PlainMemRegion::SlowRam(off)) => self.bus.mem.slow_ram[off],
+            Some(PlainMemRegion::Wcs(off)) => self.bus.mem.wcs[off],
+            Some(PlainMemRegion::ExtendedRom(off)) => self.bus.mem.extended_rom[off],
+            None => 0xFF,
         }
-        if let Some(off) = region_offset(self.bus.mem.chip_ram.len(), CHIP_RAM_BASE, addr, 1) {
-            return self.bus.mem.chip_ram[off];
-        }
-        if let Some((board, off)) = self.bus.mem.zorro.region_at(addr, 1) {
-            return self.bus.mem.zorro.board_ram(board)[off];
-        }
-        if let Some(off) = region_offset(self.bus.mem.slow_ram.len(), SLOW_RAM_BASE, addr, 1) {
-            return self.bus.mem.slow_ram[off];
-        }
-        if let Some(off) = region_offset(self.bus.mem.rom.len(), ROM_BASE, addr, 1) {
-            return self.bus.mem.rom[off];
-        }
-        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, 1) {
-            return self.bus.mem.wcs[off];
-        }
-        if let Some(off) = region_offset(
-            self.bus.mem.extended_rom.len(),
-            self.bus.mem.extended_rom_base,
-            addr,
-            1,
-        ) {
-            return self.bus.mem.extended_rom[off];
-        }
-        0xFF
     }
 
     fn debug_write_byte(&mut self, address: u32, value: u8) -> bool {
         let addr = self.mask(address);
-        if self.overlay_rom_offset(addr, 1).is_some() {
-            return false;
+        match self.classify_plain_memory(addr, 1) {
+            Some(PlainMemRegion::ChipRam(off)) => {
+                self.bus.mem.chip_ram[off] = value;
+                self.invalidate_debug_write(addr, 1);
+                true
+            }
+            Some(PlainMemRegion::ZorroRam(board, off)) => {
+                self.bus.mem.zorro.board_ram_mut(board)[off] = value;
+                self.invalidate_debug_write(addr, 1);
+                true
+            }
+            Some(PlainMemRegion::SlowRam(off)) => {
+                self.bus.mem.slow_ram[off] = value;
+                self.invalidate_debug_write(addr, 1);
+                true
+            }
+            // Overlay ROM/ROM/WCS/extended ROM are not debugger-writable.
+            _ => false,
         }
-        if let Some(off) = region_offset(self.bus.mem.chip_ram.len(), CHIP_RAM_BASE, addr, 1) {
-            self.bus.mem.chip_ram[off] = value;
-            self.invalidate_debug_write(addr, 1);
-            return true;
-        }
-        if let Some((board, off)) = self.bus.mem.zorro.region_at(addr, 1) {
-            self.bus.mem.zorro.board_ram_mut(board)[off] = value;
-            self.invalidate_debug_write(addr, 1);
-            return true;
-        }
-        if let Some(off) = region_offset(self.bus.mem.slow_ram.len(), SLOW_RAM_BASE, addr, 1) {
-            self.bus.mem.slow_ram[off] = value;
-            self.invalidate_debug_write(addr, 1);
-            return true;
-        }
-        false
     }
 
     fn invalidate_debug_write(&mut self, addr: u32, size: usize) {
@@ -1698,47 +1730,45 @@ impl CpuBus {
 
     fn read_sized_uncached(&mut self, address: u32, size: usize, kind: CpuBusAccessKind) -> u32 {
         let addr = self.mask(address);
-        if let Some(off) = self.overlay_rom_offset(addr, size) {
-            self.bus.cpu_external_access(Self::access_words(size));
-            return read_be(&self.bus.mem.rom, off, size);
-        }
-        if let Some(off) = region_offset(self.bus.mem.chip_ram.len(), CHIP_RAM_BASE, addr, size) {
-            self.bus.grant_cpu_bus_access_at(Some(addr), size, kind);
-            return read_be(&self.bus.mem.chip_ram, off, size);
-        }
-        if let Some((board, off)) = self.bus.mem.zorro.region_at(addr, size) {
-            // Expansion (Zorro) RAM runs at external-bus speed, off the
-            // chip bus, exactly like the old fixed fast RAM mapping.
-            self.bus.cpu_external_access(Self::access_words(size));
-            return read_be(self.bus.mem.zorro.board_ram(board), off, size);
-        }
-        if let Some(off) = region_offset(self.bus.mem.slow_ram.len(), SLOW_RAM_BASE, addr, size) {
-            // "Slow"/trapdoor RAM at $C00000 is decoded by Gary and reached
-            // through Agnus on the chip bus, so the CPU contends for it cycle
-            // by cycle exactly like chip RAM (that is why it is "slow" and does
-            // not accelerate chip-bus-bound code). Arbitrate it like chip RAM,
-            // not as uncontended external memory.
-            self.bus.grant_cpu_bus_access_at(Some(addr), size, kind);
-            return read_be(&self.bus.mem.slow_ram, off, size);
-        }
-        if let Some(off) = region_offset(self.bus.mem.rom.len(), ROM_BASE, addr, size) {
-            self.bus.cpu_external_access(Self::access_words(size));
-            return read_be(&self.bus.mem.rom, off, size);
-        }
-        // A1000 WCS at $FC0000 (empty -> no match on other machines): the
-        // 256 KiB writable control store the boot ROM loads Kickstart into.
-        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, size) {
-            self.bus.cpu_external_access(Self::access_words(size));
-            return read_be(&self.bus.mem.wcs, off, size);
-        }
-        if let Some(off) = region_offset(
-            self.bus.mem.extended_rom.len(),
-            self.bus.mem.extended_rom_base,
-            addr,
-            size,
-        ) {
-            self.bus.cpu_external_access(Self::access_words(size));
-            return read_be(&self.bus.mem.extended_rom, off, size);
+        match self.classify_plain_memory(addr, size) {
+            Some(PlainMemRegion::OverlayRom(off)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                return read_be(&self.bus.mem.rom, off, size);
+            }
+            Some(PlainMemRegion::ChipRam(off)) => {
+                self.bus.grant_cpu_bus_access_at(Some(addr), size, kind);
+                return read_be(&self.bus.mem.chip_ram, off, size);
+            }
+            Some(PlainMemRegion::ZorroRam(board, off)) => {
+                // Expansion (Zorro) RAM runs at external-bus speed, off the
+                // chip bus, exactly like the old fixed fast RAM mapping.
+                self.bus.cpu_external_access(Self::access_words(size));
+                return read_be(self.bus.mem.zorro.board_ram(board), off, size);
+            }
+            Some(PlainMemRegion::SlowRam(off)) => {
+                // "Slow"/trapdoor RAM at $C00000 is decoded by Gary and reached
+                // through Agnus on the chip bus, so the CPU contends for it cycle
+                // by cycle exactly like chip RAM (that is why it is "slow" and does
+                // not accelerate chip-bus-bound code). Arbitrate it like chip RAM,
+                // not as uncontended external memory.
+                self.bus.grant_cpu_bus_access_at(Some(addr), size, kind);
+                return read_be(&self.bus.mem.slow_ram, off, size);
+            }
+            Some(PlainMemRegion::Rom(off)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                return read_be(&self.bus.mem.rom, off, size);
+            }
+            // A1000 WCS at $FC0000 (empty -> no match on other machines): the
+            // 256 KiB writable control store the boot ROM loads Kickstart into.
+            Some(PlainMemRegion::Wcs(off)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                return read_be(&self.bus.mem.wcs, off, size);
+            }
+            Some(PlainMemRegion::ExtendedRom(off)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                return read_be(&self.bus.mem.extended_rom, off, size);
+            }
+            None => {}
         }
 
         if range_contains(CIA_A_BASE, CIA_A_SIZE, addr) {
@@ -1872,62 +1902,58 @@ impl CpuBus {
             // intentionally does NOT snoop writes, like real silicon.)
             dcache.invalidate_write(addr, size);
         }
-        if self.overlay_rom_offset(addr, size).is_some() {
-            self.bus.cpu_external_access(Self::access_words(size));
-            return;
-        }
-        if let Some(off) = region_offset(self.bus.mem.chip_ram.len(), CHIP_RAM_BASE, addr, size) {
-            self.bus
-                .grant_cpu_bus_access_at(Some(addr), size, CpuBusAccessKind::Write);
-            self.bus.record_cpu_chip_ram_write(off, size, value);
-            write_be(&mut self.bus.mem.chip_ram, off, size, value);
-            self.dbg_note_memw(addr, size);
-            return;
-        }
-        if let Some((board, off)) = self.bus.mem.zorro.region_at(addr, size) {
-            self.bus.cpu_external_access(Self::access_words(size));
-            write_be(self.bus.mem.zorro.board_ram_mut(board), off, size, value);
-            return;
-        }
-        if let Some(off) = region_offset(self.bus.mem.slow_ram.len(), SLOW_RAM_BASE, addr, size) {
-            // Slow/trapdoor RAM at $C00000 is on the chip bus (reached through
-            // Agnus), so CPU writes contend cycle by cycle like chip RAM rather
-            // than running at uncontended external-memory speed.
-            self.bus
-                .grant_cpu_bus_access_at(Some(addr), size, CpuBusAccessKind::Write);
-            write_be(&mut self.bus.mem.slow_ram, off, size, value);
-            self.dbg_note_memw(addr, size);
-            return;
-        }
-        if region_offset(self.bus.mem.rom.len(), ROM_BASE, addr, size).is_some() {
-            self.bus.cpu_external_access(Self::access_words(size));
-            // A1000: a CPU write anywhere in the boot-ROM window ($F80000-
-            // $FBFFFF) flips the latch to write-protect the WCS. The boot code
-            // does this once the Kickstart image is in place at $FC0000.
-            if !self.bus.mem.wcs.is_empty() {
-                self.bus.mem.wcs_write_protected = true;
+        match self.classify_plain_memory(addr, size) {
+            Some(PlainMemRegion::OverlayRom(_)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                return;
             }
-            return;
-        }
-        // A1000 WCS at $FC0000: writable until the boot ROM locks the latch.
-        if let Some(off) = region_offset(self.bus.mem.wcs.len(), WCS_BASE, addr, size) {
-            self.bus.cpu_external_access(Self::access_words(size));
-            if !self.bus.mem.wcs_write_protected {
-                write_be(&mut self.bus.mem.wcs, off, size, value);
+            Some(PlainMemRegion::ChipRam(off)) => {
+                self.bus
+                    .grant_cpu_bus_access_at(Some(addr), size, CpuBusAccessKind::Write);
+                self.bus.record_cpu_chip_ram_write(off, size, value);
+                write_be(&mut self.bus.mem.chip_ram, off, size, value);
                 self.dbg_note_memw(addr, size);
+                return;
             }
-            return;
-        }
-        if region_offset(
-            self.bus.mem.extended_rom.len(),
-            self.bus.mem.extended_rom_base,
-            addr,
-            size,
-        )
-        .is_some()
-        {
-            self.bus.cpu_external_access(Self::access_words(size));
-            return;
+            Some(PlainMemRegion::ZorroRam(board, off)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                write_be(self.bus.mem.zorro.board_ram_mut(board), off, size, value);
+                return;
+            }
+            Some(PlainMemRegion::SlowRam(off)) => {
+                // Slow/trapdoor RAM at $C00000 is on the chip bus (reached through
+                // Agnus), so CPU writes contend cycle by cycle like chip RAM rather
+                // than running at uncontended external-memory speed.
+                self.bus
+                    .grant_cpu_bus_access_at(Some(addr), size, CpuBusAccessKind::Write);
+                write_be(&mut self.bus.mem.slow_ram, off, size, value);
+                self.dbg_note_memw(addr, size);
+                return;
+            }
+            Some(PlainMemRegion::Rom(_)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                // A1000: a CPU write anywhere in the boot-ROM window ($F80000-
+                // $FBFFFF) flips the latch to write-protect the WCS. The boot code
+                // does this once the Kickstart image is in place at $FC0000.
+                if !self.bus.mem.wcs.is_empty() {
+                    self.bus.mem.wcs_write_protected = true;
+                }
+                return;
+            }
+            // A1000 WCS at $FC0000: writable until the boot ROM locks the latch.
+            Some(PlainMemRegion::Wcs(off)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                if !self.bus.mem.wcs_write_protected {
+                    write_be(&mut self.bus.mem.wcs, off, size, value);
+                    self.dbg_note_memw(addr, size);
+                }
+                return;
+            }
+            Some(PlainMemRegion::ExtendedRom(_)) => {
+                self.bus.cpu_external_access(Self::access_words(size));
+                return;
+            }
+            None => {}
         }
 
         if range_contains(CIA_A_BASE, CIA_A_SIZE, addr) {
@@ -1935,17 +1961,12 @@ impl CpuBus {
             let effect = self
                 .bus
                 .cia_a_write(u64::from(addr - CIA_A_BASE), size, u64::from(value));
-            match effect {
-                CiaSideEffect::DisableOverlay => {
-                    self.bus.overlay_disable_pending = true;
-                    self.bus.slice_preempted = true;
-                }
-                CiaSideEffect::TimerStarted => {
-                    self.bus.slice_preempted = true;
-                }
-                CiaSideEffect::KeyboardHandshakeStart
-                | CiaSideEffect::KeyboardHandshakeEnd
-                | CiaSideEffect::None => {}
+            if effect.disable_overlay {
+                self.bus.overlay_disable_pending = true;
+                self.bus.slice_preempted = true;
+            }
+            if effect.timer_started {
+                self.bus.slice_preempted = true;
             }
             return;
         }
@@ -1954,7 +1975,7 @@ impl CpuBus {
             let effect = self
                 .bus
                 .cia_b_write(u64::from(addr - CIA_B_BASE), size, u64::from(value));
-            if matches!(effect, CiaSideEffect::TimerStarted) {
+            if effect.timer_started {
                 self.bus.slice_preempted = true;
             }
             return;

--- a/src/dms.rs
+++ b/src/dms.rs
@@ -464,7 +464,13 @@ impl<'a> BitReader<'a> {
     }
 
     fn drop(&mut self, bits: u8) {
-        self.bitcount -= bits;
+        // `bits` is a fixed constant at most call sites, but a few pass a
+        // Huffman code length read straight from an untrusted .dms stream
+        // (see decode_c/decode_p); a corrupt length can exceed the bits
+        // actually buffered. Saturate rather than underflow so a bogus
+        // length degrades to a garbled decode (caught by the surrounding
+        // CRC check) instead of a panic.
+        self.bitcount = self.bitcount.saturating_sub(bits);
         self.bitbuf &= mask_bits(self.bitcount);
         while self.bitcount < 16 {
             let byte = self.data.get(self.pos).copied().unwrap_or(0);
@@ -581,7 +587,15 @@ impl HeavyState {
                 };
                 mask >>= 1;
             }
-            bits.drop(self.c_len[node as usize] - 12);
+            // `c_len[node]` is expected to exceed the 12-bit table prefix
+            // for any leaf reached by the tree walk (that's why it wasn't
+            // resolved directly by the table lookup above), but the length
+            // table comes straight from an untrusted .dms stream: a
+            // corrupt file that still passes make_table's Kraft-equality
+            // check could still violate that. Saturate rather than
+            // underflow; a bogus length here produces a garbled decode
+            // that the surrounding CRC check catches, instead of a panic.
+            bits.drop(self.c_len[node as usize].saturating_sub(12));
         }
         node
     }
@@ -602,7 +616,10 @@ impl HeavyState {
                 };
                 mask >>= 1;
             }
-            bits.drop(self.pt_len[node as usize] - 8);
+            // Same reasoning as decode_c above: saturate instead of
+            // underflowing on a length table that a corrupt stream could
+            // still have smuggled past the Kraft-equality check.
+            bits.drop(self.pt_len[node as usize].saturating_sub(8));
         }
 
         if node != self.np as u16 - 1 {
@@ -942,6 +959,25 @@ mod tests {
         let dms = make_uncompressed_dms(&adf);
         assert_eq!(decode_dms_adf(&dms)?, adf);
         Ok(())
+    }
+
+    #[test]
+    fn decode_c_saturates_instead_of_underflowing_on_a_bogus_short_code_length() {
+        // Force the table lookup to miss (so decode_c walks the tree) and
+        // land on a leaf whose code length is shorter than the 12-bit
+        // table prefix already consumed. A corrupt .dms Huffman length
+        // table that still passes make_table's Kraft-equality check could
+        // produce exactly this: `c_len[leaf] - 12` used to underflow.
+        let mut heavy = HeavyState::default();
+        heavy.c_table.fill(HeavyState::N1); // every 12-bit prefix misses
+        heavy.left[HeavyState::N1 as usize] = 5; // ... and both tree
+        heavy.right[HeavyState::N1 as usize] = 5; // branches land on leaf 5
+        heavy.c_len[5] = 5; // shorter than the 12-bit prefix
+
+        let data = [0u8; 8];
+        let mut bits = BitReader::new(&data);
+        let node = heavy.decode_c(&mut bits); // must not panic
+        assert_eq!(node, 5);
     }
 
     #[test]

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -14,7 +14,7 @@ use anyhow::{bail, ensure, Context, Result};
 use flate2::read::{DeflateDecoder, GzDecoder};
 use flate2::CrcReader;
 use log::{debug, warn};
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 pub const CYLINDERS: usize = 80;
@@ -1134,7 +1134,7 @@ impl FloppyController {
             FloppyImageData::StandardAdf(image_data) => {
                 decode_non_empty_track_write(track, write_words).and_then(|sectors| {
                     apply_standard_adf_sectors(image_data, track, &sectors);
-                    std::fs::write(&path, &*image_data).context("writing standard ADF image")
+                    write_standard_adf_sectors_to_disk(&path, track, &sectors)
                 })
             }
             FloppyImageData::Tracks(tracks) => apply_extended_adf_write(
@@ -2514,6 +2514,31 @@ fn apply_standard_adf_sectors(
         let off = adf_sector_offset(track, *sector);
         image_data[off..off + BYTES_PER_SECTOR].copy_from_slice(sector_data);
     }
+}
+
+/// Write just the given sectors to their exact byte offsets in the ADF
+/// file on disk, instead of rewriting the whole (up to several-hundred-KB)
+/// image on every write-DMA completion: a disk write typically touches
+/// only one or a handful of the image's sectors.
+fn write_standard_adf_sectors_to_disk(
+    path: &Path,
+    track: usize,
+    sectors: &[(usize, [u8; BYTES_PER_SECTOR])],
+) -> Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false) // partial write: the rest of the file must survive
+        .open(path)
+        .with_context(|| format!("opening {} for write-through", path.display()))?;
+    for (sector, sector_data) in sectors {
+        let off = adf_sector_offset(track, *sector);
+        file.seek(SeekFrom::Start(off as u64))
+            .with_context(|| format!("seeking to sector {sector} in {}", path.display()))?;
+        file.write_all(sector_data)
+            .with_context(|| format!("writing sector {sector} to {}", path.display()))?;
+    }
+    Ok(())
 }
 
 fn apply_amigados_track_sectors(

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -10,7 +10,7 @@
 use crate::debugger::{custom_reg_name, UI_ADDR_MASK};
 use crate::emulator::Emulator;
 use crate::timetravel::ReverseOutcome;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 
@@ -200,14 +200,14 @@ impl Session {
             _ if packet.starts_with("z2,") || packet.starts_with("z3,") || packet.starts_with("z4,") => {
                 self.remove_watchpoint(packet)?
             }
-            _ if packet == "s" || packet.starts_with("s") => {
+            _ if packet.starts_with('s') => {
                 if let Some(addr) = packet.strip_prefix('s').filter(|s| !s.is_empty()) {
                     let pc = parse_hex_u32(addr)?;
                     self.emu.machine.debug_set_register(17, pc);
                 }
                 self.step_forward()?
             }
-            _ if packet == "c" || packet.starts_with("c") => {
+            _ if packet.starts_with('c') => {
                 if let Some(addr) = packet.strip_prefix('c').filter(|s| !s.is_empty()) {
                     let pc = parse_hex_u32(addr)?;
                     self.emu.machine.debug_set_register(17, pc);
@@ -223,53 +223,71 @@ impl Session {
         Ok(PacketOutcome::Reply(reply))
     }
 
-    fn read_packet(&mut self) -> Result<Option<String>> {
-        let mut byte = [0u8; 1];
-        loop {
-            match self.stream.read_exact(&mut byte) {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
-                Err(e) => return Err(e).context("reading GDB packet"),
-            }
-            match byte[0] {
-                b'+' | b'-' => continue,
-                b'$' => break,
-                0x03 => {
-                    self.stop = StopReason::Interrupted;
-                    return Ok(Some("?".to_string()));
-                }
-                _ => continue,
-            }
-        }
+    /// Hard cap on a single packet's payload, well above the `PacketSize=4000`
+    /// this stub advertises in qSupported but far short of unbounded: this is
+    /// network-facing input (the stub can bind non-loopback), so a peer that
+    /// never sends the `#` terminator must not be able to grow `payload`
+    /// without limit.
+    const MAX_PACKET_PAYLOAD_BYTES: usize = 1 << 20;
 
-        let mut payload = Vec::new();
+    fn read_packet(&mut self) -> Result<Option<String>> {
+        // Loop (rather than recurse) on a checksum mismatch: a peer sending
+        // many consecutive bad-checksum packets must not grow the call
+        // stack without bound.
         loop {
+            let mut byte = [0u8; 1];
+            loop {
+                match self.stream.read_exact(&mut byte) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                    Err(e) => return Err(e).context("reading GDB packet"),
+                }
+                match byte[0] {
+                    b'+' | b'-' => continue,
+                    b'$' => break,
+                    0x03 => {
+                        self.stop = StopReason::Interrupted;
+                        return Ok(Some("?".to_string()));
+                    }
+                    _ => continue,
+                }
+            }
+
+            let mut payload = Vec::new();
+            loop {
+                self.stream
+                    .read_exact(&mut byte)
+                    .context("reading GDB packet payload")?;
+                if byte[0] == b'#' {
+                    break;
+                }
+                payload.push(byte[0]);
+                if payload.len() > Self::MAX_PACKET_PAYLOAD_BYTES {
+                    bail!(
+                        "GDB packet exceeds {}-byte limit without a '#' terminator",
+                        Self::MAX_PACKET_PAYLOAD_BYTES
+                    );
+                }
+            }
+            let mut sum_bytes = [0u8; 2];
             self.stream
-                .read_exact(&mut byte)
-                .context("reading GDB packet payload")?;
-            if byte[0] == b'#' {
-                break;
+                .read_exact(&mut sum_bytes)
+                .context("reading GDB packet checksum")?;
+            let expected = parse_hex_byte(sum_bytes[0], sum_bytes[1])?;
+            let actual = checksum(&payload);
+            if expected != actual {
+                if !self.no_ack {
+                    self.stream.write_all(b"-").ok();
+                }
+                continue;
             }
-            payload.push(byte[0]);
-        }
-        let mut sum_bytes = [0u8; 2];
-        self.stream
-            .read_exact(&mut sum_bytes)
-            .context("reading GDB packet checksum")?;
-        let expected = parse_hex_byte(sum_bytes[0], sum_bytes[1])?;
-        let actual = checksum(&payload);
-        if expected != actual {
             if !self.no_ack {
-                self.stream.write_all(b"-").ok();
+                self.stream.write_all(b"+").ok();
             }
-            return self.read_packet();
+            return String::from_utf8(payload)
+                .map(Some)
+                .context("GDB packet is not UTF-8");
         }
-        if !self.no_ack {
-            self.stream.write_all(b"+").ok();
-        }
-        String::from_utf8(payload)
-            .map(Some)
-            .context("GDB packet is not UTF-8")
     }
 
     fn send_packet(&mut self, payload: &str) -> Result<()> {
@@ -336,6 +354,13 @@ impl Session {
         };
         let addr = parse_hex_u32(addr_s)?;
         let len = parse_hex_usize(len_s)?;
+        // `len` is a hex value the peer controls directly (independent of
+        // the packet's own byte length), so a tiny packet like "m0,ffffffff"
+        // could otherwise demand a multi-GB allocation. No real GDB request
+        // needs more than a small fraction of the address space at once.
+        if len > Self::MAX_PACKET_PAYLOAD_BYTES {
+            return Ok("E01".to_string());
+        }
         Ok(hex_encode(&self.emu.machine.debug_read_memory(addr, len)))
     }
 
@@ -506,7 +531,12 @@ impl Session {
         }
         let end = offset.saturating_add(len).min(bytes.len());
         let prefix = if end == bytes.len() { 'l' } else { 'm' };
-        let chunk = std::str::from_utf8(&bytes[offset..end]).expect("target XML is UTF-8");
+        // TARGET_XML is pure ASCII today, so any offset/len is a valid char
+        // boundary, but both come straight from the peer: don't let a future
+        // non-ASCII addition (or a boundary that happens to split a
+        // multi-byte char) turn into a panic instead of a clean error.
+        let chunk = std::str::from_utf8(&bytes[offset..end])
+            .map_err(|_| anyhow!("target XML slice landed on a non-UTF-8 boundary"))?;
         Ok(format!("{prefix}{chunk}"))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,22 @@ fn expand_script_files(args: Vec<String>) -> Result<Vec<String>> {
     Ok(out)
 }
 
+/// Parse the next CLI argument as `T`: the common shape behind most of
+/// this parser's `--flag VALUE` options, which otherwise each repeat the
+/// same "missing argument" / "not a valid value" error-handling pair.
+/// `missing` names what the whole flag needs when no argument follows;
+/// `invalid` explains what shape this particular value must have.
+fn next_arg<T: std::str::FromStr>(
+    args: &mut impl Iterator<Item = String>,
+    missing: &str,
+    invalid: &str,
+) -> Result<T> {
+    args.next()
+        .ok_or_else(|| anyhow!("{missing}"))?
+        .parse()
+        .map_err(|_| anyhow!("{invalid}"))
+}
+
 fn parse_args_from<I>(args: I) -> Result<CliArgs>
 where
     I: IntoIterator<Item = String>,
@@ -305,11 +321,11 @@ where
                 overrides.fpu = Some(false);
             }
             "--cpu-clock" => {
-                let mhz: f64 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--cpu-clock requires MHZ"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--cpu-clock MHZ must be a number"))?;
+                let mhz: f64 = next_arg(
+                    &mut args,
+                    "--cpu-clock requires MHZ",
+                    "--cpu-clock MHZ must be a number",
+                )?;
                 overrides.cpu_clock_mhz = Some(mhz);
             }
             "--chip" => {
@@ -343,64 +359,40 @@ where
                 );
             }
             "--click-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--click-after requires SECS BUTTON DURATION_MS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--click-after SECS must be a number"))?;
-                let button_s = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--click-after requires SECS BUTTON DURATION_MS"))?;
+                const USAGE: &str = "--click-after requires SECS BUTTON DURATION_MS";
+                let secs: f32 = next_arg(&mut args, USAGE, "--click-after SECS must be a number")?;
+                let button_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let button = match button_s.as_str() {
                     "left" | "lmb" | "l" => MouseButtonKind::Left,
                     "right" | "rmb" | "r" => MouseButtonKind::Right,
                     "middle" | "mmb" | "m" => MouseButtonKind::Middle,
                     _ => return Err(anyhow!("--click-after BUTTON must be left/right/middle")),
                 };
-                let dur_ms: u32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--click-after requires SECS BUTTON DURATION_MS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--click-after DURATION_MS must be a number"))?;
+                let dur_ms: u32 = next_arg(
+                    &mut args,
+                    USAGE,
+                    "--click-after DURATION_MS must be a number",
+                )?;
                 click_after.push((secs, button, dur_ms));
             }
             "--joy-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--joy-after requires SECS BUTTON DURATION_MS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--joy-after SECS must be a number"))?;
-                let button_s = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--joy-after requires SECS BUTTON DURATION_MS"))?;
+                const USAGE: &str = "--joy-after requires SECS BUTTON DURATION_MS";
+                let secs: f32 = next_arg(&mut args, USAGE, "--joy-after SECS must be a number")?;
+                let button_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let button = JoyButtonKind::parse(&button_s).ok_or_else(|| {
                     anyhow!(
                         "--joy-after BUTTON must be up/down/left/right/red/blue/green/yellow/play/rwd/ffw"
                     )
                 })?;
-                let dur_ms: u32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--joy-after requires SECS BUTTON DURATION_MS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--joy-after DURATION_MS must be a number"))?;
+                let dur_ms: u32 =
+                    next_arg(&mut args, USAGE, "--joy-after DURATION_MS must be a number")?;
                 joy_after.push((secs, button, dur_ms));
             }
             "--mouse-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--mouse-after requires SECS DX DY"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--mouse-after SECS must be a number"))?;
-                let dx: i32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--mouse-after requires SECS DX DY"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--mouse-after DX must be an integer"))?;
-                let dy: i32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--mouse-after requires SECS DX DY"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--mouse-after DY must be an integer"))?;
+                const USAGE: &str = "--mouse-after requires SECS DX DY";
+                let secs: f32 = next_arg(&mut args, USAGE, "--mouse-after SECS must be a number")?;
+                let dx: i32 = next_arg(&mut args, USAGE, "--mouse-after DX must be an integer")?;
+                let dy: i32 = next_arg(&mut args, USAGE, "--mouse-after DY must be an integer")?;
                 mouse_after.push((secs, dx, dy));
             }
             "--record-input" => {
@@ -410,18 +402,15 @@ where
                 record_input = Some(PathBuf::from(v));
             }
             "--insert-disk-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--insert-disk-after requires SECS DFN PATH"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--insert-disk-after SECS must be a number"))?;
-                let drive_s = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--insert-disk-after requires SECS DFN PATH"))?;
+                const USAGE: &str = "--insert-disk-after requires SECS DFN PATH";
+                let secs: f32 = next_arg(
+                    &mut args,
+                    USAGE,
+                    "--insert-disk-after SECS must be a number",
+                )?;
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let drive_idx = parse_floppy_drive_idx(&drive_s, "--insert-disk-after")?;
-                let path = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--insert-disk-after requires SECS DFN PATH"))?;
+                let path = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 disk_insert_after.push(CliDiskInsert::Explicit(DiskInsertSpec {
                     secs,
                     drive_idx,
@@ -430,26 +419,20 @@ where
                 }));
             }
             "--defer-disk-insert" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--defer-disk-insert requires SECS DFN"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--defer-disk-insert SECS must be a number"))?;
-                let drive_s = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--defer-disk-insert requires SECS DFN"))?;
+                const USAGE: &str = "--defer-disk-insert requires SECS DFN";
+                let secs: f32 = next_arg(
+                    &mut args,
+                    USAGE,
+                    "--defer-disk-insert SECS must be a number",
+                )?;
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let drive_idx = parse_floppy_drive_idx(&drive_s, "--defer-disk-insert")?;
                 disk_insert_after.push(CliDiskInsert::Configured { secs, drive_idx });
             }
             "--press-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--press-after requires SECS KEY"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--press-after SECS must be a number"))?;
-                let key_s = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--press-after requires SECS KEY"))?;
+                const USAGE: &str = "--press-after requires SECS KEY";
+                let secs: f32 = next_arg(&mut args, USAGE, "--press-after SECS must be a number")?;
+                let key_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let rawkey = parse_amiga_key(&key_s)
                     .ok_or_else(|| anyhow!("--press-after KEY: unknown key {:?}", key_s))?;
                 press_after.push(KeyPressSpec {
@@ -459,21 +442,13 @@ where
                 });
             }
             "--key-after" | "--hold-key-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--key-after requires SECS KEY DURATION_MS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--key-after SECS must be a number"))?;
-                let key_s = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--key-after requires SECS KEY DURATION_MS"))?;
+                const USAGE: &str = "--key-after requires SECS KEY DURATION_MS";
+                let secs: f32 = next_arg(&mut args, USAGE, "--key-after SECS must be a number")?;
+                let key_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let rawkey = parse_amiga_key(&key_s)
                     .ok_or_else(|| anyhow!("--key-after KEY: unknown key {:?}", key_s))?;
-                let hold_ms: u32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--key-after requires SECS KEY DURATION_MS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--key-after DURATION_MS must be a number"))?;
+                let hold_ms: u32 =
+                    next_arg(&mut args, USAGE, "--key-after DURATION_MS must be a number")?;
                 press_after.push(KeyPressSpec {
                     secs,
                     rawkey,
@@ -481,25 +456,17 @@ where
                 });
             }
             "--screenshot-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--screenshot-after requires SECS PATH"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--screenshot-after SECS must be a number"))?;
-                let path = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--screenshot-after requires SECS PATH"))?;
+                const USAGE: &str = "--screenshot-after requires SECS PATH";
+                let secs: f32 =
+                    next_arg(&mut args, USAGE, "--screenshot-after SECS must be a number")?;
+                let path = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 screenshot_after = Some((secs, PathBuf::from(path)));
             }
             "--save-state-after" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--save-state-after requires SECS PATH"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--save-state-after SECS must be a number"))?;
-                let path = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--save-state-after requires SECS PATH"))?;
+                const USAGE: &str = "--save-state-after requires SECS PATH";
+                let secs: f32 =
+                    next_arg(&mut args, USAGE, "--save-state-after SECS must be a number")?;
+                let path = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 save_state_after = Some((secs, PathBuf::from(path)));
             }
             "--load-state" => {
@@ -509,11 +476,11 @@ where
                 load_state = Some(PathBuf::from(v));
             }
             "--benchmark-until" | "--bench-until" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--benchmark-until requires SECS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--benchmark-until SECS must be a number"))?;
+                let secs: f32 = next_arg(
+                    &mut args,
+                    "--benchmark-until requires SECS",
+                    "--benchmark-until SECS must be a number",
+                )?;
                 if secs <= 0.0 {
                     return Err(anyhow!("--benchmark-until SECS must be greater than zero"));
                 }
@@ -532,18 +499,18 @@ where
                 dump_dir = Some(PathBuf::from(path));
             }
             "--dump-start" => {
-                dump_start_secs = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--dump-start requires SECS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--dump-start SECS must be a number"))?;
+                dump_start_secs = next_arg(
+                    &mut args,
+                    "--dump-start requires SECS",
+                    "--dump-start SECS must be a number",
+                )?;
             }
             "--dump-count" => {
-                let count: u32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--dump-count requires COUNT"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--dump-count COUNT must be a positive integer"))?;
+                let count: u32 = next_arg(
+                    &mut args,
+                    "--dump-count requires COUNT",
+                    "--dump-count COUNT must be a positive integer",
+                )?;
                 if count == 0 {
                     return Err(anyhow!("--dump-count COUNT must be greater than zero"));
                 }
@@ -565,11 +532,11 @@ where
                 audio_live = false;
             }
             "--profile-live-audio" => {
-                let secs: f32 = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--profile-live-audio requires SECS"))?
-                    .parse()
-                    .map_err(|_| anyhow!("--profile-live-audio SECS must be a number"))?;
+                let secs: f32 = next_arg(
+                    &mut args,
+                    "--profile-live-audio requires SECS",
+                    "--profile-live-audio SECS must be a number",
+                )?;
                 if secs <= 0.0 {
                     return Err(anyhow!(
                         "--profile-live-audio SECS must be greater than zero"

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -251,7 +251,17 @@ impl ScsiDisk {
     /// payload. Returns the bus data phase and the status byte (for
     /// data-out commands the status is resolved by `complete_out`).
     pub fn execute(&mut self, cdb: &[u8], lun: u8) -> (ScsiExec, u8) {
-        let op = cdb[0];
+        let Some(&op) = cdb.first() else {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+        };
+        // The manual (Select + Transfer Info) path sizes the command
+        // phase from the driver's TC register, not from the opcode's
+        // real CDB length, so a short/malformed TC can hand us a `cdb`
+        // slice shorter than what this opcode's fields need. Reject it
+        // as a malformed CDB instead of indexing out of bounds below.
+        if cdb.len() < cdb_len(op) {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+        }
         // REQUEST SENSE must report (then clear) the previous command's
         // sense data; every other command starts with it cleared.
         if op != 0x03 {
@@ -410,7 +420,18 @@ impl ScsiDisk {
 
     /// Complete a data-out command once the payload has arrived.
     pub fn complete_out(&mut self, cdb: &[u8], data: &[u8]) -> u8 {
-        match cdb[0] {
+        // A data-out phase is only ever reached after `execute` accepted the
+        // command, which already rejects an empty or too-short CDB, so this
+        // guard cannot fire in normal flow. It stays as belt-and-suspenders
+        // against the raw indexing below: a malformed CDB commits nothing and
+        // reports GOOD (a no-op), never a spurious write at a garbage LBA.
+        let Some(&op) = cdb.first() else {
+            return GOOD;
+        };
+        if cdb.len() < cdb_len(op) {
+            return GOOD;
+        }
+        match op {
             0x0A | 0x2A => {
                 let lba = if cdb[0] == 0x0A {
                     u64::from(be24(cdb, 1) & 0x1F_FFFF)
@@ -1420,6 +1441,43 @@ mod tests {
         assert_eq!(sense[0], 0x70);
         assert_eq!(sense[2], SK_ILLEGAL_REQUEST);
         assert_eq!(sense[12], ASC_INVALID_OPCODE);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn execute_rejects_cdb_shorter_than_its_opcode_group_instead_of_panicking() {
+        // The manual (Select + Transfer Info) path sizes the command phase
+        // from the driver's TC register, not the opcode's real CDB length,
+        // so `execute()` can be handed a truncated `cdb` slice. It must
+        // reject that as a malformed CDB rather than indexing past the end.
+        let path = temp_image(64);
+        let mut disk = ScsiDisk::open(&path, 0, None).unwrap();
+
+        // Empty CDB.
+        let (exec, status) = disk.execute(&[], 0);
+        assert!(matches!(exec, ScsiExec::NoData));
+        assert_eq!(status, CHECK_CONDITION);
+
+        // WRITE(10) (0x2A) needs a 10-byte CDB; a short one must not panic
+        // when the opcode handler indexes cdb[7] for the transfer length.
+        let (exec, status) = disk.execute(&[0x2A, 0, 0, 0], 0);
+        assert!(matches!(exec, ScsiExec::NoData));
+        assert_eq!(status, CHECK_CONDITION);
+
+        // A correctly-sized CDB for the same opcode still works.
+        let (exec, status) = disk.execute(&[0x2A, 0, 0, 0, 0, 0, 0, 0, 1, 0], 0);
+        assert!(matches!(exec, ScsiExec::DataOut(n) if n == SECTOR_SIZE));
+        assert_eq!(status, GOOD);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn complete_out_rejects_short_cdb_instead_of_panicking() {
+        let path = temp_image(64);
+        let mut disk = ScsiDisk::open(&path, 0, None).unwrap();
+        assert_eq!(disk.complete_out(&[], &[0u8; SECTOR_SIZE]), GOOD);
+        assert_eq!(disk.complete_out(&[0x2A, 0, 0], &[0u8; SECTOR_SIZE]), GOOD);
         std::fs::remove_file(&path).ok();
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2702,8 +2702,10 @@ fn bar_layout(media: &MediaBar) -> BarLayout {
         cd_load: None,
         cd_eject: None,
     };
-    let connected: Vec<usize> = (0..4).filter(|&idx| media.drives[idx].connected).collect();
-    let stacked = connected.len() > 2;
+    // At most 4 drives, so track membership/position without allocating a
+    // Vec on every call (this runs on every mouse-move and frame redraw).
+    let connected_count = (0..4).filter(|&idx| media.drives[idx].connected).count();
+    let stacked = connected_count > 2;
 
     let cluster = |x: usize, y: usize, h: usize| {
         let button = |x: usize, w: usize| Rect { x, y, w, h };
@@ -2718,7 +2720,11 @@ fn bar_layout(media: &MediaBar) -> BarLayout {
     };
 
     let mut drives_end_x = MEDIA_CLUSTER_X;
-    for (pos, &idx) in connected.iter().enumerate() {
+    let mut pos = 0usize;
+    for idx in 0..4 {
+        if !media.drives[idx].connected {
+            continue;
+        }
         let (x, y, h) = if stacked {
             // Row-major two-column grid: DF0 DF1 over DF2 DF3.
             let col = pos % 2;
@@ -2740,10 +2746,11 @@ fn bar_layout(media: &MediaBar) -> BarLayout {
         layout.drive_swap[idx] = Some(swap);
         layout.drive_eject[idx] = Some(eject);
         drives_end_x = drives_end_x.max(x + MEDIA_CLUSTER_W);
+        pos += 1;
     }
 
     if media.cd.is_some() {
-        let x = if connected.is_empty() {
+        let x = if connected_count == 0 {
             MEDIA_CLUSTER_X
         } else {
             drives_end_x + MEDIA_CD_GAP

--- a/src/wasmboard.rs
+++ b/src/wasmboard.rs
@@ -170,6 +170,7 @@ impl WasmRuntime {
             int6: instance.get_typed_func(&mut store, "int6").ok(),
         };
         if let Ok(init) = instance.get_typed_func::<(), ()>(&mut store, "init") {
+            refuel(&mut store);
             init.call(&mut store, ())
                 .context("WASM plugin init() trapped")?;
         }
@@ -237,15 +238,35 @@ fn load_resources(manifest: &WasmManifest) -> Result<HashMap<String, Vec<u8>>> {
     Ok(map)
 }
 
+/// Fuel budget refilled before every entry into a plugin. Copperline runs
+/// synchronously on the main emulation thread (see CLAUDE.md), so a plugin
+/// with a runaway loop in `init`/`read`/`write`/`tick`/`int2`/`int6` would
+/// otherwise hang the whole process forever with no recovery path. This
+/// bounds a single call to a large but finite instruction budget instead;
+/// exhausting it surfaces as an ordinary trap through the existing
+/// log-and-fall-back-to-default handling at each call site.
+const PLUGIN_FUEL_BUDGET: u64 = 50_000_000;
+
+/// Refill a store's fuel to [`PLUGIN_FUEL_BUDGET`] ahead of a plugin call.
+/// Only fails if fuel consumption isn't configured on the engine, which
+/// `make_engine` always enables.
+fn refuel(store: &mut Store<HostCtx>) {
+    store
+        .set_fuel(PLUGIN_FUEL_BUDGET)
+        .expect("engine always configures consume_fuel(true)");
+}
+
 /// Build the deterministic wasmtime engine. NaN canonicalization removes
 /// host-CPU NaN bit-pattern leakage; SIMD/relaxed-SIMD/threads are disabled
 /// (relaxed-SIMD is nondeterministic by spec, threads add shared-memory
-/// nondeterminism).
+/// nondeterminism). Fuel consumption caps how long any single call into a
+/// plugin can run (see [`PLUGIN_FUEL_BUDGET`]).
 fn make_engine() -> Result<Engine> {
     let mut cfg = Config::new();
     cfg.cranelift_nan_canonicalization(true);
     cfg.wasm_simd(false);
     cfg.wasm_relaxed_simd(false);
+    cfg.consume_fuel(true);
     // The `threads` wasmtime feature is not built in (see Cargo.toml), so shared
     // memory / atomics are unavailable -- no separate knob needed.
     Engine::new(&cfg).context("creating WASM engine")
@@ -344,7 +365,12 @@ fn register_host_fns(linker: &mut Linker<HostCtx>, caps: WasmCaps) -> Result<()>
             "env",
             "dma_read",
             |mut caller: Caller<'_, HostCtx>, addr: i32, ptr: i32, len: i32| -> Result<()> {
-                let len = len.max(0) as usize;
+                // Validate the destination window before allocating, so a
+                // plugin-controlled `len` can't force an oversized host
+                // allocation (see `checked_wasm_window`). `write_wasm_bytes`
+                // below re-validates the same window when it stores `buf`.
+                let mem_size = caller_memory(&mut caller)?.data_size(&caller);
+                let (_, len) = checked_wasm_window(ptr, len, mem_size)?;
                 let mut buf = vec![0u8; len];
                 with_amiga_memory(&caller, |amiga| {
                     DeviceHost::new(amiga).dma_read(addr as u32, &mut buf);
@@ -415,13 +441,29 @@ fn with_amiga_memory(caller: &Caller<'_, HostCtx>, f: impl FnOnce(&mut Memory)) 
     f(amiga);
 }
 
+/// Validate a plugin-supplied `[ptr, ptr+len)` window against the plugin's
+/// current linear-memory size, returning the clamped `(ptr, len)`. `ptr`
+/// and `len` are plugin-controlled and unrelated to how much memory the
+/// plugin actually has, so an out-of-range window is rejected *before* the
+/// host allocates `len` bytes -- otherwise a huge `len` (up to ~2 GiB via
+/// i32) would force an oversized host allocation per call. An out-of-range
+/// window is a clean error, exactly as the previous trap-on-access was.
+fn checked_wasm_window(ptr: i32, len: i32, mem_size: usize) -> Result<(usize, usize)> {
+    let ptr = ptr.max(0) as usize;
+    let len = len.max(0) as usize;
+    if ptr.checked_add(len).is_none_or(|end| end > mem_size) {
+        anyhow::bail!("WASM plugin memory window {ptr}+{len} exceeds {mem_size} bytes");
+    }
+    Ok((ptr, len))
+}
+
 /// Read `len` bytes from the plugin's linear memory at `ptr`.
 fn read_wasm_bytes(caller: &mut Caller<'_, HostCtx>, ptr: i32, len: i32) -> Result<Vec<u8>> {
     let memory = caller_memory(caller)?;
-    let len = len.max(0) as usize;
+    let (ptr, len) = checked_wasm_window(ptr, len, memory.data_size(&caller))?;
     let mut buf = vec![0u8; len];
     memory
-        .read(&mut *caller, ptr.max(0) as usize, &mut buf)
+        .read(&mut *caller, ptr, &mut buf)
         .context("reading WASM plugin memory")?;
     Ok(buf)
 }
@@ -481,6 +523,7 @@ impl WasmBoard {
         let Some(func) = sel(&rt.exports) else {
             return false;
         };
+        refuel(&mut rt.store);
         match func.call(&mut rt.store, ()) {
             Ok(v) => v != 0,
             Err(e) => {
@@ -498,6 +541,7 @@ impl ZorroDevice for WasmBoard {
             return 0xFFFF_FFFF;
         };
         rt.enter(host.memory_mut());
+        refuel(&mut rt.store);
         let result = func.call(&mut rt.store, (off as i32, size as i32));
         rt.leave();
         match result {
@@ -515,6 +559,7 @@ impl ZorroDevice for WasmBoard {
             return;
         };
         rt.enter(host.memory_mut());
+        refuel(&mut rt.store);
         let result = func.call(&mut rt.store, (off as i32, size as i32, value as i32));
         rt.leave();
         if let Err(e) = result {
@@ -528,6 +573,7 @@ impl ZorroDevice for WasmBoard {
             return;
         };
         rt.enter(host.memory_mut());
+        refuel(&mut rt.store);
         let result = func.call(&mut rt.store, cck as i32);
         rt.leave();
         if let Err(e) = result {
@@ -721,6 +767,58 @@ mod tests {
         }
         assert_eq!(fresh.read(0, 2, &mut host), 5);
         assert!(fresh.int2_line());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A runaway plugin: `tick` never returns. Copperline runs synchronously
+    /// on the main thread, so without a fuel cap this would hang the whole
+    /// emulator forever instead of trapping.
+    const INFINITE_LOOP_WAT: &str = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "tick") (param $cck i32)
+            (loop $forever
+              (br $forever)))
+        )
+    "#;
+
+    #[test]
+    fn runaway_plugin_loop_traps_on_fuel_instead_of_hanging() {
+        let path = write_wasm("infinite_loop", INFINITE_LOOP_WAT);
+        let mut board = WasmBoard::from_file(&path, manifest("infinite_loop", false)).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+
+        // Must return (the fuel budget traps the loop) rather than hang;
+        // the test process itself would time out if it didn't.
+        board.tick(1, &mut host);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// `write(off, size, len)` calls `dma_read` with a caller-supplied
+    /// length instead of a fixed one, to exercise an oversized `len`.
+    const DMA_OVERSIZED_LEN_WAT: &str = r#"
+        (module
+          (import "env" "dma_read" (func $dma_read (param i32 i32 i32)))
+          (memory (export "memory") 1)
+          (func (export "write") (param $off i32) (param $size i32) (param $len i32)
+            (call $dma_read (i32.const 0) (i32.const 0) (local.get $len)))
+        )
+    "#;
+
+    #[test]
+    fn dma_read_with_oversized_len_does_not_allocate_unbounded_memory() {
+        let path = write_wasm("dma_oversized", DMA_OVERSIZED_LEN_WAT);
+        let mut board = WasmBoard::from_file(&path, manifest("dma_oversized", true)).unwrap();
+        let mut mem = empty_memory();
+        let mut host = DeviceHost::new(&mut mem);
+
+        // len = i32::MAX: without capping the allocation to the plugin's
+        // actual (1-page = 64 KiB) linear memory, this would attempt a
+        // ~2 GiB host allocation on every call.
+        board.write(0, 0, i32::MAX as u32, &mut host);
 
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
## Summary

A behavior-preserving code cleanup pass across the emulator, plus a handful of genuine robustness fixes surfaced along the way. Every change is either a bug fix with a targeted regression test or a refactor that leaves observable behavior identical.

**All 1221 unit tests pass; `cargo clippy --all-targets` and `cargo fmt --check` are clean; release builds.**

`src/video/bitplane.rs` was deliberately left untouched (work in progress elsewhere).

## Robustness / correctness fixes (each with a regression test)

- **CIA**: a single CRA write that both starts a timer (bit 0) and toggles SPMODE (bit 6) no longer silently drops the keyboard-handshake edge. `CiaSideEffect` is now a struct of independent flags rather than an exclusive enum.
- **SCSI**: reject a CDB shorter than its opcode group instead of indexing out of bounds when the driver's TC register under-sizes the command phase.
- **CD**: reject a malformed `.cue` sheet whose track INDEX claims more bytes than the file actually holds, instead of underflowing the region-size arithmetic.
- **WASM plugin host**: validate plugin-supplied read/DMA windows against the plugin's actual linear-memory size *before* allocating, and cap each plugin call with a fuel budget so a runaway loop traps rather than hanging the single-threaded emulator.
- **DMS**: saturate the Huffman bit-length subtractions so a corrupt `.dms` stream fails its CRC check rather than panicking.
- **gdbstub**: bound the packet payload and `m`-packet length, convert the checksum-retry recursion to a loop (stack safety on a hostile peer), and stop panicking on a non-UTF-8 target-XML slice.

## Duplication removed

- **cpu.rs**: the CPU-visible plain-memory address map was decoded three separate times (peek / debug-write / uncached read+write); now a single classifier feeds all three, preserving exact region order and per-path semantics.
- **bus.rs vs agnus.rs**: bus.rs kept an independently-maintained twin of the bitplane fetch-timing helpers; it now delegates to the one agnus.rs implementation.
- **bus.rs**: the per-frame render/capture-buffer reset was duplicated across the keyboard-reset and state-load paths; now one shared helper (verified field-by-field to produce identical mutations at both call sites).
- **blitter.rs**: line-mode octant decode uses named `BLTCON1_SUD`/`SUL`/`AUL` constants; added tests cross-checking the synchronous `execute` path against the scheduled FSM.
- **main.rs**: the repeated CLI "missing arg / bad value" parse boilerplate collapses to a single `next_arg` helper (error strings preserved verbatim).
- Shared `to_bcd` (cdrom / cdtv / akiko).

## Hot-path tidy-ups

- Paula audio-DMA modulation events reuse a scratch buffer instead of allocating a `Vec` per call.
- Akiko sector/subcode DMA uses a bulk copy instead of per-byte masked stores.
- bus.rs sprite descriptor loop-detection uses a small `Vec` instead of a per-call `HashSet`.
- window.rs status-bar layout counts drives instead of collecting a `Vec` on every mouse move.
- floppy.rs write-through updates only the changed ADF sectors on disk instead of rewriting the whole image on every write-DMA completion.

## Other

- Splits `begin_new_beam_frame`'s diagnostic logging out of its frame-boundary bookkeeping.
- Documents the Akiko PBX slot-fill order as an empirical model (WinUAE and MAME disagree; no datasheet exists) with a TODO, rather than justifying it with a game title.

## Deliberately not done

Splitting `write_custom_word_from` (905-line register dispatcher, no integration-test coverage here), the `config.rs` `TryFrom` split, and the video/UI dedup were investigated and left alone: on inspection those candidates were either already compiler-safe (exhaustive matches, shared rect helpers), genuinely different (config-name vs display-label), intentional by design (spelled-out enum for `Copy` hit-testing), or risky to mechanize (non-uniform closures, ordering-sensitive dispatch) — forcing them would trade real readability/regression-risk for marginal DRYness.
