### PR TITLE
blitter: model the micro-cycle protocol against the vAmiga slot oracle

### DIFF
--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -88,6 +88,7 @@ authoritative list. The most useful ones:
 | Variable | What it logs / does |
 |---|---|
 | `COPPERLINE_DIAG_SLOTMAP` | Per-colour-clock chip-bus owner map for a frame (`R`efresh, `B`itplane, `S`prite, `D`isk, `A`udio, `C`opper, b`L`itter, c`P`u, `.` idle); `COPPERLINE_DIAG_SLOTMAP_AT=SECS` picks the frame |
+| `COPPERLINE_DIAG_BLT_SLOTS` | Blitter slot trace: one stderr line per blitter pipeline cycle (`BLTP frame vpos hpos TICK phase bus=0/1`), plus per-cck owner lines while a blit is in flight and `START`/`END` markers. Formatted for side-by-side diffing against a vAmiga build instrumented with the matching `VAMIGA_BLT_PROBE` hooks |
 | `COPPERLINE_DIAG_IPL` | CPU cycles spent per interrupt level |
 | `COPPERLINE_DIAG_PCSAMPLE` | Top-50 executed-PC histogram every 50 frames |
 | `COPPERLINE_DIAG_PCHIST` | Full PC history (with `COPPERLINE_DIAG_PCHIST_START=SECS`) |

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -252,29 +252,47 @@ the same slot-eligibility primitive the live engine uses.
 
 ### Per-slot FSM
 
-Scheduled normal blits use explicit phases matching the hardware
-controller: three internal startup slots (the BLTSIZE register-commit
-cycle plus the two bus-arbitration startup cycles real Agnus spends
-before the micro-program begins, verified with a BLTSIZE-to-blitter-IRQ
-beam probe against vAmiga), a one-slot BBUSY start delay, an INIT slot,
-source slots A/B/C/D, and E/F flush slots for the delayed D holding
-register. The
-source cadence follows the enabled-channel speed table: A is always
-visited, B only when enabled, C when enabled (USEC) *or* in fill mode (an
-idle C slot, no bus access), and D when D is enabled or no C next-word
-state exists. D output is delayed through the hold register: after source
-fetches, the first D phase is the HRM "-" bubble and does not claim the
-chip bus because no destination word is queued yet. The first destination
-word is written on the next D slot and the final word in the F flush slot.
+Scheduled blits use explicit phases matching the hardware controller,
+cross-checked cycle-for-cycle against vAmiga's slot-accurate blitter with
+a two-sided slot-trace probe (`COPPERLINE_DIAG_BLT_SLOTS` in Copperline,
+`VAMIGA_BLT_PROBE` hooks in a local vAmiga build):
+
+- **Startup**: two internal extra slots (the BLTSIZE register-commit
+  cycle plus the BLT_STRT arbitration cycles real Agnus spends before the
+  micro-program begins) followed by the StartDelay/Init slots, so the
+  first body cycle runs at poke+4, matching vAmiga's BLT_STRT1/BLT_STRT2
+  timeline. The startup applies to normal and line blits alike.
+- **Body**: the source cadence follows the enabled-channel speed table: A
+  is always visited, B and C only when enabled, and D when D is enabled
+  or no C next-word state exists. D output is delayed through the hold
+  register: the first D phase of every program is the HRM "-" bubble and
+  does not claim the chip bus -- including D-only clears, which write
+  "-- D0 -- D1 | -- D2" on hardware. The first destination word is
+  written on the next D slot and the final word in the F flush slot.
+- **Termination**: every program ends with two terminal micro-cycles (the
+  internal D-hold flush and the BLTDONE cycle -- the final D write for
+  USED programs, internal otherwise). DMACONR's BBUSY drops with the
+  sequencer's final body cycle, BEFORE those terminal cycles: polling
+  loops see BBUSY clear two cycles before the last D word lands.
+  INTREQ.BLIT rises one colour clock after the BLTDONE cycle's FIRST
+  attempt (vAmiga `scheduleIrqRel(BLIT, 1)` runs before the bus
+  allocation check), so a bus-blocked final D write raises the interrupt
+  before the word lands; the Copper's blitter-finished gate opens when
+  the BLTDONE cycle completes.
+
 Normal-mode A/B barrel-shifter carry is cleared at the first word of a new
 BLTSIZE, then carries from the last source word of one row into the first
 source word of the next inside that blit; masks, modulos, and fill carry
 still observe row boundaries. Line blits use L1-L4 phases (L2 latches the C
-source word, L3 propagates, L4 stores); line-mode B data loads pass through
-the current B shifter at write time, and at completion the hardware-visible
-ASH, BSH, SIGN, and low-word BLTAPT accumulator state is written back. Tests:
+source word, L3 propagates, L4 stores) between the same startup and
+terminal cycles; a suppressed line store (USEC clear, or SING past a row's
+first dot) leaves its D slot bus-idle like vAmiga's lockD. Line-mode B data
+loads pass through the current B shifter at write time, and at completion
+the hardware-visible ASH, BSH, SIGN, and low-word BLTAPT accumulator state
+is written back. Tests:
 `scheduled_normal_mode_bbusy_start_delay_precedes_first_source_slot`,
 `blit_pipeline_identifies_idle_cycles_per_hrm_diagrams`,
+`scheduled_normal_clear_writes_progressively`,
 `scheduled_line_mode_latches_c_source_before_store_phase`,
 `scheduled_shift_carry_crosses_normal_mode_row_boundary`,
 `scheduled_a_shift_zero_fills_first_word_of_new_blit`.
@@ -294,7 +312,7 @@ classification of writes while BBUSY is set:
 | `BLTAFWM`, `BLTALWM` | Deferred | First/last-word masks captured by the scheduled state at BLTSIZE. |
 | `BLT[ABCD]PTH/PTL` | Deferred | Pointer writes do not retarget the already-scheduled transfer. |
 | `BLT[ABCD]MOD` | Deferred | Modulos captured at BLTSIZE. |
-| `BLTBDAT` | Immediate, old-register latch | The first B write after completion zeros the B old register; later writes shift through the latched B data. |
+| `BLTBDAT` | Immediate, write-time shifter | The write runs the B barrel shifter with the BSH/DESC current at write time (unlike BLTADAT/BLTCDAT); USEB-off blits consume that latched hold word. The first B write after completion zeros the B old register; later writes shift through the latched B data. |
 | `BLTSIZE` | Deferred restart | A second start strobe drains the current blit first, then starts the replacement from the post-completion pointer state. |
 | `DMACON.DMAEN/BLTEN` | Immediate | Gate blitter bus grants immediately; clearing leaves BBUSY set and preserves the pending blit until re-enabled. |
 | `DMACON.BLTPRI` | Immediate | Bus arbitration observes the priority bit directly. |
@@ -303,6 +321,27 @@ No covered mid-operation write is modelled as ignored; less common writes
 are treated as deferred by draining first. Tests:
 `busy_bltcon0_write_disables_remaining_d_output_without_draining_blit`,
 `busy_bltsize_write_finishes_current_blit_then_starts_replacement`.
+
+### Micro-cycle stall classes
+
+Non-bus blitter cycles come in two hardware classes, mirrored from
+vAmiga's micro-instructions and encoded as `BlitSlotClass`:
+
+- **Bus-free** cycles (vAmiga BUSIDLE: the D pipeline bubble, area
+  fill's extra idle cycle, the BLT_STRT startup cycles, a line blit's
+  internal Bresenham cycles) advance only on colour clocks the blitter
+  could have won: they stall while the Copper or fixed DMA owns the
+  clock, and on the clock a starved CPU is granted (the BLS line blocks
+  `busIsFree`). They never allocate the bus, so the CPU can use the same
+  colour clock on an uncontended access.
+- **Internal** cycles (vAmiga NOTHING: the BLTSIZE register commit, the
+  micro-program begin cycle, the terminal D-hold flush and a D-less
+  BLTDONE) elapse on every colour clock regardless of bus ownership.
+
+Verified cycle-for-cycle against the vAmiga slot traces: a Copper-poked
+blit on a 6-plane display line stalls its BLT_STRT cycles through the
+display fetches and lands its first A fetch on the same colour clock in
+both emulators.
 
 (cpu-contention)=
 ### CPU contention
@@ -331,19 +370,20 @@ Tests: `blithog_clear_busy_blitter_yields_to_cpu_only_after_starvation`,
 Area fill is applied only when BLTCON1.DESC is set (the HRM requires
 descending mode because the fill carry propagates in descending bit order
 across each row); IFE/EFE in ascending mode is treated as ordinary minterm
-output. Fill consumes the C-channel slot even when USEC is clear, but as an
-**idle cycle** (no bus access) -- the "-" in the HRM "A - D" fill cadence.
+output. With USEC clear, fill adds one extra **idle cycle** (no bus
+access) per word, placed AFTER the D slot -- the trailing "-" in vAmiga's
+fill micro-programs for USE masks 1/5/9/D ("A0 -- -- A1 D0 -- A2 D1 --").
 So an A->D area fill costs **3 CCK/word** vs 2 for an A->D copy. The fill
 carry datapath (`apply_fill` in `finish_source_word`) is not what adds the
-cycle -- the C-channel slot in the controller sequence is. Cross-emulator
+cycle -- the FillIdle slot in the controller sequence is. Cross-emulator
 validated: FS-UAE and vAmiga both time the `bltcon0=0x09F0` A->D fill at 3
-CCK/word (timing-test rows 23/24/26). Implemented as `c_phase = use_c ||
-fill` with `current_slot_needs_bus` false for the fill C slot; the idle fill
-phase advances on CPU/Copper/idle arbitration slots but not through fixed
-DMA (bitplane/sprite/disk/audio/refresh) slots. (An earlier
-experiment dropped this to 2 CCK/word to improve one capture, but that made
-the blitter faster than hardware and broke a separate blitter-heavy
-regression.) Test:
+CCK/word (timing-test rows 23/24/26). USEC-carrying fills reuse their real
+C cycle and D-less fills match their copy timing (vAmiga's fill programs
+change only masks 1/5/9/D). The idle fill phase advances on
+CPU/Copper/idle arbitration slots but not through fixed DMA
+(bitplane/sprite/disk/audio/refresh) slots. (An earlier experiment dropped
+the extra cycle to improve one capture, but that made the blitter faster
+than hardware and broke a separate blitter-heavy regression.) Test:
 `descending_area_fill_costs_one_extra_idle_cycle_per_word`.
 
 ### ECS registers
@@ -364,8 +404,10 @@ Cross-emulator timing-test comparisons (corroborated in
 separately:
 
 - **Line blits run slow**: a 64-pixel line measures ~317 beam-CCK in
-  Copperline vs 262 on the FS-UAE reference (and 258 predicted by
-  `line_total_slots`), roughly 21% too slow.
+  Copperline vs 262 on the FS-UAE reference (which now equals the 262
+  slots `line_total_slots` predicts with the startup and terminal
+  cycles), roughly 21% too slow -- the gap is stall behaviour of the
+  internal L1/L3 cycles under display DMA, not the slot count.
 
 The previous row-26 display-DMA contention residual is closed: with fixed DMA
 stalling idle fill phases, Copperline measures ~25074 CCK for the 3-plane

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -85,6 +85,16 @@ fn no_bus_arb() -> bool {
     false
 }
 
+/// Cached COPPERLINE_DIAG_BLT_SLOTS gate (read once). Enables the blitter
+/// slot-trace probe: one stderr line per blitter pipeline cycle with its
+/// beam position, for cross-emulator slot-sequence comparison against the
+/// vAmiga VAMIGA_BLT_PROBE hooks. Logging only; never alters timing.
+pub(crate) fn diag_blt_slots() -> bool {
+    use std::sync::OnceLock;
+    static V: OnceLock<bool> = OnceLock::new();
+    *V.get_or_init(|| crate::envcfg::flag("COPPERLINE_DIAG_BLT_SLOTS"))
+}
+
 /// One-shot latch for the COPPERLINE_DIAG_COPLEN coplist dump (it used to clear its
 /// own env var to log once; with cached env that no longer works).
 static COPLEN_LOGGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
@@ -906,6 +916,12 @@ pub struct Bus {
     #[serde(skip)]
     ui_copper_last_pc: u32,
     blitter_slowdown_cpu_misses: u8,
+    /// Pending INTREQ.BLIT raise, in colour clocks. Real Agnus raises the
+    /// blitter interrupt one clock after the sequencer's BLTDONE cycle
+    /// (vAmiga scheduleIrqRel(BLIT, 1) at the terminal micro-cycle), so a
+    /// scheduled completion arms this one-cck countdown instead of setting
+    /// INTREQ in the final slot itself. Forced drains raise immediately.
+    blit_irq_delay_cck: Option<u32>,
     slice_bus_advanced_cck: u32,
     slice_bus_tick: AgnusTick,
     // Deferred timed-device clock. Ticking CIA/serial/pots/audio/floppy/Akiko
@@ -2048,6 +2064,7 @@ impl Bus {
             ui_mem_watch_addrs: Vec::new(),
             ui_mem_writers: Vec::new(),
             blitter_slowdown_cpu_misses: 0,
+            blit_irq_delay_cck: None,
             slice_bus_advanced_cck: 0,
             slice_bus_tick: AgnusTick::default(),
             pending_device_cck: 0,
@@ -3435,6 +3452,40 @@ impl Bus {
                 ));
             }
         }
+        if diag_blt_slots() {
+            eprintln!(
+                "BLTP {} {} {} END source={source}",
+                self.emulated_frames, self.agnus.vpos, self.agnus.hpos
+            );
+        }
+        if source == "forced" {
+            // Drained synchronously (mid-blit register write): the whole
+            // hardware timeline has already been collapsed, so raise now
+            // and drop any raise already armed by the terminal cycle.
+            self.blit_irq_delay_cck = None;
+            self.raise_blit_irq(source);
+        }
+        // Scheduled completions do not raise here: INTREQ.BLIT is armed
+        // when the sequencer ENTERS its terminal BLTDONE cycle (see
+        // note_blitter_slot_ticked), one colour clock after that cycle's
+        // first attempt -- which real Agnus asserts even while a contended
+        // final D write is still blocked (vAmiga scheduleIrqRel(BLIT, 1)
+        // runs before the bus allocation check).
+    }
+
+    /// Post-tick bookkeeping shared by the blitter's bus-slot and
+    /// idle-cycle tick sites: arm the INTREQ.BLIT raise when the sequencer
+    /// just entered its terminal BLTDONE cycle. Armed with 2 because the
+    /// arming tick's own advance_beam decrements it once in the same
+    /// colour clock; the raise then lands at the end of the terminal
+    /// cycle's first attempt.
+    pub(crate) fn note_blitter_slot_ticked(&mut self) {
+        if self.blitter.take_irq_arm() {
+            self.blit_irq_delay_cck = Some(2);
+        }
+    }
+
+    fn raise_blit_irq(&mut self, source: &'static str) {
         let intreq_before = self.paula.intreq;
         self.paula.intreq |= INT_BLIT;
         self.note_irq_source_asserted();

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -12,9 +12,12 @@ impl Bus {
         match off & 0xFFE {
             0x002 => {
                 // DMACONR. Bit 14 = BBUSY (blitter busy), bit 13 = BZERO
-                // (last blit's D was all zero).
+                // (last blit's D was all zero). BBUSY is the early-dropping
+                // flag: it clears with the sequencer's final body cycle,
+                // before the terminal D flush/BLTDONE cycles finish the blit
+                // (see Blitter::bbusy).
                 let mut r = self.agnus.dmacon & 0x07FF;
-                if self.blitter.busy {
+                if self.blitter.bbusy {
                     r |= 1 << 14;
                 }
                 if self.blitter.bzero {
@@ -622,6 +625,7 @@ impl Bus {
                 // via INTENA rather than relying on INTREQ acks while the blitter
                 // is idle.
                 self.paula.intreq &= !crate::chipset::paula::INT_BLIT;
+                self.blit_irq_delay_cck = None;
                 self.note_irq_latches_changed();
                 // A blit over the exception-vector area is useful crash context:
                 // flag it so the CPU wrapper can dump the instruction history.
@@ -674,6 +678,17 @@ impl Bus {
                     );
                 }
                 self.blitter.start_scheduled(val, &self.mem.chip_ram);
+                if diag_blt_slots() {
+                    eprintln!(
+                        "BLTP {} {} {} START con0={:04x} con1={:04x} size={:04x}",
+                        self.emulated_frames,
+                        self.agnus.vpos,
+                        self.agnus.hpos,
+                        self.blitter.bltcon0,
+                        self.blitter.bltcon1,
+                        val
+                    );
+                }
                 self.record_blit_accounting();
                 self.slice_preempted = true;
                 false
@@ -702,6 +717,7 @@ impl Bus {
                 // Same as BLTSIZE: starting a new blit consumes a stale pending
                 // blitter-done interrupt request.
                 self.paula.intreq &= !crate::chipset::paula::INT_BLIT;
+                self.blit_irq_delay_cck = None;
                 self.note_irq_latches_changed();
                 self.trace_blitter_start_ecs(val, source);
                 self.diag_blit_start(u32::from(self.blitter.bltsizv), (val as u32) & 0x07FF);

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -59,6 +59,16 @@ impl Bus {
             None if eligible => self.free_chip_bus_slot_owner(),
             None => self.scheduled_dma_owner_after_fixed(false, fixed_dma_owner),
         };
+        if diag_blt_slots() && self.blitter.busy {
+            eprintln!(
+                "BLTP {} {} {} OWNER {owner:?} pending={} needs_bus={}",
+                self.emulated_frames,
+                self.agnus.vpos,
+                self.agnus.hpos,
+                self.blitter.current_slot_label(),
+                self.blitter.current_slot_needs_bus()
+            );
+        }
         self.last_chip_bus_owner = owner;
         if self.bus_accounting.enabled {
             self.bus_accounting
@@ -99,21 +109,53 @@ impl Bus {
         if !matches!(owner, ChipBusOwner::Copper) {
             self.process_chip_bus_owner(owner);
         }
-        // A busy blitter's idle pipeline cycles leave the chip bus free, but
-        // they still advance on Agnus slots that are available to the
-        // CPU/blitter/Copper arbitration domain. Fixed DMA slots stall even an
-        // idle blitter phase; otherwise display DMA would not slow area fills.
+        // A busy blitter's non-bus pipeline cycles leave the chip bus free,
+        // but they still elapse in real time, per their arbitration class
+        // (see BlitSlotClass):
+        //
+        // - Internal cycles (register commit, micro-program begin, terminal
+        //   flush/D-less BLTDONE) advance on EVERY colour clock, even under
+        //   fixed DMA (vAmiga NOTHING cycles have no bus check).
+        // - Bus-free micro-cycles (the D pipeline bubble, fill's extra idle
+        //   cycle, the BLT_STRT startup cycles, line Bresenham cycles)
+        //   advance only on colour clocks the blitter could have won: they
+        //   stall while the Copper or fixed DMA owns the clock (this is
+        //   what makes display DMA slow area fills) and on the clock a
+        //   starved CPU is granted (the BLS line blocks busIsFree).
         if !matches!(owner, ChipBusOwner::Blitter)
-            && matches!(
-                owner,
-                ChipBusOwner::Idle | ChipBusOwner::Cpu | ChipBusOwner::Copper
-            )
             && self.blitter.busy
             && self.blitter_dma_enabled()
-            && !self.blitter.current_slot_needs_bus()
-            && self.blitter.tick_scheduled_slot(&mut self.mem.chip_ram)
         {
-            self.latch_blitter_completion("idle_pipeline");
+            let ticks = match self.blitter.current_slot_class() {
+                crate::chipset::blitter::BlitSlotClass::Bus => false,
+                crate::chipset::blitter::BlitSlotClass::Internal => true,
+                crate::chipset::blitter::BlitSlotClass::BusFree => match owner {
+                    ChipBusOwner::Idle => true,
+                    ChipBusOwner::Cpu => {
+                        // A starvation grant is the cck where BLS denies the
+                        // blitter; an ordinary CPU access on a free clock
+                        // does not stall the bus-free cycle.
+                        !(matches!(forced_owner, Some(ChipBusOwner::Cpu))
+                            && self.blitter_yields_to_waiting_cpu())
+                    }
+                    _ => false,
+                },
+            };
+            if ticks {
+                if diag_blt_slots() {
+                    eprintln!(
+                        "BLTP {} {} {} TICK {} bus=0 owner={owner:?}",
+                        self.emulated_frames,
+                        self.agnus.vpos,
+                        self.agnus.hpos,
+                        self.blitter.current_slot_label()
+                    );
+                }
+                if self.blitter.tick_scheduled_slot(&mut self.mem.chip_ram) {
+                    self.latch_blitter_completion("idle_pipeline");
+                }
+                self.note_blitter_slot_ticked();
+            }
         }
         let tick = self.advance_beam(cck);
         self.audio_pending_cck = self.audio_pending_cck.saturating_add(cck);
@@ -195,6 +237,15 @@ impl Bus {
         let old_emulated_cck = self.emulated_cck;
         self.emulated_cck = self.emulated_cck.saturating_add(cck as u64);
         self.coper_cpu_irq_delay_cck = self.coper_cpu_irq_delay_cck.saturating_sub(cck);
+        if let Some(delay) = self.blit_irq_delay_cck {
+            let delay = delay.saturating_sub(cck);
+            if delay == 0 {
+                self.blit_irq_delay_cck = None;
+                self.raise_blit_irq("scheduled");
+            } else {
+                self.blit_irq_delay_cck = Some(delay);
+            }
+        }
         if self.irq_latency_cck != 0 {
             self.irq_latency_cck = self.irq_latency_cck.saturating_sub(cck);
             if self.irq_latency_cck == 0 {
@@ -245,9 +296,19 @@ impl Bus {
             // via step_copper_eligible_slot (its cadence needs per-color-clock
             // gap accounting), so it never reaches here.
             ChipBusOwner::Blitter => {
+                if diag_blt_slots() {
+                    eprintln!(
+                        "BLTP {} {} {} TICK {} bus=1",
+                        self.emulated_frames,
+                        self.agnus.vpos,
+                        self.agnus.hpos,
+                        self.blitter.current_slot_label()
+                    );
+                }
                 if self.blitter.tick_scheduled_slot(&mut self.mem.chip_ram) {
                     self.latch_blitter_completion("bus_slot");
                 }
+                self.note_blitter_slot_ticked();
             }
             ChipBusOwner::Audio => self.step_audio_dma_slot(),
             ChipBusOwner::Copper
@@ -392,11 +453,12 @@ impl Bus {
     }
 
     /// Predict the color clocks until the pending blit completes by walking its
-    /// remaining slot access pattern against the beam. Access slots (mask bit
-    /// set) consume the next color clock the blitter can win (not fixed DMA,
-    /// not Copper); idle pipeline slots consume exactly one color clock
-    /// unconditionally, matching the live arbitration where they never claim
-    /// the bus and can never be stalled.
+    /// remaining slot access pattern against the beam. Eligible-consuming slots
+    /// (mask bit set: bus accesses AND bus-free micro-cycles) consume the next
+    /// color clock the blitter can win (not fixed DMA, not Copper); internal
+    /// cycles (mask bit clear) consume exactly one color clock unconditionally,
+    /// matching the live arbitration where they elapse regardless of bus
+    /// ownership.
     pub(super) fn cck_until_blitter_completes(
         &self,
         access_mask: u64,
@@ -479,11 +541,12 @@ impl Bus {
 
             let slot_needs_bus = access_mask & (1u64 << slot_idx) != 0;
             let slot_consumed = if slot_needs_bus {
+                // Bus accesses and bus-free micro-cycles both need a colour
+                // clock the blitter could have won.
                 slot_grantable && !copper_blocks
             } else {
-                // Idle pipeline cycle: bus-free, but still stalled by fixed DMA
-                // slots just like the live path.
-                slot_grantable
+                // Internal cycle: elapses unconditionally.
+                true
             };
             if slot_consumed {
                 slot_idx += 1;

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -373,7 +373,7 @@ fn bus_with_pending_two_word_a_to_d_blit() -> Bus {
 
     assert!(!bus.custom_write(0x058, 2, ((1 << 6) | 2) as u64));
     assert!(bus.blitter.busy);
-    assert_eq!(bus.next_blitter_completion_cck(), Some(11));
+    assert_eq!(bus.next_blitter_completion_cck(), Some(10));
     bus
 }
 
@@ -847,6 +847,7 @@ fn dmacon_masks_stored_bits_and_dmaconr_derives_status() {
 
     assert_eq!(bus.agnus.dmacon, 0x07FF);
     bus.blitter.busy = true;
+    bus.blitter.bbusy = true;
     bus.blitter.bzero = true;
     assert_eq!(bus.custom_read(0x002, 2), 0x67FF);
 }
@@ -1617,8 +1618,8 @@ fn copper_wait_with_bfd_caps_to_blitter_completion_after_position_match() {
     bus.blitter.bltcon0 = 0x0100;
     bus.blitter.start_scheduled((1 << 6) | 1, &bus.mem.chip_ram);
 
-    assert_eq!(bus.next_blitter_completion_cck(), Some(9));
-    assert_eq!(bus.next_copper_wakeup_cck(), Some(9));
+    assert_eq!(bus.next_blitter_completion_cck(), Some(8));
+    assert_eq!(bus.next_copper_wakeup_cck(), Some(8));
 }
 
 #[test]
@@ -1637,9 +1638,9 @@ fn copper_wait_with_bfd_clear_resumes_after_busy_blitter_finishes() {
 
     bus.blitter.bltcon0 = 0x0100;
     bus.blitter.start_scheduled((1 << 6) | 1, &bus.mem.chip_ram);
-    assert_eq!(bus.next_copper_wakeup_cck(), Some(9));
+    assert_eq!(bus.next_copper_wakeup_cck(), Some(8));
 
-    bus.advance_chipset(8);
+    bus.advance_chipset(7);
     assert!(bus.copper.waiting().is_some());
     assert_eq!(bus.denise.palette[0], 0);
 
@@ -1652,10 +1653,12 @@ fn copper_wait_with_bfd_clear_resumes_after_busy_blitter_finishes() {
 
     // Once the blitter frees the bus, the Copper spends a dummy wake-up
     // cycle, then its MOVE fetches land on the even copper slots and the
-    // write appears at hpos 0x30.
+    // write appears at hpos 0x2E (the engine finishes one colour clock
+    // earlier now that the startup models the hardware's poke+4 first
+    // body cycle).
     bus.advance_chipset(8);
     assert_eq!(bus.denise.palette[0], 0x0555);
-    assert_eq!(bus.current_render_events()[0].hpos, 0x30);
+    assert_eq!(bus.current_render_events()[0].hpos, 0x2E);
 }
 
 #[test]
@@ -1935,26 +1938,29 @@ fn blitter_completion_deadline_skips_fixed_dma_slots() {
     write_chip_word(&mut bus, 0x10, 0x1234);
     bus.blitter.start_scheduled((1 << 6) | 1, &bus.mem.chip_ram);
 
-    assert_eq!(bus.blitter.scheduled_slots_remaining(), Some(9));
-    // Five internal lead-in cycles elapse at 0x3A-0x3E regardless of DMA
-    // (the BLTSIZE commit + startup extras plus StartDelay/Init), then the
-    // A fetch must skip the plane-1 bitplane fetch slot at 0x3F (granted at
-    // 0x40), D writes at 0x41, the internal E cycle passes at 0x42, and the
-    // final F write lands at 0x43: 10 color clocks in all.
-    assert_eq!(bus.next_blitter_completion_cck(), Some(10));
+    assert_eq!(bus.blitter.scheduled_slots_remaining(), Some(8));
+    // Four internal lead-in cycles elapse at 0x3A-0x3D regardless of DMA
+    // (the BLTSIZE commit + startup extras plus StartDelay/Init), the A
+    // fetch lands at 0x3E, then the idle D pipeline bubble must skip the
+    // plane-1 bitplane fetch slot at 0x3F (idle phases stall through fixed
+    // DMA), passing at 0x40; the internal E cycle runs at 0x41 and the
+    // final F write lands at 0x42: 9 color clocks in all.
+    assert_eq!(bus.next_blitter_completion_cck(), Some(9));
 
-    // After the internal lead-in the blit's A access is pending and the
-    // bitplane fetch owns its fixed slot.
+    // After the lead-in and the A fetch the idle D bubble is pending and
+    // the bitplane fetch owns its fixed slot.
     bus.advance_chipset(5);
     assert!(bus.blitter.busy);
     assert_eq!(bus.scheduled_dma_owner(false), ChipBusOwner::Bitplane);
 
-    bus.advance_chipset(4);
+    bus.advance_chipset(3);
     assert!(bus.blitter.busy);
     bus.advance_chipset(1);
     assert!(!bus.blitter.busy);
-    assert_ne!(bus.paula.intreq & INT_BLIT, 0);
     assert_eq!(&bus.mem.chip_ram[0x20..0x22], &[0x12, 0x34]);
+    // INTREQ.BLIT is armed off the terminal BLTDONE cycle's first attempt
+    // and is visible from the following colour clock on.
+    assert_ne!(bus.paula.intreq & INT_BLIT, 0);
 }
 
 #[test]
@@ -1979,19 +1985,25 @@ fn blitter_completion_deadline_accounts_for_copper_dma_slots() {
     write_chip_word(&mut bus, 0x10, 0x1234);
     bus.blitter.start_scheduled((1 << 6) | 1, &bus.mem.chip_ram);
 
-    assert_eq!(bus.blitter.scheduled_slots_remaining(), Some(9));
+    assert_eq!(bus.blitter.scheduled_slots_remaining(), Some(8));
     assert_eq!(bus.scheduled_dma_owner(false), ChipBusOwner::Copper);
-    // Five internal lead-in cycles pass under the Copper's fetches at
-    // 0x20-0x24, then the A and D accesses take the Copper's idle halves
-    // (0x25, 0x27), the internal E cycle passes at 0x28, and the final F
-    // write lands at 0x29: 10 color clocks in all.
+    // Four internal lead-in cycles pass under the Copper's fetches at
+    // 0x20-0x23, the A access takes the Copper's idle half at 0x25, the
+    // idle D bubble passes under the fetch at 0x26 and the internal E
+    // cycle at 0x27, and the final F write is blocked by the Copper's
+    // fetch at 0x28, landing at 0x29: 10 color clocks in all.
     assert_eq!(bus.next_blitter_completion_cck(), Some(10));
 
     bus.advance_chipset(6);
     assert!(bus.blitter.busy);
     assert_eq!(bus.next_blitter_completion_cck(), Some(4));
 
-    bus.advance_chipset(4);
+    bus.advance_chipset(3);
+    // The internal E cycle elapsed under the Copper's 0x28 fetch; the
+    // terminal F write is pending for the Copper's idle half at 0x29.
+    assert!(bus.blitter.busy);
+    assert_eq!(bus.paula.intreq & INT_BLIT, 0);
+    bus.advance_chipset(1);
     assert!(!bus.blitter.busy);
     assert_ne!(bus.paula.intreq & INT_BLIT, 0);
 }
@@ -7824,11 +7836,11 @@ fn bltsize_starts_dma_and_preempts_cpu_slice_without_irq_preempt() {
     assert!(bus.slice_preempted);
     assert_eq!(bus.paula.intreq & INT_BLIT, 0);
     assert!(bus.blitter.busy);
-    assert_eq!(bus.next_blitter_completion_cck(), Some(9));
+    assert_eq!(bus.next_blitter_completion_cck(), Some(8));
     bus.advance_chipset(1);
     assert_eq!(bus.paula.intreq & INT_BLIT, 0);
     assert!(bus.blitter.busy);
-    assert_eq!(bus.next_blitter_completion_cck(), Some(8));
+    assert_eq!(bus.next_blitter_completion_cck(), Some(7));
     bus.advance_chipset(8);
     assert_ne!(bus.paula.intreq & INT_BLIT, 0);
     assert!(!bus.blitter.busy);
@@ -7960,9 +7972,9 @@ fn busy_bltsize_write_finishes_current_blit_then_starts_replacement() {
     // interrupt request: INTREQ.BLIT means "the last started blit has
     // finished", and the replacement has not finished yet.
     assert_eq!(bus.paula.intreq & INT_BLIT, 0);
-    assert_eq!(bus.next_blitter_completion_cck(), Some(9));
+    assert_eq!(bus.next_blitter_completion_cck(), Some(8));
 
-    bus.advance_chipset(9);
+    bus.advance_chipset(8);
     assert!(!bus.blitter.busy);
     assert_eq!(&bus.mem.chip_ram[0x24..0x26], &[0x33, 0x33]);
     // The replacement blit's completion raises the request.
@@ -7986,7 +7998,7 @@ fn busy_blitter_dmacon_clear_gates_dma_without_finishing_pending_blit() {
     assert_eq!(&bus.mem.chip_ram[0x20..0x24], &[0, 0, 0, 0]);
 
     assert!(!bus.custom_write(0x096, 2, (0x8000 | DMACON_BLTEN) as u64));
-    assert_eq!(bus.next_blitter_completion_cck(), Some(11));
+    assert_eq!(bus.next_blitter_completion_cck(), Some(10));
     bus.advance_chipset(11);
 
     assert!(!bus.blitter.busy);
@@ -8028,9 +8040,9 @@ fn blithog_clear_busy_blitter_yields_to_cpu_only_after_starvation() {
     write_chip_word(&mut bus, 0x34, 0x7777);
     write_chip_word(&mut bus, 0x36, 0x8888);
     bus.blitter.start_scheduled((1 << 6) | 4, &bus.mem.chip_ram);
-    // Walk the blit past its five internal lead-in cycles (those are
+    // Walk the blit past its four internal lead-in cycles (those are
     // CPU-available) so its pending slot is an A-channel bus access.
-    bus.advance_chipset(5);
+    bus.advance_chipset(4);
     let initial_slots = bus.blitter.scheduled_slots_remaining();
     bus.set_cpu_bus_arbitration_enabled(true);
     bus.begin_cpu_slice();
@@ -8049,7 +8061,7 @@ fn blithog_clear_busy_blitter_yields_to_cpu_only_after_starvation() {
     assert_eq!(bus.paula.intreq & INT_BLIT, 0);
     assert_eq!(
         bus.agnus.hpos,
-        0x25 + u32::from(BLITTER_SLOWDOWN_CPU_MISS_LIMIT) + 2
+        0x24 + u32::from(BLITTER_SLOWDOWN_CPU_MISS_LIMIT) + 2
     );
     // The granted slot was the CPU's; the trailing bus-free tail cck is
     // reclaimed by the still-busy blitter, so it is the last chip-bus owner.
@@ -8063,9 +8075,9 @@ fn blithog_clear_bls_count_yields_blitter_priority_slot_to_cpu() {
     bus.agnus.hpos = 0x22;
     bus.blitter.bltcon0 = 0x09F0;
     bus.blitter.start_scheduled((1 << 6) | 1, &bus.mem.chip_ram);
-    // Walk the blit past its five internal lead-in cycles (those are
+    // Walk the blit past its four internal lead-in cycles (those are
     // CPU-available) so its pending slot is an A-channel bus access.
-    bus.advance_chipset(5);
+    bus.advance_chipset(4);
 
     assert_eq!(bus.scheduled_dma_owner(true), ChipBusOwner::Blitter);
 
@@ -8603,9 +8615,9 @@ fn bltpri_stalls_cpu_chip_access_through_blitter_access_cycles() {
     bus.mem.chip_ram[0x10] = 0x12;
     bus.mem.chip_ram[0x11] = 0x34;
     bus.blitter.start_scheduled((1 << 6) | 1, &bus.mem.chip_ram);
-    // Walk the blit past its five internal lead-in cycles so its pending
+    // Walk the blit past its four internal lead-in cycles so its pending
     // slot is the A-channel access.
-    bus.advance_chipset(5);
+    bus.advance_chipset(4);
     bus.set_cpu_bus_arbitration_enabled(true);
 
     bus.grant_cpu_bus_access(2, CpuBusAccessKind::Read);
@@ -8621,11 +8633,12 @@ fn bltpri_stalls_cpu_chip_access_through_blitter_access_cycles() {
     assert_eq!(&bus.mem.chip_ram[0x20..0x22], &[0x00, 0x00]);
 
     // The final F slot is still owned by the blitter and writes the queued
-    // word once the CPU's bus cycle is over.
+    // word once the CPU's bus cycle is over; the interrupt is asserted off
+    // that terminal cycle's first attempt.
     bus.advance_chipset(1);
     assert!(!bus.blitter.busy);
-    assert_ne!(bus.paula.intreq & INT_BLIT, 0);
     assert_eq!(&bus.mem.chip_ram[0x20..0x22], &[0x12, 0x34]);
+    assert_ne!(bus.paula.intreq & INT_BLIT, 0);
 }
 
 #[test]
@@ -8655,16 +8668,19 @@ fn blithog_set_blocks_cpu_slowdown_back_pressure_until_blitter_finishes() {
     write_chip_word(&mut bus, 0x34, 0x7777);
     write_chip_word(&mut bus, 0x36, 0x8888);
     bus.blitter.start_scheduled((1 << 6) | 4, &bus.mem.chip_ram);
-    // Walk the blit past its five internal lead-in cycles so its pending
+    // Walk the blit past its four internal lead-in cycles so its pending
     // slot is the first A-channel access.
-    bus.advance_chipset(5);
+    bus.advance_chipset(4);
     bus.set_cpu_bus_arbitration_enabled(true);
 
     bus.grant_cpu_bus_access(2, CpuBusAccessKind::Read);
 
     // With BLTPRI set the CPU gets no starvation yield: it waits through
     // all twelve A/B/C accesses of the four words, then spends its granted
-    // slot plus the bus-free tail cck, costing 14 color clocks.
+    // slot plus the bus-free tail cck, costing 14 color clocks. The
+    // terminal (internal) E/F cycles ride the CPU's granted/tail clocks,
+    // so the engine finishes within the same span and the interrupt is
+    // asserted off the terminal cycle.
     let (cck, _) = bus.take_slice_bus_advance();
     assert_eq!(cck, 14);
     assert!(!bus.blitter.busy);

--- a/src/chipset/blitter.rs
+++ b/src/chipset/blitter.rs
@@ -43,6 +43,28 @@ const BLTCON1_AUL: u16 = BLTCON1_FCI;
 const CHIP_DMA_ADDR_MASK: u32 = 0x001F_FFFF;
 const CHIP_DMA_HIGH_MASK: u32 = 0x001F_0000;
 
+/// Arbitration class of a blitter pipeline cycle, mirroring the three ways
+/// vAmiga's micro-instructions interact with the bus:
+///
+/// - `Bus`: a channel fetch or destination write; runs only in a granted
+///   chip-bus slot.
+/// - `BusFree`: an idle micro-cycle (vAmiga BUSIDLE: the D pipeline
+///   bubble, fill's extra idle cycle, the BLT_STRT startup cycles, a line
+///   blit's internal Bresenham cycles). It does not allocate the bus but
+///   only advances when the blitter could have had the cycle: it stalls
+///   while the Copper or fixed DMA owns the colour clock and on the
+///   colour clock a starved CPU is granted (the BLS line).
+/// - `Internal`: pure sequencer latency (vAmiga NOTHING cycles: the
+///   BLTSIZE register commit, the micro-program begin cycle, the terminal
+///   D-hold flush and a D-less BLTDONE). Advances every colour clock
+///   regardless of bus ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlitSlotClass {
+    Bus,
+    BusFree,
+    Internal,
+}
+
 /// The blitter can only DMA from populated chip RAM. Addresses outside
 /// the configured chip range do not mirror into low RAM; they hit
 /// unpopulated space.
@@ -167,6 +189,14 @@ pub struct Blitter {
     pub bltsizv: u16,
     bltbold: u16,
     bltbold_init: bool,
+    /// The B hold register as latched by the last BLTBDAT write. Unlike
+    /// BLTADAT/BLTCDAT, writing BLTBDAT runs the B barrel shifter with the
+    /// BSH and DESC values current AT WRITE TIME (vAmiga pokeBLTBDAT), and
+    /// a blit with USEB clear consumes this latched hold word for every
+    /// word -- the shifter is not re-run with the blit-time BSH
+    /// (vAmigaTS Agnus/Blitter/undocumented1: BLTBDAT written under
+    /// BSH=4, then blitted after resetting BLTCON1 to 0).
+    b_hold_latch: u16,
     line_bdat: u16,
     line_bdat_valid: bool,
 
@@ -174,12 +204,28 @@ pub struct Blitter {
     /// for DMACONR even though normally the CPU only observes the
     /// cleared state.
     pub busy: bool,
+    /// DMACONR bit 14 (BBUSY). Real Agnus clears the busy flag with the
+    /// sequencer's final REPEAT decision -- the last body cycle of the
+    /// last word -- while the terminal micro-cycles (the D-flush and the
+    /// BLTDONE cycle that raises the interrupt) still run afterwards. So
+    /// BBUSY reads 0 two cycles before the final D write lands and before
+    /// INTREQ.BLIT rises (vAmiga clearBusyFlag at REPEAT vs endBlit;
+    /// cross-checked with the slot-trace probe). `busy` above stays the
+    /// engine-running flag (bus grants, Copper BFD wait, drain logic).
+    pub bbusy: bool,
     /// Set to true at the start of `execute()` and cleared on the first
     /// non-zero D word. Surfaces as DMACONR bit 13.
     pub bzero: bool,
 
     pending: Option<PendingBlit>,
     dma_addr_mask: u32,
+    /// One-shot signal to the bus: the sequencer just entered its terminal
+    /// BLTDONE micro-cycle. Real Agnus asserts the blitter interrupt off
+    /// the BLTDONE cycle's FIRST bus attempt (vAmiga schedules the IRQ
+    /// even when the final D write is still blocked), so INTREQ.BLIT can
+    /// rise before a contended final write lands. Consumed by
+    /// `take_irq_arm`.
+    irq_arm_pending: bool,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -197,6 +243,10 @@ struct LineBlitState {
     #[serde(skip)]
     debug_watched_write: Option<(u32, u16)>,
     phase: LineBlitPhase,
+    /// Extra internal start slots before Init; see NORMAL_START_EXTRA_SLOTS
+    /// (the BLT_STRT1/2 startup applies to line blits identically: the
+    /// first body cycle runs at poke+4).
+    start_extra: u32,
     slots_remaining: u32,
     npixels_remaining: u32,
     con0: u16,
@@ -229,15 +279,9 @@ struct NormalBlitState {
     #[serde(skip)]
     debug_watched_write: Option<(u32, u16)>,
     phase: NormalBlitPhase,
-    /// Extra internal start slots before Init. Real Agnus takes the BLTSIZE
-    /// write through a one-cycle register commit and then two bus-arbitration
-    /// startup cycles (vAmiga BLT_STRT1/BLT_STRT2) plus a cycle to begin the
-    /// micro-program, so the first channel slot runs ~4 cck after the poke;
-    /// StartDelay alone modelled only one. Verified against a
-    /// BLTSIZE-to-blitter-IRQ beam probe cross-checked with vAmiga.
-    /// TODO: STRT1/STRT2 on real hardware need free odd bus slots, so heavy
-    /// contention stretches the startup; these extras are plain internal
-    /// cycles.
+    /// Extra internal start slots before Init; see NORMAL_START_EXTRA_SLOTS
+    /// for the hardware derivation (register commit + BLT_STRT1/2, first
+    /// body cycle at poke+4).
     start_extra: u32,
     slots_remaining: u32,
     h_remaining: u32,
@@ -266,7 +310,9 @@ struct NormalBlitState {
     bltafwm: u16,
     bltalwm: u16,
     bltadat: u16,
-    bltbdat: u16,
+    /// BLTBDAT's write-time-shifted hold word (see Blitter::b_hold_latch):
+    /// the constant B input for every word of a USEB-off blit.
+    b_hold_latch: u16,
     bltcdat: u16,
 
     apt: u32,
@@ -280,6 +326,9 @@ struct NormalBlitState {
     cur_b: u16,
     cur_c: u16,
     fill_state: u16,
+    /// Whether the in-flight FillIdle slot is the last body cycle (the D
+    /// slot that entered it consumed the final word).
+    fill_idle_done: bool,
     pipeline_full: bool,
     d_hold: u16,
     d_hold_pt: u32,
@@ -319,6 +368,11 @@ enum NormalBlitPhase {
     B,
     C,
     D,
+    /// Area fill's extra idle cycle. With USEC clear, fill mode appends an
+    /// idle cycle AFTER the D slot of each word (vAmiga fill programs for
+    /// USE masks 1/5/9/D: "A0 -- -- A1 D0 -- A2 D1 -- | -- D2"); with USEC
+    /// set the fill has no timing effect.
+    FillIdle,
     E,
     F,
     Done,
@@ -332,6 +386,12 @@ enum LineBlitPhase {
     L2,
     L3,
     L4,
+    /// First terminal micro-cycle after the last pixel (vAmiga's NOTHING
+    /// instruction): internal, BBUSY already clear.
+    Tail,
+    /// BLTDONE micro-cycle: internal; INTREQ.BLIT rises one colour clock
+    /// after it (handled by the bus-side raise delay).
+    TailDone,
     Done,
 }
 
@@ -364,13 +424,22 @@ impl Blitter {
             bltsizv: 0,
             bltbold: 0,
             bltbold_init: true,
+            b_hold_latch: 0,
             line_bdat: 0,
             line_bdat_valid: false,
             busy: false,
+            bbusy: false,
             bzero: true,
             pending: None,
             dma_addr_mask: CHIP_DMA_ADDR_MASK,
+            irq_arm_pending: false,
         }
+    }
+
+    /// Take the one-shot "terminal cycle entered" signal (see
+    /// `irq_arm_pending`).
+    pub fn take_irq_arm(&mut self) -> bool {
+        std::mem::take(&mut self.irq_arm_pending)
     }
 
     pub fn set_dma_addr_mask(&mut self, mask: u32) {
@@ -441,8 +510,16 @@ impl Blitter {
         self.bltbold = if self.bltbold_init { 0 } else { self.bltbdat };
         self.bltbold_init = false;
         self.bltbdat = val;
+        // Writing BLTBDAT triggers the B barrel shifter with the CURRENT
+        // BSH/DESC (unlike BLTADAT); the latched hold word feeds USEB-off
+        // blits regardless of the BSH in effect when BLTSIZE strobes.
+        let bsh = ((self.bltcon1 >> 12) & 0x0F) as u32;
+        // BLTCON1 bit 1 feeds the shifter direction even in line mode
+        // (where it doubles as SING) -- the poke path mirrors the
+        // hardware datapath, not the mode decode.
+        let desc = self.bltcon1 & BLTCON1_DESC != 0;
+        self.b_hold_latch = shift_combine(self.bltbold, val, bsh, desc);
         if self.bltcon1 & BLTCON1_LINE != 0 {
-            let bsh = ((self.bltcon1 >> 12) & 0x0F) as u32;
             self.line_bdat = self.bltbdat.rotate_right(bsh);
             self.line_bdat_valid = true;
         }
@@ -460,7 +537,12 @@ impl Blitter {
 
     fn finish_blit(&mut self) {
         self.busy = false;
+        self.bbusy = false;
         self.bltbold_init = true;
+    }
+
+    fn clear_irq_arm(&mut self) {
+        self.irq_arm_pending = false;
     }
 
     /// Triggered by a BLTSIZE write. Runs the entire blit synchronously
@@ -481,9 +563,11 @@ impl Blitter {
         self.pending = None;
         if ram.is_empty() {
             self.busy = false;
+            self.bbusy = false;
             return;
         }
         self.busy = true;
+        self.bbusy = true;
         self.bzero = true;
         if self.bltcon1 & BLTCON1_LINE != 0 {
             self.execute_line(h, ram);
@@ -505,7 +589,9 @@ impl Blitter {
 
     fn start_scheduled_dims(&mut self, h: u32, w: u32, ram: &[u8]) {
         self.busy = true;
+        self.bbusy = true;
         self.bzero = true;
+        self.clear_irq_arm();
         if self.bltcon1 & BLTCON1_LINE != 0 {
             self.pending = Some(PendingBlit::Line(LineBlitState::new(self, h)));
         } else {
@@ -549,7 +635,24 @@ impl Blitter {
         let mut pending = self.pending.take().unwrap();
         match &mut pending {
             PendingBlit::Normal(state) => {
+                let phase_before = state.phase;
                 let done = state.tick_slot(ram, &mut self.bzero);
+                // BBUSY drops with the sequencer's final REPEAT (the last
+                // body cycle); the terminal D-flush/BLTDONE cycles (E/F)
+                // still run with the flag already clear.
+                if matches!(
+                    state.phase,
+                    NormalBlitPhase::E | NormalBlitPhase::F | NormalBlitPhase::Done
+                ) {
+                    self.bbusy = false;
+                }
+                // Entering the terminal BLTDONE cycle (the E tick makes F
+                // pending) asserts the interrupt off its first attempt.
+                if matches!(phase_before, NormalBlitPhase::E)
+                    && matches!(state.phase, NormalBlitPhase::F)
+                {
+                    self.irq_arm_pending = true;
+                }
                 if let Some(write) = state.debug_watched_write.take() {
                     self.debug_watched_write = Some(write);
                 }
@@ -563,7 +666,23 @@ impl Blitter {
                 }
             }
             PendingBlit::Line(state) => {
+                let phase_before = state.phase;
                 let done = state.tick_slot(ram, &mut self.bzero);
+                // BBUSY drops with the final pixel's D cycle; the two
+                // terminal micro-cycles run with the flag already clear.
+                if matches!(
+                    state.phase,
+                    LineBlitPhase::Tail | LineBlitPhase::TailDone | LineBlitPhase::Done
+                ) {
+                    self.bbusy = false;
+                }
+                // Entering the terminal BLTDONE cycle asserts the interrupt
+                // off its first attempt.
+                if matches!(phase_before, LineBlitPhase::Tail)
+                    && matches!(state.phase, LineBlitPhase::TailDone)
+                {
+                    self.irq_arm_pending = true;
+                }
                 if let Some(write) = state.debug_watched_write.take() {
                     self.debug_watched_write = Some(write);
                 }
@@ -608,12 +727,28 @@ impl Blitter {
         }
     }
 
+    /// Arbitration class of the pipeline cycle the next `tick_scheduled_slot`
+    /// will process (see BlitSlotClass). `Internal` when no blit is pending
+    /// so callers need no extra guard.
+    pub fn current_slot_class(&self) -> BlitSlotClass {
+        if !self.busy {
+            return BlitSlotClass::Internal;
+        }
+        match self.pending.as_ref() {
+            Some(PendingBlit::Normal(state)) => state.current_slot_class(),
+            Some(PendingBlit::Line(state)) => state.current_slot_class(),
+            None => BlitSlotClass::Internal,
+        }
+    }
+
     /// Access pattern of the next scheduled pipeline slots, as a bitmask: bit k
-    /// set means slot k (k=0 is the slot the next tick processes) performs a
-    /// chip-bus access; clear means it is an internal cycle that leaves the bus
-    /// free. Returns (mask, count) with count = min(slots remaining, limit, 64).
+    /// set means slot k (k=0 is the slot the next tick processes) consumes a
+    /// blitter-eligible colour clock (a bus access or a bus-free micro-cycle,
+    /// both of which stall through Copper/fixed-DMA-owned clocks); clear means
+    /// it is an internal cycle that elapses unconditionally. Returns
+    /// (mask, count) with count = min(slots remaining, limit, 64).
     /// Used by the completion-deadline prediction so it walks the same
-    /// access/idle sequence the live bus arbitration sees.
+    /// stall/advance sequence the live bus arbitration sees.
     pub fn scheduled_slot_access_pattern(&self, limit: u32) -> Option<(u64, u32)> {
         if !self.busy {
             return None;
@@ -622,6 +757,50 @@ impl Blitter {
         match self.pending.as_ref()? {
             PendingBlit::Normal(state) => Some(state.slot_access_pattern(limit)),
             PendingBlit::Line(state) => Some(state.slot_access_pattern(limit)),
+        }
+    }
+
+    /// Diagnostic label of the pipeline cycle the next `tick_scheduled_slot`
+    /// will process (the COPPERLINE_DIAG_BLT_SLOTS slot-trace probe). "-"
+    /// when no blit is pending.
+    pub fn current_slot_label(&self) -> &'static str {
+        match self.pending.as_ref() {
+            Some(PendingBlit::Normal(state)) => match state.phase {
+                NormalBlitPhase::StartDelay => {
+                    if state.start_extra > 0 {
+                        "STRT"
+                    } else {
+                        "DLY"
+                    }
+                }
+                NormalBlitPhase::Init => "INIT",
+                NormalBlitPhase::A => "A",
+                NormalBlitPhase::B => "B",
+                NormalBlitPhase::C => "C",
+                NormalBlitPhase::D => "D",
+                NormalBlitPhase::FillIdle => "FI",
+                NormalBlitPhase::E => "E",
+                NormalBlitPhase::F => "F",
+                NormalBlitPhase::Done => "DONE",
+            },
+            Some(PendingBlit::Line(state)) => match state.phase {
+                LineBlitPhase::StartDelay => {
+                    if state.start_extra > 0 {
+                        "LSTRT"
+                    } else {
+                        "LDLY"
+                    }
+                }
+                LineBlitPhase::Init => "LINIT",
+                LineBlitPhase::L1 => "L1",
+                LineBlitPhase::L2 => "L2",
+                LineBlitPhase::L3 => "L3",
+                LineBlitPhase::L4 => "L4",
+                LineBlitPhase::Tail => "LTAIL",
+                LineBlitPhase::TailDone => "LEND",
+                LineBlitPhase::Done => "LDONE",
+            },
+            None => "-",
         }
     }
 
@@ -702,11 +881,7 @@ impl Blitter {
         let mut dpt = self.bltdpt;
 
         let mut a_prev: u16 = 0;
-        let mut b_prev: u16 = if use_b || self.bltbold_init {
-            0
-        } else {
-            self.bltbold
-        };
+        let mut b_prev: u16 = 0;
         for _row in 0..h {
             let mut fill_state: u16 = fci;
             // Buffer this row's D words so fill mode can process them
@@ -735,15 +910,17 @@ impl Blitter {
                 let a = shift_combine(a_prev, a_masked, ash, desc);
                 a_prev = a_masked;
 
-                let b_raw = if use_b {
+                let b = if use_b {
                     let v = read_word(ram, bpt);
                     bpt = bpt.wrapping_add(step as u32);
-                    v
+                    let shifted = shift_combine(b_prev, v, bsh, desc);
+                    b_prev = v;
+                    shifted
                 } else {
-                    self.bltbdat
+                    // USEB off: the write-time-shifted hold word, constant
+                    // for the whole blit (see Blitter::b_hold_latch).
+                    self.b_hold_latch
                 };
-                let b = shift_combine(b_prev, b_raw, bsh, desc);
-                b_prev = b_raw;
 
                 let c = if use_c {
                     let v = read_word(ram, cpt);
@@ -945,6 +1122,7 @@ impl LineBlitState {
             debug_watch_addrs: blitter.debug_watch_addrs.clone(),
             debug_watched_write: None,
             phase: LineBlitPhase::StartDelay,
+            start_extra: NORMAL_START_EXTRA_SLOTS,
             slots_remaining: line_total_slots(npixels),
             npixels_remaining: npixels,
             con0,
@@ -980,38 +1158,93 @@ impl LineBlitState {
 
     /// Whether the phase the next tick_slot will process is a chip-bus access.
     /// Per pixel the line engine reads C (L2) and writes D (L4); L1/L3 are
-    /// internal Bresenham cycles that leave the bus free.
+    /// internal Bresenham cycles that leave the bus free. A suppressed D
+    /// write (USEC clear, or SING past the row's first dot) leaves its slot
+    /// idle too: the hardware D cycle only runs when the pixel is stored
+    /// (vAmiga lockD turns WRITE_D into a bus-idle cycle).
     fn current_slot_needs_bus(&self) -> bool {
         match self.phase {
             LineBlitPhase::L2 => self.use_c,
-            LineBlitPhase::L4 => true,
+            LineBlitPhase::L4 => self.use_c && (!self.sing || !self.one_dot),
             LineBlitPhase::StartDelay
             | LineBlitPhase::Init
             | LineBlitPhase::L1
             | LineBlitPhase::L3
+            | LineBlitPhase::Tail
+            | LineBlitPhase::TailDone
             | LineBlitPhase::Done => false,
         }
     }
 
-    /// Access pattern of the next `limit` scheduled slots (bit k = slot k needs
-    /// the bus): 2 lead-in slots then the [L1, L2, L3, L4] cadence per pixel.
+    /// Arbitration class of the pending pipeline cycle (see BlitSlotClass
+    /// and NormalBlitState::current_slot_class for the startup ladder).
+    /// The internal Bresenham cycles L1/L3 and a suppressed store are
+    /// bus-free micro-cycles (vAmiga BUSIDLE); the two terminal cycles are
+    /// internal (NOTHING + BLTDONE).
+    fn current_slot_class(&self) -> BlitSlotClass {
+        match self.phase {
+            LineBlitPhase::StartDelay => {
+                if self.start_extra >= NORMAL_START_EXTRA_SLOTS {
+                    BlitSlotClass::Internal
+                } else {
+                    BlitSlotClass::BusFree
+                }
+            }
+            LineBlitPhase::Init | LineBlitPhase::Tail | LineBlitPhase::TailDone => {
+                BlitSlotClass::Internal
+            }
+            LineBlitPhase::L1 | LineBlitPhase::L3 => BlitSlotClass::BusFree,
+            LineBlitPhase::L2 | LineBlitPhase::L4 => {
+                if self.current_slot_needs_bus() {
+                    BlitSlotClass::Bus
+                } else {
+                    BlitSlotClass::BusFree
+                }
+            }
+            LineBlitPhase::Done => BlitSlotClass::Internal,
+        }
+    }
+
+    /// Access pattern of the next `limit` scheduled slots (bit k = slot k
+    /// consumes a blitter-eligible colour clock: a bus access or a bus-free
+    /// micro-cycle; clear = internal): the startup ladder (register commit
+    /// internal, BLT_STRT cycles bus-free, Init internal), the [L1, L2, L3,
+    /// L4] cadence per pixel (all eligible-consuming), then the two internal
+    /// terminal cycles.
     fn slot_access_pattern(&self, limit: u32) -> (u64, u32) {
         let count = self.slots_remaining.min(limit).min(64);
-        let cadence = [false, self.use_c, false, true];
-        let (lead_in, cadence_idx) = match self.phase {
-            LineBlitPhase::StartDelay => (2u32, 0usize),
-            LineBlitPhase::Init => (1, 0),
-            LineBlitPhase::L1 => (0, 0),
-            LineBlitPhase::L2 => (0, 1),
-            LineBlitPhase::L3 => (0, 2),
-            LineBlitPhase::L4 | LineBlitPhase::Done => (0, 3),
+        // Eligibility of the lead-in cycles still pending, oldest first:
+        // pending extras beyond the first are BLT_STRT cycles (eligible);
+        // the very first extra is the internal register commit; the
+        // StartDelay->Init transition cycle is the second BLT_STRT; Init is
+        // internal.
+        let lead: &[bool] = match self.phase {
+            LineBlitPhase::StartDelay => {
+                if self.start_extra >= NORMAL_START_EXTRA_SLOTS {
+                    &[false, true, true, false]
+                } else if self.start_extra == 1 {
+                    &[true, true, false]
+                } else {
+                    &[true, false]
+                }
+            }
+            LineBlitPhase::Init => &[false],
+            _ => &[],
         };
+        let tail_free = matches!(
+            self.phase,
+            LineBlitPhase::Tail | LineBlitPhase::TailDone | LineBlitPhase::Done
+        );
+        let tail_start = self.slots_remaining.saturating_sub(2);
         let mut mask = 0u64;
         for k in 0..count {
-            let needs = if k < lead_in {
+            let needs = if tail_free || k >= tail_start {
                 false
+            } else if (k as usize) < lead.len() {
+                lead[k as usize]
             } else {
-                cadence[(cadence_idx + (k - lead_in) as usize) % 4]
+                // Body cycles: every L1-L4 cycle consumes an eligible clock.
+                true
             };
             if needs {
                 mask |= 1u64 << k;
@@ -1033,7 +1266,13 @@ impl LineBlitState {
 
     fn process_phase(&mut self, ram: &mut [u8], bzero: &mut bool) {
         match self.phase {
-            LineBlitPhase::StartDelay => self.phase = LineBlitPhase::Init,
+            LineBlitPhase::StartDelay => {
+                if self.start_extra > 0 {
+                    self.start_extra -= 1;
+                } else {
+                    self.phase = LineBlitPhase::Init;
+                }
+            }
             LineBlitPhase::Init => self.phase = LineBlitPhase::L1,
             LineBlitPhase::L1 => self.phase = LineBlitPhase::L2,
             LineBlitPhase::L2 => {
@@ -1048,11 +1287,13 @@ impl LineBlitState {
             LineBlitPhase::L4 => {
                 self.process_latched_pixel(ram, bzero);
                 self.phase = if self.npixels_remaining == 0 {
-                    LineBlitPhase::Done
+                    LineBlitPhase::Tail
                 } else {
                     LineBlitPhase::L1
                 };
             }
+            LineBlitPhase::Tail => self.phase = LineBlitPhase::TailDone,
+            LineBlitPhase::TailDone => self.phase = LineBlitPhase::Done,
             LineBlitPhase::Done => {}
         }
     }
@@ -1186,22 +1427,19 @@ impl NormalBlitState {
             bltafwm: blitter.bltafwm,
             bltalwm: blitter.bltalwm,
             bltadat: blitter.bltadat,
-            bltbdat: blitter.bltbdat,
+            b_hold_latch: blitter.b_hold_latch,
             bltcdat: blitter.bltcdat,
             apt: blitter.bltapt,
             bpt: blitter.bltbpt,
             cpt: blitter.bltcpt,
             dpt: blitter.bltdpt,
             a_prev: 0,
-            b_prev: if use_b || blitter.bltbold_init {
-                0
-            } else {
-                blitter.bltbold
-            },
+            b_prev: 0,
             cur_a: 0,
             cur_b: 0,
             cur_c: 0,
             fill_state: fci,
+            fill_idle_done: false,
             pipeline_full: false,
             d_hold: 0,
             d_hold_pt: blitter.bltdpt,
@@ -1239,29 +1477,68 @@ impl NormalBlitState {
         match self.phase {
             NormalBlitPhase::A => self.use_a,
             NormalBlitPhase::B => true,
-            // A real C fetch uses the bus; fill mode's C slot is idle.
             NormalBlitPhase::C => self.use_c,
             NormalBlitPhase::D => self.d_phase_needs_bus_with(self.pipeline_full),
             NormalBlitPhase::F => self.use_d && self.pipeline_full,
             NormalBlitPhase::StartDelay
             | NormalBlitPhase::Init
+            | NormalBlitPhase::FillIdle
             | NormalBlitPhase::E
             | NormalBlitPhase::Done => false,
         }
     }
 
+    /// Arbitration class of the pending pipeline cycle (see BlitSlotClass).
+    /// The startup ladder maps to the hardware timeline: the first extra is
+    /// the BLTSIZE register-commit cycle (internal), the remaining extra
+    /// and the StartDelay cycle are the BLT_STRT1/BLT_STRT2 arbitration
+    /// cycles (bus-free), and Init is the micro-program begin latency
+    /// (internal). Disabled-channel body cycles and the D bubble are
+    /// bus-free; the terminal E flush and a D-less BLTDONE are internal.
+    fn current_slot_class(&self) -> BlitSlotClass {
+        match self.phase {
+            NormalBlitPhase::StartDelay => {
+                if self.start_extra >= NORMAL_START_EXTRA_SLOTS {
+                    BlitSlotClass::Internal
+                } else {
+                    BlitSlotClass::BusFree
+                }
+            }
+            NormalBlitPhase::Init | NormalBlitPhase::E | NormalBlitPhase::Done => {
+                BlitSlotClass::Internal
+            }
+            NormalBlitPhase::FillIdle => BlitSlotClass::BusFree,
+            NormalBlitPhase::A | NormalBlitPhase::B | NormalBlitPhase::C | NormalBlitPhase::D => {
+                if self.current_slot_needs_bus() {
+                    BlitSlotClass::Bus
+                } else {
+                    BlitSlotClass::BusFree
+                }
+            }
+            NormalBlitPhase::F => {
+                if self.current_slot_needs_bus() {
+                    BlitSlotClass::Bus
+                } else {
+                    BlitSlotClass::Internal
+                }
+            }
+        }
+    }
+
+    /// A D slot claims the bus only when a destination word is queued in
+    /// the hold register. The first word's D slot is always the HRM "-"
+    /// pipeline bubble -- including in D-only blits: real hardware writes
+    /// "-- D0 -- D1 | -- D2" (vAmiga's lockD on the first iteration), so
+    /// the first D cycle of a clear leaves the bus free.
     fn d_phase_needs_bus_with(&self, pipeline_full: bool) -> bool {
-        self.use_d && (pipeline_full || !self.d_output_waits_for_source_pipeline())
+        self.use_d && pipeline_full
     }
 
-    fn d_output_waits_for_source_pipeline(&self) -> bool {
-        self.use_a || self.use_b || self.has_c_phase()
-    }
-
-    /// Access pattern of the next `limit` scheduled slots (bit k = slot k needs
-    /// the bus). Mirrors process_phase, including the delayed D holding
-    /// register: the first D phase after source fetches is the HRM "-" bubble
-    /// until a destination word has been queued.
+    /// Access pattern of the next `limit` scheduled slots (bit k = slot k
+    /// consumes a blitter-eligible colour clock: a bus access or a bus-free
+    /// micro-cycle; clear = internal, elapses unconditionally). Mirrors
+    /// process_phase, including the startup ladder (register commit is
+    /// internal, the BLT_STRT cycles are bus-free) and the terminal cycles.
     fn slot_access_pattern(&self, limit: u32) -> (u64, u32) {
         let count = self.slots_remaining.min(limit).min(64);
         let mut mask = 0u64;
@@ -1271,18 +1548,23 @@ impl NormalBlitState {
         let mut pipeline_full = self.pipeline_full;
         let mut word_idx = self.word_idx;
         let mut h_remaining = self.h_remaining;
+        let mut fill_idle_done = self.fill_idle_done;
 
         for k in 0..count {
             let needs = match phase {
-                NormalBlitPhase::A => self.use_a,
-                NormalBlitPhase::B => true,
-                NormalBlitPhase::C => self.use_c,
-                NormalBlitPhase::D => self.d_phase_needs_bus_with(pipeline_full),
+                // Every body cycle consumes an eligible colour clock,
+                // whether it accesses the bus or idles through it.
+                NormalBlitPhase::A
+                | NormalBlitPhase::B
+                | NormalBlitPhase::C
+                | NormalBlitPhase::D
+                | NormalBlitPhase::FillIdle => true,
+                // The BLT_STRT cycles need a free bus; the commit does not.
+                NormalBlitPhase::StartDelay => start_extra < NORMAL_START_EXTRA_SLOTS,
+                // The terminal BLTDONE cycle is the final D write for USED
+                // programs and internal otherwise.
                 NormalBlitPhase::F => self.use_d && pipeline_full,
-                NormalBlitPhase::StartDelay
-                | NormalBlitPhase::Init
-                | NormalBlitPhase::E
-                | NormalBlitPhase::Done => false,
+                NormalBlitPhase::Init | NormalBlitPhase::E | NormalBlitPhase::Done => false,
             };
             if needs {
                 mask |= 1u64 << k;
@@ -1320,7 +1602,7 @@ impl NormalBlitState {
                         let done =
                             Self::advance_pattern_word(self.w, &mut word_idx, &mut h_remaining);
                         phase = if done {
-                            NormalBlitPhase::Done
+                            NormalBlitPhase::E
                         } else {
                             NormalBlitPhase::A
                         };
@@ -1329,12 +1611,20 @@ impl NormalBlitState {
                 NormalBlitPhase::D => {
                     pipeline_full = self.use_d;
                     let done = Self::advance_pattern_word(self.w, &mut word_idx, &mut h_remaining);
-                    phase = if done {
-                        if self.use_d {
+                    if self.has_fill_idle_phase() {
+                        fill_idle_done = done;
+                        phase = NormalBlitPhase::FillIdle;
+                    } else {
+                        phase = if done {
                             NormalBlitPhase::E
                         } else {
-                            NormalBlitPhase::Done
-                        }
+                            NormalBlitPhase::A
+                        };
+                    }
+                }
+                NormalBlitPhase::FillIdle => {
+                    phase = if fill_idle_done {
+                        NormalBlitPhase::E
                     } else {
                         NormalBlitPhase::A
                     };
@@ -1410,7 +1700,7 @@ impl NormalBlitState {
                 } else {
                     let done = self.finish_source_word(bzero);
                     self.phase = if done {
-                        NormalBlitPhase::Done
+                        NormalBlitPhase::E
                     } else {
                         NormalBlitPhase::A
                     };
@@ -1419,12 +1709,20 @@ impl NormalBlitState {
             NormalBlitPhase::D => {
                 self.write_queued_d(ram);
                 let done = self.finish_source_word(bzero);
-                self.phase = if done {
-                    if self.use_d {
+                if self.has_fill_idle_phase() {
+                    self.fill_idle_done = done;
+                    self.phase = NormalBlitPhase::FillIdle;
+                } else {
+                    self.phase = if done {
                         NormalBlitPhase::E
                     } else {
-                        NormalBlitPhase::Done
-                    }
+                        NormalBlitPhase::A
+                    };
+                }
+            }
+            NormalBlitPhase::FillIdle => {
+                self.phase = if self.fill_idle_done {
+                    NormalBlitPhase::E
                 } else {
                     NormalBlitPhase::A
                 };
@@ -1447,9 +1745,10 @@ impl NormalBlitState {
         // mis-shifted BLTADAT window masks whenever ASH was non-zero
         // (the CD32 boot intro's cookie-cut letter-rotation blits).
         if !self.use_b {
-            let b_raw = self.bltbdat;
-            self.cur_b = shift_combine(self.b_prev, b_raw, self.bsh, self.desc);
-            self.b_prev = b_raw;
+            // The B hold register was loaded by the BLTBDAT write itself,
+            // shifted with the write-time BSH; the blit does not re-run
+            // the B shifter for a disabled channel.
+            self.cur_b = self.b_hold_latch;
         }
         if !self.use_c {
             self.cur_c = self.bltcdat;
@@ -1457,12 +1756,21 @@ impl NormalBlitState {
     }
 
     fn has_c_phase(&self) -> bool {
-        // A real C bus cycle (USEC), or fill mode's idle C slot. Fill consumes
-        // the C cycle even with USEC clear (begin_word already supplied cur_c =
-        // bltcdat); the slot is idle, not a fetch (see process_phase C and
-        // current_slot_needs_bus). Real hardware times it -- see
-        // normal_source_slots_per_word and docs/internals/timing.md.
-        self.use_c || self.ife || self.efe
+        // A real C bus cycle: only USEC enters the C state. Fill mode's
+        // extra cycle sits AFTER the D slot instead (see FillIdle and
+        // has_fill_idle_phase); it is idle, not a fetch. Real hardware
+        // times it -- see normal_source_slots_per_word and
+        // docs/internals/timing.md.
+        self.use_c
+    }
+
+    /// Fill mode's extra idle cycle per word, placed after the D slot
+    /// (vAmiga fill micro-programs for USE masks 1/5/9/D). USEC-carrying
+    /// fills reuse their real C cycle and get no extra slot; fills without
+    /// a D channel have no timing effect either (vAmiga programs 0-E fill
+    /// variants match their copy variants).
+    fn has_fill_idle_phase(&self) -> bool {
+        (self.ife || self.efe) && self.use_d && !self.use_c
     }
 
     fn mask_a_word(&self, raw: u16) -> u16 {
@@ -1511,14 +1819,13 @@ impl NormalBlitState {
     }
 
     fn fetch_b(&mut self, ram: &[u8]) {
-        let b_raw = if self.use_b {
+        debug_assert!(self.use_b);
+        let b_raw = {
             let addr = self.bpt;
             let snap = self.snap_b.get(self.snap_b_idx).copied().unwrap_or(0);
             self.snap_b_idx += 1;
             self.bpt = self.bpt.wrapping_add(self.step as u32);
             self.overlay_read(addr, snap, ram.len())
-        } else {
-            self.bltbdat
         };
         let b = shift_combine(self.b_prev, b_raw, self.bsh, self.desc);
         self.b_prev = b_raw;
@@ -1606,9 +1913,6 @@ impl NormalBlitState {
         blitter.bltbpt = self.bpt & ptr_mask;
         blitter.bltcpt = self.cpt & ptr_mask;
         blitter.bltdpt = self.dpt & ptr_mask;
-        if !self.use_b {
-            blitter.bltbold = self.b_prev;
-        }
     }
 }
 
@@ -1641,42 +1945,61 @@ fn normal_source_slots_per_word(con0: u16, con1: u16) -> u32 {
     // B and C before the D/next-word state. The D result itself is
     // pipeline-delayed; this count is just the repeating source cadence.
     //
-    // Per-word cost is the number of channel slots A/B/C/D, EXCEPT that area
-    // fill (IFE/EFE) consumes the C slot even when USEC is clear: that slot is
-    // an idle cycle (no bus access -- see current_slot_needs_bus), the "-" in
-    // the HRM "A - D" fill cadence. Cross-emulator timing (FS-UAE and vAmiga
-    // both report an A->D area fill at 3 cck/word vs 2 for an A->D copy --
-    // timing-test rows 23/24/26) confirms the slot is real, not phantom.
-    // (A previous change dropped it to speed one frame-budget regression; that
-    // masked a separate timing bug. See docs/internals/timing.md.)
+    // Per-word cost is the number of channel slots A/B/C/D, PLUS area
+    // fill's extra idle cycle: with USEC clear, fill (IFE/EFE) appends an
+    // idle cycle AFTER the D slot of each word (no bus access -- see
+    // current_slot_needs_bus), the trailing "-" in the vAmiga fill
+    // micro-programs "A0 -- -- A1 D0 -- A2 D1 --". Cross-emulator timing
+    // (FS-UAE and vAmiga both report an A->D area fill at 3 cck/word vs 2
+    // for an A->D copy -- timing-test rows 23/24/26) confirms the slot is
+    // real, not phantom. (A previous change dropped it to speed one
+    // frame-budget regression; that masked a separate timing bug. See
+    // docs/internals/timing.md.) USEC-carrying fills reuse their real C
+    // cycle and D-less fills match their copy timing (vAmiga programs).
     let use_b = con0 & BLTCON0_USE_B != 0;
     let use_c = con0 & BLTCON0_USE_C != 0;
     let use_d = con0 & BLTCON0_USE_D != 0;
     let desc = con1 & BLTCON1_DESC != 0;
     let fill = desc && con1 & (BLTCON1_IFE | BLTCON1_EFE) != 0;
-    let c_phase = use_c || fill;
+    let c_phase = use_c;
     let d_phase = use_d || !c_phase;
-    1 + u32::from(use_b) + u32::from(c_phase) + u32::from(d_phase)
+    let fill_idle = fill && use_d && !use_c;
+    1 + u32::from(use_b) + u32::from(c_phase) + u32::from(d_phase) + u32::from(fill_idle)
 }
 
-/// Extra internal slots between the BLTSIZE write and the Init slot: the
-/// register-commit cycle plus the two BLT_STRT startup cycles and the
-/// micro-program begin cycle real Agnus takes (see NormalBlitState).
-const NORMAL_START_EXTRA_SLOTS: u32 = 3;
+/// Extra internal slots between the BLTSIZE write and the Init slot. Real
+/// Agnus takes the BLTSIZE poke through a one-cycle register commit and two
+/// bus-arbitration startup cycles (vAmiga BLT_STRT1/BLT_STRT2), and the
+/// first micro-program cycle runs at poke+4. Copperline's sequencer already
+/// ticks once in the poke's own colour clock, so two extras plus the
+/// StartDelay/Init slots put the first body cycle at poke+4 as well
+/// (verified with the two-sided VAMIGA_BLT_PROBE / COPPERLINE_DIAG_BLT_SLOTS
+/// slot trace).
+/// TODO: STRT1/STRT2 on real hardware need free bus slots, so Copper or
+/// fixed-DMA ownership stretches the startup; these extras are plain
+/// internal cycles.
+const NORMAL_START_EXTRA_SLOTS: u32 = 2;
 
 fn normal_total_slots(h: u32, w: u32, con0: u16, con1: u16) -> u32 {
     let words = h.saturating_mul(w);
     if words == 0 {
         return 1 + NORMAL_START_EXTRA_SLOTS;
     }
-    let use_d = con0 & BLTCON0_USE_D != 0;
+    // Every program ends with the two terminal micro-cycles (E/F): the
+    // internal D-hold flush and the BLTDONE cycle. With USED the BLTDONE
+    // cycle carries the final D write; without it both are internal, but
+    // they still run -- BBUSY has already dropped at the last body cycle
+    // and INTREQ.BLIT rises one clock after the BLTDONE cycle.
     2 + NORMAL_START_EXTRA_SLOTS
         + words.saturating_mul(normal_source_slots_per_word(con0, con1))
-        + if use_d { 2 } else { 0 }
+        + 2
 }
 
 fn line_total_slots(npixels: u32) -> u32 {
-    2 + npixels.saturating_mul(4)
+    // Startup extras + StartDelay/Init lead-in, four cycles per pixel, and
+    // the two terminal micro-cycles (NOTHING + BLTDONE, vAmiga's line
+    // program tail).
+    2 + NORMAL_START_EXTRA_SLOTS + npixels.saturating_mul(4) + 2
 }
 
 fn line_step_sometimes(
@@ -2236,33 +2559,39 @@ mod tests {
         b.start_scheduled(bltsize, &ram);
 
         assert!(b.busy);
-        assert_eq!(b.scheduled_slots_remaining(), Some(11));
+        assert_eq!(b.scheduled_slots_remaining(), Some(10));
         assert_eq!(&ram[0x20..0x24], &[0xAA, 0xAA, 0xAA, 0xAA]);
-        // Walk the three startup extras (BLTSIZE commit + BLT_STRT cycles).
-        for _ in 0..3 {
+        // Walk the two startup extras (register commit + BLT_STRT cycles).
+        for _ in 0..2 {
             assert!(!b.tick_scheduled_slot(&mut ram));
         }
-        assert!(!b.tick_scheduled_slot(&mut ram));
+        assert!(!b.tick_scheduled_slot(&mut ram)); // BBUSY start delay.
         assert_eq!(b.scheduled_slots_remaining(), Some(7));
         assert!(b.busy);
         assert_eq!(&ram[0x20..0x24], &[0xAA, 0xAA, 0xAA, 0xAA]);
-        assert!(!b.tick_scheduled_slot(&mut ram));
+        assert!(!b.tick_scheduled_slot(&mut ram)); // INIT.
         assert_eq!(b.scheduled_slots_remaining(), Some(6));
         assert!(b.busy);
         assert_eq!(&ram[0x20..0x24], &[0xAA, 0xAA, 0xAA, 0xAA]);
-        assert!(!b.tick_scheduled_slot(&mut ram));
+        assert!(!b.tick_scheduled_slot(&mut ram)); // A0 (idle: A DMA disabled).
         assert_eq!(b.scheduled_slots_remaining(), Some(5));
         assert!(b.busy);
         assert_eq!(&ram[0x20..0x24], &[0xAA, 0xAA, 0xAA, 0xAA]);
+        // D0: the first D cycle is the pipeline bubble even in a D-only
+        // clear (hardware writes "-- D0 -- D1 | -- D2"); nothing lands yet.
         assert!(!b.tick_scheduled_slot(&mut ram));
         assert_eq!(&ram[0x20..0x24], &[0xAA, 0xAA, 0xAA, 0xAA]);
-        assert!(!b.tick_scheduled_slot(&mut ram));
+        assert!(!b.tick_scheduled_slot(&mut ram)); // A1 (idle).
         assert_eq!(&ram[0x20..0x24], &[0xAA, 0xAA, 0xAA, 0xAA]);
-        assert!(!b.tick_scheduled_slot(&mut ram));
+        assert!(!b.tick_scheduled_slot(&mut ram)); // D1 writes word 0.
         assert_eq!(&ram[0x20..0x24], &[0x00, 0x00, 0xAA, 0xAA]);
-        assert!(!b.tick_scheduled_slot(&mut ram));
+        // BBUSY has dropped with the final body cycle; the engine still
+        // runs the terminal flush/BLTDONE cycles.
+        assert!(!b.bbusy);
+        assert!(b.busy);
+        assert!(!b.tick_scheduled_slot(&mut ram)); // E (internal).
         assert_eq!(&ram[0x20..0x24], &[0x00, 0x00, 0xAA, 0xAA]);
-        assert!(b.tick_scheduled_slot(&mut ram));
+        assert!(b.tick_scheduled_slot(&mut ram)); // F writes the final word.
         assert!(!b.busy);
         assert_eq!(b.scheduled_slots_remaining(), None);
         assert_eq!(&ram[0x20..0x24], &[0x00, 0x00, 0x00, 0x00]);
@@ -2286,9 +2615,9 @@ mod tests {
         }
 
         // D-only clear, 1 row x 2 words: startup extras + StartDelay, Init,
-        // [A D] x2, E, F. Only the D write slots and the final F flush access
-        // the bus; the A slots are idle because A DMA is disabled (HRM:
-        // "- D0" per word).
+        // [A D] x2, E, F. The first D cycle is the pipeline bubble even in a
+        // D-only clear (hardware: "-- D0 -- D1 | -- D2", vAmiga's first-
+        // iteration lockD): only D1 and the final F flush access the bus.
         let mut ram = vec![0xAAu8; 256];
         let mut b = Blitter::new();
         b.bltcon0 = BLTCON0_USE_D; // minterm $00 clears
@@ -2296,7 +2625,7 @@ mod tests {
         b.start_scheduled((1u16 << 6) | 2, &ram);
         assert_eq!(
             needs_bus_walk(&mut b, &mut ram),
-            [false, false, false, false, false, false, true, false, true, false, true]
+            [false, false, false, false, false, false, false, true, false, true]
         );
 
         // A->D copy, 1 row x 2 words: the first D phase is the delayed-D
@@ -2312,7 +2641,7 @@ mod tests {
         b.start_scheduled((1u16 << 6) | 2, &ram);
         assert_eq!(
             needs_bus_walk(&mut b, &mut ram),
-            [false, false, false, false, false, true, false, true, true, false, true]
+            [false, false, false, false, true, false, true, true, false, true]
         );
 
         // ABCD cookie-cut, 1 row x 2 words: A/B/C fetch first, then the
@@ -2330,14 +2659,15 @@ mod tests {
         assert_eq!(
             needs_bus_walk(&mut b, &mut ram),
             [
-                false, false, false, false, false, true, true, true, false, true, true, true, true,
-                false, true
+                false, false, false, false, true, true, true, false, true, true, true, true, false,
+                true
             ]
         );
 
-        // Line blit, 2 pixels: StartDelay, Init, then [L1 L2 L3 L4] per pixel.
-        // Only L2 (C read) and L4 (D write) access the bus; L1/L3 are internal
-        // Bresenham cycles.
+        // Line blit, 2 pixels: startup extras + StartDelay, Init, then
+        // [L1 L2 L3 L4] per pixel and the two internal terminal cycles.
+        // Only L2 (C read) and L4 (D write) access the bus; L1/L3 are
+        // internal Bresenham cycles.
         let mut ram = vec![0u8; 256];
         let mut b = Blitter::new();
         b.bltcon0 = BLTCON0_USE_A | BLTCON0_USE_C | BLTCON0_USE_D | 0x004A;
@@ -2352,7 +2682,10 @@ mod tests {
         b.start_scheduled((2u16 << 6) | 2, &ram);
         assert_eq!(
             needs_bus_walk(&mut b, &mut ram),
-            [false, false, false, true, false, true, false, true, false, true]
+            [
+                false, false, false, false, false, true, false, true, false, true, false, true,
+                false, false
+            ]
         );
     }
 
@@ -2370,7 +2703,7 @@ mod tests {
         b.bltdpt = 0x20;
         b.start_scheduled((1u16 << 6) | 1, &ram);
 
-        for _ in 0..3 {
+        for _ in 0..2 {
             assert!(!b.tick_scheduled_slot(&mut ram)); // startup extras
         }
         assert!(!b.tick_scheduled_slot(&mut ram)); // BBUSY start delay.
@@ -2399,12 +2732,12 @@ mod tests {
         b.bltdpt = 0x20;
         b.start_scheduled((1u16 << 6) | 1, &ram);
 
-        assert_eq!(b.scheduled_slots_remaining(), Some(9));
+        assert_eq!(b.scheduled_slots_remaining(), Some(8));
         assert!(!b.tick_scheduled_slot(&mut ram));
 
         assert_eq!(b.bltapt, 0x10);
         assert_eq!(read_word(&ram, 0x20), 0);
-        assert_eq!(b.scheduled_slots_remaining(), Some(8));
+        assert_eq!(b.scheduled_slots_remaining(), Some(7));
     }
 
     #[test]
@@ -2419,14 +2752,22 @@ mod tests {
         b.bltdpt = 0x20;
         b.start_scheduled((1u16 << 6) | 1, &ram);
 
-        assert_eq!(b.scheduled_slots_remaining(), Some(7));
-        for _ in 0..3 {
+        assert_eq!(b.scheduled_slots_remaining(), Some(8));
+        for _ in 0..2 {
             assert!(!b.tick_scheduled_slot(&mut ram)); // startup extras
         }
         assert!(!b.tick_scheduled_slot(&mut ram)); // BBUSY start delay.
         assert!(!b.tick_scheduled_slot(&mut ram)); // INIT.
         assert!(!b.tick_scheduled_slot(&mut ram)); // A state, empty when A is disabled.
-        assert!(b.tick_scheduled_slot(&mut ram)); // C state is the next-word state.
+        assert!(!b.tick_scheduled_slot(&mut ram)); // C state is the last body cycle.
+
+        // BBUSY drops with the final body cycle, but the terminal
+        // flush/BLTDONE cycles still run before the engine finishes (the
+        // blitter interrupt then rises one clock after the final cycle).
+        assert!(!b.bbusy);
+        assert!(b.busy);
+        assert!(!b.tick_scheduled_slot(&mut ram)); // E (internal).
+        assert!(b.tick_scheduled_slot(&mut ram)); // F/BLTDONE (internal, no D).
 
         assert!(!b.busy);
         assert!(!b.bzero);
@@ -2473,16 +2814,26 @@ mod tests {
         b.bltdpt = 0;
         b.start_scheduled((1u16 << 6) | 2, &ram);
 
-        assert_eq!(b.scheduled_slots_remaining(), Some(6));
+        assert_eq!(b.scheduled_slots_remaining(), Some(10));
+        for _ in 0..2 {
+            assert!(!b.tick_scheduled_slot(&mut ram)); // startup extras
+        }
         assert!(!b.tick_scheduled_slot(&mut ram)); // BBUSY start delay.
         assert!(!b.tick_scheduled_slot(&mut ram)); // INIT.
         assert!(!b.tick_scheduled_slot(&mut ram)); // L1 accumulator state.
         assert!(!b.tick_scheduled_slot(&mut ram)); // L2 fetches C.
         write_word(&mut ram, 0, 0xFFFF);
         assert!(!b.tick_scheduled_slot(&mut ram)); // L3 propagation state.
-        assert!(b.tick_scheduled_slot(&mut ram)); // L4 stores the latched C result.
+        assert!(!b.tick_scheduled_slot(&mut ram)); // L4 stores the latched C result.
 
         assert_eq!(read_word(&ram, 0), 0);
+        // BBUSY drops with the final pixel's store; the two terminal
+        // micro-cycles still run before the engine finishes.
+        assert!(!b.bbusy);
+        assert!(b.busy);
+        assert!(!b.tick_scheduled_slot(&mut ram)); // terminal NOTHING cycle.
+        assert!(b.tick_scheduled_slot(&mut ram)); // terminal BLTDONE cycle.
+        assert!(!b.busy);
     }
 
     #[test]
@@ -2637,12 +2988,12 @@ mod tests {
         let fill_total = fill.scheduled_slots_remaining();
         let (fill_total_walked, fill_bus) = walk_bus(&mut fill, &mut ram);
 
-        // Copy: 3 (startup extras) + 2 (start delay + init) + 2 words *
-        // 2 cyc/word + 2 (D flush) = 11.
-        assert_eq!(copy_total, 11);
-        // Fill: the same, but 3 cyc/word -> 5 + 2*3 + 2 = 13 (two extra slots).
-        assert_eq!(fill_total, Some(13));
-        assert_eq!(fill_total_walked, 13);
+        // Copy: 2 (startup extras) + 2 (start delay + init) + 2 words *
+        // 2 cyc/word + 2 (terminal flush/BLTDONE) = 10.
+        assert_eq!(copy_total, 10);
+        // Fill: the same, but 3 cyc/word -> 4 + 2*3 + 2 = 12 (two extra slots).
+        assert_eq!(fill_total, Some(12));
+        assert_eq!(fill_total_walked, 12);
         // The extra fill slots are IDLE: the fill performs the same number of
         // bus accesses as the copy (the A reads and D writes), just spread over
         // two more idle cycles.

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -86,7 +86,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      per-direction stamps for the mechanism's 40 us pulse floor)
 //  24: Cia gained the delayed /IRQ pin state (irq_pin,
 //      irq_pin_delay_eticks - the 8520 one-E-cycle interrupt delay)
-pub const STATE_VERSION: u32 = 24;
+//  25: Blitter gained the early-dropping DMACONR BBUSY flag (bbusy) and
+//      Bus the one-cck INTREQ.BLIT raise delay (blit_irq_delay_cck)
+pub const STATE_VERSION: u32 = 25;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
# Blitter cycle-exactness: micro-cycle protocol from the vAmiga slot oracle

Models the Agnus blitter's per-cycle protocol slot-for-slot against
vAmiga 4.4's slot-accurate blitter (the micro-program tables derived from
the HRM cycle diagrams plus Dirk Hoffmann's hardware corrections),
verified with a new two-sided slot-trace probe.

## Two-sided probe

- Copperline: `COPPERLINE_DIAG_BLT_SLOTS=1` logs one line per blitter
  pipeline cycle with its beam position, plus per-cck owner lines while a
  blit is in flight (documented in docs/debugger/headless.md).
- vAmiga: matching env-gated `VAMIGA_BLT_PROBE=1` fprintf hooks in a
  local build (add-only patch kept in
  `vamigats-reports/vamiga-blt-probe.patch`).

On the traced vAmigaTS cases (`bususage2` C-only blits, `timing9` AD
blits, poked by CPU and by Copper, on both blank and 6-plane display
lines) the two emulators now execute the blit body cycle-for-cycle at
identical beam positions relative to the BLTSIZE poke, including the
BLT_STRT stalls under display DMA and the copper-contended fetch cadence.

## Model changes

1. **End-of-blit protocol**: every program ends with the two terminal
   micro-cycles (internal D-hold flush + BLTDONE). DMACONR.BBUSY drops
   with the sequencer's final body cycle, two cycles before the last D
   word lands (vAmiga `clearBusyFlag` at REPEAT). INTREQ.BLIT rises one
   colour clock after the BLTDONE cycle's FIRST attempt (vAmiga
   `scheduleIrqRel(BLIT, 1)` runs before the bus-allocation check), so a
   bus-blocked final D write raises the interrupt before the word lands.
   The Copper's blitter-finished gate keeps opening at engine end
   (vAmiga gates BFD on `running`, not `bbusy`).
2. **Startup**: the first body cycle runs at poke+4 (register commit +
   BLT_STRT1/2 + micro-program begin), for both normal and line blits.
3. **Stall classes** (`BlitSlotClass`): bus-free micro-cycles (vAmiga
   BUSIDLE: D pipeline bubble, fill idle, BLT_STRT cycles, line
   Bresenham cycles) stall while the Copper or fixed DMA owns the colour
   clock and on the BLS starvation grant; internal cycles (register
   commit, Init, terminal flush, D-less BLTDONE) elapse unconditionally.
4. **First-D bubble everywhere**: D-only clears also write
   `-- D0 -- D1 | -- D2`; the first D cycle never claims the bus.
5. **Area-fill idle placement**: the extra idle cycle sits AFTER the D
   slot (vAmiga fill programs for USE masks 1/5/9/D); USEC fills and
   D-less fills match copy timing. Still 3 cck/word for an A->D fill
   (the calibrated real-hardware fact).
6. **Line blits**: same startup and terminal cycles; a suppressed store
   (USEC clear or SING past the row's first dot) leaves its D cycle
   bus-idle (vAmiga lockD).
7. **BLTBDAT write-time shifter**: writing BLTBDAT runs the B barrel
   shifter with the BSH/DESC current at write time; USEB-off blits
   consume the latched hold word (vAmiga `pokeBLTBDAT`;
   vAmigaTS undocumented1: 13.8% -> 2.0%).

## vAmigaTS Agnus/Blitter sweep (233 cases, sum of diff-%)

| bucket | base | new | delta |
| --- | ---: | ---: | ---: |
| cputim | 537.2 | 524.1 | -13.0 |
| bususage | 424.1 | 414.8 | -9.3 |
| irqtim | 223.5 | 220.9 | -2.6 |
| race | 163.8 | 160.1 | -3.7 |
| timing | 130.1 | 141.0 | +10.9 |
| bbusy | 109.3 | 103.4 | -6.0 |
| bltint | 67.0 | 58.1 | -8.9 |
| fill | 36.2 | 36.2 | +0.0 |
| line | 34.9 | 34.9 | +0.0 |
| undocumented | 13.8 | 2.0 | -11.8 |
| sblit/dmacon/misc/wrap | 18.9 | 18.1 | -0.8 |
| **TOTAL** | **1758.8** | **1713.5** | **-45.3** |

Baseline is a fresh sweep of the merge base (6cd266b) against the same vAmiga 4.4 headless reference build.

## Gates

- `cargo test --lib` green (1324 tests; slot-count/protocol tests updated
  with the hardware facts in comments).
- clippy -D warnings clean, fmt clean.
- 14-demo byte-identity gate vs the merge base: 11 identical (itm,
  hamazing, genx, kick13boot, kicka1200, roots-ecs, roots-aga, gods,
  rebirth, tomato, zool); eon, sota and secondnature differ only by a
  1-2 frame animation/fade phase after the BLTBDAT write-time-shifter
  change -- screenshot pairs visually verified, no corruption, and sota
  reconverges byte-identically at 31s (see Residual map).
- Agnus/Copper cross-check sweep: 223 cases, every case's score identical to the main baseline listing (to 0.01pp) -- the blitter changes leave the Copper bucket untouched.
- Save states: STATE_VERSION 25 (Blitter bbusy/b_hold_latch/irq_arm,
  Bus blit_irq_delay_cck).

## Residual map

- **Copper/CPU write-landing wall (dominant)**: the slot traces show the blit body cycle-exact relative to its BLTSIZE poke on both emulators, but Copperline's Copper MOVE (and CPU write) lands ~4 cck later than vAmiga after a WAIT (the previously characterized interfere-class divergence). The `timing` stripes visualize blit start (COL1 write) -> BFD wake (black write) and amplify that wall; the end-protocol changes moved several cases across quantization boundaries in both directions (`timing` +10.9 net, individual cases +-2pp). Fixing the copper write-landing class would move `timing`, `race`, `irqtim`, and much of the `cputim` floor together.
- **cputim/invisible floor (~20%/case)**: a CPU loop paints a 2-write checkerboard while blits steal slots; every 1-cck divergence anywhere permanently phase-shifts the remaining stripe pattern, so these cases sit on the CPU-write-landing wall, not on blitter slot placement.
- **Line-blit rate**: `line` bucket unchanged (avg 1.2%); the known 64-px line = 317 vs 262 cck residual remains and now shows as pure stall behaviour of the L1/L3 bus-free cycles (the slot count itself now predicts 262 exactly). Two-sided line traces (`bususage*l`, `irqtim*l*`) are the next probe target.
- **Demo byte-identity breaks**: eon, sota, secondnature differ from the merge base only by a 1-2 frame animation/fade phase after the BLTBDAT write-time-shifter change (screenshot pairs verified visually; sota reconverges byte-identically at 31s). All other 11 demos are byte-identical.
- The two-sided probe (`COPPERLINE_DIAG_BLT_SLOTS` + `vamigats-reports/vamiga-blt-probe.patch`) makes any future divergence directly diffable per colour clock.
