### PR TITLE
window: resize tool-window buffers when toggling the status bar

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7673,7 +7673,7 @@ impl App {
         // centring reads the live canvas height), so their buffers and
         // windows must follow the new size too.
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
-        for kind in [ToolPanelKind::Debugger, ToolPanelKind::FrameAnalyzer] {
+        for kind in ToolPanelKind::ALL {
             if let Some(tool) = self.tool_window_mut(kind) {
                 if let Err(e) = tool.pixels.resize_buffer(
                     texture_width(tool.texture_scale) as u32,
@@ -7713,11 +7713,13 @@ impl App {
                 return;
             }
         }
-        // Tool windows size their panel buffer from the same canvas height
-        // (window_present_height), so resize their buffers to match too, or a
-        // later tool draw could index past a now-too-small buffer. Buffer only:
-        // unlike a pixel-aspect switch, leave a tool window's own size alone.
-        for kind in [ToolPanelKind::Debugger, ToolPanelKind::FrameAnalyzer] {
+        // Every tool window (Debugger, Frame Analyzer, Console) draws through
+        // draw_panel_layer, which indexes its buffer by the same canvas height
+        // (window_present_height), so resize all their buffers to match too, or
+        // a later tool draw could index past a now-too-small buffer. Buffer
+        // only: unlike a pixel-aspect switch, leave a tool window's own size
+        // alone.
+        for kind in ToolPanelKind::ALL {
             if let Some(tool) = self.tool_window_mut(kind) {
                 if let Err(e) = tool.pixels.resize_buffer(
                     texture_width(tool.texture_scale) as u32,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7713,6 +7713,21 @@ impl App {
                 return;
             }
         }
+        // Tool windows size their panel buffer from the same canvas height
+        // (window_present_height), so resize their buffers to match too, or a
+        // later tool draw could index past a now-too-small buffer. Buffer only:
+        // unlike a pixel-aspect switch, leave a tool window's own size alone.
+        for kind in [ToolPanelKind::Debugger, ToolPanelKind::FrameAnalyzer] {
+            if let Some(tool) = self.tool_window_mut(kind) {
+                if let Err(e) = tool.pixels.resize_buffer(
+                    texture_width(tool.texture_scale) as u32,
+                    texture_height(tool.texture_scale) as u32,
+                ) {
+                    warn!("resize tool texture buffer for status bar toggle failed: {e}");
+                }
+                tool.window.request_redraw();
+            }
+        }
         // Only snap an unresized window to the new canvas size; a resized window
         // keeps its dimensions and the display reflows into it.
         if was_canvas_sized {


### PR DESCRIPTION
Follow-up to #289. That PR fixed the window-sizing quirk; this one closes a latent panic in the same area, flagged by Copilot review on it (the comment landed after #289 had already merged, so it needs its own PR).

Toggling the status bar changes `window_present_height()` — and therefore `texture_height()` — which the drawing helpers use for bounds and stride. A Debugger or Frame Analyzer tool window opened while the status bar is *hidden* gets a `pixels` buffer sized for the shorter canvas. Restoring the bar grows `texture_height()` but previously left that buffer untouched, so a subsequent tool-window draw could index past it and panic: `statusbar::put_pixel` bounds-checks against the live `texture_height()`, not `frame.len()`.

The sequence is reachable — the status-bar toggle is a global shortcut (Cmd/Alt+Shift+F) that fires regardless of which window is focused — though niche, since it needs a debug tool window open across a toggle. It's pre-existing (introduced with the status-bar hide feature, not the resize fix in #289).

The fix resizes the tool-window buffers alongside the main one when the bar toggles, mirroring what `apply_pixel_aspect` already does. It's buffer-only: unlike a pixel-aspect switch, the tool window keeps its own size, consistent with #289 now preserving a manual resize on the main window.

Confined to `src/video/window.rs` (frontend-gated, not built for the web crate). No user-visible surface changes, so no docs move. `cargo build --release`, `clippy --all-targets --all-features`, `fmt --check`, and the window test suite (156 tests) are all clean.