### PR TITLE
romtags: skip the ROM's scsi.device when its bus has no drives

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -106,10 +106,16 @@ model = "68000"
 # The big-box profiles (A3000, A4000) are new and incomplete, but both boot,
 # each off its own built-in disk controller: put drives on the A3000's SCSI
 # with [scsi], and on the A4000's IDE with [ide].
+# rom_scsi_device_disable skips the ROM's scsi.device. It defaults to true
+# when the machine's built-in disk controller has no drives configured (an
+# A600/A1200/A4000 with no [ide] drives, an A3000 with no [scsi] units): the
+# driver would only cost boot time probing an empty bus. With drives it runs,
+# since scsi.device is their boot path. Set explicitly to win either way.
 # [machine]
 # profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | A3000 | A4000 | CDTV | CD32
 # rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV/A3000/A4000 have one)
 # mem_controller = "ramsey-07"   # none | ramsey-04 (A3000) | ramsey-07 (A4000)
+# rom_scsi_device_disable = true # skip the ROM's scsi.device (default: see above)
 
 
 # Debugging aids. log_unmapped logs every CPU read and write that no device

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -97,6 +97,7 @@ missing.
 profile = "A1200" # A1000, A500, A500OCS, A500Plus (A500+), A600, A1200, A3000, A4000, CDTV, CD32
 rtc = true        # add a battery RTC (default: only A500+/CDTV/A3000/A4000 ship with one)
 mem_controller = "ramsey-07" # none, ramsey-04 (A3000), ramsey-07 (A4000)
+rom_scsi_device_disable = true # skip the ROM's scsi.device (default: when its bus has no drives)
 ```
 
 A machine profile bundles the chipset, CPU, memory, gate array, and
@@ -141,11 +142,19 @@ at `$DE0003` and `$DE0043` answer as, and they carry Gary rather than Gayle
 - The **A4000** has its motherboard IDE interface at `$DD2020`; attach drives
   with `[ide]`, exactly as on a Gayle machine.
 
+`rom_scsi_device_disable` skips Kickstart's built-in disk driver. It defaults
+on when the machine's own controller -- the IDE port of an A600, A1200, or
+A4000, or the A3000's SCSI -- has no drives configured: with nothing to boot,
+the driver only costs startup time probing an empty bus. Configuring a drive
+turns the driver back on automatically (it is the boot path for those
+drives), and setting the flag explicitly wins in either direction. The ROM
+file itself is never modified.
+
 Motherboard fast RAM is not emulated on either; use `[memory] z3` instead,
 which the OS is equally happy with.
 
 `mem_controller` is normally left to the profile. It is broken out because
-Ramsey answers at `$DE0000`, which nothing else decodes, so it can be fitted to
+Ramsey's registers collide with nothing else, so it can be fitted to
 a wedge machine to exercise diagnostic tools that expect one.
 
 The `A1000` profile models the original Amiga, which has no Kickstart ROM.

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,13 @@ pub struct Config {
     /// and the WD33C93 behind it. Kickstart hangs outright if nothing answers
     /// there. Drives go on its bus through `[scsi] controller = "a3000"`.
     pub sdmac: bool,
+    /// Keep the ROM's scsi.device from initialising. Defaults to set when
+    /// the machine's built-in disk controller (Gayle or A4000 IDE, A3000
+    /// SDMAC SCSI) has no drives configured: the driver would only cost boot
+    /// time probing an empty bus. With drives configured the default is
+    /// false and the driver runs -- scsi.device is their boot path. Set by
+    /// `[machine] rom_scsi_device_disable`; see [`crate::romtags`].
+    pub rom_scsi_device_disable: bool,
     /// Akiko gate array fitted (CD32 profile): ID + C2P port at $B80000.
     pub akiko: bool,
     /// CDTV DMAC/CD controller fitted (CDTV profile): a Zorro II
@@ -970,6 +977,7 @@ impl Default for Config {
             machine: None,
             gate_array: GateArray::None,
             mem_controller: MemController::None,
+            rom_scsi_device_disable: false,
             log_unmapped: None,
             ide_a4000: false,
             sdmac: false,
@@ -1072,8 +1080,9 @@ impl Config {
         // Copperline services board (experimental, `[[filesys]]`):
         // carries the guest handler, the mount table, and the DiagArea that
         // mounts the configured host directories at expansion init. See
-        // crate::filesys.
-        if !self.filesys.is_empty() {
+        // crate::filesys. The scsi.device cull rides the same DiagPoint, so
+        // the board is also fitted (with no mounts) when only that is wanted.
+        if !self.filesys.is_empty() || self.rom_scsi_device_disable {
             if self.filesys.len() > crate::filesys::MOUNT_MAX_COUNT {
                 anyhow::bail!(
                     "[[filesys]]: at most {} mounts supported",
@@ -1633,6 +1642,12 @@ pub(crate) struct RawMachine {
     /// exercise the diagnostic tools.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mem_controller: Option<String>,
+    /// Skip the ROM's scsi.device. Defaults to true only when the machine's
+    /// built-in disk controller (Gayle or A4000 IDE, A3000 SDMAC SCSI) has no
+    /// drives configured, where the driver would only cost boot time probing
+    /// an empty bus; false everywhere else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rom_scsi_device_disable: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2173,6 +2188,19 @@ impl TryFrom<RawConfig> for Config {
             gate_array: defaults.gate_array,
             ide_a4000: defaults.ide_a4000,
             sdmac: defaults.sdmac,
+            // The ROM's scsi.device is pure probe time when the machine's
+            // built-in disk controller (Gayle or A4000 IDE, A3000 SDMAC SCSI)
+            // has no drives on it: disable it then. With drives it is their
+            // boot path and runs; machines with no built-in controller carry
+            // no scsi.device in ROM, so there is nothing to disable.
+            rom_scsi_device_disable: raw.machine.rom_scsi_device_disable.unwrap_or({
+                let builtin_drives = (has_ide_port
+                    && (ide.master.is_some() || ide.slave.is_some()))
+                    || (defaults.sdmac
+                        && scsi.controller == ScsiController::A3000
+                        && scsi.units.iter().any(Option::is_some));
+                (has_ide_port || defaults.sdmac) && !builtin_drives
+            }),
             akiko: defaults.akiko,
             cdtv_cd: defaults.cdtv_cd,
             cd32_pad: defaults.cd32_pad,
@@ -2978,6 +3006,7 @@ mod tests {
                 profile: Some("A1200".to_string()),
                 rtc: Some(true),
                 mem_controller: Some("ramsey-07".to_string()),
+                rom_scsi_device_disable: Some(true),
             },
             cpu: RawCpu {
                 model: Some("68EC020".to_string()),
@@ -3378,6 +3407,34 @@ mod tests {
         assert_eq!(cfg.gate_array.gayle_id(), None);
         assert_eq!(cfg.mem_controller, MemController::Ramsey7);
         assert!(cfg.rtc_present);
+        // With no [ide] drives the ROM's scsi.device would only stall the
+        // boot probing the empty cable, so it is disabled by default...
+        assert!(cfg.ide_a4000);
+        assert!(cfg.rom_scsi_device_disable);
+
+        // ...but drives on the cable need it: scsi.device is their boot path.
+        let img = std::env::temp_dir().join(format!("clfs-ide-{}.img", std::process::id()));
+        std::fs::write(&img, vec![0u8; 512 * 16]).unwrap();
+        let cfg = parse_config(&format!(
+            r#"
+            [machine]
+            profile = "A4000"
+            [ide]
+            master = "{}"
+            "#,
+            img.display()
+        ))?;
+        assert!(!cfg.rom_scsi_device_disable);
+
+        // Same rule on a Gayle machine: an A1200 with no drives skips the
+        // driver, one with drives keeps it.
+        let cfg = parse_config("[machine]\nprofile = \"A1200\"")?;
+        assert!(cfg.rom_scsi_device_disable);
+        let cfg = parse_config(&format!(
+            "[machine]\nprofile = \"A1200\"\n[ide]\nmaster = \"{}\"",
+            img.display()
+        ))?;
+        assert!(!cfg.rom_scsi_device_disable);
 
         let cfg = parse_config(
             r#"
@@ -3389,8 +3446,30 @@ mod tests {
         assert_eq!(cfg.cpu, CpuModel::M68030);
         assert_eq!(cfg.gate_array, GateArray::FatGary);
         assert_eq!(cfg.mem_controller, MemController::Ramsey4);
-        // Kickstart's scsi.device hangs in init if the SDMAC does not answer.
         assert!(cfg.sdmac);
+        // An empty SDMAC SCSI bus is probe time too, and a drive on it brings
+        // the driver back, exactly like the IDE machines.
+        assert!(cfg.rom_scsi_device_disable);
+        let cfg = parse_config(&format!(
+            "[machine]\nprofile = \"A3000\"\n[scsi]\nunit0 = \"{}\"",
+            img.display()
+        ))?;
+        assert!(!cfg.rom_scsi_device_disable);
+        std::fs::remove_file(&img).unwrap();
+
+        // The default is an opt-out, not a lock-out: setting the flag wins
+        // over the empty-bus heuristic in both directions.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A3000"
+            rom_scsi_device_disable = false
+            "#,
+        )?;
+        assert!(!cfg.rom_scsi_device_disable);
+        // A machine with no built-in controller has no scsi.device in ROM;
+        // there is nothing to disable.
+        assert!(!parse_config("")?.rom_scsi_device_disable);
 
         let err = parse_config(
             r#"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1285,6 +1285,14 @@ impl M68kMachine {
         self.hle.set_mounts(mounts);
     }
 
+    /// `[machine] rom_scsi_device_disable`: cull the ROM's scsi.device at
+    /// expansion init. Rides on the filesys board's DiagPoint, which is the
+    /// one moment Kickstart gives us between building the resident list and
+    /// running it.
+    pub fn set_cull_rom_scsi_device(&mut self, cull: bool) {
+        self.hle.set_cull_rom_scsi_device(cull);
+    }
+
     pub fn bus(&self) -> &Bus {
         &self.bus.bus
     }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2072,6 +2072,10 @@ pub fn build_machine(
     emu.set_cache_emulation(cfg.cpu_icache, cfg.cpu_dcache);
     emu.set_machine_descriptor(cfg.descriptor());
     emu.machine.set_filesys_mounts(cfg.filesys.clone());
+    if cfg.rom_scsi_device_disable {
+        info!("romtags: the ROM's scsi.device will not be initialised");
+        emu.machine.set_cull_rom_scsi_device(true);
+    }
     Ok(emu)
 }
 

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -269,9 +269,20 @@ pub struct FilesysHle {
     units: Vec<FilesysUnit>,
     /// Board base address, captured from A0 at the DiagPoint trap.
     board_base: Option<u32>,
+    /// Cull the ROM's scsi.device at expansion init (`[machine]
+    /// rom_scsi_device_disable`). Our DiagPoint is the one moment the resident
+    /// list exists and the driver has not run yet; see [`crate::romtags`].
+    /// Survives the per-boot reset below -- it is configuration, not state.
+    cull_rom_scsi_device: bool,
 }
 
 impl FilesysHle {
+    /// `[machine] rom_scsi_device_disable`: unlink the ROM's scsi.device at
+    /// expansion init, before Kickstart initialises it.
+    pub fn set_cull_rom_scsi_device(&mut self, cull: bool) {
+        self.cull_rom_scsi_device = cull;
+    }
+
     pub fn set_mounts(&mut self, mounts: Vec<MountSpec>) {
         // Give each unit a fixed, non-overlapping slice of the board-window
         // lock pool. Size the slices by the board's *maximum* unit count, not
@@ -1276,8 +1287,10 @@ impl HleHandler for FilesysHle {
                     .into_iter()
                     .map(|u| u.mount)
                     .collect();
+                let cull_rom_scsi_device = self.cull_rom_scsi_device;
                 *self = FilesysHle::default();
                 self.set_mounts(mounts);
+                self.cull_rom_scsi_device = cull_rom_scsi_device;
                 self.board_base = Some(cpu.dar[8]);
                 self.write_startup_msgs(bus, cpu.dar[8]);
                 log::info!(
@@ -1285,6 +1298,10 @@ impl HleHandler for FilesysHle {
                     cpu.dar[8],
                     self.units.len()
                 );
+                if self.cull_rom_scsi_device {
+                    let culled = crate::romtags::cull_rom_device(bus, "scsi.device");
+                    log::info!("romtags: {culled} ROM scsi.device resident(s) culled");
+                }
                 true
             }
             TRAP_PACKET => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod priority;
 pub mod ramsey;
 pub mod recorder;
 pub mod romsearch;
+pub mod romtags;
 pub mod rtc;
 pub mod savestate;
 pub mod screenshot;

--- a/src/romtags.rs
+++ b/src/romtags.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+//! Culling ROM resident tags before Kickstart initialises them.
+//!
+//! Exec builds the ResModules list at coldstart by scanning the ROM for
+//! resident tags, then walks it in priority order calling each rt_Init. A
+//! module we do not want can be removed from that list in the window between
+//! the two, without touching the ROM image.
+//!
+//! The window we use is expansion.library's DIAG pass, which our board's
+//! DiagPoint traps into (see `guest/services/entry.s`). expansion.library is
+//! priority +110; the ROM's scsi.device is +10, so it has not run yet.
+//!
+//! This is what UAE/amiberry call `scsidevice_disable`, and it exists for the
+//! same reason: a machine whose disk controller we do not emulate yet is
+//! better off with no scsi.device than with one that probes absent hardware.
+//! On the A4000 that probe is an IDE presence test that stalls the boot for
+//! several seconds; on the A3000 the ROM's SCSI driver hangs outright waiting
+//! on an interrupt the missing WD33C93 never raises.
+//!
+//! It is a stopgap, not emulation: a real big-box Amiga has the controller
+//! fitted and its scsi.device simply finds no drives. Once the A4000 IDE and
+//! the WD33C93 are emulated, the machine profiles should stop setting it.
+
+use m68k::AddressBus;
+
+/// ExecBase.ResModules: the pointer to the resident list exec built at
+/// coldstart.
+const EXEC_RES_MODULES: u32 = 300;
+
+/// A ResModules entry with bit 31 set is not a Resident but a "the list
+/// continues here" pointer. Unlinking an entry means overwriting its slot
+/// with one of these, aimed at the following slot.
+const RESLIST_JUMP: u32 = 0x8000_0000;
+
+/// struct Resident (exec/resident.h).
+const RTC_MATCHWORD: u16 = 0x4AFC;
+const RT_MATCH_TAG: u32 = 2;
+const RT_TYPE: u32 = 12;
+const RT_NAME: u32 = 14;
+const NT_DEVICE: u8 = 3;
+
+/// The ROM windows a resident tag can legitimately live in: the extended ROM
+/// at $A80000 and Kickstart itself at $F00000. A tag outside them came from
+/// RAM (a KickTagged module, say), and is none of our business.
+fn in_rom(addr: u32) -> bool {
+    (0x00A8_0000..0x00B8_0000).contains(&addr) || (0x00F0_0000..0x0100_0000).contains(&addr)
+}
+
+/// Whether the resident tag at `tag` is a ROM device named `name`.
+fn is_rom_device(bus: &mut dyn AddressBus, tag: u32, name: &str) -> bool {
+    if !in_rom(tag)
+        || bus.read_word(tag) != RTC_MATCHWORD
+        || bus.read_long(tag + RT_MATCH_TAG) != tag
+        || bus.read_byte(tag + RT_TYPE) != NT_DEVICE
+    {
+        return false;
+    }
+    // The whole string we compare (name + NUL) must lie in ROM, not just its
+    // first byte: a tag pointing at the very end of a window would otherwise
+    // be compared against whatever the bus returns past it.
+    let rt_name = bus.read_long(tag + RT_NAME);
+    if !in_rom(rt_name) || !in_rom(rt_name + name.len() as u32) {
+        return false;
+    }
+    name.bytes()
+        .chain(std::iter::once(0)) // the NUL, so "scsi.device2" does not match
+        .enumerate()
+        .all(|(i, c)| bus.read_byte(rt_name + i as u32) == c)
+}
+
+/// Unlink every ROM resident named `name` from ExecBase's ResModules list, so
+/// Kickstart never calls its rt_Init. Returns how many were culled.
+///
+/// Only valid during the DIAG pass: earlier the list does not exist, later the
+/// module has already initialised and unlinking it achieves nothing.
+pub fn cull_rom_device(bus: &mut dyn AddressBus, name: &str) -> usize {
+    let exec_base = bus.read_long(4);
+    let mut slot = bus.read_long(exec_base + EXEC_RES_MODULES);
+    let mut culled = 0;
+    loop {
+        let entry = bus.read_long(slot);
+        if entry == 0 {
+            return culled;
+        }
+        if entry & RESLIST_JUMP != 0 {
+            slot = entry & !RESLIST_JUMP;
+            continue;
+        }
+        if is_rom_device(bus, entry, name) {
+            // Skip this slot by turning it into a jump to the next one. The
+            // final slot holds the terminating 0, so this is safe even for
+            // the last entry.
+            bus.write_long(slot, RESLIST_JUMP | (slot + 4));
+            culled += 1;
+        }
+        slot += 4;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Flat 16 MB memory, so a tag can sit at a ROM address.
+    struct FlatBus(Vec<u8>);
+
+    impl FlatBus {
+        fn new() -> Self {
+            FlatBus(vec![0; 0x0100_0000])
+        }
+        fn poke(&mut self, addr: u32, bytes: &[u8]) {
+            let at = addr as usize;
+            self.0[at..at + bytes.len()].copy_from_slice(bytes);
+        }
+        /// A resident tag for device `name`, with its rt_Name string just past
+        /// the tag itself.
+        fn poke_device(&mut self, tag: u32, name: &str) {
+            let rt_name = tag + 32;
+            self.poke(tag, &RTC_MATCHWORD.to_be_bytes());
+            self.poke(tag + RT_MATCH_TAG, &tag.to_be_bytes());
+            self.poke(tag + RT_TYPE, &[NT_DEVICE]);
+            self.poke(tag + RT_NAME, &rt_name.to_be_bytes());
+            self.poke(rt_name, name.as_bytes());
+            self.poke(rt_name + name.len() as u32, &[0]);
+        }
+        /// ExecBase at $400 with a ResModules list of `tags` at $600.
+        fn poke_res_modules(&mut self, tags: &[u32]) {
+            let (exec_base, list) = (0x400u32, 0x600u32);
+            self.poke(4, &exec_base.to_be_bytes());
+            self.poke(exec_base + EXEC_RES_MODULES, &list.to_be_bytes());
+            for (i, tag) in tags.iter().enumerate() {
+                self.poke(list + 4 * i as u32, &tag.to_be_bytes());
+            }
+            self.poke(list + 4 * tags.len() as u32, &0u32.to_be_bytes());
+        }
+        /// The tags exec would still initialise, in list order.
+        fn residents(&mut self) -> Vec<u32> {
+            let exec_base = self.read_long(4);
+            let mut slot = self.read_long(exec_base + EXEC_RES_MODULES);
+            let mut out = Vec::new();
+            loop {
+                let entry = self.read_long(slot);
+                if entry == 0 {
+                    return out;
+                }
+                if entry & RESLIST_JUMP != 0 {
+                    slot = entry & !RESLIST_JUMP;
+                    continue;
+                }
+                out.push(entry);
+                slot += 4;
+            }
+        }
+    }
+
+    impl AddressBus for FlatBus {
+        fn read_byte(&mut self, addr: u32) -> u8 {
+            self.0[addr as usize]
+        }
+        fn read_word(&mut self, addr: u32) -> u16 {
+            u16::from_be_bytes(self.0[addr as usize..addr as usize + 2].try_into().unwrap())
+        }
+        fn read_long(&mut self, addr: u32) -> u32 {
+            u32::from_be_bytes(self.0[addr as usize..addr as usize + 4].try_into().unwrap())
+        }
+        fn write_byte(&mut self, addr: u32, value: u8) {
+            self.0[addr as usize] = value;
+        }
+        fn write_word(&mut self, addr: u32, value: u16) {
+            self.poke(addr, &value.to_be_bytes());
+        }
+        fn write_long(&mut self, addr: u32, value: u32) {
+            self.poke(addr, &value.to_be_bytes());
+        }
+    }
+
+    const EXEC: u32 = 0x00F8_0042;
+    const SCSI: u32 = 0x00F8_590C;
+    const AUDIO: u32 = 0x00F8_968C;
+
+    #[test]
+    fn the_named_device_is_unlinked_and_its_neighbours_survive() {
+        let mut bus = FlatBus::new();
+        bus.poke_device(EXEC, "exec.library");
+        bus.poke_device(SCSI, "scsi.device");
+        bus.poke_device(AUDIO, "audio.device");
+        bus.poke_res_modules(&[EXEC, SCSI, AUDIO]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 1);
+        assert_eq!(bus.residents(), vec![EXEC, AUDIO]);
+    }
+
+    #[test]
+    fn a_device_in_the_last_slot_is_unlinked_without_running_off_the_list() {
+        let mut bus = FlatBus::new();
+        bus.poke_device(EXEC, "exec.library");
+        bus.poke_device(SCSI, "scsi.device");
+        bus.poke_res_modules(&[EXEC, SCSI]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 1);
+        assert_eq!(bus.residents(), vec![EXEC]);
+    }
+
+    #[test]
+    fn culling_is_idempotent_and_reports_nothing_when_the_device_is_absent() {
+        let mut bus = FlatBus::new();
+        bus.poke_device(EXEC, "exec.library");
+        bus.poke_res_modules(&[EXEC]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 0);
+        assert_eq!(bus.residents(), vec![EXEC]);
+    }
+
+    #[test]
+    fn a_ram_resident_of_the_same_name_is_left_alone() {
+        // A KickTagged scsi.device in RAM belongs to whoever installed it.
+        let mut bus = FlatBus::new();
+        let ram_scsi = 0x0020_0000;
+        bus.poke_device(ram_scsi, "scsi.device");
+        bus.poke_res_modules(&[ram_scsi]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 0);
+        assert_eq!(bus.residents(), vec![ram_scsi]);
+    }
+
+    #[test]
+    fn the_list_is_followed_across_a_jump_entry() {
+        // Exec's list is not always contiguous: an entry with bit 31 set
+        // continues it elsewhere, and a tag can sit past one.
+        let mut bus = FlatBus::new();
+        bus.poke_device(EXEC, "exec.library");
+        bus.poke_device(SCSI, "scsi.device");
+        bus.poke_res_modules(&[EXEC]);
+        let (list, tail) = (0x600u32, 0x700u32);
+        bus.poke(list + 4, &(RESLIST_JUMP | tail).to_be_bytes());
+        bus.poke(tail, &SCSI.to_be_bytes());
+        bus.poke(tail + 4, &0u32.to_be_bytes());
+        assert_eq!(bus.residents(), vec![EXEC, SCSI]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 1);
+        assert_eq!(bus.residents(), vec![EXEC]);
+    }
+
+    #[test]
+    fn a_library_of_the_same_name_is_not_a_device() {
+        let mut bus = FlatBus::new();
+        bus.poke_device(SCSI, "scsi.device");
+        bus.poke(SCSI + RT_TYPE, &[9]); // NT_LIBRARY
+        bus.poke_res_modules(&[SCSI]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 0);
+    }
+
+    #[test]
+    fn a_longer_name_with_the_same_prefix_does_not_match() {
+        let mut bus = FlatBus::new();
+        bus.poke_device(SCSI, "scsi.device.old");
+        bus.poke_res_modules(&[SCSI]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 0);
+    }
+
+    #[test]
+    fn a_name_running_off_the_rom_window_is_never_compared() {
+        // rt_Name so close to the end of the ROM that the string would spill
+        // past it: the tag is ignored rather than compared against whatever
+        // sits beyond the window.
+        let mut bus = FlatBus::new();
+        bus.poke_device(SCSI, "scsi.device");
+        let near_end = 0x00FF_FFF8u32;
+        bus.poke(SCSI + RT_NAME, &near_end.to_be_bytes());
+        bus.poke(near_end, b"scsi.de"); // truncated by the window edge
+        bus.poke_res_modules(&[SCSI]);
+
+        assert_eq!(cull_rom_device(&mut bus, "scsi.device"), 0);
+    }
+}


### PR DESCRIPTION
Booting an A4000 from host mounts with no [ide] drives spends minutes in Kickstart's scsi.device probing the empty cable; an A600/A1200 without drives and an A3000 with an empty SCSI bus pay the same tax in smaller coin. The driver has nothing to boot in those setups: it is pure probe time.

New module src/romtags.rs unlinks the driver's resident tag from ExecBase.ResModules during the Copperline services board's expansion-init DiagPoint - after Exec builds the resident list, before Kickstart initialises the entry. The ROM image is never modified. The board is fitted (with an empty mount table) even without [[filesys]] mounts when the cull is wanted.

Config: [machine] rom_scsi_device_disable = true|false forces it either way. The default engages exactly when the machine's built-in disk controller (A600/A1200/A4000 IDE, A3000 SDMAC SCSI) has no configured drives; configuring a drive keeps the driver, since scsi.device is its boot path. Machines without a built-in controller default to false - their ROMs carry no scsi.device anyway.

Unit tests cover the ResModules surgery (jump entries, last-slot unlink, RAM residents and same-name libraries left alone, idempotency) and the config heuristic for all three controller families. Verified live: an A4000 with three [[filesys]] mounts and no IDE drives logs "1 ROM scsi.device resident(s) culled" and reaches the Workbench in seconds instead of minutes.

Generated with [Claude Code](https://claude.com/claude-code)