### PR TITLE
parallel: audio sampler, on a general parallel-port framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,21 +250,37 @@ The ALSA development headers the Linux backend links against are already a
 build requirement (see Requirements); macOS and Windows need nothing beyond
 the OS.
 
-## Parallel printer capture
+## Parallel port
 
-Copperline models CIA-B's Centronics data/strobe output and the printer
-acknowledge path back through CIA-A. A config can attach a raw byte-stream
-capture; with no `[parallel]` section the connector remains unplugged:
+Copperline models the Centronics parallel port on CIA-A (data and `PC` strobe
+on port B at `$BFE101`, printer `/ACK` back through CIA-A `FLAG`) and can attach
+one peripheral, chosen by `[parallel] device`. With no `[parallel]` section the
+connector is unplugged.
+
+A **printer** captures the guest's raw byte stream to a file, preserving the
+printer-language bytes verbatim for a compatible converter or spooler:
 
 ```toml
 [parallel]
+device = "printer"
 output = "printer.raw"
 ```
 
-The capture preserves the guest's printer-language bytes verbatim for a
-compatible converter or spooler. The configured path is replaced when the
-emulator starts. See the configuration guide for the signal and interrupt
-behaviour.
+A **sampler** is an 8-bit audio digitizer on the data lines -- the emulated
+equivalent of a classic parallel-port sampler cartridge, driving AudioMaster,
+ProTracker, OctaMED, TurboSound and the like. It captures from a host audio
+input (via cpal, like live audio output) and can switch input device and gain
+live:
+
+```toml
+[parallel]
+device = "sampler"
+sampler_input = "MacBook Air Microphone"  # omit for the system default
+sampler_gain = 6.0                        # preamp gain in dB (0 = unity)
+```
+
+See the configuration guide for the full set of options, the equivalent
+`--parallel` / `--sampler-*` flags, and the signal/interrupt behaviour.
 
 ## Documentation
 

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -389,13 +389,31 @@ floppy_sounds_volume = 100
 # listen = "127.0.0.1:1234"
 
 
-# Centronics parallel-printer capture. With no section the connector is
-# electrically unplugged: CIA-B still pulses /STROBE, but no peripheral
-# returns CIA-A /ACK. When output is set, the path is replaced at startup and
-# every strobed data byte is captured in order and acknowledged; feed the raw
-# stream to the matching printer-language converter or a real spooler.
+# Parallel (Centronics) port peripheral. With no section the connector is
+# electrically unplugged: CIA-A still pulses /STROBE on port-B access, but no
+# peripheral returns CIA-A /ACK. `device` selects what is plugged in:
+#   "none"     (default) nothing connected.
+#   "printer"  a Centronics printer whose raw byte stream is captured. `output`
+#              sets the host file; it is replaced at startup and every strobed
+#              data byte is written in order and acknowledged. Feed the raw
+#              stream to the matching printer-language converter or a spooler.
+#              (A bare `output` with no `device` still implies the printer.)
+#   "sampler"  an 8-bit audio sampler (digitizer) on the data lines, fed from a
+#              host capture device -- the emulated equivalent of a classic
+#              parallel-port sampler cartridge (AudioMaster, ProTracker, OctaMED,
+#              TurboSound). `sampler_input` names the host input device
+#              (case-insensitive substring, as `--sampler-list-audio-inputs`
+#              prints; omitted = system default). `sampler_gain` is the preamp
+#              gain in decibels (0 dB = unity; ~ -24 to +24 dB). Needs a build
+#              with the `frontend` feature (it uses cpal, like live audio output).
+# --parallel DEVICE overrides this per run; --sampler-audio-input /
+# --sampler-input-gain imply "sampler".
 # [parallel]
+# device = "printer"
 # output = "printer.raw"
+# device = "sampler"
+# sampler_input = "MacBook Air Microphone"
+# sampler_gain = 6.0   # dB
 
 
 # Optional floppy drives. DF0 is always connected; set [floppy] drives

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -60,10 +60,11 @@ machine; the other flags then override individual values on top of it, just as
 explicit `[cpu]`/`[chipset]`/`[memory]` sections override a `[machine]`
 profile in a config file.
 
-The audio and serial surface has matching per-run flags too --
+The audio, serial, and parallel surface has matching per-run flags too --
 `--audio-device`, `--audio-channel-mode`, `--audio-stereo-separation`,
-`--serial`, `--midi-in`, `--midi-out` -- described with their `[audio]` and
-`[serial]` keys below.
+`--serial`, `--midi-in`, `--midi-out`, `--parallel`, `--sampler-audio-input`,
+`--sampler-input-gain` -- described with their `[audio]`, `[serial]`, and
+`[parallel]` keys below.
 
 ## Top level
 
@@ -542,21 +543,46 @@ console. `--serial MODE` overrides the mode per run, and
 **Serial** tab and the in-window **MIDI In / MIDI Out** menu items select
 the MIDI endpoints interactively.
 
-## `[parallel]` -- Centronics printer capture
+## `[parallel]` -- Centronics parallel port
 
 ```toml
 [parallel]
-output = "printer.raw"
+device = "printer"           # none | printer | sampler
+output = "printer.raw"       # printer capture path
+# device = "sampler"
+# sampler_input = "MacBook Air Microphone"  # host input; omit for the default
+# sampler_gain = 6.0                          # preamp gain in dB (0 = unity)
 ```
 
-Without this section the parallel connector is electrically disconnected:
-CIA-B still produces its hardware `PC` strobe on port-B accesses, but no
-peripheral acknowledges it. Setting `output` attaches a raw Centronics sink.
-The output file is created at startup, replacing any existing file at that
-path. Each strobed byte is then written verbatim and returns the printer `/ACK`
-falling edge through CIA-A `FLAG`, including the normal CIA interrupt delay.
-The file is intentionally not decoded because the guest may emit any printer
-language; pass it to a compatible converter or spooler afterwards.
+`device` chooses the peripheral on the parallel port (one at a time). Without
+this section the connector is electrically disconnected: CIA-A still produces
+its hardware `PC` strobe on port-B accesses (`$BFE101`), but no peripheral
+acknowledges it and port-B reads see the CIA's own pins. The equivalent per-run
+flags are `--parallel DEVICE`, `--sampler-audio-input NAME`, and
+`--sampler-input-gain X`; `--sampler-list-audio-inputs` prints the input-device
+names and exits.
+
+`"printer"` attaches a raw Centronics sink at `output` (a bare `output` with no
+`device` still selects the printer, for compatibility). The file is created at
+startup, replacing any existing file; each strobed byte is written verbatim and
+returns the printer `/ACK` falling edge through CIA-A `FLAG`, including the
+normal CIA interrupt delay. It is intentionally not decoded, since the guest may
+emit any printer language; pass it to a converter or spooler afterwards.
+
+`"sampler"` attaches an 8-bit audio sampler (digitizer) on the data lines -- the
+emulated equivalent of a classic parallel-port sampler cartridge, driving
+software such as AudioMaster, ProTracker, OctaMED, and TurboSound. It captures
+from a host input device (cpal, like live audio output, so it needs a build with
+the `frontend` feature) and presents each read of the data lines as an 8-bit
+offset-binary sample in emulated time, mono (host left/right are summed).
+`sampler_input` names the host device (case-insensitive substring, as
+`--sampler-list-audio-inputs` prints; omitted uses the system default);
+`sampler_gain` is the preamp gain in decibels (0 dB = unity) applied before the
+ADC, clamped to the sampler's range (roughly -24 to +24 dB). The input device
+and gain can also be changed live
+from the runtime menu, and the gain with `Cmd/Alt+Shift +/-`. On macOS the CLI
+binary needs microphone permission to capture a real input; routing audio in
+through a loopback device such as BlackHole needs none.
 
 ## `[floppy]` and `[floppy.df0]` .. `[floppy.df3]`
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -22,6 +22,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+K` | `Alt+K` | Open the [debugger console](../debugger/console) |
 | `Cmd+J` | `Alt+J` | Toggle joystick input mode: gamepad / keyboard (also the status-bar icon) |
 | `Cmd+Shift+A` | `Alt+Shift+A` | Cycle the audio output: Default, each host device, then Disabled (also the menu's Audio Out item) |
+| `Cmd+Shift++` / `Cmd+Shift+-` | `Alt+Shift++` / `Alt+Shift+-` | Raise / lower the parallel-port sampler input gain (only when a sampler is attached; also the menu's Sampler Gain item) |
 | `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |
 | `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Esc` | `Esc` | Close an open menu, tool window, or overlay panel; otherwise passed through to the Amiga |
@@ -135,6 +136,10 @@ tool window or overlay.
   cycle Paula's serial bridge through the host's MIDI sources and
   destinations; see the `[serial]` section of
   [Configuration](configuration.md).
+- **Sampler In / Sampler Gain** (shown when a parallel-port sampler is
+  attached): cycle the sampler's host capture device, and step its input
+  gain (also `Cmd/Alt+Shift +/-`). Both change live. See the `[parallel]`
+  section of [Configuration](configuration.md).
 - **Pixel Aspect**: flips the presentation between the 4:3 CRT pixel
   aspect (the default; PAL lo-res pixels slightly wider than tall, as a
   real TV shows them) and square pixels (a 320x256 screen is an exact
@@ -218,6 +223,8 @@ The layout is:
   insert delay, CD32 NVRAM), *Zorro* (extra autoconfig boards by metadata
   file, with a config panel for a WASM plugin board's declared options),
   *Serial* (serial mode and MIDI input/output endpoints),
+  *Parallel* (the parallel-port device -- None, Printer, or Sampler -- and, for
+  the sampler, its host audio input and input gain),
   *Input* (the controller device in each game port and the joystick input
   source), and *A/V & Emu* (audio output device, channel mode, stereo
   separation, overscan, pixel aspect, phosphor, floppy sounds and

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -186,7 +186,7 @@ extern "C" fn alsa_ignore_error(
 /// a no-op error handler once, process-wide, keeping `--list-audio-devices` and
 /// the picker readable. No-op off Linux, where the handler does not exist.
 #[cfg(all(feature = "frontend", target_os = "linux"))]
-fn quiet_alsa_probe_logging() {
+pub(crate) fn quiet_alsa_probe_logging() {
     use std::sync::Once;
     static ONCE: Once = Once::new();
     ONCE.call_once(|| unsafe {
@@ -195,7 +195,7 @@ fn quiet_alsa_probe_logging() {
 }
 
 #[cfg(all(feature = "frontend", not(target_os = "linux")))]
-fn quiet_alsa_probe_logging() {}
+pub(crate) fn quiet_alsa_probe_logging() {}
 
 /// Whether an ALSA device name is a low-level *plugin* handle rather than a
 /// device a user would pick: the channel-layout plugins (`front`, `surround51`,
@@ -209,7 +209,7 @@ fn quiet_alsa_probe_logging() {}
 /// name in the config/CLI, since only the displayed list is filtered. A no-op on
 /// macOS/Windows, whose device names never take this form.
 #[cfg(feature = "frontend")]
-fn is_alsa_plugin_variant(name: &str) -> bool {
+pub(crate) fn is_alsa_plugin_variant(name: &str) -> bool {
     let plugin = name.split(':').next().unwrap_or(name);
     matches!(
         plugin,
@@ -359,7 +359,7 @@ pub fn list_output_devices() -> Vec<String> {
 /// thing. `default_name` is the host's default output device name. When the
 /// default is some other device, `default` is a distinct choice and kept.
 #[cfg(feature = "frontend")]
-fn is_redundant_default(name: &str, default_name: Option<&str>) -> bool {
+pub(crate) fn is_redundant_default(name: &str, default_name: Option<&str>) -> bool {
     name.eq_ignore_ascii_case("default")
         && default_name.is_some_and(|d| d.eq_ignore_ascii_case("default"))
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -653,9 +653,9 @@ pub struct Bus {
     chip_dma_mask: u32,
     pub blitter: Blitter,
     pub floppy: FloppyController,
-    /// Host-side Centronics peripheral. The CIA-B PC/data and CIA-A FLAG
-    /// signals are emulated, but the attached sink itself is not machine state
-    /// and therefore survives save-state loads like Paula's audio/serial sinks.
+    /// Host-side Centronics peripheral. The CIA-A PC/data and FLAG signals are
+    /// emulated, but the attached peripheral itself is not machine state and
+    /// therefore survives save-state loads like Paula's audio/serial sinks.
     #[serde(skip, default = "crate::parallel::null_parallel_port")]
     parallel_port: Box<dyn crate::parallel::ParallelPort>,
     pub rtc: Msm6242Rtc,
@@ -3235,7 +3235,7 @@ impl Bus {
         self.paula.set_serial_time_anchor(anchor);
     }
 
-    /// Attach a Centronics peripheral to CIA-B port B. The default is a null
+    /// Attach a Centronics peripheral to CIA-A port B. The default is a null
     /// peripheral (unplugged cable), so attaching one is an explicit host-side
     /// choice and does not change ordinary machine behavior.
     pub fn attach_parallel_port(&mut self, port: Box<dyn crate::parallel::ParallelPort>) {
@@ -4720,8 +4720,17 @@ impl Bus {
             // status lines: /CHNG, /WPRO, /TK0, /RDY.
             v = (v & !0x3C) | self.floppy.cia_a_status_bits();
         }
+        if reg == REG_PRB {
+            // The parallel data pins are CIA-A port B. An input peripheral (an
+            // audio sampler digitizing the data lines) drives them, so let it
+            // override the byte the guest reads back from $BFE101.
+            if let Some(byte) = self.parallel_port.read_data(self.emulated_cck) {
+                v = byte;
+            }
+        }
         trace!("cia_a R reg={:X} sz={} val={:02X}", reg, size, v);
         self.poll_stats.tick_read("cia_a", reg);
+        self.service_parallel_strobe();
         v as u64
     }
 
@@ -4753,6 +4762,7 @@ impl Bus {
             }
             self.cd32_pad_cia_clock();
         }
+        self.service_parallel_strobe();
         eff
     }
 
@@ -4813,9 +4823,11 @@ impl Bus {
         let v = self.cia_b.read(reg);
         trace!("cia_b R reg={:X} sz={} val={:02X}", reg, size, v);
         self.poll_stats.tick_read("cia_b", reg);
-        let result = if size == 2 { (v as u64) << 8 } else { v as u64 };
-        self.service_parallel_strobe();
-        result
+        if size == 2 {
+            (v as u64) << 8
+        } else {
+            v as u64
+        }
     }
 
     pub fn cia_b_write(&mut self, addr: u64, size: usize, val: u64) -> CiaSideEffect {
@@ -4839,19 +4851,21 @@ impl Bus {
             let prb = self.cia_b.port_b_pins();
             self.floppy.write_prb(prb);
         }
-        self.service_parallel_strobe();
         eff
     }
 
-    /// Consume CIA-B's one-shot `PC` pulse as the external Centronics
-    /// `/STROBE`. An accepting peripheral returns an `/ACK`; its falling edge
-    /// is fed into CIA-A FLAG, whose existing one-E-clock interrupt delay then
-    /// drives Paula PORTS through the normal timed-device path.
+    /// Consume CIA-A's one-shot `PC` pulse as the external Centronics
+    /// `/STROBE`. The parallel data pins are CIA-A port B, and CIA-A's `PC`
+    /// output pulses on any port-B access, so a guest that writes a byte to
+    /// `$BFE101` and toggles the strobe drives this path. An accepting
+    /// peripheral returns an `/ACK`; its falling edge is fed into CIA-A FLAG,
+    /// whose existing one-E-clock interrupt delay then drives Paula PORTS
+    /// through the normal timed-device path.
     fn service_parallel_strobe(&mut self) {
-        if !self.cia_b.take_pc_pulse() {
+        if !self.cia_a.take_pc_pulse() {
             return;
         }
-        let data = self.cia_b.port_b_pins();
+        let data = self.cia_a.port_b_pins();
         if self.parallel_port.strobe(data, self.emulated_cck) {
             let _ = self.cia_a.assert_flag();
             self.cia_a.release_flag();

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -576,7 +576,7 @@ fn cia_b_mask_enable_propagates_latched_timer_interrupt_to_paula() {
 }
 
 #[test]
-fn cia_b_pc_strobe_reaches_parallel_port_and_ack_drives_cia_a_flag() {
+fn cia_a_pc_strobe_reaches_parallel_port_and_ack_drives_cia_a_flag() {
     struct AckCapture(Arc<Mutex<Vec<(u8, u64)>>>);
 
     impl crate::parallel::ParallelPort for AckCapture {
@@ -592,15 +592,15 @@ fn cia_b_pc_strobe_reaches_parallel_port_and_ack_drives_cia_a_flag() {
     let addr = |reg: usize| (reg as u64) << 8;
 
     // FLAG is a delayed CIA source. Enable it, drive all eight printer data
-    // pins, then access PRB: CIA-B pulses PC, the peripheral accepts $A5, and
-    // its acknowledge falling edge latches CIA-A ICR.FLG.
+    // pins on CIA-A port B, then access PRB: CIA-A pulses PC, the peripheral
+    // accepts $A5, and its acknowledge falling edge latches CIA-A ICR.FLG.
     let _ = bus.cia_a_write(addr(REG_ICR), 1, 0x80 | 0x10);
-    let _ = bus.cia_b_write(addr(REG_DDRB), 1, 0xFF);
+    let _ = bus.cia_a_write(addr(REG_DDRB), 1, 0xFF);
     assert!(
         events.lock().unwrap().is_empty(),
         "DDRB sampling is not a strobe"
     );
-    let _ = bus.cia_b_write(addr(REG_PRB), 1, 0xA5);
+    let _ = bus.cia_a_write(addr(REG_PRB), 1, 0xA5);
 
     assert_eq!(&*events.lock().unwrap(), &[(0xA5, 0)]);
     assert_ne!(bus.cia_a.debug_icr_data() & 0x10, 0);
@@ -608,9 +608,9 @@ fn cia_b_pc_strobe_reaches_parallel_port_and_ack_drives_cia_a_flag() {
     bus.advance_devices(5);
     assert_ne!(bus.paula.intreq & INT_PORTS, 0);
 
-    // A guest PRB read generates the same hardware PC pulse. The bus samples
-    // the pins side-effect-free, so its floppy update cannot double-strobe.
-    assert_eq!(bus.cia_b_read(addr(REG_PRB), 1), 0xA5);
+    // A guest PRB read generates the same hardware PC pulse, so it strobes the
+    // peripheral again with the latched pin levels.
+    assert_eq!(bus.cia_a_read(addr(REG_PRB), 1), 0xA5);
     assert_eq!(events.lock().unwrap().len(), 2);
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,10 +195,11 @@ pub struct Config {
     /// Defaults to [`SerialMode::Stdout`], preserving the historical
     /// terminal-diagnostics behaviour.
     pub serial: SerialConfig,
-    /// Raw Centronics printer-byte capture (`[parallel] output`). `None`
-    /// leaves the parallel port electrically disconnected, so CIA-B strobes
-    /// receive no CIA-A FLAG acknowledge.
-    pub parallel_output_path: Option<PathBuf>,
+    /// The peripheral on the Centronics parallel port (printer capture or audio
+    /// sampler) and its settings. [`ParallelDevice::None`] leaves the port
+    /// electrically disconnected, so CIA-A strobes receive no FLAG acknowledge
+    /// and port-B reads see the CIA's own pin state.
+    pub parallel: ParallelConfig,
 }
 
 /// How much of the overscan field the window presents. The
@@ -322,6 +323,58 @@ pub struct SerialConfig {
     /// TCP listen address for [`SerialMode::Tcp`]; `None` means the
     /// default `127.0.0.1:1234` (the port UAE's `TCP:` serial uses).
     pub listen: Option<String>,
+}
+
+/// Which peripheral is plugged into the Amiga's Centronics parallel port. The
+/// port carries one device at a time, chosen by `[parallel] device`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ParallelDevice {
+    /// Nothing plugged in (an unplugged cable). The default.
+    #[default]
+    None,
+    /// A Centronics printer whose raw byte stream is captured to a host file
+    /// (`[parallel] output`).
+    Printer,
+    /// An 8-bit audio sampler (digitizer) on the data lines, fed from a host
+    /// capture device. Needs a build with the `frontend` feature (cpal).
+    Sampler,
+}
+
+impl ParallelDevice {
+    /// Config-string label (round-trips through [`parse_parallel_device`]).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Printer => "printer",
+            Self::Sampler => "sampler",
+        }
+    }
+}
+
+/// Resolved `[parallel]` settings. `printer_output` is consulted only for
+/// [`ParallelDevice::Printer`], and `sampler_input`/`sampler_gain_db` only for
+/// [`ParallelDevice::Sampler`]; the inactive fields are carried through so the
+/// configuration screen round-trips them unchanged.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParallelConfig {
+    pub device: ParallelDevice,
+    /// Raw printer-byte capture path for [`ParallelDevice::Printer`].
+    pub printer_output: Option<PathBuf>,
+    /// Host capture device for [`ParallelDevice::Sampler`]; `None` = default.
+    pub sampler_input: Option<String>,
+    /// Sampler input gain in decibels (preamp); 0 dB = unity.
+    pub sampler_gain_db: f32,
+}
+
+impl Default for ParallelConfig {
+    fn default() -> Self {
+        Self {
+            device: ParallelDevice::None,
+            printer_output: None,
+            sampler_input: None,
+            sampler_gain_db: 0.0,
+        }
+    }
 }
 
 /// A configured hard-drive image: the host path plus an optional volume-name
@@ -1026,7 +1079,7 @@ impl Default for Config {
             joystick_input_mode: JoystickInputMode::Gamepad,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
-            parallel_output_path: None,
+            parallel: ParallelConfig::default(),
         }
     }
 }
@@ -1178,6 +1231,15 @@ pub struct ConfigOverrides {
     pub midi_out: Option<String>,
     /// Host MIDI input endpoint (`--midi-in`), implying `--serial midi`.
     pub midi_in: Option<String>,
+    /// Parallel port device (`--parallel`): "none", "printer", or "sampler".
+    /// Same parser as `[parallel] device`.
+    pub parallel: Option<String>,
+    /// Sampler host capture device (`--sampler-audio-input`), implying
+    /// `--parallel sampler`. Substring match.
+    pub sampler_input: Option<String>,
+    /// Sampler input gain in decibels (`--sampler-input-gain`), implying
+    /// `--parallel sampler`. Preamp; 0 dB = unity.
+    pub sampler_gain: Option<f32>,
     /// Host audio output device (`--audio-device`), substring match.
     pub audio_device: Option<String>,
     /// Output channel mode (`--audio-channel-mode`): "stereo" or "mono".
@@ -1210,6 +1272,9 @@ impl ConfigOverrides {
             && self.serial.is_none()
             && self.midi_out.is_none()
             && self.midi_in.is_none()
+            && self.parallel.is_none()
+            && self.sampler_input.is_none()
+            && self.sampler_gain.is_none()
             && self.audio_device.is_none()
             && self.audio_channel_mode.is_none()
             && self.audio_stereo_separation.is_none()
@@ -1269,6 +1334,21 @@ impl ConfigOverrides {
         // `--serial` said otherwise.
         if self.serial.is_none() && (self.midi_out.is_some() || self.midi_in.is_some()) {
             raw.serial.mode = Some(SerialMode::Midi.label().to_string());
+        }
+        if let Some(device) = &self.parallel {
+            raw.parallel.device = Some(device.clone());
+        }
+        if let Some(input) = &self.sampler_input {
+            raw.parallel.sampler_input = Some(input.clone());
+        }
+        if let Some(gain) = self.sampler_gain {
+            raw.parallel.sampler_gain = Some(gain);
+        }
+        // Naming a sampler option selects the sampler unless `--parallel` said
+        // otherwise (mirrors `--midi-out` implying `--serial midi`).
+        if self.parallel.is_none() && (self.sampler_input.is_some() || self.sampler_gain.is_some())
+        {
+            raw.parallel.device = Some(ParallelDevice::Sampler.label().to_string());
         }
         if let Some(dev) = &self.audio_device {
             raw.audio.output_device = Some(dev.clone());
@@ -1445,13 +1525,24 @@ pub(crate) struct RawSerial {
     pub(crate) listen: Option<String>,
 }
 
-/// `[parallel]` host capture for the Amiga Centronics printer port.
+/// `[parallel]` peripheral selection for the Amiga Centronics parallel port.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawParallel {
-    /// Raw byte-stream output path. When absent, no printer is connected.
+    /// Which device is plugged in: `none`, `printer`, or `sampler`. When
+    /// omitted, a bare `output` path implies `printer` (back-compat) and
+    /// otherwise the port is empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) device: Option<String>,
+    /// Printer raw byte-stream output path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) output: Option<String>,
+    /// Sampler host capture device name (substring match); absent = default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sampler_input: Option<String>,
+    /// Sampler input gain in decibels (preamp); absent = 0 dB (unity).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sampler_gain: Option<f32>,
 }
 
 /// A drive image entry in `[ide]`/`[scsi]`. Accepts either a bare path string
@@ -2380,8 +2471,52 @@ impl TryFrom<RawConfig> for Config {
             joystick_input_mode,
             port_devices,
             serial,
-            parallel_output_path: raw.parallel.output.map(PathBuf::from),
+            parallel: resolve_parallel(raw.parallel)?,
         })
+    }
+}
+
+/// Resolve `[parallel]` into a [`ParallelConfig`]. An explicit `device` selects
+/// the peripheral; with none set, a bare `output` path implies a printer
+/// (back-compat with the original `[parallel] output = "..."`) and otherwise the
+/// port is empty. Rejects a printer with no capture path and an out-of-range
+/// sampler gain.
+fn resolve_parallel(raw: RawParallel) -> Result<ParallelConfig> {
+    let device = match raw.device.as_deref() {
+        Some(s) => parse_parallel_device(s)?,
+        None if raw.output.is_some() => ParallelDevice::Printer,
+        None => ParallelDevice::None,
+    };
+    if device == ParallelDevice::Printer && raw.output.is_none() {
+        bail!("[parallel] device = \"printer\" needs an output path (output = \"...\")");
+    }
+    let sampler_gain_db = raw.sampler_gain.unwrap_or(0.0);
+    let gain_range = crate::sampler::MIN_SAMPLER_GAIN_DB..=crate::sampler::MAX_SAMPLER_GAIN_DB;
+    if device == ParallelDevice::Sampler
+        && (!sampler_gain_db.is_finite() || !gain_range.contains(&sampler_gain_db))
+    {
+        bail!(
+            "[parallel] sampler_gain must be between {} and {} dB, got {sampler_gain_db}",
+            crate::sampler::MIN_SAMPLER_GAIN_DB,
+            crate::sampler::MAX_SAMPLER_GAIN_DB
+        );
+    }
+    Ok(ParallelConfig {
+        device,
+        printer_output: raw.output.map(PathBuf::from),
+        sampler_input: raw.sampler_input,
+        sampler_gain_db,
+    })
+}
+
+pub(crate) fn parse_parallel_device(s: &str) -> Result<ParallelDevice> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "none" | "off" => Ok(ParallelDevice::None),
+        "printer" => Ok(ParallelDevice::Printer),
+        "sampler" => Ok(ParallelDevice::Sampler),
+        other => bail!(
+            "[parallel] device must be \"none\", \"printer\", or \"sampler\", got \"{other}\""
+        ),
     }
 }
 
@@ -4982,15 +5117,55 @@ mod tests {
 
     #[test]
     fn parallel_section_selects_raw_capture_path() -> Result<()> {
+        // A bare output path implies the printer (back-compat).
         let cfg = parse_config("[parallel]\noutput = \"printer.raw\"\n")?;
+        assert_eq!(cfg.parallel.device, ParallelDevice::Printer);
         assert_eq!(
-            cfg.parallel_output_path.as_deref(),
+            cfg.parallel.printer_output.as_deref(),
             Some(std::path::Path::new("printer.raw"))
         );
-        assert_eq!(parse_config("")?.parallel_output_path, None);
+        // An empty port is the default.
+        assert_eq!(parse_config("")?.parallel.device, ParallelDevice::None);
+        assert_eq!(parse_config("")?.parallel.printer_output, None);
 
         let err = parse_config("[parallel]\nmode = \"printer\"\n").unwrap_err();
         assert!(err.to_string().contains("unknown field `mode`"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
+    fn parallel_device_selects_printer_or_sampler() -> Result<()> {
+        // An explicit sampler with its options (gain in dB).
+        let cfg = parse_config(
+            "[parallel]\ndevice = \"sampler\"\nsampler_input = \"BlackHole\"\nsampler_gain = 6.0\n",
+        )?;
+        assert_eq!(cfg.parallel.device, ParallelDevice::Sampler);
+        assert_eq!(cfg.parallel.sampler_input.as_deref(), Some("BlackHole"));
+        assert_eq!(cfg.parallel.sampler_gain_db, 6.0);
+        // 0 dB (unity) is valid.
+        assert_eq!(
+            parse_config("[parallel]\ndevice = \"sampler\"\nsampler_gain = 0\n")?
+                .parallel
+                .sampler_gain_db,
+            0.0
+        );
+
+        // An explicit printer needs an output path.
+        let err = parse_config("[parallel]\ndevice = \"printer\"\n").unwrap_err();
+        assert!(err.to_string().contains("needs an output path"), "{err:#}");
+
+        // Out-of-range gain (dB) is rejected.
+        let err =
+            parse_config("[parallel]\ndevice = \"sampler\"\nsampler_gain = 100\n").unwrap_err();
+        assert!(err.to_string().contains("sampler_gain"), "{err:#}");
+
+        // An unknown device name is rejected.
+        let err = parse_config("[parallel]\ndevice = \"plotter\"\n").unwrap_err();
+        assert!(err.to_string().contains("must be"), "{err:#}");
+
+        // `none` explicitly empties the port even with a stale output path.
+        let cfg = parse_config("[parallel]\ndevice = \"none\"\n")?;
+        assert_eq!(cfg.parallel.device, ParallelDevice::None);
         Ok(())
     }
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1953,9 +1953,14 @@ pub fn build_machine(
         log::warn!("[audio] stereo_separation is ignored while channel_mode is mono");
     }
     let mut bus = Bus::new(mem, paula, floppy);
-    if let Some(path) = &cfg.parallel_output_path {
-        bus.attach_parallel_port(Box::new(crate::parallel::FileParallelPort::create(path)?));
-        info!("parallel: capturing Centronics bytes to {}", path.display());
+    // The printer attaches here (its byte sink is `Send`). A sampler owns a
+    // cpal capture stream that is `!Send` on some hosts, so the frontend builds
+    // and attaches it on the main thread from a `SamplerRequest` instead.
+    if cfg.parallel.device == crate::config::ParallelDevice::Printer {
+        if let Some(path) = &cfg.parallel.printer_output {
+            bus.attach_parallel_port(Box::new(crate::parallel::FileParallelPort::create(path)?));
+            info!("parallel: capturing Centronics bytes to {}", path.display());
+        }
     }
     bus.set_video_standard(cfg.video_standard);
     bus.set_chipset_revisions(cfg.agnus_revision, cfg.denise_revision);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod recorder;
 pub mod romsearch;
 pub mod romtags;
 pub mod rtc;
+pub mod sampler;
 pub mod savestate;
 pub mod screenshot;
 pub mod scsi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,9 @@ pub struct CliArgs {
     pub list_midi: bool,
     /// `--list-audio-devices`: print the host audio output devices and exit.
     pub list_audio_devices: bool,
+    /// `--sampler-list-audio-inputs`: print the host audio input devices (for
+    /// `--sampler-audio-input`) and exit.
+    pub list_sampler_inputs: bool,
     /// Command-line machine overrides (`--model`, `--chipset`, `--cpu`,
     /// `--fpu`/`--no-fpu`, `--cpu-clock`, `--chip`, `--fast`, `--slow`,
     /// `--floppy-drives`).
@@ -310,6 +313,7 @@ where
     let mut calibrate_gamepad = false;
     let mut list_midi = false;
     let mut list_audio_devices = false;
+    let mut list_sampler_inputs = false;
     let mut overrides = ConfigOverrides::default();
     let mut args = args.into_iter().peekable();
     while let Some(a) = args.next() {
@@ -322,6 +326,9 @@ where
             }
             "--list-audio-devices" => {
                 list_audio_devices = true;
+            }
+            "--sampler-list-audio-inputs" => {
+                list_sampler_inputs = true;
             }
             "--config" | "-c" => {
                 let v = args
@@ -424,6 +431,25 @@ where
                     args.next()
                         .ok_or_else(|| anyhow!("--midi-in requires a device name"))?,
                 );
+            }
+            "--parallel" => {
+                overrides.parallel = Some(args.next().ok_or_else(|| {
+                    anyhow!("--parallel requires a device (none/printer/sampler)")
+                })?);
+            }
+            "--sampler-audio-input" => {
+                overrides.sampler_input = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--sampler-audio-input requires a device name"))?,
+                );
+            }
+            "--sampler-input-gain" => {
+                let gain: f32 = next_arg(
+                    &mut args,
+                    "--sampler-input-gain requires a value in dB (e.g. 0, 6, -6)",
+                    "--sampler-input-gain must be a number",
+                )?;
+                overrides.sampler_gain = Some(gain);
             }
             "--audio-device" => {
                 overrides.audio_device = Some(
@@ -809,6 +835,7 @@ where
         calibrate_gamepad,
         list_midi,
         list_audio_devices,
+        list_sampler_inputs,
         overrides,
     })
 }
@@ -912,6 +939,10 @@ fn print_help() {
          --profile-live-audio SECS      run a no-window Paula-to-cpal profile workload;\n  \
          \x20                            combine with COPPERLINE_AUDIO_PROFILE=1 for counters\n  \
          --serial MODE                  Paula serial port: off, stdout, midi, tcp, or pty\n  \
+         --parallel DEVICE              parallel port: none, printer, or sampler\n  \
+         --sampler-audio-input NAME     sampler host capture device (implies --parallel sampler)\n  \
+         --sampler-input-gain DB        sampler input gain in dB (implies --parallel sampler)\n  \
+         --sampler-list-audio-inputs    list host audio input devices and exit\n  \
          {midi}--calibrate-gamepad            interactively bind a USB gamepad to the port-2\n  \
          \x20                            joystick, save the calibration, then exit\n  \
          -h, --help                     show this help and exit\n  \
@@ -1263,6 +1294,21 @@ fn print_audio_output_devices() -> Result<()> {
     Ok(())
 }
 
+/// Print the host audio input devices for `--sampler-list-audio-inputs`. These
+/// are the names `--sampler-audio-input` and `[parallel] sampler_input` match
+/// against.
+fn print_sampler_input_devices() -> Result<()> {
+    println!("Audio input devices (for --sampler-audio-input / [parallel] sampler_input):");
+    let devices = copperline::sampler::list_input_devices();
+    if devices.is_empty() {
+        println!("  (none found)");
+    }
+    for name in devices {
+        println!("  {name}");
+    }
+    Ok(())
+}
+
 /// Print the host MIDI endpoints for `--list-midi`. This is how a user finds the
 /// names `--midi-out`/`--midi-in` and `[serial]` expect. Without the `midi`
 /// feature it says how to get MIDI support rather than printing nothing.
@@ -1325,6 +1371,9 @@ fn main() -> Result<()> {
     }
     if cli.list_audio_devices {
         return print_audio_output_devices();
+    }
+    if cli.list_sampler_inputs {
+        return print_sampler_input_devices();
     }
     let (cfg, mut raw_cfg) = load_config(cli.config_path.as_deref(), &cli.overrides)?;
     if let Some(p) = &cli.rom_path {
@@ -1494,6 +1543,7 @@ fn main() -> Result<()> {
         config::about_machine_lines(&cfg),
         raw_cfg,
         live_audio,
+        copperline::sampler::SamplerRequest::from_config(&cfg.parallel),
     );
     #[cfg(feature = "control")]
     if let Some(listen) = cli.control_gui {
@@ -1594,6 +1644,8 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         vec!["Configure a machine, then press Run.".to_string()],
         raw_cfg,
         audio_output_enabled,
+        // The placeholder runs no sampler; run_machine attaches it on Run.
+        copperline::sampler::SamplerRequest::default(),
     );
     app.open_launcher();
     app.run()

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -2,19 +2,31 @@
 
 //! Amiga Centronics parallel-port peripheral boundary.
 //!
-//! CIA-B port B carries the eight data pins and its `PC` output is the
-//! active-low printer strobe. A peripheral that accepts a strobed byte returns
-//! `true`; the bus turns that response into the printer's active-low `/ACK`
-//! edge on CIA-A `FLAG`. The default null peripheral is an unplugged cable and
-//! never acknowledges.
+//! CIA-A port B (`$BFE101`) carries the eight data pins and CIA-A's `PC` output
+//! is the active-low printer strobe. An output peripheral that accepts a
+//! strobed byte returns `true`; the bus turns that response into the printer's
+//! active-low `/ACK` edge on CIA-A `FLAG`. An input peripheral instead drives
+//! the data pins itself (see [`ParallelPort::read_data`]), which is how an
+//! audio sampler digitizes the port. The default null peripheral is an
+//! unplugged cable: it neither acknowledges nor drives the pins.
 
 use std::io::Write;
 
 pub trait ParallelPort: Send {
-    /// Observe one CIA-B `PC` strobe with the current physical port-B pin
+    /// Observe one CIA-A `PC` strobe with the current physical port-B pin
     /// levels. `at_cck` is the deterministic power-on colour-clock timestamp.
     /// Return true to drive one `/ACK` falling edge back to CIA-A `FLAG`.
     fn strobe(&mut self, data: u8, at_cck: u64) -> bool;
+
+    /// Drive the eight parallel data pins as an input peripheral. Called on
+    /// every CIA-A port-B read; returning `Some(byte)` replaces the value the
+    /// guest reads from `$BFE101`, `None` leaves the CIA's own pin state. An
+    /// output-only peripheral (printer) keeps the default and never drives the
+    /// pins. `at_cck` is the deterministic power-on colour-clock timestamp,
+    /// which a free-running capture device uses to advance in emulated time.
+    fn read_data(&mut self, _at_cck: u64) -> Option<u8> {
+        None
+    }
 
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Parallel-port audio sampler (digitizer) -- a [`crate::parallel::ParallelPort`]
+//! input peripheral.
+//!
+//! Classic Amiga 8-bit samplers (AMAS, DSS, Megalosound, the open-amiga-sampler)
+//! are a mono ADC on the parallel port: the 8 data lines (D0-D7 = CIA-A port B,
+//! `$BFE101`) carry the current sample, which the software reads in a tight,
+//! CIA-timer-paced loop to record. The hardware model here -- a straight-binary
+//! 8-bit ADC (an ADC0820) on the data lines, mono -- follows the open-amiga-
+//! sampler project's schematics (github.com/echolevel/open-amiga-sampler).
+//!
+//! The emulation approach is an independent Rust implementation following the
+//! method in WinUAE's `sampler.cpp` (Toni Wilen; WinUAE is GPL-2.0-or-later,
+//! compatible with this GPL-3.0-or-later project): a host capture stream (cpal,
+//! mirroring [`crate::audio::CpalSink`]) fills a ring in real time, and each
+//! port-B read returns the sample for the elapsed *emulated* time, so the input
+//! lines up however fast or slow the Amiga polls. The value is 8-bit
+//! offset-binary (128 = silence), as the ADC presents. Host L+R are summed into
+//! the single input (these units are mono); [`CpalSampler`] is the live
+//! implementation, built only in the `frontend` feature that carries cpal.
+
+#[cfg(feature = "frontend")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "frontend")]
+use std::sync::Arc;
+
+#[cfg(feature = "frontend")]
+use anyhow::{anyhow, Result};
+#[cfg(feature = "frontend")]
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+#[cfg(feature = "frontend")]
+use ringbuf::traits::{Consumer, Observer, Producer, Split};
+#[cfg(feature = "frontend")]
+use ringbuf::HeapRb;
+
+/// Set `COPPERLINE_SAMPLER_DEBUG=1` to log the captured input level (peak
+/// amplitude) about once a second -- a CLI VU meter to confirm the host mic is
+/// feeding the sampler and to gauge input gain.
+#[cfg(feature = "frontend")]
+const SAMPLER_DEBUG_ENV: &str = "COPPERLINE_SAMPLER_DEBUG";
+
+/// The largest input gain the sampler preamp will apply (~+24 dB); higher
+/// requests are clamped. Past this a real preamp is just clipping anyway.
+/// Gain is expressed in decibels, as on a real preamp; +24 dB is ~16x.
+pub const MAX_SAMPLER_GAIN_DB: f32 = 24.0;
+/// The most the sampler preamp will attenuate (-24 dB is ~1/16x), for taming a
+/// hot line input. Lower requests are clamped.
+pub const MIN_SAMPLER_GAIN_DB: f32 = -24.0;
+
+/// Convert a preamp gain in decibels to the linear multiplier applied to
+/// samples (0 dB = unity).
+pub fn gain_db_to_linear(db: f32) -> f32 {
+    10f32.powf(db / 20.0)
+}
+
+/// A request to attach a parallel-port sampler, carried from the CLI/config
+/// through the window so machines launched from the config screen get it too.
+#[derive(Clone)]
+pub struct SamplerRequest {
+    /// Whether a sampler is attached at all.
+    pub enabled: bool,
+    /// Host capture device; `None` uses the system default.
+    pub input_device: Option<String>,
+    /// Input gain in decibels, standing in for a real sampler's preamp, applied
+    /// before the 8-bit ADC conversion. 0 dB = unity; clamped to
+    /// [`MIN_SAMPLER_GAIN_DB`]..[`MAX_SAMPLER_GAIN_DB`].
+    pub gain_db: f32,
+}
+
+impl Default for SamplerRequest {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            input_device: None,
+            gain_db: 0.0,
+        }
+    }
+}
+
+impl SamplerRequest {
+    /// Derive the request from resolved `[parallel]` config: enabled only when
+    /// the connected device is the sampler.
+    pub fn from_config(parallel: &crate::config::ParallelConfig) -> Self {
+        Self {
+            enabled: parallel.device == crate::config::ParallelDevice::Sampler,
+            input_device: parallel.sampler_input.clone(),
+            gain_db: parallel.sampler_gain_db,
+        }
+    }
+}
+
+/// Map a normalised sample in roughly [-1.0, 1.0] to the ADC's 8-bit
+/// offset-binary output (0 = -full, 128 = silence, 255 = +full), like the
+/// straight-binary ADC0820 on a real sampler.
+#[cfg(any(feature = "frontend", test))]
+fn sample_to_byte(v: f32) -> u8 {
+    let scaled = (v.clamp(-1.0, 1.0) * 128.0).round() as i32 + 128;
+    scaled.clamp(0, 255) as u8
+}
+
+/// Names of the host's audio *input* devices, for `--sampler-list-audio-inputs`
+/// and as the base for the GUI picker, with ALSA's plugin handles filtered out
+/// (as for outputs). ALSA's "default" is kept here so the CLI can name it; the
+/// GUI drops it separately (see [`picker_input_devices`]). Empty if the host
+/// cannot enumerate; a hidden entry is still selectable by name.
+#[cfg(feature = "frontend")]
+pub fn list_input_devices() -> Vec<String> {
+    crate::audio::quiet_alsa_probe_logging();
+    cpal::default_host()
+        .input_devices()
+        .map(|devs| {
+            devs.filter_map(|d| d.name().ok())
+                .filter(|name| !crate::audio::is_alsa_plugin_variant(name))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Input-device names for the GUI picker (launcher field + runtime menu). Same
+/// as [`list_input_devices`], but drops ALSA's "default" when it is the system
+/// default input, since the picker already offers a synthetic "Default" (the
+/// `None` selection). Re-enumerated on demand, so a device that came online
+/// since the screen opened appears. Still selectable by name in the config/CLI.
+#[cfg(feature = "frontend")]
+pub fn picker_input_devices() -> Vec<String> {
+    let default_name = cpal::default_host()
+        .default_input_device()
+        .and_then(|d| d.name().ok());
+    list_input_devices()
+        .into_iter()
+        .filter(|name| !crate::audio::is_redundant_default(name, default_name.as_deref()))
+        .collect()
+}
+
+/// Cycle a sampler input selection through "Default" (`None`) then the named
+/// devices and back, for the runtime menu.
+#[cfg(feature = "frontend")]
+pub fn next_input_device(current: Option<&str>, names: &[String], forward: bool) -> Option<String> {
+    let here = current
+        .and_then(|c| names.iter().position(|n| n == c))
+        .map_or(0, |i| i + 1);
+    let count = names.len() + 1;
+    let next = if forward {
+        (here + 1) % count
+    } else {
+        (here + count - 1) % count
+    };
+    (next > 0).then(|| names[next - 1].clone())
+}
+
+/// The input device to open: the first whose name contains `want`
+/// (case-insensitive), otherwise the system default. A named-but-missing device
+/// warns and falls back to the default rather than failing to attach.
+#[cfg(feature = "frontend")]
+fn select_input_device(host: &cpal::Host, want: Option<&str>) -> Result<cpal::Device> {
+    if let Some(name) = want {
+        let needle = name.to_lowercase();
+        let matched = host.input_devices().ok().and_then(|mut devs| {
+            devs.find(|d| {
+                d.name()
+                    .map(|n| n.to_lowercase().contains(&needle))
+                    .unwrap_or(false)
+            })
+        });
+        match matched {
+            Some(device) => return Ok(device),
+            None => log::warn!("sampler: no input device matches {name:?}; using the default"),
+        }
+    }
+    host.default_input_device()
+        .ok_or_else(|| anyhow!("no default audio input device"))
+}
+
+/// The bus-side of a live cpal capture: the ring consumer and the read logic
+/// that turns it into 8-bit ADC values. This is `Send` (unlike the cpal stream
+/// that feeds it), so it can live inside the `Send` [`crate::parallel::ParallelPort`]
+/// slot in the bus; the caller keeps the paired [`cpal::Stream`] alive on the
+/// main thread. Build both with [`CpalSampler::open`].
+#[cfg(feature = "frontend")]
+pub struct CpalSampler {
+    consumer: ringbuf::HeapCons<(f32, f32)>,
+    /// Host capture sample rate (frames per second).
+    capture_rate: f64,
+    /// Drop capture backlog beyond this many frames so reads stay near the live
+    /// edge (bounded latency), the role of WinUAE's `safediff`.
+    max_latency_frames: usize,
+    device_label: String,
+    /// Emulated time of the previous read, for advancing the read position.
+    last_seconds: Option<f64>,
+    /// Last summed L+R frame returned, held during underruns and sub-sample reads.
+    last_mono: f32,
+    /// Count of CIA-A port-B reads routed here since the meter last reported, so
+    /// the debug log shows whether the Amiga software is actually polling.
+    reads: Arc<AtomicU64>,
+}
+
+#[cfg(feature = "frontend")]
+impl CpalSampler {
+    /// Open the host capture device (`None` = system default) and start feeding
+    /// a ring. `gain_db` is the preamp gain in decibels (0 dB = unity), clamped
+    /// to the sampler's range and applied before the ADC conversion. Returns the
+    /// live cpal input stream -- which the caller must keep alive on the main
+    /// thread, since it is `!Send` on some hosts -- paired with the `Send` port
+    /// that reads from it and attaches to the bus. Errors if no device/stream can
+    /// open.
+    pub fn open(input_device: Option<&str>, gain_db: f32) -> Result<(cpal::Stream, Self)> {
+        crate::audio::quiet_alsa_probe_logging();
+        let clamped_db = gain_db.clamp(MIN_SAMPLER_GAIN_DB, MAX_SAMPLER_GAIN_DB);
+        if clamped_db != gain_db {
+            log::warn!(
+                "sampler: gain {gain_db} dB out of range [{MIN_SAMPLER_GAIN_DB}, \
+                 {MAX_SAMPLER_GAIN_DB}] dB; clamping"
+            );
+        }
+        // The capture callback multiplies samples by the linear equivalent.
+        let gain = gain_db_to_linear(clamped_db);
+        let host = cpal::default_host();
+        let device = select_input_device(&host, input_device)?;
+        let supported = device
+            .default_input_config()
+            .map_err(|e| anyhow!("query default input config: {e}"))?;
+        let sample_format = supported.sample_format();
+        let channels = supported.channels() as usize;
+        let capture_rate = supported.sample_rate().0 as f64;
+        let config: cpal::StreamConfig = supported.into();
+
+        // ~2 s ring at the capture rate; we trim backlog on read to stay live.
+        let capacity = (capture_rate as usize * 2).max(4096);
+        let rb = HeapRb::<(f32, f32)>::new(capacity);
+        let (mut producer, consumer) = rb.split();
+
+        // Opt-in input-level meter: log the peak captured amplitude ~once a
+        // second so it is obvious whether the host mic is actually feeding the
+        // sampler (and to gauge input gain). See `SAMPLER_DEBUG_ENV`.
+        let level_debug = crate::envcfg::flag(SAMPLER_DEBUG_ENV);
+        let log_every = capture_rate.max(1.0) as u64;
+        let reads = Arc::new(AtomicU64::new(0));
+        let reads_meter = Arc::clone(&reads);
+        let mut peak = 0.0f32;
+        let mut counted = 0u64;
+        // Shared per-frame handler: meter, then push the (l, r) frame. A mono
+        // device mirrors its one channel to both sides; a full ring drops the
+        // newest frame (the reader trims to the live edge anyway).
+        let mut on_frame = move |l: f32, r: f32| {
+            // Apply the preamp gain up front, so the meter and the ring (and thus
+            // what the Amiga reads) all reflect the post-gain level.
+            let l = l * gain;
+            let r = r * gain;
+            if level_debug {
+                peak = peak.max(l.abs()).max(r.abs());
+                counted += 1;
+                if counted >= log_every {
+                    let prb = reads_meter.swap(0, Ordering::Relaxed);
+                    log::info!(
+                        "sampler: input level {:.0}% (peak {peak:.3}), port-B reads/s {prb}",
+                        peak * 100.0
+                    );
+                    peak = 0.0;
+                    counted = 0;
+                }
+            }
+            let _ = producer.try_push((l, r));
+        };
+
+        let err_fn = |err| log::warn!("sampler: cpal input stream error: {err}");
+
+        let stream = match sample_format {
+            cpal::SampleFormat::F32 => device.build_input_stream(
+                &config,
+                move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                    for frame in data.chunks(channels) {
+                        let l = frame.first().copied().unwrap_or(0.0);
+                        let r = if channels >= 2 { frame[1] } else { l };
+                        on_frame(l, r);
+                    }
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::I16 => device.build_input_stream(
+                &config,
+                move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                    for frame in data.chunks(channels) {
+                        let l = frame.first().copied().unwrap_or(0) as f32 / 32768.0;
+                        let r = if channels >= 2 {
+                            frame[1] as f32 / 32768.0
+                        } else {
+                            l
+                        };
+                        on_frame(l, r);
+                    }
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::U16 => device.build_input_stream(
+                &config,
+                move |data: &[u16], _: &cpal::InputCallbackInfo| {
+                    for frame in data.chunks(channels) {
+                        let l =
+                            (frame.first().copied().unwrap_or(32768) as f32 - 32768.0) / 32768.0;
+                        let r = if channels >= 2 {
+                            (frame[1] as f32 - 32768.0) / 32768.0
+                        } else {
+                            l
+                        };
+                        on_frame(l, r);
+                    }
+                },
+                err_fn,
+                None,
+            ),
+            other => return Err(anyhow!("unsupported sampler input format {other:?}")),
+        }
+        .map_err(|e| anyhow!("build_input_stream: {e}"))?;
+        stream
+            .play()
+            .map_err(|e| anyhow!("input stream play: {e}"))?;
+
+        let device_label = device.name().unwrap_or_else(|_| "<unknown>".into());
+        log::info!(
+            "sampler: parallel-port sampler ready, device={device_label:?}, \
+             capture_rate={capture_rate}, format={sample_format:?}"
+        );
+
+        Ok((
+            stream,
+            Self {
+                consumer,
+                capture_rate,
+                // ~50 ms of bounded latency.
+                max_latency_frames: (capture_rate * 0.05) as usize,
+                device_label,
+                last_seconds: None,
+                last_mono: 0.0,
+                reads,
+            },
+        ))
+    }
+
+    /// The host capture device name, for logging and the UI.
+    pub fn device_label(&self) -> &str {
+        &self.device_label
+    }
+
+    /// The current 8-bit offset-binary ADC value (128 = silence), advanced
+    /// through the live capture by the emulated time since the previous read.
+    /// A mono digitizer: the host L+R are summed into the single ADC input.
+    fn next_byte(&mut self, emu_seconds: f64) -> u8 {
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        // Trim backlog so reads track the live edge instead of a growing delay.
+        let backlog = self.consumer.occupied_len();
+        if backlog > self.max_latency_frames {
+            self.consumer.skip(backlog - self.max_latency_frames);
+        }
+
+        // Advance the read position by the emulated time since the last read
+        // (WinUAE sampler.cpp's approach): faster-than-capture polling repeats a
+        // frame (advance 0), slower polling averages the frames it skips over --
+        // cheap anti-aliasing.
+        let advance = match self.last_seconds {
+            Some(prev) => ((emu_seconds - prev).max(0.0) * self.capture_rate).round() as usize,
+            None => 1,
+        };
+        self.last_seconds = Some(emu_seconds);
+
+        if advance > 0 {
+            // Sum L+R into the mono input a single-input sampler sees.
+            let mut sum = 0.0f32;
+            let mut n = 0usize;
+            for _ in 0..advance {
+                match self.consumer.try_pop() {
+                    Some((l, r)) => {
+                        sum += 0.5 * (l + r);
+                        n += 1;
+                    }
+                    None => break,
+                }
+            }
+            if n > 0 {
+                self.last_mono = sum / n as f32;
+            }
+        }
+
+        sample_to_byte(self.last_mono)
+    }
+}
+
+#[cfg(feature = "frontend")]
+impl crate::parallel::ParallelPort for CpalSampler {
+    /// A sampler is input-only: it digitizes the data lines and never accepts a
+    /// strobed output byte, so it drives no `/ACK`.
+    fn strobe(&mut self, _data: u8, _at_cck: u64) -> bool {
+        false
+    }
+
+    /// A port-B read returns the digitized sample. The ADC always drives the
+    /// data lines, so this is never `None`. `at_cck` is converted to emulated
+    /// seconds against Paula's colour clock to advance the live capture.
+    fn read_data(&mut self, at_cck: u64) -> Option<u8> {
+        let emu_seconds = at_cck as f64 / crate::chipset::paula::PAULA_CLOCK_HZ as f64;
+        Some(self.next_byte(emu_seconds))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offset_binary_conversion_centres_silence() {
+        assert_eq!(sample_to_byte(0.0), 128);
+        // Full scale hits the rails: -full = 0, +full clamps to 255.
+        assert_eq!(sample_to_byte(-1.0), 0);
+        assert_eq!(sample_to_byte(1.0), 255);
+        // Clamps beyond full-scale rather than wrapping.
+        assert_eq!(sample_to_byte(2.0), 255);
+        assert_eq!(sample_to_byte(-2.0), 0);
+    }
+}

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -24,8 +24,9 @@ use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
     format_size, machine_profile_defaults, ChannelMode, Chipset, Config, CpuModel,
-    JoystickInputMode, MachineModel, Overscan, PacingBudget, PixelAspect, RawConfig, RawDrive,
-    RawFilesysMount, RawFloppyDrive, RawZorroBoard, ScsiController, SerialMode, WarpSpeed,
+    JoystickInputMode, MachineModel, Overscan, PacingBudget, ParallelDevice, PixelAspect,
+    RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, ScsiController,
+    SerialMode, WarpSpeed,
 };
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
 use anyhow::Result;
@@ -172,6 +173,7 @@ pub enum LauncherTab {
     // Only reached in a `midi` build, where it is added to TABS.
     #[cfg_attr(not(feature = "midi"), allow(dead_code))]
     Serial,
+    Parallel,
     Input,
     Zorro,
     AvEmulation,
@@ -191,6 +193,7 @@ pub const TABS: &[LauncherTab] = &[
     LauncherTab::Cd,
     #[cfg(feature = "midi")]
     LauncherTab::Serial,
+    LauncherTab::Parallel,
     LauncherTab::Input,
     LauncherTab::Zorro,
     LauncherTab::AvEmulation,
@@ -208,6 +211,7 @@ impl LauncherTab {
             LauncherTab::HostFs => "Host Mounts",
             LauncherTab::Cd => "CD",
             LauncherTab::Serial => "Serial",
+            LauncherTab::Parallel => "Parallel",
             LauncherTab::Input => "Input",
             LauncherTab::Zorro => "Zorro",
             LauncherTab::AvEmulation => "A/V & Emu",
@@ -289,6 +293,10 @@ pub enum LauncherField {
     MidiOut,
     #[cfg(feature = "midi")]
     MidiIn,
+    // Parallel
+    ParallelDevice,
+    SamplerInput,
+    SamplerGain,
     // A/V and emulation
     AudioDevice,
     AudioChannelMode,
@@ -448,11 +456,23 @@ const CD_ROWS: [Row; 3] = [
     row(F::CdInsertDelay, "Insert delay", Cycle),
     row(F::Cd32Nvram, "CD32 NVRAM", PathRow),
 ];
+// The MIDI endpoint rows appear only when the serial port is in MIDI mode, so
+// the Serial tab shows just the Mode selector otherwise.
 #[cfg(feature = "midi")]
-const SERIAL_ROWS: [Row; 3] = [
+const SERIAL_ROWS_BASE: [Row; 1] = [row(F::SerialMode, "Mode", Cycle)];
+#[cfg(feature = "midi")]
+const SERIAL_ROWS_MIDI: [Row; 3] = [
     row(F::SerialMode, "Mode", Cycle),
     row(F::MidiIn, "MIDI input", Cycle),
     row(F::MidiOut, "MIDI output", Cycle),
+];
+// The sampler input/gain rows appear only when the sampler is the selected
+// device, so None/Printer show just the Device selector.
+const PARALLEL_ROWS_BASE: [Row; 1] = [row(F::ParallelDevice, "Device", Cycle)];
+const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
+    row(F::ParallelDevice, "Device", Cycle),
+    row(F::SamplerInput, "Audio input", Cycle),
+    row(F::SamplerGain, "Input gain", Cycle),
 ];
 const AV_EMULATION_ROWS: [Row; 12] = [
     row(F::AudioDevice, "Audio output", Cycle),
@@ -474,9 +494,16 @@ const INPUT_ROWS: [Row; 3] = [
     row(F::Joystick, "Joystick input", Cycle),
 ];
 
-/// The rows shown on a tab, top to bottom. The `Zorro` tab has no rows: it is
-/// drawn as a board list with Add/Remove controls (see the panel code).
-pub fn rows(tab: LauncherTab) -> &'static [Row] {
+/// The rows shown on a tab, top to bottom. The Serial and Parallel tabs are
+/// dynamic: the MIDI endpoint rows appear only in MIDI mode and the sampler
+/// rows only when the sampler is selected, so unrelated options stay hidden
+/// rather than greyed. The `Zorro` tab has no rows: it is drawn as a board list
+/// with Add/Remove controls (see the panel code).
+pub fn rows(
+    tab: LauncherTab,
+    parallel_device: ParallelDevice,
+    serial_mode: SerialMode,
+) -> &'static [Row] {
     match tab {
         LauncherTab::System => &SYSTEM_ROWS,
         LauncherTab::Cpu => &CPU_ROWS,
@@ -486,23 +513,38 @@ pub fn rows(tab: LauncherTab) -> &'static [Row] {
         LauncherTab::Storage => &STORAGE_ROWS,
         LauncherTab::HostFs => &HOSTFS_ROWS,
         LauncherTab::Cd => &CD_ROWS,
-        LauncherTab::Serial => serial_rows(),
+        LauncherTab::Serial => serial_rows(serial_mode),
+        LauncherTab::Parallel => parallel_rows(parallel_device),
         LauncherTab::Input => &INPUT_ROWS,
         LauncherTab::Zorro => &[],
         LauncherTab::AvEmulation => &AV_EMULATION_ROWS,
     }
 }
 
-/// Serial-tab rows. Only the `midi` build has any; without it the tab is absent
-/// from [`TABS`] and this is never reached.
-fn serial_rows() -> &'static [Row] {
+/// Serial-tab rows for the current mode. Only the `midi` build has any; without
+/// it the tab is absent from [`TABS`] and this is never reached.
+fn serial_rows(serial_mode: SerialMode) -> &'static [Row] {
     #[cfg(feature = "midi")]
     {
-        &SERIAL_ROWS
+        if serial_mode == SerialMode::Midi {
+            &SERIAL_ROWS_MIDI
+        } else {
+            &SERIAL_ROWS_BASE
+        }
     }
     #[cfg(not(feature = "midi"))]
     {
+        let _ = serial_mode;
         &[]
+    }
+}
+
+/// Parallel-tab rows for the selected device: the sampler adds its input and
+/// gain rows; None/Printer show just the Device selector.
+fn parallel_rows(parallel_device: ParallelDevice) -> &'static [Row] {
+    match parallel_device {
+        ParallelDevice::Sampler => &PARALLEL_ROWS_SAMPLER,
+        ParallelDevice::None | ParallelDevice::Printer => &PARALLEL_ROWS_BASE,
     }
 }
 
@@ -613,6 +655,25 @@ const SERIAL_MODES: [SerialMode; 5] = [
 /// The config/CLI accept any 0-100; an off-grid value snaps to the nearest here.
 const STEREO_SEPARATION_STEPS: [usize; 11] = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
+/// Sampler input-gain presets the picker steps through (preamp decibels, in
+/// 3 dB steps), ascending. 0 dB is unity; the ends are the sampler's
+/// [`crate::sampler::MIN_SAMPLER_GAIN_DB`]..[`crate::sampler::MAX_SAMPLER_GAIN_DB`].
+/// The config/CLI accept any value in range; an off-grid value snaps to the
+/// nearest here.
+const SAMPLER_GAIN_STEPS: [f64; 17] = [
+    -24.0, -21.0, -18.0, -15.0, -12.0, -9.0, -6.0, -3.0, 0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0,
+    21.0, 24.0,
+];
+
+/// Label a sampler gain in decibels, e.g. `0 dB`, `+6 dB`, `-12 dB`.
+fn sampler_gain_label(gain_db: f32) -> String {
+    if gain_db.abs() < 0.05 {
+        "0 dB".to_string()
+    } else {
+        format!("{gain_db:+.0} dB")
+    }
+}
+
 /// A fully-typed, editable mirror of a configurable machine. See the module
 /// docs for how it round-trips through [`RawConfig`].
 #[derive(Debug, Clone)]
@@ -683,9 +744,21 @@ pub struct MachineSetup {
     /// TCP listen address for `mode = "tcp"`; carried so the override
     /// round-trips through a launcher save even though no tab edits it.
     serial_listen: Option<String>,
-    /// Raw Centronics capture path. There is no launcher control yet, but a
-    /// hand-written `[parallel]` block must survive load/edit/save.
+    /// The Centronics parallel-port device (None/Printer/Sampler), edited on the
+    /// Parallel tab.
+    parallel_device: crate::config::ParallelDevice,
+    /// Raw Centronics printer capture path. There is no launcher control for the
+    /// path itself, but a hand-written `[parallel] output` must survive
+    /// load/edit/save, and its presence is what makes Printer selectable.
     parallel_output: Option<PathBuf>,
+    /// Sampler host capture device (`None` = system default) and its input gain,
+    /// edited on the Parallel tab.
+    sampler_input: Option<String>,
+    sampler_gain_db: f32,
+    /// Input device names for the sampler picker: filled when the screen opens
+    /// and re-read each time the field is cycled, so a reconnected device
+    /// appears.
+    sampler_input_devices: Vec<String>,
     /// Host endpoints for the device pickers, read once when this setup is
     /// built so a fresh config screen sees currently-connected devices.
     #[cfg(feature = "midi")]
@@ -800,7 +873,12 @@ impl MachineSetup {
             midi_out: cfg.serial.midi_out.clone(),
             midi_in: cfg.serial.midi_in.clone(),
             serial_listen: cfg.serial.listen.clone(),
-            parallel_output: cfg.parallel_output_path.clone(),
+            parallel_device: cfg.parallel.device,
+            parallel_output: cfg.parallel.printer_output.clone(),
+            sampler_input: cfg.parallel.sampler_input.clone(),
+            sampler_gain_db: cfg.parallel.sampler_gain_db,
+            // Filled by refresh_sampler_inputs on open, like the audio devices.
+            sampler_input_devices: Vec::new(),
             // Left empty here so config construction stays side-effect free; the
             // config screen fills it via refresh_midi_endpoints on open.
             #[cfg(feature = "midi")]
@@ -858,14 +936,30 @@ impl MachineSetup {
         self.audio_devices = crate::audio::picker_output_devices();
     }
 
-    /// Re-read every host device list (MIDI endpoints + audio outputs) for the
-    /// pickers. Call after (re)building the setup -- e.g. loading a config or
-    /// resetting to defaults -- so the pickers show what is connected now
-    /// instead of an empty list that can only land on "Default"/"None".
+    /// Re-read the host audio input devices for the sampler "Audio input" picker.
+    pub fn refresh_sampler_inputs(&mut self) {
+        self.sampler_input_devices = crate::sampler::picker_input_devices();
+    }
+
+    /// The selected serial mode and parallel device, so the panel can pick the
+    /// dynamic Serial/Parallel row sets (see [`rows`]).
+    pub fn serial_mode(&self) -> SerialMode {
+        self.serial_mode
+    }
+
+    pub fn parallel_device(&self) -> ParallelDevice {
+        self.parallel_device
+    }
+
+    /// Re-read every host device list (MIDI endpoints + audio outputs + sampler
+    /// inputs) for the pickers. Call after (re)building the setup -- e.g. loading
+    /// a config or resetting to defaults -- so the pickers show what is connected
+    /// now instead of an empty list that can only land on "Default"/"None".
     pub fn refresh_host_devices(&mut self) {
         #[cfg(feature = "midi")]
         self.refresh_midi_endpoints();
         self.refresh_audio_devices();
+        self.refresh_sampler_inputs();
     }
 
     /// The bare-profile config this setup is compared against when emitting
@@ -1081,7 +1175,24 @@ impl MachineSetup {
         raw.serial.midi_out = self.midi_out.clone();
         raw.serial.midi_in = self.midi_in.clone();
         raw.serial.listen = self.serial_listen.clone();
+        // Parallel port. Carry each peripheral's settings whenever they are set
+        // so a Save round-trips them even while another device is temporarily
+        // selected. The sampler options do not imply the sampler, so they are
+        // always safe to emit; a bare `output` path implies the printer, so an
+        // explicit `device` disambiguates when it is carried under None.
         raw.parallel.output = self.parallel_output.as_deref().map(path_string);
+        raw.parallel.sampler_input = self.sampler_input.clone();
+        raw.parallel.sampler_gain = (self.sampler_gain_db != 0.0).then_some(self.sampler_gain_db);
+        raw.parallel.device = match self.parallel_device {
+            // None is the resolved default (omitted to keep the TOML minimal),
+            // but emit it explicitly to override a carried-over `output` path
+            // that would otherwise be read back as the printer.
+            ParallelDevice::None => self
+                .parallel_output
+                .is_some()
+                .then(|| ParallelDevice::None.label().to_string()),
+            other => Some(other.label().to_string()),
+        };
         // The Audio output picker is one of default / a named device / Disabled.
         // A named device sets output_device; Disabled sets output_enabled=false
         // (the resolved default is true, so it is omitted otherwise).
@@ -1286,8 +1397,8 @@ impl MachineSetup {
                 let slot = filesys_readonly_slot(field).expect("readonly field");
                 reason(self.filesys_dirs[slot].is_some(), "no directory")
             }
-            #[cfg(feature = "midi")]
-            F::MidiOut | F::MidiIn => reason(self.serial_mode == SerialMode::Midi, "MIDI off"),
+            // The MIDI endpoint and sampler input/gain rows are hidden entirely
+            // when inactive (see `rows`), so they never need a greyed state.
             // Channel mode and separation shape the output, so they do nothing
             // once audio is disabled; separation also does nothing in mono.
             F::AudioChannelMode => reason(self.audio_output.is_enabled(), "off"),
@@ -1528,6 +1639,16 @@ impl MachineSetup {
             F::MidiOut => self.midi_out.clone().unwrap_or_else(|| "None".to_string()),
             #[cfg(feature = "midi")]
             F::MidiIn => self.midi_in.clone().unwrap_or_else(|| "None".to_string()),
+            F::ParallelDevice => match self.parallel_device {
+                ParallelDevice::None => "None".to_string(),
+                ParallelDevice::Printer => "Printer".to_string(),
+                ParallelDevice::Sampler => "Sampler".to_string(),
+            },
+            F::SamplerInput => self
+                .sampler_input
+                .clone()
+                .unwrap_or_else(|| "Default".to_string()),
+            F::SamplerGain => sampler_gain_label(self.sampler_gain_db),
             F::AudioDevice => self.audio_output.label().to_string(),
             F::AudioChannelMode => match self.audio_channel_mode {
                 ChannelMode::Stereo => "Stereo".to_string(),
@@ -1652,6 +1773,30 @@ impl MachineSetup {
             F::MidiOut => cycle_endpoint(&mut self.midi_out, &self.midi_endpoints.outputs, forward),
             #[cfg(feature = "midi")]
             F::MidiIn => cycle_endpoint(&mut self.midi_in, &self.midi_endpoints.inputs, forward),
+            F::ParallelDevice => {
+                // Printer is only on offer when a capture path exists (the
+                // launcher has no path editor), so a fresh screen cycles
+                // None <-> Sampler and a loaded printer config round-trips.
+                let mut choices = vec![ParallelDevice::None, ParallelDevice::Sampler];
+                if self.parallel_output.is_some() {
+                    choices.insert(1, ParallelDevice::Printer);
+                }
+                self.parallel_device = cycle_slice(&choices, self.parallel_device, forward);
+            }
+            F::SamplerInput => {
+                // Re-read on each step so a device connected since the screen
+                // opened appears; on-demand only, so no background polling.
+                self.refresh_sampler_inputs();
+                self.sampler_input = crate::sampler::next_input_device(
+                    self.sampler_input.as_deref(),
+                    &self.sampler_input_devices,
+                    forward,
+                );
+            }
+            F::SamplerGain => {
+                self.sampler_gain_db =
+                    cycle_floats(&SAMPLER_GAIN_STEPS, self.sampler_gain_db as f64, forward) as f32;
+            }
             F::AudioDevice => {
                 // Re-read on each step so a device connected since the screen
                 // opened appears; on-demand only, so no background polling.
@@ -1979,10 +2124,12 @@ fn cycle_endpoint(
 }
 
 /// Whether `field` appears anywhere with the given row kind. Used to classify a
-/// field (toggle vs path) without threading the tab through every call.
+/// field (toggle vs path) without threading the tab through every call. Passes
+/// the row-maximising selections so the dynamic Serial/Parallel rows are all in
+/// view.
 fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
     TABS.iter()
-        .flat_map(|&t| rows(t))
+        .flat_map(|&t| rows(t, ParallelDevice::Sampler, SerialMode::Midi))
         .any(|r| r.field == field && r.kind == kind)
 }
 
@@ -2531,20 +2678,82 @@ mod tests {
 
     #[test]
     fn parallel_output_round_trips_through_raw() {
-        // There is no launcher control for [parallel], so loading and saving
-        // must preserve a hand-written capture path unchanged.
+        // The launcher has no printer-path editor, so loading and saving must
+        // preserve a hand-written capture path (and its implied Printer device)
+        // unchanged.
         let mut raw = RawConfig::default();
         raw.parallel.output = Some("captures/printer.raw".into());
         let setup = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(setup.parallel_device, ParallelDevice::Printer);
         assert_eq!(
             setup.parallel_output.as_deref(),
             Some(std::path::Path::new("captures/printer.raw"))
         );
         let back = setup.to_raw();
+        assert_eq!(back.parallel.device.as_deref(), Some("printer"));
         assert_eq!(
             back.parallel.output.as_deref(),
             Some("captures/printer.raw")
         );
+    }
+
+    #[test]
+    fn parallel_sampler_rows_appear_only_when_selected() {
+        let has = |device| {
+            rows(LauncherTab::Parallel, device, SerialMode::default())
+                .iter()
+                .any(|r| r.field == LauncherField::SamplerInput)
+        };
+        // The sampler rows are hidden (not greyed) unless the sampler is chosen.
+        assert!(!has(ParallelDevice::None));
+        assert!(!has(ParallelDevice::Printer));
+        assert!(has(ParallelDevice::Sampler));
+    }
+
+    #[test]
+    fn midi_rows_appear_only_in_midi_mode() {
+        let has = |mode| {
+            rows(LauncherTab::Serial, ParallelDevice::None, mode)
+                .iter()
+                .any(|r| r.field == LauncherField::MidiOut)
+        };
+        assert!(!has(SerialMode::Stdout));
+        assert!(has(SerialMode::Midi));
+    }
+
+    #[test]
+    fn parallel_sampler_selection_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        assert_eq!(s.parallel_device, ParallelDevice::None);
+
+        // Cycle None -> Sampler (Printer is absent without a capture path).
+        s.cycle(LauncherField::ParallelDevice, true);
+        assert_eq!(s.parallel_device, ParallelDevice::Sampler);
+
+        s.sampler_input = Some("BlackHole".into());
+        s.sampler_gain_db = 6.0;
+        let raw = s.to_raw();
+        assert_eq!(raw.parallel.device.as_deref(), Some("sampler"));
+        assert_eq!(raw.parallel.sampler_input.as_deref(), Some("BlackHole"));
+        assert_eq!(raw.parallel.sampler_gain, Some(6.0));
+
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.parallel_device, ParallelDevice::Sampler);
+        assert_eq!(back.sampler_input.as_deref(), Some("BlackHole"));
+        assert_eq!(back.sampler_gain_db, 6.0);
+
+        // Switching the device to None must still carry the sampler settings
+        // through a Save (they do not imply the sampler on reload).
+        s.cycle(LauncherField::ParallelDevice, false); // Sampler -> None
+        assert_eq!(s.parallel_device, ParallelDevice::None);
+        let raw = s.to_raw();
+        assert_eq!(raw.parallel.device, None);
+        assert_eq!(raw.parallel.sampler_input.as_deref(), Some("BlackHole"));
+        assert_eq!(raw.parallel.sampler_gain, Some(6.0));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.parallel_device, ParallelDevice::None);
+        assert_eq!(back.sampler_input.as_deref(), Some("BlackHole"));
+        assert_eq!(back.sampler_gain_db, 6.0);
     }
 
     #[test]
@@ -2683,8 +2892,6 @@ mod tests {
 
         s.cycle(LauncherField::SerialMode, true); // Stdout -> MIDI
         assert_eq!(s.serial_mode, SerialMode::Midi);
-        // The device rows are live only in MIDI mode.
-        assert_eq!(s.disabled_reason(LauncherField::MidiOut), None);
         s.midi_out = Some("USB MIDI".to_string());
 
         let raw = s.to_raw();
@@ -2774,10 +2981,16 @@ mod tests {
 
     #[cfg(feature = "midi")]
     #[test]
-    fn midi_device_rows_are_disabled_off_midi_mode() {
-        let s = MachineSetup::default(); // Stdout by default
-        assert!(s.disabled_reason(LauncherField::MidiOut).is_some());
-        assert!(s.disabled_reason(LauncherField::MidiIn).is_some());
+    fn midi_device_rows_are_hidden_off_midi_mode() {
+        // Off MIDI mode the endpoint rows are absent from the Serial tab (they
+        // are hidden, not greyed), so the tab shows only the Mode selector.
+        let serial = rows(
+            LauncherTab::Serial,
+            ParallelDevice::None,
+            SerialMode::Stdout,
+        );
+        assert!(!serial.iter().any(|r| r.field == LauncherField::MidiOut));
+        assert!(!serial.iter().any(|r| r.field == LauncherField::MidiIn));
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -85,6 +85,8 @@ pub enum MenuItem {
     MidiInput,
     #[cfg(feature = "midi")]
     MidiOutput,
+    SamplerInput,
+    SamplerGain,
     PixelAspect,
     AudioOutput,
     Warp,
@@ -98,12 +100,13 @@ pub enum MenuItem {
 }
 
 /// The menu items, top to bottom. The MIDI device items appear only when the
-/// serial port is in MIDI mode, so the list is built per open rather than fixed.
-pub fn menu_items(midi_active: bool) -> Vec<MenuItem> {
+/// serial port is in MIDI mode, and the sampler items only when a parallel-port
+/// sampler is attached, so the list is built per open rather than fixed.
+pub fn menu_items(midi_active: bool, sampler_active: bool) -> Vec<MenuItem> {
     let _ = midi_active;
-    // 9 leading + up to 2 MIDI + 10 trailing items, sized so appending never
-    // reallocates.
-    let mut items = Vec::with_capacity(21);
+    // 9 leading + up to 2 MIDI + 2 sampler + 10 trailing items, sized so
+    // appending never reallocates.
+    let mut items = Vec::with_capacity(23);
     items.extend([
         MenuItem::MachineConfig,
         MenuItem::FrameAnalyzer,
@@ -119,6 +122,10 @@ pub fn menu_items(midi_active: bool) -> Vec<MenuItem> {
     if midi_active {
         items.push(MenuItem::MidiInput);
         items.push(MenuItem::MidiOutput);
+    }
+    if sampler_active {
+        items.push(MenuItem::SamplerInput);
+        items.push(MenuItem::SamplerGain);
     }
     items.push(MenuItem::PixelAspect);
     items.extend([
@@ -155,6 +162,10 @@ pub struct MenuLabels<'a> {
     /// Current audio output label: "Default", a device name, or "Disabled"
     /// (empty is treated as "Default").
     pub audio_output: &'a str,
+    /// Current sampler input device name (empty is treated as "Default") and
+    /// gain label (e.g. "2x"); only shown when a sampler is attached.
+    pub sampler_input: &'a str,
+    pub sampler_gain: &'a str,
 }
 
 fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
@@ -187,6 +198,15 @@ fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
             };
             format!("Audio Out [{}]", clip_menu_value(name))
         }
+        MenuItem::SamplerInput => {
+            let name = if s.sampler_input.is_empty() {
+                "Default"
+            } else {
+                s.sampler_input
+            };
+            format!("Sampler In [{}]", clip_menu_value(name))
+        }
+        MenuItem::SamplerGain => format!("Sampler Gain {:>5}", format!("[{}]", s.sampler_gain)),
         MenuItem::Warp if s.warp => "Warp Speed      [on]".to_string(),
         MenuItem::Warp => "Warp Speed     [off]".to_string(),
         // Right-pad so the closing bracket stays put as the value width
@@ -208,10 +228,10 @@ fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
     }
 }
 
-/// Clip a device name so a "MIDI Out [name]" / "Audio Out [name]" label stays
-/// within the popup.
+/// Clip a device name so a "MIDI Out [name]" / "Audio Out [name]" /
+/// "Sampler In [name]" label stays within the popup.
 fn clip_menu_value(name: &str) -> String {
-    const MAX: usize = MENU_MAX_LABEL_CHARS - 12; // widest prefix "Audio Out [" plus "]"
+    const MAX: usize = MENU_MAX_LABEL_CHARS - 13; // widest prefix "Sampler In [" plus "]"
     if name.chars().count() <= MAX {
         return name.to_string();
     }
@@ -545,12 +565,17 @@ impl UiState {
         self.menu_open || self.panel.is_some()
     }
 
-    /// The UI control under `pos`, if any. `midi_active` selects the same menu
-    /// item list the draw uses. `PanelBody` swallows clicks on a panel's
-    /// background so they never reach the emulated display.
-    pub fn control_at(&self, pos: (i32, i32), midi_active: bool) -> Option<UiControl> {
+    /// The UI control under `pos`, if any. `midi_active`/`sampler_active` select
+    /// the same menu item list the draw uses. `PanelBody` swallows clicks on a
+    /// panel's background so they never reach the emulated display.
+    pub fn control_at(
+        &self,
+        pos: (i32, i32),
+        midi_active: bool,
+        sampler_active: bool,
+    ) -> Option<UiControl> {
         if self.menu_open {
-            let items = menu_items(midi_active);
+            let items = menu_items(midi_active, sampler_active);
             for (index, item) in items.iter().enumerate() {
                 if menu_item_rect(index, items.len()).contains(pos) {
                     return Some(UiControl::MenuItem(*item));
@@ -1662,10 +1687,11 @@ fn draw_menu(
     frame: &mut [u8],
     hover: Option<UiControl>,
     midi_active: bool,
+    sampler_active: bool,
     labels: MenuLabels,
     scale: usize,
 ) {
-    let items = menu_items(midi_active);
+    let items = menu_items(midi_active, sampler_active);
     let rect = menu_rect(items.len());
     let scaled = scale_rect(rect, scale);
     fill_rect(frame, scaled, MENU_BG, scale);
@@ -3741,7 +3767,14 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             return Some(UiControl::LauncherZorroAdd);
         }
     } else {
-        for (i, r) in launcher::rows(state.tab).iter().enumerate() {
+        for (i, r) in launcher::rows(
+            state.tab,
+            state.setup.parallel_device(),
+            state.setup.serial_mode(),
+        )
+        .iter()
+        .enumerate()
+        {
             if !state.setup.applies(r.field) {
                 continue;
             }
@@ -4316,14 +4349,30 @@ fn draw_launcher(
     if state.tab == LauncherTab::Zorro {
         draw_launcher_zorro(frame, rect, state, hover, scale);
     } else {
-        for (i, r) in launcher::rows(state.tab).iter().enumerate() {
+        for (i, r) in launcher::rows(
+            state.tab,
+            state.setup.parallel_device(),
+            state.setup.serial_mode(),
+        )
+        .iter()
+        .enumerate()
+        {
             draw_launcher_row(frame, rect, state, r, i, hover, scale);
         }
     }
     // The Input tab spells out what the chosen wiring means: which host
     // input source ends up driving each port, live as the values cycle.
     if state.tab == LauncherTab::Input {
-        let summary_top = launcher_row_y(rect, launcher::rows(LauncherTab::Input).len() + 1);
+        let summary_top = launcher_row_y(
+            rect,
+            launcher::rows(
+                LauncherTab::Input,
+                state.setup.parallel_device(),
+                state.setup.serial_mode(),
+            )
+            .len()
+                + 1,
+        );
         draw_panel_text(
             frame,
             launcher_pane_x(rect),
@@ -4419,13 +4468,21 @@ pub fn draw(
     hover: Option<UiControl>,
     data: Option<&PanelViewData>,
     midi_active: bool,
+    sampler_active: bool,
     labels: MenuLabels,
 ) {
     if let Some(panel) = &ui.panel {
         draw_panel_layer(frame, texture_scale, panel, hover, data);
     }
     if ui.menu_open {
-        draw_menu(frame, hover, midi_active, labels, texture_scale);
+        draw_menu(
+            frame,
+            hover,
+            midi_active,
+            sampler_active,
+            labels,
+            texture_scale,
+        );
     }
 }
 
@@ -4659,7 +4716,7 @@ mod tests {
 
     #[test]
     fn menu_sits_above_the_status_bar_and_hit_tests_items() {
-        let n = menu_items(false).len();
+        let n = menu_items(false, false).len();
         let rect = menu_rect(n);
         assert!(rect.y + rect.h <= present_height());
         assert!(rect.x + rect.w <= FB_WIDTH);
@@ -4671,7 +4728,7 @@ mod tests {
         let first = menu_item_rect(0, n);
         let pos = (first.x as i32 + 4, first.y as i32 + 4);
         assert_eq!(
-            ui.control_at(pos, false),
+            ui.control_at(pos, false, false),
             Some(UiControl::MenuItem(MenuItem::MachineConfig))
         );
         // Leading block is MachineConfig, FrameAnalyzer, Debugger, Console,
@@ -4679,18 +4736,18 @@ mod tests {
         let joystick = menu_item_rect(6, n);
         let pos = (joystick.x as i32 + 4, joystick.y as i32 + 4);
         assert_eq!(
-            ui.control_at(pos, false),
+            ui.control_at(pos, false, false),
             Some(UiControl::MenuItem(MenuItem::JoystickInput))
         );
         // Outside the menu: nothing (the click closes the menu).
-        assert_eq!(ui.control_at((0, 0), false), None);
+        assert_eq!(ui.control_at((0, 0), false, false), None);
     }
 
     #[test]
     fn every_menu_label_fits_inside_the_popup() {
         // The label is drawn at `item_rect.x + MENU_TEXT_INSET`; its glyphs
         // must end before the popup's right edge or the trailing "~" clips.
-        let items = menu_items(true);
+        let items = menu_items(true, true);
         let menu = menu_rect(items.len());
         let limit = menu.x + menu.w;
         let modes = [JoystickInputMode::Gamepad, JoystickInputMode::Keyboard];
@@ -4717,6 +4774,8 @@ mod tests {
                                         midi_in: long,
                                         midi_out: long,
                                         audio_output: long,
+                                        sampler_input: long,
+                                        sampler_gain: "-24 dB",
                                     };
                                     let label = menu_item_label(item, labels);
                                     let text_w =
@@ -4748,6 +4807,7 @@ mod tests {
         assert_eq!(
             ui.control_at(
                 (raster.x as i32 + raster.w as i32 / 2, raster.y as i32 + 2),
+                false,
                 false
             ),
             Some(UiControl::AnalyzerPick {
@@ -4763,6 +4823,7 @@ mod tests {
                     scanline.x as i32 + scanline.w as i32 / 2,
                     scanline.y as i32 + 2
                 ),
+                false,
                 false
             ),
             Some(UiControl::AnalyzerPick {
@@ -4774,12 +4835,12 @@ mod tests {
         let (control, button) = analyzer_button_rects(rect)[1];
         assert_eq!(control, UiControl::AnalyzerFrame);
         assert_eq!(
-            ui.control_at((button.x as i32 + 2, button.y as i32 + 2), false),
+            ui.control_at((button.x as i32 + 2, button.y as i32 + 2), false, false),
             Some(UiControl::AnalyzerFrame)
         );
         let underlay = analyzer_underlay_rect(rect);
         assert_eq!(
-            ui.control_at((underlay.x as i32 + 2, underlay.y as i32 + 2), false),
+            ui.control_at((underlay.x as i32 + 2, underlay.y as i32 + 2), false, false),
             Some(UiControl::AnalyzerUnderlay)
         );
         // The checkbox must not overlap the transport buttons.
@@ -4903,12 +4964,18 @@ mod tests {
         let rect = panel_rect(ui.panel.as_ref().unwrap());
         let close = close_button_rect(rect);
         let pos = (close.x as i32 + 2, close.y as i32 + 2);
-        assert_eq!(ui.control_at(pos, false), Some(UiControl::PanelClose));
+        assert_eq!(
+            ui.control_at(pos, false, false),
+            Some(UiControl::PanelClose)
+        );
         // Panel body swallows clicks.
         let body = (rect.x as i32 + 5, (rect.y + TITLE_H + 5) as i32);
-        assert_eq!(ui.control_at(body, false), Some(UiControl::PanelBody));
+        assert_eq!(
+            ui.control_at(body, false, false),
+            Some(UiControl::PanelBody)
+        );
         // Outside the panel: nothing.
-        assert_eq!(ui.control_at((0, 0), false), None);
+        assert_eq!(ui.control_at((0, 0), false, false), None);
     }
 
     #[test]
@@ -4920,22 +4987,22 @@ mod tests {
         let rect = panel_rect(ui.panel.as_ref().unwrap());
         let tab = debug_tab_rect(rect, 3);
         assert_eq!(
-            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false),
+            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false, false),
             Some(UiControl::DebugTab(DebugTab::Video))
         );
         let tab = debug_tab_rect(rect, 4);
         assert_eq!(
-            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false),
+            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false, false),
             Some(UiControl::DebugTab(DebugTab::Audio))
         );
         let tab = debug_tab_rect(rect, 6);
         assert_eq!(
-            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false),
+            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false, false),
             Some(UiControl::DebugTab(DebugTab::IoMap))
         );
         let tab = debug_tab_rect(rect, 7);
         assert_eq!(
-            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false),
+            ui.control_at((tab.x as i32 + 2, tab.y as i32 + 2), false, false),
             Some(UiControl::DebugTab(DebugTab::Break))
         );
         // All eight tabs fit inside the panel.
@@ -4944,7 +5011,7 @@ mod tests {
         let (control, step) = debug_button_rects(rect)[1];
         assert_eq!(control, UiControl::DebugStep);
         assert_eq!(
-            ui.control_at((step.x as i32 + 2, step.y as i32 + 2), false),
+            ui.control_at((step.x as i32 + 2, step.y as i32 + 2), false, false),
             Some(UiControl::DebugStep)
         );
 
@@ -4959,11 +5026,11 @@ mod tests {
         assert_eq!(control, UiControl::DebugBreakToggle);
         let pos = (toggle.x as i32 + 2, toggle.y as i32 + 2);
         assert_eq!(
-            ui_break.control_at(pos, false),
+            ui_break.control_at(pos, false, false),
             Some(UiControl::DebugBreakToggle)
         );
         // On another tab the same position is just panel body.
-        assert_eq!(ui.control_at(pos, false), Some(UiControl::PanelBody));
+        assert_eq!(ui.control_at(pos, false, false), Some(UiControl::PanelBody));
 
         // Audio-tab mute buttons hit-test only while the Audio tab is active.
         let mut panel = DebuggerPanel::new();
@@ -4976,7 +5043,7 @@ mod tests {
         assert_eq!(control, UiControl::DebugAudioMute(0));
         let pos = (mute0.x as i32 + 2, mute0.y as i32 + 2);
         assert_eq!(
-            ui_audio.control_at(pos, false),
+            ui_audio.control_at(pos, false, false),
             Some(UiControl::DebugAudioMute(0))
         );
         // The CD mute is the fifth (index 4) button.
@@ -4984,11 +5051,11 @@ mod tests {
         assert_eq!(cd_control, UiControl::DebugAudioMute(4));
         let cd_pos = (cd_mute.x as i32 + 2, cd_mute.y as i32 + 2);
         assert_eq!(
-            ui_audio.control_at(cd_pos, false),
+            ui_audio.control_at(cd_pos, false, false),
             Some(UiControl::DebugAudioMute(4))
         );
         // On another tab that position does not resolve to a mute.
-        assert_eq!(ui.control_at(pos, false), Some(UiControl::PanelBody));
+        assert_eq!(ui.control_at(pos, false, false), Some(UiControl::PanelBody));
 
         let mut panel = DebuggerPanel::new();
         for ch in ['c', '0', '0', '3', 'C'] {
@@ -5243,6 +5310,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             MenuLabels {
                 warp: true,
                 warp_speed: WarpSpeed::Max,
@@ -5257,9 +5325,11 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
-        let menu = menu_rect(menu_items(false).len());
+        let menu = menu_rect(menu_items(false, false).len());
         let probe = ((menu.y + MENU_PAD + 2) * w + menu.x + 4) * 4;
         assert_eq!(&frame[probe..probe + 4], &MENU_BG.to_le_bytes());
         save(&frame, "menu");
@@ -5286,6 +5356,7 @@ mod tests {
             None,
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5300,6 +5371,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5317,6 +5390,7 @@ mod tests {
             None,
             Some(&PanelViewData::Shortcuts),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5331,6 +5405,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5364,6 +5440,7 @@ mod tests {
             Some(UiControl::DropDrive(1)),
             None,
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5378,6 +5455,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5435,6 +5514,7 @@ mod tests {
             Some(UiControl::CalCancel),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5449,6 +5529,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5493,6 +5575,7 @@ mod tests {
             Some(UiControl::DebugStep),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5507,6 +5590,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5548,6 +5633,7 @@ mod tests {
             Some(UiControl::DebugRegToggle),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5562,6 +5648,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5604,6 +5692,7 @@ mod tests {
             Some(UiControl::DebugWaveArm),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5618,6 +5707,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5713,6 +5804,7 @@ mod tests {
             Some(UiControl::DebugAudioMute(0)),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5727,6 +5819,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5782,6 +5876,7 @@ mod tests {
             None,
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5796,6 +5891,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5862,6 +5959,7 @@ mod tests {
             Some(UiControl::DebugPlaneToggle(0)),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5876,6 +5974,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -5979,6 +6079,7 @@ mod tests {
             Some(UiControl::AnalyzerUnderlay),
             Some(&data),
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -5993,6 +6094,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -6026,6 +6129,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -6040,6 +6144,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -6064,6 +6170,7 @@ mod tests {
             Some(UiControl::LauncherRun),
             None,
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -6078,6 +6185,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -6142,6 +6251,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -6156,6 +6266,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -6187,6 +6299,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -6201,6 +6314,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -6225,6 +6340,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             MenuLabels {
                 warp: false,
                 warp_speed: WarpSpeed::Max,
@@ -6239,6 +6355,8 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                sampler_input: "",
+                sampler_gain: "",
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -6247,7 +6365,16 @@ mod tests {
         let rect = panel_rect(&Panel::Launcher(Box::new(LauncherState::new(
             launcher::MachineSetup::default(),
         ))));
-        let header_y = launcher_row_y(rect, launcher::rows(LauncherTab::Input).len() + 1);
+        let header_y = launcher_row_y(
+            rect,
+            launcher::rows(
+                LauncherTab::Input,
+                crate::config::ParallelDevice::None,
+                crate::config::SerialMode::default(),
+            )
+            .len()
+                + 1,
+        );
         let row = &frame[(header_y * w + launcher_pane_x(rect)) * 4
             ..(header_y * w + launcher_pane_x(rect) + 200) * 4];
         assert!(

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -315,6 +315,19 @@ const LED_ROW_PITCH_TIGHT: usize = 11;
 const STATUS_CONTROL_H: usize = 22;
 const STATUS_CONTROL_Y: usize = (STATUS_BAR_HEIGHT - STATUS_CONTROL_H) / 2;
 const VOLUME_STEP_PERCENT: i16 = 5;
+/// Per-press step of the live sampler input-gain control, in decibels; the
+/// range is the sampler's [`crate::sampler::MIN_SAMPLER_GAIN_DB`]..
+/// [`crate::sampler::MAX_SAMPLER_GAIN_DB`].
+const SAMPLER_GAIN_STEP_DB: f32 = 3.0;
+
+/// Label a sampler gain in decibels for the OSD/menu, e.g. `0 dB`, `+6 dB`.
+fn sampler_gain_osd(gain_db: f32) -> String {
+    if gain_db.abs() < 0.05 {
+        "0 dB".to_string()
+    } else {
+        format!("{gain_db:+.0} dB")
+    }
+}
 // Media (floppy/CD) button clusters. Each connected drive gets a wide
 // load button plus narrow swap and eject buttons; a CD machine gets a
 // load and an eject button after the drives.
@@ -691,6 +704,14 @@ pub struct App {
     /// is rebuilt live (device switch, disconnect recovery, post-load install) so
     /// the new stream/callback thread keeps the same scheduling as the first sink.
     realtime_priority: bool,
+    /// Parallel-port sampler request for this session (from `[parallel]` /
+    /// `--parallel sampler` or the launcher). Re-applied whenever a machine
+    /// session starts, and edited live from the runtime menu / gain shortcut.
+    sampler: crate::sampler::SamplerRequest,
+    /// The live cpal capture stream feeding the attached sampler. The stream is
+    /// `!Send`, so it is kept here on the main thread while its `Send` read-port
+    /// sits in the bus; `None` when no sampler is attached.
+    sampler_stream: Option<cpal::Stream>,
     /// Output frame-skip level for warp/turbo mode: how many emulated frames
     /// are retired per presented frame while warp is engaged. Presentation is
     /// vsync-gated, so this is what decouples warp speed from the host monitor
@@ -926,6 +947,9 @@ impl App {
         // caller's --audio/--noaudio-resolved value; for the config-screen
         // placeholder the config intent (so a state loaded over it gets sound).
         audio_output_enabled: bool,
+        // Parallel-port sampler request (disabled for the config-screen
+        // placeholder; run_machine re-derives it from the launcher's config).
+        sampler: crate::sampler::SamplerRequest,
     ) -> Self {
         // Headless capture runs drive themselves off emulated time, so a
         // powered-off start would simply hang. Force power on for those.
@@ -959,11 +983,13 @@ impl App {
         // Config's realtime-priority request, re-fed to priority::requested when
         // the audio sink is rebuilt live so those streams keep the same setting.
         let realtime_priority = machine_config.emulation.realtime_priority.unwrap_or(false);
-        Self {
+        let mut app = Self {
             emu,
             serial_is_midi,
             audio_output,
             realtime_priority,
+            sampler,
+            sampler_stream: None,
             fb: vec![0u32; MAX_FB_PIXELS],
             deinterlacer: Deinterlacer::with_phosphor(phosphor),
             present_fb: vec![0u32; FB_WIDTH * OUT_HEIGHT],
@@ -1051,6 +1077,38 @@ impl App {
             hunt: None,
             recorder: None,
             record_fb: Vec::new(),
+        };
+        // Attach the sampler now for a directly-booted machine; the config-screen
+        // placeholder passes a disabled request and attaches on Run instead.
+        app.attach_session_sampler();
+        app
+    }
+
+    /// Build the parallel-port sampler for the current [`self.sampler`] request
+    /// and attach it to the live machine, replacing any previous one. The cpal
+    /// capture stream is kept here on the main thread (it is `!Send`); its `Send`
+    /// read-port goes into the bus. A disabled request detaches the port. A
+    /// device-open failure logs and leaves the port empty rather than aborting.
+    fn attach_session_sampler(&mut self) {
+        // Drop any prior stream first so the old capture device is released
+        // before a new one opens.
+        self.sampler_stream = None;
+        if !self.sampler.enabled {
+            return;
+        }
+        match crate::sampler::CpalSampler::open(
+            self.sampler.input_device.as_deref(),
+            self.sampler.gain_db,
+        ) {
+            Ok((stream, port)) => {
+                info!(
+                    "parallel: sampler attached (input {:?})",
+                    port.device_label()
+                );
+                self.emu.bus_mut().attach_parallel_port(Box::new(port));
+                self.sampler_stream = Some(stream);
+            }
+            Err(e) => warn!("parallel: sampler failed to attach: {e}"),
         }
     }
 
@@ -1285,6 +1343,52 @@ impl App {
             }
         }
         self.show_osd(format!("Audio output: {}", self.audio_output.label()));
+    }
+
+    /// Step the live sampler input through "Default" then the host capture
+    /// devices, rebuilding the capture so the change takes effect at once.
+    /// Re-reads the device list so a just-connected device appears. A no-op when
+    /// no sampler is attached.
+    fn cycle_sampler_input(&mut self) {
+        if !self.sampler.enabled {
+            return;
+        }
+        let devices = crate::sampler::picker_input_devices();
+        self.sampler.input_device =
+            crate::sampler::next_input_device(self.sampler.input_device.as_deref(), &devices, true);
+        self.attach_session_sampler();
+        let label = self
+            .sampler
+            .input_device
+            .clone()
+            .unwrap_or_else(|| "Default".to_string());
+        self.show_osd(format!("Sampler input: {label}"));
+    }
+
+    /// Raise (`forward`) or lower the live sampler input gain by one
+    /// [`SAMPLER_GAIN_STEP_DB`] step, clamped to the sampler's dB range,
+    /// rebuilding the capture so the new preamp level takes effect at once. A
+    /// no-op when no sampler is attached. Bound to the runtime menu and the
+    /// gain shortcut.
+    fn step_sampler_gain(&mut self, forward: bool) {
+        if !self.sampler.enabled {
+            return;
+        }
+        let delta = if forward {
+            SAMPLER_GAIN_STEP_DB
+        } else {
+            -SAMPLER_GAIN_STEP_DB
+        };
+        let gain_db = (self.sampler.gain_db + delta).clamp(
+            crate::sampler::MIN_SAMPLER_GAIN_DB,
+            crate::sampler::MAX_SAMPLER_GAIN_DB,
+        );
+        if gain_db == self.sampler.gain_db {
+            return;
+        }
+        self.sampler.gain_db = gain_db;
+        self.attach_session_sampler();
+        self.show_osd(format!("Sampler gain: {}", sampler_gain_osd(gain_db)));
     }
 
     fn set_joystick_input_mode(&mut self, mode: JoystickInputMode) {
@@ -1736,6 +1840,25 @@ impl ApplicationHandler for App {
                             self.cycle_audio_output()
                         }
                     }
+                    (KeyCode::Equal, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers)
+                            && self.modifiers.shift_key() =>
+                    {
+                        // Raise the sampler input gain (Shift+= is "+"). A no-op
+                        // unless a sampler is attached; ignored under a menu/panel.
+                        if !self.modal_ui_active() {
+                            self.step_sampler_gain(true)
+                        }
+                    }
+                    (KeyCode::Minus, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers)
+                            && self.modifiers.shift_key() =>
+                    {
+                        // Lower the sampler input gain (Shift+- is "_").
+                        if !self.modal_ui_active() {
+                            self.step_sampler_gain(false)
+                        }
+                    }
                     (other, state) => {
                         let pressed = state == ElementState::Pressed;
                         if pressed && self.ui_handle_key(other, text.as_deref()) {
@@ -2007,6 +2130,16 @@ impl ApplicationHandler for App {
                 } else {
                     (String::new(), String::new())
                 };
+                let sampler_active = self.sampler_stream.is_some();
+                let (sampler_input_label, sampler_gain_label) =
+                    if self.ui.menu_open && sampler_active {
+                        (
+                            self.sampler.input_device.clone().unwrap_or_default(),
+                            sampler_gain_osd(self.sampler.gain_db),
+                        )
+                    } else {
+                        (String::new(), String::new())
+                    };
                 let ui_data = self.build_panel_view_data();
                 if let Some(r) = self.render.as_mut() {
                     let frame = r.pixels.frame_mut();
@@ -2034,6 +2167,7 @@ impl ApplicationHandler for App {
                         ui_hover,
                         ui_data.as_ref(),
                         self.serial_is_midi,
+                        sampler_active,
                         ui::MenuLabels {
                             warp,
                             warp_speed,
@@ -2048,6 +2182,8 @@ impl ApplicationHandler for App {
                             midi_in: &midi_in_label,
                             midi_out: &midi_out_label,
                             audio_output: self.audio_output.label(),
+                            sampler_input: &sampler_input_label,
+                            sampler_gain: &sampler_gain_label,
                         },
                     );
                     // The drag hint sits on top of everything: the drop will
@@ -2746,7 +2882,8 @@ impl App {
         if self.ui.panel.is_none() && self.tool_panel_open() && !self.ui.menu_open {
             return None;
         }
-        self.ui.control_at(pos, self.serial_is_midi)
+        self.ui
+            .control_at(pos, self.serial_is_midi, self.sampler_stream.is_some())
     }
 
     fn main_ui_hover_changed(
@@ -3127,6 +3264,8 @@ impl App {
                     ui::MenuItem::MidiInput => self.cycle_midi_input(),
                     #[cfg(feature = "midi")]
                     ui::MenuItem::MidiOutput => self.cycle_midi_output(),
+                    ui::MenuItem::SamplerInput => self.cycle_sampler_input(),
+                    ui::MenuItem::SamplerGain => self.step_sampler_gain(true),
                     ui::MenuItem::PixelAspect => self.toggle_pixel_aspect(),
                     ui::MenuItem::AudioOutput => self.cycle_audio_output(),
                     ui::MenuItem::Warp => self.toggle_warp(),
@@ -4341,6 +4480,11 @@ impl App {
             self.serial_is_midi = self.emu.bus_mut().midi_serial_mut().is_some();
         }
         self.machine_config = raw;
+        // Re-derive the sampler from the launcher's parallel config and attach it
+        // to the fresh machine (the printer attaches inside build_machine, since
+        // its byte sink is Send).
+        self.sampler = crate::sampler::SamplerRequest::from_config(&cfg.parallel);
+        self.attach_session_sampler();
         self.disk_playlists = cfg.floppy_playlists.clone();
         self.disk_write_protected = std::array::from_fn(|i| {
             cfg.floppy.drives[i]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1885,6 +1885,7 @@ fn test_app_with_audio(audio: Box<dyn AudioSink>) -> super::App {
         vec!["Machine: test".to_string()],
         crate::config::RawConfig::default(),
         true,
+        crate::sampler::SamplerRequest::default(),
     )
 }
 


### PR DESCRIPTION
Add a small device framework for the Amiga parallel port and its first device, an 8-bit audio sampler. 

The framework is the point: the port is modelled so future devices (a printer, a game's protection dongle.etc) slot in without touching the core, and the sampler is a working example.

## Framework

`src/parallel.rs` defines `ParallelPortDevice` (object-safe, host-backend-free so the core stays testable). The bus holds an optional attached device and offers it the data lines on a CIA-A PRB access ($BFE101): a CPU *read* calls `read_data` -- a device that drives the lines returns the byte, others return `None` and the port register value stands -- and a CPU *write* calls `write_data`, which an output device consumes and others ignore. It is host-IO, not machine state: serde-skipped on the bus, re-attached after a state load, so **no STATE_VERSION change** and existing saves keep loading.

Both the config and the CLI mirror `[serial]`: `[parallel] device = "none" | "sampler"` (or `--parallel DEVICE`) selects the device, then device-prefixed options configure it. A future printer is `--parallel printer` + `--printer-*`, no clashes.

## Audio sampler

`--parallel sampler` (or `[parallel] device = "sampler"`) attaches the digitizer the classic Amiga samplers (AMAS, DSS, Megalosound, the open-amiga-sampler) are -- an ADC on the data lines that sampling software reads in a tight loop to record. It captures from a host audio input through cpal (same CoreAudio/WASAPI/ALSA path as the audio output; `--sampler-audio-input NAME`, `--sampler-list-audio-inputs`), and each PRB read returns the sample for the elapsed emulated time, so the input lines up however fast/slow the Amiga polls. The value is 8-bit offset-binary (128 = silence). These are mono units, so host left+right are summed into the single input -- which also means a stereo source is captured whole. `--sampler-input-gain` is a linear preamp (max 16x/~+24 dB). Naming a sampler option selects the sampler, as a MIDI endpoint selects `--serial midi`.

## GUI

A **Parallel** tab (below Serial): a Device picker (None / Sampler); the sampler's Audio input and Input gain (in dB) rows appear only when Sampler is selected, so a future device's options never clutter the tab. The runtime menu gains **Sampler In** and **Sampler Gain** items (only while a sampler is attached) that switch the input device and gain live -- the capture stream is rebuilt on the main thread (the cpal `Stream` is `!Send` on macOS). `Cmd+Shift +/-` (`Alt+Shift +/-`) nudges the gain 3 dB when attached. While here, the same dynamic-rows treatment is applied to the **Serial** tab: the MIDI in/out pickers now appear only in MIDI mode instead of being greyed out otherwise.

## Host input handling

Mirrors the audio output picker: on Linux the GUI drops ALSA's redundant "default" when it *is* the system default input (kept in the CLI list), and the picker re-enumerates on demand so a newly connected input shows up in the GUI/menu without a restart. Individual PipeWire/PulseAudio sinks aren't ALSA devices, so only the default route is offered there; macOS/Windows select each directly. (macOS note: a bare CLI binary can't prompt for the microphone permission -- grant the terminal mic access, or use a virtual loopback; a bundled .app would carry the usage description.)

## Credit and licensing

The sampler's emulation approach -- a real-time capture ring read by elapsed emulated time, 8-bit offset-binary, the latency trim -- is an independent Rust implementation following the *method* in **WinUAE's `sampler.cpp`** (Toni Wilen); no code was copied. WinUAE is GPL-2.0-or-later, compatible with this GPL-3.0-or-later project. The hardware model (an ADC0820-style 8-bit ADC on the data lines, mono) follows the **open-amiga-sampler** project's schematics (github.com/echolevel/open-amiga-sampler). Both are credited in the source.

## Verification

- clippy `-D warnings` + fmt clean, default and `--no-default-features`; 1323 tests, 0 failures. STATE_VERSION unchanged.
- Recording verified on macOS with **ProTracker, OctaMED, AudioMaster and TurboSound**, capturing both from an **external USB audio interface** and via **inter-app routing (BlackHole on macOS; a virtual audio cable on Windows)**. The bus PRB read/write routing, mono ADC conversion, `[parallel]` config parse/override (incl. the sampler-selects-implicitly rule), and the launcher's dynamic Serial/Parallel rows are unit-tested.
- Docs: README "Parallel port", configuration guide `[parallel]`, `copperline.example.toml`, and `--help`.

## Screens
<img width="884" height="993" alt="Screenshot 2026-07-06 at 16 40 59" src="https://github.com/user-attachments/assets/78a2334c-709f-4f76-be54-e68cf6fd166a" />
<img width="721" height="614" alt="Screenshot 2026-07-06 at 13 55 09" src="https://github.com/user-attachments/assets/9e07a09f-c40a-4026-887c-79f474dfef13" />
<img width="719" height="619" alt="Screenshot 2026-07-06 at 13 54 54" src="https://github.com/user-attachments/assets/493371d7-aedb-4849-a58c-4b91cc9a9dcd" />
<img width="721" height="617" alt="Screenshot 2026-07-06 at 13 57 59" src="https://github.com/user-attachments/assets/423c8b60-0409-41bc-9766-9a7b2ae91058" />


