### PR TITLE
browser: recover cleanly from a rejected boot ROM

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -247,7 +247,10 @@ function tick(nowMs) {
     running = false;
     setLoadStatus(`emulator error: ${e.message ?? e}`);
     overlay.style.display = '';
-    // Re-arm the boot button: a fresh boot replaces the wedged machine.
+    // Drop the wedged machine and re-arm the boot button: the pickers go
+    // back to stashing (never a live swap into a crashed instance, which
+    // may have panicked) and a fresh boot rebuilds from the stash.
+    emu = null;
     refreshBootButton();
     console.error(e);
     return;
@@ -481,7 +484,8 @@ canvas.addEventListener(
         padTouch = { id: t.identifier, x: t.clientX, y: t.clientY, start: now, moved: 0 };
         clearTimeout(longPressTimer);
         longPressTimer = setTimeout(() => {
-          if (padTouch && padTouch.moved < TAP_SLOP_CSS_PX && padRmbTouchId === null) {
+          // emu can be gone by now: an emulator error drops the machine.
+          if (emu && padTouch && padTouch.moved < TAP_SLOP_CSS_PX && padRmbTouchId === null) {
             padDragging = true;
             emu.mouse_button(0, true);
             navigator.vibrate?.(15);
@@ -535,7 +539,7 @@ function onTouchEnd(e) {
         padTouch.moved < TAP_SLOP_CSS_PX
       ) {
         emu.mouse_button(0, true);
-        setTimeout(() => emu.mouse_button(0, false), CLICK_HOLD_MS);
+        setTimeout(() => emu?.mouse_button(0, false), CLICK_HOLD_MS);
       }
       padTouch = null;
     } else if (t.identifier === padRmbTouchId) {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -71,6 +71,19 @@ function refreshBootButton() {
   bootBtn.textContent = bootRom && bootRom.label !== 'AROS' ? 'Boot Kickstart' : 'Boot AROS';
 }
 
+// Route picked or dropped Kickstart bytes: live-swap a running machine, or
+// stash them for the boot button. The stash is updated on a live swap too,
+// so a reboot fits the ROM chosen last, not the one from the original boot;
+// a rejected image throws before the stash is touched and changes nothing.
+function fitRom(bytes, label) {
+  if (emu) emu.load_rom(bytes, undefined);
+  bootRom = { rom: bytes, ext: null, label };
+  refreshBootButton();
+  setLoadStatus(
+    emu ? `Kickstart loaded: ${label} - machine power-cycled` : `will boot ${label}`,
+  );
+}
+
 // A disk image can also come from a link: /try/?df0=<url> fetches it and
 // inserts it at boot, so a bootable demo is one shareable URL, and the
 // "DF0 from URL" button does the same for a pasted address. The fetch
@@ -164,6 +177,19 @@ async function load() {
 async function boot() {
   bootBtn.disabled = true;
   try {
+    // Fit the ROM into a fresh machine before anything else: a bad image
+    // must abort the boot with the page still in its pre-boot state (emu
+    // stays null, so the pickers keep updating bootRom for the retry).
+    const machine = new WebEmu();
+    machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
+
+    // A reboot after an emulator error builds a new audio stack; close the
+    // previous one so it cannot keep playing alongside.
+    if (audioCtx) {
+      audioNode?.disconnect();
+      audioCtx.close().catch(() => {});
+      audioNode = null;
+    }
     audioCtx = new AudioContext({ sampleRate: 44100 });
     await audioCtx.audioWorklet.addModule('./audio-worklet.js');
     audioNode = new AudioWorkletNode(audioCtx, 'copperline-audio', {
@@ -184,13 +210,12 @@ async function boot() {
       window.addEventListener('keydown', unlock, { once: true });
     }
 
-    emu = new WebEmu();
-    emu.load_rom(bootRom.rom, bootRom.ext ?? undefined);
     if (pendingDisk) {
-      emu.insert_floppy(0, pendingDisk.bytes, pendingDisk.name);
+      machine.insert_floppy(0, pendingDisk.bytes, pendingDisk.name);
       pendingDisk = null;
     }
-    emu.set_volume_percent(Number($('vol').value));
+    machine.set_volume_percent(Number($('vol').value));
+    emu = machine;
     window.__emu = emu; // for debugging/automation
 
     overlay.style.display = 'none';
@@ -222,6 +247,8 @@ function tick(nowMs) {
     running = false;
     setLoadStatus(`emulator error: ${e.message ?? e}`);
     overlay.style.display = '';
+    // Re-arm the boot button: a fresh boot replaces the wedged machine.
+    refreshBootButton();
     console.error(e);
     return;
   }
@@ -671,15 +698,7 @@ $('kick').addEventListener('change', async (e) => {
   e.target.value = '';
   if (!file) return;
   try {
-    const bytes = new Uint8Array(await file.arrayBuffer());
-    if (emu) {
-      emu.load_rom(bytes, undefined);
-      setLoadStatus(`Kickstart loaded: ${file.name} - machine power-cycled`);
-    } else {
-      bootRom = { rom: bytes, ext: null, label: file.name };
-      refreshBootButton();
-      setLoadStatus(`will boot ${file.name}`);
-    }
+    fitRom(new Uint8Array(await file.arrayBuffer()), file.name);
   } catch (err) {
     setLoadStatus(`ROM load failed: ${err.message ?? err}`);
   }
@@ -863,15 +882,7 @@ async function handleDroppedFiles(files) {
   const disk = list.find((f) => !/\.rom$/i.test(f.name));
   try {
     if (rom) {
-      const bytes = new Uint8Array(await rom.arrayBuffer());
-      if (emu) {
-        emu.load_rom(bytes, undefined);
-        setLoadStatus(`Kickstart loaded: ${rom.name} - machine power-cycled`);
-      } else {
-        bootRom = { rom: bytes, ext: null, label: rom.name };
-        refreshBootButton();
-        setLoadStatus(`will boot ${rom.name}`);
-      }
+      fitRom(new Uint8Array(await rom.arrayBuffer()), rom.name);
     }
     if (disk) {
       const bytes = new Uint8Array(await disk.arrayBuffer());


### PR DESCRIPTION
## The bug

A field report from /try: with a bad ROM image (a TOSEC `[b]` Kickstart 2.04 dump, 528509 bytes - a byte-exact LF-to-CRLF ASCII-transfer casualty, the clean image contains exactly 4221 LFs), the page wedged in ways that looked order-dependent:

- **Bad ROM first, then a good one: "boot failed: ROM size is 528509 bytes..." forever.** `boot()` assigned `emu` before `load_rom` could throw, so a failed boot left a half-initialized, never-started machine behind. The ROM pickers then took the `if (emu)` live-swap branch, which never updated the `bootRom` stash - so every Boot retry re-fed the rejected image, whatever was picked since.
- The same stale-stash pattern existed in the drag-and-drop path (#191).

(The reporter's third symptom - a black-instead-of-blue Kickstart 1.3 insert-disk screen after a live swap from 2.04 - was chased into the core and ruled out: `reload_rom` + `power_on_reset` renders pixel-identical to a fresh boot, both at current main and at the deployed wasm's commit, for 512K and mirrored 256K images alike. Their 1.3 image is suspect; verification pending.)

## The fix

JS-only change in `crates/copperline-web/www/try.js`:

- `boot()` fits the ROM into a fresh `WebEmu` before anything else and assigns `emu` only once the whole boot has succeeded, so a rejected image aborts with the page still in its pre-boot state and the pickers keep working.
- The picker and drag-drop paths share a new `fitRom()` helper: on a successful live swap it also updates the `bootRom` stash, so a later reboot fits the ROM chosen last; a rejected image throws before the stash is touched.
- The frame loop's error path re-arms the boot button, and `boot()` closes the previous audio stack, so a machine that hit an emulator error can be rebooted cleanly instead of wedging behind a disabled button.

## Testing

Verified end-to-end in Chrome against the deployed wasm bundle (the fix uses no new WebEmu API), with a bad ROM generated the same way the reporter's was corrupted:

- bad ROM, Boot -> "boot failed: ROM size is 528509 bytes..."; good ROM then goes down the pre-boot branch ("will boot ...") and Boot starts the machine - previously this errored forever
- bad ROM picked while running -> "ROM load failed: ...", machine keeps running on its old ROM (unchanged core behaviour: `reload_rom` validates before mutating)
- live swap 2.04 -> 256K 1.3 -> hand screen renders with the correct colours

Rust untouched, so `cargo fmt/clippy/test` are unaffected by this diff.