### PR TITLE
Copper: a skipped MOVE still passes the illegal-register decode

### DIFF
--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -155,6 +155,14 @@ impl Bus {
                 }
                 true
             }
+            CopperSlotAction::SkippedMove { register } => {
+                // The SKIP suppresses the write, not the illegal-register
+                // decode: a forbidden MOVE stops the Copper even when skipped.
+                if !self.copper_can_write_custom(register) {
+                    self.copper.stop();
+                }
+                true
+            }
         }
     }
 

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -1401,6 +1401,34 @@ fn copper_lc_write_retargets_dormant_copper_pc() {
 }
 
 #[test]
+fn copper_skipped_forbidden_move_still_stops_the_copper() {
+    // A satisfied SKIP suppresses the following MOVE's write, but the MOVE
+    // still passes through the illegal-register decode: a forbidden target
+    // stops the Copper exactly as it would unskipped (real-Agnus behaviour,
+    // photographed by vAmigaTS Copper/Skip/copskip4).
+    let mut bus = empty_bus();
+    let cop1 = 0x0100usize;
+    write_chip_word(&mut bus, cop1, 0x0001); // SKIP: beam already past 0,0
+    write_chip_word(&mut bus, cop1 + 2, 0xFFFF);
+    write_chip_word(&mut bus, cop1 + 4, 0x003E); // forbidden MOVE (no CDANG)
+    write_chip_word(&mut bus, cop1 + 6, 0x0000);
+    write_chip_word(&mut bus, cop1 + 8, 0x0180); // never reached
+    write_chip_word(&mut bus, cop1 + 10, 0x0F00);
+
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_COPEN;
+    bus.agnus.vpos = 0x50;
+    bus.agnus.hpos = 0x20;
+    bus.copper.jump(cop1 as u32);
+    bus.advance_chipset(16);
+
+    assert!(
+        !bus.copper.is_running(),
+        "the skipped forbidden MOVE must halt"
+    );
+    assert_eq!(bus.denise.palette[0], 0, "the write after it must not run");
+}
+
+#[test]
 fn copper_dma_enable_gates_current_pc_until_copjmp_strobe() {
     let mut bus = empty_bus();
     let cop1 = 0x0100usize;

--- a/src/chipset/copper.rs
+++ b/src/chipset/copper.rs
@@ -305,9 +305,13 @@ pub enum CopperSlotAction {
     /// blitter/CPU.
     Idle,
     /// The Copper used the bus this color clock but produced no register write
-    /// the caller must apply (a first-word fetch, a skipped MOVE, an applied
-    /// COPJMP/WAIT/SKIP).
+    /// the caller must apply (a first-word fetch, an applied COPJMP/WAIT/SKIP).
     BusUsed,
+    /// The Copper fetched a MOVE that an active SKIP suppresses. The write is
+    /// omitted, but the register still passes through the illegal-address
+    /// decode: a MOVE the Copper may not perform stops it even when skipped
+    /// (real-Agnus behaviour, vAmigaTS Copper/Skip/copskip4).
+    SkippedMove { register: u16 },
     /// The Copper used the bus and decoded a `MOVE`; the caller applies the
     /// custom-register write (subject to COPCON) or stops the Copper.
     Move { register: u16, value: u16 },
@@ -605,9 +609,10 @@ impl Copper {
                 }
                 match self.fetch_decode(chip_ram) {
                     CopperFetch::Idle => CopperSlotAction::Idle,
-                    CopperFetch::FirstWord { .. } | CopperFetch::SkippedMove { .. } => {
-                        CopperSlotAction::BusUsed
-                    }
+                    CopperFetch::FirstWord { .. } => CopperSlotAction::BusUsed,
+                    CopperFetch::SkippedMove { first, .. } => CopperSlotAction::SkippedMove {
+                        register: first & 0x01FE,
+                    },
                     CopperFetch::Instruction { instruction, .. } => {
                         match instruction {
                             CopperInstruction::Move {


### PR DESCRIPTION
A satisfied SKIP suppresses the following MOVE's register write, but on real Agnus the fetched MOVE still goes through the illegal-address decode: a target the Copper may not write (COPCON/CDANG rules) stops the Copper exactly as it would unskipped. The vAmigaTS `Agnus/Copper/Skip/copskip4` photo shows this - a skipped illegal write still halts the list.

Copperline consumed a skipped MOVE as a plain bus fetch, so the Copper sailed past illegal targets whenever a SKIP shadowed them.

## Results

| case | before | after |
|---|---|---|
| Copper/Skip/copskip4 | 75.2% | 0.000% (exact) |

## Gates

- 1320 unit tests green (new: `copper_skipped_forbidden_move_still_stops_the_copper`); clippy + fmt clean.
- Demo screenshot set byte-identical.