### PR TITLE
video: do not synthesize a picture for a line whose fetch never ran

### DIFF
--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -10012,6 +10012,87 @@ fn render_input_refill_from_bus_matches_fresh_snapshot() {
 }
 
 #[test]
+fn line_without_captured_fetch_paints_no_playfield() {
+    // Agnus arms a line's fetch run at the DDFSTRT comparator match; a
+    // BPLCON0 raised mid-line only after that point starts no run until the
+    // next line. The DMA capture records which lines ran, so a line with no
+    // captured fetch fetched nothing and the renderer must not synthesize a
+    // picture for it from the register-derived window (regression: the
+    // Rampage bottom-scroller band entry painted a phantom, word-skewed
+    // copy of the first bitmap row one line above the real first fetch row).
+    let mut bus = empty_bus();
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x2FC1;
+    bus.denise.ddfstrt = 0x0038;
+    bus.denise.ddfstop = 0x00D0;
+    bus.denise.bplcon0 = 0x1000;
+    bus.denise.palette.write_ocs(1, 0x0FFF);
+    bus.denise.bplpt[0] = 0x0100;
+    let words_per_row = bitplane_words_per_row(
+        bus.agnus.revision(),
+        bus.denise.bplcon0,
+        bus.agnus.fmode(),
+        bus.denise.ddfstrt,
+        bus.denise.ddfstop,
+        bus.harddis_active(),
+    );
+    // Non-zero bitmap behind the pointer so a synthesized re-fetch of the
+    // uncaptured line would visibly paint.
+    for word in 0..words_per_row {
+        write_chip_word(&mut bus, 0x0100 + word * 2, 0xFFFF);
+    }
+    bus.current_frame_render_base = bus.capture_render_snapshot();
+    let captured_row = || {
+        Some(CapturedBitplaneRow {
+            nplanes: 1,
+            words_per_row,
+            fetch_origin_cck: None,
+            planes: std::array::from_fn(|plane| {
+                if plane == 0 {
+                    vec![0xFFFF; words_per_row]
+                } else {
+                    vec![0; words_per_row]
+                }
+            }),
+        })
+    };
+
+    let lit_rows = |fb: &[u32]| -> Vec<usize> {
+        let background = fb[0];
+        (0..FB_HEIGHT)
+            .filter(|row| {
+                fb[row * FB_WIDTH..(row + 1) * FB_WIDTH]
+                    .iter()
+                    .any(|&px| px != background)
+            })
+            .collect()
+    };
+
+    // Only line 1 recorded a fetch: line 0's sequencer never ran.
+    bus.current_frame_bitplane_rows[1] = captured_row();
+    let mut fb_skipped = vec![0u32; FB_PIXELS];
+    bitplane::render_from_input(&bitplane::RenderInput::from_bus(&bus), &mut fb_skipped);
+
+    // Both lines recorded fetches: shows where line 0's picture would sit.
+    bus.current_frame_bitplane_rows[0] = captured_row();
+    let mut fb_both = vec![0u32; FB_PIXELS];
+    bitplane::render_from_input(&bitplane::RenderInput::from_bus(&bus), &mut fb_both);
+
+    let skipped = lit_rows(&fb_skipped);
+    let both = lit_rows(&fb_both);
+    assert!(!skipped.is_empty(), "the captured line must paint");
+    assert!(
+        both.first() < skipped.first(),
+        "the two-capture render must start a line above ({both:?} vs {skipped:?})"
+    );
+    assert!(
+        skipped.iter().all(|row| both.contains(row)),
+        "the uncaptured line must not add pixels of its own"
+    );
+}
+
+#[test]
 fn beam_trap_fires_at_exact_position_and_one_shot_disarms() {
     let mut bus = empty_bus();
     // From power-on the beam sits at (0, 0). A one-shot trap two lines

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3807,6 +3807,25 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
             if captured_row.is_none() && !control.bitplane_dma_enabled() {
                 continue;
             }
+            // The DMA capture is the authority for whether the bitplane
+            // sequencer ran on a line. A line with no captured fetch at all
+            // fetched nothing - e.g. BPLCON0 raised mid-line only after the
+            // line's DDFSTRT comparator had already passed (the Rampage
+            // bottom-scroller band entry), where Agnus starts no run until
+            // the next line. Synthesizing a picture from the register-derived
+            // window would paint a phantom row that hardware never fetched.
+            // (A captured row that merely disagrees with the register-derived
+            // geometry still takes the re-fetch path below; frames rendered
+            // without any capture - COPPERLINE_RENDER_LIVE_CHIP_RAM - keep
+            // the synthesized path.)
+            if has_captured_bitplane_rows
+                && captured_bitplane_rows
+                    .get(y)
+                    .and_then(Option::as_ref)
+                    .is_none()
+            {
+                continue;
+            }
             // A DDFSTRT comparator below the hardwired start window ($18)
             // only arms a run when the sequencer's SHW latch survived from
             // the previous line (OCS clears it when a fetch run completes,


### PR DESCRIPTION
## Problem

In the Rampage (TEK, 1994) end scroller, a row of bright, word-skewed dots appears one line above the big letters (reported with `copperline-state-20260711154559.clstate` / the matching screenshot).

The demo's copper list turns the display off (`BPLCON0=$0000`) at line 227, then at `WAIT v248,h14` re-points BPLxPT at the scroller bitmap, rewrites DDFSTRT `$38->$28` (landing ~h42, after the line's comparator point at h40 has passed), and re-enables `BPLCON0=$3200` (~h50). Agnus therefore starts no fetch run on line 248; the first bitmap row is fetched on line 249, and the letters start at 250.

Copperline's DMA side models this correctly - the slot map shows zero bitplane slots on line 248 and a full 69-slot run on 249. But the renderer's legacy register-derived fallback (used when a line has no captured DMA row) synthesized a fetch for line 248 anyway, painting a phantom copy of bitmap row 0 with per-plane word skew (planes 1+3 shifted +16 lores px, plane 2 +32 px - the pattern of joining the lores fetch unit mid-way).

## Fix

Gate the synthesized re-fetch path on the DMA capture: when the frame carries captured bitplane rows, a line whose capture slot is empty fetched nothing and paints no playfield.

- A captured row that merely disagrees with the register-derived geometry (mid-row rewrites) still takes the re-fetch path as before.
- Frames rendered without any capture (`COPPERLINE_RENDER_LIVE_CHIP_RAM`) keep the synthesized path.
- This generalizes the capture-authority rule the sub-$18 DDFSTRT gate (vAmigaTS Agnus/DDF oldhwstop3/4) already applied.

The remaining faint dot row on line 249 is authentic: the demo's scroller ring buffer carries stray bits in its first bitmap row (identical across all three planes, scrolling along with the letters), and the real fetch displays them. vAmiga could not be used as a cross-check for this scene - VAHeadless sticks on the demo's dunes scene from ~350s and never reaches the scroller.

## Verification

- New regression test `bus::tests::line_without_captured_fetch_paints_no_playfield` - fails without the gate, passes with it.
- Full `cargo test --release` green, including the golden probe render suite (goldens unchanged, no re-bless).
- Rampage scene at 424.5s: full-frame diff against the previous build is exactly the 36 phantom pixels on the one row; the letters and the authentic row are untouched.
- gen-x at 80s and 150s (mid-line BPLCON0 stress cases): byte-identical screenshots before/after.
- `cargo clippy` and `cargo fmt --check` clean.