### PR TITLE
filesys: reach motherboard and CPU-slot RAM through the GuestBus

### DIFF
--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -1457,12 +1457,13 @@ impl FilesysUnit {
 
 /// The guest-memory view the packet engine works through while a doorbell is
 /// serviced: the board's own window (`image`, taken out of the device for the
-/// duration), all RAM the CPU can see (chip, slow, and every RAM-backed Zorro
-/// board -- which is where fast RAM lives), and the ROMs read-only (the
-/// romtags cull reads resident tags in Kickstart). Deliberately wider than
-/// the 24-bit Zorro II DMA decode a real bus-master gets: DosPackets and I/O
-/// buffers live wherever exec allocated them, and this board is paravirtual,
-/// not a DMA engine.
+/// duration), all RAM the CPU can see (chip, slow, Ramsey motherboard and
+/// CPU-slot accelerator fast RAM, and every RAM-backed Zorro board), and the
+/// ROMs read-only (the romtags cull reads resident tags in Kickstart).
+/// Deliberately wider than the 24-bit Zorro II DMA decode a real bus-master
+/// gets: DosPackets and I/O buffers live wherever exec allocated them -- on a
+/// big-box machine that is the 32-bit motherboard RAM -- and this board is
+/// paravirtual, not a DMA engine.
 struct GuestBus<'a> {
     base: u32,
     image: Vec<u8>,
@@ -1482,6 +1483,14 @@ impl GuestBus<'_> {
         let slow = crate::memory::SLOW_RAM_BASE as usize;
         if a >= slow && a < slow + self.mem.slow_ram.len() {
             return Some(&mut self.mem.slow_ram[a - slow]);
+        }
+        let mb = self.mem.mb_ram_base() as usize;
+        if a >= mb && a < mb + self.mem.mb_ram.len() {
+            return Some(&mut self.mem.mb_ram[a - mb]);
+        }
+        let accel = crate::memory::ACCEL_RAM_BASE as usize;
+        if a >= accel && a < accel + self.mem.accel_ram.len() {
+            return Some(&mut self.mem.accel_ram[a - accel]);
         }
         if let Some((board, off)) = self.mem.zorro.region_at(addr, 1) {
             return Some(&mut self.mem.zorro.board_ram_mut(board)[off]);
@@ -2301,6 +2310,75 @@ mod tests {
         assert_eq!(board.units[0].port, None);
 
         std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// The romtags cull walks ExecBase's ResModules list through the
+    /// GuestBus, and on an A3000/A4000 exec builds that list in the best RAM
+    /// it has: Ramsey motherboard fast RAM. The bus must reach the
+    /// motherboard and CPU-slot banks like any other CPU-visible RAM;
+    /// without them every read returns 0, the walk stops at the first slot,
+    /// and the boot logs "0 ROM scsi.device resident(s) culled".
+    #[test]
+    fn guest_bus_reaches_motherboard_and_cpu_slot_ram() {
+        let mut mem = Memory {
+            chip_ram: vec![0u8; 0x1000],
+            slow_ram: Vec::new(),
+            mb_ram: Vec::new(),
+            accel_ram: Vec::new(),
+            rom: vec![0u8; crate::memory::ROM_SIZE],
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        };
+        mem.fit_mb_ram(1024 * 1024);
+        mem.fit_accel_ram(1024 * 1024);
+
+        // A scsi.device resident tag in Kickstart ROM (struct Resident:
+        // rtc_MatchWord, rt_MatchTag, rt_Type = NT_DEVICE, rt_Name).
+        let tag = 0x00F8_590Cu32;
+        let name = tag + 32;
+        let at = (tag - crate::memory::ROM_BASE as u32) as usize;
+        mem.rom[at..at + 2].copy_from_slice(&0x4AFCu16.to_be_bytes());
+        mem.rom[at + 2..at + 6].copy_from_slice(&tag.to_be_bytes());
+        mem.rom[at + 12] = 3;
+        mem.rom[at + 14..at + 18].copy_from_slice(&name.to_be_bytes());
+        mem.rom[at + 32..at + 44].copy_from_slice(b"scsi.device\0");
+
+        // ExecBase in chip RAM, its ResModules list in motherboard RAM.
+        let exec_base = 0x400u32;
+        let list = mem.mb_ram_base() as u32 + 0x10;
+        mem.chip_ram[4..8].copy_from_slice(&exec_base.to_be_bytes());
+        let rm = (exec_base + 300) as usize; // ExecBase.ResModules
+        mem.chip_ram[rm..rm + 4].copy_from_slice(&list.to_be_bytes());
+        mem.mb_ram[0x10..0x14].copy_from_slice(&tag.to_be_bytes());
+        mem.mb_ram[0x14..0x18].copy_from_slice(&0u32.to_be_bytes());
+
+        let mut bus = GuestBus {
+            base: 0x00E9_0000,
+            image: Vec::new(),
+            mem: &mut mem,
+        };
+        assert_eq!(crate::romtags::cull_rom_device(&mut bus, "scsi.device"), 1);
+        // The slot in motherboard RAM was rewritten into a jump entry
+        // (bit 31 | next slot), unlinking the tag.
+        assert_eq!(
+            &mem.mb_ram[0x10..0x14],
+            &(0x8000_0000u32 | (list + 4)).to_be_bytes()
+        );
+
+        // CPU-slot accelerator RAM is reachable the same way.
+        let accel = crate::memory::ACCEL_RAM_BASE as u32;
+        let mut bus = GuestBus {
+            base: 0x00E9_0000,
+            image: Vec::new(),
+            mem: &mut mem,
+        };
+        bus.write_long(accel + 8, 0xDEAD_BEEF);
+        assert_eq!(bus.read_long(accel + 8), 0xDEAD_BEEF);
+        assert_eq!(&mem.accel_ram[8..12], &0xDEAD_BEEFu32.to_be_bytes());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Contributor-reported regression on big-box machines since the Ramsey motherboard RAM landed (#242/#244): an A3000/A4000 boot logged `romtags: 0 ROM scsi.device resident(s) culled` plus `filesys: guest read/write outside RAM at 0x04xxxxxx`.

Both symptoms are one gap. The services board's `GuestBus` -- the guest-memory view used for DosPacket handling and the scsi.device romtag cull, documented as "all RAM the CPU can see" -- only decoded chip, slow, and Zorro-board RAM. On an A3000/A4000 exec allocates its structures in the best RAM it has, which is now the motherboard bank ($04000000-$08000000 with 64M fitted), so:

- The cull walks ExecBase's ResModules list through the GuestBus; the list lives in motherboard RAM, every read returned 0, and the walk stopped at the first slot -- the ROM's scsi.device ran again, bringing back the several-second A4000 IDE probe (and the A3000 SCSI hang).
- The outside-RAM warnings were the same gap hit by packet traffic whose buffers sat in motherboard RAM.

The fix adds the `Memory::mb_ram` and `Memory::accel_ram` banks to the GuestBus decode. The `zorro_device` `dma_*` helpers stay 24-bit on purpose: they model real Zorro II bus-masters (A2091, CDTV DMAC), which cannot reach the 32-bit local banks.

## Verification

- New regression test `filesys::tests::guest_bus_reaches_motherboard_and_cpu_slot_ram` runs the actual `cull_rom_device` through a GuestBus with the ResModules list in motherboard RAM (fails without the fix, culling 0), and round-trips an accelerator-bank access.
- End to end against the real KS 3.1 A4000 ROM with `motherboard = "64M"` and a `[[filesys]]` mount: the boot now logs `romtags: 1 ROM scsi.device resident(s) culled`, the host volume handler starts, and the outside-RAM warnings are gone.
- `cargo test` (1717 unit tests), `cargo clippy`, and `cargo fmt --check` are all clean.