### PR TITLE
input: add adjustable host mouse sensitivity

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -413,6 +413,13 @@ floppy_sounds_volume = 100
 # Cmd+J / Alt+J still cycles this live; --joystick MODE overrides it per run.
 # joystick = "gamepad"
 
+# Host mouse sensitivity, 0-100. 50 (default, shown as "Default" in the GUI)
+# tracks the host mouse 1:1; 0 is a quarter speed and 100 quadruple, on an
+# exponential scale. A host-input scale only -- it does not affect the emulated
+# machine or scripted --mouse-after input. Also --mouse-sensitivity N, the
+# launcher's Input tab, and Cmd/Alt+Shift+> / < (held to ramp) to adjust live.
+# mouse_sensitivity = 50
+
 
 # Serial port wiring. The Amiga serial port doubles as the MIDI port.
 # [serial]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -48,6 +48,7 @@ range checks as the equivalent TOML fields:
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
 | `--floppy-speed PERCENT` | `[floppy] speed` | `100` (real), `200`, `400`, `800`, or `0` (turbo) |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
+| `--mouse-sensitivity N` | `[input] mouse_sensitivity` | `0`-`100` host mouse speed (`50` default = 1:1) |
 | `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
 | `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
 
@@ -524,9 +525,10 @@ Windows select each device directly.
 
 ```toml
 [input]
-port1 = "mouse"        # mouse | joystick | cd32 | analogue | none
-port2 = "joystick"     # same values; default "cd32" on the CD32 profile
-joystick = "gamepad"   # "gamepad" (default) or "keyboard"
+port1 = "mouse"           # mouse | joystick | cd32 | analogue | none
+port2 = "joystick"        # same values; default "cd32" on the CD32 profile
+joystick = "gamepad"      # "gamepad" (default) or "keyboard"
+mouse_sensitivity = 50    # host mouse speed 0-100 (50 default = 1:1)
 ```
 
 ### Port devices
@@ -590,6 +592,16 @@ keyboard icon next to the volume control), `Cmd+J` / `Alt+J`, the menu's
 without changing the config. `--joystick MODE` overrides this for a single
 run. (`auto` is still accepted here as a backward-compatibility alias for
 `gamepad`; the old auto-detect mode has been removed.)
+
+`mouse_sensitivity` scales how fast the emulated pointer tracks the host
+mouse, 0-100. `50` (the default, shown as *Default* in the GUI) is 1:1 --
+exactly the previous behaviour -- `0` is a quarter speed and `100` quadruple,
+on an exponential scale so each step is an even ratio. It is a host-input
+scale applied to live mouse motion only: it never touches the emulated machine
+or scripted `--mouse-after` input, so headless and recorded runs stay
+deterministic. Set it from the launcher's *Input* tab or
+`--mouse-sensitivity N`, and adjust it live with `Cmd+Shift+>` / `Cmd+Shift+<`
+(`Alt+Shift+>` / `Alt+Shift+<` on Linux and Windows), which ramp while held.
 
 ## `[serial]` -- serial port and MIDI
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -24,6 +24,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+Shift+A` | `Alt+Shift+A` | Cycle the audio output: Default, each host device, then Disabled (also the menu's Audio Out item) |
 | `Cmd+A` | `Alt+A` | Cycle Paula's audio filter: auto, on, off (also the menu's Audio Filter item) |
 | `Cmd+Shift++` / `Cmd+Shift+-` | `Alt+Shift++` / `Alt+Shift+-` | Raise / lower the parallel-port sampler input gain (only when a sampler is attached; also the menu's Sampler Gain item) |
+| `Cmd+Shift+>` / `Cmd+Shift+<` | `Alt+Shift+>` / `Alt+Shift+<` | Raise / lower the host mouse sensitivity (also the launcher's Input tab) |
 | `Cmd+F` | `Alt+F` | Toggle fullscreen on / off |
 | `Cmd+Shift+F` | `Alt+Shift+F` | Show / hide the status bar |
 | `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,6 +214,12 @@ pub struct Config {
     /// `Alt+J`, and the menu's Joystick Input item flip it live without
     /// affecting this start-up value.
     pub joystick_input_mode: JoystickInputMode,
+    /// Host mouse sensitivity, 0-100 (`[input] mouse_sensitivity` /
+    /// `--mouse-sensitivity`). 50 (default) is 1:1 with the host mouse; 0 is a
+    /// quarter speed and 100 quadruple, on an exponential scale. A host-input
+    /// scale only -- it does not affect the emulated machine or scripted mouse
+    /// input.
+    pub mouse_sensitivity: u8,
     /// Controller devices plugged into the two game ports at power-on
     /// (`[input] port1` / `port2`, `--port1` / `--port2`); index 0 = port 1.
     /// Defaults to a mouse in port 1 and a joystick in port 2 -- a CD32
@@ -1213,6 +1219,7 @@ impl Default for Config {
             pixel_aspect: PixelAspect::Tv,
             phosphor: 0.0,
             joystick_input_mode: JoystickInputMode::Gamepad,
+            mouse_sensitivity: 50,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
             parallel: ParallelConfig::default(),
@@ -1365,6 +1372,9 @@ pub struct ConfigOverrides {
     /// ("auto" still accepted as a compatibility alias). Validated by the same
     /// parser as `[input] joystick`.
     pub joystick: Option<String>,
+    /// Host mouse sensitivity (`--mouse-sensitivity`), 0-100. Same as
+    /// `[input] mouse_sensitivity`.
+    pub mouse_sensitivity: Option<u16>,
     /// Device in game port 1 (`--port1`): "mouse", "joystick", "cd32",
     /// "analogue", or "none". Same parser as `[input] port1`.
     pub port1: Option<String>,
@@ -1426,6 +1436,7 @@ impl ConfigOverrides {
             && self.floppy_drives.is_none()
             && self.floppy_speed.is_none()
             && self.joystick.is_none()
+            && self.mouse_sensitivity.is_none()
             && self.port1.is_none()
             && self.port2.is_none()
             && self.serial.is_none()
@@ -1485,6 +1496,9 @@ impl ConfigOverrides {
         }
         if let Some(joystick) = &self.joystick {
             raw.input.joystick = Some(joystick.clone());
+        }
+        if let Some(sensitivity) = self.mouse_sensitivity {
+            raw.input.mouse_sensitivity = Some(sensitivity);
         }
         if let Some(port1) = &self.port1 {
             raw.input.port1 = Some(port1.clone());
@@ -1694,6 +1708,9 @@ pub(crate) struct RawInput {
     /// ("cd32" on the CD32 profile).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) port2: Option<String>,
+    /// Host mouse sensitivity, 0-100 (default 50).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mouse_sensitivity: Option<u16>,
 }
 
 /// `[serial]` host wiring for Paula's serial (a.k.a. MIDI) port.
@@ -2408,6 +2425,14 @@ impl TryFrom<RawConfig> for Config {
             None => defaults.joystick_input_mode,
             Some(s) => parse_joystick_input_mode(s)?,
         };
+        let mouse_sensitivity = match raw.input.mouse_sensitivity {
+            None => defaults.mouse_sensitivity,
+            Some(v) if v <= 100 => v as u8,
+            Some(v) => {
+                errors.push(anyhow!("[input] mouse_sensitivity must be 0-100, got {v}"));
+                defaults.mouse_sensitivity
+            }
+        };
         // The profile carries the default wiring (mouse + joystick, with a
         // CD32 pad on the CD32 profile); an explicit key beats it either
         // way -- a real CD32 accepts any controller too.
@@ -2795,6 +2820,7 @@ impl TryFrom<RawConfig> for Config {
             pixel_aspect,
             phosphor,
             joystick_input_mode,
+            mouse_sensitivity,
             port_devices,
             serial,
             parallel: resolve_parallel(raw.parallel)?,
@@ -2869,6 +2895,17 @@ pub(crate) fn parse_port_device(s: &str, key: &str) -> Result<PortDevice> {
              \"analogue\", or \"none\", got {s:?}"
         )
     })
+}
+
+/// Display label for a mouse sensitivity value: the neutral midpoint shows as
+/// "Default" in the GUI and OSD, every other value as its number. The config
+/// and CLI still use the number 50.
+pub(crate) fn mouse_sensitivity_label(sensitivity: u8) -> String {
+    if sensitivity == 50 {
+        "Default".to_string()
+    } else {
+        sensitivity.to_string()
+    }
 }
 
 pub(crate) fn parse_joystick_input_mode(s: &str) -> Result<JoystickInputMode> {
@@ -4114,6 +4151,28 @@ mod tests {
             parse_config("[machine]\nprofile = \"A1200\"\n")?.joystick_input_mode,
             JoystickInputMode::Gamepad
         );
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_sensitivity_defaults_to_50_and_validates() -> Result<()> {
+        assert_eq!(parse_config("")?.mouse_sensitivity, 50);
+        assert_eq!(
+            parse_config("[input]\nmouse_sensitivity = 0\n")?.mouse_sensitivity,
+            0
+        );
+        assert_eq!(
+            parse_config("[input]\nmouse_sensitivity = 100\n")?.mouse_sensitivity,
+            100
+        );
+        assert!(parse_config("[input]\nmouse_sensitivity = 101\n").is_err());
+
+        // CLI override.
+        let overrides = ConfigOverrides {
+            mouse_sensitivity: Some(75),
+            ..Default::default()
+        };
+        assert_eq!(load_overrides(&overrides)?.mouse_sensitivity, 75);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -513,6 +513,15 @@ where
                         anyhow!("--audio-stereo-separation must be a number 0-100")
                     })?);
             }
+            "--mouse-sensitivity" => {
+                let v = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--mouse-sensitivity requires a value (0-100)"))?;
+                overrides.mouse_sensitivity = Some(
+                    v.parse::<u16>()
+                        .map_err(|_| anyhow!("--mouse-sensitivity must be a number 0-100"))?,
+                );
+            }
             "--click-after" => {
                 const USAGE: &str = "--click-after requires SECS BUTTON DURATION_MS";
                 let secs: f32 = next_arg(&mut args, USAGE, "--click-after SECS must be a number")?;
@@ -928,6 +937,7 @@ fn print_help() {
          --rtc-frozen                   stop the seeded clock at --rtc-time exactly\n  \
          --joystick MODE                initial joystick input: gamepad or keyboard\n  \
          \x20                            (gamepad lets the keyboard pass through to the Amiga)\n  \
+         --mouse-sensitivity N          host mouse sensitivity 0-100 (50 default = 1:1)\n  \
          --port1 DEVICE                 controller in port 1: mouse (default), joystick,\n  \
          \x20                            cd32, analogue, or none\n  \
          --port2 DEVICE                 controller in port 2 (default: joystick;\n  \
@@ -1621,6 +1631,7 @@ fn main() -> Result<()> {
         config::resolve_phosphor(cfg.phosphor),
         cfg.emulation.warp_speed,
         cfg.joystick_input_mode,
+        cfg.mouse_sensitivity,
         config::about_machine_lines(&cfg),
         raw_cfg,
         live_audio,
@@ -1729,6 +1740,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_phosphor(0.0),
         config::WarpSpeed::default(),
         config::JoystickInputMode::default(),
+        50,
         vec!["Configure a machine, then press Run.".to_string()],
         raw_cfg,
         audio_output_enabled,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -329,6 +329,7 @@ pub enum LauncherField {
     Warp,
     // Input
     Joystick,
+    MouseSensitivity,
     Port1Device,
     Port2Device,
 }
@@ -545,10 +546,11 @@ const AV_EMULATION_ROWS: [Row; 13] = [
     row(F::RealtimePriority, "Realtime priority", Toggle),
     row(F::Warp, "Warp speed", Cycle),
 ];
-const INPUT_ROWS: [Row; 3] = [
+const INPUT_ROWS: [Row; 4] = [
     row(F::Port1Device, "Port 1", Cycle),
     row(F::Port2Device, "Port 2", Cycle),
     row(F::Joystick, "Joystick input", Cycle),
+    row(F::MouseSensitivity, "Mouse sensitivity", Cycle),
 ];
 
 /// The rows shown on a tab, top to bottom. Most tabs are fixed and borrow their
@@ -937,6 +939,7 @@ pub struct MachineSetup {
     realtime_priority: bool,
     warp: WarpSpeed,
     joystick_input_mode: JoystickInputMode,
+    mouse_sensitivity: u8,
     port_devices: [PortDevice; 2],
     // Extra Zorro boards (metadata path + plugin config schema/overrides)
     zorro_boards: Vec<ZorroBoardSetup>,
@@ -1061,6 +1064,7 @@ impl MachineSetup {
             realtime_priority: cfg.emulation.realtime_priority,
             warp: cfg.emulation.warp_speed,
             joystick_input_mode: cfg.joystick_input_mode,
+            mouse_sensitivity: cfg.mouse_sensitivity,
             port_devices: cfg.port_devices,
             zorro_boards: raw
                 .zorro
@@ -1344,6 +1348,9 @@ impl MachineSetup {
         if self.joystick_input_mode != base.joystick_input_mode {
             raw.input.joystick = Some(self.joystick_input_mode.label().to_string());
         }
+        if self.mouse_sensitivity != base.mouse_sensitivity {
+            raw.input.mouse_sensitivity = Some(u16::from(self.mouse_sensitivity));
+        }
         // Per port against the profile baseline, so a CD32 keeps its pad
         // implicit and a stock machine emits no port keys at all.
         if self.port_devices[0] != base.port_devices[0] {
@@ -1498,6 +1505,7 @@ impl MachineSetup {
         self.realtime_priority = base.emulation.realtime_priority;
         self.warp = base.emulation.warp_speed;
         self.joystick_input_mode = base.joystick_input_mode;
+        self.mouse_sensitivity = base.mouse_sensitivity;
         self.port_devices = base.port_devices;
         if !self.has_ide() {
             self.ide_master = None;
@@ -1627,6 +1635,10 @@ impl MachineSetup {
                 } else {
                     reason(self.audio_channel_mode != ChannelMode::Mono, "mono")
                 }
+            }
+            // Mouse sensitivity does nothing unless a port holds a mouse.
+            F::MouseSensitivity => {
+                reason(self.port_devices.contains(&PortDevice::Mouse), "no mouse")
             }
             _ => None,
         }
@@ -1852,6 +1864,7 @@ impl MachineSetup {
                 JoystickInputMode::Keyboard => "Keyboard".to_string(),
                 JoystickInputMode::Gamepad => "Gamepad".to_string(),
             },
+            F::MouseSensitivity => crate::config::mouse_sensitivity_label(self.mouse_sensitivity),
             F::Port1Device => port_device_display(self.port_devices[0]).to_string(),
             F::Port2Device => port_device_display(self.port_devices[1]).to_string(),
             F::ScsiController => match self.scsi_controller {
@@ -2034,6 +2047,13 @@ impl MachineSetup {
             F::Joystick => {
                 self.joystick_input_mode =
                     cycle_slice(&JOYSTICK_MODES, self.joystick_input_mode, forward)
+            }
+            F::MouseSensitivity => {
+                self.mouse_sensitivity = if forward {
+                    self.mouse_sensitivity.saturating_add(1).min(100)
+                } else {
+                    self.mouse_sensitivity.saturating_sub(1)
+                }
             }
             F::Port1Device => {
                 self.port_devices[0] = cycle_slice(&PORT_DEVICES, self.port_devices[0], forward)
@@ -2974,6 +2994,39 @@ mod tests {
         assert!(raw.cpu.model.is_none());
         assert!(raw.chipset.revision.is_none());
         assert!(s.build_config().is_ok());
+    }
+
+    #[test]
+    fn mouse_sensitivity_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        // The neutral midpoint shows as "Default" and matches the baseline, so
+        // nothing is written.
+        assert_eq!(s.value_label(LauncherField::MouseSensitivity), "Default");
+        assert_eq!(s.to_raw().input.mouse_sensitivity, None);
+
+        // Cycle down twice (step 1): 50 -> 49 -> 48, and it now persists.
+        s.cycle(LauncherField::MouseSensitivity, false);
+        s.cycle(LauncherField::MouseSensitivity, false);
+        assert_eq!(s.value_label(LauncherField::MouseSensitivity), "48");
+        assert_eq!(s.to_raw().input.mouse_sensitivity, Some(48));
+    }
+
+    #[test]
+    fn mouse_sensitivity_greys_out_without_a_mouse() {
+        let mut s = MachineSetup::default();
+        // The default A500 has a mouse in port 1, so it is active.
+        assert_eq!(s.disabled_reason(LauncherField::MouseSensitivity), None);
+
+        // Neither port a mouse: greyed.
+        s.port_devices = [PortDevice::Joystick, PortDevice::Joystick];
+        assert_eq!(
+            s.disabled_reason(LauncherField::MouseSensitivity),
+            Some("no mouse")
+        );
+
+        // A mouse in either port re-enables it.
+        s.port_devices = [PortDevice::Joystick, PortDevice::Mouse];
+        assert_eq!(s.disabled_reason(LauncherField::MouseSensitivity), None);
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4067,12 +4067,15 @@ fn draw_launcher_row(
         scale,
     );
     // Greyed: explain why instead of drawing controls (e.g. "needs 32-bit CPU").
-    // The audio shaping rows are the exception -- channel mode and separation are
-    // merely inapplicable (audio disabled, or separation in mono), so the greyed
-    // label alone says enough and column 2 is left blank.
+    // The shaping rows are the exception -- channel mode, separation and mouse
+    // sensitivity are merely inapplicable (audio disabled, separation in mono,
+    // or no mouse in either port), so the greyed label alone says enough and
+    // column 2 is left blank.
     let blank_when_greyed = matches!(
         r.field,
-        LauncherField::AudioChannelMode | LauncherField::AudioStereoSeparation
+        LauncherField::AudioChannelMode
+            | LauncherField::AudioStereoSeparation
+            | LauncherField::MouseSensitivity
     );
     if let Some(reason) = reason {
         if !blank_when_greyed {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -441,6 +441,13 @@ const WINDOW_TITLE: &str = concat!("Copperline ", env!("COPPERLINE_DISPLAY_VERSI
 const COPPERLINE_LOGO_PNG: &[u8] = include_bytes!("../../assets/brand/copperline-logo.png");
 const COPPERLINE_ICON_PNG: &[u8] = include_bytes!("../../assets/brand/copperline-icon.png");
 const MOUSE_MOTION_SCALE: f64 = 1.0;
+
+/// Host mouse speed multiplier for a 0-100 sensitivity. Exponential so 50 is
+/// exactly 1:1 (2^0), 0 is a quarter speed (2^-2) and 100 quadruple (2^2),
+/// with perceptually even steps between.
+fn mouse_sensitivity_factor(sensitivity: u8) -> f64 {
+    2.0_f64.powf((f64::from(sensitivity.min(100)) - 50.0) / 25.0)
+}
 /// How long a transient on-screen overlay message (screenshot saved,
 /// disk swapped) stays visible.
 const OSD_DURATION: std::time::Duration = std::time::Duration::from_millis(2500);
@@ -734,6 +741,11 @@ pub struct App {
     gamepad: crate::gamepad::GamepadReader,
     /// Host source policy for the emulated port-2 joystick/CD32 pad.
     joystick_input_mode: JoystickInputMode,
+    /// Host mouse sensitivity, 0-100 ([input] mouse_sensitivity), and the speed
+    /// multiplier derived from it. A host-input scale only: it multiplies the
+    /// live host mouse delta, never scripted --mouse-after input or the core.
+    mouse_sensitivity: u8,
+    mouse_sensitivity_factor: f64,
     /// Whether the serial port is bridged to MIDI, so the runtime menu offers
     /// the device items. Fixed for the machine's life.
     serial_is_midi: bool,
@@ -1002,6 +1014,7 @@ impl App {
         phosphor: f32,
         warp_speed: WarpSpeed,
         joystick_input_mode: JoystickInputMode,
+        mouse_sensitivity: u8,
         about_machine_lines: Vec<String>,
         machine_config: RawConfig,
         // Effective live-audio state for this machine: for a real machine the
@@ -1131,6 +1144,8 @@ impl App {
             overscan,
             gamepad: crate::gamepad::GamepadReader::new(),
             joystick_input_mode,
+            mouse_sensitivity,
+            mouse_sensitivity_factor: mouse_sensitivity_factor(mouse_sensitivity),
             warp_speed,
             keyboard_joy_held: [KeyboardJoystickHeld::default(); 2],
             ui: UiState::default(),
@@ -2225,6 +2240,24 @@ impl ApplicationHandler for App {
                             self.step_sampler_gain(false)
                         }
                     }
+                    (KeyCode::Period, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers)
+                            && self.modifiers.shift_key() =>
+                    {
+                        // Raise the host mouse sensitivity (Shift+. is ">").
+                        if !self.modal_ui_active() {
+                            self.step_mouse_sensitivity(true)
+                        }
+                    }
+                    (KeyCode::Comma, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers)
+                            && self.modifiers.shift_key() =>
+                    {
+                        // Lower the host mouse sensitivity (Shift+, is "<").
+                        if !self.modal_ui_active() {
+                            self.step_mouse_sensitivity(false)
+                        }
+                    }
                     (other, state) => {
                         let pressed = state == ElementState::Pressed;
                         if pressed && self.ui_handle_key(other, text.as_deref()) {
@@ -3132,13 +3165,43 @@ impl App {
         if !dx.is_finite() || !dy.is_finite() {
             return;
         }
-        self.mouse_delta_remainder.0 += dx * MOUSE_MOTION_SCALE;
-        self.mouse_delta_remainder.1 += dy * MOUSE_MOTION_SCALE;
+        // The sensitivity scale is applied to the live host mouse only, here --
+        // scripted --mouse-after deltas go through apply_scripted_mouse_delta
+        // and stay exact, so the core is deterministic regardless of it.
+        let scale = MOUSE_MOTION_SCALE * self.mouse_sensitivity_factor;
+        self.mouse_delta_remainder.0 += dx * scale;
+        self.mouse_delta_remainder.1 += dy * scale;
         let ix = take_integral_mouse_delta(&mut self.mouse_delta_remainder.0);
         let iy = take_integral_mouse_delta(&mut self.mouse_delta_remainder.1);
         if ix != 0 || iy != 0 {
             self.add_mouse_delta_i32(ix, iy);
         }
+    }
+
+    /// Set the host mouse sensitivity (0-100), recomputing the speed factor.
+    fn set_mouse_sensitivity(&mut self, sensitivity: u8) {
+        self.mouse_sensitivity = sensitivity.min(100);
+        self.mouse_sensitivity_factor = mouse_sensitivity_factor(self.mouse_sensitivity);
+    }
+
+    /// Nudge the mouse sensitivity by one, clamped to 0-100, with an on-screen
+    /// readout. Bound to the Cmd/Alt+Shift+> / < shortcuts, which ramp while
+    /// held via key repeat. A no-op when no port holds a mouse, since the scale
+    /// would have nothing to act on.
+    fn step_mouse_sensitivity(&mut self, up: bool) {
+        if self.mouse_port().is_none() {
+            return;
+        }
+        let next = if up {
+            self.mouse_sensitivity.saturating_add(1)
+        } else {
+            self.mouse_sensitivity.saturating_sub(1)
+        };
+        self.set_mouse_sensitivity(next);
+        self.show_osd(format!(
+            "Mouse sensitivity: {}",
+            crate::config::mouse_sensitivity_label(self.mouse_sensitivity)
+        ));
     }
 
     fn add_mouse_delta_i32(&mut self, dx: i32, dy: i32) {
@@ -4861,6 +4924,7 @@ impl App {
         // Reset the host joystick source to the new machine's configured
         // start-up mode (a previous live Cmd+J toggle does not carry over).
         self.joystick_input_mode = cfg.joystick_input_mode;
+        self.set_mouse_sensitivity(cfg.mouse_sensitivity);
         self.keyboard_joy_held = [KeyboardJoystickHeld::default(); 2];
         self.about_machine_lines = crate::config::about_machine_lines(cfg);
         self.deinterlacer =

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2009,11 +2009,24 @@ fn test_app_with_audio_and_cpu(
         0.0,
         crate::config::WarpSpeed::Max,
         crate::config::JoystickInputMode::Gamepad,
+        50,
         vec!["Machine: test".to_string()],
         crate::config::RawConfig::default(),
         true,
         crate::sampler::SamplerRequest::default(),
     )
+}
+
+#[test]
+fn mouse_sensitivity_factor_hits_the_anchors_and_is_monotonic() {
+    use super::mouse_sensitivity_factor as f;
+    // 0 quarter speed, 50 exactly 1:1 (today's speed), 100 quadruple.
+    assert!((f(0) - 0.25).abs() < 1e-9);
+    assert!((f(50) - 1.0).abs() < 1e-9);
+    assert!((f(100) - 4.0).abs() < 1e-9);
+    assert!(f(25) < f(50) && f(50) < f(75));
+    // Out-of-range clamps to 100.
+    assert!((f(200) - 4.0).abs() < 1e-9);
 }
 
 #[test]


### PR DESCRIPTION
Raised under #287. Adds a host mouse sensitivity setting, 0-100, defaulting to 50.

50 (default, shown as Default in the GUI) is 1:1; 0 is a quarter speed and 100 quadruple, on an exponential scale. Adjust from the launcher's Input tab, --mouse-sensitivity N, or Cmd/Alt+Shift+> / < (held to ramp), in steps of 1.

It's purely a host-input scale: the multiplier is applied to live host mouse motion in `add_host_mouse_delta` only, never to scripted `--mouse-after` deltas or the emulated machine, so headless and recorded runs stay bit-for-bit deterministic.

Reachable four ways:
- `[input] mouse_sensitivity = 50` in the config.
- `--mouse-sensitivity N` on the command line (validated 0-100).
- A "Mouse sensitivity" row on the launcher's Input tab (under Joystick input), saved back to the TOML.
- `Cmd/Alt+Shift+>` and `Cmd/Alt+Shift+<` to raise/lower it live, with an on-screen readout — the counterparts to the sampler-gain shortcuts. There's deliberately no hamburger-menu item, since a single menu entry can't (currently) decrease/increase a value and would start getting messy having 2 separate items to increase and decrease. 

Tests cover the factor anchors (0.25 / 1.0 / 4.0 and monotonicity), config parsing/validation, and the launcher round-trip. Full suite, clippy, and fmt are clean; documented in the `[input]` section, the command-line-overrides table, the shortcut list, and the example TOML.


<img width="725" height="617" alt="Screenshot 2026-07-25 at 19 44 06" src="https://github.com/user-attachments/assets/d4ca99fa-b733-4f12-8914-b7ea6c1b38ab" />
<img width="722" height="616" alt="Screenshot 2026-07-25 at 19 43 07" src="https://github.com/user-attachments/assets/3183727e-39df-4edf-b734-34dbb8ab2458" />

