### PR TITLE
rtc: Ricoh RP5C01, the A3000/A4000 battery clock

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -118,6 +118,9 @@ model = "68000"
 # [machine]
 # profile = "A600"      # A1000 | A500 | A500OCS | A500Plus | A600 | A1200 | A3000 | A4000 | CDTV | CD32
 # rtc = true            # add a $DC0000 battery RTC (default: only A500+/CDTV/A3000/A4000 have one)
+# rtc_chip = "RP5C01"   # clock part: MSM6242 (OKI, the default) or RP5C01 (Ricoh, the
+#                       # A3000/A4000 part and their profile default; Linux/m68k requires
+#                       # it on those machines). Setting the key implies rtc = true.
 # rtc_time = "2005-03-18 01:58:29" # seed the clock (implies rtc = true); Unix seconds also accepted.
 #                                  # A seeded clock ticks in emulated time, so the guest-visible
 #                                  # time is deterministic across runs.

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -210,7 +210,8 @@ not touched), `disasm {addr?, count?}`, `custom.dump`,
 
 Battery clock (the $DC0000 RTC; see `rtc_time` in
 `docs/guide/configuration.md` for the boot-time seed): `rtc.get` reports
-`{present, seeded, frozen, unix, time}`; `rtc.set {unix | time |
+`{present, chip, seeded, frozen, unix, time}` (`chip` is the fitted part,
+`"MSM6242"` or `"RP5C01"`); `rtc.set {unix | time |
 advance, frozen?}` moves it live -- `unix` (Unix seconds) or `time`
 (`"YYYY-MM-DD HH:MM[:SS]"`) set an absolute value the clock reads from
 this instant, `advance` (signed seconds) jumps relative to the current

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -112,6 +112,7 @@ image instead.
 [machine]
 profile = "A1200" # A1000, A500, A500OCS, A500Plus (A500+), A600, A1200, A3000, A4000, CDTV, CD32
 rtc = true        # add a battery RTC (default: only A500+/CDTV/A3000/A4000 ship with one)
+# rtc_chip = "RP5C01"              # MSM6242 (default) or RP5C01 (A3000/A4000 default)
 # rtc_time = "2005-03-18 01:58:29" # seed the clock; it then ticks in emulated time
 # rtc_frozen = true                # stop the seeded clock at rtc_time exactly
 mem_controller = "ramsey-07" # none, ramsey-04 (A3000), ramsey-07 (A4000)
@@ -136,8 +137,8 @@ gives a plain 8371/8362 OCS machine.
 | `A500Plus` | ECS (8375 Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | RTC |
 | `A600` | ECS (8375 Agnus, ECS Denise) | 68000 @ 7.09 MHz | 1M | 0 | Gayle IDE |
 | `A1200` | AGA (Alice/Lisa) | 68EC020 @ 14.18 MHz | 2M | 0 | Gayle IDE |
-| `A3000` | ECS | 68030 @ 25 MHz | 2M | 0 | Ramsey-04, RTC |
-| `A4000` | AGA (Alice/Lisa) | 68040 @ 25 MHz | 2M | 0 | Ramsey-07, RTC |
+| `A3000` | ECS | 68030 @ 25 MHz | 2M | 0 | Ramsey-04, RP5C01 RTC |
+| `A4000` | AGA (Alice/Lisa) | 68040 @ 25 MHz | 2M | 0 | Ramsey-07, RP5C01 RTC |
 | `CDTV` | ECS | 68000 @ 7.09 MHz | 1M | 0 | DMAC CD controller, RTC, 256K extended ROM |
 | `CD32` | AGA (Alice/Lisa) | 68EC020 @ 14.18 MHz | 2M | 0 | Akiko, CD32 pad, NVRAM, 512K extended ROM |
 
@@ -147,6 +148,17 @@ board), `CDTV`, `A3000`, and `A4000` fit one by default; the base
 A500/A500OCS, A600, A1200, A1000, and CD32 have none. Set `rtc = true` to add
 one -- for an A600HD or a clock-equipped A1200, say -- so the Workbench clock
 keeps time.
+
+`rtc_chip` names the part in that socket, because Commodore used two with
+different register protocols: the OKI **MSM6242** on the small boxes, the
+CDTV, and the aftermarket clock expansions, and the Ricoh **RP5C01** on the
+A3000/A4000 motherboards (the Ricoh also carries 26 nibbles of battery RAM,
+which AmigaOS uses via `battmem.resource` on those machines). The default
+follows the profile -- `RP5C01` on `A3000`/`A4000`, `MSM6242` everywhere else
+-- and setting the key implies `rtc = true`. AmigaOS probes for either part,
+so the choice is mostly invisible to it, but Linux/m68k does not probe: it
+drives the chip the machine model dictates, so an A3000/A4000 booting Linux
+needs the RP5C01 answering for its clock to work.
 
 `rtc_time` seeds the clock instead of letting it mirror the host's: the value
 is either an integer (Unix seconds, UTC) or a string

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -25,7 +25,7 @@ use crate::chipset::paula::{
 use crate::floppy::FloppyController;
 use crate::gayle::Gayle;
 use crate::memory::Memory;
-use crate::rtc::Msm6242Rtc;
+use crate::rtc::{Rtc, RtcChip};
 use crate::timebase::{Duration, Instant};
 use crate::video::{beam::BeamEventIndex, FrameGeometry, FB_HEIGHT, FB_WIDTH, MAX_VISIBLE_LINES};
 use log::trace;
@@ -658,7 +658,7 @@ pub struct Bus {
     /// therefore survives save-state loads like Paula's audio/serial sinks.
     #[serde(skip, default = "crate::parallel::null_parallel_port")]
     parallel_port: Box<dyn crate::parallel::ParallelPort>,
-    pub rtc: Msm6242Rtc,
+    pub rtc: Rtc,
     /// Whether the $DC0000 RTC is fitted (machine-profile flag; the base
     /// A600 shipped without one). The CPU memory map consults this before
     /// decoding the RTC range.
@@ -2321,7 +2321,7 @@ impl Bus {
             blitter: Blitter::new(),
             floppy,
             parallel_port: crate::parallel::null_parallel_port(),
-            rtc: Msm6242Rtc::default(),
+            rtc: Rtc::default(),
             rtc_present: true,
             gayle: None,
             ramsey: None,
@@ -2792,6 +2792,15 @@ impl Bus {
 
     pub fn set_rtc_present(&mut self, present: bool) {
         self.rtc_present = present;
+    }
+
+    /// Fit the configured clock part (machine-profile default or
+    /// `[machine] rtc_chip`). Swapping parts starts from power-on state,
+    /// so apply it before the deterministic seed.
+    pub fn set_rtc_chip(&mut self, chip: RtcChip) {
+        if self.rtc.chip() != chip {
+            self.rtc = Rtc::new(chip);
+        }
     }
 
     pub fn set_video_standard(&mut self, video_standard: VideoStandard) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,12 +139,18 @@ pub struct Config {
     pub cd_insert_delay_secs: f64,
     /// CD32 NVRAM backing file (None = session-only EEPROM).
     pub cd32_nvram_path: Option<PathBuf>,
-    /// Whether the MSM6242/OKI RTC at $DC0000 is fitted. Defaults to false:
+    /// Whether the battery RTC at $DC0000 is fitted. Defaults to false:
     /// the base A500/A500OCS, A600, A1200, A1000, and CD32 shipped without a
-    /// battery-backed clock. Only the A500+ (soldered on the Rev 8A board) and
-    /// the CDTV carry one by default; the A600HD and a clock-equipped A1200 set
-    /// `[machine] rtc = true`.
+    /// battery-backed clock. Only the A500+ (soldered on the Rev 8A board),
+    /// the CDTV, and the big-box A3000/A4000 carry one by default; the A600HD
+    /// and a clock-equipped A1200 set `[machine] rtc = true`.
     pub rtc_present: bool,
+    /// Which clock part answers there (`[machine] rtc_chip`): the OKI
+    /// MSM6242 on most boards, the Ricoh RP5C01 on the A3000/A4000 -- a
+    /// different register protocol, which battclock.resource probes for
+    /// but Linux/m68k assumes from the machine model. Defaults per
+    /// profile; setting it implies `rtc = true`.
+    pub rtc_chip: crate::rtc::RtcChip,
     /// Power-on RTC value in Unix seconds (`[machine] rtc_time` /
     /// `--rtc-time`). When set, the clock starts here and ticks with
     /// *emulated* time instead of following the host wall clock, so the
@@ -835,8 +841,9 @@ pub enum MachineModel {
     A1000,
     /// A3000: ECS, 68030 at 25 MHz, 2 MB chip RAM, a Ramsey-04 memory
     /// controller with the stock 4 MB of motherboard fast RAM
-    /// (`[memory] motherboard` resizes it), and the battery-backed MSM6242
-    /// clock. No Gayle -- the big-box machines carry Gary -- and no slow RAM.
+    /// (`[memory] motherboard` resizes it), and the battery-backed Ricoh
+    /// RP5C01 clock. No Gayle -- the big-box machines carry Gary -- and no
+    /// slow RAM.
     A3000,
     /// A4000: the same board a generation later -- AGA, a 25 MHz 68040, and
     /// Ramsey-07 with the same stock 4 MB of motherboard fast RAM. Same
@@ -1147,6 +1154,7 @@ impl Default for Config {
             // clock; only the A500+/CDTV profiles fit one (see
             // machine_profile_defaults).
             rtc_present: false,
+            rtc_chip: crate::rtc::RtcChip::Msm6242,
             rtc_seed_unix: None,
             rtc_frozen: false,
             video_standard: VideoStandard::Pal,
@@ -1947,6 +1955,12 @@ pub(crate) struct RawMachine {
     /// clock-equipped A1200.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rtc: Option<bool>,
+    /// Which clock part fills the socket: `"MSM6242"` (OKI, most boards)
+    /// or `"RP5C01"` (Ricoh, the A3000/A4000 part and the only protocol
+    /// Linux/m68k drives on those models). Defaults per profile; setting
+    /// it implies `rtc = true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rtc_chip: Option<String>,
     /// Power-on clock value: an integer (Unix seconds, UTC) or a string
     /// `"YYYY-MM-DD HH:MM[:SS]"` (the wall-clock time the guest reads).
     /// Seeds the battery clock and ticks it in emulated time so the
@@ -2559,6 +2573,14 @@ impl TryFrom<RawConfig> for Config {
                 "[machine] rtc_frozen = true needs an rtc_time to freeze at"
             ));
         }
+        let rtc_chip = match raw.machine.rtc_chip.as_deref().map(parse_rtc_chip) {
+            Some(Ok(chip)) => Some(chip),
+            Some(Err(e)) => {
+                errors.push(e);
+                None
+            }
+            None => None,
+        };
 
         match errors.len() {
             0 => {}
@@ -2645,9 +2667,16 @@ impl TryFrom<RawConfig> for Config {
                     "[machine] rtc_time is set but rtc = false leaves the \
                      clock unfitted; drop one of them"
                 ),
+                // Naming a chip for a socket declared empty is the same
+                // contradiction.
+                Some(false) if rtc_chip.is_some() => anyhow::bail!(
+                    "[machine] rtc_chip is set but rtc = false leaves the \
+                     clock unfitted; drop one of them"
+                ),
                 Some(fitted) => fitted,
-                None => defaults.rtc_present || rtc_seed_unix.is_some(),
+                None => defaults.rtc_present || rtc_seed_unix.is_some() || rtc_chip.is_some(),
             },
+            rtc_chip: rtc_chip.unwrap_or(defaults.rtc_chip),
             rtc_seed_unix,
             rtc_frozen,
             log_unmapped: raw
@@ -2948,6 +2977,9 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.mem_controller = MemController::Ramsey4;
             d.gate_array = GateArray::FatGary;
             d.rtc_present = true;
+            // The big boxes carry the Ricoh clock part, not the OKI one --
+            // and Linux/m68k hard-assumes RP5C01 on these models.
+            d.rtc_chip = crate::rtc::RtcChip::Rp5c01;
             d.sdmac = true;
         }
         // The A4000: the same board a generation later -- AGA, a 25 MHz 68040,
@@ -2964,6 +2996,7 @@ pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
             d.mem_controller = MemController::Ramsey7;
             d.gate_array = GateArray::FatGary;
             d.rtc_present = true;
+            d.rtc_chip = crate::rtc::RtcChip::Rp5c01;
             d.ide_a4000 = true;
         }
         // CDTV: A500-class board with the 1 MB ECS Agnus and 1 MB chip
@@ -3023,6 +3056,19 @@ fn default_denise_revision(chipset: Chipset) -> DeniseRevision {
         Chipset::Ocs => DeniseRevision::Ocs,
         Chipset::Ecs => DeniseRevision::Ecs8373,
         Chipset::Aga => DeniseRevision::AgaLisa,
+    }
+}
+
+/// Parse `[machine] rtc_chip`. "RF5C01A" is accepted as an alias for the
+/// Ricoh part because that is what AmigaOS-lineage sources call it.
+fn parse_rtc_chip(s: &str) -> Result<crate::rtc::RtcChip> {
+    match s.trim().to_ascii_uppercase().as_str() {
+        "MSM6242" | "MSM6242B" | "OKI" => Ok(crate::rtc::RtcChip::Msm6242),
+        "RP5C01" | "RP5C01A" | "RF5C01A" | "RICOH" => Ok(crate::rtc::RtcChip::Rp5c01),
+        _ => Err(anyhow!(
+            "unknown machine rtc_chip {:?}: expected MSM6242 / RP5C01",
+            s
+        )),
     }
 }
 
@@ -3616,6 +3662,56 @@ mod tests {
     }
 
     #[test]
+    fn rtc_chip_defaults_per_profile_and_implies_a_fitted_clock() -> Result<()> {
+        use crate::rtc::RtcChip;
+
+        // The big boxes carry the Ricoh part by default.
+        for profile in ["A3000", "A4000"] {
+            let cfg = parse_config(&format!("[machine]\nprofile = \"{profile}\"\n"))?;
+            assert!(cfg.rtc_present, "{profile}");
+            assert_eq!(cfg.rtc_chip, RtcChip::Rp5c01, "{profile}");
+        }
+        // The clock-equipped small boxes keep the OKI one.
+        let cfg = parse_config("[machine]\nprofile = \"A500+\"\n")?;
+        assert!(cfg.rtc_present);
+        assert_eq!(cfg.rtc_chip, RtcChip::Msm6242);
+
+        // Naming a chip fits the clock on a machine that has none...
+        let cfg = parse_config("[machine]\nrtc_chip = \"RP5C01\"\n")?;
+        assert!(cfg.rtc_present);
+        assert_eq!(cfg.rtc_chip, RtcChip::Rp5c01);
+        // ...and the aliases and the big-box override both parse.
+        let cfg = parse_config(
+            r#"
+            [machine]
+            profile = "A3000"
+            rtc_chip = "MSM6242B"
+            "#,
+        )?;
+        assert_eq!(cfg.rtc_chip, RtcChip::Msm6242);
+        let cfg = parse_config("[machine]\nrtc_chip = \"rf5c01a\"\n")?;
+        assert_eq!(cfg.rtc_chip, RtcChip::Rp5c01);
+        Ok(())
+    }
+
+    #[test]
+    fn rtc_chip_misconfigurations_are_rejected() {
+        // A chip named for a socket declared empty is a contradiction.
+        let err = parse_config(
+            r#"
+            [machine]
+            rtc = false
+            rtc_chip = "RP5C01"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("rtc = false"), "{err:#}");
+
+        let err = parse_config("[machine]\nrtc_chip = \"DS1307\"\n").unwrap_err();
+        assert!(err.to_string().contains("rtc_chip"), "{err:#}");
+    }
+
+    #[test]
     fn rtc_time_cli_override_matches_the_config_field() -> Result<()> {
         let cfg = load_overrides(&ConfigOverrides {
             rtc_time: Some("1111111109".to_string()),
@@ -3683,6 +3779,7 @@ mod tests {
             machine: RawMachine {
                 profile: Some("A1200".to_string()),
                 rtc: Some(true),
+                rtc_chip: Some("RP5C01".to_string()),
                 rtc_time: Some(RawRtcTime::Text("2005-03-18 01:58:29".to_string())),
                 rtc_frozen: Some(true),
                 mem_controller: Some("ramsey-07".to_string()),

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1237,6 +1237,7 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             let secs = bus.emulated_seconds();
             Ok(json!({
                 "present": bus.rtc_present(),
+                "chip": bus.rtc.chip().label(),
                 "seeded": bus.rtc.seed().is_some(),
                 "frozen": bus.rtc.frozen(),
                 "unix": bus.rtc.current_unix(secs),

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2366,9 +2366,10 @@ impl CpuBus {
 
     /// The `$DC0000` clock page, a byte lane at a time.
     ///
-    /// The MSM6242 is a four-bit part wired to the low byte lane alone, so it
-    /// answers on odd addresses and the even lane floats -- with or without a
-    /// chip in the socket, since nothing else drives it either.
+    /// Both clock parts (MSM6242 and RP5C01) are four-bit chips wired to the
+    /// low byte lane alone, so they answer on odd addresses and the even lane
+    /// floats -- with or without a chip in the socket, since nothing else
+    /// drives it either.
     ///
     /// The register select is A2-A5, so A1 does not reach the decode and each
     /// register answers at *both* of its odd bytes: register 0 at `+1` and
@@ -4345,6 +4346,23 @@ mod tests {
         assert_eq!(clock_reg(&mut bus, 0x03) & 8, 0);
         assert_ne!(clock_reg(&mut bus, 0x0D), 0x8); // not an RF5C01A
         assert_eq!(clock_reg(&mut bus, 0x0F), 0x4); // an MSM6242B
+    }
+
+    /// The Ricoh branch of the same probe: an RP5C01 (the A3000/A4000
+    /// part) answers with its power-on MODE, $8 (timer running, block 0),
+    /// while the write-only RESET select reads zero -- exactly the pair
+    /// AROS matches as an "RF5C01A" before ever considering an MSM6242.
+    #[test]
+    fn the_aros_clock_probe_identifies_a_fitted_rp5c01() {
+        let mut bus = cpu_bus(test_bus(reset_rom(0, 0)));
+        bus.bus.set_rtc_chip(crate::rtc::RtcChip::Rp5c01);
+        bus.bus.set_rtc_present(true);
+        bus.bus.data_bus = 0xFFFF;
+
+        assert_eq!(clock_reg(&mut bus, 0x01) & 8, 0);
+        assert_eq!(clock_reg(&mut bus, 0x03) & 8, 0);
+        assert_eq!(clock_reg(&mut bus, 0x0D), 0x8); // an RF5C01A...
+        assert_eq!(clock_reg(&mut bus, 0x0F), 0x0); // ...whose RESET reads 0
     }
 
     /// The register select is A2-A5, so A1 never reaches the decode: each

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2050,6 +2050,7 @@ pub fn build_machine(
     bus.set_video_standard(cfg.video_standard);
     bus.set_chipset_revisions(cfg.agnus_revision, cfg.denise_revision);
     bus.set_rtc_present(cfg.rtc_present);
+    bus.set_rtc_chip(cfg.rtc_chip);
     bus.rtc.set_seed(cfg.rtc_seed_unix, cfg.rtc_frozen);
     if let Some(id) = cfg.gate_array.gayle_id() {
         let mut gayle = crate::gayle::Gayle::new(id);
@@ -2170,7 +2171,13 @@ pub fn build_machine(
     if let Some(machine) = cfg.machine {
         info!(
             "machine profile: {:?} (gate array {:?}, rtc {})",
-            machine, cfg.gate_array, cfg.rtc_present
+            machine,
+            cfg.gate_array,
+            if cfg.rtc_present {
+                cfg.rtc_chip.label()
+            } else {
+                "none"
+            }
         );
     }
     let cpu_clocks_per_cck = crate::config::clocks_per_cck_for_mhz(cfg.cpu_clock_mhz);

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -2,11 +2,21 @@
 
 //! Battery-backed real-time clock emulation.
 //!
-//! Classic big-box Amigas expose the Oki MSM6242 at $DC0000. The chip
-//! has sixteen four-bit registers; on Amiga each register is visible as
-//! a 32-bit word, so register N lives at base + N * 4. Copperline exposes a
-//! read-only wall-clock view: guest writes can control the HOLD latch,
-//! but they never change the host clock.
+//! Classic big-box Amigas expose a four-bit battery clock at $DC0000 with
+//! sixteen register selects; on Amiga each register is visible as a 32-bit
+//! word, so register N lives at base + N * 4. Two different parts fill
+//! that socket: the Oki MSM6242 (A500+/A2000/CDTV boards and the clock
+//! expansions), and the Ricoh RP5C01 on the A3000/A4000 motherboards --
+//! a different register layout, banked register blocks, and 26 nibbles of
+//! battery-backed RAM. AmigaOS probes for either part, but Linux/m68k
+//! drives the chip its machine model dictates, so an A3000/A4000 has to
+//! answer the RP5C01 protocol for the guest clock to work. [`RtcChip`]
+//! names the fitted part (`[machine] rtc_chip`) and [`Rtc`] dispatches
+//! guest traffic to it.
+//!
+//! Copperline exposes a read-only wall-clock view: guest writes drive the
+//! chips' latch/bank/control state (and the RP5C01's battery RAM), but
+//! they never change the host clock.
 //!
 //! The clock is reported in the host's *local* time zone (matching the
 //! auto-generated filename stamps in `timestamp.rs`), since AmigaOS has no
@@ -36,11 +46,124 @@ use crate::timebase::{SystemTime, UNIX_EPOCH};
 /// nibble and invent a clock (and then a date) that the machine does not have.
 pub const EMPTY_SOCKET_LANE: u8 = 0x40;
 
+/// Which battery-clock part sits in the $DC0000 socket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RtcChip {
+    /// Oki MSM6242: the A500+/A2000/CDTV part and what the aftermarket
+    /// clock expansions carry.
+    Msm6242,
+    /// Ricoh RP5C01: the A3000/A4000 motherboard part.
+    Rp5c01,
+}
+
+impl RtcChip {
+    /// The part name shown to the user (status output, control protocol).
+    pub fn label(self) -> &'static str {
+        match self {
+            RtcChip::Msm6242 => "MSM6242",
+            RtcChip::Rp5c01 => "RP5C01",
+        }
+    }
+}
+
+/// The fitted clock chip. Guest register traffic and host-side queries all
+/// funnel through here so the two parts stay interchangeable behind the one
+/// bus field.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Rtc {
+    Msm6242(Msm6242Rtc),
+    Rp5c01(Rp5c01Rtc),
+}
+
+impl Default for Rtc {
+    fn default() -> Self {
+        Rtc::Msm6242(Msm6242Rtc::default())
+    }
+}
+
+impl Rtc {
+    pub fn new(chip: RtcChip) -> Self {
+        match chip {
+            RtcChip::Msm6242 => Rtc::Msm6242(Msm6242Rtc::default()),
+            RtcChip::Rp5c01 => Rtc::Rp5c01(Rp5c01Rtc::default()),
+        }
+    }
+
+    pub fn chip(&self) -> RtcChip {
+        match self {
+            Rtc::Msm6242(_) => RtcChip::Msm6242,
+            Rtc::Rp5c01(_) => RtcChip::Rp5c01,
+        }
+    }
+
+    pub fn read(&mut self, addr: u64, size: usize, emulated_secs: f64) -> u64 {
+        match self {
+            Rtc::Msm6242(chip) => chip.read(addr, size, emulated_secs),
+            Rtc::Rp5c01(chip) => chip.read(addr, size, emulated_secs),
+        }
+    }
+
+    pub fn write(&mut self, addr: u64, size: usize, val: u64, emulated_secs: f64) {
+        match self {
+            Rtc::Msm6242(chip) => chip.write(addr, size, val, emulated_secs),
+            Rtc::Rp5c01(chip) => chip.write(addr, size, val, emulated_secs),
+        }
+    }
+
+    /// A CPU reset does not reach the battery-backed chip; see the concrete
+    /// chips' `reset` for what little state drops back to power-on defaults.
+    pub fn reset(&mut self) {
+        match self {
+            Rtc::Msm6242(chip) => chip.reset(),
+            Rtc::Rp5c01(chip) => chip.reset(),
+        }
+    }
+
+    /// Configure the power-on clock value (`None` restores the live host
+    /// clock). The seed is the value the clock reads at emulated time zero.
+    pub fn set_seed(&mut self, seed_unix: Option<u64>, frozen: bool) {
+        self.clock_mut().set_seed(seed_unix, frozen);
+    }
+
+    pub fn seed(&self) -> Option<u64> {
+        self.clock().seed()
+    }
+
+    pub fn frozen(&self) -> bool {
+        self.clock().frozen()
+    }
+
+    /// The Unix-seconds instant register reads decompose right now.
+    pub fn current_unix(&self, emulated_secs: f64) -> u64 {
+        self.clock().current_unix(emulated_secs)
+    }
+
+    /// The broken-down time register reads expose right now, formatted as
+    /// `YYYY-MM-DDTHH:MM:SS` (for status reporting, not the guest).
+    pub fn current_display(&self, emulated_secs: f64) -> String {
+        self.clock().current_display(emulated_secs)
+    }
+
+    fn clock(&self) -> &ClockSource {
+        match self {
+            Rtc::Msm6242(chip) => &chip.clock,
+            Rtc::Rp5c01(chip) => &chip.clock,
+        }
+    }
+
+    fn clock_mut(&mut self) -> &mut ClockSource {
+        match self {
+            Rtc::Msm6242(chip) => &mut chip.clock,
+            Rtc::Rp5c01(chip) => &mut chip.clock,
+        }
+    }
+}
+
+/// The time source both chips decompose into registers: the host's local
+/// wall clock by default, or the deterministic seed (`[machine] rtc_time`)
+/// ticking forward in emulated time.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct Msm6242Rtc {
-    control_d: u8,
-    control_e: u8,
-    latched: Option<RtcDateTime>,
+struct ClockSource {
     /// Power-on clock value in Unix seconds. When set, register reads
     /// derive from seed + elapsed emulated seconds instead of the host
     /// wall clock, making the guest-visible time deterministic.
@@ -51,77 +174,7 @@ pub struct Msm6242Rtc {
     test_time: Option<SystemTime>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct RtcDateTime {
-    year: u16,
-    month: u8,
-    day: u8,
-    weekday: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-impl Msm6242Rtc {
-    const CD_HOLD: u8 = 1 << 0;
-    const CD_IRQ_FLAG: u8 = 1 << 2;
-    const CF_24H: u8 = 1 << 2;
-
-    pub fn read(&mut self, addr: u64, _size: usize, emulated_secs: f64) -> u64 {
-        self.read_register(register_from_offset(addr), emulated_secs) as u64
-    }
-
-    pub fn write(&mut self, addr: u64, _size: usize, val: u64, emulated_secs: f64) {
-        let reg = register_from_offset(addr);
-        let val = (val & 0x0F) as u8;
-        match reg {
-            0xD => {
-                if val & Self::CD_HOLD != 0 {
-                    if self.latched.is_none() {
-                        self.latched = Some(self.current_time(emulated_secs));
-                    }
-                    self.control_d = Self::CD_HOLD;
-                } else {
-                    self.latched = None;
-                    self.control_d = 0;
-                }
-            }
-            0xE => {
-                self.control_e = val;
-            }
-            0xF => {
-                // Keep the clock running in 24-hour mode. STOP, RESET
-                // and TEST writes are deliberately not persistent.
-            }
-            _ => {}
-        }
-    }
-
-    fn read_register(&mut self, reg: u8, emulated_secs: f64) -> u8 {
-        let time = self
-            .latched
-            .unwrap_or_else(|| self.current_time(emulated_secs));
-        (match reg {
-            0x0 => time.second % 10,
-            0x1 => time.second / 10,
-            0x2 => time.minute % 10,
-            0x3 => time.minute / 10,
-            0x4 => time.hour % 10,
-            0x5 => time.hour / 10,
-            0x6 => time.day % 10,
-            0x7 => time.day / 10,
-            0x8 => time.month % 10,
-            0x9 => time.month / 10,
-            0xA => (time.year % 10) as u8,
-            0xB => ((time.year / 10) % 10) as u8,
-            0xC => time.weekday,
-            0xD => self.control_d | Self::CD_IRQ_FLAG,
-            0xE => self.control_e,
-            0xF => Self::CF_24H,
-            _ => 0,
-        }) & 0x0F
-    }
-
+impl ClockSource {
     fn current_time(&self, emulated_secs: f64) -> RtcDateTime {
         #[cfg(test)]
         if let Some(time) = self.test_time {
@@ -151,25 +204,23 @@ impl Msm6242Rtc {
         }
     }
 
-    /// Configure the power-on clock value (`None` restores the live host
-    /// clock). The seed is the value the clock reads at emulated time zero.
-    pub fn set_seed(&mut self, seed_unix: Option<u64>, frozen: bool) {
+    fn set_seed(&mut self, seed_unix: Option<u64>, frozen: bool) {
         self.seed_unix = seed_unix;
         self.frozen = frozen && seed_unix.is_some();
     }
 
-    pub fn seed(&self) -> Option<u64> {
+    fn seed(&self) -> Option<u64> {
         self.seed_unix
     }
 
-    pub fn frozen(&self) -> bool {
+    fn frozen(&self) -> bool {
         self.frozen
     }
 
     /// The Unix-seconds instant register reads decompose right now,
     /// following the same source precedence as `current_time` (the
     /// host-local path reports plain host Unix seconds).
-    pub fn current_unix(&self, emulated_secs: f64) -> u64 {
+    fn current_unix(&self, emulated_secs: f64) -> u64 {
         if let Some(secs) = crate::envcfg::var("COPPERLINE_RTC_FIXED_SECS")
             .and_then(|s| s.trim().parse::<u64>().ok())
         {
@@ -181,10 +232,93 @@ impl Msm6242Rtc {
         RtcDateTime::unix_secs(SystemTime::now())
     }
 
-    /// The broken-down time register reads expose right now, formatted as
-    /// `YYYY-MM-DDTHH:MM:SS` (for status reporting, not the guest).
-    pub fn current_display(&self, emulated_secs: f64) -> String {
+    fn current_display(&self, emulated_secs: f64) -> String {
         self.current_time(emulated_secs).iso8601()
+    }
+
+    #[cfg(test)]
+    fn set_test_time(&mut self, time: SystemTime) {
+        self.test_time = Some(time);
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Msm6242Rtc {
+    control_d: u8,
+    control_e: u8,
+    latched: Option<RtcDateTime>,
+    clock: ClockSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct RtcDateTime {
+    year: u16,
+    month: u8,
+    day: u8,
+    weekday: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+impl Msm6242Rtc {
+    const CD_HOLD: u8 = 1 << 0;
+    const CD_IRQ_FLAG: u8 = 1 << 2;
+    const CF_24H: u8 = 1 << 2;
+
+    pub fn read(&mut self, addr: u64, _size: usize, emulated_secs: f64) -> u64 {
+        self.read_register(register_from_offset(addr), emulated_secs) as u64
+    }
+
+    pub fn write(&mut self, addr: u64, _size: usize, val: u64, emulated_secs: f64) {
+        let reg = register_from_offset(addr);
+        let val = (val & 0x0F) as u8;
+        match reg {
+            0xD => {
+                if val & Self::CD_HOLD != 0 {
+                    if self.latched.is_none() {
+                        self.latched = Some(self.clock.current_time(emulated_secs));
+                    }
+                    self.control_d = Self::CD_HOLD;
+                } else {
+                    self.latched = None;
+                    self.control_d = 0;
+                }
+            }
+            0xE => {
+                self.control_e = val;
+            }
+            0xF => {
+                // Keep the clock running in 24-hour mode. STOP, RESET
+                // and TEST writes are deliberately not persistent.
+            }
+            _ => {}
+        }
+    }
+
+    fn read_register(&mut self, reg: u8, emulated_secs: f64) -> u8 {
+        let time = self
+            .latched
+            .unwrap_or_else(|| self.clock.current_time(emulated_secs));
+        (match reg {
+            0x0 => time.second % 10,
+            0x1 => time.second / 10,
+            0x2 => time.minute % 10,
+            0x3 => time.minute / 10,
+            0x4 => time.hour % 10,
+            0x5 => time.hour / 10,
+            0x6 => time.day % 10,
+            0x7 => time.day / 10,
+            0x8 => time.month % 10,
+            0x9 => time.month / 10,
+            0xA => (time.year % 10) as u8,
+            0xB => ((time.year / 10) % 10) as u8,
+            0xC => time.weekday,
+            0xD => self.control_d | Self::CD_IRQ_FLAG,
+            0xE => self.control_e,
+            0xF => Self::CF_24H,
+            _ => 0,
+        }) & 0x0F
     }
 
     /// A CPU reset does not reach the battery-backed chip, so the time
@@ -195,10 +329,205 @@ impl Msm6242Rtc {
         self.control_e = 0;
         self.latched = None;
     }
+}
 
-    #[cfg(test)]
-    fn set_test_time(&mut self, time: SystemTime) {
-        self.test_time = Some(time);
+/// The Ricoh RP5C01, the A3000/A4000 battery clock.
+///
+/// Same four-bit bus presence as the MSM6242, entirely different register
+/// model: the MODE register (D) selects one of four register blocks for
+/// selects 0-C -- block 0 is the time/calendar counters (note the layout
+/// differs from the Oki part: day-of-week at 6, day at 7-8, month at 9-A,
+/// year at B-C), block 1 the alarm digits plus the 12/24 select and the
+/// leap-year counter, and blocks 2/3 are 13 battery-backed RAM nibbles
+/// each (low and high halves of an internal byte, respectively), which
+/// AmigaOS uses via battmem.resource on these machines. MODE bit 3 gates
+/// the timer -- Linux's rtc-rp5c01 driver clears it around every read and
+/// write for a tearing-free window -- and bit 2 arms the alarm (stored
+/// here, but no interrupt line is wired on the Amiga boards). TEST (E) and
+/// RESET (F) are write-only and read back zero, which together with MODE
+/// reading its power-on $8 is exactly how battclock.resource-style probes
+/// (AROS names it "RF5C01A") tell this part from an MSM6242.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Rp5c01Rtc {
+    /// MODE register (select D): TIMER_EN | ALARM_EN | block select.
+    mode: u8,
+    /// Block-1 register storage (alarm digits, 12/24 select). Slots the
+    /// write mask zeroes never hold anything.
+    bank1: [u8; 13],
+    /// The 26 battery-backed RAM nibbles, one byte per select: block 2
+    /// reads/writes the low nibble, block 3 the high one.
+    ram: [u8; 13],
+    /// Time held while TIMER_EN is low. The underlying source keeps
+    /// running, so unlike the real stopped chip no time is lost.
+    latched: Option<RtcDateTime>,
+    clock: ClockSource,
+}
+
+impl Default for Rp5c01Rtc {
+    fn default() -> Self {
+        Self {
+            // Power-on: timer running, block 0. The probes match on MODE
+            // reading exactly this.
+            mode: Self::MODE_TIMER_EN,
+            // Battery-fresh block 1 with the 12/24 select in 24-hour mode,
+            // matching what AmigaOS and Linux configure and expect.
+            bank1: Self::bank1_default(),
+            ram: [0; 13],
+            latched: None,
+            clock: ClockSource::default(),
+        }
+    }
+}
+
+impl Rp5c01Rtc {
+    const MODE_TIMER_EN: u8 = 1 << 3;
+    const MODE_BLOCK_MASK: u8 = 0x03;
+    const BLOCK_TIME: u8 = 0;
+    const BLOCK_ALARM: u8 = 1;
+    const BLOCK_RAM_LO: u8 = 2;
+    const RESET_ALARM: u8 = 1 << 0;
+    /// Block-1 selects: the 12/24 flag (bit 0: 1 = 24-hour) and the
+    /// leap-year counter.
+    const REG_1224: usize = 0xA;
+    const REG_LEAP: u8 = 0xB;
+    /// Alarm digit selects within block 1 (1-minute through 10-day).
+    const ALARM_REGS: std::ops::RangeInclusive<usize> = 0x2..=0x8;
+
+    /// Writable bits per block-1 select, mirroring the digit widths the
+    /// part implements (a 10-minute alarm digit is three bits, and so on).
+    /// Selects 0, 1, 9 and C hold no register at all. The leap-year
+    /// counter (B) is masked off too: reads derive it from the year
+    /// counter, which is the value it can never drift from here.
+    const BANK1_WRITE_MASK: [u8; 13] = [
+        0x0, 0x0, 0xF, 0x7, 0xF, 0x3, 0x7, 0xF, 0x3, 0x0, 0x1, 0x0, 0x0,
+    ];
+
+    fn bank1_default() -> [u8; 13] {
+        let mut bank1 = [0u8; 13];
+        bank1[Self::REG_1224] = 1;
+        bank1
+    }
+
+    pub fn read(&mut self, addr: u64, _size: usize, emulated_secs: f64) -> u64 {
+        let reg = register_from_offset(addr);
+        let val = match reg {
+            0xD => self.mode,
+            // TEST and RESET are write-only; the lane reads back zero.
+            0xE | 0xF => 0,
+            _ => match self.mode & Self::MODE_BLOCK_MASK {
+                Self::BLOCK_TIME => self.read_time_register(reg, emulated_secs),
+                Self::BLOCK_ALARM => self.read_alarm_register(reg, emulated_secs),
+                Self::BLOCK_RAM_LO => self.ram[reg as usize],
+                _ => self.ram[reg as usize] >> 4,
+            },
+        };
+        u64::from(val & 0x0F)
+    }
+
+    pub fn write(&mut self, addr: u64, _size: usize, val: u64, emulated_secs: f64) {
+        let reg = register_from_offset(addr);
+        let val = (val & 0x0F) as u8;
+        match reg {
+            0xD => {
+                // Clearing TIMER_EN holds the read view still -- the
+                // tearing-free window Linux's driver opens around every
+                // access. The time source keeps running underneath, so
+                // the stopped interval is not actually lost.
+                if val & Self::MODE_TIMER_EN == 0 {
+                    if self.latched.is_none() {
+                        self.latched = Some(self.clock.current_time(emulated_secs));
+                    }
+                } else {
+                    self.latched = None;
+                }
+                self.mode = val;
+            }
+            0xE => {
+                // TEST: not modelled, deliberately not persistent.
+            }
+            0xF => {
+                if val & Self::RESET_ALARM != 0 {
+                    self.bank1[Self::ALARM_REGS].fill(0);
+                }
+                // The fraction reset and the 16 Hz / 1 Hz output gates go
+                // nowhere: sub-second phase derives from the time source
+                // and no output pin is wired on the Amiga boards.
+            }
+            _ => match self.mode & Self::MODE_BLOCK_MASK {
+                // Time-counter writes never move the read-only host or
+                // seeded clock (module policy, same as the MSM6242).
+                Self::BLOCK_TIME => {}
+                Self::BLOCK_ALARM => {
+                    self.bank1[reg as usize] = val & Self::BANK1_WRITE_MASK[reg as usize];
+                }
+                Self::BLOCK_RAM_LO => {
+                    self.ram[reg as usize] = (self.ram[reg as usize] & 0xF0) | val;
+                }
+                _ => {
+                    self.ram[reg as usize] = (val << 4) | (self.ram[reg as usize] & 0x0F);
+                }
+            },
+        }
+    }
+
+    fn time(&self, emulated_secs: f64) -> RtcDateTime {
+        self.latched
+            .unwrap_or_else(|| self.clock.current_time(emulated_secs))
+    }
+
+    fn read_time_register(&self, reg: u8, emulated_secs: f64) -> u8 {
+        let time = self.time(emulated_secs);
+        match reg {
+            0x0 => time.second % 10,
+            0x1 => time.second / 10,
+            0x2 => time.minute % 10,
+            0x3 => time.minute / 10,
+            0x4 => self.hour_digits(time.hour).0,
+            0x5 => self.hour_digits(time.hour).1,
+            0x6 => time.weekday,
+            0x7 => time.day % 10,
+            0x8 => time.day / 10,
+            0x9 => time.month % 10,
+            0xA => time.month / 10,
+            0xB => (time.year % 10) as u8,
+            0xC => ((time.year / 10) % 10) as u8,
+            _ => 0,
+        }
+    }
+
+    /// Hour digits under the current 12/24 select: in 12-hour mode the
+    /// ten-hours register carries the PM flag in bit 1 and hours read
+    /// 12, 1..11.
+    fn hour_digits(&self, hour: u8) -> (u8, u8) {
+        if self.bank1[Self::REG_1224] & 1 != 0 {
+            return (hour % 10, hour / 10);
+        }
+        let pm = u8::from(hour >= 12);
+        let hour = match hour % 12 {
+            0 => 12,
+            h => h,
+        };
+        (hour % 10, (hour / 10) | (pm << 1))
+    }
+
+    fn read_alarm_register(&self, reg: u8, emulated_secs: f64) -> u8 {
+        if reg == Self::REG_LEAP {
+            // The real part counts this alongside the year counter
+            // (0 = leap year); deriving both from the same source keeps
+            // them agreeing by construction.
+            return (self.time(emulated_secs).year % 4) as u8;
+        }
+        self.bank1[reg as usize]
+    }
+
+    /// A CPU reset does not reach the battery-backed chip: the time
+    /// source, alarm registers, 12/24 select, and battery RAM all
+    /// survive. Only the volatile-looking selector state returns to its
+    /// power-on default, which is also the first thing any OS probe
+    /// re-establishes.
+    pub fn reset(&mut self) {
+        self.mode = Self::MODE_TIMER_EN;
+        self.latched = None;
     }
 }
 
@@ -400,6 +729,12 @@ mod tests {
         rtc.read((reg as u64) * 4, 4, emulated_secs) as u8
     }
 
+    impl Msm6242Rtc {
+        fn set_test_time(&mut self, time: SystemTime) {
+            self.clock.set_test_time(time);
+        }
+    }
+
     #[test]
     fn registers_expose_bcd_host_time() {
         let mut rtc = Msm6242Rtc::default();
@@ -449,7 +784,7 @@ mod tests {
     #[test]
     fn seeded_clock_reads_seed_and_advances_with_emulated_time() {
         let mut rtc = Msm6242Rtc::default();
-        rtc.set_seed(Some(VECTOR_UNIX), false);
+        rtc.clock.set_seed(Some(VECTOR_UNIX), false);
 
         assert_eq!(read_reg(&mut rtc, 0x0), 9); // seconds ones
         assert_eq!(read_reg(&mut rtc, 0x1), 2); // seconds tens
@@ -468,14 +803,14 @@ mod tests {
         // 31 emulated seconds later the clock reads :00 of the next minute.
         assert_eq!(read_reg_at(&mut rtc, 0x0, 31.0), 0);
         assert_eq!(read_reg_at(&mut rtc, 0x2, 31.0), 9);
-        assert_eq!(rtc.current_unix(31.9), VECTOR_UNIX + 31);
+        assert_eq!(rtc.clock.current_unix(31.9), VECTOR_UNIX + 31);
     }
 
     #[test]
     fn frozen_clock_never_advances() {
-        let mut rtc = Msm6242Rtc::default();
+        let mut rtc = Rtc::new(RtcChip::Msm6242);
         rtc.set_seed(Some(VECTOR_UNIX), true);
-        assert_eq!(read_reg_at(&mut rtc, 0x0, 3600.0), 9);
+        assert_eq!(rtc.read(0x0, 4, 3600.0), 9);
         assert_eq!(rtc.current_unix(3600.0), VECTOR_UNIX);
         assert_eq!(rtc.current_display(3600.0), "2005-03-18T01:58:29");
     }
@@ -483,12 +818,203 @@ mod tests {
     #[test]
     fn reset_keeps_the_seed_but_drops_the_hold_latch() {
         let mut rtc = Msm6242Rtc::default();
-        rtc.set_seed(Some(VECTOR_UNIX), false);
+        rtc.clock.set_seed(Some(VECTOR_UNIX), false);
         rtc.write(0xD * 4, 4, Msm6242Rtc::CD_HOLD as u64, 0.0);
         rtc.reset();
         assert_eq!(read_reg(&mut rtc, 0xD) & Msm6242Rtc::CD_HOLD, 0);
         assert_eq!(read_reg_at(&mut rtc, 0x0, 5.0), 4); // still ticking from the seed
+        assert_eq!(rtc.clock.seed(), Some(VECTOR_UNIX));
+    }
+
+    fn seeded_rp5c01(seed: u64) -> Rp5c01Rtc {
+        let mut rtc = Rp5c01Rtc::default();
+        rtc.clock.set_seed(Some(seed), false);
+        rtc
+    }
+
+    fn rp_read_at(rtc: &mut Rp5c01Rtc, reg: u8, emulated_secs: f64) -> u8 {
+        rtc.read((reg as u64) * 4, 4, emulated_secs) as u8
+    }
+
+    fn rp_read(rtc: &mut Rp5c01Rtc, reg: u8) -> u8 {
+        rp_read_at(rtc, reg, 0.0)
+    }
+
+    fn rp_write(rtc: &mut Rp5c01Rtc, reg: u8, val: u8) {
+        rtc.write((reg as u64) * 4, 4, val as u64, 0.0);
+    }
+
+    /// The power-on tell every battclock probe matches on: MODE reads $8
+    /// (timer running, block 0) while the write-only TEST and RESET
+    /// selects read zero. AROS accepts exactly D == 8 && F == 0 as an
+    /// "RF5C01A"; an MSM6242 shows control F's 24-hour bit instead.
+    #[test]
+    fn rp5c01_powers_on_as_the_clock_probes_expect() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        assert_eq!(rp_read(&mut rtc, 0xD), 0x8);
+        assert_eq!(rp_read(&mut rtc, 0xE), 0x0);
+        assert_eq!(rp_read(&mut rtc, 0xF), 0x0);
+        // The "not a clock" early-outs: 10-second and 10-minute digits
+        // never show bit 3.
+        assert_eq!(rp_read(&mut rtc, 0x1) & 8, 0);
+        assert_eq!(rp_read(&mut rtc, 0x3) & 8, 0);
+    }
+
+    /// Block 0 has the Ricoh layout: weekday at 6, day at 7-8, month at
+    /// 9-A, year at B-C -- shifted one select up from the Oki map by the
+    /// weekday register moving to the front.
+    #[test]
+    fn rp5c01_time_registers_expose_the_ricoh_layout() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        assert_eq!(rp_read(&mut rtc, 0x0), 9); // seconds ones
+        assert_eq!(rp_read(&mut rtc, 0x1), 2); // seconds tens
+        assert_eq!(rp_read(&mut rtc, 0x2), 8); // minutes ones
+        assert_eq!(rp_read(&mut rtc, 0x3), 5); // minutes tens
+        assert_eq!(rp_read(&mut rtc, 0x4), 1); // hours ones
+        assert_eq!(rp_read(&mut rtc, 0x5), 0); // hours tens
+        assert_eq!(rp_read(&mut rtc, 0x6), 5); // Friday
+        assert_eq!(rp_read(&mut rtc, 0x7), 8); // day ones
+        assert_eq!(rp_read(&mut rtc, 0x8), 1); // day tens
+        assert_eq!(rp_read(&mut rtc, 0x9), 3); // month ones
+        assert_eq!(rp_read(&mut rtc, 0xA), 0); // month tens
+        assert_eq!(rp_read(&mut rtc, 0xB), 5); // year ones
+        assert_eq!(rp_read(&mut rtc, 0xC), 0); // year tens
+    }
+
+    /// The Linux rtc-rp5c01 access pattern: clear TIMER_EN (MODE = block
+    /// 0) for a tearing-free window, read the digits, then park the chip
+    /// in MODE = $9. The held view must not advance, and re-enabling the
+    /// timer must resume the running clock without losing the interval.
+    #[test]
+    fn rp5c01_timer_enable_gates_a_tearing_free_read_window() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        rp_write(&mut rtc, 0xD, 0x0); // lock: timer off, block 0
+        assert_eq!(rp_read_at(&mut rtc, 0x0, 31.0), 9); // still :29, not :00
+        assert_eq!(rp_read_at(&mut rtc, 0x2, 31.0), 8);
+
+        rtc.write(0xD * 4, 4, 0x9, 31.0); // unlock: timer on, block 1
+        assert_eq!(rtc.read(0xD * 4, 4, 31.0), 0x9);
+        // Back in block 0 the clock has kept ticking underneath the hold.
+        rtc.write(0xD * 4, 4, 0x8, 31.0);
+        assert_eq!(rp_read_at(&mut rtc, 0x0, 31.0), 0); // :00
+        assert_eq!(rp_read_at(&mut rtc, 0x2, 31.0), 9); // of minute 59
+    }
+
+    /// Block 1 stores alarm digits behind their hardware write masks, and
+    /// RESET bit 0 clears them all.
+    #[test]
+    fn rp5c01_alarm_registers_store_masked_digits_until_alarm_reset() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        rp_write(&mut rtc, 0xD, 0x9); // block 1
+        for reg in 0x2..=0x8 {
+            rp_write(&mut rtc, reg, 0xF);
+        }
+        assert_eq!(rp_read(&mut rtc, 0x2), 0xF); // 1-minute alarm
+        assert_eq!(rp_read(&mut rtc, 0x3), 0x7); // 10-minute: 3 bits
+        assert_eq!(rp_read(&mut rtc, 0x5), 0x3); // 10-hour: 2 bits
+        assert_eq!(rp_read(&mut rtc, 0x8), 0x3); // 10-day: 2 bits
+                                                 // Selects with no register behind them stay empty.
+        rp_write(&mut rtc, 0x0, 0xF);
+        rp_write(&mut rtc, 0x9, 0xF);
+        assert_eq!(rp_read(&mut rtc, 0x0), 0x0);
+        assert_eq!(rp_read(&mut rtc, 0x9), 0x0);
+
+        rp_write(&mut rtc, 0xF, Rp5c01Rtc::RESET_ALARM);
+        for reg in 0x2..=0x8 {
+            assert_eq!(rp_read(&mut rtc, reg), 0, "alarm select {reg:#X}");
+        }
+    }
+
+    /// The 12/24 select (block 1, select A) reshapes the hour digits: in
+    /// 12-hour mode the ten-hours register carries PM in bit 1 and hours
+    /// read 12, 1..11.
+    #[test]
+    fn rp5c01_12_hour_mode_sets_the_pm_flag() {
+        // 13:58:29 (VECTOR + 12h): 24-hour mode first.
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX + 12 * 3600);
+        assert_eq!(rp_read(&mut rtc, 0x4), 3);
+        assert_eq!(rp_read(&mut rtc, 0x5), 1);
+
+        rp_write(&mut rtc, 0xD, 0x9); // block 1
+        rp_write(&mut rtc, 0xA, 0x0); // 12-hour mode
+        rp_write(&mut rtc, 0xD, 0x8); // back to time
+        assert_eq!(rp_read(&mut rtc, 0x4), 1); // 1 PM
+        assert_eq!(rp_read(&mut rtc, 0x5), 2); // PM flag, no tens
+
+        // Midnight reads as 12 with the PM flag clear.
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX - 3600 - 58 * 60 - 29);
+        rp_write(&mut rtc, 0xD, 0x9);
+        rp_write(&mut rtc, 0xA, 0x0);
+        rp_write(&mut rtc, 0xD, 0x8);
+        assert_eq!(rp_read(&mut rtc, 0x4), 2);
+        assert_eq!(rp_read(&mut rtc, 0x5), 1);
+    }
+
+    /// The leap-year counter tracks the year counter: 0 in a leap year,
+    /// counting up to 3. 2005 % 4 = 1; one year earlier it reads 0.
+    #[test]
+    fn rp5c01_leap_year_counter_tracks_the_year() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        rp_write(&mut rtc, 0xD, 0x9);
+        assert_eq!(rp_read(&mut rtc, 0xB), 1);
+
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX - 365 * 86_400);
+        rp_write(&mut rtc, 0xD, 0x9);
+        assert_eq!(rp_read(&mut rtc, 0xB), 0); // 2004
+    }
+
+    /// Blocks 2 and 3 are the 26 battery RAM nibbles (battmem.resource's
+    /// storage on the A3000/A4000): block 2 holds the low nibble of each
+    /// of 13 bytes, block 3 the high one, and both survive a CPU reset
+    /// like everything battery-powered.
+    #[test]
+    fn rp5c01_ram_blocks_hold_26_battery_nibbles_across_reset() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        rp_write(&mut rtc, 0xD, 0xA); // block 2: low nibbles
+        rp_write(&mut rtc, 0x0, 0x5);
+        rp_write(&mut rtc, 0xC, 0xF);
+        rp_write(&mut rtc, 0xD, 0xB); // block 3: high nibbles
+        rp_write(&mut rtc, 0x0, 0xA);
+
+        rp_write(&mut rtc, 0xD, 0xA);
+        assert_eq!(rp_read(&mut rtc, 0x0), 0x5);
+        assert_eq!(rp_read(&mut rtc, 0xC), 0xF);
+        rp_write(&mut rtc, 0xD, 0xB);
+        assert_eq!(rp_read(&mut rtc, 0x0), 0xA);
+        assert_eq!(rp_read(&mut rtc, 0xC), 0x0);
+
+        rtc.reset();
+        assert_eq!(rp_read(&mut rtc, 0xD), 0x8); // selector back to power-on
+        rp_write(&mut rtc, 0xD, 0xB);
+        assert_eq!(rp_read(&mut rtc, 0x0), 0xA); // RAM kept
+        rp_write(&mut rtc, 0xD, 0x9);
+        assert_eq!(rp_read(&mut rtc, 0xA), 0x1); // 12/24 select kept too
+    }
+
+    /// Writes to the time counters never move the read-only clock view
+    /// (module policy: the guest cannot set the host or seeded clock).
+    #[test]
+    fn rp5c01_time_counter_writes_never_move_the_clock() {
+        let mut rtc = seeded_rp5c01(VECTOR_UNIX);
+        for reg in 0x0..=0xC {
+            rp_write(&mut rtc, reg, 0x7);
+        }
+        assert_eq!(rp_read(&mut rtc, 0x0), 9);
+        assert_eq!(rp_read(&mut rtc, 0x6), 5);
+        assert_eq!(rp_read(&mut rtc, 0xB), 5);
+        assert_eq!(rtc.clock.seed(), Some(VECTOR_UNIX));
+    }
+
+    #[test]
+    fn rtc_wrapper_selects_and_reports_the_chip() {
+        let mut rtc = Rtc::new(RtcChip::Rp5c01);
+        assert_eq!(rtc.chip(), RtcChip::Rp5c01);
+        assert_eq!(rtc.chip().label(), "RP5C01");
+        rtc.set_seed(Some(VECTOR_UNIX), true);
         assert_eq!(rtc.seed(), Some(VECTOR_UNIX));
+        assert!(rtc.frozen());
+        assert_eq!(rtc.read(0xD * 4, 4, 0.0), 0x8);
+        assert_eq!(Rtc::default().chip(), RtcChip::Msm6242);
     }
 
     #[test]

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -127,7 +127,11 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  36: Memory gained the CPU-slot accelerator fast RAM bank (accel_ram,
 //      starting at $08000000) and MachineDescriptor its size
 //      (accel_ram_bytes)
-pub const STATE_VERSION: u32 = 36;
+//  37: the Bus rtc field became the Rtc chip enum - MSM6242 or the
+//      A3000/A4000's RP5C01 ([machine] rtc_chip), the Ricoh part carrying
+//      its mode/alarm/battery-RAM state and both sharing the seeded
+//      ClockSource
+pub const STATE_VERSION: u32 = 37;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
The A3000/A4000 carry a Ricoh RP5C01 in the $DC0000 clock socket, not the OKI MSM6242 of the smaller boards, and the two parts speak different register protocols. AmigaOS probes for either, which masked the difference - but Linux/m68k does not probe: the kernel drives the part the machine model dictates (`a3000_hwclk` / rtc-rp5c01 hard-assume the Ricoh layout on the big boxes), so an emulated A3000/A4000 answering MSM-style handed Linux a garbage date.

**The chip** (modelled after the datasheet as mirrored by MAME's rp5c01 and Linux's rtc-rp5c01 driver):

- MODE register (select D): TIMER_EN, ALARM_EN, and a two-bit block select over selects 0-C. Block 0 is the time counters in the Ricoh layout (weekday at 6, day 7-8, month 9-A, year B-C); block 1 the alarm digits behind their hardware write masks plus the 12/24 select (12-hour mode reads 12, 1..11 with PM in bit 1 of ten-hours) and the leap-year counter (derived from the year counter so the two cannot desync); blocks 2/3 the 26 nibbles of battery-backed RAM that battmem.resource uses on these machines.
- TEST/RESET are write-only and read zero, which together with MODE reading its power-on $8 is exactly how battclock-style probes (AROS calls the part "RF5C01A") tell it from an MSM6242 - there is a new probe regression test alongside the existing MSM one.
- Clearing TIMER_EN holds a tearing-free read view (the lock window Linux opens around every access) without losing time underneath; RESET bit 0 clears the alarm digits. Guest writes to the time counters stay ignored, per the module's existing read-only clock policy.

**Integration**: both chips sit behind an `Rtc` enum on the bus and share the seeded `ClockSource`, so `rtc_time`/`rtc_frozen`/`COPPERLINE_RTC_FIXED_SECS` behave identically on either. New `[machine] rtc_chip = "MSM6242" | "RP5C01"` key defaulting per profile (RP5C01 on A3000/A4000), implying `rtc = true` and rejecting an explicit `rtc = false` like `rtc_time` does. `rtc.get` reports the fitted part. The Bus serialization changed shape, so STATE_VERSION goes 36 -> 37. Docs: configuration.md, control.md, copperline.example.toml.

**Verified** with ten new unit tests (register layout, block switching, the Linux lock/unlock access pattern, 12-hour mode, alarm masks, RAM nibbles across reset, config defaults/contradictions) plus end-to-end:

- AmigaTestKit 1.21 F8 on the A4000 profile: "RP5C01 detected at 00dc0000", seeded time ticking and rolling over correctly across separate deterministic runs.
- Debian 3.1/m68k (kernel 2.4.27) booted on the A4000 profile with `rtc_time = "2005-03-18 01:58:29"`: rc prints "System Clock set. Local time: Fri Mar 18 03:11:58 CET 2005" - the kernel's own boot-time read of the chip, correctly decoded (CET = the seed +1h).
- Full suite 1746 passing, clippy and fmt clean.