### PR TITLE
launcher: one I/O Ports tab, Add printer to GUI, "Host Mounts" sub-page

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -792,8 +792,8 @@ as you would expect. Set `readonly = true` to export a directory
 write-protected instead -- the guest sees a read-only disk and every write
 fails with the same "disk is write-protected" error a physical
 write-protected disk gives, which is worth setting on anything you would
-rather the Amiga could not damage. The launcher's Host Mounts tab exposes
-the same choice as its **Access** field.
+rather the Amiga could not damage. The launcher's Host Mounts sub-page (under
+the Hard Disk tab) exposes the same choice as its **Access** field.
 
 Amiga file attributes a host filesystem cannot hold -- protection bits
 such as script/pure/archive, file comments, and exact datestamps -- are

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -225,16 +225,20 @@ The layout is:
   caches), *Memory* (chip/fast/slow/Zorro III RAM), *ROM* (Kickstart and
   extended ROM), *Floppy* (drive count and per-drive image and write-protect),
   *Hard Disk* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
-  A3000's onboard SCSI -- and its boot ROM and units), *Host Mounts* (host
-  directories served live as AmigaDOS volumes: up to four mounts, each with a
-  boot priority and a read-write/read-only **Access** field), *CD* (image,
-  insert delay, CD32 NVRAM), *Zorro* (extra autoconfig boards by metadata
-  file, with a config panel for a WASM plugin board's declared options),
-  *Serial* (serial mode and MIDI input/output endpoints),
-  *Parallel* (the parallel-port device -- None, Printer, or Sampler -- and, for
-  the sampler, its host audio input and input gain),
+  A3000's onboard SCSI -- and its boot ROM and units, plus a **Host Mounts**
+  link to a sub-page for host directories served live as AmigaDOS volumes: up
+  to four mounts, each with a boot priority and a read-write/read-only
+  **Access** field), *CD* (image,
+  insert delay, CD32 NVRAM),
   *Input* (the controller device in each game port and the joystick input
-  source), and *A/V & Emu* (audio output device, channel mode, stereo
+  source),
+  *I/O Ports* (the serial and parallel ports under **Serial:** / **Parallel:**
+  headings: serial mode and MIDI endpoints; and the parallel device -- None,
+  Printer, or Sampler -- with, for the printer, its capture output file, or for
+  the sampler, its host audio input and input gain),
+  *Zorro* (extra autoconfig boards by metadata file, with a config panel for a
+  WASM plugin board's declared options),
+  and *A/V & Emu* (audio output device, channel mode, stereo
   separation, overscan, pixel aspect, phosphor, floppy sounds and
   volume, power-on, pacing, realtime priority, warp speed).
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -30,6 +30,7 @@ use crate::config::{
 };
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
 use anyhow::Result;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -170,18 +171,15 @@ pub enum LauncherTab {
     Storage,
     HostFs,
     Cd,
-    // Only reached in a `midi` build, where it is added to TABS.
-    #[cfg_attr(not(feature = "midi"), allow(dead_code))]
-    Serial,
-    Parallel,
+    /// Serial and parallel ports on one tab, under `Serial:` / `Parallel:`
+    /// section headings.
+    IoPorts,
     Input,
     Zorro,
     AvEmulation,
 }
 
-/// Tabs shown top to bottom. The Serial tab only holds MIDI settings for now, so
-/// it is present only in a `midi` build; drop the `cfg` if the tab gains other
-/// serial options.
+/// Tabs shown top to bottom.
 pub const TABS: &[LauncherTab] = &[
     LauncherTab::System,
     LauncherTab::Cpu,
@@ -189,12 +187,11 @@ pub const TABS: &[LauncherTab] = &[
     LauncherTab::Rom,
     LauncherTab::Floppy,
     LauncherTab::Storage,
-    LauncherTab::HostFs,
+    // HostFs is reached as a sub-page from the Hard Disk (Storage) tab, so it is
+    // not a top-level strip entry.
     LauncherTab::Cd,
-    #[cfg(feature = "midi")]
-    LauncherTab::Serial,
-    LauncherTab::Parallel,
     LauncherTab::Input,
+    LauncherTab::IoPorts,
     LauncherTab::Zorro,
     LauncherTab::AvEmulation,
 ];
@@ -210,11 +207,19 @@ impl LauncherTab {
             LauncherTab::Storage => "Hard Disk",
             LauncherTab::HostFs => "Host Mounts",
             LauncherTab::Cd => "CD",
-            LauncherTab::Serial => "Serial",
-            LauncherTab::Parallel => "Parallel",
+            LauncherTab::IoPorts => "I/O Ports",
             LauncherTab::Input => "Input",
             LauncherTab::Zorro => "Zorro",
             LauncherTab::AvEmulation => "A/V & Emu",
+        }
+    }
+
+    /// The strip entry to highlight for this (possibly sub-page) tab: the Host
+    /// Mounts sub-page keeps its parent Hard Disk tab highlighted.
+    pub fn strip_tab(self) -> LauncherTab {
+        match self {
+            LauncherTab::HostFs => LauncherTab::Storage,
+            other => other,
         }
     }
 }
@@ -295,8 +300,11 @@ pub enum LauncherField {
     MidiIn,
     // Parallel
     ParallelDevice,
+    ParallelOutput,
     SamplerInput,
     SamplerGain,
+    /// Inert field for a non-interactive [`RowKind::SectionHeader`] row.
+    SectionHeader,
     // A/V and emulation
     AudioDevice,
     AudioChannelMode,
@@ -328,6 +336,14 @@ pub enum RowKind {
     /// A hard-drive image: a path with Browse/Clear, plus an editable
     /// volume-name field (used when the image is a host directory).
     Drive,
+    /// A non-interactive greyed heading that groups the rows beneath it
+    /// (e.g. the `Serial:` / `Parallel:` sections of the I/O Ports tab). Its
+    /// `field` is inert.
+    SectionHeader,
+    /// A button that navigates to another tab used as a sub-page (the Hard Disk
+    /// tab's link to Host Mounts, and the Back link the other way). Its `field`
+    /// is inert; the payload is the destination tab.
+    SubPageLink(LauncherTab),
 }
 
 /// One settings row: a label, the field it edits, and how to edit it.
@@ -340,6 +356,25 @@ pub struct Row {
 
 const fn row(field: LauncherField, label: &'static str, kind: RowKind) -> Row {
     Row { field, label, kind }
+}
+
+/// A non-interactive section heading row (see [`RowKind::SectionHeader`]).
+const fn section_header(label: &'static str) -> Row {
+    Row {
+        field: F::SectionHeader,
+        label,
+        kind: RowKind::SectionHeader,
+    }
+}
+
+/// A row whose button navigates to `target` used as a sub-page (see
+/// [`RowKind::SubPageLink`]).
+const fn sub_page_link(label: &'static str, target: LauncherTab) -> Row {
+    Row {
+        field: F::SectionHeader,
+        label,
+        kind: RowKind::SubPageLink(target),
+    }
 }
 
 /// How many `[[filesys]]` mounts the launcher edits (the config file
@@ -457,18 +492,25 @@ const CD_ROWS: [Row; 3] = [
     row(F::Cd32Nvram, "CD32 NVRAM", PathRow),
 ];
 // The MIDI endpoint rows appear only when the serial port is in MIDI mode, so
-// the Serial tab shows just the Mode selector otherwise.
+// the Serial section shows just the Device / Mode selector otherwise. The
+// selector is labelled "Device / Mode" because some choices are devices (MIDI)
+// and some are modes (stdout, PTY, TCP).
 #[cfg(feature = "midi")]
-const SERIAL_ROWS_BASE: [Row; 1] = [row(F::SerialMode, "Mode", Cycle)];
+const SERIAL_ROWS_BASE: [Row; 1] = [row(F::SerialMode, "Device / Mode", Cycle)];
 #[cfg(feature = "midi")]
 const SERIAL_ROWS_MIDI: [Row; 3] = [
-    row(F::SerialMode, "Mode", Cycle),
+    row(F::SerialMode, "Device / Mode", Cycle),
     row(F::MidiIn, "MIDI input", Cycle),
     row(F::MidiOut, "MIDI output", Cycle),
 ];
 // The sampler input/gain rows appear only when the sampler is the selected
 // device, so None/Printer show just the Device selector.
 const PARALLEL_ROWS_BASE: [Row; 1] = [row(F::ParallelDevice, "Device", Cycle)];
+// The printer adds a capture-file picker; the sampler adds its input/gain rows.
+const PARALLEL_ROWS_PRINTER: [Row; 2] = [
+    row(F::ParallelDevice, "Device", Cycle),
+    row(F::ParallelOutput, "Output file", PathRow),
+];
 const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
     row(F::ParallelDevice, "Device", Cycle),
     row(F::SamplerInput, "Audio input", Cycle),
@@ -494,35 +536,62 @@ const INPUT_ROWS: [Row; 3] = [
     row(F::Joystick, "Joystick input", Cycle),
 ];
 
-/// The rows shown on a tab, top to bottom. The Serial and Parallel tabs are
-/// dynamic: the MIDI endpoint rows appear only in MIDI mode and the sampler
-/// rows only when the sampler is selected, so unrelated options stay hidden
+/// The rows shown on a tab, top to bottom. Most tabs are fixed and borrow their
+/// static row table; only the three composed tabs (Storage/HostFs with their
+/// sub-page links, and the dynamic I/O Ports tab) allocate. The I/O Ports tab is
+/// dynamic: the MIDI endpoint rows appear only in MIDI mode and the
+/// sampler/printer rows only for those devices, so unrelated options stay hidden
 /// rather than greyed. The `Zorro` tab has no rows: it is drawn as a board list
 /// with Add/Remove controls (see the panel code).
 pub fn rows(
     tab: LauncherTab,
     parallel_device: ParallelDevice,
     serial_mode: SerialMode,
-) -> &'static [Row] {
+) -> Cow<'static, [Row]> {
     match tab {
-        LauncherTab::System => &SYSTEM_ROWS,
-        LauncherTab::Cpu => &CPU_ROWS,
-        LauncherTab::Memory => &MEMORY_ROWS,
-        LauncherTab::Rom => &ROM_ROWS,
-        LauncherTab::Floppy => &FLOPPY_ROWS,
-        LauncherTab::Storage => &STORAGE_ROWS,
-        LauncherTab::HostFs => &HOSTFS_ROWS,
-        LauncherTab::Cd => &CD_ROWS,
-        LauncherTab::Serial => serial_rows(serial_mode),
-        LauncherTab::Parallel => parallel_rows(parallel_device),
-        LauncherTab::Input => &INPUT_ROWS,
-        LauncherTab::Zorro => &[],
-        LauncherTab::AvEmulation => &AV_EMULATION_ROWS,
+        LauncherTab::System => Cow::Borrowed(&SYSTEM_ROWS),
+        LauncherTab::Cpu => Cow::Borrowed(&CPU_ROWS),
+        LauncherTab::Memory => Cow::Borrowed(&MEMORY_ROWS),
+        LauncherTab::Rom => Cow::Borrowed(&ROM_ROWS),
+        LauncherTab::Floppy => Cow::Borrowed(&FLOPPY_ROWS),
+        LauncherTab::Storage => {
+            // The Hard Disk tab links to the Host Mounts sub-page, at the top so
+            // it sits where the sub-page's own Back link is.
+            let mut rows = vec![sub_page_link("Host Mounts", LauncherTab::HostFs)];
+            rows.extend_from_slice(&STORAGE_ROWS);
+            Cow::Owned(rows)
+        }
+        LauncherTab::HostFs => {
+            // The Host Mounts sub-page opens with a link back to Hard Disk.
+            let mut rows = vec![sub_page_link("< Hard Disk", LauncherTab::Storage)];
+            rows.extend_from_slice(&HOSTFS_ROWS);
+            Cow::Owned(rows)
+        }
+        LauncherTab::Cd => Cow::Borrowed(&CD_ROWS),
+        LauncherTab::IoPorts => Cow::Owned(io_ports_rows(serial_mode, parallel_device)),
+        LauncherTab::Input => Cow::Borrowed(&INPUT_ROWS),
+        LauncherTab::Zorro => Cow::Borrowed(&[]),
+        LauncherTab::AvEmulation => Cow::Borrowed(&AV_EMULATION_ROWS),
     }
 }
 
-/// Serial-tab rows for the current mode. Only the `midi` build has any; without
-/// it the tab is absent from [`TABS`] and this is never reached.
+/// The I/O Ports tab: a `Serial:` section (only in a `midi` build, which is the
+/// only build with serial rows) then a `Parallel:` section, each under a greyed
+/// heading and each showing only the rows relevant to its selected device/mode.
+fn io_ports_rows(serial_mode: SerialMode, parallel_device: ParallelDevice) -> Vec<Row> {
+    let mut rows = Vec::new();
+    let serial = serial_rows(serial_mode);
+    if !serial.is_empty() {
+        rows.push(section_header("Serial:"));
+        rows.extend_from_slice(serial);
+    }
+    rows.push(section_header("Parallel:"));
+    rows.extend_from_slice(parallel_rows(parallel_device));
+    rows
+}
+
+/// Serial rows for the current mode. Only the `midi` build has any; without it
+/// the Serial section is empty and omitted from the I/O Ports tab.
 fn serial_rows(serial_mode: SerialMode) -> &'static [Row] {
     #[cfg(feature = "midi")]
     {
@@ -539,12 +608,13 @@ fn serial_rows(serial_mode: SerialMode) -> &'static [Row] {
     }
 }
 
-/// Parallel-tab rows for the selected device: the sampler adds its input and
-/// gain rows; None/Printer show just the Device selector.
+/// Parallel rows for the selected device: the printer adds its output-file
+/// picker, the sampler its input and gain; None shows just the Device selector.
 fn parallel_rows(parallel_device: ParallelDevice) -> &'static [Row] {
     match parallel_device {
         ParallelDevice::Sampler => &PARALLEL_ROWS_SAMPLER,
-        ParallelDevice::None | ParallelDevice::Printer => &PARALLEL_ROWS_BASE,
+        ParallelDevice::Printer => &PARALLEL_ROWS_PRINTER,
+        ParallelDevice::None => &PARALLEL_ROWS_BASE,
     }
 }
 
@@ -738,7 +808,8 @@ pub struct MachineSetup {
     cd_insert_delay: f64,
     cd32_nvram: Option<PathBuf>,
     // Serial port. Carried in every build so a config's `[serial]` block
-    // round-trips; only edited on the Serial tab, which is a `midi` build only.
+    // round-trips; only edited in the I/O Ports tab's Serial section, which a
+    // `midi` build shows.
     serial_mode: SerialMode,
     midi_out: Option<String>,
     midi_in: Option<String>,
@@ -748,15 +819,15 @@ pub struct MachineSetup {
     /// Dial-out address for `mode = "tcp-connect"`; carried like
     /// `serial_listen` (no tab edits it, a save must not drop it).
     serial_connect: Option<String>,
-    /// The Centronics parallel-port device (None/Printer/Sampler), edited on the
-    /// Parallel tab.
+    /// The Centronics parallel-port device (None/Printer/Sampler), edited in the
+    /// I/O Ports tab's Parallel section.
     parallel_device: crate::config::ParallelDevice,
-    /// Raw Centronics printer capture path. There is no launcher control for the
-    /// path itself, but a hand-written `[parallel] output` must survive
-    /// load/edit/save, and its presence is what makes Printer selectable.
+    /// The printer capture path, edited by the Output file row (shown when the
+    /// Printer device is selected) and carried through from a hand-written
+    /// `[parallel] output`.
     parallel_output: Option<PathBuf>,
     /// Sampler host capture device (`None` = system default) and its input gain,
-    /// edited on the Parallel tab.
+    /// edited in the I/O Ports tab's Parallel section.
     sampler_input: Option<String>,
     sampler_gain_db: f32,
     /// Input device names for the sampler picker: filled when the screen opens
@@ -1197,7 +1268,14 @@ impl MachineSetup {
                 .parallel_output
                 .is_some()
                 .then(|| ParallelDevice::None.label().to_string()),
-            other => Some(other.label().to_string()),
+            // A printer needs a capture file. Without one it is an incomplete
+            // selection, so persist nothing (a bare `output` would already imply
+            // the printer, so no explicit device is needed when it is set).
+            ParallelDevice::Printer => self
+                .parallel_output
+                .is_some()
+                .then(|| ParallelDevice::Printer.label().to_string()),
+            ParallelDevice::Sampler => Some(ParallelDevice::Sampler.label().to_string()),
         };
         // The Audio output picker is one of default / a named device / Disabled.
         // A named device sets output_device; Disabled sets output_enabled=false
@@ -1464,6 +1542,7 @@ impl MachineSetup {
             F::Filesys3Dir => self.filesys_dirs[3].as_deref(),
             F::CdImage => self.cd_image.as_deref(),
             F::Cd32Nvram => self.cd32_nvram.as_deref(),
+            F::ParallelOutput => self.parallel_output.as_deref(),
             _ => None,
         }
     }
@@ -1644,7 +1723,9 @@ impl MachineSetup {
             },
             #[cfg(feature = "midi")]
             F::SerialMode => match self.serial_mode {
-                SerialMode::Off => "Off".to_string(),
+                // "None" (matching the Parallel device selector) reads better
+                // than "Off" for the no-connection state.
+                SerialMode::Off => "None".to_string(),
                 SerialMode::Stdout => "Stdout".to_string(),
                 SerialMode::Midi => "MIDI".to_string(),
                 SerialMode::Tcp => "TCP".to_string(),
@@ -1813,14 +1894,15 @@ impl MachineSetup {
             #[cfg(feature = "midi")]
             F::MidiIn => cycle_endpoint(&mut self.midi_in, &self.midi_endpoints.inputs, forward),
             F::ParallelDevice => {
-                // Printer is only on offer when a capture path exists (the
-                // launcher has no path editor), so a fresh screen cycles
-                // None <-> Sampler and a loaded printer config round-trips.
-                let mut choices = vec![ParallelDevice::None, ParallelDevice::Sampler];
-                if self.parallel_output.is_some() {
-                    choices.insert(1, ParallelDevice::Printer);
-                }
-                self.parallel_device = cycle_slice(&choices, self.parallel_device, forward);
+                // None -> Printer -> Sampler. Selecting Printer reveals its
+                // Output file row (with a Browse button); until a file is set
+                // the printer is not persisted or attached (see to_raw).
+                const DEVICES: [ParallelDevice; 3] = [
+                    ParallelDevice::None,
+                    ParallelDevice::Printer,
+                    ParallelDevice::Sampler,
+                ];
+                self.parallel_device = cycle_slice(&DEVICES, self.parallel_device, forward);
             }
             F::SamplerInput => {
                 // Re-read on each step so a device connected since the screen
@@ -1908,6 +1990,7 @@ impl MachineSetup {
             F::ScsiUnit6 => self.scsi_units[6] = Some(path),
             F::CdImage => self.cd_image = Some(path),
             F::Cd32Nvram => self.cd32_nvram = Some(path),
+            F::ParallelOutput => self.parallel_output = Some(path),
             _ => {
                 if let Some((slot, false)) = filesys_slot(field) {
                     self.filesys_dirs[slot] = Some(path);
@@ -1944,6 +2027,7 @@ impl MachineSetup {
             F::ScsiUnit6 => self.scsi_units[6] = None,
             F::CdImage => self.cd_image = None,
             F::Cd32Nvram => self.cd32_nvram = None,
+            F::ParallelOutput => self.parallel_output = None,
             _ => {
                 if let Some((slot, false)) = filesys_slot(field) {
                     self.filesys_dirs[slot] = None;
@@ -2163,12 +2247,34 @@ fn cycle_endpoint(
 }
 
 /// Whether `field` appears anywhere with the given row kind. Used to classify a
-/// field (toggle vs path) without threading the tab through every call. Passes
-/// the row-maximising selections so the dynamic Serial/Parallel rows are all in
-/// view.
+/// field (toggle vs path) without threading the tab through every call, called
+/// per drawn row, so it scans the static row tables directly rather than
+/// composing tabs (which would allocate every frame). The composed tabs only
+/// add `SectionHeader`/`SubPageLink` rows, which carry no real field, so the raw
+/// tables cover every classifiable field.
 fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
-    TABS.iter()
-        .flat_map(|&t| rows(t, ParallelDevice::Sampler, SerialMode::Midi))
+    #[cfg(feature = "midi")]
+    let serial: &[&[Row]] = &[&SERIAL_ROWS_MIDI];
+    #[cfg(not(feature = "midi"))]
+    let serial: &[&[Row]] = &[];
+    let sources: &[&[Row]] = &[
+        &SYSTEM_ROWS,
+        &CPU_ROWS,
+        &MEMORY_ROWS,
+        &ROM_ROWS,
+        &FLOPPY_ROWS,
+        &STORAGE_ROWS,
+        &HOSTFS_ROWS,
+        &CD_ROWS,
+        &INPUT_ROWS,
+        &AV_EMULATION_ROWS,
+        &PARALLEL_ROWS_PRINTER,
+        &PARALLEL_ROWS_SAMPLER,
+    ];
+    sources
+        .iter()
+        .chain(serial.iter())
+        .flat_map(|table| table.iter())
         .any(|r| r.field == field && r.kind == kind)
 }
 
@@ -2777,9 +2883,55 @@ mod tests {
     }
 
     #[test]
+    fn host_mounts_is_a_sub_page_of_hard_disk() {
+        // Host Mounts is not a top-level strip tab any more.
+        assert!(!TABS.contains(&LauncherTab::HostFs));
+        // The Hard Disk tab opens with a link into the Host Mounts sub-page.
+        let storage = rows(
+            LauncherTab::Storage,
+            ParallelDevice::None,
+            SerialMode::default(),
+        );
+        assert_eq!(
+            storage.first().map(|r| r.kind),
+            Some(RowKind::SubPageLink(LauncherTab::HostFs))
+        );
+        // The sub-page opens with a Back link, then the mount rows.
+        let mounts = rows(
+            LauncherTab::HostFs,
+            ParallelDevice::None,
+            SerialMode::default(),
+        );
+        assert_eq!(
+            mounts.first().map(|r| r.kind),
+            Some(RowKind::SubPageLink(LauncherTab::Storage))
+        );
+        assert!(mounts.iter().any(|r| r.field == LauncherField::Filesys0Dir));
+        // The sub-page keeps the Hard Disk strip tab highlighted.
+        assert_eq!(LauncherTab::HostFs.strip_tab(), LauncherTab::Storage);
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn io_ports_tab_groups_serial_and_parallel_under_headers() {
+        let r = rows(LauncherTab::IoPorts, ParallelDevice::None, SerialMode::Midi);
+        let headers: Vec<_> = r
+            .iter()
+            .filter(|x| x.kind == RowKind::SectionHeader)
+            .map(|x| x.label)
+            .collect();
+        assert_eq!(headers, ["Serial:", "Parallel:"]);
+        // Serial section: the Device / Mode selector, and (in MIDI) the endpoints.
+        assert!(r.iter().any(|x| x.field == LauncherField::SerialMode));
+        assert!(r.iter().any(|x| x.field == LauncherField::MidiOut));
+        // Parallel section: the device selector.
+        assert!(r.iter().any(|x| x.field == LauncherField::ParallelDevice));
+    }
+
+    #[test]
     fn parallel_sampler_rows_appear_only_when_selected() {
         let has = |device| {
-            rows(LauncherTab::Parallel, device, SerialMode::default())
+            rows(LauncherTab::IoPorts, device, SerialMode::default())
                 .iter()
                 .any(|r| r.field == LauncherField::SamplerInput)
         };
@@ -2792,7 +2944,7 @@ mod tests {
     #[test]
     fn midi_rows_appear_only_in_midi_mode() {
         let has = |mode| {
-            rows(LauncherTab::Serial, ParallelDevice::None, mode)
+            rows(LauncherTab::IoPorts, ParallelDevice::None, mode)
                 .iter()
                 .any(|r| r.field == LauncherField::MidiOut)
         };
@@ -2801,16 +2953,53 @@ mod tests {
     }
 
     #[test]
-    fn parallel_sampler_selection_round_trips_through_raw() {
+    fn parallel_device_cycles_none_printer_sampler() {
         let mut s = MachineSetup::default();
         assert_eq!(s.parallel_device, ParallelDevice::None);
-
-        // Cycle None -> Sampler (Printer is absent without a capture path).
+        s.cycle(LauncherField::ParallelDevice, true);
+        assert_eq!(s.parallel_device, ParallelDevice::Printer);
         s.cycle(LauncherField::ParallelDevice, true);
         assert_eq!(s.parallel_device, ParallelDevice::Sampler);
+        s.cycle(LauncherField::ParallelDevice, true);
+        assert_eq!(s.parallel_device, ParallelDevice::None);
+    }
 
-        s.sampler_input = Some("BlackHole".into());
-        s.sampler_gain_db = 6.0;
+    #[test]
+    fn parallel_printer_output_row_appears_and_round_trips() {
+        let mut s = MachineSetup::default();
+        // The Output file row shows only when the printer is selected.
+        let has_output = |device| {
+            rows(LauncherTab::IoPorts, device, SerialMode::default())
+                .iter()
+                .any(|r| r.field == LauncherField::ParallelOutput)
+        };
+        assert!(!has_output(ParallelDevice::None));
+        assert!(has_output(ParallelDevice::Printer));
+
+        s.parallel_device = ParallelDevice::Printer;
+        // A printer with no capture file yet is not persisted (incomplete).
+        assert_eq!(s.to_raw().parallel.device, None);
+
+        s.set_path(LauncherField::ParallelOutput, "captures/out.prn".into());
+        let raw = s.to_raw();
+        assert_eq!(raw.parallel.device.as_deref(), Some("printer"));
+        assert_eq!(raw.parallel.output.as_deref(), Some("captures/out.prn"));
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(back.parallel_device, ParallelDevice::Printer);
+        assert_eq!(
+            back.parallel_output.as_deref(),
+            Some(std::path::Path::new("captures/out.prn"))
+        );
+    }
+
+    #[test]
+    fn parallel_sampler_selection_round_trips_through_raw() {
+        let mut s = MachineSetup {
+            parallel_device: ParallelDevice::Sampler,
+            sampler_input: Some("BlackHole".into()),
+            sampler_gain_db: 6.0,
+            ..MachineSetup::default()
+        };
         let raw = s.to_raw();
         assert_eq!(raw.parallel.device.as_deref(), Some("sampler"));
         assert_eq!(raw.parallel.sampler_input.as_deref(), Some("BlackHole"));
@@ -2823,8 +3012,7 @@ mod tests {
 
         // Switching the device to None must still carry the sampler settings
         // through a Save (they do not imply the sampler on reload).
-        s.cycle(LauncherField::ParallelDevice, false); // Sampler -> None
-        assert_eq!(s.parallel_device, ParallelDevice::None);
+        s.parallel_device = ParallelDevice::None;
         let raw = s.to_raw();
         assert_eq!(raw.parallel.device, None);
         assert_eq!(raw.parallel.sampler_input.as_deref(), Some("BlackHole"));
@@ -3061,10 +3249,10 @@ mod tests {
     #[cfg(feature = "midi")]
     #[test]
     fn midi_device_rows_are_hidden_off_midi_mode() {
-        // Off MIDI mode the endpoint rows are absent from the Serial tab (they
-        // are hidden, not greyed), so the tab shows only the Mode selector.
+        // Off MIDI mode the endpoint rows are absent from the Serial section
+        // (they are hidden, not greyed), so it shows only the Device / Mode row.
         let serial = rows(
-            LauncherTab::Serial,
+            LauncherTab::IoPorts,
             ParallelDevice::None,
             SerialMode::Stdout,
         );

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -3468,6 +3468,10 @@ const LAUNCH_ACTION_W: usize = 84;
 const LAUNCH_ACTION_H: usize = 22;
 const LAUNCH_BROWSE_W: usize = 66;
 const LAUNCH_CLEAR_W: usize = 54;
+/// Width of the path-preview text column before a path row's Browse/Clear
+/// buttons. The buttons sit just after it (near the other control widgets)
+/// rather than out at the panel's right edge; a long value is clipped to fit.
+const LAUNCH_PATH_VALUE_W: usize = 216;
 /// Width of the editable volume-name box on a drive row.
 const LAUNCH_NAME_W: usize = 96;
 const LAUNCH_REMOVE_W: usize = 70;
@@ -3575,19 +3579,32 @@ fn launcher_toggle_rect(rect: Rect, row_y: usize) -> Rect {
     }
 }
 
-/// (Browse, Clear) buttons for a path row, right-aligned in the settings pane.
+/// The navigation button of a sub-page link row: sized to its label and
+/// aligned to the top-left of the settings pane (where the row labels sit),
+/// not stretched across the control area.
+fn launcher_sub_page_rect(rect: Rect, row_y: usize, label: &str) -> Rect {
+    Rect {
+        x: launcher_pane_x(rect),
+        y: row_y + 2,
+        w: label.chars().count() * font::GLYPH_W + 16,
+        h: LAUNCH_CONTROL_H,
+    }
+}
+
+/// (Browse, Clear) buttons for a path row, just after the fixed-width value
+/// column ([`LAUNCH_PATH_VALUE_W`]) rather than out at the panel's right edge.
 fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
     let y = row_y + 2;
-    let clear = Rect {
-        x: rect.x + rect.w - LAUNCH_MARGIN - LAUNCH_CLEAR_W,
-        y,
-        w: LAUNCH_CLEAR_W,
-        h: LAUNCH_CONTROL_H,
-    };
     let browse = Rect {
-        x: clear.x - 4 - LAUNCH_BROWSE_W,
+        x: launcher_control_x(rect) + LAUNCH_PATH_VALUE_W,
         y,
         w: LAUNCH_BROWSE_W,
+        h: LAUNCH_CONTROL_H,
+    };
+    let clear = Rect {
+        x: browse.x + LAUNCH_BROWSE_W + 4,
+        y,
+        w: LAUNCH_CLEAR_W,
         h: LAUNCH_CONTROL_H,
     };
     (browse, clear)
@@ -3787,6 +3804,14 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             }
             let row_y = launcher_row_y(rect, i);
             match r.kind {
+                // A section heading is non-interactive.
+                RowKind::SectionHeader => {}
+                // A sub-page link navigates to its target tab.
+                RowKind::SubPageLink(target) => {
+                    if launcher_sub_page_rect(rect, row_y, r.label).contains(pos) {
+                        return Some(UiControl::LauncherTab(target));
+                    }
+                }
                 RowKind::Cycle => {
                     let (prev, _value, next) = launcher_cycle_rects(rect, row_y);
                     if prev.contains(pos) {
@@ -3877,6 +3902,38 @@ fn clip_path_tail(text: &str, avail_px: usize) -> String {
     format!("...{tail}")
 }
 
+/// Clip a host path to `avail_px`, always keeping the final component (the file
+/// name) whole: leading directories are dropped and replaced by a "..." prefix,
+/// rather than cutting into the name. Splits on both `/` and `\` so Windows and
+/// Unix paths work. If even the name alone is too wide, its tail is shown.
+fn clip_path_keep_name(text: &str, avail_px: usize) -> String {
+    let max_chars = avail_px / font::GLYPH_W;
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut comps: Vec<&str> = text.split(['/', '\\']).filter(|s| !s.is_empty()).collect();
+    let name = comps.pop().unwrap_or(text);
+    let sep = if text.contains('\\') { '\\' } else { '/' };
+    // Grow from the name, prepending whole parent components while the result
+    // (with its "..." prefix) still fits.
+    let mut shown = name.to_string();
+    for comp in comps.into_iter().rev() {
+        let candidate = format!("{comp}{sep}{shown}");
+        if 3 + 1 + candidate.chars().count() <= max_chars {
+            shown = candidate;
+        } else {
+            break;
+        }
+    }
+    let prefixed = format!("...{sep}{shown}");
+    if prefixed.chars().count() <= max_chars {
+        prefixed
+    } else {
+        // The file name alone does not fit; fall back to a plain tail clip.
+        clip_path_tail(name, avail_px)
+    }
+}
+
 /// A model-selector / tab button: a flat bevel that fills with the title-bar
 /// blue when active/selected. Tabs label left, model buttons centred.
 fn draw_launcher_chip(
@@ -3924,6 +3981,32 @@ fn draw_launcher_row(
 ) {
     let setup = &state.setup;
     let row_y = launcher_row_y(rect, i);
+    // A section heading is a greyed, non-interactive label grouping the rows
+    // below it (the Serial:/Parallel: sections of the I/O Ports tab).
+    if r.kind == RowKind::SectionHeader {
+        draw_panel_text(
+            frame,
+            launcher_pane_x(rect),
+            row_y + 8,
+            r.label,
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+        return;
+    }
+    // A sub-page link is a navigation button carrying its own label.
+    if let RowKind::SubPageLink(target) = r.kind {
+        draw_text_button(
+            frame,
+            launcher_sub_page_rect(rect, row_y, r.label),
+            r.label,
+            true,
+            hover == Some(UiControl::LauncherTab(target)),
+            scale,
+        );
+        return;
+    }
     let reason = setup.disabled_reason(r.field);
     let label_color = if reason.is_none() {
         PANEL_TEXT
@@ -3962,6 +4045,8 @@ fn draw_launcher_row(
         return;
     }
     match r.kind {
+        // Drawn above with an early return.
+        RowKind::SectionHeader | RowKind::SubPageLink(_) => {}
         RowKind::Cycle => {
             let (prev, value, next) = launcher_cycle_rects(rect, row_y);
             draw_text_button(
@@ -4015,7 +4100,17 @@ fn draw_launcher_row(
             let (browse, clear) = launcher_path_rects(rect, row_y);
             let value_x = launcher_control_x(rect);
             let avail = browse.x.saturating_sub(value_x + 8);
-            let text = truncate_to_width(&setup.value_label(r.field), avail);
+            // The printer output shows its full path (clipped to keep the file
+            // name if long, so the row never overflows), "(none)" until one is
+            // chosen; other path rows show the image file name.
+            let text = if r.field == LauncherField::ParallelOutput {
+                match setup.path(r.field) {
+                    Some(p) => clip_path_keep_name(&p.to_string_lossy(), avail),
+                    None => "(none)".to_string(),
+                }
+            } else {
+                truncate_to_width(&setup.value_label(r.field), avail)
+            };
             draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
             draw_text_button(
                 frame,
@@ -4045,11 +4140,11 @@ fn draw_launcher_row(
             let name_box = launcher_drive_name_rect(rect, row_y);
             let text_right = if has_image { name_box.x } else { browse.x };
             let avail = text_right.saturating_sub(value_x + 8);
-            // Host FS mounts show the whole host path (tail-clipped with a
-            // leading "..." when long), since the full path is meaningful;
-            // other drives show the image's file name.
+            // Host FS mounts show the whole host path (clipped to keep the final
+            // directory name, with a leading "..." when long), since the path is
+            // meaningful; other drives show the image's file name.
             let text = match (r.field.is_filesys_dir_field(), setup.path(r.field)) {
-                (true, Some(p)) => clip_path_tail(&p.to_string_lossy(), avail),
+                (true, Some(p)) => clip_path_keep_name(&p.to_string_lossy(), avail),
                 _ => truncate_to_width(&setup.value_label(r.field), avail),
             };
             draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
@@ -4349,7 +4444,7 @@ fn draw_launcher(
             frame,
             launcher_tab_rect(rect, i),
             tab.label(),
-            state.tab == tab,
+            state.tab.strip_tab() == tab,
             hover == Some(UiControl::LauncherTab(tab)),
             true,
             scale,
@@ -4723,6 +4818,27 @@ pub fn hex_dump_row(addr: u32, bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clip_path_keeps_the_file_name() {
+        let g = font::GLYPH_W;
+        // Fits: returned unchanged.
+        assert_eq!(clip_path_keep_name("/a/b.txt", 100 * g), "/a/b.txt");
+
+        // A long Unix path keeps the whole file name after a "..." prefix.
+        let unix = "/Users/me/Documents/amiga/captures/printer-output.txt";
+        let out = clip_path_keep_name(unix, 24 * g);
+        assert!(out.starts_with("..."), "{out}");
+        assert!(out.ends_with("printer-output.txt"), "{out}");
+        assert!(out.chars().count() <= 24, "{out}");
+
+        // A long Windows path: backslash separators, file name preserved.
+        let win = r"C:\Users\me\Documents\amiga\captures\printer-output.txt";
+        let out = clip_path_keep_name(win, 24 * g);
+        assert!(out.contains('\\'), "{out}");
+        assert!(out.ends_with("printer-output.txt"), "{out}");
+        assert!(out.chars().count() <= 24, "{out}");
+    }
 
     #[test]
     fn menu_sits_above_the_status_bar_and_hit_tests_items() {
@@ -6444,5 +6560,65 @@ mod tests {
             "routing summary header not drawn"
         );
         save(&frame, "launcher-input");
+
+        // Configuration screen: the I/O Ports tab, with the sampler selected so
+        // both the Serial: and Parallel: sections and the sampler rows show.
+        let labels = || MenuLabels {
+            warp: false,
+            warp_speed: WarpSpeed::Max,
+            fullscreen: false,
+            recording: false,
+            input_recording: false,
+            joystick_input_mode: JoystickInputMode::Gamepad,
+            port_devices: [
+                crate::bus::PortDevice::Mouse,
+                crate::bus::PortDevice::Joystick,
+            ],
+            pixel_aspect: PixelAspect::Tv,
+            midi_in: "",
+            midi_out: "",
+            audio_output: "",
+            sampler_input: "",
+            sampler_gain: "",
+        };
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::IoPorts;
+        state.setup.cycle(LauncherField::ParallelDevice, true); // None -> Printer
+        state.setup.cycle(LauncherField::ParallelDevice, true); // Printer -> Sampler
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None, false, false, labels());
+        save(&frame, "launcher-io-ports");
+
+        // I/O Ports with the printer selected and a long output path set, to
+        // check the "Output file" value and the Browse/Clear placement.
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::IoPorts;
+        state.setup.cycle(LauncherField::ParallelDevice, true); // None -> Printer
+        state.setup.set_path(
+            LauncherField::ParallelOutput,
+            std::path::PathBuf::from("/Users/me/Documents/amiga/captures/printer-output.txt"),
+        );
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None, false, false, labels());
+        save(&frame, "launcher-printer");
+
+        // The Host Mounts sub-page reached from the Hard Disk tab.
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::HostFs;
+        let ui = UiState {
+            menu_open: false,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None, false, false, labels());
+        save(&frame, "launcher-host-mounts");
     }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4289,6 +4289,12 @@ impl App {
             self.launcher_browse_folder(field);
             return;
         }
+        // The printer capture is a file we create/overwrite, not an existing
+        // image to open, so it gets a save dialog seeded with a default name.
+        if field == LauncherField::ParallelOutput {
+            self.launcher_browse_save(field, "printer.txt");
+            return;
+        }
         let start_dir = self
             .launcher_state()
             .and_then(|s| s.setup.path(field))
@@ -4352,6 +4358,39 @@ impl App {
             dialog = dialog.set_directory(dir);
         }
         let picked = dialog.pick_folder();
+        if let Some(path) = picked {
+            if let Some(state) = self.launcher_state_mut() {
+                state.edit_cancel();
+                state.setup.set_path(field, path);
+                state.status = None;
+            }
+        }
+        self.finish_host_io_pause();
+    }
+
+    /// Save-file picker for a path field that names a host file to create or
+    /// overwrite (the printer capture), seeded with `default_name` so the dialog
+    /// suggests a filename without the user typing one. An existing file can
+    /// still be chosen.
+    fn launcher_browse_save(&mut self, field: LauncherField, default_name: &str) {
+        let current = self
+            .launcher_state()
+            .and_then(|s| s.setup.path(field))
+            .map(|p| p.to_path_buf());
+        self.suspend_live_audio_for_host_io();
+        let mut dialog = rfd::FileDialog::new().set_title("Choose output file");
+        // Seed with the existing path's directory and name, else the default.
+        match current.as_ref().and_then(|p| p.parent()) {
+            Some(dir) if !dir.as_os_str().is_empty() => dialog = dialog.set_directory(dir),
+            _ => {}
+        }
+        let name = current
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or(default_name);
+        dialog = dialog.set_file_name(name);
+        let picked = dialog.save_file();
         if let Some(path) = picked {
             if let Some(state) = self.launcher_state_mut() {
                 state.edit_cancel();


### PR DESCRIPTION
Follows on from the parallel-port sampler work (#138) with three configuration-screen (launcher) changes. General cosmetic tidy up of the front end GUI. 

## "I/O Ports" tab to replace "Serial" and "Parallel" 

The separate *Serial* and *Parallel* tabs are merged into a single **I/O Ports** tab, with greyed **Serial:** / **Parallel:** section headings (a new non-interactive `SectionHeader` row kind). Each section keeps its dynamic rows — MIDI endpoints only in MIDI mode, sampler/printer rows only for those devices.

- The serial selector is relabelled **Device / Mode**, since some choices are devices (MIDI) and some are modes (stdout, PTY, TCP), and its off state now reads **None** to match the parallel device selector.
- The tab sits below *Input* in the sidebar.

<img width="720" height="612" alt="Screenshot 2026-07-18 at 20 58 25" src="https://github.com/user-attachments/assets/bdd1e404-a7a8-4181-a4f9-fb4ae3ee3f7b" />

## Printer as a parallel port device in the GUI

The printer capture was CLI/config-only. Selecting **Printer** on the parallel port now reveals an **Output file** row with a Browse button — a save dialog seeded with `printer.txt` (an existing file can be picked too). The device selector cycles None / Printer / Sampler.

A printer with no output file is treated as an incomplete selection: it isn't attached or persisted (a bare `output` path already implies the printer, so nothing is lost on round-trip).

<img width="721" height="616" alt="Screenshot 2026-07-18 at 20 58 59" src="https://github.com/user-attachments/assets/817ca6cd-0509-496b-8b53-7d9fd09f7399" />

## Host Mounts under Hard Disk

Host Mounts is no longer a top-level tab. The **Hard Disk** tab opens with a **Host Mounts** link (a new `SubPageLink` row kind) to a sub-page that has a **‹ Hard Disk** back link and keeps Hard Disk highlighted. Both nav buttons sit top-left, sized to their label.

<img width="722" height="615" alt="Screenshot 2026-07-18 at 20 59 30" src="https://github.com/user-attachments/assets/0fc3b6c0-b597-4216-8203-88f37511a237" />

<img width="721" height="618" alt="Screenshot 2026-07-18 at 20 59 44" src="https://github.com/user-attachments/assets/5c05c38d-bf47-4715-86e6-8561e36f87ae" />

## Testing

`cargo fmt` / `clippy` / `test` clean (1600+ unit tests), and it builds without the `frontend` feature. Launcher preview renders were added for the new tab, the printer row, and the sub-page.

