### PR TITLE
docs: reconcile the docs with the externally contributed v0.11/v0.12 work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,12 @@ file and no Kickstart at all. Configuration is a TOML file
 `docs/guide/configuration.md`), and the common machine knobs are also CLI
 flags layered on top: `--model A500|A1200|CD32|...`, `--chipset OCS|ECS|AGA`,
 `--cpu 68000..68060`, `--chip`/`--fast`/`--slow` memory sizes,
-`--floppy-drives N`. A bare ROM or disk-image path is accepted positionally:
+`--floppy-drives N`. A bare ROM path (only) is accepted positionally; disk
+images go in via `[floppy.df0] path` in the config or `--insert-disk-after`:
 
 ```sh
-./target/release/copperline --model A1200 --fast 8M KICK31.ROM game.adf
+./target/release/copperline --model A1200 --fast 8M KICK31.ROM \
+  --insert-disk-after 0 df0 game.adf
 ```
 
 Running with no arguments at all opens an interactive launcher window; any

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ against real hardware.
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
   (ADF / ADZ / ZIP / DMS, read-only SCP), Gayle and A4000 IDE, SCSI (A2091,
   A4091, or the A3000's onboard Super DMAC), CDTV/CD32 CD, A2065 Ethernet,
-  host directories served live as AmigaDOS volumes, and Zorro boards
-  loadable as WASM plugins.
+  a Z3660 RTG card (high-colour Picasso96 screens), the serial port bridged
+  to host stdout/TCP/PTY/MIDI, a parallel-port printer capture and audio
+  sampler, host directories served live as AmigaDOS volumes, and Zorro
+  boards loadable as WASM plugins.
 - **Tooling**: an in-window debugger that can step backwards, an
   interactive chip-bus frame analyzer, a trigger-based VCD waveform export
   of the chipset signals for GTKWave (`docs/debugger/waveform.md`), remote
@@ -142,11 +144,12 @@ cargo build --release
 ./target/release/copperline
 ```
 
-The binary looks for `./copperline.toml`; if it isn't present, built-in
-defaults are used (68000 at ~7.09 MHz, OCS, PAL, real speed, and the bundled
-[AROS](https://www.aros.org/) ROM on a 1 MB A500: 512 KiB chip plus 512 KiB
-trapdoor slow RAM). Boot your own ROM with a positional argument, or point at a
-config file:
+The binary looks for `./copperline.toml`; if it isn't present, a bare
+invocation opens the machine-configuration screen, starting from the built-in
+defaults (an A500 Rev 6A: 68000 at ~7.09 MHz, ECS 8372A Agnus with OCS Denise,
+PAL, real speed, and the bundled [AROS](https://www.aros.org/) ROM with
+512 KiB chip plus 512 KiB trapdoor slow RAM). Any argument skips the screen
+and boots directly: your own ROM as a positional argument, or a config file:
 
 ```sh
 ./target/release/copperline path/to/kickstart.rom
@@ -236,12 +239,12 @@ substring is enough); `--midi-out`/`--midi-in` imply `--serial midi`:
 ./target/release/copperline --midi-out "FluidSynth" --midi-in "Keystation"
 ```
 
-Devices can also be chosen in the launcher's **Serial** tab, swapped live from
-the in-window **MIDI In / MIDI Out** menu, or set in the config file:
+Devices can also be chosen in the launcher's **I/O Ports** tab, swapped live
+from the in-window **MIDI In / MIDI Out** menu, or set in the config file:
 
 ```toml
 [serial]
-mode = "midi"            # off, stdout, midi, tcp, or pty
+mode = "midi"            # off, stdout, midi, tcp, tcp-connect, or pty
 midi_out = "FluidSynth"  # host destination; substring match
 midi_in = "Keystation"   # host source
 ```
@@ -321,7 +324,7 @@ release needs resolved first. Release steps for every channel are in
 | Slow RAM | Optional A500 trapdoor/fake-fast RAM at $00C00000; arbitrated on the chip bus through Agnus like chip RAM. |
 | ROM | Kickstart at $F80000 (512 KiB); optional extended ROM for CD32 ($E00000) and CDTV ($F00000). |
 | Battery RTC | Read-only MSM6242-compatible register view at $DC0000; guest writes affect only emulated latch/control state. |
-| CIA-A / CIA-B | I/O ports, /OVL, timers, TOD, keyboard SDR/ICR, disk control/status lines, and CIA-B FLAG disk index pulses. |
+| CIA-A / CIA-B | I/O ports, /OVL, timers, TOD, keyboard SDR/ICR, disk control/status lines, CIA-B FLAG disk index pulses, and the Centronics parallel port (data/strobe/ACK on CIA-A, BUSY/POUT/SEL on CIA-B). |
 | Paula serial | SERDAT through a one-word transmit buffer and timed shift register, out to stdout, a TCP port, a pseudo-terminal, or -- with the default `midi` feature -- bridged to host MIDI in/out; SERDATR reports TBE/TSRE/RBF, and serial receive is fed from the selected input. |
 | Paula audio | 4-channel DMA/sample playback, stereo mix, LED filter. |
 | Paula DMACON / INTENA / INTREQ | IRQ bits are stored and delivered through manual M68K autovectors with modelled 68000 interrupt-recognition latency; audio and disk DMA raise completion IRQs. |

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -8,6 +8,10 @@
 # which ships with Copperline as the default boot ROM.
 rom = "kickstart.rom"
 
+# The Copperline identification board: a small, inert Zorro board that lets
+# guest software (identify.library) detect it is running under Copperline.
+# identify = false           # drop it from the Zorro chain (default: present)
+
 
 [emulation]
 
@@ -219,7 +223,8 @@ slow = "512K"
 
 
 # RTG graphics card: high-resolution, high-colour screens via Picasso96.
-# Fitted by default on machines with Zorro III (A3000/A4000).
+# Fitted by default on any machine whose CPU has a 32-bit address bus
+# (stock A3000/A4000, or any profile given a 68020+ full-bus CPU).
 # [rtg]
 # card = "z3660"           # or "none"
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -270,7 +270,9 @@ Diagnostic captures: `trace.start {path?, max_lines?}`, `trace.status`,
 
 State and capture: `state.save {path}`, `state.load {path}` (re-arms
 the reverse-debug ring on the loaded timeline), `capture.screenshot
-{path?}` (raw framebuffer PNG, 716 pixels wide), `capture.digest`
+{path?}` (raw framebuffer PNG, 716 pixels wide; with an active RTG
+screen it is the board frame downsampled to that width at the board's
+native row count), `capture.digest`
 (FNV-1a hash of the rendered frame -- the cheap change-detection
 primitive, identical in both server modes), `machine.reset
 {kind: "warm"|"cold"}`.

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -171,6 +171,7 @@ authoritative list. The most useful ones:
 | `COPPERLINE_DIAG_CRASH` | CPU empty-RAM execution and low-memory blitter write context |
 | `COPPERLINE_DIAG_GAYLE` / `COPPERLINE_DIAG_CDTV` | Gayle IDE / CDTV controller traffic |
 | `COPPERLINE_DIAG_A2091` | A2091 SCSI board register traffic (DMAC + WD33C93 accesses; the trace that brings up boot-ROM issues) |
+| `COPPERLINE_DIAG_A4091` | A4091 53C710 SCRIPTS execution trace (each instruction the script processor runs) |
 | `COPPERLINE_DIAG_CURSOR` | On every mouse-button press, log the raw host cursor position, the window's scale factor and inner size, the texture supersample factor, the `window_pos_to_pixel` result, and which region (status bar / display / none) the click resolved to; for diagnosing mouse capture on DPI scale changes or mixed-scale monitors |
 | `COPPERLINE_DUMP_BLITMEM=START:END:LO:HI` | Dump chip RAM `[LO,HI)` on every BLTSIZE write between START and END emulated seconds; output goes to `$TMPDIR/copperline-blitdump` unless `COPPERLINE_DUMP_BLITMEM_DIR` is set |
 | `COPPERLINE_DUMP_BUS_ACCOUNTING` | Per-frame chip-bus slot accounting |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -561,8 +561,9 @@ With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
 console. `--serial MODE` overrides the mode per run,
 `--serial-connect HOST:PORT` sets the dial-out target (and implies
 `mode = "tcp-connect"`), and `--midi-out NAME`/`--midi-in NAME` imply
-`mode = "midi"`. The launcher's **Serial** tab and the in-window
-**MIDI In / MIDI Out** menu items select the MIDI endpoints interactively.
+`mode = "midi"`. The launcher's **I/O Ports** tab (Serial section) and the
+in-window **MIDI In / MIDI Out** menu items select the MIDI endpoints
+interactively.
 
 The browser build has its own serial transport (the page bridges the port
 to a WebSocket); see [the browser chapter](browser.md).

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -178,6 +178,8 @@ path = "MyGame.adf"
 
 Copperline accepts plain ADF images, gzip-compressed images, single file ZIP
 archives, DMS archives, UAE extended ADFs, and read-only SCP flux images.
+In a windowed session you can also just drag a disk image onto the window
+to insert it -- see [](ui#drag-and-drop).
 
 ## Example configuration
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -47,7 +47,9 @@ reboot lands a fraction of a second after the chord, as on real hardware.
 
 ## Status bar
 
-The status bar (44 pixels below the display) holds, left to right:
+The status bar (44 pixels below the display) holds, left to right (it can
+be hidden entirely with `Cmd+Shift+F` / `Alt+Shift+F` or the **Status Bar**
+menu item):
 
 - **LED block.** PWR and FDD always; a green HDD activity LED on machines
   with a hard-disk controller (Gayle or A4000 IDE, or any SCSI adapter); a
@@ -231,8 +233,9 @@ The layout is:
   CD image
   on a machine with no CD drive) are dropped so they cannot block a launch.
 - **Category tabs** (left sidebar). *System* (chipset and Agnus/Denise
-  overrides, video standard, RTC, identify board), *CPU* (model, FPU, clock,
-  caches), *Memory* (chip/fast/slow/motherboard/Zorro III RAM), *ROM*
+  overrides, video standard, RTC, identify board, RTG card), *CPU* (model,
+  FPU, clock, caches), *Memory* (chip/fast/slow/motherboard/Zorro III RAM),
+  *ROM*
   (Kickstart and
   extended ROM), *Floppy* (drive count and speed, per-drive image and
   write-protect),
@@ -240,7 +243,8 @@ The layout is:
   A3000's onboard SCSI -- and its boot ROM and units, plus a **Host Mounts**
   link to a sub-page for host directories served live as AmigaDOS volumes: up
   to four mounts, each with a boot priority and a read-write/read-only
-  **Access** field), *CD* (image,
+  **Access** field -- the config file itself takes up to eight `[[filesys]]`
+  mounts, of which the launcher edits the first four), *CD* (image,
   insert delay, CD32 NVRAM),
   *Input* (the controller device in each game port and the joystick input
   source),
@@ -260,15 +264,17 @@ The layout is:
   click it and type to set the volume name for a directory mount (left blank, a
   directory mount inherits the host directory's name; the box has no effect on a
   raw HDF). A setting that does not apply to the chosen machine is greyed and
-  shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM,
-  "needs 68020+" for the FPU, "needs A600/A1200/A4000" for IDE.
+  shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM
+  and the RTG card, "needs 68020+" for the FPU, "needs A600/A1200/A4000" for
+  IDE.
 - **Action bar** (bottom). **Load...** and **Save...** read and write a `.toml`
   config
   through a file dialog (Save writes a minimal file, only the settings that
   differ from the chosen profile's defaults, so it reads like the example
   configs). **Defaults** resets to the selected profile. **Run** validates the
   configuration and boots it; if anything is wrong -- an unusable RAM size, a
-  missing disk image, an option the chosen machine cannot use -- the reason is
+  missing disk image, a ROM file that cannot be read, an option the chosen
+  machine cannot use -- the reason is
   shown on the status line and you stay on the screen to fix it.
 
 Saved files use the same schema as a hand-written `copperline.toml`

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -223,15 +223,17 @@ the extra cycle), matching the CIASetInt latency observable from the CPU.
 
 CIA-A carries /OVL (the reset-time ROM overlay at `$0`), the keyboard
 serial port (SDR/ICR with the KDAT handshake and an emulated
-keyboard-controller pacing delay), and the fire-button lines. CIA-B
-carries the floppy control lines (motor, select, side, step) and the FLAG
-input pulsed by the disk index. Its port-B access pulse (`PC`) is also the
-Centronics `/STROBE`: the bus samples the physical PRB pins without creating
-another access, forwards one strobe to the attached parallel peripheral, and
-feeds an accepted byte's `/ACK` edge back through CIA-A FLAG. With no
-peripheral attached the line remains unacknowledged, like an unplugged cable.
-PB6/PB7 pulse-output mode holds the selected pin low for one E-clock; reading
-PRB observes the pulse without shortening it.
+keyboard-controller pacing delay), the fire-button lines, and the
+Centronics parallel data port: its port-B access pulse (`PC`) is the
+Centronics `/STROBE`, so the bus samples the physical PRB pins without
+creating another access, forwards one strobe to the attached parallel
+peripheral, and feeds an accepted byte's `/ACK` edge back through CIA-A
+FLAG. With no peripheral attached the line remains unacknowledged, like an
+unplugged cable. CIA-B carries the floppy control lines (motor, select,
+side, step), the FLAG input pulsed by the disk index, and the parallel
+status lines (BUSY/POUT/SEL on port A bits 0-2). PB6/PB7 pulse-output mode
+holds the selected pin low for one E-clock; reading PRB observes the pulse
+without shortening it.
 
 CIA timing is resolved on the E-clock grid (one tick per five colour clocks),
 which is the smallest phase the current CPU/bus boundary exposes. Timer

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -353,14 +353,16 @@ table walk rather than the physical bus -- the ATC bit; that bit is how an
 OS-level page-fault handler (mmu.library, VMM, Enforcer) tells a translation
 fault it must service from a real bus error it must pass on, and mmu.library's
 lazily-materialized user tables guru without it (issue #90). A faulted write
-is reported in writeback slot 2 (WB2S valid bit, size and transfer modifier,
-address and data in WB2A/WB2D): a handler that clears WB2S.V has absorbed
-the store -- how Enforcer/MuForce discard writes into protected pages -- and
-RTE honours that by discarding the restarted instruction's matching write. A
-handler that completes the writeback manually but leaves V set gets the
-restart's store instead (a double store to plain memory, the restart-model
-gap). The other writeback slots and continuation fields stay clear;
-mid-instruction continuation is not modelled.
+is reported in writeback slot 3 (WB3S valid bit, size and transfer modifier,
+address and data in WB3A/WB3D), matching real 68040 silicon -- WB2 is
+reserved for MOVE16 cacheline writes and stays clear. A handler that clears
+WB3S.V has absorbed the store -- how Enforcer/MuForce discard writes into
+protected pages -- and RTE honours that by discarding the restarted
+instruction's matching write; MuGuardianAngel completes an allowed write by
+storing WB3D to WB3A itself. A handler that completes the writeback manually
+but leaves V set gets the restart's store instead (a double store to plain
+memory, the restart-model gap). The other writeback slots and continuation
+fields stay clear; mid-instruction continuation is not modelled.
 
 A *data* access through an invalid/unconfigured descriptor raises an access
 fault -- this is how Enforcer/MuForce catch low-memory and freed-memory hits. An

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -10,6 +10,41 @@ Z3 RAM options and user `[[zorro]]` metadata boards all build the same
 specs. The user-facing guide, including the metadata file format and the
 autoconfig walk-through, is [](../zorro).
 
+## Fat Gary and Ramsey (`gary.rs`, `ramsey.rs`)
+
+The A3000 and A4000 profiles fit the big-box motherboard pair: Fat Gary,
+the bus controller, and Ramsey, the memory controller. Both answer in the
+`$DE0000` page Gary decodes, with an address decode cruder than a register
+map suggests: only the byte lane and two address bits matter (lanes 0-2
+are Gary's, lane 3 is Ramsey's), and the whole layout repeats every `$100`
+to the end of the page, so every register is mirrored many times over --
+the Ramsey version register Kickstart reads at `$DE0043` answers equally
+at `$DE0047` or `$DE0143`. Diagnostic tools reading addresses that look
+like nothing in particular are reading a mirror.
+
+Gary's three registers are single read/write bits in bit 7: TIMEOUT
+(`$DE0000`, whether an unanswered bus cycle produces BERR or DSACK), TOENB
+(`$DE0001`, timeout enable), and COLDBOOT (`$DE0002`, the power-up flag
+the OS clears on warm reboot). None of them change emulated behaviour --
+bus timeouts are not modelled; an unanswered cycle floats -- but the
+read/write COLDBOOT bit is what identification tools use to detect a Fat
+Gary, and without one they never go looking for the Ramsey behind it.
+
+Ramsey drives the motherboard fast RAM (`[memory] motherboard`): a 32-bit
+local bank ending at `$08000000` and growing downward, so a full 16 MiB
+reaches `$07000000`. Its two byte-wide registers sit on lane 3: the
+control register at `$DE0003` (refresh rate, page/burst/skip modes, DRAM
+geometry) and the read-only version register at `$DE0043` -- `$0D` for
+the A3000's Ramsey-04, `$0F` for the A4000's Ramsey-07, a distinction
+that matters because the two parts disagree about control bit 4
+(Ramsey-04 DRAM width versus Ramsey-07 cycle-skip mode). Refresh and the
+speed modes have no observable effect in an emulator that never loses a
+DRAM cell, but the bits store and read back because Kickstart and the
+diagnostic tools write a mode and spin until they read it back, and the
+geometry bits are seeded to describe DRAM parts matching the fitted RAM
+size so sizing probes agree with the RAM that answers. Only the register
+file lives in `ramsey.rs`; the RAM bank itself is `memory::Memory::mb_ram`.
+
 ## Gayle IDE (`gayle.rs`)
 
 A600/A1200 machines get the Gayle gate array: the ID register at
@@ -139,12 +174,30 @@ from the `dirfs.rs` path above, which snapshots a directory into an
 in-memory FFS volume behind a virtual drive. The guest side is a tiny
 handler (see `guest/services/`) mapped into the Copperline services board
 with a mount table and a hand-built DiagArea; at expansion init it builds
-one DeviceNode per mount and `AddBootNode`s it, so DOS mounts the devices
-at boot. The handler forwards every DosPacket to the host through a
-reserved A-line trap, and all `ACTION_*` semantics -- reads, writes,
-create/rename/delete, directory walks, protection, comments, datestamps
--- are implemented host-side against the real filesystem, with results
-written straight into guest memory.
+one DeviceNode per mount and `AddBootNode`s it (at the mount's configured
+boot priority), so DOS mounts the devices at boot. The handler forwards
+every DosPacket to the host through a doorbell register in the board's
+MMIO window: writing the packet APTR to `REG_DOSPKT` services the packet
+synchronously inside the register write, so `dp_Res1`/`dp_Res2` and the
+result registers are filled before the next guest instruction runs. All
+`ACTION_*` semantics -- reads, writes, create/rename/delete, directory
+walks, protection, comments, datestamps -- are implemented host-side
+against the real filesystem, with results written straight into guest
+memory.
+
+Each mount unit owns its own bank of longword registers in the window
+(layout shared with the guest via `guest/services/copperline_board.h`):
+`REG_MSGPORT` publishes the handler process's MsgPort while the unit is
+live, and `REG_RESULT`/`REG_ARG` tell the handler what to do with the
+packet it just rang in (reply it, `AddDosEntry` a host-built volume
+DosList node, or exit on `ACTION_DIE`). One handler process runs per
+unit against its own bank, so mounts never synchronize with each other.
+A single global `DIAG_DOORBELL` strobe carries the expansion-init work,
+which runs before any handler process exists. That init strobe is also
+where `[machine] rom_scsi_device_disable` takes effect: the board's
+DiagPoint culls the ROM's `scsi.device` resident tag (`romtags.rs`),
+which is why setting the flag instantiates the services board even with
+no `[[filesys]]` mounts configured.
 
 Amiga attributes a host filesystem cannot hold live in UAE-style `.uaem`
 sidecar files (read when present, written back on change, hidden from
@@ -320,10 +373,13 @@ Paula's SERDAT transmit path lands on a `SerialSink`. The default
 `StdoutSink` prints to the host terminal -- this
 is how DiagROM's diagnostic stream and the `timing-test/` results are
 captured in terminals and CI logs. `TcpSerialSink` bridges the port to a
-listening TCP socket (`[serial] mode = "tcp"`, one client at a time) and
-`PtySerialSink` to a host pseudo-terminal pair (`mode = "pty"`, Unix
-only); both are bidirectional, so an `AUX:` shell on the Amiga side gives
-a remote AmigaDOS console.
+listening TCP socket (`[serial] mode = "tcp"`, one client at a time) or
+dials out to a remote endpoint (`mode = "tcp-connect"` with `connect =
+"host:port"` -- the BBS-client wiring), and `PtySerialSink` bridges to a
+host pseudo-terminal pair (`mode = "pty"`, Unix only); all are
+bidirectional, so an `AUX:` shell on the Amiga side gives a remote
+AmigaDOS console. The browser build swaps in a channel-backed sink that
+the page bridges to a WebSocket.
 
 A `SerialSink` that can *produce* input must override
 `has_pending_input` alongside `read_byte`/`read_word`:
@@ -384,3 +440,31 @@ serial, i.e. the fault is upstream of the bridge); `=2` decodes every
 message in each direction. `COPPERLINE_MIDI_IMMEDIATE=1` bypasses
 scheduling and sends each message for immediate delivery, to separate a
 timing problem from a connection one.
+
+## Parallel port peripherals (`parallel.rs`, `sampler.rs`)
+
+The Centronics port's peripheral boundary is the `ParallelPort` trait.
+CIA-A port B (`$BFE101`) carries the eight data pins and CIA-A's `PC`
+output is the active-low printer strobe: the bus forwards each strobe
+with the physical pin levels, and a peripheral that accepts the byte
+returns true, which the bus turns into the printer's active-low `/ACK`
+edge on CIA-A FLAG. An input peripheral instead drives the data pins
+itself on every CIA-A port-B read. The status lines BUSY, POUT, and SEL
+are CIA-B port A pins 0-2, peripheral-driven inputs with motherboard
+pull-ups. The default null peripheral is an unplugged cable: it neither
+acknowledges nor drives any pin, and the pulled-up status lines read all
+high.
+
+`[parallel] device = "printer"` captures strobed bytes to the configured
+output file (`FileParallelPort`), holding the status lines at
+ready-online levels (SEL high, BUSY and POUT low) -- without those,
+`parallel.device` polls BUSY forever and never sends a byte. `device =
+"sampler"` fits the classic mono 8-bit parallel-port digitizer
+(AMAS/DSS-class, modelled on the open-amiga-sampler schematics): a host
+capture stream fills a ring in real time and each port-B read returns
+the sample for the elapsed *emulated* time, so recordings line up
+however fast or slow the Amiga polls. Samples are 8-bit offset-binary
+(128 = silence), host left and right are summed to the mono input, and
+the preamp gain is clamped to +/-24 dB. `COPPERLINE_SAMPLER_DEBUG=1`
+logs the captured input level about once a second -- a CLI VU meter for
+checking the host microphone is feeding the port.

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -346,6 +346,31 @@ framebuffer):
   display that genuinely fetches bitplane data into the overscan border is left
   exactly as rendered.
 
+### RTG scanout (Z3660)
+
+When a fitted `[rtg]` board's guest driver switches the display to RTG,
+the presentation path swaps sources: the board's panned framebuffer
+(decoded from VRAM in the scanout's pixel format, with the board's
+hardware mouse sprite -- including wide and doubled sprites -- composited
+over it in `z3660.rs`) replaces the chipset render. The window presents
+that frame at its native resolution through a dedicated GPU texture
+rather than the 716-wide chipset buffer, and the TV aperture crop is
+suppressed -- it is a chipset crop rect, and applying it would show a
+sub-rect of the board's screen. While a menu or panel is open the window
+falls back to the CPU present path (at the cost of the downscale) so the
+overlay is not overdrawn by the GPU pass. If the board claims the display
+but its frame does not compose yet (mode set before the resolution
+registers), presentation falls back to the chipset render rather than
+freezing on a stale frame.
+
+`compose_rtg_present` (`present_common.rs`) also keeps an
+`FB_WIDTH`-stride copy of the native frame for the screenshot and CCP
+capture paths, which read the shared presentation buffer: one output row
+per board row at the board's native height, downsampled horizontally by
+sampling each output pixel's source-span centre so the rightmost source
+columns survive. Screenshots under RTG are therefore 716 wide at the
+board's native row count.
+
 `ui.rs` implements the status bar widgets, the pop-up menu, the smaller
 overlay panels (About, Shortcuts, Calibration), and the shared debugger/tool
 panel drawing used by the native debugger and frame-analyzer windows. The UI

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -229,6 +229,27 @@ while traffic flows -- the emulator logs this when the board is attached. Save
 states record only the chosen backend and bring up a fresh one on load
 (in-flight frames are dropped; the guest's TCP retransmits).
 
+## Graphics: the Z3660 RTG board
+
+`[rtg] card = "z3660"` fits an in-tree RTG (retargetable graphics) board
+(`src/z3660.rs`) modelled on the Z3660 accelerator's FPGA graphics core,
+driven by the open-source Z3660.card Picasso96 driver in the guest (see
+[the configuration guide](guide/configuration) for setup). Although
+the physical board sits in the A3000/A4000 CPU slot, its RTG core
+autoconfigs as an ordinary Zorro III board -- manufacturer `0x144B`,
+product 1, the real board's identity rather than Copperline's own
+manufacturer ID below -- with one 128 MB window. The driver finds it with
+`FindConfigDev` and talks to a 32-bit register file in the first 2 KB of
+the window; the rest is board RAM, with P96 VRAM from window offset
+`+0x200000` and the GFXData blit-parameter mailbox the driver fills
+before ringing a blit at `+0x3200000`. Only the first 64 MB is backed --
+the driver never touches the window beyond ~52 MB, so the allocation
+stays honest without carrying all 128 MB.
+
+Like the A2065 it is a device-backed board, not a `[[zorro]]` metadata
+board; the scanout and blitter model live in `z3660.rs` and the
+presentation path is described in [](internals/video).
+
 ## How autoconfig works in Copperline
 
 Everything below happens automatically; it is documented so you can debug a
@@ -299,6 +320,7 @@ makes the real ROMulus flash-ROM board. The product numbers under it are:
 | 2 | Copperline identification board |
 | 3 | Built-in fast RAM (`[memory] fast`) |
 | 4 | Built-in Zorro III RAM (`[memory] z3`) |
+| 5 | Copperline services board (host `[[filesys]]` mounts; `filesys.rs`) |
 
 The **identification board** (`BoardSpec::copperline_id`) is always added to
 the chain (unless disabled, below) so guest software can detect that it is

--- a/guest/services/README.md
+++ b/guest/services/README.md
@@ -13,9 +13,10 @@ Two entry points (see `entry.s` and `copperline_board.h`):
 - `mount_boards()` -- called at expansion init from the board's DiagArea
   with the documented DiagPoint context. Builds one DeviceNode per entry in
   the mount table the emulator wrote into the board window and adds it with
-  `AddBootNode` (priority -128: mounted at DOS init, never a boot candidate).
-- `handler_main()` -- the DOS handler process, started by DOS on first
-  reference to a mount. `WaitPort`/`GetMsg`, ring the packet in through the
+  `AddBootNode` at the priority from the mount's `bootpri` config (default
+  -128: mounted at DOS init, never a boot candidate).
+- `handler_main()` -- the DOS handler process, started by DOS at mount time
+  (`ADNF_STARTPROC`). `WaitPort`/`GetMsg`, ring the packet in through the
   unit's doorbell register (the emulator fills `dp_Res1`/`dp_Res2` within
   the write), reply the packet.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1614,7 +1614,7 @@ pub(crate) struct RawInput {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawSerial {
-    /// "stdout" (default), "off", or "midi".
+    /// "stdout" (default), "off", "midi", "tcp", "tcp-connect", or "pty".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mode: Option<String>,
     /// Host MIDI output endpoint name (substring match); MIDI mode only.

--- a/src/main.rs
+++ b/src/main.rs
@@ -895,9 +895,10 @@ fn print_help() {
          \n\
          Options:\n  \
          -c, --config FILE              load configuration from FILE (default: ./copperline.toml)\n  \
-         --model NAME                   machine profile: A500, A500Plus, A600, A1200, CDTV, CD32\n  \
+         --model NAME                   machine profile: A1000, A500, A500OCS, A500Plus, A600,\n  \
+         \x20                              A1200, A3000, A4000, CDTV, CD32\n  \
          --chipset NAME                 chipset preset: OCS, ECS, or AGA\n  \
-         --cpu MODEL                    CPU: 68000, 68EC020, 68020, 68030, 68040, or 68060\n  \
+         --cpu MODEL                    CPU: 68000, 68010, 68EC020, 68020, 68030, 68040, or 68060\n  \
          --cpu-clock MHZ                CPU clock in MHz (default: the model's stock speed)\n  \
          --fpu / --no-fpu               fit / omit a 68881/68882 (68040/68060 on-die)\n  \
          --chip SIZE                    chip RAM size, e.g. 512K, 1M, 2M\n  \
@@ -1007,7 +1008,7 @@ fn print_help() {
          \n\
          If ROM is given on the command line it overrides the rom path from\n\
          the config. If no config file exists, built-in defaults are used:\n  \
-         CPU: 68000   chip RAM: 512K   slow RAM: 512K   fast RAM: 0   chipset: OCS\n  \
+         CPU: 68000   chip RAM: 512K   slow RAM: 512K   fast RAM: 0   chipset: ECS\n  \
          ROM: bundled AROS"
     );
 }

--- a/src/z3660.rs
+++ b/src/z3660.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Z3660 RTG board stub.
+//! Z3660 RTG board.
 //!
 //! The Z3660 accelerator's FPGA presents its RTG core as an ordinary
 //! Zorro III autoconfig board (manufacturer 0x144B, product 1, one 128 MB
@@ -10,9 +10,9 @@
 //! the rest of the window is board RAM (P96 VRAM from +0x200000, the
 //! GFXData blit-parameter mailbox at +0x3200000).
 //!
-//! Bring-up state: the board autoconfigs, the identity/status registers
-//! answer, every register access is latched and logged, and the RAM region
-//! is honest memory. The display pipeline presents the panned framebuffer
+//! Implemented: the board autoconfigs, the identity/status registers
+//! answer, every register access is latched, and the RAM region is honest
+//! memory. The display pipeline presents the panned framebuffer
 //! (all four pixel formats, palette captured from the upload stream) when
 //! the driver switches the display to RTG, and the core blitter ops
 //! (fill/copy/invert/template/pattern/line/planar) execute into VRAM on


### PR DESCRIPTION
An audit of the documentation against the source for everything merged since v0.10.0, focused on the contributed features that landed without their documentation half: the filesys services board (#159-#211), the Z3660 RTG card (#212), the A3000/A4000 machines (#180/#184/#185), and the serial/parallel port work (#138/#147/#221). Each finding was verified against the current code before fixing.

## Stale documentation fixed

- **peripherals.md** still described the filesys handler forwarding DosPackets through a "reserved A-line trap"; #207 replaced that with MMIO doorbell registers (`REG_DOSPKT` handled synchronously inside the write).
- **chipset.md** attributed the Centronics data/strobe to CIA-B -- the exact wiring #138 corrected. Data, `/STROBE`, and `/ACK` are CIA-A; only BUSY/POUT/SEL sit on CIA-B port A.
- **cpu.md** reported 68040 write faults in writeback slot 2; since #156 the frame builder stacks them in slot 3 (WB2 is reserved for MOVE16), matching real silicon and the MuGuardianAngel/Enforcer handler protocols.
- **AGENTS.md** promised a positional disk-image argument that `main.rs` does not implement (the single positional is the ROM; a second errors). The example now routes the disk through `--insert-disk-after`, verified to boot AmigaTestKit on both AROS and KS3.1/A1200.
- **README / `--help`** called the default machine OCS (the A500 Rev 6A default is ECS Agnus + OCS Denise) and described built-in-defaults startup where a bare invocation opens the launcher; `--help` also omitted the A1000/A500OCS/A3000/A4000 models and the 68010.
- **configuration.md / README** pointed at a "Serial" launcher tab that #221 merged into "I/O Ports"; **guest/services/README.md** described a fixed -128 boot priority (now the mount's `bootpri`) and a handler started on first reference (it is `ADNF_STARTPROC`, at mount time).

## Missing documentation added

- **Z3660 RTG**, previously covered only in configuration.md: a zorro.md section (autoconfig identity 0x144B/1, 128 MB window layout, VRAM/GFXData offsets), an internals/video.md "RTG scanout" section (native-resolution GPU present, chipset fallback, sprite compositing, pixel-centre screenshot downscale), the launcher's RTG card row in ui.md, the RTG behaviour of `capture.screenshot` in control.md, and a README feature mention.
- **peripherals.md** sections for Fat Gary and Ramsey (the lane/mirror decode, COLDBOOT as the Gary detector, the version-register identity and the Ramsey-04/-07 control-bit-4 disagreement) and for the parallel-port peripheral boundary (printer capture with ready-online status lines, the emulated-time audio sampler).
- The services-board per-unit register protocol and the DiagPoint `rom_scsi_device_disable` cull in peripherals.md, plus the board as product 5 in the manufacturer-ID table.
- Smaller gaps: the `tcp-connect` serial mode in peripherals.md and README, `COPPERLINE_DIAG_A4091` in the debugger env-var table, `identify` in the example config, drag-and-drop cross-referenced from getting-started, the status-bar hide shortcut noted in its own section, and the Host Mounts four-of-eight launcher limit.

## Verified clean

The user-facing config surface needed no fixes: every TOML key in `config.rs` is documented with correct defaults and accepted values, the `[a4091]` -> `[scsi]` break left no stale references, and the ui.md shortcut table matches `host_input.rs` 1:1.

Verification: full unit suite (1773 passed), `cargo clippy` and `cargo fmt --check` clean, `myst build --html` with no new warnings. Source changes are help-text and doc-comments only (`main.rs`, `config.rs`, `z3660.rs`).
