### PR TITLE
m68k: 68040 write faults carry writeback 2 and RTE honours its absorb

### DIFF
--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -910,11 +910,31 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                                     return 20;
                                 }
                                 7 if cpu.is_040() => {
-                                    // 68040 access-error frame (30 words):
-                                    // discard EA/SSW/writeback state. The
-                                    // faulting instruction was rolled back at
-                                    // frame-build time, so a plain restart is
-                                    // the whole continuation.
+                                    // 68040 access-error frame (30 words).
+                                    // The faulting instruction was rolled
+                                    // back at frame-build time, so a plain
+                                    // restart is the whole continuation --
+                                    // except the writeback protocol: a
+                                    // faulted write was pushed in slot 2,
+                                    // and a handler that cleared WB2S.V
+                                    // absorbed it (Enforcer/MuForce hits on
+                                    // protected pages), so the restarted
+                                    // instruction's matching write is
+                                    // discarded. A handler that completes
+                                    // the writeback manually but leaves V
+                                    // set gets the restart's write instead
+                                    // (double store to plain memory, the
+                                    // documented restart-model gap).
+                                    let sp = cpu.a(7);
+                                    let ssw = cpu.read_16(bus, sp.wrapping_add(0x0C));
+                                    let write_fault = ssw & 0x0100 == 0 && ssw & 0x0400 != 0;
+                                    if write_fault {
+                                        let wb2s = cpu.read_16(bus, sp.wrapping_add(0x10));
+                                        if wb2s & 0x0080 == 0 {
+                                            let wb2a = cpu.read_32(bus, sp.wrapping_add(0x20));
+                                            cpu.mmu_write_suppress = Some(wb2a);
+                                        }
+                                    }
                                     let sr = cpu.pull_16(bus);
                                     cpu.pc = cpu.pull_32(bus);
                                     let _ = cpu.pull_16(bus); // format word

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -454,19 +454,30 @@ impl CpuCore {
                 };
                 let ssw = rw | atc | sz | (fc as u16 & 0x7); // TM = function code
                 let fmt_vec = 0x7000 | ((vector::BUS_ERROR as u16) << 2);
-                // PD2/PD1/PD0 and the three writeback entries are all unused.
+                // A faulted write is reported in writeback slot 2 (V bit,
+                // size and TM in WB2S; address and data in WB2A/WB2D). The
+                // handler either completes it manually or clears WB2S.V to
+                // absorb it -- how Enforcer/MuForce discard stores into
+                // protected pages -- and RTE (below) honours the cleared V.
+                // WB1 and WB3 (later/earlier pipeline stages) never carry
+                // anything in this core.
+                let wb2s = if write {
+                    0x0080 | sz | (fc as u16 & 0x7) // V | SZ | TM
+                } else {
+                    0
+                };
                 for _ in 0..3 {
-                    self.push_32_raw(bus, 0); // PD2, PD1, PD0
+                    self.push_32_raw(bus, 0); // PD3, PD2, PD1
                 }
-                self.push_32_raw(bus, 0); // WB1D
+                self.push_32_raw(bus, 0); // WB1D / PD0
                 self.push_32_raw(bus, 0); // WB1A
-                self.push_32_raw(bus, 0); // WB2D
-                self.push_32_raw(bus, 0); // WB2A
+                self.push_32_raw(bus, if write { self.pending_fault_wdata } else { 0 }); // WB2D
+                self.push_32_raw(bus, if write { address } else { 0 }); // WB2A
                 self.push_32_raw(bus, 0); // WB3D
                 self.push_32_raw(bus, 0); // WB3A
                 self.push_32_raw(bus, address); // fault address
-                self.push_16_raw(bus, 0); // WB1S (status: invalid -> no writeback)
-                self.push_16_raw(bus, 0); // WB2S
+                self.push_16_raw(bus, 0); // WB1S
+                self.push_16_raw(bus, wb2s); // WB2S
                 self.push_16_raw(bus, 0); // WB3S
                 self.push_16_raw(bus, ssw); // special status word
                 self.push_32_raw(bus, address); // effective address

--- a/crates/m68k/tests/access_fault_frame_tests.rs
+++ b/crates/m68k/tests/access_fault_frame_tests.rs
@@ -12,7 +12,7 @@
 use m68k::core::cpu::CpuCore;
 use m68k::core::memory::{AddressBus, BusFault, BusFaultKind};
 use m68k::core::types::CpuType;
-use m68k::StepResult;
+use m68k::{NoOpHleHandler, StepResult};
 
 /// Simple test bus that stores memory in a vector.
 struct TestBus {
@@ -121,15 +121,19 @@ const PAGE_TABLE: u32 = 0x8400;
 const FAULT_PAGE: u32 = 0x5000;
 
 /// A 68040 in user mode with translation enabled through a three-level user
-/// table. Every entry is invalid except the FAULT_PAGE page-table slot,
-/// which holds `page_desc`. Code/stack pages walk into invalid descriptors
-/// and use the instruction-fetch identity fallback; the exception frame
-/// itself is pushed with translation bypassed (exception_processing), so
-/// only explicit data accesses exercise the walker.
+/// table. The stack/vector page, the code page, and the table page are
+/// identity-mapped (so fault handlers can run with translation on); the
+/// FAULT_PAGE page-table slot holds `page_desc`; everything else is
+/// invalid. Instruction fetches through invalid descriptors use the
+/// identity fallback, and the exception frame itself is pushed with
+/// translation bypassed (exception_processing).
 fn user_mode_040_with_table(bus: &mut TestBus, page_desc: u32) -> CpuCore {
     // Root and pointer table entries: UDT resident (bits 1:0 >= 2).
     bus.write_long(ROOT_TABLE, PTR_TABLE | 2);
     bus.write_long(PTR_TABLE, PAGE_TABLE | 2);
+    bus.write_long(PAGE_TABLE, 0x0000_0001); // page 0: vectors, code
+    bus.write_long(PAGE_TABLE + 4, 0x0000_1001); // page 1: stacks
+    bus.write_long(PAGE_TABLE + 8 * 4, 0x0000_8001); // page 8: the tables
     bus.write_long(PAGE_TABLE + (FAULT_PAGE >> 12) * 4, page_desc);
 
     // Vector 2 (bus error) -> HANDLER, which is a bare RTE.
@@ -160,12 +164,27 @@ const F_PC: u32 = 0x02;
 const F_FMT: u32 = 0x06;
 const F_EA: u32 = 0x08;
 const F_SSW: u32 = 0x0C;
+const F_WB2S: u32 = 0x10;
 const F_FA: u32 = 0x14;
+const F_WB2A: u32 = 0x20;
+const F_WB2D: u32 = 0x24;
 
 fn frame_base(cpu: &CpuCore) -> u32 {
     let sp = cpu.a(7);
     assert_eq!(sp, SSP - FRAME_LEN, "format $7 frame is 30 words");
     sp
+}
+
+fn step_n(cpu: &mut CpuCore, bus: &mut TestBus, n: usize) {
+    let mut hle = NoOpHleHandler;
+    for _ in 0..n {
+        let r = cpu.step_with_hle_handler(bus, &mut hle);
+        assert!(
+            matches!(r, StepResult::Ok { .. }),
+            "unexpected step result {r:?} at pc={:#010X}",
+            cpu.pc
+        );
+    }
 }
 
 /// A user-mode data read through an invalid page descriptor pushes a format
@@ -196,6 +215,86 @@ fn translation_fault_frame_reports_atc_read_long() {
     assert_eq!(bus.read_long(f + F_EA), FAULT_PAGE, "effective address");
     assert_eq!(bus.read_long(f + F_PC), CODE, "restart PC");
     assert_eq!(bus.read_word(f + F_SR) & 0x2000, 0, "stacked SR is user");
+    assert_eq!(
+        bus.read_word(f + F_WB2S),
+        0,
+        "no writeback for a read fault"
+    );
+}
+
+/// A faulted write is reported in writeback slot 2: WB2S carries the valid
+/// bit, size, and transfer modifier, with the address and data in
+/// WB2A/WB2D. This is the frame contract Enforcer/MuForce use to report a
+/// hit's data and absorb the store.
+#[test]
+fn write_fault_frame_carries_writeback_2() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_040_with_table(&mut bus, 0);
+
+    cpu.set_d(0, 0x1234_5678);
+    bus.write_word(CODE, 0x2080); // MOVE.L D0,(A0)
+
+    let _ = cpu.step(&mut bus);
+    let f = frame_base(&cpu);
+    assert_eq!(bus.read_word(f + F_SSW), 0x0401, "SSW = ATC | write | long");
+    assert_eq!(
+        bus.read_word(f + F_WB2S),
+        0x0081,
+        "WB2S = V | SZ=long | TM=user data"
+    );
+    assert_eq!(bus.read_long(f + F_WB2A), FAULT_PAGE, "writeback address");
+    assert_eq!(bus.read_long(f + F_WB2D), 0x1234_5678, "writeback data");
+}
+
+/// A handler that clears WB2S.V has absorbed the faulted write (an
+/// Enforcer/MuForce hit on a protected page): the restarted instruction
+/// continues past the store without re-faulting, and the page stays
+/// invalid.
+#[test]
+fn rte_with_wb2s_cleared_absorbs_the_faulted_write() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_040_with_table(&mut bus, 0);
+
+    cpu.set_d(0, 0x1234_5678);
+    bus.write_word(CODE, 0x2080); // MOVE.L D0,(A0)
+    bus.write_word(CODE + 2, 0x4E71); // NOP
+
+    // Handler: CLR.B ($11,A7) (WB2S low byte, V included); RTE.
+    bus.write_word(HANDLER, 0x422F);
+    bus.write_word(HANDLER + 2, (F_WB2S + 1) as u16);
+    bus.write_word(HANDLER + 4, 0x4E73);
+
+    // Fault + handler (2) + suppressed rerun + NOP.
+    step_n(&mut cpu, &mut bus, 5);
+    assert!(!cpu.is_supervisor(), "no re-fault loop");
+    assert_eq!(cpu.pc & 0xFFFF, (CODE + 4) & 0xFFFF, "past the NOP");
+}
+
+/// A handler that fixes the mapping and leaves WB2S.V set gets the plain
+/// restart: the re-executed store lands through the new translation.
+#[test]
+fn rte_with_wb2s_valid_restarts_the_write() {
+    let mut bus = TestBus::new(0x10000);
+    let mut cpu = user_mode_040_with_table(&mut bus, 0);
+
+    cpu.set_d(0, 0x1234_5678);
+    bus.write_word(CODE, 0x2080); // MOVE.L D0,(A0)
+    bus.write_word(CODE + 2, 0x4E71); // NOP
+
+    // Handler: materialize the page (FAULT_PAGE -> physical 0x6000), RTE.
+    // MOVE.L #$00006001,(page table slot).L
+    bus.write_word(HANDLER, 0x23FC);
+    bus.write_long(HANDLER + 2, 0x0000_6001);
+    bus.write_long(HANDLER + 6, PAGE_TABLE + (FAULT_PAGE >> 12) * 4);
+    bus.write_word(HANDLER + 10, 0x4E73);
+
+    step_n(&mut cpu, &mut bus, 5);
+    assert!(!cpu.is_supervisor());
+    assert_eq!(
+        bus.read_long(0x6000),
+        0x1234_5678,
+        "restarted write landed via the new mapping"
+    );
 }
 
 /// SSW size field follows the 68040 encoding: byte=01, word=10, long=00

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -275,8 +275,14 @@ transfer modifier (function code), and -- for faults that came out of the
 table walk rather than the physical bus -- the ATC bit; that bit is how an
 OS-level page-fault handler (mmu.library, VMM, Enforcer) tells a translation
 fault it must service from a real bus error it must pass on, and mmu.library's
-lazily-materialized user tables guru without it (issue #90). The frame's
-writeback/continuation fields are left clear (full-restart model);
+lazily-materialized user tables guru without it (issue #90). A faulted write
+is reported in writeback slot 2 (WB2S valid bit, size and transfer modifier,
+address and data in WB2A/WB2D): a handler that clears WB2S.V has absorbed
+the store -- how Enforcer/MuForce discard writes into protected pages -- and
+RTE honours that by discarding the restarted instruction's matching write. A
+handler that completes the writeback manually but leaves V set gets the
+restart's store instead (a double store to plain memory, the restart-model
+gap). The other writeback slots and continuation fields stay clear;
 mid-instruction continuation is not modelled.
 
 A *data* access through an invalid/unconfigured descriptor raises an access


### PR DESCRIPTION
Fixes the MuForce hang codewiz reported in the #91 thread ("my Lawbreaker test program hangs instead of throwing MuForce hits") -- the last known MMU issue from #90's fallout.

## Root cause

MuForce's 68040 hit handler absorbs a store into a protected page by clearing the frame's writeback-status valid bits and RTEing: on real silicon the faulted write sits in **writeback slot 2**, clearing `WB2S.V` discards it, and the instruction continues past the store. Traced against the emulated core, the handler classifies our ATC write fault correctly, clears the (already-zero) WB2S/WB3S bytes, RTEs -- and our restart-model RTE re-runs the write, which re-faults, forever.

## Fix

- The 040 access-error frame reports a faulted write in writeback slot 2: `WB2S = V | SZ | TM`, address in WB2A, data in WB2D (captured the same way the 030 frame's data output buffer is).
- RTE from a format $7 write-fault frame checks WB2S: **V cleared** = the handler absorbed the store, honoured as a one-shot suppression of the restarted instruction's matching write (the same mechanism the 030's DF-clear protocol uses since #94); **V left set** = plain restart, so fix-the-mapping handlers behave exactly as before.
- Documented gap: a handler that completes the writeback manually *and* leaves V set double-stores to plain memory (restart model).

## Verification

MuForce + a lawbreaker program (reads of $0/$30, write to $40) on the KS3.1 + MMULib harness, both CPUs:

- **68040**: all three hits print full MuForce reports -- `LONG READ from 00000000`, `LONG WRITE to 00000040 data=00000000`, `LONG READ from 00000030`, each with PC, hunk+offset ("DF1:lawbreaker Hunk 0000 Offset ..."), register and stack dumps -- and the program survives to the next shell prompt. Before: hard hang at the first write hit.
- **68030**: same lawbreaker survives with hits reported (the DF-clear path from #94), MuForce QUIT unloads cleanly.
- MuScan still passes on both CPUs; 43 m68k suites, the root suite (1265), clippy and fmt green.
- New regression tests in `access_fault_frame_tests.rs`: the WB2 frame contract (V/SZ/TM/address/data), absorb-on-V-clear continues past the store, restart-on-V-set lands the write through a newly built mapping, and WB2S stays clear for read faults.

No state-shape change (reuses the v14 fields from #94).

With this, the whole #90 constellation is covered: init crash (#93), 030 support (#94), and the MuForce/Enforcer hit protocol (this PR). Suggest asking @codewiz to re-run Lawbreaker on his OS 3.2 setup once merged.