### PR TITLE
Debugger polish: crash surfacing, runtime trace, HUNT, segment discovery, workflows docs

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -98,7 +98,17 @@ garbage):
 | `DEVS` | Devices with versions |
 | `RESOURCES`, `PORTS` | The resource and message-port lists |
 | `CATCHTASK NAME` | Stop when exec schedules a task whose name contains NAME (case-insensitive); `CATCHTASK` alone clears it |
+| `CATCHALERT` | Break at exec's `Alert()` entry: fires on every guru/alert with D7 holding the code |
+| `GURU [CODE]` | Decode an alert code (default: the current D7): deadend flag, subsystem, cause, CPU-trap alerts |
 
 `CATCHTASK` is the tool for "wake me when my process actually runs": it
 baselines on the currently scheduled task and fires on the next
 reschedule to a matching one, reporting the task's name and address.
+
+`CATCHALERT` plus `GURU` is the crash workflow: arm the catch, and when
+the machine stops in `Alert()`, `GURU` translates D7 into words
+(`DEADEND exec.library, no memory`). A CPU **double fault** -- a bus or
+address error during exception processing, the condition even the OS
+cannot report -- is always surfaced: the machine pauses with a
+"CPU halted: double fault" message on screen, in the console, and on
+the Break tab.

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -85,6 +85,8 @@ Inspection and modification:
 | `STACK`, `BT` | Heuristic call-stack walk: stack longwords that look like return addresses after a JSR/BSR |
 | `POKE ADDR VAL` | Write a memory word |
 | `SETREG REG VAL` | Set a CPU register (`SETREG D0 1234`) |
+| `TRACE START [PATH]` | Start a runtime instruction trace: one disassembled line per retired instruction with its beam position, no env var or restart needed (capped at a million lines) |
+| `TRACE STOP` / `TRACE` | Stop the trace / report its progress |
 | `HELP`, `CLEAR`, `CLOSE` | Console housekeeping |
 
 AmigaOS introspection (read-only walks of exec's lists, safe at any

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -89,6 +89,21 @@ Inspection and modification:
 | `TRACE STOP` / `TRACE` | Stop the trace / report its progress |
 | `HELP`, `CLEAR`, `CLOSE` | Console housekeeping |
 
+Memory hunting (a trainer-style delta search over all writable RAM --
+chip, slow, and Zorro RAM boards):
+
+| Command | Effect |
+|---|---|
+| `HUNT START [B\|W]` | Snapshot RAM and begin a byte- or word-wide (default) hunt |
+| `HUNT EQ\|NE\|LT\|GT VALUE` | Keep candidates whose *current* value compares to VALUE (hex) |
+| `HUNT SAME` / `HUNT DIFF` | Keep candidates unchanged / changed since the last filter |
+| `HUNT LIST [N]` | Show surviving candidates with live values |
+| `HUNT OFF` | Forget the hunt |
+
+The classic workflow: `HUNT START`, `HUNT EQ 3` while you have three
+lives, lose one, `HUNT EQ 2` -- the survivor is your lives counter,
+ready for `WATCH` (who decrements it?) or `POKE`.
+
 AmigaOS introspection (read-only walks of exec's lists, safe at any
 time -- if the OS is not up yet the command says so instead of printing
 garbage):

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -114,6 +114,7 @@ garbage):
 | `LIBS` | Opened libraries with versions (`graphics.library v40.10`) |
 | `DEVS` | Devices with versions |
 | `RESOURCES`, `PORTS` | The resource and message-port lists |
+| `SEGMENTS` | The current process's loaded hunks (its CLI command's segment list when there is one), with the `add-symbol-file` line a source-level GDB session needs |
 | `CATCHTASK NAME` | Stop when exec schedules a task whose name contains NAME (case-insensitive); `CATCHTASK` alone clears it |
 | `CATCHALERT` | Break at exec's `Alert()` entry: fires on every guru/alert with D7 holding the code |
 | `GURU [CODE]` | Decode an alert code (default: the current D7): deadend flag, subsystem, cause, CPU-trap alerts |

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -129,6 +129,31 @@ For byte-identical replay, keep the usual determinism requirements from
 [](reverse): set `COPPERLINE_RTC_FIXED_SECS` when guest RTC reads matter, and
 avoid externally mutating hard-drive/CD images during a debug session.
 
+## Source-Level Debugging of Amiga Programs
+
+Copperline answers GDB's `qOffsets` query with the load addresses of the
+current process's segment list (the hunks `LoadSeg()` scattered through
+RAM): `TextSeg=` is the first hunk and `DataSeg=` the second, when
+present. With an amiga-gcc toolchain (bebbo's `m68k-amigaos-gdb`), that
+means source-level debugging of a program running inside the emulator
+mostly just works:
+
+1. Build with debug info: `m68k-amigaos-gcc -g -O0 prog.c -o prog`.
+2. Start Copperline with `--gdb`, boot Workbench, and start `prog`
+   (easiest from a CLI so the process has a `cli_Module` seglist).
+3. `m68k-amigaos-gdb prog` then `target remote localhost:2345`. GDB asks
+   `qOffsets`, relocates the program's sections to the hunk addresses,
+   and `break main` / `next` / `print` work on source lines.
+
+If the program was not yet running when GDB attached, re-run `qOffsets`
+by reattaching, or relocate manually: `monitor segments` prints every
+hunk address, and `add-symbol-file prog.elf ADDR` (first hunk) loads the
+symbols at the right place. The `SEGMENTS` console command prints the
+same map, pre-formatted with that hint. When no process seglist is
+walkable (ROM code, task rather than process, OS not up yet), the
+`qOffsets` reply is empty and GDB falls back to link-time addresses --
+harmless for ROM-level sessions.
+
 ## Monitor Commands
 
 | Command | Effect |
@@ -146,3 +171,4 @@ avoid externally mutating hard-drive/CD images during a debug session.
 | `clear-reg-watches` | remove all custom-register watches |
 | `copper [auto\|pc\|ADDR] [COUNT]` | disassemble Copper instructions |
 | `last-writer ADDR` | reverse-search the last write to a word |
+| `segments` | the current process's loaded hunks (LoadSeg addresses) |

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -167,3 +167,7 @@ together:
    colour clock of the suspect frame.
 5. Compare against real hardware with the `timing-test/` disk when the
    question is "is this operation too fast/slow".
+
+For interactive sessions, the same instruction trace is available at
+runtime without environment variables: the [console](console)'s
+`TRACE START [PATH]` / `TRACE STOP`.

--- a/docs/debugger/workflows.md
+++ b/docs/debugger/workflows.md
@@ -1,0 +1,145 @@
+# Debugging workflows
+
+The other chapters document each tool on its own; this one shows how
+they combine. Every walkthrough below is a real investigation shape --
+the same ones Copperline's own regressions were hunted with -- written
+against the standard tool set: the [debugger window](window), the
+[console](console), the frame analyzer, [reverse execution](reverse),
+[headless knobs](headless), and the [GDB stub](gdb).
+
+All of these start the same way: get the machine *near* the problem
+cheaply, then investigate precisely. Save states are the lever --
+snapshot once just before the scene (`--save-state-after SECS out.state`
+headlessly, or from the menu), then every later experiment starts from
+`--load-state` in seconds instead of re-emulating minutes.
+
+## A sprite vanishes
+
+The logo disappears mid-demo, or an in-game object flickers out.
+Sprites fail for a handful of reasons: sprite DMA got turned off, the
+sprite pointers were repointed somewhere wrong, the control words
+disarmed it, or the display window moved off it.
+
+1. Pause just before the vanish (reverse-step back if you overshot:
+   `RFRAME` in the console rewinds a whole frame).
+2. Debugger **Video** tab: the sprite viewer decodes all eight channels
+   -- SPRxPOS/CTL positions, DMA line counts, and a thumbnail of what
+   each channel fetched this frame. A sprite that is armed but empty
+   fetched nothing: suspect DMA. A sprite with data but a wrong
+   position: suspect the copper list that positions it.
+3. If DMA is the suspect: console `RWATCH DMACON` (or the Break tab's
+   register watch) and run. When it fires, the console names the writer
+   -- CPU instruction, Copper, or blitter -- with its address. A game
+   clearing `SPREN` deliberately looks exactly like this.
+4. If the pointers are the suspect: `RWATCH SPR0PTH` catches every
+   repoint, and the **Copper** tab shows the list that does it each
+   frame.
+5. Layer isolation confirms any theory instantly: the Video tab's
+   plane/sprite masks re-render the paused frame with channels removed,
+   so "is that object sprite 4 or a playfield trick?" is one click.
+
+## The picture is torn or the copper list is trashed
+
+A horizontal band of garbage, colours changing at the wrong line, or a
+display that falls apart after some event.
+
+1. Open the **Frame Analyzer** and enable the picture underlay (`U`):
+   the captured DMA heatmap draws over the actual frame, so a band of
+   garbage lines up visually with whatever DMA was (or was not)
+   happening there.
+2. Hover the analyzer at the first bad line: it decodes the custom
+   register writes near the beam position. A `COLORxx` write that
+   arrives a line late, or a missing `BPLxPTH` refresh, is visible
+   directly.
+3. Set a beam trap at the first bad line (`BTRAP 145` in the console,
+   or the analyzer's To-slot). The machine halts with the beam exactly
+   there; the **Copper** tab now shows what the Copper is executing at
+   that moment, live.
+4. `CSTEP` single-steps Copper instructions from there. A WAIT with a
+   wrong comparator, or a list that ran past its terminating WAIT into
+   garbage, shows up within a few steps. `CBREAK ADDR` breaks when the
+   Copper reaches a specific instruction on any frame.
+5. If the list itself is corrupt in memory: `WRITER ADDR` reverse-scans
+   execution to find the last instruction that wrote the corrupted
+   word. That answers "who trashed my copper list" in one command --
+   typically a blitter destination running long, which the attribution
+   names as such.
+
+## Something writes where it should not
+
+Memory corruption generally: a variable, a bitmap, or OS structure gets
+stomped.
+
+1. `WATCH ADDR` sets an attributed watchpoint. Any CPU, blitter, or
+   disk-DMA write there halts the machine and names the writer. Filter
+   to one source with `WATCH ADDR BLITTER` when the CPU legitimately
+   touches the address constantly.
+2. If the corruption already happened: `WRITER ADDR` uses the reverse
+   engine to find the most recent writer without re-running anything by
+   hand.
+3. For "when did this go bad" rather than "who": binary-search with
+   save states -- load, `MEM ADDR`, and the deterministic core
+   guarantees the same answer on every replay.
+
+## Crash triage: guru meditation
+
+The machine gurus, or worse, freezes silently.
+
+1. Arm `CATCHALERT`. When exec's `Alert()` runs, the machine halts with
+   D7 holding the alert code -- before the flashing box is drawn, with
+   the faulting context still warm.
+2. `GURU` decodes it: deadend flag, subsystem, cause -- and for CPU
+   traps the vector name (`address error`, `illegal instruction`).
+3. `STACK` and `HISTORY` show how it got there: the call-stack scan and
+   the disassembled ring of recently retired PCs. `RSTEP` walks
+   backwards from the alert into the faulting code with full state.
+4. A **double fault** (bus/address error during exception processing)
+   cannot guru -- the CPU halts. Copperline surfaces it on screen, in
+   the console, and on the Break tab automatically; `HISTORY` is the
+   main tool from there.
+5. For OS-level context: `TASKS` shows what was scheduled, `CATCHTASK
+   NAME` stops when a suspect process next gets the CPU, and `SEGMENTS`
+   maps a process's loaded hunks so addresses in `HISTORY` can be
+   attributed to a program rather than "somewhere in RAM".
+
+## Find the lives counter (memory hunting)
+
+The trainer-making workflow, also the fastest way to locate any game
+variable you can influence.
+
+1. `HUNT START` snapshots all writable RAM (chip, slow, and Zorro
+   boards). Word width is the default; `HUNT START B` hunts bytes.
+2. You have three lives: `HUNT EQ 3`. Thousands of candidates.
+3. Lose a life, pause, `HUNT EQ 2`. The intersection is usually a
+   handful of addresses; two or three rounds isolate one. `HUNT SAME` /
+   `HUNT DIFF` filter against the previous snapshot when you cannot
+   name the value ("it changed", "it did not change").
+4. `HUNT LIST` shows the survivors with live values.
+5. From there: `WATCH ADDR` answers "what code decrements this"
+   (the death routine), and `POKE ADDR 9` tests the theory.
+
+## Source-level debugging of your own program
+
+For programs you build yourself with an amiga-gcc toolchain, the GDB
+stub supports full source-level debugging -- breakpoints on lines,
+`next`, `print` on variables -- via automatic segment relocation. The
+walkthrough lives in the [GDB chapter](gdb), "Source-Level Debugging of
+Amiga Programs". The short version: build with `-g`, run inside the
+emulator from a CLI, and `m68k-amigaos-gdb prog` + `target remote`
+relocates itself using the emulator's `qOffsets` answer.
+
+## Making it reproducible
+
+Any of the above is dramatically easier when the failure replays
+identically every run:
+
+- **Record the session**: `--record-input session.clscript`
+  (`Cmd+Shift+R` live) captures input on emulated time; `--script
+  session.clscript` replays it byte-identically.
+- **Headless repro**: once scripted, `--screenshot-after` /
+  `--dump-frames` plus the `COPPERLINE_DBG_*` knobs ([headless
+  chapter](headless)) turn the bug into a shell command -- the form a
+  regression test wants.
+- **Trace the suspect window**: console `TRACE START PATH` writes every
+  retired PC with beam positions to a file; diff two traces (one good
+  run, one bad) to find the first divergence.

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -29,6 +29,7 @@ project:
         - file: debugger/headless.md
         - file: debugger/reverse.md
         - file: debugger/gdb.md
+        - file: debugger/workflows.md
     - title: Internals
       children:
         - file: internals/architecture.md
@@ -55,6 +56,7 @@ project:
         - debugger/headless.md
         - debugger/reverse.md
         - debugger/gdb.md
+        - debugger/workflows.md
         - internals/architecture.md
         - internals/timing.md
         - internals/chipset.md

--- a/src/amigaos.rs
+++ b/src/amigaos.rs
@@ -197,6 +197,109 @@ impl OsMemory<'_> {
     }
 }
 
+/// One hunk of a loaded DOS segment list.
+pub struct Segment {
+    /// First byte of the hunk's payload (code/data).
+    pub start: u32,
+    /// Payload bytes (the loader's 8-byte size/next header excluded).
+    pub size: u32,
+}
+
+/// Process field offsets (dos/dosextens.h). pr_SegList/pr_CLI are BPTRs.
+const PR_SEGLIST: u32 = 0x80;
+const PR_CLI: u32 = 0xAC;
+/// CommandLineInterface field offsets: cli_Module is the BPTR to the
+/// currently running command's segment list.
+const CLI_MODULE: u32 = 0x3C;
+/// NT_PROCESS in ln_Type.
+const NT_PROCESS: u8 = 13;
+
+impl OsMemory<'_> {
+    /// The segment list of the program running in `task` (a Process):
+    /// the CLI's loaded command when there is one, else the process's
+    /// own creation seglist (entry 3 of the pr_SegList array).
+    pub fn process_seglist(&self, task: u32) -> Option<u32> {
+        if (self.peek8)(task.wrapping_add(LN_TYPE)) != NT_PROCESS {
+            return None;
+        }
+        let cli = (self.peek32)(task.wrapping_add(PR_CLI));
+        if cli != 0 && cli < 0x0040_0000 {
+            let module = (self.peek32)((cli << 2).wrapping_add(CLI_MODULE));
+            if module != 0 {
+                return Some(module);
+            }
+        }
+        let array = (self.peek32)(task.wrapping_add(PR_SEGLIST));
+        if array == 0 || array >= 0x0040_0000 {
+            return None;
+        }
+        let count = (self.peek32)(array << 2);
+        if count < 3 {
+            return None;
+        }
+        let seg = (self.peek32)((array << 2).wrapping_add(3 * 4));
+        (seg != 0).then_some(seg)
+    }
+
+    /// Walk a BPTR segment list into (start, size) hunks. Each segment's
+    /// BPTR addresses a next-pointer longword, preceded by the loader's
+    /// size longword; the payload follows the next pointer.
+    pub fn walk_seglist(&self, mut bptr: u32) -> Vec<Segment> {
+        let mut out = Vec::new();
+        while bptr != 0 && bptr < 0x0040_0000 && out.len() < 64 {
+            let addr = bptr << 2;
+            if !(4..0x0100_0000).contains(&addr) {
+                break;
+            }
+            let size = (self.peek32)(addr.wrapping_sub(4));
+            let next = (self.peek32)(addr);
+            out.push(Segment {
+                start: addr.wrapping_add(4),
+                size: size.saturating_sub(8),
+            });
+            bptr = next;
+        }
+        out
+    }
+
+    /// The currently scheduled process's loaded segments, when it is a
+    /// process with a walkable seglist.
+    pub fn current_process_segments(&self, execbase: u32) -> Vec<Segment> {
+        let task = (self.peek32)(execbase.wrapping_add(THIS_TASK));
+        if !plausible_ptr(task) {
+            return Vec::new();
+        }
+        match self.process_seglist(task) {
+            Some(seglist) => self.walk_seglist(seglist),
+            None => Vec::new(),
+        }
+    }
+}
+
+/// Bus-backed convenience wrapper: the current process's segments, or
+/// why exec is not walkable. Shared by the console SEGMENTS command and
+/// the GDB stub (monitor segments / qOffsets).
+pub fn segments_on_bus(bus: &crate::bus::Bus) -> Result<Vec<Segment>, String> {
+    let peek8 = |addr: u32| {
+        let word = bus.peek_word_any(addr & !1);
+        if addr & 1 == 0 {
+            (word >> 8) as u8
+        } else {
+            word as u8
+        }
+    };
+    let peek32 = |addr: u32| {
+        (u32::from(bus.peek_word_any(addr)) << 16)
+            | u32::from(bus.peek_word_any(addr.wrapping_add(2)))
+    };
+    let os = OsMemory {
+        peek8: &peek8,
+        peek32: &peek32,
+    };
+    let base = os.exec_base()?;
+    Ok(os.current_process_segments(base))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,6 +416,33 @@ mod tests {
 
         // Untouched lists read as empty, not garbage.
         assert!(os.walk(base, OsList::Ports).is_empty());
+    }
+
+    #[test]
+    fn walks_a_cli_process_seglist() {
+        let mut mem = build_exec_world();
+        // Make ThisTask a process with a CLI whose module is a two-hunk
+        // seglist: BPTRs at $8000 and $9000 (headers 8 bytes before the
+        // payload).
+        let this = 0x0002_1000;
+        mem.put8(this + LN_TYPE, NT_PROCESS);
+        let cli_addr = 0x0003_0000u32;
+        mem.put32(this + PR_CLI, cli_addr >> 2);
+        mem.put32(cli_addr + CLI_MODULE, 0x8000 >> 2);
+        mem.put32(0x8000 - 4, 0x100); // hunk size incl header
+        mem.put32(0x8000, 0x9000 >> 2); // next
+        mem.put32(0x9000 - 4, 0x40);
+        mem.put32(0x9000, 0); // end of list
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let os = os(&peek8, &peek32);
+        let base = os.exec_base().unwrap();
+        let segs = os.current_process_segments(base);
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].start, 0x8004);
+        assert_eq!(segs[0].size, 0xF8);
+        assert_eq!(segs[1].start, 0x9004);
+        assert_eq!(segs[1].size, 0x38);
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4350,6 +4350,27 @@ impl Bus {
         Some(value)
     }
 
+    /// The writable RAM regions a memory hunt should scan: chip RAM,
+    /// slow/ranger RAM, and configured Zorro RAM boards, as
+    /// (base, length) pairs.
+    pub fn writable_ram_regions(&self) -> Vec<(u32, u32)> {
+        let mut regions = Vec::new();
+        if !self.mem.chip_ram.is_empty() {
+            regions.push((
+                crate::memory::CHIP_RAM_BASE as u32,
+                self.mem.chip_ram.len() as u32,
+            ));
+        }
+        if !self.mem.slow_ram.is_empty() {
+            regions.push((
+                crate::memory::SLOW_RAM_BASE as u32,
+                self.mem.slow_ram.len() as u32,
+            ));
+        }
+        regions.extend(self.mem.zorro.ram_regions());
+        regions
+    }
+
     /// Read a 16-bit big-endian word from whichever RAM/ROM region maps
     /// `addr` (chip, fast, slow, or ROM), for the debugger's memory dumps.
     /// Returns 0 for unmapped addresses.

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1132,6 +1132,22 @@ impl M68kMachine {
         }
     }
 
+    /// Whether the CPU halted on a double fault (a bus/address error
+    /// during exception processing) -- the hardware condition behind a
+    /// dead machine that software alerts cannot even report.
+    pub fn cpu_double_faulted(&self) -> bool {
+        self.cpu.is_halted()
+    }
+
+    /// Force the halted state (tests of the surfacing path only; on the
+    /// plain 68000 model the double fault is reachable via MMU-fault
+    /// recursion, which is heavy to stage in a unit test).
+    #[cfg(test)]
+    pub fn test_force_double_fault(&mut self) {
+        self.cpu.stopped = 1;
+        self.cpu.run_mode = 1; // RUN_MODE_BERR_AERR_RESET
+    }
+
     pub fn ui_breaks(&self) -> &crate::debugger::InteractiveBreaks {
         &self.ui_breaks
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -50,6 +50,15 @@ fn sync_cck_enabled_setting() -> bool {
 /// Entries kept in the debugger's recent-PC ring.
 pub const UI_PC_HISTORY_CAP: usize = 64;
 
+/// A runtime instruction trace started from the console: disassembled
+/// lines with beam positions, written through a buffered file.
+struct UiTrace {
+    writer: std::io::BufWriter<std::fs::File>,
+    path: std::path::PathBuf,
+    lines: u64,
+    cap: u64,
+}
+
 pub struct M68kMachine {
     cpu: CpuCore,
     bus: CpuBus,
@@ -90,6 +99,9 @@ pub struct M68kMachine {
     ui_pc_history_next: usize,
     ui_pc_history_len: usize,
     ui_pc_history_enabled: bool,
+    /// Console-started instruction trace (TRACE START/STOP), None when
+    /// off; per-instruction cost only while tracing.
+    ui_trace: Option<UiTrace>,
     // COPPERLINE_DBG_SPREN: previous DMACON, to detect the instruction that
     // clears the sprite-DMA-enable bit.
     dbg_prev_dmacon: u16,
@@ -253,6 +265,7 @@ impl M68kMachine {
             ui_pc_history_next: 0,
             ui_pc_history_len: 0,
             ui_pc_history_enabled: false,
+            ui_trace: None,
             dbg_prev_dmacon: 0,
             dbg_prev_fc: 0,
             dbg_fc_count: 0,
@@ -1132,6 +1145,61 @@ impl M68kMachine {
         }
     }
 
+    /// Start a runtime instruction trace to `path`, replacing any
+    /// running one. `cap` bounds the file (a final marker line notes a
+    /// cap-stop). Costs a disassembly and a buffered write per retired
+    /// instruction while active.
+    pub fn ui_trace_start(&mut self, path: std::path::PathBuf, cap: u64) -> std::io::Result<()> {
+        let file = std::fs::File::create(&path)?;
+        self.ui_trace = Some(UiTrace {
+            writer: std::io::BufWriter::new(file),
+            path,
+            lines: 0,
+            cap: cap.max(1),
+        });
+        Ok(())
+    }
+
+    /// Stop the runtime trace, flushing it. Returns (path, lines).
+    pub fn ui_trace_stop(&mut self) -> Option<(std::path::PathBuf, u64)> {
+        use std::io::Write;
+        let mut trace = self.ui_trace.take()?;
+        let _ = trace.writer.flush();
+        Some((trace.path, trace.lines))
+    }
+
+    /// The running trace's path and line count, if one is active.
+    pub fn ui_trace_status(&self) -> Option<(&std::path::Path, u64)> {
+        self.ui_trace
+            .as_ref()
+            .map(|trace| (trace.path.as_path(), trace.lines))
+    }
+
+    fn ui_trace_record(&mut self, pc: u32) {
+        use std::io::Write;
+        let (text, _) = crate::disasm::disassemble(
+            |addr| self.bus.bus.peek_word_any(addr),
+            pc,
+            self.cpu_type(),
+        );
+        let vpos = self.bus.bus.agnus.vpos;
+        let hpos = self.bus.bus.agnus.hpos;
+        let Some(trace) = self.ui_trace.as_mut() else {
+            return;
+        };
+        let _ = writeln!(trace.writer, "{pc:06X} [{vpos:3},{hpos:3}]  {text}");
+        trace.lines += 1;
+        if trace.lines >= trace.cap {
+            let _ = writeln!(
+                trace.writer,
+                "-- trace stopped at the {} line cap --",
+                trace.cap
+            );
+            let _ = trace.writer.flush();
+            self.ui_trace = None;
+        }
+    }
+
     /// Whether the CPU halted on a double fault (a bus/address error
     /// during exception processing) -- the hardware condition behind a
     /// dead machine that software alerts cannot even report.
@@ -1515,6 +1583,9 @@ impl M68kMachine {
                                 (self.ui_pc_history_next + 1) % UI_PC_HISTORY_CAP;
                             self.ui_pc_history_len =
                                 (self.ui_pc_history_len + 1).min(UI_PC_HISTORY_CAP);
+                        }
+                        if self.ui_trace.is_some() {
+                            self.ui_trace_record(dbg_pc_before);
                         }
                         self.debug_check_ipl(dbg_ipl_before, positive_cpu_cycles(cycles));
                         if self.ui_breaks.armed() {

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -351,6 +351,67 @@ pub fn custom_reg_bit_decode(off: u16, value: u16) -> Vec<String> {
     lines
 }
 
+/// Decode an AmigaOS alert ("guru meditation") code: the deadend flag,
+/// the owning subsystem, the general cause, and the CPU-trap alerts
+/// exec raises for processor exceptions.
+pub fn guru_decode(code: u32) -> String {
+    let deadend = code & 0x8000_0000 != 0;
+    // Alerts exec raises for CPU exceptions carry the vector number in
+    // the low word with no subsystem byte.
+    if code & 0x7FFF_0000 == 0 && (2..=0x2F).contains(&(code & 0xFFFF)) {
+        return format!(
+            "{}CPU exception: {}",
+            if deadend { "DEADEND " } else { "" },
+            exception_vector_name((code & 0xFFFF) as u16)
+        );
+    }
+    let subsystem = match (code >> 24) & 0x7F {
+        0x01 => "exec.library",
+        0x02 => "graphics.library",
+        0x03 => "layers.library",
+        0x04 => "intuition.library",
+        0x05 => "mathlibs",
+        0x07 => "dos.library",
+        0x08 => "ramlib",
+        0x09 => "icon.library",
+        0x0A => "expansion.library",
+        0x0B => "diskfont.library",
+        0x10 => "audio.device",
+        0x11 => "console.device",
+        0x12 => "gameport.device",
+        0x13 => "keyboard.device",
+        0x14 => "trackdisk.device",
+        0x15 => "timer.device",
+        0x20 => "cia.resource",
+        0x21 => "disk.resource",
+        0x22 => "misc.resource",
+        0x30 => "bootstrap",
+        0x31 => "workbench",
+        0x32 => "diskcopy",
+        0x33 => "gadtools",
+        _ => "unknown subsystem",
+    };
+    let general = match (code >> 16) & 0xFF {
+        0x01 => ", no memory",
+        0x02 => ", MakeLibrary failed",
+        0x03 => ", OpenLibrary failed",
+        0x04 => ", OpenDevice failed",
+        0x05 => ", OpenResource failed",
+        0x06 => ", I/O error",
+        0x07 => ", no signal",
+        0x08 => ", bad parameter",
+        0x09 => ", CloseLibrary failed",
+        0x0A => ", CloseDevice failed",
+        0x0B => ", process creation failed",
+        _ => "",
+    };
+    format!(
+        "{}{subsystem}{general} (specific ${:04X})",
+        if deadend { "DEADEND " } else { "recoverable " },
+        code & 0xFFFF
+    )
+}
+
 /// The hardware name of a custom-register word offset into $DFF000
 /// ($000-$1FE), e.g. 0x096 -> "DMACON". Banked registers (audio channels,
 /// bitplane/sprite pointers and data, colors) are derived; offsets without
@@ -1177,6 +1238,26 @@ mod tests {
         assert!(breaks.breakpoints.is_empty());
         assert!(breaks.watches.is_empty());
         assert!(breaks.reg_watches.is_empty());
+    }
+
+    #[test]
+    fn guru_decode_names_subsystems_causes_and_cpu_traps() {
+        assert_eq!(
+            guru_decode(0x8000_0003),
+            "DEADEND CPU exception: Address error"
+        );
+        assert_eq!(
+            guru_decode(0x0000_0004),
+            "CPU exception: Illegal instruction"
+        );
+        let text = guru_decode(0x8100_0005);
+        assert!(text.starts_with("DEADEND exec.library"), "{text}");
+        let text = guru_decode(0x0701_0002);
+        assert!(
+            text.contains("dos.library") && text.contains("no memory"),
+            "{text}"
+        );
+        assert!(text.starts_with("recoverable"), "{text}");
     }
 
     #[test]

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -177,6 +177,7 @@ impl Session {
             _ if packet.starts_with("qXfer:features:read:target.xml:") => {
                 self.read_target_xml(packet)?
             }
+            _ if packet.starts_with("qOffsets") => self.query_offsets(),
             _ if packet.starts_with("qRcmd,") => {
                 let command = String::from_utf8(hex_decode(&packet[6..])?)
                     .context("decoding monitor command")?;
@@ -548,6 +549,45 @@ impl Session {
         Ok(format!("{prefix}{chunk}"))
     }
 
+    /// qOffsets: relocate the debugged executable's sections to where
+    /// LoadSeg put them. TextSeg is the first hunk; a second hunk (the
+    /// usual data hunk of an amiga-gcc build) becomes DataSeg. Empty
+    /// reply (packet unsupported) when no process seglist is walkable,
+    /// so plain ROM-level sessions are unaffected.
+    fn query_offsets(&self) -> String {
+        match crate::amigaos::segments_on_bus(self.emu.bus()) {
+            Ok(segs) if !segs.is_empty() => {
+                let mut reply = format!("TextSeg={:X}", segs[0].start);
+                if let Some(data) = segs.get(1) {
+                    reply.push_str(&format!(";DataSeg={:X}", data.start));
+                }
+                reply
+            }
+            _ => String::new(),
+        }
+    }
+
+    fn monitor_segments(&self) -> String {
+        match crate::amigaos::segments_on_bus(self.emu.bus()) {
+            Err(reason) => format!("{reason}\n"),
+            Ok(segs) if segs.is_empty() => {
+                "current task has no walkable segment list\n".to_string()
+            }
+            Ok(segs) => {
+                let mut out = String::new();
+                for (i, seg) in segs.iter().enumerate() {
+                    out.push_str(&format!(
+                        "hunk {i}: {:06X}..{:06X}  ({} bytes)\n",
+                        seg.start,
+                        seg.start + seg.size,
+                        seg.size
+                    ));
+                }
+                out
+            }
+        }
+    }
+
     fn handle_monitor(&mut self, command: &str) -> Result<String> {
         let mut parts = command.split_whitespace();
         let Some(cmd) = parts.next() else {
@@ -565,6 +605,7 @@ impl Session {
                 self.emu.retired_instructions()
             )),
             "custom" => Ok(self.monitor_custom()),
+            "segments" => Ok(self.monitor_segments()),
             "stepover" => {
                 // Step over a BSR/JSR/TRAP call (single step otherwise),
                 // bounded so a call that never returns cannot hang the server.
@@ -808,7 +849,8 @@ fn monitor_help() -> String {
      beam-trap VPOS [HPOS] | clear-beam-traps\n\
      copper-break ADDR | clear-copper-breaks\n\
      copper [auto|pc|ADDR] [COUNT]\n\
-     last-writer ADDR\n"
+     last-writer ADDR\n\
+     segments\n"
         .to_string()
 }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -633,6 +633,9 @@ pub struct App {
     /// The reason for the last interactive breakpoint/watchpoint stop,
     /// shown on the debugger's Break tab until execution resumes.
     last_debug_stop: Option<String>,
+    /// A CPU double-fault halt has been reported (reset when the CPU
+    /// leaves the halted state, e.g. by reset or a state load).
+    reported_double_fault: bool,
     /// Active video+audio capture (shortcut or the menu's Record Video item),
     /// or None when not recording. Frames and the matching mixer audio are
     /// appended on emulated-frame boundaries, so captures stay in sync
@@ -915,6 +918,7 @@ impl App {
             paused_before_analyzer: false,
             paused_before_console: false,
             last_debug_stop: None,
+            reported_double_fault: false,
             recorder: None,
             record_fb: Vec::new(),
         }
@@ -4437,8 +4441,31 @@ impl App {
 
     /// Surface a pending breakpoint/watchpoint hit: pause the machine,
     /// bring up the debugger window, and report the reason. Returns true
-    /// when a stop was pending.
+    /// when a stop was pending. Also reports (once) a CPU double-fault
+    /// halt -- the guest is dead at that point, so it must not pass
+    /// silently.
     fn surface_debug_stop(&mut self) -> bool {
+        if self.emu.machine.cpu_double_faulted() {
+            if !self.reported_double_fault {
+                self.reported_double_fault = true;
+                let message = format!(
+                    "CPU halted: double fault at pc ${:06X} (bus/address error during exception)",
+                    self.emu.machine.pc() & 0x00FF_FFFF
+                );
+                warn!("{message}");
+                self.last_debug_stop = Some(message.clone());
+                if let Some(panel) = self.console_panel.as_mut() {
+                    panel.push_output(format!("!{message}"));
+                }
+                self.paused = true;
+                self.sync_live_audio_suspension();
+                self.show_osd(message);
+                self.request_redraw();
+                return true;
+            }
+        } else {
+            self.reported_double_fault = false;
+        }
         let Some(stop) = self.emu.machine.take_ui_debug_stop() else {
             return false;
         };

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -636,6 +636,8 @@ pub struct App {
     /// A CPU double-fault halt has been reported (reset when the CPU
     /// leaves the halted state, e.g. by reset or a state load).
     reported_double_fault: bool,
+    /// The console's running memory hunt (HUNT delta search), if any.
+    hunt: Option<console::HuntState>,
     /// Active video+audio capture (shortcut or the menu's Record Video item),
     /// or None when not recording. Frames and the matching mixer audio are
     /// appended on emulated-frame boundaries, so captures stay in sync
@@ -919,6 +921,7 @@ impl App {
             paused_before_console: false,
             last_debug_stop: None,
             reported_double_fault: false,
+            hunt: None,
             recorder: None,
             record_fb: Vec::new(),
         }

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -148,7 +148,7 @@ const CONSOLE_HELP: &[&str] = &[
     "            copper [pc|ADDR] [N]   custom   blits   find HEX [START]",
     "            writer ADDR",
     "            history/h [N]   stack/bt",
-    "os:         tasks  libs  devs  resources  ports   guru [CODE]",
+    "os:         tasks  libs  devs  resources  ports   segments   guru [CODE]",
     "hunt:       hunt start [B|W]  hunt eq/ne/lt/gt VAL  hunt same|diff  hunt list",
     "modify:     poke ADDR VAL   setreg REG VAL   trace start [PATH]|stop",
     "console:    help  clear  close",
@@ -465,6 +465,7 @@ impl App {
                 ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Resources))
             }
             "PORTS" => ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Ports)),
+            "SEGMENTS" => ConsoleOutcome::lines(self.console_segments()),
             "CATCHTASK" => {
                 if args.is_empty() {
                     self.emu.machine.ui_set_task_catch(None);
@@ -1124,6 +1125,34 @@ impl App {
             if machine.stopped() { "  STOPPED" } else { "" }
         ));
         lines
+    }
+
+    /// SEGMENTS: the current process's loaded hunks (its CLI command's
+    /// segment list when there is one), plus the add-symbol-file line a
+    /// source-level GDB session needs.
+    fn console_segments(&self) -> Vec<String> {
+        match crate::amigaos::segments_on_bus(self.emu.bus()) {
+            Err(reason) => vec![format!("!{reason}")],
+            Ok(segs) if segs.is_empty() => {
+                vec!["current task has no walkable segment list".to_string()]
+            }
+            Ok(segs) => {
+                let mut lines = Vec::new();
+                for (i, seg) in segs.iter().enumerate() {
+                    lines.push(format!(
+                        "hunk {i}: ${:06X}..${:06X}  ({} bytes)",
+                        seg.start,
+                        seg.start + seg.size,
+                        seg.size
+                    ));
+                }
+                lines.push(format!(
+                    "gdb: add-symbol-file prog.elf 0x{:X}",
+                    segs[0].start
+                ));
+                lines
+            }
+        }
     }
 
     /// Run `walk` against a validated ExecBase using peeks over the bus,

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -33,6 +33,40 @@ impl ConsoleOutcome {
     }
 }
 
+/// A running memory hunt (trainer-style delta search): the last
+/// snapshot of every scanned region plus the surviving candidates.
+pub(super) struct HuntState {
+    /// Search width in bytes (1 or 2).
+    width: u32,
+    /// (base, bytes) snapshot of each scanned region at the last filter.
+    snapshot: Vec<(u32, Vec<u8>)>,
+    /// Surviving candidate addresses; None before the first filter
+    /// (everything is still a candidate).
+    candidates: Option<Vec<u32>>,
+}
+
+impl HuntState {
+    fn value_in(bytes: &[u8], off: usize, width: u32) -> u32 {
+        if width == 1 {
+            u32::from(bytes[off])
+        } else {
+            (u32::from(bytes[off]) << 8) | u32::from(bytes[off + 1])
+        }
+    }
+
+    fn candidate_count(&self) -> Option<usize> {
+        self.candidates.as_ref().map(|c| c.len())
+    }
+}
+
+/// How a hunt filter compares a candidate's current value.
+enum HuntFilter {
+    Cmp(std::cmp::Ordering, u32),
+    NotEqual(u32),
+    Same,
+    Different,
+}
+
 /// Instruction budgets for the bounded run commands, matching the
 /// debugger window's transport buttons.
 const CONSOLE_STEP_BUDGET: usize = 5_000_000;
@@ -115,6 +149,7 @@ const CONSOLE_HELP: &[&str] = &[
     "            writer ADDR",
     "            history/h [N]   stack/bt",
     "os:         tasks  libs  devs  resources  ports   guru [CODE]",
+    "hunt:       hunt start [B|W]  hunt eq/ne/lt/gt VAL  hunt same|diff  hunt list",
     "modify:     poke ADDR VAL   setreg REG VAL   trace start [PATH]|stop",
     "console:    help  clear  close",
     "Addresses and values are hex; beam positions (V, H) are decimal.",
@@ -594,6 +629,7 @@ impl App {
                 }
                 ConsoleOutcome::lines(lines)
             }
+            "HUNT" => self.console_hunt(args),
             "TRACE" => {
                 const TRACE_LINE_CAP: u64 = 1_000_000;
                 let sub = args.first().map(|t| t.to_ascii_uppercase());
@@ -794,6 +830,179 @@ impl App {
             }
             _ => ConsoleOutcome::error(format!("unknown command {cmd} (try HELP)")),
         }
+    }
+
+    /// The HUNT command family: a trainer-style delta search over
+    /// writable RAM. START snapshots, EQ/NE/LT/GT/SAME/DIFF filter the
+    /// candidates against live memory (then re-snapshot), LIST shows
+    /// survivors, OFF clears.
+    fn console_hunt(&mut self, args: &[&str]) -> ConsoleOutcome {
+        let sub = args.first().map(|t| t.to_ascii_uppercase());
+        match sub.as_deref() {
+            None => match &self.hunt {
+                Some(hunt) => ConsoleOutcome::one(format!(
+                    "hunt active ({}-bit): {}",
+                    hunt.width * 8,
+                    match hunt.candidate_count() {
+                        Some(n) => format!("{n} candidate(s)"),
+                        None => "no filter applied yet".to_string(),
+                    }
+                )),
+                None => ConsoleOutcome::one("no hunt (HUNT START [B|W] begins one)"),
+            },
+            Some("OFF") => {
+                self.hunt = None;
+                ConsoleOutcome::one("hunt cleared")
+            }
+            Some("START") => {
+                let width = match args.get(1).map(|t| t.to_ascii_uppercase()).as_deref() {
+                    Some("B") => 1,
+                    Some("W") | None => 2,
+                    Some(_) => return ConsoleOutcome::error("usage: HUNT START [B|W]"),
+                };
+                let snapshot = self.console_hunt_snapshot();
+                let total: usize = snapshot.iter().map(|(_, bytes)| bytes.len()).sum();
+                self.hunt = Some(HuntState {
+                    width,
+                    snapshot,
+                    candidates: None,
+                });
+                ConsoleOutcome::one(format!(
+                    "hunting {}-bit values across {total} bytes of RAM; filter with \
+                     HUNT EQ/NE/LT/GT VALUE or HUNT SAME/DIFF",
+                    width * 8
+                ))
+            }
+            Some("LIST") => {
+                let Some(hunt) = &self.hunt else {
+                    return ConsoleOutcome::one("no hunt running");
+                };
+                let Some(candidates) = &hunt.candidates else {
+                    return ConsoleOutcome::one("no filter applied yet");
+                };
+                let cap = args
+                    .get(1)
+                    .and_then(|t| t.parse::<usize>().ok())
+                    .unwrap_or(16)
+                    .clamp(1, 64);
+                let width = hunt.width;
+                let mut lines = vec![format!("{} candidate(s):", candidates.len())];
+                for &addr in candidates.iter().take(cap) {
+                    let bytes = self.emu.machine.debug_read_memory(addr, width as usize);
+                    let value = HuntState::value_in(&bytes, 0, width);
+                    lines.push(format!(
+                        "  ${addr:06X} = {value:0w$X}",
+                        w = width as usize * 2
+                    ));
+                }
+                if candidates.len() > cap {
+                    lines.push(format!("  ... {} more", candidates.len() - cap));
+                }
+                ConsoleOutcome::lines(lines)
+            }
+            Some(op @ ("EQ" | "NE" | "LT" | "GT" | "SAME" | "DIFF")) => {
+                let filter = match op {
+                    "EQ" => match args.get(1).and_then(|t| hex32(t)) {
+                        Some(v) => HuntFilter::Cmp(std::cmp::Ordering::Equal, v),
+                        None => return ConsoleOutcome::error("usage: HUNT EQ VALUE (hex)"),
+                    },
+                    "NE" => match args.get(1).and_then(|t| hex32(t)) {
+                        Some(v) => HuntFilter::NotEqual(v),
+                        None => return ConsoleOutcome::error("usage: HUNT NE VALUE (hex)"),
+                    },
+                    "LT" => match args.get(1).and_then(|t| hex32(t)) {
+                        Some(v) => HuntFilter::Cmp(std::cmp::Ordering::Less, v),
+                        None => return ConsoleOutcome::error("usage: HUNT LT VALUE (hex)"),
+                    },
+                    "GT" => match args.get(1).and_then(|t| hex32(t)) {
+                        Some(v) => HuntFilter::Cmp(std::cmp::Ordering::Greater, v),
+                        None => return ConsoleOutcome::error("usage: HUNT GT VALUE (hex)"),
+                    },
+                    "SAME" => HuntFilter::Same,
+                    _ => HuntFilter::Different,
+                };
+                self.console_hunt_filter(filter)
+            }
+            Some(_) => ConsoleOutcome::error(
+                "usage: HUNT [START [B|W] | EQ/NE/LT/GT VALUE | SAME | DIFF | LIST [N] | OFF]",
+            ),
+        }
+    }
+
+    fn console_hunt_snapshot(&self) -> Vec<(u32, Vec<u8>)> {
+        self.emu
+            .bus()
+            .writable_ram_regions()
+            .into_iter()
+            .map(|(base, len)| (base, self.emu.machine.debug_read_memory(base, len as usize)))
+            .collect()
+    }
+
+    fn console_hunt_filter(&mut self, filter: HuntFilter) -> ConsoleOutcome {
+        let Some(mut hunt) = self.hunt.take() else {
+            return ConsoleOutcome::one("no hunt running (HUNT START first)");
+        };
+        let current = self.console_hunt_snapshot();
+        let width = hunt.width;
+        let survives = |old_value: u32, new_value: u32| -> bool {
+            match &filter {
+                HuntFilter::Cmp(ordering, v) => new_value.cmp(v) == *ordering,
+                HuntFilter::NotEqual(v) => new_value != *v,
+                HuntFilter::Same => new_value == old_value,
+                HuntFilter::Different => new_value != old_value,
+            }
+        };
+        let mut next: Vec<u32> = Vec::new();
+        match hunt.candidates.take() {
+            Some(candidates) => {
+                for addr in candidates {
+                    let old_value = Self::hunt_value_at(&hunt.snapshot, addr, width);
+                    let new_value = Self::hunt_value_at(&current, addr, width);
+                    if let (Some(old_value), Some(new_value)) = (old_value, new_value) {
+                        if survives(old_value, new_value) {
+                            next.push(addr);
+                        }
+                    }
+                }
+            }
+            None => {
+                // First filter: scan everything.
+                for ((base, old_bytes), (_, new_bytes)) in hunt.snapshot.iter().zip(current.iter())
+                {
+                    let step = width as usize;
+                    let mut off = 0;
+                    while off + step <= old_bytes.len() {
+                        let old_value = HuntState::value_in(old_bytes, off, width);
+                        let new_value = HuntState::value_in(new_bytes, off, width);
+                        if survives(old_value, new_value) {
+                            next.push(base + off as u32);
+                        }
+                        off += step;
+                    }
+                }
+            }
+        }
+        let count = next.len();
+        hunt.candidates = Some(next);
+        hunt.snapshot = current;
+        self.hunt = Some(hunt);
+        ConsoleOutcome::one(format!(
+            "{count} candidate(s) remain{}",
+            if count > 0 && count <= 16 {
+                "  (HUNT LIST shows them)"
+            } else {
+                ""
+            }
+        ))
+    }
+
+    fn hunt_value_at(snapshot: &[(u32, Vec<u8>)], addr: u32, width: u32) -> Option<u32> {
+        for (base, bytes) in snapshot {
+            if addr >= *base && (addr - base) as usize + width as usize <= bytes.len() {
+                return Some(HuntState::value_in(bytes, (addr - base) as usize, width));
+            }
+        }
+        None
     }
 
     /// Run a bounded forward-execution operation and report where the

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -109,12 +109,12 @@ const CONSOLE_HELP: &[&str] = &[
     "stops:      break/b ADDR [COND] [IGN N]   watch/w ADDR [CPU|BLITTER|DISK]",
     "            rwatch REG",
     "            btrap V [H]   cbreak ADDR   catch irq N|trap N|vec N",
-    "            catchtask [NAME]   breaks (list)   clearbreaks",
+    "            catchtask [NAME]   catchalert   breaks (list)   clearbreaks",
     "inspect:    status  regs/r  mem/m ADDR [BYTES]  dis/d [ADDR] [N]",
     "            copper [pc|ADDR] [N]   custom   blits   find HEX [START]",
     "            writer ADDR",
     "            history/h [N]   stack/bt",
-    "os:         tasks  libs  devs  resources  ports",
+    "os:         tasks  libs  devs  resources  ports   guru [CODE]",
     "modify:     poke ADDR VAL   setreg REG VAL",
     "console:    help  clear  close",
     "Addresses and values are hex; beam positions (V, H) are decimal.",
@@ -441,6 +441,42 @@ impl App {
                 self.emu.machine.ui_set_task_catch(Some(target.clone()));
                 ConsoleOutcome::one(format!(
                     "stopping when a task whose name contains \"{target}\" is scheduled"
+                ))
+            }
+            "CATCHALERT" => {
+                let lvo = self.console_with_exec(|_, base| {
+                    // exec's Alert() lives at LVO -108; the jump-table
+                    // entry itself executes, so a PC breakpoint there
+                    // fires on every alert with D7 = the guru code.
+                    vec![format!("{:06X}", base.wrapping_sub(108) & 0x00FF_FFFF)]
+                });
+                let Some(addr) = lvo
+                    .first()
+                    .filter(|line| !line.starts_with('!'))
+                    .and_then(|line| u32::from_str_radix(line, 16).ok())
+                else {
+                    return ConsoleOutcome::lines(lvo);
+                };
+                let set = self.emu.machine.ui_set_breakpoint(addr, None, 0);
+                ConsoleOutcome::one(if set {
+                    format!(
+                        "break at exec Alert() (${addr:06X}); on stop D7 holds the code -- GURU decodes it"
+                    )
+                } else {
+                    format!("alert catch removed (${addr:06X})")
+                })
+            }
+            "GURU" => {
+                let code = match args.first() {
+                    Some(token) => match hex32(token) {
+                        Some(code) => code,
+                        None => return ConsoleOutcome::error("usage: GURU [HEXCODE] (default D7)"),
+                    },
+                    None => self.emu.machine.d(7),
+                };
+                ConsoleOutcome::one(format!(
+                    "{code:08X}: {}",
+                    crate::debugger::guru_decode(code)
                 ))
             }
             "BREAKS" | "INFO" => ConsoleOutcome::lines(self.console_breaks_lines()),

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -115,7 +115,7 @@ const CONSOLE_HELP: &[&str] = &[
     "            writer ADDR",
     "            history/h [N]   stack/bt",
     "os:         tasks  libs  devs  resources  ports   guru [CODE]",
-    "modify:     poke ADDR VAL   setreg REG VAL",
+    "modify:     poke ADDR VAL   setreg REG VAL   trace start [PATH]|stop",
     "console:    help  clear  close",
     "Addresses and values are hex; beam positions (V, H) are decimal.",
     "Cmd/Ctrl+V pastes; a multi-line paste runs each line in order.",
@@ -218,11 +218,9 @@ impl App {
     }
 
     /// Dispatch one command line. Never touches `console_panel`; the
-    /// caller applies the outcome so borrows stay simple.
+    /// caller applies the outcome so borrows stay simple. Arguments keep
+    /// their case (file paths); every parser is case-insensitive.
     fn console_execute(&mut self, line: &str) -> ConsoleOutcome {
-        // Commands and arguments are case-insensitive (hex, register
-        // names, catch grammar); pasted lowercase runs as typed.
-        let line = line.to_ascii_uppercase();
         let tokens: Vec<&str> = line.split_whitespace().collect();
         let Some((&cmd, args)) = tokens.split_first() else {
             return ConsoleOutcome::lines(Vec::new());
@@ -338,7 +336,7 @@ impl App {
                 ConsoleOutcome::lines(lines)
             }
             "BREAK" | "B" => {
-                let spec = args.join(" ");
+                let spec = args.join(" ").to_ascii_uppercase();
                 let Some((addr, cond, ignore)) = ui::parse_break_spec(&spec) else {
                     return ConsoleOutcome::error("usage: BREAK ADDR [LHS OP RHS] [IGN N]");
                 };
@@ -375,7 +373,7 @@ impl App {
             "RWATCH" | "RW" => {
                 let Some(off) = args
                     .first()
-                    .and_then(|t| crate::gdbstub::parse_custom_reg(t))
+                    .and_then(|t| crate::gdbstub::parse_custom_reg(&t.to_ascii_uppercase()))
                 else {
                     return ConsoleOutcome::error("usage: RWATCH NAME|OFFSET (e.g. DMACON or 96)");
                 };
@@ -595,6 +593,53 @@ impl App {
                     lines.push(format!("{cursor}{addr:06X}  {text}"));
                 }
                 ConsoleOutcome::lines(lines)
+            }
+            "TRACE" => {
+                const TRACE_LINE_CAP: u64 = 1_000_000;
+                let sub = args.first().map(|t| t.to_ascii_uppercase());
+                match sub.as_deref() {
+                    Some("START") => {
+                        let path = match args.get(1) {
+                            Some(path) => std::path::PathBuf::from(path),
+                            None => {
+                                let stamp = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs())
+                                    .unwrap_or(0);
+                                std::path::PathBuf::from(format!("copperline-trace-{stamp}.txt"))
+                            }
+                        };
+                        match self
+                            .emu
+                            .machine
+                            .ui_trace_start(path.clone(), TRACE_LINE_CAP)
+                        {
+                            Ok(()) => ConsoleOutcome::one(format!(
+                                "tracing to {} (cap {TRACE_LINE_CAP} lines; TRACE STOP ends it)",
+                                path.display()
+                            )),
+                            Err(e) => ConsoleOutcome::error(format!(
+                                "cannot open {}: {e}",
+                                path.display()
+                            )),
+                        }
+                    }
+                    Some("STOP") => match self.emu.machine.ui_trace_stop() {
+                        Some((path, lines)) => ConsoleOutcome::one(format!(
+                            "trace stopped: {lines} lines in {}",
+                            path.display()
+                        )),
+                        None => ConsoleOutcome::one("no trace running"),
+                    },
+                    None => match self.emu.machine.ui_trace_status() {
+                        Some((path, lines)) => ConsoleOutcome::one(format!(
+                            "tracing to {} ({lines} lines so far)",
+                            path.display()
+                        )),
+                        None => ConsoleOutcome::one("no trace running (TRACE START [PATH])"),
+                    },
+                    Some(_) => ConsoleOutcome::error("usage: TRACE [START [PATH] | STOP]"),
+                }
             }
             "BLITS" => {
                 let Some(trace) = self.emu.bus().frame_bus_trace() else {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2705,6 +2705,44 @@ fn console_blits_lists_frame_blit_records() {
 }
 
 #[test]
+fn console_hunt_narrows_to_the_changed_word() {
+    let mut app = test_app();
+    app.open_console();
+    app.emu.bus_mut().mem.overlay = false;
+
+    // Plant a "lives counter" and snapshot.
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        ram[0x60000..0x60002].copy_from_slice(&0x0003u16.to_be_bytes());
+    }
+    let out = console_run(&mut app, "HUNT START");
+    assert!(out[0].contains("hunting 16-bit"), "{out:?}");
+
+    // First filter: everything equal to 3 (the counter plus noise).
+    let out = console_run(&mut app, "HUNT EQ 3");
+    assert!(out[0].contains("candidate(s) remain"), "{out:?}");
+
+    // "Lose a life", then narrow to values now equal to 2 -- only the
+    // counter both was 3 and became 2.
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        ram[0x60000..0x60002].copy_from_slice(&0x0002u16.to_be_bytes());
+    }
+    let out = console_run(&mut app, "HUNT EQ 2");
+    assert!(out[0].starts_with("1 candidate(s) remain"), "{out:?}");
+    let out = console_run(&mut app, "HUNT LIST");
+    assert!(out.iter().any(|l| l.contains("$060000 = 0002")), "{out:?}");
+
+    // SAME keeps it (nothing changed since the last filter); DIFF drops it.
+    let out = console_run(&mut app, "HUNT SAME");
+    assert!(out[0].starts_with("1 candidate"), "{out:?}");
+    let out = console_run(&mut app, "HUNT DIFF");
+    assert!(out[0].starts_with("0 candidate"), "{out:?}");
+    console_run(&mut app, "HUNT OFF");
+    assert!(app.hunt.is_none());
+}
+
+#[test]
 fn console_trace_writes_disassembled_lines() {
     let mut app = test_app();
     app.open_console();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2705,6 +2705,32 @@ fn console_blits_lists_frame_blit_records() {
 }
 
 #[test]
+fn console_trace_writes_disassembled_lines() {
+    let mut app = test_app();
+    app.open_console();
+    let path = std::env::temp_dir().join(format!(
+        "copperline-console-trace-{}.txt",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&path);
+
+    let out = console_run(&mut app, &format!("TRACE START {}", path.display()));
+    assert!(out[0].contains("tracing to"), "{out:?}");
+    console_run(&mut app, "S 4");
+    let out = console_run(&mut app, "TRACE");
+    assert!(out[0].contains("lines so far"), "{out:?}");
+    let out = console_run(&mut app, "TRACE STOP");
+    assert!(out[0].contains("trace stopped: 4 lines"), "{out:?}");
+
+    let text = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 4, "{text}");
+    // Disassembled NOP sled with beam annotations.
+    assert!(lines[0].contains("NOP") && lines[0].contains('['), "{text}");
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn double_fault_halt_surfaces_once() {
     let mut app = test_app();
     app.open_console();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2576,6 +2576,42 @@ fn plant_exec_world(app: &mut super::App) {
 }
 
 #[test]
+fn console_segments_walks_the_cli_module() {
+    let mut app = test_app();
+    app.open_console();
+    plant_exec_world(&mut app);
+    // Make ThisTask ($2000) a CLI process: NT_PROCESS, pr_CLI -> $4000
+    // whose cli_Module is a two-hunk seglist at $8000 -> $9000.
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        let put32 = |ram: &mut [u8], addr: usize, v: u32| {
+            ram[addr..addr + 4].copy_from_slice(&v.to_be_bytes());
+        };
+        ram[0x2000 + 8] = 13; // NT_PROCESS
+        put32(ram, 0x2000 + 0xAC, 0x4000 >> 2);
+        put32(ram, 0x4000 + 0x3C, 0x8000 >> 2);
+        put32(ram, 0x8000 - 4, 0x100);
+        put32(ram, 0x8000, 0x9000 >> 2);
+        put32(ram, 0x9000 - 4, 0x40);
+        put32(ram, 0x9000, 0);
+    }
+    let out = console_run(&mut app, "SEGMENTS");
+    assert!(
+        out.iter().any(|l| l.contains("hunk 0: $008004..$0080FC")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter().any(|l| l.contains("hunk 1: $009004..$00903C")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("add-symbol-file") && l.contains("0x8004")),
+        "{out:?}"
+    );
+}
+
+#[test]
 fn console_os_introspection_and_task_catch() {
     let mut app = test_app();
     app.open_console();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2705,6 +2705,49 @@ fn console_blits_lists_frame_blit_records() {
 }
 
 #[test]
+fn double_fault_halt_surfaces_once() {
+    let mut app = test_app();
+    app.open_console();
+    assert!(!app.surface_debug_stop());
+    app.emu.machine.test_force_double_fault();
+    // First poll reports and pauses; repeat polls stay quiet.
+    assert!(app.surface_debug_stop());
+    assert!(app.paused);
+    assert!(app
+        .last_debug_stop
+        .as_deref()
+        .is_some_and(|m| m.contains("double fault")));
+    assert!(app
+        .console_panel
+        .as_ref()
+        .is_some_and(|panel| panel.output.iter().any(|l| l.contains("double fault"))));
+    assert!(!app.surface_debug_stop());
+}
+
+#[test]
+fn console_catchalert_and_guru_decode() {
+    let mut app = test_app();
+    app.open_console();
+    plant_exec_world(&mut app);
+
+    // CATCHALERT toggles a breakpoint at ExecBase - 108 (Alert's LVO).
+    let out = console_run(&mut app, "CATCHALERT");
+    assert!(out[0].contains("exec Alert()"), "{out:?}");
+    let lvo = 0x1000u32 - 108;
+    assert!(app.emu.machine.ui_breaks().is_breakpoint(lvo));
+    let out = console_run(&mut app, "CATCHALERT");
+    assert!(out[0].contains("removed"), "{out:?}");
+    assert!(!app.emu.machine.ui_breaks().is_breakpoint(lvo));
+
+    // GURU decodes an explicit code and defaults to D7.
+    let out = console_run(&mut app, "GURU 81000005");
+    assert!(out[0].contains("DEADEND exec.library"), "{out:?}");
+    console_run(&mut app, "SETREG D7 80000003");
+    let out = console_run(&mut app, "GURU");
+    assert!(out[0].contains("Address error"), "{out:?}");
+}
+
+#[test]
 fn console_history_and_stack_walk() {
     let mut app = test_app();
     app.open_console();

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -320,6 +320,16 @@ impl ZorroChain {
         None
     }
 
+    /// Configured RAM windows as (base, len) pairs, for the debugger's
+    /// memory hunt.
+    pub fn ram_regions(&self) -> Vec<(u32, u32)> {
+        self.regions
+            .iter()
+            .filter(|(_, _, idx)| !self.boards[*idx].ram.is_empty())
+            .map(|(base, len, _)| (*base, *len))
+            .collect()
+    }
+
     pub fn board_ram(&self, idx: usize) -> &[u8] {
         &self.boards[idx].ram
     }


### PR DESCRIPTION
The five polish items from the debugger survey, one commit each:

- **Guru/crash surfacing** (fcfa3e7): `CATCHALERT` breaks at exec's `Alert()` entry with D7 holding the code, and `GURU [CODE]` decodes it (deadend flag, subsystem, cause, CPU-trap alerts). CPU double faults -- the halt even the OS cannot report -- are surfaced automatically on screen, in the console, and on the Break tab.
- **Runtime instruction trace** (a701352): console `TRACE START [PATH]` / `TRACE STOP` streams disassembled retired PCs with beam positions to a file while the machine runs, capped at 1M lines; no restart or env vars needed.
- **HUNT RAM delta search** (d78e14a): trainer-style memory hunting over all writable RAM (chip, slow, Zorro boards via a new `Bus::writable_ram_regions`). `HUNT START [B|W]`, `EQ/NE/LT/GT VALUE`, `SAME`/`DIFF`, `LIST`, `OFF`. The classic lose-a-life workflow lands on the counter, ready for the attributed `WATCH`.
- **Segment discovery for source-level GDB** (0d7c51a): the exec walker learns DOS process seglists (CLI `cli_Module`, falling back to `pr_SegList`). Console `SEGMENTS` and `monitor segments` print the hunk map, and the stub answers `qOffsets` with `TextSeg`/`DataSeg` so `m68k-amigaos-gdb` relocates automatically -- source-level `break main`/`next`/`print` on programs running inside the emulator. Empty reply when no seglist is walkable, so ROM-level sessions are untouched.
- **Debugging workflows chapter** (f619e83): a scenario-driven tutorial (vanishing sprite, torn picture/trashed copper list, memory corruption, guru triage, lives-counter hunt, source-level GDB, reproducibility) showing how the tools combine.

All debug state stays `#[serde(skip)]` transient -- no `STATE_VERSION` change.

Verification: 1258 unit tests green, clippy/fmt clean, docs `myst build --html` clean, a1000 20s release screenshot byte-identical to main, integration suite green except the documented pre-existing `ocs_bpu7_ham` host flake.