### PR TITLE
web: save states, as downloadable files and a browser quick slot

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -644,6 +644,42 @@ impl WebEmu {
         self.emu.bus().cia_b.port_a_pins() & 0x80 == 0
     }
 
+    /// Snapshot the whole emulated machine (RAM, ROM, chipset, CPU, the
+    /// floppy images themselves) into a `.clstate` blob, the same format the
+    /// desktop builds write, so a state saved here loads there and back. The
+    /// page decides where it goes: a download, IndexedDB, anywhere it can
+    /// keep bytes. Call between frames -- outside `run`, which every
+    /// JS-facing method is by construction.
+    pub fn save_state(&self) -> Result<Vec<u8>, JsValue> {
+        self.emu.save_state_bytes().map_err(js_err)
+    }
+
+    /// Restore a state produced by `save_state` (or by a desktop build).
+    /// The machine rebuilds from the blob, so the fitted ROM and inserted
+    /// disks come back with it. A blob that is not a readable state of this
+    /// build's format version throws and leaves the running machine
+    /// untouched, so a page can offer a load without risking the session.
+    ///
+    /// Host-side settings do not travel with the state (they are not part of
+    /// the machine): a page that keeps its own volume, drive-sound or floppy
+    /// speed choices should re-apply them after a load.
+    pub fn load_state(&mut self, blob: &[u8]) -> Result<(), JsValue> {
+        self.emu.load_state_bytes(blob).map_err(js_err)?;
+        // Emulated time jumps to the state's timeline, so the pacer must
+        // start over from now rather than chase the gap, and motion buffered
+        // against the pre-load machine must not replay into it.
+        self.anchor = None;
+        self.mouse_remainder = (0.0, 0.0);
+        self.mouse_pending = (0, 0);
+        // The restored frame counter may match or precede the last one
+        // presented; forget it so the next render is unconditional, and
+        // paint the restored screen now so a paused page shows it without
+        // stepping the machine.
+        self.last_rendered_frame = None;
+        self.render_completed_frame();
+        Ok(())
+    }
+
     /// Cold reset (power cycle), keeping the fitted ROM and inserted disks.
     pub fn reset(&mut self) -> Result<(), JsValue> {
         self.emu.power_on_reset().map_err(js_err)?;

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -280,8 +280,12 @@ async function boot() {
     // Fit the ROM into a fresh machine before anything else: a bad image
     // must abort the boot with the page still in its pre-boot state (emu
     // stays null, so the pickers keep updating bootRom for the retry).
+    // With no ROM to fit at all, the machine keeps the placeholder WebEmu
+    // builds itself: nothing the boot button can reach (it stays disabled
+    // until a ROM exists), but a save state carries its own ROM and
+    // replaces the whole machine, so a restore can start from one.
     const machine = new WebEmu();
-    machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
+    if (bootRom) machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
 
     // A reboot after an emulator error builds a new audio stack; close the
     // previous one so it cannot keep playing alongside.
@@ -331,7 +335,9 @@ async function boot() {
     // earlier failure) would otherwise go stale into any bug report filed
     // while the machine runs.
     setLoadStatus(
-      `booted ${bootRom.label}` +
+      // A ROM-less boot is only ever a landing place for a state load,
+      // which overwrites this line the moment it lands.
+      (bootRom ? `booted ${bootRom.label}` : 'machine built, waiting for the state') +
         (df0Name ? ` - DF0: ${df0Name} (write-protected)` : ''),
     );
 
@@ -1570,15 +1576,36 @@ function updateStateButtons() {
 
 // The machine a state loads into: states carry their own ROM and disks, so
 // booting first and restoring over it is enough, and a visitor can land
-// straight back in a game from a cold page load.
+// straight back in a game from a cold page load. No boot ROM is needed for
+// that - not even AROS, whose download may have failed, or a self-hosted
+// shell that serves none - because the restore replaces the whole machine
+// including its ROM. Reports whether it had to boot, so a restore that
+// then fails can put the page back rather than strand the visitor on a
+// machine they never asked to start.
 async function machineForStateLoad() {
-  if (emu && running) return true;
-  if (bootBtn.disabled) {
-    setLoadStatus('nothing to boot yet - load a Kickstart first');
-    return false;
+  if (emu && running) return { ready: true, booted: false };
+  if (!wasm) {
+    setLoadStatus('the emulator is still loading');
+    return { ready: false, booted: false };
   }
   await boot();
-  return Boolean(emu && running);
+  return { ready: Boolean(emu && running), booted: true };
+}
+
+// Undo a boot that only happened to receive a state which then would not
+// load. Without the state there is nothing to run - a ROM-less machine
+// does nothing at all - so the page returns to its pre-boot screen with
+// the failure still on the status line.
+function unbootAfterFailedStateLoad() {
+  const failure = loadStatus.textContent;
+  emu = null;
+  window.__emu = null;
+  running = false;
+  paused = false;
+  setPauseLabel();
+  overlay.style.display = '';
+  refreshBootButton();
+  setLoadStatus(failure);
 }
 
 // Restore from a blob, whatever produced it. The core leaves the running
@@ -1647,8 +1674,9 @@ async function loadStateFromFile(file) {
     setLoadStatus(`${file.name}: could not be read (${e.message ?? e})`);
     return;
   }
-  if (!(await machineForStateLoad())) return;
-  restoreState(bytes, file.name);
+  const machine = await machineForStateLoad();
+  if (!machine.ready) return;
+  if (!restoreState(bytes, file.name) && machine.booted) unbootAfterFailedStateLoad();
 }
 
 async function quickSaveState() {
@@ -1689,8 +1717,11 @@ async function quickLoadState() {
     updateStateButtons();
     return;
   }
-  if (!(await machineForStateLoad())) return;
-  restoreState(record.bytes, 'this browser');
+  const machine = await machineForStateLoad();
+  if (!machine.ready) return;
+  if (!restoreState(record.bytes, 'this browser') && machine.booted) {
+    unbootAfterFailedStateLoad();
+  }
 }
 
 // What the quick slot holds, for the button's enabled state and tooltip.

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -72,6 +72,9 @@ let df0Name = null; // what the page believes is in DF0, for bug reports
 function refreshBootButton() {
   bootBtn.disabled = !(wasm && bootRom);
   bootBtn.textContent = bootRom && bootRom.label !== 'AROS' ? 'Boot Kickstart' : 'Boot AROS';
+  // The save-state controls follow the same milestones (the module is
+  // ready, a machine is running or has just died), so they refresh here.
+  updateStateButtons();
 }
 
 // Route picked or dropped Kickstart bytes: live-swap a running machine, or
@@ -338,6 +341,7 @@ async function boot() {
     // A reboot from a paused machine must not start the new one paused.
     paused = false;
     setPauseLabel();
+    updateStateButtons();
     // Port fittings live on the machine, so a fresh one needs the pads
     // that are still plugged into the host put back.
     for (const port of padAssignments.values()) fitCd32Pad(port);
@@ -362,6 +366,31 @@ function maxFramesForQueue() {
   return queuedMs > 150 ? 0 : 5;
 }
 
+// Blit whatever the core last rendered onto the canvas. Called once per
+// tick, and again after a save state is loaded: that repaints the restored
+// screen straight away, so a load into a paused machine shows where it
+// resumes instead of the frame from before the load.
+function presentFrame() {
+  const rows = emu.present_rows();
+  if (rows === 0) return;
+  // The presentation size follows the emulated display (the cropped TV
+  // aperture for a standard PAL screen, the full overscan framebuffer
+  // otherwise), so track both dimensions every frame.
+  const width = emu.present_width();
+  if (canvas.width !== width || canvas.height !== rows) {
+    canvas.width = width;
+    canvas.height = rows;
+  }
+  // The view must be rebuilt every frame: wasm memory may grow and the
+  // present buffer may reallocate.
+  const view = new Uint8ClampedArray(
+    wasm.memory.buffer,
+    emu.present_ptr(),
+    width * rows * 4,
+  );
+  ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
+}
+
 function tick(nowMs) {
   if (!running) return;
   if (paused) return; // resumePause() restarts the loop
@@ -384,25 +413,7 @@ function tick(nowMs) {
     return;
   }
 
-  const rows = emu.present_rows();
-  if (rows > 0) {
-    // The presentation size follows the emulated display (the cropped TV
-    // aperture for a standard PAL screen, the full overscan framebuffer
-    // otherwise), so track both dimensions every frame.
-    const width = emu.present_width();
-    if (canvas.width !== width || canvas.height !== rows) {
-      canvas.width = width;
-      canvas.height = rows;
-    }
-    // The view must be rebuilt every frame: wasm memory may grow and the
-    // present buffer may reallocate.
-    const view = new Uint8ClampedArray(
-      wasm.memory.buffer,
-      emu.present_ptr(),
-      width * rows * 4,
-    );
-    ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
-  }
+  presentFrame();
 
   const audio = emu.take_audio();
   if (audio.length > 0 && audioNode) {
@@ -1458,7 +1469,246 @@ async function copyScreenshot() {
   }
 }
 
-// Build whichever of the two the shell did not provide, in one row that
+// --- save states -----------------------------------------------------------
+// The desktop's save states, with the browser's storage instead of a
+// filesystem. A state is the whole machine - RAM, ROM, chipset, CPU and the
+// inserted floppy images themselves - in the same .clstate format the
+// desktop writes, so one moves between the two in either direction.
+//
+// Two destinations, because they answer different questions. "Save state"
+// downloads the blob as a file: it survives everything, and it can be
+// shared or carried to a desktop build. Quick save keeps it in IndexedDB
+// under a single slot, which is what a visitor resuming a game actually
+// wants - one click out, one click back in, across page loads and browser
+// restarts, with nothing in the downloads folder.
+//
+// No keyboard shortcuts: every key on this page belongs to the guest (the
+// desktop's Cmd/Alt+Shift+S has no equivalent here that would not shadow an
+// Amiga key), so these are buttons only.
+
+const STATE_DB_NAME = 'copperline';
+const STATE_STORE = 'states';
+// One quick slot. A visitor wants "where I left off", not a slot manager;
+// named slots can key off the same store later without a format change.
+const QUICK_SLOT = 'quick';
+
+let quickStateInfo = null; // metadata of the stored quick state, when there is one
+
+function openStateDb() {
+  return new Promise((resolve, reject) => {
+    if (!window.indexedDB) {
+      reject(new Error('this browser has no IndexedDB'));
+      return;
+    }
+    const req = indexedDB.open(STATE_DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STATE_STORE)) db.createObjectStore(STATE_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    // Private-browsing modes and blocked storage reject the open itself.
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB unavailable'));
+    req.onblocked = () => reject(new Error('IndexedDB blocked by another tab'));
+  });
+}
+
+// Resolve on commit, not on the request: a put that succeeds can still lose
+// its transaction to the storage quota, and a quick save that quietly did
+// not persist is exactly the failure a visitor would discover too late.
+function stateTx(db, mode, run) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STATE_STORE, mode);
+    const req = run(tx.objectStore(STATE_STORE));
+    tx.oncomplete = () => resolve(req?.result);
+    tx.onerror = () => reject(tx.error ?? new Error('IndexedDB transaction failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('IndexedDB transaction aborted'));
+  });
+}
+
+async function withStateDb(mode, run) {
+  const db = await openStateDb();
+  try {
+    return await stateTx(db, mode, run);
+  } finally {
+    db.close();
+  }
+}
+
+// Everything a state needs to describe itself in the UI. Uint8Array and Date
+// are structured-cloneable, so the record stores as it stands.
+function stateRecord(bytes) {
+  return {
+    bytes,
+    saved: new Date(),
+    emulated: emu.emulated_seconds(),
+    rom: bootRom?.label ?? 'unknown',
+    df0: df0Name,
+  };
+}
+
+function describeState(info) {
+  if (!info) return '';
+  const when = info.saved instanceof Date ? info.saved.toLocaleString() : 'unknown time';
+  return `${when} - ${info.df0 ?? 'no disk'} (${Math.round(info.emulated ?? 0)}s emulated)`;
+}
+
+// Enablement follows what each control can actually do right now: saving
+// needs a running machine, loading only needs the wasm module (it boots one
+// on demand), and quick load additionally needs something in the slot.
+function updateStateButtons() {
+  const live = Boolean(emu && running);
+  if (saveStateBtn) saveStateBtn.disabled = !live;
+  if (quickSaveBtn) quickSaveBtn.disabled = !live;
+  if (loadStateBtn) loadStateBtn.disabled = !wasm;
+  if (quickLoadBtn) {
+    quickLoadBtn.disabled = !wasm || !quickStateInfo;
+    quickLoadBtn.title = quickStateInfo
+      ? `Saved in this browser: ${describeState(quickStateInfo)}`
+      : 'No quick state saved in this browser yet';
+  }
+}
+
+// The machine a state loads into: states carry their own ROM and disks, so
+// booting first and restoring over it is enough, and a visitor can land
+// straight back in a game from a cold page load.
+async function machineForStateLoad() {
+  if (emu && running) return true;
+  if (bootBtn.disabled) {
+    setLoadStatus('nothing to boot yet - load a Kickstart first');
+    return false;
+  }
+  await boot();
+  return Boolean(emu && running);
+}
+
+// Restore from a blob, whatever produced it. The core leaves the running
+// machine untouched when a blob does not parse, so a bad file costs the
+// visitor nothing but the message.
+function restoreState(bytes, source) {
+  try {
+    emu.load_state(bytes);
+  } catch (e) {
+    setLoadStatus(`${source} failed to load: ${e.message ?? e}`);
+    return false;
+  }
+  // Host-side settings are not part of the machine, so the page's own
+  // choices are re-applied over the restored one; the state's idea of them
+  // came from whatever session saved it.
+  emu.set_volume_percent(Number($('vol').value));
+  if (floppySoundsToggle) emu.set_floppy_sounds(floppySoundsToggle.checked);
+  else if (configFloppySounds !== null) emu.set_floppy_sounds(configFloppySounds);
+  if (floppySpeed !== null) emu.set_floppy_speed(floppySpeed);
+  // Port fittings live on the machine, so the pads plugged into the host go
+  // back into the restored one, exactly as after a boot. Port 1 is the
+  // mouse socket first: a state saved while a pad occupied it would
+  // otherwise restore a stick nothing drives, and the pointer would be
+  // dead until the visitor plugged that pad back in.
+  if (!new Set(padAssignments.values()).has(1)) emu.set_port_device(1, 'mouse');
+  for (const port of padAssignments.values()) fitCd32Pad(port);
+  if (joyMode === 'cd32') fitCd32Pad(2);
+  // The disk came back inside the state; believe the machine, not the page.
+  df0Name = emu.disk_name(0) ?? null;
+  lastFddTrack = null;
+  updateStatusDisks();
+  // Paint the restored screen now: a load into a paused machine steps no
+  // frames, so nothing else would.
+  presentFrame();
+  setLoadStatus(
+    `state loaded from ${source}` + (df0Name ? ` - DF0: ${df0Name}` : ''),
+  );
+  return true;
+}
+
+// Download the state as a file, the shareable, permanent form.
+function downloadState() {
+  if (!emu || !running) return;
+  try {
+    const blob = new Blob([emu.save_state()], { type: 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `copperline-${new Date().toISOString().replace(/[:.]/g, '-')}.clstate`;
+    a.click();
+    // Revoking synchronously can cancel the download that click just
+    // started; let the current task finish first (as for screenshots).
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    setLoadStatus('save state downloaded');
+  } catch (e) {
+    setLoadStatus(`save state failed: ${e.message ?? e}`);
+  }
+}
+
+async function loadStateFromFile(file) {
+  if (!file) return;
+  let bytes;
+  try {
+    bytes = new Uint8Array(await file.arrayBuffer());
+  } catch (e) {
+    setLoadStatus(`${file.name}: could not be read (${e.message ?? e})`);
+    return;
+  }
+  if (!(await machineForStateLoad())) return;
+  restoreState(bytes, file.name);
+}
+
+async function quickSaveState() {
+  if (!emu || !running) return;
+  let record;
+  try {
+    record = stateRecord(emu.save_state());
+  } catch (e) {
+    setLoadStatus(`quick save failed: ${e.message ?? e}`);
+    return;
+  }
+  try {
+    await withStateDb('readwrite', (store) => store.put(record, QUICK_SLOT));
+  } catch (e) {
+    // Quota is the failure worth naming: states are around a megabyte and a
+    // browser low on storage refuses the write rather than evicting.
+    const hint = e.name === 'QuotaExceededError' ? ' - browser storage is full' : '';
+    setLoadStatus(`quick save failed: ${e.message ?? e}${hint}`);
+    return;
+  }
+  const { bytes, ...info } = record;
+  quickStateInfo = info;
+  updateStateButtons();
+  setLoadStatus(`quick state saved in this browser (${Math.round(bytes.length / 1024)} KB)`);
+}
+
+async function quickLoadState() {
+  let record;
+  try {
+    record = await withStateDb('readonly', (store) => store.get(QUICK_SLOT));
+  } catch (e) {
+    setLoadStatus(`quick load failed: ${e.message ?? e}`);
+    return;
+  }
+  if (!record?.bytes) {
+    setLoadStatus('no quick state saved in this browser');
+    quickStateInfo = null;
+    updateStateButtons();
+    return;
+  }
+  if (!(await machineForStateLoad())) return;
+  restoreState(record.bytes, 'this browser');
+}
+
+// What the quick slot holds, for the button's enabled state and tooltip.
+// A browser that refuses storage simply leaves quick load disabled.
+async function probeQuickState() {
+  try {
+    const record = await withStateDb('readonly', (store) => store.get(QUICK_SLOT));
+    if (record?.bytes) {
+      const { bytes, ...info } = record;
+      quickStateInfo = info;
+    }
+  } catch {
+    quickStateInfo = null;
+  }
+  updateStateButtons();
+}
+
+// Build whichever of the controls the shell did not provide, in one row that
 // matches the self-inserted floppy-speed control's styling. Listeners are
 // attached afterwards, once, so a shell-provided and a self-built button
 // take exactly the same path.
@@ -1466,6 +1716,10 @@ function buildMachineControls() {
   const missing = [
     ['pause', 'Pause'],
     ['screenshot', 'Screenshot'],
+    ['savestate', 'Save state'],
+    ['loadstate', 'Load state...'],
+    ['quicksave', 'Quick save'],
+    ['quickload', 'Quick load'],
   ].filter(([id]) => !$(id));
   if (missing.length === 0) return;
   const row = document.createElement('div');
@@ -1488,6 +1742,32 @@ const pauseBtn = $('pause');
 const screenshotBtn = $('screenshot');
 pauseBtn?.addEventListener('click', togglePause);
 screenshotBtn?.addEventListener('click', copyScreenshot);
+
+const saveStateBtn = $('savestate');
+const loadStateBtn = $('loadstate');
+const quickSaveBtn = $('quicksave');
+const quickLoadBtn = $('quickload');
+saveStateBtn?.addEventListener('click', downloadState);
+quickSaveBtn?.addEventListener('click', quickSaveState);
+quickLoadBtn?.addEventListener('click', quickLoadState);
+// The file picker is built here rather than expected from the shell, so
+// #loadstate is a plain button like the rest of the row wherever it lives.
+if (loadStateBtn) {
+  const picker = document.createElement('input');
+  picker.type = 'file';
+  picker.accept = '.clstate';
+  picker.hidden = true;
+  document.body.appendChild(picker);
+  picker.addEventListener('change', () => {
+    const file = picker.files?.[0];
+    // Clear the selection so picking the same file twice fires again.
+    picker.value = '';
+    loadStateFromFile(file);
+  });
+  loadStateBtn.addEventListener('click', () => picker.click());
+}
+updateStateButtons();
+probeQuickState();
 
 // Optional in the page shell: a checkbox #floppy-sounds toggles the
 // synthesized drive sounds (motor hum, head-step clicks, read hiss).
@@ -1879,7 +2159,7 @@ function ensureDropHint() {
     'border:2px dashed rgba(255,255,255,0.5);' +
     'color:rgba(255,255,255,0.9);padding:1rem;' +
     'font:600 1rem "IBM Plex Mono",ui-monospace,monospace;';
-  dropHint.textContent = 'Drop: disk image -> DF0, .rom -> Kickstart';
+  dropHint.textContent = 'Drop: disk image -> DF0, .rom -> Kickstart, .clstate -> restore';
   shell.appendChild(dropHint);
   return dropHint;
 }
@@ -1894,6 +2174,14 @@ async function handleDroppedFiles(files) {
   const oversize = list.find((f) => f.size > DISK_URL_MAX_BYTES);
   if (oversize) {
     setLoadStatus(`${oversize.name}: file too large`);
+    return;
+  }
+  // A dropped save state replaces the whole machine, so it takes the drop
+  // on its own: a ROM or disk alongside it would be overwritten by the
+  // state's own ROM and disks anyway.
+  const state = list.find((f) => /\.clstate$/i.test(f.name));
+  if (state) {
+    await loadStateFromFile(state);
     return;
   }
   // One drive and one ROM socket: the first of each kind wins, extras

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -23,10 +23,10 @@ document picker greys out extensions it does not recognise, which would
 lock out `.adf` and friends.
 
 Files can also be dragged onto the page: a `.rom` file loads (or, before
-boot, queues) a Kickstart exactly like the ROM picker, and anything else
-inserts into DF0 like the disk picker -- dropped before boot it queues and
-inserts when the machine starts. The same 64 MiB cap as URL fetches
-applies.
+boot, queues) a Kickstart exactly like the ROM picker, a `.clstate` file
+restores a [save state](#browser-save-states), and anything else inserts
+into DF0 like the disk picker -- dropped before boot it queues and inserts
+when the machine starts. The same 64 MiB cap as URL fetches applies.
 
 A disk can also come from a link: `/try/?df0=<url>` fetches the image while
 the emulator loads and inserts it at boot, so a bootable demo is one
@@ -103,6 +103,44 @@ track counter, and the name of the disk in each connected drive.
 Audio starts with the boot click, but a browser autoplay policy can keep
 the AudioContext suspended anyway; the boot never waits for it. The
 emulator runs silent and the next click or key press unlocks the sound.
+
+(browser-save-states)=
+### Save states
+
+The page carries the desktop's [save states](ui.md#save-states), which
+snapshot the whole emulated machine -- RAM, ROM, chipset, CPU, and the
+inserted floppy images themselves -- in the same `.clstate` format, so a
+state moves between a browser and a desktop build in either direction.
+Four buttons, which insert themselves below the canvas on a shell that
+does not place them:
+
+- **Save state** downloads the snapshot as a `.clstate` file. This is the
+  form that survives everything and can be shared or carried to a desktop
+  build.
+- **Load state...** picks a `.clstate` file and restores it; dropping the
+  file on the page does the same.
+- **Quick save** keeps the snapshot in the browser itself (IndexedDB),
+  under a single slot, which is what resuming a game usually wants: one
+  click out, one click back in, and it survives page reloads and browser
+  restarts.
+- **Quick load** restores that slot. It is enabled only when the browser
+  holds a quick state, and its tooltip says when the state was taken,
+  what was in DF0, and how far the machine had run.
+
+Loading works from a cold page: with no machine booted, a load boots one
+and restores over it, so a visitor returning to a game lands straight back
+in it. States carry their own ROM and disks, so nothing needs to be
+re-picked first. A blob that is not a readable state of this build's
+format version is refused with the running machine untouched -- including
+a state from an older Copperline whose format version has moved on.
+
+There are no keyboard shortcuts for these (the desktop's
+Cmd/Alt+Shift+S and +L): every key on the page belongs to the guest, so a
+host shortcut would shadow an Amiga key.
+
+Host-side settings are not part of a machine and do not travel in a state:
+the page re-applies its own volume, drive-sound, floppy-speed and
+controller choices over whatever is restored.
 
 ## How it is put together
 
@@ -241,7 +279,19 @@ now forward to the port-taking calls. `reset()` power-cycles,
 from a pause does not sprint through the frames the pause "owed",
 `eject_floppy(n)`
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
-exposes the guest clock for diagnostics. `set_floppy_sounds(on)` and
+exposes the guest clock for diagnostics.
+
+`save_state()` returns the whole emulated machine as a `Uint8Array` in the
+desktop's `.clstate` format, and `load_state(bytes)` restores one --
+the browser side of [save states](#browser-save-states). Where the bytes
+live is the page's choice (a download, IndexedDB, a fetch); the core only
+deals in the blob. Both are frame-boundary operations, which any
+JS-facing call is by construction, and a blob that does not parse throws
+with the running machine untouched. A load re-anchors the pacer and
+repaints the restored screen immediately, so a paused page shows where it
+resumes; host-side settings (volume, drive sounds, floppy speed, port
+devices) are not part of the machine, so a page that keeps its own should
+re-apply them afterwards. `set_floppy_sounds(on)` and
 `set_floppy_sounds_volume(p)` control the synthesized drive sounds (on and
 100 by default, like the desktop's `[audio] floppy_sounds` knobs).
 `set_floppy_speed(percent)` / `floppy_speed()` set and read the emulated
@@ -325,6 +375,13 @@ elements, and pages without them are untouched:
   file when the browser has no clipboard image support or refuses the
   write (an unfocused document, an insecure origin); the status line
   says which happened.
+- `#savestate`, `#loadstate`, `#quicksave`, `#quickload` (buttons): the
+  [save-state controls](#browser-save-states) -- download a state, pick a
+  state file, and the browser-resident quick slot. Always on like
+  `#pause`: without the elements they insert themselves below the canvas
+  shell. `#loadstate` is a plain button wherever the shell puts it; the
+  file picker behind it is built by the glue, so no `<input type="file">`
+  is needed in the shell.
 - `#ledbar` (a container): hosts the front-panel status strip (LEDs,
   track counter, disk names), letting the page own its placement and
   outer styling. Without it the strip inserts itself directly below the

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -129,10 +129,16 @@ does not place them:
 
 Loading works from a cold page: with no machine booted, a load boots one
 and restores over it, so a visitor returning to a game lands straight back
-in it. States carry their own ROM and disks, so nothing needs to be
-re-picked first. A blob that is not a readable state of this build's
-format version is refused with the running machine untouched -- including
-a state from an older Copperline whose format version has moved on.
+in it. A state carries its own ROM and disks and replaces the whole
+machine, so nothing needs to be re-picked first -- and no boot ROM is
+needed at all, not even AROS. A page whose ROM download failed, or a
+self-hosted shell that serves none, can still restore a state; the
+machine that comes out of it is complete. A blob that is not a readable
+state of this build's format version is refused with the running machine
+untouched -- including a state from an older Copperline whose format
+version has moved on. If that refusal follows a boot the load itself
+asked for, the page returns to its pre-boot screen rather than leaving a
+machine running that nothing was restored into.
 
 There are no keyboard shortcuts for these (the desktop's
 Cmd/Alt+Shift+S and +L): every key on the page belongs to the guest, so a

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -533,6 +533,15 @@ impl Emulator {
         crate::savestate::save(&self.machine, &self.descriptor, path)
     }
 
+    /// `save_state` into memory instead of a file, for hosts with no
+    /// filesystem to write to (the browser build hands the blob to a
+    /// download or IndexedDB). Same bytes, same format version.
+    pub fn save_state_bytes(&self) -> Result<Vec<u8>> {
+        let mut blob = Vec::new();
+        crate::savestate::save_to_writer(&self.machine, &self.descriptor, &mut blob)?;
+        Ok(blob)
+    }
+
     /// Restore a save state from `path`. The state carries its own machine
     /// (RAM, ROM, chip revisions, CPU), so a load fully rebuilds it; when that
     /// machine differs from the one running, the host is reconfigured to match
@@ -541,11 +550,28 @@ impl Emulator {
     /// timeline, so the real-time pacing anchor is re-baselined to "now"; on
     /// failure the running machine is untouched.
     pub fn load_state(&mut self, path: &std::path::Path) -> Result<StateLoadOutcome> {
+        self.adopt_loaded_state(|machine| crate::savestate::load(machine, path))
+    }
+
+    /// `load_state` from bytes instead of a file: the browser counterpart,
+    /// restoring a state that came from a picked file or IndexedDB. The
+    /// blob is a whole state file, so a desktop `.clstate` loads here and
+    /// vice versa; a failed parse leaves the running machine untouched.
+    pub fn load_state_bytes(&mut self, blob: &[u8]) -> Result<StateLoadOutcome> {
+        self.adopt_loaded_state(|machine| crate::savestate::load_from_reader(machine, blob))
+    }
+
+    /// Shared tail of both load paths: restore through `load`, then put the
+    /// host back in step with the machine that came out of it.
+    fn adopt_loaded_state(
+        &mut self,
+        load: impl FnOnce(&mut cpu::M68kMachine) -> Result<crate::config::MachineDescriptor>,
+    ) -> Result<StateLoadOutcome> {
         // Channel mode and stereo separation are host preferences, not part of
         // the saved machine, so carry the current choices across the load.
         let mono = self.bus_mut().paula.mono_output();
         let separation = self.bus_mut().paula.stereo_separation();
-        let loaded = crate::savestate::load(&mut self.machine, path)?;
+        let loaded = load(&mut self.machine)?;
         self.bus_mut().paula.set_mono_output(mono);
         self.bus_mut().paula.set_stereo_separation(separation);
         let reconfigured = loaded != self.descriptor;

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -25,6 +25,10 @@
 //! config and reconfigure the host to match it; the serialized components
 //! already carry the actual hardware, so the machine itself always rebuilds
 //! from the state regardless.
+//!
+//! `save`/`load` name a file; `save_to_writer`/`load_from_reader` are the
+//! same format over any byte stream, for hosts without a filesystem (the
+//! browser build keeps its states in a download or IndexedDB).
 
 use anyhow::{anyhow, bail, Context, Result};
 use flate2::read::ZlibDecoder;
@@ -128,7 +132,20 @@ pub fn auto_filename() -> std::path::PathBuf {
 pub fn save(machine: &M68kMachine, descriptor: &MachineDescriptor, path: &Path) -> Result<()> {
     let file =
         File::create(path).with_context(|| format!("creating save state {}", path.display()))?;
-    let mut writer = BufWriter::new(file);
+    save_to_writer(machine, descriptor, BufWriter::new(file))
+        .with_context(|| format!("writing save state {}", path.display()))
+}
+
+/// `save` without a filesystem: write the same bytes a state file holds into
+/// any sink. Hosts with nowhere to put a file -- the browser build, which
+/// hands the blob to a download or IndexedDB -- go through here, so a state
+/// produced in a browser and one produced by the desktop are the same format
+/// and interchangeable.
+pub fn save_to_writer<W: Write>(
+    machine: &M68kMachine,
+    descriptor: &MachineDescriptor,
+    mut writer: W,
+) -> Result<()> {
     writer.write_all(STATE_MAGIC)?;
     writer.write_all(&STATE_VERSION.to_le_bytes())?;
     // The descriptor sits uncompressed ahead of the zlib stream so it can be
@@ -137,10 +154,7 @@ pub fn save(machine: &M68kMachine, descriptor: &MachineDescriptor, path: &Path) 
         .map_err(|e| anyhow!("serializing machine descriptor: {e}"))?;
     let mut encoder = ZlibEncoder::new(writer, Compression::fast());
     machine.write_state(&mut encoder)?;
-    encoder
-        .finish()
-        .and_then(|mut w| w.flush())
-        .with_context(|| format!("writing save state {}", path.display()))?;
+    encoder.finish().and_then(|mut w| w.flush())?;
     Ok(())
 }
 
@@ -154,34 +168,42 @@ pub fn save(machine: &M68kMachine, descriptor: &MachineDescriptor, path: &Path) 
 pub fn load(machine: &mut M68kMachine, path: &Path) -> Result<MachineDescriptor> {
     let file =
         File::open(path).with_context(|| format!("opening save state {}", path.display()))?;
-    let mut reader = BufReader::new(file);
+    load_from_reader(machine, BufReader::new(file))
+        .with_context(|| format!("loading save state {}", path.display()))
+}
+
+/// `load` without a filesystem: restore from the bytes of a state file held
+/// anywhere (a browser download, an IndexedDB record, a network response).
+/// The same guarantees hold -- the live machine is untouched unless the whole
+/// state parses -- and the caller still owns re-anchoring host pacing.
+pub fn load_from_reader<R: Read>(
+    machine: &mut M68kMachine,
+    mut reader: R,
+) -> Result<MachineDescriptor> {
     let mut magic = [0u8; STATE_MAGIC.len()];
     reader
         .read_exact(&mut magic)
-        .with_context(|| format!("reading save state {}", path.display()))?;
+        .context("reading save state header")?;
     if &magic != STATE_MAGIC {
-        bail!("{} is not a Copperline save state", path.display());
+        bail!("not a Copperline save state");
     }
     let mut version_bytes = [0u8; 4];
     reader
         .read_exact(&mut version_bytes)
-        .with_context(|| format!("reading save state {}", path.display()))?;
+        .context("reading save state header")?;
     let version = u32::from_le_bytes(version_bytes);
     if version != STATE_VERSION {
         bail!(
-            "save state {} is format version {version}; this build reads version {}",
-            path.display(),
+            "save state is format version {version}; this build reads version {}",
             STATE_VERSION
         );
     }
-    // Read the descriptor straight from the BufReader; bincode consumes exactly
+    // Read the descriptor straight from the reader; bincode consumes exactly
     // its encoded bytes, leaving the reader positioned at the zlib stream.
     let descriptor: MachineDescriptor = bincode::deserialize_from(&mut reader)
-        .map_err(|e| anyhow!("reading machine descriptor from {}: {e}", path.display()))?;
+        .map_err(|e| anyhow!("reading machine descriptor: {e}"))?;
     let mut decoder = ZlibDecoder::new(reader);
-    machine
-        .apply_state(&mut decoder)
-        .with_context(|| format!("loading save state {}", path.display()))?;
+    machine.apply_state(&mut decoder)?;
     Ok(descriptor)
 }
 
@@ -438,6 +460,53 @@ mod tests {
         }
     }
 
+    /// The in-memory API writes the same format the file API reads, and
+    /// round-trips a machine through a `Vec<u8>` with no filesystem in the
+    /// way. This is the path the browser build takes, where `save`/`load`
+    /// cannot work at all.
+    #[test]
+    fn writer_reader_round_trip_matches_the_file_format() {
+        let mut machine = blitting_workload_machine();
+        // Into the running workload, then to a frame boundary: where a
+        // production save happens.
+        machine.step_slice(20_000).unwrap();
+        let start_frames = machine.bus().emulated_frames();
+        while machine.bus().emulated_frames() == start_frames {
+            machine.step_slice(16).unwrap();
+        }
+        let descriptor = MachineDescriptor::default();
+
+        let mut blob = Vec::new();
+        save_to_writer(&machine, &descriptor, &mut blob).unwrap();
+
+        // A file written by `save` is byte-identical to the blob, so states
+        // move between the desktop and the browser in either direction.
+        let path = temp_state("writer-parity");
+        save(&machine, &descriptor, &path).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), blob);
+        let _ = std::fs::remove_file(&path);
+
+        let mut restored = test_machine();
+        let loaded = load_from_reader(&mut restored, blob.as_slice()).unwrap();
+        assert_eq!(loaded, descriptor);
+        assert_eq!(restored.pc(), machine.pc());
+        assert_eq!(
+            restored.bus().emulated_cck(),
+            machine.bus().emulated_cck(),
+            "the restored timeline must resume where the save left off"
+        );
+        assert_eq!(restored.bus().mem.chip_ram, machine.bus().mem.chip_ram);
+    }
+
+    #[test]
+    fn reader_rejects_a_blob_without_the_state_magic() {
+        let mut machine = test_machine();
+        let before_pc = machine.pc();
+        let err = load_from_reader(&mut machine, b"NOTASTATEFILE".as_slice()).unwrap_err();
+        assert!(format!("{err:#}").contains("not a Copperline save state"));
+        assert_eq!(machine.pc(), before_pc);
+    }
+
     #[test]
     fn rejects_files_without_the_state_magic() {
         let path = temp_state("magic");
@@ -445,7 +514,10 @@ mod tests {
         let mut machine = test_machine();
         let before_pc = machine.pc();
         let err = load(&mut machine, &path).unwrap_err();
-        assert!(err.to_string().contains("not a Copperline save state"));
+        // The cause carries the diagnosis; the outer context names the file.
+        let reported = format!("{err:#}");
+        assert!(reported.contains("not a Copperline save state"));
+        assert!(reported.contains(&path.display().to_string()));
         // A failed load leaves the live machine untouched.
         assert_eq!(machine.pc(), before_pc);
         let _ = std::fs::remove_file(&path);
@@ -459,7 +531,7 @@ mod tests {
         std::fs::write(&path, &bytes).unwrap();
         let mut machine = test_machine();
         let err = load(&mut machine, &path).unwrap_err();
-        assert!(err.to_string().contains("format version"));
+        assert!(format!("{err:#}").contains("format version"));
         let _ = std::fs::remove_file(&path);
     }
 


### PR DESCRIPTION
Adds save/load states to the WebAssembly frontend, in the same `.clstate` format the desktop builds read and write.

## Core

`savestate` could only name a file, which is nothing a browser can do:

- `savestate::save_to_writer` / `load_from_reader` are now the format over any byte stream; `save`/`load` are thin `File` wrappers that add the path as anyhow context. Error strings inside the reader no longer embed the path, so callers want `{e:#}` (every existing report site already did).
- `Emulator::save_state_bytes()` / `load_state_bytes(&[u8])`, with both load paths sharing one host-reconfiguration tail (`adopt_loaded_state`).

## Browser

`WebEmu::save_state()` returns the blob, `load_state(bytes)` restores one. A load re-anchors the pacer, drops mouse motion buffered against the old machine, nulls the last-rendered frame and repaints, so a load into a **paused** page shows where it resumes instead of the frame from before.

The page gets four controls that insert themselves like `#pause`/`#screenshot`, and that a shell can place itself by id:

| Control | Does |
|---|---|
| **Save state** (`#savestate`) | downloads a `.clstate` file - shareable, and loadable by a desktop build |
| **Load state...** (`#loadstate`) | file picker; dropping a `.clstate` on the page does the same |
| **Quick save** (`#quicksave`) | keeps one snapshot in IndexedDB |
| **Quick load** (`#quickload`) | restores it - survives page reloads and browser restarts |

Quick load works from a cold page: with nothing booted it boots a machine and restores over it, since states carry their own ROM and disks, so a visitor returning to a game lands straight back in it. Host-side settings are not part of a machine, so the page re-applies its volume, drive-sound, floppy-speed and controller choices afterwards - including putting the mouse back on port 1 when no pad holds it, or a state saved with a pad there would restore a dead pointer.

No keyboard shortcuts: every key on the page belongs to the guest, so a host shortcut would shadow an Amiga key.

## Verification

Beyond the unit tests, driven in a real browser against a locally served copy of the site shell:

- Save/load round trip within a session, and across a full page reload (the quick slot survives).
- A state written by the **desktop** build loaded into the browser, and a state **downloaded from the browser** loaded into the desktop build - both resumed at 20.0s emulated. Byte parity between `save` and `save_to_writer` is also asserted in a unit test.
- The floppy image travels inside the state: 711 KB with an empty drive, 1.23 MB with a disk; ejecting and then restoring brings the disk back, and the status strip follows the machine.
- Garbage and truncated blobs fail with a clear status line and leave the running machine untouched.

New unit tests: `writer_reader_round_trip_matches_the_file_format` (including file/blob byte parity) and `reader_rejects_a_blob_without_the_state_magic`. `cargo test` (1670 passed), clippy, fmt, the wasm target build, and the MyST docs build are all clean.

## Docs

`docs/guide/browser.md` gains a save-states section, the new page-shell hooks, and the `save_state`/`load_state` API. The website shell's prose is a separate change in the site repository (its `try.js`/`pkg/` are published from here by CI).

Note for whoever reviews the screenshots: AROS's "Waiting for bootable media" prompt blinks about twice a second, so a browser-vs-desktop boot-screen comparison differs for reasons that are not a bug.