### PR TITLE
Fix fullscreen scaling when going fullscreen before Run

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6966,10 +6966,17 @@ impl App {
         self.emu.set_live_audio_suspended(suspended);
     }
 
+    /// Size the window to the presentation canvas, unless it is fullscreen: the
+    /// request resizes nothing there and instead shrinks the drawable into a
+    /// corner (macOS and Windows; Linux window managers ignore it), so leave the
+    /// display-sized surface alone and let the presentation scale into it.
     fn resize_for_active_panel(&self) {
         let Some(window) = self.render.as_ref().map(|r| r.window.clone()) else {
             return;
         };
+        if window.fullscreen().is_some() {
+            return;
+        }
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
         let _ = window.request_inner_size(size);
     }


### PR DESCRIPTION
Going fullscreen before starting emulation broke the scaling. Launch Copperline, hit fullscreen while the configuration screen is still up, then Run, and the machine renders small in the top-left with the rest of the screen black. Starting emulation first and going fullscreen afterwards was always fine.

`resize_for_active_panel` asks the window for a canvas-sized inner size whenever a panel opens or closes. On a fullscreen window that doesn't resize anything, it just shrinks the drawable into a corner. It's skipped now while the window is fullscreen, so the display-sized surface stands and the presentation scales into it, which is what the working case was already doing.

Tested on all three platforms: macOS and Windows both showed the bug and are fixed by this. Linux was never affected — the window manager owns fullscreen geometry there and ignores the resize request either way.

Run is the obvious way to hit this, but the same call happens on close panel, open launcher, state load and a pixel-aspect change.

<img width="1710" height="1112" alt="Screenshot 2026-07-19 at 22 48 58" src="https://github.com/user-attachments/assets/fe52cf4c-46f0-4fee-b844-3c471ba41b4c" />
<img width="1710" height="1112" alt="Screenshot 2026-07-19 at 22 48 25" src="https://github.com/user-attachments/assets/740b2ecd-dd5f-4717-9725-b52893a7dd0b" />
