### PR TITLE
config: machine profiles derive their chip revisions and CPU defaults

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1955,6 +1955,9 @@ function buildMachineControl() {
     'color:rgba(255,255,255,0.75);';
   row.appendChild(document.createTextNode('Machine'));
   const sel = document.createElement('select');
+  // Carry the hook id even when self-built (like the self-inserted
+  // buttons), so page-side scripts can drive the control either way.
+  sel.id = 'machine';
   sel.style.cssText =
     'padding:0.15rem 0.4rem;border-radius:6px;cursor:pointer;' +
     'border:1px solid rgba(255,255,255,0.35);' +

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -383,7 +383,9 @@ elements, and pages without them are untouched:
   [configuration file](#browser-page-config) sets `mono_audio`.
 - `#machine` (a `<select>`): hosts the machine model control, letting the
   page place and style it. Like `#floppy-speed` it is always on: without
-  the element a labelled select inserts itself below the canvas shell. The
+  the element a labelled select inserts itself below the canvas shell
+  (carrying the same `machine` id, so page scripts can drive it either
+  way). The
   glue fills an empty select from `WebEmu.models()` (a shell may also ship
   its own options, whose values must be model names), a
   `data-default="A1200"` attribute presets the choice, and the control

--- a/src/config.rs
+++ b/src/config.rs
@@ -3029,6 +3029,32 @@ pub fn machine_profile_defaults(model: MachineModel) -> Config {
             d.port_devices[1] = PortDevice::Cd32Pad;
         }
     }
+    // Hardware that follows from the parts picked above, derived exactly as
+    // the raw-config pipeline derives it when the matching [chipset]/[cpu]
+    // keys are absent, so a profile built directly (the browser build, the
+    // launcher's fallback) is the same machine as a config file naming the
+    // profile. Skipping this is how the browser's first A1200 ended up an
+    // AGA machine with a 1 MiB-reach ECS Agnus: the chip window mirrors by
+    // Agnus reach, so the guest sized 1 MiB of its 2 MiB chip RAM.
+    // machine_profile_defaults_match_bare_profile_configs pins the parity.
+    d.agnus_revision = match model {
+        // The A500+/A600 boards have the 2 MB "Super Fat" 8375 soldered on,
+        // regardless of fitted chip RAM.
+        MachineModel::A500Plus | MachineModel::A600 => AgnusRevision::Ecs8375,
+        // The A500 Rev 6A keeps its pinned 8372A/OCS-Denise pairing (also
+        // the no-profile default machine's chips).
+        MachineModel::A500 => AgnusRevision::Ecs8372Rev4,
+        _ => default_agnus_revision(d.chipset, d.chip_ram_bytes),
+    };
+    d.denise_revision = match model {
+        MachineModel::A500 => DeniseRevision::Ocs,
+        _ => default_denise_revision(d.chipset),
+    };
+    // The FPU and on-chip caches are silicon: present whenever the CPU has
+    // them, exactly like the pipeline's [cpu] defaults.
+    d.fpu = d.cpu.default_fpu();
+    d.cpu_icache = d.cpu.has_instruction_cache();
+    d.cpu_dcache = d.cpu.has_data_cache();
     // An RTG card comes fitted wherever the machine can host one, so RTG
     // needs no config step beyond installing the guest driver. The Z3660 is
     // a Zorro III board, so the gate is the same one Zorro III RAM uses: a
@@ -4131,6 +4157,56 @@ mod tests {
             "#,
         )?;
         assert_eq!(cfg.video_standard, VideoStandard::Ntsc);
+        Ok(())
+    }
+
+    #[test]
+    fn machine_profile_defaults_match_bare_profile_configs() -> Result<()> {
+        // machine_profile_defaults is also consumed directly, outside the
+        // raw-config pipeline (the browser build, the launcher fallback), so
+        // the machine it returns must be the machine a config file naming
+        // just the profile produces -- including everything the pipeline
+        // derives for absent [chipset]/[cpu] keys. The browser's first
+        // A1200 shipped with this broken: an AGA machine carrying the
+        // default 1 MiB-reach ECS Agnus, whose chip-window mirroring made
+        // the guest size 1 MiB of the 2 MiB fitted chip RAM.
+        use MachineModel::*;
+        for model in [
+            A1000, A500, A500Ocs, A500Plus, A600, A1200, A3000, A4000, Cdtv, Cd32,
+        ] {
+            let direct = machine_profile_defaults(model);
+            let piped = parse_config(&format!("[machine]\nprofile = \"{model:?}\"\n"))?;
+            assert_eq!(piped.chipset, direct.chipset, "{model:?} chipset");
+            assert_eq!(
+                piped.agnus_revision, direct.agnus_revision,
+                "{model:?} agnus"
+            );
+            assert_eq!(
+                piped.denise_revision, direct.denise_revision,
+                "{model:?} denise"
+            );
+            assert_eq!(piped.cpu, direct.cpu, "{model:?} cpu");
+            assert_eq!(piped.fpu, direct.fpu, "{model:?} fpu");
+            assert_eq!(piped.cpu_icache, direct.cpu_icache, "{model:?} icache");
+            assert_eq!(piped.cpu_dcache, direct.cpu_dcache, "{model:?} dcache");
+            assert_eq!(
+                piped.chip_ram_bytes, direct.chip_ram_bytes,
+                "{model:?} chip RAM"
+            );
+            assert_eq!(
+                piped.slow_ram_bytes, direct.slow_ram_bytes,
+                "{model:?} slow RAM"
+            );
+            assert_eq!(piped.mb_ram_bytes, direct.mb_ram_bytes, "{model:?} mb RAM");
+            assert_eq!(piped.gate_array, direct.gate_array, "{model:?} gate array");
+            assert_eq!(
+                piped.mem_controller, direct.mem_controller,
+                "{model:?} mem controller"
+            );
+            assert_eq!(piped.rtc_present, direct.rtc_present, "{model:?} rtc");
+            assert_eq!(piped.rtc_chip, direct.rtc_chip, "{model:?} rtc chip");
+            assert_eq!(piped.rtg, direct.rtg, "{model:?} rtg");
+        }
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,9 @@ pub struct Config {
     pub cpu: CpuModel,
     pub fpu: bool,
     /// CPU clock in MHz. Defaults to the model's stock speed
-    /// ([`CpuModel::default_clock_mhz`]); overridable via `[cpu] clock_mhz`.
+    /// ([`CpuModel::default_clock_mhz`]), or the machine profile's pinned
+    /// clock (the A1200/CD32's authentic 14.18 MHz) when the profile names
+    /// one; overridable via `[cpu] clock_mhz`.
     pub cpu_clock_mhz: f64,
     /// Model the 68020/030 on-chip instruction cache (CACR-controlled).
     /// Defaults on for the parts that have one (68EC020/68020/68030), as on
@@ -2127,6 +2129,12 @@ impl TryFrom<RawConfig> for Config {
                 errors.push(anyhow!("[cpu] clock_mhz must be a positive number"));
                 cpu.default_clock_mhz()
             }
+            // With the whole [cpu] pair absent, the profile's clock stands:
+            // the A1200/CD32 profiles pin the authentic 14.18 MHz (4x the
+            // PAL colour clock), where the generic 020 default is 14.0. An
+            // explicit [cpu] model is a different part in the socket, so it
+            // takes its own stock speed instead.
+            None if raw.cpu.model.is_none() => defaults.cpu_clock_mhz,
             None => cpu.default_clock_mhz(),
         };
         if fpu && matches!(cpu, CpuModel::M68000 | CpuModel::M68010) {
@@ -4186,6 +4194,12 @@ mod tests {
                 "{model:?} denise"
             );
             assert_eq!(piped.cpu, direct.cpu, "{model:?} cpu");
+            assert!(
+                (piped.cpu_clock_mhz - direct.cpu_clock_mhz).abs() < 1e-9,
+                "{model:?} cpu clock: piped {} vs direct {}",
+                piped.cpu_clock_mhz,
+                direct.cpu_clock_mhz
+            );
             assert_eq!(piped.fpu, direct.fpu, "{model:?} fpu");
             assert_eq!(piped.cpu_icache, direct.cpu_icache, "{model:?} icache");
             assert_eq!(piped.cpu_dcache, direct.cpu_dcache, "{model:?} dcache");


### PR DESCRIPTION
Fixes the browser A1200 detecting only 1 MB of its 2 MB chip RAM (reported from the copperline.dev deployment, reproduced with Amiga Test Kit).

## Root cause

`machine_profile_defaults` only set what each profile arm named (chipset, RAM sizes, CPU, gate array). The Agnus/Denise revision derivation ("AGA selects Alice") and the `[cpu]`-implied defaults (FPU, on-chip caches) live in the raw-config pipeline, so they only applied to configs that went through TOML/CLI parsing. A profile built directly - which is exactly what the browser build's `new WebEmu('A1200')` does - kept `Config::default()`'s chips: an AGA machine still carrying the 1 MiB-reach ECS 8372A Agnus. The chip window mirrors by Agnus reach (#196 behavior), so the second megabyte of chip RAM aliased the first and the guest's boot-time memory sizing correctly found 1 MB. The desktop's `--model A1200` goes through the pipeline and was unaffected, which is why the difference only showed in the web deployment.

The same gap also left the 020's instruction cache unmodelled on a direct-built A1200 (a real performance/timing difference against the desktop) and would have left a direct-built A4000 without its on-die FPU.

## Fix

Derive all of it at the end of `machine_profile_defaults`, exactly as the pipeline derives it for absent `[chipset]`/`[cpu]` keys: the A500+/A600 keep their soldered 8375, the A500 keeps its pinned 8372A/OCS-Denise pairing, every other profile takes the preset-derived chips, and the FPU and caches follow the CPU silicon. A new regression test (`machine_profile_defaults_match_bare_profile_configs`) pins profile-by-profile parity between the direct constructor and a config file naming just the profile, for all ten models, so the two paths cannot drift again.

A small glue commit rides along: the self-inserted machine select now carries the `#machine` id (the self-inserted buttons already carry theirs), so page-side scripts can drive the control on any shell.

## Testing

- Amiga Test Kit on the browser A1200 (AROS ROM): before 'Chip 1.00 MB', after **'Chip 2.00 MB'** - verified end-to-end in Chrome with a locally staged site and the rebuilt wasm; the desktop A1200 shows 2.00 MB unchanged.
- `cargo test` (1747 lib tests + integration suites), `cargo clippy`, `cargo fmt --check` all clean; web crate checks clean for `wasm32-unknown-unknown`.

Note for deployment: this is Rust-side, so copperline.dev needs a rebuilt wasm; the JS glue change is cosmetic.