### PR TITLE
68040 MOVEC validation, MMU reset state, debugger 32-bit fixes

### DIFF
--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -590,6 +590,18 @@ impl CpuCore {
         self.pcr = PCR_060_RESET;
         self.buscr = 0;
         self.oep060.branch_cache.clear_all();
+        // Reset disables address translation: the TC enable bit and the
+        // TTR enable bits are cleared (030/040/060 alike), so the CPU
+        // comes up fetching physical addresses even if an OS had the MMU
+        // on when the reset hit. Root pointers are left as-is (undefined
+        // at reset); with translation off they are inert until rewritten.
+        self.mmu_tc = 0;
+        self.pmmu_enabled = false;
+        self.itt0 = 0;
+        self.itt1 = 0;
+        self.dtt0 = 0;
+        self.dtt1 = 0;
+        self.atc.flush_all();
         self.prefetch_queue = [0; 2];
         self.prefetch_count = 0;
         self.consume_without_prefetch = false;

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -601,6 +601,9 @@ impl CpuCore {
         self.itt1 = 0;
         self.dtt0 = 0;
         self.dtt1 = 0;
+        // The 030's PMOVE-form TT0/TT1 (stored apart from the 040 TTRs).
+        self.mmu_tt0 = 0;
+        self.mmu_tt1 = 0;
         self.atc.flush_all();
         self.prefetch_queue = [0; 2];
         self.prefetch_count = 0;

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -694,9 +694,13 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
 // Group 4: Miscellaneous
 // ============================================================================
 
-/// MOVEC Rc-code legality per CPU model. The 68040 accepts everything its
-/// register table decodes; the 68060 drops CAAR, MMUSR, MSP, and ISP (single
-/// supervisor stack) and gains BUSCR (0x008) and PCR (0x808).
+/// MOVEC Rc-code legality per CPU model. A MOVEC naming a register the
+/// model does not implement raises an illegal-instruction exception on
+/// real silicon; CPU-detection code (e.g. the OS 3.2+ 680x0.library)
+/// relies on that to tell the models apart, probing registers like the
+/// 060-only PCR (0x808) and expecting a trap on anything older. The
+/// 68060 drops CAAR, MMUSR, MSP, and ISP (single supervisor stack) and
+/// gains BUSCR (0x008) and PCR (0x808).
 fn movec_reg_legal(cpu_type: CpuType, ctrl_reg: u16) -> bool {
     match cpu_type {
         CpuType::M68010 | CpuType::SCC68070 => {
@@ -706,11 +710,21 @@ fn movec_reg_legal(cpu_type: CpuType, ctrl_reg: u16) -> bool {
             ctrl_reg,
             0x000 | 0x001 | 0x002 | 0x800 | 0x801 | 0x802 | 0x803 | 0x804
         ),
+        // The EC040 has no MMU: no TC (0x003), MMUSR (0x805), URP (0x806),
+        // or SRP (0x807); its access-control registers reuse the TTR codes
+        // (0x004-0x007). No 040 has the 020/030 CAAR (0x802).
+        CpuType::M68EC040 => matches!(
+            ctrl_reg,
+            0x000 | 0x001 | 0x002 | 0x004..=0x007 | 0x800 | 0x801 | 0x803 | 0x804
+        ),
+        CpuType::M68LC040 | CpuType::M68040 => {
+            matches!(ctrl_reg, 0x000..=0x007 | 0x800 | 0x801 | 0x803..=0x807)
+        }
         CpuType::M68060 => matches!(
             ctrl_reg,
             0x000..=0x008 | 0x800 | 0x801 | 0x806 | 0x807 | 0x808
         ),
-        _ => true,
+        CpuType::M68000 | CpuType::Invalid => false,
     }
 }
 

--- a/crates/m68k/tests/illegal_movec_reg_68040_tests.rs
+++ b/crates/m68k/tests/illegal_movec_reg_68040_tests.rs
@@ -1,0 +1,156 @@
+use m68k::core::memory::AddressBus;
+use m68k::{CpuCore, CpuType, NoOpHleHandler};
+
+struct TestBus {
+    memory: [u8; 0x10000],
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self { memory: [0; 0x10000] }
+    }
+
+    fn write_word_at(&mut self, addr: u32, value: u16) {
+        let bytes = value.to_be_bytes();
+        let idx = addr as usize;
+        self.memory[idx] = bytes[0];
+        self.memory[idx + 1] = bytes[1];
+    }
+
+    fn write_long_at(&mut self, addr: u32, value: u32) {
+        let bytes = value.to_be_bytes();
+        let idx = addr as usize;
+        self.memory[idx] = bytes[0];
+        self.memory[idx + 1] = bytes[1];
+        self.memory[idx + 2] = bytes[2];
+        self.memory[idx + 3] = bytes[3];
+    }
+}
+
+impl AddressBus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.memory[(address as usize) & 0xFFFF]
+    }
+
+    fn read_word(&mut self, address: u32) -> u16 {
+        let addr = (address as usize) & 0xFFFF;
+        u16::from_be_bytes([self.memory[addr], self.memory[addr + 1]])
+    }
+
+    fn read_long(&mut self, address: u32) -> u32 {
+        let addr = (address as usize) & 0xFFFF;
+        u32::from_be_bytes([
+            self.memory[addr],
+            self.memory[addr + 1],
+            self.memory[addr + 2],
+            self.memory[addr + 3],
+        ])
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.memory[(address as usize) & 0xFFFF] = value;
+    }
+
+    fn write_word(&mut self, address: u32, value: u16) {
+        let addr = (address as usize) & 0xFFFF;
+        let bytes = value.to_be_bytes();
+        self.memory[addr] = bytes[0];
+        self.memory[addr + 1] = bytes[1];
+    }
+
+    fn write_long(&mut self, address: u32, value: u32) {
+        let addr = (address as usize) & 0xFFFF;
+        let bytes = value.to_be_bytes();
+        self.memory[addr] = bytes[0];
+        self.memory[addr + 1] = bytes[1];
+        self.memory[addr + 2] = bytes[2];
+        self.memory[addr + 3] = bytes[3];
+    }
+}
+
+/// Run a single MOVEC (`opcode` = $4E7A read / $4E7B write, `ext` names the
+/// control register) on `cpu_type` and return the PC afterwards. The illegal
+/// instruction vector points at 0x0300, so a trapped MOVEC lands there.
+fn pc_after_movec(cpu_type: CpuType, opcode: u16, ext: u16) -> u32 {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(cpu_type);
+    let mut bus = TestBus::new();
+
+    // Vectors: SSP=0x1000, PC=0x0200
+    bus.write_long_at(0x00, 0x1000);
+    bus.write_long_at(0x04, 0x0200);
+    // Illegal instruction vector (vector 4) -> 0x0300
+    bus.write_long_at(0x10, 0x0300);
+
+    bus.write_word_at(0x0200, opcode);
+    bus.write_word_at(0x0202, ext);
+
+    cpu.reset(&mut bus);
+    cpu.pc = 0x0200;
+    cpu.set_sr(0x2700);
+
+    let mut hle = NoOpHleHandler;
+    let result = cpu.step_with_hle_handler(&mut bus, &mut hle);
+    assert!(matches!(result, m68k::StepResult::Ok { .. }));
+    cpu.pc
+}
+
+#[test]
+fn test_movec_pcr_is_illegal_on_68040() {
+    // The 680x0.library CPU detection probes the 68060-only PCR ($808)
+    // and relies on the 040 raising an illegal instruction exception.
+    assert_eq!(
+        pc_after_movec(CpuType::M68040, 0x4E7A, 0x0808),
+        0x0300,
+        "MOVEC PCR,D0 on 68040 should trap to illegal instruction vector"
+    );
+    assert_eq!(
+        pc_after_movec(CpuType::M68040, 0x4E7B, 0x0808),
+        0x0300,
+        "MOVEC D0,PCR on 68040 should trap to illegal instruction vector"
+    );
+}
+
+#[test]
+fn test_movec_caar_is_illegal_on_68040() {
+    // CAAR ($802) exists on the 020/030 only.
+    assert_eq!(
+        pc_after_movec(CpuType::M68040, 0x4E7A, 0x0802),
+        0x0300,
+        "MOVEC CAAR,D0 on 68040 should trap to illegal instruction vector"
+    );
+}
+
+#[test]
+fn test_movec_undefined_code_is_illegal_on_68040() {
+    assert_eq!(
+        pc_after_movec(CpuType::M68040, 0x4E7A, 0x0FFF),
+        0x0300,
+        "MOVEC of an undefined control register should trap"
+    );
+}
+
+#[test]
+fn test_movec_implemented_registers_execute_on_68040() {
+    // TC ($003), VBR ($801), and SRP ($807) are all real 040 registers:
+    // the instruction retires and the PC moves past the extension word.
+    for ext in [0x0003u16, 0x0801, 0x0807] {
+        assert_eq!(
+            pc_after_movec(CpuType::M68040, 0x4E7A, ext),
+            0x0204,
+            "MOVEC of implemented register ${ext:03X} should execute on 68040"
+        );
+    }
+}
+
+#[test]
+fn test_movec_mmu_registers_are_illegal_on_68ec040() {
+    // The EC040 has no MMU: TC ($003) and SRP ($807) must trap.
+    for ext in [0x0003u16, 0x0807] {
+        assert_eq!(
+            pc_after_movec(CpuType::M68EC040, 0x4E7A, ext),
+            0x0300,
+            "MOVEC of MMU register ${ext:03X} should trap on 68EC040"
+        );
+    }
+}

--- a/crates/m68k/tests/reset_mmu_tests.rs
+++ b/crates/m68k/tests/reset_mmu_tests.rs
@@ -19,3 +19,20 @@ fn test_reset_disables_translation_and_ttrs_on_68040() {
     assert_eq!(cpu.itt0, 0, "reset must clear the TTR enable bits");
     assert_eq!(cpu.vbr, 0, "reset must clear VBR");
 }
+
+#[test]
+fn test_reset_clears_030_transparent_translation() {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68030);
+    cpu.set_sr(0x2700);
+
+    // The 030's TT registers are written by PMOVE, stored apart from the
+    // 040 TTRs; M68030UM documents reset clearing their E bits.
+    cpu.mmu_tt0 = 0x0000_8000; // enable bit set
+    cpu.mmu_tt1 = 0x0000_8000;
+
+    cpu.pulse_reset();
+
+    assert_eq!(cpu.mmu_tt0, 0, "reset must clear the 030 TT0 enable");
+    assert_eq!(cpu.mmu_tt1, 0, "reset must clear the 030 TT1 enable");
+}

--- a/crates/m68k/tests/reset_mmu_tests.rs
+++ b/crates/m68k/tests/reset_mmu_tests.rs
@@ -1,0 +1,21 @@
+use m68k::{CpuCore, CpuType};
+
+#[test]
+fn test_reset_disables_translation_and_ttrs_on_68040() {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    cpu.set_sr(0x2700);
+
+    // Enable translation (040 TC enable is bit 15) and a transparent
+    // translation register, as 68040.library does at OS boot.
+    cpu.write_control_register(0x003, 0x8000); // TC
+    cpu.write_control_register(0x004, 0x0000_8000); // ITT0 enable
+    assert!(cpu.pmmu_enabled, "TC write should enable translation");
+
+    cpu.pulse_reset();
+
+    assert!(!cpu.pmmu_enabled, "reset must disable address translation");
+    assert_eq!(cpu.mmu_tc, 0, "reset must clear TC");
+    assert_eq!(cpu.itt0, 0, "reset must clear the TTR enable bits");
+    assert_eq!(cpu.vbr, 0, "reset must clear VBR");
+}

--- a/src/amigaos.rs
+++ b/src/amigaos.rs
@@ -94,8 +94,14 @@ pub fn task_state_name(state: u8) -> &'static str {
     }
 }
 
+/// Heuristic: even and in an address range where exec structures can
+/// live -- chip+Z2 RAM, slow RAM, or Zorro III space (OS 3.2+ SetPatch
+/// moves ExecBase to fast RAM, which may be a Z3 board).
 fn plausible_ptr(addr: u32) -> bool {
-    addr != 0 && addr & 1 == 0 && addr < 0x0100_0000
+    addr & 1 == 0
+        && ((0x100..0x00A0_0000).contains(&addr)          // chip + Z2 fast
+            || (0x00C0_0000..0x00D8_0000).contains(&addr) // slow
+            || (0x1000_0000..0x8000_0000).contains(&addr)) // Zorro III
 }
 
 /// Read-only view of guest memory, built from the debugger's peek
@@ -174,7 +180,10 @@ impl OsMemory<'_> {
     /// placeholder for null/implausible name pointers.
     pub fn node_name(&self, node: u32) -> String {
         let name_ptr = (self.peek32)(node.wrapping_add(LN_NAME));
-        if name_ptr == 0 || name_ptr >= 0x0100_0000 {
+        // Names may live in ROM or at odd addresses, so no plausible_ptr
+        // here; unmapped pointers read as zero bytes and fall through to
+        // the <unnamed> placeholder below.
+        if name_ptr == 0 {
             return "<unnamed>".to_string();
         }
         let mut name = String::new();
@@ -443,6 +452,28 @@ mod tests {
         assert_eq!(segs[0].size, 0xF8);
         assert_eq!(segs[1].start, 0x9004);
         assert_eq!(segs[1].size, 0x38);
+    }
+
+    #[test]
+    fn accepts_execbase_in_z3_space_and_rejects_the_gap() {
+        // OS 3.2+ SetPatch moves ExecBase to fast RAM, e.g. Zorro III space.
+        let base = 0x4000_08C0;
+        let mut mem = FakeMem::new();
+        mem.put32(4, base);
+        mem.put32(base + CHKBASE, !base);
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        assert_eq!(
+            os(&peek8, &peek32).exec_base().expect("ExecBase in Z3 RAM"),
+            base
+        );
+
+        // A pointer in the unmapped gap between Z2 and Z3 is rejected.
+        let mut mem = FakeMem::new();
+        mem.put32(4, 0x0B00_0000);
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        assert!(os(&peek8, &peek32).exec_base().is_err());
     }
 
     #[test]

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -558,7 +558,7 @@ impl App {
                     .and_then(|t| hex32(t))
                     .unwrap_or(0x40)
                     .clamp(1, 0x400) as usize;
-                let base = addr & 0x00FF_FFF0;
+                let base = addr & !0xF;
                 let bytes = self
                     .emu
                     .machine


### PR DESCRIPTION
Three fixes found while debugging why the in-development AmigaOS 3.2+ SetPatch fails on 68040 configs. Each has regression tests.

## m68k: MOVEC of unimplemented control registers traps on the 040 family

movec_reg_legal() validates the 010/020/030 (and, since the 68060 work, 060) register sets, but let the whole 040 family through unchecked: MOVEC of the 060-only PCR ($808), the 020/030 CAAR ($802), or any undefined code executed silently instead of raising the illegal-instruction exception real silicon raises.

CPU-detection code tells the models apart exactly this way: the OS 3.2+ 680x0.library probes model-specific MOVEC registers under a trap handler and expects precise trap behavior. With every probe "succeeding", the emulated 68040 matched no known CPU and SetPatch crashed with guru #80000004 in ramlib (the library's unknown-CPU bail-out path has a stack-imbalance bug of its own, reported to the OS developers separately).

Adds the 68040/68LC040 register set and the 68EC040 set (no MMU: TC, MMUSR, URP, SRP trap; the access-control registers reuse the TTR codes).

## m68k: reset disables the MMU and TTRs

pulse_reset() cleared VBR and CACR but left TC, the TTRs, and the ATC intact. Once the OS enables translation (SetPatch + 68040.library), any warm or cold reboot fetched ROM through stale page tables whose backing RAM had just been reinitialized: black screen before the expansion scan, on A500-040 and A1200-040 configs alike. Real hardware clears the TC/TTR enable bits on /RSTI, which is why a physical 040 machine reboots fine with the MMU active.

## debugger: accept exec structures above the 24-bit space

OS 3.2+ SetPatch moves ExecBase into fast RAM, which can be a Zorro III board at $40000000+. The debugger's plausible-pointer heuristic rejected anything above 16MB, so TASKS/LIBS/etc. reported "no ExecBase (OS not booted?)" on a perfectly healthy system, and the console MEM command masked dump addresses to 24 bits. The heuristic now accepts chip+Z2, slow, and Zorro III ranges.

## Testing

- New tests: crates/m68k/tests/illegal_movec_reg_68040_tests.rs (5), crates/m68k/tests/reset_mmu_tests.rs (1), plus a Z3-ExecBase case in src/amigaos.rs.
- Full lib suite (1263) and the 040/060/MMU fixture suites pass.
- 680x0.library now detects the 040 and loads 68040.library, warm/cold reboots survive an active MMU, and TASKS works with ExecBase in fast RAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)