### PR TITLE
web: fullscreen keeps the display's aspect ratio on any page shell

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1011,10 +1011,15 @@ window.addEventListener('keyup', (e) => {
 // Esc releases the lock, as the browser enforces.
 
 let lastPos = null;
-// Emulator pixels per CSS pixel. The bitmap fills the canvas element in
-// every mode - fullscreen letterboxes the element itself, keeping the
-// display's shape - so the width ratio is the displayed scale.
-const cssToEmu = () => canvas.width / canvas.clientWidth;
+// Emulator pixels per CSS pixel, one scale per axis. The bitmap fills the
+// canvas element in every mode - fullscreen letterboxes the element
+// itself, keeping the display's shape - but the bitmap is not the
+// element's shape (the PAL capture is 668x540 shown as 4:3), so the two
+// axis ratios differ and sharing one would skew vertical pointer speed.
+const cssToEmu = () => ({
+  x: canvas.width / canvas.clientWidth,
+  y: canvas.height / canvas.clientHeight,
+});
 
 canvas.addEventListener('mousedown', (e) => {
   if (!emu || !running) return;
@@ -1033,11 +1038,11 @@ window.addEventListener('mousemove', (e) => {
   if (!emu || !running) return;
   const scale = cssToEmu();
   if (document.pointerLockElement === canvas) {
-    emu.mouse_delta(e.movementX * scale, e.movementY * scale);
+    emu.mouse_delta(e.movementX * scale.x, e.movementY * scale.y);
     lastPos = null;
   } else if (e.target === canvas) {
     if (lastPos) {
-      emu.mouse_delta((e.clientX - lastPos.x) * scale, (e.clientY - lastPos.y) * scale);
+      emu.mouse_delta((e.clientX - lastPos.x) * scale.x, (e.clientY - lastPos.y) * scale.y);
     }
     lastPos = { x: e.clientX, y: e.clientY };
   } else {
@@ -1135,7 +1140,7 @@ canvas.addEventListener(
         padTouch.moved += Math.abs(dx) + Math.abs(dy);
         padTouch.x = t.clientX;
         padTouch.y = t.clientY;
-        emu.mouse_delta(dx * scale, dy * scale);
+        emu.mouse_delta(dx * scale.x, dy * scale.y);
       }
     }
   },

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1011,13 +1011,10 @@ window.addEventListener('keyup', (e) => {
 // Esc releases the lock, as the browser enforces.
 
 let lastPos = null;
-// Emulator pixels per CSS pixel. Fullscreen letterboxes the canvas
-// (object-fit: contain), so there the displayed scale is the larger of the
-// two axis ratios; in the normal layout the bitmap fills the element.
-const cssToEmu = () =>
-  isFullscreen()
-    ? Math.max(canvas.width / canvas.clientWidth, canvas.height / canvas.clientHeight)
-    : canvas.width / canvas.clientWidth;
+// Emulator pixels per CSS pixel. The bitmap fills the canvas element in
+// every mode - fullscreen letterboxes the element itself, keeping the
+// display's shape - so the width ratio is the displayed scale.
+const cssToEmu = () => canvas.width / canvas.clientWidth;
 
 canvas.addEventListener('mousedown', (e) => {
   if (!emu || !running) return;
@@ -1416,7 +1413,29 @@ const CSS_FS_SHELL = {
   border: 'none',
   borderRadius: '0',
 };
-const CSS_FS_CANVAS = { width: '100%', height: '100%', objectFit: 'contain' };
+// Fullscreen letterbox. The shell takes the monitor's shape, which has
+// nothing to do with the display's, and a page shell's normal canvas rule
+// (width: 100%) would stretch the picture to fill it - grotesquely so on
+// an ultrawide monitor. The canvas instead becomes the largest 4:3 box
+// that fits, the TV shape every shell gives it in the page layout, and
+// the auto margins centre it. Inline styles rather than a page CSS rule
+// so every embedding shell letterboxes, not just the hosted page, and
+// applied to real fullscreen too. Dynamic viewport units: they measure
+// the monitor exactly in real fullscreen, and in the pinned fallback
+// (iPhone, where Safari's chrome stays) they track the visible area
+// where plain vh would reach under the browser chrome.
+const CSS_FS_CANVAS = {
+  position: 'absolute',
+  inset: '0',
+  margin: 'auto',
+  width: 'min(100dvw, calc(100dvh * 4 / 3))',
+  height: 'min(100dvh, calc(100dvw * 3 / 4))',
+  // The bitmap fills the box, as in the page layout: the presentation
+  // buffer is not itself 4:3 (the PAL capture is 668x540), and a shell's
+  // own :fullscreen object-fit rule would re-letterbox it inside the box
+  // at the buffer's ratio.
+  objectFit: 'fill',
+};
 
 function setStyles(el, styles, on) {
   for (const k of Object.keys(styles)) el.style[k] = on ? styles[k] : '';
@@ -1451,8 +1470,13 @@ $('fullscreen').addEventListener('click', () => {
   }
 });
 
-// Covers Esc and any other browser-initiated exit from real fullscreen.
-document.addEventListener('fullscreenchange', updateFsUi);
+// Real fullscreen carries the same canvas letterbox as the CSS fallback,
+// applied on the state change so it also covers Esc and any other
+// browser-initiated exit.
+document.addEventListener('fullscreenchange', () => {
+  setStyles(canvas, CSS_FS_CANVAS, document.fullscreenElement !== null);
+  updateFsUi();
+});
 
 $('vol').addEventListener('input', (e) => {
   if (emu) emu.set_volume_percent(Number(e.target.value));

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -104,6 +104,17 @@ Controls:
   touch mode the canvas is a pad instead: a floating eight-way stick on
   the left half and a fire button on the right.
 
+The **Fullscreen** button takes over the whole monitor, keeping the
+display's 4:3 shape: the picture becomes the largest 4:3 box that fits
+and is letterboxed against the monitor's own aspect ratio, so an
+ultrawide gets pillarbox bars instead of a stretched screen. The
+letterbox is applied by the page glue itself, not the page's stylesheet,
+so it holds on any shell that embeds the emulator. While fullscreen,
+small Joystick, Pause and Exit buttons sit in the top-right corner. On
+iPhones, where Safari has no element fullscreen, the button pins the
+shell over the page instead -- Safari's chrome stays, the page furniture
+goes, and the same letterbox applies.
+
 Once a machine boots, a status strip appears below the screen with the
 same front-panel readouts as the desktop [status bar](ui.md): the PWR and
 FDD LEDs (plus HDD/CD on machines fitted with those drives), the floppy


### PR DESCRIPTION
Fullscreen in the browser build stretched the picture to the monitor's aspect ratio on any page shell without its own `:fullscreen` CSS - very visibly on ultrawide monitors.

**Root cause.** In real element fullscreen `try.js` relied entirely on the host page's stylesheet to letterbox the canvas, and only the hosted /try shell carries a `:fullscreen` rule; any other embedding (the retro32 page, self-hosted shells) keeps its normal `width: 100%` canvas rule, which fills the monitor. The hosted rule was also subtly off: `object-fit: contain` letterboxes at the presentation buffer's own ratio (the PAL capture is 668x540, about 1.24:1), not the 4:3 TV shape every shell gives the canvas in the page layout.

**Fix**, all in the page glue so it holds on every embedding:

- `CSS_FS_CANVAS` now makes the canvas the largest 4:3 box that fits the screen, centred by auto margins, with `object-fit` pinned to `fill` so a shell's own `:fullscreen` rule cannot re-letterbox the bitmap inside the box. Dynamic viewport units (`dvw`/`dvh`) measure the monitor exactly in real fullscreen and track the visible area in the pinned iPhone fallback, where plain `vh` reaches under Safari's chrome.
- The styles are applied on `fullscreenchange` for real fullscreen (previously only the CSS fallback got them) and removed on any exit, Esc included.
- `cssToEmu()` loses its fullscreen special case: the bitmap fills the canvas element in every mode now, so the width ratio is the displayed scale.
- `docs/guide/browser.md` documents the fullscreen behaviour, which had no doc coverage.

**Verified** by serving the real page shell with the modified glue and driving Chrome: in fullscreen the canvas measures exactly 4:3 (ratio 1.3333), centred with equal pillarbox bars on a 1.75:1 viewport, and exiting restores the page layout with all inline styles cleared. Chrome denies `requestFullscreen` to automation input, so the scripted run exercised the pinned-shell fallback path; it applies the identical style object through the same fullscreenchange listener, but the real-fullscreen entry itself still wants a one-click manual check on a wide monitor.

Follow-up for the website repository (not part of this PR): the `.try-shell:fullscreen #screen` rule in `try/index.html` is now redundant - the inline styles override it - and can be dropped.
