### PR TITLE
bus: mirror CPU byte writes to custom registers onto both bus halves

### DIFF
--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -235,10 +235,16 @@ wait for the blitter to go idle.
   `TODO.md` (`t=165s`/`t=180s` frame dumps).
 
 Copper writes to "dangerous" registers are gated by COPCON's CDANG bit.
-COPCON is a one-bit Agnus control latch; byte writes use the mirrored 68000
-byte value, so a byte bit operation such as `bset #1,COPCON` sets CDANG.
 References: HRM [Coprocessor
 Hardware](https://www.theflatnet.de/pub/cbm/amiga/AmigaDevDocs/hard_2.html).
+
+A 68000 byte write drives the byte onto both halves of the data bus, and
+the custom chips latch the full 16-bit word (they have no byte lanes), so
+`move.b v,COLOR00+1` lands `$vvvv` in the register and a byte bit
+operation such as `bset #1,COPCON` sets CDANG. The vAmigaTS `CIA/oldcnt`
+cnt1/cnt3/cnt5 ramps (which paint `move.b TALO,COLOR00+1` mid-count)
+photograph the mirrored high byte on real hardware. Test:
+`custom_byte_write_drives_the_byte_onto_both_bus_halves`.
 
 ## The blitter
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4291,25 +4291,19 @@ impl Bus {
         let off = (addr & 0xFFF) as u16;
         match size {
             1 => {
+                // A 68000 byte write drives the byte onto BOTH halves of
+                // the data bus, and the custom chips have no byte lanes:
+                // they latch the full 16-bit word regardless of which
+                // strobe (/UDS or /LDS) the CPU asserted. `move.b
+                // v,COLOR00+1` therefore lands $vvvv in the register, not
+                // an addressed-lane merge (vAmigaTS CIA/oldcnt cnt1/cnt3/
+                // cnt5 ramps show the mirrored high byte on hardware;
+                // vAmiga's CPU poke8 to custom space doubles the byte the
+                // same way).
                 let b = (val & 0xFF) as u16;
-                let word_off = off & 0xFFE;
-                let word = if custom_byte_write_mirrors_to_word(word_off) {
-                    (b << 8) | b
-                } else if let Some(cur) = self.custom_byte_write_latch(word_off) {
-                    if off & 1 == 0 {
-                        (cur & 0x00FF) | (b << 8)
-                    } else {
-                        (cur & 0xFF00) | b
-                    }
-                } else {
-                    // Some write-only command/strobe registers do not
-                    // have a meaningful word latch in this model. Keep
-                    // the old mirrored-byte behavior for those rare
-                    // byte writes rather than inventing state.
-                    (b << 8) | b
-                };
+                let word = (b << 8) | b;
                 trace!("custom W8  off={:03X} val={:02X}", off, b);
-                self.write_custom_word_from(word_off, word, BeamWriteSource::Cpu)
+                self.write_custom_word_from(off & 0xFFE, word, BeamWriteSource::Cpu)
             }
             4 => {
                 // MOVE.L to $DFFxxx writes two consecutive register
@@ -4497,7 +4491,7 @@ impl Bus {
             0x09C => self.cpu_visible_intreq(),
             0x09E => self.paula.adkcon,
             audio @ 0x0A0..=0x0DF => self.paula.peek_audio_reg_latch(audio - 0x0A0)?,
-            other => self.custom_byte_write_latch(other)?,
+            other => self.custom_reg_latch(other)?,
         };
         Some(value)
     }
@@ -4883,10 +4877,6 @@ impl Bus {
             }
         }
     }
-}
-
-fn custom_byte_write_mirrors_to_word(off: u16) -> bool {
-    matches!(off & 0xFFE, 0x02E)
 }
 
 fn bus_slots_for_cpu_access(size: usize) -> u32 {

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -88,8 +88,8 @@ impl Bus {
                 // Real write-only custom registers leave the CPU reading an
                 // undriven custom bus. Copperline does not model the previous
                 // bus owner yet, so write-only and unmapped custom reads use
-                // deterministic zero. Byte writes still consult private
-                // latches through `custom_byte_write_latch`.
+                // deterministic zero. The debugger still inspects the
+                // internal latches through `custom_reg_latch`.
                 0
             }
         }
@@ -104,7 +104,12 @@ impl Bus {
         }
     }
 
-    pub(super) fn custom_byte_write_latch(&self, off: u16) -> Option<u16> {
+    /// Side-effect-free view of a custom register's internal latch, for
+    /// the debugger's `debug_custom_word`. Registers without a modelled
+    /// stored word (read-only counters, strobes, unused offsets) report
+    /// None. This is NOT a bus path: CPU byte writes mirror the byte to
+    /// both data-bus halves and never merge with these latches.
+    pub(super) fn custom_reg_latch(&self, off: u16) -> Option<u16> {
         match off & 0xFFE {
             0x02E => Some(self.agnus.copcon),
             0x032 => Some(self.paula.serper),
@@ -131,16 +136,9 @@ impl Bus {
             0x070 => Some(self.blitter.bltcdat),
             0x072 => Some(self.blitter.bltbdat),
             0x074 => Some(self.blitter.bltadat),
-            // Audio registers (AUDxLC/LEN/PER/VOL/DAT) deliberately fall
-            // through to the mirrored-byte path below. On a real 68000 a
-            // byte write drives the value onto both data-bus halves, and
-            // Paula latches the full 16-bit word, so `move.b #v,AUDxVOL`
-            // (an even address) lands the value in the volume bits 0..6
-            // exactly as `move.w` would. Some music players use this to
-            // set a channel's volume via the "set volume" effect (e.g.
-            // Magic Pockets' title tune drops its echo voice to a low
-            // volume this way); merging with the latched low byte would
-            // leave the volume at its previous full value.
+            // Audio registers (AUDxLC/LEN/PER/VOL/DAT) are not listed
+            // here: `debug_custom_word` reads their write latches through
+            // `peek_audio_reg_latch` before falling through to this map.
             0x08E => Some(self.denise.diwstrt),
             0x090 => Some(self.denise.diwstop),
             0x1E4 => self.denise_ecs_registers().then_some(self.denise.diwhigh),

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -871,17 +871,26 @@ fn dma_modulo_registers_are_word_aligned() {
 }
 
 #[test]
-fn custom_byte_write_updates_only_addressed_lane_for_stateful_registers() {
+fn custom_byte_write_drives_the_byte_onto_both_bus_halves() {
+    // A 68000 byte write drives the byte on BOTH halves of the data bus,
+    // and the custom chips latch the full 16-bit word (no byte lanes):
+    // either byte address of a register receives $vvvv, never a merge
+    // with the previously latched word. The vAmigaTS CIA/oldcnt
+    // cnt1/cnt3/cnt5 ramps (move.b TALO,COLOR00+1 showing the mirrored
+    // high nibble in red) photograph this on hardware.
     let mut bus = empty_bus();
 
-    let _ = bus.custom_write(0xDFF074, 1, 0x80);
-    assert_eq!(bus.blitter.bltadat, 0x8000);
+    let _ = bus.custom_write(0xDFF074, 1, 0x80); // BLTADAT even byte
+    assert_eq!(bus.blitter.bltadat, 0x8080);
 
-    let _ = bus.custom_write(0xDFF075, 1, 0x00);
-    assert_eq!(bus.blitter.bltadat, 0x8000);
+    let _ = bus.custom_write(0xDFF075, 1, 0x01); // BLTADAT odd byte
+    assert_eq!(bus.blitter.bltadat, 0x0101);
 
-    let _ = bus.custom_write(0xDFF075, 1, 0x01);
-    assert_eq!(bus.blitter.bltadat, 0x8001);
+    // COLOR00: `move.b v,COLOR00+1` latches $vvvv, so the red nibble
+    // mirrors the blue one ($AE -> RGB $EAE; bit 15 is the stored
+    // transparency/genlock bit from the mirrored byte's bit 7).
+    let _ = bus.custom_write(0xDFF181, 1, 0xAE);
+    assert_eq!(bus.denise.palette[0], 0x8EAE);
 
     // COPCON's one-bit Agnus control latch sees the mirrored byte value,
     // so a 68000 byte bit operation such as `bset #1,COPCON` enables CDANG.
@@ -890,11 +899,10 @@ fn custom_byte_write_updates_only_addressed_lane_for_stateful_registers() {
     let _ = bus.custom_write(0xDFF02E, 1, 0x00);
     assert_eq!(bus.agnus.copcon, 0x0000);
 
-    // Audio registers do NOT use the addressed-lane latch: a real
-    // 68000 drives a byte write onto both data-bus halves and Paula
-    // latches the full word, so `move.b #v,AUDxPER/VOL` mirrors the
-    // byte into both lanes. (Magic Pockets sets its echo voice volume
-    // with a byte write to AUDxVOL and relies on this.)
+    // Paula latches the mirrored word too, so `move.b #v,AUDxPER/VOL`
+    // lands the value in the low byte exactly as `move.w` would. (Magic
+    // Pockets sets its echo voice volume with a byte write to AUDxVOL
+    // and relies on this.)
     let _ = bus.custom_write(0xDFF0A6, 1, 0x12);
     assert_eq!(bus.paula.peek_audio_reg_latch(0x06), Some(0x1212));
 
@@ -9272,7 +9280,7 @@ fn custom_register_read_map_matches_dispatch() {
     }
 }
 
-/// ECS-only registers whose byte-write latch (and dispatch) appears
+/// ECS-only registers whose debugger latch view (and dispatch) appears
 /// only on ECS Agnus/Denise. The bus gates these on the configured
 /// revision; this list is the single place that fact is asserted.
 const ECS_ONLY_LATCHED_REGS: &[(u16, &str)] = &[
@@ -9296,22 +9304,22 @@ const ECS_ONLY_LATCHED_REGS: &[(u16, &str)] = &[
 
 #[test]
 fn custom_register_ecs_latches_follow_agnus_revision() {
-    // OCS: the ECS-only latches must report "unmodeled" so byte writes
-    // do not invent state for registers the chipset does not have.
+    // OCS: the ECS-only latches must report "unmodeled" so the debugger
+    // does not invent state for registers the chipset does not have.
     let ocs = empty_bus();
     for &(off, name) in ECS_ONLY_LATCHED_REGS {
         assert!(
-            ocs.custom_byte_write_latch(off).is_none(),
+            ocs.custom_reg_latch(off).is_none(),
             "{name} ({off:#05X}) must not latch on OCS"
         );
     }
 
-    // ECS: the same registers gain a byte-write latch.
+    // ECS: the same registers gain a debugger latch view.
     let mut ecs = empty_bus();
     ecs.set_agnus_revision(AgnusRevision::Ecs8372Rev4);
     for &(off, name) in ECS_ONLY_LATCHED_REGS {
         assert!(
-            ecs.custom_byte_write_latch(off).is_some(),
+            ecs.custom_reg_latch(off).is_some(),
             "{name} ({off:#05X}) must latch on ECS"
         );
     }
@@ -9321,17 +9329,17 @@ fn custom_register_ecs_latches_follow_agnus_revision() {
     // caught regardless of revision.
     for bus in [&ocs, &ecs] {
         // COPCON, BLTCON0, BPLCON0, BPL1PTH, BPL1DAT, SPR0PTH, SPR0POS,
-        // COLOR00 -- a spread across the byte-latched register groups.
+        // COLOR00 -- a spread across the latched register groups.
         for off in [0x02E, 0x040, 0x100, 0x0E0, 0x110, 0x120, 0x140, 0x180] {
             assert!(
-                bus.custom_byte_write_latch(off).is_some(),
+                bus.custom_reg_latch(off).is_some(),
                 "always-latched register {off:#05X}"
             );
         }
-        // DMACONR (read-only), COPJMP1 and DMACON (strobes): no byte latch.
+        // DMACONR (read-only), COPJMP1 and DMACON (strobes): no latch.
         for off in [0x002, 0x088, 0x096] {
             assert!(
-                bus.custom_byte_write_latch(off).is_none(),
+                bus.custom_reg_latch(off).is_none(),
                 "read-only/strobe register {off:#05X} must not latch"
             );
         }
@@ -9582,7 +9590,7 @@ fn custom_register_space_sweep_is_panic_free_and_unused_offsets_inert() {
     // gaining a read arm or a stored latch.
     let mut bus = empty_bus();
     for off in [0x1F0u16, 0x1F2, 0x1F4, 0x1F6, 0x1F8, 0x1FA, 0x1FC, 0x1FE] {
-        assert!(bus.custom_byte_write_latch(off).is_none());
+        assert!(bus.custom_reg_latch(off).is_none());
         bus.custom_write(u64::from(off), 2, 0xFFFF);
         assert_eq!(
             bus.custom_read(u64::from(off), 2),


### PR DESCRIPTION
## Summary

The residual vAmigaTS `CIA/oldcnt` divergence (cnt1/cnt3/cnt5 at 31-33%)
turned out not to be CIA CNT counting at all: the failing variants are
exactly the ones that paint the timer LO byte with `move.b TALO,COLOR00+1`.
Extracting the drawn ramp values showed CL and vAmiga agree on every timer
value and every beam position; the only difference was the COLOR00 red
nibble (vAmiga `$vAv`, CL `$0Av`).

A 68000 byte write drives the byte onto BOTH halves of the data bus, and
the custom chips have no byte lanes: they latch the full 16-bit word
regardless of which strobe (/UDS or /LDS) the CPU asserted. `move.b
v,COLOR00+1` therefore lands `$vvvv` in the register. Copperline instead
merged the byte into the addressed lane of an internal register latch.
vAmiga's CPU `poke8` to custom space doubles the byte the same way
(`pokeCustom16(addr & 0x1FE, HI_LO(value, value))`).

## Change

- `Bus::custom_write` size-1 path now always mirrors the byte to both
  halves of the 16-bit word; the addressed-lane merge and the COPCON
  special case (`custom_byte_write_mirrors_to_word`) are gone.
- `custom_byte_write_latch` is renamed `custom_reg_latch` and remains as
  what it really was for the debugger: the side-effect-free internal
  latch view behind `debug_custom_word`.
- `custom_byte_write_drives_the_byte_onto_both_bus_halves` regression
  test (BLTADAT even/odd byte, COLOR00 mirrored red nibble, COPCON bset,
  AUDxPER byte writes); docs/internals/timing.md documents the rule.

No CIA change: the screen data disproves the CNT count-pipeline
hypothesis at the resolutions these tests can see. The mid-ramp readback
values match vAmiga exactly (the vAmiga 2-PHI2-cycle count pipeline is
invisible at >= 3 E-cycle read distances), and the CNT-underflow IRQ
variants without the readback (oldcnt cnt2/cnt4/cnt6/cnt7) were already
at 1.6-2.7%.

## vAmigaTS CIA sweep (`COPPERLINE_VAMIGATS_FILTER=CIA/`)

| case | before | after |
|---|---|---|
| CIA/CIA/oldcnt/cnt1 | 31.459% | 2.778% |
| CIA/CIA/oldcnt/cnt3 | 31.459% | 2.778% |
| CIA/CIA/oldcnt/cnt5 | 33.205% | 2.651% |

No other case moved by more than 0.01pp (full-family sum 693.6 -> 605.7).

## Residual characterization (not fixed here)

The remaining `cnt` family residuals are a different, already-documented
class, measured from the same ramp extraction:

- `cnt/cnt3` / `cnt5` / `cnt6` (~10.8%): ramp values and loop positions
  identical; only the white IRQ bar (level-6 handler `COLOR00=$FFF`)
  starts ~14 cck earlier in CL on each PHI2 timer-A underflow IRQ, and
  the polling loop re-locks ~10 cck shifted after the handler returns.
  This is the known interrupt-recognition/CPU-write beam-timing class
  that also bounds the UART/POT families.
- `cnt/cnt3b` / `cnt3d` / `cnt3e` (19-26%): same loop with 5 bitplanes
  enabled; the vAmigaTS README states these exist to "verify E clock
  access timing in combination with many blocked DMA cycles". Ramp
  values match; the loop cadence drifts because CL composes the E-clock
  sync wait with bitplane-DMA CPU blocking differently from vAmiga.

## Gates

- `cargo test --lib`: 1324 passed
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean
- 14-demo byte-identity vs merge-base (6cd266b): all screenshots
  byte-identical (the mirrored byte write is not on any title's path)
- No serialized state shape change (no STATE_VERSION bump needed)
