### PR TITLE
Add funding and community links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: [linuxjedi]
+patreon: Copperline
+ko_fi: linuxjedi
+custom: ['https://paypal.me/linuxjedi']

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,71 @@
+# Funding Copperline
+
+Copperline is free software under the GPL, developed in the open. It will
+stay that way: nothing here buys a feature, a private build, or a place in
+the queue. What funding buys is time, and the hardware to check the emulator
+against the real thing.
+
+## Where to give
+
+| Platform | Link | Notes |
+| --- | --- | --- |
+| Patreon | [patreon.com/cw/Copperline](https://www.patreon.com/cw/Copperline) | Copperline-specific, monthly, tiers from GBP 3 |
+| GitHub Sponsors | [github.com/sponsors/linuxjedi](https://github.com/sponsors/linuxjedi) | Monthly or one-off, no platform fee |
+| Ko-fi | [ko-fi.com/linuxjedi](https://ko-fi.com/linuxjedi) | One-off, no account needed |
+| PayPal | [paypal.me/linuxjedi](https://paypal.me/linuxjedi) | One-off |
+
+Patreon is the one to pick for ongoing support of Copperline itself; the
+others are personal links covering all of Andrew "LinuxJedi" Hutchings'
+open-source work, including
+[AmigaRGBtoHDMI](https://github.com/LinuxJedi/AmigaRGBtoHDMI).
+
+## First goal: signed binaries
+
+Today the macOS disk image is only ad-hoc signed, and the Windows build is
+not signed at all. Both work, but both make the operating system tell you
+they might not be safe: macOS Gatekeeper refuses the first launch until you
+right-click-Open, and Windows SmartScreen puts up a "More info" wall. That
+is a poor first impression of a project whose whole pitch is that it boots
+straight to a working Amiga.
+
+Fixing it is not a code problem, it is a subscription problem. Signing and
+notarizing on macOS needs Apple Developer Program membership (USD 99/year),
+and clearing SmartScreen on Windows needs a code-signing certificate from a
+commercial CA, which since the move to hardware-backed keys runs to a few
+hundred a year on top. Recurring support is what makes committing to those
+sensible, which is why Patreon is the tier that moves this along fastest.
+
+Reaching it means downloads that open on a double-click, on every platform,
+with no quarantine incantations in the README.
+
+## What else it pays for
+
+- Development time on the emulator, the documentation, and the packaging
+  for macOS, Linux, and the web.
+- Real Amiga hardware and peripherals to measure against. Copperline models
+  chip behaviour rather than individual titles, so hardware-derived timing
+  numbers (the sort the `timing-test/` disk produces) are what keeps the
+  models honest.
+- Test media, capture equipment, and the hosting behind
+  [copperline.dev](https://copperline.dev/).
+
+## Other ways to help
+
+Money is not the only useful contribution, and often not the most useful
+one:
+
+- File a good bug report. A hardware-focused reproduction, the config, and
+  the emulated timestamp are worth more than a video.
+- Improve the documentation under `docs/`, or the guides on the website.
+- Send a patch. [`CONTRIBUTING.md`](CONTRIBUTING.md) has the ground rules;
+  the short version is that fixes describe 68000/Agnus/Denise/Paula/CIA
+  behaviour, never a particular game or demo.
+- Compare Copperline against real hardware. Measurements from a machine on
+  your desk resolve arguments that no amount of emulator archaeology can.
+- Come and talk about it on [Discord](https://discord.gg/HDTjt3tYAC).
+
+## Please do not send
+
+Kickstart ROMs, disk images, hard-disk images, or CD images. They are
+copyrighted, they cannot be committed, and they are not needed to report a
+problem. See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Copperline](assets/brand/copperline-logo.png)
 
-Website: [copperline.dev](https://copperline.dev/)
+Website: [copperline.dev](https://copperline.dev/) |
+Chat: [Discord](https://discord.gg/HDTjt3tYAC) |
+Support: [Patreon](https://www.patreon.com/cw/Copperline)
 
 An Amiga emulator written in Rust, built around a vendored copy of
 the pure-Rust [m68k](crates/m68k) CPU core, with a
@@ -367,6 +369,22 @@ chip-bus timings against the CIA E-clock for cross-emulator comparison.
   custom register or CIA edge case). This is non-fatal: the window stays
   alive showing the last framebuffer, and the debugger can inspect the
   halted state.
+
+## Community
+
+The project Discord is where development, bug hunting, and general Amiga
+talk happen: [discord.gg/HDTjt3tYAC](https://discord.gg/HDTjt3tYAC). Bug
+reports and feature requests are best filed as GitHub issues so they do not
+scroll away; [`CONTRIBUTING.md`](CONTRIBUTING.md) covers what a useful
+report looks like and the hardware-first rule that patches follow.
+
+If you would like to support development, [`FUNDING.md`](FUNDING.md) lists
+the options -- [Patreon](https://www.patreon.com/cw/Copperline) for ongoing
+support of Copperline, or GitHub Sponsors, Ko-fi, and PayPal for one-off
+contributions. Copperline stays GPL and freely available regardless;
+funding buys development time, real hardware to measure against, and the
+Apple and Windows code-signing subscriptions needed to ship binaries that
+open without a Gatekeeper or SmartScreen warning.
 
 ## Credits
 


### PR DESCRIPTION
Adds the funding and community pointers the project was missing.

## FUNDING.md

Lists the four donation platforms: the new [Copperline Patreon](https://www.patreon.com/cw/Copperline) (recommended, since it is the Copperline-specific one), plus GitHub Sponsors, Ko-fi, and PayPal carried over from the AmigaRGBtoHDMI funding config as personal links.

The lead section is a concrete first goal: **signed binaries**. The macOS disk image is only ad-hoc signed (`packaging/macos/build-dmg.sh`) and the Windows build is unsigned, so both currently trip Gatekeeper and SmartScreen on first launch and the workaround is documented in four places. Clearing that needs Apple Developer Program membership and a commercial code-signing certificate, both recurring, which is the argument for recurring support.

The rest covers what funding pays for (development time, real hardware to measure against, test media, hosting), non-monetary ways to help, and a reminder not to send ROMs or disk images.

## .github/FUNDING.yml

Enables the repository Sponsor button. Trimmed to the four active entries rather than carrying the commented-out placeholders.

## README.md

- Header gains Discord and Patreon alongside the website link.
- New `## Community` section before Credits: Discord invite, a nudge toward GitHub issues so reports do not scroll away, and a pointer to `FUNDING.md` with the "stays GPL regardless" caveat.

## Notes

Docs-only, no code touched. All four funding URLs and the Discord invite were checked as live. If signing does get funded, the workaround text in `RELEASE.md`, `docs/guide/getting-started.md`, and both `packaging/*/README.txt` files will need updating; they are accurate as-is today. The Discord link is currently only in the README, not on copperline.dev or under `docs/`.