### PR TITLE
A3000/A4000: Ramsey, Super DMAC + WD33C93, Fat Gary, and register access logging

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -104,8 +104,11 @@ model = "68000"
 # A500 (ECS 8372A Agnus, OCS 8362 Denise, 512 KiB chip + 512 KiB trapdoor
 # slow RAM) -- the most common and most-targeted Amiga.
 # The big-box profiles (A3000, A4000) are new and incomplete: Ramsey and the
-# chipset are there, but their on-board mass storage is not (the A3000 Super
-# DMAC SCSI and the A4000 IDE), so they need a Zorro controller to boot from.
+# chipset are there, but their on-board mass storage is not. The A4000 boots
+# (Kickstart times out probing the missing IDE at $DD2020, so give it a Zorro
+# controller or a [[filesys]] mount to boot from); the A3000 does not boot yet,
+# because its Super DMAC has no WD33C93 behind it and scsi.device waits forever
+# for an interrupt from it.
 # [machine]
 # profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | A3000 | A4000 | CDTV | CD32
 # rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV/A3000/A4000 have one)

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -103,12 +103,12 @@ model = "68000"
 # Without any [machine] section the default machine is that same Rev 6A
 # A500 (ECS 8372A Agnus, OCS 8362 Denise, 512 KiB chip + 512 KiB trapdoor
 # slow RAM) -- the most common and most-targeted Amiga.
-# The big-box profiles (A3000, A4000) are new and incomplete: Ramsey and the
-# chipset are there, but their on-board mass storage is not. The A4000 boots
-# (Kickstart times out probing the missing IDE at $DD2020, so give it a Zorro
-# controller or a [[filesys]] mount to boot from); the A3000 does not boot yet,
-# because its Super DMAC has no WD33C93 behind it and scsi.device waits forever
-# for an interrupt from it.
+# The big-box profiles (A3000, A4000) are new and incomplete, but both boot.
+# The A3000 has its motherboard SCSI (Super DMAC + WD33C93 at $DD0000, driven by
+# Kickstart's own scsi.device) with no drives attached yet; the A4000's IDE at
+# $DD2020 is not emulated at all, so Kickstart spends several seconds probing for
+# it on every boot. Give either machine a Zorro controller or a [[filesys]] mount
+# to boot from.
 # [machine]
 # profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | A3000 | A4000 | CDTV | CD32
 # rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV/A3000/A4000 have one)

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -122,7 +122,7 @@ model = "68000"
 # space to make "all" a firehose (a million lines a boot), so prefer aiming it
 # at one window.
 # [debug]
-# log_unmapped = "DD0000-DE0000"   # hex START-END, end exclusive; or "all"
+# log_unmapped = "DD0000-DEFFFF"   # hex START-END, end included; or "all"
 
 
 # Extended ROM image for CDTV/CD32 machines: a 256 KiB image maps at

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -108,6 +108,16 @@ model = "68000"
 # rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV have one)
 
 
+# Debugging aids. log_unmapped logs every CPU read and write that no device
+# decodes, which is how you find the registers a guest expects and Copperline
+# does not provide yet: reads report the floating bus value they returned,
+# writes report the value that went nowhere. A booting ROM probes enough empty
+# space to make "all" a firehose (a million lines a boot), so prefer aiming it
+# at one window.
+# [debug]
+# log_unmapped = "DD0000-DE0000"   # hex START-END, end exclusive; or "all"
+
+
 # Extended ROM image for CDTV/CD32 machines: a 256 KiB image maps at
 # $F00000 (CDTV), a 512 KiB image at $E00000 (CD32). The CDTV profile
 # boots its startup screen with this plus a Kickstart 1.3 rom; the CD32

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -103,9 +103,13 @@ model = "68000"
 # Without any [machine] section the default machine is that same Rev 6A
 # A500 (ECS 8372A Agnus, OCS 8362 Denise, 512 KiB chip + 512 KiB trapdoor
 # slow RAM) -- the most common and most-targeted Amiga.
+# The big-box profiles (A3000, A4000) are new and incomplete: Ramsey and the
+# chipset are there, but their on-board mass storage is not (the A3000 Super
+# DMAC SCSI and the A4000 IDE), so they need a Zorro controller to boot from.
 # [machine]
-# profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | CDTV | CD32
-# rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV have one)
+# profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | A3000 | A4000 | CDTV | CD32
+# rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV/A3000/A4000 have one)
+# mem_controller = "ramsey-07"   # none | ramsey-04 (A3000) | ramsey-07 (A4000)
 
 
 # Debugging aids. log_unmapped logs every CPU read and write that no device

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -123,22 +123,20 @@ board) and `CDTV` fit one by default; the base A500/A500OCS, A600, A1200,
 A1000, and CD32 have none. Set `rtc = true` to add one -- for an A600HD or a
 clock-equipped A1200, say -- so the Workbench clock keeps time.
 
-The `A3000` and `A4000` profiles are the big-box machines, and they are new and
-incomplete. They carry a Ramsey memory controller (`mem_controller`), which is
-what the two registers at `$DE0003` and `$DE0043` answer as, and they carry
-Gary rather than Gayle -- so no PCMCIA and no Gayle IDE. What they do not carry
-yet is their on-board mass storage, and the two machines fail differently
-because of it:
+The `A3000` and `A4000` profiles are the big-box machines. Both boot, but they
+are new and incomplete. They carry a Ramsey memory controller
+(`mem_controller`), which is what the two registers at `$DE0003` and `$DE0043`
+answer as, and they carry Gary rather than Gayle -- so no PCMCIA and no Gayle
+IDE.
 
-- The **A4000** boots. Its IDE interface at `$DD2020` is not implemented, so
-  Kickstart probes it, finds no drive, and waits out a timeout -- every boot is
-  slow, but it completes. Give it a Zorro controller (`[scsi]`) or a host
-  directory (`[[filesys]]`) to boot from.
-- The **A3000 does not boot yet.** Its SCSI is a Super DMAC at `$DD0000`
-  driving a WD33C93, and only the DMAC's register file exists. Kickstart's
-  `scsi.device` gets through the register probe, arms interrupts, sends the
-  missing WD33C93 a command, and waits forever for the completion interrupt.
-  The machine sits at a black screen with Exec idle and no runnable task.
+- The **A3000** has its motherboard SCSI: a Super DMAC at `$DD0000` driving a
+  WD33C93, which Kickstart's own `scsi.device` initialises at boot. No drives
+  are attached to it yet, so give the machine a Zorro controller (`[scsi]`) or a
+  host directory (`[[filesys]]`) to boot from.
+- The **A4000**'s IDE interface at `$DD2020` is not implemented. Kickstart's
+  `scsi.device` probes it, finds nothing, and waits out a timeout, so every boot
+  spends several seconds in the driver before it completes. Same story for
+  where to boot from.
 
 Motherboard fast RAM is not emulated on either; use `[memory] z3` instead,
 which the OS is equally happy with.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -575,3 +575,27 @@ Each entry adds a Zorro board described by a TOML metadata file, configured
 in file order after the built-in `[memory]` fast/z3 boards. See
 [](../zorro) for the metadata format and how autoconfig assigns
 addresses.
+
+## `[debug]` -- diagnostics
+
+```toml
+[debug]
+log_unmapped = "DD0000-DE0000"
+```
+
+`log_unmapped` logs every CPU read and write inside the given range that no
+device decodes. Reads report the floating bus value they returned, writes
+report the value that went nowhere. The value is a hex `START-END` range with
+an exclusive end (a leading `0x` is allowed), or `all` for the whole address
+space.
+
+This is how you find the registers a guest expects and Copperline does not
+implement yet. A missing register is usually invisible: a read floats, a write
+is dropped, and the guest either sulks or hangs with no diagnostic. Pointing
+this at the window a driver probes shows the access pattern directly -- an IDE
+presence probe, say, appears as a write of `$A0` to the device/head register
+followed by a long run of status reads that never come back ready.
+
+A booting Kickstart probes enough empty address space that `all` produces on
+the order of a million lines per boot, so prefer a range once you know roughly
+where to look.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -89,8 +89,9 @@ missing.
 
 ```toml
 [machine]
-profile = "A1200" # A1000, A500, A500OCS, A500Plus (A500+), A600, A1200, CDTV, CD32
-rtc = true        # add a battery RTC (default: only A500+/CDTV ship with one)
+profile = "A1200" # A1000, A500, A500OCS, A500Plus (A500+), A600, A1200, A3000, A4000, CDTV, CD32
+rtc = true        # add a battery RTC (default: only A500+/CDTV/A3000/A4000 ship with one)
+mem_controller = "ramsey-07" # none, ramsey-04 (A3000), ramsey-07 (A4000)
 ```
 
 A machine profile bundles the chipset, CPU, memory, gate array, and
@@ -111,6 +112,8 @@ gives a plain 8371/8362 OCS machine.
 | `A500Plus` | ECS (8375 Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | RTC |
 | `A600` | ECS (8375 Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | Gayle IDE |
 | `A1200` | AGA (Alice/Lisa) | 68EC020 @ 14.18 MHz | 2M | 0 | Gayle IDE |
+| `A3000` | ECS | 68030 @ 25 MHz | 2M | 0 | Ramsey-04, RTC |
+| `A4000` | AGA (Alice/Lisa) | 68040 @ 25 MHz | 2M | 0 | Ramsey-07, RTC |
 | `CDTV` | ECS | 68000 @ 7.09 MHz | 1M | 0 | DMAC CD controller, RTC, 256K extended ROM |
 | `CD32` | AGA (Alice/Lisa) | 68EC020 @ 14.18 MHz | 2M | 0 | Akiko, CD32 pad, NVRAM, 512K extended ROM |
 
@@ -119,6 +122,21 @@ only some carried one. Only the `A500Plus` (an OKI RTC soldered to the Rev 8A
 board) and `CDTV` fit one by default; the base A500/A500OCS, A600, A1200,
 A1000, and CD32 have none. Set `rtc = true` to add one -- for an A600HD or a
 clock-equipped A1200, say -- so the Workbench clock keeps time.
+
+The `A3000` and `A4000` profiles are the big-box machines, and they are new and
+incomplete. They carry a Ramsey memory controller (`mem_controller`), which is
+what the two registers at `$DE0003` and `$DE0043` answer as, and they carry
+Gary rather than Gayle -- so no PCMCIA and no Gayle IDE. What they do not carry
+yet is their on-board mass storage: the A3000's Super DMAC SCSI at `$DD0000`
+and the A4000's IDE at `$DD2020` are not implemented, so Kickstart probes them,
+finds nothing, and waits out a timeout on every boot. Give these machines a
+Zorro controller (`[scsi]`) or a host directory (`[[filesys]]`) to boot from.
+Motherboard fast RAM is not emulated either; use `[memory] z3` instead, which
+the OS is equally happy with.
+
+`mem_controller` is normally left to the profile. It is broken out because
+Ramsey answers at `$DE0000`, which nothing else decodes, so it can be fitted to
+a wedge machine to exercise diagnostic tools that expect one.
 
 The `A1000` profile models the original Amiga, which has no Kickstart ROM.
 Its `rom` is instead the 64K bootstrap ROM ("Amiga ROM Bootstrap"); on

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -607,13 +607,13 @@ addresses.
 
 ```toml
 [debug]
-log_unmapped = "DD0000-DE0000"
+log_unmapped = "DD0000-DEFFFF"
 ```
 
 `log_unmapped` logs every CPU read and write inside the given range that no
 device decodes. Reads report the floating bus value they returned, writes
-report the value that went nowhere. The value is a hex `START-END` range with
-an exclusive end (a leading `0x` is allowed), or `all` for the whole address
+report the value that went nowhere. The value is a hex `START-END` range whose
+end is included (a leading `0x` is allowed), or `all` for the whole address
 space.
 
 This is how you find the registers a guest expects and Copperline does not

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -127,12 +127,21 @@ The `A3000` and `A4000` profiles are the big-box machines, and they are new and
 incomplete. They carry a Ramsey memory controller (`mem_controller`), which is
 what the two registers at `$DE0003` and `$DE0043` answer as, and they carry
 Gary rather than Gayle -- so no PCMCIA and no Gayle IDE. What they do not carry
-yet is their on-board mass storage: the A3000's Super DMAC SCSI at `$DD0000`
-and the A4000's IDE at `$DD2020` are not implemented, so Kickstart probes them,
-finds nothing, and waits out a timeout on every boot. Give these machines a
-Zorro controller (`[scsi]`) or a host directory (`[[filesys]]`) to boot from.
-Motherboard fast RAM is not emulated either; use `[memory] z3` instead, which
-the OS is equally happy with.
+yet is their on-board mass storage, and the two machines fail differently
+because of it:
+
+- The **A4000** boots. Its IDE interface at `$DD2020` is not implemented, so
+  Kickstart probes it, finds no drive, and waits out a timeout -- every boot is
+  slow, but it completes. Give it a Zorro controller (`[scsi]`) or a host
+  directory (`[[filesys]]`) to boot from.
+- The **A3000 does not boot yet.** Its SCSI is a Super DMAC at `$DD0000`
+  driving a WD33C93, and only the DMAC's register file exists. Kickstart's
+  `scsi.device` gets through the register probe, arms interrupts, sends the
+  missing WD33C93 a command, and waits forever for the completion interrupt.
+  The machine sits at a black screen with Exec idle and no runnable task.
+
+Motherboard fast RAM is not emulated on either; use `[memory] z3` instead,
+which the OS is equally happy with.
 
 `mem_controller` is normally left to the profile. It is broken out because
 Ramsey answers at `$DE0000`, which nothing else decodes, so it can be fitted to

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -665,6 +665,10 @@ pub struct Bus {
     /// the same $DE0000 page Gayle uses, so the two are never both fitted.
     #[serde(default)]
     pub ramsey: Option<crate::ramsey::Ramsey>,
+    /// Fat Gary bus controller (A3000/A4000 machine profiles): the other three
+    /// byte lanes of the page Ramsey answers on. Fitted with it, never alone.
+    #[serde(default)]
+    pub gary: Option<crate::gary::Gary>,
     /// Super DMAC (A3000 machine profile): the SCSI DMA controller at $DD0000.
     /// Kickstart's scsi.device hangs during init if nothing answers here.
     #[serde(default)]
@@ -2099,6 +2103,7 @@ impl Bus {
             rtc_present: true,
             gayle: None,
             ramsey: None,
+            gary: None,
             sdmac: None,
             log_unmapped: None,
             akiko: None,
@@ -2530,6 +2535,10 @@ impl Bus {
         self.ramsey = Some(ramsey);
     }
 
+    pub fn attach_gary(&mut self, gary: crate::gary::Gary) {
+        self.gary = Some(gary);
+    }
+
     pub fn attach_sdmac(&mut self, sdmac: crate::sdmac::Sdmac) {
         self.sdmac = Some(sdmac);
     }
@@ -2747,6 +2756,9 @@ impl Bus {
         self.rtc = Msm6242Rtc::default();
         if let Some(gayle) = self.gayle.as_mut() {
             gayle.reset();
+        }
+        if let Some(gary) = self.gary.as_mut() {
+            gary.reset();
         }
         if let Some(ramsey) = self.ramsey.as_mut() {
             ramsey.reset();

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -663,6 +663,7 @@ pub struct Bus {
     pub gayle: Option<Gayle>,
     /// Ramsey memory controller (A3000/A4000 machine profiles). Answers on
     /// the same $DE0000 page Gayle uses, so the two are never both fitted.
+    #[serde(default)]
     pub ramsey: Option<crate::ramsey::Ramsey>,
     /// Super DMAC (A3000 machine profile): the SCSI DMA controller at $DD0000.
     /// Kickstart's scsi.device hangs during init if nothing answers here.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -671,7 +671,7 @@ pub struct Bus {
     /// `[debug] log_unmapped`: log CPU accesses in this range that no device
     /// decodes, to find the registers a guest expects and we do not provide.
     #[serde(default)]
-    pub log_unmapped: Option<std::ops::Range<u32>>,
+    pub log_unmapped: Option<std::ops::RangeInclusive<u32>>,
     /// Akiko gate array (CD32 machine profile): ID, the C2P port, and
     /// NVRAM/CD stubs at $B80000.
     pub akiko: Option<crate::akiko::Akiko>,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -661,6 +661,9 @@ pub struct Bus {
     /// Gayle gate array (A600/A1200 machine profiles); None on machines
     /// without one, which leaves $DA0000/$DE1000 floating as before.
     pub gayle: Option<Gayle>,
+    /// Ramsey memory controller (A3000/A4000 machine profiles). Answers on
+    /// the same $DE0000 page Gayle uses, so the two are never both fitted.
+    pub ramsey: Option<crate::ramsey::Ramsey>,
     /// Akiko gate array (CD32 machine profile): ID, the C2P port, and
     /// NVRAM/CD stubs at $B80000.
     pub akiko: Option<crate::akiko::Akiko>,
@@ -2086,6 +2089,7 @@ impl Bus {
             rtc: Msm6242Rtc::default(),
             rtc_present: true,
             gayle: None,
+            ramsey: None,
             akiko: None,
             cdtv: None,
             devices: Vec::new(),
@@ -2511,6 +2515,10 @@ impl Bus {
         self.gayle = Some(gayle);
     }
 
+    pub fn attach_ramsey(&mut self, ramsey: crate::ramsey::Ramsey) {
+        self.ramsey = Some(ramsey);
+    }
+
     pub fn attach_akiko(&mut self, akiko: crate::akiko::Akiko) {
         self.akiko = Some(akiko);
     }
@@ -2724,6 +2732,9 @@ impl Bus {
         self.rtc = Msm6242Rtc::default();
         if let Some(gayle) = self.gayle.as_mut() {
             gayle.reset();
+        }
+        if let Some(ramsey) = self.ramsey.as_mut() {
+            ramsey.reset();
         }
         if let Some(akiko) = self.akiko.as_mut() {
             akiko.reset();

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -664,6 +664,10 @@ pub struct Bus {
     /// Ramsey memory controller (A3000/A4000 machine profiles). Answers on
     /// the same $DE0000 page Gayle uses, so the two are never both fitted.
     pub ramsey: Option<crate::ramsey::Ramsey>,
+    /// Super DMAC (A3000 machine profile): the SCSI DMA controller at $DD0000.
+    /// Kickstart's scsi.device hangs during init if nothing answers here.
+    #[serde(default)]
+    pub sdmac: Option<crate::sdmac::Sdmac>,
     /// `[debug] log_unmapped`: log CPU accesses in this range that no device
     /// decodes, to find the registers a guest expects and we do not provide.
     #[serde(default)]
@@ -2094,6 +2098,7 @@ impl Bus {
             rtc_present: true,
             gayle: None,
             ramsey: None,
+            sdmac: None,
             log_unmapped: None,
             akiko: None,
             cdtv: None,
@@ -2524,6 +2529,10 @@ impl Bus {
         self.ramsey = Some(ramsey);
     }
 
+    pub fn attach_sdmac(&mut self, sdmac: crate::sdmac::Sdmac) {
+        self.sdmac = Some(sdmac);
+    }
+
     pub fn attach_akiko(&mut self, akiko: crate::akiko::Akiko) {
         self.akiko = Some(akiko);
     }
@@ -2740,6 +2749,9 @@ impl Bus {
         }
         if let Some(ramsey) = self.ramsey.as_mut() {
             ramsey.reset();
+        }
+        if let Some(sdmac) = self.sdmac.as_mut() {
+            sdmac.reset();
         }
         if let Some(akiko) = self.akiko.as_mut() {
             akiko.reset();

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3984,6 +3984,21 @@ impl Bus {
             self.paula.intreq |= INT_PORTS;
         }
 
+        // SDMAC (A3000 motherboard SCSI): advance the WD33C93 and its DMA, and
+        // level-feed its INT2 line like Gayle's. Kickstart's own scsi.device
+        // drives it, so nothing boots until this interrupt arrives.
+        {
+            let Self {
+                sdmac, mem, paula, ..
+            } = self;
+            if let Some(sdmac) = sdmac.as_mut() {
+                sdmac.tick(cck, mem);
+                if sdmac.int_line() {
+                    paula.intreq |= INT_PORTS;
+                }
+            }
+        }
+
         // Akiko: advance the CD controller (sector DMA pacing, command
         // and response rings) and level-feed its INT2 line like Gayle's.
         if let Some(akiko) = self.akiko.as_mut() {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -664,6 +664,10 @@ pub struct Bus {
     /// Ramsey memory controller (A3000/A4000 machine profiles). Answers on
     /// the same $DE0000 page Gayle uses, so the two are never both fitted.
     pub ramsey: Option<crate::ramsey::Ramsey>,
+    /// `[debug] log_unmapped`: log CPU accesses in this range that no device
+    /// decodes, to find the registers a guest expects and we do not provide.
+    #[serde(default)]
+    pub log_unmapped: Option<std::ops::Range<u32>>,
     /// Akiko gate array (CD32 machine profile): ID, the C2P port, and
     /// NVRAM/CD stubs at $B80000.
     pub akiko: Option<crate::akiko::Akiko>,
@@ -2090,6 +2094,7 @@ impl Bus {
             rtc_present: true,
             gayle: None,
             ramsey: None,
+            log_unmapped: None,
             akiko: None,
             cdtv: None,
             devices: Vec::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -857,25 +857,40 @@ impl MachineDescriptor {
     }
 }
 
-/// Which gate array the machine carries. Gayle owns IDE, PCMCIA, and the
-/// interrupt plumbing at $DA8000-$DAA000 plus the ID register at $DE1000.
+/// Which bus gate array the machine carries. A machine has exactly one, and
+/// they are not interchangeable parts so much as the same seat on the board:
+/// both decode the $DE0000 page, so fitting two would make the decode
+/// ambiguous.
+///
+/// Gayle (the wedge machines) is the bus controller plus IDE, PCMCIA, and the
+/// interrupt plumbing at $DA8000-$DAA000, with an ID register at $DE1000. Fat
+/// Gary (the big-box machines) is only a bus controller: three flag registers
+/// on byte lanes 0-2 of the $DE0000 page, with Ramsey answering on lane 3.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GateArray {
     #[default]
     None,
     GayleA600,
     GayleA1200,
+    /// Fat Gary, as fitted to the A3000 and A4000. Always accompanied by a
+    /// Ramsey (see [`MemController`]): they share one address decode.
+    FatGary,
 }
 
 impl GateArray {
     /// The 8-bit ID shifted out of $DE1000 (MSB first): $D0 on the A600,
-    /// $D1 on the A1200.
+    /// $D1 on the A1200. Only Gayle has one.
     pub fn gayle_id(self) -> Option<u8> {
         match self {
-            Self::None => None,
+            Self::None | Self::FatGary => None,
             Self::GayleA600 => Some(0xD0),
             Self::GayleA1200 => Some(0xD1),
         }
+    }
+
+    /// Whether this machine's gate array is a Fat Gary.
+    pub fn is_fat_gary(self) -> bool {
+        self == Self::FatGary
     }
 }
 
@@ -1932,7 +1947,11 @@ impl TryFrom<RawConfig> for Config {
             master: raw.ide.master.map(drive_image).transpose()?,
             slave: raw.ide.slave.map(drive_image).transpose()?,
         };
-        if (ide.master.is_some() || ide.slave.is_some()) && defaults.gate_array == GateArray::None {
+        // Only Gayle carries an IDE interface. A Fat Gary machine has one too
+        // (the A4000's, at $DD2020), but it is not emulated yet and it is not
+        // Gayle's, so [ide] cannot drive it.
+        if (ide.master.is_some() || ide.slave.is_some()) && defaults.gate_array.gayle_id().is_none()
+        {
             errors.push(anyhow!(
                 "[ide] images need a Gayle machine: set [machine] profile = \"A600\" (or A1200)"
             ));
@@ -2365,6 +2384,7 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.cpu = CpuModel::M68030;
             d.cpu_clock_mhz = 25.0;
             d.mem_controller = MemController::Ramsey4;
+            d.gate_array = GateArray::FatGary;
             d.rtc_present = true;
             d.sdmac = true;
         }
@@ -2377,6 +2397,7 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.cpu = CpuModel::M68040;
             d.cpu_clock_mhz = 25.0;
             d.mem_controller = MemController::Ramsey7;
+            d.gate_array = GateArray::FatGary;
             d.rtc_present = true;
         }
         // CDTV: A500-class board with the 1 MB ECS Agnus and 1 MB chip
@@ -3299,7 +3320,10 @@ mod tests {
         assert_eq!(cfg.cpu, CpuModel::M68040);
         assert_eq!(cfg.chip_ram_bytes, 2 * 1024 * 1024);
         assert_eq!(cfg.slow_ram_bytes, 0);
-        assert_eq!(cfg.gate_array, GateArray::None);
+        // Fat Gary, not Gayle: the big-box machines fill the same seat with the
+        // other chip, so no PCMCIA and no Gayle IDE.
+        assert_eq!(cfg.gate_array, GateArray::FatGary);
+        assert_eq!(cfg.gate_array.gayle_id(), None);
         assert_eq!(cfg.mem_controller, MemController::Ramsey7);
         assert!(cfg.rtc_present);
 
@@ -3311,7 +3335,7 @@ mod tests {
         )?;
         assert_eq!(cfg.chipset, Chipset::Ecs);
         assert_eq!(cfg.cpu, CpuModel::M68030);
-        assert_eq!(cfg.gate_array, GateArray::None);
+        assert_eq!(cfg.gate_array, GateArray::FatGary);
         assert_eq!(cfg.mem_controller, MemController::Ramsey4);
         // Kickstart's scsi.device hangs in init if the SDMAC does not answer.
         assert!(cfg.sdmac);

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,11 @@ pub struct Config {
     pub gate_array: GateArray,
     /// Memory controller fitted: a Ramsey on the big-box machines.
     pub mem_controller: MemController,
+    /// Log every CPU access that no device decodes, within this address range.
+    /// Set by `[debug] log_unmapped`. Off by default: on a booting machine the
+    /// ROM probes enough empty space to make this a firehose, so it is meant
+    /// to be pointed at one window (e.g. the A4000 IDE at $DD2020).
+    pub log_unmapped: Option<std::ops::Range<u32>>,
     /// Akiko gate array fitted (CD32 profile): ID + C2P port at $B80000.
     pub akiko: bool,
     /// CDTV DMAC/CD controller fitted (CDTV profile): a Zorro II
@@ -917,6 +922,7 @@ impl Default for Config {
             machine: None,
             gate_array: GateArray::None,
             mem_controller: MemController::None,
+            log_unmapped: None,
             akiko: false,
             cdtv_cd: false,
             cd32_pad: false,
@@ -1204,6 +1210,8 @@ pub struct RawConfig {
     pub(crate) identify: Option<bool>,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) cd: RawCd,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) debug: RawDebug,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) cpu: RawCpu,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -1567,6 +1575,17 @@ pub(crate) struct RawMachine {
     /// exercise the diagnostic tools.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mem_controller: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawDebug {
+    /// Log CPU accesses that no device decodes. Either `all`, or an address
+    /// range like `"DD0000-DE0000"` (hex, end exclusive) to watch one window.
+    /// Reads report the floating bus value they returned; writes report the
+    /// value that went nowhere.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) log_unmapped: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2083,6 +2102,12 @@ impl TryFrom<RawConfig> for Config {
                 .map(PathBuf::from)
                 .or_else(|| defaults.akiko.then(|| PathBuf::from("cd32-nvram.bin"))),
             rtc_present: raw.machine.rtc.unwrap_or(defaults.rtc_present),
+            log_unmapped: raw
+                .debug
+                .log_unmapped
+                .as_deref()
+                .map(parse_log_unmapped)
+                .transpose()?,
             mem_controller: match raw.machine.mem_controller.as_deref() {
                 None => defaults.mem_controller,
                 Some("none") => MemController::None,
@@ -2203,6 +2228,32 @@ fn parse_chipset(s: &str) -> Result<Chipset> {
         "AGA" => Ok(Chipset::Aga),
         _ => Err(anyhow!("unknown chipset {:?}: expected OCS / ECS / AGA", s)),
     }
+}
+
+/// Parse `[debug] log_unmapped`: `all`, or a hex `START-END` range with an
+/// exclusive end (e.g. `"DD0000-DE0000"`, or `"0x00DD0000-0x00DE0000"`).
+pub(crate) fn parse_log_unmapped(s: &str) -> Result<std::ops::Range<u32>> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("all") {
+        return Ok(0..u32::MAX);
+    }
+    let hex = |v: &str| -> Result<u32> {
+        let v = v.trim();
+        let digits = v
+            .strip_prefix("0x")
+            .or_else(|| v.strip_prefix("0X"))
+            .unwrap_or(v);
+        u32::from_str_radix(digits, 16)
+            .with_context(|| format!("[debug] log_unmapped: {v:?} is not a hex address"))
+    };
+    let (start, end) = s
+        .split_once('-')
+        .ok_or_else(|| anyhow!("[debug] log_unmapped {s:?}: expected \"all\" or \"START-END\""))?;
+    let (start, end) = (hex(start)?, hex(end)?);
+    if start >= end {
+        bail!("[debug] log_unmapped {s:?}: start must be below end");
+    }
+    Ok(start..end)
 }
 
 pub(crate) fn parse_machine_model(s: &str) -> Result<MachineModel> {
@@ -3731,6 +3782,39 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(err.contains("ramsey-04"), "{err}");
+        Ok(())
+    }
+
+    #[test]
+    fn log_unmapped_takes_all_or_a_hex_range() -> anyhow::Result<()> {
+        let cfg = parse_config(
+            r#"
+            [debug]
+            log_unmapped = "DD0000-DE0000"
+            "#,
+        )?;
+        assert_eq!(cfg.log_unmapped, Some(0x00DD_0000..0x00DE_0000));
+
+        let cfg = parse_config(
+            r#"
+            [debug]
+            log_unmapped = "all"
+            "#,
+        )?;
+        assert_eq!(cfg.log_unmapped, Some(0..u32::MAX));
+
+        assert_eq!(parse_config("")?.log_unmapped, None);
+
+        // An end below the start would silently log nothing.
+        let err = parse_config(
+            r#"
+            [debug]
+            log_unmapped = "DE0000-DD0000"
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("start must be below end"), "{err}");
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -672,6 +672,16 @@ pub enum MachineModel {
     /// stock chip RAM, no trapdoor slow RAM, no RTC. (Added last so the
     /// serialized discriminants of the other models do not shift.)
     A1000,
+    /// A3000: ECS, 68030 at 25 MHz, 2 MB chip RAM, a Ramsey-04 memory
+    /// controller and the battery-backed MSM6242 clock. No Gayle -- the
+    /// big-box machines carry Gary -- and no slow RAM. Motherboard fast RAM is
+    /// not emulated; the OS is happy taking its fast RAM from the Zorro III
+    /// board instead.
+    A3000,
+    /// A4000: the same board a generation later -- AGA, a 25 MHz 68040, and
+    /// Ramsey-07. Same story on Gayle, slow RAM and motherboard fast RAM as
+    /// the A3000.
+    A4000,
 }
 
 /// Identity of a ROM image: its length and a CRC-32 of its bytes. Enough to
@@ -2265,10 +2275,12 @@ pub(crate) fn parse_machine_model(s: &str) -> Result<MachineModel> {
         "A500PLUS" | "A500+" => Ok(MachineModel::A500Plus),
         "A600" => Ok(MachineModel::A600),
         "A1200" => Ok(MachineModel::A1200),
+        "A3000" => Ok(MachineModel::A3000),
+        "A4000" => Ok(MachineModel::A4000),
         "CDTV" => Ok(MachineModel::Cdtv),
         "CD32" => Ok(MachineModel::Cd32),
         _ => Err(anyhow!(
-            "unknown machine model {:?}: expected A1000 / A500 / A500OCS / A500Plus / A600 / A1200 / CDTV / CD32",
+            "unknown machine model {:?}: expected A1000 / A500 / A500OCS / A500Plus / A600 / A1200 / A3000 / A4000 / CDTV / CD32",
             s
         )),
     }
@@ -2333,6 +2345,30 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.cpu = CpuModel::M68EC020;
             d.cpu_clock_mhz = 14.18;
             d.gate_array = GateArray::GayleA1200;
+        }
+        // The A3000: ECS on a big-box board, a 25 MHz 68030 with a real MMU,
+        // and Ramsey-04 in front of the motherboard DRAM. Gary, not Gayle, so
+        // no PCMCIA and no Gayle IDE. Its SCSI is a Super DMAC at $DD0000
+        // driving a WD33C93, which is not emulated yet.
+        MachineModel::A3000 => {
+            d.chipset = Chipset::Ecs;
+            d.chip_ram_bytes = 2 * 1024 * 1024;
+            d.slow_ram_bytes = 0;
+            d.cpu = CpuModel::M68030;
+            d.cpu_clock_mhz = 25.0;
+            d.mem_controller = MemController::Ramsey4;
+            d.rtc_present = true;
+        }
+        // The A4000: the same board a generation later -- AGA, a 25 MHz 68040,
+        // and Ramsey-07. Its IDE lives at $DD2020, which is not emulated yet.
+        MachineModel::A4000 => {
+            d.chipset = Chipset::Aga;
+            d.chip_ram_bytes = 2 * 1024 * 1024;
+            d.slow_ram_bytes = 0;
+            d.cpu = CpuModel::M68040;
+            d.cpu_clock_mhz = 25.0;
+            d.mem_controller = MemController::Ramsey7;
+            d.rtc_present = true;
         }
         // CDTV: A500-class board with the 1 MB ECS Agnus and 1 MB chip
         // RAM, plus the 256 KiB extended ROM at $F00000 (configure it via
@@ -3243,10 +3279,36 @@ mod tests {
         assert_eq!(cfg.agnus_revision, AgnusRevision::AgaAlice);
         assert_eq!(cfg.denise_revision, DeniseRevision::AgaLisa);
 
-        let err = parse_config(
+        // The big-box machines: Ramsey instead of Gayle, and a real CPU.
+        let cfg = parse_config(
             r#"
             [machine]
             profile = "A4000"
+            "#,
+        )?;
+        assert_eq!(cfg.chipset, Chipset::Aga);
+        assert_eq!(cfg.cpu, CpuModel::M68040);
+        assert_eq!(cfg.chip_ram_bytes, 2 * 1024 * 1024);
+        assert_eq!(cfg.slow_ram_bytes, 0);
+        assert_eq!(cfg.gate_array, GateArray::None);
+        assert_eq!(cfg.mem_controller, MemController::Ramsey7);
+        assert!(cfg.rtc_present);
+
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A3000"
+            "#,
+        )?;
+        assert_eq!(cfg.chipset, Chipset::Ecs);
+        assert_eq!(cfg.cpu, CpuModel::M68030);
+        assert_eq!(cfg.gate_array, GateArray::None);
+        assert_eq!(cfg.mem_controller, MemController::Ramsey4);
+
+        let err = parse_config(
+            r#"
+            [machine]
+            profile = "A5000"
             "#,
         )
         .unwrap_err();

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,8 @@ pub struct Config {
     /// Selected machine profile, if a `[machine]` section was given.
     pub machine: Option<MachineModel>,
     pub gate_array: GateArray,
+    /// Memory controller fitted: a Ramsey on the big-box machines.
+    pub mem_controller: MemController,
     /// Akiko gate array fitted (CD32 profile): ID + C2P port at $B80000.
     pub akiko: bool,
     /// CDTV DMAC/CD controller fitted (CDTV profile): a Zorro II
@@ -856,6 +858,29 @@ impl GateArray {
     }
 }
 
+/// Which memory controller the machine carries. The big-box machines put a
+/// Ramsey at $DE0000, where the wedge machines put Gayle; the two are mutually
+/// exclusive, and everything else has neither.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MemController {
+    #[default]
+    None,
+    /// Ramsey-04, as fitted to the A3000.
+    Ramsey4,
+    /// Ramsey-07, as fitted to the A4000.
+    Ramsey7,
+}
+
+impl MemController {
+    pub fn ramsey_revision(self) -> Option<crate::ramsey::RamseyRevision> {
+        match self {
+            Self::None => None,
+            Self::Ramsey4 => Some(crate::ramsey::RamseyRevision::Rev4),
+            Self::Ramsey7 => Some(crate::ramsey::RamseyRevision::Rev7),
+        }
+    }
+}
+
 const A500_TRAPDOOR_RAM_BYTES: usize = 512 * 1024;
 
 impl Default for Config {
@@ -891,6 +916,7 @@ impl Default for Config {
             denise_revision: DeniseRevision::Ocs,
             machine: None,
             gate_array: GateArray::None,
+            mem_controller: MemController::None,
             akiko: false,
             cdtv_cd: false,
             cd32_pad: false,
@@ -1535,6 +1561,12 @@ pub(crate) struct RawMachine {
     /// clock-equipped A1200.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rtc: Option<bool>,
+    /// Memory controller fitted, defaulting per profile: `none`, `ramsey-04`
+    /// (A3000) or `ramsey-07` (A4000). Ramsey answers at $DE0000, which no
+    /// other chip decodes, so it can also be fitted to a wedge machine to
+    /// exercise the diagnostic tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mem_controller: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2051,6 +2083,16 @@ impl TryFrom<RawConfig> for Config {
                 .map(PathBuf::from)
                 .or_else(|| defaults.akiko.then(|| PathBuf::from("cd32-nvram.bin"))),
             rtc_present: raw.machine.rtc.unwrap_or(defaults.rtc_present),
+            mem_controller: match raw.machine.mem_controller.as_deref() {
+                None => defaults.mem_controller,
+                Some("none") => MemController::None,
+                Some("ramsey-04") => MemController::Ramsey4,
+                Some("ramsey-07") => MemController::Ramsey7,
+                Some(other) => anyhow::bail!(
+                    "[machine] mem_controller {other:?} is not one of \
+                     none, ramsey-04, ramsey-07"
+                ),
+            },
             video_standard,
             audio,
             ide,
@@ -2766,6 +2808,7 @@ mod tests {
             machine: RawMachine {
                 profile: Some("A1200".to_string()),
                 rtc: Some(true),
+                mem_controller: Some("ramsey-07".to_string()),
             },
             cpu: RawCpu {
                 model: Some("68EC020".to_string()),
@@ -3125,6 +3168,7 @@ mod tests {
             profile = "A500Plus"
             "#,
         )?;
+        assert_eq!(cfg.mem_controller, MemController::None);
         assert_eq!(cfg.chipset, Chipset::Ecs);
         assert_eq!(cfg.chip_ram_bytes, 1024 * 1024);
         assert_eq!(cfg.slow_ram_bytes, 0);
@@ -3660,6 +3704,33 @@ mod tests {
         )?;
         let unit0 = cfg.scsi.units[0].as_ref().expect("unit0 configured");
         assert_eq!(unit0.volume_name.as_deref(), Some("Work Disk"));
+        Ok(())
+    }
+
+    #[test]
+    fn the_memory_controller_can_be_selected() -> anyhow::Result<()> {
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A1200"
+            mem_controller = "ramsey-07"
+            "#,
+        )?;
+        assert_eq!(cfg.mem_controller, MemController::Ramsey7);
+        assert_eq!(
+            cfg.mem_controller.ramsey_revision(),
+            Some(crate::ramsey::RamseyRevision::Rev7)
+        );
+
+        let err = parse_config(
+            r#"
+            [machine]
+            mem_controller = "ramsey-08"
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("ramsey-04"), "{err}");
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -650,6 +650,9 @@ pub enum Chipset {
 /// RTC presence). With no `[machine]` section the defaults match the `A500`
 /// profile: the A500 Rev 6A (ECS 8372A Agnus, OCS 8362 Denise, 68000,
 /// 512 KiB chip RAM, and 512 KiB trapdoor slow RAM).
+///
+/// Append new models at the end: savestates carry the discriminant, so
+/// inserting one in the middle renames every model below it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MachineModel {
     /// A500 Rev 6A: the ECS "Fatter" 8372A Agnus (1 MiB chip reach, software
@@ -673,8 +676,7 @@ pub enum MachineModel {
     /// no Kickstart ROM -- the `rom` is the 64 KiB bootstrap ROM, which loads
     /// Kickstart from the Kickstart disk in DF0 into 256 KiB of writable
     /// control store (WCS) at $FC0000 and then write-protects it. 256 KiB
-    /// stock chip RAM, no trapdoor slow RAM, no RTC. (Added last so the
-    /// serialized discriminants of the other models do not shift.)
+    /// stock chip RAM, no trapdoor slow RAM, no RTC.
     A1000,
     /// A3000: ECS, 68030 at 25 MHz, 2 MB chip RAM, a Ramsey-04 memory
     /// controller and the battery-backed MSM6242 clock. No Gayle -- the

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,10 @@ pub struct Config {
     /// ROM probes enough empty space to make this a firehose, so it is meant
     /// to be pointed at one window (e.g. the A4000 IDE at $DD2020).
     pub log_unmapped: Option<std::ops::Range<u32>>,
+    /// Super DMAC fitted (A3000 profile): the SCSI DMA controller at $DD0000.
+    /// No WD33C93 behind it yet, so the machine boots with an empty SCSI
+    /// socket -- but Kickstart hangs outright if nothing answers at all.
+    pub sdmac: bool,
     /// Akiko gate array fitted (CD32 profile): ID + C2P port at $B80000.
     pub akiko: bool,
     /// CDTV DMAC/CD controller fitted (CDTV profile): a Zorro II
@@ -933,6 +937,7 @@ impl Default for Config {
             gate_array: GateArray::None,
             mem_controller: MemController::None,
             log_unmapped: None,
+            sdmac: false,
             akiko: false,
             cdtv_cd: false,
             cd32_pad: false,
@@ -2097,6 +2102,7 @@ impl TryFrom<RawConfig> for Config {
             denise_revision,
             machine,
             gate_array: defaults.gate_array,
+            sdmac: defaults.sdmac,
             akiko: defaults.akiko,
             cdtv_cd: defaults.cdtv_cd,
             cd32_pad: defaults.cd32_pad,
@@ -2358,6 +2364,7 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.cpu_clock_mhz = 25.0;
             d.mem_controller = MemController::Ramsey4;
             d.rtc_present = true;
+            d.sdmac = true;
         }
         // The A4000: the same board a generation later -- AGA, a 25 MHz 68040,
         // and Ramsey-07. Its IDE lives at $DD2020, which is not emulated yet.
@@ -3304,6 +3311,8 @@ mod tests {
         assert_eq!(cfg.cpu, CpuModel::M68030);
         assert_eq!(cfg.gate_array, GateArray::None);
         assert_eq!(cfg.mem_controller, MemController::Ramsey4);
+        // Kickstart's scsi.device hangs in init if the SDMAC does not answer.
+        assert!(cfg.sdmac);
 
         let err = parse_config(
             r#"

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,7 @@ pub struct Config {
     /// Set by `[debug] log_unmapped`. Off by default: on a booting machine the
     /// ROM probes enough empty space to make this a firehose, so it is meant
     /// to be pointed at one window (e.g. the A4000 IDE at $DD2020).
-    pub log_unmapped: Option<std::ops::Range<u32>>,
+    pub log_unmapped: Option<std::ops::RangeInclusive<u32>>,
     /// Super DMAC fitted (A3000 profile): the SCSI DMA controller at $DD0000.
     /// No WD33C93 behind it yet, so the machine boots with an empty SCSI
     /// socket -- but Kickstart hangs outright if nothing answers at all.
@@ -2247,11 +2247,11 @@ fn parse_chipset(s: &str) -> Result<Chipset> {
 }
 
 /// Parse `[debug] log_unmapped`: `all`, or a hex `START-END` range with an
-/// exclusive end (e.g. `"DD0000-DE0000"`, or `"0x00DD0000-0x00DE0000"`).
-pub(crate) fn parse_log_unmapped(s: &str) -> Result<std::ops::Range<u32>> {
+/// inclusive end (e.g. `"DD0000-DEFFFF"`, or `"0x00DD0000-0x00DEFFFF"`).
+pub(crate) fn parse_log_unmapped(s: &str) -> Result<std::ops::RangeInclusive<u32>> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("all") {
-        return Ok(0..u32::MAX);
+        return Ok(0..=u32::MAX);
     }
     let hex = |v: &str| -> Result<u32> {
         let v = v.trim();
@@ -2266,10 +2266,10 @@ pub(crate) fn parse_log_unmapped(s: &str) -> Result<std::ops::Range<u32>> {
         .split_once('-')
         .ok_or_else(|| anyhow!("[debug] log_unmapped {s:?}: expected \"all\" or \"START-END\""))?;
     let (start, end) = (hex(start)?, hex(end)?);
-    if start >= end {
-        bail!("[debug] log_unmapped {s:?}: start must be below end");
+    if start > end {
+        bail!("[debug] log_unmapped {s:?}: start must not be above end");
     }
-    Ok(start..end)
+    Ok(start..=end)
 }
 
 pub(crate) fn parse_machine_model(s: &str) -> Result<MachineModel> {
@@ -3861,10 +3861,10 @@ mod tests {
         let cfg = parse_config(
             r#"
             [debug]
-            log_unmapped = "DD0000-DE0000"
+            log_unmapped = "DD0000-DEFFFF"
             "#,
         )?;
-        assert_eq!(cfg.log_unmapped, Some(0x00DD_0000..0x00DE_0000));
+        assert_eq!(cfg.log_unmapped, Some(0x00DD_0000..=0x00DE_FFFF));
 
         let cfg = parse_config(
             r#"
@@ -3872,7 +3872,9 @@ mod tests {
             log_unmapped = "all"
             "#,
         )?;
-        assert_eq!(cfg.log_unmapped, Some(0..u32::MAX));
+        // "all" must include the very top of the address space.
+        assert_eq!(cfg.log_unmapped, Some(0..=u32::MAX));
+        assert!(cfg.log_unmapped.unwrap().contains(&0xFFFF_FFFF));
 
         assert_eq!(parse_config("")?.log_unmapped, None);
 
@@ -3885,7 +3887,7 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("start must be below end"), "{err}");
+        assert!(err.contains("start must not be above end"), "{err}");
         Ok(())
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2543,6 +2543,12 @@ impl CpuBus {
                 return u32::from(ramsey.read_byte(addr));
             }
         }
+        if size == 1 && self.bus.sdmac.is_some() && crate::sdmac::Sdmac::decodes(addr) {
+            self.bus.cpu_slow_external_access(1);
+            if let Some(sdmac) = self.bus.sdmac.as_mut() {
+                return u32::from(sdmac.read_byte(addr));
+            }
+        }
         // A configured functional Zorro board window (registers, boot ROM, DMA
         // strobes): the chain maps it to a device slot. Off the chip bus like
         // Gayle.
@@ -2757,6 +2763,13 @@ impl CpuBus {
             self.bus.cpu_slow_external_access(1);
             if let Some(ramsey) = self.bus.ramsey.as_mut() {
                 ramsey.write_byte(addr, value as u8);
+            }
+            return;
+        }
+        if size == 1 && self.bus.sdmac.is_some() && crate::sdmac::Sdmac::decodes(addr) {
+            self.bus.cpu_slow_external_access(1);
+            if let Some(sdmac) = self.bus.sdmac.as_mut() {
+                sdmac.write_byte(addr, value as u8);
             }
             return;
         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -26,9 +26,6 @@ pub const GAYLE_BASE: u32 = 0x00DA_0000;
 pub const GAYLE_SIZE: u32 = 0x0001_0000;
 pub const GAYLE_ID_BASE: u32 = 0x00DE_1000;
 pub const GAYLE_ID_SIZE: u32 = 0x0000_1000;
-/// Ramsey memory controller (A3000/A4000): control and version registers on
-/// the $DE0000 page, below the page Gayle uses for its ID register.
-pub use crate::ramsey::{RAMSEY_BASE, RAMSEY_SIZE};
 /// CDTV battery-backed bookmark RAM (top half of the RTC page).
 pub const CDTV_BATTRAM_BASE: u32 = 0x00DC_8000;
 pub const CDTV_BATTRAM_SIZE: u32 = 0x0000_8000;
@@ -2540,10 +2537,10 @@ impl CpuBus {
                 return value;
             }
         }
-        if self.bus.ramsey.is_some() && range_contains(RAMSEY_BASE, RAMSEY_SIZE, addr) {
-            self.bus.cpu_slow_external_access(Self::access_words(size));
+        if size == 1 && self.bus.ramsey.is_some() && crate::ramsey::decodes(addr) {
+            self.bus.cpu_slow_external_access(1);
             if let Some(ramsey) = self.bus.ramsey.as_ref() {
-                return ramsey.read(addr, size);
+                return u32::from(ramsey.read_byte(addr));
             }
         }
         // A configured functional Zorro board window (registers, boot ROM, DMA
@@ -2617,11 +2614,6 @@ impl CpuBus {
             return value;
         }
 
-        if crate::envcfg::flag("COPPERLINE_DIAG_GAYLE")
-            && (0x00D8_0000..0x00F0_0000).contains(&addr)
-        {
-            log::info!("float rd {addr:#08X}");
-        }
         self.bus.cpu_slow_external_access(1);
         // Undriven (unmapped) read: float to the last value the chip data bus
         // carried (display/audio DMA), as on the Agnus-arbitrated chip bus --
@@ -2629,11 +2621,20 @@ impl CpuBus {
         // to byte reads); a 68000 byte read takes the high data-bus byte at even
         // addresses, the low byte at odd.
         let data_bus = self.bus.data_bus;
-        if addr & 1 == 0 {
+        let value = if addr & 1 == 0 {
             u32::from(data_bus >> 8)
         } else {
             u32::from(data_bus & 0xFF)
+        };
+        if self
+            .bus
+            .log_unmapped
+            .as_ref()
+            .is_some_and(|r| r.contains(&addr))
+        {
+            log::info!("unmapped rd {addr:#08X}.b -> {value:#04X} (floating bus)");
         }
+        value
     }
 
     fn write_sized(&mut self, address: u32, size: usize, value: u32) {
@@ -2752,10 +2753,10 @@ impl CpuBus {
             }
             return;
         }
-        if self.bus.ramsey.is_some() && range_contains(RAMSEY_BASE, RAMSEY_SIZE, addr) {
-            self.bus.cpu_slow_external_access(Self::access_words(size));
+        if size == 1 && self.bus.ramsey.is_some() && crate::ramsey::decodes(addr) {
+            self.bus.cpu_slow_external_access(1);
             if let Some(ramsey) = self.bus.ramsey.as_mut() {
-                ramsey.write(addr, size, value);
+                ramsey.write_byte(addr, value as u8);
             }
             return;
         }
@@ -2840,10 +2841,13 @@ impl CpuBus {
             }
             return;
         }
-        if crate::envcfg::flag("COPPERLINE_DIAG_GAYLE")
-            && (0x00D8_0000..0x00F0_0000).contains(&addr)
+        if self
+            .bus
+            .log_unmapped
+            .as_ref()
+            .is_some_and(|r| r.contains(&addr))
         {
-            log::info!("float wr {addr:#08X} <- {value:#04X}");
+            log::info!("unmapped wr {addr:#08X}.b <- {value:#04X} (dropped)");
         }
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -26,6 +26,9 @@ pub const GAYLE_BASE: u32 = 0x00DA_0000;
 pub const GAYLE_SIZE: u32 = 0x0001_0000;
 pub const GAYLE_ID_BASE: u32 = 0x00DE_1000;
 pub const GAYLE_ID_SIZE: u32 = 0x0000_1000;
+/// Ramsey memory controller (A3000/A4000): control and version registers on
+/// the $DE0000 page, below the page Gayle uses for its ID register.
+pub use crate::ramsey::{RAMSEY_BASE, RAMSEY_SIZE};
 /// CDTV battery-backed bookmark RAM (top half of the RTC page).
 pub const CDTV_BATTRAM_BASE: u32 = 0x00DC_8000;
 pub const CDTV_BATTRAM_SIZE: u32 = 0x0000_8000;
@@ -2537,6 +2540,12 @@ impl CpuBus {
                 return value;
             }
         }
+        if self.bus.ramsey.is_some() && range_contains(RAMSEY_BASE, RAMSEY_SIZE, addr) {
+            self.bus.cpu_slow_external_access(Self::access_words(size));
+            if let Some(ramsey) = self.bus.ramsey.as_ref() {
+                return ramsey.read(addr, size);
+            }
+        }
         // A configured functional Zorro board window (registers, boot ROM, DMA
         // strobes): the chain maps it to a device slot. Off the chip bus like
         // Gayle.
@@ -2740,6 +2749,13 @@ impl CpuBus {
                 if gayle.take_activity() {
                     self.bus.note_hdd_activity();
                 }
+            }
+            return;
+        }
+        if self.bus.ramsey.is_some() && range_contains(RAMSEY_BASE, RAMSEY_SIZE, addr) {
+            self.bus.cpu_slow_external_access(Self::access_words(size));
+            if let Some(ramsey) = self.bus.ramsey.as_mut() {
+                ramsey.write(addr, size, value);
             }
             return;
         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2543,6 +2543,12 @@ impl CpuBus {
                 return u32::from(ramsey.read_byte(addr));
             }
         }
+        if size == 1 && self.bus.gary.is_some() && crate::gary::decodes(addr) {
+            self.bus.cpu_slow_external_access(1);
+            if let Some(gary) = self.bus.gary.as_ref() {
+                return u32::from(gary.read_byte(addr));
+            }
+        }
         if size == 1 && self.bus.sdmac.is_some() && crate::sdmac::Sdmac::decodes(addr) {
             self.bus.cpu_slow_external_access(1);
             let value = self
@@ -2766,6 +2772,13 @@ impl CpuBus {
                 }
             }
             return;
+        }
+        if size == 1 && self.bus.gary.is_some() && crate::gary::decodes(addr) {
+            self.bus.cpu_slow_external_access(1);
+            if let Some(gary) = self.bus.gary.as_mut() {
+                gary.write_byte(addr, value as u8);
+                return;
+            }
         }
         if size == 1 && self.bus.ramsey.is_some() && crate::ramsey::decodes(addr) {
             self.bus.cpu_slow_external_access(1);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2545,8 +2545,16 @@ impl CpuBus {
         }
         if size == 1 && self.bus.sdmac.is_some() && crate::sdmac::Sdmac::decodes(addr) {
             self.bus.cpu_slow_external_access(1);
-            if let Some(sdmac) = self.bus.sdmac.as_mut() {
-                return u32::from(sdmac.read_byte(addr));
+            let value = self
+                .bus
+                .sdmac
+                .as_mut()
+                .map(|sdmac| (u32::from(sdmac.read_byte(addr)), sdmac.take_activity()));
+            if let Some((value, activity)) = value {
+                if activity {
+                    self.bus.note_hdd_activity();
+                }
+                return value;
             }
         }
         // A configured functional Zorro board window (registers, boot ROM, DMA

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1963,7 +1963,7 @@ pub fn build_machine(
     }
     if cfg.sdmac {
         bus.attach_sdmac(crate::sdmac::Sdmac::new());
-        info!("sdmac: Super DMAC at $DD0000 (no WD33C93 fitted)");
+        info!("sdmac: Super DMAC + WD33C93 at $DD0000 (no drives)");
     }
     if let Some(revision) = cfg.mem_controller.ramsey_revision() {
         // TODO(codewiz): pass the real bank size once motherboard fast RAM

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1971,6 +1971,13 @@ pub fn build_machine(
         let bank_bytes = revision.stock_bank_bytes();
         bus.attach_ramsey(crate::ramsey::Ramsey::new(revision, bank_bytes));
     }
+    // Gary and Ramsey share one address decode -- Gary owns byte lanes 0-2 of
+    // the $DE0000 page and Ramsey lane 3 -- and tools probe Gary to find the
+    // Ramsey: xSysInfo gives up on the memory controller if it cannot first
+    // identify a Fat Gary. Fitting one without the other identifies as neither.
+    if cfg.gate_array.is_fat_gary() {
+        bus.attach_gary(crate::gary::Gary::new());
+    }
     if !devices.is_empty() {
         bus.attach_devices(devices);
     }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1953,6 +1953,12 @@ pub fn build_machine(
         }
         bus.attach_gayle(gayle);
     }
+    if let Some(revision) = cfg.mem_controller.ramsey_revision() {
+        // TODO(codewiz): pass the real bank size once motherboard fast RAM
+        // exists; until then Ramsey describes the stock DRAM for the part.
+        let bank_bytes = revision.stock_bank_bytes();
+        bus.attach_ramsey(crate::ramsey::Ramsey::new(revision, bank_bytes));
+    }
     if !devices.is_empty() {
         bus.attach_devices(devices);
     }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1953,6 +1953,13 @@ pub fn build_machine(
         }
         bus.attach_gayle(gayle);
     }
+    if let Some(range) = cfg.log_unmapped.clone() {
+        info!(
+            "debug: logging unmapped CPU accesses in {:#08X}-{:#08X}",
+            range.start, range.end
+        );
+        bus.log_unmapped = Some(range);
+    }
     if let Some(revision) = cfg.mem_controller.ramsey_revision() {
         // TODO(codewiz): pass the real bank size once motherboard fast RAM
         // exists; until then Ramsey describes the stock DRAM for the part.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1960,6 +1960,10 @@ pub fn build_machine(
         );
         bus.log_unmapped = Some(range);
     }
+    if cfg.sdmac {
+        bus.attach_sdmac(crate::sdmac::Sdmac::new());
+        info!("sdmac: Super DMAC at $DD0000 (no WD33C93 fitted)");
+    }
     if let Some(revision) = cfg.mem_controller.ramsey_revision() {
         // TODO(codewiz): pass the real bank size once motherboard fast RAM
         // exists; until then Ramsey describes the stock DRAM for the part.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1956,7 +1956,8 @@ pub fn build_machine(
     if let Some(range) = cfg.log_unmapped.clone() {
         info!(
             "debug: logging unmapped CPU accesses in {:#08X}-{:#08X}",
-            range.start, range.end
+            range.start(),
+            range.end()
         );
         bus.log_unmapped = Some(range);
     }

--- a/src/gary.rs
+++ b/src/gary.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Fat Gary: the bus controller of the A3000 and A4000.
+//!
+//! Gary owns the `$DE0000` page, and its address decode is cruder than a
+//! register map suggests: only the byte lane and two address bits matter, so
+//! every register is mirrored many times over.
+//!
+//! ```text
+//! lane = addr & 3          0,1,2 -> Gary; 3 -> Ramsey
+//! block = (addr >> 6) & 3  Ramsey: 0 -> control, 1 -> version, 2/3 -> $FF
+//! ```
+//!
+//! The whole thing then repeats every `$100` to the end of the page. So Gary's
+//! timeout register is at `$DE0000`, `$DE0004`, `$DE0100`, ... and the Ramsey
+//! version register that Kickstart reads at `$DE0043` is equally at `$DE0047`
+//! or `$DE0143`. This is why the diagnostic tools read addresses that look like
+//! nothing in particular: they are reading a mirror.
+//!
+//! Gary's three registers are single bits, all in bit 7:
+//!
+//! - `$DE0000` TIMEOUT: what an unanswered bus cycle produces, BERR or DSACK.
+//! - `$DE0001` TOENB: whether the timeout is enabled at all.
+//! - `$DE0002` COLDBOOT: the power-up flag, set by a cold start and cleared by
+//!   the OS. It is read/write, which is what makes it a Gary detector:
+//!   xSysInfo writes bit 7, reads a custom register to clear the sticky bus,
+//!   and expects to read bit 7 back -- a floating bus cannot fake that. Without
+//!   it, xSysInfo decides there is no Fat Gary and then does not even look for
+//!   the Ramsey behind it.
+//!
+//! Nothing here changes emulated behaviour: bus timeouts are not modelled (an
+//! unanswered cycle floats, it does not fault), and Kickstart reads COLDBOOT
+//! only to decide whether the reboot was warm. The registers exist so the
+//! machine can be identified as what it is.
+
+/// The page Gary decodes. Above `$DE8000` the decode stops (amiberry draws the
+/// line in the same place); the A600/A1200's Gayle ID register at `$DE1000` is
+/// inside it, which is correct -- those machines have a Gayle instead of a
+/// Gary, never both.
+pub const GARY_BASE: u32 = 0x00DE_0000;
+pub const GARY_SIZE: u32 = 0x8000;
+
+/// Byte lanes 0-2 are Gary's; lane 3 belongs to Ramsey.
+const LANE_TIMEOUT: u32 = 0;
+const LANE_TOENB: u32 = 1;
+const LANE_COLDBOOT: u32 = 2;
+/// Every Gary register is a single bit in bit 7.
+const FLAG: u8 = 0x80;
+
+/// Whether Gary drives the bus for a byte access at `addr`. Lane 3 is Ramsey's
+/// (see [`crate::ramsey::decodes`]), so the two never collide.
+pub fn decodes(addr: u32) -> bool {
+    (GARY_BASE..GARY_BASE + GARY_SIZE).contains(&addr) && (addr & 3) != 3
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Gary {
+    /// TIMEOUT: an unanswered bus cycle raises a bus error rather than being
+    /// completed with DSACK.
+    berr_on_timeout: bool,
+    /// TOENB: the bus timeout is enabled.
+    timeout_enabled: bool,
+    /// COLDBOOT: this reset was a cold start.
+    coldboot: bool,
+}
+
+impl Gary {
+    /// A Gary out of a cold start, which is what the flag means.
+    pub fn new() -> Self {
+        Self {
+            berr_on_timeout: false,
+            timeout_enabled: false,
+            coldboot: true,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    pub fn read_byte(&self, addr: u32) -> u8 {
+        let flag = match addr & 3 {
+            LANE_TIMEOUT => self.berr_on_timeout,
+            LANE_TOENB => self.timeout_enabled,
+            LANE_COLDBOOT => self.coldboot,
+            _ => return 0xFF, // lane 3 is Ramsey's; we never decode it
+        };
+        if flag {
+            FLAG
+        } else {
+            0x00
+        }
+    }
+
+    pub fn write_byte(&mut self, addr: u32, value: u8) {
+        let flag = value & FLAG != 0;
+        match addr & 3 {
+            LANE_TIMEOUT => self.berr_on_timeout = flag,
+            LANE_TOENB => self.timeout_enabled = flag,
+            LANE_COLDBOOT => self.coldboot = flag,
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// xSysInfo's Fat Gary probe: write bit 7 to the coldboot register, read it
+    /// back, then write zero and read that back. A floating bus fails this, and
+    /// failing it means xSysInfo never looks for the Ramsey behind Gary.
+    #[test]
+    fn the_coldboot_register_is_a_readable_writable_bit() {
+        let mut g = Gary::new();
+        g.write_byte(GARY_BASE + 2, 0x80);
+        assert_eq!(g.read_byte(GARY_BASE + 2) & 0x80, 0x80);
+        g.write_byte(GARY_BASE + 2, 0x00);
+        assert_eq!(g.read_byte(GARY_BASE + 2) & 0x80, 0x00);
+    }
+
+    /// A cold start is what the machine comes up out of.
+    #[test]
+    fn a_fresh_gary_reports_a_cold_boot() {
+        assert_eq!(Gary::new().read_byte(GARY_BASE + 2), 0x80);
+    }
+
+    /// Kickstart writes the timeout mode at $DE0000 on every boot; it and TOENB
+    /// are separate registers on separate byte lanes.
+    #[test]
+    fn the_timeout_registers_are_independent() {
+        let mut g = Gary::new();
+        g.write_byte(GARY_BASE, 0x80); // BERR on timeout
+        g.write_byte(GARY_BASE + 1, 0x00); // but the timeout is disabled
+        assert_eq!(g.read_byte(GARY_BASE), 0x80);
+        assert_eq!(g.read_byte(GARY_BASE + 1), 0x00);
+    }
+
+    /// The decode ignores everything but the byte lane, so every register is
+    /// mirrored across the page -- and lane 3 is left to Ramsey.
+    #[test]
+    fn the_registers_are_mirrored_across_the_page() {
+        let mut g = Gary::new();
+        g.write_byte(GARY_BASE + 0x144, 0x80); // a mirror of the timeout register
+        assert_eq!(g.read_byte(GARY_BASE), 0x80);
+
+        assert!(decodes(GARY_BASE));
+        assert!(decodes(GARY_BASE + 0x44));
+        assert!(decodes(GARY_BASE + 0x1002)); // where xSysInfo probes for a Gayle
+        assert!(!decodes(GARY_BASE + 3)); // Ramsey control
+        assert!(!decodes(GARY_BASE + 0x43)); // Ramsey version
+        assert!(!decodes(GARY_BASE + GARY_SIZE));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod filesys;
 pub mod floppy;
 #[cfg(feature = "frontend")]
 pub mod gamepad;
+pub mod gary;
 pub mod gayle;
 pub mod gdbstub;
 pub mod harddrive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod memory;
 pub mod midi;
 pub mod net;
 pub mod priority;
+pub mod ramsey;
 pub mod recorder;
 pub mod romsearch;
 pub mod rtc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod rtc;
 pub mod savestate;
 pub mod screenshot;
 pub mod scsi;
+pub mod sdmac;
 pub mod serial;
 pub mod timebase;
 pub mod timestamp;

--- a/src/ramsey.rs
+++ b/src/ramsey.rs
@@ -18,11 +18,13 @@ pub const RAMSEY_CONTROL: u32 = 0x00DE_0003;
 /// Ramsey version register. Byte-wide, read-only.
 pub const RAMSEY_VERSION: u32 = 0x00DE_0043;
 
-/// Base of the page Ramsey answers on.
-pub const RAMSEY_BASE: u32 = 0x00DE_0000;
-/// Size of that page. Ramsey decodes only two addresses inside it; the rest
-/// reads back as a floating bus.
-pub const RAMSEY_SIZE: u32 = 0x0100;
+/// Whether Ramsey drives the bus for a byte access at `addr`. It has exactly
+/// two registers and decodes nothing else: everything else on the $DE0000 page
+/// stays undriven, so it floats (and shows up in `[debug] log_unmapped`)
+/// rather than reading back a value we invented.
+pub fn decodes(addr: u32) -> bool {
+    addr == RAMSEY_CONTROL || addr == RAMSEY_VERSION
+}
 
 // Control register bits.
 /// Page mode enabled.
@@ -129,37 +131,20 @@ impl Ramsey {
         (1 << addr_bits) * width
     }
 
-    /// The byte at `addr`, or an all-ones floating bus off the two registers.
-    fn read_byte(&self, addr: u32) -> u8 {
-        match addr {
-            RAMSEY_CONTROL => self.control,
-            RAMSEY_VERSION => self.revision.version_id(),
-            _ => 0xFF,
+    /// Read one of the two registers. Callers must have checked `decodes`.
+    pub fn read_byte(&self, addr: u32) -> u8 {
+        if addr == RAMSEY_VERSION {
+            self.revision.version_id()
+        } else {
+            self.control
         }
     }
 
-    fn write_byte(&mut self, addr: u32, value: u8) {
+    pub fn write_byte(&mut self, addr: u32, value: u8) {
         if addr == RAMSEY_CONTROL {
             self.control = value;
         }
-        // The version register is read-only, and nothing else decodes.
-    }
-
-    /// Read `size` bytes. Both registers are byte-wide and sit on odd
-    /// addresses, so a wider access just gathers whatever each byte decodes to.
-    pub fn read(&self, addr: u32, size: usize) -> u32 {
-        let mut value = 0u32;
-        for i in 0..size as u32 {
-            value = (value << 8) | u32::from(self.read_byte(addr.wrapping_add(i)));
-        }
-        value
-    }
-
-    pub fn write(&mut self, addr: u32, size: usize, value: u32) {
-        for i in 0..size as u32 {
-            let shift = 8 * (size as u32 - 1 - i);
-            self.write_byte(addr.wrapping_add(i), (value >> shift) as u8);
-        }
+        // The version register is read-only.
     }
 }
 
@@ -171,15 +156,15 @@ mod tests {
     fn the_version_register_identifies_the_part() {
         let a3000 = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
         let a4000 = Ramsey::new(RamseyRevision::Rev7, 4 * 1024 * 1024);
-        assert_eq!(a3000.read(RAMSEY_VERSION, 1), 0x0D);
-        assert_eq!(a4000.read(RAMSEY_VERSION, 1), 0x0F);
+        assert_eq!(a3000.read_byte(RAMSEY_VERSION), 0x0D);
+        assert_eq!(a4000.read_byte(RAMSEY_VERSION), 0x0F);
     }
 
     #[test]
     fn the_version_register_ignores_writes() {
         let mut r = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
-        r.write(RAMSEY_VERSION, 1, 0xA5);
-        assert_eq!(r.read(RAMSEY_VERSION, 1), 0x0D);
+        r.write_byte(RAMSEY_VERSION, 0xA5);
+        assert_eq!(r.read_byte(RAMSEY_VERSION), 0x0D);
     }
 
     /// ziptest and Kickstart both write a mode to the control register and
@@ -189,8 +174,8 @@ mod tests {
     fn the_control_register_reads_back_what_was_written() {
         let mut r = Ramsey::new(RamseyRevision::Rev7, 4 * 1024 * 1024);
         for value in [0x00, 0xFF, CONTROL_BURST, CONTROL_PAGE | CONTROL_WRAP] {
-            r.write(RAMSEY_CONTROL, 1, u32::from(value));
-            assert_eq!(r.read(RAMSEY_CONTROL, 1), u32::from(value));
+            r.write_byte(RAMSEY_CONTROL, value);
+            assert_eq!(r.read_byte(RAMSEY_CONTROL), value);
         }
     }
 
@@ -220,12 +205,17 @@ mod tests {
         assert_eq!(r.control() & CONTROL_TEST, 0);
     }
 
-    /// Ramsey decodes two byte addresses; the rest of the page floats high.
+    /// Ramsey has exactly two registers. Anything else on the page must stay
+    /// undriven so it floats and gets logged, rather than reading back a value
+    /// we made up -- a guest reading the version at the wrong offset should
+    /// look wrong, not plausibly wrong.
     #[test]
-    fn undecoded_addresses_float_high() {
-        let r = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
-        assert_eq!(r.read(RAMSEY_BASE, 1), 0xFF);
-        assert_eq!(r.read(RAMSEY_CONTROL + 1, 1), 0xFF);
-        assert_eq!(r.read(RAMSEY_VERSION - 1, 1), 0xFF);
+    fn only_the_two_registers_are_decoded() {
+        assert!(decodes(RAMSEY_CONTROL));
+        assert!(decodes(RAMSEY_VERSION));
+        assert!(!decodes(0x00DE_0000));
+        assert!(!decodes(RAMSEY_CONTROL + 1));
+        assert!(!decodes(RAMSEY_VERSION - 1));
+        assert!(!decodes(0x00DE_1000)); // Gayle's ID page, on the wedge machines
     }
 }

--- a/src/ramsey.rs
+++ b/src/ramsey.rs
@@ -1,0 +1,231 @@
+//! Ramsey: the memory controller of the A3000 and A4000.
+//!
+//! Ramsey drives the motherboard fast RAM (32-bit local RAM at $07000000 on
+//! the A3000, $08000000 on the A4000): it refreshes the DRAM and decides
+//! whether to use page mode, burst mode and, on Ramsey-07, cycle-skip mode.
+//! The CPU sees only two registers.
+//!
+//! Only the register file is modelled. Refresh has no observable effect on an
+//! emulator that never loses a DRAM cell, and page/burst/skip mode only change
+//! how fast a real memory cycle completes, which we do not simulate either.
+//! The bits are still stored and read back, because Kickstart and the
+//! diagnostic tools write a mode and then spin until they read it back.
+
+/// Ramsey control register: refresh rate, page/burst mode, and a description
+/// of the DRAM fitted to the motherboard. Byte-wide, on an odd address.
+pub const RAMSEY_CONTROL: u32 = 0x00DE_0003;
+
+/// Ramsey version register. Byte-wide, read-only.
+pub const RAMSEY_VERSION: u32 = 0x00DE_0043;
+
+/// Base of the page Ramsey answers on.
+pub const RAMSEY_BASE: u32 = 0x00DE_0000;
+/// Size of that page. Ramsey decodes only two addresses inside it; the rest
+/// reads back as a floating bus.
+pub const RAMSEY_SIZE: u32 = 0x0100;
+
+// Control register bits.
+/// Page mode enabled.
+pub const CONTROL_PAGE: u8 = 1 << 0;
+/// Burst mode enabled.
+pub const CONTROL_BURST: u8 = 1 << 1;
+/// Allow backward bursts to wrap.
+pub const CONTROL_WRAP: u8 = 1 << 2;
+/// DRAM depth: 1 = 1Mx4 (4 MiB banks), 0 = 256Kx4 (1 MiB banks).
+pub const CONTROL_RAMSIZE: u8 = 1 << 3;
+/// Ramsey-04: DRAM width, 1 = 4-bit parts. Ramsey-07 reuses this bit for
+/// cycle-skip mode and always drives 4-bit parts.
+pub const CONTROL_RAMWIDTH: u8 = 1 << 4;
+/// Ramsey-07: 4-clock cycles instead of 5.
+pub const CONTROL_SKIP: u8 = 1 << 4;
+/// Refresh rate, 00 = 154 clocks, 01 = 238, 10 = 380, 11 = off.
+pub const CONTROL_REFRESH: u8 = 3 << 5;
+/// Test mode.
+pub const CONTROL_TEST: u8 = 1 << 7;
+
+/// Which Ramsey is fitted. The revision is not cosmetic: the diagnostic tools
+/// and Kickstart read the version register to decide how to interpret the
+/// control register, and the two parts disagree about bit 4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RamseyRevision {
+    /// Ramsey-04, as fitted to the A3000. Supports 1-bit-wide DRAM.
+    Rev4,
+    /// Ramsey-07, as fitted to the A4000. 1-bit DRAM support was dropped and
+    /// the bit reused for cycle-skip mode.
+    Rev7,
+}
+
+impl RamseyRevision {
+    /// The byte read back from the version register.
+    pub fn version_id(self) -> u8 {
+        match self {
+            Self::Rev4 => 0x0D,
+            Self::Rev7 => 0x0F,
+        }
+    }
+
+    /// Bytes per bank of the DRAM these machines shipped with: 256Kx4 parts
+    /// on the A3000, 1Mx4 on the A4000.
+    pub fn stock_bank_bytes(self) -> u32 {
+        match self {
+            Self::Rev4 => 1024 * 1024,
+            Self::Rev7 => 4 * 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Ramsey {
+    revision: RamseyRevision,
+    control: u8,
+}
+
+impl Ramsey {
+    /// A Ramsey whose control register comes up describing `bank_bytes` of
+    /// motherboard DRAM per bank.
+    ///
+    /// Real Ramsey powers up with the control register cleared and Kickstart
+    /// programs it while sizing memory. We seed it with a value that already
+    /// matches the RAM we emulate, so that a diagnostic run on a machine that
+    /// never got as far as Kickstart's memory sizing still reports the truth.
+    pub fn new(revision: RamseyRevision, bank_bytes: u32) -> Self {
+        let mut control = 0;
+        // 1Mx4 parts give 4 MiB banks; 256Kx4 parts give 1 MiB banks.
+        if bank_bytes >= 4 * 1024 * 1024 {
+            control |= CONTROL_RAMSIZE;
+        }
+        // Ramsey-07 has no 1-bit DRAM to describe, and bit 4 means skip mode.
+        if revision == RamseyRevision::Rev4 {
+            control |= CONTROL_RAMWIDTH;
+        }
+        Self { revision, control }
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new(self.revision, self.bank_bytes());
+    }
+
+    pub fn revision(&self) -> RamseyRevision {
+        self.revision
+    }
+
+    pub fn control(&self) -> u8 {
+        self.control
+    }
+
+    /// Bytes per memory bank, as currently described by the control register.
+    fn bank_bytes(&self) -> u32 {
+        let addr_bits = if self.control & CONTROL_RAMSIZE != 0 {
+            20
+        } else {
+            18
+        };
+        let width = if self.revision == RamseyRevision::Rev4 && self.control & CONTROL_RAMWIDTH == 0
+        {
+            1
+        } else {
+            4
+        };
+        (1 << addr_bits) * width
+    }
+
+    /// The byte at `addr`, or an all-ones floating bus off the two registers.
+    fn read_byte(&self, addr: u32) -> u8 {
+        match addr {
+            RAMSEY_CONTROL => self.control,
+            RAMSEY_VERSION => self.revision.version_id(),
+            _ => 0xFF,
+        }
+    }
+
+    fn write_byte(&mut self, addr: u32, value: u8) {
+        if addr == RAMSEY_CONTROL {
+            self.control = value;
+        }
+        // The version register is read-only, and nothing else decodes.
+    }
+
+    /// Read `size` bytes. Both registers are byte-wide and sit on odd
+    /// addresses, so a wider access just gathers whatever each byte decodes to.
+    pub fn read(&self, addr: u32, size: usize) -> u32 {
+        let mut value = 0u32;
+        for i in 0..size as u32 {
+            value = (value << 8) | u32::from(self.read_byte(addr.wrapping_add(i)));
+        }
+        value
+    }
+
+    pub fn write(&mut self, addr: u32, size: usize, value: u32) {
+        for i in 0..size as u32 {
+            let shift = 8 * (size as u32 - 1 - i);
+            self.write_byte(addr.wrapping_add(i), (value >> shift) as u8);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_version_register_identifies_the_part() {
+        let a3000 = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
+        let a4000 = Ramsey::new(RamseyRevision::Rev7, 4 * 1024 * 1024);
+        assert_eq!(a3000.read(RAMSEY_VERSION, 1), 0x0D);
+        assert_eq!(a4000.read(RAMSEY_VERSION, 1), 0x0F);
+    }
+
+    #[test]
+    fn the_version_register_ignores_writes() {
+        let mut r = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
+        r.write(RAMSEY_VERSION, 1, 0xA5);
+        assert_eq!(r.read(RAMSEY_VERSION, 1), 0x0D);
+    }
+
+    /// ziptest and Kickstart both write a mode to the control register and
+    /// then spin until they read it back. A write that does not stick hangs
+    /// the guest with interrupts disabled.
+    #[test]
+    fn the_control_register_reads_back_what_was_written() {
+        let mut r = Ramsey::new(RamseyRevision::Rev7, 4 * 1024 * 1024);
+        for value in [0x00, 0xFF, CONTROL_BURST, CONTROL_PAGE | CONTROL_WRAP] {
+            r.write(RAMSEY_CONTROL, 1, u32::from(value));
+            assert_eq!(r.read(RAMSEY_CONTROL, 1), u32::from(value));
+        }
+    }
+
+    /// The reset value has to describe the DRAM we actually emulate, or
+    /// ziptest reports a memory configuration that was never fitted.
+    #[test]
+    fn the_reset_control_describes_the_fitted_dram() {
+        // A4000: 1Mx4 parts, 4 MiB banks. Ramsey-07 has no width bit.
+        let a4000 = Ramsey::new(RamseyRevision::Rev7, 4 * 1024 * 1024);
+        assert_eq!(a4000.control() & CONTROL_RAMSIZE, CONTROL_RAMSIZE);
+        assert_eq!(a4000.control() & CONTROL_SKIP, 0);
+        assert_eq!(a4000.bank_bytes(), 4 * 1024 * 1024);
+
+        // A3000: 256Kx4 parts, 1 MiB banks.
+        let a3000 = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
+        assert_eq!(a3000.control() & CONTROL_RAMSIZE, 0);
+        assert_eq!(a3000.control() & CONTROL_RAMWIDTH, CONTROL_RAMWIDTH);
+        assert_eq!(a3000.bank_bytes(), 1024 * 1024);
+    }
+
+    /// Refresh comes up at index 0 (154 clocks), which is what both diagnostic
+    /// tools expect to see on a machine Kickstart has not reprogrammed.
+    #[test]
+    fn refresh_comes_up_at_the_fastest_rate() {
+        let r = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
+        assert_eq!(r.control() & CONTROL_REFRESH, 0);
+        assert_eq!(r.control() & CONTROL_TEST, 0);
+    }
+
+    /// Ramsey decodes two byte addresses; the rest of the page floats high.
+    #[test]
+    fn undecoded_addresses_float_high() {
+        let r = Ramsey::new(RamseyRevision::Rev4, 1024 * 1024);
+        assert_eq!(r.read(RAMSEY_BASE, 1), 0xFF);
+        assert_eq!(r.read(RAMSEY_CONTROL + 1, 1), 0xFF);
+        assert_eq!(r.read(RAMSEY_VERSION - 1, 1), 0xFF);
+    }
+}

--- a/src/ramsey.rs
+++ b/src/ramsey.rs
@@ -18,12 +18,22 @@ pub const RAMSEY_CONTROL: u32 = 0x00DE_0003;
 /// Ramsey version register. Byte-wide, read-only.
 pub const RAMSEY_VERSION: u32 = 0x00DE_0043;
 
-/// Whether Ramsey drives the bus for a byte access at `addr`. It has exactly
-/// two registers and decodes nothing else: everything else on the $DE0000 page
-/// stays undriven, so it floats (and shows up in `[debug] log_unmapped`)
-/// rather than reading back a value we invented.
+/// Whether Ramsey drives the bus for a byte access at `addr`.
+///
+/// Ramsey sits on byte lane 3 of the page Gary decodes (see [`crate::gary`]),
+/// and only two address bits pick the register, so both are mirrored many times
+/// over: the control register answers at $DE0003, $DE0007, ... $DE003F, and
+/// again every $100. Bits 6-7 of the address select which register, and the two
+/// blocks Ramsey does not use read back $FF.
 pub fn decodes(addr: u32) -> bool {
-    addr == RAMSEY_CONTROL || addr == RAMSEY_VERSION
+    (crate::gary::GARY_BASE..crate::gary::GARY_BASE + crate::gary::GARY_SIZE).contains(&addr)
+        && (addr & 3) == 3
+}
+
+/// Which of Ramsey's registers an address selects: block 0 is the control
+/// register, block 1 the version, and blocks 2 and 3 are undriven.
+fn block(addr: u32) -> u32 {
+    (addr >> 6) & 3
 }
 
 // Control register bits.
@@ -133,18 +143,19 @@ impl Ramsey {
 
     /// Read one of the two registers. Callers must have checked `decodes`.
     pub fn read_byte(&self, addr: u32) -> u8 {
-        if addr == RAMSEY_VERSION {
-            self.revision.version_id()
-        } else {
-            self.control
+        match block(addr) {
+            0 => self.control,
+            1 => self.revision.version_id(),
+            // Ramsey answers on the lane but drives nothing in these blocks.
+            _ => 0xFF,
         }
     }
 
     pub fn write_byte(&mut self, addr: u32, value: u8) {
-        if addr == RAMSEY_CONTROL {
+        // The version register is read-only, and so are the unused blocks.
+        if block(addr) == 0 {
             self.control = value;
         }
-        // The version register is read-only.
     }
 }
 

--- a/src/sdmac.rs
+++ b/src/sdmac.rs
@@ -1,32 +1,24 @@
-//! Super DMAC (SDMAC): the SCSI DMA controller of the A3000.
+//! Super DMAC (SDMAC): the SCSI DMA controller on the A3000 motherboard.
 //!
-//! The SDMAC sits between the CPU bus and a WD33C93 SCSI controller: it owns a
-//! DMA FIFO and the interrupt plumbing, and it maps the WD33C93's own register
-//! file into two of its addresses (a register-select latch and a data port).
+//! The SDMAC sits between the CPU bus and a WD33C93 SCSI controller: it owns
+//! the DMA FIFO and the interrupt plumbing, and it maps the WD33C93's own
+//! register file into two of its addresses (a register-select latch and a data
+//! port). Kickstart's built-in scsi.device drives the pair, so unlike the Zorro
+//! controllers there is no boot ROM to load: the machine either has a working
+//! SDMAC + WD33C93 or it hangs during scsi.device init.
 //!
-//! Only the register file is modelled: no DMA engine, and no WD33C93 behind
-//! it. This is not yet enough to boot an A3000, and the machine it leaves is
-//! not an A3000 with an empty SCSI socket either -- see below.
+//! This is the same layering `crate::a2091` uses, and the same one amiberry
+//! uses: the A2091's DMAC and the A3000's SDMAC are two front-ends onto one
+//! WD33C93 core ([`crate::scsi::Wd33c93`]). Only the front-end differs -- the
+//! register map, the ISTR bits, and a 32-bit DMA address counter instead of the
+//! Zorro II DMAC's 24-bit one.
 //!
-//! What it does fix is a hang. Kickstart's scsi.device spins on the interrupt
-//! status register waiting for the DMA FIFO to report itself empty, and with
-//! nothing decoding that address the FIFO-empty bit reads back as zero
-//! forever, so the ROM never reaches a display. An idle SDMAC reports an empty
-//! FIFO and no interrupt pending, which gets the driver moving again.
-//!
-//! It then deadlocks one step further along: the driver arms interrupts, sends
-//! the WD33C93 a command, and waits for the completion interrupt, which nothing
-//! here can raise. Exec ends up in its idle loop with no runnable task. Neither
-//! an all-ones nor an all-zeroes auxiliary status persuades it to give up on
-//! the missing chip, and amiberry offers no guidance because it has no
-//! absent-WD33C93 path at all: its SDMAC always routes the register window
-//! straight into a WD33C93 core.
-//!
-//! So the way out is to fit the chip. We already have a WD33C93 in
-//! `crate::scsi`, driven by the A2091's DMAC in `crate::a2091` -- exactly the
-//! layering amiberry uses, where the A2091 DMAC and the A3000 SDMAC are two
-//! front-ends onto one shared core. Wiring `SASR`/`SCMD` through to it, and
-//! its interrupt to INT2, is the next step and the one that should boot.
+//! The DMA engine has no FIFO of its own: a transfer moves every byte the
+//! WD33C93 offers or wants within the access that completes the handshake, so
+//! the FIFO always reads back empty and never full.
+
+use crate::memory::Memory;
+use crate::scsi::{DmaDir, ScsiDisk, Wd33c93};
 
 /// Base of the SDMAC register file.
 pub const SDMAC_BASE: u32 = 0x00DD_0000;
@@ -46,7 +38,9 @@ const CLR_INT: u32 = 0x1B; // W    Strobe: clear interrupts
 const ISTR: u32 = 0x1F; // R    Interrupt status
 const SP_DMA: u32 = 0x3F; // W    Strobe: stop DMA
 const SCMD: u32 = 0x43; // R/W  WD33C93 data port
-const SASR: u32 = 0x49; // R/W  WD33C93 register select
+const SCMD_ALT: u32 = 0x47; // R/W  ... and its alias
+const SASR: u32 = 0x49; // R/W  WD33C93 register select (reads: aux status)
+const SASR_ALT: u32 = 0x41; // R/W  ... and its alias
 const SSPBDAT: u32 = 0x58; // R/W  Synchronous serial periph. bus data, 32-bit
 const SSPBCTL: u32 = 0x5C; // R/W  Synchronous serial periph. bus control, 32-bit
 
@@ -72,38 +66,96 @@ pub const CONTR_INTEN: u8 = 0x04;
 /// Strobe: reset the WD33C93.
 pub const CONTR_RESET: u8 = 0x10;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+/// The SDMAC masters the full 32-bit address space, word-aligned -- unlike the
+/// A2091's Zorro II DMAC, which is limited to 24 bits.
+const DMA_ADDR_MASK: u32 = 0xFFFF_FFFE;
+
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct Sdmac {
+    /// The SCSI controller behind the DMA front-end.
+    pub wd: Wd33c93,
     /// Control register. Only the latched bits read back; RESET is a strobe.
     contr: u8,
     /// DACK width. Write-only on real silicon, so nothing ever reads it back.
     dawr: u8,
     /// DMA address register. It lives in Ramsey, not in the SDMAC, but it is
     /// addressed through the SDMAC window, so it is modelled here with the DMA
-    /// engine that would use it. The low two bits are wired to zero: this is a
+    /// engine that uses it. The low two bits are wired to zero: this is a
     /// longword address.
     acr: u32,
     /// Synchronous serial peripheral bus, used for the external clock/EEPROM
     /// on some boards. Nothing behind it here; the registers latch.
     sspbdat: u32,
     sspbctl: u32,
-    /// WD33C93 register-select latch. The chip it selects is not fitted.
-    sasr: u8,
+    /// Set by ST_DMA, cleared by SP_DMA and FLUSH.
+    dma_active: bool,
+    dma_warned: bool,
+    activity: bool,
+}
+
+impl Default for Sdmac {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Sdmac {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            wd: Wd33c93::new(),
+            contr: 0,
+            dawr: 0,
+            acr: 0,
+            sspbdat: 0,
+            sspbctl: 0,
+            dma_active: false,
+            dma_warned: false,
+            activity: false,
+        }
     }
 
+    /// Fit a drive at a SCSI ID (0-6; 7 is the controller itself).
+    pub fn attach_drive(&mut self, unit: usize, disk: ScsiDisk) {
+        self.wd.attach_target(unit, disk);
+    }
+
+    /// System reset: clear the DMAC and the SBIC, but keep the mounted drives.
     pub fn reset(&mut self) {
-        *self = Self::default();
+        self.wd.reset();
+        self.contr = 0;
+        self.dawr = 0;
+        self.acr = 0;
+        self.sspbdat = 0;
+        self.sspbctl = 0;
+        self.dma_active = false;
     }
 
-    /// Interrupt status. With no DMA engine the FIFO is always empty and never
-    /// full, and with no WD33C93 nothing ever raises an interrupt.
+    /// Drain the activity latch for the HDD LED.
+    pub fn take_activity(&mut self) -> bool {
+        std::mem::take(&mut self.activity) | self.wd.take_activity()
+    }
+
+    /// Advance emulated time: deliver delayed WD33C93 interrupts and pump any
+    /// DMA handshake that became ready.
+    pub fn tick(&mut self, cck: u32, mem: &mut Memory) {
+        self.wd.tick(cck);
+        self.pump_dma(mem);
+    }
+
+    /// Interrupt status. The DMA engine has no FIFO to fill, so it is empty
+    /// whenever no transfer is running and never full.
     fn istr(&self) -> u8 {
-        ISTR_FIFOE
+        let mut v = 0;
+        if !self.dma_active {
+            v |= ISTR_FIFOE;
+        }
+        if self.wd.int_asserted() {
+            v |= ISTR_INT_S | ISTR_INT_F;
+        }
+        if self.int_line() {
+            v |= ISTR_INT_P;
+        }
+        v
     }
 
     /// The word transfer count exists on the SDMAC-02 and was dropped on the
@@ -132,7 +184,16 @@ impl Sdmac {
         let in_long = |base: u32| (base..base + 4).contains(&off);
         let hit = matches!(
             off,
-            DAWR | CONTR | ST_DMA | FLUSH | CLR_INT | ISTR | SP_DMA | SCMD | SASR
+            DAWR | CONTR
+                | ST_DMA
+                | FLUSH
+                | CLR_INT
+                | ISTR
+                | SP_DMA
+                | SCMD
+                | SCMD_ALT
+                | SASR
+                | SASR_ALT
         ) || in_long(WTC)
             || in_long(ACR)
             || in_long(SSPBDAT)
@@ -157,14 +218,10 @@ impl Sdmac {
         match off {
             ISTR => self.istr(),
             CONTR => self.contr,
-            // TODO(codewiz): route these to a crate::scsi WD33C93. Reading the
-            // select address returns the chip's auxiliary status; the data
-            // port returns the selected register. Until a chip is fitted these
-            // are a guess, and no value works: scsi.device gets far enough to
-            // wait for an interrupt no one can raise. $00 at least does not
-            // claim a chip that is permanently busy (CIP and BSY set).
-            SASR => 0x00,
-            SCMD => 0xFF,
+            // Reading the select address gives the chip's auxiliary status;
+            // reading the data port gives the selected register.
+            SASR | SASR_ALT => self.wd.read_aux_status(),
+            SCMD | SCMD_ALT => self.wd.read_data_port(),
             _ if (WTC..WTC + 4).contains(&off) => Self::long_byte(self.wtc(), off, WTC),
             _ if (ACR..ACR + 4).contains(&off) => Self::long_byte(self.acr, off, ACR),
             _ if (SSPBDAT..SSPBDAT + 4).contains(&off) => {
@@ -184,17 +241,24 @@ impl Sdmac {
         };
         match off {
             DAWR => self.dawr = value,
-            // RESET would reset the WD33C93, which is not fitted. The bit is a
-            // strobe and does not latch.
-            CONTR => self.contr = value & !CONTR_RESET,
-            SASR => self.sasr = value,
-            // Writes to the missing WD33C93 go nowhere. Its register-select
-            // latch still holds, so a driver can write a register number and
-            // read $FF back from the data port, which is how it concludes the
-            // socket is empty.
-            SCMD => {}
-            // The strobes have no DMA engine to act on.
-            ST_DMA | SP_DMA | FLUSH | CLR_INT => {}
+            CONTR => {
+                // RESET is a strobe on the WD33C93's reset line: it does not
+                // latch, and it drops the drives' state, not the drives.
+                self.contr = value & !CONTR_RESET;
+                if value & CONTR_RESET != 0 {
+                    self.wd.reset();
+                }
+            }
+            SASR | SASR_ALT => self.wd.write_sasr(value),
+            SCMD | SCMD_ALT => self.wd.write_data_port(value),
+            // DMA start/stop. The transfer itself is pumped from `tick`, which
+            // runs before the driver can look at the result.
+            ST_DMA => self.dma_active = true,
+            SP_DMA | FLUSH => self.dma_active = false,
+            // Nothing to clear: ISTR is computed from the chip's own interrupt
+            // state, which the driver clears by reading the SCSI status
+            // register through SCMD.
+            CLR_INT => {}
             // The word transfer count does not exist on the SDMAC-04.
             _ if (WTC..WTC + 4).contains(&off) => {}
             _ if (ACR..ACR + 4).contains(&off) => {
@@ -211,9 +275,66 @@ impl Sdmac {
         }
     }
 
-    /// The SDMAC never raises an interrupt without a WD33C93 to raise one for.
+    /// The INT2 line into Paula (PORTS), gated by the control register's
+    /// interrupt enable.
     pub fn int_line(&self) -> bool {
-        false
+        self.contr & CONTR_INTEN != 0 && self.wd.int_asserted()
+    }
+
+    /// Move every byte the WD33C93 currently offers or wants between its data
+    /// path and Amiga memory, a word at a time, while DMA is started.
+    fn pump_dma(&mut self, mem: &mut Memory) {
+        if !self.dma_active {
+            return;
+        }
+        while let Some(dir) = self.wd.dma_request() {
+            if self.wd.dma_remaining() == 0 {
+                break;
+            }
+            self.activity = true;
+            let addr = self.acr & DMA_ADDR_MASK;
+            match dir {
+                DmaDir::In => {
+                    let b0 = self.wd.dma_in_byte();
+                    let b1 = if self.wd.dma_request().is_some() && self.wd.dma_remaining() > 0 {
+                        self.wd.dma_in_byte()
+                    } else {
+                        // An odd byte count still writes a full word; the pad
+                        // byte is whatever the FIFO carries (zero here).
+                        0
+                    };
+                    self.dma_write_word(mem, addr, (u16::from(b0) << 8) | u16::from(b1));
+                }
+                DmaDir::Out => {
+                    let w = self.dma_read_word(mem, addr);
+                    self.wd.dma_out_byte((w >> 8) as u8);
+                    if self.wd.dma_request().is_some() && self.wd.dma_remaining() > 0 {
+                        self.wd.dma_out_byte(w as u8);
+                    }
+                }
+            }
+            self.acr = self.acr.wrapping_add(2);
+        }
+    }
+
+    fn dma_read_word(&mut self, mem: &Memory, addr: u32) -> u16 {
+        crate::zorro_device::dma_read_word(mem, addr).unwrap_or_else(|| {
+            self.warn_dma_target(addr);
+            0xFFFF
+        })
+    }
+
+    fn dma_write_word(&mut self, mem: &mut Memory, addr: u32, w: u16) {
+        if !crate::zorro_device::dma_write_word(mem, addr, w) {
+            self.warn_dma_target(addr);
+        }
+    }
+
+    fn warn_dma_target(&mut self, addr: u32) {
+        if !self.dma_warned {
+            self.dma_warned = true;
+            log::warn!("sdmac: DMA to unmapped address {addr:#08X}; ignoring");
+        }
     }
 }
 
@@ -299,20 +420,78 @@ mod tests {
         }
     }
 
-    /// With no WD33C93 fitted the auxiliary status at least must not claim a
-    /// chip that is permanently busy: $FF sets CIP and BSY, and a driver then
-    /// waits forever for a command to finish. This does not make the machine
-    /// boot -- only fitting the chip will -- but it pins down the one value we
-    /// know to be wrong.
+    /// An idle WD33C93 is neither busy nor mid-command, and has nothing to say.
+    /// $FF here (CIP | BSY | INT set) leaves scsi.device waiting forever for a
+    /// command that never finishes.
     #[test]
-    fn an_absent_wd33c93_does_not_claim_to_be_permanently_busy() {
+    fn the_auxiliary_status_of_an_idle_chip_is_quiet() {
         use crate::scsi::{ASR_BSY, ASR_CIP, ASR_INT};
         let mut s = sdmac();
-        s.write_byte(SDMAC_BASE + SASR, 0x15);
-        assert_eq!(s.read_byte(SDMAC_BASE + SCMD), 0xFF);
-
         let aux = s.read_byte(SDMAC_BASE + SASR);
         assert_eq!(aux & (ASR_CIP | ASR_BSY | ASR_INT), 0, "aux {aux:#04X}");
+    }
+
+    /// The WD33C93's registers are reached by writing a register number to the
+    /// select latch and reading or writing the data port. Both addresses have
+    /// an alias four bytes below (the SDMAC decodes them loosely) -- SysInfo
+    /// polls the auxiliary status through the $41 alias, and read 250,000
+    /// floating $00s before this decoded.
+    #[test]
+    fn the_wd33c93_register_file_is_reachable_through_both_aliases() {
+        use crate::scsi::WD_OWN_ID;
+        for select in [SASR, SASR_ALT] {
+            for data in [SCMD, SCMD_ALT] {
+                let mut s = sdmac();
+                s.write_byte(SDMAC_BASE + select, WD_OWN_ID);
+                s.write_byte(SDMAC_BASE + data, 0x07);
+                s.write_byte(SDMAC_BASE + select, WD_OWN_ID);
+                assert_eq!(
+                    s.read_byte(SDMAC_BASE + data),
+                    0x07,
+                    "select {select:#04X} data {data:#04X}"
+                );
+            }
+        }
+    }
+
+    /// The control register's interrupt enable gates the INT2 line, and the
+    /// chip's interrupt shows up in ISTR whether or not it is enabled.
+    #[test]
+    fn the_interrupt_enable_gates_int2_but_not_the_status_register() {
+        let mut s = sdmac();
+        assert!(!s.int_line());
+        assert_eq!(s.istr() & (ISTR_INT_S | ISTR_INT_P), 0);
+
+        // Reset-complete raises the chip's interrupt without any drive.
+        s.write_byte(SDMAC_BASE + CONTR, CONTR_RESET);
+        s.write_byte(SDMAC_BASE + SASR, crate::scsi::WD_OWN_ID);
+        s.write_byte(SDMAC_BASE + SCMD, 0x07);
+        s.write_byte(SDMAC_BASE + SASR, crate::scsi::WD_COMMAND);
+        s.write_byte(SDMAC_BASE + SCMD, 0x00); // CSR_RESET
+        s.wd.tick(1000);
+        assert!(s.wd.int_asserted(), "the chip should interrupt after reset");
+
+        assert_eq!(s.istr() & ISTR_INT_S, ISTR_INT_S);
+        assert!(!s.int_line(), "INT2 is masked until CONTR enables it");
+
+        s.write_byte(SDMAC_BASE + CONTR, CONTR_INTEN);
+        assert!(s.int_line());
+        assert_eq!(s.istr() & ISTR_INT_P, ISTR_INT_P);
+    }
+
+    /// A started transfer takes the FIFO out of the empty state; stopping or
+    /// flushing it puts it back. Kickstart waits on this bit.
+    #[test]
+    fn the_dma_strobes_drive_the_fifo_empty_flag() {
+        let mut s = sdmac();
+        assert_eq!(s.read_byte(SDMAC_BASE + ISTR) & ISTR_FIFOE, ISTR_FIFOE);
+        s.write_byte(SDMAC_BASE + ST_DMA, 0);
+        assert_eq!(s.read_byte(SDMAC_BASE + ISTR) & ISTR_FIFOE, 0);
+        s.write_byte(SDMAC_BASE + FLUSH, 0);
+        assert_eq!(s.read_byte(SDMAC_BASE + ISTR) & ISTR_FIFOE, ISTR_FIFOE);
+        s.write_byte(SDMAC_BASE + ST_DMA, 0);
+        s.write_byte(SDMAC_BASE + SP_DMA, 0);
+        assert_eq!(s.read_byte(SDMAC_BASE + ISTR) & ISTR_FIFOE, ISTR_FIFOE);
     }
 
     /// The file repeats every $100; cdhooper's tool writes through the shadow

--- a/src/sdmac.rs
+++ b/src/sdmac.rs
@@ -1,0 +1,340 @@
+//! Super DMAC (SDMAC): the SCSI DMA controller of the A3000.
+//!
+//! The SDMAC sits between the CPU bus and a WD33C93 SCSI controller: it owns a
+//! DMA FIFO and the interrupt plumbing, and it maps the WD33C93's own register
+//! file into two of its addresses (a register-select latch and a data port).
+//!
+//! Only the register file is modelled: no DMA engine, and no WD33C93 behind
+//! it. This is not yet enough to boot an A3000, and the machine it leaves is
+//! not an A3000 with an empty SCSI socket either -- see below.
+//!
+//! What it does fix is a hang. Kickstart's scsi.device spins on the interrupt
+//! status register waiting for the DMA FIFO to report itself empty, and with
+//! nothing decoding that address the FIFO-empty bit reads back as zero
+//! forever, so the ROM never reaches a display. An idle SDMAC reports an empty
+//! FIFO and no interrupt pending, which gets the driver moving again.
+//!
+//! It then deadlocks one step further along: the driver arms interrupts, sends
+//! the WD33C93 a command, and waits for the completion interrupt, which nothing
+//! here can raise. Exec ends up in its idle loop with no runnable task. Neither
+//! an all-ones nor an all-zeroes auxiliary status persuades it to give up on
+//! the missing chip, and amiberry offers no guidance because it has no
+//! absent-WD33C93 path at all: its SDMAC always routes the register window
+//! straight into a WD33C93 core.
+//!
+//! So the way out is to fit the chip. We already have a WD33C93 in
+//! `crate::scsi`, driven by the A2091's DMAC in `crate::a2091` -- exactly the
+//! layering amiberry uses, where the A2091 DMAC and the A3000 SDMAC are two
+//! front-ends onto one shared core. Wiring `SASR`/`SCMD` through to it, and
+//! its interrupt to INT2, is the next step and the one that should boot.
+
+/// Base of the SDMAC register file.
+pub const SDMAC_BASE: u32 = 0x00DD_0000;
+/// The register file repeats every $100 bytes; the second copy is the "ALT"
+/// shadow that cdhooper's sdmac tool writes through to defeat CPU write
+/// buffering. Decoding the window as two mirrors is what makes that work.
+pub const SDMAC_SIZE: u32 = 0x0200;
+
+// Register offsets within the $100-byte file.
+const DAWR: u32 = 0x03; // W    DACK width
+const WTC: u32 = 0x04; // R/W  Word transfer count (SDMAC-02 only), 32-bit
+const CONTR: u32 = 0x0B; // R/W  Control
+const ACR: u32 = 0x0C; // R/W  DMA address (physically in Ramsey), 32-bit
+const ST_DMA: u32 = 0x13; // W    Strobe: start DMA
+const FLUSH: u32 = 0x17; // W    Strobe: flush DMA FIFO
+const CLR_INT: u32 = 0x1B; // W    Strobe: clear interrupts
+const ISTR: u32 = 0x1F; // R    Interrupt status
+const SP_DMA: u32 = 0x3F; // W    Strobe: stop DMA
+const SCMD: u32 = 0x43; // R/W  WD33C93 data port
+const SASR: u32 = 0x49; // R/W  WD33C93 register select
+const SSPBDAT: u32 = 0x58; // R/W  Synchronous serial periph. bus data, 32-bit
+const SSPBCTL: u32 = 0x5C; // R/W  Synchronous serial periph. bus control, 32-bit
+
+// ISTR bits.
+/// DMA FIFO is empty. Kickstart waits on this during scsi.device init.
+pub const ISTR_FIFOE: u8 = 0x01;
+/// DMA FIFO is full.
+pub const ISTR_FIFOF: u8 = 0x02;
+/// An enabled interrupt is pending.
+pub const ISTR_INT_P: u8 = 0x10;
+/// DMA done (end of process).
+pub const ISTR_INT_E: u8 = 0x20;
+/// The SCSI peripheral raised an interrupt.
+pub const ISTR_INT_S: u8 = 0x40;
+/// Interrupt follow.
+pub const ISTR_INT_F: u8 = 0x80;
+
+// CONTR bits.
+/// DMA data direction: 0 = read, 1 = write.
+pub const CONTR_DMADIR: u8 = 0x02;
+/// Interrupt enable.
+pub const CONTR_INTEN: u8 = 0x04;
+/// Strobe: reset the WD33C93.
+pub const CONTR_RESET: u8 = 0x10;
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Sdmac {
+    /// Control register. Only the latched bits read back; RESET is a strobe.
+    contr: u8,
+    /// DACK width. Write-only on real silicon, so nothing ever reads it back.
+    dawr: u8,
+    /// DMA address register. It lives in Ramsey, not in the SDMAC, but it is
+    /// addressed through the SDMAC window, so it is modelled here with the DMA
+    /// engine that would use it. The low two bits are wired to zero: this is a
+    /// longword address.
+    acr: u32,
+    /// Synchronous serial peripheral bus, used for the external clock/EEPROM
+    /// on some boards. Nothing behind it here; the registers latch.
+    sspbdat: u32,
+    sspbctl: u32,
+    /// WD33C93 register-select latch. The chip it selects is not fitted.
+    sasr: u8,
+}
+
+impl Sdmac {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Interrupt status. With no DMA engine the FIFO is always empty and never
+    /// full, and with no WD33C93 nothing ever raises an interrupt.
+    fn istr(&self) -> u8 {
+        ISTR_FIFOE
+    }
+
+    /// The word transfer count exists on the SDMAC-02 and was dropped on the
+    /// SDMAC-04, whose bit 2 always reads zero. Both Kickstart and cdhooper's
+    /// sdmac tool identify the part by writing a pattern here and checking what
+    /// fails to come back, so reading zero is what declares us an SDMAC-04.
+    fn wtc(&self) -> u32 {
+        0
+    }
+
+    /// Whether the SDMAC drives the bus for a byte access at `addr`.
+    /// Undecoded addresses in the window are left floating, so they show up in
+    /// `[debug] log_unmapped` rather than reading back a value we invented.
+    pub fn decodes(addr: u32) -> bool {
+        Self::offset(addr).is_some()
+    }
+
+    /// The register offset a CPU address lands in, or None if nothing decodes.
+    /// The two 32-bit registers (WTC, ACR) and the two SSPB registers occupy
+    /// four bytes each; everything else is a single byte.
+    fn offset(addr: u32) -> Option<u32> {
+        if !(SDMAC_BASE..SDMAC_BASE + SDMAC_SIZE).contains(&addr) {
+            return None;
+        }
+        let off = addr & 0xFF;
+        let in_long = |base: u32| (base..base + 4).contains(&off);
+        let hit = matches!(
+            off,
+            DAWR | CONTR | ST_DMA | FLUSH | CLR_INT | ISTR | SP_DMA | SCMD | SASR
+        ) || in_long(WTC)
+            || in_long(ACR)
+            || in_long(SSPBDAT)
+            || in_long(SSPBCTL);
+        hit.then_some(off)
+    }
+
+    /// Byte `n` (0 = most significant) of a 32-bit register.
+    fn long_byte(value: u32, off: u32, base: u32) -> u8 {
+        (value >> (8 * (3 - (off - base)))) as u8
+    }
+
+    fn set_long_byte(value: &mut u32, off: u32, base: u32, byte: u8) {
+        let shift = 8 * (3 - (off - base));
+        *value = (*value & !(0xFFu32 << shift)) | (u32::from(byte) << shift);
+    }
+
+    pub fn read_byte(&mut self, addr: u32) -> u8 {
+        let Some(off) = Self::offset(addr) else {
+            return 0xFF;
+        };
+        match off {
+            ISTR => self.istr(),
+            CONTR => self.contr,
+            // TODO(codewiz): route these to a crate::scsi WD33C93. Reading the
+            // select address returns the chip's auxiliary status; the data
+            // port returns the selected register. Until a chip is fitted these
+            // are a guess, and no value works: scsi.device gets far enough to
+            // wait for an interrupt no one can raise. $00 at least does not
+            // claim a chip that is permanently busy (CIP and BSY set).
+            SASR => 0x00,
+            SCMD => 0xFF,
+            _ if (WTC..WTC + 4).contains(&off) => Self::long_byte(self.wtc(), off, WTC),
+            _ if (ACR..ACR + 4).contains(&off) => Self::long_byte(self.acr, off, ACR),
+            _ if (SSPBDAT..SSPBDAT + 4).contains(&off) => {
+                Self::long_byte(self.sspbdat, off, SSPBDAT)
+            }
+            _ if (SSPBCTL..SSPBCTL + 4).contains(&off) => {
+                Self::long_byte(self.sspbctl, off, SSPBCTL)
+            }
+            // DAWR is write-only; the strobes read back nothing.
+            _ => 0xFF,
+        }
+    }
+
+    pub fn write_byte(&mut self, addr: u32, value: u8) {
+        let Some(off) = Self::offset(addr) else {
+            return;
+        };
+        match off {
+            DAWR => self.dawr = value,
+            // RESET would reset the WD33C93, which is not fitted. The bit is a
+            // strobe and does not latch.
+            CONTR => self.contr = value & !CONTR_RESET,
+            SASR => self.sasr = value,
+            // Writes to the missing WD33C93 go nowhere. Its register-select
+            // latch still holds, so a driver can write a register number and
+            // read $FF back from the data port, which is how it concludes the
+            // socket is empty.
+            SCMD => {}
+            // The strobes have no DMA engine to act on.
+            ST_DMA | SP_DMA | FLUSH | CLR_INT => {}
+            // The word transfer count does not exist on the SDMAC-04.
+            _ if (WTC..WTC + 4).contains(&off) => {}
+            _ if (ACR..ACR + 4).contains(&off) => {
+                Self::set_long_byte(&mut self.acr, off, ACR, value);
+                self.acr &= !0b11; // longword address: the low two bits are zero
+            }
+            _ if (SSPBDAT..SSPBDAT + 4).contains(&off) => {
+                Self::set_long_byte(&mut self.sspbdat, off, SSPBDAT, value);
+            }
+            _ if (SSPBCTL..SSPBCTL + 4).contains(&off) => {
+                Self::set_long_byte(&mut self.sspbctl, off, SSPBCTL, value);
+            }
+            _ => {}
+        }
+    }
+
+    /// The SDMAC never raises an interrupt without a WD33C93 to raise one for.
+    pub fn int_line(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sdmac() -> Sdmac {
+        Sdmac::new()
+    }
+
+    /// The register that hangs the A3000 boot. Kickstart's scsi.device spins
+    /// here waiting for the DMA FIFO to report itself empty; an address that
+    /// decodes to nothing reads back 0, meaning "not empty", forever.
+    #[test]
+    fn an_idle_sdmac_reports_an_empty_fifo_and_no_interrupt() {
+        let mut s = sdmac();
+        let istr = s.read_byte(SDMAC_BASE + ISTR);
+        assert_eq!(istr & ISTR_FIFOE, ISTR_FIFOE);
+        assert_eq!(istr & ISTR_FIFOF, 0);
+        assert_eq!(
+            istr & (ISTR_INT_P | ISTR_INT_E | ISTR_INT_S | ISTR_INT_F),
+            0
+        );
+        assert!(!s.int_line());
+    }
+
+    /// Kickstart writes $0C, reads it back, then writes $00. RESET is a strobe
+    /// and must not latch.
+    #[test]
+    fn the_control_register_reads_back_except_for_the_reset_strobe() {
+        let mut s = sdmac();
+        s.write_byte(SDMAC_BASE + CONTR, CONTR_INTEN | CONTR_DMADIR);
+        assert_eq!(s.read_byte(SDMAC_BASE + CONTR), CONTR_INTEN | CONTR_DMADIR);
+        s.write_byte(SDMAC_BASE + CONTR, CONTR_RESET);
+        assert_eq!(s.read_byte(SDMAC_BASE + CONTR), 0);
+    }
+
+    /// Both Kickstart and cdhooper's sdmac tool identify the part by writing a
+    /// pattern to WTC and seeing what comes back. Reading zero (bit 2 clear
+    /// against a written bit 2) is what says "SDMAC-04".
+    #[test]
+    fn the_word_transfer_count_is_absent_on_the_sdmac_04() {
+        let mut s = sdmac();
+        for off in WTC..WTC + 4 {
+            s.write_byte(SDMAC_BASE + off, 0xFF);
+        }
+        for off in WTC..WTC + 4 {
+            assert_eq!(s.read_byte(SDMAC_BASE + off), 0x00);
+        }
+    }
+
+    /// The DMA address register is a longword address: the low two bits are
+    /// wired to zero. cdhooper's Ramsey test writes patterns and expects them
+    /// back masked -- amiberry fails this, reading 0.
+    #[test]
+    fn the_dma_address_register_masks_its_low_two_bits() {
+        let mut s = sdmac();
+        for (written, expected) in [
+            (0xFFFF_FFFFu32, 0xFFFF_FFFCu32),
+            (0xA5A5_A5A5, 0xA5A5_A5A4),
+            (0x5A5A_5A5A, 0x5A5A_5A58),
+        ] {
+            for i in 0..4 {
+                s.write_byte(SDMAC_BASE + ACR + i, (written >> (8 * (3 - i))) as u8);
+            }
+            let mut got = 0u32;
+            for i in 0..4 {
+                got = (got << 8) | u32::from(s.read_byte(SDMAC_BASE + ACR + i));
+            }
+            assert_eq!(got, expected, "wrote {written:#010X}");
+        }
+    }
+
+    /// The serial peripheral bus data register is a plain latch. amiberry
+    /// reads $FF here and fails cdhooper's SDMAC test.
+    #[test]
+    fn the_serial_bus_data_register_latches() {
+        let mut s = sdmac();
+        for byte in [0x00u8, 0xA5, 0x5A] {
+            s.write_byte(SDMAC_BASE + SSPBDAT + 3, byte);
+            assert_eq!(s.read_byte(SDMAC_BASE + SSPBDAT + 3), byte);
+        }
+    }
+
+    /// With no WD33C93 fitted the auxiliary status at least must not claim a
+    /// chip that is permanently busy: $FF sets CIP and BSY, and a driver then
+    /// waits forever for a command to finish. This does not make the machine
+    /// boot -- only fitting the chip will -- but it pins down the one value we
+    /// know to be wrong.
+    #[test]
+    fn an_absent_wd33c93_does_not_claim_to_be_permanently_busy() {
+        use crate::scsi::{ASR_BSY, ASR_CIP, ASR_INT};
+        let mut s = sdmac();
+        s.write_byte(SDMAC_BASE + SASR, 0x15);
+        assert_eq!(s.read_byte(SDMAC_BASE + SCMD), 0xFF);
+
+        let aux = s.read_byte(SDMAC_BASE + SASR);
+        assert_eq!(aux & (ASR_CIP | ASR_BSY | ASR_INT), 0, "aux {aux:#04X}");
+    }
+
+    /// The file repeats every $100; cdhooper's tool writes through the shadow
+    /// to defeat CPU write buffering, so both copies must be the same register.
+    #[test]
+    fn the_register_file_is_mirrored_every_256_bytes() {
+        let mut s = sdmac();
+        s.write_byte(SDMAC_BASE + 0x100 + CONTR, CONTR_INTEN);
+        assert_eq!(s.read_byte(SDMAC_BASE + CONTR), CONTR_INTEN);
+        assert!(Sdmac::decodes(SDMAC_BASE + 0x100 + ISTR));
+    }
+
+    /// Undecoded addresses in the window stay undriven, so they float and get
+    /// logged rather than reading back something we made up.
+    #[test]
+    fn undecoded_addresses_are_not_claimed() {
+        assert!(Sdmac::decodes(SDMAC_BASE + ISTR));
+        assert!(Sdmac::decodes(SDMAC_BASE + ACR + 2));
+        assert!(!Sdmac::decodes(SDMAC_BASE));
+        assert!(!Sdmac::decodes(SDMAC_BASE + 0x20));
+        // Only inside the window: the offsets must not match everywhere.
+        assert!(!Sdmac::decodes(0x0000_001F));
+        assert!(!Sdmac::decodes(SDMAC_BASE + SDMAC_SIZE + ISTR));
+    }
+}

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -476,13 +476,15 @@ fn serial_rows() -> &'static [Row] {
 }
 
 /// Machine models offered in the selector strip, roughly chronological.
-pub const MODELS: [MachineModel; 8] = [
+pub const MODELS: [MachineModel; 10] = [
     MachineModel::A1000,
     MachineModel::A500Ocs,
     MachineModel::A500,
     MachineModel::A500Plus,
     MachineModel::A600,
     MachineModel::A1200,
+    MachineModel::A3000,
+    MachineModel::A4000,
     MachineModel::Cdtv,
     MachineModel::Cd32,
 ];
@@ -1947,6 +1949,8 @@ fn model_name(model: MachineModel) -> &'static str {
         MachineModel::A500Plus => "A500Plus",
         MachineModel::A600 => "A600",
         MachineModel::A1200 => "A1200",
+        MachineModel::A3000 => "A3000",
+        MachineModel::A4000 => "A4000",
         MachineModel::Cdtv => "CDTV",
         MachineModel::Cd32 => "CD32",
         MachineModel::A1000 => "A1000",
@@ -1961,6 +1965,8 @@ pub fn model_label(model: MachineModel) -> &'static str {
         MachineModel::A500Plus => "A500+",
         MachineModel::A600 => "A600",
         MachineModel::A1200 => "A1200",
+        MachineModel::A3000 => "A3000",
+        MachineModel::A4000 => "A4000",
         MachineModel::Cdtv => "CDTV",
         MachineModel::Cd32 => "CD32",
         MachineModel::A1000 => "A1000",


### PR DESCRIPTION
First slice of A3000/A4000 support. **Both machines now boot.**

## Ramsey

The memory controller of both big-box machines: a control register at `$DE0003` and a version register at `$DE0043` reporting `$0d` (Ramsey-04, A3000) or `$0f` (Ramsey-07, A4000).

The control register has to read back what was written. Guests write a mode and then spin until they see it, with interrupts and the MMU disabled -- a swallowed write is an unrecoverable hang, not a wrong value. cdhooper's `ziptest` froze the machine this way before this change.

Refresh timing is not modelled, so the MHz figure the diagnostic tools compute from it is meaningless (as it is under amiberry). The reset value describes the DRAM we actually claim, which is one place we are already more accurate: amiberry powers its control register up at zero and nothing programs it, so its A4000 reports a `256Kx4` configuration that was never fitted.

## `[debug] log_unmapped`

Logs CPU reads and writes that no device decodes, within a hex range or `all`. Reads report the floating bus value they returned; writes report the value that went nowhere.

A missing register is normally invisible -- a read floats, a write is dropped, and the guest sulks or hangs with no diagnostic. This makes it a two-minute job instead of a bisect. It found every bug in this PR. It replaces the `COPPERLINE_DIAG_GAYLE` float logging, which was an env flag hardcoded to `$D80000-$F00000` and named after the wrong chip.

## Fat Gary

The bus controller in front of Ramsey, and the reason the diagnostic tools could not see the Ramsey we already emulated correctly.

Gary and Ramsey share one address decode, and it is cruder than a register map suggests: the byte lane picks the chip (lanes 0-2 are Gary, lane 3 is Ramsey), two address bits pick Ramsey's control vs version register, and the whole thing mirrors every `$100` across the page. So the version register Kickstart reads at `$DE0043` answers equally at `$DE0047` or `$DE0143`, and the addresses the tools appear to read at random are mirrors.

Gary's three registers are single bits in bit 7: TIMEOUT (`$DE0000`, BERR vs DSACK on an unanswered cycle), TOENB (`$DE0001`), and COLDBOOT (`$DE0002`). The last one is read/write, which is what makes it a Gary detector -- xSysInfo writes bit 7, reads a custom register to defeat the sticky bus, and expects to read bit 7 back. Modelling Ramsey as two fixed addresses left all of that floating, so xSysInfo concluded there was no Fat Gary and then, by its own logic, never looked for the Ramsey behind one:

```c
void detect_ramsey(void) {
    if (hw_info.gary_type != FAT_GARY) { // no fat gary -> no ramsey!
        hw_info.ramsey_rev = 0;
        return;
    }
```

Neither register changes emulated behaviour -- bus timeouts are not modelled and an unanswered cycle floats rather than faulting -- but they are what lets the machine identify as what it is. It also gives Kickstart's `$DE0000` writes, dropped on every boot until now, somewhere to land.

Gary is a `GateArray` variant rather than a separate flag. A machine has exactly one bus gate array, Gayle and Gary both decode the `$DE0000` page, and fitting both would make the decode ambiguous; the A3000/A4000 profiles now say `FatGary` instead of claiming no gate array at all.

## A3000 and A4000 profiles

Ramsey, Gary instead of Gayle, 2 MB chip RAM, 68030/68040 at 25 MHz. No motherboard fast RAM: the OS is happy taking fast RAM from the Zorro III board, so `[memory] z3` covers it.

## Super DMAC + WD33C93

The A3000's motherboard SCSI at `$DD0000`. The SDMAC is the successor of the A2091's DMAC and pairs with the same WD33C93, so `crate::scsi`'s chip core drives it unchanged and `src/sdmac.rs` is a second front-end onto it beside `src/a2091.rs` -- the layering amiberry uses too, where both controllers share one `wd_state`.

What differs from the DMAC: byte-wide registers instead of word-wide, a 32-bit DMA address counter instead of Zorro II's 24-bit one, the SSPB serial-bus registers, and no boot ROM at all -- Kickstart's own `scsi.device` drives it, so the machine either has a working controller or it hangs in device init. The SDMAC-04 also dropped the word transfer counter (the count lives in the WD33C93), and reading it back as zero is exactly how both Kickstart and cdhooper's `sdmac` identify the part.

`SASR`/`SCMD` are decoded at their `$41`/`$47` aliases as well as `$49`/`$43`. That is not cosmetic: SysInfo polls the auxiliary status through the `$41` alias, and before it decoded it read the floating bus 250,075 times and hung the machine with the power LED flashing.

## State of the two machines

- **A3000 boots**, on Kickstart's own `scsi.device` against a real SDMAC + WD33C93. No drives are attached to it yet, so boot from a Zorro controller or a `[[filesys]]` mount.
- **A4000 boots**, but slowly: its IDE at `$DD2020` is not implemented, so `scsi.device` probes it and waits out a timeout on every boot. The log shows the probe exactly -- a write of `$A0` to the device/head register at `$DD203A`, then 138 status reads at `$DD203E` that never come back ready.

## Next

1. A4000 IDE at `$DD2020`, reusing the ATA core in `gayle.rs`. Its byte-swap has to become a property rather than a constant: Gayle swaps the IDE data bus, the A4000 does not.
2. Drives on the A3000's SCSI bus (`[scsi]` currently only fits the Zorro controllers).

## Testing

`cargo test` (1406 lib tests), clippy clean.

Booted an A4000 (68040) and ran cdhooper's `ziptest`: reports `Ramsey-07 $f $08`, `1Mx4 (4MB per bank)` -- correct, where amiberry reports RAM that was never fitted.

Booted an A3000 (68030) to Workbench and ran cdhooper's `sdmac`, which passes its Ramsey and SDMAC tests and identifies the part as `SDMAC-04`. amiberry fails four of those same subtests (ACR at `$DD000C` reads 0, SSPBDAT at `$DD0058` reads `$ff`, an invalid WD register read should float `$ff`, and its SDMAC-04 identification is a false positive off an unimplemented WTC), so this was implemented against cdhooper's tests rather than against amiberry's behaviour.

Both SysInfo and xSysInfo identify the machine: Fat Gary rev `$0`, Ramsey-04 rev `$D`, SDMAC, ECS Agnus/Denise, 68030 with the MMU in use. Neither would report the Ramsey before Gary existed -- xSysInfo's `detect_ramsey()` returns early unless it first finds a Fat Gary, and it finds one by writing and reading back bit 7 of the coldboot register.

With `[debug] log_unmapped` pointed at `$DD0000-$DEFFFF`, a full A3000 boot now produces no floating accesses at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
