### PR TITLE
vAmigaTS comparator: correct horizontal anchor, un-mask the dumps

### DIFF
--- a/tests/vamiga_ts.rs
+++ b/tests/vamiga_ts.rs
@@ -134,6 +134,7 @@ fn run_case(
     fs::write(&cfg_path, copperline_config(kick13, &case.adf_path))?;
 
     let output = Command::new(emulator)
+        .env("COPPERLINE_HCENTER", "0")
         .current_dir(repo_root())
         .env("RUST_LOG", "copperline=warn")
         .arg("--noaudio")
@@ -250,6 +251,13 @@ fn run_vamiga_reference(
 fn copperline_config(kick13: &Path, adf: &Path) -> String {
     format!(
         r#"rom = {}
+
+[display]
+# Full overscan without recentring: the comparator aligns raw beam
+# coordinates, so the TV bezel mask and the content recentring shift
+# must both stay out of the dump (COPPERLINE_HCENTER=0 is set on the
+# spawned process for the same reason).
+overscan = "full"
 
 [emulation]
 speed = "turbo"

--- a/tools/vamigats-compare.py
+++ b/tools/vamigats-compare.py
@@ -53,9 +53,20 @@ def read_png_rgb(path):
     return bytes(out), w, h, ch
 
 # Copperline expands 4-bit channels with x17 (0xF -> 255); vAmiga v4.4
-# with x16 (0xF -> 240, with occasional +-1 from its texture path), and
-# its cutout sits 16 pixels right of Copperline's framebuffer origin.
-X_SHIFT = 16
+# with x16 (0xF -> 240, with occasional +-1 from its texture path).
+#
+# Horizontal anchor: vAmiga's regression cutout starts at colour clock
+# 0x31 (RegressionTester X1 = 4 * 0x31), the same beam position as
+# Copperline's framebuffer origin, so aligned frames need no x shift.
+# Verified against mid-line copper COLOR00 write steps (identical raw x
+# in both dumps) and aperiodic bitmap/text content. The previous value
+# of 16 was an artifact: the zero-diff cases were blank screens (shift-
+# invariant), striped test patterns alias modulo their period, and
+# Copperline's line-start colour writes surface 16 px late (a separate
+# divergence this shift used to hide). Note: DDFSTRT $30 lores pictures
+# currently sit 2 px right of vAmiga's - a real placement divergence
+# under investigation; score those cases with --xshift 2 to isolate it.
+X_SHIFT = 0
 # Copperline's framebuffer row 0 sits two beam lines above vAmiga's
 # cutout start (VBLANK_MAX + 1).
 Y_SHIFT = 2
@@ -89,8 +100,17 @@ def compare(case_png, case_raw, tol):
     return diff / total, None
 
 def main():
-    root = sys.argv[1]
-    tol = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+    global X_SHIFT
+    args = [a for a in sys.argv[1:]]
+    for i, a in enumerate(list(args)):
+        if a.startswith('--xshift'):
+            X_SHIFT = int(a.split('=')[1]) if '=' in a else int(args[i + 1])
+            args.remove(a)
+            if '=' not in a:
+                args.remove(str(X_SHIFT))
+            break
+    root = args[0]
+    tol = int(args[1]) if len(args) > 1 else 0
     results = []
     for dirpath, _dirs, files in os.walk(root):
         for f in files:


### PR DESCRIPTION
## What

Two calibration fixes for the vAmigaTS sweep pipeline (PR #100):

1. **`tools/vamigats-compare.py`: X_SHIFT 16 -> 0.** vAmiga's regression cutout starts at colour clock 0x31 (`RegressionTester::X1 = 4 * 0x31`), which is the same beam position as Copperline's framebuffer origin - aligned frames need no horizontal shift. The old value of 16 came from calibration cases that turned out to be blank screens (shift-invariant) or striped patterns (which alias modulo their period). Verified with mid-line copper COLOR00 write steps: they land on **identical raw x** in both emulators' dumps.

2. **`tests/vamiga_ts.rs`: dump the full unmasked field.** The harness saved screenshots through the default TV-bezel presentation, which blanks the first 16 framebuffer columns and the deep vertical overscan rows. That mask is what made X_SHIFT=16 look right - it dodged the blanked columns instead of aligning frames. The harness now runs with `[display] overscan="full"` and `COPPERLINE_HCENTER=0`, so the dump carries neither the TV mask nor the content-recentring shift.

A `--xshift N` override was added to the comparator for isolating placement classes.

## Impact

- A copper-bar case (CIA/TOD/tod/latch2) now compares **pixel-perfect (0.000%)**.
- Bucket averages drop across the sweep, since every case previously paid the mask/shift tax: Copper/Wait 14.9 -> 1.0, Blitter/sblit 10.9 -> 1.1, Copper/oldJump 25.9 -> 9.2, sprite buckets 4-18 -> 1.6-6.2, Misc/Init 3.7 -> 0.2.
- What remains large is real: the new top of the table is Mainboard/POT (~99%), CPU/IPL/MOVES (~99%), Blitter/cputim (~86-98%), Memory/memspeed (96%), Agnus/DIW/DIWV/diwvmras (96%), plus the OLDDIW/DDF placement classes.
- One real placement divergence surfaced cleanly: DDFSTRT $30 lores pictures sit exactly 2 px right of vAmiga's (score those buckets with `--xshift 2` to isolate; tracked separately).

Full sweep regeneration with the fixed harness is running; the updated triage will inform the next round of fixes.