### PR TITLE
m68k: cputest cycle-count validation + 68000 timing fixes

### DIFF
--- a/crates/cputest-runner/src/main.rs
+++ b/crates/cputest-runner/src/main.rs
@@ -231,6 +231,7 @@ extern "C" fn run_one_test(_user: *mut c_void, ctx: *const Context, regs: *mut R
     let debug = std::env::var("CPUTEST_DEBUG").is_ok();
     let mut hle = NoOpHleHandler;
     cpu.last_exception_vector = None;
+    regs.cycles = 0;
     let mut exc = 0u32;
     let mut excframe = 0u32;
     for step in 0..MAX_STEPS {
@@ -248,8 +249,24 @@ extern "C" fn run_one_test(_user: *mut c_void, ctx: *const Context, regs: *mut R
                 &cpu.dar[..8]
             );
         }
-        let _ = cpu.step_with_hle_handler(&mut bus, &mut hle);
+        let step_result = cpu.step_with_hle_handler(&mut bus, &mut hle);
+        let step_cycles = match step_result {
+            m68k::StepResult::Ok { cycles } => cycles as u32,
+            _ => 0,
+        };
+        let _ = step;
         if let Some(v) = cpu.last_exception_vector.take() {
+            // The generator's cycle counter stops when the terminating
+            // sentinel exception is recognized, so the final faulting step
+            // is not added to the measured total (CPUTEST_CYCLES). A trace
+            // is the one exception the core bundles with a COMPLETED
+            // instruction's step: count that instruction, not the 34-clock
+            // trace stacking.
+            if v == 9 {
+                regs.cycles = regs
+                    .cycles
+                    .wrapping_add(step_cycles.saturating_sub(34));
+            }
             exc = v;
             excframe = cpu.a(7);
             if debug {
@@ -257,6 +274,7 @@ extern "C" fn run_one_test(_user: *mut c_void, ctx: *const Context, regs: *mut R
             }
             break;
         }
+        regs.cycles = regs.cycles.wrapping_add(step_cycles);
         // If the tested instruction left T1 set (e.g. RTE restoring a traced
         // SR), the trace fires after the NEXT instruction: keep stepping so
         // the sentinel at endpc executes and raises the expected trace (or
@@ -266,6 +284,13 @@ extern "C" fn run_one_test(_user: *mut c_void, ctx: *const Context, regs: *mut R
             && (cpu.pc == regs.endpc
                 || (regs.branchtarget != 0xFFFF_FFFF && cpu.pc == regs.branchtarget))
         {
+            // A taken branch stops on ARRIVAL at the target sentinel; the
+            // generator's cycle counter also includes the target's leading
+            // NOP (the linear path executes its trailing NOP before the
+            // stop, so only this side needs the correction).
+            if cpu.pc != regs.endpc && bus.read_word(cpu.pc) == 0x4E71 {
+                regs.cycles = regs.cycles.wrapping_add(4);
+            }
             break;
         }
     }

--- a/crates/cputest-runner/vendor/m68k_cpu_tester.c
+++ b/crates/cputest-runner/vendor/m68k_cpu_tester.c
@@ -1475,6 +1475,22 @@ static uae_u8* validate_test(uae_u8* p, int ignore_errors, int ignore_sr) {
             int size;
             p = restore_value(p, &val, &size);
             last_registers.cycles = val;
+            /* Local patch: opt-in cycle-count validation (CPUTEST_CYCLES=1).
+             * The callback reports its measured count in test_regs.cycles;
+             * the data records the generator's cycle-exact count (68000/010
+             * sets only, CPU-clock units). */
+            /* test_regs.cycles == 0 means the callback measured nothing
+             * for this record (round seed / skipped round): no instruction
+             * costs zero cycles, so skip rather than false-positive. */
+            if (getenv("CPUTEST_CYCLES") && test_regs.cycles != 0 && test_regs.cycles != last_registers.cycles) {
+                addinfo();
+                if (dooutput) {
+                    sprintf(outbp, "Cycles: expected %u but got %u\n",
+                            last_registers.cycles, test_regs.cycles);
+                    outbp += strlen(outbp);
+                }
+                errors++;
+            }
         } else {
             end_test();
             printf("Unknown test data %02x mode %d\n", v, mode);

--- a/crates/m68k/CYCLE_TIMING_GAP.md
+++ b/crates/m68k/CYCLE_TIMING_GAP.md
@@ -299,3 +299,18 @@ the old reconciliation).
   (candidates: interrupt entry/IACK modelling, E-clock CIA access cost,
   per-PC access profiling needed). Closing it is the most likely path to
   eliminating the residual stale repeats.
+
+## WinUAE cputest cycle validation (2026-07-03)
+
+`crates/cputest-runner` now validates cycle counts against the cputest
+data's CT_CYCLES records (`CPUTEST_CYCLES=1`; 68000/010 sets carry them).
+Status after the fixes in this round (dynamic bit-op upper-half penalty,
+BTST Dn,#imm, CHK source-EA cost, DIVS divisor-sign adjustment):
+
+- **68000: cycle-exact across the full sweep** except JSR/JMP `(An)` with
+  an odd address (the address-error path books 4 clocks differently -
+  same exception-3 accounting class as the SST residuals above).
+- **68010: not calibrated.** The sweep flags most instruction classes
+  (the 010 has different EA/ALU costs, loop mode, and a faster MOVE from
+  SR); the cputest data is the reference to do this against when 010
+  timing matters.

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -856,7 +856,7 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                     _ => return illegal_instruction(cpu, bus),
                 };
                 if cpu.cpu_type == CpuType::M68000 {
-                    cpu.bitop_cycles(ea, bit_op, opcode & 0x100 == 0)
+                    cpu.bitop_cycles(ea, bit_op, opcode & 0x100 == 0, bit_num)
                 } else {
                     legacy
                 }
@@ -992,7 +992,14 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         if let Some(mode) = AddressingMode::decode(ea_mode, ea_reg) {
             let size = Size::Word;
             let bound = cpu.read_ea(bus, mode, size);
-            return cpu.exec_chk(bus, size, bound, dst_reg);
+            let cycles = cpu.exec_chk(bus, size, bound, dst_reg);
+            // MC68000: the bound fetch pays the source EA cost on top of
+            // the base (whether or not the check traps).
+            return if cpu.cpu_type == CpuType::M68000 {
+                cycles + cpu.ea_source_cycles(mode, size)
+            } else {
+                cycles
+            };
         } else {
             return illegal_instruction(cpu, bus);
         }

--- a/crates/m68k/src/core/ea.rs
+++ b/crates/m68k/src/core/ea.rs
@@ -640,11 +640,27 @@ impl CpuCore {
     /// plus the source EA. The static (immediate bit-number) form adds 4 for the
     /// extension-word fetch.
     #[inline]
-    pub(crate) fn bitop_cycles(&self, mode: AddressingMode, bit_op: u16, is_static: bool) -> i32 {
+    pub(crate) fn bitop_cycles(
+        &self,
+        mode: AddressingMode,
+        bit_op: u16,
+        is_static: bool,
+        bit_num: u32,
+    ) -> i32 {
         let static_add = if is_static { 4 } else { 0 };
         if matches!(mode, AddressingMode::DataDirect(_)) {
             let base = if bit_op == 2 { 8 } else { 6 };
-            base + static_add
+            // The modifying ops pay 2 extra clocks when the bit number
+            // addresses the upper long word half (BTST does not).
+            let high_bit = if bit_op != 0 && (bit_num & 31) > 15 {
+                2
+            } else {
+                0
+            };
+            base + static_add + high_bit
+        } else if matches!(mode, AddressingMode::Immediate) {
+            // BTST Dn,#imm (the only bit op with an immediate destination)
+            10
         } else {
             let base = if bit_op == 0 { 4 } else { 8 };
             base + static_add + self.ea_source_cycles(mode, Size::Byte)

--- a/crates/m68k/src/core/instructions/mul_div.rs
+++ b/crates/m68k/src/core/instructions/mul_div.rs
@@ -62,6 +62,15 @@ fn divs_cycles(dividend: i32, divisor: i16) -> i32 {
         return (mcycles + 2) * 2;
     }
     mcycles += 55;
+    // A non-negative divisor saves one cycle for a non-negative dividend
+    // and costs one for a negative dividend (WinUAE getDivs68kCycles).
+    if divisor >= 0 {
+        if dividend >= 0 {
+            mcycles -= 1;
+        } else {
+            mcycles += 1;
+        }
+    }
     // Each leading 0 in the absolute quotient costs one extra cycle.
     let aquotient = adividend / adivisor;
     let mut q = (aquotient & 0xFFFF) as u16;


### PR DESCRIPTION
Follow-up to #97: the cputest data's CT_CYCLES records (cycle-exact counts for the 68000/010 sets) are now validated by the runner, and the divergences it flagged on the 68000 are fixed.

## Cycle validation (`CPUTEST_CYCLES=1`)

The runner accumulates the cost of every completed step, mirroring the generator's counter (which stops when the terminating sentinel exception is recognized). The accounting details - trailing vs branch-target sentinel NOPs, trace bundling, round seeds - are documented in the commit and code.

## 68000 fixes (all matching the WinUAE hardware model)

- dynamic/static **BCHG/BCLR/BSET on a data register**: +2 clocks when the bit number addresses the upper long-word half (BTST exempt)
- **BTST Dn,#imm**: flat 10 clocks
- **CHK <ea>,Dn**: adds the source EA cost (trap or not)
- **DIVS**: divisor-sign adjustment (-1 for non-negative dividends, +1 for negative, when the divisor is non-negative); DIVU was already exact

## Status

- **68000: cycle-exact across the full sweep** (~800k tests) except the JSR/JMP odd-address rounds (exception-3 accounting; recorded in CYCLE_TIMING_GAP.md alongside the SST residuals of the same class)
- **68010: uncalibrated** - the sweep flags most classes (different EA/ALU costs, loop mode). The data is now the reference for calibrating it if/when 010 timing matters.

## Testing

- Full 68000 cputest sweep with CPUTEST_CYCLES=1: clean bar the two documented rounds
- All six models' functional sweeps: unchanged (68060's known LPSTOP residual only)
- SingleStepTests: 127 files green (the fixes agree with the SST cycle data)
- All m68k suites + full Copperline suite (1299 tests) green

Note for review: these change 68000 instruction timing (2-cycle-scale) and therefore whole-machine emulated timing - hardware-correct per the real-silicon-validated data, but timing-sensitive scenes will shift relative to previous builds.