### PR TITLE
present: black-pad the TV aperture past the framebuffer edge

### DIFF
--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -82,11 +82,12 @@ pub fn save_scaled_y(
     save(path, &scaled, width, out_height)
 }
 
-/// Save a rectangular viewport from `fb`, clamping source coordinates at the
-/// source edges. The clamp lets a presentation aperture extend slightly beyond
-/// the emulated capture buffer while preserving the captured border colour at
-/// the edge.
-pub fn save_cropped_clamped(
+/// Save a rectangular viewport from `fb`, rendering viewport pixels that fall
+/// outside the source as opaque black. A presentation aperture may extend
+/// slightly beyond the emulated capture buffer; the uncaptured margin is
+/// bezel, not picture, so replicating edge pixels there would fabricate
+/// content whenever the display fetches into the deepest overscan.
+pub fn save_cropped_black_padded(
     path: &Path,
     fb: &[u32],
     src_width: usize,
@@ -96,11 +97,11 @@ pub fn save_cropped_clamped(
     width: usize,
     height: usize,
 ) -> Result<()> {
-    let cropped = crop_clamped(fb, src_width, src_height, x, y, width, height)?;
+    let cropped = crop_black_padded(fb, src_width, src_height, x, y, width, height)?;
     save(path, &cropped, width as u32, height as u32)
 }
 
-fn crop_clamped(
+fn crop_black_padded(
     fb: &[u32],
     src_width: usize,
     src_height: usize,
@@ -123,14 +124,17 @@ fn crop_clamped(
         anyhow::bail!("invalid crop dimensions");
     }
 
-    let mut cropped = vec![0; width * height];
+    // Opaque black in the fb's R,G,B,A memory order.
+    const BLACK: u32 = 0xFF00_0000;
+    let mut cropped = vec![BLACK; width * height];
+    let copy_w = width.min(src_width.saturating_sub(x));
     for dst_y in 0..height {
-        let src_y = (y + dst_y).min(src_height - 1);
-        let dst = &mut cropped[dst_y * width..(dst_y + 1) * width];
-        for (dst_x, pixel) in dst.iter_mut().enumerate() {
-            let src_x = (x + dst_x).min(src_width - 1);
-            *pixel = fb[src_y * src_width + src_x];
+        let src_y = y + dst_y;
+        if src_y >= src_height {
+            break;
         }
+        let src_row = &fb[src_y * src_width..src_y * src_width + x + copy_w];
+        cropped[dst_y * width..dst_y * width + copy_w].copy_from_slice(&src_row[x..]);
     }
     Ok(cropped)
 }
@@ -215,12 +219,16 @@ mod tests {
     }
 
     #[test]
-    fn cropped_clamped_view_extends_edge_pixels() -> Result<()> {
+    fn cropped_view_black_pads_outside_source() -> Result<()> {
         let fb = vec![1, 2, 3, 4, 5, 6];
+        const BLACK: u32 = 0xFF00_0000;
 
-        let cropped = crop_clamped(&fb, 3, 2, 1, 0, 4, 2)?;
+        let cropped = crop_black_padded(&fb, 3, 2, 1, 0, 4, 3)?;
 
-        assert_eq!(cropped, vec![2, 3, 3, 3, 5, 6, 6, 6]);
+        assert_eq!(
+            cropped,
+            vec![2, 3, BLACK, BLACK, 5, 6, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK]
+        );
         Ok(())
     }
 }

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -457,7 +457,12 @@ pub(super) fn copy_tv_aperture_to_window(
     let dst_stride = texture_width(texture_scale) * 4;
     let present_rows = present_height();
     let out_rows = present_rows * texture_scale;
-    let black = rgba(0, 0, 0).to_le_bytes();
+    // The aperture reaches a few columns past the framebuffer's right edge;
+    // that uncaptured margin is bezel and must stay black rather than
+    // replicate the edge column (which carries picture when a display
+    // fetches into the deepest overscan).
+    let black_px = rgba(0, 0, 0);
+    let black = black_px.to_le_bytes();
     for y in 0..out_rows {
         let Some(crop_y) = tv_aperture_source_row(y, present_rows, texture_scale) else {
             let dst = &mut frame[y * dst_stride..(y + 1) * dst_stride];
@@ -476,8 +481,13 @@ pub(super) fn copy_tv_aperture_to_window(
                     let crop_x = x
                         .saturating_sub(TV_PAL_LIVE_PAD_X)
                         .min(TV_PAL_PRESENT_WIDTH - 1);
-                    let src_x = (TV_PAL_PRESENT_SOURCE_X + crop_x).min(FB_WIDTH - 1);
-                    dst[x * 4..x * 4 + 4].copy_from_slice(&row[src_x].to_le_bytes());
+                    let src_x = TV_PAL_PRESENT_SOURCE_X + crop_x;
+                    let pixel = if src_x < FB_WIDTH {
+                        row[src_x]
+                    } else {
+                        black_px
+                    };
+                    dst[x * 4..x * 4 + 4].copy_from_slice(&pixel.to_le_bytes());
                 }
             }
             2 => {
@@ -485,8 +495,12 @@ pub(super) fn copy_tv_aperture_to_window(
                     let crop_x = x
                         .saturating_sub(TV_PAL_LIVE_PAD_X)
                         .min(TV_PAL_PRESENT_WIDTH - 1);
-                    let src_x = (TV_PAL_PRESENT_SOURCE_X + crop_x).min(FB_WIDTH - 1);
-                    let pixel = row[src_x];
+                    let src_x = TV_PAL_PRESENT_SOURCE_X + crop_x;
+                    let pixel = if src_x < FB_WIDTH {
+                        row[src_x]
+                    } else {
+                        black_px
+                    };
                     let pair = pixel as u64 | ((pixel as u64) << 32);
                     unsafe {
                         (frame.as_mut_ptr().add(dst_off + x * 8) as *mut u64).write_unaligned(pair);
@@ -500,8 +514,13 @@ pub(super) fn copy_tv_aperture_to_window(
                     let crop_x = out_x
                         .saturating_sub(TV_PAL_LIVE_PAD_X)
                         .min(TV_PAL_PRESENT_WIDTH - 1);
-                    let src_x = (TV_PAL_PRESENT_SOURCE_X + crop_x).min(FB_WIDTH - 1);
-                    dst[x * 4..x * 4 + 4].copy_from_slice(&row[src_x].to_le_bytes());
+                    let src_x = TV_PAL_PRESENT_SOURCE_X + crop_x;
+                    let pixel = if src_x < FB_WIDTH {
+                        row[src_x]
+                    } else {
+                        black_px
+                    };
+                    dst[x * 4..x * 4 + 4].copy_from_slice(&pixel.to_le_bytes());
                 }
             }
         }
@@ -799,7 +818,7 @@ pub(super) fn save_present_frame(
     }
 
     if overscan == Overscan::Tv && standard_tv_aperture {
-        return screenshot::save_cropped_clamped(
+        return screenshot::save_cropped_black_padded(
             path,
             present_fb,
             FB_WIDTH,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1258,10 +1258,45 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
         right_marker.to_le_bytes()
     );
     assert_eq!(pixel(&frame, 0, 0, scale), left_edge.to_le_bytes());
+    let dst_fb_right = TV_PAL_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PAL_PRESENT_SOURCE_X);
     assert_eq!(
-        pixel(&frame, FB_WIDTH - 1, 0, scale),
+        pixel(&frame, dst_fb_right, 0, scale),
         right_edge.to_le_bytes()
     );
+}
+
+#[test]
+fn tv_window_copy_black_pads_aperture_past_framebuffer() {
+    use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
+    // The aperture reaches a few columns past the framebuffer's right edge.
+    // A display fetching into the deepest right overscan fills the
+    // framebuffer's last column; the uncaptured aperture columns are bezel
+    // and must stay black instead of replicating that edge column into
+    // horizontal streaks (Gen-X logo slide-in).
+    let black = rgba(0, 0, 0).to_le_bytes();
+    for scale in 1..=3 {
+        let mut src = vec![0u32; OUT_PIXELS];
+        let row_y = TV_PAL_PRESENT_SOURCE_Y;
+        let edge = 0xDDEE_FF00u32;
+        src[row_y * FB_WIDTH + FB_WIDTH - 1] = edge;
+
+        let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+        copy_window_present_frame(&src, OUT_HEIGHT, &mut frame, scale, Overscan::Tv, true);
+
+        let dst_fb_right = TV_PAL_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PAL_PRESENT_SOURCE_X);
+        assert_eq!(
+            pixel(&frame, dst_fb_right * scale, 0, scale),
+            edge.to_le_bytes(),
+            "scale {scale}: framebuffer edge column should stay visible"
+        );
+        for x in (dst_fb_right + 1) * scale..FB_WIDTH * scale {
+            assert_eq!(
+                pixel(&frame, x, 0, scale),
+                black,
+                "scale {scale}: aperture past the framebuffer must be black at {x}"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

During Gen-X's logo slide-in, horizontal drag lines of the logo's right-edge pixels appeared at the far right of the window (reported from a live session; state `copperline-state-20260711063125.clstate`).

Two layers to the diagnosis:

1. **The emulation is correct.** The demo never erases behind the strip's trailing edge, leaving an authentic blit-residue trail in the right overscan. Copperline's rendering of the whole strip + trail region is pixel-identical to a vAmiga 4.4 reference (0.000% diff over the strip region, after normalising the two emulators' 4-bit colour expansions).

2. **The visible streaks were a presentation bug.** The TV aperture is 692 columns anchored at framebuffer x=36, so its last 12 columns reach past the 716-wide framebuffer. Both the live window copy (`copy_tv_aperture_to_window`) and the presentation screenshot crop clamped the source column with `.min(FB_WIDTH - 1)`, replicating the framebuffer's last column across those presented columns. That column is normally black, but this scene fetches into the deepest right overscan mid-slide (content reaches fb columns 711–715 with no recentring shift, as true overscan is presented unshifted), so each row's edge pixel smeared into a 12-px horizontal streak. Signature confirmed on the reported screenshot: presented columns 679–691 exactly constant on all 540 rows.

## Fix

Render the uncaptured aperture margin as opaque black bezel instead of replicating the edge column:

- `copy_tv_aperture_to_window`: all three texture-scale arms output black for source columns past the framebuffer.
- `screenshot::save_cropped_clamped` → `save_cropped_black_padded`: viewport pixels outside the source are opaque black (only caller was the TV-aperture screenshot path).

The framebuffer's real last column stays visible at its true aperture position (presented column 679); only the fabricated repeats beyond it become bezel.

## Testing

- New: `tv_window_copy_black_pads_aperture_past_framebuffer` (texture scales 1–3), `cropped_view_black_pads_outside_source`.
- Updated: `tv_window_copy_centres_reference_aperture_in_live_texture` had encoded the old clamp (fb edge pixel asserted at the texture's last column); it now asserts the edge pixel at its true aperture position.
- Full `cargo test --release` passes including the golden-render suite (no goldens changed — standard displays never reach the clamp zone); clippy and fmt clean.
- End-to-end: re-dumped the previously-streaked Gen-X frames; presented columns 680–691 are pure black on every frame while column 679 keeps its captured trail content mid-slide.