### PR TITLE
Configurable floppy drive speed with turbo mode

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -436,8 +436,15 @@ floppy_sounds_volume = 100
 # ADF, and read-only SCP flux captures. DMS/gzip/SCP are always treated as
 # write-protected.
 #
+# Drive speed: 100 (real, the default), 200/400/800 (that many percent of
+# real speed; the whole data path stays bit-identical, just faster), or 0
+# for turbo (disk DMA transfers complete almost instantly). Mechanics
+# (motor spin-up, stepping) always run at real speed. Faster-than-real
+# loading is a compatibility trade-off; some software times its loading.
+#
 # [floppy]
 # drives = 2
+# speed = 100
 #
 # [floppy.df0]
 # path = "Workbench.adf"

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -570,6 +570,19 @@ impl WebEmu {
             .set_volume_percent(percent);
     }
 
+    /// Emulated floppy drive speed (the desktop's `[floppy] speed`): a
+    /// data-rate percentage of 100/200/400/800, or 0 for turbo, where disk
+    /// DMA transfers complete almost instantly. Other values fall back to
+    /// 100. Applies immediately; drive mechanics stay at real speed.
+    pub fn set_floppy_speed(&mut self, percent: u16) {
+        self.emu.bus_mut().floppy.set_speed_percent(percent);
+    }
+
+    /// Current floppy drive speed value (percentage, or 0 for turbo).
+    pub fn floppy_speed(&self) -> u16 {
+        self.emu.bus().floppy.speed_percent()
+    }
+
     pub fn emulated_seconds(&self) -> f64 {
         self.emu.bus().emulated_seconds()
     }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -316,6 +316,7 @@ async function boot() {
     pendingDisk = null;
     machine.set_volume_percent(Number($('vol').value));
     if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
+    if (floppySpeed !== null) machine.set_floppy_speed(floppySpeed);
     emu = machine;
     window.__emu = emu; // for debugging/automation
     lastFddTrack = null; // a new machine starts the track latch over
@@ -1066,6 +1067,24 @@ floppySoundsToggle?.addEventListener('change', () => {
   if (emu) emu.set_floppy_sounds(floppySoundsToggle.checked);
 });
 
+// Optional in the page shell: a <select id="floppy-speed"> with option
+// values 100/200/400/800 (percent) or 0 (turbo) sets the emulated floppy
+// drive speed. Applied at boot and live on change; a ?fdspeed= link
+// overrides the select's initial choice. Without the element (and without
+// ?fdspeed=) the drives run at real speed.
+const FLOPPY_SPEEDS = [100, 200, 400, 800, 0];
+const floppySpeedSel = $('floppy-speed');
+let floppySpeed = null; // null = leave the emulator at its default (100%)
+function setFloppySpeed(value) {
+  if (!FLOPPY_SPEEDS.includes(value)) return;
+  floppySpeed = value;
+  if (floppySpeedSel) floppySpeedSel.value = String(value);
+  if (emu) emu.set_floppy_speed(value);
+}
+floppySpeedSel?.addEventListener('change', () => {
+  setFloppySpeed(Number(floppySpeedSel.value));
+});
+
 // --- status bar --------------------------------------------------------
 // Front-panel status strip mirroring the desktop status bar's LED block:
 // PWR/FDD LEDs (HDD/CD only on machines fitted with the drive), the
@@ -1448,5 +1467,15 @@ const requestedJoy = (pageParams.get('joy') ?? $('joy').dataset.default ?? '').t
 if (requestedJoy && requestedJoy !== joyMode) {
   if (JOY_MODES.includes(requestedJoy)) setJoyMode(requestedJoy);
   else if (requestedJoy === 'touch') setJoyMode('keys');
+}
+
+// Starting floppy speed: the #floppy-speed select's initial value,
+// overridden per link by ?fdspeed=100|200|400|800|0|turbo. Applied to the
+// machine at boot.
+const requestedSpeed = (pageParams.get('fdspeed') ?? '').trim();
+if (requestedSpeed) {
+  setFloppySpeed(requestedSpeed === 'turbo' ? 0 : Number(requestedSpeed));
+} else if (floppySpeedSel) {
+  setFloppySpeed(Number(floppySpeedSel.value));
 }
 load();

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1067,21 +1067,46 @@ floppySoundsToggle?.addEventListener('change', () => {
   if (emu) emu.set_floppy_sounds(floppySoundsToggle.checked);
 });
 
-// Optional in the page shell: a <select id="floppy-speed"> with option
-// values 100/200/400/800 (percent) or 0 (turbo) sets the emulated floppy
-// drive speed. Applied at boot and live on change; a ?fdspeed= link
-// overrides the select's initial choice. Without the element (and without
-// ?fdspeed=) the drives run at real speed.
+// The floppy drive speed control, always visible: a page shell can host
+// its own <select id="floppy-speed"> (option values 100/200/400/800 for
+// percent, 0 for turbo) wherever its control bar wants it; without one
+// the control builds itself directly below the canvas shell with its own
+// styling, like the status strip. Applied at boot and live on change; a
+// ?fdspeed= link overrides the initial choice.
 const FLOPPY_SPEEDS = [100, 200, 400, 800, 0];
-const floppySpeedSel = $('floppy-speed');
+const FLOPPY_SPEED_LABELS = { 100: '100%', 200: '200%', 400: '400%', 800: '800%', 0: 'Turbo' };
+function buildFloppySpeedControl() {
+  const row = document.createElement('label');
+  row.style.cssText =
+    'display:inline-flex;align-items:center;gap:0.45rem;margin:0.4rem 0;' +
+    'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;' +
+    'color:rgba(255,255,255,0.75);';
+  row.appendChild(document.createTextNode('Floppy speed'));
+  const sel = document.createElement('select');
+  sel.style.cssText =
+    'padding:0.15rem 0.4rem;border-radius:6px;cursor:pointer;' +
+    'border:1px solid rgba(255,255,255,0.35);' +
+    'background:rgba(10,13,22,0.6);color:rgba(255,255,255,0.85);' +
+    'font:inherit;';
+  for (const value of FLOPPY_SPEEDS) {
+    const option = document.createElement('option');
+    option.value = String(value);
+    option.textContent = FLOPPY_SPEED_LABELS[value];
+    sel.appendChild(option);
+  }
+  row.appendChild(sel);
+  shell.insertAdjacentElement('afterend', row);
+  return sel;
+}
+const floppySpeedSel = $('floppy-speed') ?? buildFloppySpeedControl();
 let floppySpeed = null; // null = leave the emulator at its default (100%)
 function setFloppySpeed(value) {
   if (!FLOPPY_SPEEDS.includes(value)) return;
   floppySpeed = value;
-  if (floppySpeedSel) floppySpeedSel.value = String(value);
+  floppySpeedSel.value = String(value);
   if (emu) emu.set_floppy_speed(value);
 }
-floppySpeedSel?.addEventListener('change', () => {
+floppySpeedSel.addEventListener('change', () => {
   setFloppySpeed(Number(floppySpeedSel.value));
 });
 
@@ -1469,13 +1494,13 @@ if (requestedJoy && requestedJoy !== joyMode) {
   else if (requestedJoy === 'touch') setJoyMode('keys');
 }
 
-// Starting floppy speed: the #floppy-speed select's initial value,
-// overridden per link by ?fdspeed=100|200|400|800|0|turbo. Applied to the
-// machine at boot.
+// Starting floppy speed: the speed select's initial value, overridden
+// per link by ?fdspeed=100|200|400|800|0|turbo. Applied to the machine
+// at boot.
 const requestedSpeed = (pageParams.get('fdspeed') ?? '').trim();
 if (requestedSpeed) {
   setFloppySpeed(requestedSpeed === 'turbo' ? 0 : Number(requestedSpeed));
-} else if (floppySpeedSel) {
+} else {
   setFloppySpeed(Number(floppySpeedSel.value));
 }
 load();

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -252,11 +252,14 @@ elements, and pages without them are untouched:
   sounds -- motor hum, head-step clicks, read hiss -- live and at boot, so
   a shell can also default them off by shipping the box unchecked.
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
-  `800`, and `0` for turbo): sets the emulated floppy drive speed, live
-  and at boot, so a shell can default it by its initial selection.
+  `800`, and `0` for turbo): hosts the floppy drive speed control, letting
+  the page place and style it. Unlike the other hooks this one is always
+  on: without the element the page gets a self-inserted, labelled speed
+  select directly below the canvas shell (the status strip's pattern), so
+  the option is reachable on any shell. Changes apply live and at boot;
   `?fdspeed=` in the URL (`100`..`800`, `0`, or `turbo`) overrides the
-  initial choice, so a game link can ship fast loading without any page
-  element.
+  initial choice, so a game link can ship fast loading regardless of what
+  the control shows by default.
 - `#df0list` (a `<select>`): fills itself with the disk images the site
   serves next to the page and inserts the picked one into DF0 (queued
   when picked before boot, live after). The folder is the select's

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -215,6 +215,10 @@ and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
 exposes the guest clock for diagnostics. `set_floppy_sounds(on)` and
 `set_floppy_sounds_volume(p)` control the synthesized drive sounds (on and
 100 by default, like the desktop's `[audio] floppy_sounds` knobs).
+`set_floppy_speed(percent)` / `floppy_speed()` set and read the emulated
+drive speed -- 100/200/400/800 percent, or 0 for turbo -- like the
+desktop's `[floppy] speed` option (see
+[Configuration](configuration.md)); changes apply to the live machine.
 Front-panel status getters mirror the desktop status bar's LED block and
 are cheap enough to poll every frame: `power_led()` and `fdd_led()` return
 booleans, `hdd_led()` and `cd_led()` return `undefined` on machines
@@ -247,6 +251,12 @@ elements, and pages without them are untouched:
 - `#floppy-sounds` (checkbox): toggles the synthesized floppy drive
   sounds -- motor hum, head-step clicks, read hiss -- live and at boot, so
   a shell can also default them off by shipping the box unchecked.
+- `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
+  `800`, and `0` for turbo): sets the emulated floppy drive speed, live
+  and at boot, so a shell can default it by its initial selection.
+  `?fdspeed=` in the URL (`100`..`800`, `0`, or `turbo`) overrides the
+  initial choice, so a game link can ship fast loading without any page
+  element.
 - `#df0list` (a `<select>`): fills itself with the disk images the site
   serves next to the page and inserts the picked one into DF0 (queued
   when picked before boot, live after). The folder is the select's

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,6 +44,7 @@ range checks as the equivalent TOML fields:
 | `--fast SIZE` | `[memory] fast` | `0`, `1M`, `4M`, `8M`, ... |
 | `--slow SIZE` | `[memory] slow` | `0`, up to `512K` |
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
+| `--floppy-speed PERCENT` | `[floppy] speed` | `100` (real), `200`, `400`, `800`, or `0` (turbo) |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 | `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
 | `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
@@ -607,6 +608,7 @@ through a loopback device such as BlackHole needs none.
 ```toml
 [floppy]
 drives = 2                 # DF0 and DF1 connected; default is DF0 only
+speed = 100                # 100/200/400/800 percent, or 0 for turbo
 
 [floppy.df0]
 path = "demo.adf"            # single image, or:
@@ -620,6 +622,22 @@ the internal drive; DF1-DF3 are external drives that answer the standard
 Amiga external-drive ID protocol when connected. A configured disk image
 also connects that drive automatically, so existing configs that name
 `[floppy.df1]` .. `[floppy.df3]` keep working.
+
+`speed` accelerates the emulated drives beyond the authentic data rate.
+`100` (the default) is real speed. `200`, `400`, and `800` clock the whole
+data path -- platter rotation, the MFM read shifter, sync detection,
+DSKBYTR, and DMA pacing -- at that multiple, so everything software can
+observe stays bit-identical to real speed, only compressed in time. `0`
+selects turbo: a started disk DMA transfer completes almost instantly
+(deferred by two scanlines, matching other emulators' turbo modes, so
+loaders that clear stale interrupt flags right after starting a transfer
+still see the completion). Drive mechanics are never accelerated: motor
+spin-up, head stepping, and post-seek settle always run at real time.
+Faster-than-real speeds are a compatibility trade-off, exactly as in other
+emulators: the operating system and most loaders tolerate them, but
+software that times its own loading against the beam, CIA timers, or music
+playback can break. The setting can be changed live from the runtime menu
+("Floppy Speed") without restarting the machine.
 
 Supported image formats: standard 901120-byte DD ADF, gzip-compressed
 images (ADZ), single file ZIP archives, DMS archives, UAE extended ADF, and

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -151,6 +151,12 @@ tool window or overlay.
   The window and its backing texture resize with the mode. The start-up
   mode comes from `[display] pixel_aspect`
   (see [Configuration](configuration.md)).
+- **Floppy Speed**: cycles the emulated drive speed through 100% (real
+  speed), 200%, 400%, 800%, and turbo (disk DMA transfers complete almost
+  instantly). Changes apply to the live machine immediately. The start-up
+  value comes from `[floppy] speed`; see
+  [Configuration](configuration.md) for what each level preserves and the
+  compatibility trade-off.
 - **Fullscreen** (also `Cmd+F` / `Alt+F`): borderless fullscreen on the
   window's current monitor. The picture keeps its aspect and letterboxes
   as needed, exactly as when resizing the window; the same shortcut (or
@@ -223,7 +229,8 @@ The layout is:
 - **Category tabs** (left sidebar). *System* (chipset and Agnus/Denise
   overrides, video standard, RTC, identify board), *CPU* (model, FPU, clock,
   caches), *Memory* (chip/fast/slow/Zorro III RAM), *ROM* (Kickstart and
-  extended ROM), *Floppy* (drive count and per-drive image and write-protect),
+  extended ROM), *Floppy* (drive count and speed, per-drive image and
+  write-protect),
   *Hard Disk* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units, plus a **Host Mounts**
   link to a sub-page for host directories served live as AmigaDOS volumes: up

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3234,6 +3234,9 @@ impl Bus {
         std::mem::swap(&mut self.paula.audio, &mut live.paula.audio);
         std::mem::swap(&mut self.parallel_port, &mut live.parallel_port);
         self.blitter_trace = live.blitter_trace.take();
+        // Drive speed is host configuration, not machine state: a loaded
+        // state keeps the running session's setting.
+        self.floppy.set_speed_percent(live.floppy.speed_percent());
     }
 
     pub(crate) fn reset_transient_video_after_state_load(&mut self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -656,12 +656,19 @@ impl Default for AudioConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FloppyConfig {
     pub drives: [Option<FloppyDriveConfig>; 4],
+    /// Emulated drive speed as a data-rate percentage: 100 (real speed),
+    /// 200/400/800 (that many times faster), or 0 for turbo, where DMA
+    /// transfers complete almost instantly. Values above 100 keep the full
+    /// bit-level pipeline, only compressed in time; drive mechanics (motor
+    /// spin-up, stepping) always run at real speed.
+    pub speed: u16,
 }
 
 impl Default for FloppyConfig {
     fn default() -> Self {
         Self {
             drives: std::array::from_fn(|_| None),
+            speed: 100,
         }
     }
 }
@@ -1235,6 +1242,9 @@ pub struct ConfigOverrides {
     pub fast: Option<String>,
     pub slow: Option<String>,
     pub floppy_drives: Option<u8>,
+    /// Drive speed override (`--floppy-speed`): a percentage (100/200/400/
+    /// 800) or 0 for turbo. Same values as `[floppy] speed`.
+    pub floppy_speed: Option<u16>,
     /// Initial joystick input mode (`--joystick`): "gamepad" or "keyboard"
     /// ("auto" still accepted as a compatibility alias). Validated by the same
     /// parser as `[input] joystick`.
@@ -1294,6 +1304,7 @@ impl ConfigOverrides {
             && self.fast.is_none()
             && self.slow.is_none()
             && self.floppy_drives.is_none()
+            && self.floppy_speed.is_none()
             && self.joystick.is_none()
             && self.port1.is_none()
             && self.port2.is_none()
@@ -1341,6 +1352,9 @@ impl ConfigOverrides {
         }
         if let Some(drives) = self.floppy_drives {
             raw.floppy.drives = Some(drives);
+        }
+        if let Some(speed) = self.floppy_speed {
+            raw.floppy.speed = Some(speed);
         }
         if let Some(joystick) = &self.joystick {
             raw.input.joystick = Some(joystick.clone());
@@ -1925,6 +1939,9 @@ pub(crate) struct RawFloppy {
     /// so the valid range is 1-4.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) drives: Option<u8>,
+    /// Drive speed percentage (100/200/400/800) or 0 for turbo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) speed: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) df0: Option<RawFloppyDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3059,6 +3076,16 @@ fn parse_floppy(raw: RawFloppy) -> Result<(FloppyConfig, [bool; 4], [Vec<PathBuf
         Some(n @ 1..=4) => Some(usize::from(n)),
         Some(n) => bail!("[floppy] drives must be between 1 and 4, got {n}"),
     };
+    let speed = match raw.speed {
+        None => 100,
+        Some(s)
+            if s == crate::floppy::SPEED_TURBO
+                || crate::floppy::SUPPORTED_SPEED_PERCENTS.contains(&s) =>
+        {
+            s
+        }
+        Some(s) => bail!("[floppy] speed must be 100, 200, 400, 800, or 0 (turbo), got {s}"),
+    };
     let raws = [raw.df0, raw.df1, raw.df2, raw.df3];
     let mut drives: [Option<FloppyDriveConfig>; 4] = std::array::from_fn(|_| None);
     let mut connected = match connected_count {
@@ -3115,7 +3142,7 @@ fn parse_floppy(raw: RawFloppy) -> Result<(FloppyConfig, [bool; 4], [Vec<PathBuf
         });
         playlists[idx] = images;
     }
-    Ok((FloppyConfig { drives }, connected, playlists))
+    Ok((FloppyConfig { drives, speed }, connected, playlists))
 }
 
 fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
@@ -4854,6 +4881,37 @@ mod tests {
         )?;
         assert_eq!(cfg.floppy_connected, [true, true, true, false]);
         assert!(cfg.floppy.drives.iter().all(Option::is_none));
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_speed_defaults_and_parses_supported_values() -> Result<()> {
+        assert_eq!(parse_config("")?.floppy.speed, 100);
+        for speed in [100u16, 200, 400, 800, 0] {
+            let cfg = parse_config(&format!("[floppy]\nspeed = {speed}\n"))?;
+            assert_eq!(cfg.floppy.speed, speed);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_speed_rejects_unsupported_values() {
+        for speed in [50, 150, 300, 1600] {
+            let err = parse_config(&format!("[floppy]\nspeed = {speed}\n")).unwrap_err();
+            assert!(
+                err.to_string().contains("[floppy] speed"),
+                "unexpected error for speed {speed}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn floppy_speed_cli_override_reaches_config() -> Result<()> {
+        let cfg = load_overrides(&ConfigOverrides {
+            floppy_speed: Some(0),
+            ..Default::default()
+        })?;
+        assert_eq!(cfg.floppy.speed, 0);
         Ok(())
     }
 

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -348,6 +348,17 @@ impl FloppyController {
             } else {
                 default_speed_percent()
             };
+        // Entering turbo starts a fresh grace window and burst attempt, so a
+        // live toggle with a DMA already in flight defers its burst exactly
+        // like a freshly armed transfer would, instead of completing on the
+        // very next tick (or staying blocked by a spent attempt from an
+        // earlier turbo phase).
+        if self.turbo() {
+            self.turbo_grace_cck = TURBO_DMA_GRACE_CCK;
+            self.turbo_burst_spent = false;
+        } else {
+            self.turbo_grace_cck = 0;
+        }
     }
 
     pub fn speed_percent(&self) -> u16 {
@@ -1117,20 +1128,32 @@ impl FloppyController {
         std::mem::take(&mut self.sync_irq_latch)
     }
 
-    /// Scale a raw event-horizon prediction to the configured drive speed:
-    /// the events land a whole multiple sooner at >100%, and a turbo burst
-    /// completes them within the grace window. Predictions only cap the idle
-    /// fast-forward, so an under-estimate is always safe.
-    fn scale_prediction(&self, cck: u32) -> u32 {
+    /// Scale a raw event-horizon prediction for `drive_idx` to the
+    /// configured drive speed: at percentage speeds the events land a whole
+    /// multiple sooner, and a turbo burst completes them within the grace
+    /// window. Predictions only cap the idle fast-forward, so an
+    /// under-estimate is always safe -- but a 1-cck prediction the burst
+    /// cannot actually honour (drive spinning up, head settling, attempt
+    /// already spent) would pin STOP-state fast-forward to single steps for
+    /// the whole spin-up, so those cases keep the normal-paced deadline.
+    fn scale_prediction(&self, drive_idx: usize, cck: u32) -> u32 {
         if self.turbo() {
-            return cck.min(self.turbo_grace_cck).max(1);
+            if self.turbo_grace_cck > 0 {
+                return cck.min(self.turbo_grace_cck).max(1);
+            }
+            let drive = &self.drives[drive_idx];
+            if !self.turbo_burst_spent && drive.ready() && drive.seek_settle_cck == 0 {
+                return 1;
+            }
+            return cck.max(1);
         }
         (cck / self.speed_multiplier()).max(1)
     }
 
     pub fn next_completion_cck(&self, dmacon: u16) -> Option<u32> {
+        let drive_idx = self.dma.as_ref()?.drive;
         self.next_completion_cck_raw(dmacon)
-            .map(|cck| self.scale_prediction(cck))
+            .map(|cck| self.scale_prediction(drive_idx, cck))
     }
 
     fn next_completion_cck_raw(&self, dmacon: u16) -> Option<u32> {
@@ -1170,7 +1193,7 @@ impl FloppyController {
         let rev = drive.cur_rev()?;
         let bits = rev.bits_until_sync(drive.rotation_bit, self.dsksync)?;
         let raw = (drive.head_cck_for_bits(bits).min(u64::from(u32::MAX)) as u32).max(1);
-        Some(self.scale_prediction(raw))
+        Some(self.scale_prediction(dma.drive, raw))
     }
 
     pub fn next_index_pulse_cck(&self) -> Option<u32> {
@@ -5391,6 +5414,71 @@ mod tests {
         assert!(ctrl.dma.is_some());
         assert!(ctrl.turbo_burst_spent);
         assert_eq!(read_chip_word(&chip_ram, 0), 0);
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_live_turbo_toggle_mid_dma_honors_grace() -> Result<()> {
+        // Flipping the menu to turbo while a transfer is in flight must
+        // defer the burst by the same two-scanline grace as a fresh arming,
+        // not complete on the very next tick.
+        let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+        let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        let (mut ctrl, path) = spun_up_speed_controller(&raw_words, 100)?;
+        let mut chip_ram = vec![0u8; 8];
+        let len = DSKLEN_DMAEN | 3;
+        assert!(!ctrl.write_dsklen(len, 0));
+        assert!(!ctrl.write_dsklen(len, 0));
+        // One word into the transfer, switch to turbo live.
+        assert!(!ctrl.tick(word_cck, dmacon, &mut chip_ram));
+        ctrl.set_speed_percent(SPEED_TURBO);
+        // A stale spent flag must not survive the toggle either.
+        assert!(!ctrl.turbo_burst_spent);
+        assert!(!ctrl.tick(TURBO_DMA_GRACE_CCK - 10, dmacon, &mut chip_ram));
+        assert!(ctrl.tick(10, dmacon, &mut chip_ram));
+        assert_eq!(read_chip_word(&chip_ram, 4), 0x3333);
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_turbo_prediction_paces_normally_while_drive_not_ready() -> Result<()> {
+        // With the grace elapsed but the drive still spinning up, the burst
+        // cannot run; the completion prediction must fall back to the
+        // normal-paced deadline instead of forcing 1-cck idle stepping for
+        // the rest of the spin-up.
+        let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+        let path = temp_ext2_raw(&raw_words)?;
+        let cfg = FloppyConfig {
+            speed: SPEED_TURBO,
+            drives: [
+                Some(FloppyDriveConfig {
+                    path: path.clone(),
+                    write_protected: true,
+                }),
+                None,
+                None,
+                None,
+            ],
+        };
+        let mut ctrl = FloppyController::from_config(&cfg)?;
+        let mut chip_ram = vec![0u8; 8];
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+        ctrl.set_dskpt_low(0);
+        let len = DSKLEN_DMAEN | 1;
+        assert!(!ctrl.write_dsklen(len, 0));
+        assert!(!ctrl.write_dsklen(len, 0));
+        // Inside the grace the prediction is bounded by it.
+        assert!(ctrl.next_completion_cck(dmacon).unwrap() <= TURBO_DMA_GRACE_CCK);
+        // Grace elapsed, motor still spinning up: normal-paced deadline.
+        assert!(!ctrl.tick(TURBO_DMA_GRACE_CCK, dmacon, &mut chip_ram));
+        assert!(ctrl.next_completion_cck(dmacon).unwrap() > TURBO_DMA_GRACE_CCK);
+        // Once ready the burst is imminent again.
+        ctrl.tick(MOTOR_READY_CCK, 0, &mut chip_ram);
+        assert_eq!(ctrl.next_completion_cck(dmacon), Some(1));
         let _ = fs::remove_file(path);
         Ok(())
     }

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -85,6 +85,34 @@ const MIN_STEP_PULSE_CCK: u64 = 140;
 const SEEK_REVERSAL_SETTLE_CCK: u32 = PAULA_CLOCK_HZ / 1_000 * 18; // ~18 ms on reversal
                                                                    // 300 RPM.
 const ROTATION_HZ: u32 = 5;
+// Turbo mode defers the burst completion of a freshly armed DMA by two
+// scanlines of emulated time (the same deferral WinUAE/FS-UAE apply to
+// their instant path): loaders commonly write DSKLEN and only then clear
+// stale INTREQ bits before enabling the DSKBLK interrupt, and a completion
+// raised in the very next colour clock would be eaten by that clear.
+const TURBO_DMA_GRACE_CCK: u32 = 454;
+
+/// Drive data-rate percentages the `[floppy] speed` option accepts, besides
+/// 0 (turbo). Whole multiples of real speed keep the cck -> bitcell scaling
+/// exact, so the entire read/write pipeline (shifter, sync, DSKBYTR, index)
+/// stays bit-identical to real speed, only compressed in time.
+pub const SUPPORTED_SPEED_PERCENTS: [u16; 4] = [100, 200, 400, 800];
+/// `[floppy] speed` value selecting turbo mode.
+pub const SPEED_TURBO: u16 = 0;
+
+fn default_speed_percent() -> u16 {
+    100
+}
+
+/// Human-readable label for a `[floppy] speed` value: "100%".."800%", or
+/// "turbo" for `SPEED_TURBO`. Shared by the menu, launcher, and OSD.
+pub fn speed_label(percent: u16) -> String {
+    if percent == SPEED_TURBO {
+        "turbo".to_string()
+    } else {
+        format!("{percent}%")
+    }
+}
 // 11 AmigaDOS sectors occupy 5984 MFM words. PAL Amiga floppy read timing is
 // slightly faster than nominal 250 kbit/s, so a normal 300 RPM revolution is
 // about 12668 raw bytes (6334 16-bit MFM words). Keeping generated ADF streams
@@ -182,6 +210,26 @@ pub struct FloppyController {
     dma: Option<DiskDma>,
     direct_write: Option<DiskDirectWrite>,
     dma_addr_mask: u32,
+    /// Emulated drive speed: a data-rate percentage from
+    /// `SUPPORTED_SPEED_PERCENTS`, or `SPEED_TURBO` (0) for turbo, where DMA
+    /// transfers complete almost instantly. Host configuration rather than
+    /// machine state: never serialized, carried across save-state loads by
+    /// `Bus::adopt_host_resources`.
+    #[serde(skip, default = "default_speed_percent")]
+    speed_percent: u16,
+    /// Turbo: emulated cck left before a freshly armed DMA may burst to
+    /// completion (see `TURBO_DMA_GRACE_CCK`). Transient pacing state for a
+    /// host speed hack, so not serialized; a state restored mid-grace just
+    /// bursts on the next tick.
+    #[serde(skip)]
+    turbo_grace_cck: u32,
+    /// Turbo: the pending DMA already had its burst attempt. A transfer the
+    /// burst cannot finish (a sync word missing from the track, a fuzzy
+    /// multi-revolution image moving the sync) falls back to normal pacing
+    /// instead of rescanning the track on every tick; the next DSKLEN
+    /// arming tries again, like FS-UAE's per-DSKLEN turbo scan.
+    #[serde(skip)]
+    turbo_burst_spent: bool,
     // Head-step pulses since the last take_sound_steps() drain; feeds
     // the synthesized drive sound effects.
     sound_steps: u32,
@@ -232,6 +280,9 @@ impl Default for FloppyController {
             dma: None,
             direct_write: None,
             dma_addr_mask: 0x001F_FFFF,
+            speed_percent: default_speed_percent(),
+            turbo_grace_cck: 0,
+            turbo_burst_spent: false,
             sound_steps: 0,
             read_shifter: PaulaDiskReadDpllFifo::new(),
             // Idle at power-on; the first tick confirms it.
@@ -253,6 +304,7 @@ impl FloppyController {
 
     pub fn from_config(config: &FloppyConfig) -> Result<Self> {
         let mut ctrl = Self { ..Self::default() };
+        ctrl.set_speed_percent(config.speed);
         for (idx, drive_cfg) in config.drives.iter().enumerate() {
             if let Some(drive_cfg) = drive_cfg {
                 ctrl.drives[idx] = FloppyDrive::load(drive_cfg)
@@ -283,6 +335,36 @@ impl FloppyController {
     pub fn set_dma_addr_mask(&mut self, mask: u32) {
         self.dma_addr_mask = mask | 1;
         self.dskpt &= self.dma_ptr_mask();
+    }
+
+    /// Set the emulated drive speed: a percentage from
+    /// `SUPPORTED_SPEED_PERCENTS` or `SPEED_TURBO` (0). Unsupported values
+    /// fall back to real speed. Takes effect immediately; drive mechanics
+    /// (motor spin-up, stepping, settle) are never accelerated.
+    pub fn set_speed_percent(&mut self, percent: u16) {
+        self.speed_percent =
+            if percent == SPEED_TURBO || SUPPORTED_SPEED_PERCENTS.contains(&percent) {
+                percent
+            } else {
+                default_speed_percent()
+            };
+    }
+
+    pub fn speed_percent(&self) -> u16 {
+        self.speed_percent
+    }
+
+    /// Whole multiple of real speed the data path runs at. Turbo paces the
+    /// platter at real speed between bursts, so it maps to 1 here.
+    fn speed_multiplier(&self) -> u32 {
+        match self.speed_percent {
+            0..=100 => 1,
+            p => u32::from(p / 100),
+        }
+    }
+
+    fn turbo(&self) -> bool {
+        self.speed_percent == SPEED_TURBO
     }
 
     pub fn cia_a_status_bits(&self) -> u8 {
@@ -758,12 +840,91 @@ impl FloppyController {
         };
         let is_selected = selected_drive == Some(idx);
 
-        match active_dma {
+        // Speed >100% overclocks the data path: the platter (and with it the
+        // shifter, sync detection, DSKBYTR, and DMA pacing) sees a whole
+        // multiple of the elapsed time, leaving every per-cell decision
+        // bit-identical to real speed. Mechanics (motor, seek, settle, index
+        // pulse width) above tick at real time regardless.
+        let data_cck = cck.saturating_mul(self.speed_multiplier());
+        let mut irq = match active_dma {
             Some((dma_idx, _, true)) if dma_idx == idx => {
-                self.tick_write_dma(idx, cck, is_selected, chip_ram)
+                self.tick_write_dma(idx, data_cck, is_selected, chip_ram)
             }
-            _ => self.tick_read_and_rotate(idx, cck, dmacon, is_selected, chip_ram),
+            _ => self.tick_read_and_rotate(idx, data_cck, dmacon, is_selected, chip_ram),
+        };
+        if self.turbo() {
+            irq |= self.turbo_burst(cck, dmacon, chip_ram);
         }
+        irq
+    }
+
+    /// Turbo: spin the platter forward far enough, in zero emulated time, to
+    /// complete the pending DMA through the ordinary bit engine -- first to
+    /// the next DSKSYNC match when the read is sync-waiting, then to the
+    /// transfer's end. Everything (shifter framing, sync realign, the write
+    /// path, DSKBLK) behaves exactly as if the time had really passed; only
+    /// the machine's clock does not advance. Mirrors FS-UAE's turbo, which
+    /// completes the transfer inside the DSKLEN write: here the deferred
+    /// `TURBO_DMA_GRACE_CCK` window stands in for its two-scanline delay.
+    /// A sync word that never matches leaves the DMA to normal pacing, like
+    /// FS-UAE falling back to its bit engine.
+    fn turbo_burst(&mut self, cck: u32, dmacon: u16, chip_ram: &mut [u8]) -> bool {
+        if self.turbo_grace_cck > 0 {
+            self.turbo_grace_cck = self.turbo_grace_cck.saturating_sub(cck);
+            if self.turbo_grace_cck > 0 {
+                return false;
+            }
+        }
+        if self.turbo_burst_spent {
+            return false;
+        }
+        let Some(dma) = self.dma.as_ref() else {
+            return false;
+        };
+        if !self.dma_enabled(dmacon) {
+            return false;
+        }
+        let (idx, write) = (dma.drive, dma.write);
+        // Mechanics stay honest: a drive that is still spinning up or whose
+        // head is settling after a step delivers no stable cells, so the
+        // burst waits for it like real-time pacing would.
+        if !self.drives[idx].ready() || self.drives[idx].seek_settle_cck > 0 {
+            return false;
+        }
+        let is_selected = self.selected_drive() == Some(idx);
+        let mut irq = false;
+        // Two phases at most (reach sync, then drain the transfer), plus one
+        // spare for per-word framing rounding.
+        for _ in 0..3 {
+            let Some(dma) = self.dma.as_ref() else { break };
+            // Slack above the exact prediction absorbs sub-word framing
+            // phase; the engine idles through any excess.
+            let burst = if dma.wait_sync {
+                let drive = &self.drives[idx];
+                let Some(rev) = drive.cur_rev() else { break };
+                let Some(bits) = rev.bits_until_sync(drive.rotation_bit, self.dsksync) else {
+                    break;
+                };
+                drive.head_cck_for_bits(bits.max(1)) + 32
+            } else if let Some(pred) = self.next_completion_cck_raw(dmacon) {
+                u64::from(pred) + 32
+            } else {
+                break;
+            };
+            let burst = burst.min(u64::from(u32::MAX)) as u32;
+            irq |= if write {
+                self.tick_write_dma(idx, burst, is_selected, chip_ram)
+            } else {
+                self.tick_read_and_rotate(idx, burst, dmacon, is_selected, chip_ram)
+            };
+            if irq {
+                break;
+            }
+        }
+        // A transfer still pending got its one attempt; leave it to normal
+        // pacing until the next DSKLEN arming.
+        self.turbo_burst_spent = self.dma.is_some();
+        irq
     }
 
     /// Advance the reading drive's head one MFM cell at a time at the recovered
@@ -956,7 +1117,23 @@ impl FloppyController {
         std::mem::take(&mut self.sync_irq_latch)
     }
 
+    /// Scale a raw event-horizon prediction to the configured drive speed:
+    /// the events land a whole multiple sooner at >100%, and a turbo burst
+    /// completes them within the grace window. Predictions only cap the idle
+    /// fast-forward, so an under-estimate is always safe.
+    fn scale_prediction(&self, cck: u32) -> u32 {
+        if self.turbo() {
+            return cck.min(self.turbo_grace_cck).max(1);
+        }
+        (cck / self.speed_multiplier()).max(1)
+    }
+
     pub fn next_completion_cck(&self, dmacon: u16) -> Option<u32> {
+        self.next_completion_cck_raw(dmacon)
+            .map(|cck| self.scale_prediction(cck))
+    }
+
+    fn next_completion_cck_raw(&self, dmacon: u16) -> Option<u32> {
         let dma = self.dma.as_ref()?;
         if !self.dma_enabled(dmacon) || dma.wait_sync {
             return None;
@@ -992,7 +1169,8 @@ impl FloppyController {
         }
         let rev = drive.cur_rev()?;
         let bits = rev.bits_until_sync(drive.rotation_bit, self.dsksync)?;
-        Some((drive.head_cck_for_bits(bits).min(u64::from(u32::MAX)) as u32).max(1))
+        let raw = (drive.head_cck_for_bits(bits).min(u64::from(u32::MAX)) as u32).max(1);
+        Some(self.scale_prediction(raw))
     }
 
     pub fn next_index_pulse_cck(&self) -> Option<u32> {
@@ -1010,12 +1188,14 @@ impl FloppyController {
             return None;
         }
         let bits_to_end = rev.bit_len - (drive.rotation_bit % rev.bit_len);
-        Some(
-            (drive
-                .head_cck_for_bits(bits_to_end)
-                .min(u64::from(u32::MAX)) as u32)
-                .max(1),
-        )
+        let raw = (drive
+            .head_cck_for_bits(bits_to_end)
+            .min(u64::from(u32::MAX)) as u32)
+            .max(1);
+        // The platter spins at the data-rate multiple; turbo bursts do not
+        // move the index prediction (they are bounded by the completion
+        // prediction above, which already caps the fast-forward).
+        Some((raw / self.speed_multiplier()).max(1))
     }
 
     pub fn dma_active(&self, dmacon: u16) -> bool {
@@ -1109,6 +1289,10 @@ impl FloppyController {
             write_start_word,
             write_start_bit,
         });
+        if self.turbo() {
+            self.turbo_grace_cck = TURBO_DMA_GRACE_CCK;
+            self.turbo_burst_spent = false;
+        }
         debug!(
             "floppy DMA start df{} track={} write={} words={} sync_wait={} msb_sync={}",
             idx, track, write, remaining, word_sync, msb_sync
@@ -3764,6 +3948,7 @@ mod tests {
         }
         let path = temp_adz(&adf)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -3794,6 +3979,7 @@ mod tests {
         let ext_image = fs::read(&ext_path)?;
         let path = temp_gzip("test.ext.adf.gz", &ext_image)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -3831,6 +4017,7 @@ mod tests {
         image.extend_from_slice(&0u32.to_be_bytes());
         fs::write(&path, image)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -3859,6 +4046,7 @@ mod tests {
         let first = temp_adf()?;
         let second = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: first.clone(),
@@ -3898,6 +4086,7 @@ mod tests {
         let first = temp_adf()?;
         let second = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: first.clone(),
@@ -3990,6 +4179,7 @@ mod tests {
         let protected = temp_adf()?;
         let writable = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: protected.clone(),
@@ -4023,6 +4213,7 @@ mod tests {
     fn cia_status_reflects_write_protect_track0_and_ready() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4048,6 +4239,7 @@ mod tests {
     fn cia_status_ready_line_tracks_motor_spinup_and_off() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4113,6 +4305,7 @@ mod tests {
     fn side_select_maps_lower_head_to_even_adf_tracks() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4299,6 +4492,7 @@ mod tests {
     fn track_zero_line_follows_head_position() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4551,6 +4745,7 @@ mod tests {
     fn dskbytr_byte_valid_tracks_new_rotation_words() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4590,6 +4785,7 @@ mod tests {
         let raw_words = [0x1234, 0xABCD];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4792,6 +4988,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4833,6 +5030,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4865,6 +5063,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4904,6 +5103,7 @@ mod tests {
         let raw_words = [0x1234, DEFAULT_DSKSYNC];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4952,6 +5152,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -4985,6 +5186,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5016,6 +5218,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5052,11 +5255,219 @@ mod tests {
         Ok(())
     }
 
+    /// Controller with one raw ext-ADF track in DF0 at the given `[floppy]
+    /// speed`, spun up with the head pinned to word 0, ready to arm a DMA.
+    fn spun_up_speed_controller(
+        raw_words: &[u16],
+        speed: u16,
+    ) -> Result<(FloppyController, PathBuf)> {
+        let path = temp_ext2_raw(raw_words)?;
+        let cfg = FloppyConfig {
+            speed,
+            drives: [
+                Some(FloppyDriveConfig {
+                    path: path.clone(),
+                    write_protected: true,
+                }),
+                None,
+                None,
+                None,
+            ],
+        };
+        let mut ctrl = FloppyController::from_config(&cfg)?;
+        ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+        ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
+        ctrl.ensure_track(0, 0);
+        ctrl.drives[0].set_rotation_word(0);
+        ctrl.drives[0].rotation_acc_cck = 0;
+        ctrl.set_dskpt_low(0);
+        Ok((ctrl, path))
+    }
+
+    #[test]
+    fn floppy_speed_800_compresses_read_dma_eightfold_with_identical_data() -> Result<()> {
+        let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+        let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        let mut data = [[0u16; 3]; 2];
+        for (run, speed) in [100u16, 800].into_iter().enumerate() {
+            let (mut ctrl, path) = spun_up_speed_controller(&raw_words, speed)?;
+            let mut chip_ram = vec![0u8; 8];
+            let len = DSKLEN_DMAEN | 3;
+            assert!(!ctrl.write_dsklen(len, 0));
+            assert!(!ctrl.write_dsklen(len, 0));
+            // The whole data path is scaled, so the transfer lands the
+            // multiple sooner to the exact cck, and the completion
+            // prediction reports the scaled deadline.
+            let scaled = 3 * word_cck / u32::from(speed / 100);
+            assert_eq!(ctrl.next_completion_cck(dmacon), Some(scaled));
+            assert!(!ctrl.tick(scaled - 1, dmacon, &mut chip_ram));
+            assert!(ctrl.tick(1, dmacon, &mut chip_ram));
+            data[run] = [
+                read_chip_word(&chip_ram, 0),
+                read_chip_word(&chip_ram, 2),
+                read_chip_word(&chip_ram, 4),
+            ];
+            let _ = fs::remove_file(path);
+        }
+        // Faster, but bit-identical: both speeds deliver the same words.
+        assert_eq!(data[0], data[1]);
+        assert_eq!(data[0], [0x1111, 0x2222, 0x3333]);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_turbo_bursts_read_dma_after_two_line_grace() -> Result<()> {
+        // ~177000 cck per word on this track: real pacing moves well under
+        // one word inside the grace window, so a completion there can only
+        // come from the burst.
+        let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        let (mut ctrl, path) = spun_up_speed_controller(&raw_words, SPEED_TURBO)?;
+        let mut chip_ram = vec![0u8; 8];
+        let len = DSKLEN_DMAEN | 3;
+        assert!(!ctrl.write_dsklen(len, 0));
+        assert!(!ctrl.write_dsklen(len, 0));
+        // Inside the deferral window the transfer paces normally...
+        assert!(!ctrl.tick(TURBO_DMA_GRACE_CCK - 10, dmacon, &mut chip_ram));
+        // ...and the tick that crosses it bursts the transfer to the end.
+        assert!(ctrl.tick(10, dmacon, &mut chip_ram));
+        assert_eq!(read_chip_word(&chip_ram, 0), 0x1111);
+        assert_eq!(read_chip_word(&chip_ram, 2), 0x2222);
+        assert_eq!(read_chip_word(&chip_ram, 4), 0x3333);
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_turbo_sync_wait_matches_real_speed_data() -> Result<()> {
+        // A sync-waiting read: the burst must first spin to the DSKSYNC
+        // match, then drain the transfer, delivering exactly the words a
+        // real-speed run recovers.
+        let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222, 0x3333];
+        let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        let mut data = [[0u16; 2]; 2];
+        for (run, speed) in [100u16, SPEED_TURBO].into_iter().enumerate() {
+            let (mut ctrl, path) = spun_up_speed_controller(&raw_words, speed)?;
+            let mut chip_ram = vec![0u8; 8];
+            ctrl.write_dsksync(DEFAULT_DSKSYNC);
+            let len = DSKLEN_DMAEN | 2;
+            assert!(!ctrl.write_dsklen(len, ADK_WORDSYNC));
+            assert!(!ctrl.write_dsklen(len, ADK_WORDSYNC));
+            let mut done = false;
+            for _ in 0..8 {
+                if ctrl.tick(word_cck, dmacon, &mut chip_ram) {
+                    done = true;
+                    break;
+                }
+            }
+            assert!(done, "sync-wait DMA should complete at speed {speed}");
+            assert!(ctrl.take_sync_irq());
+            data[run] = [read_chip_word(&chip_ram, 0), read_chip_word(&chip_ram, 2)];
+            let _ = fs::remove_file(path);
+        }
+        assert_eq!(data[0], data[1]);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_turbo_missing_sync_leaves_dma_to_normal_pacing() -> Result<()> {
+        // No DSKSYNC word anywhere on the track: the burst gets one look,
+        // gives up, and the armed transfer keeps waiting at normal pace
+        // (forever, like real hardware) instead of rescanning every tick.
+        let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+        let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        let (mut ctrl, path) = spun_up_speed_controller(&raw_words, SPEED_TURBO)?;
+        let mut chip_ram = vec![0u8; 8];
+        ctrl.write_dsksync(DEFAULT_DSKSYNC);
+        let len = DSKLEN_DMAEN | 2;
+        assert!(!ctrl.write_dsklen(len, ADK_WORDSYNC));
+        assert!(!ctrl.write_dsklen(len, ADK_WORDSYNC));
+        for _ in 0..8 {
+            assert!(!ctrl.tick(word_cck, dmacon, &mut chip_ram));
+        }
+        assert!(ctrl.dma.is_some());
+        assert!(ctrl.turbo_burst_spent);
+        assert_eq!(read_chip_word(&chip_ram, 0), 0);
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_turbo_burst_waits_for_motor_spinup() -> Result<()> {
+        let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+        let path = temp_ext2_raw(&raw_words)?;
+        let cfg = FloppyConfig {
+            speed: SPEED_TURBO,
+            drives: [
+                Some(FloppyDriveConfig {
+                    path: path.clone(),
+                    write_protected: true,
+                }),
+                None,
+                None,
+                None,
+            ],
+        };
+        let mut ctrl = FloppyController::from_config(&cfg)?;
+        let mut chip_ram = vec![0u8; 8];
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        // Motor just latched on: the DMA arms (spin-up arming is modelled),
+        // but turbo must not deliver data before the mechanism is ready.
+        ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+        ctrl.set_dskpt_low(0);
+        let len = DSKLEN_DMAEN | 1;
+        assert!(!ctrl.write_dsklen(len, 0));
+        assert!(!ctrl.write_dsklen(len, 0));
+        assert!(!ctrl.tick(TURBO_DMA_GRACE_CCK, dmacon, &mut chip_ram));
+        assert!(ctrl.dma.is_some());
+        // Spin-up completes within this tick; the burst follows in the
+        // same tick and finishes the transfer.
+        assert!(ctrl.tick(MOTOR_READY_CCK, dmacon, &mut chip_ram));
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_speed_never_accelerates_motor_spinup() -> Result<()> {
+        for speed in [800u16, SPEED_TURBO] {
+            let raw_words = [0x1234, 0x5678];
+            let path = temp_ext2_raw(&raw_words)?;
+            let cfg = FloppyConfig {
+                speed,
+                drives: [
+                    Some(FloppyDriveConfig {
+                        path: path.clone(),
+                        write_protected: true,
+                    }),
+                    None,
+                    None,
+                    None,
+                ],
+            };
+            let mut ctrl = FloppyController::from_config(&cfg)?;
+            ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+            ctrl.tick(MOTOR_READY_CCK - 1, 0, &mut []);
+            assert_ne!(
+                ctrl.cia_a_status_bits() & CIAA_DSKRDY,
+                0,
+                "speed {speed} must not shorten spin-up"
+            );
+            ctrl.tick(1, 0, &mut []);
+            assert_eq!(ctrl.cia_a_status_bits() & CIAA_DSKRDY, 0);
+            let _ = fs::remove_file(path);
+        }
+        Ok(())
+    }
+
     #[test]
     fn motor_off_blocks_read_dma_until_next_spinup() -> Result<()> {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5108,6 +5519,7 @@ mod tests {
     fn dsksync_write_latches_current_word_match() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5136,6 +5548,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5166,6 +5579,7 @@ mod tests {
     fn read_dma_sync_irq_does_not_require_wordsync() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5207,6 +5621,7 @@ mod tests {
     fn wordsync_skips_initial_sync_then_transfers_repeated_sync_word() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5257,6 +5672,7 @@ mod tests {
         let raw_words = [0xAA44u16, 0x8955, 0x1234, 0x5678, 0x0000];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5302,6 +5718,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5351,6 +5768,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5396,6 +5814,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5441,6 +5860,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5481,6 +5901,7 @@ mod tests {
         let track2 = [0xAAAA, 0xBBBB];
         let path = temp_ext2_raw_tracks(&[(0, &track0), (2, &track2)])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5533,6 +5954,7 @@ mod tests {
         let track0 = [0x1111u16, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw_tracks(&[(0, &track0)])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5584,6 +6006,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5626,6 +6049,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5663,6 +6087,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5707,6 +6132,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5749,6 +6175,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5788,6 +6215,7 @@ mod tests {
     fn selected_drive_index_pulse_latches_once_per_wrap() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5821,6 +6249,7 @@ mod tests {
     fn selected_drive_index_pulse_has_fixed_width() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5858,6 +6287,7 @@ mod tests {
     fn motor_off_drive_does_not_emit_index_pulse() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5887,6 +6317,7 @@ mod tests {
     fn next_index_pulse_reports_selected_drive_time() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5920,6 +6351,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA, 0x5555, 0xA144];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -5950,6 +6382,7 @@ mod tests {
     fn uae_extended_adf_raw_track_preserves_odd_byte_payload() -> Result<()> {
         let path = temp_ext2_track(1, 20, &[0x12, 0x34, 0xA0])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6034,6 +6467,7 @@ mod tests {
         let raw_words: [u16; 4] = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw_revolutions(&raw_words, 32, 2)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6082,6 +6516,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA];
         let path = temp_scp_raw_revolutions(&[&raw_words], 32)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6113,6 +6548,7 @@ mod tests {
     fn scp_flux_decode_resolves_variable_intervals_to_cells() -> Result<()> {
         let path = temp_scp_flux_entries(&[60, 100, 80], 3)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6148,6 +6584,7 @@ mod tests {
         let rev1 = [0x5555, 0xA144];
         let path = temp_scp_raw_revolutions(&[&rev0, &rev1], 32)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6199,6 +6636,7 @@ mod tests {
             SCP_FLAG_INDEX | SCP_FLAG_EXTENDED_MODE,
         )?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6232,6 +6670,7 @@ mod tests {
         fs::write(&path, &image)?;
 
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6263,6 +6702,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA];
         let path = temp_scp_raw_revolutions_with_flags(&[&raw_words], 32, 0)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6302,6 +6742,7 @@ mod tests {
         fs::write(&path, &image)?;
 
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6402,6 +6843,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6441,6 +6883,7 @@ mod tests {
         let raw_words = [0x4489];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6472,6 +6915,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6513,6 +6957,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6557,6 +7002,7 @@ mod tests {
         track_data[0..BYTES_PER_SECTOR].fill(0x5A);
         let path = temp_ext2_amigados(&track_data)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6590,6 +7036,7 @@ mod tests {
         payload.resize(0x31f0, 0);
         let path = temp_ext2_track(0, (track_data.len() * 8) as u32, &payload)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6648,6 +7095,7 @@ mod tests {
     fn writable_extended_adf_amigados_track_persists_sector_updates() -> Result<()> {
         let path = temp_ext2_amigados(&vec![0u8; SECTORS_PER_TRACK * BYTES_PER_SECTOR])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6713,6 +7161,7 @@ mod tests {
             2,
         )?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6771,6 +7220,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA, 0x5555, 0xA144];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6837,6 +7287,7 @@ mod tests {
         let raw_words = [0x0000, 0x0000, 0x0000, 0x0000];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6882,6 +7333,7 @@ mod tests {
         let raw_words = [0x0000, 0x0000];
         let path = temp_ext2_raw_revolutions(&raw_words, 20, 1)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6931,6 +7383,7 @@ mod tests {
     fn writable_extended_adf_raw_track_preserves_partial_word_tail() -> Result<()> {
         let path = temp_ext2_track(1, 20, &[0xFF, 0xFF, 0xF0])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -6984,6 +7437,7 @@ mod tests {
         let raw_words = [0xFFFF];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7028,6 +7482,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7072,6 +7527,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7118,6 +7574,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7174,6 +7631,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7225,6 +7683,7 @@ mod tests {
         let track2 = [0xFFFF, 0xFFFF];
         let path = temp_ext2_raw_tracks(&[(0, &track0), (2, &track2)])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7276,6 +7735,7 @@ mod tests {
     fn writable_legacy_extended_adf_raw_track_persists_word_stream() -> Result<()> {
         let path = temp_ext1_raw(&[0x4489, 0x1111, 0x2222])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7331,6 +7791,7 @@ mod tests {
     fn writable_legacy_extended_adf_raw_track_overwrites_sync_boundary() -> Result<()> {
         let path = temp_ext1_raw(&[0x4489, 0x1111, 0x2222])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7380,6 +7841,7 @@ mod tests {
     fn writable_legacy_extended_adf_raw_track_preserves_odd_payload_length() -> Result<()> {
         let path = temp_ext1_raw_payload(0x4489, &[0x12, 0x34, 0xA0])?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7428,6 +7890,7 @@ mod tests {
     fn write_dma_decodes_and_persists_track() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7460,6 +7923,49 @@ mod tests {
 
         let persisted = fs::read(&path)?;
         assert_eq!(&persisted[0..BYTES_PER_SECTOR], &[0xA5; BYTES_PER_SECTOR]);
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_turbo_bursts_write_dma_and_persists_track() -> Result<()> {
+        let path = temp_adf()?;
+        let cfg = FloppyConfig {
+            speed: SPEED_TURBO,
+            drives: [
+                Some(FloppyDriveConfig {
+                    path: path.clone(),
+                    write_protected: false,
+                }),
+                None,
+                None,
+                None,
+            ],
+        };
+        let mut ctrl = FloppyController::from_config(&cfg)?;
+        let mut source = vec![0u8; ADF_SIZE];
+        source[0..BYTES_PER_SECTOR].fill(0x5C);
+        let words = encode_adf_track(0, &source);
+        let mut chip_ram = vec![0u8; words.len() * 2 + 2];
+        for (i, word) in words.iter().copied().enumerate() {
+            let [hi, lo] = word.to_be_bytes();
+            chip_ram[i * 2] = hi;
+            chip_ram[i * 2 + 1] = lo;
+        }
+
+        ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+        ctrl.tick(MOTOR_READY_CCK, 0, &mut chip_ram);
+        ctrl.set_dskpt_low(0);
+        let len = DSKLEN_DMAEN | DSKLEN_WRITE | (words.len() as u16 & DSKLEN_MASK);
+        assert!(!ctrl.write_dsklen(len, 0));
+        assert!(!ctrl.write_dsklen(len, 0));
+        let dmacon = DMACON_DMAEN | DMACON_DISK;
+        // A full-track write takes a whole revolution at real pace; the
+        // tick that crosses the grace window bursts it to completion.
+        assert!(ctrl.tick(TURBO_DMA_GRACE_CCK, dmacon, &mut chip_ram));
+
+        let persisted = fs::read(&path)?;
+        assert_eq!(&persisted[0..BYTES_PER_SECTOR], &[0x5C; BYTES_PER_SECTOR]);
         let _ = fs::remove_file(path);
         Ok(())
     }
@@ -7565,6 +8071,7 @@ mod tests {
         let path = temp_path("full-track-dma-checksum.adf");
         fs::write(&path, &adf)?;
         let cfg = FloppyConfig {
+            speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
@@ -7644,7 +8151,7 @@ mod tests {
             path: adf.clone(),
             write_protected: true,
         });
-        let ctrl = FloppyController::from_config(&FloppyConfig { drives })?;
+        let ctrl = FloppyController::from_config(&FloppyConfig { drives, speed: 100 })?;
         assert!(ctrl.drive_connected(1));
         assert!(ctrl.disk_inserted(1));
         let _ = fs::remove_file(&adf);

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,12 @@ where
                     .ok_or_else(|| anyhow!("--floppy-drives requires COUNT (1-4)"))?;
                 overrides.floppy_drives = Some(parse_floppy_drive_count(&value)?);
             }
+            "--floppy-speed" | "--fdd-speed" => {
+                let value = args.next().ok_or_else(|| {
+                    anyhow!("--floppy-speed requires PERCENT (100, 200, 400, 800, or 0 for turbo)")
+                })?;
+                overrides.floppy_speed = Some(parse_floppy_speed(&value)?);
+            }
             "--rtc-time" => {
                 overrides.rtc_time = Some(args.next().ok_or_else(|| {
                     anyhow!("--rtc-time requires Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"")
@@ -892,6 +898,7 @@ fn print_help() {
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
          --floppy-drives COUNT          wired floppy drives, 1-4 (DF0 plus externals)\n  \
+         --floppy-speed PERCENT         drive speed: 100, 200, 400, 800, or 0 (turbo)\n  \
          --rtc-time TIME                seed the battery clock (implies fitting one) with\n  \
          \x20                            Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"; it then\n  \
          \x20                            ticks in emulated time, so runs are deterministic\n  \
@@ -1009,6 +1016,17 @@ fn parse_floppy_drive_idx(s: &str, option: &str) -> Result<usize> {
         return Err(anyhow!("{option} drive must be df0, df1, df2, or df3"));
     }
     Ok(idx)
+}
+
+fn parse_floppy_speed(s: &str) -> Result<u16> {
+    const MSG: &str = "--floppy-speed PERCENT must be 100, 200, 400, 800, or 0 (turbo)";
+    let speed: u16 = s.trim().parse().map_err(|_| anyhow!(MSG))?;
+    if speed != copperline::floppy::SPEED_TURBO
+        && !copperline::floppy::SUPPORTED_SPEED_PERCENTS.contains(&speed)
+    {
+        return Err(anyhow!(MSG));
+    }
+    Ok(speed)
 }
 
 fn parse_floppy_drive_count(s: &str) -> Result<u8> {
@@ -2222,6 +2240,22 @@ mod tests {
         );
         let err = parse(&["--floppy-drives", "0"]).unwrap_err();
         assert!(err.to_string().contains("from 1 to 4"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
+    fn floppy_speed_override_parses_with_alias() -> Result<()> {
+        assert_eq!(
+            parse(&["--floppy-speed", "800"])?.overrides.floppy_speed,
+            Some(800)
+        );
+        // 0 selects turbo.
+        assert_eq!(
+            parse(&["--fdd-speed", "0"])?.overrides.floppy_speed,
+            Some(0)
+        );
+        let err = parse(&["--floppy-speed", "150"]).unwrap_err();
+        assert!(err.to_string().contains("100, 200, 400, 800"), "{err:#}");
         Ok(())
     }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -253,6 +253,7 @@ pub enum LauncherField {
     ExtendedRom,
     // Floppy
     FloppyDrives,
+    FloppySpeed,
     Df0Image,
     Df0WriteProtect,
     Df1Image,
@@ -447,8 +448,9 @@ const ROM_ROWS: [Row; 2] = [
     row(F::Rom, "Kickstart ROM", PathRow),
     row(F::ExtendedRom, "Extended ROM", PathRow),
 ];
-const FLOPPY_ROWS: [Row; 9] = [
+const FLOPPY_ROWS: [Row; 10] = [
     row(F::FloppyDrives, "Drives", Cycle),
+    row(F::FloppySpeed, "Drive speed", Cycle),
     row(F::Df0Image, "DF0 image", PathRow),
     row(F::Df0WriteProtect, "DF0 write-protect", Toggle),
     row(F::Df1Image, "DF1 image", PathRow),
@@ -684,6 +686,7 @@ const Z3_PRESETS: [usize; 8] = [
 ];
 const OVERSCANS: [Overscan; 2] = [Overscan::Tv, Overscan::Full];
 const PIXEL_ASPECTS: [PixelAspect; 2] = [PixelAspect::Tv, PixelAspect::Square];
+const FLOPPY_SPEEDS: [u16; 5] = [100, 200, 400, 800, crate::floppy::SPEED_TURBO];
 const PACINGS: [PacingBudget; 2] = [PacingBudget::Cycles, PacingBudget::Instructions];
 const WARPS: [WarpSpeed; 5] = [
     WarpSpeed::X2,
@@ -777,6 +780,8 @@ pub struct MachineSetup {
     extended_rom: Option<PathBuf>,
     // Floppy
     floppy_drives: u8,
+    /// `[floppy] speed`: a percentage (100/200/400/800) or 0 for turbo.
+    floppy_speed: u16,
     /// Per-drive disk-swap playlists (entry 0 is the boot disk). A single
     /// image is a one-element list.
     df_playlists: [Vec<PathBuf>; 4],
@@ -906,6 +911,7 @@ impl MachineSetup {
             rom: raw.rom.as_deref().map(PathBuf::from),
             extended_rom: raw.extended_rom.as_deref().map(PathBuf::from),
             floppy_drives: raw.floppy.drives.unwrap_or(connected).clamp(1, 4),
+            floppy_speed: cfg.floppy.speed,
             df_playlists: cfg.floppy_playlists.clone(),
             df_write_protected,
             ide_master: cfg.ide.master.as_ref().map(|d| d.path.clone()),
@@ -1120,6 +1126,9 @@ impl MachineSetup {
         let drives = self.floppy_drives.max(media_max);
         if drives != 1 {
             raw.floppy.drives = Some(drives);
+        }
+        if self.floppy_speed != 100 {
+            raw.floppy.speed = Some(self.floppy_speed);
         }
         raw.floppy.df0 = self.floppy_drive_raw(0);
         raw.floppy.df1 = self.floppy_drive_raw(1);
@@ -1681,6 +1690,7 @@ impl MachineSetup {
             F::SlowRam => size_label(self.slow_ram),
             F::Z3Ram => size_label(self.z3_ram),
             F::FloppyDrives => self.floppy_drives.to_string(),
+            F::FloppySpeed => crate::floppy::speed_label(self.floppy_speed),
             F::CdInsertDelay => {
                 if self.cd_insert_delay <= 0.0 {
                     "At boot".to_string()
@@ -1840,6 +1850,9 @@ impl MachineSetup {
             F::Z3Ram => self.z3_ram = cycle_nearest(&Z3_PRESETS, self.z3_ram, forward),
             F::FloppyDrives => {
                 self.floppy_drives = step_u8(self.floppy_drives, forward, 1, 4);
+            }
+            F::FloppySpeed => {
+                self.floppy_speed = cycle_slice(&FLOPPY_SPEEDS, self.floppy_speed, forward)
             }
             F::CdInsertDelay => {
                 let secs = self.cd_insert_delay + if forward { 1.0 } else { -1.0 };

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -88,6 +88,7 @@ pub enum MenuItem {
     SamplerInput,
     SamplerGain,
     PixelAspect,
+    FloppySpeed,
     Fullscreen,
     AudioOutput,
     Warp,
@@ -105,9 +106,9 @@ pub enum MenuItem {
 /// sampler is attached, so the list is built per open rather than fixed.
 pub fn menu_items(midi_active: bool, sampler_active: bool) -> Vec<MenuItem> {
     let _ = midi_active;
-    // 9 leading + up to 2 MIDI + 2 sampler + pixel aspect + 10 trailing
-    // items = 24, sized so appending never reallocates.
-    let mut items = Vec::with_capacity(24);
+    // 9 leading + up to 2 MIDI + 2 sampler + pixel aspect + floppy speed +
+    // 10 trailing items = 25, sized so appending never reallocates.
+    let mut items = Vec::with_capacity(25);
     items.extend([
         MenuItem::MachineConfig,
         MenuItem::FrameAnalyzer,
@@ -129,6 +130,7 @@ pub fn menu_items(midi_active: bool, sampler_active: bool) -> Vec<MenuItem> {
         items.push(MenuItem::SamplerGain);
     }
     items.push(MenuItem::PixelAspect);
+    items.push(MenuItem::FloppySpeed);
     items.extend([
         MenuItem::Fullscreen,
         MenuItem::Warp,
@@ -158,6 +160,8 @@ pub struct MenuLabels<'a> {
     /// through the Port 1/2 Device items).
     pub port_devices: [crate::bus::PortDevice; 2],
     pub pixel_aspect: PixelAspect,
+    /// Current `[floppy] speed` value (a percentage, or 0 for turbo).
+    pub floppy_speed: u16,
     /// Current MIDI input/output device names (empty when not applicable).
     #[cfg_attr(not(feature = "midi"), allow(dead_code))]
     pub midi_in: &'a str,
@@ -189,6 +193,14 @@ fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
                 PixelAspect::Square => "square",
             };
             format!("Pixel Aspect {:>8}", format!("[{value}]"))
+        }
+        // Right-pad like Warp Limit below so the closing bracket stays put
+        // as the value width changes (100% vs turbo).
+        MenuItem::FloppySpeed => {
+            format!(
+                "Floppy Speed {:>7}",
+                format!("[{}]", crate::floppy::speed_label(s.floppy_speed))
+            )
         }
         #[cfg(feature = "midi")]
         MenuItem::MidiInput => format!("MIDI In  [{}]", clip_menu_value(s.midi_in)),
@@ -4884,6 +4896,7 @@ mod tests {
                 crate::bus::PortDevice::Joystick,
             ],
             pixel_aspect: PixelAspect::Tv,
+            floppy_speed: 100,
             midi_in: "",
             midi_out: "",
             audio_output: "",
@@ -4931,6 +4944,14 @@ mod tests {
                                         // The longest device label.
                                         port_devices: [crate::bus::PortDevice::Analogue; 2],
                                         pixel_aspect: aspect,
+                                        // Rides warp's sweep: "turbo" is the
+                                        // widest value, "100%" the tallest
+                                        // percent form.
+                                        floppy_speed: if warp {
+                                            crate::floppy::SPEED_TURBO
+                                        } else {
+                                            100
+                                        },
                                         midi_in: long,
                                         midi_out: long,
                                         audio_output: long,
@@ -5483,6 +5504,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5530,6 +5552,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5565,6 +5588,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5616,6 +5640,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5691,6 +5716,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5753,6 +5779,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5812,6 +5839,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5872,6 +5900,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -5985,6 +6014,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6058,6 +6088,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6142,6 +6173,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6263,6 +6295,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6314,6 +6347,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6356,6 +6390,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6438,6 +6473,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6487,6 +6523,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6529,6 +6566,7 @@ mod tests {
                     crate::bus::PortDevice::Joystick,
                 ],
                 pixel_aspect: PixelAspect::Tv,
+                floppy_speed: 100,
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
@@ -6575,6 +6613,7 @@ mod tests {
                 crate::bus::PortDevice::Joystick,
             ],
             pixel_aspect: PixelAspect::Tv,
+            floppy_speed: 100,
             midi_in: "",
             midi_out: "",
             audio_output: "",

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2212,6 +2212,7 @@ impl ApplicationHandler for App {
                                 self.emu.bus().input.device(1),
                             ],
                             pixel_aspect: super::pixel_aspect(),
+                            floppy_speed: self.emu.bus().floppy.speed_percent(),
                             midi_in: &midi_in_label,
                             midi_out: &midi_out_label,
                             audio_output: self.audio_output.label(),
@@ -3320,6 +3321,7 @@ impl App {
                     ui::MenuItem::SamplerInput => self.cycle_sampler_input(),
                     ui::MenuItem::SamplerGain => self.step_sampler_gain(true),
                     ui::MenuItem::PixelAspect => self.toggle_pixel_aspect(),
+                    ui::MenuItem::FloppySpeed => self.cycle_floppy_speed(),
                     ui::MenuItem::AudioOutput => self.cycle_audio_output(),
                     ui::MenuItem::Fullscreen => self.toggle_fullscreen(),
                     ui::MenuItem::Warp => self.toggle_warp(),
@@ -4747,6 +4749,20 @@ impl App {
         } else {
             self.show_osd(format!("Warp limit: {limit} (warp off)"));
         }
+        self.request_redraw();
+    }
+
+    /// Cycle the emulated floppy drive speed (100% -> 200% -> 400% -> 800%
+    /// -> turbo). Applies to the live machine immediately.
+    fn cycle_floppy_speed(&mut self) {
+        const CYCLE: [u16; 5] = [100, 200, 400, 800, crate::floppy::SPEED_TURBO];
+        let current = self.emu.bus().floppy.speed_percent();
+        let idx = CYCLE.iter().position(|&s| s == current).unwrap_or(0);
+        let next = CYCLE[(idx + 1) % CYCLE.len()];
+        self.emu.bus_mut().floppy.set_speed_percent(next);
+        let label = crate::floppy::speed_label(next);
+        info!("floppy speed: {label}");
+        self.show_osd(format!("Floppy speed: {label}"));
         self.request_redraw();
     }
 


### PR DESCRIPTION
Adds the FS-UAE-style fast floppy option that keeps getting requested: `[floppy] speed` / `--floppy-speed` (alias `--fdd-speed`) accepting `100` (real speed, default), `200`/`400`/`800` percent, or `0` for turbo.

## How it stays accurate

- **Percentage modes** multiply the elapsed time the data path sees: platter rotation, the MFM read shifter, sync detection, DSKBYTR, and DMA pacing all advance at the whole multiple, so every per-cell decision is bit-identical to a real-speed run, just compressed in time. This is the same shape as FS-UAE/WinUAE's `floppy_speed` percentage (their 8.8 fixed-point `trackspeed` divisor), minus their FIFO slot-pacing hacks, which Copperline's rate-based transfer does not need.
- **Turbo** mirrors FS-UAE's instant path but runs through the ordinary bit engine instead of a parallel copy loop: once a DMA has been armed for two scanlines (the deferral WinUAE applies so loaders that clear stale INTREQ bits right after writing DSKLEN do not lose the completion), the platter is spun forward in zero emulated time -- first to the next DSKSYNC match, then to the transfer's end. Framing, sync realignment, the write-decode path, and DSKBLK all behave exactly as if the time had really passed. A sync word the track never provides gets one scan and then falls back to normal pacing, like FS-UAE's per-DSKLEN turbo scan.
- **Mechanics are never accelerated**: motor spin-up, head stepping, and post-seek settle keep real timing at every speed, so drive-readiness behavior (Gods' spin-up gate, Shadow of the Beast II's DSKLEN-during-spin-up arming) is untouched.
- The idle fast-forward event horizon (`next_completion_cck` / `next_sync_irq_cck` / `next_index_pulse_cck`) reports the scaled deadlines, so STOP-state batching stays bounded to the accelerated events.
- The speed is host configuration, not machine state: it is never serialized, `adopt_host_resources` carries the running session's setting across save-state loads, and the default (100) leaves every timing path byte-identical to before this change.

## Hooked up everywhere

- **TOML/CLI**: `[floppy] speed`, `--floppy-speed`/`--fdd-speed`, validated to the supported set with a clear error.
- **Desktop menu**: a *Floppy Speed* item (next to Pixel Aspect) cycles 100% -> 200% -> 400% -> 800% -> turbo live, with an OSD flash.
- **Launcher**: a *Drive speed* row on the Floppy tab, round-tripping through the generated TOML only when non-default.
- **Browser**: `set_floppy_speed(percent)` / `floppy_speed()` on `WebEmu`, plus a visible speed select on the page itself: a shell-provided `#floppy-speed` element hosts it, and without one try.js builds a labelled 100%/200%/400%/800%/Turbo select below the canvas (the status strip pattern), so the control is always reachable. `?fdspeed=100..800|0|turbo` overrides the initial choice for shareable links; changes apply at boot and live.
- **Docs**: configuration.md (option + CLI table), ui.md (menu + launcher), browser.md (JS API + page hooks), and `copperline.example.toml`.

## Testing

- Seven new unit tests: 800% completes a read DMA exactly eightfold sooner with identical data, turbo bursts read and full-track write DMA after the two-scanline grace, a sync-waiting turbo read delivers the same words as a real-speed run, a missing sync word falls back to normal pacing, turbo waits for motor spin-up, and no speed shortens spin-up. Plus config parse/validation and CLI override tests.
- `cargo test` (1665 unit + integration suites), `cargo clippy --all-targets`, and `cargo fmt --check` all clean; web crate checked with `cargo check`/`clippy --target wasm32-unknown-unknown` and `fmt --check`.
- End-to-end headless verification with the Alien Breed trackloader under KS1.3: 13 disk DMA completions in the first 15 emulated seconds at 100%, 22 at 800%, 29 at turbo, all rendering the intro correctly; an AmigaDOS boot behaves identically at all speeds.
