### PR TITLE
web: show what the page says once a machine is running

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -91,11 +91,12 @@ function showOsd(text) {
 
 function setLoadStatus(text) {
   loadStatus.textContent = text;
-  // Raise the caption only when the shell's own status line cannot be seen
-  // (offsetParent goes null when any ancestor is display:none, which is
-  // exactly the hidden-overlay case). A shell that keeps its status line
-  // permanently visible keeps sole ownership of the message.
-  if (loadStatus.offsetParent === null) showOsd(text);
+  // Raise the caption only when the shell's own status line cannot be seen.
+  // A display:none ancestor -- the hidden-overlay case -- generates no
+  // layout boxes, so an empty getClientRects() is the test. (offsetParent
+  // would look simpler, but it is also null for a position:fixed element,
+  // so a shell with a pinned status line would get the message twice.)
+  if (loadStatus.getClientRects().length === 0) showOsd(text);
 }
 
 async function fetchBytes(url, label) {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -50,8 +50,52 @@ let paused = false;
 let framesThisSecond = 0;
 let lastStatUpdate = 0;
 
+// Transient caption over the screen, the page's version of the desktop's
+// on-screen display. It exists because the shell's status line lives inside
+// the boot overlay, which is hidden for the whole life of a running
+// machine: without this, everything the page says after boot -- screenshot
+// copied to the clipboard, state saved, disk inserted -- is written
+// somewhere nobody can see, and a button that worked perfectly looks like
+// it did nothing. Over the screen rather than below it so it reads in
+// fullscreen too, where there is no page left to put a status line on.
+let osd = null;
+let osdHideTimer = 0;
+
+function ensureOsd() {
+  if (osd) return osd;
+  osd = document.createElement('div');
+  // Below the drop hint (z-index 4) and never in the way of the pointer.
+  osd.style.cssText =
+    'position:absolute;left:0;right:0;bottom:0;z-index:3;' +
+    'padding:0.5rem 0.75rem;pointer-events:none;opacity:0;' +
+    'transition:opacity 220ms ease;' +
+    'background:linear-gradient(transparent,rgba(8,11,19,0.82));' +
+    'color:rgba(255,255,255,0.92);text-align:center;' +
+    'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;';
+  // Looked up here rather than through the module's `shell` binding, which
+  // is declared further down the file: a status message can be raised
+  // before that line has run.
+  $('shell').appendChild(osd);
+  return osd;
+}
+
+function showOsd(text) {
+  const el = ensureOsd();
+  el.textContent = text;
+  el.style.opacity = '1';
+  clearTimeout(osdHideTimer);
+  osdHideTimer = setTimeout(() => {
+    el.style.opacity = '0';
+  }, 3200);
+}
+
 function setLoadStatus(text) {
   loadStatus.textContent = text;
+  // Raise the caption only when the shell's own status line cannot be seen
+  // (offsetParent goes null when any ancestor is display:none, which is
+  // exactly the hidden-overlay case). A shell that keeps its status line
+  // permanently visible keeps sole ownership of the message.
+  if (loadStatus.offsetParent === null) showOsd(text);
 }
 
 async function fetchBytes(url, label) {

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -100,6 +100,15 @@ same front-panel readouts as the desktop [status bar](ui.md): the PWR and
 FDD LEDs (plus HDD/CD on machines fitted with those drives), the floppy
 track counter, and the name of the disk in each connected drive.
 
+What the page has to say -- a screenshot copied, a state saved, a disk
+inserted, something refused -- appears as a caption across the bottom of
+the screen for a few seconds, the browser's version of the desktop's
+on-screen display. It is over the screen rather than under it so it reads
+in fullscreen too. Before boot the same messages go to the status line in
+the middle of the boot overlay, which is where a shell's own
+`#load-status` element lives; the caption takes over when that line is
+hidden, which is the whole time a machine is running.
+
 Audio starts with the boot click, but a browser autoplay policy can keep
 the AudioContext suspended anyway; the boot never waits for it. The
 emulator runs silent and the next click or key press unlocks the sound.
@@ -379,8 +388,9 @@ elements, and pages without them are untouched:
   a copy of it. Screenshot writes a PNG of the canvas -- exactly what
   the screen shows -- to the clipboard, falling back to downloading the
   file when the browser has no clipboard image support or refuses the
-  write (an unfocused document, an insecure origin); the status line
-  says which happened.
+  write (an unfocused document, an insecure origin); the caption over the
+  screen says which happened, since a clipboard copy has nothing else to
+  show for itself.
 - `#savestate`, `#loadstate`, `#quicksave`, `#quickload` (buttons): the
   [save-state controls](#browser-save-states) -- download a state, pick a
   state file, and the browser-resident quick slot. Always on like


### PR DESCRIPTION
Reported on the site: the Screenshot button "doesn't seem to do anything".

It was working the whole time. It copies a PNG to the clipboard, which is silent by nature, and the confirmation it writes was going somewhere invisible.

## Cause

The page shell's `#load-status` element sits **inside** `#overlay`, and `boot()` hides that overlay for the entire life of a running machine. So every message emitted after boot went into an element with no height:

```js
statusText: "booted AROS", statusVisible: false, statusRect: 0,
overlayDisplay: "none", statusIsInsideOverlay: true
```

That is not specific to screenshots - it swallowed every post-boot message the glue produces: state saved, state loaded, disk inserted, load refused, paused.

## Fix

`setLoadStatus` now also raises a caption across the bottom of the screen, fading after ~3s - the page's version of the desktop's on-screen display. It engages only when the shell's own status line is genuinely hidden (`offsetParent === null`), so pre-boot messages still use the overlay as before, and a shell that keeps a status line permanently visible keeps sole ownership of the message.

It lives inside `#shell`, which is the fullscreen element, so it reads in fullscreen too - where there is no page left to put a status line on. It is `pointer-events: none` and sits below the drop hint's z-index, so it never intercepts input.

## Verification

In a browser against the published site shell plus this glue:

- Pre-boot: no caption element exists; the overlay's status line is doing its job.
- Screenshot: caption reads "screenshot copied to the clipboard", fading after 3.2s.
- Quick save: caption reads "quick state saved in this browser (733 KB)", so the save-state messages from #237 are visible now too.

Note for anyone re-testing: an automation tab is never focused, so `navigator.clipboard.write` throws "Document is not focused" and the real code correctly falls back to downloading the file. I stubbed the clipboard write to a no-op to exercise the path a focused browser takes.

Screenshot behaviour itself is unchanged - clipboard first, download when the browser refuses - since that was a deliberate choice in #234 and the button now explains itself.