### PR TITLE
Fix MC68020 and A1200 chip-bus timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ against real hardware.
   real speed.
 - **Configurable CPU** (68000 / 68010 / 68EC020 / 68020 / 68030 / 68040 / 68060) and clock,
   with an optional 68881/68882 FPU (default-on for the 68040/68060) and the
-  68030/68040 MMUs.
+  68030/68040 MMUs. The 68020 integer timing model selects the cache or
+  uncached execution totals from the MC68020 User's Manual per instruction.
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
   (ADF / ADZ / ZIP / DMS, read-only SCP), Gayle and A4000 IDE, SCSI (A2091,
@@ -318,7 +319,7 @@ release needs resolved first. Release steps for every channel are in
 
 | Subsystem | Notes |
 | --- | --- |
-| M68K CPU | Via a vendored pure-Rust m68k crate; model selectable through 68060, accurate 68000 cycle counts, 020+ caches, 6888x FPU, 68030/68040 MMUs. |
+| M68K CPU | Via a vendored pure-Rust m68k crate; model selectable through 68060, accurate 68000 cycle counts, datasheet-based 68020 integer timing, 020+ caches, 6888x FPU, 68030/68040 MMUs. |
 | Chip RAM | mem_map'd; reset starts with ROM overlaid at $0 until CIA-A releases /OVL. |
 | Fast RAM | Optional Zorro II autoconfig RAM at $00200000 and Zorro III autoconfig RAM (`[memory] z3`); runs at the CPU clock. |
 | Slow RAM | Optional A500 trapdoor/fake-fast RAM at $00C00000; arbitrated on the chip bus through Agnus like chip RAM. |

--- a/crates/m68k/src/core/cpu.rs
+++ b/crates/m68k/src/core/cpu.rs
@@ -167,6 +167,10 @@ pub struct CpuCore {
     pub run_mode: u32,
     /// True while processing an exception (for double-fault detection)
     pub exception_processing: bool,
+    /// Vector taken by the instruction currently being timed. Unlike the
+    /// debugger field below, this is cleared before every opcode fetch.
+    #[serde(skip)]
+    pub(crate) instruction_exception_vector: Option<u32>,
     /// Vector number of the most recent exception entry (trap, fault, or
     /// interrupt -- everything routed through `jump_vector`), for the
     /// host debugger's exception catchpoints. Polled and cleared by the
@@ -388,18 +392,10 @@ impl Default for CpuCore {
 }
 
 impl CpuCore {
-    /// Approximate 68020/030/040 instruction timing from the 68000 cycle
-    /// counts the instruction handlers produce: the 020's three-stage
-    /// pipeline and instruction cache make most instructions cost roughly
-    /// half their 68000 cycles (memory-bound work is additionally dominated
-    /// by the host bus model), with a two-cycle floor. Calibrated against a
-    /// cycle-exact A1200 reference (FS-UAE) using the Copperline
-    /// timing-test ADF: 68000 MULU.W #imm with 8 set bits = 54 cycles
-    /// scales to the measured 27, and the chip-RAM dbra loop lands on the
-    /// measured 8 clocks per iteration. The 68000/68010 paths (validated
-    /// against SingleStepTests) are untouched; see the "68020+ timing"
-    /// section of docs/internals/cpu.md for why no per-instruction 020
-    /// reference exists.
+    /// Legacy 68030/040 approximation from the handlers' corrected 68000
+    /// counts. The 68020/68EC020 is routed through its MC68020UM section-8
+    /// timing model before this function; the 68060 has a separate pipeline
+    /// engine. The 68000/68010 paths remain untouched.
     #[inline]
     pub(crate) fn scale_cycles_for_cpu_type(&self, cycles: i32) -> i32 {
         use crate::core::types::CpuType;
@@ -459,6 +455,7 @@ impl CpuCore {
             instr_mode: 0,
             run_mode: 0,
             exception_processing: false,
+            instruction_exception_vector: None,
             last_exception_vector: None,
             has_pmmu: false,
             pmmu_enabled: false,

--- a/crates/m68k/src/core/execute.rs
+++ b/crates/m68k/src/core/execute.rs
@@ -55,6 +55,8 @@ impl CpuCore {
 
         // Main execution loop
         while self.cycles_remaining > 0 {
+            self.instruction_exception_vector = None;
+            bus.begin_instruction_fetches();
             // Save previous PC
             self.ppc = self.pc;
 
@@ -79,8 +81,16 @@ impl CpuCore {
 
             // Dispatch instruction (sampling whether the opcode fetch
             // hit the icache before dispatch consumes more of the stream).
-            let fetch_cached = bus.last_fetch_was_cached();
+            let opcode_fetch_cached = bus.last_fetch_was_cached();
             let result = dispatch_instruction(self, bus, self.ir as u16);
+            let fetch_cached = if matches!(
+                self.cpu_type,
+                super::types::CpuType::M68EC020 | super::types::CpuType::M68020
+            ) {
+                bus.instruction_fetches_were_cached()
+            } else {
+                opcode_fetch_cached
+            };
 
             // Auto-take all trap exceptions, extract cycles
             use crate::core::types::InternalStepResult;
@@ -153,6 +163,8 @@ impl CpuCore {
             return StepResult::Stopped;
         }
 
+        self.instruction_exception_vector = None;
+        bus.begin_instruction_fetches();
         self.ppc = self.pc;
         self.dar_save = self.dar;
         self.sr_save = self.get_sr();
@@ -163,8 +175,16 @@ impl CpuCore {
             return StepResult::Ok { cycles: 0 };
         }
 
-        let fetch_cached = bus.last_fetch_was_cached();
+        let opcode_fetch_cached = bus.last_fetch_was_cached();
         let result = dispatch_instruction(self, bus, self.ir as u16);
+        let fetch_cached = if matches!(
+            self.cpu_type,
+            super::types::CpuType::M68EC020 | super::types::CpuType::M68020
+        ) {
+            bus.instruction_fetches_were_cached()
+        } else {
+            opcode_fetch_cached
+        };
 
         let res = match result {
             InternalStepResult::Ok { cycles } => StepResult::Ok {
@@ -249,6 +269,8 @@ impl CpuCore {
             return StepResult::Stopped;
         }
 
+        self.instruction_exception_vector = None;
+        bus.begin_instruction_fetches();
         self.ppc = self.pc;
         self.dar_save = self.dar;
         self.sr_save = self.get_sr();
@@ -259,8 +281,16 @@ impl CpuCore {
             return StepResult::Ok { cycles: 0 };
         }
 
-        let fetch_cached = bus.last_fetch_was_cached();
+        let opcode_fetch_cached = bus.last_fetch_was_cached();
         let result = dispatch_instruction(self, bus, self.ir as u16);
+        let fetch_cached = if matches!(
+            self.cpu_type,
+            super::types::CpuType::M68EC020 | super::types::CpuType::M68020
+        ) {
+            bus.instruction_fetches_were_cached()
+        } else {
+            opcode_fetch_cached
+        };
 
         // Handle trap results via callbacks, fallback to exception if not handled
         let cycles = match result {
@@ -385,6 +415,7 @@ impl CpuCore {
         // restores normal instruction fetching.
         self.loop_mode = false;
         self.last_exception_vector = Some(vector);
+        self.instruction_exception_vector = Some(vector);
         let addr = (vector << 2).wrapping_add(self.vbr);
         self.pc = self.read_32(bus, addr);
         // Exception entry refills the prefetch queue from the handler

--- a/crates/m68k/src/core/memory.rs
+++ b/crates/m68k/src/core/memory.rs
@@ -90,6 +90,20 @@ pub trait AddressBus {
         true
     }
 
+    /// Start tracking cache residency for one complete instruction. The
+    /// MC68020 timing tables define their cache case for an instruction that
+    /// is in the cache, including extension and immediate words rather than
+    /// only the opcode word. Hosts with an instruction-cache model use this
+    /// hook to reset their per-instruction hit accumulator.
+    fn begin_instruction_fetches(&mut self) {}
+
+    /// Whether every instruction-stream access since
+    /// `begin_instruction_fetches` hit the instruction cache. Functional test
+    /// buses without a cache model default to the most recent fetch result.
+    fn instruction_fetches_were_cached(&self) -> bool {
+        self.last_fetch_was_cached()
+    }
+
     fn interrupt_acknowledge(&mut self, _level: u8) -> u32 {
         0xFFFF_FFFF
     }

--- a/crates/m68k/src/core/mod.rs
+++ b/crates/m68k/src/core/mod.rs
@@ -14,5 +14,6 @@ pub mod memory;
 pub mod registers;
 pub mod status;
 pub mod timing;
+pub mod timing_020;
 pub mod timing_060;
 pub mod types;

--- a/crates/m68k/src/core/timing_020.rs
+++ b/crates/m68k/src/core/timing_020.rs
@@ -1,0 +1,834 @@
+//! MC68020 integer instruction timing.
+//!
+//! The MC68020 User's Manual section 8.2 publishes three timing columns:
+//! best case (instruction overlap), cache case (cached instruction stream
+//! without overlap), and worst case (uncached stream without overlap).
+//! Copperline does not yet model the 020 execution-stage overlap, so an
+//! instruction selects Cache Case only when all of its opcode, extension,
+//! and immediate words hit the instruction cache; any miss selects Worst
+//! Case.
+//!
+//! The published totals include zero-wait, aligned transfers on a 32-bit
+//! bus. Copperline bills the real target bus while the instruction executes;
+//! the host advances only the part of this total not already consumed by
+//! those accesses. Consequently chip-RAM arbitration and narrower buses can
+//! extend a table time, but a table entry never hides a real wait.
+//!
+//! Full-format indexed extension words cannot be distinguished from the
+//! brief form after the instruction has retired. Indexed entries therefore
+//! use the manual's brief-form row; the host still bills every extension and
+//! indirect operand access that actually occurred.
+
+use super::cpu::CpuCore;
+use super::types::Size;
+
+#[derive(Clone, Copy)]
+struct Case {
+    cache: i32,
+    worst: i32,
+}
+
+impl Case {
+    const fn new(cache: i32, worst: i32) -> Self {
+        Self { cache, worst }
+    }
+
+    #[inline]
+    const fn pick(self, cached: bool) -> i32 {
+        if cached { self.cache } else { self.worst }
+    }
+}
+
+#[inline]
+const fn size_00(bits: u16) -> Size {
+    match bits {
+        0 => Size::Byte,
+        1 => Size::Word,
+        _ => Size::Long,
+    }
+}
+
+/// Table 8-1, "Fetch Effective Address Timing".
+const fn fetch_ea(mode: u16, reg: u16, size: Size) -> Case {
+    match (mode, reg) {
+        (0 | 1, _) => Case::new(0, 0),
+        (2 | 3, _) => Case::new(4, 4),
+        (4, _) => Case::new(5, 5),
+        (5, _) | (7, 2) => Case::new(5, 6),
+        (6, _) | (7, 3) => Case::new(7, 8),
+        (7, 0) => Case::new(4, 6),
+        (7, 1) => Case::new(4, 7),
+        (7, 4) if matches!(size, Size::Long) => Case::new(4, 5),
+        (7, 4) => Case::new(2, 3),
+        _ => Case::new(0, 0),
+    }
+}
+
+/// Table 8-1, "Fetch Immediate Effective Address Timing".
+const fn fetch_immediate_ea(mode: u16, reg: u16, size: Size) -> Case {
+    let long = matches!(size, Size::Long);
+    match (mode, reg, long) {
+        (0 | 1, _, false) => Case::new(2, 3),
+        (0 | 1, _, true) => Case::new(4, 5),
+        (2, _, false) => Case::new(4, 4),
+        (2, _, true) => Case::new(4, 7),
+        (3, _, false) => Case::new(6, 7),
+        (3, _, true) => Case::new(8, 9),
+        (4, _, false) => Case::new(5, 6),
+        (4, _, true) => Case::new(7, 8),
+        (5, _, false) | (7, 0, false) => Case::new(5, 7),
+        (5, _, true) | (7, 0, true) => Case::new(7, 10),
+        (6, _, false) | (7, 3, false) => Case::new(9, 11),
+        (6, _, true) | (7, 3, true) => Case::new(11, 13),
+        (7, 1, false) => Case::new(6, 10),
+        (7, 1, true) => Case::new(8, 12),
+        _ => Case::new(0, 0),
+    }
+}
+
+/// Table 8-1, "Calculate Effective Address Timing".
+const fn calculate_ea(mode: u16, reg: u16) -> Case {
+    match (mode, reg) {
+        (0 | 1, _) => Case::new(0, 0),
+        (2..=4, _) => Case::new(2, 2),
+        (5, _) | (7, 0 | 2) => Case::new(2, 3),
+        (6, _) | (7, 3) => Case::new(4, 5),
+        (7, 1) => Case::new(4, 5),
+        _ => Case::new(0, 0),
+    }
+}
+
+/// Table 8-1, "Jump Effective Address Timing".
+const fn jump_ea(mode: u16, reg: u16) -> Case {
+    match (mode, reg) {
+        (2, _) => Case::new(2, 2),
+        (5, _) | (7, 2) => Case::new(4, 4),
+        (6, _) | (7, 3) => Case::new(6, 6),
+        (7, 0 | 1) => Case::new(2, 2),
+        _ => Case::new(0, 0),
+    }
+}
+
+/// Table 8-1, "Calculate Immediate Effective Address Timing".
+const fn calculate_immediate_ea(mode: u16, reg: u16, size: Size) -> Case {
+    let long = matches!(size, Size::Long);
+    match (mode, reg, long) {
+        (0 | 1, _, false) => Case::new(2, 3),
+        (0 | 1, _, true) => Case::new(4, 5),
+        (2, _, false) => Case::new(2, 3),
+        (2, _, true) => Case::new(4, 5),
+        (3 | 4, _, false) => Case::new(4, 5),
+        (3 | 4, _, true) => Case::new(6, 7),
+        (5, _, false) | (7, 0, false) => Case::new(4, 5),
+        (5, _, true) | (7, 0, true) => Case::new(6, 8),
+        (6, _, false) | (7, 3, false) => Case::new(6, 8),
+        (6, _, true) | (7, 3, true) => Case::new(8, 10),
+        (7, 1, false) => Case::new(4, 6),
+        (7, 1, true) => Case::new(8, 10),
+        _ => Case::new(0, 0),
+    }
+}
+
+#[inline]
+fn add(base: Case, ea: Case) -> Case {
+    Case::new(base.cache + ea.cache, base.worst + ea.worst)
+}
+
+#[inline]
+const fn move_source_row(mode: u16, reg: u16, size: Size) -> usize {
+    match (mode, reg) {
+        (0 | 1, _) => 0,
+        (2, _) => 3,
+        (3, _) => 4,
+        (4, _) => 5,
+        (5, _) | (7, 2) => 6,
+        (7, 0) => 7,
+        (7, 1) => 8,
+        (6, _) | (7, 3) => 9,
+        (7, 4) if matches!(size, Size::Long) => 2,
+        (7, 4) => 1,
+        _ => 0,
+    }
+}
+
+#[inline]
+const fn move_destination_col(mode: u16, reg: u16) -> usize {
+    match (mode, reg) {
+        (0 | 1, _) => 0,
+        (2, _) => 1,
+        (3, _) => 2,
+        (4, _) => 3,
+        (5, _) => 4,
+        (7, 0) => 5,
+        (7, 1) => 6,
+        (6, _) => 7,
+        _ => 0,
+    }
+}
+
+/// Tables 8-4 through 8-9, restricted to standard opcode-visible EAs.
+const MOVE_CACHE: [[i32; 8]; 10] = [
+    [2, 4, 4, 5, 5, 4, 6, 7],
+    [4, 6, 6, 7, 7, 6, 8, 7],
+    [6, 8, 8, 9, 9, 8, 10, 9],
+    [6, 7, 7, 7, 7, 7, 9, 9],
+    [6, 7, 7, 7, 7, 7, 9, 9],
+    [7, 8, 8, 8, 8, 8, 10, 10],
+    [7, 8, 8, 8, 8, 8, 10, 10],
+    [6, 7, 7, 7, 7, 7, 9, 9],
+    [6, 7, 7, 7, 7, 7, 9, 9],
+    [9, 10, 10, 10, 10, 10, 12, 12],
+];
+
+const MOVE_WORST: [[i32; 8]; 10] = [
+    [3, 5, 5, 6, 7, 7, 9, 9],
+    [3, 5, 8, 6, 7, 7, 9, 9],
+    [5, 7, 7, 8, 9, 9, 11, 11],
+    [7, 9, 9, 9, 11, 11, 13, 11],
+    [7, 9, 9, 9, 11, 11, 13, 11],
+    [8, 10, 10, 10, 12, 12, 14, 12],
+    [9, 11, 11, 11, 13, 13, 15, 13],
+    [8, 10, 10, 10, 12, 12, 14, 12],
+    [10, 12, 12, 12, 14, 14, 16, 14],
+    [11, 13, 13, 13, 15, 15, 17, 15],
+];
+
+fn move_cycles(op: u16, size: Size, cached: bool) -> i32 {
+    let src_mode = (op >> 3) & 7;
+    let src_reg = op & 7;
+    let dst_mode = (op >> 6) & 7;
+    let dst_reg = (op >> 9) & 7;
+    let row = move_source_row(src_mode, src_reg, size);
+    let col = move_destination_col(dst_mode, dst_reg);
+    if cached {
+        MOVE_CACHE[row][col]
+    } else {
+        MOVE_WORST[row][col]
+    }
+}
+
+#[inline]
+fn legacy_fallback(raw: i32) -> i32 {
+    ((raw * 5 + 7) / 8).max(2)
+}
+
+fn exception_cycles(cpu: &CpuCore, raw: i32, cached: bool) -> Option<i32> {
+    let vector = cpu.instruction_exception_vector?;
+    let op = cpu.ir as u16;
+    let cycles = match vector {
+        // Table 8-17: these share the same format-$0 entry cost.
+        4 | 8 | 10 | 11 => Case::new(20, 27).pick(cached),
+        // Group-2 TRAPV/TRAPcc uses a six-word format-$2 frame.
+        7 if op == 0x4E76 => Case::new(25, 32).pick(cached),
+        7 if op >> 12 == 5 => {
+            let submode = op & 7;
+            match submode {
+                2 | 3 => Case::new(25, 33).pick(cached),
+                _ => Case::new(25, 32).pick(cached),
+            }
+        }
+        // CHK and divide-by-zero timing is not specified as a complete trap
+        // path in section 8.2; retain the prior conservative calibration.
+        _ => legacy_fallback(raw),
+    };
+    Some(cycles)
+}
+
+fn group_0(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+
+    // CAS2.W/L.
+    if op == 0x0CFC || op == 0x0EFC {
+        let base = if cpu.flag_z() {
+            Case::new(25, 28)
+        } else {
+            Case::new(22, 25)
+        };
+        return Some(base.pick(cached));
+    }
+
+    // CAS.B/W/L.
+    if matches!(op & 0x0FC0, 0x0AC0 | 0x0CC0 | 0x0EC0) {
+        let base = if cpu.flag_z() {
+            Case::new(15, 16)
+        } else {
+            Case::new(12, 13)
+        };
+        return Some(add(base, calculate_immediate_ea(mode, reg, Size::Word)).pick(cached));
+    }
+
+    // MOVES: the direction bit is in the consumed extension word. Use the
+    // slower EA->Rn base; both directions still use the exact EA component.
+    if op & 0xFF00 == 0x0E00 {
+        return Some(
+            add(
+                Case::new(7, 8),
+                calculate_immediate_ea(mode, reg, Size::Word),
+            )
+            .pick(cached),
+        );
+    }
+
+    // CALLM/RTM are 68020-only and encode information not retained after
+    // retirement. Use the slower documented type-1 paths.
+    if op & 0xFFF0 == 0x06C0 {
+        return Some(Case::new(32, 35).pick(cached));
+    }
+    if op & 0xFFC0 == 0x06C0 {
+        return Some(
+            add(Case::new(57, 64), fetch_immediate_ea(mode, reg, Size::Word)).pick(cached),
+        );
+    }
+
+    // CMP2/CHK2. Both have the same section-8.2 base time.
+    if op & 0x0800 == 0 && op & 0x0100 == 0 && op & 0x00C0 == 0x00C0 && (op >> 9) & 3 != 3 {
+        return Some(
+            add(Case::new(18, 18), fetch_immediate_ea(mode, reg, Size::Word)).pick(cached),
+        );
+    }
+
+    // MOVEP.
+    if op & 0xF138 == 0x0108 {
+        let long = op & 0x0040 != 0;
+        let reg_to_mem = op & 0x0080 != 0;
+        let case = match (long, reg_to_mem) {
+            (false, true) => Case::new(11, 11),
+            (true, true) => Case::new(17, 17),
+            (false, false) => Case::new(12, 12),
+            (true, false) => Case::new(18, 18),
+        };
+        return Some(case.pick(cached));
+    }
+
+    let dynamic_bit = op & 0x0100 != 0;
+    let static_bit = op & 0x0F00 == 0x0800;
+    if dynamic_bit || static_bit {
+        if mode == 0 {
+            return Some(Case::new(4, 5).pick(cached));
+        }
+        let ea = if static_bit {
+            fetch_immediate_ea(mode, reg, Size::Word)
+        } else {
+            fetch_ea(mode, reg, Size::Byte)
+        };
+        return Some(add(Case::new(4, 5), ea).pick(cached));
+    }
+
+    // ORI/ANDI/EORI to CCR/SR.
+    if matches!(op, 0x003C | 0x007C | 0x023C | 0x027C | 0x0A3C | 0x0A7C) {
+        return Some(Case::new(12, 15).pick(cached));
+    }
+
+    // Immediate arithmetic/logical instructions.
+    let subop = (op >> 8) & 0xF;
+    if matches!(subop, 0x0 | 0x2 | 0x4 | 0x6 | 0xA | 0xC) {
+        let size = size_00((op >> 6) & 3);
+        let base = if mode == 0 || subop == 0xC {
+            Case::new(2, 3)
+        } else {
+            Case::new(4, 6)
+        };
+        return Some(add(base, fetch_immediate_ea(mode, reg, size)).pick(cached));
+    }
+
+    None
+}
+
+fn group_4(op: u16, raw: i32, cached: bool) -> Option<i32> {
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+
+    if op & 0xFFC0 == 0x4C00 {
+        return Some(
+            add(Case::new(43, 44), fetch_immediate_ea(mode, reg, Size::Word)).pick(cached),
+        );
+    }
+    if op & 0xFFC0 == 0x4C40 {
+        // Signedness lives in the consumed extension word; DIVS.L is the
+        // conservative choice and differs from DIVU.L by twelve clocks.
+        return Some(
+            add(Case::new(90, 91), fetch_immediate_ea(mode, reg, Size::Word)).pick(cached),
+        );
+    }
+
+    // MOVE from SR/CCR.
+    if matches!(op & 0xFFC0, 0x40C0 | 0x42C0) {
+        let case = if mode == 0 {
+            Case::new(4, 5)
+        } else {
+            add(Case::new(5, 7), calculate_ea(mode, reg))
+        };
+        return Some(case.pick(cached));
+    }
+    // MOVE to CCR/SR.
+    if matches!(op & 0xFFC0, 0x44C0 | 0x46C0) {
+        let base = if op & 0x0200 == 0 {
+            Case::new(4, 5)
+        } else {
+            Case::new(8, 11)
+        };
+        return Some(add(base, fetch_ea(mode, reg, Size::Word)).pick(cached));
+    }
+
+    // MOVEM (long multiply/divide was decoded above).
+    if op & 0xFB80 == 0x4880 && mode != 0 {
+        let long = op & 0x0040 != 0;
+        let to_register = op & 0x0400 != 0;
+        let transfer_cost = if long { 8 } else { 4 };
+        let count = if to_register {
+            raw.saturating_sub(12) / transfer_cost
+        } else {
+            raw.saturating_sub(8) / transfer_cost
+        };
+        let base = if to_register {
+            Case::new(8 + 4 * count, 9 + 4 * count)
+        } else {
+            Case::new(4 + 3 * count, 5 + 3 * count)
+        };
+        return Some(add(base, calculate_immediate_ea(mode, reg, Size::Word)).pick(cached));
+    }
+
+    // LEA / CHK.
+    if op & 0xF1C0 == 0x41C0 {
+        return Some(add(Case::new(2, 3), calculate_ea(mode, reg)).pick(cached));
+    }
+    let chk_opmode = (op >> 6) & 7;
+    if matches!(chk_opmode, 0b100 | 0b110) {
+        let size = if chk_opmode == 0b100 {
+            Size::Long
+        } else {
+            Size::Word
+        };
+        return Some(add(Case::new(8, 8), fetch_ea(mode, reg, size)).pick(cached));
+    }
+
+    // JSR / JMP.
+    if op & 0xFFC0 == 0x4E80 {
+        return Some(add(Case::new(5, 11), jump_ea(mode, reg)).pick(cached));
+    }
+    if op & 0xFFC0 == 0x4EC0 {
+        return Some(add(Case::new(4, 7), jump_ea(mode, reg)).pick(cached));
+    }
+
+    // LINK.L / LINK.W / UNLK.
+    if op & 0xFFF8 == 0x4808 {
+        return Some(Case::new(6, 10).pick(cached));
+    }
+    if op & 0xFFF8 == 0x4E50 {
+        return Some(Case::new(5, 7).pick(cached));
+    }
+    if op & 0xFFF8 == 0x4E58 {
+        return Some(Case::new(6, 7).pick(cached));
+    }
+
+    // MOVE USP and MOVEC.
+    if op & 0xFFF0 == 0x4E60 {
+        return Some(Case::new(2, 3).pick(cached));
+    }
+    if op == 0x4E7A {
+        return Some(Case::new(6, 7).pick(cached));
+    }
+    if op == 0x4E7B {
+        return Some(Case::new(12, 13).pick(cached));
+    }
+
+    match op {
+        0x4E70 => return Some(Case::new(518, 519).pick(cached)),
+        0x4E71 => return Some(Case::new(2, 3).pick(cached)),
+        0x4E72 => return Some(Case::new(8, 8).pick(cached)),
+        0x4E73 => {
+            let case = match raw {
+                15 => Case::new(16, 39),
+                31 => Case::new(32, 33),
+                42 => Case::new(43, 45),
+                91 => Case::new(92, 94),
+                _ => Case::new(21, 24),
+            };
+            return Some(case.pick(cached));
+        }
+        0x4E74 => return Some(Case::new(10, 12).pick(cached)),
+        0x4E75 => return Some(Case::new(10, 12).pick(cached)),
+        0x4E76 => return Some(Case::new(4, 5).pick(cached)),
+        0x4E77 => return Some(Case::new(14, 15).pick(cached)),
+        _ => {}
+    }
+
+    // PEA (after SWAP's register-direct overlap).
+    if op & 0xFFC0 == 0x4840 && mode != 0 {
+        return Some(add(Case::new(5, 6), calculate_ea(mode, reg)).pick(cached));
+    }
+    if op & 0xFFF8 == 0x4840 {
+        return Some(Case::new(4, 4).pick(cached)); // SWAP
+    }
+
+    // EXT.W/EXT.L/EXTB.L.
+    if matches!(op & 0xFFF8, 0x4880 | 0x48C0 | 0x49C0) {
+        return Some(Case::new(4, 4).pick(cached));
+    }
+
+    // TAS.
+    if op & 0xFFC0 == 0x4AC0 {
+        let base = if mode == 0 {
+            Case::new(4, 4)
+        } else {
+            add(Case::new(12, 13), calculate_ea(mode, reg))
+        };
+        return Some(base.pick(cached));
+    }
+
+    // TST.
+    if op & 0xFF00 == 0x4A00 {
+        let size = size_00((op >> 6) & 3);
+        return Some(add(Case::new(2, 3), fetch_ea(mode, reg, size)).pick(cached));
+    }
+
+    // CLR, NEGX, NEG, NOT.
+    if matches!(op & 0xFF00, 0x4000 | 0x4200 | 0x4400 | 0x4600) {
+        let size = size_00((op >> 6) & 3);
+        if mode == 0 {
+            return Some(Case::new(2, 3).pick(cached));
+        }
+        let ea = if op & 0xFF00 == 0x4200 {
+            calculate_ea(mode, reg)
+        } else {
+            fetch_ea(mode, reg, size)
+        };
+        return Some(add(Case::new(4, 6), ea).pick(cached));
+    }
+
+    // NBCD is fully specified only for Dn in the manual.
+    if op & 0xFFC0 == 0x4800 && mode == 0 {
+        return Some(Case::new(6, 6).pick(cached));
+    }
+
+    None
+}
+
+fn dyadic(op: u16, cached: bool) -> Option<i32> {
+    let group = op >> 12;
+    let opmode = (op >> 6) & 7;
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+
+    // BCD, extend, and paired-memory forms.
+    if group == 0x8 && opmode == 4 && mode <= 1 {
+        return Some(
+            if mode == 0 {
+                Case::new(4, 5)
+            } else {
+                Case::new(16, 17)
+            }
+            .pick(cached),
+        );
+    }
+    if group == 0xC && opmode == 4 && mode <= 1 {
+        return Some(
+            if mode == 0 {
+                Case::new(4, 5)
+            } else {
+                Case::new(16, 17)
+            }
+            .pick(cached),
+        );
+    }
+    if matches!(group, 0x9 | 0xD) && (4..=6).contains(&opmode) && mode <= 1 {
+        return Some(
+            if mode == 0 {
+                Case::new(2, 3)
+            } else {
+                Case::new(12, 13)
+            }
+            .pick(cached),
+        );
+    }
+    if group == 0xB && (4..=6).contains(&opmode) && mode == 1 {
+        return Some(Case::new(9, 10).pick(cached));
+    }
+    if group == 0xB && (4..=6).contains(&opmode) && mode == 0 {
+        return Some(Case::new(2, 3).pick(cached)); // EOR Dn,Dn
+    }
+    if group == 0x8 && opmode == 5 && mode <= 1 {
+        return Some(
+            if mode == 0 {
+                Case::new(6, 7)
+            } else {
+                Case::new(13, 13)
+            }
+            .pick(cached),
+        );
+    }
+    if group == 0x8 && opmode == 6 && mode <= 1 {
+        return Some(
+            if mode == 0 {
+                Case::new(8, 9)
+            } else {
+                Case::new(13, 13)
+            }
+            .pick(cached),
+        );
+    }
+
+    // EXG.
+    if group == 0xC && (4..=6).contains(&opmode) && matches!((op >> 3) & 0x1F, 0x08 | 0x09 | 0x11) {
+        return Some(Case::new(2, 3).pick(cached));
+    }
+
+    // Word multiply/divide.
+    if group == 0xC && matches!(opmode, 3 | 7) {
+        return Some(add(Case::new(27, 28), fetch_ea(mode, reg, Size::Word)).pick(cached));
+    }
+    if group == 0x8 && opmode == 3 {
+        return Some(add(Case::new(44, 44), fetch_ea(mode, reg, Size::Word)).pick(cached));
+    }
+    if group == 0x8 && opmode == 7 {
+        return Some(add(Case::new(56, 57), fetch_ea(mode, reg, Size::Word)).pick(cached));
+    }
+
+    match opmode {
+        0..=2 => Some(add(Case::new(2, 3), fetch_ea(mode, reg, size_00(opmode))).pick(cached)),
+        3 | 7 if matches!(group, 0x9 | 0xB | 0xD) => {
+            let base = if group == 0xB {
+                Case::new(4, 4) // CMPA
+            } else {
+                Case::new(2, 3) // ADDA/SUBA
+            };
+            let size = if opmode == 3 { Size::Word } else { Size::Long };
+            Some(add(base, fetch_ea(mode, reg, size)).pick(cached))
+        }
+        4..=6 => Some(add(Case::new(4, 6), fetch_ea(mode, reg, size_00(opmode - 4))).pick(cached)),
+        _ => None,
+    }
+}
+
+fn group_5(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+    let size_bits = (op >> 6) & 3;
+
+    if size_bits == 3 && mode == 7 && matches!(reg, 2..=4) {
+        // TRAPcc, no-trap path. The trap path is caught before classification.
+        let case = match reg {
+            2 => Case::new(6, 7),
+            3 => Case::new(8, 10),
+            _ => Case::new(4, 5),
+        };
+        return Some(case.pick(cached));
+    }
+    if size_bits == 3 && mode == 1 {
+        let condition = ((op >> 8) & 0xF) as u8;
+        let case = if cpu.test_condition(condition) {
+            Case::new(6, 7)
+        } else if cpu.d(reg as usize) as u16 == 0xFFFF {
+            Case::new(10, 10)
+        } else {
+            Case::new(6, 9)
+        };
+        return Some(case.pick(cached));
+    }
+    if size_bits == 3 {
+        if mode == 0 {
+            return Some(Case::new(4, 4).pick(cached));
+        }
+        return Some(add(Case::new(6, 6), calculate_ea(mode, reg)).pick(cached));
+    }
+
+    let size = size_00(size_bits);
+    if mode <= 1 {
+        Some(Case::new(2, 3).pick(cached))
+    } else {
+        Some(add(Case::new(4, 6), fetch_ea(mode, reg, size)).pick(cached))
+    }
+}
+
+fn group_6(cpu: &CpuCore, op: u16, cached: bool) -> i32 {
+    let condition = (op >> 8) & 0xF;
+    if condition == 1 {
+        return Case::new(7, 13).pick(cached); // BSR
+    }
+    if condition == 0 || cpu.change_of_flow {
+        return Case::new(6, 9).pick(cached);
+    }
+    match op as u8 {
+        0 => Case::new(6, 7).pick(cached),
+        0xFF => Case::new(6, 9).pick(cached),
+        _ => Case::new(4, 5).pick(cached),
+    }
+}
+
+fn group_e(op: u16, cached: bool) -> Option<i32> {
+    let mode = (op >> 3) & 7;
+    let reg = op & 7;
+
+    if op & 0x00C0 == 0x00C0 && (op >> 8) & 0xF >= 8 {
+        let selector = (op >> 8) & 0xF;
+        let base = if mode == 0 {
+            match selector {
+                0x8 => Case::new(6, 7),
+                0x9 | 0xB => Case::new(8, 8),
+                0xA | 0xC | 0xE => Case::new(12, 12),
+                0xD => Case::new(18, 18),
+                0xF => Case::new(10, 10),
+                _ => return None,
+            }
+        } else {
+            // Use the five-byte row: the executor can span five bytes and
+            // does not retain the extension-derived span after retirement.
+            match selector {
+                0x8 => Case::new(15, 16),
+                0x9 | 0xB => Case::new(18, 18),
+                0xA | 0xC | 0xE => Case::new(24, 24),
+                0xD => Case::new(32, 32),
+                0xF => Case::new(20, 21),
+                _ => return None,
+            }
+        };
+        return Some(
+            if mode == 0 {
+                base
+            } else {
+                add(base, calculate_immediate_ea(mode, reg, Size::Word))
+            }
+            .pick(cached),
+        );
+    }
+
+    if (op >> 6) & 3 == 3 {
+        let kind = (op >> 9) & 3;
+        let base = match kind {
+            0 if op & 0x0100 != 0 => Case::new(6, 7), // ASL
+            0 => Case::new(5, 6),                     // ASR
+            1 => Case::new(5, 6),                     // LSL/LSR
+            2 => Case::new(5, 6),                     // ROXL/ROXR
+            _ => Case::new(7, 7),                     // ROL/ROR
+        };
+        return Some(add(base, fetch_ea(mode, reg, Size::Word)).pick(cached));
+    }
+
+    let kind = (op >> 3) & 3;
+    let case = match kind {
+        0 if op & 0x0100 != 0 => Case::new(8, 8), // ASL
+        0 => Case::new(6, 6),                     // ASR
+        1 if op & 0x0020 != 0 => Case::new(6, 6), // dynamic LS
+        1 => Case::new(4, 4),                     // static LS
+        2 => Case::new(12, 12),                   // ROXL/ROXR
+        _ => Case::new(8, 8),                     // ROL/ROR
+    };
+    Some(case.pick(cached))
+}
+
+impl CpuCore {
+    /// Return the section-8.2 timing for the 68020/68EC020 instruction that
+    /// just retired. Instructions not covered by the integer tables (notably
+    /// coprocessor operations and full-format indexed detail) retain the old
+    /// conservative scale until a dedicated model exists.
+    pub(crate) fn cycles_020(&self, raw: i32, fetch_cached: bool) -> i32 {
+        if let Some(cycles) = exception_cycles(self, raw, fetch_cached) {
+            return cycles;
+        }
+
+        let op = self.ir as u16;
+        let cycles = match op >> 12 {
+            0x0 => group_0(self, op, fetch_cached),
+            0x1 => Some(move_cycles(op, Size::Byte, fetch_cached)),
+            0x2 => Some(move_cycles(op, Size::Long, fetch_cached)),
+            0x3 => Some(move_cycles(op, Size::Word, fetch_cached)),
+            0x4 => group_4(op, raw, fetch_cached),
+            0x5 => group_5(self, op, fetch_cached),
+            0x6 => Some(group_6(self, op, fetch_cached)),
+            0x7 => Some(Case::new(2, 3).pick(fetch_cached)),
+            0x8 | 0x9 | 0xB | 0xC | 0xD => dyadic(op, fetch_cached),
+            0xE => group_e(op, fetch_cached),
+            _ => None,
+        };
+        cycles.unwrap_or_else(|| legacy_fallback(raw))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn timed(op: u16, raw: i32, cached: bool) -> i32 {
+        let mut cpu = CpuCore::new();
+        cpu.ir = u32::from(op);
+        cpu.cycles_020(raw, cached)
+    }
+
+    #[test]
+    fn register_and_move_timings_follow_cache_and_worst_tables() {
+        assert_eq!(timed(0x7001, 4, true), 2); // MOVEQ #1,D0
+        assert_eq!(timed(0x7001, 4, false), 3);
+        assert_eq!(timed(0x2284, 8, true), 4); // MOVE.L D4,(A1)
+        assert_eq!(timed(0x2284, 8, false), 5);
+        assert_eq!(timed(0x2501, 12, true), 5); // MOVE.L D1,-(A2)
+        assert_eq!(timed(0x2501, 12, false), 6);
+    }
+
+    #[test]
+    fn arithmetic_and_expensive_integer_ops_use_manual_bases() {
+        assert_eq!(timed(0xD280, 4, true), 2); // ADD.L D0,D1
+        assert_eq!(timed(0xD280, 4, false), 3);
+        assert_eq!(timed(0x0650, 12, true), 8); // ADDI.W #imm,(A0)
+        assert_eq!(timed(0x0650, 12, false), 10);
+        assert_eq!(timed(0x0680, 16, true), 6); // ADDI.L #imm,D0
+        assert_eq!(timed(0x0680, 16, false), 8);
+        assert_eq!(timed(0x0C50, 12, true), 6); // CMPI.W #imm,(A0)
+        assert_eq!(timed(0x0C50, 12, false), 7);
+        assert_eq!(timed(0xB100, 4, true), 2); // EOR.B D0,D0
+        assert_eq!(timed(0xB100, 4, false), 3);
+        assert_eq!(timed(0xC0C1, 42, true), 27); // MULU.W D1,D0
+        assert_eq!(timed(0xC0C1, 42, false), 28);
+        assert_eq!(timed(0x81C1, 90, true), 56); // DIVS.W D1,D0
+        assert_eq!(timed(0x81C1, 90, false), 57);
+    }
+
+    #[test]
+    fn barrel_shifter_cost_is_count_independent() {
+        assert_eq!(timed(0xE108, 6, true), 4); // LSL.B #8,D0
+        assert_eq!(timed(0xE368, 6, true), 6); // LSL.W D1,D0
+        assert_eq!(timed(0xE570, 6, true), 12); // ROXL.W D2,D0
+    }
+
+    #[test]
+    fn dbcc_distinguishes_loop_expiry_and_true_condition() {
+        let mut cpu = CpuCore::new();
+        cpu.ir = 0x51C8; // DBF D0,<disp>
+        cpu.dar[0] = 7;
+        assert_eq!(cpu.cycles_020(12, true), 6);
+        assert_eq!(cpu.cycles_020(12, false), 9);
+
+        cpu.dar[0] = 0xFFFF;
+        assert_eq!(cpu.cycles_020(14, true), 10);
+        assert_eq!(cpu.cycles_020(14, false), 10);
+
+        cpu.ir = 0x50C8; // DBT: condition true
+        assert_eq!(cpu.cycles_020(12, true), 6);
+        assert_eq!(cpu.cycles_020(12, false), 7);
+    }
+
+    #[test]
+    fn control_and_save_restore_use_complete_table_entries() {
+        assert_eq!(timed(0x4E71, 4, true), 2); // NOP
+        assert_eq!(timed(0x4E71, 4, false), 3);
+        assert_eq!(timed(0x4E75, 16, true), 10); // RTS
+        assert_eq!(timed(0x4E75, 16, false), 12);
+        assert_eq!(timed(0x4E73, 20, true), 21); // RTE, normal frame
+        assert_eq!(timed(0x4E73, 20, false), 24);
+        assert_eq!(timed(0x4E70, 132, true), 518); // RESET
+    }
+
+    #[test]
+    fn model_dispatch_uses_tables_only_for_the_020_family() {
+        use crate::core::types::CpuType;
+
+        let mut cpu = CpuCore::new();
+        cpu.ir = 0x4E71; // NOP
+        cpu.set_cpu_type(CpuType::M68EC020);
+        assert_eq!(cpu.finalize_cycles(4, true), 2);
+        cpu.set_cpu_type(CpuType::M68020);
+        assert_eq!(cpu.finalize_cycles(4, false), 3);
+        cpu.set_cpu_type(CpuType::M68030);
+        assert_eq!(cpu.finalize_cycles(4, true), 3);
+    }
+}

--- a/crates/m68k/src/core/timing_060.rs
+++ b/crates/m68k/src/core/timing_060.rs
@@ -721,15 +721,15 @@ impl CpuCore {
         cost
     }
 
-    /// Model-dispatching wrapper for the three step paths: the 68060 uses its
-    /// own cost model; every other model keeps the existing scaling
-    /// byte-for-byte.
+    /// Model-dispatching wrapper for the three step paths.
     #[inline]
     pub(crate) fn finalize_cycles(&mut self, raw: i32, fetch_cached: bool) -> i32 {
-        if self.cpu_type == super::types::CpuType::M68060 {
-            self.cycles_060(raw, fetch_cached)
-        } else {
-            self.scale_cycles_for_cpu_type(raw)
+        match self.cpu_type {
+            super::types::CpuType::M68EC020 | super::types::CpuType::M68020 => {
+                self.cycles_020(raw, fetch_cached)
+            }
+            super::types::CpuType::M68060 => self.cycles_060(raw, fetch_cached),
+            _ => self.scale_cycles_for_cpu_type(raw),
         }
     }
 }

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -260,57 +260,70 @@ generated (the softfloat FPU retires every operation completely); FPSR
 quotient-bit and denormal traps behave as on the other parts rather
 than through the 060's unsupported-data path.
 
-## 68020+ timing
+## 68020 timing
 
 The 68000/68010 cycle counts are validated against the
 [SingleStepTests](https://github.com/SingleStepTests) (TomHarte) corpus,
-but **no equivalent vectors exist for the 68020, 68030, or 68040** -- the
-project publishes cycle-accurate vectors for the 68000 only. That is not
-an oversight: the 020+ parts have an instruction cache, a three-stage
-pipeline, and dynamic bus sizing, so there is no single cycle-exact count
-per instruction and therefore no widely-trusted reference to generate
-vectors from.
+but no equivalent vectors exist for the 68020. The later part has an
+instruction cache, a three-stage pipeline, execution overlap, dynamic bus
+sizing, and alignment-dependent transfers, so an opcode does not have one
+context-free cycle count.
 
-Copperline handles this by approximation rather than precision.
-`scale_cycles_for_cpu_type` (`crates/m68k/src/core/cpu.rs`) derives 020+
-timing from the corrected 68000 counts: the pipeline and cache make most
-instructions cost roughly half their 68000 cycles, with a two-cycle
-floor, and memory-bound work is dominated by the host bus model anyway.
-The flat scale is wrong for a few instructions whose 020 cost does not
-track the 68000 count, so those carry an explicit 020 cycle value (still
-pre-scale): the barrel-shifter shift/rotate, the fixed-cost MULU/MULS, a
-taken `DBcc`'s pipeline refill, and `MOVE` (register vs memory-source
-read latency). These are calibrated against a cycle-exact A1200 reference
-(FS-UAE) using the `timing-test/` ADF -- with the instruction cache
-enabled, since that is the A1200 default; `timing-test/compare.py` checks
-each row against the reference. This is good enough because Copperline
-paces to wall-clock time and models the CPU:chipset clock ratio and
-chip-bus arbitration exactly; per-instruction 020 cycles matter far less
-than those for Amiga software, which is overwhelmingly 68000. The
-68000/68010 paths are left untouched so the TomHarte-validated timing is
-never disturbed. If 020+ accuracy ever becomes a real requirement, the
-Motorola 68020/030 user-manual timing tables or differential testing
-against Moira/Musashi are the realistic sources.
+`crates/m68k/src/core/timing_020.rs` transcribes the integer timing tables
+from section 8.2 of the
+[MC68020 User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68020UM.pdf).
+The manual publishes Best Case (cached with maximum execution overlap),
+Cache Case (cached without overlap), and Worst Case (uncached without
+overlap). Copperline does not yet model execution-stage overlap, so an
+instruction selects Cache Case only when all of its opcode, extension, and
+immediate fetches hit the instruction cache; any instruction-stream miss
+selects Worst Case. This covers the standard effective-address tables, the
+complete MOVE matrix, arithmetic and logical instructions, multiply/divide,
+shifts, bit/bitfield operations, branches, control flow, and save/restore
+paths. The 68000 and 68010 timing paths are unchanged, and the 68030/040
+retain the earlier scaled approximation rather than incorrectly inheriting
+68020 silicon timings.
 
-On the A1200 the 020 chip-bus timing is calibrated against a cycle-exact
-FS-UAE A1200 (the 6/8 scaling above, a 32-bit Alice chip-bus data path, and
-a two-entry longword fetch latch). The 020's chip-bus cycle is modelled as 3
+The manual's totals assume aligned operands and stack, a 32-bit bus, and
+three-clock no-wait reads and writes. They include those ideal transfers.
+Copperline bills every actual operand and instruction access while the
+instruction executes, then advances only the unconsumed part of the table
+total. An A1200 chip-RAM access can therefore extend an instruction through
+Alice arbitration; selecting a smaller CPU total cannot erase a bus wait
+that already happened.
+
+This is intentionally a datasheet model, not a claim of cycle exactness.
+The opcode word does not retain a consumed extension word, so full-format
+indexed modes use the brief-index table row, `MOVES` uses the slower of its
+two direction bases, and long divide uses the conservative signed base.
+Coprocessor operations and unclassified encodings retain the old scaled
+fallback. Misalignment, detailed cache-refill sequencing, and instruction
+overlap remain to be added. Motorola explicitly demonstrates in section 8.1
+that the timing of an instruction stream cannot be obtained by simply
+summing isolated table entries; hardware traces are still the final reference
+once a machine is available. `timing-test/` remains the end-to-end regression
+for checking the combined CPU, cache, and chip-bus model rather than the
+source of the per-opcode constants.
+
+On the A1200 the 020 uses a 32-bit Alice chip-bus data path and a two-entry
+longword fetch latch. The 020's chip-bus cycle is modelled as 3
 CPU clocks, not the 68000's 4: after the granted colour-clock slot the access
 bills only the shorter remaining tail (one clock -- half a cck at the stock
-2-clock ratio, none at 14 MHz where the 3-clock cycle fits inside one slot),
-which is the whole chip-slot cost at the native 14 MHz ratio. On Alice, reads,
-writes, and custom-register reads all consume that granted slot without an
-additional colour-clock bubble; adding one over-stalls AGA 020 chip-RAM
-read/modify/write loops, while the A1200 timing-test chip-read row remains
-aligned without it. On OCS/ECS machines the 020 still talks to the 16-bit chip
-bus, so chip/slow/custom reads pay a one-CCK data-return wait when the
-3-clock short bus cycle is otherwise hidden inside a single colour-clock slot.
-The tail's fractional cck are carried so none are lost; the 68000/010 keep the
-full 4-clock (2-cck) cycle (`Bus::cpu_short_bus_cycle`). Residuals: per-frame
-throughput still runs below the reference, and the cycle model does not reflect
-instruction-cache hit/miss *latency* (only its bus-traffic effect), so software
-that toggles CACR cache-on/off and depends on the exact transition timing can
-diverge.
+2-clock ratio, none at 14 MHz where the 3-clock cycle fits inside one slot).
+That is enough for a posted write. A chip-RAM read or custom-register read
+also waits one colour clock for the chipset's data-return phase. An AGA
+instruction-cache fill does the same for its first word; the second word from
+the already-latched 32-bit value is free. On OCS/ECS machines the 020 still
+talks to the 16-bit chip bus, so chip/slow/custom data reads likewise pay the
+return wait. The tail's fractional cck are carried so none are lost; the
+68000/010 keep the full 4-clock (2-cck) cycle
+(`Bus::cpu_short_bus_cycle`).
+
+This distinction is visible in SysInfo 4.4: treating Alice reads and cache
+fills like posted writes made the A1200 profile report 5.52x A600 chip speed
+and 1.61x A1200 CPU speed after the instruction-table update. Billing the
+data-return phase changes those figures to 3.55x and 1.10x respectively,
+without altering register-only timing-test rows.
 
 ## MMU
 

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -75,6 +75,15 @@ and ROM are external-bus accesses billed at the CPU clock without chip-bus
 arbitration -- so an accelerated CPU speeds up exactly what a real
 accelerator would.
 
+The A1200's 32-bit Alice path moves an aligned longword in one granted CPU
+slot, but the slot is not the complete latency of a read. A 68020 chip-RAM
+read, instruction-cache fill, or custom-register read waits one more CCK for
+the chipset data-return phase; a write can be posted after the 020's shorter
+three-clock local-bus cycle. Sequential instruction words from the same
+aligned longword use the AGA fetch latch and do not request or wait for the
+same value twice. This read/write asymmetry is covered by
+`aga_68020_chip_reads_wait_for_data_but_writes_are_posted`.
+
 ### Deferred timed-device ticks
 
 The chipset and beam advance every colour clock, but the *timed devices*

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -903,10 +903,10 @@ pub struct Bus {
     /// hundredths of a CPU clock. At high clock ratios a single word access
     /// costs less than one cck; the carry accumulates so no time is lost.
     ext_clock_carry_x100: u32,
-    /// True for the 68020+: its chip-bus cycle is 3 CPU clocks, not the
-    /// 68000's 4 (2 cck) -- so after the granted slot it bills a shorter tail
-    /// (write-posting and the faster 020 bus). Derived from the CPU model and
-    /// re-set on construction / state load; not serialized.
+    /// True for the 68020+: its local bus cycle is 3 CPU clocks, not the
+    /// 68000's 4 (2 cck). Writes can finish after that shorter, posted cycle;
+    /// reads also wait for the chipset's data-return phase. Derived from the
+    /// CPU model and re-set on construction / state load; not serialized.
     #[serde(skip)]
     cpu_short_bus_cycle: bool,
     /// Sub-cck remainder (in CPU clocks) for the 020+ short-bus-cycle tail:
@@ -3706,9 +3706,10 @@ impl Bus {
         self.cpu_clocks_per_cck = clocks.max(1);
     }
 
-    /// Select the chip-bus cycle length: the 68020+ completes a word access in
-    /// 3 CPU clocks where the 68000 takes 4, so its post-grant tail is shorter
-    /// (write-posting; faster reads). Derived from the CPU model.
+    /// Select the local bus cycle length: the 68020+ completes its side of an
+    /// access in 3 CPU clocks where the 68000 takes 4. Chipset reads still
+    /// have a separate data-return phase; writes can be posted after the
+    /// shorter cycle. Derived from the CPU model.
     /// Whether the CPU runs the shorter 020+ bus cycle (see the field doc);
     /// also distinguishes the 68000's shared chip data bus from the 020+
     /// local bus for the floating-bus latch.
@@ -3939,12 +3940,11 @@ impl Bus {
             self.record_slice_bus_advance(cck, tick);
             // After the granted slot (one cck), the CPU's bus cycle runs out
             // its remaining clocks with the chip bus free for DMA. The 68000's
-            // 4-clock cycle leaves one whole cck (2 clocks at the stock ratio);
-            // the 68020+'s 3-clock cycle leaves only one clock -- half a cck at
-            // the stock ratio, and none at all once a slot is >= 3 clocks
-            // (14 MHz), which is the write-posting / faster-020-bus effect.
-            // Bill the 020 tail in CPU clocks through a carry so the fractional
-            // cck are not lost.
+            // 4-clock cycle leaves one whole cck (2 clocks at the stock ratio).
+            // A 020+ write can be posted after its shorter cycle; reads need
+            // the chipset's data-return phase, billed below. Bill the residual
+            // 020 write tail in CPU clocks through a carry so fractional cck
+            // are not lost on slower CPU ratios.
             if self.cpu_short_bus_cycle {
                 self.cpu_bus_tail_carry += 3u32.saturating_sub(self.cpu_clocks_per_cck);
                 while self.cpu_bus_tail_carry >= self.cpu_clocks_per_cck {
@@ -3969,7 +3969,10 @@ impl Bus {
                 );
             }
         }
-        if self.cpu_short_bus_cycle && !wide_bus && matches!(kind, CpuBusAccessKind::Read) {
+        if self.cpu_short_bus_cycle
+            && (matches!(kind, CpuBusAccessKind::Read)
+                || wide_bus && matches!(kind, CpuBusAccessKind::Fetch))
+        {
             self.bill_020_read_data_wait();
         }
     }
@@ -5090,7 +5093,7 @@ impl Bus {
             size,
             CpuBusAccessKind::Custom,
         );
-        if self.cpu_short_bus_cycle && !self.aga_enabled() {
+        if self.cpu_short_bus_cycle {
             self.bill_020_read_data_wait();
         }
         // Read-only custom registers (INTREQR, DSKBYTR, SERDATR, POTxDAT, ...)

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -8654,7 +8654,7 @@ fn cpu_chip_access_uses_two_color_clocks_slot_plus_bus_free_tail() {
 }
 
 #[test]
-fn aga_68020_chip_and_custom_reads_use_alice_slot_without_extra_wait() {
+fn aga_68020_chip_reads_wait_for_data_but_writes_are_posted() {
     let mut bus = empty_bus();
     bus.set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
     bus.set_cpu_clocks_per_cck(4);
@@ -8664,18 +8664,23 @@ fn aga_68020_chip_and_custom_reads_use_alice_slot_without_extra_wait() {
     bus.agnus.hpos = 0x20;
     bus.grant_cpu_bus_access_at(Some(0x0002_0000), 2, CpuBusAccessKind::Read);
     let (chip_read_cck, _) = bus.take_slice_bus_advance();
-    assert_eq!(chip_read_cck, 1);
-    assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Cpu);
+    assert_eq!(chip_read_cck, 2);
+    assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Idle);
 
     bus.grant_cpu_bus_access_at(Some(0x0002_0000), 2, CpuBusAccessKind::Write);
     let (chip_write_cck, _) = bus.take_slice_bus_advance();
     assert_eq!(chip_write_cck, 1);
     assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Cpu);
 
+    bus.grant_cpu_bus_access_at(Some(0x0002_0004), 2, CpuBusAccessKind::Fetch);
+    let (chip_fetch_cck, _) = bus.take_slice_bus_advance();
+    assert_eq!(chip_fetch_cck, 2);
+    assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Idle);
+
     let _ = bus.custom_read(0x002, 2);
     let (custom_read_cck, _) = bus.take_slice_bus_advance();
-    assert_eq!(custom_read_cck, 1);
-    assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Cpu);
+    assert_eq!(custom_read_cck, 2);
+    assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Idle);
 }
 
 #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -257,6 +257,11 @@ struct CpuBus {
     /// folding on a cached fetch stream. Recomputed on every fetch, never
     /// carried across a save state.
     last_fetch_cache_hit: bool,
+    /// True only if every opcode/extension/immediate fetch in the current
+    /// instruction hit the icache. The 68020 timing tables' cache case is
+    /// defined for the complete instruction being resident, not merely its
+    /// opcode word.
+    instruction_fetches_cached: bool,
     /// IPL level as sampled at the CPU's most recent bus access. The real
     /// 68000 latches its IPL pins during bus cycles, and the take-interrupt
     /// decision at an instruction boundary uses the value latched during the
@@ -329,6 +334,7 @@ impl M68kMachine {
                 dcache: None,
                 dbg_irq_window: debug_irq_window_setting(),
                 last_fetch_cache_hit: false,
+                instruction_fetches_cached: false,
                 sampled_irq_level: 0,
                 ipl_sample_held: false,
                 diag_current_pc: 0,
@@ -2544,12 +2550,14 @@ impl CpuBus {
             self.cache_fill_after_miss(addr, size, kind);
             if kind == CpuBusAccessKind::Fetch {
                 self.last_fetch_cache_hit = false;
+                self.instruction_fetches_cached = false;
             }
             self.note_cpu_data_bus(addr, size, value);
             return value;
         }
         if kind == CpuBusAccessKind::Fetch {
             self.last_fetch_cache_hit = false;
+            self.instruction_fetches_cached = false;
         }
         let value = self.read_sized_uncached(addr, size, kind);
         self.note_cpu_data_bus(addr, size, value);
@@ -3174,6 +3182,14 @@ impl CpuBus {
 impl AddressBus for CpuBus {
     fn last_fetch_was_cached(&self) -> bool {
         self.last_fetch_cache_hit
+    }
+
+    fn begin_instruction_fetches(&mut self) {
+        self.instruction_fetches_cached = true;
+    }
+
+    fn instruction_fetches_were_cached(&self) -> bool {
+        self.instruction_fetches_cached
     }
 
     fn read_byte(&mut self, address: u32) -> u8 {
@@ -3865,6 +3881,7 @@ mod tests {
             dcache: None,
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
@@ -3892,6 +3909,7 @@ mod tests {
             dcache: None,
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
@@ -3926,6 +3944,7 @@ mod tests {
             dcache: None,
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
@@ -3958,6 +3977,46 @@ mod tests {
     //   $106: 4E71            nop                  (patch target)
     //   $108: 31FC 5282 0106  move.w #$5282,($106).w   (addq.l #1,d2)
     const ICACHE_SMC_PROLOGUE: [u16; 7] = [0x7001, 0x4E7B, 0x0002, 0x4E71, 0x31FC, 0x5282, 0x0106];
+
+    #[test]
+    fn timing_cache_case_requires_every_instruction_fetch_to_hit() {
+        let mut icache = crate::cache::CpuCache::default();
+        icache.enabled = true;
+        let mut bus = CpuBus {
+            bus: test_bus(reset_rom(0, 0)),
+            address_mask: ADDRESS_MASK_24BIT,
+            dbg_memw_addr: None,
+            dbg_memw_hit: None,
+            icache: Some(Box::new(icache)),
+            dcache: None,
+            dbg_irq_window: None,
+            last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
+            sampled_irq_level: 0,
+            ipl_sample_held: false,
+            diag_current_pc: 0,
+        };
+
+        // Warm the opcode longword and a separate extension longword.
+        let _ = bus.read_immediate_word(0x100);
+        let _ = bus.read_immediate_word(0x108);
+
+        bus.begin_instruction_fetches();
+        let _ = bus.read_immediate_word(0x100);
+        let _ = bus.read_immediate_word(0x108);
+        assert!(
+            bus.instruction_fetches_were_cached(),
+            "all-resident instruction stream must select Cache Case"
+        );
+
+        bus.begin_instruction_fetches();
+        let _ = bus.read_immediate_word(0x100);
+        let _ = bus.read_immediate_word(0x110);
+        assert!(
+            !bus.instruction_fetches_were_cached(),
+            "an extension-word miss must select Worst Case even after an opcode hit"
+        );
+    }
 
     #[test]
     fn icache_serves_stale_opcode_until_cacr_clear() -> Result<()> {
@@ -4140,6 +4199,7 @@ mod tests {
             dcache: Some(Box::new(dcache)),
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
@@ -4188,6 +4248,7 @@ mod tests {
             dcache: None,
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
@@ -4214,6 +4275,7 @@ mod tests {
             dcache: None,
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
@@ -4246,6 +4308,7 @@ mod tests {
             dcache: None,
             dbg_irq_window: None,
             last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,


### PR DESCRIPTION
## Summary

- replace the flat 68020 cycle scaling with Cache Case and Worst Case timings transcribed from MC68020UM section 8.2
- require the complete instruction stream, including extension and immediate words, to hit the instruction cache before selecting Cache Case
- model the A1200 Alice data-return phase for chip RAM reads, cache fills, and custom-register reads while keeping writes posted
- keep the 68000/68010, 68030/68040, and 68060 timing paths unchanged
- document the timing model, limitations, and benchmark calibration

## Benchmark results

Classic SysInfo 4.4 on the A1200 profile:

| Measurement | Before corrections | After |
| --- | ---: | ---: |
| CPU speed vs A1200 | 1.61x | 1.10x |
| Chip speed vs A600 | 5.52x | 3.55x |

xSysInfo improves from 1.34x to 1.19x A1200. Its detected CPU clock is 13.76 MHz, so no workload-specific multiplier was added to chase the remaining difference.

## Verification

- `cargo test --locked` (1,754 passed, 5 ignored)
- `cargo test --manifest-path crates/m68k/Cargo.toml --lib --locked` (93 passed)
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `cargo build --release --locked`
- deterministic SysInfo, xSysInfo, and A1200 timing-test ADF runs

The optional broad m68k integration target expects Musashi fixture binaries that are not present in this checkout; the applicable self-contained library suite passes.