### PR TITLE
Debugger roadmap 2: OS introspection, blit records, reverse-to-watch, history/stack, watch attribution, IO map

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -60,7 +60,7 @@ Stops (each toggles: repeat the command to remove):
 | Command | Effect |
 |---|---|
 | `BREAK ADDR [COND] [IGN N]`, `B` | PC breakpoint, with the Break tab's condition grammar |
-| `WATCH ADDR`, `W` | Memory word watchpoint |
+| `WATCH ADDR [CPU\|BLITTER\|DISK]`, `W` | Memory word watchpoint; the optional filter stops only on that writer |
 | `RWATCH NAME\|OFF` | Custom-register write watch (`RWATCH DMACON`) |
 | `BTRAP V [H]` | Beam trap (decimal position) |
 | `CBREAK ADDR` | Copper breakpoint |

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -83,3 +83,19 @@ Inspection and modification:
 | `POKE ADDR VAL` | Write a memory word |
 | `SETREG REG VAL` | Set a CPU register (`SETREG D0 1234`) |
 | `HELP`, `CLEAR`, `CLOSE` | Console housekeeping |
+
+AmigaOS introspection (read-only walks of exec's lists, safe at any
+time -- if the OS is not up yet the command says so instead of printing
+garbage):
+
+| Command | Effect |
+|---|---|
+| `TASKS` | The scheduled task (`>`), then the ready and waiting lists, with priority, state, and name |
+| `LIBS` | Opened libraries with versions (`graphics.library v40.10`) |
+| `DEVS` | Devices with versions |
+| `RESOURCES`, `PORTS` | The resource and message-port lists |
+| `CATCHTASK NAME` | Stop when exec schedules a task whose name contains NAME (case-insensitive); `CATCHTASK` alone clears it |
+
+`CATCHTASK` is the tool for "wake me when my process actually runs": it
+baselines on the currently scheduled task and fires on the next
+reschedule to a matching one, reporting the task's name and address.

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -80,6 +80,8 @@ Inspection and modification:
 | `CUSTOM` | Key custom registers |
 | `FIND HEXBYTES [START]` | Search CPU-visible memory |
 | `WRITER ADDR` | Last instruction that wrote ADDR (reverse history) |
+| `HISTORY [N]`, `H` | The most recent retired PCs, disassembled (recorded while a debug window is open) |
+| `STACK`, `BT` | Heuristic call-stack walk: stack longwords that look like return addresses after a JSR/BSR |
 | `POKE ADDR VAL` | Write a memory word |
 | `SETREG REG VAL` | Set a CPU register (`SETREG D0 1234`) |
 | `HELP`, `CLEAR`, `CLOSE` | Console housekeeping |

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -78,6 +78,7 @@ Inspection and modification:
 | `DIS [ADDR] [N]`, `D` | Disassemble (default: at the PC) |
 | `COPPER [PC\|ADDR] [N]` | Copper list around the live Copper PC |
 | `CUSTOM` | Key custom registers |
+| `BLITS` | Blits started in the traced frame (needs the Frame Analyzer open): control words, size, pointers, beam start/end |
 | `FIND HEXBYTES [START]` | Search CPU-visible memory |
 | `WRITER ADDR` | Last instruction that wrote ADDR (reverse history) |
 | `HISTORY [N]`, `H` | The most recent retired PCs, disassembled (recorded while a debug window is open) |

--- a/docs/debugger/reverse.md
+++ b/docs/debugger/reverse.md
@@ -78,12 +78,23 @@ the right of the transport row:
 |---|---|
 | **&lt; Frame** | Step backward to the previous emulated video frame |
 | **&lt; Step** | Step one instruction backward |
-| **&lt; Run** | Run backward to the previous PC breakpoint hit |
+| **&lt; Run** | Run backward to the previous stop of any kind |
 
 The status line shows the current instruction position and how much history
-is retained (`pos N  rev K snaps, M MB`). **&lt; Run** uses the PC
-breakpoints set on the Break tab; watch-based reverse-continue is not yet
-modelled.
+is retained (`pos N  rev K snaps, M MB`). **&lt; Run** (and the console's
+`RRUN`) scans the replay for every armed stop: PC breakpoints (addresses;
+conditions and ignore counts are not re-evaluated), memory watchpoints
+(re-baselined at each snapshot, so a hit means "changed during the
+replayed interval"), register watches, beam traps, Copper breakpoints,
+exception catches, and the task catch. It lands at the most recent hit
+and reports the same stop message the forward run would have shown --
+"run backward to when this register was last written" is `RWATCH` plus
+`RRUN`. The GDB stub's `reverse-continue` keeps its protocol semantics
+(its own breakpoints only).
+
+Interactive debug state (beam traps, Copper breakpoints, layer masks)
+survives timeline jumps: a reverse step never silently disarms the
+debugger.
 
 ## Determinism preconditions
 

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -287,6 +287,13 @@ Opening the pane starts a partial trace immediately; pressing **Frame**
 captures a clean full frame. Closing it restores the run/pause state selected
 inside the pane and disables the tracing hot path.
 
+While the analyzer is open, every blit started in the traced frame is
+recorded (control words, size, channel pointers, and the beam positions
+where it started and finished). The console's `BLITS` command lists them,
+and selecting a slot inside a blit's beam span names it on the
+selected-slot line -- click the brown blitter run that is eating your
+frame and see which blit it is.
+
 Click a slot (or nudge the selection with the cursor keys) and press
 **To slot** to run the machine until the beam reaches exactly that colour
 clock -- a one-shot beam trap, reported like any other debugger stop. It

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -143,8 +143,14 @@ On the Break tab, type an address into the `$` box and toggle any of:
 - **Break** -- a PC breakpoint. The machine stops *before* the instruction
   at that address executes.
 - **Watch** -- a memory word watchpoint. The machine stops when the word
-  changes, whichever bus master wrote it (CPU, Copper, or blitter); the
-  current value is shown live in the list.
+  changes, whichever bus master wrote it, and the stop names the true
+  writer: CPU stops report the writing instruction's PC, while blitter
+  and disk-DMA writes are flagged at their write sites and report the
+  source with the beam position (`Watch $060000: 0000->BEEF (blitter
+  write, v44 h100)`). The console's `WATCH ADDR CPU|BLITTER|DISK` form
+  additionally filters a watch to one writer -- "stop only when the
+  blitter touches this" -- with other writers just moving the baseline.
+  The current value is shown live in the list.
 - **Reg** -- a chipset-register write watch. `96` and `DFF096` both mean
   DMACON. The machine stops on *every* write, CPU or Copper, and reports
   the writer and beam position.

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -26,8 +26,10 @@ The CPU tab: register file, live disassembly, and the transport controls.
 ## Tabs
 
 **CPU** shows the PC and SR (with decoded supervisor/IPL/CCR flags), the
-D0-D7/A0-A7 register file, and a live 68000 disassembly that follows the
-PC, with the current instruction highlighted. Type a hex address in the
+D0-D7/A0-A7 register file, a `recent` line with the last few retired PCs
+(the console's `HISTORY` command shows the full ring, disassembled), and
+a live 68000 disassembly that follows the PC, with the current
+instruction highlighted. Type a hex address in the
 `$` box and press Enter to *pin* the disassembly elsewhere; empty the box
 and press Enter to follow the PC again.
 

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -125,6 +125,16 @@ PageUp/PageDown by whole pages. Four buttons sit above the dump:
   tab to eyeball graphics data directly -- misaligned strides show as
   the familiar diagonal shear.
 
+**IO Map** is a browsable map of the whole custom bank ($DFF000-$DFF1FE):
+every word offset with its hardware name and live value (write-only
+registers show their last-written latch, `----` marks offsets with no
+latch at all). Arrows and the mouse wheel move the selection, PageUp/Down
+change page, and the `$` box jumps to an offset (`96`) or address
+(`DFF096`). The pane below decodes the selected register's bits by name
+-- DMACON's enables, INTENA/INTREQ sources, BPLCON0's mode flags and
+plane count, ADKCON, CLXCON, BEAMCON0, FMODE, and the playfield
+scroll/priority fields.
+
 **Break** manages breakpoints and watchpoints (next section) and shows the
 reason for the last stop.
 

--- a/src/amigaos.rs
+++ b/src/amigaos.rs
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Read-only AmigaOS (exec.library) structure walking for the debugger:
+//! the task, library, device, resource, and port lists, reached from
+//! ExecBase via side-effect-free memory peeks. The offsets are exec's
+//! public ABI (execbase.h / nodes.h / lists.h), stable from Kickstart
+//! 1.x through 3.x and AROS, so no version sniffing is needed -- only
+//! pointer plausibility checks, since the OS may simply not be up yet.
+
+/// ExecBase field offsets (execbase.h).
+const EXECBASE_PTR: u32 = 4;
+const CHKBASE: u32 = 0x26;
+const THIS_TASK: u32 = 0x114;
+const RESOURCE_LIST: u32 = 0x150;
+const DEVICE_LIST: u32 = 0x15E;
+const INTR_LIST: u32 = 0x16C;
+const LIB_LIST: u32 = 0x17A;
+const PORT_LIST: u32 = 0x188;
+const TASK_READY: u32 = 0x196;
+const TASK_WAIT: u32 = 0x1A4;
+
+/// Node field offsets (nodes.h).
+const LN_TYPE: u32 = 8;
+const LN_PRI: u32 = 9;
+const LN_NAME: u32 = 10;
+/// Task field offsets (tasks.h).
+const TC_STATE: u32 = 15;
+/// Library field offsets (libraries.h).
+const LIB_VERSION: u32 = 20;
+const LIB_REVISION: u32 = 22;
+
+/// Nodes returned per list, bounding walks over corrupt lists.
+const LIST_CAP: usize = 200;
+const NAME_CAP: usize = 30;
+
+/// One node lifted out of an exec list.
+pub struct OsNode {
+    pub addr: u32,
+    pub name: String,
+    pub node_type: u8,
+    pub pri: i8,
+    /// tc_State for task lists, 0 otherwise.
+    pub state: u8,
+    /// lib_Version/lib_Revision for library-shaped nodes, 0 otherwise.
+    pub version: u16,
+    pub revision: u16,
+}
+
+/// Which exec list to walk.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OsList {
+    TaskReady,
+    TaskWait,
+    Libraries,
+    Devices,
+    Resources,
+    Ports,
+    Interrupts,
+}
+
+impl OsList {
+    fn execbase_offset(self) -> u32 {
+        match self {
+            OsList::TaskReady => TASK_READY,
+            OsList::TaskWait => TASK_WAIT,
+            OsList::Libraries => LIB_LIST,
+            OsList::Devices => DEVICE_LIST,
+            OsList::Resources => RESOURCE_LIST,
+            OsList::Ports => PORT_LIST,
+            OsList::Interrupts => INTR_LIST,
+        }
+    }
+
+    fn library_shaped(self) -> bool {
+        matches!(self, OsList::Libraries | OsList::Devices)
+    }
+
+    fn task_shaped(self) -> bool {
+        matches!(self, OsList::TaskReady | OsList::TaskWait)
+    }
+}
+
+/// Human name of a tc_State value (tasks.h).
+pub fn task_state_name(state: u8) -> &'static str {
+    match state {
+        0 => "invalid",
+        1 => "added",
+        2 => "run",
+        3 => "ready",
+        4 => "wait",
+        5 => "except",
+        6 => "removed",
+        _ => "?",
+    }
+}
+
+fn plausible_ptr(addr: u32) -> bool {
+    addr != 0 && addr & 1 == 0 && addr < 0x0100_0000
+}
+
+/// Read-only view of guest memory, built from the debugger's peek
+/// primitives. `peek8`/`peek32` must be side-effect-free.
+pub struct OsMemory<'a> {
+    pub peek8: &'a dyn Fn(u32) -> u8,
+    pub peek32: &'a dyn Fn(u32) -> u32,
+}
+
+impl OsMemory<'_> {
+    fn peek16(&self, addr: u32) -> u16 {
+        ((self.peek32)(addr) >> 16) as u16
+    }
+
+    /// ExecBase, validated: the pointer at address 4 must be plausible
+    /// and its ChkBase complement should match (a mismatch usually means
+    /// the OS is not up yet). Err carries a human-readable reason.
+    pub fn exec_base(&self) -> Result<u32, String> {
+        let base = (self.peek32)(EXECBASE_PTR);
+        if !plausible_ptr(base) {
+            return Err(format!(
+                "no ExecBase (address 4 holds ${base:08X}; OS not booted?)"
+            ));
+        }
+        let chk = (self.peek32)(base.wrapping_add(CHKBASE));
+        if chk != !base {
+            return Err(format!(
+                "ExecBase ${base:06X} fails its ChkBase complement (OS booting or trashed?)"
+            ));
+        }
+        Ok(base)
+    }
+
+    /// The currently scheduled task, with its name.
+    pub fn this_task(&self, execbase: u32) -> Option<OsNode> {
+        let task = (self.peek32)(execbase.wrapping_add(THIS_TASK));
+        plausible_ptr(task).then(|| self.node(task, true, false))
+    }
+
+    /// Walk one exec list into owned nodes (bounded).
+    pub fn walk(&self, execbase: u32, list: OsList) -> Vec<OsNode> {
+        let mut out = Vec::new();
+        let mut node = (self.peek32)(execbase.wrapping_add(list.execbase_offset()));
+        while plausible_ptr(node) && (self.peek32)(node) != 0 && out.len() < LIST_CAP {
+            out.push(self.node(node, list.task_shaped(), list.library_shaped()));
+            node = (self.peek32)(node);
+        }
+        out
+    }
+
+    fn node(&self, addr: u32, task_shaped: bool, library_shaped: bool) -> OsNode {
+        let (version, revision) = if library_shaped {
+            (
+                self.peek16(addr.wrapping_add(LIB_VERSION)),
+                self.peek16(addr.wrapping_add(LIB_REVISION)),
+            )
+        } else {
+            (0, 0)
+        };
+        OsNode {
+            addr,
+            name: self.node_name(addr),
+            node_type: (self.peek8)(addr.wrapping_add(LN_TYPE)),
+            pri: (self.peek8)(addr.wrapping_add(LN_PRI)) as i8,
+            state: if task_shaped {
+                (self.peek8)(addr.wrapping_add(TC_STATE))
+            } else {
+                0
+            },
+            version,
+            revision,
+        }
+    }
+
+    /// A node's ln_Name string: printable ASCII, bounded, with a
+    /// placeholder for null/implausible name pointers.
+    pub fn node_name(&self, node: u32) -> String {
+        let name_ptr = (self.peek32)(node.wrapping_add(LN_NAME));
+        if name_ptr == 0 || name_ptr >= 0x0100_0000 {
+            return "<unnamed>".to_string();
+        }
+        let mut name = String::new();
+        for i in 0..NAME_CAP as u32 {
+            let byte = (self.peek8)(name_ptr.wrapping_add(i));
+            if byte == 0 {
+                break;
+            }
+            name.push(if (0x20..0x7F).contains(&byte) {
+                byte as char
+            } else {
+                '.'
+            });
+        }
+        if name.is_empty() {
+            "<unnamed>".to_string()
+        } else {
+            name
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A tiny fake guest memory: big-endian bytes in a map.
+    struct FakeMem(HashMap<u32, u8>);
+
+    impl FakeMem {
+        fn new() -> Self {
+            Self(HashMap::new())
+        }
+
+        fn put32(&mut self, addr: u32, value: u32) {
+            for (i, b) in value.to_be_bytes().iter().enumerate() {
+                self.0.insert(addr + i as u32, *b);
+            }
+        }
+
+        fn put8(&mut self, addr: u32, value: u8) {
+            self.0.insert(addr, value);
+        }
+
+        fn put_str(&mut self, addr: u32, s: &str) {
+            for (i, b) in s.bytes().enumerate() {
+                self.0.insert(addr + i as u32, b);
+            }
+            self.0.insert(addr + s.len() as u32, 0);
+        }
+
+        fn peek8(&self, addr: u32) -> u8 {
+            *self.0.get(&addr).unwrap_or(&0)
+        }
+
+        fn peek32(&self, addr: u32) -> u32 {
+            u32::from_be_bytes([
+                self.peek8(addr),
+                self.peek8(addr + 1),
+                self.peek8(addr + 2),
+                self.peek8(addr + 3),
+            ])
+        }
+    }
+
+    fn build_exec_world() -> FakeMem {
+        let mut mem = FakeMem::new();
+        let base = 0x00C0_0676;
+        mem.put32(4, base);
+        mem.put32(base + CHKBASE, !base);
+        // ThisTask: a running task named "input.device".
+        let this = 0x0002_1000;
+        mem.put32(base + THIS_TASK, this);
+        mem.put_str(0x0002_2000, "input.device");
+        mem.put32(this + LN_NAME, 0x0002_2000);
+        mem.put8(this + LN_TYPE, 13); // NT_PROCESS
+        mem.put8(this + LN_PRI, 20i8 as u8);
+        mem.put8(this + TC_STATE, 2); // run
+                                      // TaskReady: two tasks, then the list's null-succ tail.
+        let t1 = 0x0002_3000;
+        let t2 = 0x0002_4000;
+        mem.put32(base + TASK_READY, t1);
+        mem.put32(t1, t2); // ln_Succ
+        mem.put_str(0x0002_5000, "trackdisk.device");
+        mem.put32(t1 + LN_NAME, 0x0002_5000);
+        mem.put8(t1 + LN_PRI, 5);
+        mem.put8(t1 + TC_STATE, 3); // ready
+        mem.put32(t2, base + TASK_READY + 4); // succ -> lh_Tail pseudo-node (succ reads 0)
+        mem.put32(base + TASK_READY + 4, 0);
+        mem.put_str(0x0002_6000, "SomeTask");
+        mem.put32(t2 + LN_NAME, 0x0002_6000);
+        mem.put8(t2 + LN_PRI, -5i8 as u8);
+        mem.put8(t2 + TC_STATE, 3);
+        // LibList: one library with a version.
+        let lib = 0x0002_7000;
+        mem.put32(base + LIB_LIST, lib);
+        mem.put32(lib, base + LIB_LIST + 4);
+        mem.put32(base + LIB_LIST + 4, 0);
+        mem.put_str(0x0002_8000, "graphics.library");
+        mem.put32(lib + LN_NAME, 0x0002_8000);
+        mem.put32(lib + LIB_VERSION, 0x0028_000A); // version 40, revision 10
+        mem
+    }
+
+    fn os<'a>(peek8: &'a dyn Fn(u32) -> u8, peek32: &'a dyn Fn(u32) -> u32) -> OsMemory<'a> {
+        OsMemory { peek8, peek32 }
+    }
+
+    #[test]
+    fn walks_tasks_and_libraries_from_a_valid_execbase() {
+        let mem = build_exec_world();
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let os = os(&peek8, &peek32);
+        let base = os.exec_base().expect("valid ExecBase");
+        assert_eq!(base, 0x00C0_0676);
+
+        let this = os.this_task(base).expect("ThisTask");
+        assert_eq!(this.name, "input.device");
+        assert_eq!(this.state, 2);
+        assert_eq!(this.pri, 20);
+
+        let ready = os.walk(base, OsList::TaskReady);
+        assert_eq!(ready.len(), 2);
+        assert_eq!(ready[0].name, "trackdisk.device");
+        assert_eq!(ready[1].name, "SomeTask");
+        assert_eq!(ready[1].pri, -5);
+        assert_eq!(task_state_name(ready[0].state), "ready");
+
+        let libs = os.walk(base, OsList::Libraries);
+        assert_eq!(libs.len(), 1);
+        assert_eq!(libs[0].name, "graphics.library");
+        assert_eq!(libs[0].version, 40);
+        assert_eq!(libs[0].revision, 10);
+
+        // Untouched lists read as empty, not garbage.
+        assert!(os.walk(base, OsList::Ports).is_empty());
+    }
+
+    #[test]
+    fn rejects_a_missing_or_corrupt_execbase() {
+        let mem = FakeMem::new();
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        assert!(os(&peek8, &peek32).exec_base().is_err());
+
+        let mut mem = FakeMem::new();
+        mem.put32(4, 0x0000_2000);
+        mem.put32(0x2000 + CHKBASE, 0xDEAD_BEEF); // wrong complement
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let err = os(&peek8, &peek32).exec_base().unwrap_err();
+        assert!(err.contains("ChkBase"), "{err}");
+    }
+}

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1114,6 +1114,23 @@ impl ChipBusOwner {
     }
 }
 
+/// One blit started during the traced frame (Frame Analyzer / console
+/// BLITS). `end` stays None while the blit is still running (or when it
+/// finishes in a later frame).
+#[derive(Clone, Debug)]
+pub struct FrameBlitRecord {
+    pub bltcon0: u16,
+    pub bltcon1: u16,
+    pub width_words: u32,
+    pub height: u32,
+    pub apt: u32,
+    pub bpt: u32,
+    pub cpt: u32,
+    pub dpt: u32,
+    pub start: (u16, u16),
+    pub end: Option<(u16, u16)>,
+}
+
 /// Per-frame chip-bus ownership trace for the interactive frame analyzer.
 ///
 /// One byte records the owner for one Agnus colour clock at `(vpos, hpos)`.
@@ -1134,8 +1151,13 @@ pub struct FrameBusTrace {
     pub blitter_busy_cck: u64,
     pub blitter_starve_cck: [u64; 9],
     pub partial: bool,
+    /// Blits started this frame (capped; see FRAME_BLIT_RECORD_CAP).
+    pub blits: Vec<FrameBlitRecord>,
     owners: Vec<u8>,
 }
+
+/// Blit records kept per traced frame.
+pub const FRAME_BLIT_RECORD_CAP: usize = 64;
 
 impl Default for FrameBusTrace {
     fn default() -> Self {
@@ -1153,6 +1175,7 @@ impl Default for FrameBusTrace {
             blitter_busy_cck: 0,
             blitter_starve_cck: [0; 9],
             partial: false,
+            blits: Vec::new(),
             owners: Vec::new(),
         }
     }
@@ -1184,6 +1207,7 @@ impl FrameBusTrace {
         self.blitter_busy_cck = 0;
         self.blitter_starve_cck = [0; 9];
         self.partial = partial;
+        self.blits.clear();
         self.owners.resize(self.rows * self.cols, b'.');
         self.owners.fill(b'.');
     }
@@ -3268,6 +3292,20 @@ impl Bus {
     }
 
     fn latch_blitter_completion(&mut self, source: &'static str) {
+        if self.frame_analyzer_enabled {
+            if let Some(record) = self
+                .current_frame_bus_trace
+                .blits
+                .iter_mut()
+                .rev()
+                .find(|record| record.end.is_none())
+            {
+                record.end = Some((
+                    self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+                    self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+                ));
+            }
+        }
         let intreq_before = self.paula.intreq;
         self.paula.intreq |= INT_BLIT;
         self.note_irq_source_asserted();
@@ -4206,6 +4244,31 @@ impl Bus {
                 }
             }
         }
+    }
+
+    /// Record a started blit into the analyzer's frame trace (no-op
+    /// while the analyzer is closed).
+    pub(crate) fn record_frame_blit_start(&mut self, height: u32, width_words: u32) {
+        if !self.frame_analyzer_enabled
+            || self.current_frame_bus_trace.blits.len() >= FRAME_BLIT_RECORD_CAP
+        {
+            return;
+        }
+        self.current_frame_bus_trace.blits.push(FrameBlitRecord {
+            bltcon0: self.blitter.bltcon0,
+            bltcon1: self.blitter.bltcon1,
+            width_words,
+            height,
+            apt: self.blitter.bltapt,
+            bpt: self.blitter.bltbpt,
+            cpt: self.blitter.bltcpt,
+            dpt: self.blitter.bltdpt,
+            start: (
+                self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+                self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+            ),
+            end: None,
+        });
     }
 
     fn record_blit_accounting(&mut self) {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2029,6 +2029,19 @@ impl Bus {
         self.ui_beam_hit.take()
     }
 
+    /// Carry the interactive debug state (beam traps, Copper
+    /// breakpoints, layer-isolation masks) from the pre-restore bus into
+    /// this freshly deserialized one. These fields are transient
+    /// (serde-skipped), so without this a reverse step or state load
+    /// would silently disarm the debugger. Pending unpolled hits stay
+    /// dropped: they describe the abandoned timeline.
+    pub(crate) fn adopt_ui_debug_state(&mut self, previous: &Bus) {
+        self.ui_beam_traps = previous.ui_beam_traps.clone();
+        self.ui_copper_breaks = previous.ui_copper_breaks.clone();
+        self.ui_copper_last_pc = previous.ui_copper_last_pc;
+        self.ui_layer_masks = previous.ui_layer_masks;
+    }
+
     /// The debugger's armed Copper breakpoint addresses.
     pub fn ui_copper_breaks(&self) -> &[u32] {
         &self.ui_copper_breaks

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -808,6 +808,14 @@ pub struct Bus {
     /// the Default of all-layers-visible is restored on state load.
     #[serde(skip)]
     ui_layer_masks: UiLayerMasks,
+    /// Watched memory word addresses mirrored from the debugger (also
+    /// forwarded into the blitter and floppy so their write sites can
+    /// flag hits), plus the writers of recent watched-word writes for
+    /// stop attribution. Transient debug state.
+    #[serde(skip)]
+    ui_mem_watch_addrs: Vec<u32>,
+    #[serde(skip)]
+    ui_mem_writers: Vec<UiMemWriter>,
     /// The Copper PC at the last breakpoint check, so arrival at an
     /// address fires once instead of on every eligible colour clock the
     /// PC rests there.
@@ -922,6 +930,15 @@ pub struct BeamTrap {
     pub hpos: Option<u16>,
     /// Remove after the first hit (a run-to-position trap).
     pub once: bool,
+}
+
+/// Who last wrote a watched memory word, recorded at the write site.
+#[derive(Debug, Clone, Copy)]
+pub struct UiMemWriter {
+    pub addr: u32,
+    pub source: crate::debugger::WatchSource,
+    pub vpos: u16,
+    pub hpos: u16,
 }
 
 /// Debugger video-layer isolation masks: bit n set = bitplane n /
@@ -1925,6 +1942,8 @@ impl Bus {
             ui_copper_hit: None,
             ui_copper_last_pc: 0,
             ui_layer_masks: UiLayerMasks::default(),
+            ui_mem_watch_addrs: Vec::new(),
+            ui_mem_writers: Vec::new(),
             blitter_slowdown_cpu_misses: 0,
             slice_bus_advanced_cck: 0,
             slice_bus_tick: AgnusTick::default(),
@@ -2029,6 +2048,82 @@ impl Bus {
         self.ui_beam_hit.take()
     }
 
+    /// Replace the debugger's watched-word mirror, forwarding it into
+    /// the blitter and floppy write sites. Pending writer records are
+    /// dropped (they described the previous watch set).
+    pub fn set_ui_mem_watches(&mut self, addrs: &[u32]) {
+        self.ui_mem_watch_addrs = addrs.to_vec();
+        self.ui_mem_writers.clear();
+        self.blitter.set_debug_watch_addrs(addrs);
+        self.floppy.set_debug_watch_addrs(addrs);
+    }
+
+    /// Note a CPU write of `size` bytes at `addr` for watch attribution
+    /// (called from the CPU chip/slow RAM write paths when watches are
+    /// armed).
+    pub(crate) fn ui_note_cpu_ram_write(&mut self, addr: u32, size: usize) {
+        if self.ui_mem_watch_addrs.is_empty() {
+            return;
+        }
+        let start = addr & 0x00FF_FFFE;
+        let end = addr.wrapping_add(size.max(1) as u32);
+        for &watch in &self.ui_mem_watch_addrs {
+            if watch.wrapping_add(1) >= start && watch < end {
+                Self::push_ui_mem_writer(
+                    &mut self.ui_mem_writers,
+                    UiMemWriter {
+                        addr: watch,
+                        source: crate::debugger::WatchSource::Cpu,
+                        vpos: self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+                        hpos: self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+                    },
+                );
+            }
+        }
+    }
+
+    fn push_ui_mem_writer(writers: &mut Vec<UiMemWriter>, writer: UiMemWriter) {
+        // Latest write per address wins; the list stays tiny.
+        writers.retain(|w| w.addr != writer.addr);
+        if writers.len() >= 8 {
+            writers.remove(0);
+        }
+        writers.push(writer);
+    }
+
+    /// The writer of the most recent write to watched word `addr`, if
+    /// one was recorded since the last take. Drains the blitter/floppy
+    /// latches lazily, so the hot DMA paths never touch the bus record.
+    pub fn ui_take_mem_writer(&mut self, addr: u32) -> Option<UiMemWriter> {
+        let vpos = self.agnus.vpos.min(u32::from(u16::MAX)) as u16;
+        let hpos = self.agnus.hpos.min(u32::from(u16::MAX)) as u16;
+        if let Some((waddr, _)) = self.blitter.take_debug_watched_write() {
+            Self::push_ui_mem_writer(
+                &mut self.ui_mem_writers,
+                UiMemWriter {
+                    addr: waddr & 0x00FF_FFFE,
+                    source: crate::debugger::WatchSource::Blitter,
+                    vpos,
+                    hpos,
+                },
+            );
+        }
+        if let Some((waddr, _)) = self.floppy.take_debug_watched_write() {
+            Self::push_ui_mem_writer(
+                &mut self.ui_mem_writers,
+                UiMemWriter {
+                    addr: waddr & 0x00FF_FFFE,
+                    source: crate::debugger::WatchSource::Disk,
+                    vpos,
+                    hpos,
+                },
+            );
+        }
+        let addr = addr & 0x00FF_FFFE;
+        let found = self.ui_mem_writers.iter().position(|w| w.addr == addr)?;
+        Some(self.ui_mem_writers.remove(found))
+    }
+
     /// Carry the interactive debug state (beam traps, Copper
     /// breakpoints, layer-isolation masks) from the pre-restore bus into
     /// this freshly deserialized one. These fields are transient
@@ -2040,6 +2135,8 @@ impl Bus {
         self.ui_copper_breaks = previous.ui_copper_breaks.clone();
         self.ui_copper_last_pc = previous.ui_copper_last_pc;
         self.ui_layer_masks = previous.ui_layer_masks;
+        let watches = previous.ui_mem_watch_addrs.clone();
+        self.set_ui_mem_watches(&watches);
     }
 
     /// The debugger's armed Copper breakpoint addresses.

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -617,6 +617,15 @@ impl Bus {
                     }
                 }
                 self.trace_blitter_start(val, source);
+                {
+                    // BLTSIZE zero fields mean the maximum (1024 rows / 64 words).
+                    let h = ((val as u32) >> 6) & 0x3FF;
+                    let w = (val as u32) & 0x3F;
+                    self.record_frame_blit_start(
+                        if h == 0 { 1024 } else { h },
+                        if w == 0 { 64 } else { w },
+                    );
+                }
                 self.blitter.start_scheduled(val, &self.mem.chip_ram);
                 self.record_blit_accounting();
                 self.slice_preempted = true;
@@ -649,6 +658,14 @@ impl Bus {
                 self.note_irq_latches_changed();
                 self.trace_blitter_start_ecs(val, source);
                 self.diag_blit_start(u32::from(self.blitter.bltsizv), (val as u32) & 0x07FF);
+                {
+                    let h = u32::from(self.blitter.bltsizv);
+                    let w = (val as u32) & 0x07FF;
+                    self.record_frame_blit_start(
+                        if h == 0 { 0x8000 } else { h },
+                        if w == 0 { 0x800 } else { w },
+                    );
+                }
                 self.blitter.start_scheduled_ecs(val, &self.mem.chip_ram);
                 self.record_blit_accounting();
                 self.slice_preempted = true;

--- a/src/chipset/blitter.rs
+++ b/src/chipset/blitter.rs
@@ -137,6 +137,15 @@ fn shift_combine(prev: u16, cur: u16, n: u32, desc: bool) -> u16 {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Blitter {
+    /// Watched word addresses mirrored from the debugger, so every
+    /// write site can flag a hit precisely (a single last-write latch
+    /// would lose hits inside multi-word bursts). Transient debug state.
+    #[serde(skip)]
+    pub(crate) debug_watch_addrs: Vec<u32>,
+    /// The last write this blitter made TO A WATCHED ADDRESS, for
+    /// watchpoint writer attribution. Transient.
+    #[serde(skip)]
+    pub(crate) debug_watched_write: Option<(u32, u16)>,
     pub bltcon0: u16,
     pub bltcon1: u16,
     pub bltafwm: u16,
@@ -181,6 +190,12 @@ enum PendingBlit {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct LineBlitState {
+    /// Debugger: watched addresses (copied at blit start) and the last
+    /// write to one of them. Transient.
+    #[serde(skip)]
+    debug_watch_addrs: Vec<u32>,
+    #[serde(skip)]
+    debug_watched_write: Option<(u32, u16)>,
     phase: LineBlitPhase,
     slots_remaining: u32,
     npixels_remaining: u32,
@@ -207,6 +222,12 @@ struct LineBlitState {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct NormalBlitState {
+    /// Debugger: watched addresses (copied at blit start) and the last
+    /// write to one of them. Transient.
+    #[serde(skip)]
+    debug_watch_addrs: Vec<u32>,
+    #[serde(skip)]
+    debug_watched_write: Option<(u32, u16)>,
     phase: NormalBlitPhase,
     slots_remaining: u32,
     h_remaining: u32,
@@ -313,6 +334,8 @@ impl Default for Blitter {
 impl Blitter {
     pub fn new() -> Self {
         Self {
+            debug_watch_addrs: Vec::new(),
+            debug_watched_write: None,
             bltcon0: 0,
             bltcon1: 0,
             bltafwm: 0,
@@ -480,6 +503,35 @@ impl Blitter {
         }
     }
 
+    /// Replace the debugger's watched-address mirror (word-aligned),
+    /// propagating into a pending blit's state copy.
+    pub fn set_debug_watch_addrs(&mut self, addrs: &[u32]) {
+        self.debug_watch_addrs = addrs.to_vec();
+        match self.pending.as_mut() {
+            Some(PendingBlit::Normal(state)) => {
+                state.debug_watch_addrs = self.debug_watch_addrs.clone()
+            }
+            Some(PendingBlit::Line(state)) => {
+                state.debug_watch_addrs = self.debug_watch_addrs.clone()
+            }
+            None => {}
+        }
+    }
+
+    /// Take the last write to a watched address, if one happened.
+    pub fn take_debug_watched_write(&mut self) -> Option<(u32, u16)> {
+        if let Some(state) = self.pending.as_mut() {
+            let from_state = match state {
+                PendingBlit::Normal(state) => state.debug_watched_write.take(),
+                PendingBlit::Line(state) => state.debug_watched_write.take(),
+            };
+            if from_state.is_some() {
+                return from_state;
+            }
+        }
+        self.debug_watched_write.take()
+    }
+
     pub fn tick_scheduled_slot(&mut self, ram: &mut [u8]) -> bool {
         if self.pending.is_none() || !self.busy {
             return false;
@@ -487,7 +539,11 @@ impl Blitter {
         let mut pending = self.pending.take().unwrap();
         match &mut pending {
             PendingBlit::Normal(state) => {
-                if state.tick_slot(ram, &mut self.bzero) {
+                let done = state.tick_slot(ram, &mut self.bzero);
+                if let Some(write) = state.debug_watched_write.take() {
+                    self.debug_watched_write = Some(write);
+                }
+                if done {
                     state.write_back(self);
                     self.finish_blit();
                     true
@@ -497,7 +553,11 @@ impl Blitter {
                 }
             }
             PendingBlit::Line(state) => {
-                if state.tick_slot(ram, &mut self.bzero) {
+                let done = state.tick_slot(ram, &mut self.bzero);
+                if let Some(write) = state.debug_watched_write.take() {
+                    self.debug_watched_write = Some(write);
+                }
+                if done {
                     state.write_back(self);
                     self.finish_blit();
                     true
@@ -707,6 +767,11 @@ impl Blitter {
             // loop, so we just flush.
             for (pt, d) in row_dpt.iter().zip(row_d.iter()) {
                 write_word(ram, *pt, *d);
+                if !self.debug_watch_addrs.is_empty()
+                    && self.debug_watch_addrs.contains(&(*pt & 0x00FF_FFFE))
+                {
+                    self.debug_watched_write = Some((*pt, *d));
+                }
             }
 
             // End of row: apply modulos to every enabled pointer.
@@ -822,6 +887,11 @@ impl Blitter {
             }
             if use_c && line_pixel {
                 write_word(ram, dpt, d);
+                if !self.debug_watch_addrs.is_empty()
+                    && self.debug_watch_addrs.contains(&(dpt & 0x00FF_FFFE))
+                {
+                    self.debug_watched_write = Some((dpt, d));
+                }
             }
             dpt = cpt;
             bdat = bdat.rotate_left(1);
@@ -862,6 +932,8 @@ impl LineBlitState {
         let bdat = blitter.line_initial_bdat(bsh);
 
         Self {
+            debug_watch_addrs: blitter.debug_watch_addrs.clone(),
+            debug_watched_write: None,
             phase: LineBlitPhase::StartDelay,
             slots_remaining: line_total_slots(npixels),
             npixels_remaining: npixels,
@@ -1012,6 +1084,11 @@ impl LineBlitState {
         }
         if self.use_c && line_pixel {
             write_word(ram, self.dpt, d);
+            if !self.debug_watch_addrs.is_empty()
+                && self.debug_watch_addrs.contains(&(self.dpt & 0x00FF_FFFE))
+            {
+                self.debug_watched_write = Some((self.dpt, d));
+            }
         }
         self.dpt = self.cpt;
         self.bdat = self.bdat.rotate_left(1);
@@ -1071,6 +1148,8 @@ impl NormalBlitState {
         let snap_b = snap_source(use_b, blitter.bltbpt, mod_sign * blitter.bltbmod as i32);
 
         Self {
+            debug_watch_addrs: blitter.debug_watch_addrs.clone(),
+            debug_watched_write: None,
             phase: NormalBlitPhase::StartDelay,
             slots_remaining: normal_total_slots(h, w, con0, con1),
             h_remaining: h,
@@ -1438,6 +1517,13 @@ impl NormalBlitState {
         }
         if self.write_d {
             write_word(ram, self.d_hold_pt, self.d_hold);
+            if !self.debug_watch_addrs.is_empty()
+                && self
+                    .debug_watch_addrs
+                    .contains(&(self.d_hold_pt & 0x00FF_FFFE))
+            {
+                self.debug_watched_write = Some((self.d_hold_pt, self.d_hold));
+            }
             if self.track_overlay {
                 if let Some(off) = chip_off(self.d_hold_pt, ram.len()) {
                     self.d_overlay.insert(off, self.d_hold);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -78,6 +78,9 @@ pub struct M68kMachine {
     // window polls and surfaces (pause + reopen the debugger).
     ui_breaks: crate::debugger::InteractiveBreaks,
     ui_stop: Option<crate::debugger::DebugStop>,
+    /// ThisTask pointer at the last armed task-catch check, so only a
+    /// reschedule (a change) can fire the catch. Debug-only state.
+    ui_last_this_task: Option<u32>,
     // COPPERLINE_DBG_SPREN: previous DMACON, to detect the instruction that
     // clears the sprite-DMA-enable bit.
     dbg_prev_dmacon: u16,
@@ -236,6 +239,7 @@ impl M68kMachine {
             dbg: crate::debugger::Debugger::from_env(),
             ui_breaks: crate::debugger::InteractiveBreaks::default(),
             ui_stop: None,
+            ui_last_this_task: None,
             dbg_prev_dmacon: 0,
             dbg_prev_fc: 0,
             dbg_fc_count: 0,
@@ -1119,6 +1123,84 @@ impl M68kMachine {
         added
     }
 
+    /// Arm or clear the scheduled-task catch: stop when exec's ThisTask
+    /// changes to a task whose name contains `target` (matched
+    /// case-insensitively). Arming baselines on the currently scheduled
+    /// task so the catch fires on the next reschedule, not instantly.
+    pub fn ui_set_task_catch(&mut self, target: Option<String>) {
+        self.ui_last_this_task = self.ui_peek_this_task();
+        self.ui_breaks
+            .set_task_catch(target.map(|t| t.to_ascii_uppercase()));
+    }
+
+    /// ExecBase->ThisTask via side-effect-free peeks, when plausible.
+    fn ui_peek_this_task(&self) -> Option<u32> {
+        let peek32 = |addr: u32| {
+            (u32::from(self.bus.bus.peek_word_any(addr)) << 16)
+                | u32::from(self.bus.bus.peek_word_any(addr.wrapping_add(2)))
+        };
+        let execbase = peek32(4);
+        if execbase == 0 || execbase & 1 != 0 || execbase >= 0x0100_0000 {
+            return None;
+        }
+        let task = peek32(execbase.wrapping_add(0x114));
+        (task != 0 && task & 1 == 0 && task < 0x0100_0000).then_some(task)
+    }
+
+    /// The name a task node points at, uppercased for matching.
+    fn ui_task_name(&self, task: u32) -> String {
+        let peek32 = |addr: u32| {
+            (u32::from(self.bus.bus.peek_word_any(addr)) << 16)
+                | u32::from(self.bus.bus.peek_word_any(addr.wrapping_add(2)))
+        };
+        let name_ptr = peek32(task.wrapping_add(10));
+        if name_ptr == 0 || name_ptr >= 0x0100_0000 {
+            return String::new();
+        }
+        let mut name = String::new();
+        for i in 0..30u32 {
+            let addr = name_ptr.wrapping_add(i);
+            let word = self.bus.bus.peek_word_any(addr & !1);
+            let byte = if addr & 1 == 0 {
+                (word >> 8) as u8
+            } else {
+                word as u8
+            };
+            if byte == 0 {
+                break;
+            }
+            name.push(if (0x20..0x7F).contains(&byte) {
+                byte as char
+            } else {
+                '.'
+            });
+        }
+        name
+    }
+
+    /// Fire the task catch when exec reschedules to a matching task.
+    fn ui_check_task_catch(&mut self) {
+        if self.ui_breaks.task_catch.is_none() {
+            return;
+        }
+        let Some(task) = self.ui_peek_this_task() else {
+            return;
+        };
+        if self.ui_last_this_task == Some(task) {
+            return;
+        }
+        self.ui_last_this_task = Some(task);
+        let name = self.ui_task_name(task);
+        let matched = self
+            .ui_breaks
+            .task_catch
+            .as_deref()
+            .is_some_and(|target| name.to_ascii_uppercase().contains(target));
+        if matched {
+            self.ui_stop = Some(crate::debugger::DebugStop::Task { name, addr: task });
+        }
+    }
+
     /// Toggle an exception catchpoint (stop when the CPU enters the
     /// vector). Returns true when now set. Arming clears any stale
     /// recorded exception so an old entry cannot fire immediately.
@@ -1202,6 +1284,10 @@ impl M68kMachine {
         }
         if self.ui_breakpoint_stops(pc) {
             self.ui_stop = Some(DebugStop::Breakpoint { pc });
+            return;
+        }
+        self.ui_check_task_catch();
+        if self.ui_stop.is_some() {
             return;
         }
         self.ui_promote_reg_hit();

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -47,6 +47,9 @@ fn sync_cck_enabled_setting() -> bool {
     }
 }
 
+/// Entries kept in the debugger's recent-PC ring.
+pub const UI_PC_HISTORY_CAP: usize = 64;
+
 pub struct M68kMachine {
     cpu: CpuCore,
     bus: CpuBus,
@@ -81,6 +84,12 @@ pub struct M68kMachine {
     /// ThisTask pointer at the last armed task-catch check, so only a
     /// reschedule (a change) can fire the catch. Debug-only state.
     ui_last_this_task: Option<u32>,
+    /// Recent retired-instruction PCs, a debugger-only ring recorded
+    /// while a debug window is open ("how did I get here").
+    ui_pc_history: [u32; UI_PC_HISTORY_CAP],
+    ui_pc_history_next: usize,
+    ui_pc_history_len: usize,
+    ui_pc_history_enabled: bool,
     // COPPERLINE_DBG_SPREN: previous DMACON, to detect the instruction that
     // clears the sprite-DMA-enable bit.
     dbg_prev_dmacon: u16,
@@ -240,6 +249,10 @@ impl M68kMachine {
             ui_breaks: crate::debugger::InteractiveBreaks::default(),
             ui_stop: None,
             ui_last_this_task: None,
+            ui_pc_history: [0; UI_PC_HISTORY_CAP],
+            ui_pc_history_next: 0,
+            ui_pc_history_len: 0,
+            ui_pc_history_enabled: false,
             dbg_prev_dmacon: 0,
             dbg_prev_fc: 0,
             dbg_fc_count: 0,
@@ -1079,6 +1092,28 @@ impl M68kMachine {
     }
 
     /// The debugger window's breakpoint/watchpoint set (read-only view).
+    /// Enable/disable the recent-PC ring (cleared on enable). Recording
+    /// costs one array write per retired instruction, so it only runs
+    /// while a debug window has it on.
+    pub fn ui_set_pc_history_enabled(&mut self, enabled: bool) {
+        if enabled && !self.ui_pc_history_enabled {
+            self.ui_pc_history_len = 0;
+            self.ui_pc_history_next = 0;
+        }
+        self.ui_pc_history_enabled = enabled;
+    }
+
+    /// The recent-PC ring, oldest first.
+    pub fn ui_pc_history(&self) -> Vec<u32> {
+        let mut out = Vec::with_capacity(self.ui_pc_history_len);
+        let start = (self.ui_pc_history_next + UI_PC_HISTORY_CAP - self.ui_pc_history_len)
+            % UI_PC_HISTORY_CAP;
+        for i in 0..self.ui_pc_history_len {
+            out.push(self.ui_pc_history[(start + i) % UI_PC_HISTORY_CAP]);
+        }
+        out
+    }
+
     pub fn ui_breaks(&self) -> &crate::debugger::InteractiveBreaks {
         &self.ui_breaks
     }
@@ -1403,6 +1438,13 @@ impl M68kMachine {
                         self.debug_check_spren_clear();
                         self.debug_check_frame_counter();
                         self.debug_check_memw();
+                        if self.ui_pc_history_enabled {
+                            self.ui_pc_history[self.ui_pc_history_next] = dbg_pc_before;
+                            self.ui_pc_history_next =
+                                (self.ui_pc_history_next + 1) % UI_PC_HISTORY_CAP;
+                            self.ui_pc_history_len =
+                                (self.ui_pc_history_len + 1).min(UI_PC_HISTORY_CAP);
+                        }
                         self.debug_check_ipl(dbg_ipl_before, positive_cpu_cycles(cycles));
                         if self.ui_breaks.armed() {
                             self.ui_check_breaks_after_step();

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -971,6 +971,7 @@ impl M68kMachine {
         let mut bus: Bus = deserialize_component(r, "bus")?;
 
         bus.adopt_host_resources(&mut self.bus.bus);
+        bus.adopt_ui_debug_state(&self.bus.bus);
         bus.reset_transient_video_after_state_load();
         // The CPU model travels with the state (cpu_type, timing tables, and
         // address_mask all live in CpuCore); keep the bus adapter's mask copy
@@ -1001,6 +1002,12 @@ impl M68kMachine {
             self.last_cacr = !self.cpu.cacr;
             self.apply_cacr_updates();
         }
+        // Re-baseline the interactive stop conditions on the restored
+        // timeline: watch compare values and the scheduled-task pointer
+        // describe state, so carrying pre-restore baselines over would
+        // fire phantom hits on the first step after a restore.
+        self.ui_rebaseline_watches();
+        self.ui_last_this_task = self.ui_peek_this_task();
         Ok(())
     }
 
@@ -1112,6 +1119,15 @@ impl M68kMachine {
             out.push(self.ui_pc_history[(start + i) % UI_PC_HISTORY_CAP]);
         }
         out
+    }
+
+    /// Reset every word watchpoint's compare value to the live memory
+    /// contents (used after timeline jumps).
+    pub fn ui_rebaseline_watches(&mut self) {
+        for i in 0..self.ui_breaks.watches.len() {
+            let addr = self.ui_breaks.watches[i].addr;
+            self.ui_breaks.watches[i].last = self.bus.bus.peek_word_any(addr);
+        }
     }
 
     pub fn ui_breaks(&self) -> &crate::debugger::InteractiveBreaks {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1008,6 +1008,8 @@ impl M68kMachine {
         // fire phantom hits on the first step after a restore.
         self.ui_rebaseline_watches();
         self.ui_last_this_task = self.ui_peek_this_task();
+        let addrs: Vec<u32> = self.ui_breaks.watches.iter().map(|w| w.addr).collect();
+        self.bus.bus.set_ui_mem_watches(&addrs);
         Ok(())
     }
 
@@ -1159,9 +1161,23 @@ impl M68kMachine {
     /// Toggle a word watchpoint at `addr` (word-aligned), baselining it on
     /// the current memory contents. Returns true when now set.
     pub fn ui_toggle_watch(&mut self, addr: u32) -> bool {
+        self.ui_toggle_watch_filtered(addr, None)
+    }
+
+    /// Like [`Self::ui_toggle_watch`], stopping only on writes from
+    /// `filter`'s source when set. The watched addresses are mirrored
+    /// into the bus (and its DMA engines) for writer attribution.
+    pub fn ui_toggle_watch_filtered(
+        &mut self,
+        addr: u32,
+        filter: Option<crate::debugger::WatchSource>,
+    ) -> bool {
         let addr = addr & crate::debugger::UI_ADDR_MASK & !1;
         let current = self.bus.bus.peek_word_any(addr);
-        self.ui_breaks.toggle_watch(addr, current)
+        let added = self.ui_breaks.toggle_watch(addr, current, filter);
+        let addrs: Vec<u32> = self.ui_breaks.watches.iter().map(|w| w.addr).collect();
+        self.bus.bus.set_ui_mem_watches(&addrs);
+        added
     }
 
     /// Toggle a custom chipset register write watch (a word offset into
@@ -1266,6 +1282,7 @@ impl M68kMachine {
     pub fn ui_breaks_clear(&mut self) {
         self.ui_breaks.clear();
         self.bus.bus.set_ui_reg_watches(&[]);
+        self.bus.bus.set_ui_mem_watches(&[]);
         self.bus.bus.ui_clear_beam_traps();
         self.bus.bus.ui_clear_copper_breaks();
         self.ui_stop = None;
@@ -1346,19 +1363,41 @@ impl M68kMachine {
             return;
         }
         let writer_pc = self.cpu.ppc & crate::debugger::UI_ADDR_MASK;
-        for watch in &mut self.ui_breaks.watches {
-            let new = self.bus.bus.peek_word_any(watch.addr);
-            if new != watch.last {
-                let old = watch.last;
-                watch.last = new;
-                self.ui_stop = Some(DebugStop::Watch {
-                    addr: watch.addr,
-                    old,
-                    new,
-                    writer_pc,
-                });
-                return;
+        for i in 0..self.ui_breaks.watches.len() {
+            let addr = self.ui_breaks.watches[i].addr;
+            let new = self.bus.bus.peek_word_any(addr);
+            if new == self.ui_breaks.watches[i].last {
+                continue;
             }
+            let old = self.ui_breaks.watches[i].last;
+            self.ui_breaks.watches[i].last = new;
+            // Attribute the change: a DMA engine that flagged a write to
+            // this word wins over the default CPU story.
+            let writer = self.bus.bus.ui_take_mem_writer(addr);
+            let (source, vpos, hpos) = match writer {
+                Some(w) => (w.source, w.vpos, w.hpos),
+                None => (
+                    crate::debugger::WatchSource::Cpu,
+                    self.bus.bus.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+                    self.bus.bus.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+                ),
+            };
+            if let Some(filter) = self.ui_breaks.watches[i].filter {
+                if filter != source {
+                    // Filtered out: the baseline moved on, no stop.
+                    continue;
+                }
+            }
+            self.ui_stop = Some(DebugStop::Watch {
+                addr,
+                old,
+                new,
+                writer_pc,
+                source,
+                vpos,
+                hpos,
+            });
+            return;
         }
     }
 
@@ -2097,6 +2136,7 @@ impl CpuBus {
                 self.bus
                     .grant_cpu_bus_access_at(Some(addr), size, CpuBusAccessKind::Write);
                 self.bus.record_cpu_chip_ram_write(off, size, value);
+                self.bus.ui_note_cpu_ram_write(addr, size);
                 write_be(&mut self.bus.mem.chip_ram, off, size, value);
                 self.dbg_note_memw(addr, size);
                 return;
@@ -2112,6 +2152,7 @@ impl CpuBus {
                 // than running at uncontended external-memory speed.
                 self.bus
                     .grant_cpu_bus_access_at(Some(addr), size, CpuBusAccessKind::Write);
+                self.bus.ui_note_cpu_ram_write(addr, size);
                 write_be(&mut self.bus.mem.slow_ram, off, size, value);
                 self.dbg_note_memw(addr, size);
                 return;

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -214,6 +214,143 @@ impl DebugStop {
     }
 }
 
+/// Decoded bit/field lines for a custom register's value, for the
+/// debugger's IO Map tab. Registers without a decode table return an
+/// empty vec (the raw hex is always shown alongside).
+pub fn custom_reg_bit_decode(off: u16, value: u16) -> Vec<String> {
+    let off = off & 0x1FE;
+    let named_bits: &[(u16, &str)] = match off {
+        0x002 | 0x096 => &[
+            (14, "BBUSY"),
+            (13, "BZERO"),
+            (10, "BLTPRI"),
+            (9, "DMAEN"),
+            (8, "BPLEN"),
+            (7, "COPEN"),
+            (6, "BLTEN"),
+            (5, "SPREN"),
+            (4, "DSKEN"),
+            (3, "AUD3"),
+            (2, "AUD2"),
+            (1, "AUD1"),
+            (0, "AUD0"),
+        ],
+        0x01C | 0x01E | 0x09A | 0x09C => &[
+            (14, "INTEN"),
+            (13, "EXTER"),
+            (12, "DSKSYN"),
+            (11, "RBF"),
+            (10, "AUD3"),
+            (9, "AUD2"),
+            (8, "AUD1"),
+            (7, "AUD0"),
+            (6, "BLIT"),
+            (5, "VERTB"),
+            (4, "COPER"),
+            (3, "PORTS"),
+            (2, "SOFT"),
+            (1, "DSKBLK"),
+            (0, "TBE"),
+        ],
+        0x010 | 0x09E => &[
+            (14, "PRECOMP1"),
+            (13, "PRECOMP0"),
+            (12, "MFMPREC"),
+            (11, "WORDSYNC"),
+            (10, "MSBSYNC"),
+            (9, "FAST"),
+            (7, "USE3PN"),
+            (6, "USE2P3"),
+            (5, "USE1P2"),
+            (4, "USE0P1"),
+            (3, "USE3VN"),
+            (2, "USE2V3"),
+            (1, "USE1V2"),
+            (0, "USE0V1"),
+        ],
+        0x100 => &[
+            (15, "HIRES"),
+            (11, "HAM"),
+            (10, "DPF"),
+            (9, "COLOR"),
+            (8, "GAUD"),
+            (6, "SHRES"),
+            (3, "LPEN"),
+            (2, "LACE"),
+            (1, "ERSY"),
+            (0, "ECSENA"),
+        ],
+        0x104 => &[(6, "PF2PRI"), (10, "KILLEHB")],
+        0x098 => &[
+            (15, "ENSP7"),
+            (14, "ENSP5"),
+            (13, "ENSP3"),
+            (12, "ENSP1"),
+            (11, "ENBP6"),
+            (10, "ENBP5"),
+            (9, "ENBP4"),
+            (8, "ENBP3"),
+            (7, "ENBP2"),
+            (6, "ENBP1"),
+        ],
+        0x1DC => &[
+            (14, "HARDDIS"),
+            (13, "LPENDIS"),
+            (12, "VARVBEN"),
+            (11, "LOLDIS"),
+            (10, "CSCBEN"),
+            (9, "VARVSYEN"),
+            (8, "VARHSYEN"),
+            (7, "VARBEAMEN"),
+            (6, "DUAL"),
+            (5, "PAL"),
+        ],
+        0x1FC => &[
+            (15, "SSCAN2"),
+            (14, "BSCAN2"),
+            (3, "SPAGEM"),
+            (2, "SPR32"),
+            (1, "BPAGEM"),
+            (0, "BPL32"),
+        ],
+        _ => &[],
+    };
+    let mut lines = Vec::new();
+    if !named_bits.is_empty() {
+        let set: Vec<&str> = named_bits
+            .iter()
+            .filter(|(bit, _)| value & (1 << bit) != 0)
+            .map(|(_, name)| *name)
+            .collect();
+        lines.push(if set.is_empty() {
+            "(no named bits set)".to_string()
+        } else {
+            set.join(" ")
+        });
+    }
+    // Multi-bit fields.
+    match off {
+        0x100 => {
+            let bpu = ((value >> 12) & 7) + (((value >> 4) & 1) << 3);
+            lines.push(format!("BPU={bpu}"));
+        }
+        0x102 => lines.push(format!(
+            "PF1H={} PF2H={}",
+            value & 0x000F,
+            (value >> 4) & 0x000F
+        )),
+        0x104 => lines.push(format!(
+            "PF1P={} PF2P={}",
+            value & 0x0007,
+            (value >> 3) & 0x0007
+        )),
+        0x08E | 0x090 => lines.push(format!("v={} h={}", (value >> 8) & 0xFF, value & 0xFF)),
+        0x092 | 0x094 => lines.push(format!("cck ${:02X}", value & 0x00FC)),
+        _ => {}
+    }
+    lines
+}
+
 /// The hardware name of a custom-register word offset into $DFF000
 /// ($000-$1FE), e.g. 0x096 -> "DMACON". Banked registers (audio channels,
 /// bitplane/sprite pointers and data, colors) are derived; offsets without
@@ -1040,6 +1177,19 @@ mod tests {
         assert!(breaks.breakpoints.is_empty());
         assert!(breaks.watches.is_empty());
         assert!(breaks.reg_watches.is_empty());
+    }
+
+    #[test]
+    fn custom_reg_bit_decode_names_set_bits_and_fields() {
+        let lines = custom_reg_bit_decode(0x096, 0x0240);
+        assert_eq!(lines, vec!["DMAEN BLTEN".to_string()]);
+        let lines = custom_reg_bit_decode(0x100, 0x5800);
+        assert_eq!(lines[0], "HAM");
+        assert_eq!(lines[1], "BPU=5");
+        let lines = custom_reg_bit_decode(0x102, 0x0021);
+        assert_eq!(lines, vec!["PF1H=1 PF2H=2".to_string()]);
+        // Unknown registers decode to nothing (hex is always shown).
+        assert!(custom_reg_bit_decode(0x1F0, 0xFFFF).is_empty());
     }
 
     #[test]

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -103,6 +103,8 @@ pub enum DebugStop {
     /// The CPU entered a caught exception vector; `pc` is the handler
     /// entry the machine stopped at.
     Exception { vector: u16, pc: u32 },
+    /// Exec scheduled a task matching the armed task catch.
+    Task { name: String, addr: u32 },
 }
 
 /// Human name of a 68000 exception vector, for catchpoint listings and
@@ -155,6 +157,9 @@ impl DebugStop {
                 "Caught {} (vector {vector}), handler ${pc:06X}",
                 exception_vector_name(*vector)
             ),
+            DebugStop::Task { name, addr } => {
+                format!("Task scheduled: {name} (task ${addr:06X})")
+            }
         }
     }
 }
@@ -446,6 +451,9 @@ pub struct InteractiveBreaks {
     /// Caught exception vector numbers: the machine stops when the CPU
     /// enters one of these vectors (trap, fault, or interrupt).
     pub catches: Vec<u16>,
+    /// Stop when exec schedules a task whose name contains this
+    /// (case-insensitive) fragment; None = disabled.
+    pub task_catch: Option<String>,
     armed: bool,
 }
 
@@ -458,7 +466,8 @@ impl InteractiveBreaks {
         self.armed = !(self.breakpoints.is_empty()
             && self.watches.is_empty()
             && self.reg_watches.is_empty()
-            && self.catches.is_empty());
+            && self.catches.is_empty()
+            && self.task_catch.is_none());
     }
 
     /// Whether any breakpoint is set at `pc`, ignoring its condition. Used for
@@ -574,11 +583,19 @@ impl InteractiveBreaks {
         added
     }
 
+    /// Set or clear the scheduled-task catch. Returns the previous value.
+    pub fn set_task_catch(&mut self, target: Option<String>) -> Option<String> {
+        let previous = std::mem::replace(&mut self.task_catch, target);
+        self.rearm();
+        previous
+    }
+
     pub fn clear(&mut self) {
         self.breakpoints.clear();
         self.watches.clear();
         self.reg_watches.clear();
         self.catches.clear();
+        self.task_catch = None;
         self.armed = false;
     }
 }

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -71,6 +71,40 @@ pub const UI_ADDR_MASK: u32 = 0x00FF_FFFF;
 pub struct UiWatch {
     pub addr: u32,
     pub last: u16,
+    /// Only stop when the change was made by this writer; None = any.
+    pub filter: Option<WatchSource>,
+}
+
+/// Who wrote a watched memory word: attributed at the write site (the
+/// CPU write path, the blitter's D/line/fill writes, disk read DMA).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WatchSource {
+    Cpu,
+    Blitter,
+    Disk,
+}
+
+impl WatchSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            WatchSource::Cpu => "cpu",
+            WatchSource::Blitter => "blitter",
+            WatchSource::Disk => "disk",
+        }
+    }
+
+    /// Parse a console filter token (case-insensitive).
+    pub fn parse(token: &str) -> Option<Self> {
+        if token.eq_ignore_ascii_case("cpu") {
+            Some(WatchSource::Cpu)
+        } else if token.eq_ignore_ascii_case("blitter") {
+            Some(WatchSource::Blitter)
+        } else if token.eq_ignore_ascii_case("disk") {
+            Some(WatchSource::Disk)
+        } else {
+            None
+        }
+    }
 }
 
 /// Why the interactive debugger stopped the machine.
@@ -84,7 +118,12 @@ pub enum DebugStop {
         addr: u32,
         old: u16,
         new: u16,
+        /// The instruction that was executing when the change was seen
+        /// (the true writer when `source` is Cpu).
         writer_pc: u32,
+        source: WatchSource,
+        vpos: u16,
+        hpos: u16,
     },
     /// A watched custom chipset register was written (by any source: CPU
     /// or Copper), at the given beam position.
@@ -138,7 +177,18 @@ impl DebugStop {
                 old,
                 new,
                 writer_pc,
-            } => format!("Watch ${addr:06X}: {old:04X}->{new:04X} (pc ${writer_pc:06X})"),
+                source,
+                vpos,
+                hpos,
+            } => match source {
+                WatchSource::Cpu => {
+                    format!("Watch ${addr:06X}: {old:04X}->{new:04X} (pc ${writer_pc:06X})")
+                }
+                _ => format!(
+                    "Watch ${addr:06X}: {old:04X}->{new:04X} ({} write, v{vpos} h{hpos})",
+                    source.label()
+                ),
+            },
             DebugStop::ChipReg {
                 off,
                 value,
@@ -528,8 +578,9 @@ impl InteractiveBreaks {
     }
 
     /// Add a word watch at `addr` (recording `current` as its baseline),
-    /// or remove it when already set. Returns true when now set.
-    pub fn toggle_watch(&mut self, addr: u32, current: u16) -> bool {
+    /// or remove it when already set. `filter` limits which writer stops
+    /// it (None = any). Returns true when now set.
+    pub fn toggle_watch(&mut self, addr: u32, current: u16, filter: Option<WatchSource>) -> bool {
         let added = match self.watches.iter().position(|w| w.addr == addr) {
             Some(pos) => {
                 self.watches.remove(pos);
@@ -539,6 +590,7 @@ impl InteractiveBreaks {
                 self.watches.push(UiWatch {
                     addr,
                     last: current,
+                    filter,
                 });
                 true
             }
@@ -970,7 +1022,7 @@ mod tests {
     #[test]
     fn interactive_watches_record_baselines_and_clear() {
         let mut breaks = InteractiveBreaks::default();
-        assert!(breaks.toggle_watch(0x1000, 0xABCD));
+        assert!(breaks.toggle_watch(0x1000, 0xABCD, None));
         assert_eq!(breaks.watches[0].last, 0xABCD);
         // The register watch normalizes a full $DFFxxx address to the
         // word offset.
@@ -1002,9 +1054,25 @@ mod tests {
                 old: 0x12,
                 new: 0x13,
                 writer_pc: 0xC03374,
+                source: WatchSource::Cpu,
+                vpos: 44,
+                hpos: 100,
             }
             .describe(),
             "Watch $C09580: 0012->0013 (pc $C03374)"
+        );
+        assert_eq!(
+            DebugStop::Watch {
+                addr: 0xC09580,
+                old: 0x12,
+                new: 0x13,
+                writer_pc: 0xC03374,
+                source: WatchSource::Blitter,
+                vpos: 44,
+                hpos: 100,
+            }
+            .describe(),
+            "Watch $C09580: 0012->0013 (blitter write, v44 h100)"
         );
         assert_eq!(
             DebugStop::ChipReg {

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -811,9 +811,13 @@ impl Emulator {
     /// history that starts at power-on; `BeyondHistory` means an earlier hit
     /// may exist before the oldest snapshot. (Watch-based reverse-continue is
     /// not yet modelled; breakpoints only.)
-    pub fn tt_reverse_continue(&mut self) -> Result<crate::timetravel::ReverseOutcome<u64>> {
-        // Reverse-continue honours breakpoint addresses only (conditions are
-        // not replayed), so collect the bare addresses.
+    pub fn tt_reverse_continue(
+        &mut self,
+    ) -> Result<crate::timetravel::ReverseOutcome<(u64, String)>> {
+        // The full scan honours every armed stop kind: PC breakpoints
+        // (addresses; conditions are not replayed), watchpoints, register
+        // watches, beam traps, Copper breakpoints, exception catches, and
+        // the task catch.
         let breakpoints: Vec<u32> = self
             .machine
             .ui_breaks()
@@ -821,13 +825,20 @@ impl Emulator {
             .iter()
             .map(|bp| bp.addr)
             .collect();
-        self.tt_reverse_continue_to(&breakpoints)
+        let anything_armed = self.machine.ui_breaks().armed()
+            || !self.bus().ui_beam_traps().is_empty()
+            || !self.bus().ui_copper_breaks().is_empty();
+        if !anything_armed && breakpoints.is_empty() {
+            return Ok(crate::timetravel::ReverseOutcome::NotFound);
+        }
+        self.tt_reverse_continue_impl(&breakpoints, true)
     }
 
     /// Run backward to the previous PC breakpoint in `breakpoints`. This is
     /// the same operation as `tt_reverse_continue`, but takes an explicit
-    /// breakpoint list so remote debugger frontends can keep their protocol
-    /// breakpoints independent from the in-window debugger state.
+    /// breakpoint list (and scans nothing else) so remote debugger frontends
+    /// can keep their protocol breakpoints independent from the in-window
+    /// debugger state.
     pub fn tt_reverse_continue_to(
         &mut self,
         breakpoints: &[u32],
@@ -836,6 +847,19 @@ impl Emulator {
         if breakpoints.is_empty() {
             return Ok(ReverseOutcome::NotFound);
         }
+        Ok(match self.tt_reverse_continue_impl(breakpoints, false)? {
+            ReverseOutcome::Found((pos, _)) => ReverseOutcome::Found(pos),
+            ReverseOutcome::NotFound => ReverseOutcome::NotFound,
+            ReverseOutcome::BeyondHistory => ReverseOutcome::BeyondHistory,
+        })
+    }
+
+    fn tt_reverse_continue_impl(
+        &mut self,
+        breakpoints: &[u32],
+        full: bool,
+    ) -> Result<crate::timetravel::ReverseOutcome<(u64, String)>> {
+        use crate::timetravel::ReverseOutcome;
         let mut interval_end = self.retired_instructions;
         loop {
             let anchor = match self
@@ -850,9 +874,14 @@ impl Emulator {
                 self.tt_ring.as_ref().and_then(|r| r.oldest_pos()) == Some(anchor.0);
             self.restore_blob(&anchor.1, anchor.0)?;
             self.tt_begin_replay_input(anchor.0);
-            if let Some(pos) = self.tt_scan_breakpoint(breakpoints, interval_end)? {
+            if let Some(found) = self.tt_scan_stop(breakpoints, interval_end, full)? {
+                let (pos, reason) = found;
                 self.tt_restore_to(pos)?;
-                return Ok(ReverseOutcome::Found(pos));
+                // The final forward replay to `pos` re-fires checks along
+                // the way; the landing position's story is `reason`, so
+                // drop the stray pending stop.
+                let _ = self.machine.take_ui_debug_stop();
+                return Ok(ReverseOutcome::Found((pos, reason)));
             }
             if anchor_is_oldest {
                 return Ok(if anchor.0 == 0 {
@@ -866,15 +895,29 @@ impl Emulator {
     }
 
     /// Replay the just-restored interval up to `end_pos`, returning the latest
-    /// boundary (strictly before `end_pos`) whose PC is an armed breakpoint --
-    /// the "about to execute a breakpoint" stop the forward run uses.
-    fn tt_scan_breakpoint(&mut self, breakpoints: &[u32], end_pos: u64) -> Result<Option<u64>> {
+    /// boundary (strictly before `end_pos`) where a stop condition held: a PC
+    /// breakpoint ("about to execute", like the forward run), or -- when
+    /// `full` -- any interactive stop the forward machinery reports
+    /// (watchpoints, register watches, beam traps, Copper breakpoints,
+    /// catches). The restore that began this interval re-baselined the
+    /// watch compare values, so hits mean "changed during replay".
+    fn tt_scan_stop(
+        &mut self,
+        breakpoints: &[u32],
+        end_pos: u64,
+        full: bool,
+    ) -> Result<Option<(u64, String)>> {
         const PC_MASK: u32 = 0x00FF_FFFF;
         let is_bp = |pc: u32| breakpoints.contains(&(pc & PC_MASK));
+        // Drain any stop left over from an earlier replay segment.
+        let _ = self.machine.take_ui_debug_stop();
         self.tt_apply_due_input(self.retired_instructions);
-        let mut best = None;
+        let mut best: Option<(u64, String)> = None;
         if self.retired_instructions < end_pos && is_bp(self.machine.pc()) {
-            best = Some(self.retired_instructions);
+            best = Some((
+                self.retired_instructions,
+                format!("Breakpoint at ${:06X}", self.machine.pc() & PC_MASK),
+            ));
         }
         let mut cpu_idle = false;
         let mut guard: u64 = 0;
@@ -882,8 +925,18 @@ impl Emulator {
             let before = self.retired_instructions;
             self.run_one_step(&mut cpu_idle, INSTRUCTIONS_PER_SLICE)?;
             self.tt_apply_due_input(self.retired_instructions);
+            if full {
+                if let Some(stop) = self.machine.take_ui_debug_stop() {
+                    if self.retired_instructions < end_pos {
+                        best = Some((self.retired_instructions, stop.describe()));
+                    }
+                }
+            }
             if self.retired_instructions < end_pos && is_bp(self.machine.pc()) {
-                best = Some(self.retired_instructions);
+                best = Some((
+                    self.retired_instructions,
+                    format!("Breakpoint at ${:06X}", self.machine.pc() & PC_MASK),
+                ));
             }
             if self.retired_instructions == before && !cpu_idle {
                 break;
@@ -893,6 +946,7 @@ impl Emulator {
                 break;
             }
         }
+        let _ = self.machine.take_ui_debug_stop();
         Ok(best)
     }
 
@@ -2413,6 +2467,86 @@ mod tests {
         assert!(stopped, "conditional breakpoint did not fire");
         assert_eq!(emu.machine.pc(), 0x00F8_0020);
         assert!(emu.machine.take_ui_debug_stop().is_some());
+    }
+
+    #[test]
+    fn reverse_continue_lands_on_a_watchpoint_hit() {
+        use crate::timetravel::ReverseOutcome;
+        // NOP, NOP, MOVE.W #$1234,$60000.L, NOPs, BRA.S *.
+        let mut rom = vec![0u8; crate::memory::ROM_SIZE];
+        let put = |mem: &mut [u8], off: usize, word: u16| {
+            mem[off..off + 2].copy_from_slice(&word.to_be_bytes());
+        };
+        put(&mut rom, 0x10, 0x4E71);
+        put(&mut rom, 0x12, 0x4E71);
+        put(&mut rom, 0x14, 0x33FC);
+        put(&mut rom, 0x16, 0x1234);
+        put(&mut rom, 0x18, 0x0006);
+        put(&mut rom, 0x1A, 0x0000);
+        put(&mut rom, 0x1C, 0x4E71);
+        put(&mut rom, 0x1E, 0x4E71);
+        put(&mut rom, 0x20, 0x60FE);
+        let mut chip_ram = vec![0u8; 512 * 1024];
+        chip_ram[0..4].copy_from_slice(&0x0000_4000u32.to_be_bytes());
+        chip_ram[4..8].copy_from_slice(&0x00F8_0010u32.to_be_bytes());
+        let bus = crate::bus::Bus::new(
+            crate::memory::Memory {
+                chip_ram,
+                slow_ram: Vec::new(),
+                rom,
+                overlay: false,
+                zorro: crate::zorro::ZorroChain::default(),
+                extended_rom: Vec::new(),
+                extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
+            },
+            crate::chipset::paula::Paula::new(
+                Box::new(crate::serial::NullSerialSink),
+                Box::new(crate::audio::NullSink),
+            ),
+            crate::floppy::FloppyController::default(),
+        );
+        let mut emu = super::Emulator::new(
+            bus,
+            crate::config::CpuModel::M68000,
+            false,
+            crate::config::PacingBudget::Cycles,
+            2,
+            false,
+        )
+        .unwrap();
+        emu.enable_time_travel(64, 1);
+        emu.debug_ensure_time_travel_anchor().unwrap();
+        assert!(emu.machine.ui_toggle_watch(0x60000));
+
+        // Run forward well past the write, draining the forward stop.
+        for _ in 0..12 {
+            emu.debug_step_instructions(1).unwrap();
+        }
+        assert_eq!(emu.bus().peek_word_any(0x60000), 0x1234);
+        let _ = emu.machine.take_ui_debug_stop();
+        let here = emu.retired_instructions();
+
+        // Reverse-continue lands just after the watched write, with the
+        // watch hit as the reason.
+        match emu.tt_reverse_continue().unwrap() {
+            ReverseOutcome::Found((pos, reason)) => {
+                assert!(pos < here, "landed at {pos}, started at {here}");
+                assert!(
+                    reason.contains("Watch $060000") && reason.contains("0000->1234"),
+                    "{reason}"
+                );
+                // At the landing boundary the write has just retired.
+                assert_eq!(emu.bus().peek_word_any(0x60000), 0x1234);
+                assert_eq!(emu.machine.pc() & 0x00FF_FFFF, 0x00F8_001C);
+            }
+            other => panic!("expected a watch landing, got {other:?}"),
+        }
+        // Beam traps survive the timeline jump (adopt_ui_debug_state).
+        emu.bus_mut().ui_arm_beam_trap_once(100, None);
+        let _ = emu.tt_reverse_step(1).unwrap();
+        assert_eq!(emu.bus().ui_beam_traps().len(), 1);
     }
 
     #[test]

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2470,6 +2470,69 @@ mod tests {
     }
 
     #[test]
+    fn watchpoint_attributes_blitter_writes_and_honours_filters() {
+        use crate::debugger::{DebugStop, WatchSource};
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().mem.overlay = false;
+        assert!(emu.machine.ui_toggle_watch(0x60000));
+
+        // A 1x1 D-only blit (LF = A, ADAT latched) into the watched word,
+        // with blitter DMA enabled.
+        {
+            let bus = emu.bus_mut();
+            bus.custom_write(0x096, 2, 0x8240); // DMACON SET DMAEN|BLTEN
+            bus.custom_write(0x040, 2, 0x01F0); // BLTCON0: USED, LF=$F0 (D=A)
+            bus.custom_write(0x042, 2, 0x0000); // BLTCON1
+            bus.custom_write(0x044, 2, 0xFFFF); // BLTAFWM
+            bus.custom_write(0x046, 2, 0xFFFF); // BLTALWM
+            bus.custom_write(0x074, 2, 0xBEEF); // BLTADAT
+            bus.custom_write(0x054, 4, 0x0006_0000); // BLTDPT
+            bus.custom_write(0x058, 2, 0x0041); // BLTSIZE: 1 row x 1 word
+        }
+        let mut stop = None;
+        for _ in 0..64 {
+            emu.debug_step_instructions(1).unwrap();
+            if let Some(s) = emu.machine.take_ui_debug_stop() {
+                stop = Some(s);
+                break;
+            }
+        }
+        match stop {
+            Some(DebugStop::Watch { source, new, .. }) => {
+                assert_eq!(source, WatchSource::Blitter);
+                assert_eq!(new, 0xBEEF);
+            }
+            other => panic!("expected a blitter-attributed watch stop, got {other:?}"),
+        }
+
+        // A CPU-filtered watch swallows the same blitter write.
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().mem.overlay = false;
+        assert!(emu
+            .machine
+            .ui_toggle_watch_filtered(0x60000, Some(WatchSource::Cpu)));
+        {
+            let bus = emu.bus_mut();
+            bus.custom_write(0x096, 2, 0x8240);
+            bus.custom_write(0x040, 2, 0x01F0);
+            bus.custom_write(0x042, 2, 0x0000);
+            bus.custom_write(0x044, 2, 0xFFFF);
+            bus.custom_write(0x046, 2, 0xFFFF);
+            bus.custom_write(0x074, 2, 0xBEEF);
+            bus.custom_write(0x054, 4, 0x0006_0000);
+            bus.custom_write(0x058, 2, 0x0041);
+        }
+        for _ in 0..64 {
+            emu.debug_step_instructions(1).unwrap();
+            assert!(
+                emu.machine.take_ui_debug_stop().is_none(),
+                "cpu-filtered watch must swallow a blitter write"
+            );
+        }
+        assert_eq!(emu.bus().peek_word_any(0x60000), 0xBEEF);
+    }
+
+    #[test]
     fn reverse_continue_lands_on_a_watchpoint_hit() {
         use crate::timetravel::ReverseOutcome;
         // NOP, NOP, MOVE.W #$1234,$60000.L, NOPs, BRA.S *.

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -141,6 +141,12 @@ fn disk_speed_div() -> Option<(u32, f64)> {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct FloppyController {
+    /// Debugger: watched word addresses and the last disk-DMA write to
+    /// one of them, for watchpoint writer attribution. Transient.
+    #[serde(skip)]
+    debug_watch_addrs: Vec<u32>,
+    #[serde(skip)]
+    debug_watched_write: Option<(u32, u16)>,
     drives: [FloppyDrive; 4],
     prb: u8,
     side: usize,
@@ -189,6 +195,8 @@ impl Default for FloppyController {
             drive.external_id = 0;
         }
         Self {
+            debug_watch_addrs: Vec::new(),
+            debug_watched_write: None,
             drives,
             prb: 0xFF,
             side: 0,
@@ -220,6 +228,16 @@ impl Default for FloppyController {
 }
 
 impl FloppyController {
+    /// Replace the debugger's watched-address mirror (word-aligned).
+    pub fn set_debug_watch_addrs(&mut self, addrs: &[u32]) {
+        self.debug_watch_addrs = addrs.to_vec();
+    }
+
+    /// Take the last disk-DMA write to a watched address, if any.
+    pub fn take_debug_watched_write(&mut self) -> Option<(u32, u16)> {
+        self.debug_watched_write.take()
+    }
+
     pub fn from_config(config: &FloppyConfig) -> Result<Self> {
         let mut ctrl = Self { ..Self::default() };
         for (idx, drive_cfg) in config.drives.iter().enumerate() {
@@ -782,6 +800,11 @@ impl FloppyController {
                             break;
                         }
                         write_chip_word(chip_ram, self.dskpt, word);
+                        if !self.debug_watch_addrs.is_empty()
+                            && self.debug_watch_addrs.contains(&(self.dskpt & 0x00FF_FFFE))
+                        {
+                            self.debug_watched_write = Some((self.dskpt, word));
+                        }
                         self.last_dskdatr = word;
                         self.last_dskbytr_byte = (word & 0x00FF) as u8;
                         self.dskbyte_valid = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod a2065;
 pub mod a2091;
 pub mod akiko;
+pub mod amigaos;
 pub mod audio;
 pub mod bus;
 pub mod cache;

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -1277,6 +1277,9 @@ pub struct AnalyzerTraceView {
     pub selected_owner_code: u8,
     pub owners: Vec<u8>,
     pub markers: Vec<AnalyzerMarker>,
+    /// "in blit #N ..." when the selected slot lies inside a recorded
+    /// blit's beam span.
+    pub selected_blit: Option<String>,
     /// Frame-start display window: (v_start, v_stop) beam lines (stop
     /// already unwrapped past 255 where applicable) and (h_start, h_stop)
     /// in colour clocks. None when DIW is unprogrammed.
@@ -2984,13 +2987,17 @@ fn draw_frame_analyzer(
     let counters_x = raster.x + raster.w + 16;
     draw_owner_counters(frame, counters_x, raster.y, trace, scale);
 
-    let selected = format!(
+    let mut selected = format!(
         "selected v={:03} h={:03}  owner={} ({})",
         trace.selected_vpos,
         trace.selected_hpos,
         trace.selected_owner,
         trace.selected_owner_code as char
     );
+    if let Some(blit) = &trace.selected_blit {
+        selected.push_str("  ");
+        selected.push_str(blit);
+    }
     draw_panel_text(
         frame,
         rect.x + 10,
@@ -4506,6 +4513,7 @@ mod tests {
             selected_owner_code: b'.',
             owners: vec![b'.'; 312 * 227],
             markers: Vec::new(),
+            selected_blit: None,
             diw_v: None,
             diw_h_cck: None,
             ddf_cck: None,
@@ -4808,6 +4816,7 @@ mod tests {
                 value: 0x0000,
                 source: "copper",
             }],
+            selected_blit: None,
             diw_v: None,
             diw_h_cck: None,
             ddf_cck: None,
@@ -5296,6 +5305,7 @@ mod tests {
                 value: 0x0F00,
                 source: "copper",
             }],
+            selected_blit: Some("in blit #2 (20x100 D $060000)".to_string()),
             // A standard PAL display window and fetch bounds, so the
             // preview shows the DIW box and DDF verticals.
             diw_v: Some((0x2C, 0x12C)),

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -182,16 +182,18 @@ pub enum DebugTab {
     Video,
     Audio,
     Memory,
+    IoMap,
     Break,
 }
 
-pub const DEBUG_TABS: [DebugTab; 7] = [
+pub const DEBUG_TABS: [DebugTab; 8] = [
     DebugTab::Cpu,
     DebugTab::Chipset,
     DebugTab::Copper,
     DebugTab::Video,
     DebugTab::Audio,
     DebugTab::Memory,
+    DebugTab::IoMap,
     DebugTab::Break,
 ];
 
@@ -203,6 +205,7 @@ fn debug_tab_label(tab: DebugTab) -> &'static str {
         DebugTab::Video => "Video",
         DebugTab::Audio => "Audio",
         DebugTab::Memory => "Memory",
+        DebugTab::IoMap => "IO Map",
         DebugTab::Break => "Break",
     }
 }
@@ -227,6 +230,8 @@ pub struct DebuggerPanel {
     /// Memory tab bitmap mode: row stride in bytes (40 = a standard
     /// 320-pixel-wide plane).
     pub mem_bitmap_stride: u32,
+    /// IO Map tab: the selected custom-register word offset ($000-$1FE).
+    pub iomap_sel: u16,
 }
 
 impl DebuggerPanel {
@@ -240,6 +245,7 @@ impl DebuggerPanel {
             mem_last_find: None,
             mem_view_bits: false,
             mem_bitmap_stride: 40,
+            iomap_sel: 0x096,
         }
     }
 
@@ -770,7 +776,7 @@ fn cal_button_enabled(control: UiControl, session: &crate::gamepad::CalibrationS
 
 // Debugger chrome: a tab row under the title and a control row at the
 // bottom with the transport buttons and the shared hex-entry box.
-const DEBUG_TAB_W: usize = 90;
+const DEBUG_TAB_W: usize = 80;
 const DEBUG_TAB_H: usize = 18;
 const DEBUG_BUTTON_H: usize = 20;
 
@@ -4581,8 +4587,16 @@ mod tests {
         let tab = debug_tab_rect(rect, 6);
         assert_eq!(
             ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2)),
+            Some(UiControl::DebugTab(DebugTab::IoMap))
+        );
+        let tab = debug_tab_rect(rect, 7);
+        assert_eq!(
+            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2)),
             Some(UiControl::DebugTab(DebugTab::Break))
         );
+        // All eight tabs fit inside the panel.
+        let last = debug_tab_rect(rect, 7);
+        assert!(last.x + last.w <= rect.x + rect.w);
         let (control, step) = debug_button_rects(rect)[1];
         assert_eq!(control, UiControl::DebugStep);
         assert_eq!(
@@ -5169,6 +5183,65 @@ mod tests {
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "debugger-audio");
+
+        // IO Map tab: the register grid with a selection and decode pane.
+        let mut frame = vec![0u8; w * h * 4];
+        let mut lines: Vec<DbgLine> = Vec::new();
+        lines.push(DbgLine::plain(
+            "custom registers $DFF000-$DFF1FE  (page 2/4; arrows/wheel move, $ box jumps)",
+        ));
+        lines.push(DbgLine::plain(""));
+        for row in 0..26 {
+            let mut text = String::new();
+            for col in 0..3 {
+                let off = 0x0A0 + (col * 26 + row) * 2;
+                let cursor = if off == 0x0100 { '>' } else { ' ' };
+                text.push_str(&format!(
+                    "{cursor}{off:03X} {:<8} {:04X}   ",
+                    crate::debugger::custom_reg_name(off as u16),
+                    0x2200 + off
+                ));
+            }
+            lines.push(if row == 16 {
+                DbgLine::hilit(text.trim_end().to_string())
+            } else {
+                DbgLine::plain(text.trim_end().to_string())
+            });
+        }
+        lines.push(DbgLine::plain(""));
+        lines.push(DbgLine::hilit("$100 BPLCON0 = $5A00".to_string()));
+        lines.push(DbgLine::plain("  HAM COLOR".to_string()));
+        lines.push(DbgLine::plain("  BPU=5".to_string()));
+        let data = PanelViewData::Debugger(Box::new(DebuggerView {
+            running: false,
+            reverse_available: true,
+            status: "paused frame 1234 24.68s".to_string(),
+            lines,
+            bitmap: None,
+            video: None,
+            audio: None,
+        }));
+        let mut panel = DebuggerPanel::new();
+        panel.tab = DebugTab::IoMap;
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Debugger(panel)),
+        };
+        draw(
+            &mut frame,
+            scale,
+            &ui,
+            None,
+            Some(&data),
+            false,
+            WarpSpeed::Max,
+            false,
+            false,
+            JoystickInputMode::Gamepad,
+            PixelAspect::Tv,
+        );
+        assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
+        save(&frame, "debugger-iomap");
 
         // Video tab: layer-isolation toggles (plane 2 and sprite 5 hidden),
         // sprite rows with synthetic thumbnails, and an AGA palette grid.

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4372,10 +4372,16 @@ impl App {
         self.sync_live_audio_suspension();
         self.last_debug_stop = None;
         match self.emu.tt_reverse_continue() {
-            Ok(ReverseOutcome::Found(_)) => {
-                self.surface_debug_stop();
+            Ok(ReverseOutcome::Found((_, reason))) => {
+                let message = format!("Reverse: {reason}");
+                info!("debugger stop: {message}");
+                self.last_debug_stop = Some(message.clone());
+                self.show_osd(message);
+                if let Some(panel) = self.debugger_panel.as_mut() {
+                    panel.tab = ui::DebugTab::Break;
+                }
             }
-            Ok(ReverseOutcome::NotFound) => self.show_osd("Reverse run: no earlier breakpoint hit"),
+            Ok(ReverseOutcome::NotFound) => self.show_osd("Reverse run: no earlier stop hit"),
             Ok(ReverseOutcome::BeyondHistory) => {
                 self.show_osd("Reverse run: beyond recorded history")
             }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2503,7 +2503,15 @@ impl App {
                 // scrollback: one display row per wheel notch, a chunk for
                 // pixel-precise trackpads.
                 if kind == ToolPanelKind::Debugger {
-                    self.debugger_mem_scroll(rows);
+                    if self
+                        .debugger_panel
+                        .as_ref()
+                        .is_some_and(|panel| panel.tab == ui::DebugTab::IoMap)
+                    {
+                        self.debugger_iomap_move(rows);
+                    } else {
+                        self.debugger_mem_scroll(rows);
+                    }
                 } else if kind == ToolPanelKind::Console {
                     if let Some(panel) = self.console_panel.as_mut() {
                         panel.scroll = panel
@@ -3014,6 +3022,12 @@ impl App {
                                 panel.mem_addr = addr & !0xF;
                             }
                         }
+                        // The IO Map takes an offset (96) or address (DFF096).
+                        ui::DebugTab::IoMap => {
+                            if let Some(addr) = panel.entry_addr() {
+                                panel.iomap_sel = (addr as u16) & 0x1FE;
+                            }
+                        }
                         // On the CPU tab, Enter pins the disassembly to
                         // the typed address; an empty box follows the PC again.
                         ui::DebugTab::Cpu => panel.disasm_addr = panel.entry_addr(),
@@ -3061,7 +3075,38 @@ impl App {
                 return true;
             }
         }
+        // IO Map tab: arrows move the register selection (left/right by
+        // a display column), PageUp/Down by a page.
+        if self
+            .debugger_panel
+            .as_ref()
+            .is_some_and(|panel| panel.tab == ui::DebugTab::IoMap)
+        {
+            let delta = match code {
+                KeyCode::ArrowUp => Some(-1i32),
+                KeyCode::ArrowDown => Some(1),
+                KeyCode::ArrowLeft => Some(-26),
+                KeyCode::ArrowRight => Some(26),
+                KeyCode::PageUp => Some(-78),
+                KeyCode::PageDown => Some(78),
+                _ => None,
+            };
+            if let Some(delta) = delta {
+                self.debugger_iomap_move(delta);
+                return true;
+            }
+        }
         false
+    }
+
+    /// Move the IO Map selection by `delta` registers, clamped to the
+    /// custom bank.
+    fn debugger_iomap_move(&mut self, delta: i32) {
+        if let Some(panel) = self.debugger_panel.as_mut() {
+            let idx = i32::from(panel.iomap_sel >> 1) + delta;
+            panel.iomap_sel = (idx.clamp(0, 255) as u16) << 1;
+            self.request_redraw();
+        }
     }
 
     fn ui_handle_frame_analyzer_key(&mut self, code: KeyCode) -> bool {
@@ -5318,6 +5363,65 @@ impl App {
                             bytes[word as usize * 2 + 1] = value as u8;
                         }
                         lines.push(ui::DbgLine::plain(ui::hex_dump_row(addr, &bytes)));
+                    }
+                }
+            }
+            ui::DebugTab::IoMap => {
+                const ROWS: usize = 26;
+                const COLS: usize = 3;
+                const PER_PAGE: usize = ROWS * COLS;
+                let sel = usize::from(panel.iomap_sel & 0x1FE) / 2;
+                let page = sel / PER_PAGE;
+                lines.push(ui::DbgLine::plain(format!(
+                    "custom registers $DFF000-$DFF1FE  (page {}/{}; arrows/wheel move, $ box jumps)",
+                    page + 1,
+                    256usize.div_ceil(PER_PAGE)
+                )));
+                lines.push(ui::DbgLine::plain(""));
+                for row in 0..ROWS {
+                    let mut text = String::new();
+                    let mut row_has_sel = false;
+                    for col in 0..COLS {
+                        let idx = page * PER_PAGE + col * ROWS + row;
+                        if idx >= 256 {
+                            continue;
+                        }
+                        let off = (idx * 2) as u16;
+                        let value = bus
+                            .debug_custom_word(off)
+                            .map(|v| format!("{v:04X}"))
+                            .unwrap_or_else(|| "----".to_string());
+                        let cursor = if idx == sel {
+                            row_has_sel = true;
+                            '>'
+                        } else {
+                            ' '
+                        };
+                        text.push_str(&format!(
+                            "{cursor}{off:03X} {:<8} {value}   ",
+                            crate::debugger::custom_reg_name(off)
+                        ));
+                    }
+                    let text = text.trim_end().to_string();
+                    lines.push(if row_has_sel {
+                        ui::DbgLine::hilit(text)
+                    } else {
+                        ui::DbgLine::plain(text)
+                    });
+                }
+                lines.push(ui::DbgLine::plain(""));
+                let off = panel.iomap_sel & 0x1FE;
+                let value = bus.debug_custom_word(off);
+                lines.push(ui::DbgLine::hilit(format!(
+                    "${off:03X} {} = {}",
+                    crate::debugger::custom_reg_name(off),
+                    value
+                        .map(|v| format!("${v:04X}"))
+                        .unwrap_or_else(|| "(no latch)".to_string())
+                )));
+                if let Some(value) = value {
+                    for line in crate::debugger::custom_reg_bit_decode(off, value) {
+                        lines.push(ui::DbgLine::plain(format!("  {line}")));
                     }
                 }
             }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4825,6 +4825,20 @@ impl App {
             (None, None)
         };
         let ddf_cck = diw_programmed.then_some((base.ddfstrt & 0x00FE, base.ddfstop & 0x00FE));
+        // Annotate the selected slot with the blit whose beam span
+        // contains it, so clicking a blitter run names the blit.
+        let selected_beam = (selected_vpos as u16, selected_hpos as u16);
+        let selected_blit = trace.blits.iter().enumerate().find_map(|(i, blit)| {
+            let end = blit.end?;
+            (blit.start <= selected_beam && selected_beam <= end).then(|| {
+                format!(
+                    "in blit #{i} ({}x{} D ${:06X})",
+                    blit.width_words,
+                    blit.height,
+                    blit.dpt & 0x00FF_FFFF
+                )
+            })
+        });
         ui::FrameAnalyzerView {
             running: !self.paused,
             status,
@@ -4850,6 +4864,7 @@ impl App {
                 selected_owner_code,
                 owners,
                 markers,
+                selected_blit,
                 diw_v,
                 diw_h_cck,
                 ddf_cck,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3156,6 +3156,7 @@ impl App {
             // neighbourhood; it is usually what you came to look at.
             panel.mem_addr = self.emu.machine.pc() & 0x00FF_FFF0;
             self.debugger_panel = Some(panel);
+            self.emu.machine.ui_set_pc_history_enabled(true);
             // Arm reverse debugging so the < Step / < Run controls work. A
             // conservative interval keeps the per-snapshot serialize off the
             // critical path; captures only accrue while the machine advances
@@ -3191,6 +3192,7 @@ impl App {
             let mut panel = ui::ConsolePanel::default();
             panel.push_output("Copperline debugger console. Type HELP for commands.");
             self.console_panel = Some(panel);
+            self.emu.machine.ui_set_pc_history_enabled(true);
             // Arm reverse debugging so the reverse commands work, exactly
             // like opening the debugger window does.
             if !self.emu.time_travel_enabled() {
@@ -3723,6 +3725,9 @@ impl App {
                 self.analyzer_underlay_frame = None;
                 self.analyzer_underlay_input = None;
             }
+        }
+        if self.debugger_panel.is_none() && self.console_panel.is_none() {
+            self.emu.machine.ui_set_pc_history_enabled(false);
         }
         self.resize_for_active_panel();
         self.request_redraw();
@@ -4901,6 +4906,21 @@ impl App {
                     }
                 }
                 lines.push(ui::DbgLine::plain(""));
+                // "How did I get here": the most recent retired PCs
+                // (oldest first; the console's HISTORY command shows the
+                // full ring with disassembly).
+                let history = machine.ui_pc_history();
+                if !history.is_empty() {
+                    let recent: Vec<String> = history
+                        .iter()
+                        .rev()
+                        .take(8)
+                        .rev()
+                        .map(|pc| format!("{pc:06X}"))
+                        .collect();
+                    lines.push(ui::DbgLine::plain(format!("recent {}", recent.join(" "))));
+                    lines.push(ui::DbgLine::plain(""));
+                }
                 if let Some(origin) = panel.disasm_addr {
                     lines.push(ui::DbgLine::plain(format!(
                         "Disassembly pinned at ${origin:06X} (empty box + Enter follows PC)"

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5357,9 +5357,13 @@ impl App {
                 }
                 for watch in &breaks.watches {
                     lines.push(ui::DbgLine::plain(format!(
-                        "  ${:06X}  now {:04X}",
+                        "  ${:06X}  now {:04X}{}",
                         watch.addr,
-                        bus.peek_word_any(watch.addr)
+                        bus.peek_word_any(watch.addr),
+                        watch
+                            .filter
+                            .map(|f| format!("  [{} only]", f.label()))
+                            .unwrap_or_default()
                     )));
                 }
                 lines.push(ui::DbgLine::plain(""));

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -308,7 +308,33 @@ impl App {
                 self.console_reverse_op(|app| app.emu.tt_reverse_step(count))
             }
             "RFRAME" => self.console_reverse_op(|app| app.emu.tt_reverse_frame()),
-            "RRUN" | "RC" => self.console_reverse_op(|app| app.emu.tt_reverse_continue()),
+            "RRUN" | "RC" => {
+                use crate::timetravel::ReverseOutcome;
+                self.paused = true;
+                self.paused_before_console = true;
+                self.sync_live_audio_suspension();
+                self.last_debug_stop = None;
+                let mut lines = Vec::new();
+                match self.emu.tt_reverse_continue() {
+                    Ok(ReverseOutcome::Found((_, reason))) => {
+                        self.last_debug_stop = Some(reason.clone());
+                        lines.push(format!("!{reason}"));
+                    }
+                    Ok(ReverseOutcome::NotFound) => {
+                        lines.push("reverse: no earlier stop hit".to_string())
+                    }
+                    Ok(ReverseOutcome::BeyondHistory) => {
+                        lines.push("reverse: beyond recorded history".to_string())
+                    }
+                    Err(e) => {
+                        error!("console reverse run halted: {e:?}");
+                        return ConsoleOutcome::error(format!("reverse failed: {e}"));
+                    }
+                }
+                lines.extend(self.console_status_lines());
+                self.finish_render_for_current_frame();
+                ConsoleOutcome::lines(lines)
+            }
             "BREAK" | "B" => {
                 let spec = args.join(" ");
                 let Some((addr, cond, ignore)) = ui::parse_break_spec(&spec) else {

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -108,9 +108,10 @@ const CONSOLE_HELP: &[&str] = &[
     "            runto ADDR   toslot V [H]   rstep [N]  rframe  rrun",
     "stops:      break/b ADDR [COND] [IGN N]   watch/w ADDR   rwatch REG",
     "            btrap V [H]   cbreak ADDR   catch irq N|trap N|vec N",
-    "            breaks (list)   clearbreaks",
+    "            catchtask [NAME]   breaks (list)   clearbreaks",
     "inspect:    status  regs/r  mem/m ADDR [BYTES]  dis/d [ADDR] [N]",
     "            copper [pc|ADDR] [N]   custom   find HEX [START]   writer ADDR",
+    "os:         tasks  libs  devs  resources  ports",
     "modify:     poke ADDR VAL   setreg REG VAL",
     "console:    help  clear  close",
     "Addresses and values are hex; beam positions (V, H) are decimal.",
@@ -377,6 +378,28 @@ impl App {
                     "catch {} {}",
                     crate::debugger::exception_vector_name(vector),
                     if set { "set" } else { "removed" }
+                ))
+            }
+            "TASKS" => ConsoleOutcome::lines(self.console_os_tasks()),
+            "LIBS" | "LIBRARIES" => {
+                ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Libraries))
+            }
+            "DEVS" | "DEVICES" => {
+                ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Devices))
+            }
+            "RESOURCES" => {
+                ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Resources))
+            }
+            "PORTS" => ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Ports)),
+            "CATCHTASK" => {
+                if args.is_empty() {
+                    self.emu.machine.ui_set_task_catch(None);
+                    return ConsoleOutcome::one("task catch cleared");
+                }
+                let target = args.join(" ");
+                self.emu.machine.ui_set_task_catch(Some(target.clone()));
+                ConsoleOutcome::one(format!(
+                    "stopping when a task whose name contains \"{target}\" is scheduled"
                 ))
             }
             "BREAKS" | "INFO" => ConsoleOutcome::lines(self.console_breaks_lines()),
@@ -698,6 +721,93 @@ impl App {
         lines
     }
 
+    /// Run `walk` against a validated ExecBase using peeks over the bus,
+    /// or report why the OS structures are not walkable.
+    fn console_with_exec(
+        &self,
+        walk: impl FnOnce(&crate::amigaos::OsMemory, u32) -> Vec<String>,
+    ) -> Vec<String> {
+        let bus = self.emu.bus();
+        let peek8 = |addr: u32| {
+            let word = bus.peek_word_any(addr & !1);
+            if addr & 1 == 0 {
+                (word >> 8) as u8
+            } else {
+                word as u8
+            }
+        };
+        let peek32 = |addr: u32| {
+            (u32::from(bus.peek_word_any(addr)) << 16)
+                | u32::from(bus.peek_word_any(addr.wrapping_add(2)))
+        };
+        let os = crate::amigaos::OsMemory {
+            peek8: &peek8,
+            peek32: &peek32,
+        };
+        match os.exec_base() {
+            Ok(base) => walk(&os, base),
+            Err(reason) => vec![format!("!{reason}")],
+        }
+    }
+
+    /// TASKS: the scheduled task plus the ready and waiting lists.
+    fn console_os_tasks(&self) -> Vec<String> {
+        self.console_with_exec(|os, base| {
+            let mut lines = Vec::new();
+            match os.this_task(base) {
+                Some(task) => lines.push(format!(
+                    "> ${:06X}  pri {:>4}  {:<7} {}",
+                    task.addr, task.pri, "run", task.name
+                )),
+                None => lines.push("!ThisTask is not plausible".to_string()),
+            }
+            for (list, label) in [
+                (crate::amigaos::OsList::TaskReady, "ready"),
+                (crate::amigaos::OsList::TaskWait, "wait"),
+            ] {
+                for node in os.walk(base, list) {
+                    let state = crate::amigaos::task_state_name(node.state);
+                    let state = if state == "?" { label } else { state };
+                    lines.push(format!(
+                        "  ${:06X}  pri {:>4}  {:<7} {}",
+                        node.addr, node.pri, state, node.name
+                    ));
+                }
+            }
+            if lines.len() == 1 {
+                lines.push("  (no other tasks)".to_string());
+            }
+            lines
+        })
+    }
+
+    /// LIBS/DEVS/RESOURCES/PORTS: one line per node.
+    fn console_os_list(&self, list: crate::amigaos::OsList) -> Vec<String> {
+        let library_shaped = matches!(
+            list,
+            crate::amigaos::OsList::Libraries | crate::amigaos::OsList::Devices
+        );
+        self.console_with_exec(|os, base| {
+            let nodes = os.walk(base, list);
+            if nodes.is_empty() {
+                return vec!["(empty list)".to_string()];
+            }
+            nodes
+                .iter()
+                .map(|node| {
+                    if library_shaped {
+                        format!(
+                            "${:06X}  v{}.{:<4} {}",
+                            node.addr, node.version, node.revision, node.name
+                        )
+                    } else {
+                        format!("${:06X}  pri {:>4}  {}", node.addr, node.pri, node.name)
+                    }
+                })
+                .collect()
+        })
+    }
+
     fn console_breaks_lines(&self) -> Vec<String> {
         let breaks = self.emu.machine.ui_breaks();
         let bus = self.emu.bus();
@@ -734,6 +844,10 @@ impl App {
                 "catch  {} (vector {vector})",
                 crate::debugger::exception_vector_name(*vector)
             ));
+            any = true;
+        }
+        if let Some(target) = &breaks.task_catch {
+            lines.push(format!("ctask  name contains \"{target}\""));
             any = true;
         }
         for trap in bus.ui_beam_traps() {

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -106,7 +106,8 @@ fn parse_hex_pattern(tokens: &[&str]) -> Option<Vec<u8>> {
 const CONSOLE_HELP: &[&str] = &[
     "execution:  run  pause  step/s [N]  over  out  frame/f  line  cstep",
     "            runto ADDR   toslot V [H]   rstep [N]  rframe  rrun",
-    "stops:      break/b ADDR [COND] [IGN N]   watch/w ADDR   rwatch REG",
+    "stops:      break/b ADDR [COND] [IGN N]   watch/w ADDR [CPU|BLITTER|DISK]",
+    "            rwatch REG",
     "            btrap V [H]   cbreak ADDR   catch irq N|trap N|vec N",
     "            catchtask [NAME]   breaks (list)   clearbreaks",
     "inspect:    status  regs/r  mem/m ADDR [BYTES]  dis/d [ADDR] [N]",
@@ -349,12 +350,24 @@ impl App {
             }
             "WATCH" | "W" => {
                 let Some(addr) = args.first().and_then(|t| hex32(t)) else {
-                    return ConsoleOutcome::error("usage: WATCH ADDR (hex, word)");
+                    return ConsoleOutcome::error("usage: WATCH ADDR [CPU|BLITTER|DISK]");
                 };
-                let set = self.emu.machine.ui_toggle_watch(addr);
+                let filter = match args.get(1) {
+                    Some(token) => match crate::debugger::WatchSource::parse(token) {
+                        Some(source) => Some(source),
+                        None => {
+                            return ConsoleOutcome::error("watch filter is CPU, BLITTER, or DISK")
+                        }
+                    },
+                    None => None,
+                };
+                let set = self.emu.machine.ui_toggle_watch_filtered(addr, filter);
                 ConsoleOutcome::one(format!(
-                    "watchpoint ${:06X} {}",
+                    "watchpoint ${:06X}{} {}",
                     addr & 0x00FF_FFFE,
+                    filter
+                        .map(|f| format!(" ({} writes only)", f.label()))
+                        .unwrap_or_default(),
                     if set { "set" } else { "removed" }
                 ))
             }
@@ -950,9 +963,13 @@ impl App {
         }
         for watch in &breaks.watches {
             lines.push(format!(
-                "watch  ${:06X}  now {:04X}",
+                "watch  ${:06X}  now {:04X}{}",
                 watch.addr,
-                bus.peek_word_any(watch.addr)
+                bus.peek_word_any(watch.addr),
+                watch
+                    .filter
+                    .map(|f| format!("  [{} only]", f.label()))
+                    .unwrap_or_default()
             ));
             any = true;
         }

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -111,6 +111,7 @@ const CONSOLE_HELP: &[&str] = &[
     "            catchtask [NAME]   breaks (list)   clearbreaks",
     "inspect:    status  regs/r  mem/m ADDR [BYTES]  dis/d [ADDR] [N]",
     "            copper [pc|ADDR] [N]   custom   find HEX [START]   writer ADDR",
+    "            history/h [N]   stack/bt",
     "os:         tasks  libs  devs  resources  ports",
     "modify:     poke ADDR VAL   setreg REG VAL",
     "console:    help  clear  close",
@@ -409,6 +410,35 @@ impl App {
                 ConsoleOutcome::one("cleared all breakpoints, watchpoints, traps, and catches")
             }
             "REGS" | "R" => ConsoleOutcome::lines(self.console_regs_lines()),
+            "HISTORY" | "H" => {
+                let count = args
+                    .first()
+                    .and_then(|t| t.parse::<usize>().ok())
+                    .unwrap_or(16)
+                    .clamp(1, crate::cpu::UI_PC_HISTORY_CAP);
+                let history = self.emu.machine.ui_pc_history();
+                if history.is_empty() {
+                    return ConsoleOutcome::one(
+                        "no history yet (recorded while a debug window is open)",
+                    );
+                }
+                let cpu_type = self.emu.machine.cpu_type();
+                let bus = self.emu.bus();
+                ConsoleOutcome::lines(
+                    history
+                        .iter()
+                        .rev()
+                        .take(count)
+                        .rev()
+                        .map(|&pc| {
+                            let (text, _) =
+                                crate::disasm::disassemble(|a| bus.peek_word_any(a), pc, cpu_type);
+                            format!("{pc:06X}  {text}")
+                        })
+                        .collect(),
+                )
+            }
+            "STACK" | "BT" => ConsoleOutcome::lines(self.console_stack_lines()),
             "MEM" | "M" => {
                 let Some(addr) = args.first().and_then(|t| hex32(t)) else {
                     return ConsoleOutcome::error("usage: MEM ADDR [BYTES] (hex)");
@@ -806,6 +836,74 @@ impl App {
                 })
                 .collect()
         })
+    }
+
+    /// Heuristic 68k call-stack walk: scan up the stack for longwords
+    /// that look like return addresses (even, in the 24-bit space, and
+    /// immediately preceded by a JSR or BSR encoding). Heuristic by
+    /// nature -- data words that happen to follow call opcodes can slip
+    /// in -- but each frame shows its stack slot so it can be judged.
+    fn console_stack_lines(&self) -> Vec<String> {
+        const SLOTS: u32 = 64;
+        const FRAMES: usize = 8;
+        let machine = &self.emu.machine;
+        let bus = self.emu.bus();
+        let peek16 = |addr: u32| bus.peek_word_any(addr);
+        let peek32 =
+            |addr: u32| (u32::from(peek16(addr)) << 16) | u32::from(peek16(addr.wrapping_add(2)));
+        let looks_like_return = |addr: u32| -> bool {
+            if addr == 0 || addr & 1 != 0 || addr >= 0x0100_0000 {
+                return false;
+            }
+            // JSR (An)/-(An)+modes and BSR.B end 2 bytes before the
+            // return address; JSR abs.w/d16/d8-index/PC-rel and BSR.W end
+            // 4 before; JSR abs.l and BSR.L (020+) end 6 before.
+            let w2 = peek16(addr.wrapping_sub(2));
+            if (0x4E90..=0x4E97).contains(&w2)
+                || (w2 & 0xFF00 == 0x6100 && w2 & 0x00FF != 0 && w2 & 0x00FF != 0xFF)
+            {
+                return true;
+            }
+            let w4 = peek16(addr.wrapping_sub(4));
+            if w4 == 0x6100
+                || w4 == 0x4EB8
+                || w4 == 0x4EBA
+                || w4 == 0x4EBB
+                || (0x4EA8..=0x4EB7).contains(&w4)
+            {
+                return true;
+            }
+            let w6 = peek16(addr.wrapping_sub(6));
+            w6 == 0x4EB9 || w6 == 0x61FF
+        };
+        let sp = machine.a(7);
+        let cpu_type = machine.cpu_type();
+        let mut lines = vec![format!(
+            "#0 pc ${:06X}  sp ${:06X}",
+            machine.pc() & 0x00FF_FFFF,
+            sp & 0x00FF_FFFF
+        )];
+        let mut frame = 1usize;
+        for slot in 0..SLOTS {
+            if frame > FRAMES {
+                break;
+            }
+            let slot_addr = sp.wrapping_add(slot * 4);
+            let value = peek32(slot_addr) & 0x00FF_FFFF;
+            if !looks_like_return(value) {
+                continue;
+            }
+            let (text, _) = crate::disasm::disassemble(|a| bus.peek_word_any(a), value, cpu_type);
+            lines.push(format!(
+                "#{frame} ret ${value:06X}  (at sp+{:03X})  {text}",
+                slot * 4
+            ));
+            frame += 1;
+        }
+        if lines.len() == 1 {
+            lines.push("no return-address candidates on the stack".to_string());
+        }
+        lines
     }
 
     fn console_breaks_lines(&self) -> Vec<String> {

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -111,7 +111,8 @@ const CONSOLE_HELP: &[&str] = &[
     "            btrap V [H]   cbreak ADDR   catch irq N|trap N|vec N",
     "            catchtask [NAME]   breaks (list)   clearbreaks",
     "inspect:    status  regs/r  mem/m ADDR [BYTES]  dis/d [ADDR] [N]",
-    "            copper [pc|ADDR] [N]   custom   find HEX [START]   writer ADDR",
+    "            copper [pc|ADDR] [N]   custom   blits   find HEX [START]",
+    "            writer ADDR",
     "            history/h [N]   stack/bt",
     "os:         tasks  libs  devs  resources  ports",
     "modify:     poke ADDR VAL   setreg REG VAL",
@@ -556,6 +557,51 @@ impl App {
                 {
                     let cursor = if addr == copper_pc { ">" } else { " " };
                     lines.push(format!("{cursor}{addr:06X}  {text}"));
+                }
+                ConsoleOutcome::lines(lines)
+            }
+            "BLITS" => {
+                let Some(trace) = self.emu.bus().frame_bus_trace() else {
+                    return ConsoleOutcome::one(
+                        "no frame trace: open the Frame Analyzer (its Frame button captures one)",
+                    );
+                };
+                if trace.blits.is_empty() {
+                    return ConsoleOutcome::one(format!(
+                        "no blits started in frame {}",
+                        trace.frame
+                    ));
+                }
+                let mut lines = vec![format!(
+                    "{} blit(s) in frame {}:",
+                    trace.blits.len(),
+                    trace.frame
+                )];
+                for (i, blit) in trace.blits.iter().enumerate() {
+                    let end = match blit.end {
+                        Some((v, h)) => format!("v{v} h{h}"),
+                        None => "(running)".to_string(),
+                    };
+                    let c1 = blit.bltcon1;
+                    lines.push(format!(
+                        "#{i:<2} v{} h{} -> {end}  con0 {:04X} con1 {:04X}  {}x{}{}{}{}",
+                        blit.start.0,
+                        blit.start.1,
+                        blit.bltcon0,
+                        c1,
+                        blit.width_words,
+                        blit.height,
+                        if c1 & 0x0001 != 0 { "  LINE" } else { "" },
+                        if c1 & 0x0008 != 0 { "  FILL" } else { "" },
+                        if c1 & 0x0002 != 0 { "  DESC" } else { "" },
+                    ));
+                    lines.push(format!(
+                        "     A ${:06X}  B ${:06X}  C ${:06X}  D ${:06X}",
+                        blit.apt & 0x00FF_FFFF,
+                        blit.bpt & 0x00FF_FFFF,
+                        blit.cpt & 0x00FF_FFFF,
+                        blit.dpt & 0x00FF_FFFF,
+                    ));
                 }
                 ConsoleOutcome::lines(lines)
             }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2525,6 +2525,89 @@ fn console_text_insertion_and_multiline_paste() {
     assert_eq!(app.console_panel.as_ref().unwrap().input, "m 0");
 }
 
+/// Lay a minimal exec world into chip RAM: ExecBase with a valid
+/// ChkBase, a scheduled task, one ready task, and one library.
+fn plant_exec_world(app: &mut super::App) {
+    let bus = app.emu.bus_mut();
+    bus.mem.overlay = false;
+    let put32 = |ram: &mut [u8], addr: usize, v: u32| {
+        ram[addr..addr + 4].copy_from_slice(&v.to_be_bytes());
+    };
+    let put_str = |ram: &mut [u8], addr: usize, s: &str| {
+        ram[addr..addr + s.len()].copy_from_slice(s.as_bytes());
+        ram[addr + s.len()] = 0;
+    };
+    let ram = &mut bus.mem.chip_ram;
+    let base = 0x1000usize;
+    put32(ram, 4, base as u32);
+    put32(ram, base + 0x26, !(base as u32)); // ChkBase complement
+                                             // ThisTask -> task at $2000 named "boot.task", state run.
+    put32(ram, base + 0x114, 0x2000);
+    put32(ram, 0x2000 + 10, 0x3000);
+    put_str(ram, 0x3000, "boot.task");
+    ram[0x2000 + 9] = 10; // pri
+    ram[0x2000 + 15] = 2; // run
+                          // TaskReady: one task named "helper" (list head at base+0x196).
+    put32(ram, base + 0x196, 0x2100);
+    put32(ram, 0x2100, (base + 0x196 + 4) as u32); // succ -> lh_Tail
+    put32(ram, base + 0x196 + 4, 0);
+    put32(ram, 0x2100 + 10, 0x3100);
+    put_str(ram, 0x3100, "helper");
+    ram[0x2100 + 15] = 3; // ready
+                          // LibList: one library "exec.library" v40.10.
+    put32(ram, base + 0x17A, 0x2200);
+    put32(ram, 0x2200, (base + 0x17A + 4) as u32);
+    put32(ram, base + 0x17A + 4, 0);
+    put32(ram, 0x2200 + 10, 0x3200);
+    put_str(ram, 0x3200, "exec.library");
+    put32(ram, 0x2200 + 20, 0x0028_000A); // v40 r10
+}
+
+#[test]
+fn console_os_introspection_and_task_catch() {
+    let mut app = test_app();
+    app.open_console();
+    plant_exec_world(&mut app);
+
+    let out = console_run(&mut app, "TASKS");
+    assert!(
+        out.iter()
+            .any(|l| l.starts_with('>') && l.contains("boot.task")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("ready") && l.contains("helper")),
+        "{out:?}"
+    );
+    let out = console_run(&mut app, "LIBS");
+    assert!(
+        out.iter()
+            .any(|l| l.contains("v40.10") && l.contains("exec.library")),
+        "{out:?}"
+    );
+    // An empty exec list reads as empty, not garbage.
+    let out = console_run(&mut app, "PORTS");
+    assert!(out.iter().any(|l| l.contains("empty")), "{out:?}");
+
+    // Arm the task catch, then reschedule to a matching task: the stop
+    // fires with the task's name on the next executed instruction.
+    console_run(&mut app, "CATCHTASK HELPER");
+    {
+        let bus = app.emu.bus_mut();
+        let addr = 0x1000 + 0x114;
+        bus.mem.chip_ram[addr..addr + 4].copy_from_slice(&0x2100u32.to_be_bytes());
+    }
+    let out = console_run(&mut app, "S 1");
+    assert!(
+        out.iter().any(|l| l.contains("Task scheduled: helper")),
+        "{out:?}"
+    );
+    // Clearing disarms it.
+    console_run(&mut app, "CATCHTASK");
+    assert!(app.emu.machine.ui_breaks().task_catch.is_none());
+}
+
 #[test]
 fn console_inspection_and_stop_commands() {
     let mut app = test_app();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2609,6 +2609,61 @@ fn console_os_introspection_and_task_catch() {
 }
 
 #[test]
+fn console_blits_lists_frame_blit_records() {
+    let mut app = test_app();
+    app.open_console();
+    app.open_frame_analyzer(); // arms the frame trace
+
+    // Run a 2x2 D-only blit with blitter DMA enabled, then finish the
+    // frame so the trace (with its blit record) becomes current.
+    {
+        let bus = app.emu.bus_mut();
+        bus.mem.overlay = false;
+        bus.custom_write(0x096, 2, 0x8240); // DMACON SET DMAEN|BLTEN
+        bus.custom_write(0x040, 2, 0x01F0); // BLTCON0: USED, LF=$F0
+        bus.custom_write(0x042, 2, 0x0000);
+        bus.custom_write(0x044, 2, 0xFFFF);
+        bus.custom_write(0x046, 2, 0xFFFF);
+        bus.custom_write(0x074, 2, 0xBEEF); // BLTADAT
+        bus.custom_write(0x066, 2, 0x0000); // BLTDMOD
+        bus.custom_write(0x054, 4, 0x0006_0000); // BLTDPT
+        bus.custom_write(0x058, 2, 0x0082); // BLTSIZE: 2 rows x 2 words
+    }
+    app.frame_analyzer_step_frame();
+
+    let out = console_run(&mut app, "BLITS");
+    assert!(out[0].contains("blit(s) in frame"), "{out:?}");
+    assert!(
+        out.iter()
+            .any(|l| l.contains("2x2") && l.contains("con0 01F0")),
+        "{out:?}"
+    );
+    assert!(out.iter().any(|l| l.contains("D $060000")), "{out:?}");
+    // The record completed within the frame.
+    assert!(
+        out.iter()
+            .any(|l| l.contains("->") && !l.contains("running")),
+        "{out:?}"
+    );
+
+    // Selecting a slot inside the blit's beam span annotates it.
+    let trace_blit = app
+        .emu
+        .bus()
+        .frame_bus_trace()
+        .and_then(|t| t.blits.first().cloned())
+        .expect("a recorded blit");
+    if let Some(panel) = app.frame_analyzer_panel.as_mut() {
+        panel.selected_vpos = trace_blit.start.0;
+        panel.selected_hpos = trace_blit.start.1;
+    }
+    let panel = app.frame_analyzer_panel.clone().unwrap();
+    let view = app.build_frame_analyzer_view(&panel);
+    let annotated = view.trace.unwrap().selected_blit.expect("blit annotation");
+    assert!(annotated.contains("in blit #0"), "{annotated}");
+}
+
+#[test]
 fn console_history_and_stack_walk() {
     let mut app = test_app();
     app.open_console();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2111,6 +2111,18 @@ fn debugger_views_reflect_machine_state() {
                 assert_eq!(video.plane_mask, 0xFF);
                 assert_eq!(video.sprite_mask, 0xFF);
             }
+            super::ui::DebugTab::IoMap => {
+                // The register grid names DMACON with a live value and
+                // the selection pane decodes it.
+                assert!(
+                    view.lines.iter().any(|l| l.text.contains("DMACON")),
+                    "IO map missing DMACON"
+                );
+                assert!(view
+                    .lines
+                    .iter()
+                    .any(|l| l.highlight && l.text.starts_with("$096")));
+            }
             super::ui::DebugTab::Break => {
                 assert!(view.lines.iter().any(|l| l.text == "Breakpoints:"));
                 assert!(view.lines.iter().any(|l| l.text == "  (none)"));
@@ -2606,6 +2618,35 @@ fn console_os_introspection_and_task_catch() {
     // Clearing disarms it.
     console_run(&mut app, "CATCHTASK");
     assert!(app.emu.machine.ui_breaks().task_catch.is_none());
+}
+
+#[test]
+fn iomap_tab_navigation_and_jump() {
+    let mut app = test_app();
+    app.open_debugger();
+    if let Some(panel) = app.debugger_panel.as_mut() {
+        panel.tab = super::ui::DebugTab::IoMap;
+    }
+    assert_eq!(app.debugger_panel.as_ref().unwrap().iomap_sel, 0x096);
+    app.debugger_iomap_move(1);
+    assert_eq!(app.debugger_panel.as_ref().unwrap().iomap_sel, 0x098);
+    app.debugger_iomap_move(-300); // clamps at the bank start
+    assert_eq!(app.debugger_panel.as_ref().unwrap().iomap_sel, 0x000);
+
+    // The $ box jumps by offset or full address.
+    if let Some(panel) = app.debugger_panel.as_mut() {
+        panel.entry = "DFF180".to_string();
+        panel.entry_active = true;
+    }
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::Enter));
+    assert_eq!(app.debugger_panel.as_ref().unwrap().iomap_sel, 0x180);
+
+    let panel = app.debugger_panel.clone().unwrap();
+    let view = app.build_debugger_view(&panel);
+    assert!(view
+        .lines
+        .iter()
+        .any(|l| l.highlight && l.text.starts_with("$180 COLOR00")));
 }
 
 #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2609,6 +2609,43 @@ fn console_os_introspection_and_task_catch() {
 }
 
 #[test]
+fn console_history_and_stack_walk() {
+    let mut app = test_app();
+    app.open_console();
+
+    // Stepping with a debug window open records the retired PCs.
+    let pc0 = app.emu.machine.pc();
+    console_run(&mut app, "S 3");
+    let out = console_run(&mut app, "HISTORY 4");
+    assert!(
+        out.iter()
+            .any(|l| l.contains(&format!("{pc0:06X}")) && l.contains("NOP")),
+        "{out:?}"
+    );
+    // The CPU tab mirrors a compact trail.
+    app.open_debugger();
+    let panel = app.debugger_panel.clone().unwrap();
+    let view = app.build_debugger_view(&panel);
+    assert!(
+        view.lines.iter().any(|l| l.text.starts_with("recent ")),
+        "recent-PC line missing"
+    );
+
+    // Stack walk: plant a BSR.S and a stack slot holding its return
+    // address, then point A7 at it.
+    {
+        let bus = app.emu.bus_mut();
+        bus.mem.overlay = false;
+        bus.mem.chip_ram[0x8000..0x8002].copy_from_slice(&0x6104u16.to_be_bytes());
+        bus.mem.chip_ram[0x9000..0x9004].copy_from_slice(&0x0000_8002u32.to_be_bytes());
+    }
+    console_run(&mut app, "SETREG A7 9000");
+    let out = console_run(&mut app, "STACK");
+    assert!(out[0].starts_with("#0 pc $"), "{out:?}");
+    assert!(out.iter().any(|l| l.contains("#1 ret $008002")), "{out:?}");
+}
+
+#[test]
 fn console_inspection_and_stop_commands() {
     let mut app = test_app();
     app.open_console();


### PR DESCRIPTION
Six debugger features, one commit each (single PR so there is only one merge to do from the train).

1. **AmigaOS introspection** (`src/amigaos.rs`): console `TASKS` / `LIBS` / `DEVS` / `RESOURCES` / `PORTS` walk exec's lists via side-effect-free peeks (stable public ABI offsets, ChkBase-validated so a not-yet-booted OS reports cleanly). `CATCHTASK NAME` stops the machine when exec schedules a matching task -- the WinUAE `fp` equivalent.
2. **Recent-PC history + call stack**: a 64-entry retired-PC ring (recorded only while a debug window is open), console `HISTORY [N]` disassembled, a compact `recent` trail on the CPU tab, and `STACK`/`BT` -- a heuristic 68k stack walk that only reports longwords preceded by a JSR/BSR encoding, each frame showing its stack slot for judgement.
3. **Reverse-run to any stop**: `< Run`/`RRUN`'s replay scan now honours watchpoints (re-baselined per snapshot), register watches, beam traps, Copper breakpoints, catches, and the task catch -- landing at the most recent hit with the forward-run's stop message. Also fixes a latent bug: state restores replaced the Bus wholesale, silently disarming beam traps / Copper breakpoints / layer masks on every reverse step; debug state now survives timeline jumps, with watch baselines and the task pointer re-baselined so jumps cannot fire phantom hits.
4. **Watchpoint writer attribution + filters**: watch stops name the true writer. Write sites flag hits themselves -- CPU chip/slow-RAM paths, the blitter's D/fill/line writes (burst-precise, in both scheduled states and the immediate path), disk read DMA -- and DMA stops report source + beam position. `WATCH ADDR CPU|BLITTER|DISK` filters a watch to one writer; filtered-out changes just move the baseline. Hot paths pay one `is_empty` check per written word only while watches are armed.
5. **Per-frame blit records**: while the Frame Analyzer is armed, every blit start records control words, effective size (BLTSIZE and ECS forms, zero-field maxima decoded), channel pointers, and beam start/end. Console `BLITS` lists them; selecting a heatmap slot inside a blit's span names it on the selected-slot line.
6. **IO Map tab** (eighth debugger tab): the whole $DFF000-$DFF1FE bank with names and live values (write-only registers show their latches), wheel/arrow/page navigation, `$` box jump, and a bit-decode pane for DMACON, INTENA/INTREQ, ADKCON, BPLCON0-2, CLXCON, BEAMCON0, FMODE, and DIW positions.

Verification: 1251 unit tests (14 new across exec walking, task catch, history/stack, reverse-to-watch landing, blitter attribution + filters, blit records, IO map decode/navigation), clippy and fmt clean, and release-binary boot screenshots byte-identical to main -- the blitter/floppy/bus instrumentation is provably inert while no debug feature is armed. All new state is transient (serde-skipped): no STATE_VERSION change. Docs updated per feature.