### PR TITLE
bus: log DSKBLK raises under COPPERLINE_DBG_DSKLEN

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3801,6 +3801,17 @@ impl Bus {
             self.floppy.set_adkcon(self.paula.adkcon);
             if self.floppy.tick(cck, dmacon, &mut self.mem.chip_ram) {
                 self.paula.intreq |= INT_DSKBLK;
+                // Companion to COPPERLINE_DBG_DSKLEN: the wall-time DSKBLK
+                // raise, closing each arm -> completion interval.
+                if crate::envcfg::flag("COPPERLINE_DBG_DSKLEN") {
+                    log::info!(
+                        "dskblk f={} secs={:.4} v={} h={}",
+                        self.emulated_frames,
+                        self.emulated_seconds(),
+                        self.agnus.vpos,
+                        self.agnus.hpos,
+                    );
+                }
             }
             if self.floppy.take_sync_irq() {
                 self.paula.intreq |= INT_DSKSYNC;


### PR DESCRIPTION
Small diagnostics addition: the existing DSKLEN arm log gains a wall-time DSKBLK completion companion line, closing each arm -> completion interval. Used by the eon investigation to pair Copperline's disk latency against a vAmiga-side probe (110/110 arms matched within 8ms - the drive model is exonerated for eon; see FABLE-vamigats-diagnostics.md).

Env-gated logging only; no emulation change. 1322 lib tests, clippy, fmt clean.