### PR TITLE
web: gate the BBS bridge on the guest's DTR line

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -538,6 +538,17 @@ impl WebEmu {
         self.serial.input_backlog().min(u32::MAX as usize) as u32
     }
 
+    /// Whether the guest is asserting the serial port's DTR line (CIA-B PA7
+    /// driven low). A terminal raises DTR when it opens the port --
+    /// serial.device does it on OpenDevice, hardware-level terminals set the
+    /// CIA bit themselves -- and drops it on close and at reset, so this is
+    /// the "guest terminal is ready" signal a modem would key off. The page
+    /// bridge uses it to defer dialling until the terminal can actually
+    /// display the far end's greeting.
+    pub fn serial_dtr(&self) -> bool {
+        self.emu.bus().cia_b.port_a_pins() & 0x80 == 0
+    }
+
     /// Cold reset (power cycle), keeping the fitted ROM and inserted disks.
     pub fn reset(&mut self) -> Result<(), JsValue> {
         self.emu.power_on_reset().map_err(js_err)?;

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -425,6 +425,23 @@ document.addEventListener('visibilitychange', () => {
 // the telnet layer, for gateways to non-telnet services) are optional too.
 // Pages without the elements are untouched - the pump still drains the
 // guest's bounded serial buffer every frame, it just goes nowhere.
+//
+// Telnet-mode connections follow the guest's DTR line the way a modem
+// follows its terminal. Dialling before the terminal is up would scroll the
+// BBS greeting into a UART nobody is reading and leak boot-ROM chatter to
+// the BBS as phantom keypresses (a stray newline at a login prompt starts
+// the new-user flow), so Connect defers the dial until the terminal has
+// opened the serial port, and a live session hangs up when the guest drops
+// the line (terminal exit, reboot, power cycle) - then re-arms, so the
+// next boot of the terminal reconnects by itself. Raw mode is ungated, for
+// byte services and guests that never drive CIA-B DTR.
+//
+// The dial waits for the line to be READY (DTR asserted) and QUIET (no
+// guest transmit) continuously for a guard period, not for a mere DTR
+// edge: AROS raises DTR for a couple of seconds during early boot while
+// its kernel debug output streams to the serial port, and dialling into
+// that window is exactly the reported failure. The debug burst fails both
+// conditions; a terminal holds DTR silently and passes.
 
 const serialUrlInput = $('serial-url');
 const serialConnectBtn = $('serial-connect');
@@ -433,6 +450,21 @@ const serialRawToggle = $('serial-raw');
 
 let serialWs = null;
 let serialTelnet = null;
+// Connect clicked before the guest's line was ready: dial once it is.
+let serialWaitingDtr = false;
+// The open session is DTR-gated (telnet mode): drop of the line hangs up.
+let serialDtrGated = false;
+// Emulated-time instant the guest's line last became ready-and-quiet;
+// pushed forward by every disqualifier (DTR down, guest transmit) the
+// pump sees. Emulated seconds, not wall time: in a throttled background
+// tab the machine runs far slower than the wall clock, and a wall-time
+// guard would fire inside a stretched boot transient.
+let serialLineReadySince = 0;
+// The line must hold ready-and-quiet this long (emulated seconds) before
+// a deferred dial fires. The AROS boot-debug burst holds DTR for ~1.75s
+// while transmitting; 3s of held silence clears it with margin and still
+// feels immediate once a terminal is really up.
+const SERIAL_DIAL_GUARD_EMU_S = 3.0;
 // Inbound chunks the guest's UART has not had room for yet. The UART
 // consumes at the emulated baud rate, so a fast sender (a file download)
 // backlogs here rather than ballooning inside the wasm heap.
@@ -441,11 +473,33 @@ let serialRxQueue = [];
 // the queue above absorbs the difference, a frame at a time.
 const SERIAL_BACKLOG_LIMIT = 32768;
 
+// The guest's view of the serial DTR line. A powered-off machine has the
+// line down; a wasm bundle older than serial_dtr() reports it up, which
+// disengages the gate (see serialLineSettled) rather than waiting forever.
+function guestDtr() {
+  if (!emu) return false;
+  if (typeof emu.serial_dtr !== 'function') return true;
+  return emu.serial_dtr();
+}
+
+function emuSeconds() {
+  return emu && typeof emu.emulated_seconds === 'function' ? emu.emulated_seconds() : 0;
+}
+
+// Ready-and-quiet for the full guard period, judged from what the pump
+// has observed. Only meaningful while the machine is emulating, which is
+// when the pump keeps serialLineReadySince honest.
+function serialLineSettled() {
+  if (!emu) return false;
+  if (typeof emu.serial_dtr !== 'function') return true; // pre-gate wasm
+  return emu.serial_dtr() && emuSeconds() - serialLineReadySince >= SERIAL_DIAL_GUARD_EMU_S;
+}
+
 function setSerialStatus(text) {
   if (serialStatus) serialStatus.textContent = text;
 }
 
-function serialDisconnect(status) {
+function serialTeardown() {
   if (serialWs) {
     // Neuter the handlers first: close() fires onclose asynchronously, and
     // a stale handler would clobber the status of a connection made later.
@@ -454,27 +508,47 @@ function serialDisconnect(status) {
     serialWs = null;
   }
   serialTelnet = null;
+  serialDtrGated = false;
   serialRxQueue = [];
+}
+
+function serialDisconnect(status) {
+  serialTeardown();
+  serialWaitingDtr = false;
   if (serialConnectBtn) serialConnectBtn.textContent = 'Connect';
   setSerialStatus(status);
 }
 
-function serialConnect() {
+// DTR dropped mid-session: hang up like a modem losing its terminal, but
+// keep the visitor's intent armed - when the line settles again (the
+// terminal is back after a reboot) the dial repeats by itself.
+function serialHangup() {
+  serialTeardown();
+  serialWaitingDtr = true;
+  if (serialConnectBtn) serialConnectBtn.textContent = 'Cancel';
+  setSerialStatus('terminal closed the serial port - reconnects when it is back...');
+}
+
+// Open the socket now, with whatever is in the URL box. Reached directly
+// from a Connect click when the guest is ready (or in raw mode), or from
+// the pump when a deferred connect sees DTR rise.
+function serialOpen() {
   const url = serialUrlInput?.value?.trim();
   if (!url) {
-    setSerialStatus('enter a ws:// or wss:// gateway URL');
+    serialDisconnect('enter a ws:// or wss:// gateway URL');
     return;
   }
   let ws;
   try {
     ws = new WebSocket(url);
   } catch (e) {
-    setSerialStatus(`bad URL: ${e.message ?? e}`);
+    serialDisconnect(`bad URL: ${e.message ?? e}`);
     return;
   }
   ws.binaryType = 'arraybuffer';
   serialWs = ws;
   serialTelnet = serialRawToggle?.checked ? null : new TelnetSession();
+  serialDtrGated = serialTelnet !== null;
   serialRxQueue = [];
   if (serialConnectBtn) serialConnectBtn.textContent = 'Disconnect';
   setSerialStatus('connecting...');
@@ -492,9 +566,28 @@ function serialConnect() {
   };
 }
 
+function serialConnect() {
+  const url = serialUrlInput?.value?.trim();
+  if (!url) {
+    setSerialStatus('enter a ws:// or wss:// gateway URL');
+    return;
+  }
+  if (!serialRawToggle?.checked && !serialLineSettled()) {
+    // Telnet mode with no settled terminal yet: arm the deferred dial
+    // instead of connecting into the void. The pump completes it once
+    // the guest's line has been ready and quiet for the guard period.
+    serialWaitingDtr = true;
+    if (serialConnectBtn) serialConnectBtn.textContent = 'Cancel';
+    setSerialStatus('waiting for the terminal - boot the terminal disk, connects when it is ready...');
+    return;
+  }
+  serialOpen();
+}
+
 if (serialConnectBtn) {
   serialConnectBtn.addEventListener('click', () => {
-    if (serialWs) serialDisconnect('disconnected');
+    if (serialWaitingDtr) serialDisconnect('cancelled');
+    else if (serialWs) serialDisconnect('disconnected');
     else serialConnect();
   });
 }
@@ -505,6 +598,26 @@ function pumpSerial() {
   // the guest's bounded output buffer (which also carries boot-ROM debug
   // chatter) never overflows into dropped bytes mid-session.
   const out = emu.serial_take();
+  // Any disqualifier - line down, guest transmit, or the emulated clock
+  // rewinding (a power cycle) - restarts the ready-and-quiet guard clock.
+  // Checked here rather than on a timer because the line can only change
+  // while the machine is emulating, and emulation is what drives this
+  // pump.
+  const nowEmu = emuSeconds();
+  if (!guestDtr() || out.length || nowEmu < serialLineReadySince) {
+    serialLineReadySince = nowEmu;
+  }
+  // Deferred dial: the guest's line has settled, so connect now.
+  if (serialWaitingDtr && serialLineSettled()) {
+    serialWaitingDtr = false;
+    serialOpen();
+  }
+  // Modem-style hangup (and automatic re-arm): the guest dropped DTR, so
+  // the session ends before boot chatter can reach the far end as
+  // phantom input.
+  if (serialDtrGated && serialWs && !guestDtr()) {
+    serialHangup();
+  }
   if (out.length && serialWs?.readyState === WebSocket.OPEN) {
     serialWs.send(serialTelnet ? serialTelnet.send(out) : out);
   }

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -229,8 +229,8 @@ the selected drive's head or `undefined` when no drive is selected (latch
 the last value so a counter does not flicker), and `drive_connected(n)` /
 `disk_name(n)` describe DF0-DF3 -- a `disk_name` of `undefined` means the
 drive is empty. `serial_send(bytes)`,
-`serial_take()` and `serial_input_backlog()` bridge Paula's serial port to
-whatever byte stream the page likes (see
+`serial_take()`, `serial_input_backlog()` and `serial_dtr()` bridge
+Paula's serial port to whatever byte stream the page likes (see
 [the serial bridge section](#browser-serial-bridge)). The presentation pointer is only
 valid until the next `run` call -- rebuild the typed-array view every frame,
 because wasm memory can grow. The presentation *size* is dynamic too:
@@ -312,6 +312,12 @@ telnet BBS, with a terminal program running on the guest. Three calls:
   also carries boot-ROM/OS debug output, which a page may simply log.
 - `serial_input_backlog()` reports the bytes `serial_send` has queued that
   the UART has not yet consumed -- the flow-control signal.
+- `serial_dtr()` reports whether the guest is asserting the serial port's
+  DTR line (CIA-B PA7 driven low). A terminal raises DTR when it opens the
+  port -- serial.device does it on OpenDevice, hardware-level terminals
+  set the CIA bit themselves -- and drops it on exit and at reset, so this
+  is the "a terminal is actually listening" signal, exactly what a real
+  modem keys off.
 
 Browsers cannot open raw TCP, so the page's transport is a WebSocket to a
 gateway that forwards to the real service --
@@ -332,6 +338,26 @@ BBS adds four elements and inherits the whole flow. The guest side needs a
 terminal program on a bootable disk (set to serial.device, 8N1 -- the
 bridge carries whatever baud the guest picks), inserted like any other
 floppy.
+
+In telnet mode the connection follows the guest's DTR line the way a
+modem follows its terminal. Clicking Connect before the terminal is up
+would scroll the BBS greeting into a UART nobody is reading and forward
+boot-ROM chatter to the BBS as phantom keypresses (a stray newline at a
+login prompt walks straight into the new-user flow), so Connect defers
+the dial until the guest's line has *settled*: DTR asserted and no guest
+transmit, both held for a three-second guard period measured in emulated
+time (so a throttled background tab cannot shrink it). The guard matters
+because AROS raises DTR for a couple of seconds during early boot while
+its kernel debug output streams to the serial port; that burst fails
+both conditions, while a real terminal holds DTR silently and passes.
+While deferred, the status line shows "waiting for the terminal" and the
+button cancels. A connected session hangs up when the guest drops DTR
+(terminal exit, reboot, power cycle) and re-arms the deferred dial, so
+rebooting the terminal disk reconnects by itself. Visitors can therefore
+click Connect at any point -- before booting, after booting, mid-session
+before a reboot -- and the dial always lands on a listening terminal.
+Raw mode is ungated for byte services and guest programs that never
+drive the CIA-B DTR bit.
 
 On the desktop build the equivalent is `[serial] mode = "tcp-connect"`
 plus `connect = "host:port"` (or `--serial-connect host:port`), which

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -424,6 +424,14 @@ impl Cia {
         self.regs[REG_DDRA]
     }
 
+    /// Physical port-A pin levels: outputs at their programmed level, inputs
+    /// released (open-drain, pulled high). On CIA-B the high bits are the
+    /// RS-232 control lines (/DTR on PA7, /RTS on PA6), which a host-side
+    /// serial bridge observes the way an attached modem would.
+    pub fn port_a_pins(&self) -> u8 {
+        self.read_port(REG_PRA, REG_DDRA)
+    }
+
     /// Physical port-B pin levels without the `PC` strobe side effect of a
     /// guest PRB read. Motherboard wiring (floppy outputs and the Centronics
     /// data bus) observes pins continuously and must not create a second
@@ -1171,6 +1179,26 @@ mod tests {
             cia.ta_count, count,
             "input-mode PRA writes must not clock CNT"
         );
+    }
+
+    #[test]
+    fn port_a_pins_report_driven_levels_and_released_inputs() {
+        // CIA-B PA7 is /DTR: driven low = asserted, and an undriven pin
+        // (input) reads high through the pull-up, so a freshly reset CIA
+        // reports the line deasserted. This is what a host-side serial
+        // bridge observes to tell whether a terminal has opened the port.
+        let mut cia = Cia::new(Which::B);
+        assert_eq!(cia.port_a_pins() & 0x80, 0x80, "reset: /DTR released");
+
+        cia.write(REG_DDRA, 0xC0); // /DTR + /RTS as outputs
+        cia.write(REG_PRA, 0x00); // drive both low = asserted
+        assert_eq!(cia.port_a_pins() & 0xC0, 0x00, "driven low = asserted");
+
+        cia.write(REG_PRA, 0x80); // raise /DTR, keep /RTS low
+        assert_eq!(cia.port_a_pins() & 0xC0, 0x80);
+
+        cia.write(REG_DDRA, 0x00); // back to inputs: pins float high
+        assert_eq!(cia.port_a_pins() & 0xC0, 0xC0, "inputs read released");
     }
 
     #[test]

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -424,10 +424,14 @@ impl Cia {
         self.regs[REG_DDRA]
     }
 
-    /// Physical port-A pin levels: outputs at their programmed level, inputs
-    /// released (open-drain, pulled high). On CIA-B the high bits are the
-    /// RS-232 control lines (/DTR on PA7, /RTS on PA6), which a host-side
-    /// serial bridge observes the way an attached modem would.
+    /// Port-A pin levels as contributed by the CIA itself: outputs at their
+    /// programmed level, inputs released (open-drain, pulled high). External
+    /// peripherals are not overlaid here, so a pin an attached device drives
+    /// (the parallel port's Centronics status inputs on CIA-B PA0-2, see
+    /// `Bus::cia_b_read`) can sit at a different board-level value. The
+    /// RS-232 control outputs on CIA-B (/DTR on PA7, /RTS on PA6) have no
+    /// external driver, so for them this is the wire level, which a
+    /// host-side serial bridge observes the way an attached modem would.
     pub fn port_a_pins(&self) -> u8 {
         self.read_port(REG_PRA, REG_DDRA)
     }


### PR DESCRIPTION
## Problem

Reported from retro32.com/bbs-copperline: if a visitor clicks Connect before the terminal ADF is up, the BBS greeting scrolls into a UART nobody is reading, and the visitor blind-presses Return at a login prompt they never saw - the BBS reads it as an empty name and starts the new-user flow. Investigation showed a second half: AROS raises CIA-B /DTR from ~1.0s to ~2.75s of boot *while streaming kernel debug out the serial port*, so an early-connected socket also forwards that chatter to the BBS as phantom keypresses.

## Fix

Model the connection on a modem watching its terminal's DTR line:

- `Cia::port_a_pins()` exposes physical port-A pin levels (outputs at their programmed level, inputs released high), with a unit test; the wasm build adds `WebEmu::serial_dtr()` - CIA-B PA7 driven low, the convention serial.device uses on OpenDevice and hardware-level terminals set themselves.
- `try.js` defers a telnet-mode dial until the line has **settled**: DTR asserted and no guest transmit, both held for a 3-second guard in **emulated** seconds. The AROS debug burst fails both conditions; a real terminal holds DTR silently and passes. Emulated time matters: in a throttled background tab a wall-clock guard fires inside the stretched transient (observed before the fix).
- A live session hangs up when the guest drops DTR (terminal exit, reboot, power cycle) before boot chatter can leak, then re-arms the deferred dial - rebooting the terminal disk reconnects by itself.
- Raw mode stays ungated; a wasm bundle older than `serial_dtr()` disengages the gate instead of waiting forever.

The companion terminal disk change (retro32-term asserting /DTR+/RTS when ready) is in LinuxJedi/retro32-term.

## Verification

- CIA-B DTR timeline mapped over a 30s AROS+terminal boot via the control protocol (`cia.get` at 0.25s steps): released at reset, AROS transient 1.00-2.75s, terminal assert at 13.75s.
- In-browser end-to-end against a scripted WebSocket fake BBS that greets on connect: connect-before-boot waits with zero server traffic; the dial lands at 16.9s emulated with the greeting rendered in ANSI colour on the terminal screen; a typed login round-trips (CR NUL NVT encoding intact); mid-session Reset hangs up cleanly (no chatter bytes leaked) and auto-reconnects on the next boot; a simulated throttled tab (setTimeout-clamped rAF, ~0.1x speed) holds the dial through the stretched AROS window for 60s+ where a wall-clock guard falsely dialled.
- `cargo test` (all targets), `cargo clippy`, `cargo fmt --check` clean; web crate checked for `wasm32-unknown-unknown`.
- docs/guide/browser.md updated (serial_dtr API + the gate's behavior).