### PR TITLE
window: apply a synchronous resize request to the surface

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -414,7 +414,7 @@ use std::sync::{
 use std::thread::JoinHandle;
 use std::time::Instant;
 use winit::application::ApplicationHandler;
-use winit::dpi::LogicalSize;
+use winit::dpi::{LogicalSize, PhysicalSize};
 use winit::event::{
     DeviceEvent, DeviceId, ElementState, KeyEvent, MouseButton, MouseScrollDelta, RawKeyEvent,
     WindowEvent,
@@ -2664,24 +2664,7 @@ impl ApplicationHandler for App {
                 self.request_redraw();
             }
             WindowEvent::Resized(size) => {
-                if let Some(r) = self.render.as_mut() {
-                    // A zero-sized resize is minimization (Windows reports
-                    // the minimized client area as 0x0). Leave the surface
-                    // untouched and stop rendering until the restore
-                    // delivers a nonzero size (see Render::minimized).
-                    r.minimized = size.width == 0 || size.height == 0;
-                    if r.minimized {
-                        return;
-                    }
-                    let _ = r.pixels.resize_surface(size.width, size.height);
-                }
-                // Resizing the surface discards its contents, leaving it
-                // blank (white) until the next present. When the machine is
-                // powered off (or paused) the event loop is in Wait mode and
-                // produces no frames, so without an explicit repaint here the
-                // window can sit white after the scale-factor/resize event
-                // that macOS delivers right after window creation.
-                self.request_redraw();
+                self.apply_surface_size(size);
             }
             WindowEvent::RedrawRequested => {
                 if self.render.as_ref().is_some_and(|r| r.minimized) {
@@ -3702,16 +3685,7 @@ impl App {
                 self.request_redraw();
             }
             WindowEvent::Resized(size) => {
-                if let Some(tool) = self.tool_window_mut(kind) {
-                    // Same minimized-present deadlock guard as the main
-                    // window's Resized handler.
-                    tool.minimized = size.width == 0 || size.height == 0;
-                    if tool.minimized {
-                        return;
-                    }
-                    let _ = tool.pixels.resize_surface(size.width, size.height);
-                }
-                self.request_redraw();
+                self.apply_tool_surface_size(kind, size);
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 let rows = match delta {
@@ -7614,11 +7588,55 @@ impl App {
         self.emu.set_live_audio_suspended(suspended);
     }
 
+    /// Resize the presentation surface to a new window size. Shared by the
+    /// Resized event and by the synchronous path of request_inner_size (see
+    /// resize_for_active_panel), which on some backends returns the applied
+    /// size instead of delivering an event.
+    fn apply_surface_size(&mut self, size: PhysicalSize<u32>) {
+        if let Some(r) = self.render.as_mut() {
+            // A zero-sized resize is minimization (Windows reports the
+            // minimized client area as 0x0). Leave the surface untouched and
+            // stop rendering until the restore delivers a nonzero size (see
+            // Render::minimized).
+            r.minimized = size.width == 0 || size.height == 0;
+            if r.minimized {
+                return;
+            }
+            let _ = r.pixels.resize_surface(size.width, size.height);
+        }
+        // Resizing the surface discards its contents, leaving it blank (white)
+        // until the next present. When the machine is powered off (or paused)
+        // the event loop is in Wait mode and produces no frames, so without an
+        // explicit repaint here the window can sit white after the
+        // scale-factor/resize event that macOS delivers right after window
+        // creation.
+        self.request_redraw();
+    }
+
+    /// Tool-window counterpart of `apply_surface_size`, shared by that window's
+    /// Resized event and the synchronous `request_inner_size` path.
+    fn apply_tool_surface_size(&mut self, kind: ToolPanelKind, size: PhysicalSize<u32>) {
+        if let Some(tool) = self.tool_window_mut(kind) {
+            // Same minimized-present deadlock guard as the main window.
+            tool.minimized = size.width == 0 || size.height == 0;
+            if tool.minimized {
+                return;
+            }
+            let _ = tool.pixels.resize_surface(size.width, size.height);
+        }
+        self.request_redraw();
+    }
+
     /// Size the window to the presentation canvas, unless it is fullscreen: the
     /// request resizes nothing there and instead shrinks the drawable into a
     /// corner (macOS and Windows; Linux window managers ignore it), so leave the
     /// display-sized surface alone and let the presentation scale into it.
-    fn resize_for_active_panel(&self) {
+    ///
+    /// `request_inner_size` is only asynchronous when it returns `None`. Wayland
+    /// applies the resize client-side and returns the new size with no `Resized`
+    /// event to follow, so the surface must be resized here or the stale extent
+    /// misplaces every click through `cursor_texture_position`.
+    fn resize_for_active_panel(&mut self) {
         let Some(window) = self.render.as_ref().map(|r| r.window.clone()) else {
             return;
         };
@@ -7626,7 +7644,9 @@ impl App {
             return;
         }
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
-        let _ = window.request_inner_size(size);
+        if let Some(applied) = window.request_inner_size(size) {
+            self.apply_surface_size(applied);
+        }
     }
 
     /// Whether the main window is still exactly the presentation canvas size in
@@ -7686,6 +7706,7 @@ impl App {
         // windows must follow the new size too.
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
         for kind in ToolPanelKind::ALL {
+            let mut applied = None;
             if let Some(tool) = self.tool_window_mut(kind) {
                 if let Err(e) = tool.pixels.resize_buffer(
                     texture_width(tool.texture_scale) as u32,
@@ -7693,7 +7714,11 @@ impl App {
                 ) {
                     warn!("resize tool texture buffer for pixel aspect failed: {e}");
                 }
-                let _ = tool.window.request_inner_size(size);
+                applied = tool.window.request_inner_size(size);
+            }
+            // Synchronous on Wayland, with no Resized event to follow.
+            if let Some(applied) = applied {
+                self.apply_tool_surface_size(kind, applied);
             }
         }
         self.resize_for_active_panel();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7602,7 +7602,9 @@ impl App {
             if r.minimized {
                 return;
             }
-            let _ = r.pixels.resize_surface(size.width, size.height);
+            if let Err(e) = r.pixels.resize_surface(size.width, size.height) {
+                warn!("resize surface failed: {e}");
+            }
         }
         // Resizing the surface discards its contents, leaving it blank (white)
         // until the next present. When the machine is powered off (or paused)


### PR DESCRIPTION
Fixes #293.

`Window::request_inner_size` is asynchronous only when it returns `None`. The
Wayland backend applies the resize client-side and returns `Some(new_size)`;
`Resized` there is synthesized solely from a compositor `configure`, so no
event follows:

```rust
// winit-0.30.13 platform_impl/linux/wayland/window/mod.rs:313
pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
    let new_size = window_state.request_inner_size(size);
    self.request_redraw();
    Some(new_size)
}
```

We dropped that return value with `let _ =` and resized the `Pixels` surface
only from the `Resized` handler, so whenever the window was sized to the
presentation canvas the surface kept its old extent. `cursor_texture_position`
then mapped every click through `window_pos_to_pixel` against the stale extent,
and the status-bar controls stopped responding until a manual resize produced a
real configure. Three paths reach this, not just closing a tool window:
`resize_for_active_panel` (tool-window close, status-bar toggle) and
`apply_pixel_aspect` for the tool windows.

The fix factors the two `Resized` handlers into `apply_surface_size` and
`apply_tool_surface_size` and calls them with the size `request_inner_size`
returns. winit's own `examples/application.rs` shows the same caller-side
handling, and the API contract is unchanged on 0.31 master.

Not a winit bug, and an upgrade would not help: 0.30.13 (2026-03-02) is the
newest release and we are already on it, while 0.31.0-beta.2 is from
2025-11-16.

Not covered by a test: the seam is the return value of `request_inner_size` on
a live winit window, and `src/video/window/tests.rs` has no window harness.
Verified by inspection of the winit backend; needs a Wayland session to confirm
against the issue's repro.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
