### PR TITLE
cpu: calibrate 68010 MOVES/MOVE-from-CCR/RTE/dispatch cycles and fix STOP semantics

### DIFF
--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -707,6 +707,22 @@ impl CpuCore {
         }
     }
 
+    /// Mark the instruction's IPL poll point (the 68000/68010 sample their
+    /// IPL pins at ONE microcode-determined point per instruction; Moira's
+    /// POLL flag). Called right after the bus access that carries the
+    /// poll, for instructions where that access is NOT the last one --
+    /// e.g. read-modify-write instructions poll during the final prefetch
+    /// and then perform their writeback. The host keeps that access's
+    /// sample for the boundary interrupt decision and ignores later
+    /// accesses. Applies to the prefetch-queue CPUs; call sites where the
+    /// 68010 microcode polls elsewhere gate on the CPU type explicitly.
+    #[inline]
+    pub(crate) fn ipl_poll_point<B: AddressBus>(&mut self, bus: &mut B) {
+        if self.prefetch_enabled() {
+            bus.ipl_hold_sample();
+        }
+    }
+
     /// Mark the prefetch queue as stale (after an externally forced PC
     /// change). The next instruction-stream read fetches directly and the
     /// next instruction-end top-up restores the queue.
@@ -832,7 +848,8 @@ impl CpuCore {
 
     /// 68000 long writeback for the -(Ax),-(Ay) extended-arithmetic forms
     /// (ADDX.L/SUBX.L memory-to-memory): write the low word, perform the
-    /// final prefetch, then write the high word.
+    /// final prefetch, then write the high word. The IPL poll rides the
+    /// low-word write (Moira writeM<Word, POLL> on the first write).
     pub fn write_long_mm_interleaved_68000<B: AddressBus>(
         &mut self,
         bus: &mut B,
@@ -840,6 +857,7 @@ impl CpuCore {
         value: u32,
     ) {
         self.write_16(bus, addr.wrapping_add(2), (value & 0xFFFF) as u16);
+        self.ipl_poll_point(bus);
         self.top_up_prefetch(bus);
         self.write_16(bus, addr, (value >> 16) as u16);
     }

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -661,6 +661,9 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 let b1 = cpu.read_8(bus, addr.wrapping_add(2)) as u32;
                 let b2 = cpu.read_8(bus, addr.wrapping_add(4)) as u32;
                 let b3 = cpu.read_8(bus, addr.wrapping_add(6)) as u32;
+                // MOVEP memory-to-register polls IPL at the start of the
+                // final byte read (the poll precedes the last read).
+                cpu.ipl_poll_point(bus);
                 let v = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
                 cpu.set_d(dreg, v);
             }
@@ -671,6 +674,9 @@ fn dispatch_group_0<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         } else {
             let hi = cpu.read_8(bus, addr) as u32;
             let lo = cpu.read_8(bus, addr.wrapping_add(2)) as u32;
+            // MOVEP memory-to-register polls IPL at the start of the final
+            // byte read (the poll precedes the last read).
+            cpu.ipl_poll_point(bus);
             let v = (hi << 8) | lo;
             cpu.set_d(dreg, (cpu.d(dreg) & 0xFFFF0000) | v);
         }
@@ -1281,6 +1287,13 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         0x4E76 => {
             // TRAPV
             if cpu.flag_v() {
+                if cpu.cpu_type == CpuType::M68000 {
+                    // The taken 68000 TRAPV performs one program-space
+                    // dummy read (the would-be prefetch of the next word)
+                    // before the exception frame (Moira execTrapv).
+                    let addr = cpu.pc.wrapping_add(2);
+                    let _ = cpu.read_16(bus, addr);
+                }
                 cpu.take_group2_exception(bus, 7)
             } else {
                 4
@@ -1968,7 +1981,8 @@ fn dispatch_group_5<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                     return 50;
                 }
             }
-            cpu.write_resolved_ea(bus, ea, Size::Byte, value);
+            // Scc to memory polls IPL during the pre-writeback prefetch.
+            cpu.write_resolved_ea_np_poll(bus, ea, Size::Byte, value);
             if cpu.cpu_type == CpuType::M68000 {
                 if mode.is_register_direct() {
                     // Data register: 4 if condition false, 6 if true.
@@ -2153,7 +2167,8 @@ fn dispatch_group_8<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                     return 50;
                 }
                 let (result, _) = cpu.exec_or(bus, size, cpu.d(reg), dst);
-                cpu.write_resolved_ea(bus, ea, size, result);
+                // OR Dn,<ea> polls IPL during the pre-writeback prefetch.
+                cpu.write_resolved_ea_np_poll(bus, ea, size, result);
                 if cpu.cpu_type == CpuType::M68000 {
                     cpu.alu_dn_ea_cycles(mode, size)
                 } else {
@@ -2272,6 +2287,13 @@ fn dispatch_group_9<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 if cpu.run_mode == RUN_MODE_BERR_AERR_RESET {
                     return 50;
                 }
+                // ADDX/SUBX -(Ay),-(Ax) byte/word poll IPL at the start of
+                // the destination read (the microcode poll sits between the
+                // two operand reads); the long form polls at the low-word
+                // writeback inside the interleaved write helper.
+                if size != Size::Long {
+                    cpu.ipl_poll_point(bus);
+                }
 
                 // If the store faults (misaligned word/long), the instruction should not update
                 // flags; pre-check alignment to avoid mutating flags before the fault.
@@ -2310,7 +2332,8 @@ fn dispatch_group_9<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 let ea = cpu.resolve_ea(bus, mode, size);
                 let dst = cpu.read_resolved_ea(bus, ea, size);
                 let (result, _) = cpu.exec_sub(bus, size, src, dst);
-                cpu.write_resolved_ea(bus, ea, size, result);
+                // SUB Dn,<ea> polls IPL during the pre-writeback prefetch.
+                cpu.write_resolved_ea_np_poll(bus, ea, size, result);
                 if cpu.cpu_type == CpuType::M68000 {
                     cpu.alu_dn_ea_cycles(mode, size)
                 } else {
@@ -2383,6 +2406,13 @@ fn dispatch_group_b<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 if cpu.run_mode == RUN_MODE_BERR_AERR_RESET {
                     return 50;
                 }
+                // The 68000 polls IPL at the start of the destination read
+                // (the microcode poll sits between the two operand reads);
+                // the 68010 polls after both reads, at the final prefetch
+                // (the default last-access sample).
+                if cpu.cpu_type == CpuType::M68000 {
+                    cpu.ipl_poll_point(bus);
+                }
                 let legacy = cpu.exec_cmp(size, src_val, dst_val);
                 if cpu.cpu_type == CpuType::M68000 {
                     // CMPM (An)+,(Am)+: 12 byte/word, 20 long.
@@ -2406,7 +2436,8 @@ fn dispatch_group_b<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                     return 50;
                 }
                 let result = (cpu.d(reg) ^ dst) & size.mask();
-                cpu.write_resolved_ea(bus, ea, size, result);
+                // EOR Dn,<ea> polls IPL during the pre-writeback prefetch.
+                cpu.write_resolved_ea_np_poll(bus, ea, size, result);
                 if cpu.run_mode == RUN_MODE_BERR_AERR_RESET {
                     return 50;
                 }
@@ -2472,7 +2503,8 @@ fn dispatch_group_c<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                     let ea = cpu.resolve_ea(bus, mode, size);
                     let dst = cpu.read_resolved_ea(bus, ea, size);
                     let (result, _) = cpu.exec_and(bus, size, cpu.d(reg), dst);
-                    cpu.write_resolved_ea(bus, ea, size, result);
+                    // AND Dn,<ea> polls IPL during the pre-writeback prefetch.
+                    cpu.write_resolved_ea_np_poll(bus, ea, size, result);
                     if cpu.cpu_type == CpuType::M68000 {
                         cpu.alu_dn_ea_cycles(mode, size)
                     } else {
@@ -2592,6 +2624,13 @@ fn dispatch_group_d<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 if cpu.run_mode == RUN_MODE_BERR_AERR_RESET {
                     return 50;
                 }
+                // ADDX/SUBX -(Ay),-(Ax) byte/word poll IPL at the start of
+                // the destination read (the microcode poll sits between the
+                // two operand reads); the long form polls at the low-word
+                // writeback inside the interleaved write helper.
+                if size != Size::Long {
+                    cpu.ipl_poll_point(bus);
+                }
 
                 // If the store faults (misaligned word/long), the instruction should not update
                 // flags; pre-check alignment to avoid mutating flags before the fault.
@@ -2630,7 +2669,8 @@ fn dispatch_group_d<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                 let ea = cpu.resolve_ea(bus, mode, size);
                 let dst = cpu.read_resolved_ea(bus, ea, size);
                 let (result, _) = cpu.exec_add(bus, size, src, dst);
-                cpu.write_resolved_ea(bus, ea, size, result);
+                // ADD Dn,<ea> polls IPL during the pre-writeback prefetch.
+                cpu.write_resolved_ea_np_poll(bus, ea, size, result);
                 if cpu.cpu_type == CpuType::M68000 {
                     cpu.alu_dn_ea_cycles(mode, size)
                 } else {
@@ -2698,7 +2738,8 @@ fn dispatch_group_e<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
             (3, 1) => cpu.exec_rol(Size::Word, 1, value),
             _ => return illegal_instruction(cpu, bus),
         };
-        cpu.write_resolved_ea(bus, ea, Size::Word, result);
+        // Memory shifts poll IPL during the pre-writeback prefetch.
+        cpu.write_resolved_ea_np_poll(bus, ea, Size::Word, result);
         // MC68000 memory shift/rotate (always 1 bit, word): 8 + EA.
         if cpu.cpu_type == CpuType::M68000 {
             8 + cpu.ea_source_cycles(mode, Size::Word)

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -1114,12 +1114,16 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                         }
                         let sr = cpu.pull_16(bus);
                         cpu.pc = cpu.pull_32(bus);
-                        let _ = cpu.pull_16(bus); // vector offset word
+                        // The format/vector word was already read by the
+                        // format probe above; the 68010 does not re-read
+                        // it (Moira execRte: fmt, SR, PC = four reads,
+                        // then SP += 8). Discard it from the stack.
+                        cpu.dar[15] = cpu.dar[15].wrapping_add(2);
                         cpu.set_sr(sr);
                         // The 68010 shares the 68000's two-word prefetch
                         // queue: a return refills it from the new PC.
                         cpu.full_prefetch(bus);
-                        20
+                        24
                     }
                     _ => {
                         // 68020+ RTE loop (Musashi m68k_in.c)

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -1093,6 +1093,15 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                     cpu.ppc = cpu.pc;
                     return cpu.exception_privilege(bus);
                 }
+                // 68000-040: the SR is loaded VERBATIM -- a single-stepped
+                // STOP observes the immediate with S and T exactly as
+                // written (SST m68000 fixtures pin this). An S-clear SR
+                // stops only momentarily: the stopped state's supervisor
+                // check raises the privilege violation at the NEXT
+                // instruction boundary (`stopped_supervisor_check`). A
+                // pending trace (T set in the SR the instruction started
+                // with) has priority via the caller's end-of-step trace
+                // check, which recovers from the stop.
                 cpu.stop(sr);
                 4
             } else {

--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -984,8 +984,25 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
         }
         let mode = AddressingMode::decode(ea_mode, ea_reg).unwrap();
         let ccr = cpu.get_ccr() as u32;
-        cpu.write_ea(bus, mode, Size::Word, ccr);
-        return if mode.is_register_direct() { 6 } else { 8 };
+        if mode.is_register_direct() {
+            // 68010: register destination costs only the final prefetch.
+            cpu.write_ea(bus, mode, Size::Word, ccr);
+            return 4;
+        }
+        // 68010 memory destination: internal clocks, EA calculation, the
+        // final prefetch, THEN the write (measured hardware order; vAmigaTS
+        // CPU/Timing2/MOVECCR, Moira execMoveCcrEa).
+        let ea_internal: i32 = match mode {
+            AddressingMode::AddressIndirect(_) => 2,
+            AddressingMode::PostIncrement(_) => 4,
+            AddressingMode::PreDecrement(_) => 2,
+            _ => 0,
+        };
+        cpu.internal_cycles(ea_internal as u32);
+        let ea = cpu.resolve_ea(bus, mode, Size::Word);
+        // write_resolved_ea tops the prefetch queue up before the write.
+        cpu.write_resolved_ea(bus, ea, Size::Word, ccr);
+        return 8 + ea_internal + cpu.ea_calc_cycles(mode);
     }
 
     // CHK (68000: opmode=110 for CHK.W). Note: opmode=111 overlaps with LEA on 68000.

--- a/crates/m68k/src/core/ea.rs
+++ b/crates/m68k/src/core/ea.rs
@@ -429,6 +429,22 @@ impl CpuCore {
 /// the difference is only that `dest` omits nothing here because the access is
 /// a write rather than a read of the same width.
 impl CpuCore {
+    /// Cycles `resolve_ea` itself spends on the prefetch-modeled CPUs
+    /// (68000/68010): the extension-word fetches plus the internal clocks
+    /// the address calculation bills. No operand access is included.
+    #[inline]
+    pub(crate) fn ea_calc_cycles(&self, mode: AddressingMode) -> i32 {
+        use AddressingMode::*;
+        match mode {
+            DataDirect(_) | AddressDirect(_) | AddressIndirect(_) | PostIncrement(_) => 0,
+            PreDecrement(_) => 2,
+            Displacement(_) | AbsoluteShort | PcDisplacement => 4,
+            Index(_) | PcIndex => 6,
+            AbsoluteLong => 8,
+            Immediate => 4,
+        }
+    }
+
     /// Source-operand EA fetch time (address calc + one read), byte/word(long).
     #[inline]
     pub(crate) fn ea_source_cycles(&self, mode: AddressingMode, size: Size) -> i32 {

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -229,6 +229,9 @@ impl CpuCore {
 
     /// Process trace exception.
     pub fn exception_trace<B: AddressBus>(&mut self, bus: &mut B) -> i32 {
+        // 4 internal clocks precede the trace frame's first stack write
+        // (Moira execException TRACE: SYNC(4)).
+        self.internal_cycles(4);
         self.take_group2_exception(bus, vector::TRACE)
     }
 

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -229,6 +229,11 @@ impl CpuCore {
 
     /// Process trace exception.
     pub fn exception_trace<B: AddressBus>(&mut self, bus: &mut B) -> i32 {
+        // A pending trace recovers the CPU from the STOP state: STOP executed
+        // with the trace bit set in the incoming SR takes the trace exception
+        // instead of remaining stopped (the trace has priority over both the
+        // stopped state and its supervisor check).
+        self.stopped &= !super::execute::STOP_LEVEL_STOP;
         // 4 internal clocks precede the trace frame's first stack write
         // (Moira execException TRACE: SYNC(4)).
         self.internal_cycles(4);

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -41,10 +41,16 @@ impl CpuCore {
         // Check for pending interrupts
         self.check_and_service_interrupts(bus);
 
-        // If stopped, consume no cycles
+        // If stopped, run the stopped-state supervisor check (a STOP that
+        // loaded an S-clear SR wakes into a privilege violation here);
+        // otherwise consume no cycles.
         if self.stopped != 0 {
-            self.cycles_remaining = 0;
-            return self.initial_cycles;
+            if let Some(cycles) = self.stopped_supervisor_check(bus) {
+                self.cycles_remaining -= cycles;
+            } else {
+                self.cycles_remaining = 0;
+                return self.initial_cycles;
+            }
         }
 
         // Main execution loop
@@ -130,6 +136,9 @@ impl CpuCore {
         use crate::core::types::{InternalStepResult, StepResult};
 
         if self.stopped != 0 {
+            if let Some(cycles) = self.stopped_supervisor_check(bus) {
+                return StepResult::Ok { cycles };
+            }
             return StepResult::Stopped;
         }
 
@@ -223,6 +232,9 @@ impl CpuCore {
         use crate::core::types::{InternalStepResult, StepResult};
 
         if self.stopped != 0 {
+            if let Some(cycles) = self.stopped_supervisor_check(bus) {
+                return StepResult::Ok { cycles };
+            }
             return StepResult::Stopped;
         }
 
@@ -515,6 +527,24 @@ impl CpuCore {
         } else {
             44
         };
+    }
+
+    /// Stopped-state supervisor check, run at every instruction boundary
+    /// while stopped: STOP loads its SR operand verbatim (a single-stepped
+    /// STOP observes S and T exactly as written), and a loaded S-clear SR
+    /// wakes the CPU here with a privilege violation -- 4 internal clocks,
+    /// then the exception, stacking the STOP instruction itself so the
+    /// handler's RTE re-executes it. Returns the cycles consumed when the
+    /// wake fired; None leaves the CPU stopped (including a HALT).
+    fn stopped_supervisor_check<B: AddressBus>(&mut self, bus: &mut B) -> Option<i32> {
+        if self.stopped != STOP_LEVEL_STOP || self.s_flag != 0 {
+            return None;
+        }
+        self.stopped = 0;
+        self.internal_cycles(4);
+        // PC sits past the STOP opcode and its SR operand word.
+        self.ppc = self.pc.wrapping_sub(4);
+        Some(4 + self.exception_privilege(bus))
     }
 
     /// Halt the CPU.

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -403,17 +403,19 @@ impl CpuCore {
         }
     }
 
-    /// Service an interrupt.
-    fn service_interrupt<B: AddressBus>(&mut self, bus: &mut B, level: u8) {
-        // Get vector from interrupt acknowledge
-        let vector = bus.interrupt_acknowledge(level);
-        let vector = if vector == 0xFFFFFFFF {
+    /// Map an interrupt-acknowledge response to a vector number.
+    #[inline]
+    fn iack_vector(response: u32, level: u8) -> u32 {
+        if response == 0xFFFFFFFF {
             // Autovector
             24 + level as u32
         } else {
-            vector & 0xFF
-        };
+            response & 0xFF
+        }
+    }
 
+    /// Service an interrupt.
+    fn service_interrupt<B: AddressBus>(&mut self, bus: &mut B, level: u8) {
         // Match Musashi `m68ki_exception_interrupt`:
         // - save old SR
         // - clear trace, enter supervisor (but do not modify M)
@@ -426,13 +428,45 @@ impl CpuCore {
         self.int_mask = ((level as u32) & 7) << 8;
 
         let stacked_pc = self.pc;
-        let vec_word = (vector as u16) << 2;
+        let vector;
 
         if self.cpu_type == super::types::CpuType::M68000 {
-            // 68000: 3-word frame, hardware bus order (PC low, SR, PC high).
-            self.push_exception_frame_68000(bus, stacked_pc, old_sr);
+            // 68000 interrupt microcode (per Moira execInterrupt, same
+            // sequence as yacht): 6 idle clocks, PC-low write, the 4-clock
+            // interrupt-acknowledge bus cycle that latches the vector
+            // number, 4 more internal clocks, then the SR and PC-high
+            // writes. The idle periods are billed in place so every frame
+            // write and the IACK land at their hardware bus-time offsets
+            // (previously the frame writes ran back to back and all idle
+            // time was paid after the handler prefetch, letting the
+            // handler's first instruction start ~14 clocks early).
+            self.internal_cycles(6);
+            let sp = self.dar[15].wrapping_sub(6);
+            self.dar[15] = sp;
+            self.write_16(bus, sp.wrapping_add(4), (stacked_pc & 0xFFFF) as u16);
+            self.internal_cycles(4);
+            self.flush_sync(bus);
+            vector = Self::iack_vector(bus.interrupt_acknowledge(level), level);
+            self.internal_cycles(4);
+            self.write_16(bus, sp, old_sr);
+            self.write_16(bus, sp.wrapping_add(2), (stacked_pc >> 16) as u16);
+        } else if self.cpu_type == super::types::CpuType::M68010 {
+            // 68010 interrupt microcode (Moira execInterrupt): 12 idle
+            // clocks with the IACK at their end, then the format-0 frame
+            // in hardware bus order PC low, SR, PC high, vector word.
+            self.internal_cycles(12);
+            self.flush_sync(bus);
+            vector = Self::iack_vector(bus.interrupt_acknowledge(level), level);
+            let sp = self.dar[15].wrapping_sub(8);
+            self.dar[15] = sp;
+            self.write_16(bus, sp.wrapping_add(4), (stacked_pc & 0xFFFF) as u16);
+            self.write_16(bus, sp, old_sr);
+            self.write_16(bus, sp.wrapping_add(2), (stacked_pc >> 16) as u16);
+            self.write_16(bus, sp.wrapping_add(6), (vector as u16) << 2);
         } else {
-            // 68010+: format 0 frame: (vector<<2), PC, SR (vector word ends up at +6)
+            vector = Self::iack_vector(bus.interrupt_acknowledge(level), level);
+            let vec_word = (vector as u16) << 2;
+            // 68020+: format 0 frame: (vector<<2), PC, SR (vector word ends up at +6)
             self.push_16(bus, vec_word);
             self.push_32(bus, stacked_pc);
             self.push_16(bus, old_sr);
@@ -453,7 +487,7 @@ impl CpuCore {
         if is_ec020_plus && self.m_flag != 0 {
             self.set_sm_flag(SFLAG_SET); // clear M => ISP active
             let sr2 = old_sr | 0x2000;
-            self.push_16(bus, 0x1000 | (vec_word & 0x0FFF));
+            self.push_16(bus, 0x1000 | (((vector as u16) << 2) & 0x0FFF));
             self.push_32(bus, stacked_pc);
             self.push_16(bus, sr2);
         } else if self.cpu_type == super::types::CpuType::M68060 && self.m_flag != 0 {
@@ -468,8 +502,15 @@ impl CpuCore {
         // Clear stopped state
         self.stopped = 0;
 
-        // Use exception cycles
-        self.cycles_remaining -= 44; // Approximate interrupt cycles
+        // Use exception cycles: 44 clocks on the 68000, 46 on the 68010
+        // (12 leading internal clocks + the four-word frame), matching the
+        // internal + bus clocks billed above so the accounting equals the
+        // bus time actually consumed.
+        self.cycles_remaining -= if self.cpu_type == super::types::CpuType::M68010 {
+            46
+        } else {
+            44
+        };
     }
 
     /// Halt the CPU.

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -354,6 +354,10 @@ impl CpuCore {
     pub fn jump_vector<B: AddressBus>(&mut self, bus: &mut B, vector: u32) {
         // Any exception entry breaks an open 68060 pairing window.
         self.break_060_pipeline();
+        // An earlier poll-point hold must not survive into the handler:
+        // the refill below is a fresh IPL poll point (Moira jumpToVector
+        // polls during the final refill read).
+        bus.ipl_release_sample();
         // Any vectored dispatch ends 68010 loop mode; the refill below
         // restores normal instruction fetching.
         self.loop_mode = false;

--- a/crates/m68k/src/core/instructions/bcd.rs
+++ b/crates/m68k/src/core/instructions/bcd.rs
@@ -41,6 +41,9 @@ impl CpuCore {
 
         let src = self.read_8(bus, src_addr) as u32;
         let dst = self.read_8(bus, dst_addr) as u32;
+        // ABCD -(Ay),-(Ax) polls IPL at the start of the destination read
+        // (the microcode poll sits between the two operand reads).
+        self.ipl_poll_point(bus);
         let result = self.bcd_add(src, dst);
 
         // 68000: the final prefetch precedes the destination writeback.
@@ -82,6 +85,9 @@ impl CpuCore {
 
         let src = self.read_8(bus, src_addr) as u32;
         let dst = self.read_8(bus, dst_addr) as u32;
+        // SBCD -(Ay),-(Ax) polls IPL at the start of the destination read
+        // (the microcode poll sits between the two operand reads).
+        self.ipl_poll_point(bus);
         let result = self.bcd_sub(src, dst);
 
         // 68000: the final prefetch precedes the destination writeback.
@@ -100,7 +106,7 @@ impl CpuCore {
         if self.sst_m68000_compat {
             // SingleStepTests/MAME fixtures treat NBCD as a BCD subtraction helper.
             let res = self.bcd_sub_sst(dst, 0);
-            self.write_resolved_ea(bus, ea, Size::Byte, res);
+            self.write_resolved_ea_np_poll(bus, ea, Size::Byte, res);
             return if is_reg { 6 } else { 8 };
         }
         // Hardware model (WinUAE gencpu i_NBCD, cross-checked against real
@@ -129,7 +135,8 @@ impl CpuCore {
 
         let res8 = (newv & 0xFF) as u32;
         self.bcd_set_nvz(res8, (tmp_newv & 0x80) != 0 && (newv & 0x80) == 0);
-        self.write_resolved_ea(bus, ea, Size::Byte, res8);
+        // NBCD polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, Size::Byte, res8);
 
         if is_reg { 6 } else { 8 }
     }

--- a/crates/m68k/src/core/instructions/bit_manip.rs
+++ b/crates/m68k/src/core/instructions/bit_manip.rs
@@ -49,7 +49,8 @@ impl CpuCore {
         let value = self.read_resolved_ea(bus, ea, size);
         self.not_z_flag = if value & (1 << bit) != 0 { 1 } else { 0 };
         let result = value | (1 << bit);
-        self.write_resolved_ea(bus, ea, size, result & size.mask());
+        // BCHG/BCLR/BSET poll IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result & size.mask());
 
         8
     }
@@ -73,7 +74,8 @@ impl CpuCore {
         let value = self.read_resolved_ea(bus, ea, size);
         self.not_z_flag = if value & (1 << bit) != 0 { 1 } else { 0 };
         let result = value & !(1 << bit);
-        self.write_resolved_ea(bus, ea, size, result & size.mask());
+        // BCHG/BCLR/BSET poll IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result & size.mask());
 
         if size == Size::Long { 10 } else { 8 }
     }
@@ -97,7 +99,8 @@ impl CpuCore {
         let value = self.read_resolved_ea(bus, ea, size);
         self.not_z_flag = if value & (1 << bit) != 0 { 1 } else { 0 };
         let result = value ^ (1 << bit);
-        self.write_resolved_ea(bus, ea, size, result & size.mask());
+        // BCHG/BCLR/BSET poll IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result & size.mask());
 
         8
     }
@@ -112,7 +115,22 @@ impl CpuCore {
 
         // Set bit 7
         let result = value | 0x80;
-        self.write_resolved_ea(bus, ea, Size::Byte, result);
+        if self.cpu_type == crate::core::types::CpuType::M68000 {
+            if let crate::core::ea::EaResult::Memory(addr) = ea {
+                // 68000 TAS bus order (Moira execTasEa): read, 2 internal
+                // clocks, write, THEN the final prefetch -- unlike the
+                // other RMW instructions, whose prefetch precedes the
+                // writeback (the read-modify-write cycle is indivisible on
+                // real hardware). The trailing prefetch carries the IPL
+                // poll, which is the default last-access sample.
+                self.internal_cycles(2);
+                self.write_8(bus, addr, result as u8);
+            } else {
+                self.write_resolved_ea(bus, ea, Size::Byte, result);
+            }
+        } else {
+            self.write_resolved_ea(bus, ea, Size::Byte, result);
+        }
 
         self.trace_t0_68040_sync();
         4

--- a/crates/m68k/src/core/instructions/data_movement.rs
+++ b/crates/m68k/src/core/instructions/data_movement.rs
@@ -39,12 +39,13 @@ impl CpuCore {
         //   instruction recognized its own interrupt one boundary early
         //   (eon's scene-player yield raise).
         // - everything else: write, then the final prefetch (Class 1)
-        let class2_abs_long = !matches!(
+        let memory_source = !matches!(
             src_mode,
             AddressingMode::DataDirect(_)
                 | AddressingMode::AddressDirect(_)
                 | AddressingMode::Immediate
         );
+        let class2_abs_long = memory_source;
         if self.cpu_type == CpuType::M68000 {
             match dst_mode {
                 AddressingMode::PreDecrement(_) => {
@@ -54,6 +55,10 @@ impl CpuCore {
                     // final prefetch); cancel resolve_ea's charge.
                     self.pending_sync_clocks = self.pending_sync_clocks.saturating_sub(2);
                     self.top_up_prefetch(bus);
+                    // MOVE to -(An) behaves like an RMW instruction (pasti
+                    // class 0): the IPL poll rides this prefetch and the
+                    // trailing write does not re-latch it.
+                    self.ipl_poll_point(bus);
                     if let EaResult::Memory(addr) = ea {
                         match size {
                             Size::Byte => self.write_8(bus, addr, value as u8),
@@ -70,6 +75,35 @@ impl CpuCore {
                             }
                         }
                     }
+                }
+                AddressingMode::PostIncrement(_) => {
+                    // MOVE to (An)+ polls IPL during the destination write
+                    // itself, for every source and size (Moira execMove3
+                    // writeOp<POLL>); the final prefetch that follows does
+                    // not re-latch. Long destinations write high word then
+                    // low word with the poll riding the low word, so the
+                    // write is split explicitly.
+                    let ea = self.resolve_ea(bus, dst_mode, size);
+                    if let EaResult::Memory(addr) = ea {
+                        self.write_move_dest_68000(bus, addr, size, value);
+                    }
+                    self.ipl_poll_point(bus);
+                }
+                AddressingMode::AddressIndirect(_)
+                | AddressingMode::Displacement(_)
+                | AddressingMode::Index(_)
+                    if size == Size::Long && !memory_source =>
+                {
+                    // MOVE.L with a register or immediate source to (An),
+                    // d16(An) or d8(An,Xn) polls IPL during the write's low
+                    // word (Moira execMove2/5/6 writeOp<POLL> on the long
+                    // branch); with a memory source or smaller sizes the
+                    // poll rides the final prefetch instead (the default).
+                    let ea = self.resolve_ea(bus, dst_mode, size);
+                    if let EaResult::Memory(addr) = ea {
+                        self.write_move_dest_68000(bus, addr, size, value);
+                    }
+                    self.ipl_poll_point(bus);
                 }
                 AddressingMode::AbsoluteLong if class2_abs_long => {
                     // Consume the address high word normally, the low word
@@ -114,6 +148,28 @@ impl CpuCore {
                 c += if size == Size::Long { 11 } else { 7 };
             }
             c
+        }
+    }
+
+    /// MOVE destination write on the 68000, split into its word bus cycles:
+    /// high word first, then low word (long destinations). Splitting keeps
+    /// the host's per-access IPL samples, so a poll point placed right
+    /// after this write pins the sample taken at the FINAL word's start
+    /// (Moira's writeOp<POLL> polls before the low word of a long write).
+    fn write_move_dest_68000<B: AddressBus>(
+        &mut self,
+        bus: &mut B,
+        addr: u32,
+        size: Size,
+        value: u32,
+    ) {
+        match size {
+            Size::Byte => self.write_8(bus, addr, value as u8),
+            Size::Word => self.write_16(bus, addr, value as u16),
+            Size::Long => {
+                self.write_16(bus, addr, (value >> 16) as u16);
+                self.write_16(bus, addr.wrapping_add(2), value as u16);
+            }
         }
     }
 
@@ -181,10 +237,25 @@ impl CpuCore {
         ) {
             self.internal_cycles(2);
         }
-        // 68000 bus order: PEA performs its final prefetch BEFORE pushing the
-        // address (the pushes are the instruction's last bus accesses).
-        self.top_up_prefetch(bus);
-        self.push_32(bus, ea);
+        if self.cpu_type == CpuType::M68000
+            && matches!(
+                src_mode,
+                AddressingMode::AbsoluteShort | AddressingMode::AbsoluteLong
+            )
+        {
+            // 68000 absolute-mode PEA pushes FIRST and prefetches last
+            // (Moira execPea abs branch: push, then prefetch<POLL>); the
+            // IPL poll rides that final prefetch, the default sample.
+            self.push_32(bus, ea);
+            self.top_up_prefetch(bus);
+        } else {
+            // Other modes: the final prefetch precedes the push and
+            // carries the IPL poll (Moira: POLL_IPL/prefetch<POLL>, then
+            // push); the push does not re-latch the boundary sample.
+            self.top_up_prefetch(bus);
+            self.ipl_poll_point(bus);
+            self.push_32(bus, ea);
+        }
         12
     }
 
@@ -248,6 +319,10 @@ impl CpuCore {
             self.a(reg)
         };
         self.push_32(bus, an);
+        // LINK's IPL poll point sits right before the An push (Moira:
+        // POLL_IPL then push), i.e. the sample taken at the push's first
+        // word; the final prefetch does not re-latch it.
+        self.ipl_poll_point(bus);
 
         // An = SP
         self.set_a(reg, self.dar[15]);
@@ -288,7 +363,20 @@ impl CpuCore {
         self.dar[15] = self.a(reg);
 
         // Pop An
-        let value = self.pull_32(bus);
+        let value = if self.prefetch_enabled() {
+            // The 68000/68010 poll IPL before the LOW word of the stack
+            // read (Moira readOp<.., Long, POLL>), so the read is split
+            // into its two word cycles and the sample taken at the second
+            // word's start is held through the final prefetch.
+            let sp = self.dar[15];
+            let hi = self.read_16(bus, sp) as u32;
+            let lo = self.read_16(bus, sp.wrapping_add(2)) as u32;
+            self.ipl_poll_point(bus);
+            self.dar[15] = sp.wrapping_add(4);
+            (hi << 16) | lo
+        } else {
+            self.pull_32(bus)
+        };
         self.set_a(reg, value);
 
         12
@@ -545,12 +633,43 @@ impl CpuCore {
     /// perform their final prefetch BEFORE the writeback (unlike MOVE, whose
     /// write precedes the final prefetch), so the memory arm tops the
     /// prefetch queue up first.
+    ///
+    /// The interrupt-decision IPL sample rides the WRITEBACK here (ADDI/
+    /// SUBI and MOVE from SR poll during their write; Moira writeOp POLL).
+    /// Most RMW instructions instead poll during the preceding prefetch --
+    /// those use `write_resolved_ea_np_poll`.
     pub fn write_resolved_ea<B: AddressBus>(
         &mut self,
         bus: &mut B,
         ea: EaResult,
         size: Size,
         value: u32,
+    ) {
+        self.write_resolved_ea_impl(bus, ea, size, value, false);
+    }
+
+    /// RMW writeback whose IPL poll point is the final prefetch BEFORE the
+    /// write (the 68000 logic/shift/bit/CLR/NEG/NOT/ADDQ/Scc class: Moira
+    /// prefetch<POLL> then writeOp). The writeback accesses do not re-latch
+    /// the boundary sample, so an interrupt that rises while the write is
+    /// arbitrating is not taken until one instruction later.
+    pub fn write_resolved_ea_np_poll<B: AddressBus>(
+        &mut self,
+        bus: &mut B,
+        ea: EaResult,
+        size: Size,
+        value: u32,
+    ) {
+        self.write_resolved_ea_impl(bus, ea, size, value, true);
+    }
+
+    fn write_resolved_ea_impl<B: AddressBus>(
+        &mut self,
+        bus: &mut B,
+        ea: EaResult,
+        size: Size,
+        value: u32,
+        np_poll: bool,
     ) {
         match ea {
             EaResult::DataReg(reg) => {
@@ -564,6 +683,9 @@ impl CpuCore {
             EaResult::AddrReg(reg) => self.dar[8 + reg as usize] = value,
             EaResult::Memory(addr) => {
                 self.top_up_prefetch(bus);
+                if np_poll {
+                    self.ipl_poll_point(bus);
+                }
                 match size {
                     Size::Byte => self.write_8(bus, addr, value as u8),
                     Size::Word => self.write_16(bus, addr, value as u16),

--- a/crates/m68k/src/core/instructions/integer_arith.rs
+++ b/crates/m68k/src/core/instructions/integer_arith.rs
@@ -63,7 +63,8 @@ impl CpuCore {
         let ea = self.resolve_ea(bus, mode, size);
         let dst = self.read_resolved_ea(bus, ea, size);
         let (result, _) = self.exec_add::<B>(bus, size, data, dst);
-        self.write_resolved_ea(bus, ea, size, result);
+        // ADDQ to memory polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         4
     }
 
@@ -143,7 +144,8 @@ impl CpuCore {
         let ea = self.resolve_ea(bus, mode, size);
         let dst = self.read_resolved_ea(bus, ea, size);
         let (result, _) = self.exec_sub::<B>(bus, size, data, dst);
-        self.write_resolved_ea(bus, ea, size, result);
+        // SUBQ to memory polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         4
     }
 
@@ -218,7 +220,8 @@ impl CpuCore {
                 return 50;
             }
         }
-        self.write_resolved_ea(bus, ea, size, 0);
+        // CLR polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, 0);
         if self.run_mode == RUN_MODE_BERR_AERR_RESET {
             return 50;
         }
@@ -243,7 +246,8 @@ impl CpuCore {
         }
         let result = 0u32.wrapping_sub(src);
 
-        self.write_resolved_ea(bus, ea, size, result & size.mask());
+        // NEG polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result & size.mask());
         if self.run_mode == RUN_MODE_BERR_AERR_RESET {
             return 50;
         }
@@ -264,7 +268,8 @@ impl CpuCore {
             return 50;
         }
         let result = self.exec_subx(size, src, 0);
-        self.write_resolved_ea(bus, ea, size, result);
+        // NEGX polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         if self.run_mode == RUN_MODE_BERR_AERR_RESET {
             return 50;
         }
@@ -285,7 +290,8 @@ impl CpuCore {
         }
         let result = !src & size.mask();
 
-        self.write_resolved_ea(bus, ea, size, result);
+        // NOT polls IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         if self.run_mode == RUN_MODE_BERR_AERR_RESET {
             return 50;
         }

--- a/crates/m68k/src/core/instructions/logical.rs
+++ b/crates/m68k/src/core/instructions/logical.rs
@@ -37,7 +37,8 @@ impl CpuCore {
         let ea = self.resolve_ea(bus, mode, size);
         let dst = self.read_resolved_ea(bus, ea, size);
         let (result, _) = self.exec_and::<B>(bus, size, imm, dst);
-        self.write_resolved_ea(bus, ea, size, result);
+        // ANDI/ORI/EORI to memory poll IPL during the pre-writeback prefetch.
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         if size == Size::Long { 16 } else { 8 }
     }
 
@@ -101,7 +102,7 @@ impl CpuCore {
             return 50;
         }
         let result = (imm | dst) & size.mask();
-        self.write_resolved_ea(bus, ea, size, result);
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         if self.run_mode == RUN_MODE_BERR_AERR_RESET {
             // Address/bus error while writing the operand: exception has been taken.
             return 50;
@@ -169,7 +170,7 @@ impl CpuCore {
             return 50;
         }
         let result = (imm ^ dst) & size.mask();
-        self.write_resolved_ea(bus, ea, size, result);
+        self.write_resolved_ea_np_poll(bus, ea, size, result);
         if self.run_mode == RUN_MODE_BERR_AERR_RESET {
             return 50;
         }

--- a/crates/m68k/src/core/instructions/moves.rs
+++ b/crates/m68k/src/core/instructions/moves.rs
@@ -134,15 +134,12 @@ impl CpuCore {
             // Billed total on the 68010: extension-word prefetch + the EA
             // extension fetches + the internal clocks above + the data
             // cycle + the final prefetch.
-            let ea_ext: u32 = match mode {
-                AddressingMode::Displacement(_)
-                | AddressingMode::Index(_)
-                | AddressingMode::AbsoluteShort => 4,
-                AddressingMode::AbsoluteLong => 8,
-                _ => 0,
-            };
-            let access: u32 = if size == Size::Long { 8 } else { 4 };
-            (4 + ea_ext + moves_sync + access + 4) as i32
+            // ea_calc_cycles also counts the 2 internal clocks the -(An)
+            // and d8(An,Xn) address calculations bill inside resolve_ea
+            // (Moira computeEA SYNC(2)), putting the -(An) byte/word total
+            // at 20 and d8(An,Xn) at 24.
+            let access: i32 = if size == Size::Long { 8 } else { 4 };
+            4 + self.ea_calc_cycles(mode) + moves_sync as i32 + access + 4
         } else {
             4
         }

--- a/crates/m68k/src/core/instructions/moves.rs
+++ b/crates/m68k/src/core/instructions/moves.rs
@@ -53,6 +53,26 @@ impl CpuCore {
 
         let addr = self.get_ea_address(bus, mode, size);
 
+        // The 68010 spends mode-dependent internal clocks between the EA
+        // calculation and the data cycle (Moira execMoves: SYNC 6 for (An)
+        // and d8(An,Xn), 8 for (An)+, 6 for -(An), 4 for d16(An) and
+        // absolute modes), then performs the access and the final prefetch
+        // (which carries the IPL poll, the default last-access sample).
+        // The core previously billed none of this, running MOVES ~6-8
+        // clocks fast and shifting every later bus access early.
+        let moves_sync: u32 = match mode {
+            AddressingMode::AddressIndirect(_) | AddressingMode::PreDecrement(_) => 6,
+            AddressingMode::PostIncrement(_) => 8,
+            AddressingMode::Index(_) => 6,
+            AddressingMode::Displacement(_)
+            | AddressingMode::AbsoluteShort
+            | AddressingMode::AbsoluteLong => 4,
+            _ => 0,
+        };
+        if self.prefetch_enabled() {
+            self.internal_cycles(moves_sync);
+        }
+
         if direction == 1 {
             // Register to EA (write): the data cycle runs in the DFC space.
             let ea_updates_register = matches!(
@@ -110,6 +130,21 @@ impl CpuCore {
 
         // Condition codes are not affected
         self.trace_t0_68040_sync();
-        4
+        if self.prefetch_enabled() {
+            // Billed total on the 68010: extension-word prefetch + the EA
+            // extension fetches + the internal clocks above + the data
+            // cycle + the final prefetch.
+            let ea_ext: u32 = match mode {
+                AddressingMode::Displacement(_)
+                | AddressingMode::Index(_)
+                | AddressingMode::AbsoluteShort => 4,
+                AddressingMode::AbsoluteLong => 8,
+                _ => 0,
+            };
+            let access: u32 = if size == Size::Long { 8 } else { 4 };
+            (4 + ea_ext + moves_sync + access + 4) as i32
+        } else {
+            4
+        }
     }
 }

--- a/crates/m68k/src/core/instructions/mul_div.rs
+++ b/crates/m68k/src/core/instructions/mul_div.rs
@@ -173,22 +173,33 @@ impl CpuCore {
         }
         let dst = self.d(dst_reg);
 
+        let m68000 = self.cpu_type == CpuType::M68000;
         if src == 0 {
-            // Division by zero - trigger trap
+            // Division by zero: 8 internal clocks precede the exception's
+            // first stack write (Moira: SYNC(8) then the zero-divide
+            // exception).
+            if m68000 {
+                self.internal_cycles(8);
+            }
             return self.exception_zero_divide(bus);
         }
 
-        let m68000 = self.cpu_type == CpuType::M68000;
         let div_clocks = if m68000 { divu_cycles(dst, src as u16) } else { 140 };
         let cycles = if m68000 {
             div_clocks + self.ea_source_cycles(mode, Size::Word)
         } else {
             140
         };
-        // The division algorithm's internal clocks precede the final
-        // prefetch (the instruction's last bus access).
-        if m68000 && div_clocks > 4 {
-            self.internal_cycles((div_clocks - 4) as u32);
+        // The final prefetch precedes the division algorithm's internal
+        // clocks (Moira: prefetch<POLL> then SYNC): the np is the
+        // instruction's last bus access and carries the IPL poll, so an
+        // interrupt rising during the division is taken one instruction
+        // later.
+        if m68000 {
+            self.top_up_prefetch(bus);
+            if div_clocks > 4 {
+                self.internal_cycles((div_clocks - 4) as u32);
+            }
         }
 
         let quotient = dst / src;
@@ -233,22 +244,33 @@ impl CpuCore {
         }
         let dst = self.d(dst_reg) as i32;
 
+        let m68000 = self.cpu_type == CpuType::M68000;
         if src == 0 {
-            // Division by zero - trigger trap
+            // Division by zero: 8 internal clocks precede the exception's
+            // first stack write (Moira: SYNC(8) then the zero-divide
+            // exception).
+            if m68000 {
+                self.internal_cycles(8);
+            }
             return self.exception_zero_divide(bus);
         }
 
-        let m68000 = self.cpu_type == CpuType::M68000;
         let div_clocks = if m68000 { divs_cycles(dst, src as i16) } else { 158 };
         let cycles = if m68000 {
             div_clocks + self.ea_source_cycles(mode, Size::Word)
         } else {
             158
         };
-        // The division algorithm's internal clocks precede the final
-        // prefetch (the instruction's last bus access).
-        if m68000 && div_clocks > 4 {
-            self.internal_cycles((div_clocks - 4) as u32);
+        // The final prefetch precedes the division algorithm's internal
+        // clocks (Moira: prefetch<POLL> then SYNC): the np is the
+        // instruction's last bus access and carries the IPL poll, so an
+        // interrupt rising during the division is taken one instruction
+        // later.
+        if m68000 {
+            self.top_up_prefetch(bus);
+            if div_clocks > 4 {
+                self.internal_cycles((div_clocks - 4) as u32);
+            }
         }
 
         // Special case: 0x80000000 / -1 = 0x80000000 (would overflow)

--- a/crates/m68k/src/core/memory.rs
+++ b/crates/m68k/src/core/memory.rs
@@ -93,5 +93,26 @@ pub trait AddressBus {
     fn interrupt_acknowledge(&mut self, _level: u8) -> u32 {
         0xFFFF_FFFF
     }
+
+    /// IPL poll-point marker. The 68000/68010 sample their IPL pins at ONE
+    /// microcode-determined point per instruction, and the take-interrupt
+    /// decision at the next instruction boundary consumes that sample. A
+    /// timing-accurate host latches the IPL level at the start of every bus
+    /// access and, by default, lets the instruction's LAST access provide
+    /// the boundary sample. For instructions whose poll point is NOT the
+    /// last access (e.g. read-modify-write instructions poll during the
+    /// final prefetch that precedes the writeback), the core calls this
+    /// right after the polling access: the host must keep that access's
+    /// sample and ignore later accesses until the boundary decision
+    /// consumes it. Functional-only buses can ignore it.
+    fn ipl_hold_sample(&mut self) {}
+
+    /// Release an `ipl_hold_sample` poll-point hold before the instruction
+    /// boundary consumes it. Called on exception dispatch: the vector jump's
+    /// handler-entry prefetch is a fresh poll point on real silicon (Moira
+    /// jumpToVector polls during the final refill read), so a hold placed
+    /// earlier in the faulted instruction must not survive into the handler.
+    fn ipl_release_sample(&mut self) {}
+
     fn reset_devices(&mut self) {}
 }

--- a/crates/m68k/tests/stop_and_68010_timing_tests.rs
+++ b/crates/m68k/tests/stop_and_68010_timing_tests.rs
@@ -1,0 +1,207 @@
+//! STOP state semantics and 68010 instruction-cycle calibration.
+//!
+//! Cycle counts are the vAmigaTS CPU/Timing + CPU/Timing2 measured values
+//! (Moira's cycle-exact 68010 path, which matches A500+68010 photos):
+//! MOVES per-EA-mode totals, MOVE from CCR, format-0 RTE, and the
+//! interrupt dispatch (44 clocks on the 68000, 46 on the 68010).
+//! STOP: an incoming SR with S clear stops only momentarily -- the stopped
+//! state's supervisor check raises a privilege violation that stacks the
+//! STOP instruction itself; a pending trace has priority and recovers from
+//! the stop; a trace bit LOADED by STOP does not fire while stopped.
+
+mod common;
+
+use common::TestBus;
+use m68k::core::types::CpuType;
+use m68k::{AddressBus, CpuCore, StepResult};
+
+fn setup(prog: &[u16], cpu_type: CpuType) -> (CpuCore, TestBus) {
+    let mut cpu = CpuCore::new();
+    cpu.set_cpu_type(cpu_type);
+    let mut bus = TestBus::new();
+    let mut bytes = Vec::new();
+    for w in prog {
+        bytes.extend_from_slice(&w.to_be_bytes());
+    }
+    bus.load_rom(&bytes);
+    bus.setup_boot();
+    cpu.reset(&mut bus);
+    cpu.pc = 0x10000;
+    cpu.set_sr(0x2700);
+    (cpu, bus)
+}
+
+fn step(cpu: &mut CpuCore, bus: &mut TestBus) -> StepResult {
+    let mut hle = m68k::NoOpHleHandler;
+    cpu.step_with_hle_handler(bus, &mut hle)
+}
+
+fn step_cycles(cpu: &mut CpuCore, bus: &mut TestBus) -> i32 {
+    match step(cpu, bus) {
+        StepResult::Ok { cycles } => cycles,
+        other => panic!("unexpected step result: {:?}", other),
+    }
+}
+
+// ========== 68010 MOVES cycle totals ==========
+
+/// One MOVES case: opcode words, register/EA setup, expected 68010 cycles.
+fn run_moves(prog: &[u16], expected: i32, what: &str) {
+    let (mut cpu, mut bus) = setup(prog, CpuType::M68010);
+    cpu.dar[8 + 4] = 0x300010; // A4 (also predecrement-safe)
+    cpu.dar[5] = 0; // D5 index
+    let cycles = step_cycles(&mut cpu, &mut bus);
+    assert_eq!(cycles, expected, "{what}");
+}
+
+#[test]
+fn m68010_moves_memory_to_register_cycle_totals() {
+    // moves.b <ea>,d0 (extension word 0x0000)
+    run_moves(&[0x0E14, 0x0000], 18, "moves.b (a4),d0");
+    run_moves(&[0x0E1C, 0x0000], 20, "moves.b (a4)+,d0");
+    run_moves(&[0x0E24, 0x0000], 20, "moves.b -(a4),d0");
+    run_moves(&[0x0E2C, 0x0000, 0x0006], 20, "moves.b 6(a4),d0");
+    run_moves(&[0x0E34, 0x0000, 0x5006], 24, "moves.b 6(a4,d5),d0");
+    run_moves(&[0x0E38, 0x0000, 0x8000], 20, "moves.b (xxx).w,d0");
+    run_moves(&[0x0E39, 0x0000, 0x0030, 0x0000], 24, "moves.b (xxx).l,d0");
+    // Long data cycles add 4.
+    run_moves(&[0x0E94, 0x0000], 22, "moves.l (a4),d0");
+    run_moves(&[0x0EB4, 0x0000, 0x5006], 28, "moves.l 6(a4,d5),d0");
+}
+
+#[test]
+fn m68010_moves_register_to_memory_cycle_totals() {
+    // moves.b d0,<ea> (extension word 0x0800): same totals as the read form.
+    run_moves(&[0x0E14, 0x0800], 18, "moves.b d0,(a4)");
+    run_moves(&[0x0E1C, 0x0800], 20, "moves.b d0,(a4)+");
+    run_moves(&[0x0E24, 0x0800], 20, "moves.b d0,-(a4)");
+    run_moves(&[0x0E2C, 0x0800, 0x0006], 20, "moves.b d0,6(a4)");
+    run_moves(&[0x0E34, 0x0800, 0x5006], 24, "moves.b d0,6(a4,d5)");
+    run_moves(&[0x0E94, 0x0800], 22, "moves.l d0,(a4)");
+}
+
+// ========== 68010 MOVE from CCR ==========
+
+#[test]
+fn m68010_move_from_ccr_cycle_totals() {
+    // move.w ccr,d0: only the final prefetch (4 clocks).
+    let (mut cpu, mut bus) = setup(&[0x42C0], CpuType::M68010);
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 4, "move.w ccr,d0");
+
+    // move.w ccr,(a4): 2 internal + prefetch + write.
+    let (mut cpu, mut bus) = setup(&[0x42D4], CpuType::M68010);
+    cpu.dar[8 + 4] = 0x300010;
+    assert_eq!(step_cycles(&mut cpu, &mut bus), 10, "move.w ccr,(a4)");
+}
+
+// ========== 68010 RTE (format 0) ==========
+
+#[test]
+fn m68010_rte_format0_takes_24_cycles() {
+    let (mut cpu, mut bus) = setup(&[0x4E73], CpuType::M68010);
+    // Build a format-0 frame: SR, PC, format/vector word.
+    let sp = 0x0000_8000;
+    cpu.dar[15] = sp;
+    bus.write_word(sp, 0x2700);
+    bus.write_long(sp + 2, 0x0001_0000);
+    bus.write_word(sp + 6, 0x0064); // format 0, vector offset 0x64
+    let cycles = step_cycles(&mut cpu, &mut bus);
+    assert_eq!(cycles, 24, "68010 RTE (format 0)");
+    assert_eq!(cpu.pc, 0x0001_0000);
+    assert_eq!(cpu.dar[15], sp + 8);
+}
+
+// ========== Interrupt dispatch cycles ==========
+
+fn dispatch_cycles(cpu_type: CpuType) -> i32 {
+    let (mut cpu, mut bus) = setup(&[0x4E71, 0x4E71], cpu_type);
+    bus.write_long(0x6C, 0x0001_0002); // level-3 autovector handler
+    cpu.set_sr(0x2000); // supervisor, IPL mask 0
+    cpu.dar[15] = 0x0000_8000;
+    cpu.set_irq(3);
+    cpu.execute(&mut bus, 0)
+}
+
+#[test]
+fn interrupt_dispatch_takes_44_clocks_on_68000_and_46_on_68010() {
+    assert_eq!(dispatch_cycles(CpuType::M68000), 44);
+    assert_eq!(dispatch_cycles(CpuType::M68010), 46);
+}
+
+// ========== STOP semantics ==========
+
+#[test]
+fn stop_with_s_clear_loads_sr_verbatim_then_wakes_into_privilege() {
+    for cpu_type in [CpuType::M68000, CpuType::M68010] {
+        let (mut cpu, mut bus) = setup(&[0x4E72, 0x0014], cpu_type);
+        bus.write_long(0x20, 0x0001_0010); // privilege-violation vector
+        cpu.dar[15] = 0x0000_8000;
+        // The STOP step itself loads the SR VERBATIM (S clear, flags as
+        // written) and stops -- the SST m68000 single-step fixtures observe
+        // exactly this state.
+        let result = step(&mut cpu, &mut bus);
+        assert!(matches!(result, StepResult::Ok { .. }), "{result:?}");
+        assert!(cpu.is_stopped(), "{cpu_type:?}: stopped after the STOP step");
+        assert_eq!(cpu.get_sr(), 0x0014, "{cpu_type:?}: SR verbatim");
+        // The next instruction boundary runs the stopped state's supervisor
+        // check: privilege violation, stacking the STOP itself so the
+        // handler's RTE re-executes it.
+        let result = step(&mut cpu, &mut bus);
+        assert!(matches!(result, StepResult::Ok { .. }), "{result:?}");
+        assert!(!cpu.is_stopped(), "{cpu_type:?}: must not stay stopped");
+        assert_eq!(cpu.pc, 0x0001_0010, "{cpu_type:?}: privilege handler");
+        assert!(cpu.is_supervisor());
+        let stacked_pc = bus.read_long(cpu.dar[15] + 2);
+        assert_eq!(stacked_pc, 0x0001_0000, "{cpu_type:?}: stacked PC");
+    }
+}
+
+#[test]
+fn stop_with_s_clear_takes_42_clocks_to_the_handler_on_68000() {
+    let (mut cpu, mut bus) = setup(&[0x4E72, 0x0000], CpuType::M68000);
+    bus.write_long(0x20, 0x0001_0010);
+    cpu.dar[15] = 0x0000_8000;
+    // STOP (4), then at the next boundary 4 internal clocks in the stopped
+    // state + the privilege exception (34).
+    let stop_cycles = step_cycles(&mut cpu, &mut bus);
+    let wake_cycles = step_cycles(&mut cpu, &mut bus);
+    assert_eq!(stop_cycles, 4);
+    assert_eq!(wake_cycles, 38);
+}
+
+#[test]
+fn stop_with_pending_trace_traces_instead_of_stopping() {
+    let (mut cpu, mut bus) = setup(&[0x4E72, 0x2000], CpuType::M68000);
+    bus.write_long(0x24, 0x0001_0020); // trace vector
+    cpu.dar[15] = 0x0000_8000;
+    cpu.set_sr(0xA700); // T1 set entering STOP
+    let result = step(&mut cpu, &mut bus);
+    assert!(matches!(result, StepResult::Ok { .. }), "{result:?}");
+    assert!(!cpu.is_stopped(), "trace must recover from the stop state");
+    assert_eq!(cpu.pc, 0x0001_0020, "trace handler");
+    // The stacked PC is the instruction after STOP.
+    let stacked_pc = bus.read_long(cpu.dar[15] + 2);
+    assert_eq!(stacked_pc, 0x0001_0004);
+}
+
+#[test]
+fn stop_with_pending_trace_and_s_clear_prefers_the_trace() {
+    let (mut cpu, mut bus) = setup(&[0x4E72, 0x0000], CpuType::M68000);
+    bus.write_long(0x20, 0x0001_0010); // privilege vector
+    bus.write_long(0x24, 0x0001_0020); // trace vector
+    cpu.dar[15] = 0x0000_8000;
+    cpu.set_sr(0xA700);
+    let _ = step(&mut cpu, &mut bus);
+    assert!(!cpu.is_stopped());
+    assert_eq!(cpu.pc, 0x0001_0020, "trace wins over the supervisor check");
+}
+
+#[test]
+fn stop_loading_the_trace_bit_stays_stopped() {
+    let (mut cpu, mut bus) = setup(&[0x4E72, 0xA000], CpuType::M68000);
+    cpu.dar[15] = 0x0000_8000;
+    let result = step(&mut cpu, &mut bus);
+    assert!(matches!(result, StepResult::Ok { .. }), "{result:?}");
+    assert!(cpu.is_stopped(), "T loaded BY the stop must not trace");
+    assert!(matches!(step(&mut cpu, &mut bus), StepResult::Stopped));
+}

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -83,6 +83,25 @@ makes tight copy/clear loops measurably faster on a real 68010.
 `crates/m68k/tests/loop_mode_timing_tests.rs` pins engagement, the
 68000's non-engagement, and the no-fetch iteration cost.
 
+The 68010's own cycle costs where they differ from the 68000 are
+calibrated against the vAmigaTS `CPU/Timing`/`CPU/Timing2` measurements
+(cross-checked with Moira's cycle-exact 68010 path, which matches
+A500+68010 photos): MOVES spends per-EA-mode internal clocks between the
+address calculation and the SFC/DFC data cycle, MOVE from CCR is
+4 clocks to a register and prefetches before its memory write, a
+format-0 RTE is 24 clocks (the format word is read once, not re-read),
+and an interrupt dispatch is 46 clocks (12 internal before the four-word
+format-0 frame) against the 68000's 44. STOP semantics shared with the
+68000: the SR operand is loaded VERBATIM (a single-stepped STOP observes
+S and T exactly as written; the SST m68000 fixtures pin this), and an
+S-clear SR stops only momentarily -- at the next instruction boundary the
+stopped state's supervisor check raises a privilege violation stacking
+the STOP itself, so the handler's RTE re-executes it; a pending trace
+(T set in the SR the instruction started with) has priority and recovers
+from the stop, while a T bit loaded *by* STOP does not fire while
+stopped. `crates/m68k/tests/stop_and_68010_timing_tests.rs` pins all of
+these.
+
 ## Caches
 
 The on-chip caches are silicon, so they are modelled by default on the parts

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3643,7 +3643,18 @@ impl Bus {
         if let Some(cck) = self.cck_until_pending_copper_frame_start() {
             return Some(cck);
         }
-        let wait = self.copper.waiting()?;
+        let Some(wait) = self.copper.waiting() else {
+            // A running Copper (or one in a WAIT/SKIP tail) fetches an
+            // instruction word every other colour clock, and its next MOVE
+            // can raise INTREQ: bound the stopped-CPU fast-forward to a
+            // couple of colour clocks so a wake-up interrupt written by the
+            // instruction stream is recognized on time. A halted Copper
+            // (illegal register write) fetches nothing until restarted.
+            if self.copper.is_stopped() {
+                return None;
+            }
+            return Some(2);
+        };
         let position_cck = self.cck_until_copper_wait_position(wait)?;
         if position_cck == 0 && wait.blitter_wait_enabled() && self.blitter.busy {
             return self.next_blitter_completion_cck();

--- a/src/chipset/copper.rs
+++ b/src/chipset/copper.rs
@@ -408,6 +408,12 @@ impl Copper {
         }
     }
 
+    /// Whether the Copper has halted (illegal register write): it fetches
+    /// nothing further until a COPJMP strobe or vertical blank restarts it.
+    pub fn is_stopped(&self) -> bool {
+        matches!(self.state, CopperState::Stopped)
+    }
+
     pub fn advance_wait_free_cycle(
         &mut self,
         vpos: u32,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -231,6 +231,13 @@ struct CpuBus {
     /// instruction later. Transient: re-sampled on every access, never
     /// serialized (a loaded state re-samples within one instruction).
     sampled_irq_level: u8,
+    /// Set by the core's `ipl_hold_sample` poll-point marker: the current
+    /// `sampled_irq_level` is the instruction's microcode poll value and
+    /// later accesses in the same instruction must not re-latch it (e.g.
+    /// RMW instructions poll during the final prefetch, BEFORE their
+    /// writeback). Cleared when the boundary decision consumes the sample.
+    /// Transient like `sampled_irq_level`; never serialized.
+    ipl_sample_held: bool,
 }
 
 pub fn build(
@@ -286,6 +293,7 @@ impl M68kMachine {
                 dbg_irq_window: debug_irq_window_setting(),
                 last_fetch_cache_hit: false,
                 sampled_irq_level: 0,
+                ipl_sample_held: false,
             },
             hle: NoOpHleHandler,
             fpu_enabled,
@@ -1682,6 +1690,9 @@ impl M68kMachine {
         if self.bus.bus.irq_latency_setting != 0 && !self.cpu.is_stopped() {
             level = level.min(self.bus.sampled_irq_level);
         }
+        // The boundary decision consumed the sample: release any poll-point
+        // hold so the next instruction's accesses latch normally.
+        self.bus.ipl_sample_held = false;
         self.cpu.set_irq(level);
     }
 
@@ -2658,6 +2669,12 @@ impl CpuBus {
     /// POLL_IPL). `refresh_irq_line` consumes this latch.
     #[inline]
     fn sample_ipl(&mut self) {
+        // A poll-point hold (AddressBus::ipl_hold_sample) pins the sample
+        // taken at the instruction's microcode poll access; accesses after
+        // the poll point (e.g. an RMW writeback) do not re-latch.
+        if self.ipl_sample_held {
+            return;
+        }
         self.sampled_irq_level = if self.bus.paula.intena & INT_MASTER != 0 {
             pending_ipl(self.bus.paula.intena & self.bus.cpu_visible_intreq())
         } else {
@@ -2715,6 +2732,18 @@ impl AddressBus for CpuBus {
         // Cycle-exact core (Part E.2): internal (non-bus) CPU clocks elapse
         // with the chip bus free for DMA, timed devices ticking along.
         self.bus.sync_cpu_internal_clocks(cpu_clocks);
+    }
+
+    fn ipl_hold_sample(&mut self) {
+        // Core-marked IPL poll point: keep the sample latched by the access
+        // that just completed until the boundary decision consumes it.
+        self.ipl_sample_held = true;
+    }
+
+    fn ipl_release_sample(&mut self) {
+        // Exception dispatch: the handler-entry refill is a fresh poll
+        // point, so drop any hold from the faulted instruction.
+        self.ipl_sample_held = false;
     }
 
     fn interrupt_acknowledge(&mut self, level: u8) -> u32 {
@@ -3177,6 +3206,7 @@ mod tests {
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
             sampled_irq_level: 0,
+            ipl_sample_held: false,
         };
 
         assert_eq!(bus.read_long(0), 0x1111_4EF9);
@@ -3202,6 +3232,7 @@ mod tests {
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
             sampled_irq_level: 0,
+            ipl_sample_held: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
         // Start on a refresh slot (0x003) so the fetch both waits for and then
@@ -3234,6 +3265,7 @@ mod tests {
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
             sampled_irq_level: 0,
+            ipl_sample_held: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
 
@@ -3446,6 +3478,7 @@ mod tests {
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
             sampled_irq_level: 0,
+            ipl_sample_held: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
         let fast = FAST_RAM_BASE as u32 + 0x40;
@@ -3492,6 +3525,7 @@ mod tests {
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
             sampled_irq_level: 0,
+            ipl_sample_held: false,
         };
         let before = bus.read_long(ROM_BASE as u32);
         bus.write_long(ROM_BASE as u32, 0xDEAD_BEEF);
@@ -3516,6 +3550,7 @@ mod tests {
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
             sampled_irq_level: 0,
+            ipl_sample_held: false,
         };
         let addr = SLOW_RAM_BASE as u32 + 64 * 1024;
         // A write into unmapped space still drives the bus: the following
@@ -3663,12 +3698,16 @@ mod tests {
         // + 1 bus-free tail = limit + 2 cck.
         let rom_prefetch_cck = 5 * 2;
         let per_chip_access = u32::from(crate::bus::BLITTER_SLOWDOWN_CPU_MISS_LIMIT) + 2;
+        // TAS spends 2 internal CPU clocks (1 cck) between the operand read
+        // and the writeback half of its indivisible read-modify-write cycle
+        // (yacht: np nrb n nw; Moira execTasEa SYNC(2)).
+        let rmw_internal_cck = 1;
         assert_eq!(slice.instructions, 1);
         assert_eq!(machine.bus().mem.chip_ram[0x0400], 0x92);
         assert_eq!(
             slice.bus_advanced_cck,
-            rom_prefetch_cck + 2 * per_chip_access,
-            "TAS bus time = ROM prefetch (external, 2 cck/word) plus the two contended chip-RAM byte accesses (limit + 2 cck each under a busy BLITHOG-clear blitter)"
+            rom_prefetch_cck + 2 * per_chip_access + rmw_internal_cck,
+            "TAS bus time = ROM prefetch (external, 2 cck/word) plus the two contended chip-RAM byte accesses (limit + 2 cck each under a busy BLITHOG-clear blitter) plus the 1 cck read-to-write internal gap"
         );
         assert!(machine.bus().blitter.busy);
         // The blitter held the bus through the CPU's starvation waits rather than

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1659,10 +1659,18 @@ fn real_slice_accounting(
     if run.cpu_stopped {
         // A stopped CPU performs no bus activity; the idle period is paced by
         // the requested fast-forward span and advanced post-hoc by step_real.
-        let device_cck = run.actual_cpu_cck.max(cck_for_instructions(
-            requested_instructions,
-            cpu_cycles_per_instruction,
-        ));
+        // A pure idle single step (no instruction retired) advances one
+        // colour clock: a STOPped 68000 samples its IPL pins every bus-cycle
+        // period, so the wake-up quantum near a device event is 2 CPU clocks,
+        // not a whole instruction's worth of time.
+        let device_cck = if run.actual_instructions == 0 && requested_instructions == 1 {
+            run.actual_cpu_cck.max(1)
+        } else {
+            run.actual_cpu_cck.max(cck_for_instructions(
+                requested_instructions,
+                cpu_cycles_per_instruction,
+            ))
+        };
         return RealSliceAccounting {
             budget_debit: requested_instructions.max(run.actual_instructions).max(1),
             device_cck,


### PR DESCRIPTION
**Stacked on #144 (`fix/ipl-poll-placement`) - merge that first.** This branch
is rebased onto it; the diff shown here against `main` includes #144's
commits until it merges.

Calibrates the remaining self-contained CPU instruction-timing buckets from
the vAmigaTS suite (CPU/Timing + CPU/Timing2) against measured 68000/68010
hardware behaviour, and fixes the STOP state machine. #144 already landed
the shared foundations (68010 interrupt dispatch 46 clocks with the idles
billed in place, 68010 MOVES per-EA internal clocks, format-0 RTE read
count, IPL poll placement); this branch adds what it does not cover:

## Hardware fixes (on top of #144)

- **68010 MOVE from CCR**: 4 clocks to a register (was 6); memory
  destinations spend per-mode internal clocks and prefetch BEFORE the
  write ((An) = 10 total). vAmigaTS CPU/Timing2/MOVECCR, Moira
  execMoveCcrRg/execMoveCcrEa.
- **68010 MOVES billed total**: count the 2 internal clocks the -(An) and
  d8(An,Xn) address calculations spend inside resolve_ea (Moira computeEA
  SYNC(2)); -(An) byte/word = 20 clocks, d8(An,Xn) = 24. Placement was
  already right in #144; only the returned total under-counted.
- **STOP loads its SR verbatim** (68000-040): a single-stepped STOP
  observes S and T exactly as written - the real-chip-validated SST
  m68000 `STOP.json.bin` pins this and passes locally. An S-clear SR
  stops only momentarily: the stopped state's supervisor check (run at
  every instruction boundary on all three step paths) raises a privilege
  violation 4 internal clocks later, stacking the STOP instruction itself
  so the handler's RTE re-executes it (4 + 38 clocks to the handler).
  Previously the core stopped with a user-mode SR and never recovered.
- **STOP with a pending trace** (T set in the SR the instruction started
  with): the trace exception has priority over the stopped state and its
  supervisor check, and recovers from the stop; a T bit loaded BY the
  STOP does not fire while stopped. The 68060 keeps its distinct
  immediate-privilege model.
- **Stopped-CPU wake timing**: the idle fast-forward treated a running
  (non-waiting) Copper as event-free, so a Copper MOVE to INTREQ right
  after a WAIT was overshot by whole slices - the CPU woke up to 72 lines
  late (stop1 never visibly woke). The fast-forward horizon is now two
  colour clocks while the Copper is streaming, and a pure idle single
  step advances one colour clock (a STOPped 68000 samples its IPL pins
  every bus-cycle period).

## vAmigaTS results (summed divergence, cases)

| bucket | before (main) | after |
|---|---|---|
| CPU/Timing/STOP (10) | 557.3% | 112.6% |
| CPU/Timing2/MOVES (30) | 1332.6% | ~1316% |
| CPU/Timing2/MOVECCR (8) | 339.9% | ~340% |

stop1/stop2/stop5 drop to 0.7-3.2% (from 26-85%). stop3/stop4 remain
22-30%: their privilege-violation loop never re-syncs to the beam, so the
one-off interrupt-entry offset from the known Copper-write/IPL-recognition
class persists for the whole frame.

MOVES/MOVECCR payload cells now measure cycle-exact against vAmiga (the
bracketing COLOR00 spans match pixel-for-pixel), but the buckets' scores
are dominated by the cpu2.i harness's colour-painting main loop: its
stripe phase depends on the exact instruction boundary at which each of
the six per-frame interrupts is recognized, and Copperline's recognition
point sits a few colour clocks later in the instruction stream than
vAmiga's (the documented Copper-write-timing + IPL-pipe class; the pushed
return PCs differ by 1-2 NOPs at equal beam positions). Until that class
is fixed, the stripe-noise floor for these buckets stays ~40%; the same
payloads measured by the silent-main-loop CPU/Timing harness score
2-4.5%.

## Verification

- `crates/m68k/tests/stop_and_68010_timing_tests.rs`: 10 regression tests
  (MOVES per-mode totals both directions, MOVE from CCR, RTE 24, dispatch
  44/46, STOP verbatim-SR/privilege/trace/loaded-T semantics and cycles).
- SST `STOP.json.bin` passes locally (M68K_SST_FIXTURES).
- 14-demo byte-identity vs the #144 base: 11/14 IDENTICAL. eon, SOTA and
  Second Nature shift - isolated to the stopped-CPU wake-timing commit
  (the m68k-only commits keep full identity): these demos trackload
  through Kickstart, whose Exec idle loop STOPs between disk interrupts,
  and each wake now lands at the device event instead of up to a
  fast-forward quantum late. Verified benign: identical scenes with a
  sub-second timeline shift (SOTA's credits screen appears at 30s on the
  branch vs 31s on the base; eon/Second Nature differ by 1.6-2.2% of
  pixels). Same legitimate-shift class as this base's own dispatch-order
  change.
- Full 535-case CPU/Timing+Timing2 sweep vs the main baseline (measured
  pre-rebase): zero regressions > 1pp outside the target buckets; most of
  the 68010 landscape improves.
- cargo test --lib (1324), crates/m68k per-file suites, clippy
  --all-targets --all-features -D warnings, cargo fmt --check: clean.
  (The m68k SST/musashi fixture test bins fail to compile locally on
  clean main too - known baseline; CI runs SST on the PR.)
