### PR TITLE
audio: Cmd/Alt+Shift+A cycles the live audio output

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ default output; `--list-audio-devices` prints the alternatives and
 `--audio-device NAME` (or `[audio] output_device`) selects one by
 case-insensitive substring, falling back to the default if it disappears. The
 device is also selectable in the configuration screen and switchable live from
-the in-window menu, which additionally offers "Disabled" to turn sound off
-entirely (equivalent to `--noaudio`).
+the in-window menu (or `Cmd+Shift+A` / `Alt+Shift+A`), which additionally offers
+"Disabled" to turn sound off entirely (equivalent to `--noaudio`).
 
 Two host-side shaping options leave the emulated audio untouched:
 `--audio-channel-mode mono` averages the left/right output into both channels,

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -21,6 +21,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
 | `Cmd+K` | `Alt+K` | Open the [debugger console](../debugger/console) |
 | `Cmd+J` | `Alt+J` | Toggle joystick input mode: gamepad / keyboard (also the status-bar icon) |
+| `Cmd+Shift+A` | `Alt+Shift+A` | Cycle the audio output: Default, each host device, then Disabled (also the menu's Audio Out item) |
 | `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |
 | `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Esc` | `Esc` | Close an open menu, tool window, or overlay panel; otherwise passed through to the Amiga |

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -770,7 +770,7 @@ pub enum UiControl {
 fn panel_dims(panel: &Panel) -> (usize, usize) {
     match panel {
         Panel::About => (560, 380),
-        Panel::Shortcuts => (600, 418),
+        Panel::Shortcuts => (600, 440),
         Panel::Calibration(_) => (620, 372),
         Panel::Debugger(_) => (684, 520),
         Panel::FrameAnalyzer(_) => (700, 526),
@@ -1653,7 +1653,7 @@ fn draw_about(frame: &mut [u8], rect: Rect, view: &AboutView, scale: usize) {
     }
 }
 
-const SHORTCUT_ROWS: [(&str, &str, bool); 15] = [
+const SHORTCUT_ROWS: [(&str, &str, bool); 16] = [
     ("Q", "Quit", true),
     ("S", "Save screenshot", true),
     ("R", "Record video on/off", true),
@@ -1665,6 +1665,7 @@ const SHORTCUT_ROWS: [(&str, &str, bool); 15] = [
     ("B", "Debugger", true),
     ("K", "Console", true),
     ("J", "Joystick input mode", true),
+    ("Shift+A", "Cycle audio output", true),
     ("W", "Warp speed on/off", true),
     ("Shift+W", "Warp limit (2x..Max)", true),
     ("Esc", "Close menu/window", false),

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1480,6 +1480,18 @@ impl ApplicationHandler for App {
                     {
                         self.toggle_warp()
                     }
+                    (KeyCode::KeyA, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers)
+                            && self.modifiers.shift_key() =>
+                    {
+                        // Cycle the live audio output (Default -> devices ->
+                        // Disabled), same as the menu's Audio Out item. Ignored
+                        // while a menu/panel is open, so it acts only on the
+                        // running machine, not the config-screen placeholder.
+                        if !self.modal_ui_active() {
+                            self.cycle_audio_output()
+                        }
+                    }
                     (other, state) => {
                         let pressed = state == ElementState::Pressed;
                         if pressed && self.ui_handle_key(other) {


### PR DESCRIPTION
Adds a keyboard shortcut for the runtime "Audio Out" menu item (from #124): `Cmd+Shift+A` on macOS, `Alt+Shift+A` on Linux/Windows, cycling the live output forward -- Default -> host devices -> Disabled -- the same as the menu, reusing `cycle_audio_output()`. It's guarded so it only fires on a running machine, not the config-screen placeholder or while a menu/panel is open.

Shift (rather than a bare `Cmd+A`) matches the scheme's tier for infrequent, set-and-forget actions (save/load state, warp limit), and avoids the "Select All" muscle-memory collision accidentally silencing or misrouting audio.

Documented in the in-window Keyboard Shortcuts panel, the UI guide table, and the README audio section.

Verification: clippy `-D warnings` + fmt clean (default and `--no-default-features`); 1319 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)