### PR TITLE
gdb: program load events, reconnectable stub, and symbol-docs fixes

### DIFF
--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -20,7 +20,20 @@ Connect from GDB with the 68k architecture selected:
 The target starts paused at reset. The stub implements the normal all-stop
 remote packets for register access, RAM reads/writes, hardware-style PC
 breakpoints, memory watchpoints, single-step, continue, Ctrl-C interrupt,
-and GDB reverse execution (`reverse-step` / `reverse-continue`).
+program load events (`qXfer:libraries:read`), and GDB reverse execution
+(`reverse-step` / `reverse-continue`). Detaching leaves the machine
+paused and the stub listening, so a later `target remote` picks up the
+same session (and re-runs `qOffsets`); GDB's `kill` ends the emulator.
+
+If `monitor` (or anything else) answers `"monitor" command not supported
+by this target.`, GDB is not actually connected: that is GDB's built-in
+dummy target speaking after a failed `target remote`, and `-batch`
+scripts carry on past the connection error. A common cause is running
+GDB inside a container (e.g. a cross-toolchain Docker image): the
+container's `localhost` is not the host's, so it never reaches
+Copperline's `127.0.0.1` listener. Run GDB on the host, or bind an
+address the container can reach (`--gdb 0.0.0.0:2345`, trusted networks
+only per the warning above) and connect to the host's address.
 
 ## CPU and Memory
 
@@ -131,28 +144,79 @@ avoid externally mutating hard-drive/CD images during a debug session.
 
 ## Source-Level Debugging of Amiga Programs
 
+What symbol detail you get depends on the file you feed GDB, not on the
+stub:
+
+- An AmigaOS hunk executable built with `-g` (bebbo's amiga-gcc) carries
+  a hunk symbol table: `file prog` gives function-level symbols --
+  `break main`, named disassembly -- but no DWARF, so source lines,
+  `next`, and `print` on variables are unavailable. Reading hunk files
+  at all requires a GDB whose BFD includes the `amiga` target (check
+  with `m68k-amigaos-objdump -i`); some builds of the same toolchain
+  lack it and report "file format not recognized".
+- Full source-level debugging needs an ELF file with DWARF kept
+  alongside the hunk binary you actually run: build with an m68k ELF
+  toolchain and convert the executable with `elf2hunk` (the flow the
+  amiga-debug VS Code extension uses), then load the ELF's symbols with
+  `add-symbol-file prog.elf ADDR` or through the library list below.
+
+Either way the symbols must land at the addresses `LoadSeg()` chose.
 Copperline answers GDB's `qOffsets` query with the load addresses of the
-current process's segment list (the hunks `LoadSeg()` scattered through
-RAM): `TextSeg=` is the first hunk and `DataSeg=` the second, when
-present. With an amiga-gcc toolchain (bebbo's `m68k-amigaos-gdb`), that
-means source-level debugging of a program running inside the emulator
-mostly just works:
-
-1. Build with debug info: `m68k-amigaos-gcc -g -O0 prog.c -o prog`.
-2. Start Copperline with `--gdb`, boot Workbench, and start `prog`
-   (easiest from a CLI so the process has a `cli_Module` seglist).
-3. `m68k-amigaos-gdb prog` then `target remote localhost:2345`. GDB asks
-   `qOffsets`, relocates the program's sections to the hunk addresses,
-   and `break main` / `next` / `print` work on source lines.
-
-If the program was not yet running when GDB attached, re-run `qOffsets`
-by reattaching, or relocate manually: `monitor segments` prints every
-hunk address, and `add-symbol-file prog.elf ADDR` (first hunk) loads the
-symbols at the right place. The `SEGMENTS` console command prints the
-same map, pre-formatted with that hint. When no process seglist is
-walkable (ROM code, task rather than process, OS not up yet), the
+current process's segment list: `TextSeg=` is the first hunk and
+`DataSeg=` the second, when present. GDB asks `qOffsets` once at attach,
+so this relocates a program that is already running: start `prog` from a
+CLI inside the emulator (so the process has a `cli_Module` seglist),
+then `m68k-amigaos-gdb prog` + `target remote localhost:2345` places
+`prog`'s symbols at the loaded hunk addresses. When no process seglist
+is walkable (ROM code, task rather than process, OS not up yet), the
 `qOffsets` reply is empty and GDB falls back to link-time addresses --
 harmless for ROM-level sessions.
+
+### Program Load Events
+
+For a program AmigaDOS loads *after* GDB is connected, the stub tracks
+the scheduled process's segment list and reports the load at the moment
+`LoadSeg()`'s result is installed -- after relocation, before the
+program's first instruction.
+
+The workflow that works with every client, `-batch` scripts included:
+
+```gdb
+(gdb) target remote :2345
+(gdb) monitor loadseg-break
+(gdb) continue
+loadseg: hello first hunk $018FE8 (monitor segments / add-symbol-file FILE 0x18FE8)
+Program received signal SIGTRAP, Trace/breakpoint trap.
+(gdb) disconnect
+(gdb) file hello
+(gdb) target remote :2345
+(gdb) break main
+(gdb) continue
+```
+
+`monitor loadseg-break` makes `continue` stop, with a console hint
+naming the program and its first hunk, whenever a new program is
+loaded. Detaching does not end the emulator: the machine stays paused
+and the stub listens for the next connection, so reattaching with the
+program's file loaded re-runs `qOffsets` against the now-current
+process and relocates the symbols with no manual addresses (GDB's
+`kill` command ends the server). Alternatively stay attached and use
+`add-symbol-file FILE ADDR` with the printed hunk address; `monitor
+segments` prints the full hunk map, and the `SEGMENTS` console command
+prints the same map pre-formatted with that hint.
+
+Clients that request GDB's target library lists get automatic load
+events instead: fetching `qXfer:libraries:read` once arms them, and
+each new program then reports a `library:` stop event -- GDB re-reads
+the stub's library list (one `<library>` per tracked program, a
+`<segment>` per hunk, named by the command's basename), relocates a
+matching file found via `set solib-search-path`, binds pending
+breakpoints, and resumes on its own. Be aware that stock bare-metal
+m68k GDB builds -- `m68k-amigaos-gdb` 13.x and a multi-arch host `gdb`
+alike -- never request library lists, so they never see these events;
+use the `monitor loadseg-break` flow with them. Programs already
+running when the list is first fetched are reported in it without a
+stop; `monitor loadseg-list` prints the same table.
 
 ## Monitor Commands
 
@@ -172,3 +236,5 @@ harmless for ROM-level sessions.
 | `copper [auto\|pc\|ADDR] [COUNT]` | disassemble Copper instructions |
 | `last-writer ADDR` | reverse-search the last write to a word |
 | `segments` | the current process's loaded hunks (LoadSeg addresses) |
+| `loadseg-break` | toggle a visible stop whenever a new program is loaded |
+| `loadseg-list` | tracked program loads with their hunk addresses |

--- a/docs/debugger/workflows.md
+++ b/docs/debugger/workflows.md
@@ -120,13 +120,14 @@ variable you can influence.
 
 ## Source-level debugging of your own program
 
-For programs you build yourself with an amiga-gcc toolchain, the GDB
-stub supports full source-level debugging -- breakpoints on lines,
-`next`, `print` on variables -- via automatic segment relocation. The
-walkthrough lives in the [GDB chapter](gdb), "Source-Level Debugging of
-Amiga Programs". The short version: build with `-g`, run inside the
-emulator from a CLI, and `m68k-amigaos-gdb prog` + `target remote`
-relocates itself using the emulator's `qOffsets` answer.
+For programs you build yourself, the GDB stub relocates symbols to the
+addresses `LoadSeg()` chose -- automatically at attach for a program
+already running (`qOffsets`), and via `monitor loadseg-break` plus a
+reattach for one the guest loads later. How much detail you get depends
+on the symbol file: a `-g` hunk executable carries function-level
+symbols, while source lines, `next`, and `print` need an
+ELF-with-DWARF sibling of the binary. The walkthrough lives in the
+[GDB chapter](gdb), "Source-Level Debugging of Amiga Programs".
 
 ## Making it reproducible
 

--- a/src/amigaos.rs
+++ b/src/amigaos.rs
@@ -9,6 +9,8 @@
 
 pub mod dos;
 
+use std::collections::HashMap;
+
 /// ExecBase field offsets (execbase.h).
 const EXECBASE_PTR: u32 = 4;
 const CHKBASE: u32 = 0x26;
@@ -220,7 +222,9 @@ pub struct Segment {
 const PR_SEGLIST: u32 = 0x80;
 const PR_CLI: u32 = 0xAC;
 /// CommandLineInterface field offsets: cli_Module is the BPTR to the
-/// currently running command's segment list.
+/// currently running command's segment list, cli_CommandName the BSTR
+/// naming the command it belongs to.
+const CLI_COMMAND_NAME: u32 = 0x10;
 const CLI_MODULE: u32 = 0x3C;
 /// NT_PROCESS in ln_Type.
 const NT_PROCESS: u8 = 13;
@@ -285,12 +289,201 @@ impl OsMemory<'_> {
             None => Vec::new(),
         }
     }
+
+    /// Read a BSTR (BPTR to a length-prefixed string): printable ASCII,
+    /// bounded by `cap`, empty for implausible pointers.
+    pub fn read_bstr(&self, bptr: u32, cap: usize) -> String {
+        if bptr == 0 || bptr >= 0x0040_0000 {
+            return String::new();
+        }
+        let addr = bptr << 2;
+        let len = (self.peek8)(addr) as usize;
+        let mut out = String::new();
+        for i in 0..len.min(cap) as u32 {
+            let byte = (self.peek8)(addr.wrapping_add(1 + i));
+            out.push(if (0x20..0x7F).contains(&byte) {
+                byte as char
+            } else {
+                '.'
+            });
+        }
+        out
+    }
+
+    /// The name of the program a process is running: the basename of
+    /// cli_CommandName when the task has a CLI, else the task's ln_Name.
+    pub fn process_command_name(&self, task: u32) -> String {
+        if (self.peek8)(task.wrapping_add(LN_TYPE)) == NT_PROCESS {
+            let cli = (self.peek32)(task.wrapping_add(PR_CLI));
+            if cli != 0 && cli < 0x0040_0000 {
+                let name_bptr = (self.peek32)((cli << 2).wrapping_add(CLI_COMMAND_NAME));
+                // A full AmigaDOS path fits in a 255-byte BSTR.
+                let name = self.read_bstr(name_bptr, 255);
+                let base = command_basename(&name);
+                if !base.is_empty() {
+                    return base.to_string();
+                }
+            }
+        }
+        self.node_name(task)
+    }
+
+    /// The addresses of every task exec knows about right now: ThisTask
+    /// plus the ready and waiting lists (bounded like `walk`).
+    pub fn task_addrs(&self, execbase: u32) -> Vec<u32> {
+        let mut out = Vec::new();
+        let this = (self.peek32)(execbase.wrapping_add(THIS_TASK));
+        if plausible_ptr(this) {
+            out.push(this);
+        }
+        for list in [TASK_READY, TASK_WAIT] {
+            let mut node = (self.peek32)(execbase.wrapping_add(list));
+            while plausible_ptr(node) && (self.peek32)(node) != 0 && out.len() < LIST_CAP {
+                out.push(node);
+                node = (self.peek32)(node);
+            }
+        }
+        out
+    }
 }
 
-/// Bus-backed convenience wrapper: the current process's segments, or
-/// why exec is not walkable. Shared by the console SEGMENTS command and
-/// the GDB stub (monitor segments / qOffsets).
-pub fn segments_on_bus(bus: &crate::bus::Bus) -> Result<Vec<Segment>, String> {
+/// The basename of an AmigaDOS path: the text after the last `/` or the
+/// volume/device colon.
+pub fn command_basename(path: &str) -> &str {
+    path.rsplit(['/', ':']).next().unwrap_or(path)
+}
+
+/// A loaded hunk must sit in RAM exec could have allocated and carry a
+/// believable size (the loader's size longword is bounded by the 16MB
+/// chip/Z2 space a seglist can live in).
+fn segment_plausible(seg: &Segment) -> bool {
+    plausible_ptr(seg.start) && seg.size < 0x0100_0000
+}
+
+/// One program the debugger has seen `LoadSeg()`'d into memory: its
+/// seglist BPTR, the process running it, its command name, and the hunk
+/// addresses walked at the moment it was recorded.
+pub struct TrackedModule {
+    pub seglist: u32,
+    pub task: u32,
+    pub name: String,
+    pub segments: Vec<Segment>,
+}
+
+/// Tracked programs kept at once; gdb re-reads the whole list on every
+/// load event, so the cap only bounds guest-driven growth.
+const MODULE_CAP: usize = 16;
+/// Task->module pairs remembered before the table is reset; exceeding it
+/// costs at worst one spurious (auto-resuming) library event.
+const TASK_TABLE_CAP: usize = 256;
+
+/// Bounded record of DOS-loaded programs, and the change detector that
+/// turns a new `LoadSeg()` result appearing in the scheduled process
+/// into a debugger event. Purely observational: built from
+/// side-effect-free peeks, never written back to guest memory.
+#[derive(Default)]
+pub struct LibraryTracker {
+    armed: bool,
+    /// Tasks that already existed when the tracker was armed: a program
+    /// first seen in one of these merely became visible via a context
+    /// switch, so it is recorded without firing an event.
+    known_tasks: Vec<u32>,
+    /// Last module BPTR observed per task (0 = none), so the common
+    /// nothing-changed case costs one map probe.
+    task_modules: HashMap<u32, u32>,
+    modules: Vec<TrackedModule>,
+}
+
+impl LibraryTracker {
+    /// Snapshot the live task set and absorb the current process's
+    /// program so neither fires a load event later. Idempotent.
+    pub fn arm(&mut self, os: &OsMemory) {
+        if self.armed {
+            return;
+        }
+        self.armed = true;
+        if let Ok(base) = os.exec_base() {
+            self.known_tasks = os.task_addrs(base);
+        }
+        self.absorb_current(os);
+    }
+
+    pub fn armed(&self) -> bool {
+        self.armed
+    }
+
+    /// Record the current process's program without firing an event.
+    pub fn absorb_current(&mut self, os: &OsMemory) {
+        let _ = self.observe(os);
+    }
+
+    pub fn modules(&self) -> &[TrackedModule] {
+        &self.modules
+    }
+
+    /// Compare the scheduled process's seglist against what was last
+    /// seen. Returns the newly recorded program when a genuine load
+    /// event fired: the watched task's module changed to an unseen
+    /// seglist (AmigaDOS `LoadSeg()` + `RunCommand()`), or a process
+    /// created after arming showed up with one (`Run`, Workbench).
+    /// A first sighting of a task that existed at arm time is absorbed
+    /// silently -- its program was already running. Known limits: exec
+    /// reusing a task's address can absorb one event, and a reverse
+    /// rewind can re-fire an already-pruned module (benign; library
+    /// events auto-resume).
+    pub fn observe(&mut self, os: &OsMemory) -> Option<&TrackedModule> {
+        let base = os.exec_base().ok()?;
+        let task = (os.peek32)(base.wrapping_add(THIS_TASK));
+        if !plausible_ptr(task) {
+            return None;
+        }
+        let module = os.process_seglist(task).unwrap_or(0);
+        let prev = self.task_modules.insert(task, module);
+        if prev == Some(module) {
+            return None;
+        }
+        if self.task_modules.len() > TASK_TABLE_CAP {
+            self.task_modules.clear();
+            self.task_modules.insert(task, module);
+        }
+        if let Some(old) = prev.filter(|&m| m != 0) {
+            // The task's previous program exited or was replaced: forget
+            // it, so a later LoadSeg reusing the same BPTR re-fires.
+            self.modules
+                .retain(|m| !(m.task == task && m.seglist == old));
+        }
+        if module == 0 || self.modules.iter().any(|m| m.seglist == module) {
+            return None;
+        }
+        let segments = os.walk_seglist(module);
+        // Early boot leaves garbage in not-yet-initialized process/CLI
+        // fields that can pass the BPTR range checks; only a seglist
+        // whose every hunk looks like allocated RAM is a program load.
+        if segments.is_empty() || !segments.iter().all(segment_plausible) {
+            return None;
+        }
+        if self.modules.len() >= MODULE_CAP {
+            self.modules.remove(0);
+        }
+        self.modules.push(TrackedModule {
+            seglist: module,
+            task,
+            name: os.process_command_name(task),
+            segments,
+        });
+        let fires = prev.is_some() || !self.known_tasks.contains(&task);
+        if fires {
+            self.modules.last()
+        } else {
+            None
+        }
+    }
+}
+
+/// Run `f` against an [`OsMemory`] view built from side-effect-free bus
+/// peeks. The callback shape exists because `OsMemory` borrows local
+/// peek closures.
+pub fn with_bus_memory<R>(bus: &crate::bus::Bus, f: impl FnOnce(&OsMemory) -> R) -> R {
     let peek8 = |addr: u32| {
         let word = bus.peek_word_any(addr & !1);
         if addr & 1 == 0 {
@@ -307,8 +500,17 @@ pub fn segments_on_bus(bus: &crate::bus::Bus) -> Result<Vec<Segment>, String> {
         peek8: &peek8,
         peek32: &peek32,
     };
-    let base = os.exec_base()?;
-    Ok(os.current_process_segments(base))
+    f(&os)
+}
+
+/// Bus-backed convenience wrapper: the current process's segments, or
+/// why exec is not walkable. Shared by the console SEGMENTS command and
+/// the GDB stub (monitor segments / qOffsets).
+pub fn segments_on_bus(bus: &crate::bus::Bus) -> Result<Vec<Segment>, String> {
+    with_bus_memory(bus, |os| {
+        let base = os.exec_base()?;
+        Ok(os.current_process_segments(base))
+    })
 }
 
 #[cfg(test)]
@@ -476,6 +678,199 @@ mod tests {
         let peek8 = |a: u32| mem.peek8(a);
         let peek32 = |a: u32| mem.peek32(a);
         assert!(os(&peek8, &peek32).exec_base().is_err());
+    }
+
+    #[test]
+    fn reads_a_bounded_bstr_command_name() {
+        let mut mem = FakeMem::new();
+        // BSTR at $8000: length 11, "dh0:c/hello".
+        mem.put8(0x8000, 11);
+        for (i, b) in b"dh0:c/hello".iter().enumerate() {
+            mem.put8(0x8001 + i as u32, *b);
+        }
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            assert_eq!(os.read_bstr(0x8000 >> 2, 255), "dh0:c/hello");
+            assert_eq!(os.read_bstr(0x8000 >> 2, 5), "dh0:c");
+            assert_eq!(os.read_bstr(0, 255), "");
+        }
+        // Unprintable bytes come back filtered, not raw.
+        let mut mem = FakeMem::new();
+        mem.put8(0x8000, 2);
+        mem.put8(0x8001, 0x07);
+        mem.put8(0x8002, b'x');
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        assert_eq!(os(&peek8, &peek32).read_bstr(0x8000 >> 2, 255), ".x");
+    }
+
+    #[test]
+    fn command_basename_strips_amigados_paths() {
+        assert_eq!(command_basename("dh0:c/hello"), "hello");
+        assert_eq!(command_basename("work:hello"), "hello");
+        assert_eq!(command_basename("hello"), "hello");
+        assert_eq!(command_basename(""), "");
+    }
+
+    /// Stage a CLI process world for the tracker: ThisTask is a process
+    /// whose CLI has a cli_CommandName but no cli_Module yet.
+    fn build_cli_world() -> FakeMem {
+        let mut mem = build_exec_world();
+        let this = 0x0002_1000;
+        mem.put8(this + LN_TYPE, NT_PROCESS);
+        let cli_addr = 0x0003_0000u32;
+        mem.put32(this + PR_CLI, cli_addr >> 2);
+        mem.put32(cli_addr + CLI_COMMAND_NAME, 0x0003_1000 >> 2);
+        mem.put8(0x0003_1000, 11);
+        for (i, b) in b"dh0:c/hello".iter().enumerate() {
+            mem.put8(0x0003_1001 + i as u32, *b);
+        }
+        // A two-hunk seglist parked at $8000/$9000, not yet installed.
+        mem.put32(0x8000 - 4, 0x100);
+        mem.put32(0x8000, 0x9000 >> 2);
+        mem.put32(0x9000 - 4, 0x40);
+        mem.put32(0x9000, 0);
+        mem
+    }
+
+    #[test]
+    fn library_tracker_fires_on_loads_and_absorbs_context_switches() {
+        let mut mem = build_cli_world();
+        let this = 0x0002_1000;
+        let cli_addr = 0x0003_0000u32;
+        let mut tracker = LibraryTracker::default();
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            tracker.arm(&os);
+            assert!(tracker.armed());
+            assert!(tracker.observe(&os).is_none(), "nothing loaded yet");
+        }
+
+        // The shell LoadSegs a command into cli_Module: fires, named.
+        mem.put32(cli_addr + CLI_MODULE, 0x8000 >> 2);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            let event = tracker.observe(&os).expect("LoadSeg fires");
+            assert_eq!(event.name, "hello");
+            assert_eq!(event.segments.len(), 2);
+            assert_eq!(event.segments[0].start, 0x8004);
+            assert!(tracker.observe(&os).is_none(), "no re-fire");
+        }
+
+        // Context switch to a task that existed at arm time, already
+        // running a program: absorbed silently but listed.
+        let t1 = 0x0002_3000; // on TaskReady in build_exec_world
+        let base = 0x00C0_0676;
+        mem.put32(base + THIS_TASK, t1);
+        mem.put8(t1 + LN_TYPE, NT_PROCESS);
+        let cli2 = 0x0003_4000u32;
+        mem.put32(t1 + PR_CLI, cli2 >> 2);
+        mem.put32(cli2 + CLI_MODULE, 0xA000 >> 2);
+        mem.put32(0xA000 - 4, 0x20);
+        mem.put32(0xA000, 0);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            assert!(tracker.observe(&os).is_none(), "old task absorbed");
+            assert_eq!(tracker.modules().len(), 2);
+        }
+
+        // A process created after arming shows up with a module: fires.
+        let t3 = 0x0002_9000;
+        mem.put32(base + THIS_TASK, t3);
+        mem.put8(t3 + LN_TYPE, NT_PROCESS);
+        let cli3 = 0x0003_6000u32;
+        mem.put32(t3 + PR_CLI, cli3 >> 2);
+        mem.put32(cli3 + CLI_MODULE, 0xB000 >> 2);
+        mem.put32(0xB000 - 4, 0x20);
+        mem.put32(0xB000, 0);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            assert!(tracker.observe(&os).is_some(), "new process fires");
+        }
+
+        // Same task runs the next command: the old module is pruned and
+        // the new one fires, even at a reused seglist address.
+        mem.put32(base + THIS_TASK, this);
+        mem.put32(cli_addr + CLI_MODULE, 0x9000 >> 2);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            let event = tracker.observe(&os).expect("replacement fires");
+            assert_eq!(event.seglist, 0x9000 >> 2);
+            assert!(!tracker
+                .modules()
+                .iter()
+                .any(|m| m.seglist == 0x8000 >> 2 && m.task == this));
+        }
+    }
+
+    #[test]
+    fn library_tracker_rejects_implausible_boot_garbage_seglists() {
+        // Seen on a real KS3.1 boot: the strap process's uninitialized
+        // CLI fields yield a "seglist" whose hunk lands in ROM space
+        // with a wild size. The tracker must not fire on it.
+        let mut mem = build_cli_world();
+        let cli_addr = 0x0003_0000u32;
+        let mut tracker = LibraryTracker::default();
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            tracker.arm(&os);
+        }
+        // A hunk at $FA8240 (ROM) with a garbage size longword.
+        mem.put32(cli_addr + CLI_MODULE, 0x00FA_8240 >> 2);
+        mem.put32(0x00FA_8240 - 4, 0x7200_0008);
+        mem.put32(0x00FA_8240, 0);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            assert!(tracker.observe(&os).is_none(), "ROM-space hunk rejected");
+            assert!(tracker.modules().is_empty());
+        }
+        // A RAM hunk with an implausible size is rejected too.
+        mem.put32(cli_addr + CLI_MODULE, 0x8000 >> 2);
+        mem.put32(0x8000 - 4, 0x7200_0008);
+        mem.put32(0x8000, 0);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            assert!(tracker.observe(&os).is_none(), "oversized hunk rejected");
+        }
+        // The real load afterwards still fires.
+        mem.put32(0x8000 - 4, 0x100);
+        mem.put32(0x8000, 0);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            // Same BPTR as the rejected junk: force re-evaluation via a
+            // different module first, as a real shell would.
+            assert!(tracker.observe(&os).is_none(), "same BPTR, cached");
+        }
+        mem.put32(cli_addr + CLI_MODULE, 0x9000 >> 2);
+        mem.put32(0x9000 - 4, 0x40);
+        mem.put32(0x9000, 0);
+        {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            let os = os(&peek8, &peek32);
+            let event = tracker.observe(&os).expect("valid load fires");
+            assert_eq!(event.segments[0].start, 0x9004);
+        }
     }
 
     #[test]

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -83,21 +83,53 @@ enum StopReason {
     CopperBreak,
     Reverse,
     Interrupted,
+    /// A new program was LoadSeg'd; gdb re-reads the library list,
+    /// binds pending breakpoints, and resumes on its own.
+    LibraryLoad,
+    /// Same trigger, requested via `monitor loadseg-break`: a plain
+    /// user-visible stop.
+    LoadSeg,
 }
 
 pub fn run(mut emu: Emulator, config: Config) -> Result<()> {
     let bind = normalize_listen_addr(&config.listen)?;
     let listener = TcpListener::bind(&bind).with_context(|| format!("binding GDB stub {bind}"))?;
     log::info!("gdb: listening on {bind}");
-    let (stream, peer) = listener.accept().context("accepting GDB connection")?;
-    log::info!("gdb: connection from {peer}");
-    stream.set_nodelay(true).ok();
 
     emu.set_paced(false);
     emu.enable_time_travel(config.reverse_budget_mb, config.reverse_interval_frames);
     emu.debug_ensure_time_travel_anchor()?;
 
-    Session::new(emu, stream).run()
+    serve(listener, emu)
+}
+
+/// Accept GDB connections one at a time against the same machine. A
+/// detach (or dropped connection) keeps the emulator paused and waits
+/// for the next client -- reattaching re-runs `qOffsets`, which is the
+/// documented way to pick up a program loaded mid-session -- while
+/// GDB's `kill` ends the server.
+fn serve(listener: TcpListener, mut emu: Emulator) -> Result<()> {
+    loop {
+        let (stream, peer) = listener.accept().context("accepting GDB connection")?;
+        log::info!("gdb: connection from {peer}");
+        stream.set_nodelay(true).ok();
+        let mut session = Session::new(emu, stream);
+        let end = session.run()?;
+        session.clear_debug_hardware();
+        emu = session.emu;
+        match end {
+            SessionEnd::Detached => {
+                log::info!("gdb: client detached; machine paused, listening for reconnection");
+            }
+            SessionEnd::Killed => return Ok(()),
+        }
+    }
+}
+
+/// How a [`Session`] ended: a detach/EOF keeps serving, `k` shuts down.
+enum SessionEnd {
+    Detached,
+    Killed,
 }
 
 fn normalize_listen_addr(input: &str) -> Result<String> {
@@ -123,6 +155,15 @@ struct Session {
     reg_watches: Vec<u16>,
     stop: StopReason,
     cpu_idle: bool,
+    /// True once the client has fetched qXfer:libraries:read: from then
+    /// on new LoadSegs stop with a `library:` event.
+    lib_events_armed: bool,
+    /// `monitor loadseg-break`: new LoadSegs cause a user-visible stop.
+    loadseg_break: bool,
+    tracker: crate::amigaos::LibraryTracker,
+    /// Library-list XML cached at offset 0 so multi-chunk reads are
+    /// self-consistent.
+    libraries_xml: String,
 }
 
 impl Session {
@@ -136,13 +177,17 @@ impl Session {
             reg_watches: Vec::new(),
             stop: StopReason::Attached,
             cpu_idle: false,
+            lib_events_armed: false,
+            loadseg_break: false,
+            tracker: crate::amigaos::LibraryTracker::default(),
+            libraries_xml: String::new(),
         }
     }
 
-    fn run(&mut self) -> Result<()> {
+    fn run(&mut self) -> Result<SessionEnd> {
         loop {
             let Some(packet) = self.read_packet()? else {
-                return Ok(());
+                return Ok(SessionEnd::Detached);
             };
             if packet == "QStartNoAckMode" {
                 self.send_packet("OK")?;
@@ -153,10 +198,20 @@ impl Session {
                 PacketOutcome::Reply(reply) => self.send_packet(&reply)?,
                 PacketOutcome::Disconnect => {
                     self.send_packet("OK")?;
-                    return Ok(());
+                    return Ok(SessionEnd::Detached);
                 }
+                PacketOutcome::Kill => return Ok(SessionEnd::Killed),
             }
         }
+    }
+
+    /// Drop the bus-side debug state this session installed (register
+    /// watches, beam traps, Copper breakpoints), so a stale hit cannot
+    /// stop the next client's first continue.
+    fn clear_debug_hardware(&mut self) {
+        self.emu.bus_mut().set_ui_reg_watches(&[]);
+        self.emu.bus_mut().ui_clear_beam_traps();
+        self.emu.bus_mut().ui_clear_copper_breaks();
     }
 
     fn handle_packet(&mut self, packet: &str) -> Result<PacketOutcome> {
@@ -170,13 +225,14 @@ impl Session {
             "qsThreadInfo" => "l".to_string(),
             "vCont?" => "vCont;c;s".to_string(),
             "D" | "D;1" => return Ok(PacketOutcome::Disconnect),
-            "k" => return Ok(PacketOutcome::Disconnect),
+            "k" => return Ok(PacketOutcome::Kill),
             _ if packet.starts_with("qSupported") => {
-                "PacketSize=4000;QStartNoAckMode+;qXfer:features:read+;hwbreak+;ReverseStep+;ReverseContinue+".to_string()
+                "PacketSize=4000;QStartNoAckMode+;qXfer:features:read+;qXfer:libraries:read+;hwbreak+;ReverseStep+;ReverseContinue+".to_string()
             }
             _ if packet.starts_with("qXfer:features:read:target.xml:") => {
                 self.read_target_xml(packet)?
             }
+            _ if packet.starts_with("qXfer:libraries:read::") => self.read_libraries_xml(packet)?,
             _ if packet.starts_with("qOffsets") => self.query_offsets(),
             _ if packet.starts_with("qRcmd,") => {
                 let command = String::from_utf8(hex_decode(&packet[6..])?)
@@ -312,6 +368,7 @@ impl Session {
             StopReason::Watchpoint(addr) => format!("T05watch:{addr:x};thread:1;"),
             StopReason::RegisterWatch => "T05thread:1;".to_string(),
             StopReason::Breakpoint => "T05hwbreak:;thread:1;".to_string(),
+            StopReason::LibraryLoad => "T05library:;thread:1;".to_string(),
             _ => "T05thread:1;".to_string(),
         }
     }
@@ -496,6 +553,25 @@ impl Session {
                 return Ok(Some(StopReason::Watchpoint(watch.addr)));
             }
         }
+        if self.lib_events_armed || self.loadseg_break {
+            let tracker = &mut self.tracker;
+            let event = crate::amigaos::with_bus_memory(self.emu.bus(), |os| {
+                tracker.observe(os).map(|module| {
+                    let first = module.segments.first().map_or(0, |seg| seg.start);
+                    (module.name.clone(), first)
+                })
+            });
+            if let Some((name, first_hunk)) = event {
+                if self.loadseg_break {
+                    self.send_console(&format!(
+                        "loadseg: {name} first hunk ${first_hunk:06X} \
+                         (monitor segments / add-symbol-file FILE 0x{first_hunk:X})\n"
+                    ))?;
+                    return Ok(Some(StopReason::LoadSeg));
+                }
+                return Ok(Some(StopReason::LibraryLoad));
+            }
+        }
         Ok(None)
     }
 
@@ -529,24 +605,32 @@ impl Session {
         let Some((_, range)) = packet.rsplit_once(':') else {
             return Ok("E01".to_string());
         };
-        let Some((offset_s, len_s)) = range.split_once(',') else {
+        xml_chunk_reply(TARGET_XML, range)
+    }
+
+    /// qXfer:libraries:read: the programs LoadSeg has scattered through
+    /// RAM, as gdb's library-list XML. Fetching it arms LoadSeg
+    /// detection, so clients that never ask see no behavior change.
+    fn read_libraries_xml(&mut self, packet: &str) -> Result<String> {
+        let Some(range) = packet.strip_prefix("qXfer:libraries:read::") else {
             return Ok("E01".to_string());
         };
-        let offset = parse_hex_usize(offset_s)?;
-        let len = parse_hex_usize(len_s)?;
-        let bytes = TARGET_XML.as_bytes();
-        if offset >= bytes.len() {
-            return Ok("l".to_string());
+        let offset = range
+            .split_once(',')
+            .map(|(offset_s, _)| parse_hex_usize(offset_s))
+            .transpose()?;
+        // Regenerate only at offset 0 so a multi-chunk read stays
+        // self-consistent.
+        if offset == Some(0) {
+            let tracker = &mut self.tracker;
+            crate::amigaos::with_bus_memory(self.emu.bus(), |os| {
+                tracker.arm(os);
+                tracker.absorb_current(os);
+            });
+            self.lib_events_armed = true;
+            self.libraries_xml = build_library_list_xml(self.tracker.modules());
         }
-        let end = offset.saturating_add(len).min(bytes.len());
-        let prefix = if end == bytes.len() { 'l' } else { 'm' };
-        // TARGET_XML is pure ASCII today, so any offset/len is a valid char
-        // boundary, but both come straight from the peer: don't let a future
-        // non-ASCII addition (or a boundary that happens to split a
-        // multi-byte char) turn into a panic instead of a clean error.
-        let chunk = std::str::from_utf8(&bytes[offset..end])
-            .map_err(|_| anyhow!("target XML slice landed on a non-UTF-8 boundary"))?;
-        Ok(format!("{prefix}{chunk}"))
+        xml_chunk_reply(&self.libraries_xml, range)
     }
 
     /// qOffsets: relocate the debugged executable's sections to where
@@ -588,6 +672,29 @@ impl Session {
         }
     }
 
+    fn monitor_loadseg_list(&mut self) -> String {
+        // Fold in the current process so the list is useful even before
+        // any load event fired. Arming the tracker here does not enable
+        // stops; those are gated on lib_events_armed / loadseg_break.
+        let tracker = &mut self.tracker;
+        crate::amigaos::with_bus_memory(self.emu.bus(), |os| {
+            tracker.arm(os);
+            tracker.absorb_current(os);
+        });
+        if self.tracker.modules().is_empty() {
+            return "no tracked program loads (no walkable process seglist yet)\n".to_string();
+        }
+        let mut out = String::new();
+        for module in self.tracker.modules() {
+            out.push_str(&format!("{}:", module.name));
+            for seg in &module.segments {
+                out.push_str(&format!(" ${:06X} ({} bytes)", seg.start, seg.size));
+            }
+            out.push('\n');
+        }
+        out
+    }
+
     fn handle_monitor(&mut self, command: &str) -> Result<String> {
         let mut parts = command.split_whitespace();
         let Some(cmd) = parts.next() else {
@@ -606,6 +713,20 @@ impl Session {
             )),
             "custom" => Ok(self.monitor_custom()),
             "segments" => Ok(self.monitor_segments()),
+            "loadseg-break" => {
+                self.loadseg_break = !self.loadseg_break;
+                if self.loadseg_break {
+                    let tracker = &mut self.tracker;
+                    crate::amigaos::with_bus_memory(self.emu.bus(), |os| tracker.arm(os));
+                    Ok(
+                        "loadseg break armed: continue stops when a new program is loaded\n"
+                            .to_string(),
+                    )
+                } else {
+                    Ok("loadseg break disarmed\n".to_string())
+                }
+            }
+            "loadseg-list" => Ok(self.monitor_loadseg_list()),
             "stepover" => {
                 // Step over a BSR/JSR/TRAP call (single step otherwise),
                 // bounded so a call that never returns cannot hang the server.
@@ -836,6 +957,66 @@ impl Session {
 enum PacketOutcome {
     Reply(String),
     Disconnect,
+    Kill,
+}
+
+/// One qXfer chunk of `xml` for an "OFFSET,LENGTH" range, with the RSP
+/// more/last prefix.
+fn xml_chunk_reply(xml: &str, range: &str) -> Result<String> {
+    let Some((offset_s, len_s)) = range.split_once(',') else {
+        return Ok("E01".to_string());
+    };
+    let offset = parse_hex_usize(offset_s)?;
+    let len = parse_hex_usize(len_s)?;
+    let bytes = xml.as_bytes();
+    if offset >= bytes.len() {
+        return Ok("l".to_string());
+    }
+    let end = offset.saturating_add(len).min(bytes.len());
+    let prefix = if end == bytes.len() { 'l' } else { 'm' };
+    // The XML is pure ASCII today, so any offset/len is a valid char
+    // boundary, but both come straight from the peer: don't let a future
+    // non-ASCII addition (or a boundary that happens to split a
+    // multi-byte char) turn into a panic instead of a clean error.
+    let chunk = std::str::from_utf8(&bytes[offset..end])
+        .map_err(|_| anyhow!("qXfer XML slice landed on a non-UTF-8 boundary"))?;
+    Ok(format!("{prefix}{chunk}"))
+}
+
+/// gdb's library-list XML: one `<library>` per tracked program with a
+/// `<segment>` per hunk. gdb pairs the segments with the loadable
+/// sections of the file it finds under the library's name (see
+/// `set solib-search-path`).
+fn build_library_list_xml(modules: &[crate::amigaos::TrackedModule]) -> String {
+    if modules.is_empty() {
+        return "<library-list version=\"1.0\"/>".to_string();
+    }
+    let mut xml = String::from("<library-list version=\"1.0\">");
+    for module in modules {
+        xml.push_str(&format!("<library name=\"{}\">", xml_escape(&module.name)));
+        for seg in &module.segments {
+            xml.push_str(&format!("<segment address=\"0x{:08x}\"/>", seg.start));
+        }
+        xml.push_str("</library>");
+    }
+    xml.push_str("</library-list>");
+    xml
+}
+
+/// Names come from guest memory, so escape them before they land in an
+/// XML attribute.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 fn monitor_help() -> String {
@@ -850,7 +1031,8 @@ fn monitor_help() -> String {
      copper-break ADDR | clear-copper-breaks\n\
      copper [auto|pc|ADDR] [COUNT]\n\
      last-writer ADDR\n\
-     segments\n"
+     segments\n\
+     loadseg-break | loadseg-list\n"
         .to_string()
 }
 
@@ -981,5 +1163,248 @@ mod tests {
         bytes = &bytes[bytes.len() - 8..];
         assert!(!bytes.is_empty());
         Ok(())
+    }
+
+    /// Build an emulator whose ROM program installs a seglist BPTR into
+    /// a staged CLI structure, mimicking the tail of AmigaDOS
+    /// RunCommand() after LoadSeg():
+    ///
+    /// ```text
+    /// F80010  NOP
+    /// F80012  MOVE.L #$5000,($1303C).L   ; cli_Module <- seglist BPTR
+    /// F8001C  BRA.S  *
+    /// ```
+    ///
+    /// Chip RAM holds a fake exec world: ExecBase at $10000 (installed
+    /// at address 4 after reset), ThisTask a process at $12000 whose
+    /// CLI at $13000 names "dh0:c/hello", and a two-hunk seglist at
+    /// $14000/$15000.
+    fn emulator_with_loadseg_program() -> Emulator {
+        let mut rom = vec![0u8; crate::memory::ROM_SIZE];
+        let put_word = |mem: &mut [u8], off: usize, word: u16| {
+            mem[off..off + 2].copy_from_slice(&word.to_be_bytes());
+        };
+        put_word(&mut rom, 0x10, 0x4E71); // NOP
+        put_word(&mut rom, 0x12, 0x23FC); // MOVE.L #imm,(abs).L
+        put_word(&mut rom, 0x14, 0x0000);
+        put_word(&mut rom, 0x16, 0x5000); // seglist BPTR ($14000 >> 2)
+        put_word(&mut rom, 0x18, 0x0001);
+        put_word(&mut rom, 0x1A, 0x303C); // cli_Module at $13000 + $3C
+        put_word(&mut rom, 0x1C, 0x60FE); // BRA.S *
+
+        let mut chip_ram = vec![0u8; 512 * 1024];
+        let put32 = |mem: &mut [u8], addr: usize, value: u32| {
+            mem[addr..addr + 4].copy_from_slice(&value.to_be_bytes());
+        };
+        put32(&mut chip_ram, 0, 0x0000_4000); // reset SSP
+        put32(&mut chip_ram, 4, 0x00F8_0010); // reset PC
+        let base = 0x0001_0000u32;
+        put32(&mut chip_ram, (base + 0x26) as usize, !base); // ChkBase
+        put32(&mut chip_ram, (base + 0x114) as usize, 0x0001_2000); // ThisTask
+        chip_ram[0x1_2008] = 13; // ln_Type NT_PROCESS
+        put32(&mut chip_ram, 0x1_20AC, 0x0001_3000 >> 2); // pr_CLI
+        put32(&mut chip_ram, 0x1_3010, 0x0001_3800 >> 2); // cli_CommandName
+        chip_ram[0x1_3800] = 11;
+        chip_ram[0x1_3801..0x1_380C].copy_from_slice(b"dh0:c/hello");
+        put32(&mut chip_ram, 0x1_3FFC, 0x100); // hunk 1 size
+        put32(&mut chip_ram, 0x1_4000, 0x0001_5000 >> 2); // hunk 1 next
+        put32(&mut chip_ram, 0x1_4FFC, 0x40); // hunk 2 size
+        put32(&mut chip_ram, 0x1_5000, 0); // end of list
+
+        let bus = crate::bus::Bus::new(
+            crate::memory::Memory {
+                chip_ram,
+                slow_ram: Vec::new(),
+                rom,
+                overlay: false,
+                zorro: crate::zorro::ZorroChain::default(),
+                extended_rom: Vec::new(),
+                extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
+            },
+            crate::chipset::paula::Paula::new(
+                Box::new(crate::serial::NullSerialSink),
+                Box::new(crate::audio::NullSink),
+            ),
+            crate::floppy::FloppyController::default(),
+        );
+        let mut emu = Emulator::new(
+            bus,
+            crate::config::CpuModel::M68000,
+            false,
+            Default::default(),
+            crate::config::PacingBudget::Cycles,
+            2,
+            false,
+        )
+        .unwrap();
+        // The reset vectors are latched; address 4 can now hold the
+        // ExecBase pointer.
+        emu.machine.debug_write_memory(4, &base.to_be_bytes());
+        emu
+    }
+
+    /// A minimal RSP client for driving a [`Session`] over loopback.
+    struct GdbClient {
+        stream: TcpStream,
+    }
+
+    impl GdbClient {
+        fn connect(addr: std::net::SocketAddr) -> Self {
+            let stream = TcpStream::connect(addr).unwrap();
+            stream.set_nodelay(true).ok();
+            Self { stream }
+        }
+
+        fn send(&mut self, payload: &str) {
+            write!(
+                self.stream,
+                "${payload}#{:02x}",
+                checksum(payload.as_bytes())
+            )
+            .unwrap();
+            self.stream.flush().unwrap();
+        }
+
+        fn read_reply(&mut self) -> String {
+            let mut byte = [0u8; 1];
+            loop {
+                self.stream.read_exact(&mut byte).unwrap();
+                if byte[0] == b'$' {
+                    break;
+                }
+            }
+            let mut payload = Vec::new();
+            loop {
+                self.stream.read_exact(&mut byte).unwrap();
+                if byte[0] == b'#' {
+                    break;
+                }
+                payload.push(byte[0]);
+            }
+            let mut sum = [0u8; 2];
+            self.stream.read_exact(&mut sum).unwrap();
+            self.stream.write_all(b"+").unwrap();
+            String::from_utf8(payload).unwrap()
+        }
+
+        /// Send a request and collect decoded O (console) packets until
+        /// the final non-O reply.
+        fn request_collect(&mut self, payload: &str) -> (Vec<String>, String) {
+            self.send(payload);
+            let mut console = Vec::new();
+            loop {
+                let reply = self.read_reply();
+                if reply.starts_with('O') && reply != "OK" {
+                    console.push(String::from_utf8(hex_decode(&reply[1..]).unwrap()).unwrap());
+                    continue;
+                }
+                return (console, reply);
+            }
+        }
+
+        fn request(&mut self, payload: &str) -> String {
+            self.request_collect(payload).1
+        }
+    }
+
+    /// Run a [`Session`] against a scripted client on a loopback socket.
+    /// The session runs on the test thread; client panics propagate
+    /// through the join.
+    fn run_session(emu: Emulator, client: impl FnOnce(GdbClient) + Send + 'static) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let thread = std::thread::spawn(move || client(GdbClient::connect(addr)));
+        let (stream, _) = listener.accept().unwrap();
+        Session::new(emu, stream).run().unwrap();
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn detach_keeps_serving_and_reattach_reruns_qoffsets() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let thread = std::thread::spawn(move || {
+            // First client: arm loadseg-break, continue to the load,
+            // then detach.
+            let mut first = GdbClient::connect(addr);
+            let (_, reply) =
+                first.request_collect(&format!("qRcmd,{}", hex_encode(b"loadseg-break")));
+            assert_eq!(reply, "OK");
+            let (_, reply) = first.request_collect("c");
+            assert_eq!(reply, "T05thread:1;");
+            assert_eq!(first.request("D"), "OK");
+            drop(first);
+            // Second client: attach-time qOffsets now reports the
+            // program the first session ran into.
+            let mut second = GdbClient::connect(addr);
+            assert_eq!(second.request("qOffsets"), "TextSeg=14004;DataSeg=15004");
+            second.send("k");
+        });
+        serve(listener, emulator_with_loadseg_program()).unwrap();
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn qrcmd_monitor_commands_round_trip_over_the_wire() {
+        run_session(emulator_with_loadseg_program(), |mut client| {
+            let (console, reply) =
+                client.request_collect(&format!("qRcmd,{}", hex_encode(b"help")));
+            assert_eq!(reply, "OK");
+            let text = console.concat();
+            assert!(text.contains("segments"), "monitor help output: {text}");
+            assert_eq!(client.request("D"), "OK");
+        });
+    }
+
+    #[test]
+    fn library_list_serves_loadseg_events_over_the_wire() {
+        run_session(emulator_with_loadseg_program(), |mut client| {
+            let supported = client.request("qSupported:xmlRegisters=i386");
+            assert!(
+                supported.contains("qXfer:libraries:read+"),
+                "qSupported: {supported}"
+            );
+            // Fetching the (empty) library list arms LoadSeg detection.
+            assert_eq!(
+                client.request("qXfer:libraries:read::0,1000"),
+                "l<library-list version=\"1.0\"/>"
+            );
+            // The ROM program installs cli_Module: continue stops with
+            // a library event.
+            assert_eq!(client.request("c"), "T05library:;thread:1;");
+            let list = client.request("qXfer:libraries:read::0,1000");
+            assert!(list.contains("<library name=\"hello\">"), "list: {list}");
+            assert!(
+                list.contains("<segment address=\"0x00014004\"/>"),
+                "list: {list}"
+            );
+            assert!(
+                list.contains("<segment address=\"0x00015004\"/>"),
+                "list: {list}"
+            );
+            assert_eq!(client.request("D"), "OK");
+        });
+    }
+
+    #[test]
+    fn monitor_loadseg_break_stops_visibly() {
+        run_session(emulator_with_loadseg_program(), |mut client| {
+            let (console, reply) =
+                client.request_collect(&format!("qRcmd,{}", hex_encode(b"loadseg-break")));
+            assert_eq!(reply, "OK");
+            assert!(console.concat().contains("armed"));
+            let (console, reply) = client.request_collect("c");
+            assert_eq!(reply, "T05thread:1;");
+            let text = console.concat();
+            assert!(text.contains("loadseg: hello"), "console: {text}");
+            assert!(text.contains("$014004"), "console: {text}");
+            let (console, reply) =
+                client.request_collect(&format!("qRcmd,{}", hex_encode(b"loadseg-list")));
+            assert_eq!(reply, "OK");
+            assert!(console.concat().contains("hello:"), "loadseg-list output");
+            assert_eq!(client.request("D"), "OK");
+        });
     }
 }


### PR DESCRIPTION
Fixes #181.

## What

GDB only reads `qOffsets` once at attach, so a program AmigaDOS `LoadSeg()`s afterwards never had its symbols relocated and pending breakpoints could not bind. This PR adds program-load tracking to the GDB stub, makes the stub survive detach/reattach, and corrects the symbol-format claims in the docs.

- **`monitor loadseg-break` / `monitor loadseg-list`**: `continue` stops the moment a new program's seglist is installed (after `LoadSeg()` relocation, before its first instruction) with a console hint naming the program and its first hunk.
- **`qXfer:libraries:read` + `library:` stop events**: GDB's standard automatic mechanism, armed the first time a client fetches the list; one `<library>` per tracked program with a `<segment>` per hunk, named by the command's basename. Note: stock bare-metal m68k GDB builds (bebbo 13.x, multi-arch host gdb 17) never request library lists, so the monitor flow above is the documented workflow; the packet side is wire-tested regardless.
- **Reconnectable stub**: detach (or a dropped connection) leaves the machine paused and listening instead of exiting; `kill` ends the server. Reattaching re-runs `qOffsets`, so the fully scriptable flow needs no manual addresses:

  ```sh
  m68k-amigaos-gdb -batch \
    -ex "target remote :2345" \
    -ex "monitor loadseg-break" -ex continue \
    -ex disconnect \
    -ex "file prog" \
    -ex "target remote :2345" \
    -ex "break main" -ex continue
  ```

  Bus-side debug state (register watches, beam traps, Copper breakpoints) is cleared between sessions so a stale hit cannot stop the next client.
- **Boot-garbage filtering**: early KS3.1 boot leaves uninitialized strap-process CLI fields that pass the BPTR range checks (observed live: a "hunk" at $FA8240 in ROM space with a 1.9GB size); the tracker rejects seglists whose hunks do not look like allocated RAM.
- **Docs**: `-g` hunk executables carry only the hunk symbol table (function-level symbols, no DWARF source lines); reading hunk files at all depends on the GDB build's BFD targets (`m68k-amigaos-objdump -i`); full source-level needs an ELF-with-DWARF sibling (m68k-elf + `elf2hunk`). Added a troubleshooting note: gdb's `"monitor" command not supported by this target.` means the remote connection failed (common when gdb runs inside a container that cannot reach the host loopback) - that is what issue #181's point 1 turned out to be.

## Verification

- 5 new unit tests: `LibraryTracker` detection/absorption/garbage-rejection against the fake exec world, plus wire-level RSP tests driving a real `Session` over a loopback socket (qRcmd regression, library-list events, detach/reattach with fresh `qOffsets`).
- Full suite: 1394 passed; `cargo clippy` and `cargo fmt --check` clean; `myst build --html` clean.
- Live end-to-end on a KS3.1 A1200 boot with a bootable ADF whose startup-sequence runs a `-g` hunk exe, using `m68k-amigaos-gdb` 13.0.50 (the reporter's exact build): `loadseg-break` stopped at the load, reattach relocated symbols, `break main` bound at first hunk + link-time offset and hit inside the program; `kill` shut the emulator down.