### PR TITLE
0.14 debugging: automation primitives and the WinUAE-inspired debugger set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ repeat.
 | `--click-after SECS BUTTON MS [PORT]` | Mouse button (`left`/`right`/`middle`) for MS ms (default port 1) |
 | `--joy-after SECS BUTTON MS [PORT]` | Joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red`/`blue`/...) (default port 2) |
 | `--mouse-after SECS DX DY [PORT]` | Relative mouse motion (default port 1) |
+| `--mouse-to-after SECS X Y [PORT]` | Steer the pointer to screen pixel (X, Y) via sprite 0 (default port 1) |
 | `--pot-after SECS X Y [PORT]` | Analogue stick/paddle position, 0-255 per axis (default port 2) |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--insert-cd-after SECS PATH` | Swap the CD image in the machine's CD drive (CDTV/CD32/SCSI CD-ROM) |

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -152,6 +152,7 @@ model = "68000"
 # [debug]
 # log_unmapped = "DD0000-DEFFFF"   # hex START-END, end included; or "all"
 # validate_chipset = true          # report chipset misuse with the PC that caused it
+# detect_smc = true                # report writes landing on already-executed code
 
 
 # Extended ROM image for CDTV/CD32 machines: a 256 KiB image maps at

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -151,6 +151,7 @@ model = "68000"
 # at one window.
 # [debug]
 # log_unmapped = "DD0000-DEFFFF"   # hex START-END, end included; or "all"
+# validate_chipset = true          # report chipset misuse with the PC that caused it
 
 
 # Extended ROM image for CDTV/CD32 machines: a 256 KiB image maps at

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -60,7 +60,7 @@ Stops (each toggles: repeat the command to remove):
 | Command | Effect |
 |---|---|
 | `BREAK ADDR [COND] [IGN N]`, `B` | PC breakpoint, with the Break tab's condition grammar |
-| `WATCH ADDR [CLASS] [PC=ADDR]`, `W` | Memory word watchpoint. `CLASS` narrows it to one accessor: `CPU`, `BLITTER`, `DISK`, `COPPER`, or a DMA channel (`BPL1`..`BPL8`, `SPR0`..`SPR7`, `AUD0`..`AUD3`) -- the DMA channels catch *reads* too, which a value compare cannot see. `PC=ADDR` stops only when that instruction made the access |
+| `WATCH ADDR [CLASS] [PC=ADDR]`, `W` | Memory word watchpoint. `CLASS` narrows it to one accessor: `CPU`, `BLITTER`, `DISK`, `COPPER`, or a DMA channel (`BPL1`..`BPL8`, `SPR0`..`SPR7`, `AUD0`..`AUD3`) -- the DMA channels catch *reads* too, which a value compare cannot see. `PC=ADDR` stops only when that instruction made the access, and cannot be combined with a DMA class: only the CPU has an instruction behind an access |
 | `RWATCH NAME\|OFF`, `RW` | Custom-register write watch (`RWATCH DMACON`) |
 | `BTRAP V [H]` | Beam trap (decimal position) |
 | `CBREAK ADDR` | Copper breakpoint |

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -60,7 +60,7 @@ Stops (each toggles: repeat the command to remove):
 | Command | Effect |
 |---|---|
 | `BREAK ADDR [COND] [IGN N]`, `B` | PC breakpoint, with the Break tab's condition grammar |
-| `WATCH ADDR [CPU\|BLITTER\|DISK]`, `W` | Memory word watchpoint; the optional filter stops only on that writer |
+| `WATCH ADDR [CLASS] [PC=ADDR]`, `W` | Memory word watchpoint. `CLASS` narrows it to one accessor: `CPU`, `BLITTER`, `DISK`, `COPPER`, or a DMA channel (`BPL1`..`BPL8`, `SPR0`..`SPR7`, `AUD0`..`AUD3`) -- the DMA channels catch *reads* too, which a value compare cannot see. `PC=ADDR` stops only when that instruction made the access |
 | `RWATCH NAME\|OFF`, `RW` | Custom-register write watch (`RWATCH DMACON`) |
 | `BTRAP V [H]` | Beam trap (decimal position) |
 | `CBREAK ADDR` | Copper breakpoint |

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -255,6 +255,26 @@ replaced wholesale; port defaults to 2), `input.analogue {port?, x, y}`
 latches; port defaults to 2). Events drive the named port's electrical
 lines whatever device is configured there.
 
+`input.mouse_to {x, y, port?, tolerance?, max_frames?}` puts the guest's
+pointer at an absolute position instead: `x` and `y` are presented pixels
+in the same coordinate space `capture.screenshot` writes out, so a
+position read off a screenshot can be clicked directly. There is no
+absolute mouse to set -- the port carries a quadrature encoder, and the
+guest turns counts into pixels through its own acceleration curve, which
+is history-dependent and defeats aimed relative deltas. So this servos:
+it injects a delta, advances one frame, reads where the hardware drew
+sprite 0 (the Amiga pointer *is* sprite 0), and corrects, learning the
+pixels-per-count ratio it is being given. It runs the machine for up to
+`max_frames` frames (default 60) and is refused while a resume is in
+flight. `tolerance` (default 2 px) is how close counts as arrived: the
+pointer moves in lo-res pixels, which are two columns of the presented
+canvas, so not every coordinate is exactly reachable. Failing to land is
+an error (`-32003`) naming where the pointer settled, never a quiet
+near-miss -- a script that carried on would click the wrong thing. A
+guest that draws its pointer into a bitplane instead of a sprite has
+nothing to observe, and is reported as such; use `input.mouse` for
+relative motion there.
+
 Controller ports: `input.get_ports` -> `{"port1": "mouse", "port2":
 "joystick"}`; `input.set_port {port, device:
 "mouse"|"joystick"|"cd32"|"analogue"|"none"}` hot-plugs a device, as if

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -276,8 +276,14 @@ programmable super-hi-res scan's 35 ns canvas; with an active RTG
 screen it is the board frame downsampled to 716 at the board's
 native row count; the response reports the width), `capture.digest`
 (FNV-1a hash of the rendered frame -- the cheap change-detection
-primitive, identical in both server modes), `machine.reset
-{kind: "warm"|"cold"}`.
+primitive, identical in both server modes), `capture.region_digest
+{x?, y?, w, h}` (the same hash over one rectangle of that frame, so a
+script can assert on a single widget without the rest of the screen's
+motion changing the answer; the reply echoes the rectangle and reports
+the frame's own `width`/`height`, and a rectangle that does not fit
+inside the current frame is `-32602` rather than a silent clamp --
+frame geometry moves with the beam standard and the canvas scale),
+`machine.reset {kind: "warm"|"cold"}`.
 
 Notifications have no `id`. The subscribed `event.frame`, `event.serial`,
 `event.interrupt`, and `event.media` streams work in both server modes.

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -247,6 +247,22 @@ a few bytes ahead of the writing instruction is called out as inside the
 68000's prefetch, where it may be too late to take effect on this pass.
 An address counts as code once an instruction there has retired.
 
+Memory heat map: `memory.heatmap {enabled?, base?, span?}` arms a
+256x256 grid over a window of the address space (default the whole
+24-bit space, so one cell per 256 bytes) and reports the window and
+`bytes_per_cell`; `memory.heatmap.report {path?}` returns a `census` of
+how many cells each toucher currently holds and, with `path`, writes the
+grid as a 256x256 PNG. A slot map says what owned the chip bus at a
+colour clock; this says where in memory anything is happening -- which
+is the question when a display is drawn from the wrong buffer or a DMA
+channel is pointed at the wrong bank. Cells are coloured by what last
+touched them (CPU read/write, blitter, Copper, disk, and the bitplane,
+sprite and audio DMA channels) and fade to black over 32 frames. The
+window is movable, so the RAM a 32-bit CPU sees above the 24-bit space
+can be looked at too; moving it starts a cold map, since the cells would
+otherwise carry activity from addresses they no longer name. `-32003`
+while it is not armed.
+
 Bus faults: `fault.inject {addr, len?, on?, count?}` -> `{id}` makes CPU
 accesses inside that window take a bus error instead of reaching memory
 (`on` is `read`, `write`, or `both`, default both; `count` limits how

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -220,6 +220,22 @@ not touched), `disasm {addr?, count?}`, `custom.dump`,
 `custom.read {reg}` (name or offset), `cia.get {cia: "a"|"b"}`,
 `beam.get`, `display.get`, `copper.list {addr?, max?}`, `pc_history`.
 
+Chipset validation: `chipset.validate {enabled?, clear?}` arms or disarms
+the custom-register access validator (`[debug] validate_chipset` arms it
+from the start instead) and can empty its report; `chipset.report` ->
+`{armed, findings, dropped}` lists what it has seen, most-repeated first,
+each finding carrying `kind`, `reg`, the `by`/`addr` of the writer, its
+`count`, the beam position, and a `detail` line naming the hardware
+behaviour. The kinds are `absent-register` (a register the fitted
+Agnus/Denise does not have), `unused-bits`, `wrong-direction`,
+`byte-access`, `odd-address`, `mirrored-address`, and
+`pointer-outside-chip-ram`. `custom.writer {reg}` answers the companion
+question -- the last value written to a register and the PC or Copper
+address that wrote it -- and is `-32003` while the validator is not armed,
+since nothing has been recorded. `dropped` counts findings lost once the
+report filled, so a truncated report is distinguishable from a complete
+one.
+
 Battery clock (the $DC0000 RTC; see `rtc_time` in
 `docs/guide/configuration.md` for the boot-time seed): `rtc.get` reports
 `{present, chip, seeded, frozen, unix, time}` (`chip` is the fitted part,

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -251,10 +251,17 @@ re-read. `-32007` on a machine with no clock fitted.
 
 Breakpoints (shared with the debugger window's live store, so
 GUI-toggled points appear in `break.list`): `break.add {kind: "pc",
-addr, cond?, ignore?}` / `{kind: "watch", addr, class?}` /
+addr, cond?, ignore?}` / `{kind: "watch", addr, class?, pc?}` /
 `{kind: "reg_watch", reg}` / `{kind: "beam", vpos, hpos?}` /
 `{kind: "copper", addr}` / `{kind: "catch", vector}` -> `{id}`;
-`break.remove {id}`; `break.list`; `break.clear`. Conditions are
+`break.remove {id}`; `break.list`; `break.clear`. A watch's optional
+`class` narrows it to one accessor -- `cpu`, `blitter`, `disk`, `copper`,
+or a DMA channel (`bpl1`..`bpl8`, `spr0`..`spr7`, `aud0`..`aud3`). The
+channel classes also catch DMA *reads*, which a value comparison cannot
+see at all: "which sprite fetched this word" is the question a display
+bug actually poses. A watch's optional `pc` fires only when that
+instruction made the access, for a word a dozen routines all poke.
+Conditions are
 `{lhs, op, rhs}` with operands `"d0"`-`"a7"`, `"pc"`, `"sr"`, a number,
 or `{"mem": addr}`, and ops `eq|ne|lt|gt|le|ge|and`. A session's own
 breakpoints are removed when it disconnects; GUI-set points are left

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -201,10 +201,12 @@ guest tells you it is done by producing the same picture twice. N must be
 at least 2. The optional region params narrow the comparison the way
 `capture.region_digest` does, which is what makes the target usable on a
 live Workbench screen: a blinking cursor never lets the whole frame
-settle, but the dialog you are waiting for does. `max_frames` bounds the
-wait; running out of it stops with reason `budget` and a detail naming
-the longest run reached, rather than hanging the client on a display
-that never settles.
+settle, but the dialog you are waiting for does. Naming any of the
+region params requires the rest of a valid rectangle -- an origin with
+no size is `-32602`, not a quiet whole-frame wait. `max_frames` bounds
+the wait; running out of it stops with reason `budget` and a detail
+naming the longest run reached, rather than hanging the client on a
+display that never settles.
 
 Reverse (time travel is armed automatically for control sessions;
 `-32006` when history is exhausted): `reverse_step {n?}`,
@@ -294,7 +296,8 @@ addr, cond?, ignore?}` / `{kind: "watch", addr, class?, pc?}` /
 `{kind: "copper", addr}` / `{kind: "catch", vector}` -> `{id}`;
 `break.remove {id}`; `break.list`; `break.clear`. A watch's optional
 `class` narrows it to one accessor -- `cpu`, `blitter`, `disk`, `copper`,
-or a DMA channel (`bpl1`..`bpl8`, `spr0`..`spr7`, `aud0`..`aud3`). The
+or a DMA channel (`bpl1`..`bpl8`, `spr0`..`spr7`, `aud0`..`aud3`, each
+bounded by the channels the hardware actually has). The
 channel classes also catch DMA *reads*, which a value comparison cannot
 see at all: "which sprite fetched this word" is the question a display
 bug actually poses. A watch's optional `pc` fires only when that

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -301,7 +301,10 @@ bounded by the channels the hardware actually has). The
 channel classes also catch DMA *reads*, which a value comparison cannot
 see at all: "which sprite fetched this word" is the question a display
 bug actually poses. A watch's optional `pc` fires only when that
-instruction made the access, for a word a dozen routines all poke.
+instruction made the access, for a word a dozen routines all poke. Only
+the CPU has an instruction behind an access, so `pc` cannot be combined
+with a DMA `class` -- that pair describes something that cannot happen
+and is `-32602` rather than a watch that never fires.
 Conditions are
 `{lhs, op, rhs}` with operands `"d0"`-`"a7"`, `"pc"`, `"sr"`, a number,
 or `{"mem": addr}`, and ops `eq|ne|lt|gt|le|ge|and`. A session's own

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -245,6 +245,17 @@ a few bytes ahead of the writing instruction is called out as inside the
 68000's prefetch, where it may be too late to take effect on this pass.
 An address counts as code once an instruction there has retired.
 
+Bus faults: `fault.inject {addr, len?, on?, count?}` -> `{id}` makes CPU
+accesses inside that window take a bus error instead of reaching memory
+(`on` is `read`, `write`, or `both`, default both; `count` limits how
+many it delivers, default unlimited); `fault.list` reports each window
+with its `remaining` shots and `hits`; `fault.clear` removes them all.
+This is a host debugger facility, not emulated hardware -- it exists so a
+guest's own fault handler can be exercised deterministically, instead of
+hunting for an address that happens to be undecoded on the machine under
+test. A faulted access never reaches memory, so the guest sees exactly
+what an undecoded address would give it.
+
 Battery clock (the $DC0000 RTC; see `rtc_time` in
 `docs/guide/configuration.md` for the boot-time seed): `rtc.get` reports
 `{present, chip, seeded, frozen, unix, time}` (`chip` is the fitted part,

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -228,8 +228,10 @@ each finding carrying `kind`, `reg`, the `by`/`addr` of the writer, its
 `count`, the beam position, and a `detail` line naming the hardware
 behaviour. The kinds are `absent-register` (a register the fitted
 Agnus/Denise does not have), `unused-bits`, `wrong-direction`,
-`byte-access`, `odd-address`, `mirrored-address`, and
-`pointer-outside-chip-ram`. `custom.writer {reg}` answers the companion
+`byte-access`, `odd-address`, `mirrored-address`,
+`pointer-outside-chip-ram`, and the device-misuse kinds `blitter-busy`,
+`blitter-dma-off`, `disk-not-ready` and `keyboard-handshake-short` --
+the ones that hang rather than glitch. `custom.writer {reg}` answers the companion
 question -- the last value written to a register and the PC or Copper
 address that wrote it -- and is `-32003` while the validator is not armed,
 since nothing has been recorded. `dropped` counts findings lost once the

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -236,6 +236,15 @@ since nothing has been recorded. `dropped` counts findings lost once the
 report filled, so a truncated report is distinguishable from a complete
 one.
 
+Self-modifying code: `smc.detect {enabled?, clear?}` arms or disarms the
+detector (`[debug] detect_smc` arms it from the start) and can empty its
+report; `smc.report` -> `{armed, writes, dropped}` lists writes that
+landed on already-executed memory, each with `addr`, `writer_pc`, the
+`distance` between them, a `count`, and a `detail` line. A patch within
+a few bytes ahead of the writing instruction is called out as inside the
+68000's prefetch, where it may be too late to take effect on this pass.
+An address counts as code once an instruction there has retired.
+
 Battery clock (the $DC0000 RTC; see `rtc_time` in
 `docs/guide/configuration.md` for the boot-time seed): `rtc.get` reports
 `{present, chip, seeded, frozen, unix, time}` (`chip` is the fitted part,

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -330,7 +330,7 @@ absolute mouse to set -- the port carries a quadrature encoder, and the
 guest turns counts into pixels through its own acceleration curve, which
 is history-dependent and defeats aimed relative deltas. So this servos:
 it injects a delta, advances one frame, reads where the hardware drew
-sprite 0 (the Amiga pointer *is* sprite 0), and corrects, learning the
+sprite 0 (which is what the OS draws its pointer with), and corrects, learning the
 pixels-per-count ratio it is being given. It runs the machine for up to
 `max_frames` frames (default 60) and is refused while a resume is in
 flight. `tolerance` (default 2 px) is how close counts as arrived: the

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -191,8 +191,20 @@ Session: `hello {token?}`, `auth {token}`, `status`, `shutdown`.
 
 Execution: `continue`, `step {n?}`, `step_over`, `step_out`,
 `step_copper`, `step_frame {n?}`,
-`run_until {pc | vpos[,hpos] | frame | cck | seconds}`, `pause`
-(all resume verbs accept `collect?`).
+`run_until {pc | vpos[,hpos] | frame | cck | seconds | stable_frames}`,
+`pause` (all resume verbs accept `collect?`).
+
+`run_until {stable_frames: N, max_frames?, x?, y?, w?, h?}` runs until N
+consecutive rendered frames hash identically -- how to wait for a GUI to
+finish drawing without guessing at an emulated-seconds delay, since the
+guest tells you it is done by producing the same picture twice. N must be
+at least 2. The optional region params narrow the comparison the way
+`capture.region_digest` does, which is what makes the target usable on a
+live Workbench screen: a blinking cursor never lets the whole frame
+settle, but the dialog you are waiting for does. `max_frames` bounds the
+wait; running out of it stops with reason `budget` and a detail naming
+the longest run reached, rather than hanging the client on a display
+that never settles.
 
 Reverse (time travel is armed automatically for control sessions;
 `-32006` when history is exhausted): `reverse_step {n?}`,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1125,10 +1125,15 @@ write-only ones, byte or odd-address access to word registers, access
 through an address mirror, and DMA pointers aimed past the chip RAM Agnus
 can address. It also covers the engines behind those registers, where
 misuse hangs rather than glitches: a blit started while the previous one
-is still running or with its DMA switched off, disk DMA armed against a
-drive with no media or its motor still off (the class behind the classic
-loader dead-spins), and a keyboard handshake pulse too narrow for the
-6500/1 to sample, after which the keyboard simply stops sending. Each finding names the PC (or Copper address) that made the
+is still running (there is no register-file interlock, so the running
+blit is drained and the replacement starts from whatever pointer state it
+left) or with its DMA switched off (BBUSY is set and the blit stays
+pending until BLTEN and DMAEN are enabled), disk DMA armed against a
+drive that could not serve it at that moment -- no media, or the motor
+still off, the class behind the classic loader dead-spins -- and a
+keyboard handshake pulse too narrow to count as one while the MCU was
+waiting for it, which costs a key and stalls input until the keyboard
+resynchronises after 143 ms. Each finding names the PC (or Copper address) that made the
 access and the beam position, is deduplicated by (kind, register, writer)
 with a repeat count, and is logged the first time it is seen. It also arms
 a per-register last-writer table, which answers "what set BPLCON3, and

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1097,6 +1097,7 @@ back to the native screen. On a single-window emulator you usually want
 [debug]
 log_unmapped = "DD0000-DEFFFF"
 validate_chipset = true
+detect_smc = true
 ```
 
 `log_unmapped` logs every CPU read and write inside the given range that no
@@ -1131,3 +1132,18 @@ from where?" without a bisect. Read both over the control protocol with
 [the control protocol](../debugger/control.md)), which can also arm and
 disarm the validator live. Off by default; an unarmed machine pays nothing
 for it.
+
+`detect_smc` reports writes that land on memory the CPU has already
+executed. Self-modification is legitimate on a 68000 -- decrunchers,
+trackers and Copper-list patchers all do it -- but it is also where a
+prefetch-related bug hides, since the CPU has already fetched the word
+ahead of the one it is executing, and neither a patch applied too late
+nor one applied to the wrong address leaves a trace at the moment it
+happens. Each report names the written address, the instruction that
+wrote it, and the distance between them, calling out a patch close enough
+to sit inside the prefetch. An address counts as code once an instruction
+there has retired, so an instruction patching its own extension words on
+its only execution is not reported; every repeating pattern is caught on
+the pass after the first. Read it with `smc.report` over the control
+protocol, which can also arm and disarm the detector live. Off by
+default; it costs a 1 MiB execution map while armed.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1096,6 +1096,7 @@ back to the native screen. On a single-window emulator you usually want
 ```toml
 [debug]
 log_unmapped = "DD0000-DEFFFF"
+validate_chipset = true
 ```
 
 `log_unmapped` logs every CPU read and write inside the given range that no
@@ -1114,3 +1115,19 @@ followed by a long run of status reads that never come back ready.
 A booting Kickstart probes enough empty address space that `all` produces on
 the order of a million lines per boot, so prefer a range once you know roughly
 where to look.
+
+`validate_chipset` arms the custom-register access validator: a running
+report of software using the chipset in ways the hardware quietly ignores.
+It flags writes to registers the fitted Agnus/Denise does not have, bits a
+register does not define, writes to read-only registers and reads of
+write-only ones, byte or odd-address access to word registers, access
+through an address mirror, and DMA pointers aimed past the chip RAM Agnus
+can address. Each finding names the PC (or Copper address) that made the
+access and the beam position, is deduplicated by (kind, register, writer)
+with a repeat count, and is logged the first time it is seen. It also arms
+a per-register last-writer table, which answers "what set BPLCON3, and
+from where?" without a bisect. Read both over the control protocol with
+`chipset.report` and `custom.writer` (see
+[the control protocol](../debugger/control.md)), which can also arm and
+disarm the validator live. Off by default; an unarmed machine pays nothing
+for it.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1123,7 +1123,12 @@ It flags writes to registers the fitted Agnus/Denise does not have, bits a
 register does not define, writes to read-only registers and reads of
 write-only ones, byte or odd-address access to word registers, access
 through an address mirror, and DMA pointers aimed past the chip RAM Agnus
-can address. Each finding names the PC (or Copper address) that made the
+can address. It also covers the engines behind those registers, where
+misuse hangs rather than glitches: a blit started while the previous one
+is still running or with its DMA switched off, disk DMA armed against a
+drive with no media or its motor still off (the class behind the classic
+loader dead-spins), and a keyboard handshake pulse too narrow for the
+6500/1 to sample, after which the keyboard simply stops sending. Each finding names the PC (or Copper address) that made the
 access and the beam position, is deduplicated by (kind, register, writer)
 with a repeat count, and is logged the first time it is seen. It also arms
 a per-register last-writer table, which answers "what set BPLCON3, and

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -75,6 +75,7 @@ deterministically:
 | `--click-after SECS BUTTON MS [PORT]` | Press a mouse button (`left`/`right`/`middle`) for MS milliseconds (default port 1) |
 | `--joy-after SECS BUTTON MS [PORT]` | Press a joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red` (alias `fire`)/`blue`/`green`/`yellow`/`play`/`rwd`/`ffw`) for MS milliseconds (default port 2) |
 | `--mouse-after SECS DX DY [PORT]` | Apply a relative mouse motion of (DX, DY) counter steps (default port 1) |
+| `--mouse-to-after SECS X Y [PORT]` | From SECS, steer the guest pointer to presented pixel (X, Y) by watching sprite 0 (default port 1) |
 | `--pot-after SECS X Y [PORT]` | Set an analogue controller's stick/paddle position, 0-255 per axis (default port 2) |
 | `--floppy-drives COUNT` | Connect `COUNT` floppy drives (`1` to `4`), so scheduled inserts can target empty external drives |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
@@ -90,6 +91,22 @@ on. All the flags repeat, so several inputs can be queued:
 ```sh
 ./target/release/copperline --key-after 14.0 ctrl 500 --press-after 14.1 c
 ```
+
+`--mouse-to-after` is the odd one out: it names a destination rather than
+a motion. The Amiga mouse port carries a quadrature encoder with no
+absolute position, and the guest turns counts into pointer pixels through
+its own acceleration curve, so a relative delta cannot be aimed at a
+button. Since the Amiga pointer is sprite 0, the flag instead watches
+where the hardware draws that sprite and corrects the motion once per
+frame until it lands, learning the pixels-per-count ratio as it goes.
+`X` and `Y` are presented pixels, the same coordinates a
+`--screenshot-after` PNG is measured in, so a target can be read straight
+off a capture. Targets run one at a time and in timestamp order, each
+holding the pointer until it arrives or gives up (about a second of
+emulated time); a guest that draws its pointer into a bitplane rather
+than a sprite logs a warning and is left alone. `input.mouse_to` in the
+[control protocol](../debugger/control.md) is the same mechanism with a
+reply.
 
 The controller-port flags take an optional trailing `PORT` token (`1` or
 `2`) naming the game port the event lands on, so any controller wiring set

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1019,6 +1019,11 @@ pub struct Bus {
     /// costs a bisect.
     #[serde(skip)]
     reg_writers: Option<Box<[Option<RegWrite>; 256]>>,
+    /// Self-modifying-code detector, present only while armed
+    /// (`[debug] detect_smc`). Transient diagnostic state; a restore
+    /// starts with a fresh, empty execution map.
+    #[serde(skip)]
+    pub(crate) smc: Option<Box<crate::smc::SmcTracker>>,
     blitter_slowdown_cpu_misses: u8,
     /// Pending INTREQ.BLIT raise, in colour clocks. Real Agnus raises the
     /// blitter interrupt one clock after the sequencer's BLTDONE cycle
@@ -2492,6 +2497,7 @@ impl Bus {
             cpu_pc: 0,
             regcheck: None,
             reg_writers: None,
+            smc: None,
             ui_beam_traps: Vec::new(),
             ui_beam_hit: None,
             ui_copper_breaks: Vec::new(),
@@ -2559,6 +2565,35 @@ impl Bus {
         } else {
             self.regcheck = None;
             self.reg_writers = None;
+        }
+    }
+
+    /// Arm or disarm the self-modifying-code detector. Disarming frees
+    /// the execution map; re-arming starts from a blank one, so a report
+    /// only ever covers the window it was armed for.
+    pub fn set_smc_detection(&mut self, on: bool) {
+        if on == self.smc.is_some() {
+            return;
+        }
+        self.smc = on.then(Box::default);
+    }
+
+    pub fn smc_detection_armed(&self) -> bool {
+        self.smc.is_some()
+    }
+
+    /// The self-modifying-code reports, most-repeated first, and how many
+    /// were dropped once the report filled.
+    pub fn smc_reports(&self) -> (Vec<crate::smc::SmcReport>, u64) {
+        match &self.smc {
+            Some(smc) => (smc.reports(), smc.dropped),
+            None => (Vec::new(), 0),
+        }
+    }
+
+    pub fn clear_smc_reports(&mut self) {
+        if let Some(smc) = self.smc.as_mut() {
+            smc.clear_reports();
         }
     }
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2740,6 +2740,96 @@ impl Bus {
             self.note_chipset_finding(finding, off, writer, val, detail, vpos, hpos);
         }
         self.check_dma_pointer(off, val, writer, vpos, hpos);
+        self.check_device_misuse(off, val, writer, vpos, hpos);
+    }
+
+    /// Report a keyboard handshake pulse the 6500/1 could not sample.
+    /// Software gets no other signal: the keyboard simply stops sending,
+    /// and the guest sees keys go missing.
+    fn check_keyboard_handshake(&mut self) {
+        let Some(width) = self.keyboard.take_short_handshake() else {
+            return;
+        };
+        let writer = crate::regcheck::Writer::Cpu(self.cpu_pc);
+        self.note_chipset_finding(
+            crate::regcheck::Finding::KeyboardHandshakeShort,
+            // CIA-A's serial port is where the handshake is driven; there
+            // is no custom register involved, so the report is keyed on
+            // the pulse itself.
+            0,
+            writer,
+            width,
+            crate::chipset::keyboard::HANDSHAKE_MIN_CCK.min(u64::from(u16::MAX)) as u16,
+            self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+            self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+        );
+    }
+
+    /// Hardware-misuse checks for the engines behind the registers: a
+    /// blit that cannot run, and disk DMA armed against a drive that
+    /// cannot serve it.
+    ///
+    /// These are the cases that hang rather than glitch. A loader that
+    /// arms a read with the motor still off waits on DSKBLK forever, and
+    /// a blit started with its DMA off never raises BBUSY's completion --
+    /// both look like "it froze" with no other evidence.
+    fn check_device_misuse(
+        &mut self,
+        off: u16,
+        val: u16,
+        writer: crate::regcheck::Writer,
+        vpos: u16,
+        hpos: u16,
+    ) {
+        use crate::regcheck::Finding;
+        match off {
+            // BLTSIZE / BLTSIZH: the blit-start writes.
+            0x058 | 0x05E => {
+                if self.blitter.busy {
+                    self.note_chipset_finding(
+                        Finding::BlitterBusy,
+                        off,
+                        writer,
+                        val,
+                        0,
+                        vpos,
+                        hpos,
+                    );
+                }
+                let need = DMACON_DMAEN | DMACON_BLTEN;
+                if self.agnus.dmacon & need != need {
+                    self.note_chipset_finding(
+                        Finding::BlitterDmaOff,
+                        off,
+                        writer,
+                        val,
+                        self.agnus.dmacon,
+                        vpos,
+                        hpos,
+                    );
+                }
+            }
+            // DSKLEN: arming disk DMA.
+            0x024 if val & 0x8000 != 0 => {
+                if let Some(reason) = self.floppy.dma_arming_obstacle() {
+                    let code = match reason {
+                        r if r.contains("motor") => crate::regcheck::DISK_MOTOR_OFF,
+                        r if r.contains("empty") => crate::regcheck::DISK_EMPTY,
+                        _ => crate::regcheck::DISK_NO_DRIVE,
+                    };
+                    self.note_chipset_finding(
+                        Finding::DiskNotReady,
+                        off,
+                        writer,
+                        val,
+                        code,
+                        vpos,
+                        hpos,
+                    );
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Flag a DMA pointer aimed past the chip RAM Agnus can address.
@@ -5365,7 +5455,12 @@ impl Bus {
         }
         match eff.keyboard_handshake {
             Some(true) => self.keyboard.amiga_kdat_edge(true),
-            Some(false) => self.keyboard.amiga_kdat_edge(false),
+            Some(false) => {
+                self.keyboard.amiga_kdat_edge(false);
+                if self.regcheck.is_some() {
+                    self.check_keyboard_handshake();
+                }
+            }
             None => {}
         }
         if reg == REG_PRA || reg == REG_DDRA {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1029,6 +1029,10 @@ pub struct Bus {
     /// operator is running, not machine state.
     #[serde(skip)]
     injected_faults: Vec<FaultInjection>,
+    /// Memory heat map, present only while armed. Transient diagnostic
+    /// state; a restore starts a fresh, cold map.
+    #[serde(skip)]
+    heatmap: Option<Box<crate::heatmap::HeatMap>>,
     blitter_slowdown_cpu_misses: u8,
     /// Pending INTREQ.BLIT raise, in colour clocks. Real Agnus raises the
     /// blitter interrupt one clock after the sequencer's BLTDONE cycle
@@ -2523,6 +2527,7 @@ impl Bus {
             reg_writers: None,
             smc: None,
             injected_faults: Vec::new(),
+            heatmap: None,
             ui_beam_traps: Vec::new(),
             ui_beam_hit: None,
             ui_copper_breaks: Vec::new(),
@@ -3045,6 +3050,38 @@ impl Bus {
         }
     }
 
+    /// Arm or disarm the memory heat map over a window of the address
+    /// space. Re-arming with a different window starts a cold map: the
+    /// cells would otherwise carry activity from addresses they no
+    /// longer name.
+    pub fn set_heat_map(&mut self, window: Option<(u32, u32)>) {
+        match window {
+            None => self.heatmap = None,
+            Some((base, span)) => match self.heatmap.as_mut() {
+                Some(map) if map.base() == base && map.span() == span => {}
+                Some(map) => map.set_window(base, span),
+                None => self.heatmap = Some(Box::new(crate::heatmap::HeatMap::new(base, span))),
+            },
+        }
+    }
+
+    pub fn heat_map(&self) -> Option<&crate::heatmap::HeatMap> {
+        self.heatmap.as_deref()
+    }
+
+    /// Record memory activity for the heat map. Kept behind an
+    /// emptiness check by every caller, like the watch hooks.
+    pub(crate) fn note_heat(&mut self, addr: u32, len: u32, by: crate::heatmap::Toucher) {
+        let frame = self.emulated_frames;
+        if let Some(map) = self.heatmap.as_mut() {
+            map.touch(addr, len, by, frame);
+        }
+    }
+
+    pub(crate) fn heat_map_armed(&self) -> bool {
+        self.heatmap.is_some()
+    }
+
     /// Note a read-side DMA fetch of `len` bytes from `addr` by `source`,
     /// latching a hit when it covers a watched word.
     ///
@@ -3058,6 +3095,13 @@ impl Bus {
         addr: u32,
         len: u32,
     ) {
+        if self.heatmap.is_some() {
+            self.note_heat(
+                addr,
+                len,
+                crate::heatmap::Toucher::from_watch_source(source),
+            );
+        }
         if self.ui_mem_watch_addrs.is_empty() || self.ui_dma_hit.is_some() {
             return;
         }
@@ -3078,8 +3122,10 @@ impl Bus {
 
     /// Whether any memory watch is armed, so the DMA fetch sites can skip
     /// the call entirely on an unwatched machine.
+    /// Whether any per-access observer wants the DMA fetch sites to
+    /// report: a memory watch, or the heat map.
     pub(crate) fn mem_watches_armed(&self) -> bool {
-        !self.ui_mem_watch_addrs.is_empty()
+        !self.ui_mem_watch_addrs.is_empty() || self.heatmap.is_some()
     }
 
     /// Take the pending DMA-read watch hit, if any.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2752,9 +2752,16 @@ impl Bus {
     /// Software gets no other signal: the keyboard simply stops sending,
     /// and the guest sees keys go missing.
     fn check_keyboard_handshake(&mut self) {
+        // Drained on every handshake edge whether or not the validator is
+        // armed. The MCU latches unconditionally, so a pulse from before
+        // arming would otherwise surface at the next edge and be
+        // attributed to whatever PC happened to be running by then.
         let Some(width) = self.keyboard.take_short_handshake() else {
             return;
         };
+        if self.regcheck.is_none() {
+            return;
+        }
         let writer = crate::regcheck::Writer::Cpu(self.cpu_pc);
         self.note_chipset_finding(
             crate::regcheck::Finding::KeyboardHandshakeShort,
@@ -5498,9 +5505,7 @@ impl Bus {
             Some(true) => self.keyboard.amiga_kdat_edge(true),
             Some(false) => {
                 self.keyboard.amiga_kdat_edge(false);
-                if self.regcheck.is_some() {
-                    self.check_keyboard_handshake();
-                }
+                self.check_keyboard_handshake();
             }
             None => {}
         }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2816,12 +2816,7 @@ impl Bus {
             }
             // DSKLEN: arming disk DMA.
             0x024 if val & 0x8000 != 0 => {
-                if let Some(reason) = self.floppy.dma_arming_obstacle() {
-                    let code = match reason {
-                        r if r.contains("motor") => crate::regcheck::DISK_MOTOR_OFF,
-                        r if r.contains("empty") => crate::regcheck::DISK_EMPTY,
-                        _ => crate::regcheck::DISK_NO_DRIVE,
-                    };
+                if let Some(code) = self.floppy.dma_arming_obstacle() {
                     self.note_chipset_finding(
                         Finding::DiskNotReady,
                         off,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1024,6 +1024,11 @@ pub struct Bus {
     /// starts with a fresh, empty execution map.
     #[serde(skip)]
     pub(crate) smc: Option<Box<crate::smc::SmcTracker>>,
+    /// Debugger-injected bus faults. Transient debug state: a restore
+    /// does not resurrect them, since they describe an experiment the
+    /// operator is running, not machine state.
+    #[serde(skip)]
+    injected_faults: Vec<FaultInjection>,
     blitter_slowdown_cpu_misses: u8,
     /// Pending INTREQ.BLIT raise, in colour clocks. Real Agnus raises the
     /// blitter interrupt one clock after the sequencer's BLTDONE cycle
@@ -1220,6 +1225,25 @@ fn beam_write_source_name(source: BeamWriteSource) -> &'static str {
         BeamWriteSource::CpuCopperIrq => "cpu_copper_irq",
         BeamWriteSource::Copper => "copper",
     }
+}
+
+/// A debugger-injected bus fault: a CPU access inside this window and
+/// matching this direction takes a bus error instead of reaching memory.
+///
+/// This is a host debugger facility, not emulated hardware: it exists so
+/// a guest's own fault handler can be exercised deterministically,
+/// rather than by finding an address that happens to be undecoded on the
+/// machine under test.
+#[derive(Clone, Copy, Debug)]
+pub struct FaultInjection {
+    /// Inclusive address window.
+    pub start: u32,
+    pub end: u32,
+    pub on_read: bool,
+    pub on_write: bool,
+    /// Faults left to deliver; `None` never expires.
+    pub remaining: Option<u32>,
+    pub hits: u64,
 }
 
 /// The most recent write to one custom register, for the debugger's
@@ -2498,6 +2522,7 @@ impl Bus {
             regcheck: None,
             reg_writers: None,
             smc: None,
+            injected_faults: Vec::new(),
             ui_beam_traps: Vec::new(),
             ui_beam_hit: None,
             ui_copper_breaks: Vec::new(),
@@ -2566,6 +2591,51 @@ impl Bus {
             self.regcheck = None;
             self.reg_writers = None;
         }
+    }
+
+    /// Arm a bus fault over an address window. Returns its index, which
+    /// is stable until the list is cleared.
+    pub fn inject_bus_fault(&mut self, fault: FaultInjection) -> usize {
+        self.injected_faults.push(fault);
+        self.injected_faults.len() - 1
+    }
+
+    pub fn injected_bus_faults(&self) -> &[FaultInjection] {
+        &self.injected_faults
+    }
+
+    pub fn clear_injected_bus_faults(&mut self) {
+        self.injected_faults.clear();
+    }
+
+    /// Whether a CPU access of `len` bytes at `addr` should take an
+    /// injected bus error, consuming one of a counted injection's shots.
+    ///
+    /// Kept behind an emptiness check by every caller so an un-armed
+    /// machine pays a single branch per access.
+    pub(crate) fn take_injected_fault(&mut self, addr: u32, len: u32, write: bool) -> bool {
+        let last = addr.wrapping_add(len.max(1)).wrapping_sub(1);
+        for fault in &mut self.injected_faults {
+            if write && !fault.on_write || !write && !fault.on_read {
+                continue;
+            }
+            if last < fault.start || addr > fault.end {
+                continue;
+            }
+            if let Some(remaining) = fault.remaining.as_mut() {
+                if *remaining == 0 {
+                    continue;
+                }
+                *remaining -= 1;
+            }
+            fault.hits += 1;
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn bus_faults_armed(&self) -> bool {
+        !self.injected_faults.is_empty()
     }
 
     /// Arm or disarm the self-modifying-code detector. Disarming frees

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2698,6 +2698,13 @@ impl Bus {
     /// last-writer table. Called from the single write chokepoint, and
     /// only when armed.
     fn note_custom_write(&mut self, off: u16, val: u16, source: BeamWriteSource) {
+        // The register bank is $000-$1FE; the write path masks only to
+        // $FFE, so the rest of the custom page arrives here too and must
+        // not index the tables. Those offsets decode to nothing, which
+        // the CPU-side shape check reports separately.
+        if off > 0x1FE {
+            return;
+        }
         let writer = match source {
             BeamWriteSource::Copper => crate::regcheck::Writer::Copper(self.copper.pc()),
             BeamWriteSource::Cpu | BeamWriteSource::CpuCopperIrq => {
@@ -2820,8 +2827,11 @@ impl Bus {
                     );
                 }
             }
-            // DSKLEN: arming disk DMA.
-            0x024 if val & 0x8000 != 0 => {
+            // DSKLEN, on the write that actually starts the transfer:
+            // Paula needs the value written twice, and the first write
+            // only latches it, so reporting on that one would name a
+            // write after which DMA is by design not armed.
+            0x024 if self.floppy.dsklen_write_starts_dma(val) => {
                 if let Some(code) = self.floppy.dma_arming_obstacle() {
                     self.note_chipset_finding(
                         Finding::DiskNotReady,
@@ -2913,18 +2923,25 @@ impl Bus {
             self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
             self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
         );
-        if size == 1 {
+        // Byte *writes* are the misuse: the custom chips have no byte
+        // lanes, so the value lands in both halves. A byte read is
+        // perfectly well defined -- the chip drives the whole bus and the
+        // CPU takes its lane -- and `move.b $DFF006,d0` beam polling is
+        // one of the most common idioms in Amiga software.
+        if size == 1 && !read {
             let byte = (addr & 1) as u16;
             self.note_chipset_finding(Finding::ByteAccess, reg, writer, 0, byte, vpos, hpos);
         } else if addr & 1 != 0 {
             self.note_chipset_finding(Finding::OddAddress, reg, writer, 0, 0, vpos, hpos);
         }
-        // The custom bank repeats every $200 bytes inside the $DFF000
-        // page and again across the wider chip-register window; code that
-        // lands anywhere but the canonical address is relying on the
-        // decode gaps rather than the register map.
-        if off >= 0x200 {
-            self.note_chipset_finding(Finding::MirroredAddress, reg, writer, 0, 0, vpos, hpos);
+        // Offsets above the $000-$1FE register bank decode to nothing at
+        // all: the write is dropped and the read returns the undriven
+        // bus. (Accesses through the wider chip-register window are
+        // folded to this page before they reach here, so they are
+        // indistinguishable from a canonical access and are not
+        // reported.)
+        if off > 0x1FE {
+            self.note_chipset_finding(Finding::UnmappedOffset, reg, writer, 0, 0, vpos, hpos);
         }
         if read && matches!(crate::regcheck::direction(reg), Some(Direction::WriteOnly)) {
             self.note_chipset_finding(Finding::WrongDirection, reg, writer, 0, 0, vpos, hpos);
@@ -2941,8 +2958,11 @@ impl Bus {
             | 0x1CC | 0x1CE | 0x1D8 | 0x1DC | 0x1DE | 0x1E0 | 0x1E2 => {
                 self.blitter_ecs_registers_enabled()
             }
-            // ECS Denise: BPLCON3 and DIWHIGH.
-            0x106 => self.denise_ecs_registers(),
+            // ECS Denise: BPLCON3 latches only while BPLCON0.ECSENA is
+            // set, which is the gate the write dispatch applies -- so a
+            // BPLCON3 write without ECSENA is reported, which is one of
+            // the classic silent drops this validator exists to surface.
+            0x106 => self.bplcon3_write_enabled(),
             0x1E4 => self.denise_ecs_registers(),
             // AGA Lisa: BPLCON4, CLXCON2, and bitplanes 7-8.
             0x10C | 0x10E => self.denise_is_lisa(),
@@ -3062,7 +3082,12 @@ impl Bus {
         match window {
             None => self.heatmap = None,
             Some((base, span)) => match self.heatmap.as_mut() {
-                Some(map) if map.base() == base && map.span() == span => {}
+                // Compared against the span the request becomes, not the
+                // one asked for: the map rounds it up, so a caller
+                // repeating its own request would otherwise look like a
+                // new window every time and wipe what it had collected.
+                Some(map)
+                    if map.base() == base && map.span() == crate::heatmap::rounded_span(span) => {}
                 Some(map) => map.set_window(base, span),
                 None => self.heatmap = Some(Box::new(crate::heatmap::HeatMap::new(base, span))),
             },
@@ -3185,7 +3210,19 @@ impl Bus {
     /// (serde-skipped), so without this a reverse step or state load
     /// would silently disarm the debugger. Pending unpolled hits stay
     /// dropped: they describe the abandoned timeline.
-    pub(crate) fn adopt_ui_debug_state(&mut self, previous: &Bus) {
+    pub(crate) fn adopt_ui_debug_state(&mut self, previous: &mut Bus) {
+        // Armed diagnostics move across with the rest of the debug state.
+        // A reverse step or a state load replaces the Bus, and without
+        // this the validator, the SMC map, the heat map and any injected
+        // faults would silently disarm underneath a session that had
+        // asked for them -- while beam traps and watches stayed live,
+        // which is the tell that this was an omission. Their collected
+        // reports come too: the operator's experiment is still running.
+        self.regcheck = previous.regcheck.take();
+        self.reg_writers = previous.reg_writers.take();
+        self.smc = previous.smc.take();
+        self.heatmap = previous.heatmap.take();
+        self.injected_faults = std::mem::take(&mut previous.injected_faults);
         self.ui_beam_traps = previous.ui_beam_traps.clone();
         self.ui_copper_breaks = previous.ui_copper_breaks.clone();
         self.ui_copper_last_pc = previous.ui_copper_last_pc;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2724,25 +2724,27 @@ impl Bus {
             return;
         }
         use crate::regcheck::{Direction, Finding};
-        let mut findings: [Option<(Finding, u16)>; 3] = [None; 3];
-        let mut n = 0;
         if matches!(crate::regcheck::direction(off), Some(Direction::ReadOnly)) {
-            findings[n] = Some((Finding::WrongDirection, 0));
-            n += 1;
+            self.note_chipset_finding(Finding::WrongDirection, off, writer, val, 0, vpos, hpos);
         }
+        // Undefined bits are only meaningful on a register the fitted
+        // chipset actually has; on one it does not, the whole write is
+        // dropped and the bit pattern says nothing.
         if !self.custom_reg_present(off) {
-            findings[n] = Some((Finding::AbsentRegister, 0));
-            n += 1;
+            self.note_chipset_finding(Finding::AbsentRegister, off, writer, val, 0, vpos, hpos);
         } else if let Some(defined) = crate::regcheck::defined_bits(off) {
             let undefined = val & !defined;
             if undefined != 0 {
-                findings[n] = Some((Finding::UnusedBits, undefined));
-                n += 1;
+                self.note_chipset_finding(
+                    Finding::UnusedBits,
+                    off,
+                    writer,
+                    val,
+                    undefined,
+                    vpos,
+                    hpos,
+                );
             }
-        }
-        let _ = n;
-        for (finding, detail) in findings.into_iter().flatten() {
-            self.note_chipset_finding(finding, off, writer, val, detail, vpos, hpos);
         }
         self.check_dma_pointer(off, val, writer, vpos, hpos);
         self.check_device_misuse(off, val, writer, vpos, hpos);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2579,9 +2579,6 @@ impl Bus {
         self.rtc_present
     }
 
-    /// Replace the debugger-window custom-register watch set (word
-    /// offsets into $DFF000). A pending unpolled hit is dropped, so a
-    /// stale hit cannot fire after its watch was removed.
     /// Arm or disarm the custom-register access validator and the
     /// last-writer table. Disarming drops the report: it describes a
     /// window that is over.
@@ -2956,6 +2953,9 @@ impl Bus {
         }
     }
 
+    /// Replace the debugger-window custom-register watch set (word
+    /// offsets into $DFF000). A pending unpolled hit is dropped, so a
+    /// stale hit cannot fire after its watch was removed.
     pub fn set_ui_reg_watches(&mut self, offsets: &[u16]) {
         self.ui_reg_watches = offsets.to_vec();
         self.ui_reg_hit = None;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -994,6 +994,24 @@ pub struct Bus {
     /// PC rests there.
     #[serde(skip)]
     ui_copper_last_pc: u32,
+    /// Start PC of the instruction the CPU is currently executing,
+    /// republished here once per instruction by the CPU wrapper so the
+    /// chipset paths can attribute an access to the code that made it.
+    /// Transient: re-stamped on the next instruction after any restore.
+    #[serde(skip)]
+    pub(crate) cpu_pc: u32,
+    /// The custom-register access validator's report, present only while
+    /// the validator is armed (`[debug] validate_chipset`). Transient
+    /// diagnostic state; a restore starts a fresh report rather than
+    /// resurrecting findings from an abandoned timeline.
+    #[serde(skip)]
+    regcheck: Option<Box<crate::regcheck::RegCheck>>,
+    /// Last value written to each custom register and who wrote it,
+    /// indexed by word offset / 2. Armed alongside the validator; this is
+    /// the "what set BPLCON3, and from where?" question that otherwise
+    /// costs a bisect.
+    #[serde(skip)]
+    reg_writers: Option<Box<[Option<RegWrite>; 256]>>,
     blitter_slowdown_cpu_misses: u8,
     /// Pending INTREQ.BLIT raise, in colour clocks. Real Agnus raises the
     /// blitter interrupt one clock after the sequencer's BLTDONE cycle
@@ -1190,6 +1208,17 @@ fn beam_write_source_name(source: BeamWriteSource) -> &'static str {
         BeamWriteSource::CpuCopperIrq => "cpu_copper_irq",
         BeamWriteSource::Copper => "copper",
     }
+}
+
+/// The most recent write to one custom register, for the debugger's
+/// "who last touched this register?" view.
+#[derive(Clone, Copy, Debug)]
+pub struct RegWrite {
+    pub value: u16,
+    pub writer: crate::regcheck::Writer,
+    pub vpos: u16,
+    pub hpos: u16,
+    pub frame: u64,
 }
 
 /// A debugger-window custom-register watch hit: the first watched write
@@ -2452,6 +2481,9 @@ impl Bus {
             wave: None,
             ui_reg_watches: Vec::new(),
             ui_reg_hit: None,
+            cpu_pc: 0,
+            regcheck: None,
+            reg_writers: None,
             ui_beam_traps: Vec::new(),
             ui_beam_hit: None,
             ui_copper_breaks: Vec::new(),
@@ -2506,6 +2538,212 @@ impl Bus {
     /// Replace the debugger-window custom-register watch set (word
     /// offsets into $DFF000). A pending unpolled hit is dropped, so a
     /// stale hit cannot fire after its watch was removed.
+    /// Arm or disarm the custom-register access validator and the
+    /// last-writer table. Disarming drops the report: it describes a
+    /// window that is over.
+    pub fn set_chipset_validation(&mut self, on: bool) {
+        if on == self.regcheck.is_some() {
+            return;
+        }
+        if on {
+            self.regcheck = Some(Box::default());
+            self.reg_writers = Some(Box::new([None; 256]));
+        } else {
+            self.regcheck = None;
+            self.reg_writers = None;
+        }
+    }
+
+    pub fn chipset_validation_armed(&self) -> bool {
+        self.regcheck.is_some()
+    }
+
+    /// The validator's findings, most-repeated first, and how many were
+    /// dropped because the report was full.
+    pub fn chipset_findings(&self) -> (Vec<crate::regcheck::Report>, u64) {
+        match &self.regcheck {
+            Some(check) => (check.reports(), check.dropped),
+            None => (Vec::new(), 0),
+        }
+    }
+
+    pub fn clear_chipset_findings(&mut self) {
+        if let Some(check) = self.regcheck.as_mut() {
+            check.clear();
+        }
+    }
+
+    /// The last write to custom register `off`, if the last-writer table
+    /// is armed and the register has been written since.
+    pub fn custom_reg_last_write(&self, off: u16) -> Option<RegWrite> {
+        self.reg_writers.as_ref()?[usize::from((off & 0x1FE) >> 1)]
+    }
+
+    /// Note a custom-register write for the validator and the
+    /// last-writer table. Called from the single write chokepoint, and
+    /// only when armed.
+    fn note_custom_write(&mut self, off: u16, val: u16, source: BeamWriteSource) {
+        let writer = match source {
+            BeamWriteSource::Copper => crate::regcheck::Writer::Copper(self.copper.pc()),
+            BeamWriteSource::Cpu | BeamWriteSource::CpuCopperIrq => {
+                crate::regcheck::Writer::Cpu(self.cpu_pc)
+            }
+        };
+        let (vpos, hpos) = (
+            self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+            self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+        );
+        if let Some(writers) = self.reg_writers.as_mut() {
+            writers[usize::from(off >> 1)] = Some(RegWrite {
+                value: val,
+                writer,
+                vpos,
+                hpos,
+                frame: self.emulated_frames,
+            });
+        }
+        if self.regcheck.is_none() {
+            return;
+        }
+        use crate::regcheck::{Direction, Finding};
+        let mut findings: [Option<(Finding, u16)>; 3] = [None; 3];
+        let mut n = 0;
+        if matches!(crate::regcheck::direction(off), Some(Direction::ReadOnly)) {
+            findings[n] = Some((Finding::WrongDirection, 0));
+            n += 1;
+        }
+        if !self.custom_reg_present(off) {
+            findings[n] = Some((Finding::AbsentRegister, 0));
+            n += 1;
+        } else if let Some(defined) = crate::regcheck::defined_bits(off) {
+            let undefined = val & !defined;
+            if undefined != 0 {
+                findings[n] = Some((Finding::UnusedBits, undefined));
+                n += 1;
+            }
+        }
+        let _ = n;
+        for (finding, detail) in findings.into_iter().flatten() {
+            self.note_chipset_finding(finding, off, writer, val, detail, vpos, hpos);
+        }
+        self.check_dma_pointer(off, val, writer, vpos, hpos);
+    }
+
+    /// Flag a DMA pointer aimed past the chip RAM Agnus can address.
+    ///
+    /// Checked on the high half, where the intent is still visible: the
+    /// pointer setters mask the value down to `chip_dma_mask`, so by the
+    /// time the pointer is formed the excess has already become a silent
+    /// wrap -- which is exactly the bug ("it works with 2 MB chip") and
+    /// exactly why it is invisible without this.
+    fn check_dma_pointer(
+        &mut self,
+        off: u16,
+        val: u16,
+        writer: crate::regcheck::Writer,
+        vpos: u16,
+        hpos: u16,
+    ) {
+        let is_pointer_high = matches!(
+            off,
+            0x020 | 0x080 | 0x084 | 0x048 | 0x04C | 0x050 | 0x054 | 0x0A0 | 0x0B0 | 0x0C0 | 0x0D0
+        ) || (0x0E0..=0x0FF).contains(&off) && off & 3 == 0
+            || (0x120..=0x13F).contains(&off) && off & 3 == 0;
+        if !is_pointer_high {
+            return;
+        }
+        let aimed = u32::from(val) << 16;
+        if aimed & !self.chip_dma_mask == 0 {
+            return;
+        }
+        self.note_chipset_finding(
+            crate::regcheck::Finding::PointerOutsideChipRam,
+            off,
+            writer,
+            0,
+            val,
+            vpos,
+            hpos,
+        );
+    }
+
+    /// Record one validator finding and log its first occurrence.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn note_chipset_finding(
+        &mut self,
+        finding: crate::regcheck::Finding,
+        reg: u16,
+        writer: crate::regcheck::Writer,
+        value: u16,
+        detail: u16,
+        vpos: u16,
+        hpos: u16,
+    ) {
+        let Some(check) = self.regcheck.as_mut() else {
+            return;
+        };
+        if check.note(finding, reg, writer, value, detail, vpos, hpos) {
+            let report = check
+                .reports()
+                .into_iter()
+                .find(|r| r.finding == finding && r.reg == reg && r.writer == writer);
+            if let Some(report) = report {
+                log::warn!("chipset: {}", crate::regcheck::RegCheck::describe(&report));
+            }
+        }
+    }
+
+    /// Validate the *shape* of a CPU custom-register access: the things
+    /// only the CPU path can see, because the Copper can only ever issue
+    /// an aligned word write at a canonical address.
+    fn note_cpu_custom_access(&mut self, addr: u64, off: u16, size: usize, read: bool) {
+        use crate::regcheck::{Direction, Finding, Writer};
+        let reg = off & 0x1FE;
+        let writer = Writer::Cpu(self.cpu_pc);
+        let (vpos, hpos) = (
+            self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+            self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+        );
+        if size == 1 {
+            let byte = (addr & 1) as u16;
+            self.note_chipset_finding(Finding::ByteAccess, reg, writer, 0, byte, vpos, hpos);
+        } else if addr & 1 != 0 {
+            self.note_chipset_finding(Finding::OddAddress, reg, writer, 0, 0, vpos, hpos);
+        }
+        // The custom bank repeats every $200 bytes inside the $DFF000
+        // page and again across the wider chip-register window; code that
+        // lands anywhere but the canonical address is relying on the
+        // decode gaps rather than the register map.
+        if off >= 0x200 {
+            self.note_chipset_finding(Finding::MirroredAddress, reg, writer, 0, 0, vpos, hpos);
+        }
+        if read && matches!(crate::regcheck::direction(reg), Some(Direction::WriteOnly)) {
+            self.note_chipset_finding(Finding::WrongDirection, reg, writer, 0, 0, vpos, hpos);
+        }
+    }
+
+    /// Whether the fitted Agnus/Denise implements the register at `off`.
+    /// Mirrors the revision gates the write dispatch itself applies, so a
+    /// finding and a dropped write always agree.
+    fn custom_reg_present(&self, off: u16) -> bool {
+        match off {
+            // ECS Agnus: programmable sync/blank, UHRES, ECS blitter size.
+            0x05A | 0x05C | 0x05E | 0x078 | 0x1C0 | 0x1C2 | 0x1C4 | 0x1C6 | 0x1C8 | 0x1CA
+            | 0x1CC | 0x1CE | 0x1D8 | 0x1DC | 0x1DE | 0x1E0 | 0x1E2 => {
+                self.blitter_ecs_registers_enabled()
+            }
+            // ECS Denise: BPLCON3 and DIWHIGH.
+            0x106 => self.denise_ecs_registers(),
+            0x1E4 => self.denise_ecs_registers(),
+            // AGA Lisa: BPLCON4, CLXCON2, and bitplanes 7-8.
+            0x10C | 0x10E => self.denise_is_lisa(),
+            0x0F8..=0x0FF | 0x11C | 0x11E => self.aga_enabled(),
+            // AGA Alice: FMODE.
+            0x1FC => self.aga_enabled(),
+            _ => true,
+        }
+    }
+
     pub fn set_ui_reg_watches(&mut self, offsets: &[u16]) {
         self.ui_reg_watches = offsets.to_vec();
         self.ui_reg_hit = None;
@@ -5128,6 +5366,9 @@ impl Bus {
         // reading.
         self.flush_timed_devices();
         let off = (addr & 0xFFF) as u16;
+        if self.regcheck.is_some() {
+            self.note_cpu_custom_access(addr, off, size, true);
+        }
         self.poll_stats.tick_read_custom(off & 0xFFE);
         match size {
             1 => {
@@ -5234,6 +5475,9 @@ impl Bus {
         // pending IRQ is latched before an INTREQ clear).
         self.flush_timed_devices();
         let off = (addr & 0xFFF) as u16;
+        if self.regcheck.is_some() {
+            self.note_cpu_custom_access(addr, off, size, false);
+        }
         match size {
             1 => {
                 // A 68000 byte write drives the byte onto BOTH halves of

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -989,6 +989,13 @@ pub struct Bus {
     ui_mem_watch_addrs: Vec<u32>,
     #[serde(skip)]
     ui_mem_writers: Vec<UiMemWriter>,
+    /// A watched word touched by a read-side DMA channel since the
+    /// debugger last polled. Reads leave the value alone, so the
+    /// value-compare watch loop cannot see them at all; the channels
+    /// latch the access here instead and the CPU's post-step check
+    /// promotes it. Transient debug state.
+    #[serde(skip)]
+    ui_dma_hit: Option<UiMemWriter>,
     /// The Copper PC at the last breakpoint check, so arrival at an
     /// address fires once instead of on every eligible colour clock the
     /// PC rests there.
@@ -2481,6 +2488,7 @@ impl Bus {
             wave: None,
             ui_reg_watches: Vec::new(),
             ui_reg_hit: None,
+            ui_dma_hit: None,
             cpu_pc: 0,
             regcheck: None,
             reg_writers: None,
@@ -2840,6 +2848,48 @@ impl Bus {
                 );
             }
         }
+    }
+
+    /// Note a read-side DMA fetch of `len` bytes from `addr` by `source`,
+    /// latching a hit when it covers a watched word.
+    ///
+    /// Called from the per-channel fetch sites, which are the only places
+    /// that know *which* bitplane or sprite is fetching -- the chip-bus
+    /// arbiter above them sees only "a bitplane". "Which sprite fetched
+    /// this word" is the question a display bug actually poses.
+    pub(crate) fn note_dma_read(
+        &mut self,
+        source: crate::debugger::WatchSource,
+        addr: u32,
+        len: u32,
+    ) {
+        if self.ui_mem_watch_addrs.is_empty() || self.ui_dma_hit.is_some() {
+            return;
+        }
+        let start = addr & 0x00FF_FFFE;
+        let end = addr.wrapping_add(len.max(2));
+        for &watch in &self.ui_mem_watch_addrs {
+            if watch.wrapping_add(1) >= start && watch < end {
+                self.ui_dma_hit = Some(UiMemWriter {
+                    addr: watch,
+                    source,
+                    vpos: self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+                    hpos: self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+                });
+                return;
+            }
+        }
+    }
+
+    /// Whether any memory watch is armed, so the DMA fetch sites can skip
+    /// the call entirely on an unwatched machine.
+    pub(crate) fn mem_watches_armed(&self) -> bool {
+        !self.ui_mem_watch_addrs.is_empty()
+    }
+
+    /// Take the pending DMA-read watch hit, if any.
+    pub fn take_ui_dma_hit(&mut self) -> Option<UiMemWriter> {
+        self.ui_dma_hit.take()
     }
 
     fn push_ui_mem_writer(writers: &mut Vec<UiMemWriter>, writer: UiMemWriter) {

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -261,6 +261,9 @@ impl Bus {
         if self.wave_on {
             self.wave_note_reg_write(off, val, source);
         }
+        if self.reg_writers.is_some() {
+            self.note_custom_write(off, val, source);
+        }
         if is_audio_timing_custom_write(off) {
             self.flush_audio();
         }

--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -469,6 +469,9 @@ impl Bus {
                 self.record_sprite_display_enable_for_bitplane_dma(vpos);
             }
             let addr = self.display_dma_bplpt[plane] & addr_mask;
+            if self.mem_watches_armed() {
+                self.note_dma_read(crate::debugger::WatchSource::Bitplane(plane as u8), addr, 2);
+            }
             let fetched = read_chip_word_wrapping(&self.mem.chip_ram, addr);
             self.data_bus = fetched;
             if self.capture_bitplane_fetch_word(

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -202,14 +202,8 @@ impl Bus {
         let hpos = self.agnus.hpos;
         let blitter_busy = self.blitter.busy;
         let line_cck = self.agnus.current_line_cck();
-        if allow_fetch && self.mem_watches_armed() {
-            // The Copper fetches its instruction word pair from the PC it
-            // is about to advance past, so the watch sees the list itself
-            // being read -- which is how a self-modified Copper list gets
-            // caught in the act.
-            let pc = self.copper.pc();
-            self.note_dma_read(crate::debugger::WatchSource::Copper, pc, 4);
-        }
+        // The Copper's PC before the slot, for attribution below.
+        let fetch_pc = self.mem_watches_armed().then(|| self.copper.pc());
         let mut copper = std::mem::take(&mut self.copper);
         let action = copper.step_eligible_slot(
             &self.mem.chip_ram,
@@ -223,6 +217,17 @@ impl Bus {
             copper_cycle_free,
         );
         self.copper = copper;
+        // Attributed only when the Copper actually took the slot. A
+        // WAITing or stopped Copper leaves its PC pointing at the next
+        // instruction and touches nothing, so noting the read before the
+        // step reported a fetch on every eligible colour clock of the
+        // wait -- which re-latched a watch hit as fast as the debugger
+        // could clear it.
+        if let Some(pc) = fetch_pc {
+            if !matches!(action, CopperSlotAction::Idle) {
+                self.note_dma_read(crate::debugger::WatchSource::Copper, pc, 4);
+            }
+        }
         if !self.ui_copper_breaks.is_empty() {
             self.check_ui_copper_breaks();
         }

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -202,6 +202,14 @@ impl Bus {
         let hpos = self.agnus.hpos;
         let blitter_busy = self.blitter.busy;
         let line_cck = self.agnus.current_line_cck();
+        if allow_fetch && self.mem_watches_armed() {
+            // The Copper fetches its instruction word pair from the PC it
+            // is about to advance past, so the watch sees the list itself
+            // being read -- which is how a self-modified Copper list gets
+            // caught in the act.
+            let pc = self.copper.pc();
+            self.note_dma_read(crate::debugger::WatchSource::Copper, pc, 4);
+        }
         let mut copper = std::mem::take(&mut self.copper);
         let action = copper.step_eligible_slot(
             &self.mem.chip_ram,
@@ -361,6 +369,13 @@ impl Bus {
         let Some(request) = self.paula.audio_dma_request(channel) else {
             return;
         };
+        if self.mem_watches_armed() {
+            self.note_dma_read(
+                crate::debugger::WatchSource::Audio(channel as u8),
+                request.address,
+                2,
+            );
+        }
         let word = self.read_chip_word_for_audio_dma(request.address);
         self.data_bus = word;
         let irq = self.paula.grant_audio_dma(channel, word, self.agnus.dmacon);

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -788,6 +788,13 @@ impl Bus {
         }
         let quantum = sprite_fetch_quantum(self.agnus.fmode());
         let ptr = self.display_dma_sprpt[sprite] & self.chip_dma_mask & !1;
+        if self.mem_watches_armed() {
+            self.note_dma_read(
+                crate::debugger::WatchSource::Sprite(sprite as u8),
+                ptr,
+                2 * quantum,
+            );
+        }
         let mut words = [0u16; 4];
         for (w, word) in words.iter_mut().enumerate().take(quantum as usize) {
             *word = read_chip_word_wrapping(&self.mem.chip_ram, ptr.wrapping_add(2 * w as u32));
@@ -1147,6 +1154,13 @@ impl Bus {
                     for w in 0..quantum.min(words_per_row - word_base) {
                         let word_idx = word_base + w;
                         let addr = self.display_dma_bplpt[plane] & addr_mask;
+                        if self.mem_watches_armed() {
+                            self.note_dma_read(
+                                crate::debugger::WatchSource::Bitplane(plane as u8),
+                                addr,
+                                2,
+                            );
+                        }
                         let fetched = read_chip_word_wrapping(&self.mem.chip_ram, addr);
                         self.data_bus = fetched;
                         if self.capture_bitplane_fetch_word(
@@ -1202,6 +1216,13 @@ impl Bus {
                     for w in 0..quantum.min(words_per_row - word_base) {
                         let word_idx = word_base + w;
                         let addr = self.display_dma_bplpt[plane] & addr_mask;
+                        if self.mem_watches_armed() {
+                            self.note_dma_read(
+                                crate::debugger::WatchSource::Bitplane(plane as u8),
+                                addr,
+                                2,
+                            );
+                        }
                         let fetched = read_chip_word_wrapping(&self.mem.chip_ram, addr);
                         self.data_bus = fetched;
                         if self.capture_bitplane_fetch_word(

--- a/src/chipset/keyboard.rs
+++ b/src/chipset/keyboard.rs
@@ -537,17 +537,17 @@ impl KeyboardMcu {
         }
     }
 
-    /// The Amiga drove (true) or released (false) KDAT via CIA-A SPMODE.
-    /// The pulse is timed on the MCU clock from the actual drive edge,
-    /// so a handshake that begins while the byte's final bit cell is
-    /// still clocking out is credited with its full width -- the 6500/1
-    /// samples the line level, not the protocol state.
     /// Take the width of the last handshake pulse that was too short for
     /// the MCU to sample, if one has happened since the last drain.
     pub fn take_short_handshake(&mut self) -> Option<u16> {
         self.short_handshake_cck.take()
     }
 
+    /// The Amiga drove (true) or released (false) KDAT via CIA-A SPMODE.
+    /// The pulse is timed on the MCU clock from the actual drive edge,
+    /// so a handshake that begins while the byte's final bit cell is
+    /// still clocking out is credited with its full width -- the 6500/1
+    /// samples the line level, not the protocol state.
     pub fn amiga_kdat_edge(&mut self, driven_low: bool) {
         if driven_low {
             self.kdat_low_since = Some(self.now_cck);
@@ -558,10 +558,16 @@ impl KeyboardMcu {
         };
         let width = self.now_cck.saturating_sub(since);
         if width < HANDSHAKE_MIN_CCK {
-            // Too narrow for the MCU to sample. Latched for the
-            // hardware-misuse report, which is the only way software
-            // learns about it: the keyboard simply stops advancing.
-            self.short_handshake_cck = Some(width.min(u64::from(u16::MAX)) as u16);
+            // Too narrow to count as a handshake. Only worth reporting
+            // when the MCU was actually waiting for one: the floor exists
+            // to ignore incidental zero-width CRA reconfigurations, and
+            // flagging those would blame ordinary CIA setup code.
+            if matches!(
+                self.state,
+                McuState::AwaitHandshake { .. } | McuState::SyncAwaitHandshake { .. }
+            ) {
+                self.short_handshake_cck = Some(width.min(u64::from(u16::MAX)) as u16);
+            }
             return;
         }
         let accepted = match &self.state {

--- a/src/chipset/keyboard.rs
+++ b/src/chipset/keyboard.rs
@@ -263,6 +263,12 @@ pub struct KeyboardMcu {
     /// Latched request for a machine reset (KCLK held low long
     /// enough); the Bus copies it into its pending flag.
     system_reset_request: bool,
+    /// Width, in colour clocks, of the last KDAT-low pulse too narrow for
+    /// the MCU to sample as a handshake. Drained by the Bus for the
+    /// hardware-misuse report; it is not machine state, so it is not
+    /// serialized.
+    #[serde(skip)]
+    short_handshake_cck: Option<u16>,
     /// Caps Lock LED state, owned by the keyboard: the key toggles it,
     /// sending a press code on toggle-on and a release code on
     /// toggle-off; the physical key release sends nothing.
@@ -292,6 +298,7 @@ impl KeyboardMcu {
             held: [0; 2],
             now_cck: 0,
             kdat_low_since: None,
+            short_handshake_cck: None,
             system_reset_request: false,
             caps_lock_on: false,
             overflow_pending: false,
@@ -535,6 +542,12 @@ impl KeyboardMcu {
     /// so a handshake that begins while the byte's final bit cell is
     /// still clocking out is credited with its full width -- the 6500/1
     /// samples the line level, not the protocol state.
+    /// Take the width of the last handshake pulse that was too short for
+    /// the MCU to sample, if one has happened since the last drain.
+    pub fn take_short_handshake(&mut self) -> Option<u16> {
+        self.short_handshake_cck.take()
+    }
+
     pub fn amiga_kdat_edge(&mut self, driven_low: bool) {
         if driven_low {
             self.kdat_low_since = Some(self.now_cck);
@@ -543,7 +556,12 @@ impl KeyboardMcu {
         let Some(since) = self.kdat_low_since.take() else {
             return;
         };
-        if self.now_cck.saturating_sub(since) < HANDSHAKE_MIN_CCK {
+        let width = self.now_cck.saturating_sub(since);
+        if width < HANDSHAKE_MIN_CCK {
+            // Too narrow for the MCU to sample. Latched for the
+            // hardware-misuse report, which is the only way software
+            // learns about it: the keyboard simply stops advancing.
+            self.short_handshake_cck = Some(width.min(u64::from(u16::MAX)) as u16);
             return;
         }
         let accepted = match &self.state {

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,10 @@ pub struct Config {
     /// ROM probes enough empty space to make this a firehose, so it is meant
     /// to be pointed at one window (e.g. the A4000 IDE at $DD2020).
     pub log_unmapped: Option<std::ops::RangeInclusive<u32>>,
+    /// Arm the custom-register access validator and last-writer table.
+    /// Set by `[debug] validate_chipset`. Off by default: it is a
+    /// diagnostic, and an unarmed machine pays nothing for it.
+    pub validate_chipset: bool,
     /// A4000 motherboard IDE fitted (A4000 profile): the ATA task file at
     /// $DD2020, driven by Kickstart's own scsi.device. Takes its drives from
     /// `[ide]`, like Gayle's.
@@ -1285,6 +1289,7 @@ impl Default for Config {
             mem_controller: MemController::None,
             rom_scsi_device_disable: false,
             log_unmapped: None,
+            validate_chipset: false,
             ide_a4000: false,
             sdmac: false,
             akiko: false,
@@ -2234,6 +2239,13 @@ pub(crate) enum RawRtcTime {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawDebug {
+    /// Arm the custom-register access validator: report software using the
+    /// chipset in ways the hardware ignores (absent registers, undefined
+    /// bits, wrong-direction and byte accesses, DMA pointers past Agnus's
+    /// reach), each with the PC or Copper address that did it. Off by
+    /// default; it also arms the per-register last-writer table.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) validate_chipset: bool,
     /// Log CPU accesses that no device decodes. Either `all`, or an address
     /// range like `"DD0000-DE0000"` (hex, end exclusive) to watch one window.
     /// Reads report the floating bus value they returned; writes report the
@@ -2999,6 +3011,7 @@ impl TryFrom<RawConfig> for Config {
                 .as_deref()
                 .map(parse_log_unmapped)
                 .transpose()?,
+            validate_chipset: raw.debug.validate_chipset,
             mem_controller,
             video_standard,
             audio,

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,8 @@ pub struct Config {
     /// Set by `[debug] validate_chipset`. Off by default: it is a
     /// diagnostic, and an unarmed machine pays nothing for it.
     pub validate_chipset: bool,
+    /// Report self-modifying writes. Set by `[debug] detect_smc`.
+    pub detect_smc: bool,
     /// A4000 motherboard IDE fitted (A4000 profile): the ATA task file at
     /// $DD2020, driven by Kickstart's own scsi.device. Takes its drives from
     /// `[ide]`, like Gayle's.
@@ -1290,6 +1292,7 @@ impl Default for Config {
             rom_scsi_device_disable: false,
             log_unmapped: None,
             validate_chipset: false,
+            detect_smc: false,
             ide_a4000: false,
             sdmac: false,
             akiko: false,
@@ -2246,6 +2249,10 @@ pub(crate) struct RawDebug {
     /// default; it also arms the per-register last-writer table.
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) validate_chipset: bool,
+    /// Report writes that land on memory the CPU has already executed.
+    /// Off by default; costs a 1 MiB execution map while armed.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) detect_smc: bool,
     /// Log CPU accesses that no device decodes. Either `all`, or an address
     /// range like `"DD0000-DE0000"` (hex, end exclusive) to watch one window.
     /// Reads report the floating bus value they returned; writes report the
@@ -3012,6 +3019,7 @@ impl TryFrom<RawConfig> for Config {
                 .map(parse_log_unmapped)
                 .transpose()?,
             validate_chipset: raw.debug.validate_chipset,
+            detect_smc: raw.debug.detect_smc,
             mem_controller,
             video_standard,
             audio,

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1119,17 +1119,19 @@ fn parse_break_spec(p: &ParamReader) -> Result<BreakSpec, CtlError> {
             },
             ignore: p.u32_or("ignore", 0)?,
         }),
-        "watch" => {
-            Ok(BreakSpec::Watch {
-                addr: p.u32_req("addr")?,
-                source: match p.str_opt("class")? {
-                    None => None,
-                    Some(token) => Some(WatchSource::parse(&token).ok_or_else(|| {
-                        CtlError::invalid_params("class must be cpu|blitter|disk")
-                    })?),
-                },
-            })
-        }
+        "watch" => Ok(BreakSpec::Watch {
+            addr: p.u32_req("addr")?,
+            source: match p.str_opt("class")? {
+                None => None,
+                Some(token) => Some(WatchSource::parse(&token).ok_or_else(|| {
+                    CtlError::invalid_params(
+                        "class must be cpu|blitter|disk|copper, or a DMA channel \
+                         (bpl1..bpl8, spr0..spr7, aud0..aud3)",
+                    )
+                })?),
+            },
+            pc: p.u32_opt("pc")?,
+        }),
         "reg_watch" => Ok(BreakSpec::RegWatch {
             off: parse_custom_reg_param(p)?,
         }),
@@ -1946,6 +1948,7 @@ fn break_list_value(emu: &Emulator, ctx: &SessionCtx) -> Value {
         let spec = BreakSpec::Watch {
             addr: w.addr,
             source: None,
+            pc: None,
         };
         let mut entry = json!({"kind": "watch", "addr": w.addr});
         push_id(&mut entry, ctx.id_for(&spec));

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -211,6 +211,109 @@ impl FrameRect {
     }
 }
 
+/// A "wait until the picture stops changing" run target: keep running
+/// until `frames` consecutive rendered frames hash identically. This is
+/// how a script waits for a GUI to finish drawing without guessing at an
+/// emulated-seconds delay -- the guest tells you it is done by producing
+/// the same picture twice.
+///
+/// `rect` narrows the comparison to one region, which is what makes the
+/// target usable on a real Workbench screen: a blinking cursor or a
+/// clock in the title bar never lets the whole frame settle, but the
+/// dialog you are waiting for does. `max_frames` bounds the wait so a
+/// display that never settles ends the run instead of hanging the
+/// client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StableSpec {
+    pub frames: u32,
+    pub max_frames: Option<u64>,
+    pub rect: Option<FrameRect>,
+}
+
+/// What one sample of the display told the stable-frame watcher.
+pub enum StableStep {
+    /// Not settled yet, and still within budget.
+    Running,
+    /// `frames` consecutive frames hashed identically.
+    Settled(String),
+    /// The run ended without settling: out of budget, or the region
+    /// stopped fitting the frame. The string is the stop detail.
+    GaveUp(String),
+}
+
+/// Per-run state behind [`StableSpec`], shared by both server modes so
+/// the two cannot drift on what "stable" means.
+#[derive(Debug, Clone)]
+pub struct StableWatch {
+    spec: StableSpec,
+    /// Digest of the last frame sampled, and how many consecutive frames
+    /// (including it) have carried that digest.
+    last: Option<u64>,
+    run: u32,
+    /// Longest run seen, reported when the budget runs out: "it got to 3
+    /// of 8" is a much more useful failure than a bare timeout.
+    longest: u32,
+    seen: u64,
+}
+
+impl StableWatch {
+    pub fn new(spec: StableSpec) -> Self {
+        Self {
+            spec,
+            last: None,
+            run: 0,
+            longest: 0,
+            seen: 0,
+        }
+    }
+
+    /// Sample the currently rendered frame. Call exactly once per
+    /// emulated frame; the first call establishes the baseline, so a
+    /// `frames: 2` target settles on the first repeat.
+    pub fn sample(&mut self, emu: &Emulator) -> StableStep {
+        let (fb, lines, width) = render_frame(emu);
+        let digest = match self.spec.rect {
+            None => fnv1a64(&fb[..width * lines]),
+            Some(rect) => match rect.digest(&fb, width, lines) {
+                Ok(digest) => digest,
+                Err(_) => {
+                    return StableStep::GaveUp(format!(
+                        "region {}x{}+{}+{} does not fit the {width}x{lines} frame",
+                        rect.w, rect.h, rect.x, rect.y
+                    ))
+                }
+            },
+        };
+        self.note(digest)
+    }
+
+    /// Fold one frame's digest into the run, separately from rendering it
+    /// so the settle/give-up state machine is testable on its own.
+    fn note(&mut self, digest: u64) -> StableStep {
+        self.seen += 1;
+        self.run = if self.last == Some(digest) {
+            self.run + 1
+        } else {
+            1
+        };
+        self.last = Some(digest);
+        self.longest = self.longest.max(self.run);
+        if self.run >= self.spec.frames {
+            return StableStep::Settled(format!(
+                "stable for {} frame(s) after {} (digest {digest:016x})",
+                self.run, self.seen
+            ));
+        }
+        match self.spec.max_frames {
+            Some(max) if self.seen >= max => StableStep::GaveUp(format!(
+                "not stable within {max} frame(s) (longest run {} of {})",
+                self.longest, self.spec.frames
+            )),
+            _ => StableStep::Running,
+        }
+    }
+}
+
 /// Commands the drivers execute through their own boundary: run control
 /// (whose responses are deferred to the stop), input, media, state
 /// restore, and reset.
@@ -272,11 +375,13 @@ pub enum RunTarget {
     Frame(u64),
     Cck(u64),
     Seconds(f64),
+    Stable(StableSpec),
 }
 
 impl RunTarget {
     pub fn describe(&self) -> String {
         match self {
+            RunTarget::Stable(spec) => format!("{} stable frame(s)", spec.frames),
             RunTarget::Pc(pc) => format!("pc ${pc:06X}"),
             RunTarget::Beam { vpos, hpos } => format!(
                 "beam v{vpos}{}",
@@ -886,10 +991,34 @@ fn parse_run_target(p: &ParamReader) -> Result<RunTarget, CtlError> {
         }
         targets.push(RunTarget::Seconds(secs));
     }
+    if let Some(frames) = p.u32_opt("stable_frames")? {
+        if frames < 2 {
+            return Err(CtlError::invalid_params(
+                "stable_frames must be at least 2 (one frame is trivially stable)",
+            ));
+        }
+        let max_frames = p.u64_opt("max_frames")?;
+        if max_frames.is_some_and(|max| max < u64::from(frames)) {
+            return Err(CtlError::invalid_params(
+                "max_frames must not be below stable_frames",
+            ));
+        }
+        targets.push(RunTarget::Stable(StableSpec {
+            frames,
+            max_frames,
+            // The region params are optional here, unlike
+            // capture.region_digest: with none given the whole frame has
+            // to settle.
+            rect: match p.get("w").is_some() || p.get("h").is_some() {
+                true => Some(parse_frame_rect(p)?),
+                false => None,
+            },
+        }));
+    }
     match targets.len() {
         1 => Ok(targets.remove(0)),
         0 => Err(CtlError::invalid_params(
-            "run_until needs exactly one of pc, vpos[+hpos], frame, cck, seconds",
+            "run_until needs exactly one of pc, vpos[+hpos], frame, cck, seconds, stable_frames",
         )),
         _ => Err(CtlError::invalid_params(
             "run_until takes exactly one target",
@@ -2258,6 +2387,99 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, proto::INVALID_PARAMS);
+    }
+
+    /// The parsed `run_until` target, for the stable-frame parse tests.
+    fn run_target(params: Value) -> RunTarget {
+        match parse_method("run_until", &params).expect("parse should succeed") {
+            Request::Host(HostOp::Resume(ResumeVerb {
+                kind: ResumeKind::RunUntil(target),
+                ..
+            })) => target,
+            other => panic!("expected a run_until target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_until_parses_stable_frames_with_an_optional_region() {
+        assert_eq!(
+            run_target(json!({"stable_frames": 3})),
+            RunTarget::Stable(StableSpec {
+                frames: 3,
+                max_frames: None,
+                rect: None,
+            })
+        );
+        // Region params narrow what has to hold still; a partial region
+        // is a parse error from parse_frame_rect, not a silent default.
+        assert_eq!(
+            run_target(
+                json!({"stable_frames": 2, "max_frames": 600, "x": 10, "y": 20, "w": 4, "h": 4})
+            ),
+            RunTarget::Stable(StableSpec {
+                frames: 2,
+                max_frames: Some(600),
+                rect: Some(FrameRect {
+                    x: 10,
+                    y: 20,
+                    w: 4,
+                    h: 4
+                }),
+            })
+        );
+        assert!(parse_method("run_until", &json!({"stable_frames": 2, "w": 4})).is_err());
+    }
+
+    #[test]
+    fn stable_watch_needs_consecutive_repeats_and_gives_up_on_budget() {
+        let spec = StableSpec {
+            frames: 3,
+            max_frames: Some(6),
+            rect: None,
+        };
+        let mut watch = StableWatch::new(spec);
+        // A repeat that is broken before reaching the target restarts the
+        // run: "3 consecutive" must not be satisfied by 3 frames total.
+        assert!(matches!(watch.note(1), StableStep::Running));
+        assert!(matches!(watch.note(1), StableStep::Running));
+        assert!(matches!(watch.note(2), StableStep::Running));
+        assert!(matches!(watch.note(1), StableStep::Running));
+        assert!(matches!(watch.note(1), StableStep::Running));
+        // Sixth sample: the budget expires before a third repeat, and the
+        // detail reports the longest run reached rather than the current.
+        match watch.note(3) {
+            StableStep::GaveUp(detail) => {
+                assert!(detail.contains("longest run 2 of 3"), "{detail}");
+            }
+            other => panic!("expected the budget to expire, got {}", step_name(&other)),
+        }
+
+        let mut watch = StableWatch::new(StableSpec {
+            max_frames: None,
+            ..spec
+        });
+        assert!(matches!(watch.note(7), StableStep::Running));
+        assert!(matches!(watch.note(7), StableStep::Running));
+        assert!(matches!(watch.note(7), StableStep::Settled(_)));
+    }
+
+    fn step_name(step: &StableStep) -> &'static str {
+        match step {
+            StableStep::Running => "running",
+            StableStep::Settled(_) => "settled",
+            StableStep::GaveUp(_) => "gave up",
+        }
+    }
+
+    #[test]
+    fn run_until_stable_frames_rejects_degenerate_specs() {
+        // One frame is trivially stable, so it would return instantly and
+        // tell the caller nothing.
+        assert!(parse_method("run_until", &json!({"stable_frames": 1})).is_err());
+        // A budget below the target could never be met.
+        assert!(parse_method("run_until", &json!({"stable_frames": 4, "max_frames": 3})).is_err());
+        // Targets stay mutually exclusive.
+        assert!(parse_method("run_until", &json!({"stable_frames": 2, "frame": 10})).is_err());
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -70,6 +70,17 @@ pub enum CoreOp {
     CustomRead {
         off: u16,
     },
+    /// Who last wrote a custom register, from the last-writer table the
+    /// chipset validator arms.
+    CustomWriter {
+        off: u16,
+    },
+    /// Arm/disarm the chipset access validator, or read its report.
+    ChipsetValidate {
+        enabled: Option<bool>,
+        clear: bool,
+    },
+    ChipsetReport,
     CiaGet {
         b: bool,
     },
@@ -159,6 +170,8 @@ impl CoreOp {
                 | CoreOp::Disasm { .. }
                 | CoreOp::CustomDump
                 | CoreOp::CustomRead { .. }
+                | CoreOp::CustomWriter { .. }
+                | CoreOp::ChipsetReport
                 | CoreOp::CiaGet { .. }
                 | CoreOp::BeamGet
                 | CoreOp::DisplayGet
@@ -680,6 +693,14 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         "custom.read" => core(CoreOp::CustomRead {
             off: parse_custom_reg_param(&p)?,
         }),
+        "custom.writer" => core(CoreOp::CustomWriter {
+            off: parse_custom_reg_param(&p)?,
+        }),
+        "chipset.validate" => core(CoreOp::ChipsetValidate {
+            enabled: p.bool_opt("enabled")?,
+            clear: p.bool_or("clear", false)?,
+        }),
+        "chipset.report" => core(CoreOp::ChipsetReport),
         "cia.get" => core(CoreOp::CiaGet {
             b: match p.str_req("cia")?.as_str() {
                 "a" | "A" => false,
@@ -1686,6 +1707,59 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 .map_err(|e| CtlError::io(format!("saving state: {e:#}")))?;
             Ok(json!({"path": path.display().to_string()}))
         }
+        CoreOp::CustomWriter { off } => {
+            if !emu.bus().chipset_validation_armed() {
+                return Err(CtlError::invalid_state(
+                    "the last-writer table is not armed; chipset.validate {\"enabled\": true}",
+                ));
+            }
+            let name = crate::debugger::custom_reg_name(*off);
+            Ok(match emu.bus().custom_reg_last_write(*off) {
+                None => json!({"reg": name, "written": false}),
+                Some(write) => json!({
+                    "reg": name,
+                    "written": true,
+                    "value": write.value,
+                    "by": write.writer.label(),
+                    "addr": write.writer.address(),
+                    "frame": write.frame,
+                    "vpos": write.vpos,
+                    "hpos": write.hpos,
+                }),
+            })
+        }
+        CoreOp::ChipsetValidate { enabled, clear } => {
+            if let Some(on) = enabled {
+                emu.bus_mut().set_chipset_validation(*on);
+            }
+            if *clear {
+                emu.bus_mut().clear_chipset_findings();
+            }
+            Ok(json!({"armed": emu.bus().chipset_validation_armed()}))
+        }
+        CoreOp::ChipsetReport => {
+            let (reports, dropped) = emu.bus().chipset_findings();
+            let findings: Vec<Value> = reports
+                .iter()
+                .map(|r| {
+                    json!({
+                        "kind": r.finding.name(),
+                        "reg": crate::debugger::custom_reg_name(r.reg),
+                        "by": r.writer.label(),
+                        "addr": r.writer.address(),
+                        "count": r.count,
+                        "vpos": r.vpos,
+                        "hpos": r.hpos,
+                        "detail": crate::regcheck::RegCheck::describe(r),
+                    })
+                })
+                .collect();
+            Ok(json!({
+                "armed": emu.bus().chipset_validation_armed(),
+                "findings": findings,
+                "dropped": dropped,
+            }))
+        }
         CoreOp::Digest => Ok(digest_value(emu)),
         CoreOp::RegionDigest { rect } => region_digest_value(emu, *rect),
         CoreOp::Screenshot { path } => {
@@ -2415,6 +2489,112 @@ mod tests {
         let b = exec_core(&mut emu, &mut ctx, &CoreOp::Digest).unwrap();
         assert_eq!(a["digest"], b["digest"]);
         assert_eq!(a["width"], FB_WIDTH);
+    }
+
+    /// Findings of one kind from a report, for the validator tests.
+    fn findings_of(report: &Value, kind: &str) -> Vec<Value> {
+        report["findings"]
+            .as_array()
+            .expect("findings array")
+            .iter()
+            .filter(|f| f["kind"] == kind)
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn the_validator_flags_undefined_bits_and_names_the_writer() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        exec_core(
+            &mut emu,
+            &mut ctx,
+            &core("chipset.validate", json!({"enabled": true})),
+        )
+        .unwrap();
+        // BPLCON2 bit 15 has no function on any chipset revision.
+        emu.bus_mut().custom_write(0xDFF104, 2, 0x8020);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        let bits = findings_of(&report, "unused-bits");
+        assert_eq!(bits.len(), 1, "{report}");
+        assert_eq!(bits[0]["reg"], "BPLCON2");
+        assert_eq!(bits[0]["by"], "cpu");
+        assert!(
+            bits[0]["detail"]
+                .as_str()
+                .unwrap()
+                .contains("undefined bits 0x8000"),
+            "{}",
+            bits[0]["detail"]
+        );
+    }
+
+    #[test]
+    fn the_validator_flags_absent_registers_byte_access_and_stray_pointers() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        emu.bus_mut().set_chipset_validation(true);
+        // FMODE exists only on AGA Alice; the test machine is an OCS
+        // A500, so this write is decoded and then dropped.
+        emu.bus_mut().custom_write(0xDFF1FC, 2, 0x0003);
+        // A byte write to a word register: no byte lanes on the custom bus.
+        emu.bus_mut().custom_write(0xDFF181, 1, 0x0F);
+        // A bitplane pointer aimed at $00200000, far past the 512 KiB of
+        // chip RAM this machine's Agnus can address.
+        emu.bus_mut().custom_write(0xDFF0E0, 2, 0x0020);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        assert_eq!(findings_of(&report, "absent-register").len(), 1, "{report}");
+        assert_eq!(findings_of(&report, "byte-access").len(), 1, "{report}");
+        let stray = findings_of(&report, "pointer-outside-chip-ram");
+        assert_eq!(stray.len(), 1, "{report}");
+        assert_eq!(stray[0]["reg"], "BPL1PTH");
+    }
+
+    #[test]
+    fn the_validator_flags_a_write_to_a_read_only_register() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        emu.bus_mut().set_chipset_validation(true);
+        // DMACONR is the read side; DMACON is $096. Writing $002 is a
+        // write that lands nowhere.
+        emu.bus_mut().custom_write(0xDFF002, 2, 0x8200);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        let wrong = findings_of(&report, "wrong-direction");
+        assert_eq!(wrong.len(), 1, "{report}");
+        assert_eq!(wrong[0]["reg"], "DMACONR");
+    }
+
+    #[test]
+    fn an_unarmed_machine_reports_nothing_and_refuses_the_writer_query() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        emu.bus_mut().custom_write(0xDFF104, 2, 0x8020);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        assert_eq!(report["armed"], false);
+        assert!(report["findings"].as_array().unwrap().is_empty());
+        let err = exec_core(&mut emu, &mut ctx, &CoreOp::CustomWriter { off: 0x104 }).unwrap_err();
+        assert_eq!(err.code, proto::INVALID_STATE);
+    }
+
+    #[test]
+    fn the_last_writer_table_records_value_and_writer() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        emu.bus_mut().set_chipset_validation(true);
+        emu.bus_mut().custom_write(0xDFF180, 2, 0x0123);
+        let who = exec_core(
+            &mut emu,
+            &mut ctx,
+            &core("custom.writer", json!({"reg": "COLOR00"})),
+        )
+        .unwrap();
+        assert_eq!(who["written"], true);
+        assert_eq!(who["value"], 0x0123);
+        assert_eq!(who["by"], "cpu");
+        // A register nothing has written says so rather than inventing a
+        // writer.
+        let never = exec_core(&mut emu, &mut ctx, &CoreOp::CustomWriter { off: 0x1BE }).unwrap();
+        assert_eq!(never["written"], false);
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -120,6 +120,9 @@ pub enum CoreOp {
         path: PathBuf,
     },
     Digest,
+    RegionDigest {
+        rect: FrameRect,
+    },
     Screenshot {
         path: Option<PathBuf>,
     },
@@ -168,8 +171,43 @@ impl CoreOp {
                 | CoreOp::TraceStatus
                 | CoreOp::WaveformStatus
                 | CoreOp::Digest
+                | CoreOp::RegionDigest { .. }
                 | CoreOp::Screenshot { .. }
         )
+    }
+}
+
+/// A rectangle of presented pixels, in the coordinate space
+/// `capture.screenshot` writes out: origin top-left, one unit per
+/// framebuffer pixel column/row at the frame's current canvas scale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameRect {
+    pub x: usize,
+    pub y: usize,
+    pub w: usize,
+    pub h: usize,
+}
+
+impl FrameRect {
+    /// Digest the rectangle out of a rendered frame of `width` pixels per
+    /// row and `lines` rows. A rectangle that is not wholly inside the
+    /// frame is an error rather than a silent clamp: a script asserting on
+    /// a region needs to know its coordinates went stale (the frame
+    /// geometry changes with the beam standard and canvas scale).
+    fn digest(&self, fb: &[u32], width: usize, lines: usize) -> Result<u64, CtlError> {
+        let (right, bottom) = (self.x + self.w, self.y + self.h);
+        if right > width || bottom > lines {
+            return Err(CtlError::invalid_params(format!(
+                "region {}x{}+{}+{} is outside the {width}x{lines} frame",
+                self.w, self.h, self.x, self.y
+            )));
+        }
+        let mut hash = FNV1A64_OFFSET;
+        for row in self.y..bottom {
+            let start = row * width;
+            hash = fnv1a64_from(hash, &fb[start + self.x..start + right]);
+        }
+        Ok(hash)
     }
 }
 
@@ -713,6 +751,9 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             path: p.str_opt("path")?.map(PathBuf::from),
         }),
         "capture.digest" => core(CoreOp::Digest),
+        "capture.region_digest" => core(CoreOp::RegionDigest {
+            rect: parse_frame_rect(&p)?,
+        }),
         "machine.reset" => host(HostOp::Reset {
             warm: match p.str_opt("kind")?.as_deref() {
                 None | Some("warm") => true,
@@ -797,6 +838,27 @@ fn parse_collect(p: &ParamReader) -> Result<Vec<CoreOp>, CtlError> {
         }
     }
     Ok(ops)
+}
+
+/// Parse the `x`/`y`/`w`/`h` params of a frame region. The rectangle is
+/// bounds-checked against the live frame at digest time, not here: the
+/// geometry is not known until the frame is rendered.
+fn parse_frame_rect(p: &ParamReader) -> Result<FrameRect, CtlError> {
+    let rect = FrameRect {
+        x: p.usize_or("x", 0)?,
+        y: p.usize_or("y", 0)?,
+        w: p.usize_req("w")?,
+        h: p.usize_req("h")?,
+    };
+    if rect.w == 0 || rect.h == 0 {
+        return Err(CtlError::invalid_params("w and h must be non-zero"));
+    }
+    if rect.x.checked_add(rect.w).is_none() || rect.y.checked_add(rect.h).is_none() {
+        return Err(CtlError::invalid_params(
+            "region overflows the address space",
+        ));
+    }
+    Ok(rect)
 }
 
 fn parse_run_target(p: &ParamReader) -> Result<RunTarget, CtlError> {
@@ -1424,6 +1486,7 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             Ok(json!({"path": path.display().to_string()}))
         }
         CoreOp::Digest => Ok(digest_value(emu)),
+        CoreOp::RegionDigest { rect } => region_digest_value(emu, *rect),
         CoreOp::Screenshot { path } => {
             let (fb, lines, width) = render_frame(emu);
             let path = path
@@ -1726,10 +1789,17 @@ fn render_frame(emu: &Emulator) -> (Vec<u32>, usize, usize) {
     (fb, lines, width)
 }
 
+const FNV1A64_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+
 /// FNV-1a over the framebuffer words (little-endian byte order), for
 /// cheap change detection without pulling pixels over the wire.
 fn fnv1a64(words: &[u32]) -> u64 {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    fnv1a64_from(FNV1A64_OFFSET, words)
+}
+
+/// Continue an FNV-1a digest over another run of words, so a region
+/// digest can chain its rows without materialising a copy.
+fn fnv1a64_from(mut hash: u64, words: &[u32]) -> u64 {
     for word in words {
         for byte in word.to_le_bytes() {
             hash ^= u64::from(byte);
@@ -1751,6 +1821,27 @@ pub(crate) fn digest_value(emu: &Emulator) -> Value {
         "height": lines,
         "frame": emu.bus().emulated_frames(),
     })
+}
+
+/// Digest one rectangle of the presented frame, so a script can assert on
+/// a single widget ("is this button highlighted?") without the whole
+/// frame's unrelated motion changing the answer. `width`/`height` in the
+/// reply are the frame's, not the region's, so a caller whose coordinates
+/// have gone stale can see the geometry that rejected them.
+pub(crate) fn region_digest_value(emu: &Emulator, rect: FrameRect) -> Result<Value, CtlError> {
+    let (fb, lines, width) = render_frame(emu);
+    let digest = rect.digest(&fb, width, lines)?;
+    Ok(json!({
+        "algo": "fnv1a64",
+        "digest": format!("{digest:016x}"),
+        "x": rect.x,
+        "y": rect.y,
+        "w": rect.w,
+        "h": rect.h,
+        "width": width,
+        "height": lines,
+        "frame": emu.bus().emulated_frames(),
+    }))
 }
 
 #[cfg(test)]
@@ -1832,9 +1923,10 @@ mod tests {
         let params = json!({"collect": [
             {"method": "regs.get"},
             {"method": "mem.read", "params": {"addr": 0, "len": 8}},
+            {"method": "capture.region_digest", "params": {"w": 8, "h": 8}},
         ]});
         match parse_method("continue", &params).unwrap() {
-            Request::Host(HostOp::Resume(verb)) => assert_eq!(verb.collect.len(), 2),
+            Request::Host(HostOp::Resume(verb)) => assert_eq!(verb.collect.len(), 3),
             other => panic!("expected resume, got {other:?}"),
         }
         let bad = json!({"collect": [
@@ -2122,6 +2214,67 @@ mod tests {
         let b = exec_core(&mut emu, &mut ctx, &CoreOp::Digest).unwrap();
         assert_eq!(a["digest"], b["digest"]);
         assert_eq!(a["width"], FB_WIDTH);
+    }
+
+    #[test]
+    fn region_digest_covers_only_its_rectangle() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        let rect = FrameRect {
+            x: 4,
+            y: 8,
+            w: 16,
+            h: 4,
+        };
+        let a = exec_core(&mut emu, &mut ctx, &CoreOp::RegionDigest { rect }).unwrap();
+        let b = exec_core(&mut emu, &mut ctx, &CoreOp::RegionDigest { rect }).unwrap();
+        assert_eq!(a["digest"], b["digest"]);
+        assert_eq!(a["x"], 4);
+        assert_eq!(a["w"], 16);
+        // The reply reports the frame geometry, not the region's, so a
+        // caller can tell why stale coordinates were rejected.
+        assert_eq!(a["width"], FB_WIDTH);
+        // A different rectangle of the same frame is a different digest
+        // (the test ROM's display is not uniform across these rows).
+        let whole = exec_core(&mut emu, &mut ctx, &CoreOp::Digest).unwrap();
+        assert_ne!(a["digest"], whole["digest"]);
+    }
+
+    #[test]
+    fn region_digest_rejects_a_rectangle_off_the_frame() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        let err = exec_core(
+            &mut emu,
+            &mut ctx,
+            &CoreOp::RegionDigest {
+                rect: FrameRect {
+                    x: 0,
+                    y: 0,
+                    w: FB_WIDTH + 1,
+                    h: 1,
+                },
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.code, proto::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn region_digest_parses_defaults_and_rejects_empty_rectangles() {
+        assert_eq!(
+            core("capture.region_digest", json!({"w": 8, "h": 4})),
+            CoreOp::RegionDigest {
+                rect: FrameRect {
+                    x: 0,
+                    y: 0,
+                    w: 8,
+                    h: 4
+                }
+            }
+        );
+        assert!(parse_method("capture.region_digest", &json!({"w": 0, "h": 4})).is_err());
+        assert!(parse_method("capture.region_digest", &json!({"h": 4})).is_err());
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -87,6 +87,17 @@ pub enum CoreOp {
         clear: bool,
     },
     SmcReport,
+    /// Arm a bus fault over an address window, list the armed ones, or
+    /// clear them.
+    FaultInject {
+        addr: u32,
+        len: u32,
+        on_read: bool,
+        on_write: bool,
+        count: Option<u32>,
+    },
+    FaultList,
+    FaultClear,
     CiaGet {
         b: bool,
     },
@@ -179,6 +190,7 @@ impl CoreOp {
                 | CoreOp::CustomWriter { .. }
                 | CoreOp::ChipsetReport
                 | CoreOp::SmcReport
+                | CoreOp::FaultList
                 | CoreOp::CiaGet { .. }
                 | CoreOp::BeamGet
                 | CoreOp::DisplayGet
@@ -713,6 +725,31 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             clear: p.bool_or("clear", false)?,
         }),
         "smc.report" => core(CoreOp::SmcReport),
+        "fault.inject" => {
+            let (on_read, on_write) = match p.str_opt("on")?.as_deref() {
+                None | Some("both") => (true, true),
+                Some("read") => (true, false),
+                Some("write") => (false, true),
+                Some(other) => {
+                    return Err(CtlError::invalid_params(format!(
+                        "on must be read|write|both, got {other}"
+                    )))
+                }
+            };
+            let len = p.u32_or("len", 2)?;
+            if len == 0 {
+                return Err(CtlError::invalid_params("len must be non-zero"));
+            }
+            core(CoreOp::FaultInject {
+                addr: p.u32_req("addr")?,
+                len,
+                on_read,
+                on_write,
+                count: p.u32_opt("count")?,
+            })
+        }
+        "fault.list" => core(CoreOp::FaultList),
+        "fault.clear" => core(CoreOp::FaultClear),
         "cia.get" => core(CoreOp::CiaGet {
             b: match p.str_req("cia")?.as_str() {
                 "a" | "A" => false,
@@ -1802,6 +1839,50 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 "writes": writes,
                 "dropped": dropped,
             }))
+        }
+        CoreOp::FaultInject {
+            addr,
+            len,
+            on_read,
+            on_write,
+            count,
+        } => {
+            let id = emu.bus_mut().inject_bus_fault(crate::bus::FaultInjection {
+                start: *addr,
+                end: addr.wrapping_add(len - 1),
+                on_read: *on_read,
+                on_write: *on_write,
+                remaining: *count,
+                hits: 0,
+            });
+            Ok(json!({"id": id}))
+        }
+        CoreOp::FaultList => {
+            let faults: Vec<Value> = emu
+                .bus()
+                .injected_bus_faults()
+                .iter()
+                .enumerate()
+                .map(|(id, f)| {
+                    json!({
+                        "id": id,
+                        "start": f.start,
+                        "end": f.end,
+                        "on": match (f.on_read, f.on_write) {
+                            (true, true) => "both",
+                            (true, false) => "read",
+                            _ => "write",
+                        },
+                        "remaining": f.remaining,
+                        "hits": f.hits,
+                    })
+                })
+                .collect();
+            Ok(json!({"faults": faults}))
+        }
+        CoreOp::FaultClear => {
+            emu.bus_mut().clear_injected_bus_faults();
+            Ok(json!({"faults": 0}))
         }
         CoreOp::Digest => Ok(digest_value(emu)),
         CoreOp::RegionDigest { rect } => region_digest_value(emu, *rect),

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -774,14 +774,14 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         }
         "memory.heatmap" => {
             let enabled = p.bool_or("enabled", true)?;
+            // Parsed outside the `then`, and whether or not the call is
+            // arming: inside a closure the error had nowhere to go and
+            // was being swallowed into the default, which turns a
+            // client's typo into a silently wrong window.
+            let base = p.u32_or("base", 0)?;
+            let span = p.u32_or("span", crate::heatmap::DEFAULT_SPAN)?;
             core(CoreOp::HeatMapSet {
-                window: enabled.then(|| {
-                    (
-                        p.u32_or("base", 0).unwrap_or(0),
-                        p.u32_or("span", crate::heatmap::DEFAULT_SPAN)
-                            .unwrap_or(crate::heatmap::DEFAULT_SPAN),
-                    )
-                }),
+                window: enabled.then_some((base, span)),
             })
         }
         "memory.heatmap.report" => core(CoreOp::HeatMapReport {
@@ -2869,6 +2869,18 @@ mod tests {
         let kinds: Vec<&str> = census.iter().map(|c| c["by"].as_str().unwrap()).collect();
         assert!(kinds.contains(&"cpu-read"), "{report}");
         assert!(kinds.contains(&"cpu-write"), "{report}");
+    }
+
+    #[test]
+    fn heat_map_parameters_are_validated_rather_than_defaulted() {
+        assert!(parse_method("memory.heatmap", &json!({"base": "nope"})).is_err());
+        assert!(parse_method("memory.heatmap", &json!({"span": {}})).is_err());
+        // A bad value is still a bad value when the call is disarming.
+        assert!(parse_method("memory.heatmap", &json!({"enabled": false, "base": []})).is_err());
+        assert_eq!(
+            parse_method("memory.heatmap", &json!({"enabled": false})).unwrap(),
+            Request::Core(CoreOp::HeatMapSet { window: None })
+        );
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -236,7 +236,15 @@ impl FrameRect {
     /// a region needs to know its coordinates went stale (the frame
     /// geometry changes with the beam standard and canvas scale).
     fn digest(&self, fb: &[u32], width: usize, lines: usize) -> Result<u64, CtlError> {
-        let (right, bottom) = (self.x + self.w, self.y + self.h);
+        // Checked rather than plain addition: the parser range-checks
+        // what it builds, but FrameRect is public and this is the method
+        // that indexes the framebuffer.
+        let (Some(right), Some(bottom)) = (self.x.checked_add(self.w), self.y.checked_add(self.h))
+        else {
+            return Err(CtlError::invalid_params(
+                "region overflows the address space",
+            ));
+        };
         if right > width || bottom > lines {
             return Err(CtlError::invalid_params(format!(
                 "region {}x{}+{}+{} is outside the {width}x{lines} frame",
@@ -748,8 +756,16 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             if len == 0 {
                 return Err(CtlError::invalid_params("len must be non-zero"));
             }
+            let addr = p.u32_req("addr")?;
+            // A window whose end wraps would match nothing at all, so the
+            // fault would silently never fire.
+            if addr.checked_add(len - 1).is_none() {
+                return Err(CtlError::invalid_params(
+                    "addr + len overflows the address space",
+                ));
+            }
             core(CoreOp::FaultInject {
-                addr: p.u32_req("addr")?,
+                addr,
                 len,
                 on_read,
                 on_write,
@@ -3002,6 +3018,36 @@ mod tests {
         assert!(parse_method("run_until", &json!({"stable_frames": 4, "max_frames": 3})).is_err());
         // Targets stay mutually exclusive.
         assert!(parse_method("run_until", &json!({"stable_frames": 2, "frame": 10})).is_err());
+    }
+
+    #[test]
+    fn a_region_that_overflows_is_rejected_by_the_digest_itself() {
+        // FrameRect is public, so the bounds check cannot assume the JSON
+        // parser built it.
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        let err = exec_core(
+            &mut emu,
+            &mut ctx,
+            &CoreOp::RegionDigest {
+                rect: FrameRect {
+                    x: usize::MAX,
+                    y: 0,
+                    w: 8,
+                    h: 8,
+                },
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.code, proto::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn a_fault_window_that_wraps_the_address_space_is_refused() {
+        // A wrapped window matches nothing, so the injected fault would
+        // silently never fire.
+        assert!(parse_method("fault.inject", &json!({"addr": 0xFFFF_FFFFu32, "len": 2})).is_err());
+        assert!(parse_method("fault.inject", &json!({"addr": 0xFFFF_FFFEu32, "len": 2})).is_ok());
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -2723,6 +2723,43 @@ mod tests {
     }
 
     #[test]
+    fn the_validator_flags_a_blit_that_cannot_run() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        emu.bus_mut().set_chipset_validation(true);
+        // BLTSIZE with blitter DMA off: the blit never runs and never
+        // raises its completion interrupt, which is a hang, not a glitch.
+        emu.bus_mut().custom_write(0xDFF058, 2, 0x0041);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        let dead = findings_of(&report, "blitter-dma-off");
+        assert_eq!(dead.len(), 1, "{report}");
+        assert_eq!(dead[0]["reg"], "BLTSIZE");
+        assert!(
+            dead[0]["detail"]
+                .as_str()
+                .unwrap()
+                .contains("never run or raise its completion interrupt"),
+            "{}",
+            dead[0]["detail"]
+        );
+    }
+
+    #[test]
+    fn the_validator_flags_disk_dma_armed_against_an_empty_drive() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        emu.bus_mut().set_chipset_validation(true);
+        // The test machine has no disk in df0, so arming a read waits on
+        // DSKBLK forever -- the class that produced the Gods and Shadow
+        // of the Beast dead-spins.
+        emu.bus_mut().custom_write(0xDFF024, 2, 0x8000 | 0x1000);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        let stuck = findings_of(&report, "disk-not-ready");
+        assert_eq!(stuck.len(), 1, "{report}");
+        assert_eq!(stuck[0]["reg"], "DSKLEN");
+    }
+
+    #[test]
     fn region_digest_covers_only_its_rectangle() {
         let mut emu = test_emulator();
         let mut ctx = SessionCtx::new();

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -98,6 +98,13 @@ pub enum CoreOp {
     },
     FaultList,
     FaultClear,
+    /// Arm/disarm the memory heat map over a window, or read it.
+    HeatMapSet {
+        window: Option<(u32, u32)>,
+    },
+    HeatMapReport {
+        path: Option<PathBuf>,
+    },
     CiaGet {
         b: bool,
     },
@@ -191,6 +198,7 @@ impl CoreOp {
                 | CoreOp::ChipsetReport
                 | CoreOp::SmcReport
                 | CoreOp::FaultList
+                | CoreOp::HeatMapReport { .. }
                 | CoreOp::CiaGet { .. }
                 | CoreOp::BeamGet
                 | CoreOp::DisplayGet
@@ -748,6 +756,21 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 count: p.u32_opt("count")?,
             })
         }
+        "memory.heatmap" => {
+            let enabled = p.bool_or("enabled", true)?;
+            core(CoreOp::HeatMapSet {
+                window: enabled.then(|| {
+                    (
+                        p.u32_or("base", 0).unwrap_or(0),
+                        p.u32_or("span", crate::heatmap::DEFAULT_SPAN)
+                            .unwrap_or(crate::heatmap::DEFAULT_SPAN),
+                    )
+                }),
+            })
+        }
+        "memory.heatmap.report" => core(CoreOp::HeatMapReport {
+            path: p.str_opt("path")?.map(PathBuf::from),
+        }),
         "fault.list" => core(CoreOp::FaultList),
         "fault.clear" => core(CoreOp::FaultClear),
         "cia.get" => core(CoreOp::CiaGet {
@@ -1884,6 +1907,53 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             emu.bus_mut().clear_injected_bus_faults();
             Ok(json!({"faults": 0}))
         }
+        CoreOp::HeatMapSet { window } => {
+            emu.bus_mut().set_heat_map(*window);
+            Ok(match emu.bus().heat_map() {
+                None => json!({"armed": false}),
+                Some(map) => json!({
+                    "armed": true,
+                    "base": map.base(),
+                    "span": map.span(),
+                    "bytes_per_cell": map.bytes_per_cell(),
+                    "grid": crate::heatmap::GRID,
+                }),
+            })
+        }
+        CoreOp::HeatMapReport { path } => {
+            let frame = emu.bus().emulated_frames();
+            let Some(map) = emu.bus().heat_map() else {
+                return Err(CtlError::invalid_state(
+                    "the heat map is not armed; memory.heatmap {\"enabled\": true}",
+                ));
+            };
+            let census: Vec<Value> = map
+                .census(frame)
+                .into_iter()
+                .map(|(by, cells)| json!({"by": by.name(), "cells": cells}))
+                .collect();
+            let mut reply = json!({
+                "base": map.base(),
+                "span": map.span(),
+                "bytes_per_cell": map.bytes_per_cell(),
+                "grid": crate::heatmap::GRID,
+                "frame": frame,
+                "census": census,
+            });
+            if let Some(path) = path {
+                let mut image = vec![0u32; crate::heatmap::CELLS];
+                map.render(frame, &mut image);
+                crate::screenshot::save(
+                    path,
+                    &image,
+                    crate::heatmap::GRID as u32,
+                    crate::heatmap::GRID as u32,
+                )
+                .map_err(|e| CtlError::io(format!("writing heat map: {e:#}")))?;
+                reply["path"] = json!(path.display().to_string());
+            }
+            Ok(reply)
+        }
         CoreOp::Digest => Ok(digest_value(emu)),
         CoreOp::RegionDigest { rect } => region_digest_value(emu, *rect),
         CoreOp::Screenshot { path } => {
@@ -2757,6 +2827,39 @@ mod tests {
         let stuck = findings_of(&report, "disk-not-ready");
         assert_eq!(stuck.len(), 1, "{report}");
         assert_eq!(stuck[0]["reg"], "DSKLEN");
+    }
+
+    #[test]
+    fn the_heat_map_records_what_touched_the_address_space() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        let armed = exec_core(
+            &mut emu,
+            &mut ctx,
+            &core("memory.heatmap", json!({"enabled": true})),
+        )
+        .unwrap();
+        assert_eq!(armed["armed"], true);
+        assert_eq!(armed["bytes_per_cell"], 256);
+        // The test ROM loops and stores to chip RAM, so after a few
+        // instructions the map has both CPU reads (the fetches) and a
+        // CPU write.
+        for _ in 0..8 {
+            emu.debug_step_instructions(1).unwrap();
+        }
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::HeatMapReport { path: None }).unwrap();
+        let census = report["census"].as_array().unwrap();
+        let kinds: Vec<&str> = census.iter().map(|c| c["by"].as_str().unwrap()).collect();
+        assert!(kinds.contains(&"cpu-read"), "{report}");
+        assert!(kinds.contains(&"cpu-write"), "{report}");
+    }
+
+    #[test]
+    fn an_unarmed_heat_map_refuses_to_report() {
+        let mut emu = test_emulator();
+        let mut ctx = SessionCtx::new();
+        let err = exec_core(&mut emu, &mut ctx, &CoreOp::HeatMapReport { path: None }).unwrap_err();
+        assert_eq!(err.code, proto::INVALID_STATE);
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1158,16 +1158,17 @@ fn parse_run_target(p: &ParamReader) -> Result<RunTarget, CtlError> {
                 "max_frames must not be below stable_frames",
             ));
         }
+        // The region is optional here, unlike capture.region_digest: with
+        // no region param at all the whole frame has to settle. But any
+        // of them means a region was intended, so an incomplete one is an
+        // error rather than a silent fall back to whole-frame -- `x` and
+        // `y` without `w`/`h` would otherwise be quietly ignored and the
+        // caller would wait on the wrong thing.
+        let region_named = ["x", "y", "w", "h"].iter().any(|k| p.get(k).is_some());
         targets.push(RunTarget::Stable(StableSpec {
             frames,
             max_frames,
-            // The region params are optional here, unlike
-            // capture.region_digest: with none given the whole frame has
-            // to settle.
-            rect: match p.get("w").is_some() || p.get("h").is_some() {
-                true => Some(parse_frame_rect(p)?),
-                false => None,
-            },
+            rect: region_named.then(|| parse_frame_rect(p)).transpose()?,
         }));
     }
     match targets.len() {
@@ -2944,7 +2945,11 @@ mod tests {
                 }),
             })
         );
+        // A partial region is an error, not a quiet whole-frame wait:
+        // that includes an origin with no size.
         assert!(parse_method("run_until", &json!({"stable_frames": 2, "w": 4})).is_err());
+        assert!(parse_method("run_until", &json!({"stable_frames": 2, "x": 10, "y": 20})).is_err());
+        assert!(parse_method("run_until", &json!({"stable_frames": 2, "h": 4})).is_err());
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -282,6 +282,19 @@ pub fn mouse_to(
                 inject(emu, InputAction::MouseMove { port, dx, dy });
                 emu.step_frame()
                     .map_err(|e| CtlError::internal(format!("stepping the mouse servo: {e:#}")))?;
+                // step_frame reports Ok even when it ended early on a
+                // breakpoint or watch, so without this the servo would
+                // keep stepping and swallow the stop entirely. The stop
+                // stays pending for the normal path to surface.
+                if emu.machine.ui_debug_stop_pending() {
+                    return Err(CtlError::invalid_state(format!(
+                        "a debugger stop interrupted the pointer servo after {} frame(s); \
+                         the pointer is short of ({}, {})",
+                        servo.frames(),
+                        target.0,
+                        target.1,
+                    )));
+                }
             }
             ServoStep::Arrived { x, y, frames } => {
                 return Ok(json!({

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -1221,9 +1221,8 @@ fn parse_break_spec(p: &ParamReader) -> Result<BreakSpec, CtlError> {
             },
             ignore: p.u32_or("ignore", 0)?,
         }),
-        "watch" => Ok(BreakSpec::Watch {
-            addr: p.u32_req("addr")?,
-            source: match p.str_opt("class")? {
+        "watch" => {
+            let source = match p.str_opt("class")? {
                 None => None,
                 Some(token) => Some(WatchSource::parse(&token).ok_or_else(|| {
                     CtlError::invalid_params(
@@ -1231,9 +1230,23 @@ fn parse_break_spec(p: &ParamReader) -> Result<BreakSpec, CtlError> {
                          (bpl1..bpl8, spr0..spr7, aud0..aud3)",
                     )
                 })?),
-            },
-            pc: p.u32_opt("pc")?,
-        }),
+            };
+            let pc = p.u32_opt("pc")?;
+            // Only the CPU has an instruction behind an access, so this
+            // pair describes something that cannot happen; accepting it
+            // would install a watch that never fires.
+            if pc.is_some() && source.is_some_and(|s| !s.takes_pc_qualifier()) {
+                return Err(CtlError::invalid_params(
+                    "pc only qualifies cpu accesses; a DMA engine's access has no \
+                     instruction behind it",
+                ));
+            }
+            Ok(BreakSpec::Watch {
+                addr: p.u32_req("addr")?,
+                source,
+                pc,
+            })
+        }
         "reg_watch" => Ok(BreakSpec::RegWatch {
             off: parse_custom_reg_param(p)?,
         }),
@@ -3043,6 +3056,27 @@ mod tests {
         assert!(parse_method("run_until", &json!({"stable_frames": 4, "max_frames": 3})).is_err());
         // Targets stay mutually exclusive.
         assert!(parse_method("run_until", &json!({"stable_frames": 2, "frame": 10})).is_err());
+    }
+
+    #[test]
+    fn a_pc_qualified_watch_on_a_dma_class_is_refused() {
+        // The pair can never match, so accepting it would install a
+        // watch that silently never fires.
+        for class in ["blitter", "disk", "copper", "spr3", "bpl1", "aud0"] {
+            let bad = json!({"kind": "watch", "addr": 0x1000, "class": class, "pc": 0x2000});
+            assert!(
+                parse_method("break.add", &bad).is_err(),
+                "{class} + pc should be refused"
+            );
+        }
+        // The useful combination, and each qualifier alone, still parse.
+        for good in [
+            json!({"kind": "watch", "addr": 0x1000, "class": "cpu", "pc": 0x2000}),
+            json!({"kind": "watch", "addr": 0x1000, "pc": 0x2000}),
+            json!({"kind": "watch", "addr": 0x1000, "class": "spr3"}),
+        ] {
+            assert!(parse_method("break.add", &good).is_ok(), "{good}");
+        }
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -782,7 +782,12 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 len,
                 on_read,
                 on_write,
-                count: p.u32_opt("count")?,
+                count: match p.u32_opt("count")? {
+                    // A zero-shot injection is armed and inert; saying so
+                    // beats installing something that never fires.
+                    Some(0) => return Err(CtlError::invalid_params("count must be at least 1")),
+                    other => other,
+                },
             })
         }
         "memory.heatmap" => {
@@ -903,8 +908,8 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         })),
         "input.mouse_to" => host(HostOp::MouseTo {
             port: parse_port_param(&p, 1)?,
-            x: p.i32_req("x")?,
-            y: p.i32_req("y")?,
+            x: parse_pointer_target(&p, "x")?,
+            y: parse_pointer_target(&p, "y")?,
             tolerance: p
                 .i32_or("tolerance", crate::pointer::DEFAULT_TOLERANCE)?
                 .clamp(0, crate::pointer::TOLERANCE_LIMIT),
@@ -1127,6 +1132,24 @@ fn parse_collect(p: &ParamReader) -> Result<Vec<CoreOp>, CtlError> {
         }
     }
     Ok(ops)
+}
+
+/// Largest pointer target accepted, in presented pixels. The canvas is
+/// at most 1432 wide and 626 tall; this leaves generous room around that
+/// while keeping the servo's error arithmetic away from i32's edges,
+/// where `target - at` would overflow and `abs()` of i32::MIN stays
+/// negative -- which would satisfy the arrival test at a wild position.
+const POINTER_TARGET_LIMIT: i32 = 1 << 16;
+
+/// Parse one axis of a pointer target.
+fn parse_pointer_target(p: &ParamReader, key: &str) -> Result<i32, CtlError> {
+    let value = p.i32_req(key)?;
+    if !(-POINTER_TARGET_LIMIT..=POINTER_TARGET_LIMIT).contains(&value) {
+        return Err(CtlError::invalid_params(format!(
+            "{key} must be within +/-{POINTER_TARGET_LIMIT} presented pixels"
+        )));
+    }
+    Ok(value)
 }
 
 /// Parse the `x`/`y`/`w`/`h` params of a frame region. The rectangle is
@@ -1861,7 +1884,10 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 .map(|r| {
                     json!({
                         "kind": r.finding.name(),
-                        "reg": crate::debugger::custom_reg_name(r.reg),
+                        // The keyboard handshake is not a register access,
+                        // so it does not name one; everything else does.
+                        "reg": (r.finding != crate::regcheck::Finding::KeyboardHandshakeShort)
+                            .then(|| crate::debugger::custom_reg_name(r.reg)),
                         "by": r.writer.label(),
                         "addr": r.writer.address(),
                         "count": r.count,
@@ -2741,6 +2767,16 @@ mod tests {
     }
 
     #[test]
+    fn a_write_above_the_register_bank_does_not_panic_the_validator() {
+        let mut emu = test_emulator();
+        emu.bus_mut().set_chipset_validation(true);
+        // $DFF200 upward is inside the custom page but past the register
+        // bank; a guest can write there and the validator must survive it.
+        emu.bus_mut().custom_write(0xDFF200, 2, 0x1234);
+        emu.bus_mut().custom_write(0xDFFFFE, 2, 0x1234);
+    }
+
+    #[test]
     fn the_validator_flags_undefined_bits_and_names_the_writer() {
         let mut emu = test_emulator();
         let mut ctx = SessionCtx::new();
@@ -2862,14 +2898,27 @@ mod tests {
         let mut emu = test_emulator();
         let mut ctx = SessionCtx::new();
         emu.bus_mut().set_chipset_validation(true);
-        // The test machine has no disk in df0, so arming a read waits on
-        // DSKBLK forever -- the class that produced the Gods and Shadow
-        // of the Beast dead-spins.
+        // The test machine has no disk in df0, so a read armed here can
+        // never be served -- the class that produced the Gods and Shadow
+        // of the Beast dead-spins. Written twice, because that is Paula's
+        // arming interlock and the first write only latches the value.
+        emu.bus_mut().custom_write(0xDFF024, 2, 0x8000 | 0x1000);
         emu.bus_mut().custom_write(0xDFF024, 2, 0x8000 | 0x1000);
         let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
         let stuck = findings_of(&report, "disk-not-ready");
         assert_eq!(stuck.len(), 1, "{report}");
         assert_eq!(stuck[0]["reg"], "DSKLEN");
+
+        // A single write arms nothing, so it is not reported: saying so
+        // would name a write after which DMA is by design not running.
+        let mut emu = test_emulator();
+        emu.bus_mut().set_chipset_validation(true);
+        emu.bus_mut().custom_write(0xDFF024, 2, 0x8000 | 0x1000);
+        let report = exec_core(&mut emu, &mut ctx, &CoreOp::ChipsetReport).unwrap();
+        assert!(
+            findings_of(&report, "disk-not-ready").is_empty(),
+            "{report}"
+        );
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -81,6 +81,12 @@ pub enum CoreOp {
         clear: bool,
     },
     ChipsetReport,
+    /// Arm/disarm the self-modifying-code detector, or read its report.
+    SmcDetect {
+        enabled: Option<bool>,
+        clear: bool,
+    },
+    SmcReport,
     CiaGet {
         b: bool,
     },
@@ -172,6 +178,7 @@ impl CoreOp {
                 | CoreOp::CustomRead { .. }
                 | CoreOp::CustomWriter { .. }
                 | CoreOp::ChipsetReport
+                | CoreOp::SmcReport
                 | CoreOp::CiaGet { .. }
                 | CoreOp::BeamGet
                 | CoreOp::DisplayGet
@@ -701,6 +708,11 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             clear: p.bool_or("clear", false)?,
         }),
         "chipset.report" => core(CoreOp::ChipsetReport),
+        "smc.detect" => core(CoreOp::SmcDetect {
+            enabled: p.bool_opt("enabled")?,
+            clear: p.bool_or("clear", false)?,
+        }),
+        "smc.report" => core(CoreOp::SmcReport),
         "cia.get" => core(CoreOp::CiaGet {
             b: match p.str_req("cia")?.as_str() {
                 "a" | "A" => false,
@@ -1759,6 +1771,35 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             Ok(json!({
                 "armed": emu.bus().chipset_validation_armed(),
                 "findings": findings,
+                "dropped": dropped,
+            }))
+        }
+        CoreOp::SmcDetect { enabled, clear } => {
+            if let Some(on) = enabled {
+                emu.bus_mut().set_smc_detection(*on);
+            }
+            if *clear {
+                emu.bus_mut().clear_smc_reports();
+            }
+            Ok(json!({"armed": emu.bus().smc_detection_armed()}))
+        }
+        CoreOp::SmcReport => {
+            let (reports, dropped) = emu.bus().smc_reports();
+            let writes: Vec<Value> = reports
+                .iter()
+                .map(|r| {
+                    json!({
+                        "addr": r.addr,
+                        "writer_pc": r.writer_pc,
+                        "distance": r.distance,
+                        "count": r.count,
+                        "detail": crate::smc::SmcTracker::describe(r),
+                    })
+                })
+                .collect();
+            Ok(json!({
+                "armed": emu.bus().smc_detection_armed(),
+                "writes": writes,
                 "dropped": dropped,
             }))
         }

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -14,6 +14,7 @@ use super::session::{BreakSpec, InputAction, SessionCtx};
 use crate::debugger::{BreakCond, CondOp, CondOperand, DebugStop, WatchSource};
 use crate::emulator::Emulator;
 use crate::inputsched::JoyState;
+use crate::pointer::{PointerServo, ServoStep};
 use crate::timetravel::ReverseOutcome;
 use crate::video::{FB_WIDTH, MAX_CANVAS_PIXELS};
 use serde_json::{json, Map, Value};
@@ -211,6 +212,46 @@ impl FrameRect {
     }
 }
 
+/// Move the guest's pointer to an absolute presented-pixel position by
+/// servoing relative mouse deltas until sprite 0 lands there; see
+/// [`crate::pointer`] for why absolute positioning has to be closed-loop.
+///
+/// `inject` hands each delta to the caller's own input path, so the motion
+/// is journaled for reverse debugging and input recording exactly like a
+/// human's would be.
+pub fn mouse_to(
+    emu: &mut Emulator,
+    port: u8,
+    target: (i32, i32),
+    tolerance: i32,
+    max_frames: u32,
+    mut inject: impl FnMut(&mut Emulator, InputAction),
+) -> Result<Value, CtlError> {
+    let mut servo = PointerServo::new(port, target, tolerance, max_frames);
+    loop {
+        match servo.poll(emu.bus()) {
+            ServoStep::Move { port, dx, dy } => {
+                inject(emu, InputAction::MouseMove { port, dx, dy });
+                emu.step_frame()
+                    .map_err(|e| CtlError::internal(format!("stepping the mouse servo: {e:#}")))?;
+            }
+            ServoStep::Arrived { x, y, frames } => {
+                return Ok(json!({
+                    "x": x,
+                    "y": y,
+                    "target_x": target.0,
+                    "target_y": target.1,
+                    "port": u32::from(port) + 1,
+                    "frames": frames,
+                }))
+            }
+            // Not converging is an error, not an "ok, but": a script that
+            // carried on would click somewhere it did not intend to.
+            ServoStep::Failed(why) => return Err(CtlError::invalid_state(why)),
+        }
+    }
+}
+
 /// A "wait until the picture stops changing" run target: keep running
 /// until `frames` consecutive rendered frames hash identically. This is
 /// how a script waits for a GUI to finish drawing without guessing at an
@@ -346,6 +387,16 @@ pub enum HostOp {
     },
     Reset {
         warm: bool,
+    },
+    /// Servo the guest pointer to an absolute presented-pixel position;
+    /// see [`mouse_to`]. A host op because it both injects input and runs
+    /// the machine, so each driver applies it through its own boundary.
+    MouseTo {
+        port: u8,
+        x: i32,
+        y: i32,
+        tolerance: i32,
+        max_frames: u32,
     },
 }
 
@@ -728,6 +779,17 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             dx: p.i32_or("dx", 0)?,
             dy: p.i32_or("dy", 0)?,
         })),
+        "input.mouse_to" => host(HostOp::MouseTo {
+            port: parse_port_param(&p, 1)?,
+            x: p.i32_req("x")?,
+            y: p.i32_req("y")?,
+            tolerance: p
+                .i32_or("tolerance", crate::pointer::DEFAULT_TOLERANCE)?
+                .clamp(0, crate::pointer::TOLERANCE_LIMIT),
+            max_frames: p
+                .u32_or("max_frames", crate::pointer::DEFAULT_MAX_FRAMES)?
+                .clamp(1, crate::pointer::FRAME_LIMIT),
+        }),
         "input.joy" => host(HostOp::Input(InputCmd::Joy {
             port: parse_port_param(&p, 2)?,
             state: JoyState {
@@ -1253,6 +1315,16 @@ impl<'a> ParamReader<'a> {
     fn i32_or(&self, key: &str, default: i32) -> Result<i32, CtlError> {
         match self.get(key) {
             None | Some(Value::Null) => Ok(default),
+            Some(v) => v
+                .as_i64()
+                .and_then(|n| i32::try_from(n).ok())
+                .ok_or_else(|| CtlError::invalid_params(format!("bad {key}"))),
+        }
+    }
+
+    fn i32_req(&self, key: &str) -> Result<i32, CtlError> {
+        match self.get(key) {
+            None | Some(Value::Null) => Err(CtlError::invalid_params(format!("missing {key}"))),
             Some(v) => v
                 .as_i64()
                 .and_then(|n| i32::try_from(n).ok())

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -14,7 +14,8 @@
 //! lands -- which is inherently wall-clock, like a GDB Ctrl-C.
 
 use super::exec::{
-    self, HostOp, Request, ResumeKind, ResumeVerb, RunTarget, CCK_FINE_WINDOW, RUN_BUDGET,
+    self, HostOp, Request, ResumeKind, ResumeVerb, RunTarget, StableStep, StableWatch,
+    CCK_FINE_WINDOW, RUN_BUDGET,
 };
 use super::proto::{self, AuthGate, CtlError, Gate, MAX_LINE_BYTES};
 use super::session::SessionCtx;
@@ -603,6 +604,10 @@ impl Session {
             }
             _ => None,
         };
+        let mut stable = match target {
+            Some(RunTarget::Stable(spec)) => Some(StableWatch::new(spec)),
+            _ => None,
+        };
         let mut extra_ids = Vec::new();
         let finish = |reason: &str, detail: String, extra_ids: Vec<Value>, kill: bool| {
             Ok(RunOutcome::Stop {
@@ -629,6 +634,19 @@ impl Session {
             if let Some(cck) = cck_target {
                 if self.emu.bus().emulated_cck() >= cck {
                     return finish("target", format!("cck {cck}"), extra_ids, false);
+                }
+            }
+            // Sampled before the quantum, so the frame already on screen
+            // when the client asked is the baseline for "unchanged".
+            if let Some(watch) = stable.as_mut() {
+                match watch.sample(&self.emu) {
+                    StableStep::Running => {}
+                    StableStep::Settled(detail) => {
+                        return finish("target", detail, extra_ids, false)
+                    }
+                    StableStep::GaveUp(detail) => {
+                        return finish("budget", detail, extra_ids, false)
+                    }
                 }
             }
 
@@ -1072,6 +1090,29 @@ mod tests {
             let a = c.result("capture.digest", json!({}));
             let b = c.result("capture.digest", json!({}));
             assert_eq!(a["digest"], b["digest"]);
+        });
+    }
+
+    #[test]
+    fn run_until_stable_frames_settles_and_respects_its_budget() {
+        run_session(None, |c| {
+            c.auth();
+            // The test ROM drives no display DMA, so the picture is
+            // already still and the second sample confirms it.
+            let stop = c.result("run_until", json!({"stable_frames": 2}));
+            assert_eq!(stop["reason"], "target");
+            assert!(
+                stop["detail"].as_str().unwrap().contains("stable for 2"),
+                "{}",
+                stop["detail"]
+            );
+            // A region of that same still frame settles too, and the
+            // stop lands without advancing to any wall-clock deadline.
+            let stop = c.result(
+                "run_until",
+                json!({"stable_frames": 2, "max_frames": 600, "x": 8, "y": 8, "w": 32, "h": 32}),
+            );
+            assert_eq!(stop["reason"], "target");
         });
     }
 

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -360,6 +360,31 @@ impl Session {
                 ))?;
                 Ok(None)
             }
+            HostOp::MouseTo {
+                port,
+                x,
+                y,
+                tolerance,
+                max_frames,
+            } => {
+                let ctx = &mut self.ctx;
+                let reply = match exec::mouse_to(
+                    &mut self.emu,
+                    port,
+                    (x, y),
+                    tolerance,
+                    max_frames,
+                    |emu, action| {
+                        ctx.inject_now(emu, action);
+                    },
+                ) {
+                    Ok(value) => proto::ok_line(&id, value),
+                    Err(e) => proto::err_line(&id, &e),
+                };
+                self.write(&reply)?;
+                self.emit_events()?;
+                Ok(None)
+            }
             HostOp::FloppyInsert {
                 drive,
                 path,
@@ -821,6 +846,15 @@ impl Session {
                         &CtlError::invalid_state("pause before loading a state"),
                     ))?;
                 }
+                Request::Host(HostOp::MouseTo { .. }) => {
+                    // The servo advances the machine frame by frame to
+                    // watch what its own deltas did, so it cannot share
+                    // the timeline with an in-flight resume.
+                    self.write(&proto::err_line(
+                        &req.id,
+                        &CtlError::invalid_state("pause before servoing the pointer"),
+                    ))?;
+                }
                 Request::Host(
                     op @ (HostOp::FloppyInsert { .. }
                     | HostOp::FloppyEject { .. }
@@ -1090,6 +1124,37 @@ mod tests {
             let a = c.result("capture.digest", json!({}));
             let b = c.result("capture.digest", json!({}));
             assert_eq!(a["digest"], b["digest"]);
+        });
+    }
+
+    #[test]
+    fn mouse_to_reports_a_guest_with_no_sprite_pointer() {
+        run_session(None, |c| {
+            c.auth();
+            // The test ROM draws no sprites, so there is no pointer to
+            // observe. That must be a loud, specific failure rather than
+            // a blind guess at relative motion.
+            let refused = c.call("input.mouse_to", json!({"x": 200, "y": 100}));
+            assert_eq!(refused["error"]["code"], proto::INVALID_STATE);
+            assert!(
+                refused["error"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("sprite 0 is not being drawn"),
+                "{}",
+                refused["error"]["message"]
+            );
+        });
+    }
+
+    #[test]
+    fn mouse_to_is_refused_while_a_resume_is_in_flight() {
+        run_session(None, |c| {
+            c.auth();
+            c.send("continue", json!({}));
+            let refused = c.call("input.mouse_to", json!({"x": 10, "y": 10}));
+            assert_eq!(refused["error"]["code"], proto::INVALID_STATE);
+            c.result("pause", json!({}));
         });
     }
 

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -1076,6 +1076,23 @@ mod tests {
     }
 
     #[test]
+    fn region_digest_reports_its_rectangle_and_rejects_stale_coordinates() {
+        run_session(None, |c| {
+            c.auth();
+            let region = c.result(
+                "capture.region_digest",
+                json!({"x": 8, "y": 16, "w": 32, "h": 8}),
+            );
+            assert_eq!(region["w"], 32);
+            assert_eq!(region["width"], 716);
+            // Coordinates that outran the frame must fail loudly rather
+            // than silently digesting a clamped rectangle.
+            let stale = c.call("capture.region_digest", json!({"x": 700, "w": 64, "h": 8}));
+            assert_eq!(stale["error"]["code"], proto::INVALID_PARAMS);
+        });
+    }
+
+    #[test]
     fn frame_events_stream_before_the_resume_response() {
         run_session(None, |c| {
             c.auth();

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -26,6 +26,8 @@ pub enum BreakSpec {
     Watch {
         addr: u32,
         source: Option<WatchSource>,
+        /// Stop only when this instruction made the access.
+        pc: Option<u32>,
     },
     RegWatch {
         off: u16,
@@ -290,9 +292,10 @@ fn normalize_spec(emu: &Emulator, spec: BreakSpec) -> BreakSpec {
             cond,
             ignore,
         },
-        BreakSpec::Watch { addr, source } => BreakSpec::Watch {
+        BreakSpec::Watch { addr, source, pc } => BreakSpec::Watch {
             addr: addr & addr_mask & !1,
             source,
+            pc: pc.map(|pc| pc & addr_mask),
         },
         BreakSpec::Copper { addr } => BreakSpec::Copper {
             addr: addr & 0x00FF_FFFE,
@@ -327,7 +330,9 @@ fn toggle_spec(emu: &mut Emulator, spec: &BreakSpec) -> bool {
         BreakSpec::Pc { addr, cond, ignore } => {
             emu.machine.ui_set_breakpoint(*addr, *cond, *ignore)
         }
-        BreakSpec::Watch { addr, source } => emu.machine.ui_toggle_watch_filtered(*addr, *source),
+        BreakSpec::Watch { addr, source, pc } => {
+            emu.machine.ui_toggle_watch_qualified(*addr, *source, *pc)
+        }
         BreakSpec::RegWatch { off } => emu.machine.ui_toggle_reg_watch(*off),
         BreakSpec::Beam { vpos, hpos } => emu.bus_mut().ui_toggle_beam_trap(*vpos, *hpos),
         BreakSpec::Copper { addr } => emu.bus_mut().ui_toggle_copper_break(*addr),
@@ -349,11 +354,12 @@ pub fn describe_spec(spec: &BreakSpec) -> String {
             }
             s
         }
-        BreakSpec::Watch { addr, source } => format!(
-            "memory watch at ${addr:06X}{}",
+        BreakSpec::Watch { addr, source, pc } => format!(
+            "memory watch at ${addr:06X}{}{}",
             source
-                .map(|f| format!(" ({} writes)", f.label()))
-                .unwrap_or_default()
+                .map(|f| format!(" ({} accesses)", f.describe()))
+                .unwrap_or_default(),
+            pc.map(|pc| format!(" from ${pc:06X}")).unwrap_or_default()
         ),
         BreakSpec::RegWatch { off } => format!(
             "register watch {} (${off:03X})",
@@ -638,6 +644,7 @@ mod tests {
             BreakSpec::Watch {
                 addr: 0x3_0001,
                 source: None,
+                pc: None,
             },
         )
         .unwrap();
@@ -646,6 +653,7 @@ mod tests {
             BreakSpec::Watch {
                 addr: 0x3_0000,
                 source: None,
+                pc: None,
             },
         );
         assert!(dup.is_err());

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -295,7 +295,9 @@ fn normalize_spec(emu: &Emulator, spec: BreakSpec) -> BreakSpec {
         BreakSpec::Watch { addr, source, pc } => BreakSpec::Watch {
             addr: addr & addr_mask & !1,
             source,
-            pc: pc.map(|pc| pc & addr_mask),
+            // Instruction addresses are even; an odd one could never
+            // equal a writer PC, so the watch would never fire.
+            pc: pc.map(|pc| pc & addr_mask & !1),
         },
         BreakSpec::Copper { addr } => BreakSpec::Copper {
             addr: addr & 0x00FF_FFFE,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2650,6 +2650,12 @@ impl CpuBus {
 
     fn read_sized(&mut self, address: u32, size: usize, kind: CpuBusAccessKind) -> u32 {
         let addr = self.mask(address);
+        if self.bus.heat_map_armed() {
+            // Instruction fetches count as reads: seeing where the CPU is
+            // executing is half of what the map is for.
+            self.bus
+                .note_heat(addr, size as u32, crate::heatmap::Toucher::CpuRead);
+        }
         if self.icache.is_some() || self.dcache.is_some() {
             // 68020/030 cache models: a hit costs no bus cycle at all; a
             // miss goes through the normal (billed) path and then fills
@@ -2998,6 +3004,10 @@ impl CpuBus {
         self.note_cpu_data_bus(addr, size, value);
         if self.bus.smc.is_some() {
             self.note_self_modifying_write(addr, size as u32);
+        }
+        if self.bus.heat_map_armed() {
+            self.bus
+                .note_heat(addr, size as u32, crate::heatmap::Toucher::CpuWrite);
         }
         if let Some(dcache) = self.dcache.as_deref_mut() {
             // Write-through with invalidate-on-hit: the write itself goes

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1972,6 +1972,7 @@ impl M68kMachine {
                     None
                 };
                 self.bus.diag_current_pc = dbg_pc_before;
+                self.bus.bus.cpu_pc = dbg_pc_before;
                 // The no-op handler declines every trap, so the CPU takes the
                 // real exception -- the plain step() would surface traps as
                 // StepResults instead of raising them.

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -237,6 +237,12 @@ struct MachineRuntimeState {
     cpu_clock_carry: u32,
 }
 
+/// Longest 68000-family instruction worth attributing to one PC when
+/// marking executed code: opcode plus full extension words. A larger
+/// jump between instruction boundaries is a branch or an exception, not
+/// a straight-line advance, so only the opcode word is marked.
+const MAX_INSTRUCTION_BYTES: u32 = 12;
+
 struct CpuBus {
     bus: Bus,
     address_mask: u32,
@@ -2027,6 +2033,22 @@ impl M68kMachine {
                     .step_with_hle_handler(&mut self.bus, &mut m68k::NoOpHleHandler)
                 {
                     StepResult::Ok { cycles } => {
+                        if self.bus.bus.smc.is_some() {
+                            // Mark the instruction just retired as code.
+                            // Its own span is the honest answer: the
+                            // prefetch queue also reads a word past the
+                            // stream, which the CPU may never execute.
+                            let after = self.cpu.pc & self.cpu.address_mask;
+                            let span = after.wrapping_sub(dbg_pc_before);
+                            let len = if span > 0 && span <= MAX_INSTRUCTION_BYTES {
+                                span
+                            } else {
+                                2
+                            };
+                            if let Some(smc) = self.bus.bus.smc.as_mut() {
+                                smc.mark_executed(dbg_pc_before, len);
+                            }
+                        }
                         if self.bus.icache.is_some() || self.bus.dcache.is_some() {
                             self.apply_cacr_updates();
                         }
@@ -2592,6 +2614,17 @@ impl CpuBus {
         };
     }
 
+    /// Report a CPU write that lands on memory already fetched as code.
+    fn note_self_modifying_write(&mut self, addr: u32, len: u32) {
+        let pc = self.diag_current_pc;
+        let Some(smc) = self.bus.smc.as_mut() else {
+            return;
+        };
+        if let Some(report) = smc.note_write(addr, len, pc) {
+            log::warn!("smc: {}", crate::smc::SmcTracker::describe(&report));
+        }
+    }
+
     fn read_sized(&mut self, address: u32, size: usize, kind: CpuBusAccessKind) -> u32 {
         let addr = self.mask(address);
         if self.icache.is_some() || self.dcache.is_some() {
@@ -2940,6 +2973,9 @@ impl CpuBus {
     fn write_sized(&mut self, address: u32, size: usize, value: u32) {
         let addr = self.mask(address);
         self.note_cpu_data_bus(addr, size, value);
+        if self.bus.smc.is_some() {
+            self.note_self_modifying_write(addr, size as u32);
+        }
         if let Some(dcache) = self.dcache.as_deref_mut() {
             // Write-through with invalidate-on-hit: the write itself goes
             // to memory below; later reads refill. (The instruction cache

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1647,9 +1647,23 @@ impl M68kMachine {
         addr: u32,
         filter: Option<crate::debugger::WatchSource>,
     ) -> bool {
+        self.ui_toggle_watch_qualified(addr, filter, None)
+    }
+
+    /// A watch further qualified by the instruction that made the
+    /// access: with `pc` set it stops only when that PC was executing.
+    /// Watching a word a dozen routines poke is otherwise a matter of
+    /// stopping repeatedly until the interesting caller comes round.
+    pub fn ui_toggle_watch_qualified(
+        &mut self,
+        addr: u32,
+        filter: Option<crate::debugger::WatchSource>,
+        pc: Option<u32>,
+    ) -> bool {
         let addr = addr & self.cpu.address_mask & !1;
         let current = self.bus.bus.peek_word_any(addr);
-        let added = self.ui_breaks.toggle_watch(addr, current, filter);
+        let pc = pc.map(|pc| pc & self.cpu.address_mask);
+        let added = self.ui_breaks.toggle_watch(addr, current, filter, pc);
         let addrs: Vec<u32> = self.ui_breaks.watches.iter().map(|w| w.addr).collect();
         self.bus.bus.set_ui_mem_watches(&addrs);
         added
@@ -1841,6 +1855,31 @@ impl M68kMachine {
             return;
         }
         let writer_pc = self.cpu.ppc & self.cpu.address_mask;
+        // A read-side DMA channel touching a watched word leaves the
+        // value alone, so the compare loop below can never see it; the
+        // channels latch the access on the bus and it is promoted here.
+        if let Some(hit) = self.bus.bus.take_ui_dma_hit() {
+            if let Some(watch) = self
+                .ui_breaks
+                .watches
+                .iter()
+                .find(|w| w.addr == hit.addr && w.pc.is_none())
+            {
+                if watch.filter.is_none_or(|f| f.accepts(hit.source)) {
+                    let value = self.bus.bus.peek_word_any(hit.addr);
+                    self.ui_stop = Some(DebugStop::Watch {
+                        addr: hit.addr,
+                        old: value,
+                        new: value,
+                        writer_pc,
+                        source: hit.source,
+                        vpos: hit.vpos,
+                        hpos: hit.hpos,
+                    });
+                    return;
+                }
+            }
+        }
         for i in 0..self.ui_breaks.watches.len() {
             let addr = self.ui_breaks.watches[i].addr;
             let new = self.bus.bus.peek_word_any(addr);
@@ -1861,8 +1900,15 @@ impl M68kMachine {
                 ),
             };
             if let Some(filter) = self.ui_breaks.watches[i].filter {
-                if filter != source {
+                if !filter.accepts(source) {
                     // Filtered out: the baseline moved on, no stop.
+                    continue;
+                }
+            }
+            if let Some(want) = self.ui_breaks.watches[i].pc {
+                // The PC qualifier only speaks for CPU writes; a DMA
+                // engine's write has no instruction behind it.
+                if !matches!(source, crate::debugger::WatchSource::Cpu) || want != writer_pc {
                     continue;
                 }
             }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1350,7 +1350,7 @@ impl M68kMachine {
         let mut bus: Bus = deserialize_component(r, "bus")?;
 
         bus.adopt_host_resources(&mut self.bus.bus);
-        bus.adopt_ui_debug_state(&self.bus.bus);
+        bus.adopt_ui_debug_state(&mut self.bus.bus);
         bus.reset_transient_video_after_state_load();
         bus.reset_transient_diagnostics_after_state_load();
         // The CPU model travels with the state (cpu_type, timing tables, and
@@ -1669,7 +1669,9 @@ impl M68kMachine {
     ) -> bool {
         let addr = addr & self.cpu.address_mask & !1;
         let current = self.bus.bus.peek_word_any(addr);
-        let pc = pc.map(|pc| pc & self.cpu.address_mask);
+        // Even, like every instruction address: an odd qualifier could
+        // never match a writer PC and the watch would never fire.
+        let pc = pc.map(|pc| pc & self.cpu.address_mask & !1);
         let added = self.ui_breaks.toggle_watch(addr, current, filter, pc);
         let addrs: Vec<u32> = self.ui_breaks.watches.iter().map(|w| w.addr).collect();
         self.bus.bus.set_ui_mem_watches(&addrs);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -11,6 +11,7 @@ use crate::memory::{
 };
 use anyhow::{anyhow, Result};
 use log::{debug, trace};
+use m68k::core::memory::{BusFault, BusFaultKind};
 use m68k::{AddressBus, CpuCore, CpuType, StepResult};
 
 pub const CIA_A_BASE: u32 = 0x00BF_E000;
@@ -2614,6 +2615,28 @@ impl CpuBus {
         };
     }
 
+    /// Consume a debugger-injected bus fault covering this access, if
+    /// one is armed. The access does not reach memory when it fires, so
+    /// the guest sees exactly what an undecoded address gives it.
+    fn check_injected_fault(
+        &mut self,
+        address: u32,
+        len: u32,
+        write: bool,
+    ) -> Result<(), BusFault> {
+        if !self.bus.bus_faults_armed() {
+            return Ok(());
+        }
+        let addr = self.mask(address);
+        if self.bus.take_injected_fault(addr, len, write) {
+            return Err(BusFault {
+                kind: BusFaultKind::BusError,
+                address: addr,
+            });
+        }
+        Ok(())
+    }
+
     /// Report a CPU write that lands on memory already fetched as code.
     fn note_self_modifying_write(&mut self, addr: u32, len: u32) {
         let pc = self.diag_current_pc;
@@ -3284,6 +3307,49 @@ impl AddressBus for CpuBus {
 
     fn instruction_fetches_were_cached(&self) -> bool {
         self.instruction_fetches_cached
+    }
+
+    fn try_read_byte(&mut self, address: u32) -> Result<u8, BusFault> {
+        self.check_injected_fault(address, 1, false)?;
+        Ok(self.read_byte(address))
+    }
+
+    fn try_read_word(&mut self, address: u32) -> Result<u16, BusFault> {
+        self.check_injected_fault(address, 2, false)?;
+        Ok(self.read_word(address))
+    }
+
+    fn try_read_long(&mut self, address: u32) -> Result<u32, BusFault> {
+        self.check_injected_fault(address, 4, false)?;
+        Ok(self.read_long(address))
+    }
+
+    fn try_write_byte(&mut self, address: u32, value: u8) -> Result<(), BusFault> {
+        self.check_injected_fault(address, 1, true)?;
+        self.write_byte(address, value);
+        Ok(())
+    }
+
+    fn try_write_word(&mut self, address: u32, value: u16) -> Result<(), BusFault> {
+        self.check_injected_fault(address, 2, true)?;
+        self.write_word(address, value);
+        Ok(())
+    }
+
+    fn try_write_long(&mut self, address: u32, value: u32) -> Result<(), BusFault> {
+        self.check_injected_fault(address, 4, true)?;
+        self.write_long(address, value);
+        Ok(())
+    }
+
+    fn try_read_immediate_word(&mut self, address: u32) -> Result<u16, BusFault> {
+        self.check_injected_fault(address, 2, false)?;
+        Ok(self.read_immediate_word(address))
+    }
+
+    fn try_read_immediate_long(&mut self, address: u32) -> Result<u32, BusFault> {
+        self.check_injected_fault(address, 4, false)?;
+        Ok(self.read_immediate_long(address))
     }
 
     fn read_byte(&mut self, address: u32) -> u8 {

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -130,10 +130,11 @@ impl WatchSource {
         }
     }
 
-    /// Parse a console filter token (case-insensitive). A bare channel
-    /// name filters to that engine whatever the channel number
-    /// (`sprite`), while a numbered form pins one (`spr3`, `bpl1`,
-    /// `aud0`).
+    /// Parse a console filter token (case-insensitive): an engine name
+    /// (`cpu`, `blitter`, `disk`, `copper`) or a numbered DMA channel
+    /// (`bpl1`-`bpl8`, `spr0`-`spr7`, `aud0`-`aud3`). A DMA filter names
+    /// exactly one channel; there is no "any bitplane" form, because the
+    /// question a display bug poses is which one.
     pub fn parse(token: &str) -> Option<Self> {
         for (name, make) in [
             ("bpl", (|n| WatchSource::Bitplane(n)) as fn(u8) -> Self),
@@ -165,16 +166,10 @@ impl WatchSource {
         None
     }
 
-    /// Whether a watch filtered on `self` accepts an access attributed to
-    /// `actual`. An engine name with no channel number matches every
-    /// channel of that engine.
+    /// Whether a watch filtered on `self` accepts an access attributed
+    /// to `actual`. A DMA filter matches its own channel only.
     pub fn accepts(self, actual: WatchSource) -> bool {
-        match (self, actual) {
-            (WatchSource::Bitplane(0xFF), WatchSource::Bitplane(_)) => true,
-            (WatchSource::Sprite(0xFF), WatchSource::Sprite(_)) => true,
-            (WatchSource::Audio(0xFF), WatchSource::Audio(_)) => true,
-            (a, b) => a == b,
-        }
+        self == actual
     }
 }
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -132,14 +132,18 @@ impl WatchSource {
 
     /// Parse a console filter token (case-insensitive): an engine name
     /// (`cpu`, `blitter`, `disk`, `copper`) or a numbered DMA channel
-    /// (`bpl1`-`bpl8`, `spr0`-`spr7`, `aud0`-`aud3`). A DMA filter names
+    /// (`bpl1`-`bpl8`, `spr0`-`spr7`, `aud0`-`aud3`, each bounded by the
+    /// channels the hardware has). A DMA filter names
     /// exactly one channel; there is no "any bitplane" form, because the
     /// question a display bug poses is which one.
     pub fn parse(token: &str) -> Option<Self> {
-        for (name, make) in [
-            ("bpl", (|n| WatchSource::Bitplane(n)) as fn(u8) -> Self),
-            ("spr", |n| WatchSource::Sprite(n)),
-            ("aud", |n| WatchSource::Audio(n)),
+        // Channel counts are the hardware's, not a shared bound: Paula
+        // has four audio channels where Denise has eight sprites, so
+        // `aud4` must not parse into a filter nothing can ever match.
+        for (name, make, channels) in [
+            ("bpl", (|n| WatchSource::Bitplane(n)) as fn(u8) -> Self, 8u8),
+            ("spr", |n| WatchSource::Sprite(n), 8),
+            ("aud", |n| WatchSource::Audio(n), 4),
         ] {
             if let Some(rest) = token
                 .to_ascii_lowercase()
@@ -150,7 +154,7 @@ impl WatchSource {
                 // BPL channels are named from 1 on the hardware; the
                 // others from 0.
                 let index = if name == "bpl" { n.checked_sub(1)? } else { n };
-                return (index < 8).then(|| make(index));
+                return (index < channels).then(|| make(index));
             }
         }
         for (name, source) in [
@@ -1477,6 +1481,10 @@ mod tests {
         assert_eq!(WatchSource::parse("bpl0"), None);
         assert_eq!(WatchSource::parse("bpl9"), None);
         assert_eq!(WatchSource::parse("spr8"), None);
+        // Paula has four audio channels, not eight: a filter naming a
+        // channel that does not exist could never match.
+        assert_eq!(WatchSource::parse("aud3"), Some(WatchSource::Audio(3)));
+        assert_eq!(WatchSource::parse("aud4"), None);
         assert_eq!(WatchSource::parse("nonsense"), None);
     }
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -78,15 +78,33 @@ pub struct UiWatch {
     pub last: u16,
     /// Only stop when the change was made by this writer; None = any.
     pub filter: Option<WatchSource>,
+    /// Only stop when the CPU was executing this instruction; None = any.
+    /// A word a dozen routines all poke is otherwise unwatchable: this is
+    /// how you ask about the one caller you care about.
+    pub pc: Option<u32>,
 }
 
-/// Who wrote a watched memory word: attributed at the write site (the
-/// CPU write path, the blitter's D/line/fill writes, disk read DMA).
+/// Who touched a watched memory word: attributed at the access site (the
+/// CPU write path, the blitter's D/line/fill writes, disk read DMA, and
+/// the read-side DMA channels that fetch through the chip bus).
+///
+/// The channel-numbered variants exist because "which bitplane fetched
+/// this word" and "which sprite" are the questions a display bug
+/// actually poses; a bare "some DMA engine" answer sends you back to the
+/// slot map to work it out by hand.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WatchSource {
     Cpu,
     Blitter,
     Disk,
+    /// Bitplane DMA fetch, plane 0-7 (BPL1DAT is plane 0).
+    Bitplane(u8),
+    /// Sprite DMA fetch, sprite 0-7.
+    Sprite(u8),
+    /// Audio sample DMA fetch, channel 0-3.
+    Audio(u8),
+    /// A Copper instruction-word fetch.
+    Copper,
 }
 
 impl WatchSource {
@@ -95,19 +113,67 @@ impl WatchSource {
             WatchSource::Cpu => "cpu",
             WatchSource::Blitter => "blitter",
             WatchSource::Disk => "disk",
+            WatchSource::Bitplane(_) => "bitplane",
+            WatchSource::Sprite(_) => "sprite",
+            WatchSource::Audio(_) => "audio",
+            WatchSource::Copper => "copper",
         }
     }
 
-    /// Parse a console filter token (case-insensitive).
+    /// The label with its channel number, as reports print it.
+    pub fn describe(self) -> String {
+        match self {
+            WatchSource::Bitplane(n) => format!("bpl{}", n + 1),
+            WatchSource::Sprite(n) => format!("spr{n}"),
+            WatchSource::Audio(n) => format!("aud{n}"),
+            other => other.label().to_string(),
+        }
+    }
+
+    /// Parse a console filter token (case-insensitive). A bare channel
+    /// name filters to that engine whatever the channel number
+    /// (`sprite`), while a numbered form pins one (`spr3`, `bpl1`,
+    /// `aud0`).
     pub fn parse(token: &str) -> Option<Self> {
-        if token.eq_ignore_ascii_case("cpu") {
-            Some(WatchSource::Cpu)
-        } else if token.eq_ignore_ascii_case("blitter") {
-            Some(WatchSource::Blitter)
-        } else if token.eq_ignore_ascii_case("disk") {
-            Some(WatchSource::Disk)
-        } else {
-            None
+        for (name, make) in [
+            ("bpl", (|n| WatchSource::Bitplane(n)) as fn(u8) -> Self),
+            ("spr", |n| WatchSource::Sprite(n)),
+            ("aud", |n| WatchSource::Audio(n)),
+        ] {
+            if let Some(rest) = token
+                .to_ascii_lowercase()
+                .strip_prefix(name)
+                .map(str::to_string)
+            {
+                let n: u8 = rest.parse().ok()?;
+                // BPL channels are named from 1 on the hardware; the
+                // others from 0.
+                let index = if name == "bpl" { n.checked_sub(1)? } else { n };
+                return (index < 8).then(|| make(index));
+            }
+        }
+        for (name, source) in [
+            ("cpu", WatchSource::Cpu),
+            ("blitter", WatchSource::Blitter),
+            ("disk", WatchSource::Disk),
+            ("copper", WatchSource::Copper),
+        ] {
+            if token.eq_ignore_ascii_case(name) {
+                return Some(source);
+            }
+        }
+        None
+    }
+
+    /// Whether a watch filtered on `self` accepts an access attributed to
+    /// `actual`. An engine name with no channel number matches every
+    /// channel of that engine.
+    pub fn accepts(self, actual: WatchSource) -> bool {
+        match (self, actual) {
+            (WatchSource::Bitplane(0xFF), WatchSource::Bitplane(_)) => true,
+            (WatchSource::Sprite(0xFF), WatchSource::Sprite(_)) => true,
+            (WatchSource::Audio(0xFF), WatchSource::Audio(_)) => true,
+            (a, b) => a == b,
         }
     }
 }
@@ -189,9 +255,16 @@ impl DebugStop {
                 WatchSource::Cpu => {
                     format!("Watch ${addr:06X}: {old:04X}->{new:04X} (pc ${writer_pc:06X})")
                 }
+                // A read-side DMA channel leaves the word alone, so an
+                // unchanged value is the tell that this was a fetch, not
+                // a write.
+                _ if old == new => format!(
+                    "Watch ${addr:06X}: {new:04X} read by {} (v{vpos} h{hpos})",
+                    source.describe()
+                ),
                 _ => format!(
                     "Watch ${addr:06X}: {old:04X}->{new:04X} ({} write, v{vpos} h{hpos})",
-                    source.label()
+                    source.describe()
                 ),
             },
             DebugStop::ChipReg {
@@ -799,8 +872,15 @@ impl InteractiveBreaks {
 
     /// Add a word watch at `addr` (recording `current` as its baseline),
     /// or remove it when already set. `filter` limits which writer stops
-    /// it (None = any). Returns true when now set.
-    pub fn toggle_watch(&mut self, addr: u32, current: u16, filter: Option<WatchSource>) -> bool {
+    /// it and `pc` limits which instruction does (None = any). Returns
+    /// true when now set.
+    pub fn toggle_watch(
+        &mut self,
+        addr: u32,
+        current: u16,
+        filter: Option<WatchSource>,
+        pc: Option<u32>,
+    ) -> bool {
         let added = match self.watches.iter().position(|w| w.addr == addr) {
             Some(pos) => {
                 self.watches.remove(pos);
@@ -811,6 +891,7 @@ impl InteractiveBreaks {
                     addr,
                     last: current,
                     filter,
+                    pc,
                 });
                 true
             }
@@ -1319,7 +1400,7 @@ mod tests {
     #[test]
     fn interactive_watches_record_baselines_and_clear() {
         let mut breaks = InteractiveBreaks::new(UI_ADDR_MASK);
-        assert!(breaks.toggle_watch(0x1000, 0xABCD, None));
+        assert!(breaks.toggle_watch(0x1000, 0xABCD, None, None));
         assert_eq!(breaks.watches[0].last, 0xABCD);
         // The register watch normalizes a full $DFFxxx address to the
         // word offset.
@@ -1386,6 +1467,49 @@ mod tests {
         assert_eq!(lines, vec!["PF1H=1 PF2H=2".to_string()]);
         // Unknown registers decode to nothing (hex is always shown).
         assert!(custom_reg_bit_decode(0x1F0, 0xFFFF).is_empty());
+    }
+
+    #[test]
+    fn watch_source_parses_engine_names_and_dma_channels() {
+        assert_eq!(WatchSource::parse("cpu"), Some(WatchSource::Cpu));
+        assert_eq!(WatchSource::parse("COPPER"), Some(WatchSource::Copper));
+        // BPL channels are named from 1 on the hardware and from 0 in the
+        // register file; the console speaks the hardware's names.
+        assert_eq!(WatchSource::parse("bpl1"), Some(WatchSource::Bitplane(0)));
+        assert_eq!(WatchSource::parse("BPL8"), Some(WatchSource::Bitplane(7)));
+        assert_eq!(WatchSource::parse("spr0"), Some(WatchSource::Sprite(0)));
+        assert_eq!(WatchSource::parse("aud3"), Some(WatchSource::Audio(3)));
+        assert_eq!(WatchSource::parse("bpl0"), None);
+        assert_eq!(WatchSource::parse("bpl9"), None);
+        assert_eq!(WatchSource::parse("spr8"), None);
+        assert_eq!(WatchSource::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn a_channel_filter_accepts_only_its_own_channel() {
+        assert!(WatchSource::Sprite(3).accepts(WatchSource::Sprite(3)));
+        assert!(!WatchSource::Sprite(3).accepts(WatchSource::Sprite(4)));
+        assert!(!WatchSource::Sprite(3).accepts(WatchSource::Bitplane(3)));
+        assert!(WatchSource::Cpu.accepts(WatchSource::Cpu));
+        assert!(!WatchSource::Cpu.accepts(WatchSource::Blitter));
+    }
+
+    #[test]
+    fn a_dma_read_stop_says_read_rather_than_inventing_a_change() {
+        // A read leaves the word alone, so old == new is the tell.
+        let stop = DebugStop::Watch {
+            addr: 0x21000,
+            old: 0xBEEF,
+            new: 0xBEEF,
+            writer_pc: 0xF80010,
+            source: WatchSource::Bitplane(2),
+            vpos: 100,
+            hpos: 40,
+        };
+        assert_eq!(
+            stop.describe(),
+            "Watch $021000: BEEF read by bpl3 (v100 h40)"
+        );
     }
 
     #[test]

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -175,6 +175,16 @@ impl WatchSource {
     pub fn accepts(self, actual: WatchSource) -> bool {
         self == actual
     }
+
+    /// Whether a PC qualifier means anything for this access class.
+    ///
+    /// Only the CPU has an instruction behind an access. A DMA engine's
+    /// fetch or write is issued by the chip bus with no PC to compare,
+    /// so pairing a PC with a channel filter describes something that
+    /// cannot happen, and the watch would simply never fire.
+    pub fn takes_pc_qualifier(self) -> bool {
+        matches!(self, WatchSource::Cpu)
+    }
 }
 
 /// Why the interactive debugger stopped the machine.
@@ -1486,6 +1496,24 @@ mod tests {
         assert_eq!(WatchSource::parse("aud3"), Some(WatchSource::Audio(3)));
         assert_eq!(WatchSource::parse("aud4"), None);
         assert_eq!(WatchSource::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn only_cpu_accesses_carry_an_instruction_to_qualify_on() {
+        assert!(WatchSource::Cpu.takes_pc_qualifier());
+        for source in [
+            WatchSource::Blitter,
+            WatchSource::Disk,
+            WatchSource::Copper,
+            WatchSource::Bitplane(0),
+            WatchSource::Sprite(3),
+            WatchSource::Audio(1),
+        ] {
+            assert!(
+                !source.takes_pc_qualifier(),
+                "{source:?} has no PC behind its accesses"
+            );
+        }
     }
 
     #[test]

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2784,6 +2784,44 @@ mod tests {
     }
 
     #[test]
+    fn armed_diagnostics_survive_a_state_restore() {
+        use crate::bus::FaultInjection;
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().set_chipset_validation(true);
+        emu.bus_mut().set_smc_detection(true);
+        emu.bus_mut()
+            .set_heat_map(Some((0, crate::heatmap::DEFAULT_SPAN)));
+        emu.bus_mut().inject_bus_fault(FaultInjection {
+            start: 0x40000,
+            end: 0x40001,
+            on_read: true,
+            on_write: true,
+            remaining: None,
+            hits: 0,
+        });
+        // Collect a finding, then round-trip the machine through a state
+        // save and load, which is the path a reverse step takes.
+        emu.bus_mut().custom_write(0xDFF104, 2, 0x8020);
+        assert_eq!(emu.bus().chipset_findings().0.len(), 1);
+        let path = std::env::temp_dir().join(format!(
+            "copperline-diag-restore-{}.clstate",
+            std::process::id()
+        ));
+        emu.save_state(&path).unwrap();
+        emu.load_state(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        // The session asked for these; a restore must not silently
+        // disarm them underneath it, and the report is still the
+        // operator's in-progress experiment.
+        assert!(emu.bus().chipset_validation_armed());
+        assert!(emu.bus().smc_detection_armed());
+        assert!(emu.bus().heat_map().is_some());
+        assert_eq!(emu.bus().injected_bus_faults().len(), 1);
+        assert_eq!(emu.bus().chipset_findings().0.len(), 1);
+    }
+
+    #[test]
     fn an_injected_bus_fault_takes_the_guest_into_its_own_handler() {
         use crate::bus::FaultInjection;
         let mut emu = emulator_with_self_modifying_program();

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2195,6 +2195,10 @@ pub fn build_machine(
         );
         bus.log_unmapped = Some(range);
     }
+    if cfg.validate_chipset {
+        info!("debug: chipset access validator armed");
+        bus.set_chipset_validation(true);
+    }
     if cfg.sdmac {
         let mut sdmac = crate::sdmac::Sdmac::new();
         let mut drives = 0;

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2877,6 +2877,83 @@ mod tests {
     }
 
     #[test]
+    fn watchpoint_catches_a_bitplane_dma_fetch_of_the_watched_word() {
+        use crate::debugger::{DebugStop, WatchSource};
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().mem.overlay = false;
+        // Watch a chip-RAM word and point bitplane 1 at it, then let a
+        // frame's display DMA run. A fetch changes nothing, so only the
+        // per-channel read attribution can see this at all.
+        assert!(emu.machine.ui_toggle_watch(0x60000));
+        {
+            let bus = emu.bus_mut();
+            bus.custom_write(0x0E0, 4, 0x0006_0000); // BPL1PT = $60000
+            bus.custom_write(0x100, 2, 0x1200); // BPLCON0: 1 plane, lores
+            bus.custom_write(0x092, 2, 0x0038); // DDFSTRT
+            bus.custom_write(0x094, 2, 0x00D0); // DDFSTOP
+            bus.custom_write(0x08E, 2, 0x2C81); // DIWSTRT
+            bus.custom_write(0x090, 2, 0xF4C1); // DIWSTOP
+            bus.custom_write(0x096, 2, 0x8300); // DMACON SET DMAEN|BPLEN
+        }
+        let mut stop = None;
+        // Display DMA only runs inside the vertical window, so give it
+        // whole frames rather than an instruction budget.
+        for _ in 0..3 {
+            emu.step_frame().unwrap();
+            if let Some(s) = emu.machine.take_ui_debug_stop() {
+                stop = Some(s);
+                break;
+            }
+        }
+        match stop {
+            Some(DebugStop::Watch {
+                source, old, new, ..
+            }) => {
+                assert_eq!(source, WatchSource::Bitplane(0));
+                assert_eq!(old, new, "a fetch must not be reported as a change");
+            }
+            other => panic!("expected a bitplane-attributed watch stop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_pc_qualified_watch_ignores_writes_from_other_instructions() {
+        use crate::debugger::WatchSource;
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().mem.overlay = false;
+        // Qualify on a PC that never executes: the blitter write below
+        // still lands, but no stop belongs to that instruction.
+        assert!(emu.machine.ui_toggle_watch_qualified(
+            0x60000,
+            Some(WatchSource::Cpu),
+            Some(0x00F8_0F00)
+        ));
+        {
+            let bus = emu.bus_mut();
+            bus.custom_write(0x096, 2, 0x8240);
+            bus.custom_write(0x040, 2, 0x01F0);
+            bus.custom_write(0x042, 2, 0x0000);
+            bus.custom_write(0x044, 2, 0xFFFF);
+            bus.custom_write(0x046, 2, 0xFFFF);
+            bus.custom_write(0x074, 2, 0xBEEF);
+            bus.custom_write(0x054, 4, 0x0006_0000);
+            bus.custom_write(0x058, 2, 0x0041);
+        }
+        for _ in 0..64 {
+            emu.debug_step_instructions(1).unwrap();
+            assert!(
+                emu.machine.take_ui_debug_stop().is_none(),
+                "a PC-qualified watch must not fire for another writer"
+            );
+        }
+        assert_eq!(
+            emu.bus().peek_word_any(0x60000),
+            0xBEEF,
+            "the blit still ran"
+        );
+    }
+
+    #[test]
     fn watchpoint_attributes_blitter_writes_and_honours_filters() {
         use crate::debugger::{DebugStop, WatchSource};
         let mut emu = emulator_with_call_program();

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2199,6 +2199,10 @@ pub fn build_machine(
         info!("debug: chipset access validator armed");
         bus.set_chipset_validation(true);
     }
+    if cfg.detect_smc {
+        info!("debug: self-modifying-code detector armed");
+        bus.set_smc_detection(true);
+    }
     if cfg.sdmac {
         let mut sdmac = crate::sdmac::Sdmac::new();
         let mut drives = 0;
@@ -2723,6 +2727,62 @@ mod tests {
     /// SSP resets to $4000 (chip RAM), so BSR/RTS push and pop the return
     /// address through real memory. The reset vectors live in chip RAM (overlay
     /// is off, so the CPU reads them from address 0 at reset).
+    /// An emulator running a self-modifying program out of chip RAM:
+    ///
+    /// ```text
+    /// 030000  NOP                        ; the word that gets patched
+    /// 030002  MOVE.W #$4E71,($30000).L
+    /// 03000A  BRA.S  *
+    /// ```
+    ///
+    /// The NOP retires before the store lands, so $30000 is known to be
+    /// code by the time it is written over.
+    fn emulator_with_self_modifying_program() -> super::Emulator {
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().mem.overlay = false;
+        let program: [u16; 6] = [
+            0x4E71, // NOP
+            0x33FC, // MOVE.W #imm,(abs).L
+            0x4E71, // immediate: NOP
+            0x0003, // destination high
+            0x0000, // destination low
+            0x60FE, // BRA.S *
+        ];
+        let bytes: Vec<u8> = program.iter().flat_map(|w| w.to_be_bytes()).collect();
+        emu.machine.debug_write_memory(0x30000, &bytes);
+        emu.machine.debug_set_register(17, 0x30000);
+        emu
+    }
+
+    #[test]
+    fn the_smc_detector_reports_a_write_over_code_and_its_prefetch_distance() {
+        let mut emu = emulator_with_self_modifying_program();
+        emu.bus_mut().set_smc_detection(true);
+        for _ in 0..4 {
+            emu.debug_step_instructions(1).unwrap();
+        }
+        let (reports, dropped) = emu.bus().smc_reports();
+        assert_eq!(dropped, 0);
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].addr, 0x30000);
+        assert_eq!(reports[0].writer_pc, 0x30002);
+        let line = crate::smc::SmcTracker::describe(&reports[0]);
+        assert!(line.contains("2 bytes behind"), "{line}");
+    }
+
+    #[test]
+    fn an_unarmed_machine_records_no_self_modifying_writes() {
+        let mut emu = emulator_with_self_modifying_program();
+        for _ in 0..4 {
+            emu.debug_step_instructions(1).unwrap();
+        }
+        assert!(emu.bus().smc_reports().0.is_empty());
+        // Arming after the fact starts from a blank execution map, so it
+        // reports only what it actually watched.
+        emu.bus_mut().set_smc_detection(true);
+        assert!(emu.bus().smc_reports().0.is_empty());
+    }
+
     fn emulator_with_call_program() -> super::Emulator {
         let mut rom = vec![0u8; crate::memory::ROM_SIZE];
         let put = |mem: &mut [u8], off: usize, word: u16| {

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2783,6 +2783,66 @@ mod tests {
         assert!(emu.bus().smc_reports().0.is_empty());
     }
 
+    #[test]
+    fn an_injected_bus_fault_takes_the_guest_into_its_own_handler() {
+        use crate::bus::FaultInjection;
+        let mut emu = emulator_with_self_modifying_program();
+        // Point the bus-error vector (2) somewhere recognisable.
+        emu.machine
+            .debug_write_memory(0x08, &0x0003_1000u32.to_be_bytes());
+        emu.machine
+            .debug_write_memory(0x31000, &0x4E71u16.to_be_bytes());
+        // One shot on the program's own store target.
+        emu.bus_mut().inject_bus_fault(FaultInjection {
+            start: 0x30000,
+            end: 0x30001,
+            on_read: false,
+            on_write: true,
+            remaining: Some(1),
+            hits: 0,
+        });
+        for _ in 0..6 {
+            emu.debug_step_instructions(1).unwrap();
+        }
+        assert_eq!(
+            emu.bus().injected_bus_faults()[0].hits,
+            1,
+            "the write should have taken the fault"
+        );
+        // The store never reached memory, so the NOP it aimed at is
+        // untouched, and the CPU is running the handler.
+        assert_eq!(emu.bus().peek_word_any(0x30000), 0x4E71);
+        assert!(
+            (0x31000..0x31010).contains(&emu.machine.pc()),
+            "expected the bus-error handler, pc = {:06X}",
+            emu.machine.pc()
+        );
+    }
+
+    #[test]
+    fn a_counted_bus_fault_stops_firing_once_it_is_spent() {
+        use crate::bus::FaultInjection;
+        let mut emu = emulator_with_call_program();
+        emu.bus_mut().mem.overlay = false;
+        emu.bus_mut().inject_bus_fault(FaultInjection {
+            start: 0x40000,
+            end: 0x40001,
+            on_read: true,
+            on_write: true,
+            remaining: Some(2),
+            hits: 0,
+        });
+        let fired: Vec<bool> = (0..4)
+            .map(|_| emu.bus_mut().take_injected_fault(0x40000, 2, false))
+            .collect();
+        assert_eq!(fired, [true, true, false, false]);
+        let fault = emu.bus().injected_bus_faults()[0];
+        assert_eq!(fault.hits, 2);
+        assert_eq!(fault.remaining, Some(0));
+        // An address outside the window is never faulted.
+        assert!(!emu.bus_mut().take_injected_fault(0x50000, 2, false));
+    }
+
     fn emulator_with_call_program() -> super::Emulator {
         let mut rom = vec![0u8; crate::memory::ROM_SIZE];
         let put = |mem: &mut [u8], off: usize, word: u16| {

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -408,16 +408,18 @@ impl FloppyController {
 
     /// Whether a disk-DMA arming right now would find a drive able to
     /// serve it: a selected drive, its motor spinning, and media in it.
-    /// Returns the reason it could not, for the hardware-misuse report.
-    pub fn dma_arming_obstacle(&self) -> Option<&'static str> {
+    /// Returns the `regcheck::DISK_*` code for what is missing, so the
+    /// wording of the report lives in one place rather than being
+    /// recovered from a string here.
+    pub fn dma_arming_obstacle(&self) -> Option<u16> {
         let Some(idx) = self.selected_drive() else {
-            return Some("no drive is selected");
+            return Some(crate::regcheck::DISK_NO_DRIVE);
         };
         if !self.drives[idx].motor_on {
-            return Some("the selected drive's motor is off");
+            return Some(crate::regcheck::DISK_MOTOR_OFF);
         }
         if self.drives[idx].cached.is_empty() {
-            return Some("the selected drive is empty");
+            return Some(crate::regcheck::DISK_EMPTY);
         }
         None
     }

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -406,6 +406,17 @@ impl FloppyController {
         bits
     }
 
+    /// Whether a DSKLEN write of `val` right now would be the one that
+    /// actually starts a transfer.
+    ///
+    /// Paula requires the value written twice in succession as a safety
+    /// interlock: the first write only latches it. Asked before the
+    /// write is dispatched, so it reads the latch the previous write
+    /// left.
+    pub fn dsklen_write_starts_dma(&self, val: u16) -> bool {
+        val & DSKLEN_DMAEN != 0 && self.dma.is_none() && self.armed_dsklen == Some(val)
+    }
+
     /// Whether a disk-DMA arming right now would find a drive able to
     /// serve it: a selected drive, its motor spinning, and media in it.
     /// Returns the `regcheck::DISK_*` code for what is missing, so the

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -406,6 +406,22 @@ impl FloppyController {
         bits
     }
 
+    /// Whether a disk-DMA arming right now would find a drive able to
+    /// serve it: a selected drive, its motor spinning, and media in it.
+    /// Returns the reason it could not, for the hardware-misuse report.
+    pub fn dma_arming_obstacle(&self) -> Option<&'static str> {
+        let Some(idx) = self.selected_drive() else {
+            return Some("no drive is selected");
+        };
+        if !self.drives[idx].motor_on {
+            return Some("the selected drive's motor is off");
+        }
+        if self.drives[idx].cached.is_empty() {
+            return Some("the selected drive is empty");
+        }
+        None
+    }
+
     pub fn activity_led_on(&self) -> bool {
         self.selected_drive()
             .is_some_and(|idx| self.drives[idx].motor_on)

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -112,6 +112,20 @@ impl Toucher {
     }
 }
 
+/// The span a requested one becomes: rounded up to a whole number of
+/// bytes per cell, and clamped so the grid stays inside a u32.
+///
+/// Public because callers deciding whether a window has changed have to
+/// compare what the request *becomes*, not what was asked for. Without
+/// that, repeating a request whose span is not a multiple of the grid
+/// looks like a different window every time and silently wipes the map.
+pub fn rounded_span(span: u32) -> u32 {
+    let cells = CELLS as u32;
+    // A span shorter than the grid would give less than one byte per
+    // cell, and the window's last addresses would index past its end.
+    span.max(cells).div_ceil(cells).clamp(1, u32::MAX / cells) * cells
+}
+
 /// The live map.
 pub struct HeatMap {
     /// First address the grid covers, and how much of the address space
@@ -131,14 +145,9 @@ impl Default for HeatMap {
 
 impl HeatMap {
     pub fn new(base: u32, span: u32) -> Self {
-        // The span is rounded up to a whole number of bytes per cell.
-        // Without that, a span like CELLS + 1 gives one byte per cell and
-        // leaves the window's last addresses indexing one past the grid.
-        let cells = CELLS as u32;
-        let per_cell = span.max(cells).div_ceil(cells).clamp(1, u32::MAX / cells);
         Self {
             base,
-            span: per_cell * cells,
+            span: rounded_span(span),
             source: Box::new([0; CELLS]),
             stamp: Box::new([0; CELLS]),
         }
@@ -258,6 +267,17 @@ mod tests {
         // The largest span the grid can describe stays inside u32.
         let wide = HeatMap::new(0, u32::MAX);
         assert_eq!(wide.bytes_per_cell(), u32::MAX / CELLS as u32);
+    }
+
+    #[test]
+    fn re_requesting_the_same_window_is_recognised_after_rounding() {
+        // A span that is not a whole number of cells becomes one; a
+        // caller repeating its own request must be seen as asking for
+        // the window it already has, or the map is wiped each time.
+        let asked = DEFAULT_SPAN + 1;
+        let map = HeatMap::new(0, asked);
+        assert_eq!(map.span(), rounded_span(asked));
+        assert_eq!(rounded_span(rounded_span(asked)), rounded_span(asked));
     }
 
     #[test]

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Memory heat map: which parts of the address space are being touched,
+//! by what, and how recently.
+//!
+//! A slot map answers "what owned the chip bus at this colour clock". It
+//! does not answer "where in memory is anything happening", which is the
+//! question you have when a display is drawn from the wrong buffer, a
+//! decruncher is writing somewhere unexpected, or a DMA channel is
+//! pointed at the wrong bank. This paints the address space instead of
+//! the beam: one cell per block of memory, coloured by what last touched
+//! it and faded by how long ago.
+//!
+//! The grid is 256x256 cells over a window of the address space, so a
+//! 16 MiB window gives one cell per 256 bytes. The window is movable, so
+//! the RAM banks a 32-bit CPU sees above the 24-bit space can be looked
+//! at too, rather than the map silently stopping at 16 MiB.
+//!
+//! Everything here is derived from bus activity: nothing knows what
+//! program is running, only which engine touched which address.
+
+use crate::debugger::WatchSource;
+
+pub const GRID: usize = 256;
+pub const CELLS: usize = GRID * GRID;
+
+/// Default window: the 24-bit space a 68000 and Agnus share, which is
+/// where chip RAM, slow RAM, the custom registers, the CIAs and the
+/// Zorro II space all live.
+pub const DEFAULT_SPAN: u32 = 0x0100_0000;
+
+/// Frames a cell takes to fade from its freshest colour to black. The
+/// eye reads a two-second tail as "recent" at 50 Hz without smearing
+/// everything together.
+pub const DECAY_FRAMES: u32 = 32;
+
+/// What last touched a cell. Kept as a small code so the grid is one
+/// byte of source plus one frame stamp per cell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Toucher {
+    None,
+    CpuRead,
+    CpuWrite,
+    Blitter,
+    Copper,
+    Disk,
+    Bitplane,
+    Sprite,
+    Audio,
+}
+
+impl Toucher {
+    /// The cell's colour at full brightness, as 0xAARRGGBB. Chosen so
+    /// the read-side display channels sit in the blues and greens, the
+    /// CPU in red/yellow, and the engines that write memory stand out.
+    pub fn colour(self) -> u32 {
+        match self {
+            Toucher::None => 0xFF00_0000,
+            Toucher::CpuRead => 0xFF80_4040,
+            Toucher::CpuWrite => 0xFFFF_4040,
+            Toucher::Blitter => 0xFFFF_A000,
+            Toucher::Copper => 0xFFFF_FF40,
+            Toucher::Disk => 0xFFFF_40FF,
+            Toucher::Bitplane => 0xFF40_A0FF,
+            Toucher::Sprite => 0xFF40_FFA0,
+            Toucher::Audio => 0xFF40_FFFF,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Toucher::None => "none",
+            Toucher::CpuRead => "cpu-read",
+            Toucher::CpuWrite => "cpu-write",
+            Toucher::Blitter => "blitter",
+            Toucher::Copper => "copper",
+            Toucher::Disk => "disk",
+            Toucher::Bitplane => "bitplane",
+            Toucher::Sprite => "sprite",
+            Toucher::Audio => "audio",
+        }
+    }
+
+    pub fn from_watch_source(source: WatchSource) -> Self {
+        match source {
+            WatchSource::Cpu => Toucher::CpuWrite,
+            WatchSource::Blitter => Toucher::Blitter,
+            WatchSource::Disk => Toucher::Disk,
+            WatchSource::Bitplane(_) => Toucher::Bitplane,
+            WatchSource::Sprite(_) => Toucher::Sprite,
+            WatchSource::Audio(_) => Toucher::Audio,
+            WatchSource::Copper => Toucher::Copper,
+        }
+    }
+
+    fn code(self) -> u8 {
+        self as u8
+    }
+
+    fn from_code(code: u8) -> Self {
+        match code {
+            1 => Toucher::CpuRead,
+            2 => Toucher::CpuWrite,
+            3 => Toucher::Blitter,
+            4 => Toucher::Copper,
+            5 => Toucher::Disk,
+            6 => Toucher::Bitplane,
+            7 => Toucher::Sprite,
+            8 => Toucher::Audio,
+            _ => Toucher::None,
+        }
+    }
+}
+
+/// The live map.
+pub struct HeatMap {
+    /// First address the grid covers, and how much of the address space
+    /// it spans. `span` is rounded up so every cell covers whole bytes.
+    base: u32,
+    span: u32,
+    source: Box<[u8; CELLS]>,
+    /// Frame each cell was last touched on.
+    stamp: Box<[u32; CELLS]>,
+}
+
+impl Default for HeatMap {
+    fn default() -> Self {
+        Self::new(0, DEFAULT_SPAN)
+    }
+}
+
+impl HeatMap {
+    pub fn new(base: u32, span: u32) -> Self {
+        Self {
+            base,
+            span: span.max(CELLS as u32),
+            source: Box::new([0; CELLS]),
+            stamp: Box::new([0; CELLS]),
+        }
+    }
+
+    pub fn base(&self) -> u32 {
+        self.base
+    }
+
+    pub fn span(&self) -> u32 {
+        self.span
+    }
+
+    /// Bytes of the address space one cell covers.
+    pub fn bytes_per_cell(&self) -> u32 {
+        self.span / CELLS as u32
+    }
+
+    /// Move the window, clearing what the old one had recorded: the cells
+    /// would otherwise carry activity from addresses they no longer name.
+    pub fn set_window(&mut self, base: u32, span: u32) {
+        *self = Self::new(base, span);
+    }
+
+    /// Record `len` bytes at `addr` touched by `by` on `frame`.
+    pub fn touch(&mut self, addr: u32, len: u32, by: Toucher, frame: u64) {
+        let Some(first) = self.cell_of(addr) else {
+            return;
+        };
+        let last = self
+            .cell_of(addr.wrapping_add(len.max(1)).wrapping_sub(1))
+            .unwrap_or(first);
+        let stamp = frame as u32;
+        // A transfer never spans more than a handful of cells; a wrapped
+        // range is recorded at its first cell rather than sweeping.
+        for cell in first..=last.max(first) {
+            self.source[cell] = by.code();
+            self.stamp[cell] = stamp;
+        }
+    }
+
+    fn cell_of(&self, addr: u32) -> Option<usize> {
+        let offset = addr.checked_sub(self.base)?;
+        if offset >= self.span {
+            return None;
+        }
+        Some((offset / self.bytes_per_cell()) as usize)
+    }
+
+    /// Paint the grid into a 256x256 ARGB image as of `frame`, fading
+    /// each cell by how long ago it was touched.
+    pub fn render(&self, frame: u64, out: &mut [u32]) {
+        let now = frame as u32;
+        for (cell, pixel) in out.iter_mut().enumerate().take(CELLS) {
+            let source = Toucher::from_code(self.source[cell]);
+            if source == Toucher::None {
+                *pixel = 0xFF00_0000;
+                continue;
+            }
+            let age = now.saturating_sub(self.stamp[cell]);
+            if age >= DECAY_FRAMES {
+                *pixel = 0xFF00_0000;
+                continue;
+            }
+            *pixel = fade(source.colour(), DECAY_FRAMES - age, DECAY_FRAMES);
+        }
+    }
+
+    /// A census of the window: how many cells each toucher currently
+    /// holds, for a caller that wants numbers rather than pixels.
+    pub fn census(&self, frame: u64) -> Vec<(Toucher, usize)> {
+        let now = frame as u32;
+        let mut counts = [0usize; 9];
+        for cell in 0..CELLS {
+            let source = Toucher::from_code(self.source[cell]);
+            if source == Toucher::None || now.saturating_sub(self.stamp[cell]) >= DECAY_FRAMES {
+                continue;
+            }
+            counts[source.code() as usize] += 1;
+        }
+        (1..9)
+            .map(|code| (Toucher::from_code(code as u8), counts[code]))
+            .filter(|(_, n)| *n > 0)
+            .collect()
+    }
+}
+
+/// Scale a colour's channels by `num`/`den`, keeping it opaque.
+fn fade(colour: u32, num: u32, den: u32) -> u32 {
+    let scale = |shift: u32| {
+        let channel = (colour >> shift) & 0xFF;
+        ((channel * num / den) & 0xFF) << shift
+    };
+    0xFF00_0000 | scale(16) | scale(8) | scale(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_touch_lands_in_the_cell_covering_its_address() {
+        let mut map = HeatMap::new(0, DEFAULT_SPAN);
+        assert_eq!(map.bytes_per_cell(), 256);
+        map.touch(0x20000, 2, Toucher::Blitter, 10);
+        let mut image = vec![0u32; CELLS];
+        map.render(10, &mut image);
+        let cell = 0x20000 / 256;
+        assert_eq!(image[cell], Toucher::Blitter.colour());
+        assert_eq!(image[cell + 1], 0xFF00_0000, "neighbours stay cold");
+    }
+
+    #[test]
+    fn a_cell_fades_to_black_over_the_decay_window() {
+        let mut map = HeatMap::new(0, DEFAULT_SPAN);
+        map.touch(0x1000, 2, Toucher::CpuWrite, 0);
+        let cell = 0x1000 / 256;
+        let mut image = vec![0u32; CELLS];
+        map.render(0, &mut image);
+        let fresh = image[cell];
+        map.render(u64::from(DECAY_FRAMES / 2), &mut image);
+        let half = image[cell];
+        assert!(half < fresh && half > 0xFF00_0000, "{half:08X}");
+        map.render(u64::from(DECAY_FRAMES), &mut image);
+        assert_eq!(image[cell], 0xFF00_0000, "a stale cell is black");
+    }
+
+    #[test]
+    fn addresses_outside_the_window_are_ignored_not_wrapped() {
+        let mut map = HeatMap::new(0, DEFAULT_SPAN);
+        // A 32-bit machine's accelerator RAM is far above the window.
+        map.touch(0x0800_0000, 4, Toucher::CpuWrite, 1);
+        assert!(map.census(1).is_empty());
+        // Move the window there and it is visible, with the old window's
+        // record cleared rather than reinterpreted.
+        map.set_window(0x0800_0000, 0x0100_0000);
+        map.touch(0x0800_0000, 4, Toucher::CpuWrite, 1);
+        assert_eq!(map.census(1), vec![(Toucher::CpuWrite, 1)]);
+    }
+
+    #[test]
+    fn a_transfer_marks_every_cell_it_spans() {
+        let mut map = HeatMap::new(0, DEFAULT_SPAN);
+        map.touch(0x1000, 1024, Toucher::Disk, 5);
+        assert_eq!(map.census(5), vec![(Toucher::Disk, 4)]);
+    }
+
+    #[test]
+    fn the_census_only_counts_cells_still_inside_the_decay_window() {
+        let mut map = HeatMap::new(0, DEFAULT_SPAN);
+        map.touch(0x1000, 2, Toucher::Copper, 0);
+        assert_eq!(map.census(0), vec![(Toucher::Copper, 1)]);
+        assert!(map.census(u64::from(DECAY_FRAMES)).is_empty());
+    }
+}

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -131,9 +131,14 @@ impl Default for HeatMap {
 
 impl HeatMap {
     pub fn new(base: u32, span: u32) -> Self {
+        // The span is rounded up to a whole number of bytes per cell.
+        // Without that, a span like CELLS + 1 gives one byte per cell and
+        // leaves the window's last addresses indexing one past the grid.
+        let cells = CELLS as u32;
+        let per_cell = span.max(cells).div_ceil(cells).clamp(1, u32::MAX / cells);
         Self {
             base,
-            span: span.max(CELLS as u32),
+            span: per_cell * cells,
             source: Box::new([0; CELLS]),
             stamp: Box::new([0; CELLS]),
         }
@@ -233,6 +238,21 @@ fn fade(colour: u32, num: u32, den: u32) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_span_that_is_not_a_whole_number_of_cells_is_rounded_up() {
+        // A span one byte past the grid size would otherwise give one
+        // byte per cell and let the window's top address index off the
+        // end of the grid.
+        let mut map = HeatMap::new(0, CELLS as u32 + 1);
+        assert_eq!(map.bytes_per_cell(), 2);
+        assert_eq!(map.span(), CELLS as u32 * 2);
+        map.touch(map.span() - 1, 1, Toucher::CpuWrite, 0);
+        assert_eq!(map.census(0), vec![(Toucher::CpuWrite, 1)]);
+        // The largest span the grid can describe stays inside u32.
+        let wide = HeatMap::new(0, u32::MAX);
+        assert_eq!(wide.bytes_per_cell(), u32::MAX / CELLS as u32);
+    }
 
     #[test]
     fn a_touch_lands_in_the_cell_covering_its_address() {

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -168,12 +168,18 @@ impl HeatMap {
         let Some(first) = self.cell_of(addr) else {
             return;
         };
-        let last = self
-            .cell_of(addr.wrapping_add(len.max(1)).wrapping_sub(1))
-            .unwrap_or(first);
+        let end = addr.wrapping_add(len.max(1)).wrapping_sub(1);
+        let last = match self.cell_of(end) {
+            Some(cell) => cell,
+            // Past the top of the window: mark what the transfer does
+            // cover rather than only its first cell, which would
+            // under-report every access near the window's edge. A
+            // transfer that wrapped the address space (end below its own
+            // start) is recorded at its first cell instead of sweeping.
+            None if end > addr => CELLS - 1,
+            None => first,
+        };
         let stamp = frame as u32;
-        // A transfer never spans more than a handful of cells; a wrapped
-        // range is recorded at its first cell rather than sweeping.
         for cell in first..=last.max(first) {
             self.source[cell] = by.code();
             self.stamp[cell] = stamp;
@@ -299,6 +305,20 @@ mod tests {
         let mut map = HeatMap::new(0, DEFAULT_SPAN);
         map.touch(0x1000, 1024, Toucher::Disk, 5);
         assert_eq!(map.census(5), vec![(Toucher::Disk, 4)]);
+    }
+
+    #[test]
+    fn a_transfer_running_past_the_window_marks_the_part_inside_it() {
+        let mut map = HeatMap::new(0, DEFAULT_SPAN);
+        let per_cell = map.bytes_per_cell();
+        // Starts two cells from the top and runs well past the end.
+        map.touch(
+            map.span() - 2 * per_cell,
+            16 * per_cell,
+            Toucher::Blitter,
+            0,
+        );
+        assert_eq!(map.census(0), vec![(Toucher::Blitter, 2)]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod pointer;
 pub mod priority;
 pub mod ramsey;
 pub mod recorder;
+pub mod regcheck;
 pub mod romsearch;
 pub mod romtags;
 pub mod rtc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod gary;
 pub mod gayle;
 pub mod gdbstub;
 pub mod harddrive;
+pub mod heatmap;
 pub mod ide_a4000;
 pub mod inputrec;
 pub mod inputsched;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod midi;
 pub mod net;
 pub mod parallel;
 pub mod paths;
+pub mod pointer;
 pub mod priority;
 pub mod ramsey;
 pub mod recorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub mod screenshot;
 pub mod scsi;
 pub mod sdmac;
 pub mod serial;
+pub mod smc;
 pub mod timebase;
 pub mod timestamp;
 pub mod timetravel;

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,13 @@ pub struct CliArgs {
     /// to 1 (carried 0-based). Emitted by the input recorder one event
     /// per frame of recorded movement.
     pub mouse_after: Vec<(f32, i32, i32, u8)>,
+    /// `--mouse-to-after SECS X Y [PORT]`: at SECS emulated seconds,
+    /// servo the guest pointer to presented-pixel (X, Y) -- the same
+    /// coordinates a screenshot is measured in -- by watching sprite 0
+    /// and correcting relative motion until it lands. PORT defaults to 1
+    /// (carried 0-based). See `src/pointer.rs` for why absolute pointer
+    /// positioning has to be closed-loop.
+    pub mouse_to_after: Vec<(f32, i32, i32, u8)>,
     /// `--pot-after SECS X Y [PORT]`: at SECS emulated seconds, set an
     /// analogue controller's stick/paddle position (each axis 0-255, the
     /// count POTxDAT latches). PORT defaults to 2 (carried 0-based).
@@ -152,13 +159,14 @@ fn parse_args() -> Result<CliArgs> {
 /// the flag names (without the leading dashes) whose effects accumulate;
 /// anything else in a script is an error so a typo cannot silently change
 /// emulator configuration.
-const SCRIPT_DIRECTIVES: [&str; 10] = [
+const SCRIPT_DIRECTIVES: [&str; 11] = [
     "press-after",
     "key-after",
     "hold-key-after",
     "click-after",
     "joy-after",
     "mouse-after",
+    "mouse-to-after",
     "pot-after",
     "insert-disk-after",
     "defer-disk-insert",
@@ -303,6 +311,7 @@ where
     let mut click_after: Vec<(f32, MouseButtonKind, u32, u8)> = Vec::new();
     let mut joy_after: Vec<(f32, JoyButtonKind, u32, u8)> = Vec::new();
     let mut mouse_after: Vec<(f32, i32, i32, u8)> = Vec::new();
+    let mut mouse_to_after: Vec<(f32, i32, i32, u8)> = Vec::new();
     let mut pot_after: Vec<(f32, u8, u8, u8)> = Vec::new();
     let mut record_input: Option<PathBuf> = None;
     let mut wave_path: Option<PathBuf> = None;
@@ -575,6 +584,15 @@ where
                     next_arg(&mut args, USAGE, "--joy-after DURATION_MS must be a number")?;
                 let port = take_port_token(&mut args, 2);
                 joy_after.push((secs, button, dur_ms, port));
+            }
+            "--mouse-to-after" => {
+                const USAGE: &str = "--mouse-to-after requires SECS X Y";
+                let secs: f32 =
+                    next_arg(&mut args, USAGE, "--mouse-to-after SECS must be a number")?;
+                let x: i32 = next_arg(&mut args, USAGE, "--mouse-to-after X must be an integer")?;
+                let y: i32 = next_arg(&mut args, USAGE, "--mouse-to-after Y must be an integer")?;
+                let port = take_port_token(&mut args, 1);
+                mouse_to_after.push((secs, x, y, port));
             }
             "--mouse-after" => {
                 const USAGE: &str = "--mouse-after requires SECS DX DY";
@@ -904,6 +922,7 @@ where
         click_after,
         joy_after,
         mouse_after,
+        mouse_to_after,
         pot_after,
         record_input,
         disk_insert_after,
@@ -1005,6 +1024,9 @@ fn print_help() {
          --mouse-after SECS DX DY [PORT]\n  \
          \x20                            apply a relative mouse motion at SECS on PORT\n  \
          \x20                            (default 1)\n  \
+         --mouse-to-after SECS X Y [PORT]\n  \
+         \x20                            from SECS, move the pointer to screen pixel\n  \
+         \x20                            (X, Y) by watching sprite 0, on PORT (default 1)\n  \
          --pot-after SECS X Y [PORT]    set an analogue controller position (0-255 per\n  \
          \x20                            axis) at SECS on PORT (default 2)\n  \
          --record-input PATH            record all machine-bound input for the whole run\n  \
@@ -1168,6 +1190,7 @@ fn validate_benchmark_args(cli: &CliArgs) -> Result<()> {
         || !cli.click_after.is_empty()
         || !cli.joy_after.is_empty()
         || !cli.mouse_after.is_empty()
+        || !cli.mouse_to_after.is_empty()
         || !cli.pot_after.is_empty()
     {
         return Err(anyhow!(
@@ -1214,6 +1237,7 @@ fn validate_gdb_args(cli: &CliArgs) -> Result<()> {
         || !cli.click_after.is_empty()
         || !cli.joy_after.is_empty()
         || !cli.mouse_after.is_empty()
+        || !cli.mouse_to_after.is_empty()
         || !cli.pot_after.is_empty()
     {
         return Err(anyhow!(
@@ -1279,6 +1303,7 @@ fn validate_control_args(cli: &CliArgs) -> Result<()> {
         || !cli.click_after.is_empty()
         || !cli.joy_after.is_empty()
         || !cli.mouse_after.is_empty()
+        || !cli.mouse_to_after.is_empty()
         || !cli.pot_after.is_empty()
     {
         return Err(anyhow!(
@@ -1646,6 +1671,7 @@ fn main() -> Result<()> {
         cli.click_after,
         cli.joy_after,
         cli.mouse_after,
+        cli.mouse_to_after,
         cli.pot_after,
         disk_insert_after,
         cli.cd_insert_after,
@@ -1760,6 +1786,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
         None,
         std::array::from_fn(|_| Vec::new()),
         [true; 4],
@@ -1802,6 +1829,7 @@ fn launcher_requested(cli: &CliArgs) -> bool {
         && cli.click_after.is_empty()
         && cli.joy_after.is_empty()
         && cli.mouse_after.is_empty()
+        && cli.mouse_to_after.is_empty()
         && cli.pot_after.is_empty()
         && cli.disk_insert_after.is_empty()
         && cli.record_input.is_none()
@@ -1979,6 +2007,18 @@ mod tests {
     fn mouse_after_parses_signed_deltas() -> Result<()> {
         let args = parse(&["--mouse-after", "1.5", "-3", "10"])?;
         assert_eq!(args.mouse_after, vec![(1.5, -3, 10, 0)]);
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_to_after_parses_absolute_targets_on_either_port() -> Result<()> {
+        let args = parse(&["--mouse-to-after", "3.0", "320", "128"])?;
+        assert_eq!(args.mouse_to_after, vec![(3.0, 320, 128, 0)]);
+        // The same directive inside a script, with the optional port.
+        let path = temp_script("mouse-to", "mouse-to-after 4.5 100 40 2\n");
+        let args = parse(&["--script", &path.display().to_string()])?;
+        assert_eq!(args.mouse_to_after, vec![(4.5, 100, 40, 1)]);
+        std::fs::remove_file(&path).ok();
         Ok(())
     }
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Absolute pointer positioning by closed-loop servo of relative mouse
+//! motion.
+//!
+//! The Amiga mouse has no absolute position to set: it is a quadrature
+//! encoder, and the guest turns counts into pointer pixels through its own
+//! acceleration curve. Intuition's is history-dependent, so open-loop
+//! deltas cannot be aimed -- the same count sequence lands somewhere
+//! different depending on what preceded it.
+//!
+//! What the machine does expose is where the pointer actually is: the
+//! Amiga pointer is sprite 0, so the sprite's on-screen position is the
+//! pointer's position, and reading it is the same observation a person
+//! makes by looking at the screen. This servo injects a delta, watches
+//! where sprite 0 moved to on the next frame, and corrects, learning the
+//! pixels-per-count ratio it is being given instead of modelling it. That
+//! keeps the whole mechanism hardware-derived: nothing here knows which
+//! guest is running, only where the hardware is drawing.
+//!
+//! A guest that draws its pointer into a bitplane rather than a sprite has
+//! nothing to observe, and the servo says so rather than moving blindly.
+
+use crate::bus::Bus;
+
+/// The sprite the Amiga pointer is drawn with.
+const POINTER_SPRITE: usize = 0;
+
+/// Largest quadrature count injected in one frame. The counters are 8-bit
+/// and the guest reads them as a signed difference, so a step past 127
+/// would be seen as motion the other way; 64 keeps a comfortable margin
+/// under that and under any delta coalescing in the guest.
+const MAX_COUNTS: i32 = 64;
+
+/// Bounds on the learned pixels-per-count gain, so one anomalous frame
+/// (an acceleration threshold crossing, a pointer clamped at a screen
+/// edge) cannot produce a wild step.
+const MIN_GAIN: f64 = 0.25;
+const MAX_GAIN: f64 = 16.0;
+
+/// Frames a servo spends chasing its target before giving up, by default
+/// and at most. Sixty frames is a little over a second of emulated time,
+/// where a pointer that can converge normally does so in a handful.
+pub const DEFAULT_MAX_FRAMES: u32 = 60;
+pub const FRAME_LIMIT: u32 = 600;
+
+/// How close counts as arrived, by default. The pointer moves in lo-res
+/// pixels, which are two columns of the presented canvas, so an exact
+/// landing is not available for every target -- half of all horizontal
+/// coordinates are simply not on the lattice the guest can put the
+/// pointer on, and demanding one would fail on them forever. Two pixels
+/// is that quantum, and comfortably inside any clickable widget.
+pub const DEFAULT_TOLERANCE: i32 = 2;
+pub const TOLERANCE_LIMIT: i32 = 64;
+
+/// Consecutive moves allowed without beating the closest approach so far
+/// before the servo calls the pointer stuck. Two covers an oscillation
+/// between the lattice points either side of an unreachable target.
+const STALL_LIMIT: u32 = 3;
+
+/// What the servo wants to happen next.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ServoStep {
+    /// Apply this quadrature delta to `port`, advance exactly one frame,
+    /// then poll again.
+    Move { port: u8, dx: i32, dy: i32 },
+    /// The pointer is on the target.
+    Arrived { x: i32, y: i32, frames: u32 },
+    /// The servo cannot get there; the string says why.
+    Failed(String),
+}
+
+/// One in-flight "put the pointer here" request. Poll once per emulated
+/// frame, applying whatever [`ServoStep::Move`] it asks for in between.
+#[derive(Debug, Clone)]
+pub struct PointerServo {
+    port: u8,
+    target: (i32, i32),
+    tolerance: i32,
+    max_frames: u32,
+    frames: u32,
+    /// Closest approach so far, and how many moves since it improved.
+    /// A pointer whose reachable lattice straddles the target oscillates
+    /// rather than converging, and has to be recognised as arrived-as-
+    /// close-as-it-gets instead of running out the frame budget.
+    best: Option<(i32, (i32, i32))>,
+    stalled: u32,
+    /// Presented pixels per mouse count, learned per axis. A lo-res
+    /// pointer pixel is two columns of the 716-wide canvas, so horizontal
+    /// motion starts at 2 and vertical at 1.
+    gain: (f64, f64),
+    /// Position and counts of the delta currently in flight, so the next
+    /// poll can measure what the guest did with it.
+    outstanding: Option<((i32, i32), (i32, i32))>,
+}
+
+impl PointerServo {
+    pub fn new(port: u8, target: (i32, i32), tolerance: i32, max_frames: u32) -> Self {
+        Self {
+            port,
+            target,
+            tolerance: tolerance.clamp(0, TOLERANCE_LIMIT),
+            max_frames: max_frames.clamp(1, FRAME_LIMIT),
+            frames: 0,
+            best: None,
+            stalled: 0,
+            gain: (2.0, 1.0),
+            outstanding: None,
+        }
+    }
+
+    pub fn target(&self) -> (i32, i32) {
+        self.target
+    }
+
+    /// Read the pointer off the frame just completed and decide the next
+    /// move.
+    pub fn poll(&mut self, bus: &Bus) -> ServoStep {
+        self.poll_at(pointer_position(bus))
+    }
+
+    /// [`poll`] with the observation supplied, so the control loop can be
+    /// exercised without an emulator.
+    ///
+    /// [`poll`]: Self::poll
+    fn poll_at(&mut self, at: Option<(i32, i32)>) -> ServoStep {
+        let Some(at) = at else {
+            return ServoStep::Failed(if self.frames == 0 {
+                "sprite 0 is not being drawn: the guest is not using a hardware pointer, \
+                 so there is nothing to servo"
+                    .to_string()
+            } else {
+                format!(
+                    "sprite 0 stopped being drawn after {} servo frame(s)",
+                    self.frames
+                )
+            });
+        };
+        // Fold in what the delta already in flight actually achieved.
+        if let Some((was, counts)) = self.outstanding.take() {
+            if counts.0 != 0 && at.0 != was.0 {
+                self.gain.0 = learn(self.gain.0, at.0 - was.0, counts.0);
+            }
+            if counts.1 != 0 && at.1 != was.1 {
+                self.gain.1 = learn(self.gain.1, at.1 - was.1, counts.1);
+            }
+        }
+        let error = (self.target.0 - at.0, self.target.1 - at.1);
+        let miss = error.0.abs().max(error.1.abs());
+        if miss <= self.tolerance {
+            return ServoStep::Arrived {
+                x: at.0,
+                y: at.1,
+                frames: self.frames,
+            };
+        }
+        // Track how close the pointer has been brought. A target that is
+        // not on the guest's reachable lattice makes the servo oscillate
+        // around it; that is a real answer ("this is as close as the
+        // pointer goes"), not something to spend the frame budget on.
+        match self.best {
+            Some((best, _)) if miss >= best => self.stalled += 1,
+            _ => {
+                self.best = Some((miss, at));
+                self.stalled = 0;
+            }
+        }
+        if self.stalled >= STALL_LIMIT {
+            let (miss, at) = self.best.expect("a stall implies a recorded best");
+            return ServoStep::Failed(format!(
+                "pointer cannot reach ({}, {}): it settles {miss} px away at ({}, {}), \
+                 which is outside the {} px tolerance",
+                self.target.0, self.target.1, at.0, at.1, self.tolerance,
+            ));
+        }
+        if self.frames >= self.max_frames {
+            return ServoStep::Failed(format!(
+                "pointer did not reach ({}, {}) in {} frame(s): stopped at ({}, {}), \
+                 {} px short horizontally and {} px vertically",
+                self.target.0, self.target.1, self.max_frames, at.0, at.1, error.0, error.1,
+            ));
+        }
+        let counts = (
+            counts_for(error.0, self.gain.0),
+            counts_for(error.1, self.gain.1),
+        );
+        self.outstanding = Some((at, counts));
+        self.frames += 1;
+        ServoStep::Move {
+            port: self.port,
+            dx: counts.0,
+            dy: counts.1,
+        }
+    }
+}
+
+/// Where the guest's pointer is on the presented canvas, in the same
+/// coordinates `capture.screenshot` writes out.
+pub fn pointer_position(bus: &Bus) -> Option<(i32, i32)> {
+    crate::video::bitplane::sprite_framebuffer_origin(bus, POINTER_SPRITE)
+}
+
+/// Counts to request for a pixel error at the measured gain, never
+/// deliberately overshooting and never exceeding one frame's safe step.
+fn counts_for(error: i32, gain: f64) -> i32 {
+    if error == 0 {
+        return 0;
+    }
+    let wanted = (f64::from(error) / gain).round() as i32;
+    wanted.abs().min(error.abs()).min(MAX_COUNTS) * error.signum()
+}
+
+/// Blend a fresh pixels-per-count measurement into the running gain. The
+/// average damps a single odd frame without slowing convergence.
+fn learn(gain: f64, moved: i32, counts: i32) -> f64 {
+    let measured = f64::from(moved) / f64::from(counts);
+    if measured <= 0.0 {
+        // The pointer went the other way (a clamp at a screen edge, or an
+        // axis the guest inverts); keep the estimate rather than flipping
+        // its sign and chasing away from the target.
+        return gain;
+    }
+    ((gain + measured) / 2.0).clamp(MIN_GAIN, MAX_GAIN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a servo against a synthetic pointer that applies a fixed
+    /// pixels-per-count ratio, to check the loop converges without being
+    /// told what that ratio is.
+    fn converge(
+        ratio: (f64, f64),
+        start: (i32, i32),
+        target: (i32, i32),
+        tolerance: i32,
+    ) -> (u32, (i32, i32)) {
+        let mut servo = PointerServo::new(0, target, tolerance, DEFAULT_MAX_FRAMES);
+        let mut at = start;
+        for _ in 0..DEFAULT_MAX_FRAMES + 2 {
+            // Stand in for the poll's bus read.
+            let step = servo.poll_at(Some(at));
+            match step {
+                ServoStep::Move { dx, dy, .. } => {
+                    at.0 += (f64::from(dx) * ratio.0).round() as i32;
+                    at.1 += (f64::from(dy) * ratio.1).round() as i32;
+                }
+                ServoStep::Arrived { frames, .. } => return (frames, at),
+                ServoStep::Failed(why) => panic!("servo gave up: {why}"),
+            }
+        }
+        panic!("servo never terminated");
+    }
+
+    #[test]
+    fn converges_at_the_gain_it_was_built_for() {
+        let (frames, at) = converge((2.0, 1.0), (0, 0), (300, 120), 0);
+        assert_eq!(at, (300, 120));
+        assert!(frames <= 6, "took {frames} frames");
+    }
+
+    #[test]
+    fn converges_when_the_guest_accelerates_more_than_expected() {
+        // Four presented pixels per count on both axes: the servo must
+        // learn the ratio rather than overshoot forever.
+        let (frames, at) = converge((4.0, 4.0), (600, 250), (40, 12), DEFAULT_TOLERANCE);
+        assert!(
+            (at.0 - 40).abs() <= DEFAULT_TOLERANCE && (at.1 - 12).abs() <= DEFAULT_TOLERANCE,
+            "landed at {at:?}"
+        );
+        assert!(frames <= 10, "took {frames} frames");
+    }
+
+    #[test]
+    fn converges_when_the_guest_moves_less_than_one_pixel_per_count() {
+        let (frames, at) = converge((1.0, 1.0), (10, 10), (200, 90), 0);
+        assert_eq!(at, (200, 90));
+        assert!(frames <= 8, "took {frames} frames");
+    }
+
+    #[test]
+    fn gives_up_when_the_pointer_will_not_move() {
+        let mut servo = PointerServo::new(0, (400, 100), 0, 8);
+        let mut steps = 0;
+        loop {
+            match servo.poll_at(Some((10, 10))) {
+                ServoStep::Move { .. } => {
+                    steps += 1;
+                    assert!(steps <= 8, "servo ran past its frame budget");
+                }
+                ServoStep::Failed(why) => {
+                    assert!(why.contains("cannot reach (400, 100)"), "{why}");
+                    assert!(why.contains("settles 390 px away at (10, 10)"), "{why}");
+                    return;
+                }
+                ServoStep::Arrived { .. } => panic!("a stuck pointer must not report arrival"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_target_the_pointer_is_already_on_needs_no_motion() {
+        let mut servo = PointerServo::new(0, (128, 64), 0, DEFAULT_MAX_FRAMES);
+        assert_eq!(
+            servo.poll_at(Some((128, 64))),
+            ServoStep::Arrived {
+                x: 128,
+                y: 64,
+                frames: 0
+            }
+        );
+    }
+
+    #[test]
+    fn learned_gain_stays_inside_its_bounds() {
+        assert_eq!(learn(2.0, 1000, 1), MAX_GAIN);
+        assert_eq!(learn(0.3, 1, 1000), MIN_GAIN);
+        // A move against the requested direction leaves the estimate be.
+        assert_eq!(learn(2.0, -8, 4), 2.0);
+    }
+}

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -113,6 +113,11 @@ impl PointerServo {
         self.target
     }
 
+    /// Frames this servo has spent so far.
+    pub fn frames(&self) -> u32 {
+        self.frames
+    }
+
     /// Read the pointer off the frame just completed and decide the next
     /// move.
     pub fn poll(&mut self, bus: &Bus) -> ServoStep {

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -200,14 +200,26 @@ pub fn pointer_position(bus: &Bus) -> Option<(i32, i32)> {
     crate::video::bitplane::sprite_framebuffer_origin(bus, POINTER_SPRITE)
 }
 
-/// Counts to request for a pixel error at the measured gain, never
-/// deliberately overshooting and never exceeding one frame's safe step.
+/// Counts to request for a pixel error at the measured gain, bounded by
+/// one frame's safe step.
+///
+/// The gain already expresses the overshoot guard -- error/gain is the
+/// number of counts that covers exactly this error -- so there is no
+/// second clamp in pixels. Clamping counts by the pixel error would be a
+/// unit confusion, and it throttles the servo badly whenever the guest
+/// gives less than one pixel per count.
+///
+/// A non-zero error always asks for at least one count. A count is the
+/// smallest motion available, so requesting none would burn a frame
+/// injecting nothing and let the stall detector call a reachable target
+/// stuck; if one count overshoots, the tolerance and the stall detector
+/// are what resolve it.
 fn counts_for(error: i32, gain: f64) -> i32 {
     if error == 0 {
         return 0;
     }
-    let wanted = (f64::from(error) / gain).round() as i32;
-    wanted.abs().min(error.abs()).min(MAX_COUNTS) * error.signum()
+    let wanted = (f64::from(error.abs()) / gain).round() as i32;
+    wanted.clamp(1, MAX_COUNTS) * error.signum()
 }
 
 /// Blend a fresh pixels-per-count measurement into the running gain. The
@@ -310,6 +322,26 @@ mod tests {
                 frames: 0
             }
         );
+    }
+
+    #[test]
+    fn a_sub_gain_error_still_asks_for_motion() {
+        // Four pixels per count with one pixel to go: asking for zero
+        // would burn a frame injecting nothing.
+        assert_eq!(counts_for(1, 4.0), 1);
+        assert_eq!(counts_for(-1, 4.0), -1);
+        // A quarter of a pixel per count needs four counts per pixel; the
+        // request must not be throttled to the pixel error.
+        assert_eq!(counts_for(100, 0.25), MAX_COUNTS);
+        assert_eq!(counts_for(4, 0.25), 16);
+        assert_eq!(counts_for(0, 2.0), 0);
+    }
+
+    #[test]
+    fn a_guest_moving_less_than_a_pixel_per_count_still_converges() {
+        let (frames, at) = converge((0.25, 0.25), (0, 0), (200, 100), 0);
+        assert_eq!(at, (200, 100));
+        assert!(frames <= 20, "took {frames} frames");
     }
 
     #[test]

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -9,10 +9,11 @@
 //! deltas cannot be aimed -- the same count sequence lands somewhere
 //! different depending on what preceded it.
 //!
-//! What the machine does expose is where the pointer actually is: the
-//! Amiga pointer is sprite 0, so the sprite's on-screen position is the
-//! pointer's position, and reading it is the same observation a person
-//! makes by looking at the screen. This servo injects a delta, watches
+//! What the machine does expose is where the pointer actually is. The
+//! Amiga has no hardware pointer; Intuition draws one with sprite 0, and
+//! effectively every guest follows that convention, so the sprite's
+//! on-screen position is the pointer's position and reading it is the
+//! same observation a person makes by looking at the screen. This servo injects a delta, watches
 //! where sprite 0 moved to on the next frame, and corrects, learning the
 //! pixels-per-count ratio it is being given instead of modelling it. That
 //! keeps the whole mechanism hardware-derived: nothing here knows which
@@ -23,7 +24,9 @@
 
 use crate::bus::Bus;
 
-/// The sprite the Amiga pointer is drawn with.
+/// The sprite the OS draws its pointer with. A convention, not hardware:
+/// a guest is free to draw a pointer any way it likes, and one that does
+/// is reported as unobservable rather than guessed at.
 const POINTER_SPRITE: usize = 0;
 
 /// Largest quadrature count injected in one frame. The counters are 8-bit

--- a/src/regcheck.rs
+++ b/src/regcheck.rs
@@ -55,6 +55,20 @@ pub enum Finding {
     /// The register was reached through an address mirror rather than at
     /// its canonical $DFFxxx address.
     MirroredAddress,
+    /// A blit was started while the previous one was still running. On
+    /// hardware the CPU stalls until the blitter frees the register file,
+    /// and with BLTPRI set it can be locked out for the whole blit.
+    BlitterBusy,
+    /// A blit was started with the DMA that runs it switched off, so it
+    /// never progresses and its completion interrupt never fires -- the
+    /// classic wait-for-BBUSY hang.
+    BlitterDmaOff,
+    /// Disk DMA was armed against a drive that cannot serve it (none
+    /// selected, motor off, or no media). Nothing arrives, and a loader
+    /// waiting on DSKBLK waits forever.
+    DiskNotReady,
+    /// A keyboard handshake pulse too short for the 6500/1 to sample.
+    KeyboardHandshakeShort,
 }
 
 impl Finding {
@@ -67,6 +81,10 @@ impl Finding {
             Finding::OddAddress => "odd-address",
             Finding::PointerOutsideChipRam => "pointer-outside-chip-ram",
             Finding::MirroredAddress => "mirrored-address",
+            Finding::BlitterBusy => "blitter-busy",
+            Finding::BlitterDmaOff => "blitter-dma-off",
+            Finding::DiskNotReady => "disk-not-ready",
+            Finding::KeyboardHandshakeShort => "keyboard-handshake-short",
         }
     }
 }
@@ -180,9 +198,23 @@ impl RegCheck {
     /// One human-readable line for a finding, in the shape the log and
     /// the debugger console both print.
     pub fn describe(report: &Report) -> String {
-        let reg = crate::debugger::custom_reg_name(report.reg);
         let who = report.writer.label();
         let at = report.writer.address();
+        let times = match report.count {
+            1 => String::new(),
+            n => format!(", {n} times"),
+        };
+        // The keyboard handshake is driven through CIA-A's serial port,
+        // not a custom register, so it does not name one.
+        if report.finding == Finding::KeyboardHandshakeShort {
+            return format!(
+                "keyboard handshake pulse of {} cck is below the {} cck the 6500/1 can \
+                 sample; the keyboard stops advancing to the next code \
+                 (by {who} at {at:#08X}, v{} h{}{times})",
+                report.value, report.detail, report.vpos, report.hpos,
+            );
+        }
+        let reg = crate::debugger::custom_reg_name(report.reg);
         let what = match report.finding {
             Finding::AbsentRegister => format!(
                 "{reg} is not present on the fitted chipset; write {:#06X} is dropped",
@@ -210,16 +242,40 @@ impl RegCheck {
                 "{reg} reached through an address mirror, not its $DFF{:03X} address",
                 report.reg
             ),
+            Finding::BlitterBusy => format!(
+                "{reg} started a blit while the previous one was still running; the CPU \
+                 stalls until the blitter frees its registers"
+            ),
+            Finding::BlitterDmaOff => format!(
+                "{reg} started a blit with DMACON BLTEN/DMAEN clear ({:#06X}); it will \
+                 never run or raise its completion interrupt",
+                report.detail
+            ),
+            Finding::DiskNotReady => {
+                format!("{reg} armed disk DMA but {}", disk_obstacle(report.detail))
+            }
+            Finding::KeyboardHandshakeShort => unreachable!("handled above"),
         };
         format!(
-            "{what} (by {who} at {at:#08X}, v{} h{}{})",
-            report.vpos,
-            report.hpos,
-            match report.count {
-                1 => String::new(),
-                n => format!(", {n} times"),
-            }
+            "{what} (by {who} at {at:#08X}, v{} h{}{times})",
+            report.vpos, report.hpos
         )
+    }
+}
+
+/// Codes for [`Finding::DiskNotReady`]'s `detail`, so the report stays a
+/// plain Copy struct rather than carrying a string per finding.
+pub const DISK_NO_DRIVE: u16 = 0;
+pub const DISK_MOTOR_OFF: u16 = 1;
+pub const DISK_EMPTY: u16 = 2;
+
+/// The reason code as the report prints it. Kept in step with
+/// `FloppyController::dma_arming_obstacle`.
+pub fn disk_obstacle(code: u16) -> &'static str {
+    match code {
+        DISK_MOTOR_OFF => "the selected drive's motor is off",
+        DISK_EMPTY => "the selected drive is empty",
+        _ => "no drive is selected",
     }
 }
 

--- a/src/regcheck.rs
+++ b/src/regcheck.rs
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Custom-register access validator: a running report of software using
+//! the chipset in ways the hardware does not reward.
+//!
+//! Every custom-register access in Copperline funnels through one place
+//! (`Bus::custom_write` and `Bus::write_custom_word_from`), which makes it
+//! cheap to notice the classic misuses: writing a register the fitted
+//! chipset does not have, writing bits a register does not define,
+//! reading a write-only register, byte or odd-address access to a word
+//! register, and pointing a DMA channel outside the RAM Agnus can reach.
+//! None of those are errors the machine reports -- the write simply lands
+//! nowhere, or somewhere unintended -- so the effect shows up much later
+//! as "the display is wrong" with nothing to bisect.
+//!
+//! Each finding names the offending PC (or Copper address) and the beam
+//! position, so it points at an instruction rather than at a symptom. The
+//! checks describe 68000/Agnus/Denise/Paula behaviour only: nothing here
+//! knows what program is running.
+//!
+//! Findings are deduplicated by (kind, register, writer) and counted, so
+//! a Copper list repeating the same mistake every frame produces one
+//! entry with a tally rather than fifty thousand log lines.
+
+use std::collections::BTreeMap;
+
+/// Findings retained before the oldest is dropped. Generous enough for
+/// any real report; bounded so a pathological program cannot grow the
+/// bus without limit.
+pub const MAX_FINDINGS: usize = 256;
+
+/// What kind of hardware misuse was seen.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Finding {
+    /// A register the fitted Agnus/Denise does not implement. The write
+    /// is accepted by the address decode and then dropped.
+    AbsentRegister,
+    /// A read-only register was written, or a write-only register read.
+    /// The access goes nowhere; a write-only read returns the undriven
+    /// bus rather than the latch.
+    WrongDirection,
+    /// Bits with no defined function were set. Real silicon ignores
+    /// them, but they are almost always a sign of a miscomputed value,
+    /// and some become real bits on a later chipset.
+    UnusedBits,
+    /// A byte-sized access to a word register. The data bus mirrors the
+    /// byte into both halves, so the register does not receive the value
+    /// the code appears to be writing.
+    ByteAccess,
+    /// A word access at an odd address.
+    OddAddress,
+    /// A DMA pointer was set outside the chip RAM Agnus can address, so
+    /// the channel will fetch from wrapped or unbacked addresses.
+    PointerOutsideChipRam,
+    /// The register was reached through an address mirror rather than at
+    /// its canonical $DFFxxx address.
+    MirroredAddress,
+}
+
+impl Finding {
+    pub fn name(self) -> &'static str {
+        match self {
+            Finding::AbsentRegister => "absent-register",
+            Finding::WrongDirection => "wrong-direction",
+            Finding::UnusedBits => "unused-bits",
+            Finding::ByteAccess => "byte-access",
+            Finding::OddAddress => "odd-address",
+            Finding::PointerOutsideChipRam => "pointer-outside-chip-ram",
+            Finding::MirroredAddress => "mirrored-address",
+        }
+    }
+}
+
+/// Who made the access, for attribution in a finding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Writer {
+    /// The CPU, at this PC.
+    Cpu(u32),
+    /// The Copper, at this list address.
+    Copper(u32),
+}
+
+impl Writer {
+    pub fn label(self) -> &'static str {
+        match self {
+            Writer::Cpu(_) => "cpu",
+            Writer::Copper(_) => "copper",
+        }
+    }
+
+    pub fn address(self) -> u32 {
+        match self {
+            Writer::Cpu(pc) | Writer::Copper(pc) => pc,
+        }
+    }
+}
+
+/// One deduplicated finding and everything needed to report it.
+#[derive(Clone, Copy, Debug)]
+pub struct Report {
+    pub finding: Finding,
+    /// Custom-register word offset ($000-$1FE).
+    pub reg: u16,
+    pub writer: Writer,
+    /// The value written (or read), and for `UnusedBits` the offending
+    /// bits alone.
+    pub value: u16,
+    pub detail: u16,
+    /// Beam position of the first occurrence.
+    pub vpos: u16,
+    pub hpos: u16,
+    /// How many times this (kind, register, writer) has been seen.
+    pub count: u64,
+}
+
+/// The validator's accumulated report.
+#[derive(Clone, Debug, Default)]
+pub struct RegCheck {
+    seen: BTreeMap<(Finding, u16, Writer), Report>,
+    /// Findings dropped because the report was full, so a reader can
+    /// tell a complete report from a truncated one.
+    pub dropped: u64,
+}
+
+impl RegCheck {
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.seen.clear();
+        self.dropped = 0;
+    }
+
+    /// Record one finding, merging it into an existing entry for the
+    /// same (kind, register, writer).
+    #[allow(clippy::too_many_arguments)]
+    pub fn note(
+        &mut self,
+        finding: Finding,
+        reg: u16,
+        writer: Writer,
+        value: u16,
+        detail: u16,
+        vpos: u16,
+        hpos: u16,
+    ) -> bool {
+        let key = (finding, reg, writer);
+        if let Some(entry) = self.seen.get_mut(&key) {
+            entry.count += 1;
+            return false;
+        }
+        if self.seen.len() >= MAX_FINDINGS {
+            self.dropped += 1;
+            return false;
+        }
+        self.seen.insert(
+            key,
+            Report {
+                finding,
+                reg,
+                writer,
+                value,
+                detail,
+                vpos,
+                hpos,
+                count: 1,
+            },
+        );
+        true
+    }
+
+    /// Every finding, most-repeated first.
+    pub fn reports(&self) -> Vec<Report> {
+        let mut out: Vec<Report> = self.seen.values().copied().collect();
+        out.sort_by(|a, b| b.count.cmp(&a.count).then(a.reg.cmp(&b.reg)));
+        out
+    }
+
+    /// One human-readable line for a finding, in the shape the log and
+    /// the debugger console both print.
+    pub fn describe(report: &Report) -> String {
+        let reg = crate::debugger::custom_reg_name(report.reg);
+        let who = report.writer.label();
+        let at = report.writer.address();
+        let what = match report.finding {
+            Finding::AbsentRegister => format!(
+                "{reg} is not present on the fitted chipset; write {:#06X} is dropped",
+                report.value
+            ),
+            Finding::WrongDirection => format!(
+                "{reg} accessed against its direction; a write to a read-only register \
+                 lands nowhere, and a read of a write-only one returns the undriven bus"
+            ),
+            Finding::UnusedBits => format!(
+                "{reg} write {:#06X} sets undefined bits {:#06X}",
+                report.value, report.detail
+            ),
+            Finding::ByteAccess => format!(
+                "{reg} accessed a byte at a time; the custom chips have no byte lanes, \
+                 so a byte write latches into both halves of the register"
+            ),
+            Finding::OddAddress => format!("{reg} accessed at an odd address"),
+            Finding::PointerOutsideChipRam => format!(
+                "{reg} aimed at {:#08X}, past the chip RAM Agnus can address; \
+                 the pointer wraps",
+                u32::from(report.detail) << 16
+            ),
+            Finding::MirroredAddress => format!(
+                "{reg} reached through an address mirror, not its $DFF{:03X} address",
+                report.reg
+            ),
+        };
+        format!(
+            "{what} (by {who} at {at:#08X}, v{} h{}{})",
+            report.vpos,
+            report.hpos,
+            match report.count {
+                1 => String::new(),
+                n => format!(", {n} times"),
+            }
+        )
+    }
+}
+
+/// Bits each writable custom register actually defines. A register with
+/// no entry is not checked for undefined bits: the omission means "every
+/// bit of this register is data" (pointers, modulos, palette entries,
+/// sprite position words, blitter data) or that the field layout is
+/// resolution- or revision-dependent in a way a fixed mask would
+/// misreport.
+///
+/// Masks are the OCS/ECS/AGA union: a bit that exists on any fitted
+/// revision is defined, because the absent-register check already covers
+/// writing to hardware that is not there, and flagging an AGA bit on an
+/// AGA machine would be wrong.
+pub fn defined_bits(reg: u16) -> Option<u16> {
+    Some(match reg {
+        0x02E => 0x0002,         // COPCON: CDANG only
+        0x034 => 0xFF01,         // POTGO: OUTRY/DATRY..OUTLX/DATLX plus START
+        0x040 => 0xFFFF,         // BLTCON0: ASH, USE mask, LF
+        0x042 => 0xFF17,         // BLTCON1: BSH, DOFF, EFE/IFE, FCI, DESC, LINE
+        0x058 => 0xFFFF,         // BLTSIZE: h9-0, w5-0
+        0x05A => 0x00FF,         // BLTCON0L (ECS): the LF byte only
+        0x05C => 0x7FFF,         // BLTSIZV (ECS): 15-bit height
+        0x05E => 0x07FF,         // BLTSIZH (ECS): 11-bit width
+        0x08E | 0x090 => 0xFFFF, // DIWSTRT/DIWSTOP: V and H bytes
+        0x092 | 0x094 => 0x00FF, // DDFSTRT/DDFSTOP: H8-H2 (+H1 on AGA)
+        0x096 => 0xBFFF,         // DMACON: SET/CLR plus BBUSY..AUD0EN; BZERO is read-only
+        0x098 => 0xFFFF,         // CLXCON: ENSP/ENBP and their match values
+        0x09A | 0x09C => 0xFFFF, // INTENA/INTREQ: SET/CLR plus 14 sources
+        0x09E => 0xFFFF,         // ADKCON: SET/CLR plus precomp..ATPER
+        0x100 => 0xFFFF,         // BPLCON0: HIRES..ECSENA (BPU3/SHRES/UHRES on ECS/AGA)
+        0x102 => 0xFFFF,         // BPLCON1: PF1/PF2 scroll (8-bit fields on AGA)
+        0x104 => 0x7FFF,         // BPLCON2: ZDCTL..PF2P0; bit 15 undefined
+        0x106 => 0xFFFF,         // BPLCON3 (ECS/AGA): BANK/PF2OF/LOCT/SPRES/BRDRBLNK...
+        0x10C => 0xFFFF,         // BPLCON4 (AGA): BPLAM, ESPRM, OSPRM
+        0x10E => 0x0FFF,         // CLXCON2 (AGA): planes 7-8 enable/match only
+        0x1DC => 0xFFFF,         // BEAMCON0 (ECS): HARDDIS..ERSY
+        0x1FC => 0xC00F,         // FMODE (AGA): SSCAN2/BSCAN2, SPAGEM/SPR32, BPAGEM/BPL32
+        _ => return None,
+    })
+}
+
+/// Registers that only read (the CPU writing one is misuse) and
+/// registers that only write (the CPU reading one gets the undriven bus,
+/// not the latch).
+pub fn direction(reg: u16) -> Option<Direction> {
+    Some(match reg {
+        0x000 => Direction::ReadOnly,         // BLTDDAT
+        0x002 => Direction::ReadOnly,         // DMACONR
+        0x004 | 0x006 => Direction::ReadOnly, // VPOSR/VHPOSR (VPOSW/VHPOSW are $02A/$02C)
+        0x008 => Direction::ReadOnly,         // DSKDATR
+        0x00A | 0x00C => Direction::ReadOnly, // JOY0DAT/JOY1DAT
+        0x00E => Direction::ReadOnly,         // CLXDAT
+        0x010 => Direction::ReadOnly,         // ADKCONR
+        0x012 | 0x014 => Direction::ReadOnly, // POT0DAT/POT1DAT
+        0x016 => Direction::ReadOnly,         // POTGOR
+        0x018 => Direction::ReadOnly,         // SERDATR
+        0x01A => Direction::ReadOnly,         // DSKBYTR
+        0x01C | 0x01E => Direction::ReadOnly, // INTENAR/INTREQR
+        0x07C => Direction::ReadOnly,         // DENISEID
+        // Everything from the strobes upward is write-only; the ones with
+        // a read counterpart at another offset are listed above.
+        0x020..=0x03E | 0x040..=0x07A | 0x07E..=0x1BE | 0x1C0..=0x1FE => Direction::WriteOnly,
+        _ => return None,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    ReadOnly,
+    WriteOnly,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_findings_merge_into_one_entry_with_a_tally() {
+        let mut check = RegCheck::default();
+        assert!(check.note(
+            Finding::UnusedBits,
+            0x104,
+            Writer::Cpu(0x100),
+            0x8000,
+            0x8000,
+            10,
+            20
+        ));
+        assert!(!check.note(
+            Finding::UnusedBits,
+            0x104,
+            Writer::Cpu(0x100),
+            0x8000,
+            0x8000,
+            11,
+            20
+        ));
+        let reports = check.reports();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].count, 2);
+        // The first occurrence's beam position is the one kept: it is the
+        // one worth breakpointing on.
+        assert_eq!(reports[0].vpos, 10);
+    }
+
+    #[test]
+    fn a_different_writer_is_a_different_finding() {
+        let mut check = RegCheck::default();
+        check.note(
+            Finding::UnusedBits,
+            0x104,
+            Writer::Cpu(0x100),
+            0x8000,
+            0x8000,
+            0,
+            0,
+        );
+        check.note(
+            Finding::UnusedBits,
+            0x104,
+            Writer::Copper(0x200),
+            0x8000,
+            0x8000,
+            0,
+            0,
+        );
+        assert_eq!(check.reports().len(), 2);
+    }
+
+    #[test]
+    fn the_report_is_bounded_and_says_when_it_truncated() {
+        let mut check = RegCheck::default();
+        for pc in 0..(MAX_FINDINGS as u32 + 10) {
+            check.note(Finding::UnusedBits, 0x104, Writer::Cpu(pc), 1, 1, 0, 0);
+        }
+        assert_eq!(check.reports().len(), MAX_FINDINGS);
+        assert_eq!(check.dropped, 10);
+    }
+
+    #[test]
+    fn read_only_and_write_only_registers_are_classified() {
+        assert_eq!(direction(0x002), Some(Direction::ReadOnly)); // DMACONR
+        assert_eq!(direction(0x096), Some(Direction::WriteOnly)); // DMACON
+        assert_eq!(direction(0x004), Some(Direction::ReadOnly)); // VPOSR
+        assert_eq!(direction(0x02A), Some(Direction::WriteOnly)); // VPOSW
+        assert_eq!(direction(0x180), Some(Direction::WriteOnly)); // COLOR00
+    }
+
+    #[test]
+    fn undefined_bit_masks_cover_the_control_registers_only() {
+        // BPLCON2 bit 15 has no function on any revision.
+        assert_eq!(defined_bits(0x104), Some(0x7FFF));
+        // Pointers, modulos and palette entries are all data: no mask, so
+        // no false "undefined bit" report on a legitimate value.
+        assert_eq!(defined_bits(0x0E0), None);
+        assert_eq!(defined_bits(0x108), None);
+        assert_eq!(defined_bits(0x180), None);
+    }
+
+    #[test]
+    fn descriptions_name_the_register_the_writer_and_the_repeat_count() {
+        let mut check = RegCheck::default();
+        check.note(
+            Finding::UnusedBits,
+            0x104,
+            Writer::Copper(0x7C00),
+            0x8020,
+            0x8000,
+            42,
+            100,
+        );
+        check.note(
+            Finding::UnusedBits,
+            0x104,
+            Writer::Copper(0x7C00),
+            0x8020,
+            0x8000,
+            43,
+            100,
+        );
+        let line = RegCheck::describe(&check.reports()[0]);
+        assert!(line.contains("BPLCON2"), "{line}");
+        assert!(line.contains("undefined bits 0x8000"), "{line}");
+        assert!(line.contains("by copper at 0x007C00"), "{line}");
+        assert!(line.contains("2 times"), "{line}");
+    }
+}

--- a/src/regcheck.rs
+++ b/src/regcheck.rs
@@ -52,9 +52,9 @@ pub enum Finding {
     /// A DMA pointer was set outside the chip RAM Agnus can address, so
     /// the channel will fetch from wrapped or unbacked addresses.
     PointerOutsideChipRam,
-    /// The register was reached through an address mirror rather than at
-    /// its canonical $DFFxxx address.
-    MirroredAddress,
+    /// An access above the $000-$1FE register bank. Nothing decodes
+    /// there: the write is dropped and the read returns the undriven bus.
+    UnmappedOffset,
     /// A blit was started while the previous one was still running. On
     /// hardware the CPU stalls until the blitter frees the register file,
     /// and with BLTPRI set it can be locked out for the whole blit.
@@ -80,7 +80,7 @@ impl Finding {
             Finding::ByteAccess => "byte-access",
             Finding::OddAddress => "odd-address",
             Finding::PointerOutsideChipRam => "pointer-outside-chip-ram",
-            Finding::MirroredAddress => "mirrored-address",
+            Finding::UnmappedOffset => "unmapped-offset",
             Finding::BlitterBusy => "blitter-busy",
             Finding::BlitterDmaOff => "blitter-dma-off",
             Finding::DiskNotReady => "disk-not-ready",
@@ -208,8 +208,10 @@ impl RegCheck {
         // not a custom register, so it does not name one.
         if report.finding == Finding::KeyboardHandshakeShort {
             return format!(
-                "keyboard handshake pulse of {} cck is below the {} cck the 6500/1 can \
-                 sample; the keyboard stops advancing to the next code \
+                "keyboard handshake pulse of {} cck is under the {} cck floor that \
+                 separates a deliberate pulse from an incidental CIA reconfiguration, \
+                 and the MCU was waiting for one; it resynchronises after 143 ms and \
+                 resends with $F9, so a key is lost and input stalls until then \
                  (by {who} at {at:#08X}, v{} h{}{times})",
                 report.value, report.detail, report.vpos, report.hpos,
             );
@@ -238,8 +240,9 @@ impl RegCheck {
                  the pointer wraps",
                 u32::from(report.detail) << 16
             ),
-            Finding::MirroredAddress => format!(
-                "{reg} reached through an address mirror, not its $DFF{:03X} address",
+            Finding::UnmappedOffset => format!(
+                "${:03X} is above the $000-$1FE custom register bank; nothing decodes \
+                 there, so the access reaches no register",
                 report.reg
             ),
             Finding::BlitterBusy => format!(
@@ -292,28 +295,45 @@ pub fn disk_obstacle(code: u16) -> &'static str {
 /// AGA machine would be wrong.
 pub fn defined_bits(reg: u16) -> Option<u16> {
     Some(match reg {
-        0x02E => 0x0002,         // COPCON: CDANG only
-        0x034 => 0xFF01,         // POTGO: OUTRY/DATRY..OUTLX/DATLX plus START
-        0x040 => 0xFFFF,         // BLTCON0: ASH, USE mask, LF
-        0x042 => 0xFF17,         // BLTCON1: BSH, DOFF, EFE/IFE, FCI, DESC, LINE
+        0x02E => 0x0002, // COPCON: CDANG only
+        0x034 => 0xFF01, // POTGO: OUTRY/DATRY..OUTLX/DATLX plus START
+        0x040 => 0xFFFF, // BLTCON0: ASH, USE mask, LF
+        // BLTCON1: LINE, DESC/SING, FCI/AUL, IFE/SUL, EFE/SUD, SIGN,
+        // DOFF (ECS), BSH/texture. Bits 5 and 8-11 have no function --
+        // 8-11 are BLTCON0's USE bits, not this register's.
+        0x042 => 0xF0DF,
         0x058 => 0xFFFF,         // BLTSIZE: h9-0, w5-0
         0x05A => 0x00FF,         // BLTCON0L (ECS): the LF byte only
         0x05C => 0x7FFF,         // BLTSIZV (ECS): 15-bit height
         0x05E => 0x07FF,         // BLTSIZH (ECS): 11-bit width
         0x08E | 0x090 => 0xFFFF, // DIWSTRT/DIWSTOP: V and H bytes
-        0x092 | 0x094 => 0x00FF, // DDFSTRT/DDFSTOP: H8-H2 (+H1 on AGA)
-        0x096 => 0xBFFF,         // DMACON: SET/CLR plus BBUSY..AUD0EN; BZERO is read-only
-        0x098 => 0xFFFF,         // CLXCON: ENSP/ENBP and their match values
-        0x09A | 0x09C => 0xFFFF, // INTENA/INTREQ: SET/CLR plus 14 sources
-        0x09E => 0xFFFF,         // ADKCON: SET/CLR plus precomp..ATPER
-        0x100 => 0xFFFF,         // BPLCON0: HIRES..ECSENA (BPU3/SHRES/UHRES on ECS/AGA)
-        0x102 => 0xFFFF,         // BPLCON1: PF1/PF2 scroll (8-bit fields on AGA)
-        0x104 => 0x7FFF,         // BPLCON2: ZDCTL..PF2P0; bit 15 undefined
-        0x106 => 0xFFFF,         // BPLCON3 (ECS/AGA): BANK/PF2OF/LOCT/SPRES/BRDRBLNK...
-        0x10C => 0xFFFF,         // BPLCON4 (AGA): BPLAM, ESPRM, OSPRM
-        0x10E => 0x0FFF,         // CLXCON2 (AGA): planes 7-8 enable/match only
-        0x1DC => 0xFFFF,         // BEAMCON0 (ECS): HARDDIS..ERSY
-        0x1FC => 0xC00F,         // FMODE (AGA): SSCAN2/BSCAN2, SPAGEM/SPR32, BPAGEM/BPL32
+        // DDFSTRT/DDFSTOP: H8-H2. OCS decodes to 4-cck granularity and
+        // ECS/AGA to 2, but neither implements bit 0.
+        0x092 | 0x094 => 0x00FE,
+        // DMACON: SET/CLR plus BLTPRI..AUD0EN. BBUSY (14) and BZERO (13)
+        // are read-only status seen through DMACONR, and 11-12 are unused;
+        // Agnus masks writes to the low 11 bits.
+        0x096 => 0x87FF,
+        0x098 => 0xFFFF, // CLXCON: ENSP/ENBP and their match values
+        0x09A => 0xFFFF, // INTENA: SET/CLR, INTEN, and the 14 sources
+        0x09C => 0xBFFF, // INTREQ: the same less INTEN, which is INTENA's alone
+        0x09E => 0xFFFF, // ADKCON: SET/CLR plus PRECOMP..USE0V1
+        0x100 => 0xFFFF, // BPLCON0: HIRES..ECSENA (BPU3/SHRES/UHRES on ECS/AGA)
+        0x102 => 0xFFFF, // BPLCON1: PF1/PF2 scroll (8-bit fields on AGA)
+        0x104 => 0x7FFF, // BPLCON2: ZDCTL..PF2P0; bit 15 undefined
+        // BPLCON3 (ECS/AGA): BANK, PF2OF, LOCT, SPRES, BRDRBLNK,
+        // BRDNTRAN, ZDCLKEN, BRDRSPRT, EXTBLKEN. Bits 3 and 8 have no
+        // function on either revision.
+        0x106 => 0xFEF7,
+        0x10C => 0xFFFF, // BPLCON4 (AGA): BPLAM, ESPRM, OSPRM
+        // CLXCON2 (AGA): ENBP7/ENBP8 (6-7) and MVBP7/MVBP8 (0-1) only,
+        // which is exactly what the renderer decodes.
+        0x10E => 0x00C3,
+        // BEAMCON0 (ECS): HARDDIS (14) down to the colour-burst enable;
+        // bit 15 has no function. (ERSY is BPLCON0 bit 1 -- a different
+        // chip's register entirely.)
+        0x1DC => 0x7FFF,
+        0x1FC => 0xC00F, // FMODE (AGA): SSCAN2/BSCAN2, SPAGEM/SPR32, BPAGEM/BPL32
         _ => return None,
     })
 }
@@ -336,6 +356,10 @@ pub fn direction(reg: u16) -> Option<Direction> {
         0x01A => Direction::ReadOnly,         // DSKBYTR
         0x01C | 0x01E => Direction::ReadOnly, // INTENAR/INTREQR
         0x07C => Direction::ReadOnly,         // DENISEID
+        // HHPOSR: the ECS UHRES counter readback, paired with HHPOSW at
+        // $1D8. It sits inside the otherwise write-only tail, and the
+        // emulator does serve guest reads of it.
+        0x1DA => Direction::ReadOnly,
         // Everything from the strobes upward is write-only; the ones with
         // a read counterpart at another offset are listed above.
         0x020..=0x03E | 0x040..=0x07A | 0x07E..=0x1BE | 0x1C0..=0x1FE => Direction::WriteOnly,

--- a/src/smc.rs
+++ b/src/smc.rs
@@ -30,11 +30,22 @@
 //!
 //! Being executed is a property of the address, not of the program: this
 //! knows nothing about what is running, only what has run.
+//!
+//! Scope: the 24-bit space a 68000 and Agnus share, which is where chip
+//! RAM, slow RAM and the ROM live, and so where essentially all
+//! self-modifying Amiga code runs. Accesses above it are ignored rather
+//! than folded down, so a 32-bit machine's accelerator RAM cannot alias
+//! into chip space and manufacture reports; the trade is that
+//! self-modification up there is not detected.
 
 use std::collections::BTreeMap;
 
-/// One bit per word of the 24-bit address space Agnus and a 68000 share.
-const WORDS: usize = 0x0100_0000 / 2;
+/// The address space the detector tracks: the 24-bit space a 68000 and
+/// Agnus share, which is where chip RAM, slow RAM and the ROM live, and
+/// so where essentially all self-modifying Amiga code runs.
+const TRACKED_BYTES: u32 = 0x0100_0000;
+/// One bit per word of it.
+const WORDS: usize = TRACKED_BYTES as usize / 2;
 const BITMAP_LEN: usize = WORDS / 64;
 
 /// Distinct (address, writer) pairs retained before the report stops
@@ -81,7 +92,10 @@ impl SmcTracker {
     }
 
     pub fn is_executed(&self, addr: u32) -> bool {
-        let word = (addr as usize & 0x00FF_FFFF) / 2;
+        if addr >= TRACKED_BYTES {
+            return false;
+        }
+        let word = addr as usize / 2;
         self.executed[word / 64] & (1 << (word % 64)) != 0
     }
 
@@ -149,19 +163,44 @@ impl SmcTracker {
     }
 }
 
-/// The word indices `len` bytes at `addr` touch, inside the 24-bit space.
+/// The word indices `len` bytes at `addr` touch.
+///
+/// Addresses outside the tracked space yield nothing rather than being
+/// masked into it. Masking would alias a 32-bit machine's accelerator or
+/// motherboard RAM onto chip-space words and report code being written
+/// at addresses nothing touched -- the recurring 16 MiB-mask mistake this
+/// project keeps rediscovering. The cost is that self-modification in
+/// those banks is not detected; see the module note.
 fn words_of(addr: u32, len: u32) -> impl Iterator<Item = usize> {
-    let start = (addr & 0x00FF_FFFF) as usize / 2;
-    let end = ((addr.wrapping_add(len.max(1)).wrapping_sub(1)) & 0x00FF_FFFF) as usize / 2;
-    // A transfer that wraps the 24-bit space is reported at its start
-    // word only, rather than sweeping the whole bitmap.
-    let end = if end < start { start } else { end };
-    (start..=end).take(8)
+    let last = addr.wrapping_add(len.max(1)).wrapping_sub(1);
+    let span = if addr >= TRACKED_BYTES {
+        None
+    } else if last < TRACKED_BYTES && last >= addr {
+        Some((addr as usize / 2, last as usize / 2))
+    } else {
+        // Starts inside and runs past the end (or wraps the address
+        // space): take the part that is inside.
+        Some((addr as usize / 2, WORDS - 1))
+    };
+    span.into_iter()
+        .flat_map(|(start, end)| start..=end)
+        .take(8)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn addresses_above_the_tracked_space_are_ignored_not_folded_down() {
+        let mut smc = SmcTracker::default();
+        // A 32-bit machine's accelerator RAM. Folding it into the 24-bit
+        // space would mark chip-space words nothing executed.
+        smc.mark_executed(0x0800_0000, 2);
+        assert!(!smc.is_executed(0x0000_0000));
+        assert!(!smc.is_executed(0x0800_0000));
+        assert!(smc.note_write(0x0800_0000, 2, 0x1000).is_none());
+    }
 
     #[test]
     fn a_write_over_unexecuted_memory_is_not_a_finding() {

--- a/src/smc.rs
+++ b/src/smc.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Self-modifying-code detector: notice when a write lands on memory the
+//! CPU has already executed.
+//!
+//! Self-modification is legitimate on a 68000 -- decrunchers, trackers
+//! and copper-list patchers all do it -- but it is also where a
+//! prefetch-related bug hides, because the 68000 has already fetched the
+//! word ahead of the one it is executing. A patch applied too late runs
+//! the *old* instruction once; a patch applied to the wrong address
+//! corrupts a routine that will not misbehave until it is next called.
+//! Neither leaves a trace at the moment it happens.
+//!
+//! The detector keeps one bit per word of the 24-bit address space
+//! marking "the CPU has executed an instruction here", set as each
+//! instruction retires, and reports a write that lands on a marked word.
+//! Reports are deduplicated by (written address, writing PC) and
+//! counted, so a decruncher's inner loop is one entry rather than a
+//! flood.
+//!
+//! Marking at retirement rather than at prefetch is deliberate. The
+//! 68000's prefetch queue also reads a word past the end of the
+//! instruction stream, which the CPU may never execute; marking that
+//! would report a write to the data following a routine as if it were
+//! code. The cost is one uncaught case: an instruction that patches its
+//! own extension words during its only execution is not reported,
+//! because nothing had run there yet. Every repeating pattern -- loops,
+//! decrunchers, patch-then-call -- is caught on the pass after the
+//! first.
+//!
+//! Being executed is a property of the address, not of the program: this
+//! knows nothing about what is running, only what has run.
+
+use std::collections::BTreeMap;
+
+/// One bit per word of the 24-bit address space Agnus and a 68000 share.
+const WORDS: usize = 0x0100_0000 / 2;
+const BITMAP_LEN: usize = WORDS / 64;
+
+/// Distinct (address, writer) pairs retained before the report stops
+/// growing.
+pub const MAX_REPORTS: usize = 256;
+
+/// One place code was written, and by what.
+#[derive(Clone, Copy, Debug)]
+pub struct SmcReport {
+    /// The word written over.
+    pub addr: u32,
+    /// The instruction that wrote it.
+    pub writer_pc: u32,
+    /// How far ahead of the write the CPU was executing. A patch landing
+    /// within a few bytes of the PC is the prefetch-sensitive case: the
+    /// 68000 has already fetched past it.
+    pub distance: i64,
+    pub count: u64,
+}
+
+pub struct SmcTracker {
+    /// Set for every word an instruction has retired from.
+    executed: Vec<u64>,
+    reports: BTreeMap<(u32, u32), SmcReport>,
+    pub dropped: u64,
+}
+
+impl Default for SmcTracker {
+    fn default() -> Self {
+        Self {
+            executed: vec![0; BITMAP_LEN],
+            reports: BTreeMap::new(),
+            dropped: 0,
+        }
+    }
+}
+
+impl SmcTracker {
+    /// Mark `len` bytes at `addr` as executed code.
+    pub fn mark_executed(&mut self, addr: u32, len: u32) {
+        for word in words_of(addr, len) {
+            self.executed[word / 64] |= 1 << (word % 64);
+        }
+    }
+
+    pub fn is_executed(&self, addr: u32) -> bool {
+        let word = (addr as usize & 0x00FF_FFFF) / 2;
+        self.executed[word / 64] & (1 << (word % 64)) != 0
+    }
+
+    /// Record a write of `len` bytes at `addr` by the instruction at
+    /// `pc`. Returns the report when this is the first time that
+    /// (address, writer) pair has been seen, for one-shot logging.
+    pub fn note_write(&mut self, addr: u32, len: u32, pc: u32) -> Option<SmcReport> {
+        let mut first = None;
+        for word in words_of(addr, len) {
+            if self.executed[word / 64] & (1 << (word % 64)) == 0 {
+                continue;
+            }
+            let hit = (word * 2) as u32;
+            let key = (hit, pc);
+            if let Some(entry) = self.reports.get_mut(&key) {
+                entry.count += 1;
+                continue;
+            }
+            if self.reports.len() >= MAX_REPORTS {
+                self.dropped += 1;
+                continue;
+            }
+            let report = SmcReport {
+                addr: hit,
+                writer_pc: pc,
+                distance: i64::from(hit) - i64::from(pc),
+                count: 1,
+            };
+            self.reports.insert(key, report);
+            first.get_or_insert(report);
+        }
+        first
+    }
+
+    /// Every report, most-repeated first.
+    pub fn reports(&self) -> Vec<SmcReport> {
+        let mut out: Vec<SmcReport> = self.reports.values().copied().collect();
+        out.sort_by(|a, b| b.count.cmp(&a.count).then(a.addr.cmp(&b.addr)));
+        out
+    }
+
+    pub fn clear_reports(&mut self) {
+        self.reports.clear();
+        self.dropped = 0;
+    }
+
+    pub fn describe(report: &SmcReport) -> String {
+        format!(
+            "code at ${:06X} written by ${:06X}{}{}",
+            report.addr,
+            report.writer_pc,
+            // A 68000 has already prefetched the word after the one it is
+            // executing, so a patch this close may be too late to take
+            // effect on this pass.
+            match report.distance {
+                d if (0..=8).contains(&d) => format!(" ({d} bytes ahead, inside the prefetch)"),
+                d if d > 0 => format!(" ({d} bytes ahead)"),
+                d => format!(" ({} bytes behind)", -d),
+            },
+            match report.count {
+                1 => String::new(),
+                n => format!(", {n} times"),
+            }
+        )
+    }
+}
+
+/// The word indices `len` bytes at `addr` touch, inside the 24-bit space.
+fn words_of(addr: u32, len: u32) -> impl Iterator<Item = usize> {
+    let start = (addr & 0x00FF_FFFF) as usize / 2;
+    let end = ((addr.wrapping_add(len.max(1)).wrapping_sub(1)) & 0x00FF_FFFF) as usize / 2;
+    // A transfer that wraps the 24-bit space is reported at its start
+    // word only, rather than sweeping the whole bitmap.
+    let end = if end < start { start } else { end };
+    (start..=end).take(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_write_over_unexecuted_memory_is_not_a_finding() {
+        let mut smc = SmcTracker::default();
+        assert!(smc.note_write(0x20000, 2, 0xF80010).is_none());
+        assert!(smc.reports().is_empty());
+    }
+
+    #[test]
+    fn a_write_over_executed_code_is_reported_once_then_counted() {
+        let mut smc = SmcTracker::default();
+        smc.mark_executed(0x20000, 2);
+        let first = smc
+            .note_write(0x20000, 2, 0x20100)
+            .expect("first hit reported");
+        assert_eq!(first.addr, 0x20000);
+        assert_eq!(first.writer_pc, 0x20100);
+        // The same pair again only bumps the tally.
+        assert!(smc.note_write(0x20000, 2, 0x20100).is_none());
+        let reports = smc.reports();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].count, 2);
+    }
+
+    #[test]
+    fn a_long_write_covers_every_word_it_spans() {
+        let mut smc = SmcTracker::default();
+        smc.mark_executed(0x20002, 2);
+        // A longword write at $20000 covers $20000 and $20002.
+        assert!(smc.note_write(0x20000, 4, 0x30000).is_some());
+        assert_eq!(smc.reports()[0].addr, 0x20002);
+    }
+
+    #[test]
+    fn the_distance_to_the_writing_pc_flags_the_prefetch_window() {
+        let mut smc = SmcTracker::default();
+        smc.mark_executed(0x20004, 2);
+        smc.note_write(0x20004, 2, 0x20000);
+        let line = SmcTracker::describe(&smc.reports()[0]);
+        assert!(line.contains("inside the prefetch"), "{line}");
+
+        let mut smc = SmcTracker::default();
+        smc.mark_executed(0x30000, 2);
+        smc.note_write(0x30000, 2, 0x20000);
+        let line = SmcTracker::describe(&smc.reports()[0]);
+        assert!(line.contains("65536 bytes ahead"), "{line}");
+        assert!(!line.contains("prefetch"), "{line}");
+    }
+
+    #[test]
+    fn the_report_is_bounded_and_counts_what_it_dropped() {
+        let mut smc = SmcTracker::default();
+        smc.mark_executed(0x20000, 2);
+        for pc in 0..(MAX_REPORTS as u32 + 5) {
+            smc.note_write(0x20000, 2, pc * 2);
+        }
+        assert_eq!(smc.reports().len(), MAX_REPORTS);
+        assert_eq!(smc.dropped, 5);
+    }
+}

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3612,6 +3612,41 @@ pub(super) fn active_debug_sprite_mask() -> u8 {
     ACTIVE_DEBUG_MASKS.with(|masks| masks.get().1)
 }
 
+/// Where the hardware painted sprite `sprite`'s top-left pixel on the
+/// last completed frame, in the same presented-pixel coordinates
+/// `capture.screenshot` writes out, or `None` when that sprite drew
+/// nothing.
+///
+/// This observes the sprite the way a person looking at the screen does:
+/// it reads the captured sprite-DMA lines, so it follows a pointer whose
+/// position the guest updates by rewriting SPR0POS through the DMA list,
+/// not just one written straight to the register. It reuses the
+/// renderer's own comparator mapping, so a caller cannot drift out of
+/// step with where the pixels actually land.
+pub fn sprite_framebuffer_origin(bus: &Bus, sprite: usize) -> Option<(i32, i32)> {
+    let top = bus
+        .frame_captured_sprite_lines()
+        .iter()
+        .filter(|line| line.sprite == sprite)
+        .min_by_key(|line| line.beam_y)?;
+    let base = bus.frame_render_base();
+    let geometry = bus.frame_geometry();
+    // The comparator origin shift render_from_input installs for the
+    // running scan; see ACTIVE_CANVAS_SHIFT_H.
+    let shift = if geometry.programmable {
+        H_COUNTER_LINE_ORIGIN
+    } else {
+        0
+    };
+    let hstart = crate::bus::sprite_hstart_for_fmode(top.hstart, base.fmode);
+    let x = (hstart + crate::bus::SPRITE_OUTPUT_DELAY_LORES - DIW_HSTART_FB0 + shift) * 2
+        + i32::from(top.hsub_70ns && base.bplcon0 & BPLCON0_SHRES != 0);
+    // Logical sprite coordinates live in the hi-res pitch domain; the
+    // presented canvas may be double-width for a 35 ns super-hi-res scan.
+    let scale = bus.frame_canvas_scale() as i32;
+    Some((x * scale, top.beam_y - geometry.visible_start_vpos as i32))
+}
+
 pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
     let render_started = Instant::now();
     ACTIVE_DEBUG_MASKS.with(|masks| masks.set((input.debug_plane_mask, input.debug_sprite_mask)));

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2032,7 +2032,15 @@ impl App {
         // The servo is advanced first so a target coming due this frame
         // takes ownership before the deltas are considered, and so the
         // frame it finishes on releases them again immediately.
-        self.advance_scripted_pointer_targets(emu_secs);
+        // Only while the machine is actually advancing. fire_scheduled_events
+        // runs on every event-loop pass, including while paused or powered
+        // off; polling the servo there would compare the same frame to
+        // itself, inject counts the guest never gets to act on, and then
+        // call a reachable target stuck -- with the phantom deltas landing
+        // on unpause.
+        if self.powered_on && !self.paused && !self.cpu_halted {
+            self.advance_scripted_pointer_targets(emu_secs);
+        }
         let mut mouse_deltas = Vec::new();
         if self.active_mouse_to.is_none() {
             self.auto_mouse.retain(|&(at, dx, dy, port)| {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -559,6 +559,13 @@ pub struct App {
     /// one-shot per entry; (at_emulated_secs, dx, dy).
     auto_mouse: Vec<(f64, i32, i32, u8)>,
     pending_auto_mouse: Vec<(f32, i32, i32, u8)>,
+    /// `--mouse-to-after` requests waiting for their timestamp, and the
+    /// one servo currently steering the pointer. Only one runs at a time:
+    /// two servos fighting over the same quadrature counters would each
+    /// mis-measure the other's motion as its own.
+    auto_mouse_to: Vec<(f64, i32, i32, u8)>,
+    pending_auto_mouse_to: Vec<(f32, i32, i32, u8)>,
+    active_mouse_to: Option<crate::pointer::PointerServo>,
     /// Scheduled analogue pot positions from --pot-after (one-shot each).
     auto_pots: Vec<(f64, u8, u8, u8)>,
     pending_auto_pots: Vec<(f32, u8, u8, u8)>,
@@ -914,6 +921,7 @@ impl App {
         click_after: Vec<(f32, MouseButtonKind, u32, u8)>,
         joy_after: Vec<(f32, JoyButtonKind, u32, u8)>,
         mouse_after: Vec<(f32, i32, i32, u8)>,
+        mouse_to_after: Vec<(f32, i32, i32, u8)>,
         pot_after: Vec<(f32, u8, u8, u8)>,
         disk_insert_after: Vec<DiskInsertSpec>,
         cd_insert_after: Vec<(f32, PathBuf)>,
@@ -1041,6 +1049,9 @@ impl App {
             control: None,
             auto_mouse: Vec::new(),
             pending_auto_mouse: mouse_after,
+            auto_mouse_to: Vec::new(),
+            pending_auto_mouse_to: mouse_to_after,
+            active_mouse_to: None,
             auto_pots: Vec::new(),
             pending_auto_pots: pot_after,
             auto_disk_inserts: Vec::new(),
@@ -1868,6 +1879,19 @@ impl App {
         for (secs, dx, dy, port) in self.pending_auto_mouse.drain(..) {
             self.auto_mouse.push((secs.max(0.0) as f64, dx, dy, port));
         }
+        for (secs, x, y, port) in self.pending_auto_mouse_to.drain(..) {
+            self.auto_mouse_to.push((secs.max(0.0) as f64, x, y, port));
+        }
+        if !self.auto_mouse_to.is_empty() {
+            // Earliest first: the firing pass takes one at a time, and a
+            // servo holds the pointer until it lands or gives up.
+            self.auto_mouse_to
+                .sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+            info!(
+                "auto-mouse-to armed: {} scheduled pointer targets",
+                self.auto_mouse_to.len()
+            );
+        }
         if !self.auto_mouse.is_empty() {
             info!(
                 "auto-mouse armed: {} scheduled motions",
@@ -2011,6 +2035,7 @@ impl App {
         for (dx, dy, port) in mouse_deltas {
             self.apply_scripted_mouse_delta(port, dx, dy);
         }
+        self.advance_scripted_pointer_targets(emu_secs);
         // Fire any scheduled --pot-after analogue positions (one-shot
         // each).
         let mut pot_sets = Vec::new();
@@ -3424,6 +3449,65 @@ impl App {
         // Reverse-debug: note the motion so replay can reproduce it.
         self.emu
             .tt_note_input(crate::inputsched::ReplayAction::MouseMove { port, dx, dy });
+    }
+
+    /// Arm one scripted pointer target directly, for tests that do not go
+    /// through the CLI.
+    #[cfg(test)]
+    pub(super) fn arm_scripted_pointer_target(&mut self, secs: f64, x: i32, y: i32, port: u8) {
+        self.auto_mouse_to.push((secs, x, y, port));
+    }
+
+    /// Whether a scripted pointer servo is currently steering.
+    #[cfg(test)]
+    pub(super) fn scripted_pointer_target_active(&self) -> bool {
+        self.active_mouse_to.is_some()
+    }
+
+    /// Advance the scripted `--mouse-to-after` pointer targets: start the
+    /// next one that is due when nothing is steering, then give the
+    /// running servo this frame's correction.
+    ///
+    /// One correction per frame is the servo's whole contract -- it has
+    /// to see what the previous delta did before choosing the next -- and
+    /// this runs once per emulated frame, in the same pass the other
+    /// scheduled input fires from.
+    fn advance_scripted_pointer_targets(&mut self, emu_secs: f64) {
+        if self.active_mouse_to.is_none() {
+            if let Some(pos) = self
+                .auto_mouse_to
+                .iter()
+                .position(|&(at, ..)| emu_secs >= at)
+            {
+                let (_, x, y, port) = self.auto_mouse_to.remove(pos);
+                info!(
+                    "auto-mouse-to: steering the pointer to ({x}, {y}) on port {}",
+                    port + 1
+                );
+                self.active_mouse_to = Some(crate::pointer::PointerServo::new(
+                    port,
+                    (x, y),
+                    crate::pointer::DEFAULT_TOLERANCE,
+                    crate::pointer::DEFAULT_MAX_FRAMES,
+                ));
+            }
+        }
+        let Some(servo) = self.active_mouse_to.as_mut() else {
+            return;
+        };
+        match servo.poll(self.emu.bus()) {
+            crate::pointer::ServoStep::Move { port, dx, dy } => {
+                self.apply_scripted_mouse_delta(port, dx, dy);
+            }
+            crate::pointer::ServoStep::Arrived { x, y, frames } => {
+                info!("auto-mouse-to: pointer at ({x}, {y}) after {frames} frame(s)");
+                self.active_mouse_to = None;
+            }
+            crate::pointer::ServoStep::Failed(why) => {
+                warn!("auto-mouse-to: {why}");
+                self.active_mouse_to = None;
+            }
+        }
     }
 
     fn set_output_volume_from_pos(&mut self, pos: (i32, i32)) {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2023,19 +2023,30 @@ impl App {
         // Fire any scheduled --mouse-after relative motions (one-shot
         // each); these land on the named port's quadrature counters,
         // whatever device is configured there (the lines are the lines).
+        // Held back while a --mouse-to-after servo is steering: the servo
+        // measures the pointer's response to its own counts to learn the
+        // guest's acceleration, so motion from another source in the same
+        // frame is attributed to it and corrupts the estimate. The
+        // deferral is bounded by the servo's own frame budget.
+        //
+        // The servo is advanced first so a target coming due this frame
+        // takes ownership before the deltas are considered, and so the
+        // frame it finishes on releases them again immediately.
+        self.advance_scripted_pointer_targets(emu_secs);
         let mut mouse_deltas = Vec::new();
-        self.auto_mouse.retain(|&(at, dx, dy, port)| {
-            if emu_secs >= at {
-                mouse_deltas.push((dx, dy, port));
-                false
-            } else {
-                true
-            }
-        });
+        if self.active_mouse_to.is_none() {
+            self.auto_mouse.retain(|&(at, dx, dy, port)| {
+                if emu_secs >= at {
+                    mouse_deltas.push((dx, dy, port));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
         for (dx, dy, port) in mouse_deltas {
             self.apply_scripted_mouse_delta(port, dx, dy);
         }
-        self.advance_scripted_pointer_targets(emu_secs);
         // Fire any scheduled --pot-after analogue positions (one-shot
         // each).
         let mut pot_sets = Vec::new();

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -480,6 +480,15 @@ impl App {
                         }
                     }
                 }
+                // Only the CPU has an instruction behind an access, so a
+                // channel filter paired with PC= describes something that
+                // cannot happen and would never fire.
+                if pc.is_some() && filter.is_some_and(|f| !f.takes_pc_qualifier()) {
+                    return ConsoleOutcome::error(
+                        "PC= only qualifies CPU accesses; a DMA engine's access has no \
+                         instruction behind it",
+                    );
+                }
                 let set = self.emu.machine.ui_toggle_watch_qualified(addr, filter, pc);
                 ConsoleOutcome::one(format!(
                     "watchpoint ${:06X}{}{} {}",

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -453,23 +453,41 @@ impl App {
             }
             "WATCH" | "W" => {
                 let Some(addr) = args.first().and_then(|t| hex32(t)) else {
-                    return ConsoleOutcome::error("usage: WATCH ADDR [CPU|BLITTER|DISK]");
+                    return ConsoleOutcome::error("usage: WATCH ADDR [CLASS] [PC=ADDR]");
                 };
-                let filter = match args.get(1) {
-                    Some(token) => match crate::debugger::WatchSource::parse(token) {
-                        Some(source) => Some(source),
-                        None => {
-                            return ConsoleOutcome::error("watch filter is CPU, BLITTER, or DISK")
+                // Trailing PC=ADDR qualifies the watch to one instruction;
+                // the remaining token, if any, is the access class.
+                let mut filter = None;
+                let mut pc = None;
+                for token in args.iter().skip(1) {
+                    if let Some(value) = token
+                        .strip_prefix("PC=")
+                        .or_else(|| token.strip_prefix("pc="))
+                    {
+                        match hex32(value) {
+                            Some(addr) => pc = Some(addr),
+                            None => return ConsoleOutcome::error("PC= wants an address"),
                         }
-                    },
-                    None => None,
-                };
-                let set = self.emu.machine.ui_toggle_watch_filtered(addr, filter);
+                        continue;
+                    }
+                    match crate::debugger::WatchSource::parse(token) {
+                        Some(source) => filter = Some(source),
+                        None => {
+                            return ConsoleOutcome::error(
+                                "watch class is CPU, BLITTER, DISK, COPPER, or a DMA \
+                                 channel (BPL1..BPL8, SPR0..SPR7, AUD0..AUD3)",
+                            )
+                        }
+                    }
+                }
+                let set = self.emu.machine.ui_toggle_watch_qualified(addr, filter, pc);
                 ConsoleOutcome::one(format!(
-                    "watchpoint ${:06X}{} {}",
+                    "watchpoint ${:06X}{}{} {}",
                     addr & self.emu.machine.ui_addr_mask() & !1,
                     filter
-                        .map(|f| format!(" ({} writes only)", f.label()))
+                        .map(|f| format!(" ({} accesses only)", f.describe()))
+                        .unwrap_or_default(),
+                    pc.map(|pc| format!(" from ${pc:06X} only"))
                         .unwrap_or_default(),
                     if set { "set" } else { "removed" }
                 ))

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -459,11 +459,17 @@ impl App {
                 // the remaining token, if any, is the access class.
                 let mut filter = None;
                 let mut pc = None;
+                // Each qualifier may appear once. Letting a later token
+                // win would make `WATCH addr CPU BLITTER` install a
+                // blitter watch with no sign that the CPU was ignored.
                 for token in args.iter().skip(1) {
                     if let Some(value) = token
                         .strip_prefix("PC=")
                         .or_else(|| token.strip_prefix("pc="))
                     {
+                        if pc.is_some() {
+                            return ConsoleOutcome::error("PC= given more than once");
+                        }
                         match hex32(value) {
                             Some(addr) => pc = Some(addr),
                             None => return ConsoleOutcome::error("PC= wants an address"),
@@ -471,6 +477,9 @@ impl App {
                         continue;
                     }
                     match crate::debugger::WatchSource::parse(token) {
+                        Some(_) if filter.is_some() => {
+                            return ConsoleOutcome::error("watch class given more than once")
+                        }
                         Some(source) => filter = Some(source),
                         None => {
                             return ConsoleOutcome::error(

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -10,7 +10,8 @@
 
 use super::*;
 use crate::control::exec::{
-    self, CoreOp, HostOp, Request, ResumeKind, ResumeVerb, RunTarget, CCK_FINE_WINDOW, RUN_BUDGET,
+    self, CoreOp, HostOp, Request, ResumeKind, ResumeVerb, RunTarget, StableStep, StableWatch,
+    CCK_FINE_WINDOW, RUN_BUDGET,
 };
 use crate::control::proto::{self, CtlError};
 use crate::control::session::{InputAction, SessionCtx};
@@ -43,6 +44,9 @@ struct PendingResume {
     beam_target: Option<u16>,
     frame_target: Option<u64>,
     cck_target: Option<u64>,
+    /// A `run_until {stable_frames}` watcher, sampled once per emulated
+    /// frame by the burst loop.
+    stable: Option<StableWatch>,
     reason_on_target: &'static str,
 }
 
@@ -55,6 +59,7 @@ impl PendingResume {
             beam_target: None,
             frame_target: None,
             cck_target: None,
+            stable: None,
             reason_on_target: "target",
         }
     }
@@ -415,6 +420,7 @@ impl App {
                     }
                     RunTarget::Frame(frame) => pending.frame_target = Some(frame),
                     RunTarget::Cck(cck) => pending.cck_target = Some(cck),
+                    RunTarget::Stable(spec) => pending.stable = Some(StableWatch::new(spec)),
                     RunTarget::Seconds(secs) => {
                         pending.cck_target = Some(
                             (secs * f64::from(crate::chipset::paula::PAULA_CLOCK_HZ)).ceil() as u64,
@@ -586,6 +592,34 @@ impl App {
             pending.cck_target,
             pending.reason_on_target,
         );
+        // The burst loop calls this once per emulated frame, which is the
+        // sampling cadence the stable-frame watcher is defined on. The
+        // watcher is lifted out for the sample because sampling renders
+        // the frame, which needs the emulator the pending borrow holds.
+        if let Some(mut watch) = self
+            .control
+            .as_mut()
+            .and_then(|c| c.pending.as_mut())
+            .and_then(|p| p.stable.take())
+        {
+            let (reason, detail) = match watch.sample(&self.emu) {
+                StableStep::Running => {
+                    if let Some(p) = self.control.as_mut().and_then(|c| c.pending.as_mut()) {
+                        p.stable = Some(watch);
+                    }
+                    // A stable target is exclusive, so there is no
+                    // frame/cck target left to check below.
+                    return false;
+                }
+                StableStep::Settled(detail) => (reason, detail),
+                StableStep::GaveUp(detail) => ("budget", detail),
+            };
+            self.paused = true;
+            self.sync_live_audio_suspension();
+            self.control_complete_pending(reason, &detail);
+            self.request_redraw();
+            return true;
+        }
         if let Some(frame) = frame_target {
             if self.emu.bus().emulated_frames() >= frame {
                 self.paused = true;

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -263,6 +263,35 @@ impl App {
                     json!({"applied_at_seconds": now, "scheduled": scheduled}),
                 ));
             }
+            HostOp::MouseTo {
+                port,
+                x,
+                y,
+                tolerance,
+                max_frames,
+            } => {
+                // The servo runs the machine for up to max_frames frames
+                // right here, like the bounded step verbs above: it needs
+                // to see each frame it caused before choosing the next
+                // delta, which a frame-boundary drain cannot do.
+                let line = match exec::mouse_to(
+                    &mut self.emu,
+                    port,
+                    (x, y),
+                    tolerance,
+                    max_frames,
+                    |emu, action| {
+                        crate::control::session::inject_input(emu, &mut None, action);
+                    },
+                ) {
+                    Ok(value) => proto::ok_line(&id, value),
+                    Err(e) => proto::err_line(&id, &e),
+                };
+                self.control_send(line);
+                self.control_emit_events();
+                self.finish_render_for_current_frame();
+                self.request_redraw();
+            }
             HostOp::FloppyInsert {
                 drive,
                 path,

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -270,6 +270,18 @@ impl App {
                 tolerance,
                 max_frames,
             } => {
+                // Refused mid-resume, as the headless server does and as
+                // the protocol documents: the servo advances the machine
+                // itself, so it would step frames out from under a
+                // pending run_until -- past a pc target, or through
+                // frames a stable_frames watcher never got to sample.
+                if self.control.as_ref().is_some_and(|c| c.pending.is_some()) {
+                    self.control_send(proto::err_line(
+                        &id,
+                        &CtlError::invalid_state("pause before servoing the pointer"),
+                    ));
+                    return;
+                }
                 // The servo runs the machine for up to max_frames frames
                 // right here, like the bounded step verbs above: it needs
                 // to see each frame it caused before choosing the next

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3548,6 +3548,15 @@ fn console_watch_refuses_a_pc_qualifier_on_a_dma_class() {
         "{out:?}"
     );
     assert!(app.emu.machine.ui_breaks().watches.is_empty());
+    // A repeated qualifier is a typo, not a last-one-wins override.
+    for cmd in ["WATCH 20010 CPU BLITTER", "WATCH 20010 PC=F80010 PC=F80020"] {
+        let out = console_run(&mut app, cmd);
+        assert!(
+            out.iter().any(|l| l.contains("more than once")),
+            "{cmd}: {out:?}"
+        );
+    }
+    assert!(app.emu.machine.ui_breaks().watches.is_empty());
     // Either qualifier alone, and the CPU pairing, are accepted.
     for cmd in [
         "WATCH 20000 SPR3",

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4890,6 +4890,37 @@ mod control_drain {
     }
 
     #[test]
+    fn run_until_stable_frames_completes_in_the_burst_check() {
+        let (mut app, cmd_tx, reply_rx) = attached_app();
+        push(&cmd_tx, 1, "run_until", json!({"stable_frames": 2}));
+        app.drain_control();
+        assert!(!app.paused);
+        let mut completed = false;
+        for _ in 0..4 {
+            app.emu.step_frame().unwrap();
+            if app.surface_debug_stop() {
+                break;
+            }
+            if app.control_run_target_reached() {
+                completed = true;
+                break;
+            }
+        }
+        assert!(completed, "the NOP sled's still display should settle");
+        assert!(app.paused);
+        let stop = reply(&reply_rx);
+        assert_eq!(stop["result"]["reason"], "target");
+        assert!(
+            stop["result"]["detail"]
+                .as_str()
+                .unwrap()
+                .contains("stable for 2"),
+            "{}",
+            stop["result"]["detail"]
+        );
+    }
+
+    #[test]
     fn user_pause_completes_a_pending_resume() {
         let (mut app, cmd_tx, reply_rx) = attached_app();
         push(&cmd_tx, 1, "continue", json!({}));

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2255,6 +2255,7 @@ fn test_app_with_audio_and_cpu(
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
         None,
         std::array::from_fn(|_| Vec::new()),
         [true; 4],
@@ -4887,6 +4888,21 @@ mod control_drain {
         let stop = reply(&reply_rx);
         assert_eq!(stop["result"]["reason"], "target");
         assert!(stop["result"]["frame"].as_u64().unwrap() >= target);
+    }
+
+    #[test]
+    fn a_scripted_pointer_target_gives_up_when_no_sprite_pointer_exists() {
+        let (mut app, _cmd_tx, _reply_rx) = attached_app();
+        app.arm_scripted_pointer_target(0.0, 300, 120, 0);
+        // The NOP sled draws no sprites, so the first poll has nothing to
+        // observe. It must clear the servo rather than steering blind or
+        // retrying every frame for the rest of the run.
+        app.emu.step_frame().unwrap();
+        app.fire_scheduled_events();
+        assert!(
+            !app.scripted_pointer_target_active(),
+            "a pointerless guest must not leave a servo armed"
+        );
     }
 
     #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3536,6 +3536,31 @@ fn plant_exec_world(app: &mut super::App) {
 }
 
 #[test]
+fn console_watch_refuses_a_pc_qualifier_on_a_dma_class() {
+    let mut app = test_app();
+    app.open_console();
+    // A DMA engine's access has no instruction behind it, so this pair
+    // could only ever install a watch that never fires.
+    let out = console_run(&mut app, "WATCH 20000 SPR3 PC=F80010");
+    assert!(
+        out.iter()
+            .any(|l| l.contains("only qualifies CPU accesses")),
+        "{out:?}"
+    );
+    assert!(app.emu.machine.ui_breaks().watches.is_empty());
+    // Either qualifier alone, and the CPU pairing, are accepted.
+    for cmd in [
+        "WATCH 20000 SPR3",
+        "WATCH 20002 PC=F80010",
+        "WATCH 20004 CPU PC=F80010",
+    ] {
+        let out = console_run(&mut app, cmd);
+        assert!(out.iter().any(|l| l.contains("set")), "{cmd}: {out:?}");
+    }
+    assert_eq!(app.emu.machine.ui_breaks().watches.len(), 3);
+}
+
+#[test]
 fn console_segments_walks_the_cli_module() {
     let mut app = test_app();
     app.open_console();


### PR DESCRIPTION
The debugging features from `ROADMAP-0.14.md`: Tier 1's automation
primitives and the WinUAE-inspired debugger set from Axis 4. Nine
commits, one per feature, each with tests and docs.

## Tier 1 -- "the machine you can drive"

**`capture.region_digest {x?, y?, w, h}`** hashes one rectangle of the
frame, so a script can ask "is this button highlighted?" and get a
stable answer while the rest of the display moves. A rectangle that does
not fit the current frame is `-32602` rather than a silent clamp: frame
geometry moves with the beam standard and the canvas scale, so stale
coordinates need to be heard about.

**`run_until {stable_frames: N, max_frames?, x?, y?, w?, h?}`** runs
until N consecutive frames hash identically -- how to wait for a GUI to
finish drawing without guessing an emulated-seconds delay. The optional
region is what makes it usable on a live Workbench: a blinking cursor
never lets a whole frame settle, but the dialog being waited on does.
Both server modes share one `StableWatch`, and the settle/give-up state
machine is split from the rendering so it can be tested on synthetic
digest sequences.

**`input.mouse_to` and `--mouse-to-after SECS X Y [PORT]`** give absolute
pointer positioning. The mouse port carries a quadrature encoder with no
absolute position, and the guest turns counts into pixels through its own
history-dependent acceleration curve -- which is why driving the OS 3.9
Installer headlessly stalled on 6 px radio circles. Since the Amiga
pointer *is* sprite 0, `src/pointer.rs` injects a delta, watches where
the hardware drew that sprite on the next frame, and corrects, learning
the pixels-per-count ratio rather than modelling it. Coordinates are
presented pixels, the same ones a screenshot is measured in.

Two things fell out of building it. The pointer moves in lo-res pixels,
which are two columns of the presented canvas, so not every coordinate is
exactly reachable -- hence a 2 px default tolerance and a stall detector,
so a target the guest's lattice straddles is reported as "it settles
here" instead of oscillating until the frame budget runs out. And failing
to land is an error rather than a quiet near-miss, because a script that
carried on would click the wrong thing.

## The WinUAE-inspired debugger set

**Custom-register access validator** (`[debug] validate_chipset`,
`chipset.validate`, `chipset.report`). Chipset misuse is silent on real
hardware: a write to a register the fitted Agnus does not have is decoded
and dropped, undefined bits are ignored, a byte write to a word register
latches into both halves, and a DMA pointer past Agnus's reach quietly
wraps. Every custom-register access already funnels through one place,
so all of that can be noticed and attributed to a PC or Copper address.
Findings are deduplicated by (kind, register, writer) and counted, so a
Copper list repeating a mistake every frame is one entry with a tally.

The undefined-bit masks are the OCS/ECS/AGA union and cover control
registers only -- pointers, modulos, palette entries and sprite position
words are data, so a mask there would report legitimate values. The
DMA-pointer check runs on the high half, where the intent is still
visible: by the time the pointer is formed the setters have masked the
excess away, which is exactly the bug and exactly why it is invisible.

**Per-register last-writer** (`custom.writer`) rides on the same arming:
the last value and the code that wrote it, answering "what set BPLCON3,
and from where?" without a bisect.

**Per-DMA-channel and PC-qualified watchpoints.** A watch could not see a
read at all -- the mechanism compares the word's value after each
instruction, and a DMA fetch leaves it alone, so "which sprite fetched
this word" had no way to be asked. The read-side channels now latch the
access at their own fetch sites, which are the only places that know
*which* bitplane or sprite is fetching. A watch also takes an optional PC
qualifier, for a word a dozen routines all poke.

**Self-modifying-code detector** (`[debug] detect_smc`, `smc.report`).
Reports writes landing on memory that has already executed, with the
writing PC and the distance between them, calling out a patch close
enough to sit inside the 68000's prefetch. Marking at retirement rather
than at prefetch is deliberate: the prefetch queue also reads a word past
the end of the instruction stream, and marking that would report a write
to the data following a routine as if it were code. The one uncaught
case is documented.

**Blitter, floppy and keyboard misuse checks.** The cases that hang
rather than glitch: a blit started while the previous is still running or
with its DMA off, disk DMA armed against a drive with no media or its
motor still off (the class behind the Gods and Shadow of the Beast
dead-spins), and a keyboard handshake pulse too narrow for the 6500/1 to
sample, after which the keyboard simply stops sending.

**Bus-error injection** (`fault.inject`, `fault.list`, `fault.clear`).
Exercising a guest's fault handler meant hunting for an address that
happens to be undecoded on the machine under test. A faulted access never
reaches memory, so the guest sees exactly what an undecoded address gives
it.

**Memory heat map** (`memory.heatmap`, `memory.heatmap.report`). A slot
map says what owned the chip bus at a colour clock; this says where in
memory anything is happening. A 256x256 grid over a movable window of the
address space, cells coloured by what last touched them and faded over 32
frames, reusing the per-channel attribution from the watchpoint work. The
window is movable rather than fixed at 16 MiB so the RAM a 32-bit CPU
sees above the 24-bit space can be looked at too.

## Verification

`cargo test --release` green: 1894 lib + 36 bin + 2 ctl + 24 golden
probes, no goldens re-blessed (nothing here changes timing). `cargo
clippy --all-targets --all-features --locked` and `cargo fmt --check`
clean.

The heat map was exercised against a live AROS boot over CCP: six
seconds in, 640 cells of bitplane DMA, 58 of CPU writes, 4 of Copper
fetches, against the ROM's instruction-fetch band.

## Not included

The heat map has no in-window panel -- the data model, census and PNG
export are there, but not a `Panel` variant in `ui.rs`/`window.rs`. That
is a change across two very large files and the right shape for it is
worth deciding first (a tab in the Frame Analyzer window rather than a
fourth tool window, most likely).
