### PR TITLE
Log Denise's hardware sprite latch view in the frame-state dump

### DIFF
--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -131,16 +131,17 @@ cannot change at runtime (see [](../internals/architecture)).
   `COPPERLINE_DBG_EXPORT_PLANES_DIR=DIR` sets the output directory.
 
 `COPPERLINE_DBG_FRAMESTATE=1`
-: Log the per-frame display state (one summary line per rendered frame)
-  inside the `AFTER`/`UNTIL` window, followed by the frame geometry, the
-  palette, a captured-sprite-DMA summary, and *both* of Denise's sprite
-  register views: the CPU/Copper write shadow (`sprpos`/`sprctl`/`sprarmed`)
-  and the hardware-true latch view (`hw_sprpos`/`hw_sprctl`/`hw_sprdata`/
-  `hw_sprdatb`/`hw_sprarmed`), which sprite DMA fetches write through as
-  well. The two disagreeing on a channel is the signature of a stale
-  display latch: the shadow shows what software last wrote, the hardware
-  view what Denise would actually serialize, and the latter drives the
-  DMA-idle latched redisplay.
+: Log the display state the renderer starts each frame from, as a block per
+  rendered frame inside the `AFTER`/`UNTIL` window: a `framestate` summary
+  line (DMA enable, scroll, window, modulos, bitplane pointers), then the
+  frame geometry, the palette, a captured-sprite-DMA summary, and *both* of
+  Denise's sprite register views -- the CPU/Copper write shadow
+  (`sprpos`/`sprctl`/`sprarmed`) and the hardware-true latch view
+  (`spr_hw_pos`/`spr_hw_ctl`/`spr_hw_data`/`spr_hw_datb`/`spr_hw_armed`),
+  which sprite DMA fetches write through as well. The two disagreeing on a
+  channel is the signature of a stale display latch: the shadow shows what
+  software last wrote, the hardware view what Denise would actually
+  serialize, and the latter drives the DMA-idle latched redisplay.
 
 ## Diagnostic knobs
 

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -132,7 +132,15 @@ cannot change at runtime (see [](../internals/architecture)).
 
 `COPPERLINE_DBG_FRAMESTATE=1`
 : Log the per-frame display state (one summary line per rendered frame)
-  inside the `AFTER`/`UNTIL` window.
+  inside the `AFTER`/`UNTIL` window, followed by the frame geometry, the
+  palette, a captured-sprite-DMA summary, and *both* of Denise's sprite
+  register views: the CPU/Copper write shadow (`sprpos`/`sprctl`/`sprarmed`)
+  and the hardware-true latch view (`hw_sprpos`/`hw_sprctl`/`hw_sprdata`/
+  `hw_sprdatb`/`hw_sprarmed`), which sprite DMA fetches write through as
+  well. The two disagreeing on a channel is the signature of a stale
+  display latch: the shadow shows what software last wrote, the hardware
+  view what Denise would actually serialize, and the latter drives the
+  DMA-idle latched redisplay.
 
 ## Diagnostic knobs
 

--- a/src/video/bitplane/diag.rs
+++ b/src/video/bitplane/diag.rs
@@ -90,9 +90,10 @@ pub(super) fn maybe_log_frame_state(
         state.spr_armed,
     );
     // The hardware-true latch view (spr_hw_*, fed by DMA fetches as well as
-    // CPU/Copper writes) decides the DMA-idle latched redisplay.
+    // CPU/Copper writes) decides the DMA-idle latched redisplay. The labels
+    // are the field names, so a line from a log grep straight back to here.
     log::info!(
-        "  hw_sprpos={:04X?} hw_sprctl={:04X?} hw_sprdata={:04X?} hw_sprdatb={:04X?} hw_sprarmed={:?}",
+        "  spr_hw_pos={:04X?} spr_hw_ctl={:04X?} spr_hw_data={:04X?} spr_hw_datb={:04X?} spr_hw_armed={:?}",
         state.spr_hw_pos,
         state.spr_hw_ctl,
         state.spr_hw_data,

--- a/src/video/bitplane/diag.rs
+++ b/src/video/bitplane/diag.rs
@@ -89,6 +89,16 @@ pub(super) fn maybe_log_frame_state(
         state.sprctl,
         state.spr_armed,
     );
+    // The hardware-true latch view (spr_hw_*, fed by DMA fetches as well as
+    // CPU/Copper writes) decides the DMA-idle latched redisplay.
+    log::info!(
+        "  hw_sprpos={:04X?} hw_sprctl={:04X?} hw_sprdata={:04X?} hw_sprdatb={:04X?} hw_sprarmed={:?}",
+        state.spr_hw_pos,
+        state.spr_hw_ctl,
+        state.spr_hw_data,
+        state.spr_hw_datb,
+        state.spr_hw_armed,
+    );
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Small debugger addition that fell out of the #278 investigation.

`COPPERLINE_DBG_FRAMESTATE` printed only the CPU/Copper write shadow of the
sprite registers:

```
  sprpos=[FE00, FE00, ...] sprctl=[FF00, FF00, ...] sprarmed=[false, ...]
```

Denise keeps a second, hardware-true view of those same registers (`spr_hw_*`)
which sprite DMA fetches write through as well as CPU/Copper writes, and that
view -- not the shadow -- is what drives the DMA-idle latched redisplay. So a
frame with a stale sprite column but no sprite register writes at all looked
completely clean in the dump. Now both views print:

```
  sprpos=[FE00, FE00, ...] sprctl=[FF00, FF00, ...] sprarmed=[false, ...]
  spr_hw_pos=[2B3F, FE00, ...] spr_hw_ctl=[3B01, FF00, ...] spr_hw_data=[0080, 0000, ...]
  spr_hw_datb=[0140, 0000, ...] spr_hw_armed=[true, false, ...]
```

That is the real output from the state I was handed while chasing the residual
Giana Sisters column: the program had parked all eight channels with the
`SPRxPOS=$FE00 / SPRxCTL=$FF00` idiom (a CTL write, which disarms), sprites 1-7
show exactly that in both views, and sprite 0 alone still held its DMA-fetched
descriptor words with the latch armed. One line, whole diagnosis -- worth having
next time a sprite appears out of nowhere.

Diagnostic-only: the knob is off by default, so the added line costs nothing in
a normal run. Documented in `docs/debugger/headless.md` alongside the knob,
including what a disagreement between the two views means.

