### PR TITLE
Fix the frame spikes and render-thread saturation behind issue #99

### DIFF
--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -43,6 +43,10 @@ pub(super) struct DdfSeqLine {
     pub modulo_at: [bool; DDF_SEQ_MAX_LINE_CCKS],
     /// Words each plane fetches over the whole line.
     pub words_per_plane: [u16; 8],
+    /// Highest per-plane word count (the capture row width).
+    pub words_per_row: u16,
+    /// DMA plane count implied by the table (highest plane with a slot).
+    pub dma_planes: u8,
     /// The fetching plane's word ordinal at each slot colour clock (holes
     /// keep their position when DMA enables mid-line: the ordinal counts
     /// table slots, and unfetched earlier slots stay zero words).
@@ -247,6 +251,8 @@ impl Bus {
             plane_at: [0; DDF_SEQ_MAX_LINE_CCKS],
             modulo_at: [false; DDF_SEQ_MAX_LINE_CCKS],
             words_per_plane: [0; 8],
+            words_per_row: 0,
+            dma_planes: 0,
             word_idx_at: [0; DDF_SEQ_MAX_LINE_CCKS],
             first_fetch_cck: None,
             run_origin_cck: None,
@@ -281,6 +287,8 @@ impl Bus {
                 }
             }
         }
+        line.words_per_row = line.words_per_plane.iter().copied().max().unwrap_or(0);
+        line.dma_planes = line.plane_at.iter().copied().max().unwrap_or(0);
         line
     }
 
@@ -420,14 +428,21 @@ impl Bus {
             // must not skew the visible rows' pointer progression).
             return;
         };
-        let (plane_at, modulo_at, word_idx_at, words_per_row, run_origin) = {
+        // This runs on every chip-bus quantum (a single colour clock), so the
+        // table stays behind its borrow: copying the ~1KB slot arrays out per
+        // quantum was a measured hot spot, dominated by blank lines that then
+        // fetched nothing. The line-constant aggregates are precomputed at
+        // build time; a mid-loop re-borrow rebuilds from unchanged inputs, so
+        // it yields the same table.
+        let end = new_hpos.min(DDF_SEQ_MAX_LINE_CCKS as u32);
+        let (words_per_row, dma_planes, run_origin) = {
             let table = self.ddf_seq_line_table();
-            let wpr = table.words_per_plane.iter().copied().max().unwrap_or(0) as usize;
+            if !(old_hpos..end).any(|hpos| table.plane_at[hpos as usize] != 0) {
+                return;
+            }
             (
-                table.plane_at,
-                table.modulo_at,
-                table.word_idx_at,
-                wpr,
+                usize::from(table.words_per_row),
+                usize::from(table.dma_planes),
                 table.run_origin_cck,
             )
         };
@@ -435,23 +450,27 @@ impl Bus {
             return;
         }
         let addr_mask = self.chip_dma_mask;
-        let end = new_hpos.min(DDF_SEQ_MAX_LINE_CCKS as u32);
         let mut slots = 0usize;
         let mut rows_started = 0usize;
         for hpos in old_hpos..end {
-            let slot = plane_at[hpos as usize];
-            if slot == 0 {
-                continue;
-            }
-            let plane = usize::from(slot - 1);
+            let (plane, word_idx, apply_modulo) = {
+                let table = self.ddf_seq_line_table();
+                let slot = table.plane_at[hpos as usize];
+                if slot == 0 {
+                    continue;
+                }
+                (
+                    usize::from(slot - 1),
+                    usize::from(table.word_idx_at[hpos as usize]),
+                    table.modulo_at[hpos as usize],
+                )
+            };
             if plane == 0 {
                 self.record_sprite_display_enable_for_bitplane_dma(vpos);
             }
-            let word_idx = usize::from(word_idx_at[hpos as usize]);
             let addr = self.display_dma_bplpt[plane] & addr_mask;
             let fetched = read_chip_word_wrapping(&self.mem.chip_ram, addr);
             self.data_bus = fetched;
-            let dma_planes = plane_count_from_table(&plane_at);
             if self.capture_bitplane_fetch_word(
                 fb_y,
                 display_planes,
@@ -466,7 +485,7 @@ impl Bus {
             self.denise.write_bpldat(plane, fetched);
             self.display_dma_bplpt[plane] =
                 self.display_dma_bplpt[plane].wrapping_add(2) & addr_mask;
-            if modulo_at[hpos as usize] {
+            if apply_modulo {
                 let modulo = self.display_dma_modulo_for_plane(plane, vpos);
                 self.display_dma_bplpt[plane] =
                     ((self.display_dma_bplpt[plane] as i64).wrapping_add(modulo as i64) as u32)
@@ -513,11 +532,6 @@ impl Bus {
         self.ddf_seq_writes.borrow_mut().clear();
         self.ddf_seq_invalidate_line();
     }
-}
-
-/// DMA plane count implied by the walked table (highest plane with a slot).
-fn plane_count_from_table(plane_at: &[u8; DDF_SEQ_MAX_LINE_CCKS]) -> usize {
-    plane_at.iter().copied().max().unwrap_or(0) as usize
 }
 
 #[cfg(test)]

--- a/src/chipset/denise.rs
+++ b/src/chipset/denise.rs
@@ -164,11 +164,22 @@ impl Palette {
     /// renderer's palette diffs.
     pub fn write_entry(&mut self, entry: usize, loct: bool, value: u16) {
         let entry = entry & (PALETTE_ENTRIES - 1);
-        if loct {
-            self.lo[entry] = value & COLOR_RGB_MASK;
-        } else {
-            self.hi[entry] = value & COLOR_REGISTER_MASK;
-            self.lo[entry] = value & COLOR_RGB_MASK;
+        let mut view = PaletteEntry {
+            hi: self.hi[entry],
+            lo: self.lo[entry],
+        };
+        view.write(loct, value);
+        self.hi[entry] = view.hi;
+        self.lo[entry] = view.lo;
+    }
+
+    /// One entry's nibble planes, for callers that sample a single colour
+    /// without materializing a whole palette.
+    pub fn entry(&self, entry: usize) -> PaletteEntry {
+        let entry = entry & (PALETTE_ENTRIES - 1);
+        PaletteEntry {
+            hi: self.hi[entry],
+            lo: self.lo[entry],
         }
     }
 
@@ -204,9 +215,39 @@ impl Palette {
     /// low nibble planes.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn rgb24(&self, entry: usize) -> u32 {
-        let entry = entry & (PALETTE_ENTRIES - 1);
-        let hi = u32::from(self.hi[entry]);
-        let lo = u32::from(self.lo[entry]);
+        self.entry(entry).rgb24()
+    }
+}
+
+/// One [`Palette`] entry's nibble planes, sampled and written with the same
+/// semantics as the full palette. Lets per-pixel colour resolution work on
+/// four bytes instead of copying the 1KB palette.
+#[derive(Clone, Copy)]
+pub struct PaletteEntry {
+    hi: u16,
+    lo: u16,
+}
+
+impl PaletteEntry {
+    /// The OCS-layout high word: what indexing the full palette reads.
+    pub fn latch(self) -> u16 {
+        self.hi
+    }
+
+    /// Same masking as [`Palette::write_entry`], applied to this entry.
+    pub fn write(&mut self, loct: bool, value: u16) {
+        if loct {
+            self.lo = value & COLOR_RGB_MASK;
+        } else {
+            self.hi = value & COLOR_REGISTER_MASK;
+            self.lo = value & COLOR_RGB_MASK;
+        }
+    }
+
+    /// Same composition as [`Palette::rgb24`], for this entry.
+    pub fn rgb24(self) -> u32 {
+        let hi = u32::from(self.hi);
+        let lo = u32::from(self.lo);
         let t = (hi & u32::from(COLOR_TRANSPARENCY_BIT)) << 16;
         let r = ((hi >> 8) & 0xF) << 20 | ((lo >> 8) & 0xF) << 16;
         let g = ((hi >> 4) & 0xF) << 12 | ((lo >> 4) & 0xF) << 8;

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,8 +891,11 @@ fn run_headless_benchmark(mut emu: Emulator, target_secs: f32) -> Result<()> {
 
     let start_frames = emu.bus().emulated_frames();
     let started = Instant::now();
+    let mut frame_times: Vec<f64> = Vec::new();
     while emu.bus().emulated_seconds() < target_secs {
+        let frame_started = Instant::now();
         emu.step_frame()?;
+        frame_times.push(frame_started.elapsed().as_secs_f64() * 1_000.0);
     }
     let elapsed = started.elapsed().as_secs_f64();
     let frames = emu.bus().emulated_frames().saturating_sub(start_frames);
@@ -905,10 +908,60 @@ fn run_headless_benchmark(mut emu: Emulator, target_secs: f32) -> Result<()> {
         frames,
         frames as f64 / elapsed.max(f64::EPSILON)
     );
+    report_benchmark_frame_times(start_frames, &frame_times);
     emu.report_stats();
     // Evaluate an untargeted reverse watchpoint at the benchmark's end.
     emu.tt_finalize_reverse_watch()?;
     Ok(())
+}
+
+/// A frame slower than this stalls the audio ring on a PAL host (50 Hz = 20 ms
+/// per frame, minus headroom for the window render path).
+const BENCH_FRAME_BUDGET_MS: f64 = 20.0;
+
+/// Summarize the per-frame wall times of a `--benchmark-until` run: the
+/// distribution, and every frame that individually blew the audio budget.
+/// Averages hide these spikes, and a single late frame is an audible underrun.
+fn report_benchmark_frame_times(start_frame: u64, frame_times: &[f64]) {
+    if frame_times.is_empty() {
+        return;
+    }
+    let mut sorted: Vec<f64> = frame_times.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let pct = |p: f64| sorted[((sorted.len() - 1) as f64 * p) as usize];
+    info!(
+        "benchmark frame times: p50={:.2}ms p90={:.2}ms p99={:.2}ms max={:.2}ms",
+        pct(0.50),
+        pct(0.90),
+        pct(0.99),
+        sorted[sorted.len() - 1]
+    );
+    let over: Vec<(usize, f64)> = frame_times
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|&(_, ms)| ms > BENCH_FRAME_BUDGET_MS)
+        .collect();
+    if over.is_empty() {
+        info!(
+            "benchmark frame times: all {} frames within the {:.0}ms budget",
+            frame_times.len(),
+            BENCH_FRAME_BUDGET_MS
+        );
+        return;
+    }
+    info!(
+        "benchmark frame times: {} of {} frames over the {:.0}ms budget:",
+        over.len(),
+        frame_times.len(),
+        BENCH_FRAME_BUDGET_MS
+    );
+    for (idx, ms) in over.iter().take(50) {
+        info!("  frame {} ({:.2}ms)", start_frame + *idx as u64, ms);
+    }
+    if over.len() > 50 {
+        info!("  ... and {} more", over.len() - 50);
+    }
 }
 
 /// Whether to open a live audio sink. `[audio] output_enabled = false` (the GUI

--- a/src/video/bitplane/output.rs
+++ b/src/video/bitplane/output.rs
@@ -17,6 +17,29 @@ pub(super) fn palette_at_x(mut palette: Palette, segments: &[PaletteSegment], x:
     palette
 }
 
+/// One palette entry at horizontal position `x`: the base palette's entry
+/// with the row's segment writes to that entry up to `x` applied. The sprite
+/// pixel loops resolve exactly one colour per pixel, so sampling that entry
+/// alone avoids copying the whole 1KB palette per pixel (a measured render
+/// hot spot on sprite-multiplexing games).
+pub(super) fn palette_entry_at_x(
+    palette: &Palette,
+    segments: &[PaletteSegment],
+    x: usize,
+    entry: usize,
+) -> crate::chipset::denise::PaletteEntry {
+    let mut out = palette.entry(entry);
+    for seg in segments {
+        if seg.x > x {
+            break;
+        }
+        if usize::from(seg.entry) == entry & (crate::chipset::denise::PALETTE_ENTRIES - 1) {
+            out.write(seg.loct, seg.value);
+        }
+    }
+    out
+}
+
 pub(super) fn control_at_x(
     mut control: ControlState,
     segments: &[ControlSegment],

--- a/src/video/bitplane/sprite.rs
+++ b/src/video/bitplane/sprite.rs
@@ -862,11 +862,13 @@ pub(super) fn render_sprites_with_manual_lines_and_writes(
         let odd_sprite = even_sprite + 1;
         let even_lines = &sprite_lines[even_sprite];
         let odd_lines = &sprite_lines[odd_sprite];
+        let attached_beams = pair_attached_beams(even_lines, odd_lines);
 
         clxdat |= render_attached_sprite_pair_lines(
             even_sprite,
             even_lines,
             odd_lines,
+            &attached_beams,
             fb,
             clip,
             base_palettes,
@@ -883,6 +885,7 @@ pub(super) fn render_sprites_with_manual_lines_and_writes(
             even_sprite,
             even_lines,
             odd_lines,
+            &attached_beams,
             fb,
             clip,
             base_palettes,
@@ -899,10 +902,27 @@ pub(super) fn render_sprites_with_manual_lines_and_writes(
     clxdat
 }
 
+/// The sorted, deduplicated beam lines on which this sprite pair has an
+/// attached line. Computed once per pair: the per-line attach test is a
+/// binary search here instead of a rescan of every line of the pair
+/// (quadratic on sprite-multiplexing games, a measured render hot spot).
+pub(super) fn pair_attached_beams(even_lines: &[SpriteLine], odd_lines: &[SpriteLine]) -> Vec<i32> {
+    let mut beams: Vec<i32> = even_lines
+        .iter()
+        .chain(odd_lines.iter())
+        .filter(|line| line.attached)
+        .map(|line| line.beam_y)
+        .collect();
+    beams.sort_unstable();
+    beams.dedup();
+    beams
+}
+
 pub(super) fn render_unattached_sprite_pair_lines(
     even_sprite: usize,
     even_lines: &[SpriteLine],
     odd_lines: &[SpriteLine],
+    attached_beams: &[i32],
     fb: &mut [u32],
     clip: SpriteClip,
     base_palettes: &[Palette],
@@ -920,7 +940,7 @@ pub(super) fn render_unattached_sprite_pair_lines(
     clxdat |= render_collected_sprite_lines(
         odd_sprite,
         odd_lines,
-        |line| !sprite_pair_attach_active_for_beam(even_lines, odd_lines, line.beam_y),
+        |line| attached_beams.binary_search(&line.beam_y).is_err(),
         fb,
         clip,
         base_palettes,
@@ -934,7 +954,7 @@ pub(super) fn render_unattached_sprite_pair_lines(
         visible_line0,
     );
     for even in even_lines {
-        if sprite_pair_attach_active_for_beam(even_lines, odd_lines, even.beam_y) {
+        if attached_beams.binary_search(&even.beam_y).is_ok() {
             continue;
         }
         clxdat |= draw_sprite_line(
@@ -1003,6 +1023,7 @@ pub(super) fn render_attached_sprite_pair_lines(
     even_sprite: usize,
     even_lines: &[SpriteLine],
     odd_lines: &[SpriteLine],
+    attached_beams: &[i32],
     fb: &mut [u32],
     clip: SpriteClip,
     base_palettes: &[Palette],
@@ -1016,16 +1037,7 @@ pub(super) fn render_attached_sprite_pair_lines(
     visible_line0: i32,
 ) -> u16 {
     let mut clxdat = 0u16;
-    let mut beams: Vec<i32> = even_lines
-        .iter()
-        .chain(odd_lines.iter())
-        .filter(|line| line.attached)
-        .map(|line| line.beam_y)
-        .collect();
-    beams.sort_unstable();
-    beams.dedup();
-
-    for beam_y in beams {
+    for &beam_y in attached_beams {
         let y = beam_y - visible_line0;
         if y < 0 || y >= base_controls.len() as i32 {
             continue;
@@ -1099,12 +1111,13 @@ pub(super) fn render_attached_sprite_pair_lines(
             if sprite_mask & (0b11 << even_sprite) != 0b11 << even_sprite {
                 continue;
             }
-            let palette = palette_at_x(base_palettes[y], &palette_segments[y], x_usize);
             let color_idx = sprite_color_entry(control, even_sprite, idx, true);
-            let color_latch = palette[color_idx];
+            let entry =
+                palette_entry_at_x(&base_palettes[y], &palette_segments[y], x_usize, color_idx);
+            let color_latch = entry.latch();
             let transparent = control.genlock_transparent(color_latch, None, false);
             let color = if control.aga() {
-                palette.rgb24(color_idx) & 0x00FF_FFFF
+                entry.rgb24() & 0x00FF_FFFF
             } else {
                 rgb12_to_rgb24(color_rgb12(color_latch))
             };
@@ -1334,11 +1347,12 @@ pub(super) fn draw_sprite_line(
                     continue;
                 }
                 let color_idx = sprite_color_entry(control, sprite, idx, false);
-                let palette = palette_at_x(base_palettes[y], &palette_segments[y], x);
-                let color_latch = palette[color_idx];
+                let entry =
+                    palette_entry_at_x(&base_palettes[y], &palette_segments[y], x, color_idx);
+                let color_latch = entry.latch();
                 let transparent = control.genlock_transparent(color_latch, None, false);
                 let color = if control.aga() {
-                    palette.rgb24(color_idx) & 0x00FF_FFFF
+                    entry.rgb24() & 0x00FF_FFFF
                 } else {
                     rgb12_to_rgb24(color_rgb12(color_latch))
                 };


### PR DESCRIPTION
Part of #99 (performance). The crash and gfx legs are already fixed (#153, #162); this addresses the sound stalls / cpal underruns on i5-class machines, reproduced and profiled on a 10th-gen-i5-class test machine with a save state taken while the Jim Power intro loads.

## Fixes

- **bus: stop copying the DDF fetch table out per colour clock.** `capture_bitplane_dma_words_fsm` copied ~1KB of walked-table arrays out of the cache on every single-cck bus quantum, before its nothing-to-fetch early-out, plus a 232-byte plane rescan per fetched word. Line-constant aggregates are now precomputed at table build and slots resolved through the cached borrow.
- **render: sample one palette entry per sprite pixel.** `palette_at_x` copied the 1KB `Palette` by value per sprite pixel to read a single entry. New `Palette::entry()` / `PaletteEntry` view with identical write/rgb24 semantics (the full-palette paths delegate to it).
- **render: precompute per-pair attached beams.** The unattached sprite pass called `sprite_pair_attach_active_for_beam` per line, rescanning every line of the pair — quadratic on sprite multiplexers (Jim Power: ~3300 sprite lines/frame). Now a sorted beam list built once per pair, binary-searched per line.
- **benchmark: per-frame wall-time distribution.** `--benchmark-until` now reports p50/p90/p99/max frame times and lists frames over the 20 ms audio budget — averages hid these spikes; this is the instrumentation that exposed them.

## Results (Jim Power state, this machine)

| metric | before | after |
|---|---|---|
| loading benchmark throughput | 54.7 f/s | ~90 f/s |
| worst core frame | 100.8 ms | 16.1 ms |
| frames over 20 ms budget (74 s span) | 66+ | 0 |
| sprite render phase (2937 frames) | 41.1 s | 4.7 s |
| total render per frame | 18.9 ms | 5.6 ms |
| cpal underruns, 90 s live run | continuous | 1 (startup transient) |

## Verification

- Full test suite passes.
- `--dump-frames` PNG hashes byte-identical to pre-change baselines in the loading window (17 s, 28 s) and the sprite-heavy demo window (52 s, 68 s).
- 90 s live windowed run with audio: steady state clean after the ~5 s post-state-load warmup.

Known remaining hotspots, deliberately out of scope: floppy deferred-tick fixed overhead (~8%, loading only, where headroom is now largest) and the playfield render phase (~3.2 ms/frame, already ~26 ns/px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)