### PR TITLE
build: give the Windows main thread an 8 MiB stack (fixes #225)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,27 @@ fn main() {
     };
 
     println!("cargo:rustc-env=COPPERLINE_DISPLAY_VERSION={display_version}");
+
+    set_windows_main_thread_stack();
+}
+
+/// Give the Windows binaries the same ~8 MiB main-thread stack that Linux and
+/// macOS provide by default; the MSVC linker otherwise reserves only 1 MiB.
+///
+/// The winit event loop must run on the main thread, and the configuration
+/// screen's Run boots the machine from inside that event-loop callback -- so the
+/// machine build, the render-state rebuild, and the first present all run deep in
+/// the OS message-pump stack. That bounded-but-substantial work overflows the
+/// 1 MiB default (a silent exit / STATUS_STACK_OVERFLOW when the user clicks Run),
+/// while it fits comfortably in the 8 MiB the other platforms already give. Scoped
+/// to binary targets and, via the target cfg, to Windows MSVC builds only.
+fn set_windows_main_thread_stack() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        const STACK_BYTES: usize = 8 * 1024 * 1024;
+        println!("cargo:rustc-link-arg-bins=/STACK:{STACK_BYTES}");
+    }
 }
 
 fn current_head_ref(git_dir: &str) -> Option<String> {


### PR DESCRIPTION
## Summary
Fixes #225 — on Windows, clicking **Run** in the configuration screen crashes
the emulator with a silent exit (`STATUS_STACK_OVERFLOW`, `0xc00000fd`). A
regression since 0.11.0; the GUI otherwise works for configuring and saving.

## Root cause
Windows reserves only ~1 MiB of stack for the main thread; Linux and macOS
default to 8 MiB. The winit event loop must run on the main thread, and the
configuration screen's **Run** (`launcher_run` → `build_machine` →
`run_machine`) builds the machine, rebuilds the host render/presentation state,
and does the first present **from inside the event-loop callback** — already
deep in the OS message-pump stack. That bounded-but-substantial work fits in
8 MiB but overflows 1 MiB. It crossed the 1 MiB line between 0.11 and 0.12,
which is why 0.11 was unaffected.

It reproduces only on the launcher Run path:
- Headless (`--screenshot-after`, unpaced) runs cleanly.
- The same bundled-AROS machine booted directly (`--config`, paced + audio)
  runs cleanly — the machine and run loop are fine.
- Only clicking **Run** — which builds deep inside the event-loop callback —
  overflows.

`size_of::<Emulator>()` is ~48 KiB, so this is call-stack depth on that path,
not a single oversized value on the stack.

## Fix
Emit `/STACK:8388608` for Windows-MSVC binary targets from `build.rs`, giving
the Windows main thread the same 8 MiB the other platforms already provide.
Target-gated via `CARGO_CFG_TARGET_{OS,ENV}` and scoped to binaries, so
Linux/macOS and library builds are untouched.

Matching the main-thread stack (rather than deferring the boot out of the
callback) is deliberate: the work is bounded and already known-good with an
8 MiB stack on the other two platforms, so this is the minimal change that
makes Windows behave the same.

## Testing
- Windows MSVC release build: the binary's PE `SizeOfStackReserve` is now 8 MiB
  (was 1 MiB), and clicking **Run** boots the machine instead of crashing.
- Applies to both `x86_64-pc-windows-msvc` (the reporter's platform) and
  `aarch64-pc-windows-msvc` (where I verified). No effect on non-Windows targets.