### PR TITLE
web: gamepads in both ports, pause, and screenshot to clipboard

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -167,8 +167,8 @@ fn w3c_code_to_amiga_rawkey(code: &str) -> Option<u8> {
     })
 }
 
-/// Page-facing port number (1 or 2) to the core's index convention, where 0
-/// selects port 1 and anything else port 2.
+/// Map a page-facing port number to the core's port index: `1` selects the
+/// mouse/port-1 socket (index 0) and any other value port 2 (index 1).
 fn port_index(port: u8) -> usize {
     usize::from(port != 1)
 }
@@ -480,10 +480,15 @@ impl WebEmu {
         fire: bool,
         button2: bool,
     ) {
-        self.emu
-            .bus_mut()
-            .input
-            .set_joystick(port_index(port), up, down, left, right, fire, button2);
+        self.emu.bus_mut().input.set_joystick(
+            port_index(port),
+            up,
+            down,
+            left,
+            right,
+            fire,
+            button2,
+        );
     }
 
     /// The CD32 pad's extra buttons on either port (red/blue arrive through

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use copperline::audio::AudioSink;
+use copperline::bus::PortDevice;
 use copperline::config::{Config, Overscan};
 use copperline::emulator::{build_machine, Emulator};
 use copperline::serial::{ChannelSerialHandle, ChannelSerialSink};
@@ -164,6 +165,12 @@ fn w3c_code_to_amiga_rawkey(code: &str) -> Option<u8> {
         "NumpadParenRight" => 0x5B,
         _ => return None,
     })
+}
+
+/// Page-facing port number (1 or 2) to the core's index convention, where 0
+/// selects port 1 and anything else port 2.
+fn port_index(port: u8) -> usize {
+    usize::from(port != 1)
 }
 
 /// Mirrors the desktop frontend's fractional mouse-delta accumulator
@@ -456,12 +463,16 @@ impl WebEmu {
         }
     }
 
-    /// Port-2 digital joystick state (the page's keyboard-joystick mapping,
-    /// or a Gamepad API bridge). Marks port 2 as a joystick; `fire` is the
-    /// red/primary button, `button2` the blue/second button.
+    /// Digital joystick state for either port (1 or 2): the page's
+    /// keyboard-joystick mapping, or a Gamepad API bridge. Marks the port as
+    /// a joystick, which is what makes two-player work -- a second pad takes
+    /// port 1, exactly like unplugging the mouse to plug a stick in. `fire`
+    /// is the red/primary button, `button2` the blue/second button. Any port
+    /// number other than 1 means port 2, matching the core's convention.
     #[allow(clippy::too_many_arguments)]
-    pub fn set_joystick_port2(
+    pub fn set_joystick_port(
         &mut self,
+        port: u8,
         up: bool,
         down: bool,
         left: bool,
@@ -472,13 +483,14 @@ impl WebEmu {
         self.emu
             .bus_mut()
             .input
-            .set_joystick(1, up, down, left, right, fire, button2);
+            .set_joystick(port_index(port), up, down, left, right, fire, button2);
     }
 
-    /// The CD32 pad's extra buttons on port 2 (red/blue arrive through
-    /// `set_joystick_port2` as fire/button2).
-    pub fn set_cd32_buttons_port2(
+    /// The CD32 pad's extra buttons on either port (red/blue arrive through
+    /// `set_joystick_port` as fire/button2).
+    pub fn set_cd32_buttons_port(
         &mut self,
+        port: u8,
         play: bool,
         rwd: bool,
         ffw: bool,
@@ -488,7 +500,48 @@ impl WebEmu {
         self.emu
             .bus_mut()
             .input
-            .set_cd32_buttons(1, play, rwd, ffw, green, yellow);
+            .set_cd32_buttons(port_index(port), play, rwd, ffw, green, yellow);
+    }
+
+    /// Plug a device into a port: "mouse", "joystick", "cd32", "analogue",
+    /// or "none". Unplugging releases every line the old device drove, so a
+    /// page whose gamepad goes away restores the mouse on port 1 with
+    /// `set_port_device(1, "mouse")` rather than leaving a stuck stick.
+    /// Unknown names are ignored.
+    pub fn set_port_device(&mut self, port: u8, device: &str) {
+        if let Some(device) = PortDevice::parse(device) {
+            self.emu
+                .bus_mut()
+                .input
+                .set_port_device(port_index(port), device);
+        }
+    }
+
+    /// Port-2 joystick state. Superseded by `set_joystick_port`, kept
+    /// because it is the published page-glue API.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_joystick_port2(
+        &mut self,
+        up: bool,
+        down: bool,
+        left: bool,
+        right: bool,
+        fire: bool,
+        button2: bool,
+    ) {
+        self.set_joystick_port(2, up, down, left, right, fire, button2);
+    }
+
+    /// Port-2 CD32 buttons. Superseded by `set_cd32_buttons_port`.
+    pub fn set_cd32_buttons_port2(
+        &mut self,
+        play: bool,
+        rwd: bool,
+        ffw: bool,
+        green: bool,
+        yellow: bool,
+    ) {
+        self.set_cd32_buttons_port(2, play, rwd, ffw, green, yellow);
     }
 
     /// Insert a floppy image (ADF/ADZ/DMS/extended ADF, optionally
@@ -595,6 +648,15 @@ impl WebEmu {
         self.mouse_remainder = (0.0, 0.0);
         self.mouse_pending = (0, 0);
         Ok(())
+    }
+
+    /// Forget the wall-clock/emulated-time pairing, so the next `run` starts
+    /// pacing from now instead of trying to make up the gap. A page calls
+    /// this when resuming from a pause: without it the first tick after the
+    /// pause sees a wall clock that ran on while the guest did not, and
+    /// sprints through frames until the catch-up clamp trips.
+    pub fn resync_clock(&mut self) {
+        self.anchor = None;
     }
 
     pub fn set_volume_percent(&mut self, percent: u8) {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -46,6 +46,7 @@ let audioCtx = null;
 let audioNode = null;
 let queuedMs = 0;
 let running = false;
+let paused = false;
 let framesThisSecond = 0;
 let lastStatUpdate = 0;
 
@@ -334,6 +335,9 @@ async function boot() {
     overlay.style.display = 'none';
     showBugLink(false);
     running = true;
+    // A reboot from a paused machine must not start the new one paused.
+    paused = false;
+    setPauseLabel();
     requestAnimationFrame(tick);
   } catch (e) {
     setLoadStatus(`boot failed: ${e.message ?? e}`);
@@ -356,6 +360,10 @@ function maxFramesForQueue() {
 
 function tick(nowMs) {
   if (!running) return;
+  if (paused) return; // resumePause() restarts the loop
+  // Polled, not event-driven: the Gamepad API reports button state only
+  // when asked, so this is where a controller reaches the machine.
+  pumpGamepads();
   try {
     framesThisSecond += emu.run(nowMs, maxFramesForQueue());
   } catch (e) {
@@ -669,17 +677,87 @@ const JOY_MODES = hasTouch ? ['off', 'keys', 'cd32', 'touch'] : ['off', 'keys', 
 let joyMode = 'off';
 const joyHeld = {};
 
-function applyJoystick() {
+// Port state each input source contributes. The keyboard mapping and the
+// touch pad always drive port 2 (the Amiga's joystick port); gamepads fill
+// port 2 first and port 1 second (see the gamepad section). Sources on the
+// same port are OR-ed rather than one silencing the other, so a pad and
+// the keyboard can both be live without either going dead mid-game.
+const EMPTY_PAD = {
+  up: false,
+  down: false,
+  left: false,
+  right: false,
+  fire: false,
+  button2: false,
+  play: false,
+  rwd: false,
+  ffw: false,
+  green: false,
+  yellow: false,
+};
+const padPort = { 1: null, 2: null }; // gamepad-sourced state per Amiga port
+
+// The touch pad's stick and fire button, when the canvas is in pad mode.
+// Declared before the touch section that fills these in; hoisting makes
+// that safe, and keeping every port source in one merge is worth it.
+function touchPortState() {
+  if (joyMode !== 'touch') return null;
+  return {
+    ...EMPTY_PAD,
+    up: stickDirs.up,
+    down: stickDirs.down,
+    left: stickDirs.left,
+    right: stickDirs.right,
+    fire: fireTouchId !== null,
+  };
+}
+
+function keyboardPortState() {
   const h = joyHeld;
-  emu.set_joystick_port2(
-    !!h.up,
-    !!h.down,
-    !!h.left,
-    !!h.right,
-    !!(h.fireCtrl || h.fireAlt || h.fireLCtrl || h.red),
-    !!(h.blue || h.blueLAlt),
-  );
-  emu.set_cd32_buttons_port2(!!h.play, !!h.rwd, !!h.ffw, !!h.green, !!h.yellow);
+  return {
+    up: !!h.up,
+    down: !!h.down,
+    left: !!h.left,
+    right: !!h.right,
+    fire: !!(h.fireCtrl || h.fireAlt || h.fireLCtrl || h.red),
+    button2: !!(h.blue || h.blueLAlt),
+    play: !!h.play,
+    rwd: !!h.rwd,
+    ffw: !!h.ffw,
+    green: !!h.green,
+    yellow: !!h.yellow,
+  };
+}
+
+function orPortState(a, b) {
+  if (!a) return b ?? EMPTY_PAD;
+  if (!b) return a;
+  const out = {};
+  for (const k of Object.keys(EMPTY_PAD)) out[k] = a[k] || b[k];
+  return out;
+}
+
+// Push both ports' merged state into the machine. Port 1 is only touched
+// while a gamepad holds it, so a mouse-only session never has its port 1
+// switched away from the mouse.
+function applyJoystick() {
+  if (!emu) return;
+  const port2 = orPortState(orPortState(keyboardPortState(), touchPortState()), padPort[2]);
+  emu.set_joystick_port(2, port2.up, port2.down, port2.left, port2.right, port2.fire, port2.button2);
+  emu.set_cd32_buttons_port(2, port2.play, port2.rwd, port2.ffw, port2.green, port2.yellow);
+  const port1 = padPort[1];
+  if (port1) {
+    emu.set_joystick_port(
+      1,
+      port1.up,
+      port1.down,
+      port1.left,
+      port1.right,
+      port1.fire,
+      port1.button2,
+    );
+    emu.set_cd32_buttons_port(1, port1.play, port1.rwd, port1.ffw, port1.green, port1.yellow);
+  }
 }
 
 // Returns true when the key was captured for the joystick.
@@ -703,10 +781,7 @@ function setJoyMode(mode) {
   if (fsUi) fsUi.joy.textContent = `Joystick: ${joyMode}`;
   for (const k of Object.keys(joyHeld)) joyHeld[k] = false;
   resetTouchState();
-  if (emu) {
-    applyJoystick();
-    emu.set_cd32_buttons_port2(false, false, false, false, false);
-  }
+  applyJoystick();
 }
 
 // Cycles the mode; wired to the control-bar button and to the fullscreen
@@ -716,6 +791,104 @@ function cycleJoyMode() {
 }
 
 $('joy').addEventListener('click', cycleJoyMode);
+
+// --- gamepads (USB / Bluetooth controllers) --------------------------------
+// Real controllers need no toggle: the Gamepad API has no events for
+// button state, so the frame loop polls it and whatever is plugged in
+// drives a port. The first pad takes port 2 (where an Amiga game looks for
+// its joystick), the second takes port 1 -- which is two-player, and is
+// also literally what the hardware does: plugging a stick into port 1
+// means the mouse is not there any more. When a pad on port 1 goes away
+// the mouse is plugged back in, so the pointer never stays dead.
+//
+// Sticks and d-pads both steer, so the same pad works whichever a game
+// expects. The face buttons follow the CD32 pad, which is a superset of a
+// two-button stick: A fires (red), B is button 2 (blue), X/Y are
+// green/yellow, the shoulders are rewind/forward, Start is play. A plain
+// joystick guest only ever sees fire and button 2; the rest exist for
+// CD32 titles and cost nothing when unused.
+
+const PAD_AXIS_THRESHOLD = 0.5; // analogue stick deflection that counts
+const padAssignments = new Map(); // gamepad index -> Amiga port (2 first)
+
+function padPressed(pad, index) {
+  const b = pad.buttons[index];
+  if (!b) return false;
+  return typeof b === 'object' ? b.pressed || b.value > 0.5 : b > 0.5;
+}
+
+function readPad(pad) {
+  const axis = (i) => (typeof pad.axes[i] === 'number' ? pad.axes[i] : 0);
+  return {
+    up: padPressed(pad, 12) || axis(1) <= -PAD_AXIS_THRESHOLD,
+    down: padPressed(pad, 13) || axis(1) >= PAD_AXIS_THRESHOLD,
+    left: padPressed(pad, 14) || axis(0) <= -PAD_AXIS_THRESHOLD,
+    right: padPressed(pad, 15) || axis(0) >= PAD_AXIS_THRESHOLD,
+    fire: padPressed(pad, 0),
+    button2: padPressed(pad, 1),
+    green: padPressed(pad, 2),
+    yellow: padPressed(pad, 3),
+    rwd: padPressed(pad, 4),
+    ffw: padPressed(pad, 5),
+    play: padPressed(pad, 9),
+  };
+}
+
+// Assign connected pads to ports and drop assignments for pads that went
+// away. Returns true when the mapping changed, so the caller can report it.
+function refreshPadAssignments(pads) {
+  let changed = false;
+  for (const index of [...padAssignments.keys()]) {
+    if (!pads[index]) {
+      const port = padAssignments.get(index);
+      padAssignments.delete(index);
+      padPort[port] = null;
+      // Port 1 belongs to the mouse when no pad holds it; port 2 keeps its
+      // (now idle) joystick, which is the machine's normal fitting.
+      if (port === 1 && emu) emu.set_port_device(1, 'mouse');
+      changed = true;
+    }
+  }
+  for (const pad of pads) {
+    if (!pad || padAssignments.has(pad.index)) continue;
+    const taken = new Set(padAssignments.values());
+    const port = !taken.has(2) ? 2 : !taken.has(1) ? 1 : null;
+    if (port === null) continue; // a third pad has nowhere to go
+    padAssignments.set(pad.index, port);
+    changed = true;
+  }
+  return changed;
+}
+
+function pumpGamepads() {
+  if (!navigator.getGamepads) return;
+  const pads = navigator.getGamepads();
+  const anyConnected = [...pads].some((p) => p);
+  if (!anyConnected && padAssignments.size === 0) return;
+  const changed = refreshPadAssignments(pads);
+  for (const [index, port] of padAssignments) {
+    const pad = pads[index];
+    if (pad) padPort[port] = readPad(pad);
+  }
+  applyJoystick();
+  if (changed) updatePadStatus();
+}
+
+// A pad is invisible until the browser reports it, and the assignment is
+// not something the visitor chose, so say which port each one landed on.
+function updatePadStatus() {
+  if (padAssignments.size === 0) {
+    setLoadStatus('gamepad disconnected - mouse restored on port 1');
+    return;
+  }
+  const where = [...padAssignments.values()]
+    .sort()
+    .map((port) => `port ${port}`)
+    .join(' + ');
+  setLoadStatus(
+    `gamepad ready: ${where}` + (padAssignments.size > 1 ? ' (two players)' : ''),
+  );
+}
 
 // --- keyboard ------------------------------------------------------------
 
@@ -815,14 +988,7 @@ function resetTouchState() {
 }
 
 function applyTouchJoystick() {
-  emu.set_joystick_port2(
-    stickDirs.up,
-    stickDirs.down,
-    stickDirs.left,
-    stickDirs.right,
-    fireTouchId !== null,
-    false,
-  );
+  applyJoystick(); // the touch pad is one more port-2 source; see the merge
 }
 
 canvas.addEventListener(
@@ -1116,10 +1282,12 @@ function ensureFsUi() {
   };
   const joy = mk(`Joystick: ${joyMode}`);
   joy.addEventListener('click', cycleJoyMode);
+  const pause = mk(paused ? 'Resume' : 'Pause');
+  pause.addEventListener('click', togglePause);
   const exit = mk('Exit');
   exit.addEventListener('click', exitFullscreen);
   shell.appendChild(bar);
-  fsUi = { bar, joy };
+  fsUi = { bar, joy, pause };
   return fsUi;
 }
 
@@ -1130,6 +1298,7 @@ function updateFsUi() {
   }
   const ui = ensureFsUi();
   ui.joy.textContent = `Joystick: ${joyMode}`;
+  ui.pause.textContent = paused ? 'Resume' : 'Pause';
   ui.bar.style.display = 'flex';
 }
 
@@ -1184,6 +1353,109 @@ document.addEventListener('fullscreenchange', updateFsUi);
 $('vol').addEventListener('input', (e) => {
   if (emu) emu.set_volume_percent(Number(e.target.value));
 });
+
+// --- pause / screenshot ----------------------------------------------------
+// Two machine controls that belong on every shell, so they follow the
+// floppy-speed pattern: a page can host its own #pause / #screenshot
+// buttons wherever its control bar wants them, and without those elements
+// the controls insert themselves below the canvas.
+//
+// Pause stops the emulated clock rather than the page: the frame loop
+// stops stepping, audio is suspended so the last buffer does not loop,
+// and resuming resyncs the pacer's wall-clock anchor (otherwise the first
+// tick back would sprint through every frame the pause "owed").
+
+function setPauseLabel() {
+  const label = paused ? 'Resume' : 'Pause';
+  if (pauseBtn) pauseBtn.textContent = label;
+  if (fsUi) fsUi.pause.textContent = label;
+}
+
+function setPaused(next) {
+  if (!emu || !running || next === paused) return;
+  paused = next;
+  setPauseLabel();
+  if (paused) {
+    audioCtx?.suspend().catch(() => {});
+    setLoadStatus('paused');
+  } else {
+    audioCtx?.resume().catch(() => {});
+    // Nothing elapsed for the guest while paused; start pacing from now.
+    emu.resync_clock?.();
+    setLoadStatus('running');
+    requestAnimationFrame(tick);
+  }
+}
+
+function togglePause() {
+  setPaused(!paused);
+}
+
+// The canvas already holds exactly what the screen shows, so a screenshot
+// is the canvas itself. Clipboard first (what was asked for), with a file
+// download as the fallback: clipboard image writes need a secure context
+// and browser support, and Firefox has neither for ClipboardItem in all
+// versions. Both paths are driven from a click, which is the user gesture
+// the clipboard API requires.
+async function copyScreenshot() {
+  if (!emu || !running) return;
+  const blobOf = () =>
+    new Promise((resolve, reject) => {
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('canvas capture failed'))), 'image/png');
+    });
+  try {
+    if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
+      throw new Error('clipboard images unsupported');
+    }
+    // Safari requires the ClipboardItem to be constructed with the promise
+    // inside the gesture; Chrome and Firefox accept that form too.
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blobOf() })]);
+    setLoadStatus('screenshot copied to the clipboard');
+  } catch (e) {
+    try {
+      const url = URL.createObjectURL(await blobOf());
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `copperline-${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setLoadStatus(`screenshot downloaded (clipboard unavailable: ${e.message ?? e})`);
+    } catch (err) {
+      setLoadStatus(`screenshot failed: ${err.message ?? err}`);
+    }
+  }
+}
+
+// Build whichever of the two the shell did not provide, in one row that
+// matches the self-inserted floppy-speed control's styling. Listeners are
+// attached afterwards, once, so a shell-provided and a self-built button
+// take exactly the same path.
+function buildMachineControls() {
+  const missing = [
+    ['pause', 'Pause'],
+    ['screenshot', 'Screenshot'],
+  ].filter(([id]) => !$(id));
+  if (missing.length === 0) return;
+  const row = document.createElement('div');
+  row.style.cssText = 'display:inline-flex;align-items:center;gap:0.45rem;margin:0.4rem 0.6rem 0.4rem 0;';
+  for (const [id, label] of missing) {
+    const b = document.createElement('button');
+    b.id = id;
+    b.textContent = label;
+    b.style.cssText =
+      'padding:0.25rem 0.7rem;border-radius:6px;cursor:pointer;' +
+      'border:1px solid rgba(255,255,255,0.35);' +
+      'background:rgba(10,13,22,0.6);color:rgba(255,255,255,0.85);' +
+      'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;';
+    row.appendChild(b);
+  }
+  shell.insertAdjacentElement('afterend', row);
+}
+buildMachineControls();
+const pauseBtn = $('pause');
+const screenshotBtn = $('screenshot');
+pauseBtn?.addEventListener('click', togglePause);
+screenshotBtn?.addEventListener('click', copyScreenshot);
 
 // Optional in the page shell: a checkbox #floppy-sounds toggles the
 // synthesized drive sounds (motor hum, head-step clicks, read hiss).

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -338,6 +338,10 @@ async function boot() {
     // A reboot from a paused machine must not start the new one paused.
     paused = false;
     setPauseLabel();
+    // Port fittings live on the machine, so a fresh one needs the pads
+    // that are still plugged into the host put back.
+    for (const port of padAssignments.values()) fitCd32Pad(port);
+    if (joyMode === 'cd32') fitCd32Pad(2);
     requestAnimationFrame(tick);
   } catch (e) {
     setLoadStatus(`boot failed: ${e.message ?? e}`);
@@ -781,6 +785,9 @@ function setJoyMode(mode) {
   if (fsUi) fsUi.joy.textContent = `Joystick: ${joyMode}`;
   for (const k of Object.keys(joyHeld)) joyHeld[k] = false;
   resetTouchState();
+  // The cd32 mapping's extra buttons only reach a guest through a fitted
+  // CD32 pad; the plain modes leave whatever is in the port alone.
+  if (joyMode === 'cd32') fitCd32Pad(2);
   applyJoystick();
 }
 
@@ -811,6 +818,17 @@ $('joy').addEventListener('click', cycleJoyMode);
 const PAD_AXIS_THRESHOLD = 0.5; // analogue stick deflection that counts
 const padAssignments = new Map(); // gamepad index -> Amiga port (2 first)
 
+// A port only reports the CD32 pad's extra buttons while a CD32 pad is
+// what is plugged into it: the core runs the pad's shift register for
+// PortDevice::Cd32Pad alone, so on a plain joystick those buttons exist
+// but nothing can read them. Fitting the pad costs nothing elsewhere --
+// outside the serial mode a CD32-aware game selects through POTGO, a pad
+// reads exactly like a two-button stick -- so any source that can produce
+// the extras (a gamepad, or the keyboard's cd32 mapping) fits one.
+function fitCd32Pad(port) {
+  emu?.set_port_device(port, 'cd32');
+}
+
 function padPressed(pad, index) {
   const b = pad.buttons[index];
   if (!b) return false;
@@ -835,17 +853,23 @@ function readPad(pad) {
 }
 
 // Assign connected pads to ports and drop assignments for pads that went
-// away. Returns true when the mapping changed, so the caller can report it.
+// away. Returns what changed, so the caller can report it accurately.
 function refreshPadAssignments(pads) {
   let changed = false;
+  let releasedPort1 = false;
   for (const index of [...padAssignments.keys()]) {
     if (!pads[index]) {
       const port = padAssignments.get(index);
       padAssignments.delete(index);
       padPort[port] = null;
-      // Port 1 belongs to the mouse when no pad holds it; port 2 keeps its
-      // (now idle) joystick, which is the machine's normal fitting.
-      if (port === 1 && emu) emu.set_port_device(1, 'mouse');
+      // Port 1 is the mouse socket on every machine this build boots, so
+      // a pad leaving it puts the mouse back; port 2 keeps the pad fitting
+      // (idle, and indistinguishable from a joystick to anything that is
+      // not driving the CD32 serial protocol).
+      if (port === 1 && emu) {
+        emu.set_port_device(1, 'mouse');
+        releasedPort1 = true;
+      }
       changed = true;
     }
   }
@@ -855,9 +879,10 @@ function refreshPadAssignments(pads) {
     const port = !taken.has(2) ? 2 : !taken.has(1) ? 1 : null;
     if (port === null) continue; // a third pad has nowhere to go
     padAssignments.set(pad.index, port);
+    fitCd32Pad(port); // a real pad has the extra buttons; let them count
     changed = true;
   }
-  return changed;
+  return { changed, releasedPort1 };
 }
 
 function pumpGamepads() {
@@ -865,28 +890,33 @@ function pumpGamepads() {
   const pads = navigator.getGamepads();
   const anyConnected = [...pads].some((p) => p);
   if (!anyConnected && padAssignments.size === 0) return;
-  const changed = refreshPadAssignments(pads);
+  const { changed, releasedPort1 } = refreshPadAssignments(pads);
   for (const [index, port] of padAssignments) {
     const pad = pads[index];
     if (pad) padPort[port] = readPad(pad);
   }
   applyJoystick();
-  if (changed) updatePadStatus();
+  if (changed) updatePadStatus(releasedPort1);
 }
 
 // A pad is invisible until the browser reports it, and the assignment is
 // not something the visitor chose, so say which port each one landed on.
-function updatePadStatus() {
-  if (padAssignments.size === 0) {
-    setLoadStatus('gamepad disconnected - mouse restored on port 1');
-    return;
-  }
+// The mouse is only worth mentioning when a pad actually vacated port 1,
+// which is the only case where the pointer was displaced.
+function updatePadStatus(releasedPort1) {
   const where = [...padAssignments.values()]
     .sort()
     .map((port) => `port ${port}`)
     .join(' + ');
+  const mouse = releasedPort1 ? ' - mouse restored on port 1' : '';
+  if (padAssignments.size === 0) {
+    setLoadStatus(`gamepad disconnected${mouse}`);
+    return;
+  }
   setLoadStatus(
-    `gamepad ready: ${where}` + (padAssignments.size > 1 ? ' (two players)' : ''),
+    `gamepad ready: ${where}` +
+      (padAssignments.size > 1 ? ' (two players)' : '') +
+      mouse,
   );
 }
 
@@ -1418,7 +1448,9 @@ async function copyScreenshot() {
       a.href = url;
       a.download = `copperline-${new Date().toISOString().replace(/[:.]/g, '-')}.png`;
       a.click();
-      URL.revokeObjectURL(url);
+      // Revoking synchronously can cancel the download that click just
+      // started; let the current task finish first.
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
       setLoadStatus(`screenshot downloaded (clipboard unavailable: ${e.message ?? e})`);
     } catch (err) {
       setLoadStatus(`screenshot failed: ${err.message ?? err}`);

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -74,6 +74,18 @@ Controls:
   title captures them. A link can preset the mode with `?joy=keys` (or
   `off`/`cd32`/`touch`), so a game URL starts with the joystick already
   on; `touch` falls back to `keys` on screens without touch.
+- **Gamepads**: a USB or Bluetooth controller needs no toggle -- the page
+  polls the Gamepad API every frame and whatever is plugged in drives a
+  port. The first pad takes port 2 (where a game looks for its joystick),
+  a second pad takes port 1, which is two-player. Claiming port 1 also
+  displaces the mouse, exactly as plugging a stick into that socket does
+  on real hardware; unplugging the pad plugs the mouse back in. Sticks
+  and d-pads both steer. The face buttons follow the CD32 pad, a superset
+  of a two-button stick: A fires (red), B is button 2 (blue), X and Y are
+  green and yellow, the shoulders are rewind and forward, Start is play --
+  a plain joystick guest only ever sees fire and button 2. Browsers hide
+  gamepads until the page has seen a real interaction, so the first
+  button press after loading may be the one that makes a pad appear.
 - **Touch**: the canvas works like a trackpad, because the Amiga pointer
   only takes relative motion and an absolute finger position cannot map to
   it. One finger drags the pointer, a quick tap left-clicks, holding still
@@ -215,11 +227,19 @@ mapped, for `preventDefault`), `mouse_delta(dx, dy)` and
 hardware counters at a physically plausible rate (at most 100 counts per
 emulated frame): browsers coalesce pointer events, and a fast flick
 delivered as one huge delta would wrap the 8-bit JOYxDAT counters and
-read back as motion in the wrong direction. `set_joystick_port2(...)` and
-`set_cd32_buttons_port2(...)` drive a port-2 pad, which the hosted page
-feeds from the desktop frontend's FS-UAE-compatible keyboard mapping
-(cursor keys, Right Ctrl / Right Alt fire, CD32 extras on C/X/D/S/Enter/Z/A).
-`reset()` power-cycles, `eject_floppy(n)`
+read back as motion in the wrong direction. `set_joystick_port(port, ...)`
+and `set_cd32_buttons_port(port, ...)` drive a joystick or CD32 pad in
+either port (`1` or `2`) -- two ports is two players, and the hosted page
+feeds them from the keyboard mapping and from the Gamepad API.
+`set_port_device(port, name)` plugs a device into a port (`"mouse"`,
+`"joystick"`, `"cd32"`, `"analogue"`, `"none"`); a page whose gamepad
+disappears restores the mouse with `set_port_device(1, "mouse")` rather
+than leaving a stuck stick where the pointer used to be. The older
+`set_joystick_port2(...)` / `set_cd32_buttons_port2(...)` still work and
+now forward to the port-taking calls. `reset()` power-cycles,
+`resync_clock()` forgets the pacer's wall-clock anchor so a page resuming
+from a pause does not sprint through the frames the pause "owed",
+`eject_floppy(n)`
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
 exposes the guest clock for diagnostics. `set_floppy_sounds(on)` and
 `set_floppy_sounds_volume(p)` control the synthesized drive sounds (on and
@@ -292,6 +312,19 @@ elements, and pages without them are untouched:
   refused pick by pick. The hosted page's server carries no ROMs, so the
   select never appears there; a self-hosted shell that serves its owner's
   ROMs next to the page gets a one-click ROM chooser.
+- `#pause` and `#screenshot` (buttons): pause/resume the machine, and
+  copy the current screen to the clipboard. Like `#floppy-speed` these
+  are always on -- without the elements the two buttons insert
+  themselves below the canvas shell, so both are reachable on any shell.
+  Pause stops the emulated clock (not just the page): the frame loop
+  stops stepping, audio is suspended, and resuming resyncs the pacer so
+  the guest carries on from where it was rather than racing to catch up;
+  the button relabels itself Resume, and the fullscreen overlay carries
+  a copy of it. Screenshot writes a PNG of the canvas -- exactly what
+  the screen shows -- to the clipboard, falling back to downloading the
+  file when the browser has no clipboard image support or refuses the
+  write (an unfocused document, an insecure origin); the status line
+  says which happened.
 - `#ledbar` (a container): hosts the front-panel status strip (LEDs,
   track counter, disk names), letting the page own its placement and
   outer styling. Without it the strip inserts itself directly below the


### PR DESCRIPTION
Three more requests from the retro32.com page. The first needed the wasm input API to grow a port argument.

## Gamepads, in either port (two-player)

`set_joystick_port(port, ...)`, `set_cd32_buttons_port(port, ...)` and `set_port_device(port, name)` replace the port-2-only calls, which stay as forwarding wrappers since they are the published page API. `try.js` polls the Gamepad API from the frame loop (it reports button state only when asked, so there is nothing to subscribe to): the first pad takes port 2, where a game looks for its joystick, and a second takes port 1 -- two players.

Claiming port 1 displaces the mouse, exactly as plugging a stick into that socket does on real hardware; when the pad disconnects the mouse is plugged back in via `set_port_device(1, "mouse")`, so the pointer cannot stay dead. Sticks and d-pads both steer, and the face buttons follow the CD32 pad (A red/fire, B blue/button 2, X/Y green/yellow, shoulders rwd/ffw, Start play) -- a superset of a two-button stick, so a plain joystick guest only ever sees fire and button 2. Keyboard, touch and pad state is OR-merged per port so no input source silences another.

## Pause

Stops the emulated clock rather than the page: the frame loop stops stepping, audio is suspended, and resuming calls the new `resync_clock()` to forget the pacer's wall-clock anchor -- without it the first tick back sprints through every frame the pause owed. The fullscreen overlay carries a copy of the button, and a reboot never starts the new machine paused.

## Screenshot to clipboard

Writes the canvas as a PNG through `ClipboardItem`, falling back to downloading the file when the browser lacks clipboard image support or refuses the write (an unfocused document, an insecure origin); the status line says which happened.

`#pause` and `#screenshot` join `#floppy-speed` as controls that insert themselves when the shell does not provide them, so both are reachable on any page shell.

## Verification

- **Two-player, through the guest's own eyes**: AmigaTestKit's Controller Ports screen (F4, then F1 to switch the port-1 panel from Mouse to Joystick) with two pads connected -- port 1 lights B1+L and port 2 lights B1+U simultaneously, each matching what its own pad holds.
- **Port-1 mouse displacement**: measured by locating the pointer sprite on the canvas under KS2.05. It tracks the mouse (+120,+60 lands exactly), freezes through three further moves while a pad holds port 1, and tracks again once the pad disconnects.
- **Pause**: zero emulated drift across a five-second pause, no catch-up sprint on resume, and identical run speed measured before (0.73x) and after (0.74x) in the same throttled tab.
- **Screenshot**: valid PNG at the exact emulated resolution; clipboard write confirmed with a real click, and the download fallback confirmed on an unfocused document.
- `cargo test` (1668 lib tests), `cargo clippy`, `cargo fmt --check` clean; web crate checks and clippy-passes for `wasm32-unknown-unknown`.
- docs/guide/browser.md updated: gamepad input, the `#pause`/`#screenshot` hooks, and the new API calls.