### PR TITLE
Support any controller device in either game port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,10 @@ repeat.
 |---|---|
 | `--press-after SECS KEY` | Press and release an Amiga key (~100 ms hold) |
 | `--key-after SECS KEY MS` | Hold a key for exactly MS milliseconds |
-| `--click-after SECS BUTTON MS` | Mouse button (`left`/`right`/`middle`) for MS ms |
-| `--joy-after SECS BUTTON MS` | Port-2 joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red`/`blue`/...) |
-| `--mouse-after SECS DX DY` | Relative mouse motion |
+| `--click-after SECS BUTTON MS [PORT]` | Mouse button (`left`/`right`/`middle`) for MS ms (default port 1) |
+| `--joy-after SECS BUTTON MS [PORT]` | Joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red`/`blue`/...) (default port 2) |
+| `--mouse-after SECS DX DY [PORT]` | Relative mouse motion (default port 1) |
+| `--pot-after SECS X Y [PORT]` | Analogue stick/paddle position, 0-255 per axis (default port 2) |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--script FILE` | Same directives from a file, one per line, no leading dashes |
 | `--record-input PATH` | Record all machine-bound input as a replayable script |
@@ -80,6 +81,13 @@ repeat.
 `KEY` is a raw key code (`0x45`) or a name (`ctrl`, `f1`, `esc`, letters,
 digits). A session played by hand under `--record-input` (or Cmd+Shift+R /
 Alt+Shift+R in the window) replays deterministically via `--script`.
+
+Either controller port takes any device -- `[input] port1/port2` in the
+TOML, or `--port1`/`--port2` (`mouse`/`joystick`/`cd32`/`analogue`/`none`;
+default mouse + joystick, CD32 pad on the CD32 profile). The scripted-input
+flags' optional trailing `PORT` token (`1` or `2`) aims an event at either
+port; omitted, each flag keeps its traditional port, so existing scripts
+are unchanged.
 
 ## Save states
 

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -330,13 +330,32 @@ floppy_sounds_volume = 100
 # Host input preferences.
 # [input]
 
-# Initial source for the emulated port-2 joystick / CD32 pad:
-#   "gamepad"  (default) only a physical pad drives port 2; the keyboard passes
-#              straight through to the Amiga (Shell, editor, Workbench). With
-#              no pad connected there is simply no port-2 input -- ideal for
-#              keyboard-driven setup of an AmigaOS environment.
+# Controller device plugged into each game port. Either port accepts any
+# device, as on a real Amiga:
+#   "mouse"    quadrature mouse (three buttons)
+#   "joystick" digital switch joystick (fire + second button)
+#   "cd32"     CD32 joypad (adds the serial button protocol)
+#   "analogue" analogue paddles / proportional stick on the POT pins,
+#              driven by --pot-after scripting or the CCP input.analogue
+#              method (no live host device maps to it yet)
+#   "none"     empty port
+# Defaults: port1 = "mouse", port2 = "joystick" ("cd32" on the CD32
+# profile). Also --port1 DEVICE / --port2 DEVICE per run; the runtime menu
+# and the CCP input.set_port method hot-plug a device live.
+# port1 = "mouse"
+# port2 = "joystick"
+
+# Initial host source for the joystick/CD32-pad port:
+#   "gamepad"  (default) only a physical pad drives the port; the keyboard
+#              passes straight through to the Amiga (Shell, editor,
+#              Workbench). With no pad connected there is simply no joystick
+#              input -- ideal for keyboard-driven setup of an AmigaOS
+#              environment.
 #   "keyboard" always use the keyboard-joystick mapping (cursor keys + fire
-#              keys), so port 2 stays usable without a controller.
+#              keys), so the port stays usable without a controller.
+# With BOTH ports configured as joysticks, the gamepad and the keyboard
+# mapping drive one port each: this mode picks which source gets the
+# lower-numbered port.
 # Cmd+J / Alt+J still cycles this live; --joystick MODE overrides it per run.
 # joystick = "gamepad"
 

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -353,9 +353,13 @@ floppy_sounds_volume = 100
 #              environment.
 #   "keyboard" always use the keyboard-joystick mapping (cursor keys + fire
 #              keys), so the port stays usable without a controller.
-# With BOTH ports configured as joysticks, the gamepad and the keyboard
+# With BOTH ports configured as joysticks, the gamepad and the cursor-key
 # mapping drive one port each: this mode picks which source gets the
-# lower-numbered port.
+# lower-numbered port, and with no physical pad a second keyboard mapping
+# on the numeric keypad (8/2/4/6 + 0 fire + . second button) stands in
+# for the gamepad. With both ports as mice, "keyboard" drives the second
+# mouse from the cursor-key mapping (keys move the pointer, fire keys =
+# left button, X = right, D = middle).
 # Cmd+J / Alt+J still cycles this live; --joystick MODE overrides it per run.
 # joystick = "gamepad"
 

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -392,7 +392,7 @@ impl WebEmu {
         let ix = take_integral_delta(&mut self.mouse_remainder.0);
         let iy = take_integral_delta(&mut self.mouse_remainder.1);
         if ix != 0 || iy != 0 {
-            self.emu.bus_mut().input.add_mouse_delta_port1(ix, iy);
+            self.emu.bus_mut().input.add_mouse_delta(0, ix, iy);
         }
     }
 
@@ -400,9 +400,9 @@ impl WebEmu {
     pub fn mouse_button(&mut self, button: u8, pressed: bool) {
         let input = &mut self.emu.bus_mut().input;
         match button {
-            0 => input.lmb_port1 = pressed,
-            1 => input.mmb_port1 = pressed,
-            2 => input.rmb_port1 = pressed,
+            0 => input.set_mouse_button(0, 0, pressed),
+            1 => input.set_mouse_button(0, 2, pressed),
+            2 => input.set_mouse_button(0, 1, pressed),
             _ => {}
         }
     }
@@ -423,7 +423,7 @@ impl WebEmu {
         self.emu
             .bus_mut()
             .input
-            .set_joystick_port2(up, down, left, right, fire, button2);
+            .set_joystick(1, up, down, left, right, fire, button2);
     }
 
     /// The CD32 pad's extra buttons on port 2 (red/blue arrive through
@@ -439,7 +439,7 @@ impl WebEmu {
         self.emu
             .bus_mut()
             .input
-            .set_cd32_buttons_port2(play, rwd, ffw, green, yellow);
+            .set_cd32_buttons(1, play, rwd, ffw, green, yellow);
     }
 
     /// Insert a floppy image (ADF/ADZ/DMS/extended ADF, optionally

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -234,9 +234,26 @@ alone.
 Input (applied now by default, or scheduled with `at_seconds`; `tap`
 presses and schedules the release after `hold_ms`, default 80):
 `input.key {rawkey, action: "press"|"release"|"tap", hold_ms?,
-at_seconds?}`, `input.mouse {left?, right?, middle?, dx?, dy?}`,
-`input.joy {up, down, left, right, red/fire1, blue/fire2, green,
-yellow, play, rwd, ffw}` (port-2 held state, replaced wholesale).
+at_seconds?}`, `input.mouse {port?, left?, right?, middle?, dx?, dy?}`
+(port defaults to 1), `input.joy {port?, up, down, left, right,
+red/fire1, blue/fire2, green, yellow, play, rwd, ffw}` (held state,
+replaced wholesale; port defaults to 2), `input.analogue {port?, x, y}`
+(analogue stick/paddle position, 0-255 per axis, the count POTxDAT
+latches; port defaults to 2). Events drive the named port's electrical
+lines whatever device is configured there.
+
+Controller ports: `input.get_ports` -> `{"port1": "mouse", "port2":
+"joystick"}`; `input.set_port {port, device:
+"mouse"|"joystick"|"cd32"|"analogue"|"none"}` hot-plugs a device, as if
+swapping the physical plug (the old device's held lines release; the
+change is applied live, mid-run included, and is not journaled for
+reverse replay):
+
+```sh
+copperline-ctl --info /tmp/ccp.json input.set_port '{"port": 1, "device": "cd32"}'
+copperline-ctl --info /tmp/ccp.json input.joy '{"port": 1, "red": true}'
+copperline-ctl --info /tmp/ccp.json input.analogue '{"port": 2, "x": 50, "y": 200}'
+```
 
 Media: `media.floppy.insert {drive, path, write_protected?}`,
 `media.floppy.eject {drive}`, `media.floppy.query`,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -45,6 +45,8 @@ range checks as the equivalent TOML fields:
 | `--slow SIZE` | `[memory] slow` | `0`, up to `512K` |
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
+| `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
+| `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
 
 For example, to boot a stock A1200 profile but with 8 MB of fast RAM and a
 faster CPU, with no config file at all:
@@ -440,23 +442,60 @@ Windows select each device directly.
 
 ```toml
 [input]
+port1 = "mouse"        # mouse | joystick | cd32 | analogue | none
+port2 = "joystick"     # same values; default "cd32" on the CD32 profile
 joystick = "gamepad"   # "gamepad" (default) or "keyboard"
 ```
 
-Selects the initial host source for the emulated port-2 joystick / CD32 pad.
+### Controller ports
+
+`port1` and `port2` name the controller device plugged into each game port.
+Either port accepts any device, exactly as on real hardware:
+
+- `mouse` -- a quadrature mouse. Its three buttons are the left (`/FIRx`),
+  right (`POTxY`), and middle (`POTxX`) lines.
+- `joystick` -- a digital switch joystick with a fire button and a second
+  button on the `POTxY` line.
+- `cd32` -- a CD32 joypad: a digital joystick plus the serial button
+  protocol lowlevel.library reads (Red/Blue ride the fire/button-2 lines;
+  Green, Yellow, Play, Rewind and Forward exist only serially).
+- `analogue` -- analogue paddles or a proportional stick presenting
+  resistances on the `POTxX`/`POTxY` pins, with the two paddle buttons on
+  the left/right direction lines. No live host device maps to it yet:
+  drive it with `--pot-after` scripting or the control protocol's
+  `input.analogue` method (positions default to centre).
+- `none` -- an empty port.
+
+The defaults are today's stock wiring: a mouse in port 1 and a joystick in
+port 2 -- a CD32 pad on the CD32 profile, whose bundled controller the
+machine expects (an explicit key beats the profile; a real CD32 accepts any
+controller too). `--port1` / `--port2` override for one run, the runtime
+menu's **Port 1/2 Device** items hot-plug a device live, and the control
+protocol's `input.set_port` does the same from a script.
+
+Putting joysticks in *both* ports is a real two-player setup: the host
+gamepad and the keyboard mapping then drive one port each (see below).
+
+### Joystick input source
+
+`joystick` selects the initial host source for the joystick/CD32-pad port.
 There are two explicit modes, so the active source is always visible rather
 than depending on whether a pad happens to be connected:
 
-- `gamepad` (the default) -- only a physical pad drives port 2. The keyboard
-  is left to the Amiga, so it passes straight through to a Shell, an editor,
-  or Workbench, and no keys are unexpectedly captured as joystick input. With
-  no pad connected there is simply no port-2 input.
+- `gamepad` (the default) -- only a physical pad drives the joystick port.
+  The keyboard is left to the Amiga, so it passes straight through to a
+  Shell, an editor, or Workbench, and no keys are unexpectedly captured as
+  joystick input. With no pad connected there is simply no joystick input.
 - `keyboard` -- use the keyboard-joystick mapping (cursor keys plus the fire
-  keys), so port 2 stays usable without a controller.
+  keys), so the port stays usable without a controller.
+
+With one joystick/CD32-pad port the mode picks its source. With two, both
+sources are in play -- the gamepad and the keyboard mapping drive one port
+each -- and the mode picks which source gets the lower-numbered port.
 
 This only sets the starting mode. The status-bar toggle (the gamepad /
 keyboard icon next to the volume control), `Cmd+J` / `Alt+J`, the menu's
-**Joystick Input** item, and the launcher's *A/V & Emu* tab all flip it live
+**Joystick Input** item, and the launcher's *Input* tab all flip it live
 without changing the config. `--joystick MODE` overrides this for a single
 run. (`auto` is still accepted here as a backward-compatibility alias for
 `gamepad`; the old auto-detect mode has been removed.)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -490,8 +490,17 @@ than depending on whether a pad happens to be connected:
   keys), so the port stays usable without a controller.
 
 With one joystick/CD32-pad port the mode picks its source. With two, both
-sources are in play -- the gamepad and the keyboard mapping drive one port
-each -- and the mode picks which source gets the lower-numbered port.
+sources are in play -- the gamepad and the cursor-key mapping drive one
+port each -- and the mode picks which source gets the lower-numbered port;
+whenever no physical pad is present, a second keyboard mapping on the
+numeric keypad (`8`/`2`/`4`/`6` directions, `0` fire, `.` second button)
+stands in for the gamepad, so two players can share one keyboard.
+
+The keyboard mapping drives whatever device its port carries. In
+particular, with mice in *both* ports the host mouse takes the
+lower-numbered one and, in `keyboard` mode, the cursor-key mapping drives
+the second as an emulated mouse: cursor keys move the pointer, the fire
+keys are the left button, `X` the right, `D` the middle.
 
 This only sets the starting mode. The status-bar toggle (the gamepad /
 keyboard icon next to the volume control), `Cmd+J` / `Alt+J`, the menu's

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -447,7 +447,7 @@ port2 = "joystick"     # same values; default "cd32" on the CD32 profile
 joystick = "gamepad"   # "gamepad" (default) or "keyboard"
 ```
 
-### Controller ports
+### Port devices
 
 `port1` and `port2` name the controller device plugged into each game port.
 Either port accepts any device, exactly as on real hardware:

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -67,9 +67,10 @@ deterministically:
 |---|---|
 | `--press-after SECS KEY` | Press and release an Amiga key (default ~100 ms hold) |
 | `--key-after SECS KEY MS` | Hold a key for exactly MS milliseconds (for modifier chords) |
-| `--click-after SECS BUTTON MS` | Press a mouse button (`left`/`right`/`middle`) for MS milliseconds |
-| `--joy-after SECS BUTTON MS` | Press a port-2 joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red` (alias `fire`)/`blue`/`green`/`yellow`/`play`/`rwd`/`ffw`) for MS milliseconds |
-| `--mouse-after SECS DX DY` | Apply a relative port-1 mouse motion of (DX, DY) counter steps |
+| `--click-after SECS BUTTON MS [PORT]` | Press a mouse button (`left`/`right`/`middle`) for MS milliseconds (default port 1) |
+| `--joy-after SECS BUTTON MS [PORT]` | Press a joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red` (alias `fire`)/`blue`/`green`/`yellow`/`play`/`rwd`/`ffw`) for MS milliseconds (default port 2) |
+| `--mouse-after SECS DX DY [PORT]` | Apply a relative mouse motion of (DX, DY) counter steps (default port 1) |
+| `--pot-after SECS X Y [PORT]` | Set an analogue controller's stick/paddle position, 0-255 per axis (default port 2) |
 | `--floppy-drives COUNT` | Connect `COUNT` floppy drives (`1` to `4`), so scheduled inserts can target empty external drives |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--defer-disk-insert SECS DFN` | Start with the configured drive empty, then insert its configured image |
@@ -82,6 +83,23 @@ on. All the flags repeat, so several inputs can be queued:
 
 ```sh
 ./target/release/copperline --key-after 14.0 ctrl 500 --press-after 14.1 c
+```
+
+The controller-port flags take an optional trailing `PORT` token (`1` or
+`2`) naming the game port the event lands on, so any controller wiring set
+with `--port1`/`--port2` (see the configuration guide) can be driven:
+omitted, each flag keeps its traditional port (mouse events port 1,
+joystick/pot events port 2), so existing invocations are unchanged. The
+events drive the named port's electrical lines whatever device is
+configured there. (One consequence of the optional token: a positional
+ROM/disk path literally named `1` or `2` cannot directly follow one of
+these flags -- write it as `./1`.)
+
+```sh
+# Joystick in port 1, mouse in port 2, and inputs aimed at each.
+./target/release/copperline --port1 joystick --port2 mouse \
+  --joy-after 43 up 3000 1 --click-after 43 left 3000 2 \
+  --mouse-after 43.5 20 10 2
 ```
 
 ## Input recording and script files
@@ -97,6 +115,9 @@ emulator configuration.
 joy-after 60.0 red 300
 key-after 75.0 f1 200
 insert-disk-after 90.0 df1 "disk 2.adf"
+# port-tagged forms work here too: fire on port 1, paddles on port 2
+joy-after 95.0 red 300 1
+pot-after 96.0 50 200
 ```
 
 Run it with `--script FILE` (combines freely with the other flags).
@@ -108,8 +129,9 @@ live-input recording, written to
 headless equivalent `--record-input PATH` records the whole run and
 writes the file on exit. Every input event that reaches the emulated
 machine is captured with its emulated timestamp -- key holds, mouse
-buttons and motion, port-2 joystick / CD32-pad controls, and floppy
-inserts -- so a manually driven session replays deterministically:
+buttons and motion, joystick / CD32-pad controls, analogue pot positions,
+and floppy inserts -- so a manually driven session replays
+deterministically:
 
 ```sh
 # Play through the section by hand once...
@@ -127,6 +149,16 @@ recorded from that point is a complete, shareable reproduction. Mouse
 motion is captured at frame granularity (one `mouse-after` per frame of
 movement); CD inserts are not recorded -- use the `[cd]` config section
 for those.
+
+The recorder is port-aware: each port is diffed according to the device
+plugged into it (mouse buttons/motion, joystick/pad controls, or analogue
+`pot-after` positions), and a port token is emitted only when it differs
+from the directive's default -- a session on the stock mouse+joystick
+wiring records byte-identically to the pre-port-aware format. Sessions on
+other wirings note it in a `# ports: port1=... port2=...` header comment;
+replay the script together with the matching `--port1`/`--port2` flags.
+Hot-plugging a device mid-recording closes that port's open holds; the
+device change itself has no directive and is not replayed.
 
 ## A deterministic guest clock
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -61,9 +61,9 @@ The status bar (44 pixels below the display) holds, left to right:
   a cue sheet with the proper media-change notification, and a CD eject
   button. These do not appear on machines without a CD drive.
 - **Joystick toggle** (just left of the volume control): a gamepad or
-  keyboard icon showing which source drives the port-2 joystick. Click it to
+  keyboard icon showing which source drives the joystick port. Click it to
   flip between gamepad-only and keyboard joystick emulation; see
-  [](#mouse-and-joystick).
+  [](#controller-ports).
 - **Volume slider**: drag, or scroll the mouse wheel over it for 5% steps.
 - **Hamburger menu button**: opens the pop-up menu (below).
 - **Camera button**: saves a screenshot (same as `Cmd+S` on macOS or
@@ -128,6 +128,9 @@ tool window or overlay.
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Joystick Input** (also `Cmd+J` / `Alt+J`, or the status-bar icon):
   toggles between gamepad-only and keyboard joystick emulation.
+- **Port 1 Device / Port 2 Device**: hot-plug the controller in a game
+  port, cycling mouse, joystick, CD32 pad, analogue, and empty; see
+  [](#controller-ports).
 - **MIDI In / MIDI Out** (shown when the serial port is in MIDI mode):
   cycle Paula's serial bridge through the host's MIDI sources and
   destinations; see the `[serial]` section of
@@ -215,10 +218,10 @@ The layout is:
   insert delay, CD32 NVRAM), *Zorro* (extra autoconfig boards by metadata
   file, with a config panel for a WASM plugin board's declared options),
   *Serial* (serial mode and MIDI input/output endpoints),
-  and *A/V & Emu* (audio output device, channel mode, stereo separation,
-  overscan, pixel aspect, phosphor, floppy sounds and
-  volume, power-on, pacing, realtime priority, warp speed, joystick input
-  mode).
+  *Input* (the controller device in each game port and the joystick input
+  source), and *A/V & Emu* (audio output device, channel mode, stereo
+  separation, overscan, pixel aspect, phosphor, floppy sounds and
+  volume, power-on, pacing, realtime priority, warp speed).
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
   buttons flip a toggle, and the **Browse** and **Clear** buttons set or remove
   a file path through a native file dialog. On the *Hard Disk* tab, once an IDE
@@ -273,7 +276,8 @@ continues.
 `Cmd+Shift+R` on macOS or `Alt+Shift+R` on Linux/Windows (or the menu's
 "Record Input") starts logging every input event that reaches the emulated
 machine -- key presses with their hold times, mouse buttons and motion,
-port-2 joystick / CD32-pad controls, and floppy inserts -- each stamped
+joystick / CD32-pad controls, analogue pot positions, and floppy inserts,
+on whichever port carries each device -- each stamped
 with its emulated time. Pressing it again stops the recording and writes
 `copperline-input-<YYYYMMDDHHmmSS>.clscript` in the working directory: a plain
 text file of scripted-input directives that
@@ -328,35 +332,53 @@ iterate from the state in seconds instead of re-emulating minutes. The
 file format and what exactly is (and is not) captured are specified in
 [the internals chapter](../internals/savestate.md).
 
-## Mouse and joystick
+## Controller ports
 
-The mouse lives on port 1 and feeds the JOY0DAT counters. Click the display
-(or press `Cmd+G` on macOS or `Alt+G` on Linux/Windows) to capture the host
-mouse; the same shortcut releases it. While an overlay panel is open, host
-cursor motion is not fed to the emulated mouse. Tool windows likewise keep
-the debugger or analyzer interaction separate from Amiga mouse input.
+An Amiga has two game ports, and either accepts any controller. Copperline
+models that: each port carries a device -- `mouse`, `joystick`, `cd32` pad,
+`analogue` paddles, or `none` -- set with `[input] port1`/`port2` in the
+config (or `--port1`/`--port2`, or the launcher's *Input* tab). The default
+is the stock wiring, a mouse in port 1 and a joystick in port 2 (a CD32 pad
+on the CD32 profile). The runtime menu's **Port 1 Device** / **Port 2
+Device** items hot-plug a different device live, exactly like swapping the
+physical plug: the old device's lines release, and the port's quadrature
+counters hold.
 
-A USB gamepad drives the emulated port-2 digital joystick: directions
-through JOY1DAT, fire through /FIR1, and a second button through
-POT1Y/POTGOR. On a CD32 machine the pad speaks the CD32 serial button
+The host mouse drives the (lowest-numbered) port with a mouse plugged in
+and feeds its JOYxDAT counters. Click the display (or press `Cmd+G` on
+macOS or `Alt+G` on Linux/Windows) to capture the host mouse; the same
+shortcut releases it. While an overlay panel is open, host cursor motion is
+not fed to the emulated mouse. Tool windows likewise keep the debugger or
+analyzer interaction separate from Amiga mouse input.
+
+A USB gamepad drives the emulated digital joystick on whichever port one is
+plugged into: directions through JOYxDAT, fire through /FIRx, and a second
+button through POTxY/POTGOR. A `cd32` device speaks the CD32 serial button
 protocol instead, including the red/blue/green/yellow and transport
-buttons. Mouse and gamepad coexist because they use different ports.
+buttons, on either port. An `analogue` device presents pot resistances on
+the POTxX/POTxY pins; no live host device maps to it yet -- drive it with
+`--pot-after` scripting or the control protocol's `input.analogue`.
 
-Copperline can also emulate the port-2 joystick from the host keyboard.
-There are two explicit input modes, and the active one is always shown by the
-gamepad / keyboard icon in the status bar (next to the volume control), so a
-"my keys aren't working" surprise can be spotted and fixed at a glance:
+Copperline can also emulate the joystick from the host keyboard. There are
+two explicit input modes, and the active one is always shown by the gamepad
+/ keyboard icon in the status bar (next to the volume control), so a "my
+keys aren't working" surprise can be spotted and fixed at a glance:
 
 - **gamepad** (the default): use only a calibrated gamepad; every keyboard
-  key passes through to the Amiga. With no pad connected there is no port-2
-  input. This is the no-surprise mode for interactive AmigaOS setup.
-- **keyboard**: use the keyboard-joystick mapping so port 2 works without a
-  controller.
+  key passes through to the Amiga. With no pad connected there is no
+  joystick input. This is the no-surprise mode for interactive AmigaOS
+  setup.
+- **keyboard**: use the keyboard-joystick mapping so the joystick port
+  works without a controller.
+
+With joysticks (or pads) in *both* ports -- a two-player setup -- the
+gamepad and the keyboard mapping drive one port each, and the mode picks
+which source gets the lower-numbered port.
 
 Click the status-bar icon to flip between them; the menu's **Joystick Input**
 item and `Cmd+J` on macOS / `Alt+J` on Linux and Windows do the same. Set the
 starting mode with `[input] joystick` in the config (or `--joystick MODE`, or
-the launcher's *A/V & Emu* tab).
+the launcher's *Input* tab).
 
 Keyboard joystick mode uses the FS-UAE-compatible mapping: cursor keys for
 directions, and Right Ctrl or Right Alt for fire. For CD32 pad buttons,

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -372,19 +372,31 @@ keys aren't working" surprise can be spotted and fixed at a glance:
   works without a controller.
 
 With joysticks (or pads) in *both* ports -- a two-player setup -- the
-gamepad and the keyboard mapping drive one port each, and the mode picks
-which source gets the lower-numbered port.
+gamepad and the cursor-key mapping drive one port each, and the mode picks
+which source gets the lower-numbered port. Whenever no physical pad is
+present, a second keyboard mapping on the numeric keypad stands in for it,
+so two players can share one keyboard.
+
+With mice in both ports, the host mouse drives the lower-numbered one and
+the cursor-key mapping drives the second as an emulated mouse (in
+`keyboard` mode; in `gamepad` mode the second mouse is undriven and the
+keyboard passes through). The same applies whenever the keyboard-routed
+port carries a mouse: the mapping's keys become the pointer.
 
 Click the status-bar icon to flip between them; the menu's **Joystick Input**
 item and `Cmd+J` on macOS / `Alt+J` on Linux and Windows do the same. Set the
 starting mode with `[input] joystick` in the config (or `--joystick MODE`, or
 the launcher's *Input* tab).
 
-Keyboard joystick mode uses the FS-UAE-compatible mapping: cursor keys for
+The primary keyboard mapping is FS-UAE-compatible: cursor keys for
 directions, and Right Ctrl or Right Alt for fire. For CD32 pad buttons,
 `C` is red/fire, `X` is blue, `D` is green, `S` is yellow, Return is
-play/pause, `Z` is rewind, and `A` is forward. While keyboard joystick mode
-owns these keys, they are not sent to the Amiga keyboard.
+play/pause, `Z` is rewind, and `A` is forward. On a mouse port the same
+keys drive the pointer: cursor keys move it, the fire keys are the left
+button, `X` the right, and `D` the middle. The second (numpad) mapping is
+`8`/`2`/`4`/`6` for directions, `0` for fire, `.` for the second button,
+and numpad Enter for play. While a mapping owns its keys, they are not
+sent to the Amiga keyboard.
 
 ## Gamepad calibration
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -702,14 +702,6 @@ pub struct Bus {
     /// most recent Gayle IDE activity, so short synchronous transfers stay
     /// visible for a human-perceptible stretch.
     hdd_led_until_cck: u64,
-    /// CD32 joypad shift register position for port 2: starts at 8
-    /// (Blue), decremented by /FIR1 falling edges the CPU drives while
-    /// the pad is in serial mode, 1 returns the pad-present bit, 0
-    /// returns zeros. Reset to 8 whenever serial mode is left.
-    cd32_pad_shifter: i8,
-    /// Previous CPU-driven /FIR1 output level (DDR & PRA & 0x80), for
-    /// the shift-clock edge detector.
-    cd32_pad_fire_oldstate: u8,
     /// One-time diagnostic when software writes BPLCON3 and the write is
     /// dropped (OCS Denise, or ECS with ENBPLCN3 clear).
     bplcon3_drop_warned: bool,
@@ -1782,51 +1774,170 @@ impl VideoPipelineStats {
     }
 }
 
+/// The kind of controller plugged into an Amiga game port. Selects how the
+/// port's pins are driven: which JOYxDAT encoding the port reports, what
+/// /FIRx and POTxX/POTxY carry, and whether the CD32 pad's serial button
+/// shifter is present. Either port accepts any device, as on real hardware.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum PortDevice {
+    /// Quadrature mouse: JOYxDAT reports the movement counters, left button
+    /// on /FIRx, right on POTxY, middle on POTxX.
+    #[default]
+    Mouse,
+    /// Digital switch joystick: directions encode into JOYxDAT, fire on
+    /// /FIRx, button 2 grounds POTxY.
+    Joystick,
+    /// CD32 joypad: a digital joystick plus the serial button shifter
+    /// (POTxX driven low selects shift mode, /FIRx clocks, POTxY is data).
+    Cd32Pad,
+    /// Analogue paddles / proportional stick: positions present resistances
+    /// on POTxX/POTxY; the two buttons ground the LEFT/RIGHT lines.
+    Analogue,
+    /// Empty port: nothing drives the pins. Reads like an idle mouse (the
+    /// JOYxDAT counters hold, the pot pins float).
+    None,
+}
+
+impl PortDevice {
+    /// Canonical configuration name, as accepted by `[input] port1/port2`.
+    pub fn label(self) -> &'static str {
+        match self {
+            PortDevice::Mouse => "mouse",
+            PortDevice::Joystick => "joystick",
+            PortDevice::Cd32Pad => "cd32",
+            PortDevice::Analogue => "analogue",
+            PortDevice::None => "none",
+        }
+    }
+
+    /// Parse a configuration name (canonical or alias, case-insensitive).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "mouse" => Some(PortDevice::Mouse),
+            "joystick" | "joy" => Some(PortDevice::Joystick),
+            "cd32" | "cd32pad" | "pad" => Some(PortDevice::Cd32Pad),
+            "analogue" | "analog" | "paddle" => Some(PortDevice::Analogue),
+            "none" | "off" => Some(PortDevice::None),
+            _ => None,
+        }
+    }
+}
+
+/// One Amiga game port: the device plugged into it plus the state of every
+/// line a controller can drive. The JOYxDAT counters are chip-side state, so
+/// they survive device changes and JOYTEST loads them whatever is plugged in.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct ControllerPort {
+    pub device: PortDevice,
+    /// JOYxDAT horizontal/vertical quadrature counters.
+    pub counter_x: u8,
+    pub counter_y: u8,
+    /// Primary button line /FIRx (CIA-A PRA bit 6/7 reports it active-low):
+    /// left mouse button / joystick fire / CD32 Red.
+    pub fire: bool,
+    /// POTxY switch to ground: right mouse button / joystick button 2 /
+    /// CD32 Blue.
+    pub button2: bool,
+    /// POTxX switch to ground: middle mouse button (third button).
+    pub button3: bool,
+    /// Direction switch lines. On an Analogue device the left/right lines
+    /// double as the two paddle buttons (HRM paddle wiring).
+    pub up: bool,
+    pub down: bool,
+    pub left: bool,
+    pub right: bool,
+    /// CD32 buttons that exist only in the serial report (Red rides `fire`,
+    /// Blue rides `button2`).
+    pub cd32_play: bool,
+    pub cd32_rwd: bool,
+    pub cd32_ffw: bool,
+    pub cd32_green: bool,
+    pub cd32_yellow: bool,
+    /// CD32 serial shift position: starts at 8 (Blue), decremented by /FIRx
+    /// falling edges the CPU drives while the pad is in serial mode, 1
+    /// returns the pad-present bit, 0 returns zeros. Reset to 8 whenever
+    /// serial mode is left.
+    pub cd32_shifter: i8,
+    /// Previous CPU-driven /FIRx output level (DDR and PRA), the shift-clock
+    /// falling-edge detector's memory.
+    pub cd32_fire_driven_high: bool,
+    /// Analogue resistance from +5 V to POTxX/POTxY in ohms; `None` leaves
+    /// the pin floating. Values above Paula's specified maximum are clamped
+    /// by the converter.
+    pub pot_x_ohms: Option<u32>,
+    pub pot_y_ohms: Option<u32>,
+}
+
+impl Default for ControllerPort {
+    fn default() -> Self {
+        Self {
+            device: PortDevice::Mouse,
+            counter_x: 0,
+            counter_y: 0,
+            fire: false,
+            button2: false,
+            button3: false,
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+            cd32_play: false,
+            cd32_rwd: false,
+            cd32_ffw: false,
+            cd32_green: false,
+            cd32_yellow: false,
+            cd32_shifter: 8,
+            cd32_fire_driven_high: false,
+            pot_x_ohms: None,
+            pot_y_ohms: None,
+        }
+    }
+}
+
+impl ControllerPort {
+    /// The JOYxDAT word this port's device presents.
+    pub fn joydat(&self) -> u16 {
+        match self.device {
+            PortDevice::Mouse | PortDevice::None => mouse_joydat(self.counter_x, self.counter_y),
+            PortDevice::Joystick | PortDevice::Cd32Pad => {
+                digital_joydat(self.up, self.down, self.left, self.right)
+            }
+            PortDevice::Analogue => {
+                // Paddle buttons are switches on the LEFT/RIGHT lines, which
+                // read back directly as JOYxDAT bits 9 and 1 on top of the
+                // idle counters.
+                let mut v = mouse_joydat(self.counter_x, self.counter_y);
+                if self.left {
+                    v |= 0x0200;
+                }
+                if self.right {
+                    v |= 0x0002;
+                }
+                v
+            }
+        }
+    }
+
+    /// The /FIRx line pulled to ground (CIA-A reports it active-low).
+    pub fn fir_asserted(&self) -> bool {
+        self.fire
+    }
+
+    /// POTxX pin not switched to ground (the polarity `PotPins` carries).
+    pub fn pot_x_released(&self) -> bool {
+        !self.button3
+    }
+
+    /// POTxY pin not switched to ground.
+    pub fn pot_y_released(&self) -> bool {
+        !self.button2
+    }
+}
+
 #[derive(Default, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct InputState {
-    pub mouse_x_port1: u8,
-    pub mouse_y_port1: u8,
-    pub mouse_x_port2: u8,
-    pub mouse_y_port2: u8,
-    pub lmb_port1: bool,
-    pub lmb_port2: bool,
-    pub rmb_port1: bool,
-    pub rmb_port2: bool,
-    /// A CD32 joypad is plugged into port 2: enables the pad's serial
-    /// button protocol (POT1X low selects shift mode, the /FIR1 line
-    /// clocks, POT1Y carries the active-low button bits). Red rides the
-    /// normal fire line (`lmb_port2`), Blue the button-2 line
-    /// (`rmb_port2`); the rest only exist serially.
-    pub cd32_pad_port2: bool,
-    pub cd32_play_port2: bool,
-    pub cd32_rwd_port2: bool,
-    pub cd32_ffw_port2: bool,
-    pub cd32_green_port2: bool,
-    pub cd32_yellow_port2: bool,
-    pub mmb_port1: bool,
-    pub mmb_port2: bool,
-    /// Optional analogue paddle resistance from +5 V to POT0X/POT0Y/POT1X/
-    /// POT1Y, in ohms. `None` leaves the pin floating, which is the normal
-    /// mouse/digital-joystick default. Values above Paula's specified maximum
-    /// are clamped by the converter.
-    pub pot_resistance_ohms: [Option<u32>; 4],
-    /// Digital-joystick direction lines per controller port. When the
-    /// matching `joystick_portN` flag is set, JOYxDAT reports these as the
-    /// Gray-coded direction bits an Amiga game decodes, instead of the mouse
-    /// quadrature counters. Fire reuses the FIR0/FIR1 lines (`lmb_portN`),
-    /// which CIA-A PRA bits 6/7 already report.
-    pub joy_up_port1: bool,
-    pub joy_down_port1: bool,
-    pub joy_left_port1: bool,
-    pub joy_right_port1: bool,
-    pub joy_up_port2: bool,
-    pub joy_down_port2: bool,
-    pub joy_left_port2: bool,
-    pub joy_right_port2: bool,
-    /// True when a digital joystick (not a mouse) is the active device on the
-    /// port, so JOYxDAT returns the direction encoding.
-    pub joystick_port1: bool,
-    pub joystick_port2: bool,
+    /// Index 0 = port 1 (JOY0DAT/POT0/FIR0), 1 = port 2 (JOY1DAT/POT1/FIR1).
+    pub ports: [ControllerPort; 2],
 }
 
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -1907,51 +2018,65 @@ impl DeviceClock {
 }
 
 impl InputState {
-    pub fn add_mouse_delta_port1(&mut self, dx: i32, dy: i32) {
-        self.mouse_x_port1 = self.mouse_x_port1.wrapping_add(dx as u8);
-        self.mouse_y_port1 = self.mouse_y_port1.wrapping_add(dy as u8);
+    /// Port argument convention across the input API: 0 selects port 1,
+    /// every other value port 2.
+    fn port_index(port: usize) -> usize {
+        usize::from(port != 0)
     }
 
-    pub fn write_joytest(&mut self, val: u16) {
-        self.mouse_y_port1 = (val >> 8) as u8;
-        self.mouse_x_port1 = val as u8;
-        self.mouse_y_port2 = (val >> 8) as u8;
-        self.mouse_x_port2 = val as u8;
+    /// The device currently plugged into a port.
+    pub fn device(&self, port: usize) -> PortDevice {
+        self.ports[Self::port_index(port)].device
     }
 
-    pub fn joy0dat(&self) -> u16 {
-        if self.joystick_port1 {
-            digital_joydat(
-                self.joy_up_port1,
-                self.joy_down_port1,
-                self.joy_left_port1,
-                self.joy_right_port1,
-            )
-        } else {
-            mouse_joydat(self.mouse_x_port1, self.mouse_y_port1)
+    /// Change the device plugged into a port. Unplugging releases every line
+    /// the old device drove; the JOYxDAT counters are chip-side and hold
+    /// their values. A freshly plugged analogue controller presents its pots
+    /// centred: a real paddle always shows some resistance.
+    pub fn set_port_device(&mut self, port: usize, device: PortDevice) {
+        let p = &mut self.ports[Self::port_index(port)];
+        if p.device == device {
+            return;
+        }
+        *p = ControllerPort {
+            device,
+            counter_x: p.counter_x,
+            counter_y: p.counter_y,
+            ..ControllerPort::default()
+        };
+        if device == PortDevice::Analogue {
+            let centre = crate::chipset::paula::pot_position_resistance_ohms(128);
+            p.pot_x_ohms = Some(centre);
+            p.pot_y_ohms = Some(centre);
         }
     }
 
-    pub fn joy1dat(&self) -> u16 {
-        if self.joystick_port2 {
-            digital_joydat(
-                self.joy_up_port2,
-                self.joy_down_port2,
-                self.joy_left_port2,
-                self.joy_right_port2,
-            )
-        } else {
-            mouse_joydat(self.mouse_x_port2, self.mouse_y_port2)
+    /// Accumulate mouse quadrature movement into a port's JOYxDAT counters.
+    pub fn add_mouse_delta(&mut self, port: usize, dx: i32, dy: i32) {
+        let p = &mut self.ports[Self::port_index(port)];
+        p.counter_x = p.counter_x.wrapping_add(dx as u8);
+        p.counter_y = p.counter_y.wrapping_add(dy as u8);
+    }
+
+    /// Mouse buttons by index: 0 = left (/FIRx), 1 = right (POTxY),
+    /// 2 = middle (POTxX).
+    pub fn set_mouse_button(&mut self, port: usize, index: u8, pressed: bool) {
+        let p = &mut self.ports[Self::port_index(port)];
+        match index {
+            0 => p.fire = pressed,
+            1 => p.button2 = pressed,
+            _ => p.button3 = pressed,
         }
     }
 
-    /// Set the port-2 digital joystick state from a host gamepad. Marks the
-    /// port as a joystick so JOY1DAT reports directions. Fire (button 1)
-    /// drives /FIR1 (CIA-A PRA bit 7) through the shared `lmb_port2` line;
-    /// button 2 drives POT1Y, read back through POTGOR (the shared
-    /// `rmb_port2` line), matching a real Amiga's second joystick button.
-    pub fn set_joystick_port2(
+    /// Set a port's digital-joystick state. Engages the Joystick device on a
+    /// Mouse or empty port so JOYxDAT reports directions; a CD32 pad or
+    /// analogue controller keeps its device and just has its lines driven --
+    /// fire is /FIRx, button 2 grounds POTxY, and the direction switch lines
+    /// double as the paddle buttons on an analogue device.
+    pub fn set_joystick(
         &mut self,
+        port: usize,
         up: bool,
         down: bool,
         left: bool,
@@ -1959,40 +2084,90 @@ impl InputState {
         fire: bool,
         button2: bool,
     ) {
-        self.joystick_port2 = true;
-        self.joy_up_port2 = up;
-        self.joy_down_port2 = down;
-        self.joy_left_port2 = left;
-        self.joy_right_port2 = right;
-        self.lmb_port2 = fire;
-        self.rmb_port2 = button2;
+        let idx = Self::port_index(port);
+        if matches!(self.ports[idx].device, PortDevice::Mouse | PortDevice::None) {
+            self.set_port_device(port, PortDevice::Joystick);
+        }
+        let p = &mut self.ports[idx];
+        p.up = up;
+        p.down = down;
+        p.left = left;
+        p.right = right;
+        p.fire = fire;
+        p.button2 = button2;
     }
 
-    /// Set the CD32 joypad's extra buttons (port 2). Red and Blue arrive
-    /// through `set_joystick_port2` as fire/button2; these five only
-    /// exist in the pad's serial report.
-    pub fn set_cd32_buttons_port2(
+    /// Set a CD32 joypad's extra buttons. Red and Blue arrive through
+    /// `set_joystick` as fire/button2; these five only exist in the pad's
+    /// serial report.
+    pub fn set_cd32_buttons(
         &mut self,
+        port: usize,
         play: bool,
         rwd: bool,
         ffw: bool,
         green: bool,
         yellow: bool,
     ) {
-        self.cd32_play_port2 = play;
-        self.cd32_rwd_port2 = rwd;
-        self.cd32_ffw_port2 = ffw;
-        self.cd32_green_port2 = green;
-        self.cd32_yellow_port2 = yellow;
+        let p = &mut self.ports[Self::port_index(port)];
+        p.cd32_play = play;
+        p.cd32_rwd = rwd;
+        p.cd32_ffw = ffw;
+        p.cd32_green = green;
+        p.cd32_yellow = yellow;
     }
 
-    /// Connect an analogue paddle pair to a controller port. Each resistance
-    /// is measured from +5 V to the corresponding POT pin; `None` disconnects
-    /// that axis. Port 0 maps to POT0X/Y, every other value to POT1X/Y.
+    /// Set an analogue controller's stick/paddle position, 0..=255 per axis:
+    /// the count the port's POTxDAT byte latches after a POTGO scan. Engages
+    /// the Analogue device.
+    pub fn set_analogue(&mut self, port: usize, x: u8, y: u8) {
+        let idx = Self::port_index(port);
+        if self.ports[idx].device != PortDevice::Analogue {
+            self.set_port_device(port, PortDevice::Analogue);
+        }
+        let p = &mut self.ports[idx];
+        p.pot_x_ohms = Some(crate::chipset::paula::pot_position_resistance_ohms(x));
+        p.pot_y_ohms = Some(crate::chipset::paula::pot_position_resistance_ohms(y));
+    }
+
+    /// Connect an analogue paddle pair to a controller port by raw
+    /// resistance. Each value is measured from +5 V to the corresponding POT
+    /// pin; `None` disconnects that axis. Does not change the port's device.
     pub fn set_paddle_resistance(&mut self, port: usize, x_ohms: Option<u32>, y_ohms: Option<u32>) {
-        let base = usize::from(port != 0) * 2;
-        self.pot_resistance_ohms[base] = x_ohms;
-        self.pot_resistance_ohms[base + 1] = y_ohms;
+        let p = &mut self.ports[Self::port_index(port)];
+        p.pot_x_ohms = x_ohms;
+        p.pot_y_ohms = y_ohms;
+    }
+
+    /// JOYTEST loads both ports' quadrature counters with the same value,
+    /// whatever devices are plugged in.
+    pub fn write_joytest(&mut self, val: u16) {
+        for p in &mut self.ports {
+            p.counter_y = (val >> 8) as u8;
+            p.counter_x = val as u8;
+        }
+    }
+
+    /// The JOYxDAT word for a port (0 = JOY0DAT, other = JOY1DAT).
+    pub fn joydat(&self, port: usize) -> u16 {
+        self.ports[Self::port_index(port)].joydat()
+    }
+
+    /// A machine reset: the chips reset but nothing is unplugged. Each
+    /// port keeps its device and analogue knob positions (physical
+    /// state), while the chip-side quadrature counters clear, the pad
+    /// shifters reload, and the driven lines release -- the host input
+    /// path re-asserts anything still physically held on the next
+    /// quantum.
+    pub fn reset_for_machine_reset(&mut self) {
+        for p in &mut self.ports {
+            *p = ControllerPort {
+                device: p.device,
+                pot_x_ohms: p.pot_x_ohms,
+                pot_y_ohms: p.pot_y_ohms,
+                ..ControllerPort::default()
+            };
+        }
     }
 }
 
@@ -2145,8 +2320,6 @@ impl Bus {
             cdtv: None,
             devices: Vec::new(),
             hdd_led_until_cck: 0,
-            cd32_pad_shifter: 8,
-            cd32_pad_fire_oldstate: 0,
             bplcon3_drop_warned: false,
             cpu_fetch_latch: [None; 2],
             overlay_disable_pending: false,
@@ -2827,7 +3000,7 @@ impl Bus {
         // held and are reported in the upcoming $FD/$FE stream.
         self.keyboard.begin_power_up();
         self.keyboard_system_reset_pending = false;
-        self.input = InputState::default();
+        self.input.reset_for_machine_reset();
         self.video_pipeline_stats = VideoPipelineStats::default();
         self.slice_preempted = false;
         self.pending_vbi = 0;
@@ -4533,12 +4706,12 @@ impl Bus {
             // PRA bits 6 and 7 (/FIR0, /FIR1) report the live port-1/port-2
             // primary button: left-mouse button or joystick fire (they share
             // the FIR line). Active-low: 0 = pressed, 1 = released.
-            if self.input.lmb_port1 {
+            if self.input.ports[0].fir_asserted() {
                 v &= !0x40;
             } else {
                 v |= 0x40;
             }
-            if self.input.lmb_port2 {
+            if self.input.ports[1].fir_asserted() {
                 v &= !0x80;
             } else {
                 v |= 0x80;
@@ -4583,47 +4756,54 @@ impl Bus {
         eff
     }
 
-    /// Whether the port-2 CD32 pad is in serial (shift) mode: the CPU
-    /// drives POT1X (P5) low through POTGO (OUTRX set, DATRX clear).
-    fn cd32_pad_serial_mode(&self) -> bool {
-        self.input.cd32_pad_port2 && self.paula.potgo & 0x3000 == 0x2000
+    /// Whether a port's CD32 pad is in serial (shift) mode: the CPU drives
+    /// that port's POTxX pin low through POTGO (output-enable set, data
+    /// clear; POT0X lives at bits 9/8, POT1X at bits 13/12).
+    fn cd32_pad_serial_mode(&self, port: usize) -> bool {
+        let x_dat = (8 + 4 * port) as u16;
+        self.input.ports[port].device == PortDevice::Cd32Pad
+            && self.paula.potgo & (0x3 << x_dat) == (0x2 << x_dat)
     }
 
-    /// CD32 pad shift clock: with the pad in serial mode, a falling edge
-    /// the CPU drives on /FIR1 (CIA-A PRA bit 7 with DDR output) steps
-    /// the shift register. Outside serial mode the register reloads.
+    /// CD32 pad shift clock: with a pad in serial mode, a falling edge the
+    /// CPU drives on that port's /FIRx line (CIA-A PRA bit 6/7 with DDR
+    /// output) steps its shift register. Outside serial mode the register
+    /// reloads.
     fn cd32_pad_cia_clock(&mut self) {
-        if !self.input.cd32_pad_port2 {
-            return;
-        }
-        const FIR1: u8 = 0x80;
         let pra = self.cia_a.peek_register(REG_PRA);
         let ddra = self.cia_a.peek_register(REG_DDRA);
-        if self.cd32_pad_serial_mode() {
-            if ddra & FIR1 != 0 && (pra & FIR1) != self.cd32_pad_fire_oldstate && pra & FIR1 == 0 {
-                self.cd32_pad_shifter = (self.cd32_pad_shifter - 1).max(0);
+        for port in 0..2 {
+            if self.input.ports[port].device != PortDevice::Cd32Pad {
+                continue;
             }
-        } else {
-            self.cd32_pad_shifter = 8;
+            let fir = 0x40u8 << port;
+            if self.cd32_pad_serial_mode(port) {
+                let p = &mut self.input.ports[port];
+                if ddra & fir != 0 && p.cd32_fire_driven_high && pra & fir == 0 {
+                    p.cd32_shifter = (p.cd32_shifter - 1).max(0);
+                }
+            } else {
+                self.input.ports[port].cd32_shifter = 8;
+            }
+            self.input.ports[port].cd32_fire_driven_high = ddra & pra & fir != 0;
         }
-        self.cd32_pad_fire_oldstate = ddra & pra & FIR1;
     }
 
-    /// The serial button bit for the current shift position, active-low
-    /// on POT1Y. Order from 8 down: Blue, Red, Yellow, Green, FFW, RWD,
-    /// Play; 1 is the always-high pad-present bit; 0 reads zero.
-    fn cd32_pad_serial_bit(&self) -> bool {
-        let input = &self.input;
-        match self.cd32_pad_shifter {
+    /// The serial button bit for a pad's current shift position, active-low
+    /// on its POTxY pin. Order from 8 down: Blue, Red, Yellow, Green, FFW,
+    /// RWD, Play; 1 is the always-high pad-present bit; 0 reads zero.
+    fn cd32_pad_serial_bit(&self, port: usize) -> bool {
+        let p = &self.input.ports[port];
+        match p.cd32_shifter {
             0 => false,
             1 => true,
-            2 => !input.cd32_play_port2,
-            3 => !input.cd32_rwd_port2,
-            4 => !input.cd32_ffw_port2,
-            5 => !input.cd32_green_port2,
-            6 => !input.cd32_yellow_port2,
-            7 => !input.lmb_port2, // Red
-            _ => !input.rmb_port2, // Blue
+            2 => !p.cd32_play,
+            3 => !p.cd32_rwd,
+            4 => !p.cd32_ffw,
+            5 => !p.cd32_green,
+            6 => !p.cd32_yellow,
+            7 => !p.fire,    // Red
+            _ => !p.button2, // Blue
         }
     }
 

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -28,8 +28,8 @@ impl Bus {
             }
             0x004 => self.agnus.read_vposr(), // VPOSR
             0x006 => self.agnus.read_vhposr(),
-            0x00A => self.input.joy0dat(), // JOY0DAT (mouse port 1 counters)
-            0x00C => self.input.joy1dat(), // JOY1DAT (mouse port 2 counters)
+            0x00A => self.input.joydat(0), // JOY0DAT (port 1)
+            0x00C => self.input.joydat(1), // JOY1DAT (port 2)
             0x00E => {
                 // Software is observing collisions: arm the per-frame flush from
                 // now on so the latch is maintained exactly as hardware does.
@@ -44,19 +44,25 @@ impl Bus {
             0x016 => {
                 // POTGOR
                 let mut v = self.paula.read_potgor(self.pot_pins());
-                if self.cd32_pad_serial_mode() {
-                    // P5 reads low (driven), P9 carries the serial bit.
-                    v &= !(1 << 12);
-                    if self.cd32_pad_serial_bit() && !self.input.rmb_port2 {
-                        v |= 1 << 14;
-                    } else {
-                        v &= !(1 << 14);
+                for port in 0..2 {
+                    let x_bit = (8 + 4 * port) as u16; // POT0X=8, POT1X=12
+                    let y_bit = x_bit + 2; // POT0Y=10, POT1Y=14
+                    if self.cd32_pad_serial_mode(port) {
+                        // The mode-select POTxX pin reads low (driven);
+                        // POTxY carries the serial bit, which a held Blue
+                        // button still grounds.
+                        v &= !(1 << x_bit);
+                        if self.cd32_pad_serial_bit(port) && !self.input.ports[port].button2 {
+                            v |= 1 << y_bit;
+                        } else {
+                            v &= !(1 << y_bit);
+                        }
+                    } else if self.input.ports[port].device == PortDevice::Cd32Pad {
+                        // Leaving serial mode reloads the shift register.
+                        // (Interior mutability not needed: POTGOR reads come
+                        // through custom_read with &mut self.)
+                        self.input.ports[port].cd32_shifter = 8;
                     }
-                } else if self.input.cd32_pad_port2 {
-                    // Leaving serial mode reloads the shift register.
-                    // (Interior mutability not needed: POTGOR reads come
-                    // through custom_read with &mut self.)
-                    self.cd32_pad_shifter = 8;
                 }
                 v
             }
@@ -99,12 +105,13 @@ impl Bus {
     }
 
     pub(super) fn pot_pins(&self) -> PotPins {
+        let [p1, p2] = &self.input.ports;
         PotPins {
-            left_x_released: !self.input.mmb_port1,
-            left_y_released: !self.input.rmb_port1,
-            right_x_released: !self.input.mmb_port2,
-            right_y_released: !self.input.rmb_port2,
-            resistance_ohms: self.input.pot_resistance_ohms,
+            left_x_released: p1.pot_x_released(),
+            left_y_released: p1.pot_y_released(),
+            right_x_released: p2.pot_x_released(),
+            right_y_released: p2.pot_y_released(),
+            resistance_ohms: [p1.pot_x_ohms, p1.pot_y_ohms, p2.pot_x_ohms, p2.pot_y_ohms],
         }
     }
 
@@ -118,6 +125,10 @@ impl Bus {
             0x02E => Some(self.agnus.copcon),
             0x032 => Some(self.paula.serper),
             0x034 => Some(self.paula.potgo),
+            // The pot counters are stored words a scan latches; reading
+            // them has no side effect, unlike most read-only counters.
+            0x012 => Some(self.paula.read_potdat(0)),
+            0x014 => Some(self.paula.read_potdat(1)),
             0x098 => Some(self.denise.clxcon),
             0x040 => Some(self.blitter.bltcon0),
             0x042 => Some(self.blitter.bltcon1),

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -12,7 +12,7 @@ use super::{
     live_sprite_sprite_collision_bits, visible_start_vpos_for_diw, BeamChipRamWrite,
     BeamRegisterWrite, BeamWriteSource, Bus, CapturedBitplaneRow, CapturedSpriteLine, ChipBusOwner,
     CpuBusAccessKind, DeviceClock, DisplaySpriteDmaState, DisplaySpriteLineData, FrameBusTrace,
-    LiveCollisionControl, LiveCollisionLineReplay, LiveSpriteCollisionSource,
+    LiveCollisionControl, LiveCollisionLineReplay, LiveSpriteCollisionSource, PortDevice,
     RenderRegisterSnapshot, BLITTER_SLOWDOWN_CPU_MISS_LIMIT, BLTCON0_USE_A, BLTCON0_USE_C,
     BLTCON0_USE_D, BLTCON1_DOFF, BLTCON1_LINE, BPLCON0_ECSENA, BPLCON3_BRDRBLNK, BPLCON3_BRDSPRT,
     BPLCON3_SPRES_HIRES, DENISE_HPOS_LAG_CCK, DMACON_BLTEN, DMACON_BLTPRI, DMACON_BPLEN,
@@ -9172,12 +9172,12 @@ fn a1000_led_line_does_not_switch_the_audio_filter() {
 fn cd32_pad_serial_protocol_shifts_button_bits() {
     use crate::chipset::cia::REG_DDRA;
     let mut bus = empty_bus();
-    bus.input.cd32_pad_port2 = true;
+    bus.input.set_port_device(1, PortDevice::Cd32Pad);
     // Pressed: Red (fire line), Green, Play. Released: Blue, Yellow,
     // FFW, RWD.
-    bus.input.lmb_port2 = true;
-    bus.input.cd32_green_port2 = true;
-    bus.input.cd32_play_port2 = true;
+    bus.input.ports[1].fire = true;
+    bus.input.ports[1].cd32_green = true;
+    bus.input.ports[1].cd32_play = true;
 
     // lowlevel.library's read: drive /FIR1 as output high, put the
     // pad into serial mode by driving POT1X low through POTGO, then
@@ -9220,6 +9220,190 @@ fn cd32_pad_serial_protocol_shifts_button_bits() {
 }
 
 #[test]
+fn cd32_pad_serial_protocol_on_port_1_uses_pot0x_fir0_and_pot0y() {
+    use crate::chipset::cia::REG_DDRA;
+    let mut bus = empty_bus();
+    bus.input.set_port_device(0, PortDevice::Cd32Pad);
+    // Pressed: Red (fire line), Green, Play. Released: Blue, Yellow,
+    // FFW, RWD.
+    bus.input.ports[0].fire = true;
+    bus.input.ports[0].cd32_green = true;
+    bus.input.ports[0].cd32_play = true;
+
+    // The port-1 mirror of the pad read: drive /FIR0 (PA6) as output
+    // high, select serial mode by driving POT0X low through POTGO
+    // (OUTLX set, DATLX clear -> bits 9/8 = 10), then sample POT0Y
+    // (bit 10) and clock with /FIR0 edges.
+    let ddra = (REG_DDRA as u64) << 8;
+    let pra = (REG_PRA as u64) << 8;
+    let _ = bus.cia_a_write(ddra, 1, 0x40);
+    let _ = bus.cia_a_write(pra, 1, 0x40);
+    bus.custom_write(0x034, 2, 0x0200);
+
+    let expected = [
+        true,  // 8 Blue released
+        false, // 7 Red pressed
+        true,  // 6 Yellow released
+        false, // 5 Green pressed
+        true,  // 4 FFW released
+        true,  // 3 RWD released
+        false, // 2 Play pressed
+        true,  // 1 pad-present
+        false, // 0 zeros
+        false, // stays zero
+    ];
+    for (step, want) in expected.iter().enumerate() {
+        let potgor = bus.custom_read(0x016, 2) as u16;
+        assert_eq!(potgor & (1 << 10) != 0, *want, "serial bit at step {step}");
+        // The mode-select POT0X pin reads low throughout.
+        assert_eq!(potgor & (1 << 8), 0, "POT0X driven low at step {step}");
+        let _ = bus.cia_a_write(pra, 1, 0x00); // falling edge: shift
+        let _ = bus.cia_a_write(pra, 1, 0x40); // rising edge
+    }
+
+    // Leaving serial mode reloads the shifter: Blue again first.
+    bus.custom_write(0x034, 2, 0x0300); // POT0X driven high
+    let _ = bus.custom_read(0x016, 2);
+    bus.custom_write(0x034, 2, 0x0200);
+    let potgor = bus.custom_read(0x016, 2) as u16;
+    assert!(potgor & (1 << 10) != 0, "Blue (released) after reload");
+}
+
+#[test]
+fn cd32_pads_shift_independently_per_port() {
+    use crate::chipset::cia::REG_DDRA;
+    let mut bus = empty_bus();
+    bus.input.set_port_device(0, PortDevice::Cd32Pad);
+    bus.input.set_port_device(1, PortDevice::Cd32Pad);
+    // Red pressed on both pads: a pad that has shifted once reports Red
+    // (0), one still at the reload position reports Blue released (1).
+    bus.input.ports[0].fire = true;
+    bus.input.ports[1].fire = true;
+
+    let ddra = (REG_DDRA as u64) << 8;
+    let pra = (REG_PRA as u64) << 8;
+    // Only /FIR1 is CPU-driven; /FIR0 stays an input.
+    let _ = bus.cia_a_write(ddra, 1, 0x80);
+    let _ = bus.cia_a_write(pra, 1, 0x80);
+    // Both X pins driven low: both pads in serial mode.
+    bus.custom_write(0x034, 2, 0x2200);
+
+    // Clock /FIR1 once: only the port-2 shifter advances to Red.
+    let _ = bus.cia_a_write(pra, 1, 0x00);
+    let _ = bus.cia_a_write(pra, 1, 0x80);
+    let potgor = bus.custom_read(0x016, 2) as u16;
+    assert_eq!(potgor & (1 << 14), 0, "port 2 shifted to Red (pressed)");
+    assert_ne!(potgor & (1 << 10), 0, "port 1 still at Blue (released)");
+}
+
+#[test]
+fn mouse_middle_button_grounds_potx_pin_per_port() {
+    let mut bus = empty_bus();
+    assert_eq!(bus.custom_read(0x016, 2) & 0x1100, 0x1100);
+    bus.input.set_mouse_button(0, 2, true);
+    assert_eq!(bus.custom_read(0x016, 2) & 0x1100, 0x1000);
+    bus.input.set_mouse_button(1, 2, true);
+    bus.input.set_mouse_button(0, 2, false);
+    assert_eq!(bus.custom_read(0x016, 2) & 0x1100, 0x0100);
+}
+
+#[test]
+fn analogue_stick_position_latches_as_potxdat_count_per_port() {
+    let mut bus = empty_bus();
+    bus.input.set_analogue(0, 100, 200);
+    bus.input.set_analogue(1, 30, 60);
+
+    // START the scan, then advance well past the 8 discharge lines plus
+    // the 255-count ramp.
+    assert!(!bus.custom_write(0x034, 2, 0x0001));
+    bus.advance_devices(227 * 300);
+
+    assert_eq!(bus.custom_read(0x012, 2), 0xC864); // POT0DAT: y=200, x=100
+    assert_eq!(bus.custom_read(0x014, 2), 0x3C1E); // POT1DAT: y=60, x=30
+}
+
+#[test]
+fn analogue_buttons_read_through_joydat_left_right_lines() {
+    let mut bus = empty_bus();
+    bus.input.set_analogue(0, 10, 10);
+    bus.input.set_analogue(1, 10, 10);
+
+    // Driving the joystick lines on an analogue port must not change the
+    // device: the left/right switch lines ARE the paddle buttons.
+    bus.input
+        .set_joystick(0, false, false, true, false, false, false);
+    bus.input
+        .set_joystick(1, false, false, false, true, false, false);
+    assert_eq!(bus.input.device(0), PortDevice::Analogue);
+    assert_eq!(bus.input.device(1), PortDevice::Analogue);
+
+    // Button 1 (left line) reads back as JOYxDAT bit 9, button 2 (right
+    // line) as bit 1, on top of the idle counters.
+    assert_eq!(bus.custom_read(0x00A, 2), 0x0200);
+    assert_eq!(bus.custom_read(0x00C, 2), 0x0002);
+    // The paddle buttons do not touch the /FIRx lines.
+    assert_eq!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0xC0, 0xC0);
+}
+
+#[test]
+fn unplugging_a_device_releases_its_lines_but_keeps_the_counters() {
+    let mut bus = empty_bus();
+    assert!(!bus.custom_write(0x036, 2, 0x1234)); // JOYTEST loads counters
+    bus.input
+        .set_joystick(1, true, false, false, false, true, true);
+    assert_eq!(
+        bus.custom_read(0x00C, 2) as u16,
+        super::digital_joydat(true, false, false, false)
+    );
+
+    // Swapping the joystick for a mouse releases fire and button 2, and
+    // the chip-side quadrature counters still hold the JOYTEST value.
+    bus.input.set_port_device(1, PortDevice::Mouse);
+    assert_eq!(bus.custom_read(0x00C, 2), 0x1234);
+    assert_ne!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0x80, 0);
+    assert_ne!(bus.custom_read(0x016, 2) & 0x4000, 0);
+}
+
+#[test]
+fn machine_reset_keeps_plugged_devices_and_knob_positions() {
+    let mut bus = empty_bus();
+    bus.input.set_port_device(0, PortDevice::Cd32Pad);
+    bus.input.set_analogue(1, 50, 200);
+    bus.input.ports[0].fire = true;
+    bus.input.ports[0].up = true;
+    assert!(!bus.custom_write(0x036, 2, 0x1234)); // JOYTEST loads counters
+
+    // A reset does not unplug anything: Ctrl-Amiga-Amiga, the CPU RESET
+    // instruction, and a cold boot all leave the physical controllers
+    // (and a paddle's knob position) where they are, while the chip-side
+    // counters clear and the driven lines release.
+    bus.reset_for_keyboard_reset();
+    assert_eq!(bus.input.device(0), PortDevice::Cd32Pad);
+    assert_eq!(bus.input.device(1), PortDevice::Analogue);
+    assert_eq!(
+        bus.input.ports[1].pot_x_ohms,
+        Some(crate::chipset::paula::pot_position_resistance_ohms(50))
+    );
+    assert!(!bus.input.ports[0].fire, "reset released the fire line");
+    assert!(!bus.input.ports[0].up);
+    assert_eq!(bus.input.ports[0].counter_x, 0, "chip counters cleared");
+    assert_eq!(bus.input.ports[0].cd32_shifter, 8, "pad shifter reloaded");
+}
+
+#[test]
+fn empty_port_reads_like_an_idle_mouse() {
+    let mut bus = empty_bus();
+    bus.input.set_port_device(0, PortDevice::None);
+    assert!(!bus.custom_write(0x036, 2, 0xABCD));
+
+    // Nothing drives the pins: JOY0DAT reports the counters, the pot
+    // pins float high, and /FIR0 stays released.
+    assert_eq!(bus.custom_read(0x00A, 2), 0xABCD);
+    assert_eq!(bus.custom_read(0x016, 2) & 0x0500, 0x0500);
+    assert_ne!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0x40, 0);
+}
+
+#[test]
 fn front_panel_hdd_led_follows_gayle_activity_with_hold() {
     let mut bus = empty_bus();
     // No Gayle: no HDD LED at all.
@@ -9253,21 +9437,22 @@ fn front_panel_reports_host_output_volume() {
 fn joy0dat_reports_wrapping_mouse_counters() {
     let mut bus = empty_bus();
 
-    bus.input.add_mouse_delta_port1(5, -2);
+    bus.input.add_mouse_delta(0, 5, -2);
     assert_eq!(bus.custom_read(0x00A, 2), 0xFE05);
 
-    bus.input.add_mouse_delta_port1(-6, 4);
+    bus.input.add_mouse_delta(0, -6, 4);
     assert_eq!(bus.custom_read(0x00A, 2), 0x02FF);
 }
 
 #[test]
-fn joy1dat_reports_second_port_mouse_counters() {
+fn mouse_on_port_2_counts_through_real_deltas() {
     let mut bus = empty_bus();
 
-    bus.input.mouse_x_port2 = 0xFF;
-    bus.input.mouse_y_port2 = 0x03;
+    bus.input.add_mouse_delta(1, -1, 3);
 
     assert_eq!(bus.custom_read(0x00C, 2), 0x03FF);
+    // Port 1's counters are independent.
+    assert_eq!(bus.custom_read(0x00A, 2), 0x0000);
 }
 
 /// The decode an Amiga game (or AmigaTestKit) applies to a JOYxDAT word to
@@ -9290,13 +9475,10 @@ fn digital_joystick_directions_round_trip_through_joydat_on_both_ports() {
         let (up, down, left, right) = (bits & 1 != 0, bits & 2 != 0, bits & 4 != 0, bits & 8 != 0);
 
         let mut bus = empty_bus();
-        bus.input.joystick_port1 = true;
-        bus.input.joy_up_port1 = up;
-        bus.input.joy_down_port1 = down;
-        bus.input.joy_left_port1 = left;
-        bus.input.joy_right_port1 = right;
         bus.input
-            .set_joystick_port2(up, down, left, right, false, false);
+            .set_joystick(0, up, down, left, right, false, false);
+        bus.input
+            .set_joystick(1, up, down, left, right, false, false);
 
         let p1 = bus.custom_read(0x00A, 2) as u16;
         let p2 = bus.custom_read(0x00C, 2) as u16;
@@ -9316,16 +9498,16 @@ fn digital_joystick_directions_round_trip_through_joydat_on_both_ports() {
 #[test]
 fn joydat_reports_mouse_until_joystick_engaged() {
     let mut bus = empty_bus();
-    bus.input.mouse_x_port2 = 0x12;
-    bus.input.mouse_y_port2 = 0x34;
+    bus.input.ports[1].counter_x = 0x12;
+    bus.input.ports[1].counter_y = 0x34;
     // Direction lines set but the port is still a mouse: JOY1DAT must keep
     // reporting the quadrature counters.
-    bus.input.joy_right_port2 = true;
+    bus.input.ports[1].right = true;
     assert_eq!(bus.custom_read(0x00C, 2), 0x3412);
 
     // Engaging the joystick switches JOY1DAT to the direction encoding.
     bus.input
-        .set_joystick_port2(false, false, false, true, false, false);
+        .set_joystick(1, false, false, false, true, false, false);
     assert_eq!(
         bus.custom_read(0x00C, 2) as u16,
         super::digital_joydat(false, false, false, true)
@@ -9333,29 +9515,46 @@ fn joydat_reports_mouse_until_joystick_engaged() {
 }
 
 #[test]
-fn joystick_fire_drives_cia_a_pra_fir1() {
+fn fire_drives_cia_a_pra_fir0_and_fir1_per_port() {
     let mut bus = empty_bus();
-    // Released: /FIR1 (PRA bit 7) reads high.
+    // Released: /FIR0 (PRA bit 6) and /FIR1 (PRA bit 7) read high.
     bus.input
-        .set_joystick_port2(false, false, false, false, false, false);
-    assert_ne!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0x80, 0);
-    // Pressed: /FIR1 reads low (active-low).
+        .set_joystick(0, false, false, false, false, false, false);
     bus.input
-        .set_joystick_port2(false, false, false, false, true, false);
-    assert_eq!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0x80, 0);
+        .set_joystick(1, false, false, false, false, false, false);
+    assert_eq!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0xC0, 0xC0);
+    // Port-1 fire pulls only /FIR0 low (active-low).
+    bus.input
+        .set_joystick(0, false, false, false, false, true, false);
+    assert_eq!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0xC0, 0x80);
+    // Port-2 fire pulls only /FIR1 low.
+    bus.input
+        .set_joystick(0, false, false, false, false, false, false);
+    bus.input
+        .set_joystick(1, false, false, false, false, true, false);
+    assert_eq!(bus.cia_a_read((REG_PRA as u64) * 256, 1) & 0xC0, 0x40);
 }
 
 #[test]
-fn joystick_button2_drives_pot1y_through_potgor() {
+fn joystick_button2_drives_potxy_through_potgor_per_port() {
     let mut bus = empty_bus();
-    // Released: POT1Y (POTGOR bit 14) reads high (input pin, button up).
+    // Released: POT0Y (bit 10) and POT1Y (bit 14) read high (input pins,
+    // buttons up).
     bus.input
-        .set_joystick_port2(false, false, false, false, false, false);
-    assert_ne!(bus.custom_read(0x016, 2) & 0x4000, 0);
-    // Pressed: POT1Y reads low.
+        .set_joystick(0, false, false, false, false, false, false);
     bus.input
-        .set_joystick_port2(false, false, false, false, false, true);
-    assert_eq!(bus.custom_read(0x016, 2) & 0x4000, 0);
+        .set_joystick(1, false, false, false, false, false, false);
+    assert_eq!(bus.custom_read(0x016, 2) & 0x4400, 0x4400);
+    // Port-2 button 2 pulls only POT1Y low.
+    bus.input
+        .set_joystick(1, false, false, false, false, false, true);
+    assert_eq!(bus.custom_read(0x016, 2) & 0x4400, 0x0400);
+    // Port-1 button 2 pulls only POT0Y low.
+    bus.input
+        .set_joystick(0, false, false, false, false, false, true);
+    bus.input
+        .set_joystick(1, false, false, false, false, false, false);
+    assert_eq!(bus.custom_read(0x016, 2) & 0x4400, 0x4000);
 }
 
 #[test]
@@ -9370,18 +9569,18 @@ fn fire_buttons_read_through_potgo_pullup_mode() {
     // Port 2 pull-ups (POT1X bits 12/13, POT1Y bits 14/15).
     assert!(!bus.custom_write(0x034, 2, 0xF000));
     bus.input
-        .set_joystick_port2(false, false, false, false, false, false);
+        .set_joystick(1, false, false, false, false, false, false);
     assert_ne!(bus.custom_read(0x016, 2) & 0x4000, 0); // button 2 up -> high
     bus.input
-        .set_joystick_port2(false, false, false, false, false, true);
+        .set_joystick(1, false, false, false, false, false, true);
     assert_eq!(bus.custom_read(0x016, 2) & 0x4000, 0); // button 2 down -> low
 
     // Port 1 pull-ups (POT0X bits 8/9, POT0Y bits 10/11): the right mouse
     // button reads through POT0Y the same way.
     assert!(!bus.custom_write(0x034, 2, 0x0F00));
-    bus.input.rmb_port1 = false;
+    bus.input.set_mouse_button(0, 1, false);
     assert_ne!(bus.custom_read(0x016, 2) & 0x0400, 0); // RMB up -> high
-    bus.input.rmb_port1 = true;
+    bus.input.set_mouse_button(0, 1, true);
     assert_eq!(bus.custom_read(0x016, 2) & 0x0400, 0); // RMB down -> low
 }
 
@@ -9411,7 +9610,7 @@ fn joytest_sets_both_mouse_counter_pairs() {
 #[test]
 fn potgo_starts_counters_and_potgor_reflects_button_pins() {
     let mut bus = empty_bus();
-    bus.input.rmb_port1 = true;
+    bus.input.set_mouse_button(0, 1, true);
 
     assert!(!bus.custom_write(0x034, 2, 0x0001));
     // The pot counters clock at H-sync, so while the scan runs it caps the

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -242,6 +242,25 @@ impl Default for PotPins {
 /// Manual. The recommended 470 kΩ +/- 10% part fits under this 528 kΩ limit.
 pub const POT_MAX_RESISTANCE_OHMS: u32 = 528_000;
 
+/// Resistance from +5 V to a POT pin that makes the RC scan latch POTxDAT
+/// count == `position`: the exact inverse of `pot_resistance_position`, so
+/// an analogue controller's stick/paddle position round-trips through the
+/// comparator model unchanged.
+pub fn pot_position_resistance_ohms(position: u8) -> u32 {
+    u32::from(position) * POT_MAX_RESISTANCE_OHMS / u32::from(u8::MAX)
+}
+
+/// The count a POTxDAT byte latches for a pin charging through
+/// `resistance_ohms`: threshold time is linear in R (see
+/// `pot_threshold_count`), calibrated so the documented maximum lands on
+/// the last 8-bit count.
+pub fn pot_resistance_position(resistance_ohms: u32) -> u8 {
+    let resistance = resistance_ohms.min(POT_MAX_RESISTANCE_OHMS);
+    resistance
+        .saturating_mul(u32::from(u8::MAX))
+        .div_ceil(POT_MAX_RESISTANCE_OHMS) as u8
+}
+
 /// POTGOR bits 7..1 are documented as a Paula chip-identification field, but
 /// the production 8364R7 fitted across OCS/ECS/AGA machines returns zero (and
 /// has no software-selectable revision). Keep the readback explicit rather
@@ -830,10 +849,7 @@ impl Paula {
     /// linear in R. Calibrate the documented 528 kΩ maximum to the last 8-bit
     /// count; the recommended 470 kΩ part therefore lands at count 227.
     fn pot_threshold_count(resistance_ohms: u32) -> u8 {
-        let resistance = resistance_ohms.min(POT_MAX_RESISTANCE_OHMS);
-        resistance
-            .saturating_mul(u32::from(u8::MAX))
-            .div_ceil(POT_MAX_RESISTANCE_OHMS) as u8
+        pot_resistance_position(resistance_ohms)
     }
 
     /// Advance the pot capacitor scan by one horizontal line. Paula holds all
@@ -3494,6 +3510,22 @@ mod tests {
         }
         assert_eq!(paula.read_potdat(0) >> 8, 227);
         assert!(paula.pot_running(), "the disconnected POT1Y keeps scanning");
+    }
+
+    #[test]
+    fn pot_position_resistance_round_trips_every_count() {
+        // The analogue-controller position converter must be the exact
+        // inverse of the comparator threshold, or a device set to position N
+        // would latch a different POTxDAT count.
+        for position in 0..=u8::MAX {
+            let ohms = pot_position_resistance_ohms(position);
+            assert!(ohms <= POT_MAX_RESISTANCE_OHMS);
+            assert_eq!(
+                Paula::pot_threshold_count(ohms),
+                position,
+                "position {position} (ohms {ohms})"
+            );
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 //! Loadable configuration. The file format is TOML; see
 //! `copperline.example.toml` (or the README) for the full schema.
 
+use crate::bus::PortDevice;
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::zorro::{zorro_ii_size_code, zorro_iii_size_bits, BoardSpec, ZorroChain, ZorroVersion};
@@ -113,9 +114,6 @@ pub struct Config {
     /// CDTV DMAC/CD controller fitted (CDTV profile): a Zorro II
     /// autoconfig board carrying the 6525 TPI and the Matshita drive.
     pub cdtv_cd: bool,
-    /// A CD32 joypad is plugged into port 2 (CD32 profile): enables the
-    /// pad's serial button protocol for lowlevel.library.
-    pub cd32_pad: bool,
     /// Extended ROM image (`extended_rom = "path"`): 512 KiB maps at
     /// $E00000 (CD32), 256 KiB at $F00000 (CDTV).
     pub extended_rom_path: Option<PathBuf>,
@@ -179,12 +177,20 @@ pub struct Config {
     /// decay that fuses field-rate dither and interlace flicker on a
     /// real CRT.
     pub phosphor: f32,
-    /// Initial host input source for the emulated port-2 joystick/CD32 pad
+    /// Initial host input source for the emulated joystick/CD32-pad port
     /// (`[input] joystick` / `--joystick`). Defaults to
     /// [`JoystickInputMode::Gamepad`]; the runtime status-bar toggle, `Cmd+J` /
     /// `Alt+J`, and the menu's Joystick Input item flip it live without
     /// affecting this start-up value.
     pub joystick_input_mode: JoystickInputMode,
+    /// Controller devices plugged into the two game ports at power-on
+    /// (`[input] port1` / `port2`, `--port1` / `--port2`); index 0 = port 1.
+    /// Defaults to a mouse in port 1 and a joystick in port 2 -- a CD32
+    /// joypad on the CD32 profile, whose serial button protocol
+    /// lowlevel.library expects. Runtime hot-plug (menu, CCP
+    /// `input.set_port`) changes the live machine without affecting this
+    /// start-up value.
+    pub port_devices: [PortDevice; 2],
     /// Host wiring for Paula's serial port (`[serial]` / `--serial`).
     /// Defaults to [`SerialMode::Stdout`], preserving the historical
     /// terminal-diagnostics behaviour.
@@ -996,7 +1002,6 @@ impl Default for Config {
             sdmac: false,
             akiko: false,
             cdtv_cd: false,
-            cd32_pad: false,
             extended_rom_path: None,
             cd_image_path: None,
             cd_insert_delay_secs: 0.0,
@@ -1019,6 +1024,7 @@ impl Default for Config {
             pixel_aspect: PixelAspect::Tv,
             phosphor: 0.0,
             joystick_input_mode: JoystickInputMode::Gamepad,
+            port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
             parallel_output_path: None,
         }
@@ -1159,6 +1165,11 @@ pub struct ConfigOverrides {
     /// ("auto" still accepted as a compatibility alias). Validated by the same
     /// parser as `[input] joystick`.
     pub joystick: Option<String>,
+    /// Device in game port 1 (`--port1`): "mouse", "joystick", "cd32",
+    /// "analogue", or "none". Same parser as `[input] port1`.
+    pub port1: Option<String>,
+    /// Device in game port 2 (`--port2`). Same parser as `[input] port2`.
+    pub port2: Option<String>,
     /// Serial port wiring (`--serial`): "off", "stdout", "midi", "tcp",
     /// or "pty" ("none" and "terminal" parse as compatibility aliases of
     /// the first two). Same parser as `[serial] mode`.
@@ -1194,6 +1205,8 @@ impl ConfigOverrides {
             && self.slow.is_none()
             && self.floppy_drives.is_none()
             && self.joystick.is_none()
+            && self.port1.is_none()
+            && self.port2.is_none()
             && self.serial.is_none()
             && self.midi_out.is_none()
             && self.midi_in.is_none()
@@ -1236,6 +1249,12 @@ impl ConfigOverrides {
         }
         if let Some(joystick) = &self.joystick {
             raw.input.joystick = Some(joystick.clone());
+        }
+        if let Some(port1) = &self.port1 {
+            raw.input.port1 = Some(port1.clone());
+        }
+        if let Some(port2) = &self.port2 {
+            raw.input.port2 = Some(port2.clone());
         }
         if let Some(mode) = &self.serial {
             raw.serial.mode = Some(mode.clone());
@@ -1387,8 +1406,9 @@ pub(crate) struct RawFilesysMount {
     pub(crate) readonly: Option<bool>,
 }
 
-/// `[input]` host-input preferences. Currently just the initial joystick input
-/// mode; the status-bar toggle and `Cmd+J` / `Alt+J` flip it live.
+/// `[input]` host-input preferences: which controller device is plugged into
+/// each game port, and the host source for the joystick port. The status-bar
+/// toggle and `Cmd+J` / `Alt+J` flip the joystick source live.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawInput {
@@ -1397,6 +1417,14 @@ pub(crate) struct RawInput {
     /// "gamepad".)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) joystick: Option<String>,
+    /// Device in game port 1: "mouse" (default), "joystick", "cd32",
+    /// "analogue", or "none".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) port1: Option<String>,
+    /// Device in game port 2: same values; defaults to "joystick"
+    /// ("cd32" on the CD32 profile).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) port2: Option<String>,
 }
 
 /// `[serial]` host wiring for Paula's serial (a.k.a. MIDI) port.
@@ -2031,6 +2059,19 @@ impl TryFrom<RawConfig> for Config {
             None => defaults.joystick_input_mode,
             Some(s) => parse_joystick_input_mode(s)?,
         };
+        // The profile carries the default wiring (mouse + joystick, with a
+        // CD32 pad on the CD32 profile); an explicit key beats it either
+        // way -- a real CD32 accepts any controller too.
+        let port_devices = [
+            match raw.input.port1.as_deref() {
+                None => defaults.port_devices[0],
+                Some(s) => parse_port_device(s, "port1")?,
+            },
+            match raw.input.port2.as_deref() {
+                None => defaults.port_devices[1],
+                Some(s) => parse_port_device(s, "port2")?,
+            },
+        ];
         let serial = SerialConfig {
             mode: match raw.serial.mode.as_deref() {
                 None => defaults.serial.mode,
@@ -2286,7 +2327,6 @@ impl TryFrom<RawConfig> for Config {
             }),
             akiko: defaults.akiko,
             cdtv_cd: defaults.cdtv_cd,
-            cd32_pad: defaults.cd32_pad,
             extended_rom_path: raw
                 .extended_rom
                 .map(PathBuf::from)
@@ -2338,6 +2378,7 @@ impl TryFrom<RawConfig> for Config {
             pixel_aspect,
             phosphor,
             joystick_input_mode,
+            port_devices,
             serial,
             parallel_output_path: raw.parallel.output.map(PathBuf::from),
         })
@@ -2358,6 +2399,15 @@ pub(crate) fn parse_pixel_aspect(s: &str) -> Result<PixelAspect> {
         "square" => Ok(PixelAspect::Square),
         other => bail!("[display] pixel_aspect must be \"tv\" or \"square\", got \"{other}\""),
     }
+}
+
+pub(crate) fn parse_port_device(s: &str, key: &str) -> Result<PortDevice> {
+    PortDevice::parse(s).ok_or_else(|| {
+        anyhow!(
+            "[input] {key} must be \"mouse\", \"joystick\", \"cd32\", \
+             \"analogue\", or \"none\", got {s:?}"
+        )
+    })
 }
 
 pub(crate) fn parse_joystick_input_mode(s: &str) -> Result<JoystickInputMode> {
@@ -2593,7 +2643,9 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.cpu = CpuModel::M68EC020;
             d.cpu_clock_mhz = 14.18;
             d.akiko = true;
-            d.cd32_pad = true;
+            // The bundled controller: lowlevel.library expects the pad's
+            // serial button protocol on port 2.
+            d.port_devices[1] = PortDevice::Cd32Pad;
         }
     }
     d
@@ -3343,6 +3395,69 @@ mod tests {
         assert_eq!(
             load_overrides(&overrides)?.joystick_input_mode,
             JoystickInputMode::Gamepad
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn port_devices_default_to_mouse_and_joystick() -> Result<()> {
+        // No [input] port keys: the stock wiring, on every non-CD32 profile.
+        assert_eq!(
+            parse_config("")?.port_devices,
+            [PortDevice::Mouse, PortDevice::Joystick]
+        );
+        assert_eq!(
+            parse_config("[machine]\nprofile = \"A1200\"\n")?.port_devices,
+            [PortDevice::Mouse, PortDevice::Joystick]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cd32_profile_defaults_port_2_to_the_bundled_pad() -> Result<()> {
+        let cfg = parse_config("[machine]\nprofile = \"CD32\"\n")?;
+        assert_eq!(cfg.port_devices, [PortDevice::Mouse, PortDevice::Cd32Pad]);
+        // An explicit key beats the profile: a real CD32 accepts any
+        // controller.
+        let cfg = parse_config("[machine]\nprofile = \"CD32\"\n[input]\nport2 = \"joystick\"\n")?;
+        assert_eq!(cfg.port_devices[1], PortDevice::Joystick);
+        Ok(())
+    }
+
+    #[test]
+    fn port_device_keys_parse_aliases_and_reject_garbage() -> Result<()> {
+        for (text, expected) in [
+            ("mouse", PortDevice::Mouse),
+            ("joystick", PortDevice::Joystick),
+            ("JOY", PortDevice::Joystick),
+            ("cd32", PortDevice::Cd32Pad),
+            ("cd32pad", PortDevice::Cd32Pad),
+            ("pad", PortDevice::Cd32Pad),
+            ("analogue", PortDevice::Analogue),
+            ("analog", PortDevice::Analogue),
+            ("paddle", PortDevice::Analogue),
+            ("none", PortDevice::None),
+            ("off", PortDevice::None),
+        ] {
+            let cfg = parse_config(&format!("[input]\nport1 = {text:?}\n"))?;
+            assert_eq!(cfg.port_devices[0], expected, "for {text:?}");
+        }
+        let err = parse_config("[input]\nport2 = \"trackball\"\n").unwrap_err();
+        assert!(err.to_string().contains("port2"), "{err}");
+        Ok(())
+    }
+
+    #[test]
+    fn port_device_cli_overrides_swap_the_wiring() -> Result<()> {
+        let overrides = ConfigOverrides {
+            port1: Some("joystick".to_string()),
+            port2: Some("mouse".to_string()),
+            ..ConfigOverrides::default()
+        };
+        assert!(!overrides.is_empty());
+        assert_eq!(
+            load_overrides(&overrides)?.port_devices,
+            [PortDevice::Joystick, PortDevice::Mouse]
         );
         Ok(())
     }

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -74,6 +74,7 @@ pub enum CoreOp {
     },
     BeamGet,
     DisplayGet,
+    InputPortsGet,
     RtcGet,
     RtcSet {
         unix: Option<u64>,
@@ -157,6 +158,7 @@ impl CoreOp {
                 | CoreOp::CiaGet { .. }
                 | CoreOp::BeamGet
                 | CoreOp::DisplayGet
+                | CoreOp::InputPortsGet
                 | CoreOp::RtcGet
                 | CoreOp::CopperList { .. }
                 | CoreOp::PcHistory
@@ -191,6 +193,13 @@ pub enum HostOp {
         path: PathBuf,
     },
     CdEject,
+    /// Hot-plug a controller device into a port (0 = port 1, 1 = port 2).
+    /// Releases every line the previous device drove; not journaled for
+    /// reverse replay (like a media change, it is host state).
+    SetPortDevice {
+        port: u8,
+        device: crate::bus::PortDevice,
+    },
     StateLoad {
         path: PathBuf,
     },
@@ -243,7 +252,9 @@ impl RunTarget {
 }
 
 /// A parsed input command, before the driver expands it into immediate
-/// and scheduled transitions.
+/// and scheduled transitions. Port fields are 0-based (0 = port 1), the
+/// bus convention; the wire protocol's 1-based `port` param is converted
+/// at parse time.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum InputCmd {
     Key {
@@ -252,13 +263,22 @@ pub enum InputCmd {
         at_seconds: Option<f64>,
     },
     Mouse {
+        port: u8,
         left: Option<bool>,
         right: Option<bool>,
         middle: Option<bool>,
         dx: i32,
         dy: i32,
     },
-    Joy(JoyState),
+    Joy {
+        port: u8,
+        state: JoyState,
+    },
+    Analogue {
+        port: u8,
+        x: u8,
+        y: u8,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -326,6 +346,7 @@ impl InputCmd {
                 }
             },
             InputCmd::Mouse {
+                port,
                 left,
                 right,
                 middle,
@@ -334,14 +355,22 @@ impl InputCmd {
             } => {
                 for (index, state) in [(0u8, left), (1, right), (2, middle)] {
                     if let Some(pressed) = state {
-                        emit(None, InputAction::MouseButton { index, pressed });
+                        emit(
+                            None,
+                            InputAction::MouseButton {
+                                port,
+                                index,
+                                pressed,
+                            },
+                        );
                     }
                 }
                 if dx != 0 || dy != 0 {
-                    emit(None, InputAction::MouseMove { dx, dy });
+                    emit(None, InputAction::MouseMove { port, dx, dy });
                 }
             }
-            InputCmd::Joy(j) => emit(None, InputAction::Joy(j)),
+            InputCmd::Joy { port, state } => emit(None, InputAction::Joy { port, state }),
+            InputCmd::Analogue { port, x, y } => emit(None, InputAction::Pot { port, x, y }),
         }
         (now, later)
     }
@@ -349,6 +378,25 @@ impl InputCmd {
 
 // ---------------------------------------------------------------------
 // Parsing
+
+/// Parse the optional 1-based `port` param (1 or 2), defaulting to
+/// `default`, into the bus's 0-based port index.
+fn parse_port_param(p: &ParamReader, default: u32) -> Result<u8, CtlError> {
+    let port = p.u32_or("port", default)?;
+    if !(1..=2).contains(&port) {
+        return Err(CtlError::invalid_params("port must be 1 or 2"));
+    }
+    Ok((port - 1) as u8)
+}
+
+/// Parse a required 1-based `port` param into the 0-based port index.
+fn parse_port_req(p: &ParamReader) -> Result<u8, CtlError> {
+    let port = p.u32_req("port")?;
+    if !(1..=2).contains(&port) {
+        return Err(CtlError::invalid_params("port must be 1 or 2"));
+    }
+    Ok((port - 1) as u8)
+}
 
 /// Parse a method name and params object into a typed request.
 pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
@@ -530,25 +578,53 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             }))
         }
         "input.mouse" => host(HostOp::Input(InputCmd::Mouse {
+            port: parse_port_param(&p, 1)?,
             left: p.bool_opt("left")?,
             right: p.bool_opt("right")?,
             middle: p.bool_opt("middle")?,
             dx: p.i32_or("dx", 0)?,
             dy: p.i32_or("dy", 0)?,
         })),
-        "input.joy" => host(HostOp::Input(InputCmd::Joy(JoyState {
-            up: p.bool_or("up", false)?,
-            down: p.bool_or("down", false)?,
-            left: p.bool_or("left", false)?,
-            right: p.bool_or("right", false)?,
-            red: p.bool_or("red", false)? || p.bool_or("fire1", false)?,
-            blue: p.bool_or("blue", false)? || p.bool_or("fire2", false)?,
-            play: p.bool_or("play", false)?,
-            rwd: p.bool_or("rwd", false)?,
-            ffw: p.bool_or("ffw", false)?,
-            green: p.bool_or("green", false)?,
-            yellow: p.bool_or("yellow", false)?,
-        }))),
+        "input.joy" => host(HostOp::Input(InputCmd::Joy {
+            port: parse_port_param(&p, 2)?,
+            state: JoyState {
+                up: p.bool_or("up", false)?,
+                down: p.bool_or("down", false)?,
+                left: p.bool_or("left", false)?,
+                right: p.bool_or("right", false)?,
+                red: p.bool_or("red", false)? || p.bool_or("fire1", false)?,
+                blue: p.bool_or("blue", false)? || p.bool_or("fire2", false)?,
+                play: p.bool_or("play", false)?,
+                rwd: p.bool_or("rwd", false)?,
+                ffw: p.bool_or("ffw", false)?,
+                green: p.bool_or("green", false)?,
+                yellow: p.bool_or("yellow", false)?,
+            },
+        })),
+        "input.analogue" => {
+            let (x, y) = (p.u32_req("x")?, p.u32_req("y")?);
+            if x > 0xFF || y > 0xFF {
+                return Err(CtlError::invalid_params("x and y must be 0..=255"));
+            }
+            host(HostOp::Input(InputCmd::Analogue {
+                port: parse_port_param(&p, 2)?,
+                x: x as u8,
+                y: y as u8,
+            }))
+        }
+        "input.set_port" => {
+            let device = p.str_req("device")?;
+            let device = crate::bus::PortDevice::parse(&device).ok_or_else(|| {
+                CtlError::invalid_params(format!(
+                    "device must be mouse|joystick|cd32|analogue|none, got {device}"
+                ))
+            })?;
+            host(HostOp::SetPortDevice {
+                port: parse_port_req(&p)?,
+                device,
+            })
+        }
+        "input.get_ports" => core(CoreOp::InputPortsGet),
         "media.floppy.insert" => host(HostOp::FloppyInsert {
             drive: p.usize_req("drive")?,
             path: PathBuf::from(p.str_req("path")?),
@@ -1147,6 +1223,13 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             Ok(json!({
                 "dmacon": bus.debug_dmacon(),
                 "display": bus.debug_display_state(),
+            }))
+        }
+        CoreOp::InputPortsGet => {
+            let input = &emu.bus().input;
+            Ok(json!({
+                "port1": input.ports[0].device.label(),
+                "port2": input.ports[1].device.label(),
             }))
         }
         CoreOp::RtcGet => {

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -417,6 +417,17 @@ impl Session {
                 self.write(&reply)?;
                 Ok(None)
             }
+            HostOp::SetPortDevice { port, device } => {
+                self.emu
+                    .bus_mut()
+                    .input
+                    .set_port_device(port as usize, device);
+                self.write(&proto::ok_line(
+                    &id,
+                    json!({"port": port + 1, "device": device.label()}),
+                ))?;
+                Ok(None)
+            }
             HostOp::StateLoad { path } => {
                 let reply = match self.emu.load_state(&path) {
                     Ok(outcome) => {
@@ -796,10 +807,11 @@ impl Session {
                     | HostOp::FloppyEject { .. }
                     | HostOp::CdInsert { .. }
                     | HostOp::CdEject
+                    | HostOp::SetPortDevice { .. }
                     | HostOp::Reset { .. }),
                 ) => {
-                    // Media changes and reset are ordinary live events;
-                    // apply them at this boundary.
+                    // Media changes, controller hot-plug, and reset are
+                    // ordinary live events; apply them at this boundary.
                     if let Some(end) = self.dispatch_host(req.id, op)? {
                         return Ok(MidRun::Lost(end));
                     }
@@ -1130,6 +1142,34 @@ mod tests {
             script.contains("0x45"),
             "recording carries the injected key: {script}"
         );
+    }
+
+    #[test]
+    fn input_port_methods_hot_plug_and_report_devices() {
+        run_session(None, |c| {
+            c.auth();
+            // A fresh machine (no config layer here) has two mouse ports.
+            let ports = c.result("input.get_ports", json!({}));
+            assert_eq!(ports["port1"], "mouse");
+            assert_eq!(ports["port2"], "mouse");
+
+            // Hot-plug a CD32 pad into port 1 and report it back.
+            let set = c.result("input.set_port", json!({"port": 1, "device": "cd32"}));
+            assert_eq!(set["port"], 1);
+            assert_eq!(set["device"], "cd32");
+            let ports = c.result("input.get_ports", json!({}));
+            assert_eq!(ports["port1"], "cd32");
+
+            // input.joy/analogue take an optional port; port 3 is refused.
+            c.result("input.joy", json!({"port": 1, "up": true, "red": true}));
+            c.result("input.analogue", json!({"port": 2, "x": 50, "y": 200}));
+            let ports = c.result("input.get_ports", json!({}));
+            assert_eq!(ports["port2"], "analogue");
+            let bad = c.call("input.mouse", json!({"port": 3, "dx": 1}));
+            assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
+            let bad = c.call("input.set_port", json!({"port": 1, "device": "trackball"}));
+            assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
+        });
     }
 
     #[test]

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -51,16 +51,28 @@ pub enum InputAction {
         rawkey: u8,
         pressed: bool,
     },
-    /// Port-1 mouse button: index 0 = left, 1 = right, 2 = middle.
+    /// Mouse button on a port (0 = port 1, 1 = port 2): index 0 = left,
+    /// 1 = right, 2 = middle.
     MouseButton {
+        port: u8,
         index: u8,
         pressed: bool,
     },
     MouseMove {
+        port: u8,
         dx: i32,
         dy: i32,
     },
-    Joy(JoyState),
+    Joy {
+        port: u8,
+        state: JoyState,
+    },
+    /// Analogue pot positions on a port.
+    Pot {
+        port: u8,
+        x: u8,
+        y: u8,
+    },
 }
 
 /// An input action deferred to an emulated-time boundary (`at_seconds`
@@ -380,27 +392,36 @@ pub fn inject_input(
                 rec.record_key(rawkey, pressed, secs);
             }
         }
-        InputAction::MouseButton { index, pressed } => {
-            let input = &mut emu.bus_mut().input;
-            match index {
-                0 => input.lmb_port1 = pressed,
-                1 => input.rmb_port1 = pressed,
-                2 => input.mmb_port1 = pressed,
-                _ => {}
-            }
-            emu.tt_note_input(ReplayAction::MouseButton { index, pressed });
+        InputAction::MouseButton {
+            port,
+            index,
+            pressed,
+        } => {
+            emu.bus_mut()
+                .input
+                .set_mouse_button(port as usize, index, pressed);
+            emu.tt_note_input(ReplayAction::MouseButton {
+                port,
+                index,
+                pressed,
+            });
             observe_recorder(emu, recorder, secs);
         }
-        InputAction::MouseMove { dx, dy } => {
-            emu.bus_mut().input.add_mouse_delta_port1(dx, dy);
-            emu.tt_note_input(ReplayAction::MouseMove { dx, dy });
+        InputAction::MouseMove { port, dx, dy } => {
+            emu.bus_mut().input.add_mouse_delta(port as usize, dx, dy);
+            emu.tt_note_input(ReplayAction::MouseMove { port, dx, dy });
             observe_recorder(emu, recorder, secs);
         }
-        InputAction::Joy(j) => {
+        InputAction::Joy { port, state: j } => {
             let input = &mut emu.bus_mut().input;
-            input.set_joystick_port2(j.up, j.down, j.left, j.right, j.red, j.blue);
-            input.set_cd32_buttons_port2(j.play, j.rwd, j.ffw, j.green, j.yellow);
-            emu.tt_note_input(ReplayAction::Joy(j));
+            input.set_joystick(port as usize, j.up, j.down, j.left, j.right, j.red, j.blue);
+            input.set_cd32_buttons(port as usize, j.play, j.rwd, j.ffw, j.green, j.yellow);
+            emu.tt_note_input(ReplayAction::Joy { port, state: j });
+            observe_recorder(emu, recorder, secs);
+        }
+        InputAction::Pot { port, x, y } => {
+            emu.bus_mut().input.set_analogue(port as usize, x, y);
+            emu.tt_note_input(ReplayAction::Pot { port, x, y });
             observe_recorder(emu, recorder, secs);
         }
     }
@@ -453,6 +474,63 @@ mod tests {
         emu.step_frame().unwrap();
         ctx.apply_due_scheduled(&mut emu);
         assert!(ctx.scheduled.is_empty());
+    }
+
+    #[test]
+    fn injected_input_routes_to_the_named_port() {
+        use crate::bus::PortDevice;
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+
+        // Mouse motion and buttons land on the named port's lines.
+        ctx.inject_now(
+            &mut emu,
+            InputAction::MouseMove {
+                port: 1,
+                dx: 7,
+                dy: -2,
+            },
+        );
+        ctx.inject_now(
+            &mut emu,
+            InputAction::MouseButton {
+                port: 1,
+                index: 0,
+                pressed: true,
+            },
+        );
+        assert_eq!(emu.bus().input.ports[1].counter_x, 7);
+        assert_eq!(emu.bus().input.ports[1].counter_y, 0xFE);
+        assert!(emu.bus().input.ports[1].fire);
+        assert_eq!(emu.bus().input.ports[0].counter_x, 0);
+
+        // A joystick state on port 1 engages the device there.
+        ctx.inject_now(
+            &mut emu,
+            InputAction::Joy {
+                port: 0,
+                state: JoyState {
+                    up: true,
+                    red: true,
+                    ..JoyState::default()
+                },
+            },
+        );
+        assert_eq!(emu.bus().input.device(0), PortDevice::Joystick);
+        assert!(emu.bus().input.ports[0].up);
+        assert!(emu.bus().input.ports[0].fire);
+
+        // Analogue positions engage the Analogue device and set the pots.
+        ctx.inject_now(
+            &mut emu,
+            InputAction::Pot {
+                port: 1,
+                x: 50,
+                y: 200,
+            },
+        );
+        assert_eq!(emu.bus().input.device(1), PortDevice::Analogue);
+        assert!(emu.bus().input.ports[1].pot_x_ohms.is_some());
     }
 
     #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -5114,14 +5114,18 @@ mod tests {
         }
         // Apply a port-1 mouse motion live and note it for replay, exactly as
         // the window's add_mouse_delta_i32 does.
-        emu.bus_mut().input.add_mouse_delta_port1(40, 0);
-        emu.tt_note_input(ReplayAction::MouseMove { dx: 40, dy: 0 });
+        emu.bus_mut().input.add_mouse_delta(0, 40, 0);
+        emu.tt_note_input(ReplayAction::MouseMove {
+            port: 0,
+            dx: 40,
+            dy: 0,
+        });
 
         while emu.bus().emulated_frames() < 6 {
             emu.step_frame()?;
         }
         let pos_now = emu.retired_instructions();
-        let counter_with_input = emu.bus().input.mouse_x_port1;
+        let counter_with_input = emu.bus().input.ports[0].counter_x;
         assert_eq!(counter_with_input, 40, "the motion landed");
 
         // Reverse to before the motion: replaying from the early anchor stops
@@ -5142,7 +5146,7 @@ mod tests {
             other => panic!("restore_to failed: {other:?}"),
         }
         assert_eq!(
-            emu.bus().input.mouse_x_port1,
+            emu.bus().input.ports[0].counter_x,
             counter_with_input,
             "replay did not reproduce the logged mouse motion"
         );

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2037,10 +2037,13 @@ pub fn build_machine(
     if !devices.is_empty() {
         bus.attach_devices(devices);
     }
-    if cfg.cd32_pad {
-        bus.input.cd32_pad_port2 = true;
-        info!("input: CD32 joypad on port 2 (serial button protocol)");
-    }
+    bus.input.set_port_device(0, cfg.port_devices[0]);
+    bus.input.set_port_device(1, cfg.port_devices[1]);
+    info!(
+        "input: port 1 = {}, port 2 = {}",
+        cfg.port_devices[0].label(),
+        cfg.port_devices[1].label()
+    );
     if cfg.akiko {
         let mut akiko = crate::akiko::Akiko::new();
         if let Some(path) = &cfg.cd32_nvram_path {

--- a/src/inputrec.rs
+++ b/src/inputrec.rs
@@ -15,10 +15,19 @@
 //!   afterwards: Amiga key transitions (`record_key`, from
 //!   `handle_amiga_key_event`) and floppy inserts (`record_disk_insert`).
 //! - A once-per-quantum `observe` of the live `InputState`, which diffs
-//!   port-1 mouse buttons, the port-1 quadrature counters (wrapped u8
-//!   deltas become `mouse-after` lines), and the port-2
-//!   joystick/CD32-pad controls. Frame-rate granularity (~20 ms PAL) is
-//!   the same resolution the replay side schedules at.
+//!   each controller port according to the device plugged into it: mouse
+//!   buttons and quadrature counters (wrapped u8 deltas become
+//!   `mouse-after` lines), joystick/CD32-pad controls, or analogue pot
+//!   positions. Frame-rate granularity (~20 ms PAL) is the same
+//!   resolution the replay side schedules at.
+//!
+//! Port tokens are emitted only when they differ from a directive's
+//! default port (`click-after`/`mouse-after` default to port 1,
+//! `joy-after`/`pot-after` to port 2), so a session on the default
+//! mouse+joystick wiring records byte-identically to the pre-port-aware
+//! format. A device change mid-recording (hot-plug) closes that port's
+//! open holds; the change itself has no script directive and is not
+//! replayed.
 //!
 //! Press/release pairs are merged into hold directives (`key-after` /
 //! `click-after` / `joy-after`) keyed at the press time; controls still
@@ -28,38 +37,67 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-use crate::bus::InputState;
+use crate::bus::{ControllerPort, InputState, PortDevice};
+use crate::chipset::paula::pot_resistance_position;
 
 /// Minimum emitted hold so a press/release pair that lands inside one
 /// quantum still asserts the control for at least one emulated frame on
 /// replay.
 const MIN_HOLD_MS: u32 = 20;
 
-/// Reads one control's held state out of the live input.
-type ControlRead = fn(&InputState) -> bool;
+/// Reads one control's held state out of a controller port.
+type ControlRead = fn(&ControllerPort) -> bool;
 
-/// The port-2 controls the per-quantum diff watches: the canonical
-/// `joy-after` name (accepted by `JoyButtonKind::parse`) and the
-/// `InputState` field each one reads.
-const PORT2_CONTROLS: [(&str, ControlRead); 11] = [
-    ("up", |i| i.joy_up_port2),
-    ("down", |i| i.joy_down_port2),
-    ("left", |i| i.joy_left_port2),
-    ("right", |i| i.joy_right_port2),
-    ("red", |i| i.lmb_port2),
-    ("blue", |i| i.rmb_port2),
-    ("green", |i| i.cd32_green_port2),
-    ("yellow", |i| i.cd32_yellow_port2),
-    ("play", |i| i.cd32_play_port2),
-    ("rwd", |i| i.cd32_rwd_port2),
-    ("ffw", |i| i.cd32_ffw_port2),
+/// The joystick/CD32-pad controls the per-quantum diff watches: the
+/// canonical `joy-after` name (accepted by `JoyButtonKind::parse`) and the
+/// port line each one reads.
+const JOY_CONTROLS: [(&str, ControlRead); 11] = [
+    ("up", |p| p.up),
+    ("down", |p| p.down),
+    ("left", |p| p.left),
+    ("right", |p| p.right),
+    ("red", |p| p.fire),
+    ("blue", |p| p.button2),
+    ("green", |p| p.cd32_green),
+    ("yellow", |p| p.cd32_yellow),
+    ("play", |p| p.cd32_play),
+    ("rwd", |p| p.cd32_rwd),
+    ("ffw", |p| p.cd32_ffw),
 ];
 
-const PORT1_BUTTONS: [(&str, ControlRead); 3] = [
-    ("left", |i| i.lmb_port1),
-    ("right", |i| i.rmb_port1),
-    ("middle", |i| i.mmb_port1),
+/// Mouse buttons by `click-after` name: left = /FIRx, right = POTxY,
+/// middle = POTxX.
+const MOUSE_BUTTONS: [(&str, ControlRead); 3] = [
+    ("left", |p| p.fire),
+    ("right", |p| p.button2),
+    ("middle", |p| p.button3),
 ];
+
+/// Trailing port token for a mouse directive (default port 1).
+fn mouse_port_suffix(port: usize) -> &'static str {
+    if port == 1 {
+        " 2"
+    } else {
+        ""
+    }
+}
+
+/// Trailing port token for a joystick/pot directive (default port 2).
+fn joy_port_suffix(port: usize) -> &'static str {
+    if port == 0 {
+        " 1"
+    } else {
+        ""
+    }
+}
+
+/// Both analogue pot positions of a port, when both axes are connected.
+fn pot_positions(p: &ControllerPort) -> Option<(u8, u8)> {
+    match (p.pot_x_ohms, p.pot_y_ohms) {
+        (Some(x), Some(y)) => Some((pot_resistance_position(x), pot_resistance_position(y))),
+        _ => None,
+    }
+}
 
 /// Default recording file name, timestamped like the screenshot/recorder
 /// names.
@@ -76,13 +114,16 @@ pub struct InputRecorder {
     lines: Vec<(f64, String)>,
     /// Open key presses: rawkey -> press time.
     open_keys: HashMap<u8, f64>,
-    /// Open port-1 mouse-button presses, indexed like PORT1_BUTTONS.
-    open_clicks: [Option<f64>; 3],
-    /// Open port-2 control presses, indexed like PORT2_CONTROLS.
-    open_joys: [Option<f64>; 11],
+    /// Open mouse-button presses per port, indexed like MOUSE_BUTTONS.
+    open_clicks: [[Option<f64>; 3]; 2],
+    /// Open joystick/pad control presses per port, indexed like
+    /// JOY_CONTROLS.
+    open_joys: [[Option<f64>; 11]; 2],
     /// Input state at the previous `observe`, the diff baseline. Controls
     /// already held when recording starts are not recorded.
     prev: Option<InputState>,
+    /// Devices seen on the first `observe`, for the script header note.
+    first_devices: Option<[PortDevice; 2]>,
 }
 
 /// Format an event time truncated (not rounded) to milliseconds. Replay
@@ -104,17 +145,18 @@ impl InputRecorder {
             last_secs: now_secs,
             lines: Vec::new(),
             open_keys: HashMap::new(),
-            open_clicks: [None; 3],
-            open_joys: [None; 11],
+            open_clicks: [[None; 3]; 2],
+            open_joys: [[None; 11]; 2],
             prev: None,
+            first_devices: None,
         }
     }
 
     pub fn events_recorded(&self) -> usize {
         self.lines.len()
             + self.open_keys.len()
-            + self.open_clicks.iter().flatten().count()
-            + self.open_joys.iter().flatten().count()
+            + self.open_clicks.iter().flatten().flatten().count()
+            + self.open_joys.iter().flatten().flatten().count()
     }
 
     /// Record an Amiga key transition that reached the keyboard queue
@@ -149,56 +191,115 @@ impl InputRecorder {
         ));
     }
 
-    /// Diff the live input state against the previous quantum: port-1
-    /// mouse buttons and motion counters, and the port-2 joystick/pad.
+    fn emit_click(&mut self, port: usize, name: &str, press: f64, release: f64) {
+        self.lines.push((
+            press,
+            format!(
+                "click-after {} {name} {}{}",
+                fmt_secs(press),
+                hold_ms(press, release),
+                mouse_port_suffix(port)
+            ),
+        ));
+    }
+
+    fn emit_joy(&mut self, port: usize, name: &str, press: f64, release: f64) {
+        self.lines.push((
+            press,
+            format!(
+                "joy-after {} {name} {}{}",
+                fmt_secs(press),
+                hold_ms(press, release),
+                joy_port_suffix(port)
+            ),
+        ));
+    }
+
+    /// Close every hold a port's device left open, at `secs`.
+    fn close_port_holds(&mut self, port: usize, secs: f64) {
+        for idx in 0..MOUSE_BUTTONS.len() {
+            if let Some(press) = self.open_clicks[port][idx].take() {
+                self.emit_click(port, MOUSE_BUTTONS[idx].0, press, secs);
+            }
+        }
+        for idx in 0..JOY_CONTROLS.len() {
+            if let Some(press) = self.open_joys[port][idx].take() {
+                self.emit_joy(port, JOY_CONTROLS[idx].0, press, secs);
+            }
+        }
+    }
+
+    /// Diff the live input state against the previous quantum, per port
+    /// and according to the device plugged into it.
     pub fn observe(&mut self, input: &InputState, secs: f64) {
         self.last_secs = secs;
         let Some(prev) = self.prev.replace(*input) else {
+            self.first_devices = Some([input.ports[0].device, input.ports[1].device]);
             return;
         };
 
-        let dx = input.mouse_x_port1.wrapping_sub(prev.mouse_x_port1) as i8;
-        let dy = input.mouse_y_port1.wrapping_sub(prev.mouse_y_port1) as i8;
-        if dx != 0 || dy != 0 {
-            self.lines
-                .push((secs, format!("mouse-after {} {dx} {dy}", fmt_secs(secs))));
-        }
-
-        for (idx, (name, read)) in PORT1_BUTTONS.iter().enumerate() {
-            match (read(&prev), read(input)) {
-                (false, true) => self.open_clicks[idx] = Some(secs),
-                (true, false) => {
-                    if let Some(press) = self.open_clicks[idx].take() {
-                        self.lines.push((
-                            press,
-                            format!(
-                                "click-after {} {name} {}",
-                                fmt_secs(press),
-                                hold_ms(press, secs)
-                            ),
-                        ));
-                    }
-                }
-                _ => {}
+        for port in 0..2 {
+            let old = &prev.ports[port];
+            let cur = &input.ports[port];
+            if old.device != cur.device {
+                // Hot-plug: close what the old device held; the device
+                // change itself has no script directive.
+                self.close_port_holds(port, secs);
             }
-        }
-
-        for (idx, (name, read)) in PORT2_CONTROLS.iter().enumerate() {
-            match (read(&prev), read(input)) {
-                (false, true) => self.open_joys[idx] = Some(secs),
-                (true, false) => {
-                    if let Some(press) = self.open_joys[idx].take() {
+            match cur.device {
+                PortDevice::Mouse => {
+                    let dx = cur.counter_x.wrapping_sub(old.counter_x) as i8;
+                    let dy = cur.counter_y.wrapping_sub(old.counter_y) as i8;
+                    if dx != 0 || dy != 0 {
                         self.lines.push((
-                            press,
+                            secs,
                             format!(
-                                "joy-after {} {name} {}",
-                                fmt_secs(press),
-                                hold_ms(press, secs)
+                                "mouse-after {} {dx} {dy}{}",
+                                fmt_secs(secs),
+                                mouse_port_suffix(port)
                             ),
                         ));
                     }
+                    for (idx, (name, read)) in MOUSE_BUTTONS.iter().enumerate() {
+                        match (read(old), read(cur)) {
+                            (false, true) => self.open_clicks[port][idx] = Some(secs),
+                            (true, false) => {
+                                if let Some(press) = self.open_clicks[port][idx].take() {
+                                    self.emit_click(port, name, press, secs);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
                 }
-                _ => {}
+                PortDevice::Joystick | PortDevice::Cd32Pad => {
+                    for (idx, (name, read)) in JOY_CONTROLS.iter().enumerate() {
+                        match (read(old), read(cur)) {
+                            (false, true) => self.open_joys[port][idx] = Some(secs),
+                            (true, false) => {
+                                if let Some(press) = self.open_joys[port][idx].take() {
+                                    self.emit_joy(port, name, press, secs);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                PortDevice::Analogue => {
+                    if let Some((x, y)) = pot_positions(cur) {
+                        if pot_positions(old) != Some((x, y)) {
+                            self.lines.push((
+                                secs,
+                                format!(
+                                    "pot-after {} {x} {y}{}",
+                                    fmt_secs(secs),
+                                    joy_port_suffix(port)
+                                ),
+                            ));
+                        }
+                    }
+                }
+                PortDevice::None => {}
             }
         }
     }
@@ -218,29 +319,8 @@ impl InputRecorder {
                 ),
             ));
         }
-        for (idx, (name, _)) in PORT1_BUTTONS.iter().enumerate() {
-            if let Some(press) = self.open_clicks[idx].take() {
-                self.lines.push((
-                    press,
-                    format!(
-                        "click-after {} {name} {}",
-                        fmt_secs(press),
-                        hold_ms(press, end)
-                    ),
-                ));
-            }
-        }
-        for (idx, (name, _)) in PORT2_CONTROLS.iter().enumerate() {
-            if let Some(press) = self.open_joys[idx].take() {
-                self.lines.push((
-                    press,
-                    format!(
-                        "joy-after {} {name} {}",
-                        fmt_secs(press),
-                        hold_ms(press, end)
-                    ),
-                ));
-            }
+        for port in 0..2 {
+            self.close_port_holds(port, end);
         }
         self.lines
             .sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
@@ -252,6 +332,16 @@ impl InputRecorder {
             "# Replay: copperline --config <config> --script <this file>"
         );
         let _ = writeln!(out, "# Times are absolute emulated seconds.");
+        if let Some(devices) = self.first_devices {
+            if devices != [PortDevice::Mouse, PortDevice::Joystick] {
+                let _ = writeln!(
+                    out,
+                    "# ports: port1={} port2={}",
+                    devices[0].label(),
+                    devices[1].label()
+                );
+            }
+        }
         for (_, line) in &self.lines {
             let _ = writeln!(out, "{line}");
         }
@@ -264,7 +354,10 @@ mod tests {
     use super::*;
 
     fn base_input() -> InputState {
-        InputState::default()
+        let mut input = InputState::default();
+        // The stock machine wiring: mouse in port 1, joystick in port 2.
+        input.set_port_device(1, PortDevice::Joystick);
+        input
     }
 
     #[test]
@@ -295,10 +388,10 @@ mod tests {
         let mut input = base_input();
         rec.observe(&input, 1.0);
         // Forward motion, including a wrap through 255 -> 2.
-        input.mouse_x_port1 = 253;
-        input.mouse_y_port1 = 10;
+        input.ports[0].counter_x = 253;
+        input.ports[0].counter_y = 10;
         rec.observe(&input, 1.02);
-        input.mouse_x_port1 = 2;
+        input.ports[0].counter_x = 2;
         rec.observe(&input, 1.04);
         // No motion: no line.
         rec.observe(&input, 1.06);
@@ -313,16 +406,85 @@ mod tests {
         let mut rec = InputRecorder::new(0.0);
         let mut input = base_input();
         rec.observe(&input, 5.0);
-        input.lmb_port1 = true;
-        input.cd32_green_port2 = true;
+        input.ports[0].fire = true;
+        input.ports[1].cd32_green = true;
         rec.observe(&input, 5.5);
-        input.lmb_port1 = false;
+        input.ports[0].fire = false;
         rec.observe(&input, 6.0);
-        input.cd32_green_port2 = false;
+        input.ports[1].cd32_green = false;
         rec.observe(&input, 6.5);
         let script = rec.finish();
         assert!(script.contains("click-after 5.500 left 500"), "{script}");
         assert!(script.contains("joy-after 5.500 green 1000"), "{script}");
+    }
+
+    #[test]
+    fn default_wiring_emits_no_port_tokens_or_ports_header() {
+        let mut rec = InputRecorder::new(0.0);
+        let mut input = base_input();
+        rec.observe(&input, 1.0);
+        input.ports[0].fire = true;
+        input.ports[1].up = true;
+        rec.observe(&input, 1.5);
+        input.ports[0].fire = false;
+        input.ports[1].up = false;
+        rec.observe(&input, 2.0);
+        let script = rec.finish();
+        assert!(script.contains("click-after 1.500 left 500\n"), "{script}");
+        assert!(script.contains("joy-after 1.500 up 500\n"), "{script}");
+        assert!(!script.contains("# ports:"), "{script}");
+    }
+
+    #[test]
+    fn swapped_ports_emit_port_tokens_and_a_ports_header() {
+        let mut rec = InputRecorder::new(0.0);
+        let mut input = InputState::default();
+        input.set_port_device(0, PortDevice::Joystick);
+        input.set_port_device(1, PortDevice::Mouse);
+        rec.observe(&input, 1.0);
+        input.ports[0].up = true;
+        input.ports[1].fire = true;
+        input.ports[1].counter_x = 7;
+        rec.observe(&input, 1.5);
+        input.ports[0].up = false;
+        input.ports[1].fire = false;
+        rec.observe(&input, 2.0);
+        let script = rec.finish();
+        assert!(
+            script.contains("# ports: port1=joystick port2=mouse"),
+            "{script}"
+        );
+        assert!(script.contains("joy-after 1.500 up 500 1"), "{script}");
+        assert!(script.contains("click-after 1.500 left 500 2"), "{script}");
+        assert!(script.contains("mouse-after 1.500 7 0 2"), "{script}");
+    }
+
+    #[test]
+    fn analogue_position_changes_emit_pot_after_lines() {
+        let mut rec = InputRecorder::new(0.0);
+        let mut input = base_input();
+        input.set_analogue(1, 128, 128);
+        rec.observe(&input, 1.0);
+        input.set_analogue(1, 50, 200);
+        rec.observe(&input, 1.5);
+        // Unchanged position: no line.
+        rec.observe(&input, 2.0);
+        let script = rec.finish();
+        assert!(script.contains("pot-after 1.500 50 200\n"), "{script}");
+        assert_eq!(script.matches("pot-after").count(), 1, "{script}");
+    }
+
+    #[test]
+    fn hot_plug_closes_the_old_devices_open_holds() {
+        let mut rec = InputRecorder::new(0.0);
+        let mut input = base_input();
+        rec.observe(&input, 1.0);
+        input.ports[1].fire = true;
+        rec.observe(&input, 1.5);
+        input.set_port_device(1, PortDevice::Mouse);
+        rec.observe(&input, 2.0);
+        let script = rec.finish();
+        assert!(script.contains("joy-after 1.500 red 500"), "{script}");
     }
 
     #[test]
@@ -357,7 +519,7 @@ mod tests {
         rec.observe(&input, 1.0);
         rec.record_key(0x20, true, 9.0);
         rec.record_key(0x20, false, 9.5);
-        input.mouse_x_port1 = 4;
+        input.ports[0].counter_x = 4;
         rec.observe(&input, 2.0);
         let script = rec.finish();
         let mouse_pos = script.find("mouse-after").unwrap();

--- a/src/inputsched.rs
+++ b/src/inputsched.rs
@@ -18,9 +18,9 @@
 
 use crate::bus::Bus;
 
-/// Full port-2 joystick / CD32-pad held state. Reverse replay re-applies the
-/// whole state (matching how the live joystick path asserts the held set),
-/// so it is self-contained and order-independent.
+/// Full joystick / CD32-pad held state for one port. Reverse replay
+/// re-applies the whole state (matching how the live joystick path asserts
+/// the held set), so it is self-contained and order-independent.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct JoyState {
     pub up: bool,
@@ -37,16 +37,19 @@ pub struct JoyState {
 }
 
 /// One machine-visible input action, captured for deterministic replay.
+/// Port fields follow the bus convention: 0 = port 1, 1 = port 2.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReplayAction {
     /// Keyboard transition (`rawkey` is the Amiga raw keycode).
     Key { rawkey: u8, pressed: bool },
-    /// Port-1 mouse button: index 0 = left, 1 = right, 2 = middle.
-    MouseButton { index: u8, pressed: bool },
-    /// Port-1 quadrature mouse motion.
-    MouseMove { dx: i32, dy: i32 },
-    /// Port-2 joystick / CD32-pad held state.
-    Joy(JoyState),
+    /// Mouse button on a port: index 0 = left, 1 = right, 2 = middle.
+    MouseButton { port: u8, index: u8, pressed: bool },
+    /// Quadrature mouse motion on a port.
+    MouseMove { port: u8, dx: i32, dy: i32 },
+    /// Joystick / CD32-pad held state on a port.
+    Joy { port: u8, state: JoyState },
+    /// Analogue pot positions on a port.
+    Pot { port: u8, x: u8, y: u8 },
     /// A floppy media change occurred. Replaying across a media change cannot
     /// be reconstructed from the log (the inserted image is host-file state),
     /// so the engine warns rather than silently diverging.
@@ -65,19 +68,22 @@ impl ReplayAction {
                     bus.enqueue_key_event(rawkey, false);
                 }
             }
-            ReplayAction::MouseButton { index, pressed } => match index {
-                0 => bus.input.lmb_port1 = pressed,
-                1 => bus.input.rmb_port1 = pressed,
-                2 => bus.input.mmb_port1 = pressed,
-                _ => {}
-            },
-            ReplayAction::MouseMove { dx, dy } => bus.input.add_mouse_delta_port1(dx, dy),
-            ReplayAction::Joy(j) => {
-                bus.input
-                    .set_joystick_port2(j.up, j.down, j.left, j.right, j.red, j.blue);
-                bus.input
-                    .set_cd32_buttons_port2(j.play, j.rwd, j.ffw, j.green, j.yellow);
+            ReplayAction::MouseButton {
+                port,
+                index,
+                pressed,
+            } => bus.input.set_mouse_button(port as usize, index, pressed),
+            ReplayAction::MouseMove { port, dx, dy } => {
+                bus.input.add_mouse_delta(port as usize, dx, dy)
             }
+            ReplayAction::Joy { port, state: j } => {
+                let port = port as usize;
+                bus.input
+                    .set_joystick(port, j.up, j.down, j.left, j.right, j.red, j.blue);
+                bus.input
+                    .set_cd32_buttons(port, j.play, j.rwd, j.ffw, j.green, j.yellow);
+            }
+            ReplayAction::Pot { port, x, y } => bus.input.set_analogue(port as usize, x, y),
             ReplayAction::DiskChange => {
                 log::warn!(
                     "reverse-debug replay crossed a floppy media change; \

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,22 +68,29 @@ pub struct CliArgs {
     /// Scripted key presses to inject after the window opens. Useful
     /// for headless testing of menus and modifier chords.
     pub press_after: Vec<KeyPressSpec>,
-    /// `--click-after SECS BUTTON DURATION_MS`: at SECS seconds after
-    /// the window opens, press the named mouse button (left/right/middle),
-    /// hold for DURATION_MS, then release. Useful for headless testing
-    /// of the mouse-button-driven wait prompts.
-    pub click_after: Vec<(f32, MouseButtonKind, u32)>,
-    /// `--joy-after SECS BUTTON DURATION_MS`: at SECS emulated seconds,
-    /// press a port-2 joystick / CD32-pad control (up/down/left/right/
+    /// `--click-after SECS BUTTON DURATION_MS [PORT]`: at SECS seconds
+    /// after the window opens, press the named mouse button
+    /// (left/right/middle), hold for DURATION_MS, then release. The
+    /// optional trailing PORT (1 or 2) names the controller port,
+    /// defaulting to 1; the tuple carries it 0-based. Useful for headless
+    /// testing of the mouse-button-driven wait prompts.
+    pub click_after: Vec<(f32, MouseButtonKind, u32, u8)>,
+    /// `--joy-after SECS BUTTON DURATION_MS [PORT]`: at SECS emulated
+    /// seconds, press a joystick / CD32-pad control (up/down/left/right/
     /// red|fire/blue/green/yellow/play/rwd/ffw), hold for DURATION_MS,
-    /// then release. Useful for headless testing of joystick-driven
-    /// titles, especially CD32 games whose pad otherwise needs a
-    /// calibrated physical gamepad.
-    pub joy_after: Vec<(f32, JoyButtonKind, u32)>,
-    /// `--mouse-after SECS DX DY`: at SECS emulated seconds, apply a
-    /// relative port-1 mouse motion of (DX, DY) counter steps. Emitted
-    /// by the input recorder one event per frame of recorded movement.
-    pub mouse_after: Vec<(f32, i32, i32)>,
+    /// then release. PORT defaults to 2 (carried 0-based). Useful for
+    /// headless testing of joystick-driven titles, especially CD32 games
+    /// whose pad otherwise needs a calibrated physical gamepad.
+    pub joy_after: Vec<(f32, JoyButtonKind, u32, u8)>,
+    /// `--mouse-after SECS DX DY [PORT]`: at SECS emulated seconds, apply
+    /// a relative mouse motion of (DX, DY) counter steps. PORT defaults
+    /// to 1 (carried 0-based). Emitted by the input recorder one event
+    /// per frame of recorded movement.
+    pub mouse_after: Vec<(f32, i32, i32, u8)>,
+    /// `--pot-after SECS X Y [PORT]`: at SECS emulated seconds, set an
+    /// analogue controller's stick/paddle position (each axis 0-255, the
+    /// count POTxDAT latches). PORT defaults to 2 (carried 0-based).
+    pub pot_after: Vec<(f32, u8, u8, u8)>,
     /// `--record-input PATH`: record every input event that reaches the
     /// emulated machine for the whole run and write the scripted-input
     /// file to PATH on exit (the windowed toggle is the host shortcut
@@ -138,13 +145,14 @@ fn parse_args() -> Result<CliArgs> {
 /// the flag names (without the leading dashes) whose effects accumulate;
 /// anything else in a script is an error so a typo cannot silently change
 /// emulator configuration.
-const SCRIPT_DIRECTIVES: [&str; 8] = [
+const SCRIPT_DIRECTIVES: [&str; 9] = [
     "press-after",
     "key-after",
     "hold-key-after",
     "click-after",
     "joy-after",
     "mouse-after",
+    "pot-after",
     "insert-disk-after",
     "defer-disk-insert",
 ];
@@ -241,6 +249,29 @@ fn next_arg<T: std::str::FromStr>(
         .map_err(|_| anyhow!("{invalid}"))
 }
 
+/// Consume the optional trailing PORT token (exactly "1" or "2") a
+/// scripted-input flag accepts after its fixed arguments, returning the
+/// 0-based port index; anything else leaves the token for the main loop
+/// and yields the flag's traditional default port. (A positional ROM/disk
+/// path literally named "1" or "2" therefore cannot directly follow one
+/// of these flags; name it "./1" instead.)
+fn take_port_token(
+    args: &mut std::iter::Peekable<impl Iterator<Item = String>>,
+    default_port: u8,
+) -> u8 {
+    match args.peek().map(String::as_str) {
+        Some("1") => {
+            args.next();
+            0
+        }
+        Some("2") => {
+            args.next();
+            1
+        }
+        _ => default_port - 1,
+    }
+}
+
 fn parse_args_from<I>(args: I) -> Result<CliArgs>
 where
     I: IntoIterator<Item = String>,
@@ -261,9 +292,10 @@ where
     let mut dump_start_secs: f32 = 0.0;
     let mut dump_count: Option<u32> = None;
     let mut press_after: Vec<KeyPressSpec> = Vec::new();
-    let mut click_after: Vec<(f32, MouseButtonKind, u32)> = Vec::new();
-    let mut joy_after: Vec<(f32, JoyButtonKind, u32)> = Vec::new();
-    let mut mouse_after: Vec<(f32, i32, i32)> = Vec::new();
+    let mut click_after: Vec<(f32, MouseButtonKind, u32, u8)> = Vec::new();
+    let mut joy_after: Vec<(f32, JoyButtonKind, u32, u8)> = Vec::new();
+    let mut mouse_after: Vec<(f32, i32, i32, u8)> = Vec::new();
+    let mut pot_after: Vec<(f32, u8, u8, u8)> = Vec::new();
     let mut record_input: Option<PathBuf> = None;
     let mut wave_path: Option<PathBuf> = None;
     let mut wave_trigger: Option<copperline::waveform::Trigger> = None;
@@ -279,7 +311,7 @@ where
     let mut list_midi = false;
     let mut list_audio_devices = false;
     let mut overrides = ConfigOverrides::default();
-    let mut args = args.into_iter();
+    let mut args = args.into_iter().peekable();
     while let Some(a) = args.next() {
         match a.as_str() {
             "--calibrate-gamepad" => {
@@ -366,6 +398,16 @@ where
                         .ok_or_else(|| anyhow!("--joystick requires a mode (gamepad/keyboard)"))?,
                 );
             }
+            "--port1" => {
+                overrides.port1 = Some(args.next().ok_or_else(|| {
+                    anyhow!("--port1 requires a device (mouse/joystick/cd32/analogue/none)")
+                })?);
+            }
+            "--port2" => {
+                overrides.port2 = Some(args.next().ok_or_else(|| {
+                    anyhow!("--port2 requires a device (mouse/joystick/cd32/analogue/none)")
+                })?);
+            }
             "--serial" => {
                 overrides.serial = Some(args.next().ok_or_else(|| {
                     anyhow!("--serial requires a mode (off/stdout/midi/tcp/pty)")
@@ -419,7 +461,8 @@ where
                     USAGE,
                     "--click-after DURATION_MS must be a number",
                 )?;
-                click_after.push((secs, button, dur_ms));
+                let port = take_port_token(&mut args, 1);
+                click_after.push((secs, button, dur_ms, port));
             }
             "--joy-after" => {
                 const USAGE: &str = "--joy-after requires SECS BUTTON DURATION_MS";
@@ -432,14 +475,24 @@ where
                 })?;
                 let dur_ms: u32 =
                     next_arg(&mut args, USAGE, "--joy-after DURATION_MS must be a number")?;
-                joy_after.push((secs, button, dur_ms));
+                let port = take_port_token(&mut args, 2);
+                joy_after.push((secs, button, dur_ms, port));
             }
             "--mouse-after" => {
                 const USAGE: &str = "--mouse-after requires SECS DX DY";
                 let secs: f32 = next_arg(&mut args, USAGE, "--mouse-after SECS must be a number")?;
                 let dx: i32 = next_arg(&mut args, USAGE, "--mouse-after DX must be an integer")?;
                 let dy: i32 = next_arg(&mut args, USAGE, "--mouse-after DY must be an integer")?;
-                mouse_after.push((secs, dx, dy));
+                let port = take_port_token(&mut args, 1);
+                mouse_after.push((secs, dx, dy, port));
+            }
+            "--pot-after" => {
+                const USAGE: &str = "--pot-after requires SECS X Y";
+                let secs: f32 = next_arg(&mut args, USAGE, "--pot-after SECS must be a number")?;
+                let x: u8 = next_arg(&mut args, USAGE, "--pot-after X must be a number 0-255")?;
+                let y: u8 = next_arg(&mut args, USAGE, "--pot-after Y must be a number 0-255")?;
+                let port = take_port_token(&mut args, 2);
+                pot_after.push((secs, x, y, port));
             }
             "--record-input" => {
                 let v = args
@@ -746,6 +799,7 @@ where
         click_after,
         joy_after,
         mouse_after,
+        pot_after,
         record_input,
         disk_insert_after,
         audio_live,
@@ -792,6 +846,10 @@ fn print_help() {
          --rtc-frozen                   stop the seeded clock at --rtc-time exactly\n  \
          --joystick MODE                initial joystick input: gamepad or keyboard\n  \
          \x20                            (gamepad lets the keyboard pass through to the Amiga)\n  \
+         --port1 DEVICE                 controller in port 1: mouse (default), joystick,\n  \
+         \x20                            cd32, analogue, or none\n  \
+         --port2 DEVICE                 controller in port 2 (default: joystick;\n  \
+         \x20                            cd32 on the CD32 profile)\n  \
          \x20                            (--model/--cpu/etc. override the config file or defaults)\n  \
          --screenshot-after SECS PATH   save a PNG to PATH after SECS emulated seconds, then exit\n  \
          --save-state-after SECS PATH   write a save state to PATH after SECS emulated seconds,\n  \
@@ -823,9 +881,17 @@ fn print_help() {
          \x20                            decimal, 0x.., or a name like ctrl/lalt/lami/f1\n  \
          --key-after SECS KEY MS        press KEY after SECS, hold for MS milliseconds,\n  \
          \x20                            then release; may be passed multiple times\n  \
-         --click-after SECS BTN MS      press mouse BTN (left/right/middle) at SECS,\n  \
-         \x20                            release MS milliseconds later\n  \
-         --mouse-after SECS DX DY       apply a relative port-1 mouse motion at SECS\n  \
+         --click-after SECS BTN MS [PORT]\n  \
+         \x20                            press mouse BTN (left/right/middle) at SECS,\n  \
+         \x20                            release MS ms later, on PORT (default 1)\n  \
+         --joy-after SECS BTN MS [PORT] press joystick/CD32-pad BTN (up/down/left/right/\n  \
+         \x20                            red|fire/blue/green/yellow/play/rwd/ffw) at SECS,\n  \
+         \x20                            release MS ms later, on PORT (default 2)\n  \
+         --mouse-after SECS DX DY [PORT]\n  \
+         \x20                            apply a relative mouse motion at SECS on PORT\n  \
+         \x20                            (default 1)\n  \
+         --pot-after SECS X Y [PORT]    set an analogue controller position (0-255 per\n  \
+         \x20                            axis) at SECS on PORT (default 2)\n  \
          --record-input PATH            record all machine-bound input for the whole run\n  \
          \x20                            and write the script to PATH on exit\n  \
          --script FILE                  run scripted-input directives from FILE (the flag\n  \
@@ -961,6 +1027,7 @@ fn validate_benchmark_args(cli: &CliArgs) -> Result<()> {
         || !cli.click_after.is_empty()
         || !cli.joy_after.is_empty()
         || !cli.mouse_after.is_empty()
+        || !cli.pot_after.is_empty()
     {
         return Err(anyhow!(
             "--benchmark-until cannot be combined with scheduled input events"
@@ -1006,6 +1073,7 @@ fn validate_gdb_args(cli: &CliArgs) -> Result<()> {
         || !cli.click_after.is_empty()
         || !cli.joy_after.is_empty()
         || !cli.mouse_after.is_empty()
+        || !cli.pot_after.is_empty()
     {
         return Err(anyhow!(
             "--gdb cannot be combined with scheduled input events"
@@ -1070,6 +1138,7 @@ fn validate_control_args(cli: &CliArgs) -> Result<()> {
         || !cli.click_after.is_empty()
         || !cli.joy_after.is_empty()
         || !cli.mouse_after.is_empty()
+        || !cli.pot_after.is_empty()
     {
         return Err(anyhow!(
             "--control cannot be combined with scheduled input events (use input.*)"
@@ -1413,6 +1482,7 @@ fn main() -> Result<()> {
         cli.click_after,
         cli.joy_after,
         cli.mouse_after,
+        cli.pot_after,
         disk_insert_after,
         cli.record_input,
         cfg.floppy_playlists.clone(),
@@ -1513,6 +1583,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
         None,
         std::array::from_fn(|_| Vec::new()),
         [true; 4],
@@ -1549,6 +1620,7 @@ fn launcher_requested(cli: &CliArgs) -> bool {
         && cli.click_after.is_empty()
         && cli.joy_after.is_empty()
         && cli.mouse_after.is_empty()
+        && cli.pot_after.is_empty()
         && cli.disk_insert_after.is_empty()
         && cli.record_input.is_none()
         && cli.audio_wav.is_none()
@@ -1724,7 +1796,60 @@ mod tests {
     #[test]
     fn mouse_after_parses_signed_deltas() -> Result<()> {
         let args = parse(&["--mouse-after", "1.5", "-3", "10"])?;
-        assert_eq!(args.mouse_after, vec![(1.5, -3, 10)]);
+        assert_eq!(args.mouse_after, vec![(1.5, -3, 10, 0)]);
+        Ok(())
+    }
+
+    #[test]
+    fn scripted_input_flags_take_an_optional_trailing_port() -> Result<()> {
+        let args = parse(&[
+            "--mouse-after",
+            "1.5",
+            "-3",
+            "10",
+            "2",
+            "--click-after",
+            "5",
+            "left",
+            "100",
+            "2",
+            "--joy-after",
+            "60",
+            "red",
+            "300",
+            "1",
+            "--pot-after",
+            "12",
+            "50",
+            "200",
+            "1",
+        ])?;
+        assert_eq!(args.mouse_after, vec![(1.5, -3, 10, 1)]);
+        assert_eq!(args.click_after, vec![(5.0, MouseButtonKind::Left, 100, 1)]);
+        assert_eq!(args.joy_after, vec![(60.0, JoyButtonKind::Red, 300, 0)]);
+        assert_eq!(args.pot_after, vec![(12.0, 50, 200, 0)]);
+        Ok(())
+    }
+
+    #[test]
+    fn port_token_lookahead_does_not_eat_a_following_flag() -> Result<()> {
+        // No trailing port: the next flag must survive as a flag, and the
+        // defaults are click/mouse -> port 1, joy/pot -> port 2 (0-based
+        // 0/1 in the tuples).
+        let args = parse(&[
+            "--joy-after",
+            "60",
+            "red",
+            "300",
+            "--pot-after",
+            "12",
+            "50",
+            "200",
+            "--noaudio",
+        ])?;
+        assert_eq!(args.joy_after, vec![(60.0, JoyButtonKind::Red, 300, 1)]);
+        assert_eq!(args.pot_after, vec![(12.0, 50, 200, 1)]);
+        assert!(!args.audio_live);
         Ok(())
     }
 
@@ -1737,16 +1862,18 @@ mod tests {
              press-after 14.1 0x63\n\
              \n\
              click-after 5.0 left 100\n\
-             joy-after 60.0 red 300\n\
-             mouse-after 1.020 -3 10\n\
+             joy-after 60.0 red 300 1\n\
+             mouse-after 1.020 -3 10 2\n\
+             pot-after 12.0 50 200\n\
              insert-disk-after 30.0 df1 \"/tmp/with space.adf\"\n",
         );
         let args = parse(&["--script", path.to_str().unwrap()])?;
         assert_eq!(args.press_after.len(), 2);
         assert_eq!(args.press_after[0].hold_ms, 500);
-        assert_eq!(args.click_after, vec![(5.0, MouseButtonKind::Left, 100)]);
-        assert_eq!(args.joy_after, vec![(60.0, JoyButtonKind::Red, 300)]);
-        assert_eq!(args.mouse_after, vec![(1.02, -3, 10)]);
+        assert_eq!(args.click_after, vec![(5.0, MouseButtonKind::Left, 100, 0)]);
+        assert_eq!(args.joy_after, vec![(60.0, JoyButtonKind::Red, 300, 0)]);
+        assert_eq!(args.mouse_after, vec![(1.02, -3, 10, 1)]);
+        assert_eq!(args.pot_after, vec![(12.0, 50, 200, 1)]);
         assert_eq!(
             args.disk_insert_after,
             vec![CliDiskInsert::Explicit(DiskInsertSpec {
@@ -1793,13 +1920,14 @@ mod tests {
         // events through --script.
         let mut rec = copperline::inputrec::InputRecorder::new(0.0);
         let mut input = copperline::bus::InputState::default();
+        input.set_port_device(1, copperline::bus::PortDevice::Joystick);
         rec.observe(&input, 1.0);
         rec.record_key(0x45, true, 1.5);
         rec.record_key(0x45, false, 1.75);
-        input.mouse_x_port1 = 5;
-        input.lmb_port1 = true;
+        input.ports[0].counter_x = 5;
+        input.ports[0].fire = true;
         rec.observe(&input, 2.0);
-        input.lmb_port1 = false;
+        input.ports[0].fire = false;
         rec.observe(&input, 2.5);
         rec.record_disk_insert(0, Path::new("/tmp/demo.adf"), 3.0);
         let path = temp_script("roundtrip", &rec.finish());
@@ -1808,8 +1936,8 @@ mod tests {
         assert_eq!(args.press_after.len(), 1);
         assert_eq!(args.press_after[0].rawkey, 0x45);
         assert_eq!(args.press_after[0].hold_ms, 250);
-        assert_eq!(args.mouse_after, vec![(2.0, 5, 0)]);
-        assert_eq!(args.click_after, vec![(2.0, MouseButtonKind::Left, 500)]);
+        assert_eq!(args.mouse_after, vec![(2.0, 5, 0, 0)]);
+        assert_eq!(args.click_after, vec![(2.0, MouseButtonKind::Left, 500, 0)]);
         assert_eq!(args.disk_insert_after.len(), 1);
         let _ = std::fs::remove_file(&path);
         Ok(())

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -104,7 +104,11 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      the same guest-visible time
 //  30: Paula gained per-channel POT scan/discharge state and InputState gained
 //      analogue paddle resistances for the RC-based POTxDAT converter
-pub const STATE_VERSION: u32 = 30;
+//  31: InputState reshaped into per-port ControllerPort device state (device
+//      kind, JOYxDAT counters, button/direction/pot lines, CD32 serial
+//      shifter); the Bus cd32_pad_shifter/cd32_pad_fire_oldstate fields
+//      moved into the port
+pub const STATE_VERSION: u32 = 31;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1419,6 +1419,42 @@ impl MachineSetup {
         *slot = value;
     }
 
+    /// The Input tab's live summary: which host input ends up driving
+    /// each port under the chosen devices and joystick-input mode.
+    /// Computed by the same routing function the runtime input pump
+    /// uses, so the promise cannot drift from the behavior.
+    pub fn input_routing_summary(&self) -> [String; 2] {
+        let routing =
+            crate::video::window::host_routing_for(self.port_devices, self.joystick_input_mode);
+        std::array::from_fn(|port| {
+            let source = if routing.mouse == Some(port) {
+                "the host mouse".to_string()
+            } else if routing.gamepad == Some(port) && routing.keyboard2 == Some(port) {
+                "the gamepad (numpad keys without a pad)".to_string()
+            } else if routing.gamepad == Some(port) {
+                "the gamepad".to_string()
+            } else if routing.keyboard == Some(port) {
+                if self.port_devices[port] == PortDevice::Mouse {
+                    "cursor keys as a mouse (fire keys = buttons)".to_string()
+                } else {
+                    "cursor keys (Right Ctrl / Right Alt = fire)".to_string()
+                }
+            } else {
+                match self.port_devices[port] {
+                    PortDevice::Mouse => "nothing (flip Joystick input to keyboard)".to_string(),
+                    PortDevice::Joystick | PortDevice::Cd32Pad => {
+                        "nothing (keyboard passes through to the Amiga)".to_string()
+                    }
+                    PortDevice::Analogue => {
+                        "--pot-after scripting or the control protocol".to_string()
+                    }
+                    PortDevice::None => "nothing (empty port)".to_string(),
+                }
+            };
+            format!("Port {} is driven by {}", port + 1, source)
+        })
+    }
+
     /// The value text shown on a row (the current enum/size/number; the file
     /// name or a placeholder for paths; On/Off for toggles).
     pub fn value_label(&self, field: LauncherField) -> String {
@@ -2531,6 +2567,71 @@ mod tests {
         s.cycle(LauncherField::Joystick, true);
         s.select_model(Some(MachineModel::A1200));
         assert_eq!(s.joystick_input_mode, JoystickInputMode::Gamepad);
+    }
+
+    #[test]
+    fn input_routing_summary_names_the_driving_source_per_port() {
+        let mut s = MachineSetup::default();
+        // Stock wiring, gamepad mode.
+        let lines = s.input_routing_summary();
+        assert!(lines[0].contains("host mouse"), "{lines:?}");
+        assert!(lines[1].contains("gamepad"), "{lines:?}");
+
+        // Stock wiring, keyboard mode: the cursor keys take the joystick.
+        s.cycle(LauncherField::Joystick, true);
+        let lines = s.input_routing_summary();
+        assert!(lines[1].contains("cursor keys"), "{lines:?}");
+
+        // Two joysticks: the numpad stand-in is called out.
+        s.port_devices = [PortDevice::Joystick, PortDevice::Joystick];
+        let lines = s.input_routing_summary();
+        assert!(lines.iter().any(|l| l.contains("numpad")), "{lines:?}");
+        assert!(lines.iter().any(|l| l.contains("cursor keys")), "{lines:?}");
+
+        // Two mice, keyboard mode: the second mouse is keyboard-driven.
+        s.port_devices = [PortDevice::Mouse, PortDevice::Mouse];
+        let lines = s.input_routing_summary();
+        assert!(lines[0].contains("host mouse"), "{lines:?}");
+        assert!(lines[1].contains("as a mouse"), "{lines:?}");
+
+        // Two mice, gamepad mode: the second mouse is undriven, with the
+        // remedy named.
+        s.cycle(LauncherField::Joystick, true);
+        let lines = s.input_routing_summary();
+        assert!(
+            lines[1].contains("flip Joystick input to keyboard"),
+            "{lines:?}"
+        );
+
+        // Analogue and empty ports say how (or that nothing) drives them.
+        s.port_devices = [PortDevice::Analogue, PortDevice::None];
+        let lines = s.input_routing_summary();
+        assert!(lines[0].contains("pot-after"), "{lines:?}");
+        assert!(lines[1].contains("empty"), "{lines:?}");
+
+        // Every device/mode combination fits the settings pane (the panel
+        // draws these at 8 px per character with no wrapping).
+        let all = [
+            PortDevice::Mouse,
+            PortDevice::Joystick,
+            PortDevice::Cd32Pad,
+            PortDevice::Analogue,
+            PortDevice::None,
+        ];
+        for p0 in all {
+            for p1 in all {
+                for _ in 0..2 {
+                    s.cycle(LauncherField::Joystick, true);
+                    s.port_devices = [p0, p1];
+                    for line in s.input_routing_summary() {
+                        assert!(
+                            line.chars().count() <= 68,
+                            "summary line too wide for the pane: {line:?}"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -19,6 +19,7 @@
 //! fields that differ from the selected profile's defaults, so a saved file
 //! reads like the hand-written `*.example.toml`.
 
+use crate::bus::PortDevice;
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
@@ -171,6 +172,7 @@ pub enum LauncherTab {
     // Only reached in a `midi` build, where it is added to TABS.
     #[cfg_attr(not(feature = "midi"), allow(dead_code))]
     Serial,
+    Input,
     Zorro,
     AvEmulation,
 }
@@ -189,6 +191,7 @@ pub const TABS: &[LauncherTab] = &[
     LauncherTab::Cd,
     #[cfg(feature = "midi")]
     LauncherTab::Serial,
+    LauncherTab::Input,
     LauncherTab::Zorro,
     LauncherTab::AvEmulation,
 ];
@@ -205,6 +208,7 @@ impl LauncherTab {
             LauncherTab::HostFs => "Host Mounts",
             LauncherTab::Cd => "CD",
             LauncherTab::Serial => "Serial",
+            LauncherTab::Input => "Input",
             LauncherTab::Zorro => "Zorro",
             LauncherTab::AvEmulation => "A/V & Emu",
         }
@@ -298,7 +302,10 @@ pub enum LauncherField {
     PacingBudget,
     RealtimePriority,
     Warp,
+    // Input
     Joystick,
+    Port1Device,
+    Port2Device,
 }
 
 /// How a row's value is edited, and therefore which widget the panel draws.
@@ -447,7 +454,7 @@ const SERIAL_ROWS: [Row; 3] = [
     row(F::MidiIn, "MIDI input", Cycle),
     row(F::MidiOut, "MIDI output", Cycle),
 ];
-const AV_EMULATION_ROWS: [Row; 13] = [
+const AV_EMULATION_ROWS: [Row; 12] = [
     row(F::AudioDevice, "Audio output", Cycle),
     row(F::AudioChannelMode, "Channel mode", Cycle),
     row(F::AudioStereoSeparation, "Stereo separation", Cycle),
@@ -460,6 +467,10 @@ const AV_EMULATION_ROWS: [Row; 13] = [
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::RealtimePriority, "Realtime priority", Toggle),
     row(F::Warp, "Warp speed", Cycle),
+];
+const INPUT_ROWS: [Row; 3] = [
+    row(F::Port1Device, "Port 1", Cycle),
+    row(F::Port2Device, "Port 2", Cycle),
     row(F::Joystick, "Joystick input", Cycle),
 ];
 
@@ -476,6 +487,7 @@ pub fn rows(tab: LauncherTab) -> &'static [Row] {
         LauncherTab::HostFs => &HOSTFS_ROWS,
         LauncherTab::Cd => &CD_ROWS,
         LauncherTab::Serial => serial_rows(),
+        LauncherTab::Input => &INPUT_ROWS,
         LauncherTab::Zorro => &[],
         LauncherTab::AvEmulation => &AV_EMULATION_ROWS,
     }
@@ -571,6 +583,14 @@ const WARPS: [WarpSpeed; 5] = [
 // The stepper flips the two explicit modes, matching the runtime toggle.
 const JOYSTICK_MODES: [JoystickInputMode; 2] =
     [JoystickInputMode::Gamepad, JoystickInputMode::Keyboard];
+// Controller devices a game port accepts, in stepper order.
+const PORT_DEVICES: [PortDevice; 5] = [
+    PortDevice::Mouse,
+    PortDevice::Joystick,
+    PortDevice::Cd32Pad,
+    PortDevice::Analogue,
+    PortDevice::None,
+];
 // `None` = no SCSI board fitted; the two boards are mutually exclusive here even
 // though the engine could run both, so a config round-trips through this picker.
 const SCSI_CONTROLLERS: [Option<ScsiController>; 4] = [
@@ -691,6 +711,7 @@ pub struct MachineSetup {
     realtime_priority: bool,
     warp: WarpSpeed,
     joystick_input_mode: JoystickInputMode,
+    port_devices: [PortDevice; 2],
     // Extra Zorro boards (metadata path + plugin config schema/overrides)
     zorro_boards: Vec<ZorroBoardSetup>,
 }
@@ -802,6 +823,7 @@ impl MachineSetup {
             realtime_priority: cfg.emulation.realtime_priority,
             warp: cfg.emulation.warp_speed,
             joystick_input_mode: cfg.joystick_input_mode,
+            port_devices: cfg.port_devices,
             zorro_boards: raw
                 .zorro
                 .iter()
@@ -1045,6 +1067,14 @@ impl MachineSetup {
         if self.joystick_input_mode != base.joystick_input_mode {
             raw.input.joystick = Some(self.joystick_input_mode.label().to_string());
         }
+        // Per port against the profile baseline, so a CD32 keeps its pad
+        // implicit and a stock machine emits no port keys at all.
+        if self.port_devices[0] != base.port_devices[0] {
+            raw.input.port1 = Some(self.port_devices[0].label().to_string());
+        }
+        if self.port_devices[1] != base.port_devices[1] {
+            raw.input.port2 = Some(self.port_devices[1].label().to_string());
+        }
         if self.serial_mode != base.serial.mode {
             raw.serial.mode = Some(self.serial_mode.label().to_string());
         }
@@ -1156,6 +1186,7 @@ impl MachineSetup {
         self.realtime_priority = base.emulation.realtime_priority;
         self.warp = base.emulation.warp_speed;
         self.joystick_input_mode = base.joystick_input_mode;
+        self.port_devices = base.port_devices;
         if !self.has_ide() {
             self.ide_master = None;
             self.ide_master_name = None;
@@ -1441,6 +1472,8 @@ impl MachineSetup {
                 JoystickInputMode::Keyboard => "Keyboard".to_string(),
                 JoystickInputMode::Gamepad => "Gamepad".to_string(),
             },
+            F::Port1Device => port_device_display(self.port_devices[0]).to_string(),
+            F::Port2Device => port_device_display(self.port_devices[1]).to_string(),
             F::ScsiController => match self.scsi_controller {
                 None => "None".to_string(),
                 Some(ScsiController::A2091) => "A2091 (Z2)".to_string(),
@@ -1560,6 +1593,12 @@ impl MachineSetup {
             F::Joystick => {
                 self.joystick_input_mode =
                     cycle_slice(&JOYSTICK_MODES, self.joystick_input_mode, forward)
+            }
+            F::Port1Device => {
+                self.port_devices[0] = cycle_slice(&PORT_DEVICES, self.port_devices[0], forward)
+            }
+            F::Port2Device => {
+                self.port_devices[1] = cycle_slice(&PORT_DEVICES, self.port_devices[1], forward)
             }
             F::ScsiController => {
                 // The motherboard SCSI is only on offer where the silicon is.
@@ -1953,6 +1992,18 @@ fn cycle_bootpri(current: i8, forward: bool) -> i8 {
         (idx + n - 1) % n
     };
     BOOTPRI_STEPS[next]
+}
+
+/// Human form of a port device for the picker rows (the config strings
+/// stay lowercase).
+fn port_device_display(device: PortDevice) -> &'static str {
+    match device {
+        PortDevice::Mouse => "Mouse",
+        PortDevice::Joystick => "Joystick",
+        PortDevice::Cd32Pad => "CD32 pad",
+        PortDevice::Analogue => "Analogue",
+        PortDevice::None => "None",
+    }
 }
 
 fn cycle_slice<T: Copy + PartialEq>(items: &[T], current: T, forward: bool) -> T {
@@ -2480,6 +2531,35 @@ mod tests {
         s.cycle(LauncherField::Joystick, true);
         s.select_model(Some(MachineModel::A1200));
         assert_eq!(s.joystick_input_mode, JoystickInputMode::Gamepad);
+    }
+
+    #[test]
+    fn port_devices_round_trip_through_raw_against_the_profile_baseline() {
+        let mut s = MachineSetup::default();
+        // Stock wiring emits no port keys.
+        assert_eq!(s.port_devices, [PortDevice::Mouse, PortDevice::Joystick]);
+        let raw = s.to_raw();
+        assert!(raw.input.port1.is_none());
+        assert!(raw.input.port2.is_none());
+
+        // Non-default devices are written and read back.
+        s.cycle(LauncherField::Port1Device, true); // Mouse -> Joystick
+        s.cycle(LauncherField::Port2Device, true); // Joystick -> Cd32Pad
+        let raw = s.to_raw();
+        assert_eq!(raw.input.port1.as_deref(), Some("joystick"));
+        assert_eq!(raw.input.port2.as_deref(), Some("cd32"));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(
+            back.port_devices,
+            [PortDevice::Joystick, PortDevice::Cd32Pad]
+        );
+
+        // The CD32 profile's bundled pad is its baseline: selecting the
+        // model adopts it and keeps it implicit in the raw config.
+        let mut s = MachineSetup::default();
+        s.select_model(Some(MachineModel::Cd32));
+        assert_eq!(s.port_devices[1], PortDevice::Cd32Pad);
+        assert!(s.to_raw().input.port2.is_none());
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -79,6 +79,8 @@ pub enum MenuItem {
     Debugger,
     Console,
     JoystickInput,
+    Port1Device,
+    Port2Device,
     #[cfg(feature = "midi")]
     MidiInput,
     #[cfg(feature = "midi")]
@@ -99,9 +101,9 @@ pub enum MenuItem {
 /// serial port is in MIDI mode, so the list is built per open rather than fixed.
 pub fn menu_items(midi_active: bool) -> Vec<MenuItem> {
     let _ = midi_active;
-    // 7 leading + up to 2 MIDI + 10 trailing items, sized so appending never
+    // 9 leading + up to 2 MIDI + 10 trailing items, sized so appending never
     // reallocates.
-    let mut items = Vec::with_capacity(19);
+    let mut items = Vec::with_capacity(21);
     items.extend([
         MenuItem::MachineConfig,
         MenuItem::FrameAnalyzer,
@@ -110,6 +112,8 @@ pub fn menu_items(midi_active: bool) -> Vec<MenuItem> {
         MenuItem::AudioOutput,
         MenuItem::Calibration,
         MenuItem::JoystickInput,
+        MenuItem::Port1Device,
+        MenuItem::Port2Device,
     ]);
     #[cfg(feature = "midi")]
     if midi_active {
@@ -139,6 +143,9 @@ pub struct MenuLabels<'a> {
     pub recording: bool,
     pub input_recording: bool,
     pub joystick_input_mode: JoystickInputMode,
+    /// Devices currently plugged into the two game ports (hot-pluggable
+    /// through the Port 1/2 Device items).
+    pub port_devices: [crate::bus::PortDevice; 2],
     pub pixel_aspect: PixelAspect,
     /// Current MIDI input/output device names (empty when not applicable).
     #[cfg_attr(not(feature = "midi"), allow(dead_code))]
@@ -159,6 +166,8 @@ fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
         MenuItem::Debugger => "Debugger...".to_string(),
         MenuItem::Console => "Console...".to_string(),
         MenuItem::JoystickInput => format!("Joystick Input  [{}]", s.joystick_input_mode.label()),
+        MenuItem::Port1Device => format!("Port 1 Device  [{}]", s.port_devices[0].label()),
+        MenuItem::Port2Device => format!("Port 2 Device  [{}]", s.port_devices[1].label()),
         MenuItem::PixelAspect => {
             let value = match s.pixel_aspect {
                 PixelAspect::Tv => "tv",
@@ -4677,6 +4686,8 @@ mod tests {
                                         recording,
                                         input_recording,
                                         joystick_input_mode: mode,
+                                        // The longest device label.
+                                        port_devices: [crate::bus::PortDevice::Analogue; 2],
                                         pixel_aspect: aspect,
                                         midi_in: long,
                                         midi_out: long,
@@ -5213,6 +5224,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5252,6 +5267,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5279,6 +5298,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5322,6 +5345,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5389,6 +5416,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5443,6 +5474,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5494,6 +5529,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5546,6 +5585,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5651,6 +5694,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5716,6 +5763,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5792,6 +5843,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5905,6 +5960,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5948,6 +6007,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -5982,6 +6045,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -6056,6 +6123,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",
@@ -6097,6 +6168,10 @@ mod tests {
                 recording: false,
                 input_recording: false,
                 joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
                 pixel_aspect: PixelAspect::Tv,
                 midi_in: "",
                 midi_out: "",

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4320,6 +4320,31 @@ fn draw_launcher(
             draw_launcher_row(frame, rect, state, r, i, hover, scale);
         }
     }
+    // The Input tab spells out what the chosen wiring means: which host
+    // input source ends up driving each port, live as the values cycle.
+    if state.tab == LauncherTab::Input {
+        let summary_top = launcher_row_y(rect, launcher::rows(LauncherTab::Input).len() + 1);
+        draw_panel_text(
+            frame,
+            launcher_pane_x(rect),
+            summary_top,
+            "With these settings:",
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+        for (i, line) in setup.input_routing_summary().iter().enumerate() {
+            draw_panel_text(
+                frame,
+                launcher_pane_x(rect) + 8,
+                summary_top + 16 + i * 14,
+                line,
+                PANEL_TEXT,
+                1,
+                scale,
+            );
+        }
+    }
     // Status / error line.
     if let Some(status) = &state.status {
         let color = if status.error {
@@ -6180,5 +6205,56 @@ mod tests {
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher-storage");
+
+        // Configuration screen: the Input tab, with the live routing
+        // summary spelled out under the rows (two joysticks, so the
+        // numpad stand-in line shows).
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        // Port 1: Mouse -> Joystick, making a two-stick setup.
+        state.setup.cycle(LauncherField::Port1Device, true);
+        state.tab = LauncherTab::Input;
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(
+            &mut frame,
+            scale,
+            &ui,
+            None,
+            None,
+            false,
+            MenuLabels {
+                warp: false,
+                warp_speed: WarpSpeed::Max,
+                recording: false,
+                input_recording: false,
+                joystick_input_mode: JoystickInputMode::Gamepad,
+                port_devices: [
+                    crate::bus::PortDevice::Mouse,
+                    crate::bus::PortDevice::Joystick,
+                ],
+                pixel_aspect: PixelAspect::Tv,
+                midi_in: "",
+                midi_out: "",
+                audio_output: "",
+            },
+        );
+        assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
+        // The summary header landed below the rows: some text pixel is lit
+        // on its line inside the settings pane.
+        let rect = panel_rect(&Panel::Launcher(Box::new(LauncherState::new(
+            launcher::MachineSetup::default(),
+        ))));
+        let header_y = launcher_row_y(rect, launcher::rows(LauncherTab::Input).len() + 1);
+        let row = &frame[(header_y * w + launcher_pane_x(rect)) * 4
+            ..(header_y * w + launcher_pane_x(rect) + 200) * 4];
+        assert!(
+            row.chunks_exact(4)
+                .any(|px| px == PANEL_TEXT_DIM.to_le_bytes()),
+            "routing summary header not drawn"
+        );
+        save(&frame, "launcher-input");
     }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -13,7 +13,7 @@ use super::{
     MAX_FB_PIXELS, MAX_VISIBLE_LINES,
 };
 use crate::audio::{AudioSink, CpalSink};
-use crate::bus::{BeamWriteSource, FrontPanelStatus, VideoRenderFrameTiming};
+use crate::bus::{BeamWriteSource, FrontPanelStatus, PortDevice, VideoRenderFrameTiming};
 use crate::config::{Config, Overscan, PixelAspect, RawConfig, WarpSpeed};
 use crate::emulator::Emulator;
 use crate::screenshot;
@@ -181,14 +181,7 @@ fn keyboard_joystick_key_for(code: KeyCode) -> Option<KeyboardJoystickKey> {
     })
 }
 
-/// Whether the active mode routes the keyboard joystick mapping to port 2. With
-/// only the two explicit modes this is a direct read of the mode -- `Keyboard`
-/// captures the arrow/fire keys, `Gamepad` lets every key reach the Amiga.
-fn joystick_mode_uses_keyboard(mode: JoystickInputMode) -> bool {
-    matches!(mode, JoystickInputMode::Keyboard)
-}
-
-/// The port-2 controls currently held by `--joy-after` scripting.
+/// One port's controls currently held by `--joy-after` scripting.
 #[derive(Debug, Default, Clone, Copy)]
 struct AutoJoyHeld {
     up: bool,
@@ -527,15 +520,16 @@ pub struct App {
     /// Scheduled mouse-button press/release events from --click-after.
     /// `Press` and `Release` deadlines per requested click.
     auto_clicks: Vec<ScheduledClick>,
-    pending_auto_clicks: Vec<(f32, MouseButtonKind, u32)>,
-    /// Scheduled port-2 joystick/CD32-pad events from --joy-after, plus
-    /// the controls currently held. `auto_joy_engaged` stays true once
-    /// any scripted joy event has fired so the state keeps overriding
-    /// the (absent) physical pad, including the final release.
+    pending_auto_clicks: Vec<(f32, MouseButtonKind, u32, u8)>,
+    /// Scheduled joystick/CD32-pad events from --joy-after, plus the
+    /// controls currently held per port. An `auto_joy_engaged` entry stays
+    /// true once any scripted joy event has fired on that port so the state
+    /// keeps overriding the (absent) physical pad, including the final
+    /// release.
     auto_joys: Vec<ScheduledJoy>,
-    pending_auto_joys: Vec<(f32, JoyButtonKind, u32)>,
-    auto_joy_held: AutoJoyHeld,
-    auto_joy_engaged: bool,
+    pending_auto_joys: Vec<(f32, JoyButtonKind, u32, u8)>,
+    auto_joy_held: [AutoJoyHeld; 2],
+    auto_joy_engaged: [bool; 2],
     /// The windowed control-protocol server (`--control-gui`), attached
     /// after construction via [`App::attach_control`]; its commands are
     /// drained at the top of `about_to_wait` (see window/control.rs).
@@ -543,8 +537,11 @@ pub struct App {
     control: Option<control::ControlState>,
     /// Scheduled relative port-1 mouse motions from --mouse-after,
     /// one-shot per entry; (at_emulated_secs, dx, dy).
-    auto_mouse: Vec<(f64, i32, i32)>,
-    pending_auto_mouse: Vec<(f32, i32, i32)>,
+    auto_mouse: Vec<(f64, i32, i32, u8)>,
+    pending_auto_mouse: Vec<(f32, i32, i32, u8)>,
+    /// Scheduled analogue pot positions from --pot-after (one-shot each).
+    auto_pots: Vec<(f64, u8, u8, u8)>,
+    pending_auto_pots: Vec<(f32, u8, u8, u8)>,
     auto_disk_inserts: Vec<ScheduledDiskInsert>,
     pending_auto_disk_inserts: Vec<DiskInsertSpec>,
     /// Live-input recorder: logs every input event that reaches the
@@ -670,6 +667,8 @@ struct ScheduledClick {
     press_at_emulated_secs: f64,
     release_at_emulated_secs: f64,
     button: MouseButtonKind,
+    /// 0-based controller port the click lands on.
+    port: u8,
     pressed: bool,
 }
 
@@ -686,6 +685,8 @@ struct ScheduledJoy {
     press_at_emulated_secs: f64,
     release_at_emulated_secs: f64,
     button: JoyButtonKind,
+    /// 0-based controller port the control belongs to.
+    port: u8,
     pressed: bool,
 }
 
@@ -834,9 +835,10 @@ impl App {
         save_state_after: Option<(f32, PathBuf)>,
         frame_dump: Option<FrameDumpSpec>,
         press_after: Vec<KeyPressSpec>,
-        click_after: Vec<(f32, MouseButtonKind, u32)>,
-        joy_after: Vec<(f32, JoyButtonKind, u32)>,
-        mouse_after: Vec<(f32, i32, i32)>,
+        click_after: Vec<(f32, MouseButtonKind, u32, u8)>,
+        joy_after: Vec<(f32, JoyButtonKind, u32, u8)>,
+        mouse_after: Vec<(f32, i32, i32, u8)>,
+        pot_after: Vec<(f32, u8, u8, u8)>,
         disk_insert_after: Vec<DiskInsertSpec>,
         record_input: Option<PathBuf>,
         disk_playlists: [Vec<PathBuf>; 4],
@@ -924,12 +926,14 @@ impl App {
             pending_auto_clicks: click_after,
             auto_joys: Vec::new(),
             pending_auto_joys: joy_after,
-            auto_joy_held: AutoJoyHeld::default(),
-            auto_joy_engaged: false,
+            auto_joy_held: [AutoJoyHeld::default(); 2],
+            auto_joy_engaged: [false; 2],
             #[cfg(feature = "control")]
             control: None,
             auto_mouse: Vec::new(),
             pending_auto_mouse: mouse_after,
+            auto_pots: Vec::new(),
+            pending_auto_pots: pot_after,
             auto_disk_inserts: Vec::new(),
             pending_auto_disk_inserts: disk_insert_after,
             input_recorder: record_input
@@ -977,39 +981,91 @@ impl App {
         }
     }
 
-    /// Poll the active host joystick source and drive the emulated port-2
-    /// joystick. Called once per scheduler quantum. In Gamepad mode a calibrated
-    /// physical pad drives the port; in Keyboard mode the keyboard mapping does,
-    /// so port 2 stays usable without a physical controller.
-    fn pump_joystick_input(&mut self) {
-        let gamepad_state = match self.joystick_input_mode {
-            JoystickInputMode::Keyboard => None,
-            JoystickInputMode::Gamepad => self.gamepad.poll(),
-        };
+    /// The port live host-mouse input drives: the lowest-numbered port with
+    /// a mouse plugged in. With no mouse on either port, live mouse input is
+    /// dropped.
+    fn mouse_port(&self) -> Option<usize> {
+        self.emu
+            .bus()
+            .input
+            .ports
+            .iter()
+            .position(|p| p.device == PortDevice::Mouse)
+    }
 
-        match gamepad_state {
-            Some(state) => self.apply_joystick_state(state),
-            // No physical pad but --joy-after scripting has fired: keep
-            // asserting the scripted state so it survives this release
-            // path and drives the upcoming scheduler quantum.
-            None if self.auto_joy_engaged => self.apply_auto_joy_state(),
-            None if self.keyboard_joystick_enabled() => self.apply_keyboard_joystick_state(),
-            // Pad gone/uncalibrated and keyboard fallback disabled: release
-            // everything so nothing sticks.
-            None if self.emu.bus().input.joystick_port2 => {
-                self.release_port2_joystick();
-            }
-            None => {}
+    /// Which port each host joystick source drives, over the ascending list
+    /// of ports with a joystick or CD32 pad plugged in: with one such port,
+    /// the [`JoystickInputMode`] source drives it (Gamepad leaves the
+    /// keyboard passing through to the Amiga); with two (a two-player
+    /// setup), the gamepad and the keyboard mapping drive one each and the
+    /// mode picks which source gets the lower-numbered port. Returns
+    /// `(gamepad_port, keyboard_port)`, 0-based.
+    fn joystick_routing(&self) -> (Option<usize>, Option<usize>) {
+        let input = &self.emu.bus().input;
+        let mut ports = (0..2).filter(|&p| {
+            matches!(
+                input.ports[p].device,
+                PortDevice::Joystick | PortDevice::Cd32Pad
+            )
+        });
+        let first = ports.next();
+        let second = ports.next();
+        match (first, second, self.joystick_input_mode) {
+            (None, _, _) => (None, None),
+            (Some(p), None, JoystickInputMode::Gamepad) => (Some(p), None),
+            (Some(p), None, JoystickInputMode::Keyboard) => (None, Some(p)),
+            (Some(p), Some(q), JoystickInputMode::Gamepad) => (Some(p), Some(q)),
+            (Some(p), Some(q), JoystickInputMode::Keyboard) => (Some(q), Some(p)),
         }
     }
 
-    fn keyboard_joystick_enabled(&self) -> bool {
-        joystick_mode_uses_keyboard(self.joystick_input_mode)
+    /// Poll the host joystick sources and drive the emulated joystick
+    /// port(s). Called once per scheduler quantum. Scripted --joy-after
+    /// state beats the keyboard mapping on a shared port and asserts alone
+    /// on ports no host source drives; a present physical pad beats the
+    /// scripted state on its port, as it always has.
+    fn pump_joystick_input(&mut self) {
+        let (gamepad_port, keyboard_port) = self.joystick_routing();
+        if let Some(port) = gamepad_port {
+            match self.gamepad.poll() {
+                Some(state) => self.apply_joystick_state(port, state),
+                // No physical pad but --joy-after scripting has fired: keep
+                // asserting the scripted state so it survives this release
+                // path and drives the upcoming scheduler quantum.
+                None if self.auto_joy_engaged[port] => self.apply_auto_joy_state(port),
+                // Pad gone/uncalibrated: release the port so nothing sticks.
+                None => self.release_joystick_lines(port),
+            }
+        }
+        if let Some(port) = keyboard_port {
+            if self.auto_joy_engaged[port] {
+                self.apply_auto_joy_state(port);
+            } else {
+                self.apply_joystick_state(port, self.keyboard_joy_held.joystick_state());
+            }
+        }
+        // Scripted joy state on ports no host source drives asserts
+        // independently.
+        for port in 0..2 {
+            if Some(port) != gamepad_port
+                && Some(port) != keyboard_port
+                && self.auto_joy_engaged[port]
+            {
+                self.apply_auto_joy_state(port);
+            }
+        }
     }
 
-    fn apply_joystick_state(&mut self, state: crate::gamepad::JoystickState) {
+    /// Whether the keyboard-joystick mapping owns the mapped keys right
+    /// now: some port is routed to the keyboard source.
+    fn keyboard_joystick_enabled(&self) -> bool {
+        self.joystick_routing().1.is_some()
+    }
+
+    fn apply_joystick_state(&mut self, port: usize, state: crate::gamepad::JoystickState) {
         let input = &mut self.emu.bus_mut().input;
-        input.set_joystick_port2(
+        input.set_joystick(
+            port,
             state.up,
             state.down,
             state.left,
@@ -1017,17 +1073,62 @@ impl App {
             state.fire,
             state.button2,
         );
-        input.set_cd32_buttons_port2(state.play, state.rwd, state.ffw, state.green, state.yellow);
+        input.set_cd32_buttons(
+            port,
+            state.play,
+            state.rwd,
+            state.ffw,
+            state.green,
+            state.yellow,
+        );
     }
 
     fn apply_keyboard_joystick_state(&mut self) {
-        self.apply_joystick_state(self.keyboard_joy_held.joystick_state());
+        if let (_, Some(port)) = self.joystick_routing() {
+            self.apply_joystick_state(port, self.keyboard_joy_held.joystick_state());
+        }
     }
 
-    fn release_port2_joystick(&mut self) {
+    /// Release every control on a joystick port. A no-op unless a
+    /// joystick/pad is engaged there, so a mouse sharing the line fields is
+    /// never clobbered.
+    fn release_joystick_lines(&mut self, port: usize) {
         let input = &mut self.emu.bus_mut().input;
-        input.set_joystick_port2(false, false, false, false, false, false);
-        input.set_cd32_buttons_port2(false, false, false, false, false);
+        if matches!(
+            input.device(port),
+            PortDevice::Joystick | PortDevice::Cd32Pad
+        ) {
+            input.set_joystick(port, false, false, false, false, false, false);
+            input.set_cd32_buttons(port, false, false, false, false, false);
+        }
+    }
+
+    /// Hot-plug a controller device into a port, as if swapping the
+    /// physical plug: the old device's lines release, the quadrature
+    /// counters hold, and any stale scripted --joy-after ownership of the
+    /// port is dropped so it cannot re-engage the old device kind on the
+    /// next quantum. Not journaled for reverse replay -- like a media
+    /// change, the plugged device is host state.
+    fn hot_plug_port_device(&mut self, port: usize, device: PortDevice) {
+        self.auto_joy_engaged[port] = false;
+        self.auto_joy_held[port] = AutoJoyHeld::default();
+        self.emu.bus_mut().input.set_port_device(port, device);
+    }
+
+    /// The menu items' stepper: hot-plug the next device in the cycle.
+    fn cycle_port_device(&mut self, port: usize) {
+        const CYCLE: [PortDevice; 5] = [
+            PortDevice::Mouse,
+            PortDevice::Joystick,
+            PortDevice::Cd32Pad,
+            PortDevice::Analogue,
+            PortDevice::None,
+        ];
+        let current = self.emu.bus().input.device(port);
+        let idx = CYCLE.iter().position(|&d| d == current).unwrap_or(0);
+        let next = CYCLE[(idx + 1) % CYCLE.len()];
+        self.hot_plug_port_device(port, next);
+        self.show_osd(format!("Port {}: {}", port + 1, next.label()));
     }
 
     fn cycle_joystick_input_mode(&mut self) {
@@ -1102,7 +1203,16 @@ impl App {
             self.pump_joystick_input();
         }
         info!("joystick input mode: {}", mode.label());
-        self.show_osd(format!("Joystick input: {}", mode.label()));
+        let osd = match (mode, self.joystick_routing()) {
+            (JoystickInputMode::Keyboard, (_, Some(port))) => {
+                format!("Joystick input: keyboard (port {})", port + 1)
+            }
+            (JoystickInputMode::Gamepad, (Some(port), _)) => {
+                format!("Joystick input: gamepad (port {})", port + 1)
+            }
+            _ => format!("Joystick input: {}", mode.label()),
+        };
+        self.show_osd(osd);
     }
 
     /// Consume a mapped host key as joystick input when keyboard joystick
@@ -1123,31 +1233,33 @@ impl App {
         true
     }
 
-    /// Drive the emulated port-2 joystick/CD32 pad from the --joy-after
+    /// Drive a port's emulated joystick/CD32 pad from the --joy-after
     /// held-control set.
-    fn apply_auto_joy_state(&mut self) {
-        let held = self.auto_joy_held;
+    fn apply_auto_joy_state(&mut self, port: usize) {
+        let held = self.auto_joy_held[port];
         let input = &mut self.emu.bus_mut().input;
-        input.set_joystick_port2(
-            held.up, held.down, held.left, held.right, held.red, held.blue,
+        input.set_joystick(
+            port, held.up, held.down, held.left, held.right, held.red, held.blue,
         );
-        input.set_cd32_buttons_port2(held.play, held.rwd, held.ffw, held.green, held.yellow);
+        input.set_cd32_buttons(port, held.play, held.rwd, held.ffw, held.green, held.yellow);
         // Reverse-debug: note the held state so replay can reproduce it.
-        self.emu.tt_note_input(crate::inputsched::ReplayAction::Joy(
-            crate::inputsched::JoyState {
-                up: held.up,
-                down: held.down,
-                left: held.left,
-                right: held.right,
-                red: held.red,
-                blue: held.blue,
-                play: held.play,
-                rwd: held.rwd,
-                ffw: held.ffw,
-                green: held.green,
-                yellow: held.yellow,
-            },
-        ));
+        self.emu
+            .tt_note_input(crate::inputsched::ReplayAction::Joy {
+                port: port as u8,
+                state: crate::inputsched::JoyState {
+                    up: held.up,
+                    down: held.down,
+                    left: held.left,
+                    right: held.right,
+                    red: held.red,
+                    blue: held.blue,
+                    play: held.play,
+                    rwd: held.rwd,
+                    ffw: held.ffw,
+                    green: held.green,
+                    yellow: held.yellow,
+                },
+            });
     }
 
     pub fn run(self) -> Result<()> {
@@ -1333,22 +1445,26 @@ impl ApplicationHandler for App {
                 pressed: false,
             });
         }
-        for (secs, button, dur_ms) in self.pending_auto_clicks.drain(..) {
+        for (secs, button, dur_ms, port) in self.pending_auto_clicks.drain(..) {
             let press_at = secs.max(0.0) as f64;
             let release_at = press_at + dur_ms as f64 / 1000.0;
             info!(
-                "auto-click armed: {:?} press at {:.1}s emulated, hold {}ms",
-                button, secs, dur_ms
+                "auto-click armed: {:?} press at {:.1}s emulated, hold {}ms, port {}",
+                button,
+                secs,
+                dur_ms,
+                port + 1
             );
             self.auto_clicks.push(ScheduledClick {
                 press_at_emulated_secs: press_at,
                 release_at_emulated_secs: release_at,
                 button,
+                port,
                 pressed: false,
             });
         }
-        for (secs, dx, dy) in self.pending_auto_mouse.drain(..) {
-            self.auto_mouse.push((secs.max(0.0) as f64, dx, dy));
+        for (secs, dx, dy, port) in self.pending_auto_mouse.drain(..) {
+            self.auto_mouse.push((secs.max(0.0) as f64, dx, dy, port));
         }
         if !self.auto_mouse.is_empty() {
             info!(
@@ -1356,17 +1472,30 @@ impl ApplicationHandler for App {
                 self.auto_mouse.len()
             );
         }
-        for (secs, button, dur_ms) in self.pending_auto_joys.drain(..) {
+        for (secs, x, y, port) in self.pending_auto_pots.drain(..) {
+            self.auto_pots.push((secs.max(0.0) as f64, x, y, port));
+        }
+        if !self.auto_pots.is_empty() {
+            info!(
+                "auto-pot armed: {} scheduled positions",
+                self.auto_pots.len()
+            );
+        }
+        for (secs, button, dur_ms, port) in self.pending_auto_joys.drain(..) {
             let press_at = secs.max(0.0) as f64;
             let release_at = press_at + dur_ms as f64 / 1000.0;
             info!(
-                "auto-joy armed: {:?} press at {:.1}s emulated, hold {}ms",
-                button, secs, dur_ms
+                "auto-joy armed: {:?} press at {:.1}s emulated, hold {}ms, port {}",
+                button,
+                secs,
+                dur_ms,
+                port + 1
             );
             self.auto_joys.push(ScheduledJoy {
                 press_at_emulated_secs: press_at,
                 release_at_emulated_secs: release_at,
                 button,
+                port,
                 pressed: false,
             });
         }
@@ -1670,14 +1799,23 @@ impl ApplicationHandler for App {
                 }
                 if pressed && !self.mouse_captured && self.cursor_pos.is_some_and(cursor_in_display)
                 {
-                    self.set_mouse_captured(true);
+                    // With no mouse on either port there is nothing to
+                    // drive: grabbing and hiding the host cursor would
+                    // just trap it.
+                    if self.mouse_port().is_some() {
+                        self.set_mouse_captured(true);
+                    } else {
+                        self.show_osd("No mouse on either port".to_string());
+                    }
                 }
-                let input = &mut self.emu.bus_mut().input;
-                match button {
-                    MouseButton::Left => input.lmb_port1 = pressed,
-                    MouseButton::Right => input.rmb_port1 = pressed,
-                    MouseButton::Middle => input.mmb_port1 = pressed,
-                    _ => {}
+                if let Some(port) = self.mouse_port() {
+                    let input = &mut self.emu.bus_mut().input;
+                    match button {
+                        MouseButton::Left => input.set_mouse_button(port, 0, pressed),
+                        MouseButton::Right => input.set_mouse_button(port, 1, pressed),
+                        MouseButton::Middle => input.set_mouse_button(port, 2, pressed),
+                        _ => {}
+                    }
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
@@ -1805,6 +1943,10 @@ impl ApplicationHandler for App {
                             recording,
                             input_recording,
                             joystick_input_mode: self.joystick_input_mode,
+                            port_devices: [
+                                self.emu.bus().input.device(0),
+                                self.emu.bus().input.device(1),
+                            ],
                             pixel_aspect: super::pixel_aspect(),
                             midi_in: &midi_in_label,
                             midi_out: &midi_out_label,
@@ -1897,10 +2039,8 @@ impl ApplicationHandler for App {
                     self.request_redraw();
                 }
             }
-            let input = &mut self.emu.bus_mut().input;
-            if input.joystick_port2 {
-                input.set_joystick_port2(false, false, false, false, false, false);
-                input.set_cd32_buttons_port2(false, false, false, false, false);
+            for port in 0..2 {
+                self.release_joystick_lines(port);
             }
             if !running {
                 // Nothing paces the loop while the machine is not stepping;
@@ -2016,55 +2156,75 @@ impl ApplicationHandler for App {
         // release_at, then drop the entry.
         self.auto_clicks.retain_mut(|c| {
             if !c.pressed && emu_secs >= c.press_at_emulated_secs {
-                info!("auto-click pressing: {:?}", c.button);
-                set_mouse_button(&mut self.emu, c.button, true);
+                info!("auto-click pressing: {:?} (port {})", c.button, c.port + 1);
+                set_mouse_button(&mut self.emu, c.port, c.button, true);
                 c.pressed = true;
             }
             if c.pressed && emu_secs >= c.release_at_emulated_secs {
                 info!("auto-click releasing: {:?}", c.button);
-                set_mouse_button(&mut self.emu, c.button, false);
+                set_mouse_button(&mut self.emu, c.port, c.button, false);
                 return false;
             }
             true
         });
-        // Fire any scheduled --joy-after events into the port-2
-        // joystick/CD32-pad state, then assert the held set (input polling
-        // re-applies it every quantum while scripting is engaged).
-        let mut joy_changed = false;
+        // Fire any scheduled --joy-after events into the named port's
+        // joystick/CD32-pad state, then assert the held sets (input polling
+        // re-applies them every quantum while scripting is engaged).
+        let mut joy_changed = [false; 2];
         let held = &mut self.auto_joy_held;
         self.auto_joys.retain_mut(|j| {
+            let port = usize::from(j.port != 0);
             if !j.pressed && emu_secs >= j.press_at_emulated_secs {
-                info!("auto-joy pressing: {:?}", j.button);
-                held.set(j.button, true);
+                info!("auto-joy pressing: {:?} (port {})", j.button, port + 1);
+                held[port].set(j.button, true);
                 j.pressed = true;
-                joy_changed = true;
+                joy_changed[port] = true;
             }
             if j.pressed && emu_secs >= j.release_at_emulated_secs {
                 info!("auto-joy releasing: {:?}", j.button);
-                held.set(j.button, false);
-                joy_changed = true;
+                held[port].set(j.button, false);
+                joy_changed[port] = true;
                 return false;
             }
             true
         });
-        if joy_changed {
-            self.auto_joy_engaged = true;
-            self.apply_auto_joy_state();
+        for port in 0..2 {
+            if joy_changed[port] {
+                self.auto_joy_engaged[port] = true;
+                self.apply_auto_joy_state(port);
+            }
         }
         // Fire any scheduled --mouse-after relative motions (one-shot
-        // each); these land on the same port-1 quadrature counters as
-        // live captured-mouse movement.
+        // each); these land on the named port's quadrature counters,
+        // whatever device is configured there (the lines are the lines).
         let mut mouse_deltas = Vec::new();
-        self.auto_mouse.retain(|&(at, dx, dy)| {
+        self.auto_mouse.retain(|&(at, dx, dy, port)| {
             if emu_secs >= at {
-                mouse_deltas.push((dx, dy));
+                mouse_deltas.push((dx, dy, port));
                 false
             } else {
                 true
             }
         });
-        for (dx, dy) in mouse_deltas {
-            self.add_mouse_delta_i32(dx, dy);
+        for (dx, dy, port) in mouse_deltas {
+            self.apply_scripted_mouse_delta(port, dx, dy);
+        }
+        // Fire any scheduled --pot-after analogue positions (one-shot
+        // each).
+        let mut pot_sets = Vec::new();
+        self.auto_pots.retain(|&(at, x, y, port)| {
+            if emu_secs >= at {
+                pot_sets.push((x, y, port));
+                false
+            } else {
+                true
+            }
+        });
+        for (x, y, port) in pot_sets {
+            info!("auto-pot: position ({x}, {y}) on port {}", port + 1);
+            self.emu.bus_mut().input.set_analogue(port as usize, x, y);
+            self.emu
+                .tt_note_input(crate::inputsched::ReplayAction::Pot { port, x, y });
         }
         let mut disk_inserts = Vec::new();
         self.auto_disk_inserts.retain(|insert| {
@@ -2171,24 +2331,21 @@ fn short_status_error(err: &anyhow::Error) -> String {
     first_line.chars().take(96).collect()
 }
 
-fn set_mouse_button(emu: &mut Emulator, button: MouseButtonKind, pressed: bool) {
-    let input = &mut emu.bus_mut().input;
+fn set_mouse_button(emu: &mut Emulator, port: u8, button: MouseButtonKind, pressed: bool) {
     let index = match button {
-        MouseButtonKind::Left => {
-            input.lmb_port1 = pressed;
-            0
-        }
-        MouseButtonKind::Right => {
-            input.rmb_port1 = pressed;
-            1
-        }
-        MouseButtonKind::Middle => {
-            input.mmb_port1 = pressed;
-            2
-        }
+        MouseButtonKind::Left => 0,
+        MouseButtonKind::Right => 1,
+        MouseButtonKind::Middle => 2,
     };
+    emu.bus_mut()
+        .input
+        .set_mouse_button(port as usize, index, pressed);
     // Reverse-debug: note the transition so replay can reproduce it.
-    emu.tt_note_input(crate::inputsched::ReplayAction::MouseButton { index, pressed });
+    emu.tt_note_input(crate::inputsched::ReplayAction::MouseButton {
+        port,
+        index,
+        pressed,
+    });
 }
 
 impl Rect {
@@ -2317,6 +2474,10 @@ fn decode_embedded_png(bytes: &[u8]) -> Result<EmbeddedRgbaImage> {
 
 impl App {
     fn toggle_mouse_capture(&mut self) {
+        if !self.mouse_captured && self.mouse_port().is_none() {
+            self.show_osd("No mouse on either port".to_string());
+            return;
+        }
         self.set_mouse_captured(!self.mouse_captured);
     }
 
@@ -2403,10 +2564,12 @@ impl App {
     }
 
     fn release_mouse_buttons(&mut self) {
-        let input = &mut self.emu.bus_mut().input;
-        input.lmb_port1 = false;
-        input.rmb_port1 = false;
-        input.mmb_port1 = false;
+        if let Some(port) = self.mouse_port() {
+            let input = &mut self.emu.bus_mut().input;
+            for index in 0..3 {
+                input.set_mouse_button(port, index, false);
+            }
+        }
     }
 
     fn track_uncaptured_cursor_motion(&mut self, pos: Option<(i32, i32)>) {
@@ -2438,10 +2601,23 @@ impl App {
     }
 
     fn add_mouse_delta_i32(&mut self, dx: i32, dy: i32) {
-        self.emu.bus_mut().input.add_mouse_delta_port1(dx, dy);
+        let Some(port) = self.mouse_port() else {
+            return;
+        };
+        self.apply_scripted_mouse_delta(port as u8, dx, dy);
+    }
+
+    /// Apply quadrature motion to an explicit port: scripted/CCP events
+    /// drive the named port's counters whatever device is configured
+    /// there, while live host-mouse motion goes through `mouse_port`.
+    fn apply_scripted_mouse_delta(&mut self, port: u8, dx: i32, dy: i32) {
+        self.emu
+            .bus_mut()
+            .input
+            .add_mouse_delta(port as usize, dx, dy);
         // Reverse-debug: note the motion so replay can reproduce it.
         self.emu
-            .tt_note_input(crate::inputsched::ReplayAction::MouseMove { dx, dy });
+            .tt_note_input(crate::inputsched::ReplayAction::MouseMove { port, dx, dy });
     }
 
     fn set_output_volume_from_pos(&mut self, pos: (i32, i32)) {
@@ -2848,6 +3024,8 @@ impl App {
                     ui::MenuItem::Debugger => self.open_debugger(),
                     ui::MenuItem::Console => self.open_console(),
                     ui::MenuItem::JoystickInput => self.cycle_joystick_input_mode(),
+                    ui::MenuItem::Port1Device => self.cycle_port_device(0),
+                    ui::MenuItem::Port2Device => self.cycle_port_device(1),
                     #[cfg(feature = "midi")]
                     ui::MenuItem::MidiInput => self.cycle_midi_input(),
                     #[cfg(feature = "midi")]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -159,27 +159,62 @@ impl KeyboardJoystickHeld {
     }
 }
 
-/// FS-UAE-compatible keyboard joystick/gamepad emulation:
-/// cursor keys for directions; Right Ctrl/Right Alt for fire; CD32 extras
-/// on C/X/D/S/Return/Z/A.
-fn keyboard_joystick_key_for(code: KeyCode) -> Option<KeyboardJoystickKey> {
+/// Keyboard controller emulation, two collision-free layouts so a
+/// two-controller setup can be driven from one keyboard:
+///
+/// - Mapping 0 (FS-UAE-compatible): cursor keys for directions; Right
+///   Ctrl/Right Alt for fire; CD32 extras on C/X/D/S/Return/Z/A. On a
+///   mouse port the same keys become pointer motion, with fire = left
+///   button, X = right, D = middle.
+/// - Mapping 1 (numpad): 8/2/4/6 for directions, 0 for fire, `.` for
+///   the second button, numpad Enter for play. It stands in for the
+///   gamepad when a two-controller setup has no physical pad.
+fn keyboard_joystick_key_for(code: KeyCode) -> Option<(usize, KeyboardJoystickKey)> {
     Some(match code {
-        KeyCode::ArrowUp => KeyboardJoystickKey::Up,
-        KeyCode::ArrowDown => KeyboardJoystickKey::Down,
-        KeyCode::ArrowLeft => KeyboardJoystickKey::Left,
-        KeyCode::ArrowRight => KeyboardJoystickKey::Right,
-        KeyCode::ControlRight => KeyboardJoystickKey::FireRightCtrl,
-        KeyCode::AltRight => KeyboardJoystickKey::FireRightAlt,
-        KeyCode::KeyC => KeyboardJoystickKey::Red,
-        KeyCode::KeyX => KeyboardJoystickKey::Blue,
-        KeyCode::KeyD => KeyboardJoystickKey::Green,
-        KeyCode::KeyS => KeyboardJoystickKey::Yellow,
-        KeyCode::Enter | KeyCode::NumpadEnter => KeyboardJoystickKey::Play,
-        KeyCode::KeyZ => KeyboardJoystickKey::Rewind,
-        KeyCode::KeyA => KeyboardJoystickKey::Forward,
+        KeyCode::ArrowUp => (0, KeyboardJoystickKey::Up),
+        KeyCode::ArrowDown => (0, KeyboardJoystickKey::Down),
+        KeyCode::ArrowLeft => (0, KeyboardJoystickKey::Left),
+        KeyCode::ArrowRight => (0, KeyboardJoystickKey::Right),
+        KeyCode::ControlRight => (0, KeyboardJoystickKey::FireRightCtrl),
+        KeyCode::AltRight => (0, KeyboardJoystickKey::FireRightAlt),
+        KeyCode::KeyC => (0, KeyboardJoystickKey::Red),
+        KeyCode::KeyX => (0, KeyboardJoystickKey::Blue),
+        KeyCode::KeyD => (0, KeyboardJoystickKey::Green),
+        KeyCode::KeyS => (0, KeyboardJoystickKey::Yellow),
+        KeyCode::Enter => (0, KeyboardJoystickKey::Play),
+        KeyCode::KeyZ => (0, KeyboardJoystickKey::Rewind),
+        KeyCode::KeyA => (0, KeyboardJoystickKey::Forward),
+        KeyCode::Numpad8 => (1, KeyboardJoystickKey::Up),
+        KeyCode::Numpad2 => (1, KeyboardJoystickKey::Down),
+        KeyCode::Numpad4 => (1, KeyboardJoystickKey::Left),
+        KeyCode::Numpad6 => (1, KeyboardJoystickKey::Right),
+        KeyCode::Numpad0 => (1, KeyboardJoystickKey::Red),
+        KeyCode::NumpadDecimal => (1, KeyboardJoystickKey::Blue),
+        KeyCode::NumpadEnter => (1, KeyboardJoystickKey::Play),
         _ => return None,
     })
 }
+
+/// Where each host input source lands this quantum; see
+/// [`App::host_routing`]. Ports are 0-based.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct HostRouting {
+    /// Port the host mouse drives: the lowest-numbered mouse port.
+    mouse: Option<usize>,
+    /// Port the physical gamepad drives (joystick/CD32 devices only).
+    gamepad: Option<usize>,
+    /// Port keyboard mapping 0 (cursor keys) drives; the device there may
+    /// be a joystick/pad or a mouse (keyboard mouse emulation).
+    keyboard: Option<usize>,
+    /// Port keyboard mapping 1 (numpad) drives, as the gamepad port's
+    /// stand-in in a two-controller setup.
+    keyboard2: Option<usize>,
+}
+
+/// Quadrature counter steps per scheduler quantum (~one frame) while a
+/// keyboard-mouse direction key is held: ~150 counts/second at PAL frame
+/// rate, a comfortable Workbench pointer speed.
+const KEYBOARD_MOUSE_COUNTS_PER_QUANTUM: i32 = 3;
 
 /// One port's controls currently held by `--joy-after` scripting.
 #[derive(Debug, Default, Clone, Copy)]
@@ -624,7 +659,7 @@ pub struct App {
     /// refresh rate. Adjustable from the Emulator menu and the keyboard.
     warp_speed: WarpSpeed,
     /// Mapped host keys currently held for keyboard joystick emulation.
-    keyboard_joy_held: KeyboardJoystickHeld,
+    keyboard_joy_held: [KeyboardJoystickHeld; 2],
     /// Pop-up menu and main-window overlay state. Debugger and frame
     /// analyzer panes live in separate tool-window state so they can be
     /// open at the same time.
@@ -966,7 +1001,7 @@ impl App {
             gamepad: crate::gamepad::GamepadReader::new(),
             joystick_input_mode,
             warp_speed,
-            keyboard_joy_held: KeyboardJoystickHeld::default(),
+            keyboard_joy_held: [KeyboardJoystickHeld::default(); 2],
             ui: UiState::default(),
             about_machine_lines,
             machine_config,
@@ -993,73 +1028,129 @@ impl App {
             .position(|p| p.device == PortDevice::Mouse)
     }
 
-    /// Which port each host joystick source drives, over the ascending list
-    /// of ports with a joystick or CD32 pad plugged in: with one such port,
-    /// the [`JoystickInputMode`] source drives it (Gamepad leaves the
-    /// keyboard passing through to the Amiga); with two (a two-player
-    /// setup), the gamepad and the keyboard mapping drive one each and the
-    /// mode picks which source gets the lower-numbered port. Returns
-    /// `(gamepad_port, keyboard_port)`, 0-based.
-    fn joystick_routing(&self) -> (Option<usize>, Option<usize>) {
+    /// Which port each host input source drives this quantum. The host
+    /// mouse claims the lowest-numbered mouse port; the ports left over
+    /// that a host source can drive (joysticks, CD32 pads, and a second
+    /// mouse) are assigned by count:
+    ///
+    /// - One port: the [`JoystickInputMode`] picks its source. `Gamepad`
+    ///   leaves the keyboard passing through to the Amiga -- and cannot
+    ///   drive a second mouse, which is then undriven until the mode is
+    ///   flipped to `Keyboard`.
+    /// - Two ports (a two-controller setup): the gamepad -- backed by the
+    ///   numpad keyboard mapping whenever no physical pad is present --
+    ///   and the cursor-key mapping drive one each, the mode picking
+    ///   which source pair gets the lower-numbered port.
+    ///
+    /// The cursor-key mapping drives whatever device its port carries:
+    /// direction lines on a joystick/pad, pointer motion and buttons on a
+    /// mouse.
+    fn host_routing(&self) -> HostRouting {
         let input = &self.emu.bus().input;
-        let mut ports = (0..2).filter(|&p| {
-            matches!(
-                input.ports[p].device,
-                PortDevice::Joystick | PortDevice::Cd32Pad
-            )
+        let mouse = input
+            .ports
+            .iter()
+            .position(|p| p.device == PortDevice::Mouse);
+        let mut remaining = (0..2).filter(|&p| {
+            Some(p) != mouse
+                && matches!(
+                    input.ports[p].device,
+                    PortDevice::Mouse | PortDevice::Joystick | PortDevice::Cd32Pad
+                )
         });
-        let first = ports.next();
-        let second = ports.next();
-        match (first, second, self.joystick_input_mode) {
-            (None, _, _) => (None, None),
-            (Some(p), None, JoystickInputMode::Gamepad) => (Some(p), None),
-            (Some(p), None, JoystickInputMode::Keyboard) => (None, Some(p)),
-            (Some(p), Some(q), JoystickInputMode::Gamepad) => (Some(p), Some(q)),
-            (Some(p), Some(q), JoystickInputMode::Keyboard) => (Some(q), Some(p)),
+        let first = remaining.next();
+        let second = remaining.next();
+        let (gamepad, keyboard, keyboard2) = match (first, second, self.joystick_input_mode) {
+            (None, _, _) => (None, None, None),
+            (Some(p), None, JoystickInputMode::Gamepad) => {
+                if input.ports[p].device == PortDevice::Mouse {
+                    (None, None, None)
+                } else {
+                    (Some(p), None, None)
+                }
+            }
+            (Some(p), None, JoystickInputMode::Keyboard) => (None, Some(p), None),
+            // Two leftover ports are always joysticks/pads: a second
+            // mouse would itself have been claimed as the mouse port.
+            (Some(p), Some(q), JoystickInputMode::Gamepad) => (Some(p), Some(q), Some(p)),
+            (Some(p), Some(q), JoystickInputMode::Keyboard) => (Some(q), Some(p), Some(q)),
+        };
+        HostRouting {
+            mouse,
+            gamepad,
+            keyboard,
+            keyboard2,
         }
     }
 
-    /// Poll the host joystick sources and drive the emulated joystick
-    /// port(s). Called once per scheduler quantum. Scripted --joy-after
-    /// state beats the keyboard mapping on a shared port and asserts alone
-    /// on ports no host source drives; a present physical pad beats the
-    /// scripted state on its port, as it always has.
+    /// Poll the host input sources and drive the emulated port(s). Called
+    /// once per scheduler quantum. Scripted --joy-after state beats the
+    /// keyboard mapping on a shared port and asserts alone on ports no
+    /// host source drives; a present physical pad beats the scripted
+    /// state on its port, as it always has.
     fn pump_joystick_input(&mut self) {
-        let (gamepad_port, keyboard_port) = self.joystick_routing();
-        if let Some(port) = gamepad_port {
+        let r = self.host_routing();
+        if let Some(port) = r.gamepad {
             match self.gamepad.poll() {
                 Some(state) => self.apply_joystick_state(port, state),
                 // No physical pad but --joy-after scripting has fired: keep
                 // asserting the scripted state so it survives this release
                 // path and drives the upcoming scheduler quantum.
                 None if self.auto_joy_engaged[port] => self.apply_auto_joy_state(port),
+                // No pad in a two-controller setup: the numpad keyboard
+                // mapping stands in for it.
+                None if r.keyboard2 == Some(port) => {
+                    self.apply_joystick_state(port, self.keyboard_joy_held[1].joystick_state())
+                }
                 // Pad gone/uncalibrated: release the port so nothing sticks.
                 None => self.release_joystick_lines(port),
             }
         }
-        if let Some(port) = keyboard_port {
-            if self.auto_joy_engaged[port] {
+        if let Some(port) = r.keyboard {
+            if self.emu.bus().input.device(port) == PortDevice::Mouse {
+                self.apply_keyboard_mouse_state(port);
+            } else if self.auto_joy_engaged[port] {
                 self.apply_auto_joy_state(port);
             } else {
-                self.apply_joystick_state(port, self.keyboard_joy_held.joystick_state());
+                self.apply_joystick_state(port, self.keyboard_joy_held[0].joystick_state());
             }
         }
         // Scripted joy state on ports no host source drives asserts
         // independently.
         for port in 0..2 {
-            if Some(port) != gamepad_port
-                && Some(port) != keyboard_port
-                && self.auto_joy_engaged[port]
-            {
+            if Some(port) != r.gamepad && Some(port) != r.keyboard && self.auto_joy_engaged[port] {
                 self.apply_auto_joy_state(port);
             }
         }
     }
 
-    /// Whether the keyboard-joystick mapping owns the mapped keys right
-    /// now: some port is routed to the keyboard source.
-    fn keyboard_joystick_enabled(&self) -> bool {
-        self.joystick_routing().1.is_some()
+    /// Whether a keyboard mapping owns its keys right now: mapping 0
+    /// (cursor keys) when a port routes to the keyboard source, mapping 1
+    /// (numpad) when it is the gamepad port's stand-in.
+    fn keyboard_mapping_active(&self, mapping: usize) -> bool {
+        let r = self.host_routing();
+        if mapping == 0 {
+            r.keyboard.is_some()
+        } else {
+            r.keyboard2.is_some()
+        }
+    }
+
+    /// Drive a mouse port from the cursor-key mapping: held direction
+    /// keys become steady pointer motion, the fire keys the left button,
+    /// X the right, D the middle.
+    fn apply_keyboard_mouse_state(&mut self, port: usize) {
+        let held = self.keyboard_joy_held[0];
+        let dx = KEYBOARD_MOUSE_COUNTS_PER_QUANTUM * (i32::from(held.right) - i32::from(held.left));
+        let dy = KEYBOARD_MOUSE_COUNTS_PER_QUANTUM * (i32::from(held.down) - i32::from(held.up));
+        if dx != 0 || dy != 0 {
+            self.apply_scripted_mouse_delta(port as u8, dx, dy);
+        }
+        let state = held.joystick_state();
+        let input = &mut self.emu.bus_mut().input;
+        input.set_mouse_button(port, 0, state.fire);
+        input.set_mouse_button(port, 1, state.button2);
+        input.set_mouse_button(port, 2, state.green);
     }
 
     fn apply_joystick_state(&mut self, port: usize, state: crate::gamepad::JoystickState) {
@@ -1081,12 +1172,6 @@ impl App {
             state.green,
             state.yellow,
         );
-    }
-
-    fn apply_keyboard_joystick_state(&mut self) {
-        if let (_, Some(port)) = self.joystick_routing() {
-            self.apply_joystick_state(port, self.keyboard_joy_held.joystick_state());
-        }
     }
 
     /// Release every control on a joystick port. A no-op unless a
@@ -1203,11 +1288,12 @@ impl App {
             self.pump_joystick_input();
         }
         info!("joystick input mode: {}", mode.label());
-        let osd = match (mode, self.joystick_routing()) {
-            (JoystickInputMode::Keyboard, (_, Some(port))) => {
+        let routing = self.host_routing();
+        let osd = match (mode, routing.keyboard, routing.gamepad) {
+            (JoystickInputMode::Keyboard, Some(port), _) => {
                 format!("Joystick input: keyboard (port {})", port + 1)
             }
-            (JoystickInputMode::Gamepad, (Some(port), _)) => {
+            (JoystickInputMode::Gamepad, _, Some(port)) => {
                 format!("Joystick input: gamepad (port {})", port + 1)
             }
             _ => format!("Joystick input: {}", mode.label()),
@@ -1219,16 +1305,19 @@ impl App {
     /// emulation is active. Releases for previously consumed mapped keys
     /// are also swallowed, even if a gamepad has taken over meanwhile.
     fn handle_keyboard_joystick_key(&mut self, code: KeyCode, pressed: bool) -> bool {
-        let Some(key) = keyboard_joystick_key_for(code) else {
+        let Some((mapping, key)) = keyboard_joystick_key_for(code) else {
             return false;
         };
-        let was_held = self.keyboard_joy_held.is_set(key);
-        if !self.keyboard_joystick_enabled() && !was_held {
+        let active = self.keyboard_mapping_active(mapping);
+        let was_held = self.keyboard_joy_held[mapping].is_set(key);
+        if !active && !was_held {
             return false;
         }
-        self.keyboard_joy_held.set(key, pressed);
-        if self.keyboard_joystick_enabled() {
-            self.apply_keyboard_joystick_state();
+        self.keyboard_joy_held[mapping].set(key, pressed);
+        if active {
+            // Re-run the input pump so the transition lands this quantum
+            // on whatever port and device the mapping drives.
+            self.pump_joystick_input();
         }
         true
     }
@@ -4258,7 +4347,7 @@ impl App {
         // Reset the host joystick source to the new machine's configured
         // start-up mode (a previous live Cmd+J toggle does not carry over).
         self.joystick_input_mode = cfg.joystick_input_mode;
-        self.keyboard_joy_held = KeyboardJoystickHeld::default();
+        self.keyboard_joy_held = [KeyboardJoystickHeld::default(); 2];
         self.about_machine_lines = crate::config::about_machine_lines(cfg);
         self.deinterlacer =
             Deinterlacer::with_phosphor(crate::config::resolve_phosphor(cfg.phosphor));

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -196,19 +196,57 @@ fn keyboard_joystick_key_for(code: KeyCode) -> Option<(usize, KeyboardJoystickKe
 }
 
 /// Where each host input source lands this quantum; see
-/// [`App::host_routing`]. Ports are 0-based.
+/// [`host_routing_for`]. Ports are 0-based.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-struct HostRouting {
+pub(crate) struct HostRouting {
     /// Port the host mouse drives: the lowest-numbered mouse port.
-    mouse: Option<usize>,
+    pub(crate) mouse: Option<usize>,
     /// Port the physical gamepad drives (joystick/CD32 devices only).
-    gamepad: Option<usize>,
+    pub(crate) gamepad: Option<usize>,
     /// Port keyboard mapping 0 (cursor keys) drives; the device there may
     /// be a joystick/pad or a mouse (keyboard mouse emulation).
-    keyboard: Option<usize>,
+    pub(crate) keyboard: Option<usize>,
     /// Port keyboard mapping 1 (numpad) drives, as the gamepad port's
     /// stand-in in a two-controller setup.
-    keyboard2: Option<usize>,
+    pub(crate) keyboard2: Option<usize>,
+}
+
+/// The host input sources' port assignment for a device wiring and
+/// joystick-input mode. Pure, and shared by the live input pump and the
+/// launcher's Input-tab summary, so what the GUI promises is exactly what
+/// the pump does. The rules are documented on [`App::host_routing`].
+pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode) -> HostRouting {
+    let mouse = devices.iter().position(|&d| d == PortDevice::Mouse);
+    let mut remaining = (0..2).filter(|&p| {
+        Some(p) != mouse
+            && matches!(
+                devices[p],
+                PortDevice::Mouse | PortDevice::Joystick | PortDevice::Cd32Pad
+            )
+    });
+    let first = remaining.next();
+    let second = remaining.next();
+    let (gamepad, keyboard, keyboard2) = match (first, second, mode) {
+        (None, _, _) => (None, None, None),
+        (Some(p), None, JoystickInputMode::Gamepad) => {
+            if devices[p] == PortDevice::Mouse {
+                (None, None, None)
+            } else {
+                (Some(p), None, None)
+            }
+        }
+        (Some(p), None, JoystickInputMode::Keyboard) => (None, Some(p), None),
+        // Two leftover ports are always joysticks/pads: a second mouse
+        // would itself have been claimed as the mouse port.
+        (Some(p), Some(q), JoystickInputMode::Gamepad) => (Some(p), Some(q), Some(p)),
+        (Some(p), Some(q), JoystickInputMode::Keyboard) => (Some(q), Some(p), Some(q)),
+    };
+    HostRouting {
+        mouse,
+        gamepad,
+        keyboard,
+        keyboard2,
+    }
 }
 
 /// Quadrature counter steps per scheduler quantum (~one frame) while a
@@ -1047,40 +1085,10 @@ impl App {
     /// mouse.
     fn host_routing(&self) -> HostRouting {
         let input = &self.emu.bus().input;
-        let mouse = input
-            .ports
-            .iter()
-            .position(|p| p.device == PortDevice::Mouse);
-        let mut remaining = (0..2).filter(|&p| {
-            Some(p) != mouse
-                && matches!(
-                    input.ports[p].device,
-                    PortDevice::Mouse | PortDevice::Joystick | PortDevice::Cd32Pad
-                )
-        });
-        let first = remaining.next();
-        let second = remaining.next();
-        let (gamepad, keyboard, keyboard2) = match (first, second, self.joystick_input_mode) {
-            (None, _, _) => (None, None, None),
-            (Some(p), None, JoystickInputMode::Gamepad) => {
-                if input.ports[p].device == PortDevice::Mouse {
-                    (None, None, None)
-                } else {
-                    (Some(p), None, None)
-                }
-            }
-            (Some(p), None, JoystickInputMode::Keyboard) => (None, Some(p), None),
-            // Two leftover ports are always joysticks/pads: a second
-            // mouse would itself have been claimed as the mouse port.
-            (Some(p), Some(q), JoystickInputMode::Gamepad) => (Some(p), Some(q), Some(p)),
-            (Some(p), Some(q), JoystickInputMode::Keyboard) => (Some(q), Some(p), Some(q)),
-        };
-        HostRouting {
-            mouse,
-            gamepad,
-            keyboard,
-            keyboard2,
-        }
+        host_routing_for(
+            [input.ports[0].device, input.ports[1].device],
+            self.joystick_input_mode,
+        )
     }
 
     /// Poll the host input sources and drive the emulated port(s). Called

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -297,6 +297,14 @@ impl App {
                 };
                 self.control_send(line);
             }
+            HostOp::SetPortDevice { port, device } => {
+                self.hot_plug_port_device(port as usize, device);
+                self.show_osd(format!("Port {}: {}", port + 1, device.label()));
+                self.control_send(proto::ok_line(
+                    &id,
+                    json!({"port": port + 1, "device": device.label()}),
+                ));
+            }
             HostOp::StateLoad { path } => {
                 if self.control.as_ref().is_some_and(|c| c.pending.is_some()) {
                     self.control_send(proto::err_line(
@@ -642,17 +650,28 @@ impl App {
     fn control_apply_input(&mut self, action: InputAction) {
         match action {
             InputAction::Key { rawkey, pressed } => self.handle_amiga_key_event(rawkey, pressed),
-            InputAction::MouseButton { index, pressed } => {
+            InputAction::MouseButton {
+                port,
+                index,
+                pressed,
+            } => {
                 let kind = match index {
                     0 => MouseButtonKind::Left,
                     1 => MouseButtonKind::Right,
                     _ => MouseButtonKind::Middle,
                 };
-                set_mouse_button(&mut self.emu, kind, pressed);
+                set_mouse_button(&mut self.emu, port, kind, pressed);
             }
-            InputAction::MouseMove { dx, dy } => self.add_mouse_delta_i32(dx, dy),
-            InputAction::Joy(j) => {
-                self.auto_joy_held = AutoJoyHeld {
+            InputAction::MouseMove { port, dx, dy } => {
+                self.emu
+                    .bus_mut()
+                    .input
+                    .add_mouse_delta(port as usize, dx, dy);
+                self.emu
+                    .tt_note_input(crate::inputsched::ReplayAction::MouseMove { port, dx, dy });
+            }
+            InputAction::Joy { port, state: j } => {
+                self.auto_joy_held[port as usize] = AutoJoyHeld {
                     up: j.up,
                     down: j.down,
                     left: j.left,
@@ -665,7 +684,12 @@ impl App {
                     rwd: j.rwd,
                     ffw: j.ffw,
                 };
-                self.apply_auto_joy_state();
+                self.apply_auto_joy_state(port as usize);
+            }
+            InputAction::Pot { port, x, y } => {
+                self.emu.bus_mut().input.set_analogue(port as usize, x, y);
+                self.emu
+                    .tt_note_input(crate::inputsched::ReplayAction::Pot { port, x, y });
             }
         }
     }

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1312,10 +1312,12 @@ pub(super) fn draw_pause_button(
     }
 }
 
-/// Joystick input-source toggle: shows the device currently driving the
-/// emulated port-2 joystick (a gamepad in `Gamepad` mode, a keyboard in
-/// `Keyboard` mode). Clicking it flips between the two, so the active source is
-/// always visible rather than hidden behind a key combination.
+/// Joystick input-source toggle: shows the host source currently driving the
+/// emulated joystick port (a gamepad in `Gamepad` mode, a keyboard in
+/// `Keyboard` mode; with joysticks in both ports the mode picks which source
+/// gets the lower-numbered port). Clicking it flips between the two, so the
+/// active source is always visible rather than hidden behind a key
+/// combination.
 pub(super) fn draw_joystick_button(
     frame: &mut [u8],
     rect: Rect,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -298,71 +298,51 @@ fn raw_device_alt_right_respects_keyboard_joystick_ownership() {
         physical_key: PhysicalKey::Code(KeyCode::AltRight),
         state: ElementState::Pressed,
     });
-    assert!(app.keyboard_joy_held.fire_right_alt);
+    assert!(app.keyboard_joy_held[0].fire_right_alt);
     assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
 
     app.handle_raw_device_key_event(RawKeyEvent {
         physical_key: PhysicalKey::Code(KeyCode::AltRight),
         state: ElementState::Released,
     });
-    assert!(!app.keyboard_joy_held.fire_right_alt);
+    assert!(!app.keyboard_joy_held[0].fire_right_alt);
     assert!(!rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_RIGHT_ALT));
 }
 
 #[test]
 fn keyboard_joystick_mapping_matches_fsuae_controls() {
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::ArrowUp),
-        Some(KeyboardJoystickKey::Up)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::ArrowDown),
-        Some(KeyboardJoystickKey::Down)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::ArrowLeft),
-        Some(KeyboardJoystickKey::Left)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::ArrowRight),
-        Some(KeyboardJoystickKey::Right)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::ControlRight),
-        Some(KeyboardJoystickKey::FireRightCtrl)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::AltRight),
-        Some(KeyboardJoystickKey::FireRightAlt)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::KeyC),
-        Some(KeyboardJoystickKey::Red)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::KeyX),
-        Some(KeyboardJoystickKey::Blue)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::KeyD),
-        Some(KeyboardJoystickKey::Green)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::KeyS),
-        Some(KeyboardJoystickKey::Yellow)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::Enter),
-        Some(KeyboardJoystickKey::Play)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::KeyZ),
-        Some(KeyboardJoystickKey::Rewind)
-    );
-    assert_eq!(
-        keyboard_joystick_key_for(KeyCode::KeyA),
-        Some(KeyboardJoystickKey::Forward)
-    );
+    use KeyboardJoystickKey as K;
+    // Mapping 0: the FS-UAE-compatible cursor-key layout.
+    for (code, key) in [
+        (KeyCode::ArrowUp, K::Up),
+        (KeyCode::ArrowDown, K::Down),
+        (KeyCode::ArrowLeft, K::Left),
+        (KeyCode::ArrowRight, K::Right),
+        (KeyCode::ControlRight, K::FireRightCtrl),
+        (KeyCode::AltRight, K::FireRightAlt),
+        (KeyCode::KeyC, K::Red),
+        (KeyCode::KeyX, K::Blue),
+        (KeyCode::KeyD, K::Green),
+        (KeyCode::KeyS, K::Yellow),
+        (KeyCode::Enter, K::Play),
+        (KeyCode::KeyZ, K::Rewind),
+        (KeyCode::KeyA, K::Forward),
+    ] {
+        assert_eq!(keyboard_joystick_key_for(code), Some((0, key)), "{code:?}");
+    }
+    // Mapping 1: the numpad layout for the second controller, collision
+    // free against mapping 0's letters.
+    for (code, key) in [
+        (KeyCode::Numpad8, K::Up),
+        (KeyCode::Numpad2, K::Down),
+        (KeyCode::Numpad4, K::Left),
+        (KeyCode::Numpad6, K::Right),
+        (KeyCode::Numpad0, K::Red),
+        (KeyCode::NumpadDecimal, K::Blue),
+        (KeyCode::NumpadEnter, K::Play),
+    ] {
+        assert_eq!(keyboard_joystick_key_for(code), Some((1, key)), "{code:?}");
+    }
     assert_eq!(keyboard_joystick_key_for(KeyCode::ControlLeft), None);
 }
 
@@ -395,43 +375,75 @@ fn joystick_input_mode_toggles_between_two_explicit_modes() {
 }
 
 #[test]
-fn joystick_routing_assigns_sources_by_device_and_mode() {
+fn host_routing_assigns_sources_by_device_and_mode() {
+    use super::HostRouting;
     use crate::bus::PortDevice;
+    fn routing(
+        mouse: Option<usize>,
+        gamepad: Option<usize>,
+        keyboard: Option<usize>,
+        keyboard2: Option<usize>,
+    ) -> HostRouting {
+        HostRouting {
+            mouse,
+            gamepad,
+            keyboard,
+            keyboard2,
+        }
+    }
     let mut app = test_app();
+    let set = |app: &mut super::App, p0: PortDevice, p1: PortDevice| {
+        app.emu.bus_mut().input.set_port_device(0, p0);
+        app.emu.bus_mut().input.set_port_device(1, p1);
+    };
 
     // Stock wiring (mouse + joystick): the mode picks the single source
-    // for port 2 (index 1); the keyboard mapping is engaged exactly when
-    // (and only when) some port routes to it.
-    app.emu
-        .bus_mut()
-        .input
-        .set_port_device(0, PortDevice::Mouse);
-    app.emu
-        .bus_mut()
-        .input
-        .set_port_device(1, PortDevice::Joystick);
+    // for port 2 (index 1); the cursor-key mapping owns its keys exactly
+    // when some port routes to it.
+    set(&mut app, PortDevice::Mouse, PortDevice::Joystick);
     app.joystick_input_mode = JoystickInputMode::Gamepad;
-    assert_eq!(app.joystick_routing(), (Some(1), None));
-    assert!(!app.keyboard_joystick_enabled());
+    assert_eq!(app.host_routing(), routing(Some(0), Some(1), None, None));
+    assert!(!app.keyboard_mapping_active(0));
     app.joystick_input_mode = JoystickInputMode::Keyboard;
-    assert_eq!(app.joystick_routing(), (None, Some(1)));
-    assert!(app.keyboard_joystick_enabled());
+    assert_eq!(app.host_routing(), routing(Some(0), None, Some(1), None));
+    assert!(app.keyboard_mapping_active(0));
 
-    // Swapped wiring: the joystick port follows the device, wherever it is.
-    app.emu
-        .bus_mut()
-        .input
-        .set_port_device(0, PortDevice::Cd32Pad);
-    app.emu
-        .bus_mut()
-        .input
-        .set_port_device(1, PortDevice::Mouse);
+    // Swapped wiring: the sources follow the devices, wherever they are.
+    set(&mut app, PortDevice::Cd32Pad, PortDevice::Mouse);
     app.joystick_input_mode = JoystickInputMode::Gamepad;
-    assert_eq!(app.joystick_routing(), (Some(0), None));
+    assert_eq!(app.host_routing(), routing(Some(1), Some(0), None, None));
     assert_eq!(app.mouse_port(), Some(1));
 
-    // Two joysticks (two-player): both sources drive a port each; the
-    // mode picks which gets the lower-numbered one.
+    // Two joysticks (two-player): the gamepad -- backed by the numpad
+    // mapping -- and the cursor-key mapping drive one each; the mode
+    // picks which pair gets the lower-numbered port.
+    set(&mut app, PortDevice::Joystick, PortDevice::Joystick);
+    assert_eq!(app.host_routing(), routing(None, Some(0), Some(1), Some(0)));
+    assert!(app.keyboard_mapping_active(1));
+    app.joystick_input_mode = JoystickInputMode::Keyboard;
+    assert_eq!(app.host_routing(), routing(None, Some(1), Some(0), Some(1)));
+    assert_eq!(app.mouse_port(), None, "no mouse port in a two-stick setup");
+
+    // Two mice: the host mouse takes port 1; the second mouse is
+    // keyboard-driven in Keyboard mode and undriven in Gamepad mode (a
+    // pad cannot be a pointer, and the keyboard keeps passing through).
+    set(&mut app, PortDevice::Mouse, PortDevice::Mouse);
+    assert_eq!(app.host_routing(), routing(Some(0), None, Some(1), None));
+    app.joystick_input_mode = JoystickInputMode::Gamepad;
+    assert_eq!(app.host_routing(), routing(Some(0), None, None, None));
+
+    // No host-drivable port besides the mouse: neither joystick source
+    // engages and the keyboard passes through to the Amiga.
+    set(&mut app, PortDevice::Mouse, PortDevice::Analogue);
+    app.joystick_input_mode = JoystickInputMode::Keyboard;
+    assert_eq!(app.host_routing(), routing(Some(0), None, None, None));
+    assert!(!app.keyboard_mapping_active(0));
+}
+
+#[test]
+fn numpad_mapping_stands_in_for_the_missing_gamepad() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
     app.emu
         .bus_mut()
         .input
@@ -440,13 +452,28 @@ fn joystick_routing_assigns_sources_by_device_and_mode() {
         .bus_mut()
         .input
         .set_port_device(1, PortDevice::Joystick);
-    assert_eq!(app.joystick_routing(), (Some(0), Some(1)));
-    app.joystick_input_mode = JoystickInputMode::Keyboard;
-    assert_eq!(app.joystick_routing(), (Some(1), Some(0)));
-    assert_eq!(app.mouse_port(), None, "no mouse port in a two-stick setup");
+    app.joystick_input_mode = JoystickInputMode::Gamepad;
 
-    // No joystick anywhere: neither source drives a port and the keyboard
-    // passes through to the Amiga.
+    // No physical pad in the test rig: the numpad mapping drives the
+    // gamepad port (port 1) while the cursor-key mapping drives port 2,
+    // so both players work from one keyboard.
+    app.keyboard_joy_held[1].up = true;
+    app.keyboard_joy_held[0].down = true;
+    app.keyboard_joy_held[0].fire_right_ctrl = true;
+    app.pump_joystick_input();
+    assert!(app.emu.bus().input.ports[0].up, "numpad drives port 1");
+    assert!(!app.emu.bus().input.ports[0].down);
+    assert!(
+        app.emu.bus().input.ports[1].down,
+        "cursor keys drive port 2"
+    );
+    assert!(app.emu.bus().input.ports[1].fire);
+}
+
+#[test]
+fn keyboard_mouse_drives_a_second_mouse_port() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
     app.emu
         .bus_mut()
         .input
@@ -454,9 +481,35 @@ fn joystick_routing_assigns_sources_by_device_and_mode() {
     app.emu
         .bus_mut()
         .input
-        .set_port_device(1, PortDevice::Analogue);
-    assert_eq!(app.joystick_routing(), (None, None));
-    assert!(!app.keyboard_joystick_enabled());
+        .set_port_device(1, PortDevice::Mouse);
+    app.joystick_input_mode = JoystickInputMode::Keyboard;
+
+    // The cursor-key mapping drives the second mouse: held directions
+    // become steady pointer motion, fire the left button, X the right.
+    app.keyboard_joy_held[0].right = true;
+    app.keyboard_joy_held[0].fire_right_ctrl = true;
+    app.keyboard_joy_held[0].blue = true;
+    app.pump_joystick_input();
+    assert_eq!(
+        app.emu.bus().input.ports[1].counter_x,
+        super::KEYBOARD_MOUSE_COUNTS_PER_QUANTUM as u8
+    );
+    assert!(app.emu.bus().input.ports[1].fire, "fire keys = left button");
+    assert!(app.emu.bus().input.ports[1].button2, "X = right button");
+    assert_eq!(
+        app.emu.bus().input.device(1),
+        PortDevice::Mouse,
+        "stays a mouse"
+    );
+    // The host-mouse port is untouched.
+    assert_eq!(app.emu.bus().input.ports[0].counter_x, 0);
+    assert!(!app.emu.bus().input.ports[0].fire);
+
+    // Releasing the keys releases the buttons on the next pump.
+    app.keyboard_joy_held[0] = KeyboardJoystickHeld::default();
+    app.pump_joystick_input();
+    assert!(!app.emu.bus().input.ports[1].fire);
+    assert!(!app.emu.bus().input.ports[1].button2);
 }
 
 #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -9,9 +9,9 @@ use super::{
     bar_layout, center_present_frame_for_visible_start, center_present_frame_horizontally,
     control_at, copperline_icon_image, copperline_logo_image, copy_present_frame,
     copy_window_present_frame, draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect,
-    host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_mode_uses_keyboard,
-    joystick_toggle_rect, keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv,
-    paint_test_screen, parse_amiga_key, pause_button_rect, power_button_rect, present_height,
+    host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_toggle_rect,
+    keyboard_joystick_key_for, led_row_rect, mask_present_frame_to_tv, paint_test_screen,
+    parse_amiga_key, pause_button_rect, power_button_rect, present_height,
     presentation_h_shift_for, presentation_source_y_offset, raw_device_qualifier_family_held,
     raw_device_qualifier_rawkey, rawkey_is_held, rawkey_transition_is_duplicate,
     reboot_button_rect, repeated_main_key_should_drop, rgba, shot_button_rect,
@@ -383,8 +383,7 @@ fn keyboard_joystick_fire_aliases_release_independently() {
 #[test]
 fn joystick_input_mode_toggles_between_two_explicit_modes() {
     // The toggle flips directly between the two modes; there is no hidden
-    // auto-detect state, so the keyboard mapping is engaged exactly when
-    // (and only when) the mode is Keyboard.
+    // auto-detect state.
     assert_eq!(
         JoystickInputMode::Gamepad.next(),
         JoystickInputMode::Keyboard
@@ -393,9 +392,133 @@ fn joystick_input_mode_toggles_between_two_explicit_modes() {
         JoystickInputMode::Keyboard.next(),
         JoystickInputMode::Gamepad
     );
+}
 
-    assert!(joystick_mode_uses_keyboard(JoystickInputMode::Keyboard));
-    assert!(!joystick_mode_uses_keyboard(JoystickInputMode::Gamepad));
+#[test]
+fn joystick_routing_assigns_sources_by_device_and_mode() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
+
+    // Stock wiring (mouse + joystick): the mode picks the single source
+    // for port 2 (index 1); the keyboard mapping is engaged exactly when
+    // (and only when) some port routes to it.
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Mouse);
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, PortDevice::Joystick);
+    app.joystick_input_mode = JoystickInputMode::Gamepad;
+    assert_eq!(app.joystick_routing(), (Some(1), None));
+    assert!(!app.keyboard_joystick_enabled());
+    app.joystick_input_mode = JoystickInputMode::Keyboard;
+    assert_eq!(app.joystick_routing(), (None, Some(1)));
+    assert!(app.keyboard_joystick_enabled());
+
+    // Swapped wiring: the joystick port follows the device, wherever it is.
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Cd32Pad);
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, PortDevice::Mouse);
+    app.joystick_input_mode = JoystickInputMode::Gamepad;
+    assert_eq!(app.joystick_routing(), (Some(0), None));
+    assert_eq!(app.mouse_port(), Some(1));
+
+    // Two joysticks (two-player): both sources drive a port each; the
+    // mode picks which gets the lower-numbered one.
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Joystick);
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, PortDevice::Joystick);
+    assert_eq!(app.joystick_routing(), (Some(0), Some(1)));
+    app.joystick_input_mode = JoystickInputMode::Keyboard;
+    assert_eq!(app.joystick_routing(), (Some(1), Some(0)));
+    assert_eq!(app.mouse_port(), None, "no mouse port in a two-stick setup");
+
+    // No joystick anywhere: neither source drives a port and the keyboard
+    // passes through to the Amiga.
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Mouse);
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, PortDevice::Analogue);
+    assert_eq!(app.joystick_routing(), (None, None));
+    assert!(!app.keyboard_joystick_enabled());
+}
+
+#[test]
+fn hot_plug_drops_scripted_joy_ownership_so_the_new_device_sticks() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
+    // A --joy-after event has fired and released: the scripted state owns
+    // the port until something changes.
+    app.auto_joy_engaged[1] = true;
+    app.auto_joy_held[1] = super::AutoJoyHeld::default();
+
+    // Hot-plugging a mouse must drop that ownership; otherwise the next
+    // input pump would re-assert the scripted state and set_joystick
+    // would flip the device straight back to Joystick.
+    app.hot_plug_port_device(1, PortDevice::Mouse);
+    assert!(!app.auto_joy_engaged[1]);
+    app.pump_joystick_input();
+    assert_eq!(app.emu.bus().input.device(1), PortDevice::Mouse);
+}
+
+#[test]
+fn mouse_capture_is_refused_with_no_mouse_on_either_port() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Joystick);
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, PortDevice::Joystick);
+    assert_eq!(app.mouse_port(), None);
+    app.toggle_mouse_capture();
+    assert!(!app.mouse_captured, "nothing to capture for");
+}
+
+#[test]
+fn cycle_port_device_hot_plugs_and_releases_held_lines() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, PortDevice::Joystick);
+    app.emu
+        .bus_mut()
+        .input
+        .set_joystick(1, true, false, false, false, true, false);
+
+    // Joystick -> Cd32Pad -> Analogue -> None -> Mouse, releasing the
+    // held fire/direction lines at the first swap.
+    app.cycle_port_device(1);
+    assert_eq!(app.emu.bus().input.device(1), PortDevice::Cd32Pad);
+    assert!(!app.emu.bus().input.ports[1].fire, "hot-plug released fire");
+    assert!(!app.emu.bus().input.ports[1].up);
+    app.cycle_port_device(1);
+    assert_eq!(app.emu.bus().input.device(1), PortDevice::Analogue);
+    app.cycle_port_device(1);
+    assert_eq!(app.emu.bus().input.device(1), PortDevice::None);
+    app.cycle_port_device(1);
+    assert_eq!(app.emu.bus().input.device(1), PortDevice::Mouse);
 }
 
 #[test]
@@ -1635,7 +1758,14 @@ fn pixel(frame: &[u8], x: usize, y: usize, scale: usize) -> [u8; 4] {
 /// debugger window's actions and view builders run against the real
 /// emulator without a host window.
 fn test_app() -> super::App {
-    test_app_with_audio(Box::new(NullSink))
+    let mut app = test_app_with_audio(Box::new(NullSink));
+    // The stock wiring the config layer applies on a real machine: mouse
+    // in port 1, joystick in port 2.
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(1, crate::bus::PortDevice::Joystick);
+    app
 }
 
 fn test_app_with_audio(audio: Box<dyn AudioSink>) -> super::App {
@@ -1686,6 +1816,7 @@ fn test_app_with_audio(audio: Box<dyn AudioSink>) -> super::App {
         None,
         None,
         None,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
         Vec::new(),


### PR DESCRIPTION
## Summary

A real Amiga accepts a mouse, digital joystick, CD32 pad, or analogue controller in either game port; Copperline hardwired mouse=port 1 and joystick/CD32 pad=port 2 across every layer. This models the ports as pluggable devices end to end.

### Core
- `InputState` becomes `ports: [ControllerPort; 2]` carrying a `PortDevice` (`mouse`/`joystick`/`cd32`/`analogue`/`none`) plus every line a controller can drive. The JOYxDAT counters are chip-side, so they survive device swaps and JOYTEST loads them whatever is plugged in. `STATE_VERSION` 31.
- The CD32 pad serial protocol works on both ports: POT0X mode select (POTGO bits 9/8), /FIR0 clock, POT0Y data mirror the port-2 wiring, with an independent shifter per port.
- An analogue device presents pot resistances as the exact inverse of the RC comparator threshold (position N latches POTxDAT count N), paddle buttons on the left/right lines per the HRM, pots seeded centred on plug-in. POT0DAT/POT1DAT join the debugger's side-effect-free latch view.
- Machine resets (keyboard chord, CPU RESET, cold boot) keep the plugged devices and analogue knob positions; the driven lines release and the chip counters clear.

### Surface
- `[input] port1/port2` + `--port1`/`--port2` (stock wiring by default; the CD32 profile supplies its bundled pad, subsuming the `cd32_pad` bool).
- Scripted input takes an optional trailing PORT token (`joy-after SECS BTN MS [PORT]`) plus a new `pot-after SECS X Y [PORT]`; omitted, every flag keeps its traditional port, so existing scripts, recordings, TOMLs, and CCP clients are unchanged.
- The recorder diffs each port by its device, emitting port tokens only when non-default: default-wiring sessions record byte-identically, other wirings note a `# ports:` header.
- CCP: `input.mouse`/`input.joy` gain an optional `port`, plus `input.analogue`, `input.set_port` (hot-plug), `input.get_ports`.
- Host routing: the mouse drives the lowest-numbered mouse port; with joysticks in both ports the gamepad and keyboard mapping drive one each (two-player), the input mode picking which gets the lower port. The launcher gains an Input tab; the runtime menu hot-plugs devices per port, clearing stale scripted joy ownership.
- Gamepad-analogue-stick-to-pot mapping is deferred (needs a gamepads.toml calibration schema extension); analogue is script/CCP/config-driven for now, noted in the docs.

## Verification

All headless against AmigaTestKit 1.21 (F4 controller-port test), plus `cargo test` (1640 tests), `clippy`, `fmt`, and the golden-probe suite in release:

- **Defaults regression**: the F4 screenshot is byte-identical to the pre-change render.
- **Swapped wiring** (`--port1 joystick --port2 mouse`): port-tagged input lands on each port's view.
- **CD32 pad in port 1**: ATK reports *Pad Detected* with exactly the held buttons (red, green, rewind) lit; a mouse in a port correctly reads *Pad Not Detected*.
- **Analogue**: ATK's Analog view actively strobes POTGO and reads back `--pot-after 50 200` as literally (50,200), min/max tracing the sweep from the centre seed.
- **Reset survival**: input keeps driving a swapped port across a scripted Ctrl-Amiga-Amiga reset.
- **Recorder round-trip**: a recorded swapped-wiring session replays to a byte-identical screenshot.