### PR TITLE
web: suppress the browser default on held-key auto-repeats

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -996,13 +996,26 @@ function updatePadStatus(releasedPort1) {
 
 // --- keyboard ------------------------------------------------------------
 
+// Auto-repeat keydowns must not reach the emulator (the Amiga keyboard
+// sends one down code; the guest OS does its own repeat), but the browser
+// default still has to be suppressed on every repeat or holding a cursor
+// key scrolls the page. Track which codes the first keydown consumed.
+const consumedKeys = new Set();
 window.addEventListener('keydown', (e) => {
-  if (!emu || !running || e.repeat) return;
-  if (joystickKey(e.code, true) || emu.key_event(e.code, true)) e.preventDefault();
+  if (!emu || !running) return;
+  if (e.repeat) {
+    if (consumedKeys.has(e.code)) e.preventDefault();
+    return;
+  }
+  if (joystickKey(e.code, true) || emu.key_event(e.code, true)) {
+    consumedKeys.add(e.code);
+    e.preventDefault();
+  }
 });
 window.addEventListener('keyup', (e) => {
   if (!emu || !running) return;
-  if (joystickKey(e.code, false) || emu.key_event(e.code, false)) e.preventDefault();
+  const consumed = joystickKey(e.code, false) || emu.key_event(e.code, false);
+  if (consumedKeys.delete(e.code) || consumed) e.preventDefault();
 });
 
 // --- mouse ---------------------------------------------------------------

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1010,12 +1010,18 @@ window.addEventListener('keydown', (e) => {
   if (joystickKey(e.code, true) || emu.key_event(e.code, true)) {
     consumedKeys.add(e.code);
     e.preventDefault();
+  } else {
+    consumedKeys.delete(e.code);
   }
 });
 window.addEventListener('keyup', (e) => {
+  // Delete before the running check: a hold that spans an emulator stop
+  // or a focus loss must not leave a stale entry behind.
+  const consumed = consumedKeys.delete(e.code);
   if (!emu || !running) return;
-  const consumed = joystickKey(e.code, false) || emu.key_event(e.code, false);
-  if (consumedKeys.delete(e.code) || consumed) e.preventDefault();
+  if (joystickKey(e.code, false) || emu.key_event(e.code, false) || consumed) {
+    e.preventDefault();
+  }
 });
 
 // --- mouse ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Holding a cursor key in a browser session scrolled the page under the game. The `keydown` handler in `try.js` returned early on `e.repeat` before reaching `preventDefault()`, so only the initial press of a captured key was consumed - every auto-repeat keydown fell through to the browser, whose default action for ArrowUp/ArrowDown (and Space/PageUp/PageDown) is scrolling.

Skipping repeats remains correct for the emulator side: the Amiga keyboard sends one down code per press and the guest OS performs its own key repeat, so repeats must not be re-forwarded to the keyboard MCU or the joystick mapping. The fix tracks which codes the initial keydown consumed (Amiga-mapped key or joystick control) in a set and calls `preventDefault()` on their repeats without forwarding them. `keyup` clears the entry, which also keeps the set from going stale when a hold spans a focus loss.

## Testing

- `node --check` on `try.js`
- Manual: hold ArrowUp/ArrowDown in a scrollable page shell while a game is running, in both keyboard mode and the `keys` joystick mode - the page no longer scrolls and the guest still sees a single key-down per press.