### PR TITLE
debugger: peek device-board windows where side-effect-free

### DIFF
--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -374,6 +374,16 @@ impl crate::zorro_device::ZorroDevice for A2091 {
         Self::write(self, off, size, value, host.memory_mut())
     }
 
+    fn peek_word(&self, off: u32) -> Option<u16> {
+        // Only the boot ROM half of the window is side-effect-free; the
+        // DMAC/SBIC registers below ROM_OFFSET stay opaque to peeks.
+        let off = (off & !1) as usize;
+        (off >= ROM_OFFSET as usize).then(|| {
+            let mask = self.rom.len() - 1;
+            (u16::from(self.rom[off & mask]) << 8) | u16::from(self.rom[(off + 1) & mask])
+        })
+    }
+
     fn tick(&mut self, cck: u32, host: &mut crate::zorro_device::DeviceHost) {
         Self::tick(self, cck, host.memory_mut())
     }
@@ -491,6 +501,21 @@ mod tests {
             }
         }
         panic!("no INT2");
+    }
+
+    #[test]
+    fn peek_serves_rom_and_leaves_registers_opaque() {
+        use crate::zorro_device::ZorroDevice;
+        let rom = fake_rom();
+        let board = A2091::new(rom.clone()).unwrap();
+        // ROM half of the window (>= ROM_OFFSET): debugger peeks read the
+        // same bytes a CPU read would (scsi.device names live here).
+        let off = ROM_OFFSET + 0xA9;
+        let want =
+            (u16::from(rom[(off & !1) as usize]) << 8) | u16::from(rom[(off as usize & !1) + 1]);
+        assert_eq!(ZorroDevice::peek_word(&board, off), Some(want));
+        // Register half: opaque to side-effect-free peeks.
+        assert_eq!(ZorroDevice::peek_word(&board, 0x40), None);
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4443,6 +4443,15 @@ impl Bus {
             let ram = self.mem.zorro.board_ram(board);
             return ((ram[off] as u16) << 8) | ram[off + 1] as u16;
         }
+        // Device-board windows: serve what the device can answer without
+        // side effects (e.g. the A2091 boot ROM, where scsi.device task
+        // and node names live), 0 for live registers.
+        if let Some((crate::zorro::BoardBacking::Device(dev), off)) =
+            self.mem.zorro.device_region_at(addr, 2)
+        {
+            return crate::zorro_device::ZorroDevice::peek_word(&self.devices[dev], off)
+                .unwrap_or(0);
+        }
         let a = addr as usize;
         let regions: [(usize, &[u8]); 4] = [
             (CHIP_RAM_BASE as usize, &self.mem.chip_ram),

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -203,6 +203,14 @@ pub trait ZorroDevice {
     /// Write `size` bytes of `value` at window offset `off`.
     fn write(&mut self, off: u32, size: usize, value: u32, host: &mut DeviceHost);
 
+    /// Side-effect-free debugger peek of the word at window offset `off`:
+    /// what a read would return where that is knowable without disturbing
+    /// device state (e.g. boot ROM), None elsewhere (live registers).
+    fn peek_word(&self, off: u32) -> Option<u16> {
+        let _ = off;
+        None
+    }
+
     /// Advance the device by `cck` colour clocks.
     fn tick(&mut self, cck: u32, host: &mut DeviceHost);
 
@@ -272,6 +280,14 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::A2091(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::A2065(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::Wasm(d) => ZorroDevice::write(d, off, size, value, host),
+        }
+    }
+
+    fn peek_word(&self, off: u32) -> Option<u16> {
+        match self {
+            BoardDevice::A2091(d) => ZorroDevice::peek_word(d, off),
+            BoardDevice::A2065(d) => ZorroDevice::peek_word(d, off),
+            BoardDevice::Wasm(d) => ZorroDevice::peek_word(d, off),
         }
     }
 


### PR DESCRIPTION
Bus::peek_word_any() routed RAM-backed Zorro regions but fell through device-backed windows, so every debugger surface (console TASKS/MEM, the GDB stub's memory reads) saw zeros or junk where the emulated CPU reads the A2091's boot ROM. Symptom: scsi.device sub-task and node names - ln_Name pointers into the board window's ROM half - displayed as 30 unprintable characters in TASKS.

Adds ZorroDevice::peek_word(), a side-effect-free peek defaulting to None: the A2091 answers for its ROM range (>= $2000) and keeps the DMAC/SBIC registers opaque, and peek_word_any() consults it for device windows. A2065/WASM boards keep the default.

Test: A2091 peeks return ROM bytes in the ROM half and None over registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)