### PR TITLE
GDB stub: name A6 "fp" so real GDBs accept the target description

### DIFF
--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -41,6 +41,14 @@ Use `monitor write-reg` for deliberate custom-chip writes.
 
 ## Custom Chips
 
+The stub is exercised against real clients: `m68k-amigaos-gdb` (the
+bebbo amiga-gcc toolchain) connects, disassembles live ROM, steps,
+breaks, and reverse-steps as expected. A stock multi-arch host `gdb`
+also accepts the target description, but without an executable loaded
+it guesses endianness from the host -- issue `set endian big` before
+`target remote` (or just load your program's ELF with `file`, which the
+Amiga toolchains' gdb does implicitly).
+
 Use GDB's `monitor` command for Amiga-specific state:
 
 ```gdb

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -36,7 +36,7 @@ const TARGET_XML: &str = r#"<?xml version="1.0"?>
     <reg name="a3" bitsize="32" regnum="11"/>
     <reg name="a4" bitsize="32" regnum="12"/>
     <reg name="a5" bitsize="32" regnum="13"/>
-    <reg name="a6" bitsize="32" regnum="14"/>
+    <reg name="fp" bitsize="32" regnum="14"/>
     <reg name="sp" bitsize="32" regnum="15" type="data_ptr"/>
     <reg name="ps" bitsize="32" regnum="16"/>
     <reg name="pc" bitsize="32" regnum="17" type="code_ptr"/>


### PR DESCRIPTION
Verification follow-up from the debugger work: driving the stub with real GDB clients showed every stock GDB rejecting our target description ("Architecture rejected target-supplied description") and falling back to a host-endian register layout -- every value byte-swapped.

Root cause: GDB's standard `org.gnu.gdb.m68k.core` feature defines the register set as `d0-d7, a0-a5, fp, sp, ps, pc`; our XML named register 14 `a6`.

With the one-line rename, verified end to end against `m68k-amigaos-gdb` (bebbo toolchain): connect, correct big-endian registers and memory, live Kickstart ROM disassembly, `stepi`, breakpoint + `continue` (hits and reports), `reverse-stepi` (walks the snapshot ring backwards), and the `monitor` commands. Docs note the stock-host-gdb caveat (`set endian big` when no executable is loaded).

Also re-verified merged main while here: the asset-gated image-regression suite passes 5/6, the one failure being the documented pre-existing `ocs_bpu7_ham` host flake (fails on clean main too), and the docs build (`myst build --html`) is clean.