### PR TITLE
ci: make the DiagROM boot smoke actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,31 +151,59 @@ jobs:
     name: DiagROM boot smoke
     needs: build-test
     runs-on: macos-latest
-    # Opt-in. DiagROM is freely redistributable but not committed, so CI
-    # fetches it at run time. Set the DIAGROM_URL repository variable to a
-    # direct URL for the DiagROM ROM image to enable this job; until then it
-    # is skipped.
-    if: ${{ vars.DIAGROM_URL != '' }}
+    # DiagROM (diagrom.com) is freely downloadable but its author keeps
+    # redistribution to the official site, so it is fetched at run time
+    # (checksum-pinned, cached across runs) instead of being committed.
+    # The DIAGROM_URL repository variable optionally overrides the
+    # download location should the official URL move; the stable V1.3
+    # archive has been frozen upstream since 2023, so a checksum change
+    # means the pin below needs updating, not that the job is flaky.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build (release)
         run: cargo build --release --locked
-      - name: Fetch DiagROM
-        run: curl -fsSL "${{ vars.DIAGROM_URL }}" -o diagrom.rom
-      - name: Boot smoke (headless screenshot)
-        # No config and no positional ROM: the built-in defaults point at
-        # ./diagrom.rom, so this boots DiagROM, renders a frame after 6
-        # emulated seconds, and exits. A non-empty PNG means it booted
-        # without halting.
+      - name: Restore cached DiagROM
+        id: diagrom-cache
+        uses: actions/cache@v4
+        with:
+          path: diagrom.rom
+          key: diagrom-stable-v1.3
+      - name: Fetch DiagROM (stable V1.3)
+        if: steps.diagrom-cache.outputs.cache-hit != 'true'
+        env:
+          DIAGROM_URL: ${{ vars.DIAGROM_URL }}
         run: |
-          ./target/release/copperline --noaudio --screenshot-after 6 diag.png
+          curl -fsSL --retry 3 "${DIAGROM_URL:-https://www.diagrom.com/files/stable/DiagROM.zip}" -o DiagROM.zip
+          echo "a575f8fa69b1ac7fd566fcdcd19a68e53d472ac6c56d8a6a9489229882c5b208  DiagROM.zip" | shasum -a 256 -c
+          unzip -o DiagROM.zip DiagROM/DiagROM
+          mv DiagROM/DiagROM diagrom.rom
+          rm -rf DiagROM.zip DiagROM
+      - name: Boot smoke (serial banner + headless screenshot)
+        # DiagROM boots as a Kickstart replacement, so the ROM is passed
+        # positionally (the no-argument default is the bundled AROS ROM).
+        # DiagROM mirrors its diagnostics to the serial port, which the
+        # emulator routes to stdout by default; seeing the version banner
+        # proves the ROM's boot code actually executed, which a non-empty
+        # PNG alone does not (a black screen still writes one).
+        run: |
+          ./target/release/copperline diagrom.rom --noaudio --screenshot-after 6 diag.png > serial.log
+          grep -q "Amiga DiagROM" serial.log
           test -s diag.png
+      - name: DiagROM menu image regression
+        # The asset-gated integration test boots to the main menu and
+        # asserts the status bar's left-margin text columns survive.
+        run: |
+          mkdir -p test-assets
+          cp diagrom.rom test-assets/
+          cargo test --release --locked --test image_regression diagrom -- --ignored --nocapture
       - name: Upload boot screenshot
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: diagrom-boot
-          path: diag.png
+          path: |
+            diag.png
+            serial.log
           if-no-files-found: ignore

--- a/tests/image_regression.rs
+++ b/tests/image_regression.rs
@@ -791,15 +791,25 @@ fn diagrom_menu_preserves_left_margin_text_columns() -> Result<(), Box<dyn std::
         return Ok(());
     }
 
-    let img = run_screenshot("diagrom-left-margin", "6.0", &[])?;
+    // DiagROM boots as a Kickstart replacement, so the ROM is passed
+    // positionally (there is no ./diagrom.rom fallback; the bundled AROS
+    // ROM is the no-argument default). Boot-time memory detection plus the
+    // serial-mode countdown take ~28s on the default 512K chip + 512K slow
+    // machine; after that the main menu waits for input indefinitely, so a
+    // 35s screenshot is stable frame over frame.
+    let img = run_screenshot("diagrom-menu", "35.0", &["diagrom.rom"])?;
     assert_eq!((img.width, img.height), (716, 537));
 
+    // The yellow "Serial:" label of the menu's status bar is the leftmost
+    // text on screen (glyphs start at x=40 in the full-overscan frame);
+    // clipping the left margin cuts its columns away. The label renders
+    // ~230 pure-yellow pixels in this region.
     assert_region_color_count(
         &img,
-        (70, 103, 80, 116),
+        (38, 495, 95, 515),
         [255, 255, 0, 255],
-        12,
-        "DiagROM left-margin text column",
+        100,
+        "DiagROM menu status-bar left-margin text column",
     );
     Ok(())
 }


### PR DESCRIPTION
## Problem

The `diagrom-smoke` CI job has never executed, for three stacked reasons:

1. **Never enabled**: it was gated on `vars.DIAGROM_URL`, a repository variable that was never set, so the job silently skipped on every run.
2. **Fetch was wrong anyway**: the step saved whatever the URL serves directly as `diagrom.rom`, but [diagrom.com](https://www.diagrom.com/) only serves **zip archives** (there is no raw ROM URL upstream, and the GitHub repo holds source only).
3. **Boot assumption went stale**: the run step relied on the old `./diagrom.rom` default ROM lookup, which was removed when the bundled AROS ROM became the no-argument fallback. Even a correctly fetched ROM would not have been booted.

The local ignored test `diagrom_menu_preserves_left_margin_text_columns` was broken by the same removed default, and its 6s screenshot expectation predates the current default machine (512K chip + 512K slow), where DiagROM's memory detection plus serial-mode countdown still own the screen at that point.

## Changes

**`.github/workflows/ci.yml`** -- the job now runs unconditionally:
- Downloads the official stable V1.3 archive, checksum-pinned (frozen upstream since April 2023) and cached via `actions/cache`, so the author's site is hit roughly once rather than per-run. `DIAGROM_URL` remains as an override should the official URL move. The ROM is deliberately **not** committed: the author keeps distribution to the official site.
- Extracts `DiagROM/DiagROM`, the emulator-usable image per the archive's Readme, and boots it as an explicit positional ROM.
- Asserts on DiagROM's version banner (`Amiga DiagROM V1.3 ...`) arriving over the emulated serial port on stdout -- this proves the ROM's boot code executed, where the previous `test -s diag.png` passed even for a black screen. The serial log is uploaded alongside the screenshot artifact.
- Then runs the repaired asset-gated image-regression test against the fetched ROM.

**`tests/image_regression.rs`** -- the ignored test now passes the ROM positionally and screenshots the main menu at 35s (reached at ~28s on the default machine, then static while waiting for input), asserting the yellow `Serial:` status-bar label at the left margin of the full-overscan frame (230 pure-yellow pixels measured; threshold 100).

## Verification

All steps were run locally end-to-end:
- Fetch/checksum/extract logic verified verbatim (zip sha256 `a575f8fa...`, extracted ROM `1803bfff...`).
- Boot smoke: banner lands on stdout within the 6s window, screenshot non-empty.
- `cargo test --release --locked --test image_regression diagrom -- --ignored` passes (menu screenshot pixel-identical at 30s and 40s).
- `cargo fmt --check` and `cargo clippy --release --tests` clean.