### PR TITLE
Skip presenting to minimized windows to avoid a Windows deadlock

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -662,6 +662,13 @@ struct Render {
     window: Arc<Window>,
     pixels: Pixels<'static>,
     texture_scale: usize,
+    /// True while the host window is minimized (Windows delivers a 0x0
+    /// Resized). Presenting while minimized deadlocks on Windows: DWM stops
+    /// consuming swapchain frames, so once the in-flight buffers fill,
+    /// pixels.render() blocks the main thread, the message pump dies, and
+    /// the window can never be restored (which is what would unblock the
+    /// present). Skip all rendering until a nonzero resize restores it.
+    minimized: bool,
 }
 
 struct ToolWindow {
@@ -669,6 +676,8 @@ struct ToolWindow {
     pixels: Pixels<'static>,
     texture_scale: usize,
     cursor_pos: Option<(i32, i32)>,
+    /// Same Windows minimized-present deadlock hazard as Render::minimized.
+    minimized: bool,
 }
 
 /// Frame-loop repaints of the tool windows (debugger, frame analyzer) are
@@ -1103,6 +1112,7 @@ impl ApplicationHandler for App {
             window,
             pixels,
             texture_scale,
+            minimized: false,
         });
         // Paint at least once so the status bar (and power button) is
         // visible immediately, even when the machine starts powered off
@@ -1502,9 +1512,15 @@ impl ApplicationHandler for App {
             }
             WindowEvent::Resized(size) => {
                 if let Some(r) = self.render.as_mut() {
-                    let _ = r
-                        .pixels
-                        .resize_surface(size.width.max(1), size.height.max(1));
+                    // A zero-sized resize is minimization (Windows reports
+                    // the minimized client area as 0x0). Leave the surface
+                    // untouched and stop rendering until the restore
+                    // delivers a nonzero size (see Render::minimized).
+                    r.minimized = size.width == 0 || size.height == 0;
+                    if r.minimized {
+                        return;
+                    }
+                    let _ = r.pixels.resize_surface(size.width, size.height);
                 }
                 // Resizing the surface discards its contents, leaving it
                 // blank (white) until the next present. When the machine is
@@ -1515,6 +1531,9 @@ impl ApplicationHandler for App {
                 self.request_redraw();
             }
             WindowEvent::RedrawRequested => {
+                if self.render.as_ref().is_some_and(|r| r.minimized) {
+                    return;
+                }
                 let status = status_with_latched_fdd_track(
                     self.emu.bus().front_panel_status(),
                     &mut self.last_fdd_track,
@@ -4912,9 +4931,13 @@ impl App {
             }
             WindowEvent::Resized(size) => {
                 if let Some(tool) = self.tool_window_mut(kind) {
-                    let _ = tool
-                        .pixels
-                        .resize_surface(size.width.max(1), size.height.max(1));
+                    // Same minimized-present deadlock guard as the main
+                    // window's Resized handler.
+                    tool.minimized = size.width == 0 || size.height == 0;
+                    if tool.minimized {
+                        return;
+                    }
+                    let _ = tool.pixels.resize_surface(size.width, size.height);
                 }
                 self.request_redraw();
             }
@@ -4934,6 +4957,9 @@ impl App {
             .and_then(|tool| tool.cursor_pos)
             .and_then(|pos| ui::panel_control_at(&panel, pos));
         if let Some(tool) = self.tool_window_mut(kind) {
+            if tool.minimized {
+                return;
+            }
             let frame = tool.pixels.frame_mut();
             frame.fill(0);
             ui::draw_panel_layer(frame, tool.texture_scale, &panel, hover, ui_data.as_ref());
@@ -5485,7 +5511,7 @@ impl App {
         let title = Self::tool_window_title(kind);
         if let Some(tool) = self.tool_window(kind) {
             tool.window.set_title(title);
-            if redraw {
+            if redraw && !tool.minimized {
                 tool.window.request_redraw();
             }
             return;
@@ -5529,6 +5555,7 @@ impl App {
             pixels,
             texture_scale,
             cursor_pos: None,
+            minimized: false,
         });
         self.request_redraw();
     }
@@ -7205,17 +7232,23 @@ impl App {
 
     fn request_main_redraw(&self) {
         if let Some(render) = self.render.as_ref() {
-            render.window.request_redraw();
+            if !render.minimized {
+                render.window.request_redraw();
+            }
         }
     }
 
     fn request_redraw(&self) {
         self.request_main_redraw();
         if let Some(tool) = self.debugger_tool_window.as_ref() {
-            tool.window.request_redraw();
+            if !tool.minimized {
+                tool.window.request_redraw();
+            }
         }
         if let Some(tool) = self.frame_analyzer_tool_window.as_ref() {
-            tool.window.request_redraw();
+            if !tool.minimized {
+                tool.window.request_redraw();
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Reported on Windows: after minimizing the emulator window it could not be restored (taskbar click, alt-tab) and taskbar right-click "Close window" was ignored. Works fine on macOS.

## Cause

Everything (emulation, winit message pump, presentation) runs on the main thread. Minimizing on Windows delivers a 0x0 `Resized` event; the handler clamped it to a 1x1 surface and the frame loop kept presenting every frame through the vsynced `pixels.render()`.

With a DXGI flip-model swapchain, DWM stops consuming frames from a minimized window. Once the in-flight backbuffers fill, the present blocks the main thread indefinitely, which kills the message pump: `WM_SYSCOMMAND`/`SC_RESTORE` and `WM_CLOSE` are never processed. It is a deadlock - the present cannot complete until the window is restored, and the window cannot be restored until the app pumps messages again. macOS never blocks there (CAMetalLayer keeps handing out drawables while miniaturized), which is why it only reproduces on Windows.

## Fix

Track a `minimized` flag on the main window (`Render`) and the tool windows (`ToolWindow`):

- Set when a `Resized` event reports a zero dimension (how Windows reports minimization); cleared by the nonzero resize that restore delivers, which also resizes the surface and repaints.
- While set, skip `resize_surface`, all `request_redraw` traffic, and the `RedrawRequested` render bodies, so the swapchain is never touched while minimized.

Emulation keeps stepping while minimized (audio keeps playing); pacing is unaffected because real-time pacing sleeps on wall clock rather than the vsync gate. macOS/Linux never deliver a 0x0 resize on minimize, so the flag never sets and behavior there is unchanged (verified with a headless screenshot run).

## Testing

- `cargo test`: 1245 passed, 0 failed
- `cargo clippy` and `cargo fmt --check` clean
- Headless smoke run (a1000 config, `--screenshot-after 2`) unchanged on macOS
- Needs confirmation from the Windows reporter: minimize -> restore and taskbar Close, ideally also with the debugger tool window open and minimized independently