### PR TITLE
cia: model the 8520 IRQ pin delay per source (timers same E-cycle)

### DIFF
--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -556,6 +556,9 @@ fn cia_b_mask_enable_propagates_latched_timer_interrupt_to_paula() {
 
     let _ = bus.cia_b_write(addr(REG_ICR), 1, 0x80 | 0x01);
 
+    // The pin (and so INTREQ) follows the mask write one E-cycle later.
+    assert_eq!(bus.paula.intreq & INT_EXTER, 0);
+    bus.advance_devices(8);
     assert_ne!(bus.paula.intreq & INT_EXTER, 0);
 }
 
@@ -9111,8 +9114,10 @@ fn keyboard_bit_stream_delivers_encoded_transition_to_sdr() {
     // Half a byte: no SP interrupt yet.
     bus.advance_devices(KEYBOARD_BYTE_CCK / 2);
     assert_eq!(bus.paula.intreq & INT_PORTS, 0);
-    // The full byte arrives bit by bit over KCLK/KDAT.
+    // The full byte arrives bit by bit over KCLK/KDAT; the CIA pin edge
+    // follows one E-cycle behind the final shift.
     bus.advance_devices(2 * KEYBOARD_BYTE_CCK);
+    bus.advance_devices(8);
     assert_ne!(bus.paula.intreq & INT_PORTS, 0);
     assert_eq!(bus.cia_a.read(crate::chipset::cia::REG_SDR), 0xFD);
 }

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -1292,7 +1292,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn probe_pin_drain_after_sdr_arm() {
         let mut cia = Cia::new(Which::A);
         cia.write(REG_ICR, 0x88); // enable SP

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -819,6 +819,14 @@ impl Cia {
         self.irq_pin
     }
 
+    /// Test-harness stand-in for the E-clock passing: settle a pending
+    /// pin assert whose lag the caller's own timekeeping already covers
+    /// (the bus drains through `tick`; timers are not advanced here).
+    #[cfg(test)]
+    pub fn settle_irq_pin(&mut self) -> bool {
+        self.drain_irq_pin_delay(u32::from(u8::MAX))
+    }
+
     fn update_irq_line(&mut self) {
         if self.icr_data & self.icr_mask & 0x1F != 0 {
             if self.icr_data & ICR_IR == 0 {
@@ -1027,8 +1035,10 @@ mod tests {
             .into_iter()
             .enumerate()
         {
-            let irq = cia.cnt_rising_edge(bit);
+            let _ = cia.cnt_rising_edge(bit);
             cia.cnt_falling_edge();
+            // The pin lags the internal latch by one E-cycle.
+            let irq = cia.settle_irq_pin();
             assert_eq!(irq, i == 7, "IRQ only on the 8th bit (bit {i})");
         }
         assert_eq!(cia.read(REG_SDR), 0xA5);
@@ -1049,8 +1059,9 @@ mod tests {
         // interrupt exactly on the 8th.
         cia.write(REG_CRA, 0);
         for i in 0..8 {
-            let fired = cia.cnt_rising_edge(i % 2 == 0);
+            let _ = cia.cnt_rising_edge(i % 2 == 0);
             cia.cnt_falling_edge();
+            let fired = cia.settle_irq_pin();
             assert_eq!(fired, i == 7, "SP must latch exactly on edge 8 (edge {i})");
         }
         assert_eq!(cia.read(REG_SDR), 0xAA);
@@ -1079,6 +1090,7 @@ mod tests {
         assert_eq!(cia.ta_count, 0);
         cia.write(REG_PRA, 0x00);
         cia.write(REG_PRA, 0xFF); // underflow edge
+        let _ = cia.settle_irq_pin();
         assert!(
             cia.irq_line_asserted(),
             "underflow must assert the IRQ line"
@@ -1108,8 +1120,9 @@ mod tests {
         let mut edges = 0;
         let fired = loop {
             edges += 1;
-            let fired = cia.cnt_rising_edge(true);
+            let _ = cia.cnt_rising_edge(true);
             cia.cnt_falling_edge();
+            let fired = cia.settle_irq_pin();
             if fired || edges > 16 {
                 break fired;
             }
@@ -1279,6 +1292,21 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn probe_pin_drain_after_sdr_arm() {
+        let mut cia = Cia::new(Which::A);
+        cia.write(REG_ICR, 0x88); // enable SP
+                                  // SPMODE=0 input; shift 8 bits in via CNT.
+        for _ in 0..8 {
+            let _ = cia.cnt_rising_edge(true);
+            cia.cnt_falling_edge();
+        }
+        assert!(!cia.irq_line_asserted(), "pin must lag the ICR condition");
+        assert!(cia.tick(1), "one E-cycle later the pin asserts");
+        assert!(cia.irq_line_asserted());
+    }
+
+    #[test]
     fn flag_input_latches_icr_and_respects_mask() {
         let mut cia = Cia::new(Which::B);
 
@@ -1289,7 +1317,11 @@ mod tests {
 
         cia.write(REG_ICR, 0x80 | ICR_FLG);
         cia.release_flag();
-        assert!(cia.assert_flag());
+        let _ = cia.assert_flag();
+        assert!(
+            cia.settle_irq_pin(),
+            "FLAG edge reaches the pin an E-cycle later"
+        );
         assert_eq!(cia.read(REG_ICR), ICR_IR | ICR_FLG);
     }
 
@@ -1306,6 +1338,8 @@ mod tests {
 
         cia.write(REG_ICR, 0x80 | ICR_TA);
 
+        assert!(!cia.irq_line_asserted(), "the pin lags the mask write");
+        assert!(cia.settle_irq_pin());
         assert!(cia.irq_line_asserted());
         assert_eq!(cia.read(REG_ICR), ICR_IR | ICR_TA);
     }

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -42,14 +42,20 @@ pub struct Cia {
     ///   bit 0 TA, 1 TB, 2 ALRM, 3 SP, 4 FLG, 7 IR
     /// Reading ICR returns this and then clears all bits (including IR).
     icr_data: u8,
-    /// The external /IRQ pin, which lags the internal interrupt condition
-    /// by one E-clock cycle (the 6526-family one-cycle interrupt delay:
-    /// the ICR IR bit sets at the triggering E-cycle, the pin asserts on
-    /// the next). `irq_pin_delay_eticks` counts down the remaining lag.
+    /// The external /IRQ pin. Timer underflows drive it in the SAME
+    /// E-cycle as the underflow; TOD/FLAG/serial latches and ICR mask
+    /// writes lag one E-cycle (the 6526-family interrupt delay, vAmiga
+    /// CIASetInt1 vs CIASetInt0). `irq_pin_delay_eticks` counts down
+    /// the remaining lag of a pending delayed assert.
     #[serde(default)]
     irq_pin: bool,
     #[serde(default)]
     irq_pin_delay_eticks: u8,
+    /// An ICR read is in flight in the current E-cycle: a timer
+    /// underflow racing it asserts the pin one E-cycle late instead of
+    /// in the same cycle (vAmiga CIAReadIcr0 gating triggerTimerIrq).
+    #[serde(default)]
+    icr_read_race: bool,
     /// ICR mask: which sources are allowed to raise IR.
     icr_mask: u8,
     /// Serial Data Register. The Amiga keyboard wires its data line
@@ -155,6 +161,7 @@ impl Cia {
             icr_data: 0,
             irq_pin: false,
             irq_pin_delay_eticks: 0,
+            icr_read_race: false,
             icr_mask: 0,
             sdr: 0,
             sdr_out: None,
@@ -226,8 +233,10 @@ impl Cia {
     }
 
     /// Advance the 24-bit TOD counter by one tick. CIA-A is ticked
-    /// once per VSYNC, CIA-B once per HSYNC. Returns true if the
-    /// CIA's IR line just asserted (alarm match with mask enabled).
+    /// once per VSYNC, CIA-B once per HSYNC. An alarm match latches
+    /// ICR.ALRM; the /IRQ pin follows one E-cycle later from the
+    /// `tick` drain, so this returns false (kept for signature parity
+    /// with the pin-edge sources the bus forwards to INTREQ).
     pub fn tick_tod(&mut self) -> bool {
         if self.tod_stopped {
             return false;
@@ -265,7 +274,9 @@ impl Cia {
     }
 
     /// Alarm comparator: latch ICR.ALRM on the transition into equality
-    /// (see `tod_matching`). Returns true if the CIA IR line just asserted.
+    /// (see `tod_matching`). The alarm is a delayed source: the /IRQ pin
+    /// follows one E-cycle later, surfacing from the `tick` drain, so
+    /// this always returns false (no immediate pin edge).
     fn tod_check_alarm(&mut self) -> bool {
         let equal = self.tod_count == self.tod_alarm;
         let fired = !self.tod_matching && equal;
@@ -273,13 +284,7 @@ impl Cia {
         if !fired {
             return false;
         }
-        self.icr_data |= ICR_ALRM;
-        if self.icr_mask & ICR_ALRM == 0 {
-            return false;
-        }
-        let was_ir = self.icr_data & ICR_IR != 0;
-        self.icr_data |= ICR_IR;
-        !was_ir
+        self.latch_interrupts(ICR_ALRM)
     }
 
     /// Anchor the TOD counter to the current raster line. The emulator
@@ -295,8 +300,8 @@ impl Cia {
     }
 
     /// Snap an anchored TOD counter to the exact frame-boundary value.
-    /// Returns true if this frame-boundary update asserted the CIA IR
-    /// line via a TOD alarm.
+    /// An alarm match latches ICR.ALRM; the pin edge follows an E-cycle
+    /// later from the `tick` drain (see `tick_tod`).
     pub fn sync_tod_to_frame(&mut self, lines_per_frame: u32) -> bool {
         if self.tod_stopped {
             return false;
@@ -396,6 +401,9 @@ impl Cia {
                 self.icr_data = 0;
                 self.irq_pin = false;
                 self.irq_pin_delay_eticks = 0;
+                // A timer underflow in this same E-cycle loses the race
+                // and asserts the pin one E-cycle late.
+                self.icr_read_race = true;
                 v
             }
             _ => self.regs[reg],
@@ -617,8 +625,10 @@ impl Cia {
     }
 
     /// Advance both timers by `ticks` (CIA PHI2 cycles = CPU/10).
-    /// Returns true if any timer underflowed AND its source bit is
-    /// enabled in the mask - i.e. the CIA's IRQ line just asserted.
+    /// Returns true if the external /IRQ pin asserted during this span,
+    /// either from a masked-in timer underflow (same E-cycle) or from a
+    /// delayed source (TOD/FLAG/serial/mask write) whose one-E-cycle
+    /// lag drains here.
     pub fn tick(&mut self, ticks: u32) -> bool {
         // Zero E-clock ticks advance nothing: timer A needs ticks > 0, the
         // SDR shifter and timer B only move on timer-A underflows (or CNT,
@@ -628,24 +638,23 @@ impl Cia {
         if ticks == 0 {
             return false;
         }
-        // The external pin lags the internal condition by one E-cycle:
-        // edges armed earlier (by timers, CNT, FLAG, SDR, TOD, or mask
+        // Delayed asserts armed earlier (by FLAG, SDR, TOD, or mask
         // writes) surface here on the E-clock grid.
         let mut pin_edge = self.drain_irq_pin_delay(ticks);
-        let mut fired_mask: u8 = 0;
+        let mut timer_mask: u8 = 0;
         let mut ta_underflows = 0;
         if self.ta_running && !self.ta_counts_cnt && ticks > 0 {
             ta_underflows = advance(&mut self.ta_count, self.ta_latch, ticks);
-            fired_mask |= u8::from(ta_underflows != 0) * ICR_TA;
-            if fired_mask & ICR_TA != 0 && self.ta_oneshot {
+            timer_mask |= u8::from(ta_underflows != 0) * ICR_TA;
+            if timer_mask & ICR_TA != 0 && self.ta_oneshot {
                 self.ta_running = false;
                 self.regs[REG_CRA] &= !0x01;
             }
-            if fired_mask & ICR_TA != 0 {
+            if timer_mask & ICR_TA != 0 {
                 self.update_timer_a_pb_output();
             }
         }
-        fired_mask |= self.tick_sdr_output(ta_underflows);
+        let sp_mask = self.tick_sdr_output(ta_underflows);
         let tb_ticks = match self.tb_input_mode {
             TimerBInputMode::Phi2 => ticks,
             TimerBInputMode::Cnt => 0,
@@ -660,19 +669,24 @@ impl Cia {
         };
         if self.tb_running && tb_ticks > 0 {
             let tb_underflows = advance(&mut self.tb_count, self.tb_latch, tb_ticks);
-            fired_mask |= u8::from(tb_underflows != 0) * ICR_TB;
-            if fired_mask & ICR_TB != 0 && self.tb_oneshot {
+            timer_mask |= u8::from(tb_underflows != 0) * ICR_TB;
+            if timer_mask & ICR_TB != 0 && self.tb_oneshot {
                 self.tb_running = false;
                 self.regs[REG_CRB] &= !0x01;
             }
-            if fired_mask & ICR_TB != 0 {
+            if timer_mask & ICR_TB != 0 {
                 self.update_timer_b_pb_output();
             }
         }
-        let _ = self.latch_interrupts(fired_mask);
-        // A latch from this call's final E-cycle asserts the pin at the
-        // NEXT E-cycle, so it does not fold into this call's edge.
+        // Timer underflows drive the pin in the same E-cycle; serial
+        // completion is a delayed source.
+        pin_edge |= self.latch_timer_interrupts(timer_mask);
+        let _ = self.latch_interrupts(sp_mask);
+        // A delayed arm from this call's final E-cycle asserts the pin
+        // at the NEXT E-cycle, so it does not fold into this call's edge.
         pin_edge |= self.drain_irq_pin_delay(ticks.saturating_sub(1));
+        // Any ICR-read race window ends with the E-cycle covered here.
+        self.icr_read_race = false;
         pin_edge
     }
 
@@ -702,10 +716,11 @@ impl Cia {
     // keyboard MCU's KCLK line (CIA-A) and the PA1-to-CNT parallel-port
     // board tie (CIA-B) through cnt_rising_edge.
     fn pulse_cnt(&mut self) -> bool {
-        let mut fired_mask = 0;
+        let mut timer_mask = 0;
+        let mut sp_mask = 0;
         if self.ta_running && self.ta_counts_cnt {
             let ta_underflows = advance(&mut self.ta_count, self.ta_latch, 1);
-            fired_mask |= u8::from(ta_underflows != 0) * ICR_TA;
+            timer_mask |= u8::from(ta_underflows != 0) * ICR_TA;
             if ta_underflows != 0 && self.ta_oneshot {
                 self.ta_running = false;
                 self.regs[REG_CRA] &= !0x01;
@@ -713,7 +728,7 @@ impl Cia {
             if ta_underflows != 0 {
                 self.update_timer_a_pb_output();
             }
-            fired_mask |= self.tick_sdr_output(ta_underflows);
+            sp_mask |= self.tick_sdr_output(ta_underflows);
             if self.tb_running
                 && matches!(
                     self.tb_input_mode,
@@ -723,7 +738,7 @@ impl Cia {
                 && ta_underflows != 0
             {
                 let tb_underflows = advance(&mut self.tb_count, self.tb_latch, ta_underflows);
-                fired_mask |= u8::from(tb_underflows != 0) * ICR_TB;
+                timer_mask |= u8::from(tb_underflows != 0) * ICR_TB;
                 if tb_underflows != 0 {
                     self.update_timer_b_pb_output();
                 }
@@ -731,7 +746,7 @@ impl Cia {
         }
         if self.tb_running && self.tb_input_mode == TimerBInputMode::Cnt {
             let tb_underflows = advance(&mut self.tb_count, self.tb_latch, 1);
-            fired_mask |= u8::from(tb_underflows != 0) * ICR_TB;
+            timer_mask |= u8::from(tb_underflows != 0) * ICR_TB;
             if tb_underflows != 0 && self.tb_oneshot {
                 self.tb_running = false;
                 self.regs[REG_CRB] &= !0x01;
@@ -740,7 +755,9 @@ impl Cia {
                 self.update_timer_b_pb_output();
             }
         }
-        self.latch_interrupts(fired_mask)
+        let edge = self.latch_timer_interrupts(timer_mask);
+        let _ = self.latch_interrupts(sp_mask);
+        edge
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -771,6 +788,11 @@ impl Cia {
         ICR_SP
     }
 
+    /// Latch delayed interrupt sources (TOD alarm, FLAG, serial): the
+    /// external pin follows one E-cycle later (vAmiga CIASetInt0), so
+    /// no immediate edge is ever returned; it surfaces from the `tick`
+    /// drain. The constant false keeps the signature parallel with
+    /// `latch_timer_interrupts` for callers that forward the edge.
     fn latch_interrupts(&mut self, fired_mask: u8) -> bool {
         if fired_mask == 0 {
             return false;
@@ -785,6 +807,32 @@ impl Cia {
             }
         }
         false
+    }
+
+    /// Latch timer-underflow sources: the underflow drives the pin in
+    /// the SAME E-cycle (vAmiga CIASetInt1) and the edge is returned to
+    /// the caller now -- unless the underflow races an ICR read in this
+    /// E-cycle, which pushes the assert one E-cycle out like a delayed
+    /// source (vAmiga CIAReadIcr0 gating triggerTimerIrq).
+    fn latch_timer_interrupts(&mut self, fired_mask: u8) -> bool {
+        if fired_mask == 0 {
+            return false;
+        }
+        self.icr_data |= fired_mask;
+        if fired_mask & self.icr_mask == 0 {
+            return false;
+        }
+        self.icr_data |= ICR_IR;
+        if self.icr_read_race {
+            self.arm_irq_pin();
+            return false;
+        }
+        if self.irq_pin {
+            return false;
+        }
+        self.irq_pin = true;
+        self.irq_pin_delay_eticks = 0;
+        true
     }
 
     /// The internal interrupt condition just asserted: the external pin
@@ -1089,8 +1137,7 @@ mod tests {
         cia.write(REG_PRA, 0xFF);
         assert_eq!(cia.ta_count, 0);
         cia.write(REG_PRA, 0x00);
-        cia.write(REG_PRA, 0xFF); // underflow edge
-        let _ = cia.settle_irq_pin();
+        cia.write(REG_PRA, 0xFF); // underflow edge asserts the pin same-cycle
         assert!(
             cia.irq_line_asserted(),
             "underflow must assert the IRQ line"
@@ -1120,9 +1167,9 @@ mod tests {
         let mut edges = 0;
         let fired = loop {
             edges += 1;
-            let _ = cia.cnt_rising_edge(true);
+            // A timer underflow asserts the pin on the same edge.
+            let fired = cia.cnt_rising_edge(true);
             cia.cnt_falling_edge();
-            let fired = cia.settle_irq_pin();
             if fired || edges > 16 {
                 break fired;
             }
@@ -1253,8 +1300,13 @@ mod tests {
         cia.write(REG_TODLO, 0x20);
         let _ = cia.read(REG_ICR);
 
-        assert!(cia.tick_tod());
+        assert!(!cia.tick_tod(), "the pin lags the alarm latch");
         assert_eq!(cia.tod_count, 0x000021);
+        assert!(!cia.irq_line_asserted());
+        assert!(
+            cia.settle_irq_pin(),
+            "the alarm reaches the pin an E-cycle later"
+        );
         assert_eq!(cia.read(REG_ICR) & (ICR_ALRM | ICR_IR), ICR_ALRM | ICR_IR);
     }
 
@@ -1289,6 +1341,40 @@ mod tests {
         cia.tod_count = 0x778899;
         assert_eq!(cia.read(REG_TODMID), 0x88);
         assert_eq!(cia.read(REG_TODLO), 0x99);
+    }
+
+    #[test]
+    fn timer_underflow_asserts_pin_in_same_e_cycle() {
+        // vAmiga CIASetInt1: a timer underflow pulls the pin down in the
+        // E-cycle of the underflow itself, with no one-cycle lag.
+        let mut cia = Cia::new(Which::A);
+        cia.write(REG_ICR, 0x80 | ICR_TA);
+        cia.write(REG_TALO, 3);
+        cia.write(REG_TAHI, 0);
+        cia.write(REG_CRA, 0x01);
+
+        assert!(!cia.tick(3));
+        assert!(!cia.irq_line_asserted());
+        assert!(cia.tick(1), "underflow must assert the pin same-cycle");
+        assert!(cia.irq_line_asserted());
+    }
+
+    #[test]
+    fn icr_read_race_delays_timer_pin_by_one_e_cycle() {
+        // vAmiga CIAReadIcr0: a timer underflow in the same E-cycle as
+        // an ICR read asserts the pin one E-cycle late.
+        let mut cia = Cia::new(Which::A);
+        cia.write(REG_ICR, 0x80 | ICR_TA);
+        cia.write(REG_TALO, 3);
+        cia.write(REG_TAHI, 0);
+        cia.write(REG_CRA, 0x01);
+
+        assert!(!cia.tick(3));
+        let _ = cia.read(REG_ICR); // the read the underflow races
+        assert!(!cia.tick(1), "racing underflow must not assert same-cycle");
+        assert!(!cia.irq_line_asserted());
+        assert!(cia.tick(1), "the assert lands one E-cycle later");
+        assert!(cia.irq_line_asserted());
     }
 
     #[test]

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -42,6 +42,14 @@ pub struct Cia {
     ///   bit 0 TA, 1 TB, 2 ALRM, 3 SP, 4 FLG, 7 IR
     /// Reading ICR returns this and then clears all bits (including IR).
     icr_data: u8,
+    /// The external /IRQ pin, which lags the internal interrupt condition
+    /// by one E-clock cycle (the 6526-family one-cycle interrupt delay:
+    /// the ICR IR bit sets at the triggering E-cycle, the pin asserts on
+    /// the next). `irq_pin_delay_eticks` counts down the remaining lag.
+    #[serde(default)]
+    irq_pin: bool,
+    #[serde(default)]
+    irq_pin_delay_eticks: u8,
     /// ICR mask: which sources are allowed to raise IR.
     icr_mask: u8,
     /// Serial Data Register. The Amiga keyboard wires its data line
@@ -145,6 +153,8 @@ impl Cia {
             tb_oneshot: false,
             tb_input_mode: TimerBInputMode::Phi2,
             icr_data: 0,
+            irq_pin: false,
+            irq_pin_delay_eticks: 0,
             icr_mask: 0,
             sdr: 0,
             sdr_out: None,
@@ -380,9 +390,12 @@ impl Cia {
             REG_SDR => self.sdr,
             REG_ICR => {
                 // Reading ICR returns the latched events and the IR
-                // bit, then clears every bit (and lowers the line).
+                // bit, then clears every bit (and lowers the line,
+                // cancelling a pin assert still in its E-cycle lag).
                 let v = self.icr_data;
                 self.icr_data = 0;
+                self.irq_pin = false;
+                self.irq_pin_delay_eticks = 0;
                 v
             }
             _ => self.regs[reg],
@@ -615,6 +628,10 @@ impl Cia {
         if ticks == 0 {
             return false;
         }
+        // The external pin lags the internal condition by one E-cycle:
+        // edges armed earlier (by timers, CNT, FLAG, SDR, TOD, or mask
+        // writes) surface here on the E-clock grid.
+        let mut pin_edge = self.drain_irq_pin_delay(ticks);
         let mut fired_mask: u8 = 0;
         let mut ta_underflows = 0;
         if self.ta_running && !self.ta_counts_cnt && ticks > 0 {
@@ -652,7 +669,11 @@ impl Cia {
                 self.update_timer_b_pb_output();
             }
         }
-        self.latch_interrupts(fired_mask)
+        let _ = self.latch_interrupts(fired_mask);
+        // A latch from this call's final E-cycle asserts the pin at the
+        // NEXT E-cycle, so it does not fold into this call's edge.
+        pin_edge |= self.drain_irq_pin_delay(ticks.saturating_sub(1));
+        pin_edge
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -759,20 +780,55 @@ impl Cia {
         if enabled != 0 {
             let was_set = self.icr_data & ICR_IR != 0;
             self.icr_data |= ICR_IR;
-            return !was_set;
+            if !was_set {
+                self.arm_irq_pin();
+            }
+        }
+        false
+    }
+
+    /// The internal interrupt condition just asserted: the external pin
+    /// follows one E-clock cycle later (drained in `drain_irq_pin_delay`).
+    fn arm_irq_pin(&mut self) {
+        if !self.irq_pin && self.irq_pin_delay_eticks == 0 {
+            self.irq_pin_delay_eticks = 1;
+        }
+    }
+
+    /// Advance the pin-lag countdown by `eticks`. Returns true when the
+    /// pin asserts during this span (the bus latches INTREQ on that edge).
+    fn drain_irq_pin_delay(&mut self, eticks: u32) -> bool {
+        if self.irq_pin_delay_eticks == 0 || eticks == 0 {
+            return false;
+        }
+        if eticks as u64 >= u64::from(self.irq_pin_delay_eticks) {
+            self.irq_pin_delay_eticks = 0;
+            // The condition may have been acknowledged inside the lag
+            // window; the pin only rises if it still holds.
+            if self.icr_data & ICR_IR != 0 {
+                self.irq_pin = true;
+                return true;
+            }
+        } else {
+            self.irq_pin_delay_eticks -= eticks as u8;
         }
         false
     }
 
     pub fn irq_line_asserted(&self) -> bool {
-        self.icr_data & ICR_IR != 0
+        self.irq_pin
     }
 
     fn update_irq_line(&mut self) {
         if self.icr_data & self.icr_mask & 0x1F != 0 {
-            self.icr_data |= ICR_IR;
+            if self.icr_data & ICR_IR == 0 {
+                self.icr_data |= ICR_IR;
+                self.arm_irq_pin();
+            }
         } else {
             self.icr_data &= !ICR_IR;
+            self.irq_pin = false;
+            self.irq_pin_delay_eticks = 0;
         }
     }
 

--- a/src/chipset/keyboard.rs
+++ b/src/chipset/keyboard.rs
@@ -814,7 +814,7 @@ mod tests {
     fn handshake(mcu: &mut KeyboardMcu, cia: &mut Cia, cck: u32) {
         cia.write(REG_CRA, CRA_SPMODE);
         mcu.amiga_kdat_edge(true);
-        mcu.tick(cck, cia);
+        (mcu.tick(cck, cia) | cia.settle_irq_pin());
         cia.write(REG_CRA, 0);
         mcu.amiga_kdat_edge(false);
     }
@@ -823,13 +823,13 @@ mod tests {
     /// power-up stream, leaving it Idle. Returns the decoded stream.
     fn complete_power_up(mcu: &mut KeyboardMcu, cia: &mut Cia) -> Vec<u8> {
         let mut stream = Vec::new();
-        mcu.tick(SELF_TEST_CCK as u32, cia);
+        (mcu.tick(SELF_TEST_CCK as u32, cia) | cia.settle_irq_pin());
         // Sync bit, then its handshake.
-        mcu.tick(BIT_CCK, cia);
+        (mcu.tick(BIT_CCK, cia) | cia.settle_irq_pin());
         handshake(mcu, cia, HANDSHAKE_MIN_CCK as u32);
         // Stream bytes until $FE has been sent and handshaked.
         for _ in 0..32 {
-            if mcu.tick(2 * BYTE_CCK, cia) {
+            if (mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin()) {
                 let byte = decode(cia.read(REG_SDR));
                 stream.push(byte);
                 cia.read(REG_ICR);
@@ -840,7 +840,7 @@ mod tests {
             }
         }
         // Drain the inter-byte gap left by the final handshake.
-        mcu.tick(2 * BYTE_CCK, cia);
+        (mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin());
         stream
     }
 
@@ -888,15 +888,17 @@ mod tests {
     fn power_up_stream_marches_on_without_handshakes() {
         let mut cia = unmasked_cia();
         let mut mcu = KeyboardMcu::new();
-        mcu.tick(SELF_TEST_CCK as u32, &mut cia);
-        mcu.tick(BIT_CCK, &mut cia);
+        (mcu.tick(SELF_TEST_CCK as u32, &mut cia) | cia.settle_irq_pin());
+        (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
         // $FD transmits; nobody handshakes it. After the 143 ms window
         // the stream continues regardless (firmware ignores the result).
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(decode(cia.read(REG_SDR)), STATUS_INIT_START);
         cia.read(REG_ICR);
-        assert!(mcu.tick(RESYNC_TIMEOUT_CCK as u32 + 2 * BYTE_CCK, &mut cia));
+        assert!(
+            (mcu.tick(RESYNC_TIMEOUT_CCK as u32 + 2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin())
+        );
         assert_eq!(decode(cia.read(REG_SDR)), STATUS_INIT_END);
     }
 
@@ -909,11 +911,11 @@ mod tests {
         // 7 full bit times: no SP interrupt yet.
         let mut irq = false;
         for _ in 0..7 {
-            irq |= mcu.tick(BIT_CCK, &mut cia);
+            irq |= (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
         }
         assert!(!irq, "SP fired before the 8th bit");
         // The 8th bit completes the byte.
-        assert!(mcu.tick(BIT_CCK, &mut cia));
+        assert!((mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), 0xFD);
     }
 
@@ -922,7 +924,7 @@ mod tests {
         let mut cia = unmasked_cia();
         let mut mcu = idle_mcu(&mut cia);
         mcu.key_transition(0x35, false);
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), encode_keyboard_byte(0x35, false));
     }
 
@@ -939,7 +941,7 @@ mod tests {
         let mut mcu = idle_mcu(&mut cia);
         mcu.key_transition(0x01, true);
         mcu.key_transition(0x02, true);
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), 0xFD);
         // Software acknowledges the byte (clears ICR / the IR line).
         cia.read(REG_ICR);
@@ -947,13 +949,13 @@ mod tests {
         // A zero-width CRA double-write (no emulated time between the SPMODE
         // set and clear) is not a timed pulse and is ignored: no second byte.
         handshake(&mut mcu, &mut cia, 0);
-        assert!(!mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!(!(mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), 0xFD);
 
         // A ~13.5 us pulse (Pinball Dreams) is accepted; the second byte
         // follows immediately.
         handshake(&mut mcu, &mut cia, us_to_cck(14) as u32);
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), 0xFB);
     }
 
@@ -968,9 +970,12 @@ mod tests {
         // recovers through the resync path (covered separately). The pulse
         // spans more than a bit cell so it reliably straddles a KCLK
         // sampling edge.
-        mcu.tick(3 * BIT_CCK, &mut cia);
+        (mcu.tick(3 * BIT_CCK, &mut cia) | cia.settle_irq_pin());
         handshake(&mut mcu, &mut cia, 2 * BIT_CCK);
-        assert!(!mcu.tick(8 * BIT_CCK, &mut cia), "byte must not complete");
+        assert!(
+            !(mcu.tick(8 * BIT_CCK, &mut cia) | cia.settle_irq_pin()),
+            "byte must not complete"
+        );
         assert_ne!(cia.read(REG_SDR), 0xFD);
         // The MCU is now waiting for a handshake that will not come;
         // its next deadline is the resync timeout.
@@ -982,16 +987,16 @@ mod tests {
         let mut cia = unmasked_cia();
         let mut mcu = idle_mcu(&mut cia);
         mcu.key_transition(0x01, true);
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), 0xFD);
 
         // 143 ms with no handshake: the keyboard clocks a single sync
         // bit (one bit time) and waits again.
-        mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia);
-        mcu.tick(BIT_CCK, &mut cia);
+        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
+        (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
         // Two more timeout rounds keep clocking lone bits, not bytes.
-        mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia);
-        mcu.tick(BIT_CCK, &mut cia);
+        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
+        (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
 
         // The sync bits shifted into the CIA garble SDR; software acks
         // whatever arrived, as keyboard.device does.
@@ -999,12 +1004,12 @@ mod tests {
 
         // Handshake one sync bit: $F9 arrives...
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
-        mcu.tick(2 * BYTE_CCK, &mut cia);
+        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin());
         assert_eq!(decode(cia.read(REG_SDR)), STATUS_LAST_CODE_BAD);
         cia.read(REG_ICR);
         // ...and after its handshake, the lost key is retransmitted.
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(cia.read(REG_SDR), 0xFD);
     }
 
@@ -1018,22 +1023,22 @@ mod tests {
 
         // First $78, handshaked (any buffered chord presses are
         // discarded when the chord lands).
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(decode(cia.read(REG_SDR)), STATUS_RESET_WARNING);
         cia.read(REG_ICR);
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
 
         // Second $78, acknowledged.
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia));
+        assert!((mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()));
         assert_eq!(decode(cia.read(REG_SDR)), STATUS_RESET_WARNING);
         cia.read(REG_ICR);
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
 
         // KCLK is now held low; the reset fires after 500 ms.
         assert!(!mcu.take_system_reset_request());
-        mcu.tick(KCLK_RESET_HOLD_CCK as u32 / 2, &mut cia);
+        (mcu.tick(KCLK_RESET_HOLD_CCK as u32 / 2, &mut cia) | cia.settle_irq_pin());
         assert!(!mcu.take_system_reset_request());
-        mcu.tick(KCLK_RESET_HOLD_CCK as u32, &mut cia);
+        (mcu.tick(KCLK_RESET_HOLD_CCK as u32, &mut cia) | cia.settle_irq_pin());
         assert!(mcu.take_system_reset_request());
         // The MCU restarts its own power-up flow (already inside it,
         // since the tick's leftover budget ran into the self-test).
@@ -1050,10 +1055,10 @@ mod tests {
 
         // $78 transmits but nobody handshakes: after the wait the
         // keyboard resets the machine anyway.
-        mcu.tick(2 * BYTE_CCK, &mut cia);
-        mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia);
+        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin());
+        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
         assert!(!mcu.take_system_reset_request());
-        mcu.tick(KCLK_RESET_HOLD_CCK as u32 + 1, &mut cia);
+        (mcu.tick(KCLK_RESET_HOLD_CCK as u32 + 1, &mut cia) | cia.settle_irq_pin());
         assert!(mcu.take_system_reset_request());
     }
 
@@ -1062,7 +1067,7 @@ mod tests {
         let mut cia = unmasked_cia();
         let mut mcu = idle_mcu(&mut cia);
         mcu.key_transition(0x40, true); // space held across the reset
-        mcu.tick(2 * BYTE_CCK, &mut cia); // its press transmits
+        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()); // its press transmits
         cia.read(REG_ICR);
 
         mcu.begin_power_up();
@@ -1084,18 +1089,18 @@ mod tests {
         // Idle with a buffered byte: act now.
         assert_eq!(mcu.next_event_cck(), Some(1));
         // Mid-bit: the next KCLK edge.
-        mcu.tick(10, &mut cia);
+        (mcu.tick(10, &mut cia) | cia.settle_irq_pin());
         let edge = mcu.next_event_cck().expect("bit-edge deadline");
         assert!(edge > 0 && edge as u64 <= BIT_PHASE_CCK, "edge {edge}");
         // Awaiting handshake: the resync timeout keeps a deadline alive.
-        mcu.tick(2 * BYTE_CCK, &mut cia);
+        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin());
         let deadline = mcu.next_event_cck().expect("timeout deadline");
         assert!(deadline as u64 <= RESYNC_TIMEOUT_CCK);
         // Through the resync timeout: the lone sync bit clocks out and
         // the MCU parks waiting for its handshake -- a deadline exists
         // in both of those states too (residual budget from the earlier
         // ticks decides which one we land in).
-        mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia);
+        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
         let next = mcu.next_event_cck().expect("resync deadline");
         assert!(next > 0 && next as u64 <= RESYNC_TIMEOUT_CCK, "next {next}");
     }
@@ -1105,7 +1110,7 @@ mod tests {
     fn drain_stream(mcu: &mut KeyboardMcu, cia: &mut Cia) -> Vec<u8> {
         let mut stream = Vec::new();
         for _ in 0..32 {
-            if !mcu.tick(2 * BYTE_CCK, cia) {
+            if !(mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin()) {
                 break;
             }
             stream.push(decode(cia.read(REG_SDR)));
@@ -1215,21 +1220,24 @@ mod tests {
         mcu.key_transition(0x02, true);
 
         // Stop 40 cck short of the byte's final edge.
-        mcu.tick(2 * BYTE_CCK - 40, &mut cia);
+        (mcu.tick(2 * BYTE_CCK - 40, &mut cia) | cia.settle_irq_pin());
         // The Amiga drives KDAT low now, mid-final-bit...
         cia.write(REG_CRA, CRA_SPMODE);
         mcu.amiga_kdat_edge(true);
         // ...the byte completes 40 cck later, and the pulse is released
         // 280 cck after that: 320 cck total, >= the 301 cck minimum,
         // even though only 280 fell inside AwaitHandshake.
-        mcu.tick(40, &mut cia);
-        mcu.tick(280, &mut cia);
+        (mcu.tick(40, &mut cia) | cia.settle_irq_pin());
+        (mcu.tick(280, &mut cia) | cia.settle_irq_pin());
         cia.write(REG_CRA, 0);
         mcu.amiga_kdat_edge(false);
 
         cia.read(REG_SDR);
         cia.read(REG_ICR);
-        assert!(mcu.tick(2 * BYTE_CCK, &mut cia), "second byte must follow");
+        assert!(
+            (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()),
+            "second byte must follow"
+        );
         assert_eq!(cia.read(REG_SDR), 0xFB);
     }
 }

--- a/src/chipset/keyboard.rs
+++ b/src/chipset/keyboard.rs
@@ -814,7 +814,7 @@ mod tests {
     fn handshake(mcu: &mut KeyboardMcu, cia: &mut Cia, cck: u32) {
         cia.write(REG_CRA, CRA_SPMODE);
         mcu.amiga_kdat_edge(true);
-        (mcu.tick(cck, cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(cck, cia) | cia.settle_irq_pin();
         cia.write(REG_CRA, 0);
         mcu.amiga_kdat_edge(false);
     }
@@ -823,13 +823,13 @@ mod tests {
     /// power-up stream, leaving it Idle. Returns the decoded stream.
     fn complete_power_up(mcu: &mut KeyboardMcu, cia: &mut Cia) -> Vec<u8> {
         let mut stream = Vec::new();
-        (mcu.tick(SELF_TEST_CCK as u32, cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(SELF_TEST_CCK as u32, cia) | cia.settle_irq_pin();
         // Sync bit, then its handshake.
-        (mcu.tick(BIT_CCK, cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(BIT_CCK, cia) | cia.settle_irq_pin();
         handshake(mcu, cia, HANDSHAKE_MIN_CCK as u32);
         // Stream bytes until $FE has been sent and handshaked.
         for _ in 0..32 {
-            if (mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin()) {
+            if mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin() {
                 let byte = decode(cia.read(REG_SDR));
                 stream.push(byte);
                 cia.read(REG_ICR);
@@ -840,7 +840,7 @@ mod tests {
             }
         }
         // Drain the inter-byte gap left by the final handshake.
-        (mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(2 * BYTE_CCK, cia) | cia.settle_irq_pin();
         stream
     }
 
@@ -888,8 +888,8 @@ mod tests {
     fn power_up_stream_marches_on_without_handshakes() {
         let mut cia = unmasked_cia();
         let mut mcu = KeyboardMcu::new();
-        (mcu.tick(SELF_TEST_CCK as u32, &mut cia) | cia.settle_irq_pin());
-        (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(SELF_TEST_CCK as u32, &mut cia) | cia.settle_irq_pin();
+        let _ = mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin();
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
         // $FD transmits; nobody handshakes it. After the 143 ms window
         // the stream continues regardless (firmware ignores the result).
@@ -911,7 +911,7 @@ mod tests {
         // 7 full bit times: no SP interrupt yet.
         let mut irq = false;
         for _ in 0..7 {
-            irq |= (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
+            irq |= mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin();
         }
         assert!(!irq, "SP fired before the 8th bit");
         // The 8th bit completes the byte.
@@ -970,7 +970,7 @@ mod tests {
         // recovers through the resync path (covered separately). The pulse
         // spans more than a bit cell so it reliably straddles a KCLK
         // sampling edge.
-        (mcu.tick(3 * BIT_CCK, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(3 * BIT_CCK, &mut cia) | cia.settle_irq_pin();
         handshake(&mut mcu, &mut cia, 2 * BIT_CCK);
         assert!(
             !(mcu.tick(8 * BIT_CCK, &mut cia) | cia.settle_irq_pin()),
@@ -992,11 +992,11 @@ mod tests {
 
         // 143 ms with no handshake: the keyboard clocks a single sync
         // bit (one bit time) and waits again.
-        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
-        (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin();
+        let _ = mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin();
         // Two more timeout rounds keep clocking lone bits, not bytes.
-        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
-        (mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin();
+        let _ = mcu.tick(BIT_CCK, &mut cia) | cia.settle_irq_pin();
 
         // The sync bits shifted into the CIA garble SDR; software acks
         // whatever arrived, as keyboard.device does.
@@ -1004,7 +1004,7 @@ mod tests {
 
         // Handshake one sync bit: $F9 arrives...
         handshake(&mut mcu, &mut cia, HANDSHAKE_MIN_CCK as u32);
-        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin();
         assert_eq!(decode(cia.read(REG_SDR)), STATUS_LAST_CODE_BAD);
         cia.read(REG_ICR);
         // ...and after its handshake, the lost key is retransmitted.
@@ -1036,9 +1036,9 @@ mod tests {
 
         // KCLK is now held low; the reset fires after 500 ms.
         assert!(!mcu.take_system_reset_request());
-        (mcu.tick(KCLK_RESET_HOLD_CCK as u32 / 2, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(KCLK_RESET_HOLD_CCK as u32 / 2, &mut cia) | cia.settle_irq_pin();
         assert!(!mcu.take_system_reset_request());
-        (mcu.tick(KCLK_RESET_HOLD_CCK as u32, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(KCLK_RESET_HOLD_CCK as u32, &mut cia) | cia.settle_irq_pin();
         assert!(mcu.take_system_reset_request());
         // The MCU restarts its own power-up flow (already inside it,
         // since the tick's leftover budget ran into the self-test).
@@ -1055,10 +1055,10 @@ mod tests {
 
         // $78 transmits but nobody handshakes: after the wait the
         // keyboard resets the machine anyway.
-        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin());
-        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin();
+        let _ = mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin();
         assert!(!mcu.take_system_reset_request());
-        (mcu.tick(KCLK_RESET_HOLD_CCK as u32 + 1, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(KCLK_RESET_HOLD_CCK as u32 + 1, &mut cia) | cia.settle_irq_pin();
         assert!(mcu.take_system_reset_request());
     }
 
@@ -1067,7 +1067,7 @@ mod tests {
         let mut cia = unmasked_cia();
         let mut mcu = idle_mcu(&mut cia);
         mcu.key_transition(0x40, true); // space held across the reset
-        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin()); // its press transmits
+        let _ = mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin(); // its press transmits
         cia.read(REG_ICR);
 
         mcu.begin_power_up();
@@ -1089,18 +1089,18 @@ mod tests {
         // Idle with a buffered byte: act now.
         assert_eq!(mcu.next_event_cck(), Some(1));
         // Mid-bit: the next KCLK edge.
-        (mcu.tick(10, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(10, &mut cia) | cia.settle_irq_pin();
         let edge = mcu.next_event_cck().expect("bit-edge deadline");
         assert!(edge > 0 && edge as u64 <= BIT_PHASE_CCK, "edge {edge}");
         // Awaiting handshake: the resync timeout keeps a deadline alive.
-        (mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(2 * BYTE_CCK, &mut cia) | cia.settle_irq_pin();
         let deadline = mcu.next_event_cck().expect("timeout deadline");
         assert!(deadline as u64 <= RESYNC_TIMEOUT_CCK);
         // Through the resync timeout: the lone sync bit clocks out and
         // the MCU parks waiting for its handshake -- a deadline exists
         // in both of those states too (residual budget from the earlier
         // ticks decides which one we land in).
-        (mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(RESYNC_TIMEOUT_CCK as u32, &mut cia) | cia.settle_irq_pin();
         let next = mcu.next_event_cck().expect("resync deadline");
         assert!(next > 0 && next as u64 <= RESYNC_TIMEOUT_CCK, "next {next}");
     }
@@ -1220,15 +1220,15 @@ mod tests {
         mcu.key_transition(0x02, true);
 
         // Stop 40 cck short of the byte's final edge.
-        (mcu.tick(2 * BYTE_CCK - 40, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(2 * BYTE_CCK - 40, &mut cia) | cia.settle_irq_pin();
         // The Amiga drives KDAT low now, mid-final-bit...
         cia.write(REG_CRA, CRA_SPMODE);
         mcu.amiga_kdat_edge(true);
         // ...the byte completes 40 cck later, and the pulse is released
         // 280 cck after that: 320 cck total, >= the 301 cck minimum,
         // even though only 280 fell inside AwaitHandshake.
-        (mcu.tick(40, &mut cia) | cia.settle_irq_pin());
-        (mcu.tick(280, &mut cia) | cia.settle_irq_pin());
+        let _ = mcu.tick(40, &mut cia) | cia.settle_irq_pin();
+        let _ = mcu.tick(280, &mut cia) | cia.settle_irq_pin();
         cia.write(REG_CRA, 0);
         mcu.amiga_kdat_edge(false);
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -144,6 +144,18 @@ pub struct M68kMachine {
     dbg_sched_bhist: std::collections::HashMap<u32, u64>,
     dbg_sched_bhist_dumped: bool,
     dbg_sched_loop_dumped: bool,
+    // Level-6 (vec 30, CIA-B EXTER) handler-duration probe: entry state,
+    // per-PC cck billing across runs, and the one-shot cost-table dump.
+    // return_pc == 0 means no handler is being tracked.
+    dbg_sched_vec30_return_pc: u32,
+    dbg_sched_vec30_entry_cck: u64,
+    dbg_sched_vec30_entry_vpos: u32,
+    dbg_sched_vec30_entry_hpos: u32,
+    dbg_sched_vec30_prev_pc: u32,
+    dbg_sched_vec30_prev_cck: u64,
+    dbg_sched_vec30_cost: std::collections::HashMap<u32, (u64, u64)>,
+    dbg_sched_vec30_runs: u32,
+    dbg_sched_vec30_cost_dumped: bool,
     // Cached per-instruction diagnostic gates (read from the environment once at
     // construction). These run on every instruction, so they must not do a live
     // std::env lookup -- that lock+scan, millions of times a second, drops the
@@ -315,6 +327,15 @@ impl M68kMachine {
             dbg_sched_bhist: std::collections::HashMap::new(),
             dbg_sched_bhist_dumped: false,
             dbg_sched_loop_dumped: false,
+            dbg_sched_vec30_return_pc: 0,
+            dbg_sched_vec30_entry_cck: 0,
+            dbg_sched_vec30_entry_vpos: 0,
+            dbg_sched_vec30_entry_hpos: 0,
+            dbg_sched_vec30_prev_pc: 0,
+            dbg_sched_vec30_prev_cck: 0,
+            dbg_sched_vec30_cost: std::collections::HashMap::new(),
+            dbg_sched_vec30_runs: 0,
+            dbg_sched_vec30_cost_dumped: false,
             dbg_fc_addr: crate::envcfg::var("COPPERLINE_DBG_FC")
                 .and_then(|s| u32::from_str_radix(s.trim().trim_start_matches("0x"), 16).ok()),
             dbg_ipl_on: crate::envcfg::flag("COPPERLINE_DIAG_IPL"),
@@ -745,15 +766,23 @@ impl M68kMachine {
         // the loader's resume PC -- logging it reveals the loader's main loop /
         // yield point, which sizes each decrunch slice.
         const SWITCH_B_RTE: u32 = 0x00C0_3702;
+        // 30 = level 6 autovector: the CIA-B EXTER kernel tick whose handler
+        // duration this probe measures (entry at the handler's first
+        // instruction, exit when the pushed return PC is reached).
+        const VEC_LEVEL6: u32 = 30;
         let is_bp = pc == LOOP_TOP
             || pc == NUDGE
             || pc == COUNTER_INC
             || pc == RENDER_DONE
             || pc == SOFTINT_RET
             || pc == SWITCH_B_RTE;
-        // Fast path: when not actively capturing the task-B span, only the five
-        // breakpoint PCs matter.
-        if !self.dbg_sched_capturing && !is_bp {
+        // Exception entries surface here at the handler's first instruction
+        // (the dispatch already pushed [SR][return PC] at a7).
+        let vec_entry = self.cpu.last_exception_vector.take();
+        let in_vec30 = self.dbg_sched_vec30_return_pc != 0;
+        // Fast path: when not capturing the task-B span nor timing a level-6
+        // handler, only the five breakpoint PCs and exception entries matter.
+        if !self.dbg_sched_capturing && !is_bp && vec_entry.is_none() && !in_vec30 {
             return;
         }
         let secs = self.bus.bus.emulated_seconds();
@@ -765,6 +794,68 @@ impl M68kMachine {
             .unwrap_or(f64::INFINITY);
         if secs < after || secs >= until {
             return;
+        }
+        if let Some(vector) = vec_entry {
+            let sp = self.cpu.a(7);
+            let return_pc = (u32::from(self.bus.bus.peek_word_any(sp.wrapping_add(2))) << 16)
+                | u32::from(self.bus.bus.peek_word_any(sp.wrapping_add(4)));
+            log::info!(
+                "sched vec={} secs={secs:.5} v={} h={} return_pc={return_pc:#010X}",
+                vector,
+                self.bus.bus.agnus.vpos,
+                self.bus.bus.agnus.hpos,
+            );
+            if vector == VEC_LEVEL6 {
+                self.dbg_sched_vec30_return_pc = return_pc;
+                self.dbg_sched_vec30_entry_cck = self.bus.bus.emulated_cck();
+                self.dbg_sched_vec30_entry_vpos = self.bus.bus.agnus.vpos;
+                self.dbg_sched_vec30_entry_hpos = self.bus.bus.agnus.hpos;
+                self.dbg_sched_vec30_prev_pc = pc;
+                self.dbg_sched_vec30_prev_cck = self.dbg_sched_vec30_entry_cck;
+            }
+        } else if in_vec30 {
+            // Bill the instruction that just retired (prev_pc) with the cck
+            // the bus advanced since it started; slice-boundary chipset
+            // catch-up rides on whichever instruction spans it.
+            let now_cck = self.bus.bus.emulated_cck();
+            let cost = self
+                .dbg_sched_vec30_cost
+                .entry(self.dbg_sched_vec30_prev_pc)
+                .or_insert((0, 0));
+            cost.0 += 1;
+            cost.1 += now_cck.saturating_sub(self.dbg_sched_vec30_prev_cck);
+            if pc == self.dbg_sched_vec30_return_pc {
+                self.dbg_sched_vec30_return_pc = 0;
+                self.dbg_sched_vec30_runs += 1;
+                log::info!(
+                    "sched vec30-dur secs={secs:.5} cck={} entry(v={} h={}) exit(v={} h={})",
+                    now_cck.saturating_sub(self.dbg_sched_vec30_entry_cck),
+                    self.dbg_sched_vec30_entry_vpos,
+                    self.dbg_sched_vec30_entry_hpos,
+                    self.bus.bus.agnus.vpos,
+                    self.bus.bus.agnus.hpos,
+                );
+                if self.dbg_sched_vec30_runs == 40 && !self.dbg_sched_vec30_cost_dumped {
+                    self.dbg_sched_vec30_cost_dumped = true;
+                    let mut rows: Vec<(u32, u64, u64)> = self
+                        .dbg_sched_vec30_cost
+                        .iter()
+                        .map(|(&p, &(n, cck))| (p, n, cck))
+                        .collect();
+                    rows.sort_by_key(|r| r.0);
+                    log::info!("sched vec30-cost over {} runs:", self.dbg_sched_vec30_runs);
+                    for (p, n, cck) in rows {
+                        log::info!(
+                            "sched vec30-cost PC={p:#010X} op={:04X} n={n} avg_cck={:.2}",
+                            self.bus.bus.peek_word_any(p),
+                            cck as f64 / n as f64,
+                        );
+                    }
+                }
+            } else {
+                self.dbg_sched_vec30_prev_pc = pc;
+                self.dbg_sched_vec30_prev_cck = now_cck;
+            }
         }
         // While inside the render-done -> task-B-return span, histogram every PC
         // so we can see what task B (and the interrupt handlers that fire in the
@@ -800,18 +891,6 @@ impl M68kMachine {
                 self.cpu.a(2),
             );
             return;
-        }
-        // Log every exception/interrupt entry while the window is active:
-        // vector, beam position, and the PC the handler will return to.
-        if let Some(vector) = self.cpu.last_exception_vector.take() {
-            log::info!(
-                "sched vec={} secs={secs:.5} v={} h={} return_pc={:#010X}",
-                vector,
-                self.bus.bus.agnus.vpos,
-                self.bus.bus.agnus.hpos,
-                (u32::from(self.bus.bus.peek_word_any(self.cpu.a(7).wrapping_add(2))) << 16)
-                    | u32::from(self.bus.bus.peek_word_any(self.cpu.a(7).wrapping_add(4))),
-            );
         }
         if pc == LOOP_TOP {
             if !self.dbg_sched_loop_dumped {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -143,6 +143,7 @@ pub struct M68kMachine {
     dbg_sched_capturing: bool,
     dbg_sched_bhist: std::collections::HashMap<u32, u64>,
     dbg_sched_bhist_dumped: bool,
+    dbg_sched_loop_dumped: bool,
     // Cached per-instruction diagnostic gates (read from the environment once at
     // construction). These run on every instruction, so they must not do a live
     // std::env lookup -- that lock+scan, millions of times a second, drops the
@@ -313,6 +314,7 @@ impl M68kMachine {
             dbg_sched_capturing: false,
             dbg_sched_bhist: std::collections::HashMap::new(),
             dbg_sched_bhist_dumped: false,
+            dbg_sched_loop_dumped: false,
             dbg_fc_addr: crate::envcfg::var("COPPERLINE_DBG_FC")
                 .and_then(|s| u32::from_str_radix(s.trim().trim_start_matches("0x"), 16).ok()),
             dbg_ipl_on: crate::envcfg::flag("COPPERLINE_DIAG_IPL"),
@@ -799,7 +801,34 @@ impl M68kMachine {
             );
             return;
         }
+        // Log every exception/interrupt entry while the window is active:
+        // vector, beam position, and the PC the handler will return to.
+        if let Some(vector) = self.cpu.last_exception_vector.take() {
+            log::info!(
+                "sched vec={} secs={secs:.5} v={} h={} return_pc={:#010X}",
+                vector,
+                self.bus.bus.agnus.vpos,
+                self.bus.bus.agnus.hpos,
+                (u32::from(self.bus.bus.peek_word_any(self.cpu.a(7).wrapping_add(2))) << 16)
+                    | u32::from(self.bus.bus.peek_word_any(self.cpu.a(7).wrapping_add(4))),
+            );
+        }
         if pc == LOOP_TOP {
+            if !self.dbg_sched_loop_dumped {
+                self.dbg_sched_loop_dumped = true;
+                let mut words = String::new();
+                for i in 0..56u32 {
+                    let a = LOOP_TOP.wrapping_add(i * 2);
+                    words.push_str(&format!(" {:04X}", self.bus.bus.peek_word_any(a)));
+                }
+                log::info!("sched loop-code {LOOP_TOP:#010X}..:{words}");
+                let mut words = String::new();
+                for i in 0..72u32 {
+                    let a = 0x00C0_3580u32.wrapping_add(i * 2);
+                    words.push_str(&format!(" {:04X}", self.bus.bus.peek_word_any(a)));
+                }
+                log::info!("sched vertb-code 0x00C03580..:{words}");
+            }
             self.dbg_sched_top_vpos = vpos;
             self.dbg_sched_top_frame = frame;
             self.dbg_sched_top_counter = counter;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -144,13 +144,14 @@ pub struct M68kMachine {
     dbg_sched_bhist: std::collections::HashMap<u32, u64>,
     dbg_sched_bhist_dumped: bool,
     dbg_sched_loop_dumped: bool,
-    // Level-6 (vec 30, CIA-B EXTER) handler-duration probe: entry state,
-    // per-PC cck billing across runs, and the one-shot cost-table dump.
-    // return_pc == 0 means no handler is being tracked.
-    dbg_sched_vec30_return_pc: u32,
-    dbg_sched_vec30_entry_cck: u64,
-    dbg_sched_vec30_entry_vpos: u32,
-    dbg_sched_vec30_entry_hpos: u32,
+    // Interrupt handler-duration probe: per-IPL-level entry state (index =
+    // level, vector = level + 24; return_pc == 0 means not in flight), plus
+    // a per-PC cck billing table for the level-6 body with its one-shot
+    // cost-table dump.
+    dbg_sched_vec_return_pc: [u32; 8],
+    dbg_sched_vec_entry_cck: [u64; 8],
+    dbg_sched_vec_entry_vpos: [u32; 8],
+    dbg_sched_vec_entry_hpos: [u32; 8],
     dbg_sched_vec30_prev_pc: u32,
     dbg_sched_vec30_prev_cck: u64,
     dbg_sched_vec30_cost: std::collections::HashMap<u32, (u64, u64)>,
@@ -327,10 +328,10 @@ impl M68kMachine {
             dbg_sched_bhist: std::collections::HashMap::new(),
             dbg_sched_bhist_dumped: false,
             dbg_sched_loop_dumped: false,
-            dbg_sched_vec30_return_pc: 0,
-            dbg_sched_vec30_entry_cck: 0,
-            dbg_sched_vec30_entry_vpos: 0,
-            dbg_sched_vec30_entry_hpos: 0,
+            dbg_sched_vec_return_pc: [0; 8],
+            dbg_sched_vec_entry_cck: [0; 8],
+            dbg_sched_vec_entry_vpos: [0; 8],
+            dbg_sched_vec_entry_hpos: [0; 8],
             dbg_sched_vec30_prev_pc: 0,
             dbg_sched_vec30_prev_cck: 0,
             dbg_sched_vec30_cost: std::collections::HashMap::new(),
@@ -766,10 +767,6 @@ impl M68kMachine {
         // the loader's resume PC -- logging it reveals the loader's main loop /
         // yield point, which sizes each decrunch slice.
         const SWITCH_B_RTE: u32 = 0x00C0_3702;
-        // 30 = level 6 autovector: the CIA-B EXTER kernel tick whose handler
-        // duration this probe measures (entry at the handler's first
-        // instruction, exit when the pushed return PC is reached).
-        const VEC_LEVEL6: u32 = 30;
         let is_bp = pc == LOOP_TOP
             || pc == NUDGE
             || pc == COUNTER_INC
@@ -779,10 +776,11 @@ impl M68kMachine {
         // Exception entries surface here at the handler's first instruction
         // (the dispatch already pushed [SR][return PC] at a7).
         let vec_entry = self.cpu.last_exception_vector.take();
-        let in_vec30 = self.dbg_sched_vec30_return_pc != 0;
-        // Fast path: when not capturing the task-B span nor timing a level-6
-        // handler, only the five breakpoint PCs and exception entries matter.
-        if !self.dbg_sched_capturing && !is_bp && vec_entry.is_none() && !in_vec30 {
+        let in_flight = self.dbg_sched_vec_return_pc.iter().any(|&p| p != 0);
+        // Fast path: when not capturing the task-B span nor timing an
+        // interrupt handler, only the five breakpoint PCs and exception
+        // entries matter.
+        if !self.dbg_sched_capturing && !is_bp && vec_entry.is_none() && !in_flight {
             return;
         }
         let secs = self.bus.bus.emulated_seconds();
@@ -805,36 +803,55 @@ impl M68kMachine {
                 self.bus.bus.agnus.vpos,
                 self.bus.bus.agnus.hpos,
             );
-            if vector == VEC_LEVEL6 {
-                self.dbg_sched_vec30_return_pc = return_pc;
-                self.dbg_sched_vec30_entry_cck = self.bus.bus.emulated_cck();
-                self.dbg_sched_vec30_entry_vpos = self.bus.bus.agnus.vpos;
-                self.dbg_sched_vec30_entry_hpos = self.bus.bus.agnus.hpos;
-                self.dbg_sched_vec30_prev_pc = pc;
-                self.dbg_sched_vec30_prev_cck = self.dbg_sched_vec30_entry_cck;
+            // Autovectors 25..31 = IPL levels 1..7.
+            if (25..=31).contains(&vector) {
+                let level = (vector - 24) as usize;
+                self.dbg_sched_vec_return_pc[level] = return_pc;
+                self.dbg_sched_vec_entry_cck[level] = self.bus.bus.emulated_cck();
+                self.dbg_sched_vec_entry_vpos[level] = self.bus.bus.agnus.vpos;
+                self.dbg_sched_vec_entry_hpos[level] = self.bus.bus.agnus.hpos;
+                if level == 6 {
+                    self.dbg_sched_vec30_prev_pc = pc;
+                    self.dbg_sched_vec30_prev_cck = self.dbg_sched_vec_entry_cck[level];
+                }
             }
-        } else if in_vec30 {
-            // Bill the instruction that just retired (prev_pc) with the cck
-            // the bus advanced since it started; slice-boundary chipset
-            // catch-up rides on whichever instruction spans it.
+        } else if in_flight {
             let now_cck = self.bus.bus.emulated_cck();
-            let cost = self
-                .dbg_sched_vec30_cost
-                .entry(self.dbg_sched_vec30_prev_pc)
-                .or_insert((0, 0));
-            cost.0 += 1;
-            cost.1 += now_cck.saturating_sub(self.dbg_sched_vec30_prev_cck);
-            if pc == self.dbg_sched_vec30_return_pc {
-                self.dbg_sched_vec30_return_pc = 0;
-                self.dbg_sched_vec30_runs += 1;
+            if self.dbg_sched_vec_return_pc[6] != 0 {
+                // Bill the level-6 instruction that just retired (prev_pc)
+                // with the cck the bus advanced since it started;
+                // slice-boundary chipset catch-up rides on whichever
+                // instruction spans it.
+                let cost = self
+                    .dbg_sched_vec30_cost
+                    .entry(self.dbg_sched_vec30_prev_pc)
+                    .or_insert((0, 0));
+                cost.0 += 1;
+                cost.1 += now_cck.saturating_sub(self.dbg_sched_vec30_prev_cck);
+                if pc != self.dbg_sched_vec_return_pc[6] {
+                    self.dbg_sched_vec30_prev_pc = pc;
+                    self.dbg_sched_vec30_prev_cck = now_cck;
+                }
+            }
+            for level in 1..8usize {
+                if self.dbg_sched_vec_return_pc[level] == 0
+                    || pc != self.dbg_sched_vec_return_pc[level]
+                {
+                    continue;
+                }
+                self.dbg_sched_vec_return_pc[level] = 0;
                 log::info!(
-                    "sched vec30-dur secs={secs:.5} cck={} entry(v={} h={}) exit(v={} h={})",
-                    now_cck.saturating_sub(self.dbg_sched_vec30_entry_cck),
-                    self.dbg_sched_vec30_entry_vpos,
-                    self.dbg_sched_vec30_entry_hpos,
+                    "sched vecdur level={level} secs={secs:.5} cck={} entry(v={} h={}) exit(v={} h={})",
+                    now_cck.saturating_sub(self.dbg_sched_vec_entry_cck[level]),
+                    self.dbg_sched_vec_entry_vpos[level],
+                    self.dbg_sched_vec_entry_hpos[level],
                     self.bus.bus.agnus.vpos,
                     self.bus.bus.agnus.hpos,
                 );
+                if level != 6 {
+                    continue;
+                }
+                self.dbg_sched_vec30_runs += 1;
                 if self.dbg_sched_vec30_runs == 40 && !self.dbg_sched_vec30_cost_dumped {
                     self.dbg_sched_vec30_cost_dumped = true;
                     let mut rows: Vec<(u32, u64, u64)> = self
@@ -852,9 +869,6 @@ impl M68kMachine {
                         );
                     }
                 }
-            } else {
-                self.dbg_sched_vec30_prev_pc = pc;
-                self.dbg_sched_vec30_prev_cck = now_cck;
             }
         }
         // While inside the render-done -> task-B-return span, histogram every PC

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -84,7 +84,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      buffer/auddat holding registers, percnt, request latches)
 //  23: FloppyDrive gained the step-pulse timestamps (last_step_cck and the
 //      per-direction stamps for the mechanism's 40 us pulse floor)
-pub const STATE_VERSION: u32 = 23;
+//  24: Cia gained the delayed /IRQ pin state (irq_pin,
+//      irq_pin_delay_eticks - the 8520 one-E-cycle interrupt delay)
+pub const STATE_VERSION: u32 = 24;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
## Hardware behaviour

The 6526-family CIAs do not assert the external /IRQ pin uniformly with the
internal interrupt condition:

- A **timer underflow** pulls the pin down in the **same E-cycle** as the
  underflow (vAmiga `CIASetInt1`).
- **TOD alarm, FLAG, serial, and ICR-mask-write** asserts reach the pin
  **one E-cycle later** (vAmiga `CIASetInt0`).
- A timer underflow **racing an ICR read** in the same E-cycle loses the race
  and asserts one E-cycle late (vAmiga `CIAReadIcr0` gating `triggerTimerIrq`).

Copperline previously latched INTREQ in the same tick for every source. The
first cut of this branch modelled a blanket +1 E-cycle on all sources, which
regressed the vAmigaTS CIA family 992.7 -> 1060.4; this PR refines it to the
per-source split above. The TOD alarm path also bypassed the pin model
entirely (asserting INTREQ with no delay and never raising the pin level);
it now routes through the delayed arm like the other non-timer sources.

An ICR read still cancels a pending delayed assert (the condition is gone
before the pin ever rose). `savestate::STATE_VERSION` is 24 (Cia gained the
pin, lag, and read-race fields).

The branch also extends the `COPPERLINE_DIAG_SCHED` diagnostics with a
level-6 handler duration probe (vector entry -> pushed return PC, plus a
per-PC cck cost table) - the instrument for the ongoing eon scene-player
investigation; it is inert without the env flag.

## Results

- vAmigaTS CIA family (93 cases, OCS+ECS): **992.7 (main) / 1060.4 (blanket
  delay) -> 989.9** - slightly better than main.
- Paula/Interrupts guard sweep: **no case moved >0.5pp** vs the main baseline.
- Demo byte-identity: **14/14 identical** (eon@108s, SOTA, ITM, Hamazing,
  Gen-X@110s, kick13 boot, A1200 boot, Second Nature, Roots ECS+AGA, Gods,
  Rebirth, Turbo Tomato, Zool).
- eon crossed_vblank 60-110s: 30.5% = neutral (the eon regression is a
  separate open investigation; this change is not its fix).
- 1322 lib tests green; clippy --all-targets --all-features -D warnings and
  fmt clean.

## Test updates

Timer-underflow tests assert the pin in the same call again; serial (keyboard
MCU byte arrival), FLAG, TOD-alarm, and mask-write tests drain the one-E-cycle
lag through `tick(1)`/`settle_irq_pin()`. New regression tests pin the
same-E-cycle timer assert, the ICR-read race, and the TOD alarm lag.