### PR TITLE
serial: browser WebSocket bridge and native tcp-connect dial-out

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -9,8 +9,9 @@ name: Browser demo
 # The page shell (try/index.html) is hand-written in the website repository
 # and left alone. This workflow replaces the parts that must change together
 # with the emulator: the wasm-bindgen bundle (try/pkg), the JS glue that
-# drives the WebEmu API (try/try.js, try/audio-worklet.js, sourced from
-# crates/copperline-web/www), and the AROS ROMs (try/aros).
+# drives the WebEmu API (try/try.js, try/serial-telnet.js,
+# try/audio-worklet.js, sourced from crates/copperline-web/www), and the
+# AROS ROMs (try/aros).
 #
 # Pushing to the website repository needs the SITE_DEPLOY_KEY secret: the
 # private half of an SSH deploy key whose public half is installed with
@@ -63,6 +64,7 @@ jobs:
           cp crates/copperline-web/pkg/copperline_web.js \
              crates/copperline-web/pkg/copperline_web_bg.wasm site/try/pkg/
           cp crates/copperline-web/www/try.js \
+             crates/copperline-web/www/serial-telnet.js \
              crates/copperline-web/www/audio-worklet.js site/try/
           cp assets/aros/aros-amiga-m68k-rom.bin \
              assets/aros/aros-amiga-m68k-ext.bin \

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -382,13 +382,18 @@ floppy_sounds_volume = 100
 #   "tcp"     serial in/out is bridged to a host TCP port, like UAE's "TCP:"
 #             device. listen sets the bind address (default 127.0.0.1:1234);
 #             connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
+#   "tcp-connect"
+#             the outbound counterpart of "tcp": dial the remote named by
+#             connect (required, "host:port") at startup - a telnet BBS, a
+#             tcpser modem bridge, any TCP byte service.
 #   "pty"     serial in/out is bridged to a host pseudo-terminal (Unix only).
 #             The slave path (/dev/pts/N) is logged at startup; attach a
 #             terminal with e.g. `minicom -D`, `screen`, or `cu -l`.
 # With an AUX: shell on the Amiga side, "tcp"/"pty" give a remote AmigaDOS
-# console. --serial MODE overrides this per run; --midi-out/--midi-in NAME
-# imply "midi".
+# console. --serial MODE overrides this per run; --serial-connect HOST:PORT
+# implies "tcp-connect"; --midi-out/--midi-in NAME imply "midi".
 # mode = "stdout"
+# connect = "bbs.example.com:1337"
 # midi_out = "USB MIDI Interface"
 # midi_in = "USB MIDI Interface"
 # listen = "127.0.0.1:1234"

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -17,6 +17,7 @@ use std::rc::Rc;
 use copperline::audio::AudioSink;
 use copperline::config::{Config, Overscan};
 use copperline::emulator::{build_machine, Emulator};
+use copperline::serial::{ChannelSerialHandle, ChannelSerialSink};
 use copperline::video::deinterlace::Deinterlacer;
 use copperline::video::{bitplane, present_common, FB_WIDTH, MAX_FB_PIXELS};
 use wasm_bindgen::prelude::*;
@@ -201,6 +202,9 @@ pub struct WebEmu {
     /// first `run` call after (re)boot.
     anchor: Option<(f64, f64)>,
     mouse_remainder: (f64, f64),
+    /// Host side of Paula's serial port; the page bridges it to whatever
+    /// byte stream it likes (typically a WebSocket to a telnet gateway).
+    serial: ChannelSerialHandle,
 }
 
 #[wasm_bindgen]
@@ -214,7 +218,13 @@ impl WebEmu {
         let sink = WebAudioSink { buf: audio.clone() };
         // rom_optional: the default rom_path names the bundled AROS file,
         // which does not exist in the browser; build with a placeholder.
-        let emu = build_machine(&cfg, Box::new(sink), false, true).map_err(js_err)?;
+        let mut emu = build_machine(&cfg, Box::new(sink), false, true).map_err(js_err)?;
+        // Replace the default stdout serial sink (useless in a browser) with
+        // the channel pair the serial_* methods drive. Paula keeps host sinks
+        // across resets and ROM swaps, so installing it once here holds for
+        // the machine's whole life.
+        let (serial_sink, serial) = ChannelSerialSink::pair();
+        emu.bus_mut().paula.serial = Box::new(serial_sink);
         Ok(WebEmu {
             emu,
             audio,
@@ -226,6 +236,7 @@ impl WebEmu {
             last_rendered_frame: None,
             anchor: None,
             mouse_remainder: (0.0, 0.0),
+            serial,
         })
     }
 
@@ -459,6 +470,30 @@ impl WebEmu {
             .floppy
             .eject_disk_image(drive as usize)
             .map_err(js_err)
+    }
+
+    /// Queue received bytes for Paula's serial receiver (the page's
+    /// socket -> the guest). The queue is unbounded and the UART consumes it
+    /// at the emulated baud rate, so pace large transfers with
+    /// `serial_input_backlog` instead of pushing megabytes at once.
+    pub fn serial_send(&mut self, bytes: Vec<u8>) {
+        self.serial.push_input(&bytes);
+    }
+
+    /// Drain everything the guest transmitted on the serial port since the
+    /// last call (the guest -> the page's socket). Call once per animation
+    /// frame, like `take_audio`; output is bounded, and anything a
+    /// non-draining page lets pile up past that bound is dropped oldest
+    /// first. This also carries boot-ROM/OS debug output, so a page may log
+    /// it even with no socket connected.
+    pub fn serial_take(&mut self) -> Vec<u8> {
+        self.serial.take_output()
+    }
+
+    /// Bytes queued by `serial_send` that the guest's UART has not yet
+    /// consumed. Flow control: stop reading the socket while this is large.
+    pub fn serial_input_backlog(&self) -> u32 {
+        self.serial.input_backlog().min(u32::MAX as usize) as u32
     }
 
     /// Cold reset (power cycle), keeping the fitted ROM and inserted disks.

--- a/crates/copperline-web/www/serial-telnet.js
+++ b/crates/copperline-web/www/serial-telnet.js
@@ -80,6 +80,10 @@ export class TelnetSession {
       switch (this.state) {
         case 'data':
           if (b === IAC) {
+            // CR/NUL collapsing applies only to adjacent data bytes: a
+            // command sequence starting here must not leave a stale CR
+            // flag that would swallow a later, unrelated NUL.
+            this.lastWasCr = false;
             this.state = 'iac';
           } else if (this.lastWasCr && b === 0 && !this.remoteOn.has(OPT_BINARY)) {
             // CR NUL is the NVT encoding of a bare CR; the CR already went

--- a/crates/copperline-web/www/serial-telnet.js
+++ b/crates/copperline-web/www/serial-telnet.js
@@ -1,0 +1,189 @@
+// Telnet NVT (RFC 854) layer for the browser serial bridge: the thin
+// protocol between a raw byte stream (the emulated Amiga's serial port) and
+// a telnet server (a BBS) reached over a WebSocket-to-TCP gateway.
+//
+// The guest side is a plain terminal program talking to serial.device, so it
+// knows nothing of IAC negotiation; this module answers the server's option
+// negotiation, unescapes inbound data, and escapes outbound data. It
+// deliberately implements the minimal subset a BBS session needs:
+//
+// - ECHO (1) and SUPPRESS-GO-AHEAD (3): accepted from the server, the normal
+//   character-at-a-time BBS mode.
+// - BINARY (0): accepted both ways, which telnet-aware BBSes negotiate
+//   before ZModem transfers so nothing rewrites the stream.
+// - TERMINAL-TYPE (24): answered with a fixed name ("ANSI" by default),
+//   which BBS menus use to pick their art/charset.
+// - Everything else is refused (WONT/DONT), which every server must accept.
+//
+// Data transforms: IAC (0xFF) bytes are doubled outbound and undoubled
+// inbound; in non-binary mode a bare outbound CR becomes CR NUL (the RFC
+// form, servers strip the NUL) and an inbound CR NUL becomes CR.
+//
+// Usage:
+//   const telnet = new TelnetSession();
+//   ws.onmessage: const { data, reply } = telnet.receive(bytes);
+//                 if (reply.length) ws.send(reply);   // negotiation answers
+//                 feed data to the guest;
+//   guest output: ws.send(telnet.send(bytes));
+
+const IAC = 255;
+const DONT = 254;
+const DO = 253;
+const WONT = 252;
+const WILL = 251;
+const SB = 250;
+const SE = 240;
+
+const OPT_BINARY = 0;
+const OPT_ECHO = 1;
+const OPT_SGA = 3;
+const OPT_TTYPE = 24;
+
+const TTYPE_IS = 0;
+const TTYPE_SEND = 1;
+
+export class TelnetSession {
+  constructor({ termType = 'ANSI' } = {}) {
+    this.termType = termType;
+    // Parser state: 'data', 'iac', 'opt' (after WILL/WONT/DO/DONT),
+    // 'sb' (inside a subnegotiation), 'sb-iac' (IAC seen inside one).
+    this.state = 'data';
+    this.command = 0; // the pending WILL/WONT/DO/DONT verb
+    this.sb = []; // subnegotiation payload, first byte is the option
+    this.lastWasCr = false;
+    // Negotiated option state. Tracking it (rather than blindly acking)
+    // is what prevents the ack loops RFC 854 warns about: an option
+    // already in the requested state is not re-acknowledged.
+    this.remoteOn = new Set(); // options the server WILLed and we accepted
+    this.localOn = new Set(); // options we agreed to perform (DO -> WILL)
+  }
+
+  // Options we agree to perform ourselves when the server sends IAC DO x.
+  acceptsLocal(opt) {
+    return opt === OPT_BINARY || opt === OPT_SGA || opt === OPT_TTYPE;
+  }
+
+  // Options we want the server to perform when it offers IAC WILL x.
+  acceptsRemote(opt) {
+    return opt === OPT_BINARY || opt === OPT_ECHO || opt === OPT_SGA;
+  }
+
+  /**
+   * Feed bytes received from the socket. Returns { data, reply }: `data`
+   * is the application byte stream for the guest, `reply` is negotiation
+   * output that must be sent back over the socket (already escaped).
+   */
+  receive(bytes) {
+    const data = [];
+    const reply = [];
+    for (const b of bytes) {
+      switch (this.state) {
+        case 'data':
+          if (b === IAC) {
+            this.state = 'iac';
+          } else if (this.lastWasCr && b === 0 && !this.remoteOn.has(OPT_BINARY)) {
+            // CR NUL is the NVT encoding of a bare CR; the CR already went
+            // through, so the NUL is swallowed.
+            this.lastWasCr = false;
+          } else {
+            this.lastWasCr = b === 13;
+            data.push(b);
+          }
+          break;
+        case 'iac':
+          if (b === IAC) {
+            // Doubled IAC is a literal 0xFF data byte.
+            data.push(IAC);
+            this.state = 'data';
+          } else if (b === WILL || b === WONT || b === DO || b === DONT) {
+            this.command = b;
+            this.state = 'opt';
+          } else if (b === SB) {
+            this.sb = [];
+            this.state = 'sb';
+          } else {
+            // NOP, GA, AYT, ... - nothing a BBS bridge needs to act on.
+            this.state = 'data';
+          }
+          break;
+        case 'opt':
+          this.negotiate(this.command, b, reply);
+          this.state = 'data';
+          break;
+        case 'sb':
+          if (b === IAC) this.state = 'sb-iac';
+          else this.sb.push(b);
+          break;
+        case 'sb-iac':
+          if (b === SE) {
+            this.subnegotiate(this.sb, reply);
+            this.state = 'data';
+          } else {
+            // IAC IAC inside a subnegotiation is a literal 0xFF.
+            this.sb.push(b);
+            this.state = 'sb';
+          }
+          break;
+      }
+    }
+    return { data: Uint8Array.from(data), reply: Uint8Array.from(reply) };
+  }
+
+  negotiate(command, opt, reply) {
+    switch (command) {
+      case DO: // the server asks us to perform `opt`
+        if (this.acceptsLocal(opt)) {
+          if (!this.localOn.has(opt)) {
+            this.localOn.add(opt);
+            reply.push(IAC, WILL, opt);
+          }
+        } else {
+          reply.push(IAC, WONT, opt);
+        }
+        break;
+      case DONT:
+        if (this.localOn.delete(opt)) reply.push(IAC, WONT, opt);
+        break;
+      case WILL: // the server offers to perform `opt`
+        if (this.acceptsRemote(opt)) {
+          if (!this.remoteOn.has(opt)) {
+            this.remoteOn.add(opt);
+            reply.push(IAC, DO, opt);
+          }
+        } else {
+          reply.push(IAC, DONT, opt);
+        }
+        break;
+      case WONT:
+        if (this.remoteOn.delete(opt)) reply.push(IAC, DONT, opt);
+        break;
+    }
+  }
+
+  subnegotiate(sb, reply) {
+    // The only subnegotiation we volunteered for: TTYPE SEND -> TTYPE IS.
+    if (sb.length >= 2 && sb[0] === OPT_TTYPE && sb[1] === TTYPE_SEND) {
+      reply.push(IAC, SB, OPT_TTYPE, TTYPE_IS);
+      for (const c of this.termType) reply.push(c.charCodeAt(0) & 0x7f);
+      reply.push(IAC, SE);
+    }
+  }
+
+  /**
+   * Escape guest output for the wire: double IAC bytes, and in non-binary
+   * mode send a bare CR as CR NUL (its NVT encoding).
+   */
+  send(bytes) {
+    const out = [];
+    for (const b of bytes) {
+      if (b === IAC) {
+        out.push(IAC, IAC);
+      } else if (b === 13 && !this.localOn.has(OPT_BINARY)) {
+        out.push(13, 0);
+      } else {
+        out.push(b);
+      }
+    }
+    return Uint8Array.from(out);
+  }
+}

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -9,6 +9,7 @@
 // worklet. Everything is served from this site - no external requests.
 
 import init, { WebEmu } from './pkg/copperline_web.js';
+import { TelnetSession } from './serial-telnet.js';
 
 const $ = (id) => document.getElementById(id);
 const canvas = $('screen');
@@ -389,6 +390,8 @@ function tick(nowMs) {
     audioNode.port.postMessage(audio, [audio.buffer]);
   }
 
+  pumpSerial();
+
   if (nowMs - lastStatUpdate >= 1000) {
     statLine.textContent =
       `${framesThisSecond} fps | ` +
@@ -405,6 +408,103 @@ document.addEventListener('visibilitychange', () => {
   if (document.hidden) audioCtx.suspend();
   else audioCtx.resume();
 });
+
+// --- serial / BBS bridge ---------------------------------------------------
+// Optional page feature: a shell that provides #serial-url (text input) and
+// #serial-connect (button) gets the Amiga serial port bridged to a WebSocket
+// (a websockify-style gateway in front of a telnet BBS or any TCP service).
+// #serial-status (a status span) and #serial-raw (a checkbox that bypasses
+// the telnet layer, for gateways to non-telnet services) are optional too.
+// Pages without the elements are untouched - the pump still drains the
+// guest's bounded serial buffer every frame, it just goes nowhere.
+
+const serialUrlInput = $('serial-url');
+const serialConnectBtn = $('serial-connect');
+const serialStatus = $('serial-status');
+const serialRawToggle = $('serial-raw');
+
+let serialWs = null;
+let serialTelnet = null;
+// Inbound chunks the guest's UART has not had room for yet. The UART
+// consumes at the emulated baud rate, so a fast sender (a file download)
+// backlogs here rather than ballooning inside the wasm heap.
+let serialRxQueue = [];
+// Stop feeding the guest while its input backlog exceeds this many bytes;
+// the queue above absorbs the difference, a frame at a time.
+const SERIAL_BACKLOG_LIMIT = 32768;
+
+function setSerialStatus(text) {
+  if (serialStatus) serialStatus.textContent = text;
+}
+
+function serialDisconnect(status) {
+  if (serialWs) {
+    // Neuter the handlers first: close() fires onclose asynchronously, and
+    // a stale handler would clobber the status of a connection made later.
+    serialWs.onopen = serialWs.onclose = serialWs.onerror = serialWs.onmessage = null;
+    serialWs.close();
+    serialWs = null;
+  }
+  serialTelnet = null;
+  serialRxQueue = [];
+  if (serialConnectBtn) serialConnectBtn.textContent = 'Connect';
+  setSerialStatus(status);
+}
+
+function serialConnect() {
+  const url = serialUrlInput?.value?.trim();
+  if (!url) {
+    setSerialStatus('enter a ws:// or wss:// gateway URL');
+    return;
+  }
+  let ws;
+  try {
+    ws = new WebSocket(url);
+  } catch (e) {
+    setSerialStatus(`bad URL: ${e.message ?? e}`);
+    return;
+  }
+  ws.binaryType = 'arraybuffer';
+  serialWs = ws;
+  serialTelnet = serialRawToggle?.checked ? null : new TelnetSession();
+  serialRxQueue = [];
+  if (serialConnectBtn) serialConnectBtn.textContent = 'Disconnect';
+  setSerialStatus('connecting...');
+  ws.onopen = () => setSerialStatus(`connected (${serialTelnet ? 'telnet' : 'raw'})`);
+  ws.onclose = () => serialDisconnect('disconnected');
+  ws.onerror = () => setSerialStatus('connection failed');
+  ws.onmessage = (e) => {
+    let bytes = new Uint8Array(e.data);
+    if (serialTelnet) {
+      const { data, reply } = serialTelnet.receive(bytes);
+      if (reply.length && ws.readyState === WebSocket.OPEN) ws.send(reply);
+      bytes = data;
+    }
+    if (bytes.length) serialRxQueue.push(bytes);
+  };
+}
+
+if (serialConnectBtn) {
+  serialConnectBtn.addEventListener('click', () => {
+    if (serialWs) serialDisconnect('disconnected');
+    else serialConnect();
+  });
+}
+
+function pumpSerial() {
+  if (!emu) return;
+  // Guest -> socket. Drained every frame even with no socket connected, so
+  // the guest's bounded output buffer (which also carries boot-ROM debug
+  // chatter) never overflows into dropped bytes mid-session.
+  const out = emu.serial_take();
+  if (out.length && serialWs?.readyState === WebSocket.OPEN) {
+    serialWs.send(serialTelnet ? serialTelnet.send(out) : out);
+  }
+  // Socket -> guest, paced by the UART's own consumption.
+  while (serialRxQueue.length && emu.serial_input_backlog() < SERIAL_BACKLOG_LIMIT) {
+    emu.serial_send(serialRxQueue.shift());
+  }
+}
 
 // --- joystick (port 2) -----------------------------------------------------
 // The toggle cycles off -> keys (-> touch on touch screens). Keys is the

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -202,7 +202,10 @@ feeds from the desktop frontend's FS-UAE-compatible keyboard mapping
 (cursor keys, Right Ctrl / Right Alt fire, CD32 extras on C/X/D/S/Enter/Z/A).
 `reset()` power-cycles, `eject_floppy(n)`
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
-exposes the guest clock for diagnostics. The presentation pointer is only
+exposes the guest clock for diagnostics. `serial_send(bytes)`,
+`serial_take()` and `serial_input_backlog()` bridge Paula's serial port to
+whatever byte stream the page likes (see
+[the serial bridge section](#browser-serial-bridge)). The presentation pointer is only
 valid until the next `run` call -- rebuild the typed-array view every frame,
 because wasm memory can grow. The presentation *size* is dynamic too:
 `present_width()` and `present_rows()` change when the guest switches
@@ -212,6 +215,49 @@ from both every frame rather than assuming fixed dimensions.
 
 `www/try.js` and `www/audio-worklet.js` are the reference implementation of
 all of the above, including the audio drift control.
+
+(browser-serial-bridge)=
+## The serial port: dialling a BBS from a browser
+
+The wasm build exposes Paula's serial port as a byte channel, so a page can
+bridge the emulated Amiga to a network service -- the classic use being a
+telnet BBS, with a terminal program running on the guest. Three calls:
+
+- `serial_send(bytes)` queues received bytes for the guest's UART. The
+  queue is unbounded and consumed at the emulated baud rate, so pace large
+  transfers with `serial_input_backlog()` (stop reading the socket while
+  it is large) instead of pushing megabytes at once.
+- `serial_take()` drains everything the guest transmitted since the last
+  call; call it once per animation frame like `take_audio`. The buffer
+  behind it is bounded (oldest bytes drop if a page never drains), and it
+  also carries boot-ROM/OS debug output, which a page may simply log.
+- `serial_input_backlog()` reports the bytes `serial_send` has queued that
+  the UART has not yet consumed -- the flow-control signal.
+
+Browsers cannot open raw TCP, so the page's transport is a WebSocket to a
+gateway that forwards to the real service --
+[websockify](https://github.com/novnc/websockify) in front of a telnet
+port is the standard shape, and the page must use `wss://` when it is
+served over HTTPS. Telnet servers also negotiate options in-band (IAC
+sequences) that a guest terminal program knows nothing about;
+`www/serial-telnet.js` is a small NVT layer that answers the negotiation
+(ECHO, suppress-go-ahead, binary mode for ZModem, and a terminal-type
+reply of "ANSI"), unescapes inbound data, and escapes outbound data.
+
+`try.js` wires all of this up when the page shell provides the elements:
+an input `#serial-url` for the gateway URL, a button `#serial-connect`,
+and optionally a status span `#serial-status` and a checkbox `#serial-raw`
+that bypasses the telnet layer (for gateways to non-telnet byte services).
+The hosted `/try` page omits them; a page embedding the emulator next to a
+BBS adds four elements and inherits the whole flow. The guest side needs a
+terminal program on a bootable disk (set to serial.device, 8N1 -- the
+bridge carries whatever baud the guest picks), inserted like any other
+floppy.
+
+On the desktop build the equivalent is `[serial] mode = "tcp-connect"`
+plus `connect = "host:port"` (or `--serial-connect host:port`), which
+dials the service directly with no gateway in between; see
+[the configuration chapter](configuration.md).
 
 (benchmarking-the-core-as-wasm)=
 ## Benchmarking the core as wasm

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -514,10 +514,11 @@ run. (`auto` is still accepted here as a backward-compatibility alias for
 
 ```toml
 [serial]
-mode = "stdout"          # off, stdout, midi, tcp, or pty
+mode = "stdout"          # off, stdout, midi, tcp, tcp-connect, or pty
 # midi_out = "FluidSynth"  # midi mode: host destination, substring match
 # midi_in = "Keystation"   # midi mode: host source, substring match
 # listen = "127.0.0.1:1234"  # tcp mode: bind address
+# connect = "bbs.example.com:1337"  # tcp-connect mode: remote to dial
 ```
 
 The Amiga serial port doubles as the MIDI port. `mode` selects where
@@ -533,15 +534,28 @@ Paula's serial in/out is connected:
 - `tcp` -- serial in/out is bridged to a host TCP port, like UAE's `TCP:`
   device. `listen` sets the bind address (default `127.0.0.1:1234`);
   connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
+- `tcp-connect` -- the outbound counterpart of `tcp`: at startup the
+  serial port dials the remote named by `connect` (required, `host:port`)
+  and the session talks to that service. Point a guest terminal program
+  at a telnet BBS, a `tcpser` modem bridge, or any TCP byte service. The
+  connection is made once; if the remote hangs up, output drops like an
+  unplugged cable until the next run. Note that the wire carries raw
+  bytes: for telnet servers that insist on option negotiation, put a
+  telnet-aware relay in between, or pick a BBS/port that accepts raw
+  connections (most do).
 - `pty` -- serial in/out is bridged to a host pseudo-terminal (Unix only).
   The slave path (`/dev/pts/N`) is logged at startup; attach a terminal
   with e.g. `minicom -D`, `screen`, or `cu -l`.
 
 With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
-console. `--serial MODE` overrides the mode per run, and
-`--midi-out NAME`/`--midi-in NAME` imply `mode = "midi"`. The launcher's
-**Serial** tab and the in-window **MIDI In / MIDI Out** menu items select
-the MIDI endpoints interactively.
+console. `--serial MODE` overrides the mode per run,
+`--serial-connect HOST:PORT` sets the dial-out target (and implies
+`mode = "tcp-connect"`), and `--midi-out NAME`/`--midi-in NAME` imply
+`mode = "midi"`. The launcher's **Serial** tab and the in-window
+**MIDI In / MIDI Out** menu items select the MIDI endpoints interactively.
+
+The browser build has its own serial transport (the page bridges the port
+to a WebSocket); see [the browser chapter](browser.md).
 
 ## `[parallel]` -- Centronics parallel port
 

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -399,7 +399,14 @@ Paula's INTENA/INTREQ levels are delivered as M68K autovectors through the
 modelled IPL pipe and boundary sampling described in [](timing). When the CPU
 executes `STOP`, the frame loop fast-forwards device time to the next
 event that can raise an interrupt instead of spinning -- behaviour the
-debugger's Step control inherits.
+debugger's Step control inherits. One event source is invisible to that
+horizon: a serial sink with a live host input side (TCP, pty, the browser
+channel) can start a reception at any wall-clock moment. While such a sink
+is attached, the blind fast-forward span is capped to a fraction of a
+serial character time, so a byte landing mid-nap raises RBF and wakes the
+CPU before a second byte can complete and overrun Paula's one-word receive
+buffer -- matching a real machine, which wakes from `STOP` within
+microseconds of the interrupt.
 
 ## Exceptions
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4448,7 +4448,16 @@ impl Bus {
         // emulated_cck already covers this span, so it is the color clock at
         // the span's end. Paula uses it to stamp any serial byte that finishes
         // here; passing it avoids arithmetic on the common (no byte) path.
-        self.paula.intreq |= self.paula.tick_serial(cck, self.emulated_cck);
+        // A freshly-raised serial interrupt preempts the slice like any
+        // other interrupt source: OR-ing it in silently would leave a
+        // running CPU blind to RBF until its instruction slice ran out,
+        // which is longer than a character time at BBS baud rates -- the
+        // next word would overrun the one-word receive buffer before the
+        // guest's handler ever ran.
+        let serial_irq = self.paula.tick_serial(cck, self.emulated_cck);
+        if serial_irq != 0 && self.paula.latch_interrupt_sources(serial_irq) {
+            self.slice_preempted = true;
+        }
         let dmacon = self.agnus.dmacon;
         self.flush_audio();
         // The floppy mechanism is quiescent for almost all of normal running

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -8124,6 +8124,27 @@ fn same_line_bplcon3_spres_write_does_not_retime_earlier_live_sprite_playfield_c
 }
 
 #[test]
+fn serial_receive_completion_preempts_the_cpu_slice() {
+    // A word finishing in Paula's receiver raises RBF through the same
+    // slice-preempting path as every other interrupt source. Regression:
+    // the serial tick's bits were OR'd into INTREQ silently, so a running
+    // CPU stayed blind to RBF until its instruction slice ran out --
+    // longer than a character time at BBS baud rates, overrunning the
+    // one-word receive buffer before the guest handler ran.
+    let mut bus = empty_bus();
+    let (sink, handle) = crate::serial::ChannelSerialSink::pair();
+    bus.paula.serial = Box::new(sink);
+    bus.paula.serper = 0; // 1 cck per bit: a word completes in 10 ccks
+    handle.push_input(b"a");
+    bus.begin_cpu_slice();
+
+    bus.advance_devices(20);
+
+    assert!(bus.slice_preempted);
+    assert_ne!(bus.paula.intreq & crate::chipset::paula::INT_RBF, 0);
+}
+
+#[test]
 fn bltsize_starts_dma_and_preempts_cpu_slice_without_irq_preempt() {
     let mut bus = empty_bus();
     bus.paula.intena = INT_BLIT;

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -746,8 +746,13 @@ impl Paula {
             self.intreq |= bits;
         } else {
             self.intreq &= !bits;
+            // Clearing RBF releases the receiver for the next word and
+            // clears OVRUN, but the receive buffer is a physical latch:
+            // its data stays readable in SERDATR until the next word
+            // overwrites it. AROS's level-5 dispatcher relies on this --
+            // it acks INTREQ BEFORE running the RBF handler, which then
+            // reads the still-latched word from SERDATR.
             if bits & INT_RBF != 0 && source_bits & INT_RBF == 0 {
-                self.serial_rx_buffer = None;
                 self.serial_overrun = false;
             }
         }
@@ -1010,7 +1015,12 @@ impl Paula {
             shift.bit_index += 1;
             if shift.bit_index >= shift.total_bits {
                 let word = Self::serdatr_receive_word(shift.word, shift.long);
-                if self.serial_rx_buffer.is_some() {
+                // Overrun is gated on the RBF interrupt flag (the buffer
+                // itself always holds the last received word): a word
+                // completing while RBF is still pending is dropped and
+                // latches OVRUN. `irq` carries completions from earlier in
+                // this same span that the caller has not latched yet.
+                if (self.intreq | irq) & INT_RBF != 0 {
                     self.serial_overrun = true;
                 } else {
                     self.serial_rx_buffer = Some(word);
@@ -3098,6 +3108,34 @@ mod tests {
 
         paula.write_intreq(INT_RBF);
         assert_eq!(paula.read_serdatr() & ((1 << 15) | (1 << 14)), 0);
+    }
+
+    #[test]
+    fn rbf_ack_leaves_received_word_latched_in_serdatr() {
+        // AROS's level-5 dispatcher acks INTREQ BEFORE running the RBF
+        // handler, which then reads the word from SERDATR. The receive
+        // buffer is a physical latch: the ack drops RBF and OVRUN but must
+        // leave the data readable, and with RBF clear the next word stores
+        // instead of overrunning.
+        let (mut paula, _, read) = paula_with_collect_serial();
+        read.lock().unwrap().extend_from_slice(&[0x41, 0x42]);
+
+        assert_eq!(paula.tick_serial(9, 0) & INT_RBF, 0);
+        let irq = paula.tick_serial(1, 0);
+        assert_eq!(irq & INT_RBF, INT_RBF);
+        paula.latch_interrupt_sources(irq);
+
+        paula.write_intreq(INT_RBF); // the AROS-style early ack
+        let serdatr = paula.read_serdatr();
+        assert_eq!(serdatr & (1 << 14), 0, "RBF drops with the ack");
+        assert_eq!(serdatr & 0x00FF, 0x41, "data survives the ack");
+
+        let irq = paula.tick_serial(10, 0);
+        assert_eq!(irq & INT_RBF, INT_RBF, "next word stores, no overrun");
+        paula.latch_interrupt_sources(irq);
+        let serdatr = paula.read_serdatr();
+        assert_eq!(serdatr & 0x00FF, 0x42);
+        assert_eq!(serdatr & (1 << 15), 0);
     }
 
     #[test]

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -1032,10 +1032,19 @@ impl Paula {
             .serial_tx_shift
             .as_ref()
             .map(|shift| shift.remaining_cck.max(1));
+        // Host input waiting with the receiver idle is an imminent event
+        // too: real Paula starts shifting the moment the start bit hits the
+        // pin, so the next span must be short enough to load the shift now.
+        // Without this, an idle machine runs a multi-millisecond span in
+        // which a whole burst loads AND completes inside one tick_serial
+        // call -- the first word buffers, the rest overrun -- before the
+        // CPU ever gets to service RBF, dropping bytes real hardware would
+        // have delivered.
         let rx = self
             .serial_rx_shift
             .as_ref()
-            .map(|shift| shift.remaining_cck.max(1));
+            .map(|shift| shift.remaining_cck.max(1))
+            .or_else(|| self.serial.has_pending_input().then_some(1));
         match (tx, rx) {
             (Some(tx), Some(rx)) => Some(tx.min(rx)),
             (Some(tx), None) => Some(tx),
@@ -2992,6 +3001,32 @@ mod tests {
         assert_eq!(observations[0].word, 0x0041);
         assert!(!observations[0].long);
         assert_eq!(observations[0].at_cck, 100);
+    }
+
+    #[test]
+    fn pending_sink_input_bounds_the_serial_event_horizon() {
+        // An idle receiver with host bytes queued must report an imminent
+        // serial event: real Paula starts shifting when the start bit hits
+        // the pin, so the bus needs a span boundary now, not at the end of
+        // a long idle chunk. Regression: without this, a burst arriving on
+        // an idle machine loaded and completed several words inside one
+        // span -- the first buffered, the rest overran -- before the CPU
+        // ever saw RBF.
+        let (mut paula, _, _) = paula_with_collect_serial_words();
+        paula.serper = 30;
+        assert_eq!(paula.next_serial_event_cck(), None);
+
+        let (sink, handle) = crate::serial::ChannelSerialSink::pair();
+        paula.serial = Box::new(sink);
+        handle.push_input(b"ab");
+        assert_eq!(paula.next_serial_event_cck(), Some(1));
+
+        // Ticking loads the shift; the horizon then tracks it bit by bit,
+        // and the queued second byte keeps the horizon short after the
+        // first completes instead of letting it go idle-long again.
+        assert_eq!(paula.tick_serial(1, 1), 0);
+        let horizon = paula.next_serial_event_cck().expect("shift active");
+        assert!(horizon <= 31, "horizon {horizon} exceeds a bit time");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,6 +292,13 @@ pub enum SerialMode {
     /// serial device. With an `AUX:` shell on the Amiga side, a connected
     /// client gets a remote AmigaDOS console.
     Tcp,
+    /// Serial in/out dials out to a remote TCP service at startup (the
+    /// address in [`SerialConfig::connect`]): a telnet BBS, a `tcpser`
+    /// modem bridge, a `socat`-exposed device. The outbound counterpart
+    /// of [`Tcp`].
+    ///
+    /// [`Tcp`]: SerialMode::Tcp
+    TcpConnect,
     /// Serial in/out is bridged to a host pseudo-terminal. The emulator
     /// allocates a pty and logs the slave path (`/dev/pts/N`); a terminal
     /// program (`minicom`, `screen`, `cu`) attaches to it. Unix hosts only.
@@ -306,6 +313,7 @@ impl SerialMode {
             Self::Stdout => "stdout",
             Self::Midi => "midi",
             Self::Tcp => "tcp",
+            Self::TcpConnect => "tcp-connect",
             Self::Pty => "pty",
         }
     }
@@ -323,6 +331,9 @@ pub struct SerialConfig {
     /// TCP listen address for [`SerialMode::Tcp`]; `None` means the
     /// default `127.0.0.1:1234` (the port UAE's `TCP:` serial uses).
     pub listen: Option<String>,
+    /// Remote `host:port` for [`SerialMode::TcpConnect`]. Required in that
+    /// mode (there is no sensible default host to dial).
+    pub connect: Option<String>,
 }
 
 /// Which peripheral is plugged into the Amiga's Centronics parallel port. The
@@ -1234,9 +1245,13 @@ pub struct ConfigOverrides {
     /// Device in game port 2 (`--port2`). Same parser as `[input] port2`.
     pub port2: Option<String>,
     /// Serial port wiring (`--serial`): "off", "stdout", "midi", "tcp",
-    /// or "pty" ("none" and "terminal" parse as compatibility aliases of
-    /// the first two). Same parser as `[serial] mode`.
+    /// "tcp-connect", or "pty" ("none" and "terminal" parse as
+    /// compatibility aliases of the first two). Same parser as
+    /// `[serial] mode`.
     pub serial: Option<String>,
+    /// Remote host:port the serial port dials (`--serial-connect`),
+    /// implying `--serial tcp-connect`.
+    pub serial_connect: Option<String>,
     /// Host MIDI output endpoint (`--midi-out`), implying `--serial midi`.
     pub midi_out: Option<String>,
     /// Host MIDI input endpoint (`--midi-in`), implying `--serial midi`.
@@ -1280,6 +1295,7 @@ impl ConfigOverrides {
             && self.port1.is_none()
             && self.port2.is_none()
             && self.serial.is_none()
+            && self.serial_connect.is_none()
             && self.midi_out.is_none()
             && self.midi_in.is_none()
             && self.parallel.is_none()
@@ -1334,16 +1350,26 @@ impl ConfigOverrides {
         if let Some(mode) = &self.serial {
             raw.serial.mode = Some(mode.clone());
         }
+        if let Some(addr) = &self.serial_connect {
+            raw.serial.connect = Some(addr.clone());
+        }
         if let Some(out) = &self.midi_out {
             raw.serial.midi_out = Some(out.clone());
         }
         if let Some(input) = &self.midi_in {
             raw.serial.midi_in = Some(input.clone());
         }
-        // Naming a MIDI endpoint on the command line selects MIDI mode unless
-        // `--serial` said otherwise.
+        // Naming a MIDI endpoint or a dial-out address on the command line
+        // selects the matching mode unless `--serial` said otherwise.
         if self.serial.is_none() && (self.midi_out.is_some() || self.midi_in.is_some()) {
             raw.serial.mode = Some(SerialMode::Midi.label().to_string());
+        }
+        if self.serial.is_none()
+            && self.midi_out.is_none()
+            && self.midi_in.is_none()
+            && self.serial_connect.is_some()
+        {
+            raw.serial.mode = Some(SerialMode::TcpConnect.label().to_string());
         }
         if let Some(device) = &self.parallel {
             raw.parallel.device = Some(device.clone());
@@ -1533,6 +1559,9 @@ pub(crate) struct RawSerial {
     /// TCP listen address; tcp mode only. Defaults to 127.0.0.1:1234.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) listen: Option<String>,
+    /// Remote host:port to dial; tcp-connect mode only, and required there.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) connect: Option<String>,
 }
 
 /// `[parallel]` peripheral selection for the Amiga Centronics parallel port.
@@ -2181,6 +2210,7 @@ impl TryFrom<RawConfig> for Config {
             midi_out: raw.serial.midi_out.clone(),
             midi_in: raw.serial.midi_in.clone(),
             listen: raw.serial.listen.clone(),
+            connect: raw.serial.connect.clone(),
         };
 
         let ide = IdeConfig {
@@ -2586,9 +2616,11 @@ pub(crate) fn parse_serial_mode(s: &str) -> Result<SerialMode> {
         "stdout" | "terminal" => Ok(SerialMode::Stdout),
         "midi" => Ok(SerialMode::Midi),
         "tcp" => Ok(SerialMode::Tcp),
+        "tcp-connect" => Ok(SerialMode::TcpConnect),
         "pty" => Ok(SerialMode::Pty),
         _ => Err(anyhow!(
-            "unknown [serial] mode {:?}: expected \"off\", \"stdout\", \"midi\", \"tcp\", or \"pty\"",
+            "unknown [serial] mode {:?}: expected \"off\", \"stdout\", \"midi\", \"tcp\", \
+             \"tcp-connect\", or \"pty\"",
             s
         )),
     }
@@ -5169,6 +5201,38 @@ mod tests {
 
         let err = parse_config("[serial]\nmode = \"rs232\"\n").unwrap_err();
         assert!(err.to_string().contains("unknown [serial] mode"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
+    fn serial_section_selects_tcp_connect_and_address() -> Result<()> {
+        let cfg =
+            parse_config("[serial]\nmode = \"tcp-connect\"\nconnect = \"bbs.example.com:1337\"\n")?;
+        assert_eq!(cfg.serial.mode, SerialMode::TcpConnect);
+        assert_eq!(cfg.serial.connect.as_deref(), Some("bbs.example.com:1337"));
+        Ok(())
+    }
+
+    #[test]
+    fn cli_serial_connect_implies_tcp_connect_mode() -> Result<()> {
+        // Like --midi-out implying midi mode: naming a dial-out address is
+        // enough, unless --serial explicitly chose another mode.
+        let overrides = ConfigOverrides {
+            serial_connect: Some("bbs.example.com:1337".to_string()),
+            ..Default::default()
+        };
+        let cfg = load_overrides(&overrides)?;
+        assert_eq!(cfg.serial.mode, SerialMode::TcpConnect);
+        assert_eq!(cfg.serial.connect.as_deref(), Some("bbs.example.com:1337"));
+
+        let overrides = ConfigOverrides {
+            serial: Some("off".to_string()),
+            serial_connect: Some("bbs.example.com:1337".to_string()),
+            ..Default::default()
+        };
+        let cfg = load_overrides(&overrides)?;
+        assert_eq!(cfg.serial.mode, SerialMode::Off);
+        assert_eq!(cfg.serial.connect.as_deref(), Some("bbs.example.com:1337"));
         Ok(())
     }
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1765,6 +1765,15 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
         SerialMode::Tcp => Ok(Box::new(crate::serial::TcpSerialSink::listen(
             cfg.serial.listen.as_deref().unwrap_or("127.0.0.1:1234"),
         )?)),
+        SerialMode::TcpConnect => {
+            let addr = cfg.serial.connect.as_deref().ok_or_else(|| {
+                anyhow!(
+                    "[serial] mode = \"tcp-connect\" needs a remote address: set \
+                     [serial] connect = \"host:port\" or pass --serial-connect"
+                )
+            })?;
+            Ok(Box::new(crate::serial::TcpSerialSink::connect(addr)?))
+        }
         #[cfg(unix)]
         SerialMode::Pty => Ok(Box::new(crate::serial::PtySerialSink::open()?)),
         #[cfg(not(unix))]

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -18,6 +18,13 @@ use log::{info, warn};
 
 const INSTRUCTIONS_PER_SLICE: usize = 32_000;
 const INSTRUCTIONS_PER_REALTIME_SLICE: usize = 8_192;
+/// Longest blind STOP-state fast-forward, in colour clocks, while a serial
+/// sink with a live host input side is attached (see the cap site in
+/// `idle_fast_forward_chunk`). 256 cck is about 72 microseconds: well under
+/// one character time even at 115200 baud (about 10 x 31 cck), so a byte
+/// arriving from the host mid-nap raises RBF and wakes the CPU before a
+/// second byte can complete and overrun Paula's one-word receive buffer.
+const SERIAL_LIVE_IDLE_CAP_CCK: u32 = 256;
 /// Safety bound on a single reverse-debug replay so a pathological target
 /// (e.g. a permanently halted CPU) cannot spin forever. Far larger than the
 /// instruction distance between two snapshots at any sane capture interval.
@@ -1496,6 +1503,16 @@ impl Emulator {
         }
         if let Some(cck) = bus.next_serial_event_cck() {
             cap_cck(cck, &mut chunk);
+        }
+        // A serial sink wired to a live host byte source (TCP, pty, the
+        // browser channel) can start a reception at any wall-clock moment,
+        // invisibly to the event horizon computed here. Bound the blind nap
+        // while one is attached, so a byte landing mid-nap is recognized
+        // within a fraction of a character time -- a real machine halted in
+        // STOP wakes on RBF within microseconds, and sleeping past a whole
+        // character would overrun the one-word receive buffer.
+        if bus.paula.serial.can_produce_input() {
+            cap_cck(SERIAL_LIVE_IDLE_CAP_CCK, &mut chunk);
         }
         if let Some(cck) = bus.next_keyboard_event_cck() {
             cap_cck(cck, &mut chunk);

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,8 +423,14 @@ where
             }
             "--serial" => {
                 overrides.serial = Some(args.next().ok_or_else(|| {
-                    anyhow!("--serial requires a mode (off/stdout/midi/tcp/pty)")
+                    anyhow!("--serial requires a mode (off/stdout/midi/tcp/tcp-connect/pty)")
                 })?);
+            }
+            "--serial-connect" => {
+                overrides.serial_connect =
+                    Some(args.next().ok_or_else(|| {
+                        anyhow!("--serial-connect requires an address (host:port)")
+                    })?);
             }
             "--midi-out" => {
                 overrides.midi_out = Some(
@@ -955,7 +961,10 @@ fn print_help() {
          \x20                            instead of live output\n  \
          --profile-live-audio SECS      run a no-window Paula-to-cpal profile workload;\n  \
          \x20                            combine with COPPERLINE_AUDIO_PROFILE=1 for counters\n  \
-         --serial MODE                  Paula serial port: off, stdout, midi, tcp, or pty\n  \
+         --serial MODE                  Paula serial port: off, stdout, midi, tcp,\n  \
+         \x20                            tcp-connect, or pty\n  \
+         --serial-connect HOST:PORT     dial a remote TCP service (a telnet BBS) with the\n  \
+         \x20                            serial port (implies --serial tcp-connect)\n  \
          --parallel DEVICE              parallel port: none, printer, or sampler\n  \
          --sampler-audio-input NAME     sampler host capture device (implies --parallel sampler)\n  \
          --sampler-input-gain DB        sampler input gain in dB (implies --parallel sampler)\n  \

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -94,6 +94,17 @@ pub trait SerialSink: Send {
         false
     }
 
+    /// Whether this sink can EVER produce input (a live host byte source is
+    /// wired up), regardless of whether any is pending right now. Input
+    /// arrives on the host's schedule, invisible to the emulated event
+    /// horizon, so the emulator bounds its blind idle fast-forwards while
+    /// such a sink is attached (a real machine halted in STOP wakes within
+    /// microseconds of RBF; a multi-millisecond blind nap would overrun the
+    /// one-word receive buffer instead). Output-only sinks keep the default.
+    fn can_produce_input(&self) -> bool {
+        false
+    }
+
     /// Update the emulated-to-host time mapping (see [`SerialTimeAnchor`]).
     /// Sinks that schedule output store it; others ignore it.
     fn set_time_anchor(&mut self, _anchor: SerialTimeAnchor) {}
@@ -277,6 +288,10 @@ impl SerialSink for TcpSerialSink {
         self.buffered.load(std::sync::atomic::Ordering::Acquire) > 0
     }
 
+    fn can_produce_input(&self) -> bool {
+        true
+    }
+
     fn flush(&mut self) {}
 }
 
@@ -443,6 +458,10 @@ impl SerialSink for PtySerialSink {
         self.buffered.load(std::sync::atomic::Ordering::Acquire) > 0
     }
 
+    fn can_produce_input(&self) -> bool {
+        true
+    }
+
     fn flush(&mut self) {
         let _ = self.master.flush();
     }
@@ -517,6 +536,10 @@ impl SerialSink for ChannelSerialSink {
 
     fn has_pending_input(&self) -> bool {
         self.buffered.load(std::sync::atomic::Ordering::Acquire) > 0
+    }
+
+    fn can_produce_input(&self) -> bool {
+        true
     }
 
     fn flush(&mut self) {}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -115,6 +115,9 @@ pub trait SerialSink: Send {
 /// client at a time; a new connection replaces a finished one. Output with
 /// no client connected is dropped, like an unplugged serial cable.
 ///
+/// [`TcpSerialSink::connect`] is the outbound counterpart: it dials a remote
+/// service (a telnet BBS, a modem bridge) instead of waiting for one.
+///
 /// A background thread owns the accept loop and the read half (pushing
 /// bytes into a channel), so Paula's idle fast path polls a channel probe,
 /// never a socket syscall.
@@ -130,7 +133,8 @@ pub struct TcpSerialSink {
     /// dips to a transient -1 "debt" instead of wrapping to a stuck-huge
     /// unsigned value.
     buffered: std::sync::Arc<std::sync::atomic::AtomicIsize>,
-    /// The bound listen address (resolves port 0 to the real port).
+    /// The bound listen address (resolves port 0 to the real port) in listen
+    /// mode; the connected peer in connect mode.
     local_addr: std::net::SocketAddr,
 }
 
@@ -195,7 +199,55 @@ impl TcpSerialSink {
         })
     }
 
-    /// The bound listen address (a port of 0 in the config resolves here).
+    /// Dial `addr` and bridge Paula's serial port to that connection: the
+    /// outbound counterpart of [`TcpSerialSink::listen`], for talking to a
+    /// service that expects to be called (a telnet BBS, `tcpser`, a
+    /// `socat`-exposed device). The connection is made once at startup; if
+    /// the peer disconnects, output is dropped like an unplugged cable and
+    /// input simply stops (restart the emulator to redial).
+    pub fn connect(addr: &str) -> anyhow::Result<Self> {
+        let stream = std::net::TcpStream::connect(addr)
+            .map_err(|e| anyhow::anyhow!("[serial] tcp-connect: connecting {addr}: {e}"))?;
+        let peer = stream.peer_addr()?;
+        let _ = stream.set_nodelay(true);
+        log::info!("serial: connected to tcp://{peer}");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let writer = std::sync::Arc::new(std::sync::Mutex::new(Some(stream.try_clone()?)));
+        let reader_writer = std::sync::Arc::clone(&writer);
+        let buffered = std::sync::Arc::new(std::sync::atomic::AtomicIsize::new(0));
+        let reader_buffered = std::sync::Arc::clone(&buffered);
+        std::thread::Builder::new()
+            .name("serial-tcp-connect".into())
+            .spawn(move || {
+                use std::io::Read;
+                let mut stream = stream;
+                let mut buf = [0u8; 512];
+                loop {
+                    match stream.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            for &b in &buf[..n] {
+                                if tx.send(b).is_err() {
+                                    return;
+                                }
+                                reader_buffered.fetch_add(1, std::sync::atomic::Ordering::Release);
+                            }
+                        }
+                    }
+                }
+                log::info!("serial: {peer} disconnected");
+                *reader_writer.lock().unwrap() = None;
+            })?;
+        Ok(Self {
+            rx,
+            writer,
+            buffered,
+            local_addr: peer,
+        })
+    }
+
+    /// The bound listen address (a port of 0 in the config resolves here);
+    /// the peer address in connect mode.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn local_addr(&self) -> std::net::SocketAddr {
         self.local_addr
@@ -396,6 +448,130 @@ impl SerialSink for PtySerialSink {
     }
 }
 
+/// Guest->host bytes the channel sink retains while the host does not drain
+/// them. Paula's transmitter tops out around 31 KB/s at practical baud rates,
+/// so this is minutes of headroom; once full the oldest byte is evicted (and
+/// counted), because a frontend that stopped draining must never apply
+/// unbounded memory pressure or back-pressure to the emulated UART.
+pub const CHANNEL_OUTPUT_CAPACITY: usize = 256 * 1024;
+
+/// Queues shared between a [`ChannelSerialSink`] (owned by Paula) and the
+/// [`ChannelSerialHandle`] the host frontend keeps.
+#[derive(Default)]
+struct ChannelSerialShared {
+    /// Host -> guest bytes waiting for Paula's receiver.
+    input: VecDeque<u8>,
+    /// Guest -> host bytes waiting for the frontend to drain.
+    output: VecDeque<u8>,
+    /// Output bytes evicted because the frontend stopped draining.
+    output_dropped: u64,
+}
+
+/// Bidirectional in-process serial bridge with no host I/O of its own: the
+/// frontend pushes received bytes in and drains transmitted bytes out through
+/// a [`ChannelSerialHandle`]. This is the browser build's serial transport --
+/// the page owns the socket (a WebSocket to a telnet bridge), and wasm32 has
+/// no threads or TCP -- but it works the same on any host, so a frontend can
+/// wire the serial port to any byte stream it likes.
+pub struct ChannelSerialSink {
+    shared: std::sync::Arc<std::sync::Mutex<ChannelSerialShared>>,
+    /// Mirror of the input queue length, so `has_pending_input` (`&self`, on
+    /// Paula's idle fast path) reads an atomic instead of taking the lock.
+    /// Signed for the same transient-debt reason as
+    /// [`TcpSerialSink::buffered`].
+    buffered: std::sync::Arc<std::sync::atomic::AtomicIsize>,
+}
+
+impl ChannelSerialSink {
+    /// Create the sink plus the handle the host side keeps. The handle is
+    /// `Clone`, so a frontend can hold it in several places.
+    pub fn pair() -> (Self, ChannelSerialHandle) {
+        let shared = std::sync::Arc::new(std::sync::Mutex::new(ChannelSerialShared::default()));
+        let buffered = std::sync::Arc::new(std::sync::atomic::AtomicIsize::new(0));
+        let handle = ChannelSerialHandle {
+            shared: std::sync::Arc::clone(&shared),
+            buffered: std::sync::Arc::clone(&buffered),
+        };
+        (Self { shared, buffered }, handle)
+    }
+}
+
+impl SerialSink for ChannelSerialSink {
+    fn write_byte(&mut self, b: u8, _at_cck: u64) {
+        let mut shared = self.shared.lock().unwrap();
+        if shared.output.len() == CHANNEL_OUTPUT_CAPACITY {
+            shared.output.pop_front();
+            shared.output_dropped += 1;
+        }
+        shared.output.push_back(b);
+    }
+
+    fn read_byte(&mut self) -> Option<u8> {
+        let b = self.shared.lock().unwrap().input.pop_front();
+        if b.is_some() {
+            self.buffered
+                .fetch_sub(1, std::sync::atomic::Ordering::Release);
+        }
+        b
+    }
+
+    fn has_pending_input(&self) -> bool {
+        self.buffered.load(std::sync::atomic::Ordering::Acquire) > 0
+    }
+
+    fn flush(&mut self) {}
+}
+
+/// The host side of a [`ChannelSerialSink`].
+#[derive(Clone)]
+pub struct ChannelSerialHandle {
+    shared: std::sync::Arc<std::sync::Mutex<ChannelSerialShared>>,
+    buffered: std::sync::Arc<std::sync::atomic::AtomicIsize>,
+}
+
+impl ChannelSerialHandle {
+    /// Queue bytes for Paula's receiver (host -> guest). The input queue is
+    /// unbounded on purpose: the UART consumes it at the emulated baud rate,
+    /// so a fast remote (a file download) backlogs here rather than being
+    /// dropped, and the caller paces its own reads with [`input_backlog`]
+    /// (stop reading the socket while the backlog is large).
+    ///
+    /// [`input_backlog`]: ChannelSerialHandle::input_backlog
+    pub fn push_input(&self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        self.shared
+            .lock()
+            .unwrap()
+            .input
+            .extend(bytes.iter().copied());
+        self.buffered
+            .fetch_add(bytes.len() as isize, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Drain everything the guest has transmitted since the last call.
+    pub fn take_output(&self) -> Vec<u8> {
+        self.shared.lock().unwrap().output.drain(..).collect()
+    }
+
+    /// Bytes pushed with [`push_input`] that the guest's UART has not yet
+    /// consumed. Flow control for the pushing side.
+    ///
+    /// [`push_input`]: ChannelSerialHandle::push_input
+    pub fn input_backlog(&self) -> usize {
+        self.shared.lock().unwrap().input.len()
+    }
+
+    /// Total guest output bytes evicted because [`take_output`] was not
+    /// called often enough (see [`CHANNEL_OUTPUT_CAPACITY`]). Diagnostics.
+    ///
+    /// [`take_output`]: ChannelSerialHandle::take_output
+    pub fn output_overflow(&self) -> u64 {
+        self.shared.lock().unwrap().output_dropped
+    }
+}
+
 /// Inert sink: discards output and never produces input. Placeholder used
 /// where a `Box<dyn SerialSink>` must exist before the host wires the real
 /// one (serde-skipped fields during save-state deserialization).
@@ -495,6 +671,82 @@ mod tests {
             .unwrap();
         client.read_exact(&mut got).unwrap();
         assert_eq!(&got, b"x");
+    }
+
+    #[test]
+    fn tcp_connect_sink_round_trips_input_and_output() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accepted = std::thread::spawn(move || listener.accept().unwrap().0);
+        let mut sink = TcpSerialSink::connect(&addr.to_string()).unwrap();
+        let mut peer = accepted.join().unwrap();
+
+        // Input: bytes the remote service sends reach the sink.
+        peer.write_all(b"ab").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !sink.has_pending_input() {
+            assert!(std::time::Instant::now() < deadline, "input never arrived");
+            std::thread::yield_now();
+        }
+        assert_eq!(sink.read_byte(), Some(b'a'));
+        while !sink.has_pending_input() {
+            assert!(std::time::Instant::now() < deadline, "second byte lost");
+            std::thread::yield_now();
+        }
+        assert_eq!(sink.read_byte(), Some(b'b'));
+        assert!(!sink.has_pending_input());
+
+        // Output: bytes written to the sink arrive at the remote service.
+        sink.write_byte(b'x', 0);
+        let mut got = [0u8; 1];
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .unwrap();
+        peer.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"x");
+    }
+
+    #[test]
+    fn tcp_connect_to_nothing_is_an_error() {
+        // Bind-then-drop yields a port with no listener behind it.
+        let addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap()
+        };
+        assert!(TcpSerialSink::connect(&addr.to_string()).is_err());
+    }
+
+    #[test]
+    fn channel_sink_round_trips_input_and_output() {
+        let (mut sink, handle) = ChannelSerialSink::pair();
+
+        assert!(!sink.has_pending_input());
+        handle.push_input(b"ab");
+        assert_eq!(handle.input_backlog(), 2);
+        assert!(sink.has_pending_input());
+        assert_eq!(sink.read_byte(), Some(b'a'));
+        assert_eq!(sink.read_byte(), Some(b'b'));
+        assert_eq!(sink.read_byte(), None);
+        assert!(!sink.has_pending_input());
+        assert_eq!(handle.input_backlog(), 0);
+
+        sink.write_byte(b'x', 0);
+        sink.write_byte(b'y', 1);
+        assert_eq!(handle.take_output(), b"xy");
+        assert!(handle.take_output().is_empty());
+        assert_eq!(handle.output_overflow(), 0);
+    }
+
+    #[test]
+    fn channel_sink_bounds_undrained_output() {
+        let (mut sink, handle) = ChannelSerialSink::pair();
+        for i in 0..CHANNEL_OUTPUT_CAPACITY + 3 {
+            sink.write_byte(i as u8, i as u64);
+        }
+        let drained = handle.take_output();
+        assert_eq!(drained.len(), CHANNEL_OUTPUT_CAPACITY);
+        // The oldest three bytes were evicted, so the queue starts at 3.
+        assert_eq!(drained[0], 3u8);
+        assert_eq!(handle.output_overflow(), 3);
     }
 
     #[cfg(unix)]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1798,7 +1798,15 @@ impl MachineSetup {
             }
             #[cfg(feature = "midi")]
             F::SerialMode => {
-                self.serial_mode = cycle_slice(&SERIAL_MODES, self.serial_mode, forward)
+                // tcp-connect is only on offer when the config already
+                // carries a dial-out address (the launcher has no editor
+                // for it, and the mode fails at Run without one) -- same
+                // pattern as the printer's capture path below.
+                let choices: Vec<SerialMode> = SERIAL_MODES
+                    .into_iter()
+                    .filter(|m| self.serial_connect.is_some() || *m != SerialMode::TcpConnect)
+                    .collect();
+                self.serial_mode = cycle_slice(&choices, self.serial_mode, forward)
             }
             #[cfg(feature = "midi")]
             F::MidiOut => cycle_endpoint(&mut self.midi_out, &self.midi_endpoints.outputs, forward),
@@ -2705,6 +2713,28 @@ mod tests {
         assert_eq!(setup.serial_listen.as_deref(), Some("0.0.0.0:2323"));
         let back = setup.to_raw();
         assert_eq!(back.serial.listen.as_deref(), Some("0.0.0.0:2323"));
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn serial_mode_cycle_offers_tcp_connect_only_with_an_address() {
+        // The launcher has no editor for the dial-out address, so without
+        // one in the loaded config the mode would always fail at Run;
+        // cycling skips it (same pattern as the printer capture path).
+        let mut setup = MachineSetup {
+            serial_mode: SerialMode::Tcp,
+            ..Default::default()
+        };
+        setup.cycle(LauncherField::SerialMode, true);
+        assert_eq!(setup.serial_mode, SerialMode::Pty);
+
+        let mut setup = MachineSetup {
+            serial_mode: SerialMode::Tcp,
+            serial_connect: Some("bbs.example.com:1337".into()),
+            ..Default::default()
+        };
+        setup.cycle(LauncherField::SerialMode, true);
+        assert_eq!(setup.serial_mode, SerialMode::TcpConnect);
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -642,11 +642,12 @@ const SCSI_CONTROLLERS: [Option<ScsiController>; 4] = [
     Some(ScsiController::A3000),
 ];
 #[cfg(feature = "midi")]
-const SERIAL_MODES: [SerialMode; 5] = [
+const SERIAL_MODES: [SerialMode; 6] = [
     SerialMode::Off,
     SerialMode::Stdout,
     SerialMode::Midi,
     SerialMode::Tcp,
+    SerialMode::TcpConnect,
     SerialMode::Pty,
 ];
 
@@ -744,6 +745,9 @@ pub struct MachineSetup {
     /// TCP listen address for `mode = "tcp"`; carried so the override
     /// round-trips through a launcher save even though no tab edits it.
     serial_listen: Option<String>,
+    /// Dial-out address for `mode = "tcp-connect"`; carried like
+    /// `serial_listen` (no tab edits it, a save must not drop it).
+    serial_connect: Option<String>,
     /// The Centronics parallel-port device (None/Printer/Sampler), edited on the
     /// Parallel tab.
     parallel_device: crate::config::ParallelDevice,
@@ -873,6 +877,7 @@ impl MachineSetup {
             midi_out: cfg.serial.midi_out.clone(),
             midi_in: cfg.serial.midi_in.clone(),
             serial_listen: cfg.serial.listen.clone(),
+            serial_connect: cfg.serial.connect.clone(),
             parallel_device: cfg.parallel.device,
             parallel_output: cfg.parallel.printer_output.clone(),
             sampler_input: cfg.parallel.sampler_input.clone(),
@@ -1175,6 +1180,7 @@ impl MachineSetup {
         raw.serial.midi_out = self.midi_out.clone();
         raw.serial.midi_in = self.midi_in.clone();
         raw.serial.listen = self.serial_listen.clone();
+        raw.serial.connect = self.serial_connect.clone();
         // Parallel port. Carry each peripheral's settings whenever they are set
         // so a Save round-trips them even while another device is temporarily
         // selected. The sampler options do not imply the sampler, so they are
@@ -1642,6 +1648,7 @@ impl MachineSetup {
                 SerialMode::Stdout => "Stdout".to_string(),
                 SerialMode::Midi => "MIDI".to_string(),
                 SerialMode::Tcp => "TCP".to_string(),
+                SerialMode::TcpConnect => "TCP connect".to_string(),
                 SerialMode::Pty => "PTY".to_string(),
             },
             #[cfg(feature = "midi")]
@@ -2698,6 +2705,24 @@ mod tests {
         assert_eq!(setup.serial_listen.as_deref(), Some("0.0.0.0:2323"));
         let back = setup.to_raw();
         assert_eq!(back.serial.listen.as_deref(), Some("0.0.0.0:2323"));
+    }
+
+    #[test]
+    fn serial_tcp_connect_round_trips_through_raw() {
+        // Same contract as the listen override: the dial-out address has no
+        // launcher editor, so loading and saving must carry it unchanged.
+        let mut raw = RawConfig::default();
+        raw.serial.mode = Some("tcp-connect".into());
+        raw.serial.connect = Some("bbs.example.com:1337".into());
+        let setup = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(setup.serial_mode, SerialMode::TcpConnect);
+        assert_eq!(
+            setup.serial_connect.as_deref(),
+            Some("bbs.example.com:1337")
+        );
+        let back = setup.to_raw();
+        assert_eq!(back.serial.mode.as_deref(), Some("tcp-connect"));
+        assert_eq!(back.serial.connect.as_deref(), Some("bbs.example.com:1337"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Route A of the Retro32 BBS request: run a telnet BBS session from the browser build, with the guest side being a plain terminal program on serial.device.

- **Wasm serial transport**: `ChannelSerialSink`/`ChannelSerialHandle` in `serial.rs` (thread-free, works on wasm32). `WebEmu` exports `serial_send(bytes)`, `serial_take()`, and `serial_input_backlog()`; the channel sink replaces the stdout sink in browser machines and survives resets/ROM swaps. Guest output is bounded (drop-oldest + counter) so a non-draining page cannot balloon memory; input is unbounded by design (the UART consumes at emulated baud) with the backlog exposed for flow control.
- **Telnet NVT layer** (`www/serial-telnet.js`): answers option negotiation (ECHO, SGA, BINARY for ZModem, TERMINAL-TYPE replying "ANSI"), refuses everything else, handles IAC escaping and CR NUL both ways, and survives negotiation split across WebSocket frames.
- **Page glue** (`www/try.js`): a shell providing `#serial-url`/`#serial-connect` (+ optional `#serial-status`/`#serial-raw`) gets the whole connect/disconnect/telnet/flow-control loop; pages without the elements are untouched. The wasm-demo workflow ships the new file.
- **Native parity**: `[serial] mode = "tcp-connect"` + `connect = "host:port"`, or `--serial-connect HOST:PORT` (implies the mode) — the outbound counterpart of the existing tcp listen mode, for dialling a BBS directly from the desktop build.

Docs updated in the same change: `docs/guide/configuration.md` (new mode), `docs/guide/browser.md` (serial bridge section: API, page contract, websockify-style gateway shape), `copperline.example.toml`.

## Testing

- `cargo test` green (1617 unit tests, including new channel-sink round-trip/bounding tests, tcp-connect socket round-trip, config/CLI/launcher round-trips); `cargo clippy` and `cargo fmt --check` clean; web crate builds for `wasm32-unknown-unknown`.
- Telnet layer exercised under node: 14 behavioral checks (negotiation, refusals, TTYPE subnegotiation, IAC/CR escaping both directions, binary mode, chunk-split sequences).
- Native smoke test: `--serial-connect` against a local listener connects, logs, and exits cleanly.
- Browser end-to-end: local copy of the /try page with this bundle + a scripted WebSocket "fake BBS"; booted AROS in Chrome, clicked Connect, and verified the negotiation on the server side (`IAC DO ECHO`, `DO SGA`, `WILL TTYPE`, then `TTYPE IS ANSI`), banner bytes draining into the guest UART, and a clean disconnect on both ends.