### PR TITLE
Reset Zorro boards to unconfigured state on warm reset

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2355,6 +2355,13 @@ impl Bus {
     pub fn reset_custom_chips_from_cpu_reset(&mut self) {
         self.agnus.reset_copcon();
         self.floppy.reset_external_drives();
+        // RESET asserts /RST on the expansion bus: boards drop back to
+        // unconfigured (Kickstart re-runs autoconfig on the way back up)
+        // and expansion devices see a hardware reset.
+        for dev in &mut self.devices {
+            crate::zorro_device::ZorroDevice::reset(dev);
+        }
+        self.mem.zorro.warm_reset();
     }
 
     fn effective_diwhigh(&self) -> DiwHigh {
@@ -2497,6 +2504,7 @@ impl Bus {
         for dev in &mut self.devices {
             crate::zorro_device::ZorroDevice::reset(dev);
         }
+        self.mem.zorro.warm_reset();
         self.hdd_led_until_cck = 0;
         self.overlay_disable_pending = false;
         // The MCU restarts its power-up flow; physically held keys stay

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -272,9 +272,19 @@ impl ZorroChain {
 
     /// Return all boards to unconfigured with zeroed RAM (cold power-on).
     pub fn power_on_reset(&mut self) {
+        self.warm_reset();
+        for board in &mut self.boards {
+            board.ram.fill(0);
+        }
+    }
+
+    /// Return all boards to unconfigured, preserving RAM contents. /RST on
+    /// the expansion bus (keyboard reset or the CPU RESET instruction)
+    /// clears each board's autoconfig latch, including shut-up boards, but
+    /// expansion RAM keeps its contents so reset-surviving structures work.
+    pub fn warm_reset(&mut self) {
         for board in &mut self.boards {
             board.state = BoardState::Unconfigured;
-            board.ram.fill(0);
         }
         self.regions.clear();
         self.device_regions.clear();
@@ -986,6 +996,31 @@ mod tests {
         assert_eq!(chain.region_at(0x0020_0000, 1), None);
         assert_eq!(chain.config_read(AUTOCONFIG_BASE, 1), 0xE0);
         assert_eq!(chain.board_ram(0)[0], 0);
+    }
+
+    #[test]
+    fn warm_reset_unconfigures_and_preserves_ram() {
+        let mut chain = chain_with(vec![
+            BoardSpec::fast_ram(512 * 1024),
+            BoardSpec::fast_ram(512 * 1024),
+        ]);
+        chain.config_write(AUTOCONFIG_BASE + EC_BASEADDRESS_PHYS, 2, 0x2000);
+        let (idx, off) = chain.region_at(0x0020_0000, 1).unwrap();
+        chain.board_ram_mut(idx)[off] = 0xAA;
+        // Shut up the second board; /RST must revive it too.
+        chain.config_write(AUTOCONFIG_BASE + EC_SHUTUP_PHYS, 1, 0);
+
+        chain.warm_reset();
+
+        // Both boards are back in the autoconfig chain, RAM intact.
+        assert_eq!(chain.region_at(0x0020_0000, 1), None);
+        assert_eq!(chain.config_read(AUTOCONFIG_BASE, 1), 0xE0);
+        assert_eq!(chain.board_ram(0)[0], 0xAA);
+        chain.config_write(AUTOCONFIG_BASE + EC_BASEADDRESS_PHYS, 2, 0x2000);
+        assert_eq!(chain.config_read(AUTOCONFIG_BASE, 1), 0xE0);
+        chain.config_write(AUTOCONFIG_BASE + EC_BASEADDRESS_PHYS, 2, 0x2800);
+        assert_eq!(chain.region_at(0x0020_0000, 1), Some((0, 0)));
+        assert_eq!(chain.region_at(0x0028_0000, 1), Some((1, 0)));
     }
 
     #[test]


### PR DESCRIPTION
Zorro boards vanished after a warm boot (Ctrl-Amiga-Amiga or a software reboot): the autoconfig chain stayed in the Configured state across reset, so Kickstart's autoconfig scan at $E80000 found no unconfigured board and rebuilt an empty ConfigDev list.

On real hardware both the keyboard reset and the CPU RESET instruction assert /RST on the expansion bus, which clears every board's autoconfig latch (including shut-up boards) while expansion RAM keeps its contents.

Add ZorroChain::warm_reset() that returns all boards to Unconfigured without zeroing RAM, and call it from both warm-reset paths. The RESET instruction path previously only reset COPCON and the floppies, so it also gains the ZorroDevice::reset loop the keyboard path already had.

Closes https://github.com/LinuxJedi/Copperline/issues/87