### PR TITLE
Fix Paula deferred AUDxEN disable and add an audio debugger tab

### DIFF
--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -36,6 +36,29 @@ pointers, and the full palette.
 decoded targets and positions -- and highlights the instruction at the
 current Copper fetch address.
 
+**Audio** decodes Paula's four audio channels. A header line shows DMACON
+(master DMAEN and the per-channel AUDx enable bits) and ADKCON (the audio
+attach bits for volume/period modulation). Each channel then shows its DMA
+state-machine state (Off, Manual, ManualHold, StartPending, Running), whether
+its DMA is enabled, its interrupt-pending flag, the CPU latches
+(AUDxLC/LEN/PER/VOL), and the live playback state: the current pointer, words
+remaining, the period accumulator, the output phase, and the sample currently
+on the output. A `pending:` line appears when the channel is holding a
+deferred DMA-disable (AUDxEN cleared mid-word), a deferred loop reload, a
+manual AUDxDAT write, an outstanding DMA request, or a fetched-ahead word.
+Step frames (**Frame**) to watch the state machine advance -- the Running
+line is highlighted while a channel is actively streaming samples.
+
+Each channel row also has a **Mute** button on the left and an oscilloscope on
+the right; a fifth row at the bottom does the same for the **CD-DA** audio
+stream (CDTV/CD32). The oscilloscope traces the channel's output level (the DAC
+sample scaled by AUDxVOL), so both the waveform and its loudness are visible;
+the CD scope traces the mixed CD stereo level. Clicking **Mute** silences that
+channel (or the CD stream) in the host output while leaving its trace drawn
+(greyed) so you can still see what it would play. Mutes are developer aids:
+they change only the audio you hear, never the emulated Paula state, and are
+not part of a save state.
+
 **Memory** is a hex/ASCII dump, 256 bytes per page. Type a hex address in
 the `$` box and press Enter to jump there; the `<` and `>` buttons page by
 256 bytes.

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -119,6 +119,10 @@ modelled 68000 recognition latency), serial, and audio:
   a period accumulator clocked at CCK rate, and the hardware's one-word
   fetch-ahead (audible with short periods). Channel interrupts fire on
   buffer completion; LEN=0 plays a full 65536-word block, as on hardware.
+  Clearing AUDxEN while a DMA word is being output is deferred until the
+  current word boundary, so a clear/set pair shorter than the remaining
+  word time is missed by the audio state machine and playback continues
+  instead of restarting from AUDxLC.
   Output is mixed in emulated time to stereo with the LED filter, then
   resampled at the host boundary.
 - **Serial**: SERDAT through a one-word transmit buffer and a timed shift

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -76,9 +76,54 @@ enum ChanState {
     Running,
 }
 
+impl ChanState {
+    /// Short label for the debugger's audio tab.
+    fn name(self) -> &'static str {
+        match self {
+            ChanState::Off => "Off",
+            ChanState::Manual => "Manual",
+            ChanState::ManualHold => "ManualHold",
+            ChanState::StartPending => "StartPending",
+            ChanState::Running => "Running",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AudioDmaRequest {
     pub address: u32,
+}
+
+/// Read-only snapshot of one audio channel's live state, for the debugger
+/// window's Audio tab. Mirrors the private `AudChannel` fields; there is no
+/// serialized state here, so exposing it costs nothing at runtime.
+#[derive(Debug, Clone, Copy)]
+pub struct AudioChannelDebug {
+    /// State-machine state (Off/Manual/ManualHold/StartPending/Running).
+    pub state: &'static str,
+    // CPU-visible latches.
+    pub lc: u32,
+    pub len: u16,
+    pub per: u16,
+    pub vol: u8,
+    // Live buffer position.
+    pub ptr: u32,
+    pub words_left: u32,
+    // Output engine.
+    pub period_acc: u32,
+    pub phase: u8,
+    pub current: i8,
+    /// AUDxEN was cleared mid-word and the disable is deferred to the next
+    /// word boundary (issue-74 behaviour).
+    pub dma_disable_pending: bool,
+    /// Length counter underflowed; the AUDxLC/AUDxLEN loop reload is deferred.
+    pub restart_pending: bool,
+    /// A CPU AUDxDAT write is waiting to play (manual mode).
+    pub manual_pending: bool,
+    /// A DMA fetch is pending to Agnus.
+    pub dma_request: bool,
+    /// The one-word fetch-ahead register holds a prefetched word.
+    pub next_word_ready: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -379,6 +424,10 @@ pub struct CdAudioRing {
 /// 32 sectors (~0.43 s) of buffered CD audio.
 const CD_AUDIO_RING_LIMIT: usize = 32 * 588;
 
+/// Length of each debugger oscilloscope ring (host output samples, ~5.8 ms
+/// at the 44.1 kHz mixer rate).
+const AUDIO_SCOPE_LEN: usize = 256;
+
 impl CdAudioRing {
     /// Decode one 2352-byte CD-DA sector (s16le interleaved stereo) into
     /// the ring. Returns false (dropping the sector) when full.
@@ -406,6 +455,15 @@ impl CdAudioRing {
 
     pub fn clear(&mut self) {
         self.samples.clear();
+    }
+}
+
+/// Push one sample into a debugger oscilloscope ring, evicting the oldest
+/// once the ring is full so it always holds the most recent AUDIO_SCOPE_LEN.
+fn scope_push(ring: &mut std::collections::VecDeque<i8>, sample: i8) {
+    ring.push_back(sample);
+    while ring.len() > AUDIO_SCOPE_LEN {
+        ring.pop_front();
     }
 }
 
@@ -477,6 +535,22 @@ pub struct Paula {
     // recordings stay full scale regardless of the volume slider) for
     // the window's video recorder to drain once per emulated frame.
     capture: Option<Vec<(f32, f32)>>,
+    // Developer mute switches (debugger audio tab). Muting a channel or the
+    // CD-DA stream silences its contribution to the host output only; the
+    // Paula state machine, counters and interrupts keep running exactly as
+    // before, so this is not emulated state and never touches a save state.
+    #[serde(skip)]
+    channel_muted: [bool; 4],
+    #[serde(skip)]
+    cd_muted: bool,
+    // Rolling per-channel and CD output-level scopes for the debugger's
+    // oscilloscope meters. Each holds the most recent AUDIO_SCOPE_LEN host
+    // output samples (output level = DAC sample * volume, -128..127). Purely
+    // a debug tap, so it is skipped by the save state.
+    #[serde(skip)]
+    channel_scope: [std::collections::VecDeque<i8>; 4],
+    #[serde(skip)]
+    cd_scope: std::collections::VecDeque<i8>,
 }
 
 impl Paula {
@@ -519,6 +593,12 @@ impl Paula {
             audio_mod_next_period: [false; 4],
             audio_min_period_cck: PAL_AUDIO_MIN_PERIOD_CCK,
             capture: None,
+            channel_muted: [false; 4],
+            cd_muted: false,
+            channel_scope: std::array::from_fn(|_| {
+                std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1)
+            }),
+            cd_scope: std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1),
         }
     }
 
@@ -535,6 +615,42 @@ impl Paula {
             Some(buf) => std::mem::take(buf),
             None => Vec::new(),
         }
+    }
+
+    /// Developer mute for one audio channel (debugger audio tab). Toggling
+    /// silences the channel's contribution to the host output without
+    /// disturbing its state machine, counters or interrupts.
+    pub fn toggle_channel_muted(&mut self, ch_idx: usize) {
+        if let Some(flag) = self.channel_muted.get_mut(ch_idx) {
+            *flag = !*flag;
+        }
+    }
+
+    pub fn channel_muted(&self, ch_idx: usize) -> bool {
+        self.channel_muted.get(ch_idx).copied().unwrap_or(false)
+    }
+
+    /// Developer mute for the CD-DA stream (CDTV/CD32).
+    pub fn toggle_cd_muted(&mut self) {
+        self.cd_muted = !self.cd_muted;
+    }
+
+    pub fn cd_muted(&self) -> bool {
+        self.cd_muted
+    }
+
+    /// Snapshot of a channel's oscilloscope ring (oldest..newest output
+    /// levels, up to AUDIO_SCOPE_LEN samples) for the debugger meter.
+    pub fn audio_scope_samples(&self, ch_idx: usize) -> Vec<i8> {
+        self.channel_scope
+            .get(ch_idx)
+            .map(|ring| ring.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Snapshot of the CD-DA oscilloscope ring (oldest..newest).
+    pub fn cd_scope_samples(&self) -> Vec<i8> {
+        self.cd_scope.iter().copied().collect()
     }
 
     pub fn set_dma_addr_mask(&mut self, mask: u32) {
@@ -571,6 +687,28 @@ impl Paula {
     #[cfg(test)]
     pub fn audio_current_sample_for_test(&self, ch_idx: usize) -> Option<i8> {
         self.chans.get(ch_idx).map(|ch| ch.current)
+    }
+
+    /// Read-only snapshot of a channel's live state for the debugger.
+    pub fn audio_channel_debug(&self, ch_idx: usize) -> Option<AudioChannelDebug> {
+        let ch = self.chans.get(ch_idx)?;
+        Some(AudioChannelDebug {
+            state: ch.state.name(),
+            lc: ch.lc,
+            len: ch.len,
+            per: ch.per,
+            vol: ch.vol,
+            ptr: ch.ptr,
+            words_left: ch.words_left,
+            period_acc: ch.period_acc,
+            phase: ch.phase,
+            current: ch.current,
+            dma_disable_pending: ch.dma_disable_pending,
+            restart_pending: ch.restart_pending,
+            manual_pending: ch.manual_pending,
+            dma_request: ch.dma_request,
+            next_word_ready: ch.next_word.is_some(),
+        })
     }
 
     pub fn reset_registers(&mut self) {
@@ -1529,6 +1667,14 @@ impl Paula {
         // unclipped: worst case is +/-2.0 if both channels saturate
         // with full volume in opposite phase, which is essentially
         // never the case for real music.
+        // Tap each channel's output level (DAC sample * volume, -128..127)
+        // for the debugger oscilloscopes. This is pre-mute so a muted
+        // channel's trace still shows its activity (drawn greyed).
+        for i in 0..4 {
+            let level =
+                ((self.chans[i].current as i32 * self.chans[i].vol as i32) / 64).clamp(-128, 127);
+            scope_push(&mut self.channel_scope[i], level as i8);
+        }
         let l_raw = self.channel_mixed_sample(0) + self.channel_mixed_sample(3);
         let r_raw = self.channel_mixed_sample(1) + self.channel_mixed_sample(2);
         let scale = 1.0 / (128.0 * 64.0);
@@ -1546,7 +1692,16 @@ impl Paula {
         // CD audio (CD32/CDTV) is line-mixed with Paula's output after
         // the LED filter, like the real mixer stage, and also sits under
         // the master volume control.
-        let (cd_left, cd_right) = self.cd_audio.next_sample();
+        let (mut cd_left, mut cd_right) = self.cd_audio.next_sample();
+        // Record the pre-mute CD level for the debugger scope, then apply
+        // the developer CD mute so the trace still shows activity while the
+        // stream is silenced in the mix.
+        let cd_level = (((cd_left + cd_right) * 0.5).clamp(-1.0, 1.0) * 127.0) as i8;
+        scope_push(&mut self.cd_scope, cd_level);
+        if self.cd_muted {
+            cd_left = 0.0;
+            cd_right = 0.0;
+        }
         left += cd_left;
         right += cd_right;
         if let Some(capture) = &mut self.capture {
@@ -1557,7 +1712,7 @@ impl Paula {
     }
 
     fn channel_mixed_sample(&self, ch_idx: usize) -> i32 {
-        if self.channel_attached_as_modulator(ch_idx) {
+        if self.channel_muted[ch_idx] || self.channel_attached_as_modulator(ch_idx) {
             0
         } else {
             let ch = &self.chans[ch_idx];
@@ -2269,6 +2424,147 @@ mod tests {
         assert_eq!(paula.chans[0].state, ChanState::Running);
         assert_eq!(paula.chans[0].current, 0x12);
         assert_eq!(paula.chans[0].period_acc, 1);
+    }
+
+    #[test]
+    fn audio_channel_debug_snapshot_mirrors_live_state() {
+        let (mut paula, _) = paula_with_collect_sink();
+        let mut ram = vec![0u8; 64];
+        ram[0] = 0x12;
+        ram[1] = 0x34;
+        let dmacon = DMACON_DMAEN | 0x0001;
+
+        paula.write_audio_reg(0x00, 0);
+        paula.write_audio_reg(0x02, 0);
+        paula.write_audio_reg(0x04, 2);
+        paula.write_audio_reg(0x06, 8);
+        paula.write_audio_reg(0x08, 40);
+        paula.tick_audio(1, dmacon, &ram);
+        paula.tick_audio(3, dmacon, &ram);
+
+        let dbg = paula.audio_channel_debug(0).expect("channel 0 snapshot");
+        assert_eq!(dbg.state, "Running");
+        assert_eq!(dbg.per, 8);
+        assert_eq!(dbg.vol, 40);
+        assert_eq!(dbg.current, 0x12);
+        assert_eq!(dbg.period_acc, 4);
+        assert!(!dbg.dma_disable_pending);
+
+        // Clearing AUDxEN mid-word defers the disable; the snapshot exposes it.
+        paula.tick_audio(1, 0, &ram);
+        let dbg = paula.audio_channel_debug(0).expect("channel 0 snapshot");
+        assert_eq!(dbg.state, "Running");
+        assert!(dbg.dma_disable_pending);
+
+        assert!(paula.audio_channel_debug(4).is_none());
+    }
+
+    #[test]
+    fn audio_channel_mute_silences_mix_but_keeps_state() {
+        let (mut paula, _) = paula_with_collect_sink();
+        let mut ram = vec![0u8; 64];
+        ram[0] = 0x40;
+        ram[1] = 0x40;
+        let dmacon = DMACON_DMAEN | 0x0001;
+        paula.write_audio_reg(0x00, 0);
+        paula.write_audio_reg(0x02, 0);
+        paula.write_audio_reg(0x04, 2);
+        paula.write_audio_reg(0x06, 8);
+        paula.write_audio_reg(0x08, 40);
+        paula.tick_audio(1, dmacon, &ram);
+        paula.tick_audio(3, dmacon, &ram);
+
+        // The channel contributes to the stereo mix.
+        assert_ne!(paula.channel_mixed_sample(0), 0);
+        let before = paula.audio_channel_debug(0).unwrap();
+
+        // Muting zeroes the mix contribution but leaves the state machine,
+        // volume, output sample and pointer untouched.
+        paula.toggle_channel_muted(0);
+        assert!(paula.channel_muted(0));
+        assert_eq!(paula.channel_mixed_sample(0), 0);
+        let after = paula.audio_channel_debug(0).unwrap();
+        assert_eq!(after.state, before.state);
+        assert_eq!(after.current, before.current);
+        assert_eq!(after.vol, before.vol);
+        assert_eq!(after.ptr, before.ptr);
+
+        // Unmuting restores the contribution.
+        paula.toggle_channel_muted(0);
+        assert!(!paula.channel_muted(0));
+        assert_ne!(paula.channel_mixed_sample(0), 0);
+    }
+
+    #[test]
+    fn audio_scope_records_channel_output_level_even_when_muted() {
+        let (mut paula, _) = paula_with_collect_sink();
+        let mut ram = vec![0u8; 512 * 1024];
+        for byte in &mut ram[0..4] {
+            *byte = 0x40;
+        }
+        let dmacon = DMACON_DMAEN | 0x0001;
+        paula.write_audio_reg(0x00, 0);
+        paula.write_audio_reg(0x02, 0);
+        paula.write_audio_reg(0x04, 2);
+        paula.write_audio_reg(0x06, 80);
+        paula.write_audio_reg(0x08, 64);
+
+        paula.tick_audio(4000, dmacon, &ram);
+        let scope = paula.audio_scope_samples(0);
+        assert!(!scope.is_empty());
+        assert!(scope.len() <= AUDIO_SCOPE_LEN);
+        assert!(
+            scope.iter().any(|&s| s != 0),
+            "scope should trace the channel output"
+        );
+
+        // The scope tap is pre-mute, so a muted channel keeps tracing.
+        paula.toggle_channel_muted(0);
+        assert!(paula.channel_muted(0));
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(paula.audio_scope_samples(0).iter().any(|&s| s != 0));
+    }
+
+    #[test]
+    fn cd_audio_mute_zeroes_cd_contribution_but_scope_keeps_tracing() {
+        let (mut paula, frames) = paula_with_collect_sink();
+        paula.set_led_filter_enabled(false);
+        let ram = vec![0u8; 64];
+        // One CD-DA sector (2352 bytes = 588 s16le stereo frames) of a
+        // constant non-zero level.
+        let mut sector = vec![0u8; 2352];
+        for frame in sector.chunks_exact_mut(4) {
+            frame[0..2].copy_from_slice(&4000i16.to_le_bytes());
+            frame[2..4].copy_from_slice(&4000i16.to_le_bytes());
+        }
+        // No Paula channel audio, so the sink output is CD-only.
+        let dmacon = DMACON_DMAEN;
+        paula.cd_audio_mut().push_sector(&sector);
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(
+            frames
+                .borrow()
+                .iter()
+                .any(|&(l, r)| l.abs() > 1e-3 || r.abs() > 1e-3),
+            "CD audio should reach the sink"
+        );
+        assert!(paula.cd_scope_samples().iter().any(|&s| s != 0));
+
+        // Muted: the CD stream is silent in the mix, but the scope still
+        // records the pre-mute level.
+        frames.borrow_mut().clear();
+        paula.toggle_cd_muted();
+        assert!(paula.cd_muted());
+        paula.cd_audio_mut().push_sector(&sector);
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(
+            frames
+                .borrow()
+                .iter()
+                .all(|&(l, r)| l.abs() < 1e-6 && r.abs() < 1e-6),
+            "muted CD must be silent"
+        );
+        assert!(paula.cd_scope_samples().iter().any(|&s| s != 0));
     }
 
     #[test]

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -102,6 +102,11 @@ struct AudChannel {
     dat_latch: u16,
     manual_pending: bool,
     dma_request: bool,
+    /// AUDxEN was cleared while the DMA state machine was outputting a
+    /// word. Paula only samples that clear at the next word boundary; if
+    /// software sets AUDxEN again before then, playback continues without
+    /// a fresh start.
+    dma_disable_pending: bool,
     /// Set when the length counter underflowed and the channel raised its
     /// interrupt, but the AUDxLC/AUDxLEN reload for the next buffer has
     /// not been applied yet. Real Paula leaves a one-word gap between the
@@ -143,6 +148,7 @@ impl AudChannel {
             dat_latch: 0,
             manual_pending: false,
             dma_request: false,
+            dma_disable_pending: false,
             restart_pending: false,
             next_word: None,
         }
@@ -176,6 +182,7 @@ impl AudChannel {
         self.period_acc = 0;
         self.dma_fetch_cooldown_cck = 0;
         self.next_word = None;
+        self.dma_disable_pending = false;
         self.restart_pending = false;
     }
 
@@ -210,7 +217,17 @@ impl AudChannel {
         self.period_acc = 0;
         self.state = ChanState::Manual;
         self.manual_pending = false;
+        self.dma_disable_pending = false;
         self.next_word = None;
+        self.clear_dma_request();
+    }
+
+    fn finish_deferred_dma_disable(&mut self) {
+        self.state = ChanState::Off;
+        self.current = 0;
+        self.next_word = None;
+        self.restart_pending = false;
+        self.dma_disable_pending = false;
         self.clear_dma_request();
     }
 
@@ -1191,24 +1208,41 @@ impl Paula {
                 (self.last_dmacon & DMACON_DMAEN != 0) && (self.last_dmacon & (1 << ch_idx)) != 0;
             let ch = &mut self.chans[ch_idx];
             if enabled && !prev_enabled {
-                // DMA-enable rising edge: latch a fresh buffer from
-                // AUDxLC/AUDxLEN and raise the per-channel IRQ. Real
-                // Paula uses this to let the CPU prime the *next*
-                // buffer. The first word is fetched into the holding
-                // register and promoted to start playback.
-                ch.reload_buffer(ptr_mask);
-                ch.reset_dma_start_timing();
-                ch.state = ChanState::StartPending;
+                if ch.dma_disable_pending {
+                    // AUDxEN was cleared but Paula had not yet reached a
+                    // word boundary where the DMA-off state is sampled.
+                    // Re-enabling before that boundary is invisible to the
+                    // audio state machine, so keep the active shifter,
+                    // counters, and pending fetches intact.
+                    ch.dma_disable_pending = false;
+                } else {
+                    // DMA-enable rising edge: latch a fresh buffer from
+                    // AUDxLC/AUDxLEN and raise the per-channel IRQ. Real
+                    // Paula uses this to let the CPU prime the *next*
+                    // buffer. The first word is fetched into the holding
+                    // register and promoted to start playback.
+                    ch.reload_buffer(ptr_mask);
+                    ch.reset_dma_start_timing();
+                    ch.state = ChanState::StartPending;
+                    ch.request_dma();
+                    *irq_bits |= INT_AUDX[ch_idx];
+                }
                 ch.manual_pending = false;
-                ch.request_dma();
-                *irq_bits |= INT_AUDX[ch_idx];
             } else if enabled {
                 // CPU AUDxDAT writes made while DMA owns the channel
                 // update the CPU-visible data latch but must not arm a
                 // stale manual restart or replace the DMA sample word.
+                ch.dma_disable_pending = false;
                 ch.manual_pending = false;
             } else if !enabled {
-                if ch.manual_pending {
+                if matches!(ch.state, ChanState::Running) {
+                    if ch.per == 0 {
+                        ch.finish_deferred_dma_disable();
+                    } else {
+                        ch.dma_disable_pending = true;
+                    }
+                    ch.manual_pending = false;
+                } else if ch.manual_pending {
                     if self.intreq & INT_AUDX[ch_idx] == 0 {
                         ch.latch_manual_word();
                     } else {
@@ -1218,6 +1252,7 @@ impl Paula {
                     ch.state = ChanState::Off;
                     ch.current = 0;
                     ch.next_word = None;
+                    ch.dma_disable_pending = false;
                     ch.restart_pending = false;
                     ch.clear_dma_request();
                 }
@@ -1383,13 +1418,21 @@ impl Paula {
                     // soon as it is empty and the per-line fetch budget has
                     // recovered, ask Agnus for the next word so it arrives
                     // before the active word is exhausted.
-                    if ch.next_word.is_none() && ch.dma_fetch_cooldown_cck == 0 && !ch.dma_request {
+                    if !ch.dma_disable_pending
+                        && ch.next_word.is_none()
+                        && ch.dma_fetch_cooldown_cck == 0
+                        && !ch.dma_request
+                    {
                         ch.arm_next_buffer_fetch(ptr_mask);
                     }
                     if ch.period_acc < period {
                         continue;
                     }
                     ch.period_acc -= period;
+                    if ch.dma_disable_pending && ch.phase == 0 {
+                        ch.finish_deferred_dma_disable();
+                        break;
+                    }
                     // Emit the next byte and advance phase.
                     if ch.phase == 0 {
                         ch.current = ch.word_hi;
@@ -1417,7 +1460,8 @@ impl Paula {
                         // e.g. AUDxPER below the per-line fetch budget) the
                         // active word's two samples simply repeat.
                         ch.promote_next_word();
-                        if ch.next_word.is_none()
+                        if !ch.dma_disable_pending
+                            && ch.next_word.is_none()
                             && ch.dma_fetch_cooldown_cck == 0
                             && !ch.dma_request
                         {
@@ -2165,7 +2209,7 @@ mod tests {
     }
 
     #[test]
-    fn audio_dma_disable_mid_period_silences_until_reenabled() {
+    fn audio_dma_disable_reenabled_before_word_boundary_continues_stream() {
         let (mut paula, _) = paula_with_collect_sink();
         let mut ram = vec![0u8; 64];
         ram[0] = 0x12;
@@ -2181,11 +2225,48 @@ mod tests {
         assert_eq!(paula.chans[0].current, 0x12);
         assert_eq!(paula.chans[0].period_acc, 4);
 
+        // Paula does not sample AUDxEN while it is still outputting the
+        // current DMA word. If software sets the bit again before the word
+        // boundary, the clear is missed: no fresh start IRQ is raised and
+        // the period countdown continues.
         assert_eq!(paula.tick_audio(1, 0, &ram) & INT_AUD0, 0);
+        assert_eq!(paula.chans[0].state, ChanState::Running);
+        assert_eq!(paula.chans[0].current, 0x12);
+        assert_eq!(paula.chans[0].period_acc, 5);
+        assert!(paula.chans[0].dma_disable_pending);
+
+        assert_eq!(paula.tick_audio(1, dmacon, &ram) & INT_AUD0, 0);
+        assert_eq!(paula.chans[0].state, ChanState::Running);
+        assert_eq!(paula.chans[0].current, 0x12);
+        assert_eq!(paula.chans[0].period_acc, 6);
+        assert!(!paula.chans[0].dma_disable_pending);
+
+        assert_eq!(paula.tick_audio(2, dmacon, &ram) & INT_AUD0, 0);
+        assert_eq!(paula.chans[0].current, 0x34);
+    }
+
+    #[test]
+    fn audio_dma_disable_takes_effect_at_current_word_boundary() {
+        let (mut paula, _) = paula_with_collect_sink();
+        let mut ram = vec![0u8; 64];
+        ram[0] = 0x12;
+        ram[1] = 0x34;
+        let dmacon = DMACON_DMAEN | 0x0001;
+
+        paula.write_audio_reg(0x00, 0);
+        paula.write_audio_reg(0x02, 0);
+        paula.write_audio_reg(0x04, 2);
+        paula.write_audio_reg(0x06, 8);
+        assert_eq!(paula.tick_audio(1, dmacon, &ram) & INT_AUD0, INT_AUD0);
+        assert_eq!(paula.tick_audio(3, dmacon, &ram) & INT_AUD0, 0);
+        assert_eq!(paula.chans[0].period_acc, 4);
+
+        assert_eq!(paula.tick_audio(12, 0, &ram) & INT_AUD0, 0);
         assert_eq!(paula.chans[0].state, ChanState::Off);
         assert_eq!(paula.chans[0].current, 0);
 
         assert_eq!(paula.tick_audio(1, dmacon, &ram) & INT_AUD0, INT_AUD0);
+        assert_eq!(paula.chans[0].state, ChanState::Running);
         assert_eq!(paula.chans[0].current, 0x12);
         assert_eq!(paula.chans[0].period_acc, 1);
     }
@@ -2356,7 +2437,7 @@ mod tests {
         assert_eq!(paula.tick_audio(1, dmacon, &ram) & INT_AUD0, 0);
         assert!(!paula.chans[0].manual_pending);
 
-        assert_eq!(paula.tick_audio(1, 0, &ram) & INT_AUD0, 0);
+        assert_eq!(paula.tick_audio(14, 0, &ram) & INT_AUD0, 0);
         assert_eq!(paula.chans[0].state, ChanState::Off);
         assert_eq!(paula.chans[0].current, 0);
     }

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -61,7 +61,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  11: CpuCore MMU registers collapsed (removed tc/urp/srp/mmusr duplicates;
 //      mmu_sr retyped u16->u32) so the 040 MOVEC path and the page-table
 //      walker share one register set
-pub const STATE_VERSION: u32 = 11;
+//  12: Paula audio channels gained deferred AUDxEN-disable state so a DMA
+//      clear is observed at the current word boundary
+pub const STATE_VERSION: u32 = 12;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -39,6 +39,15 @@ const ENTRY_BG: u32 = rgba(8, 10, 8);
 const ENTRY_TEXT: u32 = rgba(27, 220, 71);
 const SCRIM: u32 = rgba(0, 0, 0);
 const SCRIM_ALPHA: f32 = 0.45;
+// Audio-tab oscilloscope trace colours (Paula ch0..3 then CD-DA).
+const AUDIO_SCOPE_COLORS: [u32; 5] = [
+    rgba(120, 255, 150), // ch0 green
+    rgba(96, 200, 255),  // ch1 cyan
+    rgba(230, 130, 245), // ch2 magenta
+    rgba(240, 214, 96),  // ch3 yellow
+    rgba(255, 170, 90),  // CD amber
+];
+const AUDIO_MUTE_FACE: u32 = rgba(96, 44, 44);
 
 // ---------------------------------------------------------------------------
 // Menu
@@ -155,14 +164,16 @@ pub enum DebugTab {
     Cpu,
     Chipset,
     Copper,
+    Audio,
     Memory,
     Break,
 }
 
-pub const DEBUG_TABS: [DebugTab; 5] = [
+pub const DEBUG_TABS: [DebugTab; 6] = [
     DebugTab::Cpu,
     DebugTab::Chipset,
     DebugTab::Copper,
+    DebugTab::Audio,
     DebugTab::Memory,
     DebugTab::Break,
 ];
@@ -172,6 +183,7 @@ fn debug_tab_label(tab: DebugTab) -> &'static str {
         DebugTab::Cpu => "CPU",
         DebugTab::Chipset => "Chipset",
         DebugTab::Copper => "Copper",
+        DebugTab::Audio => "Audio",
         DebugTab::Memory => "Memory",
         DebugTab::Break => "Break",
     }
@@ -346,6 +358,13 @@ pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
                     }
                 }
             }
+            if panel.tab == DebugTab::Audio {
+                for (control, button_rect) in audio_tab_button_rects(rect) {
+                    if button_rect.contains(pos) {
+                        return Some(control);
+                    }
+                }
+            }
         }
         Panel::FrameAnalyzer(_) => {
             if let Some(control) = analyzer_pick_control(rect, pos) {
@@ -410,6 +429,8 @@ pub enum UiControl {
     DebugRegToggle,
     /// Break tab: remove all breakpoints and watchpoints.
     DebugBreaksClear,
+    /// Audio tab: toggle mute for a channel (0..3 = Paula, 4 = CD audio).
+    DebugAudioMute(usize),
     /// Frame analyzer: run/pause the machine while keeping the pane open.
     AnalyzerRun,
     /// Frame analyzer: step/capture one complete Agnus frame.
@@ -626,6 +647,45 @@ fn break_tab_button_rects(rect: Rect) -> [(UiControl, Rect); 4] {
     ]
 }
 
+// Audio tab layout: a header line, four Paula channel blocks, then a CD row.
+// Each block has a mute button on the left, text detail in the middle, and an
+// oscilloscope box on the right.
+const AUDIO_HEADER_H: usize = 16;
+const AUDIO_ROW_H: usize = 46;
+const AUDIO_CD_ROW_H: usize = 30;
+const AUDIO_MUTE_W: usize = 54;
+const AUDIO_TEXT_X: usize = 70;
+const AUDIO_SCOPE_X: usize = 470;
+
+/// Geometry of one Audio-tab row: (mute button rect, scope box rect). `idx`
+/// 0..3 are the Paula channels, 4 is the CD-DA row.
+fn audio_row_geom(rect: Rect, idx: usize) -> (Rect, Rect) {
+    let top = debug_content_top(rect) + AUDIO_HEADER_H + idx.min(4) * AUDIO_ROW_H;
+    let row_h = if idx >= 4 {
+        AUDIO_CD_ROW_H
+    } else {
+        AUDIO_ROW_H
+    };
+    let mute = Rect {
+        x: rect.x + 8,
+        y: top,
+        w: AUDIO_MUTE_W,
+        h: row_h.saturating_sub(8),
+    };
+    let scope = Rect {
+        x: rect.x + AUDIO_SCOPE_X,
+        y: top,
+        w: rect.w.saturating_sub(AUDIO_SCOPE_X + 10),
+        h: row_h.saturating_sub(8),
+    };
+    (mute, scope)
+}
+
+/// The five Audio-tab mute buttons (four Paula channels then CD).
+fn audio_tab_button_rects(rect: Rect) -> [(UiControl, Rect); 5] {
+    std::array::from_fn(|i| (UiControl::DebugAudioMute(i), audio_row_geom(rect, i).0))
+}
+
 fn analyzer_raster_rect(rect: Rect) -> Rect {
     Rect {
         x: rect.x + 10,
@@ -713,6 +773,7 @@ pub struct CalibrationView {
     pub status: String,
 }
 
+#[derive(Clone)]
 pub struct DbgLine {
     pub text: String,
     pub highlight: bool,
@@ -744,6 +805,30 @@ pub struct DebuggerView {
     pub status: String,
     /// Pre-formatted content lines of the active tab.
     pub lines: Vec<DbgLine>,
+    /// Structured data for the Audio tab's per-channel mute buttons and
+    /// oscilloscopes. Some only when the Audio tab is active; the plain text
+    /// is also mirrored into `lines` for headless/text use.
+    pub audio: Option<AudioScopeView>,
+}
+
+/// Per-channel and CD audio state for the debugger Audio tab.
+pub struct AudioScopeView {
+    /// Header line (DMACON / AUDEN / ADKCON summary).
+    pub header: String,
+    /// The four Paula channels, in order.
+    pub channels: Vec<AudioRowView>,
+    /// The CD-DA row.
+    pub cd: AudioRowView,
+}
+
+/// One row of the Audio tab: text detail, mute state, and a scope trace.
+pub struct AudioRowView {
+    /// Formatted detail lines for this channel/row.
+    pub text: Vec<DbgLine>,
+    /// Whether this channel/stream is developer-muted.
+    pub muted: bool,
+    /// Oscilloscope samples (oldest..newest, output level -128..127).
+    pub scope: Vec<i8>,
 }
 
 pub struct AnalyzerMarker {
@@ -1227,27 +1312,35 @@ fn draw_debugger(
             );
         }
     }
-    // Content lines. Two transport rows sit at the bottom now (the main row
-    // plus the Step Over/Out row), so the text area ends above both.
-    let content_top = debug_content_top(rect);
-    let content_bottom = rect.y + rect.h - 2 * DEBUG_BUTTON_H - 16;
-    let pitch = 10;
-    let max_lines = content_bottom.saturating_sub(content_top) / pitch;
-    for (index, line) in view.lines.iter().take(max_lines).enumerate() {
-        let color = if line.highlight {
-            PANEL_TEXT_HILIGHT
-        } else {
-            PANEL_TEXT
-        };
-        draw_panel_text(
-            frame,
-            rect.x + 10,
-            content_top + index * pitch,
-            &line.text,
-            color,
-            1,
-            scale,
-        );
+    // The Audio tab is drawn as a custom graphical layout (mute buttons and
+    // oscilloscopes); every other tab is a plain list of content lines.
+    if panel.tab == DebugTab::Audio {
+        if let Some(audio) = &view.audio {
+            draw_audio_tab(frame, rect, audio, hover, scale);
+        }
+    } else {
+        // Content lines. Two transport rows sit at the bottom now (the main row
+        // plus the Step Over/Out row), so the text area ends above both.
+        let content_top = debug_content_top(rect);
+        let content_bottom = rect.y + rect.h - 2 * DEBUG_BUTTON_H - 16;
+        let pitch = 10;
+        let max_lines = content_bottom.saturating_sub(content_top) / pitch;
+        for (index, line) in view.lines.iter().take(max_lines).enumerate() {
+            let color = if line.highlight {
+                PANEL_TEXT_HILIGHT
+            } else {
+                PANEL_TEXT
+            };
+            draw_panel_text(
+                frame,
+                rect.x + 10,
+                content_top + index * pitch,
+                &line.text,
+                color,
+                1,
+                scale,
+            );
+        }
     }
     // Transport buttons and the hex-entry box.
     for (control, button_rect) in debug_button_rects(rect) {
@@ -1321,6 +1414,148 @@ fn draw_debugger(
                 );
             }
         }
+    }
+}
+
+/// Draw the Audio tab: a header line, four Paula channel blocks and a CD row,
+/// each with a mute button, text detail, and an output oscilloscope.
+fn draw_audio_tab(
+    frame: &mut [u8],
+    rect: Rect,
+    audio: &AudioScopeView,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    let content_top = debug_content_top(rect);
+    draw_panel_text(
+        frame,
+        rect.x + 10,
+        content_top,
+        &audio.header,
+        PANEL_TEXT_HILIGHT,
+        1,
+        scale,
+    );
+    for idx in 0..5 {
+        let (mute_rect, scope_rect) = audio_row_geom(rect, idx);
+        let row = if idx < 4 {
+            audio.channels.get(idx)
+        } else {
+            Some(&audio.cd)
+        };
+        let Some(row) = row else { continue };
+        let control = UiControl::DebugAudioMute(idx);
+        draw_mute_button(frame, mute_rect, row.muted, hover == Some(control), scale);
+        // Text detail lines to the right of the mute button.
+        for (line, dbg) in row.text.iter().enumerate() {
+            let color = if dbg.highlight {
+                PANEL_TEXT_HILIGHT
+            } else {
+                PANEL_TEXT
+            };
+            draw_panel_text(
+                frame,
+                rect.x + AUDIO_TEXT_X,
+                mute_rect.y + line * 10,
+                &dbg.text,
+                color,
+                1,
+                scale,
+            );
+        }
+        let color = AUDIO_SCOPE_COLORS[idx.min(4)];
+        draw_audio_scope(frame, scope_rect, &row.scope, color, row.muted, scale);
+    }
+}
+
+/// A single mute toggle button: red-tinted face and "Muted" label when active.
+fn draw_mute_button(frame: &mut [u8], rect: Rect, muted: bool, hover: bool, scale: usize) {
+    let face = if muted {
+        AUDIO_MUTE_FACE
+    } else if hover {
+        BUTTON_FACE_HOVER
+    } else {
+        BUTTON_FACE
+    };
+    let scaled = scale_rect(rect, scale);
+    fill_rect(frame, scaled, face, scale);
+    draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
+    let label = if muted { "Muted" } else { "Mute" };
+    let text_w = label.chars().count() * font::GLYPH_W;
+    let x = rect.x + rect.w.saturating_sub(text_w) / 2;
+    let y = rect.y + rect.h.saturating_sub(font::GLYPH_H) / 2;
+    draw_panel_text(frame, x, y, label, BUTTON_TEXT, 1, scale);
+}
+
+/// Draw one oscilloscope box: dark background, centre zero line, and a trace
+/// of the newest samples (greyed when muted).
+fn draw_audio_scope(
+    frame: &mut [u8],
+    box_rect: Rect,
+    samples: &[i8],
+    color: u32,
+    muted: bool,
+    scale: usize,
+) {
+    let scaled = scale_rect(box_rect, scale);
+    fill_rect(frame, scaled, ENTRY_BG, scale);
+    draw_rect_bevel(frame, scaled, BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, scale);
+    if box_rect.w < 3 || box_rect.h < 3 {
+        return;
+    }
+    // Interior, inset one pixel from the bevel.
+    let inner = Rect {
+        x: box_rect.x + 1,
+        y: box_rect.y + 1,
+        w: box_rect.w - 2,
+        h: box_rect.h - 2,
+    };
+    let centre_y = inner.y + inner.h / 2;
+    // Zero line.
+    fill_rect_clipped(
+        frame,
+        Rect {
+            x: inner.x,
+            y: centre_y,
+            w: inner.w,
+            h: 1,
+        },
+        inner,
+        PANEL_TEXT_DIM,
+        scale,
+    );
+    if samples.is_empty() {
+        return;
+    }
+    let trace = if muted { PANEL_TEXT_DIM } else { color };
+    // Map the newest `inner.w` samples across the box (1 sample per column),
+    // connecting consecutive points with a vertical span so the trace reads as
+    // a continuous waveform. Amplitude: +/-128 maps to half the box height.
+    let half = (inner.h / 2).max(1);
+    let start = samples.len().saturating_sub(inner.w);
+    let window = &samples[start..];
+    let sample_y = |s: i8| -> usize {
+        let offset = (s as i32 * half as i32) / 128;
+        (centre_y as i32 - offset).clamp(inner.y as i32, (inner.y + inner.h - 1) as i32) as usize
+    };
+    let mut prev_y = sample_y(window[0]);
+    for (col, &s) in window.iter().enumerate() {
+        let x = inner.x + col;
+        let y = sample_y(s);
+        let (top, bottom) = (prev_y.min(y), prev_y.max(y));
+        fill_rect_clipped(
+            frame,
+            Rect {
+                x,
+                y: top,
+                w: 1,
+                h: bottom - top + 1,
+            },
+            inner,
+            trace,
+            scale,
+        );
+        prev_y = y;
     }
 }
 
@@ -3059,6 +3294,24 @@ pub fn sr_flags(sr: u16) -> String {
     format!("{trace}{mode} IPL{ipl} {ccr}")
 }
 
+/// ADKCON audio-modulation attach bits (bits 0-7). Vx = the channel's
+/// volume modulates the next channel; Px = its period modulates the next.
+const ADKCON_AUDIO_BITS: [(u16, &str); 8] = [
+    (1 << 7, "3PN"),
+    (1 << 6, "2P3"),
+    (1 << 5, "1P2"),
+    (1 << 4, "0P1"),
+    (1 << 3, "3VN"),
+    (1 << 2, "2V3"),
+    (1 << 1, "1V2"),
+    (1 << 0, "0V1"),
+];
+
+/// The set ADKCON audio attach bits, or "-" when no channels are attached.
+pub fn adkcon_audio_flags(value: u16) -> String {
+    decode_bits(value, &ADKCON_AUDIO_BITS)
+}
+
 /// One hex-dump row: address, 16 bytes as hex, then printable ASCII.
 pub fn hex_dump_row(addr: u32, bytes: &[u8]) -> String {
     let hex: Vec<String> = bytes.iter().map(|b| format!("{b:02X}")).collect();
@@ -3205,6 +3458,11 @@ mod tests {
         let tab = debug_tab_rect(rect, 3);
         assert_eq!(
             ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2)),
+            Some(UiControl::DebugTab(DebugTab::Audio))
+        );
+        let tab = debug_tab_rect(rect, 4);
+        assert_eq!(
+            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2)),
             Some(UiControl::DebugTab(DebugTab::Memory))
         );
         let (control, step) = debug_button_rects(rect)[1];
@@ -3226,6 +3484,28 @@ mod tests {
         let pos = (toggle.x as i32 + 2, toggle.y as i32 + 2);
         assert_eq!(ui_break.control_at(pos), Some(UiControl::DebugBreakToggle));
         // On another tab the same position is just panel body.
+        assert_eq!(ui.control_at(pos), Some(UiControl::PanelBody));
+
+        // Audio-tab mute buttons hit-test only while the Audio tab is active.
+        let mut panel = DebuggerPanel::new();
+        panel.tab = DebugTab::Audio;
+        let ui_audio = UiState {
+            menu_open: false,
+            panel: Some(Panel::Debugger(panel)),
+        };
+        let (control, mute0) = audio_tab_button_rects(rect)[0];
+        assert_eq!(control, UiControl::DebugAudioMute(0));
+        let pos = (mute0.x as i32 + 2, mute0.y as i32 + 2);
+        assert_eq!(ui_audio.control_at(pos), Some(UiControl::DebugAudioMute(0)));
+        // The CD mute is the fifth (index 4) button.
+        let (cd_control, cd_mute) = audio_tab_button_rects(rect)[4];
+        assert_eq!(cd_control, UiControl::DebugAudioMute(4));
+        let cd_pos = (cd_mute.x as i32 + 2, cd_mute.y as i32 + 2);
+        assert_eq!(
+            ui_audio.control_at(cd_pos),
+            Some(UiControl::DebugAudioMute(4))
+        );
+        // On another tab that position does not resolve to a mute.
         assert_eq!(ui.control_at(pos), Some(UiControl::PanelBody));
 
         let mut panel = DebuggerPanel::new();
@@ -3593,6 +3873,7 @@ mod tests {
             reverse_available: true,
             status: "paused frame 1234 24.68s".to_string(),
             lines,
+            audio: None,
         });
         let mut panel = DebuggerPanel::new();
         panel.entry = "C00000".to_string();
@@ -3634,6 +3915,7 @@ mod tests {
             reverse_available: true,
             status: "paused frame 1234 24.68s".to_string(),
             lines,
+            audio: None,
         });
         let mut panel = DebuggerPanel::new();
         panel.tab = DebugTab::Break;
@@ -3656,6 +3938,100 @@ mod tests {
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "debugger-break");
+
+        // Audio tab: the four Paula channels plus CD, with representative
+        // state, mute buttons (AUD2 shown muted), and synthetic scope traces.
+        let mut frame = vec![0u8; w * h * 4];
+        let wave = |amp: f32, cycles: f32| -> Vec<i8> {
+            (0..220)
+                .map(|i| {
+                    let t = i as f32 / 220.0 * cycles * std::f32::consts::TAU;
+                    (amp * t.sin()) as i8
+                })
+                .collect()
+        };
+        let header = "DMACON 8203  DMAEN on  AUDEN 1 1 . .   ADKCON 0000  -".to_string();
+        let channels = vec![
+            AudioRowView {
+                text: vec![
+                    DbgLine::hilit("AUD0 [Running]  DMA on  IRQ -"),
+                    DbgLine::plain("  LC 021A3C  LEN 0140  PER 01B0  VOL 40"),
+                    DbgLine::plain("  PTR 021B1C  words 00E2  acc 00A4  ph1  out -12"),
+                    DbgLine::plain("  pending: next-word"),
+                ],
+                muted: false,
+                scope: wave(96.0, 3.0),
+            },
+            AudioRowView {
+                text: vec![
+                    DbgLine::plain("AUD1 [StartPending]  DMA on  IRQ pend"),
+                    DbgLine::plain("  LC 030000  LEN 0080  PER 00F0  VOL 3F"),
+                    DbgLine::plain("  PTR 030000  words 0080  acc 0000  ph0  out 0"),
+                    DbgLine::plain("  pending: dma-req"),
+                ],
+                muted: false,
+                scope: wave(60.0, 6.0),
+            },
+            AudioRowView {
+                text: vec![
+                    DbgLine::plain("AUD2 [Off]  DMA off  IRQ -"),
+                    DbgLine::plain("  LC 000000  LEN 0000  PER 0000  VOL 00"),
+                    DbgLine::plain("  PTR 000000  words 0000  acc 0000  ph0  out 0"),
+                ],
+                muted: true,
+                scope: wave(40.0, 2.0),
+            },
+            AudioRowView {
+                text: vec![
+                    DbgLine::plain("AUD3 [Manual]  DMA off  IRQ -"),
+                    DbgLine::plain("  LC 000000  LEN 0000  PER 0140  VOL 20"),
+                    DbgLine::plain("  PTR 000000  words 0000  acc 0050  ph1  out 7"),
+                    DbgLine::plain("  pending: dma-disable manual"),
+                ],
+                muted: false,
+                scope: wave(48.0, 9.0),
+            },
+        ];
+        let cd = AudioRowView {
+            text: vec![
+                DbgLine::hilit("CD-DA  playing"),
+                DbgLine::plain("  peak  72"),
+            ],
+            muted: false,
+            scope: wave(72.0, 4.0),
+        };
+        let audio = AudioScopeView {
+            header,
+            channels,
+            cd,
+        };
+        let data = PanelViewData::Debugger(DebuggerView {
+            running: false,
+            reverse_available: true,
+            status: "paused frame 1234 24.68s".to_string(),
+            lines: Vec::new(),
+            audio: Some(audio),
+        });
+        let mut panel = DebuggerPanel::new();
+        panel.tab = DebugTab::Audio;
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Debugger(panel)),
+        };
+        draw(
+            &mut frame,
+            scale,
+            &ui,
+            Some(UiControl::DebugAudioMute(0)),
+            Some(&data),
+            false,
+            WarpSpeed::Max,
+            false,
+            false,
+            JoystickInputMode::Gamepad,
+        );
+        assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
+        save(&frame, "debugger-audio");
 
         // Configuration screen: an A1200 on the Memory tab.
         let mut frame = vec![0u8; w * h * 4];

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5038,6 +5038,9 @@ impl App {
             UiControl::DebugBreaksClear => {
                 self.activate_tool_control(ToolPanelKind::Debugger, control)
             }
+            UiControl::DebugAudioMute(_) => {
+                self.activate_tool_control(ToolPanelKind::Debugger, control)
+            }
             UiControl::AnalyzerRun => {
                 self.activate_tool_control(ToolPanelKind::FrameAnalyzer, control)
             }
@@ -5182,6 +5185,20 @@ impl App {
                 self.emu.machine.ui_breaks_clear();
                 self.last_debug_stop = None;
                 self.show_osd("Cleared all breakpoints and watchpoints");
+            }
+            (ToolPanelKind::Debugger, UiControl::DebugAudioMute(idx)) => {
+                let paula = &mut self.emu.bus_mut().paula;
+                let (label, muted) = if idx < 4 {
+                    paula.toggle_channel_muted(idx);
+                    (format!("AUD{idx}"), paula.channel_muted(idx))
+                } else {
+                    paula.toggle_cd_muted();
+                    ("CD audio".to_string(), paula.cd_muted())
+                };
+                self.show_osd(format!(
+                    "{label} {}",
+                    if muted { "muted" } else { "unmuted" }
+                ));
             }
             (ToolPanelKind::FrameAnalyzer, UiControl::AnalyzerRun) => {
                 self.frame_analyzer_toggle_run()
@@ -6584,6 +6601,7 @@ impl App {
         }
         let read = |addr: u32| bus.peek_word_any(addr);
         let mut lines: Vec<ui::DbgLine> = Vec::new();
+        let mut audio: Option<ui::AudioScopeView> = None;
         match panel.tab {
             ui::DebugTab::Cpu => {
                 let pc = machine.pc();
@@ -6725,6 +6743,117 @@ impl App {
                     });
                 }
             }
+            ui::DebugTab::Audio => {
+                let dmacon = bus.agnus.dmacon;
+                let master = dmacon & 0x0200 != 0; // DMACON DMAEN
+                let adkcon = bus.paula.adkcon;
+                // Audio interrupt-pending latches live in INTREQ bits 7..10
+                // (AUD0..AUD3); use the CPU-visible copy like the Chipset tab.
+                let intreq = bus.cpu_visible_intreq();
+                // Per-channel AUDxEN bit (AUD0..AUD3 = bits 0..3).
+                let auden: Vec<&str> = (0..4)
+                    .map(|ch| if dmacon & (1 << ch) != 0 { "1" } else { "." })
+                    .collect();
+                let header = format!(
+                    "DMACON {:04X}  DMAEN {}  AUDEN {}   ADKCON {:04X}  {}",
+                    dmacon,
+                    if master { "on" } else { "off" },
+                    auden.join(" "),
+                    adkcon,
+                    ui::adkcon_audio_flags(adkcon),
+                );
+                let mut channels: Vec<ui::AudioRowView> = Vec::with_capacity(4);
+                for ch in 0..4 {
+                    let Some(a) = bus.paula.audio_channel_debug(ch) else {
+                        continue;
+                    };
+                    let dma_on = master && (dmacon & (1 << ch)) != 0;
+                    let mut text: Vec<ui::DbgLine> = Vec::new();
+                    let head = format!(
+                        "AUD{} [{}]  DMA {}  IRQ {}",
+                        ch,
+                        a.state,
+                        if dma_on { "on" } else { "off" },
+                        if intreq & (1 << (7 + ch)) != 0 {
+                            "pend"
+                        } else {
+                            "-"
+                        },
+                    );
+                    // Highlight a channel that is actively streaming samples.
+                    text.push(if a.state == "Running" {
+                        ui::DbgLine::hilit(head)
+                    } else {
+                        ui::DbgLine::plain(head)
+                    });
+                    text.push(ui::DbgLine::plain(format!(
+                        "  LC {:06X}  LEN {:04X}  PER {:04X}  VOL {:02X}",
+                        a.lc, a.len, a.per, a.vol
+                    )));
+                    text.push(ui::DbgLine::plain(format!(
+                        "  PTR {:06X}  words {:04X}  acc {:04X}  ph{}  out {}",
+                        a.ptr, a.words_left, a.period_acc, a.phase, a.current
+                    )));
+                    let mut pending: Vec<&str> = Vec::new();
+                    if a.dma_disable_pending {
+                        pending.push("dma-disable");
+                    }
+                    if a.restart_pending {
+                        pending.push("restart");
+                    }
+                    if a.manual_pending {
+                        pending.push("manual");
+                    }
+                    if a.dma_request {
+                        pending.push("dma-req");
+                    }
+                    if a.next_word_ready {
+                        pending.push("next-word");
+                    }
+                    if !pending.is_empty() {
+                        text.push(ui::DbgLine::plain(format!(
+                            "  pending: {}",
+                            pending.join(" ")
+                        )));
+                    }
+                    channels.push(ui::AudioRowView {
+                        text,
+                        muted: bus.paula.channel_muted(ch),
+                        scope: bus.paula.audio_scope_samples(ch),
+                    });
+                }
+                let cd_scope = bus.paula.cd_scope_samples();
+                let cd_active = cd_scope.iter().any(|&s| s != 0);
+                let cd_peak = cd_scope
+                    .iter()
+                    .map(|&s| (s as i16).abs())
+                    .max()
+                    .unwrap_or(0);
+                let cd = ui::AudioRowView {
+                    text: vec![
+                        ui::DbgLine::hilit(format!(
+                            "CD-DA  {}",
+                            if cd_active { "playing" } else { "idle" }
+                        )),
+                        ui::DbgLine::plain(format!("  peak {cd_peak:>3}")),
+                    ],
+                    muted: bus.paula.cd_muted(),
+                    scope: cd_scope,
+                };
+                // Mirror the text into `lines` for the headless/text fallback
+                // and the non-empty-view invariant; the tab itself is drawn
+                // graphically from the structured view.
+                lines.push(ui::DbgLine::hilit(header.clone()));
+                for row in channels.iter().chain(std::iter::once(&cd)) {
+                    lines.push(ui::DbgLine::plain(""));
+                    lines.extend(row.text.iter().cloned());
+                }
+                audio = Some(ui::AudioScopeView {
+                    header,
+                    channels,
+                    cd,
+                });
+            }
             ui::DebugTab::Memory => {
                 lines.push(ui::DbgLine::plain(
                     "Click the $ box, type a hex address, Enter to jump; </> to page",
@@ -6817,6 +6946,7 @@ impl App {
             reverse_available: self.emu.time_travel_enabled(),
             status,
             lines,
+            audio,
         }
     }
 
@@ -10016,6 +10146,20 @@ mod tests {
                 super::ui::DebugTab::Copper => {
                     assert!(view.lines[0].text.contains("COP1LC"));
                 }
+                super::ui::DebugTab::Audio => {
+                    // Text is mirrored into `lines` for the fallback/invariant.
+                    assert!(view.lines[0].text.starts_with("DMACON"));
+                    assert!(view.lines[0].text.contains("ADKCON"));
+                    assert!(view.lines.iter().any(|l| l.text.starts_with("AUD0")));
+                    assert!(view.lines.iter().any(|l| l.text.starts_with("AUD3")));
+                    // The structured view drives the graphical layout: four
+                    // Paula channels plus a CD row.
+                    let audio = view.audio.as_ref().expect("audio scope view");
+                    assert!(audio.header.starts_with("DMACON"));
+                    assert_eq!(audio.channels.len(), 4);
+                    assert!(audio.channels[0].text[0].text.starts_with("AUD0"));
+                    assert!(audio.cd.text[0].text.contains("CD-DA"));
+                }
                 super::ui::DebugTab::Memory => {
                     // The hex dump shows the NOP sled at the PC's ROM page.
                     assert!(view.lines.iter().any(|l| l.text.contains("4E 71")));
@@ -10026,6 +10170,26 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn audio_tab_mute_buttons_toggle_paula_mutes() {
+        let mut app = test_app();
+        app.open_debugger();
+        if let Some(panel) = app.debugger_panel.as_mut() {
+            panel.tab = super::ui::DebugTab::Audio;
+        }
+        // Clicking a channel's mute button toggles that Paula channel's mute
+        // through the full dispatch path.
+        assert!(!app.emu.bus().paula.channel_muted(1));
+        app.activate_ui_control(super::ui::UiControl::DebugAudioMute(1));
+        assert!(app.emu.bus().paula.channel_muted(1));
+        app.activate_ui_control(super::ui::UiControl::DebugAudioMute(1));
+        assert!(!app.emu.bus().paula.channel_muted(1));
+        // Index 4 is the CD-DA mute.
+        assert!(!app.emu.bus().paula.cd_muted());
+        app.activate_ui_control(super::ui::UiControl::DebugAudioMute(4));
+        assert!(app.emu.bus().paula.cd_muted());
     }
 
     #[test]


### PR DESCRIPTION
Addresses issue #74 (Paula state machine) in two parts.

## 1. Fix: deferred AUDxEN disable

Real Paula only samples an AUDxEN clear at the current DMA word boundary. Clearing DMA mid-word while a channel is outputting now defers the disable until the word finishes, and re-enabling AUDxEN before that boundary preserves the active shifter, counters and fetch state instead of restarting from AUDxLC/AUDxLEN and raising a fresh channel interrupt. Bumps the save-state version for the serialized channel state and documents the timing in the chipset internals.

## 2. Feature: an Audio debugger tab

Follows up on the issue comment asking to see the audio state in the frame debugger. A new **Audio** tab visualises Paula's four channels and the CD-DA stream:

- **State**: DMA state machine (Off/Manual/ManualHold/StartPending/Running), DMACON/AUDEN/ADKCON, the CPU latches (AUDxLC/LEN/PER/VOL) and live playback (pointer, words left, period accumulator, phase, output sample, and the deferred-disable / loop-reload / manual / fetch pending flags).
- **Mute buttons** per channel and for CD-DA that silence the stream in the host output without disturbing the emulated state machine, counters or interrupts.
- **Oscilloscopes** per channel and for CD-DA tracing the output level (DAC sample x AUDxVOL), greyed while muted.

The mute flags and scope ring buffers are runtime-only debug state (serde-skipped), so the save-state version is unchanged by the tab and deterministic replay stays byte-identical.

## Testing

- `cargo build --release`, `cargo clippy --release`, `cargo fmt --check` clean.
- Full unit suite green (adds coverage for the deferred disable, the channel/CD mutes not disturbing state, the scope tap recording output level even when muted, mute-button hit-testing, and the end-to-end click -> mute dispatch).
- Save-state round-trip stays byte-identical; `STATE_VERSION` unchanged by the tab.
- Audio tab layout verified via the deterministic `COPPERLINE_UI_PREVIEW=1` render.

Fixes #74.