### PR TITLE
m68k: resumable 68030 bus-fault frames and the MMU walk features behind them

### DIFF
--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -233,6 +233,30 @@ pub struct CpuCore {
     /// physical bus errors leave it None. Transient within one exception.
     #[serde(skip)]
     pub(crate) pending_fault_cause: Option<crate::mmu::MmuFaultCause>,
+    /// Function code forced for the current data access: MOVES reads and
+    /// writes carry SFC/DFC instead of the CPU-state-derived code, and the
+    /// MMU translates in that address space (the 68030 FCL table level and
+    /// TTR matching see the alternate code; on the 040 it selects URP vs
+    /// SRP). None for ordinary accesses; transient within one instruction.
+    #[serde(skip)]
+    pub(crate) mmu_fc_override: Option<u8>,
+    /// One-shot faulted-read completion, from an RTE of a 68030 bus-fault
+    /// frame whose handler cleared the SSW DF bit and supplied the result
+    /// in the data input buffer: (logical address, value). Real silicon
+    /// continues the instruction using that value instead of rerunning the
+    /// data cycle (mmu.library emulates lazily-zeroed pages this way); this
+    /// restart-model core re-executes the instruction and substitutes the
+    /// value on its matching data read.
+    pub(crate) mmu_read_override: Option<(u32, u32)>,
+    /// One-shot suppressed data write: the DF-cleared write-fault analogue
+    /// of `mmu_read_override` -- the re-executed instruction's write to
+    /// this logical address is discarded (the handler already completed or
+    /// absorbed it).
+    pub(crate) mmu_write_suppress: Option<u32>,
+    /// Data value of the most recent data write, captured so a write fault
+    /// can stack it in the 030 frame's data output buffer (the handler
+    /// completes the write from there).
+    pub(crate) pending_fault_wdata: u32,
 
     // ========== Execution State ==========
     /// Remaining cycles in current timeslice
@@ -437,6 +461,10 @@ impl CpuCore {
             buscr: 0,
             atc: crate::mmu::Atc::default(),
             pending_fault_cause: None,
+            mmu_fc_override: None,
+            mmu_read_override: None,
+            mmu_write_suppress: None,
+            pending_fault_wdata: 0,
             cycles_remaining: 0,
             initial_cycles: 0,
             oep060: Default::default(),
@@ -1218,6 +1246,14 @@ impl CpuCore {
         // Part E.2: report internal clocks elapsed before this bus access.
         self.flush_sync(bus);
         let mut addr = self.address(addr);
+        if let Some((a, v)) = self.mmu_read_override {
+            if a == addr {
+                // RTE'd 030 bus-fault frame with DF cleared: the handler
+                // supplied this read's result in the data input buffer.
+                self.mmu_read_override = None;
+                return v as u8;
+            }
+        }
         {
             if self.has_pmmu && self.pmmu_enabled {
                 match crate::mmu::translate_address(
@@ -1263,6 +1299,14 @@ impl CpuCore {
         {
             self.trigger_address_error(bus, addr, false, false);
             return 0;
+        }
+        if let Some((a, v)) = self.mmu_read_override {
+            if a == addr {
+                // RTE'd 030 bus-fault frame with DF cleared: the handler
+                // supplied this read's result in the data input buffer.
+                self.mmu_read_override = None;
+                return v as u16;
+            }
         }
         {
             if self.has_pmmu && self.pmmu_enabled {
@@ -1310,6 +1354,14 @@ impl CpuCore {
             self.trigger_address_error(bus, addr, false, false);
             return 0;
         }
+        if let Some((a, v)) = self.mmu_read_override {
+            if a == addr {
+                // RTE'd 030 bus-fault frame with DF cleared: the handler
+                // supplied this read's result in the data input buffer.
+                self.mmu_read_override = None;
+                return v;
+            }
+        }
         {
             if self.has_pmmu && self.pmmu_enabled {
                 match crate::mmu::translate_address(
@@ -1348,6 +1400,13 @@ impl CpuCore {
         // Part E.2: report internal clocks elapsed before this bus access.
         self.flush_sync(bus);
         let mut addr = self.address(addr);
+        if self.mmu_write_suppress == Some(addr) {
+            // RTE'd 030 bus-fault frame with DF cleared on a write fault:
+            // the handler completed or absorbed this write.
+            self.mmu_write_suppress = None;
+            return;
+        }
+        self.pending_fault_wdata = value as u32;
         {
             if self.has_pmmu && self.pmmu_enabled {
                 match crate::mmu::translate_address(
@@ -1390,6 +1449,12 @@ impl CpuCore {
             self.trigger_address_error(bus, addr, true, false);
             return;
         }
+        if self.mmu_write_suppress == Some(addr) {
+            // See write_8: DF-cleared write fault, already completed.
+            self.mmu_write_suppress = None;
+            return;
+        }
+        self.pending_fault_wdata = value as u32;
         {
             if self.has_pmmu && self.pmmu_enabled {
                 match crate::mmu::translate_address(
@@ -1432,6 +1497,12 @@ impl CpuCore {
             self.trigger_address_error(bus, addr, true, false);
             return;
         }
+        if self.mmu_write_suppress == Some(addr) {
+            // See write_8: DF-cleared write fault, already completed.
+            self.mmu_write_suppress = None;
+            return;
+        }
+        self.pending_fault_wdata = value;
         {
             if self.has_pmmu && self.pmmu_enabled {
                 match crate::mmu::translate_address(
@@ -1540,25 +1611,59 @@ impl CpuCore {
                 | super::types::CpuType::M68040
         );
         if is_ptest && is_040 {
-            // PTEST on 68040 - treat as NOP
+            // 030-form PTEST on the 68040 - treat as NOP (68040.library
+            // issues these during setup; the 040 form is 0xF548).
             return 4;
         }
-        // PLOAD / PFLUSH / PFLUSHA / PTEST (68030 forms): recognized but not yet
-        // fully modelled. Treat them as NOPs rather than returning 0, which the
-        // decoder would turn into a LINE-1111 trap -- AROS and the 68040.library
-        // issue these during MMU setup, so trapping crashes the boot. PTEST
-        // reports "no fault" via a benign MMUSR; an ATC to flush (PFLUSH/PLOAD)
-        // and precise MMUSR bits (PTEST) come with later phases.
+        if is_ptest {
+            // 68030 PTEST: walk the tables for the EA in the address space
+            // named by the extension word's fc field, at most `level`
+            // descriptors deep, and report the outcome in MMUSR. With the
+            // A bit set, the physical address of the last descriptor
+            // examined lands in An -- mmu.library's lazy fault handler
+            // finds the shared descriptor slot to materialize by stepping
+            // PTEST through the levels exactly this way.
+            let level = ((modes >> 10) & 7) as u32;
+            let read = (modes & 0x0200) != 0;
+            let a_bit = (modes & 0x0100) != 0;
+            let an = ((modes >> 5) & 7) as usize;
+            let fcf = (modes & 0x1F) as u32;
+            let fc = if fcf & 0x10 != 0 {
+                fcf & 7 // immediate
+            } else if fcf & 0x08 != 0 {
+                self.d((fcf & 7) as usize) & 7 // Dn
+            } else if fcf == 1 {
+                self.dfc & 7
+            } else {
+                self.sfc & 7 // 00000 = SFC (00001 = DFC above)
+            };
+            let ea_mode = ((opcode >> 3) & 0x7) as u8;
+            let ea_reg = (opcode & 0x7) as u8;
+            let Some(am) = AddressingMode::decode(ea_mode, ea_reg) else {
+                return 0;
+            };
+            let super::ea::EaResult::Memory(addr) = self.resolve_ea(bus, am, Size::Long) else {
+                return 0;
+            };
+            let (sr, desc_addr) = crate::mmu::ptest_030(self, bus, addr, fc, !read, level);
+            self.mmu_sr = sr as u32;
+            if a_bit && level != 0 {
+                self.set_a(an, desc_addr);
+            }
+            return 8;
+        }
+        // PLOAD / PFLUSH / PFLUSHA (68030 forms): recognized but not yet
+        // fully modelled. Treat them as NOPs rather than returning 0, which
+        // the decoder would turn into a LINE-1111 trap -- AROS and the
+        // 68040.library issue these during MMU setup, so trapping crashes
+        // the boot. There is no ATC on the 030 walk, so a flush has nothing
+        // to drop.
         if (modes & 0xFDE0) == 0x2000   // PLOAD
             || (modes & 0xE200) == 0x2000
             || modes == 0xA000          // PFLUSHA
             || modes == 0x2800
             || (modes & 0xFFF8) == 0x2C00 // PFLUSH
-            || is_ptest
         {
-            if is_ptest {
-                self.mmu_sr = 0;
-            }
             return 8;
         }
 
@@ -1621,6 +1726,12 @@ impl CpuCore {
                     self.write_resolved_ea(bus, ea, Size::Long, self.mmu_tt1);
                     4
                 }
+                0x18 => {
+                    // MMUSR / PSR (16): how a fault handler reads the PTEST
+                    // result (PMOVE PSR,<ea>).
+                    self.write_resolved_ea(bus, ea, Size::Word, self.mmu_sr & 0xFFFF);
+                    4
+                }
                 _ => 0,
             }
         } else {
@@ -1661,6 +1772,12 @@ impl CpuCore {
                     // TT1 (32)
                     let v = self.read_resolved_ea(bus, ea, Size::Long);
                     self.mmu_tt1 = v;
+                    4
+                }
+                0x18 => {
+                    // MMUSR / PSR (16)
+                    let v = self.read_resolved_ea(bus, ea, Size::Word);
+                    self.mmu_sr = v & 0xFFFF;
                     4
                 }
                 _ => 0,

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -207,7 +207,11 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 let an = 8 + (opcode & 7) as usize;
                 let addr = cpu.dar[an];
                 let supervisor = (cpu.dfc & 4) != 0;
-                match crate::mmu::translate_address(cpu, bus, addr, write, supervisor, false) {
+                cpu.mmu_fc_override = Some((cpu.dfc & 7) as u8);
+                let translated =
+                    crate::mmu::translate_address(cpu, bus, addr, write, supervisor, false);
+                cpu.mmu_fc_override = None;
+                match translated {
                     Ok(phys) => {
                         cpu.dar[an] = phys;
                         return 4;
@@ -234,15 +238,19 @@ fn dispatch_group_f<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             // PTEST: walk the page for An and report it in MMUSR. We model the
             // physical-address and resident (R) bits, enough for an OS to tell a
             // mapped page from an invalid one; the cache-mode / used / modified
-            // attribute bits are not yet filled in.
+            // attribute bits are not yet filled in. The address space under
+            // test comes from DFC (how an OS PTESTs user mappings from
+            // supervisor mode), carried by the same override MOVES uses.
             let read = (opcode & 0x0020) != 0;
             let addr = cpu.dar[8 + (opcode & 7) as usize];
-            let supervisor = cpu.is_supervisor();
+            let fc = (cpu.dfc & 7) as u8;
+            cpu.mmu_fc_override = Some(fc);
             cpu.mmu_sr =
-                match crate::mmu::translate_address(cpu, bus, addr, !read, supervisor, false) {
+                match crate::mmu::translate_address(cpu, bus, addr, !read, (fc & 4) != 0, false) {
                     Ok(phys) => (phys & 0xFFFF_F000) | 0x0000_0001, // R = resident
                     Err(_) => 0,                                    // not resident
                 };
+            cpu.mmu_fc_override = None;
             return 4;
         }
         // PFLUSH variants flush the ATC. We do not track entries finely enough
@@ -911,6 +919,63 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                                     cpu.pc = cpu.pull_32(bus);
                                     let _ = cpu.pull_16(bus); // format word
                                     cpu.dar[15] = cpu.dar[15].wrapping_add(52);
+                                    cpu.set_sr(sr);
+                                    return 20;
+                                }
+                                0xA | 0xB
+                                    if matches!(
+                                        cpu.cpu_type,
+                                        CpuType::M68EC020
+                                            | CpuType::M68020
+                                            | CpuType::M68EC030
+                                            | CpuType::M68030
+                                    ) =>
+                                {
+                                    // 68020/68030 bus-cycle fault frames:
+                                    // short format $A (16 words) and long
+                                    // format $B (46 words). Real silicon
+                                    // reloads pipeline state from the frame
+                                    // and continues the instruction; this
+                                    // core stacked the rolled-back
+                                    // instruction's PC at frame-build time,
+                                    // so discarding the dump and resuming at
+                                    // the stacked PC restarts it.
+                                    //
+                                    // A handler that CLEARS the SSW DF bit
+                                    // has completed the data cycle itself:
+                                    // for a read it supplies the result in
+                                    // the data input buffer (+$2C) -- how
+                                    // mmu.library emulates lazily-zeroed
+                                    // pages -- and for a write the data is
+                                    // considered absorbed. The restart
+                                    // honours that with a one-shot
+                                    // substitution on the re-executed
+                                    // instruction's matching access.
+                                    if format == 0xB {
+                                        let sp = cpu.a(7);
+                                        let ssw = cpu.read_16(bus, sp.wrapping_add(0x0A));
+                                        let df_cleared = ssw & 0x0100 == 0;
+                                        // No stage-rerun bits (FC/FB/RC/RB)
+                                        // = this frame described a data
+                                        // fault (DF was set when pushed).
+                                        let was_data = ssw & 0xF000 == 0;
+                                        if df_cleared && was_data {
+                                            let fa = cpu.read_32(bus, sp.wrapping_add(0x10));
+                                            if ssw & 0x0040 != 0 {
+                                                // RW=1: faulted read
+                                                let dib =
+                                                    cpu.read_32(bus, sp.wrapping_add(0x2C));
+                                                cpu.mmu_read_override = Some((fa, dib));
+                                            } else {
+                                                cpu.mmu_write_suppress = Some(fa);
+                                            }
+                                        }
+                                    }
+                                    let sr = cpu.pull_16(bus);
+                                    cpu.pc = cpu.pull_32(bus);
+                                    let _ = cpu.pull_16(bus); // format word
+                                    let dump = if format == 0xA { 24 } else { 84 };
+                                    cpu.dar[15] = cpu.dar[15].wrapping_add(dump);
                                     cpu.set_sr(sr);
                                     return 20;
                                 }

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -366,17 +366,25 @@ impl CpuCore {
         self.t1_flag = 0;
         self.t0_flag = 0;
 
-        // Build function code / status word
-        let fc = if was_supervisor {
-            if instruction {
-                fc::SUPERVISOR_PROGRAM
-            } else {
-                fc::SUPERVISOR_DATA
+        // Build function code / status word. A MOVES data fault carries the
+        // SFC/DFC space it faulted in, not the CPU-state code: the handler
+        // reads the fc back out of the frame's SSW to PTEST the faulted
+        // space (mmu.library does exactly this).
+        let fc = match self.mmu_fc_override {
+            Some(ofc) => ofc as u16,
+            None => {
+                if was_supervisor {
+                    if instruction {
+                        fc::SUPERVISOR_PROGRAM
+                    } else {
+                        fc::SUPERVISOR_DATA
+                    }
+                } else if instruction {
+                    fc::USER_PROGRAM
+                } else {
+                    fc::USER_DATA
+                }
             }
-        } else if instruction {
-            fc::USER_PROGRAM
-        } else {
-            fc::USER_DATA
         };
         let status_word = fc | if write { 0 } else { 0x10 } | if instruction { 0 } else { 0x08 };
 
@@ -467,12 +475,73 @@ impl CpuCore {
                 self.push_16_raw(bus, old_sr);
             }
             _ => {
-                // TODO: 68020/68030 bus-error stack frames (format A / long
-                // format B) are not yet implemented. Minimal fallback.
-                self.push_16_raw(bus, (vector::BUS_ERROR as u16) << 2);
-                self.push_32_raw(bus, self.ppc);
-                self.push_16_raw(bus, old_sr);
-                let _ = (status_word, address);
+                // 68020/68030 long bus-cycle fault frame (format $B, 46
+                // words, M68030UM 8.2). Real silicon dumps pipeline state
+                // here and RTE *continues* the faulted instruction, with the
+                // handler able to rerun or complete the data cycle through
+                // the DF bit and the data input/output buffers. This core
+                // rolls the faulting instruction back instead and stacks its
+                // PC, so RTE restarts it from scratch: the pipeline dump and
+                // writeback buffers are left zero, and a handler that
+                // clears DF to suppress the rerun is not honoured (the
+                // restart re-issues the access; harmless for memory, the
+                // documented gap for side-effecting hardware registers).
+                //
+                // The special status word at +$0A is what a page-fault
+                // handler (mmu.library, VMM, Enforcer) actually parses:
+                // DF (bit 8) marks a faulted data cycle with its address in
+                // the long at +$10, RW (bit 6) the direction, SIZ (bits 5:4,
+                // 01 byte / 10 word / 00 long) the width, and FC2:0 the
+                // address space. An instruction-fetch fault instead reports
+                // a stage-B rerun (FB|RB, bits 14/12) with the fetch address
+                // in the stage B address long at +$24, the shape real
+                // handlers use to demand-page code.
+                let data_fault = !instruction;
+                let mut ssw: u16 = fc as u16 & 0x7;
+                if data_fault {
+                    ssw |= 0x0100; // DF: rerun data cycle
+                    if !write {
+                        ssw |= 0x0040; // RW: read
+                    }
+                    ssw |= match size {
+                        1 => 0x0010, // SIZ 01: byte
+                        2 => 0x0020, // SIZ 10: word
+                        _ => 0x0000, // SIZ 00: long
+                    };
+                } else {
+                    ssw |= 0x4000 | 0x1000; // FB|RB: rerun instruction stage B
+                }
+                let fmt_vec = 0xB000 | ((vector::BUS_ERROR as u16) << 2);
+                // Pushed high address -> low: internal words +$38..$5A (18
+                // words), version word +$36, internal +$30..$34 (3 words),
+                // data input buffer +$2C, internal +$28/$2A, stage B address
+                // +$24, internal +$1C..$22 (4 words), data output buffer
+                // +$18, internal +$14/$16, data fault address +$10, stage B
+                // and C pipe words +$0E/$0C, SSW +$0A, internal +$08.
+                for _ in 0..9 {
+                    self.push_32_raw(bus, 0); // +$38..$5A
+                }
+                self.push_16_raw(bus, 0); // +$36 version/internal
+                for _ in 0..3 {
+                    self.push_16_raw(bus, 0); // +$30..$34
+                }
+                self.push_32_raw(bus, 0); // +$2C data input buffer
+                self.push_32_raw(bus, 0); // +$28/$2A internal
+                self.push_32_raw(bus, if data_fault { 0 } else { address }); // +$24 stage B address
+                self.push_32_raw(bus, 0); // +$20/$22 internal
+                self.push_32_raw(bus, 0); // +$1C/$1E internal
+                // +$18 data output buffer: the value of a faulted write, so
+                // a handler can complete the write itself (clear DF).
+                self.push_32_raw(bus, if write { self.pending_fault_wdata } else { 0 });
+                self.push_32_raw(bus, 0); // +$14/$16 internal
+                self.push_32_raw(bus, if data_fault { address } else { 0 }); // +$10 data fault address
+                self.push_16_raw(bus, 0); // +$0E pipe stage B
+                self.push_16_raw(bus, 0); // +$0C pipe stage C
+                self.push_16_raw(bus, ssw); // +$0A special status word
+                self.push_16_raw(bus, 0); // +$08 internal
+                self.push_16_raw(bus, fmt_vec); // +$06 format/vector
+                self.push_32_raw(bus, self.ppc); // +$02 restart PC
+                self.push_16_raw(bus, old_sr); // +$00 SR
             }
         }
 

--- a/crates/m68k/src/core/instructions/moves.rs
+++ b/crates/m68k/src/core/instructions/moves.rs
@@ -12,8 +12,11 @@ use crate::core::types::Size;
 
 impl CpuCore {
     /// MOVES - Move to/from address space using SFC/DFC.
-    /// In emulation, we treat this as a normal memory access since we don't
-    /// emulate separate address spaces.
+    /// The Amiga bus does not decode function codes, so the access itself is
+    /// a normal memory access -- but with the PMMU enabled the address space
+    /// matters: the data cycle translates under SFC/DFC (mmu_fc_override),
+    /// which selects the 030 FCL table branch / TTR matches and the 040
+    /// user-vs-supervisor root pointer.
     pub fn exec_moves<B: AddressBus>(&mut self, bus: &mut B, opcode: u16) -> i32 {
         // Check supervisor mode
         if self.s_flag == 0 {
@@ -44,25 +47,29 @@ impl CpuCore {
         let addr = self.get_ea_address(bus, mode, size);
 
         if direction == 1 {
-            // Register to EA (write)
+            // Register to EA (write): the data cycle runs in the DFC space.
             let value = if is_areg {
                 self.a(reg_idx)
             } else {
                 self.d(reg_idx)
             };
 
+            self.mmu_fc_override = Some((self.dfc & 7) as u8);
             match size {
                 Size::Byte => self.write_8(bus, addr, value as u8),
                 Size::Word => self.write_16(bus, addr, value as u16),
                 Size::Long => self.write_32(bus, addr, value),
             }
+            self.mmu_fc_override = None;
         } else {
-            // EA to register (read)
+            // EA to register (read): the data cycle runs in the SFC space.
+            self.mmu_fc_override = Some((self.sfc & 7) as u8);
             let value = match size {
                 Size::Byte => self.read_8(bus, addr) as u32,
                 Size::Word => self.read_16(bus, addr) as u32,
                 Size::Long => self.read_32(bus, addr),
             };
+            self.mmu_fc_override = None;
 
             if is_areg {
                 // Sign extend for address register

--- a/crates/m68k/src/mmu/mod.rs
+++ b/crates/m68k/src/mmu/mod.rs
@@ -8,6 +8,7 @@ use crate::core::cpu::CpuCore;
 use crate::core::memory::AddressBus;
 
 pub use atc::Atc;
+pub(crate) use translation::ptest_030;
 pub use translation::translate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/m68k/src/mmu/translation.rs
+++ b/crates/m68k/src/mmu/translation.rs
@@ -70,6 +70,15 @@ pub fn translate<B: AddressBus>(
         return Ok(logical);
     }
 
+    // MOVES carries SFC/DFC instead of the CPU-state function code: the
+    // access translates in that address space (mmu.library's 030 MMU
+    // detection probes exactly this, remapping the user-data space and
+    // reading it back with MOVES from supervisor mode).
+    let (supervisor, instruction) = match cpu.mmu_fc_override {
+        Some(fc) => ((fc & 4) != 0, (fc & 3) == 2),
+        None => (supervisor, instruction),
+    };
+
     // During exception processing, bypass translation to prevent recursive faults.
     // Real hardware uses transparent translation or physical addressing for exception frames.
     if cpu.exception_processing {
@@ -88,7 +97,109 @@ pub fn translate<B: AddressBus>(
         return translate_040(cpu, bus, logical, write, supervisor, instruction);
     }
 
-    // Root pointer selection: if SRP enabled and supervisor, use SRP; else CRP.
+    translate_030(cpu, bus, logical, write, supervisor, instruction)
+}
+
+/// One fetched 68030 table descriptor, normalized across the short (4-byte)
+/// and long (8-byte) formats. `field` is the address long (the whole
+/// descriptor for short format, the second long for long format); `wp` is
+/// the write-protect bit and `sup` the long-format supervisor-only bit,
+/// both of which accumulate along the walk on real silicon.
+struct Desc030 {
+    dt: u32,
+    field: u32,
+    wp: bool,
+    sup: bool,
+}
+
+fn read_desc_030<B: AddressBus>(
+    bus: &mut B,
+    base: u32,
+    index: u32,
+    long: bool,
+) -> MmuResult<Desc030> {
+    if long {
+        let at = base.wrapping_add(index * 8);
+        let hi = read_u32_phys(bus, at)?;
+        let lo = read_u32_phys(bus, at.wrapping_add(4))?;
+        Ok(Desc030 {
+            dt: hi & 3,
+            field: lo,
+            wp: hi & 0x0000_0004 != 0,
+            sup: hi & 0x0000_0100 != 0,
+        })
+    } else {
+        let at = base.wrapping_add(index * 4);
+        let e = read_u32_phys(bus, at)?;
+        Ok(Desc030 {
+            dt: e & 3,
+            field: e,
+            wp: e & 0x0000_0004 != 0,
+            sup: false,
+        })
+    }
+}
+
+/// How a 68030 table walk ended.
+enum Walk030End {
+    /// A page / early-termination descriptor: `field` is its address long,
+    /// `consumed` the logical bits eaten by the levels above it.
+    Page { field: u32, consumed: u32 },
+    /// An invalid (DT=0) descriptor, or an indirect descriptor whose target
+    /// is not a page descriptor (`indirect` tells the two apart).
+    Invalid { indirect: bool },
+    /// The level limit stopped the walk on a valid table pointer (PTEST
+    /// with a level operand; a full walk never ends here).
+    LevelStop,
+    /// A bus error while fetching a descriptor at this physical address.
+    BusErr { at: u32 },
+    /// Unusable configuration: invalid root DT or zero configured levels.
+    Config,
+}
+
+/// A finished 68030 walk: the outcome plus the accumulated protection bits,
+/// the number of descriptors fetched, and the physical address of the last
+/// descriptor examined (what PTEST's A bit hands back for lazy table fills).
+struct Walk030 {
+    end: Walk030End,
+    wp: bool,
+    sup: bool,
+    levels: u32,
+    desc_addr: u32,
+}
+
+/// The 68030 programmable table walk, shared between address translation
+/// and PTEST.
+///
+/// TC configures an optional function-code level (FCL, bit 24) followed by
+/// up to four address-indexed levels (TIA/TIB/TIC/TID, bits 15:0), with IS
+/// (bits 19:16) leading address bits ignored; the page offset is whatever
+/// logical bits the configured levels leave unconsumed (PS, bits 23:20, is
+/// redundant with that on a well-formed TC and is not consulted). At every
+/// level a descriptor can be: invalid (DT=0), a page / early termination
+/// descriptor (DT=1, maps the whole remaining space), or a pointer to the
+/// next table in short or long format (DT=2/3). A pointer found when no
+/// configured level remains is an *indirect* descriptor: its address field
+/// names the real page descriptor, fetched in the pointed-to format, which
+/// must itself be DT=1 (mmu.library shares per-page descriptors between its
+/// user and supervisor trees this way, exactly as on the 68040; the fetch
+/// counts as a walk level, which is how its lazy fault handler locates the
+/// poisoned target with level-limited PTESTs). Write-protect accumulates
+/// across all fetched descriptors; the long-format S bit restricts a
+/// subtree to supervisor accesses. `max_levels` bounds how many descriptors
+/// are fetched (PTEST's level operand); `u32::MAX` walks to completion.
+///
+/// Not modelled: CRP/long-descriptor limit checks, the DT=1 page-descriptor
+/// root, and used/modified descriptor write-back.
+fn walk_030<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    logical: u32,
+    fc: u32,
+    max_levels: u32,
+) -> Walk030 {
+    let supervisor = fc & 4 != 0;
+    // Root pointer selection: if SRE set and supervisor space, SRP; else CRP.
     let use_srp = (cpu.mmu_tc & 0x0200_0000) != 0 && supervisor;
     let (root_aptr, root_limit) = if use_srp {
         (cpu.mmu_srp_aptr, cpu.mmu_srp_limit)
@@ -96,139 +207,223 @@ pub fn translate<B: AddressBus>(
         (cpu.mmu_crp_aptr, cpu.mmu_crp_limit)
     };
 
-    // Initial shift / table bits (Musashi):
-    // is = tc[19:16], abits=tc[15:12], bbits=tc[11:8], cbits=tc[7:4]
+    let fcl = (cpu.mmu_tc & 0x0100_0000) != 0;
     let is = (cpu.mmu_tc >> 16) & 0xF;
-    let abits = (cpu.mmu_tc >> 12) & 0xF;
-    let bbits = (cpu.mmu_tc >> 8) & 0xF;
-    let cbits = (cpu.mmu_tc >> 4) & 0xF;
-
-    let addr_in = logical;
+    let ti = [
+        (cpu.mmu_tc >> 12) & 0xF, // TIA
+        (cpu.mmu_tc >> 8) & 0xF,  // TIB
+        (cpu.mmu_tc >> 4) & 0xF,  // TIC
+        cpu.mmu_tc & 0xF,         // TID
+    ];
 
     #[inline]
     fn top_index(addr: u32, left_shift: u32, bits: u32) -> u32 {
-        if bits == 0 {
-            return 0;
-        }
-        // bits is 1..=32. When bits==32, shift right by 0.
-        let rshift = 32u32.saturating_sub(bits);
-        addr.wrapping_shl(left_shift) >> rshift
+        // bits is 1..=15 for a configured level.
+        addr.wrapping_shl(left_shift) >> (32 - bits)
     }
 
-    #[inline]
-    fn low_bits(addr: u32, shift: u32) -> u32 {
-        if shift >= 32 {
-            0
+    let mut w = Walk030 {
+        end: Walk030End::Config,
+        wp: false,
+        sup: false,
+        levels: 0,
+        desc_addr: root_aptr,
+    };
+
+    // Walk state: current table pointer + descriptor format and the logical
+    // bits consumed so far. This is the per-access hot path (the 030 walk
+    // has no ATC), so no allocation.
+    let mut long = match root_limit & 3 {
+        2 => false,
+        3 => true,
+        // DT=0 root is invalid; the DT=1 page-descriptor root is not
+        // implemented (nothing exercises it).
+        _ => return w,
+    };
+    let mut ptr = root_aptr & 0xFFFF_FFF0;
+    let mut consumed = is;
+
+    // An FC level first when FCL is set (consumes no logical bits), then
+    // the configured TIA/TIB/TIC/TID levels.
+    let n_addr = ti.iter().take_while(|&&b| b != 0).count();
+    let n = n_addr + fcl as usize;
+    if n == 0 {
+        return w;
+    }
+
+    for li in 0..n {
+        if w.levels >= max_levels {
+            w.end = Walk030End::LevelStop;
+            return w;
+        }
+        let index = if fcl && li == 0 {
+            fc
         } else {
-            addr.wrapping_shl(shift) >> shift
-        }
-    }
-
-    // Table A offset.
-    let mut tofs = top_index(addr_in, is, abits);
-
-    let mut tbl_entry: u32;
-    let tamode: u32;
-
-    match root_limit & 3 {
-        0 => return Err(config_fault(logical)),
-        1 => return Err(config_fault(logical)), // page descriptor root mode not implemented yet
-        2 => {
-            // 4-byte descriptors
-            tofs = tofs.wrapping_mul(4);
-            let e = read_u32_phys(bus, tofs.wrapping_add(root_aptr & 0xFFFF_FFFC))?;
-            tbl_entry = e;
-            tamode = e & 3;
-        }
-        3 => {
-            // 8-byte descriptors: mode in high long, pointer/base in low long
-            tofs = tofs.wrapping_mul(8);
-            let hi = read_u32_phys(bus, tofs.wrapping_add(root_aptr & 0xFFFF_FFFC))?;
-            let lo = read_u32_phys(
-                bus,
-                tofs.wrapping_add(root_aptr & 0xFFFF_FFFC).wrapping_add(4),
-            )?;
-            tamode = hi & 3;
-            tbl_entry = lo;
-        }
-        _ => unreachable!(),
-    }
-
-    // Table B offset and pointer from A entry.
-    tofs = top_index(addr_in, is + abits, bbits);
-    let mut tptr = tbl_entry & 0xFFFF_FFF0;
-    let tbmode: u32;
-
-    match tamode {
-        0 => return Err(access_fault(logical)),
-        1 => {
-            // Early termination descriptor (Musashi uses &0xffffff00).
-            if write && tbl_entry & 0x4 != 0 {
-                return Err(access_fault(logical)); // WP: write-protected page
+            let bits = ti[li - fcl as usize];
+            let idx = top_index(logical, consumed, bits);
+            consumed += bits;
+            idx
+        };
+        w.desc_addr = ptr.wrapping_add(index * if long { 8 } else { 4 });
+        let d = match read_desc_030(bus, ptr, index, long) {
+            Ok(d) => d,
+            Err(f) => {
+                w.end = Walk030End::BusErr { at: f.address };
+                return w;
             }
-            let base = tbl_entry & 0xFFFF_FF00;
-            let shift = is + abits;
-            let addr_out = low_bits(addr_in, shift).wrapping_add(base);
-            return Ok(addr_out);
-        }
-        2 => {
-            tofs = tofs.wrapping_mul(4);
-            tbl_entry = read_u32_phys(bus, tofs.wrapping_add(tptr))?;
-            tbmode = tbl_entry & 3;
-        }
-        3 => {
-            tofs = tofs.wrapping_mul(8);
-            let hi = read_u32_phys(bus, tofs.wrapping_add(tptr))?;
-            let lo = read_u32_phys(bus, tofs.wrapping_add(tptr).wrapping_add(4))?;
-            tbmode = hi & 3;
-            tbl_entry = lo;
-        }
-        _ => return Err(access_fault(logical)),
-    }
+        };
+        w.levels += 1;
 
-    // Table C
-    tofs = top_index(addr_in, is + abits + bbits, cbits);
-    tptr = tbl_entry & 0xFFFF_FFF0;
-    let tcmode: u32;
-
-    match tbmode {
-        0 => return Err(access_fault(logical)),
-        1 => {
-            if write && tbl_entry & 0x4 != 0 {
-                return Err(access_fault(logical)); // WP: write-protected page
+        match d.dt {
+            0 => {
+                w.end = Walk030End::Invalid { indirect: false };
+                return w;
             }
-            let base = tbl_entry & 0xFFFF_FF00;
-            let shift = is + abits + bbits;
-            let addr_out = low_bits(addr_in, shift).wrapping_add(base);
-            return Ok(addr_out);
-        }
-        2 => {
-            tofs = tofs.wrapping_mul(4);
-            tbl_entry = read_u32_phys(bus, tofs.wrapping_add(tptr))?;
-            tcmode = tbl_entry & 3;
-        }
-        3 => {
-            tofs = tofs.wrapping_mul(8);
-            let hi = read_u32_phys(bus, tofs.wrapping_add(tptr))?;
-            let lo = read_u32_phys(bus, tofs.wrapping_add(tptr).wrapping_add(4))?;
-            tcmode = hi & 3;
-            tbl_entry = lo;
-        }
-        _ => return Err(access_fault(logical)),
-    }
-
-    // Final termination at table C.
-    match tcmode {
-        1 => {
-            if write && tbl_entry & 0x4 != 0 {
-                return Err(access_fault(logical)); // WP: write-protected page
+            1 => {
+                w.wp |= d.wp;
+                w.sup |= d.sup;
+                w.end = Walk030End::Page {
+                    field: d.field,
+                    consumed,
+                };
+                return w;
             }
-            let base = tbl_entry & 0xFFFF_FF00;
-            let shift = is + abits + bbits + cbits;
-            Ok(low_bits(addr_in, shift).wrapping_add(base))
+            _ => {
+                if li + 1 < n {
+                    // Pointer to the next table level.
+                    w.wp |= d.wp;
+                    w.sup |= d.sup;
+                    ptr = d.field & 0xFFFF_FFF0;
+                    long = d.dt == 3;
+                } else {
+                    // Walk exhausted: DT=2/3 here is an indirect descriptor
+                    // naming the real page descriptor (in the pointed-to
+                    // format), which must itself be a page descriptor. The
+                    // target fetch belongs to this same walk level (it does
+                    // not count towards N or the PTEST level limit), and an
+                    // indirect descriptor carries no protection bits -- its
+                    // address field reaches down to bit 2 -- so only the
+                    // fetched target contributes WP/S. PTEST's A bit hands
+                    // back the target's address: that is the shared slot
+                    // mmu.library's lazy fault handler materializes.
+                    w.desc_addr = d.field & 0xFFFF_FFFC;
+                    let t = match read_desc_030(bus, w.desc_addr, 0, d.dt == 3) {
+                        Ok(t) => t,
+                        Err(f) => {
+                            w.end = Walk030End::BusErr { at: f.address };
+                            return w;
+                        }
+                    };
+                    w.wp |= t.wp;
+                    w.sup |= t.sup;
+                    w.end = if t.dt == 1 {
+                        Walk030End::Page {
+                            field: t.field,
+                            consumed,
+                        }
+                    } else {
+                        Walk030End::Invalid { indirect: true }
+                    };
+                    return w;
+                }
+            }
         }
-        _ => Err(access_fault(logical)),
     }
+    unreachable!("the last level always terminates or indirects");
+}
+
+#[inline]
+fn low_bits(addr: u32, shift: u32) -> u32 {
+    if shift >= 32 {
+        0
+    } else {
+        addr.wrapping_shl(shift) >> shift
+    }
+}
+
+/// 68030 address translation on top of [`walk_030`], enforcing the
+/// accumulated write-protect and supervisor-only bits for the access.
+fn translate_030<B: AddressBus>(
+    cpu: &mut CpuCore,
+    bus: &mut B,
+    logical: u32,
+    write: bool,
+    supervisor: bool,
+    instruction: bool,
+) -> MmuResult<u32> {
+    let fc = if supervisor {
+        if instruction { 6 } else { 5 }
+    } else if instruction {
+        2
+    } else {
+        1
+    };
+    let w = walk_030(cpu, bus, logical, fc, u32::MAX);
+    match w.end {
+        Walk030End::Page { field, consumed } => {
+            if w.sup && !supervisor {
+                return Err(access_fault_cause(
+                    logical,
+                    MmuFaultCause::SupervisorProtect,
+                ));
+            }
+            if write && w.wp {
+                return Err(access_fault_cause(logical, MmuFaultCause::WriteProtect));
+            }
+            let base = field & 0xFFFF_FF00;
+            Ok(low_bits(logical, consumed).wrapping_add(base))
+        }
+        Walk030End::Invalid { indirect: false } => Err(access_fault(logical)),
+        Walk030End::Invalid { indirect: true } => {
+            Err(access_fault_cause(logical, MmuFaultCause::Indirect))
+        }
+        Walk030End::BusErr { at } => Err(buserr(at)),
+        Walk030End::Config => Err(config_fault(logical)),
+        // A full walk never stops on the level limit.
+        Walk030End::LevelStop => Err(config_fault(logical)),
+    }
+}
+
+/// 68030 PTEST: walk the tables for `logical` in the `fc` address space,
+/// fetching at most `level` descriptors (level 0 tests only transparent
+/// translation), and compose the 16-bit MMUSR: B (bit 15, bus error during
+/// search), S (bit 13, supervisor-only mapping probed from a user space),
+/// W (bit 11, write-protect accumulated along the walk -- reported for
+/// reads too), I (bit 10, invalid translation), T (bit 6, transparent-
+/// translation hit, level 0 only), N (bits 2:0, descriptors fetched).
+/// Returns the MMUSR and the physical address of the last descriptor
+/// examined (handed back through PTEST's A bit; mmu.library's lazy fault
+/// handler locates the shared descriptor slot to materialize with exactly
+/// this). The L (limit) and M (modified) bits are not modelled.
+pub(crate) fn ptest_030<B: AddressBus>(
+    cpu: &CpuCore,
+    bus: &mut B,
+    logical: u32,
+    fc: u32,
+    write: bool,
+    level: u32,
+) -> (u16, u32) {
+    if level == 0 {
+        let fc8 = fc as u8;
+        let t = super::ttr::ttr_matches(cpu.mmu_tt0, logical, fc8, write)
+            || super::ttr::ttr_matches(cpu.mmu_tt1, logical, fc8, write);
+        return (if t { 0x0040 } else { 0 }, 0);
+    }
+    let w = walk_030(cpu, bus, logical, fc, level);
+    let n = (w.levels & 7) as u16;
+    let mut sr = n;
+    if w.wp {
+        sr |= 0x0800; // W
+    }
+    if w.sup && fc & 4 == 0 {
+        sr |= 0x2000; // S: supervisor-only mapping probed from user space
+    }
+    match w.end {
+        Walk030End::Page { .. } | Walk030End::LevelStop => {}
+        Walk030End::Invalid { .. } => sr |= 0x0400, // I
+        Walk030End::BusErr { .. } | Walk030End::Config => sr |= 0x8000, // B
+    }
+    (sr, w.desc_addr)
 }
 
 /// Perform 68040 PMMU translation.

--- a/crates/m68k/src/mmu/ttr.rs
+++ b/crates/m68k/src/mmu/ttr.rs
@@ -113,6 +113,10 @@ pub fn check_transparent_translation(
 /// - 6: Supervisor Program (instruction)
 /// - 7: CPU Space (interrupt acknowledge, etc.)
 fn compute_function_code(cpu: &CpuCore, instruction: bool) -> u8 {
+    // A MOVES data access carries SFC/DFC instead of the CPU-state code.
+    if let Some(fc) = cpu.mmu_fc_override {
+        return fc;
+    }
     let is_supervisor = cpu.is_supervisor();
     match (is_supervisor, instruction) {
         (false, false) => 1, // User Data

--- a/crates/m68k/tests/bus_fault_frame_030_tests.rs
+++ b/crates/m68k/tests/bus_fault_frame_030_tests.rs
@@ -1,0 +1,450 @@
+//! 68030 bus-cycle fault frames (format $B), their RTE continuation
+//! protocol, and the 030 table-walk features mmu.library's lazy fault
+//! handling depends on: FCL function-code lookup, indirect descriptors at
+//! walk exhaustion, level-limited PTEST with the A bit, and PMOVE MMUSR.
+//!
+//! The RTE protocol under test is what real handlers use (mmu.library, VMM,
+//! MuGuardianAngel): a data fault pushes SSW.DF; the handler either fixes
+//! the mapping and RTEs (rerun), or clears DF and completes the data cycle
+//! itself -- supplying a faulted read's result in the frame's data input
+//! buffer, or absorbing a faulted write whose value it takes from the data
+//! output buffer. mmu.library emulates lazily-zeroed pages with the
+//! DF-cleared read path, which is how issue #90's 030 variant hangs without
+//! it.
+
+use m68k::core::cpu::CpuCore;
+use m68k::core::memory::AddressBus;
+use m68k::core::types::CpuType;
+use m68k::{NoOpHleHandler, StepResult};
+
+/// Simple test bus that stores memory in a vector.
+struct TestBus {
+    mem: Vec<u8>,
+}
+
+impl TestBus {
+    fn new(size: usize) -> Self {
+        Self { mem: vec![0; size] }
+    }
+
+    fn write_long(&mut self, addr: u32, val: u32) {
+        let addr = addr as usize;
+        if addr + 3 < self.mem.len() {
+            self.mem[addr] = (val >> 24) as u8;
+            self.mem[addr + 1] = (val >> 16) as u8;
+            self.mem[addr + 2] = (val >> 8) as u8;
+            self.mem[addr + 3] = val as u8;
+        }
+    }
+}
+
+impl AddressBus for TestBus {
+    fn read_byte(&mut self, addr: u32) -> u8 {
+        self.mem.get(addr as usize).copied().unwrap_or(0)
+    }
+
+    fn write_byte(&mut self, addr: u32, val: u8) {
+        if let Some(m) = self.mem.get_mut(addr as usize) {
+            *m = val;
+        }
+    }
+
+    fn read_word(&mut self, addr: u32) -> u16 {
+        let hi = self.read_byte(addr) as u16;
+        let lo = self.read_byte(addr + 1) as u16;
+        (hi << 8) | lo
+    }
+
+    fn write_word(&mut self, addr: u32, val: u16) {
+        self.write_byte(addr, (val >> 8) as u8);
+        self.write_byte(addr + 1, val as u8);
+    }
+
+    fn read_long(&mut self, addr: u32) -> u32 {
+        let hi = self.read_word(addr) as u32;
+        let lo = self.read_word(addr + 2) as u32;
+        (hi << 16) | lo
+    }
+
+    fn write_long(&mut self, addr: u32, val: u32) {
+        self.write_word(addr, (val >> 16) as u16);
+        self.write_word(addr + 2, val as u16);
+    }
+}
+
+const SSP: u32 = 0x1F00;
+const USP: u32 = 0x1800;
+const CODE: u32 = 0x0100;
+const HANDLER: u32 = 0x0300;
+const ROOT_TABLE: u32 = 0x8000;
+const B_TABLE: u32 = 0x8400;
+/// Logical test page: with TIA=8/TIB=9 (32K pages) this walks root index 0,
+/// B index 2, so its descriptor is the third B-table entry.
+const FAULT_PAGE: u32 = 0x0001_0000;
+const FAULT_DESC: u32 = B_TABLE + 8;
+
+/// Frame field offsets from the post-exception supervisor SP (M68030UM 8.2):
+/// format $B is 46 words with the SSW at +$0A, the data-cycle fault address
+/// at +$10, the data output buffer at +$18 and the data input buffer at +$2C.
+const FRAME_LEN: u32 = 0x5C;
+const F_PC: u32 = 0x02;
+const F_FMT: u32 = 0x06;
+const F_SSW: u32 = 0x0A;
+const F_FA: u32 = 0x10;
+const F_DOB: u32 = 0x18;
+const F_DIB: u32 = 0x2C;
+
+/// A 68030 in user mode with translation enabled through a two-level table
+/// (TC: E=1, IS=0, TIA=8, TIB=9 -> 32 KB pages). The first 64 KB (code,
+/// stack, vectors, the tables themselves) is identity-mapped through two
+/// page descriptors; FAULT_PAGE's descriptor holds `fault_desc`. Vector 2
+/// points at HANDLER, whose code the individual test writes.
+fn user_mode_030_with_table(bus: &mut TestBus, fault_desc: u32) -> CpuCore {
+    bus.write_long(ROOT_TABLE, B_TABLE | 2); // root[0] -> B table (short)
+    bus.write_long(B_TABLE, 0x0000_0001); // B[0]: identity page at 0
+    bus.write_long(B_TABLE + 4, 0x0000_8001); // B[1]: identity page at 0x8000
+    bus.write_long(FAULT_DESC, fault_desc); // B[2]: page under test
+
+    bus.write_long(8, HANDLER); // vector 2
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68030);
+    cpu.mmu_crp_limit = 0x8000_0002; // short (4-byte) root descriptors
+    cpu.mmu_crp_aptr = ROOT_TABLE;
+    cpu.mmu_tc = 0x80F0_8900; // E=1, PS=32K, IS=0, TIA=8, TIB=9
+    cpu.pmmu_enabled = true;
+
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, SSP);
+    cpu.set_sr(0x0000);
+    cpu.set_a(7, USP);
+    cpu.set_a(0, FAULT_PAGE);
+    cpu.pc = CODE;
+    cpu
+}
+
+fn frame_base(cpu: &CpuCore) -> u32 {
+    let sp = cpu.a(7);
+    assert_eq!(sp, SSP - FRAME_LEN, "format $B frame is 46 words");
+    sp
+}
+
+fn step_n(cpu: &mut CpuCore, bus: &mut TestBus, n: usize) {
+    let mut hle = NoOpHleHandler;
+    for _ in 0..n {
+        let r = cpu.step_with_hle_handler(bus, &mut hle);
+        assert!(
+            matches!(r, StepResult::Ok { .. }),
+            "unexpected step result {r:?} at pc={:#010X}",
+            cpu.pc
+        );
+    }
+}
+
+/// A user-mode data read through an invalid page descriptor pushes a format
+/// $B frame: vector 2, SSW = DF | RW | SIZ=long | FC=user data, the fault
+/// address in the data-cycle fault address long, and the rolled-back
+/// instruction's PC for the restart.
+#[test]
+fn translation_fault_pushes_resumable_format_b_frame() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_030_with_table(&mut bus, 0); // invalid
+
+    bus.write_word(CODE, 0x2010); // MOVE.L (A0),D0
+
+    let result = cpu.step(&mut bus);
+    assert!(matches!(result, StepResult::Ok { .. }));
+    assert!(cpu.is_supervisor(), "fault must enter supervisor mode");
+    assert_eq!(cpu.pc & 0xFFFF, HANDLER, "must vector through vector 2");
+
+    let f = frame_base(&cpu);
+    assert_eq!(bus.read_word(f + F_FMT), 0xB008, "format $B, vector 2");
+    assert_eq!(
+        bus.read_word(f + F_SSW),
+        0x0141,
+        "SSW = DF | RW=read | SIZ=long | FC=user data"
+    );
+    assert_eq!(bus.read_long(f + F_FA), FAULT_PAGE, "data fault address");
+    assert_eq!(bus.read_long(f + F_PC), CODE, "restart PC");
+}
+
+/// The fix-and-rerun path: the vector-2 handler materializes the page
+/// descriptor and RTEs with DF still set, and the restarted instruction
+/// completes against the new mapping.
+#[test]
+fn rte_with_df_set_restarts_the_faulted_access() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_030_with_table(&mut bus, 0);
+
+    bus.write_long(0x9000, 0xCAFE_F00D); // data in the to-be-mapped page
+    bus.write_word(CODE, 0x2010); // MOVE.L (A0),D0
+    bus.write_word(CODE + 2, 0x4E71); // NOP
+
+    // Handler materializes the page: FAULT_PAGE -> physical 0, so the
+    // restarted read of logical 0x10000 resolves to physical 0.
+    // MOVE.L #$00000001,(FAULT_DESC).L ; descriptor: page at 0, DT=1
+    bus.write_word(HANDLER, 0x23FC);
+    bus.write_long(HANDLER + 2, 0x0000_0001);
+    bus.write_long(HANDLER + 6, FAULT_DESC);
+    bus.write_word(HANDLER + 10, 0x4E73); // RTE
+
+    // Fault + handler (2 instructions) + rerun + NOP.
+    step_n(&mut cpu, &mut bus, 5);
+    assert!(!cpu.is_supervisor(), "back in user mode after RTE");
+    assert_eq!(cpu.pc & 0xFFFF, (CODE + 4) & 0xFFFF, "past the NOP");
+    // Logical 0x10000 now maps to physical 0: D0 = longword at 0 = SSP
+    // from the vector table image (0x1F00 was never written to the bus;
+    // vectors 0/4 are only read by reset. The test wrote vector 2 only,
+    // so physical 0 reads 0).
+    assert_eq!(cpu.d(0), bus.read_long(0), "read completed via new mapping");
+}
+
+/// The DF-cleared read path: the handler supplies the faulted read's result
+/// in the data input buffer, clears DF, and RTEs. The instruction completes
+/// with that value while the page stays invalid (mmu.library's lazily
+/// zero-filled pages).
+#[test]
+fn rte_with_df_cleared_supplies_the_data_input_buffer() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_030_with_table(&mut bus, 0);
+
+    bus.write_word(CODE, 0x2010); // MOVE.L (A0),D0
+    bus.write_word(CODE + 2, 0x4E71); // NOP
+
+    // Handler:
+    //   BCLR #0,($A,A7)                ; clear SSW bit 8 (DF)
+    //   MOVE.L #$CAFEBABE,($2C,A7)     ; data input buffer
+    //   RTE
+    bus.write_word(HANDLER, 0x08AF);
+    bus.write_word(HANDLER + 2, 0x0000);
+    bus.write_word(HANDLER + 4, F_SSW as u16);
+    bus.write_word(HANDLER + 6, 0x2F7C);
+    bus.write_long(HANDLER + 8, 0xCAFE_BABE);
+    bus.write_word(HANDLER + 12, F_DIB as u16);
+    bus.write_word(HANDLER + 14, 0x4E73); // RTE
+
+    // Fault + handler (3 instructions) + completed re-execution + NOP.
+    step_n(&mut cpu, &mut bus, 6);
+    assert!(!cpu.is_supervisor());
+    assert_eq!(cpu.d(0), 0xCAFE_BABE, "read completed from the DIB");
+    assert_eq!(
+        bus.read_long(FAULT_DESC),
+        0,
+        "page descriptor stays invalid"
+    );
+}
+
+/// The DF-cleared write path: a faulted write stacks its value in the data
+/// output buffer; a handler that clears DF absorbs the write, and the
+/// re-executed instruction does not redo (or re-fault) it.
+#[test]
+fn rte_with_df_cleared_absorbs_the_faulted_write() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_030_with_table(&mut bus, 0);
+
+    cpu.set_d(0, 0x1234_5678);
+    bus.write_word(CODE, 0x2080); // MOVE.L D0,(A0)
+    bus.write_word(CODE + 2, 0x4E71); // NOP
+
+    // Handler: assert-by-copy the DOB into D7, clear DF, RTE.
+    //   MOVE.L ($18,A7),D7
+    //   BCLR #0,($A,A7)
+    //   RTE
+    bus.write_word(HANDLER, 0x2E2F);
+    bus.write_word(HANDLER + 2, F_DOB as u16);
+    bus.write_word(HANDLER + 4, 0x08AF);
+    bus.write_word(HANDLER + 6, 0x0000);
+    bus.write_word(HANDLER + 8, F_SSW as u16);
+    bus.write_word(HANDLER + 10, 0x4E73); // RTE
+
+    // Check the frame SSW marks a write before running the handler.
+    let _ = cpu.step(&mut bus); // fault
+    let f = frame_base(&cpu);
+    assert_eq!(
+        bus.read_word(f + F_SSW),
+        0x0101,
+        "SSW = DF | RW=write | SIZ=long | FC=user data"
+    );
+    assert_eq!(
+        bus.read_long(f + F_DOB),
+        0x1234_5678,
+        "data output buffer holds the faulted write's value"
+    );
+
+    step_n(&mut cpu, &mut bus, 5); // handler (3) + suppressed rerun + NOP
+    assert!(!cpu.is_supervisor());
+    assert_eq!(cpu.d(7), 0x1234_5678, "handler saw the write data");
+    assert_eq!(cpu.pc & 0xFFFF, (CODE + 4) & 0xFFFF, "no re-fault loop");
+}
+
+/// A format $B frame RTE'd on a 68040 is a format error, as on real
+/// silicon: the frame formats are not portable across models.
+#[test]
+fn format_b_frame_is_a_format_error_on_the_040() {
+    let mut bus = TestBus::new(0x10000);
+    bus.write_long(14 * 4, 0x0500); // format error vector
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68040);
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, SSP - FRAME_LEN);
+    // Hand-built minimal format $B frame: SR, PC, format/vector.
+    bus.write_word(SSP - FRAME_LEN, 0x0000);
+    bus.write_long(SSP - FRAME_LEN + F_PC, CODE);
+    bus.write_word(SSP - FRAME_LEN + F_FMT, 0xB008);
+    bus.write_word(CODE, 0x4E73); // RTE
+    cpu.pc = CODE;
+
+    let _ = cpu.step(&mut bus);
+    assert_eq!(cpu.pc, 0x0500, "format error handler entered");
+}
+
+/// FCL walks index the root table by function code: with the user-data
+/// entry remapped and the supervisor entries identity, the same logical
+/// address reads differently through MOVES with SFC=1 -- exactly
+/// mmu.library's 030 MMU-presence probe.
+#[test]
+fn fcl_walk_indexes_the_root_table_by_function_code() {
+    let mut bus = TestBus::new(0x10000);
+
+    // FC-indexed root of early-termination descriptors: supervisor data
+    // and program (5, 6) identity, user data (1) remapped to 0x4000.
+    bus.write_long(ROOT_TABLE + 5 * 4, 0x0000_0059);
+    bus.write_long(ROOT_TABLE + 6 * 4, 0x0000_0059);
+    bus.write_long(ROOT_TABLE + 4, 0x0000_4059);
+
+    bus.write_long(0x2000, 0x1111_2222); // identity view of 0x2000
+    bus.write_long(0x6000, 0x3333_4444); // user-data view (0x4000 + 0x2000)
+
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(CpuType::M68030);
+    cpu.mmu_crp_limit = 0x8000_0002;
+    cpu.mmu_crp_aptr = ROOT_TABLE;
+    cpu.mmu_tc = 0x81F0_9800; // E=1, FCL=1, PS=32K, TIA=9, TIB=8 (as mmu.library programs it)
+    cpu.pmmu_enabled = true;
+    cpu.sfc = 1;
+
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, SSP);
+    cpu.set_a(0, 0x2000);
+
+    // MOVE.L (A0),D0 : supervisor data space, identity.
+    bus.write_word(CODE, 0x2010);
+    // MOVES.L (A0),D1 : SFC=1, user data space, remapped.
+    bus.write_word(CODE + 2, 0x0E90);
+    bus.write_word(CODE + 4, 0x1000);
+    cpu.pc = CODE;
+
+    step_n(&mut cpu, &mut bus, 2);
+    assert_eq!(cpu.d(0), 0x1111_2222, "supervisor read is identity");
+    assert_eq!(cpu.d(1), 0x3333_4444, "MOVES read translates in SFC space");
+}
+
+/// A DT=2 pointer where the configured levels are exhausted is an indirect
+/// descriptor: the walk follows it to the real page descriptor. Its address
+/// field reaches bit 2, so a set bit 2 is address, not write-protect.
+#[test]
+fn exhausted_walk_follows_indirect_descriptors() {
+    let mut bus = TestBus::new(0x10000);
+    // Indirect descriptor at B[1] -> shared descriptor at 0x9004 (bit 2
+    // set in the pointer on purpose) -> resident page at 0.
+    let mut cpu = user_mode_030_with_table(&mut bus, 0x9004 | 2);
+    bus.write_long(0x9004, 0x0000_0001);
+    bus.write_long(0x0ABC, 0xFEED_FACE);
+
+    cpu.set_a(0, FAULT_PAGE + 0x0ABC);
+    bus.write_word(CODE, 0x2010); // MOVE.L (A0),D0
+
+    step_n(&mut cpu, &mut bus, 1);
+    assert!(
+        !cpu.is_supervisor(),
+        "resident indirect target must not fault"
+    );
+    assert_eq!(cpu.d(0), 0xFEED_FACE, "translated through the indirection");
+
+    // A write through the same mapping is not write-protected: the
+    // indirect descriptor's bit 2 is part of its address field.
+    cpu.set_d(2, 0xD00D_D00D);
+    bus.write_word(cpu.pc as u16 as u32, 0x2082); // MOVE.L D2,(A0)
+    step_n(&mut cpu, &mut bus, 1);
+    assert!(!cpu.is_supervisor(), "write must not take a WP fault");
+    assert_eq!(bus.read_long(0x0ABC), 0xD00D_D00D);
+}
+
+/// PTEST walks in the extension word's function-code space, reports the
+/// invalid translation in MMUSR (I + level count, readable through PMOVE
+/// PSR), and with the A bit hands back the address of the last descriptor
+/// examined -- for an exhausted-walk indirection that is the shared target
+/// slot mmu.library materializes.
+#[test]
+fn ptest_reports_mmusr_and_locates_the_descriptor() {
+    let mut bus = TestBus::new(0x10000);
+    // B[1] indirect -> poisoned shared descriptor (mmu.library's tag).
+    let mut cpu = user_mode_030_with_table(&mut bus, 0x9000 | 2);
+    bus.write_long(0x9000, 0xBADF_EED0);
+
+    // Supervisor: DFC=1, PTESTR #1... use SFC form like mmu.library:
+    // MOVEC D0,SFC with D0=1; PTESTR SFC,(A0),#7; PMOVE PSR,(A7); then
+    // PTESTR SFC,(A0),#2,A1 (level-limited, A bit).
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, SSP);
+    cpu.set_a(0, FAULT_PAGE);
+    cpu.set_d(0, 1);
+    let mut p = CODE;
+    bus.write_word(p, 0x4E7B); // MOVEC D0,SFC
+    bus.write_word(p + 2, 0x0000);
+    p += 4;
+    bus.write_word(p, 0xF010); // PTESTR SFC,(A0),#7
+    bus.write_word(p + 2, 0x9E00);
+    p += 4;
+    bus.write_word(p, 0xF017); // PMOVE PSR,(A7)
+    bus.write_word(p + 2, 0x6200);
+    p += 4;
+    bus.write_word(p, 0xF010); // PTESTR SFC,(A0),#2,A1
+    bus.write_word(p + 2, 0x8B20);
+    p += 4;
+    bus.write_word(p, 0x4E71); // NOP
+    cpu.pc = CODE;
+
+    step_n(&mut cpu, &mut bus, 4);
+    assert_eq!(
+        cpu.mmu_sr & 0xFFFF,
+        0x0402,
+        "MMUSR = I | N=2 (indirection resolves within level 2)"
+    );
+    assert_eq!(
+        bus.read_word(SSP),
+        0x0402,
+        "PMOVE PSR wrote MMUSR to memory"
+    );
+    assert_eq!(
+        cpu.a(1),
+        0x9000,
+        "A bit returns the indirect target slot to materialize"
+    );
+}
+
+/// PTEST reports accumulated write-protect on the walked path in MMUSR W,
+/// for read tests too (a handler classifies write faults with it).
+#[test]
+fn ptest_reports_write_protect_on_read_walks() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_030_with_table(&mut bus, 0x0000_0005); // DT=1 | WP
+
+    cpu.set_sr(0x2700);
+    cpu.set_a(7, SSP);
+    cpu.set_a(0, FAULT_PAGE);
+    cpu.set_d(0, 1);
+    bus.write_word(CODE, 0x4E7B); // MOVEC D0,SFC
+    bus.write_word(CODE + 2, 0x0000);
+    bus.write_word(CODE + 4, 0xF010); // PTESTR SFC,(A0),#7
+    bus.write_word(CODE + 6, 0x9E00);
+    cpu.pc = CODE;
+
+    step_n(&mut cpu, &mut bus, 2);
+    assert_eq!(
+        cpu.mmu_sr & 0xFFFF,
+        0x0802,
+        "MMUSR = W | N=2 for a resident write-protected page"
+    );
+}

--- a/crates/m68k/tests/mmu_translate_tests.rs
+++ b/crates/m68k/tests/mmu_translate_tests.rs
@@ -248,6 +248,9 @@ fn ptest_040_reports_resident_and_physical_in_mmusr() {
     cpu.set_sr(0x2700);
     cpu.write_control_register(0x807, root);
     cpu.write_control_register(0x003, 0x0000_8000);
+    // PTEST probes the address space named by DFC: supervisor data here
+    // (the table is on SRP).
+    cpu.write_control_register(0x001, 5);
 
     let mut hle = m68k::NoOpHleHandler;
 

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -233,19 +233,26 @@ diverge.
 The 68030, 68040, and 68060 model the on-chip MMU (`has_pmmu`), so software that sets up
 and enables address translation runs rather than having its MMU writes ignored.
 The two parts differ enough to need separate walkers: the 68030 uses its
-programmable table walk (CRP/SRP selection, the TC index fields, 4-/8-byte
-descriptor modes, early-termination descriptors), while the 68040 has a
-fixed-format three-level walk (root -> pointer -> page, 4 KB or 8 KB pages,
-URP/SRP split by supervisor) keyed off its own TC layout. Both share the
-transparent translation registers (TTRs: the 030's TT0/1, the 040's ITT0/1 +
-DTT0/1), which short-circuit the walk for a matching address range.
+programmable table walk (CRP/SRP selection, the optional function-code lookup
+level (TC FCL), the TC index fields TIA-TID, 4-/8-byte descriptor modes,
+early-termination descriptors, indirect descriptors when the configured
+levels are exhausted, and the long-format supervisor-only bit), while the
+68040 has a fixed-format three-level walk (root -> pointer -> page, 4 KB or
+8 KB pages, URP/SRP split by supervisor) keyed off its own TC layout. Both
+share the transparent translation registers (TTRs: the 030's TT0/1, the
+040's ITT0/1 + DTT0/1), which short-circuit the walk for a matching address
+range. Accesses carry their function code into the walk: `MOVES` translates
+in the SFC/DFC space (mmu.library's 030 MMU-detection probe remaps the
+user-data space and reads it back with `MOVES` from supervisor mode), and
+`PTEST`/`PLPA` probe the DFC space.
 
 One register set (`mmu_*` in `CpuCore`) is canonical for both paths, so the 030
 `PMOVE` writes, the 040 `MOVEC` writes, and the walker can never desync (the 040
 root pointers overload the CRP/SRP address slots, dispatched by `cpu_type`). The
 enable bit differs by part -- TC[31] on the 030, TC[15] on the 040 -- via
-`tc_enable()`. `PMOVE`/`MOVEC` load the registers and `PTEST`/`PLOAD`/`PFLUSH`
-are accepted as no-ops rather than trapping.
+`tc_enable()`. `PMOVE`/`MOVEC` load the registers (including the 030 MMUSR
+via `PMOVE PSR`); `PLOAD`/`PFLUSH` are accepted as no-ops on the 030 walk
+(which has no ATC to flush).
 
 A 68040 table walk costs three descriptor fetches, far too much to pay on every
 access, so the 040 walker is fronted by an address-translation cache
@@ -282,11 +289,26 @@ re-translate (and a fault while delivering a fault is a clean double-fault halt)
 
 `PTEST` (68040) walks the addressed page and reports the physical address and
 resident bit in MMUSR (the cache-mode/used/modified attribute bits are not yet
-filled in). The 68030 also enforces the descriptor write-protect (WP) bit, and
-its faults are routed to the bus-error vector like the 040's, though the 68030
-long bus-fault stack frame (format A/B) is still the minimal fallback rather than
-a fully resumable frame. Remaining: the indirect/used/modified MMUSR bits and
-the resumable 030 frame.
+filled in). The 68030 `PTEST` performs a real level-limited walk in the
+extension word's function-code space and composes the 16-bit MMUSR (B, S, W
+-- reported for read tests too -- I, T, and the level count N); with the A
+bit it hands back the physical address of the last descriptor examined,
+which is how mmu.library's fault handler locates the shared descriptor slot
+to materialize.
+
+68030 faults push the long bus-cycle fault frame (format $B, 46 words):
+SSW (DF/RW/SIZ/FC for data faults, FB|RB with the stage B address for
+instruction faults), the data-cycle fault address, and -- for write faults
+-- the write's value in the data output buffer. `RTE` supports both
+continuation protocols on top of the rollback/restart core: a handler that
+fixed the mapping RTEs with DF set and the instruction restarts; a handler
+that *completed* the data cycle itself clears DF, supplying a faulted
+read's result in the data input buffer (mmu.library emulates lazily-zeroed
+pages this way) or absorbing a faulted write, honoured as a one-shot
+substitution on the re-executed instruction's matching access. Remaining:
+the used/modified/limit MMUSR bits and descriptor write-back, CRP limit
+checks, and the DT=1 page-descriptor root; the 030 walk has no ATC, so
+every access re-walks the tables.
 
 ## Interrupts and STOP
 

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -67,7 +67,11 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      emulate_unimplemented_060, and the Oep060Timing pairing/branch-cache
 //      state; MmuFault gained a cause (transient, but part of CpuCore's
 //      serde shape indirectly via new fields)
-pub const STATE_VERSION: u32 = 13;
+//  14: 68030 resumable bus-fault frames - CpuCore gained mmu_read_override
+//      and mmu_write_suppress (the RTE DF-cleared completion protocol,
+//      pending across one instruction boundary) and pending_fault_wdata
+//      (the frame's data output buffer)
+pub const STATE_VERSION: u32 = 14;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
The 68030 half of #90: with #91 and #93 merged, a 68030 config with the MMU libraries first reported "No MMU available" and, once detection was fixed, hung forever re-faulting the same access during mmu.library init. This PR makes the same KS3.1 + Aminet-MMULib harness pass on the 030 exactly as #93 did for the 040.

## What mmu.library actually needs (traced against the emulated core)

1. **MMU detection**: builds a function-code-indexed root table (TC FCL=1) remapping the *user-data* space to ROM, then reads through it with `MOVES` (SFC=1) from supervisor mode and compares. Our walker ignored FCL and `MOVES` translated in the CPU-state space, so detection read identity and concluded "No MMU".
2. **Lazy tables**: its user trees end in indirect descriptors (DT=2 at walk exhaustion) whose shared targets are poisoned with `0xBADFEED0`.
3. **Fault classification**: its vector-2 handler parses the format $B frame (SSW DF/RW/SIZ/FC, fault address at +$10), sets SFC from the SSW's FC bits, PTESTs the fault address to classify (MMUSR B/W/I), then locates the descriptor slot with a level-limited `PTEST ...,#n,A0` (A-bit). Our 030 PTEST was a NOP and `PMOVE PSR` didn't decode: the handler F-lined.
4. **The continuation protocol**: for lazily-zeroed pages it never maps anything -- it clears the SSW DF bit, supplies the read result through the frame's data input buffer (+$2C), and RTEs. Real silicon then completes the instruction with that value instead of rerunning the cycle. Our restart-model RTE re-executed the read, same fault, forever.

## Implementation

- 030 walk rewritten as a shared level loop: FCL level, TIA-TID, early termination at any level, indirect descriptors at exhaustion (the target fetch belongs to the same level and carries no protection bits -- its address field reaches bit 2), WP accumulation, long-format S bit. No allocation on the per-access path (the 030 walk has no ATC).
- `MOVES` data cycles translate under SFC/DFC; 040 `PTEST` and 060 `PLPA` probe the DFC space; a MOVES fault stacks its SFC/DFC in the frame SSW.
- Real 030 `PTEST` (level limit, fc field incl. SFC/DFC/Dn/immediate, A-bit descriptor address) + MMUSR composition (B/S/W/I/T/N, W reported on read tests too) + `PMOVE PSR` both directions.
- Format $B frame (46 words) from the 020/030 arm of `exception_bus_error`: SSW, fault address, and the faulted write's value in the data output buffer. `RTE` accepts formats $A/$B and honours DF-cleared completion on top of the rollback/restart core via a one-shot read-substitution / write-suppression on the re-executed access (documented limitation: a DF-clear cannot skip a *hardware-register* side effect the way mid-instruction continuation can, since the instruction restarts; for memory it is exact).
- `STATE_VERSION` 13 -> 14 (`CpuCore` gained the two continuation fields and the DOB capture).

## Verification

- **End-to-end 030**: A1200/68030/KS3.1 + MMULib boot floppy: `68030 MMU detected`, mmu.library builds and enables its 1K-page CRP/SRP tree (`TC=0x82A08680`), lazy faults are serviced through the new frame (including the DF-cleared zero-fill path), MuScan prints the full live memory map, all startup markers pass.
- **End-to-end 040**: unchanged, same harness still passes (`68040 MMU detected`).
- **New suite** `crates/m68k/tests/bus_fault_frame_030_tests.rs` (9 tests): frame layout/SSW/FA/DOB, fix-and-rerun RTE, DF-cleared read completion, DF-cleared write absorption, format-error on the 040, the FCL+MOVES probe shape, indirect descriptors (resident and poisoned), PTEST MMUSR + A-bit slot location, W-on-read reporting.
- All 41 asset-free m68k suites, the root suite (1265), clippy (`-D warnings`) and fmt pass; stock A500/KS1.3 boot sanity-checked for the hot-path changes.

Remaining 030 gaps (documented in docs/internals/cpu.md): MMUSR used/modified/limit bits and descriptor write-back, CRP limit checks, DT=1 page-descriptor root, and the ATC-less walk cost.