### PR TITLE
video: [display] tint - bw/green/amber/sepia screen filters

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -363,6 +363,10 @@ video = "PAL"
 # shader-processed, so captures stay comparable whatever is set here.
 # shader_strength: how strongly the shader is mixed in, 0.0-1.0 (default
 # 1.0, the preset's full effect); 0.0 leaves the picture visually untouched.
+# tint: screen tint over the window image. "none" (default, full colour),
+# "bw" (black and white), "green" or "amber" (monochrome-monitor
+# phosphor), or "sepia". Like shader, a window-display effect only:
+# captures are never tinted, and RTG board scanout stays untinted.
 # full_screen: open the window fullscreen at start (default false; also
 # --full-screen / --windowed, and Cmd/Alt+F toggles it live).
 # status_bar: show the status bar at start (default true; also
@@ -373,6 +377,7 @@ video = "PAL"
 # phosphor = 0.4
 # shader = "none"
 # shader_strength = 1.0
+# tint = "none"
 # full_screen = false
 # status_bar = true
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -451,6 +451,7 @@ pixel_aspect = "tv"   # "tv" (default, 4:3 CRT) or "square" (exact 2x2 lo-res)
 phosphor = 0.0        # CRT persistence fraction, 0.0 (off) to 0.95
 shader = "none"       # "none" (default), "scanlines", "mask", "crt", or a .wgsl file
 shader_strength = 1.0 # how strongly the shader is mixed in, 0.0-1.0
+tint = "none"         # "none" (default), "bw", "green", "amber", or "sepia"
 full_screen = false   # open fullscreen at start (default false)
 status_bar = true     # show the status bar at start (default true)
 ```
@@ -522,8 +523,9 @@ texel-snapped pass-through the window otherwise uses at magnification.
 `"none"` skips the pass altogether and is the only truly zero-cost setting.
 
 The menu's *CRT Shader* item cycles the presets live for the rest of the
-session without touching the config file; the launcher's *Display* page has
-*CRT shader* and *Shader strength* rows that do write it.
+session without touching the config file; the launcher's *A/V & Emu* tab
+(*Video* category) has *CRT shader* and *Shader strength* rows that do
+write it.
 `COPPERLINE_SHADER=crt|scanlines|mask|none|PATH.wgsl` and
 `COPPERLINE_SHADER_STRENGTH=0.0..1.0` override the config for a single run.
 There is no command-line flag.
@@ -538,6 +540,22 @@ open (a phosphor mask and a curved face make overlay text unreadable), for
 frames coming from an RTG board's scanout (see `[rtg]` below), and for
 programmable multisync scan modes -- a 31 kHz scanout has no 15 kHz line
 structure to reproduce.
+
+`tint` recolours the picture like the phosphor of a monochrome monitor:
+`"bw"` (black and white), `"green"` and `"amber"` (the two classic
+monochrome phosphors), or `"sepia"`; `"none"` (the default; `"off"` is
+accepted) presents full colour. The same five looks the web frontend's
+*Screen* selector offers, produced by the same colour chain, so a tint
+chosen in the browser matches the desktop. It composes with `shader` --
+green phosphor under the `crt` preset makes a convincing monochrome tube.
+Like the shader, the tint is presentation only: screenshots, frame dumps,
+recordings and headless runs stay untinted, the status bar and overlay
+menus keep their colours, and RTG board scanout (the monitor on the
+board's own output, not the Amiga's video output) is never tinted. The
+menu's *Screen Tint* item cycles the tints live for the rest of the
+session without touching the config file; the launcher's *A/V & Emu* tab
+(*Video* category) has a *Screen tint* row that does write it.
+`COPPERLINE_TINT=bw|green|...` overrides the config for a single run.
 
 ### Custom WGSL shaders
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -189,6 +189,14 @@ tool window or overlay.
   screenshots, frame dumps and recordings are never shader-processed -- and
   it steps aside for the frames it cannot sensibly draw: while this menu or
   any panel is open, under RTG, and in programmable multisync scan modes.
+- **Screen Tint**: cycles the monochrome-monitor tint over the picture --
+  **off** (full colour), **bw**, **green** and **amber** (the two classic
+  monochrome phosphors), and **sepia** -- the same looks as the web
+  frontend's *Screen* selector. Session-only, like the shader; the
+  start-up tint is `[display] tint` (see
+  [Configuration](configuration.md)). A window effect only: captures stay
+  untinted, this menu and the status bar keep their colours, and RTG
+  scanout is never tinted.
 - **Floppy Speed**: cycles the emulated drive speed through 100% (real
   speed), 200%, 400%, 800%, and turbo (disk DMA transfers complete almost
   instantly). Changes apply to the live machine immediately. The start-up
@@ -318,7 +326,7 @@ The layout is:
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
   sounds and volume), **Video** (start fullscreen, status bar, overscan, pixel
-  aspect, phosphor, CRT shader and shader strength), and **Emulation**
+  aspect, screen tint, phosphor, CRT shader and shader strength), and **Emulation**
   (power-on, warp speed, pacing, realtime priority) -- opening on Audio, and
   switched freely between the three.
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,6 +220,9 @@ pub struct Config {
     /// (the preset's full effect, the default). A single knob for every
     /// preset so the effect can be dialled back without editing shaders.
     pub shader_strength: f32,
+    /// Screen tint applied to the window image: the phosphor colour of a
+    /// monochrome monitor, or a sepia treatment. See [`Tint`].
+    pub tint: Tint,
     /// Open the window in fullscreen at start (`[display] full_screen`, or
     /// `--full-screen` / `--windowed`). The `Cmd+F` / `Alt+F` toggle flips it
     /// live without affecting this start-up value.
@@ -365,6 +368,44 @@ impl ShaderKind {
             ShaderKind::Mask => "mask",
             ShaderKind::Crt => "crt",
             ShaderKind::Custom => "custom",
+        }
+    }
+}
+
+/// Screen tint the window applies to the presented chipset display: a
+/// monochrome-monitor phosphor look or a sepia treatment, matching the web
+/// front-end's screen filter. The `COPPERLINE_TINT` env var overrides the
+/// config for one run. A presentation stage only, like [`ShaderMode`]:
+/// screenshots, frame dumps, recordings and headless runs are never
+/// tinted, so captures stay comparable whatever is selected here. RTG
+/// board scanout is presented untinted too: the tint models the monitor
+/// on the Amiga's video output.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Tint {
+    /// Full colour, untinted. The default. Spelled "none" or "off" in the
+    /// config.
+    #[default]
+    None,
+    /// Black and white: luminance only, like a mono composite feed.
+    Bw,
+    /// Green phosphor, the classic P1 monochrome monitor look.
+    Green,
+    /// Amber phosphor, the other common monochrome monitor look.
+    Amber,
+    /// Sepia-toned monochrome.
+    Sepia,
+}
+
+impl Tint {
+    /// Picker label: the config name of the tint (round-trips through
+    /// [`parse_tint`], which takes "off" as well as "none").
+    pub fn label(self) -> &'static str {
+        match self {
+            Tint::None => "off",
+            Tint::Bw => "bw",
+            Tint::Green => "green",
+            Tint::Amber => "amber",
+            Tint::Sepia => "sepia",
         }
     }
 }
@@ -1432,6 +1473,7 @@ impl Default for Config {
             phosphor: 0.0,
             shader: ShaderMode::None,
             shader_strength: 1.0,
+            tint: Tint::None,
             full_screen: false,
             status_bar: true,
             joystick_input_mode: JoystickInputMode::Gamepad,
@@ -1920,6 +1962,9 @@ pub(crate) struct RawDisplay {
     /// Shader mix, 0.0 (invisible) to 1.0 (full effect, the default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) shader_strength: Option<f32>,
+    /// Screen tint: "none" (default), "bw", "green", "amber", or "sepia".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tint: Option<String>,
     /// Open fullscreen at start (default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) full_screen: Option<bool>,
@@ -2762,6 +2807,10 @@ impl TryFrom<RawConfig> for Config {
                 defaults.shader_strength
             }
         };
+        let tint = match raw.display.tint.as_deref() {
+            None => defaults.tint,
+            Some(s) => parse_tint(s)?,
+        };
         let full_screen = raw.display.full_screen.unwrap_or(defaults.full_screen);
         let status_bar = raw.display.status_bar.unwrap_or(defaults.status_bar);
         let joystick_input_mode = match raw.input.joystick.as_deref() {
@@ -3183,6 +3232,7 @@ impl TryFrom<RawConfig> for Config {
             phosphor,
             shader,
             shader_strength,
+            tint,
             full_screen,
             status_bar,
             joystick_input_mode,
@@ -3275,6 +3325,22 @@ pub(crate) fn parse_shader(s: &str) -> Result<ShaderMode> {
              or a \".wgsl\" file path, got {:?}",
             s
         )),
+    }
+}
+
+/// Parse a `[display] tint` value ("off" is accepted for "none", so
+/// [`Tint::label`] round-trips).
+pub(crate) fn parse_tint(s: &str) -> Result<Tint> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "none" | "off" => Ok(Tint::None),
+        "bw" => Ok(Tint::Bw),
+        "green" => Ok(Tint::Green),
+        "amber" => Ok(Tint::Amber),
+        "sepia" => Ok(Tint::Sepia),
+        other => bail!(
+            "[display] tint must be \"none\", \"bw\", \"green\", \"amber\", \
+             or \"sepia\", got \"{other}\""
+        ),
     }
 }
 
@@ -4160,6 +4226,21 @@ pub fn resolve_shader_strength(from_config: f32) -> f32 {
     }
 }
 
+/// Resolve the screen tint: the `COPPERLINE_TINT` env var (a tint name)
+/// overrides the `[display] tint` config for one run.
+pub fn resolve_tint(from_config: Tint) -> Tint {
+    match crate::envcfg::var("COPPERLINE_TINT") {
+        Some(v) => match parse_tint(&v) {
+            Ok(t) => t,
+            Err(e) => {
+                log::warn!("ignoring COPPERLINE_TINT: {e}");
+                from_config
+            }
+        },
+        None => from_config,
+    }
+}
+
 /// Substitute the bundled AROS ROM when the user named no ROM. The default
 /// `rom_path` is a sentinel ([`BUNDLED_AROS_ROM`]); any real path from
 /// `rom = "..."` or the CLI argument replaces it before this runs and is left
@@ -5023,11 +5104,47 @@ mod tests {
     }
 
     #[test]
+    fn display_tint_parses_names_and_defaults_to_none() -> Result<()> {
+        assert_eq!(parse_config("")?.tint, Tint::None);
+        assert_eq!(parse_tint(" None ")?, Tint::None);
+        // "off" is the label spelling, and must parse back to the same tint.
+        assert_eq!(parse_tint("off")?, Tint::None);
+        assert_eq!(parse_tint(Tint::None.label())?, Tint::None);
+        assert_eq!(parse_tint("BW")?, Tint::Bw);
+        assert_eq!(parse_tint("Green")?, Tint::Green);
+        assert_eq!(parse_tint("\tamber\n")?, Tint::Amber);
+        assert_eq!(parse_tint("sepia")?, Tint::Sepia);
+        // Every label round-trips through the parser.
+        for tint in [Tint::Bw, Tint::Green, Tint::Amber, Tint::Sepia] {
+            assert_eq!(parse_tint(tint.label())?, tint);
+        }
+        let cfg = parse_config(
+            r#"
+            [display]
+            tint = "green"
+            "#,
+        )?;
+        assert_eq!(cfg.tint, Tint::Green);
+        Ok(())
+    }
+
+    #[test]
+    fn display_tint_rejects_an_unknown_name() {
+        let e = parse_tint("purple").unwrap_err().to_string();
+        assert!(
+            e.contains("green") && e.contains("sepia") && e.contains(r#""purple""#),
+            "{e}"
+        );
+        assert!(parse_config("[display]\ntint = \"purple\"").is_err());
+    }
+
+    #[test]
     fn display_shader_keys_round_trip_through_saved_toml() {
         let raw = RawConfig {
             display: RawDisplay {
                 shader: Some("crt".to_string()),
                 shader_strength: Some(0.75),
+                tint: Some("amber".to_string()),
                 ..RawDisplay::default()
             },
             ..RawConfig::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1689,6 +1689,7 @@ fn main() -> Result<()> {
         config::resolve_phosphor(cfg.phosphor),
         config::resolve_shader(cfg.shader.clone()),
         config::resolve_shader_strength(cfg.shader_strength),
+        config::resolve_tint(cfg.tint),
         cfg.full_screen,
         !cfg.status_bar,
         cfg.emulation.warp_speed,
@@ -1804,6 +1805,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_phosphor(0.0),
         config::resolve_shader(config::ShaderMode::None),
         config::resolve_shader_strength(1.0),
+        config::resolve_tint(config::Tint::None),
         // The config-screen placeholder is always a normal windowed UI.
         false,
         false,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -26,7 +26,7 @@ use crate::config::{
     format_size, machine_profile_defaults, AudioFilterMode, ChannelMode, Chipset, Config, CpuModel,
     JoystickInputMode, MachineModel, MouseCapture, Overscan, PacingBudget, ParallelDevice,
     PixelAspect, RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, RtgCard,
-    ScsiController, SerialMode, ShaderMode, WarpSpeed, BOOT_PRI_NEVER,
+    ScsiController, SerialMode, ShaderMode, Tint, WarpSpeed, BOOT_PRI_NEVER,
 };
 use crate::net::NetConfig;
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
@@ -388,6 +388,7 @@ pub enum LauncherField {
     AudioFilter,
     Overscan,
     PixelAspect,
+    Tint,
     Phosphor,
     Shader,
     ShaderStrength,
@@ -631,11 +632,12 @@ const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
 const ETHERNET_ROWS: [Row; 1] = [row(F::Ethernet, "  A2065 board", Cycle)];
 // The A/V & Emu tab is split into three categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
-const VIDEO_ROWS: [Row; 7] = [
+const VIDEO_ROWS: [Row; 8] = [
     row(F::StartFullscreen, "Start fullscreen", Toggle),
     row(F::ShowStatusBar, "Status bar", Toggle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
+    row(F::Tint, "Screen tint", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
     row(F::Shader, "CRT shader", Cycle),
     row(F::ShaderStrength, "Shader strength", Cycle),
@@ -851,6 +853,7 @@ const Z3_PRESETS: [usize; 8] = [
 ];
 const OVERSCANS: [Overscan; 2] = [Overscan::Tv, Overscan::Full];
 const PIXEL_ASPECTS: [PixelAspect; 2] = [PixelAspect::Tv, PixelAspect::Square];
+const TINTS: [Tint; 5] = [Tint::None, Tint::Bw, Tint::Green, Tint::Amber, Tint::Sepia];
 const AUDIO_FILTER_MODES: [AudioFilterMode; 3] = [
     AudioFilterMode::Auto,
     AudioFilterMode::On,
@@ -1071,6 +1074,8 @@ pub struct MachineSetup {
     shader_custom: Option<PathBuf>,
     /// Shader mix, 0.0 to 1.0 ([display] shader_strength).
     shader_strength: f32,
+    /// Screen tint ([display] tint).
+    tint: Tint,
     /// Open fullscreen at start ([display] full_screen).
     start_fullscreen: bool,
     /// Show the status bar at start ([display] status_bar).
@@ -1217,6 +1222,7 @@ impl MachineSetup {
                 _ => None,
             },
             shader_strength: cfg.shader_strength,
+            tint: cfg.tint,
             start_fullscreen: cfg.full_screen,
             show_status_bar: cfg.status_bar,
             floppy_sounds: cfg.audio.floppy_sounds,
@@ -1511,6 +1517,9 @@ impl MachineSetup {
         if (self.shader_strength - base.shader_strength).abs() > 1e-6 {
             raw.display.shader_strength = Some(self.shader_strength);
         }
+        if self.tint != base.tint {
+            raw.display.tint = Some(tint_name(self.tint).to_string());
+        }
         if self.start_fullscreen != base.full_screen {
             raw.display.full_screen = Some(self.start_fullscreen);
         }
@@ -1696,6 +1705,7 @@ impl MachineSetup {
         // "Custom" again.
         self.shader = base.shader.clone();
         self.shader_strength = base.shader_strength;
+        self.tint = base.tint;
         self.start_fullscreen = base.full_screen;
         self.show_status_bar = base.status_bar;
         self.floppy_sounds = base.audio.floppy_sounds;
@@ -2087,6 +2097,15 @@ impl MachineSetup {
                 PixelAspect::Tv => "TV (4:3)".to_string(),
                 PixelAspect::Square => "Square".to_string(),
             },
+            // "Colour" rather than "Off": the web front-end's wording for
+            // the same picker, and it says what the picture looks like.
+            F::Tint => match self.tint {
+                Tint::None => "Colour".to_string(),
+                Tint::Bw => "Black & white".to_string(),
+                Tint::Green => "Green".to_string(),
+                Tint::Amber => "Amber".to_string(),
+                Tint::Sepia => "Sepia".to_string(),
+            },
             F::Phosphor => {
                 if self.phosphor <= 0.0 {
                     "Off".to_string()
@@ -2336,6 +2355,7 @@ impl MachineSetup {
             }
             F::FloppyVolume => self.floppy_volume = step_u8(self.floppy_volume, forward, 0, 100),
             F::Overscan => self.overscan = cycle_slice(&OVERSCANS, self.overscan, forward),
+            F::Tint => self.tint = cycle_slice(&TINTS, self.tint, forward),
             F::PixelAspect => {
                 self.pixel_aspect = cycle_slice(&PIXEL_ASPECTS, self.pixel_aspect, forward)
             }
@@ -3366,6 +3386,18 @@ fn shader_name(shader: &ShaderMode) -> String {
     }
 }
 
+/// The `[display] tint` value for a tint: the canonical config name (not
+/// the picker's "off" spelling, which only parses back).
+fn tint_name(tint: Tint) -> &'static str {
+    match tint {
+        Tint::None => "none",
+        Tint::Bw => "bw",
+        Tint::Green => "green",
+        Tint::Amber => "amber",
+        Tint::Sepia => "sepia",
+    }
+}
+
 fn pacing_name(pacing: PacingBudget) -> &'static str {
     match pacing {
         PacingBudget::Cycles => "cycles",
@@ -3659,6 +3691,31 @@ mod tests {
         s.cycle(LauncherField::MouseSensitivity, false);
         assert_eq!(s.value_label(LauncherField::MouseSensitivity), "48");
         assert_eq!(s.to_raw().input.mouse_sensitivity, Some(48));
+    }
+
+    #[test]
+    fn screen_tint_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        // Full colour is the baseline, so nothing is written for it.
+        assert_eq!(s.value_label(LauncherField::Tint), "Colour");
+        assert_eq!(s.to_raw().display.tint, None);
+
+        s.cycle(LauncherField::Tint, true);
+        assert_eq!(s.value_label(LauncherField::Tint), "Black & white");
+        assert_eq!(s.to_raw().display.tint, Some("bw".to_string()));
+
+        s.cycle(LauncherField::Tint, true);
+        assert_eq!(s.value_label(LauncherField::Tint), "Green");
+        assert_eq!(s.to_raw().display.tint, Some("green".to_string()));
+
+        // The written config has to load back into the same setting.
+        assert_eq!(s.build_config().expect("valid config").tint, Tint::Green);
+
+        // Cycling backwards from the baseline wraps to the end of the list.
+        let mut s = MachineSetup::default();
+        s.cycle(LauncherField::Tint, false);
+        assert_eq!(s.value_label(LauncherField::Tint), "Sepia");
+        assert_eq!(s.to_raw().display.tint, Some("sepia".to_string()));
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -94,6 +94,7 @@ pub enum MenuItem {
     SamplerGain,
     PixelAspect,
     CrtShader,
+    ScreenTint,
     FloppySpeed,
     Fullscreen,
     StatusBar,
@@ -119,9 +120,9 @@ pub enum MenuItem {
 pub fn menu_items(midi_active: bool, sampler_active: bool) -> Vec<MenuItem> {
     let _ = midi_active;
     // 12 leading + up to 2 MIDI + 2 sampler + pixel aspect + CRT shader +
-    // floppy speed + 15 trailing items = 34, sized so appending never
-    // reallocates.
-    let mut items = Vec::with_capacity(34);
+    // screen tint + floppy speed + 15 trailing items = 35, sized so
+    // appending never reallocates.
+    let mut items = Vec::with_capacity(35);
     items.extend([
         MenuItem::MachineConfig,
         MenuItem::FrameAnalyzer,
@@ -147,6 +148,7 @@ pub fn menu_items(midi_active: bool, sampler_active: bool) -> Vec<MenuItem> {
     }
     items.push(MenuItem::PixelAspect);
     items.push(MenuItem::CrtShader);
+    items.push(MenuItem::ScreenTint);
     items.push(MenuItem::FloppySpeed);
     items.extend([
         MenuItem::Fullscreen,
@@ -192,6 +194,8 @@ pub struct MenuLabels<'a> {
     pub pixel_aspect: PixelAspect,
     /// Window shader pass in effect (the CRT Shader item cycles it).
     pub shader: crate::config::ShaderKind,
+    /// Screen tint in effect (the Screen Tint item cycles it).
+    pub tint: crate::config::Tint,
     /// Current `[floppy] speed` value (a percentage, or 0 for turbo).
     pub floppy_speed: u16,
     /// Current MIDI input/output device names (empty when not applicable).
@@ -238,6 +242,11 @@ fn menu_item_label(item: MenuItem, s: MenuLabels) -> String {
         // as the value width changes ("off" vs "scanlines").
         MenuItem::CrtShader => {
             format!("CRT Shader {:>11}", format!("[{}]", s.shader.label()))
+        }
+        // Right-pad like CRT Shader above so the closing bracket stays put
+        // as the value width changes ("off" vs "green").
+        MenuItem::ScreenTint => {
+            format!("Screen Tint {:>7}", format!("[{}]", s.tint.label()))
         }
         // Right-pad like Warp Limit below so the closing bracket stays put
         // as the value width changes (100% vs turbo).
@@ -6539,6 +6548,7 @@ mod tests {
             sampler_input: "",
             sampler_gain: "",
             shader: crate::config::ShaderKind::None,
+            tint: crate::config::Tint::None,
         };
         assert_eq!(
             menu_item_label(MenuItem::Fullscreen, labels(false)),
@@ -6577,6 +6587,7 @@ mod tests {
             sampler_input: "",
             sampler_gain: "",
             shader: crate::config::ShaderKind::None,
+            tint: crate::config::Tint::None,
         };
         // "on" means the bar is shown.
         assert_eq!(
@@ -6661,6 +6672,10 @@ mod tests {
                                             sampler_input: long,
                                             sampler_gain: "-24 dB",
                                             shader,
+                                            // The widest tint value; the
+                                            // {:>7} pad makes every other
+                                            // one the same width.
+                                            tint: crate::config::Tint::Green,
                                         };
                                         check(item, labels);
                                     }
@@ -7607,6 +7622,7 @@ mod tests {
             sampler_input: "",
             sampler_gain: "",
             shader: crate::config::ShaderKind::None,
+            tint: crate::config::Tint::None,
         };
         let panel_has_title_bar = |frame: &[u8], panel: &Panel| {
             let rect = panel_rect(panel);
@@ -7653,6 +7669,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         let menu = menu_rect(menu_items(false, false).len());
@@ -7708,6 +7725,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -7751,6 +7769,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -7810,6 +7829,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -7893,6 +7913,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -7986,6 +8007,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8053,6 +8075,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8121,6 +8144,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8242,6 +8266,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8323,6 +8348,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8415,6 +8441,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8546,6 +8573,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8667,6 +8695,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8717,6 +8746,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8807,6 +8837,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8864,6 +8895,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8914,6 +8946,7 @@ mod tests {
                 sampler_input: "",
                 sampler_gain: "",
                 shader: crate::config::ShaderKind::None,
+                tint: crate::config::Tint::None,
             },
         );
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
@@ -8967,6 +9000,7 @@ mod tests {
             sampler_input: "",
             sampler_gain: "",
             shader: crate::config::ShaderKind::None,
+            tint: crate::config::Tint::None,
         };
         let mut frame = vec![0u8; w * h * 4];
         let mut state = LauncherState::new(launcher::MachineSetup::default());

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -771,6 +771,13 @@ pub struct App {
     /// How strongly the shader pass is mixed in, 0.0 to 1.0 ([display]
     /// shader_strength).
     shader_strength: f32,
+    /// Screen tint in effect ([display] tint). Presentation only, applied
+    /// to the chipset display region of the window frame: captures and
+    /// RTG board scanout are never tinted.
+    tint: crate::config::Tint,
+    /// Luma-indexed colour table for `tint`; `None` when the tint is off,
+    /// which skips the pass entirely.
+    tint_lut: Option<Box<[u32; 256]>>,
     /// Open the window fullscreen when it is first created ([display]
     /// full_screen). Applied once in `resumed`; the runtime toggle takes over
     /// after that.
@@ -1090,6 +1097,7 @@ impl App {
         phosphor: f32,
         shader: crate::config::ShaderMode,
         shader_strength: f32,
+        tint: crate::config::Tint,
         start_fullscreen: bool,
         hide_status_bar: bool,
         warp_speed: WarpSpeed,
@@ -1255,6 +1263,8 @@ impl App {
                 _ => None,
             },
             shader_strength,
+            tint,
+            tint_lut: tint_lut(tint),
             start_fullscreen,
             gamepad: crate::gamepad::GamepadReader::new(),
             joystick_input_mode,
@@ -3055,6 +3065,15 @@ impl ApplicationHandler for App {
                             // board's screen.
                             self.present_standard_tv_aperture && self.rtg_present_dims.is_none(),
                         );
+                        // The tint models the monitor on the Amiga's video
+                        // output, so RTG board scanout stays untinted here
+                        // too, matching the GPU RTG path (which never sees
+                        // this buffer).
+                        if self.rtg_present_dims.is_none() {
+                            if let Some(lut) = &self.tint_lut {
+                                tint_display_rows(frame, r.texture_scale, lut);
+                            }
+                        }
                     }
                     if !super::status_bar_hidden() {
                         draw_status_bar(frame, &view, r.texture_scale);
@@ -3099,6 +3118,7 @@ impl ApplicationHandler for App {
                             sampler_input: &sampler_input_label,
                             sampler_gain: &sampler_gain_label,
                             shader: self.crt_shader_kind,
+                            tint: self.tint,
                         },
                     );
                     // The drag hint sits on top of everything: the drop will
@@ -4296,6 +4316,7 @@ impl App {
                     ui::MenuItem::SamplerGain => self.step_sampler_gain(true),
                     ui::MenuItem::PixelAspect => self.toggle_pixel_aspect(),
                     ui::MenuItem::CrtShader => self.cycle_crt_shader(),
+                    ui::MenuItem::ScreenTint => self.cycle_screen_tint(),
                     ui::MenuItem::FloppySpeed => self.cycle_floppy_speed(),
                     ui::MenuItem::AudioOutput => self.cycle_audio_output(),
                     ui::MenuItem::AudioFilter => self.cycle_audio_filter(),
@@ -5740,7 +5761,7 @@ impl App {
         if is_fullscreen == Some(!cfg.full_screen) {
             self.toggle_fullscreen();
         }
-        if super::status_bar_hidden() != !cfg.status_bar {
+        if super::status_bar_hidden() == cfg.status_bar {
             self.toggle_status_bar();
         }
         self.warp_speed = cfg.emulation.warp_speed;
@@ -5784,6 +5805,7 @@ impl App {
             r.crt_shader.clear_custom();
         }
         self.shader_strength = crate::config::resolve_shader_strength(cfg.shader_strength);
+        self.set_tint(crate::config::resolve_tint(cfg.tint));
         self.ui.menu_open = false;
         self.ui.panel = None;
         self.powered_on = true;
@@ -8417,6 +8439,30 @@ impl App {
             None => format!("CRT shader: {}", next.label()),
         });
         self.request_redraw();
+    }
+
+    /// Menu "Screen Tint": step through the tints for the rest of the run
+    /// (the config file default is unchanged; set `[display] tint` to make
+    /// it stick).
+    fn cycle_screen_tint(&mut self) {
+        use crate::config::Tint;
+        let next = match self.tint {
+            Tint::None => Tint::Bw,
+            Tint::Bw => Tint::Green,
+            Tint::Green => Tint::Amber,
+            Tint::Amber => Tint::Sepia,
+            Tint::Sepia => Tint::None,
+        };
+        self.set_tint(next);
+        info!("screen tint: {}", next.label());
+        self.show_osd(format!("Screen tint: {}", next.label()));
+        self.request_redraw();
+    }
+
+    /// Install a screen tint and its presentation table together.
+    fn set_tint(&mut self, tint: crate::config::Tint) {
+        self.tint = tint;
+        self.tint_lut = tint_lut(tint);
     }
 
     /// Compile the configured user shader against the live device. The full

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -7,6 +7,7 @@
 //! parent's private items.
 
 use super::*;
+use crate::config::Tint;
 
 // The pure post-render helpers live in `video/present_common.rs` so headless
 // consumers can present frames without the winit frontend; re-exported here so
@@ -647,6 +648,145 @@ pub(super) fn alpha_blit_rgba(
             };
         }
     }
+}
+
+// --- screen tint ---------------------------------------------------------
+//
+// The [display] tint knob: a monochrome-monitor look over the window's
+// picture, matching the web front-end's screen filter. Presentation only,
+// like the CRT shader pass: it runs on the composited window frame after
+// the display copy, so screenshots, frame dumps, recordings and headless
+// runs stay untinted, and the status bar and UI overlays (drawn after it)
+// stay in colour.
+//
+// Every tint is a luma ramp: the pixel collapses to its luminance, which
+// indexes a 256-entry table of pre-tinted colours. The ramps reproduce the
+// web frontend's CSS filter chains (Filter Effects Module Level 1
+// colour matrices, results clamped to [0, 1] between stages), evaluated on
+// the grey axis once at build time, so the desktop and browser tints match.
+
+/// Rec. 709-style luma weights in 8.8 fixed point, summing to exactly 256
+/// so a grey pixel maps to its own level and the b/w ramp is an identity.
+const LUMA_R: u32 = 54;
+const LUMA_G: u32 = 183;
+const LUMA_B: u32 = 19;
+
+fn clamp01(c: [f32; 3]) -> [f32; 3] {
+    c.map(|v| v.clamp(0.0, 1.0))
+}
+
+fn mat_mul(m: [[f32; 3]; 3], c: [f32; 3]) -> [f32; 3] {
+    clamp01([
+        m[0][0] * c[0] + m[0][1] * c[1] + m[0][2] * c[2],
+        m[1][0] * c[0] + m[1][1] * c[1] + m[1][2] * c[2],
+        m[2][0] * c[0] + m[2][1] * c[1] + m[2][2] * c[2],
+    ])
+}
+
+/// CSS `sepia(1)`.
+fn sepia(c: [f32; 3]) -> [f32; 3] {
+    mat_mul(
+        [
+            [0.393, 0.769, 0.189],
+            [0.349, 0.686, 0.168],
+            [0.272, 0.534, 0.131],
+        ],
+        c,
+    )
+}
+
+/// CSS `saturate(s)`.
+fn saturate(c: [f32; 3], s: f32) -> [f32; 3] {
+    mat_mul(
+        [
+            [0.213 + 0.787 * s, 0.715 - 0.715 * s, 0.072 - 0.072 * s],
+            [0.213 - 0.213 * s, 0.715 + 0.285 * s, 0.072 - 0.072 * s],
+            [0.213 - 0.213 * s, 0.715 - 0.715 * s, 0.072 + 0.928 * s],
+        ],
+        c,
+    )
+}
+
+/// CSS `hue-rotate(deg)`.
+fn hue_rotate(c: [f32; 3], degrees: f32) -> [f32; 3] {
+    let (sin, cos) = degrees.to_radians().sin_cos();
+    mat_mul(
+        [
+            [
+                0.213 + cos * 0.787 - sin * 0.213,
+                0.715 - cos * 0.715 - sin * 0.715,
+                0.072 - cos * 0.072 + sin * 0.928,
+            ],
+            [
+                0.213 - cos * 0.213 + sin * 0.143,
+                0.715 + cos * 0.285 + sin * 0.140,
+                0.072 - cos * 0.072 - sin * 0.283,
+            ],
+            [
+                0.213 - cos * 0.213 - sin * 0.787,
+                0.715 - cos * 0.715 + sin * 0.715,
+                0.072 + cos * 0.928 + sin * 0.072,
+            ],
+        ],
+        c,
+    )
+}
+
+/// CSS `brightness(b)`.
+fn brightness(c: [f32; 3], b: f32) -> [f32; 3] {
+    clamp01(c.map(|v| v * b))
+}
+
+/// The tinted colour one grey level maps to: the web frontend's CSS
+/// filter chain for the tint, evaluated on grey (its leading
+/// `grayscale(1)` is the luma collapse the per-pixel step performs).
+fn tint_ramp(tint: Tint, level: f32) -> [f32; 3] {
+    let grey = [level, level, level];
+    match tint {
+        Tint::None | Tint::Bw => grey,
+        Tint::Green => brightness(hue_rotate(saturate(sepia(grey), 4.0), 80.0), 0.92),
+        Tint::Amber => hue_rotate(saturate(sepia(grey), 4.0), -8.0),
+        Tint::Sepia => sepia(grey),
+    }
+}
+
+/// Build the luma-indexed colour table for a tint, or `None` for
+/// [`Tint::None`] so the untinted path costs nothing per frame.
+pub(super) fn tint_lut(tint: Tint) -> Option<Box<[u32; 256]>> {
+    if tint == Tint::None {
+        return None;
+    }
+    let mut lut = Box::new([0u32; 256]);
+    for (level, out) in lut.iter_mut().enumerate() {
+        let [r, g, b] = tint_ramp(tint, level as f32 / 255.0);
+        *out = rgba(
+            (r * 255.0 + 0.5) as u32,
+            (g * 255.0 + 0.5) as u32,
+            (b * 255.0 + 0.5) as u32,
+        );
+    }
+    Some(lut)
+}
+
+/// Tint a run of RGBA pixels in place through a [`tint_lut`] table.
+pub(super) fn tint_rows_in_place(px: &mut [u8], lut: &[u32; 256]) {
+    for p in px.chunks_exact_mut(4) {
+        let luma =
+            (LUMA_R * u32::from(p[0]) + LUMA_G * u32::from(p[1]) + LUMA_B * u32::from(p[2])) >> 8;
+        let tinted = lut[luma as usize].to_le_bytes();
+        p[0] = tinted[0];
+        p[1] = tinted[1];
+        p[2] = tinted[2];
+    }
+}
+
+/// Tint the display region of the composited window frame in place. Runs
+/// between the display copy and the status-bar/UI drawing, so only the
+/// emulated picture is tinted.
+pub(super) fn tint_display_rows(frame: &mut [u8], texture_scale: usize, lut: &[u32; 256]) {
+    let rows = present_height() * texture_scale;
+    let stride = texture_width(texture_scale) * 4;
+    tint_rows_in_place(&mut frame[..rows * stride], lut);
 }
 
 pub(super) fn blend_rgba_over_opaque(dst: u32, sr: u32, sg: u32, sb: u32, sa: u32) -> u32 {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -16,20 +16,20 @@ use super::{
     rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
     short_status_error, shorten_status_paths, shot_button_rect, should_render_emulated_frame,
     standard_window_top_row, status_with_latched_fdd_track, take_integral_mouse_delta,
-    texture_height, texture_width, tv_aperture_source_row, tv_source_h_bounds,
-    volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, JoystickInputMode,
-    MediaBar, StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT,
-    AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY,
-    CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON,
-    HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL,
-    POWER_LED_OFF, STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG,
-    TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON, TV_PAL_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
-    TV_PAL_PRESENT_SOURCE_X, TV_PAL_PRESENT_SOURCE_Y, TV_PAL_PRESENT_WIDTH, VOLUME_FILL,
-    VOLUME_GLYPH_X,
+    texture_height, texture_width, tint_display_rows, tint_lut, tint_rows_in_place,
+    tv_aperture_source_row, tv_source_h_bounds, volume_percent_from_pos, volume_slider_track_rect,
+    BarControl, DriveBar, JoystickInputMode, MediaBar, StatusBarView, ToolPanelKind,
+    AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
+    AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON,
+    DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
+    POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL, POWER_LED_OFF,
+    STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
+    TRACK_SEGMENT_ON, TV_PAL_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT, TV_PAL_PRESENT_SOURCE_X,
+    TV_PAL_PRESENT_SOURCE_Y, TV_PAL_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
-use crate::config::{Overscan, WarpSpeed};
+use crate::config::{Overscan, Tint, WarpSpeed};
 use crate::heatmap;
 use crate::video::{FB_HEIGHT, FB_PIXELS, FB_WIDTH};
 use std::cell::RefCell;
@@ -2004,6 +2004,116 @@ fn present_frame_copy_downmaps_35ns_canvas_on_single_scale_texture() {
 }
 
 #[test]
+fn tint_off_builds_no_lut() {
+    assert!(tint_lut(Tint::None).is_none());
+}
+
+#[test]
+fn bw_tint_lut_is_the_identity_on_grey() {
+    let lut = tint_lut(Tint::Bw).unwrap();
+    for level in 0..=255u32 {
+        assert_eq!(lut[level as usize], rgba(level, level, level));
+    }
+}
+
+/// Every tint is a phosphor-style ramp: black stays black, the top end is
+/// bright, alpha stays opaque, and no channel dips along the way (beyond
+/// the one-step wobble the CSS chain's inter-stage clamping can produce).
+#[test]
+fn tint_luts_ramp_from_black_to_bright() {
+    for tint in [Tint::Bw, Tint::Green, Tint::Amber, Tint::Sepia] {
+        let lut = tint_lut(tint).unwrap();
+        assert_eq!(lut[0], rgba(0, 0, 0), "{tint:?} must map black to black");
+        let mut prev = [0u8; 4];
+        for (level, px) in lut.iter().enumerate() {
+            let cur = px.to_le_bytes();
+            assert_eq!(cur[3], 0xFF, "{tint:?} level {level} must stay opaque");
+            for c in 0..3 {
+                assert!(
+                    cur[c].saturating_add(2) >= prev[c],
+                    "{tint:?} channel {c} dips at level {level}: {} -> {}",
+                    prev[c],
+                    cur[c]
+                );
+            }
+            prev = cur;
+        }
+        let top = lut[255].to_le_bytes();
+        assert!(
+            top[..3].iter().any(|&v| v >= 200),
+            "{tint:?} top of the ramp is dim: {top:?}"
+        );
+    }
+}
+
+/// Each tint's mid-grey lands on its nominal hue: green phosphor is
+/// green-dominant, amber and sepia run warm (r > g > b).
+#[test]
+fn tint_luts_favour_their_phosphor_colour() {
+    let mid = |tint| tint_lut(tint).unwrap()[128].to_le_bytes();
+
+    let [r, g, b, _] = mid(Tint::Green);
+    assert!(
+        g > r.saturating_add(50) && g > b.saturating_add(50),
+        "green mid: {r} {g} {b}"
+    );
+
+    let [r, g, b, _] = mid(Tint::Amber);
+    assert!(
+        r > g.saturating_add(50) && g > b.saturating_add(50),
+        "amber mid: {r} {g} {b}"
+    );
+
+    let [r, g, b, _] = mid(Tint::Sepia);
+    assert!(r > g && g > b, "sepia mid: {r} {g} {b}");
+}
+
+/// The per-pixel step collapses a colour to its luma and takes the ramp
+/// entry: a pure-green pixel and the grey of its luma tint identically,
+/// and the alpha byte passes through.
+#[test]
+fn tint_rows_collapse_colour_to_luma() {
+    let lut = tint_lut(Tint::Green).unwrap();
+    let luma_of_green = 182u8; // (183 * 255) >> 8: the green weight on a full channel
+    let mut px = [
+        rgba(0, 255, 0).to_le_bytes(),
+        rgba(
+            u32::from(luma_of_green),
+            u32::from(luma_of_green),
+            u32::from(luma_of_green),
+        )
+        .to_le_bytes(),
+    ]
+    .concat();
+    tint_rows_in_place(&mut px, &lut);
+    let expected = lut[usize::from(luma_of_green)].to_le_bytes();
+    assert_eq!(&px[0..4], &expected);
+    assert_eq!(&px[4..8], &expected);
+}
+
+/// The in-place pass covers exactly the display region of the composited
+/// frame: the status-bar rows below it keep their pixels.
+#[test]
+fn tint_display_rows_leave_the_status_bar_alone() {
+    let scale = 1;
+    let lut = tint_lut(Tint::Bw).unwrap();
+    let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+    let saturated = rgba(255, 0, 0).to_le_bytes();
+    for px in frame.chunks_exact_mut(4) {
+        px.copy_from_slice(&saturated);
+    }
+    tint_display_rows(&mut frame, scale, &lut);
+    let display_bytes = present_height() * scale * texture_width(scale) * 4;
+    let grey_red = lut[usize::from(53u8)].to_le_bytes(); // (54 * 255) >> 8
+    for px in frame[..display_bytes].chunks_exact(4) {
+        assert_eq!(px, grey_red, "display pixel left untinted");
+    }
+    for px in frame[display_bytes..].chunks_exact(4) {
+        assert_eq!(px, saturated, "status-bar pixel was tinted");
+    }
+}
+
+#[test]
 fn tv_window_copy_centres_reference_aperture_in_live_texture() {
     use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
     let scale = 1;
@@ -2535,6 +2645,7 @@ fn test_app_with_audio_cpu_and_program(
         0.0,
         crate::config::ShaderMode::None,
         1.0,
+        crate::config::Tint::None,
         false,
         false,
         crate::config::WarpSpeed::Max,


### PR DESCRIPTION
## Summary

Ports the web frontend's screen tints (its **Screen** selector: Colour, Black & white, Green phosphor, Amber phosphor, Sepia) to the desktop:

- `[display] tint = "none"|"bw"|"green"|"amber"|"sepia"` in the TOML (`"off"` accepted for `"none"`), with a `COPPERLINE_TINT` env override mirroring `COPPERLINE_SHADER`
- a **Screen tint** cycle row in the launcher's *A/V & Emu -> Video* category, persisted to the config only when it differs from the profile default
- a live **Screen Tint** window-menu item that cycles the tints for the session without touching the config, like *CRT Shader*

## Implementation

The web applies these as CSS filters on the canvas. The desktop reproduces the same CSS filter chains (Filter Effects colour matrices - sepia, saturate, hue-rotate, brightness - clamped to [0,1] between stages like a browser) evaluated on the grey axis once, into a 256-entry luma-indexed colour table. The present path collapses each display pixel to its luma and takes the table entry, so the desktop and browser looks match, the per-frame cost is one table fetch per pixel, and the untinted path is untouched.

Presentation only, following the CRT shader pass's contract (and diverging deliberately from the web, which bakes the tint into copied screenshots): the tint runs on the composited window frame between the display copy and the status-bar/UI drawing, so

- screenshots, frame dumps, recordings and headless runs stay untinted and comparable,
- the status bar, OSD and overlay panels keep their colours,
- RTG board scanout is never tinted (the tint models the monitor on the Amiga's video output; the GPU RTG path never sees this buffer, and the CPU fallback while an overlay is open skips it to match).

It composes with the CRT shader presets - green under `crt` gives a convincing monochrome tube.

Also fixes the pre-existing clippy `nonminimal_bool` warning in window.rs so `cargo clippy` is clean again on current toolchains.

## Testing

- `cargo test`: full unit suite green, including new tests for `parse_tint`/round-trip, the launcher cycle-and-save round-trip, LUT properties (b/w is a grey identity, black stays black, green/amber/sepia land on their phosphor hues, ramps stay opaque and bright), and that the in-place pass stops exactly at the status bar
- `cargo clippy` and `cargo fmt --check` clean
- `COPPERLINE_UI_PREVIEW=1` renders verified the launcher row and menu item layouts

Docs updated in `docs/guide/configuration.md`, `docs/guide/ui.md`, and the commented `[display]` block in `copperline.example.toml`.