### PR TITLE
input: fix three host mouse-capture defects and add a capture policy

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -448,6 +448,18 @@ floppy_sounds_volume = 100
 # launcher's Input tab, and Cmd/Alt+Shift+> / < (held to ramp) to adjust live.
 # mouse_sensitivity = 50
 
+# When the host mouse is grabbed (pointer confined to the window, host cursor
+# hidden, so the Amiga pointer is the only one on screen):
+#   "click"  (default) clicking the display grabs it; that click is a window
+#            action and is not passed to the Amiga
+#   "auto"   grab whenever the window has the focus, and on entering
+#            fullscreen -- no host cursor is ever loose over the display
+#   "manual" only Cmd+G / Alt+G grabs; clicks go straight to the Amiga
+# Cmd+G / Alt+G releases and re-takes it by hand in every mode. Uncaptured
+# motion over the display still drives the emulated mouse whatever this is set
+# to. Also --mouse-capture MODE and the launcher's Input tab.
+# mouse_capture = "click"
+
 # Autofire: pulse a HELD fire button this many times per second (0 = off, the
 # default; up to 30). Live input only -- the gamepad and the keyboard mapping;
 # scripted --joy-after/--script input is never gated, so a replay reproduces

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -49,6 +49,7 @@ range checks as the equivalent TOML fields:
 | `--floppy-speed PERCENT` | `[floppy] speed` | `100` (real), `200`, `400`, `800`, or `0` (turbo) |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 | `--mouse-sensitivity N` | `[input] mouse_sensitivity` | `0`-`100` host mouse speed (`50` default = 1:1) |
+| `--mouse-capture MODE` | `[input] mouse_capture` | When the host mouse is grabbed: `click` (default), `auto`, `manual` |
 | `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
 | `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
 | `--autofire HZ` | `[input] autofire_hz` | `0` (off, the default) to `30` |
@@ -559,6 +560,7 @@ port1 = "mouse"           # mouse | joystick | cd32 | analogue | none
 port2 = "joystick"        # same values; default "cd32" on the CD32 profile
 joystick = "gamepad"      # "gamepad" (default) or "keyboard"
 mouse_sensitivity = 50    # host mouse speed 0-100 (50 default = 1:1)
+mouse_capture = "click"   # when to grab the mouse: click | auto | manual
 autofire_hz = 0           # pulse a held fire button at this rate; 0 = off
 ```
 
@@ -633,6 +635,32 @@ or scripted `--mouse-after` input, so headless and recorded runs stay
 deterministic. Set it from the launcher's *Input* tab or
 `--mouse-sensitivity N`, and adjust it live with `Cmd+Shift+>` / `Cmd+Shift+<`
 (`Alt+Shift+>` / `Alt+Shift+<` on Linux and Windows), which ramp while held.
+
+### Mouse capture
+
+Capturing the mouse confines the host pointer to the window and hides the
+host cursor, so the Amiga pointer is the only one on screen. `mouse_capture`
+decides when that grab is taken:
+
+- `click` (the default) -- clicking the display grabs it. That click is a
+  window action and is not passed to the Amiga, so the first click the guest
+  sees is the first one aimed at it.
+- `auto` -- grab as soon as the window has the focus, and again whenever it
+  regains it, so no host cursor is ever loose over the display. Entering
+  fullscreen grabs too. This suits a mouse-driven game or a fullscreen
+  session where the host desktop is not wanted.
+- `manual` -- only the shortcut grabs. Clicks on the display go straight to
+  the Amiga and the host cursor is left alone.
+
+`Cmd+G` / `Alt+G` releases and re-takes the grab by hand in every mode, and
+an explicit release is never undone automatically. Opening a panel or tool
+window borrows the cursor and hands the capture back when the last one
+closes.
+
+Uncaptured, host cursor motion over the display still drives the emulated
+mouse in every mode; this setting only decides when the grab is taken, not
+whether motion reaches the machine. Set it from the launcher's *Input* tab
+or `--mouse-capture MODE`.
 
 ### Autofire
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -481,9 +481,31 @@ counters hold.
 The host mouse drives the (lowest-numbered) port with a mouse plugged in
 and feeds its JOYxDAT counters. Click the display (or press `Cmd+G` on
 macOS or `Alt+G` on Linux/Windows) to capture the host mouse; the same
-shortcut releases it. While an overlay panel is open, host cursor motion is
-not fed to the emulated mouse. Tool windows likewise keep the debugger or
-analyzer interaction separate from Amiga mouse input.
+shortcut releases it. The click that takes the capture is a window
+action and is not passed to the Amiga, so the first click that reaches
+the guest is the first one aimed at it -- otherwise a single click on a
+gadget arrives as two, close enough together to read as a double click.
+
+While an overlay panel is open, host cursor motion is not fed to the
+emulated mouse. Tool windows likewise keep the debugger or analyzer
+interaction separate from Amiga mouse input. A panel or tool window
+opened while the mouse was captured borrows the cursor and hands the
+capture back when the last of them closes, so a visit to the debugger
+does not leave the machine uncaptured -- which matters most in
+fullscreen, where there is no desktop to reach for. An explicit
+`Cmd/Alt+G` release settles it the other way: the capture stays off.
+
+Uncaptured, host cursor motion over the display still drives the
+emulated mouse, and `[input] mouse_sensitivity` scales it the same way
+it scales captured motion. At the default setting the factor is 1.0 and
+the pointer tracks the host cursor one-for-one.
+
+`[input] mouse_capture` (`--mouse-capture`, the launcher's *Input* tab)
+changes when the grab is taken: `auto` grabs whenever the window has the
+focus and on entering fullscreen, so no host cursor is ever loose over
+the display, and `manual` grabs only on the shortcut, leaving display
+clicks to go straight to the Amiga. See
+[Mouse capture](configuration.md#mouse-capture).
 
 A USB gamepad drives the emulated digital joystick on whichever port one is
 plugged into: directions through JOYxDAT, fire through /FIRx, and a second

--- a/src/config.rs
+++ b/src/config.rs
@@ -234,6 +234,11 @@ pub struct Config {
     /// scale only -- it does not affect the emulated machine or scripted mouse
     /// input.
     pub mouse_sensitivity: u8,
+    /// When the host mouse is grabbed (`[input] mouse_capture` /
+    /// `--mouse-capture`). Defaults to [`MouseCapture::Click`], the
+    /// historical click-the-display behaviour; `auto` grabs on focus, which
+    /// suits a fullscreen session where no host cursor is wanted.
+    pub mouse_capture: MouseCapture,
     /// `[input] autofire_hz`: how fast a held fire button is pulsed, or 0 for
     /// off (the default). A host input convenience, not machine state -- the
     /// emulated port sees an ordinary button being pressed and released.
@@ -324,6 +329,40 @@ impl JoystickInputMode {
         match self {
             Self::Gamepad => "gamepad",
             Self::Keyboard => "keyboard",
+        }
+    }
+}
+
+/// When the host mouse is grabbed: the pointer is confined to the window
+/// and the host cursor hidden, so the emulated mouse is the only one on
+/// screen (`[input] mouse_capture` / `--mouse-capture`).
+///
+/// Uncaptured, host cursor motion over the display still drives the
+/// emulated mouse; this setting only decides when the grab is taken, not
+/// whether motion reaches the machine. `Cmd+G` / `Alt+G` releases and
+/// re-takes it by hand in every mode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MouseCapture {
+    /// Clicking the display takes the grab (the default). That click is a
+    /// window action and is not passed to the Amiga.
+    #[default]
+    Click,
+    /// Grab as soon as the window has the focus, and again whenever it
+    /// regains it, so there is never a host cursor loose over the display.
+    Auto,
+    /// Only the shortcut grabs. Clicks on the display go straight to the
+    /// Amiga with the host cursor left alone.
+    Manual,
+}
+
+impl MouseCapture {
+    /// Short label for menus and the config string (round-trips through
+    /// [`parse_mouse_capture`]).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Click => "click",
+            Self::Auto => "auto",
+            Self::Manual => "manual",
         }
     }
 }
@@ -1325,6 +1364,7 @@ impl Default for Config {
             status_bar: true,
             joystick_input_mode: JoystickInputMode::Gamepad,
             mouse_sensitivity: 50,
+            mouse_capture: MouseCapture::Click,
             autofire_hz: 0,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
@@ -1481,6 +1521,9 @@ pub struct ConfigOverrides {
     /// Host mouse sensitivity (`--mouse-sensitivity`), 0-100. Same as
     /// `[input] mouse_sensitivity`.
     pub mouse_sensitivity: Option<u16>,
+    /// When the host mouse is grabbed (`--mouse-capture`): "click",
+    /// "auto", or "manual". Same parser as `[input] mouse_capture`.
+    pub mouse_capture: Option<String>,
     /// Device in game port 1 (`--port1`): "mouse", "joystick", "cd32",
     /// "analogue", or "none". Same parser as `[input] port1`.
     pub port1: Option<String>,
@@ -1552,6 +1595,7 @@ impl ConfigOverrides {
             && self.floppy_speed.is_none()
             && self.joystick.is_none()
             && self.mouse_sensitivity.is_none()
+            && self.mouse_capture.is_none()
             && self.port1.is_none()
             && self.port2.is_none()
             && self.autofire_hz.is_none()
@@ -1617,6 +1661,9 @@ impl ConfigOverrides {
         }
         if let Some(sensitivity) = self.mouse_sensitivity {
             raw.input.mouse_sensitivity = Some(sensitivity);
+        }
+        if let Some(capture) = &self.mouse_capture {
+            raw.input.mouse_capture = Some(capture.clone());
         }
         if let Some(port1) = &self.port1 {
             raw.input.port1 = Some(port1.clone());
@@ -1844,6 +1891,10 @@ pub(crate) struct RawInput {
     /// Host mouse sensitivity, 0-100 (default 50).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mouse_sensitivity: Option<u16>,
+    /// When the host mouse is grabbed: "click" (default), "auto", or
+    /// "manual".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mouse_capture: Option<String>,
     /// Autofire rate in Hz for the fire button, or 0 (the default) for off.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) autofire_hz: Option<u8>,
@@ -2632,6 +2683,10 @@ impl TryFrom<RawConfig> for Config {
                 defaults.mouse_sensitivity
             }
         };
+        let mouse_capture = match raw.input.mouse_capture.as_deref() {
+            None => defaults.mouse_capture,
+            Some(s) => parse_mouse_capture(s)?,
+        };
         // An implausibly fast autofire is a typo, not a preference: at more
         // than ~30 Hz the pulse is shorter than the frame the guest samples
         // it on, so the button would read as noise or as never pressed.
@@ -3037,6 +3092,7 @@ impl TryFrom<RawConfig> for Config {
             status_bar,
             joystick_input_mode,
             mouse_sensitivity,
+            mouse_capture,
             autofire_hz,
             port_devices,
             serial,
@@ -3134,6 +3190,18 @@ pub(crate) fn parse_joystick_input_mode(s: &str) -> Result<JoystickInputMode> {
         "keyboard" | "kbd" | "key" => Ok(JoystickInputMode::Keyboard),
         _ => Err(anyhow!(
             "unknown [input] joystick {:?}: expected \"gamepad\" or \"keyboard\"",
+            s
+        )),
+    }
+}
+
+pub(crate) fn parse_mouse_capture(s: &str) -> Result<MouseCapture> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "click" | "on-click" => Ok(MouseCapture::Click),
+        "auto" | "focus" => Ok(MouseCapture::Auto),
+        "manual" | "off" | "none" => Ok(MouseCapture::Manual),
+        _ => Err(anyhow!(
+            "unknown [input] mouse_capture {:?}: expected \"click\", \"auto\", or \"manual\"",
             s
         )),
     }
@@ -4419,6 +4487,57 @@ mod tests {
             load_overrides(&overrides)?.joystick_input_mode,
             JoystickInputMode::Gamepad
         );
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_capture_defaults_to_click_and_parses_its_modes() -> Result<()> {
+        // The default is the historical behaviour: no config, no change.
+        assert_eq!(parse_config("")?.mouse_capture, MouseCapture::Click);
+
+        for (text, expected) in [
+            ("click", MouseCapture::Click),
+            ("on-click", MouseCapture::Click),
+            ("auto", MouseCapture::Auto),
+            ("focus", MouseCapture::Auto),
+            ("manual", MouseCapture::Manual),
+            ("off", MouseCapture::Manual),
+            ("none", MouseCapture::Manual),
+            ("AUTO", MouseCapture::Auto),
+        ] {
+            let cfg = parse_config(&format!("[input]\nmouse_capture = {text:?}\n"))?;
+            assert_eq!(cfg.mouse_capture, expected, "for {text:?}");
+        }
+
+        // A typo is an error rather than a silent fallback to the default.
+        assert!(parse_config("[input]\nmouse_capture = \"grab\"\n").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_capture_cli_override_sets_the_mode() -> Result<()> {
+        let overrides = ConfigOverrides {
+            mouse_capture: Some("auto".to_string()),
+            ..ConfigOverrides::default()
+        };
+        assert_eq!(
+            load_overrides(&overrides)?.mouse_capture,
+            MouseCapture::Auto
+        );
+        Ok(())
+    }
+
+    /// Every mode's label has to parse back to the same mode: the launcher
+    /// writes the label into the config file it saves.
+    #[test]
+    fn mouse_capture_labels_round_trip_through_the_parser() -> Result<()> {
+        for mode in [
+            MouseCapture::Click,
+            MouseCapture::Auto,
+            MouseCapture::Manual,
+        ] {
+            assert_eq!(parse_mouse_capture(mode.label())?, mode);
+        }
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,12 @@ where
                         .map_err(|_| anyhow!("--mouse-sensitivity must be a number 0-100"))?,
                 );
             }
+            "--mouse-capture" => {
+                let v = args.next().ok_or_else(|| {
+                    anyhow!("--mouse-capture requires a mode (click, auto, or manual)")
+                })?;
+                overrides.mouse_capture = Some(v);
+            }
             "--click-after" => {
                 const USAGE: &str = "--click-after requires SECS BUTTON DURATION_MS";
                 let secs: f32 = next_arg(&mut args, USAGE, "--click-after SECS must be a number")?;
@@ -979,6 +985,7 @@ fn print_help() {
          --joystick MODE                initial joystick input: gamepad or keyboard\n  \
          \x20                            (gamepad lets the keyboard pass through to the Amiga)\n  \
          --mouse-sensitivity N          host mouse sensitivity 0-100 (50 default = 1:1)\n  \
+         --mouse-capture MODE           when to grab the host mouse: click (default), auto, manual\n  \
          --port1 DEVICE                 controller in port 1: mouse (default), joystick,\n  \
          \x20                            cd32, analogue, or none\n  \
          --port2 DEVICE                 controller in port 2 (default: joystick;\n  \
@@ -1685,6 +1692,7 @@ fn main() -> Result<()> {
         cfg.emulation.warp_speed,
         cfg.joystick_input_mode,
         cfg.mouse_sensitivity,
+        cfg.mouse_capture,
         config::about_machine_lines(&cfg),
         raw_cfg,
         live_audio,
@@ -1798,6 +1806,10 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::WarpSpeed::default(),
         config::JoystickInputMode::default(),
         50,
+        // The config screen is a UI to be clicked around; an auto grab
+        // belongs to the machine, and apply_live_config installs the real
+        // setting when one is started.
+        config::MouseCapture::default(),
         vec!["Configure a machine, then press Run.".to_string()],
         raw_cfg,
         audio_output_enabled,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1807,8 +1807,8 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::JoystickInputMode::default(),
         50,
         // The config screen is a UI to be clicked around; an auto grab
-        // belongs to the machine, and apply_live_config installs the real
-        // setting when one is started.
+        // belongs to the machine, and run_machine installs the real setting
+        // when one is started.
         config::MouseCapture::default(),
         vec!["Configure a machine, then press Run.".to_string()],
         raw_cfg,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -24,9 +24,9 @@ use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
     format_size, machine_profile_defaults, AudioFilterMode, ChannelMode, Chipset, Config, CpuModel,
-    JoystickInputMode, MachineModel, Overscan, PacingBudget, ParallelDevice, PixelAspect,
-    RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, RtgCard, ScsiController,
-    SerialMode, WarpSpeed, BOOT_PRI_NEVER,
+    JoystickInputMode, MachineModel, MouseCapture, Overscan, PacingBudget, ParallelDevice,
+    PixelAspect, RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, RtgCard,
+    ScsiController, SerialMode, WarpSpeed, BOOT_PRI_NEVER,
 };
 use crate::net::NetConfig;
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
@@ -354,6 +354,7 @@ pub enum LauncherField {
     // Input
     Joystick,
     MouseSensitivity,
+    MouseCapture,
     Port1Device,
     Port2Device,
 }
@@ -597,11 +598,12 @@ const AV_EMULATION_ROWS: [Row; 15] = [
     row(F::RealtimePriority, "Realtime priority", Toggle),
     row(F::Warp, "Warp speed", Cycle),
 ];
-const INPUT_ROWS: [Row; 4] = [
+const INPUT_ROWS: [Row; 5] = [
     row(F::Port1Device, "Port 1", Cycle),
     row(F::Port2Device, "Port 2", Cycle),
     row(F::Joystick, "Joystick input", Cycle),
     row(F::MouseSensitivity, "Mouse sensitivity", Cycle),
+    row(F::MouseCapture, "Mouse capture", Cycle),
 ];
 
 /// The rows shown on a tab, top to bottom. Most tabs are fixed and borrow their
@@ -806,6 +808,12 @@ const WARPS: [WarpSpeed; 5] = [
 // The stepper flips the two explicit modes, matching the runtime toggle.
 const JOYSTICK_MODES: [JoystickInputMode; 2] =
     [JoystickInputMode::Gamepad, JoystickInputMode::Keyboard];
+// When the host mouse is grabbed, in stepper order.
+const MOUSE_CAPTURES: [MouseCapture; 3] = [
+    MouseCapture::Click,
+    MouseCapture::Auto,
+    MouseCapture::Manual,
+];
 // Controller devices a game port accepts, in stepper order.
 const PORT_DEVICES: [PortDevice; 5] = [
     PortDevice::Mouse,
@@ -1006,6 +1014,7 @@ pub struct MachineSetup {
     warp: WarpSpeed,
     joystick_input_mode: JoystickInputMode,
     mouse_sensitivity: u8,
+    mouse_capture: MouseCapture,
     port_devices: [PortDevice; 2],
     // Extra Zorro boards (metadata path + plugin config schema/overrides)
     zorro_boards: Vec<ZorroBoardSetup>,
@@ -1143,6 +1152,7 @@ impl MachineSetup {
             warp: cfg.emulation.warp_speed,
             joystick_input_mode: cfg.joystick_input_mode,
             mouse_sensitivity: cfg.mouse_sensitivity,
+            mouse_capture: cfg.mouse_capture,
             port_devices: cfg.port_devices,
             zorro_boards: raw
                 .zorro
@@ -1450,6 +1460,9 @@ impl MachineSetup {
         if self.mouse_sensitivity != base.mouse_sensitivity {
             raw.input.mouse_sensitivity = Some(u16::from(self.mouse_sensitivity));
         }
+        if self.mouse_capture != base.mouse_capture {
+            raw.input.mouse_capture = Some(self.mouse_capture.label().to_string());
+        }
         // Per port against the profile baseline, so a CD32 keeps its pad
         // implicit and a stock machine emits no port keys at all.
         if self.port_devices[0] != base.port_devices[0] {
@@ -1607,6 +1620,7 @@ impl MachineSetup {
         self.warp = base.emulation.warp_speed;
         self.joystick_input_mode = base.joystick_input_mode;
         self.mouse_sensitivity = base.mouse_sensitivity;
+        self.mouse_capture = base.mouse_capture;
         self.port_devices = base.port_devices;
         if !self.has_ide() {
             self.ide_master = None;
@@ -1757,8 +1771,8 @@ impl MachineSetup {
                     reason(self.audio_channel_mode != ChannelMode::Mono, "mono")
                 }
             }
-            // Mouse sensitivity does nothing unless a port holds a mouse.
-            F::MouseSensitivity => {
+            // Neither mouse row does anything unless a port holds a mouse.
+            F::MouseSensitivity | F::MouseCapture => {
                 reason(self.port_devices.contains(&PortDevice::Mouse), "no mouse")
             }
             _ => None,
@@ -1988,6 +2002,11 @@ impl MachineSetup {
                 JoystickInputMode::Gamepad => "Gamepad".to_string(),
             },
             F::MouseSensitivity => crate::config::mouse_sensitivity_label(self.mouse_sensitivity),
+            F::MouseCapture => match self.mouse_capture {
+                MouseCapture::Click => "On click".to_string(),
+                MouseCapture::Auto => "Automatic".to_string(),
+                MouseCapture::Manual => "Shortcut only".to_string(),
+            },
             F::Port1Device => port_device_display(self.port_devices[0]).to_string(),
             F::Port2Device => port_device_display(self.port_devices[1]).to_string(),
             F::ScsiController => match self.scsi_controller {
@@ -2186,6 +2205,9 @@ impl MachineSetup {
                 } else {
                     self.mouse_sensitivity.saturating_sub(1)
                 }
+            }
+            F::MouseCapture => {
+                self.mouse_capture = cycle_slice(&MOUSE_CAPTURES, self.mouse_capture, forward)
             }
             F::Port1Device => {
                 self.port_devices[0] = cycle_slice(&PORT_DEVICES, self.port_devices[0], forward)
@@ -3474,6 +3496,39 @@ mod tests {
         s.cycle(LauncherField::MouseSensitivity, false);
         assert_eq!(s.value_label(LauncherField::MouseSensitivity), "48");
         assert_eq!(s.to_raw().input.mouse_sensitivity, Some(48));
+    }
+
+    #[test]
+    fn mouse_capture_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        // Click-to-capture is the baseline, so nothing is written for it.
+        assert_eq!(s.value_label(LauncherField::MouseCapture), "On click");
+        assert_eq!(s.to_raw().input.mouse_capture, None);
+
+        s.cycle(LauncherField::MouseCapture, true);
+        assert_eq!(s.value_label(LauncherField::MouseCapture), "Automatic");
+        assert_eq!(s.to_raw().input.mouse_capture, Some("auto".to_string()));
+
+        s.cycle(LauncherField::MouseCapture, true);
+        assert_eq!(s.value_label(LauncherField::MouseCapture), "Shortcut only");
+        assert_eq!(s.to_raw().input.mouse_capture, Some("manual".to_string()));
+
+        // The written config has to load back into the same setting.
+        assert_eq!(
+            s.build_config().expect("valid config").mouse_capture,
+            MouseCapture::Manual
+        );
+    }
+
+    #[test]
+    fn mouse_capture_greys_out_without_a_mouse() {
+        let mut s = MachineSetup::default();
+        assert_eq!(s.disabled_reason(LauncherField::MouseCapture), None);
+        s.port_devices = [PortDevice::Joystick, PortDevice::Joystick];
+        assert_eq!(
+            s.disabled_reason(LauncherField::MouseCapture),
+            Some("no mouse")
+        );
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2698,6 +2698,11 @@ impl ApplicationHandler for App {
             WindowEvent::Focused(focused) => {
                 self.main_window_focused = focused;
                 if focused {
+                    // A capture a panel borrowed can only be repaid to a
+                    // focused window, so a panel that closed while the focus
+                    // was still elsewhere left the loan outstanding for this
+                    // moment.
+                    self.restore_mouse_capture_after_ui();
                     // In auto mode the grab follows the focus, so the
                     // window that has the keyboard also has the pointer and
                     // no host cursor is ever loose over the display. This is
@@ -3497,13 +3502,28 @@ impl App {
         if !self.capture_suspended_by_ui || self.modal_ui_active() {
             return;
         }
-        self.capture_suspended_by_ui = false;
         // Same guard the click-to-capture path applies: with no mouse left
         // on either port there is nothing to drive, and grabbing would only
         // trap a hidden cursor. Cheap insurance against a port device that
-        // changed while the panel was open.
-        if self.mouse_port().is_some() {
-            self.set_mouse_captured(true);
+        // changed while the panel was open -- and the loan is void, not
+        // outstanding, because no later event can repay it.
+        if self.mouse_port().is_none() {
+            self.capture_suspended_by_ui = false;
+            return;
+        }
+        // A grab wants the focus. Closing a tool window hands the focus back
+        // to the main window, but the order of that against this call is the
+        // window manager's business: attempted too early the grab fails, and
+        // clearing the loan on a failed grab would lose the capture for good
+        // -- the very thing this mechanism exists to prevent. Leave it
+        // outstanding and let the Focused(true) that follows retry.
+        if !self.main_window_focused {
+            return;
+        }
+        self.set_mouse_captured(true);
+        // Only a grab that actually took discharges the loan.
+        if self.mouse_captured {
+            self.capture_suspended_by_ui = false;
         }
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -691,6 +691,14 @@ pub struct App {
     /// mouse button.
     analyzer_dragging: bool,
     mouse_captured: bool,
+    /// Set when a menu, overlay panel, or tool window took the mouse away
+    /// from a capture that was live, so closing the last of them can hand
+    /// it back. The Cmd/Alt+G toggle clears it: the capture is then off
+    /// because the operator asked for it, not because the UI borrowed the
+    /// cursor. Focus loss deliberately does not clear it -- opening a tool
+    /// window unfocuses the main window as a matter of course, and that
+    /// must not count as the operator letting the capture go.
+    capture_suspended_by_ui: bool,
     mouse_delta_remainder: (f64, f64),
     last_rendered_emulated_frame: Option<u64>,
     last_submitted_render_frame: Option<u64>,
@@ -737,6 +745,15 @@ pub struct App {
     /// live host mouse delta, never scripted --mouse-after input or the core.
     mouse_sensitivity: u8,
     mouse_sensitivity_factor: f64,
+    /// When the host mouse is grabbed ([input] mouse_capture): on a display
+    /// click, automatically whenever the window holds the focus, or only on
+    /// the Cmd/Alt+G shortcut.
+    mouse_capture: crate::config::MouseCapture,
+    /// Whether the "press Cmd/Alt+G to release" hint has been shown for an
+    /// automatic capture yet. Auto mode grabs on every focus gain, and a
+    /// message on each one would be noise; the operator only needs telling
+    /// how to get the cursor back the first time.
+    auto_capture_hint_shown: bool,
     /// Whether the serial port is bridged to MIDI, so the runtime menu offers
     /// the device items. Fixed for the machine's life.
     serial_is_midi: bool,
@@ -1028,6 +1045,7 @@ impl App {
         warp_speed: WarpSpeed,
         joystick_input_mode: JoystickInputMode,
         mouse_sensitivity: u8,
+        mouse_capture: crate::config::MouseCapture,
         about_machine_lines: Vec<String>,
         machine_config: RawConfig,
         // Effective live-audio state for this machine: for a real machine the
@@ -1166,6 +1184,7 @@ impl App {
             volume_dragging: false,
             analyzer_dragging: false,
             mouse_captured: false,
+            capture_suspended_by_ui: false,
             mouse_delta_remainder: (0.0, 0.0),
             last_rendered_emulated_frame: None,
             last_submitted_render_frame: None,
@@ -1184,6 +1203,8 @@ impl App {
             joystick_input_mode,
             mouse_sensitivity,
             mouse_sensitivity_factor: mouse_sensitivity_factor(mouse_sensitivity),
+            mouse_capture,
+            auto_capture_hint_shown: false,
             warp_speed,
             rewind_budget_mb,
             rewind_interval_frames,
@@ -2676,7 +2697,14 @@ impl ApplicationHandler for App {
             }
             WindowEvent::Focused(focused) => {
                 self.main_window_focused = focused;
-                if !focused {
+                if focused {
+                    // In auto mode the grab follows the focus, so the
+                    // window that has the keyboard also has the pointer and
+                    // no host cursor is ever loose over the display. This is
+                    // also the start-up grab: the first Focused(true) is the
+                    // one that arrives when the window opens.
+                    self.apply_auto_mouse_capture();
+                } else {
                     self.volume_dragging = false;
                     self.analyzer_dragging = false;
                     self.set_mouse_captured(false);
@@ -2746,13 +2774,29 @@ impl ApplicationHandler for App {
                     }
                     return;
                 }
-                if pressed && !self.mouse_captured && self.cursor_pos.is_some_and(cursor_in_display)
+                if pressed
+                    && !self.mouse_captured
+                    && self.mouse_capture != crate::config::MouseCapture::Manual
+                    && self.cursor_pos.is_some_and(cursor_in_display)
                 {
                     // With no mouse on either port there is nothing to
                     // drive: grabbing and hiding the host cursor would
                     // just trap it.
                     if self.mouse_port().is_some() {
                         self.set_mouse_captured(true);
+                        // The click that takes the grab is a window-management
+                        // action, not an Amiga click. Forwarding it as well
+                        // lands a press on the guest immediately before the
+                        // first intended one, and two presses that close
+                        // together are what Intuition's double-click window is
+                        // looking for -- so a single deliberate click on a
+                        // gadget arrives as a double click. Swallow it, but
+                        // only once the grab has actually taken: if it failed
+                        // the mouse stays uncaptured and this click is the only
+                        // thing the guest is going to get.
+                        if self.mouse_captured {
+                            return;
+                        }
                     } else {
                         self.show_osd("No mouse on either port".to_string());
                     }
@@ -3392,7 +3436,75 @@ impl App {
             self.show_osd("No mouse on either port".to_string());
             return;
         }
+        // An explicit toggle settles the question either way: whatever the
+        // UI borrowed earlier is no longer owed back.
+        self.capture_suspended_by_ui = false;
         self.set_mouse_captured(!self.mouse_captured);
+    }
+
+    /// Release the mouse on behalf of a panel or tool window that needs the
+    /// host cursor, remembering a live capture so
+    /// `restore_mouse_capture_after_ui` can hand it back when the last of
+    /// them closes. Without that, opening the debugger over a captured
+    /// session left the machine uncaptured for good -- most visible in
+    /// fullscreen, where there is no desktop to reach for anyway.
+    ///
+    /// This covers the routes that can be taken *while* captured, which is
+    /// the keyboard shortcuts. The menu and status bar are not among them:
+    /// their click targets are refused while the mouse is captured, so
+    /// reaching them means releasing it by hand first, and that explicit
+    /// release is not something to undo afterwards.
+    fn suspend_mouse_capture_for_ui(&mut self) {
+        if self.mouse_captured {
+            self.capture_suspended_by_ui = true;
+            self.set_mouse_captured(false);
+        }
+    }
+
+    /// Take the grab if `[input] mouse_capture = "auto"` and the moment is
+    /// right for it: the window holds the focus, nothing modal wants the
+    /// cursor, and there is a mouse on a port to drive.
+    ///
+    /// Deliberately driven by discrete events (focus gain, entering
+    /// fullscreen, the last panel closing) rather than polled per frame --
+    /// a poll would re-take the grab the instant the operator released it
+    /// with the shortcut, leaving no way to get the cursor back at all.
+    fn apply_auto_mouse_capture(&mut self) {
+        if self.mouse_capture != crate::config::MouseCapture::Auto
+            || self.mouse_captured
+            || !self.main_window_focused
+            || self.modal_ui_active()
+            || self.mouse_port().is_none()
+        {
+            return;
+        }
+        self.set_mouse_captured(true);
+        // Auto mode hides the host cursor without the operator having done
+        // anything to ask for it, so say once how to get it back. Every
+        // later focus gain re-grabs silently.
+        if self.mouse_captured && !self.auto_capture_hint_shown {
+            self.auto_capture_hint_shown = true;
+            self.show_osd(format!(
+                "Mouse captured ({HOST_SHORTCUT_MODIFIER_LABEL}+G releases)"
+            ));
+        }
+    }
+
+    /// Re-take a capture the UI borrowed, once no modal UI still wants the
+    /// cursor. A no-op unless `suspend_mouse_capture_for_ui` recorded one,
+    /// so a session that was never captured is never surprised by a grab.
+    fn restore_mouse_capture_after_ui(&mut self) {
+        if !self.capture_suspended_by_ui || self.modal_ui_active() {
+            return;
+        }
+        self.capture_suspended_by_ui = false;
+        // Same guard the click-to-capture path applies: with no mouse left
+        // on either port there is nothing to drive, and grabbing would only
+        // trap a hidden cursor. Cheap insurance against a port device that
+        // changed while the panel was open.
+        if self.mouse_port().is_some() {
+            self.set_mouse_captured(true);
+        }
     }
 
     /// COPPERLINE_DIAG_CURSOR: trace how the most recent click maps from host
@@ -3495,7 +3607,15 @@ impl App {
             let dx = pos.0 - prev.0;
             let dy = pos.1 - prev.1;
             if dx != 0 || dy != 0 {
-                self.add_mouse_delta_i32(dx, dy);
+                // Through the same scale the captured path uses, so the
+                // sensitivity setting means something on both sides of a
+                // grab instead of silently doing nothing until the mouse is
+                // captured. The units still differ -- these are texture
+                // pixels where a captured delta is a raw device count -- so
+                // this equalises the operator's knob, not the underlying
+                // ratio; at the default sensitivity the factor is 1.0 and
+                // the long-standing 1:1 tracking is unchanged.
+                self.add_host_mouse_delta(f64::from(dx), f64::from(dy));
             }
         }
         self.last_display_cursor_pos = Some(pos);
@@ -4715,8 +4835,9 @@ impl App {
     fn open_debugger(&mut self) {
         if self.debugger_panel.is_none() {
             // The debugger shortcut can arrive while the mouse is captured;
-            // release it so the window's controls are reachable.
-            self.set_mouse_captured(false);
+            // release it so the window's controls are reachable, and note
+            // it so closing the panel gives the capture back.
+            self.suspend_mouse_capture_for_ui();
             self.ui.panel = None;
             self.paused_before_debugger = self.paused;
             self.paused = true;
@@ -4754,7 +4875,7 @@ impl App {
 
     fn open_console(&mut self) {
         if self.console_panel.is_none() {
-            self.set_mouse_captured(false);
+            self.suspend_mouse_capture_for_ui();
             self.ui.panel = None;
             self.paused_before_console = self.paused;
             self.paused = true;
@@ -4873,7 +4994,7 @@ impl App {
 
     fn open_frame_analyzer(&mut self) {
         if self.frame_analyzer_panel.is_none() {
-            self.set_mouse_captured(false);
+            self.suspend_mouse_capture_for_ui();
             self.ui.panel = None;
             self.paused_before_analyzer = self.paused;
             self.paused = true;
@@ -5484,6 +5605,7 @@ impl App {
         // start-up mode (a previous live Cmd+J toggle does not carry over).
         self.joystick_input_mode = cfg.joystick_input_mode;
         self.set_mouse_sensitivity(cfg.mouse_sensitivity);
+        self.mouse_capture = cfg.mouse_capture;
         self.autofire_hz = cfg.autofire_hz;
         // Rewind history belongs to the machine that recorded it, so the new
         // machine starts a fresh ring under its own config (or none at all).
@@ -5556,6 +5678,13 @@ impl App {
         if self.debugger_panel.is_none() && self.console_panel.is_none() {
             self.emu.machine.ui_set_pc_history_enabled(false);
         }
+        // Hand the mouse back if this was the last panel holding it. With
+        // two panels open, closing one leaves the other still wanting the
+        // cursor, and the check inside declines until that one goes too.
+        self.restore_mouse_capture_after_ui();
+        // In auto mode the grab is owed to the machine regardless of
+        // whether this panel is the one that borrowed it.
+        self.apply_auto_mouse_capture();
         self.resize_for_active_panel();
         self.request_redraw();
     }
@@ -5595,6 +5724,10 @@ impl App {
             self.show_osd(format!(
                 "Fullscreen on ({HOST_SHORTCUT_MODIFIER_LABEL}+F restores)"
             ));
+            // Fullscreen leaves no desktop to reach for, so auto mode takes
+            // the grab here as well as on focus: entering fullscreen does
+            // not itself change the focus, so no Focused event follows.
+            self.apply_auto_mouse_capture();
         }
     }
 

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -848,6 +848,7 @@ fn a_tool_panel_hands_the_mouse_capture_back_when_it_closes() {
     // state the shortcut would have found. What is under test is the
     // bookkeeping that decides whether to re-grab, not winit's grab.
     app.mouse_captured = true;
+    app.main_window_focused = true;
 
     app.open_debugger();
     assert!(
@@ -866,6 +867,7 @@ fn a_tool_panel_hands_the_mouse_capture_back_when_it_closes() {
 fn the_capture_stays_suspended_while_another_panel_wants_the_cursor() {
     let mut app = test_app();
     app.mouse_captured = true;
+    app.main_window_focused = true;
 
     app.open_debugger();
     app.open_frame_analyzer();
@@ -897,12 +899,68 @@ fn closing_a_panel_does_not_grab_a_mouse_that_was_never_captured() {
     assert!(!app.mouse_captured, "so nothing is handed back");
 }
 
+/// Closing a tool window hands the focus back to the main window, but the
+/// order of that against the close is the window manager's business. A grab
+/// attempted while the focus is still elsewhere fails, and discharging the
+/// loan on a failed grab would lose the capture for good -- the exact bug
+/// this mechanism exists to prevent. The loan stays outstanding until a
+/// focused moment can repay it.
+#[test]
+fn a_capture_loan_outlives_a_panel_that_closed_while_unfocused() {
+    let mut app = test_app();
+    app.mouse_captured = true;
+    app.main_window_focused = true;
+    app.open_debugger();
+    assert!(app.capture_suspended_by_ui);
+
+    // The tool window still holds the focus as the panel goes away.
+    app.main_window_focused = false;
+    app.close_tool_panel(ToolPanelKind::Debugger);
+    assert!(
+        app.capture_suspended_by_ui,
+        "the loan survives a close that could not repay it"
+    );
+
+    // The Focused(true) that follows is what actually repays it.
+    app.main_window_focused = true;
+    app.restore_mouse_capture_after_ui();
+    assert!(
+        !app.capture_suspended_by_ui,
+        "and is discharged once the window can take the grab"
+    );
+}
+
+/// A loan no later event could repay is void rather than outstanding: with
+/// no mouse left on a port there is nothing to capture for.
+#[test]
+fn a_capture_loan_is_dropped_when_no_port_holds_a_mouse() {
+    use crate::bus::PortDevice;
+    let mut app = test_app();
+    app.mouse_captured = true;
+    app.main_window_focused = true;
+    app.open_debugger();
+    assert!(app.capture_suspended_by_ui);
+
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Joystick);
+    assert_eq!(app.mouse_port(), None);
+
+    app.close_tool_panel(ToolPanelKind::Debugger);
+    assert!(
+        !app.capture_suspended_by_ui,
+        "nothing to drive, so the loan is void rather than held forever"
+    );
+}
+
 /// An explicit Cmd/Alt+G settles the question: the operator asked for the
 /// capture to be off, and a panel closing later must not overrule that.
 #[test]
 fn an_explicit_toggle_clears_a_pending_ui_suspension() {
     let mut app = test_app();
     app.mouse_captured = true;
+    app.main_window_focused = true;
     app.open_console();
     assert!(app.capture_suspended_by_ui);
 

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -794,6 +794,131 @@ fn mouse_capture_is_refused_with_no_mouse_on_either_port() {
     assert!(!app.mouse_captured, "nothing to capture for");
 }
 
+/// Uncaptured host motion used to reach the port as raw texture-space
+/// pixels, bypassing the sensitivity scale that captured motion goes
+/// through -- so the setting silently did nothing until the display was
+/// clicked, and the mouse changed feel the moment it was grabbed.
+#[test]
+fn uncaptured_cursor_motion_honours_the_sensitivity_setting() {
+    // The counters are 8-bit quadrature; read the port the host mouse
+    // drives before and after to get the applied motion.
+    fn drag_x(app: &mut super::App, from: i32, to: i32) -> u8 {
+        let port = app.mouse_port().expect("fixture has a mouse in port 1");
+        // The first sample only anchors the baseline; the second is the
+        // one that produces a delta.
+        app.track_uncaptured_cursor_motion(Some((from, 64)));
+        let before = app.emu.bus().input.ports[port].counter_x;
+        app.track_uncaptured_cursor_motion(Some((to, 64)));
+        app.emu.bus().input.ports[port]
+            .counter_x
+            .wrapping_sub(before)
+    }
+
+    // Default sensitivity is the neutral midpoint, where the factor is
+    // exactly 1.0: the historical 1:1 tracking is unchanged.
+    let mut app = test_app();
+    assert_eq!(app.mouse_sensitivity, 50);
+    assert_eq!(drag_x(&mut app, 100, 110), 10);
+
+    // Turned up, the same host travel moves the pointer further.
+    let mut app = test_app();
+    app.set_mouse_sensitivity(100);
+    assert_eq!(drag_x(&mut app, 100, 110), 40);
+
+    // Turned down, less -- and the fractional remainder is carried, not
+    // dropped, so slow motion still accumulates instead of vanishing.
+    let mut app = test_app();
+    app.set_mouse_sensitivity(0);
+    assert_eq!(drag_x(&mut app, 100, 110), 2);
+    assert!(
+        app.mouse_delta_remainder.0 > 0.0,
+        "the 0.5-count remainder is kept for the next motion"
+    );
+}
+
+/// A tool window borrows the host cursor while it is open. It used to
+/// release the capture outright and never give it back, so every trip to
+/// the debugger left the machine uncaptured for good -- worst in
+/// fullscreen, where there is no desktop to reach for anyway.
+#[test]
+fn a_tool_panel_hands_the_mouse_capture_back_when_it_closes() {
+    let mut app = test_app();
+    // The windowless fixture cannot take a real grab -- set_mouse_captured
+    // needs a window to call set_cursor_grab on -- so stage the captured
+    // state the shortcut would have found. What is under test is the
+    // bookkeeping that decides whether to re-grab, not winit's grab.
+    app.mouse_captured = true;
+
+    app.open_debugger();
+    assert!(
+        app.capture_suspended_by_ui,
+        "the panel noted that it borrowed a live capture"
+    );
+
+    app.close_tool_panel(ToolPanelKind::Debugger);
+    assert!(
+        !app.capture_suspended_by_ui,
+        "and handed it back on the way out"
+    );
+}
+
+#[test]
+fn the_capture_stays_suspended_while_another_panel_wants_the_cursor() {
+    let mut app = test_app();
+    app.mouse_captured = true;
+
+    app.open_debugger();
+    app.open_frame_analyzer();
+    app.close_tool_panel(ToolPanelKind::Debugger);
+    assert!(
+        app.capture_suspended_by_ui,
+        "the analyzer still needs the cursor"
+    );
+
+    app.close_tool_panel(ToolPanelKind::FrameAnalyzer);
+    assert!(
+        !app.capture_suspended_by_ui,
+        "the last panel out returns the capture"
+    );
+}
+
+/// The restore is owed only to a capture the UI actually took: a session
+/// that was never captured must not find the cursor grabbed because it
+/// happened to open the debugger.
+#[test]
+fn closing_a_panel_does_not_grab_a_mouse_that_was_never_captured() {
+    let mut app = test_app();
+    assert!(!app.mouse_captured);
+
+    app.open_debugger();
+    assert!(!app.capture_suspended_by_ui, "nothing was borrowed");
+
+    app.close_tool_panel(ToolPanelKind::Debugger);
+    assert!(!app.mouse_captured, "so nothing is handed back");
+}
+
+/// An explicit Cmd/Alt+G settles the question: the operator asked for the
+/// capture to be off, and a panel closing later must not overrule that.
+#[test]
+fn an_explicit_toggle_clears_a_pending_ui_suspension() {
+    let mut app = test_app();
+    app.mouse_captured = true;
+    app.open_console();
+    assert!(app.capture_suspended_by_ui);
+
+    // The console does not count as modal UI, so the shortcut still
+    // reaches the toggle while it is open.
+    app.mouse_captured = false;
+    app.toggle_mouse_capture();
+    assert!(
+        !app.capture_suspended_by_ui,
+        "the operator's own toggle wins over the borrowed capture"
+    );
+
+    app.close_tool_panel(ToolPanelKind::Console);
+    assert!(!app.mouse_captured, "closing the panel does not re-grab");
+}
+
 #[test]
 fn cycle_port_device_hot_plugs_and_releases_held_lines() {
     use crate::bus::PortDevice;
@@ -2282,6 +2407,7 @@ fn test_app_with_audio_cpu_and_program(
         crate::config::WarpSpeed::Max,
         crate::config::JoystickInputMode::Gamepad,
         50,
+        crate::config::MouseCapture::Click,
         vec!["Machine: test".to_string()],
         crate::config::RawConfig::default(),
         true,


### PR DESCRIPTION
Addresses #300, where the host mouse reads as "not locked to the emulator".

The reporter is on Windows 11. Capture already existed (`Cmd`/`Alt+G`, or clicking the display), but three defects on the *uncaptured* path produced exactly the symptoms described. Each is fixed independently here.

## The three defects

**The grabbing click was also sent to the Amiga.** The click-to-capture branch fell through to the button-forwarding block with no early return, so the guest saw a press immediately before the first one actually aimed at it. Two presses that close together are what Intuition's double-click window is looking for, so a single deliberate click on a gadget arrived as a double click -- the reporter's "left mouse-button double-click events". Now swallowed, but only once the grab has actually taken: if `set_cursor_grab` fails the mouse stays uncaptured and the click is all the guest is going to get.

**A panel or tool window never gave the capture back.** `open_debugger`/`open_console`/`open_frame_analyzer` released outright, so a trip to the debugger left the machine uncaptured permanently. The capture is now borrowed and returned when the last panel closes. Focus loss deliberately does *not* cancel the loan -- opening a tool window unfocuses the main window as a matter of course, and that must not count as the operator letting go.

**The sensitivity setting did nothing uncaptured.** Uncaptured motion went to the port as raw texture-space pixels via `add_mouse_delta_i32`; captured motion went through `add_host_mouse_delta`, which applies `MOUSE_MOTION_SCALE * mouse_sensitivity_factor`. So `[input] mouse_sensitivity` was inert until the display was clicked, and the mouse changed feel at the moment of the grab -- the reporter's "click into the window each time to get correctly scaled mouse inputs". Both paths now share the scale.

At the default sensitivity of 50 the factor is exactly 1.0, so stock behaviour is byte-identical; only users who moved the slider see a change. Scripted `--mouse-after` still goes through `apply_scripted_mouse_delta` and bypasses the scale entirely, so headless determinism is untouched.

## New setting

`[input] mouse_capture` / `--mouse-capture` / the launcher's *Input* tab:

| Mode | Behaviour |
|---|---|
| `click` | Default, unchanged: clicking the display grabs (that click is not passed to the Amiga) |
| `auto` | Grab whenever the window holds the focus, and on entering fullscreen |
| `manual` | Only the shortcut grabs; display clicks go straight to the Amiga |

`auto` is what #300 is asking for. It is driven by discrete events (focus gain, entering fullscreen, the last panel closing) rather than polled per frame -- a poll would re-take the grab the instant the operator released it with the shortcut, leaving no way to get the cursor back. The first automatic grab shows the release shortcut on screen once.

Uncaptured cursor motion still drives the emulated mouse in every mode; the setting only decides when the grab is taken, not whether motion reaches the machine.

## Testing

`cargo test --release` (1938 unit + integration), `cargo clippy --all-targets`, `cargo fmt --check` all clean. Nine new tests: config parsing/aliases/rejection/label round-trip, launcher round-trip and greying, uncaptured sensitivity scaling at three settings, and the panel borrow/return bookkeeping including the two-panel and never-captured cases.

**Known test gap.** The window fixture is windowless (`set_mouse_captured` needs a window to call `set_cursor_grab` on, and `run_headless` legitimately has none), so the tests cover the *bookkeeping* around the grab, not winit's grab itself. The click-swallow and the auto-grab have no automated coverage for the same reason and want a hands-on check -- which is what the Windows CI artifact is for.

Docs updated: `docs/guide/configuration.md` (new *Mouse capture* section + flag table), `docs/guide/ui.md`, `copperline.example.toml`.