### PR TITLE
parallel: drive the Centronics status lines from the attached peripheral

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,11 @@ the OS.
 ## Parallel port
 
 Copperline models the Centronics parallel port on CIA-A (data and `PC` strobe
-on port B at `$BFE101`, printer `/ACK` back through CIA-A `FLAG`) and can attach
-one peripheral, chosen by `[parallel] device`. With no `[parallel]` section the
-connector is unplugged.
+on port B at `$BFE101`, printer `/ACK` back through CIA-A `FLAG`, the
+BUSY/POUT/SEL status lines on CIA-B port A) and can attach one peripheral,
+chosen by `[parallel] device`. With no `[parallel]` section the connector is
+unplugged: the status lines float high on their pull-ups, so guest software
+waits for a printer exactly as on a real machine with an empty port.
 
 A **printer** captures the guest's raw byte stream to a file, preserving the
 printer-language bytes verbatim for a compatible converter or spooler:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -566,7 +566,11 @@ names and exits.
 `device` still selects the printer, for compatibility). The file is created at
 startup, replacing any existing file; each strobed byte is written verbatim and
 returns the printer `/ACK` falling edge through CIA-A `FLAG`, including the
-normal CIA interrupt delay. It is intentionally not decoded, since the guest may
+normal CIA interrupt delay. The printer also drives the Centronics status
+lines on CIA-B port A -- SEL high, BUSY and POUT low -- so the guest's
+`parallel.device` sees a ready online printer and starts sending. (Without an
+attached device those lines float high, and printing waits forever for a
+printer to appear, as on a real machine.) It is intentionally not decoded, since the guest may
 emit any printer language; pass it to a converter or spooler afterwards.
 
 `"sampler"` attaches an 8-bit audio sampler (digitizer) on the data lines -- the

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4880,7 +4880,17 @@ impl Bus {
     pub fn cia_b_read(&mut self, addr: u64, size: usize) -> u64 {
         self.sync_realtime_devices();
         let reg = reg_from_addr(addr);
-        let v = self.cia_b.read(reg);
+        let mut v = self.cia_b.read(reg);
+        if reg == REG_PRA {
+            // CIA-B PA0-2 are the parallel port's Centronics status inputs
+            // (BUSY, POUT, SEL), pulled up when nothing drives them. An
+            // attached peripheral holds them at its own levels; pins the
+            // guest has switched to outputs stay CIA-driven.
+            if let Some(lines) = self.parallel_port.control_lines() {
+                let inputs = !self.cia_b.port_a_ddr() & 0x07;
+                v = (v & !inputs) | (lines & inputs);
+            }
+        }
         trace!("cia_b R reg={:X} sz={} val={:02X}", reg, size, v);
         self.poll_stats.tick_read("cia_b", reg);
         if size == 2 {

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -26,8 +26,8 @@ use crate::chipset::agnus::{
     BEAMCON0_VARBEAMEN, COLORCLOCKS_PER_LINE, NTSC_LONG_COLORCLOCKS_PER_LINE, PAL_LINES,
 };
 use crate::chipset::cia::{
-    REG_CRA, REG_CRB, REG_DDRB, REG_ICR, REG_PRA, REG_PRB, REG_TAHI, REG_TALO, REG_TBHI, REG_TBLO,
-    REG_TODHI, REG_TODLO, REG_TODMID,
+    REG_CRA, REG_CRB, REG_DDRA, REG_DDRB, REG_ICR, REG_PRA, REG_PRB, REG_TAHI, REG_TALO, REG_TBHI,
+    REG_TBLO, REG_TODHI, REG_TODLO, REG_TODMID,
 };
 use crate::chipset::copper::{CopperWait, DMACON_COPEN};
 use crate::chipset::denise::{rgb12_to_rgba8, DeniseRevision, DiwHigh, COLOR_TRANSPARENCY_BIT};
@@ -612,6 +612,35 @@ fn cia_a_pc_strobe_reaches_parallel_port_and_ack_drives_cia_a_flag() {
     // peripheral again with the latched pin levels.
     assert_eq!(bus.cia_a_read(addr(REG_PRB), 1), 0xA5);
     assert_eq!(events.lock().unwrap().len(), 2);
+}
+
+#[test]
+fn parallel_peripheral_drives_cia_b_centronics_status_inputs() {
+    let mut bus = empty_bus();
+    let addr = |reg: usize| (reg as u64) << 8;
+
+    // An empty port: BUSY, POUT, and SEL float high on the pull-ups, like
+    // the serial handshake lines on PA3-7. parallel.device reads this as a
+    // busy offline printer and never sends a byte, as on a real machine.
+    assert_eq!(bus.cia_b_read(addr(REG_PRA), 1), 0xFF);
+
+    // A printer holds SEL high with BUSY and POUT low, so the guest reads
+    // $FC: online, ready, paper loaded.
+    let path = std::env::temp_dir().join(format!(
+        "copperline-bus-parallel-status-{}.raw",
+        std::process::id()
+    ));
+    let printer = crate::parallel::FileParallelPort::create(&path).unwrap();
+    bus.attach_parallel_port(Box::new(printer));
+    assert_eq!(bus.cia_b_read(addr(REG_PRA), 1), 0xFC);
+
+    // Pins the guest switches to outputs stay CIA-driven: BUSY written high
+    // as an output reads back high even with the printer attached.
+    let _ = bus.cia_b_write(addr(REG_DDRA), 1, 0x01);
+    let _ = bus.cia_b_write(addr(REG_PRA), 1, 0x01);
+    assert_eq!(bus.cia_b_read(addr(REG_PRA), 1), 0xFD);
+
+    let _ = std::fs::remove_file(path);
 }
 
 #[test]

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -416,6 +416,14 @@ impl Cia {
         std::mem::take(&mut self.pc_pulse_pending)
     }
 
+    /// Port-A data direction register: set bits are CIA-driven outputs. The
+    /// bus consults this to decide which port-A pins an external peripheral
+    /// (the parallel port's Centronics status lines on CIA-B PA0-2) may
+    /// drive.
+    pub fn port_a_ddr(&self) -> u8 {
+        self.regs[REG_DDRA]
+    }
+
     /// Physical port-B pin levels without the `PC` strobe side effect of a
     /// guest PRB read. Motherboard wiring (floppy outputs and the Centronics
     /// data bus) observes pins continuously and must not create a second

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -7,10 +7,21 @@
 //! strobed byte returns `true`; the bus turns that response into the printer's
 //! active-low `/ACK` edge on CIA-A `FLAG`. An input peripheral instead drives
 //! the data pins itself (see [`ParallelPort::read_data`]), which is how an
-//! audio sampler digitizes the port. The default null peripheral is an
-//! unplugged cable: it neither acknowledges nor drives the pins.
+//! audio sampler digitizes the port. The Centronics status lines BUSY, POUT,
+//! and SEL are CIA-B port A pins 0-2 (see [`ParallelPort::control_lines`]);
+//! a printer must hold them at ready-online levels or the guest's
+//! parallel.device never sends a byte. The default null peripheral is an
+//! unplugged cable: it neither acknowledges nor drives any pin.
 
 use std::io::Write;
+
+/// Centronics status-line bits, as wired to CIA-B port A pins 0-2. All three
+/// are peripheral-driven inputs with motherboard pull-ups, so an unplugged
+/// connector reads them all high. The levels are the physical pin states:
+/// BUSY high = not ready, POUT high = out of paper, SEL high = online.
+pub const CTL_BUSY: u8 = 0x01;
+pub const CTL_POUT: u8 = 0x02;
+pub const CTL_SEL: u8 = 0x04;
 
 pub trait ParallelPort: Send {
     /// Observe one CIA-A `PC` strobe with the current physical port-B pin
@@ -25,6 +36,17 @@ pub trait ParallelPort: Send {
     /// pins. `at_cck` is the deterministic power-on colour-clock timestamp,
     /// which a free-running capture device uses to advance in emulated time.
     fn read_data(&mut self, _at_cck: u64) -> Option<u8> {
+        None
+    }
+
+    /// Drive the Centronics status lines BUSY, POUT, and SEL (the `CTL_*`
+    /// bits, CIA-B port A pins 0-2). `Some(bits)` holds the pins at those
+    /// levels; `None` leaves them undriven, so the pull-ups read them all
+    /// high like an unplugged cable -- which is why the guest's
+    /// parallel.device waits forever on an empty port, exactly as on a real
+    /// machine. Pins the guest has switched to outputs stay CIA-driven
+    /// regardless.
+    fn control_lines(&mut self) -> Option<u8> {
         None
     }
 
@@ -78,6 +100,13 @@ impl ParallelPort for FileParallelPort {
         true
     }
 
+    /// A ready online printer: SEL high, BUSY and POUT low. Without these
+    /// levels parallel.device never sends a byte, since its default write
+    /// path polls BUSY before each transfer.
+    fn control_lines(&mut self) -> Option<u8> {
+        Some(CTL_SEL)
+    }
+
     fn flush(&mut self) -> std::io::Result<()> {
         self.writer.flush()
     }
@@ -90,6 +119,21 @@ mod tests {
     #[test]
     fn null_parallel_port_models_an_unplugged_peripheral() {
         assert!(!NullParallelPort.strobe(0x55, 123));
+        assert_eq!(NullParallelPort.control_lines(), None);
+    }
+
+    #[test]
+    fn printer_drives_ready_online_status_lines() {
+        let path = std::env::temp_dir().join(format!(
+            "copperline-parallel-status-{}.raw",
+            std::process::id()
+        ));
+        let mut port = FileParallelPort::create(&path).unwrap();
+        // SEL high (online), BUSY and POUT low (ready, paper loaded).
+        assert_eq!(port.control_lines(), Some(CTL_SEL));
+
+        drop(port);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #138. The parallel-port rework there put the data, strobe, and /ACK on the right CIA, but printing still could not work end-to-end: nothing modelled the Centronics status lines, so the guest's parallel.device never sent a byte.

## Problem

CIA-B port A pins 0-2 are the parallel port's BUSY, POUT, and SEL status inputs, pulled up when undriven. With no peripheral model for them, a guest read of CIA-B PRA returned $FF -- printer busy and out of paper -- and parallel.device's default write path polls BUSY before each transfer. `Copy file TO PAR:` (or `PRT:`) therefore hung forever with an empty capture file: a CIA access trace shows thousands of CIA-B PRA polls reading $FF and zero CIA-A PRB/DDRB accesses. (This is authentic no-printer-connected behaviour, and it predates #138 -- the earlier wiring could not print either.)

## Fix

- `ParallelPort` gains `control_lines() -> Option<u8>` (bits `CTL_BUSY`/`CTL_POUT`/`CTL_SEL`): the pin levels the peripheral holds the three lines at. The default `None` models the unplugged cable, keeping the authentic wait-forever behaviour of an empty port. The sampler is untouched.
- `FileParallelPort` (the printer capture) drives SEL high with BUSY and POUT low: a ready online printer.
- The bus applies the driven levels to CIA-B PRA reads on input pins only; pins the guest has switched to outputs via DDRA stay CIA-driven.

No state-shape change (the port stays serde-skipped host IO), so no STATE_VERSION bump.

## Verification

Headless Workbench 3.2 boot (A4000/IDE, KS 3.2 ROM) with a startup-sequence that copies a 4 KiB `0x00-0xFF` ramp to `PAR:` and a text file to `PRT:` against `--parallel printer`:

- Before: both copies hang, capture empty.
- After: both complete; the capture holds the ramp **byte-exact** (all eight data lines land, correct order) followed by the PRT: text via printer.device + the Generic driver (with its LF -> LF+CR translation), the transfer paced by the PC-strobe -> /ACK -> CIA-A FLAG handshake.

Guest-side note for anyone reproducing: the 3.2 Port-Handler lives on extras3.2.adf (`L/Port-Handler`), and with no printer.prefs, printer.device wants an `Assign PRINTERS: SYS:Devs/Printers`.

Unit tests cover the null port (all lines float high), the printer's ready levels, and DDRA-output pins winning over the peripheral. Full suite 1610 passed / 0 failed; clippy and fmt clean. Docs updated (README parallel section, configuration guide).