### PR TITLE
web: Kickstart list select for site-served ROMs

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1236,21 +1236,25 @@ function updateStatusDisks() {
   }
 }
 
-// --- disk list ---------------------------------------------------------
+// --- disk and Kickstart lists ------------------------------------------
 // Optional in the page shell: a <select id="df0list"> fills itself with
 // the disk images the site serves next to the page and inserts the picked
-// one into DF0 (before boot it queues, like the picker). The folder comes
-// from the select's data-src attribute (default "adf/"), and the list from
+// one into DF0 (before boot it queues, like the picker), and a
+// <select id="kicklist"> does the same for Kickstart ROMs, fitting the
+// picked one like the ROM picker. Each folder comes from the select's
+// data-src attribute (defaults "adf/" and "kick/"), and the list from
 // <folder>/index.json - a JSON array of file names, or of {name, url}
 // objects with URLs relative to the folder. Without a manifest, a server
 // directory listing of the folder (nginx autoindex, Apache, python -m
-// http.server) is scraped for disk-image links instead. An empty or
-// unreachable folder hides the select.
+// http.server) is scraped for links with a matching extension instead.
+// An empty or unreachable folder hides the select.
 
-const diskListSelect = $('df0list');
 const DISK_LIST_EXT = /\.(adf|adz|dms|ipf|scp|zip|gz)$/i;
+// Raw ROM images only: a list pick feeds load_rom directly, which takes
+// uncompressed 256/512 KiB images.
+const KICK_LIST_EXT = /\.(rom|bin)$/i;
 
-async function diskListEntries(folder) {
+async function folderListEntries(folder, extensions) {
   // A manifest wins when the site ships one; a missing or invalid one
   // (fetch error, unparsable JSON, not an array) falls through to the
   // directory listing.
@@ -1292,7 +1296,7 @@ async function diskListEntries(folder) {
       // Only files inside the folder itself; autoindex pages also carry
       // parent-directory and sort links.
       if (url.origin !== folder.origin || !url.pathname.startsWith(folder.pathname)) continue;
-      if (!DISK_LIST_EXT.test(url.pathname)) continue;
+      if (!extensions.test(url.pathname)) continue;
       entries.push({ name: nameFromUrlPath(url.pathname, url.pathname), url: url.href });
     }
     return entries;
@@ -1301,26 +1305,37 @@ async function diskListEntries(folder) {
   }
 }
 
-async function loadDiskList(select) {
+// sameOriginOnly enforces the Kickstart copyright gate at the list level:
+// the folder must be on the page's own site and cross-origin manifest
+// entries are dropped, so the select never offers a ROM that
+// fitRomFromUrl's own gate would refuse pick by pick.
+async function loadFolderList(select, defaultSrc, extensions, placeholder, sameOriginOnly, pick) {
   let folder;
   try {
-    folder = new URL(select.dataset.src || 'adf/', location.href);
+    folder = new URL(select.dataset.src || defaultSrc, location.href);
   } catch {
     select.hidden = true;
     return;
   }
+  if (sameOriginOnly && folder.origin !== location.origin) {
+    select.hidden = true;
+    return;
+  }
   if (!folder.pathname.endsWith('/')) folder.pathname += '/';
-  const entries = await diskListEntries(folder);
+  let entries = await folderListEntries(folder, extensions);
+  if (sameOriginOnly) {
+    entries = entries.filter((entry) => new URL(entry.url).origin === location.origin);
+  }
   if (!entries.length) {
     select.hidden = true;
     return;
   }
   entries.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
   if (!select.options.length) {
-    const placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.textContent = 'DF0 from list...';
-    select.appendChild(placeholder);
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = placeholder;
+    select.appendChild(option);
   }
   for (const { name, url } of entries) {
     const option = document.createElement('option');
@@ -1329,11 +1344,22 @@ async function loadDiskList(select) {
     select.appendChild(option);
   }
   select.addEventListener('change', () => {
-    if (select.value) insertDiskFromUrl(select.value);
+    if (select.value) pick(select.value);
   });
 }
 
-if (diskListSelect) loadDiskList(diskListSelect);
+const diskListSelect = $('df0list');
+if (diskListSelect) {
+  loadFolderList(diskListSelect, 'adf/', DISK_LIST_EXT, 'DF0 from list...', false, insertDiskFromUrl);
+}
+
+// The hosted page's server carries no ROMs, so its kick/ folder lists
+// nothing and the select hides; a self-hosted shell that serves its
+// owner's ROMs next to the page gets a one-click ROM chooser.
+const kickListSelect = $('kicklist');
+if (kickListSelect) {
+  loadFolderList(kickListSelect, 'kick/', KICK_LIST_EXT, 'Kickstart from list...', true, fitRomFromUrl);
+}
 
 // Optional in the page shell: older shells have no URL button.
 $('df0url')?.addEventListener('click', () => {

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -49,8 +49,10 @@ Docker deployment with a mounted volume, an intranet install) can boot
 them by URL: `?kick=files/kick13.rom`. ROM fetches are capped at 4 MiB
 and the image is validated like a picked file. A page shell may also
 offer a **Kickstart from URL** button (id `kickurl`), which prompts for
-a same-origin address; the hosted page has no ROMs to point it at and
-omits it.
+a same-origin address, or a **Kickstart list** select (id `kicklist`)
+that fills itself with the ROMs the site serves next to the page (see
+the page-shell hooks below); the hosted page has no ROMs to point them
+at and omits both.
 
 Controls:
 
@@ -269,6 +271,18 @@ elements, and pages without them are untouched:
   manifest, a server directory listing of the folder (nginx `autoindex`,
   Apache, `python -m http.server`) is scraped for disk-image links
   instead. If the folder yields nothing, the select hides itself.
+- `#kicklist` (a `<select>`): the same list pattern for Kickstart ROMs.
+  The folder is the select's `data-src` attribute (default `kick/`), with
+  the same manifest-or-directory-listing contract as `#df0list`, filtered
+  to raw `.rom`/`.bin` images (a list pick feeds the ROM loader directly,
+  which takes uncompressed 256/512 KiB images). A picked ROM is fitted
+  like the picker: queued before boot (the boot button relabels), and a
+  running machine is power-cycled. Picks go through the same-origin
+  copyright gate described above, and the list enforces it up front -- a
+  cross-origin folder or manifest entry is hidden rather than offered and
+  refused pick by pick. The hosted page's server carries no ROMs, so the
+  select never appears there; a self-hosted shell that serves its owner's
+  ROMs next to the page gets a one-click ROM chooser.
 - `#ledbar` (a container): hosts the front-panel status strip (LEDs,
   track counter, disk names), letting the page own its placement and
   outer styling. Without it the strip inserts itself directly below the

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -273,9 +273,11 @@ elements, and pages without them are untouched:
   instead. If the folder yields nothing, the select hides itself.
 - `#kicklist` (a `<select>`): the same list pattern for Kickstart ROMs.
   The folder is the select's `data-src` attribute (default `kick/`), with
-  the same manifest-or-directory-listing contract as `#df0list`, filtered
-  to raw `.rom`/`.bin` images (a list pick feeds the ROM loader directly,
-  which takes uncompressed 256/512 KiB images). A picked ROM is fitted
+  the same manifest-or-directory-listing contract as `#df0list`: a
+  manifest lists whatever the site chooses, while a scraped directory
+  listing is filtered to raw `.rom`/`.bin` images (a list pick feeds the
+  ROM loader directly, which takes uncompressed 256/512 KiB images). A
+  picked ROM is fitted
   like the picker: queued before boot (the boot button relabels), and a
   running machine is power-cycled. Picks go through the same-origin
   copyright gate described above, and the list enforces it up front -- a


### PR DESCRIPTION
## Summary

Adds a `#kicklist` page-shell hook: a `<select>` that fills itself with the Kickstart ROMs the site serves next to the page and fits the picked one like the ROM picker, mirroring the existing `#df0list` disk list.

- The df0list folder-listing glue (a `<folder>/index.json` manifest, or a scraped server directory listing) is generalised into a shared `loadFolderList` helper; the disk list's behaviour is unchanged.
- The Kickstart list defaults to a `kick/` folder (overridable via `data-src`), filtered to raw `.rom`/`.bin` images since a pick feeds `load_rom` directly (uncompressed 256/512 KiB images).
- A picked ROM rides the existing `fitRomFromUrl` path: queued before boot (the boot button relabels), and a running machine is power-cycled.
- The same-origin copyright gate is enforced at the list level too: a cross-origin folder hides the select and cross-origin manifest entries are dropped, so the list never offers a ROM the pick path would refuse. The hosted page serves no ROMs, so the select never appears there; self-hosted shells that serve their owner's ROMs next to the page get a one-click ROM chooser.
- No wasm-side changes; `docs/guide/browser.md` documents the hook.

## Testing

- `node --check` on the modified `try.js` (as an ES module).
- Live browser test against the real site shell (patched with both selects) served by `python3 -m http.server`, with a freshly built wasm pkg:
  - Directory-listing scrape populated both lists (`.rom`/`.bin` filter for kick, disk extensions for df0).
  - Pre-boot pick queued the ROM, relabelled the boot button, and booted into the Kickstart 1.3 insert-disk screen.
  - Live pick power-cycled the running machine into Kickstart 3.1.
  - df0list still inserts live after the refactor (disk booted on the swapped machine).
  - `kick/index.json` manifest: friendly labels and bare-string entries listed, a cross-origin entry filtered out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yMn3JdhkQaeep5y3o9L3y