### PR TITLE
68060 CPU support: full instruction-set contract, FPU/MMU, superscalar timing

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -56,17 +56,18 @@ pacing_budget = "cycles"
 
 [cpu]
 
-# CPU type. One of: 68000, 68EC020, 68020, 68030, 68040.
+# CPU type. One of: 68000, 68EC020, 68020, 68030, 68040, 68060.
 # 68EC020 uses the 68020 instruction set with a 24-bit external address bus.
 model = "68000"
 
-# FPU (68881/68882 coprocessor; on-die on the full 68040). Needs a
-# 68020 or later -- a 68000 cannot drive one. The 68040 enables it by
-# default; on other 020+ CPUs opt in here.
+# FPU (68881/68882 coprocessor; on-die on the full 68040/68060). Needs a
+# 68020 or later -- a 68000 cannot drive one. The 68040 and 68060 enable
+# it by default; on other 020+ CPUs opt in here. fpu = false on the 68060
+# models the FPU-less LC/EC parts (PCR.DFP).
 # fpu = true
 
 # CPU clock in MHz. Defaults to the model's stock speed (68000 ~7.09,
-# 020 ~14, 030/040 ~25). The chipset and pacing model the CPU as a whole
+# 020 ~14, 030/040 ~25, 060 50). The chipset and pacing model the CPU as a whole
 # multiple of the colour clock, so the effective clock is rounded to the
 # nearest multiple. Fast RAM runs at the CPU clock; chip and slow/trapdoor
 # RAM stay chip-bus bound.
@@ -75,13 +76,22 @@ model = "68000"
 # Model the on-chip caches (a hit serves with no chip-bus cycle, as on
 # real silicon, so cached code stops contending with DMA). On by default
 # for the CPUs that have them, since AmigaOS enables them at boot: the
-# instruction cache on the 68020/68EC020/68030/68040 (256 bytes on the
-# 020/030, 4 KB on the 040) and the data cache on the 68030/68040. The
+# instruction cache on the 68020/68EC020/68030/68040/68060 (256 bytes on
+# the 020/030, 4 KB on the 040, 8 KB on the 060) and the data cache on
+# the 68030/68040/68060. The
 # data cache only covers expansion RAM/ROM -- chip and slow RAM are
 # cache-inhibited because DMA writes them, as on real Amigas. Set false
 # to force a CPU to run cacheless (e.g. for the uncalibrated baseline).
 # icache = false
 # dcache = false
+
+# 68060 only: the 68060 dropped MOVEP, CHK2/CMP2, CAS2, misaligned CAS,
+# 64-bit MUL/DIV, and most FPU operations beyond basic arithmetic from
+# silicon. "trap" (default) raises the chip's unimplemented-instruction
+# exceptions for the OS-side 68060.library to emulate, exactly like a
+# real accelerator board; "native" executes them directly for systems
+# without the library.
+# unimplemented = "trap"
 
 
 # Optional machine profile: a validated bundle of chipset revisions, CPU,

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -217,6 +217,13 @@ pub struct CpuCore {
     pub dacr1: u32, // Data Access Control 1 (0x009)
     pub iacr0: u32, // Instruction Access Control 0 (0x00A)
     pub iacr1: u32, // Instruction Access Control 1 (0x00B)
+    // 68060-specific control registers
+    /// Processor Configuration Register (MOVEC 0x808): identification and
+    /// revision in the high half (read-only), EDEBUG/DFP/ESS in the low bits.
+    pub pcr: u32,
+    /// Bus Control Register (MOVEC 0x008 on the 060 only; the same code is
+    /// DACR0 on the 68040). Stored, not behaviorally modeled.
+    pub buscr: u32,
     /// Address Translation Cache: a pure cache of recent page-table walks, so it
     /// is not serialized (restored empty) and is flushed on any mapping change.
     #[serde(skip)]
@@ -267,6 +274,43 @@ pub const CACR_WA: u32 = 1 << 13;
 pub const CACR_040_IE: u32 = 1 << 15;
 /// Enable data cache (68040).
 pub const CACR_040_DE: u32 = 1 << 31;
+
+// CACR bit assignments (68060). The cache enables sit at the 68040
+// positions; the 060 adds branch-cache and store-buffer controls. The
+// branch-cache clears (CABC/CUBC) are write-only strobes.
+/// Enable data cache (68060).
+pub const CACR_060_EDC: u32 = 1 << 31;
+/// No allocate mode, data cache (68060; stored only).
+pub const CACR_060_NAD: u32 = 1 << 30;
+/// Enable store buffer (68060; stored only - the host bills writes at bus rate).
+pub const CACR_060_ESB: u32 = 1 << 29;
+/// Disable CPUSH invalidation, data (68060; stored only).
+pub const CACR_060_DPI: u32 = 1 << 28;
+/// Half-cache operation mode, data (68060; stored only).
+pub const CACR_060_FOC: u32 = 1 << 27;
+/// Enable branch cache (68060).
+pub const CACR_060_EBC: u32 = 1 << 23;
+/// Clear all entries in the branch cache (68060, write-only strobe).
+pub const CACR_060_CABC: u32 = 1 << 22;
+/// Clear all user entries in the branch cache (68060, write-only strobe).
+pub const CACR_060_CUBC: u32 = 1 << 21;
+/// Enable instruction cache (68060).
+pub const CACR_060_EIC: u32 = 1 << 15;
+/// No allocate mode, instruction cache (68060; stored only).
+pub const CACR_060_NAI: u32 = 1 << 14;
+/// Half-cache operation mode, instruction (68060; stored only).
+pub const CACR_060_FIC: u32 = 1 << 13;
+
+// PCR (68060 MOVEC 0x808) bit assignments.
+/// Enable superscalar dispatch.
+pub const PCR_ESS: u32 = 1 << 0;
+/// Disable the on-chip FPU: FP instructions raise Line-F.
+pub const PCR_DFP: u32 = 1 << 1;
+/// Enable debug features (stored only).
+pub const PCR_EDEBUG: u32 = 1 << 7;
+/// Reset value: identification 0x0430 (full MC68060), revision 1, ESS and
+/// DFP clear (superscalar dispatch off until system software enables it).
+pub const PCR_060_RESET: u32 = 0x0430_0100;
 
 impl Default for CpuCore {
     fn default() -> Self {
@@ -374,6 +418,8 @@ impl CpuCore {
             dacr1: 0,
             iacr0: 0,
             iacr1: 0,
+            pcr: PCR_060_RESET,
+            buscr: 0,
             atc: crate::mmu::Atc::default(),
             cycles_remaining: 0,
             initial_cycles: 0,
@@ -457,9 +503,17 @@ impl CpuCore {
     // Results: USP=0, ISP=4, MSP=6
 
     /// Get the current stack pointer bank index.
+    ///
+    /// The 68060 implements a single supervisor stack: the SR M bit is
+    /// storable (interrupts still clear it, system software may use it) but
+    /// it never selects a separate master-stack bank.
     #[inline]
     fn sp_index(&self) -> usize {
-        (self.s_flag | ((self.s_flag >> 1) & self.m_flag)) as usize
+        if self.cpu_type == CpuType::M68060 {
+            self.s_flag as usize
+        } else {
+            (self.s_flag | ((self.s_flag >> 1) & self.m_flag)) as usize
+        }
     }
 
     /// Backup current SP to banked storage.
@@ -512,6 +566,10 @@ impl CpuCore {
         // enable/freeze bits drop and the host model must invalidate.
         self.cacr = 0;
         self.cacr_pending_ops |= CACR_CI | CACR_CD;
+        // 68060 control registers: identification/revision persist, the
+        // writable bits (EDEBUG/DFP/ESS) clear.
+        self.pcr = PCR_060_RESET;
+        self.buscr = 0;
         self.prefetch_queue = [0; 2];
         self.prefetch_count = 0;
         self.consume_without_prefetch = false;
@@ -829,6 +887,8 @@ impl CpuCore {
             0x005 => self.itt1,  // Instruction TTR 1 (68040)
             0x006 => self.dtt0,  // Data TTR 0 (68040)
             0x007 => self.dtt1,  // Data TTR 1 (68040)
+            // 0x008 is BUSCR on the 68060 and DACR0 on the 68040.
+            0x008 if self.is_060() => self.buscr,
             0x008 => self.dacr0, // Data Access Control 0 (68040)
             0x009 => self.dacr1, // Data Access Control 1 (68040)
             0x00A => self.iacr0, // Instruction Access Control 0 (68040)
@@ -862,6 +922,7 @@ impl CpuCore {
             0x805 => self.mmu_sr,        // MMU Status Register (68040)
             0x806 => self.mmu_crp_aptr,  // User Root Pointer (68040; URP)
             0x807 => self.mmu_srp_aptr,  // Supervisor Root Pointer (68040)
+            0x808 if self.is_060() => self.pcr, // Processor Configuration (68060)
             _ => 0,                      // Unknown register
         }
     }
@@ -883,6 +944,24 @@ impl CpuCore {
                         CACR_EI | CACR_FI | CACR_IBE | CACR_ED | CACR_FD | CACR_DBE | CACR_WA,
                         CACR_CEI | CACR_CI | CACR_CED | CACR_CD,
                     ),
+                    // The 68060 keeps the cache enables at the 040 positions
+                    // and adds branch-cache / store-buffer controls. CABC and
+                    // CUBC are write-only branch-cache clear strobes (wired to
+                    // the branch-cache model when it lands; accepted and
+                    // discarded until then). Cache invalidation stays with
+                    // CINV/CPUSH like the 040.
+                    CpuType::M68060 => (
+                        CACR_060_EDC
+                            | CACR_060_NAD
+                            | CACR_060_ESB
+                            | CACR_060_DPI
+                            | CACR_060_FOC
+                            | CACR_060_EBC
+                            | CACR_060_EIC
+                            | CACR_060_NAI
+                            | CACR_060_FIC,
+                        0,
+                    ),
                     // 68040 CACR defines only the two cache-enable bits and
                     // has no clear strobes - invalidation is done with the
                     // CINV/CPUSH instructions (see decode.rs). Reserved bits
@@ -902,6 +981,8 @@ impl CpuCore {
             0x005 => self.itt1 = value,    // Instruction TTR 1 (68040)
             0x006 => self.dtt0 = value,    // Data TTR 0 (68040)
             0x007 => self.dtt1 = value,    // Data TTR 1 (68040)
+            // 0x008 is BUSCR on the 68060 and DACR0 on the 68040.
+            0x008 if self.is_060() => self.buscr = value,
             0x008 => self.dacr0 = value,   // Data Access Control 0 (68040)
             0x009 => self.dacr1 = value,   // Data Access Control 1 (68040)
             0x00A => self.iacr0 = value,   // Instruction Access Control 0 (68040)
@@ -935,6 +1016,12 @@ impl CpuCore {
             0x805 => self.mmu_sr = value,        // MMU Status Register (68040)
             0x806 => self.mmu_crp_aptr = value,  // User Root Pointer (68040; URP)
             0x807 => self.mmu_srp_aptr = value,  // Supervisor Root Pointer (68040)
+            0x808 if self.is_060() => {
+                // PCR: identification and revision are read-only; only
+                // EDEBUG, DFP, and ESS are writable.
+                let writable = PCR_EDEBUG | PCR_DFP | PCR_ESS;
+                self.pcr = (self.pcr & !writable) | (value & writable);
+            }
             _ => {}                              // Unknown register - ignore
         }
         // A write to TC, a root pointer, or a TTR can change every translation,

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -1473,6 +1473,15 @@ impl CpuCore {
         use super::ea::AddressingMode;
         use super::types::Size;
 
+        // The 68060 has no PMOVE (MMU registers are MOVEC-only) and no
+        // 030-form PTEST/PFLUSH in this encoding space: undefined F-line.
+        // Watch item: the 040 arm below NOPs 030-form PTESTs because
+        // 68040.library issues them during setup; extend that pragmatism
+        // here if an OS's 68060 support library turns out to do the same.
+        if self.is_060() {
+            return 0;
+        }
+
         // MMU ops require PMMU-capable CPU (68030/68040).
         if !self.has_pmmu {
             return 0;

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -228,6 +228,11 @@ pub struct CpuCore {
     /// is not serialized (restored empty) and is flushed on any mapping change.
     #[serde(skip)]
     pub atc: crate::mmu::Atc,
+    /// Cause of the MMU fault currently being delivered (set by
+    /// handle_mmu_fault, consumed while composing the 68060 FSLW); plain
+    /// physical bus errors leave it None. Transient within one exception.
+    #[serde(skip)]
+    pub(crate) pending_fault_cause: Option<crate::mmu::MmuFaultCause>,
 
     // ========== Execution State ==========
     /// Remaining cycles in current timeslice
@@ -427,6 +432,7 @@ impl CpuCore {
             pcr: PCR_060_RESET,
             buscr: 0,
             atc: crate::mmu::Atc::default(),
+            pending_fault_cause: None,
             cycles_remaining: 0,
             initial_cycles: 0,
             emulate_unimplemented_060: false,
@@ -643,7 +649,7 @@ impl CpuCore {
         match bus.try_read_word(addr) {
             Ok(v) => Some(v),
             Err(_) => {
-                self.trigger_bus_error(bus, addr, false, true);
+                self.trigger_bus_error(bus, addr, false, true, 2);
                 None
             }
         }
@@ -1143,6 +1149,7 @@ impl CpuCore {
         address: u32,
         write: bool,
         instruction: bool,
+        size: u32,
     ) {
         if self.faulted() {
             return;
@@ -1160,7 +1167,8 @@ impl CpuCore {
         self.set_sr_noint_nosp(self.sr_save);
         self.dar = self.dar_save;
         self.exception_processing = true;
-        let _ = self.exception_bus_error(bus, address, write, instruction);
+        let cause = self.pending_fault_cause.take();
+        let _ = self.exception_bus_error(bus, address, write, instruction, size, cause);
         self.exception_processing = false;
         self.run_mode = RUN_MODE_BERR_AERR_RESET;
     }
@@ -1186,9 +1194,7 @@ impl CpuCore {
                 ) {
                     Ok(p) => addr = self.address(p),
                     Err(f) => {
-                        self.handle_mmu_fault(
-                            bus, f, /*write=*/ false, /*instruction=*/ false,
-                        );
+                        self.handle_mmu_fault(bus, f, false, false, 1);
                         return 0;
                     }
                 }
@@ -1198,7 +1204,7 @@ impl CpuCore {
             Ok(v) => v,
             Err(f) => {
                 if matches!(f.kind, BusFaultKind::BusError) {
-                    self.trigger_bus_error(bus, addr, false, false);
+                    self.trigger_bus_error(bus, addr, false, false, 1);
                 }
                 0
             }
@@ -1234,9 +1240,7 @@ impl CpuCore {
                 ) {
                     Ok(p) => addr = self.address(p),
                     Err(f) => {
-                        self.handle_mmu_fault(
-                            bus, f, /*write=*/ false, /*instruction=*/ false,
-                        );
+                        self.handle_mmu_fault(bus, f, false, false, 2);
                         return 0;
                     }
                 }
@@ -1246,7 +1250,7 @@ impl CpuCore {
             Ok(v) => v,
             Err(f) => {
                 if matches!(f.kind, BusFaultKind::BusError) {
-                    self.trigger_bus_error(bus, addr, false, false);
+                    self.trigger_bus_error(bus, addr, false, false, 2);
                 }
                 0
             }
@@ -1282,9 +1286,7 @@ impl CpuCore {
                 ) {
                     Ok(p) => addr = self.address(p),
                     Err(f) => {
-                        self.handle_mmu_fault(
-                            bus, f, /*write=*/ false, /*instruction=*/ false,
-                        );
+                        self.handle_mmu_fault(bus, f, false, false, 4);
                         return 0;
                     }
                 }
@@ -1294,7 +1296,7 @@ impl CpuCore {
             Ok(v) => v,
             Err(f) => {
                 if matches!(f.kind, BusFaultKind::BusError) {
-                    self.trigger_bus_error(bus, addr, false, false);
+                    self.trigger_bus_error(bus, addr, false, false, 4);
                 }
                 0
             }
@@ -1322,9 +1324,7 @@ impl CpuCore {
                 ) {
                     Ok(p) => addr = self.address(p),
                     Err(f) => {
-                        self.handle_mmu_fault(
-                            bus, f, /*write=*/ true, /*instruction=*/ false,
-                        );
+                        self.handle_mmu_fault(bus, f, true, false, 1);
                         return;
                     }
                 }
@@ -1333,7 +1333,7 @@ impl CpuCore {
         if let Err(f) = bus.try_write_byte(addr, value)
             && matches!(f.kind, BusFaultKind::BusError)
         {
-            self.trigger_bus_error(bus, addr, true, false);
+            self.trigger_bus_error(bus, addr, true, false, 1);
         }
     }
 
@@ -1366,9 +1366,7 @@ impl CpuCore {
                 ) {
                     Ok(p) => addr = self.address(p),
                     Err(f) => {
-                        self.handle_mmu_fault(
-                            bus, f, /*write=*/ true, /*instruction=*/ false,
-                        );
+                        self.handle_mmu_fault(bus, f, true, false, 2);
                         return;
                     }
                 }
@@ -1377,7 +1375,7 @@ impl CpuCore {
         if let Err(f) = bus.try_write_word(addr, value)
             && matches!(f.kind, BusFaultKind::BusError)
         {
-            self.trigger_bus_error(bus, addr, true, false);
+            self.trigger_bus_error(bus, addr, true, false, 2);
         }
     }
 
@@ -1410,9 +1408,7 @@ impl CpuCore {
                 ) {
                     Ok(p) => addr = self.address(p),
                     Err(f) => {
-                        self.handle_mmu_fault(
-                            bus, f, /*write=*/ true, /*instruction=*/ false,
-                        );
+                        self.handle_mmu_fault(bus, f, true, false, 4);
                         return;
                     }
                 }
@@ -1421,7 +1417,7 @@ impl CpuCore {
         if let Err(f) = bus.try_write_long(addr, value)
             && matches!(f.kind, BusFaultKind::BusError)
         {
-            self.trigger_bus_error(bus, addr, true, false);
+            self.trigger_bus_error(bus, addr, true, false, 4);
         }
     }
 
@@ -1431,6 +1427,7 @@ impl CpuCore {
         fault: crate::mmu::MmuFault,
         write: bool,
         instruction: bool,
+        size: u32,
     ) {
         use crate::core::exceptions::vector;
         use crate::mmu::MmuFaultKind;
@@ -1439,9 +1436,10 @@ impl CpuCore {
         // 1. exception_processing flag in translate() bypasses MMU during exception handling
         // 2. Double-fault detection in take_exception() halts CPU on recursive faults
 
+        self.pending_fault_cause = Some(fault.cause);
         match fault.kind {
             MmuFaultKind::BusError => {
-                self.trigger_bus_error(bus, fault.address, write, instruction)
+                self.trigger_bus_error(bus, fault.address, write, instruction, size)
             }
             MmuFaultKind::ConfigurationError => {
                 let _ = self.take_exception(bus, vector::MMU_CONFIGURATION_ERROR);
@@ -1458,7 +1456,7 @@ impl CpuCore {
                 // can restart it once the handler fixes the mapping (the 040
                 // gets a resumable format-7 frame; the 030 long bus-fault
                 // format-A/B frame is still the minimal fallback).
-                self.trigger_bus_error(bus, fault.address, write, instruction);
+                self.trigger_bus_error(bus, fault.address, write, instruction, size);
             }
         }
     }

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -439,6 +439,13 @@ impl CpuCore {
                 self.sr_mask = 0xF71F;
                 self.has_pmmu = true;
             }
+            CpuType::M68060 => {
+                self.address_mask = 0xFFFFFFFF;
+                // The 68060 drops T0 (trace on change of flow, SR bit 14) and
+                // keeps the single T bit and the M bit.
+                self.sr_mask = 0xB71F;
+                self.has_pmmu = true;
+            }
             _ => {}
         }
     }
@@ -947,11 +954,18 @@ impl CpuCore {
         )
     }
 
+    /// True for the 68060, which shares the 68040's MMU table format and
+    /// TC enable bit but drops PTEST/PMOVE and adds PLPA.
+    #[inline]
+    pub fn is_060(&self) -> bool {
+        self.cpu_type == CpuType::M68060
+    }
+
     /// Whether TC's translation-enable bit is set. The bit position differs by
-    /// part: the 68040 uses TC[15], the 68030 uses TC[31].
+    /// part: the 68040 and 68060 use TC[15], the 68030 uses TC[31].
     #[inline]
     pub fn tc_enable(&self) -> bool {
-        if self.is_040() {
+        if self.is_040() || self.is_060() {
             self.mmu_tc & 0x0000_8000 != 0
         } else {
             self.mmu_tc & 0x8000_0000 != 0

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -240,6 +240,10 @@ pub struct CpuCore {
     /// Initial cycles for timeslice
     pub initial_cycles: i32,
 
+    /// 68060 pipeline timing state: the branch cache (and, with pairing,
+    /// the pending pOEP head). Serialized - it changes cycle counts.
+    pub oep060: crate::core::timing_060::Oep060Timing,
+
     /// 68060 escape hatch: execute the instructions the 060 removed from
     /// silicon (MOVEP, CHK2/CMP2, CAS2, misaligned CAS, 64-bit MUL/DIV, and
     /// the unimplemented FPU subset) natively instead of trapping for the
@@ -435,6 +439,7 @@ impl CpuCore {
             pending_fault_cause: None,
             cycles_remaining: 0,
             initial_cycles: 0,
+            oep060: Default::default(),
             emulate_unimplemented_060: false,
             sst_m68000_compat: false,
         };
@@ -580,9 +585,11 @@ impl CpuCore {
         self.cacr = 0;
         self.cacr_pending_ops |= CACR_CI | CACR_CD;
         // 68060 control registers: identification/revision persist, the
-        // writable bits (EDEBUG/DFP/ESS) clear.
+        // writable bits (EDEBUG/DFP/ESS) clear. Reset invalidates the
+        // branch cache along with the other caches.
         self.pcr = PCR_060_RESET;
         self.buscr = 0;
+        self.oep060.branch_cache.clear_all();
         self.prefetch_queue = [0; 2];
         self.prefetch_count = 0;
         self.consume_without_prefetch = false;
@@ -963,18 +970,32 @@ impl CpuCore {
                     // the branch-cache model when it lands; accepted and
                     // discarded until then). Cache invalidation stays with
                     // CINV/CPUSH like the 040.
-                    CpuType::M68060 => (
-                        CACR_060_EDC
-                            | CACR_060_NAD
-                            | CACR_060_ESB
-                            | CACR_060_DPI
-                            | CACR_060_FOC
-                            | CACR_060_EBC
-                            | CACR_060_EIC
-                            | CACR_060_NAI
-                            | CACR_060_FIC,
-                        0,
-                    ),
+                    CpuType::M68060 => {
+                        // The branch-cache clear strobes act immediately and
+                        // never store; disabling EBC also clears the table so
+                        // re-enabling starts cold (software is required to
+                        // clear before re-enabling anyway).
+                        if value & CACR_060_CABC != 0 {
+                            self.oep060.branch_cache.clear_all();
+                        } else if value & CACR_060_CUBC != 0 {
+                            self.oep060.branch_cache.clear_user();
+                        }
+                        if self.cacr & CACR_060_EBC != 0 && value & CACR_060_EBC == 0 {
+                            self.oep060.branch_cache.clear_all();
+                        }
+                        (
+                            CACR_060_EDC
+                                | CACR_060_NAD
+                                | CACR_060_ESB
+                                | CACR_060_DPI
+                                | CACR_060_FOC
+                                | CACR_060_EBC
+                                | CACR_060_EIC
+                                | CACR_060_NAI
+                                | CACR_060_FIC,
+                            0,
+                        )
+                    }
                     // 68040 CACR defines only the two cache-enable bits and
                     // has no clear strobes - invalidation is done with the
                     // CINV/CPUSH instructions (see decode.rs). Reserved bits

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -235,6 +235,12 @@ pub struct CpuCore {
     /// Initial cycles for timeslice
     pub initial_cycles: i32,
 
+    /// 68060 escape hatch: execute the instructions the 060 removed from
+    /// silicon (MOVEP, CHK2/CMP2, CAS2, misaligned CAS, 64-bit MUL/DIV, and
+    /// the unimplemented FPU subset) natively instead of trapping for the
+    /// OS-side 68060 software package. False = faithful traps.
+    pub emulate_unimplemented_060: bool,
+
     /// When enabled, use SingleStepTests/MAME-derived semantics for a few edge cases where
     /// Musashi and MAME fixtures intentionally differ (notably BCD "invalid digit" behavior and
     pub sst_m68000_compat: bool,
@@ -423,6 +429,7 @@ impl CpuCore {
             atc: crate::mmu::Atc::default(),
             cycles_remaining: 0,
             initial_cycles: 0,
+            emulate_unimplemented_060: false,
             sst_m68000_compat: false,
         };
         cpu.set_cpu_type(CpuType::M68000);
@@ -1039,6 +1046,13 @@ impl CpuCore {
             self.cpu_type,
             CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040
         )
+    }
+
+    /// Whether an instruction the 68060 dropped from silicon must take the
+    /// unimplemented-integer trap (vector 61) rather than execute natively.
+    #[inline]
+    pub(crate) fn trap_unimpl_int_060(&self) -> bool {
+        self.cpu_type == CpuType::M68060 && !self.emulate_unimplemented_060
     }
 
     /// True for the 68060, which shares the 68040's MMU table format and

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -1048,10 +1048,11 @@ impl CpuCore {
         )
     }
 
-    /// Whether an instruction the 68060 dropped from silicon must take the
-    /// unimplemented-integer trap (vector 61) rather than execute natively.
+    /// Whether an instruction the 68060 dropped from silicon must take its
+    /// unimplemented trap (vector 61 for integer, the FP-unimplemented
+    /// family for FPU ops) rather than execute natively.
     #[inline]
-    pub(crate) fn trap_unimpl_int_060(&self) -> bool {
+    pub(crate) fn trap_unimpl_060(&self) -> bool {
         self.cpu_type == CpuType::M68060 && !self.emulate_unimplemented_060
     }
 

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -141,6 +141,7 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 | CpuType::M68EC040
                 | CpuType::M68LC040
                 | CpuType::M68040
+                | CpuType::M68060
         );
         if !supports_move16 {
             return illegal_instruction(cpu, bus);
@@ -166,17 +167,18 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             | CpuType::M68EC040
             | CpuType::M68LC040
             | CpuType::M68040
+            | CpuType::M68060
     );
     if is_cache_cpu && (opcode >> 8) & 0xF == 4 {
         // Check for supervisor mode (cache ops are privileged)
         if !cpu.is_supervisor() {
             return cpu.take_exception(bus, 8); // Privilege violation
         }
-        let is_68040 = matches!(
+        let has_cinv_cpush = matches!(
             cpu.cpu_type,
-            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040
+            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040 | CpuType::M68060
         );
-        if is_68040 {
+        if has_cinv_cpush {
             let caches = (opcode >> 6) & 0b11;
             if caches & 0b01 != 0 {
                 cpu.cacr_pending_ops |= super::cpu::CACR_CD; // clear data cache

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -617,6 +617,26 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
 // Group 4: Miscellaneous
 // ============================================================================
 
+/// MOVEC Rc-code legality per CPU model. The 68040 accepts everything its
+/// register table decodes; the 68060 drops CAAR, MMUSR, MSP, and ISP (single
+/// supervisor stack) and gains BUSCR (0x008) and PCR (0x808).
+fn movec_reg_legal(cpu_type: CpuType, ctrl_reg: u16) -> bool {
+    match cpu_type {
+        CpuType::M68010 | CpuType::SCC68070 => {
+            matches!(ctrl_reg, 0x000 | 0x001 | 0x800 | 0x801)
+        }
+        CpuType::M68EC020 | CpuType::M68020 | CpuType::M68EC030 | CpuType::M68030 => matches!(
+            ctrl_reg,
+            0x000 | 0x001 | 0x002 | 0x800 | 0x801 | 0x802 | 0x803 | 0x804
+        ),
+        CpuType::M68060 => matches!(
+            ctrl_reg,
+            0x000..=0x008 | 0x800 | 0x801 | 0x806 | 0x807 | 0x808
+        ),
+        _ => true,
+    }
+}
+
 fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) -> i32 {
     let subop = (opcode >> 8) & 0xF;
     let ea_mode = ((opcode >> 3) & 7) as u8;
@@ -837,25 +857,7 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             let reg_type = (ext >> 15) & 1; // 0=Dn, 1=An
             let reg_num = ((ext >> 12) & 7) as usize;
             let ctrl_reg = ext & 0xFFF;
-            if matches!(cpu.cpu_type, CpuType::M68010 | CpuType::SCC68070)
-                && !matches!(ctrl_reg, 0x000 | 0x001 | 0x800 | 0x801)
-            {
-                return illegal_instruction(cpu, bus);
-            }
-            if matches!(cpu.cpu_type, CpuType::M68EC020 | CpuType::M68020)
-                && !matches!(
-                    ctrl_reg,
-                    0x000 | 0x001 | 0x002 | 0x800 | 0x801 | 0x802 | 0x803 | 0x804
-                )
-            {
-                return illegal_instruction(cpu, bus);
-            }
-            if matches!(cpu.cpu_type, CpuType::M68EC030 | CpuType::M68030)
-                && !matches!(
-                    ctrl_reg,
-                    0x000 | 0x001 | 0x002 | 0x800 | 0x801 | 0x802 | 0x803 | 0x804
-                )
-            {
+            if !movec_reg_legal(cpu.cpu_type, ctrl_reg) {
                 return illegal_instruction(cpu, bus);
             }
             if !cpu.is_supervisor() {
@@ -879,25 +881,7 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             let reg_type = (ext >> 15) & 1; // 0=Dn, 1=An
             let reg_num = ((ext >> 12) & 7) as usize;
             let ctrl_reg = ext & 0xFFF;
-            if matches!(cpu.cpu_type, CpuType::M68010 | CpuType::SCC68070)
-                && !matches!(ctrl_reg, 0x000 | 0x001 | 0x800 | 0x801)
-            {
-                return illegal_instruction(cpu, bus);
-            }
-            if matches!(cpu.cpu_type, CpuType::M68EC020 | CpuType::M68020)
-                && !matches!(
-                    ctrl_reg,
-                    0x000 | 0x001 | 0x002 | 0x800 | 0x801 | 0x802 | 0x803 | 0x804
-                )
-            {
-                return illegal_instruction(cpu, bus);
-            }
-            if matches!(cpu.cpu_type, CpuType::M68EC030 | CpuType::M68030)
-                && !matches!(
-                    ctrl_reg,
-                    0x000 | 0x001 | 0x002 | 0x800 | 0x801 | 0x802 | 0x803 | 0x804
-                )
-            {
+            if !movec_reg_legal(cpu.cpu_type, ctrl_reg) {
                 return illegal_instruction(cpu, bus);
             }
             if !cpu.is_supervisor() {

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -254,6 +254,23 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         return 4;
     }
 
+    // LPSTOP #imm (68060 only): F800 / 01C0 / SR word. Privileged; loads
+    // SR and stops until an interrupt or reset, like STOP with a low-power
+    // bus broadcast (the bus indication is not modeled). A wrong extension
+    // word is an undefined F-line.
+    if cpu.is_060() && opcode == 0xF800 {
+        if cpu.read_16(bus, cpu.pc) != 0x01C0 {
+            return FLINE_TRAP_SENTINEL;
+        }
+        if !cpu.is_supervisor() {
+            return cpu.exception_privilege(bus);
+        }
+        let _ = cpu.read_imm_16(bus); // consume the 01C0 extension
+        let sr = cpu.read_imm_16(bus);
+        cpu.stop(sr);
+        return 4;
+    }
+
     // PMMU/COP0 opcodes are in the 0xF0xx/0xF1xx range (1111 000? .... ....) and are further
     // subdivided by (opcode>>9)&7. Group 0 carries PMOVE/PFLUSH/PTEST/etc with an extension word.
     if ((opcode >> 9) & 0x7) == 0 {

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -344,6 +344,11 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         {
             return illegal_instruction(cpu, bus);
         }
+        // CAS2 was dropped from 68060 silicon; trap before any extension
+        // word is consumed so the 68060SP handler can re-decode it.
+        if cpu.trap_unimpl_int_060() {
+            return cpu.take_exception(bus, super::exceptions::vector::UNIMPLEMENTED_INTEGER);
+        }
         return cpu.exec_cas2(bus, opcode);
     }
     // CAS: 0000 1ss0 11 mmm rrr with extension word (Du/Dc)
@@ -415,6 +420,10 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         if cpu.is_pre_68020 {
             return illegal_instruction(cpu, bus);
         }
+        // CHK2/CMP2 were dropped from 68060 silicon.
+        if cpu.trap_unimpl_int_060() {
+            return cpu.take_exception(bus, super::exceptions::vector::UNIMPLEMENTED_INTEGER);
+        }
         return cpu.exec_cmp2_chk2(bus, opcode);
     }
 
@@ -422,6 +431,11 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
     // 0000 ddd 1 s 0 0 1 aaa  with extension word = displacement (d16,An)
     // s: 0=word, 1=long. direction: bit7 (0=mem->reg, 1=reg->mem)
     if (opcode & 0xF138) == 0x0108 {
+        // MOVEP was dropped from 68060 silicon; trap before the displacement
+        // word is consumed and before any register or memory access.
+        if cpu.trap_unimpl_int_060() {
+            return cpu.take_exception(bus, super::exceptions::vector::UNIMPLEMENTED_INTEGER);
+        }
         let dreg = ((opcode >> 9) & 7) as usize;
         let areg = (opcode & 7) as usize;
         let is_long = (opcode & 0x0040) != 0;

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -828,6 +828,29 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                                     cpu.set_sr(sr);
                                     return 20;
                                 }
+                                4 if cpu.is_060() => {
+                                    // 68060 access-error / FP-disabled frame
+                                    // (8 words): discard EA and FSLW.
+                                    let sr = cpu.pull_16(bus);
+                                    cpu.pc = cpu.pull_32(bus);
+                                    let _ = cpu.pull_16(bus); // format word
+                                    cpu.dar[15] = cpu.dar[15].wrapping_add(8);
+                                    cpu.set_sr(sr);
+                                    return 20;
+                                }
+                                7 if cpu.is_040() => {
+                                    // 68040 access-error frame (30 words):
+                                    // discard EA/SSW/writeback state. The
+                                    // faulting instruction was rolled back at
+                                    // frame-build time, so a plain restart is
+                                    // the whole continuation.
+                                    let sr = cpu.pull_16(bus);
+                                    cpu.pc = cpu.pull_32(bus);
+                                    let _ = cpu.pull_16(bus); // format word
+                                    cpu.dar[15] = cpu.dar[15].wrapping_add(52);
+                                    cpu.set_sr(sr);
+                                    return 20;
+                                }
                                 _ => {
                                     return cpu.take_exception(bus, 14); // format error
                                 }

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -198,6 +198,38 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         if !cpu.is_supervisor() {
             return cpu.take_exception(bus, 8); // Privilege violation
         }
+        if cpu.is_060() {
+            // PLPAW (F588+An) / PLPAR (F5C8+An): translate the logical
+            // address in An (address space from DFC) and write the physical
+            // address back to An. These replace PTEST on the 68060.
+            if (opcode & 0xFFF0) == 0xF580 || (opcode & 0xFFF0) == 0xF5C0 {
+                let write = (opcode & 0x0040) == 0; // F588 = PLPAW
+                let an = 8 + (opcode & 7) as usize;
+                let addr = cpu.dar[an];
+                let supervisor = (cpu.dfc & 4) != 0;
+                match crate::mmu::translate_address(cpu, bus, addr, write, supervisor, false) {
+                    Ok(phys) => {
+                        cpu.dar[an] = phys;
+                        return 4;
+                    }
+                    Err(fault) => {
+                        // Access error, format $4: An is untouched (the
+                        // rollback keeps it) so the handler can map the
+                        // page and restart the PLPA.
+                        cpu.handle_mmu_fault(bus, fault, write, false, 4);
+                        return 50;
+                    }
+                }
+            }
+            if (opcode & 0x00C0) == 0 {
+                // PFLUSH/PFLUSHN/PFLUSHA/PFLUSHAN: flush-all pragmatism as
+                // on the 040 (over-flushing only costs re-walks).
+                cpu.atc.flush_all();
+                return 4;
+            }
+            // PTEST was dropped from 68060 silicon: undefined F-line.
+            return FLINE_TRAP_SENTINEL;
+        }
         if cpu.is_040() && (opcode & 0x0040) != 0 {
             // PTEST: walk the page for An and report it in MMUSR. We model the
             // physical-address and resident (R) bits, enough for an OS to tell a

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -241,6 +241,11 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         let w2 = cpu.read_imm_16(bus);
         let cond = (w2 & 0x3F) as u8;
         if ea_mode == 1 {
+            // FDBcc was dropped from 68060 silicon (68060SP emulates it).
+            if cpu.trap_unimpl_060() {
+                cpu.pc = cpu.pc.wrapping_add(2); // skip the displacement word
+                return cpu.take_fp_unimp_060(bus, 0);
+            }
             return cpu.exec_fdbcc(bus, ea_reg, cond);
         }
         if ea_mode == 7 && (2..=4).contains(&ea_reg) {
@@ -249,7 +254,16 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 3 => 2,
                 _ => 0,
             };
+            // FTRAPcc was dropped from 68060 silicon.
+            if cpu.trap_unimpl_060() {
+                cpu.pc = cpu.pc.wrapping_add(2 * imm_words);
+                return cpu.take_fp_unimp_060(bus, 0);
+            }
             return cpu.exec_ftrapcc(bus, cond, imm_words);
+        }
+        // FScc was dropped from 68060 silicon.
+        if cpu.trap_unimpl_060() {
+            return cpu.fpu_060_scc_trap(bus, ea_mode, ea_reg as usize);
         }
         return cpu.exec_fscc(bus, ea_mode, ea_reg, cond);
     }
@@ -346,7 +360,7 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         }
         // CAS2 was dropped from 68060 silicon; trap before any extension
         // word is consumed so the 68060SP handler can re-decode it.
-        if cpu.trap_unimpl_int_060() {
+        if cpu.trap_unimpl_060() {
             return cpu.take_exception(bus, super::exceptions::vector::UNIMPLEMENTED_INTEGER);
         }
         return cpu.exec_cas2(bus, opcode);
@@ -421,7 +435,7 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             return illegal_instruction(cpu, bus);
         }
         // CHK2/CMP2 were dropped from 68060 silicon.
-        if cpu.trap_unimpl_int_060() {
+        if cpu.trap_unimpl_060() {
             return cpu.take_exception(bus, super::exceptions::vector::UNIMPLEMENTED_INTEGER);
         }
         return cpu.exec_cmp2_chk2(bus, opcode);
@@ -433,7 +447,7 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
     if (opcode & 0xF138) == 0x0108 {
         // MOVEP was dropped from 68060 silicon; trap before the displacement
         // word is consumed and before any register or memory access.
-        if cpu.trap_unimpl_int_060() {
+        if cpu.trap_unimpl_060() {
             return cpu.take_exception(bus, super::exceptions::vector::UNIMPLEMENTED_INTEGER);
         }
         let dreg = ((opcode >> 9) & 7) as usize;

--- a/crates/m68k/src/core/ea.rs
+++ b/crates/m68k/src/core/ea.rs
@@ -308,9 +308,7 @@ impl CpuCore {
             ) {
                 Ok(p) => addr = self.address(p),
                 Err(f) => {
-                    self.handle_mmu_fault(
-                        bus, f, /*write=*/ false, /*instruction=*/ true,
-                    );
+                    self.handle_mmu_fault(bus, f, false, true, 2);
                     return 0;
                 }
             }
@@ -321,7 +319,7 @@ impl CpuCore {
                 v
             }
             Err(_) => {
-                self.trigger_bus_error(bus, addr, false, true);
+                self.trigger_bus_error(bus, addr, false, true, 2);
                 0
             }
         }
@@ -378,9 +376,7 @@ impl CpuCore {
             ) {
                 Ok(p) => addr = self.address(p),
                 Err(f) => {
-                    self.handle_mmu_fault(
-                        bus, f, /*write=*/ false, /*instruction=*/ true,
-                    );
+                    self.handle_mmu_fault(bus, f, false, true, 4);
                     return 0;
                 }
             }
@@ -391,7 +387,7 @@ impl CpuCore {
                 v
             }
             Err(_) => {
-                self.trigger_bus_error(bus, addr, false, true);
+                self.trigger_bus_error(bus, addr, false, true, 4);
                 0
             }
         }

--- a/crates/m68k/src/core/ea.rs
+++ b/crates/m68k/src/core/ea.rs
@@ -276,6 +276,7 @@ impl CpuCore {
                 | CpuType::M68EC040
                 | CpuType::M68LC040
                 | CpuType::M68040
+                | CpuType::M68060
         )
     }
 

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -26,6 +26,11 @@ pub mod vector {
     pub const SPURIOUS_INTERRUPT: u32 = 24;
     pub const TRAP_BASE: u32 = 32;
 
+    /// 68060: integer instructions removed from silicon (MOVEP, CHK2/CMP2,
+    /// CAS2, misaligned CAS, 64-bit MUL/DIV) trap here for the OS-side
+    /// 68060 software package to emulate.
+    pub const UNIMPLEMENTED_INTEGER: u32 = 61;
+
     // 68020+ MMU exceptions (vector numbers per 68k docs; used by 68030/68040 PMMU).
     pub const MMU_CONFIGURATION_ERROR: u32 = 56;
     pub const MMU_ILLEGAL_OPERATION_ERROR: u32 = 57;

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -44,6 +44,78 @@ pub mod vector {
     pub const MMU_ACCESS_LEVEL_VIOLATION_ERROR: u32 = 58;
 }
 
+/// 68060 fault status long word (FSLW) bits, as consumed by OS fault
+/// handlers (bit names per MC68060UM Table 8-9 / Linux asm/traps.h).
+pub mod fslw {
+    /// Read access.
+    pub const RW_R: u32 = 0x0100_0000;
+    /// Write access.
+    pub const RW_W: u32 = 0x0080_0000;
+    /// Transfer size shift (bits 22-21): 00 long, 01 byte, 10 word.
+    pub const SIZE_SHIFT: u32 = 21;
+    /// Transfer modifier shift (bits 18-16): holds the function code.
+    pub const TM_SHIFT: u32 = 16;
+    /// Instruction (1) or operand (0) access.
+    pub const IO: u32 = 0x0000_8000;
+    /// Invalid descriptor in the root (level A) table.
+    pub const PTA: u32 = 0x0000_1000;
+    /// Invalid descriptor in the pointer (level B) table.
+    pub const PTB: u32 = 0x0000_0800;
+    /// Invalid indirect page descriptor.
+    pub const IL: u32 = 0x0000_0400;
+    /// Page fault (invalid page descriptor).
+    pub const PF: u32 = 0x0000_0200;
+    /// Supervisor protection violation.
+    pub const SP: u32 = 0x0000_0100;
+    /// Write protection violation.
+    pub const WP: u32 = 0x0000_0080;
+    /// Bus error on table search.
+    pub const TWE: u32 = 0x0000_0040;
+    /// Bus error on read.
+    pub const RE: u32 = 0x0000_0020;
+    /// Bus error on write.
+    pub const WE: u32 = 0x0000_0010;
+}
+
+/// Compose the 68060 FSLW for an access error.
+fn fslw_060(
+    write: bool,
+    instruction: bool,
+    size: u32,
+    fc: u16,
+    cause: Option<crate::mmu::MmuFaultCause>,
+) -> u32 {
+    use crate::mmu::MmuFaultCause;
+    let mut w = if write { fslw::RW_W } else { fslw::RW_R };
+    w |= match size {
+        1 => 0b01 << fslw::SIZE_SHIFT,
+        2 => 0b10 << fslw::SIZE_SHIFT,
+        _ => 0, // long
+    };
+    w |= u32::from(fc & 7) << fslw::TM_SHIFT;
+    if instruction {
+        w |= fslw::IO;
+    }
+    w |= match cause {
+        Some(MmuFaultCause::PointerA) => fslw::PTA,
+        Some(MmuFaultCause::PointerB) => fslw::PTB,
+        Some(MmuFaultCause::Indirect) => fslw::IL,
+        Some(MmuFaultCause::PageFault) => fslw::PF,
+        Some(MmuFaultCause::WriteProtect) => fslw::WP,
+        Some(MmuFaultCause::SupervisorProtect) => fslw::SP,
+        Some(MmuFaultCause::TableWalkBusError) => fslw::TWE,
+        // A physical bus error on the access itself.
+        Some(MmuFaultCause::AccessBusError) | None => {
+            if write {
+                fslw::WE
+            } else {
+                fslw::RE
+            }
+        }
+    };
+    w
+}
+
 /// Function code bits for exception stack frames.
 pub mod fc {
     pub const USER_DATA: u16 = 1;
@@ -283,6 +355,8 @@ impl CpuCore {
         address: u32,
         write: bool,
         instruction: bool,
+        size: u32,
+        cause: Option<crate::mmu::MmuFaultCause>,
     ) -> i32 {
         let old_sr = self.get_sr();
         let was_supervisor = (old_sr & 0x2000) != 0;
@@ -332,6 +406,20 @@ impl CpuCore {
                 self.push_32_raw(bus, self.ppc);
                 self.push_16_raw(bus, old_sr);
                 let _ = (status_word, address); // currently unused in this placeholder
+            }
+            _ if self.is_060() => {
+                // 68060 access-error stack frame (format $4, 8 words): the
+                // fault address long at +$08 and the fault status long word
+                // (FSLW) at +$0C. The instruction has been rolled back, so
+                // RTE restarts it (same demand-paging model as the 040).
+                let fslw = fslw_060(write, instruction, size, fc, cause);
+                let fmt_vec = 0x4000 | ((vector::BUS_ERROR as u16) << 2);
+                self.push_32_raw(bus, fslw);
+                self.push_32_raw(bus, address);
+                self.push_16_raw(bus, fmt_vec);
+                self.push_32_raw(bus, self.ppc); // restart PC
+                self.push_16_raw(bus, old_sr);
+                let _ = status_word;
             }
             _ if self.is_040() => {
                 // 68040 access-error stack frame (format 7, 30 words). The

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -30,6 +30,13 @@ pub mod vector {
     /// CAS2, misaligned CAS, 64-bit MUL/DIV) trap here for the OS-side
     /// 68060 software package to emulate.
     pub const UNIMPLEMENTED_INTEGER: u32 = 61;
+    /// 68060: FP operand data types the FPU no longer handles in hardware
+    /// (packed decimal, denormals) - pre-instruction, format $0.
+    pub const FP_UNSUPP_DATA_TYPE: u32 = 55;
+    /// 68060: FP addressing forms dropped from silicon (dynamic-list
+    /// FMOVEM, immediate packed operands, multi-register control-list
+    /// FMOVEM.L #imm) - pre-instruction, format $0.
+    pub const FP_UNIMPLEMENTED_EA: u32 = 60;
 
     // 68020+ MMU exceptions (vector numbers per 68k docs; used by 68030/68040 PMMU).
     pub const MMU_CONFIGURATION_ERROR: u32 = 56;
@@ -435,6 +442,48 @@ impl CpuCore {
         self.exception_processing = false;
 
         self.exception_cycles(vector)
+    }
+
+    /// 68060 "FP unimplemented instruction" exception: Line-F vector with
+    /// the six-word format $2 frame the 68060SP dispatches on (fmt/vector
+    /// word $202C). The frame's PC is the NEXT instruction (every extension
+    /// word must be consumed before calling this), the EA field holds the
+    /// calculated operand address (0 when the operand is not in memory),
+    /// and FPIAR points at the faulting instruction - the 060SP fetches
+    /// the opcode through FPIAR, not the frame.
+    pub(crate) fn take_fp_unimp_060<B: AddressBus>(&mut self, bus: &mut B, ea: u32) -> i32 {
+        self.fpiar = self.ppc;
+        let old_sr = self.get_sr();
+        self.set_s_flag(SFLAG_SET);
+        self.t1_flag = 0;
+        self.t0_flag = 0;
+        let vec_word = (vector::LINE_1111 as u16) << 2;
+        self.push_32(bus, ea);
+        self.push_16(bus, 0x2000 | (vec_word & 0x0FFF));
+        self.push_32(bus, self.pc);
+        self.push_16(bus, old_sr);
+        self.jump_vector(bus, vector::LINE_1111);
+        self.exception_cycles(vector::LINE_1111)
+    }
+
+    /// 68060 "FPU disabled" exception (PCR.DFP set, or an LC/EC060): the
+    /// eight-word format $4 frame ($402C) whose +$0C long holds the PC of
+    /// the faulted instruction so the OS can enable the FPU and restart.
+    /// The stacked PC also restarts the instruction; FPIAR is untouched
+    /// (the FPU never saw the instruction).
+    pub(crate) fn take_fp_disabled_060<B: AddressBus>(&mut self, bus: &mut B) -> i32 {
+        let old_sr = self.get_sr();
+        self.set_s_flag(SFLAG_SET);
+        self.t1_flag = 0;
+        self.t0_flag = 0;
+        let vec_word = (vector::LINE_1111 as u16) << 2;
+        self.push_32(bus, self.ppc); // PC of the faulted instruction
+        self.push_32(bus, 0); // effective address (unused for disabled)
+        self.push_16(bus, 0x4000 | (vec_word & 0x0FFF));
+        self.push_32(bus, self.ppc); // restart the instruction
+        self.push_16(bus, old_sr);
+        self.jump_vector(bus, vector::LINE_1111);
+        self.exception_cycles(vector::LINE_1111)
     }
 
     /// Get cycles for exception processing.

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -436,6 +436,7 @@ impl CpuCore {
                 | super::types::CpuType::M68EC040
                 | super::types::CpuType::M68LC040
                 | super::types::CpuType::M68040
+                | super::types::CpuType::M68060
         );
         if is_ec020_plus && self.m_flag != 0 {
             self.set_sm_flag(SFLAG_SET); // clear M => ISP active

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -436,7 +436,6 @@ impl CpuCore {
                 | super::types::CpuType::M68EC040
                 | super::types::CpuType::M68LC040
                 | super::types::CpuType::M68040
-                | super::types::CpuType::M68060
         );
         if is_ec020_plus && self.m_flag != 0 {
             self.set_sm_flag(SFLAG_SET); // clear M => ISP active
@@ -444,6 +443,10 @@ impl CpuCore {
             self.push_16(bus, 0x1000 | (vec_word & 0x0FFF));
             self.push_32(bus, stacked_pc);
             self.push_16(bus, sr2);
+        } else if self.cpu_type == super::types::CpuType::M68060 && self.m_flag != 0 {
+            // The 68060 clears M on interrupt entry but has a single
+            // supervisor stack: no bank switch and no throwaway frame.
+            self.m_flag = 0;
         }
 
         // Jump to vector

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -72,7 +72,7 @@ impl CpuCore {
             // Auto-take all trap exceptions, extract cycles
             use crate::core::types::InternalStepResult;
             let cycles = match result {
-                InternalStepResult::Ok { cycles } => self.scale_cycles_for_cpu_type(cycles),
+                InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles),
                 InternalStepResult::AlineTrap { .. } => self.take_aline_exception(bus),
                 InternalStepResult::FlineTrap { .. } => self.take_fline_exception(bus),
                 InternalStepResult::TrapInstruction { trap_num } => {
@@ -145,7 +145,7 @@ impl CpuCore {
 
         let res = match result {
             InternalStepResult::Ok { cycles } => StepResult::Ok {
-                cycles: self.scale_cycles_for_cpu_type(cycles),
+                cycles: self.finalize_cycles(cycles),
             },
             InternalStepResult::AlineTrap { opcode } => StepResult::AlineTrap { opcode },
             InternalStepResult::FlineTrap { opcode } => StepResult::FlineTrap { opcode },
@@ -237,7 +237,7 @@ impl CpuCore {
 
         // Handle trap results via callbacks, fallback to exception if not handled
         let cycles = match result {
-            InternalStepResult::Ok { cycles } => self.scale_cycles_for_cpu_type(cycles),
+            InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles),
             InternalStepResult::AlineTrap { opcode } => {
                 if !handler.handle_aline(self, bus, opcode) {
                     self.take_aline_exception(bus)

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -66,13 +66,15 @@ impl CpuCore {
                 continue;
             }
 
-            // Dispatch instruction
+            // Dispatch instruction (sampling whether the opcode fetch
+            // hit the icache before dispatch consumes more of the stream).
+            let fetch_cached = bus.last_fetch_was_cached();
             let result = dispatch_instruction(self, bus, self.ir as u16);
 
             // Auto-take all trap exceptions, extract cycles
             use crate::core::types::InternalStepResult;
             let cycles = match result {
-                InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles),
+                InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles, fetch_cached),
                 InternalStepResult::AlineTrap { .. } => self.take_aline_exception(bus),
                 InternalStepResult::FlineTrap { .. } => self.take_fline_exception(bus),
                 InternalStepResult::TrapInstruction { trap_num } => {
@@ -141,11 +143,12 @@ impl CpuCore {
             return StepResult::Ok { cycles: 0 };
         }
 
+        let fetch_cached = bus.last_fetch_was_cached();
         let result = dispatch_instruction(self, bus, self.ir as u16);
 
         let res = match result {
             InternalStepResult::Ok { cycles } => StepResult::Ok {
-                cycles: self.finalize_cycles(cycles),
+                cycles: self.finalize_cycles(cycles, fetch_cached),
             },
             InternalStepResult::AlineTrap { opcode } => StepResult::AlineTrap { opcode },
             InternalStepResult::FlineTrap { opcode } => StepResult::FlineTrap { opcode },
@@ -233,15 +236,19 @@ impl CpuCore {
             return StepResult::Ok { cycles: 0 };
         }
 
+        let fetch_cached = bus.last_fetch_was_cached();
         let result = dispatch_instruction(self, bus, self.ir as u16);
 
         // Handle trap results via callbacks, fallback to exception if not handled
         let cycles = match result {
-            InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles),
+            InternalStepResult::Ok { cycles } => self.finalize_cycles(cycles, fetch_cached),
             InternalStepResult::AlineTrap { opcode } => {
                 if !handler.handle_aline(self, bus, opcode) {
                     self.take_aline_exception(bus)
                 } else {
+                    // On real hardware this is an exception: no pairing
+                    // window survives it.
+                    self.break_060_pipeline();
                     0 // HLE handled, 0 cycles for now
                 }
             }
@@ -249,6 +256,7 @@ impl CpuCore {
                 if !handler.handle_fline(self, bus, opcode) {
                     self.take_fline_exception(bus)
                 } else {
+                    self.break_060_pipeline();
                     0
                 }
             }
@@ -344,6 +352,8 @@ impl CpuCore {
 
     /// Jump to an exception vector.
     pub fn jump_vector<B: AddressBus>(&mut self, bus: &mut B, vector: u32) {
+        // Any exception entry breaks an open 68060 pairing window.
+        self.break_060_pipeline();
         self.last_exception_vector = Some(vector);
         let addr = (vector << 2).wrapping_add(self.vbr);
         self.pc = self.read_32(bus, addr);
@@ -466,6 +476,7 @@ impl CpuCore {
 
     /// Stop the CPU (STOP instruction).
     pub fn stop(&mut self, new_sr: u16) {
+        self.break_060_pipeline();
         self.set_sr(new_sr);
         self.stopped |= STOP_LEVEL_STOP;
     }

--- a/crates/m68k/src/core/instructions/compare_swap.rs
+++ b/crates/m68k/src/core/instructions/compare_swap.rs
@@ -54,7 +54,7 @@ impl CpuCore {
             }
             _ => (self.get_ea_address(bus, mode, size), None),
         };
-        if size != Size::Byte && (addr & 1) != 0 && self.trap_unimpl_int_060() {
+        if size != Size::Byte && (addr & 1) != 0 && self.trap_unimpl_060() {
             return self
                 .take_exception(bus, crate::core::exceptions::vector::UNIMPLEMENTED_INTEGER);
         }

--- a/crates/m68k/src/core/instructions/compare_swap.rs
+++ b/crates/m68k/src/core/instructions/compare_swap.rs
@@ -29,7 +29,38 @@ impl CpuCore {
         }
 
         let size = decode_cas_size(opcode);
-        let addr = self.get_ea_address(bus, mode, size);
+        // Resolve the operand address with post-increment/pre-decrement
+        // commits deferred: a misaligned CAS was dropped from 68060 silicon
+        // and must trap with no architectural state changed, so the 68060SP
+        // handler can emulate the whole instruction.
+        let (addr, ea_commit) = match mode {
+            AddressingMode::PostIncrement(reg) => {
+                let addr = self.a(reg as usize);
+                let inc = if reg == 7 && size == Size::Byte {
+                    2 // A7 always stays word-aligned
+                } else {
+                    size.bytes()
+                };
+                (addr, Some((reg as usize, addr.wrapping_add(inc))))
+            }
+            AddressingMode::PreDecrement(reg) => {
+                let dec = if reg == 7 && size == Size::Byte {
+                    2
+                } else {
+                    size.bytes()
+                };
+                let addr = self.a(reg as usize).wrapping_sub(dec);
+                (addr, Some((reg as usize, addr)))
+            }
+            _ => (self.get_ea_address(bus, mode, size), None),
+        };
+        if size != Size::Byte && (addr & 1) != 0 && self.trap_unimpl_int_060() {
+            return self
+                .take_exception(bus, crate::core::exceptions::vector::UNIMPLEMENTED_INTEGER);
+        }
+        if let Some((reg, value)) = ea_commit {
+            self.set_a(reg, value);
+        }
         let mem = match size {
             Size::Byte => self.read_8(bus, addr) as u32,
             Size::Word => self.read_16(bus, addr) as u32,

--- a/crates/m68k/src/core/instructions/mul_div_long.rs
+++ b/crates/m68k/src/core/instructions/mul_div_long.rs
@@ -23,7 +23,7 @@ impl CpuCore {
         let use_64 = (ext & 0x0400) != 0;
         // The 64/32 form was dropped from 68060 silicon; trap before the
         // divisor EA is touched (no zero-divide evaluation either).
-        if use_64 && self.trap_unimpl_int_060() {
+        if use_64 && self.trap_unimpl_060() {
             return self.take_exception(bus, crate::core::exceptions::vector::UNIMPLEMENTED_INTEGER);
         }
         let dq = ((ext >> 12) & 7) as usize;
@@ -110,7 +110,7 @@ impl CpuCore {
         // The 64-bit-result form was dropped from 68060 silicon (the 32-bit
         // form stays native). The consumed extension word is harmless: the
         // trap stacks the instruction address and the handler re-decodes.
-        if wide && self.trap_unimpl_int_060() {
+        if wide && self.trap_unimpl_060() {
             return self.take_exception(bus, crate::core::exceptions::vector::UNIMPLEMENTED_INTEGER);
         }
         let dl = ((ext >> 12) & 7) as usize;

--- a/crates/m68k/src/core/instructions/mul_div_long.rs
+++ b/crates/m68k/src/core/instructions/mul_div_long.rs
@@ -21,6 +21,11 @@ impl CpuCore {
 
         let signed = (ext & 0x0800) != 0;
         let use_64 = (ext & 0x0400) != 0;
+        // The 64/32 form was dropped from 68060 silicon; trap before the
+        // divisor EA is touched (no zero-divide evaluation either).
+        if use_64 && self.trap_unimpl_int_060() {
+            return self.take_exception(bus, crate::core::exceptions::vector::UNIMPLEMENTED_INTEGER);
+        }
         let dq = ((ext >> 12) & 7) as usize;
         let dr = (ext & 7) as usize;
 
@@ -102,6 +107,12 @@ impl CpuCore {
 
         let signed = (ext & 0x0800) != 0;
         let wide = (ext & 0x0400) != 0;
+        // The 64-bit-result form was dropped from 68060 silicon (the 32-bit
+        // form stays native). The consumed extension word is harmless: the
+        // trap stacks the instruction address and the handler re-decodes.
+        if wide && self.trap_unimpl_int_060() {
+            return self.take_exception(bus, crate::core::exceptions::vector::UNIMPLEMENTED_INTEGER);
+        }
         let dl = ((ext >> 12) & 7) as usize;
         let dh = (ext & 7) as usize;
 

--- a/crates/m68k/src/core/memory.rs
+++ b/crates/m68k/src/core/memory.rs
@@ -82,6 +82,14 @@ pub trait AddressBus {
     fn try_read_immediate_long(&mut self, address: u32) -> Result<u32, BusFault> {
         Ok(self.read_immediate_long(address))
     }
+    /// Whether the most recent instruction-stream read was served from the
+    /// CPU's instruction cache. The 68060 timing model gates superscalar
+    /// pairing and branch folding on a cached fetch stream; plain test
+    /// buses default to true (pair freely).
+    fn last_fetch_was_cached(&self) -> bool {
+        true
+    }
+
     fn interrupt_acknowledge(&mut self, _level: u8) -> u32 {
         0xFFFF_FFFF
     }

--- a/crates/m68k/src/core/mod.rs
+++ b/crates/m68k/src/core/mod.rs
@@ -14,4 +14,5 @@ pub mod memory;
 pub mod registers;
 pub mod status;
 pub mod timing;
+pub mod timing_060;
 pub mod types;

--- a/crates/m68k/src/core/timing_060.rs
+++ b/crates/m68k/src/core/timing_060.rs
@@ -585,9 +585,15 @@ impl CpuCore {
             } else {
                 flowed
             };
+            // A folded branch needs an instruction to fold onto: only an
+            // open pairing window lets it retire for free. This also
+            // guarantees progress - a bare predicted `bra self` idle loop
+            // still costs a clock per iteration instead of freezing
+            // emulated time.
+            let fold_target_open = self.oep060.pending_head.is_some();
             // A branch ends any open pairing window; the target starts cold.
             self.oep060.pending_head = None;
-            return self.branch_cost_060(taken, info.has(F_DBCC), fetch_cached);
+            return self.branch_cost_060(taken, info.has(F_DBCC), fetch_cached, fold_target_open);
         }
         if flowed {
             // JMP/JSR/RTS/RTE/RTR and friends: pipeline refill floor.
@@ -687,7 +693,13 @@ impl CpuCore {
     /// with CACR.EBC set, a correctly predicted taken branch folds to zero
     /// cycles, a correct not-taken costs one, and everything else pays the
     /// mispredict refill.
-    fn branch_cost_060(&mut self, taken: bool, is_dbcc: bool, fetch_cached: bool) -> i32 {
+    fn branch_cost_060(
+        &mut self,
+        taken: bool,
+        is_dbcc: bool,
+        fetch_cached: bool,
+        fold_target_open: bool,
+    ) -> i32 {
         if self.cacr & super::cpu::CACR_060_EBC == 0 || !fetch_cached {
             return match (is_dbcc, taken) {
                 (true, true) => CYC_060_DBCC_TAKEN,
@@ -699,7 +711,9 @@ impl CpuCore {
         let user = !self.is_supervisor();
         let predicted_taken = self.oep060.branch_cache.predict(self.ppc).unwrap_or(false);
         let cost = match (predicted_taken, taken) {
-            (true, true) => 0, // folded out of the stream
+            // Folded out of the stream when it can ride the previous
+            // instruction's cycle; a lone branch still issues for a clock.
+            (true, true) => i32::from(!fold_target_open),
             (false, false) => 1,
             _ => CYC_060_MISPREDICT,
         };

--- a/crates/m68k/src/core/timing_060.rs
+++ b/crates/m68k/src/core/timing_060.rs
@@ -1,0 +1,416 @@
+//! 68060 instruction timing: superscalar classification and pOEP cycle costs.
+//!
+//! The 68060 executes most integer instructions in one clock in the primary
+//! operand-execution pipeline (pOEP); a restricted subset may dispatch to the
+//! secondary pipeline (sOEP) in the same clock. MC68060UM Chapter 10 defines
+//! the dispatch algorithm (Table 10-1) and classifies every instruction
+//! (Tables 10-2/10-3); this module transcribes that classification as a pure
+//! function of the opcode word, accelerated by a build-once 64K table.
+//!
+//! Costs returned here are pOEP occupancy assuming zero-wait operand access:
+//! all memory latency is billed by the host bus at access time, so a cheap
+//! count here never double-bills a bus access. The classification is
+//! deliberately pessimistic where the manual's rules are finer than an
+//! opcode-word decode can see (pessimism under-pairs; it never over-pairs).
+//! The per-instruction constants are calibration knobs - see the timing-test
+//! ADF rows and docs/internals/cpu.md.
+
+use super::cpu::CpuCore;
+use std::sync::OnceLock;
+
+/// UM Tables 10-2/10-3 dispatch classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum OepClass {
+    /// May execute in either pipeline (the common 1-cycle instructions).
+    PoepSoep = 0,
+    /// Occupies the pOEP; nothing dispatches to the sOEP that cycle.
+    PoepOnly = 1,
+    /// Multi-cycle in the pOEP; an sOEP partner may join the final cycle
+    /// (MOVEM is the canonical case).
+    PoepUntilLast = 2,
+    /// Must start in the pOEP but a pOEP|sOEP successor may still pair.
+    PoepButAllowsSoep = 3,
+}
+
+/// Packed per-opcode timing entry: class(2) | cycles(5) | flags(9).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Info060(pub u16);
+
+const CLASS_SHIFT: u16 = 0;
+const CYCLES_SHIFT: u16 = 2;
+const CYCLES_MASK: u16 = 0x1F;
+
+/// Bcc/BRA/BSR: costed via the branch path (branch cache once it lands).
+pub const F_BRANCH: u16 = 1 << 7;
+/// DBcc: a branch with its own loop-mode cost.
+pub const F_DBCC: u16 = 1 << 8;
+/// Cost varies with data (divides, MOVEM, ...): derive from the handler's
+/// raw 68000 count instead of the packed cycles field.
+pub const F_VARIABLE: u16 = 1 << 9;
+/// Instruction defines the CCR (partner CCR-consumers cannot pair behind it).
+pub const F_DEFINES_CCR: u16 = 1 << 10;
+/// Instruction consumes the CCR/X late (Scc, ADDX-style, DBcc).
+pub const F_USES_CCR_LATE: u16 = 1 << 11;
+/// Memory-indirect or indexed EA: +1 pOEP cycle, and never an sOEP candidate.
+pub const F_EA_INDEXED: u16 = 1 << 12;
+/// Not yet classified from the UM tables: pessimistic pOEP-only + raw fallback.
+pub const F_UNCLASSIFIED: u16 = 1 << 13;
+/// Instruction reads a memory operand.
+pub const F_READS_MEM: u16 = 1 << 14;
+/// Instruction writes a memory operand.
+pub const F_WRITES_MEM: u16 = 1 << 15;
+
+impl Info060 {
+    const fn new(class: OepClass, cycles: u16, flags: u16) -> Self {
+        Self((class as u16) << CLASS_SHIFT | (cycles & CYCLES_MASK) << CYCLES_SHIFT | flags)
+    }
+
+    pub fn class(self) -> OepClass {
+        match (self.0 >> CLASS_SHIFT) & 3 {
+            0 => OepClass::PoepSoep,
+            1 => OepClass::PoepOnly,
+            2 => OepClass::PoepUntilLast,
+            _ => OepClass::PoepButAllowsSoep,
+        }
+    }
+
+    pub fn cycles(self) -> i32 {
+        i32::from((self.0 >> CYCLES_SHIFT) & CYCLES_MASK)
+    }
+
+    pub fn has(self, flag: u16) -> bool {
+        self.0 & flag != 0
+    }
+}
+
+// Calibration knobs (all approximate pending timing-test/WinUAE cross-checks;
+// see docs/internals/cpu.md "68060 timing").
+/// Taken Bcc/BRA/BSR without branch-cache help: pipeline refill.
+pub const CYC_060_BRANCH_TAKEN: i32 = 7;
+/// Not-taken conditional branch.
+pub const CYC_060_BRANCH_NOT_TAKEN: i32 = 1;
+/// DBcc that loops (counter not expired, condition false).
+pub const CYC_060_DBCC_TAKEN: i32 = 2;
+/// DBcc that falls through.
+pub const CYC_060_DBCC_EXPIRED: i32 = 3;
+/// Floor for non-branch flow changes (JMP/JSR/RTS/RTE...): refill cost.
+pub const CYC_060_FLOW_MIN: i32 = 5;
+
+/// The 68060 rule of thumb for costs not in the table: a 4-clock 68000
+/// register operation is 1 clock on the 060. Never reuse the 020+ scaling
+/// formula here - its `.max(2)` floor would destroy 1-cycle costs.
+#[inline]
+fn fallback_cycles(raw: i32) -> i32 {
+    (raw / 4).max(1)
+}
+
+/// Standard-EA helper: flags contributed by an effective-address field.
+/// `read`/`write` say whether the instruction reads/writes that operand.
+const fn ea_flags(mode: u16, reg: u16, read: bool, write: bool) -> u16 {
+    let mut flags = 0;
+    let is_mem = mode >= 2 && !(mode == 7 && reg == 4); // not Rn, not #imm
+    if is_mem {
+        if read {
+            flags |= F_READS_MEM;
+        }
+        if write {
+            flags |= F_WRITES_MEM;
+        }
+    }
+    // Brief/full-format indexed and memory-indirect modes: (d8,An,Xn) and
+    // (d8,PC,Xn) families. The opcode word cannot distinguish brief from
+    // full extension words, so both are treated as indexed (pessimistic).
+    if mode == 6 || (mode == 7 && reg == 3) {
+        flags |= F_EA_INDEXED;
+    }
+    flags
+}
+
+/// One-cycle pOEP|sOEP ALU entry with standard EA flags.
+const fn alu(mode: u16, reg: u16, read: bool, write: bool) -> Info060 {
+    Info060::new(
+        OepClass::PoepSoep,
+        1,
+        F_DEFINES_CCR | ea_flags(mode, reg, read, write),
+    )
+}
+
+/// Classify one opcode word. Arranged in the same group order as
+/// `decode::dispatch_instruction` so the two files can be reviewed side by
+/// side. Unknown encodings return a pessimistic unclassified entry; illegal
+/// encodings never reach the cost path (they trap).
+pub fn classify_060_opcode(op: u16) -> Info060 {
+    let group = op >> 12;
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+    let unclassified = Info060::new(OepClass::PoepOnly, 1, F_UNCLASSIFIED | F_VARIABLE);
+
+    match group {
+        0x0 => {
+            if op & 0x0100 != 0 || (op & 0x0F00) == 0x0800 {
+                // Bit ops BTST/BCHG/BCLR/BSET (dynamic and static #), MOVEP.
+                // UM Table 10-2: bit operations are pOEP-only.
+                Info060::new(
+                    OepClass::PoepOnly,
+                    1,
+                    F_DEFINES_CCR | ea_flags(mode, reg, true, op & 0x00C0 != 0),
+                )
+            } else if (op & 0x0FC0) == 0x00C0 || (op & 0x09C0) == 0x08C0 {
+                // CMP2/CHK2/CAS/CAS2/MOVES: pOEP-only, data-dependent.
+                unclassified
+            } else {
+                // ORI/ANDI/SUBI/ADDI/EORI/CMPI #imm,<ea> (1 cycle, pOEP|sOEP);
+                // the to-CCR/to-SR forms are privileged/serializing.
+                if mode == 7 && reg == 4 {
+                    Info060::new(OepClass::PoepOnly, 1, F_VARIABLE) // to CCR/SR
+                } else {
+                    alu(mode, reg, true, (op & 0x0F00) != 0x0C00) // CMPI never writes
+                }
+            }
+        }
+        // MOVE.B/L/W and MOVEA: 1 cycle, pOEP|sOEP. Source EA read plus
+        // destination EA write; indexed penalty from either side.
+        0x1 | 0x2 | 0x3 => {
+            let dst_mode = (op >> 6) & 7;
+            let dst_reg = (op >> 9) & 7;
+            Info060::new(
+                OepClass::PoepSoep,
+                1,
+                F_DEFINES_CCR
+                    | ea_flags(mode, reg, true, false)
+                    | ea_flags(dst_mode, dst_reg, false, true),
+            )
+        }
+        0x4 => {
+            match op & 0x0FC0 {
+                // MOVE from SR / from CCR: serializing.
+                0x00C0 | 0x02C0 => Info060::new(OepClass::PoepOnly, 1, F_VARIABLE),
+                // MOVE to CCR / to SR.
+                0x04C0 | 0x06C0 => Info060::new(OepClass::PoepOnly, 1, F_VARIABLE),
+                _ => {
+                    if (op & 0x0B80) == 0x0880 && mode != 0 {
+                        // MOVEM: pOEP-until-last, one cycle per register plus
+                        // setup - data-dependent, so raw fallback.
+                        Info060::new(
+                            OepClass::PoepUntilLast,
+                            2,
+                            F_VARIABLE | F_READS_MEM | F_WRITES_MEM,
+                        )
+                    } else if (op & 0x0FC0) == 0x0AC0 {
+                        // TAS: locked RMW, pOEP-only.
+                        Info060::new(
+                            OepClass::PoepOnly,
+                            2,
+                            F_DEFINES_CCR | F_READS_MEM | F_WRITES_MEM,
+                        )
+                    } else if (op & 0x0F80) == 0x0C00 {
+                        // MULL/DIVL (4C00/4C40): pOEP-only, data-dependent.
+                        Info060::new(OepClass::PoepOnly, 2, F_DEFINES_CCR | F_VARIABLE)
+                    } else if (op & 0x0FF8) == 0x0840 {
+                        // SWAP
+                        alu(0, 0, false, false)
+                    } else if (op & 0x0E00) == 0x0800 && (op & 0x00C0) != 0x0040 {
+                        // NBCD/EXT/EXTB (CLR handled below); EXT is pOEP|sOEP.
+                        alu(mode, reg, true, true)
+                    } else if (op & 0x0F00) == 0x0200
+                        || (op & 0x0F00) == 0x0000
+                        || (op & 0x0F00) == 0x0400
+                        || (op & 0x0F00) == 0x0600
+                    {
+                        // NEGX/CLR/NEG/NOT <ea>: 1 cycle pOEP|sOEP.
+                        alu(mode, reg, true, true)
+                    } else if (op & 0x01C0) == 0x01C0 {
+                        // LEA: 1 cycle, pOEP|sOEP (indexed forms pay +1).
+                        Info060::new(OepClass::PoepSoep, 1, ea_flags(mode, reg, false, false))
+                    } else if (op & 0x01C0) == 0x0180 {
+                        // CHK: pOEP-only.
+                        Info060::new(OepClass::PoepOnly, 2, F_VARIABLE)
+                    } else {
+                        // JSR/JMP/RTS/RTE/RTR/LINK/UNLK/PEA/TRAP/STOP/MOVEC/
+                        // MOVE USP/TST... TST is common enough to special-case.
+                        if (op & 0x0F00) == 0x0A00 {
+                            // TST <ea>
+                            alu(mode, reg, true, false)
+                        } else {
+                            // Control-flow and supervisor ops: pOEP-only; the
+                            // flow-change floor in cycles_060 covers refills.
+                            Info060::new(OepClass::PoepOnly, 1, F_VARIABLE)
+                        }
+                    }
+                }
+            }
+        }
+        0x5 => {
+            if (op & 0x00F8) == 0x00C8 {
+                // DBcc
+                Info060::new(
+                    OepClass::PoepOnly,
+                    CYC_060_DBCC_EXPIRED as u16,
+                    F_BRANCH | F_DBCC | F_USES_CCR_LATE,
+                )
+            } else if (op & 0x00C0) == 0x00C0 {
+                // Scc <ea>: 1 cycle but consumes the CCR late.
+                Info060::new(
+                    OepClass::PoepSoep,
+                    1,
+                    F_USES_CCR_LATE | ea_flags(mode, reg, false, true),
+                )
+            } else {
+                // ADDQ/SUBQ: 1 cycle, pOEP|sOEP.
+                alu(mode, reg, true, true)
+            }
+        }
+        0x6 => {
+            // Bcc/BRA/BSR: branch path.
+            Info060::new(
+                OepClass::PoepOnly,
+                CYC_060_BRANCH_TAKEN as u16,
+                F_BRANCH | if (op & 0x0F00) != 0 { F_USES_CCR_LATE } else { 0 },
+            )
+        }
+        0x7 => {
+            // MOVEQ: the canonical 1-cycle pOEP|sOEP instruction.
+            Info060::new(OepClass::PoepSoep, 1, F_DEFINES_CCR)
+        }
+        0x8 => {
+            if (op & 0x00C0) == 0x00C0 {
+                // DIVU.W/DIVS.W: pOEP-only, data-dependent.
+                Info060::new(OepClass::PoepOnly, 2, F_DEFINES_CCR | F_VARIABLE)
+            } else if (op & 0x01F0) == 0x0100 || (op & 0x01F0) == 0x0140 {
+                // SBCD, PACK/UNPK: pOEP-only.
+                Info060::new(OepClass::PoepOnly, 2, F_DEFINES_CCR | F_VARIABLE)
+            } else {
+                // OR
+                alu(mode, reg, true, (op & 0x0100) != 0)
+            }
+        }
+        0x9 | 0xD => {
+            if (op & 0x0130) == 0x0100 && mode <= 1 {
+                // ADDX/SUBX: consume X late, pOEP-only per UM.
+                Info060::new(
+                    OepClass::PoepOnly,
+                    1,
+                    F_DEFINES_CCR | F_USES_CCR_LATE | ea_flags(mode, reg, true, true),
+                )
+            } else {
+                // ADD/SUB/ADDA/SUBA
+                alu(mode, reg, true, (op & 0x0100) != 0 && (op & 0x00C0) != 0x00C0)
+            }
+        }
+        0xB => {
+            // CMP/CMPA/CMPM/EOR
+            alu(mode, reg, true, (op & 0x0100) != 0 && (op & 0x00C0) != 0x00C0)
+        }
+        0xC => {
+            if (op & 0x00C0) == 0x00C0 {
+                // MULU.W/MULS.W: 2 cycles, pOEP-only.
+                Info060::new(OepClass::PoepOnly, 2, F_DEFINES_CCR)
+            } else if (op & 0x01F0) == 0x0100 {
+                // ABCD
+                Info060::new(OepClass::PoepOnly, 2, F_DEFINES_CCR | F_VARIABLE)
+            } else if (op & 0x01F8) == 0x0140 || (op & 0x01F8) == 0x0148 || (op & 0x01F8) == 0x0188
+            {
+                // EXG: pOEP-only per UM.
+                Info060::new(OepClass::PoepOnly, 1, 0)
+            } else {
+                // AND
+                alu(mode, reg, true, (op & 0x0100) != 0)
+            }
+        }
+        0xE => {
+            if (op & 0x08C0) == 0x08C0 {
+                // Bitfields: pOEP-only, data-dependent.
+                unclassified
+            } else if (op & 0x00C0) == 0x00C0 {
+                // Memory shifts (single bit): 1 cycle.
+                Info060::new(
+                    OepClass::PoepSoep,
+                    1,
+                    F_DEFINES_CCR | F_READS_MEM | F_WRITES_MEM,
+                )
+            } else if (op & 0x0018) == 0x0010 {
+                // ROXL/ROXR: consume X, pOEP-only.
+                Info060::new(OepClass::PoepOnly, 1, F_DEFINES_CCR | F_USES_CCR_LATE)
+            } else {
+                // Register shifts/rotates: 1 cycle, pOEP|sOEP per UM.
+                Info060::new(OepClass::PoepSoep, 1, F_DEFINES_CCR)
+            }
+        }
+        // A-line, F-line (FPU/MMU/MOVE16/LPSTOP), and anything else: pOEP-only
+        // with data-dependent cost.
+        _ => unclassified,
+    }
+}
+
+/// The 64K classification table, built once per process. Pure function of
+/// the opcode word; never serialized.
+fn info_table() -> &'static [u16; 0x10000] {
+    static TABLE: OnceLock<Box<[u16; 0x10000]>> = OnceLock::new();
+    TABLE.get_or_init(|| {
+        let mut table = vec![0u16; 0x10000];
+        for (op, slot) in table.iter_mut().enumerate() {
+            *slot = classify_060_opcode(op as u16).0;
+        }
+        table.into_boxed_slice().try_into().unwrap()
+    })
+}
+
+/// Look up the packed timing entry for an opcode.
+#[inline]
+pub fn info_060(op: u16) -> Info060 {
+    Info060(info_table()[op as usize])
+}
+
+impl CpuCore {
+    /// 68060 cycle cost for the instruction that just retired normally
+    /// (exception entries keep the handlers' own costs). `raw` is the
+    /// handler's 68000-reference count, used for data-dependent fallbacks.
+    pub(crate) fn cycles_060(&mut self, raw: i32) -> i32 {
+        let info = info_060(self.ir as u16);
+        let flowed = self.change_of_flow;
+
+        if info.has(F_BRANCH) {
+            // Static branch costs; the branch-cache model replaces these for
+            // Bcc/BRA/BSR when EBC is enabled.
+            return if info.has(F_DBCC) {
+                // The DBcc handler does not raise change_of_flow; a loop is
+                // visible as a PC that is not the fall-through (ppc + 4).
+                if self.pc != self.ppc.wrapping_add(4) {
+                    CYC_060_DBCC_TAKEN
+                } else {
+                    CYC_060_DBCC_EXPIRED
+                }
+            } else if flowed {
+                CYC_060_BRANCH_TAKEN
+            } else {
+                CYC_060_BRANCH_NOT_TAKEN
+            };
+        }
+        if flowed {
+            // JMP/JSR/RTS/RTE/RTR and friends: pipeline refill floor.
+            return fallback_cycles(raw).max(CYC_060_FLOW_MIN);
+        }
+        let mut cycles = if info.has(F_VARIABLE) || info.has(F_UNCLASSIFIED) {
+            fallback_cycles(raw)
+        } else {
+            info.cycles()
+        };
+        if info.has(F_EA_INDEXED) {
+            cycles += 1;
+        }
+        cycles
+    }
+
+    /// Model-dispatching wrapper for the three step paths: the 68060 uses its
+    /// own cost model; every other model keeps the existing scaling
+    /// byte-for-byte.
+    #[inline]
+    pub(crate) fn finalize_cycles(&mut self, raw: i32) -> i32 {
+        if self.cpu_type == super::types::CpuType::M68060 {
+            self.cycles_060(raw)
+        } else {
+            self.scale_cycles_for_cpu_type(raw)
+        }
+    }
+}

--- a/crates/m68k/src/core/timing_060.rs
+++ b/crates/m68k/src/core/timing_060.rs
@@ -179,11 +179,28 @@ impl BranchCache060 {
     }
 }
 
+/// An instruction resident in the pOEP with its sOEP slot still open,
+/// waiting for the next instruction to try the dispatch test.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PendingHead060 {
+    /// Registers the head writes (D0-D7 = bits 0-7, A0-A7 = 8-15).
+    pub def_mask: u16,
+    /// The head defines the CCR (late CCR consumers cannot pair behind it).
+    pub defines_ccr: bool,
+    /// The head has a memory operand (v1: at most one per pair).
+    pub accessed_mem: bool,
+    /// The head's opcode fetch hit the instruction cache.
+    pub head_cached: bool,
+}
+
 /// 68060 pipeline timing state carried on the CPU (serialized: it changes
 /// future cycle counts, and cycle counts change chipset interleaving).
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Oep060Timing {
     pub branch_cache: BranchCache060,
+    /// Retrospective pairing: the previous instruction, when it left an
+    /// sOEP slot open. None after any pipeline break.
+    pub pending_head: Option<PendingHead060>,
 }
 
 /// The 68060 rule of thumb for costs not in the table: a 4-clock 68000
@@ -432,6 +449,105 @@ pub fn classify_060_opcode(op: u16) -> Info060 {
     }
 }
 
+/// Registers an instruction uses and defines (D0-D7 = bits 0-7,
+/// A0-A7 = bits 8-15), decoded from the opcode word alone for the pairing
+/// dependency test. Extension-word index registers are invisible here,
+/// which is safe: indexed EAs classify pOEP-only and never pair. Anything
+/// not decoded returns full masks - pessimistic, so pairing is blocked
+/// rather than wrongly allowed.
+pub fn reg_masks_060(op: u16) -> (u16, u16) {
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+    let full = (0xFFFFu16, 0xFFFFu16);
+
+    // (use, def) contributed by a standard EA field. The operand value
+    // use/def is the caller's business; this covers address registers.
+    fn ea_masks(mode: u16, reg: u16) -> (u16, u16) {
+        match mode {
+            0 => (1 << reg, 0),           // Dn operand
+            1 => (1 << (8 + reg), 0),     // An operand
+            2 | 5 => (1 << (8 + reg), 0), // (An) / (d16,An)
+            // (An)+ / -(An): reads and updates An.
+            3 | 4 => (1 << (8 + reg), 1 << (8 + reg)),
+            // Indexed: the index register is in the extension word -
+            // pessimistic full use (these are pOEP-only anyway).
+            6 => (0xFFFF, 0),
+            _ => (0, 0), // abs / pc-rel / immediate
+        }
+    }
+
+    match op >> 12 {
+        // MOVE/MOVEA: src EA -> dst EA.
+        0x1 | 0x2 | 0x3 => {
+            let (su, sd) = ea_masks(mode, reg);
+            let dst_mode = (op >> 6) & 7;
+            let dst_reg = (op >> 9) & 7;
+            let (du, dd) = ea_masks(dst_mode, dst_reg);
+            let extra_def = match dst_mode {
+                0 => 1 << dst_reg,
+                1 => 1 << (8 + dst_reg),
+                _ => 0,
+            };
+            (su | du, sd | dd | extra_def)
+        }
+        // MOVEQ #imm,Dn.
+        0x7 => (0, 1 << ((op >> 9) & 7)),
+        // Dyadic groups: OR/SUB/CMP-EOR/AND/ADD with a Dn (or An for the
+        // address forms) and an EA.
+        0x8 | 0x9 | 0xB | 0xC | 0xD => {
+            let opmode = (op >> 6) & 7;
+            let dn = (op >> 9) & 7;
+            let (eu, ed) = ea_masks(mode, reg);
+            match opmode {
+                // <ea>,Dn: uses EA and Dn, defines Dn.
+                0..=2 => (eu | (1 << dn), ed | (1 << dn)),
+                // ADDA/SUBA/CMPA <ea>,An (word/long).
+                3 | 7 => (eu | (1 << (8 + dn)), ed | (1 << (8 + dn))),
+                // Dn,<ea>: memory destination RMW (or the X-forms, which
+                // classify pOEP-only and never reach the masks).
+                _ => ((1 << dn) | eu, ed),
+            }
+        }
+        // ADDQ/SUBQ/Scc: single EA operand.
+        0x5 => {
+            let (eu, ed) = ea_masks(mode, reg);
+            let operand_def = match mode {
+                0 => 1 << reg,
+                1 => 1 << (8 + reg),
+                _ => 0,
+            };
+            (eu, ed | operand_def)
+        }
+        // Register shifts/rotates define Dn; the register-count form also
+        // uses the count register.
+        0xE if (op & 0x00C0) != 0x00C0 => {
+            let dn = op & 7;
+            let count_use = if (op & 0x0020) != 0 {
+                1 << ((op >> 9) & 7)
+            } else {
+                0
+            };
+            ((1 << dn) | count_use, 1 << dn)
+        }
+        0x4 => {
+            if (op & 0x01C0) == 0x01C0 {
+                // LEA <ea>,An.
+                let an = (op >> 9) & 7;
+                let (eu, _) = ea_masks(mode, reg);
+                (eu, 1 << (8 + an))
+            } else if (op & 0x0F00) < 0x0700 || (op & 0x0F00) == 0x0A00 {
+                // CLR/NEG/NEGX/NOT/TST/EXT/SWAP-shaped single-EA forms.
+                let (eu, ed) = ea_masks(mode, reg);
+                let operand_def = if mode == 0 { 1 << reg } else { 0 };
+                (eu, ed | operand_def)
+            } else {
+                full
+            }
+        }
+        _ => full,
+    }
+}
+
 /// The 64K classification table, built once per process. Pure function of
 /// the opcode word; never serialized.
 fn info_table() -> &'static [u16; 0x10000] {
@@ -454,8 +570,10 @@ pub fn info_060(op: u16) -> Info060 {
 impl CpuCore {
     /// 68060 cycle cost for the instruction that just retired normally
     /// (exception entries keep the handlers' own costs). `raw` is the
-    /// handler's 68000-reference count, used for data-dependent fallbacks.
-    pub(crate) fn cycles_060(&mut self, raw: i32) -> i32 {
+    /// handler's 68000-reference count, used for data-dependent fallbacks;
+    /// `fetch_cached` says whether the opcode fetch hit the instruction
+    /// cache (pairing and branch folding need a cached stream).
+    pub(crate) fn cycles_060(&mut self, raw: i32, fetch_cached: bool) -> i32 {
         let info = info_060(self.ir as u16);
         let flowed = self.change_of_flow;
 
@@ -467,10 +585,13 @@ impl CpuCore {
             } else {
                 flowed
             };
-            return self.branch_cost_060(taken, info.has(F_DBCC));
+            // A branch ends any open pairing window; the target starts cold.
+            self.oep060.pending_head = None;
+            return self.branch_cost_060(taken, info.has(F_DBCC), fetch_cached);
         }
         if flowed {
             // JMP/JSR/RTS/RTE/RTR and friends: pipeline refill floor.
+            self.oep060.pending_head = None;
             return fallback_cycles(raw).max(CYC_060_FLOW_MIN);
         }
         let mut cycles = if info.has(F_VARIABLE) || info.has(F_UNCLASSIFIED) {
@@ -481,15 +602,93 @@ impl CpuCore {
         if info.has(F_EA_INDEXED) {
             cycles += 1;
         }
+
+        // Superscalar dispatch (retrospective pairing): if the previous
+        // instruction left its sOEP slot open and this one satisfies the
+        // dispatch test, it executes in the same clock - refund all but
+        // the pair's shared cycle.
+        let (use_mask, def_mask) = reg_masks_060(self.ir as u16);
+        if let Some(head) = self.oep060.pending_head {
+            if self.soep_dispatch_test(&head, info, use_mask, def_mask, fetch_cached) {
+                self.oep060.pending_head = None;
+                return (cycles - 1).max(0);
+            }
+        }
+        // This instruction becomes the new head when its class leaves the
+        // sOEP slot open (pOEP-only occupies both dispatch positions).
+        self.oep060.pending_head = match info.class() {
+            OepClass::PoepSoep | OepClass::PoepButAllowsSoep | OepClass::PoepUntilLast => {
+                Some(PendingHead060 {
+                    def_mask,
+                    defines_ccr: info.has(F_DEFINES_CCR),
+                    accessed_mem: info.has(F_READS_MEM) || info.has(F_WRITES_MEM),
+                    head_cached: fetch_cached,
+                })
+            }
+            OepClass::PoepOnly => None,
+        };
         cycles
+    }
+
+    /// UM Table 10-1's dispatch test, one predicate so the manual's rules
+    /// transcribe in one place. Deliberately pessimistic where the opcode
+    /// word cannot express the full rule (under-pairing is the safe
+    /// direction).
+    fn soep_dispatch_test(
+        &self,
+        head: &PendingHead060,
+        info: Info060,
+        use_mask: u16,
+        def_mask: u16,
+        fetch_cached: bool,
+    ) -> bool {
+        // PCR.ESS gates superscalar dispatch globally (68060.library sets
+        // it at boot; reset state is scalar).
+        if self.pcr & super::cpu::PCR_ESS == 0 {
+            return false;
+        }
+        // Both instructions must stream from the instruction cache: an
+        // uncached fetch stream is bus-limited and cannot feed two OEPs.
+        if !(head.head_cached && fetch_cached) {
+            return false;
+        }
+        // Only pOEP|sOEP instructions with a simple EA may dispatch to the
+        // secondary pipeline.
+        if info.class() != OepClass::PoepSoep
+            || info.has(F_EA_INDEXED)
+            || info.has(F_UNCLASSIFIED)
+            || info.has(F_VARIABLE)
+        {
+            return false;
+        }
+        // No same-cycle pOEP -> sOEP forwarding: RAW and WAW both block.
+        if (use_mask | def_mask) & head.def_mask != 0 {
+            return false;
+        }
+        // A late CCR consumer cannot pair behind a CCR producer.
+        if info.has(F_USES_CCR_LATE) && head.defines_ccr {
+            return false;
+        }
+        // v1: at most one memory operand per pair.
+        if head.accessed_mem && (info.has(F_READS_MEM) || info.has(F_WRITES_MEM)) {
+            return false;
+        }
+        true
+    }
+
+    /// Clear any open pairing window: called at every exception entry
+    /// (jump_vector), on HLE-handled traps, reset, and STOP.
+    #[inline]
+    pub(crate) fn break_060_pipeline(&mut self) {
+        self.oep060.pending_head = None;
     }
 
     /// Branch cost: static refill numbers with the branch cache disabled;
     /// with CACR.EBC set, a correctly predicted taken branch folds to zero
     /// cycles, a correct not-taken costs one, and everything else pays the
     /// mispredict refill.
-    fn branch_cost_060(&mut self, taken: bool, is_dbcc: bool) -> i32 {
-        if self.cacr & super::cpu::CACR_060_EBC == 0 {
+    fn branch_cost_060(&mut self, taken: bool, is_dbcc: bool, fetch_cached: bool) -> i32 {
+        if self.cacr & super::cpu::CACR_060_EBC == 0 || !fetch_cached {
             return match (is_dbcc, taken) {
                 (true, true) => CYC_060_DBCC_TAKEN,
                 (true, false) => CYC_060_DBCC_EXPIRED,
@@ -512,9 +711,9 @@ impl CpuCore {
     /// own cost model; every other model keeps the existing scaling
     /// byte-for-byte.
     #[inline]
-    pub(crate) fn finalize_cycles(&mut self, raw: i32) -> i32 {
+    pub(crate) fn finalize_cycles(&mut self, raw: i32, fetch_cached: bool) -> i32 {
         if self.cpu_type == super::types::CpuType::M68060 {
-            self.cycles_060(raw)
+            self.cycles_060(raw, fetch_cached)
         } else {
             self.scale_cycles_for_cpu_type(raw)
         }

--- a/crates/m68k/src/core/timing_060.rs
+++ b/crates/m68k/src/core/timing_060.rs
@@ -97,6 +97,95 @@ pub const CYC_060_DBCC_EXPIRED: i32 = 3;
 /// Floor for non-branch flow changes (JMP/JSR/RTS/RTE...): refill cost.
 pub const CYC_060_FLOW_MIN: i32 = 5;
 
+/// Mispredicted (or unpredicted-taken) branch with the branch cache on.
+pub const CYC_060_MISPREDICT: i32 = 7;
+
+/// The 68060's 256-entry branch cache, modeled as a direct-mapped table of
+/// branch PCs with 2-bit saturating taken counters. A hit that predicts a
+/// taken branch correctly folds it to zero cycles; misses predict not-taken
+/// and allocate on a taken execution. Entries record the privilege mode at
+/// allocation so CACR.CUBC can clear only user entries. The cache changes
+/// cycle counts and cycle counts change chipset interleaving, so it is
+/// serialized with the rest of the CPU.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BranchCache060 {
+    /// Full branch PC per slot (the tag).
+    tags: Vec<u32>,
+    /// Bit 2 = valid, bit 3 = allocated in user mode, bits 1:0 = 2-bit
+    /// saturating taken counter (predict taken when >= 2).
+    state: Vec<u8>,
+}
+
+const BC_VALID: u8 = 1 << 2;
+const BC_USER: u8 = 1 << 3;
+const BC_COUNTER: u8 = 0x03;
+
+impl Default for BranchCache060 {
+    fn default() -> Self {
+        Self {
+            tags: vec![0; 256],
+            state: vec![0; 256],
+        }
+    }
+}
+
+impl BranchCache060 {
+    #[inline]
+    fn slot(pc: u32) -> usize {
+        ((pc >> 1) & 0xFF) as usize
+    }
+
+    pub fn clear_all(&mut self) {
+        self.state.iter_mut().for_each(|s| *s = 0);
+    }
+
+    /// CACR.CUBC: clear only entries allocated in user mode.
+    pub fn clear_user(&mut self) {
+        for s in self.state.iter_mut() {
+            if *s & BC_USER != 0 {
+                *s = 0;
+            }
+        }
+    }
+
+    /// Prediction for the branch at `pc`: Some(taken?) on a hit, None on a
+    /// miss (which predicts not-taken).
+    fn predict(&self, pc: u32) -> Option<bool> {
+        let i = Self::slot(pc);
+        if self.state[i] & BC_VALID != 0 && self.tags[i] == pc {
+            Some(self.state[i] & BC_COUNTER >= 2)
+        } else {
+            None
+        }
+    }
+
+    /// Record an executed branch: allocate on a taken miss (weakly taken),
+    /// step the counter on a hit. Not-taken misses do not allocate.
+    fn update(&mut self, pc: u32, taken: bool, user: bool) {
+        let i = Self::slot(pc);
+        let hit = self.state[i] & BC_VALID != 0 && self.tags[i] == pc;
+        if hit {
+            let mut counter = self.state[i] & BC_COUNTER;
+            counter = if taken {
+                (counter + 1).min(3)
+            } else {
+                counter.saturating_sub(1)
+            };
+            self.state[i] = (self.state[i] & !BC_COUNTER) | counter;
+        } else if taken {
+            self.tags[i] = pc;
+            self.state[i] = BC_VALID | if user { BC_USER } else { 0 } | 2;
+        }
+    }
+}
+
+/// 68060 pipeline timing state carried on the CPU (serialized: it changes
+/// future cycle counts, and cycle counts change chipset interleaving).
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Oep060Timing {
+    pub branch_cache: BranchCache060,
+}
+
 /// The 68060 rule of thumb for costs not in the table: a 4-clock 68000
 /// register operation is 1 clock on the 060. Never reuse the 020+ scaling
 /// formula here - its `.max(2)` floor would destroy 1-cycle costs.
@@ -371,21 +460,14 @@ impl CpuCore {
         let flowed = self.change_of_flow;
 
         if info.has(F_BRANCH) {
-            // Static branch costs; the branch-cache model replaces these for
-            // Bcc/BRA/BSR when EBC is enabled.
-            return if info.has(F_DBCC) {
-                // The DBcc handler does not raise change_of_flow; a loop is
-                // visible as a PC that is not the fall-through (ppc + 4).
-                if self.pc != self.ppc.wrapping_add(4) {
-                    CYC_060_DBCC_TAKEN
-                } else {
-                    CYC_060_DBCC_EXPIRED
-                }
-            } else if flowed {
-                CYC_060_BRANCH_TAKEN
+            // The DBcc handler does not raise change_of_flow; a loop is
+            // visible as a PC that is not the fall-through (ppc + 4).
+            let taken = if info.has(F_DBCC) {
+                self.pc != self.ppc.wrapping_add(4)
             } else {
-                CYC_060_BRANCH_NOT_TAKEN
+                flowed
             };
+            return self.branch_cost_060(taken, info.has(F_DBCC));
         }
         if flowed {
             // JMP/JSR/RTS/RTE/RTR and friends: pipeline refill floor.
@@ -400,6 +482,30 @@ impl CpuCore {
             cycles += 1;
         }
         cycles
+    }
+
+    /// Branch cost: static refill numbers with the branch cache disabled;
+    /// with CACR.EBC set, a correctly predicted taken branch folds to zero
+    /// cycles, a correct not-taken costs one, and everything else pays the
+    /// mispredict refill.
+    fn branch_cost_060(&mut self, taken: bool, is_dbcc: bool) -> i32 {
+        if self.cacr & super::cpu::CACR_060_EBC == 0 {
+            return match (is_dbcc, taken) {
+                (true, true) => CYC_060_DBCC_TAKEN,
+                (true, false) => CYC_060_DBCC_EXPIRED,
+                (false, true) => CYC_060_BRANCH_TAKEN,
+                (false, false) => CYC_060_BRANCH_NOT_TAKEN,
+            };
+        }
+        let user = !self.is_supervisor();
+        let predicted_taken = self.oep060.branch_cache.predict(self.ppc).unwrap_or(false);
+        let cost = match (predicted_taken, taken) {
+            (true, true) => 0, // folded out of the stream
+            (false, false) => 1,
+            _ => CYC_060_MISPREDICT,
+        };
+        self.oep060.branch_cache.update(self.ppc, taken, user);
+        cost
     }
 
     /// Model-dispatching wrapper for the three step paths: the 68060 uses its

--- a/crates/m68k/src/core/types.rs
+++ b/crates/m68k/src/core/types.rs
@@ -19,6 +19,7 @@ pub enum CpuType {
     M68LC040 = 8,
     M68040 = 9,
     SCC68070 = 10,
+    M68060 = 11,
 }
 
 /// Trap handler with CPU and bus access for HLE.

--- a/crates/m68k/src/fpu/operations.rs
+++ b/crates/m68k/src/fpu/operations.rs
@@ -572,54 +572,63 @@ impl CpuCore {
         }
     }
 
-    /// 68060 FSAVE: the floating-point state frame is a fixed three
-    /// longwords. The format byte lives in bits 15:8 of the first long:
-    /// $00 = NULL (FPU untouched since reset), $60 = IDLE. The EXCP frame
-    /// ($E0, carrying pending-exception operands) is not modeled - the
-    /// softfloat FPU completes every operation before retiring.
+    /// 68060 FSAVE: the floating-point state frame carries its format in
+    /// bits 15:8 of the first long word: $00 = NULL (FPU untouched since
+    /// reset), $60 = IDLE. A NULL frame is a single long word - the same
+    /// one-long NULL every part since the 68881 has used, and the size
+    /// AmigaOS's hand-built task contexts rely on - while IDLE occupies
+    /// the full three long words. The EXCP frame ($E0, carrying pending-
+    /// exception operands) is not modeled: the softfloat FPU completes
+    /// every operation before retiring.
     fn exec_fsave_060<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
-        let header: u32 = if self.fpu_just_reset {
-            0x0000_0000
+        let (header, size): (u32, u32) = if self.fpu_just_reset {
+            (0x0000_0000, 4)
         } else {
-            0x0000_6000
+            (0x0000_6000, 12)
         };
         match ea_mode {
             2 | 3 => {
                 // (An) / (An)+
                 let addr = self.a(ea_reg);
                 if ea_mode == 3 {
-                    self.set_a(ea_reg, addr.wrapping_add(12));
+                    self.set_a(ea_reg, addr.wrapping_add(size));
                 }
                 self.write_32(bus, addr, header);
-                self.write_32(bus, addr.wrapping_add(4), 0);
-                self.write_32(bus, addr.wrapping_add(8), 0);
+                for off in (4..size).step_by(4) {
+                    self.write_32(bus, addr.wrapping_add(off), 0);
+                }
                 8
             }
             4 => {
                 // -(An)
-                let addr = self.a(ea_reg).wrapping_sub(12);
+                let addr = self.a(ea_reg).wrapping_sub(size);
                 self.set_a(ea_reg, addr);
                 self.write_32(bus, addr, header);
-                self.write_32(bus, addr.wrapping_add(4), 0);
-                self.write_32(bus, addr.wrapping_add(8), 0);
+                for off in (4..size).step_by(4) {
+                    self.write_32(bus, addr.wrapping_add(off), 0);
+                }
                 8
             }
             _ => 0,
         }
     }
 
-    /// 68060 FRESTORE: consume the fixed 12-byte frame; a NULL format byte
-    /// resets the FPU, anything else restores "some" state (the softfloat
-    /// FPU keeps its live register file - IDLE frames carry none).
+    /// 68060 FRESTORE: size the frame from the format byte - one long word
+    /// for NULL (resetting the FPU), three for anything else. Kickstart's
+    /// exec builds initial task contexts by hand with a one-long NULL frame
+    /// and launches them through FRESTORE (An)+, so a fixed 12-byte read
+    /// would skew the context walk and launch the first task at PC 0.
     fn exec_frestore_060<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
         match ea_mode {
             2 | 3 => {
                 let addr = self.a(ea_reg);
-                if ea_mode == 3 {
-                    self.set_a(ea_reg, addr.wrapping_add(12));
-                }
                 let header = self.read_32(bus, addr);
-                if (header & 0x0000_FF00) == 0 {
+                let null_frame = (header & 0x0000_FF00) == 0;
+                if ea_mode == 3 {
+                    let size = if null_frame { 4 } else { 12 };
+                    self.set_a(ea_reg, addr.wrapping_add(size));
+                }
+                if null_frame {
                     self.do_frestore_null();
                 } else {
                     self.fpu_just_reset = false;

--- a/crates/m68k/src/fpu/operations.rs
+++ b/crates/m68k/src/fpu/operations.rs
@@ -54,6 +54,42 @@ fn f64_to_int_saturating(value: f64, fpcr: u32, min: i64, max: i64) -> i64 {
     }
 }
 
+/// The FP opmodes the 68060 dropped from silicon, emulated by the 68060SP:
+/// the transcendental set, FINT/FINTRZ, FGETEXP/FGETMAN, FMOD/FREM/FSCALE,
+/// and FSINCOS (FMOVECR is gated separately by encoding). FSGLMUL/FSGLDIV
+/// and every rounded (FS/FD-prefixed) variant remain in hardware. Keep in
+/// sync with fpu_apply_op's table.
+fn fpu_060_traps_opmode(opmode: u16) -> bool {
+    matches!(
+        opmode,
+        0x01 | 0x02
+            | 0x03
+            | 0x06
+            | 0x08
+            | 0x09
+            | 0x0A
+            | 0x0C
+            | 0x0D
+            | 0x0E
+            | 0x0F
+            | 0x10
+            | 0x11
+            | 0x12
+            | 0x14
+            | 0x15
+            | 0x16
+            | 0x19
+            | 0x1C
+            | 0x1D
+            | 0x1E
+            | 0x1F
+            | 0x21
+            | 0x25
+            | 0x26
+            | 0x30..=0x37
+    )
+}
+
 /// Sign-extend a 7-bit FMOVE k-factor to i8.
 fn sign_extend7(v: u16) -> i8 {
     let raw = (v & 0x7F) as i16;
@@ -82,6 +118,12 @@ impl CpuCore {
             return 0;
         }
 
+        // 68060 with the FPU disabled through PCR.DFP (also how an LC/EC060
+        // presents): every FP instruction takes the format $4 disabled frame.
+        if self.is_060() && (self.pcr & crate::core::cpu::PCR_DFP) != 0 {
+            return self.take_fp_disabled_060(bus);
+        }
+
         // IMPORTANT:
         // - PC currently points at the first extension word (w2).
         // - We must NOT consume w2 (or any EA extension) unless we handle the instruction.
@@ -108,11 +150,33 @@ impl CpuCore {
                 let _w2 = self.read_imm_16(bus);
 
                 if src_fmt == 7 {
+                    // FMOVECR was dropped from 68060 silicon.
+                    if self.trap_unimpl_060() {
+                        return self.take_fp_unimp_060(bus, 0);
+                    }
                     // FMOVECR - load constant from ROM. The opmode field is
                     // the ROM index; there is no <ea> source operand.
                     self.fpr[dst] = softfloat::const_rom(opmode as usize);
                     self.fpu_set_cc(self.fpr[dst]);
                     return 4;
+                }
+
+                if self.trap_unimpl_060() && fpu_060_traps_opmode(opmode) {
+                    // Unimplemented FP instruction: resolve the operand EA
+                    // (consuming its extension words - the frame needs the
+                    // next-instruction PC) and take the format $2 trap.
+                    let ea = self.fpu_060_trap_ea(bus, opcode, src_fmt);
+                    return self.take_fp_unimp_060(bus, ea);
+                }
+                if self.trap_unimpl_060() && src_fmt == 3 {
+                    // Packed decimal: unsupported data type in 060 hardware;
+                    // the immediate form is an unimplemented <ea> instead.
+                    let vector = if (opcode & 0x3F) == 0x3C {
+                        crate::core::exceptions::vector::FP_UNIMPLEMENTED_EA
+                    } else {
+                        crate::core::exceptions::vector::FP_UNSUPP_DATA_TYPE
+                    };
+                    return self.take_exception(bus, vector);
                 }
 
                 let Some(src) = self.fpu_read_source(bus, opcode, src_fmt) else {
@@ -124,6 +188,13 @@ impl CpuCore {
                 // FMOVE FP, <ea> - move FP register to memory/integer register
                 let dst_fmt = (w2 >> 10) & 0x7;
                 let src = ((w2 >> 7) & 7) as usize;
+
+                // Packed-decimal output is an unsupported data type in 68060
+                // hardware (both static and dynamic k-factor forms).
+                if self.trap_unimpl_060() && (dst_fmt == 3 || dst_fmt == 7) {
+                    return self
+                        .take_exception(bus, crate::core::exceptions::vector::FP_UNSUPP_DATA_TYPE);
+                }
 
                 // Packed-decimal k-factor: static (fmt 3) in w2 bits 6-0;
                 // dynamic (fmt 7) in bits 6-0 of the Dn named by w2 bits 6-4.
@@ -156,11 +227,20 @@ impl CpuCore {
                 let _ = self.read_imm_16(bus);
 
                 if opmode == 0x17 {
+                    // FMOVECR was dropped from 68060 silicon.
+                    if self.trap_unimpl_060() {
+                        return self.take_fp_unimp_060(bus, 0);
+                    }
                     // FMOVECR - load constant from ROM. In this register-form
                     // encoding the source-register field carries the ROM index.
                     self.fpr[dst] = softfloat::const_rom(src);
                     self.fpu_set_cc(self.fpr[dst]);
                     return 4;
+                }
+                if self.trap_unimpl_060() && fpu_060_traps_opmode(opmode) {
+                    // Register-to-register form of an unimplemented FP
+                    // instruction: no operand EA.
+                    return self.take_fp_unimp_060(bus, 0);
                 }
                 self.fpu_apply_op(opmode, dst, self.fpr[src])
             }
@@ -178,6 +258,13 @@ impl CpuCore {
                 let ea = (opcode & 0x3f) as u8;
                 let ea_mode = (ea >> 3) & 7;
                 let ea_reg = (ea & 7) as usize;
+
+                // A dynamic register list was dropped from 68060 silicon
+                // (unimplemented <ea>).
+                if self.trap_unimpl_060() && (mode_bits & 0x1) != 0 {
+                    return self
+                        .take_exception(bus, crate::core::exceptions::vector::FP_UNIMPLEMENTED_EA);
+                }
 
                 // MODE field (w2 bits 12-11): bit 11 selects a dynamic
                 // register list (named by w2 bits 4-6), bit 12 selects the
@@ -265,6 +352,12 @@ impl CpuCore {
                 let count = (ctrl_sel & 4 != 0) as u32
                     + (ctrl_sel & 2 != 0) as u32
                     + (ctrl_sel & 1 != 0) as u32;
+                // FMOVEM.L #imm to two or three control registers was
+                // dropped from 68060 silicon (unimplemented <ea>).
+                if self.trap_unimpl_060() && count >= 2 && (opcode & 0x3F) == 0x3C {
+                    return self
+                        .take_exception(bus, crate::core::exceptions::vector::FP_UNIMPLEMENTED_EA);
+                }
                 let mut values = [0u32; 3];
                 match self.fpu_ea(bus, ea_mode, ea_reg, 4 * count) {
                     Some(FpuEa::DataReg(r)) if count == 1 => values[0] = self.d(r),
@@ -425,6 +518,11 @@ impl CpuCore {
     ///
     /// Implements a minimal subset: `FSAVE <ea>` and `FRESTORE <ea>` for a NULL/IDLE frame.
     pub fn exec_fpu_op1<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
+        // FSAVE/FRESTORE also take the disabled trap when PCR.DFP is set.
+        if self.is_060() && (self.pcr & crate::core::cpu::PCR_DFP) != 0 {
+            return self.take_fp_disabled_060(bus);
+        }
+
         let ea_mode = ((opcode >> 3) & 7) as u8;
         let ea_reg = (opcode & 7) as usize;
         let op = ((opcode >> 6) & 3) as u8;
@@ -437,6 +535,9 @@ impl CpuCore {
     }
 
     fn exec_fsave<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
+        if self.is_060() {
+            return self.exec_fsave_060(bus, ea_mode, ea_reg);
+        }
         // Musashi supports only (An)+ and -(An) here for 68040.
         match ea_mode {
             3 => {
@@ -471,7 +572,68 @@ impl CpuCore {
         }
     }
 
+    /// 68060 FSAVE: the floating-point state frame is a fixed three
+    /// longwords. The format byte lives in bits 15:8 of the first long:
+    /// $00 = NULL (FPU untouched since reset), $60 = IDLE. The EXCP frame
+    /// ($E0, carrying pending-exception operands) is not modeled - the
+    /// softfloat FPU completes every operation before retiring.
+    fn exec_fsave_060<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
+        let header: u32 = if self.fpu_just_reset {
+            0x0000_0000
+        } else {
+            0x0000_6000
+        };
+        match ea_mode {
+            2 | 3 => {
+                // (An) / (An)+
+                let addr = self.a(ea_reg);
+                if ea_mode == 3 {
+                    self.set_a(ea_reg, addr.wrapping_add(12));
+                }
+                self.write_32(bus, addr, header);
+                self.write_32(bus, addr.wrapping_add(4), 0);
+                self.write_32(bus, addr.wrapping_add(8), 0);
+                8
+            }
+            4 => {
+                // -(An)
+                let addr = self.a(ea_reg).wrapping_sub(12);
+                self.set_a(ea_reg, addr);
+                self.write_32(bus, addr, header);
+                self.write_32(bus, addr.wrapping_add(4), 0);
+                self.write_32(bus, addr.wrapping_add(8), 0);
+                8
+            }
+            _ => 0,
+        }
+    }
+
+    /// 68060 FRESTORE: consume the fixed 12-byte frame; a NULL format byte
+    /// resets the FPU, anything else restores "some" state (the softfloat
+    /// FPU keeps its live register file - IDLE frames carry none).
+    fn exec_frestore_060<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
+        match ea_mode {
+            2 | 3 => {
+                let addr = self.a(ea_reg);
+                if ea_mode == 3 {
+                    self.set_a(ea_reg, addr.wrapping_add(12));
+                }
+                let header = self.read_32(bus, addr);
+                if (header & 0x0000_FF00) == 0 {
+                    self.do_frestore_null();
+                } else {
+                    self.fpu_just_reset = false;
+                }
+                8
+            }
+            _ => 0,
+        }
+    }
+
     fn exec_frestore<B: AddressBus>(&mut self, bus: &mut B, ea_mode: u8, ea_reg: usize) -> i32 {
+        if self.is_060() {
+            return self.exec_frestore_060(bus, ea_mode, ea_reg);
+        }
         match ea_mode {
             2 => {
                 // (An)
@@ -843,6 +1005,50 @@ impl CpuCore {
     /// apply the FPU operand width; every other mode -- including the
     /// 68020 indexed and full-extension forms -- goes through the core
     /// resolver. Address-register direct is not a legal FPU operand.
+    /// Resolve the operand address of an FP instruction that traps as
+    /// unimplemented on the 68060: extension words are consumed (the trap
+    /// frame carries the next-instruction PC) and post-increment /
+    /// pre-decrement commit, matching the calculated-EA semantics of the
+    /// format $2 frame. Returns the EA long for the frame (0 when the
+    /// operand is not in memory).
+    fn fpu_060_trap_ea<B: AddressBus>(&mut self, bus: &mut B, opcode: u16, fmt: u16) -> u32 {
+        let ea_mode = ((opcode >> 3) & 7) as u8;
+        let ea_reg = (opcode & 7) as usize;
+        let bytes: u32 = match fmt {
+            4 => 2,      // word
+            6 => 1,      // byte
+            5 => 8,      // double
+            2 | 3 => 12, // extended / packed
+            _ => 4,      // long / single
+        };
+        match self.fpu_ea(bus, ea_mode, ea_reg, bytes) {
+            Some(FpuEa::Memory(addr)) => addr,
+            Some(FpuEa::Immediate) => {
+                // Immediate operands live in the instruction stream; skip
+                // them so the frame PC lands on the next instruction.
+                let skip = bytes.max(2) & !1;
+                self.pc = self.pc.wrapping_add(skip);
+                0
+            }
+            _ => 0,
+        }
+    }
+
+    /// FScc <ea> trap on the 68060: the instruction is emulated by the
+    /// 68060SP. Resolve the byte-sized destination EA for the frame.
+    pub(crate) fn fpu_060_scc_trap<B: AddressBus>(
+        &mut self,
+        bus: &mut B,
+        ea_mode: u8,
+        ea_reg: usize,
+    ) -> i32 {
+        let ea = match self.fpu_ea(bus, ea_mode, ea_reg, 1) {
+            Some(FpuEa::Memory(addr)) => addr,
+            _ => 0,
+        };
+        self.take_fp_unimp_060(bus, ea)
+    }
+
     fn fpu_ea<B: AddressBus>(
         &mut self,
         bus: &mut B,

--- a/crates/m68k/src/lib.rs
+++ b/crates/m68k/src/lib.rs
@@ -12,8 +12,9 @@ pub mod mmu;
 // Re-export commonly used types from core
 pub use core::cpu::CpuCore;
 pub use core::cpu::{
-    CACR_040_DE, CACR_040_IE, CACR_CD, CACR_CED, CACR_CEI, CACR_CI, CACR_ED, CACR_EI, CACR_FD,
-    CACR_FI,
+    CACR_040_DE, CACR_040_IE, CACR_060_CABC, CACR_060_CUBC, CACR_060_EBC, CACR_060_EDC,
+    CACR_060_EIC, CACR_060_ESB, CACR_CD, CACR_CED, CACR_CEI, CACR_CI, CACR_ED, CACR_EI, CACR_FD,
+    CACR_FI, PCR_060_RESET, PCR_DFP, PCR_ESS,
 };
 pub use core::memory::AddressBus;
 pub use core::types::{CpuType, HleHandler, NoOpHleHandler, Size, StepResult};

--- a/crates/m68k/src/mmu/mod.rs
+++ b/crates/m68k/src/mmu/mod.rs
@@ -19,10 +19,35 @@ pub enum MmuFaultKind {
     BusError,
 }
 
+/// Why a translation failed, at the granularity the 68060 FSLW reports:
+/// which walk level held the invalid descriptor, or which protection or
+/// bus condition stopped the access. The 030/040 frames do not consume
+/// this detail; the 68060 access-error frame does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MmuFaultCause {
+    /// Invalid descriptor in the root (level A) table.
+    PointerA,
+    /// Invalid descriptor in the pointer (level B) table.
+    PointerB,
+    /// Invalid indirect page descriptor.
+    Indirect,
+    /// Invalid page descriptor.
+    PageFault,
+    /// Write to a write-protected page.
+    WriteProtect,
+    /// User access to a supervisor-only page.
+    SupervisorProtect,
+    /// Physical bus error while walking the tables.
+    TableWalkBusError,
+    /// Physical bus error on the access itself.
+    AccessBusError,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MmuFault {
     pub kind: MmuFaultKind,
     pub address: u32,
+    pub cause: MmuFaultCause,
 }
 
 pub type MmuResult<T> = Result<T, MmuFault>;

--- a/crates/m68k/src/mmu/translation.rs
+++ b/crates/m68k/src/mmu/translation.rs
@@ -3,19 +3,27 @@
 use crate::core::cpu::CpuCore;
 use crate::core::memory::{AddressBus, BusFaultKind};
 
-use super::{MmuFault, MmuFaultKind, MmuResult};
+use super::{MmuFault, MmuFaultCause, MmuFaultKind, MmuResult};
 
 fn buserr(address: u32) -> MmuFault {
     MmuFault {
         kind: MmuFaultKind::BusError,
         address,
+        cause: MmuFaultCause::TableWalkBusError,
     }
 }
 
+/// Access fault with the generic invalid-page cause (030 walker sites,
+/// where the frame does not report the cause).
 fn access_fault(address: u32) -> MmuFault {
+    access_fault_cause(address, MmuFaultCause::PageFault)
+}
+
+fn access_fault_cause(address: u32, cause: MmuFaultCause) -> MmuFault {
     MmuFault {
         kind: MmuFaultKind::AccessLevelViolation,
         address,
+        cause,
     }
 }
 
@@ -23,6 +31,7 @@ fn config_fault(address: u32) -> MmuFault {
     MmuFault {
         kind: MmuFaultKind::ConfigurationError,
         address,
+        cause: MmuFaultCause::PageFault,
     }
 }
 
@@ -75,7 +84,7 @@ pub fn translate<B: AddressBus>(
 
     // The 68040 page table is a fixed three-level format unrelated to the
     // 68030's programmable walk below; dispatch to its own walker.
-    if cpu.is_040() {
+    if cpu.is_040() || cpu.is_060() {
         return translate_040(cpu, bus, logical, write, supervisor, instruction);
     }
 
@@ -247,12 +256,14 @@ fn translate_040<B: AddressBus>(
     supervisor: bool,
     instruction: bool,
 ) -> MmuResult<u32> {
-    // Invalid-descriptor outcome: fault on data, identity-fallback on a fetch.
-    let invalid = |logical: u32| -> MmuResult<u32> {
+    // Invalid-descriptor outcome: fault on data, identity-fallback on a
+    // fetch. The cause records which walk level held the invalid
+    // descriptor (the 68060 FSLW reports it).
+    let invalid = |logical: u32, cause: MmuFaultCause| -> MmuResult<u32> {
         if instruction {
             Ok(logical)
         } else {
-            Err(access_fault(logical))
+            Err(access_fault_cause(logical, cause))
         }
     };
     // Page size: TC bit 14 (P) selects 8 KB, else 4 KB.
@@ -279,7 +290,8 @@ fn translate_040<B: AddressBus>(
     let root_idx = (logical >> 25) & 0x7F;
     let root_desc = read_u32_phys(bus, (root & 0xFFFF_FE00).wrapping_add(root_idx * 4))?;
     if root_desc & 3 < 2 {
-        return invalid(logical); // UDT invalid: data faults, fetch falls back
+        // UDT invalid: data faults, fetch falls back
+        return invalid(logical, MmuFaultCause::PointerA);
     }
 
     // Level 2: pointer table (512-byte aligned), indexed by logical[24:18].
@@ -287,7 +299,8 @@ fn translate_040<B: AddressBus>(
     let ptr_idx = (logical >> 18) & 0x7F;
     let ptr_desc = read_u32_phys(bus, ptr_table.wrapping_add(ptr_idx * 4))?;
     if ptr_desc & 3 < 2 {
-        return invalid(logical); // UDT invalid: data faults, fetch falls back
+        // UDT invalid: data faults, fetch falls back
+        return invalid(logical, MmuFaultCause::PointerB);
     }
 
     // Level 3: page table. With 4 KB pages it has 64 entries (256-byte aligned,
@@ -303,11 +316,20 @@ fn translate_040<B: AddressBus>(
 
     // PDT: 0 invalid, 2 indirect (the descriptor points to the real page
     // descriptor), 1/3 resident.
-    if page_desc & 3 == 2 {
+    let was_indirect = page_desc & 3 == 2;
+    if was_indirect {
         page_desc = read_u32_phys(bus, page_desc & 0xFFFF_FFFC)?;
     }
     if page_desc & 3 == 0 {
-        return invalid(logical); // PDT invalid: data faults, fetch falls back
+        // PDT invalid: data faults, fetch falls back
+        return invalid(
+            logical,
+            if was_indirect {
+                MmuFaultCause::Indirect
+            } else {
+                MmuFaultCause::PageFault
+            },
+        );
     }
 
     // Protection bits: W (write-protect, bit 2) accumulates across the table and
@@ -315,8 +337,14 @@ fn translate_040<B: AddressBus>(
     // A violating access faults (resumable on the 040, vector 2 / format 7).
     let write_protected = (root_desc | ptr_desc | page_desc) & 0x0000_0004 != 0;
     let supervisor_only = page_desc & 0x0000_0080 != 0;
-    if (write && write_protected) || (!supervisor && supervisor_only) {
-        return Err(access_fault(logical));
+    if write && write_protected {
+        return Err(access_fault_cause(logical, MmuFaultCause::WriteProtect));
+    }
+    if !supervisor && supervisor_only {
+        return Err(access_fault_cause(
+            logical,
+            MmuFaultCause::SupervisorProtect,
+        ));
     }
 
     let phys_page = page_desc & !page_mask;

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -621,3 +621,59 @@ fn rte_pops_format_7_frame_on_68040() {
     assert_eq!(cpu.pc, 0x0555, "RTE must pop the 040 access-error frame");
     assert_eq!(cpu.dar[15], sp + 60, "30 words consumed");
 }
+
+#[test]
+fn plpar_translates_and_ptest_is_line_f_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // Identity table for page 0x1000, then remap it to 0x5000 before
+    // enabling translation.
+    let root = build_060_table(&mut bus, 0x1000, false);
+    bus.write_long_at(0x4000 + 1 * 4, 0x5000 | 1); // page descriptor -> 0x5000
+    movec_to(&mut cpu, &mut bus, 0x807, root);
+    movec_to(&mut cpu, &mut bus, 0x003, 0x0000_8000);
+    movec_to(&mut cpu, &mut bus, 0x001, 5); // DFC = supervisor data
+
+    // PLPAR (A0): physical address lands in A0.
+    bus.write_word_at(0x0210, 0xF5C8);
+    cpu.dar[8] = 0x1234;
+    cpu.pc = 0x0210;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0212, "PLPAR executes on the 68060");
+    assert_eq!(cpu.dar[8], 0x5234, "A0 holds the translated address");
+
+    // PTEST encodings were dropped from the 68060: Line-F.
+    bus.write_word_at(0x0212, 0xF548); // PTESTW (A0) on an 040
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0340, "PTEST is an undefined F-line on the 68060");
+}
+
+#[test]
+fn plpar_faults_with_format_4_on_unmapped_page_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_long_at(0x08, 0x0400); // vector 2
+    build_060_table(&mut bus, 0x0000, false); // keep stack/code mapped
+    let root = build_060_table(&mut bus, 0x1000, false);
+    movec_to(&mut cpu, &mut bus, 0x807, root);
+    movec_to(&mut cpu, &mut bus, 0x003, 0x0000_8000);
+    movec_to(&mut cpu, &mut bus, 0x001, 5);
+
+    // PLPAR (A0) with A0 pointing at an unmapped page.
+    bus.write_word_at(0x0210, 0xF5C8);
+    cpu.dar[8] = 0x0080_0000;
+    cpu.pc = 0x0210;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0400, "unmapped PLPAR takes the access error");
+    let sp = cpu.dar[15];
+    assert_eq!(bus.read_word(sp.wrapping_add(6)), 0x4008, "format $4 frame");
+    assert_eq!(cpu.dar[8], 0x0080_0000, "An untouched for restart");
+}
+
+#[test]
+fn pmove_is_line_f_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // 030-form PMOVE TC,<mem> (0xF000 with MMU extension word).
+    bus.write_word_at(0x0200, 0xF010);
+    bus.write_word_at(0x0202, 0x4200);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0340, "PMOVE is an undefined F-line on the 68060");
+}

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -1,0 +1,154 @@
+//! 68060-specific behavior: model configuration, the instruction subset the
+//! 060 kept, the unimplemented-instruction traps, and the 060-only control
+//! registers. Programs are hand-assembled into a flat test bus; no external
+//! fixtures.
+
+use m68k::core::memory::AddressBus;
+use m68k::{CpuCore, CpuType, NoOpHleHandler, StepResult};
+
+struct TestBus {
+    memory: Vec<u8>,
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self {
+            memory: vec![0; 0x10000],
+        }
+    }
+
+    fn write_word_at(&mut self, addr: u32, value: u16) {
+        let bytes = value.to_be_bytes();
+        let idx = addr as usize;
+        self.memory[idx] = bytes[0];
+        self.memory[idx + 1] = bytes[1];
+    }
+
+    fn write_long_at(&mut self, addr: u32, value: u32) {
+        let bytes = value.to_be_bytes();
+        self.memory[addr as usize..addr as usize + 4].copy_from_slice(&bytes);
+    }
+
+    fn read_long_at(&self, addr: u32) -> u32 {
+        let idx = addr as usize;
+        u32::from_be_bytes([
+            self.memory[idx],
+            self.memory[idx + 1],
+            self.memory[idx + 2],
+            self.memory[idx + 3],
+        ])
+    }
+}
+
+impl AddressBus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.memory[(address as usize) & 0xFFFF]
+    }
+
+    fn read_word(&mut self, address: u32) -> u16 {
+        let addr = (address as usize) & 0xFFFF;
+        u16::from_be_bytes([self.memory[addr], self.memory[addr + 1]])
+    }
+
+    fn read_long(&mut self, address: u32) -> u32 {
+        let addr = (address as usize) & 0xFFFF;
+        u32::from_be_bytes([
+            self.memory[addr],
+            self.memory[addr + 1],
+            self.memory[addr + 2],
+            self.memory[addr + 3],
+        ])
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.memory[(address as usize) & 0xFFFF] = value;
+    }
+
+    fn write_word(&mut self, address: u32, value: u16) {
+        let addr = (address as usize) & 0xFFFF;
+        let bytes = value.to_be_bytes();
+        self.memory[addr] = bytes[0];
+        self.memory[addr + 1] = bytes[1];
+    }
+
+    fn write_long(&mut self, address: u32, value: u32) {
+        let addr = (address as usize) & 0xFFFF;
+        let bytes = value.to_be_bytes();
+        self.memory[addr..addr + 4].copy_from_slice(&bytes);
+    }
+}
+
+/// A 68060 reset into supervisor mode with SSP $1000, PC $0200, and the
+/// illegal (4), privilege (8), Line-F (11), and unimplemented-integer (61)
+/// vectors pointed at distinct handlers.
+fn setup_060() -> (CpuCore, TestBus) {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68060);
+    let mut bus = TestBus::new();
+    bus.write_long_at(0x00, 0x1000); // SSP
+    bus.write_long_at(0x04, 0x0200); // PC
+    bus.write_long_at(0x10, 0x0300); // vector 4: illegal instruction
+    bus.write_long_at(0x20, 0x0320); // vector 8: privilege violation
+    bus.write_long_at(0x2C, 0x0340); // vector 11: Line-F
+    bus.write_long_at(61 * 4, 0x0360); // vector 61: unimplemented integer
+    cpu.reset(&mut bus);
+    cpu.pc = 0x0200;
+    cpu.set_sr(0x2700);
+    (cpu, bus)
+}
+
+fn step(cpu: &mut CpuCore, bus: &mut TestBus) -> StepResult {
+    let mut hle = NoOpHleHandler;
+    cpu.step_with_hle_handler(bus, &mut hle)
+}
+
+#[test]
+fn m68060_sets_masks_and_pmmu() {
+    let (mut cpu, _bus) = setup_060();
+    assert_eq!(cpu.address_mask, 0xFFFF_FFFF);
+    assert!(cpu.has_pmmu);
+    assert!(!cpu.is_pre_68020);
+    // The 060 keeps the M bit but drops T0 (SR bit 14).
+    cpu.set_sr(0xF71F);
+    assert_eq!(cpu.get_sr() & 0x4000, 0, "T0 must not be storable on the 060");
+    assert_ne!(cpu.get_sr() & 0x1000, 0, "M bit must be storable on the 060");
+}
+
+#[test]
+fn move16_executes_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // MOVE16 (A0)+,(A1)+
+    bus.write_word_at(0x0200, 0xF620);
+    bus.write_word_at(0x0202, 0x9000); // dest A1
+    cpu.dar[8] = 0x4000;
+    cpu.dar[9] = 0x5000;
+    for i in 0..4u32 {
+        bus.write_long_at(0x4000 + i * 4, 0x1111_0000 + i);
+    }
+    let result = step(&mut cpu, &mut bus);
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert_eq!(cpu.pc, 0x0204, "MOVE16 must execute, not trap");
+    for i in 0..4u32 {
+        assert_eq!(bus.read_long_at(0x5000 + i * 4), 0x1111_0000 + i);
+    }
+    assert_eq!(cpu.dar[8], 0x4010);
+    assert_eq!(cpu.dar[9], 0x5010);
+}
+
+#[test]
+fn full_extension_word_ea_executes_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // MOVE.L (bd,A0,D1.L*4),D0 with a full-format extension word:
+    //   D1.L index (0x1800), scale *4 (0x0400), full format (0x0100),
+    //   base displacement word (0x0020).
+    bus.write_word_at(0x0200, 0x2030); // MOVE.L <ea mode 6, reg A0>,D0
+    bus.write_word_at(0x0202, 0x1D20); // ext: D1.L*4, full, word bd follows
+    bus.write_word_at(0x0204, 0x0020); // bd = 0x20
+    cpu.dar[8] = 0x4000;
+    cpu.dar[1] = 4; // D1 index -> 4 * 4 = 16
+    bus.write_long_at(0x4030, 0xCAFE_F00D);
+    let result = step(&mut cpu, &mut bus);
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert_eq!(cpu.pc, 0x0206);
+    assert_eq!(cpu.dar[0], 0xCAFE_F00D, "scaled full-format EA must resolve");
+}

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -252,3 +252,142 @@ fn m_bit_does_not_switch_stacks_on_68060() {
     cpu.set_sr(0x2700);
     assert_eq!(cpu.dar[15], 0x0000_2000);
 }
+
+/// Assert the machine trapped to the unimplemented-integer handler at
+/// $0360 with a format-0 frame whose vector offset is 61*4 and whose
+/// stacked PC is the faulting instruction.
+fn assert_vector_61(cpu: &CpuCore, bus: &mut TestBus, instr_addr: u32) {
+    assert_eq!(cpu.pc, 0x0360, "must vector through 61");
+    let sp = cpu.dar[15];
+    let frame_pc = bus.read_long(sp.wrapping_add(2));
+    let fmt_vec = bus.read_word(sp.wrapping_add(6));
+    assert_eq!(frame_pc, instr_addr, "stacked PC = faulting instruction");
+    assert_eq!(fmt_vec, 61 * 4, "format 0 frame, vector offset 61*4");
+}
+
+#[test]
+fn movep_traps_to_vector_61_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // MOVEP.W D0,(4,A0)
+    bus.write_word_at(0x0200, 0x0188);
+    bus.write_word_at(0x0202, 0x0004);
+    cpu.dar[0] = 0x1234;
+    cpu.dar[8] = 0x4000;
+    let result = step(&mut cpu, &mut bus);
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert_vector_61(&cpu, &mut bus, 0x0200);
+    assert_eq!(bus.read_word(0x4004), 0, "memory untouched");
+    assert_eq!(cpu.dar[8], 0x4000, "A0 untouched");
+}
+
+#[test]
+fn movep_executes_natively_with_escape_flag() {
+    let (mut cpu, mut bus) = setup_060();
+    cpu.emulate_unimplemented_060 = true;
+    bus.write_word_at(0x0200, 0x0188); // MOVEP.W D0,(4,A0)
+    bus.write_word_at(0x0202, 0x0004);
+    cpu.dar[0] = 0x1234;
+    cpu.dar[8] = 0x4000;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0204);
+    assert_eq!(bus.read_byte(0x4004), 0x12);
+    assert_eq!(bus.read_byte(0x4006), 0x34);
+}
+
+#[test]
+fn movep_still_executes_on_68040() {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    let mut bus = TestBus::new();
+    bus.write_long_at(0x00, 0x1000);
+    bus.write_long_at(0x04, 0x0200);
+    cpu.reset(&mut bus);
+    cpu.set_sr(0x2700);
+    bus.write_word_at(0x0200, 0x0188);
+    bus.write_word_at(0x0202, 0x0004);
+    cpu.dar[0] = 0x1234;
+    cpu.dar[8] = 0x4000;
+    cpu.pc = 0x0200;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0204, "MOVEP is native on the 68040");
+    assert_eq!(bus.read_byte(0x4004), 0x12);
+}
+
+#[test]
+fn mull_64bit_traps_but_32bit_executes_on_68060() {
+    // 64-bit form: MULU.L D1,D2:D0 (ext bit 10 set).
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0x4C01); // MULx.L D1,...
+    bus.write_word_at(0x0202, 0x0402); // D0 low, wide, D2 high
+    cpu.dar[0] = 7;
+    cpu.dar[1] = 6;
+    step(&mut cpu, &mut bus);
+    assert_vector_61(&cpu, &mut bus, 0x0200);
+    assert_eq!(cpu.dar[0], 7, "registers untouched");
+
+    // 32-bit form: MULU.L D1,D0 stays native.
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0x4C01);
+    bus.write_word_at(0x0202, 0x0000);
+    cpu.dar[0] = 7;
+    cpu.dar[1] = 6;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0204);
+    assert_eq!(cpu.dar[0], 42, "32-bit MULU.L executes natively");
+}
+
+#[test]
+fn divl_64bit_traps_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // DIVU.L D1,D2:D0 (64/32, ext bit 10 set). Divisor zero on purpose:
+    // the unimplemented trap must win over zero-divide evaluation.
+    bus.write_word_at(0x0200, 0x4C41);
+    bus.write_word_at(0x0202, 0x0402);
+    cpu.dar[1] = 0;
+    step(&mut cpu, &mut bus);
+    assert_vector_61(&cpu, &mut bus, 0x0200);
+}
+
+#[test]
+fn cas2_and_chk2_trap_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // CAS2.W D0:D1,D2:D3,(A0):(A1)
+    bus.write_word_at(0x0200, 0x0CFC);
+    bus.write_word_at(0x0202, 0x8080);
+    bus.write_word_at(0x0204, 0x9081);
+    step(&mut cpu, &mut bus);
+    assert_vector_61(&cpu, &mut bus, 0x0200);
+
+    let (mut cpu, mut bus) = setup_060();
+    // CMP2.W (A0),D0
+    bus.write_word_at(0x0200, 0x02D0);
+    bus.write_word_at(0x0202, 0x0000);
+    cpu.dar[8] = 0x4000;
+    step(&mut cpu, &mut bus);
+    assert_vector_61(&cpu, &mut bus, 0x0200);
+}
+
+#[test]
+fn cas_misaligned_traps_aligned_executes_on_68060() {
+    // Misaligned word CAS: trap with A0 and memory untouched.
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0x0CD8); // CAS.W D0,D1,(A0)+
+    bus.write_word_at(0x0202, 0x0040); // Du=D1, Dc=D0
+    cpu.dar[8] = 0x4001;
+    step(&mut cpu, &mut bus);
+    assert_vector_61(&cpu, &mut bus, 0x0200);
+    assert_eq!(cpu.dar[8], 0x4001, "post-increment must not commit");
+
+    // Aligned CAS executes (and post-increments).
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0x0CD8);
+    bus.write_word_at(0x0202, 0x0040);
+    bus.write_word_at(0x4000, 0x0005);
+    cpu.dar[8] = 0x4000;
+    cpu.dar[0] = 0x0005; // compare matches
+    cpu.dar[1] = 0x0009; // update value
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0204);
+    assert_eq!(bus.read_word(0x4000), 0x0009, "aligned CAS swaps");
+    assert_eq!(cpu.dar[8], 0x4002, "post-increment commits");
+}

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -677,3 +677,49 @@ fn pmove_is_line_f_on_68060() {
     step(&mut cpu, &mut bus);
     assert_eq!(cpu.pc, 0x0340, "PMOVE is an undefined F-line on the 68060");
 }
+
+#[test]
+fn lpstop_loads_sr_and_stops_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0xF800);
+    bus.write_word_at(0x0202, 0x01C0);
+    bus.write_word_at(0x0204, 0x2300); // supervisor, IPL 3
+    step(&mut cpu, &mut bus);
+    assert_ne!(cpu.stopped, 0, "LPSTOP must stop the CPU");
+    assert_eq!(cpu.get_sr() & 0x0700, 0x0300, "SR loaded from the immediate");
+}
+
+#[test]
+fn lpstop_is_privileged_and_line_f_elsewhere() {
+    // User mode: privilege violation.
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0xF800);
+    bus.write_word_at(0x0202, 0x01C0);
+    bus.write_word_at(0x0204, 0x0000);
+    cpu.set_sr(0x0000);
+    cpu.pc = 0x0200;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0320, "user-mode LPSTOP is a privilege violation");
+
+    // Wrong extension word: undefined F-line.
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_word_at(0x0200, 0xF800);
+    bus.write_word_at(0x0202, 0x1234);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0340, "F800 with a wrong extension is Line-F");
+
+    // 68040: no LPSTOP at all.
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    let mut bus = TestBus::new();
+    bus.write_long_at(0x00, 0x1000);
+    bus.write_long_at(0x04, 0x0200);
+    bus.write_long_at(0x2C, 0x0340);
+    cpu.reset(&mut bus);
+    cpu.set_sr(0x2700);
+    bus.write_word_at(0x0200, 0xF800);
+    bus.write_word_at(0x0202, 0x01C0);
+    cpu.pc = 0x0200;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0340, "LPSTOP is Line-F on the 68040");
+}

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -391,3 +391,153 @@ fn cas_misaligned_traps_aligned_executes_on_68060() {
     assert_eq!(bus.read_word(0x4000), 0x0009, "aligned CAS swaps");
     assert_eq!(cpu.dar[8], 0x4002, "post-increment commits");
 }
+
+/// Assert an FP-unimplemented trap: vector 11 handler, six-word format $2
+/// frame ($202C) with the given next-PC and EA fields, FPIAR = instruction.
+fn assert_fp_unimp(cpu: &CpuCore, bus: &mut TestBus, instr: u32, next_pc: u32, ea: u32) {
+    assert_eq!(cpu.pc, 0x0340, "must vector through Line-F (11)");
+    let sp = cpu.dar[15];
+    assert_eq!(bus.read_word(sp.wrapping_add(6)), 0x202C, "format $2 frame");
+    assert_eq!(bus.read_long(sp.wrapping_add(2)), next_pc, "next-PC field");
+    assert_eq!(bus.read_long(sp.wrapping_add(8)), ea, "EA field");
+    assert_eq!(cpu.fpiar, instr, "FPIAR holds the faulting instruction");
+}
+
+#[test]
+fn fadd_register_form_executes_natively_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // FADD.X FP0,FP1
+    bus.write_word_at(0x0200, 0xF200);
+    bus.write_word_at(0x0202, 0x00A2); // src FP0? bits: (0<<10)|(1<<7)|0x22
+    cpu.fpr[0] = m68k::fpu::FloatX80::from_f64(2.0);
+    cpu.fpr[1] = m68k::fpu::FloatX80::from_f64(3.0);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0204, "FADD must execute, not trap");
+    assert_eq!(cpu.fpr[1].to_f64(), 5.0);
+}
+
+#[test]
+fn fsin_register_form_traps_fp_unimplemented_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // FSIN.X FP0,FP1
+    bus.write_word_at(0x0200, 0xF200);
+    bus.write_word_at(0x0202, 0x008E);
+    cpu.fpr[1] = m68k::fpu::FloatX80::from_f64(9.0);
+    step(&mut cpu, &mut bus);
+    assert_fp_unimp(&cpu, &mut bus, 0x0200, 0x0204, 0);
+    assert_eq!(cpu.fpr[1].to_f64(), 9.0, "FP registers unchanged");
+}
+
+#[test]
+fn fsin_memory_source_traps_with_calculated_ea_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // FSIN.L (A0)+,FP0
+    bus.write_word_at(0x0200, 0xF218);
+    bus.write_word_at(0x0202, 0x400E);
+    cpu.dar[8] = 0x4000;
+    step(&mut cpu, &mut bus);
+    assert_fp_unimp(&cpu, &mut bus, 0x0200, 0x0204, 0x4000);
+    assert_eq!(cpu.dar[8], 0x4004, "calculated EA commits post-increment");
+}
+
+#[test]
+fn fsin_executes_with_escape_flag_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    cpu.emulate_unimplemented_060 = true;
+    bus.write_word_at(0x0200, 0xF200);
+    bus.write_word_at(0x0202, 0x008E); // FSIN.X FP0,FP1
+    cpu.fpr[0] = m68k::fpu::FloatX80::from_f64(0.0);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0204);
+    assert_eq!(cpu.fpr[1].to_f64(), 0.0, "sin(0) = 0 computed natively");
+}
+
+#[test]
+fn fmovecr_and_fdbcc_trap_fp_unimplemented_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    // FMOVECR #$32,FP0 (opclass 2, src_fmt 7)
+    bus.write_word_at(0x0200, 0xF200);
+    bus.write_word_at(0x0202, 0x5C32);
+    step(&mut cpu, &mut bus);
+    assert_fp_unimp(&cpu, &mut bus, 0x0200, 0x0204, 0);
+
+    let (mut cpu, mut bus) = setup_060();
+    // FDBF D0,<disp> (opcode + cond word + displacement word)
+    bus.write_word_at(0x0200, 0xF248);
+    bus.write_word_at(0x0202, 0x0000);
+    bus.write_word_at(0x0204, 0xFFFC);
+    step(&mut cpu, &mut bus);
+    assert_fp_unimp(&cpu, &mut bus, 0x0200, 0x0206, 0);
+}
+
+#[test]
+fn packed_and_dynamic_fmovem_take_their_own_vectors_on_68060() {
+    // Packed-decimal source: FP unsupported data type (vector 55).
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_long_at(55 * 4, 0x0380);
+    bus.write_word_at(0x0200, 0xF210); // FMOVE.P (A0),FP0
+    bus.write_word_at(0x0202, 0x4C00);
+    cpu.dar[8] = 0x4000;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0380, "packed operand vectors through 55");
+    let sp = cpu.dar[15];
+    assert_eq!(bus.read_word(sp.wrapping_add(6)), 55 * 4, "format $0 frame");
+    assert_eq!(bus.read_long(sp.wrapping_add(2)), 0x0200, "pre-instruction PC");
+
+    // Dynamic FMOVEM register list: unimplemented <ea> (vector 60).
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_long_at(60 * 4, 0x03A0);
+    bus.write_word_at(0x0200, 0xF210); // FMOVEM.X <dynamic D1>,(A0)
+    bus.write_word_at(0x0202, 0xE810);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x03A0, "dynamic list vectors through 60");
+}
+
+#[test]
+fn pcr_dfp_takes_the_disabled_frame_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    movec_to(&mut cpu, &mut bus, 0x808, 0x02); // set DFP
+    // FADD.X FP0,FP1 at 0x0210
+    bus.write_word_at(0x0210, 0xF200);
+    bus.write_word_at(0x0212, 0x00A2);
+    cpu.pc = 0x0210;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0340, "disabled FPU vectors through Line-F");
+    let sp = cpu.dar[15];
+    assert_eq!(bus.read_word(sp.wrapping_add(6)), 0x402C, "format $4 frame");
+    assert_eq!(
+        bus.read_long(sp.wrapping_add(0xC)),
+        0x0210,
+        "PC of the faulted instruction at +$0C"
+    );
+    assert_eq!(bus.read_long(sp.wrapping_add(2)), 0x0210, "restart PC");
+}
+
+#[test]
+fn fsave_writes_060_frames_and_frestore_null_resets() {
+    let (mut cpu, mut bus) = setup_060();
+    // FSAVE -(A0) straight after reset: 12-byte NULL frame.
+    bus.write_word_at(0x0200, 0xF320);
+    cpu.dar[8] = 0x5000;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.dar[8], 0x4FF4, "060 state frame is 12 bytes");
+    assert_eq!(bus.read_long(0x4FF4), 0, "NULL frame after reset");
+
+    // Touch the FPU, then FSAVE again: IDLE frame (format byte $60).
+    bus.write_word_at(0x0202, 0xF200); // FADD.X FP0,FP1
+    bus.write_word_at(0x0204, 0x00A2);
+    bus.write_word_at(0x0206, 0xF320); // FSAVE -(A0)
+    step(&mut cpu, &mut bus);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.dar[8], 0x4FE8);
+    assert_eq!(bus.read_long(0x4FE8), 0x0000_6000, "IDLE frame format $60");
+
+    // FRESTORE (A0)+ of a NULL frame resets the FPU.
+    cpu.fpcr = 0x1234;
+    bus.write_long_at(0x6000, 0);
+    bus.write_word_at(0x0208, 0xF358); // FRESTORE (A0)+
+    cpu.dar[8] = 0x6000;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.dar[8], 0x600C, "FRESTORE consumes 12 bytes");
+    assert_eq!(cpu.fpcr, 0, "NULL frame resets the FPU");
+}

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -516,30 +516,39 @@ fn pcr_dfp_takes_the_disabled_frame_on_68060() {
 #[test]
 fn fsave_writes_060_frames_and_frestore_null_resets() {
     let (mut cpu, mut bus) = setup_060();
-    // FSAVE -(A0) straight after reset: 12-byte NULL frame.
+    // FSAVE -(A0) straight after reset: one-long NULL frame (the size
+    // AmigaOS's hand-built task contexts rely on).
     bus.write_word_at(0x0200, 0xF320);
     cpu.dar[8] = 0x5000;
     step(&mut cpu, &mut bus);
-    assert_eq!(cpu.dar[8], 0x4FF4, "060 state frame is 12 bytes");
-    assert_eq!(bus.read_long(0x4FF4), 0, "NULL frame after reset");
+    assert_eq!(cpu.dar[8], 0x4FFC, "NULL state frame is one long word");
+    assert_eq!(bus.read_long(0x4FFC), 0, "NULL frame after reset");
 
-    // Touch the FPU, then FSAVE again: IDLE frame (format byte $60).
+    // Touch the FPU, then FSAVE again: 12-byte IDLE frame (format $60).
     bus.write_word_at(0x0202, 0xF200); // FADD.X FP0,FP1
     bus.write_word_at(0x0204, 0x00A2);
     bus.write_word_at(0x0206, 0xF320); // FSAVE -(A0)
     step(&mut cpu, &mut bus);
     step(&mut cpu, &mut bus);
-    assert_eq!(cpu.dar[8], 0x4FE8);
-    assert_eq!(bus.read_long(0x4FE8), 0x0000_6000, "IDLE frame format $60");
+    assert_eq!(cpu.dar[8], 0x4FF0, "IDLE state frame is 12 bytes");
+    assert_eq!(bus.read_long(0x4FF0), 0x0000_6000, "IDLE frame format $60");
 
-    // FRESTORE (A0)+ of a NULL frame resets the FPU.
+    // FRESTORE (A0)+ sizes the frame from the format byte: a NULL frame
+    // consumes one long and resets the FPU.
     cpu.fpcr = 0x1234;
     bus.write_long_at(0x6000, 0);
     bus.write_word_at(0x0208, 0xF358); // FRESTORE (A0)+
     cpu.dar[8] = 0x6000;
     step(&mut cpu, &mut bus);
-    assert_eq!(cpu.dar[8], 0x600C, "FRESTORE consumes 12 bytes");
+    assert_eq!(cpu.dar[8], 0x6004, "NULL FRESTORE consumes one long");
     assert_eq!(cpu.fpcr, 0, "NULL frame resets the FPU");
+
+    // An IDLE frame consumes the full 12 bytes.
+    bus.write_long_at(0x7000, 0x0000_6000);
+    bus.write_word_at(0x020A, 0xF358); // FRESTORE (A0)+
+    cpu.dar[8] = 0x7000;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.dar[8], 0x700C, "IDLE FRESTORE consumes 12 bytes");
 }
 
 /// Identity-map the 4 KB page containing `logical` through a 68040-style

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -152,3 +152,103 @@ fn full_extension_word_ea_executes_on_68060() {
     assert_eq!(cpu.pc, 0x0206);
     assert_eq!(cpu.dar[0], 0xCAFE_F00D, "scaled full-format EA must resolve");
 }
+
+/// MOVEC Rc,Dn / Dn,Rc helpers: assemble at 0x0200 and step once.
+fn movec_from(cpu: &mut CpuCore, bus: &mut TestBus, ctrl_reg: u16) -> StepResult {
+    bus.write_word_at(0x0200, 0x4E7A);
+    bus.write_word_at(0x0202, ctrl_reg); // D0
+    cpu.pc = 0x0200;
+    step(cpu, bus)
+}
+
+fn movec_to(cpu: &mut CpuCore, bus: &mut TestBus, ctrl_reg: u16, value: u32) -> StepResult {
+    bus.write_word_at(0x0200, 0x4E7B);
+    bus.write_word_at(0x0202, ctrl_reg); // D0
+    cpu.dar[0] = value;
+    cpu.pc = 0x0200;
+    step(cpu, bus)
+}
+
+#[test]
+fn movec_caar_mmusr_msp_isp_are_illegal_on_68060() {
+    for ctrl_reg in [0x802u16, 0x805, 0x803, 0x804] {
+        let (mut cpu, mut bus) = setup_060();
+        let result = movec_from(&mut cpu, &mut bus, ctrl_reg);
+        assert!(matches!(result, StepResult::Ok { .. }));
+        assert_eq!(
+            cpu.pc, 0x0300,
+            "MOVEC ${ctrl_reg:03X} must be illegal on the 68060"
+        );
+    }
+}
+
+#[test]
+fn movec_pcr_round_trips_with_read_only_identification() {
+    let (mut cpu, mut bus) = setup_060();
+    // Write all-ones: only EDEBUG/DFP/ESS may stick.
+    movec_to(&mut cpu, &mut bus, 0x808, 0xFFFF_FFFF);
+    movec_from(&mut cpu, &mut bus, 0x808);
+    assert_eq!(
+        cpu.dar[0],
+        0x0430_0100 | 0x83,
+        "identification/revision read-only; EDEBUG/DFP/ESS writable"
+    );
+}
+
+#[test]
+fn movec_buscr_does_not_alias_dacr0_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    cpu.dacr0 = 0xDEAD_BEEF;
+    movec_to(&mut cpu, &mut bus, 0x008, 0x1234_5678);
+    assert_eq!(cpu.buscr, 0x1234_5678);
+    assert_eq!(cpu.dacr0, 0xDEAD_BEEF, "BUSCR write must not touch DACR0");
+    movec_from(&mut cpu, &mut bus, 0x008);
+    assert_eq!(cpu.dar[0], 0x1234_5678);
+}
+
+#[test]
+fn movec_pcr_is_illegal_on_68040() {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    let mut bus = TestBus::new();
+    bus.write_long_at(0x00, 0x1000);
+    bus.write_long_at(0x04, 0x0200);
+    bus.write_long_at(0x10, 0x0300);
+    cpu.reset(&mut bus);
+    cpu.set_sr(0x2700);
+    // The 040 register table has no 0x808 decode: reads return 0 rather than
+    // trapping (matching the existing permissive 040 MOVEC model).
+    let result = movec_from(&mut cpu, &mut bus, 0x808);
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert_eq!(cpu.dar[0], 0, "PCR must not exist on the 68040");
+}
+
+#[test]
+fn cacr_060_persists_enables_and_discards_strobes() {
+    let (mut cpu, mut bus) = setup_060();
+    // EDC | EBC | CABC | EIC: the clear strobe must not store.
+    movec_to(
+        &mut cpu,
+        &mut bus,
+        0x002,
+        (1 << 31) | (1 << 23) | (1 << 22) | (1 << 15),
+    );
+    movec_from(&mut cpu, &mut bus, 0x002);
+    assert_eq!(
+        cpu.dar[0],
+        (1u32 << 31) | (1 << 23) | (1 << 15),
+        "EDC/EBC/EIC persist; CABC reads back 0"
+    );
+}
+
+#[test]
+fn m_bit_does_not_switch_stacks_on_68060() {
+    let (mut cpu, _bus) = setup_060();
+    cpu.dar[15] = 0x0000_2000;
+    // Setting M on an 020/040 would bank A7 to the MSP; the 060 has a
+    // single supervisor stack, so A7 must stay put.
+    cpu.set_sr(0x3700);
+    assert_eq!(cpu.dar[15], 0x0000_2000, "no MSP bank on the 68060");
+    cpu.set_sr(0x2700);
+    assert_eq!(cpu.dar[15], 0x0000_2000);
+}

--- a/crates/m68k/tests/m68060_tests.rs
+++ b/crates/m68k/tests/m68060_tests.rs
@@ -541,3 +541,83 @@ fn fsave_writes_060_frames_and_frestore_null_resets() {
     assert_eq!(cpu.dar[8], 0x600C, "FRESTORE consumes 12 bytes");
     assert_eq!(cpu.fpcr, 0, "NULL frame resets the FPU");
 }
+
+/// Identity-map the 4 KB page containing `logical` through a 68040-style
+/// table (the 68060 shares the walker), optionally write-protected.
+fn build_060_table(bus: &mut TestBus, logical: u32, write_protect: bool) -> u32 {
+    const ROOT: u32 = 0x2000;
+    const PTR: u32 = 0x3000;
+    const PAGE: u32 = 0x4000;
+    let root_idx = (logical >> 25) & 0x7F;
+    let ptr_idx = (logical >> 18) & 0x7F;
+    let page_idx = (logical >> 12) & 0x3F;
+    bus.write_long_at(ROOT + root_idx * 4, PTR | 2);
+    bus.write_long_at(PTR + ptr_idx * 4, PAGE | 2);
+    let mut pd = (logical & 0xFFFF_F000) | 1;
+    if write_protect {
+        pd |= 0x0000_0004;
+    }
+    bus.write_long_at(PAGE + page_idx * 4, pd);
+    ROOT
+}
+
+#[test]
+fn mmu_write_protect_pushes_format_4_with_fslw_on_68060() {
+    let (mut cpu, mut bus) = setup_060();
+    bus.write_long_at(0x08, 0x0400); // vector 2: access error
+    build_060_table(&mut bus, 0x0000, false); // stack/vector page stays writable
+    let root = build_060_table(&mut bus, 0x1000, true);
+    movec_to(&mut cpu, &mut bus, 0x807, root); // SRP
+    movec_to(&mut cpu, &mut bus, 0x003, 0x0000_8000); // TC enable
+
+    // MOVE.L D0,(A0) into the write-protected page.
+    bus.write_word_at(0x0210, 0x2080);
+    cpu.dar[0] = 0xDEAD_BEEF;
+    cpu.dar[8] = 0x1000;
+    cpu.pc = 0x0210;
+    let sp_before = cpu.dar[15];
+    step(&mut cpu, &mut bus);
+
+    assert_eq!(cpu.pc, 0x0400, "write-protect fault vectors through 2");
+    let sp = cpu.dar[15];
+    assert_eq!(sp_before.wrapping_sub(sp), 16, "format $4 frame is 8 words");
+    assert_eq!(bus.read_word(sp.wrapping_add(6)), 0x4008, "format $4, vector 2");
+    assert_eq!(bus.read_long(sp.wrapping_add(2)), 0x0210, "restart PC");
+    assert_eq!(bus.read_long(sp.wrapping_add(8)), 0x1000, "fault address");
+    // FSLW: write, size long, TM = supervisor data (5), WP cause.
+    let fslw = bus.read_long(sp.wrapping_add(0xC));
+    assert_eq!(fslw, 0x0080_0000 | (5 << 16) | 0x80, "FSLW W|TM|WP");
+
+    // RTE from the handler pops the whole frame and restarts the write
+    // (which faults again - the page is still protected - proving the
+    // restart semantics rather than a skip).
+    bus.write_word_at(0x0400, 0x4E73);
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0210, "RTE format $4 restarts the instruction");
+    assert_eq!(cpu.dar[15], sp_before, "RTE consumed all 8 words");
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0400, "the restarted write faults again");
+}
+
+#[test]
+fn rte_pops_format_7_frame_on_68040() {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    let mut bus = TestBus::new();
+    bus.write_long_at(0x00, 0x1000);
+    bus.write_long_at(0x04, 0x0200);
+    cpu.reset(&mut bus);
+    cpu.set_sr(0x2700);
+
+    // Hand-build a format 7 (30-word) access-error frame at 0x0F00.
+    let sp = 0x0F00u32;
+    bus.write_word_at(sp, 0x2700); // SR
+    bus.write_long_at(sp + 2, 0x0555); // PC
+    bus.write_word_at(sp + 6, 0x7008); // format 7, vector 2
+    cpu.dar[15] = sp;
+    bus.write_word_at(0x0200, 0x4E73); // RTE
+    cpu.pc = 0x0200;
+    step(&mut cpu, &mut bus);
+    assert_eq!(cpu.pc, 0x0555, "RTE must pop the 040 access-error frame");
+    assert_eq!(cpu.dar[15], sp + 60, "30 words consumed");
+}

--- a/crates/m68k/tests/timing_060_tests.rs
+++ b/crates/m68k/tests/timing_060_tests.rs
@@ -170,3 +170,109 @@ fn other_models_keep_their_cycle_counts() {
         );
     }
 }
+
+/// Enable the branch cache (CACR.EBC) via MOVEC.
+fn enable_ebc(cpu: &mut CpuCore, bus: &mut TestBus, extra: u32) {
+    let pc = cpu.pc;
+    bus.write_word_at(0x0100, 0x4E7B); // MOVEC D0,CACR
+    bus.write_word_at(0x0102, 0x0002);
+    cpu.dar[0] = (1 << 23) | extra;
+    cpu.pc = 0x0100;
+    step_cycles(cpu, bus);
+    cpu.pc = pc;
+}
+
+#[test]
+fn branch_cache_folds_the_second_taken_branch() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ebc(&mut cpu, &mut bus, 0);
+    // BRA.S looping on itself.
+    bus.write_word_at(0x0200, 0x60FE);
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        7,
+        "first taken branch misses and pays the refill"
+    );
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        0,
+        "second execution is predicted and folded"
+    );
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0);
+}
+
+#[test]
+fn branch_cache_cabc_strobe_clears_and_ebc_off_is_static() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ebc(&mut cpu, &mut bus, 0);
+    bus.write_word_at(0x0200, 0x60FE); // BRA.S self
+    step_cycles(&mut cpu, &mut bus);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "folded before the clear");
+
+    enable_ebc(&mut cpu, &mut bus, 1 << 22); // EBC | CABC strobe
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        7,
+        "CABC cleared the entry: miss again"
+    );
+
+    // EBC off: static cost every time, no learning.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    bus.write_word_at(0x0200, 0x60FE);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "EBC off never folds");
+}
+
+#[test]
+fn branch_cache_counter_follows_alternating_condition() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ebc(&mut cpu, &mut bus, 0);
+    // BEQ.S +2: toggle Z each execution by re-running the same branch.
+    bus.write_word_at(0x0200, 0x6702);
+    // taken (Z set), miss -> mispredict cost, allocates weakly-taken.
+    cpu.set_sr(0x2704);
+    cpu.pc = 0x0200;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "taken miss");
+    // not taken (Z clear), predicted taken -> mispredict; counter 2->1.
+    cpu.set_sr(0x2700);
+    cpu.pc = 0x0200;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "hit-wrong");
+    // not taken again, counter 1 predicts not-taken -> 1 cycle.
+    cpu.pc = 0x0200;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "correct not-taken");
+    // taken, predicted not-taken -> mispredict; counter 0->1... then grows.
+    cpu.set_sr(0x2704);
+    cpu.pc = 0x0200;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7);
+}
+
+#[test]
+fn branch_cache_cubc_clears_only_user_entries() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ebc(&mut cpu, &mut bus, 0);
+    // Allocate in supervisor mode.
+    bus.write_word_at(0x0200, 0x60FE);
+    step_cycles(&mut cpu, &mut bus);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "supervisor entry folded");
+    // CUBC must not clear a supervisor entry.
+    enable_ebc(&mut cpu, &mut bus, 1 << 21);
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        0,
+        "supervisor entry survives CUBC"
+    );
+}
+
+#[test]
+fn dbcc_loop_folds_with_branch_cache() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ebc(&mut cpu, &mut bus, 0);
+    bus.write_word_at(0x0200, 0x51C8); // DBF D0,-2 (self-loop)
+    bus.write_word_at(0x0202, 0xFFFE);
+    cpu.dar[0] = 3;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "first loop iteration misses");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "steady-state loop folds");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0);
+    // Expiry: predicted taken but falls through -> mispredict.
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "loop exit mispredicts");
+}

--- a/crates/m68k/tests/timing_060_tests.rs
+++ b/crates/m68k/tests/timing_060_tests.rs
@@ -186,19 +186,30 @@ fn enable_ebc(cpu: &mut CpuCore, bus: &mut TestBus, extra: u32) {
 fn branch_cache_folds_the_second_taken_branch() {
     let (mut cpu, mut bus) = setup(CpuType::M68060);
     enable_ebc(&mut cpu, &mut bus, 0);
-    // BRA.S looping on itself.
-    bus.write_word_at(0x0200, 0x60FE);
+    // MOVEQ + BRA.S back to the MOVEQ: the branch folds onto the MOVEQ.
+    bus.write_word_at(0x0200, 0x7000);
+    bus.write_word_at(0x0202, 0x60FC);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "moveq");
     assert_eq!(
         step_cycles(&mut cpu, &mut bus),
         7,
         "first taken branch misses and pays the refill"
     );
+    step_cycles(&mut cpu, &mut bus); // moveq
     assert_eq!(
         step_cycles(&mut cpu, &mut bus),
         0,
-        "second execution is predicted and folded"
+        "predicted branch folds onto the preceding instruction"
     );
-    assert_eq!(step_cycles(&mut cpu, &mut bus), 0);
+
+    // A bare self-loop cannot fold into nothing: one clock per iteration,
+    // so a predicted idle loop still advances emulated time.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ebc(&mut cpu, &mut bus, 0);
+    bus.write_word_at(0x0200, 0x60FE); // BRA.S self
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 7);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "lone branch still issues");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
 }
 
 #[test]
@@ -207,7 +218,7 @@ fn branch_cache_cabc_strobe_clears_and_ebc_off_is_static() {
     enable_ebc(&mut cpu, &mut bus, 0);
     bus.write_word_at(0x0200, 0x60FE); // BRA.S self
     step_cycles(&mut cpu, &mut bus);
-    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "folded before the clear");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "predicted before the clear");
 
     enable_ebc(&mut cpu, &mut bus, 1 << 22); // EBC | CABC strobe
     assert_eq!(
@@ -253,12 +264,12 @@ fn branch_cache_cubc_clears_only_user_entries() {
     // Allocate in supervisor mode.
     bus.write_word_at(0x0200, 0x60FE);
     step_cycles(&mut cpu, &mut bus);
-    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "supervisor entry folded");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "supervisor entry predicted");
     // CUBC must not clear a supervisor entry.
     enable_ebc(&mut cpu, &mut bus, 1 << 21);
     assert_eq!(
         step_cycles(&mut cpu, &mut bus),
-        0,
+        1,
         "supervisor entry survives CUBC"
     );
 }
@@ -271,8 +282,12 @@ fn dbcc_loop_folds_with_branch_cache() {
     bus.write_word_at(0x0202, 0xFFFE);
     cpu.dar[0] = 3;
     assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "first loop iteration misses");
-    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "steady-state loop folds");
-    assert_eq!(step_cycles(&mut cpu, &mut bus), 0);
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        1,
+        "steady-state lone-DBcc loop runs one clock per iteration"
+    );
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
     // Expiry: predicted taken but falls through -> mispredict.
     assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "loop exit mispredicts");
 }

--- a/crates/m68k/tests/timing_060_tests.rs
+++ b/crates/m68k/tests/timing_060_tests.rs
@@ -1,0 +1,172 @@
+//! 68060 cycle-cost model: classification spot checks and scalar costs.
+//! Pairing and branch-cache behavior get their own tests as those land.
+
+use m68k::core::memory::AddressBus;
+use m68k::core::timing_060::{info_060, OepClass};
+use m68k::{CpuCore, CpuType, NoOpHleHandler, StepResult};
+
+struct TestBus {
+    memory: Vec<u8>,
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self {
+            memory: vec![0; 0x10000],
+        }
+    }
+
+    fn write_word_at(&mut self, addr: u32, value: u16) {
+        let bytes = value.to_be_bytes();
+        self.memory[addr as usize] = bytes[0];
+        self.memory[addr as usize + 1] = bytes[1];
+    }
+
+    fn write_long_at(&mut self, addr: u32, value: u32) {
+        let bytes = value.to_be_bytes();
+        self.memory[addr as usize..addr as usize + 4].copy_from_slice(&bytes);
+    }
+}
+
+impl AddressBus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.memory[(address as usize) & 0xFFFF]
+    }
+
+    fn read_word(&mut self, address: u32) -> u16 {
+        let addr = (address as usize) & 0xFFFF;
+        u16::from_be_bytes([self.memory[addr], self.memory[addr + 1]])
+    }
+
+    fn read_long(&mut self, address: u32) -> u32 {
+        let addr = (address as usize) & 0xFFFF;
+        u32::from_be_bytes([
+            self.memory[addr],
+            self.memory[addr + 1],
+            self.memory[addr + 2],
+            self.memory[addr + 3],
+        ])
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.memory[(address as usize) & 0xFFFF] = value;
+    }
+
+    fn write_word(&mut self, address: u32, value: u16) {
+        let addr = (address as usize) & 0xFFFF;
+        let bytes = value.to_be_bytes();
+        self.memory[addr] = bytes[0];
+        self.memory[addr + 1] = bytes[1];
+    }
+
+    fn write_long(&mut self, address: u32, value: u32) {
+        let addr = (address as usize) & 0xFFFF;
+        let bytes = value.to_be_bytes();
+        self.memory[addr..addr + 4].copy_from_slice(&bytes);
+    }
+}
+
+fn setup(cpu_type: CpuType) -> (CpuCore, TestBus) {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(cpu_type);
+    let mut bus = TestBus::new();
+    bus.write_long_at(0x00, 0x1000);
+    bus.write_long_at(0x04, 0x0200);
+    cpu.reset(&mut bus);
+    cpu.pc = 0x0200;
+    cpu.set_sr(0x2700);
+    (cpu, bus)
+}
+
+fn step_cycles(cpu: &mut CpuCore, bus: &mut TestBus) -> i32 {
+    let mut hle = NoOpHleHandler;
+    match cpu.step_with_hle_handler(bus, &mut hle) {
+        StepResult::Ok { cycles } => cycles,
+        other => panic!("unexpected step result: {other:?}"),
+    }
+}
+
+#[test]
+fn classification_spot_checks() {
+    // MOVEQ #0,D0: the canonical 1-cycle pOEP|sOEP instruction.
+    assert_eq!(info_060(0x7000).class(), OepClass::PoepSoep);
+    assert_eq!(info_060(0x7000).cycles(), 1);
+    // MULU.W D0,D0: pOEP-only.
+    assert_eq!(info_060(0xC0C0).class(), OepClass::PoepOnly);
+    // MOVEM.L D0-A6,-(A7): pOEP-until-last.
+    assert_eq!(info_060(0x48E7).class(), OepClass::PoepUntilLast);
+    // ADD.L D1,D0 (0xD081): pOEP|sOEP.
+    assert_eq!(info_060(0xD081).class(), OepClass::PoepSoep);
+    // LSL.L #1,D0 (0xE388): register shifts pair.
+    assert_eq!(info_060(0xE388).class(), OepClass::PoepSoep);
+    // ROXL.L #1,D0 (0xE390): consumes X, pOEP-only.
+    assert_eq!(info_060(0xE390).class(), OepClass::PoepOnly);
+}
+
+#[test]
+fn scalar_costs_one_cycle_alu_on_68060() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    bus.write_word_at(0x0200, 0x7000); // MOVEQ #0,D0
+    bus.write_word_at(0x0202, 0xD081); // ADD.L D1,D0
+    bus.write_word_at(0x0204, 0x4E71); // NOP
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "MOVEQ is 1 cycle");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "ADD.L Dn,Dn is 1 cycle");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "NOP is 1 cycle");
+}
+
+#[test]
+fn branch_costs_taken_vs_not_taken_on_68060() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    // BEQ.S +2 with Z clear: not taken.
+    bus.write_word_at(0x0200, 0x6702);
+    // BRA.S back to 0x0200: taken.
+    bus.write_word_at(0x0202, 0x60FC);
+    cpu.set_sr(0x2700); // Z clear
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "not-taken Bcc is 1 cycle");
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        7,
+        "taken branch without branch cache pays the refill"
+    );
+    assert_eq!(cpu.pc, 0x0200);
+}
+
+#[test]
+fn dbcc_loop_cost_on_68060() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    // DBF D0,-2 (loop on itself while D0 >= 0).
+    bus.write_word_at(0x0200, 0x51C8);
+    bus.write_word_at(0x0202, 0xFFFE);
+    cpu.dar[0] = 1;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 2, "looping DBcc");
+    assert_eq!(cpu.pc, 0x0200);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 3, "expired DBcc");
+    assert_eq!(cpu.pc, 0x0204);
+}
+
+#[test]
+fn flow_change_pays_refill_floor_on_68060() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    bus.write_word_at(0x0200, 0x4ED0); // JMP (A0)
+    cpu.dar[8] = 0x0300;
+    let cycles = step_cycles(&mut cpu, &mut bus);
+    assert!(cycles >= 5, "JMP must pay the refill floor, got {cycles}");
+    assert_eq!(cpu.pc, 0x0300);
+}
+
+#[test]
+fn other_models_keep_their_cycle_counts() {
+    // Regression guard: the 060 cost model must not disturb 000-040 paths.
+    for (cpu_type, moveq_expected) in [
+        (CpuType::M68000, 4),
+        (CpuType::M68030, 3), // ((4*5+7)/8).max(2)
+    ] {
+        let (mut cpu, mut bus) = setup(cpu_type);
+        bus.write_word_at(0x0200, 0x7000);
+        assert_eq!(
+            step_cycles(&mut cpu, &mut bus),
+            moveq_expected,
+            "{cpu_type:?} MOVEQ cycles changed"
+        );
+    }
+}

--- a/crates/m68k/tests/timing_060_tests.rs
+++ b/crates/m68k/tests/timing_060_tests.rs
@@ -276,3 +276,173 @@ fn dbcc_loop_folds_with_branch_cache() {
     // Expiry: predicted taken but falls through -> mispredict.
     assert_eq!(step_cycles(&mut cpu, &mut bus), 7, "loop exit mispredicts");
 }
+
+/// Enable superscalar dispatch (PCR.ESS) via MOVEC.
+fn enable_ess(cpu: &mut CpuCore, bus: &mut TestBus) {
+    let pc = cpu.pc;
+    bus.write_word_at(0x0110, 0x4E7B); // MOVEC D0,PCR
+    bus.write_word_at(0x0112, 0x0808);
+    cpu.dar[0] = 1; // ESS
+    cpu.pc = 0x0110;
+    step_cycles(cpu, bus);
+    cpu.pc = pc;
+    cpu.dar[0] = 0;
+}
+
+#[test]
+fn independent_pair_folds_to_one_cycle_total() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7000); // MOVEQ #0,D0
+    bus.write_word_at(0x0202, 0x7201); // MOVEQ #1,D1
+    bus.write_word_at(0x0204, 0x7402); // MOVEQ #2,D2
+    bus.write_word_at(0x0206, 0x7603); // MOVEQ #3,D3
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "head pays the cycle");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "partner folds");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "next head");
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 0, "next partner");
+}
+
+#[test]
+fn dependencies_and_classes_block_pairing() {
+    // RAW: the partner reads the head's result.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7007); // MOVEQ #7,D0
+    bus.write_word_at(0x0202, 0x2200); // MOVE.L D0,D1
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "RAW blocks the fold");
+
+    // WAW: both write the same register.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7007);
+    bus.write_word_at(0x0202, 0x7009); // MOVEQ #9,D0
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "WAW blocks the fold");
+
+    // pOEP-only partner never dispatches to the sOEP.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7007);
+    bus.write_word_at(0x0202, 0xC4C1); // MULU.W D1,D2
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 2, "pOEP-only partner");
+
+    // A late CCR consumer cannot pair behind a CCR producer.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7007); // MOVEQ (defines CCR)
+    bus.write_word_at(0x0202, 0x51C1); // SF D1 (consumes CCR late)
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "CCR rule blocks");
+}
+
+#[test]
+fn ess_clear_or_uncached_stream_never_folds() {
+    // ESS clear (reset state): scalar.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    bus.write_word_at(0x0200, 0x7000);
+    bus.write_word_at(0x0202, 0x7201);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "ESS clear runs scalar");
+
+    // A bus whose fetches never hit an icache: scalar too.
+    struct UncachedBus(TestBus);
+    impl AddressBus for UncachedBus {
+        fn read_byte(&mut self, a: u32) -> u8 {
+            self.0.read_byte(a)
+        }
+        fn read_word(&mut self, a: u32) -> u16 {
+            self.0.read_word(a)
+        }
+        fn read_long(&mut self, a: u32) -> u32 {
+            self.0.read_long(a)
+        }
+        fn write_byte(&mut self, a: u32, v: u8) {
+            self.0.write_byte(a, v)
+        }
+        fn write_word(&mut self, a: u32, v: u16) {
+            self.0.write_word(a, v)
+        }
+        fn write_long(&mut self, a: u32, v: u32) {
+            self.0.write_long(a, v)
+        }
+        fn last_fetch_was_cached(&self) -> bool {
+            false
+        }
+    }
+    let (mut cpu, bus) = setup(CpuType::M68060);
+    let mut bus = UncachedBus(bus);
+    // Enable ESS directly (the helper wants a TestBus).
+    cpu.write_control_register(0x808, 1);
+    bus.0.write_word_at(0x0200, 0x7000);
+    bus.0.write_word_at(0x0202, 0x7201);
+    let mut hle = NoOpHleHandler;
+    let c1 = match cpu.step_with_hle_handler(&mut bus, &mut hle) {
+        StepResult::Ok { cycles } => cycles,
+        other => panic!("{other:?}"),
+    };
+    let c2 = match cpu.step_with_hle_handler(&mut bus, &mut hle) {
+        StepResult::Ok { cycles } => cycles,
+        other => panic!("{other:?}"),
+    };
+    assert_eq!((c1, c2), (1, 1), "uncached fetch stream runs scalar");
+}
+
+#[test]
+fn no_fold_across_a_trap_or_taken_branch() {
+    // TRAP between two otherwise-pairable instructions.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_long_at(0x80, 0x0300); // vector 32 (TRAP #0)
+    bus.write_word_at(0x0200, 0x7000); // MOVEQ (opens a window)
+    bus.write_word_at(0x0202, 0x4E40); // TRAP #0
+    bus.write_word_at(0x0300, 0x7201); // MOVEQ at the handler
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    step_cycles(&mut cpu, &mut bus); // TRAP
+    assert_eq!(cpu.pc, 0x0300);
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        1,
+        "no pairing window survives an exception"
+    );
+
+    // Taken branch between the pair.
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7000); // MOVEQ (opens a window)
+    bus.write_word_at(0x0202, 0x6002); // BRA.S +2
+    bus.write_word_at(0x0206, 0x7201); // MOVEQ at the target
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1);
+    step_cycles(&mut cpu, &mut bus); // BRA
+    assert_eq!(
+        step_cycles(&mut cpu, &mut bus),
+        1,
+        "no pairing window survives a taken branch"
+    );
+}
+
+#[test]
+fn pairing_state_survives_serialization() {
+    let (mut cpu, mut bus) = setup(CpuType::M68060);
+    enable_ess(&mut cpu, &mut bus);
+    bus.write_word_at(0x0200, 0x7000);
+    bus.write_word_at(0x0202, 0x7201);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 1, "head opens the window");
+
+    // Round-trip the whole CPU mid-window: the partner must still fold.
+    let blob = serde_json::to_string(&cpu).expect("serialize");
+    let mut restored: CpuCore = serde_json::from_str(&blob).expect("deserialize");
+    assert_eq!(
+        {
+            let mut hle = NoOpHleHandler;
+            match restored.step_with_hle_handler(&mut bus, &mut hle) {
+                StepResult::Ok { cycles } => cycles,
+                other => panic!("{other:?}"),
+            }
+        },
+        0,
+        "restored state folds identically"
+    );
+}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -37,7 +37,7 @@ range checks as the equivalent TOML fields:
 |---|---|---|
 | `--model NAME` | `[machine] profile` | `A1000`, `A500`, `A500OCS`, `A500Plus`, `A600`, `A1200`, `CDTV`, `CD32` |
 | `--chipset NAME` | `[chipset] revision` | `OCS`, `ECS`, `AGA` |
-| `--cpu MODEL` | `[cpu] model` | `68000`, `68EC020`, `68020`, `68030`, `68040` |
+| `--cpu MODEL` | `[cpu] model` | `68000`, `68EC020`, `68020`, `68030`, `68040`, `68060` |
 | `--cpu-clock MHZ` | `[cpu] clock_mhz` | a number of MHz |
 | `--fpu` / `--no-fpu` | `[cpu] fpu` | fit / omit a 68881/68882 |
 | `--chip SIZE` | `[memory] chip` | `512K`, `1M`, `2M`, ... |
@@ -195,27 +195,46 @@ carried no information.)
 
 ```toml
 [cpu]
-model = "68000"     # 68000, 68EC020, 68020, 68030, 68040
+model = "68000"     # 68000, 68EC020, 68020, 68030, 68040, 68060
 clock_mhz = 14.0    # optional; defaults to the model's stock speed
-# icache = false    # instruction-cache model (on by default: 020/030/040)
-# dcache = false    # data-cache model (on by default: 030/040)
+# icache = false    # instruction-cache model (on by default: 020/030/040/060)
+# dcache = false    # data-cache model (on by default: 030/040/060)
 # fpu = true        # fit a 68881/68882 (68020/68030; needs the coprocessor
 #                   # interface, so not valid on a 68000). The full 68040's
-#                   # on-die FPU is enabled by default.
+#                   # and 68060's on-die FPUs are enabled by default.
+# unimplemented = "trap"  # 68060 only: "trap" (faithful; the OS needs
+#                   # 68060.library) or "native" (execute the removed
+#                   # instructions directly)
 ```
 
 - `model`: the 68EC020 is a 68020 instruction set with a 24-bit external
-  address bus. The 68060 is explicitly unsupported.
+  address bus.
 - `clock_mhz` defaults to the model's stock speed (68000 ~7.09, 020 ~14,
-  030/040 ~25) and is modelled as a whole multiple of the colour clock
+  030/040 ~25, 060 50) and is modelled as a whole multiple of the colour clock
   (3.546895 MHz). Fast RAM and ROM run at the CPU clock; chip and slow RAM
   stay chip-bus bound, so overclocking speeds up only what a real
   accelerator would speed up.
 - `icache`/`dcache` model the on-chip caches and default **on** for the
-  silicon that has them (instruction cache on the 020/68EC020/030/040, data
-  cache on the 030/040), matching real hardware where AmigaOS enables them via
-  CACR. The cache is sized to the CPU: 256 bytes on the 020/030, 4 KB on the
-  040. Set either to `false` to opt out. This is not cosmetic: code that loops
+  silicon that has them (instruction cache on the 020/68EC020/030/040/060,
+  data cache on the 030/040/060), matching real hardware where AmigaOS
+  enables them via CACR. The cache is sized to the CPU: 256 bytes on the
+  020/030, 4 KB on the 040, 8 KB on the 060. Set either to `false` to opt
+  out.
+- `unimplemented` (68060 only) picks what happens on the instructions the
+  68060 dropped from silicon: MOVEP, CHK2/CMP2, CAS2, misaligned CAS,
+  64-bit MUL/DIV, and most of the FPU beyond basic arithmetic
+  (transcendentals, FMOVECR, packed decimal). `"trap"` (the default) is
+  what the chip does - they raise the unimplemented-instruction exceptions
+  and the OS-side `68060.library` emulates them, exactly as on a real
+  CyberStorm or Blizzard board, so software using them needs that library
+  installed. `"native"` executes them directly for systems without it.
+  Kickstart 3.1 itself boots fine under `"trap"`. `fpu = false` on the
+  68060 models the LC/EC060: FP instructions take the FPU-disabled
+  exception (PCR.DFP), which an OS handler can also use to enable and
+  restart. The 68060's superscalar dual-issue and branch cache are
+  modelled and activate when system software enables them (PCR.ESS and
+  CACR.EBC, which `68060.library` does at boot); until then the chip runs
+  scalar, as on real silicon. This is not cosmetic: code that loops
   out of chip RAM otherwise contends with bitplane DMA on every instruction
   fetch and can run at roughly half speed, which is why an AGA demo's music or
   animation may pace correctly only with the cache modelled. The data cache
@@ -242,7 +261,7 @@ plain byte counts, and must be multiples of 4 KiB.
   4M, or 8M.
 - **Slow RAM** ($C00000 "ranger" RAM) is arbitrated on the chip bus through
   Agnus exactly like chip RAM -- it is slow in the authentic way.
-- **Z3 RAM** requires a 68020/68030/68040 (a 24-bit bus cannot reach it);
+- **Z3 RAM** requires a 68020/68030/68040/68060 (a 24-bit bus cannot reach it);
   Kickstart assigns its base address, usually `$40000000`.
 
 Additional expansion boards can be described with `[[zorro]]` metadata

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -104,6 +104,78 @@ disabled) re-establishes the model's cache cold and re-derives its enable bits
 from the restored CACR, so the machine keeps the cache its CPU has rather than
 silently running cacheless after a load.
 
+## The 68060
+
+The 68060 is modelled as the full part: on-die FPU and MMU, the 8 KB
+caches (in the same pragmatic direct-mapped host model as the other
+parts), and its own timing engine.
+
+**Instruction set.** The 060 dropped instructions from silicon; on real
+boards the OS-side `68060.library` (Motorola's 68060SP) emulates them
+via the chip's trap interface, and Copperline models exactly that
+contract. The unimplemented integer set (MOVEP, CHK2/CMP2, CAS2,
+misaligned CAS, 64-bit MUL/DIV) raises vector 61 with a format $0 frame
+stacking the faulting instruction, gated before any architectural side
+effect so the handler can re-decode and re-execute. The unimplemented
+FPU set (the transcendentals, FINT/FINTRZ, FGETEXP/FGETMAN,
+FMOD/FREM/FSCALE, FSINCOS, FMOVECR, and the FDBcc/FTRAPcc/FScc
+conditionals) raises the Line-F vector with the six-word format $2
+frame the 68060SP dispatches on - next-instruction PC stacked, the
+calculated operand EA in the frame, FPIAR pointing at the instruction.
+Packed decimal is the unsupported-data-type exception (vector 55),
+dynamic-list FMOVEM and immediate packed operands the unimplemented-EA
+exception (vector 60). `[cpu] unimplemented = "native"` executes the
+whole set directly instead, for systems without the library. LPSTOP is
+implemented as STOP semantics.
+
+**Registers and frames.** PCR (MOVEC $808) carries the identification/
+revision word with EDEBUG/DFP/ESS writable; BUSCR shares MOVEC code
+$008 with the 040's DACR0, dispatched by model. The 060 CACR persists
+the cache/branch-cache/store-buffer enables with CABC/CUBC as
+write-only clear strobes. The part has a single supervisor stack: the
+SR M bit is storable (and interrupts clear it) but never banks A7, and
+MSP/ISP are gone from the MOVEC set. Access errors push the eight-word
+format $4 frame with the fault address and FSLW (composed from the MMU
+walk cause, R/W, size, and transfer modifier), and RTE pops it - along
+with the 040's format 7, which previously format-errored. The FPU state
+frame is one long word for NULL (as every part since the 68881; exec's
+hand-built task contexts depend on it) and three for IDLE. The MMU
+shares the 040's three-level walker and TC[15] enable; PTEST is gone
+(undefined F-line) and PLPAR/PLPAW translate an address into An,
+faulting with the format $4 frame.
+
+**Timing.** `crates/m68k/src/core/timing_060.rs` replaces the 020+
+scaling formula for the 060: every opcode word classifies (a build-once
+64K table over a pure function) into the MC68060UM Chapter 10 dispatch
+classes with a pOEP cycle cost - most ALU/move instructions one clock,
+data-dependent costs derived from the 68000-reference count as
+(raw/4).max(1). Costs are pOEP occupancy at zero-wait: memory latency
+stays billed by the host bus per access, so bus-bound code shows no
+pairing benefit, which matches silicon. Superscalar dual issue is
+modelled retrospectively: an instruction that satisfies the UM Table
+10-1 dispatch test against the previous instruction's open sOEP slot
+(pOEP|sOEP class, simple EA, no RAW/WAW against the head's defs, CCR
+rule, one memory operand per pair, both fetches icache hits, PCR.ESS
+enabled) refunds to zero additional cycles. The 256-entry branch cache
+(CACR.EBC; CABC/CUBC clears) folds correctly predicted taken branches
+onto the preceding instruction's cycle - a lone predicted branch still
+issues for one clock, which both matches the canonical one-clock
+subq/bne loop and guarantees a bare `bra self` idle loop advances
+emulated time. Both structures are serialized: prediction state changes
+cycle counts, and cycle counts change chipset interleaving. timing-test
+rows 28-30 measure the pair/RAW/loop cases end to end (a 50 MHz 060
+runs row 30 at exactly one clock per iteration).
+
+Residuals, all deliberately pessimistic (they under-pair, never
+over-pair): the sOEP EA subset and dual-memory rule are coarser than UM
+Table 10-1; the 96-byte IFU FIFO and AGU change/use stalls are not
+modelled; the store buffer is stored (CACR.ESB) but writes bill at bus
+rate; pairing across a folded branch is not modelled, and a branch
+folds only when a pairing window is open; the FSAVE EXCP frame is not
+generated (the softfloat FPU retires every operation completely); FPSR
+quotient-bit and denormal traps behave as on the other parts rather
+than through the 060's unsupported-data path.
+
 ## 68020+ timing
 
 The 68000/68010 cycle counts are validated against the
@@ -158,7 +230,7 @@ diverge.
 
 ## MMU
 
-The 68030 and 68040 model the on-chip MMU (`has_pmmu`), so software that sets up
+The 68030, 68040, and 68060 model the on-chip MMU (`has_pmmu`), so software that sets up
 and enables address translation runs rather than having its MMU writes ignored.
 The two parts differ enough to need separate walkers: the 68030 uses its
 programmable table walk (CRP/SRP selection, the TC index fields, 4-/8-byte

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -32,6 +32,9 @@
 pub const LINES_020: usize = 64;
 /// Longword entries for the 4 KB 68040 caches.
 pub const LINES_040: usize = 1024;
+/// 68060: 8 KB caches (real silicon is 4-way set-associative; the model
+/// stays pragmatically direct-mapped like the other parts).
+pub const LINES_060: usize = 2048;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LongwordCache {

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,8 @@ pub struct Config {
     /// the 68030. Only caches expansion RAM and ROM (chip/slow RAM get
     /// cache inhibit, as on real Amigas, because DMA writes them).
     pub cpu_dcache: bool,
+    /// 68060 unimplemented-instruction policy (faithful traps by default).
+    pub cpu_unimplemented: UnimplementedPolicy,
     pub emulation: Emulation,
     pub chip_ram_bytes: usize,
     pub fast_ram_bytes: usize,
@@ -426,6 +428,7 @@ pub enum CpuModel {
     M68020,
     M68030,
     M68040,
+    M68060,
 }
 
 impl CpuModel {
@@ -434,7 +437,7 @@ impl CpuModel {
     /// parts, which Copperline does not model); 68881/68882 boards for the
     /// other CPUs are opt-in via `[cpu] fpu = true`.
     pub fn default_fpu(self) -> bool {
-        self == CpuModel::M68040
+        matches!(self, CpuModel::M68040 | CpuModel::M68060)
     }
 
     /// Default CPU clock in MHz for this model: a stock 68000/68010 runs at
@@ -446,6 +449,7 @@ impl CpuModel {
             CpuModel::M68000 => 7.09,
             CpuModel::M68EC020 | CpuModel::M68020 => 14.0,
             CpuModel::M68030 | CpuModel::M68040 => 25.0,
+            CpuModel::M68060 => 50.0,
         }
     }
 
@@ -458,15 +462,30 @@ impl CpuModel {
     pub fn has_instruction_cache(self) -> bool {
         matches!(
             self,
-            CpuModel::M68EC020 | CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040
+            CpuModel::M68EC020
+                | CpuModel::M68020
+                | CpuModel::M68030
+                | CpuModel::M68040
+                | CpuModel::M68060
         )
     }
 
     /// Whether this model has the on-chip data cache Copperline models. The
     /// 68030 (256 bytes) and 68040 (4 KB) have one; the 020 has none.
     pub fn has_data_cache(self) -> bool {
-        matches!(self, CpuModel::M68030 | CpuModel::M68040)
+        matches!(self, CpuModel::M68030 | CpuModel::M68040 | CpuModel::M68060)
     }
+}
+
+/// What a 68060 does with the instructions dropped from its silicon:
+/// faithful traps (the OS-side 68060.library emulates them, as on real
+/// accelerator boards) or direct native execution for systems without
+/// the library.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum UnimplementedPolicy {
+    #[default]
+    Trap,
+    Native,
 }
 
 /// PAL Amiga colour clock (CCK), in Hz. The 68000 bus advances one slot per
@@ -724,6 +743,7 @@ impl Default for Config {
             cpu_clock_mhz: CpuModel::M68000.default_clock_mhz(),
             cpu_icache: false,
             cpu_dcache: false,
+            cpu_unimplemented: UnimplementedPolicy::Trap,
             emulation: Emulation {
                 power_on: true,
                 pacing_budget: PacingBudget::Cycles,
@@ -1202,6 +1222,13 @@ pub(crate) struct RawCpu {
     /// Model the on-chip data cache (68030 only; default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) dcache: Option<bool>,
+    /// 68060 only: what happens on the instructions the 68060 dropped from
+    /// silicon (MOVEP, CHK2/CMP2, CAS2, misaligned CAS, 64-bit MUL/DIV, the
+    /// unimplemented FPU subset). "trap" (default) is faithful - the OS
+    /// needs 68060.library to emulate them; "native" executes them directly
+    /// for systems without the library.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) unimplemented: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -1397,6 +1424,29 @@ impl TryFrom<RawConfig> for Config {
             .icache
             .unwrap_or_else(|| cpu.has_instruction_cache());
         let cpu_dcache = raw.cpu.dcache.unwrap_or_else(|| cpu.has_data_cache());
+        let cpu_unimplemented = match raw.cpu.unimplemented.as_deref() {
+            None => UnimplementedPolicy::Trap,
+            Some(s) => {
+                let policy = match s.trim().to_ascii_lowercase().as_str() {
+                    "trap" => UnimplementedPolicy::Trap,
+                    "native" => UnimplementedPolicy::Native,
+                    _ => {
+                        errors.push(anyhow!(
+                            "[cpu] unimplemented must be \"trap\" or \"native\", got {:?}",
+                            s
+                        ));
+                        UnimplementedPolicy::Trap
+                    }
+                };
+                if cpu != CpuModel::M68060 {
+                    errors.push(anyhow!(
+                        "[cpu] unimplemented applies only to the 68060 \
+                         (other models implement their full instruction sets)"
+                    ));
+                }
+                policy
+            }
+        };
         if cpu_icache && !cpu.has_instruction_cache() {
             errors.push(anyhow!(
                 "[cpu] icache = true needs a 68020/68EC020/68030/68040 \
@@ -1649,6 +1699,7 @@ impl TryFrom<RawConfig> for Config {
             cpu_clock_mhz,
             cpu_icache,
             cpu_dcache,
+            cpu_unimplemented,
             emulation,
             chip_ram_bytes,
             fast_ram_bytes,
@@ -1756,12 +1807,9 @@ fn parse_cpu(s: &str) -> Result<CpuModel> {
         "68020" | "020" => Ok(CpuModel::M68020),
         "68030" | "030" => Ok(CpuModel::M68030),
         "68040" | "040" => Ok(CpuModel::M68040),
-        "68060" | "060" => Err(anyhow!(
-            "cpu model {:?} is not supported by the m68k backend: expected 68000 / 68EC020 / 68020 / 68030 / 68040",
-            s
-        )),
+        "68060" | "060" => Ok(CpuModel::M68060),
         _ => Err(anyhow!(
-            "unknown cpu model {:?}: expected 68000 / 68EC020 / 68020 / 68030 / 68040",
+            "unknown cpu model {:?}: expected 68000 / 68EC020 / 68020 / 68030 / 68040 / 68060",
             s
         )),
     }
@@ -2046,7 +2094,10 @@ fn validate_fast_ram(fast: usize, chip: usize) -> Result<()> {
 }
 
 fn cpu_has_32bit_bus(cpu: CpuModel) -> bool {
-    matches!(cpu, CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040)
+    matches!(
+        cpu,
+        CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040 | CpuModel::M68060
+    )
 }
 
 fn validate_z3_ram(z3: usize, cpu: CpuModel) -> Result<()> {
@@ -2360,6 +2411,7 @@ mod tests {
                 clock_mhz: Some(14.18),
                 icache: Some(true),
                 dcache: None,
+                unimplemented: None,
             },
             memory: RawMemory {
                 chip: Some("2M".to_string()),
@@ -3041,16 +3093,20 @@ mod tests {
     }
 
     #[test]
-    fn cpu_68060_is_rejected() {
-        let err = parse_config(
+    fn cpu_68060_without_fpu_is_an_lc060() -> Result<()> {
+        // fpu = false on the 060 models the LC/EC parts: accepted, and the
+        // core presents it as PCR.DFP (FP instructions take the disabled
+        // trap) rather than a config error.
+        let cfg = parse_config(
             r#"
             [cpu]
             model = "68060"
             fpu = false
             "#,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("not supported"));
+        )?;
+        assert_eq!(cfg.cpu, CpuModel::M68060);
+        assert!(!cfg.fpu);
+        Ok(())
     }
 
     #[test]
@@ -3473,6 +3529,58 @@ mod tests {
         assert_eq!(clocks_per_cck_for_mhz(25.0), 7);
         // Never zero.
         assert_eq!(clocks_per_cck_for_mhz(0.5), 1);
+    }
+
+    #[test]
+    fn cpu_68060_parses_with_full_defaults() -> Result<()> {
+        let cfg = parse_config(
+            r#"
+            [cpu]
+            model = "68060"
+            "#,
+        )?;
+        assert_eq!(cfg.cpu, CpuModel::M68060);
+        assert_eq!(cfg.cpu_clock_mhz, 50.0, "060 defaults to 50 MHz");
+        assert!(cfg.fpu, "the full 68060 has its FPU on-die");
+        assert!(cfg.cpu_icache && cfg.cpu_dcache, "8 KB caches default on");
+        assert_eq!(cfg.cpu_unimplemented, UnimplementedPolicy::Trap);
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_unimplemented_policy_parses_and_is_68060_only() -> Result<()> {
+        let cfg = parse_config(
+            r#"
+            [cpu]
+            model = "68060"
+            unimplemented = "native"
+            "#,
+        )?;
+        assert_eq!(cfg.cpu_unimplemented, UnimplementedPolicy::Native);
+
+        let err = parse_config(
+            r#"
+            [cpu]
+            model = "68040"
+            unimplemented = "native"
+            "#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("applies only to the 68060"),
+            "{err}"
+        );
+
+        let err = parse_config(
+            r#"
+            [cpu]
+            model = "68060"
+            unimplemented = "sometimes"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("trap"), "{err}");
+        Ok(())
     }
 
     #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -216,9 +216,18 @@ pub fn build(
     cpu_model: CpuModel,
     fpu_enabled: bool,
     cpu_clocks_per_cck: u32,
+    unimplemented: crate::config::UnimplementedPolicy,
     _track_stopped_slice_progress: bool,
 ) -> Result<M68kMachine> {
     let mut machine = M68kMachine::new(bus, cpu_model, fpu_enabled)?;
+    machine.cpu.emulate_unimplemented_060 =
+        unimplemented == crate::config::UnimplementedPolicy::Native;
+    if cpu_model == CpuModel::M68060 && unimplemented == crate::config::UnimplementedPolicy::Trap {
+        log::info!(
+            "68060 unimplemented instructions will trap faithfully: the OS \
+             needs 68060.library (or set [cpu] unimplemented = \"native\")"
+        );
+    }
     machine.cpu_clocks_per_cck = cpu_clocks_per_cck.max(1);
     machine
         .bus
@@ -232,6 +241,12 @@ impl M68kMachine {
         let mut cpu = CpuCore::new();
         cpu.set_cpu_type(cpu_type_for_model(cpu_model));
         cpu.address_mask = address_mask_for_model(cpu_model);
+        if cpu_model == CpuModel::M68060 && !fpu_enabled {
+            // An FPU-less 060 (LC/EC060) presents as PCR.DFP: the core
+            // raises the faithful format $4 disabled frame instead of the
+            // host's generic Line-F shim for discrete 68881/68882 absence.
+            cpu.pcr |= m68k::PCR_DFP;
+        }
 
         let mut machine = Self {
             cpu,
@@ -1713,12 +1728,14 @@ impl M68kMachine {
         }
         self.last_cacr = cacr;
         let caar = self.cpu.caar;
-        // The 68040 CACR uses different enable bits (IE/DE) and has no freeze
-        // or CACR clear strobes - invalidation arrives through CINV/CPUSH,
-        // which decode.rs surfaces as the CACR_CI/CACR_CD pending ops below.
+        // The 68040/68060 CACR uses different enable bits (IE/DE - the 060's
+        // EIC/EDC sit at the same positions) and has no freeze or CACR clear
+        // strobes - invalidation arrives through CINV/CPUSH, which decode.rs
+        // surfaces as the CACR_CI/CACR_CD pending ops below. The 060's
+        // branch-cache strobes (CABC/CUBC) are consumed inside the core.
         if matches!(
             self.cpu.cpu_type,
-            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040
+            CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040 | CpuType::M68060
         ) {
             if let Some(icache) = self.bus.icache.as_deref_mut() {
                 icache.enabled = cacr & CACR_040_IE != 0;
@@ -1802,6 +1819,11 @@ impl M68kMachine {
 
     fn force_fpu_line_f_if_needed(&mut self) -> bool {
         if self.fpu_enabled {
+            return false;
+        }
+        // The 060 models FPU absence in the core via PCR.DFP (set at
+        // construction), with the proper format $4 disabled frame.
+        if self.cpu.is_060() {
             return false;
         }
         let pc = self.cpu.pc;
@@ -2545,13 +2567,16 @@ fn cpu_type_for_model(model: CpuModel) -> CpuType {
         // Full 68040: FPU on-die (default_fpu) and the MMU enabled (has_pmmu).
         // The FPU-less LC/EC variants are not modelled (see CpuModel docs).
         CpuModel::M68040 => CpuType::M68040,
+        CpuModel::M68060 => CpuType::M68060,
     }
 }
 
-/// Longword entries in each on-chip cache for this CPU: the 040's caches are
-/// 4 KB (1024 longwords), the 020/030's 256 bytes (64). See `crate::cache`.
+/// Longword entries in each on-chip cache for this CPU: the 060's caches
+/// are 8 KB (2048 longwords), the 040's 4 KB, the 020/030's 256 bytes.
+/// See `crate::cache`.
 fn cache_lines_for_cpu_type(cpu_type: CpuType) -> usize {
     match cpu_type {
+        CpuType::M68060 => crate::cache::LINES_060,
         CpuType::M68EC040 | CpuType::M68LC040 | CpuType::M68040 => crate::cache::LINES_040,
         _ => crate::cache::LINES_020,
     }
@@ -2560,7 +2585,9 @@ fn cache_lines_for_cpu_type(cpu_type: CpuType) -> usize {
 fn address_mask_for_model(model: CpuModel) -> u32 {
     match model {
         CpuModel::M68000 | CpuModel::M68EC020 => ADDRESS_MASK_24BIT,
-        CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040 => ADDRESS_MASK_32BIT,
+        CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040 | CpuModel::M68060 => {
+            ADDRESS_MASK_32BIT
+        }
     }
 }
 
@@ -2630,6 +2657,7 @@ mod tests {
                 CpuModel::M68000,
                 false,
                 clocks_per_cck,
+                Default::default(),
                 false,
             )
         };
@@ -3156,6 +3184,7 @@ mod tests {
                 CpuModel::M68EC020,
                 false,
                 4,
+                Default::default(),
                 false,
             )?;
             machine.set_cache_emulation(icache, false);
@@ -3462,7 +3491,14 @@ mod tests {
         let run = |pc: u32, clocks_per_cck: u32| -> Result<u32> {
             let mut bus = test_bus_with_pc(pc);
             write_program(&mut bus, pc, &program);
-            let mut machine = build(bus, CpuModel::M68000, false, clocks_per_cck, false)?;
+            let mut machine = build(
+                bus,
+                CpuModel::M68000,
+                false,
+                clocks_per_cck,
+                Default::default(),
+                false,
+            )?;
             machine.bus_mut().agnus.hpos = 0x21;
             let mut total = 0u32;
             for _ in 0..nops {
@@ -3938,7 +3974,7 @@ mod tests {
                 0x60EE, // bra.s back to 0x1000
             ],
         );
-        let mut machine = build(bus, CpuModel::M68000, false, 2, false)?;
+        let mut machine = build(bus, CpuModel::M68000, false, 2, Default::default(), false)?;
 
         // Get past the first frame wraps so the per-frame capture buffers
         // hold both current- and last-frame contents when the state is taken.
@@ -4023,6 +4059,7 @@ mod tests {
             bus,
             CpuModel::M68000,
             false,
+            Default::default(),
             PacingBudget::Instructions,
             2,
             false,
@@ -4104,6 +4141,7 @@ mod tests {
             bus,
             CpuModel::M68000,
             false,
+            Default::default(),
             PacingBudget::Instructions,
             2,
             false,
@@ -4171,6 +4209,7 @@ mod tests {
                 bus,
                 CpuModel::M68000,
                 false,
+                Default::default(),
                 PacingBudget::Instructions,
                 2,
                 false,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -204,6 +204,11 @@ struct CpuBus {
     /// COPPERLINE_DBG_IRQ cached time window. Interrupt acknowledge can be hot
     /// during IRQ storms, so parse the environment once at construction.
     dbg_irq_window: Option<(f64, f64)>,
+    /// Whether the most recent instruction-stream read hit the icache
+    /// model. The 68060 timing model gates superscalar pairing and branch
+    /// folding on a cached fetch stream. Recomputed on every fetch, never
+    /// carried across a save state.
+    last_fetch_cache_hit: bool,
 }
 
 pub fn build(
@@ -242,6 +247,7 @@ impl M68kMachine {
                 icache: None,
                 dcache: None,
                 dbg_irq_window: debug_irq_window_setting(),
+                last_fetch_cache_hit: false,
             },
             hle: NoOpHleHandler,
             fpu_enabled,
@@ -1951,11 +1957,20 @@ impl CpuBus {
             // miss goes through the normal (billed) path and then fills
             // the line from backing memory.
             if let Some(value) = self.cache_read(addr, size, kind) {
+                if kind == CpuBusAccessKind::Fetch {
+                    self.last_fetch_cache_hit = true;
+                }
                 return value;
             }
             let value = self.read_sized_uncached(addr, size, kind);
             self.cache_fill_after_miss(addr, size, kind);
+            if kind == CpuBusAccessKind::Fetch {
+                self.last_fetch_cache_hit = false;
+            }
             return value;
+        }
+        if kind == CpuBusAccessKind::Fetch {
+            self.last_fetch_cache_hit = false;
         }
         self.read_sized_uncached(addr, size, kind)
     }
@@ -2418,6 +2433,10 @@ impl CpuBus {
 }
 
 impl AddressBus for CpuBus {
+    fn last_fetch_was_cached(&self) -> bool {
+        self.last_fetch_cache_hit
+    }
+
     fn read_byte(&mut self, address: u32) -> u8 {
         self.read_sized(address, 1, CpuBusAccessKind::Read) as u8
     }
@@ -2907,6 +2926,7 @@ mod tests {
             icache: None,
             dcache: None,
             dbg_irq_window: None,
+            last_fetch_cache_hit: false,
         };
 
         assert_eq!(bus.read_long(0), 0x1111_4EF9);
@@ -2930,6 +2950,7 @@ mod tests {
             icache: None,
             dcache: None,
             dbg_irq_window: None,
+            last_fetch_cache_hit: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
         // Start on a refresh slot (0x003) so the fetch both waits for and then
@@ -2960,6 +2981,7 @@ mod tests {
             icache: None,
             dcache: None,
             dbg_irq_window: None,
+            last_fetch_cache_hit: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
 
@@ -3169,6 +3191,7 @@ mod tests {
             icache: None,
             dcache: Some(Box::new(dcache)),
             dbg_irq_window: None,
+            last_fetch_cache_hit: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
         let fast = FAST_RAM_BASE as u32 + 0x40;
@@ -3213,6 +3236,7 @@ mod tests {
             icache: None,
             dcache: None,
             dbg_irq_window: None,
+            last_fetch_cache_hit: false,
         };
         let before = bus.read_long(ROM_BASE as u32);
         bus.write_long(ROM_BASE as u32, 0xDEAD_BEEF);
@@ -3235,6 +3259,7 @@ mod tests {
             icache: None,
             dcache: None,
             dbg_irq_window: None,
+            last_fetch_cache_hit: false,
         };
         let addr = SLOW_RAM_BASE as u32 + 64 * 1024;
         // With nothing yet driven, the bus rests at 0.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -378,6 +378,7 @@ impl Emulator {
         bus: Bus,
         cpu_model: CpuModel,
         fpu_enabled: bool,
+        cpu_unimplemented: crate::config::UnimplementedPolicy,
         pacing_budget: PacingBudget,
         cpu_clocks_per_cck: u32,
         paced: bool,
@@ -401,7 +402,14 @@ impl Emulator {
         let mut bus = bus;
         // The chipset/CIA/Paula advance in emulated time, not wall-clock.
         bus.set_realtime_devices_enabled(false);
-        let machine = cpu::build(bus, cpu_model, fpu_enabled, cpu_clocks_per_cck, false)?;
+        let machine = cpu::build(
+            bus,
+            cpu_model,
+            fpu_enabled,
+            cpu_clocks_per_cck,
+            cpu_unimplemented,
+            false,
+        )?;
         Ok(Self {
             machine,
             stats: EmuStats::default(),
@@ -1895,6 +1903,7 @@ pub fn build_machine(
         bus,
         cfg.cpu,
         cfg.fpu,
+        cfg.cpu_unimplemented,
         cfg.emulation.pacing_budget,
         cpu_clocks_per_cck,
         paced,
@@ -2302,6 +2311,7 @@ mod tests {
             bus,
             crate::config::CpuModel::M68000,
             false,
+            Default::default(),
             crate::config::PacingBudget::Cycles,
             2,
             false,
@@ -2359,6 +2369,7 @@ mod tests {
             bus,
             crate::config::CpuModel::M68000,
             false,
+            Default::default(),
             crate::config::PacingBudget::Cycles,
             2,
             false,
@@ -2413,6 +2424,7 @@ mod tests {
             bus,
             crate::config::CpuModel::M68000,
             false,
+            Default::default(),
             crate::config::PacingBudget::Cycles,
             2,
             false,
@@ -2574,6 +2586,7 @@ mod tests {
             bus,
             crate::config::CpuModel::M68000,
             false,
+            Default::default(),
             crate::config::PacingBudget::Cycles,
             2,
             false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ where
             }
             "--cpu" => {
                 overrides.cpu = Some(args.next().ok_or_else(|| {
-                    anyhow!("--cpu requires a model (68000/68EC020/68020/68030/68040)")
+                    anyhow!("--cpu requires a model (68000/68EC020/68020/68030/68040/68060)")
                 })?);
             }
             "--fpu" => {
@@ -584,9 +584,9 @@ fn print_help() {
          -c, --config FILE              load configuration from FILE (default: ./copperline.toml)\n  \
          --model NAME                   machine profile: A500, A500Plus, A600, A1200, CDTV, CD32\n  \
          --chipset NAME                 chipset preset: OCS, ECS, or AGA\n  \
-         --cpu MODEL                    CPU: 68000, 68EC020, 68020, 68030, or 68040\n  \
+         --cpu MODEL                    CPU: 68000, 68EC020, 68020, 68030, 68040, or 68060\n  \
          --cpu-clock MHZ                CPU clock in MHz (default: the model's stock speed)\n  \
-         --fpu / --no-fpu               fit / omit a 68881/68882 (68040 has one on-die)\n  \
+         --fpu / --no-fpu               fit / omit a 68881/68882 (68040/68060 on-die)\n  \
          --chip SIZE                    chip RAM size, e.g. 512K, 1M, 2M\n  \
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
@@ -1053,6 +1053,7 @@ fn build_placeholder_machine() -> Result<Emulator> {
         bus,
         copperline::config::CpuModel::M68000,
         false,
+        Default::default(),
         copperline::config::PacingBudget::Cycles,
         2,
         true,

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -63,7 +63,11 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      walker share one register set
 //  12: Paula audio channels gained deferred AUDxEN-disable state so a DMA
 //      clear is observed at the current word boundary
-pub const STATE_VERSION: u32 = 12;
+//  13: 68060 support - CpuType::M68060 appended; CpuCore gained pcr, buscr,
+//      emulate_unimplemented_060, and the Oep060Timing pairing/branch-cache
+//      state; MmuFault gained a cause (transient, but part of CpuCore's
+//      serde shape indirectly via new fields)
+pub const STATE_VERSION: u32 = 13;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {
@@ -167,7 +171,7 @@ mod tests {
             Paula::new(Box::new(NullSerialSink), Box::new(NullSink)),
             FloppyController::default(),
         );
-        crate::cpu::build(bus, CpuModel::M68000, false, 2, false).unwrap()
+        crate::cpu::build(bus, CpuModel::M68000, false, 2, Default::default(), false).unwrap()
     }
 
     fn temp_state(name: &str) -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -410,12 +410,13 @@ const DENISE_CHOICES: [Option<DeniseRevision>; 4] = [
     Some(DeniseRevision::AgaLisa),
 ];
 const VIDEO_CHOICES: [VideoStandard; 2] = [VideoStandard::Pal, VideoStandard::Ntsc];
-const CPUS: [CpuModel; 5] = [
+const CPUS: [CpuModel; 6] = [
     CpuModel::M68000,
     CpuModel::M68EC020,
     CpuModel::M68020,
     CpuModel::M68030,
     CpuModel::M68040,
+    CpuModel::M68060,
 ];
 const CLOCK_PRESETS: [f64; 8] = [7.09, 14.0, 14.18, 25.0, 28.0, 33.0, 40.0, 50.0];
 const CHIP_PRESETS: [usize; 4] = [256 * 1024, 512 * 1024, 1024 * 1024, 2 * 1024 * 1024];
@@ -1403,7 +1404,10 @@ impl LauncherState {
 // --- helpers --------------------------------------------------------------
 
 fn cpu_is_32bit(cpu: CpuModel) -> bool {
-    matches!(cpu, CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040)
+    matches!(
+        cpu,
+        CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040 | CpuModel::M68060
+    )
 }
 
 /// Whether `field` appears anywhere with the given row kind. Used to classify a
@@ -1555,6 +1559,7 @@ fn cpu_name(cpu: CpuModel) -> &'static str {
         CpuModel::M68020 => "68020",
         CpuModel::M68030 => "68030",
         CpuModel::M68040 => "68040",
+        CpuModel::M68060 => "68060",
     }
 }
 
@@ -1719,6 +1724,24 @@ mod tests {
         let toml = s.to_toml().unwrap();
         assert!(toml.trim().is_empty(), "expected empty TOML, got:\n{toml}");
         assert!(s.build_config().is_ok());
+    }
+
+    #[test]
+    fn launcher_cycles_to_the_68060_with_50mhz_defaults() {
+        let mut s = MachineSetup::default();
+        for _ in 0..CPUS.len() {
+            if s.cpu == CpuModel::M68060 {
+                break;
+            }
+            s.cycle(LauncherField::Cpu, true);
+        }
+        assert_eq!(s.cpu, CpuModel::M68060, "cycled to the 68060");
+        assert_eq!(s.clock_mhz, 50.0, "50 MHz default");
+        assert!(s.fpu, "on-die FPU defaults on");
+        assert_eq!(s.disabled_reason(LauncherField::Icache), None);
+        assert_eq!(s.disabled_reason(LauncherField::Dcache), None);
+        assert!(s.toggle_value(LauncherField::Icache));
+        assert!(s.toggle_value(LauncherField::Dcache));
     }
 
     #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1631,8 +1631,16 @@ fn test_app_with_audio(audio: Box<dyn AudioSink>) -> super::App {
         Paula::new(Box::new(StdoutSink::new()), audio),
         FloppyController::default(),
     );
-    let emu = Emulator::new(bus, CpuModel::M68000, false, PacingBudget::Cycles, 2, false)
-        .expect("test emulator");
+    let emu = Emulator::new(
+        bus,
+        CpuModel::M68000,
+        false,
+        Default::default(),
+        PacingBudget::Cycles,
+        2,
+        false,
+    )
+    .expect("test emulator");
     super::App::new(
         emu,
         true,

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -86,6 +86,23 @@ ticks everywhere.
 | 25 | beam cck while a 64-pixel line blit runs, display off | `BLTCON0=$bb4a BLTCON1=$0003` |
 | 26 | beam cck while the A->D fill (row 24) runs **with a 3-bitplane display + BLTPRI** | beam-vs-blitter race with active display DMA |
 | 27 | VHPOSR when the CPU first sees a COPPER-raised INTREQR.COPER, interrupts off | copper-vs-CPU phase (`vp`<<8 | `hpos`/2); `FFFFFFFF` if it never fired |
+| 28 | independent pair `move.w d2,d0` + `move.w d3,d1` x8192 | 68060 dual-issue: pairs into one clock; compare rows 4 and 29 |
+| 29 | RAW pair `move.w d2,d0` + `move.w d0,d1` x8192 | the dependency blocks dual issue |
+| 30 | `dbra`-only loop x8192, after the 68060 enable block | branch-cache folding: 1 clock/iteration on a 68060 |
+
+### Rows 28-30: 68060 superscalar dispatch and branch cache
+
+Before row 28 a TRAP #0 supervisor stub probes `MOVEC PCR` for the 68060
+identification ($0430) and, when found, enables superscalar dispatch
+(PCR.ESS) plus the caches and branch cache (CACR EDC|EBC|EIC) - what
+`68060.library` does at boot on real boards. On every other CPU the probe
+faults harmlessly and the rows run scalar, so the numbers stay comparable
+across the whole family. On Copperline's 50 MHz 68060, row 30 measures
+exactly one clock per loop iteration (0x76 E-ticks) and rows 28/29 land at
+two clocks per iteration; the model currently lets a predicted branch fold
+only when it can ride the preceding instruction's cycle, so rows 28 and 29
+coincide (the fold moves between the pair and the branch) - real-hardware
+captures welcome to calibrate the split.
 
 ### Row 27: the copper-vs-CPU interrupt phase
 

--- a/timing-test/test.asm
+++ b/timing-test/test.asm
@@ -43,6 +43,20 @@
 ;          waits for line $64 then MOVEs SET-COPER into INTREQ; CPU polls with
 ;          interrupts off). The copper-vs-CPU phase the 020 chase-the-beam
 ;          copper-chunky effects depend on. FFFFFFFF if the copper never fired.
+;   row 28 pair x8192       move.w d2,d0 + move.w d3,d1 (independent pair;
+;          on a 68060 with superscalar dispatch enabled the two issue in one
+;          clock - compare against row 4 and row 29)
+;   row 29 RAW pair x8192   move.w d2,d0 + move.w d0,d1 (the dependency
+;          blocks dual issue: row 29 - row 28 exposes the pairing gain)
+;   row 30 dbra x8192       branch-cache row: same body as row 7, but run
+;          after the 68060 enable block (ESS + caches + branch cache), so a
+;          folding branch cache collapses the loop overhead
+;
+; Before row 28 a TRAP #0 supervisor stub probes MOVEC PCR for the 68060
+; identification ($0430) and, if found, enables superscalar dispatch
+; (PCR.ESS) plus the caches and branch cache (CACR EDC|EBC|EIC). On every
+; other CPU the probe faults harmlessly and rows 28-30 run scalar, so the
+; rows stay comparable across the whole family.
 ;
 ; Rows 0/1/9/13 use slow RAM ($C00000); on a machine without it (A1200) they
 ; store a 0 sentinel. All other rows -- including 27 -- run regardless.
@@ -73,7 +87,29 @@ COPLIST equ     $50000          ; scratch copper list for the copper-phase row (
 ; addresses) so the load address does not matter.
 ;----------------------------------------------------- entry (a6=sys at load)
 boot:
-        lea     CUST,a6
+        bra     boot1
+
+; TRAP #0 stub (supervisor): probe for the 68060 and enable its superscalar
+; dispatch, caches, and branch cache. MOVEC is encoded with dc.w so the
+; binary still assembles for -m68000.
+t0sup:  move.l  $10.w,-(sp)     ; save the illegal-instruction vector
+        lea     t0skip(pc),a0
+        move.l  a0,$10.w
+        moveq   #0,d0
+        dc.w    $4e7a,$0808     ; movec pcr,d0 (illegal before the 68060)
+        swap    d0
+        cmp.w   #$0430,d0       ; 68060 identification in PCR[31:16]
+        bne     t0out
+        moveq   #1,d0           ; PCR.ESS: enable superscalar dispatch
+        dc.w    $4e7b,$0808     ; movec d0,pcr
+        move.l  #$80808000,d0   ; CACR: EDC | EBC | EIC
+        dc.w    $4e7b,$0002     ; movec d0,cacr
+t0out:  move.l  (sp)+,$10.w
+        rte
+t0skip: addq.l  #4,2(sp)        ; skip the faulting 4-byte movec, d0 stays 0
+        rte
+
+boot1:  lea     CUST,a6
         move.w  #$7fff,$9a(a6)  ; INTENA: disable all interrupts
         move.w  #$7fff,$9c(a6)  ; INTREQ: clear all pending
         move.w  #$7fff,$96(a6)  ; DMACON: disable all DMA
@@ -685,6 +721,42 @@ boot:
         move.w  #$7fff,$096(a6) ; all DMA off
         move.w  #$7fff,$09c(a6) ; clear pending
 
+        ; 68060 enable block: from user mode, TRAP #0 into a supervisor stub
+        ; that probes MOVEC PCR (illegal before the 060; the recovery handler
+        ; skips the 4-byte instruction and leaves d0 = 0) and, on a 68060,
+        ; sets PCR.ESS and CACR EDC|EBC|EIC so rows 28-30 measure the
+        ; dual-issue machine. Everything is restored afterwards.
+        move.l  $80.w,-(sp)     ; save TRAP #0 vector
+        lea     t0sup(pc),a0
+        move.l  a0,$80.w
+        trap    #0
+        move.l  (sp)+,$80.w     ; restore TRAP #0 vector
+
+        ; row 28: independent pair (move.w d2,d0 + move.w d3,d1)
+        bsr     tstart
+        move.w  #ITERS-1,d6
+.t28    move.w  d2,d0
+        move.w  d3,d1
+        dbra    d6,.t28
+        bsr     tread
+        move.l  d0,(a3)+
+
+        ; row 29: RAW-dependent pair (move.w d2,d0 + move.w d0,d1)
+        bsr     tstart
+        move.w  #ITERS-1,d6
+.t29    move.w  d2,d0
+        move.w  d0,d1
+        dbra    d6,.t29
+        bsr     tread
+        move.l  d0,(a3)+
+
+        ; row 30: dbra-only loop with the 68060 branch cache active
+        bsr     tstart
+        move.w  #ITERS-1,d6
+.t30    dbra    d6,.t30
+        bsr     tread
+        move.l  d0,(a3)+
+
         move.w  #$0ff0,$180(a6) ; phase marker: all tests done (yellow)
 
         ;------------------------------------------------ render + show
@@ -695,7 +767,7 @@ boot:
         ; the serial port to a file, giving a screenshot-free way to compare.
         move.w  #$0170,$032(a6) ; SERPER ~9600 baud
         lea     RESULTS,a2
-        moveq   #28-1,d4
+        moveq   #31-1,d4
 .sl     move.l  (a2)+,d3
         moveq   #8-1,d6
 .sh     rol.l   #4,d3
@@ -890,7 +962,7 @@ render:
 .rr:
         move.l  (a2)+,d3        ; value
         move.w  d4,d0
-        mulu    #360,d0         ; 9 scanlines * 40 bytes per row (27 rows fit)
+        mulu    #320,d0         ; 8 scanlines * 40 bytes per row (31 rows fit)
         lea     SCREEN,a5
         adda.l  d0,a5           ; row top in bitplane
         moveq   #7,d6           ; 8 hex digits
@@ -912,7 +984,7 @@ render:
         addq.w  #1,d2
         dbra    d6,.rd
         addq.w  #1,d4
-        cmp.w   #28,d4
+        cmp.w   #31,d4
         bne     .rr
         rts
 

--- a/timing-test/tt-060.toml
+++ b/timing-test/tt-060.toml
@@ -1,0 +1,16 @@
+# 68060 @ 50 MHz on an A1200-class AGA machine: the configuration for the
+# superscalar rows (28-30). The test's TRAP #0 stub enables PCR.ESS and the
+# caches/branch cache itself, so no special knobs are needed here.
+rom = "../Kickstart v3.1 r40.68 (1993)(Commodore)(A1200)[!].rom"
+[machine]
+profile = "A1200"
+[cpu]
+model = "68060"
+[emulation]
+speed = "real"
+[chipset]
+revision = "AGA"
+video = "PAL"
+[floppy.df0]
+path = "timing-test.adf"
+write_protected = true


### PR DESCRIPTION
Adds the 68060 as a first-class CPU model (`[cpu] model = "68060"`, default 50 MHz), with the FPU and MMU hooked up and a real 060 timing engine. Thirteen commits, each green on its own.

## Instruction-set contract (faithful traps by default)

The 060 dropped instructions from silicon; on real boards the OS-side 68060.library emulates them through the chip's trap interface, and that contract is what's modelled:

- **Vector 61** (unimplemented integer): MOVEP, CHK2/CMP2, CAS2, misaligned CAS, 64-bit MUL/DIV - every gate fires before any architectural side effect so the SP handler can re-execute (CAS defers its post-increment past the alignment check).
- **FP-unimplemented** (Line-F, format $2 frame per the 68060SP sources: next-PC stacked, calculated operand EA, FPIAR = faulting instruction): transcendentals, FINT/FINTRZ, FGETEXP/FGETMAN, FMOD/FREM/FSCALE, FSINCOS, FMOVECR, FDBcc/FTRAPcc/FScc. Packed decimal = vector 55; dynamic FMOVEM / immediate packed = vector 60. PCR.DFP (and `fpu = false` = LC060) takes the format $4 disabled frame.
- `[cpu] unimplemented = "native"` executes the whole set directly for setups without 68060.library. **Kickstart 3.1 boots under the faithful default.**

## Registers, frames, MMU

PCR ($808, id $0430 rev 1, EDEBUG/DFP/ESS writable), BUSCR ($008, disambiguated from the 040's DACR0), the 060 CACR layout with CABC/CUBC strobes, and the single supervisor stack (M bit storable but never banks A7; MSP/ISP dropped from MOVEC). Access errors push the eight-word format $4 frame with FSLW composed from the MMU walk cause (bit layout cross-checked against Linux's consumers) - and RTE now pops format 4 *and* the 040's format 7, which previously format-errored on our own frames. The MMU shares the 040 walker (TC[15], URP/SRP, 4K/8K pages); PTEST is gone, PLPAR/PLPAW translate into An, PMOVE is Line-F. LPSTOP implemented. FSAVE/FRESTORE use the 060 state frames - NULL is one long word (exec's hand-built task contexts depend on it; a fixed 12-byte read launched the first task at PC 0), IDLE is three.

## Timing: superscalar dual-issue + branch cache

`timing_060.rs` replaces the 020+ scaling for the 060: every opcode classifies into the UM Chapter 10 dispatch classes (build-once 64K table) with pOEP-occupancy costs - memory latency stays billed by the host bus per access, so bus-bound code shows no pairing benefit, as on silicon. Dual issue is retrospective: an instruction satisfying the Table 10-1 test against the previous instruction's open sOEP slot (class, simple EA, no RAW/WAW, CCR rule, one memory operand, both fetches icache hits, PCR.ESS on) refunds to zero cycles. The 256-entry branch cache (CACR.EBC, CABC/CUBC, user-entry tracking) folds predicted taken branches onto the preceding instruction's cycle; a lone predicted branch still issues for one clock - which matches the canonical 1-clock subq/bne loop and guarantees a predicted `bra self` idle loop advances emulated time (that livelock was found booting KS3.1). Pairing state and the branch cache are serialized; save/restore replays byte-identically. All residuals are pessimistic (under-pair, never over-pair) and documented in docs/internals/cpu.md.

timing-test gains rows 28-30 (pair / RAW pair / lone-DBcc loop) behind a TRAP #0 stub that enables ESS+EBC only on a real 060 - on Copperline's 50 MHz 060 row 30 measures exactly one clock per iteration, and rows 0-27 are byte-identical to main on the EC020 reference config.

## Verification

- 1261 Copperline + 47 new m68k-crate 68060/timing tests green; clippy/fmt clean; docs build clean; STATE_VERSION 12 -> 13.
- Byte-identity vs main: a1000 (68000) and kicka1200 (EC020 AGA) 15-20 s release screenshots, plus all 27 EC020 timing-test rows.
- KS 3.1 40.068 boots to the insert-disk screen on a 50 MHz 68060 in trap mode; 060 save states replay byte-identically; bundled AROS on the 060 matches the known AROS-on-040 high-clock behavior (pre-existing).
- Cross-checked against the MC68060 UM, the 68060SP/FPSP sources (frame contracts), Linux's FSLW consumers, WinUAE, and QEMU during design.