### PR TITLE
Update anyhow, memmap2 and quick-xml for security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2342,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3479,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -210,14 +210,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.102.crate",
-        "sha256": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c",
-        "dest": "cargo/vendor/anyhow-1.0.102"
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.104.crate",
+        "sha256": "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470",
+        "dest": "cargo/vendor/anyhow-1.0.104"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\", \"files\": {}}",
-        "dest": "cargo/vendor/anyhow-1.0.102",
+        "contents": "{\"package\": \"330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.104",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2160,14 +2160,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memmap2/memmap2-0.9.10.crate",
-        "sha256": "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3",
-        "dest": "cargo/vendor/memmap2-0.9.10"
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.9.11.crate",
+        "sha256": "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0",
+        "dest": "cargo/vendor/memmap2-0.9.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3\", \"files\": {}}",
-        "dest": "cargo/vendor/memmap2-0.9.10",
+        "contents": "{\"package\": \"d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.9.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3135,14 +3135,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.39.4.crate",
-        "sha256": "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e",
-        "dest": "cargo/vendor/quick-xml-0.39.4"
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.41.0.crate",
+        "sha256": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1",
+        "dest": "cargo/vendor/quick-xml-0.41.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e\", \"files\": {}}",
-        "dest": "cargo/vendor/quick-xml-0.39.4",
+        "contents": "{\"package\": \"e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.41.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4591,14 +4591,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.10.crate",
-        "sha256": "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a",
-        "dest": "cargo/vendor/wayland-scanner-0.31.10"
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.11.crate",
+        "sha256": "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0",
+        "dest": "cargo/vendor/wayland-scanner-0.31.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-scanner-0.31.10",
+        "contents": "{\"package\": \"338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.31.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {


### PR DESCRIPTION
Audited the locked tree against the OSV/RustSec advisory database ahead of the
release. Three advisories have fixes available in range; this takes them and
nothing else.

## Taken

| Crate | Advisory | Issue | Now |
|---|---|---|---|
| `anyhow` 1.0.102 | RUSTSEC-2026-0190 | Unsoundness in `Error::downcast_mut()` | 1.0.104 |
| `memmap2` 0.9.10 | RUSTSEC-2026-0186 | Unchecked pointer offset | 0.9.11 |
| `quick-xml` 0.39.4 | RUSTSEC-2026-0194 / -0195 | Quadratic parse, unbounded allocation DoS | 0.41.0 |

`anyhow` is a direct dependency on every platform. `memmap2` arrives through
`winit` / `smithay-client-toolkit` / `sctk-adwaita` on the Linux window path.
`quick-xml` is build-time only -- the `wayland-scanner` proc-macro parsing the
protocol XML shipped inside the crate -- so neither DoS is reachable from guest
or user input; taken because it costs nothing. `wayland-scanner` moves
0.31.10 -> 0.31.11 as the parent permitting that bump.

Deliberately surgical: a bare `cargo update` moves 97 crates, which is not a
change to make the day before a release. Exactly four move here, with no crates
added or removed.

## Not taken, and why

`bincode` 1.3.3, `paste` 1.0.15 and `ttf-parser` 0.25.1 carry unmaintained
notices with no patched version to move to. `bincode` is the save-state
encoding specifically, so a 1 -> 2 migration would invalidate every existing
state -- not a drive-by change.

## wasmtime

27 advisories match `wasmtime` 27.0.0 in the database and none are reachable in
this configuration. The engine is Cranelift-only (excluding the four Winch
advisories, including the aarch64 sandbox escape), builds without the WASI,
component-model and threads features (excluding eight more), sets
`wasm_simd(false)` in `make_engine` (excluding the `f64x2.splat` Cranelift one),
and uses the default allocator rather than the pooling one.

The advisory that would have mattered -- GHSA-jhxm-h53p-jm7w, aarch64 Cranelift
miscompile enabling sandbox escape -- is introduced in 32.0.0, so 27 predates
it. The RustSec mirror over-reports it with a range starting at zero; the
upstream GHSA has the accurate bounds.

Worth tracking separately (not here): 27.x is an unsupported line that receives
no backports, so the next advisory will not be fixed there either. Moving to the
36.x LTS is a real piece of work rather than a version bump, since the `=27.0.0`
pin exists for save-state determinism of plugin linear memory.

## Verification

`cargo-sources.json` regenerated from the new lock (the Flatpak workflow fails
on a stale file); the diff touches only those four crates. Both nested workspace
lockfiles still resolve `--locked`.

Release build clean; `fmt` clean; `clippy --all-targets --all-features --locked
-D warnings` clean; unit suite 1839 passing; 22 golden renders passing; full
`--ignored` suite passing (`image_regression` 8/8, `mb_ram` 3/3, `vamiga_ts`
1/1). Re-querying OSV against the updated lock leaves only the three
unmaintained notices above.