### PR TITLE
debugger: dump ExecBase scheduler state and struct Task

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -113,6 +113,9 @@ garbage):
 | Command | Effect |
 |---|---|
 | `TASKS` | The scheduled task (`>`), then the ready and waiting lists, with priority, state, and name |
+| `TASK [ADDR\|NAME]` | One task in full; no argument dumps `ExecBase->ThisTask` |
+| `EXECBASE`, `EXEC` | ExecBase's own state: the scheduler counters and nesting counts, then what exec recorded about the machine |
+| `MEMLIST`, `AVAIL` | Exec's memory list: free, largest chunk, and attributes per region |
 | `LIBS`, `LIBRARIES` | Opened libraries with versions (`graphics.library v40.10`) |
 | `DEVS`, `DEVICES` | Devices with versions |
 | `RESOURCES`, `PORTS` | The resource and message-port lists |
@@ -120,6 +123,54 @@ garbage):
 | `CATCHTASK NAME` | Stop when exec schedules a task whose name contains NAME (case-insensitive); `CATCHTASK` alone clears it |
 | `CATCHALERT` | Break at exec's `Alert()` entry: fires on every guru/alert with D7 holding the code |
 | `GURU [CODE]` | Decode an alert code (default: the current D7): deadend flag, subsystem, cause, CPU-trap alerts |
+
+`EXECBASE` answers "what is the OS doing right now": `IdleCount` and
+`DispCount` say whether exec is dispatching at all, `SysFlags` shows the
+scheduler's pending attention bits, and `IDNestCnt`/`TDNestCnt` decode
+into plain English -- `-1` means enabled, anything else is live
+`Disable()`/`Forbid()` nesting, which is the usual reason a machine
+"hangs" with the display still running. `AttnFlags` is the CPU and FPU
+exec detected at boot, and the rest is what exec measured of the machine
+(memory bounds, VBlank/PSU frequency, E-clock, its own supervisor stack)
+plus the last alert code, decoded.
+
+```text
+> execbase
+ExecBase $C00B00  exec.library v40.10  SoftVer 63
+sched  IdleCount 34  DispCount 145  Quantum 4  Elapsed 2
+sched  SysFlags $0000 (none)  AttnResched $0000
+sched  IDNestCnt -1 (interrupts enabled)
+sched  TDNestCnt -1 (task switching enabled)
+cpu    AttnFlags $0000 (none)
+task   ThisTask $C03580  exec.library
+```
+
+`TASK` dumps one `struct Task`: node type and priority, `tc_Flags`,
+signal masks, trap and exception vectors, and stack bounds with the
+bytes in use. For the *running* task the stack pointer is taken live
+from the CPU (the user stack pointer, so a snapshot taken inside an
+interrupt still measures the task's own stack) rather than from the
+stale `tc_SPReg`. A `NT_PROCESS` continues into the DOS half: CLI
+number and command name, `pr_StackSize`, `IoErr()`, the directory
+locks, and the loaded hunks.
+
+```text
+> task input
+task $C07192  input.device  (task)  pri 20  state wait
+  flags  $00 (none)  IDNestCnt -1  TDNestCnt 0
+  sigs   alloc $C000FFFF  wait $C0000000  recvd $00000000
+  sigs   except $00000000  trap alloc $8000 able $0000
+  vecs   trap $F83558/$000000  except $F83558/$000000
+  vecs   switch $000000  launch $000000  userdata $000000
+  stack  $C071F0-$C081F0 (4096 bytes)  sp $C0819E (SPReg), 82 used
+```
+
+The argument is an address (`TASK $C07192`) or a case-insensitive
+substring of a task name; an ambiguous name lists the candidates instead
+of guessing. `MEMLIST` walks the memory list exec allocates from, per
+region: `mh_Free`, the largest free chunk and the chunk count (walked
+from `mh_First`, so fragmentation is visible), and the `MEMF_*`
+attributes.
 
 `CATCHTASK` is the tool for "wake me when my process actually runs": it
 baselines on the currently scheduled task and fires on the next

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -242,3 +242,12 @@ stop; `monitor loadseg-list` prints the same table.
 | `segments` | the current process's loaded hunks (LoadSeg addresses) |
 | `loadseg-break` | toggle a visible stop whenever a new program is loaded |
 | `loadseg-list` | tracked program loads with their hunk addresses |
+| `execbase` | ExecBase scheduler state (dispatch counters, `Disable()`/`Forbid()` nesting, `AttnFlags`) and the machine facts exec recorded at boot |
+| `tasks` | the scheduled task plus the ready and waiting lists |
+| `task [ADDR\|NAME]` | one `struct Task` in full -- flags, signals, trap/exception vectors, stack use, and the process/CLI half when it has one (no argument: `ThisTask`) |
+| `memlist` | exec's memory list with free, largest chunk, and attributes per region |
+
+These four are the same dumps the debugger console prints for `EXECBASE`,
+`TASKS`, `TASK`, and `MEMLIST` (see [](console.md)), so a headless
+`--gdb` session sees exactly what the window would show. When the OS is
+not up yet, they say so rather than printing garbage.

--- a/docs/debugger/workflows.md
+++ b/docs/debugger/workflows.md
@@ -97,10 +97,14 @@ The machine gurus, or worse, freezes silently.
    cannot guru -- the CPU halts. Copperline surfaces it on screen, in
    the console, and on the Break tab automatically; `HISTORY` is the
    main tool from there.
-5. For OS-level context: `TASKS` shows what was scheduled, `CATCHTASK
-   NAME` stops when a suspect process next gets the CPU, and `SEGMENTS`
-   maps a process's loaded hunks so addresses in `HISTORY` can be
-   attributed to a program rather than "somewhere in RAM".
+5. For OS-level context: `TASKS` shows what was scheduled, `TASK` dumps
+   the culprit in full (stack use, signals, trap vectors, its CLI
+   command), `EXECBASE` says whether exec is still dispatching at all --
+   a stuck `IDNestCnt`/`TDNestCnt` is a `Disable()`/`Forbid()` nobody
+   paired -- `CATCHTASK NAME` stops when a suspect process next gets the
+   CPU, and `SEGMENTS` maps a process's loaded hunks so addresses in
+   `HISTORY` can be attributed to a program rather than "somewhere in
+   RAM".
 
 ## Find the lives counter (memory hunting)
 

--- a/src/amigaos.rs
+++ b/src/amigaos.rs
@@ -1,20 +1,44 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 //! Read-only AmigaOS (exec.library) structure walking for the debugger:
-//! the task, library, device, resource, and port lists, reached from
-//! ExecBase via side-effect-free memory peeks. The offsets are exec's
-//! public ABI (execbase.h / nodes.h / lists.h), stable from Kickstart
-//! 1.x through 3.x and AROS, so no version sniffing is needed -- only
-//! pointer plausibility checks, since the OS may simply not be up yet.
+//! the task, library, device, resource, and port lists, ExecBase's own
+//! scheduler state, one task or process in full, and the memory list,
+//! all reached from ExecBase via side-effect-free memory peeks. The
+//! offsets are exec's public ABI (execbase.h / nodes.h / lists.h /
+//! tasks.h / memory.h), stable from Kickstart 1.x through 3.x and AROS,
+//! so no version sniffing is needed -- only pointer plausibility checks,
+//! since the OS may simply not be up yet.
 
 pub mod dos;
+pub mod dump;
 
 use std::collections::HashMap;
 
 /// ExecBase field offsets (execbase.h).
 const EXECBASE_PTR: u32 = 4;
+const SOFT_VER: u32 = 0x22;
 const CHKBASE: u32 = 0x26;
+const COLD_CAPTURE: u32 = 0x2A;
+const COOL_CAPTURE: u32 = 0x2E;
+const WARM_CAPTURE: u32 = 0x32;
+const SYS_STK_UPPER: u32 = 0x36;
+const SYS_STK_LOWER: u32 = 0x3A;
+const MAX_LOC_MEM: u32 = 0x3E;
+const MAX_EXT_MEM: u32 = 0x4E;
 const THIS_TASK: u32 = 0x114;
+const IDLE_COUNT: u32 = 0x118;
+const DISP_COUNT: u32 = 0x11C;
+const QUANTUM: u32 = 0x120;
+const ELAPSED: u32 = 0x122;
+const SYS_FLAGS: u32 = 0x124;
+const ID_NEST_CNT: u32 = 0x126;
+const TD_NEST_CNT: u32 = 0x127;
+const ATTN_FLAGS: u32 = 0x128;
+const ATTN_RESCHED: u32 = 0x12A;
+const RES_MODULES: u32 = 0x12C;
+const TASK_SIG_ALLOC: u32 = 0x13C;
+const TASK_TRAP_ALLOC: u32 = 0x140;
+const MEM_LIST: u32 = 0x142;
 const RESOURCE_LIST: u32 = 0x150;
 const DEVICE_LIST: u32 = 0x15E;
 const INTR_LIST: u32 = 0x16C;
@@ -22,16 +46,53 @@ const LIB_LIST: u32 = 0x17A;
 const PORT_LIST: u32 = 0x188;
 const TASK_READY: u32 = 0x196;
 const TASK_WAIT: u32 = 0x1A4;
+const LAST_ALERT: u32 = 0x202;
+const VBLANK_FREQUENCY: u32 = 0x212;
+const POWER_SUPPLY_FREQUENCY: u32 = 0x213;
+/// V36+ only; reads as garbage on a 1.x ExecBase, so it is only
+/// reported when it looks like a real E-clock rate.
+const ECLOCK_FREQUENCY: u32 = 0x238;
 
 /// Node field offsets (nodes.h).
 const LN_TYPE: u32 = 8;
 const LN_PRI: u32 = 9;
 const LN_NAME: u32 = 10;
 /// Task field offsets (tasks.h).
+const TC_FLAGS: u32 = 14;
 const TC_STATE: u32 = 15;
+const TC_ID_NEST_CNT: u32 = 0x10;
+const TC_TD_NEST_CNT: u32 = 0x11;
+const TC_SIG_ALLOC: u32 = 0x12;
+const TC_SIG_WAIT: u32 = 0x16;
+const TC_SIG_RECVD: u32 = 0x1A;
+const TC_SIG_EXCEPT: u32 = 0x1E;
+/// tc_TrapAlloc/tc_TrapAble, or the ETask pointer that overlays them
+/// (tc_UnionETask) once TF_ETASK says the task has one -- which is how
+/// AROS and OS 4-era exec keep per-task extended state.
+const TC_TRAP_ALLOC: u32 = 0x22;
+const TC_TRAP_ABLE: u32 = 0x24;
+const TF_ETASK: u8 = 0x08;
+const TC_EXCEPT_DATA: u32 = 0x26;
+const TC_EXCEPT_CODE: u32 = 0x2A;
+const TC_TRAP_DATA: u32 = 0x2E;
+const TC_TRAP_CODE: u32 = 0x32;
+const TC_SP_REG: u32 = 0x36;
+const TC_SP_LOWER: u32 = 0x3A;
+const TC_SP_UPPER: u32 = 0x3E;
+const TC_SWITCH: u32 = 0x42;
+const TC_LAUNCH: u32 = 0x46;
+const TC_USER_DATA: u32 = 0x58;
 /// Library field offsets (libraries.h).
 const LIB_VERSION: u32 = 20;
 const LIB_REVISION: u32 = 22;
+/// MemHeader field offsets (memory.h).
+const MH_ATTRIBUTES: u32 = 0x0E;
+const MH_FIRST: u32 = 0x10;
+const MH_LOWER: u32 = 0x14;
+const MH_UPPER: u32 = 0x18;
+const MH_FREE: u32 = 0x1C;
+/// MemChunk: mc_Next, then mc_Bytes.
+const MC_BYTES: u32 = 4;
 
 /// Nodes returned per list, bounding walks over corrupt lists.
 const LIST_CAP: usize = 200;
@@ -96,6 +157,104 @@ pub fn task_state_name(state: u8) -> &'static str {
         6 => "removed",
         _ => "?",
     }
+}
+
+/// Human name of an ln_Type value (nodes.h).
+pub fn node_type_name(node_type: u8) -> &'static str {
+    match node_type {
+        0 => "unknown",
+        1 => "task",
+        2 => "interrupt",
+        3 => "device",
+        4 => "msgport",
+        5 => "message",
+        6 => "freemsg",
+        7 => "replymsg",
+        8 => "resource",
+        9 => "library",
+        10 => "memory",
+        11 => "softint",
+        12 => "font",
+        13 => "process",
+        14 => "semaphore",
+        15 => "signalsem",
+        16 => "bootnode",
+        17 => "kickmem",
+        18 => "graphics",
+        19 => "deathmessage",
+        254 => "user",
+        255 => "extended",
+        _ => "?",
+    }
+}
+
+/// Set tc_Flags bit names (tasks.h).
+pub fn task_flag_names(flags: u8) -> Vec<&'static str> {
+    const NAMES: [(u8, &str); 6] = [
+        (0x01, "PROCTIME"),
+        (0x08, "ETASK"),
+        (0x10, "STACKCHK"),
+        (0x20, "EXCEPT"),
+        (0x40, "SWITCH"),
+        (0x80, "LAUNCH"),
+    ];
+    NAMES
+        .iter()
+        .filter(|(bit, _)| flags & bit != 0)
+        .map(|(_, name)| *name)
+        .collect()
+}
+
+/// Set AttnFlags bit names: the CPU and FPU exec detected at boot
+/// (execbase.h). Bit 7 is the 68060 flag the 68060 support libraries
+/// and OS 3.5+ set; Commodore's own includes leave it reserved.
+pub fn attn_flag_names(flags: u16) -> Vec<&'static str> {
+    const NAMES: [(u16, &str); 8] = [
+        (0x0001, "68010"),
+        (0x0002, "68020"),
+        (0x0004, "68030"),
+        (0x0008, "68040"),
+        (0x0010, "68881"),
+        (0x0020, "68882"),
+        (0x0040, "FPU40"),
+        (0x0080, "68060"),
+    ];
+    NAMES
+        .iter()
+        .filter(|(bit, _)| flags & bit != 0)
+        .map(|(_, name)| *name)
+        .collect()
+}
+
+/// Set SysFlags bit names: exec's private scheduler attention bits.
+pub fn sys_flag_names(flags: u16) -> Vec<&'static str> {
+    const NAMES: [(u16, &str); 3] = [
+        (0x2000, "SINT"), // a software interrupt is pending
+        (0x4000, "TQE"),  // the running task's quantum expired
+        (0x8000, "SAR"),  // scheduling attention required
+    ];
+    NAMES
+        .iter()
+        .filter(|(bit, _)| flags & bit != 0)
+        .map(|(_, name)| *name)
+        .collect()
+}
+
+/// Set MemHeader mh_Attributes bit names (memory.h).
+pub fn mem_attr_names(attrs: u16) -> Vec<&'static str> {
+    const NAMES: [(u16, &str); 6] = [
+        (0x0001, "PUBLIC"),
+        (0x0002, "CHIP"),
+        (0x0004, "FAST"),
+        (0x0100, "LOCAL"),
+        (0x0200, "24BITDMA"),
+        (0x0400, "KICK"),
+    ];
+    NAMES
+        .iter()
+        .filter(|(bit, _)| attrs & bit != 0)
+        .map(|(_, name)| *name)
+        .collect()
 }
 
 /// Heuristic: even and in an address range where exec structures can
@@ -221,6 +380,169 @@ impl OsMemory<'_> {
     }
 }
 
+/// ExecBase's own state: the scheduler fields that say what exec is
+/// doing right now, plus the machine facts it recorded at boot. Only
+/// what a dump wants is lifted; the rest stays a memory peek away.
+pub struct ExecInfo {
+    pub base: u32,
+    /// exec.library's own lib_Version/lib_Revision and SoftVer.
+    pub version: u16,
+    pub revision: u16,
+    pub soft_ver: u16,
+    /// Scheduler state (the fields that move on every dispatch).
+    pub idle_count: u32,
+    pub disp_count: u32,
+    pub quantum: u16,
+    pub elapsed: u16,
+    pub sys_flags: u16,
+    /// Disable()/Forbid() nesting. -1 means enabled; 0 and up is the
+    /// nesting depth, so a positive IDNestCnt means interrupts are off.
+    pub id_nest_cnt: i8,
+    pub td_nest_cnt: i8,
+    pub attn_flags: u16,
+    pub attn_resched: u16,
+    /// ThisTask and its name (empty when the pointer is implausible).
+    pub this_task: u32,
+    pub this_task_name: String,
+    /// Signals and traps exec hands newly created tasks.
+    pub task_sig_alloc: u32,
+    pub task_trap_alloc: u16,
+    /// Memory exec sized at boot, and its own supervisor stack.
+    pub max_loc_mem: u32,
+    pub max_ext_mem: u32,
+    pub sys_stk_lower: u32,
+    pub sys_stk_upper: u32,
+    /// Timing, as exec measured it. `eclock_freq` is a V36+ field and is
+    /// None on a 1.x ExecBase, where the longword is something else.
+    pub vblank_freq: u8,
+    pub power_freq: u8,
+    pub eclock_freq: Option<u32>,
+    /// The last alert exec put up (LastAlert[4]).
+    pub last_alert: [u32; 4],
+    /// Reset-survival vectors and the resident list.
+    pub cold_capture: u32,
+    pub cool_capture: u32,
+    pub warm_capture: u32,
+    pub res_modules: u32,
+}
+
+/// One MemHeader off ExecBase's MemList, with its free list summarized.
+pub struct MemRegion {
+    pub addr: u32,
+    pub name: String,
+    pub pri: i8,
+    pub attributes: u16,
+    pub lower: u32,
+    pub upper: u32,
+    /// mh_Free as exec maintains it.
+    pub free: u32,
+    /// Largest free chunk and the chunk count, walked from mh_First.
+    pub largest: u32,
+    pub chunks: usize,
+}
+
+impl MemRegion {
+    /// Bytes between mh_Lower and mh_Upper, 0 for a nonsensical header.
+    pub fn size(&self) -> u32 {
+        self.upper.saturating_sub(self.lower)
+    }
+}
+
+/// Free chunks walked per MemHeader, bounding a corrupt free list.
+const CHUNK_CAP: usize = 4096;
+
+impl OsMemory<'_> {
+    /// ExecBase's scheduler and machine state.
+    pub fn exec_info(&self, base: u32) -> ExecInfo {
+        let peek32 = |off: u32| (self.peek32)(base.wrapping_add(off));
+        let peek16 = |off: u32| self.peek16(base.wrapping_add(off));
+        let peek8 = |off: u32| (self.peek8)(base.wrapping_add(off));
+        let this_task = peek32(THIS_TASK);
+        // PAL 709379 Hz, NTSC 715909 Hz; anything far off that is a 1.x
+        // ExecBase whose structure simply ends before this field.
+        let eclock = peek32(ECLOCK_FREQUENCY);
+        ExecInfo {
+            base,
+            version: peek16(LIB_VERSION),
+            revision: peek16(LIB_REVISION),
+            soft_ver: peek16(SOFT_VER),
+            idle_count: peek32(IDLE_COUNT),
+            disp_count: peek32(DISP_COUNT),
+            quantum: peek16(QUANTUM),
+            elapsed: peek16(ELAPSED),
+            sys_flags: peek16(SYS_FLAGS),
+            id_nest_cnt: peek8(ID_NEST_CNT) as i8,
+            td_nest_cnt: peek8(TD_NEST_CNT) as i8,
+            attn_flags: peek16(ATTN_FLAGS),
+            attn_resched: peek16(ATTN_RESCHED),
+            this_task,
+            this_task_name: if plausible_ptr(this_task) {
+                self.node_name(this_task)
+            } else {
+                String::new()
+            },
+            task_sig_alloc: peek32(TASK_SIG_ALLOC),
+            task_trap_alloc: peek16(TASK_TRAP_ALLOC),
+            max_loc_mem: peek32(MAX_LOC_MEM),
+            max_ext_mem: peek32(MAX_EXT_MEM),
+            sys_stk_lower: peek32(SYS_STK_LOWER),
+            sys_stk_upper: peek32(SYS_STK_UPPER),
+            vblank_freq: peek8(VBLANK_FREQUENCY),
+            power_freq: peek8(POWER_SUPPLY_FREQUENCY),
+            eclock_freq: (600_000..1_000_000).contains(&eclock).then_some(eclock),
+            last_alert: [
+                peek32(LAST_ALERT),
+                peek32(LAST_ALERT + 4),
+                peek32(LAST_ALERT + 8),
+                peek32(LAST_ALERT + 12),
+            ],
+            cold_capture: peek32(COLD_CAPTURE),
+            cool_capture: peek32(COOL_CAPTURE),
+            warm_capture: peek32(WARM_CAPTURE),
+            res_modules: peek32(RES_MODULES),
+        }
+    }
+
+    /// Walk ExecBase's MemList, summarizing each region's free list.
+    pub fn mem_list(&self, execbase: u32) -> Vec<MemRegion> {
+        let mut out = Vec::new();
+        let mut node = (self.peek32)(execbase.wrapping_add(MEM_LIST));
+        while plausible_ptr(node) && (self.peek32)(node) != 0 && out.len() < LIST_CAP {
+            let (largest, chunks) = self.free_chunks(node);
+            out.push(MemRegion {
+                addr: node,
+                name: self.node_name(node),
+                pri: (self.peek8)(node.wrapping_add(LN_PRI)) as i8,
+                attributes: self.peek16(node.wrapping_add(MH_ATTRIBUTES)),
+                lower: (self.peek32)(node.wrapping_add(MH_LOWER)),
+                upper: (self.peek32)(node.wrapping_add(MH_UPPER)),
+                free: (self.peek32)(node.wrapping_add(MH_FREE)),
+                largest,
+                chunks,
+            });
+            node = (self.peek32)(node);
+        }
+        out
+    }
+
+    /// (largest chunk, chunk count) of one MemHeader's free list. Chunks
+    /// must sit inside the header's own bounds and ascend, which is what
+    /// exec guarantees and what stops a trashed list from looping.
+    fn free_chunks(&self, header: u32) -> (u32, usize) {
+        let lower = (self.peek32)(header.wrapping_add(MH_LOWER));
+        let upper = (self.peek32)(header.wrapping_add(MH_UPPER));
+        let mut chunk = (self.peek32)(header.wrapping_add(MH_FIRST));
+        let (mut largest, mut count, mut prev) = (0u32, 0usize, 0u32);
+        while chunk >= lower && chunk < upper && chunk > prev && count < CHUNK_CAP {
+            largest = largest.max((self.peek32)(chunk.wrapping_add(MC_BYTES)));
+            count += 1;
+            prev = chunk;
+            chunk = (self.peek32)(chunk);
+        }
+        (largest, count)
+    }
+}
+
 /// One hunk of a loaded DOS segment list.
 pub struct Segment {
     /// First byte of the hunk's payload (code/data).
@@ -229,13 +551,27 @@ pub struct Segment {
     pub size: u32,
 }
 
-/// Process field offsets (dos/dosextens.h). pr_SegList/pr_CLI are BPTRs.
+/// Process field offsets (dos/dosextens.h). pr_SegList/pr_CLI and the
+/// directory and stack fields are BPTRs.
 const PR_SEGLIST: u32 = 0x80;
+const PR_STACK_SIZE: u32 = 0x84;
+const PR_TASK_NUM: u32 = 0x8C;
+const PR_STACK_BASE: u32 = 0x90;
+const PR_RESULT2: u32 = 0x94;
+const PR_CURRENT_DIR: u32 = 0x98;
+const PR_CONSOLE_TASK: u32 = 0xA4;
 const PR_CLI: u32 = 0xAC;
+const PR_WINDOW_PTR: u32 = 0xB8;
+const PR_HOME_DIR: u32 = 0xBC;
 /// CommandLineInterface field offsets: cli_Module is the BPTR to the
 /// currently running command's segment list, cli_CommandName the BSTR
 /// naming the command it belongs to.
+const CLI_SET_NAME: u32 = 0x04;
+const CLI_RETURN_CODE: u32 = 0x0C;
 const CLI_COMMAND_NAME: u32 = 0x10;
+const CLI_FAIL_LEVEL: u32 = 0x14;
+const CLI_BACKGROUND: u32 = 0x2C;
+const CLI_DEFAULT_STACK: u32 = 0x34;
 const CLI_MODULE: u32 = 0x3C;
 /// NT_PROCESS in ln_Type.
 const NT_PROCESS: u8 = 13;
@@ -359,6 +695,175 @@ impl OsMemory<'_> {
 /// volume/device colon.
 pub fn command_basename(path: &str) -> &str {
     path.rsplit(['/', ':']).next().unwrap_or(path)
+}
+
+/// One task in full: struct Task as exec keeps it (tasks.h), plus the
+/// process half when ln_Type says the structure continues.
+pub struct TaskInfo {
+    pub addr: u32,
+    pub name: String,
+    pub node_type: u8,
+    pub pri: i8,
+    pub flags: u8,
+    pub state: u8,
+    /// Per-task Disable()/Forbid() nesting, saved across a switch.
+    pub id_nest_cnt: i8,
+    pub td_nest_cnt: i8,
+    pub sig_alloc: u32,
+    pub sig_wait: u32,
+    pub sig_recvd: u32,
+    pub sig_except: u32,
+    pub trap_alloc: u16,
+    pub trap_able: u16,
+    /// tc_UnionETask: with TF_ETASK set, the two trap words are really a
+    /// pointer to the task's ETask, and `trap_alloc`/`trap_able` are the
+    /// halves of that pointer rather than trap masks.
+    pub etask: Option<u32>,
+    pub except_code: u32,
+    pub except_data: u32,
+    pub trap_code: u32,
+    pub trap_data: u32,
+    /// tc_SPReg is the stack pointer exec saved at the last switch; for
+    /// the running task the live A7 is the truthful one.
+    pub sp_reg: u32,
+    pub sp_lower: u32,
+    pub sp_upper: u32,
+    pub switch_fn: u32,
+    pub launch_fn: u32,
+    pub user_data: u32,
+    pub process: Option<ProcessInfo>,
+}
+
+/// The DOS half of a Process, and the CLI behind it when it has one.
+pub struct ProcessInfo {
+    /// pr_TaskNum: the CLI number, 0 for a non-CLI process.
+    pub task_num: i32,
+    pub stack_size: u32,
+    /// pr_StackBase (BPTR) and the IoErr() value pr_Result2.
+    pub stack_base: u32,
+    pub result2: i32,
+    /// BPTR locks and pointers worth showing raw.
+    pub current_dir: u32,
+    pub home_dir: u32,
+    pub console_task: u32,
+    pub window_ptr: u32,
+    pub seglist: u32,
+    /// The CLI, when the process has one: its BPTR, the command it is
+    /// running, and the shell state a crash investigation wants.
+    pub cli: u32,
+    pub command: String,
+    pub set_name: String,
+    pub return_code: i32,
+    pub fail_level: i32,
+    pub background: bool,
+    pub default_stack: u32,
+    /// Hunks of the program the process is running, when walkable.
+    pub segments: Vec<Segment>,
+}
+
+impl TaskInfo {
+    /// (stack size, bytes in use) measured from `sp`, or None when the
+    /// bounds are not a sane stack. Pass the live A7 for the running
+    /// task; tc_SPReg is stale until exec switches away from it.
+    pub fn stack_usage(&self, sp: u32) -> Option<(u32, u32)> {
+        if self.sp_lower == 0 || self.sp_upper <= self.sp_lower {
+            return None;
+        }
+        let size = self.sp_upper - self.sp_lower;
+        // A stack larger than 16 MiB is a misread, not a stack.
+        if size > 0x0100_0000 || !(self.sp_lower..=self.sp_upper).contains(&sp) {
+            return None;
+        }
+        Some((size, self.sp_upper - sp))
+    }
+}
+
+impl OsMemory<'_> {
+    /// Read one task (or process) structure. The caller decides that
+    /// `addr` is worth reading; nothing here writes or faults.
+    pub fn task_info(&self, addr: u32) -> TaskInfo {
+        let peek32 = |off: u32| (self.peek32)(addr.wrapping_add(off));
+        let peek16 = |off: u32| self.peek16(addr.wrapping_add(off));
+        let peek8 = |off: u32| (self.peek8)(addr.wrapping_add(off));
+        let node_type = peek8(LN_TYPE);
+        let flags = peek8(TC_FLAGS);
+        TaskInfo {
+            addr,
+            name: self.node_name(addr),
+            node_type,
+            pri: peek8(LN_PRI) as i8,
+            flags,
+            state: peek8(TC_STATE),
+            id_nest_cnt: peek8(TC_ID_NEST_CNT) as i8,
+            td_nest_cnt: peek8(TC_TD_NEST_CNT) as i8,
+            sig_alloc: peek32(TC_SIG_ALLOC),
+            sig_wait: peek32(TC_SIG_WAIT),
+            sig_recvd: peek32(TC_SIG_RECVD),
+            sig_except: peek32(TC_SIG_EXCEPT),
+            trap_alloc: peek16(TC_TRAP_ALLOC),
+            trap_able: peek16(TC_TRAP_ABLE),
+            etask: (flags & TF_ETASK != 0).then(|| peek32(TC_TRAP_ALLOC)),
+            except_code: peek32(TC_EXCEPT_CODE),
+            except_data: peek32(TC_EXCEPT_DATA),
+            trap_code: peek32(TC_TRAP_CODE),
+            trap_data: peek32(TC_TRAP_DATA),
+            sp_reg: peek32(TC_SP_REG),
+            sp_lower: peek32(TC_SP_LOWER),
+            sp_upper: peek32(TC_SP_UPPER),
+            switch_fn: peek32(TC_SWITCH),
+            launch_fn: peek32(TC_LAUNCH),
+            user_data: peek32(TC_USER_DATA),
+            process: (node_type == NT_PROCESS).then(|| self.process_info(addr)),
+        }
+    }
+
+    /// The DOS half of a process structure.
+    fn process_info(&self, task: u32) -> ProcessInfo {
+        let peek32 = |off: u32| (self.peek32)(task.wrapping_add(off));
+        let cli = peek32(PR_CLI);
+        let cli_addr = plausible_bptr(cli).then_some(cli << 2);
+        let cli32 = |off: u32| cli_addr.map_or(0, |a| (self.peek32)(a.wrapping_add(off)));
+        let seglist = self.process_seglist(task).unwrap_or(0);
+        ProcessInfo {
+            task_num: peek32(PR_TASK_NUM) as i32,
+            stack_size: peek32(PR_STACK_SIZE),
+            stack_base: peek32(PR_STACK_BASE),
+            result2: peek32(PR_RESULT2) as i32,
+            current_dir: peek32(PR_CURRENT_DIR),
+            home_dir: peek32(PR_HOME_DIR),
+            console_task: peek32(PR_CONSOLE_TASK),
+            window_ptr: peek32(PR_WINDOW_PTR),
+            seglist,
+            cli,
+            // A full AmigaDOS path fits in a 255-byte BSTR.
+            command: command_basename(&self.read_bstr(cli32(CLI_COMMAND_NAME), 255)).to_string(),
+            set_name: self.read_bstr(cli32(CLI_SET_NAME), 255),
+            return_code: cli32(CLI_RETURN_CODE) as i32,
+            fail_level: cli32(CLI_FAIL_LEVEL) as i32,
+            background: cli32(CLI_BACKGROUND) != 0,
+            default_stack: cli32(CLI_DEFAULT_STACK),
+            segments: if seglist != 0 {
+                self.walk_seglist(seglist)
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    /// Every task exec knows about whose name contains `needle`, matched
+    /// case-insensitively -- the same rule as the debugger's task catch.
+    pub fn find_tasks(&self, execbase: u32, needle: &str) -> Vec<u32> {
+        let needle = needle.to_ascii_lowercase();
+        let mut out: Vec<u32> = Vec::new();
+        for addr in self.task_addrs(execbase) {
+            // ThisTask can also appear on a list; one hit per task keeps
+            // a name lookup unambiguous.
+            if !out.contains(&addr) && self.node_name(addr).to_ascii_lowercase().contains(&needle) {
+                out.push(addr);
+            }
+        }
+        out
+    }
 }
 
 /// A loaded hunk must sit in RAM exec could have allocated and carry a
@@ -542,6 +1047,12 @@ mod tests {
             }
         }
 
+        fn put16(&mut self, addr: u32, value: u16) {
+            for (i, b) in value.to_be_bytes().iter().enumerate() {
+                self.0.insert(addr + i as u32, *b);
+            }
+        }
+
         fn put8(&mut self, addr: u32, value: u8) {
             self.0.insert(addr, value);
         }
@@ -639,6 +1150,236 @@ mod tests {
 
         // Untouched lists read as empty, not garbage.
         assert!(os.walk(base, OsList::Ports).is_empty());
+    }
+
+    #[test]
+    fn reads_execbase_scheduler_and_machine_state() {
+        let mut mem = build_exec_world();
+        let base = 0x00C0_0676;
+        mem.put16(base + LIB_VERSION, 40);
+        mem.put16(base + LIB_REVISION, 10);
+        mem.put16(base + SOFT_VER, 40);
+        mem.put32(base + IDLE_COUNT, 0x0001_2345);
+        mem.put32(base + DISP_COUNT, 6789);
+        mem.put16(base + QUANTUM, 4);
+        mem.put16(base + ELAPSED, 3);
+        mem.put16(base + SYS_FLAGS, 0xA000); // SAR + SINT
+        mem.put8(base + ID_NEST_CNT, 0xFF); // -1: interrupts enabled
+        mem.put8(base + TD_NEST_CNT, 1); // Forbid()den, nested twice
+        mem.put16(base + ATTN_FLAGS, 0x0027); // 68010/68020/68030/68882
+        mem.put16(base + ATTN_RESCHED, 0x0080);
+        mem.put8(base + VBLANK_FREQUENCY, 50);
+        mem.put8(base + POWER_SUPPLY_FREQUENCY, 50);
+        mem.put32(base + ECLOCK_FREQUENCY, 709_379);
+        mem.put32(base + LAST_ALERT, 0x8100_0009);
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let info = {
+            let os = os(&peek8, &peek32);
+            os.exec_info(os.exec_base().unwrap())
+        };
+
+        assert_eq!((info.version, info.revision, info.soft_ver), (40, 10, 40));
+        assert_eq!(info.idle_count, 0x0001_2345);
+        assert_eq!(info.disp_count, 6789);
+        assert_eq!((info.quantum, info.elapsed), (4, 3));
+        assert_eq!(sys_flag_names(info.sys_flags), ["SINT", "SAR"]);
+        assert_eq!(info.id_nest_cnt, -1);
+        assert_eq!(info.td_nest_cnt, 1);
+        assert_eq!(
+            attn_flag_names(info.attn_flags),
+            ["68010", "68020", "68030", "68882"]
+        );
+        assert_eq!(info.attn_resched, 0x0080);
+        assert_eq!(info.this_task_name, "input.device");
+        assert_eq!((info.vblank_freq, info.power_freq), (50, 50));
+        assert_eq!(info.eclock_freq, Some(709_379));
+        assert_eq!(info.last_alert[0], 0x8100_0009);
+
+        // A 1.x ExecBase ends before ex_EClockFrequency: whatever the
+        // longword holds there is not reported as a clock rate.
+        let mut old = build_exec_world();
+        old.put32(base + ECLOCK_FREQUENCY, 0x0002_1000);
+        let peek8 = |a: u32| old.peek8(a);
+        let peek32 = |a: u32| old.peek32(a);
+        assert_eq!(os(&peek8, &peek32).exec_info(base).eclock_freq, None);
+    }
+
+    #[test]
+    fn reads_a_task_structure_with_stack_use() {
+        let mut mem = build_exec_world();
+        let this = 0x0002_1000;
+        mem.put8(this + TC_FLAGS, 0x50); // STACKCHK | SWITCH
+        mem.put8(this + TC_ID_NEST_CNT, 0xFF);
+        mem.put8(this + TC_TD_NEST_CNT, 0xFF);
+        mem.put32(this + TC_SIG_ALLOC, 0x0000_FFFF);
+        mem.put32(this + TC_SIG_WAIT, 0x0000_1000);
+        mem.put32(this + TC_SIG_RECVD, 0x0000_0010);
+        mem.put32(this + TC_SIG_EXCEPT, 0x0000_0020);
+        mem.put16(this + TC_TRAP_ALLOC, 0x0003);
+        mem.put16(this + TC_TRAP_ABLE, 0x0001);
+        mem.put32(this + TC_TRAP_CODE, 0x00FC_1234);
+        mem.put32(this + TC_EXCEPT_CODE, 0x0002_A000);
+        mem.put32(this + TC_SP_REG, 0x0007_FF00);
+        mem.put32(this + TC_SP_LOWER, 0x0007_F000);
+        mem.put32(this + TC_SP_UPPER, 0x0008_0000);
+        mem.put32(this + TC_USER_DATA, 0x0002_B000);
+        let task = {
+            let peek8 = |a: u32| mem.peek8(a);
+            let peek32 = |a: u32| mem.peek32(a);
+            os(&peek8, &peek32).task_info(this)
+        };
+
+        assert_eq!(task.name, "input.device");
+        assert_eq!(task_flag_names(task.flags), ["STACKCHK", "SWITCH"]);
+        assert_eq!(node_type_name(task.node_type), "process");
+        assert_eq!(task_state_name(task.state), "run");
+        assert_eq!(task.sig_wait, 0x0000_1000);
+        assert_eq!(task.trap_code, 0x00FC_1234);
+        assert_eq!(task.except_code, 0x0002_A000);
+        assert_eq!(task.user_data, 0x0002_B000);
+        // 4 KiB of stack with 256 bytes below the top in use.
+        assert_eq!(task.stack_usage(task.sp_reg), Some((0x1000, 0x100)));
+        // The live A7 is what counts for the running task.
+        assert_eq!(task.stack_usage(0x0007_F800), Some((0x1000, 0x800)));
+        // A stack pointer outside the bounds is not a use figure.
+        assert_eq!(task.stack_usage(0x0009_0000), None);
+        // Without TF_ETASK the trap words are trap masks.
+        assert_eq!(task.etask, None);
+        assert_eq!((task.trap_alloc, task.trap_able), (3, 1));
+
+        // With TF_ETASK (AROS, and OS 4-era exec) the same two words are
+        // the ETask pointer, so they must not read as trap masks.
+        mem.put8(this + TC_FLAGS, 0x58);
+        mem.put32(this + TC_TRAP_ALLOC, 0x00C3_5978);
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        assert_eq!(os(&peek8, &peek32).task_info(this).etask, Some(0x00C3_5978));
+    }
+
+    #[test]
+    fn reads_the_process_and_cli_half_of_a_task() {
+        let mut mem = build_cli_world();
+        let this = 0x0002_1000;
+        let cli_addr = 0x0003_0000u32;
+        mem.put32(cli_addr + CLI_MODULE, 0x8000 >> 2);
+        mem.put32(cli_addr + CLI_RETURN_CODE, 20);
+        mem.put32(cli_addr + CLI_FAIL_LEVEL, 10);
+        mem.put32(cli_addr + CLI_BACKGROUND, 1);
+        mem.put32(cli_addr + CLI_DEFAULT_STACK, 1024);
+        mem.put32(cli_addr + CLI_SET_NAME, 0x0003_2000 >> 2);
+        mem.put8(0x0003_2000, 5);
+        for (i, b) in b"Work:".iter().enumerate() {
+            mem.put8(0x0003_2001 + i as u32, *b);
+        }
+        mem.put32(this + PR_TASK_NUM, 3);
+        mem.put32(this + PR_STACK_SIZE, 4096);
+        mem.put32(this + PR_RESULT2, 205); // ERROR_OBJECT_NOT_FOUND
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let os = os(&peek8, &peek32);
+        let task = os.task_info(this);
+        let proc = task.process.expect("NT_PROCESS gets a process half");
+
+        assert_eq!(proc.task_num, 3);
+        assert_eq!(proc.command, "hello");
+        assert_eq!(proc.set_name, "Work:");
+        assert_eq!((proc.return_code, proc.fail_level), (20, 10));
+        assert!(proc.background);
+        assert_eq!(proc.default_stack, 1024);
+        assert_eq!(proc.stack_size, 4096);
+        assert_eq!(proc.result2, 205);
+        assert_eq!(proc.seglist, 0x8000 >> 2);
+        assert_eq!(proc.segments.len(), 2);
+        assert_eq!(proc.segments[0].start, 0x8004);
+
+        // A plain task has no process half at all.
+        let t1 = 0x0002_3000; // NT_UNKNOWN in build_exec_world
+        assert!(os.task_info(t1).process.is_none());
+    }
+
+    #[test]
+    fn finds_tasks_by_name_across_the_lists() {
+        let mem = build_exec_world();
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let os = os(&peek8, &peek32);
+        let base = os.exec_base().unwrap();
+        // Case-insensitive substring, ThisTask and the ready list both.
+        assert_eq!(os.find_tasks(base, "INPUT"), [0x0002_1000]);
+        assert_eq!(os.find_tasks(base, "trackdisk"), [0x0002_3000]);
+        assert_eq!(os.find_tasks(base, ".device").len(), 2);
+        assert!(os.find_tasks(base, "workbench").is_empty());
+    }
+
+    #[test]
+    fn summarizes_the_exec_memory_list() {
+        let mut mem = build_exec_world();
+        let base = 0x00C0_0676;
+        // One MemHeader for chip RAM with two free chunks, and one for
+        // fast RAM that is fully allocated (mh_First = 0).
+        let chip = 0x0004_0000u32;
+        let fast = 0x0004_1000u32;
+        mem.put32(base + MEM_LIST, chip);
+        mem.put32(chip, fast);
+        mem.put32(fast, base + MEM_LIST + 4); // succ -> lh_Tail
+        mem.put32(base + MEM_LIST + 4, 0);
+        mem.put_str(0x0004_2000, "chip memory");
+        mem.put32(chip + LN_NAME, 0x0004_2000);
+        mem.put8(chip + LN_PRI, -10i8 as u8);
+        mem.put16(chip + MH_ATTRIBUTES, 0x0003); // PUBLIC | CHIP
+        mem.put32(chip + MH_LOWER, 0x0000_0400);
+        mem.put32(chip + MH_UPPER, 0x0020_0000);
+        mem.put32(chip + MH_FREE, 0x0010_0000);
+        mem.put32(chip + MH_FIRST, 0x0001_0000);
+        mem.put32(0x0001_0000, 0x0018_0000); // mc_Next
+        mem.put32(0x0001_0000 + MC_BYTES, 0x0004_0000);
+        mem.put32(0x0018_0000, 0); // end of the free list
+        mem.put32(0x0018_0000 + MC_BYTES, 0x000C_0000);
+        mem.put_str(0x0004_3000, "fast memory");
+        mem.put32(fast + LN_NAME, 0x0004_3000);
+        mem.put16(fast + MH_ATTRIBUTES, 0x0005); // PUBLIC | FAST
+        mem.put32(fast + MH_LOWER, 0x0020_0000);
+        mem.put32(fast + MH_UPPER, 0x00A0_0000);
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let os = os(&peek8, &peek32);
+        let regions = os.mem_list(base);
+
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[0].name, "chip memory");
+        assert_eq!(regions[0].pri, -10);
+        assert_eq!(mem_attr_names(regions[0].attributes), ["PUBLIC", "CHIP"]);
+        assert_eq!(regions[0].size(), 0x0020_0000 - 0x400);
+        assert_eq!(regions[0].free, 0x0010_0000);
+        assert_eq!(regions[0].largest, 0x000C_0000);
+        assert_eq!(regions[0].chunks, 2);
+        // Fully allocated: no chunks, no largest, but still listed.
+        assert_eq!(regions[1].name, "fast memory");
+        assert_eq!(regions[1].chunks, 0);
+        assert_eq!(regions[1].largest, 0);
+    }
+
+    /// A trashed free list must not spin: chunks have to stay inside the
+    /// header and ascend, so a self-referential or backwards mc_Next
+    /// ends the walk.
+    #[test]
+    fn a_looping_free_list_terminates() {
+        let mut mem = build_exec_world();
+        let base = 0x00C0_0676;
+        let header = 0x0004_0000u32;
+        mem.put32(base + MEM_LIST, header);
+        mem.put32(header, base + MEM_LIST + 4);
+        mem.put32(base + MEM_LIST + 4, 0);
+        mem.put32(header + MH_LOWER, 0x0001_0000);
+        mem.put32(header + MH_UPPER, 0x0002_0000);
+        mem.put32(header + MH_FIRST, 0x0001_8000);
+        mem.put32(0x0001_8000, 0x0001_8000); // points at itself
+        mem.put32(0x0001_8000 + MC_BYTES, 0x100);
+        let peek8 = |a: u32| mem.peek8(a);
+        let peek32 = |a: u32| mem.peek32(a);
+        let regions = os(&peek8, &peek32).mem_list(base);
+        assert_eq!(regions[0].chunks, 1);
     }
 
     #[test]

--- a/src/amigaos/dump.rs
+++ b/src/amigaos/dump.rs
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Text dumps of the exec structures, one line per `Vec` entry, shared
+//! by the debugger console (`TASKS`, `TASK`, `EXECBASE`, `MEMLIST`) and
+//! the GDB stub's matching `monitor` commands so both interfaces report
+//! the same thing. A line beginning with `!` is an error the caller
+//! should surface as such; everything else is data.
+//!
+//! Every dump starts from a validated ExecBase and reads only through
+//! [`OsMemory`]'s side-effect-free peeks, so it is safe to run at any
+//! point in a session -- including before the OS exists, where the
+//! validation failure is what gets printed.
+
+use super::{OsList, OsMemory, TaskInfo};
+
+/// EXECBASE: exec's own state -- the scheduler counters and nesting
+/// counts that say what exec is doing, then the machine facts it
+/// recorded at boot.
+pub fn exec(os: &OsMemory, base: u32) -> Vec<String> {
+    let info = os.exec_info(base);
+    let flags = |names: Vec<&str>| {
+        if names.is_empty() {
+            "none".to_string()
+        } else {
+            names.join(" ")
+        }
+    };
+    let nesting = |count: i8, enabled: &str, disabled: &str| {
+        if count < 0 {
+            enabled.to_string()
+        } else {
+            format!("{disabled}, nesting {}", i32::from(count) + 1)
+        }
+    };
+    let mut lines = vec![
+        format!(
+            "ExecBase ${:06X}  exec.library v{}.{}  SoftVer {}",
+            info.base, info.version, info.revision, info.soft_ver
+        ),
+        format!(
+            "sched  IdleCount {}  DispCount {}  Quantum {}  Elapsed {}",
+            info.idle_count, info.disp_count, info.quantum, info.elapsed
+        ),
+        format!(
+            "sched  SysFlags ${:04X} ({})  AttnResched ${:04X}",
+            info.sys_flags,
+            flags(super::sys_flag_names(info.sys_flags)),
+            info.attn_resched
+        ),
+        format!(
+            "sched  IDNestCnt {} ({})",
+            info.id_nest_cnt,
+            nesting(info.id_nest_cnt, "interrupts enabled", "Disable()d")
+        ),
+        format!(
+            "sched  TDNestCnt {} ({})",
+            info.td_nest_cnt,
+            nesting(info.td_nest_cnt, "task switching enabled", "Forbid()den")
+        ),
+        format!(
+            "cpu    AttnFlags ${:04X} ({})",
+            info.attn_flags,
+            flags(super::attn_flag_names(info.attn_flags))
+        ),
+        format!(
+            "task   ThisTask ${:06X}  {}",
+            info.this_task,
+            if info.this_task_name.is_empty() {
+                "<not plausible>"
+            } else {
+                &info.this_task_name
+            }
+        ),
+        format!(
+            "task   TaskSigAlloc ${:08X}  TaskTrapAlloc ${:04X}",
+            info.task_sig_alloc, info.task_trap_alloc
+        ),
+        format!(
+            "mem    MaxLocMem ${:06X}  MaxExtMem ${:06X}",
+            info.max_loc_mem, info.max_ext_mem
+        ),
+        format!(
+            "mem    SysStk ${:06X}-${:06X}  ResModules ${:06X}",
+            info.sys_stk_lower, info.sys_stk_upper, info.res_modules
+        ),
+        format!(
+            "time   VBlank {} Hz  PSU {} Hz  EClock {}",
+            info.vblank_freq,
+            info.power_freq,
+            match info.eclock_freq {
+                Some(hz) => format!("{hz} Hz"),
+                None => "n/a (pre-V36 ExecBase)".to_string(),
+            }
+        ),
+        format!(
+            "capt   Cold ${:06X}  Cool ${:06X}  Warm ${:06X}",
+            info.cold_capture, info.cool_capture, info.warm_capture
+        ),
+    ];
+    // Exec parks -1 in LastAlert[0] when nothing has alerted; both
+    // Kickstart 3.1 and AROS boot with it that way.
+    lines.push(if matches!(info.last_alert[0], 0 | 0xFFFF_FFFF) {
+        "alert  none since reset".to_string()
+    } else {
+        format!(
+            "alert  ${:08X}: {}",
+            info.last_alert[0],
+            crate::debugger::guru_decode(info.last_alert[0])
+        )
+    });
+    lines
+}
+
+/// TASKS: the scheduled task (marked `>`) plus the ready and waiting
+/// lists, one line each.
+pub fn task_list(os: &OsMemory, base: u32) -> Vec<String> {
+    let mut lines = Vec::new();
+    match os.this_task(base) {
+        Some(task) => lines.push(format!(
+            "> ${:06X}  pri {:>4}  {:<7} {}",
+            task.addr, task.pri, "run", task.name
+        )),
+        None => lines.push("!ThisTask is not plausible".to_string()),
+    }
+    for (list, label) in [(OsList::TaskReady, "ready"), (OsList::TaskWait, "wait")] {
+        for node in os.walk(base, list) {
+            let state = super::task_state_name(node.state);
+            let state = if state == "?" { label } else { state };
+            lines.push(format!(
+                "  ${:06X}  pri {:>4}  {:<7} {}",
+                node.addr, node.pri, state, node.name
+            ));
+        }
+    }
+    if lines.len() == 1 {
+        lines.push("  (no other tasks)".to_string());
+    }
+    lines
+}
+
+/// The CPU's live stack pointers, which are what the running task's
+/// stack pointer really is: exec tasks run in user mode, so USP is the
+/// task's own SP whenever the snapshot lands in an interrupt or
+/// exception, and A7 (which then addresses the supervisor stack) is it
+/// otherwise -- in user mode the two are the same register. A task that
+/// runs supervisor-mode code is unusual but legal, so both are offered
+/// and whichever lands inside the task's stack is the one reported.
+#[derive(Clone, Copy)]
+pub struct LiveSp {
+    pub a7: u32,
+    pub usp: u32,
+}
+
+impl LiveSp {
+    /// The live stack pointer to report for `task`, with the register
+    /// name it came from.
+    fn pick(self, task: &TaskInfo) -> (u32, &'static str) {
+        if task.stack_usage(self.usp).is_some() || task.stack_usage(self.a7).is_none() {
+            (self.usp, "live USP")
+        } else {
+            (self.a7, "live A7")
+        }
+    }
+}
+
+/// TASK [ADDR|NAME]: one task or process in full. An empty `spec` dumps
+/// ExecBase->ThisTask; a `$`-prefixed spec is always an address; any
+/// other text is matched case-insensitively against the task names exec
+/// knows, falling back to a bare hex address when nothing matches.
+pub fn task(os: &OsMemory, base: u32, spec: &str, cpu_sp: LiveSp) -> Vec<String> {
+    let spec = spec.trim();
+    let hex = |token: &str| u32::from_str_radix(token.trim_start_matches('$'), 16).ok();
+    let single_token = !spec.contains(char::is_whitespace);
+    let this_task = os.exec_info(base).this_task;
+    let addr = match spec
+        .strip_prefix('$')
+        .filter(|_| single_token)
+        .and_then(hex)
+    {
+        Some(addr) => addr,
+        None if spec.is_empty() => this_task,
+        None => {
+            let matches = os.find_tasks(base, spec);
+            match matches[..] {
+                [] => match hex(spec).filter(|_| single_token) {
+                    Some(addr) => addr,
+                    None => return vec![format!("!no task matches \"{spec}\"")],
+                },
+                [addr] => addr,
+                _ => {
+                    let mut lines = vec![format!("\"{spec}\" matches several tasks:")];
+                    for addr in matches {
+                        lines.push(format!("  ${addr:06X}  {}", os.node_name(addr)));
+                    }
+                    lines.push("dump one with TASK $ADDR".to_string());
+                    return lines;
+                }
+            }
+        }
+    };
+    if !super::plausible_ptr(addr) {
+        return vec![format!(
+            "!${addr:06X} is not where a task structure can live"
+        )];
+    }
+    let info = os.task_info(addr);
+    // tc_SPReg is only current for a task exec has switched away from;
+    // the running task's stack pointer is live in the CPU.
+    let live_sp = (addr == this_task).then(|| cpu_sp.pick(&info));
+    task_lines(os, &info, live_sp)
+}
+
+/// Format one `struct Task` (and its process half, when it has one).
+/// `live_sp` is the CPU's stack pointer (and the register it came from)
+/// when this is the running task, whose tc_SPReg is stale until exec
+/// switches away from it.
+fn task_lines(os: &OsMemory, task: &TaskInfo, live_sp: Option<(u32, &str)>) -> Vec<String> {
+    let flag_names = super::task_flag_names(task.flags);
+    let mut lines = vec![
+        format!(
+            "task ${:06X}  {}  ({})  pri {}  state {}",
+            task.addr,
+            task.name,
+            super::node_type_name(task.node_type),
+            task.pri,
+            super::task_state_name(task.state)
+        ),
+        format!(
+            "  flags  ${:02X} ({})  IDNestCnt {}  TDNestCnt {}",
+            task.flags,
+            if flag_names.is_empty() {
+                "none".to_string()
+            } else {
+                flag_names.join(" ")
+            },
+            task.id_nest_cnt,
+            task.td_nest_cnt
+        ),
+        format!(
+            "  sigs   alloc ${:08X}  wait ${:08X}  recvd ${:08X}",
+            task.sig_alloc, task.sig_wait, task.sig_recvd
+        ),
+        format!(
+            "  sigs   except ${:08X}  {}",
+            task.sig_except,
+            match task.etask {
+                // TF_ETASK: the trap words are an ETask pointer instead.
+                Some(etask) => format!("ETask ${etask:06X}"),
+                None => format!(
+                    "trap alloc ${:04X} able ${:04X}",
+                    task.trap_alloc, task.trap_able
+                ),
+            }
+        ),
+        format!(
+            "  vecs   trap ${:06X}/${:06X}  except ${:06X}/${:06X}",
+            task.trap_code, task.trap_data, task.except_code, task.except_data
+        ),
+        format!(
+            "  vecs   switch ${:06X}  launch ${:06X}  userdata ${:06X}",
+            task.switch_fn, task.launch_fn, task.user_data
+        ),
+    ];
+    let (sp, source) = live_sp.unwrap_or((task.sp_reg, "SPReg"));
+    lines.push(match task.stack_usage(sp) {
+        Some((size, used)) => format!(
+            "  stack  ${:06X}-${:06X} ({size} bytes)  sp ${sp:06X} ({source}), {used} used",
+            task.sp_lower, task.sp_upper
+        ),
+        None => format!(
+            "  stack  ${:06X}-${:06X}  sp ${sp:06X} ({source}, outside the stack?)",
+            task.sp_lower, task.sp_upper
+        ),
+    });
+    let Some(proc) = &task.process else {
+        return lines;
+    };
+    lines.push(format!(
+        "  proc   CLI {}  {}  StackSize {}  Result2 {}",
+        proc.task_num,
+        if proc.command.is_empty() {
+            "<no command>".to_string()
+        } else {
+            format!("\"{}\"", proc.command)
+        },
+        proc.stack_size,
+        proc.result2
+    ));
+    if proc.cli != 0 {
+        lines.push(format!(
+            "  cli    ${:06X}  rc {}  fail {}  {}  stack {}",
+            proc.cli << 2,
+            proc.return_code,
+            proc.fail_level,
+            if proc.background {
+                "background"
+            } else {
+                "foreground"
+            },
+            proc.default_stack
+        ));
+        if !proc.set_name.is_empty() {
+            lines.push(format!("  cli    dir \"{}\"", proc.set_name));
+        }
+    }
+    lines.push(format!(
+        "  dos    CurrentDir ${:06X}  HomeDir ${:06X}  StackBase ${:06X}",
+        proc.current_dir << 2,
+        proc.home_dir << 2,
+        proc.stack_base << 2
+    ));
+    lines.push(format!(
+        "  dos    ConsoleTask ${:06X}{}  WindowPtr ${:06X}",
+        proc.console_task,
+        // The console handler is a message port, so it carries a name;
+        // a null or wild pointer just gets no name rather than garbage.
+        if super::plausible_ptr(proc.console_task) {
+            format!(" {}", os.node_name(proc.console_task))
+        } else {
+            String::new()
+        },
+        proc.window_ptr
+    ));
+    if proc.seglist != 0 {
+        lines.push(format!("  seg    BPTR ${:06X}", proc.seglist << 2));
+        for (i, seg) in proc.segments.iter().enumerate() {
+            lines.push(format!(
+                "  hunk {i}  ${:06X}..${:06X}  ({} bytes)",
+                seg.start,
+                seg.start + seg.size,
+                seg.size
+            ));
+        }
+    }
+    lines
+}
+
+/// MEMLIST: exec's memory list, two lines per MemHeader plus a total.
+pub fn memory(os: &OsMemory, base: u32) -> Vec<String> {
+    let regions = os.mem_list(base);
+    if regions.is_empty() {
+        return vec!["(exec has no memory list yet)".to_string()];
+    }
+    let mut lines = Vec::new();
+    let (mut total, mut total_free) = (0u64, 0u64);
+    for region in &regions {
+        total += u64::from(region.size());
+        total_free += u64::from(region.free);
+        lines.push(format!(
+            "${:06X}-${:06X}  {:>8} free of {:>8}  pri {:>4}  {}",
+            region.lower,
+            region.upper,
+            region.free,
+            region.size(),
+            region.pri,
+            region.name
+        ));
+        lines.push(format!(
+            "    attrs ${:04X} ({})  largest {}  chunks {}",
+            region.attributes,
+            match super::mem_attr_names(region.attributes) {
+                names if names.is_empty() => "none".to_string(),
+                names => names.join(" "),
+            },
+            region.largest,
+            region.chunks
+        ));
+    }
+    lines.push(format!(
+        "total  {total_free} free of {total} bytes in {} region{}",
+        regions.len(),
+        if regions.len() == 1 { "" } else { "s" }
+    ));
+    lines
+}

--- a/src/amigaos/dump.rs
+++ b/src/amigaos/dump.rs
@@ -97,16 +97,16 @@ pub fn exec(os: &OsMemory, base: u32) -> Vec<String> {
             info.cold_capture, info.cool_capture, info.warm_capture
         ),
     ];
-    // Exec parks -1 in LastAlert[0] when nothing has alerted; both
-    // Kickstart 3.1 and AROS boot with it that way.
-    lines.push(if matches!(info.last_alert[0], 0 | 0xFFFF_FFFF) {
-        "alert  none since reset".to_string()
-    } else {
-        format!(
-            "alert  ${:08X}: {}",
-            info.last_alert[0],
-            crate::debugger::guru_decode(info.last_alert[0])
-        )
+    lines.push(match info.last_alert[0] {
+        // Exec parks -1 in LastAlert[0] when nothing has alerted; both
+        // Kickstart 3.1 and AROS boot with it that way.
+        0xFFFF_FFFF => "alert  none since reset".to_string(),
+        // A zero is not that sentinel: it is the field as a cold reset
+        // left it, or (in principle) an Alert(0). Nothing distinguishes
+        // the two from the field alone and no subsystem raises code 0,
+        // so it is shown raw rather than decoded or called "none".
+        0 => "alert  LastAlert $00000000".to_string(),
+        code => format!("alert  ${code:08X}: {}", crate::debugger::guru_decode(code)),
     });
     lines
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1405,6 +1405,14 @@ impl M68kMachine {
         self.cpu.a(reg)
     }
 
+    /// The user stack pointer: A7 in user mode, the banked USP while the
+    /// CPU is in supervisor mode. AmigaOS tasks run in user mode, so this
+    /// is the running task's own stack pointer even when the snapshot
+    /// lands inside an interrupt.
+    pub fn usp(&self) -> u32 {
+        self.cpu.get_usp()
+    }
+
     pub fn d(&self, reg: usize) -> u32 {
         self.cpu.d(reg)
     }

--- a/src/gdbstub.rs
+++ b/src/gdbstub.rs
@@ -675,6 +675,24 @@ impl Session {
         }
     }
 
+    /// Run one of the shared exec dumps against a validated ExecBase and
+    /// join it into a monitor reply, or report why the OS is not
+    /// walkable. The `!` an error line carries in the console is dropped
+    /// here: gdb prints monitor output verbatim.
+    fn monitor_os(
+        &self,
+        dump: impl FnOnce(&crate::amigaos::OsMemory, u32) -> Vec<String>,
+    ) -> String {
+        let lines = crate::amigaos::with_bus_memory(self.emu.bus(), |os| match os.exec_base() {
+            Ok(base) => dump(os, base),
+            Err(reason) => vec![reason],
+        });
+        lines
+            .iter()
+            .map(|line| format!("{}\n", line.strip_prefix('!').unwrap_or(line)))
+            .collect()
+    }
+
     fn monitor_loadseg_list(&mut self) -> String {
         // Fold in the current process so the list is useful even before
         // any load event fired. Arming the tracker here does not enable
@@ -716,6 +734,17 @@ impl Session {
             )),
             "custom" => Ok(self.monitor_custom()),
             "segments" => Ok(self.monitor_segments()),
+            "execbase" => Ok(self.monitor_os(crate::amigaos::dump::exec)),
+            "tasks" => Ok(self.monitor_os(crate::amigaos::dump::task_list)),
+            "task" => {
+                let spec = parts.collect::<Vec<_>>().join(" ");
+                let sp = crate::amigaos::dump::LiveSp {
+                    a7: self.emu.machine.a(7),
+                    usp: self.emu.machine.usp(),
+                };
+                Ok(self.monitor_os(|os, base| crate::amigaos::dump::task(os, base, &spec, sp)))
+            }
+            "memlist" => Ok(self.monitor_os(crate::amigaos::dump::memory)),
             "loadseg-break" => {
                 self.loadseg_break = !self.loadseg_break;
                 if self.loadseg_break {
@@ -1035,6 +1064,7 @@ fn monitor_help() -> String {
      copper [auto|pc|ADDR] [COUNT]\n\
      last-writer ADDR\n\
      segments\n\
+     execbase | tasks | task [ADDR|NAME] | memlist\n\
      loadseg-break | loadseg-list\n"
         .to_string()
 }
@@ -1359,6 +1389,44 @@ mod tests {
             assert_eq!(reply, "OK");
             let text = console.concat();
             assert!(text.contains("segments"), "monitor help output: {text}");
+            assert_eq!(client.request("D"), "OK");
+        });
+    }
+
+    /// The exec dumps the debugger console prints are served over the
+    /// wire too, so a headless gdb session can ask what the OS is doing.
+    #[test]
+    fn monitor_os_dumps_report_exec_state() {
+        run_session(emulator_with_loadseg_program(), |mut client| {
+            let monitor = |client: &mut GdbClient, cmd: &str| {
+                let (console, reply) =
+                    client.request_collect(&format!("qRcmd,{}", hex_encode(cmd.as_bytes())));
+                assert_eq!(reply, "OK");
+                console.concat()
+            };
+            let text = monitor(&mut client, "execbase");
+            assert!(text.contains("ExecBase $010000"), "{text}");
+            assert!(text.contains("ThisTask $012000"), "{text}");
+            assert!(text.contains("IDNestCnt"), "{text}");
+            let text = monitor(&mut client, "tasks");
+            assert!(text.contains("> $012000"), "{text}");
+            // No argument dumps ThisTask, which this fixture stages as a
+            // CLI process running "hello".
+            let text = monitor(&mut client, "task");
+            assert!(
+                text.contains("task $012000") && text.contains("(process)"),
+                "{text}"
+            );
+            assert!(text.contains("\"hello\""), "{text}");
+            // An address that cannot hold a task is refused, not read.
+            let text = monitor(&mut client, "task $DFF000");
+            assert!(
+                text.contains("not where a task structure can live"),
+                "{text}"
+            );
+            // This fixture has no MemList at all.
+            let text = monitor(&mut client, "memlist");
+            assert!(text.contains("no memory list"), "{text}");
             assert_eq!(client.request("D"), "OK");
         });
     }

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -214,7 +214,8 @@ const CONSOLE_HELP: &[&str] = &[
     "            copper [pc|ADDR] [N]   custom   blits   find HEX [START]",
     "            writer ADDR",
     "            history/h [N]   stack/bt",
-    "os:         tasks  libs  devs  resources  ports   segments   guru [CODE]",
+    "os:         tasks  task [ADDR|NAME]  execbase  memlist  segments",
+    "            libs  devs  resources  ports  guru [CODE]",
     "hunt:       hunt start [B|W]  hunt eq/ne/lt/gt VAL  hunt same|diff  hunt list",
     "modify:     poke ADDR VAL   setreg REG VAL   trace start [PATH]|stop",
     "waveform:   wave start [PATH] [TRIGGER] [DURATION] [SIGNALS]   wave stop   wave",
@@ -522,7 +523,16 @@ impl App {
                     if set { "set" } else { "removed" }
                 ))
             }
-            "TASKS" => ConsoleOutcome::lines(self.console_os_tasks()),
+            "TASKS" => {
+                ConsoleOutcome::lines(self.console_with_exec(crate::amigaos::dump::task_list))
+            }
+            "TASK" => ConsoleOutcome::lines(self.console_task(args)),
+            "EXECBASE" | "EXEC" => {
+                ConsoleOutcome::lines(self.console_with_exec(crate::amigaos::dump::exec))
+            }
+            "MEMLIST" | "AVAIL" => {
+                ConsoleOutcome::lines(self.console_with_exec(crate::amigaos::dump::memory))
+            }
             "LIBS" | "LIBRARIES" => {
                 ConsoleOutcome::lines(self.console_os_list(crate::amigaos::OsList::Libraries))
             }
@@ -1299,35 +1309,16 @@ impl App {
         }
     }
 
-    /// TASKS: the scheduled task plus the ready and waiting lists.
-    fn console_os_tasks(&self) -> Vec<String> {
-        self.console_with_exec(|os, base| {
-            let mut lines = Vec::new();
-            match os.this_task(base) {
-                Some(task) => lines.push(format!(
-                    "> ${:06X}  pri {:>4}  {:<7} {}",
-                    task.addr, task.pri, "run", task.name
-                )),
-                None => lines.push("!ThisTask is not plausible".to_string()),
-            }
-            for (list, label) in [
-                (crate::amigaos::OsList::TaskReady, "ready"),
-                (crate::amigaos::OsList::TaskWait, "wait"),
-            ] {
-                for node in os.walk(base, list) {
-                    let state = crate::amigaos::task_state_name(node.state);
-                    let state = if state == "?" { label } else { state };
-                    lines.push(format!(
-                        "  ${:06X}  pri {:>4}  {:<7} {}",
-                        node.addr, node.pri, state, node.name
-                    ));
-                }
-            }
-            if lines.len() == 1 {
-                lines.push("  (no other tasks)".to_string());
-            }
-            lines
-        })
+    /// TASK [ADDR|NAME]: one task or process in full, defaulting to the
+    /// scheduled one. The CPU's live stack pointers go with it, since
+    /// they are the running task's real stack pointer.
+    fn console_task(&self, args: &[&str]) -> Vec<String> {
+        let spec = args.join(" ");
+        let sp = crate::amigaos::dump::LiveSp {
+            a7: self.emu.machine.a(7),
+            usp: self.emu.machine.usp(),
+        };
+        self.console_with_exec(|os, base| crate::amigaos::dump::task(os, base, &spec, sp))
     }
 
     /// LIBS/DEVS/RESOURCES/PORTS: one line per node.

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3676,6 +3676,18 @@ fn console_execbase_dumps_the_scheduler_state() {
         "{out:?}"
     );
 
+    // Exec's own "nothing has alerted" sentinel is -1, which reads as
+    // such; a zeroed field is neither that sentinel nor a decodable
+    // code, so it is reported raw.
+    for (stored, expected) in [
+        (0xFFFF_FFFFu32, "alert  none since reset"),
+        (0, "alert  LastAlert $00000000"),
+    ] {
+        app.emu.bus_mut().mem.chip_ram[0x1202..0x1206].copy_from_slice(&stored.to_be_bytes());
+        let out = console_run(&mut app, "EXECBASE");
+        assert!(out.iter().any(|l| l == expected), "{stored:08X}: {out:?}");
+    }
+
     // Before the OS is up the command says so rather than printing junk.
     app.emu.bus_mut().mem.chip_ram[4..8].copy_from_slice(&0u32.to_be_bytes());
     let out = console_run(&mut app, "EXEC");

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3616,6 +3616,211 @@ fn console_os_introspection_and_task_catch() {
 }
 
 #[test]
+fn console_execbase_dumps_the_scheduler_state() {
+    let mut app = test_app();
+    app.open_console();
+    plant_exec_world(&mut app);
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        let put32 = |ram: &mut [u8], addr: usize, v: u32| {
+            ram[addr..addr + 4].copy_from_slice(&v.to_be_bytes());
+        };
+        let put16 = |ram: &mut [u8], addr: usize, v: u16| {
+            ram[addr..addr + 2].copy_from_slice(&v.to_be_bytes());
+        };
+        let base = 0x1000usize;
+        put32(ram, base + 0x118, 4242); // IdleCount
+        put32(ram, base + 0x11C, 999); // DispCount
+        put16(ram, base + 0x120, 4); // Quantum
+        put16(ram, base + 0x124, 0x4000); // SysFlags: TQE
+        ram[base + 0x126] = 0xFF; // IDNestCnt -1
+        ram[base + 0x127] = 0x00; // TDNestCnt 0: one Forbid()
+        put16(ram, base + 0x128, 0x0007); // AttnFlags: 68010/20/30
+        put32(ram, base + 0x202, 0x8100_0009); // LastAlert
+    }
+    let out = console_run(&mut app, "EXECBASE");
+    assert!(out[0].contains("ExecBase $001000"), "{out:?}");
+    assert!(
+        out.iter()
+            .any(|l| l.contains("IdleCount 4242") && l.contains("DispCount 999")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter().any(|l| l.contains("SysFlags $4000 (TQE)")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("IDNestCnt -1 (interrupts enabled)")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("TDNestCnt 0 (Forbid()den, nesting 1)")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("AttnFlags $0007 (68010 68020 68030)")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("ThisTask $002000  boot.task")),
+        "{out:?}"
+    );
+    // The stored alert code comes back decoded, not just in hex.
+    assert!(
+        out.iter()
+            .any(|l| l.starts_with("alert  $81000009") && l.contains("DEADEND")),
+        "{out:?}"
+    );
+
+    // Before the OS is up the command says so rather than printing junk.
+    app.emu.bus_mut().mem.chip_ram[4..8].copy_from_slice(&0u32.to_be_bytes());
+    let out = console_run(&mut app, "EXEC");
+    assert!(out[0].starts_with("!no ExecBase"), "{out:?}");
+}
+
+#[test]
+fn console_task_dumps_one_task_by_default_address_or_name() {
+    let mut app = test_app();
+    app.open_console();
+    plant_exec_world(&mut app);
+    // ThisTask ($2000) is a CLI process with a one-hunk command loaded.
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        let put32 = |ram: &mut [u8], addr: usize, v: u32| {
+            ram[addr..addr + 4].copy_from_slice(&v.to_be_bytes());
+        };
+        ram[0x2000 + 8] = 13; // NT_PROCESS
+        ram[0x2000 + 14] = 0x40; // tc_Flags: SWITCH
+        put32(ram, 0x2000 + 0x12, 0x0000_FFFF); // tc_SigAlloc
+        put32(ram, 0x2000 + 0x16, 0x0000_1000); // tc_SigWait
+        put32(ram, 0x2000 + 0x36, 0x0000_7F00); // tc_SPReg
+        put32(ram, 0x2000 + 0x3A, 0x0000_7000); // tc_SPLower
+        put32(ram, 0x2000 + 0x3E, 0x0000_8000); // tc_SPUpper
+        put32(ram, 0x2000 + 0x84, 4096); // pr_StackSize
+        put32(ram, 0x2000 + 0x8C, 3); // pr_TaskNum
+        put32(ram, 0x2000 + 0xAC, 0x4000 >> 2); // pr_CLI
+        put32(ram, 0x4000 + 0x10, 0x4100 >> 2); // cli_CommandName
+        ram[0x4100] = 11;
+        ram[0x4101..0x410C].copy_from_slice(b"dh0:c/hello");
+        put32(ram, 0x4000 + 0x3C, 0x8000 >> 2); // cli_Module
+        put32(ram, 0x8000 - 4, 0x100);
+        put32(ram, 0x8000, 0);
+    }
+    // Park the CPU's A7 in the task's stack: the running task's live
+    // stack pointer is what the dump must measure against.
+    app.emu.machine.debug_set_register(15, 0x0000_7C00);
+
+    let out = console_run(&mut app, "TASK");
+    assert!(
+        out[0].contains("task $002000  boot.task  (process)")
+            && out[0].contains("pri 10")
+            && out[0].contains("state run"),
+        "{out:?}"
+    );
+    assert!(out.iter().any(|l| l.contains("$40 (SWITCH)")), "{out:?}");
+    assert!(
+        out.iter()
+            .any(|l| l.contains("alloc $0000FFFF") && l.contains("wait $00001000")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter()
+            .any(|l| l.contains("$007000-$008000 (4096 bytes)")
+                && l.contains("sp $007C00 (live A7), 1024 used")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter().any(|l| l.contains("CLI 3")
+            && l.contains("\"hello\"")
+            && l.contains("StackSize 4096")),
+        "{out:?}"
+    );
+    assert!(
+        out.iter().any(|l| l.contains("hunk 0  $008004..$0080FC")),
+        "{out:?}"
+    );
+
+    // By name (case-insensitive) and by explicit address, and a
+    // non-process task stops after the exec half.
+    let by_name = console_run(&mut app, "TASK HELP");
+    assert!(by_name[0].contains("task $002100  helper"), "{by_name:?}");
+    assert!(
+        !by_name.iter().any(|l| l.contains("proc ")),
+        "a plain task has no process half: {by_name:?}"
+    );
+    // tc_SPReg is what a task exec has switched away from is measured by.
+    assert!(by_name.iter().any(|l| l.contains("SPReg")), "{by_name:?}");
+    let by_addr = console_run(&mut app, "TASK $2100");
+    assert_eq!(by_addr[0], by_name[0]);
+    let missing = console_run(&mut app, "TASK nosuchtask");
+    assert!(missing[0].starts_with("!no task matches"), "{missing:?}");
+
+    // An ambiguous name lists the candidates instead of guessing.
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        ram[0x3000..0x3007].copy_from_slice(b"helper2");
+        ram[0x3007] = 0;
+    }
+    let both = console_run(&mut app, "TASK helper");
+    assert!(both[0].contains("matches several tasks"), "{both:?}");
+    assert_eq!(both.len(), 4, "{both:?}");
+}
+
+#[test]
+fn console_memlist_summarizes_exec_memory() {
+    let mut app = test_app();
+    app.open_console();
+    plant_exec_world(&mut app);
+    {
+        let ram = &mut app.emu.bus_mut().mem.chip_ram;
+        let put32 = |ram: &mut [u8], addr: usize, v: u32| {
+            ram[addr..addr + 4].copy_from_slice(&v.to_be_bytes());
+        };
+        let put16 = |ram: &mut [u8], addr: usize, v: u16| {
+            ram[addr..addr + 2].copy_from_slice(&v.to_be_bytes());
+        };
+        // One MemHeader at $5000 covering chip RAM, two free chunks.
+        put32(ram, 0x1000 + 0x142, 0x5000); // MemList lh_Head
+        put32(ram, 0x5000, 0x1000 + 0x142 + 4); // succ -> lh_Tail
+        put32(ram, 0x1000 + 0x142 + 4, 0);
+        put32(ram, 0x5000 + 10, 0x5100); // ln_Name
+        ram[0x5100..0x5104].copy_from_slice(b"chip");
+        ram[0x5104] = 0;
+        ram[0x5000 + 9] = (-10i8) as u8; // ln_Pri
+        put16(ram, 0x5000 + 0x0E, 0x0003); // PUBLIC | CHIP
+        put32(ram, 0x5000 + 0x10, 0x6000); // mh_First
+        put32(ram, 0x5000 + 0x14, 0x0000_0400); // mh_Lower
+        put32(ram, 0x5000 + 0x18, 0x0008_0000); // mh_Upper
+        put32(ram, 0x5000 + 0x1C, 0x0004_0000); // mh_Free
+        put32(ram, 0x6000, 0x7000); // mc_Next
+        put32(ram, 0x6004, 0x0001_0000); // mc_Bytes
+        put32(ram, 0x7000, 0);
+        put32(ram, 0x7004, 0x0003_0000);
+    }
+    let out = console_run(&mut app, "MEMLIST");
+    assert!(
+        out[0].contains("$000400-$080000")
+            && out[0].contains("pri  -10")
+            && out[0].ends_with("chip"),
+        "{out:?}"
+    );
+    assert!(
+        out[1].contains("PUBLIC CHIP")
+            && out[1].contains("largest 196608")
+            && out[1].contains("chunks 2"),
+        "{out:?}"
+    );
+    assert!(
+        out.last().unwrap().contains("free of") && out.last().unwrap().contains("1 region"),
+        "{out:?}"
+    );
+}
+
+#[test]
 fn iomap_tab_navigation_and_jump() {
     let mut app = test_app();
     app.open_debugger();


### PR DESCRIPTION
Closes #296.

The console could list exec's tasks, libraries, devices, resources and ports, but nothing showed what the scheduler itself was doing, or what is inside one task.

## New console commands

| Command | Effect |
|---|---|
| `EXECBASE` (`EXEC`) | ExecBase's own scheduler and machine state |
| `TASK [ADDR\|NAME]` | One `struct Task` in full; no argument dumps `ThisTask` |
| `MEMLIST` (`AVAIL`) | Exec's memory list per region |

`EXECBASE` leads with the fields the issue asked for, decoded rather than printed raw -- `-1` versus `0` in the nesting counts is the difference between a running machine and an unpaired `Disable()`/`Forbid()`:

```
> execbase
ExecBase $C00B00  exec.library v40.10  SoftVer 63
sched  IdleCount 87  DispCount 413  Quantum 4  Elapsed 3
sched  SysFlags $4000 (TQE)  AttnResched $0000
sched  IDNestCnt -1 (interrupts enabled)
sched  TDNestCnt -1 (task switching enabled)
cpu    AttnFlags $0000 (none)
task   ThisTask $C03580  exec.library
```

...followed by the machine facts exec recorded at boot (memory bounds, its supervisor stack, VBlank/PSU frequency, the V36+ E-clock rate, capture vectors, `ResModules`) and the last alert run through the guru decoder.

`TASK` prints node type, priority, `tc_Flags`, the four signal masks, trap/exception vectors, the switch/launch hooks, and stack bounds with bytes in use; an `NT_PROCESS` continues into the DOS half (CLI number and command, `pr_StackSize`, `IoErr()`, directory locks, console handler, loaded hunks). The argument is an address or a case-insensitive name substring; an ambiguous name lists candidates instead of guessing.

```
> task input
task $C07192  input.device  (task)  pri 20  state wait
  flags  $00 (none)  IDNestCnt -1  TDNestCnt 0
  sigs   alloc $C000FFFF  wait $C0000000  recvd $00000000
  sigs   except $00000000  trap alloc $8000 able $0000
  vecs   trap $F83558/$000000  except $F83558/$000000
  vecs   switch $000000  launch $000000  userdata $000000
  stack  $C071F0-$C081F0 (4096 bytes)  sp $C0819E (SPReg), 82 used
```

`MEMLIST` walks `ExecBase->MemList`: `mh_Free`, the largest free chunk and chunk count walked from `mh_First` (so fragmentation is visible), and the `MEMF_*` attributes.

## Hardware details worth calling out

- **The running task's stack pointer comes from the CPU, and from USP, not A7.** `tc_SPReg` is only written when exec switches away. AmigaOS tasks run in user mode, so a snapshot caught inside an interrupt has A7 on the supervisor stack -- on a real AROS boot that first reported the task's SP 300 KiB outside its own stack. A task running supervisor-mode code is unusual but legal, so whichever of USP/A7 lands inside the task's bounds is reported, labelled with the register it came from.
- **`LastAlert[0]` is -1, not 0, when nothing has alerted** (both Kickstart 3.1 and AROS boot that way).
- **With `TF_ETASK` set, `tc_TrapAlloc`/`tc_TrapAble` are the `tc_UnionETask` pointer.** AROS sets that flag on every task, where the trap masks would otherwise read as halves of an address; the dump reports `ETask $...` instead.

Both of the last two came out of checking the readers against real booted systems rather than fixtures.

## Also in this change

The formatting lives in `amigaos::dump`, so the GDB stub serves the same four dumps as `monitor execbase|tasks|task|memlist` -- a headless session sees what the window shows. `TASKS` moved there too so both frontends agree.

## Verification

- 10 new tests: 7 unit tests over a fake exec world in `amigaos` (scheduler state, task/process/CLI, ETask overlay, stack usage, name lookup, memory list, and a trashed free list that must terminate), 3 console tests driving a planted ExecBase in chip RAM, and one GDB wire test round-tripping the monitor dumps.
- Validated against real booted systems: Kickstart 3.1 and the bundled AROS, both structurally sane throughout (PAL E-clock 709379 Hz, `input.device` at pri 20, the chip/slow `MemHeader` pair with believable free lists). Final check was a live `--gdb` session against a booted KICK31.ROM.
- `cargo test --release`, `cargo clippy --all-targets`, `cargo fmt --check` clean. No golden renders touched (no timing-model change).