### PR TITLE
vAmigaTS sweep fixes: 68000 floating bus + CIA-B POUT/CNT wiring

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3058,6 +3058,13 @@ impl Bus {
     /// Select the chip-bus cycle length: the 68020+ completes a word access in
     /// 3 CPU clocks where the 68000 takes 4, so its post-grant tail is shorter
     /// (write-posting; faster reads). Derived from the CPU model.
+    /// Whether the CPU runs the shorter 020+ bus cycle (see the field doc);
+    /// also distinguishes the 68000's shared chip data bus from the 020+
+    /// local bus for the floating-bus latch.
+    pub(crate) fn cpu_short_bus_cycle(&self) -> bool {
+        self.cpu_short_bus_cycle
+    }
+
     pub fn set_cpu_short_bus_cycle(&mut self, enabled: bool) {
         self.cpu_short_bus_cycle = enabled;
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1972,6 +1972,33 @@ impl CpuBus {
         size.max(1).div_ceil(2) as u32
     }
 
+    /// Latch the last word the CPU drove onto (or sampled from) the shared
+    /// data bus: undriven (unmapped) reads float to this value. A byte
+    /// cycle drives one lane while the other keeps its previous charge.
+    /// DMA fetches latch through their own paths (dma_slots /
+    /// frame_capture); cache hits perform no bus cycle and do not latch.
+    fn note_cpu_data_bus(&mut self, addr: u32, size: usize, value: u32) {
+        // Only the 68000 shares the 16-bit chip data bus directly with
+        // Agnus, which is the float-to-last-value behavior modeled here
+        // (and what the vAmigaTS uninit tests pin down). The 020+ run on
+        // their own wider local bus with different undriven behavior;
+        // KS3.1-era memory probing misdetects if their reads echo here.
+        if self.bus.cpu_short_bus_cycle() {
+            return;
+        }
+        self.bus.data_bus = if size == 1 {
+            let b = (value & 0xFF) as u16;
+            if addr & 1 == 0 {
+                (self.bus.data_bus & 0x00FF) | (b << 8)
+            } else {
+                (self.bus.data_bus & 0xFF00) | b
+            }
+        } else {
+            // The last word of the transfer stays on the bus.
+            (value & 0xFFFF) as u16
+        };
+    }
+
     fn read_sized(&mut self, address: u32, size: usize, kind: CpuBusAccessKind) -> u32 {
         let addr = self.mask(address);
         if self.icache.is_some() || self.dcache.is_some() {
@@ -1989,12 +2016,15 @@ impl CpuBus {
             if kind == CpuBusAccessKind::Fetch {
                 self.last_fetch_cache_hit = false;
             }
+            self.note_cpu_data_bus(addr, size, value);
             return value;
         }
         if kind == CpuBusAccessKind::Fetch {
             self.last_fetch_cache_hit = false;
         }
-        self.read_sized_uncached(addr, size, kind)
+        let value = self.read_sized_uncached(addr, size, kind);
+        self.note_cpu_data_bus(addr, size, value);
+        value
     }
 
     #[inline]
@@ -2245,6 +2275,7 @@ impl CpuBus {
 
     fn write_sized(&mut self, address: u32, size: usize, value: u32) {
         let addr = self.mask(address);
+        self.note_cpu_data_bus(addr, size, value);
         if let Some(dcache) = self.dcache.as_deref_mut() {
             // Write-through with invalidate-on-hit: the write itself goes
             // to memory below; later reads refill. (The instruction cache
@@ -3291,12 +3322,13 @@ mod tests {
             last_fetch_cache_hit: false,
         };
         let addr = SLOW_RAM_BASE as u32 + 64 * 1024;
-        // With nothing yet driven, the bus rests at 0.
+        // A write into unmapped space still drives the bus: the following
+        // undriven read floats to the last word of the transfer.
         bus.write_long(addr, 0x1234_5678);
-        assert_eq!(bus.read_long(addr), 0);
-        // Once a real access latches a value, undriven reads float to it; a
-        // 68000 byte read takes the high data-bus byte at even addresses and the
-        // low byte at odd.
+        assert_eq!(bus.read_long(addr), 0x5678_5678);
+        // Any latched value is what undriven reads float to; a 68000 byte
+        // read takes the high data-bus byte at even addresses and the low
+        // byte at odd.
         bus.bus.data_bus = 0xA53C;
         assert_eq!(bus.read_byte(addr), 0xA5);
         assert_eq!(bus.read_byte(addr + 1), 0x3C);


### PR DESCRIPTION
Second round of vAmigaTS sweep triage fixes (#100), two independent hardware behaviors:

## 1. 68000 floating bus: CPU cycles drive the shared chip data bus

Undriven (unmapped) reads floated to the last **DMA-fetched** word only. On a real 68000 machine the CPU shares the same 16-bit chip data bus as Agnus, so its own fetches and writes leave their value on the bus too — an unmapped read right after an instruction fetch floats to the instruction stream, deterministically. The suite's `Memory/Ram/uninit` tests pin this down:

- `uninit2`: 46.5% → **0.14%** pixel divergence against the vAmiga reference
- `uninit1`: 46.5% → 12.9%

Byte cycles drive one bus lane (the other keeps its charge); word/long transfers latch their last word; unmapped writes drive the bus too. **Scoped to 68000/010**: the 020+ run their own wider local bus with different undriven behavior, and KS3.1-era memory probing misdetects when their reads echo the latch — the DblPAL and MMU-library boot regression tests caught this during development and gate the scoping.

## 2. CIA-B PA1 (POUT) drives the CNT pin

Board wiring: CIA-B's PA1 and CNT pins share the parallel port's POUT line, so toggling PA1 as an output clocks CNT — counted by CNT-mode timers (CRA/CRB INMODE) and sampled by the serial shifter. The CNT plumbing existed for CIA-A's keyboard clock; this adds the CIA-B tie (with EXTER raised like any other CIA-B IRQ source) plus a unit test. `CIA/CIA/cnt1b` halves its divergence (84% → 50%); the remainder across the cnt bucket is the value-at-beam-position display dynamics class shared with the other timing visualizations.

## Testing

- Full unit suite: 1300 passed
- Image regression suite: all pass except the pre-existing host-flaky HAM capture (fails identically on clean main)
- vAmigaTS buckets as above

Local-dev note: creating `test-assets/` (for the vAmigaTS checkout) shadows the repo-root legacy asset fallback for the ignored suites — symlink the root ROMs/ADFs into `test-assets/` (done locally, gitignored).