### PR TITLE
m68k: Class 2 MOVE-to-abs.l prefetch order needs a memory source (fixes the eon half-speed regression)

### DIFF
--- a/crates/m68k/src/core/instructions/data_movement.rs
+++ b/crates/m68k/src/core/instructions/data_movement.rs
@@ -25,9 +25,26 @@ impl CpuCore {
         // Write to destination. The 68000 sequences its final prefetch
         // differently per destination mode:
         // - predecrement: prefetch BEFORE the write (the write is last)
-        // - absolute long: the address low word is consumed without its np;
-        //   both remaining prefetches happen AFTER the write (Class 2)
+        // - absolute long WITH A MEMORY SOURCE: the address low word is
+        //   consumed without its np; both remaining prefetches happen AFTER
+        //   the write (Class 2). With a register or immediate source the
+        //   68000 uses the normal Class 1 order instead (pasti 68kPrefetch:
+        //   "if the source operand is a data or address register, or
+        //   immediate, then the behavior is the same as other MOVE
+        //   variants") - the order matters beyond timing, because the
+        //   interrupt-decision IPL sample rides the final access: a Class 1
+        //   MOVE #x,INTREQ polls right after its own write (too early to
+        //   see the interrupt it just raised), while the misapplied Class 2
+        //   tail let bus contention push the poll past the IPL pipe and the
+        //   instruction recognized its own interrupt one boundary early
+        //   (eon's scene-player yield raise).
         // - everything else: write, then the final prefetch (Class 1)
+        let class2_abs_long = !matches!(
+            src_mode,
+            AddressingMode::DataDirect(_)
+                | AddressingMode::AddressDirect(_)
+                | AddressingMode::Immediate
+        );
         if self.cpu_type == CpuType::M68000 {
             match dst_mode {
                 AddressingMode::PreDecrement(_) => {
@@ -54,7 +71,7 @@ impl CpuCore {
                         }
                     }
                 }
-                AddressingMode::AbsoluteLong => {
+                AddressingMode::AbsoluteLong if class2_abs_long => {
                     // Consume the address high word normally, the low word
                     // without its accompanying prefetch.
                     let hi = self.read_imm_16(bus) as u32;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -956,12 +956,26 @@ impl M68kMachine {
             }
             return;
         }
-        // pc == NUDGE: report the iteration span and its render / task-B split.
+        // pc == NUDGE: report the iteration span and its render / task-B split,
+        // plus the pacing-gate state: the live frame counter, d2 (the target
+        // the wait loop compares against), and the scene descriptor's step.
         let frame_delta = frame.wrapping_sub(self.dbg_sched_top_frame);
         let counter_delta = counter.wrapping_sub(self.dbg_sched_top_counter);
+        let peek_long = |bus: &crate::bus::Bus, addr: u32| -> u32 {
+            (u32::from(bus.peek_word_any(addr)) << 16)
+                | u32::from(bus.peek_word_any(addr.wrapping_add(2)))
+        };
+        let counter_live = peek_long(&self.bus.bus, 0x00C0_9580);
+        let descriptor = peek_long(&self.bus.bus, 0x00C0_9578);
+        let step = if descriptor != 0 {
+            peek_long(&self.bus.bus, descriptor)
+        } else {
+            0
+        };
         log::info!(
             "sched iter secs={secs:.5} top(f={} v={}) render(f={} v={}) b8(f={} v={}) \
-             nudge(f={} v={}) frame_delta={} counter_delta={} crossed_vblank={} d2={:#X}",
+             nudge(f={} v={}) frame_delta={} counter_delta={} crossed_vblank={} d2={:#X} \
+             counter={counter_live:#X} step={step} desc={descriptor:#010X}",
             self.dbg_sched_top_frame,
             self.dbg_sched_top_vpos,
             self.dbg_sched_render_frame,


### PR DESCRIPTION
## Hardware behaviour

The 68000 defers the address low word's np and performs both remaining
prefetches after the write - the Class 2 sequence - ONLY when a MOVE to an
absolute-long destination has a memory-mode source. With a data/address
register or immediate source it uses the ordinary Class 1 order: write, then
the single final prefetch (pasti 68kPrefetch, the same source Moira
implements). The vendored core applied the Class 2 tail to every abs.l
destination.

Cycle totals are unchanged; what changes is the bus-access ORDER - and the
interrupt-decision IPL sample rides the final access. With the misapplied
Class 2 tail, `MOVE #value,INTREQ` had two prefetches after its write, and
under heavy DMA contention the first prefetch's arbitration wait pushed the
final sample past the IPL pipe: the instruction recognized the very interrupt
it had just raised, one boundary early.

## What this fixes

**eon's half-speed pans** (the PR #125-era regression). The demo's scheduler
yield is `move.w #$8004,$DFF09C`. When the CPU dispatched that softint before
the following `cmp.l` executed, the compare ran after the yielded slice with
the frame counter already advanced, and the demo's re-sync path burned a full
extra frame - ~146 times during heavy disk streaming (matching the observed
"frame drops coincide with FDD access"). Full forensic trail in
FABLE-vamigats-diagnostics.md ("ROOT CAUSE FOUND AND FIXED").

## Results

- eon 60-104s: self-softint recognized at the next boundary 253 -> **0**;
  iteration rate 98-101 per 2s in every bucket (was 60-88 in the streaming
  window); total 2183 vs vAmiga's 2182. The 106s wolf frame matches vAmiga
  to within the known constant ~8-frame boot offset (separate open item).
- vAmigaTS CIA family: **989.9 -> 693.6** summed diff (93 cases). The
  cnt/oldcnt CNT-pin bucket (PRA toggles via MOVE to abs.l) collapses:
  cnt1 66.4 -> 3.8, cnt2 57.2 -> 2.3, cnt4 39.5 -> 2.9.
- vAmigaTS CPU/IPL (446 cases): **zero cases moved vs main** (sums equal).
- Paula/Interrupts: +15.7 summed, confined to inttim4/5 (the known
  IRQ-cadence class).
- 14-demo byte-identity suite: **identical at every sampled time** - the
  reorder swaps which access occupies which bus slot, not the slot times, so
  chipset evolution is unchanged. eon itself differs only inside the
  streaming window (92s) and reconverges by 108s (frame-locked scene
  schedule).
- 1324 lib tests, clippy --all-targets --all-features -D warnings, fmt clean.
  SingleStepTests assert final state (order-neutral); CI validates.

The sched-iter diagnostic line also gains the live frame counter, scene
descriptor and step (the pacing-gate state used to isolate this).