### PR TITLE
video: extend the TV-aperture crop to standard 60 Hz scans

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -425,26 +425,38 @@ impl WebEmu {
         );
         let woven_rows = self.deinterlacer.output_rows();
         let woven = self.deinterlacer.output();
-        if self.overscan == Overscan::Tv
-            && present_common::uses_standard_pal_tv_aperture(geometry, woven_rows, &base)
-        {
-            // Standard PAL display: present the captured TV aperture, the
+        let tv_aperture_rows = if self.overscan == Overscan::Tv {
+            present_common::standard_tv_aperture_rows(geometry, woven_rows, &base)
+        } else {
+            None
+        };
+        if let Some(aperture_rows) = tv_aperture_rows {
+            // Standard 15 kHz display: present the captured TV aperture, the
             // browser counterpart of the desktop's TV-aperture crop. Clipped
             // to real framebuffer columns so the canvas never shows the
             // bezel-mask black stripe on the left or bezel padding on the
-            // right; the standard window sits exactly centred.
-            self.present_width = present_common::TV_PAL_CAPTURED_WIDTH;
-            self.present_rows = present_common::TV_PAL_PRESENT_HEIGHT;
+            // right; the standard window sits exactly centred. The canvas
+            // keeps one shape for both video standards -- their apertures
+            // fill the same 4:3 glass -- so a 60 Hz crop's rows scale onto
+            // the 50 Hz aperture's native row count (whole-row selection,
+            // like the desktop present copy).
+            self.present_width = present_common::TV_CAPTURED_WIDTH;
+            self.present_rows = present_common::TV_GLASS_PRESENT_ROWS;
             self.present
                 .resize(self.present_width * self.present_rows, 0);
             for (y, dst) in self
                 .present
-                .chunks_exact_mut(present_common::TV_PAL_CAPTURED_WIDTH)
+                .chunks_exact_mut(present_common::TV_CAPTURED_WIDTH)
                 .enumerate()
             {
-                let src = (present_common::TV_PAL_PRESENT_SOURCE_Y + y) * FB_WIDTH
-                    + present_common::TV_PAL_CAPTURED_SOURCE_X;
-                dst.copy_from_slice(&woven[src..src + present_common::TV_PAL_CAPTURED_WIDTH]);
+                let crop_y = copperline::screenshot::scaled_source_row(
+                    y,
+                    aperture_rows,
+                    present_common::TV_GLASS_PRESENT_ROWS,
+                );
+                let src = (present_common::TV_PRESENT_SOURCE_Y + crop_y) * FB_WIDTH
+                    + present_common::TV_CAPTURED_SOURCE_X;
+                dst.copy_from_slice(&woven[src..src + present_common::TV_CAPTURED_WIDTH]);
             }
         } else {
             self.present_width = self.deinterlacer.output_width();
@@ -470,9 +482,9 @@ impl WebEmu {
     }
 
     /// Width of the presentation buffer in pixels. The captured TV aperture
-    /// for standard PAL displays, the full framebuffer width otherwise; it
-    /// can change between frames, so JS must size the canvas from it each
-    /// frame alongside `present_rows`.
+    /// for standard 15 kHz displays (PAL and NTSC alike), the full
+    /// framebuffer width otherwise; it can change between frames, so JS must
+    /// size the canvas from it each frame alongside `present_rows`.
     pub fn present_width(&self) -> u32 {
         self.present_width as u32
     }
@@ -791,7 +803,7 @@ impl WebEmu {
 
     /// Presentation overscan, the desktop's `[display] overscan` knob:
     /// "tv" (the default) masks the deep horizontal overscan margins like a
-    /// CRT bezel and presents standard PAL screens as the captured TV
+    /// CRT bezel and presents standard screens as the captured TV
     /// aperture; "full" presents the whole overscan field the renderer
     /// produces. Unknown names are ignored, like `set_port_device`. The
     /// last completed frame is re-presented under the new aperture, so a

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -46,8 +46,9 @@ a **Forget** button that puts the boot button back on AROS.
 Two more selects shape what the glass shows without touching the
 machine. **View** is the desktop's `[display] overscan` knob: *TV* (the
 default) masks the deep horizontal overscan like a CRT bezel and crops
-standard PAL screens to a TV aperture, *Full overscan* presents the
-whole field Denise produced -- junk pixels, border tricks and all.
+standard screens (PAL and NTSC alike) to a TV aperture, *Full overscan*
+presents the whole field Denise produced -- junk pixels, border tricks
+and all.
 **Screen** tints the picture like a monochrome monitor's phosphor --
 black & white, green, amber, or sepia -- applied as a CSS filter on the
 canvas (zero per-frame cost; screenshots bake it in). Both are viewing
@@ -246,13 +247,16 @@ through wasm-bindgen; the page's JavaScript drives everything from
 - **Video**: the core's rendered frame is post-processed and deinterlaced by
   the same code the desktop uses, then blitted to a `<canvas>` with
   `putImageData` -- the internal framebuffer is RGBA in memory order, so no
-  conversion happens. Standard PAL screens are presented as the captured TV
-  aperture, a 668x540 crop with the standard window exactly centred between
-  symmetric overscan margins, so the canvas carries none of the bezel-mask
-  black columns of the full framebuffer; non-standard frames (true
-  overscan, NTSC, programmable scans) keep the full 716-pixel width, as on
-  the desktop, and a programmable super-hi-res scan carries its double
-  (1432-pixel, 35 ns pitch) canvas straight to the browser canvas (see
+  conversion happens. Standard screens are presented as the captured TV
+  aperture, a 668x540 canvas with the standard window exactly centred
+  between symmetric overscan margins, so the canvas carries none of the
+  bezel-mask black columns of the full framebuffer. PAL and NTSC share the
+  one canvas shape -- both apertures fill the same 4:3 glass, so an NTSC
+  scan's shorter 428-row crop is scaled onto the same 540 output rows.
+  Non-standard frames (true overscan, programmable scans) keep the full
+  716-pixel width, as on the desktop, and a programmable super-hi-res scan
+  carries its double (1432-pixel, 35 ns pitch) canvas straight to the
+  browser canvas (see
   [the presentation internals](../internals/video.md)).
   There is no wgpu in the build, which keeps the wasm
   around 1.4 MiB (about 0.6 MiB over the wire).
@@ -403,7 +407,7 @@ desktop's `[floppy] speed` option (see
 [Configuration](configuration.md)); changes apply to the live machine.
 `set_overscan(mode)` picks the presentation overscan, the desktop's
 `[display] overscan` knob: `"tv"` (the default) masks the deep
-horizontal overscan like a CRT bezel and presents standard PAL screens
+horizontal overscan like a CRT bezel and presents standard screens
 as the captured TV aperture, `"full"` presents the whole overscan field;
 unknown names are ignored. The last completed frame is re-presented
 under the new aperture immediately, so a paused page only has to blit.
@@ -421,7 +425,7 @@ Paula's serial port to whatever byte stream the page likes (see
 valid until the next `run` call -- rebuild the typed-array view every frame,
 because wasm memory can grow. The presentation *size* is dynamic too:
 `present_width()` and `present_rows()` change when the guest switches
-between a standard PAL screen (presented as the captured TV aperture crop)
+between a standard screen (presented as the captured TV aperture crop)
 and anything else (presented as the full framebuffer), so size the canvas
 from both every frame rather than assuming fixed dimensions.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -458,10 +458,13 @@ status_bar = true     # show the status bar at start (default true)
 
 The emulated framebuffer always carries the full overscan field Denise
 produces. `"tv"` masks the deep horizontal overscan margins in black like a
-CRT bezel, presenting the standard PAL window plus 24 lo-res pixels per side
+CRT bezel, presenting the standard window plus 24 lo-res pixels per side
 of TV-style overscan while preserving vertical border colour changes. PNG
-screenshots and `--dump-frames` crop standard PAL TV output to a 692x540
-aperture for reference-emulator comparison. `"full"` shows everything, which
+screenshots and `--dump-frames` crop standard TV output to a 692x540
+aperture for reference-emulator comparison; PAL and NTSC scans share the
+one shape because both apertures fill the same 4:3 glass -- an NTSC scan's
+shorter crop (the 200-line standard window plus the same overscan margin)
+is scaled onto the same output rows. `"full"` shows everything, which
 is useful when debugging display alignment. `COPPERLINE_OVERSCAN=full|tv`
 overrides this for a single run.
 
@@ -506,9 +509,9 @@ picture untouched, and any value ending in `.wgsl` is the path of a shader
 of your own -- see [Custom WGSL shaders](#custom-wgsl-shaders) below.
 
 The scanline gaps are drawn at the pitch of the emulated field lines the
-window is actually showing: 270 in the default TV-overscan presentation and
-285 in `"full"`, so the line structure follows the picture rather than the
-window size. TV overscan with `pixel_aspect = "square"` is 285 as well --
+window is actually showing: 270 in the default TV-overscan presentation
+(214 on an NTSC scan) and 285 in `"full"`, so the line structure follows
+the picture rather than the window size. TV overscan with `pixel_aspect = "square"` is 285 as well --
 that canvas is taller than the TV aperture and pads it with bezel rows, so
 the same 270 lines are rescaled to keep their pitch across the whole
 window. Interlaced content is deliberately drawn at field-line pitch

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -398,25 +398,35 @@ framebuffer):
   rendered source texture instead of copying the picture sideways. Vertical
   border colour changes remain visible because they are part of the Denise
   output and are often deliberate border effects.
-- **PAL TV PNG aperture**: normal screenshots and `--dump-frames` in TV mode
+- **TV PNG aperture**: normal screenshots and `--dump-frames` in TV mode
   crop standard horizontal content to a 692x540 aperture. The horizontal crop
-  keeps a 640-pixel standard display centred with 26 pixels of visible overscan
-  on both sides; vertically it keeps the PAL title-bar/top-border position
-  aligned with the reference-emulator crop. The live window keeps its 716-pixel
-  4:3 texture for the status bar and scaling path, but centres the same TV
-  aperture inside that texture instead of showing the raw framebuffer origin.
-  True horizontal overscan fetches are not cropped to this aperture: they stay
-  on the full-width TV path so intentional border content remains visible.
-  `COPPERLINE_SHOT_RAW=1` bypasses the PNG crop and writes the raw 716x570
-  woven framebuffer. A second, narrower aperture (`TV_PAL_CAPTURED_*`,
-  668x540) clips the same rect to columns the framebuffer actually
-  captures: the reference aperture's right margin reaches 12 columns past
-  the framebuffer's right edge, which the window and PNG paths pad with
-  black bezel. Frontends whose frame should end on real pixels present the
-  captured aperture instead -- the browser canvas hugs its border on every
-  side -- with the margin mirrored from the captured right-overscan width
-  so the standard window stays exactly centred. Its geometry invariants are
-  const-evaluated beside the definitions.
+  keeps a 640-pixel standard display centred with 26 pixels of visible
+  overscan on both sides and is shared by both video standards, which place
+  the standard window at the same colour clocks; vertically it keeps the
+  title-bar/top-border position aligned with the reference-emulator crop.
+  The aperture's height follows the scan the frame actually ran, not the
+  configured standard: a 312/313-line (50 Hz) field carries the 256-line
+  standard window (540 woven rows with a 7-line overscan margin each side),
+  a 262/263-line (60 Hz) field the 200-line one (428 rows with the same
+  margin). Both apertures fill the same 4:3 glass, so presentation keeps
+  one shape -- a 60 Hz crop's rows are scaled onto the 50 Hz aperture's
+  native row count (whole-row selection, no blending) in the saved PNG, and
+  the live window stretches it over the same display rect. The window keeps
+  its 716-pixel 4:3 texture for the status bar and scaling path, but
+  centres the TV aperture inside that texture instead of showing the raw
+  framebuffer origin. True horizontal overscan fetches are not cropped to
+  this aperture: they stay on the full-width TV path so intentional border
+  content remains visible. `COPPERLINE_SHOT_RAW=1` bypasses the PNG crop
+  and writes the raw 716x570 woven framebuffer. A second, narrower aperture
+  (`TV_CAPTURED_*`, 668 wide) clips the same rect to columns the
+  framebuffer actually captures: the reference aperture's right margin
+  reaches 12 columns past the framebuffer's right edge, which the window
+  and PNG paths pad with black bezel. Frontends whose frame should end on
+  real pixels present the captured aperture instead -- the browser canvas
+  hugs its border on every side -- with the margin mirrored from the
+  captured right-overscan width so the standard window stays exactly
+  centred. Its geometry invariants are const-evaluated beside the
+  definitions.
 - **Full-overscan horizontal recentring**: in `"full"` presentation, a standard
   (non-overscan) display is recentred because the framebuffer captures a deep
   slab of left overscan that would otherwise push the picture right of centre.
@@ -501,11 +511,12 @@ staircase.
 
 The scanline count is what the window actually shows, not what the
 framebuffer holds (`crt_scanline_count`). The TV-aperture present path
-copies a fixed `TV_PAL_PRESENT_HEIGHT` (540) row crop rather than the whole
-woven buffer, so its count comes from the aperture -- 270 lines, against 285
-for a standard PAL field in `"full"` overscan -- and is rescaled by the
-rect/content ratio when the square-pixel canvas pads the aperture with bezel
-rows. Interlaced content is deliberately drawn at field-line pitch over the
+copies the standard scan's aperture crop (`TV_PAL_PRESENT_HEIGHT`, 540
+rows, or `TV_NTSC_PRESENT_HEIGHT`, 428) rather than the whole woven
+buffer, so its count comes from the aperture -- 270 lines on a 50 Hz scan
+and 214 on a 60 Hz one, against 285 for a standard field in `"full"`
+overscan -- and is rescaled by the rect/content ratio when the
+square-pixel canvas pads the aperture with bezel rows. Interlaced content is deliberately drawn at field-line pitch over the
 woven frame: one gap per emulated line, which is what a 15 kHz set fed an
 interlaced signal looks like, rather than one per woven row.
 

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -87,6 +87,12 @@ pub fn save_scaled_y(
 /// slightly beyond the emulated capture buffer; the uncaptured margin is
 /// bezel, not picture, so replicating edge pixels there would fabricate
 /// content whenever the display fetches into the deepest overscan.
+///
+/// The crop's `height` rows are resampled onto `out_height` output rows
+/// (centre-aligned whole-row selection, no blending; a no-op when equal).
+/// The TV-aperture screenshot path relies on this: both video standards'
+/// apertures fill the same 4:3 glass, so a 60 Hz crop's rows scale onto the
+/// 50 Hz aperture's native row count.
 pub fn save_cropped_black_padded(
     path: &Path,
     fb: &[u32],
@@ -96,9 +102,15 @@ pub fn save_cropped_black_padded(
     y: usize,
     width: usize,
     height: usize,
+    out_height: usize,
 ) -> Result<()> {
     let cropped = crop_black_padded(fb, src_width, src_height, x, y, width, height)?;
-    save(path, &cropped, width as u32, height as u32)
+    if out_height == height {
+        return save(path, &cropped, width as u32, height as u32);
+    }
+    let mut scaled = Vec::new();
+    scale_y_into(&cropped, width, height, out_height, &mut scaled);
+    save(path, &scaled, width as u32, out_height as u32)
 }
 
 fn crop_black_padded(

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -50,20 +50,39 @@ pub fn compose_rtg_present(
 
 pub const STANDARD_PAL_VISIBLE_WIDTH: usize = 320 * 2;
 pub const STANDARD_PAL_VISIBLE_LINES: usize = 256;
+pub const STANDARD_NTSC_VISIBLE_LINES: usize = 200;
 pub const STANDARD_PAL_VISIBLE_START_VPOS: u32 = 0x2C;
 // Default TV presentation keeps a small consumer-visible overscan margin while
 // still hiding the deep edge columns that often contain unfinished effects.
 pub const TV_HORIZONTAL_OVERSCAN_MARGIN: usize = 24 * 2;
+// Overscan field lines the TV aperture keeps above and below the standard
+// window.
+pub const TV_VERTICAL_OVERSCAN_MARGIN: usize = 7;
 
-// The reference TV aperture for standard PAL displays: the standard window
-// plus a symmetric 26-column overscan margin, cropped from the woven
-// presentation buffer. The desktop window and screenshot paths present this
-// rect; its right margin reaches 12 columns past the framebuffer's right
-// edge, which those paths pad with black bezel.
-pub const TV_PAL_PRESENT_WIDTH: usize = STANDARD_PAL_VISIBLE_WIDTH + 2 * 26;
-pub const TV_PAL_PRESENT_HEIGHT: usize = 540;
-pub const TV_PAL_PRESENT_SOURCE_X: usize = bitplane::STANDARD_VISIBLE_X0 - 26;
-pub const TV_PAL_PRESENT_SOURCE_Y: usize = 18;
+// The reference TV aperture for standard 15 kHz displays, cropped from the
+// woven presentation buffer. Horizontally the two video standards agree --
+// both place the standard 640-wide window at the same colour clocks -- so one
+// cutout (the standard window plus a symmetric 26-column overscan margin)
+// serves 50 Hz and 60 Hz scans alike; its right margin reaches 12 columns
+// past the framebuffer's right edge, which the presentation paths pad with
+// black bezel. Vertically the aperture follows the field line count: a
+// 312/313-line (50 Hz) scan carries the 256-line standard window, a
+// 262/263-line (60 Hz) scan the 200-line one, each cropped with the same
+// symmetric overscan margin.
+pub const TV_PRESENT_WIDTH: usize = STANDARD_PAL_VISIBLE_WIDTH + 2 * 26;
+pub const TV_PRESENT_SOURCE_X: usize = bitplane::STANDARD_VISIBLE_X0 - 26;
+pub const TV_PRESENT_SOURCE_Y: usize = 18;
+pub const TV_PAL_PRESENT_HEIGHT: usize =
+    (STANDARD_PAL_VISIBLE_LINES + 2 * TV_VERTICAL_OVERSCAN_MARGIN) * 2;
+pub const TV_NTSC_PRESENT_HEIGHT: usize =
+    (STANDARD_NTSC_VISIBLE_LINES + 2 * TV_VERTICAL_OVERSCAN_MARGIN) * 2;
+
+// Output rows a TV-aperture crop presents: both standards' apertures fill
+// the same 4:3 glass, so the crop always presents at the 50 Hz aperture's
+// native row count. A 50 Hz crop maps 1:1; a 60 Hz crop's 428 rows stretch
+// onto it, the taller picture lines of a 200-line display on the same
+// screen.
+pub const TV_GLASS_PRESENT_ROWS: usize = TV_PAL_PRESENT_HEIGHT;
 
 // The TV aperture clipped to columns the framebuffer actually captures, for
 // frontends whose frame should end on real pixels instead of black bezel
@@ -71,26 +90,26 @@ pub const TV_PAL_PRESENT_SOURCE_Y: usize = 18;
 // captured right-overscan width, mirrored to the left so the standard
 // window stays exactly centred; the right edge lands on the framebuffer's
 // edge by construction.
-pub const TV_PAL_CAPTURED_MARGIN_X: usize =
+pub const TV_CAPTURED_MARGIN_X: usize =
     FB_WIDTH - bitplane::STANDARD_VISIBLE_X0 - STANDARD_PAL_VISIBLE_WIDTH;
-pub const TV_PAL_CAPTURED_SOURCE_X: usize =
-    bitplane::STANDARD_VISIBLE_X0 - TV_PAL_CAPTURED_MARGIN_X;
-pub const TV_PAL_CAPTURED_WIDTH: usize = STANDARD_PAL_VISIBLE_WIDTH + 2 * TV_PAL_CAPTURED_MARGIN_X;
+pub const TV_CAPTURED_SOURCE_X: usize = bitplane::STANDARD_VISIBLE_X0 - TV_CAPTURED_MARGIN_X;
+pub const TV_CAPTURED_WIDTH: usize = STANDARD_PAL_VISIBLE_WIDTH + 2 * TV_CAPTURED_MARGIN_X;
 
 // The captured aperture's invariants: it ends exactly on the framebuffer
 // edge (no bezel columns), keeps symmetric margins around the standard
-// window, starts inside the reference aperture, and its vertical crop fits
-// the woven field.
+// window, starts inside the reference aperture, and both standards'
+// vertical crops fit the woven field.
 const _: () = {
-    assert!(TV_PAL_CAPTURED_SOURCE_X + TV_PAL_CAPTURED_WIDTH == FB_WIDTH);
-    assert!(bitplane::STANDARD_VISIBLE_X0 - TV_PAL_CAPTURED_SOURCE_X == TV_PAL_CAPTURED_MARGIN_X);
+    assert!(TV_CAPTURED_SOURCE_X + TV_CAPTURED_WIDTH == FB_WIDTH);
+    assert!(bitplane::STANDARD_VISIBLE_X0 - TV_CAPTURED_SOURCE_X == TV_CAPTURED_MARGIN_X);
     assert!(
-        TV_PAL_CAPTURED_SOURCE_X + TV_PAL_CAPTURED_WIDTH
+        TV_CAPTURED_SOURCE_X + TV_CAPTURED_WIDTH
             - (bitplane::STANDARD_VISIBLE_X0 + STANDARD_PAL_VISIBLE_WIDTH)
-            == TV_PAL_CAPTURED_MARGIN_X
+            == TV_CAPTURED_MARGIN_X
     );
-    assert!(TV_PAL_CAPTURED_SOURCE_X >= TV_PAL_PRESENT_SOURCE_X);
-    assert!(TV_PAL_PRESENT_SOURCE_Y + TV_PAL_PRESENT_HEIGHT <= OUT_HEIGHT);
+    assert!(TV_CAPTURED_SOURCE_X >= TV_PRESENT_SOURCE_X);
+    assert!(TV_PRESENT_SOURCE_Y + TV_PAL_PRESENT_HEIGHT <= OUT_HEIGHT);
+    assert!(TV_NTSC_PRESENT_HEIGHT < TV_PAL_PRESENT_HEIGHT);
 };
 
 pub fn post_process_rendered_field(
@@ -295,17 +314,32 @@ pub fn should_render_emulated_frame(last_rendered: Option<u64>, current: u64) ->
     last_rendered != Some(current)
 }
 
-pub fn is_standard_pal_presentation(geometry: FrameGeometry, src_rows: usize) -> bool {
-    !geometry.programmable && geometry.frame_lines >= 312 && src_rows == OUT_HEIGHT
+pub fn is_standard_presentation(geometry: FrameGeometry, src_rows: usize) -> bool {
+    !geometry.programmable && src_rows == OUT_HEIGHT
 }
 
-pub fn uses_standard_pal_tv_aperture(
+/// TV-aperture crop height in woven rows for this frame, or None when the
+/// frame is not a standard 15 kHz scan rendering the standard horizontal
+/// window (programmable scans and true horizontal-overscan fetches present
+/// on the full framebuffer instead). The height follows the scan the frame
+/// actually ran, not the configured standard: a 312/313-line (50 Hz) field
+/// carries the 256-line standard window, a 262/263-line (60 Hz) field the
+/// 200-line one.
+pub fn standard_tv_aperture_rows(
     geometry: FrameGeometry,
     src_rows: usize,
     snapshot: &RenderRegisterSnapshot,
-) -> bool {
-    is_standard_pal_presentation(geometry, src_rows)
-        && bitplane::uses_standard_horizontal_content(snapshot)
+) -> Option<usize> {
+    if !is_standard_presentation(geometry, src_rows)
+        || !bitplane::uses_standard_horizontal_content(snapshot)
+    {
+        return None;
+    }
+    Some(if geometry.frame_lines >= 312 {
+        TV_PAL_PRESENT_HEIGHT
+    } else {
+        TV_NTSC_PRESENT_HEIGHT
+    })
 }
 
 #[cfg(test)]
@@ -314,11 +348,53 @@ mod tests {
 
     #[test]
     fn captured_aperture_clears_the_tv_bezel_mask() {
-        // The const block by the TV_PAL_CAPTURED_* definitions pins the
+        // The const block by the TV_CAPTURED_* definitions pins the
         // aperture geometry at compile time; the mask bounds come from a
         // runtime helper, so check here that a captured-aperture crop never
         // shows masked black columns.
-        assert!(TV_PAL_CAPTURED_SOURCE_X >= tv_source_h_bounds().0);
+        assert!(TV_CAPTURED_SOURCE_X >= tv_source_h_bounds().0);
+    }
+
+    #[test]
+    fn tv_aperture_rows_follow_the_scans_field_line_count() {
+        // A standard scan's TV aperture is picked by the lines the frame
+        // actually ran (BEAMCON0 can retune Agnus mid-session), holding the
+        // 256-line standard window of a 50 Hz field and the 200-line window
+        // of a 60 Hz field with the same overscan margin.
+        let snapshot = RenderRegisterSnapshot {
+            diwstrt: 0x2C81,
+            diwstop: 0xF4C1,
+            ddfstrt: 0x38,
+            ddfstop: 0xD0,
+            ..Default::default()
+        };
+        let pal = FrameGeometry::standard(0x1C, 313, false);
+        let ntsc = FrameGeometry::standard(0x1C, 262, false);
+        assert_eq!(
+            standard_tv_aperture_rows(pal, OUT_HEIGHT, &snapshot),
+            Some(TV_PAL_PRESENT_HEIGHT)
+        );
+        assert_eq!(
+            standard_tv_aperture_rows(ntsc, OUT_HEIGHT, &snapshot),
+            Some(TV_NTSC_PRESENT_HEIGHT)
+        );
+        // A programmable scan or a native-height field presents in full.
+        let mut programmable = ntsc;
+        programmable.programmable = true;
+        assert_eq!(
+            standard_tv_aperture_rows(programmable, OUT_HEIGHT, &snapshot),
+            None
+        );
+        assert_eq!(standard_tv_aperture_rows(ntsc, 400, &snapshot), None);
+    }
+
+    #[test]
+    fn ntsc_aperture_stays_inside_the_rendered_field() {
+        // A 60 Hz field renders (frame_lines - visible_start) field rows;
+        // the aperture crop must end inside them so it never shows
+        // unscanned buffer rows as picture.
+        let rendered_woven_rows = 2 * (262 - 0x1C);
+        assert!(TV_PRESENT_SOURCE_Y + TV_NTSC_PRESENT_HEIGHT <= rendered_woven_rows);
     }
 
     fn v_window_fixture(field_rows: usize, total_rows: usize) -> Vec<u32> {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -10,7 +10,7 @@ use super::launcher::{LauncherField, LauncherState, MachineSetup, StatusMessage}
 use super::ui::{self, Panel, UiControl, UiState};
 use super::{
     bitplane, font, present_height, FB_HEIGHT, FB_PIXELS, FB_WIDTH, HOST_SHORTCUT_MODIFIER_LABEL,
-    MAX_CANVAS_PIXELS, MAX_VISIBLE_LINES,
+    MAX_CANVAS_PIXELS, MAX_VISIBLE_LINES, PRESENT_HEIGHT_SQUARE,
 };
 use crate::audio::{AudioSink, CpalSink};
 use crate::bus::{BeamWriteSource, FrontPanelStatus, PortDevice, VideoRenderFrameTiming};
@@ -181,18 +181,26 @@ fn window_present_height() -> usize {
 /// lines the present copy actually puts on screen, rescaled when that copy
 /// letterboxes them inside the rect.
 ///
-/// `tv_aperture` mirrors `copy_window_present_frame`'s own branch condition.
-/// That path shows the fixed [`TV_PAL_PRESENT_HEIGHT`]-row aperture crop
-/// instead of the whole woven buffer, so its line count comes from the
-/// aperture, not from `present_rows` -- 270 lines, not 285, in the default
-/// TV-overscan presentation. The square-pixel canvas is taller than the
-/// aperture and pads it with bezel rows (`tv_aperture_source_row`), so the
-/// count scales back up by the rect/content ratio to keep the pitch right
-/// across the whole viewport.
-fn crt_scanline_count(present_rows: usize, present_h: usize, tv_aperture: bool) -> f32 {
-    let (woven_rows, content_rows) = if tv_aperture {
-        let pad = present_h.saturating_sub(TV_PAL_PRESENT_HEIGHT) / 2;
-        (TV_PAL_PRESENT_HEIGHT, present_h - 2 * pad)
+/// `tv_aperture_rows` mirrors `copy_window_present_frame`'s own branch
+/// condition: Some when that path shows a TV-aperture crop instead of the
+/// whole woven buffer, carrying the crop's row count, so the line count
+/// comes from the aperture, not from `present_rows` -- 270 lines, not 285,
+/// in the default 50 Hz TV-overscan presentation, 214 on a 60 Hz scan. The
+/// square-pixel canvas is taller than the aperture and pads it with bezel
+/// rows (`tv_aperture_source_row`), so the count scales back up by the
+/// rect/content ratio to keep the pitch right across the whole viewport.
+fn crt_scanline_count(
+    present_rows: usize,
+    present_h: usize,
+    tv_aperture_rows: Option<usize>,
+) -> f32 {
+    let (woven_rows, content_rows) = if let Some(aperture_rows) = tv_aperture_rows {
+        let pad = if present_h == PRESENT_HEIGHT_SQUARE {
+            present_h.saturating_sub(aperture_rows) / 2
+        } else {
+            0
+        };
+        (aperture_rows, present_h - 2 * pad)
     } else {
         (present_rows, present_h)
     };
@@ -278,7 +286,7 @@ const JOY_TOGGLE_X: usize = VOLUME_GLYPH_X - 2 - JOY_TOGGLE_W;
 // The standard-window and TV-aperture constants live in
 // `video/present_common.rs` with the presentation helpers they anchor
 // (re-exported through `use present::*` below).
-const TV_PAL_LIVE_PAD_X: usize = (FB_WIDTH - TV_PAL_PRESENT_WIDTH) / 2;
+const TV_LIVE_PAD_X: usize = (FB_WIDTH - TV_PRESENT_WIDTH) / 2;
 const STATUS_BG: u32 = rgba(28, 28, 26);
 const STATUS_TOP: u32 = rgba(78, 76, 70);
 const STATUS_BOTTOM: u32 = rgba(12, 12, 11);
@@ -596,7 +604,10 @@ pub struct App {
     /// Pixels per `present_fb` row: FB_WIDTH classically, twice that for
     /// a 35 ns super-hi-res canvas.
     present_width: usize,
-    present_standard_tv_aperture: bool,
+    /// TV-aperture crop rows for the presented frame when it is a standard
+    /// 15 kHz scan with the standard horizontal window (None otherwise);
+    /// applied by the present copy under `Overscan::Tv`.
+    present_tv_aperture_rows: Option<usize>,
     /// Whether the presented frame came from a programmable (multisync) scan
     /// rather than a woven 15 kHz one. Those fields reach the presentation
     /// buffer at their native height, so neither the CRT pass nor its
@@ -1006,7 +1017,7 @@ struct RenderWorkerResult {
     presentation_fb: Vec<u32>,
     present_rows: usize,
     present_width: usize,
-    standard_tv_aperture: bool,
+    tv_aperture_rows: Option<usize>,
     programmable: bool,
     /// The job's frame snapshot, handed back for buffer reuse.
     input: bitplane::RenderInput,
@@ -1180,7 +1191,7 @@ impl App {
             present_width: FB_WIDTH,
             rtg_fb: Vec::new(),
             rtg_present_dims: None,
-            present_standard_tv_aperture: true,
+            present_tv_aperture_rows: Some(TV_PAL_PRESENT_HEIGHT),
             present_programmable: false,
             render: None,
             debugger_tool_window: None,
@@ -3063,7 +3074,8 @@ impl ApplicationHandler for App {
                             // frame fills the buffer on its own terms, so
                             // applying it here would show a sub-rect of the
                             // board's screen.
-                            self.present_standard_tv_aperture && self.rtg_present_dims.is_none(),
+                            self.present_tv_aperture_rows
+                                .filter(|_| self.rtg_present_dims.is_none()),
                         );
                         // The tint models the monitor on the Amiga's video
                         // output, so RTG board scanout stays untinted here
@@ -3149,10 +3161,11 @@ impl ApplicationHandler for App {
                             self.present_rows,
                             present_height(),
                             // The same branch copy_window_present_frame took.
-                            self.overscan == Overscan::Tv
-                                && self.present_standard_tv_aperture
-                                && self.rtg_present_dims.is_none()
-                                && self.present_width == FB_WIDTH,
+                            self.present_tv_aperture_rows.filter(|_| {
+                                self.overscan == Overscan::Tv
+                                    && self.rtg_present_dims.is_none()
+                                    && self.present_width == FB_WIDTH
+                            }),
                         );
                         let kind = self.crt_shader_kind;
                         let strength = self.shader_strength;
@@ -8719,7 +8732,7 @@ impl App {
             src_rows,
             self.present_width,
             self.overscan,
-            self.present_standard_tv_aperture,
+            self.present_tv_aperture_rows,
         );
         match result {
             Ok(()) => info!("screenshot saved: {}", path.display()),
@@ -8793,7 +8806,7 @@ impl App {
             src_rows,
             self.present_width,
             self.overscan,
-            self.present_standard_tv_aperture,
+            self.present_tv_aperture_rows,
         );
         match result {
             Ok(()) => {
@@ -8939,7 +8952,7 @@ impl App {
         self.render_recycle_fb = old;
         self.present_rows = result.present_rows;
         self.present_width = result.present_width;
-        self.present_standard_tv_aperture = result.standard_tv_aperture;
+        self.present_tv_aperture_rows = result.tv_aperture_rows;
         self.present_programmable = result.programmable;
         self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(result.emulated_frame);
@@ -9066,7 +9079,7 @@ impl App {
         self.rtg_present_dims = Some((native_w, native_h));
         self.present_rows = rows;
         self.present_width = FB_WIDTH;
-        self.present_standard_tv_aperture = false;
+        self.present_tv_aperture_rows = None;
         self.present_programmable = false;
         self.last_rendered_emulated_frame = Some(emulated_frame);
         self.last_submitted_render_frame = Some(emulated_frame);
@@ -9131,8 +9144,8 @@ impl App {
             !geometry.programmable,
         );
         self.refresh_present_from_deinterlacer();
-        self.present_standard_tv_aperture =
-            uses_standard_pal_tv_aperture(geometry, self.present_rows, &base);
+        self.present_tv_aperture_rows =
+            standard_tv_aperture_rows(geometry, self.present_rows, &base);
         self.present_programmable = geometry.programmable;
         self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(emulated_frame);

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -62,7 +62,7 @@ pub(super) fn render_job_to_presentation(
         presentation_fb,
         present_rows,
         present_width,
-        standard_tv_aperture: uses_standard_pal_tv_aperture(geometry, present_rows, &base),
+        tv_aperture_rows: standard_tv_aperture_rows(geometry, present_rows, &base),
         programmable: geometry.programmable,
         input,
     }
@@ -452,14 +452,15 @@ pub(super) fn copy_window_present_frame(
     frame: &mut [u8],
     texture_scale: usize,
     overscan: Overscan,
-    standard_tv_aperture: bool,
+    tv_aperture_rows: Option<usize>,
 ) {
     // The TV aperture is a standard-scan crop; standard scans always render
     // the classic canvas width.
-    if overscan == Overscan::Tv && standard_tv_aperture && src_width == FB_WIDTH {
-        copy_tv_aperture_to_window(src_fb, src_rows, frame, texture_scale);
-    } else {
-        copy_present_frame(src_fb, src_rows, src_width, frame, texture_scale);
+    match tv_aperture_rows {
+        Some(aperture_rows) if overscan == Overscan::Tv && src_width == FB_WIDTH => {
+            copy_tv_aperture_to_window(src_fb, src_rows, frame, texture_scale, aperture_rows)
+        }
+        _ => copy_present_frame(src_fb, src_rows, src_width, frame, texture_scale),
     }
 }
 
@@ -468,6 +469,7 @@ pub(super) fn copy_tv_aperture_to_window(
     src_rows: usize,
     frame: &mut [u8],
     texture_scale: usize,
+    aperture_rows: usize,
 ) {
     debug_assert!(src_fb.len() >= src_rows * FB_WIDTH);
     debug_assert_eq!(
@@ -484,24 +486,23 @@ pub(super) fn copy_tv_aperture_to_window(
     let black_px = rgba(0, 0, 0);
     let black = black_px.to_le_bytes();
     for y in 0..out_rows {
-        let Some(crop_y) = tv_aperture_source_row(y, present_rows, texture_scale) else {
+        let Some(crop_y) = tv_aperture_source_row(y, present_rows, texture_scale, aperture_rows)
+        else {
             let dst = &mut frame[y * dst_stride..(y + 1) * dst_stride];
             for px in dst.chunks_exact_mut(4) {
                 px.copy_from_slice(&black);
             }
             continue;
         };
-        let src_y = (TV_PAL_PRESENT_SOURCE_Y + crop_y).min(src_rows - 1);
+        let src_y = (TV_PRESENT_SOURCE_Y + crop_y).min(src_rows - 1);
         let row = &src_fb[src_y * FB_WIDTH..(src_y + 1) * FB_WIDTH];
         let dst_off = y * dst_stride;
         match texture_scale {
             1 => {
                 let dst = &mut frame[dst_off..dst_off + dst_stride];
                 for x in 0..FB_WIDTH {
-                    let crop_x = x
-                        .saturating_sub(TV_PAL_LIVE_PAD_X)
-                        .min(TV_PAL_PRESENT_WIDTH - 1);
-                    let src_x = TV_PAL_PRESENT_SOURCE_X + crop_x;
+                    let crop_x = x.saturating_sub(TV_LIVE_PAD_X).min(TV_PRESENT_WIDTH - 1);
+                    let src_x = TV_PRESENT_SOURCE_X + crop_x;
                     let pixel = if src_x < FB_WIDTH {
                         row[src_x]
                     } else {
@@ -512,10 +513,8 @@ pub(super) fn copy_tv_aperture_to_window(
             }
             2 => {
                 for x in 0..FB_WIDTH {
-                    let crop_x = x
-                        .saturating_sub(TV_PAL_LIVE_PAD_X)
-                        .min(TV_PAL_PRESENT_WIDTH - 1);
-                    let src_x = TV_PAL_PRESENT_SOURCE_X + crop_x;
+                    let crop_x = x.saturating_sub(TV_LIVE_PAD_X).min(TV_PRESENT_WIDTH - 1);
+                    let src_x = TV_PRESENT_SOURCE_X + crop_x;
                     let pixel = if src_x < FB_WIDTH {
                         row[src_x]
                     } else {
@@ -532,9 +531,9 @@ pub(super) fn copy_tv_aperture_to_window(
                 for x in 0..FB_WIDTH * texture_scale {
                     let out_x = x / texture_scale;
                     let crop_x = out_x
-                        .saturating_sub(TV_PAL_LIVE_PAD_X)
-                        .min(TV_PAL_PRESENT_WIDTH - 1);
-                    let src_x = TV_PAL_PRESENT_SOURCE_X + crop_x;
+                        .saturating_sub(TV_LIVE_PAD_X)
+                        .min(TV_PRESENT_WIDTH - 1);
+                    let src_x = TV_PRESENT_SOURCE_X + crop_x;
                     let pixel = if src_x < FB_WIDTH {
                         row[src_x]
                     } else {
@@ -547,27 +546,33 @@ pub(super) fn copy_tv_aperture_to_window(
     }
 }
 
-/// Map an output texture row to a row of the 540-line TV aperture crop,
-/// or None for rows that fall on the black bezel of the square-pixel
-/// presentation. The square canvas (570 rows) is taller than the
-/// aperture, so the crop is centred between black bands -- the vertical
-/// counterpart of the TV_PAL_LIVE_PAD_X side bands -- and its rows map
-/// 1:1. The default 4:3 canvas (537 rows) is shorter than the aperture
-/// and keeps mapping all 540 rows onto the output, as before.
+/// Map an output texture row to a row of the `aperture_rows`-line TV
+/// aperture crop, or None for rows that fall on the black bezel of the
+/// square-pixel presentation. The square canvas (570 rows) maps woven rows
+/// 1:1, so an aperture shorter than it is centred between black bands --
+/// the vertical counterpart of the TV_LIVE_PAD_X side bands. The 4:3
+/// canvas (537 rows) is the glass itself, which both standards' apertures
+/// fill: all aperture rows rescale onto the whole output (540 onto 537 for
+/// a 50 Hz scan, 428 for a 60 Hz one).
 pub(super) fn tv_aperture_source_row(
     y: usize,
     present_rows: usize,
     texture_scale: usize,
+    aperture_rows: usize,
 ) -> Option<usize> {
     let out_rows = present_rows * texture_scale;
-    let pad_rows = present_rows.saturating_sub(TV_PAL_PRESENT_HEIGHT) / 2 * texture_scale;
+    let pad_rows = if present_rows == crate::video::PRESENT_HEIGHT_SQUARE {
+        present_rows.saturating_sub(aperture_rows) / 2 * texture_scale
+    } else {
+        0
+    };
     let content_rows = out_rows - 2 * pad_rows;
     if y < pad_rows || y >= pad_rows + content_rows {
         return None;
     }
     Some(screenshot::scaled_source_row(
         y - pad_rows,
-        TV_PAL_PRESENT_HEIGHT,
+        aperture_rows,
         content_rows,
     ))
 }
@@ -858,7 +863,7 @@ pub(super) fn save_present_frame(
     src_rows: usize,
     src_width: usize,
     overscan: Overscan,
-    standard_tv_aperture: bool,
+    tv_aperture_rows: Option<usize>,
 ) -> anyhow::Result<()> {
     if crate::envcfg::flag("COPPERLINE_SHOT_RAW") {
         return screenshot::save(
@@ -869,17 +874,23 @@ pub(super) fn save_present_frame(
         );
     }
 
-    if overscan == Overscan::Tv && standard_tv_aperture && src_width == FB_WIDTH {
-        return screenshot::save_cropped_black_padded(
-            path,
-            present_fb,
-            FB_WIDTH,
-            src_rows,
-            TV_PAL_PRESENT_SOURCE_X,
-            TV_PAL_PRESENT_SOURCE_Y,
-            TV_PAL_PRESENT_WIDTH,
-            TV_PAL_PRESENT_HEIGHT,
-        );
+    if let Some(aperture_rows) = tv_aperture_rows {
+        if overscan == Overscan::Tv && src_width == FB_WIDTH {
+            // Both standards' apertures fill the same 4:3 glass, so the
+            // saved picture keeps one shape: a 60 Hz crop's rows scale onto
+            // the 50 Hz aperture's native row count.
+            return screenshot::save_cropped_black_padded(
+                path,
+                present_fb,
+                FB_WIDTH,
+                src_rows,
+                TV_PRESENT_SOURCE_X,
+                TV_PRESENT_SOURCE_Y,
+                TV_PRESENT_WIDTH,
+                aperture_rows,
+                TV_GLASS_PRESENT_ROWS,
+            );
+        }
     }
 
     // A double-width (35 ns) canvas saves at double height too, keeping the

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -24,8 +24,8 @@ use super::{
     DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
     POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL, POWER_LED_OFF,
     STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-    TRACK_SEGMENT_ON, TV_PAL_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT, TV_PAL_PRESENT_SOURCE_X,
-    TV_PAL_PRESENT_SOURCE_Y, TV_PAL_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
+    TRACK_SEGMENT_ON, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT, TV_PRESENT_SOURCE_X,
+    TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
@@ -765,27 +765,27 @@ fn crt_scanline_count_follows_what_the_present_copy_shows() {
     // TV aspect + TV aperture (the out-of-the-box config): 540 aperture rows
     // = 270 lines, filling the rect.
     assert_eq!(
-        crt_scanline_count(woven, PRESENT_HEIGHT_TV, true),
+        crt_scanline_count(woven, PRESENT_HEIGHT_TV, Some(TV_PAL_PRESENT_HEIGHT)),
         (TV_PAL_PRESENT_HEIGHT / 2) as f32
     );
     // Full overscan takes the plain copy, which shows every woven row.
     assert_eq!(
-        crt_scanline_count(woven, PRESENT_HEIGHT_TV, false),
+        crt_scanline_count(woven, PRESENT_HEIGHT_TV, None),
         (woven / 2) as f32
     );
     // The square canvas is taller than the aperture and pads it with bezel
     // rows, so the same 270 lines cover only 540 of 570 rect rows: the pitch
     // across the whole viewport scales up to match.
     assert_eq!(
-        crt_scanline_count(woven, PRESENT_HEIGHT_SQUARE, true),
+        crt_scanline_count(woven, PRESENT_HEIGHT_SQUARE, Some(TV_PAL_PRESENT_HEIGHT)),
         270.0 * PRESENT_HEIGHT_SQUARE as f32 / TV_PAL_PRESENT_HEIGHT as f32
     );
     assert_eq!(
-        crt_scanline_count(woven, PRESENT_HEIGHT_SQUARE, true),
+        crt_scanline_count(woven, PRESENT_HEIGHT_SQUARE, Some(TV_PAL_PRESENT_HEIGHT)),
         285.0
     );
     assert_eq!(
-        crt_scanline_count(woven, PRESENT_HEIGHT_SQUARE, false),
+        crt_scanline_count(woven, PRESENT_HEIGHT_SQUARE, None),
         (woven / 2) as f32
     );
 }
@@ -2118,7 +2118,7 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
     use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
     let scale = 1;
     let mut src = vec![0u32; OUT_PIXELS];
-    let row_y = TV_PAL_PRESENT_SOURCE_Y;
+    let row_y = TV_PRESENT_SOURCE_Y;
     let standard_left = crate::video::bitplane::STANDARD_VISIBLE_X0;
     let standard_right = standard_left + 320 * 2 - 1;
     let left_marker = 0x1122_3344u32;
@@ -2126,7 +2126,7 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
     let left_edge = 0x99AA_BBCCu32;
     let right_edge = 0xDDEE_FF00u32;
 
-    src[row_y * FB_WIDTH + TV_PAL_PRESENT_SOURCE_X] = left_edge;
+    src[row_y * FB_WIDTH + TV_PRESENT_SOURCE_X] = left_edge;
     src[row_y * FB_WIDTH + FB_WIDTH - 1] = right_edge;
     src[row_y * FB_WIDTH + standard_left] = left_marker;
     src[row_y * FB_WIDTH + standard_right] = right_marker;
@@ -2139,10 +2139,10 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
         &mut frame,
         scale,
         Overscan::Tv,
-        true,
+        Some(TV_PAL_PRESENT_HEIGHT),
     );
 
-    let dst_standard_left = TV_PAL_LIVE_PAD_X + (standard_left - TV_PAL_PRESENT_SOURCE_X);
+    let dst_standard_left = TV_LIVE_PAD_X + (standard_left - TV_PRESENT_SOURCE_X);
     let dst_standard_right = dst_standard_left + 320 * 2 - 1;
     assert_eq!(dst_standard_left, FB_WIDTH - 1 - dst_standard_right);
     assert_eq!(
@@ -2154,7 +2154,7 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
         right_marker.to_le_bytes()
     );
     assert_eq!(pixel(&frame, 0, 0, scale), left_edge.to_le_bytes());
-    let dst_fb_right = TV_PAL_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PAL_PRESENT_SOURCE_X);
+    let dst_fb_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PRESENT_SOURCE_X);
     assert_eq!(
         pixel(&frame, dst_fb_right, 0, scale),
         right_edge.to_le_bytes()
@@ -2172,7 +2172,7 @@ fn tv_window_copy_black_pads_aperture_past_framebuffer() {
     let black = rgba(0, 0, 0).to_le_bytes();
     for scale in 1..=3 {
         let mut src = vec![0u32; OUT_PIXELS];
-        let row_y = TV_PAL_PRESENT_SOURCE_Y;
+        let row_y = TV_PRESENT_SOURCE_Y;
         let edge = 0xDDEE_FF00u32;
         src[row_y * FB_WIDTH + FB_WIDTH - 1] = edge;
 
@@ -2184,10 +2184,10 @@ fn tv_window_copy_black_pads_aperture_past_framebuffer() {
             &mut frame,
             scale,
             Overscan::Tv,
-            true,
+            Some(TV_PAL_PRESENT_HEIGHT),
         );
 
-        let dst_fb_right = TV_PAL_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PAL_PRESENT_SOURCE_X);
+        let dst_fb_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PRESENT_SOURCE_X);
         assert_eq!(
             pixel(&frame, dst_fb_right * scale, 0, scale),
             edge.to_le_bytes(),
@@ -2212,7 +2212,7 @@ fn tv_window_copy_preserves_true_overscan_fetches() {
     let standard_crop_edge = 0x5566_7788u32;
 
     src[0] = left_overscan;
-    src[TV_PAL_PRESENT_SOURCE_X] = standard_crop_edge;
+    src[TV_PRESENT_SOURCE_X] = standard_crop_edge;
 
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
     copy_window_present_frame(
@@ -2222,7 +2222,7 @@ fn tv_window_copy_preserves_true_overscan_fetches() {
         &mut frame,
         scale,
         Overscan::Tv,
-        false,
+        None,
     );
 
     assert_eq!(pixel(&frame, 0, 0, scale), left_overscan.to_le_bytes());
@@ -2250,47 +2250,141 @@ fn tv_aperture_row_mapping_pads_square_bezel_and_covers_43() {
     use crate::video::{PRESENT_HEIGHT_SQUARE, PRESENT_HEIGHT_TV};
     // 4:3 canvas: no bezel rows; the 540 aperture rows map onto all
     // 537 output rows exactly as before the square-pixel option.
-    assert_eq!(tv_aperture_source_row(0, PRESENT_HEIGHT_TV, 1), Some(0));
     assert_eq!(
-        tv_aperture_source_row(PRESENT_HEIGHT_TV - 1, PRESENT_HEIGHT_TV, 1),
+        tv_aperture_source_row(0, PRESENT_HEIGHT_TV, 1, TV_PAL_PRESENT_HEIGHT),
+        Some(0)
+    );
+    assert_eq!(
+        tv_aperture_source_row(
+            PRESENT_HEIGHT_TV - 1,
+            PRESENT_HEIGHT_TV,
+            1,
+            TV_PAL_PRESENT_HEIGHT
+        ),
         Some(TV_PAL_PRESENT_HEIGHT - 1)
     );
     // Square canvas: black bezel bands centre the aperture and its
     // rows map 1:1.
     let pad = (PRESENT_HEIGHT_SQUARE - TV_PAL_PRESENT_HEIGHT) / 2;
-    assert_eq!(tv_aperture_source_row(0, PRESENT_HEIGHT_SQUARE, 1), None);
     assert_eq!(
-        tv_aperture_source_row(pad - 1, PRESENT_HEIGHT_SQUARE, 1),
+        tv_aperture_source_row(0, PRESENT_HEIGHT_SQUARE, 1, TV_PAL_PRESENT_HEIGHT),
         None
     );
     assert_eq!(
-        tv_aperture_source_row(pad, PRESENT_HEIGHT_SQUARE, 1),
+        tv_aperture_source_row(pad - 1, PRESENT_HEIGHT_SQUARE, 1, TV_PAL_PRESENT_HEIGHT),
+        None
+    );
+    assert_eq!(
+        tv_aperture_source_row(pad, PRESENT_HEIGHT_SQUARE, 1, TV_PAL_PRESENT_HEIGHT),
         Some(0)
     );
     assert_eq!(
-        tv_aperture_source_row(pad + TV_PAL_PRESENT_HEIGHT - 1, PRESENT_HEIGHT_SQUARE, 1),
+        tv_aperture_source_row(
+            pad + TV_PAL_PRESENT_HEIGHT - 1,
+            PRESENT_HEIGHT_SQUARE,
+            1,
+            TV_PAL_PRESENT_HEIGHT
+        ),
         Some(TV_PAL_PRESENT_HEIGHT - 1)
     );
     assert_eq!(
-        tv_aperture_source_row(pad + TV_PAL_PRESENT_HEIGHT, PRESENT_HEIGHT_SQUARE, 1),
+        tv_aperture_source_row(
+            pad + TV_PAL_PRESENT_HEIGHT,
+            PRESENT_HEIGHT_SQUARE,
+            1,
+            TV_PAL_PRESENT_HEIGHT
+        ),
         None
     );
     // HiDPI: bezel and 1:1 mapping scale with the texture factor.
     assert_eq!(
-        tv_aperture_source_row(2 * pad - 1, PRESENT_HEIGHT_SQUARE, 2),
+        tv_aperture_source_row(2 * pad - 1, PRESENT_HEIGHT_SQUARE, 2, TV_PAL_PRESENT_HEIGHT),
         None
     );
     assert_eq!(
-        tv_aperture_source_row(2 * pad, PRESENT_HEIGHT_SQUARE, 2),
+        tv_aperture_source_row(2 * pad, PRESENT_HEIGHT_SQUARE, 2, TV_PAL_PRESENT_HEIGHT),
         Some(0)
     );
     assert_eq!(
-        tv_aperture_source_row(2 * pad + 1, PRESENT_HEIGHT_SQUARE, 2),
+        tv_aperture_source_row(2 * pad + 1, PRESENT_HEIGHT_SQUARE, 2, TV_PAL_PRESENT_HEIGHT),
         Some(0)
     );
     assert_eq!(
-        tv_aperture_source_row(2 * pad + 2, PRESENT_HEIGHT_SQUARE, 2),
+        tv_aperture_source_row(2 * pad + 2, PRESENT_HEIGHT_SQUARE, 2, TV_PAL_PRESENT_HEIGHT),
         Some(1)
+    );
+}
+
+#[test]
+fn ntsc_tv_aperture_row_mapping_stretches_43_and_pads_square() {
+    use crate::video::present_common::TV_NTSC_PRESENT_HEIGHT;
+    use crate::video::{PRESENT_HEIGHT_SQUARE, PRESENT_HEIGHT_TV};
+    // The 4:3 canvas is the glass, which a 60 Hz scan's aperture fills
+    // like a 50 Hz one: its 428 rows stretch onto all output rows, with
+    // no bezel bands (the lines of a 200-line display are taller on the
+    // same screen).
+    assert_eq!(
+        tv_aperture_source_row(0, PRESENT_HEIGHT_TV, 1, TV_NTSC_PRESENT_HEIGHT),
+        Some(0)
+    );
+    assert_eq!(
+        tv_aperture_source_row(
+            PRESENT_HEIGHT_TV - 1,
+            PRESENT_HEIGHT_TV,
+            1,
+            TV_NTSC_PRESENT_HEIGHT
+        ),
+        Some(TV_NTSC_PRESENT_HEIGHT - 1)
+    );
+    // The square-pixel canvas maps woven rows 1:1, so the shorter 60 Hz
+    // aperture is centred between black bezel bands.
+    let pad = (PRESENT_HEIGHT_SQUARE - TV_NTSC_PRESENT_HEIGHT) / 2;
+    assert_eq!(
+        tv_aperture_source_row(pad - 1, PRESENT_HEIGHT_SQUARE, 1, TV_NTSC_PRESENT_HEIGHT),
+        None
+    );
+    assert_eq!(
+        tv_aperture_source_row(pad, PRESENT_HEIGHT_SQUARE, 1, TV_NTSC_PRESENT_HEIGHT),
+        Some(0)
+    );
+    assert_eq!(
+        tv_aperture_source_row(
+            pad + TV_NTSC_PRESENT_HEIGHT - 1,
+            PRESENT_HEIGHT_SQUARE,
+            1,
+            TV_NTSC_PRESENT_HEIGHT
+        ),
+        Some(TV_NTSC_PRESENT_HEIGHT - 1)
+    );
+    assert_eq!(
+        tv_aperture_source_row(
+            pad + TV_NTSC_PRESENT_HEIGHT,
+            PRESENT_HEIGHT_SQUARE,
+            1,
+            TV_NTSC_PRESENT_HEIGHT
+        ),
+        None
+    );
+    // The CRT pass follows the same geometry: 214 beam lines fill the 4:3
+    // rect, and on the square canvas the bezel padding scales the pitch
+    // back to the uniform woven-row spacing.
+    use super::crt_scanline_count;
+    assert_eq!(
+        crt_scanline_count(
+            crate::video::deinterlace::OUT_HEIGHT,
+            PRESENT_HEIGHT_TV,
+            Some(TV_NTSC_PRESENT_HEIGHT)
+        ),
+        (TV_NTSC_PRESENT_HEIGHT / 2) as f32
+    );
+    assert_eq!(
+        crt_scanline_count(
+            crate::video::deinterlace::OUT_HEIGHT,
+            PRESENT_HEIGHT_SQUARE,
+            Some(TV_NTSC_PRESENT_HEIGHT)
+        ),
+        (TV_NTSC_PRESENT_HEIGHT / 2) as f32 * PRESENT_HEIGHT_SQUARE as f32
+            / TV_NTSC_PRESENT_HEIGHT as f32
     );
 }
 
@@ -2381,14 +2475,14 @@ fn tv_pal_crop_centres_standard_display_in_aperture() {
     let standard_left = crate::video::bitplane::STANDARD_VISIBLE_X0;
     let standard_right = standard_left + 640;
 
-    assert_eq!(TV_PAL_PRESENT_WIDTH, 692);
+    assert_eq!(TV_PRESENT_WIDTH, 692);
     assert_eq!(TV_PAL_PRESENT_HEIGHT, 540);
-    assert_eq!(standard_left - TV_PAL_PRESENT_SOURCE_X, 26);
+    assert_eq!(standard_left - TV_PRESENT_SOURCE_X, 26);
     assert_eq!(
-        TV_PAL_PRESENT_WIDTH - (standard_right - TV_PAL_PRESENT_SOURCE_X),
+        TV_PRESENT_WIDTH - (standard_right - TV_PRESENT_SOURCE_X),
         26
     );
-    assert_eq!(TV_PAL_PRESENT_SOURCE_Y, 18);
+    assert_eq!(TV_PRESENT_SOURCE_Y, 18);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Booting the WASM build in NTSC showed a black bar on the left of the picture inside the screen frame, plus a dead black band at the bottom. The desktop had the same problem: an NTSC `--screenshot-after` capture came out 716x537 with both artifacts baked in.

## Root cause

The default `overscan = "tv"` aperture crop was gated on `frame_lines >= 312`, so a standard NTSC field (262/263 lines) never qualified anywhere. Every frontend fell back to presenting the raw framebuffer:

- the TV bezel *mask* blacks the deep-left overscan columns (0..14) in the buffer, and the fallback shows them instead of cropping past them, hence the asymmetric left bar;
- the woven presentation buffer is PAL-sized (570 rows) but a 60 Hz field scans only ~470 of them, hence the bottom band.

## Fix

`present_common::standard_tv_aperture_rows()` now picks the crop height from the scan the frame actually ran: 540 woven rows around the 256-line standard window of a 312/313-line field, 428 around the 200-line window of a 262/263-line field, same 7-line overscan margin each side. The horizontal cutout is shared -- both standards place the standard window at the same colour clocks -- so its `TV_PAL_*` constants drop the PAL prefix.

Both apertures fill the same 4:3 glass, so presentation keeps one shape: screenshots/frame dumps stay 692x540 and the browser canvas 668x540 for either standard (a 60 Hz crop's rows scale up by whole-row selection, no blending). The square-pixel canvas keeps its 1:1 row mapping and centres the shorter aperture between bezel bands, and the CRT shader's scanline count follows (270 lines on 50 Hz, 214 on 60 Hz).

Docs updated in `docs/guide/configuration.md`, `docs/guide/browser.md`, and `docs/internals/video.md`.

## Verification

- KICK13 NTSC headless screenshot is now a clean 692x540 aperture; the same PAL capture is **byte-identical** before/after the change.
- Node smoke test against the rebuilt wasm pkg: `WebEmu('A500','NTSC')` + KICK13 presents 668x540 with zero black edge columns/rows.
- `cargo test` fully green incl. new regression tests for the aperture selection (PAL vs NTSC vs programmable), the NTSC row mapping (4:3 stretch, square-pixel padding), and the aperture-fits-the-rendered-field invariant; clippy/fmt clean; wasm target builds.
- `timing-test` goldens and vAmigaTS captures are unaffected (they run `COPPERLINE_SHOT_RAW` / `overscan = "full"`).

Note: `overscan = "full"` on NTSC still shows the unscanned bottom band, since that mode deliberately presents the whole capture buffer. The website repo ships its own copy of `pkg/`, so it needs a resync once this lands.