### PR TITLE
crashlog: write panics to a copperline-crash.txt report file

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -207,5 +207,6 @@ Windows, desktop launchers). The file is written next to the executable
 where possible, falling back to the current working directory and then the
 system temporary directory when that location is read-only (installed
 Homebrew/AppImage/Flatpak layouts); a run from a terminal prints the path
-chosen. The file holds the most recent crash -- attach it when filing a
-bug report.
+chosen. The first crash of a run replaces the file, and any further
+crashes in the same run are appended to it, so it always covers the most
+recent session -- attach it when filing a bug report.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -197,3 +197,15 @@ Copperline logs through the standard Rust `log`/`env_logger` machinery.
 `RUST_LOG=debug` (or `trace`) prints more detail from the CPU and MMIO
 layers, and is also how the [headless debugger](../debugger/headless)
 output is surfaced.
+
+## Crash reports
+
+If Copperline itself crashes, it writes the crash message and a backtrace
+to `copperline-crash.txt` before exiting, so the details survive launches
+where nobody is watching the terminal (double-clicking `copperline.exe` on
+Windows, desktop launchers). The file is written next to the executable
+where possible, falling back to the current working directory and then the
+system temporary directory when that location is read-only (installed
+Homebrew/AppImage/Flatpak layouts); a run from a terminal prints the path
+chosen. The file holds the most recent crash -- attach it when filing a
+bug report.

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -34,8 +34,9 @@ Troubleshooting
 ---------------
 If Copperline crashes, it writes the crash details to copperline-crash.txt
 next to copperline.exe (or, if that folder is read-only, to the current
-directory or the system temporary directory). The file holds the most
-recent crash; please attach it when reporting a bug at
+directory or the system temporary directory). The file is replaced at the
+first crash of each run, and any further crashes in the same run are
+appended to it; please attach it when reporting a bug at
 https://github.com/LinuxJedi/Copperline/issues
 
 Copperline is licensed under GPL-3.0-or-later; see LICENSE.txt.

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -30,4 +30,12 @@ own Kickstart ROM and disk/hard-disk images, and launch with:
 
 Run "copperline.exe --help" for the full command-line surface.
 
+Troubleshooting
+---------------
+If Copperline crashes, it writes the crash details to copperline-crash.txt
+next to copperline.exe (or, if that folder is read-only, to the current
+directory or the system temporary directory). The file holds the most
+recent crash; please attach it when reporting a bug at
+https://github.com/LinuxJedi/Copperline/issues
+
 Copperline is licensed under GPL-3.0-or-later; see LICENSE.txt.

--- a/src/crashlog.rs
+++ b/src/crashlog.rs
@@ -22,10 +22,13 @@ use std::sync::Mutex;
 /// directory (see [`install`]).
 pub const CRASH_FILE_NAME: &str = "copperline-crash.txt";
 
-/// Serializes concurrently panicking threads and remembers whether this
-/// process has already written a report: the first panic truncates a stale
-/// report left by an earlier run, later panics in the same process append.
-static REPORT_WRITTEN: Mutex<bool> = Mutex::new(false);
+/// Serializes concurrently panicking threads and remembers where this
+/// process wrote its report: the first panic picks a location, truncating
+/// a stale report left by an earlier run, and later panics in the same
+/// process append to that same file even if the candidate list would
+/// resolve differently by then (the working directory can change at
+/// runtime).
+static REPORT_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 /// Install the process panic hook: print the panic to stderr, persist a
 /// crash report, and chain to the previously installed hook.
@@ -76,19 +79,29 @@ fn candidate_dirs() -> Vec<PathBuf> {
 /// Write `report` to [`CRASH_FILE_NAME`] in the first directory that
 /// accepts it, returning the path written.
 fn write_report(dirs: &[PathBuf], report: &str) -> Option<PathBuf> {
-    write_report_locked(&REPORT_WRITTEN, dirs, report)
+    write_report_locked(&REPORT_PATH, dirs, report)
 }
 
-/// Testable core of [`write_report`]: `written` carries the
-/// truncate-or-append state so tests get isolated instances. A poisoned
-/// lock is taken anyway -- the flag stays usable, and the alternative is
-/// dropping the report.
-fn write_report_locked(written: &Mutex<bool>, dirs: &[PathBuf], report: &str) -> Option<PathBuf> {
-    let mut written = written.lock().unwrap_or_else(|e| e.into_inner());
+/// Testable core of [`write_report`]: `state` carries the chosen report
+/// path so tests get isolated instances. A poisoned lock is taken
+/// anyway -- the path stays usable, and the alternative is dropping the
+/// report.
+fn write_report_locked(
+    state: &Mutex<Option<PathBuf>>,
+    dirs: &[PathBuf],
+    report: &str,
+) -> Option<PathBuf> {
+    let mut chosen = state.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(path) = chosen.as_ref() {
+        if write_file(path, true, report).is_ok() {
+            return Some(path.clone());
+        }
+        // The chosen location vanished mid-run; fall through to pick anew.
+    }
     for dir in dirs {
         let path = dir.join(CRASH_FILE_NAME);
-        if write_file(&path, *written, report).is_ok() {
-            *written = true;
+        if write_file(&path, false, report).is_ok() {
+            *chosen = Some(path.clone());
             return Some(path);
         }
     }
@@ -141,7 +154,7 @@ mod tests {
         let dir = temp_dir("truncate");
         let path = dir.join(CRASH_FILE_NAME);
         std::fs::write(&path, "stale report from an earlier run").unwrap();
-        let state = Mutex::new(false);
+        let state = Mutex::new(None);
         let got =
             write_report_locked(&state, std::slice::from_ref(&dir), "first\n").expect("written");
         assert_eq!(got, path);
@@ -154,7 +167,7 @@ mod tests {
     #[test]
     fn falls_back_past_an_unwritable_directory() {
         let dir = temp_dir("fallback");
-        let state = Mutex::new(false);
+        let state = Mutex::new(None);
         let got = write_report_locked(&state, &[unwritable_dir(), dir.clone()], "report")
             .expect("written");
         assert_eq!(got, dir.join(CRASH_FILE_NAME));
@@ -166,10 +179,49 @@ mod tests {
     }
 
     #[test]
+    fn later_panic_stays_with_the_chosen_file() {
+        // A second panic must append to the file the first one picked even
+        // when the candidate list has since changed (e.g. the working
+        // directory moved), not start a second report elsewhere.
+        let first = temp_dir("chosen");
+        let other = temp_dir("other");
+        let state = Mutex::new(None);
+        write_report_locked(&state, std::slice::from_ref(&first), "first\n").expect("written");
+        let got = write_report_locked(&state, &[other.clone(), first.clone()], "second\n")
+            .expect("written");
+        assert_eq!(got, first.join(CRASH_FILE_NAME));
+        assert_eq!(
+            std::fs::read_to_string(first.join(CRASH_FILE_NAME)).unwrap(),
+            "first\nsecond\n"
+        );
+        assert!(!other.join(CRASH_FILE_NAME).exists());
+        std::fs::remove_dir_all(&first).ok();
+        std::fs::remove_dir_all(&other).ok();
+    }
+
+    #[test]
+    fn vanished_chosen_file_location_is_repicked() {
+        let first = temp_dir("vanishing");
+        let fallback = temp_dir("repick");
+        let state = Mutex::new(None);
+        write_report_locked(&state, std::slice::from_ref(&first), "first\n").expect("written");
+        std::fs::remove_dir_all(&first).unwrap();
+        let got = write_report_locked(&state, std::slice::from_ref(&fallback), "second\n")
+            .expect("written");
+        assert_eq!(got, fallback.join(CRASH_FILE_NAME));
+        assert_eq!(
+            std::fs::read_to_string(fallback.join(CRASH_FILE_NAME)).unwrap(),
+            "second\n"
+        );
+        assert_eq!(*state.lock().unwrap(), Some(got));
+        std::fs::remove_dir_all(&fallback).ok();
+    }
+
+    #[test]
     fn no_writable_candidate_returns_none() {
-        let state = Mutex::new(false);
+        let state = Mutex::new(None);
         assert!(write_report_locked(&state, &[unwritable_dir()], "report").is_none());
-        assert!(!*state.lock().unwrap());
+        assert!(state.lock().unwrap().is_none());
     }
 
     #[test]

--- a/src/crashlog.rs
+++ b/src/crashlog.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Persistent crash reports from the process panic hook.
+//!
+//! A panic already prints to stderr, but that is invisible for the common
+//! double-click launch: on Windows the console window closes with the
+//! process, and desktop launchers on every platform discard stderr. The
+//! hook installed here therefore also writes the panic message and a
+//! backtrace to `copperline-crash.txt` so users can attach it to a bug
+//! report. The file lands next to the executable (the natural spot for the
+//! portable Windows bundle), falling back to the working directory and then
+//! the system temporary directory when that location is not writable
+//! (installed Homebrew/AppImage/Flatpak layouts).
+
+use std::backtrace::Backtrace;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Crash-report filename, created in the first writable candidate
+/// directory (see [`install`]).
+pub const CRASH_FILE_NAME: &str = "copperline-crash.txt";
+
+/// Serializes concurrently panicking threads and remembers whether this
+/// process has already written a report: the first panic truncates a stale
+/// report left by an earlier run, later panics in the same process append.
+static REPORT_WRITTEN: Mutex<bool> = Mutex::new(false);
+
+/// Install the process panic hook: print the panic to stderr, persist a
+/// crash report, and chain to the previously installed hook.
+pub fn install() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        eprintln!("\n!!! PANIC: {info}");
+        match write_report(&candidate_dirs(), &format_report(&info.to_string())) {
+            Some(path) => eprintln!("crash report written to {}", path.display()),
+            None => eprintln!("could not write a crash report file"),
+        }
+        prev(info);
+    }));
+}
+
+/// Render one report: build/host identification, the panic message (with
+/// its source location), and a backtrace. The backtrace is captured
+/// independently of RUST_BACKTRACE -- crash reporters cannot be asked to
+/// reproduce the crash with the variable set.
+fn format_report(panic_display: &str) -> String {
+    format!(
+        "Copperline {} ({} {})\ntime: {}\nthread: {}\n\n{}\n\nbacktrace:\n{}\n",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        crate::timestamp::compact_now(),
+        std::thread::current().name().unwrap_or("<unnamed>"),
+        panic_display,
+        Backtrace::force_capture(),
+    )
+}
+
+/// Where to try writing the report, in preference order.
+fn candidate_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            dirs.push(dir.to_path_buf());
+        }
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        dirs.push(cwd);
+    }
+    dirs.push(std::env::temp_dir());
+    dirs
+}
+
+/// Write `report` to [`CRASH_FILE_NAME`] in the first directory that
+/// accepts it, returning the path written.
+fn write_report(dirs: &[PathBuf], report: &str) -> Option<PathBuf> {
+    write_report_locked(&REPORT_WRITTEN, dirs, report)
+}
+
+/// Testable core of [`write_report`]: `written` carries the
+/// truncate-or-append state so tests get isolated instances. A poisoned
+/// lock is taken anyway -- the flag stays usable, and the alternative is
+/// dropping the report.
+fn write_report_locked(written: &Mutex<bool>, dirs: &[PathBuf], report: &str) -> Option<PathBuf> {
+    let mut written = written.lock().unwrap_or_else(|e| e.into_inner());
+    for dir in dirs {
+        let path = dir.join(CRASH_FILE_NAME);
+        if write_file(&path, *written, report).is_ok() {
+            *written = true;
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn write_file(path: &Path, append: bool, report: &str) -> std::io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.write(true).create(true);
+    if append {
+        opts.append(true);
+    } else {
+        opts.truncate(true);
+    }
+    let mut file = opts.open(path)?;
+    file.write_all(report.as_bytes())?;
+    file.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-crashlog-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        dir
+    }
+
+    /// A directory that cannot accept the report: a child of a path that
+    /// does not exist (OpenOptions::create does not create parents).
+    fn unwritable_dir() -> PathBuf {
+        std::env::temp_dir()
+            .join(format!(
+                "copperline-crashlog-missing-{}",
+                std::process::id()
+            ))
+            .join("nonexistent")
+    }
+
+    #[test]
+    fn first_report_truncates_stale_and_later_appends() {
+        let dir = temp_dir("truncate");
+        let path = dir.join(CRASH_FILE_NAME);
+        std::fs::write(&path, "stale report from an earlier run").unwrap();
+        let state = Mutex::new(false);
+        let got =
+            write_report_locked(&state, std::slice::from_ref(&dir), "first\n").expect("written");
+        assert_eq!(got, path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first\n");
+        write_report_locked(&state, std::slice::from_ref(&dir), "second\n").expect("written");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first\nsecond\n");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn falls_back_past_an_unwritable_directory() {
+        let dir = temp_dir("fallback");
+        let state = Mutex::new(false);
+        let got = write_report_locked(&state, &[unwritable_dir(), dir.clone()], "report")
+            .expect("written");
+        assert_eq!(got, dir.join(CRASH_FILE_NAME));
+        assert_eq!(
+            std::fs::read_to_string(dir.join(CRASH_FILE_NAME)).unwrap(),
+            "report"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn no_writable_candidate_returns_none() {
+        let state = Mutex::new(false);
+        assert!(write_report_locked(&state, &[unwritable_dir()], "report").is_none());
+        assert!(!*state.lock().unwrap());
+    }
+
+    #[test]
+    fn report_names_the_build_and_the_panic() {
+        let report = format_report("panicked at src/foo.rs:1:1:\nboom");
+        assert!(report.contains(env!("CARGO_PKG_VERSION")));
+        assert!(report.contains(std::env::consts::OS));
+        assert!(report.contains("boom"));
+        assert!(report.contains("backtrace:"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod config;
 #[cfg(feature = "control")]
 pub mod control;
 pub mod cpu;
+pub mod crashlog;
 pub mod debugger;
 pub mod dirfs;
 pub mod disasm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 //!   the bundled AROS open-source Kickstart replacement (see src/romsearch.rs).
 
 use anyhow::{anyhow, Result};
-use copperline::{config, debugger, emulator, envcfg, gamepad, gdbstub, priority, video};
+use copperline::{config, crashlog, debugger, emulator, envcfg, gamepad, gdbstub, priority, video};
 use log::{info, warn};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -1386,11 +1386,7 @@ fn main() -> Result<()> {
     }
     log_builder.init();
 
-    let prev = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        eprintln!("\n!!! PANIC: {info}");
-        prev(info);
-    }));
+    crashlog::install();
 
     let cli = parse_args()?;
     validate_benchmark_args(&cli)?;


### PR DESCRIPTION
## Summary

Silent-exit reports like #225 happen because a panic only prints to stderr, which nobody sees on the common double-click launch: on Windows the console window closes with the process, and desktop launchers discard stderr on every platform.

The panic hook (moved from `main.rs` into a new `crashlog` module) now also persists a crash report to `copperline-crash.txt`:

- Contents: Copperline version, host OS/arch, timestamp, panicking thread, the panic message with its source location, and a backtrace captured with `Backtrace::force_capture()` so it works without `RUST_BACKTRACE` set (crash reporters cannot be asked to reproduce with it).
- Location: next to the executable (the natural spot for the portable Windows zip), falling back to the working directory and then the system temp directory for read-only install layouts (Homebrew/AppImage/Flatpak). Terminal runs print the path chosen.
- The first panic of a run replaces a stale report from an earlier run; later panics in the same process append. Concurrent panicking threads are serialized by a mutex.

Docs: new "Crash reports" section in `docs/guide/getting-started.md` and a Troubleshooting section in the Windows bundle's `README.txt` asking users to attach the file to bug reports.

## Testing

- 4 new unit tests in `src/crashlog.rs` cover the truncate-then-append lifecycle, directory fallback, the no-writable-candidate case, and report contents.
- `cargo test` (1653 passed), `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Verified end to end with a scratch binary linking the lib: installed the hook, panicked, and confirmed the stderr pointer plus a well-formed `copperline-crash.txt` with a symbolized backtrace.