### PR TITLE
m68k: report 68040 write faults in writeback slot 3

### DIFF
--- a/crates/m68k/src/core/decode.rs
+++ b/crates/m68k/src/core/decode.rs
@@ -1193,29 +1193,25 @@ fn dispatch_group_4<B: AddressBus>(cpu: &mut CpuCore, bus: &mut B, opcode: u16) 
                                     return 20;
                                 }
                                 7 if cpu.is_040() => {
-                                    // 68040 access-error frame (30 words).
-                                    // The faulting instruction was rolled
-                                    // back at frame-build time, so a plain
-                                    // restart is the whole continuation --
-                                    // except the writeback protocol: a
-                                    // faulted write was pushed in slot 2,
-                                    // and a handler that cleared WB2S.V
-                                    // absorbed it (Enforcer/MuForce hits on
-                                    // protected pages), so the restarted
-                                    // instruction's matching write is
-                                    // discarded. A handler that completes
-                                    // the writeback manually but leaves V
-                                    // set gets the restart's write instead
-                                    // (double store to plain memory, the
-                                    // documented restart-model gap).
+                                    // 68040 access-error frame (30 words). The
+                                    // faulting instruction was rolled back at
+                                    // frame-build time, so a plain restart is
+                                    // the whole continuation -- except the
+                                    // writeback protocol: a faulted write is
+                                    // pushed in slot 3 (WB3S/WB3A at +$0E/+$18,
+                                    // matching Amiberry cpummu.cpp:434), and a
+                                    // handler that cleared WB3S.V absorbed it
+                                    // (Enforcer/MuForce hits on protected
+                                    // pages), so the restarted instruction's
+                                    // matching write is discarded.
                                     let sp = cpu.a(7);
                                     let ssw = cpu.read_16(bus, sp.wrapping_add(0x0C));
                                     let write_fault = ssw & 0x0100 == 0 && ssw & 0x0400 != 0;
                                     if write_fault {
-                                        let wb2s = cpu.read_16(bus, sp.wrapping_add(0x10));
-                                        if wb2s & 0x0080 == 0 {
-                                            let wb2a = cpu.read_32(bus, sp.wrapping_add(0x20));
-                                            cpu.mmu_write_suppress = Some(wb2a);
+                                        let wb3s = cpu.read_16(bus, sp.wrapping_add(0x0E));
+                                        if wb3s & 0x0080 == 0 {
+                                            let wb3a = cpu.read_32(bus, sp.wrapping_add(0x18));
+                                            cpu.mmu_write_suppress = Some(wb3a);
                                         }
                                     }
                                     let sr = cpu.pull_16(bus);

--- a/crates/m68k/src/core/exceptions.rs
+++ b/crates/m68k/src/core/exceptions.rs
@@ -436,14 +436,17 @@ impl CpuCore {
                 };
                 let ssw = rw | atc | sz | (fc as u16 & 0x7); // TM = function code
                 let fmt_vec = 0x7000 | ((vector::BUS_ERROR as u16) << 2);
-                // A faulted write is reported in writeback slot 2 (V bit,
-                // size and TM in WB2S; address and data in WB2A/WB2D). The
-                // handler either completes it manually or clears WB2S.V to
-                // absorb it -- how Enforcer/MuForce discard stores into
-                // protected pages -- and RTE (below) honours the cleared V.
-                // WB1 and WB3 (later/earlier pipeline stages) never carry
-                // anything in this core.
-                let wb2s = if write {
+                // A normal faulted write is reported in writeback slot 3 (V
+                // bit, size and TM in WB3S; address and data in WB3A/WB3D),
+                // matching real 68040 silicon and the WinUAE/Amiberry MMU
+                // reference (cpummu.cpp sets regs.wb3_status/wb3_data on a
+                // write fault and clears wb2 -- WB2 is reserved for MOVE16
+                // cacheline writes). MuGuardianAngel completes an allowed
+                // write by storing WB3D to WB3A, and Enforcer/MuForce discard
+                // a protected store by clearing WB3S.V; RTE (below) honours
+                // the cleared V. Putting the store in WB2 instead makes MuGA
+                // read a zero WB3D and clobber the target with 0.
+                let wb3s = if write {
                     0x0080 | sz | (fc as u16 & 0x7) // V | SZ | TM
                 } else {
                     0
@@ -453,14 +456,14 @@ impl CpuCore {
                 }
                 self.push_32_raw(bus, 0); // WB1D / PD0
                 self.push_32_raw(bus, 0); // WB1A
-                self.push_32_raw(bus, if write { self.pending_fault_wdata } else { 0 }); // WB2D
-                self.push_32_raw(bus, if write { address } else { 0 }); // WB2A
-                self.push_32_raw(bus, 0); // WB3D
-                self.push_32_raw(bus, 0); // WB3A
+                self.push_32_raw(bus, 0); // WB2D
+                self.push_32_raw(bus, 0); // WB2A
+                self.push_32_raw(bus, if write { self.pending_fault_wdata } else { 0 }); // WB3D
+                self.push_32_raw(bus, if write { address } else { 0 }); // WB3A
                 self.push_32_raw(bus, address); // fault address
                 self.push_16_raw(bus, 0); // WB1S
-                self.push_16_raw(bus, wb2s); // WB2S
-                self.push_16_raw(bus, 0); // WB3S
+                self.push_16_raw(bus, 0); // WB2S
+                self.push_16_raw(bus, wb3s); // WB3S
                 self.push_16_raw(bus, ssw); // special status word
                 self.push_32_raw(bus, address); // effective address
                 self.push_16_raw(bus, fmt_vec); // format 7 / vector offset

--- a/crates/m68k/tests/access_fault_frame_tests.rs
+++ b/crates/m68k/tests/access_fault_frame_tests.rs
@@ -164,10 +164,10 @@ const F_PC: u32 = 0x02;
 const F_FMT: u32 = 0x06;
 const F_EA: u32 = 0x08;
 const F_SSW: u32 = 0x0C;
-const F_WB2S: u32 = 0x10;
+const F_WB3S: u32 = 0x0E;
 const F_FA: u32 = 0x14;
-const F_WB2A: u32 = 0x20;
-const F_WB2D: u32 = 0x24;
+const F_WB3A: u32 = 0x18;
+const F_WB3D: u32 = 0x1C;
 
 fn frame_base(cpu: &CpuCore) -> u32 {
     let sp = cpu.a(7);
@@ -216,18 +216,19 @@ fn translation_fault_frame_reports_atc_read_long() {
     assert_eq!(bus.read_long(f + F_PC), CODE, "restart PC");
     assert_eq!(bus.read_word(f + F_SR) & 0x2000, 0, "stacked SR is user");
     assert_eq!(
-        bus.read_word(f + F_WB2S),
+        bus.read_word(f + F_WB3S),
         0,
         "no writeback for a read fault"
     );
 }
 
-/// A faulted write is reported in writeback slot 2: WB2S carries the valid
+/// A faulted write is reported in writeback slot 3: WB3S carries the valid
 /// bit, size, and transfer modifier, with the address and data in
-/// WB2A/WB2D. This is the frame contract Enforcer/MuForce use to report a
-/// hit's data and absorb the store.
+/// WB3A/WB3D (matching real 68040 silicon and the WinUAE reference; WB2 is
+/// reserved for MOVE16). This is the frame contract Enforcer/MuForce use to
+/// report a hit's data and MuGuardianAngel uses to complete the store.
 #[test]
-fn write_fault_frame_carries_writeback_2() {
+fn write_fault_frame_carries_writeback_3() {
     let mut bus = TestBus::new(0x10000);
     let mut cpu = user_mode_040_with_table(&mut bus, 0);
 
@@ -238,20 +239,20 @@ fn write_fault_frame_carries_writeback_2() {
     let f = frame_base(&cpu);
     assert_eq!(bus.read_word(f + F_SSW), 0x0401, "SSW = ATC | write | long");
     assert_eq!(
-        bus.read_word(f + F_WB2S),
+        bus.read_word(f + F_WB3S),
         0x0081,
-        "WB2S = V | SZ=long | TM=user data"
+        "WB3S = V | SZ=long | TM=user data"
     );
-    assert_eq!(bus.read_long(f + F_WB2A), FAULT_PAGE, "writeback address");
-    assert_eq!(bus.read_long(f + F_WB2D), 0x1234_5678, "writeback data");
+    assert_eq!(bus.read_long(f + F_WB3A), FAULT_PAGE, "writeback address");
+    assert_eq!(bus.read_long(f + F_WB3D), 0x1234_5678, "writeback data");
 }
 
-/// A handler that clears WB2S.V has absorbed the faulted write (an
+/// A handler that clears WB3S.V has absorbed the faulted write (an
 /// Enforcer/MuForce hit on a protected page): the restarted instruction
 /// continues past the store without re-faulting, and the page stays
 /// invalid.
 #[test]
-fn rte_with_wb2s_cleared_absorbs_the_faulted_write() {
+fn rte_with_wb3s_cleared_absorbs_the_faulted_write() {
     let mut bus = TestBus::new(0x10000);
     let mut cpu = user_mode_040_with_table(&mut bus, 0);
 
@@ -259,9 +260,9 @@ fn rte_with_wb2s_cleared_absorbs_the_faulted_write() {
     bus.write_word(CODE, 0x2080); // MOVE.L D0,(A0)
     bus.write_word(CODE + 2, 0x4E71); // NOP
 
-    // Handler: CLR.B ($11,A7) (WB2S low byte, V included); RTE.
+    // Handler: CLR.B ($0F,A7) (WB3S low byte, V included); RTE.
     bus.write_word(HANDLER, 0x422F);
-    bus.write_word(HANDLER + 2, (F_WB2S + 1) as u16);
+    bus.write_word(HANDLER + 2, (F_WB3S + 1) as u16);
     bus.write_word(HANDLER + 4, 0x4E73);
 
     // Fault + handler (2) + suppressed rerun + NOP.
@@ -270,10 +271,10 @@ fn rte_with_wb2s_cleared_absorbs_the_faulted_write() {
     assert_eq!(cpu.pc & 0xFFFF, (CODE + 4) & 0xFFFF, "past the NOP");
 }
 
-/// A handler that fixes the mapping and leaves WB2S.V set gets the plain
+/// A handler that fixes the mapping and leaves WB3S.V set gets the plain
 /// restart: the re-executed store lands through the new translation.
 #[test]
-fn rte_with_wb2s_valid_restarts_the_write() {
+fn rte_with_wb3s_valid_restarts_the_write() {
     let mut bus = TestBus::new(0x10000);
     let mut cpu = user_mode_040_with_table(&mut bus, 0);
 


### PR DESCRIPTION
## What

The 68040 access-error stack frame builder pushed a faulted write into
writeback slot 2 (WB2S/WB2A/WB2D), and the RTE handler read the pending
writeback status back from that slot.

Real 68040 silicon and the WinUAE/Amiberry MMU core put a normal write
fault in slot **3**. See Amiberry `src/cpummu.cpp:434`:

```c
regs.wb3_status = write ? 0x80 | (ssw & 0x7f) : 0;
regs.wb3_data = val;
regs.wb2_status = 0;
```

WB2 is reserved for MOVE16 cacheline writes. Frame push order confirmed
at `src/newcpu_common.cpp:1442-1455` (WB3D at +$1C, WB3A at +$18, WB3S
at +$0E).

With the data in the wrong slot, a monitor that completes an allowed
store by copying WB3D to WB3A (MuGuardianAngel) reads a zero WB3D and
clobbers the target with 0.

## Change

- `exceptions.rs`: build the write into slot 3 (WB3S/WB3A/WB3D), clear WB2.
- `decode.rs`: the RTE absorb path reads WB3S/WB3A from +$0E/+$18.
- `access_fault_frame_tests.rs`: updated to assert the slot-3 layout (8 tests pass).

## Scope

This corrects the writeback slot to match the reference; it is **not** a
fix for the separate access-fault continuation issue tracked in #155, and
no functional repro isolates this change from that bug. It stands on the
frame unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
