### PR TITLE
m68k: flush a division's internal clocks at the instruction boundary

### DIFF
--- a/crates/m68k/src/core/instructions/mul_div.rs
+++ b/crates/m68k/src/core/instructions/mul_div.rs
@@ -199,6 +199,14 @@ impl CpuCore {
             self.top_up_prefetch(bus);
             if div_clocks > 4 {
                 self.internal_cycles((div_clocks - 4) as u32);
+                // Advance the beam for the division's internal clocks now, before
+                // the instruction boundary (Moira's SYNC runs immediately after
+                // prefetch<POLL>). Deferring them past the boundary -- to the next
+                // instruction's first bus access -- mistimes CPU-vs-bitplane-DMA
+                // contention during an active display, doubling the beam cost of a
+                // DIV run mid-fetch (timing-test row 31 8722 -> 4820 cck vs vAmiga
+                // 4790; TEK Rampage's Ellis scene depends on it).
+                self.flush_sync(bus);
             }
         }
 
@@ -270,6 +278,14 @@ impl CpuCore {
             self.top_up_prefetch(bus);
             if div_clocks > 4 {
                 self.internal_cycles((div_clocks - 4) as u32);
+                // Advance the beam for the division's internal clocks now, before
+                // the instruction boundary (Moira's SYNC runs immediately after
+                // prefetch<POLL>). Deferring them past the boundary -- to the next
+                // instruction's first bus access -- mistimes CPU-vs-bitplane-DMA
+                // contention during an active display, doubling the beam cost of a
+                // DIV run mid-fetch (timing-test row 31 8722 -> 4820 cck vs vAmiga
+                // 4790; TEK Rampage's Ellis scene depends on it).
+                self.flush_sync(bus);
             }
         }
 

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -89,6 +89,7 @@ ticks everywhere.
 | 28 | independent pair `move.w d2,d0` + `move.w d3,d1` x8192 | 68060 dual-issue: pairs into one clock; compare rows 4 and 29 |
 | 29 | RAW pair `move.w d2,d0` + `move.w d0,d1` x8192 | the dependency blocks dual issue |
 | 30 | `dbra`-only loop x8192, after the 68060 enable block | branch-cache folding: 1 clock/iteration on a 68060 |
+| 31 | beam cck while a 64-iteration DIVU loop runs **with a 6-bitplane display active** | DIV-during-active-display: a DIV's prefetch contends with plane DMA, and its internal clocks must advance the beam at the boundary, not leak into the next instruction |
 
 ### Rows 28-30: 68060 superscalar dispatch and branch cache
 
@@ -138,8 +139,27 @@ rows 23-26 = 9944 / 15308 / 383 / 16842 cck, timing the row-24 A->D fill at
 display fetch an unfinished buffer. The fill cadence was corrected on 2026-06-09;
 Copperline now reads ~9922 / 18339 / 317 / 25074 against the current FS-UAE
 reference 9908 / 18357 / 262 / 25208, matching rows 23-24 and the row-26
-display-DMA contention. Known residual tracked by these rows: row 25 (line
-blit) is ~21% slow (317 vs 262).
+display-DMA contention.
+
+Row 31 found (and now guards) a second real bug (2026-07-07). On the plain 68000
+Copperline matches vAmiga on every other row -- including the CPU-vs-6-bitplane
+contention (row 11) and the line blit (row 25); the apparent "row 25 ~21% slow"
+seen against the FS-UAE reference is a **68EC020 instruction-cache** artifact (the
+020 caches the loop so its prefetches never contend) and does not reproduce on the
+68000. But DIV-during-active-display (row 31) read 8722 cck where vAmiga reads
+4790: the 68000 DIV reorder that puts the final prefetch before the division's
+internal clocks left those internal clocks *deferred* past the instruction
+boundary (billed at the next instruction's first bus access), which mistimed the
+CPU-vs-bitplane-DMA contention and roughly doubled the beam cost of a DIV run
+mid-fetch. Flushing the internal clocks at the DIV boundary (Moira runs `SYNC`
+immediately after `prefetch<POLL>`) fixed it: row 31 8722 -> 4820 vs vAmiga 4790,
+with rows 23-26 and the CPU/blitter rows unchanged. This was TEK Rampage's Ellis
+scene going saturated (EHB half-bright dropped) and its Mirror scene crashing --
+the DIV-heavy per-frame math patches the copper list while the 6-plane screen
+fetches, so the doubled DIV cost let the CPU fall behind the beam.
+(`getbeam` also had a latent bug -- it left the upper word of `d2` dirty across
+the `add.l d2,d0`, so a caller with a non-zero high word in `d2` corrupted the
+reading; harmless for rows 23-26, fixed for row 31.)
 
 ### Rows 19-21: the cooperative-scheduler interrupt chain
 

--- a/timing-test/test.asm
+++ b/timing-test/test.asm
@@ -51,6 +51,14 @@
 ;   row 30 dbra x8192       branch-cache row: same body as row 7, but run
 ;          after the 68060 enable block (ESS + caches + branch cache), so a
 ;          folding branch cache collapses the loop overhead
+;   row 31 BEAM cck advanced while a 64-iteration DIVU loop runs during a
+;          6-bitplane lores display -- DIV-during-active-display, the one phase
+;          the other rows miss. A DIV's final prefetch is a chip-bus access
+;          whose beam position (and thus contention) matters; if the division's
+;          internal clocks are deferred past the instruction boundary they
+;          mistime that contention and double the beam cost. (TEK Rampage's
+;          Ellis scene is exactly this: DIV-heavy per-frame math patching the
+;          copper list while the 6-plane screen fetches.)
 ;
 ; Before row 28 a TRAP #0 supervisor stub probes MOVEC PCR for the 68060
 ; identification ($0430) and, if found, enables superscalar dispatch
@@ -757,6 +765,51 @@ boot1:  lea     CUST,a6
         bsr     tread
         move.l  d0,(a3)+
 
+        ; row 31: BEAM cck advanced while a fixed 256-iteration DIVU loop runs
+        ; during a 6-bitplane lores (EHB) display -- the rampage Ellis condition
+        ; (DIV-heavy per-frame math whose final prefetch is a chip-bus access
+        ; that contends with 6-plane bitplane DMA). The 25bd80b prefetch reorder
+        ; moved that prefetch's beam position; this row is the only one that
+        ; exercises DIV-during-active-display, the phase the other rows miss.
+        move.w  #$6000,$100(a6) ; BPLCON0: 6 bitplanes, lores
+        move.w  #$0038,$092(a6) ; DDFSTRT
+        move.w  #$00d0,$094(a6) ; DDFSTOP
+        move.w  #$2c81,$08e(a6) ; DIWSTRT
+        move.w  #$2cc1,$090(a6) ; DIWSTOP
+        move.w  #$0000,$108(a6) ; BPL1MOD
+        move.w  #$0000,$10a(a6) ; BPL2MOD
+        move.l  #$10000,d0      ; point all 6 planes at a scratch buffer
+        move.w  d0,$0e2(a6)
+        move.w  d0,$0e6(a6)
+        move.w  d0,$0ea(a6)
+        move.w  d0,$0ee(a6)
+        move.w  d0,$0f2(a6)
+        move.w  d0,$0f6(a6)
+        swap    d0
+        move.w  d0,$0e0(a6)
+        move.w  d0,$0e4(a6)
+        move.w  d0,$0e8(a6)
+        move.w  d0,$0ec(a6)
+        move.w  d0,$0f0(a6)
+        move.w  d0,$0f4(a6)
+        move.w  #$8300,$096(a6) ; DMACON: DMAEN | BPLEN (6-plane fetch active)
+        bsr     syncframe
+.c31w   bsr     getvpos
+        cmp.w   #60,d0
+        blo     .c31w           ; start a few lines into the active display
+        bsr     getbeam
+        move.l  d0,d7
+        move.l  #$12345678,d2   ; fixed dividend (quotient fits 16 bits, no ovf)
+        move.w  #$789a,d3       ; fixed divisor (non-zero)
+        move.w  #64-1,d5
+.c31    move.l  d2,d0
+        divu.w  d3,d0
+        dbra    d5,.c31
+        bsr     getbeam
+        sub.l   d7,d0
+        move.l  d0,(a3)+        ; row 31
+        move.w  #$7fff,$096(a6) ; all DMA off again
+
         move.w  #$0ff0,$180(a6) ; phase marker: all tests done (yellow)
 
         ;------------------------------------------------ render + show
@@ -767,7 +820,7 @@ boot1:  lea     CUST,a6
         ; the serial port to a file, giving a screenshot-free way to compare.
         move.w  #$0170,$032(a6) ; SERPER ~9600 baud
         lea     RESULTS,a2
-        moveq   #31-1,d4
+        moveq   #32-1,d4
 .sl     move.l  (a2)+,d3
         moveq   #8-1,d6
 .sh     rol.l   #4,d3
@@ -905,6 +958,7 @@ getbeam:
         and.w   #1,d0           ; V8
         lsl.w   #8,d0           ; -> bit 8
         move.w  $006(a6),d1     ; VHPOSR
+        moveq   #0,d2           ; clear d2 upper (caller may leave it dirty)
         move.w  d1,d2
         lsr.w   #8,d1           ; V7..V0
         or.w    d1,d0           ; full vpos (d0.w)


### PR DESCRIPTION
## Problem

The 68000 `DIVU`/`DIVS` reorder issues the final prefetch **before** the division's internal clocks (Moira: `prefetch<POLL>` then `SYNC`). But `internal_cycles` only *accumulates* the clocks; the host advances the beam lazily at the next bus access. With the prefetch now ahead of them, a division's internal clocks **leaked past the instruction boundary** and were billed against the *following* instruction's chip-bus arbitration. During an active display that mistimed the CPU-vs-bitplane-DMA contention and roughly **doubled the beam cost of a DIV that runs mid-fetch**.

TEK Rampage's Ellis scene runs DIV-heavy per-frame math while patching the copper list as the 6-plane screen fetches, so the doubled DIV cost made the CPU fall behind the beam and lose the copper-list-patch-vs-copper-read race:

- **Ellis circles** dropped the EHB half-bright plane and rendered as saturated primaries instead of pastel;
- **Mirror scene** dot cube jittered, then executed garbage → illegal-instruction guru;
- **loading gear** beam-race tipped one frame per loop.

## Fix

Flush the division's internal clocks at the DIV boundary (Moira runs `SYNC` immediately after `prefetch<POLL>`) instead of deferring them, in `crates/m68k/src/core/instructions/mul_div.rs`. This keeps the IPL poll placement, so no CPU-timing accuracy is traded away.

## How it was found / guarded

Cross-checked cycle-for-cycle against vAmiga (Moira). On the plain 68000 Copperline already matched vAmiga on every existing row (the `compare.py` "row 11 / row 25 slow" are 68EC020 instruction-cache artifacts, not bugs). The gap was invisible because no row exercised DIV during an active display, so this adds one:

- **timing-test row 31** — a `DIVU` loop under a 6-bitplane display: Copperline **8722 → 4820 cck** vs vAmiga **4790**.

`getbeam` also left the upper word of `d2` dirty across its `add.l d2,d0` (harmless for the existing blitter rows); fixed so row 31's dividend in `d2` can't corrupt the reading.

## Verification

- Row 31 8722 → 4820 (vAmiga 4790); rows 23-26 and all CPU/blitter rows unchanged.
- All four rampage scenes now render correctly (circles pastel, cube smooth, gear stable, no crash), matching vAmiga and the demo's own `ellis/screen.png`.
- 1383/1383 unit tests pass; `clippy` and `fmt` clean.