### PR TITLE
audio: add a Paula filter override and rework the power LED

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -369,6 +369,13 @@ floppy_sounds_volume = 100
 # values narrow it and 0 collapses to mono. Also `--audio-stereo-separation`.
 # stereo_separation = 100
 
+# Paula's analogue low-pass ("power LED") filter. "auto" (default) lets the
+# guest drive it through CIA-A's /LED line, as real hardware does; "on" and
+# "off" force it regardless of the software. Also `--audio-filter`, the runtime
+# Audio Filter menu item, and Cmd/Alt+A. The PWR LED burns brighter while the
+# filter is engaged.
+# audio_filter = "auto"
+
 
 # Host input preferences.
 # [input]

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -612,11 +612,12 @@ impl WebEmu {
             .map_err(js_err)
     }
 
-    /// Power LED, following CIA-A's /LED output like the desktop status
-    /// bar's LED block. The front-panel getters below are cheap enough to
-    /// poll once per animation frame.
+    /// Power LED: true while Paula's analogue filter is engaged (CIA-A's /LED
+    /// output), which the desktop status bar shows as the PWR LED brightness.
+    /// The front-panel getters below are cheap enough to poll once per
+    /// animation frame.
     pub fn power_led(&self) -> bool {
-        self.emu.bus().front_panel_status().power_led_on
+        self.emu.bus().front_panel_status().audio_filter_on
     }
 
     /// Floppy activity LED: lit while any drive's motor runs.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -64,10 +64,11 @@ explicit `[cpu]`/`[chipset]`/`[memory]` sections override a `[machine]`
 profile in a config file.
 
 The audio, serial, parallel, and network surface has matching per-run flags
-too -- `--audio-device`, `--audio-channel-mode`, `--audio-stereo-separation`,
-`--serial`, `--midi-in`, `--midi-out`, `--parallel`, `--sampler-audio-input`,
-`--sampler-input-gain`, `--a2065-net` -- described with their `[audio]`,
-`[serial]`, `[parallel]`, and `[a2065]` keys below.
+too -- `--audio-device`, `--audio-channel-mode`, `--audio-filter`,
+`--audio-stereo-separation`, `--serial`, `--midi-in`, `--midi-out`,
+`--parallel`, `--sampler-audio-input`, `--sampler-input-gain`, `--a2065-net` --
+described with their `[audio]`, `[serial]`, `[parallel]`, and `[a2065]` keys
+below.
 
 ## Top level
 
@@ -476,6 +477,7 @@ floppy_sounds_volume = 100  # 0-100, relative to Paula's output
 # output_enabled = true     # false = no sound (GUI "Disabled"); --audio/--noaudio still win
 channel_mode = "stereo"     # "stereo" (default) or "mono"
 stereo_separation = 100     # 0-100; 100 = hardware panning, 0 = mono
+audio_filter = "auto"       # Paula filter: "auto" (guest-driven), "on", or "off"
 ```
 
 The drive sounds are generated from scratch: motor hum with spin-up/down
@@ -502,6 +504,16 @@ at all (the launcher and runtime-menu "Disabled" option); the `--audio` and
 not change the emulated audio and are not stored in save states. The equivalent
 CLI flags are `--audio-device`, `--audio-channel-mode`, `--audio-stereo-separation`
 and `--list-audio-devices`.
+
+`audio_filter` controls Paula's analogue low-pass filter, the one a
+post-A1000 Amiga switches with the same CIA-A line that drives the power
+LED. `"auto"` (the default) lets the guest engage or bypass it as the
+software asks, matching real hardware; `"on"` and `"off"` force it either
+way as a listener override. Unlike the host-output settings above it is
+part of the emulated audio path, so it also affects WAV capture. Also on
+`--audio-filter`, the runtime **Audio Filter** menu item, and Cmd/Alt+A;
+the status-bar PWR LED is lit whenever the machine is powered and burns
+brighter while the filter is engaged.
 
 On Linux with PipeWire/PulseAudio, individual sinks are not ALSA devices, so
 only the `default`/`pipewire` route is offered; pick the output in the desktop

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -22,6 +22,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+K` | `Alt+K` | Open the [debugger console](../debugger/console) |
 | `Cmd+J` | `Alt+J` | Toggle joystick input mode: gamepad / keyboard (also the status-bar icon) |
 | `Cmd+Shift+A` | `Alt+Shift+A` | Cycle the audio output: Default, each host device, then Disabled (also the menu's Audio Out item) |
+| `Cmd+A` | `Alt+A` | Cycle Paula's audio filter: auto, on, off (also the menu's Audio Filter item) |
 | `Cmd+Shift++` / `Cmd+Shift+-` | `Alt+Shift++` / `Alt+Shift+-` | Raise / lower the parallel-port sampler input gain (only when a sampler is attached; also the menu's Sampler Gain item) |
 | `Cmd+F` | `Alt+F` | Toggle fullscreen on / off |
 | `Cmd+Shift+F` | `Alt+Shift+F` | Show / hide the status bar |
@@ -57,7 +58,9 @@ menu item):
   or plays CD audio (on a machine whose CD drive is a SCSI CD-ROM unit,
   the LED shows CD-DA playback; its data reads ride the HDD LED with the
   rest of the SCSI bus). A small digital counter shows the current floppy
-  track.
+  track. The PWR LED is lit whenever the machine is powered and burns
+  brighter while Paula's analogue filter is engaged, as the real /LED line
+  drives it (see the **Audio Filter** menu item).
 - **Per-drive floppy controls.** Every connected drive gets a disk button
   (marked with the drive number) that opens a file dialog -- multi-select
   several images to queue a swap playlist for that drive -- plus a swap
@@ -133,6 +136,10 @@ tool window or overlay.
   output through the system default, each host output device, and
   **Disabled** (sound off entirely, equivalent to `--noaudio`). The
   device switches live without a restart.
+- **Audio Filter** (also `Cmd+A` / `Alt+A`): cycles Paula's analogue
+  low-pass filter through **auto** (guest-driven, the default), **on**, and
+  **off**. `on`/`off` force it regardless of what the software asks; `auto`
+  restores hardware behaviour. The PWR LED brightens while it is engaged.
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Joystick Input** (also `Cmd+J` / `Alt+J`, or the status-bar icon):
   toggles between gamepad-only and keyboard joystick emulation.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1632,7 +1632,10 @@ impl BusAccounting {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrontPanelStatus {
-    pub power_led_on: bool,
+    /// The Paula analogue low-pass filter is engaged. The PWR LED is lit
+    /// whenever the machine is powered; it burns brighter when this is set, as
+    /// the real /LED line does.
+    pub audio_filter_on: bool,
     pub fdd_led_on: bool,
     pub fdd_track: Option<u8>,
     /// HDD activity LED: None on machines without an IDE port (no Gayle),
@@ -1647,7 +1650,7 @@ pub struct FrontPanelStatus {
 impl Default for FrontPanelStatus {
     fn default() -> Self {
         Self {
-            power_led_on: false,
+            audio_filter_on: false,
             fdd_led_on: false,
             fdd_track: None,
             hdd_led: None,
@@ -3125,9 +3128,8 @@ impl Bus {
     }
 
     pub fn front_panel_status(&self) -> FrontPanelStatus {
-        let pra = self.cia_a.peek_register(REG_PRA);
         FrontPanelStatus {
-            power_led_on: pra & 0x02 == 0,
+            audio_filter_on: self.paula.led_filter_enabled(),
             fdd_led_on: self.floppy.activity_led_on(),
             fdd_track: self.floppy.selected_track(),
             hdd_led: (self.gayle.is_some() || self.ide_a4000.is_some() || self.has_scsi_device())
@@ -4967,7 +4969,7 @@ impl Bus {
             let is_a1000 = !self.mem.wcs.is_empty();
             if !is_a1000 {
                 let pra = self.cia_a.read(REG_PRA);
-                self.paula.set_led_filter_enabled(pra & 0x02 == 0);
+                self.paula.set_led_filter_guest(pra & 0x02 == 0);
             }
             self.cd32_pad_cia_clock();
         }

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -709,7 +709,7 @@ fn real_mode_cpu_bus_advance_ticks_cia_without_double_counting() {
 #[test]
 fn audio_time_flushes_before_audio_register_write() {
     let (mut bus, frames) = empty_bus_with_collect_audio();
-    bus.paula.set_led_filter_enabled(false);
+    bus.paula.set_led_filter_guest(false);
     bus.mem.chip_ram[0] = 0x7F;
     bus.mem.chip_ram[1] = 0x7F;
     bus.mem.chip_ram[2] = 0x7F;
@@ -9215,14 +9215,21 @@ fn bltpri_line_blit_bresenham_cycles_stay_cpu_available_after_warmup() {
 #[test]
 fn front_panel_power_led_follows_cia_a_led_bit() {
     let mut bus = empty_bus();
-    assert!(bus.front_panel_status().power_led_on);
+    // Filter engaged at power-on (the default /LED state).
+    assert!(bus.front_panel_status().audio_filter_on);
+
+    // Drive PA1 (/LED) as an output, as the OS does, so the written level
+    // reaches the pin the filter follows.
+    let ddra = (REG_DDRA as u64) << 8;
+    let _ = bus.cia_a_write(ddra, 1, 0x02);
 
     let pra = (REG_PRA as u64) << 8;
-    let _ = bus.cia_a_write(pra, 1, 0xC3);
-    assert!(!bus.front_panel_status().power_led_on);
-
-    let _ = bus.cia_a_write(pra, 1, 0xC1);
-    assert!(bus.front_panel_status().power_led_on);
+    // Bit 1 high = /LED released = filter bypassed.
+    let _ = bus.cia_a_write(pra, 1, 0x02);
+    assert!(!bus.front_panel_status().audio_filter_on);
+    // Bit 1 low = /LED asserted = filter engaged.
+    let _ = bus.cia_a_write(pra, 1, 0x00);
+    assert!(bus.front_panel_status().audio_filter_on);
 }
 
 #[test]

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -337,6 +337,12 @@ fn default_stereo_separation() -> f32 {
     1.0
 }
 
+/// serde default for `led_filter_guest_on`: the guest's /LED line reads engaged
+/// until it drives it otherwise, matching the power-on default.
+fn default_true() -> bool {
+    true
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Paula {
     pub serper: u16,
@@ -384,7 +390,18 @@ pub struct Paula {
     // time this reaches PAULA_CLOCK_HZ.
     host_sample_acc: u64,
 
+    /// Effective filter state (what the mix actually applies), resolved from
+    /// the mode and the guest's /LED line.
     led_filter_enabled: bool,
+    /// User override: `Auto` follows the guest, `On`/`Off` force it. A host
+    /// preference, skipped and carried across state loads from config like
+    /// mono_output.
+    #[serde(skip)]
+    led_filter_mode: crate::config::AudioFilterMode,
+    /// The guest's request via CIA-A /LED (bit 1 low = engaged); what `Auto`
+    /// follows. Machine state, so it rides the save state.
+    #[serde(default = "default_true")]
+    led_filter_guest_on: bool,
     led_filter: StereoLedFilter,
     output_volume: f32,
     // Host output preference: average L/R into both channels. Not part of the
@@ -463,6 +480,8 @@ impl Paula {
             test_line_cck: 0,
             host_sample_acc: 0,
             led_filter_enabled: true,
+            led_filter_mode: crate::config::AudioFilterMode::Auto,
+            led_filter_guest_on: true,
             led_filter: StereoLedFilter::new(),
             output_volume: 1.0,
             mono_output: false,
@@ -619,12 +638,37 @@ impl Paula {
         self.pot_active = [false; 4];
         self.pot_discharge_lines = 0;
         self.host_sample_acc = 0;
-        self.led_filter_enabled = true;
+        // A reset releases the guest's /LED line; the filter override is a host
+        // preference and stays put.
+        self.led_filter_guest_on = true;
+        self.recompute_led_filter();
         self.led_filter = StereoLedFilter::new();
     }
 
-    pub fn set_led_filter_enabled(&mut self, enabled: bool) {
-        self.led_filter_enabled = enabled;
+    /// Record the guest's /LED line (CIA-A PRA bit 1: true = engaged). Followed
+    /// only in `Auto` mode.
+    pub fn set_led_filter_guest(&mut self, on: bool) {
+        self.led_filter_guest_on = on;
+        self.recompute_led_filter();
+    }
+
+    /// Set the user's filter override (`Auto`/`On`/`Off`).
+    pub fn set_led_filter_mode(&mut self, mode: crate::config::AudioFilterMode) {
+        self.led_filter_mode = mode;
+        self.recompute_led_filter();
+    }
+
+    pub fn led_filter_mode(&self) -> crate::config::AudioFilterMode {
+        self.led_filter_mode
+    }
+
+    fn recompute_led_filter(&mut self) {
+        use crate::config::AudioFilterMode;
+        self.led_filter_enabled = match self.led_filter_mode {
+            AudioFilterMode::On => true,
+            AudioFilterMode::Off => false,
+            AudioFilterMode::Auto => self.led_filter_guest_on,
+        };
     }
 
     /// Publish the emulated-to-host time mapping to the serial sink.
@@ -2067,9 +2111,30 @@ mod tests {
     }
 
     #[test]
+    fn audio_filter_mode_overrides_the_guest_led_line() {
+        use crate::config::AudioFilterMode;
+        let (mut paula, _frames) = paula_with_collect_sink();
+        // Auto follows the guest /LED line.
+        paula.set_led_filter_mode(AudioFilterMode::Auto);
+        paula.set_led_filter_guest(true);
+        assert!(paula.led_filter_enabled());
+        paula.set_led_filter_guest(false);
+        assert!(!paula.led_filter_enabled());
+        // On forces the filter engaged whatever the guest asks.
+        paula.set_led_filter_mode(AudioFilterMode::On);
+        assert!(paula.led_filter_enabled());
+        paula.set_led_filter_guest(false);
+        assert!(paula.led_filter_enabled());
+        // Off forces it bypassed whatever the guest asks.
+        paula.set_led_filter_mode(AudioFilterMode::Off);
+        paula.set_led_filter_guest(true);
+        assert!(!paula.led_filter_enabled());
+    }
+
+    #[test]
     fn audio_capture_tap_mirrors_sink_frames_before_master_volume() {
         let (mut paula, frames) = paula_with_collect_sink();
-        paula.set_led_filter_enabled(false);
+        paula.set_led_filter_guest(false);
         paula.set_output_volume_percent(50);
         let mut ram = vec![0u8; 512 * 1024];
         ram[0] = 0x7F;
@@ -2109,7 +2174,7 @@ mod tests {
     #[test]
     fn large_audio_tick_emits_chronological_samples() {
         let (mut paula, frames) = paula_with_collect_sink();
-        paula.set_led_filter_enabled(false);
+        paula.set_led_filter_guest(false);
         let mut ram = vec![0u8; 512 * 1024];
         ram[0] = 0x7F;
         ram[1] = 0x81;
@@ -2688,7 +2753,7 @@ mod tests {
     #[test]
     fn cd_audio_mute_zeroes_cd_contribution_but_scope_keeps_tracing() {
         let (mut paula, frames) = paula_with_collect_sink();
-        paula.set_led_filter_enabled(false);
+        paula.set_led_filter_guest(false);
         let ram = vec![0u8; 64];
         // One CD-DA sector (2352 bytes = 588 s16le stereo frames) of a
         // constant non-zero level.
@@ -2865,7 +2930,7 @@ mod tests {
         {
             let wav = WavSink::new(&path).expect("create wav sink");
             let mut paula = Paula::new(Box::new(NoopSerial), Box::new(wav));
-            paula.set_led_filter_enabled(false);
+            paula.set_led_filter_guest(false);
             let mut ram = vec![0u8; 64];
             ram[0] = 0x40;
             ram[1] = 0xC0;
@@ -2914,7 +2979,7 @@ mod tests {
         {
             let wav = WavSink::new(&path).expect("create wav sink");
             let mut paula = Paula::new(Box::new(NoopSerial), Box::new(wav));
-            paula.set_led_filter_enabled(false);
+            paula.set_led_filter_guest(false);
 
             for ch_idx in 0..4 {
                 paula.chans[ch_idx].current = 64;
@@ -3310,7 +3375,7 @@ mod tests {
     #[test]
     fn adkcon_attached_source_channel_is_not_mixed_to_dac() {
         let (mut paula, frames) = paula_with_collect_sink();
-        paula.set_led_filter_enabled(false);
+        paula.set_led_filter_guest(false);
         paula.chans[0].current = 127;
         paula.chans[0].audvol = 64;
         paula.chans[1].current = 127;
@@ -3329,7 +3394,7 @@ mod tests {
     fn led_filter_attenuates_high_frequency_output() {
         fn alternating_average(filter_enabled: bool) -> f32 {
             let (mut paula, frames) = paula_with_collect_sink();
-            paula.set_led_filter_enabled(filter_enabled);
+            paula.set_led_filter_guest(filter_enabled);
             paula.chans[0].audvol = 64;
             for i in 0..256 {
                 paula.chans[0].current = if i & 1 == 0 { 127 } else { -127 };
@@ -3397,7 +3462,7 @@ mod tests {
             {
                 let wav = WavSink::new(&path).expect("create wav sink");
                 let mut paula = Paula::new(Box::new(NoopSerial), Box::new(wav));
-                paula.set_led_filter_enabled(filter_enabled);
+                paula.set_led_filter_guest(filter_enabled);
                 paula.chans[0].audvol = 64;
                 for i in 0..256 {
                     paula.chans[0].current = if i & 1 == 0 { 127 } else { -127 };
@@ -3432,7 +3497,7 @@ mod tests {
     #[test]
     fn host_output_volume_scales_mixed_audio_without_changing_audvol() {
         let (mut paula, frames) = paula_with_collect_sink();
-        paula.set_led_filter_enabled(false);
+        paula.set_led_filter_guest(false);
         paula.set_output_volume_percent(50);
         paula.chans[0].current = 64;
         paula.chans[0].audvol = 64;
@@ -3449,7 +3514,7 @@ mod tests {
     #[test]
     fn mono_output_averages_left_and_right_into_both_channels() {
         let (mut paula, frames) = paula_with_collect_sink();
-        paula.set_led_filter_enabled(false);
+        paula.set_led_filter_guest(false);
         paula.set_mono_output(true);
         // Drive only a left channel (0); the right side stays silent, so stereo
         // output would be (0.5, 0.0) and mono is the average, 0.25, in both.
@@ -3468,7 +3533,7 @@ mod tests {
         // Drive left channel only: hardware panning gives (0.5, 0.0).
         let out = |sep: f32| {
             let (mut paula, frames) = paula_with_collect_sink();
-            paula.set_led_filter_enabled(false);
+            paula.set_led_filter_guest(false);
             paula.set_stereo_separation(sep);
             paula.chans[0].current = 64;
             paula.chans[0].audvol = 64;

--- a/src/config.rs
+++ b/src/config.rs
@@ -662,6 +662,38 @@ pub(crate) fn parse_channel_mode(s: &str) -> Result<ChannelMode> {
     }
 }
 
+/// Control over Paula's analogue low-pass ("power LED") filter. `Auto` lets the
+/// guest drive it through CIA-A's /LED line, as real hardware does; `On`/`Off`
+/// force it regardless of what the software asks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum AudioFilterMode {
+    #[default]
+    Auto,
+    On,
+    Off,
+}
+
+impl AudioFilterMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            AudioFilterMode::Auto => "auto",
+            AudioFilterMode::On => "on",
+            AudioFilterMode::Off => "off",
+        }
+    }
+}
+
+pub(crate) fn parse_audio_filter_mode(s: &str) -> Result<AudioFilterMode> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "auto" => Ok(AudioFilterMode::Auto),
+        "on" | "enabled" | "true" => Ok(AudioFilterMode::On),
+        "off" | "disabled" | "false" => Ok(AudioFilterMode::Off),
+        other => {
+            bail!("unknown [audio] audio_filter {other:?}; expected \"auto\", \"on\", or \"off\"")
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AudioConfig {
     /// Synthesized floppy-drive sound effects: motor hum, head-step
@@ -682,6 +714,8 @@ pub struct AudioConfig {
     /// Stereo width, 0-100. 100 keeps the hardware left/right panning (default),
     /// 0 collapses to mono; values between narrow the separation.
     pub stereo_separation: u8,
+    /// Paula's analogue low-pass filter: guest-driven (`Auto`) or forced.
+    pub filter: AudioFilterMode,
 }
 
 impl Default for AudioConfig {
@@ -693,6 +727,7 @@ impl Default for AudioConfig {
             output_enabled: true,
             channel_mode: ChannelMode::Stereo,
             stereo_separation: 100,
+            filter: AudioFilterMode::Auto,
         }
     }
 }
@@ -1360,6 +1395,8 @@ pub struct ConfigOverrides {
     pub audio_device: Option<String>,
     /// Output channel mode (`--audio-channel-mode`): "stereo" or "mono".
     pub audio_channel_mode: Option<String>,
+    /// Paula audio filter mode (`--audio-filter`): "auto", "on", or "off".
+    pub audio_filter: Option<String>,
     /// Stereo separation percent (`--audio-stereo-separation`), 0-100.
     pub audio_stereo_separation: Option<u16>,
     /// Power-on RTC value (`--rtc-time`): Unix seconds or
@@ -1400,6 +1437,7 @@ impl ConfigOverrides {
             && self.sampler_gain.is_none()
             && self.audio_device.is_none()
             && self.audio_channel_mode.is_none()
+            && self.audio_filter.is_none()
             && self.audio_stereo_separation.is_none()
             && self.rtc_time.is_none()
             && self.rtc_frozen.is_none()
@@ -1498,6 +1536,9 @@ impl ConfigOverrides {
         }
         if let Some(mode) = &self.audio_channel_mode {
             raw.audio.channel_mode = Some(mode.clone());
+        }
+        if let Some(filter) = &self.audio_filter {
+            raw.audio.audio_filter = Some(filter.clone());
         }
         if let Some(sep) = self.audio_stereo_separation {
             raw.audio.stereo_separation = Some(sep);
@@ -2052,6 +2093,12 @@ pub(crate) struct RawAudio {
     pub(crate) output_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) channel_mode: Option<String>,
+    // `filter` is accepted as an alias so a config that followed the #278
+    // request (which spelled it `[audio] filter`) still loads under
+    // deny_unknown_fields; `audio_filter` is canonical and matches
+    // `--audio-filter`.
+    #[serde(alias = "filter", skip_serializing_if = "Option::is_none")]
+    pub(crate) audio_filter: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) stereo_separation: Option<u16>,
 }
@@ -2326,6 +2373,16 @@ impl TryFrom<RawConfig> for Config {
                     errors.push(anyhow!("[audio] stereo_separation must be 0-100, got {v}"));
                     defaults.audio.stereo_separation
                 }
+            },
+            filter: match raw.audio.audio_filter.as_deref() {
+                None => defaults.audio.filter,
+                Some(s) => match parse_audio_filter_mode(s) {
+                    Ok(mode) => mode,
+                    Err(e) => {
+                        errors.push(e);
+                        defaults.audio.filter
+                    }
+                },
             },
         };
         let (floppy, floppy_connected, floppy_playlists) = parse_floppy(raw.floppy)?;
@@ -6176,6 +6233,46 @@ mod tests {
         assert_eq!(
             load_overrides(&overrides)?.audio.channel_mode,
             ChannelMode::Mono
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn audio_filter_defaults_to_auto_and_parses() -> Result<()> {
+        assert_eq!(parse_config("")?.audio.filter, AudioFilterMode::Auto);
+        assert_eq!(
+            parse_config("[audio]\naudio_filter = \"on\"\n")?
+                .audio
+                .filter,
+            AudioFilterMode::On
+        );
+        assert_eq!(
+            parse_config("[audio]\naudio_filter = \"OFF\"\n")?
+                .audio
+                .filter,
+            AudioFilterMode::Off
+        );
+        assert_eq!(
+            parse_config("[audio]\naudio_filter = \"disabled\"\n")?
+                .audio
+                .filter,
+            AudioFilterMode::Off
+        );
+        assert!(parse_config("[audio]\naudio_filter = \"sometimes\"\n").is_err());
+        // `filter` is accepted as an alias for `audio_filter`.
+        assert_eq!(
+            parse_config("[audio]\nfilter = \"off\"\n")?.audio.filter,
+            AudioFilterMode::Off
+        );
+
+        // CLI override.
+        let overrides = ConfigOverrides {
+            audio_filter: Some("on".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            load_overrides(&overrides)?.audio.filter,
+            AudioFilterMode::On
         );
         Ok(())
     }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -575,13 +575,16 @@ impl Emulator {
         &mut self,
         load: impl FnOnce(&mut cpu::M68kMachine) -> Result<crate::config::MachineDescriptor>,
     ) -> Result<StateLoadOutcome> {
-        // Channel mode and stereo separation are host preferences, not part of
-        // the saved machine, so carry the current choices across the load.
+        // Channel mode, stereo separation, and the filter override are host
+        // preferences, not part of the saved machine, so carry the current
+        // choices across the load.
         let mono = self.bus_mut().paula.mono_output();
         let separation = self.bus_mut().paula.stereo_separation();
+        let filter = self.bus_mut().paula.led_filter_mode();
         let loaded = load(&mut self.machine)?;
         self.bus_mut().paula.set_mono_output(mono);
         self.bus_mut().paula.set_stereo_separation(separation);
+        self.bus_mut().paula.set_led_filter_mode(filter);
         let reconfigured = loaded != self.descriptor;
         if reconfigured {
             let diffs = self.descriptor.differences(&loaded).join(", ");
@@ -728,14 +731,16 @@ impl Emulator {
     /// coordinate to `pos`. The pacing anchor is re-baselined like a normal
     /// save-state load.
     fn restore_blob(&mut self, blob: &[u8], pos: u64) -> Result<()> {
-        // Preserve host-side channel mode + separation across the restore (see
-        // load_state).
+        // Preserve host-side channel mode, separation, and filter override
+        // across the restore (see load_state).
         let mono = self.bus_mut().paula.mono_output();
         let separation = self.bus_mut().paula.stereo_separation();
+        let filter = self.bus_mut().paula.led_filter_mode();
         let mut cursor = std::io::Cursor::new(blob);
         self.machine.apply_state(&mut cursor)?;
         self.bus_mut().paula.set_mono_output(mono);
         self.bus_mut().paula.set_stereo_separation(separation);
+        self.bus_mut().paula.set_led_filter_mode(filter);
         self.retired_instructions = pos;
         self.reset_live_audio_after_timeline_jump();
         self.reanchor_realtime_clock();
@@ -2042,6 +2047,7 @@ pub fn build_machine(
         .set_volume_percent(cfg.audio.floppy_sounds_volume);
     paula.set_mono_output(cfg.audio.channel_mode.is_mono());
     paula.set_stereo_separation(f32::from(cfg.audio.stereo_separation) / 100.0);
+    paula.set_led_filter_mode(cfg.audio.filter);
     if cfg.audio.channel_mode.is_mono() && cfg.audio.stereo_separation != 100 {
         log::warn!("[audio] stereo_separation is ignored while channel_mode is mono");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,12 @@ where
                         .ok_or_else(|| anyhow!("--audio-channel-mode requires stereo or mono"))?,
                 );
             }
+            "--audio-filter" => {
+                overrides.audio_filter = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--audio-filter requires auto, on, or off"))?,
+                );
+            }
             "--audio-stereo-separation" => {
                 let v = args.next().ok_or_else(|| {
                     anyhow!("--audio-stereo-separation requires a percent (0-100)")
@@ -984,6 +990,7 @@ fn print_help() {
          --noaudio                      disable real-time audio output\n  \
          --audio-device NAME            host audio output device (substring match)\n  \
          --audio-channel-mode MODE      output channels: stereo (default) or mono\n  \
+         --audio-filter MODE            Paula filter: auto (default), on, or off\n  \
          --audio-stereo-separation PCT  stereo width 0-100 (100 default, 0 = mono)\n  \
          --list-audio-devices           list host audio output devices and exit\n  \
          --audio-wav PATH               dump mixed stereo audio to a 32-bit float WAV file\n  \
@@ -1769,7 +1776,7 @@ fn run_live_audio_profile(secs: f32) -> Result<()> {
     // and it always uses the default output device.
     let audio = Box::new(CpalSink::new(priority::requested(false), None)?);
     let mut paula = Paula::new(Box::new(StdoutSink::new()), audio);
-    paula.set_led_filter_enabled(true);
+    paula.set_led_filter_guest(true);
 
     let mut chip_ram = vec![0u8; 64];
     chip_ram[0] = 0x40;

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -145,7 +145,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      an older state would still deserialize - and then run against
 //      different codegen. Bump so it is refused rather than resumed into
 //      a silent divergence (see the wasmtime pin in Cargo.toml)
-pub const STATE_VERSION: u32 = 40;
+//  41: Paula records the guest /LED bit (led_filter_guest_on) apart from the
+//      effective filter state, for the [audio] audio_filter override; the
+//      override mode itself is a host preference and is not serialized
+pub const STATE_VERSION: u32 = 41;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -23,7 +23,7 @@ use crate::bus::PortDevice;
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
-    format_size, machine_profile_defaults, ChannelMode, Chipset, Config, CpuModel,
+    format_size, machine_profile_defaults, AudioFilterMode, ChannelMode, Chipset, Config, CpuModel,
     JoystickInputMode, MachineModel, Overscan, PacingBudget, ParallelDevice, PixelAspect,
     RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, RtgCard, ScsiController,
     SerialMode, WarpSpeed,
@@ -317,6 +317,7 @@ pub enum LauncherField {
     AudioDevice,
     AudioChannelMode,
     AudioStereoSeparation,
+    AudioFilter,
     Overscan,
     PixelAspect,
     Phosphor,
@@ -529,10 +530,11 @@ const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
     row(F::SamplerGain, "Input gain", Cycle),
 ];
 const ETHERNET_ROWS: [Row; 1] = [row(F::Ethernet, "A2065 board", Cycle)];
-const AV_EMULATION_ROWS: [Row; 12] = [
+const AV_EMULATION_ROWS: [Row; 13] = [
     row(F::AudioDevice, "Audio output", Cycle),
     row(F::AudioChannelMode, "Channel mode", Cycle),
     row(F::AudioStereoSeparation, "Stereo separation", Cycle),
+    row(F::AudioFilter, "Audio filter", Cycle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
@@ -735,6 +737,11 @@ const Z3_PRESETS: [usize; 8] = [
 ];
 const OVERSCANS: [Overscan; 2] = [Overscan::Tv, Overscan::Full];
 const PIXEL_ASPECTS: [PixelAspect; 2] = [PixelAspect::Tv, PixelAspect::Square];
+const AUDIO_FILTER_MODES: [AudioFilterMode; 3] = [
+    AudioFilterMode::Auto,
+    AudioFilterMode::On,
+    AudioFilterMode::Off,
+];
 const FLOPPY_SPEEDS: [u16; 5] = [100, 200, 400, 800, crate::floppy::SPEED_TURBO];
 const PACINGS: [PacingBudget; 2] = [PacingBudget::Cycles, PacingBudget::Instructions];
 const WARPS: [WarpSpeed; 5] = [
@@ -918,6 +925,8 @@ pub struct MachineSetup {
     audio_channel_mode: ChannelMode,
     /// Stereo width, 0-100 (100 = full hardware panning).
     audio_stereo_separation: u8,
+    /// Paula analogue filter override: Auto (guest-driven), On, or Off.
+    audio_filter: AudioFilterMode,
     overscan: Overscan,
     pixel_aspect: PixelAspect,
     phosphor: f32,
@@ -1041,6 +1050,7 @@ impl MachineSetup {
             audio_devices: Vec::new(),
             audio_channel_mode: cfg.audio.channel_mode,
             audio_stereo_separation: cfg.audio.stereo_separation,
+            audio_filter: cfg.audio.filter,
             overscan: cfg.overscan,
             pixel_aspect: cfg.pixel_aspect,
             phosphor: cfg.phosphor,
@@ -1390,6 +1400,8 @@ impl MachineSetup {
             .then(|| self.audio_channel_mode.label().to_string());
         raw.audio.stereo_separation = (self.audio_stereo_separation != 100)
             .then_some(u16::from(self.audio_stereo_separation));
+        raw.audio.audio_filter = (self.audio_filter != AudioFilterMode::Auto)
+            .then(|| self.audio_filter.label().to_string());
         // Zorro boards: emit the metadata path plus any per-board overrides
         // (typed per the option schema), only when the user changed something.
         raw.zorro = self
@@ -1608,6 +1620,7 @@ impl MachineSetup {
             // Channel mode and separation shape the output, so they do nothing
             // once audio is disabled; separation also does nothing in mono.
             F::AudioChannelMode => reason(self.audio_output.is_enabled(), "off"),
+            F::AudioFilter => reason(self.audio_output.is_enabled(), "off"),
             F::AudioStereoSeparation => {
                 if !self.audio_output.is_enabled() {
                     Some("off")
@@ -1884,6 +1897,11 @@ impl MachineSetup {
                 ChannelMode::Mono => "Mono".to_string(),
             },
             F::AudioStereoSeparation => format!("{}%", self.audio_stereo_separation),
+            F::AudioFilter => match self.audio_filter {
+                AudioFilterMode::Auto => "Auto".to_string(),
+                AudioFilterMode::On => "Enabled".to_string(),
+                AudioFilterMode::Off => "Disabled".to_string(),
+            },
             F::Filesys0Boot | F::Filesys1Boot | F::Filesys2Boot | F::Filesys3Boot => {
                 let (slot, _) = filesys_slot(field).expect("boot field");
                 match self.filesys_bootpri[slot] {
@@ -2092,6 +2110,9 @@ impl MachineSetup {
                     ChannelMode::Stereo => ChannelMode::Mono,
                     ChannelMode::Mono => ChannelMode::Stereo,
                 }
+            }
+            F::AudioFilter => {
+                self.audio_filter = cycle_slice(&AUDIO_FILTER_MODES, self.audio_filter, forward)
             }
             F::AudioStereoSeparation => {
                 self.audio_stereo_separation = cycle_nearest(
@@ -3553,19 +3574,21 @@ mod tests {
     fn disabled_audio_greys_out_channel_mode_and_separation() {
         use crate::audio::AudioOutput;
         let mut s = MachineSetup::default();
-        // Enabled: channel mode is active, separation active in stereo.
+        // Enabled: channel mode, filter, and separation are all active.
         assert_eq!(s.disabled_reason(LauncherField::AudioChannelMode), None);
+        assert_eq!(s.disabled_reason(LauncherField::AudioFilter), None);
         assert_eq!(
             s.disabled_reason(LauncherField::AudioStereoSeparation),
             None
         );
 
-        // Disabled audio greys both shaping controls.
+        // Disabled audio greys the shaping controls.
         s.audio_output = AudioOutput::Disabled;
         assert_eq!(
             s.disabled_reason(LauncherField::AudioChannelMode),
             Some("off")
         );
+        assert_eq!(s.disabled_reason(LauncherField::AudioFilter), Some("off"));
         assert_eq!(
             s.disabled_reason(LauncherField::AudioStereoSeparation),
             Some("off")

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -92,6 +92,7 @@ pub enum MenuItem {
     Fullscreen,
     StatusBar,
     AudioOutput,
+    AudioFilter,
     Warp,
     WarpLimit,
     Record,
@@ -107,15 +108,16 @@ pub enum MenuItem {
 /// sampler is attached, so the list is built per open rather than fixed.
 pub fn menu_items(midi_active: bool, sampler_active: bool) -> Vec<MenuItem> {
     let _ = midi_active;
-    // 9 leading + up to 2 MIDI + 2 sampler + pixel aspect + floppy speed +
-    // 11 trailing items = 26, sized so appending never reallocates.
-    let mut items = Vec::with_capacity(26);
+    // 10 leading + up to 2 MIDI + 2 sampler + pixel aspect + floppy speed +
+    // 11 trailing items = 27, sized so appending never reallocates.
+    let mut items = Vec::with_capacity(27);
     items.extend([
         MenuItem::MachineConfig,
         MenuItem::FrameAnalyzer,
         MenuItem::Debugger,
         MenuItem::Console,
         MenuItem::AudioOutput,
+        MenuItem::AudioFilter,
         MenuItem::Calibration,
         MenuItem::JoystickInput,
         MenuItem::Port1Device,
@@ -174,6 +176,9 @@ pub struct MenuLabels<'a> {
     /// Current audio output label: "Default", a device name, or "Disabled"
     /// (empty is treated as "Default").
     pub audio_output: &'a str,
+    /// Current Paula filter override (Auto/On/Off), shown on the Audio Filter
+    /// item.
+    pub audio_filter: crate::config::AudioFilterMode,
     /// Current sampler input device name (empty is treated as "Default") and
     /// gain label (e.g. "2x"); only shown when a sampler is attached.
     pub sampler_input: &'a str,
@@ -217,6 +222,14 @@ fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
                 s.audio_output
             };
             format!("Audio Out [{}]", clip_menu_value(name))
+        }
+        MenuItem::AudioFilter => {
+            let value = match s.audio_filter {
+                crate::config::AudioFilterMode::Auto => "auto",
+                crate::config::AudioFilterMode::On => "on",
+                crate::config::AudioFilterMode::Off => "off",
+            };
+            format!("Audio Filter {:>7}", format!("[{value}]"))
         }
         MenuItem::SamplerInput => {
             let name = if s.sampler_input.is_empty() {
@@ -4928,8 +4941,9 @@ mod tests {
             Some(UiControl::MenuItem(MenuItem::MachineConfig))
         );
         // Leading block is MachineConfig, FrameAnalyzer, Debugger, Console,
-        // AudioOutput, Calibration, so Joystick Input sits at index 6.
-        let joystick = menu_item_rect(6, n);
+        // AudioOutput, AudioFilter, Calibration, so Joystick Input sits at
+        // index 7.
+        let joystick = menu_item_rect(7, n);
         let pos = (joystick.x as i32 + 4, joystick.y as i32 + 4);
         assert_eq!(
             ui.control_at(pos, false, false),
@@ -4959,6 +4973,7 @@ mod tests {
             midi_in: "",
             midi_out: "",
             audio_output: "",
+            audio_filter: crate::config::AudioFilterMode::Auto,
             sampler_input: "",
             sampler_gain: "",
         };
@@ -4992,6 +5007,7 @@ mod tests {
             midi_in: "",
             midi_out: "",
             audio_output: "",
+            audio_filter: crate::config::AudioFilterMode::Auto,
             sampler_input: "",
             sampler_gain: "",
         };
@@ -5049,6 +5065,7 @@ mod tests {
                                         midi_in: long,
                                         midi_out: long,
                                         audio_output: long,
+                                        audio_filter: crate::config::AudioFilterMode::Auto,
                                         sampler_input: long,
                                         sampler_gain: "-24 dB",
                                     };
@@ -5604,6 +5621,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -5653,6 +5671,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -5690,6 +5709,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -5743,6 +5763,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -5820,6 +5841,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -5884,6 +5906,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -5945,6 +5968,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6007,6 +6031,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6122,6 +6147,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6197,6 +6223,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6283,6 +6310,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6407,6 +6435,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6460,6 +6489,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6504,6 +6534,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6588,6 +6619,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6639,6 +6671,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6683,6 +6716,7 @@ mod tests {
                 midi_in: "",
                 midi_out: "",
                 audio_output: "",
+                audio_filter: crate::config::AudioFilterMode::Auto,
                 sampler_input: "",
                 sampler_gain: "",
             },
@@ -6731,6 +6765,7 @@ mod tests {
             midi_in: "",
             midi_out: "",
             audio_output: "",
+            audio_filter: crate::config::AudioFilterMode::Auto,
             sampler_input: "",
             sampler_gain: "",
         };

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -394,7 +394,12 @@ const STATUS_TOP: u32 = rgba(78, 76, 70);
 const STATUS_BOTTOM: u32 = rgba(12, 12, 11);
 const LED_BEZEL_DARK: u32 = rgba(8, 8, 7);
 const LED_BEZEL_LIGHT: u32 = rgba(78, 76, 68);
-const POWER_LED_ON: u32 = rgba(232, 31, 24);
+// The power LED is lit whenever the machine is powered. POWER_LED_NORMAL is the
+// resting lit red (the filter bypassed, its usual state); it burns to a more
+// intense POWER_LED_BRIGHT while Paula's analogue filter is engaged, as the real
+// /LED line drives it. POWER_LED_OFF is the unpowered bezel.
+const POWER_LED_BRIGHT: u32 = rgba(255, 38, 28);
+const POWER_LED_NORMAL: u32 = rgba(232, 31, 24);
 const POWER_LED_OFF: u32 = rgba(66, 12, 10);
 const FDD_LED_ON: u32 = rgba(236, 142, 28);
 const FDD_LED_OFF: u32 = rgba(72, 38, 10);
@@ -1408,6 +1413,25 @@ impl App {
         self.show_osd(format!("Audio output: {}", self.audio_output.label()));
     }
 
+    /// Cycle Paula's analogue filter override: Auto (guest-driven) -> On -> Off.
+    /// Applies live and updates the PWR LED brightness on the next redraw.
+    fn cycle_audio_filter(&mut self) {
+        use crate::config::AudioFilterMode;
+        let next = match self.emu.bus().paula.led_filter_mode() {
+            AudioFilterMode::Auto => AudioFilterMode::On,
+            AudioFilterMode::On => AudioFilterMode::Off,
+            AudioFilterMode::Off => AudioFilterMode::Auto,
+        };
+        self.emu.bus_mut().paula.set_led_filter_mode(next);
+        let label = match next {
+            AudioFilterMode::Auto => "Auto",
+            AudioFilterMode::On => "Enabled",
+            AudioFilterMode::Off => "Disabled",
+        };
+        self.show_osd(format!("Audio filter: {label}"));
+        self.request_redraw();
+    }
+
     /// Step the live sampler input through "Default" then the host capture
     /// devices, rebuilding the capture so the change takes effect at once.
     /// Re-reads the device list so a just-connected device appears. A no-op when
@@ -2172,6 +2196,16 @@ impl ApplicationHandler for App {
                             self.cycle_audio_output()
                         }
                     }
+                    (KeyCode::KeyA, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers) =>
+                    {
+                        // Cycle Paula's analogue filter (auto -> on -> off),
+                        // the counterpart to Cmd/Alt+Shift+A. Ignored while a
+                        // menu or panel is open.
+                        if !self.modal_ui_active() {
+                            self.cycle_audio_filter()
+                        }
+                    }
                     (KeyCode::Equal, ElementState::Pressed)
                         if host_shortcut_modifier_pressed(self.modifiers)
                             && self.modifiers.shift_key() =>
@@ -2551,6 +2585,7 @@ impl ApplicationHandler for App {
                             midi_in: &midi_in_label,
                             midi_out: &midi_out_label,
                             audio_output: self.audio_output.label(),
+                            audio_filter: self.emu.bus().paula.led_filter_mode(),
                             sampler_input: &sampler_input_label,
                             sampler_gain: &sampler_gain_label,
                         },
@@ -3533,6 +3568,7 @@ impl App {
                     ui::MenuItem::PixelAspect => self.toggle_pixel_aspect(),
                     ui::MenuItem::FloppySpeed => self.cycle_floppy_speed(),
                     ui::MenuItem::AudioOutput => self.cycle_audio_output(),
+                    ui::MenuItem::AudioFilter => self.cycle_audio_filter(),
                     ui::MenuItem::Fullscreen => self.toggle_fullscreen(),
                     ui::MenuItem::StatusBar => self.toggle_status_bar(),
                     ui::MenuItem::Warp => self.toggle_warp(),

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -355,11 +355,21 @@ pub(super) struct LedRowSpec {
 pub(super) fn led_rows(status: &FrontPanelStatus, powered_on: bool) -> Vec<LedRowSpec> {
     let mut rows = vec![
         LedRowSpec {
+            // Lit whenever powered, like a real Amiga; brighter when Paula's
+            // analogue filter is engaged.
             label: "PWR",
-            on: powered_on && status.power_led_on,
-            on_color: POWER_LED_ON,
+            on: powered_on,
+            on_color: if status.audio_filter_on {
+                POWER_LED_BRIGHT
+            } else {
+                POWER_LED_NORMAL
+            },
             off_color: POWER_LED_OFF,
-            highlight_on: rgba(255, 91, 82),
+            highlight_on: if status.audio_filter_on {
+                rgba(255, 120, 108)
+            } else {
+                rgba(255, 91, 82)
+            },
             highlight_off: rgba(90, 27, 24),
         },
         LedRowSpec {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -22,10 +22,11 @@ use super::{
     StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT,
     AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY,
     CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON,
-    HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_OFF, POWER_LED_ON,
-    STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-    TRACK_SEGMENT_ON, TV_PAL_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT, TV_PAL_PRESENT_SOURCE_X,
-    TV_PAL_PRESENT_SOURCE_Y, TV_PAL_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
+    HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL,
+    POWER_LED_OFF, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG,
+    TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, TV_PAL_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
+    TV_PAL_PRESENT_SOURCE_X, TV_PAL_PRESENT_SOURCE_Y, TV_PAL_PRESENT_WIDTH, VOLUME_FILL,
+    VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
@@ -789,7 +790,7 @@ fn status_bar_draws_power_and_fdd_led_states() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: false,
                 fdd_track: Some(5),
                 hdd_led: None,
@@ -806,7 +807,7 @@ fn status_bar_draws_power_and_fdd_led_states() {
     let fdd = led_row_rect(1, 2);
     assert_eq!(
         pixel(&frame, power.x + power.w / 2, power.y + power.h / 2, scale),
-        POWER_LED_ON.to_le_bytes()
+        POWER_LED_BRIGHT.to_le_bytes()
     );
     assert_eq!(
         pixel(&frame, fdd.x + fdd.w / 2, fdd.y + fdd.h / 2, scale),
@@ -832,7 +833,7 @@ fn status_bar_draws_power_and_fdd_led_states() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: false,
+                audio_filter_on: false,
                 fdd_led_on: true,
                 fdd_track: Some(42),
                 hdd_led: None,
@@ -851,6 +852,39 @@ fn status_bar_draws_power_and_fdd_led_states() {
 }
 
 #[test]
+fn power_led_is_lit_normal_or_bright_by_the_audio_filter() {
+    let scale = 1;
+    let power = led_row_rect(0, 2);
+    let center = |frame: &[u8]| pixel(frame, power.x + power.w / 2, power.y + power.h / 2, scale);
+    let render = |filter_on: bool, powered: bool| {
+        let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+        draw_status_bar(
+            &mut frame,
+            &view(
+                FrontPanelStatus {
+                    audio_filter_on: filter_on,
+                    fdd_led_on: false,
+                    fdd_track: Some(0),
+                    hdd_led: None,
+                    cd_led: None,
+                    output_volume_percent: 100,
+                },
+                powered,
+                false,
+            ),
+            scale,
+        );
+        center(&frame)
+    };
+    // Powered: lit at the normal red when bypassed, a more intense red when
+    // the filter is engaged.
+    assert_eq!(render(true, true), POWER_LED_BRIGHT.to_le_bytes());
+    assert_eq!(render(false, true), POWER_LED_NORMAL.to_le_bytes());
+    // Unpowered: dark regardless of the filter state.
+    assert_eq!(render(true, false), POWER_LED_OFF.to_le_bytes());
+}
+
+#[test]
 fn status_bar_extinguishes_power_led_when_host_power_is_off() {
     let scale = 1;
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
@@ -858,7 +892,7 @@ fn status_bar_extinguishes_power_led_when_host_power_is_off() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: false,
                 fdd_track: Some(0),
                 hdd_led: None,
@@ -907,7 +941,7 @@ fn status_bar_power_button_glyph_tracks_power_state() {
             &mut frame,
             &view(
                 FrontPanelStatus {
-                    power_led_on: powered_on,
+                    audio_filter_on: powered_on,
                     fdd_led_on: false,
                     fdd_track: Some(0),
                     hdd_led: None,
@@ -1011,7 +1045,7 @@ fn status_bar_pause_button_glyph_tracks_pause_state() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: false,
                 fdd_track: Some(0),
                 hdd_led: None,
@@ -1032,7 +1066,7 @@ fn status_bar_pause_button_glyph_tracks_pause_state() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: false,
                 fdd_track: Some(0),
                 hdd_led: None,
@@ -1055,7 +1089,7 @@ fn status_bar_draws_disk_image_button_next_to_track_counter() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: true,
                 fdd_track: Some(5),
                 hdd_led: None,
@@ -1298,7 +1332,7 @@ fn status_bar_draws_volume_control_and_maps_pointer_position() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: true,
                 fdd_track: Some(5),
                 hdd_led: None,
@@ -1328,7 +1362,7 @@ fn status_bar_latches_fdd_track_when_no_drive_is_selected() {
     let mut last_fdd_track = None;
     let status = status_with_latched_fdd_track(
         FrontPanelStatus {
-            power_led_on: true,
+            audio_filter_on: true,
             fdd_led_on: true,
             fdd_track: Some(42),
             hdd_led: None,
@@ -1342,7 +1376,7 @@ fn status_bar_latches_fdd_track_when_no_drive_is_selected() {
 
     let status = status_with_latched_fdd_track(
         FrontPanelStatus {
-            power_led_on: true,
+            audio_filter_on: true,
             fdd_led_on: false,
             fdd_track: None,
             hdd_led: None,
@@ -1363,7 +1397,7 @@ fn status_bar_draws_at_hidpi_texture_scale() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                power_led_on: true,
+                audio_filter_on: true,
                 fdd_led_on: true,
                 fdd_track: Some(159),
                 hdd_led: None,
@@ -1384,7 +1418,7 @@ fn status_bar_draws_at_hidpi_texture_scale() {
             (power.y + power.h / 2) * scale,
             scale
         ),
-        POWER_LED_ON.to_le_bytes()
+        POWER_LED_BRIGHT.to_le_bytes()
     );
     let ones = fdd_track_digit_rect(2);
     assert_eq!(


### PR DESCRIPTION
This adds control over Paula's analogue low-pass filter — the "power LED" filter that a post-A1000 Amiga switches with the same CIA-A line that drives the power LED — closing part of the request in #278.

Until now the filter could only follow the guest's /LED line. There's now an override with three modes: `auto` (the default — guest-driven, exactly as before), `on`, and `off`. `on`/`off` force the filter either way regardless of what the software asks, as a listener override; `auto` restores hardware behaviour. Internally Paula tracks the guest's /LED bit separately from the override and resolves the effective state from the two. The override is a host preference rather than machine state, so it survives a reset, and because it sits on the emulated audio path it applies to WAV capture as well as live output.

It's reachable everywhere the other audio settings are: `[audio] filter = "auto"|"on"|"off"`, the `--audio-filter` flag, an "Audio filter" row on the A/V & Emu launcher page, an "Audio Filter" item in the runtime menu next to Audio Out, and a new `Cmd/Alt+A` shortcut that cycles the three modes live — the counterpart to `Cmd/Alt+Shift+A` for the audio device.

While here, the status-bar PWR LED is reworked slightly to behave more like a real Amiga's. It was only lit while the filter was engaged, so a program that bypasses the filter (a tracker like OctaMED with its filter off) made the LED look off. It's now lit whenever the machine is powered, at a normal red that burns brighter when the filter is engaged — matching how the real /LED line drives it. A guest that toggles the line rapidly (a crash flash) now flashes between the two lit shades rather than blinking off.

The save-state format version is bumped for the two new Paula fields. New tests cover the override resolution, the PWR LED's normal/bright/off states, config parsing, and the CIA-follows-/LED path. Full test suite, clippy, and fmt are clean.

<img width="720" height="616" alt="Screenshot 2026-07-25 at 14 39 29" src="https://github.com/user-attachments/assets/d0854f96-1432-4e3b-a7b8-f13027936b07" />
<img width="717" height="613" alt="Screenshot 2026-07-25 at 14 38 45" src="https://github.com/user-attachments/assets/d0dbafb4-fefd-4af8-a8de-b3c0b5c6d10e" />
<img width="720" height="614" alt="Screenshot 2026-07-25 at 14 38 41" src="https://github.com/user-attachments/assets/32861537-e731-42b6-aa3d-f5dcb19f22ad" />
<img width="720" height="614" alt="Screenshot 2026-07-25 at 14 41 21" src="https://github.com/user-attachments/assets/85276f6f-dd82-465a-86db-3a87e9d85831" />
<img width="720" height="615" alt="Screenshot 2026-07-25 at 14 41 54" src="https://github.com/user-attachments/assets/d1973843-ea58-4aa4-9e9f-a9d3570e44ed" />
