### PR TITLE
Browser page hooks: drive-sound toggle, local disk list, joystick presets, left-hand fire

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -507,6 +507,27 @@ impl WebEmu {
         self.emu.bus_mut().set_output_volume_percent(percent);
     }
 
+    /// Enable or mute the synthesized floppy drive sounds (motor hum,
+    /// head-step clicks, read hiss). On by default, like the desktop's
+    /// `[audio] floppy_sounds` knob.
+    pub fn set_floppy_sounds(&mut self, enabled: bool) {
+        self.emu
+            .bus_mut()
+            .paula
+            .drive_sounds_mut()
+            .set_enabled(enabled);
+    }
+
+    /// Drive-sound level, 0-100, relative to Paula's output (the desktop's
+    /// `[audio] floppy_sounds_volume`).
+    pub fn set_floppy_sounds_volume(&mut self, percent: u8) {
+        self.emu
+            .bus_mut()
+            .paula
+            .drive_sounds_mut()
+            .set_volume_percent(percent);
+    }
+
     pub fn emulated_seconds(&self) -> f64 {
         self.emu.bus().emulated_seconds()
     }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1073,23 +1073,28 @@ const diskListSelect = $('df0list');
 const DISK_LIST_EXT = /\.(adf|adz|dms|ipf|scp|zip|gz)$/i;
 
 async function diskListEntries(folder) {
-  // A manifest wins when the site ships one; only a missing or invalid
-  // one falls through to the directory listing.
+  // A manifest wins when the site ships one; a missing or invalid one
+  // (fetch error, unparsable JSON, not an array) falls through to the
+  // directory listing.
   try {
     const resp = await fetch(new URL('index.json', folder).href);
     if (resp.ok) {
       const manifest = await resp.json();
-      return (Array.isArray(manifest) ? manifest : [])
-        .map((entry) => {
-          const rel = typeof entry === 'string' ? entry : entry?.url;
-          if (typeof rel !== 'string') return null;
-          const url = new URL(rel, folder);
-          const name =
-            (typeof entry === 'object' && entry?.name) ||
-            nameFromUrlPath(url.pathname, rel);
-          return { name, url: url.href };
-        })
-        .filter(Boolean);
+      if (Array.isArray(manifest)) {
+        return manifest
+          .map((entry) => {
+            const rel = typeof entry === 'string' ? entry : entry?.url;
+            if (typeof rel !== 'string') return null;
+            const url = new URL(rel, folder);
+            // A non-string name is ignored rather than trusted: the
+            // sort and the option label both expect a string.
+            const name =
+              (typeof entry?.name === 'string' && entry.name) ||
+              nameFromUrlPath(url.pathname, rel);
+            return { name, url: url.href };
+          })
+          .filter(Boolean);
+      }
     }
   } catch {
     // fall through to the directory listing

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -313,6 +313,7 @@ async function boot() {
     df0Name = pendingDisk?.name ?? null;
     pendingDisk = null;
     machine.set_volume_percent(Number($('vol').value));
+    if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
     emu = machine;
     window.__emu = emu; // for debugging/automation
 
@@ -508,10 +509,14 @@ function pumpSerial() {
 
 // --- joystick (port 2) -----------------------------------------------------
 // The toggle cycles off -> keys (-> touch on touch screens). Keys is the
-// desktop frontend's FS-UAE-compatible mapping: cursor keys for directions,
-// Right Ctrl / Right Alt for fire, CD32 extras on C/X/D/S/Enter/Z/A; while
-// on, these keys drive the port-2 joystick instead of reaching the Amiga
-// keyboard. Touch turns the canvas into a pad (see the touch section).
+// desktop frontend's FS-UAE-compatible mapping plus left-hand fire keys:
+// cursor keys for directions, Right Ctrl / Right Alt or Left Ctrl for fire,
+// Left Alt for the second button (left-hand fire pairs with the right-hand
+// arrows, and compact keyboards often lack the right-side modifiers), CD32
+// extras on C/X/D/S/Enter/Z/A; while on, these keys drive the port-2
+// joystick instead of reaching the Amiga keyboard. Touch turns the canvas
+// into a pad (see the touch section). The page shell can preset the mode
+// (data-default on the toggle) and ?joy=off|keys|touch overrides per link.
 
 const JOY_KEYS = {
   ArrowUp: 'up',
@@ -520,6 +525,8 @@ const JOY_KEYS = {
   ArrowRight: 'right',
   ControlRight: 'fireCtrl',
   AltRight: 'fireAlt',
+  ControlLeft: 'fireLCtrl',
+  AltLeft: 'blueLAlt',
   KeyC: 'red',
   KeyX: 'blue',
   KeyD: 'green',
@@ -540,8 +547,8 @@ function applyJoystick() {
     !!h.down,
     !!h.left,
     !!h.right,
-    !!(h.fireCtrl || h.fireAlt || h.red),
-    !!h.blue,
+    !!(h.fireCtrl || h.fireAlt || h.fireLCtrl || h.red),
+    !!(h.blue || h.blueLAlt),
   );
   emu.set_cd32_buttons_port2(!!h.play, !!h.rwd, !!h.ffw, !!h.green, !!h.yellow);
 }
@@ -556,10 +563,8 @@ function joystickKey(code, pressed) {
   return true;
 }
 
-// Cycles the mode; wired to the control-bar button and to the fullscreen
-// overlay's copy of it, which stay in step.
-function cycleJoyMode() {
-  joyMode = JOY_MODES[(JOY_MODES.indexOf(joyMode) + 1) % JOY_MODES.length];
+function setJoyMode(mode) {
+  joyMode = mode;
   $('joy').textContent = `Joystick: ${joyMode}`;
   if (fsUi) fsUi.joy.textContent = `Joystick: ${joyMode}`;
   for (const k of Object.keys(joyHeld)) joyHeld[k] = false;
@@ -568,6 +573,12 @@ function cycleJoyMode() {
     applyJoystick();
     emu.set_cd32_buttons_port2(false, false, false, false, false);
   }
+}
+
+// Cycles the mode; wired to the control-bar button and to the fullscreen
+// overlay's copy of it, which stay in step.
+function cycleJoyMode() {
+  setJoyMode(JOY_MODES[(JOY_MODES.indexOf(joyMode) + 1) % JOY_MODES.length]);
 }
 
 $('joy').addEventListener('click', cycleJoyMode);
@@ -1038,6 +1049,109 @@ $('vol').addEventListener('input', (e) => {
   if (emu) emu.set_volume_percent(Number(e.target.value));
 });
 
+// Optional in the page shell: a checkbox #floppy-sounds toggles the
+// synthesized drive sounds (motor hum, head-step clicks, read hiss).
+// Without the element the sounds stay on, as before; the checkbox's
+// initial state is applied at boot, so a shell can default them off.
+const floppySoundsToggle = $('floppy-sounds');
+floppySoundsToggle?.addEventListener('change', () => {
+  if (emu) emu.set_floppy_sounds(floppySoundsToggle.checked);
+});
+
+// --- disk list ---------------------------------------------------------
+// Optional in the page shell: a <select id="df0list"> fills itself with
+// the disk images the site serves next to the page and inserts the picked
+// one into DF0 (before boot it queues, like the picker). The folder comes
+// from the select's data-src attribute (default "adf/"), and the list from
+// <folder>/index.json - a JSON array of file names, or of {name, url}
+// objects with URLs relative to the folder. Without a manifest, a server
+// directory listing of the folder (nginx autoindex, Apache, python -m
+// http.server) is scraped for disk-image links instead. An empty or
+// unreachable folder hides the select.
+
+const diskListSelect = $('df0list');
+const DISK_LIST_EXT = /\.(adf|adz|dms|ipf|scp|zip|gz)$/i;
+
+async function diskListEntries(folder) {
+  // A manifest wins when the site ships one; only a missing or invalid
+  // one falls through to the directory listing.
+  try {
+    const resp = await fetch(new URL('index.json', folder).href);
+    if (resp.ok) {
+      const manifest = await resp.json();
+      return (Array.isArray(manifest) ? manifest : [])
+        .map((entry) => {
+          const rel = typeof entry === 'string' ? entry : entry?.url;
+          if (typeof rel !== 'string') return null;
+          const url = new URL(rel, folder);
+          const name =
+            (typeof entry === 'object' && entry?.name) ||
+            nameFromUrlPath(url.pathname, rel);
+          return { name, url: url.href };
+        })
+        .filter(Boolean);
+    }
+  } catch {
+    // fall through to the directory listing
+  }
+  try {
+    const resp = await fetch(folder.href);
+    if (!resp.ok) return [];
+    const doc = new DOMParser().parseFromString(await resp.text(), 'text/html');
+    const entries = [];
+    for (const a of doc.querySelectorAll('a[href]')) {
+      let url;
+      try {
+        url = new URL(a.getAttribute('href'), folder);
+      } catch {
+        continue;
+      }
+      // Only files inside the folder itself; autoindex pages also carry
+      // parent-directory and sort links.
+      if (url.origin !== folder.origin || !url.pathname.startsWith(folder.pathname)) continue;
+      if (!DISK_LIST_EXT.test(url.pathname)) continue;
+      entries.push({ name: nameFromUrlPath(url.pathname, url.pathname), url: url.href });
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+async function loadDiskList(select) {
+  let folder;
+  try {
+    folder = new URL(select.dataset.src || 'adf/', location.href);
+  } catch {
+    select.hidden = true;
+    return;
+  }
+  if (!folder.pathname.endsWith('/')) folder.pathname += '/';
+  const entries = await diskListEntries(folder);
+  if (!entries.length) {
+    select.hidden = true;
+    return;
+  }
+  entries.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+  if (!select.options.length) {
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'DF0 from list...';
+    select.appendChild(placeholder);
+  }
+  for (const { name, url } of entries) {
+    const option = document.createElement('option');
+    option.value = url;
+    option.textContent = name;
+    select.appendChild(option);
+  }
+  select.addEventListener('change', () => {
+    if (select.value) insertDiskFromUrl(select.value);
+  });
+}
+
+if (diskListSelect) loadDiskList(diskListSelect);
+
 // Optional in the page shell: older shells have no URL button.
 $('df0url')?.addEventListener('click', () => {
   const url = window.prompt(
@@ -1186,4 +1300,14 @@ const linkedDisk = pageParams.get('df0');
 if (linkedDisk) insertDiskFromUrl(linkedDisk);
 const linkedKick = pageParams.get('kick');
 if (linkedKick) fitRomFromUrl(linkedKick);
+
+// Starting joystick mode: the page shell's default (data-default on the
+// toggle), overridden per link by ?joy=off|keys|touch. A touch request on
+// a screen without touch falls back to keys, so a game link written for
+// tablets still gets a joystick on a desktop.
+const requestedJoy = (pageParams.get('joy') ?? $('joy').dataset.default ?? '').trim();
+if (requestedJoy && requestedJoy !== joyMode) {
+  if (JOY_MODES.includes(requestedJoy)) setJoyMode(requestedJoy);
+  else if (requestedJoy === 'touch') setJoyMode('keys');
+}
 load();

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -61,9 +61,14 @@ Controls:
   as the desktop frontend.
 - **Joystick**: the toggle cycles off -> keys (-> touch on touch screens).
   Keys is the desktop frontend's FS-UAE-compatible mapping -- cursor keys
-  for directions, Right Ctrl / Right Alt for fire, CD32 extras on
-  C/X/D/S/Enter/Z/A -- and while enabled those keys are captured from the
-  Amiga keyboard, like the desktop toggle.
+  for directions, Right Ctrl / Right Alt or Left Ctrl for fire, Left Alt
+  for the second button (the left-hand fire keys pair with the right-hand
+  arrows, and compact keyboards often lack the right-side modifiers), CD32
+  extras on C/X/D/S/Enter/Z/A -- and while enabled those keys are captured
+  from the Amiga keyboard, like the desktop toggle. A link can preset the
+  mode with `?joy=keys` (or `off`/`touch`), so a game URL starts with the
+  joystick already on; `touch` falls back to `keys` on screens without
+  touch.
 - **Touch**: the canvas works like a trackpad, because the Amiga pointer
   only takes relative motion and an absolute finger position cannot map to
   it. One finger drags the pointer, a quick tap left-clicks, holding still
@@ -202,7 +207,9 @@ feeds from the desktop frontend's FS-UAE-compatible keyboard mapping
 (cursor keys, Right Ctrl / Right Alt fire, CD32 extras on C/X/D/S/Enter/Z/A).
 `reset()` power-cycles, `eject_floppy(n)`
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
-exposes the guest clock for diagnostics. `serial_send(bytes)`,
+exposes the guest clock for diagnostics. `set_floppy_sounds(on)` and
+`set_floppy_sounds_volume(p)` control the synthesized drive sounds (on and
+100 by default, like the desktop's `[audio] floppy_sounds` knobs). `serial_send(bytes)`,
 `serial_take()` and `serial_input_backlog()` bridge Paula's serial port to
 whatever byte stream the page likes (see
 [the serial bridge section](#browser-serial-bridge)). The presentation pointer is only
@@ -215,6 +222,32 @@ from both every frame rather than assuming fixed dimensions.
 
 `www/try.js` and `www/audio-worklet.js` are the reference implementation of
 all of the above, including the audio drift control.
+
+### Optional page-shell hooks
+
+`try.js` drives any page shell that provides its element ids; beyond the
+required canvas and control bar, a shell can opt into extras by adding
+elements, and pages without them are untouched:
+
+- `#df0url` / `#kickurl` (buttons): prompt for a disk / same-origin ROM
+  URL, as described above.
+- `#floppy-sounds` (checkbox): toggles the synthesized floppy drive
+  sounds -- motor hum, head-step clicks, read hiss -- live and at boot, so
+  a shell can also default them off by shipping the box unchecked.
+- `#df0list` (a `<select>`): fills itself with the disk images the site
+  serves next to the page and inserts the picked one into DF0 (queued
+  when picked before boot, live after). The folder is the select's
+  `data-src` attribute (default `adf/`), and the list comes from
+  `<folder>/index.json` -- a JSON array of file names, or of
+  `{name, url}` objects with URLs resolved against the folder. Without a
+  manifest, a server directory listing of the folder (nginx `autoindex`,
+  Apache, `python -m http.server`) is scraped for disk-image links
+  instead. If the folder yields nothing, the select hides itself.
+- `data-default="keys"` on the `#joy` toggle: the joystick mode the page
+  starts in (`?joy=` in the URL overrides it).
+- `#serial-url`, `#serial-connect`, `#serial-status`, `#serial-raw`: the
+  serial/BBS bridge, described in
+  [the serial bridge section](#browser-serial-bridge).
 
 (browser-serial-bridge)=
 ## The serial port: dialling a BBS from a browser

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -404,11 +404,14 @@ starting mode with `[input] joystick` in the config (or `--joystick MODE`, or
 the launcher's *Input* tab).
 
 The primary keyboard mapping is FS-UAE-compatible: cursor keys for
-directions, and Right Ctrl or Right Alt for fire. For CD32 pad buttons,
-`C` is red/fire, `X` is blue, `D` is green, `S` is yellow, Return is
-play/pause, `Z` is rewind, and `A` is forward. On a mouse port the same
-keys drive the pointer: cursor keys move it, the fire keys are the left
-button, `X` the right, and `D` the middle. The second (numpad) mapping is
+directions, and Right Ctrl, Right Alt or Left Ctrl for fire, with Left
+Alt as the second button (the left-hand fire keys pair naturally with the
+right-hand arrows, and compact keyboards often lack the right-side
+modifiers). For CD32 pad buttons, `C` is red/fire, `X` is blue, `D` is
+green, `S` is yellow, Return is play/pause, `Z` is rewind, and `A` is
+forward. On a mouse port the same keys drive the pointer: cursor keys
+move it, the fire keys are the left button, `X` or Left Alt the right,
+and `D` the middle. The second (numpad) mapping is
 `8`/`2`/`4`/`6` for directions, `0` for fire, `.` for the second button,
 and numpad Enter for play. While a mapping owns its keys, they are not
 sent to the Amiga keyboard.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1554,7 +1554,7 @@ impl MachineSetup {
                 if self.port_devices[port] == PortDevice::Mouse {
                     "cursor keys as a mouse (fire keys = buttons)".to_string()
                 } else {
-                    "cursor keys (Ctrl = fire, Left Alt = button 2)".to_string()
+                    "cursor keys (Ctrl / Right Alt = fire, Left Alt = button 2)".to_string()
                 }
             } else {
                 match self.port_devices[port] {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1554,7 +1554,7 @@ impl MachineSetup {
                 if self.port_devices[port] == PortDevice::Mouse {
                     "cursor keys as a mouse (fire keys = buttons)".to_string()
                 } else {
-                    "cursor keys (Right Ctrl / Right Alt = fire)".to_string()
+                    "cursor keys (Ctrl = fire, Left Alt = button 2)".to_string()
                 }
             } else {
                 match self.port_devices[port] {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1554,7 +1554,7 @@ impl MachineSetup {
                 if self.port_devices[port] == PortDevice::Mouse {
                     "cursor keys as a mouse (fire keys = buttons)".to_string()
                 } else {
-                    "cursor keys (Ctrl / Right Alt = fire, Left Alt = button 2)".to_string()
+                    "cursor keys (Ctrl/RAlt = fire, LAlt = button 2)".to_string()
                 }
             } else {
                 match self.port_devices[port] {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -76,8 +76,10 @@ enum KeyboardJoystickKey {
     Right,
     FireRightCtrl,
     FireRightAlt,
+    FireLeftCtrl,
     Red,
     Blue,
+    BlueLeftAlt,
     Green,
     Yellow,
     Play,
@@ -96,8 +98,10 @@ struct KeyboardJoystickHeld {
     right: bool,
     fire_right_ctrl: bool,
     fire_right_alt: bool,
+    fire_left_ctrl: bool,
     red: bool,
     blue: bool,
+    blue_left_alt: bool,
     green: bool,
     yellow: bool,
     play: bool,
@@ -114,8 +118,10 @@ impl KeyboardJoystickHeld {
             KeyboardJoystickKey::Right => self.right = held,
             KeyboardJoystickKey::FireRightCtrl => self.fire_right_ctrl = held,
             KeyboardJoystickKey::FireRightAlt => self.fire_right_alt = held,
+            KeyboardJoystickKey::FireLeftCtrl => self.fire_left_ctrl = held,
             KeyboardJoystickKey::Red => self.red = held,
             KeyboardJoystickKey::Blue => self.blue = held,
+            KeyboardJoystickKey::BlueLeftAlt => self.blue_left_alt = held,
             KeyboardJoystickKey::Green => self.green = held,
             KeyboardJoystickKey::Yellow => self.yellow = held,
             KeyboardJoystickKey::Play => self.play = held,
@@ -132,8 +138,10 @@ impl KeyboardJoystickHeld {
             KeyboardJoystickKey::Right => self.right,
             KeyboardJoystickKey::FireRightCtrl => self.fire_right_ctrl,
             KeyboardJoystickKey::FireRightAlt => self.fire_right_alt,
+            KeyboardJoystickKey::FireLeftCtrl => self.fire_left_ctrl,
             KeyboardJoystickKey::Red => self.red,
             KeyboardJoystickKey::Blue => self.blue,
+            KeyboardJoystickKey::BlueLeftAlt => self.blue_left_alt,
             KeyboardJoystickKey::Green => self.green,
             KeyboardJoystickKey::Yellow => self.yellow,
             KeyboardJoystickKey::Play => self.play,
@@ -148,8 +156,8 @@ impl KeyboardJoystickHeld {
             down: self.down,
             left: self.left,
             right: self.right,
-            fire: self.fire_right_ctrl || self.fire_right_alt || self.red,
-            button2: self.blue,
+            fire: self.fire_right_ctrl || self.fire_right_alt || self.fire_left_ctrl || self.red,
+            button2: self.blue || self.blue_left_alt,
             green: self.green,
             yellow: self.yellow,
             play: self.play,
@@ -162,10 +170,13 @@ impl KeyboardJoystickHeld {
 /// Keyboard controller emulation, two collision-free layouts so a
 /// two-controller setup can be driven from one keyboard:
 ///
-/// - Mapping 0 (FS-UAE-compatible): cursor keys for directions; Right
-///   Ctrl/Right Alt for fire; CD32 extras on C/X/D/S/Return/Z/A. On a
-///   mouse port the same keys become pointer motion, with fire = left
-///   button, X = right, D = middle.
+/// - Mapping 0 (FS-UAE-compatible, plus left-hand fire keys): cursor keys
+///   for directions; Right Ctrl/Right Alt or Left Ctrl for fire; Left Alt
+///   for the second button (left-hand fire keys pair with the right-hand
+///   arrows, and compact keyboards often lack the right-side modifiers);
+///   CD32 extras on C/X/D/S/Return/Z/A. On a mouse port the same keys
+///   become pointer motion, with fire = left button, X or Left Alt =
+///   right, D = middle.
 /// - Mapping 1 (numpad): 8/2/4/6 for directions, 0 for fire, `.` for
 ///   the second button, numpad Enter for play. It stands in for the
 ///   gamepad when a two-controller setup has no physical pad.
@@ -177,6 +188,8 @@ fn keyboard_joystick_key_for(code: KeyCode) -> Option<(usize, KeyboardJoystickKe
         KeyCode::ArrowRight => (0, KeyboardJoystickKey::Right),
         KeyCode::ControlRight => (0, KeyboardJoystickKey::FireRightCtrl),
         KeyCode::AltRight => (0, KeyboardJoystickKey::FireRightAlt),
+        KeyCode::ControlLeft => (0, KeyboardJoystickKey::FireLeftCtrl),
+        KeyCode::AltLeft => (0, KeyboardJoystickKey::BlueLeftAlt),
         KeyCode::KeyC => (0, KeyboardJoystickKey::Red),
         KeyCode::KeyX => (0, KeyboardJoystickKey::Blue),
         KeyCode::KeyD => (0, KeyboardJoystickKey::Green),

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -320,6 +320,8 @@ fn keyboard_joystick_mapping_matches_fsuae_controls() {
         (KeyCode::ArrowRight, K::Right),
         (KeyCode::ControlRight, K::FireRightCtrl),
         (KeyCode::AltRight, K::FireRightAlt),
+        (KeyCode::ControlLeft, K::FireLeftCtrl),
+        (KeyCode::AltLeft, K::BlueLeftAlt),
         (KeyCode::KeyC, K::Red),
         (KeyCode::KeyX, K::Blue),
         (KeyCode::KeyD, K::Green),
@@ -343,7 +345,7 @@ fn keyboard_joystick_mapping_matches_fsuae_controls() {
     ] {
         assert_eq!(keyboard_joystick_key_for(code), Some((1, key)), "{code:?}");
     }
-    assert_eq!(keyboard_joystick_key_for(KeyCode::ControlLeft), None);
+    assert_eq!(keyboard_joystick_key_for(KeyCode::Space), None);
 }
 
 #[test]
@@ -351,13 +353,31 @@ fn keyboard_joystick_fire_aliases_release_independently() {
     let mut held = KeyboardJoystickHeld::default();
     held.set(KeyboardJoystickKey::FireRightCtrl, true);
     held.set(KeyboardJoystickKey::Red, true);
+    held.set(KeyboardJoystickKey::FireLeftCtrl, true);
     assert!(held.joystick_state().fire);
 
     held.set(KeyboardJoystickKey::FireRightCtrl, false);
     assert!(held.joystick_state().fire);
 
     held.set(KeyboardJoystickKey::Red, false);
+    assert!(held.joystick_state().fire);
+
+    held.set(KeyboardJoystickKey::FireLeftCtrl, false);
     assert!(!held.joystick_state().fire);
+}
+
+#[test]
+fn keyboard_joystick_second_button_aliases_release_independently() {
+    let mut held = KeyboardJoystickHeld::default();
+    held.set(KeyboardJoystickKey::Blue, true);
+    held.set(KeyboardJoystickKey::BlueLeftAlt, true);
+    assert!(held.joystick_state().button2);
+
+    held.set(KeyboardJoystickKey::Blue, false);
+    assert!(held.joystick_state().button2);
+
+    held.set(KeyboardJoystickKey::BlueLeftAlt, false);
+    assert!(!held.joystick_state().button2);
 }
 
 #[test]


### PR DESCRIPTION
Implements the four features requested by the Retro32 embed. All are opt-in page hooks: a shell without the new elements behaves exactly as before.

## What's in it

- **Drive-sound toggle**: `WebEmu` exposes the core's synthesized floppy sounds as `set_floppy_sounds(on)` / `set_floppy_sounds_volume(0-100)` (the desktop's `[audio] floppy_sounds` knobs), and `try.js` drives them from an optional `#floppy-sounds` checkbox, applied live and at boot (ship it unchecked to default the sounds off).
- **Local disk list**: an optional `<select id="df0list">` fills itself from a disk folder next to the page (`data-src`, default `adf/`). It reads `<folder>/index.json` (a JSON array of file names, or `{name, url}` objects) and falls back to scraping a server directory listing (nginx autoindex, Apache, `python -m http.server`). Picked before boot it queues like the file picker; after boot it inserts live. An empty folder hides the select.
- **Joystick preset**: the starting mode can be set by the shell (`data-default="keys"` on `#joy`) and per link (`?joy=off|keys|touch`; the URL wins, and `touch` falls back to `keys` on screens without touch).
- **Left-hand fire keys**: the keys mapping adds Left Ctrl = fire and Left Alt = second button alongside the FS-UAE-classic Right Ctrl / Right Alt, so fire sits under the left hand while the right hand has the arrows. The desktop keyboard-joystick mapping gains the same aliases (the docs promise the two frontends share one table); the launcher's Input-tab caption, `docs/guide/ui.md` and `docs/guide/browser.md` are updated, and browser.md gains an "Optional page-shell hooks" section documenting the try.js element contract.

## Verification

- `cargo test` green (new second-button alias test; the mapping test now covers Left Ctrl/Alt), `cargo clippy` and `cargo fmt --check` clean, web crate builds for `wasm32-unknown-unknown` and the wasm-bindgen 0.2.126 output exports the new calls.
- Live browser smoke test against a minimal shell served by `python -m http.server`: directory-listing scrape (encoded names decode correctly), `index.json` manifest override with friendly labels, pre-boot queue then insert-at-boot from the list, sounds toggle and volume calls, `data-default` and `?joy=` override all behaved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1dK61eNHj3RaCQBQ3GveX