### PR TITLE
Add streaming CCP observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ against real hardware.
   interactive chip-bus frame analyzer, a trigger-based VCD waveform export
   of the chipset signals for GTKWave (`docs/debugger/waveform.md`), remote
   GDB support, a JSON-RPC control protocol for scripts and AI agents
-  (`docs/debugger/control.md`, with the `copperline-ctl` client),
+  (`docs/debugger/control.md`, with the `copperline-ctl` client and bounded
+  frame/serial/interrupt/media event streams),
   deterministic save states, input recording/replay, and
   headless screenshot/frame-dump capture -- the deterministic core makes
   every replay byte-identical.

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -121,6 +121,67 @@ and where a host-timed `pause` lands is inherently wall-clock, like a
 GDB Ctrl-C. Every deterministic stop condition is detected by the core
 per instruction regardless of how often the server polls the socket.
 
+## Streaming observability
+
+An authenticated connection can subscribe to low-overhead machine events:
+
+```text
+# In copperline-ctl --repl (subscriptions live for this connection):
+events.subscribe {"events":["frame","serial","interrupt","media"],"frame_interval":50,"frame_digest":true}
+events.list
+events.unsubscribe {"events":["serial"]}
+events.unsubscribe
+```
+
+`events.subscribe` adds the named families to the connection's current set.
+`frame_interval` is 1--1,000,000 completed frames (default 1), and
+`frame_digest` adds the same FNV-1a framebuffer result as
+`capture.digest` to each `event.frame`; leave it off when the pixels are
+not relevant because rendering and hashing every selected frame has a cost.
+`events.unsubscribe` removes the named families, or all of them when
+`events` is omitted. `events.list` returns `supported`, `active`, the frame
+options, buffer limits, and the cumulative `dropped_notifications` count.
+
+Subscriptions are per connection, so use `copperline-ctl --repl`, a client
+library, or a raw long-lived socket rather than separate one-shot client
+invocations. Both headless and windowed servers send JSON-RPC notifications
+without an `id`:
+
+- `event.frame`: current timeline `position`, `previous_frame`, and optional
+  `digest`.
+- `event.serial`: a batch of completed Paula transmissions as
+  `{word, long, at_cck}`, plus `dropped_words`. The tap observes output in
+  parallel with the configured serial sink; it does not replace or delay it.
+- `event.interrupt`: `previous` and `current` INTENA, raw INTREQ,
+  CPU-visible INTREQ, and enabled-pending values, plus raw-source `asserted`
+  and `cleared` masks.
+- `event.media`: floppy or CD `inserted`/`ejected`; floppy events also carry
+  the drive number and inserted image name.
+
+Every payload includes a deterministic `position` (`frame`, `cck`,
+`seconds`, beam position, PC, and retired-instruction count). Interrupt
+changes are coalesced between CCP sampling boundaries: instruction boundaries
+for an explicit instruction step, otherwise the running driver's quantum
+(normally one frame). Use register watches or a VCD waveform when every
+within-frame transition matters.
+
+Streaming is bounded. Paula retains at most 4,096 unconsumed serial words,
+evicts the oldest on overflow, and reports the count in `dropped_words`.
+The windowed socket path queues at most 256 stream notifications and drops
+new notifications rather than blocking the emulator; the next delivered
+event and `events.list` expose the cumulative drop count. Headless delivery
+writes events directly and detaches a client that stops draining the socket.
+
+The same connection can start and stop the heavier file-backed diagnostics
+when an event identifies an interesting window. `trace.start {path?,
+max_lines?}` writes a disassembled instruction trace (default cap 1,000,000;
+maximum 10,000,000), with `trace.status` and `trace.stop`. `waveform.start
+{path?, trigger?, duration?, signals?}` accepts the same trigger, duration,
+and signal strings as the command-line VCD exporter, with
+`waveform.status` and `waveform.stop`. Their replies report the output path,
+progress, and final sample/line count; the actual trace remains in the host
+file rather than being pushed through the bounded notification stream.
+
 ## Method reference
 
 Session: `hello {token?}`, `auth {token}`, `status`, `shutdown`.
@@ -178,6 +239,15 @@ Media: `media.floppy.insert {drive, path, write_protected?}`,
 `media.floppy.eject {drive}`, `media.floppy.query`,
 `media.cd.insert {path}`, `media.cd.eject`.
 
+Streaming: `events.subscribe {events, frame_interval?, frame_digest?}`,
+`events.unsubscribe {events?}`, `events.list`. Event names are `frame`,
+`serial`, `interrupt`, and `media`; see
+[Streaming observability](#streaming-observability).
+
+Diagnostic captures: `trace.start {path?, max_lines?}`, `trace.status`,
+`trace.stop`; `waveform.start {path?, trigger?, duration?, signals?}`,
+`waveform.status`, `waveform.stop`.
+
 State and capture: `state.save {path}`, `state.load {path}` (re-arms
 the reverse-debug ring on the loaded timeline), `capture.screenshot
 {path?}` (raw framebuffer PNG, 716 pixels wide), `capture.digest`
@@ -185,9 +255,11 @@ the reverse-debug ring on the loaded timeline), `capture.screenshot
 primitive, identical in both server modes), `machine.reset
 {kind: "warm"|"cold"}`.
 
-Notifications (windowed mode; no `id`): `event.stopped` fires when the
-machine stops without a pending resume -- a GUI breakpoint, a user
-pause, a guru/double fault -- so an attached client can follow along.
+Notifications have no `id`. The subscribed `event.frame`, `event.serial`,
+`event.interrupt`, and `event.media` streams work in both server modes.
+Additionally, windowed mode sends `event.stopped` when the machine stops
+without a pending resume -- a GUI breakpoint, a user pause, or a
+guru/double fault -- so an attached client can follow along.
 
 ## Errors
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -169,8 +169,11 @@ Streaming is bounded. Paula retains at most 4,096 unconsumed serial words,
 evicts the oldest on overflow, and reports the count in `dropped_words`.
 The windowed socket path queues at most 256 stream notifications and drops
 new notifications rather than blocking the emulator; the next delivered
-event and `events.list` expose the cumulative drop count. Headless delivery
-writes events directly and detaches a client that stops draining the socket.
+event and `events.list` expose the cumulative drop count. If that bounded
+queue cannot accept a required request reply, the server detaches the slow
+client rather than blocking emulation or silently losing the reply. Headless
+delivery writes events directly and detaches a client that stops draining the
+socket.
 
 The same connection can start and stop the heavier file-backed diagnostics
 when an event identifies an interesting window. `trace.start {path?,

--- a/docs/debugger/waveform.md
+++ b/docs/debugger/waveform.md
@@ -37,6 +37,14 @@ WAVE            (status)
 WAVE STOP       (finish early)
 ```
 
+From a live [CCP control session](control.md), using the same spec strings:
+
+```text
+waveform.start {"path":"out.vcd","trigger":"pc=0x00C033C2","duration":"20000cck","signals":"cpu,bus,copper,blitter"}
+waveform.status
+waveform.stop
+```
+
 From the debugger window (`Cmd/Alt+B`): the **Wave** tab has Arm and Stop
 buttons; type the same order-free spec into the entry box (empty means all
 defaults) and click Arm.

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -301,6 +301,14 @@ Paula's per-tick UART step takes an idle fast path that skips the receiver
 entirely while it reports false -- the TCP and pty sinks poll a counter
 there, never a syscall.
 
+CCP serial observability is a host-side tap beside `SerialSink`, not another
+serial device. When a control connection subscribes, each successfully
+completed transmit word is copied into a 4,096-entry `VecDeque`; the normal
+sink receives the same word immediately. Overflow evicts and counts the
+oldest observation, so a debugger cannot back-pressure Paula. The tap is
+skipped by serde and carried across state loads with the live serial/audio
+sinks; disconnecting or unsubscribing removes it.
+
 ## MIDI serial bridge (`midi/`)
 
 `[serial] mode = "midi"` (or `--midi-out`/`--midi-in`) bridges Paula's

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -35,10 +35,12 @@ What is captured:
 
 Deliberately excluded, with the mechanism in parentheses:
 
-- **Host sinks**: Paula's `Box<dyn SerialSink>` / `Box<dyn AudioSink>`
-  (`#[serde(skip, default = ...)]` producing inert null sinks). On load,
-  `Bus::adopt_host_resources` moves the live sinks from the old Bus onto
-  the restored one, so audio output continues uninterrupted.
+- **Host sinks and taps**: Paula's `Box<dyn SerialSink>` /
+  `Box<dyn AudioSink>` and the bounded CCP serial-observation tap
+  (`#[serde(skip)]`; the sink defaults produce inert null devices). On load,
+  `Bus::adopt_host_resources` moves the live sinks and tap from the old Bus
+  onto the restored one, so output and an active subscription continue
+  uninterrupted.
 - **Diagnostic host state**: the `COPPERLINE_TRACE_BLITTER` file handle
   (skipped, moved across like the sinks), the debugger and its
   breakpoints/watchpoints (never serialized; they stay armed across a

--- a/src/bin/copperline-ctl.rs
+++ b/src/bin/copperline-ctl.rs
@@ -20,7 +20,7 @@
 
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
-use std::net::TcpStream;
+use std::net::{Shutdown, TcpStream};
 use std::process::ExitCode;
 
 struct Options {
@@ -94,7 +94,7 @@ fn parse_options() -> Result<Options, String> {
 }
 
 struct Client {
-    reader: BufReader<TcpStream>,
+    reader: Option<BufReader<TcpStream>>,
     writer: TcpStream,
     next_id: u64,
 }
@@ -109,7 +109,7 @@ impl Client {
                 .map_err(|e| format!("cloning stream: {e}"))?,
         );
         Ok(Self {
-            reader,
+            reader: Some(reader),
             writer: stream,
             next_id: 1,
         })
@@ -134,6 +134,8 @@ impl Client {
             let mut line = String::new();
             let n = self
                 .reader
+                .as_mut()
+                .expect("client reader already moved to REPL")
                 .read_line(&mut line)
                 .map_err(|e| format!("reading response: {e}"))?;
             if n == 0 {
@@ -170,6 +172,111 @@ impl Client {
             Err(format!("auth failed: {msg}"))
         }
     }
+
+    /// Run the interactive client with a dedicated socket reader. Keeping the
+    /// reader active while stdin waits at the prompt is what makes subscribed
+    /// notifications genuinely streaming rather than merely piggybacking on
+    /// the next request/response round trip.
+    fn run_repl(mut self) -> Result<(), String> {
+        let reader = self
+            .reader
+            .take()
+            .expect("client reader already moved to REPL");
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        let reader_thread = std::thread::Builder::new()
+            .name("copperline-ctl-read".into())
+            .spawn(move || read_repl_messages(reader, response_tx))
+            .map_err(|e| format!("starting response reader: {e}"))?;
+
+        let mut result = Ok(());
+        let stdin = std::io::stdin();
+        for line in stdin.lock().lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(e) => {
+                    result = Err(format!("reading command: {e}"));
+                    break;
+                }
+            };
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (method, rest) = match line.split_once(char::is_whitespace) {
+                Some((method, rest)) => (method, rest.trim()),
+                None => (line, ""),
+            };
+            let params: Value = if rest.is_empty() {
+                Value::Null
+            } else {
+                match serde_json::from_str(rest) {
+                    Ok(params) => params,
+                    Err(e) => {
+                        eprintln!("params must be JSON: {e}");
+                        continue;
+                    }
+                }
+            };
+            let id = match self.send(method, &params) {
+                Ok(id) => id,
+                Err(e) => {
+                    result = Err(e);
+                    break;
+                }
+            };
+            loop {
+                match response_rx.recv() {
+                    Ok(Ok(response_id)) if response_id == id => break,
+                    Ok(Ok(_)) => {} // no pipelining today, but tolerate it
+                    Ok(Err(e)) => {
+                        result = Err(e);
+                        break;
+                    }
+                    Err(_) => {
+                        result = Err("server response reader stopped".to_string());
+                        break;
+                    }
+                }
+            }
+            if result.is_err() {
+                break;
+            }
+        }
+
+        let _ = self.writer.shutdown(Shutdown::Both);
+        if reader_thread.join().is_err() && result.is_ok() {
+            result = Err("server response reader panicked".to_string());
+        }
+        result
+    }
+}
+
+fn read_repl_messages(
+    mut reader: impl BufRead,
+    response_tx: std::sync::mpsc::Sender<Result<u64, String>>,
+) {
+    loop {
+        let mut line = String::new();
+        let message = match reader.read_line(&mut line) {
+            Ok(0) => Err("server closed the connection".to_string()),
+            Ok(_) => serde_json::from_str::<Value>(line.trim())
+                .map_err(|e| format!("bad server message: {e}")),
+            Err(e) => Err(format!("reading response: {e}")),
+        };
+        let message = match message {
+            Ok(message) => message,
+            Err(error) => {
+                let _ = response_tx.send(Err(error));
+                return;
+            }
+        };
+        println!("{message}");
+        if let Some(id) = message.get("id").and_then(Value::as_u64) {
+            if response_tx.send(Ok(id)).is_err() {
+                return;
+            }
+        }
+    }
 }
 
 fn main() -> ExitCode {
@@ -195,37 +302,12 @@ fn main() -> ExitCode {
         }
     }
     if options.repl {
-        let stdin = std::io::stdin();
-        for line in stdin.lock().lines() {
-            let Ok(line) = line else { break };
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-            let (method, rest) = match line.split_once(char::is_whitespace) {
-                Some((method, rest)) => (method, rest.trim()),
-                None => (line, ""),
-            };
-            let params: Value = if rest.is_empty() {
-                Value::Null
-            } else {
-                match serde_json::from_str(rest) {
-                    Ok(params) => params,
-                    Err(e) => {
-                        eprintln!("params must be JSON: {e}");
-                        continue;
-                    }
-                }
-            };
-            match client.call(method, &params) {
-                Ok(_) => {}
-                Err(message) => {
-                    eprintln!("{message}");
-                    return ExitCode::FAILURE;
-                }
-            }
+        if let Err(message) = client.run_repl() {
+            eprintln!("{message}");
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
         }
-        ExitCode::SUCCESS
     } else {
         let method = options.method.as_deref().expect("checked in parsing");
         match client.call(method, &options.params) {
@@ -251,5 +333,20 @@ mod tests {
         let line = msg.to_string();
         assert!(line.contains("\"jsonrpc\":\"2.0\""));
         assert!(line.contains("\"method\":\"status\""));
+    }
+
+    #[test]
+    fn repl_reader_prints_notifications_and_reports_only_response_ids() {
+        let input = concat!(
+            "{\"jsonrpc\":\"2.0\",\"method\":\"event.frame\",\"params\":{}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{}}\n",
+        );
+        let (tx, rx) = std::sync::mpsc::channel();
+        read_repl_messages(std::io::Cursor::new(input), tx);
+        assert_eq!(rx.recv().unwrap(), Ok(7));
+        assert_eq!(
+            rx.recv().unwrap(),
+            Err("server closed the connection".to_string())
+        );
     }
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2973,11 +2973,15 @@ impl Bus {
 
     /// Move the host-side resources that a save state does not capture from
     /// the currently live Bus into this freshly deserialized one: the Paula
-    /// audio/serial sinks and the open blitter trace file. The realtime
+    /// audio/serial sinks, serial observer, and the open blitter trace file. The realtime
     /// device-clock anchor needs no carry-over -- it deserializes as None
     /// and `realtime_cck_due` re-anchors to the host clock on first use.
     pub(crate) fn adopt_host_resources(&mut self, live: &mut Bus) {
         std::mem::swap(&mut self.paula.serial, &mut live.paula.serial);
+        std::mem::swap(
+            &mut self.paula.serial_observer,
+            &mut live.paula.serial_observer,
+        );
         std::mem::swap(&mut self.paula.audio, &mut live.paula.audio);
         self.blitter_trace = live.blitter_trace.take();
     }

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -301,6 +301,10 @@ pub struct Paula {
     // loader moves the live sinks across to the restored Paula.
     #[serde(skip, default = "null_serial_sink")]
     pub serial: Box<dyn SerialSink>,
+    /// Optional debugger tap for completed transmissions. Host-only: save
+    /// states carry it over from the live machine like the serial sink.
+    #[serde(skip)]
+    pub(crate) serial_observer: Option<crate::serial::SerialObserver>,
     #[serde(skip, default = "null_audio_sink")]
     pub audio: Box<dyn AudioSink>,
     pub adkcon: u16,
@@ -383,6 +387,7 @@ impl Paula {
             intena: 0,
             intreq: 0,
             serial,
+            serial_observer: None,
             audio,
             adkcon: 0,
             potgo: 0,
@@ -439,6 +444,20 @@ impl Paula {
             Some(buf) => std::mem::take(buf),
             None => Vec::new(),
         }
+    }
+
+    /// Enable or disable the bounded host-side serial transmit tap.
+    pub fn set_serial_observation_enabled(&mut self, enabled: bool) {
+        self.serial_observer = enabled.then(crate::serial::SerialObserver::default);
+    }
+
+    /// Drain transmissions completed since the last poll, plus the number of
+    /// oldest records evicted because the observer was not drained in time.
+    pub fn take_serial_observations(&mut self) -> (Vec<crate::serial::SerialTxObservation>, u64) {
+        self.serial_observer
+            .as_mut()
+            .map(crate::serial::SerialObserver::drain)
+            .unwrap_or_default()
     }
 
     /// Developer mute for one audio channel (debugger audio tab). Toggling
@@ -842,11 +861,15 @@ impl Paula {
                     if !shift.break_seen && !self.uart_break_active() {
                         // Stop bit done: this many clocks are left of the span.
                         let at_cck = end_cck.saturating_sub(u64::from(remaining));
-                        self.serial.write_word(
-                            Self::serial_tx_data_word(&shift),
-                            shift.long,
-                            at_cck,
-                        );
+                        let word = Self::serial_tx_data_word(&shift);
+                        if let Some(observer) = self.serial_observer.as_mut() {
+                            observer.push(crate::serial::SerialTxObservation {
+                                word,
+                                long: shift.long,
+                                at_cck,
+                            });
+                        }
+                        self.serial.write_word(word, shift.long, at_cck);
                     }
                     self.serial_tx_pin_high = true;
                     irq |= self.load_serial_shift_if_idle();
@@ -2854,6 +2877,22 @@ mod tests {
         assert_eq!(word_b, 0x41);
         assert!(at0 > 0, "emit time should be before the span end");
         assert_eq!(at_b, at0 + 5000, "the span end offsets the emit time");
+    }
+
+    #[test]
+    fn serial_observer_taps_completed_words_without_replacing_the_sink() {
+        let (mut paula, written, _) = paula_with_collect_serial_words();
+        paula.set_serial_observation_enabled(true);
+        assert_eq!(paula.write_serdat(0x0141), INT_TBE);
+        assert_eq!(paula.tick_serial(10, 100), 0);
+
+        assert_eq!(&*written.lock().unwrap(), &[(0x0041, false)]);
+        let (observations, dropped) = paula.take_serial_observations();
+        assert_eq!(dropped, 0);
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].word, 0x0041);
+        assert!(!observations[0].long);
+        assert_eq!(observations[0].at_cck, 100);
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -23,6 +23,7 @@
 
 pub mod exec;
 pub mod headless;
+pub mod observe;
 pub mod proto;
 pub mod session;
 pub mod windowed;

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -8,6 +8,7 @@
 //! debugger window, console, and GDB stub already share; there is no
 //! second debugger implementation.
 
+use super::observe::{EventKind, MAX_FRAME_INTERVAL};
 use super::proto::{self, CtlError, StopEvent};
 use super::session::{BreakSpec, InputAction, SessionCtx};
 use crate::debugger::{BreakCond, CondOp, CondOperand, DebugStop, WatchSource};
@@ -30,6 +31,9 @@ pub const RUN_BUDGET: usize = 5_000_000;
 /// so the stop lands at the first instruction boundary at or past the
 /// target.
 pub const CCK_FINE_WINDOW: u64 = 80_000;
+
+const DEFAULT_TRACE_LINE_CAP: u64 = 1_000_000;
+const MAX_TRACE_LINE_CAP: u64 = 10_000_000;
 
 /// A parsed request, split by which layer executes it.
 #[derive(Debug, Clone, PartialEq)]
@@ -91,6 +95,26 @@ pub enum CoreOp {
     BreakList,
     BreakClear,
     FloppyQuery,
+    EventsSubscribe {
+        events: Vec<EventKind>,
+        frame_interval: Option<u64>,
+        frame_digest: Option<bool>,
+    },
+    EventsUnsubscribe {
+        events: Option<Vec<EventKind>>,
+    },
+    EventsList,
+    TraceStart {
+        path: PathBuf,
+        max_lines: u64,
+    },
+    TraceStop,
+    TraceStatus,
+    WaveformStart {
+        options: crate::waveform::WaveOptions,
+    },
+    WaveformStop,
+    WaveformStatus,
     StateSave {
         path: PathBuf,
     },
@@ -138,6 +162,9 @@ impl CoreOp {
                 | CoreOp::PcHistory
                 | CoreOp::BreakList
                 | CoreOp::FloppyQuery
+                | CoreOp::EventsList
+                | CoreOp::TraceStatus
+                | CoreOp::WaveformStatus
                 | CoreOp::Digest
                 | CoreOp::Screenshot { .. }
         )
@@ -535,6 +562,71 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             path: PathBuf::from(p.str_req("path")?),
         }),
         "media.cd.eject" => host(HostOp::CdEject),
+        "events.subscribe" => {
+            let events = parse_event_list(&p, true)?.expect("required event list");
+            let frame_interval = p.u64_opt("frame_interval")?;
+            if frame_interval.is_some_and(|interval| interval == 0 || interval > MAX_FRAME_INTERVAL)
+            {
+                return Err(CtlError::invalid_params(format!(
+                    "frame_interval must be 1..={MAX_FRAME_INTERVAL}"
+                )));
+            }
+            core(CoreOp::EventsSubscribe {
+                events,
+                frame_interval,
+                frame_digest: p.bool_opt("frame_digest")?,
+            })
+        }
+        "events.unsubscribe" => core(CoreOp::EventsUnsubscribe {
+            events: parse_event_list(&p, false)?,
+        }),
+        "events.list" => core(CoreOp::EventsList),
+        "trace.start" => {
+            let max_lines = p.u64_opt("max_lines")?.unwrap_or(DEFAULT_TRACE_LINE_CAP);
+            if max_lines == 0 || max_lines > MAX_TRACE_LINE_CAP {
+                return Err(CtlError::invalid_params(format!(
+                    "max_lines must be 1..={MAX_TRACE_LINE_CAP}"
+                )));
+            }
+            core(CoreOp::TraceStart {
+                path: p
+                    .str_opt("path")?
+                    .map(PathBuf::from)
+                    .unwrap_or_else(default_trace_path),
+                max_lines,
+            })
+        }
+        "trace.stop" => core(CoreOp::TraceStop),
+        "trace.status" => core(CoreOp::TraceStatus),
+        "waveform.start" => {
+            let mut options = crate::waveform::WaveOptions::new(
+                p.str_opt("path")?
+                    .map(PathBuf::from)
+                    .unwrap_or_else(crate::waveform::default_wave_path),
+            );
+            if let Some(trigger) = p.str_opt("trigger")? {
+                options.trigger = crate::waveform::parse_trigger(&trigger).ok_or_else(|| {
+                    CtlError::invalid_params(
+                        "bad trigger; expected now|pc=ADDR|beam=VPOS[:HPOS]|reg=OFF|time=SECS",
+                    )
+                })?;
+            }
+            if let Some(duration) = p.str_opt("duration")? {
+                options.duration = crate::waveform::parse_duration(&duration).ok_or_else(|| {
+                    CtlError::invalid_params("bad duration; expected Ncck|Nf|Nframes|Nms|Ns")
+                })?;
+            }
+            if let Some(signals) = p.str_opt("signals")? {
+                options.signals = crate::waveform::parse_signals(&signals).ok_or_else(|| {
+                    CtlError::invalid_params(
+                        "bad signals; expected beam,bus,cpu,copper,blitter,regs,irq,audio|all",
+                    )
+                })?;
+            }
+            core(CoreOp::WaveformStart { options })
+        }
+        "waveform.stop" => core(CoreOp::WaveformStop),
+        "waveform.status" => core(CoreOp::WaveformStatus),
         "state.save" => core(CoreOp::StateSave {
             path: PathBuf::from(p.str_req("path")?),
         }),
@@ -558,6 +650,43 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         }),
         other => Err(CtlError::method_not_found(other)),
     }
+}
+
+fn parse_event_list(
+    p: &ParamReader<'_>,
+    required: bool,
+) -> Result<Option<Vec<EventKind>>, CtlError> {
+    let Some(value) = p.get("events") else {
+        return if required {
+            Err(CtlError::invalid_params("missing events"))
+        } else {
+            Ok(None)
+        };
+    };
+    if value.is_null() && !required {
+        return Ok(None);
+    }
+    let Some(items) = value.as_array() else {
+        return Err(CtlError::invalid_params("events must be an array"));
+    };
+    if items.is_empty() {
+        return Err(CtlError::invalid_params("events must not be empty"));
+    }
+    let mut events = Vec::with_capacity(items.len());
+    for item in items {
+        let Some(name) = item.as_str() else {
+            return Err(CtlError::invalid_params("event names must be strings"));
+        };
+        let Some(event) = EventKind::from_name(name) else {
+            return Err(CtlError::invalid_params(format!(
+                "unknown event {name}; expected frame|serial|interrupt|media"
+            )));
+        };
+        if !events.contains(&event) {
+            events.push(event);
+        }
+    }
+    Ok(Some(events))
 }
 
 fn resume(kind: ResumeKind, p: &ParamReader) -> Result<Request, CtlError> {
@@ -1168,22 +1297,49 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 .collect();
             Ok(json!({"drives": drives}))
         }
+        CoreOp::EventsSubscribe {
+            events,
+            frame_interval,
+            frame_digest,
+        } => Ok(ctx.subscribe_events(emu, events, *frame_interval, *frame_digest)),
+        CoreOp::EventsUnsubscribe { events } => Ok(ctx.unsubscribe_events(emu, events.as_deref())),
+        CoreOp::EventsList => Ok(ctx.event_subscriptions()),
+        CoreOp::TraceStart { path, max_lines } => {
+            emu.machine
+                .ui_trace_start(path.clone(), *max_lines)
+                .map_err(|e| CtlError::io(format!("starting instruction trace: {e}")))?;
+            Ok(trace_status_value(emu))
+        }
+        CoreOp::TraceStop => match emu.machine.ui_trace_stop() {
+            Some((path, lines)) => Ok(json!({
+                "active": false,
+                "path": path.display().to_string(),
+                "lines": lines,
+            })),
+            None => Ok(json!({"active": false})),
+        },
+        CoreOp::TraceStatus => Ok(trace_status_value(emu)),
+        CoreOp::WaveformStart { options } => {
+            emu.machine
+                .ui_wave_start(options.clone())
+                .map_err(|e| CtlError::io(format!("starting waveform capture: {e}")))?;
+            Ok(waveform_status_value(emu))
+        }
+        CoreOp::WaveformStop => match emu.machine.ui_wave_stop() {
+            Some(status) => Ok(json!({
+                "active": false,
+                "present": false,
+                "capture": wave_status_value(&status),
+            })),
+            None => Ok(json!({"active": false, "present": false})),
+        },
+        CoreOp::WaveformStatus => Ok(waveform_status_value(emu)),
         CoreOp::StateSave { path } => {
             emu.save_state(path)
                 .map_err(|e| CtlError::io(format!("saving state: {e:#}")))?;
             Ok(json!({"path": path.display().to_string()}))
         }
-        CoreOp::Digest => {
-            let (fb, lines) = render_frame(emu);
-            let digest = fnv1a64(&fb[..FB_WIDTH * lines]);
-            Ok(json!({
-                "algo": "fnv1a64",
-                "digest": format!("{digest:016x}"),
-                "width": FB_WIDTH,
-                "height": lines,
-                "frame": emu.bus().emulated_frames(),
-            }))
-        }
+        CoreOp::Digest => Ok(digest_value(emu)),
         CoreOp::Screenshot { path } => {
             let (fb, lines) = render_frame(emu);
             let path = path
@@ -1427,6 +1583,49 @@ fn push_id(entry: &mut Value, id: Option<u32>) {
     }
 }
 
+fn default_trace_path() -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    PathBuf::from(format!("copperline-trace-{stamp}.txt"))
+}
+
+fn trace_status_value(emu: &Emulator) -> Value {
+    match emu.machine.ui_trace_status() {
+        Some((path, lines)) => json!({
+            "active": true,
+            "path": path.display().to_string(),
+            "lines": lines,
+        }),
+        None => json!({"active": false}),
+    }
+}
+
+fn waveform_status_value(emu: &Emulator) -> Value {
+    match emu.machine.ui_wave_status() {
+        Some(status) => json!({
+            "active": matches!(status.state, "armed" | "capturing"),
+            "present": true,
+            "capture": wave_status_value(&status),
+        }),
+        None => json!({"active": false, "present": false}),
+    }
+}
+
+fn wave_status_value(status: &crate::waveform::WaveStatus) -> Value {
+    json!({
+        "path": status.path.display().to_string(),
+        "state": status.state,
+        "trigger": status.trigger,
+        "duration": status.duration,
+        "signals": status.signals,
+        "samples": status.samples,
+        "captured_cck": status.captured_cck,
+        "window_cck": status.window_cck,
+    })
+}
+
 /// Render the current frame into a fresh buffer via the side-effect-free
 /// display path, returning the buffer and its visible line count. Both
 /// `capture.digest` and `capture.screenshot` use this in BOTH server
@@ -1449,6 +1648,20 @@ fn fnv1a64(words: &[u32]) -> u64 {
         }
     }
     hash
+}
+
+/// Frame digest payload shared by the request/response capture method and the
+/// opt-in streaming frame notification.
+pub(crate) fn digest_value(emu: &Emulator) -> Value {
+    let (fb, lines) = render_frame(emu);
+    let digest = fnv1a64(&fb[..FB_WIDTH * lines]);
+    json!({
+        "algo": "fnv1a64",
+        "digest": format!("{digest:016x}"),
+        "width": FB_WIDTH,
+        "height": lines,
+        "frame": emu.bus().emulated_frames(),
+    })
 }
 
 #[cfg(test)]
@@ -1546,6 +1759,128 @@ mod tests {
     fn parse_unknown_method_reports_method_not_found() {
         let err = parse_method("warp.nine", &Value::Null).unwrap_err();
         assert_eq!(err.code, proto::METHOD_NOT_FOUND);
+    }
+
+    #[test]
+    fn parse_event_subscriptions_validates_names_and_interval() {
+        assert_eq!(
+            core(
+                "events.subscribe",
+                json!({
+                    "events": ["frame", "serial", "frame"],
+                    "frame_interval": 25,
+                    "frame_digest": true,
+                }),
+            ),
+            CoreOp::EventsSubscribe {
+                events: vec![EventKind::Frame, EventKind::Serial],
+                frame_interval: Some(25),
+                frame_digest: Some(true),
+            }
+        );
+        assert_eq!(
+            core("events.unsubscribe", json!({})),
+            CoreOp::EventsUnsubscribe { events: None }
+        );
+        for params in [
+            json!({}),
+            json!({"events": ["unknown"]}),
+            json!({"events": ["frame"], "frame_interval": 0}),
+            json!({"events": ["frame"], "frame_interval": MAX_FRAME_INTERVAL + 1}),
+        ] {
+            assert!(parse_method("events.subscribe", &params).is_err());
+        }
+    }
+
+    #[test]
+    fn parse_trace_and_waveform_controls_validate_bounds_and_specs() {
+        assert_eq!(
+            core(
+                "trace.start",
+                json!({"path": "/tmp/trace.txt", "max_lines": 123}),
+            ),
+            CoreOp::TraceStart {
+                path: PathBuf::from("/tmp/trace.txt"),
+                max_lines: 123,
+            }
+        );
+        assert_eq!(
+            core(
+                "waveform.start",
+                json!({
+                    "path": "/tmp/wave.vcd",
+                    "trigger": "beam=100:64",
+                    "duration": "2f",
+                    "signals": "cpu,bus",
+                }),
+            ),
+            CoreOp::WaveformStart {
+                options: crate::waveform::WaveOptions {
+                    path: PathBuf::from("/tmp/wave.vcd"),
+                    trigger: crate::waveform::Trigger::Beam {
+                        vpos: 100,
+                        hpos: Some(64),
+                    },
+                    duration: crate::waveform::WaveDuration::Frames(2),
+                    signals: crate::waveform::parse_signals("cpu,bus").unwrap(),
+                },
+            }
+        );
+        for (method, params) in [
+            ("trace.start", json!({"max_lines": 0})),
+            ("waveform.start", json!({"trigger": "later"})),
+            ("waveform.start", json!({"duration": "forever"})),
+            ("waveform.start", json!({"signals": "cpu,mystery"})),
+        ] {
+            assert!(parse_method(method, &params).is_err());
+        }
+    }
+
+    #[test]
+    fn trace_and_waveform_controls_create_report_and_finish_files() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        let dir = std::env::temp_dir().join(format!("ccp-captures-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let trace_path = dir.join("instructions.txt");
+        let started = exec_core(
+            &mut emu,
+            &mut ctx,
+            &CoreOp::TraceStart {
+                path: trace_path.clone(),
+                max_lines: 100,
+            },
+        )
+        .unwrap();
+        assert_eq!(started["active"], true);
+        assert_eq!(
+            exec_core(&mut emu, &mut ctx, &CoreOp::TraceStatus).unwrap()["active"],
+            true
+        );
+        let stopped = exec_core(&mut emu, &mut ctx, &CoreOp::TraceStop).unwrap();
+        assert_eq!(stopped["active"], false);
+        assert!(trace_path.exists());
+
+        let wave_path = dir.join("signals.vcd");
+        let started = exec_core(
+            &mut emu,
+            &mut ctx,
+            &CoreOp::WaveformStart {
+                options: crate::waveform::WaveOptions::new(wave_path.clone()),
+            },
+        )
+        .unwrap();
+        assert_eq!(started["active"], true);
+        assert_eq!(started["capture"]["state"], "capturing");
+        let stopped = exec_core(&mut emu, &mut ctx, &CoreOp::WaveformStop).unwrap();
+        assert_eq!(stopped["active"], false);
+        assert_eq!(stopped["capture"]["state"], "done");
+        assert!(wave_path.exists());
+
+        std::fs::remove_file(trace_path).ok();
+        std::fs::remove_file(wave_path).ok();
+        std::fs::remove_dir(dir).ok();
     }
 
     #[test]

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -230,6 +230,9 @@ impl Session {
         recorder: Option<InputRecorder>,
     ) -> Self {
         let reader = LineReader::new(stream.try_clone().expect("cloning control stream"));
+        stream
+            .set_write_timeout(Some(Duration::from_millis(250)))
+            .ok();
         let mut ctx = SessionCtx::new();
         ctx.recorder = recorder;
         Self {
@@ -259,6 +262,7 @@ impl Session {
     /// Remove everything this session installed and drain any pending
     /// stop, so a stale hit cannot ambush the next client.
     fn teardown(&mut self) {
+        self.ctx.disable_events(&mut self.emu);
         self.ctx.remove_all_breaks(&mut self.emu);
         self.emu.bus_mut().ui_disarm_beam_trap_once();
         while self.emu.machine.take_ui_debug_stop().is_some() {}
@@ -266,6 +270,14 @@ impl Session {
 
     fn write(&mut self, line: &str) -> io::Result<()> {
         proto::write_line(&mut self.writer, line)
+    }
+
+    fn emit_events(&mut self) -> Result<()> {
+        let lines = self.ctx.poll_events(&mut self.emu);
+        for line in lines {
+            self.write(&line)?;
+        }
+        Ok(())
     }
 
     fn handle_line(&mut self, line: &str) -> Result<Option<SessionEnd>> {
@@ -308,9 +320,16 @@ impl Session {
                     Err(err) => proto::err_line(&req.id, &err),
                 };
                 self.write(&reply)?;
+                self.emit_events()?;
                 Ok(None)
             }
-            Request::Host(op) => self.dispatch_host(req.id, op),
+            Request::Host(op) => {
+                let end = self.dispatch_host(req.id, op)?;
+                if end.is_none() {
+                    self.emit_events()?;
+                }
+                Ok(end)
+            }
         }
     }
 
@@ -510,6 +529,7 @@ impl Session {
                 for _ in 0..*n {
                     self.emu.debug_step_for_gdb(&mut cpu_idle)?;
                     self.ctx.apply_due_scheduled(&mut self.emu);
+                    self.emit_events()?;
                     if let Some((reason, detail)) = self.take_stop() {
                         return stop(reason, detail);
                     }
@@ -518,14 +538,17 @@ impl Session {
             }
             ResumeKind::StepOver => {
                 self.emu.debug_step_over(RUN_BUDGET)?;
+                self.emit_events()?;
                 return self.bounded_result("stepped over");
             }
             ResumeKind::StepOut => {
                 self.emu.debug_step_out(RUN_BUDGET)?;
+                self.emit_events()?;
                 return self.bounded_result("stepped out");
             }
             ResumeKind::StepCopper => {
                 let advanced = self.emu.debug_step_copper(RUN_BUDGET)?;
+                self.emit_events()?;
                 if let Some((reason, detail)) = self.take_stop() {
                     return stop(reason, detail);
                 }
@@ -542,6 +565,7 @@ impl Session {
                 for _ in 0..*n {
                     self.emu.step_frame()?;
                     self.ctx.apply_due_scheduled(&mut self.emu);
+                    self.emit_events()?;
                     if let Some((reason, detail)) = self.take_stop() {
                         return stop(reason, detail);
                     }
@@ -633,6 +657,7 @@ impl Session {
                 }
             }
             self.ctx.apply_due_scheduled(&mut self.emu);
+            self.emit_events()?;
 
             if self.emu.machine.cpu_double_faulted() {
                 return finish(
@@ -778,6 +803,7 @@ impl Session {
                     if let Some(end) = self.dispatch_host(req.id, op)? {
                         return Ok(MidRun::Lost(end));
                     }
+                    self.emit_events()?;
                 }
                 Request::Core(op) if op.allowed_while_running() => {
                     let reply = match exec::exec_core(&mut self.emu, &mut self.ctx, &op) {
@@ -785,6 +811,7 @@ impl Session {
                         Err(err) => proto::err_line(&req.id, &err),
                     };
                     self.write(&reply)?;
+                    self.emit_events()?;
                 }
                 Request::Core(_) => {
                     self.write(&proto::err_line(
@@ -1032,6 +1059,40 @@ mod tests {
             let a = c.result("capture.digest", json!({}));
             let b = c.result("capture.digest", json!({}));
             assert_eq!(a["digest"], b["digest"]);
+        });
+    }
+
+    #[test]
+    fn frame_events_stream_before_the_resume_response() {
+        run_session(None, |c| {
+            c.auth();
+            let subscribed = c.result(
+                "events.subscribe",
+                json!({
+                    "events": ["frame"],
+                    "frame_interval": 1,
+                    "frame_digest": true,
+                }),
+            );
+            assert_eq!(subscribed["active"], json!(["frame"]));
+
+            let stop = c.result("step_frame", json!({"n": 3}));
+            let frame_events: Vec<&Value> = c
+                .stash
+                .iter()
+                .filter(|message| message["method"] == "event.frame")
+                .collect();
+            let event = frame_events
+                .last()
+                .expect("frame notification should precede the stop response");
+            assert_eq!(
+                event["params"]["position"]["frame"], stop["frame"],
+                "last notification and stop describe the same completed frame"
+            );
+            assert_eq!(event["params"]["digest"]["algo"], "fnv1a64");
+
+            let state = c.result("events.unsubscribe", json!({}));
+            assert_eq!(state["active"], json!([]));
         });
     }
 

--- a/src/control/observe.rs
+++ b/src/control/observe.rs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Per-connection CCP event subscriptions. Sampling happens only at the
+//! deterministic command/driver boundaries used by the two control-server
+//! modes. Paula's serial tap is separately bounded at the point of capture;
+//! windowed delivery adds another bounded queue at the socket boundary.
+
+use super::{exec, proto};
+use crate::emulator::Emulator;
+use crate::serial::SERIAL_OBSERVATION_CAPACITY;
+use serde_json::{json, Value};
+
+pub const MAX_FRAME_INTERVAL: u64 = 1_000_000;
+pub const OUTBOUND_NOTIFICATION_CAPACITY: usize = 256;
+
+const FRAME: u8 = 1 << 0;
+const SERIAL: u8 = 1 << 1;
+const INTERRUPT: u8 = 1 << 2;
+const MEDIA: u8 = 1 << 3;
+
+/// Event families exposed by `events.subscribe`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EventKind {
+    Frame,
+    Serial,
+    Interrupt,
+    Media,
+}
+
+impl EventKind {
+    pub const ALL: [Self; 4] = [Self::Frame, Self::Serial, Self::Interrupt, Self::Media];
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "frame" => Some(Self::Frame),
+            "serial" => Some(Self::Serial),
+            "interrupt" => Some(Self::Interrupt),
+            "media" => Some(Self::Media),
+            _ => None,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Frame => "frame",
+            Self::Serial => "serial",
+            Self::Interrupt => "interrupt",
+            Self::Media => "media",
+        }
+    }
+
+    fn bit(self) -> u8 {
+        match self {
+            Self::Frame => FRAME,
+            Self::Serial => SERIAL,
+            Self::Interrupt => INTERRUPT,
+            Self::Media => MEDIA,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InterruptState {
+    intena: u16,
+    intreq: u16,
+    cpu_visible: u16,
+    enabled_pending: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MediaState {
+    floppy: [Option<String>; 4],
+    cd_inserted: bool,
+}
+
+/// Subscription and sampling state for one authenticated connection.
+pub struct Observer {
+    active: u8,
+    frame_interval: u64,
+    frame_digest: bool,
+    last_frame: Option<u64>,
+    last_interrupt: Option<InterruptState>,
+    last_media: Option<MediaState>,
+    dropped_notifications: u64,
+}
+
+impl Observer {
+    pub fn new() -> Self {
+        Self {
+            active: 0,
+            frame_interval: 1,
+            frame_digest: false,
+            last_frame: None,
+            last_interrupt: None,
+            last_media: None,
+            dropped_notifications: 0,
+        }
+    }
+
+    pub fn subscribe(
+        &mut self,
+        emu: &mut Emulator,
+        events: &[EventKind],
+        frame_interval: Option<u64>,
+        frame_digest: Option<bool>,
+    ) -> Value {
+        if let Some(interval) = frame_interval {
+            self.frame_interval = interval;
+        }
+        if let Some(digest) = frame_digest {
+            self.frame_digest = digest;
+        }
+
+        for event in events {
+            let newly_active = self.active & event.bit() == 0;
+            self.active |= event.bit();
+            if !newly_active {
+                continue;
+            }
+            match event {
+                EventKind::Frame => self.last_frame = Some(emu.bus().emulated_frames()),
+                EventKind::Serial => emu.bus_mut().paula.set_serial_observation_enabled(true),
+                EventKind::Interrupt => self.last_interrupt = Some(interrupt_state(emu)),
+                EventKind::Media => self.last_media = Some(media_state(emu)),
+            }
+        }
+        self.list_value()
+    }
+
+    pub fn unsubscribe(&mut self, emu: &mut Emulator, events: Option<&[EventKind]>) -> Value {
+        let remove = events
+            .map(|events| events.iter().fold(0, |bits, event| bits | event.bit()))
+            .unwrap_or(FRAME | SERIAL | INTERRUPT | MEDIA);
+        let serial_was_active = self.active & SERIAL != 0;
+        self.active &= !remove;
+
+        if remove & FRAME != 0 {
+            self.last_frame = None;
+            self.frame_digest = false;
+        }
+        if remove & INTERRUPT != 0 {
+            self.last_interrupt = None;
+        }
+        if remove & MEDIA != 0 {
+            self.last_media = None;
+        }
+        if serial_was_active && self.active & SERIAL == 0 {
+            emu.bus_mut().paula.set_serial_observation_enabled(false);
+        }
+        self.list_value()
+    }
+
+    pub fn disable(&mut self, emu: &mut Emulator) {
+        self.unsubscribe(emu, None);
+    }
+
+    pub fn list_value(&self) -> Value {
+        let supported: Vec<&str> = EventKind::ALL.iter().map(|event| event.name()).collect();
+        let active: Vec<&str> = EventKind::ALL
+            .iter()
+            .filter(|event| self.active & event.bit() != 0)
+            .map(|event| event.name())
+            .collect();
+        json!({
+            "supported": supported,
+            "active": active,
+            "frame_interval": self.frame_interval,
+            "frame_digest": self.frame_digest,
+            "dropped_notifications": self.dropped_notifications,
+            "limits": {
+                "serial_records": SERIAL_OBSERVATION_CAPACITY,
+                "windowed_outbound_notifications": OUTBOUND_NOTIFICATION_CAPACITY,
+            },
+        })
+    }
+
+    pub fn note_notification_dropped(&mut self) {
+        self.dropped_notifications = self.dropped_notifications.saturating_add(1);
+    }
+
+    /// Sample all active families and return complete JSON-RPC notification
+    /// lines. The caller owns transport-specific bounded delivery.
+    pub fn poll(&mut self, emu: &mut Emulator) -> Vec<String> {
+        let mut events = Vec::new();
+
+        if self.active & SERIAL != 0 {
+            let (records, dropped) = emu.bus_mut().paula.take_serial_observations();
+            if !records.is_empty() || dropped != 0 {
+                let words: Vec<Value> = records
+                    .into_iter()
+                    .map(|record| {
+                        json!({
+                            "word": record.word,
+                            "long": record.long,
+                            "at_cck": record.at_cck,
+                        })
+                    })
+                    .collect();
+                events.push(proto::event_line(
+                    "event.serial",
+                    json!({
+                        "position": position(emu),
+                        "words": words,
+                        "dropped_words": dropped,
+                        "dropped_notifications": self.dropped_notifications,
+                    }),
+                ));
+            }
+        }
+
+        if self.active & INTERRUPT != 0 {
+            let current = interrupt_state(emu);
+            if self
+                .last_interrupt
+                .is_some_and(|previous| previous != current)
+            {
+                let previous = self.last_interrupt.expect("checked above");
+                events.push(proto::event_line(
+                    "event.interrupt",
+                    json!({
+                        "position": position(emu),
+                        "previous": interrupt_value(previous),
+                        "current": interrupt_value(current),
+                        "asserted": current.intreq & !previous.intreq,
+                        "cleared": previous.intreq & !current.intreq,
+                        "dropped_notifications": self.dropped_notifications,
+                    }),
+                ));
+            }
+            self.last_interrupt = Some(current);
+        }
+
+        if self.active & MEDIA != 0 {
+            let current = media_state(emu);
+            if let Some(previous) = self.last_media.as_ref() {
+                for drive in 0..4 {
+                    if previous.floppy[drive] != current.floppy[drive] {
+                        let name = current.floppy[drive].clone();
+                        events.push(proto::event_line(
+                            "event.media",
+                            json!({
+                                "position": position(emu),
+                                "kind": "floppy",
+                                "drive": drive,
+                                "action": if name.is_some() { "inserted" } else { "ejected" },
+                                "name": name,
+                                "dropped_notifications": self.dropped_notifications,
+                            }),
+                        ));
+                    }
+                }
+                if previous.cd_inserted != current.cd_inserted {
+                    events.push(proto::event_line(
+                        "event.media",
+                        json!({
+                            "position": position(emu),
+                            "kind": "cd",
+                            "action": if current.cd_inserted { "inserted" } else { "ejected" },
+                            "dropped_notifications": self.dropped_notifications,
+                        }),
+                    ));
+                }
+            }
+            self.last_media = Some(current);
+        }
+
+        if self.active & FRAME != 0 {
+            let current = emu.bus().emulated_frames();
+            let previous = self.last_frame.unwrap_or(current);
+            if current != previous && current.abs_diff(previous) >= self.frame_interval {
+                let mut params = json!({
+                    "position": position(emu),
+                    "previous_frame": previous,
+                    "dropped_notifications": self.dropped_notifications,
+                });
+                if self.frame_digest {
+                    params["digest"] = exec::digest_value(emu);
+                }
+                events.push(proto::event_line("event.frame", params));
+                self.last_frame = Some(current);
+            } else if self.last_frame.is_none() {
+                self.last_frame = Some(current);
+            }
+        }
+
+        events
+    }
+}
+
+impl Default for Observer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn interrupt_state(emu: &Emulator) -> InterruptState {
+    let bus = emu.bus();
+    let intena = bus.paula.intena;
+    let intreq = bus.paula.intreq;
+    let cpu_visible = bus.cpu_visible_intreq();
+    InterruptState {
+        intena,
+        intreq,
+        cpu_visible,
+        enabled_pending: intena & cpu_visible,
+    }
+}
+
+fn interrupt_value(state: InterruptState) -> Value {
+    json!({
+        "intena": state.intena,
+        "intreq": state.intreq,
+        "cpu_visible": state.cpu_visible,
+        "enabled_pending": state.enabled_pending,
+    })
+}
+
+fn media_state(emu: &Emulator) -> MediaState {
+    let bus = emu.bus();
+    MediaState {
+        floppy: std::array::from_fn(|drive| bus.floppy.inserted_disk_name(drive)),
+        cd_inserted: bus.cd_disc_inserted(),
+    }
+}
+
+fn position(emu: &Emulator) -> Value {
+    let bus = emu.bus();
+    json!({
+        "frame": bus.emulated_frames(),
+        "cck": bus.emulated_cck(),
+        "seconds": bus.emulated_seconds(),
+        "vpos": bus.agnus.vpos,
+        "hpos": bus.agnus.hpos,
+        "pc": emu.machine.pc(),
+        "retired_instructions": emu.retired_instructions(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::test_emulator;
+
+    #[test]
+    fn frame_subscription_is_baselined_and_interval_limited() {
+        let mut emu = test_emulator();
+        let mut observer = Observer::new();
+        observer.subscribe(&mut emu, &[EventKind::Frame], Some(2), Some(false));
+
+        assert!(observer.poll(&mut emu).is_empty());
+
+        // Exercise the sampler directly at deterministic frame values; frame
+        // production itself is covered by the emulator scheduler tests.
+        let start = emu.bus().emulated_frames();
+        observer.last_frame = Some(start + 2);
+        let events = observer.poll(&mut emu);
+        assert_eq!(events.len(), 1);
+        let event: Value = serde_json::from_str(&events[0]).unwrap();
+        assert_eq!(event["method"], "event.frame");
+        assert_eq!(event["params"]["position"]["frame"], start);
+    }
+
+    #[test]
+    fn interrupt_subscription_reports_state_changes() {
+        let mut emu = test_emulator();
+        let mut observer = Observer::new();
+        observer.subscribe(&mut emu, &[EventKind::Interrupt], None, None);
+        emu.bus_mut().paula.intreq ^= 1 << 5;
+
+        let events = observer.poll(&mut emu);
+        assert_eq!(events.len(), 1);
+        let event: Value = serde_json::from_str(&events[0]).unwrap();
+        assert_eq!(event["method"], "event.interrupt");
+        assert_eq!(event["params"]["asserted"], 1 << 5);
+    }
+
+    #[test]
+    fn unsubscribe_disables_all_families() {
+        let mut emu = test_emulator();
+        let mut observer = Observer::new();
+        observer.subscribe(&mut emu, &EventKind::ALL, Some(3), Some(true));
+        let state = observer.unsubscribe(&mut emu, None);
+        assert_eq!(state["active"], json!([]));
+        assert_eq!(state["frame_digest"], false);
+    }
+}

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -89,6 +89,7 @@ pub struct SessionCtx {
     /// A resume verb's response is still outstanding.
     pub pending: bool,
     pub powered_on: bool,
+    observations: super::observe::Observer,
 }
 
 impl SessionCtx {
@@ -101,6 +102,7 @@ impl SessionCtx {
             running: false,
             pending: false,
             powered_on: true,
+            observations: super::observe::Observer::new(),
         }
     }
 
@@ -218,6 +220,41 @@ impl SessionCtx {
     /// landed at.
     pub fn inject_now(&mut self, emu: &mut Emulator, action: InputAction) -> f64 {
         inject_input(emu, &mut self.recorder, action)
+    }
+
+    pub fn subscribe_events(
+        &mut self,
+        emu: &mut Emulator,
+        events: &[super::observe::EventKind],
+        frame_interval: Option<u64>,
+        frame_digest: Option<bool>,
+    ) -> serde_json::Value {
+        self.observations
+            .subscribe(emu, events, frame_interval, frame_digest)
+    }
+
+    pub fn unsubscribe_events(
+        &mut self,
+        emu: &mut Emulator,
+        events: Option<&[super::observe::EventKind]>,
+    ) -> serde_json::Value {
+        self.observations.unsubscribe(emu, events)
+    }
+
+    pub fn event_subscriptions(&self) -> serde_json::Value {
+        self.observations.list_value()
+    }
+
+    pub fn poll_events(&mut self, emu: &mut Emulator) -> Vec<String> {
+        self.observations.poll(emu)
+    }
+
+    pub fn note_event_notification_dropped(&mut self) {
+        self.observations.note_notification_dropped();
+    }
+
+    pub fn disable_events(&mut self, emu: &mut Emulator) {
+        self.observations.disable(emu);
     }
 }
 

--- a/src/control/windowed.rs
+++ b/src/control/windowed.rs
@@ -14,6 +14,7 @@
 //! one JSON error line and are closed.
 
 use super::exec::{self, Request};
+use super::observe::OUTBOUND_NOTIFICATION_CAPACITY;
 use super::proto::{self, AuthGate, CtlError, Gate};
 use super::Config;
 use anyhow::{Context, Result};
@@ -21,7 +22,7 @@ use serde_json::Value;
 use std::io::BufReader;
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 
 /// A message from the socket threads to the frame loop.
@@ -46,7 +47,7 @@ pub struct ControlHandle {
     token: String,
     cmd_tx: Sender<CtlMsg>,
     cmd_rx: Receiver<CtlMsg>,
-    reply_tx: Arc<Mutex<Option<Sender<String>>>>,
+    reply_tx: Arc<Mutex<Option<SyncSender<String>>>>,
     connected: Arc<AtomicBool>,
 }
 
@@ -79,7 +80,7 @@ impl ControlHandle {
     /// returned sender, replies arrive on the returned receiver.
     pub fn test_pair() -> (Self, Sender<CtlMsg>, Receiver<String>) {
         let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
-        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+        let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(OUTBOUND_NOTIFICATION_CAPACITY);
         let handle = Self {
             listener: None,
             token: String::new(),
@@ -128,13 +129,26 @@ impl ControlHandle {
             let _ = tx.send(line);
         }
     }
+
+    /// Attempt to enqueue a streaming notification without blocking the
+    /// emulator frame loop. A full queue means the client is not draining its
+    /// stream quickly enough; the caller records the drop in session stats.
+    pub fn try_send_event(&self, line: String) -> bool {
+        let Some(tx) = self.reply_tx.lock().expect("reply slot lock").clone() else {
+            return false;
+        };
+        match tx.try_send(line) {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => false,
+        }
+    }
 }
 
 fn accept_loop(
     listener: TcpListener,
     token: String,
     cmd_tx: Sender<CtlMsg>,
-    reply_slot: Arc<Mutex<Option<Sender<String>>>>,
+    reply_slot: Arc<Mutex<Option<SyncSender<String>>>>,
     connected: Arc<AtomicBool>,
     wake: Arc<dyn Fn() + Send + Sync>,
 ) {
@@ -162,7 +176,8 @@ fn accept_loop(
         stream.set_nodelay(true).ok();
 
         // Writer thread: owns the write half, drains the reply channel.
-        let (reply_tx, reply_rx) = std::sync::mpsc::channel::<String>();
+        let (reply_tx, reply_rx) =
+            std::sync::mpsc::sync_channel::<String>(OUTBOUND_NOTIFICATION_CAPACITY);
         let write_stream = match stream.try_clone() {
             Ok(clone) => clone,
             Err(e) => {
@@ -170,6 +185,9 @@ fn accept_loop(
                 continue;
             }
         };
+        write_stream
+            .set_write_timeout(Some(std::time::Duration::from_millis(250)))
+            .ok();
         let writer = std::thread::Builder::new()
             .name("control-write".into())
             .spawn(move || {
@@ -207,7 +225,7 @@ fn read_connection(
     stream: TcpStream,
     token: &str,
     cmd_tx: &Sender<CtlMsg>,
-    reply_tx: &Sender<String>,
+    reply_tx: &SyncSender<String>,
     wake: &Arc<dyn Fn() + Send + Sync>,
 ) {
     let mut reader = BufReader::new(stream);
@@ -256,5 +274,19 @@ fn read_connection(
                 let _ = reply_tx.send(proto::err_line(&req.id, &err));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn streaming_delivery_is_bounded_and_nonblocking() {
+        let (handle, _cmd_tx, _reply_rx) = ControlHandle::test_pair();
+        for index in 0..OUTBOUND_NOTIFICATION_CAPACITY {
+            assert!(handle.try_send_event(index.to_string()));
+        }
+        assert!(!handle.try_send_event("overflow".to_string()));
     }
 }

--- a/src/control/windowed.rs
+++ b/src/control/windowed.rs
@@ -20,7 +20,7 @@ use super::Config;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::BufReader;
-use std::net::{TcpListener, TcpStream};
+use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
@@ -47,8 +47,13 @@ pub struct ControlHandle {
     token: String,
     cmd_tx: Sender<CtlMsg>,
     cmd_rx: Receiver<CtlMsg>,
-    reply_tx: Arc<Mutex<Option<SyncSender<String>>>>,
+    connection: Arc<Mutex<Option<Arc<OutboundConnection>>>>,
     connected: Arc<AtomicBool>,
+}
+
+struct OutboundConnection {
+    reply_tx: SyncSender<String>,
+    disconnect_stream: Option<TcpStream>,
 }
 
 impl ControlHandle {
@@ -70,7 +75,7 @@ impl ControlHandle {
             token,
             cmd_tx,
             cmd_rx,
-            reply_tx: Arc::new(Mutex::new(None)),
+            connection: Arc::new(Mutex::new(None)),
             connected: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -81,12 +86,16 @@ impl ControlHandle {
     pub fn test_pair() -> (Self, Sender<CtlMsg>, Receiver<String>) {
         let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
         let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(OUTBOUND_NOTIFICATION_CAPACITY);
+        let connection = OutboundConnection {
+            reply_tx,
+            disconnect_stream: None,
+        };
         let handle = Self {
             listener: None,
             token: String::new(),
             cmd_tx: cmd_tx.clone(),
             cmd_rx,
-            reply_tx: Arc::new(Mutex::new(Some(reply_tx))),
+            connection: Arc::new(Mutex::new(Some(Arc::new(connection)))),
             connected: Arc::new(AtomicBool::new(true)),
         };
         (handle, cmd_tx, reply_rx)
@@ -100,13 +109,13 @@ impl ControlHandle {
         };
         let token = self.token.clone();
         let cmd_tx = self.cmd_tx.clone();
-        let reply_slot = Arc::clone(&self.reply_tx);
+        let connection_slot = Arc::clone(&self.connection);
         let connected = Arc::clone(&self.connected);
         let wake: Arc<dyn Fn() + Send + Sync> = Arc::from(wake);
         std::thread::Builder::new()
             .name("control-accept".into())
             .spawn(move || {
-                accept_loop(listener, token, cmd_tx, reply_slot, connected, wake);
+                accept_loop(listener, token, cmd_tx, connection_slot, connected, wake);
             })
             .expect("spawning control accept thread");
     }
@@ -121,12 +130,21 @@ impl ControlHandle {
         self.cmd_rx.try_recv().ok()
     }
 
-    /// Send one reply/notification line to the current client; quietly
-    /// drops it if the client is gone (its stop already ended the
-    /// session).
+    /// Enqueue one required reply/notification without blocking the emulator
+    /// frame loop. If the bounded queue is full, disconnect the slow client:
+    /// silently dropping a JSON-RPC reply would leave its request unresolved.
     pub fn send(&self, line: String) {
-        if let Some(tx) = self.reply_tx.lock().expect("reply slot lock").as_ref() {
-            let _ = tx.send(line);
+        let Some(connection) = self.connection.lock().expect("connection lock").clone() else {
+            return;
+        };
+        match connection.reply_tx.try_send(line) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                self.disconnect_current(&connection, "outbound reply queue is full");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                self.disconnect_current(&connection, "control writer stopped");
+            }
         }
     }
 
@@ -134,12 +152,42 @@ impl ControlHandle {
     /// emulator frame loop. A full queue means the client is not draining its
     /// stream quickly enough; the caller records the drop in session stats.
     pub fn try_send_event(&self, line: String) -> bool {
-        let Some(tx) = self.reply_tx.lock().expect("reply slot lock").clone() else {
+        let Some(connection) = self.connection.lock().expect("connection lock").clone() else {
             return false;
         };
-        match tx.try_send(line) {
+        match connection.reply_tx.try_send(line) {
             Ok(()) => true,
-            Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => false,
+            Err(TrySendError::Full(_)) => false,
+            Err(TrySendError::Disconnected(_)) => {
+                self.disconnect_current(&connection, "control writer stopped");
+                false
+            }
+        }
+    }
+
+    /// Tear down the socket side of the current connection. `shutdown`
+    /// wakes the blocking reader so the accept thread can perform normal
+    /// session cleanup and begin accepting a replacement client.
+    fn disconnect_current(&self, connection: &Arc<OutboundConnection>, reason: &str) {
+        let removed = {
+            let mut active = self.connection.lock().expect("connection lock");
+            if active
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, connection))
+            {
+                active.take();
+                true
+            } else {
+                false
+            }
+        };
+        if !removed {
+            return;
+        }
+        log::warn!("control: {reason}; detaching client");
+        self.connected.store(false, Ordering::Relaxed);
+        if let Some(stream) = &connection.disconnect_stream {
+            let _ = stream.shutdown(Shutdown::Both);
         }
     }
 }
@@ -148,7 +196,7 @@ fn accept_loop(
     listener: TcpListener,
     token: String,
     cmd_tx: Sender<CtlMsg>,
-    reply_slot: Arc<Mutex<Option<SyncSender<String>>>>,
+    connection_slot: Arc<Mutex<Option<Arc<OutboundConnection>>>>,
     connected: Arc<AtomicBool>,
     wake: Arc<dyn Fn() + Send + Sync>,
 ) {
@@ -178,6 +226,13 @@ fn accept_loop(
         // Writer thread: owns the write half, drains the reply channel.
         let (reply_tx, reply_rx) =
             std::sync::mpsc::sync_channel::<String>(OUTBOUND_NOTIFICATION_CAPACITY);
+        let disconnect_stream = match stream.try_clone() {
+            Ok(clone) => clone,
+            Err(e) => {
+                log::warn!("control: cloning disconnect stream failed: {e}");
+                continue;
+            }
+        };
         let write_stream = match stream.try_clone() {
             Ok(clone) => clone,
             Err(e) => {
@@ -200,20 +255,31 @@ fn accept_loop(
             })
             .expect("spawning control writer thread");
 
-        *reply_slot.lock().expect("reply slot lock") = Some(reply_tx.clone());
+        let connection = Arc::new(OutboundConnection {
+            reply_tx,
+            disconnect_stream: Some(disconnect_stream),
+        });
+        *connection_slot.lock().expect("connection lock") = Some(Arc::clone(&connection));
         connected.store(true, Ordering::Relaxed);
         let _ = cmd_tx.send(CtlMsg::Connected);
         wake();
 
         // Read this connection to completion on the accept thread; the
         // next client is only accepted afterwards (one at a time).
-        read_connection(stream, &token, &cmd_tx, &reply_tx, &wake);
+        read_connection(stream, &token, &cmd_tx, &connection.reply_tx, &wake);
 
-        *reply_slot.lock().expect("reply slot lock") = None;
+        let mut active = connection_slot.lock().expect("connection lock");
+        if active
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, &connection))
+        {
+            active.take();
+        }
+        drop(active);
         connected.store(false, Ordering::Relaxed);
         let _ = cmd_tx.send(CtlMsg::Disconnected);
         wake();
-        drop(reply_tx); // writer thread drains and exits
+        drop(connection); // writer thread drains and exits
         let _ = writer.join();
         log::info!("control: client detached; listening again");
     }
@@ -242,13 +308,17 @@ fn read_connection(
         let req = match proto::parse_request(&line) {
             Ok(req) => req,
             Err(reply) => {
-                let _ = reply_tx.send(reply);
+                if reply_tx.send(reply).is_err() {
+                    return;
+                }
                 continue;
             }
         };
         match gate.handle(&req) {
             Gate::Reply(reply) => {
-                let _ = reply_tx.send(reply);
+                if reply_tx.send(reply).is_err() {
+                    return;
+                }
                 continue;
             }
             Gate::ReplyAndClose(reply) => {
@@ -271,7 +341,9 @@ fn read_connection(
                 wake();
             }
             Err(err) => {
-                let _ = reply_tx.send(proto::err_line(&req.id, &err));
+                if reply_tx.send(proto::err_line(&req.id, &err)).is_err() {
+                    return;
+                }
             }
         }
     }
@@ -288,5 +360,29 @@ mod tests {
             assert!(handle.try_send_event(index.to_string()));
         }
         assert!(!handle.try_send_event("overflow".to_string()));
+        assert!(handle.connected());
+    }
+
+    #[test]
+    fn required_reply_overflow_disconnects_without_blocking() {
+        let (handle, _cmd_tx, reply_rx) = ControlHandle::test_pair();
+        for index in 0..OUTBOUND_NOTIFICATION_CAPACITY {
+            assert!(handle.try_send_event(index.to_string()));
+        }
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            handle.send("required reply".to_string());
+            done_tx.send(handle.connected()).unwrap();
+        });
+        let completed = done_rx.recv_timeout(std::time::Duration::from_secs(2));
+        if completed.is_err() {
+            drop(reply_rx);
+            worker.join().unwrap();
+            panic!("required reply blocked behind a full outbound queue");
+        }
+        assert!(!completed.unwrap());
+        drop(reply_rx);
+        worker.join().unwrap();
     }
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,7 +3,46 @@
 //! Serial output sink. Paula's SERDAT writes are funneled through here.
 
 use crate::timebase::Instant;
+use std::collections::VecDeque;
 use std::io::{self, Write};
+
+/// Maximum number of completed Paula transmissions retained for a host-side
+/// observer. The tap evicts the oldest word once full; it must never let a
+/// debugger client apply unbounded back-pressure to the emulated UART.
+pub const SERIAL_OBSERVATION_CAPACITY: usize = 4096;
+
+/// One word that finished shifting out of Paula's serial transmitter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SerialTxObservation {
+    pub word: u16,
+    pub long: bool,
+    pub at_cck: u64,
+}
+
+/// Bounded, host-side tap used by streaming debugger transports. This is not
+/// emulated state and is deliberately kept independent of the active serial
+/// sink, so observing output cannot change what the configured device sees.
+#[derive(Default)]
+pub struct SerialObserver {
+    pending: VecDeque<SerialTxObservation>,
+    dropped: u64,
+}
+
+impl SerialObserver {
+    pub fn push(&mut self, observation: SerialTxObservation) {
+        if self.pending.len() == SERIAL_OBSERVATION_CAPACITY {
+            self.pending.pop_front();
+            self.dropped = self.dropped.saturating_add(1);
+        }
+        self.pending.push_back(observation);
+    }
+
+    pub fn drain(&mut self) -> (Vec<SerialTxObservation>, u64) {
+        let observations = self.pending.drain(..).collect();
+        let dropped = std::mem::take(&mut self.dropped);
+        (observations, dropped)
+    }
+}
 
 /// Maps the emulated serial timeline onto the host clock so a timing-sensitive
 /// sink can schedule its output. `host_epoch` is the host instant of emulated
@@ -411,6 +450,23 @@ impl SerialSink for StdoutSink {
 mod tests {
     use super::*;
     use std::io::Read;
+
+    #[test]
+    fn serial_observer_evicts_oldest_records_at_its_limit() {
+        let mut observer = SerialObserver::default();
+        for word in 0..=SERIAL_OBSERVATION_CAPACITY {
+            observer.push(SerialTxObservation {
+                word: word as u16,
+                long: false,
+                at_cck: word as u64,
+            });
+        }
+        let (records, dropped) = observer.drain();
+        assert_eq!(records.len(), SERIAL_OBSERVATION_CAPACITY);
+        assert_eq!(records[0].word, 1);
+        assert_eq!(dropped, 1);
+        assert!(observer.drain().0.is_empty());
+    }
 
     #[test]
     fn tcp_sink_round_trips_input_and_output() {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1941,6 +1941,8 @@ impl ApplicationHandler for App {
                     self.sync_live_audio_suspension();
                     break;
                 }
+                #[cfg(feature = "control")]
+                self.control_emit_events();
                 frames_done += 1;
                 // A breakpoint/watchpoint hit pauses the machine and brings
                 // the debugger window up with the reason; end the burst so the

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -101,11 +101,34 @@ impl App {
                 CtlMsg::Request { id, req } => self.control_dispatch(id, req),
             }
         }
+        self.control_emit_events();
     }
 
     fn control_send(&self, line: String) {
         if let Some(ctl) = &self.control {
             ctl.handle.send(line);
+        }
+    }
+
+    /// Sample subscribed event families and enqueue notifications without
+    /// ever blocking the winit/emulation thread behind a slow client.
+    pub(super) fn control_emit_events(&mut self) {
+        let lines = {
+            let Some(ctl) = self.control.as_mut() else {
+                return;
+            };
+            ctl.ctx.poll_events(&mut self.emu)
+        };
+        for line in lines {
+            let sent = self
+                .control
+                .as_ref()
+                .is_some_and(|ctl| ctl.handle.try_send_event(line));
+            if !sent {
+                if let Some(ctl) = self.control.as_mut() {
+                    ctl.ctx.note_event_notification_dropped();
+                }
+            }
         }
     }
 
@@ -139,6 +162,7 @@ impl App {
         // keeps whatever run state it is in (the window still owns it).
         ctl.pending = None;
         let temp_pc = ctl.temp_pc_break.take();
+        ctl.ctx.disable_events(&mut self.emu);
         let mut ctx = std::mem::take(&mut ctl.ctx);
         if let Some(addr) = temp_pc {
             self.emu.machine.ui_set_breakpoint(addr, None, 0);
@@ -178,6 +202,7 @@ impl App {
                     Err(err) => proto::err_line(&id, &err),
                 };
                 self.control_send(line);
+                self.control_emit_events();
                 if repositions {
                     // Reverse steps / last-writer moved the timeline;
                     // refresh the presentation like the debugger's own
@@ -450,6 +475,7 @@ impl App {
             ("step", label.to_string())
         };
         self.control_reply_stop(&id, verb.collect, reason, &detail);
+        self.control_emit_events();
         self.last_debug_stop = Some(detail);
         self.finish_render_for_current_frame();
         self.request_redraw();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3849,4 +3849,34 @@ mod control_drain {
         assert_eq!(stop["result"]["pc"], before + 4, "two NOPs retired");
         assert!(app.paused, "sync steps leave the machine paused");
     }
+
+    #[test]
+    fn frame_subscription_streams_from_the_windowed_sampler() {
+        let (mut app, cmd_tx, reply_rx) = attached_app();
+        push(
+            &cmd_tx,
+            1,
+            "events.subscribe",
+            json!({"events": ["frame"], "frame_interval": 1}),
+        );
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["result"]["active"], json!(["frame"]));
+
+        for _ in 0..3 {
+            app.emu.step_frame().unwrap();
+            app.control_emit_events();
+        }
+        let mut notifications = Vec::new();
+        while let Ok(line) = reply_rx.try_recv() {
+            notifications.push(serde_json::from_str::<Value>(&line).unwrap());
+        }
+        let notification = notifications
+            .last()
+            .expect("at least one hardware frame should complete");
+        assert_eq!(notification["method"], "event.frame");
+        assert_eq!(
+            notification["params"]["position"]["frame"],
+            app.emu.bus().emulated_frames()
+        );
+    }
 }

--- a/src/waveform.rs
+++ b/src/waveform.rs
@@ -243,7 +243,7 @@ impl fmt::Display for WaveDuration {
 // ---------------------------------------------------------------------------
 
 /// Everything needed to arm a capture.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WaveOptions {
     pub path: PathBuf,
     pub trigger: Trigger,


### PR DESCRIPTION
## Summary

- add bounded per-connection CCP subscriptions for frame, serial TX, interrupt, and media events, including delivery and drop accounting
- expose runtime trace and waveform start, status, and stop controls
- keep the copperline-ctl REPL draining asynchronous notifications while idle
- cover headless, windowed, and save-state integration and update the debugger and internals documentation

## Testing

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `git diff --check`