### PR TITLE
web: page config file, two-button/CD32 joystick split, mouse pacing

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -202,6 +202,13 @@ pub struct WebEmu {
     /// first `run` call after (re)boot.
     anchor: Option<(f64, f64)>,
     mouse_remainder: (f64, f64),
+    /// Whole-pixel mouse motion not yet applied to the hardware counters.
+    /// The JOYxDAT counters are 8 bits and input.device samples them once
+    /// per vblank, so any burst past +/-127 counts in a frame reads back
+    /// as motion in the opposite direction. Browsers coalesce pointer
+    /// events (a fast flick can arrive as one huge delta), so the pool
+    /// re-spreads host input at a rate a physical mouse could produce.
+    mouse_pending: (i32, i32),
     /// Host side of Paula's serial port; the page bridges it to whatever
     /// byte stream it likes (typically a WebSocket to a telnet gateway).
     serial: ChannelSerialHandle,
@@ -236,6 +243,7 @@ impl WebEmu {
             last_rendered_frame: None,
             anchor: None,
             mouse_remainder: (0.0, 0.0),
+            mouse_pending: (0, 0),
             serial,
         })
     }
@@ -275,8 +283,14 @@ impl WebEmu {
         let target = anchor_emu + (now_ms - anchor_wall) / 1000.0;
         let mut stepped = 0u32;
         while self.emu.bus().emulated_seconds() < target && stepped < max_frames {
+            self.drain_pending_mouse();
             self.emu.step_frame().map_err(js_err)?;
             stepped += 1;
+        }
+        // Audio-saturated or already-on-target ticks step no frames; keep
+        // the pool draining so buffered motion cannot stall.
+        if stepped == 0 {
+            self.drain_pending_mouse();
         }
         if target - self.emu.bus().emulated_seconds() > MAX_CATCHUP_SECONDS {
             self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
@@ -403,8 +417,31 @@ impl WebEmu {
         self.mouse_remainder.1 += dy;
         let ix = take_integral_delta(&mut self.mouse_remainder.0);
         let iy = take_integral_delta(&mut self.mouse_remainder.1);
-        if ix != 0 || iy != 0 {
-            self.emu.bus_mut().input.add_mouse_delta(0, ix, iy);
+        // Into the pending pool, not the counters: `run` drains it a
+        // bounded amount per emulated frame (see `mouse_pending`).
+        self.mouse_pending.0 = self.mouse_pending.0.saturating_add(ix);
+        self.mouse_pending.1 = self.mouse_pending.1.saturating_add(iy);
+    }
+
+    /// Move at most one frame's worth of physically plausible mouse motion
+    /// from the pending pool into the hardware counters. 100 counts per
+    /// vblank sits under the 127-count wrap limit of the 8-bit JOYxDAT
+    /// counters with margin, and is still ~5000 counts/second - faster
+    /// than a hand can sweep a real mouse.
+    fn drain_pending_mouse(&mut self) {
+        const MAX_COUNTS_PER_FRAME: i32 = 100;
+        let dx = self
+            .mouse_pending
+            .0
+            .clamp(-MAX_COUNTS_PER_FRAME, MAX_COUNTS_PER_FRAME);
+        let dy = self
+            .mouse_pending
+            .1
+            .clamp(-MAX_COUNTS_PER_FRAME, MAX_COUNTS_PER_FRAME);
+        if dx != 0 || dy != 0 {
+            self.mouse_pending.0 -= dx;
+            self.mouse_pending.1 -= dy;
+            self.emu.bus_mut().input.add_mouse_delta(0, dx, dy);
         }
     }
 
@@ -553,6 +590,10 @@ impl WebEmu {
     pub fn reset(&mut self) -> Result<(), JsValue> {
         self.emu.power_on_reset().map_err(js_err)?;
         self.anchor = None;
+        // Motion buffered against the old machine must not replay into the
+        // fresh one.
+        self.mouse_remainder = (0.0, 0.0);
+        self.mouse_pending = (0, 0);
         Ok(())
     }
 

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -316,6 +316,7 @@ async function boot() {
     pendingDisk = null;
     machine.set_volume_percent(Number($('vol').value));
     if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
+    else if (configFloppySounds !== null) machine.set_floppy_sounds(configFloppySounds);
     if (floppySpeed !== null) machine.set_floppy_speed(floppySpeed);
     emu = machine;
     window.__emu = emu; // for debugging/automation
@@ -628,17 +629,22 @@ function pumpSerial() {
 }
 
 // --- joystick (port 2) -----------------------------------------------------
-// The toggle cycles off -> keys (-> touch on touch screens). Keys is the
-// desktop frontend's FS-UAE-compatible mapping plus left-hand fire keys:
-// cursor keys for directions, Right Ctrl / Right Alt or Left Ctrl for fire,
-// Left Alt for the second button (left-hand fire pairs with the right-hand
-// arrows, and compact keyboards often lack the right-side modifiers), CD32
-// extras on C/X/D/S/Enter/Z/A; while on, these keys drive the port-2
-// joystick instead of reaching the Amiga keyboard. Touch turns the canvas
-// into a pad (see the touch section). The page shell can preset the mode
-// (data-default on the toggle) and ?joy=off|keys|touch overrides per link.
+// The toggle cycles off -> keys -> cd32 (-> touch on touch screens). Keys
+// is a two-button stick, the desktop frontend's FS-UAE-compatible mapping
+// plus left-hand fire keys: cursor keys for directions, Right Ctrl /
+// Right Alt or Left Ctrl for fire, Left Alt for the second button
+// (left-hand fire pairs with the right-hand arrows, and compact keyboards
+// often lack the right-side modifiers). Cd32 adds the pad extras on
+// C/X/D/S/Enter/Z/A. The split matters for typing-heavy guests (a BBS
+// terminal): keys mode leaves Enter and the letters on the Amiga
+// keyboard, so only a CD32 title needs the full capture. While a mode is
+// on, its mapped keys drive the port-2 joystick instead of reaching the
+// Amiga keyboard. Touch turns the canvas into a pad (see the touch
+// section). The page shell can preset the mode (data-default on the
+// toggle, or the config file's "joy") and ?joy=off|keys|cd32|touch
+// overrides per link.
 
-const JOY_KEYS = {
+const JOY_KEYS_TWO_BUTTON = {
   ArrowUp: 'up',
   ArrowDown: 'down',
   ArrowLeft: 'left',
@@ -647,6 +653,9 @@ const JOY_KEYS = {
   AltRight: 'fireAlt',
   ControlLeft: 'fireLCtrl',
   AltLeft: 'blueLAlt',
+};
+const JOY_KEYS_CD32 = {
+  ...JOY_KEYS_TWO_BUTTON,
   KeyC: 'red',
   KeyX: 'blue',
   KeyD: 'green',
@@ -656,7 +665,7 @@ const JOY_KEYS = {
   KeyZ: 'rwd',
   KeyA: 'ffw',
 };
-const JOY_MODES = hasTouch ? ['off', 'keys', 'touch'] : ['off', 'keys'];
+const JOY_MODES = hasTouch ? ['off', 'keys', 'cd32', 'touch'] : ['off', 'keys', 'cd32'];
 let joyMode = 'off';
 const joyHeld = {};
 
@@ -675,8 +684,13 @@ function applyJoystick() {
 
 // Returns true when the key was captured for the joystick.
 function joystickKey(code, pressed) {
-  if (joyMode !== 'keys') return false;
-  const control = JOY_KEYS[code];
+  const map =
+    joyMode === 'keys'
+      ? JOY_KEYS_TWO_BUTTON
+      : joyMode === 'cd32'
+        ? JOY_KEYS_CD32
+        : null;
+  const control = map?.[code];
   if (!control) return false;
   joyHeld[control] = pressed;
   applyJoystick();
@@ -1176,6 +1190,9 @@ $('vol').addEventListener('input', (e) => {
 // Without the element the sounds stay on, as before; the checkbox's
 // initial state is applied at boot, so a shell can default them off.
 const floppySoundsToggle = $('floppy-sounds');
+// The config file's floppy_sounds on a shell without the checkbox: stashed
+// here and applied at boot.
+let configFloppySounds = null;
 floppySoundsToggle?.addEventListener('change', () => {
   if (emu) emu.set_floppy_sounds(floppySoundsToggle.checked);
 });
@@ -1618,28 +1635,98 @@ document.addEventListener('drop', (e) => {
 
 bootBtn.addEventListener('click', boot);
 const pageParams = new URLSearchParams(location.search);
-const linkedDisk = pageParams.get('df0');
-if (linkedDisk) insertDiskFromUrl(linkedDisk);
-const linkedKick = pageParams.get('kick');
-if (linkedKick) fitRomFromUrl(linkedKick);
 
-// Starting joystick mode: the page shell's default (data-default on the
-// toggle), overridden per link by ?joy=off|keys|touch. A touch request on
-// a screen without touch falls back to keys, so a game link written for
-// tablets still gets a joystick on a desktop.
-const requestedJoy = (pageParams.get('joy') ?? $('joy').dataset.default ?? '').trim();
-if (requestedJoy && requestedJoy !== joyMode) {
-  if (JOY_MODES.includes(requestedJoy)) setJoyMode(requestedJoy);
-  else if (requestedJoy === 'touch') setJoyMode('keys');
+// --- page configuration file ---------------------------------------------
+// Optional copperline.json next to the page: a site sets its defaults in
+// one hand-editable file instead of touching the shell or this glue. All
+// keys are optional; a missing or invalid file is simply no defaults.
+// Link parameters (?df0=, ?kick=, ?joy=, ?fdspeed=) override the file,
+// and anything the visitor changes by hand wins as usual.
+//
+//   {
+//     "kick": "roms/kick31.rom",     same-origin path, like ?kick=
+//     "df0": "adf/demo.adf",         URL, like ?df0=
+//     "floppy_sounds": false,        preset the drive-sounds toggle
+//     "floppy_speed": 800,           100|200|400|800|0 (0 = turbo)
+//     "joy": "keys",                 off|keys|cd32|touch
+//     "serial_url": "wss://...",     preset the BBS gateway input
+//     "serial_raw": true,            preset the raw checkbox
+//     "autoboot": true               power on once everything is loaded
+//   }
+async function fetchPageConfig() {
+  try {
+    const resp = await fetch('./copperline.json');
+    if (!resp.ok) return {};
+    const cfg = await resp.json();
+    return cfg && typeof cfg === 'object' && !Array.isArray(cfg) ? cfg : {};
+  } catch {
+    return {};
+  }
 }
 
-// Starting floppy speed: the speed select's initial value, overridden
-// per link by ?fdspeed=100|200|400|800|0|turbo. Applied to the machine
-// at boot.
-const requestedSpeed = (pageParams.get('fdspeed') ?? '').trim();
-if (requestedSpeed) {
-  setFloppySpeed(requestedSpeed === 'turbo' ? 0 : Number(requestedSpeed));
-} else {
-  setFloppySpeed(Number(floppySpeedSel.value));
+async function startup() {
+  // The wasm + AROS download starts immediately; the config fetch rides
+  // alongside and its choices land before anything needs them (a config
+  // Kickstart simply replaces the stashed boot ROM when it arrives).
+  const loaded = load();
+  const cfg = await fetchPageConfig();
+
+  if (serialUrlInput && typeof cfg.serial_url === 'string') {
+    serialUrlInput.value = cfg.serial_url;
+  }
+  if (serialRawToggle && typeof cfg.serial_raw === 'boolean') {
+    serialRawToggle.checked = cfg.serial_raw;
+  }
+  if (typeof cfg.floppy_sounds === 'boolean') {
+    if (floppySoundsToggle) floppySoundsToggle.checked = cfg.floppy_sounds;
+    else configFloppySounds = cfg.floppy_sounds;
+  }
+
+  const fetches = [];
+  const linkedDisk =
+    pageParams.get('df0') ?? (typeof cfg.df0 === 'string' ? cfg.df0 : null);
+  if (linkedDisk) fetches.push(insertDiskFromUrl(linkedDisk));
+  const linkedKick =
+    pageParams.get('kick') ?? (typeof cfg.kick === 'string' ? cfg.kick : null);
+  if (linkedKick) fetches.push(fitRomFromUrl(linkedKick));
+
+  // Starting joystick mode: the page shell's default (data-default on the
+  // toggle or the config file), overridden per link by
+  // ?joy=off|keys|cd32|touch. A touch request on a screen without touch
+  // falls back to keys, so a game link written for tablets still gets a
+  // joystick on a desktop.
+  const requestedJoy = (
+    pageParams.get('joy') ??
+    (typeof cfg.joy === 'string' ? cfg.joy : null) ??
+    $('joy').dataset.default ??
+    ''
+  ).trim();
+  if (requestedJoy && requestedJoy !== joyMode) {
+    if (JOY_MODES.includes(requestedJoy)) setJoyMode(requestedJoy);
+    else if (requestedJoy === 'touch') setJoyMode('keys');
+  }
+
+  // Starting floppy speed: the speed select's initial value, overridden by
+  // the config file and per link by ?fdspeed=100|200|400|800|0|turbo.
+  // Applied to the machine at boot.
+  const requestedSpeed = (
+    pageParams.get('fdspeed') ??
+    (typeof cfg.floppy_speed === 'number' ? String(cfg.floppy_speed) : '')
+  ).trim();
+  if (requestedSpeed) {
+    setFloppySpeed(requestedSpeed === 'turbo' ? 0 : Number(requestedSpeed));
+  } else {
+    setFloppySpeed(Number(floppySpeedSel.value));
+  }
+
+  // Autoboot: a page dedicated to one demo or the BBS can land straight in
+  // the machine. Waits for the ROM/disk choices above so the boot never
+  // races its own media; the boot button staying disabled (ROMs failed)
+  // vetoes it. Browsers keep audio locked until a real gesture - the
+  // existing unlock listeners pick that up.
+  if (cfg.autoboot === true) {
+    await Promise.all([loaded, ...fetches]);
+    if (!bootBtn.disabled && !emu) boot();
+  }
 }
-load();
+startup();

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -324,12 +324,15 @@ anything the visitor changes by hand wins as usual:
 }
 ```
 
-`kick` follows the same same-origin rule as `?kick=` (the file can only
-name a ROM the site already serves); `df0` is any URL the visitor's
-browser may fetch, like `?df0=`. `floppy_sounds`, `floppy_speed`,
-`serial_url` and `serial_raw` preset the matching controls (and apply
-even on a shell without the optional elements). `joy` picks the starting
-joystick mode. `autoboot: true` powers the machine on by itself once the
+`kick` follows the same-origin rule as `?kick=` (the file can only name
+a ROM the site already serves); `df0` is any URL the visitor's browser
+may fetch, like `?df0=`. `floppy_sounds` and `floppy_speed` reach the
+machine whether or not the shell has their controls -- the speed select
+inserts itself, and a configured `floppy_sounds` is applied at boot even
+with no checkbox to show it. `serial_url` and `serial_raw` preset the
+serial bridge's inputs and therefore need those elements: a shell
+without them has no connect button to dial with either. `joy` picks the
+starting joystick mode. `autoboot: true` powers the machine on by itself once the
 emulator, the ROM, and any configured disk have loaded -- the whole
 recipe for a page dedicated to one demo or a BBS: name the disk, set
 `autoboot`, and a visitor lands in the running machine. Browsers keep

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -61,16 +61,19 @@ Controls:
   requests pointer lock for relative motion (games), and Esc releases it.
 - **Keyboard**: physical keys map to Amiga raw keycodes with the same table
   as the desktop frontend.
-- **Joystick**: the toggle cycles off -> keys (-> touch on touch screens).
-  Keys is the desktop frontend's FS-UAE-compatible mapping -- cursor keys
-  for directions, Right Ctrl / Right Alt or Left Ctrl for fire, Left Alt
-  for the second button (the left-hand fire keys pair with the right-hand
-  arrows, and compact keyboards often lack the right-side modifiers), CD32
-  extras on C/X/D/S/Enter/Z/A -- and while enabled those keys are captured
-  from the Amiga keyboard, like the desktop toggle. A link can preset the
-  mode with `?joy=keys` (or `off`/`touch`), so a game URL starts with the
-  joystick already on; `touch` falls back to `keys` on screens without
-  touch.
+- **Joystick**: the toggle cycles off -> keys -> cd32 (-> touch on touch
+  screens). Keys is a two-button stick, the desktop frontend's
+  FS-UAE-compatible mapping -- cursor keys for directions, Right Ctrl /
+  Right Alt or Left Ctrl for fire, Left Alt for the second button (the
+  left-hand fire keys pair with the right-hand arrows, and compact
+  keyboards often lack the right-side modifiers). Cd32 adds the pad
+  extras on C/X/D/S/Enter/Z/A. While a mode is enabled its mapped keys
+  are captured from the Amiga keyboard, like the desktop toggle -- the
+  two-mode split exists so a typing-heavy guest (a BBS terminal) keeps
+  Enter and the letters on the keyboard in keys mode, and only a CD32
+  title captures them. A link can preset the mode with `?joy=keys` (or
+  `off`/`cd32`/`touch`), so a game URL starts with the joystick already
+  on; `touch` falls back to `keys` on screens without touch.
 - **Touch**: the canvas works like a trackpad, because the Amiga pointer
   only takes relative motion and an absolute finger position cannot map to
   it. One finger drags the pointer, a quick tap left-clicks, holding still
@@ -208,7 +211,11 @@ function tick(nowMs) {
 
 Input goes through `key_event(event.code, pressed)` (returns whether the key
 mapped, for `preventDefault`), `mouse_delta(dx, dy)` and
-`mouse_button(button, pressed)`; `set_joystick_port2(...)` and
+`mouse_button(button, pressed)`. Mouse motion is pooled and fed to the
+hardware counters at a physically plausible rate (at most 100 counts per
+emulated frame): browsers coalesce pointer events, and a fast flick
+delivered as one huge delta would wrap the 8-bit JOYxDAT counters and
+read back as motion in the wrong direction. `set_joystick_port2(...)` and
 `set_cd32_buttons_port2(...)` drive a port-2 pad, which the hosted page
 feeds from the desktop frontend's FS-UAE-compatible keyboard mapping
 (cursor keys, Right Ctrl / Right Alt fire, CD32 extras on C/X/D/S/Enter/Z/A).
@@ -290,10 +297,44 @@ elements, and pages without them are untouched:
   outer styling. Without it the strip inserts itself directly below the
   canvas shell. Either way it fills in once a machine boots.
 - `data-default="keys"` on the `#joy` toggle: the joystick mode the page
-  starts in (`?joy=` in the URL overrides it).
+  starts in -- `off`, `keys`, `cd32`, or `touch` (the config file's
+  `joy` and then `?joy=` in the URL override it).
 - `#serial-url`, `#serial-connect`, `#serial-status`, `#serial-raw`: the
   serial/BBS bridge, described in
   [the serial bridge section](#browser-serial-bridge).
+
+### The page configuration file
+
+A site can set its defaults in one hand-editable file instead of editing
+the shell: `copperline.json`, served next to the page. Every key is
+optional, a missing or invalid file means no defaults, link parameters
+(`?df0=`, `?kick=`, `?joy=`, `?fdspeed=`) override the file per URL, and
+anything the visitor changes by hand wins as usual:
+
+```json
+{
+  "kick": "roms/kick31.rom",
+  "df0": "adf/demo.adf",
+  "floppy_sounds": false,
+  "floppy_speed": 800,
+  "joy": "keys",
+  "serial_url": "wss://bbs.example.com:8443/",
+  "serial_raw": false,
+  "autoboot": true
+}
+```
+
+`kick` follows the same same-origin rule as `?kick=` (the file can only
+name a ROM the site already serves); `df0` is any URL the visitor's
+browser may fetch, like `?df0=`. `floppy_sounds`, `floppy_speed`,
+`serial_url` and `serial_raw` preset the matching controls (and apply
+even on a shell without the optional elements). `joy` picks the starting
+joystick mode. `autoboot: true` powers the machine on by itself once the
+emulator, the ROM, and any configured disk have loaded -- the whole
+recipe for a page dedicated to one demo or a BBS: name the disk, set
+`autoboot`, and a visitor lands in the running machine. Browsers keep
+audio suspended until the first real click or keypress; the page unlocks
+it on that gesture.
 
 (browser-serial-bridge)=
 ## The serial port: dialling a BBS from a browser


### PR DESCRIPTION
Three follow-ups requested for the retro32.com BBS page.

## copperline.json page configuration file

An optional `copperline.json` next to the page sets site defaults in one hand-editable file: `kick`, `df0`, `floppy_sounds`, `floppy_speed`, `joy`, `serial_url`, `serial_raw`, `autoboot`. Precedence is link parameters > config file > page HTML presets, and visitor changes win as usual. `autoboot` awaits the config's own ROM/disk fetches before powering on, so it can never boot ahead of its media; the boot button staying disabled (ROM load failure) vetoes it. `kick` goes through the existing same-origin copyright gate.

## Two-button vs CD32 keyboard joystick

The joystick toggle now cycles off -> keys -> cd32 (-> touch). `keys` is a plain two-button stick (arrows, Right Ctrl / Right Alt or Left Ctrl fire, Left Alt button 2); `cd32` adds the pad extras on C/X/D/S/Enter/Z/A. Motivation: the old single mapping captured Enter and the letters whenever the joystick was on, which made a BBS terminal unusable without toggling the stick off. `?joy=` and `data-default` accept `cd32`; `touch` still falls back to `keys` on non-touch screens.

## Mouse pacing (fast-flick glitch)

Browsers coalesce pointer events, so a fast flick arrives as one delta beyond +/-127 counts and wrapped Paula's 8-bit JOYxDAT counters within a single vblank poll -- input.device read the wrap as motion in the wrong direction (reported as 'the mouse glitches out when moved fast'). `WebEmu` now pools whole-pixel motion and drains at most 100 counts per emulated frame into the counters: under the wrap limit with margin, ~5000 counts/second throughput (faster than a hand can sweep a real mouse), cleared on `reset()` so buffered motion cannot replay into a fresh machine. The desktop frontend applies raw per-event deltas (much smaller per event, so unreported) and could get the same treatment as a follow-up.

## Verification

- In-browser against a scripted fake BBS: a config file with `df0` + `joy` + `serial_url` + `autoboot` lands in a booted machine with the disk inserted and the gateway prefilled; typing `bbs` + Return with joy=keys reaches the BBS (previously 's' and Enter were captured as pad buttons) while cd32 mode captures Enter as play; on a KS2.05 boot a +300,+120 delta in one event travels fully and -280,-100 returns correctly (previously +44 and -24 with direction loss).
- `cargo test` (1668 lib tests), `cargo clippy`, `cargo fmt --check` clean; web crate checked and clippy-clean for `wasm32-unknown-unknown`; `node --check` on try.js.
- docs/guide/browser.md updated: configuration-file section, joystick modes, mouse pacing note.

Companion terminal-disk change (hidden kiosk pointer) is in LinuxJedi/retro32-term.