### PR TITLE
release: nested-lockfile sync notes and CI guard

### DIFF
--- a/.github/workflows/locks.yml
+++ b/.github/workflows/locks.yml
@@ -1,0 +1,48 @@
+name: Lockfile sync
+
+# Verifies every committed Cargo.lock still resolves with --locked, i.e. is
+# in sync with its workspace's manifests. The root lock is already exercised
+# by the --locked builds in ci.yml, but the nested workspaces mostly are not:
+# crates/copperline-web and crates/cputest-runner carry their own committed
+# locks that pin sibling path crates (copperline and copperline-m68k) by
+# version, and a version bump in the sibling silently invalidates them
+# (issue #219: the v0.12.0 tag shipped crates/copperline-web/Cargo.lock
+# still pinning copperline 0.11.0, so `cargo build --locked` failed for
+# anyone building the web crate from the tag). crates/m68k is also its own
+# workspace but deliberately gitignores its lock, so there is nothing to
+# check there.
+#
+# The v* tag trigger is the part that closes issue #219: the drift reached
+# the 0.12.0 release because the tag was cut directly from a fresh bump
+# commit, before any PR- or push-triggered check had a chance to run. A red
+# check on the tag itself appears within about a minute of pushing it, while
+# the tag can still be deleted and re-cut.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+
+concurrency:
+  group: locks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  locks:
+    name: Committed lockfiles resolve with --locked
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # cargo tree resolves the full dependency graph without compiling
+      # anything, and --locked turns any would-be lockfile update into an
+      # error, so each check runs in seconds.
+      - name: Root workspace
+        run: cargo tree --locked > /dev/null
+      - name: crates/copperline-web
+        working-directory: crates/copperline-web
+        run: cargo tree --locked > /dev/null
+      - name: crates/cputest-runner
+        working-directory: crates/cputest-runner
+        run: cargo tree --locked > /dev/null

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,6 +38,35 @@ resolve that dependency story before attempting a crates.io release.
    git check-ignore -v KICK13.ROM AmigaTestKit.adf cdtv_single.bin
    ```
 
+## Version bump
+
+`crates/copperline-web` and `crates/cputest-runner` are separate workspaces
+with their own committed `Cargo.lock` files, so a root build never refreshes
+them (`crates/m68k` is also its own workspace, but its lock is deliberately
+gitignored, so it cannot drift). Both pin sibling crates by path:
+`copperline-web` locks the root `copperline` version and `cputest-runner`
+locks the `copperline-m68k` version. If either version is bumped without
+regenerating the matching nested lock, every `cargo build --locked` in that
+crate fails at the release tag, and tags are immutable so the breakage
+cannot be fixed after the fact (issue #219: the `v0.12.0` tag shipped
+`crates/copperline-web/Cargo.lock` still pinning `copperline 0.11.0`).
+
+In the same commit as any version bump, resync the affected nested locks
+and commit them:
+
+```sh
+(cd crates/copperline-web && cargo update -p copperline)      # root version bump
+(cd crates/cputest-runner && cargo update -p copperline-m68k) # crates/m68k bump
+```
+
+The `Lockfile sync` workflow (`.github/workflows/locks.yml`) runs these
+checks on every pull request, push to `main`, and `v*` tag push, so a tag
+cut from a commit with a stale lock turns red within about a minute --
+delete and re-cut the tag if that happens. The pre-tag check below is still
+part of the checklist so the drift never reaches the tag at all; the
+v0.12.0 breakage happened precisely because the tag was cut from a fresh
+bump commit before any CI had run against it.
+
 ## Checks
 
 Run these before tagging a source release:
@@ -46,6 +75,14 @@ Run these before tagging a source release:
 cargo fmt --check
 cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --locked
+```
+
+Confirm every nested workspace lockfile is in sync (fails if a version bump
+missed one; see "Version bump" above):
+
+```sh
+(cd crates/copperline-web && cargo tree --locked > /dev/null)
+(cd crates/cputest-runner && cargo tree --locked > /dev/null)
 ```
 
 Build the documentation:

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -8,6 +8,18 @@ project:
   title: Copperline
   description: A cycle-driven Amiga emulator in Rust
   keywords: [amiga, emulator, ocs, ecs, rust]
+  # --check-links + --strict fails the CI docs build when a linked site is
+  # unreachable. archive.org has outages regularly enough that it broke an
+  # unrelated PR; exempt it from link resolution (the link stays in the
+  # rendered docs) so CI does not depend on its uptime. Keys match the
+  # exact link URL, not the domain, so any new archive.org link needs its
+  # own entry here. Everything else stays checked; add a key only for
+  # sites with a history of downtime.
+  error_rules:
+    - rule: link-resolves
+      severity: ignore
+      keys:
+        - http://archive.org
   authors:
     - name: Andrew Hutchings
   github: https://github.com/LinuxJedi/Copperline


### PR DESCRIPTION
Closes #219.

The v0.12.0 tag shipped a stale `crates/copperline-web/Cargo.lock`: the root version bump did not refresh the nested workspace's lock, so `cargo build --locked` failed for anyone building the web crate from the tag. The fix (fa99ea1) landed on `main` three minutes after the bump, but the tag had already been cut from the bump commit, before any CI had run against it. This PR is the release-process update promised on the issue, in two parts:

## RELEASE.md

- New **Version bump** section: documents that `crates/copperline-web` and `crates/cputest-runner` are separate workspaces with committed locks that pin sibling path crates (`copperline` and `copperline-m68k` respectively), gives the resync commands to run in the same commit as any version bump, and records the issue #219 incident as the rationale (`crates/m68k` deliberately gitignores its lock, so it cannot drift).
- **Checks** section: adds pre-tag `cargo tree --locked` one-liners for both nested workspaces.

## New `Lockfile sync` workflow

A fast ubuntu job running `cargo tree --locked` in the root workspace and both nested workspaces, triggered on pull requests, pushes to `main`, and **`v*` tag pushes**. The tag trigger is the part that closes the gap that produced #219: the existing `wasm` job in ci.yml already checks `copperline-web` with `--locked` on PRs and main pushes, but nothing ran at tag time, and nothing checks `cputest-runner` at all. A tag cut from a stale-lock commit now turns red within about a minute, while it can still be deleted and re-cut.

Verified: `cargo tree --locked` exits non-zero against the exact historical drift (the v0.12.0 lock restored into the working tree) and passes on the current tree; the workflow YAML parses.
