### PR TITLE
CIA: synchronize CPU CIA accesses to the E clock

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3240,6 +3240,29 @@ impl Bus {
     /// RTC, autoconfig, undecoded space). These stay on the slow motherboard
     /// bus no matter how fast the CPU is clocked, so bill the stock 68000
     /// figure of 2 cck per word regardless of the configured CPU speed.
+    /// A CPU access to a CIA ($BFxxxx). These are 6800-style VPA cycles: the
+    /// 68000 synchronizes to the E clock (CPU/10, six clocks low, four high)
+    /// before the data transfer, so the access costs 6..15 CPU cycles
+    /// depending on the E phase it starts in, not a plain bus cycle. The
+    /// delay table is vAmiga's Agnus::syncWithEClock at Copperline's colour
+    /// clock resolution (one cck = two CPU clocks; the CIA PHI2 divider
+    /// remainder is the live E phase). Software loops that poll or toggle a
+    /// CIA lock to the E clock through this - the vAmigaTS CIA/cnt ramps
+    /// count it directly.
+    pub fn cpu_cia_access(&mut self, words: u32) {
+        if !self.cpu_bus_arbitration_enabled || words == 0 {
+            return;
+        }
+        self.flush_timed_devices();
+        const E_SYNC_DELAY_CCK: [u32; 5] = [6, 5, 4, 3, 7];
+        let phase = (self.device_clock.cia_tick_remainder_cck as usize).min(4);
+        let delay = E_SYNC_DELAY_CCK[phase];
+        let cck = delay + words * 2;
+        let tick = self.advance_chipset(cck);
+        self.record_slice_bus_advance(cck, tick);
+        self.flush_timed_devices();
+    }
+
     pub fn cpu_slow_external_access(&mut self, words: u32) {
         if !self.cpu_bus_arbitration_enabled || words == 0 {
             return;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3565,8 +3565,8 @@ mod tests {
         // for the E clock (Bus::cpu_cia_access), adding a phase-dependent
         // 3..7 cck on top of the plain external cost. The phase here is
         // fixed by the test's deterministic start time.
-        let hi = ((CIA_A_BASE as u32 >> 16) & 0xFFFF) as u16;
-        let lo = (CIA_A_BASE as u32 & 0xFFFF) as u16;
+        let hi = ((CIA_A_BASE >> 16) & 0xFFFF) as u16;
+        let lo = (CIA_A_BASE & 0xFFFF) as u16;
         let slice = run_rom_instruction(&[0x3039, hi, lo])?;
         assert_single_instruction_timing("CIA word data read", slice, 8, 15);
         Ok(())

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2178,11 +2178,11 @@ impl CpuBus {
         }
 
         if range_contains(CIA_A_BASE, CIA_A_SIZE, addr) {
-            self.bus.cpu_slow_external_access(Self::access_words(size));
+            self.bus.cpu_cia_access(Self::access_words(size));
             return self.bus.cia_a_read(u64::from(addr - CIA_A_BASE), size) as u32;
         }
         if range_contains(CIA_B_BASE, CIA_B_SIZE, addr) {
-            self.bus.cpu_slow_external_access(Self::access_words(size));
+            self.bus.cpu_cia_access(Self::access_words(size));
             return self.bus.cia_b_read(u64::from(addr - CIA_B_BASE), size) as u32;
         }
         if self.bus.cdtv.is_some() && range_contains(CDTV_BATTRAM_BASE, CDTV_BATTRAM_SIZE, addr) {
@@ -2366,7 +2366,7 @@ impl CpuBus {
         }
 
         if range_contains(CIA_A_BASE, CIA_A_SIZE, addr) {
-            self.bus.cpu_slow_external_access(Self::access_words(size));
+            self.bus.cpu_cia_access(Self::access_words(size));
             let effect = self
                 .bus
                 .cia_a_write(u64::from(addr - CIA_A_BASE), size, u64::from(value));
@@ -2380,7 +2380,7 @@ impl CpuBus {
             return;
         }
         if range_contains(CIA_B_BASE, CIA_B_SIZE, addr) {
-            self.bus.cpu_slow_external_access(Self::access_words(size));
+            self.bus.cpu_cia_access(Self::access_words(size));
             let effect = self
                 .bus
                 .cia_b_write(u64::from(addr - CIA_B_BASE), size, u64::from(value));
@@ -3555,13 +3555,20 @@ mod tests {
             ("fast RAM word data read", FAST_RAM_BASE as u32 + 0x0200),
             ("slow RAM word data read", SLOW_RAM_BASE as u32 + 0x0200),
             ("ROM word data read", ROM_BASE as u32 + 0x0200),
-            ("CIA word data read", CIA_A_BASE),
         ] {
             let hi = ((address >> 16) & 0xFFFF) as u16;
             let lo = (address & 0xFFFF) as u16;
             let slice = run_rom_instruction(&[0x3039, hi, lo])?;
             assert_single_instruction_timing(label, slice, 8, 12);
         }
+        // A CIA access is a 6800-style VPA cycle: the data transfer waits
+        // for the E clock (Bus::cpu_cia_access), adding a phase-dependent
+        // 3..7 cck on top of the plain external cost. The phase here is
+        // fixed by the test's deterministic start time.
+        let hi = ((CIA_A_BASE as u32 >> 16) & 0xFFFF) as u16;
+        let lo = (CIA_A_BASE as u32 & 0xFFFF) as u16;
+        let slice = run_rom_instruction(&[0x3039, hi, lo])?;
+        assert_single_instruction_timing("CIA word data read", slice, 8, 15);
         Ok(())
     }
 


### PR DESCRIPTION
CIA accesses on the 68000 are 6800-style VPA cycles: the CPU synchronizes to the E clock (CPU/10, six low + four high) before the data transfer, so an access costs **6..15 CPU cycles depending on the E phase** - not a plain 4-clock bus cycle. Software that polls or toggles a CIA in a loop locks to the E clock through this. Copperline billed a flat external cost, so CIA-polling loops ran ~25% too fast (the vAmigaTS CIA/cnt TALO ramps count it directly: 4.00 loop iterations per scanline vs the reference's 3.15).

The delay table is vAmiga's `Agnus::syncWithEClock` at colour-clock resolution; the live E phase comes from the CIA PHI2 divider remainder. Applies only to the CIA windows ($BFxxxx) - Gayle, Akiko, RTC and autoconfig keep the plain cost (they are not E-clock devices).

## Results

- **timing-test rows 5 (shift) and 10 (chip-write baseline) now match FS-UAE's real-hardware-verified values exactly** (6CFD, 074B); other rows move ±1 E tick from the now-synchronized tstart/tread accesses.
- vAmigaTS CIA family summed (with the merged TOD/CNT fixes): **1465% → 993%**. todint4 46.3→8.4%, oldcnt cnt2/4/6 → ~1.8% each, tod3 22.1→1.7%, todbug1/3 → ~1%.
- The cnt1/cnt1b-style integral ramp cases remain lock-phase-sensitive (the known sub-cck class) and swing a few percent either way; net strongly positive.

## Gates

- 1322 unit tests green (the external-access accounting test now carries a separate E-sync expectation for the CIA row); clippy + fmt clean.
- Demo screenshot set byte-identical; eon unchanged (37.1% vs 36.9%).