### PR TITLE
cpu: charge the 020 pipeline refill on a taken branch

### DIFF
--- a/crates/m68k/src/core/timing_020.rs
+++ b/crates/m68k/src/core/timing_020.rs
@@ -631,16 +631,16 @@ fn group_5(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
     }
     if size_bits == 3 && mode == 1 {
         let condition = ((op >> 8) & 0xF) as u8;
+        // Both exits fall through with the pipeline intact; only the looping
+        // arm branches, so only it pays the refill.
         let case = if cpu.test_condition(condition) {
             Case::new(6, 7)
         } else if cpu.d(reg as usize) as u16 == 0xFFFF {
             Case::new(10, 10)
         } else {
-            Case::new(6, 9)
+            Case::new(6 + TAKEN_BRANCH_REFILL, 9 + TAKEN_BRANCH_REFILL)
         };
-        let taken = !cpu.test_condition(condition) && cpu.d(reg as usize) as u16 != 0xFFFF;
-        let refill = if taken { TAKEN_BRANCH_REFILL } else { 0 };
-        return Some(case.pick(cached) + refill);
+        return Some(case.pick(cached));
     }
     if size_bits == 3 {
         if mode == 0 {

--- a/crates/m68k/src/core/timing_020.rs
+++ b/crates/m68k/src/core/timing_020.rs
@@ -18,9 +18,23 @@
 //! brief form after the instruction has retired. Indexed entries therefore
 //! use the manual's brief-form row; the host still bills every extension and
 //! indirect operand access that actually occurred.
+//!
+//! A taken branch additionally pays `TAKEN_BRANCH_REFILL`. The section-8.2
+//! entries are written for an instruction whose successor is already in the
+//! three-stage pipeline; a taken branch invalidates the decode and execute
+//! stages, so the target instruction cannot begin until the pipe refills from
+//! the cache. The manual accounts for that in the *following* instruction's
+//! head, which a per-instruction model with no overlap stage cannot express,
+//! so the cost is charged where the flush happens. Without it a `dbra` loop
+//! runs 6 clocks per iteration instead of 8 (`timing-test` rows 4, 5, 7, 14,
+//! 28, 29, 30, all 25% fast against the A1200 reference in
+//! `timing-test/README.md`).
 
 use super::cpu::CpuCore;
 use super::types::Size;
+
+/// Clocks a taken branch loses refilling the 020's instruction pipeline.
+const TAKEN_BRANCH_REFILL: i32 = 2;
 
 #[derive(Clone, Copy)]
 struct Case {
@@ -624,7 +638,9 @@ fn group_5(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
         } else {
             Case::new(6, 9)
         };
-        return Some(case.pick(cached));
+        let taken = !cpu.test_condition(condition) && cpu.d(reg as usize) as u16 != 0xFFFF;
+        let refill = if taken { TAKEN_BRANCH_REFILL } else { 0 };
+        return Some(case.pick(cached) + refill);
     }
     if size_bits == 3 {
         if mode == 0 {
@@ -644,10 +660,10 @@ fn group_5(cpu: &CpuCore, op: u16, cached: bool) -> Option<i32> {
 fn group_6(cpu: &CpuCore, op: u16, cached: bool) -> i32 {
     let condition = (op >> 8) & 0xF;
     if condition == 1 {
-        return Case::new(7, 13).pick(cached); // BSR
+        return Case::new(7, 13).pick(cached) + TAKEN_BRANCH_REFILL; // BSR
     }
     if condition == 0 || cpu.change_of_flow {
-        return Case::new(6, 9).pick(cached);
+        return Case::new(6, 9).pick(cached) + TAKEN_BRANCH_REFILL;
     }
     match op as u8 {
         0 => Case::new(6, 7).pick(cached),
@@ -793,11 +809,13 @@ mod tests {
     #[test]
     fn dbcc_distinguishes_loop_expiry_and_true_condition() {
         let mut cpu = CpuCore::new();
+        // Looping: the branch is taken, so it also pays the pipeline refill.
         cpu.ir = 0x51C8; // DBF D0,<disp>
         cpu.dar[0] = 7;
-        assert_eq!(cpu.cycles_020(12, true), 6);
-        assert_eq!(cpu.cycles_020(12, false), 9);
+        assert_eq!(cpu.cycles_020(12, true), 6 + TAKEN_BRANCH_REFILL);
+        assert_eq!(cpu.cycles_020(12, false), 9 + TAKEN_BRANCH_REFILL);
 
+        // Both fall-through exits leave the pipeline intact: table entry only.
         cpu.dar[0] = 0xFFFF;
         assert_eq!(cpu.cycles_020(14, true), 10);
         assert_eq!(cpu.cycles_020(14, false), 10);
@@ -805,6 +823,26 @@ mod tests {
         cpu.ir = 0x50C8; // DBT: condition true
         assert_eq!(cpu.cycles_020(12, true), 6);
         assert_eq!(cpu.cycles_020(12, false), 7);
+    }
+
+    #[test]
+    fn only_taken_branches_pay_the_pipeline_refill() {
+        let mut cpu = CpuCore::new();
+        // BRA is unconditional, so it always flushes.
+        cpu.ir = 0x6002;
+        cpu.change_of_flow = false;
+        assert_eq!(cpu.cycles_020(10, true), 6 + TAKEN_BRANCH_REFILL);
+
+        // BSR likewise.
+        cpu.ir = 0x6102;
+        assert_eq!(cpu.cycles_020(18, true), 7 + TAKEN_BRANCH_REFILL);
+
+        // A conditional branch pays it only when it is actually taken.
+        cpu.ir = 0x6702; // BEQ.B
+        cpu.change_of_flow = true;
+        assert_eq!(cpu.cycles_020(10, true), 6 + TAKEN_BRANCH_REFILL);
+        cpu.change_of_flow = false;
+        assert_eq!(cpu.cycles_020(10, true), 4);
     }
 
     #[test]

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -292,6 +292,19 @@ total. An A1200 chip-RAM access can therefore extend an instruction through
 Alice arbitration; selecting a smaller CPU total cannot erase a bus wait
 that already happened.
 
+A taken branch pays two clocks on top of its table entry. The section-8.2
+entries are written for an instruction whose successor is already in the
+three-stage pipeline; a taken branch invalidates the decode and execute stages,
+so the target cannot begin until the pipe refills. The manual charges that to
+the *following* instruction's head, which a per-instruction model with no
+overlap stage has nowhere to put, so Copperline charges it where the flush
+happens (`TAKEN_BRANCH_REFILL`). Without it a `dbra` loop runs at the isolated
+cache-case 6 clocks per iteration instead of 8, which makes every tight loop --
+depackers, MFM decoders, chase-the-beam poll loops -- about 10% fast. It is the
+one divergence that showed up across seven independent `timing-test` rows (4,
+5, 7, 14, 28, 29, 30) against the FS-UAE A1200 reference; see
+`timing-test/README.md`.
+
 This is intentionally a datasheet model, not a claim of cycle exactness.
 The opcode word does not retain a consumed extension word, so full-format
 indexed modes use the brief-index table row, `MOVES` uses the slower of its
@@ -311,7 +324,16 @@ CPU clocks, not the 68000's 4: after the granted colour-clock slot the access
 bills only the shorter remaining tail (one clock -- half a cck at the stock
 2-clock ratio, none at 14 MHz where the 3-clock cycle fits inside one slot).
 That is enough for a posted write. A chip-RAM read or custom-register read
-also waits one colour clock for the chipset's data-return phase. An AGA
+also waits one colour clock for the chipset's data-return phase, and a
+custom-register read waits one colour clock beyond that: chip RAM answers out of
+Agnus' DRAM controller with the row already open for the granted slot, while a
+register read has to cross to the addressed chip, be driven back onto the 16-bit
+chipset bus, and only then meet the CPU's data-return phase. A 68000 cannot see
+the difference -- its four-clock bus cycle is longer than either path -- but a
+14 MHz 020 samples early enough that the crossing costs a whole slot. This is
+what sets the rate of a VHPOSR/INTREQR polling loop, so it decides where
+chase-the-beam code lands relative to the copper: `timing-test` rows 16, 17 and
+21 fit 27% more iterations per frame without it. An AGA
 instruction-cache fill does the same for its first word; the second word from
 the already-latched 32-bit value is free. On OCS/ECS machines the 020 still
 talks to the 16-bit chip bus, so chip/slow/custom data reads likewise pay the

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4041,6 +4041,22 @@ impl Bus {
         self.record_slice_bus_advance(cck, tick);
     }
 
+    /// A 020+ CPU read of a custom register costs one colour clock more than a
+    /// chip-RAM read of the same width. Chip RAM answers out of Agnus' DRAM
+    /// controller, which has the row already open for the granted slot; a
+    /// register read has to cross to the addressed chip (Agnus, Denise or
+    /// Paula), be driven back onto the 16-bit chipset bus, and only then meet
+    /// the CPU's data-return phase. A 68000 cannot see the difference - its
+    /// four-clock bus cycle is longer than either path - but a 14 MHz 020
+    /// samples early enough that the extra chip-crossing shows up as a whole
+    /// slot. Beam-polling loops (VHPOSR/INTREQR) are what this decides:
+    /// `timing-test` rows 16, 17 and 21 fit 27% more iterations per frame
+    /// without it (A1200 reference in `timing-test/README.md`).
+    fn bill_custom_register_return(&mut self) {
+        let (cck, tick) = self.advance_one_chip_bus_quantum(None);
+        self.record_slice_bus_advance(cck, tick);
+    }
+
     fn note_cpu_missed_chip_bus_cycle(&mut self) {
         self.cpu_missed_chip_slots = self.cpu_missed_chip_slots.wrapping_add(1);
         if self.blitter_slowdown_counter_enabled() && self.blitter.current_slot_counts_for_bls() {
@@ -5105,6 +5121,7 @@ impl Bus {
         );
         if self.cpu_short_bus_cycle {
             self.bill_020_read_data_wait();
+            self.bill_custom_register_return();
         }
         // Read-only custom registers (INTREQR, DSKBYTR, SERDATR, POTxDAT, ...)
         // reflect timed-device state, so apply the deferred device clocks before

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -8701,9 +8701,11 @@ fn aga_68020_chip_reads_wait_for_data_but_writes_are_posted() {
     assert_eq!(chip_fetch_cck, 2);
     assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Idle);
 
+    // A custom-register read crosses to Agnus/Denise/Paula and back over the
+    // 16-bit chipset bus, one colour clock beyond the chip-RAM data return.
     let _ = bus.custom_read(0x002, 2);
     let (custom_read_cck, _) = bus.take_slice_bus_advance();
-    assert_eq!(custom_read_cck, 2);
+    assert_eq!(custom_read_cck, 3);
     assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Idle);
 }
 
@@ -8728,7 +8730,7 @@ fn ecs_68020_chip_and_custom_reads_wait_for_16_bit_data_return() {
 
     let _ = bus.custom_read(0x002, 2);
     let (custom_read_cck, _) = bus.take_slice_bus_advance();
-    assert_eq!(custom_read_cck, 2);
+    assert_eq!(custom_read_cck, 3);
     assert_eq!(bus.last_chip_bus_owner(), ChipBusOwner::Idle);
 }
 

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -48,6 +48,29 @@ trap). Every other row -- including the copper-vs-CPU row 27, which is what the
 (68EC020, ECS, 2 MB chip, no slow, KS 2.05); compare against FS-UAE/vAmiga set
 up the same way.
 
+vAmiga cannot arbitrate this machine (it is OCS/ECS and A500/A1000/A2000 only),
+so the only cross-check on file for the 020 at 14 MHz is FS-UAE.
+`tt-a1200.fs-uae` boots the same disk on FS-UAE's A1200 and serves the probe's
+serial stream on `tcp://127.0.0.1:1234`; connect to that socket and the 32 words
+arrive as ASCII hex:
+
+```sh
+fs-uae timing-test/tt-a1200.fs-uae &
+nc 127.0.0.1 1234        # or any client that holds the socket open
+python3 timing-test/compare-a1200.py    # captured reference, run from timing-test/
+```
+
+That reference column found the 020's taken-branch cost: rows 4, 5, 7, 14, 28,
+29 and 30 all differ from FS-UAE by exactly two clocks per loop iteration, and
+only in the iteration's branch (`move`, `shift`, `mul` and every chip-bus row
+agree once the branch is accounted for). Rows 16, 17 and 21 -- the per-frame
+VHPOSR-polling loops -- separately expose the extra colour clock a CPU
+custom-register read costs over a chip-RAM read. Both are modelled; see
+`docs/internals/cpu.md`. What the column still shows open is the write class:
+chip writes (rows 3, 10, 12, 18) are billed a whole colour clock where a real
+020 posts the write inside its shorter bus cycle, so they run ~10% slow (~29%
+under bitplane DMA), and row 31 (DIV during an active display) is ~27% fast.
+
 ## What each row measures
 
 Most values are the elapsed CIA E-clock ticks for the test (8192 iterations

--- a/timing-test/compare-a1200.py
+++ b/timing-test/compare-a1200.py
@@ -9,6 +9,7 @@
 # Rows 19, 20, 22 and 27 are raw VHPOSR beam positions, not tick counts, so a
 # ratio is meaningless for them; rows 0, 1, 9 and 13 probe slow RAM and read the
 # 00000000 sentinel on a machine without it.
+import os
 import subprocess
 import sys
 
@@ -35,7 +36,7 @@ RAW = {19, 20, 22, 27}
 def copperline_rows():
     out = subprocess.run(
         ["../target/release/copperline", "--config", "tt-a1200.toml",
-         "--noaudio", "--screenshot-after", "16", "/dev/null"],
+         "--noaudio", "--screenshot-after", "16", os.devnull],
         capture_output=True, text=True, cwd=sys.path[0] or ".",
     ).stdout
     words = out.replace("\0", "").split()

--- a/timing-test/compare-a1200.py
+++ b/timing-test/compare-a1200.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Compare Copperline's A1200 timing-test rows against the FS-UAE A1200 reference.
+#
+# Reference capture (FS-UAE 3.2.35, core from WinUAE 3300b2), A1200: 68EC020 at
+# 14.19 MHz, AGA, 2 MB chip, no slow RAM, KS 3.1 (40.68), PAL -- the same machine
+# tt-a1200.toml describes. Run `fs-uae tt-a1200.fs-uae`, which serves the probe's
+# serial stream on tcp://127.0.0.1:1234, and read the 32 words off that socket.
+#
+# Rows 19, 20, 22 and 27 are raw VHPOSR beam positions, not tick counts, so a
+# ratio is meaningless for them; rows 0, 1, 9 and 13 probe slow RAM and read the
+# 00000000 sentinel on a machine without it.
+import subprocess
+import sys
+
+FS = [
+    0x00000000, 0x00000000, 0x19BB, 0x11A2, 0x1004, 0x1337, 0x3803, 0x0CD0,
+    0x377D, 0x00000000, 0x0237, 0x02DD, 0x023C, 0x00000000, 0x0CD3, 0x02DD,
+    0x11A6, 0x11A4, 0x0248, 0x0019, 0x0084, 0x119D, 0x000D, 0x2731,
+    0x479D, 0x017F, 0x622E, 0x641B, 0x1338, 0x1337, 0x0CD0, 0x04D2,
+]
+
+DESC = {
+    0: "slowR", 1: "slowW", 2: "chipR", 3: "chipW", 4: "move", 5: "shift",
+    6: "mul", 7: "dbra", 8: "frame", 9: "slowRd/f", 10: "cw1024",
+    11: "cw/6bpl", 12: "cw/8spr", 13: "dbraSlow", 14: "dbraChip",
+    15: "cw/6bpl+8spr", 16: "cw/f", 17: "cw/f+VB", 18: "cw/3bpl",
+    19: "VBentry", 20: "SOFTend", 21: "cw/chain", 22: "VBraise",
+    23: "blitClr", 24: "blitFill", 25: "blitLine", 26: "fill+3bpl",
+    27: "copperPoll", 28: "pair", 29: "pairRAW", 30: "dbraBC", 31: "div/6bpl",
+}
+
+RAW = {19, 20, 22, 27}
+
+
+def copperline_rows():
+    out = subprocess.run(
+        ["../target/release/copperline", "--config", "tt-a1200.toml",
+         "--noaudio", "--screenshot-after", "16", "/dev/null"],
+        capture_output=True, text=True, cwd=sys.path[0] or ".",
+    ).stdout
+    words = out.replace("\0", "").split()
+    return [int(w, 16) for w in words
+            if len(w) == 8 and all(c in "0123456789ABCDEFabcdef" for c in w)][:32]
+
+
+rows = copperline_rows()
+if len(rows) < 32:
+    print(f"only {len(rows)} rows: {rows}")
+    sys.exit(1)
+
+print(f"{'row':>3} {'desc':13} {'CL':>7} {'FS-UAE':>7} {'CL/FS':>6}")
+worst = []
+for i in range(32):
+    ref, got = FS[i], rows[i]
+    if i in RAW or ref == 0:
+        state = "ok" if got == ref else "DIFF"
+        print(f"{i:>3} {DESC[i]:13} {got:>7} {ref:>7} {'(raw)':>6} {state}")
+        continue
+    ratio = got / ref
+    off = abs(ratio - 1)
+    flag = "<<<" if off > 0.15 else ("<<" if off > 0.05 else "")
+    if off > 0.05:
+        worst.append((off, i))
+    print(f"{i:>3} {DESC[i]:13} {got:>7} {ref:>7} {ratio:>6.2f} {flag}")
+
+worst.sort(reverse=True)
+print("worst:", [f"r{i}({DESC[i]} {o * 100:.0f}%)" for o, i in worst[:10]])

--- a/timing-test/tt-a1200.fs-uae
+++ b/timing-test/tt-a1200.fs-uae
@@ -1,0 +1,8 @@
+[fs-uae]
+amiga_model = A1200
+kickstart_file = $CONFIG/../Kickstart v3.1 r40.68 (1993)(Commodore)(A1200)[!].rom
+floppy_drive_0 = $CONFIG/timing-test.adf
+chip_memory = 2048
+slow_memory = 0
+fast_memory = 0
+serial_port = tcp://127.0.0.1:1234


### PR DESCRIPTION
Fixes #285.

## What goes wrong

Not a general "too fast" — Cubic Dream is racing itself, with 33 frames of margin.

- The demo's level-3 (VERTB) autovector points at `$7888C`. The picture part is a state machine at `$78BC2`; entering state 3 starts a **33-frame countdown**, after which the VERTB handler at `$78A80` installs the next part's handler (`$6C` -> `$7CD96`).
- Meanwhile the trackloader (wait loop `$1030`, MFM store at `$108C`) streams the next part over `$78xxx` — *including the live handler*.
- Copperline reached the overwrite at **state3+28 frames**, five frames before the handover. The next VERTB executed loaded data (`8240 A643`) -> Line-A -> Guru `8000 000A` at t=39.86s.

## Root cause

The first commit adds an **FS-UAE A1200 reference column** for `timing-test/`. The repo only ever had the 7 MHz A500+ one, and vAmiga cannot arbitrate an A1200 (OCS/ECS, A500/A1000/A2000 only), so there was no cross-check at the clock every AGA demo actually runs at.

It isolated the error cleanly: rows 4, 5, 7, 14, 28, 29, 30 were each exactly **two clocks per loop iteration** fast, and only in the branch — `move`, `shift`, `mul` and every chip-bus/blitter/beam row already agreed.

`timing_020.rs` bills the MC68020UM section-8.2 entry for the branch in isolation, but the manual accounts for the post-flush pipeline refill in the *following* instruction's head, which a per-instruction model with no overlap stage has nowhere to put. `TAKEN_BRANCH_REFILL` charges it where the flush happens. A `dbra` loop goes 6 -> 8 clocks per iteration; the demo's margin goes 28 -> 42 frames and it plays through.

Second, independent fix: a 020 custom-register read now costs one colour clock beyond a chip-RAM read. Chip RAM answers from Agnus' DRAM controller with the row already open; a register read crosses to Agnus/Denise/Paula and back over the 16-bit chipset bus first. A 68000's four-clock bus cycle is longer than either path so it cannot see the difference. This sets the rate of every VHPOSR/INTREQR poll loop — rows 16, 17 and 21 were fitting 27% more iterations per frame.

17 of the 27 comparable rows now match the reference exactly.

## Still open

Chip **writes** are billed a whole colour clock where a real 020 posts inside its shorter bus cycle: rows 3/10/12 ~10% slow, row 18 ~29% slow under bitplane DMA. That error used to partially cancel the branch one — the demo's own decrunch benchmark read 5.08s before and reads 5.54s now, against FS-UAE's 5.31. Fixing it needs the sub-colour-clock write-posting work. Row 31 (DIV during an active display) is ~27% fast; `MULU.W #imm` is +2. All recorded in `timing-test/README.md`.

Separately worth knowing: `[cpu] clock_mhz` quantises to integer colour-clock multiples, so 12.5–16 MHz all mean 4x CCK. @sonnenscheinchen's "~10 MHz" was 3x CCK = 10.64, and there is no way to sweep CPU speed finely through config today.

## Verification

- 1827 root tests + 94 `crates/m68k` tests pass, clippy and fmt clean. (`cargo test` at the root **skips** `crates/m68k` — it is a path dep, not a workspace member. Its DBcc test only failed under `cargo test --lib` inside the crate.)
- 23 golden probe renders unchanged — no re-bless needed.
- Roots II AGA, Zool and the A1200 Kickstart boot render pixel-identical; the CD32 intro shifts animation phase with no blank gap (250-frame luminance scan clean).
- Cubic Dream runs clean past 110s through the later parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRCdzExVHg1HVUXx7K9AoU