### PR TITLE
docs: catch the documentation up with the merged hardware and tooling work

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ menu; it now boots Kickstart and runs timing-sensitive OCS and AGA software
 from the regression set at real speed.
 
 It covers OCS, ECS, and AGA (independent Agnus/Denise revisions,
-programmable blanking, machine profiles from the A500 to the A1200,
-CDTV, and CD32, with Gayle IDE, A2091 SCSI, and the AGA display path: 8 bitplanes,
+programmable blanking, machine profiles from the A500 to the A4000,
+CDTV, and CD32, with Gayle and A4000 IDE, A2091/A4091/A3000 SCSI, and the
+AGA display path: 8 bitplanes,
 256-entry palette, HAM8, FMODE wide fetch; remaining gaps are recorded in
 the internals docs). Cycle-driven means the whole machine advances on one
 colour-clock timeline: the chip bus is arbitrated per colour clock, the
@@ -41,16 +42,19 @@ against real hardware.
   latency is modelled. Real-hardware reference numbers come from the
   cross-emulator disk in `timing-test/`.
 - **OCS, ECS, and AGA**, with independent Agnus/Denise revisions and machine
-  profiles from the A500 to the A1200, plus CDTV and CD32. Boots the bundled
+  profiles from the A500 to the A4000, plus CDTV and CD32. Boots the bundled
   AROS ROM out of the box, as well as Kickstart 1.3 / 2.05 / 3.1 and DiagROM
   v2.0, and runs the current timing-sensitive OCS and AGA regression set at
   real speed.
 - **Configurable CPU** (68000 / 68010 / 68EC020 / 68020 / 68030 / 68040 / 68060) and clock,
-  with an optional 68881/68882 FPU (default-on for the 68040).
+  with an optional 68881/68882 FPU (default-on for the 68040/68060) and the
+  68030/68040 MMUs.
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
-  (ADF / ADZ / ZIP / DMS, read-only SCP), Gayle IDE, A2091 SCSI, and CDTV/CD32
-  CD.
+  (ADF / ADZ / ZIP / DMS, read-only SCP), Gayle and A4000 IDE, SCSI (A2091,
+  A4091, or the A3000's onboard Super DMAC), CDTV/CD32 CD, A2065 Ethernet,
+  host directories served live as AmigaDOS volumes, and Zorro boards
+  loadable as WASM plugins.
 - **Tooling**: an in-window debugger that can step backwards, an
   interactive chip-bus frame analyzer, a trigger-based VCD waveform export
   of the chipset signals for GTKWave (`docs/debugger/waveform.md`), remote
@@ -234,7 +238,7 @@ the in-window **MIDI In / MIDI Out** menu, or set in the config file:
 
 ```toml
 [serial]
-mode = "midi"            # off, stdout, or midi
+mode = "midi"            # off, stdout, midi, tcp, or pty
 midi_out = "FluidSynth"  # host destination; substring match
 midi_in = "Keystation"   # host source
 ```
@@ -273,17 +277,20 @@ release needs resolved first. Release steps for every channel are in
 
 | Subsystem | Notes |
 | --- | --- |
-| M68K CPU | Via a vendored pure-Rust m68k crate; model selectable through 68040, accurate 68000 cycle counts, 6888x FPU. |
+| M68K CPU | Via a vendored pure-Rust m68k crate; model selectable through 68060, accurate 68000 cycle counts, 020+ caches, 6888x FPU, 68030/68040 MMUs. |
 | Chip RAM | mem_map'd; reset starts with ROM overlaid at $0 until CIA-A releases /OVL. |
 | Fast RAM | Optional Zorro II autoconfig RAM at $00200000 and Zorro III autoconfig RAM (`[memory] z3`); runs at the CPU clock. |
 | Slow RAM | Optional A500 trapdoor/fake-fast RAM at $00C00000; arbitrated on the chip bus through Agnus like chip RAM. |
 | ROM | Kickstart at $F80000 (512 KiB); optional extended ROM for CD32 ($E00000) and CDTV ($F00000). |
 | Battery RTC | Read-only MSM6242-compatible register view at $DC0000; guest writes affect only emulated latch/control state. |
 | CIA-A / CIA-B | I/O ports, /OVL, timers, TOD, keyboard SDR/ICR, disk control/status lines, and CIA-B FLAG disk index pulses. |
-| Paula serial | SERDAT through a one-word transmit buffer and timed shift register, out to stdout or -- with the optional `midi` feature -- bridged to host MIDI in/out; SERDATR reports TBE/TSRE/RBF, and serial receive is fed from the selected MIDI input. |
+| Paula serial | SERDAT through a one-word transmit buffer and timed shift register, out to stdout, a TCP port, a pseudo-terminal, or -- with the default `midi` feature -- bridged to host MIDI in/out; SERDATR reports TBE/TSRE/RBF, and serial receive is fed from the selected input. |
 | Paula audio | 4-channel DMA/sample playback, stereo mix, LED filter. |
 | Paula DMACON / INTENA / INTREQ | IRQ bits are stored and delivered through manual M68K autovectors with modelled 68000 interrupt-recognition latency; audio and disk DMA raise completion IRQs. |
 | Floppy / ADF / DMS / SCP | DF0-DF3 standard DD ADF read/write, read-only ADZ/DMS, UAE extended ADF, initial read-only SCP flux import, track-timed disk DMA, CIA drive lines, index FLAG, DSKLEN/DSKBYTR/DSKSYNC/DSKDAT, per-drive multi-disk playlists with a swap key. |
+| Hard disks | Gayle IDE (A600/A1200) and A4000 motherboard IDE; SCSI via the A2091 (Zorro II DMAC + WD33C93A), A4091 (Zorro III 53C710 with SCRIPTS), or A3000 Super DMAC; RDB HDFs, bare partition hardfiles, and host-directory volumes. |
+| Host filesystem | `[[filesys]]` mounts serve host directories live as AmigaDOS volumes (read/write, `.uaem` attribute sidecars, Latin-1 name mapping). |
+| Expansion | Zorro II/III autoconfig chain, TOML-described RAM boards, WASM plugin boards (registers/interrupts/DMA in a sandboxed module), A2065 Ethernet (Am7990 LANCE) with host network backends. |
 | Agnus VPOSR / VHPOSR | Beam counters advanced per colour clock; PAL and NTSC timing (including NTSC long/short lines). |
 | Agnus Copper | Beam-scheduled OCS Copper with COP1/COP2 jumps, WAIT, SKIP, DMAEN/COPEN gating, and chip-bus grants. |
 | Agnus blitter | Scheduled per-slot engine: normal/line/fill modes, hardware per-word channel bus sequences (including the area-fill idle C slot), BBUSY/BZERO, BLTPRI "nasty" vs CPU starvation-yield arbitration, blit-done IRQ. |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,8 +18,17 @@ resolve that dependency story before attempting a crates.io release.
    Expected tracked binary files are:
 
    - `assets/brand/*.png`
+   - `assets/aros/aros-amiga-m68k-rom.bin` and
+     `assets/aros/aros-amiga-m68k-ext.bin`, the bundled AROS boot ROMs
+     (APL-licensed; see `assets/aros/README.md`)
+   - `assets/services/services_rom.bin`, the guest-side host-filesystem
+     handler built from `guest/services/`
    - `docs/images/*.png`; review provenance before release when these change
-   - `timing-test/boot.bin`, built from `timing-test/boot.asm`
+   - `timing-test/*.bin` probe programs (`boot.bin`, `test.bin`, the
+     `ddfprobe-*`/`bltprobe-*`/`audprobe-*`/`clxprobe`/`regprobe-*`/
+     `sprprobe-*` bootblocks), each built from its adjacent `.asm`
+   - `timing-test/golden/*.png`, the blessed golden renders for
+     `tests/probe_golden.rs`
    - `crates/m68k/tests/fixtures/extra/**/bin/*.bin`, built from the
      adjacent assembly sources under sibling `src/` directories
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,11 +5,15 @@
 - Copperline now uses the pure-Rust `m68k` CPU core. The Unicorn backend,
   forked QEMU patches, MOVEC/F-line hooks, and stopped-slice block
   estimator have been removed.
-- Configurable CPU models are `68000`, `68EC020`, `68020`, `68030`,
-  and `68040`. `68060` remains rejected (no backend support).
+- Configurable CPU models are `68000`, `68010`, `68EC020`, `68020`,
+  `68030`, `68040`, and `68060` (`[cpu] unimplemented` selects trap
+  vs. native handling for the instructions the 68060 dropped). The
+  68030 and 68040 MMUs are modelled with resumable fault frames.
   `cpu.fpu = true` fits a 68881/68882 on any 020+ (default-on for the
-  full 68040): the vendored core's 6888x implementation runs in f64
-  precision with all operand formats except packed decimal, real
+  full 68040 and the 68060, whose FPUs are on-die): the vendored
+  core's FPU is a pure-Rust 80-bit extended-precision softfloat
+  engine covering every operand format including packed decimal,
+  extended-precision transcendentals (faithful to ~64 bits), real
   FSAVE/FRESTORE frames (NULL after reset), and the full conditional
   family. Verified against Kickstart detection + exec context
   switching on 1.3/2.05/3.1 and SysInfo's hardware report (68881).
@@ -25,8 +29,9 @@
   Paula serial, live/WAV audio, Copper scheduling, blitter basics, and
   OCS bitplane rendering all have focused coverage.
 - Floppy support covers standard DD ADF, read-only ADZ/DMS/SCP, UAE
-  extended ADF variants, track-timed read/write DMA, and writable
-  sector/raw-track persistence for supported writable formats.
+  extended ADF variants, gzip- or single-file-ZIP-packed images,
+  track-timed read/write DMA, and writable sector/raw-track
+  persistence for supported writable formats.
 - IPF/CAPS protected-image support is an explicit non-goal for the
   built-in loader for now. IPF files start with a `CAPS` record; useful
   support should either be a direct IPF parser or an optional SPS/CAPS
@@ -39,10 +44,13 @@
   path has a prefetch-queue model with per-access cycle billing
   (~99.6% timing-exact against SingleStepTests, see
   `crates/m68k/CYCLE_TIMING_GAP.md`), interrupt-recognition latency,
-  and chip-bus slot arbitration with CPU/blitter/DMA contention.
-  68020+ timing, some Paula disk details, and ECS/AGA behavior remain
-  pragmatic and should be tightened only when driven by a concrete
-  regression.
+  and chip-bus slot arbitration with CPU/blitter/DMA contention. The
+  020+ models add the on-chip instruction/data caches with calibrated
+  bus costs rather than per-microcycle sequences, and all models run
+  clean through the cputest harness (`crates/cputest-runner`). Paula
+  audio follows the HRM DMA state machine. Remaining ECS/AGA gaps are
+  recorded next to each subsystem in `docs/internals/` and should be
+  tightened only when driven by a concrete regression.
 
 ## Standard Checks
 
@@ -52,10 +60,13 @@ done. DiagROM comes first; Kickstart is a follow-up chipset/OS check.
 1. `cargo test`
 2. `cargo build --release`
 3. `./target/release/copperline --noaudio --config copperline.example.toml --screenshot-after 5.0 /tmp/diag.png`
-4. `cargo test --release --test image_regression -- --ignored --nocapture`
-5. Kickstart 2.05 boot check, from a local config whose `rom` is a Kickstart 2.05 image: `./target/release/copperline --noaudio --config path/to/local.toml --screenshot-after 8.0 /tmp/ks.png`
-6. Run any local/private smoke configs needed for the subsystem under review.
-7. `git diff --check`
+4. `cargo test --release --test probe_golden` (the golden renders in
+   `timing-test/golden/`; a timing or render change that alters them must
+   be re-blessed with `COPPERLINE_BLESS_GOLDEN=1`, see timing-test/README.md)
+5. `cargo test --release --test image_regression -- --ignored --nocapture`
+6. Kickstart 2.05 boot check, from a local config whose `rom` is a Kickstart 2.05 image: `./target/release/copperline --noaudio --config path/to/local.toml --screenshot-after 8.0 /tmp/ks.png`
+7. Run any local/private smoke configs needed for the subsystem under review.
+8. `git diff --check`
 
 Expected results:
 
@@ -119,17 +130,13 @@ git history, not as a done-log in this file.
    address-masking test on `68EC020`, and a `68040`-as-LC040 snippet (the
    `cpu_type_for_model` mapping exists but is untested).
 
-2. **POTGO RC modelling.** `write_potgo`/`read_potgor`/`tick_pots`
+2. **POTGO RC modelling.** `write_potgo`/`read_potgor`/`tick_pot_hsync`
    (`src/chipset/paula.rs`) model output loopback with open-drain pin
-   sense, the START reset/restart, and a linear fixed-rate counter charge.
-   Remaining: an RC-style charge curve from real pot resistance,
-   chip-revision bits, and a scan-rate-dependent counter range.
+   sense, the START reset/restart, and a per-scan-line counter charge
+   paced by horizontal sync. Remaining: an RC-style charge curve from
+   real pot resistance and chip-revision bits.
 
 3. **CIA gaps.**
-   - A real reset path for CIA state (port DDRs, timer counters/latches,
-     TOD/alarm defaults, ICR masks, CIA-A `PRA.OVL`) driven by CPU
-     `RESET`. Power-on defaults exist via `Cia::new`, but there is no
-     RESET-instruction-driven reset.
    - CIA-A physical port restrictions: disk-sense bits PA5-PA2 must stay
      inputs even when DDRA marks them as outputs.
    - Parallel-port / Centronics behaviour: CIA-B PRA strobe on data write,
@@ -142,9 +149,10 @@ git history, not as a done-log in this file.
      the $000000 alarm reset are already correct, with tests.)
 
 4. **Memory-map tests.** Chip/slow/fast RAM sizes are config-selectable and
-   `src/cpu.rs` covers the boot overlay, ROM write-protect, and slow-RAM
-   bus contention. Remaining: chip/slow/fast mirror tests and an explicit
-   A500 Rev.6 512K+512K layout regression.
+   `src/cpu.rs` covers the boot overlay, ROM write-protect, slow-RAM bus
+   contention, chip-window aliasing by Agnus reach, and the small-box
+   custom-register mirror. Remaining: fast-RAM mirror coverage and an
+   explicit A500 Rev.6 512K+512K layout regression.
 
 5. **Keep the test matrix maintainable.** Promote a repeated manual smoke
    path into a fast unit test, an ignored image regression, or a scripted

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -56,12 +56,12 @@ pacing_budget = "cycles"
 
 [cpu]
 
-# CPU type. One of: 68000, 68EC020, 68020, 68030, 68040, 68060.
+# CPU type. One of: 68000, 68010, 68EC020, 68020, 68030, 68040, 68060.
 # 68EC020 uses the 68020 instruction set with a 24-bit external address bus.
 model = "68000"
 
 # FPU (68881/68882 coprocessor; on-die on the full 68040/68060). Needs a
-# 68020 or later -- a 68000 cannot drive one. The 68040 and 68060 enable
+# 68020 or later -- a 68000/68010 cannot drive one. The 68040 and 68060 enable
 # it by default; on other 020+ CPUs opt in here. fpu = false on the 68060
 # models the FPU-less LC/EC parts (PCR.DFP).
 # fpu = true
@@ -167,23 +167,34 @@ fast = "0"
 slow = "512K"
 
 # Zorro III autoconfig RAM. Kickstart assigns the base address (usually
-# $40000000). Needs a CPU with a 32-bit address bus (68020/68030/68040;
-# not the 24-bit 68000/68EC020). Must be 0 or a power of two from 64K
-# to 1G.
+# $40000000). Needs a CPU with a 32-bit address bus (68020 and later;
+# not the 24-bit 68000/68010/68EC020). Must be 0 or a power of two from
+# 64K to 1G.
 # z3 = "16M"
 
 
 # Additional Zorro boards described by TOML metadata files, configured
 # in file order after the built-in [memory] fast/z3 boards. The metadata
-# file carries the autoconfig identity (see src/zorro.rs for the schema):
+# file carries the autoconfig identity (see docs/zorro.md for the schema):
 #   name = "MegaRAM"
 #   zorro = 3            # 2 or 3
-#   type = "ram"         # board backing; only "ram" so far
-#   size = "64M"
+#   type = "ram"         # board backing: "ram", or "wasm" for a plugin
+#   size = "64M"         # board whose behaviour comes from a .wasm module
 #   manufacturer = 0x07DB
 #   product = 0x20
+# A "wasm" board's manifest can declare settings; override them per board
+# with config = { key = value, ... }.
 # [[zorro]]
 # metadata = "boards/megaram.toml"
+
+
+# A2065 Ethernet board (Am7990 LANCE, driven by the SANA-II a2065.device).
+# net picks the host network backend: "loopback" echoes transmitted frames
+# back (self-contained), "none" leaves the NIC isolated. Omit the section
+# for no board. Host networking is non-deterministic, so a fitted NIC
+# breaks byte-identical replay/save-state determinism while traffic flows.
+# [a2065]
+# net = "loopback"
 
 
 # SCSI bus with up to seven drives, on any machine model. Preferred over [ide]
@@ -223,8 +234,8 @@ slow = "512K"
 
 # Optional per-chip overrides on top of the preset, for mixed machines
 # that really shipped (e.g. a late A500: ECS Agnus + OCS Denise).
-#   agnus  = "OCS" | "8370" | "8371" | "8372" | "8372A" | "8375"
-#   denise = "OCS" | "8362" | "ECS" | "8373"
+#   agnus  = "OCS" | "8370" | "8371" | "8372" | "8372A" | "8372B" | "8375" | "ALICE" (8374)
+#   denise = "OCS" | "8362" | "ECS" | "8373" | "LISA" (4203)
 # agnus = "8372A"
 # denise = "OCS"
 
@@ -246,7 +257,7 @@ video = "PAL"
 # Host directories mounted directly as AmigaDOS volumes (HOSTFS0:,
 # HOSTFS1:, ...), served live with no disk image in between: the guest reads
 # and writes the host's files directly, and changes land in the directory as
-# you would expect. Up to 16 mounts. volume defaults to the directory name.
+# you would expect. Up to 8 mounts. volume defaults to the directory name.
 # bootpri (-128..127, default -128 = never boot) enters the boot-device vote:
 # hard-disk boot partitions typically sit at 0 and DF0: at 5. readonly exports
 # the directory write-protected: the guest sees a read-only disk and every
@@ -310,16 +321,14 @@ floppy_sounds_volume = 100
 # [input]
 
 # Initial source for the emulated port-2 joystick / CD32 pad:
-#   "auto"     (default) a calibrated USB gamepad drives port 2 when present,
-#              otherwise the keyboard-joystick mapping (cursor keys + fire keys)
-#              takes over so port 2 stays usable without a controller.
-#   "gamepad"  only a physical pad drives port 2; the keyboard passes straight
-#              through to the Amiga (Shell, editor, Workbench). With no pad
-#              connected there is simply no port-2 input -- ideal for
+#   "gamepad"  (default) only a physical pad drives port 2; the keyboard passes
+#              straight through to the Amiga (Shell, editor, Workbench). With
+#              no pad connected there is simply no port-2 input -- ideal for
 #              keyboard-driven setup of an AmigaOS environment.
-#   "keyboard" always use the keyboard-joystick mapping.
+#   "keyboard" always use the keyboard-joystick mapping (cursor keys + fire
+#              keys), so port 2 stays usable without a controller.
 # Cmd+J / Alt+J still cycles this live; --joystick MODE overrides it per run.
-# joystick = "auto"
+# joystick = "gamepad"
 
 
 # Serial port wiring. The Amiga serial port doubles as the MIDI port.

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -37,19 +37,19 @@ Execution:
 
 | Command | Effect |
 |---|---|
-| `RUN` | Resume the machine (also `GO`, `C`) |
+| `RUN` | Resume the machine (also `GO`, `CONTINUE`, `C`) |
 | `PAUSE` | Pause and report where the machine is |
 | `STEP [N]`, `S` | Execute N instructions (default 1) |
-| `OVER`, `N` | Step over a BSR/JSR/TRAP call |
-| `OUT` | Run until the current subroutine returns |
+| `OVER`, `N` | Step over a BSR/JSR/TRAP call (also `NEXT`) |
+| `OUT` | Run until the current subroutine returns (also `FINISH`) |
 | `FRAME`, `F` | Run one video frame |
 | `LINE` | Run to the start of the next scanline |
 | `CSTEP` | Run until the Copper retires one instruction |
 | `RUNTO ADDR` | Run until the PC reaches ADDR |
 | `TOSLOT V [H]` | Run until the beam reaches the position |
-| `RSTEP [N]` | Step backward (reverse debugging) |
+| `RSTEP [N]`, `RS` | Step backward (reverse debugging) |
 | `RFRAME` | Step one frame backward |
-| `RRUN` | Run backward to the previous breakpoint |
+| `RRUN`, `RC` | Run backward to the previous breakpoint |
 
 Every forward command ends by printing the stop reason (if a breakpoint,
 watchpoint, trap, or catchpoint fired) and a status line: the PC with its
@@ -61,11 +61,11 @@ Stops (each toggles: repeat the command to remove):
 |---|---|
 | `BREAK ADDR [COND] [IGN N]`, `B` | PC breakpoint, with the Break tab's condition grammar |
 | `WATCH ADDR [CPU\|BLITTER\|DISK]`, `W` | Memory word watchpoint; the optional filter stops only on that writer |
-| `RWATCH NAME\|OFF` | Custom-register write watch (`RWATCH DMACON`) |
+| `RWATCH NAME\|OFF`, `RW` | Custom-register write watch (`RWATCH DMACON`) |
 | `BTRAP V [H]` | Beam trap (decimal position) |
 | `CBREAK ADDR` | Copper breakpoint |
 | `CATCH IRQ N \| TRAP N \| VEC N` | Exception catchpoint |
-| `BREAKS` | List everything armed |
+| `BREAKS`, `INFO` | List everything armed |
 | `CLEARBREAKS` | Remove everything |
 
 Inspection and modification:
@@ -88,8 +88,8 @@ Inspection and modification:
 | `TRACE START [PATH]` | Start a runtime instruction trace: one disassembled line per retired instruction with its beam position, no env var or restart needed (capped at a million lines) |
 | `TRACE STOP` / `TRACE` | Stop the trace / report its progress |
 | `WAVE START [PATH] [TRIGGER] [DURATION] [SIGNALS]` | Arm a trigger-based VCD "logic analyser" capture of chipset signals for GTKWave; the arguments are order-free and all optional (see [](waveform.md)) |
-| `WAVE STOP` / `WAVE` | Finish the capture early / report its progress |
-| `HELP`, `CLEAR`, `CLOSE` | Console housekeeping |
+| `WAVE STOP` / `WAVE` | Finish the capture early / report its progress (`WAVEFORM` is an alias) |
+| `HELP` (`?`), `CLEAR`, `CLOSE` (`QUIT`, `EXIT`) | Console housekeeping |
 
 Memory hunting (a trainer-style delta search over all writable RAM --
 chip, slow, and Zorro RAM boards):
@@ -113,8 +113,8 @@ garbage):
 | Command | Effect |
 |---|---|
 | `TASKS` | The scheduled task (`>`), then the ready and waiting lists, with priority, state, and name |
-| `LIBS` | Opened libraries with versions (`graphics.library v40.10`) |
-| `DEVS` | Devices with versions |
+| `LIBS`, `LIBRARIES` | Opened libraries with versions (`graphics.library v40.10`) |
+| `DEVS`, `DEVICES` | Devices with versions |
 | `RESOURCES`, `PORTS` | The resource and message-port lists |
 | `SEGMENTS` | The current process's loaded hunks (its CLI command's segment list when there is one), with the `add-symbol-file` line a source-level GDB session needs |
 | `CATCHTASK NAME` | Stop when exec schedules a task whose name contains NAME (case-insensitive); `CATCHTASK` alone clears it |

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -234,6 +234,10 @@ stop; `monitor loadseg-list` prints the same table.
 | `unwatch-reg NAME\|OFFSET` | remove one custom-register watch |
 | `clear-reg-watches` | remove all custom-register watches |
 | `copper [auto\|pc\|ADDR] [COUNT]` | disassemble Copper instructions |
+| `beam-trap VPOS [HPOS]` | toggle a stop when the beam reaches that position |
+| `clear-beam-traps` | remove all beam traps |
+| `copper-break ADDR` | toggle a stop when the Copper PC reaches ADDR |
+| `clear-copper-breaks` | remove all Copper breakpoints |
 | `last-writer ADDR` | reverse-search the last write to a word |
 | `segments` | the current process's loaded hunks (LoadSeg addresses) |
 | `loadseg-break` | toggle a visible stop whenever a new program is loaded |

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -35,6 +35,18 @@ cannot change at runtime (see [](../internals/architecture)).
   changes, whoever wrote it:
   `DBG WATCH 0x00c09580 0012->0013 by pc=0x00c03374`.
 
+`COPPERLINE_DBG_MEMW=ADDR`
+: CPU-write watchpoint on one word: whenever a CPU write covers the
+  watched word, logs the writer PC, the post-write value, and the emulated
+  time and frame. Narrower than `WATCH` (CPU writes only), but attributes
+  the write from inside the CPU's own decode, so chip-RAM mirror aliases
+  are noted too. Bounded by `AFTER`/`UNTIL`.
+
+`COPPERLINE_DBG_FC=ADDR`
+: Log every change of the 16-bit word at ADDR -- whoever caused it -- with
+  emulated time and a running change count. Useful for pacing questions
+  ("how often does this frame counter tick").
+
 `COPPERLINE_DBG_DUMP=ADDR:WORDS[,...]`
 : Memory regions to hex-dump with every break/watch report
   (`mem 0x00c09580: 0000 0001 0002 0003`).
@@ -65,6 +77,29 @@ cannot change at runtime (see [](../internals/architecture)).
   exec.library `Alert()`. Each hit includes the D7 alert code decoded with the
   same Guru table used by the interactive debugger.
 
+`COPPERLINE_DBG_IRQ=1`
+: Log every serviced interrupt -- level plus the enabled pending source
+  bits -- with emulated time. Bounded by `AFTER`/`UNTIL`.
+
+`COPPERLINE_DBG_CIA=1`
+: Log INTENA/INTREQ writes that touch the EXTER bit or the master enable,
+  for tracing CIA-interrupt enable/acknowledge traffic.
+
+`COPPERLINE_DBG_DSKLEN=1`
+: Log every DSKLEN write (disk DMA arming: word count, direction, DSKPT,
+  beam position) and the matching DSKBLK completion, closing each
+  arm-to-completion interval to correlate disk activity with scene
+  timing.
+
+`COPPERLINE_DBG_SPREN=1`
+: When a DMACON write clears the sprite-DMA-enable bit, log the
+  instruction that did it (previous PC) and the full register file.
+
+`COPPERLINE_DBG_BLIT=LO:HI`
+: Log each blit started between LO and HI emulated seconds: control
+  words, D pointer/modulo, size, and mode flags, with the starting beam
+  position. For finding which blit produces a given rendered region.
+
 `COPPERLINE_DBG_RAMDUMP=ADDR:LEN:FILE`
 : One-shot memory dump the first time the debugger activates: LEN bytes
   from hex address ADDR are written to FILE, read through the CPU's own
@@ -88,6 +123,16 @@ cannot change at runtime (see [](../internals/architecture)).
 `COPPERLINE_DBG_SHOT=PREFIX`
 : Save a PNG of the last completed frame on every hit, as
   `PREFIX-0000.png`, `PREFIX-0001.png`, ...
+
+`COPPERLINE_DBG_EXPORT_PLANES=1`
+: Export each bitplane and a composite colour-index image for every frame
+  rendered inside the `AFTER`/`UNTIL` window, using the exact per-line
+  plane words the renderer fetched -- a ground-truth view of each plane.
+  `COPPERLINE_DBG_EXPORT_PLANES_DIR=DIR` sets the output directory.
+
+`COPPERLINE_DBG_FRAMESTATE=1`
+: Log the per-frame display state (one summary line per rendered frame)
+  inside the `AFTER`/`UNTIL` window.
 
 ## Diagnostic knobs
 
@@ -166,9 +211,16 @@ Timing-model knobs that pair well with the debugger:
 
 Behavior-changing A/B switches such as `COPPERLINE_NO_*`,
 `COPPERLINE_EXP_*`, `COPPERLINE_DISK_SPEED_DIV`, and
-`COPPERLINE_DBG_EXTCCK` are compiled only with the
+`COPPERLINE_DBG_EXTCCK` (external-access cost in hundredths of a colour
+clock, default 200 = 2.00 cck) are compiled only with the
 `internal-diagnostics` feature. Normal builds ignore them so release runs
 stay hardware-derived and reproducible.
+
+For finding registers a guest probes that Copperline does not decode,
+see the `[debug] log_unmapped` config key in
+[Configuration](../guide/configuration.md) -- it is a config setting
+rather than an environment variable because it pairs with a specific
+machine setup.
 
 ## A worked example
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -35,7 +35,7 @@ range checks as the equivalent TOML fields:
 
 | Flag | Overrides | Accepts |
 |---|---|---|
-| `--model NAME` | `[machine] profile` | `A1000`, `A500`, `A500OCS`, `A500Plus`, `A600`, `A1200`, `CDTV`, `CD32` |
+| `--model NAME` | `[machine] profile` | `A1000`, `A500`, `A500OCS`, `A500Plus`, `A600`, `A1200`, `A3000`, `A4000`, `CDTV`, `CD32` |
 | `--chipset NAME` | `[chipset] revision` | `OCS`, `ECS`, `AGA` |
 | `--cpu MODEL` | `[cpu] model` | `68000`, `68010`, `68EC020`, `68020`, `68030`, `68040`, `68060` |
 | `--cpu-clock MHZ` | `[cpu] clock_mhz` | a number of MHz |
@@ -57,6 +57,11 @@ A `--model` profile supplies the chipset, CPU, and memory defaults of a real
 machine; the other flags then override individual values on top of it, just as
 explicit `[cpu]`/`[chipset]`/`[memory]` sections override a `[machine]`
 profile in a config file.
+
+The audio and serial surface has matching per-run flags too --
+`--audio-device`, `--audio-channel-mode`, `--audio-stereo-separation`,
+`--serial`, `--midi-in`, `--midi-out` -- described with their `[audio]` and
+`[serial]` keys below.
 
 ## Top level
 
@@ -118,25 +123,23 @@ gives a plain 8371/8362 OCS machine.
 | `CD32` | AGA (Alice/Lisa) | 68EC020 @ 14.18 MHz | 2M | 0 | Akiko, CD32 pad, NVRAM, 512K extended ROM |
 
 `rtc` exists because most Amigas shipped without a battery-backed clock and
-only some carried one. Only the `A500Plus` (an OKI RTC soldered to the Rev 8A
-board) and `CDTV` fit one by default; the base A500/A500OCS, A600, A1200,
-A1000, and CD32 have none. Set `rtc = true` to add one -- for an A600HD or a
-clock-equipped A1200, say -- so the Workbench clock keeps time.
+only some carried one. The `A500Plus` (an OKI RTC soldered to the Rev 8A
+board), `CDTV`, `A3000`, and `A4000` fit one by default; the base
+A500/A500OCS, A600, A1200, A1000, and CD32 have none. Set `rtc = true` to add
+one -- for an A600HD or a clock-equipped A1200, say -- so the Workbench clock
+keeps time.
 
-The `A3000` and `A4000` profiles are the big-box machines. Both boot, but they
-are new and incomplete. They carry a Ramsey memory controller
-(`mem_controller`), which is what the two registers at `$DE0003` and `$DE0043`
-answer as, and they carry Gary rather than Gayle -- so no PCMCIA and no Gayle
-IDE.
+The `A3000` and `A4000` profiles are the big-box machines. They carry a
+Ramsey memory controller (`mem_controller`), which is what the two registers
+at `$DE0003` and `$DE0043` answer as, and they carry Gary rather than Gayle
+-- so no PCMCIA and no Gayle IDE.
 
 - The **A3000** has its motherboard SCSI: a Super DMAC at `$DD0000` driving a
-  WD33C93, which Kickstart's own `scsi.device` initialises at boot. No drives
-  are attached to it yet, so give the machine a Zorro controller (`[scsi]`) or a
-  host directory (`[[filesys]]`) to boot from.
-- The **A4000**'s IDE interface at `$DD2020` is not implemented. Kickstart's
-  `scsi.device` probes it, finds nothing, and waits out a timeout, so every boot
-  spends several seconds in the driver before it completes. Same story for
-  where to boot from.
+  WD33C93, which Kickstart's own `scsi.device` initialises at boot. Attach
+  drives to it with `[scsi] controller = "a3000"` (the default controller on
+  an A3000; see the `[scsi]` section below).
+- The **A4000** has its motherboard IDE interface at `$DD2020`; attach drives
+  with `[ide]`, exactly as on a Gayle machine.
 
 Motherboard fast RAM is not emulated on either; use `[memory] z3` instead,
 which the OS is equally happy with.
@@ -222,7 +225,7 @@ carried no information.)
 [cpu]
 model = "68000"     # 68000, 68010, 68EC020, 68020, 68030, 68040, 68060
 clock_mhz = 14.0    # optional; defaults to the model's stock speed
-# icache = false    # instruction-cache model (on by default: 020/030/040/060)
+# icache = false    # instruction-cache model (on by default on all 020+ models)
 # dcache = false    # data-cache model (on by default: 030/040/060)
 # fpu = true        # fit a 68881/68882 (68020/68030; needs the coprocessor
 #                   # interface, so not valid on a 68000). The full 68040's
@@ -425,6 +428,39 @@ without changing the config. `--joystick MODE` overrides this for a single
 run. (`auto` is still accepted here as a backward-compatibility alias for
 `gamepad`; the old auto-detect mode has been removed.)
 
+## `[serial]` -- serial port and MIDI
+
+```toml
+[serial]
+mode = "stdout"          # off, stdout, midi, tcp, or pty
+# midi_out = "FluidSynth"  # midi mode: host destination, substring match
+# midi_in = "Keystation"   # midi mode: host source, substring match
+# listen = "127.0.0.1:1234"  # tcp mode: bind address
+```
+
+The Amiga serial port doubles as the MIDI port. `mode` selects where
+Paula's serial in/out is connected:
+
+- `stdout` (the default) -- serial output prints to the host terminal,
+  matching the historical behaviour (DiagROM and similar tools log here).
+- `off` -- serial output is discarded and there is no serial input.
+- `midi` -- serial in/out is bridged to host MIDI endpoints. Needs a build
+  with the `midi` feature (the default); `midi_out`/`midi_in` name the
+  endpoints by case-insensitive substring (a USB interface or a virtual
+  port). `--list-midi` prints the host endpoints.
+- `tcp` -- serial in/out is bridged to a host TCP port, like UAE's `TCP:`
+  device. `listen` sets the bind address (default `127.0.0.1:1234`);
+  connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
+- `pty` -- serial in/out is bridged to a host pseudo-terminal (Unix only).
+  The slave path (`/dev/pts/N`) is logged at startup; attach a terminal
+  with e.g. `minicom -D`, `screen`, or `cu -l`.
+
+With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
+console. `--serial MODE` overrides the mode per run, and
+`--midi-out NAME`/`--midi-in NAME` imply `mode = "midi"`. The launcher's
+**Serial** tab and the in-window **MIDI In / MIDI Out** menu items select
+the MIDI endpoints interactively.
+
 ## `[floppy]` and `[floppy.df0]` .. `[floppy.df3]`
 
 ```toml
@@ -455,11 +491,12 @@ without a second drive: the first entry is the boot disk and the disk-swap
 shortcut (`Cmd+D` on macOS, `Alt+D` on Linux/Windows) or the status-bar
 swap button cycles to the next image, wrapping around.
 
-## `[ide]` -- Gayle hard disks
+## `[ide]` -- IDE hard disks
 
 ```toml
 [machine]
-profile = "A600"             # IDE needs a Gayle machine (A600 or A1200)
+profile = "A600"             # IDE needs a machine with an IDE port
+                             # (A600 or A1200 Gayle, or the A4000)
 
 [ide]
 master = "AmigaSYS.hdf"      # raw flat HDF, read/write
@@ -502,35 +539,50 @@ effect on a raw HDF, which carries its own label inside the image.
 
 The drive responds to ATA IDENTIFY with the Gayle byte order real hardware
 uses, so both Kickstart 3.1 variants boot from it. An HDD activity LED
-appears in the status bar on IDE machines.
+appears in the status bar on IDE machines. On the `A4000` profile the same
+`[ide]` section attaches drives to the motherboard IDE interface at
+`$DD2020` (no Gayle involved; Kickstart's `scsi.device` drives it the same
+way).
 
-## `[scsi]` -- A2091 SCSI controller
+## `[scsi]` -- SCSI controllers
 
 ```toml
 [scsi]
-rom = "a2091-v6.6.rom"       # A590/A2091 boot ROM image (required)
-# rom_odd = "a2091-odd.rom"  # for split even/odd EPROM dumps
+# controller = "a2091"       # a2091 (default), a4091, or a3000
+rom = "a2091-v6.6.rom"       # boot ROM image (a2091/a4091; the a3000 needs none)
+# rom_odd = "a2091-odd.rom"  # a2091 only: split even/odd EPROM dumps
 unit0 = "workbench.hdf"      # SCSI IDs 0-6
 unit1 = "data.hdf"
 # unit2..unit6 = ...
 ```
 
-The `[scsi]` section attaches a Commodore A2091 controller (Commodore
-DMAC + WD33C93A) as a Zorro II autoconfig board. It is the preferred way
-to mount hard disks: up to **seven drives** on one controller, on **any
-machine model** (the board needs no Gayle), and with no dependence on the
-Kickstart IDE driver -- the board's own boot ROM carries `scsi.device`
-and autoboots on Kickstart 1.3 and newer, which also sidesteps the stock
-A600/A1200 `scsi.device` only probing the IDE master. `[ide]` remains
-available, and both can be used at once.
+The `[scsi]` section attaches a SCSI host adapter with up to **seven
+drives**. `controller` picks which one:
 
-`rom` must point at an A590/A2091 boot ROM image (version 6.6 or later;
-16K/32K, available from the same vendors and dump sets as Kickstart
-ROMs). Dumps split into even/odd EPROM halves can be given as `rom`
-(even, U13) plus `rom_odd` (odd, U12). The ROM is required because the
-autoboot DiagArea and the scsi.device driver itself live in it; the
-autoconfig identity comes from the board (Commodore, product 3, DiagArea
-vector at `$2000`).
+- `"a2091"` (the default on machines without onboard SCSI): a Commodore
+  A2091 (Commodore DMAC + WD33C93A) as a Zorro II autoconfig board. It
+  works on **any machine model** (the board needs no Gayle) and has no
+  dependence on the Kickstart IDE driver -- the board's own boot ROM
+  carries `scsi.device` and autoboots on Kickstart 1.3 and newer, which
+  also sidesteps the stock A600/A1200 `scsi.device` only probing the IDE
+  master. `[ide]` remains available, and both can be used at once.
+- `"a4091"`: a Commodore A4091 (NCR 53C710 SCSI-2) as a Zorro III
+  autoconfig board, for machines with a 32-bit CPU. It needs a raw A4091
+  EPROM image (e.g. the open-source `a4091.rom`) as `rom`; it has a single
+  ROM, so `rom_odd` does not apply.
+- `"a3000"` (the default on the `A3000` profile): the A3000's motherboard
+  SCSI -- the Super DMAC at `$DD0000` driving a WD33C93. It is silicon, not
+  a card, so it needs no boot ROM: Kickstart's own `scsi.device` drives it
+  and autoboots from an RDB drive. It is only valid on a machine with the
+  Super DMAC (the A3000).
+
+For the A2091, `rom` must point at an A590/A2091 boot ROM image (version
+6.6 or later; 16K/32K, available from the same vendors and dump sets as
+Kickstart ROMs). Dumps split into even/odd EPROM halves can be given as
+`rom` (even, U13) plus `rom_odd` (odd, U12). The ROM is required on the
+Zorro boards because the autoboot DiagArea and the scsi.device driver
+itself live in it; the autoconfig identity comes from the board (the
+A2091 is Commodore product 3, with its DiagArea vector at `$2000`).
 
 Each `unitN` accepts everything `[ide]` paths do: RDB images, bare
 partition hardfiles (a synthesized RDB advertises a bootable `DHn`
@@ -549,6 +601,7 @@ bootpri = 6            # optional boot priority; default -128 = never boot
 
 [[filesys]]
 path = "/data/amiga/downloads"
+readonly = true        # optional, export the directory write-protected
 ```
 
 Each `[[filesys]]` entry exports a host directory to the guest as an
@@ -556,13 +609,28 @@ AmigaDOS volume on its own `HOSTFS<n>:` device, served live by the
 emulator: no disk image is built, and guest reads always see the current
 host contents. This differs from giving `[ide]`/`[scsi]` a directory
 path, which snapshots the tree into an in-memory FFS volume at startup.
-Up to 16 mounts.
+Up to 8 mounts.
 
-The volumes are read-only for now: write operations fail with the same
-"disk is write-protected" error a physical write-protected disk gives.
-Protection bits, comments, and exact datestamps are taken from UAE-style
-`.uaem` sidecar files when present (the sidecars stay hidden from
-listings).
+The volumes are read-write by default: the guest creates, writes, renames,
+and deletes the host's files directly, and changes land in the directory
+as you would expect. Set `readonly = true` to export a directory
+write-protected instead -- the guest sees a read-only disk and every write
+fails with the same "disk is write-protected" error a physical
+write-protected disk gives, which is worth setting on anything you would
+rather the Amiga could not damage. The launcher's Host Mounts tab exposes
+the same choice as its **Access** field.
+
+Amiga file attributes a host filesystem cannot hold -- protection bits
+such as script/pure/archive, file comments, and exact datestamps -- are
+kept in UAE-style `.uaem` sidecar files, read when present and written
+back when the guest changes them; the sidecars stay hidden from guest
+listings, and the delete-protection bit is honoured. Host filenames are
+mapped between UTF-8 and the guest's Latin-1 (names with no Latin-1
+spelling are hidden, since the guest could neither display nor reopen
+them). Host symlinks inside the mount are followed, wherever they point:
+the guest has no way to create one, so a symlink is treated as the host
+user deliberately grafting a directory into the mount, the same trust
+model as the UAE family.
 
 `volume` sets the AmigaDOS volume name (up to 30 characters, no `:` or
 `/`). `bootpri` enters the volume in the boot-device vote (-128..127;
@@ -594,12 +662,35 @@ overridden; without a path the EEPROM is session-only.
 ```toml
 [[zorro]]
 metadata = "boards/megaram.toml"
+
+[[zorro]]
+metadata = "boards/myboard.toml"
+# config = { mode = "fast" }  # WASM plugin boards: setting overrides
 ```
 
 Each entry adds a Zorro board described by a TOML metadata file, configured
-in file order after the built-in `[memory]` fast/z3 boards. See
-[](../zorro) for the metadata format and how autoconfig assigns
-addresses.
+in file order after the built-in `[memory]` fast/z3 boards. For a WASM
+plugin board, the optional `config` table overrides individual settings
+that the plugin's manifest declares (layered over the manifest's `[config]`
+defaults; the launcher's Zorro tab edits the same values). See
+[](../zorro) for the metadata format, the plugin ABI, and how autoconfig
+assigns addresses.
+
+## `[a2065]` -- Ethernet
+
+```toml
+[a2065]
+net = "loopback"   # or "none" for an isolated NIC
+```
+
+Fits a Commodore A2065 Ethernet board (Am7990 LANCE) on the Zorro chain.
+`net` selects the host network backend: `"loopback"` echoes transmitted
+frames back (self-contained, useful for driver bring-up), `"none"` leaves
+the NIC isolated. Omit the section entirely for no board. Note that host
+networking is inherently non-deterministic: inbound frames arrive on the
+host's schedule, not the emulated clock, so a NIC board breaks
+byte-identical replay and save-state determinism while traffic flows. See
+[](../zorro) for the board details.
 
 ## `[debug]` -- diagnostics
 

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -175,7 +175,8 @@ COPPERLINE_DBG_BREAK=C033C2 COPPERLINE_DBG_DUMP=C09580:4 \
 For chip-bus timing questions, the [waveform export](../debugger/waveform)
 records a trigger-based VCD trace of the internal chipset signals during
 the same kind of run (`--waveform out.vcd --wave-trigger pc=0xC033C2
---wave-duration 20000cck`) for viewing in GTKWave.
+--wave-duration 20000cck`, with `--wave-signals` selecting the signal
+groups) for viewing in GTKWave.
 
 ## The vAmigaTS compatibility suite
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -46,10 +46,11 @@ reboot lands a fraction of a second after the chord, as on real hardware.
 
 The status bar (44 pixels below the display) holds, left to right:
 
-- **LED block.** PWR and FDD always; a green HDD activity LED on Gayle IDE
-  machines (A600/A1200); a blue CD activity LED on CDTV/CD32 that lights
-  while the drive reads data or plays CD audio. A small digital counter
-  shows the current floppy track.
+- **LED block.** PWR and FDD always; a green HDD activity LED on machines
+  with a hard-disk controller (Gayle or A4000 IDE, or any SCSI adapter); a
+  blue CD activity LED on CDTV/CD32 that lights while the drive reads data
+  or plays CD audio. A small digital counter shows the current floppy
+  track.
 - **Per-drive floppy controls.** Every connected drive gets a disk button
   (marked with the drive number) that opens a file dialog -- multi-select
   several images to queue a swap playlist for that drive -- plus a swap
@@ -59,14 +60,14 @@ The status bar (44 pixels below the display) holds, left to right:
 - **CD controls** on CDTV/CD32 machines: a CD button that loads (or swaps)
   a cue sheet with the proper media-change notification, and a CD eject
   button. These do not appear on machines without a CD drive.
-- **Camera button**: saves a screenshot (same as `Cmd+S` on macOS or
-  `Alt+S` on Linux/Windows).
-- **Hamburger menu button**: opens the pop-up menu (below).
 - **Joystick toggle** (just left of the volume control): a gamepad or
   keyboard icon showing which source drives the port-2 joystick. Click it to
   flip between gamepad-only and keyboard joystick emulation; see
   [](#mouse-and-joystick).
 - **Volume slider**: drag, or scroll the mouse wheel over it for 5% steps.
+- **Hamburger menu button**: opens the pop-up menu (below).
+- **Camera button**: saves a screenshot (same as `Cmd+S` on macOS or
+  `Alt+S` on Linux/Windows).
 - **Pause / power / reboot buttons.** Pause freezes emulation while staying
   powered; power cold-boots (clears RAM) or powers off back to the test
   screen; reboot is a warm reset.
@@ -115,14 +116,22 @@ tool window or overlay.
   window showing which chip-bus owner had each Agnus colour clock across
   the captured frame, including overscan and blanking; see
   [](../debugger/window.md#frame-analyzer-pane).
-- **Debugger** (also `Cmd+B` on macOS or `Alt+B` on Linux/Windows):
+- **Debugger...** (also `Cmd+B` on macOS or `Alt+B` on Linux/Windows):
   pauses the machine and opens the tabbed debugger in a tool window; see
   [](../debugger/window).
 - **Console...** (also `Cmd+K` / `Alt+K`): a GDB-flavoured debugger
   command line in its own tool window; see [](../debugger/console).
+- **Audio Out** (also `Cmd+Shift+A` / `Alt+Shift+A`): cycles the audio
+  output through the system default, each host output device, and
+  **Disabled** (sound off entirely, equivalent to `--noaudio`). The
+  device switches live without a restart.
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Joystick Input** (also `Cmd+J` / `Alt+J`, or the status-bar icon):
   toggles between gamepad-only and keyboard joystick emulation.
+- **MIDI In / MIDI Out** (shown when the serial port is in MIDI mode):
+  cycle Paula's serial bridge through the host's MIDI sources and
+  destinations; see the `[serial]` section of
+  [Configuration](configuration.md).
 - **Pixel Aspect**: flips the presentation between the 4:3 CRT pixel
   aspect (the default; PAL lo-res pixels slightly wider than tall, as a
   real TV shows them) and square pixels (a 320x256 screen is an exact
@@ -154,8 +163,8 @@ tool window or overlay.
   $E00000 or 256 KiB at $F00000; Cancel to skip and remove any fitted
   extended ROM). The machine then cold-resets, as if the chip had been
   swapped and the power cycled.
-- **Keyboard Shortcuts**: the shortcut reference.
-- **About**: app version plus a summary of the emulated machine. Builds
+- **Keyboard Shortcuts...**: the shortcut reference.
+- **About...**: app version plus a summary of the emulated machine. Builds
   made from an untagged git commit append the short commit ID to the version
   shown in the window title and About panel.
 
@@ -188,18 +197,26 @@ an A1200 is selected on the Memory tab; Zorro III RAM is greyed with the reason
 The layout is:
 
 - **Machine selector** (top). Pick a machine -- A1000, A500 (OCS), A500, A500+,
-  A600, A1200, CDTV, or CD32. With no profile chosen the A500 is highlighted,
+  A600, A1200, A3000, A4000, CDTV, or CD32. With no profile chosen the A500 is
+  highlighted,
   since that is the machine the defaults describe. Selecting a machine applies
   that profile's defaults (chipset, CPU, RAM, gate array, RTC) to every tab;
-  settings that no longer apply (an IDE image on a non-Gayle machine, a CD image
+  settings that no longer apply (an IDE image on a machine with no IDE port, a
+  CD image
   on a machine with no CD drive) are dropped so they cannot block a launch.
 - **Category tabs** (left sidebar). *System* (chipset and Agnus/Denise
   overrides, video standard, RTC, identify board), *CPU* (model, FPU, clock,
   caches), *Memory* (chip/fast/slow/Zorro III RAM), *ROM* (Kickstart and
   extended ROM), *Floppy* (drive count and per-drive image and write-protect),
-  *Hard Disk* (IDE master/slave and the A2091 SCSI ROM and units), *CD* (image,
-  insert delay, CD32 NVRAM), *Zorro* (extra autoconfig boards by metadata file),
-  and *A/V & Emu* (overscan, pixel aspect, phosphor, floppy sounds and
+  *Hard Disk* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
+  A3000's onboard SCSI -- and its boot ROM and units), *Host Mounts* (host
+  directories served live as AmigaDOS volumes: up to four mounts, each with a
+  boot priority and a read-write/read-only **Access** field), *CD* (image,
+  insert delay, CD32 NVRAM), *Zorro* (extra autoconfig boards by metadata
+  file, with a config panel for a WASM plugin board's declared options),
+  *Serial* (serial mode and MIDI input/output endpoints),
+  and *A/V & Emu* (audio output device, channel mode, stereo separation,
+  overscan, pixel aspect, phosphor, floppy sounds and
   volume, power-on, pacing, realtime priority, warp speed, joystick input
   mode).
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
@@ -210,7 +227,7 @@ The layout is:
   directory mount inherits the host directory's name; the box has no effect on a
   raw HDF). A setting that does not apply to the chosen machine is greyed and
   shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM,
-  "needs 68020+" for the FPU, "needs A600/A1200" for IDE.
+  "needs 68020+" for the FPU, "needs A600/A1200/A4000" for IDE.
 - **Action bar** (bottom). **Load...** and **Save...** read and write a `.toml`
   config
   through a file dialog (Save writes a minimal file, only the settings that

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,9 @@
 abstract: |
   Copperline is a cycle-driven Commodore Amiga emulator (OCS, ECS, and
   AGA) written in Rust. This document covers using the emulator,
-  configuring machines from the A500 to the CD32, describing Zorro
-  expansion boards, the interactive and headless debuggers, and the
+  configuring machines from the A500 to the A4000 and CD32, describing
+  Zorro expansion boards, the browser (WebAssembly) build, the
+  interactive and headless debuggers, and the
   internal architecture: the per-colour-clock chip-bus timing model, the
   chipset modules, and the beam-event-replay video pipeline.
 ---
@@ -36,12 +37,15 @@ running in Copperline.
 - [](guide/getting-started) -- build the emulator and boot your first
   machine.
 - [](guide/configuration) -- the `copperline.toml` reference: machine
-  profiles (A500 through CD32), CPU, memory, chipset, floppy, IDE, and CD
-  options.
+  profiles (A500 through the A4000 and CD32), CPU, memory, chipset,
+  floppy, IDE/SCSI, host-directory mounts, serial/MIDI, and CD options.
 - [](guide/ui) -- the window, status bar, keyboard shortcuts, menus, and
   gamepad calibration.
 - [](guide/headless) -- scripted, deterministic runs: screenshots, frame
   dumps, scripted input, and WAV capture.
+- [](guide/browser) -- the same core compiled to WebAssembly, hosted at
+  [copperline.dev/try](https://copperline.dev/try/): how it works and how
+  to embed it.
 - [](zorro) -- describing additional Zorro II/III expansion boards in
   TOML metadata files.
 - [](debugger/window), [](debugger/headless), and [](debugger/gdb) -- the

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -16,6 +16,7 @@ src/
   envcfg.rs         # cached COPPERLINE_* environment-variable snapshot
   emulator.rs       # frame loop driving CPU, chipset, and host I/O
   debugger.rs       # env-driven headless debugger
+  waveform.rs       # trigger-based VCD chipset-signal capture (GTKWave)
   disasm.rs         # 68000 + Copper-list disassemblers
   gdbstub.rs        # GDB remote-protocol stub (host debugger transport)
   amigaos.rs        # read-only exec.library structure walking for the debugger
@@ -25,8 +26,10 @@ src/
   bus/              # size-split impl Bus continuations + the bus test suite
     custom_regs.rs  #   custom-chip register read/write dispatch
     dma_slots.rs    #   chip-bus slot arbitration + DMA scheduling
+    ddf_line.rs     #   per-line DDF sequencer walk for slot planning
     collisions.rs   #   live (beam-timed) collision accumulation
     frame_capture.rs#   per-frame sprite/bitplane DMA + render capture
+    wave.rs         #   waveform-capture signal sampling hooks
   memory.rs         # chip/slow RAM, ROM, extended ROM containers
   romsearch.rs      # locate the bundled AROS default boot ROM
   zorro.rs          # Zorro II/III autoconfig chain and boards
@@ -36,10 +39,15 @@ src/
   floppy.rs         # disk images + timed disk DMA controller
   dms.rs            # DMS archive decompression
   drive_sounds.rs   # synthesized floppy-drive sound effects
+  gary.rs           # Gary motherboard address decode (big-box machines)
+  ramsey.rs         # Ramsey memory controller registers (A3000/A4000)
   gayle.rs          # A600/A1200 Gayle gate array + IDE
+  ata.rs            # shared ATA task-file/drive model behind Gayle and A4000 IDE
+  ide_a4000.rs      # A4000 motherboard IDE at $DD2020
   a2091.rs          # A2091 SCSI controller board (DMAC + boot ROM)
   a4091.rs          # A4091 Zorro III SCSI-2 controller (NCR 53C710)
   scsi.rs           # WD33C93A SBIC + SCSI-2 disk targets
+  sdmac.rs          # A3000 Super DMAC fronting the WD33C93
   harddrive.rs      # shared hard-drive image backend (IDE + SCSI)
   dirfs.rs          # host directory -> in-memory FFS partition image
   filesys.rs        # host directories mounted live as AmigaDOS volumes
@@ -49,7 +57,8 @@ src/
   cdtv.rs           # CDTV DMAC + Matshita drive model
   akiko.rs          # CD32 Akiko (C2P, NVRAM, Chinon drive)
   rtc.rs            # MSM6242-compatible battery RTC
-  serial.rs         # Paula serial sink (stdout)
+  serial.rs         # Paula serial sinks (stdout, TCP, pty)
+  midi/             # host MIDI serial bridge (CoreMIDI / ALSA / WinMM)
   audio.rs          # AudioSink trait + cpal/WAV/null outputs
   priority.rs       # opt-in realtime-like thread scheduling (pacer + audio)
   gamepad.rs        # gilrs input + guided calibration
@@ -64,6 +73,7 @@ src/
   chipset/
     agnus.rs        # beam counters, DMACON, display fetch, arbitration data
     copper.rs       # Copper decode + cycle-stepped execution
+    ddf_sequencer.rs#   Agnus DDF comparator/flop model (bitplane fetch gating)
     blitter.rs      # scheduled per-DMA-slot blitter engine
     paula.rs        # interrupts, audio DMA, serial, disk regs
     denise.rs       # palette + bitplane/sprite control registers
@@ -78,8 +88,9 @@ src/
     present_common.rs # frontend-independent post-processing + TV apertures
     window.rs       # winit ApplicationHandler + render worker + main/tool pixels surfaces + status bar
     window/         # size-split window submodules + its test suite
-                    #   (statusbar.rs, present.rs, host_input.rs, tests.rs)
+                    #   (statusbar.rs, present.rs, host_input.rs, console.rs, tests.rs)
     ui.rs           # pop-up menu, overlay panels, and debugger/analyzer panel drawing
+    launcher.rs     # machine-configuration (launcher) screen
     font.rs         # 8x8 overlay font
 crates/m68k/        # vendored m68k CPU core
 crates/copperline-web/   # standalone wasm-bindgen browser frontend (WebEmu + page glue)

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -41,7 +41,9 @@ spreading those slots across the 32-CCK unit.
 
 Agnus revisions are modelled independently of Denise (machines shipped
 mixed): OCS (8370/8371), ECS 8372A (1M chip RAM reach), ECS 8375 (2M), and
-AGA Alice (2M, HRM IDs $23/$33). The ECS Agnus adds DIWHIGH and the
+AGA Alice (2M, HRM IDs $23/$33). VPOSR bits 8-14 report the chipset ID:
+$00 on OCS, $20/$30 (PAL/NTSC) on every ECS Agnus regardless of revision,
+and the Alice IDs above. The ECS Agnus adds DIWHIGH and the
 implemented subset of BEAMCON0 (PAL/VARBEAMEN/LOLDIS/HARDDIS and friends);
 Alice adds the FMODE wide-fetch latch, which scales the bitplane and
 sprite fetch quanta (FMODE=0 stays byte-identical to the OCS/ECS slot
@@ -210,7 +212,10 @@ A small 8520 model used for both CIAs: I/O ports, the
 interval timers with cascading and underflow pulses, the 24-bit TOD
 counters (VSYNC-clocked on CIA-A, HSYNC on CIA-B) with latch and alarm
 semantics (including the hardware quirk that a reset alarm is $000000),
-and the ICR with its read-clears behaviour.
+and the ICR with its read-clears behaviour. The /IRQ pin follows an
+INT-flag edge one E-clock later, armed per interrupt source (timers land
+on the same E-cycle their underflow was observed; the other sources take
+the extra cycle), matching the CIASetInt latency observable from the CPU.
 
 CIA-A carries /OVL (the reset-time ROM overlay at `$0`), the keyboard
 serial port (SDR/ICR with the KDAT handshake and an emulated
@@ -228,7 +233,10 @@ visible again before Kickstart reads the reset vectors.
 The floppy subsystem is track-timed: a drive has a rotational position,
 and data under the head right now is what disk DMA sees. Track stepping
 pays settle time, direction reversals cost more, and the index pulse fires
-once per revolution into CIA-B FLAG. Reads assemble MFM bitstreams from
+once per revolution into CIA-B FLAG. The stepper also enforces a minimum
+step-pulse spacing (~40 us, 140 colour clocks): a pulse arriving sooner
+after the last accepted one -- in either direction -- is ignored, so the
+mechanism never over-steps on pulses faster than the head can move. Reads assemble MFM bitstreams from
 the 11-sector AmigaDOS track layout; DSKSYNC matching, word-at-a-time
 DSKDAT, and DMA into chip RAM behave as Paula documents. Non-WORDSYNC read
 DMA drains Paula's recovered 16-bit disk word phase even when DSKLEN is

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -24,11 +24,29 @@ WinUAE-verified model so device scans terminate correctly. PCMCIA reports
 an empty slot (the status/config registers exist so card.resource
 behaves); credit-card device emulation is a non-goal.
 
-## A2091 SCSI (`a2091.rs`, `scsi.rs`)
+## A4000 motherboard IDE (`ide_a4000.rs`)
 
-The `[scsi]` option attaches a Commodore A2091: a Zorro II device board
-pairing the Commodore DMAC (rev 02 modeled) with a WD33C93A SBIC, plus
-the board's autoboot ROM whose `scsi.device` drives them. The autoconfig
+The A4000 profile decodes the same ATA task file (`ata.rs`) at `$DD2020`
+with no gate array in front of it -- the layout Kickstart's own
+`scsi.device` probes, with the Gayle-style 4-byte register stride, the
+control block one A12 page up at `$DD3038`, and an interrupt status byte
+at `$DD3020` whose bit 7 is the drive's INTRQ. Unlike Gayle there is no
+interrupt-change latch: INTRQ feeds INT2 directly and the driver drops it
+by reading the status register. Drives come from the same `[ide]`
+section as Gayle machines.
+
+## SCSI controllers (`a2091.rs`, `a4091.rs`, `sdmac.rs`, `scsi.rs`)
+
+The `[scsi]` option attaches one of three host adapters, selected by its
+`controller` key: the Zorro II A2091 (the default), the Zorro III A4091,
+or the A3000's motherboard Super DMAC. All three drive the same SCSI-2
+target layer in `scsi.rs`.
+
+### A2091 (`a2091.rs`)
+
+The A2091 is a Zorro II device board pairing the Commodore DMAC (rev 02
+modeled) with a WD33C93A SBIC, plus the board's autoboot ROM whose
+`scsi.device` drives them. The autoconfig
 identity comes from the DMAC -- Commodore West Chester (514), product 3,
 `ERTF_DIAGVALID` with `er_InitDiagVec` pointing at `$2000` -- while the
 ROM supplies the DiagArea and the driver; the ROM image therefore is a
@@ -67,7 +85,37 @@ short emulated delay, and INT2 is the level `CNTR_INTEN && ISTR &
 (INTS|E_INT)` fed to Paula's PORTS latch each tick. DMAC bus-master
 cycles are not yet arbitrated against the CPU (TODO in `a2091.rs`).
 
-Both IDE and SCSI drives share the `harddrive.rs` sector backend: raw
+### A4091 (`a4091.rs`)
+
+The A4091 is a Zorro III SCSI-2 controller carrying an NCR 53C710 and a
+nibble-wide autoboot ROM. Within its 16M window, `$000000-$7FFFFF` is the
+boot ROM presented nibble-wide (expansion.library reassembles the
+DiagArea with DAC_NIBBLEWIDE, and the ROM's own relocator copies the
+driver the same way), `$800000` is the 53C710 register file (only the low
+6 address bits decode, so it mirrors across the window -- the driver
+relies on the `+$40` shadow as a cache write-allocate workaround), and
+`$8C0003` reads the DIP-switch byte (host ID, termination, negotiation
+enables). A DSP write starts the 53C710's SCRIPTS processor, whose phase
+engine executes the driver's SCRIPTS programs against the disk targets.
+The autoconfig identity is Commodore product 84 with `er_InitDiagVec`
+`$0200`.
+
+### A3000 Super DMAC (`sdmac.rs`)
+
+The SDMAC is the SCSI DMA controller on the A3000 motherboard, not a
+Zorro board: a register file at `$DD0000` (repeating at `$DD0100` -- the
+"ALT" shadow that write-through tools use to defeat CPU write buffering)
+that owns the DMA FIFO and interrupt plumbing and maps a WD33C93's
+register file into a select latch and data port. It is the same layering
+as the A2091 -- two front-ends onto the one `Wd33c93` core -- differing in
+the register map, the ISTR bits, and a 32-bit DMA address counter
+(physically in Ramsey) instead of the Zorro II DMAC's 24-bit one.
+Kickstart's built-in `scsi.device` drives the pair directly, so there is
+no boot ROM to configure.
+
+### Shared drive backend
+
+All IDE and SCSI drives share the `harddrive.rs` sector backend: raw
 HDF images, bare partition hardfiles wrapped in a synthesized RDB
 (bootable `DHn` named after the unit), and host directories built into
 in-memory FFS volumes by `dirfs.rs` (whose volume label defaults to the
@@ -76,6 +124,51 @@ SCSI-2 target layer in
 `scsi.rs` answers INQUIRY, MODE SENSE pages 3/4, READ CAPACITY,
 READ/WRITE(6)/(10), REQUEST SENSE, and the no-op housekeeping commands,
 with sense state kept per target.
+
+The drive controllers latch read/write activity, which the bus drains to
+light the status-bar HDD LED; the LED holds for a short minimum period so
+brief accesses stay visible. Gayle, the A4000 IDE, the A2091, and the
+SDMAC report activity today; the A4091 shows the LED but does not latch
+activity into it yet.
+
+## Host filesystem service (`filesys.rs`)
+
+`[[filesys]]` mounts export host directories as live AmigaDOS volumes
+(`HOSTFS0:` ... up to 8 mounts), with no disk image in between -- distinct
+from the `dirfs.rs` path above, which snapshots a directory into an
+in-memory FFS volume behind a virtual drive. The guest side is a tiny
+handler (see `guest/services/`) mapped into the Copperline services board
+with a mount table and a hand-built DiagArea; at expansion init it builds
+one DeviceNode per mount and `AddBootNode`s it, so DOS mounts the devices
+at boot. The handler forwards every DosPacket to the host through a
+reserved A-line trap, and all `ACTION_*` semantics -- reads, writes,
+create/rename/delete, directory walks, protection, comments, datestamps
+-- are implemented host-side against the real filesystem, with results
+written straight into guest memory.
+
+Amiga attributes a host filesystem cannot hold live in UAE-style `.uaem`
+sidecar files (read when present, written back on change, hidden from
+guest listings); the delete-protection bit is honoured on
+`ACTION_DELETE_OBJECT`. Filenames map between host UTF-8 and guest
+Latin-1, hiding names with no Latin-1 spelling; host symlinks are
+followed (the guest cannot create one, so a symlink is the host user
+deliberately grafting a tree into the mount), while the escapes a guest
+could construct itself (`..`, separators) are blocked. A `readonly`
+mount refuses writes with the standard write-protection error.
+
+## A2065 Ethernet (`a2065.rs`, `net.rs`)
+
+The `[a2065]` option fits a Commodore A2065: a Zorro II board carrying an
+Am7990 LANCE and 32 KiB of on-board RAM, driven by the AmigaOS SANA-II
+`a2065.device`. Unlike the DMAC boards the LANCE never masters the Amiga
+bus: its init block, descriptor rings, and packet buffers all live in the
+board's own RAM, which the CPU reaches through the board window, so the
+board is self-contained and owns a host `NetBackend` (`net.rs`) for real
+frames. Networking is inherently non-deterministic, so a fitted NIC
+breaks byte-identical replay while traffic flows; save states record only
+the chosen backend and bring up a fresh one on load. The board and
+backend story, including the WASM plugin `net` capability, is covered in
+[](../zorro).
 
 ## CDTV (`cdtv.rs`, `cdrom.rs`)
 
@@ -132,12 +225,12 @@ feed the JOY0DAT quadrature counters. Gamepads are read through raw
 the CD32 pad protocol instead of the plain digital joystick lines.
 
 The window layer has one host-source policy for the emulated port-2
-joystick/CD32 pad: auto, keyboard, or gamepad. Auto is the default. It
-polls the calibrated gamepad first and, when no usable pad state is
-available, resolves the keyboard joystick state instead. Keyboard mode
+joystick/CD32 pad: gamepad (the default) or keyboard. Keyboard mode
 skips gamepad polling for port-2 input; gamepad mode disables keyboard
 joystick capture so the mapped keys take the normal Amiga keyboard path.
-All three sources ultimately call the same `InputState::set_joystick_port2`
+(The old auto-detect mode has been removed; `"auto"` in a config parses
+as a backward-compatibility alias for gamepad.) Both sources ultimately
+call the same `InputState::set_joystick_port2`
 and `set_cd32_buttons_port2` helpers, so JOY1DAT, /FIR1, POT1Y/POTGOR, and
 the CD32 serial bits remain hardware-derived.
 
@@ -192,14 +285,20 @@ counter is nonzero.
 
 ## Serial (`serial.rs`)
 
-Paula's SERDAT transmit path lands on stdout through `StdoutSink` -- this
+Paula's SERDAT transmit path lands on a `SerialSink`. The default
+`StdoutSink` prints to the host terminal -- this
 is how DiagROM's diagnostic stream and the `timing-test/` results are
-captured in terminals and CI logs.
+captured in terminals and CI logs. `TcpSerialSink` bridges the port to a
+listening TCP socket (`[serial] mode = "tcp"`, one client at a time) and
+`PtySerialSink` to a host pseudo-terminal pair (`mode = "pty"`, Unix
+only); both are bidirectional, so an `AUX:` shell on the Amiga side gives
+a remote AmigaDOS console.
 
-A `SerialSink` that can *produce* input (none of the built-in sinks do)
-must override `has_pending_input` alongside `read_byte`/`read_word`:
+A `SerialSink` that can *produce* input must override
+`has_pending_input` alongside `read_byte`/`read_word`:
 Paula's per-tick UART step takes an idle fast path that skips the receiver
-entirely while it reports false.
+entirely while it reports false -- the TCP and pty sinks poll a counter
+there, never a syscall.
 
 ## MIDI serial bridge (`midi/`)
 

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -152,8 +152,9 @@ guest listings); the delete-protection bit is honoured on
 `ACTION_DELETE_OBJECT`. Filenames map between host UTF-8 and guest
 Latin-1, hiding names with no Latin-1 spelling; host symlinks are
 followed (the guest cannot create one, so a symlink is the host user
-deliberately grafting a tree into the mount), while the escapes a guest
-could construct itself (`..`, separators) are blocked. A `readonly`
+deliberately grafting a tree into the mount), while path escapes that a
+guest could construct on its own (`..`, embedded separators) are
+blocked. A `readonly`
 mount refuses writes with the standard write-protection error.
 
 ## A2065 Ethernet (`a2065.rs`, `net.rs`)

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -11,7 +11,10 @@ the inline suites (`src/chipset/copper.rs`, `blitter.rs`, `src/bus.rs`).
 ## Chip-bus arbitration
 
 Every colour clock of every scanline has an owner, decided in priority
-order (`fixed_dma_owner_at`, `src/bus.rs`):
+order. The fixed-DMA levels (steps 1-5) are decided by
+`fixed_dma_owner_at` (`src/bus/dma_slots.rs`); Copper, blitter, and CPU
+contend for the slots it leaves free. (The function tests audio before
+disk, which is equivalent because their fixed slots never overlap.)
 
 1. **Memory refresh** -- fixed odd slots 1/3/5 plus the line-end refresh
    slot (E2, or E3 on NTSC long lines). Refresh only ever uses odd slots,
@@ -326,7 +329,7 @@ with a delay: it is **scheduled per DMA slot**. Each word issues its
 hardware channel bus sequence, so DMACONR's BBUSY reflects genuine
 in-flight state and BBUSY-polling loops see hardware timing. Because the
 renderer and the CPU both need to know when a blit finishes,
-`cck_until_blitter_completes` (`src/bus.rs`) predicts completion by walking
+`cck_until_blitter_completes` (`src/bus/dma_slots.rs`) predicts completion by walking
 the same slot-eligibility primitive the live engine uses.
 
 ### Per-slot FSM

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -5,9 +5,11 @@ Copperline's expansion bus models Zorro II/III autoconfig
 described by a `BoardSpec`, and additional boards are added from TOML
 metadata files without writing any Rust. The built-in `[memory] fast` and
 `z3` options are themselves just boards built from the same specs, and the
-`[scsi]` option adds the A2091 SCSI controller (`src/a2091.rs`) as a
-device-backed board (see the device-board notes below and the `[scsi]`
-section of [](guide/configuration)).
+`[scsi]` option can add the A2091 (Zorro II, `src/a2091.rs`) or A4091
+(Zorro III, `src/a4091.rs`) SCSI controller as a device-backed board (see
+the device-board notes below and the `[scsi]` section of
+[](guide/configuration); the third `[scsi]` choice, the A3000's
+motherboard SDMAC, is silicon at `$DD0000` rather than a Zorro board).
 
 There are two board kinds:
 
@@ -19,9 +21,10 @@ There are two board kinds:
   forking and recompiling Copperline. See
   [WASM plugin boards](#wasm-plugin-boards) below.
 
-Functional boards (the A2091, the CDTV DMAC, and WASM plugins) all implement
-the `ZorroDevice` trait (`src/zorro_device.rs`): the bus drives every board
-through that one boundary for register access, ticking, interrupts, and DMA.
+Functional boards (the A2091, the A4091, the A2065, the CDTV DMAC, and WASM
+plugins) all implement the `ZorroDevice` trait (`src/zorro_device.rs`): the
+bus drives every board through that one boundary for register access,
+ticking, interrupts, and DMA.
 
 ## Describing a board in TOML
 
@@ -55,9 +58,9 @@ Field notes:
 - `zorro = 2` boards must be a legal Zorro II size: 64K, 128K, 256K, 512K,
   1M, 2M, 4M, or 8M. `zorro = 3` boards may be any power of two from 64K to
   1G. Sizes accept `K`/`KB`/`M`/`MB`/`G`/`GB` suffixes or plain bytes.
-- Zorro III boards need a 32-bit CPU (68020/68030/68040); configuring one
-  on a 68000/68EC020 machine is rejected at startup, since a 24-bit address
-  bus cannot reach the Zorro III space.
+- Zorro III boards need a 32-bit CPU (68020 and later); configuring one on
+  a 68000/68010/68EC020 machine is rejected at startup, since a 24-bit
+  address bus cannot reach the Zorro III space.
 - `memlist` sets the autoconfig `ERTF_MEMLIST` flag, which asks Kickstart to
   link the board's space into the Exec free-memory list. Leave it `true`
   for RAM boards; a future I/O-style board would set it `false`.

--- a/src/a4091.rs
+++ b/src/a4091.rs
@@ -16,9 +16,8 @@
 //!   low 6 address bits, so the 64-byte register file mirrors across the
 //!   whole window; the driver relies on this, writing TEMP/SCRATCH through
 //!   the `+$40` shadow (a 68030/68040 cache write-allocate workaround) and
-//!   reading them back at the base offsets. Registers are plain storage for
-//!   now -- enough for the driver's walking-bits hardware test -- with the
-//!   SCRIPTS processor still to come (a DSP write warns once).
+//!   reading them back at the base offsets. A DSP write starts the SCRIPTS
+//!   processor, whose phase engine drives the SCSI-2 targets.
 //! - `$8C0003` the DIP-switch byte (SCSI host ID, termination, sync/fast
 //!   negotiation enables). `$FF` means all switches off: host ID 7.
 //!
@@ -202,7 +201,7 @@ pub struct A4091 {
     /// DIP switches as read at `$8C0003`; `$FF` = all off (host ID 7).
     dip: u8,
     /// The 53C710 register file, indexed by CPU-visible (big-endian) byte
-    /// address. Plain storage until the SCRIPTS core lands.
+    /// address.
     regs: Vec<u8>,
     /// The DMA FIFO: four byte lanes, 16 entries deep, 8 data bits plus a
     /// parity bit per entry. CTEST6 pushes/pops the lane selected by

--- a/src/config.rs
+++ b/src/config.rs
@@ -1141,7 +1141,8 @@ pub struct ConfigOverrides {
     /// parser as `[input] joystick`.
     pub joystick: Option<String>,
     /// Serial port wiring (`--serial`): "off", "stdout", "midi", "tcp",
-    /// or "pty". Same parser as `[serial] mode`.
+    /// or "pty" ("none" and "terminal" parse as compatibility aliases of
+    /// the first two). Same parser as `[serial] mode`.
     pub serial: Option<String>,
     /// Host MIDI output endpoint (`--midi-out`), implying `--serial midi`.
     pub midi_out: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1140,8 +1140,8 @@ pub struct ConfigOverrides {
     /// ("auto" still accepted as a compatibility alias). Validated by the same
     /// parser as `[input] joystick`.
     pub joystick: Option<String>,
-    /// Serial port wiring (`--serial`): "off", "stdout", or "midi". Same
-    /// parser as `[serial] mode`.
+    /// Serial port wiring (`--serial`): "off", "stdout", "midi", "tcp",
+    /// or "pty". Same parser as `[serial] mode`.
     pub serial: Option<String>,
     /// Host MIDI output endpoint (`--midi-out`), implying `--serial midi`.
     pub midi_out: Option<String>,
@@ -1483,7 +1483,8 @@ pub(crate) struct RawIde {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawScsi {
-    /// Host adapter to fit: "a2091" (Zorro II, default) or "a4091" (Zorro III).
+    /// Host adapter to fit: "a2091" (Zorro II, default), "a4091" (Zorro
+    /// III), or "a3000" (the motherboard SDMAC, default on an A3000).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) controller: Option<String>,
     /// Boot ROM image. For split even/odd A2091 EPROM dumps, `rom` is the
@@ -1546,10 +1547,12 @@ pub(crate) struct RawCpu {
     /// Override the CPU clock in MHz. Defaults to the model's stock speed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) clock_mhz: Option<f64>,
-    /// Model the on-chip instruction cache (68020/030; default false).
+    /// Model the on-chip instruction cache. Defaults on for the models
+    /// that have one (all 020+).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) icache: Option<bool>,
-    /// Model the on-chip data cache (68030 only; default false).
+    /// Model the on-chip data cache. Defaults on for the models that have
+    /// one (030/040/060).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) dcache: Option<bool>,
     /// 68060 only: what happens on the instructions the 68060 dropped from
@@ -2421,7 +2424,7 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
         // The A3000: ECS on a big-box board, a 25 MHz 68030 with a real MMU,
         // and Ramsey-04 in front of the motherboard DRAM. Gary, not Gayle, so
         // no PCMCIA and no Gayle IDE. Its SCSI is a Super DMAC at $DD0000
-        // driving a WD33C93, which is not emulated yet.
+        // driving a WD33C93; `[scsi]` fits drives to it.
         MachineModel::A3000 => {
             d.chipset = Chipset::Ecs;
             d.chip_ram_bytes = 2 * 1024 * 1024;

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,13 +71,23 @@ tests; they follow the same "never committed" rule.
 
 The tracked `.bin` files are generated test programs, not ROM or disk images:
 
-- `timing-test/boot.bin` is built from `timing-test/boot.asm`.
+- `timing-test/*.bin` files (the boot block plus the `ddfprobe-*`,
+  `bltprobe-*`, `audprobe-*`, `clxprobe`, `regprobe-*`, and `sprprobe-*`
+  probe programs) are each built from the adjacent `.asm` source, and
+  `timing-test/golden/*.png` are their blessed reference renders (see
+  `timing-test/README.md` "CI golden renders").
+- `assets/services/services_rom.bin` is the guest-side host-filesystem
+  handler built from `guest/services/`.
 - `crates/m68k/tests/fixtures/extra/**/bin/*.bin` files are built from the
   adjacent assembly sources under sibling `src/` directories and are used by
   the vendored CPU core's tests.
 
 Run the tracked-file audit in `RELEASE.md` before publishing a rewritten
 public repository.
+
+Unlike the suites above, `probe_golden.rs` (the golden-render suite for
+those probes) needs no external assets: it boots the bundled AROS ROM and
+runs in CI on every push.
 
 ## vAmigaTS
 

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -278,7 +278,7 @@ under `golden/`. The emulator core is deterministic, so any pixel change is
 a real behaviour change.
 
 Each probe is its own `#[test]`, so the harness runs the emulator boots in
-parallel on the available cores (the full suite of 18 takes ~20 s on an
+parallel on the available cores (the full suite of 20 takes ~20 s on an
 8-core host vs ~90 s sequentially).
 
 Covered: `timing-test` (all 32 timing rows as rendered hex), `ddfprobe`


### PR DESCRIPTION
A full staleness audit of the documentation against the current source: README, TODO, RELEASE, the example config, every `docs/` chapter, the tests/timing-test READMEs, and the stale doc comments in `config.rs`/`a4091.rs`. A lot of merged work (filesys write support, the A3000/A4000 profiles, SDMAC, A4091 SCRIPTS, A4000 IDE, A2065 + WASM boards, serial tcp/pty, 68010/68060, the launcher tabs) had landed without its documentation half.

## Stale documentation fixed

- **TODO.md**: the CPU list stopped at the 68040 with the 68060 "rejected" (68010 and 68060 both shipped); the FPU was described as f64-precision with no packed decimal (it is an 80-bit extended-precision softfloat with packed decimal and ~64-bit-faithful transcendentals); the POTGO, CIA-reset, and memory-map Open Work items described work that has since landed. Added the `probe_golden` suite to Standard Checks.
- **configuration.md**: the A4000 IDE was "not implemented"; the A3000 motherboard SCSI had "no drives attached yet"; `[[filesys]]` mounts were "read-only for now" with an "up to 16 mounts" cap (they are writable by default and the cap is 8); the `--model` and RTC lists omitted A3000/A4000.
- **copperline.example.toml**: the removed `auto` joystick mode was still documented as the default; the CPU list omitted the 68010; Zorro board types said "only ram so far"; the agnus/denise override lists were incomplete.
- **ui.md**: the status-bar buttons were listed in the wrong left-to-right order; the IDE greyed-reason text predated the A4000.
- **peripherals.md**: serial described only the stdout sink (tcp/pty exist); the removed auto joystick mode was still documented.
- **timing.md** pointed at `src/bus.rs` for `fixed_dma_owner_at`/`cck_until_blitter_completes`, which live in `bus/dma_slots.rs`; **timing-test/README.md** counted 18 probes (there are 20); **RELEASE.md**'s tracked-binary whitelist predated the golden renders and the AROS/services ROMs.

## Missing documentation added

- The three-controller `[scsi]` story (A2091 / A4091 / A3000 SDMAC) in the guide and zorro.md, with new peripherals.md sections for the A4091 SCRIPTS engine, the Super DMAC, and the A4000 motherboard IDE.
- New guide sections for `[serial]` (all five modes), `[a2065]` Ethernet, and per-board `[[zorro]] config` overrides; the filesys write semantics (`.uaem` sidecars, Latin-1 filename mapping, symlink policy, delete protection).
- Ten undocumented `COPPERLINE_DBG_*` knobs in the headless debugger reference (MEMW, FC, SPREN, IRQ, CIA, DSKLEN, BLIT, EXPORT_PLANES[_DIR], FRAMESTATE), four missing GDB monitor commands (`beam-trap`, `clear-beam-traps`, `copper-break`, `clear-copper-breaks`), and the console command aliases.
- UI guide: the **Audio Out** and **MIDI In/Out** menu items, the **Host Mounts** (with the Access spinner) and **Serial** launcher tabs, A3000/A4000 in the machine selector, and the HDD LED behaviour.
- README: A3000/A4000 profiles, the SCSI trio, A2065, WASM plugin boards, host mounts, and 68060/MMUs in the hardware table; the browser build on the docs landing page; architecture.md's source map caught up with `sdmac`/`ide_a4000`/`gary`/`ramsey`/`waveform`/`launcher`/`ddf_sequencer`/`midi`.

## One code gap found (documented as-is, not fixed here)

The A4091 shows the HDD LED but implements no `take_activity` latch, so the LED never lights from A4091 traffic (despite 9b11fa9's title). peripherals.md documents the actual behaviour; wiring the latch like the A2091's `activity` bool is a small follow-up candidate.

## Verification

- `cargo build --release`, `cargo clippy`, `cargo fmt --check` clean; all 1454 unit tests pass (the `.rs` changes are comment-only).
- `myst build --html` builds all 22 doc pages with no new warnings.
- Every factual claim in the diff was verified against the source in a second review pass; the A4091 LED finding above came out of that pass.