### PR TITLE
web: PAL/NTSC + overscan/tint display options, remembered Kickstart, named save states, wake lock

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -16,7 +16,10 @@ use std::rc::Rc;
 
 use copperline::audio::AudioSink;
 use copperline::bus::PortDevice;
-use copperline::config::{machine_profile_defaults, parse_machine_model, Config, Overscan};
+use copperline::chipset::agnus::VideoStandard;
+use copperline::config::{
+    machine_profile_defaults, parse_machine_model, parse_video_standard, Config, Overscan,
+};
 use copperline::emulator::{build_machine, Emulator};
 use copperline::serial::{ChannelSerialHandle, ChannelSerialSink};
 use copperline::video::deinterlace::Deinterlacer;
@@ -219,6 +222,10 @@ pub struct WebEmu {
     /// Host side of Paula's serial port; the page bridges it to whatever
     /// byte stream it likes (typically a WebSocket to a telnet gateway).
     serial: ChannelSerialHandle,
+    /// Presentation overscan, the desktop's `[display] overscan` knob: `Tv`
+    /// masks the deep horizontal overscan like a CRT bezel (the default),
+    /// `Full` presents everything Denise produced.
+    overscan: Overscan,
 }
 
 #[wasm_bindgen]
@@ -232,12 +239,21 @@ impl WebEmu {
     /// desktop flag takes is accepted here, but the ones outside that list
     /// may need pieces a browser page cannot supply (CDTV/CD32 want an
     /// extended ROM and a CD). An unknown name throws.
+    ///
+    /// `video` picks the video standard ("PAL" or "NTSC", the desktop's
+    /// `[chipset] video` key) on top of whatever the profile chose; omitted
+    /// or empty keeps the profile's own standard (PAL for every offered
+    /// profile). An unknown name throws, like an unknown model.
     #[wasm_bindgen(constructor)]
-    pub fn new(model: Option<String>) -> Result<WebEmu, JsValue> {
-        let cfg = match model.as_deref().map(str::trim) {
+    pub fn new(model: Option<String>, video: Option<String>) -> Result<WebEmu, JsValue> {
+        let mut cfg = match model.as_deref().map(str::trim) {
             None | Some("") => Config::default(),
             Some(name) => machine_profile_defaults(parse_machine_model(name).map_err(js_err)?),
         };
+        match video.as_deref().map(str::trim) {
+            None | Some("") => {}
+            Some(name) => cfg.video_standard = parse_video_standard(name).map_err(js_err)?,
+        }
         let audio = Rc::new(RefCell::new(Vec::new()));
         let sink = WebAudioSink { buf: audio.clone() };
         // rom_optional: the default rom_path names the bundled AROS file,
@@ -262,6 +278,7 @@ impl WebEmu {
             mouse_remainder: (0.0, 0.0),
             mouse_pending: (0, 0),
             serial,
+            overscan: Overscan::Tv,
         })
     }
 
@@ -288,6 +305,14 @@ impl WebEmu {
         vec!["A500".to_string(), "A1200".to_string()]
     }
 
+    /// The video standards the constructor's `video` argument accepts, in
+    /// menu order. Like `models`, the page builds its select from this list
+    /// and its presence doubles as the feature test: older bundles have no
+    /// `video_standards` and the control stays hidden.
+    pub fn video_standards() -> Vec<String> {
+        vec!["PAL".to_string(), "NTSC".to_string()]
+    }
+
     /// The running machine's profile name ("A500", "A1200", ...), or
     /// undefined for a machine no profile describes -- the model-less
     /// default constructor's machine, or a custom-shaped machine restored
@@ -298,6 +323,18 @@ impl WebEmu {
             .machine_descriptor()
             .machine
             .map(|model| format!("{model:?}"))
+    }
+
+    /// The running machine's video standard ("PAL" or "NTSC"). Follows
+    /// `load_state` like `machine_model`, so a page can re-point its video
+    /// select at what a state brought back. This is the machine's fitted
+    /// standard (the Agnus crystal), not the live BEAMCON0 PAL bit ECS
+    /// software can flip at runtime.
+    pub fn video_standard(&self) -> String {
+        match self.emu.machine_descriptor().video_standard {
+            VideoStandard::Pal => "PAL".to_string(),
+            VideoStandard::Ntsc => "NTSC".to_string(),
+        }
     }
 
     /// One-line description of the running machine for bug reports and
@@ -362,6 +399,12 @@ impl WebEmu {
         bitplane::render(self.emu.bus_mut(), &mut self.fb);
         let geometry = self.emu.bus().frame_geometry();
         let canvas_scale = self.emu.bus().frame_canvas_scale();
+        let base = self.emu.bus().frame_render_base();
+        // The desktop's recentring shift (window.rs render jobs): full
+        // overscan recentres a standard display whose deep left overscan
+        // would push the picture right of centre; TV mode is a fixed
+        // aperture and shifts nothing.
+        let h_shift = present_common::presentation_h_shift_for(&base, self.overscan);
         let field_rows = present_common::post_process_rendered_field(
             &mut self.fb,
             geometry,
@@ -369,10 +412,9 @@ impl WebEmu {
             self.emu.bus().frame_presentation_h_window(),
             self.emu.bus().frame_presentation_v_window(),
             visible_start_vpos,
-            0,
-            Overscan::Tv,
+            h_shift,
+            self.overscan,
         );
-        let base = self.emu.bus().frame_render_base();
         self.deinterlacer.push_field(
             &self.fb,
             field_rows,
@@ -383,7 +425,9 @@ impl WebEmu {
         );
         let woven_rows = self.deinterlacer.output_rows();
         let woven = self.deinterlacer.output();
-        if present_common::uses_standard_pal_tv_aperture(geometry, woven_rows, &base) {
+        if self.overscan == Overscan::Tv
+            && present_common::uses_standard_pal_tv_aperture(geometry, woven_rows, &base)
+        {
             // Standard PAL display: present the captured TV aperture, the
             // browser counterpart of the desktop's TV-aperture crop. Clipped
             // to real framebuffer columns so the canvas never shows the
@@ -743,6 +787,27 @@ impl WebEmu {
     /// sprints through frames until the catch-up clamp trips.
     pub fn resync_clock(&mut self) {
         self.anchor = None;
+    }
+
+    /// Presentation overscan, the desktop's `[display] overscan` knob:
+    /// "tv" (the default) masks the deep horizontal overscan margins like a
+    /// CRT bezel and presents standard PAL screens as the captured TV
+    /// aperture; "full" presents the whole overscan field the renderer
+    /// produces. Unknown names are ignored, like `set_port_device`. The
+    /// last completed frame is re-presented under the new aperture, so a
+    /// paused page repaints without stepping the machine.
+    pub fn set_overscan(&mut self, mode: &str) {
+        let overscan = match mode.trim().to_ascii_lowercase().as_str() {
+            "tv" => Overscan::Tv,
+            "full" => Overscan::Full,
+            _ => return,
+        };
+        if overscan == self.overscan {
+            return;
+        }
+        self.overscan = overscan;
+        self.last_rendered_frame = None;
+        self.render_completed_frame();
     }
 
     pub fn set_volume_percent(&mut self, percent: u8) {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -215,10 +215,21 @@ async function forgetStoredRom() {
   // The next boot goes back to AROS; a running machine keeps the ROM that
   // is physically fitted, exactly like ejecting the box the chip came in.
   if (bootRom?.remembered) {
+    // The AROS stash can still be empty here: its download may be in
+    // flight (load() adopts the empty boot stash when it lands) or may
+    // have failed (the boot button goes back to disabled, exactly as
+    // before anything was picked).
     bootRom = arosRom;
     refreshBootButton();
   }
-  setLoadStatus('Kickstart forgotten - the boot button builds AROS again');
+  // Say what the boot button will actually build: the AROS fallback, a
+  // Kickstart picked this session (forgetting the memory does not unfit
+  // an explicit choice), or nothing yet while AROS is still downloading.
+  setLoadStatus(
+    bootRom
+      ? `Kickstart forgotten - the boot button builds ${bootRom.label}`
+      : 'Kickstart forgotten - waiting for the AROS ROM',
+  );
   refreshStatesPanel();
 }
 
@@ -631,9 +642,16 @@ async function syncWakeLock() {
     try {
       const lock = await navigator.wakeLock.request('screen');
       // The browser can release it behind our back (tab hidden, battery
-      // saver); forget the handle so the next sync re-requests.
+      // saver, OS policy). Re-sync right away: a hidden page fails the
+      // want-check and is instead re-requested on visibilitychange, and
+      // a policy that keeps refusing surfaces as a rejected request, so
+      // this cannot ping-pong. Our own release path nulls the handle
+      // before releasing, so it never re-enters here.
       lock.addEventListener('release', () => {
-        if (wakeLock === lock) wakeLock = null;
+        if (wakeLock === lock) {
+          wakeLock = null;
+          syncWakeLock();
+        }
       });
       wakeLock = lock;
     } catch {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -126,17 +126,100 @@ function refreshBootButton() {
   updateStateButtons();
 }
 
+// The AROS ROMs the page fetched, kept beyond the boot stash: forgetting a
+// remembered Kickstart falls back to these without another download.
+let arosRom = null; // { rom, ext, label: 'AROS' }
+// Whether a Kickstart was explicitly chosen this session (picker, drop,
+// URL, list). The remembered ROM only ever fills in when nothing was: an
+// explicit pick always wins, whichever of the two resolves first.
+let romChosenExplicitly = false;
+
 // Route picked or dropped Kickstart bytes: live-swap a running machine, or
 // stash them for the boot button. The stash is updated on a live swap too,
 // so a reboot fits the ROM chosen last, not the one from the original boot;
 // a rejected image throws before the stash is touched and changes nothing.
+// A ROM that fits is remembered in the browser (IndexedDB), so the next
+// visit boots it without the picker; see the saved-states panel to forget.
 function fitRom(bytes, label) {
   if (emu) emu.load_rom(bytes, undefined);
   bootRom = { rom: bytes, ext: null, label };
+  romChosenExplicitly = true;
   refreshBootButton();
   setLoadStatus(
     emu ? `Kickstart loaded: ${label} - machine power-cycled` : `will boot ${label}`,
   );
+  persistRom(bytes, label);
+}
+
+// --- remembered Kickstart ----------------------------------------------
+// The loaded ROM sticks in browser storage so a returning visitor's page
+// boots their Kickstart with no picker round trip, the way the quick state
+// does for a whole session. Only an explicitly chosen ROM is stored (AROS
+// is bundled and never needs remembering), and only after the core
+// accepted it. Everything stays in this browser; nothing is uploaded.
+
+let storedRomInfo = null; // { label, size } of the remembered ROM, when any
+
+async function persistRom(bytes, label) {
+  let failure = null;
+  try {
+    await withDb(ROM_STORE, 'readwrite', (store) =>
+      store.put({ rom: bytes, label, saved: new Date() }, ROM_SLOT),
+    );
+  } catch (e) {
+    failure = e;
+  }
+  if (failure) {
+    // The fit itself succeeded; only the remembering did not. Say so once
+    // rather than failing silently - a visitor counting on it would
+    // otherwise discover the gap a session too late.
+    const hint =
+      failure.name === 'QuotaExceededError' ? ' - browser storage is full' : '';
+    showOsd(`could not remember the Kickstart: ${failure.message ?? failure}${hint}`);
+    return;
+  }
+  storedRomInfo = { label, size: bytes.length };
+  refreshStatesPanel();
+}
+
+// Startup probe: put the remembered ROM in the boot stash unless something
+// explicit (picker, ?kick=, config) already claimed it. Racing the AROS
+// fetch is fine either way: whoever lands second sees the other's choice
+// (load() only installs AROS into an empty stash, and this only replaces
+// nothing or AROS).
+async function probeStoredRom() {
+  let record;
+  try {
+    record = await withDb(ROM_STORE, 'readonly', (store) => store.get(ROM_SLOT));
+  } catch {
+    return;
+  }
+  if (!record?.rom) return;
+  storedRomInfo = { label: record.label ?? 'Kickstart', size: record.rom.length };
+  if (romChosenExplicitly || (bootRom && bootRom.label !== 'AROS')) return;
+  bootRom = { rom: record.rom, ext: null, label: storedRomInfo.label, remembered: true };
+  refreshBootButton();
+  if (wasm) {
+    setLoadStatus(`ready - boots ${storedRomInfo.label} (remembered in this browser)`);
+  }
+}
+
+async function forgetStoredRom() {
+  try {
+    await withDb(ROM_STORE, 'readwrite', (store) => store.delete(ROM_SLOT));
+  } catch (e) {
+    setLoadStatus(`could not forget the Kickstart: ${e.message ?? e}`);
+    return;
+  }
+  storedRomInfo = null;
+  // The next boot goes back to AROS; a running machine keeps the ROM that
+  // is physically fitted, exactly like ejecting the box the chip came in.
+  if (bootRom?.remembered) {
+    bootRom = arosRom;
+    refreshBootButton();
+  }
+  setLoadStatus('Kickstart forgotten - the boot button builds AROS again');
+  refreshStatesPanel();
 }
 
 // Route disk bytes from any source (picker, URL, drop): insert into a
@@ -290,6 +373,7 @@ async function load() {
     wasm = await init();
     buildInfo = WebEmu.build_info?.() ?? null;
     populateMachineSelect();
+    populateVideoSelect();
   } catch (e) {
     setLoadStatus(`failed to load the emulator: ${e.message ?? e}`);
     console.error(e);
@@ -301,16 +385,27 @@ async function load() {
       fetchBytes('./aros/aros-amiga-m68k-rom.bin', 'AROS ROM'),
       fetchBytes('./aros/aros-amiga-m68k-ext.bin', 'AROS extended ROM'),
     ]);
-    // A Kickstart picked while the ROMs were downloading wins.
+    // Kept beyond the stash: forgetting a remembered Kickstart falls back
+    // to AROS without re-downloading it.
+    arosRom = { rom, ext, label: 'AROS' };
+    // A Kickstart picked (or remembered) while the ROMs were downloading
+    // wins; a ?kick= failure rides along either way.
+    const problem = romUrlProblem ? ` (${romUrlProblem})` : '';
     if (!bootRom) {
-      bootRom = { rom, ext, label: 'AROS' };
+      bootRom = arosRom;
       // A disk that landed first (file picker or ?df0= fetch) keeps its
-      // place in the status line, and a ?kick= failure rides along.
-      const problem = romUrlProblem ? ` (${romUrlProblem})` : '';
+      // place in the status line.
       setLoadStatus(
         (pendingDisk
           ? `ready - DF0: ${pendingDisk.name} inserts at boot`
           : 'ready - boots the open-source AROS ROM') + problem,
+      );
+    } else {
+      setLoadStatus(
+        `ready - boots ${bootRom.label}` +
+          (bootRom.remembered ? ' (remembered in this browser)' : '') +
+          (pendingDisk ? ` - DF0: ${pendingDisk.name} inserts at boot` : '') +
+          problem,
       );
     }
   } catch (e) {
@@ -336,8 +431,10 @@ async function boot() {
     // until a ROM exists), but a save state carries its own ROM and
     // replaces the whole machine, so a restore can start from one.
     // The model argument picks the machine profile; undefined (an older
-    // shell, or the list not knowing better) builds the default A500.
-    const machine = new WebEmu(machineModel ?? undefined);
+    // shell, or the list not knowing better) builds the default A500. The
+    // video argument picks PAL/NTSC the same way; a bundle older than both
+    // ignores the extra arguments.
+    const machine = new WebEmu(machineModel ?? undefined, videoStandard ?? undefined);
     if (bootRom) machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
 
     // A reboot after an emulator error builds a new audio stack; close the
@@ -381,6 +478,7 @@ async function boot() {
     if (monoAudioToggle) machine.set_mono_audio(monoAudioToggle.checked);
     else if (configMonoAudio !== null) machine.set_mono_audio(configMonoAudio);
     if (floppySpeed !== null) machine.set_floppy_speed(floppySpeed);
+    if (overscanMode !== null) machine.set_overscan?.(overscanMode);
     emu = machine;
     window.__emu = emu; // for debugging/automation
     lastFddTrack = null; // a new machine starts the track latch over
@@ -397,6 +495,13 @@ async function boot() {
         : 'machine built, waiting for the state') +
         (df0Name ? ` - DF0: ${df0Name} (write-protected)` : ''),
     );
+    // The AROS ROM cannot open its boot screen on an NTSC chipset: it
+    // gurus "unknown type of system screen" to the serial port and
+    // reboot-loops, which a visitor sees as a black screen. Real
+    // Kickstarts boot NTSC fine, so say why the screen stays dark.
+    if (videoStandard === 'NTSC' && bootRom?.label === 'AROS') {
+      showOsd('the AROS ROM cannot open an NTSC screen - load a Kickstart to boot NTSC');
+    }
 
     overlay.style.display = 'none';
     showBugLink(false);
@@ -405,6 +510,7 @@ async function boot() {
     paused = false;
     setPauseLabel();
     updateStateButtons();
+    syncWakeLock();
     // Port fittings live on the machine, so a fresh one needs the pads
     // that are still plugged into the host put back.
     for (const port of padAssignments.values()) fitCd32Pad(port);
@@ -472,6 +578,7 @@ function tick(nowMs) {
     emu = null;
     refreshBootButton();
     showBugLink(true);
+    syncWakeLock();
     console.error(e);
     return;
   }
@@ -499,10 +606,50 @@ function tick(nowMs) {
 }
 
 document.addEventListener('visibilitychange', () => {
+  // The browser drops a screen wake lock when the page hides; re-request
+  // it when a still-running machine comes back into view.
+  syncWakeLock();
   if (!audioCtx) return;
   if (document.hidden) audioCtx.suspend();
   else audioCtx.resume();
 });
+
+// --- screen wake lock --------------------------------------------------
+// A running machine keeps the screen awake, the way a video player does:
+// demos and long loading sequences are exactly the hands-off viewing that
+// trips a host's idle timeout. Released while paused, stopped, or hidden,
+// so an idle page never pins the display; browsers without the API (or a
+// battery saver refusing it) simply keep their usual timeout.
+
+let wakeLock = null;
+let wakeLockPending = false;
+
+async function syncWakeLock() {
+  const want = running && !paused && !document.hidden;
+  if (want && !wakeLock && !wakeLockPending && navigator.wakeLock?.request) {
+    wakeLockPending = true;
+    try {
+      const lock = await navigator.wakeLock.request('screen');
+      // The browser can release it behind our back (tab hidden, battery
+      // saver); forget the handle so the next sync re-requests.
+      lock.addEventListener('release', () => {
+        if (wakeLock === lock) wakeLock = null;
+      });
+      wakeLock = lock;
+    } catch {
+      // Refused: nothing to hold, nothing to report.
+    } finally {
+      wakeLockPending = false;
+    }
+    // The machine can have paused or stopped while the request was in
+    // flight; settle on the state that is true now.
+    if (wakeLock && !(running && !paused && !document.hidden)) syncWakeLock();
+  } else if (!want && wakeLock) {
+    const lock = wakeLock;
+    wakeLock = null;
+    lock.release().catch(() => {});
+  }
+}
 
 // --- serial / BBS bridge ---------------------------------------------------
 // Optional page feature: a shell that provides #serial-url (text input) and
@@ -1527,6 +1674,7 @@ function setPaused(next) {
   if (!emu || !running || next === paused) return;
   paused = next;
   setPauseLabel();
+  syncWakeLock();
   if (paused) {
     audioCtx?.suspend().catch(() => {});
     setLoadStatus('paused');
@@ -1553,7 +1701,24 @@ async function copyScreenshot() {
   if (!emu || !running) return;
   const blobOf = () =>
     new Promise((resolve, reject) => {
-      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('canvas capture failed'))), 'image/png');
+      // The screen tint is a CSS filter on the canvas element, which
+      // toBlob never sees; bake it in through a filtered copy so the
+      // screenshot shows what the visitor is looking at. Browsers without
+      // canvas-context filters capture the untinted picture.
+      let source = canvas;
+      const filter = tintFilter();
+      if (filter) {
+        const copy = document.createElement('canvas');
+        copy.width = canvas.width;
+        copy.height = canvas.height;
+        const copyCtx = copy.getContext('2d');
+        if (copyCtx && typeof copyCtx.filter === 'string') {
+          copyCtx.filter = filter;
+          copyCtx.drawImage(canvas, 0, 0);
+          source = copy;
+        }
+      }
+      source.toBlob((b) => (b ? resolve(b) : reject(new Error('canvas capture failed'))), 'image/png');
     });
   try {
     if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
@@ -1598,10 +1763,19 @@ async function copyScreenshot() {
 // Amiga key), so these are buttons only.
 
 const STATE_DB_NAME = 'copperline';
+// Version 2 adds the 'roms' store (the remembered Kickstart); version 1
+// databases upgrade in place, keeping their quick state.
+const STATE_DB_VERSION = 2;
 const STATE_STORE = 'states';
-// One quick slot. A visitor wants "where I left off", not a slot manager;
-// named slots can key off the same store later without a format change.
+const ROM_STORE = 'roms';
+// One quick slot, still what a visitor resuming a game wants first; named
+// slots live in the same store under a prefix (see the saved-states panel).
 const QUICK_SLOT = 'quick';
+// Named slots are keyed 'named:<name>', so a state literally named "quick"
+// can never shadow the quick slot.
+const NAMED_SLOT_PREFIX = 'named:';
+// The remembered Kickstart's key in the roms store.
+const ROM_SLOT = 'kick';
 
 let quickStateInfo = null; // metadata of the stored quick state, when there is one
 
@@ -1611,10 +1785,11 @@ function openStateDb() {
       reject(new Error('this browser has no IndexedDB'));
       return;
     }
-    const req = indexedDB.open(STATE_DB_NAME, 1);
+    const req = indexedDB.open(STATE_DB_NAME, STATE_DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STATE_STORE)) db.createObjectStore(STATE_STORE);
+      if (!db.objectStoreNames.contains(ROM_STORE)) db.createObjectStore(ROM_STORE);
     };
     req.onsuccess = () => resolve(req.result);
     // Private-browsing modes and blocked storage reject the open itself.
@@ -1626,23 +1801,27 @@ function openStateDb() {
 // Resolve on commit, not on the request: a put that succeeds can still lose
 // its transaction to the storage quota, and a quick save that quietly did
 // not persist is exactly the failure a visitor would discover too late.
-function stateTx(db, mode, run) {
+function dbTx(db, storeName, mode, run) {
   return new Promise((resolve, reject) => {
-    const tx = db.transaction(STATE_STORE, mode);
-    const req = run(tx.objectStore(STATE_STORE));
+    const tx = db.transaction(storeName, mode);
+    const req = run(tx.objectStore(storeName));
     tx.oncomplete = () => resolve(req?.result);
     tx.onerror = () => reject(tx.error ?? new Error('IndexedDB transaction failed'));
     tx.onabort = () => reject(tx.error ?? new Error('IndexedDB transaction aborted'));
   });
 }
 
-async function withStateDb(mode, run) {
+async function withDb(storeName, mode, run) {
   const db = await openStateDb();
   try {
-    return await stateTx(db, mode, run);
+    return await dbTx(db, storeName, mode, run);
   } finally {
     db.close();
   }
+}
+
+async function withStateDb(mode, run) {
+  return withDb(STATE_STORE, mode, run);
 }
 
 // Everything a state needs to describe itself in the UI. Uint8Array and Date
@@ -1654,13 +1833,15 @@ function stateRecord(bytes) {
     emulated: emu.emulated_seconds(),
     rom: bootRom?.label ?? 'unknown',
     df0: df0Name,
+    machine: emu.machine_model?.() ?? machineModel ?? null,
   };
 }
 
 function describeState(info) {
   if (!info) return '';
   const when = info.saved instanceof Date ? info.saved.toLocaleString() : 'unknown time';
-  return `${when} - ${info.df0 ?? 'no disk'} (${Math.round(info.emulated ?? 0)}s emulated)`;
+  const machine = info.machine ? `${info.machine}, ` : '';
+  return `${when} - ${info.df0 ?? 'no disk'} (${machine}${Math.round(info.emulated ?? 0)}s emulated)`;
 }
 
 // Enablement follows what each control can actually do right now: saving
@@ -1708,6 +1889,7 @@ function unbootAfterFailedStateLoad() {
   running = false;
   paused = false;
   setPauseLabel();
+  syncWakeLock();
   overlay.style.display = '';
   refreshBootButton();
   setLoadStatus(failure);
@@ -1732,6 +1914,7 @@ function restoreState(bytes, source) {
   if (monoAudioToggle) emu.set_mono_audio(monoAudioToggle.checked);
   else if (configMonoAudio !== null) emu.set_mono_audio(configMonoAudio);
   if (floppySpeed !== null) emu.set_floppy_speed(floppySpeed);
+  if (overscanMode !== null) emu.set_overscan?.(overscanMode);
   // Port fittings live on the machine, so the pads plugged into the host go
   // back into the restored one, exactly as after a boot. Port 1 is the
   // mouse socket first: a state saved while a pad occupied it would
@@ -1744,8 +1927,9 @@ function restoreState(bytes, source) {
   df0Name = emu.disk_name(0) ?? null;
   lastFddTrack = null;
   updateStatusDisks();
-  // So did the machine itself, model and all.
+  // So did the machine itself, model, video standard and all.
   syncMachineSelect();
+  syncVideoSelect();
   // Paint the restored screen now: a load into a paused machine steps no
   // frames, so nothing else would.
   presentFrame();
@@ -1810,6 +1994,7 @@ async function quickSaveState() {
   quickStateInfo = info;
   updateStateButtons();
   setLoadStatus(`quick state saved in this browser (${Math.round(bytes.length / 1024)} KB)`);
+  refreshStatesPanel();
 }
 
 async function quickLoadState() {
@@ -1860,6 +2045,7 @@ function buildMachineControls() {
     ['loadstate', 'Load state...'],
     ['quicksave', 'Quick save'],
     ['quickload', 'Quick load'],
+    ['savedstates', 'Saved states...'],
   ].filter(([id]) => !$(id));
   if (missing.length === 0) return;
   const row = document.createElement('div');
@@ -1908,6 +2094,269 @@ if (loadStateBtn) {
 }
 updateStateButtons();
 probeQuickState();
+
+// --- saved-states panel ------------------------------------------------
+// One place to see everything this browser remembers: the Kickstart the
+// pickers stored, the quick slot, and named save states - the browser's
+// version of a desktop save-state folder. The panel is glue-built (a
+// shell only needs the #savedstates button, self-inserted like the other
+// state controls) and lists each state with Load / Export / Delete, plus
+// a name box that saves the running machine under a named slot. Export
+// downloads the stored blob as the same .clstate file "Save state"
+// writes, so a browser-kept state can still move to a desktop build.
+
+let statesPanel = null; // { root, list, name, save } - built lazily
+let statesPanelOpen = false;
+// Refresh generation: an await inside a stale refresh must not rebuild
+// the list a newer refresh already built.
+let statesPanelRefresh = 0;
+
+const PANEL_BTN_CSS =
+  'padding:0.15rem 0.55rem;border-radius:6px;cursor:pointer;' +
+  'border:1px solid rgba(255,255,255,0.35);' +
+  'background:rgba(10,13,22,0.6);color:rgba(255,255,255,0.85);' +
+  'font:600 0.75rem "IBM Plex Mono",ui-monospace,monospace;';
+
+function ensureStatesPanel() {
+  if (statesPanel) return statesPanel;
+  const root = document.createElement('div');
+  root.id = 'savedstates-panel';
+  root.style.cssText =
+    'display:none;margin:0.6rem 0;padding:0.55rem 0.75rem;' +
+    'border:1px solid rgba(255,255,255,0.25);border-radius:8px;' +
+    'background:rgba(10,13,22,0.55);color:rgba(255,255,255,0.85);' +
+    'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;';
+  const list = document.createElement('div');
+  const saveRow = document.createElement('div');
+  saveRow.style.cssText =
+    'display:flex;flex-wrap:wrap;gap:0.45rem;align-items:center;margin-top:0.55rem;';
+  const name = document.createElement('input');
+  name.type = 'text';
+  name.placeholder = 'name this state';
+  name.maxLength = 60;
+  name.style.cssText =
+    'flex:1;min-width:10rem;padding:0.25rem 0.5rem;border-radius:6px;' +
+    'border:1px solid rgba(255,255,255,0.35);background:rgba(10,13,22,0.6);' +
+    'color:rgba(255,255,255,0.85);font:inherit;';
+  const save = document.createElement('button');
+  save.textContent = 'Save new';
+  save.style.cssText = PANEL_BTN_CSS;
+  save.addEventListener('click', () => saveNamedState(name.value));
+  // Typing a name must reach neither the guest's keyboard nor the page's
+  // joystick mapping; Enter saves, like the button.
+  const fence = (e) => {
+    e.stopPropagation();
+    if (e.type === 'keydown' && e.key === 'Enter') saveNamedState(name.value);
+  };
+  name.addEventListener('keydown', fence);
+  name.addEventListener('keyup', fence);
+  root.appendChild(list);
+  saveRow.appendChild(name);
+  saveRow.appendChild(save);
+  root.appendChild(saveRow);
+  shell.insertAdjacentElement('afterend', root);
+  statesPanel = { root, list, name, save };
+  return statesPanel;
+}
+
+function toggleStatesPanel() {
+  statesPanelOpen = !statesPanelOpen;
+  const panel = ensureStatesPanel();
+  panel.root.style.display = statesPanelOpen ? '' : 'none';
+  if (statesPanelOpen) refreshStatesPanel();
+}
+
+function stateKeyName(key) {
+  return key === QUICK_SLOT ? 'Quick slot' : key.slice(NAMED_SLOT_PREFIX.length);
+}
+
+// Everything the states store holds, bytes left behind: the panel only
+// needs each state's metadata and size, not megabytes of machine.
+async function listStoredStates() {
+  const rows = [];
+  await withStateDb('readonly', (store) => {
+    const req = store.openCursor();
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (!cursor) return;
+      const key = String(cursor.key);
+      if (key === QUICK_SLOT || key.startsWith(NAMED_SLOT_PREFIX)) {
+        const { bytes, ...info } = cursor.value ?? {};
+        rows.push({ key, size: bytes?.length ?? 0, info });
+      }
+      cursor.continue();
+    };
+    return req;
+  });
+  rows.sort((a, b) => {
+    // The quick slot first (it has its own buttons and its own meaning),
+    // then named states newest first.
+    if (a.key === QUICK_SLOT) return -1;
+    if (b.key === QUICK_SLOT) return 1;
+    return (b.info.saved?.getTime?.() ?? 0) - (a.info.saved?.getTime?.() ?? 0);
+  });
+  return rows;
+}
+
+// Rebuild the panel from storage. Called whenever stored content changes;
+// a closed (or never-built) panel skips the storage round trip.
+async function refreshStatesPanel() {
+  if (!statesPanel || !statesPanelOpen) return;
+  const token = ++statesPanelRefresh;
+  let rows = null;
+  let storageError = null;
+  try {
+    rows = await listStoredStates();
+  } catch (e) {
+    storageError = e;
+  }
+  if (token !== statesPanelRefresh || !statesPanelOpen) return;
+  const { list } = statesPanel;
+  statesPanel.save.disabled = !(emu && running);
+  statesPanel.save.title = emu && running ? '' : 'boot a machine first';
+  list.textContent = '';
+  const mkRow = () => {
+    const row = document.createElement('div');
+    row.style.cssText =
+      'display:flex;flex-wrap:wrap;align-items:center;gap:0.45rem;padding:0.18rem 0;';
+    list.appendChild(row);
+    return row;
+  };
+  const mkText = (row, text, muted) => {
+    const s = document.createElement('span');
+    s.textContent = text;
+    s.style.cssText = `flex:1;min-width:12rem;${muted ? 'color:rgba(255,255,255,0.55);' : ''}`;
+    row.appendChild(s);
+    return s;
+  };
+  const mkBtn = (row, label, fn) => {
+    const b = document.createElement('button');
+    b.textContent = label;
+    b.style.cssText = PANEL_BTN_CSS;
+    b.addEventListener('click', fn);
+    row.appendChild(b);
+    return b;
+  };
+  const romRow = mkRow();
+  if (storedRomInfo) {
+    mkText(
+      romRow,
+      `Kickstart: ${storedRomInfo.label} (${Math.round(storedRomInfo.size / 1024)} KB) - remembered for your next visit`,
+    );
+    mkBtn(romRow, 'Forget', forgetStoredRom);
+  } else {
+    mkText(romRow, 'Kickstart: none remembered - load one and it sticks', true);
+  }
+  if (storageError) {
+    mkText(mkRow(), `browser storage unavailable: ${storageError.message ?? storageError}`, true);
+    return;
+  }
+  if (!rows.length) {
+    mkText(mkRow(), 'no states saved in this browser yet', true);
+    return;
+  }
+  for (const { key, size, info } of rows) {
+    const row = mkRow();
+    mkText(row, `${stateKeyName(key)} - ${describeState(info)}, ${Math.round(size / 1024)} KB`);
+    mkBtn(row, 'Load', () => loadStoredState(key));
+    mkBtn(row, 'Export', () => exportStoredState(key));
+    mkBtn(row, 'Delete', () => deleteStoredState(key));
+  }
+}
+
+async function saveNamedState(rawName) {
+  if (!emu || !running) return;
+  const name = String(rawName ?? '').trim();
+  if (!name) {
+    setLoadStatus('give the state a name first');
+    return;
+  }
+  let record;
+  try {
+    record = stateRecord(emu.save_state());
+  } catch (e) {
+    setLoadStatus(`save failed: ${e.message ?? e}`);
+    return;
+  }
+  try {
+    // put() replaces an existing state of the same name, which is what
+    // re-saving under a name means.
+    await withStateDb('readwrite', (store) => store.put(record, NAMED_SLOT_PREFIX + name));
+  } catch (e) {
+    const hint = e.name === 'QuotaExceededError' ? ' - browser storage is full' : '';
+    setLoadStatus(`save failed: ${e.message ?? e}${hint}`);
+    return;
+  }
+  if (statesPanel) statesPanel.name.value = '';
+  setLoadStatus(`state "${name}" saved in this browser (${Math.round(record.bytes.length / 1024)} KB)`);
+  refreshStatesPanel();
+}
+
+async function getStoredState(key) {
+  return withStateDb('readonly', (store) => store.get(key));
+}
+
+async function loadStoredState(key) {
+  let record;
+  try {
+    record = await getStoredState(key);
+  } catch (e) {
+    setLoadStatus(`load failed: ${e.message ?? e}`);
+    return;
+  }
+  if (!record?.bytes) {
+    setLoadStatus('that state is no longer in browser storage');
+    refreshStatesPanel();
+    return;
+  }
+  const machine = await machineForStateLoad();
+  if (!machine.ready) return;
+  if (!restoreState(record.bytes, `"${stateKeyName(key)}"`) && machine.booted) {
+    unbootAfterFailedStateLoad();
+  }
+}
+
+async function exportStoredState(key) {
+  let record;
+  try {
+    record = await getStoredState(key);
+  } catch (e) {
+    setLoadStatus(`export failed: ${e.message ?? e}`);
+    return;
+  }
+  if (!record?.bytes) {
+    setLoadStatus('that state is no longer in browser storage');
+    refreshStatesPanel();
+    return;
+  }
+  const blob = new Blob([record.bytes], { type: 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${stateKeyName(key).replace(/[^\w.-]+/g, '_')}.clstate`;
+  a.click();
+  // Revoking synchronously can cancel the download that click just
+  // started; let the current task finish first (as for screenshots).
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  setLoadStatus(`state "${stateKeyName(key)}" downloaded`);
+}
+
+async function deleteStoredState(key) {
+  try {
+    await withStateDb('readwrite', (store) => store.delete(key));
+  } catch (e) {
+    setLoadStatus(`delete failed: ${e.message ?? e}`);
+    return;
+  }
+  if (key === QUICK_SLOT) {
+    quickStateInfo = null;
+    updateStateButtons();
+  }
+  setLoadStatus(`state "${stateKeyName(key)}" deleted`);
+  refreshStatesPanel();
+}
+
+$('savedstates')?.addEventListener('click', toggleStatesPanel);
 
 // Optional in the page shell: a checkbox #floppy-sounds toggles the
 // synthesized drive sounds (motor hum, head-step clicks, read hiss).
@@ -1995,17 +2444,19 @@ floppySpeedSel.addEventListener('change', () => {
 
 const MACHINE_LABELS = { A500: 'A500', A1200: 'A1200 (AGA)' };
 
-function buildMachineControl() {
+// A labelled select below the canvas shell, the machine control's pattern,
+// shared by every self-inserted setting. Carries the hook id even when
+// self-built (like the self-inserted buttons), so page-side scripts can
+// drive the control either way.
+function buildSettingControl(id, labelText) {
   const row = document.createElement('label');
   row.style.cssText =
     'display:inline-flex;align-items:center;gap:0.45rem;margin:0.4rem 0.6rem 0.4rem 0;' +
     'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;' +
     'color:rgba(255,255,255,0.75);';
-  row.appendChild(document.createTextNode('Machine'));
+  row.appendChild(document.createTextNode(labelText));
   const sel = document.createElement('select');
-  // Carry the hook id even when self-built (like the self-inserted
-  // buttons), so page-side scripts can drive the control either way.
-  sel.id = 'machine';
+  sel.id = id;
   sel.style.cssText =
     'padding:0.15rem 0.4rem;border-radius:6px;cursor:pointer;' +
     'border:1px solid rgba(255,255,255,0.35);' +
@@ -2016,7 +2467,7 @@ function buildMachineControl() {
   return sel;
 }
 const machineShellSel = $('machine');
-const machineSel = machineShellSel ?? buildMachineControl();
+const machineSel = machineShellSel ?? buildSettingControl('machine', 'Machine');
 // null = the wasm default machine (the A500); boot() passes it through.
 let machineModel = null;
 // A ?machine=/config/data-default choice that arrived before the model
@@ -2101,6 +2552,199 @@ machineSel.addEventListener('change', () => {
     setLoadStatus(`machine: ${model} - applies at boot`);
   }
 });
+
+// --- video standard ----------------------------------------------------
+// PAL or NTSC, the desktop's `[chipset] video` key. Like the machine
+// model this is the board itself - the Agnus crystal - not a knob on it,
+// so it follows the machine select's pattern exactly: always visible
+// (self-inserting without a shell `#video` select), rebuilding a running
+// machine on change with the ROM and disk carried over, preset by the
+// config file's "video" or `?video=NTSC` in the URL, synced to whatever a
+// save state brings back, and hidden on a wasm bundle too old to take a
+// standard (`WebEmu.video_standards` is the feature test).
+
+const videoShellSel = $('video');
+const videoSel = videoShellSel ?? buildSettingControl('video', 'Video');
+// null = the profile's own standard (PAL); boot() passes it through.
+let videoStandard = null;
+// A ?video=/config/data-default choice that arrived before the standards
+// list did; applied once both exist.
+let requestedVideo = null;
+
+function matchVideoOption(name) {
+  const norm = (s) => String(s).trim().toUpperCase();
+  return [...videoSel.options].map((o) => o.value).find((v) => v && norm(v) === norm(name));
+}
+
+function tryApplyRequestedVideo() {
+  if (requestedVideo === null || !videoSel.options.length) return;
+  const name = String(requestedVideo).trim();
+  requestedVideo = null;
+  if (!name) return;
+  const std = matchVideoOption(name);
+  if (std) {
+    videoStandard = std;
+    videoSel.value = std;
+  } else {
+    console.warn(`unknown video standard ${name}; keeping ${videoSel.value}`);
+  }
+}
+
+// Called once the wasm module is ready (load()), like the machine select.
+function populateVideoSelect() {
+  let standards = null;
+  try {
+    standards = WebEmu.video_standards?.();
+  } catch {
+    standards = null;
+  }
+  if (!standards?.length) {
+    (videoShellSel ?? videoSel.parentElement).hidden = true;
+    return;
+  }
+  if (!videoSel.options.length) {
+    for (const name of standards) {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      videoSel.appendChild(option);
+    }
+  }
+  // From here on every boot names its standard explicitly, like the model.
+  if (videoStandard === null) videoStandard = videoSel.value || null;
+  tryApplyRequestedVideo();
+}
+
+// A restored state carries its machine's standard; point the select at
+// what is actually running (the getter follows load_state).
+function syncVideoSelect() {
+  const std = emu?.video_standard?.();
+  if (!std) return;
+  const match = matchVideoOption(std);
+  if (match) {
+    videoStandard = match;
+    videoSel.value = match;
+  }
+}
+
+videoSel.addEventListener('change', () => {
+  const std = videoSel.value;
+  if (!std || std === videoStandard) return;
+  videoStandard = std;
+  if (emu && running) {
+    // The machine select's rebuild, for the same reason: the standard is
+    // soldered in. ROM and disk carry over the same way.
+    if (df0Name && lastDisk?.name === df0Name) pendingDisk = lastDisk;
+    boot();
+  } else if (!emu) {
+    setLoadStatus(`video: ${std} - applies at boot`);
+  }
+});
+
+// --- display: overscan and screen tint -----------------------------------
+// Presentation-only choices, so unlike the machine and video standard they
+// are remembered per browser (localStorage) and re-applied on the next
+// visit: nothing the guest can observe changes, only what the glass shows.
+//
+// Overscan is the desktop's `[display] overscan` knob: "tv" (default)
+// masks the deep horizontal overscan like a CRT bezel and crops standard
+// PAL screens to the TV aperture; "full" shows everything Denise produced.
+// The tint is a monitor phosphor choice rendered as a CSS filter on the
+// canvas - pure presentation, zero per-frame cost, and baked into
+// screenshots via a filtered copy (see copyScreenshot).
+
+function storedPref(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storePref(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Private browsing or blocked storage: the choice just does not stick.
+  }
+}
+
+const OVERSCAN_STORAGE_KEY = 'copperline-overscan';
+const OVERSCAN_MODES = ['tv', 'full'];
+const OVERSCAN_LABELS = { tv: 'TV', full: 'Full overscan' };
+
+const overscanShellSel = $('overscan');
+const overscanSel = overscanShellSel ?? buildSettingControl('overscan', 'View');
+if (!overscanSel.options.length) {
+  for (const mode of OVERSCAN_MODES) {
+    const option = document.createElement('option');
+    option.value = mode;
+    option.textContent = OVERSCAN_LABELS[mode];
+    overscanSel.appendChild(option);
+  }
+}
+// Hidden on a bundle that cannot switch (the class methods exist as soon
+// as the module is imported, so no need to wait for init()).
+if (typeof WebEmu.prototype?.set_overscan !== 'function') {
+  (overscanShellSel ?? overscanSel.parentElement).hidden = true;
+}
+let overscanMode = null; // null = leave the emulator at its default (tv)
+
+function setOverscanMode(mode, remember) {
+  if (!OVERSCAN_MODES.includes(mode)) return;
+  overscanMode = mode;
+  overscanSel.value = mode;
+  if (remember) storePref(OVERSCAN_STORAGE_KEY, mode);
+  if (emu) {
+    emu.set_overscan?.(mode);
+    // The wasm re-presents the last frame under the new aperture, but a
+    // paused page has no ticking loop to blit it.
+    if (running && paused) presentFrame();
+  }
+}
+overscanSel.addEventListener('change', () => setOverscanMode(overscanSel.value, true));
+
+const TINT_STORAGE_KEY = 'copperline-tint';
+// Phosphor approximations: grayscale first so the sepia+hue chain works
+// from luminance, saturate to pull the single-hue look together.
+const TINTS = {
+  none: { label: 'Colour', filter: '' },
+  bw: { label: 'Black & white', filter: 'grayscale(1)' },
+  green: {
+    label: 'Green phosphor',
+    filter: 'grayscale(1) sepia(1) saturate(4) hue-rotate(80deg) brightness(0.92)',
+  },
+  amber: {
+    label: 'Amber phosphor',
+    filter: 'grayscale(1) sepia(1) saturate(4) hue-rotate(-8deg)',
+  },
+  sepia: { label: 'Sepia', filter: 'sepia(1)' },
+};
+
+const tintShellSel = $('tint');
+const tintSel = tintShellSel ?? buildSettingControl('tint', 'Screen');
+if (!tintSel.options.length) {
+  for (const [value, { label }] of Object.entries(TINTS)) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    tintSel.appendChild(option);
+  }
+}
+let tintMode = 'none';
+
+function tintFilter() {
+  return TINTS[tintMode]?.filter ?? '';
+}
+
+function setTintMode(mode, remember) {
+  if (!TINTS[mode]) return;
+  tintMode = mode;
+  tintSel.value = mode;
+  if (remember) storePref(TINT_STORAGE_KEY, mode);
+  canvas.style.filter = tintFilter();
+}
+tintSel.addEventListener('change', () => setTintMode(tintSel.value, true));
 
 // --- status bar --------------------------------------------------------
 // Front-panel status strip mirroring the desktop status bar's LED block:
@@ -2517,11 +3161,16 @@ const pageParams = new URLSearchParams(location.search);
 //
 //   {
 //     "machine": "A1200",            machine model (WebEmu.models() lists them)
+//     "video": "NTSC",               video standard, like ?video= (PAL|NTSC)
 //     "kick": "roms/kick31.rom",     same-origin path, like ?kick=
 //     "df0": "adf/demo.adf",         URL, like ?df0=
 //     "floppy_sounds": false,        preset the drive-sounds toggle
 //     "mono_audio": true,            preset the mono-audio toggle
 //     "floppy_speed": 800,           100|200|400|800|0 (0 = turbo)
+//     "overscan": "full",            starting view (tv|full); a visitor's
+//                                    own remembered choice wins
+//     "tint": "green",               starting screen tint (none|bw|green|
+//                                    amber|sepia); same visitor rule
 //     "joy": "keys",                 off|keys|cd32|touch
 //     "serial_url": "wss://...",     preset the BBS gateway input
 //     "serial_raw": true,            preset the raw checkbox
@@ -2541,8 +3190,11 @@ async function fetchPageConfig() {
 async function startup() {
   // The wasm + AROS download starts immediately; the config fetch rides
   // alongside and its choices land before anything needs them (a config
-  // Kickstart simply replaces the stashed boot ROM when it arrives).
+  // Kickstart simply replaces the stashed boot ROM when it arrives). The
+  // remembered-Kickstart probe rides along too: it only ever fills an
+  // empty or AROS boot stash, so it cannot beat an explicit choice.
   const loaded = load();
+  probeStoredRom();
   const cfg = await fetchPageConfig();
 
   if (serialUrlInput && typeof cfg.serial_url === 'string') {
@@ -2579,6 +3231,28 @@ async function startup() {
     machineSel.dataset.default ??
     null;
   tryApplyRequestedMachine();
+
+  // Starting video standard, the machine pattern: shell data-default or
+  // config "video", overridden per link by ?video=NTSC (names compare
+  // case-insensitively). Applied once the wasm module has supplied the
+  // standards list.
+  requestedVideo =
+    pageParams.get('video') ??
+    (typeof cfg.video === 'string' ? cfg.video : null) ??
+    videoSel.dataset.default ??
+    null;
+  tryApplyRequestedVideo();
+
+  // Starting view and tint: the visitor's own remembered choice first
+  // (these are per-browser viewing preferences), then the config file's
+  // starting point for first-time visitors.
+  const overscanPref =
+    storedPref(OVERSCAN_STORAGE_KEY) ??
+    (typeof cfg.overscan === 'string' ? cfg.overscan.trim() : null);
+  if (overscanPref) setOverscanMode(overscanPref, false);
+  const tintPref =
+    storedPref(TINT_STORAGE_KEY) ?? (typeof cfg.tint === 'string' ? cfg.tint.trim() : null);
+  if (tintPref) setTintMode(tintPref, false);
 
   // Starting joystick mode: the page shell's default (data-default on the
   // toggle or the config file), overridden per link by

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -18,7 +18,14 @@ machine and powers it up again -- the model is the board itself, not a
 knob on it -- keeping the chosen ROM and the inserted disk. A link can
 preset the model with `?machine=A1200`, and a
 [save state](#browser-save-states) carries its own machine, so loading
-one switches the select to whatever the state brings back. The
+one switches the select to whatever the state brings back. The **Video**
+select is the same idea for the standard: PAL (the default) or NTSC (the
+desktop's `[chipset] video` key) -- the standard is the Agnus crystal,
+so changing it rebuilds a running machine exactly like the model select,
+and `?video=NTSC` presets it per link. NTSC wants a real Kickstart: the
+bundled AROS ROM cannot open its boot screen on an NTSC chipset (it
+gurus "unknown type of system screen" and reboot-loops, which looks
+like a black screen; the page says so when it happens). The
 page fetches the open-source AROS ROM while it loads, so the boot button
 works with no files of your own; the **Kickstart ROM** and **DF0 disk**
 pickers load local images instead. Both work before or after boot: a
@@ -30,6 +37,32 @@ the browser has no filesystem to write changes back to. On iOS the pickers
 offer every file rather than filtering by extension, because the system
 document picker greys out extensions it does not recognise, which would
 lock out `.adf` and friends.
+
+A Kickstart that fits is also *remembered*: the image goes into the
+browser's own storage (IndexedDB, never uploaded anywhere), and the next
+visit boots it with no picker round trip -- the boot button simply reads
+"Boot Kickstart" again. An explicit choice always wins over the memory
+(the picker, a drop, `?kick=`), and the
+[saved-states panel](#browser-save-states) shows what is remembered with
+a **Forget** button that puts the boot button back on AROS.
+
+Two more selects shape what the glass shows without touching the
+machine. **View** is the desktop's `[display] overscan` knob: *TV* (the
+default) masks the deep horizontal overscan like a CRT bezel and crops
+standard PAL screens to a TV aperture, *Full overscan* presents the
+whole field Denise produced -- junk pixels, border tricks and all.
+**Screen** tints the picture like a monochrome monitor's phosphor --
+black & white, green, amber, or sepia -- applied as a CSS filter on the
+canvas (zero per-frame cost; screenshots bake it in). Both are viewing
+preferences rather than machine state, so the page remembers them in the
+browser and restores them on the next visit; the machine and video
+selects deliberately reset instead, because a shared `?df0=` link should
+boot the same machine for everyone.
+
+While a machine runs (and is not paused), the page holds a screen wake
+lock where the browser supports one, the way a video player does: a demo
+or a long loading sequence is exactly the hands-off viewing that trips a
+host's idle timeout. Pausing or stopping releases it.
 
 Files can also be dragged onto the page: a `.rom` file loads (or, before
 boot, queues) a Kickstart exactly like the ROM picker, a `.clstate` file
@@ -155,6 +188,15 @@ does not place them:
 - **Quick load** restores that slot. It is enabled only when the browser
   holds a quick state, and its tooltip says when the state was taken,
   what was in DF0, and how far the machine had run.
+- **Saved states...** opens the panel over everything the browser
+  remembers: the stored Kickstart (with its **Forget** button), the quick
+  slot, and *named* states -- type a name and **Save new** keeps the
+  running machine under it, as many as browser storage will hold, so one
+  browser can park several games at once rather than fighting over the
+  quick slot. Each row has **Load**, **Export** (downloads the stored
+  state as the same `.clstate` file Save state writes, so a browser-kept
+  state can still move to a desktop build), and **Delete**; saving under
+  an existing name replaces it.
 
 Loading works from a cold page: with no machine booted, a load boots one
 and restores over it, so a visitor returning to a game lands straight back
@@ -297,21 +339,28 @@ function tick(nowMs) {
 }
 ```
 
-The constructor's optional argument picks the machine profile by name,
-exactly as the desktop's `--model` flag does ("A500", "A1200", ...);
+The constructor's first optional argument picks the machine profile by
+name, exactly as the desktop's `--model` flag does ("A500", "A1200", ...);
 omitted, it builds the default A500, so pages written against the
 model-less constructor keep booting what they always did. The static
 `WebEmu.models()` lists the vetted profiles a page can offer
 unconditionally (currently `A500` and `A1200` -- both boot AROS or a
 plain Kickstart with nothing but a floppy; other names the desktop flag
 takes are accepted too, but CDTV/CD32 want pieces a browser page cannot
-supply), and its absence on an older bundle is the feature test.
-`machine_model()` returns the running machine's profile name
+supply), and its absence on an older bundle is the feature test. The
+second optional argument picks the video standard on top of the profile
+(`new WebEmu('A500', 'NTSC')`), the desktop's `[chipset] video` key;
+omitted, the profile keeps its own (PAL for every offered profile).
+`WebEmu.video_standards()` lists the accepted names and is the matching
+feature test. `machine_model()` returns the running machine's profile name
 (`undefined` for a shape no profile describes, such as a state saved
 from a custom desktop config) and follows `load_state`, so a page can
 re-point its machine select at what a state brought back;
+`video_standard()` does the same for the standard ("PAL"/"NTSC" -- the
+fitted Agnus crystal, not the live BEAMCON0 bit ECS software can flip);
 `machine_summary()` is a one-line description of the machine -- profile,
-CPU, chipset, RAM, ROM fingerprint -- for bug reports and diagnostics.
+CPU, chipset, video standard, RAM, ROM fingerprint -- for bug reports
+and diagnostics.
 
 Input goes through `key_event(event.code, pressed)` (returns whether the key
 mapped, for `preventDefault`), `mouse_delta(dx, dy)` and
@@ -355,6 +404,12 @@ default, leaving Paula's hardware stereo panning.
 drive speed -- 100/200/400/800 percent, or 0 for turbo -- like the
 desktop's `[floppy] speed` option (see
 [Configuration](configuration.md)); changes apply to the live machine.
+`set_overscan(mode)` picks the presentation overscan, the desktop's
+`[display] overscan` knob: `"tv"` (the default) masks the deep
+horizontal overscan like a CRT bezel and presents standard PAL screens
+as the captured TV aperture, `"full"` presents the whole overscan field;
+unknown names are ignored. The last completed frame is re-presented
+under the new aperture immediately, so a paused page only has to blit.
 Front-panel status getters mirror the desktop status bar's LED block and
 are cheap enough to poll every frame: `power_led()` and `fdd_led()` return
 booleans, `hdd_led()` and `cd_led()` return `undefined` on machines
@@ -404,6 +459,25 @@ elements, and pages without them are untouched:
   rebuilds a running machine as described above; `?machine=` in the URL
   overrides the initial choice (model names match the way the core parses
   them, so `?machine=a1200` works).
+- `#video` (a `<select>`): hosts the PAL/NTSC video standard control,
+  the machine select's pattern exactly -- always on (self-inserting
+  without the element, carrying the `video` id), filled from
+  `WebEmu.video_standards()` unless the shell ships its own options,
+  preset by `data-default="NTSC"`, hidden on a wasm bundle too old to
+  take a standard, and rebuilding a running machine on change with the
+  ROM and disk carried over. `?video=` in the URL overrides the initial
+  choice (names compare case-insensitively, so `?video=ntsc` works).
+- `#overscan` (a `<select>` with option values `tv` and `full`): hosts
+  the presentation overscan control (**View** on the hosted page), always
+  on and self-inserting like `#video`. Changes apply live, including to a
+  paused machine; the choice is a viewing preference, so the glue
+  remembers it in the browser (localStorage) and restores it next visit.
+  Hidden on a wasm bundle without `set_overscan`.
+- `#tint` (a `<select>`): the screen tint (**Screen** on the hosted
+  page) -- `none`, `bw`, `green`, `amber`, `sepia` -- rendered as a CSS
+  filter on the canvas and baked into screenshots. Always on,
+  self-inserting, and remembered in the browser like `#overscan`; it
+  never touches the wasm, so it works with any bundle.
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
   `800`, and `0` for turbo): hosts the floppy drive speed control, letting
   the page place and style it. Unlike the other hooks this one is always
@@ -450,13 +524,16 @@ elements, and pages without them are untouched:
   write (an unfocused document, an insecure origin); the caption over the
   screen says which happened, since a clipboard copy has nothing else to
   show for itself.
-- `#savestate`, `#loadstate`, `#quicksave`, `#quickload` (buttons): the
-  [save-state controls](#browser-save-states) -- download a state, pick a
-  state file, and the browser-resident quick slot. Always on like
-  `#pause`: without the elements they insert themselves below the canvas
-  shell. `#loadstate` is a plain button wherever the shell puts it; the
-  file picker behind it is built by the glue, so no `<input type="file">`
-  is needed in the shell.
+- `#savestate`, `#loadstate`, `#quicksave`, `#quickload`, `#savedstates`
+  (buttons): the [save-state controls](#browser-save-states) -- download
+  a state, pick a state file, the browser-resident quick slot, and the
+  saved-states panel (named states, the quick slot, and the remembered
+  Kickstart with its Forget button; the panel itself is glue-built, the
+  shell only places the button). Always on like `#pause`: without the
+  elements they insert themselves below the canvas shell. `#loadstate`
+  is a plain button wherever the shell puts it; the file picker behind
+  it is built by the glue, so no `<input type="file">` is needed in the
+  shell.
 - `#ledbar` (a container): hosts the front-panel status strip (LEDs,
   track counter, disk names), letting the page own its placement and
   outer styling. Without it the strip inserts itself directly below the
@@ -480,11 +557,14 @@ per URL, and anything the visitor changes by hand wins as usual:
 ```json
 {
   "machine": "A1200",
+  "video": "NTSC",
   "kick": "roms/kick31.rom",
   "df0": "adf/demo.adf",
   "floppy_sounds": false,
   "mono_audio": true,
   "floppy_speed": 800,
+  "overscan": "full",
+  "tint": "green",
   "joy": "keys",
   "serial_url": "wss://bbs.example.com:8443/",
   "serial_raw": false,
@@ -492,14 +572,17 @@ per URL, and anything the visitor changes by hand wins as usual:
 }
 ```
 
-`machine` picks the machine model, like `?machine=`; `kick` follows the
+`machine` picks the machine model, like `?machine=`; `video` the PAL/NTSC
+standard, like `?video=`; `kick` follows the
 same-origin rule as `?kick=` (the file can only name a ROM the site
 already serves); `df0` is any URL the visitor's browser may fetch, like
 `?df0=`. `floppy_sounds`, `mono_audio`, and
 `floppy_speed` reach the machine whether or not the shell has their
 controls -- the speed select inserts itself, and a configured
 `floppy_sounds` or `mono_audio` is applied at boot even with no checkbox
-to show it. `serial_url` and `serial_raw` preset the
+to show it. `overscan` and `tint` are starting points for first-time
+visitors only: both are per-browser viewing preferences the glue
+remembers, and a visitor's own remembered choice wins over the file. `serial_url` and `serial_raw` preset the
 serial bridge's inputs and therefore need those elements: a shell
 without them has no connect button to dial with either. `joy` picks the
 starting joystick mode. `autoboot: true` powers the machine on by itself once the

--- a/src/config.rs
+++ b/src/config.rs
@@ -3664,7 +3664,10 @@ fn parse_denise_revision(s: &str) -> Result<DeniseRevision> {
     }
 }
 
-fn parse_video_standard(s: &str) -> Result<VideoStandard> {
+/// Public for the browser frontend (crates/copperline-web), whose `WebEmu`
+/// constructor takes the same PAL/NTSC names as the `[chipset] video` key,
+/// like `parse_machine_model`.
+pub fn parse_video_standard(s: &str) -> Result<VideoStandard> {
     match s.trim().to_ascii_uppercase().as_str() {
         "PAL" => Ok(VideoStandard::Pal),
         "NTSC" => Ok(VideoStandard::Ntsc),


### PR DESCRIPTION
## What

Three browser-build features (the agreed items from the vAmigaWeb gap review):

**Display options**
- `WebEmu` takes an optional video standard next to the model (`new WebEmu('A500', 'NTSC')`, the desktop's `[chipset] video` key), with `WebEmu.video_standards()` as the feature test and `video_standard()` tracking state loads. The page's new **Video** select follows the machine select's pattern (rebuild on change, `?video=`, config key, state-load sync).
- `set_overscan("tv"|"full")` carries `[display] overscan` into the browser render path (bezel mask + TV-aperture crop vs the full field, recentred via the same `presentation_h_shift_for` the desktop uses). Page control: **View**.
- **Screen** tint (b/w, green/amber phosphor, sepia) as CSS filters on the canvas, baked into screenshots via a filtered copy. View and Screen persist per browser (localStorage); Video deliberately does not, so shared links boot the same machine for everyone.

**Browser persistence**
- A loaded Kickstart is remembered (IndexedDB v2 adds a `roms` store; v1 upgrades keep the quick state) and boots on the next visit; explicit picks always win, and the panel offers Forget.
- Named save states in the existing states store under `named:` keys, with a glue-built **Saved states...** panel: remembered ROM, quick slot, and named states with Load / Export (`.clstate`) / Delete plus save-new.

**Wake lock** while a machine runs unpaused and visible, so demos and loaders play out unattended.

## AROS on NTSC

The bundled AROS ROM cannot boot an NTSC machine: it gurus `0x84000009 "unknown type of system screen"` (Exec Bootstrap) to the serial port and reboot-loops. Cross-checked against vAmiga headless (v4.4, `VIDEO_FORMAT NTSC`, same rom+ext): AROS never gets past the grey early-boot screen there either and the guest dies between 6 and 8 emulated seconds, while the PAL control boots normally and Kickstart 1.3 boots NTSC fine on both emulators - so this is guest behaviour, not an emulation gap. The page raises an on-screen note when AROS boots on NTSC, and the docs say NTSC wants a real Kickstart.

## Verification

- Full `cargo test --release`, clippy, fmt clean (one pre-existing dead-code warning on main: unused `config::mouse_sensitivity_label`).
- Node smoke suite on the wasm bundle: PAL TV-aperture geometry, overscan switching (668 <-> 716), NTSC construction/getters/summary, unknown-standard throw, NTSC state save -> restore into a PAL-built machine (comes back NTSC-shaped with content), KICK13 NTSC hand screen rendered identically to the desktop.
- Staged-site Chrome session: all four selects populate, machine rebuild on Video change, View/Screen live switching + localStorage persistence, ROM remember -> reload -> "Boot Kickstart" -> Forget, named state save/load from a cold page (select sync back to PAL/A500), corrupt-blob refusal leaves the page unbooted, IndexedDB v1 -> v2 upgrade keeps the quick slot.

Companion shell changes (PWA manifest + service worker + hosted controls) go to the website repository; after this merges, a `wasm-demo` workflow dispatch publishes the matching glue + bundle.