### PR TITLE
68010 CPU model: prefetch queue, exception returns, DBcc loop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ against real hardware.
   AROS ROM out of the box, as well as Kickstart 1.3 / 2.05 / 3.1 and DiagROM
   v2.0, and runs the current timing-sensitive OCS and AGA regression set at
   real speed.
-- **Configurable CPU** (68000 / 68EC020 / 68020 / 68030 / 68040) and clock,
+- **Configurable CPU** (68000 / 68010 / 68EC020 / 68020 / 68030 / 68040 / 68060) and clock,
   with an optional 68881/68882 FPU (default-on for the 68040).
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
@@ -157,7 +157,7 @@ optional and missing fields use documented defaults.
 rom = "kickstart205.rom"
 
 [cpu]
-model = "68000"       # 68000, 68EC020, 68020, 68030, 68040
+model = "68000"       # 68000, 68010, 68EC020, 68020, 68030, 68040, 68060
 # fpu = true          # fit a 68881/68882 (default-on for the 68040)
 # clock_mhz = 14.0    # defaults to the model's stock speed
 

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -112,6 +112,21 @@ pub struct CpuCore {
     /// Change-of-flow flag for T0 trace (set by BRA, JMP, JSR, RTS, etc.)
     pub change_of_flow: bool,
 
+    // ========== 68010 loop mode ==========
+    /// A DBcc that branches -4 to a loopable one-word instruction holds the
+    /// pair in the prefetch queue and re-executes without instruction
+    /// fetches (68010 loop mode). While set, the queue is reseeded from the
+    /// held words each iteration and the end-of-instruction top-up is
+    /// suppressed; any exception or interrupt (jump_vector) drops the mode.
+    #[serde(default)]
+    pub loop_mode: bool,
+    /// The looped one-word body instruction (queue word 0 at entry).
+    #[serde(default)]
+    pub loop_body_word: u16,
+    /// The looping DBcc opcode (queue word 1 at entry).
+    #[serde(default)]
+    pub loop_dbcc_word: u16,
+
     // ========== Prefetch (Part E.1, 68000 only) ==========
     /// The 68000's two-word instruction prefetch queue (IRD/IRC model).
     ///
@@ -421,6 +436,9 @@ impl CpuCore {
             int_level: 0,
             stopped: 0,
             change_of_flow: false,
+            loop_mode: false,
+            loop_body_word: 0,
+            loop_dbcc_word: 0,
             prefetch_queue: [0; 2],
             prefetch_count: 0,
             consume_without_prefetch: false,
@@ -659,11 +677,12 @@ impl CpuCore {
     // ========== Prefetch queue (Part E.1, 68000 only) ==========
 
     /// Whether the two-word prefetch queue models instruction fetching.
-    /// Only the 68000 path is prefetch-modeled; other CPU types keep the
-    /// direct fetch-at-PC behavior.
+    /// The 68000 and 68010 share the two-word IRD/IRC queue (the 68010 adds
+    /// loop mode on top of it); later CPU types keep the direct fetch-at-PC
+    /// behavior with their cache models layered above.
     #[inline]
     pub fn prefetch_enabled(&self) -> bool {
-        self.cpu_type == CpuType::M68000
+        matches!(self.cpu_type, CpuType::M68000 | CpuType::M68010)
     }
 
     // ========== Precise per-access timing (Part E.2, 68000 only) ==========
@@ -762,6 +781,9 @@ impl CpuCore {
     /// micro-operation). The fetch address is the first instruction-stream
     /// word the queue does not yet hold.
     pub fn top_up_prefetch_one<B: AddressBus>(&mut self, bus: &mut B) {
+        if self.loop_mode {
+            return;
+        }
         if !self.prefetch_enabled() || self.pc & 1 != 0 || self.prefetch_count >= 2 {
             return;
         }
@@ -782,6 +804,9 @@ impl CpuCore {
     /// already filled the queue), on a stopped CPU (STOP performs no
     /// further bus activity), and on non-prefetch CPU types.
     pub fn top_up_prefetch<B: AddressBus>(&mut self, bus: &mut B) {
+        if self.loop_mode {
+            return;
+        }
         if !self.prefetch_enabled() || self.pc & 1 != 0 || self.stopped != 0 {
             return;
         }

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -1091,13 +1091,28 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                         // Musashi m68k_in.c: format word at (SP+6) >> 12
                         let sp = cpu.a(7);
                         let format = cpu.read_16(bus, sp.wrapping_add(6)) >> 12;
-                        if format != 0 {
-                            return cpu.take_exception(bus, 14); // format error
+                        match format {
+                            0 => {}
+                            8 => {
+                                // 68010 bus/address-error frame (29 words):
+                                // restore SR/PC and discard the fault info.
+                                let sr = cpu.pull_16(bus);
+                                cpu.pc = cpu.pull_32(bus);
+                                let _ = cpu.pull_16(bus); // format/vector word
+                                cpu.dar[15] = cpu.dar[15].wrapping_add(2 * 25);
+                                cpu.set_sr(sr);
+                                cpu.full_prefetch(bus);
+                                return 20;
+                            }
+                            _ => return cpu.take_exception(bus, 14), // format error
                         }
                         let sr = cpu.pull_16(bus);
                         cpu.pc = cpu.pull_32(bus);
                         let _ = cpu.pull_16(bus); // vector offset word
                         cpu.set_sr(sr);
+                        // The 68010 shares the 68000's two-word prefetch
+                        // queue: a return refills it from the new PC.
+                        cpu.full_prefetch(bus);
                         20
                     }
                     _ => {
@@ -1251,6 +1266,8 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 let disp = cpu.read_imm_16(bus) as i16 as i32;
                 cpu.pc = cpu.pull_32(bus);
                 cpu.dar[15] = (cpu.dar[15] as i32).wrapping_add(disp) as u32;
+                // Refill the 68010's prefetch queue from the return address.
+                cpu.full_prefetch(bus);
                 20
             }
         }
@@ -1290,8 +1307,7 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             if !cpu.is_supervisor() && !cpu.is_060() {
                 return cpu.exception_privilege(bus);
             }
-            let ext = bus.read_word(cpu.pc);
-            cpu.pc += 2;
+            let ext = cpu.read_imm_16(bus);
             let reg_type = (ext >> 15) & 1; // 0=Dn, 1=An
             let reg_num = ((ext >> 12) & 7) as usize;
             let ctrl_reg = ext & 0xFFF;
@@ -1325,8 +1341,7 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             if !cpu.is_supervisor() && !cpu.is_060() {
                 return cpu.exception_privilege(bus);
             }
-            let ext = bus.read_word(cpu.pc);
-            cpu.pc += 2;
+            let ext = cpu.read_imm_16(bus);
             let reg_type = (ext >> 15) & 1; // 0=Dn, 1=An
             let reg_num = ((ext >> 12) & 7) as usize;
             let ctrl_reg = ext & 0xFFF;
@@ -1725,6 +1740,62 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
 }
 
 // ============================================================================
+
+/// 68010 loop mode: whether `opcode` is a loopable one-word instruction (the
+/// 68010 UM loop-mode set, mirrored from Moira's loop-handler registrations).
+/// Loopable memory EAs are (An), (An)+ and -(An).
+fn loopable_68010(op: u16) -> bool {
+    let mode = (op >> 3) & 7;
+    let loop_ea = (2..=4).contains(&mode);
+    let opmode = (op >> 6) & 7;
+    match op >> 12 {
+        // MOVE: source Dn/An/(An)/(An)+/-(An), destination (An)/(An)+/-(An).
+        0x1 | 0x2 | 0x3 => {
+            let dst_mode = opmode; // MOVE encodes the destination mode here
+            mode <= 4 && (2..=4).contains(&dst_mode)
+        }
+        // CLR/NEG/NEGX/NOT/TST (all sizes) and NBCD with a memory EA.
+        0x4 => {
+            let hi = (op >> 8) & 0xF;
+            let size = (op >> 6) & 3;
+            loop_ea
+                && ((matches!(hi, 0x0 | 0x2 | 0x4 | 0x6) && size != 3)
+                    || (hi == 0x8 && size == 0)
+                    || (hi == 0xA && size != 3))
+        }
+        // OR/SUB/CMP/EOR/AND/ADD register<->memory forms, the address forms
+        // (ADDA/SUBA/CMPA), and the -(An)/(An)+ pair forms (ABCD/SBCD,
+        // ADDX/SUBX, CMPM).
+        0x8 | 0x9 | 0xB | 0xC | 0xD => {
+            let family = op >> 12;
+            // ABCD/SBCD -(Ax),-(Ay)
+            if (family == 0xC || family == 0x8) && op & 0x01F8 == 0x0108 {
+                return true;
+            }
+            // ADDX/SUBX -(Ax),-(Ay)
+            if (family == 0x9 || family == 0xD) && op & 0x0138 == 0x0108 && opmode & 3 != 3 {
+                return true;
+            }
+            // CMPM (Ay)+,(Ax)+
+            if family == 0xB && op & 0x0138 == 0x0108 && opmode & 3 != 3 {
+                return true;
+            }
+            match opmode {
+                // <ea>,Dn (and CMP)
+                0..=2 => loop_ea,
+                // ADDA/SUBA/CMPA word/long
+                3 | 7 => loop_ea && family != 0x8 && family != 0xC,
+                // Dn,<ea> (OR/SUB/EOR/AND/ADD to memory)
+                4..=6 => loop_ea,
+                _ => false,
+            }
+        }
+        // Memory shifts/rotates (word, by one): ASd/LSd/ROXd/ROd <ea>.
+        0xE => opmode == 3 && loop_ea && (op >> 9) & 7 <= 3,
+        _ => false,
+    }
+}
+
 // Group 5: ADDQ/SUBQ/Scc/DBcc
 // ============================================================================
 
@@ -1782,6 +1853,35 @@ fn dispatch_group_5<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         let condition = ((opcode >> 8) & 0xF) as u8;
         if ea_mode == 1 {
             // DBcc
+            // 68010 loop mode: a looping DBcc re-evaluates from the held
+            // prefetch pair without any instruction fetches. The taken
+            // iteration costs 6 internal clocks (Moira's execDbcc loop arm);
+            // exits refill the queue from the fall-through path.
+            if cpu.loop_mode {
+                let condition = ((opcode >> 8) & 0xF) as u8;
+                if cpu.test_condition(condition) {
+                    cpu.loop_mode = false;
+                    cpu.pc = cpu.pc.wrapping_add(2);
+                    cpu.full_prefetch(bus);
+                    return 12;
+                }
+                let dn = ea_reg as usize;
+                let counter = cpu.d(dn) as u16;
+                let new_counter = counter.wrapping_sub(1);
+                cpu.set_d(dn, (cpu.d(dn) & 0xFFFF_0000) | u32::from(new_counter));
+                if new_counter != 0xFFFF {
+                    // Re-enter the body: PC back over the displacement and
+                    // the body word; reseed the held pair.
+                    cpu.pc = cpu.pc.wrapping_sub(4);
+                    cpu.prefetch_queue = [cpu.loop_body_word, cpu.loop_dbcc_word];
+                    cpu.prefetch_count = 2;
+                    return 6;
+                }
+                cpu.loop_mode = false;
+                cpu.pc = cpu.pc.wrapping_add(2);
+                cpu.full_prefetch(bus);
+                return 16;
+            }
             let counter = cpu.d(ea_reg as usize) as u16;
             // The 68000 evaluates the condition and counter before consuming
             // the displacement: on branching paths (cc false) the consume does
@@ -1811,6 +1911,19 @@ fn dispatch_group_5<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 if new_counter != 0xFFFF {
                     cpu.pc = target;
                     cpu.full_prefetch(bus);
+                    // 68010 loop mode entry: a -4 displacement targeting a
+                    // loopable one-word instruction holds the freshly
+                    // prefetched body/DBcc pair and re-executes it without
+                    // further instruction fetches.
+                    if cpu.cpu_type == CpuType::M68010
+                        && disp == -4
+                        && cpu.prefetch_count == 2
+                        && loopable_68010(cpu.prefetch_queue[0])
+                    {
+                        cpu.loop_mode = true;
+                        cpu.loop_body_word = cpu.prefetch_queue[0];
+                        cpu.loop_dbcc_word = opcode;
+                    }
                     // 68000 DBcc taken = 10. On 020+ a taken branch refills the
                     // pipeline; the flat scale alone lands the chip-RAM dbra
                     // loop at 7 clocks/iter where the cycle-exact A1200/FS-UAE

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -354,6 +354,9 @@ impl CpuCore {
     pub fn jump_vector<B: AddressBus>(&mut self, bus: &mut B, vector: u32) {
         // Any exception entry breaks an open 68060 pairing window.
         self.break_060_pipeline();
+        // Any vectored dispatch ends 68010 loop mode; the refill below
+        // restores normal instruction fetching.
+        self.loop_mode = false;
         self.last_exception_vector = Some(vector);
         let addr = (vector << 2).wrapping_add(self.vbr);
         self.pc = self.read_32(bus, addr);

--- a/crates/m68k/tests/loop_mode_timing_tests.rs
+++ b/crates/m68k/tests/loop_mode_timing_tests.rs
@@ -1,0 +1,111 @@
+//! 68010 loop-mode engagement and per-iteration timing.
+//!
+//! A DBcc that branches -4 back to a loopable one-word instruction enters
+//! loop mode: the body/DBcc pair is held in the prefetch queue and re-executed
+//! without instruction fetches until the condition turns true, the counter
+//! expires, or an exception is taken.
+
+mod common;
+
+use common::TestBus;
+use m68k::core::types::CpuType;
+use m68k::{CpuCore, StepResult};
+
+fn setup(prog: &[u16], cpu_type: CpuType) -> (CpuCore, TestBus) {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(cpu_type);
+    let mut bus = TestBus::new();
+    let mut bytes = Vec::new();
+    for w in prog {
+        bytes.extend_from_slice(&w.to_be_bytes());
+    }
+    bus.load_rom(&bytes);
+    bus.setup_boot();
+    cpu.reset(&mut bus);
+    cpu.pc = 0x10000;
+    cpu.set_sr(0x2700);
+    (cpu, bus)
+}
+
+fn step(cpu: &mut CpuCore, bus: &mut TestBus) -> i32 {
+    let mut hle = m68k::NoOpHleHandler;
+    match cpu.step_with_hle_handler(bus, &mut hle) {
+        StepResult::Ok { cycles } => cycles,
+        other => panic!("unexpected step result: {:?}", other),
+    }
+}
+
+// move.w (a4),(a5); dbra d4,-4; nop
+const MOVE_LOOP: [u16; 4] = [0x3A94, 0x51CC, 0xFFFC, 0x4E71];
+
+#[test]
+fn m68010_dbra_move_enters_loop_mode() {
+    let (mut cpu, mut bus) = setup(&MOVE_LOOP, CpuType::M68010);
+    cpu.dar[4] = 3; // D4: 4 iterations
+    cpu.dar[8 + 4] = 0x300000; // A4
+    cpu.dar[8 + 5] = 0x300100; // A5
+    bus.extra_ram.write_word(0, 0xBEEF);
+
+    let mut log = Vec::new();
+    for _ in 0..16 {
+        let pc = cpu.pc;
+        let cycles = step(&mut cpu, &mut bus);
+        log.push((pc, cycles, cpu.loop_mode));
+        if pc == 0x10006 {
+            break;
+        }
+    }
+    assert!(
+        log.iter().any(|&(_, _, lm)| lm),
+        "loop mode never engaged: {:x?}",
+        log
+    );
+    // The copy ran to completion.
+    assert_eq!(cpu.dar[4] as u16, 0xFFFF);
+    assert_eq!(bus.extra_ram.read_word(0x100), 0xBEEF);
+    // Looping DBcc iterations execute with no bus activity in 6 clocks.
+    let looped: Vec<i32> = log
+        .iter()
+        .filter(|&&(pc, _, lm)| pc == 0x10002 && lm)
+        .map(|&(_, c, _)| c)
+        .collect();
+    assert!(
+        looped.iter().any(|&c| c == 6),
+        "no 6-cycle looping DBcc seen: {:x?}",
+        log
+    );
+}
+
+#[test]
+fn m68000_dbra_does_not_enter_loop_mode() {
+    let (mut cpu, mut bus) = setup(&MOVE_LOOP, CpuType::M68000);
+    cpu.dar[4] = 3;
+    cpu.dar[8 + 4] = 0x300000;
+    cpu.dar[8 + 5] = 0x300100;
+    for _ in 0..16 {
+        step(&mut cpu, &mut bus);
+        assert!(!cpu.loop_mode);
+        if cpu.pc == 0x10006 {
+            break;
+        }
+    }
+    assert_eq!(cpu.dar[4] as u16, 0xFFFF);
+}
+
+#[test]
+fn m68010_loop_mode_not_entered_for_two_word_body() {
+    // move.w 2(a4),(a5) has an extension word: not loopable.
+    let prog: [u16; 5] = [0x3AAC, 0x0002, 0x51CC, 0xFFFA, 0x4E71];
+    let (mut cpu, mut bus) = setup(&prog, CpuType::M68010);
+    cpu.dar[4] = 3;
+    cpu.dar[8 + 4] = 0x300000;
+    cpu.dar[8 + 5] = 0x300100;
+    for _ in 0..24 {
+        step(&mut cpu, &mut bus);
+        assert!(!cpu.loop_mode);
+        if cpu.pc == 0x10008 {
+            break;
+        }
+    }
+    assert_eq!(cpu.dar[4] as u16, 0xFFFF);
+}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -37,7 +37,7 @@ range checks as the equivalent TOML fields:
 |---|---|---|
 | `--model NAME` | `[machine] profile` | `A1000`, `A500`, `A500OCS`, `A500Plus`, `A600`, `A1200`, `CDTV`, `CD32` |
 | `--chipset NAME` | `[chipset] revision` | `OCS`, `ECS`, `AGA` |
-| `--cpu MODEL` | `[cpu] model` | `68000`, `68EC020`, `68020`, `68030`, `68040`, `68060` |
+| `--cpu MODEL` | `[cpu] model` | `68000`, `68010`, `68EC020`, `68020`, `68030`, `68040`, `68060` |
 | `--cpu-clock MHZ` | `[cpu] clock_mhz` | a number of MHz |
 | `--fpu` / `--no-fpu` | `[cpu] fpu` | fit / omit a 68881/68882 |
 | `--chip SIZE` | `[memory] chip` | `512K`, `1M`, `2M`, ... |
@@ -195,7 +195,7 @@ carried no information.)
 
 ```toml
 [cpu]
-model = "68000"     # 68000, 68EC020, 68020, 68030, 68040, 68060
+model = "68000"     # 68000, 68010, 68EC020, 68020, 68030, 68040, 68060
 clock_mhz = 14.0    # optional; defaults to the model's stock speed
 # icache = false    # instruction-cache model (on by default: 020/030/040/060)
 # dcache = false    # data-cache model (on by default: 030/040/060)
@@ -207,9 +207,10 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
 #                   # instructions directly)
 ```
 
-- `model`: the 68EC020 is a 68020 instruction set with a 24-bit external
-  address bus.
-- `clock_mhz` defaults to the model's stock speed (68000 ~7.09, 020 ~14,
+- `model`: the 68010 models the vector base register, the format-stacking
+  exception model, and DBcc loop mode; the 68EC020 is a 68020 instruction
+  set with a 24-bit external address bus.
+- `clock_mhz` defaults to the model's stock speed (68000/68010 ~7.09, 020 ~14,
   030/040 ~25, 060 50) and is modelled as a whole multiple of the colour clock
   (3.546895 MHz). Fast RAM and ROM run at the CPU clock; chip and slow RAM
   stay chip-bus bound, so overclocking speeds up only what a real

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -15,9 +15,10 @@ colour clocks:
   clock (`cpu_external_access`), scaled by `cpu_clocks_per_cck` with
   sub-CCK carry so accelerated clocks bill fractional costs exactly.
 - Addresses are masked to the model's bus width: 24-bit for
-  68000/68EC020, 32-bit for 68020/030/040.
+  68000/68010/68EC020, 32-bit for 68020/030/040/060.
 
-Selectable models: 68000, 68EC020, 68020, 68030, 68040. `[cpu] fpu`
+Selectable models: 68000, 68010, 68EC020, 68020, 68030, 68040, 68060.
+`[cpu] fpu`
 fits a 68881/68882 to any 020/030 (and is on by default for the 68040,
 whose FPU is on-die): the vendored core executes the 6888x instruction
 set in true 80-bit extended precision via a pure-Rust software floating-
@@ -57,12 +58,30 @@ stale pre-write word (real MC68000 Class 1 SMC behaviour), while a taken
 branch flushes and refills the stream from the target. The queue lives in
 the backend core rather than a Copperline-side bus cache, because correct
 flushing depends on the CPU's own control flow, exceptions, and
-interrupts. It is gated to the 68000 (`prefetch_enabled`); 68010+ fetch
-directly at PC through the bus adapter. Chip-RAM probes pin both cases:
+interrupts. It is gated to the 68000 and 68010 (`prefetch_enabled`);
+68020+ fetch directly at PC through the bus adapter (their real pipelines
+hide behind the instruction cache model instead). Chip-RAM probes pin both
+cases:
 `cpu_prefetch_probe_documents_self_modified_next_opcode_behavior` (stale
 fall-through) and
 `cpu_prefetch_probe_branch_refetches_self_modified_chip_ram_target`
 (branch refetch).
+
+## 68010
+
+The 68010 shares the 68000's bus interface and two-word prefetch queue but
+adds the vector base register, the format-stacking exception model
+(format 0 four-word frames, format 8 bus/address-error frames, RTD), and
+DBcc loop mode: a DBcc that branches -4 back to a loopable one-word
+instruction holds the body/DBcc pair in the prefetch queue and re-executes
+it with no instruction fetches until the condition turns true, the counter
+expires, or an exception intervenes (`loop_mode` in
+`crates/m68k/src/core/cpu.rs`; the loopable set and the DBcc entry/exit
+arms live in `core/decode.rs`). A looping DBcc iteration costs 6 internal
+clocks and touches the bus only for the body's operands, which is what
+makes tight copy/clear loops measurably faster on a real 68010.
+`crates/m68k/tests/loop_mode_timing_tests.rs` pins engagement, the
+68000's non-engagement, and the no-fetch iteration cost.
 
 ## Caches
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -514,6 +514,7 @@ pub struct FloppyDriveConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum CpuModel {
     M68000,
+    M68010,
     M68EC020,
     M68020,
     M68030,
@@ -536,7 +537,7 @@ impl CpuModel {
     /// Fast RAM runs at the CPU clock; chip/slow RAM stays chip-bus bound.
     pub fn default_clock_mhz(self) -> f64 {
         match self {
-            CpuModel::M68000 => 7.09,
+            CpuModel::M68000 | CpuModel::M68010 => 7.09,
             CpuModel::M68EC020 | CpuModel::M68020 => 14.0,
             CpuModel::M68030 | CpuModel::M68040 => 25.0,
             CpuModel::M68060 => 50.0,
@@ -1574,10 +1575,10 @@ impl TryFrom<RawConfig> for Config {
             }
             None => cpu.default_clock_mhz(),
         };
-        if fpu && cpu == CpuModel::M68000 {
+        if fpu && matches!(cpu, CpuModel::M68000 | CpuModel::M68010) {
             errors.push(anyhow!(
                 "[cpu] fpu = true needs the 68020+ coprocessor interface; \
-                 a 68000 cannot drive a 68881/68882"
+                 a 68000/68010 cannot drive a 68881/68882"
             ));
         }
         // The on-chip caches are silicon: model them by default whenever the
@@ -2016,13 +2017,14 @@ fn parse_cpu(s: &str) -> Result<CpuModel> {
     let norm = s.trim().to_ascii_lowercase().replace(['m', '_', '-'], "");
     match norm.as_str() {
         "68000" | "000" => Ok(CpuModel::M68000),
+        "68010" | "010" => Ok(CpuModel::M68010),
         "68ec020" | "ec020" => Ok(CpuModel::M68EC020),
         "68020" | "020" => Ok(CpuModel::M68020),
         "68030" | "030" => Ok(CpuModel::M68030),
         "68040" | "040" => Ok(CpuModel::M68040),
         "68060" | "060" => Ok(CpuModel::M68060),
         _ => Err(anyhow!(
-            "unknown cpu model {:?}: expected 68000 / 68EC020 / 68020 / 68030 / 68040 / 68060",
+            "unknown cpu model {:?}: expected 68000 / 68010 / 68EC020 / 68020 / 68030 / 68040 / 68060",
             s
         )),
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2645,6 +2645,7 @@ impl crate::debugger::BreakContext for MachineBreakContext<'_> {
 fn cpu_type_for_model(model: CpuModel) -> CpuType {
     match model {
         CpuModel::M68000 => CpuType::M68000,
+        CpuModel::M68010 => CpuType::M68010,
         CpuModel::M68EC020 => CpuType::M68EC020,
         CpuModel::M68020 => CpuType::M68020,
         CpuModel::M68030 => CpuType::M68030,
@@ -2668,7 +2669,7 @@ fn cache_lines_for_cpu_type(cpu_type: CpuType) -> usize {
 
 fn address_mask_for_model(model: CpuModel) -> u32 {
     match model {
-        CpuModel::M68000 | CpuModel::M68EC020 => ADDRESS_MASK_24BIT,
+        CpuModel::M68000 | CpuModel::M68010 | CpuModel::M68EC020 => ADDRESS_MASK_24BIT,
         CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040 | CpuModel::M68060 => {
             ADDRESS_MASK_32BIT
         }

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -78,7 +78,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      for rows whose fetch diverges from the register-derived window)
 //  17: DisplaySpriteDmaState gained the two-slot sprite fetch fields
 //      (data_words_fetched pointer progression, pending_data)
-pub const STATE_VERSION: u32 = 20;
+//  21: CpuCore gained the 68010 loop-mode state (loop_mode,
+//      loop_body_word, loop_dbcc_word)
+pub const STATE_VERSION: u32 = 21;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -451,8 +451,9 @@ const DENISE_CHOICES: [Option<DeniseRevision>; 4] = [
     Some(DeniseRevision::AgaLisa),
 ];
 const VIDEO_CHOICES: [VideoStandard; 2] = [VideoStandard::Pal, VideoStandard::Ntsc];
-const CPUS: [CpuModel; 6] = [
+const CPUS: [CpuModel; 7] = [
     CpuModel::M68000,
+    CpuModel::M68010,
     CpuModel::M68EC020,
     CpuModel::M68020,
     CpuModel::M68030,
@@ -1745,6 +1746,7 @@ fn chipset_name(chipset: Chipset) -> &'static str {
 fn cpu_name(cpu: CpuModel) -> &'static str {
     match cpu {
         CpuModel::M68000 => "68000",
+        CpuModel::M68010 => "68010",
         CpuModel::M68EC020 => "68EC020",
         CpuModel::M68020 => "68020",
         CpuModel::M68030 => "68030",

--- a/tests/vamiga_ts.rs
+++ b/tests/vamiga_ts.rs
@@ -11,17 +11,31 @@ mod envcfg;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 struct VAmigaTsCase {
     name: String,
+    /// Output-relative path (directory of the case + the retrosh stem), so
+    /// multiple shipped scripts per ADF (OCS/ECS/68010 variants) get
+    /// distinct artifacts.
     rel_path: PathBuf,
     adf_path: PathBuf,
+    /// vAmiga regression setup from the shipped .retrosh (machine model);
+    /// mirrored onto the Copperline config's chipset revision.
+    setup: String,
+    /// CPU revision from the script's `cpu set revision` line (68000 when
+    /// absent); mirrored onto both emulators.
+    cpu: String,
+    /// `wait N seconds` from the shipped script (COPPERLINE_VAMIGATS_SECONDS
+    /// still overrides globally when set).
+    seconds: Option<f32>,
 }
 
 #[derive(Debug)]
 struct VAmigaReference {
     executable: PathBuf,
-    setup: String,
+    /// COPPERLINE_VAMIGATS_VAMIGA_SETUP override; when unset each case runs
+    /// on the machine its shipped script names.
+    setup_override: Option<String>,
 }
 
 #[test]
@@ -77,11 +91,12 @@ fn run_vamiga_ts_adf_screenshots() -> TestResult {
         .into());
     }
 
-    let seconds = envcfg::var("COPPERLINE_VAMIGATS_SECONDS")
+    // A global COPPERLINE_VAMIGATS_SECONDS overrides everything; otherwise
+    // each case uses its shipped script's wait time (default 9s).
+    let seconds_override = envcfg::var("COPPERLINE_VAMIGATS_SECONDS")
         .map(|s| s.parse::<f32>())
         .transpose()
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?
-        .unwrap_or(9.0);
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     let out_root = env_path("COPPERLINE_VAMIGATS_OUT")
         .unwrap_or_else(|| unique_temp_dir("copperline-vamigats"));
     fs::create_dir_all(&out_root)?;
@@ -90,17 +105,17 @@ fn run_vamiga_ts_adf_screenshots() -> TestResult {
     let vamiga_reference =
         env_path("COPPERLINE_VAMIGATS_VAMIGA").map(|executable| VAmigaReference {
             executable,
-            setup: envcfg::var("COPPERLINE_VAMIGATS_VAMIGA_SETUP")
-                .unwrap_or_else(|| "A500_OCS_1MB".to_string()),
+            setup_override: envcfg::var("COPPERLINE_VAMIGATS_VAMIGA_SETUP"),
         });
 
     eprintln!(
-        "running {} vAmigaTS case(s) from {} for {seconds:.1}s each; output {}",
+        "running {} vAmigaTS case(s) from {}; output {}",
         cases.len(),
         root.display(),
         out_root.display()
     );
     for case in cases {
+        let seconds = seconds_override.or(case.seconds).unwrap_or(9.0);
         run_case(
             env!("CARGO_BIN_EXE_copperline"),
             &kick13,
@@ -131,7 +146,10 @@ fn run_case(
     if let Some(parent) = cfg_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&cfg_path, copperline_config(kick13, &case.adf_path))?;
+    fs::write(
+        &cfg_path,
+        copperline_config(kick13, &case.adf_path, &case.setup, &case.cpu),
+    )?;
 
     let output = Command::new(emulator)
         .env("COPPERLINE_HCENTER", "0")
@@ -202,7 +220,14 @@ fn run_vamiga_reference(
         }
         fs::write(
             &script_path,
-            vamiga_retroshell_script(&reference.setup, &tmp_kick, &tmp_adf, seconds, &stem),
+            vamiga_retroshell_script(
+                reference.setup_override.as_deref().unwrap_or(&case.setup),
+                &case.cpu,
+                &tmp_kick,
+                &tmp_adf,
+                seconds,
+                &stem,
+            ),
         )?;
 
         let output = Command::new(&reference.executable)
@@ -248,7 +273,15 @@ fn run_vamiga_reference(
     result
 }
 
-fn copperline_config(kick13: &Path, adf: &Path) -> String {
+fn copperline_config(kick13: &Path, adf: &Path, setup: &str, cpu: &str) -> String {
+    // Mirror the vAmiga regression setup: *_ECS_*/*_PLUS_* machines use the
+    // ECS chipset, everything else OCS; the CPU revision comes from the
+    // shipped script's `cpu set revision` line.
+    let revision = if setup.contains("_ECS_") || setup.contains("_PLUS_") {
+        "ECS"
+    } else {
+        "OCS"
+    };
     format!(
         r#"rom = {}
 
@@ -263,7 +296,7 @@ overscan = "full"
 speed = "turbo"
 
 [cpu]
-model = "68000"
+model = "{cpu}"
 fpu = false
 
 [memory]
@@ -272,7 +305,7 @@ fast = "0"
 slow = "512K"
 
 [chipset]
-revision = "OCS"
+revision = "{revision}"
 video = "PAL"
 
 [floppy.df0]
@@ -291,10 +324,40 @@ fn discover_adf_cases(root: &Path) -> TestResult<Vec<VAmigaTsCase>> {
     Ok(cases)
 }
 
+/// Parse a shipped vAmigaTS RetroShell regression script: the machine setup,
+/// an optional `cpu set revision` line, the ADF it runs, and the wait time.
+fn parse_shipped_retrosh(
+    text: &str,
+) -> (Option<String>, Option<String>, Option<String>, Option<f32>) {
+    let mut setup = None;
+    let mut cpu = None;
+    let mut adf = None;
+    let mut seconds = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("regression setup ") {
+            setup = rest.split_whitespace().next().map(str::to_owned);
+        } else if let Some(rest) = line.strip_prefix("cpu set revision ") {
+            cpu = rest.split_whitespace().next().map(str::to_owned);
+        } else if let Some(rest) = line.strip_prefix("regression run ") {
+            adf = rest
+                .split_whitespace()
+                .next()
+                .and_then(|p| Path::new(p).file_name())
+                .map(|n| n.to_string_lossy().into_owned());
+        } else if let Some(rest) = line.strip_prefix("wait ") {
+            seconds = rest.split_whitespace().next().and_then(|n| n.parse().ok());
+        }
+    }
+    (setup, cpu, adf, seconds)
+}
+
 fn collect_adf_cases(root: &Path, dir: &Path, cases: &mut Vec<VAmigaTsCase>) -> TestResult {
     let mut entries = fs::read_dir(dir)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.path());
-    for entry in entries {
+    let mut adfs_with_scripts: Vec<PathBuf> = Vec::new();
+    let mut bare_adfs: Vec<PathBuf> = Vec::new();
+    for entry in &entries {
         let file_type = entry.file_type()?;
         let path = entry.path();
         if file_type.is_dir() {
@@ -303,7 +366,58 @@ fn collect_adf_cases(root: &Path, dir: &Path, cases: &mut Vec<VAmigaTsCase>) -> 
             }
             continue;
         }
-        if !file_type.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("adf") {
+        if !file_type.is_file() {
+            continue;
+        }
+        match path.extension().and_then(|ext| ext.to_str()) {
+            Some("adf") => bare_adfs.push(path),
+            // Shipped scripts drive the case's machine/CPU/duration; skip the
+            // harness's own generated reference scripts.
+            Some("retrosh") if !path.to_string_lossy().ends_with(".vamiga.retrosh") => {
+                let text = fs::read_to_string(&path)?;
+                let (setup, cpu, adf_name, seconds) = parse_shipped_retrosh(&text);
+                let Some(adf_name) = adf_name else { continue };
+                // The suite's Makefile copies the case's shipped ADF to
+                // /tmp/<script-stem>.adf before running, so the script's ADF
+                // name rarely matches the shipped file. Resolve to the named
+                // file when present, otherwise to the directory's ADF.
+                let named = dir.join(&adf_name);
+                let adf_path = if named.exists() {
+                    named
+                } else {
+                    let mut adfs = fs::read_dir(dir)?
+                        .filter_map(|e| e.ok())
+                        .map(|e| e.path())
+                        .filter(|p| p.extension().and_then(|ext| ext.to_str()) == Some("adf"))
+                        .collect::<Vec<_>>();
+                    adfs.sort();
+                    match adfs.into_iter().next() {
+                        Some(p) => p,
+                        None => continue,
+                    }
+                };
+                let rel_path = path.strip_prefix(root)?.with_extension("");
+                let name = rel_path
+                    .components()
+                    .map(|component| component.as_os_str().to_string_lossy().into_owned())
+                    .collect::<Vec<String>>()
+                    .join("/");
+                adfs_with_scripts.push(adf_path.clone());
+                cases.push(VAmigaTsCase {
+                    name,
+                    rel_path: rel_path.with_extension("adf"),
+                    adf_path,
+                    setup: setup.unwrap_or_else(|| "A500_OCS_1MB".to_owned()),
+                    cpu: cpu.unwrap_or_else(|| "68000".to_owned()),
+                    seconds,
+                });
+            }
+            _ => {}
+        }
+    }
+    // ADFs without any shipped script keep the old default-machine behaviour.
+    for path in bare_adfs {
+        if adfs_with_scripts.contains(&path) {
             continue;
         }
         let rel_path = path.strip_prefix(root)?.to_path_buf();
@@ -317,6 +431,9 @@ fn collect_adf_cases(root: &Path, dir: &Path, cases: &mut Vec<VAmigaTsCase>) -> 
             name,
             rel_path,
             adf_path: path,
+            setup: "A500_OCS_1MB".to_owned(),
+            cpu: "68000".to_owned(),
+            seconds: None,
         });
     }
     Ok(())
@@ -324,14 +441,24 @@ fn collect_adf_cases(root: &Path, dir: &Path, cases: &mut Vec<VAmigaTsCase>) -> 
 
 fn vamiga_retroshell_script(
     setup: &str,
+    cpu: &str,
     kick13: &Path,
     adf: &Path,
     seconds: f32,
     screenshot_stem: &str,
 ) -> String {
+    // vAmiga 4.4's RetroShell registers option setters under the option's
+    // uppercase key: `cpu set REVISION 68010` (the suite's shipped scripts
+    // use an older lowercase syntax).
+    let cpu_line = if cpu == "68000" {
+        String::new()
+    } else {
+        format!("cpu set REVISION {cpu}\n")
+    };
     format!(
         "# Regression reference script generated by Copperline\n\
          regression setup {setup} {}\n\
+         {cpu_line}\
          regression run {}\n\
          wait {} seconds\n\
          screenshot save {screenshot_stem}\n",
@@ -505,6 +632,7 @@ fn discover_adf_cases_finds_nested_tests_in_sorted_order() -> TestResult {
 fn vamiga_retroshell_script_uses_temp_paths_and_setup() {
     let script = vamiga_retroshell_script(
         "A500_OCS_1MB",
+        "68010",
         Path::new("/tmp/kick13.rom"),
         Path::new("/tmp/bbusy0.adf"),
         9.0,
@@ -512,6 +640,7 @@ fn vamiga_retroshell_script_uses_temp_paths_and_setup() {
     );
 
     assert!(script.contains("regression setup A500_OCS_1MB /tmp/kick13.rom"));
+    assert!(script.contains("cpu set REVISION 68010"));
     assert!(script.contains("regression run /tmp/bbusy0.adf"));
     assert!(script.contains("wait 9 seconds"));
     assert!(script.contains("screenshot save bbusy0"));
@@ -523,6 +652,9 @@ fn vamiga_temp_stem_keeps_shell_word_characters() {
         name: "Agnus/Blitter/test case/test case".to_string(),
         rel_path: PathBuf::from("Agnus/Blitter/test case/test case.adf"),
         adf_path: PathBuf::from("/suite/Agnus/Blitter/test case/test case.adf"),
+        setup: "A500_OCS_1MB".to_string(),
+        cpu: "68000".to_string(),
+        seconds: None,
     };
 
     let stem = vamiga_temp_stem(&case);


### PR DESCRIPTION
## Summary

Adds a selectable 68010 to Copperline and makes the vAmigaTS harness honor the suite's shipped RetroShell scripts, so the CPU/68010 families now actually run on a 68010.

### Vendored core (crates/m68k)
- **Prefetch queue on the 68010**: it shares the 68000's two-word IRD/IRC queue. Without it, KS1.3's $F00000 diagnostic probe false-matches (the CMPI immediate floats in from the open bus) and the ROM never boots.
- **Exception-return refills**: 68010 RTE (format 0) and RTD returned with a stale queue; both now refill after pulling the new PC. RTE also handles the format-8 29-word bus/address-error frame instead of raising a format error.
- **MOVEC** read its extension word around the queue, executing the queued copy as the next opcode (caught by the existing `test_m68010_vbr` fixture); both directions now consume through `read_imm_16`.
- **DBcc loop mode**: a DBcc branching -4 to a loopable one-word instruction holds the body/DBcc pair in the queue and re-executes with no instruction fetches (6 internal clocks per looping iteration; exits refill from the fall-through path; any vectored dispatch drops the mode). Loopable set per the M68000UM loop-mode table. New `loop_mode_timing_tests` pin engagement, 68000 non-engagement, the 6-clock iteration, and two-word-body rejection.

### Copperline
- `[cpu] model = "68010"` end to end (config, launcher picker, 24-bit mask, ~7.09 MHz stock clock, no caches, fpu = true rejected like the 68000); docs updated.
- STATE_VERSION 21 (CpuCore gained the loop-mode state).

### vAmigaTS harness
- Cases are now derived from the shipped `.retrosh` scripts: regression setup -> chipset revision, `cpu set revision` -> CPU model on both emulators, `wait N seconds` -> per-case runtime. Previously everything ran as an OCS 68000 for a fixed 9s, so the 68010 families compared a 68000 against a 68010 reference.

## Verification
- cputest 68010 sweep: all tests complete; `cargo test --release --lib` 1322 green; all compiling m68k crate test bins green (including the four m68010 fixtures).
- KS1.3 boots to the insert-disk screen on the 68010; loop mode engages in the ROM's dbra loops and the vAmigaTS Loopmode bodies.
- Demo byte-identity (phooey / tomato / roots-ecs / roots-aga / zool at 4s+8s): byte-identical.
- CPU/68010 family (38 cases) vs vAmiga 4.4 refs: 42.56% avg, dominated by the known CPU-write-landing class (loop mode itself is metric-neutral there; the wedge-shaped band offsets match that class's signature).
- `cargo clippy --all-targets --all-features --locked -- -D warnings` and `cargo fmt --check` clean.