### PR TITLE
Fix vblank-armed manual sprites and late-DDF scroll-in carry

### DIFF
--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -59,7 +59,12 @@ BPLCON1-delayed samples at the left edge of a contiguous bitplane-DMA block
 come from the previous line's shifter tail when current-line DMA is already
 feeding Denise at the display edge. Block-start lines, and lines whose output
 is held until a delayed first BPL1DAT load, blank that scroll-in because no
-current-line shifter data has reached the visible gate yet. AGA's extended
+current-line shifter data has reached the visible gate yet. The same applies
+when a late DDFSTRT places the row's fetch origin inside the open display
+window (`fetch_start_native_x > 0`): the serializer has run far past its
+previous load by the time the window opens, so the taps between window open
+and the first new word shift out empty and show playfield colour 0, never the
+previous line's tail. AGA's extended
 BPLCON1 delays can exceed one 16-bit shifter word; replay does not reuse the
 single cached line-tail word for those wider delays, so the extra leading gap
 stays background until current-line samples reach Lisa.
@@ -116,6 +121,19 @@ can still be repositioned by later SPRxPOS/CTL writes. Merely enabling
 sprite DMA and crossing an empty sprite pair slot is not enough to make
 captured DMA authoritative; the frame must contain actual fetched or held
 sprite data.
+
+Two manual-replay guards exist only to reconcile DMA writes the beam replay
+cannot see (Agnus drives POS/CTL/DATA through the same Denise registers
+without recording beam events): an early same-line SPRxPOS write hands the
+line to the DMA capture, and a pre-visible SPRxDATA/DATB write seeds the
+latch for later retiming instead of arming direct output. Both apply only
+when sprite DMA was observed in the frame. With sprite DMA idle Denise's own
+rules hold unmodified: SPRxDATA arms at any beam position (including
+vertical blank), SPRxCTL disarms, SPRxPOS never disarms, and an armed sprite
+serializes at HSTART on every line because Denise has no vertical
+comparator. A vblank arm sequence with VSTART equal to VSTOP therefore
+displays full-height columns, which is how Gen-X draws the vertical
+edge-masking line sprites of its shutter transitions.
 
 The mapping from beam coordinates to framebuffer x is anchored by
 constants that encode the hardware's fetch-to-display pipeline delays --

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3068,6 +3068,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         visible_line0,
         rows,
         false,
+        input.sprite_dma_observed,
     );
     if input.sprite_dma_observed {
         let dma_seeded_lines = manual_sprite_lines_from_captured_dma_reuse(
@@ -3478,10 +3479,22 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 words_per_row,
                 dma_planes.min(nplanes),
             );
+            let fetch_starts_inside_window = {
+                let mut display_control = base_controls[y];
+                for segment in row_control_segments {
+                    if segment.x <= x_start {
+                        display_control = segment.control;
+                    }
+                }
+                let pixel_repeat = display_control.framebuffer_pixel_repeat();
+                display_control.fetch_start_native_x(display_control.diw_h_start(), pixel_repeat)
+                    > 0
+            };
             let carry_words = bitplane_carry_words_for_line(
                 block_start,
                 x_start,
                 dma_output_start_x,
+                fetch_starts_inside_window,
                 previous_playfield_tail_words,
             );
             let line_plan = DenisePlannedPlayfieldLine::new(

--- a/src/video/bitplane/fetch.rs
+++ b/src/video/bitplane/fetch.rs
@@ -348,9 +348,20 @@ pub(super) fn bitplane_carry_words_for_line(
     block_start: bool,
     display_start_x: usize,
     dma_output_start_x: Option<usize>,
+    fetch_starts_inside_window: bool,
     previous_playfield_tail_words: [Option<u16>; 8],
 ) -> [Option<u16>; 8] {
-    if block_start || dma_output_start_x.is_some_and(|start| start > display_start_x) {
+    // A carried shifter tail is only observable when the serializer reloads
+    // at the moment the display window opens, so the BPLCON1 taps still
+    // address the previous load. When the line's first BPL1DAT arrives after
+    // the window is already open (late DDFSTRT places the fetch origin inside
+    // the window), the serializer has long run past its last load and the
+    // taps shift out empty: the gap between window open and the first new
+    // word shows playfield colour 0, not the previous line's tail.
+    if block_start
+        || fetch_starts_inside_window
+        || dma_output_start_x.is_some_and(|start| start > display_start_x)
+    {
         [None; 8]
     } else {
         previous_playfield_tail_words

--- a/src/video/bitplane/sprite.rs
+++ b/src/video/bitplane/sprite.rs
@@ -348,6 +348,7 @@ pub(super) fn manual_sprite_lines_from_events(
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         true,
+        true,
     )
 }
 
@@ -357,6 +358,16 @@ pub(super) enum ManualSpriteFlushMode {
     PreserveStartedOutput,
 }
 
+/// `sprite_dma_observed` says whether sprite DMA actually fetched data this
+/// frame. The beam replay only sees CPU/Copper register writes; when DMA also
+/// drives a channel, Agnus writes POS/CTL/DATA through the same Denise
+/// registers without appearing here, so two reconciliation guards approximate
+/// those unseen writes (an early same-line SPRxPOS hands the line to the DMA
+/// capture, and a pre-visible SPRxDATA seeds the latch for later retiming
+/// instead of arming direct output). With sprite DMA idle Denise's own rules
+/// apply unmodified: SPRxDATA arms at any beam position, SPRxCTL disarms, and
+/// SPRxPOS never disarms, so an armed sprite serializes on every line (there
+/// is no vertical comparator in Denise).
 pub(super) fn manual_sprite_lines_from_events_with_visible_line0(
     initial_state: &RenderState,
     events: &[BeamRegisterWrite],
@@ -364,6 +375,7 @@ pub(super) fn manual_sprite_lines_from_events_with_visible_line0(
     visible_line0: i32,
     rows: usize,
     include_latched_sprite_state: bool,
+    sprite_dma_observed: bool,
 ) -> Vec<Vec<SpriteLine>> {
     let mut regs = BeamSpriteState::from_render_state(initial_state, held);
     let visible_end = visible_line0 + rows as i32;
@@ -418,7 +430,8 @@ pub(super) fn manual_sprite_lines_from_events_with_visible_line0(
             ManualSpriteFlushMode::PreserveStartedOutput,
             &mut lines,
         );
-        if !include_latched_sprite_state
+        if sprite_dma_observed
+            && !include_latched_sprite_state
             && held[sprite].is_none()
             && (off - 0x140) & 0x0006 == 0
             && event.hpos < SPRITE_DMA_PAIR_CAPTURE_HPOS[sprite / 2]
@@ -429,7 +442,10 @@ pub(super) fn manual_sprite_lines_from_events_with_visible_line0(
             regs.direct_data_armed[sprite] = false;
         }
         regs.apply_write(off, event.value);
-        if (event.vpos as i32) < visible_line0 && matches!((off - 0x140) & 0x0006, 0x4 | 0x6) {
+        if sprite_dma_observed
+            && (event.vpos as i32) < visible_line0
+            && matches!((off - 0x140) & 0x0006, 0x4 | 0x6)
+        {
             regs.direct_data_armed[sprite] = false;
         }
         next_beam[sprite] = event_beam;

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -1381,15 +1381,24 @@ fn bplcon1_delay_drops_carry_when_first_bpl1dat_is_late() {
     previous_tail[0] = Some(0x0001);
 
     assert_eq!(
-        bitplane_carry_words_for_line(false, 64, Some(64), previous_tail),
+        bitplane_carry_words_for_line(false, 64, Some(64), false, previous_tail),
         previous_tail
     );
     assert_eq!(
-        bitplane_carry_words_for_line(false, 64, Some(158), previous_tail),
+        bitplane_carry_words_for_line(false, 64, Some(158), false, previous_tail),
         [None; 8]
     );
     assert_eq!(
-        bitplane_carry_words_for_line(true, 64, Some(64), previous_tail),
+        bitplane_carry_words_for_line(true, 64, Some(64), false, previous_tail),
+        [None; 8]
+    );
+    // A late DDFSTRT places the line's first BPL1DAT load inside the open
+    // display window; the serializer taps have run empty by then, so no
+    // previous-line tail is observable. Regression example: Gen-X's rippled
+    // reflection rows (DDFSTRT $40, BPLCON1 scroll) showed stray dashes at
+    // the window's left edge.
+    assert_eq!(
+        bitplane_carry_words_for_line(false, 64, Some(64), true, previous_tail),
         [None; 8]
     );
 }
@@ -2324,6 +2333,7 @@ fn latched_sprite_vstart_equal_vstop_is_empty() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         true,
+        true,
     );
 
     assert!(manual_sprite_lines[0].is_empty());
@@ -2353,6 +2363,7 @@ fn direct_sprite_data_write_ignores_dma_vertical_window() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0]
@@ -2464,6 +2475,7 @@ fn sprite_dma_capture_suppresses_latched_manual_sprite_spans() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0].is_empty());
@@ -2485,6 +2497,7 @@ fn manual_sprite_replay_does_not_seed_from_frame_start_data_latch() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0].is_empty());
@@ -2525,6 +2538,7 @@ fn pre_dma_position_write_preserves_armed_latch_for_later_position_write() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0].iter().any(|line| {
@@ -2557,6 +2571,7 @@ fn post_dma_position_write_reuses_armed_frame_start_data_latch() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0].iter().any(|line| {
@@ -2584,6 +2599,7 @@ fn offscreen_pre_dma_position_write_preserves_armed_latch_for_same_line_retime()
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[3].iter().any(|line| {
@@ -2609,10 +2625,84 @@ fn pre_visible_data_write_seeds_latch_without_direct_output_guard() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[3].iter().any(|line| {
         line.beam_y == 99 && line.hstart == 0x78 && line.data == 0xE92D && line.datb == 0x16FF
+    }));
+}
+
+#[test]
+fn vblank_data_write_arms_manual_sprite_for_all_lines_without_sprite_dma() {
+    // With sprite DMA idle, a vertical-blank arm sequence (SPRxPOS, SPRxCTL,
+    // SPRxDATA, SPRxDATB) must behave like Denise: the CTL write disarms, the
+    // DATA write re-arms, and the armed serializer fires at HSTART on every
+    // line. VSTART == VSTOP is irrelevant without DMA (Denise has no vertical
+    // comparator). Regression example: Gen-X's edge-masking line sprites,
+    // armed once per frame during vblank.
+    let initial_state = blank_state();
+
+    let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+        &initial_state,
+        &[
+            cpu_event(0, 34, 0x140, 0x2C7E),
+            cpu_event(0, 38, 0x142, 0x2C00),
+            cpu_event(0, 50, 0x144, 0x0001),
+            cpu_event(0, 54, 0x146, 0xFFFE),
+        ],
+        &[None; 8],
+        PAL_VISIBLE_LINE0,
+        FB_HEIGHT,
+        false,
+        false,
+    );
+
+    let hstart = 0x00FC;
+    for beam_y in [
+        PAL_VISIBLE_LINE0,
+        PAL_VISIBLE_LINE0 + FB_HEIGHT as i32 / 2,
+        PAL_VISIBLE_LINE0 + FB_HEIGHT as i32 - 1,
+    ] {
+        assert!(
+            manual_sprite_lines[0].iter().any(|line| {
+                line.beam_y == beam_y
+                    && line.hstart == hstart
+                    && line.data == 0x0001
+                    && line.datb == 0xFFFE
+            }),
+            "expected armed manual sprite line at beam_y={beam_y}"
+        );
+    }
+}
+
+#[test]
+fn early_position_write_keeps_manual_sprite_armed_without_sprite_dma() {
+    // SPRxPOS never disarms a sprite on Denise; the early same-line POS guard
+    // reconciles unseen DMA writes and must not fire when no sprite DMA ran.
+    let initial_state = blank_state();
+    let beam_y = PAL_VISIBLE_LINE0;
+    let (pos, ctl) = sprite_control_words(beam_y as u16, beam_y as u16, DIW_HSTART_FB0 as u16);
+    let (moved_pos, _) =
+        sprite_control_words(beam_y as u16, beam_y as u16, (DIW_HSTART_FB0 + 32) as u16);
+
+    let manual_sprite_lines = manual_sprite_lines_from_events_with_visible_line0(
+        &initial_state,
+        &[
+            cpu_event(0, 34, 0x140, pos),
+            cpu_event(0, 38, 0x142, ctl),
+            cpu_event(0, 50, 0x144, 0x8000),
+            cpu_event((beam_y + 1) as u32, 8, 0x140, moved_pos),
+        ],
+        &[None; 8],
+        PAL_VISIBLE_LINE0,
+        FB_HEIGHT,
+        false,
+        false,
+    );
+
+    assert!(manual_sprite_lines[0].iter().any(|line| {
+        line.beam_y == beam_y + 1 && line.hstart == DIW_HSTART_FB0 + 32 && line.data == 0x8000
     }));
 }
 
@@ -2639,6 +2729,7 @@ fn manual_sprite_replay_starts_from_beam_timed_data_write() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0]
@@ -2669,6 +2760,7 @@ fn early_line_position_write_does_not_reuse_previous_manual_sprite_data() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0]
@@ -2771,6 +2863,7 @@ fn held_sprite_after_dma_disable_persists_past_descriptor_vstop() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         true,
+        true,
     );
 
     let line = manual_sprite_lines[0]
@@ -2817,6 +2910,7 @@ fn held_sprite_starts_from_dma_loaded_position_and_control() {
         &held,
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
+        true,
         true,
     );
 
@@ -4124,6 +4218,7 @@ fn dma_loaded_sprite_data_rearms_on_same_line_position_write() {
         PAL_VISIBLE_LINE0,
         FB_HEIGHT,
         false,
+        true,
     );
 
     assert!(manual_sprite_lines[0].is_empty());


### PR DESCRIPTION
## Summary

Two hardware-model fixes for the 0.9.0-only Gen-X regressions in #69 (referenced only, not closed: the remaining items there are still open).

- **Manual-sprite replay guards apply only when sprite DMA was observed.** The early same-line `SPRxPOS` hand-off and the pre-visible `SPRxDATA` latch-seeding rules exist to reconcile DMA register writes the beam replay cannot see. With sprite DMA idle, Denise's own rules hold unmodified: `SPRxDATA` arms at any beam position (vertical blank included), `SPRxCTL` disarms, `SPRxPOS` never disarms, and an armed sprite serializes at HSTART on every line - Denise has no vertical comparator, so a vblank arm sequence with VSTART == VSTOP displays full-height columns. Regression example: Gen-X's greetings shutter arms its white edge-masking line sprites once per frame during vblank; they were invisible since 0.9.0 (fd62f96).
- **A carried previous-line shifter tail is only observable when the row's first `BPL1DAT` load lands at the display-window edge.** When a late DDFSTRT places the fetch origin inside the open window, the serializer has run far past its previous load by the time the window opens, so the BPLCON1 scroll-in taps shift out empty (playfield colour 0), never the previous line's tail. The existing first-load check missed this because `bitplane_dma_output_start_x` maps the word-0 fetch hpos in a different coordinate domain than the placement model. Regression example: Gen-X's credit-banner reflection rows (DDFSTRT $40, per-row BPLCON1 ripple, DIW $81) painted a stray dash column at the window's left edge.

Both fixes were verified frame-by-frame against a real-hardware capture of the demo (greetings opening and closing shutters; reflection left edge).

## Verification

- `cargo test` (1264 + 30 + 4 green), `cargo clippy --all-targets`, `cargo fmt --check`
- New focused regressions: `vblank_data_write_arms_manual_sprite_for_all_lines_without_sprite_dma`, `early_position_write_keeps_manual_sprite_armed_without_sprite_dma`, plus a late-DDF case in `bplcon1_delay_drops_carry_when_first_bpl1dat_is_late`
- Byte-identity A/B against clean main: Rebirth `r.adf` boot at 30/60/90/120s, State of the Art at 40/80s, bare Kickstart 1.3 boot at 10s - all byte-identical, so the #76 Rebirth behavior is untouched

Part of #69 (crossfade and dotmorph remain open there; the rotozoom and endpart reports need a re-test on current main since they appear to be resolved by the #76 presentation work).