### PR TITLE
Drop claims implying common emulator behaviour is unique from README …

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ It covers OCS, ECS, and AGA (independent Agnus/Denise revisions,
 programmable blanking, machine profiles from the A500 to the A1200,
 CDTV, and CD32, with Gayle IDE, A2091 SCSI, and the AGA display path: 8 bitplanes,
 256-entry palette, HAM8, FMODE wide fetch; remaining gaps are recorded in
-the internals docs). The timing model is taken seriously: the
-chip bus is arbitrated per colour clock, the Copper and blitter are
-scheduled per DMA slot with hardware bus sequences, and 68000
-interrupt-recognition latency is modelled. The source is organized so the
-hardware model can be read and extended without chasing title-specific
-patches.
+the internals docs). Cycle-driven means the whole machine advances on one
+colour-clock timeline: the chip bus is arbitrated per colour clock, the
+Copper and blitter are scheduled per DMA slot with the hardware bus
+sequences, and 68000 interrupt-recognition latency is modelled. 68000 cycle
+counts are validated against the TomHarte SingleStepTests, and chip-bus
+timing against a test disk cross-checked on real hardware
+(`timing-test/`).
 
 ## Background
 
@@ -50,10 +51,10 @@ against real hardware.
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
   (ADF / ADZ / ZIP / DMS, read-only SCP), Gayle IDE, A2091 SCSI, and CDTV/CD32
   CD.
-- **Tooling**: an in-window debugger, an interactive chip-bus frame
-  analyzer, remote GDB support, deterministic save states, input
-  recording/replay, and headless screenshot/frame-dump capture -- the
-  deterministic core makes every replay byte-identical.
+- **Tooling**: an in-window debugger that can step backwards, an
+  interactive chip-bus frame analyzer, remote GDB support, deterministic
+  save states, input recording/replay, and headless screenshot/frame-dump
+  capture -- the deterministic core makes every replay byte-identical.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,14 @@ abstract: |
 # Copperline
 
 Copperline is a cycle-driven Commodore Amiga emulator (OCS, ECS, and AGA)
-written in Rust. It models the hardware -- the 68000-family CPU, Agnus,
-Denise, Paula, the CIAs, the floppy subsystem, and the chip bus that ties
-them together -- rather than patching around individual software titles. The
-chip bus is arbitrated per colour clock, the Copper and blitter are scheduled
+written in Rust. Cycle-driven means the whole machine -- the 68000-family
+CPU, Agnus, Denise, Paula, the CIAs, the floppy subsystem, and the chip bus
+that ties them together -- advances on one colour-clock timeline: the chip
+bus is arbitrated per colour clock, the Copper and blitter are scheduled
 per DMA slot with the hardware bus sequences, and 68000
-interrupt-recognition latency is modelled. That timing discipline is what
-lets it run the current cycle-sensitive OCS and AGA regression set, as well
-as Kickstart, Workbench, games, and CDTV/CD32 titles.
+interrupt-recognition latency is modelled. That timing model is what lets
+it run the current cycle-sensitive OCS and AGA regression set, as well as
+Kickstart, Workbench, games, and CDTV/CD32 titles.
 
 The project home is [copperline.dev](https://copperline.dev/); the source
 lives on [GitHub](https://github.com/LinuxJedi/Copperline).
@@ -59,5 +59,6 @@ Two rules shape every change in Copperline:
    chip behaviour; software titles appear only as regression examples.
 2. **Determinism.** The emulated core is deterministic and independent of
    the host: a headless unthrottled run and a real-time windowed run produce
-   the same emulated result when given the same inputs and media. Headless
-   captures are reproducible by construction.
+   the same emulated result when given the same inputs and media. That is
+   what makes headless captures reproducible, and it is also what lets the
+   debugger step backwards.


### PR DESCRIPTION
…and docs

Align the README and docs index with the copperline.dev copy rewrite: remove the framing that other emulators patch around individual titles ("without chasing title-specific patches", "rather than patching around individual software titles"), replace the "timing model is taken seriously" editorialising with a plain definition of cycle-driven plus the actual validation evidence (SingleStepTests, real-hardware timing disk), and swap "reproducible by construction" for a plain explanation that determinism is what makes captures reproducible and reverse stepping possible. Also mention reverse stepping in the README tooling bullet, since it is the headline debugger feature.


Claude-Session: https://claude.ai/code/session_01MM7GP5Ex2vmbbT6zEeLpzj