### PR TITLE
web: machine model select (A500 / AGA A1200)

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 
 use copperline::audio::AudioSink;
 use copperline::bus::PortDevice;
-use copperline::config::{Config, Overscan};
+use copperline::config::{machine_profile_defaults, parse_machine_model, Config, Overscan};
 use copperline::emulator::{build_machine, Emulator};
 use copperline::serial::{ChannelSerialHandle, ChannelSerialSink};
 use copperline::video::deinterlace::Deinterlacer;
@@ -223,11 +223,21 @@ pub struct WebEmu {
 
 #[wasm_bindgen]
 impl WebEmu {
-    /// Build the default machine (the A500 AROS profile of the desktop
-    /// launcher) with a placeholder ROM; `load_rom` supplies the real one.
+    /// Build a machine with a placeholder ROM; `load_rom` supplies the real
+    /// one. `model` picks the machine profile by name ("A500", "A1200", ...)
+    /// exactly as the desktop's `--model` flag does; omitted or empty, the
+    /// default machine is the A500 of the desktop launcher, so pages built
+    /// against the model-less constructor keep booting what they always did.
+    /// `models` lists the profiles the hosted page offers; any name the
+    /// desktop flag takes is accepted here, but the ones outside that list
+    /// may need pieces a browser page cannot supply (CDTV/CD32 want an
+    /// extended ROM and a CD). An unknown name throws.
     #[wasm_bindgen(constructor)]
-    pub fn new() -> Result<WebEmu, JsValue> {
-        let cfg = Config::default();
+    pub fn new(model: Option<String>) -> Result<WebEmu, JsValue> {
+        let cfg = match model.as_deref().map(str::trim) {
+            None | Some("") => Config::default(),
+            Some(name) => machine_profile_defaults(parse_machine_model(name).map_err(js_err)?),
+        };
         let audio = Rc::new(RefCell::new(Vec::new()));
         let sink = WebAudioSink { buf: audio.clone() };
         // rom_optional: the default rom_path names the bundled AROS file,
@@ -266,6 +276,35 @@ impl WebEmu {
             }
             _ => "dev build".to_string(),
         }
+    }
+
+    /// The machine profiles the page's machine select offers, in menu
+    /// order. A vetted subset of what the constructor accepts: every model
+    /// here boots the bundled AROS ROM (or a plain Kickstart) with nothing
+    /// but a floppy, so the page can offer it unconditionally. The page
+    /// builds its select from this list, which is also its feature test --
+    /// older bundles have no `models` and the select stays hidden.
+    pub fn models() -> Vec<String> {
+        vec!["A500".to_string(), "A1200".to_string()]
+    }
+
+    /// The running machine's profile name ("A500", "A1200", ...), or
+    /// undefined for a machine no profile describes -- the model-less
+    /// default constructor's machine, or a custom-shaped machine restored
+    /// from a save state. Follows `load_state`, so a page can re-point its
+    /// machine select at what a state brought back.
+    pub fn machine_model(&self) -> Option<String> {
+        self.emu
+            .machine_descriptor()
+            .machine
+            .map(|model| format!("{model:?}"))
+    }
+
+    /// One-line description of the running machine for bug reports and
+    /// diagnostics: profile, CPU, chipset, RAM sizes, and the fitted ROM's
+    /// fingerprint. Tracks ROM swaps and state loads.
+    pub fn machine_summary(&self) -> String {
+        self.emu.machine_descriptor().summary()
     }
 
     /// Fit a Kickstart/AROS ROM (and optional extended ROM) from bytes and

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1981,14 +1981,18 @@ function matchModelOption(name) {
 
 function tryApplyRequestedMachine() {
   if (requestedMachine === null || !machineSel.options.length) return;
-  const model = matchModelOption(requestedMachine);
+  const name = String(requestedMachine).trim();
+  requestedMachine = null;
+  // A blank request (?machine= with no value, "machine": "" in the config)
+  // is no request, like the constructor's empty model and the joy param.
+  if (!name) return;
+  const model = matchModelOption(name);
   if (model) {
     machineModel = model;
     machineSel.value = model;
   } else {
-    console.warn(`unknown machine ${requestedMachine}; keeping ${machineSel.value}`);
+    console.warn(`unknown machine ${name}; keeping ${machineSel.value}`);
   }
-  requestedMachine = null;
 }
 
 // Called once the wasm module is ready (load()): fill the select from the

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -113,6 +113,10 @@ async function fetchBytes(url, label) {
 let bootRom = null; // { rom, ext, label } - what the boot button will fit
 let pendingDisk = null; // { bytes, name } - inserted right after boot
 let df0Name = null; // what the page believes is in DF0, for bug reports
+// The page's copy of the last disk that went into DF0. The inserted bytes
+// live inside the machine, so switching the machine model (which builds a
+// new one) re-inserts from this stash; kept forever, like the ROM stash.
+let lastDisk = null; // { bytes, name }
 
 function refreshBootButton() {
   bootBtn.disabled = !(wasm && bootRom);
@@ -138,6 +142,7 @@ function fitRom(bytes, label) {
 // Route disk bytes from any source (picker, URL, drop): insert into a
 // running machine, or stash them for the boot button to insert after boot.
 function insertDisk(bytes, name) {
+  lastDisk = { bytes, name };
   if (emu) {
     emu.insert_floppy(0, bytes, name);
     setLoadStatus(`DF0: ${name} (write-protected)`);
@@ -284,6 +289,7 @@ async function load() {
     setLoadStatus('loading emulator...');
     wasm = await init();
     buildInfo = WebEmu.build_info?.() ?? null;
+    populateMachineSelect();
   } catch (e) {
     setLoadStatus(`failed to load the emulator: ${e.message ?? e}`);
     console.error(e);
@@ -329,7 +335,9 @@ async function boot() {
     // builds itself: nothing the boot button can reach (it stays disabled
     // until a ROM exists), but a save state carries its own ROM and
     // replaces the whole machine, so a restore can start from one.
-    const machine = new WebEmu();
+    // The model argument picks the machine profile; undefined (an older
+    // shell, or the list not knowing better) builds the default A500.
+    const machine = new WebEmu(machineModel ?? undefined);
     if (bootRom) machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
 
     // A reboot after an emulator error builds a new audio stack; close the
@@ -384,7 +392,9 @@ async function boot() {
     setLoadStatus(
       // A ROM-less boot is only ever a landing place for a state load,
       // which overwrites this line the moment it lands.
-      (bootRom ? `booted ${bootRom.label}` : 'machine built, waiting for the state') +
+      (bootRom
+        ? `booted ${bootRom.label}${machineModel ? ` on the ${machineModel}` : ''}`
+        : 'machine built, waiting for the state') +
         (df0Name ? ` - DF0: ${df0Name} (write-protected)` : ''),
     );
 
@@ -1686,6 +1696,8 @@ function restoreState(bytes, source) {
   df0Name = emu.disk_name(0) ?? null;
   lastFddTrack = null;
   updateStatusDisks();
+  // So did the machine itself, model and all.
+  syncMachineSelect();
   // Paint the restored screen now: a load into a paused machine steps no
   // frames, so nothing else would.
   presentFrame();
@@ -1915,6 +1927,124 @@ function setFloppySpeed(value) {
 }
 floppySpeedSel.addEventListener('change', () => {
   setFloppySpeed(Number(floppySpeedSel.value));
+});
+
+// --- machine model ---------------------------------------------------------
+// Which Amiga the boot button builds: the A500 the page has always booted,
+// or an AGA A1200. Always visible like the floppy speed select: a page
+// shell can host its own <select id="machine"> wherever its control bar
+// wants it (option values are model names; data-default presets one), and
+// without the element the control inserts itself below the canvas. The
+// option list comes from WebEmu.models() once the wasm module is ready,
+// which doubles as the feature test: an older wasm bundle has no models()
+// and the control hides rather than promising a switch it cannot make.
+// The config file's "machine" and ?machine= in the URL preset the choice.
+//
+// Changing the model while a machine runs rebuilds it: the model is the
+// board itself, not a knob on it. The chosen ROM (the boot stash) and the
+// page's copy of the inserted disk carry over, and the new machine powers
+// up - the browser version of picking another profile in the launcher.
+
+const MACHINE_LABELS = { A500: 'A500', A1200: 'A1200 (AGA)' };
+
+function buildMachineControl() {
+  const row = document.createElement('label');
+  row.style.cssText =
+    'display:inline-flex;align-items:center;gap:0.45rem;margin:0.4rem 0.6rem 0.4rem 0;' +
+    'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;' +
+    'color:rgba(255,255,255,0.75);';
+  row.appendChild(document.createTextNode('Machine'));
+  const sel = document.createElement('select');
+  sel.style.cssText =
+    'padding:0.15rem 0.4rem;border-radius:6px;cursor:pointer;' +
+    'border:1px solid rgba(255,255,255,0.35);' +
+    'background:rgba(10,13,22,0.6);color:rgba(255,255,255,0.85);' +
+    'font:inherit;';
+  row.appendChild(sel);
+  shell.insertAdjacentElement('afterend', row);
+  return sel;
+}
+const machineShellSel = $('machine');
+const machineSel = machineShellSel ?? buildMachineControl();
+// null = the wasm default machine (the A500); boot() passes it through.
+let machineModel = null;
+// A ?machine=/config/data-default choice that arrived before the model
+// list did; applied once both exist.
+let requestedMachine = null;
+
+// Model names compare like the core parses them: case-insensitive, with
+// separator characters ignored, so ?machine=a1200 matches "A1200".
+function matchModelOption(name) {
+  const norm = (s) => String(s).replace(/[-_ ]/g, '').toUpperCase();
+  return [...machineSel.options].map((o) => o.value).find((v) => v && norm(v) === norm(name));
+}
+
+function tryApplyRequestedMachine() {
+  if (requestedMachine === null || !machineSel.options.length) return;
+  const model = matchModelOption(requestedMachine);
+  if (model) {
+    machineModel = model;
+    machineSel.value = model;
+  } else {
+    console.warn(`unknown machine ${requestedMachine}; keeping ${machineSel.value}`);
+  }
+  requestedMachine = null;
+}
+
+// Called once the wasm module is ready (load()): fill the select from the
+// build's own list - unless the shell shipped its own options - and hide
+// the control on a bundle too old to take a model.
+function populateMachineSelect() {
+  let models = null;
+  try {
+    models = WebEmu.models?.();
+  } catch {
+    models = null;
+  }
+  if (!models?.length) {
+    (machineShellSel ?? machineSel.parentElement).hidden = true;
+    return;
+  }
+  if (!machineSel.options.length) {
+    for (const name of models) {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = MACHINE_LABELS[name] ?? name;
+      machineSel.appendChild(option);
+    }
+  }
+  // From here on every boot names its model explicitly, so the machine is
+  // properly labelled in save states and bug reports.
+  if (machineModel === null) machineModel = machineSel.value || null;
+  tryApplyRequestedMachine();
+}
+
+// A restored state carries its machine, model and all; point the select at
+// what is actually running. A shape no offered profile describes (a state
+// from a custom desktop config) leaves the select alone.
+function syncMachineSelect() {
+  const model = emu?.machine_model?.();
+  if (!model) return;
+  const match = matchModelOption(model);
+  if (match) {
+    machineModel = match;
+    machineSel.value = match;
+  }
+}
+
+machineSel.addEventListener('change', () => {
+  const model = machineSel.value;
+  if (!model || model === machineModel) return;
+  machineModel = model;
+  if (emu && running) {
+    // Carry the page's copy of the inserted disk into the new machine; a
+    // disk that only exists inside the old one (restored from a state)
+    // cannot come along.
+    if (df0Name && lastDisk?.name === df0Name) pendingDisk = lastDisk;
+    boot();
+  } else if (!emu) {
+    setLoadStatus(`machine: ${model} - applies at boot`);
+  }
 });
 
 // --- status bar --------------------------------------------------------
@@ -2205,7 +2335,9 @@ function bugReportHref() {
     host: navigator.userAgent,
     config: [
       'frontend = "copperline.dev/try (WebAssembly)"',
-      'machine = "A500, 512K chip RAM + 512K trapdoor"',
+      // The running machine's own description when there is one (it also
+      // tracks state loads); otherwise what the next boot would build.
+      `machine = ${toml(emu?.machine_summary?.() ?? machineModel ?? 'A500 (default)')}`,
       `kickstart = ${toml(bootRom?.label ?? 'none')}`,
       `df0 = ${toml(df0Name ?? 'empty')}`,
       `joystick = ${toml(joyMode)}`,
@@ -2325,10 +2457,11 @@ const pageParams = new URLSearchParams(location.search);
 // Optional copperline.json next to the page: a site sets its defaults in
 // one hand-editable file instead of touching the shell or this glue. All
 // keys are optional; a missing or invalid file is simply no defaults.
-// Link parameters (?df0=, ?kick=, ?joy=, ?fdspeed=) override the file,
-// and anything the visitor changes by hand wins as usual.
+// Link parameters (?df0=, ?kick=, ?machine=, ?joy=, ?fdspeed=) override
+// the file, and anything the visitor changes by hand wins as usual.
 //
 //   {
+//     "machine": "A1200",            machine model (WebEmu.models() lists them)
 //     "kick": "roms/kick31.rom",     same-origin path, like ?kick=
 //     "df0": "adf/demo.adf",         URL, like ?df0=
 //     "floppy_sounds": false,        preset the drive-sounds toggle
@@ -2379,6 +2512,18 @@ async function startup() {
   const linkedKick =
     pageParams.get('kick') ?? (typeof cfg.kick === 'string' ? cfg.kick : null);
   if (linkedKick) fetches.push(fitRomFromUrl(linkedKick));
+
+  // Starting machine model: the shell's data-default on the #machine
+  // select or the config file's "machine", overridden per link by
+  // ?machine=A1200 (names compare like the core parses them, so a1200
+  // works too). Applied once the wasm module has supplied the model list;
+  // whichever of the two arrives second completes it.
+  requestedMachine =
+    pageParams.get('machine') ??
+    (typeof cfg.machine === 'string' ? cfg.machine : null) ??
+    machineSel.dataset.default ??
+    null;
+  tryApplyRequestedMachine();
 
   // Starting joystick mode: the page shell's default (data-default on the
   // toggle or the config file), overridden per link by

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -10,6 +10,15 @@ locally, and how to embed the emulator in your own page.
 ## Using the hosted page
 
 [copperline.dev/try](https://copperline.dev/try/) boots a default A500. The
+**Machine** select below the screen switches to an AGA A1200 (68EC020,
+2 MiB chip RAM, like the desktop's `--model A1200`); both models boot the
+AROS ROM or a loaded Kickstart. Changing it before boot just changes what
+the boot button builds, and changing it while a machine runs rebuilds the
+machine and powers it up again -- the model is the board itself, not a
+knob on it -- keeping the chosen ROM and the inserted disk. A link can
+preset the model with `?machine=A1200`, and a
+[save state](#browser-save-states) carries its own machine, so loading
+one switches the select to whatever the state brings back. The
 page fetches the open-source AROS ROM while it loads, so the boot button
 works with no files of your own; the **Kickstart ROM** and **DF0 disk**
 pickers load local images instead. Both work before or after boot: a
@@ -259,6 +268,7 @@ import init, { WebEmu } from './pkg/copperline_web.js';
 
 const wasm = await init();
 const emu = new WebEmu();          // default A500 machine, placeholder ROM
+// ...or pick a machine model: new WebEmu('A1200')
 emu.load_rom(romBytes, extBytes);  // Kickstart or AROS bytes; cold reset
 emu.insert_floppy(0, adfBytes, 'game.adf');
 
@@ -275,6 +285,22 @@ function tick(nowMs) {
   requestAnimationFrame(tick);
 }
 ```
+
+The constructor's optional argument picks the machine profile by name,
+exactly as the desktop's `--model` flag does ("A500", "A1200", ...);
+omitted, it builds the default A500, so pages written against the
+model-less constructor keep booting what they always did. The static
+`WebEmu.models()` lists the vetted profiles a page can offer
+unconditionally (currently `A500` and `A1200` -- both boot AROS or a
+plain Kickstart with nothing but a floppy; other names the desktop flag
+takes are accepted too, but CDTV/CD32 want pieces a browser page cannot
+supply), and its absence on an older bundle is the feature test.
+`machine_model()` returns the running machine's profile name
+(`undefined` for a shape no profile describes, such as a state saved
+from a custom desktop config) and follows `load_state`, so a page can
+re-point its machine select at what a state brought back;
+`machine_summary()` is a one-line description of the machine -- profile,
+CPU, chipset, RAM, ROM fingerprint -- for bug reports and diagnostics.
 
 Input goes through `key_event(event.code, pressed)` (returns whether the key
 mapped, for `preventDefault`), `mouse_delta(dx, dy)` and
@@ -355,6 +381,16 @@ elements, and pages without them are untouched:
   boot, so a shell can default to mono by shipping the box checked.
   Without the element the output stays stereo unless the
   [configuration file](#browser-page-config) sets `mono_audio`.
+- `#machine` (a `<select>`): hosts the machine model control, letting the
+  page place and style it. Like `#floppy-speed` it is always on: without
+  the element a labelled select inserts itself below the canvas shell. The
+  glue fills an empty select from `WebEmu.models()` (a shell may also ship
+  its own options, whose values must be model names), a
+  `data-default="A1200"` attribute presets the choice, and the control
+  hides itself on a wasm bundle too old to take a model. Changing it
+  rebuilds a running machine as described above; `?machine=` in the URL
+  overrides the initial choice (model names match the way the core parses
+  them, so `?machine=a1200` works).
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
   `800`, and `0` for turbo): hosts the floppy drive speed control, letting
   the page place and style it. Unlike the other hooks this one is always
@@ -425,11 +461,12 @@ elements, and pages without them are untouched:
 A site can set its defaults in one hand-editable file instead of editing
 the shell: `copperline.json`, served next to the page. Every key is
 optional, a missing or invalid file means no defaults, link parameters
-(`?df0=`, `?kick=`, `?joy=`, `?fdspeed=`) override the file per URL, and
-anything the visitor changes by hand wins as usual:
+(`?df0=`, `?kick=`, `?machine=`, `?joy=`, `?fdspeed=`) override the file
+per URL, and anything the visitor changes by hand wins as usual:
 
 ```json
 {
+  "machine": "A1200",
   "kick": "roms/kick31.rom",
   "df0": "adf/demo.adf",
   "floppy_sounds": false,
@@ -442,9 +479,10 @@ anything the visitor changes by hand wins as usual:
 }
 ```
 
-`kick` follows the same-origin rule as `?kick=` (the file can only name
-a ROM the site already serves); `df0` is any URL the visitor's browser
-may fetch, like `?df0=`. `floppy_sounds`, `mono_audio`, and
+`machine` picks the machine model, like `?machine=`; `kick` follows the
+same-origin rule as `?kick=` (the file can only name a ROM the site
+already serves); `df0` is any URL the visitor's browser may fetch, like
+`?df0=`. `floppy_sounds`, `mono_audio`, and
 `floppy_speed` reach the machine whether or not the shell has their
 controls -- the speed select inserts itself, and a configured
 `floppy_sounds` or `mono_audio` is applied at boot even with no checkbox

--- a/src/config.rs
+++ b/src/config.rs
@@ -2882,7 +2882,11 @@ pub(crate) fn parse_log_unmapped(s: &str) -> Result<std::ops::RangeInclusive<u32
     Ok(start..=end)
 }
 
-pub(crate) fn parse_machine_model(s: &str) -> Result<MachineModel> {
+/// Parse a machine model name (`"A500"`, `"A1200"`, ...) as the `--model`
+/// flag and `[machine] profile` accept it: case-insensitive, with `_`/`-`/
+/// spaces ignored. Public for alternative frontends (the browser build) that
+/// take a model name from their own UI.
+pub fn parse_machine_model(s: &str) -> Result<MachineModel> {
     let norm = s.trim().to_ascii_uppercase().replace(['_', '-', ' '], "");
     match norm.as_str() {
         "A1000" => Ok(MachineModel::A1000),
@@ -2903,8 +2907,10 @@ pub(crate) fn parse_machine_model(s: &str) -> Result<MachineModel> {
 }
 
 /// The defaults a `[machine] profile` supplies before the explicit
-/// `[cpu]`/`[chipset]`/`[memory]` sections override them.
-pub(crate) fn machine_profile_defaults(model: MachineModel) -> Config {
+/// `[cpu]`/`[chipset]`/`[memory]` sections override them. Also the way an
+/// alternative frontend builds a stock machine of a given model without a
+/// config file, as the desktop launcher and the browser build do.
+pub fn machine_profile_defaults(model: MachineModel) -> Config {
     let mut d = Config {
         machine: Some(model),
         ..Config::default()

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -446,6 +446,14 @@ impl Emulator {
         self.refresh_rom_fingerprint();
     }
 
+    /// The shape descriptor of the running machine: stamped from the boot
+    /// `Config` by `build_machine` and adopted from the state on a
+    /// successful `load_state`, so it always describes the machine as it
+    /// stands.
+    pub fn machine_descriptor(&self) -> &crate::config::MachineDescriptor {
+        &self.descriptor
+    }
+
     /// Re-fingerprint the descriptor's ROM from the live in-memory images.
     /// Call whenever the shape descriptor is (re)set or the ROM is swapped.
     fn refresh_rom_fingerprint(&mut self) {


### PR DESCRIPTION
The browser build always booted the default A500. This adds machine-model selection to the wasm frontend, so the hosted /try page (and any embedding shell) can switch between the A500 and an AGA A1200.

## WebEmu API
- The constructor takes an optional model name: `new WebEmu('A1200')` builds the AGA machine (68EC020 @ 14 MHz, 2 MiB chip RAM, Gayle) through the same `parse_machine_model` / `machine_profile_defaults` pair the CLI and launcher use (both made `pub`). Omitted, it builds the A500 as before - existing shells are untouched.
- `WebEmu.models()` lists the vetted profiles a page can offer unconditionally (A500, A1200 - both boot AROS or a plain Kickstart with nothing but a floppy), and doubles as the feature test on older bundles.
- `machine_model()` / `machine_summary()` describe the running machine from the Emulator's shape descriptor (new `machine_descriptor()` getter), so they track ROM swaps and state loads.

## Page glue (try.js)
- A **Machine** select on the floppy-speed pattern: a shell can host `#machine` (with `data-default`), and without the element the control inserts itself below the canvas, filled from `WebEmu.models()`. It hides on a wasm bundle too old to take a model.
- `?machine=A1200` in the URL and the config file's `"machine"` key preset the choice; names match the way the core parses them, so `?machine=a1200` works.
- Switching while a machine runs rebuilds it (the model is the board, not a knob), keeping the chosen ROM and re-inserting the page's copy of the disk from a new `lastDisk` stash.
- Loading a save state re-points the select at the machine the state brought back (the descriptor is adopted from the state), and the bug-report link now carries the live machine summary instead of a hardcoded A500 line.

Docs updated in `docs/guide/browser.md` (hosted page, WebEmu API, page-shell hooks, configuration file). The published `try/index.html` shell needs no changes.

## Testing
- Verified end-to-end in Chrome against a locally staged site: AROS boots on the A1200 (AGA display, HDD LED appears because Gayle is fitted), live A1200/A500 switching carries DF0 across the rebuild, lowercase `?machine=` normalisation, and quick-save/quick-load flips the select to match the restored machine.
- `cargo test`, `cargo clippy`, `cargo fmt --check` clean on the core; the web crate checks clean for `wasm32-unknown-unknown`.