### PR TITLE
window: persist fullscreen and status-bar visibility in the config

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -333,10 +333,16 @@ video = "PAL"
 # pixel-exact comparison against square-pixel emulators). phosphor: CRT
 # persistence fraction (0.0-0.95, default 0.0): fuses field-rate
 # flicker/dither like a real tube at the cost of a slight motion trail.
+# full_screen: open the window fullscreen at start (default false; also
+# --full-screen / --windowed, and Cmd/Alt+F toggles it live).
+# status_bar: show the status bar at start (default true; also
+# --show-status-bar / --hide-status-bar, and Cmd/Alt+Shift+F toggles it live).
 # [display]
 # overscan = "tv"
 # pixel_aspect = "tv"
 # phosphor = 0.4
+# full_screen = false
+# status_bar = true
 
 
 [audio]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -50,6 +50,8 @@ range checks as the equivalent TOML fields:
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 | `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
 | `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
+| `--full-screen` / `--windowed` | `[display] full_screen` | open fullscreen or windowed at start (default windowed) |
+| `--show-status-bar` / `--hide-status-bar` | `[display] status_bar` | status bar at start (default shown) |
 
 For example, to boot a stock A1200 profile but with 8 MB of fast RAM and a
 faster CPU, with no config file at all:
@@ -429,6 +431,8 @@ recorded in [](../internals/chipset)).
 overscan = "tv"      # "tv" (default) or "full"
 pixel_aspect = "tv"  # "tv" (default, 4:3 CRT) or "square" (exact 2x2 lo-res)
 phosphor = 0.0       # CRT persistence fraction, 0.0 (off) to 0.95
+full_screen = false  # open fullscreen at start (default false)
+status_bar = true    # show the status bar at start (default true)
 ```
 
 The emulated framebuffer always carries the full overscan field Denise
@@ -460,6 +464,16 @@ around `0.3`-`0.5`,
 at the cost of a slight motion trail. Off by default so screenshots and
 frame dumps stay frame-exact. `COPPERLINE_PHOSPHOR=0.4` overrides the
 config for a single run.
+
+`full_screen` opens the window fullscreen at start (borderless), and
+`status_bar` chooses whether the status bar starts visible. Both are start-up
+preferences; the runtime toggles -- `Cmd+F` / `Alt+F` for fullscreen and
+`Cmd+Shift+F` / `Alt+Shift+F` for the status bar, plus their menu items --
+still flip either live without changing the saved value. On the command line
+`--full-screen` / `--windowed` set the fullscreen state and `--show-status-bar` /
+`--hide-status-bar` set the status bar; the launcher's A/V & Emu page has
+*Start fullscreen* and *Status bar* toggles for the same. Left unset they keep
+the defaults: windowed, status bar shown.
 
 Rendering completed frames uses a worker thread by default so emulation can
 advance while the previous frame is painted. The worker is an implementation

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,14 @@ pub struct Config {
     /// decay that fuses field-rate dither and interlace flicker on a
     /// real CRT.
     pub phosphor: f32,
+    /// Open the window in fullscreen at start (`[display] full_screen`, or
+    /// `--full-screen` / `--windowed`). The `Cmd+F` / `Alt+F` toggle flips it
+    /// live without affecting this start-up value.
+    pub full_screen: bool,
+    /// Show the status bar at start (`[display] status_bar`, or
+    /// `--show-status-bar` / `--hide-status-bar`). `Cmd+Shift+F` /
+    /// `Alt+Shift+F` toggles it live.
+    pub status_bar: bool,
     /// Initial host input source for the emulated joystick/CD32-pad port
     /// (`[input] joystick` / `--joystick`). Defaults to
     /// [`JoystickInputMode::Gamepad`]; the runtime status-bar toggle, `Cmd+J` /
@@ -1212,6 +1220,8 @@ impl Default for Config {
             overscan: Overscan::Tv,
             pixel_aspect: PixelAspect::Tv,
             phosphor: 0.0,
+            full_screen: false,
+            status_bar: true,
             joystick_input_mode: JoystickInputMode::Gamepad,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
@@ -1408,6 +1418,12 @@ pub struct ConfigOverrides {
     /// A2065 Ethernet backend (`--a2065-net`): "none", "loopback", or "nat".
     /// Same parser as `[a2065] net`; setting it fits the board.
     pub a2065_net: Option<String>,
+    /// Open fullscreen at start (`--full-screen` / `--windowed`). Same as
+    /// `[display] full_screen`.
+    pub full_screen: Option<bool>,
+    /// Show the status bar at start (`--show-status-bar` /
+    /// `--hide-status-bar`). Same as `[display] status_bar`.
+    pub status_bar: Option<bool>,
 }
 
 impl ConfigOverrides {
@@ -1442,6 +1458,8 @@ impl ConfigOverrides {
             && self.rtc_time.is_none()
             && self.rtc_frozen.is_none()
             && self.a2065_net.is_none()
+            && self.full_screen.is_none()
+            && self.status_bar.is_none()
     }
 
     /// Inject the set overrides into the raw config, replacing the values
@@ -1554,6 +1572,12 @@ impl ConfigOverrides {
         if let Some(net) = &self.a2065_net {
             raw.a2065.net = Some(net.clone());
         }
+        if let Some(full_screen) = self.full_screen {
+            raw.display.full_screen = Some(full_screen);
+        }
+        if let Some(status_bar) = self.status_bar {
+            raw.display.status_bar = Some(status_bar);
+        }
     }
 }
 
@@ -1653,6 +1677,12 @@ pub(crate) struct RawDisplay {
     /// CRT phosphor persistence fraction, 0.0 (off, default) to 0.95.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) phosphor: Option<f32>,
+    /// Open fullscreen at start (default false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) full_screen: Option<bool>,
+    /// Show the status bar at start (default true).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) status_bar: Option<bool>,
 }
 
 /// One `[[filesys]]` entry (experimental): a host directory exported to the
@@ -2404,6 +2434,8 @@ impl TryFrom<RawConfig> for Config {
                 defaults.phosphor
             }
         };
+        let full_screen = raw.display.full_screen.unwrap_or(defaults.full_screen);
+        let status_bar = raw.display.status_bar.unwrap_or(defaults.status_bar);
         let joystick_input_mode = match raw.input.joystick.as_deref() {
             None => defaults.joystick_input_mode,
             Some(s) => parse_joystick_input_mode(s)?,
@@ -2794,6 +2826,8 @@ impl TryFrom<RawConfig> for Config {
             overscan,
             pixel_aspect,
             phosphor,
+            full_screen,
+            status_bar,
             joystick_input_mode,
             port_devices,
             serial,
@@ -4258,6 +4292,29 @@ mod tests {
             "#,
         )?;
         assert!(!cfg.emulation.power_on);
+        Ok(())
+    }
+
+    #[test]
+    fn display_fullscreen_and_status_bar_default_and_parse() -> Result<()> {
+        // Defaults: windowed, status bar shown.
+        let cfg = parse_config("")?;
+        assert!(!cfg.full_screen);
+        assert!(cfg.status_bar);
+
+        let cfg = parse_config("[display]\nfull_screen = true\nstatus_bar = false\n")?;
+        assert!(cfg.full_screen);
+        assert!(!cfg.status_bar);
+
+        // CLI overrides.
+        let overrides = ConfigOverrides {
+            full_screen: Some(true),
+            status_bar: Some(false),
+            ..Default::default()
+        };
+        let cfg = load_overrides(&overrides)?;
+        assert!(cfg.full_screen);
+        assert!(!cfg.status_bar);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,18 @@ where
             "--no-fpu" => {
                 overrides.fpu = Some(false);
             }
+            "--full-screen" => {
+                overrides.full_screen = Some(true);
+            }
+            "--windowed" => {
+                overrides.full_screen = Some(false);
+            }
+            "--show-status-bar" => {
+                overrides.status_bar = Some(true);
+            }
+            "--hide-status-bar" => {
+                overrides.status_bar = Some(false);
+            }
             "--cpu-clock" => {
                 let mhz: f64 = next_arg(
                     &mut args,
@@ -997,6 +1009,8 @@ fn print_help() {
          \x20                            instead of live output\n  \
          --profile-live-audio SECS      run a no-window Paula-to-cpal profile workload;\n  \
          \x20                            combine with COPPERLINE_AUDIO_PROFILE=1 for counters\n  \
+         --full-screen / --windowed     open fullscreen / windowed at start (default: windowed)\n  \
+         --show-status-bar / --hide-status-bar  status bar at start (default: shown)\n  \
          --serial MODE                  Paula serial port: off, stdout, midi, tcp,\n  \
          \x20                            tcp-connect, or pty\n  \
          --serial-connect HOST:PORT     dial a remote TCP service (a telnet BBS) with the\n  \
@@ -1619,6 +1633,8 @@ fn main() -> Result<()> {
         disk_write_protected,
         config::resolve_overscan(cfg.overscan),
         config::resolve_phosphor(cfg.phosphor),
+        cfg.full_screen,
+        !cfg.status_bar,
         cfg.emulation.warp_speed,
         cfg.joystick_input_mode,
         config::about_machine_lines(&cfg),
@@ -1727,6 +1743,9 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         [true; 4],
         config::resolve_overscan(config::Overscan::Tv),
         config::resolve_phosphor(0.0),
+        // The config-screen placeholder is always a normal windowed UI.
+        false,
+        false,
         config::WarpSpeed::default(),
         config::JoystickInputMode::default(),
         vec!["Configure a machine, then press Run.".to_string()],

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -321,6 +321,8 @@ pub enum LauncherField {
     Overscan,
     PixelAspect,
     Phosphor,
+    StartFullscreen,
+    ShowStatusBar,
     FloppySounds,
     FloppyVolume,
     PowerOn,
@@ -530,7 +532,7 @@ const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
     row(F::SamplerGain, "Input gain", Cycle),
 ];
 const ETHERNET_ROWS: [Row; 1] = [row(F::Ethernet, "A2065 board", Cycle)];
-const AV_EMULATION_ROWS: [Row; 13] = [
+const AV_EMULATION_ROWS: [Row; 15] = [
     row(F::AudioDevice, "Audio output", Cycle),
     row(F::AudioChannelMode, "Channel mode", Cycle),
     row(F::AudioStereoSeparation, "Stereo separation", Cycle),
@@ -538,6 +540,8 @@ const AV_EMULATION_ROWS: [Row; 13] = [
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
+    row(F::StartFullscreen, "Start fullscreen", Toggle),
+    row(F::ShowStatusBar, "Status bar", Toggle),
     row(F::FloppySounds, "Floppy sounds", Toggle),
     row(F::FloppyVolume, "Floppy volume", Cycle),
     row(F::PowerOn, "Power on at start", Toggle),
@@ -930,6 +934,10 @@ pub struct MachineSetup {
     overscan: Overscan,
     pixel_aspect: PixelAspect,
     phosphor: f32,
+    /// Open fullscreen at start ([display] full_screen).
+    start_fullscreen: bool,
+    /// Show the status bar at start ([display] status_bar).
+    show_status_bar: bool,
     floppy_sounds: bool,
     floppy_volume: u8,
     power_on: bool,
@@ -1054,6 +1062,8 @@ impl MachineSetup {
             overscan: cfg.overscan,
             pixel_aspect: cfg.pixel_aspect,
             phosphor: cfg.phosphor,
+            start_fullscreen: cfg.full_screen,
+            show_status_bar: cfg.status_bar,
             floppy_sounds: cfg.audio.floppy_sounds,
             floppy_volume: cfg.audio.floppy_sounds_volume,
             power_on: cfg.emulation.power_on,
@@ -1323,6 +1333,12 @@ impl MachineSetup {
         if (self.phosphor - base.phosphor).abs() > 1e-6 {
             raw.display.phosphor = Some(self.phosphor);
         }
+        if self.start_fullscreen != base.full_screen {
+            raw.display.full_screen = Some(self.start_fullscreen);
+        }
+        if self.show_status_bar != base.status_bar {
+            raw.display.status_bar = Some(self.show_status_bar);
+        }
         if self.floppy_sounds != base.audio.floppy_sounds {
             raw.audio.floppy_sounds = Some(self.floppy_sounds);
         }
@@ -1491,6 +1507,8 @@ impl MachineSetup {
         self.overscan = base.overscan;
         self.pixel_aspect = base.pixel_aspect;
         self.phosphor = base.phosphor;
+        self.start_fullscreen = base.full_screen;
+        self.show_status_bar = base.status_bar;
         self.floppy_sounds = base.audio.floppy_sounds;
         self.floppy_volume = base.audio.floppy_sounds_volume;
         self.power_on = base.emulation.power_on;
@@ -1645,6 +1663,8 @@ impl MachineSetup {
             F::Df2WriteProtect => self.df_write_protected[2],
             F::Df3WriteProtect => self.df_write_protected[3],
             F::FloppySounds => self.floppy_sounds,
+            F::StartFullscreen => self.start_fullscreen,
+            F::ShowStatusBar => self.show_status_bar,
             F::PowerOn => self.power_on,
             F::RealtimePriority => self.realtime_priority,
             _ => false,
@@ -2145,6 +2165,8 @@ impl MachineSetup {
             F::Df2WriteProtect => self.df_write_protected[2] = !self.df_write_protected[2],
             F::Df3WriteProtect => self.df_write_protected[3] = !self.df_write_protected[3],
             F::FloppySounds => self.floppy_sounds = !self.floppy_sounds,
+            F::StartFullscreen => self.start_fullscreen = !self.start_fullscreen,
+            F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
             F::PowerOn => self.power_on = !self.power_on,
             F::RealtimePriority => self.realtime_priority = !self.realtime_priority,
             _ => {}
@@ -3568,6 +3590,24 @@ mod tests {
             s.disabled_reason(LauncherField::AudioStereoSeparation),
             Some("mono")
         );
+    }
+
+    #[test]
+    fn display_start_toggles_round_trip_through_raw_config() {
+        let mut s = MachineSetup::default();
+        // Defaults (windowed, status bar shown) emit nothing.
+        let raw = s.to_raw();
+        assert_eq!(raw.display.full_screen, None);
+        assert_eq!(raw.display.status_bar, None);
+        assert!(!s.toggle_value(LauncherField::StartFullscreen));
+        assert!(s.toggle_value(LauncherField::ShowStatusBar));
+
+        // Flip both; the non-default values now persist to [display].
+        s.toggle(LauncherField::StartFullscreen);
+        s.toggle(LauncherField::ShowStatusBar);
+        let raw = s.to_raw();
+        assert_eq!(raw.display.full_screen, Some(true));
+        assert_eq!(raw.display.status_bar, Some(false));
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -727,6 +727,10 @@ pub struct App {
     /// Presentation-level overscan handling ([display] overscan): Tv masks
     /// the deep-overscan margins with black like a CRT bezel.
     overscan: Overscan,
+    /// Open the window fullscreen when it is first created ([display]
+    /// full_screen). Applied once in `resumed`; the runtime toggle takes over
+    /// after that.
+    start_fullscreen: bool,
     /// Host USB gamepad reader (pure-Rust, no SDL2), mapped to the emulated
     /// port-2 digital joystick via a per-pad calibration. A no-op when no
     /// input backend is available (e.g. headless CI) or the pad is not yet
@@ -1000,6 +1004,8 @@ impl App {
         disk_write_protected: [bool; 4],
         overscan: Overscan,
         phosphor: f32,
+        start_fullscreen: bool,
+        hide_status_bar: bool,
         warp_speed: WarpSpeed,
         joystick_input_mode: JoystickInputMode,
         about_machine_lines: Vec<String>,
@@ -1012,6 +1018,10 @@ impl App {
         // placeholder; run_machine re-derives it from the launcher's config).
         sampler: crate::sampler::SamplerRequest,
     ) -> Self {
+        // The status-bar visibility is a process-global read from deep in the
+        // presentation code; seed it before the window is built so the initial
+        // window size accounts for it.
+        super::set_status_bar_hidden(hide_status_bar);
         // Headless capture runs drive themselves off emulated time, so a
         // powered-off start would simply hang. Force power on for those.
         let powered_on = power_on
@@ -1129,6 +1139,7 @@ impl App {
             disk_playlist_index: [0; 4],
             hcenter: hcenter_enabled(),
             overscan,
+            start_fullscreen,
             gamepad: crate::gamepad::GamepadReader::new(),
             joystick_input_mode,
             warp_speed,
@@ -1980,10 +1991,15 @@ impl ApplicationHandler for App {
         // advance as fast as the host allows. Emulated state is identical.
         let headless_capture =
             self.pending_auto_shot.is_some() || self.pending_frame_dump.is_some();
+        // Start fullscreen only for an interactive window ([display] full_screen
+        // / --full-screen); a headless capture window stays hidden and windowed.
+        let fullscreen =
+            (self.start_fullscreen && !headless_capture).then(|| Fullscreen::Borderless(None));
         let attrs = WindowAttributes::default()
             .with_title(WINDOW_TITLE)
             .with_window_icon(copperline_window_icon())
             .with_visible(!headless_capture)
+            .with_fullscreen(fullscreen)
             .with_inner_size(size)
             .with_min_inner_size(LogicalSize::new(
                 FB_WIDTH as f64 / 2.0,
@@ -4857,6 +4873,19 @@ impl App {
         self.disk_playlist_index = [0; 4];
         self.overscan = crate::config::resolve_overscan(cfg.overscan);
         self.apply_pixel_aspect(crate::config::resolve_pixel_aspect(cfg.pixel_aspect));
+        // Apply the configured start-up window state; the runtime toggles
+        // (Cmd+F, Cmd+Shift+F) take over from here. Reuse the toggles so the
+        // surface/window resize stays in one place.
+        let is_fullscreen = self
+            .render
+            .as_ref()
+            .map(|r| r.window.fullscreen().is_some());
+        if is_fullscreen == Some(!cfg.full_screen) {
+            self.toggle_fullscreen();
+        }
+        if super::status_bar_hidden() != !cfg.status_bar {
+            self.toggle_status_bar();
+        }
         self.warp_speed = cfg.emulation.warp_speed;
         // Reset the host joystick source to the new machine's configured
         // start-up mode (a previous live Cmd+J toggle does not carry over).

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2007,6 +2007,8 @@ fn test_app_with_audio_and_cpu(
         [true; 4],
         crate::config::Overscan::Full,
         0.0,
+        false,
+        false,
         crate::config::WarpSpeed::Max,
         crate::config::JoystickInputMode::Gamepad,
         vec!["Machine: test".to_string()],


### PR DESCRIPTION
Follows up #278: window/UI states can now be saved in the config and restored at launch, starting with fullscreen and the status bar (the audio filter already landed in #282).

Adds two `[display]` keys — `full_screen` (default `false`) and `status_bar` (default `true`) — so a loaded config can open the window fullscreen, or with the status bar already hidden, instead of always starting windowed with the bar shown. Left unset, both keep the current defaults, so nothing changes for existing configs.

Each is reachable three ways:

- **Config:** `[display] full_screen = true`, `[display] status_bar = false`.
- **CLI:** `--full-screen` / `--windowed` set the fullscreen state, and `--show-status-bar` / `--hide-status-bar` set the status bar. Both directions exist so a flag can override whatever the config file chose (e.g. `--windowed` when a config turned fullscreen on, or `--show-status-bar` when a config hid the bar).
- **Launcher:** *Start fullscreen* and *Status bar* toggles on the A/V & Emu page, saved back to the TOML.

The window applies them once at creation: the status-bar flag seeds the presentation global before the initial window size is computed, and an interactive window opens borderless-fullscreen (a headless capture run stays hidden and windowed). Pressing Run from the launcher applies them to the already-open window too, reusing the existing fullscreen/status-bar toggles so the surface resize stays in one place.

These are start-up preferences only — the runtime toggles (`Cmd/Alt+F` for fullscreen, `Cmd/Alt+Shift+F` for the status bar, plus their menu items) still flip either live without touching the saved value, exactly like the existing *Power on at start*.

Config parsing, CLI overrides, and the launcher round-trip are covered by new tests; the full suite, clippy, and fmt are clean. Documented in the `[display]` section, the command-line-overrides table, and the example TOML.