### PR TITLE
RTG: Emulate the Z3660 video board

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -211,8 +211,9 @@ slow = "512K"
 
 
 # RTG graphics card: high-resolution, high-colour screens via Picasso96.
+# Fitted by default on machines with Zorro III (A3000/A4000).
 # [rtg]
-# card = "z3660"           # or "none" (default)
+# card = "z3660"           # or "none"
 
 
 # SCSI bus with up to seven drives, on any machine model. Preferred over [ide]

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -210,6 +210,14 @@ slow = "512K"
 # net = "nat"
 
 
+# Z3660 RTG board (bring-up stub): autoconfigs the Z3660 accelerator's RTG
+# core (manufacturer 0x144B, product 1, 128 MB Zorro III window) so the
+# open-source Z3660.card Picasso96 driver finds it. Register accesses are
+# logged; there is no display output yet.
+# [z3660]
+# enabled = true
+
+
 # SCSI bus with up to seven drives, on any machine model. Preferred over [ide]
 # for multiple disks: a Zorro board's own boot ROM carries scsi.device and
 # autoboots on Kickstart 1.3+, so it does not depend on the Kickstart IDE

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -210,12 +210,9 @@ slow = "512K"
 # net = "nat"
 
 
-# Z3660 RTG board: autoconfigs the Z3660 accelerator's RTG core
-# (manufacturer 0x144B, product 1, 128 MB Zorro III window) for the
-# open-source Z3660.card Picasso96 driver. RTG screens display (all pixel
-# formats, core blitter ops, hardware mouse sprite); planar blits, line
-# draws, and surface ops are not implemented yet. Register accesses are
-# logged by name.
+# Z3660 RTG graphics board: adds high-resolution, high-colour (RTG)
+# screens, driven by the open-source Z3660.card Picasso96 driver in the
+# guest.
 # [z3660]
 # enabled = true
 

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -210,11 +210,9 @@ slow = "512K"
 # net = "nat"
 
 
-# Z3660 RTG graphics board: adds high-resolution, high-colour (RTG)
-# screens, driven by the open-source Z3660.card Picasso96 driver in the
-# guest.
-# [z3660]
-# enabled = true
+# RTG graphics card: high-resolution, high-colour screens via Picasso96.
+# [rtg]
+# card = "z3660"           # or "none" (default)
 
 
 # SCSI bus with up to seven drives, on any machine model. Preferred over [ide]

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -210,10 +210,12 @@ slow = "512K"
 # net = "nat"
 
 
-# Z3660 RTG board (bring-up stub): autoconfigs the Z3660 accelerator's RTG
-# core (manufacturer 0x144B, product 1, 128 MB Zorro III window) so the
-# open-source Z3660.card Picasso96 driver finds it. Register accesses are
-# logged; there is no display output yet.
+# Z3660 RTG board: autoconfigs the Z3660 accelerator's RTG core
+# (manufacturer 0x144B, product 1, 128 MB Zorro III window) for the
+# open-source Z3660.card Picasso96 driver. RTG screens display (all pixel
+# formats, core blitter ops, hardware mouse sprite); planar blits, line
+# draws, and surface ops are not implemented yet. Register accesses are
+# logged by name.
 # [z3660]
 # enabled = true
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -895,26 +895,24 @@ schedule, not the emulated clock, so a NIC board breaks byte-identical
 replay and save-state determinism while traffic flows. See [](../zorro)
 for the board details and the NAT's limitations.
 
-## `[z3660]` -- RTG board stub
+## `[z3660]` -- RTG board
 
 ```toml
 [z3660]
 enabled = true
 ```
 
-Fits the Z3660 accelerator's RTG core on the Zorro chain: a 128 MB
-Zorro III autoconfig board (manufacturer 0x144B, product 1) with the
-register file and VRAM layout the open-source Z3660.card Picasso96 driver
-expects. A Picasso96 install with the Z3660 monitor drives real RTG
-screens: the display switches between the native chipset and the board's
-framebuffer (all four pixel formats), the core blitter ops and the
-hardware mouse sprite are implemented, and every register access and
-mailbox op is logged by name for driver development. Not yet implemented:
-planar-to-chunky/direct blits, line draws, and the surface ops -- software
-using only those renders incompletely. Note that the monitor's stock
-`DISPLAYCHAIN=NO` tooltype models the real board's dual-display setup and
-never switches back to the native screen; set `DISPLAYCHAIN=YES` for a
-single-window emulator.
+Fits a Z3660 RTG graphics board on the Zorro chain, giving the guest
+high-resolution, high-colour screens through Picasso96. It needs the
+open-source Z3660.card driver installed in the guest (with its monitor in
+`DEVS:Monitors`); with that in place, Z3660 screen modes appear in
+ScreenMode, and the window shows the board's output when a screen is
+opened, switching back to the native Amiga display when it closes.
+
+The board's stock monitor ships with the `DISPLAYCHAIN=NO` tooltype, which
+models the real hardware's separate RTG monitor and never hands the display
+back to the native screen. On a single-window emulator you usually want
+`DISPLAYCHAIN=YES`, so the one window follows whichever screen is active.
 
 ## `[debug]` -- diagnostics
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -905,10 +905,16 @@ enabled = true
 Fits the Z3660 accelerator's RTG core on the Zorro chain: a 128 MB
 Zorro III autoconfig board (manufacturer 0x144B, product 1) with the
 register file and VRAM layout the open-source Z3660.card Picasso96 driver
-expects. This is a bring-up stub for driver development: the driver's
-FindCard probe succeeds and every register access is logged with the
-register's name, but register semantics are not implemented and nothing is
-displayed yet.
+expects. A Picasso96 install with the Z3660 monitor drives real RTG
+screens: the display switches between the native chipset and the board's
+framebuffer (all four pixel formats), the core blitter ops and the
+hardware mouse sprite are implemented, and every register access and
+mailbox op is logged by name for driver development. Not yet implemented:
+planar-to-chunky/direct blits, line draws, and the surface ops -- software
+using only those renders incompletely. Note that the monitor's stock
+`DISPLAYCHAIN=NO` tooltype models the real board's dual-display setup and
+never switches back to the native screen; set `DISPLAYCHAIN=YES` for a
+single-window emulator.
 
 ## `[debug]` -- diagnostics
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -895,15 +895,16 @@ schedule, not the emulated clock, so a NIC board breaks byte-identical
 replay and save-state determinism while traffic flows. See [](../zorro)
 for the board details and the NAT's limitations.
 
-## `[z3660]` -- RTG board
+## `[rtg]` -- RTG graphics card
 
 ```toml
-[z3660]
-enabled = true
+[rtg]
+card = "z3660"
 ```
 
-Fits a Z3660 RTG graphics board on the Zorro chain, giving the guest
-high-resolution, high-colour screens through Picasso96. It needs the
+`card` is `"z3660"` or `"none"` (the default); a machine takes at most one.
+The Z3660 fits on the Zorro chain, giving the guest high-resolution,
+high-colour screens through Picasso96. It needs the
 open-source Z3660.card driver installed in the guest (with its monitor in
 `DEVS:Monitors`); with that in place, Z3660 screen modes appear in
 ScreenMode, and the window shows the board's output when a screen is

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -902,8 +902,11 @@ for the board details and the NAT's limitations.
 card = "z3660"
 ```
 
-`card` is `"z3660"` or `"none"` (the default); a machine takes at most one.
-The Z3660 fits on the Zorro chain, giving the guest high-resolution,
+`card` is `"z3660"` or `"none"`; a machine takes at most one. The Z3660 is a
+Zorro III board, so it comes fitted by default on machines whose CPU has a
+32-bit address bus (the A3000 and A4000) and is unavailable on the rest --
+asking for it there is an error, as it is for Zorro III RAM. It gives the
+guest high-resolution,
 high-colour screens through Picasso96. It needs the
 open-source Z3660.card driver installed in the guest (with its monitor in
 `DEVS:Monitors`); with that in place, Z3660 screen modes appear in

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -895,6 +895,21 @@ schedule, not the emulated clock, so a NIC board breaks byte-identical
 replay and save-state determinism while traffic flows. See [](../zorro)
 for the board details and the NAT's limitations.
 
+## `[z3660]` -- RTG board stub
+
+```toml
+[z3660]
+enabled = true
+```
+
+Fits the Z3660 accelerator's RTG core on the Zorro chain: a 128 MB
+Zorro III autoconfig board (manufacturer 0x144B, product 1) with the
+register file and VRAM layout the open-source Z3660.card Picasso96 driver
+expects. This is a bring-up stub for driver development: the driver's
+FindCard probe succeeds and every register access is logged with the
+register's name, but register semantics are not implemented and nothing is
+displayed yet.
+
 ## `[debug]` -- diagnostics
 
 ```toml

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3168,6 +3168,25 @@ impl Bus {
             })
     }
 
+    /// Whether an RTG board is driving the display (native chipset output
+    /// is presented otherwise). Cheap; safe to poll every frame.
+    pub fn rtg_active(&self) -> bool {
+        self.devices.iter().any(|d| match d {
+            crate::zorro_device::BoardDevice::Z3660(z) => z.rtg_active(),
+            _ => false,
+        })
+    }
+
+    /// Compose the active RTG board frame (Z3660 scanout) into `out` as
+    /// presentation pixels, returning its dimensions; `None` while no RTG
+    /// board is driving the display (native chipset output shown).
+    pub fn rtg_frame(&self, out: &mut Vec<u32>) -> Option<(u32, u32)> {
+        self.devices.iter().find_map(|d| match d {
+            crate::zorro_device::BoardDevice::Z3660(z) => z.rtg_frame(out),
+            _ => None,
+        })
+    }
+
     /// Whether a disc is mounted (or waiting in the tray).
     pub fn cd_disc_inserted(&self) -> bool {
         self.cdtv.as_ref().is_some_and(|cdtv| cdtv.has_disc())

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,8 +156,8 @@ pub struct Config {
     pub a2065_net: Option<crate::net::NetConfig>,
     /// Z3660 RTG board (`[z3660] enabled`): when true, the Z3660
     /// accelerator's RTG core autoconfigs on the Zorro chain for the
-    /// open-source Z3660.card Picasso96 driver. Bring-up stub: registers
-    /// are logged, no display output yet.
+    /// open-source Z3660.card Picasso96 driver, presenting RTG screens
+    /// (all pixel formats, core blitter ops, hardware mouse sprite).
     pub z3660: bool,
     pub floppy: FloppyConfig,
     /// Which floppy drive slots are electrically present. DF0 is the
@@ -1754,11 +1754,11 @@ pub(crate) struct RawA2065 {
     pub(crate) net: Option<String>,
 }
 
-/// `[z3660]` RTG board stub: the Z3660's FPGA RTG core on the Zorro chain.
+/// `[z3660]` RTG board: the Z3660's FPGA RTG core on the Zorro chain.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawZ3660 {
-    /// Fit the board. Bring-up stub: registers are logged, no display yet.
+    /// Fit the board (drives Picasso96 RTG screens via the Z3660.card driver).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) enabled: Option<bool>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2312,7 +2312,7 @@ impl TryFrom<RawConfig> for Config {
             },
         };
         let rtg = match raw.rtg.card.as_deref() {
-            None => RtgCard::None,
+            None => defaults.rtg,
             Some(raw_card) => match raw_card.trim().to_ascii_lowercase().as_str() {
                 "none" => RtgCard::None,
                 "z3660" => RtgCard::Z3660,
@@ -2425,6 +2425,7 @@ impl TryFrom<RawConfig> for Config {
         errors.extend(validate_fast_ram(fast_ram_bytes, chip_ram_bytes).err());
         errors.extend(validate_slow_ram(slow_ram_bytes).err());
         errors.extend(validate_z3_ram(z3_ram_bytes, cpu).err());
+        errors.extend(validate_rtg_card(rtg, cpu).err());
         let board_specs = zorro_boards
             .iter()
             .chain(wasm_boards.iter().map(|w| &w.spec));
@@ -2906,6 +2907,14 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.port_devices[1] = PortDevice::Cd32Pad;
         }
     }
+    // An RTG card comes fitted wherever the machine can host one, so RTG
+    // needs no config step beyond installing the guest driver. The Z3660 is
+    // a Zorro III board, so the gate is the same one Zorro III RAM uses: a
+    // CPU with a 32-bit address bus. That is the A3000 and A4000 today, and
+    // any future profile that qualifies, without a model list to maintain.
+    if cpu_has_32bit_bus(d.cpu) {
+        d.rtg = RtgCard::Z3660;
+    }
     d
 }
 
@@ -3081,6 +3090,18 @@ fn cpu_has_32bit_bus(cpu: CpuModel) -> bool {
         cpu,
         CpuModel::M68020 | CpuModel::M68030 | CpuModel::M68040 | CpuModel::M68060
     )
+}
+
+fn validate_rtg_card(rtg: RtgCard, cpu: CpuModel) -> Result<()> {
+    if rtg == RtgCard::Z3660 && !cpu_has_32bit_bus(cpu) {
+        bail!(
+            "[rtg] card = \"z3660\" is a Zorro III board and needs a CPU \
+             with a 32-bit address bus (68020/68030/68040/68060); {:?} has \
+             a 24-bit bus",
+            cpu
+        );
+    }
+    Ok(())
 }
 
 fn validate_z3_ram(z3: usize, cpu: CpuModel) -> Result<()> {
@@ -5210,18 +5231,53 @@ mod tests {
 
     #[test]
     fn rtg_card_selects_the_board() -> Result<()> {
+        // The board is Zorro III, so these need a 32-bit-bus CPU.
+        let with_cpu = |rtg: &str| format!("[cpu]\nmodel = \"68030\"\n{rtg}");
         assert_eq!(
-            parse_config("[rtg]\ncard = \"z3660\"\n")?.rtg,
+            parse_config(&with_cpu("[rtg]\ncard = \"z3660\"\n"))?.rtg,
             RtgCard::Z3660
         );
         // Spelling and spacing are forgiving, as for [scsi] controller.
         assert_eq!(
-            parse_config("[rtg]\ncard = \" Z3660 \"\n")?.rtg,
+            parse_config(&with_cpu("[rtg]\ncard = \" Z3660 \"\n"))?.rtg,
             RtgCard::Z3660
         );
-        assert_eq!(parse_config("[rtg]\ncard = \"none\"\n")?.rtg, RtgCard::None);
-        // Absent section: no RTG board, chipset drives the display.
+        assert_eq!(
+            parse_config(&with_cpu("[rtg]\ncard = \"none\"\n"))?.rtg,
+            RtgCard::None
+        );
+        // A bare config is a 68000 machine, which cannot host a Zorro III
+        // board, so nothing is fitted.
         assert_eq!(parse_config("")?.rtg, RtgCard::None);
+        Ok(())
+    }
+
+    /// A machine that can host a Zorro III board gets one fitted by default,
+    /// so RTG needs no config beyond the guest driver. The gate is the CPU's
+    /// address bus, the same one Zorro III RAM uses, not a model list.
+    #[test]
+    fn rtg_card_defaults_to_the_machine_capability() -> Result<()> {
+        assert_eq!(
+            parse_config("[machine]\nprofile = \"A4000\"\n")?.rtg,
+            RtgCard::Z3660
+        );
+        assert_eq!(
+            parse_config("[machine]\nprofile = \"A3000\"\n")?.rtg,
+            RtgCard::Z3660
+        );
+        // 68EC020: 24-bit bus, so no Zorro III and no card.
+        assert_eq!(
+            parse_config("[machine]\nprofile = \"A1200\"\n")?.rtg,
+            RtgCard::None
+        );
+        assert_eq!(
+            parse_config("[machine]\nprofile = \"A500\"\n")?.rtg,
+            RtgCard::None
+        );
+        // Asking anyway is an error rather than a board the CPU cannot reach.
+        let err =
+            parse_config("[machine]\nprofile = \"A500\"\n[rtg]\ncard = \"z3660\"\n").unwrap_err();
+        assert!(err.to_string().contains("32-bit address bus"), "{err:#}");
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,6 +154,11 @@ pub struct Config {
     /// the Zorro chain using the named host network backend. Networking is
     /// non-deterministic, so a fitted A2065 breaks byte-identical replay.
     pub a2065_net: Option<crate::net::NetConfig>,
+    /// Z3660 RTG board (`[z3660] enabled`): when true, the Z3660
+    /// accelerator's RTG core autoconfigs on the Zorro chain for the
+    /// open-source Z3660.card Picasso96 driver. Bring-up stub: registers
+    /// are logged, no display output yet.
+    pub z3660: bool,
     pub floppy: FloppyConfig,
     /// Which floppy drive slots are electrically present. DF0 is the
     /// internal drive and is always present; DF1-DF3 are external drives
@@ -1098,6 +1103,7 @@ impl Default for Config {
             ide: IdeConfig::default(),
             scsi: ScsiConfig::default(),
             a2065_net: None,
+            z3660: false,
             floppy: FloppyConfig::default(),
             floppy_connected: [true, false, false, false],
             floppy_playlists: std::array::from_fn(|_| Vec::new()),
@@ -1473,6 +1479,8 @@ pub struct RawConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) a2065: RawA2065,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) z3660: RawZ3660,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) floppy: RawFloppy,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) display: RawDisplay,
@@ -1744,6 +1752,15 @@ pub(crate) struct RawA2065 {
     /// isolated NIC. Absent means no A2065 board is fitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) net: Option<String>,
+}
+
+/// `[z3660]` RTG board stub: the Z3660's FPGA RTG core on the Zorro chain.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawZ3660 {
+    /// Fit the board. Bring-up stub: registers are logged, no display yet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) enabled: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2537,6 +2554,7 @@ impl TryFrom<RawConfig> for Config {
             ide,
             scsi,
             a2065_net,
+            z3660: raw.z3660.enabled.unwrap_or(false),
             floppy,
             floppy_connected,
             floppy_playlists,

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,11 +154,10 @@ pub struct Config {
     /// the Zorro chain using the named host network backend. Networking is
     /// non-deterministic, so a fitted A2065 breaks byte-identical replay.
     pub a2065_net: Option<crate::net::NetConfig>,
-    /// Z3660 RTG board (`[z3660] enabled`): when true, the Z3660
-    /// accelerator's RTG core autoconfigs on the Zorro chain for the
-    /// open-source Z3660.card Picasso96 driver, presenting RTG screens
-    /// (all pixel formats, core blitter ops, hardware mouse sprite).
-    pub z3660: bool,
+    /// RTG graphics card (`[rtg] card`): when set, the card autoconfigs on
+    /// the Zorro chain and presents RTG screens (all pixel formats, core
+    /// blitter ops, hardware mouse sprite) to its Picasso96 driver.
+    pub rtg: RtgCard,
     pub floppy: FloppyConfig,
     /// Which floppy drive slots are electrically present. DF0 is the
     /// internal drive and is always present; DF1-DF3 are external drives
@@ -418,6 +417,19 @@ pub fn is_cd_image_path(path: &std::path::Path) -> bool {
 pub struct IdeConfig {
     pub master: Option<DriveImage>,
     pub slave: Option<DriveImage>,
+}
+
+/// Which RTG graphics card the `[rtg]` section fits. A machine has at most
+/// one: RTG screens come from whichever card the P96 driver finds, so a
+/// second board would only compete for the display.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RtgCard {
+    /// No RTG board; the chipset drives the display. The default.
+    #[default]
+    None,
+    /// The Z3660 accelerator's FPGA RTG core, driven by the open-source
+    /// Z3660.card Picasso96 driver.
+    Z3660,
 }
 
 /// Which SCSI host adapter the `[scsi]` section fits: one of the two Zorro
@@ -1103,7 +1115,7 @@ impl Default for Config {
             ide: IdeConfig::default(),
             scsi: ScsiConfig::default(),
             a2065_net: None,
-            z3660: false,
+            rtg: RtgCard::None,
             floppy: FloppyConfig::default(),
             floppy_connected: [true, false, false, false],
             floppy_playlists: std::array::from_fn(|_| Vec::new()),
@@ -1479,7 +1491,7 @@ pub struct RawConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) a2065: RawA2065,
     #[serde(default, skip_serializing_if = "is_default")]
-    pub(crate) z3660: RawZ3660,
+    pub(crate) rtg: RawRtg,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) floppy: RawFloppy,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -1754,13 +1766,14 @@ pub(crate) struct RawA2065 {
     pub(crate) net: Option<String>,
 }
 
-/// `[z3660]` RTG board: the Z3660's FPGA RTG core on the Zorro chain.
+/// `[rtg]` graphics card: an RTG board on the Zorro chain.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct RawZ3660 {
-    /// Fit the board (drives Picasso96 RTG screens via the Z3660.card driver).
+pub(crate) struct RawRtg {
+    /// Card to fit: "z3660" (the Z3660's FPGA RTG core, driven by
+    /// Z3660.card) or "none" (the default).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) enabled: Option<bool>,
+    pub(crate) card: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2298,6 +2311,21 @@ impl TryFrom<RawConfig> for Config {
                 }
             },
         };
+        let rtg = match raw.rtg.card.as_deref() {
+            None => RtgCard::None,
+            Some(raw_card) => match raw_card.trim().to_ascii_lowercase().as_str() {
+                "none" => RtgCard::None,
+                "z3660" => RtgCard::Z3660,
+                _ => {
+                    errors.push(anyhow!(
+                        "[rtg] card = {raw_card:?} is not known \
+                         (expected \"z3660\" or \"none\")"
+                    ));
+                    RtgCard::None
+                }
+            },
+        };
+
         let scsi = ScsiConfig {
             controller: scsi_controller,
             rom: raw.scsi.rom.map(PathBuf::from),
@@ -2554,7 +2582,7 @@ impl TryFrom<RawConfig> for Config {
             ide,
             scsi,
             a2065_net,
-            z3660: raw.z3660.enabled.unwrap_or(false),
+            rtg,
             floppy,
             floppy_connected,
             floppy_playlists,
@@ -5178,6 +5206,29 @@ mod tests {
         let err = parse_config("[floppy]\ndrives = 0").unwrap_err();
         assert!(err.to_string().contains("between 1 and 4"), "{err:#}");
         Ok(())
+    }
+
+    #[test]
+    fn rtg_card_selects_the_board() -> Result<()> {
+        assert_eq!(
+            parse_config("[rtg]\ncard = \"z3660\"\n")?.rtg,
+            RtgCard::Z3660
+        );
+        // Spelling and spacing are forgiving, as for [scsi] controller.
+        assert_eq!(
+            parse_config("[rtg]\ncard = \" Z3660 \"\n")?.rtg,
+            RtgCard::Z3660
+        );
+        assert_eq!(parse_config("[rtg]\ncard = \"none\"\n")?.rtg, RtgCard::None);
+        // Absent section: no RTG board, chipset drives the display.
+        assert_eq!(parse_config("")?.rtg, RtgCard::None);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_rtg_card_fails_cleanly() {
+        let err = parse_config("[rtg]\ncard = \"picasso4\"\n").unwrap_err();
+        assert!(err.to_string().contains("is not known"), "{err:#}");
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1718,7 +1718,7 @@ fn render_frame(emu: &Emulator) -> (Vec<u32>, usize) {
     // exactly as the window presentation does.
     let mut fb = Vec::new();
     let mut scratch = Vec::new();
-    if let Some(rows) =
+    if let Some((rows, _, _)) =
         crate::video::present_common::compose_rtg_present(emu.bus(), &mut scratch, &mut fb)
     {
         return (fb, rows);

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1714,7 +1714,16 @@ fn wave_status_value(status: &crate::waveform::WaveStatus) -> Value {
 /// `capture.digest` and `capture.screenshot` use this in BOTH server
 /// modes, so captures are mode-identical and comparable.
 fn render_frame(emu: &Emulator) -> (Vec<u32>, usize) {
-    let mut fb = vec![0u32; MAX_FB_PIXELS];
+    // An RTG board driving the display supersedes the chipset output,
+    // exactly as the window presentation does.
+    let mut fb = Vec::new();
+    let mut scratch = Vec::new();
+    if let Some(rows) =
+        crate::video::present_common::compose_rtg_present(emu.bus(), &mut scratch, &mut fb)
+    {
+        return (fb, rows);
+    }
+    fb = vec![0u32; MAX_FB_PIXELS];
     crate::video::bitplane::render_display_only(emu.bus(), &mut fb);
     let lines = emu.bus().frame_geometry().visible_lines;
     (fb, lines)

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1922,9 +1922,9 @@ pub fn build_machine(
             crate::a2065::A2065::new(net_config),
         ));
     }
-    // Z3660 RTG board (`[z3660]`): the Z3660.card P96 driver drives RTG
-    // screens through its register file and framebuffer; see crate::z3660.
-    if cfg.z3660 {
+    // RTG board (`[rtg] card`): the Z3660.card P96 driver drives RTG screens
+    // through its register file and framebuffer; see crate::z3660.
+    if cfg.rtg == crate::config::RtgCard::Z3660 {
         let slot = devices.len();
         zorro.add_board(crate::zorro::BoardSpec::z3660(slot))?;
         info!("z3660: RTG board on the Zorro chain (slot {slot})");

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1922,6 +1922,16 @@ pub fn build_machine(
             crate::a2065::A2065::new(net_config),
         ));
     }
+    // Z3660 RTG board stub (`[z3660]`): autoconfig identity and logged
+    // registers for the Z3660.card P96 driver; see crate::z3660.
+    if cfg.z3660 {
+        let slot = devices.len();
+        zorro.add_board(crate::zorro::BoardSpec::z3660(slot))?;
+        info!("z3660: RTG board stub on the Zorro chain (slot {slot})");
+        devices.push(crate::zorro_device::BoardDevice::Z3660(
+            crate::z3660::Z3660::new(),
+        ));
+    }
     // The A1000 has no Kickstart ROM: cfg.rom_path is its 64 KiB bootstrap
     // ROM, and a 256 KiB WCS is allocated for it to load Kickstart into from
     // the Kickstart disk in DF0.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1922,12 +1922,12 @@ pub fn build_machine(
             crate::a2065::A2065::new(net_config),
         ));
     }
-    // Z3660 RTG board stub (`[z3660]`): autoconfig identity and logged
-    // registers for the Z3660.card P96 driver; see crate::z3660.
+    // Z3660 RTG board (`[z3660]`): the Z3660.card P96 driver drives RTG
+    // screens through its register file and framebuffer; see crate::z3660.
     if cfg.z3660 {
         let slot = devices.len();
         zorro.add_board(crate::zorro::BoardSpec::z3660(slot))?;
-        info!("z3660: RTG board stub on the Zorro chain (slot {slot})");
+        info!("z3660: RTG board on the Zorro chain (slot {slot})");
         devices.push(crate::zorro_device::BoardDevice::Z3660(
             crate::z3660::Z3660::new(),
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,5 +70,6 @@ pub mod wasm_manifest;
 #[cfg(feature = "wasm-boards")]
 pub mod wasmboard;
 pub mod waveform;
+pub mod z3660;
 pub mod zorro;
 pub mod zorro_device;

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -114,7 +114,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  33: A2065 gained the latched init-block MODE word (DTX/DRX/LOOP gating
 //      of the LANCE engines) and NetConfig the Nat variant (userspace NAT
 //      backend)
-pub const STATE_VERSION: u32 = 33;
+//  34: the Z3660 RTG board was appended to the BoardDevice enum; a state
+//      holding one cannot be read by a build without the variant, so the
+//      shape change bumps the version
+pub const STATE_VERSION: u32 = 34;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2818,25 +2818,31 @@ mod tests {
 
     #[test]
     fn rtg_card_round_trips_through_raw() {
+        // An A4000 hosts Zorro III, so it comes with the card fitted; that
+        // matches its baseline, so nothing is written for it.
         let mut s = MachineSetup::default();
-        assert_eq!(s.rtg, RtgCard::None);
-        assert_eq!(s.value_label(LauncherField::Rtg), "None");
-        s.cycle(LauncherField::Rtg, true);
+        s.select_model(Some(MachineModel::A4000));
         assert_eq!(s.rtg, RtgCard::Z3660);
         assert_eq!(s.value_label(LauncherField::Rtg), "Z3660");
-
-        // The written key must be what [rtg] card parses back, not the
-        // display label: the parse is case-forgiving but the round trip
-        // should not depend on that.
-        let raw = s.to_raw();
-        assert_eq!(raw.rtg.card.as_deref(), Some("z3660"));
-        let back = MachineSetup::from_raw(&raw).unwrap();
-        assert_eq!(back.rtg, RtgCard::Z3660);
-
-        // Back to the default, which is the baseline, so nothing is written.
-        s.cycle(LauncherField::Rtg, false);
-        assert_eq!(s.rtg, RtgCard::None);
         assert!(s.to_raw().rtg.card.is_none());
+
+        // Turning it off differs from the baseline, so it is written, and
+        // the written key is what [rtg] card parses back rather than the
+        // display label -- the parse is case-forgiving, the round trip
+        // should not lean on that.
+        s.cycle(LauncherField::Rtg, true);
+        assert_eq!(s.rtg, RtgCard::None);
+        assert_eq!(s.value_label(LauncherField::Rtg), "None");
+        let raw = s.to_raw();
+        assert_eq!(raw.rtg.card.as_deref(), Some("none"));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.rtg, RtgCard::None);
+        assert!(s.build_config().is_ok());
+
+        // A 68000 machine cannot host the board, so it has none and the row
+        // still cycles without producing an unbuildable config.
+        s.select_model(Some(MachineModel::A500));
+        assert_eq!(s.rtg, RtgCard::None);
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -25,7 +25,7 @@ use crate::chipset::denise::DeniseRevision;
 use crate::config::{
     format_size, machine_profile_defaults, ChannelMode, Chipset, Config, CpuModel,
     JoystickInputMode, MachineModel, Overscan, PacingBudget, ParallelDevice, PixelAspect,
-    RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, ScsiController,
+    RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, RtgCard, ScsiController,
     SerialMode, WarpSpeed,
 };
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
@@ -237,6 +237,7 @@ pub enum LauncherField {
     Video,
     Rtc,
     Identify,
+    Rtg,
     // CPU
     Cpu,
     Fpu,
@@ -423,13 +424,14 @@ use RowKind::{Cycle, Drive, Toggle};
 // `std::path::Path` import.
 use RowKind::Path as PathRow;
 
-const SYSTEM_ROWS: [Row; 6] = [
+const SYSTEM_ROWS: [Row; 7] = [
     row(F::Chipset, "Chipset", Cycle),
     row(F::Agnus, "Agnus", Cycle),
     row(F::Denise, "Denise", Cycle),
     row(F::Video, "Video", Cycle),
     row(F::Rtc, "Real-time clock", Toggle),
     row(F::Identify, "Identify board", Toggle),
+    row(F::Rtg, "RTG card", Cycle),
 ];
 const CPU_ROWS: [Row; 5] = [
     row(F::Cpu, "CPU", Cycle),
@@ -637,6 +639,7 @@ pub const MODELS: [MachineModel; 10] = [
 // --- value preset lists for the cycle/stepper controls -------------------
 
 const CHIPSETS: [Chipset; 3] = [Chipset::Ocs, Chipset::Ecs, Chipset::Aga];
+const RTG_CARDS: [RtgCard; 2] = [RtgCard::None, RtgCard::Z3660];
 const AGNUS_CHOICES: [Option<AgnusRevision>; 5] = [
     None,
     Some(AgnusRevision::Ocs),
@@ -764,6 +767,7 @@ pub struct MachineSetup {
     video: VideoStandard,
     rtc: bool,
     identify: bool,
+    rtg: RtgCard,
     // CPU
     cpu: CpuModel,
     fpu: bool,
@@ -899,6 +903,7 @@ impl MachineSetup {
             video: cfg.video_standard,
             rtc: cfg.rtc_present,
             identify: cfg.identify_board,
+            rtg: cfg.rtg,
             cpu: cfg.cpu,
             fpu: cfg.fpu,
             clock_mhz: cfg.cpu_clock_mhz,
@@ -1083,6 +1088,9 @@ impl MachineSetup {
         }
         if self.identify != base.identify_board {
             raw.identify = Some(self.identify);
+        }
+        if self.rtg != base.rtg {
+            raw.rtg.card = Some(rtg_card_name(self.rtg).to_ascii_lowercase());
         }
         // CPU
         if self.cpu != base.cpu {
@@ -1371,6 +1379,7 @@ impl MachineSetup {
         self.video = base.video_standard;
         self.rtc = base.rtc_present;
         self.identify = base.identify_board;
+        self.rtg = base.rtg;
         self.cpu = base.cpu;
         self.fpu = base.fpu;
         self.clock_mhz = base.cpu_clock_mhz;
@@ -1674,6 +1683,7 @@ impl MachineSetup {
     pub fn value_label(&self, field: LauncherField) -> String {
         match field {
             F::Chipset => chipset_name(self.chipset).to_string(),
+            F::Rtg => rtg_card_name(self.rtg).to_string(),
             F::Agnus => match self.agnus {
                 None => "Auto".to_string(),
                 Some(a) => agnus_name(a).to_string(),
@@ -1827,6 +1837,7 @@ impl MachineSetup {
     pub fn cycle(&mut self, field: LauncherField, forward: bool) {
         match field {
             F::Chipset => self.chipset = cycle_slice(&CHIPSETS, self.chipset, forward),
+            F::Rtg => self.rtg = cycle_slice(&RTG_CARDS, self.rtg, forward),
             F::Agnus => self.agnus = cycle_slice(&AGNUS_CHOICES, self.agnus, forward),
             F::Denise => self.denise = cycle_slice(&DENISE_CHOICES, self.denise, forward),
             F::Video => self.video = cycle_slice(&VIDEO_CHOICES, self.video, forward),
@@ -2460,6 +2471,13 @@ pub fn model_label(model: MachineModel) -> &'static str {
     }
 }
 
+fn rtg_card_name(card: RtgCard) -> &'static str {
+    match card {
+        RtgCard::None => "None",
+        RtgCard::Z3660 => "Z3660",
+    }
+}
+
 fn chipset_name(chipset: Chipset) -> &'static str {
     match chipset {
         Chipset::Ocs => "OCS",
@@ -2796,6 +2814,29 @@ mod tests {
         assert!(raw.cpu.model.is_none());
         assert!(raw.chipset.revision.is_none());
         assert!(s.build_config().is_ok());
+    }
+
+    #[test]
+    fn rtg_card_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        assert_eq!(s.rtg, RtgCard::None);
+        assert_eq!(s.value_label(LauncherField::Rtg), "None");
+        s.cycle(LauncherField::Rtg, true);
+        assert_eq!(s.rtg, RtgCard::Z3660);
+        assert_eq!(s.value_label(LauncherField::Rtg), "Z3660");
+
+        // The written key must be what [rtg] card parses back, not the
+        // display label: the parse is case-forgiving but the round trip
+        // should not depend on that.
+        let raw = s.to_raw();
+        assert_eq!(raw.rtg.card.as_deref(), Some("z3660"));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.rtg, RtgCard::Z3660);
+
+        // Back to the default, which is the baseline, so nothing is written.
+        s.cycle(LauncherField::Rtg, false);
+        assert_eq!(s.rtg, RtgCard::None);
+        assert!(s.to_raw().rtg.card.is_none());
     }
 
     #[test]

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -18,17 +18,18 @@ pub const fn rgba(r: u32, g: u32, b: u32) -> u32 {
     0xFF00_0000 | (b << 16) | (g << 8) | r
 }
 
-/// Compose the active RTG board frame (Z3660 scanout) into an
-/// FB_WIDTH-stride presentation buffer: the board frame lands in `scratch`
-/// at its own resolution and is scaled horizontally (nearest) into `out`,
-/// one output row per board row -- the shared vertical scaling then maps
-/// rows to the output height like any chipset frame. Returns the row count,
-/// or `None` while no RTG board drives the display.
+/// Compose the active RTG board frame (Z3660 scanout). The board frame lands
+/// in `scratch` at its native resolution; `out` gets an FB_WIDTH-stride copy
+/// (nearest, one output row per board row) for the screenshot path, which
+/// reads the shared presentation buffer. Returns
+/// `(present_rows, native_w, native_h)`, or `None` while no RTG board drives
+/// the display. The window presents the native `scratch` frame directly (see
+/// [`crate::video::window`]); `out` exists only for the screenshot path.
 pub fn compose_rtg_present(
     bus: &crate::bus::Bus,
     scratch: &mut Vec<u32>,
     out: &mut Vec<u32>,
-) -> Option<usize> {
+) -> Option<(usize, u32, u32)> {
     let (w, h) = bus.rtg_frame(scratch)?;
     let (w, h) = (w as usize, h as usize);
     out.clear();
@@ -40,7 +41,7 @@ pub fn compose_rtg_present(
             *px = src[x * w / FB_WIDTH];
         }
     }
-    Some(h)
+    Some((h, w as u32, h as u32))
 }
 
 pub const STANDARD_PAL_VISIBLE_WIDTH: usize = 320 * 2;

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -38,7 +38,11 @@ pub fn compose_rtg_present(
         let src = &scratch[y * w..(y + 1) * w];
         let dst = &mut out[y * FB_WIDTH..(y + 1) * FB_WIDTH];
         for (x, px) in dst.iter_mut().enumerate() {
-            *px = src[x * w / FB_WIDTH];
+            // Sample the centre of each output pixel's source span, not its
+            // left edge: `x * w / FB_WIDTH` tops out below `w - 1` whenever
+            // the board frame is wider than FB_WIDTH, so the rightmost
+            // source columns never reach a downscaled screenshot.
+            *px = src[(2 * x + 1) * w / (2 * FB_WIDTH)];
         }
     }
     Some((h, w as u32, h as u32))

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -18,6 +18,31 @@ pub const fn rgba(r: u32, g: u32, b: u32) -> u32 {
     0xFF00_0000 | (b << 16) | (g << 8) | r
 }
 
+/// Compose the active RTG board frame (Z3660 scanout) into an
+/// FB_WIDTH-stride presentation buffer: the board frame lands in `scratch`
+/// at its own resolution and is scaled horizontally (nearest) into `out`,
+/// one output row per board row -- the shared vertical scaling then maps
+/// rows to the output height like any chipset frame. Returns the row count,
+/// or `None` while no RTG board drives the display.
+pub fn compose_rtg_present(
+    bus: &crate::bus::Bus,
+    scratch: &mut Vec<u32>,
+    out: &mut Vec<u32>,
+) -> Option<usize> {
+    let (w, h) = bus.rtg_frame(scratch)?;
+    let (w, h) = (w as usize, h as usize);
+    out.clear();
+    out.resize(h * FB_WIDTH, 0xFF00_0000);
+    for y in 0..h {
+        let src = &scratch[y * w..(y + 1) * w];
+        let dst = &mut out[y * FB_WIDTH..(y + 1) * FB_WIDTH];
+        for (x, px) in dst.iter_mut().enumerate() {
+            *px = src[x * w / FB_WIDTH];
+        }
+    }
+    Some(h)
+}
+
 pub const STANDARD_PAL_VISIBLE_WIDTH: usize = 320 * 2;
 pub const STANDARD_PAL_VISIBLE_LINES: usize = 256;
 pub const STANDARD_PAL_VISIBLE_START_VPOS: u32 = 0x2C;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7495,7 +7495,10 @@ impl App {
         self.rtg_fb = rtg;
         self.present_fb = present;
         let Some(rows) = rows else {
-            return Some(false);
+            // rtg_active() is true but the frame did not compose (e.g. MODE
+            // set before ORIG_RES): fall back to the chipset render rather
+            // than freezing on the stale frame.
+            return None;
         };
         self.present_rows = rows;
         self.present_standard_tv_aperture = false;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -568,6 +568,9 @@ pub struct App {
     present_fb: Vec<u32>,
     present_rows: usize,
     present_standard_tv_aperture: bool,
+    /// Scratch for composing an RTG board frame (Z3660 scanout); reused
+    /// across frames to avoid a per-frame allocation.
+    rtg_fb: Vec<u32>,
     render: Option<Render>,
     debugger_tool_window: Option<ToolWindow>,
     frame_analyzer_tool_window: Option<ToolWindow>,
@@ -1012,6 +1015,7 @@ impl App {
             deinterlacer: Deinterlacer::with_phosphor(phosphor),
             present_fb: vec![0u32; FB_WIDTH * OUT_HEIGHT],
             present_rows: OUT_HEIGHT,
+            rtg_fb: Vec::new(),
             present_standard_tv_aperture: true,
             render: None,
             debugger_tool_window: None,
@@ -7472,14 +7476,53 @@ impl App {
         rendered
     }
 
+    /// Present the RTG board frame when one is driving the display: the
+    /// board frame (own resolution) is scaled horizontally into the
+    /// FB_WIDTH-stride presentation buffer, and the shared vertical scaling
+    /// maps its rows to the output height. Returns `None` when no RTG board
+    /// is active (native chipset presentation as usual).
+    fn render_rtg_frame_if_active(&mut self) -> Option<bool> {
+        if !self.emu.bus().rtg_active() {
+            return None;
+        }
+        let emulated_frame = self.emu.bus().emulated_frames();
+        if !should_render_emulated_frame(self.last_rendered_emulated_frame, emulated_frame) {
+            return Some(false);
+        }
+        let mut rtg = std::mem::take(&mut self.rtg_fb);
+        let mut present = std::mem::take(&mut self.present_fb);
+        let rows = compose_rtg_present(self.emu.bus(), &mut rtg, &mut present);
+        self.rtg_fb = rtg;
+        self.present_fb = present;
+        let Some(rows) = rows else {
+            return Some(false);
+        };
+        self.present_rows = rows;
+        self.present_standard_tv_aperture = false;
+        self.last_rendered_emulated_frame = Some(emulated_frame);
+        self.last_submitted_render_frame = Some(emulated_frame);
+        Some(true)
+    }
+
     fn render_emulated_frame_if_needed(&mut self) -> bool {
         if !self.emu.bus().frame_render_available() {
             return false;
         }
+        // Drain in-flight chipset render results first (recycling their
+        // buffers) so a stale result cannot land on top of an RTG frame.
+        // Their "new frame applied" outcome must propagate to the caller,
+        // which uses it to schedule the window redraw.
+        let mut rendered = false;
         if self.render_worker.is_some() {
-            return self.render_emulated_frame_threaded();
+            rendered = self.collect_threaded_render_results(false);
         }
-        self.render_emulated_frame_sync()
+        if let Some(rtg_rendered) = self.render_rtg_frame_if_active() {
+            return rendered | rtg_rendered;
+        }
+        if self.render_worker.is_some() {
+            return rendered | self.render_emulated_frame_threaded();
+        }
+        rendered | self.render_emulated_frame_sync()
     }
 
     fn render_emulated_frame_sync(&mut self) -> bool {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2192,8 +2192,15 @@ impl ApplicationHandler for App {
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
                     // through its own texture in the GPU render pass below.
-                    let rtg_gpu = self.rtg_present_dims.is_some();
-                    if let Some((w, h)) = self.rtg_present_dims {
+                    //
+                    // Not while the UI is up, though: that pass overdraws the
+                    // display region after the UI has been drawn into it, so
+                    // an open menu or panel would be painted over and vanish.
+                    // Fall back to the CPU present, which composites the UI on
+                    // top as usual, at the cost of the FB_WIDTH downscale for
+                    // as long as the overlay is open.
+                    let rtg_gpu = self.rtg_present_dims.is_some() && !self.ui.active();
+                    if let Some((w, h)) = self.rtg_present_dims.filter(|_| rtg_gpu) {
                         r.rtg_texture.upload(
                             r.pixels.device(),
                             r.pixels.queue(),
@@ -2216,7 +2223,11 @@ impl ApplicationHandler for App {
                             frame,
                             r.texture_scale,
                             self.overscan,
-                            self.present_standard_tv_aperture,
+                            // The TV aperture is a chipset crop rect. An RTG
+                            // frame fills the buffer on its own terms, so
+                            // applying it here would show a sub-rect of the
+                            // board's screen.
+                            self.present_standard_tv_aperture && self.rtg_present_dims.is_none(),
                         );
                     }
                     draw_status_bar(frame, &view, r.texture_scale);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -571,6 +571,10 @@ pub struct App {
     /// Scratch for composing an RTG board frame (Z3660 scanout); reused
     /// across frames to avoid a per-frame allocation.
     rtg_fb: Vec<u32>,
+    /// Native (width, height) of the RTG frame in `rtg_fb` when the last
+    /// presented frame was RTG; `None` when the chipset drives the display.
+    /// The draw path uploads `rtg_fb` to the RTG texture when set.
+    rtg_present_dims: Option<(u32, u32)>,
     render: Option<Render>,
     debugger_tool_window: Option<ToolWindow>,
     frame_analyzer_tool_window: Option<ToolWindow>,
@@ -825,6 +829,10 @@ struct Render {
     window: Arc<Window>,
     pixels: Pixels<'static>,
     texture_scale: usize,
+    /// Native-resolution RTG display texture, drawn over the UI buffer in
+    /// the `pixels` render pass (see [`rtg_texture`]). Present whenever the
+    /// window is (its pipeline uses the same GPU device as `pixels`).
+    rtg_texture: rtg_texture::RtgTexture,
     /// True while the host window is minimized (Windows delivers a 0x0
     /// Resized). Presenting while minimized deadlocks on Windows: DWM stops
     /// consuming swapchain frames, so once the in-flight buffers fill,
@@ -1016,6 +1024,7 @@ impl App {
             present_fb: vec![0u32; FB_WIDTH * OUT_HEIGHT],
             present_rows: OUT_HEIGHT,
             rtg_fb: Vec::new(),
+            rtg_present_dims: None,
             present_standard_tv_aperture: true,
             render: None,
             debugger_tool_window: None,
@@ -1604,10 +1613,13 @@ impl ApplicationHandler for App {
             texture_width(texture_scale),
             texture_height(texture_scale)
         );
+        let rtg_texture =
+            rtg_texture::RtgTexture::new(pixels.device(), pixels.render_texture_format());
         self.render = Some(Render {
             window,
             pixels,
             texture_scale,
+            rtg_texture,
             minimized: false,
         });
         // Paint at least once so the status bar (and power button) is
@@ -2178,15 +2190,35 @@ impl ApplicationHandler for App {
                     };
                 let ui_data = self.build_panel_view_data();
                 if let Some(r) = self.render.as_mut() {
+                    // RTG with a working GPU pipeline presents the native frame
+                    // through its own texture in the GPU render pass below.
+                    let rtg_gpu = self.rtg_present_dims.is_some();
+                    if let Some((w, h)) = self.rtg_present_dims {
+                        r.rtg_texture.upload(
+                            r.pixels.device(),
+                            r.pixels.queue(),
+                            &self.rtg_fb,
+                            w,
+                            h,
+                        );
+                    }
                     let frame = r.pixels.frame_mut();
-                    copy_window_present_frame(
-                        &self.present_fb,
-                        self.present_rows,
-                        frame,
-                        r.texture_scale,
-                        self.overscan,
-                        self.present_standard_tv_aperture,
-                    );
+                    if rtg_gpu {
+                        // The GPU pass overdraws the display region; black it
+                        // out so nothing stale shows at the seams.
+                        let rows = present_height() * r.texture_scale;
+                        let stride = texture_width(r.texture_scale) * 4;
+                        frame[..rows * stride].fill(0);
+                    } else {
+                        copy_window_present_frame(
+                            &self.present_fb,
+                            self.present_rows,
+                            frame,
+                            r.texture_scale,
+                            self.overscan,
+                            self.present_standard_tv_aperture,
+                        );
+                    }
                     draw_status_bar(frame, &view, r.texture_scale);
                     if recording {
                         // Painted into the presentation texture only, so
@@ -2230,7 +2262,24 @@ impl ApplicationHandler for App {
                     if self.drop_hover && !matches!(self.ui.panel, Some(Panel::Launcher(_))) {
                         ui::draw_drop_hint(frame, r.texture_scale);
                     }
-                    if let Err(e) = r.pixels.render() {
+                    let render_result = if rtg_gpu {
+                        // Draw the UI buffer, then overdraw the display region
+                        // with the native RTG texture (GPU-scaled). The display
+                        // rect is the top present_height fraction of the buffer's
+                        // letterboxed clip rect on the surface.
+                        let rtg = &r.rtg_texture;
+                        r.pixels.render_with(|encoder, target, ctx| {
+                            ctx.scaling_renderer.render(encoder, target);
+                            let (cx, cy, cw, ch) = ctx.scaling_renderer.clip_rect();
+                            let disp_h = ch as f32 * present_height() as f32
+                                / window_present_height() as f32;
+                            rtg.render(encoder, target, (cx as f32, cy as f32, cw as f32, disp_h));
+                            Ok(())
+                        })
+                    } else {
+                        r.pixels.render()
+                    };
+                    if let Err(e) = render_result {
                         error!("pixels.render: {e}");
                     }
                 }
@@ -7383,6 +7432,7 @@ impl App {
         self.render_recycle_fb = old;
         self.present_rows = result.present_rows;
         self.present_standard_tv_aperture = result.standard_tv_aperture;
+        self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(result.emulated_frame);
         true
     }
@@ -7491,15 +7541,20 @@ impl App {
         }
         let mut rtg = std::mem::take(&mut self.rtg_fb);
         let mut present = std::mem::take(&mut self.present_fb);
-        let rows = compose_rtg_present(self.emu.bus(), &mut rtg, &mut present);
+        let composed = compose_rtg_present(self.emu.bus(), &mut rtg, &mut present);
         self.rtg_fb = rtg;
         self.present_fb = present;
-        let Some(rows) = rows else {
+        let Some((rows, native_w, native_h)) = composed else {
             // rtg_active() is true but the frame did not compose (e.g. MODE
             // set before ORIG_RES): fall back to the chipset render rather
             // than freezing on the stale frame.
+            self.rtg_present_dims = None;
             return None;
         };
+        // The native frame stays in `rtg_fb`; the window presents it at full
+        // resolution through the RTG texture, while `present_fb` keeps the
+        // FB_WIDTH version the screenshot path reads.
+        self.rtg_present_dims = Some((native_w, native_h));
         self.present_rows = rows;
         self.present_standard_tv_aperture = false;
         self.last_rendered_emulated_frame = Some(emulated_frame);
@@ -7562,6 +7617,7 @@ impl App {
         self.refresh_present_from_deinterlacer();
         self.present_standard_tv_aperture =
             uses_standard_pal_tv_aperture(geometry, self.present_rows, &base);
+        self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(emulated_frame);
         self.last_submitted_render_frame = Some(emulated_frame);
         true
@@ -7573,6 +7629,7 @@ mod console;
 mod control;
 mod host_input;
 mod present;
+mod rtg_texture;
 mod statusbar;
 pub(super) use present::{scale_rect, texture_height, texture_width, Rect};
 pub(super) use statusbar::{draw_rect_bevel, fill_rect, fill_rect_blend};

--- a/src/video/window/rtg_texture.rs
+++ b/src/video/window/rtg_texture.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! GPU presentation of the RTG board frame at native resolution.
+//!
+//! The desktop window composites the display and the UI into one fixed
+//! `FB_WIDTH`-wide `pixels` buffer, so an RTG mode wider than that buffer
+//! (or shown in a window larger than it) is sampled from a lower-resolution
+//! intermediate and looks soft. This module keeps a GPU texture at the RTG
+//! mode's native resolution and, in the `pixels` `render_with` pass, draws
+//! it straight into the display sub-rect of the surface after the UI buffer
+//! -- one hardware-filtered scale from native pixels to the physical display
+//! rect, bypassing the intermediate entirely.
+//!
+//! The UI buffer (status bar, menus, cursor mapping) is untouched: the RTG
+//! texture only overdraws the display region on top of it.
+
+use pixels::wgpu;
+use std::borrow::Cow;
+
+const SHADER: &str = r#"
+struct VOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VOut {
+    // Fullscreen triangle: the viewport restricts it to the display rect.
+    let tc = vec2<f32>(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VOut;
+    out.uv = tc;
+    out.pos = vec4<f32>(tc * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+    return out;
+}
+
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+
+@fragment
+fn fs_main(in: VOut) -> @location(0) vec4<f32> {
+    return textureSample(tex, samp, in.uv);
+}
+"#;
+
+/// A native-resolution RTG display texture and the pipeline that scales it
+/// into the window's display rect.
+pub(super) struct RtgTexture {
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    texture: Option<wgpu::Texture>,
+    bind_group: Option<wgpu::BindGroup>,
+    dims: (u32, u32),
+}
+
+impl RtgTexture {
+    pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("rtg_texture_shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
+        });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("rtg_texture_bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("rtg_texture_pl"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("rtg_texture_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("rtg_texture_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+        Self {
+            pipeline,
+            bind_group_layout,
+            sampler,
+            texture: None,
+            bind_group: None,
+            dims: (0, 0),
+        }
+    }
+
+    /// Upload the native RTG frame (`src`, `w` x `h` RGBA words). The texture
+    /// (and its bind group) is recreated when the resolution changes.
+    pub(super) fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        src: &[u32],
+        w: u32,
+        h: u32,
+    ) {
+        if w == 0 || h == 0 || (src.len() as u32) < w * h {
+            return;
+        }
+        if self.dims != (w, h) || self.texture.is_none() {
+            let texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("rtg_texture"),
+                size: wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("rtg_texture_bg"),
+                layout: &self.bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&self.sampler),
+                    },
+                ],
+            });
+            self.texture = Some(texture);
+            self.bind_group = Some(bind_group);
+            self.dims = (w, h);
+        }
+        let bytes =
+            unsafe { std::slice::from_raw_parts(src.as_ptr() as *const u8, (w * h * 4) as usize) };
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: self.texture.as_ref().unwrap(),
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            bytes,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w * 4),
+                rows_per_image: Some(h),
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    /// Draw the uploaded texture into the `(x, y, w, h)` viewport rect of
+    /// `target` (physical surface pixels), on top of what is already there.
+    pub(super) fn render(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        viewport: (f32, f32, f32, f32),
+    ) {
+        let Some(bind_group) = &self.bind_group else {
+            return;
+        };
+        let (x, y, w, h) = viewport;
+        if w < 1.0 || h < 1.0 {
+            return;
+        }
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("rtg_texture_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.set_viewport(x, y, w, h, 0.0, 1.0);
+        pass.draw(0..3, 0..1);
+    }
+}

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -15,9 +15,9 @@
 //! is honest memory. The display pipeline presents the panned framebuffer
 //! (all four pixel formats, palette captured from the upload stream) when
 //! the driver switches the display to RTG, and the core blitter ops
-//! (fill/copy/invert/template/pattern) execute into VRAM on the doorbell.
-//! Still stubbed: DRAWLINE, P2C/P2D, the ACC_OP surface ops, and the
-//! hardware sprite (the pointer is invisible until it is composited).
+//! (fill/copy/invert/template/pattern) execute into VRAM on the doorbell,
+//! with the hardware sprite (mouse pointer) composited over the output.
+//! Still stubbed: DRAWLINE, P2C/P2D, and the ACC_OP surface ops.
 
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 
@@ -41,6 +41,7 @@ const BACKED_BYTES: usize = 0x0400_0000;
 
 // The registers the FindCard/init path probes.
 const REG_MODE: u32 = 0x100;
+const REG_SPRITE_BITMAP: u32 = 0x174;
 const REG_VBLANK_STATUS: u32 = 0x17C;
 const REG_BLITTER_DMA_OP: u32 = 0x180;
 const REG_ACC_OP: u32 = 0x184;
@@ -110,6 +111,17 @@ pub struct Z3660 {
     /// Whether SetGC has programmed a display mode since power-on; RTG
     /// scanout is meaningless before the first mode set.
     mode_set: bool,
+    /// Hardware sprite (the mouse pointer): composited over the frame at
+    /// scanout, never written to VRAM. Pixel values 0-3 index
+    /// `sprite_colors` (0 = transparent), row-major `sprite_w` wide.
+    sprite_visible: bool,
+    sprite_x: i32,
+    sprite_y: i32,
+    sprite_w: usize,
+    sprite_h: usize,
+    sprite_pix: Vec<u8>,
+    /// Sprite pens as 0x00RRGGBB (pen 0 unused).
+    sprite_colors: [u32; 4],
 }
 
 impl Z3660 {
@@ -123,6 +135,13 @@ impl Z3660 {
             pan_offset: 0,
             pan_width: 0,
             mode_set: false,
+            sprite_visible: false,
+            sprite_x: 0,
+            sprite_y: 0,
+            sprite_w: 0,
+            sprite_h: 0,
+            sprite_pix: Vec::new(),
+            sprite_colors: [0; 4],
         }
     }
 
@@ -202,6 +221,15 @@ impl Z3660 {
                     value & 0xFFFF
                 );
             }
+            REG_SPRITE_BITMAP => {
+                // SetSprite: 1 = show the hardware sprite (2 = hide; the
+                // driver ships only the show write, hiding via position).
+                if value == 1 {
+                    self.sprite_visible = true;
+                } else if value == 2 {
+                    self.sprite_visible = false;
+                }
+            }
             REG_CUSTOM_VIDMODE => self.vidmode_param = value,
             REG_CUSTOM_VIDMODE_DATA => {
                 log::info!(
@@ -271,6 +299,9 @@ impl Z3660 {
         const OP_RECT_TEMPLATE: u32 = 5;
         const OP_RECT_PATTERN: u32 = 6;
         const OP_INVERTRECT: u32 = 9;
+        const OP_SPRITE_XY: u32 = 11;
+        const OP_SPRITE_COLOR: u32 = 12;
+        const OP_SPRITE_BITMAP: u32 = 13;
         const MINTERM_SRC: u8 = 0xC0;
         const JAM1: u8 = 0;
         const INVERSVID: u8 = 8;
@@ -438,6 +469,45 @@ impl Z3660 {
                     }
                 }
             }
+            OP_SPRITE_XY => {
+                self.sprite_x = i32::from(self.be16(g + 0x10) as i16);
+                self.sprite_y = i32::from(self.be16(g + 0x18) as i16);
+            }
+            OP_SPRITE_COLOR => {
+                // rgb0 was assembled bytewise on the 68k as B,G,R,0; the
+                // u8offset byte selects the pen (driver sends idx+1).
+                let pen = (self.vram[g + 0x3B] & 3) as usize;
+                let (b, gr, r) = (rgb0 >> 24, (rgb0 >> 16) & 0xFF, (rgb0 >> 8) & 0xFF);
+                self.sprite_colors[pen] = (r << 16) | (gr << 8) | b;
+            }
+            OP_SPRITE_BITMAP => {
+                // Amiga 2-plane sprite rows at offset[1]: `hires` words of
+                // plane 0 then plane 1 per row; pixel value = plane bits.
+                let (w, h) = (x1, y1);
+                let hires = y2 + 1;
+                // Row: `hires` words of plane 0, then plane 1 (the driver
+                // copies (w>>3)*2*hires bytes per row).
+                let row_bytes = (w / 8) * 2 * hires;
+                if w == 0 || h == 0 || w > 16 * hires {
+                    log::debug!("z3660: sprite bitmap {w}x{h} hires {hires} unsupported");
+                    self.sprite_pix.clear();
+                    return;
+                }
+                self.sprite_w = w;
+                self.sprite_h = h;
+                self.sprite_pix = vec![0u8; w * h];
+                for y in 0..h {
+                    let row = src + y * row_bytes;
+                    for x in 0..w {
+                        let word = x / 16;
+                        let bit = 15 - (x & 15);
+                        let p0 = self.be16(row + 2 * word);
+                        let p1 = self.be16(row + 2 * hires + 2 * word);
+                        let v = (((p1 >> bit) & 1) << 1) | ((p0 >> bit) & 1);
+                        self.sprite_pix[y * w + x] = v as u8;
+                    }
+                }
+            }
             _ => {
                 log::debug!("z3660: dma-op {} not executed yet", dma_op_name(op));
             }
@@ -531,6 +601,26 @@ impl Z3660 {
                     _ => (self.vram[at + 2], self.vram[at + 1], self.vram[at]),
                 };
                 out.push(0xFF00_0000 | (u32::from(b) << 16) | (u32::from(g) << 8) | u32::from(r));
+            }
+        }
+        // The hardware sprite (mouse pointer) is composited over the output
+        // stream; it never exists in VRAM. Pen 0 is transparent.
+        if self.sprite_visible && !self.sprite_pix.is_empty() {
+            for sy in 0..self.sprite_h {
+                let py = self.sprite_y + sy as i32;
+                if py < 0 || py >= h as i32 {
+                    continue;
+                }
+                for sx in 0..self.sprite_w {
+                    let px = self.sprite_x + sx as i32;
+                    let pen = self.sprite_pix[sy * self.sprite_w + sx];
+                    if pen == 0 || px < 0 || px >= w as i32 {
+                        continue;
+                    }
+                    let rgb = self.sprite_colors[pen as usize];
+                    out[py as usize * w as usize + px as usize] =
+                        0xFF00_0000 | ((rgb & 0xFF) << 16) | (rgb & 0xFF00) | ((rgb >> 16) & 0xFF);
+                }
             }
         }
         Some((w, h))
@@ -628,6 +718,9 @@ impl ZorroDevice for Z3660 {
         self.pan_offset = 0;
         self.pan_width = 0;
         self.mode_set = false;
+        self.sprite_visible = false;
+        self.sprite_pix.clear();
+        self.sprite_colors = [0; 4];
     }
 
     fn kind(&self) -> &'static str {
@@ -1041,5 +1134,70 @@ mod exec_tests {
         );
         ring(&mut z, &mut m, 5);
         assert_eq!(&z.vram[v..v + 4], &[3, 9, 3, 9]);
+    }
+}
+
+#[cfg(test)]
+mod sprite_tests {
+    use super::*;
+    use crate::memory::Memory;
+
+    fn mem() -> Memory {
+        Memory {
+            chip_ram: vec![0u8; 0x100],
+            slow_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    fn w32(z: &mut Z3660, m: &mut Memory, off: u32, value: u32) {
+        z.write(off, 4, value, &mut DeviceHost::new(m));
+    }
+
+    /// The pointer overlays the frame at its position without touching
+    /// VRAM: SetSprite shows it, SPRITE_BITMAP uploads the 2-plane image,
+    /// SPRITE_COLOR sets pen 1 (u8offset = idx+1, B/G/R bytes), SPRITE_XY
+    /// places it.
+    #[test]
+    fn sprite_composites_over_the_frame() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let g = GFXDATA_OFFSET;
+        // 4x2 8-bit screen showing palette entry 0 (black).
+        w32(&mut z, &mut m, REG_ORIG_RES, (4 << 16) | 2);
+        w32(&mut z, &mut m, REG_MODE, 0x16);
+        // Pen 1 = pure red: rgb0 guest bytes B,G,R,0 = 00 00 FF 00.
+        z.vram[g + 8..g + 12].copy_from_slice(&[0x00, 0x00, 0xFF, 0x00]);
+        z.vram[g + 0x3B] = 1;
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, 12);
+        // 16x1 bitmap at src offset 0x1000: plane0 = 0x8000 (first pixel).
+        z.vram[g + 4..g + 8].copy_from_slice(&0x1000u32.to_be_bytes());
+        z.vram[g + 0x12..g + 0x14].copy_from_slice(&16u16.to_be_bytes()); // x[1]=w
+        z.vram[g + 0x1A..g + 0x1C].copy_from_slice(&1u16.to_be_bytes()); // y[1]=h
+        z.vram[g + 0x14..g + 0x16].copy_from_slice(&[0, 0]); // x[2] doubled=0
+        z.vram[g + 0x1C..g + 0x1E].copy_from_slice(&[0, 0]); // y[2] hires-1=0
+        let v = VRAM_OFFSET as usize + 0x1000;
+        z.vram[v] = 0x80; // plane 0 word 0x8000
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, 13);
+        // Position (1,1), show.
+        z.vram[g + 0x10..g + 0x12].copy_from_slice(&1u16.to_be_bytes());
+        z.vram[g + 0x18..g + 0x1A].copy_from_slice(&1u16.to_be_bytes());
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, 11);
+        w32(&mut z, &mut m, REG_SPRITE_BITMAP, 1);
+
+        let mut out = Vec::new();
+        assert_eq!(z.rtg_frame(&mut out), Some((4, 2)));
+        let red = 0xFF00_0000 | 0xFF; // R in the low byte
+        assert_eq!(out[0], 0xFF00_0000, "screen pixel outside the sprite");
+        assert_eq!(out[4 + 1], red, "sprite pixel at (1,1)");
+        // Hide: the overlay disappears.
+        w32(&mut z, &mut m, REG_SPRITE_BITMAP, 2);
+        z.rtg_frame(&mut out);
+        assert_eq!(out[4 + 1], 0xFF00_0000);
     }
 }

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -358,8 +358,15 @@ impl Z3660 {
         const INVERSVID: u8 = 4;
 
         let g = GFXDATA_OFFSET;
-        let dst = VRAM_OFFSET as usize + self.be32(g) as usize;
-        let src = VRAM_OFFSET as usize + self.be32(g + 4) as usize;
+        // The surface offsets are guest-controlled, and usize is 32-bit on
+        // wasm32, where adding VRAM_OFFSET could wrap a large offset back
+        // into live VRAM. Widen, then saturate: an out-of-range base stays
+        // out of range, so every access below fails its bounds check and the
+        // op drops, which is what the firmware's writes into scratch do.
+        let base_of =
+            |v: u32| usize::try_from(u64::from(VRAM_OFFSET) + u64::from(v)).unwrap_or(usize::MAX);
+        let dst = base_of(self.be32(g));
+        let src = base_of(self.be32(g + 4));
         let rgb0 = self.be32(g + 8);
         let rgb1 = self.be32(g + 0xC);
         // x1/y1 are the blit width/height (x2/y2 for the planar ops); clamp
@@ -420,26 +427,32 @@ impl Z3660 {
                     log::debug!("z3660: copyrect minterm {minterm:#04x} treated as SRC");
                 }
                 let apply_mask = op == OP_COPYRECT && bpp == 1 && mask != 0xFF;
-                // Snapshot the source rect first: rects may overlap.
-                let mut rect = vec![0u8; x1 * y1 * bpp];
-                for y in 0..y1 {
+                // Rects may overlap, so a row cannot be written while it is
+                // still needed as source. Buffer one row rather than the
+                // whole rect: x1/y1 are clamped to MAX_DIM apiece, so a
+                // whole-rect snapshot would reach 64 MiB per blit, which is
+                // a large allocation and a long stall for a guest-supplied
+                // pair of numbers. Vertical overlap is handled by walking
+                // rows away from the destination instead.
+                let row_bytes = x1 * bpp;
+                let mut row = vec![0u8; row_bytes];
+                let down = dst + y0 * dpitch >= sbase + y2 * spitch;
+                for i in 0..y1 {
+                    let y = if down { y1 - 1 - i } else { i };
                     let srow = sbase + (y2 + y) * spitch + x2 * bpp;
-                    for b in 0..x1 * bpp {
-                        rect[y * x1 * bpp + b] = if srow + b < self.vram.len() {
+                    for (b, r) in row.iter_mut().enumerate() {
+                        *r = if srow + b < self.vram.len() {
                             self.vram[srow + b]
                         } else {
                             0
                         };
                     }
-                }
-                for y in 0..y1 {
                     let drow = dst + (y0 + y) * dpitch + x0 * bpp;
-                    for x in 0..x1 * bpp {
+                    for (x, &s) in row.iter().enumerate() {
                         let at = drow + x;
                         if at >= self.vram.len() {
                             continue;
                         }
-                        let s = rect[y * x1 * bpp + x];
                         self.vram[at] = if apply_mask {
                             (self.vram[at] & !mask) | (s & mask)
                         } else {
@@ -1363,6 +1376,77 @@ mod exec_tests {
         );
         ring(&mut z, &mut m, 3);
         assert_eq!(&z.vram[v..v + 8], &[0, 1, 0, 1, 2, 3, 6, 7]);
+    }
+
+    /// Rects that overlap vertically scroll without smearing. Only one row
+    /// is buffered, so rows must be walked away from the destination: a
+    /// downward copy taken top-first would overwrite row n before reading
+    /// it as the source for row n+1, painting the first row everywhere.
+    #[test]
+    fn copyrect_scrolls_down_without_smearing() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        // Four 4-byte rows, contiguous (pitch0 = 1 longword).
+        for i in 0..16 {
+            z.vram[v + i] = i as u8;
+        }
+        // Copy rows 0..3 down one row, so each row takes the one above it.
+        gfxdata(
+            &mut z,
+            0,
+            0,
+            0,
+            0,
+            [0, 4, 0],
+            [1, 3, 0],
+            0,
+            [1, 0],
+            0,
+            0,
+            0xFF,
+            0,
+        );
+        ring(&mut z, &mut m, 3);
+        assert_eq!(
+            &z.vram[v..v + 16],
+            &[0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        );
+    }
+
+    /// A surface offset near the top of the 32-bit address space must not
+    /// wrap back into live VRAM when VRAM_OFFSET is added to it.
+    ///
+    /// This only discriminates where usize is 32 bits: on wasm32 the
+    /// unwidened add wrapped to 0x1FFFF0, inside the mailbox region, and
+    /// corrupted it. On a 64-bit host the sum is merely far out of range and
+    /// the op drops either way, so here this is a guard rather than a
+    /// reproduction.
+    #[test]
+    fn blit_base_near_the_address_space_top_does_not_wrap() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        for i in 0..8 {
+            z.vram[v + i] = i as u8;
+        }
+        // dst = 0xFFFF_FFF0: adding VRAM_OFFSET overflows 32 bits, and a
+        // wrapped base would land inside VRAM and corrupt it.
+        gfxdata(
+            &mut z,
+            0xFFFF_FFF0,
+            0,
+            0xAA,
+            0,
+            [0, 4, 0],
+            [0, 1, 0],
+            0,
+            [4, 0],
+            0,
+            0,
+            0xFF,
+            0,
+        );
+        ring(&mut z, &mut m, 2); // FILLRECT
+        assert_eq!(&z.vram[v..v + 8], &[0, 1, 2, 3, 4, 5, 6, 7]);
     }
 
     #[test]

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -15,9 +15,9 @@
 //! is honest memory. The display pipeline presents the panned framebuffer
 //! (all four pixel formats, palette captured from the upload stream) when
 //! the driver switches the display to RTG, and the core blitter ops
-//! (fill/copy/invert/template/pattern) execute into VRAM on the doorbell,
-//! with the hardware sprite (mouse pointer) composited over the output.
-//! Still stubbed: DRAWLINE, P2C/P2D, and the ACC_OP surface ops.
+//! (fill/copy/invert/template/pattern/line/planar) execute into VRAM on
+//! the doorbell, with the hardware sprite (mouse pointer) composited over
+//! the output. Still stubbed: the ACC_OP surface ops and exotic minterms.
 
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 
@@ -298,8 +298,14 @@ impl Z3660 {
         const OP_COPYRECT_NOMASK: u32 = 4;
         const OP_RECT_TEMPLATE: u32 = 5;
         const OP_RECT_PATTERN: u32 = 6;
+        const OP_DRAWLINE: u32 = 1;
+        const OP_P2C: u32 = 7;
+        const OP_P2D: u32 = 8;
         const OP_INVERTRECT: u32 = 9;
         const OP_SPRITE_XY: u32 = 11;
+        const MINTERM_NOTSRC: u8 = 3;
+        const MINTERM_SRC_IDX: u8 = 12;
+        const COMPLEMENT: u8 = 2;
         const OP_SPRITE_COLOR: u32 = 12;
         const OP_SPRITE_BITMAP: u32 = 13;
         const MINTERM_SRC: u8 = 0xC0;
@@ -465,6 +471,103 @@ impl Z3660 {
                                 self.px_put_masked(at, bpp, rgb1, mask);
                             }
                             _ => {}
+                        }
+                    }
+                }
+            }
+            OP_DRAWLINE => {
+                // From (x[0],y[0]) along the signed deltas (x[1],y[1]);
+                // pattern user[1] rotates per pixel (0xFFFF = solid). JAM2
+                // draws bg where the pattern bit is clear; the COMPLEMENT
+                // bit inverts the destination instead (shell XOR cursor).
+                let pitch = pitch0 * 4;
+                let (ax, ay) = (
+                    i32::from(self.be16(g + 0x10) as i16),
+                    i32::from(self.be16(g + 0x18) as i16),
+                );
+                let (dx, dy) = (
+                    i32::from(self.be16(g + 0x12) as i16),
+                    i32::from(self.be16(g + 0x1A) as i16),
+                );
+                let mut pattern = self.gfx_u16(0x20, 1) as u16;
+                if drawmode & INVERSVID != 0 {
+                    pattern ^= 0xFFFF;
+                }
+                let complement = drawmode & COMPLEMENT != 0;
+                let jam2 = !complement && drawmode & 1 != 0;
+                let steps = dx.abs().max(dy.abs());
+                let mut cur_bit = 0x8000u16;
+                for i in 0..=steps {
+                    let px = ax + if steps == 0 { 0 } else { dx * i / steps };
+                    let py = ay + if steps == 0 { 0 } else { dy * i / steps };
+                    if px >= 0 && py >= 0 {
+                        let at = dst + py as usize * pitch + px as usize * bpp;
+                        if pattern & cur_bit != 0 {
+                            if complement {
+                                let d = self.px_get(at, bpp);
+                                let v = if bpp == 1 {
+                                    d ^ u32::from(mask)
+                                } else {
+                                    !d & (u32::MAX >> (8 * (4 - bpp)))
+                                };
+                                self.px_put(at, bpp, v);
+                            } else {
+                                self.px_put_masked(at, bpp, rgb0, mask);
+                            }
+                        } else if jam2 {
+                            self.px_put_masked(at, bpp, rgb1, mask);
+                        }
+                    }
+                    cur_bit = cur_bit.rotate_right(1);
+                }
+            }
+            OP_P2C | OP_P2D => {
+                // Planar source staged at offset[1] (P2D: after a 256-entry
+                // CLUT of destination-format pixel values): `planes`
+                // consecutive planes of pitch[1]-byte rows. x[0] = source
+                // bit phase, dest rect (x[1],y[1]) w=x[2] h=y[2],
+                // layer_mask user[0] gates planes, depth user[1].
+                let (phase, dxr, w) = (x0, x1, x2);
+                let (dyr, h) = (y1, y2);
+                let planes = self.gfx_u16(0x20, 1).min(8);
+                let layer_mask = user0 as u8;
+                let sp = pitch1;
+                let plane_size = sp * h;
+                let (pal, data) = if op == OP_P2D {
+                    (src, src + 1024)
+                } else {
+                    (0, src)
+                };
+                let dpitch = pitch0 * 4;
+                if minterm != MINTERM_SRC_IDX && minterm != MINTERM_NOTSRC {
+                    log::debug!("z3660: p2c/p2d minterm {minterm} treated as SRC");
+                }
+                let inv = if minterm == MINTERM_NOTSRC { 0xFF } else { 0 };
+                for y in 0..h {
+                    for i in 0..w {
+                        let bitpos = phase + i;
+                        let bit = 0x80u8 >> (bitpos & 7);
+                        let mut pen = 0usize;
+                        for p in 0..planes {
+                            if layer_mask & (1 << p) == 0 {
+                                continue;
+                            }
+                            let at = data + plane_size * p + y * sp + bitpos / 8;
+                            let b = if at < self.vram.len() {
+                                self.vram[at] ^ inv
+                            } else {
+                                0
+                            };
+                            if b & bit != 0 {
+                                pen |= 1 << p;
+                            }
+                        }
+                        let at = dst + (dyr + y) * dpitch + (dxr + i) * bpp;
+                        if op == OP_P2C {
+                            self.px_put_masked(at, 1, pen as u32, mask);
+                        } else {
+                            let col = self.px_get(pal + 4 * pen, 4);
+                            self.px_put(at, bpp, col);
                         }
                     }
                 }
@@ -1134,6 +1237,64 @@ mod exec_tests {
         );
         ring(&mut z, &mut m, 5);
         assert_eq!(&z.vram[v..v + 4], &[3, 9, 3, 9]);
+    }
+
+    /// P2C decodes staged bitplanes to pens; P2D looks the pens up in the
+    /// staged destination-format CLUT.
+    #[test]
+    fn planar_blits_decode_planes() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        // Two planes staged at 0x1000, 1 byte per row, 1 row: plane 0 =
+        // 0b1100_0000, plane 1 = 0b0100_0000 -> pens 1, 3, 0, 0 ...
+        z.vram[v + 0x1000] = 0xC0;
+        z.vram[v + 0x1001] = 0x40;
+        // P2C to an 8-bit row at (0,0): minterm SRC (12), depth 2 in
+        // user[1], layer mask 0xFF in user[0], src pitch[1] = 1.
+        gfxdata(
+            &mut z,
+            0,
+            0x1000,
+            0,
+            0,
+            [0, 0, 4],
+            [0, 0, 1],
+            0xFF,
+            [4, 1],
+            0,
+            0,
+            0xFF,
+            12,
+        );
+        let g = GFXDATA_OFFSET;
+        z.vram[g + 0x22..g + 0x24].copy_from_slice(&2u16.to_be_bytes()); // user[1] depth
+        ring(&mut z, &mut m, 7);
+        assert_eq!(&z.vram[v..v + 4], &[1, 3, 0, 0]);
+
+        // P2D to a 16-bit row at (0,4): CLUT staged at 0x2000, planes
+        // follow at +1024; pen 3 = 0xB67D.
+        z.vram[v + 0x2000 + 4 * 3 + 2..v + 0x2000 + 4 * 3 + 4].copy_from_slice(&[0xB6, 0x7D]);
+        z.vram[v + 0x2400] = 0xC0;
+        z.vram[v + 0x2401] = 0x40;
+        gfxdata(
+            &mut z,
+            0x100,
+            0x2000,
+            0,
+            0,
+            [0, 0, 2],
+            [0, 0, 1],
+            0xFF,
+            [4, 1],
+            1,
+            0,
+            0xFF,
+            12,
+        );
+        z.vram[g + 0x22..g + 0x24].copy_from_slice(&2u16.to_be_bytes());
+        ring(&mut z, &mut m, 8);
+        // Pixel 0 = pen 1 (CLUT entry 0), pixel 1 = pen 3 = 0xB67D.
+        assert_eq!(&z.vram[v + 0x100..v + 0x104], &[0x00, 0x00, 0xB6, 0x7D]);
     }
 }
 

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -514,8 +514,13 @@ impl Z3660 {
                 let x_step = if dx < 0 { -1 } else { 1 };
                 let y_step = if dy < 0 { -1 } else { 1 };
                 let mut cur_bit = 0x8000u16;
+                // A pixel past the end of a row would otherwise address the
+                // start of the next one, drawing a wrapped line rather than a
+                // clipped one. The row is the only bound the request carries;
+                // beyond the bitmap's last row the VRAM bound in px_put applies.
+                let row_px = (pitch / bpp) as i32;
                 let put = |z: &mut Self, x: i32, y: i32, bit: u16| {
-                    if x < 0 || y < 0 {
+                    if x < 0 || y < 0 || x >= row_px {
                         return;
                     }
                     if pattern & bit == 0 && !jam2 {

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -14,8 +14,10 @@
 //! answer, every register access is latched and logged, and the RAM region
 //! is honest memory. The display pipeline presents the panned framebuffer
 //! (all four pixel formats, palette captured from the upload stream) when
-//! the driver switches the display to RTG; the blitter ops are not
-//! executed yet, so only CPU-rendered pixels show.
+//! the driver switches the display to RTG, and the core blitter ops
+//! (fill/copy/invert/template/pattern) execute into VRAM on the doorbell.
+//! Still stubbed: DRAWLINE, P2C/P2D, the ACC_OP surface ops, and the
+//! hardware sprite (the pointer is invisible until it is composited).
 
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 
@@ -215,9 +217,240 @@ impl Z3660 {
                     self.pan_offset = self.be32(GFXDATA_OFFSET);
                     self.pan_width = u32::from(self.be16(GFXDATA_OFFSET + 0x12));
                 }
+                self.exec_dma_op(value);
             }
             REG_ACC_OP => self.log_gfxdata("acc-op", acc_op_name(value), value),
             _ => {}
+        }
+    }
+
+    // --- GFXData blitter-op executor -------------------------------------
+    //
+    // Semantics follow the ARM firmware (z3660-firmware src/rtg/gfx.c and
+    // dma_rtg.c, GPL-3.0-or-later like Copperline). Ops run synchronously on
+    // the doorbell write, which is faithful: the real board holds the CPU in
+    // bus wait states while the ARM services the register.
+    //
+    // Byte-order note: GFXData fields are written by the 68k and read
+    // byteswapped by the little-endian ARM, whose "fg >> 24" is therefore the
+    // guest value's LOW byte, and whose pixel stores land in guest byte
+    // order. This executor works directly in guest byte order: the 8-bit pen
+    // is `rgb & 0xFF`, wider pixels are stored big-endian.
+    //
+    // Pitch quirk: fill/copy/invert/line pass pitch[0] in longwords
+    // (BytesPerRow >> 2); template/pattern pass raw BytesPerRow (the
+    // firmware divides by 4 in u32-pointer arithmetic, so bytes here).
+
+    fn gfx_u16(&self, field: usize, i: usize) -> usize {
+        self.be16(GFXDATA_OFFSET + field + 2 * i) as usize
+    }
+
+    /// One pixel store in guest byte order, bounds-checked (out-of-window
+    /// pixels are dropped, as the firmware's fb writes wrap into scratch).
+    fn px_put(&mut self, at: usize, bpp: usize, v: u32) {
+        if at + bpp <= self.vram.len() {
+            let bytes = v.to_be_bytes();
+            self.vram[at..at + bpp].copy_from_slice(&bytes[4 - bpp..]);
+        }
+    }
+
+    fn px_get(&self, at: usize, bpp: usize) -> u32 {
+        if at + bpp > self.vram.len() {
+            return 0;
+        }
+        self.vram[at..at + bpp]
+            .iter()
+            .fold(0, |acc, &b| (acc << 8) | u32::from(b))
+    }
+
+    /// Execute one REG_BLITTER_DMA_OP request against VRAM.
+    fn exec_dma_op(&mut self, op: u32) {
+        const OP_FILLRECT: u32 = 2;
+        const OP_COPYRECT: u32 = 3;
+        const OP_COPYRECT_NOMASK: u32 = 4;
+        const OP_RECT_TEMPLATE: u32 = 5;
+        const OP_RECT_PATTERN: u32 = 6;
+        const OP_INVERTRECT: u32 = 9;
+        const MINTERM_SRC: u8 = 0xC0;
+        const JAM1: u8 = 0;
+        const INVERSVID: u8 = 8;
+
+        let g = GFXDATA_OFFSET;
+        let dst = VRAM_OFFSET as usize + self.be32(g) as usize;
+        let src = VRAM_OFFSET as usize + self.be32(g + 4) as usize;
+        let rgb0 = self.be32(g + 8);
+        let rgb1 = self.be32(g + 0xC);
+        let (x0, x1, x2) = (
+            self.gfx_u16(0x10, 0),
+            self.gfx_u16(0x10, 1),
+            self.gfx_u16(0x10, 2),
+        );
+        let (y0, y1, y2) = (
+            self.gfx_u16(0x18, 0),
+            self.gfx_u16(0x18, 1),
+            self.gfx_u16(0x18, 2),
+        );
+        let user0 = self.gfx_u16(0x20, 0);
+        let (pitch0, pitch1) = (self.gfx_u16(0x28, 0), self.gfx_u16(0x28, 1));
+        let colormode = u32::from(self.vram[g + 0x30]);
+        let drawmode = self.vram[g + 0x31];
+        let mask = self.vram[g + 0x39];
+        let minterm = self.vram[g + 0x3A];
+        let bpp: usize = match colormode {
+            COLORMODE_8BIT => 1,
+            COLORMODE_16BIT565 | COLORMODE_15BIT => 2,
+            COLORMODE_32BIT => 4,
+            _ => return,
+        };
+
+        match op {
+            OP_FILLRECT => {
+                // (x0,y0) w=x1 h=y1, colour rgb0; the 8-bit mask keeps
+                // unmasked destination bits (planar write masks).
+                let pitch = pitch0 * 4;
+                for y in 0..y1 {
+                    let row = dst + (y0 + y) * pitch + x0 * bpp;
+                    for x in 0..x1 {
+                        let at = row + x * bpp;
+                        if bpp == 1 && mask != 0xFF {
+                            let d = self.px_get(at, 1) as u8;
+                            let v = (d & !mask) | (rgb0 as u8 & mask);
+                            self.px_put(at, 1, u32::from(v));
+                        } else {
+                            self.px_put(at, bpp, rgb0);
+                        }
+                    }
+                }
+            }
+            OP_COPYRECT | OP_COPYRECT_NOMASK => {
+                // dst rect (x0,y0) w=x1 h=y1 from src rect (x2,y2). Plain
+                // COPYRECT blits within the surface at offset[0]/pitch[0];
+                // the NOMASK variant reads surface offset[1]/pitch[1] and
+                // carries a minterm (only SRC is implemented; others log).
+                let dpitch = pitch0 * 4;
+                let (sbase, spitch) = if op == OP_COPYRECT {
+                    (dst, dpitch)
+                } else {
+                    (src, pitch1 * 4)
+                };
+                if op == OP_COPYRECT_NOMASK && minterm != MINTERM_SRC {
+                    log::debug!("z3660: copyrect minterm {minterm:#04x} treated as SRC");
+                }
+                let apply_mask = op == OP_COPYRECT && bpp == 1 && mask != 0xFF;
+                // Snapshot the source rect first: rects may overlap.
+                let mut rect = vec![0u8; x1 * y1 * bpp];
+                for y in 0..y1 {
+                    let srow = sbase + (y2 + y) * spitch + x2 * bpp;
+                    for b in 0..x1 * bpp {
+                        rect[y * x1 * bpp + b] = if srow + b < self.vram.len() {
+                            self.vram[srow + b]
+                        } else {
+                            0
+                        };
+                    }
+                }
+                for y in 0..y1 {
+                    let drow = dst + (y0 + y) * dpitch + x0 * bpp;
+                    for x in 0..x1 * bpp {
+                        let at = drow + x;
+                        if at >= self.vram.len() {
+                            continue;
+                        }
+                        let s = rect[y * x1 * bpp + x];
+                        self.vram[at] = if apply_mask {
+                            (self.vram[at] & !mask) | (s & mask)
+                        } else {
+                            s
+                        };
+                    }
+                }
+            }
+            OP_INVERTRECT => {
+                let pitch = pitch0 * 4;
+                for y in 0..y1 {
+                    let row = dst + (y0 + y) * pitch + x0 * bpp;
+                    for x in 0..x1 {
+                        let at = row + x * bpp;
+                        let d = self.px_get(at, bpp);
+                        let v = if bpp == 1 {
+                            d ^ u32::from(mask)
+                        } else {
+                            !d & (u32::MAX >> (8 * (4 - bpp)))
+                        };
+                        self.px_put(at, bpp, v);
+                    }
+                }
+            }
+            OP_RECT_TEMPLATE | OP_RECT_PATTERN => {
+                // 1-bit source data at offset[1]: a template row is
+                // pitch[1] bytes; a pattern is 16 bits wide repeating every
+                // user[0] rows (power of two). (x2,y2) is the bit phase.
+                // JAM1 draws fg where set; JAM2 draws fg/bg; COMPLEMENT
+                // inverts where set; INVERSVID inverts the source bits.
+                let pitch = pitch0 & !3; // raw bytes, truncated like fb+n/4
+                let inversion = drawmode & INVERSVID != 0;
+                let dm = drawmode & 0x03;
+                let (pat_rows, tpitch) = if op == OP_RECT_PATTERN {
+                    (user0.max(1), 2)
+                } else {
+                    (usize::MAX, pitch1)
+                };
+                for y in 0..y1 {
+                    let trow = if op == OP_RECT_PATTERN {
+                        src + ((y2 + y) & (pat_rows - 1)) * tpitch
+                    } else {
+                        src + y * tpitch
+                    };
+                    let row = dst + (y0 + y) * pitch;
+                    for x in 0..x1 {
+                        let bit_index = x2 + x;
+                        let tat = if op == OP_RECT_PATTERN {
+                            trow + (bit_index & 15) / 8
+                        } else {
+                            trow + bit_index / 8
+                        };
+                        let byte = if tat < self.vram.len() {
+                            self.vram[tat]
+                        } else {
+                            0
+                        };
+                        let byte = if inversion { !byte } else { byte };
+                        let set = byte & (0x80 >> (bit_index & 7)) != 0;
+                        let at = row + (x0 + x) * bpp;
+                        match (dm, set) {
+                            (2, true) => {
+                                // COMPLEMENT
+                                let d = self.px_get(at, bpp);
+                                let v = if bpp == 1 {
+                                    d ^ u32::from(mask)
+                                } else {
+                                    !d & (u32::MAX >> (8 * (4 - bpp)))
+                                };
+                                self.px_put(at, bpp, v);
+                            }
+                            (2, false) => {}
+                            (_, true) => self.px_put_masked(at, bpp, rgb0, mask),
+                            (_, false) if dm != JAM1 => {
+                                self.px_put_masked(at, bpp, rgb1, mask);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            _ => {
+                log::debug!("z3660: dma-op {} not executed yet", dma_op_name(op));
+            }
+        }
+    }
+
+    /// Foreground/background store honouring the 8-bit plane mask.
+    fn px_put_masked(&mut self, at: usize, bpp: usize, v: u32, mask: u8) {
+        if bpp == 1 && mask != 0xFF {
+            let d = self.px_get(at, 1) as u8;
+            self.px_put(at, 1, u32::from((d & !mask) | (v as u8 & mask)));
+        } else {
+            self.px_put(at, bpp, v);
         }
     }
 
@@ -667,5 +900,146 @@ mod tests {
         let mut out = Vec::new();
         assert_eq!(z.rtg_frame(&mut out), Some((1, 1)));
         assert_eq!(out[0], 0xFFFF_FFFF);
+    }
+}
+
+#[cfg(test)]
+mod exec_tests {
+    use super::*;
+    use crate::memory::Memory;
+
+    fn mem() -> Memory {
+        Memory {
+            chip_ram: vec![0u8; 0x100],
+            slow_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    /// Fill the GFXData mailbox fields a blit op reads.
+    #[allow(clippy::too_many_arguments)]
+    fn gfxdata(
+        z: &mut Z3660,
+        dst: u32,
+        src: u32,
+        rgb0: u32,
+        rgb1: u32,
+        x: [u16; 3],
+        y: [u16; 3],
+        user0: u16,
+        pitch: [u16; 2],
+        colormode: u8,
+        drawmode: u8,
+        mask: u8,
+        minterm: u8,
+    ) {
+        let g = GFXDATA_OFFSET;
+        z.vram[g..g + 4].copy_from_slice(&dst.to_be_bytes());
+        z.vram[g + 4..g + 8].copy_from_slice(&src.to_be_bytes());
+        z.vram[g + 8..g + 12].copy_from_slice(&rgb0.to_be_bytes());
+        z.vram[g + 12..g + 16].copy_from_slice(&rgb1.to_be_bytes());
+        for i in 0..3 {
+            z.vram[g + 0x10 + 2 * i..g + 0x12 + 2 * i].copy_from_slice(&x[i].to_be_bytes());
+            z.vram[g + 0x18 + 2 * i..g + 0x1A + 2 * i].copy_from_slice(&y[i].to_be_bytes());
+        }
+        z.vram[g + 0x20..g + 0x22].copy_from_slice(&user0.to_be_bytes());
+        for i in 0..2 {
+            z.vram[g + 0x28 + 2 * i..g + 0x2A + 2 * i].copy_from_slice(&pitch[i].to_be_bytes());
+        }
+        z.vram[g + 0x30] = colormode;
+        z.vram[g + 0x31] = drawmode;
+        z.vram[g + 0x39] = mask;
+        z.vram[g + 0x3A] = minterm;
+    }
+
+    fn ring(z: &mut Z3660, m: &mut Memory, op: u32) {
+        z.write(0x180, 4, op, &mut DeviceHost::new(m));
+    }
+
+    #[test]
+    fn fillrect_fills_the_rect_and_nothing_else() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        // 8-bit surface, pitch 16 bytes (pitch[0] = 4 longwords): fill a
+        // 3x2 rect of pen 7 at (1,1).
+        gfxdata(
+            &mut z,
+            0,
+            0,
+            7,
+            0,
+            [1, 3, 0],
+            [1, 2, 0],
+            0,
+            [4, 0],
+            0,
+            0,
+            0xFF,
+            0,
+        );
+        ring(&mut z, &mut m, 2);
+        let v = VRAM_OFFSET as usize;
+        assert_eq!(&z.vram[v..v + 4], &[0, 0, 0, 0], "row 0 untouched");
+        assert_eq!(&z.vram[v + 16..v + 21], &[0, 7, 7, 7, 0]);
+        assert_eq!(&z.vram[v + 32..v + 37], &[0, 7, 7, 7, 0]);
+        assert_eq!(z.vram[v + 48], 0, "row 3 untouched");
+    }
+
+    #[test]
+    fn copyrect_moves_an_overlapping_rect() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        // One row of 8 pixels 0..8; copy 4 pixels from x=0 to x=2 (overlap).
+        for i in 0..8 {
+            z.vram[v + i] = i as u8;
+        }
+        gfxdata(
+            &mut z,
+            0,
+            0,
+            0,
+            0,
+            [2, 4, 0],
+            [0, 1, 0],
+            0,
+            [4, 0],
+            0,
+            0,
+            0xFF,
+            0,
+        );
+        ring(&mut z, &mut m, 3);
+        assert_eq!(&z.vram[v..v + 8], &[0, 1, 0, 1, 2, 3, 6, 7]);
+    }
+
+    #[test]
+    fn template_jam2_draws_fg_and_bg() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        // Template data 0b1010_0000 at VRAM offset 0x1000; 4x1 rect at
+        // (0,0), fg pen 3, bg pen 9, JAM2 (drawmode 1), pitch[0] raw 16.
+        z.vram[v + 0x1000] = 0xA0;
+        gfxdata(
+            &mut z,
+            0,
+            0x1000,
+            3,
+            9,
+            [0, 4, 0],
+            [0, 1, 0],
+            0,
+            [16, 1],
+            0,
+            1,
+            0xFF,
+            0,
+        );
+        ring(&mut z, &mut m, 5);
+        assert_eq!(&z.vram[v..v + 4], &[3, 9, 3, 9]);
     }
 }

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -310,7 +310,9 @@ impl Z3660 {
         const OP_SPRITE_BITMAP: u32 = 13;
         const MINTERM_SRC: u8 = 0xC0;
         const JAM1: u8 = 0;
-        const INVERSVID: u8 = 8;
+        // Drawmode bits (firmware rtg/gfx.h): JAM1/JAM2 in bit 0, COMPLEMENT
+        // in bit 1, INVERSVID in bit 2.
+        const INVERSVID: u8 = 4;
 
         let g = GFXDATA_OFFSET;
         let dst = VRAM_OFFSET as usize + self.be32(g) as usize;

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -87,6 +87,17 @@ const COLORMODE_16BIT565: u32 = 1;
 const COLORMODE_32BIT: u32 = 2;
 const COLORMODE_15BIT: u32 = 3;
 
+/// Bytes per pixel of a colour mode, or `None` if the mode is not one we
+/// can scan out.
+fn colormode_bpp(colormode: u32) -> Option<u32> {
+    match colormode {
+        COLORMODE_8BIT => Some(1),
+        COLORMODE_16BIT565 | COLORMODE_15BIT => Some(2),
+        COLORMODE_32BIT => Some(4),
+        _ => None,
+    }
+}
+
 /// Upper bound on a blit rect / framebuffer dimension. The mailbox fields
 /// are guest-controlled, so clamping them keeps a bogus op from sizing a
 /// huge allocation or a multi-billion-iteration loop; no real screen or
@@ -108,11 +119,15 @@ pub struct Z3660 {
     /// The 512-entry palette (256 primary + 256 secondary), captured from
     /// the OP_DATA/OP palette upload stream as packed 0x00RRGGBB.
     palette: Vec<u32>,
-    /// Framebuffer start relative to VRAM_OFFSET, from the last PAN op.
+    /// Framebuffer start relative to VRAM_OFFSET, from the last PAN op, with
+    /// its x/y viewport offsets already folded in. The sprite needs no such
+    /// adjustment: SetSpritePosition sends viewport coordinates already.
     pan_offset: u32,
-    /// Framebuffer row width in pixels, from the last PAN op (x[1]). For
-    /// pixel-doubled small modes this is the real framebuffer width while
-    /// ORIG_RES holds the doubled output resolution.
+    /// The bitmap's row width in pixels, from the last PAN op (x[1]). This
+    /// is a stride, not a visible width: a bitmap wider than the display
+    /// mode scans out only the mode's worth of each row. For pixel-doubled
+    /// small modes it is the real framebuffer width while ORIG_RES holds the
+    /// doubled output resolution.
     pan_width: u32,
     /// Whether SetGC has programmed a display mode since power-on; RTG
     /// scanout is meaningless before the first mode set.
@@ -247,9 +262,31 @@ impl Z3660 {
                 self.log_gfxdata("dma-op", dma_op_name(value), value);
                 if value == DMA_OP_PAN {
                     // GFXData: offset[0] = framebuffer start relative to
-                    // MemoryBase, x[1] = row width in pixels.
-                    self.pan_offset = self.be32(GFXDATA_OFFSET);
-                    self.pan_width = u32::from(self.be16(GFXDATA_OFFSET + 0x12));
+                    // MemoryBase, x[0]/y[0] = signed viewport offsets within
+                    // the bitmap, x[1] = the bitmap's row width in pixels.
+                    //
+                    // The viewport offsets fold into the scanout base, so
+                    // panning around a bitmap larger than the mode just
+                    // moves the DMA start address:
+                    //   pan = offset[0] + x[0] * bpp + y[0] * x[1] * bpp
+                    //
+                    // The firmware writes this as a shift by the GFXData
+                    // colormode, which equals the pixel size for 8/16/32-bit
+                    // but strides 8 bytes per pixel for colormode 3
+                    // (15-bit). Panning a 15-bit screen on real hardware is
+                    // therefore broken; the pixel size is what P96 means, so
+                    // that is what we scan with.
+                    let cm = u32::from(self.vram[GFXDATA_OFFSET + 0x30]) & 0xF;
+                    let bpp = i64::from(colormode_bpp(cm).unwrap_or(1));
+                    let x0 = i32::from(self.be16(GFXDATA_OFFSET + 0x10) as i16);
+                    let y0 = i32::from(self.be16(GFXDATA_OFFSET + 0x18) as i16);
+                    let width = u32::from(self.be16(GFXDATA_OFFSET + 0x12));
+                    let base = self.be32(GFXDATA_OFFSET) as i64;
+                    let pan = base + (i64::from(x0) + i64::from(y0) * i64::from(width)) * bpp;
+                    // A guest offset that leaves the board's RAM scans
+                    // nothing; clamp rather than wrapping into live VRAM.
+                    self.pan_offset = u32::try_from(pan.max(0)).unwrap_or(u32::MAX);
+                    self.pan_width = width;
                 }
                 self.exec_dma_op(value);
             }
@@ -344,11 +381,9 @@ impl Z3660 {
         let drawmode = self.vram[g + 0x31];
         let mask = self.vram[g + 0x39];
         let minterm = self.vram[g + 0x3A];
-        let bpp: usize = match colormode {
-            COLORMODE_8BIT => 1,
-            COLORMODE_16BIT565 | COLORMODE_15BIT => 2,
-            COLORMODE_32BIT => 4,
-            _ => return,
+        let bpp = match colormode_bpp(colormode) {
+            Some(b) => b as usize,
+            None => return,
         };
 
         match op {
@@ -715,22 +750,23 @@ impl Z3660 {
         } else {
             (out_w, out_h)
         };
-        if self.pan_width != 0 {
-            w = self.pan_width;
-        }
         w = w.min(MAX_DIM as u32);
         h = h.min(MAX_DIM as u32);
         if w == 0 || h == 0 {
             return None;
         }
-        let bpp: u32 = match colormode {
-            COLORMODE_8BIT => 1,
-            COLORMODE_16BIT565 | COLORMODE_15BIT => 2,
-            COLORMODE_32BIT => 4,
-            _ => return None,
+        let bpp = colormode_bpp(colormode)?;
+        // Rows advance by the bitmap's stride, which is wider than the
+        // visible width when the guest pans around an oversized bitmap; the
+        // board scans out only the mode's worth of each row (video.c sets
+        // the VDMA stride from pan_width whenever it differs from hsize).
+        let stride = if self.pan_width != 0 {
+            self.pan_width
+        } else {
+            w
         };
-        let pitch = (w * bpp) as usize;
-        let base = (VRAM_OFFSET + self.pan_offset) as usize;
+        let pitch = (stride * bpp) as usize;
+        let base = VRAM_OFFSET.checked_add(self.pan_offset)? as usize;
         out.clear();
         out.reserve((w * h) as usize);
         for y in 0..h as usize {
@@ -1162,6 +1198,56 @@ mod tests {
         let mut out = Vec::new();
         assert_eq!(z.rtg_frame(&mut out), Some((1, 1)));
         assert_eq!(out[0], 0xFFFF_FFFF);
+    }
+
+    /// A 2x2 screen on a 4-pixel-wide bitmap, pen p at every cell:
+    ///     1 2 3 4
+    ///     5 6 7 8
+    ///     9 A B C
+    /// Pen p is coloured 0x0000pp, so a scanned-out pen appears as
+    /// 0xFF00_0000 | (p << 16).
+    fn panned_bitmap(x: u16, y: u16) -> Vec<u32> {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        w32(&mut z, &mut m, REG_ORIG_RES, (2 << 16) | 2);
+        w32(&mut z, &mut m, REG_MODE, 0x16);
+        for pen in 1..=12u32 {
+            w32(&mut z, &mut m, REG_OP_DATA, (pen << 24) | pen);
+            w32(&mut z, &mut m, REG_OP, ARM_OP_PALETTE);
+            let at = VRAM_OFFSET + pen - 1;
+            z.write(at, 1, pen, &mut DeviceHost::new(&mut m));
+        }
+        let g = GFXDATA_OFFSET as u32;
+        let mut h = DeviceHost::new(&mut m);
+        z.write(g, 4, 0, &mut h); // offset[0]: bitmap at VRAM start
+        z.write(g + 0x10, 2, u32::from(x), &mut h); // x[0]
+        z.write(g + 0x18, 2, u32::from(y), &mut h); // y[0]
+        z.write(g + 0x12, 2, 4, &mut h); // x[1]: bitmap is 4 wide
+        z.write(g + 0x30, 1, COLORMODE_8BIT, &mut h); // u8_user[COLORMODE]
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, DMA_OP_PAN);
+        let mut out = Vec::new();
+        // The visible size is the mode's, not the bitmap's.
+        assert_eq!(z.rtg_frame(&mut out), Some((2, 2)));
+        out
+    }
+
+    /// PAN's x[1] is the bitmap's row stride, not the visible width: a
+    /// bitmap wider than the mode still scans out only the mode's width,
+    /// with rows advancing by the full stride.
+    #[test]
+    fn pan_width_is_a_stride_not_a_visible_width() {
+        let pen = |p: u32| 0xFF00_0000 | (p << 16);
+        // Top-left 2x2 of the bitmap: pens 1,2 over 5,6 -- so row 1 starts
+        // 4 pixels in, not 2.
+        assert_eq!(panned_bitmap(0, 0), [pen(1), pen(2), pen(5), pen(6)]);
+    }
+
+    /// PAN's x[0]/y[0] move the viewport within the bitmap, which the board
+    /// implements by folding them into the scanout base.
+    #[test]
+    fn pan_viewport_offsets_move_the_scanout_origin() {
+        let pen = |p: u32| 0xFF00_0000 | (p << 16);
+        // One pixel right and one row down: pens 6,7 over 10,11.
+        assert_eq!(panned_bitmap(1, 1), [pen(6), pen(7), pen(10), pen(11)]);
     }
 }
 

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -37,10 +37,27 @@ const REG_END: u32 = 0x800;
 const BACKED_BYTES: usize = 0x0400_0000;
 
 // The registers the FindCard/init path probes.
+const REG_MODE: u32 = 0x100;
 const REG_VBLANK_STATUS: u32 = 0x17C;
+const REG_BLITTER_DMA_OP: u32 = 0x180;
+const REG_ACC_OP: u32 = 0x184;
+const REG_ORIG_RES: u32 = 0x18C;
 const REG_FW_VERSION: u32 = 0x1A0;
 const REG_INT_STATUS: u32 = 0x1A8;
+const REG_CUSTOM_VIDMODE: u32 = 0x200;
+const REG_CUSTOM_VIDMODE_DATA: u32 = 0x204;
 const REG_MONITOR_SWITCH: u32 = 0x318;
+
+/// The GFXData blit-parameter mailbox the driver fills in board RAM before
+/// ringing REG_BLITTER_DMA_OP / REG_ACC_OP (window offset 0x3200000).
+const GFXDATA_OFFSET: usize = 0x0320_0000;
+
+/// Vertical timing of the fake video output: a 60 Hz frame in PAL colour
+/// clocks (3546895 Hz / 60), with VBLANK_STATUS asserted for the first
+/// ~2400 ccks (~0.7 ms) of each frame. The driver's WaitVerticalSync
+/// busy-waits for a full 0 -> 1 transition of the flag.
+const FRAME_CCK: u32 = 59115;
+const VBLANK_CCK: u32 = 2400;
 
 /// Firmware revision reported to the driver: major 1 (FindCard requires
 /// exactly 1), minor 6 (>= 3, below which the driver raises an alert).
@@ -52,10 +69,12 @@ pub struct Z3660 {
     regs: Vec<u32>,
     /// Board RAM behind the register file: P96 VRAM and the GFXData mailbox.
     vram: Vec<u8>,
-    /// Fake vblank flip-flop: VBLANK_STATUS alternates on every read so the
-    /// driver's WaitVerticalSync busy-wait terminates.
-    // TODO(codewiz): drive this from emulated frame timing instead.
-    vblank: bool,
+    /// Position inside the fake 60 Hz output frame, in colour clocks;
+    /// VBLANK_STATUS reads 1 while it is inside the vblank window.
+    frame_phase: u32,
+    /// The last CUSTOM_VIDMODE parameter index written, so the matching
+    /// CUSTOM_VIDMODE_DATA write can be logged with the parameter's name.
+    vidmode_param: u32,
 }
 
 impl Z3660 {
@@ -63,7 +82,8 @@ impl Z3660 {
         Self {
             regs: vec![0u32; ((REG_END - REG_FIRST) / 4) as usize],
             vram: vec![0u8; BACKED_BYTES],
-            vblank: false,
+            frame_phase: 0,
+            vidmode_param: 0,
         }
     }
 
@@ -72,15 +92,74 @@ impl Z3660 {
     }
 
     /// The current value of the aligned register word at `off`.
-    fn reg_value(&mut self, off: u32) -> u32 {
+    fn reg_value(&self, off: u32) -> u32 {
         match off {
             REG_FW_VERSION => FW_VERSION,
-            REG_VBLANK_STATUS => {
-                self.vblank = !self.vblank;
-                u32::from(self.vblank)
-            }
+            REG_VBLANK_STATUS => u32::from(self.frame_phase < VBLANK_CCK),
             REG_INT_STATUS | REG_MONITOR_SWITCH => 0,
             _ => self.regs[Self::reg_index(off)],
+        }
+    }
+
+    /// Big-endian words from board RAM (the GFXData mailbox fields).
+    fn be32(&self, at: usize) -> u32 {
+        u32::from_be_bytes(self.vram[at..at + 4].try_into().unwrap())
+    }
+
+    fn be16(&self, at: usize) -> u16 {
+        u16::from_be_bytes(self.vram[at..at + 2].try_into().unwrap())
+    }
+
+    /// Decode and log the GFXData mailbox on a doorbell ring. The struct
+    /// layout is common/z3660_regs.h's `struct GFXData` (68k-endian; the op
+    /// selector is the doorbell value, not the struct's op byte).
+    fn log_gfxdata(&self, kind: &str, op_name: &str, op: u32) {
+        let g = GFXDATA_OFFSET;
+        let x: Vec<u16> = (0..4).map(|i| self.be16(g + 0x10 + 2 * i)).collect();
+        let y: Vec<u16> = (0..4).map(|i| self.be16(g + 0x18 + 2 * i)).collect();
+        let pitch: Vec<u16> = (0..4).map(|i| self.be16(g + 0x28 + 2 * i)).collect();
+        log::info!(
+            "z3660: {kind} {op_name} ({op}) dst={:#x} src={:#x} rgb={:#010x}/{:#010x} \
+             x={x:?} y={y:?} pitch={pitch:?} colormode={} drawmode={} mask={:#04x} minterm={:#04x}",
+            self.be32(g),
+            self.be32(g + 4),
+            self.be32(g + 8),
+            self.be32(g + 0xC),
+            self.vram[g + 0x30],
+            self.vram[g + 0x31],
+            self.vram[g + 0x39],
+            self.vram[g + 0x3A],
+        );
+    }
+
+    /// Side effects of a completed register write (the low lane landed).
+    fn reg_written(&mut self, off: u32, value: u32) {
+        match off {
+            REG_MODE => {
+                log::info!(
+                    "z3660: mode set: vmode {} colormode {} scalemode {}",
+                    vmode_name(value & 0xFF),
+                    colormode_name((value >> 8) & 0xF),
+                    (value >> 12) & 0xF,
+                );
+            }
+            REG_ORIG_RES => {
+                log::info!(
+                    "z3660: original resolution {}x{}",
+                    value >> 16,
+                    value & 0xFFFF
+                );
+            }
+            REG_CUSTOM_VIDMODE => self.vidmode_param = value,
+            REG_CUSTOM_VIDMODE_DATA => {
+                log::info!(
+                    "z3660: vidmode param {} = {value}",
+                    vmode_param_name(self.vidmode_param)
+                );
+            }
+            REG_BLITTER_DMA_OP => self.log_gfxdata("dma-op", dma_op_name(value), value),
+            REG_ACC_OP => self.log_gfxdata("acc-op", acc_op_name(value), value),
+            _ => {}
         }
     }
 }
@@ -138,6 +217,11 @@ impl ZorroDevice for Z3660 {
                 "z3660: write {} ({off:#05x},{size}) = {value:#010x}",
                 reg_name(aligned)
             );
+            // Register semantics fire once the low lane has landed (the bus
+            // sometimes splits a 32-bit write into two halfwords, high first).
+            if off + size as u32 == aligned + 4 {
+                self.reg_written(aligned, self.regs[idx]);
+            }
             return;
         }
         let at = off as usize;
@@ -159,15 +243,108 @@ impl ZorroDevice for Z3660 {
         Some((u16::from(self.vram[at]) << 8) | u16::from(self.vram[at + 1]))
     }
 
-    fn tick(&mut self, _cck: u32, _host: &mut DeviceHost) {}
+    fn tick(&mut self, cck: u32, _host: &mut DeviceHost) {
+        self.frame_phase = (self.frame_phase + cck) % FRAME_CCK;
+    }
 
     fn reset(&mut self) {
         self.regs.fill(0);
-        self.vblank = false;
+        self.frame_phase = 0;
+        self.vidmode_param = 0;
     }
 
     fn kind(&self) -> &'static str {
         "z3660"
+    }
+}
+
+/// `enum gfx_dma_op` (common/z3660_regs.h): REG_BLITTER_DMA_OP selectors.
+fn dma_op_name(op: u32) -> &'static str {
+    const NAMES: [&str; 17] = [
+        "NONE",
+        "DRAWLINE",
+        "FILLRECT",
+        "COPYRECT",
+        "COPYRECT_NOMASK",
+        "RECT_TEMPLATE",
+        "RECT_PATTERN",
+        "P2C",
+        "P2D",
+        "INVERTRECT",
+        "PAN",
+        "SPRITE_XY",
+        "SPRITE_COLOR",
+        "SPRITE_BITMAP",
+        "SPRITE_CLUT_BITMAP",
+        "ETH_USB_OFFSETS",
+        "SET_SPLIT_POS",
+    ];
+    NAMES.get(op as usize).copied().unwrap_or("unknown")
+}
+
+/// `enum gfx_acc_op` (common/z3660_regs.h): REG_ACC_OP selectors.
+fn acc_op_name(op: u32) -> &'static str {
+    const NAMES: [&str; 9] = [
+        "NONE",
+        "BUFFER_FLIP",
+        "BUFFER_CLEAR",
+        "BLIT_RECT",
+        "ALLOC_SURFACE",
+        "FREE_SURFACE",
+        "SET_BPP_CONVERSION_TABLE",
+        "DRAW_LINE",
+        "FILL_RECT",
+    ];
+    NAMES.get(op as usize).copied().unwrap_or("unknown")
+}
+
+/// `enum custom_vmode_params` (common/z3660_regs.h).
+fn vmode_param_name(param: u32) -> &'static str {
+    const NAMES: [&str; 16] = [
+        "HRES", "VRES", "HSTART", "HEND", "HMAX", "VSTART", "VEND", "VMAX", "POLARITY", "MHZ",
+        "PHZ", "VHZ", "HDMI", "MUL", "DIV", "DIV2",
+    ];
+    NAMES.get(param as usize).copied().unwrap_or("unknown")
+}
+
+/// `enum zz_video_modes` (rtg/rtg.h).
+fn vmode_name(mode: u32) -> &'static str {
+    const NAMES: [&str; 23] = [
+        "1280x720",
+        "800x600",
+        "640x480",
+        "1024x768",
+        "1280x1024",
+        "1920x1080_60",
+        "720x576",
+        "1920x1080_50",
+        "720x480",
+        "640x512",
+        "1600x1200",
+        "2560x1440_30",
+        "720x576_NS_PAL",
+        "720x480_NS_PAL",
+        "720x576_NS_NTSC",
+        "720x480_NS_NTSC",
+        "640x400",
+        "1280x800",
+        "1920x1200",
+        "1600x900",
+        "1680x1050",
+        "1366x768",
+        "CUSTOM",
+    ];
+    NAMES.get(mode as usize).copied().unwrap_or("unknown")
+}
+
+/// MNTVA colour modes (common/z3660_regs.h).
+fn colormode_name(mode: u32) -> &'static str {
+    match mode {
+        0 => "8BIT",
+        1 => "16BIT565",
+        2 => "32BIT",
+        3 => "15BIT",
+        _ => "unknown",
     }
 }
 

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Z3660 RTG board stub.
+//!
+//! The Z3660 accelerator's FPGA presents its RTG core as an ordinary
+//! Zorro III autoconfig board (manufacturer 0x144B, product 1, one 128 MB
+//! window) even though the physical board sits in the A3000/A4000 CPU slot.
+//! The open-source Z3660.card Picasso96 driver finds it via FindConfigDev
+//! and then talks to a 32-bit register file in the first 2 KB of the window;
+//! the rest of the window is board RAM (P96 VRAM from +0x200000, the
+//! GFXData blit-parameter mailbox at +0x3200000).
+//!
+//! This is a bring-up stub, not a working display: the board autoconfigs,
+//! the identity/status registers the driver probes at init answer, every
+//! other register access is latched and logged so the driver's expectations
+//! can be mapped, and the RAM region is honest memory. No pixels are scanned
+//! out yet.
+
+use crate::zorro_device::{DeviceHost, ZorroDevice};
+
+/// The Z3660's autoconfig manufacturer ID.
+pub const Z3660_MANUFACTURER_ID: u16 = 0x144B;
+/// The RTG board's product number.
+pub const Z3660_PRODUCT: u8 = 1;
+/// The autoconfig window: 128 MB of Zorro III space.
+pub const Z3660_WINDOW_BYTES: usize = 0x0800_0000;
+
+/// The register file: 32-bit registers at window offsets 0x100..0x800
+/// (common/z3660_regs.h in the driver source).
+const REG_FIRST: u32 = 0x100;
+const REG_END: u32 = 0x800;
+
+/// Backed RAM: the driver only touches the first 52 MB of the window
+/// (VRAM cap 0x3000000, GFXData at 0x3200000, template scratch at
+/// 0x3210000), so backing 64 MB keeps the allocation honest without
+/// carrying the full 128 MB window.
+const BACKED_BYTES: usize = 0x0400_0000;
+
+// The registers the FindCard/init path probes.
+const REG_VBLANK_STATUS: u32 = 0x17C;
+const REG_FW_VERSION: u32 = 0x1A0;
+const REG_INT_STATUS: u32 = 0x1A8;
+const REG_MONITOR_SWITCH: u32 = 0x318;
+
+/// Firmware revision reported to the driver: major 1 (FindCard requires
+/// exactly 1), minor 6 (>= 3, below which the driver raises an alert).
+const FW_VERSION: u32 = 0x0106;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Z3660 {
+    /// Latched register words, indexed by (offset - REG_FIRST) / 4.
+    regs: Vec<u32>,
+    /// Board RAM behind the register file: P96 VRAM and the GFXData mailbox.
+    vram: Vec<u8>,
+    /// Fake vblank flip-flop: VBLANK_STATUS alternates on every read so the
+    /// driver's WaitVerticalSync busy-wait terminates.
+    // TODO(codewiz): drive this from emulated frame timing instead.
+    vblank: bool,
+}
+
+impl Z3660 {
+    pub fn new() -> Self {
+        Self {
+            regs: vec![0u32; ((REG_END - REG_FIRST) / 4) as usize],
+            vram: vec![0u8; BACKED_BYTES],
+            vblank: false,
+        }
+    }
+
+    fn reg_index(off: u32) -> usize {
+        ((off - REG_FIRST) / 4) as usize
+    }
+
+    /// The current value of the aligned register word at `off`.
+    fn reg_value(&mut self, off: u32) -> u32 {
+        match off {
+            REG_FW_VERSION => FW_VERSION,
+            REG_VBLANK_STATUS => {
+                self.vblank = !self.vblank;
+                u32::from(self.vblank)
+            }
+            REG_INT_STATUS | REG_MONITOR_SWITCH => 0,
+            _ => self.regs[Self::reg_index(off)],
+        }
+    }
+}
+
+impl Default for Z3660 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ZorroDevice for Z3660 {
+    fn read(&mut self, off: u32, size: usize, _host: &mut DeviceHost) -> u32 {
+        if (REG_FIRST..REG_END).contains(&off) {
+            let aligned = off & !3;
+            if (off & 3) as usize + size > 4 {
+                log::debug!("z3660: register read straddles a word at {off:#x}");
+                return 0;
+            }
+            let word = self.reg_value(aligned);
+            let shift = 8 * (4 - (off & 3) as usize - size);
+            let value = (word >> shift) & (u32::MAX >> (8 * (4 - size)));
+            if aligned == REG_VBLANK_STATUS {
+                log::trace!("z3660: read  {} -> {value:#x}", reg_name(aligned));
+            } else {
+                log::info!(
+                    "z3660: read  {} ({off:#05x},{size}) -> {value:#010x}",
+                    reg_name(aligned)
+                );
+            }
+            return value;
+        }
+        let at = off as usize;
+        if at + size > self.vram.len() {
+            log::debug!("z3660: read beyond backed RAM at {off:#x}");
+            return 0;
+        }
+        self.vram[at..at + size]
+            .iter()
+            .fold(0, |acc, &b| (acc << 8) | u32::from(b))
+    }
+
+    fn write(&mut self, off: u32, size: usize, value: u32, _host: &mut DeviceHost) {
+        if (REG_FIRST..REG_END).contains(&off) {
+            let aligned = off & !3;
+            if (off & 3) as usize + size > 4 {
+                log::debug!("z3660: register write straddles a word at {off:#x}");
+                return;
+            }
+            // Merge a sub-word write into the latched word's byte lanes.
+            let idx = Self::reg_index(aligned);
+            let shift = 8 * (4 - (off & 3) as usize - size);
+            let mask = (u32::MAX >> (8 * (4 - size))) << shift;
+            self.regs[idx] = (self.regs[idx] & !mask) | ((value << shift) & mask);
+            log::info!(
+                "z3660: write {} ({off:#05x},{size}) = {value:#010x}",
+                reg_name(aligned)
+            );
+            return;
+        }
+        let at = off as usize;
+        if at + size > self.vram.len() {
+            log::debug!("z3660: write beyond backed RAM at {off:#x}");
+            return;
+        }
+        for i in 0..size {
+            self.vram[at + i] = (value >> (8 * (size - 1 - i))) as u8;
+        }
+    }
+
+    fn peek_word(&self, off: u32) -> Option<u16> {
+        // Registers are live (VBLANK_STATUS flips on read); RAM is safe.
+        let at = off as usize;
+        if (REG_FIRST..REG_END).contains(&off) || at + 2 > self.vram.len() {
+            return None;
+        }
+        Some((u16::from(self.vram[at]) << 8) | u16::from(self.vram[at + 1]))
+    }
+
+    fn tick(&mut self, _cck: u32, _host: &mut DeviceHost) {}
+
+    fn reset(&mut self) {
+        self.regs.fill(0);
+        self.vblank = false;
+    }
+
+    fn kind(&self) -> &'static str {
+        "z3660"
+    }
+}
+
+/// Register names from the driver's common/z3660_regs.h, for the access log.
+fn reg_name(off: u32) -> &'static str {
+    match off {
+        0x100 => "MODE",
+        0x104 => "CONFIG",
+        0x108 => "SPRITE_X",
+        0x10C => "SPRITE_Y",
+        0x110 => "X1",
+        0x114 => "Y1",
+        0x118 => "X2",
+        0x11C => "Y2",
+        0x120 => "PAN",
+        0x124 => "ROW_PITCH",
+        0x128 => "X3",
+        0x12C => "Y3",
+        0x130 => "RGB",
+        0x134 => "FILLRECT",
+        0x138 => "COPYRECT",
+        0x13C => "FILLTEMPLATE",
+        0x140 => "BLIT_SRC",
+        0x144 => "BLIT_DST",
+        0x148 => "COLORMODE",
+        0x14C => "SRC_PITCH",
+        0x150 => "RGB2",
+        0x154 => "P2C",
+        0x158 => "DRAWLINE",
+        0x15C => "P2D",
+        0x160 => "USER1",
+        0x164 => "USER2",
+        0x168 => "USER3",
+        0x16C => "USER4",
+        0x170 => "INVERTRECT",
+        0x174 => "SPRITE_BITMAP",
+        0x178 => "SPRITE_COLORS",
+        0x17C => "VBLANK_STATUS",
+        0x180 => "BLITTER_DMA_OP",
+        0x184 => "ACC_OP",
+        0x188 => "SET_SPLIT_POS",
+        0x18C => "ORIG_RES",
+        0x1A0 => "FW_VERSION",
+        0x1A8 => "INT_STATUS",
+        0x1E0 => "SET_FEATURE",
+        0x1FC => "DEBUG",
+        0x200 => "CUSTOM_VIDMODE",
+        0x204 => "CUSTOM_VIDMODE_DATA",
+        0x300 => "OP_DATA",
+        0x304 => "OP",
+        0x308 => "OP_NOP",
+        0x30C => "OP_CAPTUREMODE",
+        0x318 => "MONITOR_SWITCH",
+        _ => "reg",
+    }
+}

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -10,11 +10,12 @@
 //! the rest of the window is board RAM (P96 VRAM from +0x200000, the
 //! GFXData blit-parameter mailbox at +0x3200000).
 //!
-//! This is a bring-up stub, not a working display: the board autoconfigs,
-//! the identity/status registers the driver probes at init answer, every
-//! other register access is latched and logged so the driver's expectations
-//! can be mapped, and the RAM region is honest memory. No pixels are scanned
-//! out yet.
+//! Bring-up state: the board autoconfigs, the identity/status registers
+//! answer, every register access is latched and logged, and the RAM region
+//! is honest memory. The display pipeline presents the panned framebuffer
+//! (all four pixel formats, palette captured from the upload stream) when
+//! the driver switches the display to RTG; the blitter ops are not
+//! executed yet, so only CPU-rendered pixels show.
 
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -87,6 +87,12 @@ const COLORMODE_16BIT565: u32 = 1;
 const COLORMODE_32BIT: u32 = 2;
 const COLORMODE_15BIT: u32 = 3;
 
+/// Upper bound on a blit rect / framebuffer dimension. The mailbox fields
+/// are guest-controlled, so clamping them keeps a bogus op from sizing a
+/// huge allocation or a multi-billion-iteration loop; no real screen or
+/// blit exceeds this.
+const MAX_DIM: usize = 4096;
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Z3660 {
     /// Latched register words, indexed by (offset - REG_FIRST) / 4.
@@ -319,15 +325,18 @@ impl Z3660 {
         let src = VRAM_OFFSET as usize + self.be32(g + 4) as usize;
         let rgb0 = self.be32(g + 8);
         let rgb1 = self.be32(g + 0xC);
+        // x1/y1 are the blit width/height (x2/y2 for the planar ops); clamp
+        // the extents so a guest-supplied field cannot size an oversized
+        // allocation or loop. x0/y0 are positions, bounds-checked per access.
         let (x0, x1, x2) = (
             self.gfx_u16(0x10, 0),
-            self.gfx_u16(0x10, 1),
-            self.gfx_u16(0x10, 2),
+            self.gfx_u16(0x10, 1).min(MAX_DIM),
+            self.gfx_u16(0x10, 2).min(MAX_DIM),
         );
         let (y0, y1, y2) = (
             self.gfx_u16(0x18, 0),
-            self.gfx_u16(0x18, 1),
-            self.gfx_u16(0x18, 2),
+            self.gfx_u16(0x18, 1).min(MAX_DIM),
+            self.gfx_u16(0x18, 2).min(MAX_DIM),
         );
         let user0 = self.gfx_u16(0x20, 0);
         let (pitch0, pitch1) = (self.gfx_u16(0x28, 0), self.gfx_u16(0x28, 1));
@@ -667,8 +676,8 @@ impl Z3660 {
         if self.pan_width != 0 {
             w = self.pan_width;
         }
-        w = w.min(4096);
-        h = h.min(4096);
+        w = w.min(MAX_DIM as u32);
+        h = h.min(MAX_DIM as u32);
         if w == 0 || h == 0 {
             return None;
         }

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -586,30 +586,39 @@ impl Z3660 {
                 self.sprite_colors[pen] = (r << 16) | (gr << 8) | b;
             }
             OP_SPRITE_BITMAP => {
-                // Amiga 2-plane sprite rows at offset[1]: `hires` words of
-                // plane 0 then plane 1 per row; pixel value = plane bits.
-                let (w, h) = (x1, y1);
-                let hires = y2 + 1;
-                // Row: `hires` words of plane 0, then plane 1 (the driver
-                // copies (w>>3)*2*hires bytes per row).
-                let row_bytes = (w / 8) * 2 * hires;
-                if w == 0 || h == 0 || w > 16 * hires {
-                    log::debug!("z3660: sprite bitmap {w}x{h} hires {hires} unsupported");
+                // The pointer image at offset[1] is a 2-bitplane sprite (pen
+                // 0-3, 0 transparent). Each source row is plane 0's bytes
+                // followed by plane 1's (firmware update_hw_sprite, video.c).
+                // x[2] doubles the sprite: a w/2 x h/2 source shown 2x. The
+                // firmware buffer caps at 32x48, so clamp there.
+                let double = x2 != 0;
+                let scale = if double { 2 } else { 1 };
+                let (out_w, out_h) = (x1.min(64), y1.min(64));
+                let (sw, sh) = (out_w / scale, out_h / scale);
+                if sw == 0 || sh == 0 {
+                    log::debug!("z3660: sprite bitmap {out_w}x{out_h} empty");
                     self.sprite_pix.clear();
                     return;
                 }
-                self.sprite_w = w;
-                self.sprite_h = h;
-                self.sprite_pix = vec![0u8; w * h];
-                for y in 0..h {
-                    let row = src + y * row_bytes;
-                    for x in 0..w {
-                        let word = x / 16;
-                        let bit = 15 - (x & 15);
-                        let p0 = self.be16(row + 2 * word);
-                        let p1 = self.be16(row + 2 * hires + 2 * word);
-                        let v = (((p1 >> bit) & 1) << 1) | ((p0 >> bit) & 1);
-                        self.sprite_pix[y * w + x] = v as u8;
+                let plane = sw.div_ceil(8); // bytes per plane per source row
+                let row_bytes = plane * 2;
+                self.sprite_w = out_w;
+                self.sprite_h = out_h;
+                self.sprite_pix = vec![0u8; out_w * out_h];
+                for sy in 0..sh {
+                    let row = src + sy * row_bytes;
+                    for sx in 0..sw {
+                        let byte = sx / 8;
+                        let bit = 7 - (sx & 7);
+                        let p0 = self.px_get(row + byte, 1) as u8;
+                        let p1 = self.px_get(row + plane + byte, 1) as u8;
+                        let pen = ((p0 >> bit) & 1) | (((p1 >> bit) & 1) << 1);
+                        for dy in 0..scale {
+                            for dx in 0..scale {
+                                let (ox, oy) = (sx * scale + dx, sy * scale + dy);
+                                self.sprite_pix[oy * out_w + ox] = pen;
+                            }
+                        }
                     }
                 }
             }
@@ -1362,5 +1371,46 @@ mod sprite_tests {
         w32(&mut z, &mut m, REG_SPRITE_BITMAP, 2);
         z.rtg_frame(&mut out);
         assert_eq!(out[4 + 1], 0xFF00_0000);
+    }
+
+    /// A doubled sprite (x[2] = 1, as the OS 3.2 32x48 pointer uses) decodes
+    /// its half-size source and scales each pixel to a 2x2 block, instead of
+    /// being rejected as too wide.
+    #[test]
+    fn doubled_sprite_scales_2x() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let g = GFXDATA_OFFSET;
+        w32(&mut z, &mut m, REG_ORIG_RES, (4 << 16) | 4);
+        w32(&mut z, &mut m, REG_MODE, 0x16);
+        // Pen 1 = red.
+        z.vram[g + 8..g + 12].copy_from_slice(&[0x00, 0x00, 0xFF, 0x00]);
+        z.vram[g + 0x3B] = 1;
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, 12);
+        // Doubled 4x4 sprite from a 2x2 source at src 0x1000; source row is
+        // one plane-0 byte then one plane-1 byte. Row 0 plane 0 = 0x80
+        // (source pixel (0,0) set) -> a 2x2 red block at output (0,0).
+        z.vram[g + 4..g + 8].copy_from_slice(&0x1000u32.to_be_bytes());
+        z.vram[g + 0x12..g + 0x14].copy_from_slice(&4u16.to_be_bytes()); // x[1]=out w
+        z.vram[g + 0x14..g + 0x16].copy_from_slice(&1u16.to_be_bytes()); // x[2]=double
+        z.vram[g + 0x1A..g + 0x1C].copy_from_slice(&4u16.to_be_bytes()); // y[1]=out h
+        z.vram[g + 0x1C..g + 0x1E].copy_from_slice(&[0, 0]); // y[2]=hires-1=0
+        z.vram[VRAM_OFFSET as usize + 0x1000] = 0x80;
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, 13);
+        z.vram[g + 0x10..g + 0x12].copy_from_slice(&[0, 0]); // pos (0,0)
+        z.vram[g + 0x18..g + 0x1A].copy_from_slice(&[0, 0]);
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, 11);
+        w32(&mut z, &mut m, REG_SPRITE_BITMAP, 1);
+
+        let mut out = Vec::new();
+        assert_eq!(z.rtg_frame(&mut out), Some((4, 4)));
+        let red = 0xFF00_0000 | 0xFF;
+        // The single source pixel fills the 2x2 top-left block.
+        assert_eq!(out[0], red);
+        assert_eq!(out[1], red);
+        assert_eq!(out[4], red);
+        assert_eq!(out[5], red);
+        // Outside the block is transparent (screen shows through).
+        assert_eq!(out[2], 0xFF00_0000);
+        assert_eq!(out[8], 0xFF00_0000);
     }
 }

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -46,7 +46,17 @@ const REG_FW_VERSION: u32 = 0x1A0;
 const REG_INT_STATUS: u32 = 0x1A8;
 const REG_CUSTOM_VIDMODE: u32 = 0x200;
 const REG_CUSTOM_VIDMODE_DATA: u32 = 0x204;
+const REG_OP_DATA: u32 = 0x300;
+const REG_OP: u32 = 0x304;
+const REG_OP_CAPTUREMODE: u32 = 0x30C;
 const REG_MONITOR_SWITCH: u32 = 0x318;
+
+// REG_OP commands (the ARM mailbox the palette upload rides on).
+const ARM_OP_PALETTE: u32 = 3;
+const ARM_OP_PALETTE_HI: u32 = 19;
+
+// REG_BLITTER_DMA_OP selectors acted on (enum gfx_dma_op).
+const DMA_OP_PAN: u32 = 10;
 
 /// The GFXData blit-parameter mailbox the driver fills in board RAM before
 /// ringing REG_BLITTER_DMA_OP / REG_ACC_OP (window offset 0x3200000).
@@ -63,6 +73,16 @@ const VBLANK_CCK: u32 = 2400;
 /// exactly 1), minor 6 (>= 3, below which the driver raises an alert).
 const FW_VERSION: u32 = 0x0106;
 
+/// P96 VRAM starts at this window offset (Z3660_MEMBASE_ADDR in gfx.c);
+/// the framebuffer the driver pans to is relative to it.
+const VRAM_OFFSET: u32 = 0x0020_0000;
+
+// MNTVA colour modes (the MODE register's bits 8-11).
+const COLORMODE_8BIT: u32 = 0;
+const COLORMODE_16BIT565: u32 = 1;
+const COLORMODE_32BIT: u32 = 2;
+const COLORMODE_15BIT: u32 = 3;
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Z3660 {
     /// Latched register words, indexed by (offset - REG_FIRST) / 4.
@@ -75,6 +95,18 @@ pub struct Z3660 {
     /// The last CUSTOM_VIDMODE parameter index written, so the matching
     /// CUSTOM_VIDMODE_DATA write can be logged with the parameter's name.
     vidmode_param: u32,
+    /// The 512-entry palette (256 primary + 256 secondary), captured from
+    /// the OP_DATA/OP palette upload stream as packed 0x00RRGGBB.
+    palette: Vec<u32>,
+    /// Framebuffer start relative to VRAM_OFFSET, from the last PAN op.
+    pan_offset: u32,
+    /// Framebuffer row width in pixels, from the last PAN op (x[1]). For
+    /// pixel-doubled small modes this is the real framebuffer width while
+    /// ORIG_RES holds the doubled output resolution.
+    pan_width: u32,
+    /// Whether SetGC has programmed a display mode since power-on; RTG
+    /// scanout is meaningless before the first mode set.
+    mode_set: bool,
 }
 
 impl Z3660 {
@@ -84,6 +116,10 @@ impl Z3660 {
             vram: vec![0u8; BACKED_BYTES],
             frame_phase: 0,
             vidmode_param: 0,
+            palette: vec![0u32; 512],
+            pan_offset: 0,
+            pan_width: 0,
+            mode_set: false,
         }
     }
 
@@ -136,12 +172,25 @@ impl Z3660 {
     fn reg_written(&mut self, off: u32, value: u32) {
         match off {
             REG_MODE => {
+                self.mode_set = true;
                 log::info!(
                     "z3660: mode set: vmode {} colormode {} scalemode {}",
                     vmode_name(value & 0xFF),
                     colormode_name((value >> 8) & 0xF),
                     (value >> 12) & 0xF,
                 );
+            }
+            REG_OP => {
+                // The palette rides the ARM op mailbox: OP_DATA holds
+                // index<<24 | R<<16 | G<<8 | B, OP selects the bank.
+                let data = self.reg_value(REG_OP_DATA);
+                match value {
+                    ARM_OP_PALETTE => self.palette[(data >> 24) as usize] = data & 0x00FF_FFFF,
+                    ARM_OP_PALETTE_HI => {
+                        self.palette[256 + (data >> 24) as usize] = data & 0x00FF_FFFF;
+                    }
+                    _ => {}
+                }
             }
             REG_ORIG_RES => {
                 log::info!(
@@ -157,10 +206,100 @@ impl Z3660 {
                     vmode_param_name(self.vidmode_param)
                 );
             }
-            REG_BLITTER_DMA_OP => self.log_gfxdata("dma-op", dma_op_name(value), value),
+            REG_BLITTER_DMA_OP => {
+                self.log_gfxdata("dma-op", dma_op_name(value), value);
+                if value == DMA_OP_PAN {
+                    // GFXData: offset[0] = framebuffer start relative to
+                    // MemoryBase, x[1] = row width in pixels.
+                    self.pan_offset = self.be32(GFXDATA_OFFSET);
+                    self.pan_width = u32::from(self.be16(GFXDATA_OFFSET + 0x12));
+                }
+            }
             REG_ACC_OP => self.log_gfxdata("acc-op", acc_op_name(value), value),
             _ => {}
         }
+    }
+
+    /// Whether the board is driving the display: SetSwitch(1) turns video
+    /// capture off (RTG shown); SetSwitch(0) turns it on (the real firmware
+    /// then shows the captured native video, which for the emulator means
+    /// presenting the chipset output as usual).
+    pub fn rtg_active(&self) -> bool {
+        self.mode_set && self.reg_value(REG_OP_CAPTUREMODE) == 0
+    }
+
+    /// Compose the currently displayed RTG frame into `out` as presentation
+    /// pixels (RGBA byte order, alpha opaque), returning (width, height).
+    /// `None` when RTG is not active. Scaled small modes (MODE scalemode
+    /// != 0) compose at framebuffer resolution; the presenter scales.
+    pub fn rtg_frame(&self, out: &mut Vec<u32>) -> Option<(u32, u32)> {
+        if !self.rtg_active() {
+            return None;
+        }
+        let mode = self.reg_value(REG_MODE);
+        let colormode = (mode >> 8) & 0xF;
+        let scaled = (mode >> 12) & 0xF != 0;
+        let orig = self.reg_value(REG_ORIG_RES);
+        let (out_w, out_h) = (orig >> 16, orig & 0xFFFF);
+        let (mut w, mut h) = if scaled {
+            (out_w / 2, out_h / 2)
+        } else {
+            (out_w, out_h)
+        };
+        if self.pan_width != 0 {
+            w = self.pan_width;
+        }
+        w = w.min(4096);
+        h = h.min(4096);
+        if w == 0 || h == 0 {
+            return None;
+        }
+        let bpp: u32 = match colormode {
+            COLORMODE_8BIT => 1,
+            COLORMODE_16BIT565 | COLORMODE_15BIT => 2,
+            COLORMODE_32BIT => 4,
+            _ => return None,
+        };
+        let pitch = (w * bpp) as usize;
+        let base = (VRAM_OFFSET + self.pan_offset) as usize;
+        out.clear();
+        out.reserve((w * h) as usize);
+        for y in 0..h as usize {
+            let row = base + y * pitch;
+            for x in 0..w as usize {
+                let at = row + x * bpp as usize;
+                if at + bpp as usize > self.vram.len() {
+                    out.push(0xFF00_0000);
+                    continue;
+                }
+                let (r, g, b) = match colormode {
+                    COLORMODE_8BIT => {
+                        let rgb = self.palette[self.vram[at] as usize];
+                        ((rgb >> 16) as u8, (rgb >> 8) as u8, rgb as u8)
+                    }
+                    COLORMODE_16BIT565 => {
+                        let v = self.be16(at);
+                        (
+                            ((v >> 11) as u8 & 0x1F) << 3,
+                            ((v >> 5) as u8 & 0x3F) << 2,
+                            (v as u8 & 0x1F) << 3,
+                        )
+                    }
+                    COLORMODE_15BIT => {
+                        let v = self.be16(at);
+                        (
+                            ((v >> 10) as u8 & 0x1F) << 3,
+                            ((v >> 5) as u8 & 0x1F) << 3,
+                            (v as u8 & 0x1F) << 3,
+                        )
+                    }
+                    // 32-bit is BGRA in memory (RTG_COLOR_FORMAT_BGRA).
+                    _ => (self.vram[at + 2], self.vram[at + 1], self.vram[at]),
+                };
+                out.push(0xFF00_0000 | (u32::from(b) << 16) | (u32::from(g) << 8) | u32::from(r));
+            }
+        }
+        Some((w, h))
     }
 }
 
@@ -251,6 +390,10 @@ impl ZorroDevice for Z3660 {
         self.regs.fill(0);
         self.frame_phase = 0;
         self.vidmode_param = 0;
+        self.palette.fill(0);
+        self.pan_offset = 0;
+        self.pan_width = 0;
+        self.mode_set = false;
     }
 
     fn kind(&self) -> &'static str {
@@ -399,5 +542,129 @@ fn reg_name(off: u32) -> &'static str {
         0x30C => "OP_CAPTUREMODE",
         0x318 => "MONITOR_SWITCH",
         _ => "reg",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::Memory;
+
+    fn mem() -> Memory {
+        Memory {
+            chip_ram: vec![0u8; 0x100],
+            slow_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    fn w32(z: &mut Z3660, mem: &mut Memory, off: u32, value: u32) {
+        z.write(off, 4, value, &mut DeviceHost::new(mem));
+    }
+
+    /// The driver's palette upload (SetColorArray): OP_DATA carries
+    /// index<<24|RGB, OP selects the primary or secondary bank.
+    #[test]
+    fn palette_capture_from_op_stream() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        w32(&mut z, &mut m, REG_OP_DATA, (7 << 24) | 0x0012_3456);
+        w32(&mut z, &mut m, REG_OP, ARM_OP_PALETTE);
+        w32(&mut z, &mut m, REG_OP_DATA, (7 << 24) | 0x00AB_CDEF);
+        w32(&mut z, &mut m, REG_OP, ARM_OP_PALETTE_HI);
+        assert_eq!(z.palette[7], 0x0012_3456);
+        assert_eq!(z.palette[256 + 7], 0x00AB_CDEF);
+    }
+
+    /// SetGC + SetSwitch gate the scanout: no frame before a mode is set,
+    /// none when capture mode (native video) is on.
+    #[test]
+    fn rtg_activates_on_mode_set_and_capture_off() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let mut out = Vec::new();
+        assert!(z.rtg_frame(&mut out).is_none());
+        w32(&mut z, &mut m, REG_ORIG_RES, (4 << 16) | 2);
+        w32(&mut z, &mut m, REG_MODE, 0x16); // CUSTOM, 8BIT
+        assert!(z.rtg_active());
+        w32(&mut z, &mut m, REG_OP_CAPTUREMODE, 1);
+        assert!(!z.rtg_active());
+        w32(&mut z, &mut m, REG_OP_CAPTUREMODE, 0);
+        assert!(z.rtg_active());
+    }
+
+    /// An 8-bit frame reads pixels through the captured palette from the
+    /// panned framebuffer start.
+    #[test]
+    fn clut_frame_composes_through_palette() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        w32(&mut z, &mut m, REG_ORIG_RES, (4 << 16) | 2);
+        w32(&mut z, &mut m, REG_MODE, 0x16);
+        w32(&mut z, &mut m, REG_OP_DATA, (1 << 24) | 0x00FF_0000); // index 1 = red
+        w32(&mut z, &mut m, REG_OP, ARM_OP_PALETTE);
+        // Framebuffer at VRAM start: row 0 = 0,1,1,0; row 1 = 1,0,0,1.
+        for (i, px) in [0u8, 1, 1, 0, 1, 0, 0, 1].iter().enumerate() {
+            z.write(
+                VRAM_OFFSET + i as u32,
+                1,
+                u32::from(*px),
+                &mut DeviceHost::new(&mut m),
+            );
+        }
+        let mut out = Vec::new();
+        assert_eq!(z.rtg_frame(&mut out), Some((4, 2)));
+        let red = 0xFF00_0000 | 0x0000_00FF; // RGBA byte order: R in the low byte
+        let black = 0xFF00_0000;
+        assert_eq!(out, vec![black, red, red, black, red, black, black, red]);
+    }
+
+    /// Direct-colour pixel decoding: R5G6B5 and B8G8R8A8, big-endian in VRAM.
+    #[test]
+    fn direct_color_frames_decode() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        w32(&mut z, &mut m, REG_ORIG_RES, (1 << 16) | 1);
+        // 16-bit 565: pure green = 0x07E0.
+        w32(&mut z, &mut m, REG_MODE, 0x16 | (COLORMODE_16BIT565 << 8));
+        z.write(VRAM_OFFSET, 2, 0x07E0, &mut DeviceHost::new(&mut m));
+        let mut out = Vec::new();
+        assert_eq!(z.rtg_frame(&mut out), Some((1, 1)));
+        assert_eq!(out[0], 0xFF00_FC00); // green FC in byte 1
+                                         // 32-bit BGRA: bytes B,G,R,A.
+        w32(&mut z, &mut m, REG_MODE, 0x16 | (COLORMODE_32BIT << 8));
+        z.write(VRAM_OFFSET, 4, 0x2040_80FF, &mut DeviceHost::new(&mut m));
+        assert_eq!(z.rtg_frame(&mut out), Some((1, 1)));
+        assert_eq!(out[0], 0xFF20_4080); // B=0x20 high, G=0x40, R=0x80 low
+    }
+
+    /// The PAN op moves the framebuffer start inside VRAM.
+    #[test]
+    fn pan_offsets_the_framebuffer() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        w32(&mut z, &mut m, REG_ORIG_RES, (1 << 16) | 1);
+        w32(&mut z, &mut m, REG_MODE, 0x16);
+        w32(&mut z, &mut m, REG_OP_DATA, (5 << 24) | 0x00FF_FFFF);
+        w32(&mut z, &mut m, REG_OP, ARM_OP_PALETTE);
+        // GFXData offset[0] = 0x1000, x[1] = 1: pan one page in.
+        z.write(
+            GFXDATA_OFFSET as u32,
+            4,
+            0x1000,
+            &mut DeviceHost::new(&mut m),
+        );
+        z.write(
+            GFXDATA_OFFSET as u32 + 0x12,
+            2,
+            1,
+            &mut DeviceHost::new(&mut m),
+        );
+        w32(&mut z, &mut m, REG_BLITTER_DMA_OP, DMA_OP_PAN);
+        z.write(VRAM_OFFSET + 0x1000, 1, 5, &mut DeviceHost::new(&mut m));
+        let mut out = Vec::new();
+        assert_eq!(z.rtg_frame(&mut out), Some((1, 1)));
+        assert_eq!(out[0], 0xFFFF_FFFF);
     }
 }

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -839,6 +839,10 @@ impl ZorroDevice for Z3660 {
 
     fn reset(&mut self) {
         self.regs.fill(0);
+        // Clear VRAM so a cold boot comes up with zeroed board RAM, like the
+        // rest of the machine (Bus::power_on_reset). A warm reset re-inits
+        // the board and repaints, so clearing here too is harmless.
+        self.vram.fill(0);
         self.frame_phase = 0;
         self.vidmode_param = 0;
         self.palette.fill(0);

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -550,6 +550,10 @@ impl Z3660 {
                     (0, src)
                 };
                 let dpitch = pitch0 * 4;
+                // P2C output is always one chunky byte per pixel;
+                // BlitPlanar2Chunky leaves the mailbox colormode from a prior
+                // op, so it cannot be used for the destination stride here.
+                let dbpp = if op == OP_P2C { 1 } else { bpp };
                 if minterm != MINTERM_SRC_IDX && minterm != MINTERM_NOTSRC {
                     log::debug!("z3660: p2c/p2d minterm {minterm} treated as SRC");
                 }
@@ -573,7 +577,7 @@ impl Z3660 {
                                 pen |= 1 << p;
                             }
                         }
-                        let at = dst + (dyr + y) * dpitch + (dxr + i) * bpp;
+                        let at = dst + (dyr + y) * dpitch + (dxr + i) * dbpp;
                         if op == OP_P2C {
                             self.px_put_masked(at, 1, pen as u32, mask);
                         } else {
@@ -1269,8 +1273,11 @@ mod exec_tests {
         // 0b1100_0000, plane 1 = 0b0100_0000 -> pens 1, 3, 0, 0 ...
         z.vram[v + 0x1000] = 0xC0;
         z.vram[v + 0x1001] = 0x40;
-        // P2C to an 8-bit row at (0,0): minterm SRC (12), depth 2 in
-        // user[1], layer mask 0xFF in user[0], src pitch[1] = 1.
+        // P2C to a chunky row at (0,0): minterm SRC (12), depth 2 in
+        // user[1], layer mask 0xFF in user[0], src pitch[1] = 1. Colormode
+        // is deliberately 16-bit (a stale value from a prior op): P2C output
+        // is one byte per pixel regardless, so the pens must land at
+        // consecutive bytes, not on a 2-byte stride.
         gfxdata(
             &mut z,
             0,
@@ -1281,7 +1288,7 @@ mod exec_tests {
             [0, 0, 1],
             0xFF,
             [4, 1],
-            0,
+            1,
             0,
             0xFF,
             12,

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -487,12 +487,15 @@ impl Z3660 {
                 }
             }
             OP_DRAWLINE => {
-                // From (x[0],y[0]) along the signed deltas (x[1],y[1]);
-                // pattern user[1] rotates per pixel (0xFFFF = solid). JAM2
-                // draws bg where the pattern bit is clear; the COMPLEMENT
-                // bit inverts the destination instead (shell XOR cursor).
+                // Bresenham from (x[0],y[0]) along the signed deltas
+                // (x[1],y[1]), per the P96 DrawLine spec. user[0] is
+                // Line.Length -- authoritative over the delta so a clipped
+                // line segment draws the right pixel count (0 = major-axis
+                // span). The 16-bit pattern (user[1]) rotates one bit per
+                // pixel; JAM2 draws bg on pattern-clear pixels, COMPLEMENT
+                // inverts the destination.
                 let pitch = pitch0 * 4;
-                let (ax, ay) = (
+                let (mut x, mut y) = (
                     i32::from(self.be16(g + 0x10) as i16),
                     i32::from(self.be16(g + 0x18) as i16),
                 );
@@ -500,36 +503,66 @@ impl Z3660 {
                     i32::from(self.be16(g + 0x12) as i16),
                     i32::from(self.be16(g + 0x1A) as i16),
                 );
+                let req_len = self.gfx_u16(0x20, 0);
                 let mut pattern = self.gfx_u16(0x20, 1) as u16;
                 if drawmode & INVERSVID != 0 {
                     pattern ^= 0xFFFF;
                 }
                 let complement = drawmode & COMPLEMENT != 0;
-                let jam2 = !complement && drawmode & 1 != 0;
-                let steps = dx.abs().max(dy.abs());
+                let jam2 = drawmode & 1 != 0;
+                let (dx_abs, dy_abs) = (dx.unsigned_abs() as i32, dy.unsigned_abs() as i32);
+                let x_step = if dx < 0 { -1 } else { 1 };
+                let y_step = if dy < 0 { -1 } else { 1 };
                 let mut cur_bit = 0x8000u16;
-                for i in 0..=steps {
-                    let px = ax + if steps == 0 { 0 } else { dx * i / steps };
-                    let py = ay + if steps == 0 { 0 } else { dy * i / steps };
-                    if px >= 0 && py >= 0 {
-                        let at = dst + py as usize * pitch + px as usize * bpp;
-                        if pattern & cur_bit != 0 {
-                            if complement {
-                                let d = self.px_get(at, bpp);
-                                let v = if bpp == 1 {
-                                    d ^ u32::from(mask)
-                                } else {
-                                    !d & (u32::MAX >> (8 * (4 - bpp)))
-                                };
-                                self.px_put(at, bpp, v);
-                            } else {
-                                self.px_put_masked(at, bpp, rgb0, mask);
-                            }
-                        } else if jam2 {
-                            self.px_put_masked(at, bpp, rgb1, mask);
-                        }
+                let put = |z: &mut Self, x: i32, y: i32, bit: u16| {
+                    if x < 0 || y < 0 {
+                        return;
                     }
-                    cur_bit = cur_bit.rotate_right(1);
+                    if pattern & bit == 0 && !jam2 {
+                        return;
+                    }
+                    let at = dst + y as usize * pitch + x as usize * bpp;
+                    if complement {
+                        let d = z.px_get(at, bpp);
+                        let v = if bpp == 1 {
+                            d ^ u32::from(mask)
+                        } else {
+                            !d & (u32::MAX >> (8 * (4 - bpp)))
+                        };
+                        z.px_put(at, bpp, v);
+                    } else {
+                        let pen = if pattern & bit != 0 { rgb0 } else { rgb1 };
+                        z.px_put_masked(at, bpp, pen, mask);
+                    }
+                };
+                put(self, x, y, cur_bit);
+                cur_bit = cur_bit.rotate_right(1);
+                if dx_abs >= dy_abs {
+                    let len = if req_len != 0 { req_len as i32 } else { dx_abs };
+                    let mut err = dx_abs >> 1;
+                    for _ in 0..len {
+                        err += dy_abs;
+                        if err >= dx_abs {
+                            err -= dx_abs;
+                            y += y_step;
+                        }
+                        x += x_step;
+                        put(self, x, y, cur_bit);
+                        cur_bit = cur_bit.rotate_right(1);
+                    }
+                } else {
+                    let len = if req_len != 0 { req_len as i32 } else { dy_abs };
+                    let mut err = dy_abs >> 1;
+                    for _ in 0..len {
+                        err += dx_abs;
+                        if err >= dy_abs {
+                            err -= dy_abs;
+                            x += x_step;
+                        }
+                        y += y_step;
+                        put(self, x, y, cur_bit);
+                        cur_bit = cur_bit.rotate_right(1);
+                    }
                 }
             }
             OP_P2C | OP_P2D => {
@@ -1265,6 +1298,65 @@ mod exec_tests {
         );
         ring(&mut z, &mut m, 5);
         assert_eq!(&z.vram[v..v + 4], &[3, 9, 3, 9]);
+    }
+
+    #[test]
+    fn drawline_steps_like_bresenham() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        // 8-bit surface, pitch 8 bytes (pitch[0] = 2 longwords). Line from
+        // (0,0) with delta (2,1), pen 5, solid pattern, JAM1. Bresenham on
+        // the major (x) axis puts the second pixel at (1,1) -- not (1,0) as
+        // the old interpolation did.
+        gfxdata(
+            &mut z,
+            0,
+            0,
+            5,
+            0,
+            [0, 2, 0],
+            [0, 1, 0],
+            0,
+            [2, 0],
+            0,
+            0,
+            0xFF,
+            0,
+        );
+        let g = GFXDATA_OFFSET;
+        z.vram[g + 0x22..g + 0x24].copy_from_slice(&0xFFFFu16.to_be_bytes()); // user[1] pattern
+        ring(&mut z, &mut m, 1);
+        assert_eq!(z.vram[v], 5, "(0,0)");
+        assert_eq!(z.vram[v + 8 + 1], 5, "(1,1)");
+        assert_eq!(z.vram[v + 8 + 2], 5, "(2,1)");
+        assert_eq!(z.vram[v + 1], 0, "(1,0) must be untouched");
+    }
+
+    #[test]
+    fn drawline_honors_line_length() {
+        let (mut z, mut m) = (Z3660::new(), mem());
+        let v = VRAM_OFFSET as usize;
+        // Horizontal delta (10,0) but Line.Length (user[0]) = 3, so only
+        // pixels 0..=3 are drawn -- the clipped segment, not the full delta.
+        gfxdata(
+            &mut z,
+            0,
+            0,
+            7,
+            0,
+            [0, 10, 0],
+            [0, 0, 0],
+            3,
+            [4, 0],
+            0,
+            0,
+            0xFF,
+            0,
+        );
+        let g = GFXDATA_OFFSET;
+        z.vram[g + 0x22..g + 0x24].copy_from_slice(&0xFFFFu16.to_be_bytes());
+        ring(&mut z, &mut m, 1);
+        assert_eq!(&z.vram[v..v + 6], &[7, 7, 7, 7, 0, 0]);
     }
 
     /// P2C decodes staged bitplanes to pens; P2D looks the pens up in the

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -176,7 +176,7 @@ impl Z3660 {
         let x: Vec<u16> = (0..4).map(|i| self.be16(g + 0x10 + 2 * i)).collect();
         let y: Vec<u16> = (0..4).map(|i| self.be16(g + 0x18 + 2 * i)).collect();
         let pitch: Vec<u16> = (0..4).map(|i| self.be16(g + 0x28 + 2 * i)).collect();
-        log::info!(
+        log::debug!(
             "z3660: {kind} {op_name} ({op}) dst={:#x} src={:#x} rgb={:#010x}/{:#010x} \
              x={x:?} y={y:?} pitch={pitch:?} colormode={} drawmode={} mask={:#04x} minterm={:#04x}",
             self.be32(g),
@@ -750,7 +750,7 @@ impl ZorroDevice for Z3660 {
             if aligned == REG_VBLANK_STATUS {
                 log::trace!("z3660: read  {} -> {value:#x}", reg_name(aligned));
             } else {
-                log::info!(
+                log::debug!(
                     "z3660: read  {} ({off:#05x},{size}) -> {value:#010x}",
                     reg_name(aligned)
                 );
@@ -779,7 +779,7 @@ impl ZorroDevice for Z3660 {
             let shift = 8 * (4 - (off & 3) as usize - size);
             let mask = (u32::MAX >> (8 * (4 - size))) << shift;
             self.regs[idx] = (self.regs[idx] & !mask) | ((value << shift) & mask);
-            log::info!(
+            log::debug!(
                 "z3660: write {} ({off:#05x},{size}) = {value:#010x}",
                 reg_name(aligned)
             );

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -235,6 +235,25 @@ impl BoardSpec {
         }
     }
 
+    /// The Z3660 accelerator's FPGA RTG core: one 128 MB Zorro III window
+    /// (manufacturer 0x144B, product 1) holding the register file, the P96
+    /// VRAM, and the GFXData mailbox; no autoboot ROM (the Z3660.card
+    /// driver is disk-loaded). `slot` is the index of the matching `Z3660`
+    /// device in `Bus::devices`.
+    pub fn z3660(slot: usize) -> Self {
+        Self {
+            name: "Z3660 RTG".into(),
+            version: ZorroVersion::III,
+            manufacturer: crate::z3660::Z3660_MANUFACTURER_ID,
+            product: crate::z3660::Z3660_PRODUCT,
+            serial: 0,
+            size_bytes: crate::z3660::Z3660_WINDOW_BYTES,
+            backing: BoardBacking::Device(slot),
+            memlist: false,
+            diag_vec: None,
+        }
+    }
+
     fn validate(&self) -> Result<()> {
         match self.version {
             ZorroVersion::II => {

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -334,6 +334,7 @@ pub enum BoardDevice {
     // Appended last: bincode encodes variants by index, so inserting
     // anywhere else would break save states holding the boards above.
     Filesys(crate::filesys::FilesysBoard),
+    Z3660(crate::z3660::Z3660),
 }
 
 impl ZorroDevice for BoardDevice {
@@ -345,6 +346,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::read(d, off, size, host),
             BoardDevice::Filesys(d) => ZorroDevice::read(d, off, size, host),
+            BoardDevice::Z3660(d) => ZorroDevice::read(d, off, size, host),
         }
     }
 
@@ -356,6 +358,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::Filesys(d) => ZorroDevice::write(d, off, size, value, host),
+            BoardDevice::Z3660(d) => ZorroDevice::write(d, off, size, value, host),
         }
     }
 
@@ -367,6 +370,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::peek_word(d, off),
             BoardDevice::Filesys(d) => ZorroDevice::peek_word(d, off),
+            BoardDevice::Z3660(d) => ZorroDevice::peek_word(d, off),
         }
     }
 
@@ -378,6 +382,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::tick(d, cck, host),
             BoardDevice::Filesys(d) => ZorroDevice::tick(d, cck, host),
+            BoardDevice::Z3660(d) => ZorroDevice::tick(d, cck, host),
         }
     }
 
@@ -389,6 +394,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::int2_line(d),
             BoardDevice::Filesys(d) => ZorroDevice::int2_line(d),
+            BoardDevice::Z3660(d) => ZorroDevice::int2_line(d),
         }
     }
 
@@ -400,6 +406,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::int6_line(d),
             BoardDevice::Filesys(d) => ZorroDevice::int6_line(d),
+            BoardDevice::Z3660(d) => ZorroDevice::int6_line(d),
         }
     }
 
@@ -411,6 +418,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::is_idle(d),
             BoardDevice::Filesys(d) => ZorroDevice::is_idle(d),
+            BoardDevice::Z3660(d) => ZorroDevice::is_idle(d),
         }
     }
 
@@ -422,6 +430,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::next_event_cck(d),
             BoardDevice::Filesys(d) => ZorroDevice::next_event_cck(d),
+            BoardDevice::Z3660(d) => ZorroDevice::next_event_cck(d),
         }
     }
 
@@ -433,6 +442,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::take_activity(d),
             BoardDevice::Filesys(d) => ZorroDevice::take_activity(d),
+            BoardDevice::Z3660(d) => ZorroDevice::take_activity(d),
         }
     }
 
@@ -444,6 +454,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::reset(d),
             BoardDevice::Filesys(d) => ZorroDevice::reset(d),
+            BoardDevice::Z3660(d) => ZorroDevice::reset(d),
         }
     }
 
@@ -455,6 +466,7 @@ impl ZorroDevice for BoardDevice {
             #[cfg(feature = "wasm-boards")]
             BoardDevice::Wasm(d) => ZorroDevice::kind(d),
             BoardDevice::Filesys(d) => ZorroDevice::kind(d),
+            BoardDevice::Z3660(d) => ZorroDevice::kind(d),
         }
     }
 }


### PR DESCRIPTION
<img width="1528" height="1301" alt="Image" src="https://github.com/user-attachments/assets/164e0b3c-5c11-4bb1-ac6e-bd816f5a0129" />

## Summary

Emulates the Z3660 accelerator's FPGA RTG core as a Zorro III autoconfig
board (manufacturer 0x144B, product 1, one 128 MB window), driven by the
unmodified open-source Z3660.card Picasso96 driver. Workbench runs on
Z3660 screen modes in 8/16/32-bit with a working mouse pointer, and the
display switches cleanly between the native chipset and the RTG
framebuffer.

First RTG board for #19. The ZZ9000 (largely register-compatible with
this board) and a Copperline-native card discoverable by the bundled
AROS ROM's p96gfx HIDD are natural follow-ups on the same
infrastructure.

Enabled with:

```toml
[z3660]
enabled = true
```

## What is emulated

- Autoconfig identity and the 32-bit register file at window offsets
  0x100-0x7FF. Every register access and mailbox op is logged by name,
  so the board doubles as a driver-development rig.
- FindCard/InitCard probes: FW_VERSION (reports v1.06), INT_STATUS,
  MONITOR_SWITCH (0 = no CIA display-switch fiddling).
- VBLANK_STATUS follows a 60 Hz frame phase in emulated colour clocks,
  so WaitVerticalSync/GetVSyncState behave like hardware.
- SetGC/SetPanning: custom modelines (CUSTOM_VIDMODE parameter pairs),
  MODE (vmode/colormode/scalemode), ORIG_RES, and the PAN op.
- Scanout: the panned VRAM framebuffer is composed in all four pixel
  formats (CLUT through the captured palette, R5G6B5, R5G5B5,
  B8G8R8A8) and presented by the window and the CCP capture path;
  OP_CAPTUREMODE switches back to native chipset output.
- The GFXData mailbox blitter ops, executed synchronously on the
  doorbell write as the bus-stalling hardware does: FILLRECT, COPYRECT
  (overlap-safe, 8-bit plane mask), COPYRECT_NOMASK, INVERTRECT,
  RECT_TEMPLATE and RECT_PATTERN (JAM1/JAM2/COMPLEMENT + INVERSVID),
  DRAWLINE (patterned, with the COMPLEMENT XOR mode the shell cursor
  uses), and the planar P2C/P2D blits that render icons and window
  gadget imagery.
- The hardware sprite: the mouse pointer image, colours, and position
  ride the sprite ops and are composited over the output at present
  time, never touching VRAM -- like the real output-stage overlay.

Semantics follow the board's ARM firmware (z3660-firmware, GPL-3.0
like Copperline), including its quirks: the GFXData pitch field is
longwords for fill/copy/invert/line but raw bytes for
template/pattern, colours ride in guest byte order (the little-endian
ARM reads the 68k values byteswapped), and minterms are the firmware's
0-15 enum, not raw blitter bytes.

Not implemented yet (logged when hit): the ACC_OP surface ops, exotic
minterms, screen-split, overlays, and the video-capture path. RTG
frames are currently scaled into the Amiga-sized presentation texture;
pixel-perfect presentation is a follow-up.

## Test plan

- Unit tests for the register latch, palette capture, scanout in all
  pixel formats, pan, each blit-op family, the planar decodes, and the
  sprite compositing cycle (show/upload/colour/move/hide).
- Live: Workbench 3.2 on Z3660:800x600 and 1920x1200 modes in 8, 16,
  and 32-bit with the real Z3660.card 1.06 built from source; window
  dragging, shell text and cursor, icons, and gadget imagery render;
  ScreenMode test-cycle and DISPLAYCHAIN=YES switch RTG <-> AGA both
  ways. Headless: deterministic boots driving the driver via the
  serial shell with CCP screenshots.
- cargo test (1593), clippy, fmt clean.

Generated with [Claude Code](https://claude.com/claude-code)

