### PR TITLE
Fix phantom battery clock detection and the blank console window

### DIFF
--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -219,6 +219,17 @@ An MSM6242-compatible register view at `$DC0000`, present on machines
 configured with `rtc = true`. Reads reflect host time; guest writes only
 affect the emulated latch/control state, never the host clock.
 
+The part is four bits wide and sits on the low byte lane alone, so register
+N answers at `$DC0000 + N * 4 + 3` and nowhere else; the even lane is not
+wired to the clock and floats with the bus whether or not a chip is fitted.
+With `rtc = false` the page still answers the cycle, and the odd lane reads
+back `$40` (measured on real A500 hardware) rather than floating. That
+distinction matters: every OS clock probe -- AROS `battclock.resource`,
+1.3's `SetClock`, 2.0+'s `battclock.resource` -- decides a clock is present
+by writing a control nibble and reading it back, so a lane floating to the
+last value on the data bus eventually echoes the write and hands the guest
+an imaginary clock, and then an imaginary date.
+
 ## Input (`gamepad.rs`, window input paths)
 
 Host keyboard events translate to Amiga raw codes and feed a 6500/1

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -219,9 +219,13 @@ An MSM6242-compatible register view at `$DC0000`, present on machines
 configured with `rtc = true`. Reads reflect host time; guest writes only
 affect the emulated latch/control state, never the host clock.
 
-The part is four bits wide and sits on the low byte lane alone, so register
-N answers at `$DC0000 + N * 4 + 3` and nowhere else; the even lane is not
-wired to the clock and floats with the bus whether or not a chip is fitted.
+The part is four bits wide and wired to the low byte lane alone, so it answers
+on odd addresses while the even lane floats with the bus -- with or without a
+chip in the socket, since nothing else drives it either. The register select is
+A2-A5, so A1 does not reach the decode and each register answers at both of its
+odd bytes (register 0 at `+1` and `+3`, register 1 at `+5` and `+7`, ...);
+AmigaOS uses `$DC0000 + N * 4 + 3` by convention, not because the part is deaf
+at `+1`. Writes take the same lanes as reads.
 With `rtc = false` the page still answers the cycle, and the odd lane reads
 back `$40` (measured on real A500 hardware) rather than floating. That
 distinction matters: every OS clock probe -- AROS `battclock.resource`,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2323,6 +2323,33 @@ impl CpuBus {
         (ranger || reserved || below_canonical).then_some(addr & 0xFFF)
     }
 
+    /// Read the `$DC0000` clock page.
+    ///
+    /// The MSM6242 is a four-bit part sitting on the low byte lane alone, so
+    /// register N answers at `base + N * 4 + 3` and only there. The even lane
+    /// is not wired to the clock at all: it floats whether or not a clock is
+    /// fitted, which is why the OS probes address the page a byte at a time.
+    fn rtc_page_read(&mut self, addr: u32, size: usize) -> u32 {
+        let mut value = 0u32;
+        for i in 0..size {
+            let byte = self.rtc_page_byte(addr.wrapping_add(i as u32));
+            value = (value << 8) | u32::from(byte);
+        }
+        value
+    }
+
+    fn rtc_page_byte(&mut self, addr: u32) -> u8 {
+        if addr & 1 == 0 {
+            // The clock never drives this lane; it keeps the bus's charge.
+            return (self.bus.data_bus >> 8) as u8;
+        }
+        if !self.bus.rtc_present() {
+            return crate::rtc::EMPTY_SOCKET_LANE;
+        }
+        let secs = self.bus.emulated_seconds();
+        self.bus.rtc.read(u64::from(addr - RTC_BASE), 1, secs) as u8
+    }
+
     fn peek_word(&self, address: u32) -> u16 {
         let addr = self.mask(address);
         ((self.peek_byte(addr) as u16) << 8) | self.peek_byte(addr.wrapping_add(1)) as u16
@@ -2594,10 +2621,9 @@ impl CpuBus {
                 return cdtv.battram_read(addr - CDTV_BATTRAM_BASE, size);
             }
         }
-        if self.bus.rtc_present() && range_contains(RTC_BASE, RTC_SIZE, addr) {
+        if range_contains(RTC_BASE, RTC_SIZE, addr) {
             self.bus.cpu_slow_external_access(Self::access_words(size));
-            let secs = self.bus.emulated_seconds();
-            return self.bus.rtc.read(u64::from(addr - RTC_BASE), size, secs) as u32;
+            return self.rtc_page_read(addr, size);
         }
         if self.bus.gayle.is_some()
             && (range_contains(GAYLE_BASE, GAYLE_SIZE, addr)
@@ -2846,12 +2872,15 @@ impl CpuBus {
             }
             return;
         }
-        if self.bus.rtc_present() && range_contains(RTC_BASE, RTC_SIZE, addr) {
+        if range_contains(RTC_BASE, RTC_SIZE, addr) {
             self.bus.cpu_slow_external_access(Self::access_words(size));
-            let secs = self.bus.emulated_seconds();
-            self.bus
-                .rtc
-                .write(u64::from(addr - RTC_BASE), size, u64::from(value), secs);
+            // An empty clock socket answers the cycle but latches nothing.
+            if self.bus.rtc_present() {
+                let secs = self.bus.emulated_seconds();
+                self.bus
+                    .rtc
+                    .write(u64::from(addr - RTC_BASE), size, u64::from(value), secs);
+            }
             return;
         }
         if self.bus.gayle.is_some()
@@ -4031,6 +4060,123 @@ mod tests {
             ipl_sample_held: false,
             diag_current_pc: 0,
         }
+    }
+
+    /// `getreg`/`putreg` as every AmigaOS clock probe writes them: the
+    /// four-bit part answers at `base + reg * 4 + 3` and the read is masked
+    /// to the nibble.
+    fn clock_reg(bus: &mut CpuBus, reg: u32) -> u8 {
+        bus.read_byte(RTC_BASE + reg * 4 + 3) & 0x0F
+    }
+
+    fn set_clock_reg(bus: &mut CpuBus, reg: u32, value: u8) {
+        bus.write_byte(RTC_BASE + reg * 4 + 3, value);
+    }
+
+    /// An empty clock socket must not be talked into existing. Every OS probe
+    /// asks the same question -- write a control nibble, read it back -- so a
+    /// lane that floated to the last value on the data bus would eventually
+    /// echo the write and hand the guest a clock, and a date, that the machine
+    /// does not have (issue #235: KS1.3 `SetClock` printing `<unset>` instead
+    /// of "Battery Backed up Clock not found", AROS inventing a past date).
+    #[test]
+    fn an_empty_clock_socket_never_reads_back_a_written_control_nibble() {
+        let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
+        bus.bus.set_rtc_present(false);
+
+        // Whatever the bus last carried -- including the value about to be
+        // written, which is the case that invented a clock.
+        for float in [0x0000u16, 0x0404, 0x4444, 0xFFFF, 0xA53C] {
+            for reg in 0x0u32..=0xF {
+                for nibble in 0x0u8..=0xF {
+                    bus.bus.data_bus = float;
+                    set_clock_reg(&mut bus, reg, nibble);
+                    bus.bus.data_bus = float;
+                    assert_eq!(
+                        clock_reg(&mut bus, reg),
+                        0,
+                        "reg {reg:#X} echoed {nibble:#X} with the bus at {float:#06X}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// AROS `battclock.resource` init (arch/m68k-amiga), the probe from the
+    /// issue, played out in full: it looks for an RF5C01A (control D reading
+    /// 8 with control F reading 0) and an MSM6242B (control F reading 4),
+    /// resetting the part and retrying once before giving up. With no clock
+    /// fitted it must reach the end having found neither.
+    #[test]
+    fn the_aros_clock_probe_finds_nothing_in_an_empty_socket() {
+        let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
+        bus.bus.set_rtc_present(false);
+        bus.bus.data_bus = 0x0404; // the float that used to fake an MSM6242B
+
+        // "10 minutes or hours bit 3 set = not a clock" -- the early out.
+        assert_eq!(clock_reg(&mut bus, 0x01) & 8, 0);
+        assert_eq!(clock_reg(&mut bus, 0x03) & 8, 0);
+
+        let mut found = false;
+        for _ in 0..2 {
+            if clock_reg(&mut bus, 0x0D) == 0x8 && clock_reg(&mut bus, 0x0F) == 0x0 {
+                found = true; // RF5C01A
+                break;
+            }
+            if clock_reg(&mut bus, 0x0F) == 0x4 {
+                found = true; // MSM6242B
+                break;
+            }
+            set_clock_reg(&mut bus, 0xE, 0);
+            set_clock_reg(&mut bus, 0xD, 0);
+            set_clock_reg(&mut bus, 0xD, 4); // set the IRQ flag...
+            if clock_reg(&mut bus, 0xD) == 0 {
+                // ...which an MSM6242B cannot hold, so reset it as one.
+                set_clock_reg(&mut bus, 0xF, 7);
+                set_clock_reg(&mut bus, 0xF, 4);
+            } else {
+                set_clock_reg(&mut bus, 0xF, 3);
+                set_clock_reg(&mut bus, 0xF, 0);
+                set_clock_reg(&mut bus, 0xD, 8);
+            }
+        }
+        assert!(!found, "AROS found a clock in an empty socket");
+    }
+
+    /// The same probe against a fitted MSM6242 has to succeed, or the fix
+    /// above would have cost the machine its clock: control F reads the
+    /// 24-hour bit, which is the tell AROS matches on.
+    #[test]
+    fn the_aros_clock_probe_identifies_a_fitted_msm6242() {
+        let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
+        bus.bus.set_rtc_present(true);
+        bus.bus.data_bus = 0xFFFF;
+
+        assert_eq!(clock_reg(&mut bus, 0x01) & 8, 0);
+        assert_eq!(clock_reg(&mut bus, 0x03) & 8, 0);
+        assert_ne!(clock_reg(&mut bus, 0x0D), 0x8); // not an RF5C01A
+        assert_eq!(clock_reg(&mut bus, 0x0F), 0x4); // an MSM6242B
+    }
+
+    /// The clock sits on the low byte lane only: the even lane is not wired
+    /// to it and floats whether or not a chip is in the socket. AROS reads a
+    /// *word* at $DC0010 to test whether the custom registers are mirrored
+    /// into clock space, so the even lane has to keep floating.
+    #[test]
+    fn only_the_odd_byte_lane_reaches_the_clock() {
+        let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
+        bus.bus.set_rtc_present(false);
+        bus.bus.data_bus = 0xA53C;
+
+        assert_eq!(bus.read_byte(RTC_BASE + 0x34), 0xA5);
+        assert_eq!(
+            bus.read_byte(RTC_BASE + 0x37),
+            crate::rtc::EMPTY_SOCKET_LANE
+        );
+        assert_eq!(
+            bus.read_word(RTC_BASE + 0x36),
+            0xA500 | u16::from(crate::rtc::EMPTY_SOCKET_LANE)
+        );
     }
 
     #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2323,12 +2323,16 @@ impl CpuBus {
         (ranger || reserved || below_canonical).then_some(addr & 0xFFF)
     }
 
-    /// Read the `$DC0000` clock page.
+    /// The `$DC0000` clock page, a byte lane at a time.
     ///
-    /// The MSM6242 is a four-bit part sitting on the low byte lane alone, so
-    /// register N answers at `base + N * 4 + 3` and only there. The even lane
-    /// is not wired to the clock at all: it floats whether or not a clock is
-    /// fitted, which is why the OS probes address the page a byte at a time.
+    /// The MSM6242 is a four-bit part wired to the low byte lane alone, so it
+    /// answers on odd addresses and the even lane floats -- with or without a
+    /// chip in the socket, since nothing else drives it either.
+    ///
+    /// The register select is A2-A5, so A1 does not reach the decode and each
+    /// register answers at *both* of its odd bytes: register 0 at `+1` and
+    /// `+3`, register 1 at `+5` and `+7`, and so on. AmigaOS addresses them at
+    /// `base + N * 4 + 3` by convention, not because the part is deaf at `+1`.
     fn rtc_page_read(&mut self, addr: u32, size: usize) -> u32 {
         let mut value = 0u32;
         for i in 0..size {
@@ -2348,6 +2352,22 @@ impl CpuBus {
         }
         let secs = self.bus.emulated_seconds();
         self.bus.rtc.read(u64::from(addr - RTC_BASE), 1, secs) as u8
+    }
+
+    /// Writes take the same lanes as reads: a byte aimed at the even lane
+    /// reaches nothing, and a wider access lands only its odd bytes.
+    fn rtc_page_write(&mut self, addr: u32, size: usize, value: u32) {
+        for i in 0..size {
+            let addr = addr.wrapping_add(i as u32);
+            if addr & 1 == 0 {
+                continue;
+            }
+            let byte = u64::from(value >> (8 * (size - 1 - i)) & 0xFF);
+            let secs = self.bus.emulated_seconds();
+            self.bus
+                .rtc
+                .write(u64::from(addr - RTC_BASE), 1, byte, secs);
+        }
     }
 
     fn peek_word(&self, address: u32) -> u16 {
@@ -2876,10 +2896,7 @@ impl CpuBus {
             self.bus.cpu_slow_external_access(Self::access_words(size));
             // An empty clock socket answers the cycle but latches nothing.
             if self.bus.rtc_present() {
-                let secs = self.bus.emulated_seconds();
-                self.bus
-                    .rtc
-                    .write(u64::from(addr - RTC_BASE), size, u64::from(value), secs);
+                self.rtc_page_write(addr, size, value);
             }
             return;
         }
@@ -4158,10 +4175,29 @@ mod tests {
         assert_eq!(clock_reg(&mut bus, 0x0F), 0x4); // an MSM6242B
     }
 
+    /// The register select is A2-A5, so A1 never reaches the decode: each
+    /// register answers at both of its odd bytes, `+1` as well as the `+3`
+    /// AmigaOS uses by convention. Writes take the same lanes, so a value
+    /// poked at `+1` is readable at `+3` and vice versa.
+    #[test]
+    fn a1_is_not_decoded_so_both_odd_bytes_reach_the_same_register() {
+        let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
+        bus.bus.set_rtc_present(true);
+
+        // Control E (register $E) is plain readable/writable storage.
+        let plus_one = RTC_BASE + 0xE * 4 + 1;
+        let plus_three = RTC_BASE + 0xE * 4 + 3;
+        bus.write_byte(plus_three, 0x5);
+        assert_eq!(bus.read_byte(plus_one) & 0x0F, 0x5);
+        bus.write_byte(plus_one, 0xA);
+        assert_eq!(bus.read_byte(plus_three) & 0x0F, 0xA);
+    }
+
     /// The clock sits on the low byte lane only: the even lane is not wired
     /// to it and floats whether or not a chip is in the socket. AROS reads a
     /// *word* at $DC0010 to test whether the custom registers are mirrored
-    /// into clock space, so the even lane has to keep floating.
+    /// into clock space, so the even lane has to keep floating. A byte write
+    /// aimed at that lane reaches nothing.
     #[test]
     fn only_the_odd_byte_lane_reaches_the_clock() {
         let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
@@ -4177,6 +4213,13 @@ mod tests {
             bus.read_word(RTC_BASE + 0x36),
             0xA500 | u16::from(crate::rtc::EMPTY_SOCKET_LANE)
         );
+
+        // A byte write to the even lane goes nowhere, so control E keeps the
+        // value the odd lane put there.
+        bus.bus.set_rtc_present(true);
+        bus.write_byte(RTC_BASE + 0xE * 4 + 3, 0x6);
+        bus.write_byte(RTC_BASE + 0xE * 4, 0x9);
+        assert_eq!(bus.read_byte(RTC_BASE + 0xE * 4 + 3) & 0x0F, 0x6);
     }
 
     #[test]

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -24,6 +24,18 @@
 
 use crate::timebase::{SystemTime, UNIX_EPOCH};
 
+/// What the clock's byte lane reads back with no chip in the socket.
+///
+/// An empty socket does not leave the lane floating: it settles on a fixed
+/// pattern, measured as `$40` on real A500 hardware (vAmiga reports the same
+/// value from the same measurement). The low nibble reading zero is the part
+/// that matters. Every OS clock probe -- AROS `battclock.resource`, 1.3's
+/// `SetClock`, 2.0+'s `battclock.resource` -- decides a clock is there by
+/// writing a control nibble and reading it back, so a lane that floated to
+/// the last value on the data bus would sooner or later echo the written
+/// nibble and invent a clock (and then a date) that the machine does not have.
+pub const EMPTY_SOCKET_LANE: u8 = 0x40;
+
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct Msm6242Rtc {
     control_d: u8,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -856,6 +856,14 @@ enum ToolPanelKind {
     Console,
 }
 
+impl ToolPanelKind {
+    /// Every kind of tool window. The lifecycle passes and, above all,
+    /// `request_redraw` iterate this rather than naming windows one by one:
+    /// a window left out of the redraw only shows what it drew last, and the
+    /// panels that pause the machine have nothing else to repaint them.
+    const ALL: [Self; 3] = [Self::Debugger, Self::FrameAnalyzer, Self::Console];
+}
+
 struct RenderJob {
     generation: u64,
     input: bitplane::RenderInput,
@@ -3015,18 +3023,9 @@ impl App {
     }
 
     fn tool_window_kind(&self, window_id: WindowId) -> Option<ToolPanelKind> {
-        [
-            (ToolPanelKind::Debugger, self.debugger_tool_window.as_ref()),
-            (
-                ToolPanelKind::FrameAnalyzer,
-                self.frame_analyzer_tool_window.as_ref(),
-            ),
-            (ToolPanelKind::Console, self.console_tool_window.as_ref()),
-        ]
-        .into_iter()
-        .find_map(|(kind, tool)| {
-            tool.is_some_and(|tool| tool.window.id() == window_id)
-                .then_some(kind)
+        ToolPanelKind::ALL.into_iter().find(|&kind| {
+            self.tool_window(kind)
+                .is_some_and(|tool| tool.window.id() == window_id)
         })
     }
 
@@ -4019,9 +4018,9 @@ impl App {
     }
 
     fn ensure_tool_windows_for_open_panels(&mut self, event_loop: &ActiveEventLoop) {
-        self.ensure_tool_window_for_kind(event_loop, ToolPanelKind::Debugger, true);
-        self.ensure_tool_window_for_kind(event_loop, ToolPanelKind::FrameAnalyzer, true);
-        self.ensure_tool_window_for_kind(event_loop, ToolPanelKind::Console, true);
+        for kind in ToolPanelKind::ALL {
+            self.ensure_tool_window_for_kind(event_loop, kind, true);
+        }
     }
 
     /// Frame-loop variant of ensure_tool_windows_for_open_panels: still
@@ -4032,9 +4031,9 @@ impl App {
         if due {
             self.last_tool_redraw = Instant::now();
         }
-        self.ensure_tool_window_for_kind(event_loop, ToolPanelKind::Debugger, due);
-        self.ensure_tool_window_for_kind(event_loop, ToolPanelKind::FrameAnalyzer, due);
-        self.ensure_tool_window_for_kind(event_loop, ToolPanelKind::Console, due);
+        for kind in ToolPanelKind::ALL {
+            self.ensure_tool_window_for_kind(event_loop, kind, due);
+        }
     }
 
     fn ensure_tool_window_for_kind(
@@ -7037,14 +7036,11 @@ impl App {
 
     fn request_redraw(&self) {
         self.request_main_redraw();
-        if let Some(tool) = self.debugger_tool_window.as_ref() {
-            if !tool.minimized {
-                tool.window.request_redraw();
-            }
-        }
-        if let Some(tool) = self.frame_analyzer_tool_window.as_ref() {
-            if !tool.minimized {
-                tool.window.request_redraw();
+        for kind in ToolPanelKind::ALL {
+            if let Some(tool) = self.tool_window(kind) {
+                if !tool.minimized {
+                    tool.window.request_redraw();
+                }
             }
         }
     }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2256,6 +2256,44 @@ fn debugger_window_pauses_steps_and_restores_run_state() {
     assert!(!app.paused);
 }
 
+/// Every tool-window kind has to appear in `ToolPanelKind::ALL`, because
+/// that is what `request_redraw` iterates. The panels that pause the machine
+/// (debugger, console) stop the frame loop, and the frame loop is the only
+/// other thing that repaints tool windows -- so a kind missing from `ALL` is
+/// a window frozen on whatever it last drew. That was issue #236: the console
+/// opened blank and stayed blank until a click happened to expose it, and
+/// typed characters did not show up until something else forced a repaint.
+#[test]
+fn every_tool_panel_kind_is_in_the_redraw_pass() {
+    for kind in [
+        ToolPanelKind::Debugger,
+        ToolPanelKind::FrameAnalyzer,
+        ToolPanelKind::Console,
+    ] {
+        // Exhaustive on purpose: a new kind stops compiling here, which is
+        // the prompt to add it to the list above and to ALL.
+        match kind {
+            ToolPanelKind::Debugger | ToolPanelKind::FrameAnalyzer | ToolPanelKind::Console => {}
+        }
+        assert!(
+            ToolPanelKind::ALL.contains(&kind),
+            "{kind:?} is not in ToolPanelKind::ALL, so its window never repaints"
+        );
+    }
+}
+
+/// The console pauses the machine, which is what makes the redraw pass the
+/// only thing that can repaint its window.
+#[test]
+fn opening_the_console_pauses_the_machine() {
+    let mut app = test_app();
+    assert!(!app.paused);
+    app.open_console();
+    assert!(app.paused);
+    app.close_tool_panel(ToolPanelKind::Console);
+    assert!(!app.paused);
+}
+
 #[test]
 fn debugger_and_frame_analyzer_can_stay_open_together() {
     let mut app = test_app();


### PR DESCRIPTION
Two unrelated bug reports.

## #235 -- phantom battery-backed clock

With no clock fitted, reads of the `$DC0000` page floated to the last value the
data bus carried. Every AmigaOS clock probe -- AROS `battclock.resource`, 1.3's
`SetClock`, 2.0+'s `battclock.resource` -- decides a clock is present by writing
a control nibble and reading it back, so sooner or later the float echoed the
write, the guest concluded a clock was there, and read a date out of DMA noise.
That is the reported `<unset> <unset> <unset>` under KS1.3 and the random past
date under AROS, and it explains why both were intermittent: it depended on what
DMA had just fetched.

Reproduced and fixed end to end, KS1.3 + WB1.3, same config, 30s headless boot:

| | Result |
|---|---|
| main | `Thursday 22-Jun-89 02:00:03` -- a phantom clock, and an invented date |
| this branch | `Battery Backed up Clock not found` |

The fix models the page's byte lanes. The MSM6242 is a four-bit part wired to
the low lane alone, so it answers on odd addresses while the even lane floats --
with or without a chip in the socket, since nothing else drives it either. With
no clock fitted the odd lane reads back `$40`: measured on real A500 hardware,
and the value vAmiga returns from the same measurement. Its low nibble reading
zero is what makes the probes reach the right conclusion every time.

Traced by logging the page during an AROS boot (`[debug] log_unmapped`), which
caught the probe mid-sequence:

```
wr 0xDC0037.b <- 0x04     ; putreg(p, 0xd, 4) -- set the IRQ flag
rd 0xDC0037.b -> 0x00     ; getreg(p, 0xd)    -- must not read back 4
```

and checked against `AROS/arch/m68k-amiga/battclock/battclock_init.c`, whose
init sequence is now a regression test in both directions: an empty socket must
find nothing, a fitted MSM6242 must still be identified. Further tests sweep
every register and nibble against several bus values to assert no write is ever
echoed back, and pin the decode (A2-A5 select, so each register answers at both
of its odd bytes).

A fitted clock is unaffected: the WB1.3 boot with `rtc = true` and
`--rtc-time "2005-03-18 01:58:29"` is byte-identical to the same boot on main.
(It reads `18-Mar-78` because AmigaOS 1.3 clamps a two-digit year predating its
1978 epoch -- pre-existing, and identical on both sides.)

## #236 -- console window blank until clicked

`request_redraw` named the debugger and frame-analyzer windows one by one and
never learned about the console. Opening the console pauses the machine, which
stops the frame loop -- the only other thing that repaints tool windows -- so the
window came up blank and stayed blank until a click happened to expose it, and
typed characters did not appear until something else forced a repaint. The input
line already draws a caret; it was never redrawn.

Now the redraw pass and the two lifecycle passes iterate `ToolPanelKind::ALL`, so
a window cannot be left out again, with a test that fails if a kind goes missing.

## Verification

`cargo test` (1674 + 20 golden probes), `cargo clippy`, `cargo fmt --check` all
clean; no golden re-blessing needed. `cargo test --release -- --ignored` passes
except `ocs_bpu7_ham_captures_avoid_isolated_vertical_rectangle_frames`, which
fails at the byte-identical pixel count (24092) already recorded for this host on
clean main.

The console fix is verified by code inspection and the redraw-coverage test only
-- I could not drive the real window on this host to watch it repaint, so a quick
manual check (Cmd+K, type a few letters) is worth doing before merge.