### PR TITLE
web: mono audio option (mix left and right into both speakers)

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -709,6 +709,13 @@ impl WebEmu {
         self.emu.bus_mut().set_output_volume_percent(percent);
     }
 
+    /// Average the left and right channels into both outputs (the desktop's
+    /// `[audio] channel_mode = "mono"`). Off by default: Paula's hardware
+    /// panning, with two channels on each side.
+    pub fn set_mono_audio(&mut self, enabled: bool) {
+        self.emu.bus_mut().paula.set_mono_output(enabled);
+    }
+
     /// Enable or mute the synthesized floppy drive sounds (motor hum,
     /// head-step clicks, read hiss). On by default, like the desktop's
     /// `[audio] floppy_sounds` knob.

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -370,6 +370,8 @@ async function boot() {
     machine.set_volume_percent(Number($('vol').value));
     if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
     else if (configFloppySounds !== null) machine.set_floppy_sounds(configFloppySounds);
+    if (monoAudioToggle) machine.set_mono_audio(monoAudioToggle.checked);
+    else if (configMonoAudio !== null) machine.set_mono_audio(configMonoAudio);
     if (floppySpeed !== null) machine.set_floppy_speed(floppySpeed);
     emu = machine;
     window.__emu = emu; // for debugging/automation
@@ -1669,6 +1671,8 @@ function restoreState(bytes, source) {
   emu.set_volume_percent(Number($('vol').value));
   if (floppySoundsToggle) emu.set_floppy_sounds(floppySoundsToggle.checked);
   else if (configFloppySounds !== null) emu.set_floppy_sounds(configFloppySounds);
+  if (monoAudioToggle) emu.set_mono_audio(monoAudioToggle.checked);
+  else if (configMonoAudio !== null) emu.set_mono_audio(configMonoAudio);
   if (floppySpeed !== null) emu.set_floppy_speed(floppySpeed);
   // Port fittings live on the machine, so the pads plugged into the host go
   // back into the restored one, exactly as after a boot. Port 1 is the
@@ -1855,6 +1859,19 @@ const floppySoundsToggle = $('floppy-sounds');
 let configFloppySounds = null;
 floppySoundsToggle?.addEventListener('change', () => {
   if (emu) emu.set_floppy_sounds(floppySoundsToggle.checked);
+});
+
+// Optional in the page shell: a checkbox #mono-audio mixes the left and
+// right channels into both speakers (the desktop's [audio]
+// channel_mode = "mono"). Without the element the output stays stereo;
+// the checkbox's initial state is applied at boot, so a shell can
+// default it on.
+const monoAudioToggle = $('mono-audio');
+// The config file's mono_audio on a shell without the checkbox: stashed
+// here and applied at boot.
+let configMonoAudio = null;
+monoAudioToggle?.addEventListener('change', () => {
+  if (emu) emu.set_mono_audio(monoAudioToggle.checked);
 });
 
 // The floppy drive speed control, always visible: a page shell can host
@@ -2315,6 +2332,7 @@ const pageParams = new URLSearchParams(location.search);
 //     "kick": "roms/kick31.rom",     same-origin path, like ?kick=
 //     "df0": "adf/demo.adf",         URL, like ?df0=
 //     "floppy_sounds": false,        preset the drive-sounds toggle
+//     "mono_audio": true,            preset the mono-audio toggle
 //     "floppy_speed": 800,           100|200|400|800|0 (0 = turbo)
 //     "joy": "keys",                 off|keys|cd32|touch
 //     "serial_url": "wss://...",     preset the BBS gateway input
@@ -2348,6 +2366,10 @@ async function startup() {
   if (typeof cfg.floppy_sounds === 'boolean') {
     if (floppySoundsToggle) floppySoundsToggle.checked = cfg.floppy_sounds;
     else configFloppySounds = cfg.floppy_sounds;
+  }
+  if (typeof cfg.mono_audio === 'boolean') {
+    if (monoAudioToggle) monoAudioToggle.checked = cfg.mono_audio;
+    else configMonoAudio = cfg.mono_audio;
   }
 
   const fetches = [];

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1863,9 +1863,9 @@ floppySoundsToggle?.addEventListener('change', () => {
 
 // Optional in the page shell: a checkbox #mono-audio mixes the left and
 // right channels into both speakers (the desktop's [audio]
-// channel_mode = "mono"). Without the element the output stays stereo;
-// the checkbox's initial state is applied at boot, so a shell can
-// default it on.
+// channel_mode = "mono"). Without the element (and no mono_audio key in
+// copperline.json) the output stays stereo; the checkbox's initial
+// state is applied at boot, so a shell can default it on.
 const monoAudioToggle = $('mono-audio');
 // The config file's mono_audio on a shell without the checkbox: stashed
 // here and applied at boot.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -311,6 +311,9 @@ devices) are not part of the machine, so a page that keeps its own should
 re-apply them afterwards. `set_floppy_sounds(on)` and
 `set_floppy_sounds_volume(p)` control the synthesized drive sounds (on and
 100 by default, like the desktop's `[audio] floppy_sounds` knobs).
+`set_mono_audio(on)` averages the left and right channels into both
+outputs, like the desktop's `[audio] channel_mode = "mono"`; off by
+default, leaving Paula's hardware stereo panning.
 `set_floppy_speed(percent)` / `floppy_speed()` set and read the emulated
 drive speed -- 100/200/400/800 percent, or 0 for turbo -- like the
 desktop's `[floppy] speed` option (see
@@ -347,6 +350,10 @@ elements, and pages without them are untouched:
 - `#floppy-sounds` (checkbox): toggles the synthesized floppy drive
   sounds -- motor hum, head-step clicks, read hiss -- live and at boot, so
   a shell can also default them off by shipping the box unchecked.
+- `#mono-audio` (checkbox): mixes the left and right channels into both
+  speakers (the desktop's `[audio] channel_mode = "mono"`), live and at
+  boot, so a shell can default to mono by shipping the box checked.
+  Without the element the output stays stereo.
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
   `800`, and `0` for turbo): hosts the floppy drive speed control, letting
   the page place and style it. Unlike the other hooks this one is always
@@ -424,6 +431,7 @@ anything the visitor changes by hand wins as usual:
   "kick": "roms/kick31.rom",
   "df0": "adf/demo.adf",
   "floppy_sounds": false,
+  "mono_audio": true,
   "floppy_speed": 800,
   "joy": "keys",
   "serial_url": "wss://bbs.example.com:8443/",
@@ -434,10 +442,11 @@ anything the visitor changes by hand wins as usual:
 
 `kick` follows the same-origin rule as `?kick=` (the file can only name
 a ROM the site already serves); `df0` is any URL the visitor's browser
-may fetch, like `?df0=`. `floppy_sounds` and `floppy_speed` reach the
-machine whether or not the shell has their controls -- the speed select
-inserts itself, and a configured `floppy_sounds` is applied at boot even
-with no checkbox to show it. `serial_url` and `serial_raw` preset the
+may fetch, like `?df0=`. `floppy_sounds`, `mono_audio`, and
+`floppy_speed` reach the machine whether or not the shell has their
+controls -- the speed select inserts itself, and a configured
+`floppy_sounds` or `mono_audio` is applied at boot even with no checkbox
+to show it. `serial_url` and `serial_raw` preset the
 serial bridge's inputs and therefore need those elements: a shell
 without them has no connect button to dial with either. `joy` picks the
 starting joystick mode. `autoboot: true` powers the machine on by itself once the

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -353,7 +353,8 @@ elements, and pages without them are untouched:
 - `#mono-audio` (checkbox): mixes the left and right channels into both
   speakers (the desktop's `[audio] channel_mode = "mono"`), live and at
   boot, so a shell can default to mono by shipping the box checked.
-  Without the element the output stays stereo.
+  Without the element the output stays stereo unless the
+  [configuration file](#browser-page-config) sets `mono_audio`.
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
   `800`, and `0` for turbo): hosts the floppy drive speed control, letting
   the page place and style it. Unlike the other hooks this one is always
@@ -418,6 +419,7 @@ elements, and pages without them are untouched:
   serial/BBS bridge, described in
   [the serial bridge section](#browser-serial-bridge).
 
+(browser-page-config)=
 ### The page configuration file
 
 A site can set its defaults in one hand-editable file instead of editing


### PR DESCRIPTION
The desktop side already ships `[audio] channel_mode = "mono"` (config file, `--audio-channel-mode`, launcher GUI, Paula's `set_mono_output` mix). This adds the same option to the WASM build:

- `WebEmu::set_mono_audio(on)`: averages the left and right channels into both outputs, off by default. Like the other host audio preferences it is carried across `load_state`.
- `try.js`: an optional `#mono-audio` page-shell checkbox (applied at boot, live on change, re-applied after a state restore -- pages without the element are untouched), plus a `mono_audio` key in `copperline.json` so a shell without the checkbox can still default to mono.
- `docs/guide/browser.md`: documents the API call, the shell hook, and the config key.

Verified with `cargo check --target wasm32-unknown-unknown` on the web crate, `cargo fmt --check`, and `node --check` on try.js. No native code changes.

Note: the hosted demo's page shell lives in the website repository; surfacing the toggle there needs the one-line checkbox added to `try/index.html`.