### PR TITLE
rtc: deterministic guest clock seeding (--rtc-time / rtc_frozen + control rtc.get/rtc.set)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ Full reference: `docs/guide/headless.md`.
 Audio: `--noaudio` runs silent; `--audio-wav PATH` captures the mixed output
 as a WAV in emulated time instead of playing it.
 
+Guest clock: `--rtc-time "2005-03-18 01:58:29"` (Unix seconds also accepted)
+fits a battery clock seeded to that instant, ticking in emulated time -- the
+guest boots to the same deterministic time on every run, which is how to
+test time-dependent guest software (TOTP vectors, date logic).
+`--rtc-frozen` pins it to the seed exactly.
+
 ## Scripted input
 
 Input is scheduled at emulated timestamps and composes with screenshots and

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -109,6 +109,10 @@ model = "68000"
 # [machine]
 # profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | A3000 | A4000 | CDTV | CD32
 # rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV/A3000/A4000 have one)
+# rtc_time = "2005-03-18 01:58:29" # seed the clock (implies rtc = true); Unix seconds also accepted.
+#                                  # A seeded clock ticks in emulated time, so the guest-visible
+#                                  # time is deterministic across runs.
+# rtc_frozen = true                # stop the seeded clock at rtc_time exactly
 # mem_controller = "ramsey-07"   # none | ramsey-04 (A3000) | ramsey-07 (A4000)
 
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -144,6 +144,18 @@ not touched), `disasm {addr?, count?}`, `custom.dump`,
 `custom.read {reg}` (name or offset), `cia.get {cia: "a"|"b"}`,
 `beam.get`, `display.get`, `copper.list {addr?, max?}`, `pc_history`.
 
+Battery clock (the $DC0000 RTC; see `rtc_time` in
+`docs/guide/configuration.md` for the boot-time seed): `rtc.get` reports
+`{present, seeded, frozen, unix, time}`; `rtc.set {unix | time |
+advance, frozen?}` moves it live -- `unix` (Unix seconds) or `time`
+(`"YYYY-MM-DD HH:MM[:SS]"`) set an absolute value the clock reads from
+this instant, `advance` (signed seconds) jumps relative to the current
+reading, and `frozen` stops or resumes the tick (alone it
+freezes/unfreezes in place). The guest only notices when it re-reads
+the chip -- AmigaOS loads system time from it at boot (KS 2.0+) or via
+`SetClock LOAD`, so pair `rtc.set` with a warm reset or a guest-side
+re-read. `-32007` on a machine with no clock fitted.
+
 Breakpoints (shared with the debugger window's live store, so
 GUI-toggled points appear in `break.list`): `break.add {kind: "pc",
 addr, cond?, ignore?}` / `{kind: "watch", addr, class?}` /

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -96,6 +96,8 @@ missing.
 [machine]
 profile = "A1200" # A1000, A500, A500OCS, A500Plus (A500+), A600, A1200, A3000, A4000, CDTV, CD32
 rtc = true        # add a battery RTC (default: only A500+/CDTV/A3000/A4000 ship with one)
+# rtc_time = "2005-03-18 01:58:29" # seed the clock; it then ticks in emulated time
+# rtc_frozen = true                # stop the seeded clock at rtc_time exactly
 mem_controller = "ramsey-07" # none, ramsey-04 (A3000), ramsey-07 (A4000)
 ```
 
@@ -128,6 +130,28 @@ board), `CDTV`, `A3000`, and `A4000` fit one by default; the base
 A500/A500OCS, A600, A1200, A1000, and CD32 have none. Set `rtc = true` to add
 one -- for an A600HD or a clock-equipped A1200, say -- so the Workbench clock
 keeps time.
+
+`rtc_time` seeds the clock instead of letting it mirror the host's: the value
+is either an integer (Unix seconds, UTC) or a string
+`"YYYY-MM-DD HH:MM[:SS]"` giving exactly the wall-clock time the guest reads
+at power-on. A seeded clock ticks with *emulated* time, so the time the guest
+sees is deterministic and reproducible byte-for-byte across runs -- the way
+to test time-dependent guest software (TOTP/RFC 6238 vectors, timestamped
+logs, date rollovers) or just to boot into a fixed date. Setting a time
+implies `rtc = true`; combining it with an explicit `rtc = false` is an
+error. `rtc_frozen = true` additionally stops the tick so every read returns
+`rtc_time` exactly. Both are also available as `--rtc-time` / `--rtc-frozen`
+CLI flags, and a control-protocol session can inspect and move the clock live
+with `rtc.get` / `rtc.set` (see `docs/debugger/control.md`).
+
+Two guest-side notes: Kickstart 2.0+ loads the system time from the battery
+clock automatically at boot, while Kickstart 1.3 only does so when the
+startup-sequence runs `SetClock LOAD`; and the chip's two-digit year registers
+mean AmigaOS applies its usual century window, so seeds outside 1978-2077
+will not read back as the year you set. A host-initiated reset or power
+cycle restarts the emulated timeline and therefore restarts a seeded clock
+from `rtc_time`; a guest-initiated reboot (the 68000 `RESET` instruction)
+leaves it ticking, like real battery-backed hardware.
 
 The `A3000` and `A4000` profiles are the big-box machines. They carry a
 Ramsey memory controller (`mem_controller`), which is what the two registers

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -128,6 +128,31 @@ motion is captured at frame granularity (one `mouse-after` per frame of
 movement); CD inserts are not recorded -- use the `[cd]` config section
 for those.
 
+## A deterministic guest clock
+
+The emulated core never depends on the host clock -- with one deliberate
+exception: the battery-backed RTC mirrors host time on machines that have
+one, and an RTC-less machine boots to whatever date the guest OS invents.
+Both are wrong for testing time-dependent guest software. `--rtc-time`
+(or `[machine] rtc_time`) fits a battery clock seeded to a fixed instant --
+Unix seconds or `"YYYY-MM-DD HH:MM:SS"` -- that then ticks in *emulated*
+time, so every run boots to the same time and reads the same clock at the
+same emulated instant, on any host. `--rtc-frozen` stops it entirely.
+
+```sh
+# Validate a TOTP generator against an RFC 6238 vector time: the guest
+# boots with the clock at 2005-03-18 01:58:29 UTC (unix 1111111109),
+# deterministically, on every run.
+./target/release/copperline --config auth.toml --noaudio \
+  --rtc-time 1111111109 \
+  --screenshot-after 45 /tmp/code.png
+```
+
+Kickstart 2.0+ loads system time from the battery clock at boot on its
+own; Kickstart 1.3 needs `SetClock LOAD` in the startup-sequence. A
+[control-protocol](../debugger/control) session can also inspect, move,
+freeze, and resume the clock mid-run with `rtc.get` / `rtc.set`.
+
 ## Audio capture
 
 - `--noaudio` runs silent (live audio is otherwise on by default).

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2775,7 +2775,7 @@ impl Bus {
         self.denise = Denise::new();
         self.blitter = Blitter::new();
         self.configure_chip_dma_masks();
-        self.rtc = Msm6242Rtc::default();
+        self.rtc.reset();
         if let Some(gayle) = self.gayle.as_mut() {
             gayle.reset();
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,6 +126,15 @@ pub struct Config {
     /// the CDTV carry one by default; the A600HD and a clock-equipped A1200 set
     /// `[machine] rtc = true`.
     pub rtc_present: bool,
+    /// Power-on RTC value in Unix seconds (`[machine] rtc_time` /
+    /// `--rtc-time`). When set, the clock starts here and ticks with
+    /// *emulated* time instead of following the host wall clock, so the
+    /// guest-visible time is deterministic and reproducible. Setting a time
+    /// implies fitting the clock (`rtc = true`).
+    pub rtc_seed_unix: Option<u64>,
+    /// Stop the seeded RTC (`[machine] rtc_frozen`): every read returns
+    /// exactly `rtc_seed_unix`, for pinning a guest to one time window.
+    pub rtc_frozen: bool,
     pub video_standard: VideoStandard,
     pub audio: AudioConfig,
     /// Gayle IDE drive images (raw flat HDF, RDB inside), opened
@@ -984,6 +993,8 @@ impl Default for Config {
             // clock; only the A500+/CDTV profiles fit one (see
             // machine_profile_defaults).
             rtc_present: false,
+            rtc_seed_unix: None,
+            rtc_frozen: false,
             video_standard: VideoStandard::Pal,
             audio: AudioConfig::default(),
             ide: IdeConfig::default(),
@@ -1154,6 +1165,12 @@ pub struct ConfigOverrides {
     pub audio_channel_mode: Option<String>,
     /// Stereo separation percent (`--audio-stereo-separation`), 0-100.
     pub audio_stereo_separation: Option<u16>,
+    /// Power-on RTC value (`--rtc-time`): Unix seconds or
+    /// "YYYY-MM-DD HH:MM[:SS]". Same parser as `[machine] rtc_time`.
+    pub rtc_time: Option<String>,
+    /// Freeze the seeded RTC (`--rtc-frozen`). Same as
+    /// `[machine] rtc_frozen`.
+    pub rtc_frozen: Option<bool>,
 }
 
 impl ConfigOverrides {
@@ -1175,6 +1192,8 @@ impl ConfigOverrides {
             && self.audio_device.is_none()
             && self.audio_channel_mode.is_none()
             && self.audio_stereo_separation.is_none()
+            && self.rtc_time.is_none()
+            && self.rtc_frozen.is_none()
     }
 
     /// Inject the set overrides into the raw config, replacing the values
@@ -1232,6 +1251,14 @@ impl ConfigOverrides {
         }
         if let Some(sep) = self.audio_stereo_separation {
             raw.audio.stereo_separation = Some(sep);
+        }
+        if let Some(time) = &self.rtc_time {
+            // The text form parses bare digits as Unix seconds, so both
+            // CLI notations funnel through one raw variant.
+            raw.machine.rtc_time = Some(RawRtcTime::Text(time.clone()));
+        }
+        if let Some(frozen) = self.rtc_frozen {
+            raw.machine.rtc_frozen = Some(frozen);
         }
     }
 }
@@ -1627,12 +1654,32 @@ pub(crate) struct RawMachine {
     /// clock-equipped A1200.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rtc: Option<bool>,
+    /// Power-on clock value: an integer (Unix seconds, UTC) or a string
+    /// `"YYYY-MM-DD HH:MM[:SS]"` (the wall-clock time the guest reads).
+    /// Seeds the battery clock and ticks it in emulated time so the
+    /// guest-visible time is deterministic; implies `rtc = true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rtc_time: Option<RawRtcTime>,
+    /// Stop the seeded clock so every read returns `rtc_time` exactly.
+    /// Only meaningful together with `rtc_time`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rtc_frozen: Option<bool>,
     /// Memory controller fitted, defaulting per profile: `none`, `ramsey-04`
     /// (A3000) or `ramsey-07` (A4000). Ramsey answers at $DE0000, which no
     /// other chip decodes, so it can also be fitted to a wedge machine to
     /// exercise the diagnostic tools.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mem_controller: Option<String>,
+}
+
+/// `[machine] rtc_time` accepts both TOML notations for one instant: a
+/// bare integer (Unix seconds) or a calendar string. Both funnel through
+/// `crate::rtc::parse_rtc_time` at validation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum RawRtcTime {
+    Unix(i64),
+    Text(String),
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2122,6 +2169,32 @@ impl TryFrom<RawConfig> for Config {
             }
             None => 0.0,
         };
+        let rtc_seed_unix = match &raw.machine.rtc_time {
+            Some(RawRtcTime::Unix(n)) => match u64::try_from(*n) {
+                Ok(secs) => Some(secs),
+                Err(_) => {
+                    errors.push(anyhow!(
+                        "[machine] rtc_time must be non-negative Unix seconds \
+                         (1970 or later)"
+                    ));
+                    None
+                }
+            },
+            Some(RawRtcTime::Text(s)) => match crate::rtc::parse_rtc_time(s) {
+                Ok(secs) => Some(secs),
+                Err(e) => {
+                    errors.push(anyhow!("[machine] rtc_time: {e}"));
+                    None
+                }
+            },
+            None => None,
+        };
+        let rtc_frozen = raw.machine.rtc_frozen.unwrap_or(false);
+        if rtc_frozen && raw.machine.rtc_time.is_none() {
+            errors.push(anyhow!(
+                "[machine] rtc_frozen = true needs an rtc_time to freeze at"
+            ));
+        }
 
         match errors.len() {
             0 => {}
@@ -2187,7 +2260,18 @@ impl TryFrom<RawConfig> for Config {
                 .nvram
                 .map(PathBuf::from)
                 .or_else(|| defaults.akiko.then(|| PathBuf::from("cd32-nvram.bin"))),
-            rtc_present: raw.machine.rtc.unwrap_or(defaults.rtc_present),
+            rtc_present: match raw.machine.rtc {
+                // A configured time on an explicitly unfitted clock would
+                // silently do nothing; make the contradiction loud.
+                Some(false) if rtc_seed_unix.is_some() => anyhow::bail!(
+                    "[machine] rtc_time is set but rtc = false leaves the \
+                     clock unfitted; drop one of them"
+                ),
+                Some(fitted) => fitted,
+                None => defaults.rtc_present || rtc_seed_unix.is_some(),
+            },
+            rtc_seed_unix,
+            rtc_frozen,
             log_unmapped: raw
                 .debug
                 .log_unmapped
@@ -2923,6 +3007,77 @@ mod tests {
     }
 
     #[test]
+    fn rtc_time_accepts_both_notations_and_implies_a_fitted_clock() -> Result<()> {
+        // Integer form: Unix seconds (an RFC 6238 test-vector instant).
+        let cfg = parse_config(
+            r#"
+            [machine]
+            rtc_time = 1111111109
+            "#,
+        )?;
+        assert_eq!(cfg.rtc_seed_unix, Some(1_111_111_109));
+        assert!(!cfg.rtc_frozen);
+        // The default A500 has no clock, but seeding one fits it.
+        assert!(cfg.rtc_present);
+
+        // Calendar form: the same instant as the guest reads it.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            rtc_time = "2005-03-18 01:58:29"
+            rtc_frozen = true
+            "#,
+        )?;
+        assert_eq!(cfg.rtc_seed_unix, Some(1_111_111_109));
+        assert!(cfg.rtc_frozen);
+        assert!(cfg.rtc_present);
+        Ok(())
+    }
+
+    #[test]
+    fn rtc_time_misconfigurations_are_rejected() {
+        // An explicitly unfitted clock contradicts a configured time.
+        let err = parse_config(
+            r#"
+            [machine]
+            rtc = false
+            rtc_time = 1111111109
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("rtc = false"), "{err:#}");
+
+        // Freezing needs a time to freeze at.
+        let err = parse_config(
+            r#"
+            [machine]
+            rtc_frozen = true
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("rtc_frozen"), "{err:#}");
+
+        // Negative Unix seconds and malformed strings fail validation.
+        for bad in ["rtc_time = -1", "rtc_time = \"tomorrow\""] {
+            let err = parse_config(&format!("[machine]\n{bad}\n")).unwrap_err();
+            assert!(err.to_string().contains("rtc_time"), "{bad}: {err:#}");
+        }
+    }
+
+    #[test]
+    fn rtc_time_cli_override_matches_the_config_field() -> Result<()> {
+        let cfg = load_overrides(&ConfigOverrides {
+            rtc_time: Some("1111111109".to_string()),
+            rtc_frozen: Some(true),
+            ..ConfigOverrides::default()
+        })?;
+        assert_eq!(cfg.rtc_seed_unix, Some(1_111_111_109));
+        assert!(cfg.rtc_frozen);
+        assert!(cfg.rtc_present);
+        Ok(())
+    }
+
+    #[test]
     fn format_size_inverts_parse_size() {
         for (bytes, text) in [
             (0usize, "0"),
@@ -2977,6 +3132,8 @@ mod tests {
             machine: RawMachine {
                 profile: Some("A1200".to_string()),
                 rtc: Some(true),
+                rtc_time: Some(RawRtcTime::Text("2005-03-18 01:58:29".to_string())),
+                rtc_frozen: Some(true),
                 mem_controller: Some("ramsey-07".to_string()),
             },
             cpu: RawCpu {

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1045,9 +1045,11 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             let current = emu.bus().rtc.current_unix(secs);
             let target = match (unix, advance) {
                 (Some(u), _) => *u,
-                (None, Some(d)) => current
-                    .checked_add_signed(*d)
-                    .ok_or_else(|| CtlError::invalid_params("advance underflows the Unix epoch"))?,
+                (None, Some(d)) => current.checked_add_signed(*d).ok_or_else(|| {
+                    CtlError::invalid_params(
+                        "advance moves the clock outside the Unix-seconds range",
+                    )
+                })?,
                 (None, None) => current,
             };
             let frozen = frozen.unwrap_or_else(|| emu.bus().rtc.frozen());

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -44,27 +44,63 @@ pub enum Request {
 pub enum CoreOp {
     Status,
     RegsGet,
-    RegsSet { reg: usize, value: u32 },
-    MemRead { addr: u32, len: usize, base64: bool },
-    MemWrite { addr: u32, data: Vec<u8> },
-    Disasm { addr: Option<u32>, count: usize },
+    RegsSet {
+        reg: usize,
+        value: u32,
+    },
+    MemRead {
+        addr: u32,
+        len: usize,
+        base64: bool,
+    },
+    MemWrite {
+        addr: u32,
+        data: Vec<u8>,
+    },
+    Disasm {
+        addr: Option<u32>,
+        count: usize,
+    },
     CustomDump,
-    CustomRead { off: u16 },
-    CiaGet { b: bool },
+    CustomRead {
+        off: u16,
+    },
+    CiaGet {
+        b: bool,
+    },
     BeamGet,
     DisplayGet,
-    CopperList { addr: Option<u32>, max: usize },
-    LastWriter { addr: u32 },
+    RtcGet,
+    RtcSet {
+        unix: Option<u64>,
+        advance: Option<i64>,
+        frozen: Option<bool>,
+    },
+    CopperList {
+        addr: Option<u32>,
+        max: usize,
+    },
+    LastWriter {
+        addr: u32,
+    },
     PcHistory,
     BreakAdd(BreakSpec),
-    BreakRemove { id: u32 },
+    BreakRemove {
+        id: u32,
+    },
     BreakList,
     BreakClear,
     FloppyQuery,
-    StateSave { path: PathBuf },
+    StateSave {
+        path: PathBuf,
+    },
     Digest,
-    Screenshot { path: Option<PathBuf> },
-    ReverseStep { n: u64 },
+    Screenshot {
+        path: Option<PathBuf>,
+    },
+    ReverseStep {
+        n: u64,
+    },
     ReverseFrame,
     ReverseContinue,
 }
@@ -97,6 +133,7 @@ impl CoreOp {
                 | CoreOp::CiaGet { .. }
                 | CoreOp::BeamGet
                 | CoreOp::DisplayGet
+                | CoreOp::RtcGet
                 | CoreOp::CopperList { .. }
                 | CoreOp::PcHistory
                 | CoreOp::BreakList
@@ -387,6 +424,40 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         }),
         "beam.get" => core(CoreOp::BeamGet),
         "display.get" => core(CoreOp::DisplayGet),
+        "rtc.get" => core(CoreOp::RtcGet),
+        "rtc.set" => {
+            let unix = p.u64_opt("unix")?;
+            let time = match p.str_opt("time")? {
+                Some(s) => Some(
+                    crate::rtc::parse_rtc_time(&s)
+                        .map_err(|e| CtlError::invalid_params(format!("time: {e}")))?,
+                ),
+                None => None,
+            };
+            let advance = p.i64_opt("advance")?;
+            let frozen = p.bool_opt("frozen")?;
+            let absolute = match (unix, time) {
+                (Some(_), Some(_)) => {
+                    return Err(CtlError::invalid_params("give unix or time, not both"))
+                }
+                (u, t) => u.or(t),
+            };
+            if absolute.is_some() && advance.is_some() {
+                return Err(CtlError::invalid_params(
+                    "give an absolute time or advance, not both",
+                ));
+            }
+            if absolute.is_none() && advance.is_none() && frozen.is_none() {
+                return Err(CtlError::invalid_params(
+                    "nothing to set: give unix, time, advance, or frozen",
+                ));
+            }
+            core(CoreOp::RtcSet {
+                unix: absolute,
+                advance,
+                frozen,
+            })
+        }
         "copper.list" => core(CoreOp::CopperList {
             addr: p.u32_opt("addr")?,
             max: p.usize_or("max", 32)?.clamp(1, 256),
@@ -793,6 +864,16 @@ impl<'a> ParamReader<'a> {
         }
     }
 
+    fn i64_opt(&self, key: &str) -> Result<Option<i64>, CtlError> {
+        match self.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(v) => v
+                .as_i64()
+                .map(Some)
+                .ok_or_else(|| CtlError::invalid_params(format!("bad {key}"))),
+        }
+    }
+
     fn f64_opt(&self, key: &str) -> Result<Option<f64>, CtlError> {
         match self.get(key) {
             None | Some(Value::Null) => Ok(None),
@@ -938,6 +1019,63 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 "dmacon": bus.debug_dmacon(),
                 "display": bus.debug_display_state(),
             }))
+        }
+        CoreOp::RtcGet => {
+            let bus = emu.bus();
+            let secs = bus.emulated_seconds();
+            Ok(json!({
+                "present": bus.rtc_present(),
+                "seeded": bus.rtc.seed().is_some(),
+                "frozen": bus.rtc.frozen(),
+                "unix": bus.rtc.current_unix(secs),
+                "time": bus.rtc.current_display(secs),
+            }))
+        }
+        CoreOp::RtcSet {
+            unix,
+            advance,
+            frozen,
+        } => {
+            if !emu.bus().rtc_present() {
+                return Err(CtlError::not_found(
+                    "no battery clock fitted ([machine] rtc = true or --rtc-time fits one)",
+                ));
+            }
+            let secs = emu.bus().emulated_seconds();
+            let current = emu.bus().rtc.current_unix(secs);
+            let target = match (unix, advance) {
+                (Some(u), _) => *u,
+                (None, Some(d)) => current
+                    .checked_add_signed(*d)
+                    .ok_or_else(|| CtlError::invalid_params("advance underflows the Unix epoch"))?,
+                (None, None) => current,
+            };
+            let frozen = frozen.unwrap_or_else(|| emu.bus().rtc.frozen());
+            let seed = if frozen {
+                target
+            } else {
+                // The seed is the clock's value at emulated time zero, so
+                // subtract the elapsed timeline to make it read `target`
+                // from this instant onward.
+                target.checked_sub(secs as u64).ok_or_else(|| {
+                    CtlError::invalid_params(
+                        "time is earlier than the elapsed emulated timeline allows",
+                    )
+                })?
+            };
+            emu.bus_mut().rtc.set_seed(Some(seed), frozen);
+            let bus = emu.bus();
+            let mut result = json!({
+                "unix": bus.rtc.current_unix(secs),
+                "time": bus.rtc.current_display(secs),
+                "frozen": bus.rtc.frozen(),
+            });
+            if emu.time_travel_enabled() {
+                // Like mem.write, a clock change is not part of the replay
+                // journal, so a reverse replay across it can diverge.
+                result["replay_unsafe"] = Value::Bool(true);
+            }
+            Ok(result)
         }
         CoreOp::CopperList { addr, max } => {
             let bus = emu.bus();
@@ -1451,6 +1589,68 @@ mod tests {
             proto::decode_base64(read["data"].as_str().unwrap()).unwrap(),
             vec![0xde, 0xad, 0xbe, 0xef, 0x01, 0x02]
         );
+    }
+
+    #[test]
+    fn rtc_set_rejects_conflicting_or_empty_params() {
+        let err = parse_method("rtc.set", &json!({})).unwrap_err();
+        assert_eq!(err.code, proto::INVALID_PARAMS);
+        let err = parse_method(
+            "rtc.set",
+            &json!({"unix": 1, "time": "2005-03-18 01:58:29"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, proto::INVALID_PARAMS);
+        let err = parse_method("rtc.set", &json!({"unix": 1, "advance": 30})).unwrap_err();
+        assert_eq!(err.code, proto::INVALID_PARAMS);
+        let err = parse_method("rtc.set", &json!({"time": "later"})).unwrap_err();
+        assert_eq!(err.code, proto::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn rtc_set_seeds_freezes_and_advances_the_clock() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+
+        // Seed with an RFC 6238 vector instant via the calendar notation.
+        let set = exec_core(
+            &mut emu,
+            &mut ctx,
+            &core("rtc.set", json!({"time": "2005-03-18 01:58:29"})),
+        )
+        .unwrap();
+        assert_eq!(set["unix"], 1_111_111_109u64);
+        assert_eq!(set["time"], "2005-03-18T01:58:29");
+        assert_eq!(set["frozen"], false);
+
+        let get = exec_core(&mut emu, &mut ctx, &CoreOp::RtcGet).unwrap();
+        assert_eq!(get["present"], true);
+        assert_eq!(get["seeded"], true);
+        assert_eq!(get["unix"], 1_111_111_109u64);
+
+        // Freeze in place, then step the frozen clock forward one TOTP
+        // window at a time.
+        let set = exec_core(
+            &mut emu,
+            &mut ctx,
+            &core("rtc.set", json!({"frozen": true})),
+        )
+        .unwrap();
+        assert_eq!(set["frozen"], true);
+        assert_eq!(set["unix"], 1_111_111_109u64);
+        let set = exec_core(&mut emu, &mut ctx, &core("rtc.set", json!({"advance": 30}))).unwrap();
+        assert_eq!(set["unix"], 1_111_111_139u64);
+        assert_eq!(set["frozen"], true);
+
+        // Unfreeze without a time: the clock resumes from where it stood.
+        let set = exec_core(
+            &mut emu,
+            &mut ctx,
+            &core("rtc.set", json!({"frozen": false})),
+        )
+        .unwrap();
+        assert_eq!(set["unix"], 1_111_111_139u64);
+        assert_eq!(set["frozen"], false);
     }
 
     #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2598,7 +2598,8 @@ impl CpuBus {
         }
         if self.bus.rtc_present() && range_contains(RTC_BASE, RTC_SIZE, addr) {
             self.bus.cpu_slow_external_access(Self::access_words(size));
-            return self.bus.rtc.read(u64::from(addr - RTC_BASE), size) as u32;
+            let secs = self.bus.emulated_seconds();
+            return self.bus.rtc.read(u64::from(addr - RTC_BASE), size, secs) as u32;
         }
         if self.bus.gayle.is_some()
             && (range_contains(GAYLE_BASE, GAYLE_SIZE, addr)
@@ -2849,9 +2850,10 @@ impl CpuBus {
         }
         if self.bus.rtc_present() && range_contains(RTC_BASE, RTC_SIZE, addr) {
             self.bus.cpu_slow_external_access(Self::access_words(size));
+            let secs = self.bus.emulated_seconds();
             self.bus
                 .rtc
-                .write(u64::from(addr - RTC_BASE), size, u64::from(value));
+                .write(u64::from(addr - RTC_BASE), size, u64::from(value), secs);
             return;
         }
         if self.bus.gayle.is_some()

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1938,6 +1938,7 @@ pub fn build_machine(
     bus.set_video_standard(cfg.video_standard);
     bus.set_chipset_revisions(cfg.agnus_revision, cfg.denise_revision);
     bus.set_rtc_present(cfg.rtc_present);
+    bus.rtc.set_seed(cfg.rtc_seed_unix, cfg.rtc_frozen);
     if let Some(id) = cfg.gate_array.gayle_id() {
         let mut gayle = crate::gayle::Gayle::new(id);
         if let Some(drive) = &cfg.ide.master {

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,6 +352,14 @@ where
                     .ok_or_else(|| anyhow!("--floppy-drives requires COUNT (1-4)"))?;
                 overrides.floppy_drives = Some(parse_floppy_drive_count(&value)?);
             }
+            "--rtc-time" => {
+                overrides.rtc_time = Some(args.next().ok_or_else(|| {
+                    anyhow!("--rtc-time requires Unix seconds or \"YYYY-MM-DD HH:MM:SS\"")
+                })?);
+            }
+            "--rtc-frozen" => {
+                overrides.rtc_frozen = Some(true);
+            }
             "--joystick" => {
                 overrides.joystick = Some(
                     args.next()
@@ -778,6 +786,10 @@ fn print_help() {
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
          --floppy-drives COUNT          wired floppy drives, 1-4 (DF0 plus externals)\n  \
+         --rtc-time TIME                seed the battery clock (implies fitting one) with\n  \
+         \x20                            Unix seconds or \"YYYY-MM-DD HH:MM:SS\"; it then\n  \
+         \x20                            ticks in emulated time, so runs are deterministic\n  \
+         --rtc-frozen                   stop the seeded clock at --rtc-time exactly\n  \
          --joystick MODE                initial joystick input: gamepad or keyboard\n  \
          \x20                            (gamepad lets the keyboard pass through to the Amiga)\n  \
          \x20                            (--model/--cpu/etc. override the config file or defaults)\n  \

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,7 +354,7 @@ where
             }
             "--rtc-time" => {
                 overrides.rtc_time = Some(args.next().ok_or_else(|| {
-                    anyhow!("--rtc-time requires Unix seconds or \"YYYY-MM-DD HH:MM:SS\"")
+                    anyhow!("--rtc-time requires Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"")
                 })?);
             }
             "--rtc-frozen" => {
@@ -787,7 +787,7 @@ fn print_help() {
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
          --floppy-drives COUNT          wired floppy drives, 1-4 (DF0 plus externals)\n  \
          --rtc-time TIME                seed the battery clock (implies fitting one) with\n  \
-         \x20                            Unix seconds or \"YYYY-MM-DD HH:MM:SS\"; it then\n  \
+         \x20                            Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"; it then\n  \
          \x20                            ticks in emulated time, so runs are deterministic\n  \
          --rtc-frozen                   stop the seeded clock at --rtc-time exactly\n  \
          --joystick MODE                initial joystick input: gamepad or keyboard\n  \

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -228,12 +228,19 @@ pub fn parse_rtc_time(s: &str) -> Result<u64, String> {
     if year < 1970 {
         return Err(format!("rtc_time {s:?} is before 1970 (Unix epoch)"));
     }
+    // Explicit bounds before the casts below: a year above i32::MAX or a
+    // month/day above u32::MAX would wrap identically in the computation
+    // and in the round-trip check, slipping past it as a wrong date.
+    if year > 9999 || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return Err(format!("rtc_time {s:?} is not a valid calendar date"));
+    }
     if hour > 23 || minute > 59 || second > 59 {
         return Err(format!("rtc_time {s:?} has an out-of-range time of day"));
     }
     let days = days_from_civil(year as i64, month as u32, day as u32);
-    // Round-tripping through the decomposition rejects impossible dates
-    // (month 13, Feb 30) without a hand-written calendar table.
+    // Round-tripping through the decomposition rejects the impossible
+    // dates the bounds above cannot (Feb 30, Apr 31) without a
+    // hand-written calendar table.
     if civil_from_days(days) != (year as i32, month as u32, day as u32) {
         return Err(format!("rtc_time {s:?} is not a valid calendar date"));
     }
@@ -488,9 +495,15 @@ mod tests {
         assert!(parse_rtc_time("2005-03-18").is_err()); // no time of day
         assert!(parse_rtc_time("2005-13-01 00:00:00").is_err());
         assert!(parse_rtc_time("2005-02-30 00:00:00").is_err());
+        assert!(parse_rtc_time("2005-03-00 00:00:00").is_err());
         assert!(parse_rtc_time("2005-03-18 24:00:00").is_err());
         assert!(parse_rtc_time("1969-12-31 23:59:59").is_err());
         assert!(parse_rtc_time("-100").is_err());
+        // Values that would wrap the internal casts (u32 month, i32 year)
+        // must fail loudly, not alias onto a nearby valid date.
+        assert!(parse_rtc_time("2005-4294967299-18 00:00:00").is_err());
+        assert!(parse_rtc_time("4294969296-03-18 00:00:00").is_err());
+        assert!(parse_rtc_time("99999999999-01-01 00:00:00").is_err());
     }
 
     #[cfg(any(unix, windows))]

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -13,6 +13,14 @@
 //! real notion of time zones and a UTC clock just confuses users. The
 //! deterministic `COPPERLINE_RTC_FIXED_SECS` override stays UTC so it
 //! remains host-independent.
+//!
+//! A configured seed (`[machine] rtc_time` / `--rtc-time`) replaces the
+//! host clock entirely: the chip powers on reading the seed and ticks
+//! forward with *emulated* time, like a battery clock that was set before
+//! the machine was switched on. Reads are then reproducible byte-for-byte,
+//! which is what a guest program validating time-dependent behaviour
+//! (TOTP vectors, timestamped logs) needs. `rtc_frozen` additionally stops
+//! the tick, as if the chip's STOP bit were wired permanently high.
 
 use crate::timebase::{SystemTime, UNIX_EPOCH};
 
@@ -21,6 +29,12 @@ pub struct Msm6242Rtc {
     control_d: u8,
     control_e: u8,
     latched: Option<RtcDateTime>,
+    /// Power-on clock value in Unix seconds. When set, register reads
+    /// derive from seed + elapsed emulated seconds instead of the host
+    /// wall clock, making the guest-visible time deterministic.
+    seed_unix: Option<u64>,
+    /// Stop the seeded clock: reads always decompose the seed itself.
+    frozen: bool,
     #[cfg(test)]
     test_time: Option<SystemTime>,
 }
@@ -41,18 +55,18 @@ impl Msm6242Rtc {
     const CD_IRQ_FLAG: u8 = 1 << 2;
     const CF_24H: u8 = 1 << 2;
 
-    pub fn read(&mut self, addr: u64, _size: usize) -> u64 {
-        self.read_register(register_from_offset(addr)) as u64
+    pub fn read(&mut self, addr: u64, _size: usize, emulated_secs: f64) -> u64 {
+        self.read_register(register_from_offset(addr), emulated_secs) as u64
     }
 
-    pub fn write(&mut self, addr: u64, _size: usize, val: u64) {
+    pub fn write(&mut self, addr: u64, _size: usize, val: u64, emulated_secs: f64) {
         let reg = register_from_offset(addr);
         let val = (val & 0x0F) as u8;
         match reg {
             0xD => {
                 if val & Self::CD_HOLD != 0 {
                     if self.latched.is_none() {
-                        self.latched = Some(self.current_time());
+                        self.latched = Some(self.current_time(emulated_secs));
                     }
                     self.control_d = Self::CD_HOLD;
                 } else {
@@ -71,8 +85,10 @@ impl Msm6242Rtc {
         }
     }
 
-    fn read_register(&mut self, reg: u8) -> u8 {
-        let time = self.latched.unwrap_or_else(|| self.current_time());
+    fn read_register(&mut self, reg: u8, emulated_secs: f64) -> u8 {
+        let time = self
+            .latched
+            .unwrap_or_else(|| self.current_time(emulated_secs));
         (match reg {
             0x0 => time.second % 10,
             0x1 => time.second / 10,
@@ -94,7 +110,7 @@ impl Msm6242Rtc {
         }) & 0x0F
     }
 
-    fn current_time(&self) -> RtcDateTime {
+    fn current_time(&self, emulated_secs: f64) -> RtcDateTime {
         #[cfg(test)]
         if let Some(time) = self.test_time {
             return RtcDateTime::from_system_time(time);
@@ -102,19 +118,126 @@ impl Msm6242Rtc {
         // COPPERLINE_RTC_FIXED_SECS pins the clock to a fixed Unix-seconds
         // value, making RTC reads deterministic across runs (otherwise the
         // host wall-clock differs run-to-run, which pollutes differential
-        // traces with spurious timestamp divergences).
+        // traces with spurious timestamp divergences). As a diagnostic
+        // override it wins over the configured seed.
         if let Some(secs) = crate::envcfg::var("COPPERLINE_RTC_FIXED_SECS")
             .and_then(|s| s.trim().parse::<u64>().ok())
         {
             return RtcDateTime::from_unix_seconds(secs);
         }
+        if let Some(seed) = self.seed_unix {
+            return RtcDateTime::from_unix_seconds(self.seeded_unix(seed, emulated_secs));
+        }
         RtcDateTime::from_system_time_local(SystemTime::now())
+    }
+
+    fn seeded_unix(&self, seed: u64, emulated_secs: f64) -> u64 {
+        if self.frozen {
+            seed
+        } else {
+            seed + emulated_secs as u64
+        }
+    }
+
+    /// Configure the power-on clock value (`None` restores the live host
+    /// clock). The seed is the value the clock reads at emulated time zero.
+    pub fn set_seed(&mut self, seed_unix: Option<u64>, frozen: bool) {
+        self.seed_unix = seed_unix;
+        self.frozen = frozen && seed_unix.is_some();
+    }
+
+    pub fn seed(&self) -> Option<u64> {
+        self.seed_unix
+    }
+
+    pub fn frozen(&self) -> bool {
+        self.frozen
+    }
+
+    /// The Unix-seconds instant register reads decompose right now,
+    /// following the same source precedence as `current_time` (the
+    /// host-local path reports plain host Unix seconds).
+    pub fn current_unix(&self, emulated_secs: f64) -> u64 {
+        if let Some(secs) = crate::envcfg::var("COPPERLINE_RTC_FIXED_SECS")
+            .and_then(|s| s.trim().parse::<u64>().ok())
+        {
+            return secs;
+        }
+        if let Some(seed) = self.seed_unix {
+            return self.seeded_unix(seed, emulated_secs);
+        }
+        RtcDateTime::unix_secs(SystemTime::now())
+    }
+
+    /// The broken-down time register reads expose right now, formatted as
+    /// `YYYY-MM-DDTHH:MM:SS` (for status reporting, not the guest).
+    pub fn current_display(&self, emulated_secs: f64) -> String {
+        self.current_time(emulated_secs).iso8601()
+    }
+
+    /// A CPU reset does not reach the battery-backed chip, so the time
+    /// source keeps running; only the bus-visible latch state drops back
+    /// to power-on defaults.
+    pub fn reset(&mut self) {
+        self.control_d = 0;
+        self.control_e = 0;
+        self.latched = None;
     }
 
     #[cfg(test)]
     fn set_test_time(&mut self, time: SystemTime) {
         self.test_time = Some(time);
     }
+}
+
+/// Parse a `[machine] rtc_time` / `--rtc-time` value: either a bare
+/// integer (Unix seconds, UTC) or a calendar timestamp
+/// `YYYY-MM-DD HH:MM[:SS]` (a `T` date/time separator is also accepted).
+/// The calendar form is exactly the wall-clock time the guest reads at
+/// power-on, independent of the host time zone.
+pub fn parse_rtc_time(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty rtc_time value".into());
+    }
+    if s.bytes().all(|b| b.is_ascii_digit()) {
+        return s
+            .parse::<u64>()
+            .map_err(|_| format!("Unix-seconds value {s:?} is out of range"));
+    }
+    let form = "expected Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"";
+    let (date, time) = s
+        .split_once(['T', ' '])
+        .ok_or_else(|| format!("cannot parse rtc_time {s:?}: {form}"))?;
+    let mut date_parts = date.splitn(3, '-');
+    let num = |part: Option<&str>| -> Result<u64, String> {
+        part.filter(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+            .and_then(|p| p.parse::<u64>().ok())
+            .ok_or_else(|| format!("cannot parse rtc_time {s:?}: {form}"))
+    };
+    let year = num(date_parts.next())?;
+    let month = num(date_parts.next())?;
+    let day = num(date_parts.next())?;
+    let mut time_parts = time.splitn(3, ':');
+    let hour = num(time_parts.next())?;
+    let minute = num(time_parts.next())?;
+    let second = match time_parts.next() {
+        Some(sec) => num(Some(sec))?,
+        None => 0,
+    };
+    if year < 1970 {
+        return Err(format!("rtc_time {s:?} is before 1970 (Unix epoch)"));
+    }
+    if hour > 23 || minute > 59 || second > 59 {
+        return Err(format!("rtc_time {s:?} has an out-of-range time of day"));
+    }
+    let days = days_from_civil(year as i64, month as u32, day as u32);
+    // Round-tripping through the decomposition rejects impossible dates
+    // (month 13, Feb 30) without a hand-written calendar table.
+    if civil_from_days(days) != (year as i32, month as u32, day as u32) {
+        return Err(format!("rtc_time {s:?} is not a valid calendar date"));
+    }
+    Ok(days as u64 * 86_400 + hour * 3_600 + minute * 60 + second)
 }
 
 fn register_from_offset(addr: u64) -> u8 {
@@ -143,6 +266,13 @@ impl RtcDateTime {
         time.duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs()
+    }
+
+    fn iso8601(&self) -> String {
+        format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+            self.year, self.month, self.day, self.hour, self.minute, self.second
+        )
     }
 
     fn from_unix_seconds(secs: u64) -> Self {
@@ -212,6 +342,18 @@ impl RtcDateTime {
     }
 }
 
+/// Inverse of `civil_from_days` (Howard Hinnant's civil-calendar
+/// algorithm): days since the Unix epoch for a Gregorian date.
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let y = year - if month <= 2 { 1 } else { 0 };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let m = month as i64;
+    let doy = (153 * (m + if m > 2 { -3 } else { 9 }) + 2) / 5 + day as i64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
 fn civil_from_days(days_since_unix_epoch: i64) -> (i32, u32, u32) {
     let z = days_since_unix_epoch + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
@@ -232,7 +374,11 @@ mod tests {
     use std::time::Duration;
 
     fn read_reg(rtc: &mut Msm6242Rtc, reg: u8) -> u8 {
-        rtc.read((reg as u64) * 4, 4) as u8
+        rtc.read((reg as u64) * 4, 4, 0.0) as u8
+    }
+
+    fn read_reg_at(rtc: &mut Msm6242Rtc, reg: u8, emulated_secs: f64) -> u8 {
+        rtc.read((reg as u64) * 4, 4, emulated_secs) as u8
     }
 
     #[test]
@@ -263,7 +409,7 @@ mod tests {
     fn hold_write_latches_time_without_setting_host_clock() {
         let mut rtc = Msm6242Rtc::default();
         rtc.set_test_time(UNIX_EPOCH + Duration::from_secs(946_782_245));
-        rtc.write(0xD * 4, 4, Msm6242Rtc::CD_HOLD as u64);
+        rtc.write(0xD * 4, 4, Msm6242Rtc::CD_HOLD as u64, 0.0);
         assert_eq!(
             read_reg(&mut rtc, 0xD) & Msm6242Rtc::CD_HOLD,
             Msm6242Rtc::CD_HOLD
@@ -272,8 +418,79 @@ mod tests {
         rtc.set_test_time(UNIX_EPOCH + Duration::from_secs(946_782_245 + 55));
         assert_eq!(read_reg(&mut rtc, 0x0), 5);
 
-        rtc.write(0xD * 4, 4, 0);
+        rtc.write(0xD * 4, 4, 0, 0.0);
         assert_eq!(read_reg(&mut rtc, 0x0), 0);
+    }
+
+    // RFC 6238 test-vector instant: 1111111109 = 2005-03-18T01:58:29Z,
+    // a Friday. The seeded clock must expose exactly this decomposition
+    // regardless of the host clock or time zone.
+    const VECTOR_UNIX: u64 = 1_111_111_109;
+
+    #[test]
+    fn seeded_clock_reads_seed_and_advances_with_emulated_time() {
+        let mut rtc = Msm6242Rtc::default();
+        rtc.set_seed(Some(VECTOR_UNIX), false);
+
+        assert_eq!(read_reg(&mut rtc, 0x0), 9); // seconds ones
+        assert_eq!(read_reg(&mut rtc, 0x1), 2); // seconds tens
+        assert_eq!(read_reg(&mut rtc, 0x2), 8); // minutes ones
+        assert_eq!(read_reg(&mut rtc, 0x3), 5); // minutes tens
+        assert_eq!(read_reg(&mut rtc, 0x4), 1); // hours ones
+        assert_eq!(read_reg(&mut rtc, 0x5), 0); // hours tens
+        assert_eq!(read_reg(&mut rtc, 0x6), 8); // day ones
+        assert_eq!(read_reg(&mut rtc, 0x7), 1); // day tens
+        assert_eq!(read_reg(&mut rtc, 0x8), 3); // month ones
+        assert_eq!(read_reg(&mut rtc, 0x9), 0); // month tens
+        assert_eq!(read_reg(&mut rtc, 0xA), 5); // year ones
+        assert_eq!(read_reg(&mut rtc, 0xB), 0); // year tens
+        assert_eq!(read_reg(&mut rtc, 0xC), 5); // Friday
+
+        // 31 emulated seconds later the clock reads :00 of the next minute.
+        assert_eq!(read_reg_at(&mut rtc, 0x0, 31.0), 0);
+        assert_eq!(read_reg_at(&mut rtc, 0x2, 31.0), 9);
+        assert_eq!(rtc.current_unix(31.9), VECTOR_UNIX + 31);
+    }
+
+    #[test]
+    fn frozen_clock_never_advances() {
+        let mut rtc = Msm6242Rtc::default();
+        rtc.set_seed(Some(VECTOR_UNIX), true);
+        assert_eq!(read_reg_at(&mut rtc, 0x0, 3600.0), 9);
+        assert_eq!(rtc.current_unix(3600.0), VECTOR_UNIX);
+        assert_eq!(rtc.current_display(3600.0), "2005-03-18T01:58:29");
+    }
+
+    #[test]
+    fn reset_keeps_the_seed_but_drops_the_hold_latch() {
+        let mut rtc = Msm6242Rtc::default();
+        rtc.set_seed(Some(VECTOR_UNIX), false);
+        rtc.write(0xD * 4, 4, Msm6242Rtc::CD_HOLD as u64, 0.0);
+        rtc.reset();
+        assert_eq!(read_reg(&mut rtc, 0xD) & Msm6242Rtc::CD_HOLD, 0);
+        assert_eq!(read_reg_at(&mut rtc, 0x0, 5.0), 4); // still ticking from the seed
+        assert_eq!(rtc.seed(), Some(VECTOR_UNIX));
+    }
+
+    #[test]
+    fn parse_accepts_unix_seconds_and_calendar_forms() {
+        assert_eq!(parse_rtc_time("1111111109"), Ok(VECTOR_UNIX));
+        assert_eq!(parse_rtc_time("2005-03-18 01:58:29"), Ok(VECTOR_UNIX));
+        assert_eq!(parse_rtc_time("2005-03-18T01:58:29"), Ok(VECTOR_UNIX));
+        assert_eq!(parse_rtc_time("2005-03-18T01:58"), Ok(VECTOR_UNIX - 29));
+        assert_eq!(parse_rtc_time("1970-01-01 00:00:00"), Ok(0));
+    }
+
+    #[test]
+    fn parse_rejects_malformed_and_impossible_values() {
+        assert!(parse_rtc_time("").is_err());
+        assert!(parse_rtc_time("yesterday").is_err());
+        assert!(parse_rtc_time("2005-03-18").is_err()); // no time of day
+        assert!(parse_rtc_time("2005-13-01 00:00:00").is_err());
+        assert!(parse_rtc_time("2005-02-30 00:00:00").is_err());
+        assert!(parse_rtc_time("2005-03-18 24:00:00").is_err());
+        assert!(parse_rtc_time("1969-12-31 23:59:59").is_err());
+        assert!(parse_rtc_time("-100").is_err());
     }
 
     #[cfg(any(unix, windows))]

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -99,7 +99,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      sprite DMA fetches, last writer wins; the existing spr* fields
 //      remain the CPU/Copper write shadow the render replay is calibrated
 //      against)
-pub const STATE_VERSION: u32 = 28;
+//  29: Msm6242Rtc gained the deterministic clock seed (seed_unix, frozen -
+//      [machine] rtc_time / rtc_frozen), so a resumed run keeps reading
+//      the same guest-visible time
+pub const STATE_VERSION: u32 = 29;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
## What this is

A way to give the guest a known, reproducible clock. `[machine] rtc_time` (or `--rtc-time`) seeds the emulated MSM6242 battery clock with a power-on time -- Unix seconds (`1111111109`) or a calendar string (`"2005-03-18 01:58:29"`, exactly the wall-clock the guest reads) -- and the seeded clock then ticks with *emulated* time instead of mirroring the host wall clock. Every run boots to the same time and reads the same clock at the same emulated instant, on any host, byte-for-byte. `rtc_frozen` / `--rtc-frozen` additionally stops the tick so every read returns the seed exactly.

This came in as a feature request from AmiAuth: TOTP is time-dependent, an RTC-less A500 boots to an arbitrary date, and validating RFC 6238 time vectors (plus locale/manual offset logic) needs a deterministic guest clock. The hardware-first shape of that request is a battery clock that was set before power-on: setting a time implies fitting the clock (`rtc = true`), so even a base A500 profile can carry one, exactly like plugging in a clock-equipped trapdoor expansion.

## Design

- The seed is the clock's value at emulated time zero; register reads derive from `seed + elapsed emulated seconds` through the existing BCD register model. Unseeded machines keep the host-local view, and the `COPPERLINE_RTC_FIXED_SECS` diagnostic override still wins over both.
- `Msm6242Rtc::read/write` now take the emulated-seconds coordinate from the bus, so the chip has no host-clock dependency when seeded.
- Reset semantics follow the battery domain: a CPU reset no longer re-defaults the chip (only the bus-visible HOLD latch drops), so a guest-initiated `RESET` keeps the clock ticking across the preserved timeline. Host-initiated resets restart the emulated timeline and therefore restart a seeded clock from the seed -- deterministic from reset.
- Contradictions are loud: `rtc_time` with an explicit `rtc = false` is a config error, as is `rtc_frozen` without a time; malformed and impossible dates (Feb 30, pre-1970) are rejected by round-tripping the civil-calendar math.
- **Control protocol**: `rtc.get` reports `{present, seeded, frozen, unix, time}`; `rtc.set {unix | time | advance, frozen?}` moves the clock live -- absolute set, signed relative `advance` (step a TOTP window at a time), and freeze/unfreeze in place. Flagged `replay_unsafe` while time travel is armed, like `mem.write`. The guest only notices on its next battclock read, so the docs pair it with a warm reset or a guest-side `SetClock LOAD`.
- `STATE_VERSION` 28 -> 29 (`Msm6242Rtc` now serializes `seed_unix`/`frozen`), so resumed states keep reading the same guest time.

Docs in the same change: the `[machine]` chapter, a "deterministic guest clock" section in the headless guide (with the RFC 6238 example), the control.md method reference, `copperline.example.toml`, `AGENTS.md`, and `--help`. Guest-side contract documented: KS 2.0+ loads system time from the battery clock at boot on its own, KS 1.3 needs `SetClock LOAD`, and the chip's two-digit year registers mean AmigaOS's century window only reads back seeds in 1978-2077 faithfully.

## Testing

- 14 new tests, 1518 total green: seeded advance/freeze/reset-survival against the BCD registers, the `parse_rtc_time` notations and rejection cases, config validation (both notations, implied `rtc = true`, the contradiction errors, CLI override parity), and control-protocol parse + execute round trips (seed, freeze in place, advance, unfreeze).
- `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Verified end-to-end on a WB3.2 dirfs boot with the clock seeded to the RFC 6238 vector instant 1111111109: the guest's own `Date` prints **Friday 18-Mar-05 01:58:30** (seed + one emulated boot second) with no `SetClock` in the startup-sequence; two runs produce byte-identical screenshots; with `--rtc-frozen` the guest reads **01:58:29** exactly. `rtc.get`/`rtc.set` (absolute, advance+freeze, unfreeze, param-conflict errors) exercised over a live `copperline-ctl` session.
- No timing-model changes: no golden-probe re-bless needed.

## Known limits

Guest writes to the chip's time registers still don't set the clock (the documented read-only-view semantics) -- honoring them in seeded mode would be the natural follow-up if anyone needs to test the `SetClock SAVE` path. The launcher's configuration screen doesn't surface `rtc_time`, consistent with the other specialist knobs it omits.
