### PR TITLE
Add SCSI CD-ROM drives with CD audio and runtime disc swap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ repeat.
 | `--mouse-after SECS DX DY [PORT]` | Relative mouse motion (default port 1) |
 | `--pot-after SECS X Y [PORT]` | Analogue stick/paddle position, 0-255 per axis (default port 2) |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
+| `--insert-cd-after SECS PATH` | Swap the CD image in the machine's CD drive (CDTV/CD32/SCSI CD-ROM) |
 | `--script FILE` | Same directives from a file, one per line, no leading dashes |
 | `--record-input PATH` | Record all machine-bound input as a replayable script |
 

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -214,7 +214,9 @@ slow = "512K"
 # same images as [ide]: RDB HDFs, bare partition hardfiles, or host
 # directories. A path ending in .cue or .iso attaches a SCSI CD-ROM drive
 # at that ID instead (read-only; mount it in the guest with a CD filesystem
-# pointed at the controller's scsi.device and that unit number).
+# pointed at the controller's scsi.device and that unit number). CD audio
+# tracks play through the machine's audio output, and discs swap at runtime
+# (status-bar CD buttons, drag-and-drop, --insert-cd-after).
 #
 # controller picks the host adapter:
 #   "a2091" - Zorro II, WD33C93. The default on machines without onboard SCSI.

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -212,7 +212,9 @@ slow = "512K"
 # autoboots on Kickstart 1.3+, so it does not depend on the Kickstart IDE
 # driver (which only probes the master on stock 3.1). Drive paths accept the
 # same images as [ide]: RDB HDFs, bare partition hardfiles, or host
-# directories.
+# directories. A path ending in .cue or .iso attaches a SCSI CD-ROM drive
+# at that ID instead (read-only; mount it in the guest with a CD filesystem
+# pointed at the controller's scsi.device and that unit number).
 #
 # controller picks the host adapter:
 #   "a2091" - Zorro II, WD33C93. The default on machines without onboard SCSI.
@@ -228,6 +230,7 @@ slow = "512K"
 # rom = "a2091-v6.6.rom"
 # unit0 = "workbench.hdf"
 # unit1 = "data.hdf"
+# unit2 = "game.cue"
 
 
 [chipset]

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -94,13 +94,15 @@ line is highlighted while a channel is actively streaming samples.
 
 Each channel row also has a **Mute** button on the left and an oscilloscope on
 the right; a fifth row at the bottom does the same for the **CD-DA** audio
-stream (CDTV/CD32). The oscilloscope traces the channel's output level (the DAC
-sample scaled by AUDxVOL), so both the waveform and its loudness are visible;
-the CD scope traces the mixed CD stereo level. Clicking **Mute** silences that
-channel (or the CD stream) in the host output while leaving its trace drawn
-(greyed) so you can still see what it would play. Mutes are developer aids:
-they change only the audio you hear, never the emulated Paula state, and are
-not part of a save state.
+stream (CDTV, CD32, or a SCSI CD-ROM unit). The oscilloscope traces the
+channel's output level (the DAC sample scaled by AUDxVOL), so both the
+waveform and its loudness are visible; the CD scope traces the mixed CD stereo
+level, and when the machine's CD drive is a SCSI CD-ROM unit the row's status
+line reports its play operation (playing/paused/done, track, and MSF
+position). Clicking **Mute** silences that channel (or the CD stream) in the
+host output while leaving its trace drawn (greyed) so you can still see what
+it would play. Mutes are developer aids: they change only the audio you hear,
+never the emulated Paula state, and are not part of a save state.
 
 **Memory** is a hex/ASCII dump, 256 bytes per page. Type a hex address in
 the `$` box and press Enter to jump there; the `<` and `>` buttons page by

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -647,6 +647,10 @@ appears in the status bar on IDE machines. On the `A4000` profile the same
 `$DD2020` (no Gayle involved; Kickstart's `scsi.device` drives it the same
 way).
 
+CD images (`.cue`/`.iso`) are rejected here: the emulated IDE port speaks
+plain ATA, not ATAPI. Attach CD-ROM drives as `[scsi]` units instead (see
+below).
+
 ## `[scsi]` -- SCSI controllers
 
 ```toml
@@ -656,7 +660,8 @@ rom = "a2091-v6.6.rom"       # boot ROM image (a2091/a4091; the a3000 needs none
 # rom_odd = "a2091-odd.rom"  # a2091 only: split even/odd EPROM dumps
 unit0 = "workbench.hdf"      # SCSI IDs 0-6
 unit1 = "data.hdf"
-# unit2..unit6 = ...
+unit2 = "game.cue"           # a .cue or .iso attaches a CD-ROM drive
+# unit3..unit6 = ...
 ```
 
 The `[scsi]` section attaches a SCSI host adapter with up to **seven
@@ -693,6 +698,21 @@ partition, named after the SCSI ID), and host directories built into
 in-memory FFS volumes -- including the `{ path = "...", name = "..." }`
 table form that overrides a directory mount's volume name. The HDD
 activity LED covers SCSI traffic too.
+
+A `unitN` path ending in `.cue` or `.iso` attaches a **SCSI CD-ROM
+drive** at that ID instead of a hard disk: a read-only removable SCSI-2
+target (INQUIRY device type 5) serving 2048-byte blocks, with the full
+READ TOC / READ CD / mode-page surface CD filesystems expect. Cue/bin
+images may mix data and audio tracks; a bare `.iso` is a single data
+track. The drive answers on the host adapter's `scsi.device` like any
+other unit, so mount it the way you would on real hardware: a
+`DOSDrivers` mount entry (or MountList) pointing `CDFileSystem` --
+CacheCDFS, AsimCDFS, and AmiCDROM work the same way -- at the controller's
+`scsi.device` and the drive's unit number. CD *data* is fully served;
+CD *audio* commands keep coherent play/status state for player software
+but produce no sound, matching a drive whose analogue audio output is
+simply not cabled to anything. The disc cannot be swapped at runtime;
+changing discs is a config change and restart.
 
 ## `[[filesys]]` -- host directories as live volumes
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -708,11 +708,19 @@ track. The drive answers on the host adapter's `scsi.device` like any
 other unit, so mount it the way you would on real hardware: a
 `DOSDrivers` mount entry (or MountList) pointing `CDFileSystem` --
 CacheCDFS, AsimCDFS, and AmiCDROM work the same way -- at the controller's
-`scsi.device` and the drive's unit number. CD *data* is fully served;
-CD *audio* commands keep coherent play/status state for player software
-but produce no sound, matching a drive whose analogue audio output is
-simply not cabled to anything. The disc cannot be swapped at runtime;
-changing discs is a config change and restart.
+`scsi.device` and the drive's unit number.
+
+CD audio plays: the PLAY AUDIO command group streams the disc's audio
+tracks into the machine's audio output at 75 sectors per second of
+emulated time (as if the drive's analogue output were cabled to the
+machine), the sub-channel reports the live playback position, and the
+debugger's Audio tab shows the stream on its CD-DA row with the play
+state, track, and position. Discs swap at runtime like CDTV/CD32 media:
+the status bar's CD load/eject buttons, dropping a `.cue`/`.iso` on the
+window, the scheduled `--insert-cd-after SECS PATH` flag, or the control
+protocol's `media.cd.insert` all eject the current disc, run the tray
+for a second of emulated time, and mount the new one with a
+medium-change unit attention for the guest's filesystem to notice.
 
 ## `[[filesys]]` -- host directories as live volumes
 

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -74,6 +74,7 @@ deterministically:
 | `--floppy-drives COUNT` | Connect `COUNT` floppy drives (`1` to `4`), so scheduled inserts can target empty external drives |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--defer-disk-insert SECS DFN` | Start with the configured drive empty, then insert its configured image |
+| `--insert-cd-after SECS PATH` | Swap the CD image (`.cue`/`.iso`) in the machine's CD drive (CDTV, CD32, or a SCSI CD-ROM unit) |
 | `--script FILE` | Run scripted-input directives from a file (below) |
 | `--record-input PATH` | Record all machine-bound input for the whole run; the script is written to PATH on exit |
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -49,7 +49,9 @@ The status bar (44 pixels below the display) holds, left to right:
 - **LED block.** PWR and FDD always; a green HDD activity LED on machines
   with a hard-disk controller (Gayle or A4000 IDE, or any SCSI adapter); a
   blue CD activity LED on CDTV/CD32 that lights while the drive reads data
-  or plays CD audio. A small digital counter shows the current floppy
+  or plays CD audio (on a machine whose CD drive is a SCSI CD-ROM unit,
+  the LED shows CD-DA playback; its data reads ride the HDD LED with the
+  rest of the SCSI bus). A small digital counter shows the current floppy
   track.
 - **Per-drive floppy controls.** Every connected drive gets a disk button
   (marked with the drive number) that opens a file dialog -- multi-select
@@ -57,9 +59,10 @@ The status bar (44 pixels below the display) holds, left to right:
   button that cycles to the next queued disk and an eject button. Swap and
   eject grey out when there is nothing to swap to or eject. With three or
   four drives the clusters stack two-up.
-- **CD controls** on CDTV/CD32 machines: a CD button that loads (or swaps)
-  a cue sheet with the proper media-change notification, and a CD eject
-  button. These do not appear on machines without a CD drive.
+- **CD controls** on machines with a CD drive (CDTV, CD32, or a SCSI
+  CD-ROM unit): a CD button that loads (or swaps) a CD image
+  (`.cue`/`.iso`) with the proper media-change notification, and a CD
+  eject button. These do not appear on machines without a CD drive.
 - **Joystick toggle** (just left of the volume control): a gamepad or
   keyboard icon showing which source drives the joystick port. Click it to
   flip between gamepad-only and keyboard joystick emulation; see
@@ -82,8 +85,8 @@ Disk images can be dropped anywhere on the emulator window:
   (`1`-`4`), or press `Esc` to cancel. Dropping several floppies at once
   queues them all as the target drive's swap playlist, exactly like a
   multi-selection in the disk dialog.
-- **Cue sheets** (`.cue`) mount in the CD drive on CDTV/CD32 machines,
-  with the media-change notification.
+- **CD images** (`.cue`/`.iso`) mount in the machine's CD drive (CDTV,
+  CD32, or a SCSI CD-ROM unit), with the media-change notification.
 - **Hard disk images and Kickstart ROMs** cannot be swapped at runtime; a
   notice points at the machine-configuration screen, which also refuses
   drops while it is open.

--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -119,6 +119,16 @@ impl A2091 {
         self.wd.attach_target(unit, target);
     }
 
+    /// The lowest-ID CD-ROM drive on the board's bus, when one is attached.
+    pub fn first_cd(&self) -> Option<&crate::scsi::ScsiCdRom> {
+        self.wd.first_cd()
+    }
+
+    /// Mutable view of the lowest-ID CD-ROM drive on the board's bus.
+    pub fn first_cd_mut(&mut self) -> Option<&mut crate::scsi::ScsiCdRom> {
+        self.wd.first_cd_mut()
+    }
+
     /// System reset: clear the DMAC and SBIC but keep the mounted drives.
     pub fn reset(&mut self) {
         self.wd.reset();
@@ -385,7 +395,12 @@ impl crate::zorro_device::ZorroDevice for A2091 {
     }
 
     fn tick(&mut self, cck: u32, host: &mut crate::zorro_device::DeviceHost) {
-        Self::tick(self, cck, host.memory_mut())
+        Self::tick(self, cck, host.memory_mut());
+        // A CD-ROM target streams its CD-DA playback into the host mixer
+        // ring, which the bus tick loop provides.
+        if let Some(cd_audio) = host.cd_audio_opt() {
+            self.wd.tick_targets(cck, cd_audio);
+        }
     }
 
     fn int2_line(&self) -> bool {

--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -26,7 +26,7 @@
 //! bus for cycle-accurate transfer timing.
 
 use crate::memory::Memory;
-use crate::scsi::{DmaDir, ScsiDisk, Wd33c93};
+use crate::scsi::{DmaDir, ScsiTarget, Wd33c93};
 use anyhow::{bail, Result};
 use std::path::Path;
 
@@ -115,8 +115,8 @@ impl A2091 {
         Ok(merged)
     }
 
-    pub fn attach_drive(&mut self, unit: usize, disk: ScsiDisk) {
-        self.wd.attach_target(unit, disk);
+    pub fn attach_drive(&mut self, unit: usize, target: impl Into<ScsiTarget>) {
+        self.wd.attach_target(unit, target);
     }
 
     /// System reset: clear the DMAC and SBIC but keep the mounted drives.

--- a/src/a4091.rs
+++ b/src/a4091.rs
@@ -262,6 +262,19 @@ impl A4091 {
         }
     }
 
+    /// The lowest-ID CD-ROM drive on the board's bus, when one is attached.
+    pub fn first_cd(&self) -> Option<&crate::scsi::ScsiCdRom> {
+        self.targets.iter().flatten().find_map(ScsiTarget::cd_ref)
+    }
+
+    /// Mutable view of the lowest-ID CD-ROM drive on the board's bus.
+    pub fn first_cd_mut(&mut self) -> Option<&mut crate::scsi::ScsiCdRom> {
+        self.targets
+            .iter_mut()
+            .flatten()
+            .find_map(ScsiTarget::cd_mut)
+    }
+
     /// Whether a target answers at the given SCSI ID.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn target_present(&self, id: usize) -> bool {
@@ -943,10 +956,32 @@ impl crate::zorro_device::ZorroDevice for A4091 {
         }
     }
 
-    fn tick(&mut self, _cck: u32, _host: &mut crate::zorro_device::DeviceHost) {}
+    fn tick(&mut self, cck: u32, host: &mut crate::zorro_device::DeviceHost) {
+        // The chip itself completes everything within the SCRIPTS run; only
+        // the targets carry emulated-time state (a CD-ROM drive's tray
+        // countdown and CD-DA streaming into the host mixer ring).
+        if let Some(cd_audio) = host.cd_audio_opt() {
+            for target in self.targets.iter_mut().flatten() {
+                if let ScsiTarget::CdRom(cd) = target {
+                    cd.tick(cck, cd_audio);
+                }
+            }
+        }
+    }
 
     fn int2_line(&self) -> bool {
         self.irq_line()
+    }
+
+    // The 53C710 model completes its work within each SCRIPTS run, but a
+    // CD-ROM target with playback or a tray load in flight needs its tick.
+    fn is_idle(&self) -> bool {
+        !self
+            .targets
+            .iter()
+            .flatten()
+            .filter_map(ScsiTarget::cd_ref)
+            .any(crate::scsi::ScsiCdRom::needs_tick)
     }
 
     fn reset(&mut self) {

--- a/src/a4091.rs
+++ b/src/a4091.rs
@@ -26,7 +26,7 @@
 //! the same nibbles are also baked into the first `$60` bytes of the real
 //! EPROM, which is how the physical board presents them.
 
-use crate::scsi::{ScsiDisk, ScsiExec};
+use crate::scsi::{ScsiExec, ScsiTarget};
 use anyhow::{bail, Result};
 use std::collections::VecDeque;
 use std::path::Path;
@@ -210,10 +210,10 @@ pub struct A4091 {
     /// The SCSI FIFO: 8 entries, 8 data bits plus parity. SODL pushes it
     /// (with CTEST4.SFWR), CTEST3 pops it, SSTAT2 counts it.
     scsi_fifo: Vec<u16>,
-    /// SCSI-2 disk targets on the bus, indexed by SCSI ID (0-6; 7 is the
-    /// host adapter). Kept across resets; part of save state.
+    /// SCSI-2 targets (disks and CD-ROMs) on the bus, indexed by SCSI ID
+    /// (0-6; 7 is the host adapter). Kept across resets; part of save state.
     #[serde(default)]
-    targets: [Option<ScsiDisk>; 7],
+    targets: [Option<ScsiTarget>; 7],
     /// The live nexus while a SCRIPTS command is in flight. Rebuilt as the
     /// driver reissues commands, so it is not persisted.
     #[serde(skip)]
@@ -255,10 +255,10 @@ impl A4091 {
         })
     }
 
-    /// Attach a disk target at the given SCSI ID (0-6).
-    pub fn attach_drive(&mut self, id: usize, disk: ScsiDisk) {
+    /// Attach a target at the given SCSI ID (0-6).
+    pub fn attach_drive(&mut self, id: usize, target: impl Into<ScsiTarget>) {
         if id < self.targets.len() {
-            self.targets[id] = Some(disk);
+            self.targets[id] = Some(target.into());
         }
     }
 
@@ -531,7 +531,7 @@ impl A4091 {
             c.cdb = cdb.to_vec();
         }
         let (exec, status) = match self.targets[target].as_mut() {
-            Some(disk) => disk.execute(cdb, lun),
+            Some(dev) => dev.execute(cdb, lun),
             None => (ScsiExec::NoData, 0x02),
         };
         let Some(conn) = self.conn.as_mut() else {
@@ -567,7 +567,7 @@ impl A4091 {
             return;
         };
         let status = match self.targets[target].as_mut() {
-            Some(disk) => disk.complete_out(&cdb, &data),
+            Some(dev) => dev.complete_out(&cdb, &data),
             None => 0x02,
         };
         if let Some(conn) = self.conn.as_mut() {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3098,14 +3098,61 @@ impl Bus {
                 .cdtv
                 .as_ref()
                 .map(|cdtv| cdtv.activity_led_on())
-                .or_else(|| self.akiko.as_ref().map(|akiko| akiko.activity_led_on())),
+                .or_else(|| self.akiko.as_ref().map(|akiko| akiko.activity_led_on()))
+                // A SCSI CD-ROM's data traffic rides the HDD LED with the
+                // rest of the bus; its own LED shows CD-DA playback (and
+                // brings the status-bar eject button with it).
+                .or_else(|| {
+                    self.scsi_cd_ref()
+                        .map(crate::scsi::ScsiCdRom::audio_playing)
+                }),
             output_volume_percent: self.paula.output_volume_percent(),
         }
     }
 
-    /// Whether the machine has a CD drive (CDTV DMAC or CD32 Akiko).
+    /// Whether the machine has a CD drive: the CDTV DMAC, the CD32 Akiko,
+    /// or a CD-ROM target on a SCSI bus.
     pub fn cd_drive_present(&self) -> bool {
-        self.cdtv.is_some() || self.akiko.is_some()
+        self.cdtv.is_some() || self.akiko.is_some() || self.scsi_cd_ref().is_some()
+    }
+
+    /// The first SCSI CD-ROM drive across the machine's SCSI buses (the
+    /// A3000 motherboard SCSI, then the Zorro boards), when one is fitted.
+    pub fn scsi_cd_ref(&self) -> Option<&crate::scsi::ScsiCdRom> {
+        if let Some(cd) = self.sdmac.as_ref().and_then(crate::sdmac::Sdmac::first_cd) {
+            return Some(cd);
+        }
+        self.devices.iter().find_map(|dev| match dev {
+            crate::zorro_device::BoardDevice::A2091(board) => board.first_cd(),
+            crate::zorro_device::BoardDevice::A4091(board) => board.first_cd(),
+            _ => None,
+        })
+    }
+
+    /// Mutable view of the first SCSI CD-ROM drive; the disc-swap target.
+    pub fn scsi_cd_mut(&mut self) -> Option<&mut crate::scsi::ScsiCdRom> {
+        if self
+            .sdmac
+            .as_ref()
+            .is_some_and(|sdmac| sdmac.first_cd().is_some())
+        {
+            return self
+                .sdmac
+                .as_mut()
+                .and_then(crate::sdmac::Sdmac::first_cd_mut);
+        }
+        self.devices.iter_mut().find_map(|dev| match dev {
+            crate::zorro_device::BoardDevice::A2091(board) => board.first_cd_mut(),
+            crate::zorro_device::BoardDevice::A4091(board) => board.first_cd_mut(),
+            _ => None,
+        })
+    }
+
+    /// The SCSI CD-ROM drive's playback status line for the debugger's
+    /// audio tab, when a drive is present and a play operation has state.
+    pub fn scsi_cd_playback_line(&self) -> Option<String> {
+        self.scsi_cd_ref()
+            .and_then(crate::scsi::ScsiCdRom::playback_line)
     }
 
     /// Whether the machine has a hard-disk controller, which is what gives it
@@ -3121,17 +3168,22 @@ impl Bus {
             })
     }
 
-    /// Whether a disc is mounted (or, on CDTV, waiting in the tray).
+    /// Whether a disc is mounted (or waiting in the tray).
     pub fn cd_disc_inserted(&self) -> bool {
         self.cdtv.as_ref().is_some_and(|cdtv| cdtv.has_disc())
             || self.akiko.as_ref().is_some_and(|akiko| akiko.has_disc())
+            || self
+                .scsi_cd_ref()
+                .is_some_and(crate::scsi::ScsiCdRom::has_disc)
     }
 
     /// Runtime disc insert with media-change notification. On CDTV the
     /// disc lands after a short tray delay (the same media-change STCH
     /// path as `[cd] insert_delay`); Akiko mounts immediately and
-    /// volunteers a media-status packet.
-    pub fn cd_insert_disc(&mut self, image: crate::cdrom::CdImage) {
+    /// volunteers a media-status packet; a SCSI CD-ROM mounts after its
+    /// tray delay and raises a medium-change unit attention. `path` names
+    /// the image for the SCSI drive's logs.
+    pub fn cd_insert_disc(&mut self, image: crate::cdrom::CdImage, path: &std::path::Path) {
         // A second or so of tray time keeps the eject and insert
         // media-change interrupts distinct for cdtv.device.
         const CDTV_TRAY_SECS: f64 = 1.0;
@@ -3143,6 +3195,8 @@ impl Bus {
             // after a delay (media-present), so cd.device sees the
             // absent->present change instead of an instantaneous swap.
             akiko.insert_disc_after(image, CDTV_TRAY_SECS);
+        } else if let Some(cd) = self.scsi_cd_mut() {
+            cd.swap_disc(image, path);
         }
     }
 
@@ -3152,6 +3206,8 @@ impl Bus {
             cdtv.eject_disc();
         } else if let Some(akiko) = self.akiko.as_mut() {
             akiko.eject_disc();
+        } else if let Some(cd) = self.scsi_cd_mut() {
+            cd.eject();
         }
     }
 
@@ -4257,7 +4313,7 @@ impl Bus {
                 sdmac, mem, paula, ..
             } = self;
             if let Some(sdmac) = sdmac.as_mut() {
-                sdmac.tick(cck, mem);
+                sdmac.tick(cck, mem, paula.cd_audio_mut());
                 if sdmac.int_line() {
                     paula.intreq |= INT_PORTS;
                 }
@@ -4299,7 +4355,11 @@ impl Bus {
                 ..
             } = self;
             for (slot, dev) in devices.iter_mut().enumerate() {
-                let mut host = crate::zorro_device::DeviceHost::for_slot(&mut *mem, slot);
+                let mut host = crate::zorro_device::DeviceHost::for_slot_with_cd_audio(
+                    &mut *mem,
+                    slot,
+                    paula.cd_audio_mut(),
+                );
                 crate::zorro_device::ZorroDevice::tick(dev, cck, &mut host);
                 if crate::zorro_device::ZorroDevice::int2_line(dev) {
                     paula.intreq |= INT_PORTS;

--- a/src/cdrom.rs
+++ b/src/cdrom.rs
@@ -6,7 +6,9 @@
 //! MODE1/2352, and AUDIO tracks, including INDEX 00 pregaps stored in
 //! the files. INDEX times are file-relative running time at 75 sectors
 //! per second regardless of each track's sector size; the disc address
-//! space is the concatenation of all files in cue order.
+//! space is the concatenation of all files in cue order. A bare `.iso`
+//! image (2048-byte cooked data sectors, no cue sheet) loads as a
+//! single-track data disc.
 
 use anyhow::{bail, Context, Result};
 use std::fs::File;
@@ -129,8 +131,58 @@ struct RawTrack {
 }
 
 impl CdImage {
+    /// Load a CD image: a cue sheet (with its BINARY file(s)), or a bare
+    /// `.iso` data image.
+    pub fn load(path: &Path) -> Result<Self> {
+        let is_iso = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("iso"));
+        if is_iso {
+            Self::load_iso(path)
+        } else {
+            Self::load_cue(path)
+        }
+    }
+
+    /// Load a bare data image as one MODE1/2048 track.
+    fn load_iso(path: &Path) -> Result<Self> {
+        let file =
+            File::open(path).with_context(|| format!("opening CD image {}", path.display()))?;
+        let len = file
+            .metadata()
+            .with_context(|| format!("stat {}", path.display()))?
+            .len();
+        if len == 0 || !len.is_multiple_of(DATA_SECTOR_BYTES as u64) {
+            bail!(
+                "{}: {len} bytes is not a whole number of 2048-byte data sectors",
+                path.display()
+            );
+        }
+        let sectors = (len / DATA_SECTOR_BYTES as u64) as u32;
+        Ok(Self {
+            files: vec![file],
+            paths: vec![path.to_path_buf()],
+            tracks: vec![CdTrack {
+                number: 1,
+                kind: TrackKind::Mode1_2048,
+                start_sector: 0,
+                sector_count: sectors,
+            }],
+            extents: vec![Extent {
+                disc_start: 0,
+                sector_count: sectors,
+                sector_bytes: DATA_SECTOR_BYTES,
+                file_index: 0,
+                byte_offset: 0,
+                kind: TrackKind::Mode1_2048,
+            }],
+            total_sectors: sectors,
+        })
+    }
+
     /// Load a cue sheet and open its BINARY image file(s).
-    pub fn load(cue_path: &Path) -> Result<Self> {
+    fn load_cue(cue_path: &Path) -> Result<Self> {
         let text = std::fs::read_to_string(cue_path)
             .with_context(|| format!("reading cue sheet {}", cue_path.display()))?;
         let dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
@@ -702,6 +754,34 @@ mod tests {
         );
         let _ = std::fs::remove_file(&cue);
         let _ = std::fs::remove_file(&bin);
+    }
+
+    #[test]
+    fn bare_iso_loads_as_single_data_track() {
+        let iso = temp_path("plain.iso");
+        let mut bytes = Vec::new();
+        for s in 0..3u8 {
+            bytes.extend(std::iter::repeat_n(s, DATA_SECTOR_BYTES));
+        }
+        write_file(&iso, &bytes);
+        let mut image = CdImage::load(&iso).unwrap();
+        assert_eq!(image.tracks().len(), 1);
+        assert_eq!(image.tracks()[0].kind, TrackKind::Mode1_2048);
+        assert_eq!(image.total_sectors(), 3);
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        image.read_data_sector(2, &mut data).unwrap();
+        assert!(data.iter().all(|&b| b == 2));
+        assert!(!image.is_audio_sector(0));
+        let _ = std::fs::remove_file(&iso);
+    }
+
+    #[test]
+    fn iso_with_partial_sector_is_rejected() {
+        let iso = temp_path("ragged.iso");
+        write_file(&iso, &vec![0u8; DATA_SECTOR_BYTES + 100]);
+        let err = CdImage::load(&iso).unwrap_err();
+        assert!(err.to_string().contains("2048-byte"), "{err:#}");
+        let _ = std::fs::remove_file(&iso);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -335,6 +335,16 @@ pub struct DriveImage {
     pub volume_name: Option<String>,
 }
 
+/// Whether a drive-image path names a CD image (a cue sheet or a bare ISO).
+/// On the SCSI bus such an entry attaches a CD-ROM drive instead of a hard
+/// disk; the file extension is the format signal, exactly as it is for the
+/// hard-drive back ends (HDF vs. directory).
+pub fn is_cd_image_path(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("cue") || e.eq_ignore_ascii_case("iso"))
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IdeConfig {
     pub master: Option<DriveImage>,
@@ -2095,6 +2105,17 @@ impl TryFrom<RawConfig> for Config {
                 "[ide] images need a machine with an IDE port: set [machine] profile = \"A600\" \
                  (or A1200, or A4000)"
             ));
+        }
+        // The IDE interfaces speak plain ATA, not ATAPI: a CD image on the
+        // cable would be served as a garbage hard disk.
+        for drive in [&ide.master, &ide.slave].into_iter().flatten() {
+            if is_cd_image_path(&drive.path) {
+                errors.push(anyhow!(
+                    "[ide] {}: CD images attach a CD-ROM drive on the SCSI bus \
+                     ([scsi] unit0..unit6); the IDE port has no ATAPI support",
+                    drive.path.display()
+                ));
+            }
         }
 
         let scsi_controller = match raw.scsi.controller.as_deref() {
@@ -4252,6 +4273,42 @@ mod tests {
             "#,
         )?;
         assert!(cfg.scsi.enabled());
+        Ok(())
+    }
+
+    /// CD images (cue sheets and bare ISOs) are recognised by extension:
+    /// they attach as SCSI CD-ROM drives, and the ATA-only IDE port
+    /// rejects them.
+    #[test]
+    fn cd_images_fit_scsi_units_but_not_the_ide_port() -> Result<()> {
+        assert!(is_cd_image_path(Path::new("games/Disc.CUE")));
+        assert!(is_cd_image_path(Path::new("cd32.iso")));
+        assert!(!is_cd_image_path(Path::new("workbench.hdf")));
+        assert!(!is_cd_image_path(Path::new("directory/")));
+
+        let cfg = parse_config(
+            r#"
+            [scsi]
+            rom = "a2091.rom"
+            unit0 = "workbench.hdf"
+            unit2 = "game.cue"
+            "#,
+        )?;
+        assert_eq!(
+            cfg.scsi.units[2].as_ref().map(|d| d.path.as_path()),
+            Some(Path::new("game.cue"))
+        );
+
+        let err = parse_config(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = "game.iso"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("ATAPI"), "{err:#}");
         Ok(())
     }
 

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -398,7 +398,7 @@ impl Session {
                     match crate::cdrom::CdImage::load(&path) {
                         Ok(image) => {
                             let describe = image.describe();
-                            self.emu.bus_mut().cd_insert_disc(image);
+                            self.emu.bus_mut().cd_insert_disc(image, &path);
                             proto::ok_line(&id, json!({"disc": describe}))
                         }
                         Err(e) => proto::err_line(&id, &CtlError::io(format!("{e:#}"))),

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1774,6 +1774,27 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
     }
 }
 
+/// Open a `[scsi]` unit entry as a bus target: a CD image (cue/ISO) becomes
+/// a CD-ROM drive, anything else a hard disk. Logs the fitted unit.
+fn open_scsi_target(
+    drive: &crate::config::DriveImage,
+    unit: usize,
+) -> Result<crate::scsi::ScsiTarget> {
+    if crate::config::is_cd_image_path(&drive.path) {
+        let cd = crate::scsi::ScsiCdRom::open(&drive.path)?;
+        info!(
+            "scsi: unit {unit} CD-ROM {} ({})",
+            drive.path.display(),
+            cd.describe()
+        );
+        Ok(cd.into())
+    } else {
+        let disk = crate::scsi::ScsiDisk::open(&drive.path, unit, drive.volume_name.as_deref())?;
+        info!("scsi: unit {unit} {}", drive.path.display());
+        Ok(disk.into())
+    }
+}
+
 pub fn build_machine(
     cfg: &Config,
     audio: Box<dyn AudioSink>,
@@ -1799,15 +1820,7 @@ pub fn build_machine(
                 let mut board = crate::a2091::A2091::new(rom)?;
                 for (unit, drive) in cfg.scsi.units.iter().enumerate() {
                     let Some(drive) = drive else { continue };
-                    board.attach_drive(
-                        unit,
-                        crate::scsi::ScsiDisk::open(
-                            &drive.path,
-                            unit,
-                            drive.volume_name.as_deref(),
-                        )?,
-                    );
-                    info!("scsi: unit {unit} {}", drive.path.display());
+                    board.attach_drive(unit, open_scsi_target(drive, unit)?);
                 }
                 zorro.add_board(crate::zorro::BoardSpec::a2091(slot))?;
                 info!(
@@ -1821,15 +1834,7 @@ pub fn build_machine(
                 let mut board = crate::a4091::A4091::new(rom)?;
                 for (unit, drive) in cfg.scsi.units.iter().enumerate() {
                     let Some(drive) = drive else { continue };
-                    board.attach_drive(
-                        unit,
-                        crate::scsi::ScsiDisk::open(
-                            &drive.path,
-                            unit,
-                            drive.volume_name.as_deref(),
-                        )?,
-                    );
-                    info!("scsi: unit {unit} {}", drive.path.display());
+                    board.attach_drive(unit, open_scsi_target(drive, unit)?);
                 }
                 zorro.add_board(crate::zorro::BoardSpec::a4091(slot))?;
                 info!(
@@ -2007,11 +2012,7 @@ pub fn build_machine(
         if cfg.scsi.controller == crate::config::ScsiController::A3000 {
             for (unit, drive) in cfg.scsi.units.iter().enumerate() {
                 let Some(drive) = drive else { continue };
-                sdmac.attach_drive(
-                    unit,
-                    crate::scsi::ScsiDisk::open(&drive.path, unit, drive.volume_name.as_deref())?,
-                );
-                info!("scsi: unit {unit} {}", drive.path.display());
+                sdmac.attach_drive(unit, open_scsi_target(drive, unit)?);
                 drives += 1;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,10 @@ pub struct CliArgs {
     /// Scripted floppy image insertion. This supports both explicit
     /// paths and deferring a disk image already configured in the TOML.
     pub disk_insert_after: Vec<CliDiskInsert>,
+    /// Scripted CD swaps: (SECS, image path) pairs from --insert-cd-after,
+    /// landing in whichever CD drive the machine has (CDTV, CD32, or a
+    /// SCSI CD-ROM unit).
+    pub cd_insert_after: Vec<(f32, PathBuf)>,
     /// Real-time stereo audio output through cpal. Enabled by default;
     /// `--noaudio` disables it, and `--audio-wav` selects WAV output.
     pub audio_live: bool,
@@ -145,7 +149,7 @@ fn parse_args() -> Result<CliArgs> {
 /// the flag names (without the leading dashes) whose effects accumulate;
 /// anything else in a script is an error so a typo cannot silently change
 /// emulator configuration.
-const SCRIPT_DIRECTIVES: [&str; 9] = [
+const SCRIPT_DIRECTIVES: [&str; 10] = [
     "press-after",
     "key-after",
     "hold-key-after",
@@ -155,6 +159,7 @@ const SCRIPT_DIRECTIVES: [&str; 9] = [
     "pot-after",
     "insert-disk-after",
     "defer-disk-insert",
+    "insert-cd-after",
 ];
 
 /// Split one script line into tokens: whitespace-separated, with
@@ -302,6 +307,7 @@ where
     let mut wave_duration: Option<copperline::waveform::WaveDuration> = None;
     let mut wave_signals: Option<copperline::waveform::SignalSet> = None;
     let mut disk_insert_after: Vec<CliDiskInsert> = Vec::new();
+    let mut cd_insert_after: Vec<(f32, PathBuf)> = Vec::new();
     let mut audio_live = true;
     let mut explicit_audio_live = false;
     let mut explicit_noaudio = false;
@@ -527,6 +533,13 @@ where
                 let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let drive_idx = parse_floppy_drive_idx(&drive_s, "--defer-disk-insert")?;
                 disk_insert_after.push(CliDiskInsert::Configured { secs, drive_idx });
+            }
+            "--insert-cd-after" => {
+                const USAGE: &str = "--insert-cd-after requires SECS PATH";
+                let secs: f32 =
+                    next_arg(&mut args, USAGE, "--insert-cd-after SECS must be a number")?;
+                let path = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                cd_insert_after.push((secs, PathBuf::from(path)));
             }
             "--press-after" => {
                 const USAGE: &str = "--press-after requires SECS KEY";
@@ -802,6 +815,7 @@ where
         pot_after,
         record_input,
         disk_insert_after,
+        cd_insert_after,
         audio_live,
         audio_live_forced: explicit_audio_live,
         audio_wav,
@@ -901,6 +915,9 @@ fn print_help() {
          \x20                            insert PATH into DFN after SECS seconds\n  \
          --defer-disk-insert SECS DFN   start with configured DFN empty, then insert\n  \
          \x20                            its configured disk image after SECS seconds\n  \
+         --insert-cd-after SECS PATH    swap the CD image (cue/iso) in the machine's CD\n  \
+         \x20                            drive (CDTV, CD32, or a SCSI CD-ROM unit) after\n  \
+         \x20                            SECS seconds\n  \
          --audio                        enable real-time stereo audio output via cpal (default)\n  \
          --noaudio                      disable real-time audio output\n  \
          --audio-device NAME            host audio output device (substring match)\n  \
@@ -1484,6 +1501,7 @@ fn main() -> Result<()> {
         cli.mouse_after,
         cli.pot_after,
         disk_insert_after,
+        cli.cd_insert_after,
         cli.record_input,
         cfg.floppy_playlists.clone(),
         disk_write_protected,
@@ -1578,6 +1596,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         None,
         None,
         None,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
         Vec::new(),

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -109,7 +109,8 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      shifter); the Bus cd32_pad_shifter/cd32_pad_fire_oldstate fields
 //      moved into the port
 //  32: SCSI target slots (Wd33c93, A4091) hold a ScsiTarget enum (disk or
-//      CD-ROM drive) instead of a bare ScsiDisk
+//      CD-ROM drive) instead of a bare ScsiDisk; the CD-ROM drive carries
+//      CD-DA playback state and the tray countdown of a pending disc swap
 pub const STATE_VERSION: u32 = 32;
 
 /// Default state file name, timestamped like the screenshot/recorder names.

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -108,7 +108,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      kind, JOYxDAT counters, button/direction/pot lines, CD32 serial
 //      shifter); the Bus cd32_pad_shifter/cd32_pad_fire_oldstate fields
 //      moved into the port
-pub const STATE_VERSION: u32 = 31;
+//  32: SCSI target slots (Wd33c93, A4091) hold a ScsiTarget enum (disk or
+//      CD-ROM drive) instead of a bare ScsiDisk
+pub const STATE_VERSION: u32 = 32;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -20,6 +20,10 @@ use crate::harddrive::{HardDriveImage, SECTOR_SIZE};
 use std::collections::VecDeque;
 use std::path::Path;
 
+pub mod cd;
+
+pub use cd::ScsiCdRom;
+
 // ----- WD33C93A register file (SASR values) --------------------------------
 
 pub const WD_OWN_ID: u8 = 0x00;
@@ -101,34 +105,39 @@ const PHS_MESS_IN: u8 = 0x07;
 pub const GOOD: u8 = 0x00;
 pub const CHECK_CONDITION: u8 = 0x02;
 
-// Sense keys / additional sense codes.
-const SK_HARDWARE_ERROR: u8 = 0x04;
-const SK_ILLEGAL_REQUEST: u8 = 0x05;
-const ASC_INVALID_OPCODE: u8 = 0x20;
-const ASC_LBA_OUT_OF_RANGE: u8 = 0x21;
-const ASC_INVALID_FIELD_IN_CDB: u8 = 0x24;
-const ASC_LUN_NOT_SUPPORTED: u8 = 0x25;
-const SENSE_LEN: usize = 18;
+// Sense keys / additional sense codes (shared with the CD-ROM target).
+pub(crate) const SK_NOT_READY: u8 = 0x02;
+pub(crate) const SK_HARDWARE_ERROR: u8 = 0x04;
+pub(crate) const SK_ILLEGAL_REQUEST: u8 = 0x05;
+pub(crate) const SK_UNIT_ATTENTION: u8 = 0x06;
+pub(crate) const ASC_INVALID_OPCODE: u8 = 0x20;
+pub(crate) const ASC_LBA_OUT_OF_RANGE: u8 = 0x21;
+pub(crate) const ASC_INVALID_FIELD_IN_CDB: u8 = 0x24;
+pub(crate) const ASC_LUN_NOT_SUPPORTED: u8 = 0x25;
+pub(crate) const ASC_MEDIUM_MAY_HAVE_CHANGED: u8 = 0x28;
+pub(crate) const ASC_MEDIUM_NOT_PRESENT: u8 = 0x3A;
+pub(crate) const ASC_ILLEGAL_MODE_FOR_THIS_TRACK: u8 = 0x64;
+pub(crate) const SENSE_LEN: usize = 18;
 
 /// Emulated delay (chip-bus colour clocks) between issuing a command and
 /// its completion interrupt, so drivers see busy-then-interrupt rather
 /// than an instant flip mid-instruction.
 const CMD_DELAY_CCK: u32 = 64;
 
-fn be16(b: &[u8], off: usize) -> u32 {
+pub(crate) fn be16(b: &[u8], off: usize) -> u32 {
     (u32::from(b[off]) << 8) | u32::from(b[off + 1])
 }
 
-fn be24(b: &[u8], off: usize) -> u32 {
+pub(crate) fn be24(b: &[u8], off: usize) -> u32 {
     (u32::from(b[off]) << 16) | (u32::from(b[off + 1]) << 8) | u32::from(b[off + 2])
 }
 
-fn be32(b: &[u8], off: usize) -> u32 {
+pub(crate) fn be32(b: &[u8], off: usize) -> u32 {
     (be24(b, off) << 8) | u32::from(b[off + 3])
 }
 
 /// CDB length from the opcode's command group.
-fn cdb_len(opcode: u8) -> usize {
+pub(crate) fn cdb_len(opcode: u8) -> usize {
     match opcode >> 5 {
         0 => 6,
         1 | 2 => 10,
@@ -467,6 +476,48 @@ impl ScsiDisk {
     }
 }
 
+// ----- target dispatch -------------------------------------------------------
+
+/// A device on the SCSI bus: a direct-access disk or a CD-ROM drive. The
+/// host adapters only ever parse a CDB into a bus data phase and resolve a
+/// data-out payload, so this is the whole target interface.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum ScsiTarget {
+    Disk(ScsiDisk),
+    CdRom(ScsiCdRom),
+}
+
+impl ScsiTarget {
+    /// Parse and execute a CDB up to (but not including) any data-out
+    /// payload; see [`ScsiDisk::execute`].
+    pub fn execute(&mut self, cdb: &[u8], lun: u8) -> (ScsiExec, u8) {
+        match self {
+            ScsiTarget::Disk(disk) => disk.execute(cdb, lun),
+            ScsiTarget::CdRom(cd) => cd.execute(cdb, lun),
+        }
+    }
+
+    /// Complete a data-out command once the payload has arrived.
+    pub fn complete_out(&mut self, cdb: &[u8], data: &[u8]) -> u8 {
+        match self {
+            ScsiTarget::Disk(disk) => disk.complete_out(cdb, data),
+            ScsiTarget::CdRom(cd) => cd.complete_out(cdb, data),
+        }
+    }
+}
+
+impl From<ScsiDisk> for ScsiTarget {
+    fn from(disk: ScsiDisk) -> Self {
+        ScsiTarget::Disk(disk)
+    }
+}
+
+impl From<ScsiCdRom> for ScsiTarget {
+    fn from(cd: ScsiCdRom) -> Self {
+        ScsiTarget::CdRom(cd)
+    }
+}
+
 // ----- WD33C93A --------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -522,7 +573,7 @@ pub struct Wd33c93 {
     /// currently asserted; reading the SCSI status register acknowledges
     /// the current one and arms the next.
     pending: VecDeque<(u8, u32)>,
-    targets: [Option<ScsiDisk>; 8],
+    targets: [Option<ScsiTarget>; 8],
     xfer: Option<Transaction>,
     /// Active data phase routed to the DMAC (the board pumps bytes).
     dma_dir: Option<DmaDir>,
@@ -561,8 +612,8 @@ impl Wd33c93 {
         }
     }
 
-    pub fn attach_target(&mut self, id: usize, disk: ScsiDisk) {
-        self.targets[id.min(7)] = Some(disk);
+    pub fn attach_target(&mut self, id: usize, target: impl Into<ScsiTarget>) {
+        self.targets[id.min(7)] = Some(target.into());
     }
 
     pub fn target_present(&self, id: usize) -> bool {

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -16,6 +16,7 @@
 //! delay so software that issues a command and then polls the auxiliary
 //! status register observes the busy-then-interrupt sequence.
 
+use crate::chipset::paula::CdAudioRing;
 use crate::harddrive::{HardDriveImage, SECTOR_SIZE};
 use std::collections::VecDeque;
 use std::path::Path;
@@ -504,6 +505,22 @@ impl ScsiTarget {
             ScsiTarget::CdRom(cd) => cd.complete_out(cdb, data),
         }
     }
+
+    /// The CD-ROM drive behind this target, when it is one.
+    pub fn cd_ref(&self) -> Option<&ScsiCdRom> {
+        match self {
+            ScsiTarget::CdRom(cd) => Some(cd),
+            ScsiTarget::Disk(_) => None,
+        }
+    }
+
+    /// Mutable view of the CD-ROM drive behind this target, when it is one.
+    pub fn cd_mut(&mut self) -> Option<&mut ScsiCdRom> {
+        match self {
+            ScsiTarget::CdRom(cd) => Some(cd),
+            ScsiTarget::Disk(_) => None,
+        }
+    }
 }
 
 impl From<ScsiDisk> for ScsiTarget {
@@ -618,6 +635,29 @@ impl Wd33c93 {
 
     pub fn target_present(&self, id: usize) -> bool {
         self.targets.get(id).is_some_and(Option::is_some)
+    }
+
+    /// The lowest-ID CD-ROM drive on the bus, when one is attached.
+    pub fn first_cd(&self) -> Option<&ScsiCdRom> {
+        self.targets.iter().flatten().find_map(ScsiTarget::cd_ref)
+    }
+
+    /// Mutable view of the lowest-ID CD-ROM drive on the bus.
+    pub fn first_cd_mut(&mut self) -> Option<&mut ScsiCdRom> {
+        self.targets
+            .iter_mut()
+            .flatten()
+            .find_map(ScsiTarget::cd_mut)
+    }
+
+    /// Advance the targets' emulated time: CD-ROM drives run their tray
+    /// countdowns and stream CD-DA playback into the host mixer ring.
+    pub fn tick_targets(&mut self, cck: u32, cd_audio: &mut CdAudioRing) {
+        for target in self.targets.iter_mut().flatten() {
+            if let ScsiTarget::CdRom(cd) = target {
+                cd.tick(cck, cd_audio);
+            }
+        }
     }
 
     /// Hardware reset (board /RST or system reset): clear chip state but

--- a/src/scsi/cd.rs
+++ b/src/scsi/cd.rs
@@ -281,20 +281,33 @@ impl ScsiCdRom {
         d
     }
 
-    /// A 4-byte TOC/header/sub-channel address: absolute MSF (with the
-    /// 2-second lead-in offset) or a plain LBA, by the CDB's TIME bit.
+    /// A 4-byte absolute TOC/header/sub-channel address: MSF with the
+    /// 2-second lead-in offset, or a plain LBA, by the CDB's TIME bit.
     fn addr4(sector: u32, msf: bool) -> [u8; 4] {
         if msf {
-            let s = sector + LEADIN_SECTORS;
-            [
-                0,
-                (s / (60 * 75)) as u8,
-                ((s / 75) % 60) as u8,
-                (s % 75) as u8,
-            ]
+            Self::msf_bytes(sector + LEADIN_SECTORS)
         } else {
             sector.to_be_bytes()
         }
+    }
+
+    /// A 4-byte track-relative address: MSF counted from the track start
+    /// (no lead-in offset), or the plain sector difference.
+    fn rel4(sectors: u32, msf: bool) -> [u8; 4] {
+        if msf {
+            Self::msf_bytes(sectors)
+        } else {
+            sectors.to_be_bytes()
+        }
+    }
+
+    fn msf_bytes(s: u32) -> [u8; 4] {
+        [
+            0,
+            (s / (60 * 75)) as u8,
+            ((s / 75) % 60) as u8,
+            (s % 75) as u8,
+        ]
     }
 
     /// The ADR/control byte a TOC entry carries: position-information ADR
@@ -796,7 +809,7 @@ impl ScsiCdRom {
                         (Self::ctl_adr(track), track.number, track.start_sector);
                     data.extend_from_slice(&[0x01, ctl, number, 1]);
                     data.extend_from_slice(&Self::addr4(self.play_pos, msf));
-                    data.extend_from_slice(&Self::addr4(self.play_pos.saturating_sub(start), msf));
+                    data.extend_from_slice(&Self::rel4(self.play_pos.saturating_sub(start), msf));
                 }
                 // Media catalogue number / ISRC: nothing encoded (the
                 // MCVal/TCVal bit stays clear).
@@ -1084,6 +1097,13 @@ mod tests {
         assert_eq!(data[1], AUDIO_STATUS_COMPLETED);
         assert_eq!(be32(&data, 8), 5); // last played sector
         assert_eq!(be32(&data, 12), 1); // relative to the track start
+
+        // MSF form: the absolute address carries the 2-second lead-in
+        // offset (sector 5 = 00:02:05); the track-relative address counts
+        // from the track start without it (sector 1 into track 2).
+        let data = data_in(&mut cd, &[0x42, 0x02, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(&data[8..12], &[0, 0, 2, 5]);
+        assert_eq!(&data[12..16], &[0, 0, 0, 1]);
 
         // Playing a data track is an illegal mode.
         check_sense(

--- a/src/scsi/cd.rs
+++ b/src/scsi/cd.rs
@@ -1,0 +1,996 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! SCSI-2 CD-ROM target: a read-only removable-medium device (peripheral
+//! type 5) backed by a cue/bin or ISO image.
+//!
+//! The command set covers what Amiga CD filesystems (CDFileSystem,
+//! CacheCDFS, AsimCDFS and friends) drive through a host adapter's
+//! scsi.device: INQUIRY, READ CAPACITY / READ TOC / READ HEADER /
+//! READ SUB-CHANNEL, the READ family in 2048-byte blocks, READ CD, mode
+//! pages 01h/0Dh/0Eh/2Ah, and the audio-play group. Audio commands keep
+//! coherent status for players, but produce no sound: on real hardware
+//! CD audio leaves through the drive's own analogue output, which is not
+//! cabled to the Amiga's audio path. A play command therefore completes
+//! immediately, and the sub-channel reports the end of the played range.
+
+use super::{
+    be16, be24, be32, cdb_len, ScsiExec, ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_INVALID_FIELD_IN_CDB,
+    ASC_INVALID_OPCODE, ASC_LBA_OUT_OF_RANGE, ASC_LUN_NOT_SUPPORTED, ASC_MEDIUM_MAY_HAVE_CHANGED,
+    ASC_MEDIUM_NOT_PRESENT, CHECK_CONDITION, GOOD, SENSE_LEN, SK_HARDWARE_ERROR,
+    SK_ILLEGAL_REQUEST, SK_NOT_READY, SK_UNIT_ATTENTION,
+};
+use crate::cdrom::{CdImage, CdTrack, DATA_SECTOR_BYTES, LEADIN_SECTORS, RAW_SECTOR_BYTES};
+use std::path::{Path, PathBuf};
+
+// READ SUB-CHANNEL audio status codes. "Play in progress" (0x11) never
+// surfaces because play commands complete within the command.
+const AUDIO_STATUS_PAUSED: u8 = 0x12;
+const AUDIO_STATUS_COMPLETED: u8 = 0x13;
+const AUDIO_STATUS_NONE: u8 = 0x15;
+
+/// A SCSI-2 CD-ROM target backed by a CD image.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ScsiCdRom {
+    image: CdImage,
+    /// Path the drive was opened from (the cue sheet or ISO), for logs.
+    path: PathBuf,
+    /// Tray closed with the medium in place. START STOP UNIT's eject and
+    /// load strobes toggle it; reloading raises a unit attention.
+    loaded: bool,
+    /// Report a medium-change unit attention on the next command.
+    unit_attention: bool,
+    sense: [u8; SENSE_LEN],
+    /// Audio status byte for READ SUB-CHANNEL.
+    audio_status: u8,
+    /// Disc sector the sub-channel reports as the audio position.
+    audio_pos: u32,
+}
+
+impl ScsiCdRom {
+    /// Open a CD-ROM unit from a cue sheet or bare ISO image.
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        let image = CdImage::load(path)?;
+        Ok(Self {
+            image,
+            path: path.to_path_buf(),
+            loaded: true,
+            unit_attention: false,
+            sense: [0u8; SENSE_LEN],
+            audio_status: AUDIO_STATUS_NONE,
+            audio_pos: 0,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// One-line TOC summary for the log.
+    pub fn describe(&self) -> String {
+        self.image.describe()
+    }
+
+    fn set_sense(&mut self, key: u8, asc: u8) {
+        self.sense = [0u8; SENSE_LEN];
+        self.sense[0] = 0x70; // current error, fixed format
+        self.sense[2] = key;
+        self.sense[7] = 10; // additional sense length
+        self.sense[12] = asc;
+    }
+
+    fn clear_sense(&mut self) {
+        self.sense = [0u8; SENSE_LEN];
+    }
+
+    fn check(&mut self, key: u8, asc: u8) -> (ScsiExec, u8) {
+        self.set_sense(key, asc);
+        (ScsiExec::NoData, CHECK_CONDITION)
+    }
+
+    fn total_sectors(&self) -> u32 {
+        self.image.total_sectors()
+    }
+
+    /// Whether an opcode touches the medium (and so needs a disc loaded).
+    fn needs_medium(op: u8) -> bool {
+        matches!(
+            op,
+            0x00 | 0x08
+                | 0x0B
+                | 0x25
+                | 0x28
+                | 0x2B
+                | 0x42
+                | 0x43
+                | 0x44
+                | 0x45
+                | 0x47
+                | 0x48
+                | 0x4B
+                | 0x4E
+                | 0xA8
+                | 0xBE
+        )
+    }
+
+    fn inquiry_data(lun: u8) -> Vec<u8> {
+        let mut d = vec![0u8; 36];
+        // Peripheral qualifier 011b + type 1Fh for an unsupported LUN.
+        d[0] = if lun == 0 { 0x05 } else { 0x7F };
+        d[1] = 0x80; // removable medium
+        d[2] = 0x02; // SCSI-2
+        d[3] = 0x02; // response data format: SCSI-2
+        d[4] = 31; // additional length
+        d[8..16].copy_from_slice(b"COPPERLN");
+        d[16..32].copy_from_slice(b"SCSI CD-ROM     ");
+        d[32..36].copy_from_slice(b"1.0 ");
+        d
+    }
+
+    /// A 4-byte TOC/header/sub-channel address: absolute MSF (with the
+    /// 2-second lead-in offset) or a plain LBA, by the CDB's TIME bit.
+    fn addr4(sector: u32, msf: bool) -> [u8; 4] {
+        if msf {
+            let s = sector + LEADIN_SECTORS;
+            [
+                0,
+                (s / (60 * 75)) as u8,
+                ((s / 75) % 60) as u8,
+                (s % 75) as u8,
+            ]
+        } else {
+            sector.to_be_bytes()
+        }
+    }
+
+    /// The ADR/control byte a TOC entry carries: position-information ADR
+    /// with the data bit for data tracks.
+    fn ctl_adr(track: &CdTrack) -> u8 {
+        if track.kind.is_data() {
+            0x14
+        } else {
+            0x10
+        }
+    }
+
+    /// The track containing a disc sector (falling back to the outermost
+    /// edges for out-of-range positions).
+    fn track_at(&self, sector: u32) -> &CdTrack {
+        let tracks = self.image.tracks();
+        tracks
+            .iter()
+            .rev()
+            .find(|t| sector >= t.start_sector)
+            .unwrap_or(&tracks[0])
+    }
+
+    /// Convert a CDB MSF field (3 binary bytes) to a disc sector, `None`
+    /// when it lies before the start of the program area.
+    fn msf_to_sector(m: u8, s: u8, f: u8) -> Option<u32> {
+        let abs = (u32::from(m) * 60 + u32::from(s)) * 75 + u32::from(f);
+        abs.checked_sub(LEADIN_SECTORS)
+    }
+
+    /// Parse and execute a CDB up to (but not including) any data-out
+    /// payload; the counterpart of [`super::ScsiDisk::execute`].
+    pub fn execute(&mut self, cdb: &[u8], lun: u8) -> (ScsiExec, u8) {
+        let Some(&op) = cdb.first() else {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+        };
+        if cdb.len() < cdb_len(op) {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+        }
+        // REQUEST SENSE must report (then clear) the previous command's
+        // sense data; every other command starts with it cleared.
+        if op != 0x03 {
+            self.clear_sense();
+        }
+        if lun != 0 {
+            return match op {
+                // INQUIRY for an unsupported LUN reports qualifier 011b.
+                0x12 => {
+                    let alloc = usize::from(cdb[4]);
+                    let data = Self::inquiry_data(lun);
+                    (ScsiExec::DataIn(data[..alloc.min(36)].to_vec()), GOOD)
+                }
+                _ => self.check(SK_ILLEGAL_REQUEST, ASC_LUN_NOT_SUPPORTED),
+            };
+        }
+        // A pending unit attention (the medium changed) preempts every
+        // command except INQUIRY and REQUEST SENSE.
+        if self.unit_attention && !matches!(op, 0x03 | 0x12) {
+            self.unit_attention = false;
+            return self.check(SK_UNIT_ATTENTION, ASC_MEDIUM_MAY_HAVE_CHANGED);
+        }
+        if !self.loaded && Self::needs_medium(op) {
+            return self.check(SK_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
+        }
+        match op {
+            // TEST UNIT READY (the medium gate above did the work)
+            0x00 => (ScsiExec::NoData, GOOD),
+            // REQUEST SENSE
+            0x03 => {
+                let alloc = match cdb[4] {
+                    0 => 4, // SCSI-1: zero means four bytes
+                    n => usize::from(n),
+                };
+                let data = self.sense[..alloc.min(SENSE_LEN)].to_vec();
+                self.clear_sense();
+                (ScsiExec::DataIn(data), GOOD)
+            }
+            // READ(6)
+            0x08 => {
+                let lba = u64::from(be24(cdb, 1) & 0x1F_FFFF);
+                let count = match cdb[4] {
+                    0 => 256u64,
+                    n => u64::from(n),
+                };
+                self.read_data(lba, count)
+            }
+            // SEEK(6) / SEEK(10)
+            0x0B | 0x2B => (ScsiExec::NoData, GOOD),
+            // INQUIRY
+            0x12 => {
+                if cdb[1] & 0x01 != 0 {
+                    // EVPD: only the supported-pages page.
+                    if cdb[2] == 0x00 {
+                        let data = [0u8, 0, 0, 1, 0];
+                        let alloc = usize::from(cdb[4]);
+                        return (ScsiExec::DataIn(data[..alloc.min(5)].to_vec()), GOOD);
+                    }
+                    return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+                }
+                let alloc = usize::from(cdb[4]);
+                let data = Self::inquiry_data(0);
+                (ScsiExec::DataIn(data[..alloc.min(36)].to_vec()), GOOD)
+            }
+            // MODE SELECT(6)/(10): accept and ignore the parameter list
+            // (the only block size served is 2048).
+            0x15 => (ScsiExec::DataOut(usize::from(cdb[4])), GOOD),
+            0x55 => (ScsiExec::DataOut(be16(cdb, 7) as usize), GOOD),
+            // RESERVE / RELEASE
+            0x16 | 0x17 => (ScsiExec::NoData, GOOD),
+            // MODE SENSE(6)/(10)
+            0x1A => self.mode_sense(cdb, false),
+            0x5A => self.mode_sense(cdb, true),
+            // START STOP UNIT: with LoEj the tray ejects/reloads the disc.
+            0x1B => {
+                let load_eject = cdb[4] & 0x02 != 0;
+                let start = cdb[4] & 0x01 != 0;
+                if load_eject {
+                    if start {
+                        if !self.loaded {
+                            self.loaded = true;
+                            self.unit_attention = true;
+                        }
+                    } else {
+                        self.loaded = false;
+                        self.audio_status = AUDIO_STATUS_NONE;
+                    }
+                }
+                (ScsiExec::NoData, GOOD)
+            }
+            // PREVENT ALLOW MEDIUM REMOVAL
+            0x1E => (ScsiExec::NoData, GOOD),
+            // READ CAPACITY(10)
+            0x25 => {
+                let last = self.total_sectors().saturating_sub(1);
+                let mut data = Vec::with_capacity(8);
+                data.extend_from_slice(&last.to_be_bytes());
+                data.extend_from_slice(&(DATA_SECTOR_BYTES as u32).to_be_bytes());
+                (ScsiExec::DataIn(data), GOOD)
+            }
+            // READ(10)
+            0x28 => {
+                let lba = u64::from(be32(cdb, 2));
+                let count = u64::from(be16(cdb, 7));
+                self.read_data(lba, count)
+            }
+            // READ SUB-CHANNEL
+            0x42 => self.read_sub_channel(cdb),
+            // READ TOC
+            0x43 => self.read_toc(cdb),
+            // READ HEADER
+            0x44 => {
+                let msf = cdb[1] & 0x02 != 0;
+                let lba = be32(cdb, 2);
+                if lba >= self.total_sectors() {
+                    return self.check(SK_ILLEGAL_REQUEST, ASC_LBA_OUT_OF_RANGE);
+                }
+                let alloc = be16(cdb, 7) as usize;
+                let mut data = vec![0u8; 8];
+                data[0] = if self.image.is_audio_sector(lba) {
+                    0
+                } else {
+                    1
+                };
+                data[4..8].copy_from_slice(&Self::addr4(lba, msf));
+                data.truncate(alloc);
+                (ScsiExec::DataIn(data), GOOD)
+            }
+            // PLAY AUDIO(10)
+            0x45 => {
+                let lba = be32(cdb, 2);
+                let count = be16(cdb, 7);
+                if count == 0 {
+                    return (ScsiExec::NoData, GOOD);
+                }
+                self.play_range(lba, lba + count)
+            }
+            // PLAY AUDIO MSF
+            0x47 => {
+                let start = match cdb[3] {
+                    // FFh: continue from the current position.
+                    0xFF => Some(self.audio_pos),
+                    _ => Self::msf_to_sector(cdb[3], cdb[4], cdb[5]),
+                };
+                let end = Self::msf_to_sector(cdb[6], cdb[7], cdb[8]);
+                let (Some(start), Some(end)) = (start, end) else {
+                    return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+                };
+                if end < start {
+                    return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+                }
+                if end == start {
+                    return (ScsiExec::NoData, GOOD);
+                }
+                self.play_range(start, end)
+            }
+            // PLAY AUDIO TRACK/INDEX
+            0x48 => {
+                let tracks = self.image.tracks();
+                let start = tracks.iter().find(|t| t.number == cdb[4]);
+                let end = tracks.iter().find(|t| t.number == cdb[7]);
+                let (Some(start), Some(end)) = (start, end) else {
+                    return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+                };
+                let (start, end) = (start.start_sector, end.start_sector + end.sector_count);
+                self.play_range(start, end)
+            }
+            // PAUSE / RESUME
+            0x4B => {
+                self.audio_status = if cdb[8] & 0x01 != 0 {
+                    // Resume: the (instant) playback has already finished.
+                    AUDIO_STATUS_COMPLETED
+                } else {
+                    AUDIO_STATUS_PAUSED
+                };
+                (ScsiExec::NoData, GOOD)
+            }
+            // STOP PLAY/SCAN
+            0x4E => {
+                self.audio_status = AUDIO_STATUS_NONE;
+                (ScsiExec::NoData, GOOD)
+            }
+            // READ(12)
+            0xA8 => {
+                let lba = u64::from(be32(cdb, 2));
+                let count = u64::from(be32(cdb, 6));
+                self.read_data(lba, count)
+            }
+            // READ CD
+            0xBE => self.read_cd(cdb),
+            _ => {
+                log::debug!("scsi cd: unsupported opcode {op:#04X}");
+                self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_OPCODE)
+            }
+        }
+    }
+
+    /// Complete a data-out command once the payload has arrived. The only
+    /// data-out commands the CD-ROM accepts are MODE SELECT parameter
+    /// lists, which are accepted and ignored.
+    pub fn complete_out(&mut self, _cdb: &[u8], _data: &[u8]) -> u8 {
+        GOOD
+    }
+
+    /// The READ family: user data in 2048-byte blocks. Audio tracks cannot
+    /// be read this way.
+    fn read_data(&mut self, lba: u64, count: u64) -> (ScsiExec, u8) {
+        let total = u64::from(self.total_sectors());
+        if lba + count > total {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_LBA_OUT_OF_RANGE);
+        }
+        if count == 0 {
+            return (ScsiExec::NoData, GOOD);
+        }
+        let mut data = vec![0u8; (count as usize) * DATA_SECTOR_BYTES];
+        for i in 0..count {
+            let sector = (lba + i) as u32;
+            if self.image.is_audio_sector(sector) {
+                return self.check(SK_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
+            }
+            let mut buf = [0u8; DATA_SECTOR_BYTES];
+            if let Err(e) = self.image.read_data_sector(sector, &mut buf) {
+                log::warn!("scsi cd {}: read lba {sector}: {e}", self.path.display());
+                return self.check(SK_HARDWARE_ERROR, 0x00);
+            }
+            data[(i as usize) * DATA_SECTOR_BYTES..][..DATA_SECTOR_BYTES].copy_from_slice(&buf);
+        }
+        (ScsiExec::DataIn(data), GOOD)
+    }
+
+    /// READ CD: raw or cooked frames by the main-channel byte field.
+    fn read_cd(&mut self, cdb: &[u8]) -> (ScsiExec, u8) {
+        let expected = (cdb[1] >> 2) & 0x07;
+        let lba = u64::from(be32(cdb, 2));
+        let count = u64::from(be24(cdb, 6));
+        let main = cdb[9];
+        if cdb[10] & 0x07 != 0 {
+            // No sub-channel data to interleave.
+            return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+        }
+        let total = u64::from(self.total_sectors());
+        if lba + count > total {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_LBA_OUT_OF_RANGE);
+        }
+        if count == 0 || main == 0 {
+            return (ScsiExec::NoData, GOOD);
+        }
+        // Main-channel selection: full raw frames or user data only.
+        let raw = match main {
+            0xF8 => true,
+            0x10 => false,
+            _ => return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB),
+        };
+        let sector_bytes = if raw {
+            RAW_SECTOR_BYTES
+        } else {
+            DATA_SECTOR_BYTES
+        };
+        let mut data = vec![0u8; (count as usize) * sector_bytes];
+        for i in 0..count {
+            let sector = (lba + i) as u32;
+            let audio = self.image.is_audio_sector(sector);
+            // Expected sector type: 1 = CD-DA, 2 = mode 1; 0 accepts any.
+            let type_ok = match expected {
+                1 => audio,
+                2 => !audio,
+                _ => true,
+            };
+            if !type_ok || (!raw && audio) {
+                return self.check(SK_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
+            }
+            let out = &mut data[(i as usize) * sector_bytes..][..sector_bytes];
+            let result = if raw {
+                let mut buf = [0u8; RAW_SECTOR_BYTES];
+                let r = self.image.read_raw_sector(sector, &mut buf);
+                out.copy_from_slice(&buf);
+                r
+            } else {
+                let mut buf = [0u8; DATA_SECTOR_BYTES];
+                let r = self.image.read_data_sector(sector, &mut buf);
+                out.copy_from_slice(&buf);
+                r
+            };
+            if let Err(e) = result {
+                log::warn!("scsi cd {}: read cd lba {sector}: {e}", self.path.display());
+                return self.check(SK_HARDWARE_ERROR, 0x00);
+            }
+        }
+        (ScsiExec::DataIn(data), GOOD)
+    }
+
+    /// Play an audio range. Playback is silent and completes within the
+    /// command; the sub-channel then reports the end of the range.
+    fn play_range(&mut self, start: u32, end: u32) -> (ScsiExec, u8) {
+        if start >= self.total_sectors() || end > self.total_sectors() {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_LBA_OUT_OF_RANGE);
+        }
+        if !self.image.is_audio_sector(start) {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
+        }
+        self.audio_status = AUDIO_STATUS_COMPLETED;
+        self.audio_pos = end.saturating_sub(1);
+        (ScsiExec::NoData, GOOD)
+    }
+
+    fn mode_sense(&mut self, cdb: &[u8], ten: bool) -> (ScsiExec, u8) {
+        let dbd = cdb[1] & 0x08 != 0;
+        let page = cdb[2] & 0x3F;
+        let Some(pages) = self.mode_pages(page) else {
+            return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+        };
+        let mut body = Vec::new();
+        if !dbd {
+            // Block descriptor: density 0, all blocks, 2048-byte blocks.
+            let blocks = if self.loaded { self.total_sectors() } else { 0 };
+            body.push(0);
+            body.extend_from_slice(&blocks.min(0x00FF_FFFF).to_be_bytes()[1..]);
+            body.push(0);
+            body.extend_from_slice(&(DATA_SECTOR_BYTES as u32).to_be_bytes()[1..]);
+        }
+        let bd_len = body.len() as u8;
+        body.extend_from_slice(&pages);
+        let mut data = Vec::new();
+        // The device-specific parameter carries the write-protect bit: the
+        // medium is read-only.
+        if ten {
+            let len = (body.len() + 6) as u32;
+            data.extend_from_slice(&[(len >> 8) as u8, len as u8, 0, 0x80, 0, 0, 0, bd_len]);
+        } else {
+            data.extend_from_slice(&[(body.len() + 3) as u8, 0, 0x80, bd_len]);
+        }
+        data.extend_from_slice(&body);
+        let alloc = if ten {
+            be16(cdb, 7) as usize
+        } else {
+            usize::from(cdb[4])
+        };
+        data.truncate(alloc);
+        (ScsiExec::DataIn(data), GOOD)
+    }
+
+    fn mode_pages(&self, page: u8) -> Option<Vec<u8>> {
+        // Read error recovery: retries at the drive's discretion.
+        let page1 = || vec![0x01u8, 6, 0, 0, 0, 0, 0, 0];
+        // CD-ROM parameters: 60 seconds per minute, 75 frames per second.
+        let page13 = || vec![0x0Du8, 6, 0, 0, 0, 60, 0, 75];
+        // CD audio control: immediate play, ports 0/1 to channels L/R at
+        // full volume.
+        let page14 = || {
+            let mut p = vec![0u8; 16];
+            p[0] = 0x0E;
+            p[1] = 14;
+            p[2] = 0x04; // IMMED
+            p[8] = 0x01; // port 0: channel 1
+            p[9] = 0xFF;
+            p[10] = 0x02; // port 1: channel 2
+            p[11] = 0xFF;
+            p
+        };
+        // Capabilities and mechanical status: audio play and CD-DA reads,
+        // tray loader with eject and lock, 4x speed, 256 volume levels,
+        // a 64K buffer.
+        let page2a = || {
+            let mut p = vec![0u8; 22];
+            p[0] = 0x2A;
+            p[1] = 20;
+            p[4] = 0x01; // audio play
+            p[5] = 0x01; // CD-DA commands
+            p[6] = 0x29; // tray loader, eject, lock
+            p[8..10].copy_from_slice(&706u16.to_be_bytes()); // max KB/s
+            p[10..12].copy_from_slice(&256u16.to_be_bytes());
+            p[12..14].copy_from_slice(&64u16.to_be_bytes());
+            p[14..16].copy_from_slice(&706u16.to_be_bytes()); // current KB/s
+            p
+        };
+        match page {
+            0x01 => Some(page1()),
+            0x0D => Some(page13()),
+            0x0E => Some(page14()),
+            0x2A => Some(page2a()),
+            0x3F => {
+                let mut all = page1();
+                all.extend_from_slice(&page13());
+                all.extend_from_slice(&page14());
+                all.extend_from_slice(&page2a());
+                Some(all)
+            }
+            _ => None,
+        }
+    }
+
+    fn read_toc(&mut self, cdb: &[u8]) -> (ScsiExec, u8) {
+        let msf = cdb[1] & 0x02 != 0;
+        let format = match cdb[2] & 0x0F {
+            // SCSI-2 drives carried the format in the control byte's top
+            // bits before byte 2 was defined; honour either encoding.
+            0 => cdb[9] >> 6,
+            f => f,
+        };
+        let alloc = be16(cdb, 7) as usize;
+        let tracks = self.image.tracks();
+        let first = tracks.first().map_or(1, |t| t.number);
+        let last = tracks.last().map_or(1, |t| t.number);
+        let mut data = match format {
+            // Format 0: the TOC proper, from the starting track to the
+            // lead-out.
+            0 => {
+                let start = cdb[6];
+                if start > last && start != 0xAA {
+                    return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+                }
+                let mut d = vec![0, 0, first, last];
+                for track in tracks.iter().filter(|t| t.number >= start) {
+                    d.extend_from_slice(&[0, Self::ctl_adr(track), track.number, 0]);
+                    d.extend_from_slice(&Self::addr4(track.start_sector, msf));
+                }
+                // The lead-out, as track AAh.
+                d.extend_from_slice(&[0, 0x14, 0xAA, 0]);
+                d.extend_from_slice(&Self::addr4(self.total_sectors(), msf));
+                let len = (d.len() - 2) as u16;
+                d[0..2].copy_from_slice(&len.to_be_bytes());
+                d
+            }
+            // Format 1: session info. Images are single-session, so the
+            // first track doubles as the last session's first track.
+            1 => {
+                let mut d = vec![0, 0x0A, 1, 1, 0, 0, first, 0];
+                let (ctl, sector) = tracks
+                    .first()
+                    .map_or((0x14, 0), |t| (Self::ctl_adr(t), t.start_sector));
+                d[5] = ctl;
+                d.extend_from_slice(&Self::addr4(sector, msf));
+                d
+            }
+            _ => return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB),
+        };
+        data.truncate(alloc);
+        (ScsiExec::DataIn(data), GOOD)
+    }
+
+    fn read_sub_channel(&mut self, cdb: &[u8]) -> (ScsiExec, u8) {
+        let msf = cdb[1] & 0x02 != 0;
+        let want_subq = cdb[2] & 0x40 != 0;
+        let format = cdb[3];
+        let alloc = be16(cdb, 7) as usize;
+        let mut data = vec![0u8, self.audio_status, 0, 0];
+        if want_subq {
+            match format {
+                // Current position.
+                0x01 => {
+                    let track = self.track_at(self.audio_pos);
+                    let (ctl, number, start) =
+                        (Self::ctl_adr(track), track.number, track.start_sector);
+                    data.extend_from_slice(&[0x01, ctl, number, 1]);
+                    data.extend_from_slice(&Self::addr4(self.audio_pos, msf));
+                    data.extend_from_slice(&Self::addr4(self.audio_pos.saturating_sub(start), msf));
+                }
+                // Media catalogue number / ISRC: nothing encoded (the
+                // MCVal/TCVal bit stays clear).
+                0x02 | 0x03 => {
+                    data.push(format);
+                    data.extend_from_slice(&[0u8; 19]);
+                }
+                _ => return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB),
+            }
+            let len = (data.len() - 4) as u16;
+            data[2..4].copy_from_slice(&len.to_be_bytes());
+        }
+        data.truncate(alloc);
+        (ScsiExec::DataIn(data), GOOD)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scsi::{CHECK_CONDITION, GOOD};
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn temp_path(name: &str) -> PathBuf {
+        static UNIQUE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = UNIQUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "copperline-scsicd-{}-{unique}-{name}",
+            std::process::id()
+        ))
+    }
+
+    /// A 6-sector disc: 4 data sectors (filled with the sector number)
+    /// then a 2-sector audio track.
+    fn mixed_disc() -> (ScsiCdRom, Vec<PathBuf>) {
+        let cue = temp_path("mixed.cue");
+        let bin = temp_path("mixed.bin");
+        let mut bytes = Vec::new();
+        for s in 0..4u8 {
+            bytes.extend(std::iter::repeat_n(s, DATA_SECTOR_BYTES));
+        }
+        for s in 0..2u8 {
+            bytes.extend(std::iter::repeat_n(0xA0 + s, RAW_SECTOR_BYTES));
+        }
+        let mut f = std::fs::File::create(&bin).unwrap();
+        f.write_all(&bytes).unwrap();
+        std::fs::write(
+            &cue,
+            format!(
+                "FILE \"{}\" BINARY\n  TRACK 01 MODE1/2048\n    INDEX 01 00:00:00\n  TRACK 02 AUDIO\n    INDEX 01 00:00:04\n",
+                bin.file_name().unwrap().to_string_lossy()
+            ),
+        )
+        .unwrap();
+        (ScsiCdRom::open(&cue).unwrap(), vec![cue, bin])
+    }
+
+    fn cleanup(paths: &[PathBuf]) {
+        for p in paths {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    fn data_in(cd: &mut ScsiCdRom, cdb: &[u8]) -> Vec<u8> {
+        let (exec, status) = cd.execute(cdb, 0);
+        assert_eq!(status, GOOD, "status for {:#04X}", cdb[0]);
+        match exec {
+            ScsiExec::DataIn(d) => d,
+            _ => panic!("expected data-in for {:#04X}", cdb[0]),
+        }
+    }
+
+    fn check_sense(cd: &mut ScsiCdRom, cdb: &[u8], key: u8, asc: u8) {
+        let (_, status) = cd.execute(cdb, 0);
+        assert_eq!(status, CHECK_CONDITION, "status for {:#04X}", cdb[0]);
+        let sense = data_in(cd, &[0x03, 0, 0, 0, 18, 0]);
+        assert_eq!(sense[2] & 0x0F, key, "sense key for {:#04X}", cdb[0]);
+        assert_eq!(sense[12], asc, "asc for {:#04X}", cdb[0]);
+    }
+
+    #[test]
+    fn inquiry_identifies_a_removable_cdrom() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x12, 0, 0, 0, 36, 0]);
+        assert_eq!(data[0], 0x05); // CD-ROM device
+        assert_eq!(data[1], 0x80); // removable
+        assert_eq!(&data[8..16], b"COPPERLN");
+        assert_eq!(&data[16..27], b"SCSI CD-ROM");
+        // An unsupported LUN reports qualifier 011b.
+        let (exec, status) = cd.execute(&[0x12, 0x20, 0, 0, 36, 0], 1);
+        assert_eq!(status, GOOD);
+        let ScsiExec::DataIn(data) = exec else {
+            panic!("expected data-in");
+        };
+        assert_eq!(data[0], 0x7F);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read_capacity_reports_2048_byte_blocks() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x25, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(u32::from_be_bytes(data[0..4].try_into().unwrap()), 5);
+        assert_eq!(u32::from_be_bytes(data[4..8].try_into().unwrap()), 2048);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read10_returns_user_data_and_rejects_audio_tracks() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x28, 0, 0, 0, 0, 2, 0, 0, 2, 0]);
+        assert_eq!(data.len(), 2 * DATA_SECTOR_BYTES);
+        assert!(data[..DATA_SECTOR_BYTES].iter().all(|&b| b == 2));
+        assert!(data[DATA_SECTOR_BYTES..].iter().all(|&b| b == 3));
+        // Reading into the audio track is an illegal mode for that track.
+        check_sense(
+            &mut cd,
+            &[0x28, 0, 0, 0, 0, 4, 0, 0, 1, 0],
+            SK_ILLEGAL_REQUEST,
+            ASC_ILLEGAL_MODE_FOR_THIS_TRACK,
+        );
+        // Reading past the end of the disc is out of range.
+        check_sense(
+            &mut cd,
+            &[0x28, 0, 0, 0, 0, 6, 0, 0, 1, 0],
+            SK_ILLEGAL_REQUEST,
+            ASC_LBA_OUT_OF_RANGE,
+        );
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read12_matches_read10() {
+        let (mut cd, paths) = mixed_disc();
+        let ten = data_in(&mut cd, &[0x28, 0, 0, 0, 0, 1, 0, 0, 1, 0]);
+        let twelve = data_in(&mut cd, &[0xA8, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0]);
+        assert_eq!(ten, twelve);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read_toc_lists_tracks_and_lead_out() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x43, 0, 0, 0, 0, 0, 0, 1, 0, 0]);
+        assert_eq!(data[2], 1); // first track
+        assert_eq!(data[3], 2); // last track
+        assert_eq!(be16(&data, 0) as usize, data.len() - 2);
+        // Track 1: data (control 0x14), LBA 0.
+        assert_eq!(data[5], 0x14);
+        assert_eq!(data[6], 1);
+        assert_eq!(be32(&data, 8), 0);
+        // Track 2: audio (control 0x10), LBA 4.
+        assert_eq!(data[13], 0x10);
+        assert_eq!(data[14], 2);
+        assert_eq!(be32(&data, 16), 4);
+        // Lead-out at the disc's end.
+        assert_eq!(data[22], 0xAA);
+        assert_eq!(be32(&data, 24), 6);
+
+        // MSF form: track 1 starts at 00:02:00 (the 150-sector lead-in).
+        let data = data_in(&mut cd, &[0x43, 0x02, 0, 0, 0, 0, 0, 1, 0, 0]);
+        assert_eq!(&data[8..12], &[0, 0, 2, 0]);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read_toc_session_info_names_the_single_session() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x43, 0, 1, 0, 0, 0, 0, 0, 12, 0]);
+        assert_eq!(data[2], 1); // first session
+        assert_eq!(data[3], 1); // last session
+        assert_eq!(data[6], 1); // first track in it
+        assert_eq!(be32(&data, 8), 0);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn mode_sense_carries_cd_pages_and_write_protect() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x1A, 0, 0x3F, 0, 254, 0]);
+        assert_eq!(data[0] as usize, data.len() - 1);
+        assert_eq!(data[2], 0x80); // write-protected medium
+        assert_eq!(data[3], 8); // block descriptor present
+        assert_eq!(be24(&data, 5), 6); // blocks
+        assert_eq!(be24(&data, 9), 2048); // block size
+                                          // Pages 01, 0D, 0E, 2A in ascending order after the descriptor.
+        let mut off = 12;
+        let mut seen = Vec::new();
+        while off + 1 < data.len() {
+            seen.push(data[off]);
+            off += 2 + usize::from(data[off + 1]);
+        }
+        assert_eq!(seen, vec![0x01, 0x0D, 0x0E, 0x2A]);
+
+        // MODE SENSE(10) returns the same pages behind the 8-byte header.
+        let ten = data_in(&mut cd, &[0x5A, 0, 0x2A, 0, 0, 0, 0, 0, 254, 0]);
+        assert_eq!(be16(&ten, 0) as usize, ten.len() - 2);
+        assert_eq!(ten[3], 0x80);
+        assert_eq!(ten[16], 0x2A);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn eject_reload_cycle_reports_not_ready_then_unit_attention() {
+        let (mut cd, paths) = mixed_disc();
+        // Eject the disc: media-access commands report NOT READY.
+        let (_, status) = cd.execute(&[0x1B, 0, 0, 0, 0x02, 0], 0);
+        assert_eq!(status, GOOD);
+        check_sense(
+            &mut cd,
+            &[0x00, 0, 0, 0, 0, 0],
+            SK_NOT_READY,
+            ASC_MEDIUM_NOT_PRESENT,
+        );
+        // INQUIRY still answers while the tray is open.
+        let data = data_in(&mut cd, &[0x12, 0, 0, 0, 36, 0]);
+        assert_eq!(data[0], 0x05);
+        // Reload: the first command reports the medium change once...
+        let (_, status) = cd.execute(&[0x1B, 0, 0, 0, 0x03, 0], 0);
+        assert_eq!(status, GOOD);
+        check_sense(
+            &mut cd,
+            &[0x00, 0, 0, 0, 0, 0],
+            SK_UNIT_ATTENTION,
+            ASC_MEDIUM_MAY_HAVE_CHANGED,
+        );
+        // ...and then the unit is ready again.
+        let (_, status) = cd.execute(&[0x00, 0, 0, 0, 0, 0], 0);
+        assert_eq!(status, GOOD);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read_cd_serves_raw_frames_with_synthesized_headers() {
+        let (mut cd, paths) = mixed_disc();
+        // Full raw frame of a cooked data sector: sync + BCD MSF header.
+        let data = data_in(&mut cd, &[0xBE, 0, 0, 0, 0, 0, 0, 0, 1, 0xF8, 0, 0]);
+        assert_eq!(data.len(), RAW_SECTOR_BYTES);
+        assert_eq!(data[0], 0);
+        assert!(data[1..11].iter().all(|&b| b == 0xFF));
+        assert_eq!(&data[12..16], &[0, 2, 0, 1]); // 00:02:00, mode 1
+        assert!(data[16..16 + DATA_SECTOR_BYTES].iter().all(|&b| b == 0));
+        // User-data-only read of an audio sector is an illegal mode.
+        check_sense(
+            &mut cd,
+            &[0xBE, 0, 0, 0, 0, 4, 0, 0, 1, 0x10, 0, 0],
+            SK_ILLEGAL_REQUEST,
+            ASC_ILLEGAL_MODE_FOR_THIS_TRACK,
+        );
+        // Raw read of the audio sector returns the CD-DA frame verbatim.
+        let data = data_in(&mut cd, &[0xBE, 0x04, 0, 0, 0, 4, 0, 0, 1, 0xF8, 0, 0]);
+        assert!(data.iter().all(|&b| b == 0xA0));
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn play_audio_completes_and_subchannel_reports_the_position() {
+        let (mut cd, paths) = mixed_disc();
+        // Nothing played yet: no audio status.
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_NONE);
+        // Play the audio track (sectors 4-6): completes immediately.
+        let (_, status) = cd.execute(&[0x45, 0, 0, 0, 0, 4, 0, 0, 2, 0], 0);
+        assert_eq!(status, GOOD);
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_COMPLETED);
+        assert_eq!(data[6], 2); // track 2
+        assert_eq!(be32(&data, 8), 5); // absolute position: last played sector
+        assert_eq!(be32(&data, 12), 1); // relative to the track start
+                                        // Playing a data track is an illegal mode.
+        check_sense(
+            &mut cd,
+            &[0x45, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+            SK_ILLEGAL_REQUEST,
+            ASC_ILLEGAL_MODE_FOR_THIS_TRACK,
+        );
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn play_audio_msf_honours_lead_in_offset() {
+        let (mut cd, paths) = mixed_disc();
+        // 00:02:04 - 00:02:06 = sectors 4-6.
+        let (_, status) = cd.execute(&[0x47, 0, 0, 0, 2, 4, 0, 2, 6, 0], 0);
+        assert_eq!(status, GOOD);
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_COMPLETED);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn read_header_names_the_sector_mode() {
+        let (mut cd, paths) = mixed_disc();
+        let data = data_in(&mut cd, &[0x44, 0, 0, 0, 0, 0, 0, 0, 8, 0]);
+        assert_eq!(data[0], 1); // data sector
+        assert_eq!(be32(&data, 4), 0);
+        let data = data_in(&mut cd, &[0x44, 0, 0, 0, 0, 4, 0, 0, 8, 0]);
+        assert_eq!(data[0], 0); // audio sector
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn write_commands_are_rejected_as_invalid_opcodes() {
+        let (mut cd, paths) = mixed_disc();
+        check_sense(
+            &mut cd,
+            &[0x2A, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+            SK_ILLEGAL_REQUEST,
+            ASC_INVALID_OPCODE,
+        );
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn cdrom_target_answers_through_the_wd33c93() {
+        use crate::scsi::{
+            ASR_DBR, ASR_INT, WD_CDB_1, WD_COMMAND, WD_CONTROL, WD_DATA, WD_DESTINATION_ID,
+            WD_SCSI_STATUS, WD_TARGET_LUN, WD_TC_LSB, WD_TC_MID, WD_TC_MSB,
+        };
+        let (cd, paths) = mixed_disc();
+        let mut wd = crate::scsi::Wd33c93::new();
+        wd.attach_target(2, cd);
+        assert!(wd.target_present(2));
+
+        let wr = |wd: &mut crate::scsi::Wd33c93, reg: u8, val: u8| {
+            wd.write_sasr(reg);
+            wd.write_data_port(val);
+        };
+        wr(&mut wd, WD_CONTROL, 0x00); // PIO
+        wr(&mut wd, WD_DESTINATION_ID, 2);
+        wr(&mut wd, WD_TARGET_LUN, 0);
+        wd.write_sasr(WD_CDB_1);
+        for b in [0x12u8, 0, 0, 0, 36, 0] {
+            wd.write_data_port(b);
+        }
+        wr(&mut wd, WD_TC_MSB, 0);
+        wr(&mut wd, WD_TC_MID, 0);
+        wr(&mut wd, WD_TC_LSB, 36);
+        wr(&mut wd, WD_COMMAND, 0x08); // Select-with-ATN-and-Transfer
+        wd.write_sasr(WD_DATA);
+        let mut data = Vec::new();
+        while wd.read_aux_status() & ASR_DBR != 0 {
+            data.push(wd.read_data_port());
+        }
+        for _ in 0..10_000 {
+            wd.tick(16);
+            if wd.read_aux_status() & ASR_INT != 0 {
+                break;
+            }
+        }
+        wd.write_sasr(WD_SCSI_STATUS);
+        let csr = wd.read_data_port();
+        assert_eq!(csr, crate::scsi::CSR_SEL_XFER_DONE);
+        assert_eq!(data[0], 0x05); // a CD-ROM answered
+        cleanup(&paths);
+    }
+}

--- a/src/scsi/cd.rs
+++ b/src/scsi/cd.rs
@@ -7,11 +7,12 @@
 //! CacheCDFS, AsimCDFS and friends) drive through a host adapter's
 //! scsi.device: INQUIRY, READ CAPACITY / READ TOC / READ HEADER /
 //! READ SUB-CHANNEL, the READ family in 2048-byte blocks, READ CD, mode
-//! pages 01h/0Dh/0Eh/2Ah, and the audio-play group. Audio commands keep
-//! coherent status for players, but produce no sound: on real hardware
-//! CD audio leaves through the drive's own analogue output, which is not
-//! cabled to the Amiga's audio path. A play command therefore completes
-//! immediately, and the sub-channel reports the end of the played range.
+//! pages 01h/0Dh/0Eh/2Ah, and the audio-play group. CD-DA playback is
+//! real: the drive paces sectors at 75 per second of emulated time and
+//! streams them into Paula's CD-audio ring, where they are mixed into
+//! the host output at 44.1 kHz -- as if the drive's analogue output were
+//! cabled to the machine's audio path -- and the sub-channel reports the
+//! live playback position.
 
 use super::{
     be16, be24, be32, cdb_len, ScsiExec, ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_INVALID_FIELD_IN_CDB,
@@ -19,14 +20,45 @@ use super::{
     ASC_MEDIUM_NOT_PRESENT, CHECK_CONDITION, GOOD, SENSE_LEN, SK_HARDWARE_ERROR,
     SK_ILLEGAL_REQUEST, SK_NOT_READY, SK_UNIT_ATTENTION,
 };
-use crate::cdrom::{CdImage, CdTrack, DATA_SECTOR_BYTES, LEADIN_SECTORS, RAW_SECTOR_BYTES};
+use crate::cdrom::{
+    CdImage, CdTrack, DATA_SECTOR_BYTES, LEADIN_SECTORS, RAW_SECTOR_BYTES, SECTORS_PER_SECOND,
+};
+use crate::chipset::paula::{CdAudioRing, PAULA_CLOCK_HZ};
 use std::path::{Path, PathBuf};
 
-// READ SUB-CHANNEL audio status codes. "Play in progress" (0x11) never
-// surfaces because play commands complete within the command.
+// READ SUB-CHANNEL audio status codes.
+const AUDIO_STATUS_PLAYING: u8 = 0x11;
 const AUDIO_STATUS_PAUSED: u8 = 0x12;
 const AUDIO_STATUS_COMPLETED: u8 = 0x13;
 const AUDIO_STATUS_NONE: u8 = 0x15;
+
+/// Colour clocks per CD frame: audio plays 75 sectors per second of
+/// emulated time, in step with the mixer draining the ring at 44.1 kHz.
+const CCK_PER_CD_FRAME: u32 = PAULA_CLOCK_HZ / SECTORS_PER_SECOND;
+
+/// Tray travel time for a runtime disc swap: eject and mount stay far
+/// enough apart in emulated time that a filesystem polling TEST UNIT
+/// READY observes the absent-then-present transition.
+const TRAY_CCK: i64 = PAULA_CLOCK_HZ as i64;
+
+/// Audio playback progression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+enum PlayPhase {
+    /// No play operation (or an explicit stop).
+    Idle,
+    Playing,
+    Paused,
+    /// The play range finished.
+    Done,
+}
+
+/// A disc travelling in the tray after a runtime swap.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PendingDisc {
+    image: CdImage,
+    path: PathBuf,
+    tray_cck: i64,
+}
 
 /// A SCSI-2 CD-ROM target backed by a CD image.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -40,10 +72,18 @@ pub struct ScsiCdRom {
     /// Report a medium-change unit attention on the next command.
     unit_attention: bool,
     sense: [u8; SENSE_LEN],
-    /// Audio status byte for READ SUB-CHANNEL.
-    audio_status: u8,
-    /// Disc sector the sub-channel reports as the audio position.
-    audio_pos: u32,
+    /// Audio playback state; the position pair is meaningful outside
+    /// `Idle`.
+    play: PlayPhase,
+    /// Current playback disc sector.
+    play_pos: u32,
+    /// One past the last sector of the play range.
+    play_end: u32,
+    /// Colour-clock countdown pacing audio sector production at 75 Hz.
+    audio_cck: i32,
+    /// Disc waiting in the tray after a runtime swap; mounts (with the
+    /// medium-change unit attention) when the countdown expires.
+    pending: Option<PendingDisc>,
 }
 
 impl ScsiCdRom {
@@ -56,9 +96,123 @@ impl ScsiCdRom {
             loaded: true,
             unit_attention: false,
             sense: [0u8; SENSE_LEN],
-            audio_status: AUDIO_STATUS_NONE,
-            audio_pos: 0,
+            play: PlayPhase::Idle,
+            play_pos: 0,
+            play_end: 0,
+            audio_cck: 0,
+            pending: None,
         })
+    }
+
+    /// Whether a disc is mounted or waiting in the tray.
+    pub fn has_disc(&self) -> bool {
+        self.loaded || self.pending.is_some()
+    }
+
+    /// Whether CD-DA playback is running (not paused or finished).
+    pub fn audio_playing(&self) -> bool {
+        self.play == PlayPhase::Playing
+    }
+
+    /// Whether the drive has emulated-time work in flight (playback or a
+    /// tray load), so its board must not be treated as idle.
+    pub fn needs_tick(&self) -> bool {
+        self.play == PlayPhase::Playing || self.pending.is_some()
+    }
+
+    /// Open the tray: stop playback and drop the medium. The next
+    /// media-access command reports NOT READY.
+    pub fn eject(&mut self) {
+        self.loaded = false;
+        self.pending = None;
+        self.play = PlayPhase::Idle;
+    }
+
+    /// Runtime disc swap: eject now and mount the new disc after the
+    /// tray delay, raising the medium-change unit attention at mount.
+    pub fn swap_disc(&mut self, image: CdImage, path: &Path) {
+        self.eject();
+        self.pending = Some(PendingDisc {
+            image,
+            path: path.to_path_buf(),
+            tray_cck: TRAY_CCK,
+        });
+    }
+
+    /// Advance emulated time: the tray-load countdown, and CD-DA
+    /// playback streaming into the host mixer ring.
+    pub fn tick(&mut self, cck: u32, cd_audio: &mut CdAudioRing) {
+        if let Some(pending) = self.pending.as_mut() {
+            pending.tray_cck -= i64::from(cck);
+            if pending.tray_cck <= 0 {
+                let PendingDisc { image, path, .. } = self.pending.take().unwrap();
+                log::info!("scsi cd: mounted {} ({})", path.display(), image.describe());
+                self.image = image;
+                self.path = path;
+                self.loaded = true;
+                self.unit_attention = true;
+            }
+        }
+        if self.play != PlayPhase::Playing {
+            return;
+        }
+        self.audio_cck -= cck as i32;
+        while self.audio_cck <= 0 && self.play == PlayPhase::Playing {
+            self.audio_cck += CCK_PER_CD_FRAME as i32;
+            self.stream_audio_sector(cd_audio);
+        }
+    }
+
+    /// Produce one CD frame of audio. Data sectors inside the range are
+    /// skipped silently; the range end completes the play operation.
+    fn stream_audio_sector(&mut self, cd_audio: &mut CdAudioRing) {
+        if self.play_pos >= self.play_end {
+            self.play = PlayPhase::Done;
+            self.play_pos = self.play_end.saturating_sub(1);
+            return;
+        }
+        if !cd_audio.wants_sector() {
+            // Mixer backlog: hold this frame slot; production resumes as
+            // the ring drains.
+            return;
+        }
+        let sector = self.play_pos;
+        if self.image.is_audio_sector(sector) {
+            let mut raw = [0u8; RAW_SECTOR_BYTES];
+            if self.image.read_audio_sector(sector, &mut raw).is_ok() {
+                cd_audio.push_sector(&raw);
+            }
+        }
+        self.play_pos += 1;
+    }
+
+    /// The READ SUB-CHANNEL audio status byte for the current state.
+    fn audio_status(&self) -> u8 {
+        match self.play {
+            PlayPhase::Idle => AUDIO_STATUS_NONE,
+            PlayPhase::Playing => AUDIO_STATUS_PLAYING,
+            PlayPhase::Paused => AUDIO_STATUS_PAUSED,
+            PlayPhase::Done => AUDIO_STATUS_COMPLETED,
+        }
+    }
+
+    /// One-line playback status for the debugger's audio tab, `None`
+    /// while no play operation has state to report.
+    pub fn playback_line(&self) -> Option<String> {
+        let verb = match self.play {
+            PlayPhase::Idle => return None,
+            PlayPhase::Playing => "playing",
+            PlayPhase::Paused => "paused",
+            PlayPhase::Done => "done",
+        };
+        let track = self.track_at(self.play_pos).number;
+        let msf = self.play_pos + LEADIN_SECTORS;
+        Some(format!(
+            "{verb} trk {track:02} {:02}:{:02}:{:02}",
+            msf / (60 * SECTORS_PER_SECOND),
+            (msf / SECTORS_PER_SECOND) % 60,
+            msf % SECTORS_PER_SECOND,
+        ))
     }
 
     pub fn path(&self) -> &Path {
@@ -253,19 +407,24 @@ impl ScsiCdRom {
             // MODE SENSE(6)/(10)
             0x1A => self.mode_sense(cdb, false),
             0x5A => self.mode_sense(cdb, true),
-            // START STOP UNIT: with LoEj the tray ejects/reloads the disc.
+            // START STOP UNIT: with LoEj the tray ejects/reloads the disc;
+            // stopping the spindle (either way) ends audio playback.
             0x1B => {
                 let load_eject = cdb[4] & 0x02 != 0;
                 let start = cdb[4] & 0x01 != 0;
+                if !start {
+                    self.play = PlayPhase::Idle;
+                }
                 if load_eject {
                     if start {
-                        if !self.loaded {
+                        // Reload the tray (a disc travelling after a swap
+                        // keeps its own mount countdown).
+                        if !self.loaded && self.pending.is_none() {
                             self.loaded = true;
                             self.unit_attention = true;
                         }
                     } else {
-                        self.loaded = false;
-                        self.audio_status = AUDIO_STATUS_NONE;
+                        self.eject();
                     }
                 }
                 (ScsiExec::NoData, GOOD)
@@ -321,7 +480,7 @@ impl ScsiCdRom {
             0x47 => {
                 let start = match cdb[3] {
                     // FFh: continue from the current position.
-                    0xFF => Some(self.audio_pos),
+                    0xFF => Some(self.play_pos),
                     _ => Self::msf_to_sector(cdb[3], cdb[4], cdb[5]),
                 };
                 let end = Self::msf_to_sector(cdb[6], cdb[7], cdb[8]);
@@ -349,17 +508,17 @@ impl ScsiCdRom {
             }
             // PAUSE / RESUME
             0x4B => {
-                self.audio_status = if cdb[8] & 0x01 != 0 {
-                    // Resume: the (instant) playback has already finished.
-                    AUDIO_STATUS_COMPLETED
-                } else {
-                    AUDIO_STATUS_PAUSED
-                };
+                let resume = cdb[8] & 0x01 != 0;
+                match (resume, self.play) {
+                    (true, PlayPhase::Paused) => self.play = PlayPhase::Playing,
+                    (false, PlayPhase::Playing) => self.play = PlayPhase::Paused,
+                    _ => {}
+                }
                 (ScsiExec::NoData, GOOD)
             }
             // STOP PLAY/SCAN
             0x4E => {
-                self.audio_status = AUDIO_STATUS_NONE;
+                self.play = PlayPhase::Idle;
                 (ScsiExec::NoData, GOOD)
             }
             // READ(12)
@@ -471,8 +630,8 @@ impl ScsiCdRom {
         (ScsiExec::DataIn(data), GOOD)
     }
 
-    /// Play an audio range. Playback is silent and completes within the
-    /// command; the sub-channel then reports the end of the range.
+    /// Start playing an audio range: the drive streams it into the host
+    /// mixer at 75 sectors per second of emulated time from `tick`.
     fn play_range(&mut self, start: u32, end: u32) -> (ScsiExec, u8) {
         if start >= self.total_sectors() || end > self.total_sectors() {
             return self.check(SK_ILLEGAL_REQUEST, ASC_LBA_OUT_OF_RANGE);
@@ -480,8 +639,10 @@ impl ScsiCdRom {
         if !self.image.is_audio_sector(start) {
             return self.check(SK_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
         }
-        self.audio_status = AUDIO_STATUS_COMPLETED;
-        self.audio_pos = end.saturating_sub(1);
+        self.play = PlayPhase::Playing;
+        self.play_pos = start;
+        self.play_end = end;
+        self.audio_cck = 0;
         (ScsiExec::NoData, GOOD)
     }
 
@@ -625,17 +786,17 @@ impl ScsiCdRom {
         let want_subq = cdb[2] & 0x40 != 0;
         let format = cdb[3];
         let alloc = be16(cdb, 7) as usize;
-        let mut data = vec![0u8, self.audio_status, 0, 0];
+        let mut data = vec![0u8, self.audio_status(), 0, 0];
         if want_subq {
             match format {
-                // Current position.
+                // Current position: the live playback cursor.
                 0x01 => {
-                    let track = self.track_at(self.audio_pos);
+                    let track = self.track_at(self.play_pos);
                     let (ctl, number, start) =
                         (Self::ctl_adr(track), track.number, track.start_sector);
                     data.extend_from_slice(&[0x01, ctl, number, 1]);
-                    data.extend_from_slice(&Self::addr4(self.audio_pos, msf));
-                    data.extend_from_slice(&Self::addr4(self.audio_pos.saturating_sub(start), msf));
+                    data.extend_from_slice(&Self::addr4(self.play_pos, msf));
+                    data.extend_from_slice(&Self::addr4(self.play_pos.saturating_sub(start), msf));
                 }
                 // Media catalogue number / ISRC: nothing encoded (the
                 // MCVal/TCVal bit stays clear).
@@ -893,20 +1054,38 @@ mod tests {
     }
 
     #[test]
-    fn play_audio_completes_and_subchannel_reports_the_position() {
+    fn play_audio_streams_sectors_into_the_ring_and_completes() {
         let (mut cd, paths) = mixed_disc();
+        let mut ring = CdAudioRing::default();
         // Nothing played yet: no audio status.
         let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
         assert_eq!(data[1], AUDIO_STATUS_NONE);
-        // Play the audio track (sectors 4-6): completes immediately.
+        // Play the audio track (sectors 4-6): playback starts and runs on
+        // emulated time.
         let (_, status) = cd.execute(&[0x45, 0, 0, 0, 0, 4, 0, 0, 2, 0], 0);
         assert_eq!(status, GOOD);
         let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
-        assert_eq!(data[1], AUDIO_STATUS_COMPLETED);
+        assert_eq!(data[1], AUDIO_STATUS_PLAYING);
+        assert_eq!(be32(&data, 8), 4); // playback cursor at the range start
+
+        // The first CD frame is due immediately; the second after 1/75 s.
+        cd.tick(1, &mut ring);
+        // Sector 4 is all 0xA0 bytes: each s16le sample is 0xA0A0 = -24416.
+        assert_eq!(ring.next_sample(), (-24416.0 / 32768.0, -24416.0 / 32768.0));
+        cd.tick(CCK_PER_CD_FRAME, &mut ring);
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_PLAYING);
         assert_eq!(data[6], 2); // track 2
-        assert_eq!(be32(&data, 8), 5); // absolute position: last played sector
+        assert_eq!(be32(&data, 8), 6); // both sectors produced
+
+        // The frame after the range end completes the play operation.
+        cd.tick(CCK_PER_CD_FRAME, &mut ring);
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_COMPLETED);
+        assert_eq!(be32(&data, 8), 5); // last played sector
         assert_eq!(be32(&data, 12), 1); // relative to the track start
-                                        // Playing a data track is an illegal mode.
+
+        // Playing a data track is an illegal mode.
         check_sense(
             &mut cd,
             &[0x45, 0, 0, 0, 0, 0, 0, 0, 2, 0],
@@ -917,13 +1096,103 @@ mod tests {
     }
 
     #[test]
+    fn pause_resume_and_stop_steer_playback() {
+        let (mut cd, paths) = mixed_disc();
+        let mut ring = CdAudioRing::default();
+        let (_, status) = cd.execute(&[0x45, 0, 0, 0, 0, 4, 0, 0, 2, 0], 0);
+        assert_eq!(status, GOOD);
+        // Pause: no sectors are produced while paused.
+        let (_, status) = cd.execute(&[0x4B, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0);
+        assert_eq!(status, GOOD);
+        cd.tick(4 * CCK_PER_CD_FRAME, &mut ring);
+        assert_eq!(ring.next_sample(), (0.0, 0.0));
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_PAUSED);
+        // Resume plays on; stop clears the operation.
+        let (_, status) = cd.execute(&[0x4B, 0, 0, 0, 0, 0, 0, 0, 1, 0], 0);
+        assert_eq!(status, GOOD);
+        assert!(cd.audio_playing());
+        let (_, status) = cd.execute(&[0x4E, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0);
+        assert_eq!(status, GOOD);
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(data[1], AUDIO_STATUS_NONE);
+        assert!(cd.playback_line().is_none());
+        cleanup(&paths);
+    }
+
+    #[test]
     fn play_audio_msf_honours_lead_in_offset() {
         let (mut cd, paths) = mixed_disc();
         // 00:02:04 - 00:02:06 = sectors 4-6.
         let (_, status) = cd.execute(&[0x47, 0, 0, 0, 2, 4, 0, 2, 6, 0], 0);
         assert_eq!(status, GOOD);
+        assert!(cd.audio_playing());
+        assert_eq!(
+            cd.playback_line().as_deref(),
+            Some("playing trk 02 00:02:04")
+        );
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn disc_swap_travels_through_the_tray_with_unit_attention() {
+        let (mut cd, paths) = mixed_disc();
+        let mut ring = CdAudioRing::default();
+        // Build a second disc (a bare ISO) to swap in.
+        let iso = temp_path("swap.iso");
+        std::fs::write(&iso, vec![0x5Au8; 2 * DATA_SECTOR_BYTES]).unwrap();
+        let image = CdImage::load(&iso).unwrap();
+
+        cd.swap_disc(image, &iso);
+        assert!(cd.has_disc());
+        // While the tray travels the medium is absent.
+        check_sense(
+            &mut cd,
+            &[0x00, 0, 0, 0, 0, 0],
+            SK_NOT_READY,
+            ASC_MEDIUM_NOT_PRESENT,
+        );
+        // The mount lands after the tray delay and latches the medium
+        // change; the first command reports it once.
+        cd.tick(TRAY_CCK as u32 + 1, &mut ring);
+        check_sense(
+            &mut cd,
+            &[0x00, 0, 0, 0, 0, 0],
+            SK_UNIT_ATTENTION,
+            ASC_MEDIUM_MAY_HAVE_CHANGED,
+        );
+        // The new disc is now served: 2 sectors of 0x5A.
+        let data = data_in(&mut cd, &[0x25, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(u32::from_be_bytes(data[0..4].try_into().unwrap()), 1);
+        let data = data_in(&mut cd, &[0x28, 0, 0, 0, 0, 0, 0, 0, 1, 0]);
+        assert!(data.iter().all(|&b| b == 0x5A));
+        let _ = std::fs::remove_file(&iso);
+        cleanup(&paths);
+    }
+
+    #[test]
+    fn ring_backlog_stalls_production_without_losing_sectors() {
+        let (mut cd, paths) = mixed_disc();
+        let mut ring = CdAudioRing::default();
+        // Fill the ring to capacity so the drive cannot push.
+        let sector = [0u8; RAW_SECTOR_BYTES];
+        while ring.wants_sector() {
+            ring.push_sector(&sector);
+        }
+        let (_, status) = cd.execute(&[0x45, 0, 0, 0, 0, 4, 0, 0, 2, 0], 0);
+        assert_eq!(status, GOOD);
+        cd.tick(10 * CCK_PER_CD_FRAME, &mut ring);
+        // Still playing at the range start: nothing was dropped.
         let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
-        assert_eq!(data[1], AUDIO_STATUS_COMPLETED);
+        assert_eq!(data[1], AUDIO_STATUS_PLAYING);
+        assert_eq!(be32(&data, 8), 4);
+        // Drain one sector: production resumes.
+        for _ in 0..588 {
+            ring.next_sample();
+        }
+        cd.tick(CCK_PER_CD_FRAME, &mut ring);
+        let data = data_in(&mut cd, &[0x42, 0, 0x40, 1, 0, 0, 0, 0, 16, 0]);
+        assert_eq!(be32(&data, 8), 5);
         cleanup(&paths);
     }
 

--- a/src/sdmac.rs
+++ b/src/sdmac.rs
@@ -17,6 +17,7 @@
 //! WD33C93 offers or wants within the access that completes the handshake, so
 //! the FIFO always reads back empty and never full.
 
+use crate::chipset::paula::CdAudioRing;
 use crate::memory::Memory;
 use crate::scsi::{DmaDir, ScsiTarget, Wd33c93};
 
@@ -119,6 +120,16 @@ impl Sdmac {
         self.wd.attach_target(unit, target);
     }
 
+    /// The lowest-ID CD-ROM drive on the bus, when one is attached.
+    pub fn first_cd(&self) -> Option<&crate::scsi::ScsiCdRom> {
+        self.wd.first_cd()
+    }
+
+    /// Mutable view of the lowest-ID CD-ROM drive on the bus.
+    pub fn first_cd_mut(&mut self) -> Option<&mut crate::scsi::ScsiCdRom> {
+        self.wd.first_cd_mut()
+    }
+
     /// System reset: clear the DMAC and the SBIC, but keep the mounted drives.
     pub fn reset(&mut self) {
         self.wd.reset();
@@ -135,11 +146,13 @@ impl Sdmac {
         std::mem::take(&mut self.activity) | self.wd.take_activity()
     }
 
-    /// Advance emulated time: deliver delayed WD33C93 interrupts and pump any
-    /// DMA handshake that became ready.
-    pub fn tick(&mut self, cck: u32, mem: &mut Memory) {
+    /// Advance emulated time: deliver delayed WD33C93 interrupts, pump any
+    /// DMA handshake that became ready, and run the targets (a CD-ROM
+    /// drive's tray countdown and CD-DA streaming into the mixer ring).
+    pub fn tick(&mut self, cck: u32, mem: &mut Memory, cd_audio: &mut CdAudioRing) {
         self.wd.tick(cck);
         self.pump_dma(mem);
+        self.wd.tick_targets(cck, cd_audio);
     }
 
     /// Interrupt status. The DMA engine has no FIFO to fill, so it is empty

--- a/src/sdmac.rs
+++ b/src/sdmac.rs
@@ -18,7 +18,7 @@
 //! the FIFO always reads back empty and never full.
 
 use crate::memory::Memory;
-use crate::scsi::{DmaDir, ScsiDisk, Wd33c93};
+use crate::scsi::{DmaDir, ScsiTarget, Wd33c93};
 
 /// Base of the SDMAC register file.
 pub const SDMAC_BASE: u32 = 0x00DD_0000;
@@ -115,8 +115,8 @@ impl Sdmac {
     }
 
     /// Fit a drive at a SCSI ID (0-6; 7 is the controller itself).
-    pub fn attach_drive(&mut self, unit: usize, disk: ScsiDisk) {
-        self.wd.attach_target(unit, disk);
+    pub fn attach_drive(&mut self, unit: usize, target: impl Into<ScsiTarget>) {
+        self.wd.attach_target(unit, target);
     }
 
     /// System reset: clear the DMAC and the SBIC, but keep the mounted drives.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1457,6 +1457,15 @@ impl MachineSetup {
 
     /// The value text shown on a row (the current enum/size/number; the file
     /// name or a placeholder for paths; On/Off for toggles).
+    /// Whether the drive row's volume-name box applies: a name labels a
+    /// directory mount's FFS volume, so a CD image (which attaches a
+    /// CD-ROM drive) has nothing to name.
+    pub fn drive_name_applies(&self, field: LauncherField) -> bool {
+        !self
+            .path(field)
+            .is_some_and(crate::config::is_cd_image_path)
+    }
+
     pub fn value_label(&self, field: LauncherField) -> String {
         match field {
             F::Chipset => chipset_name(self.chipset).to_string(),
@@ -1550,6 +1559,21 @@ impl MachineSetup {
                     "Read-only".to_string()
                 } else {
                     "Read-write".to_string()
+                }
+            }
+            // SCSI units: flag CD images, which attach a CD-ROM drive
+            // rather than a hard disk at that ID.
+            F::ScsiUnit0
+            | F::ScsiUnit1
+            | F::ScsiUnit2
+            | F::ScsiUnit3
+            | F::ScsiUnit4
+            | F::ScsiUnit5
+            | F::ScsiUnit6 => {
+                let label = self.path_label(field, "(none)");
+                match self.path(field) {
+                    Some(p) if crate::config::is_cd_image_path(p) => format!("{label} (CD-ROM)"),
+                    _ => label,
                 }
             }
             // Path/drive fields: the file name, or a placeholder.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -3784,8 +3784,10 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                     if clear.contains(pos) {
                         return Some(UiControl::LauncherClear(r.field));
                     }
-                    // The volume name only matters once an image is chosen.
+                    // The volume name only matters once an image is chosen
+                    // (and never for a CD image).
                     if state.setup.path(r.field).is_some()
+                        && state.setup.drive_name_applies(r.field)
                         && launcher_drive_name_rect(rect, row_y).contains(pos)
                     {
                         return Some(UiControl::LauncherDriveNameEdit(r.field));
@@ -3996,9 +3998,10 @@ fn draw_launcher_row(
             let (browse, clear) = launcher_path_rects(rect, row_y);
             let value_x = launcher_control_x(rect);
             // The volume-name box only appears once an image is chosen (a name
-            // has nothing to label otherwise); until then the row reads like a
-            // plain path row and the path text fills the full width.
-            let has_image = setup.path(r.field).is_some();
+            // has nothing to label otherwise, and never labels a CD image);
+            // until then the row reads like a plain path row and the path text
+            // fills the full width.
+            let has_image = setup.path(r.field).is_some() && setup.drive_name_applies(r.field);
             let name_box = launcher_drive_name_rect(rect, row_y);
             let text_right = if has_image { name_box.x } else { browse.x };
             let avail = text_right.saturating_sub(value_x + 8);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2434,8 +2434,8 @@ enum DroppedMediaKind {
     /// unknown extensions): FloppyImage::from_bytes sniffs the content and
     /// rejects what it cannot read, surfacing a clean OSD failure.
     Floppy,
-    /// A cue sheet for the CD drive (runtime CD loading is cue-only).
-    CdCue,
+    /// A CD image (cue sheet or bare ISO) for the CD drive.
+    Cd,
     /// Hard disk images cannot be hot-attached; point at the config screen.
     HardDisk,
     /// Kickstart ROMs load from the config screen, not at runtime.
@@ -2447,7 +2447,7 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
         .extension()
         .map(|e| e.to_string_lossy().to_ascii_lowercase());
     match ext.as_deref() {
-        Some("cue") | Some("iso") => DroppedMediaKind::CdCue,
+        Some("cue") | Some("iso") => DroppedMediaKind::Cd,
         Some("hdf") | Some("img") => DroppedMediaKind::HardDisk,
         Some("rom") => DroppedMediaKind::Rom,
         _ => DroppedMediaKind::Floppy,
@@ -4161,7 +4161,9 @@ impl App {
                 "Floppy images",
                 &["adf", "adz", "dms", "scp", "gz", "ipf", "zip"],
             ),
-            LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "bin"]),
+            // Only formats CdImage::load takes: a cue sheet or a bare ISO
+            // (a raw .bin is a cue sheet's payload, not loadable alone).
+            LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso"]),
             LauncherField::Cd32Nvram => dialog.add_filter("NVRAM images", &["bin", "nv", "sav"]),
             // SCSI units take hard disks or CD images (a cue/iso attaches a
             // CD-ROM drive at that ID).
@@ -6519,13 +6521,13 @@ impl App {
             return;
         }
         let mut floppies: Vec<PathBuf> = Vec::new();
-        let mut cue: Option<PathBuf> = None;
+        let mut cd: Option<PathBuf> = None;
         let mut notice: Option<&'static str> = None;
         for path in files {
             match classify_dropped_media(&path) {
                 DroppedMediaKind::Floppy => floppies.push(path),
-                // One disc tray; the first cue sheet wins.
-                DroppedMediaKind::CdCue => cue = cue.or(Some(path)),
+                // One disc tray; the first CD image wins.
+                DroppedMediaKind::Cd => cd = cd.or(Some(path)),
                 DroppedMediaKind::HardDisk => {
                     notice = Some("Hard disks are configured in the machine screen");
                 }
@@ -6535,7 +6537,7 @@ impl App {
             }
         }
         let mut handled = false;
-        if let Some(path) = cue {
+        if let Some(path) = cd {
             if self.emu.bus().cd_drive_present() {
                 self.insert_cd_image_from_path(&path);
             } else {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4129,6 +4129,17 @@ impl App {
             ),
             LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "bin"]),
             LauncherField::Cd32Nvram => dialog.add_filter("NVRAM images", &["bin", "nv", "sav"]),
+            // SCSI units take hard disks or CD images (a cue/iso attaches a
+            // CD-ROM drive at that ID).
+            LauncherField::ScsiUnit0
+            | LauncherField::ScsiUnit1
+            | LauncherField::ScsiUnit2
+            | LauncherField::ScsiUnit3
+            | LauncherField::ScsiUnit4
+            | LauncherField::ScsiUnit5
+            | LauncherField::ScsiUnit6 => dialog
+                .add_filter("Hard disk images", &["hdf", "img", "bin"])
+                .add_filter("CD images", &["cue", "iso"]),
             _ => dialog.add_filter("Hard disk images", &["hdf", "img", "bin"]),
         };
         if let Some(dir) = start_dir {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -617,6 +617,10 @@ pub struct App {
     pending_auto_pots: Vec<(f32, u8, u8, u8)>,
     auto_disk_inserts: Vec<ScheduledDiskInsert>,
     pending_auto_disk_inserts: Vec<DiskInsertSpec>,
+    /// Scheduled CD swaps from --insert-cd-after (one-shot each);
+    /// (at_emulated_secs, image path).
+    auto_cd_inserts: Vec<(f64, PathBuf)>,
+    pending_auto_cd_inserts: Vec<(f32, PathBuf)>,
     /// Live-input recorder: logs every input event that reaches the
     /// emulated machine and writes a --script-replayable file on stop.
     /// None while not recording.
@@ -913,6 +917,7 @@ impl App {
         mouse_after: Vec<(f32, i32, i32, u8)>,
         pot_after: Vec<(f32, u8, u8, u8)>,
         disk_insert_after: Vec<DiskInsertSpec>,
+        cd_insert_after: Vec<(f32, PathBuf)>,
         record_input: Option<PathBuf>,
         disk_playlists: [Vec<PathBuf>; 4],
         disk_write_protected: [bool; 4],
@@ -1009,6 +1014,8 @@ impl App {
             pending_auto_pots: pot_after,
             auto_disk_inserts: Vec::new(),
             pending_auto_disk_inserts: disk_insert_after,
+            auto_cd_inserts: Vec::new(),
+            pending_auto_cd_inserts: cd_insert_after,
             input_recorder: record_input
                 .is_some()
                 .then(|| crate::inputrec::InputRecorder::new(0.0)),
@@ -1610,6 +1617,13 @@ impl ApplicationHandler for App {
                 path: insert.path,
                 write_protected: insert.write_protected,
             });
+        }
+        for (secs, path) in self.pending_auto_cd_inserts.drain(..) {
+            info!(
+                "auto-cd armed: insert {} at {secs:.1}s emulated time",
+                path.display()
+            );
+            self.auto_cd_inserts.push((secs.max(0.0) as f64, path));
         }
     }
 
@@ -2335,6 +2349,26 @@ impl ApplicationHandler for App {
         for insert in disk_inserts {
             self.insert_disk_image(insert.drive_idx, insert.path, insert.write_protected);
         }
+        // Fire any scheduled --insert-cd-after swaps (one-shot each).
+        let mut cd_inserts = Vec::new();
+        self.auto_cd_inserts.retain(|(at, path)| {
+            if emu_secs >= *at {
+                cd_inserts.push(path.clone());
+                false
+            } else {
+                true
+            }
+        });
+        for path in cd_inserts {
+            if self.emu.bus().cd_drive_present() {
+                self.insert_cd_image_from_path(&path);
+            } else {
+                warn!(
+                    "--insert-cd-after {}: no CD drive on this machine",
+                    path.display()
+                );
+            }
+        }
         // Input recording: with every input source for this quantum
         // applied (live, gamepad, and the scheduled events above), diff
         // the machine-visible input state once at this quantum's emulated
@@ -2413,7 +2447,7 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
         .extension()
         .map(|e| e.to_string_lossy().to_ascii_lowercase());
     match ext.as_deref() {
-        Some("cue") => DroppedMediaKind::CdCue,
+        Some("cue") | Some("iso") => DroppedMediaKind::CdCue,
         Some("hdf") | Some("img") => DroppedMediaKind::HardDisk,
         Some("rom") => DroppedMediaKind::Rom,
         _ => DroppedMediaKind::Floppy,
@@ -6023,12 +6057,15 @@ impl App {
                     .map(|&s| (s as i16).abs())
                     .max()
                     .unwrap_or(0);
+                // A SCSI CD-ROM drive reports its play operation (state,
+                // track, position); the CDTV/CD32 controllers stream
+                // without one, so their row keeps the scope-derived state.
+                let cd_status = bus
+                    .scsi_cd_playback_line()
+                    .unwrap_or_else(|| if cd_active { "playing" } else { "idle" }.to_string());
                 let cd = ui::AudioRowView {
                     text: vec![
-                        ui::DbgLine::hilit(format!(
-                            "CD-DA  {}",
-                            if cd_active { "playing" } else { "idle" }
-                        )),
+                        ui::DbgLine::hilit(format!("CD-DA  {cd_status}")),
                         ui::DbgLine::plain(format!("  peak {cd_peak:>3}")),
                     ],
                     muted: bus.paula.cd_muted(),
@@ -6429,8 +6466,8 @@ impl App {
     fn load_cd_from_dialog(&mut self) {
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
-            .set_title("Load CD image (cue sheet)")
-            .add_filter("CD cue sheets", &["cue"])
+            .set_title("Load CD image")
+            .add_filter("CD images", &["cue", "iso"])
             .pick_file();
 
         // Re-baseline pacing after the modal dialog, as for floppies.
@@ -6441,12 +6478,13 @@ impl App {
     }
 
     /// Mount a CD image with the media-change notification, ejecting any
-    /// current disc first. Shared by the load dialog and window drops.
+    /// current disc first. Shared by the load dialog, window drops, and
+    /// scheduled `--insert-cd-after` events.
     fn insert_cd_image_from_path(&mut self, path: &std::path::Path) {
         match crate::cdrom::CdImage::load(path) {
             Ok(image) => {
                 info!("cd image: {} ({})", path.display(), image.describe());
-                self.emu.bus_mut().cd_insert_disc(image);
+                self.emu.bus_mut().cd_insert_disc(image, path);
                 self.show_osd(format!("CD: {}", display_file_name(path)));
                 self.request_redraw();
             }
@@ -6469,9 +6507,9 @@ impl App {
 
     /// Route files dropped on the window: floppy images to a drive
     /// (directly, or via the chooser panel when several drives could take
-    /// them), a cue sheet to the CD drive, and everything else to an
-    /// explanatory notice. winit reports drops with no cursor position, so
-    /// the target drive can only be picked after the fact.
+    /// them), a CD image (cue/iso) to the CD drive, and everything else to
+    /// an explanatory notice. winit reports drops with no cursor position,
+    /// so the target drive can only be picked after the fact.
     fn handle_dropped_files(&mut self, files: Vec<PathBuf>) {
         // The configuration screen runs on a placeholder machine: an insert
         // would target hardware the launcher is about to rebuild, and the

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1875,6 +1875,7 @@ fn test_app_with_audio(audio: Box<dyn AudioSink>) -> super::App {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
         None,
         std::array::from_fn(|_| Vec::new()),
         [true; 4],

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3724,7 +3724,8 @@ fn dropped_media_classifies_by_extension() {
     assert_eq!(kind("game.adf.gz"), DroppedMediaKind::Floppy);
     assert_eq!(kind("game.zip"), DroppedMediaKind::Floppy);
     assert_eq!(kind("mystery"), DroppedMediaKind::Floppy);
-    assert_eq!(kind("game.CUE"), DroppedMediaKind::CdCue);
+    assert_eq!(kind("game.CUE"), DroppedMediaKind::Cd);
+    assert_eq!(kind("game.iso"), DroppedMediaKind::Cd);
     assert_eq!(kind("disk.hdf"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("disk.img"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("kick31.rom"), DroppedMediaKind::Rom);

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -163,6 +163,21 @@ impl<'a> DeviceHost<'a> {
         }
     }
 
+    /// A slot-aware host that also exposes Paula's CD-audio ring: the bus
+    /// device-tick loop, where a SCSI board's CD-ROM target streams CD-DA.
+    pub fn for_slot_with_cd_audio(
+        mem: &'a mut Memory,
+        slot: usize,
+        cd_audio: &'a mut CdAudioRing,
+    ) -> Self {
+        Self {
+            mem,
+            cd_audio: Some(cd_audio),
+            self_slot: Some(slot),
+            touched_memory: false,
+        }
+    }
+
     /// The guest memory the board DMAs into.
     pub fn memory_mut(&mut self) -> &mut Memory {
         self.touched_memory = true;
@@ -183,6 +198,12 @@ impl<'a> DeviceHost<'a> {
         self.cd_audio
             .as_deref_mut()
             .expect("DeviceHost::cd_audio requested without a CD-audio ring")
+    }
+
+    /// Paula's CD-audio ring when this host carries one. The bus tick loop
+    /// provides it; hosts built for memory-access dispatch do not.
+    pub fn cd_audio_opt(&mut self) -> Option<&mut CdAudioRing> {
+        self.cd_audio.as_deref_mut()
     }
 
     // These wrap the shared decode for boards that hold a `DeviceHost` rather


### PR DESCRIPTION
## Summary

Adds CD-ROM drives to the SCSI buses (the "at least CD-ROM drives" part of #190). A `[scsi]` unit path ending in `.cue` or `.iso` attaches a SCSI-2 CD-ROM drive at that ID instead of a hard disk, on all three host adapters (A2091/A590, A4091, A3000 motherboard SCSI).

### Target model
- New `ScsiCdRom` (`src/scsi/cd.rs`): a read-only removable type-5 target serving the command surface Amiga CD filesystems drive through `scsi.device` -- the READ family in 2048-byte blocks, READ TOC / READ HEADER / READ SUB-CHANNEL / READ CD (cooked and raw frames with synthesized headers), mode pages 01/0D/0E/2A, MODE SELECT, RESERVE/RELEASE, and START STOP with tray eject/reload plus a medium-change unit attention. NOT READY while the tray is open; REQUEST SENSE/INQUIRY answer throughout.
- The WD33C93 and 53C710 target slots hold a `ScsiTarget` enum (disk or CD-ROM); `STATE_VERSION` 32.
- `CdImage::load` accepts a bare `.iso` (one MODE1/2048 track) alongside cue/bin -- the launcher's CD picker already offered `.iso` but could not load it -- and `[ide]` rejects CD images with a pointer to `[scsi]`, since the emulated IDE port speaks plain ATA with no ATAPI.

### CD audio
- The audio-play group produces sound: the drive paces sectors at 75 per second of emulated time (the same `PAULA_CLOCK_HZ / 75` cadence as the Akiko and CDTV models) into Paula's CD-audio ring, mixing into the host output at 44.1 kHz as if the drive's analogue output were cabled to the machine. PLAY AUDIO (10/MSF/TRACK INDEX), PAUSE/RESUME, and STOP drive a play-state machine; READ SUB-CHANNEL reports the live position; a mixer backlog stalls production without losing sectors.
- The SDMAC tick and the bus's Zorro device-tick loop hand the boards the audio ring, so all three adapters stream.
- The debugger's Audio tab picks the stream up through the shared ring (scope, peak, mute), and its CD-DA status line shows the drive's play operation (state, track, MSF position). The status-bar CD LED lights during playback; data reads ride the HDD LED with the rest of the SCSI bus.

### Disc swap
- Runtime swaps eject, run a one-second emulated tray, and mount the new disc with a medium-change unit attention. The bus CD-media surface routes to the first SCSI CD-ROM when no CDTV/Akiko is fitted, which wires the status-bar CD load/eject buttons, `.cue`/`.iso` window drops, and the control protocol's `media.cd.insert`/`media.cd.eject` in one go.
- New scheduled `--insert-cd-after SECS PATH` flag and script directive for headless runs.

### Machine config
- The launcher's SCSI unit rows offer CD images in the file dialog, label them "(CD-ROM)", and drop the volume-name box (which labels FFS directory mounts, not CDs). Extension-based detection means saved configs round-trip unchanged.

## Verification

`cargo test` (1603 tests, 20+ new), `clippy`, `fmt` all clean, plus headless runs against real guest software:

- **Data mount**: AmigaOS 3.2 CDFileSystem mounts and reads an ISO9660 disc through Kickstart's `scsi.device` on the A3000 SCSI, and through the real A2091 7.0 boot ROM, whose autoboot probe walks past the type-5 unit and boots the system from unit 0.
- **CD audio**: a guest tool issuing PLAY AUDIO MSF via `HD_SCSICMD` plays a 440 Hz test tone from a cue/bin disc; `--audio-wav` capture shows the tone at the disc's amplitude for exactly the played range, on both the A3000 and A2091 paths.
- **Disc swap**: `--insert-cd-after` swaps discs under a live CDFileSystem mount; the guest reads the new disc's contents automatically off the unit attention, no manual DiskChange needed.
- **Save states**: a state saved mid-playback resumes and finishes the tone; a state with a CD target round-trips.

Closes the CD-ROM part of #190; tape drives remain open there.