### PR TITLE
Front-panel status strip for the browser page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Core without the desktop frontend
         run: cargo check --no-default-features --locked
@@ -277,6 +278,11 @@ jobs:
       - name: Web crate (wasm32-unknown-unknown)
         working-directory: crates/copperline-web
         run: cargo check --target wasm32-unknown-unknown --locked
+      - name: Web crate formatting
+        # The web crate is a standalone workspace, so the root Formatting
+        # step never reaches it.
+        working-directory: crates/copperline-web
+        run: cargo fmt --check
 
   m68k-singlestep:
     name: m68k SingleStepTests (68000 fixtures)

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -326,7 +326,8 @@ impl WebEmu {
             // right; the standard window sits exactly centred.
             self.present_width = present_common::TV_PAL_CAPTURED_WIDTH;
             self.present_rows = present_common::TV_PAL_PRESENT_HEIGHT;
-            self.present.resize(self.present_width * self.present_rows, 0);
+            self.present
+                .resize(self.present_width * self.present_rows, 0);
             for (y, dst) in self
                 .present
                 .chunks_exact_mut(present_common::TV_PAL_CAPTURED_WIDTH)

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -473,6 +473,47 @@ impl WebEmu {
             .map_err(js_err)
     }
 
+    /// Power LED, following CIA-A's /LED output like the desktop status
+    /// bar's LED block. The front-panel getters below are cheap enough to
+    /// poll once per animation frame.
+    pub fn power_led(&self) -> bool {
+        self.emu.bus().front_panel_status().power_led_on
+    }
+
+    /// Floppy activity LED: lit while any drive's motor runs.
+    pub fn fdd_led(&self) -> bool {
+        self.emu.bus().front_panel_status().fdd_led_on
+    }
+
+    /// Cylinder under the selected floppy drive's head, or undefined when
+    /// no drive is selected. The page latches the last value so a track
+    /// counter does not flicker between accesses, like the desktop bar.
+    pub fn fdd_track(&self) -> Option<u8> {
+        self.emu.bus().front_panel_status().fdd_track
+    }
+
+    /// Hard-disk activity LED, or undefined on machines without a disk
+    /// controller (the page hides the LED).
+    pub fn hdd_led(&self) -> Option<bool> {
+        self.emu.bus().front_panel_status().hdd_led
+    }
+
+    /// CD activity LED, or undefined on machines without a CD drive.
+    pub fn cd_led(&self) -> Option<bool> {
+        self.emu.bus().front_panel_status().cd_led
+    }
+
+    /// Whether DFn is wired up: DF0 always, DF1-DF3 when configured.
+    pub fn drive_connected(&self, drive: u8) -> bool {
+        self.emu.bus().floppy.drive_connected(drive as usize)
+    }
+
+    /// File name of the image in DFn, or undefined when the drive is
+    /// empty (so this doubles as the inserted check).
+    pub fn disk_name(&self, drive: u8) -> Option<String> {
+        self.emu.bus().floppy.inserted_disk_name(drive as usize)
+    }
+
     /// Queue received bytes for Paula's serial receiver (the page's
     /// socket -> the guest). The queue is unbounded and the UART consumes it
     /// at the emulated baud rate, so pace large transfers with

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -92,6 +92,7 @@ function insertDisk(bytes, name) {
   if (emu) {
     emu.insert_floppy(0, bytes, name);
     setLoadStatus(`DF0: ${name} (write-protected)`);
+    lastFddTrack = null; // desktop clears its track latch on insert too
     updateStatusDisks();
   } else {
     pendingDisk = { bytes, name };
@@ -941,6 +942,7 @@ $('reset').addEventListener('click', () => {
   if (!emu) return;
   try {
     emu.reset();
+    lastFddTrack = null; // desktop clears its track latch on reset too
     setLoadStatus('machine reset');
   } catch (err) {
     setLoadStatus(`reset failed: ${err.message ?? err}`);

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -92,6 +92,7 @@ function insertDisk(bytes, name) {
   if (emu) {
     emu.insert_floppy(0, bytes, name);
     setLoadStatus(`DF0: ${name} (write-protected)`);
+    updateStatusDisks();
   } else {
     pendingDisk = { bytes, name };
     setLoadStatus(`DF0: ${name} (inserts at boot)`);
@@ -316,6 +317,8 @@ async function boot() {
     if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
     emu = machine;
     window.__emu = emu; // for debugging/automation
+    lastFddTrack = null; // a new machine starts the track latch over
+    updateStatusDisks();
 
     // Leave a fresh status behind: the old line ("inserts at boot", an
     // earlier failure) would otherwise go stale into any bug report filed
@@ -392,6 +395,7 @@ function tick(nowMs) {
   }
 
   pumpSerial();
+  updateStatusLeds();
 
   if (nowMs - lastStatUpdate >= 1000) {
     statLine.textContent =
@@ -400,6 +404,7 @@ function tick(nowMs) {
       `audio ${queuedMs.toFixed(0)} ms`;
     framesThisSecond = 0;
     lastStatUpdate = nowMs;
+    updateStatusDisks();
   }
   requestAnimationFrame(tick);
 }
@@ -926,6 +931,7 @@ $('eject').addEventListener('click', () => {
     emu.eject_floppy(0);
     df0Name = null;
     setLoadStatus('DF0 ejected');
+    updateStatusDisks();
   } catch (err) {
     setLoadStatus(`${err.message ?? err}`);
   }
@@ -1057,6 +1063,132 @@ const floppySoundsToggle = $('floppy-sounds');
 floppySoundsToggle?.addEventListener('change', () => {
   if (emu) emu.set_floppy_sounds(floppySoundsToggle.checked);
 });
+
+// --- status bar --------------------------------------------------------
+// Front-panel status strip mirroring the desktop status bar's LED block:
+// PWR/FDD LEDs (HDD/CD only on machines fitted with the drive), the
+// floppy track counter, and the inserted disk name per connected drive.
+// Built lazily at first boot, like the fullscreen UI, so it never sits on
+// an idle page. Optional in the page shell: a #ledbar element hosts the
+// strip and the page owns its layout; without one the strip drops in
+// directly below the canvas shell with its own styling.
+
+// The desktop status bar's LED and track-counter palette (window.rs).
+const LED_COLORS = {
+  pwr: ['rgb(232,31,24)', 'rgb(66,12,10)'],
+  fdd: ['rgb(236,142,28)', 'rgb(72,38,10)'],
+  hdd: ['rgb(44,200,80)', 'rgb(14,56,24)'],
+  cd: ['rgb(64,170,234)', 'rgb(16,46,70)'],
+};
+
+let statusBar = null;
+// Latched like the desktop bar: the counter keeps showing the last track
+// between accesses instead of flickering back to "---".
+let lastFddTrack = null;
+
+function ensureStatusBar() {
+  if (statusBar) return statusBar;
+  const host = $('ledbar');
+  const bar = host ?? document.createElement('div');
+  if (!host) {
+    bar.style.cssText =
+      'display:flex;align-items:center;gap:0.9rem;flex-wrap:wrap;' +
+      'margin:0.4rem 0;' +
+      'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;' +
+      'color:rgba(255,255,255,0.75);';
+  }
+  const mkLed = (label, [onColor, offColor]) => {
+    const row = document.createElement('span');
+    row.style.cssText = 'display:inline-flex;align-items:center;gap:0.35rem;';
+    const dot = document.createElement('span');
+    dot.style.cssText =
+      'width:10px;height:10px;border-radius:50%;' +
+      `border:1px solid rgba(0,0,0,0.6);background:${offColor};`;
+    row.appendChild(dot);
+    row.appendChild(document.createTextNode(label));
+    bar.appendChild(row);
+    return { row, dot, onColor, offColor, state: null };
+  };
+  const pwr = mkLed('PWR', LED_COLORS.pwr);
+  const fdd = mkLed('FDD', LED_COLORS.fdd);
+  const hdd = mkLed('HDD', LED_COLORS.hdd);
+  const cd = mkLed('CD', LED_COLORS.cd);
+  const track = document.createElement('span');
+  // The desktop's seven-segment track counter, as text.
+  track.style.cssText =
+    'background:rgb(6,8,6);color:rgb(27,220,71);padding:0.1rem 0.4rem;' +
+    'border-radius:3px;letter-spacing:0.1em;';
+  track.textContent = '---';
+  bar.appendChild(track);
+  const disks = document.createElement('span');
+  disks.style.cssText =
+    'overflow:hidden;text-overflow:ellipsis;white-space:nowrap;' +
+    'max-width:24rem;color:rgba(255,255,255,0.55);';
+  bar.appendChild(disks);
+  if (!host) shell.insertAdjacentElement('afterend', bar);
+  statusBar = {
+    bar,
+    pwr,
+    fdd,
+    hdd,
+    cd,
+    track,
+    disks,
+    trackText: '---',
+    disksText: null,
+  };
+  return statusBar;
+}
+
+// state: true/false lights or dims the LED; undefined hides the whole row
+// (the machine has no such drive). Early-returns on no change so steady
+// frames do no DOM writes.
+function setLed(led, state) {
+  if (led.state === state) return;
+  led.state = state;
+  if (state === undefined) {
+    led.row.style.display = 'none';
+    return;
+  }
+  led.row.style.display = 'inline-flex';
+  led.dot.style.background = state ? led.onColor : led.offColor;
+}
+
+// Called every animation frame: LEDs and the track counter.
+function updateStatusLeds() {
+  if (!emu) return;
+  const sb = ensureStatusBar();
+  setLed(sb.pwr, emu.power_led());
+  setLed(sb.fdd, emu.fdd_led());
+  setLed(sb.hdd, emu.hdd_led());
+  setLed(sb.cd, emu.cd_led());
+  const track = emu.fdd_track();
+  if (track !== undefined) lastFddTrack = track;
+  const text =
+    lastFddTrack === null ? '---' : String(lastFddTrack).padStart(3, '0');
+  if (text !== sb.trackText) {
+    sb.trackText = text;
+    sb.track.textContent = text;
+  }
+}
+
+// Called at the 1 Hz stat refresh and right after insert/eject/boot, so a
+// disk change shows immediately.
+function updateStatusDisks() {
+  if (!emu) return;
+  const sb = ensureStatusBar();
+  const parts = [];
+  for (let drive = 0; drive < 4; drive++) {
+    if (!emu.drive_connected(drive)) continue;
+    parts.push(`DF${drive}: ${emu.disk_name(drive) ?? '-'}`);
+  }
+  const text = parts.join('  ');
+  if (text !== sb.disksText) {
+    sb.disksText = text;
+    sb.disks.textContent = text;
+    sb.disks.title = text;
+  }
+}
 
 // --- disk list ---------------------------------------------------------
 // Optional in the page shell: a <select id="df0list"> fills itself with

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -78,6 +78,11 @@ Controls:
   touch mode the canvas is a pad instead: a floating eight-way stick on
   the left half and a fire button on the right.
 
+Once a machine boots, a status strip appears below the screen with the
+same front-panel readouts as the desktop [status bar](ui.md): the PWR and
+FDD LEDs (plus HDD/CD on machines fitted with those drives), the floppy
+track counter, and the name of the disk in each connected drive.
+
 Audio starts with the boot click, but a browser autoplay policy can keep
 the AudioContext suspended anyway; the boot never waits for it. The
 emulator runs silent and the next click or key press unlocks the sound.
@@ -209,7 +214,15 @@ feeds from the desktop frontend's FS-UAE-compatible keyboard mapping
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
 exposes the guest clock for diagnostics. `set_floppy_sounds(on)` and
 `set_floppy_sounds_volume(p)` control the synthesized drive sounds (on and
-100 by default, like the desktop's `[audio] floppy_sounds` knobs). `serial_send(bytes)`,
+100 by default, like the desktop's `[audio] floppy_sounds` knobs).
+Front-panel status getters mirror the desktop status bar's LED block and
+are cheap enough to poll every frame: `power_led()` and `fdd_led()` return
+booleans, `hdd_led()` and `cd_led()` return `undefined` on machines
+without the drive (hide the LED), `fdd_track()` returns the cylinder under
+the selected drive's head or `undefined` when no drive is selected (latch
+the last value so a counter does not flicker), and `drive_connected(n)` /
+`disk_name(n)` describe DF0-DF3 -- a `disk_name` of `undefined` means the
+drive is empty. `serial_send(bytes)`,
 `serial_take()` and `serial_input_backlog()` bridge Paula's serial port to
 whatever byte stream the page likes (see
 [the serial bridge section](#browser-serial-bridge)). The presentation pointer is only
@@ -243,6 +256,10 @@ elements, and pages without them are untouched:
   manifest, a server directory listing of the folder (nginx `autoindex`,
   Apache, `python -m http.server`) is scraped for disk-image links
   instead. If the folder yields nothing, the select hides itself.
+- `#ledbar` (a container): hosts the front-panel status strip (LEDs,
+  track counter, disk names), letting the page own its placement and
+  outer styling. Without it the strip inserts itself directly below the
+  canvas shell. Either way it fills in once a machine boots.
 - `data-default="keys"` on the `#joy` toggle: the joystick mode the page
   starts in (`?joy=` in the URL overrides it).
 - `#serial-url`, `#serial-connect`, `#serial-status`, `#serial-raw`: the


### PR DESCRIPTION
## Summary

The browser build had no drive or power feedback. This adds a status strip below the canvas on the /try page with the same front-panel readouts as the desktop status bar:

- **PWR and FDD LEDs** (HDD/CD LEDs appear only on machines fitted with those drives), using the desktop bar's exact LED palette.
- **Three-digit floppy track counter**, latching the last track like the desktop bar so it does not flicker back to `---` between accesses.
- **Inserted disk name per connected drive** (`DF0: name.adf`), with ellipsis + hover tooltip for long names.

No controls -- the page already has insert/eject/volume -- and the strip only appears once a machine boots.

### How

- `WebEmu` gains flat scalar getters wrapping the core's existing `Bus::front_panel_status()` snapshot: `power_led()`, `fdd_led()`, `fdd_track()`, `hdd_led()`, `cd_led()`, `drive_connected(n)`, `disk_name(n)`. Option returns map to `undefined` in JS (no drive selected / hardware absent / drive empty).
- `try.js` builds the strip lazily like the fullscreen UI. LEDs and the track counter poll every animation frame with change guards (steady frames do no DOM writes); disk names refresh at the 1 Hz stat tick and immediately on insert, eject and boot.
- Optional page-shell hook: a `#ledbar` element hosts the strip and the page owns its layout; without one the strip inserts itself after the canvas shell, so the hosted page works with no markup change.
- Docs: new getters in the `WebEmu` embedding API section, `#ledbar` in the page-shell hooks list, and a mention in the hosted-page section of `docs/guide/browser.md`.

Also fixes a pre-existing rustfmt drift in the web crate and adds a `cargo fmt --check` step for it to the wasm CI job -- the crate is a standalone workspace, so the root Formatting step never reached it.

## Testing

- `cargo check --target wasm32-unknown-unknown --locked` and `cargo clippy` clean; `cargo fmt --check` now clean on the web crate.
- Rebuilt `pkg/` with wasm-bindgen 0.2.126 and confirmed the generated `.d.ts` signatures (`fdd_track(): number | undefined`, `disk_name(drive: number): string | undefined`, ...).
- Drove the unchanged production `try/index.html` locally in Chrome: booted AROS with a `?df0=` disk queued and watched PWR light red, the FDD LED go amber during the disk load and off after, the track counter step `---` -> `000` -> `001` and hold, the disk name appear at boot, and Eject clear it synchronously. HDD/CD rows stay hidden on the A500, no console errors, and the `#ledbar` host path renders into a page-provided element without creating the fallback strip.