### PR TITLE
console: report ThisTask's own state in TASKS

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -124,6 +124,11 @@ garbage):
 | `CATCHALERT` | Break at exec's `Alert()` entry: fires on every guru/alert with D7 holding the code |
 | `GURU [CODE]` | Decode an alert code (default: the current D7): deadend flag, subsystem, cause, CPU-trap alerts |
 
+`TASKS` prints `ThisTask` on the `>` line with that task's own state, so on
+an idle machine it reads `wait` and appears again in the waiting list below.
+Exec leaves `ThisTask` naming the task it dispatched last, so read the `>`
+line as "last dispatched", not "running".
+
 `EXECBASE` answers "what is the OS doing right now": `IdleCount` and
 `DispCount` say whether exec is dispatching at all, `SysFlags` shows the
 scheduler's pending attention bits, and `IDNestCnt`/`TDNestCnt` decode

--- a/src/amigaos/dump.rs
+++ b/src/amigaos/dump.rs
@@ -113,13 +113,21 @@ pub fn exec(os: &OsMemory, base: u32) -> Vec<String> {
 
 /// TASKS: the scheduled task (marked `>`) plus the ready and waiting
 /// lists, one line each.
+///
+/// The `>` line shows `ThisTask`'s own `tc_State`, so an idle machine reads
+/// `wait` there and lists the task again below: exec leaves `ThisTask`
+/// naming the task it dispatched last.
 pub fn task_list(os: &OsMemory, base: u32) -> Vec<String> {
     let mut lines = Vec::new();
     match os.this_task(base) {
-        Some(task) => lines.push(format!(
-            "> ${:06X}  pri {:>4}  {:<7} {}",
-            task.addr, task.pri, "run", task.name
-        )),
+        Some(task) => {
+            let state = super::task_state_name(task.state);
+            let state = if state == "?" { "this" } else { state };
+            lines.push(format!(
+                "> ${:06X}  pri {:>4}  {:<7} {}",
+                task.addr, task.pri, state, task.name
+            ))
+        }
         None => lines.push("!ThisTask is not plausible".to_string()),
     }
     for (list, label) in [(OsList::TaskReady, "ready"), (OsList::TaskWait, "wait")] {

--- a/src/amigaos/dump.rs
+++ b/src/amigaos/dump.rs
@@ -121,8 +121,10 @@ pub fn task_list(os: &OsMemory, base: u32) -> Vec<String> {
     let mut lines = Vec::new();
     match os.this_task(base) {
         Some(task) => {
-            let state = super::task_state_name(task.state);
-            let state = if state == "?" { "this" } else { state };
+            let state = match super::task_state_name(task.state) {
+                "?" => format!("?${:02X}", task.state),
+                name => name.to_string(),
+            };
             lines.push(format!(
                 "> ${:06X}  pri {:>4}  {:<7} {}",
                 task.addr, task.pri, state, task.name


### PR DESCRIPTION
The `>` line in `TASKS` hardcoded `run`, which contradicted the same task
appearing as `wait` in the waiting list just below it. On an idle machine
that made the output look self-inconsistent.

Exec leaves `ThisTask` pointing at whichever task it dispatched last, and
`Wait()` has already moved that task to the waiting list, so both readings
are correct - the `>` line just should not claim the task is running.
Follow `tc_State` instead, and say so in the console chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)