### PR TITLE
blitter: a blit with no channels enabled asserts no BLTPRI CPU fence

### DIFF
--- a/src/chipset/blitter.rs
+++ b/src/chipset/blitter.rs
@@ -1686,8 +1686,15 @@ impl NormalBlitState {
     /// the hold register. That covers the first-word pipeline bubble; from
     /// the second word on, bus-free micro-cycles release the request line.
     /// The terminal E/F cycles are past the fence: BBUSY has already
-    /// dropped at the last body cycle.
+    /// dropped at the last body cycle. A blit with NO channels enabled
+    /// never asserts a bus request at all, so it fences nothing: BLS
+    /// follows the request line, and interrupt-driven null-blit chains
+    /// (BLTSIZE with BLTCON0 USE=0 restarted every scanline, vAmigaTS
+    /// Agnus/Blitter/bltint) must run with the CPU at full speed.
     fn bltpri_warmup_fences_cpu(&self) -> bool {
+        if !self.use_a && !self.use_b && !self.use_c && !self.use_d {
+            return false;
+        }
         match self.phase {
             NormalBlitPhase::StartDelay | NormalBlitPhase::Init => true,
             NormalBlitPhase::A


### PR DESCRIPTION
Found by the pre-0.11 full vAmigaTS sweep (2998 cases vs fresh vAmiga references, compared against the 0.10 release-morning baseline).

## Problem

`Agnus/Blitter/bltint1` and `bltint5` collapsed from ~8-10% to **95.5%** divergence: Copperline rendered a near-solid blue frame where vAmiga (and the real A500 photo in the test folder) show the interrupt-choreographed stripe pattern. Bisect: first bad at #162 (the BLTPRI BLS fence), not repaired by #166's warm-up narrowing.

These tests restart a **null blit** (`BLTSIZE` with all `BLTCON0` USE bits clear, 1x1) from the blitter interrupt handler every scanline under BLTPRI. The warm-up fence charged every BLTPRI blit ~4 cck of CPU denial during the startup ladder -- but a blit with no channels never asserts a bus request at all, and BLS follows the request line. The accumulated denial across the per-line null-blit chain wedged the tests' COLOR00 choreography.

## Fix

`bltpri_warmup_fences_cpu` returns false when no channel is enabled. Channel-carrying blits keep the full warm-up fence (the Jim Power trackloader guarantee is untouched).

## Verification

- Full `Agnus/Blitter` suite re-run against the sweep's vAmiga references: bltint1 **95.5 -> 3.9**, bltint5 **95.5 -> 7.4** (both better than the 0.10 baseline of 8.5/10.2); the null-blit `cputim/invisible0` case improves 21.8 -> 1.5, `bususage0` 6.4 -> 3.2, `race0` 3.0 -> 0.02; **no other case moves**.
- Save-state oracles unchanged: Jim Power in-game (byte-identical screenshot), Rampage "present" cadence, dot-cube smoothness.
- Full `cargo test --release` green; all 18 golden probes byte-identical; CI-exact clippy and fmt clean.

Sweep summary for context (0.10 baseline -> 0.11): mean divergence 9.06% -> 7.04%, cases over 5% divergence 1148 -> 771, 1400 cases improved vs ~200 mildly moved. The remaining notable movers (`cputim2/4`) are a separate story: the real-hardware photos show vAmiga does not match real hardware there either (its bars miss the red/yellow colouring that Copperline reproduces), so they are not treated as reference regressions.