### PR TITLE
Fix the stale-documentation defects from the 0.14 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ release needs resolved first. Release steps for every channel are in
 | Fast RAM | Optional Zorro II autoconfig RAM at $00200000 and Zorro III autoconfig RAM (`[memory] z3`); runs at the CPU clock. |
 | Slow RAM | Optional A500 trapdoor/fake-fast RAM at $00C00000; arbitrated on the chip bus through Agnus like chip RAM. |
 | ROM | Kickstart at $F80000 (512 KiB); optional extended ROM for CD32 ($E00000) and CDTV ($F00000). |
-| Battery RTC | Read-only MSM6242-compatible register view at $DC0000; guest writes affect only emulated latch/control state. |
+| Battery RTC | Oki MSM6242 or Ricoh RP5C01 at $DC0000 (`rtc_chip`; Ricoh is the A3000/A4000 default), read-only wall clock -- guest writes drive latch/bank/control state and the RP5C01's battery RAM, which persists to a WinUAE/Amiberry-compatible `.nvram` file (`battmem`). A `rtc_time` seed ticks in emulated time for reproducible runs; `rtc_frozen` pins it. |
 | CIA-A / CIA-B | I/O ports, /OVL, timers, TOD, keyboard SDR/ICR, disk control/status lines, CIA-B FLAG disk index pulses, and the Centronics parallel port (data/strobe/ACK on CIA-A, BUSY/POUT/SEL on CIA-B). |
 | Paula serial | SERDAT through a one-word transmit buffer and timed shift register, out to stdout, a TCP port, a pseudo-terminal, or -- with the default `midi` feature -- bridged to host MIDI in/out; SERDATR reports TBE/TSRE/RBF, and serial receive is fed from the selected input. |
 | Paula audio | 4-channel DMA/sample playback, stereo mix, LED filter. |

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -2241,7 +2241,7 @@ function updateStatusDisks() {
 // http.server) is scraped for links with a matching extension instead.
 // An empty or unreachable folder hides the select.
 
-const DISK_LIST_EXT = /\.(adf|adz|dms|ipf|scp|zip|gz)$/i;
+const DISK_LIST_EXT = /\.(adf|adz|dms|scp|zip|gz)$/i;
 // Raw ROM images only: a list pick feeds load_rom directly, which takes
 // uncompressed 256/512 KiB images.
 const KICK_LIST_EXT = /\.(rom|bin)$/i;
@@ -2356,7 +2356,7 @@ if (kickListSelect) {
 // Optional in the page shell: older shells have no URL button.
 $('df0url')?.addEventListener('click', () => {
   const url = window.prompt(
-    'Disk image URL (ADF/ADZ/DMS/IPF/SCP, gzip or zip packed):',
+    'Disk image URL (ADF/ADZ/DMS/SCP, gzip or zip packed):',
   );
   if (url && url.trim()) insertDiskFromUrl(url.trim());
 });

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -24,8 +24,8 @@ works with no files of your own; the **Kickstart ROM** and **DF0 disk**
 pickers load local images instead. Both work before or after boot: a
 pre-boot choice is stashed and applied when the machine starts (the boot
 button relabels to show which ROM it will use), and a post-boot pick swaps
-the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, IPF,
-and SCP, plain or gzip/zip packed -- and are always write-protected, since
+the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, and
+SCP, plain or gzip/zip packed -- and are always write-protected, since
 the browser has no filesystem to write changes back to. On iOS the pickers
 offer every file rather than filtering by extension, because the system
 document picker greys out extensions it does not recognise, which would

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -800,11 +800,10 @@ read-only SCP flux images. DMS, gzip, and SCP images are decoded at load time
 and always treated as write-protected; set `write_protected = false` on a plain
 ADF to allow write-through updates to the image file.
 
-The native loader deliberately rejects IPF/CAPS images. Useful native support
-would require either a direct IPF parser or an optional SPS/CAPS library, with
-its licensing, platform packaging, and dynamic-loading strategy settled before
-it becomes a desktop dependency. (The browser frontend has its own
-write-protected media decoder and does accept IPF.)
+The loader deliberately rejects IPF/CAPS images. Useful support would require
+either a direct IPF parser or an optional SPS/CAPS library, with its licensing,
+platform packaging, and dynamic-loading strategy settled before it becomes a
+dependency. The browser frontend shares this decoder, so it rejects IPF too.
 
 A `paths` playlist lets multi-disk software that only drives DF0: run
 without a second drive: the first entry is the boot disk and the disk-swap

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -7544,8 +7544,10 @@ fn apply_live_bpldat_event(bpldat: &mut [u16; 8], offset: u16, value: u16) {
     }
 }
 
-/// Live collisions evaluate at most the classic 6 bitplanes until the AGA
-/// CLXCON2 collision extensions are interpreted (plan 3.4).
+/// Live collisions evaluate at most the classic 6 bitplanes. The rendered
+/// collision path already interprets the AGA CLXCON2 extensions for planes
+/// 7-8; extending the beam-timed path to match is an open gap (see
+/// docs/internals/chipset.md).
 const COLLISIONS_AGA_DECODE: bool = false;
 
 fn live_manual_bpl_word_collision_bits(
@@ -7575,8 +7577,8 @@ fn live_manual_bpl_word_collision_bits(
         let hires = bitplane_hires(source_control.bplcon0);
         let pixel_repeat = if hires || shres { 1 } else { 2 };
         let native_step = if shres { 2 } else { 1 };
-        // Collision sampling stays on the pre-AGA 6-plane decode until
-        // CLXCON2 / 8-plane collisions land (plan 3.4).
+        // Collision sampling stays on the pre-AGA 6-plane decode; see
+        // COLLISIONS_AGA_DECODE.
         let mode = BitplaneMode::from_bplcon0(source_control.bplcon0, COLLISIONS_AGA_DECODE);
         let nplanes = mode.display_planes().min(planes.len());
         let dual_playfield = source_control.bplcon0 & 0x0400 != 0;
@@ -7730,8 +7732,8 @@ fn live_bitplane_collision_pixel_at(
     let native_x = relative_native_x
         + live_fetch_origin_native_offset(agnus_revision, bplcon0, diwstrt, diwhigh, ddfstrt);
     let fetched_pixels = row.words_per_row * 16;
-    // Collision sampling stays on the pre-AGA 6-plane decode until CLXCON2 /
-    // 8-plane collisions land (plan 3.4).
+    // Collision sampling stays on the pre-AGA 6-plane decode; see
+    // COLLISIONS_AGA_DECODE.
     let mode = BitplaneMode::from_bplcon0(bplcon0, COLLISIONS_AGA_DECODE);
     let nplanes = mode.display_planes().min(row.nplanes).min(6);
     let dma_planes = mode.dma_planes().min(nplanes);

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -1051,9 +1051,10 @@ impl Bus {
                 }
                 false
             }
-            // AGA Lisa registers: latched only until the AGA display path
-            // lands (plan 3.3/3.4); unreachable from config today because
-            // Lisa is not selectable.
+            // AGA Lisa registers, reached whenever the configured Denise is
+            // a Lisa (`Chipset::Aga`). BPLCON4's BPLAM/OSPRM/ESPRM fields
+            // are consumed by the render replay; CLXCON2 reaches the
+            // rendered collision decode but not the beam-timed one.
             0x10C => {
                 if self.denise_is_lisa() {
                     if crate::envcfg::flag("COPPERLINE_DIAG_DISPLAY") && self.denise.bplcon4 != val
@@ -1227,8 +1228,9 @@ impl Bus {
                     if self.denise_is_lisa() {
                         // AGA: BPLCON3 BANK/LOCT route the write into the
                         // 256-entry store. Bank 0 with LOCT clear is the
-                        // OCS-compatible case. The replay renderer still
-                        // tracks bank 0 only until plan 3.3 lands.
+                        // OCS-compatible case. The replay renderer resolves
+                        // the same bank/LOCT pair from its own recorded
+                        // BPLCON3, so both stores stay in step.
                         self.denise.palette.write_banked(
                             crate::chipset::denise::Palette::bank_from_bplcon3(self.denise.bplcon3),
                             idx,

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -10182,9 +10182,8 @@ fn chip_revisions_split_deniseid_from_vposr_id() {
     );
 }
 
-/// Plan 3.1: AGA identification and register latches, gated on the
-/// Alice/Lisa revisions (not selectable from config until the AGA
-/// display path lands).
+/// AGA identification and register latches, gated on the Alice/Lisa
+/// revisions that `Chipset::Aga` selects.
 #[test]
 fn aga_ids_and_register_latches_gate_on_alice_lisa() {
     let mut aga = empty_bus();

--- a/src/chipset/agnus.rs
+++ b/src/chipset/agnus.rs
@@ -228,9 +228,10 @@ pub struct Agnus {
     /// not emulated (BEAMCON0.DUAL logs a one-time warning), so HHPOSR reads
     /// back the last written value.
     hhpos: u16,
-    /// AGA FMODE ($1FC): bitplane/sprite fetch width. Latched only
-    /// (Alice-gated); the wide-fetch DMA interpretation lands with plan 3.3
-    /// and must keep FMODE=0 byte-identical to the OCS/ECS slot timing.
+    /// AGA FMODE ($1FC): bitplane/sprite fetch width. Alice-gated; drives
+    /// the bitplane fetch quantum/period, the sprite fetch width, and
+    /// SSCAN2 scan doubling. FMODE=0 stays byte-identical to the OCS/ECS
+    /// slot timing.
     fmode: u16,
 }
 

--- a/src/chipset/denise.rs
+++ b/src/chipset/denise.rs
@@ -88,7 +88,7 @@ impl DiwHigh {
     }
 }
 
-/// Display palette store, generation-agnostic (plan 3.2). AGA's 256 colour
+/// Display palette store, generation-agnostic. AGA's 256 colour
 /// entries each hold 24 bits plus the genlock T bit, written as two 12-bit
 /// halves: `hi` is the OCS-layout word (bit 15 = T, low 12 bits = the high
 /// colour nibbles as $0RGB) and `lo` carries the low nibbles (written by AGA
@@ -264,11 +264,13 @@ pub struct Denise {
     pub bplcon2: u16,
     pub bplcon3: u16,
     /// AGA BPLCON4 ($10C): BPLAM bitplane XOR mask (high byte) and the
-    /// OSPRM/ESPRM sprite palette offsets. Latched only (Lisa-gated);
-    /// interpretation lands with the AGA display path (plan 3.3/3.4).
+    /// OSPRM/ESPRM sprite palette offsets (low byte). Lisa-gated; both
+    /// fields are consumed by the render replay, on the separate Lisa
+    /// timing paths described in docs/internals/chipset.md.
     pub bplcon4: u16,
     /// AGA CLXCON2 ($10E): collision enable/match bits for planes 7-8.
-    /// Latched only (Lisa-gated) until 8-bitplane collisions land.
+    /// Lisa-gated. Interpreted by the rendered collision decode; the
+    /// beam-timed live path still stops at the classic 6 planes.
     pub clxcon2: u16,
     pub clxcon: u16,
     pub clxdat: u16,

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -4842,7 +4842,10 @@ fn sprite_ctl_write_stops_dma_data_reuse_by_later_position_write() {
     // left, so only the repositioned copy could be visible.
     let fetched_hstart = 20i32;
     let reused_hstart = DIW_HSTART_FB0 as u16 + 100;
-    let (_, ctl) = sprite_control_words(beam_y as u16, beam_y as u16 + 1, 0);
+    // CTL carries the fetched line's own register-decoded HSTART, so build
+    // it from the register parts rather than the output-position helper.
+    let (_, ctl) =
+        sprite_control_words_from_parts(beam_y, beam_y + 1, fetched_hstart, false, false);
     let (reused_pos, _) = sprite_control_words(beam_y as u16, beam_y as u16 + 1, reused_hstart);
     let captured = [CapturedSpriteLine {
         sprite: 0,
@@ -4859,12 +4862,7 @@ fn sprite_ctl_write_stops_dma_data_reuse_by_later_position_write() {
         width_words: 1,
     }];
     let events = [
-        beam_event(
-            beam_y as u32,
-            COPPER_WAIT_HPOS_FB0 as u32,
-            0x0142,
-            ctl | (fetched_hstart as u16 & 1),
-        ),
+        beam_event(beam_y as u32, COPPER_WAIT_HPOS_FB0 as u32, 0x0142, ctl),
         beam_event(
             beam_y as u32,
             COPPER_WAIT_HPOS_FB0 as u32 + 4,


### PR DESCRIPTION
Works through the "Defects found during this review" list in
`ROADMAP-0.14.md`, plus three more instances of the same staleness that
the review missed and one pre-existing test failure found on the way.

### The browser does not accept IPF

`crates/copperline-web` has no decoder of its own -- `insert_floppy`
calls the same `Floppy::insert_disk_image_bytes` as the desktop build,
so an IPF image reaches the same `bail!` that rejects CAPS signatures
natively. The configuration guide claimed the browser "has its own
write-protected media decoder and does accept IPF", the browser guide
listed IPF among recognised formats, and `try.js` advertised it in both
the folder-listing filter and the disk URL prompt. Selecting one failed
only after the user had picked it.

IPF remains an explicit non-goal pending a direct parser or an optional
SPS/CAPS library, and the browser cannot outrun the decoder it shares,
so the claim is dropped in all four places. SCP is genuinely supported
and is untouched.

### Comments that still call AGA unimplemented

BPLCON4, CLXCON2 and FMODE were described as "latched only", the Lisa
registers as "unreachable from config today because Lisa is not
selectable", and the banked palette write as tracking "bank 0 only".
`Chipset::Aga` selects AgaLisa/AgaAlice, BPLCON4's BPLAM and
OSPRM/ESPRM fields are both consumed by the render replay on their
separate Lisa timing paths, FMODE drives the bitplane fetch quantum and
period, the sprite fetch width and SSCAN2 doubling, and the replay
resolves the same BPLCON3 bank/LOCT pair as the live store. From the
source alone an auditor would have concluded AGA was absent.

Beyond the five the review listed, a sweep found three more: the doc
comment on `aga_ids_and_register_latches_gate_on_alice_lisa`, the
palette store comment in `denise.rs`, and the `COLLISIONS_AGA_DECODE`
comments in `bus.rs`. All eight referenced "plan 3.1" through
"plan 3.4", a planning document no longer in the tree, so those
references are replaced by the behaviour or by the `docs/internals`
section recording the gap.

One was not merely stale. Live collisions really do stay on the classic
6-plane decode (`COLLISIONS_AGA_DECODE` is false). That gap is
unchanged, but is now stated as the beam-timed path lagging the rendered
path, which does interpret CLXCON2 for planes 7-8.

### README battery RTC row

Still described the 0.12 clock. Now covers the RP5C01, `rtc_chip`
selection with the A3000/A4000 default, `battmem` `.nvram` persistence,
and the `rtc_time` / `rtc_frozen` seeds.

### A debug-only test failure on main

`cargo test` was red on `7273a64f`, independently of these changes:

```
video::bitplane::tests::sprite_ctl_write_stops_dma_data_reuse_by_later_position_write
panicked at src/video/bitplane/tests.rs:556: attempt to subtract with overflow
```

The test built its CTL word with `sprite_control_words`, which subtracts
`SPRITE_OUTPUT_DELAY_LORES` from an output position, and passed 0. Debug
panicked; release wrapped to `0xFFFF` and passed. CI runs only
`cargo test --release`, so it never surfaced.

The wrap also defeated the test's intent, forcing CTL's HSTART low bit
to 1 where the following `ctl | (fetched_hstart as u16 & 1)` wanted 0.
`CapturedSpriteLine::hstart` is register-decoded, so the word is built
with `sprite_control_words_from_parts`, which takes one directly, and
the redundant OR is gone. The assertion is unchanged.

### Verification

`cargo test`, `cargo test --release`, `cargo clippy --all-targets` and
`cargo fmt --check` all clean. No behaviour change outside that one
test: everything else is comments, docs and UI strings.

`ROADMAP-0.14.md` is left alone as a dated review artifact; its three
defect entries are now resolved.
