### PR TITLE
video: light HDD LED on host-folder filesystem access

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -57,7 +57,8 @@ be hidden entirely with `Cmd+Shift+F` / `Alt+Shift+F` or the **Status Bar**
 menu item):
 
 - **LED block.** PWR and FDD always; a green HDD activity LED on machines
-  with a hard-disk controller (Gayle or A4000 IDE, or any SCSI adapter); a
+  with a hard-disk controller (Gayle or A4000 IDE, or any SCSI adapter) or a
+  host-folder filesystem mount (`[[filesys]]`), lit while either is accessed; a
   blue CD activity LED on CDTV/CD32 that lights while the drive reads data
   or plays CD audio (on a machine whose CD drive is a SCSI CD-ROM unit,
   the LED shows CD-DA playback; its data reads ride the HDD LED with the

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3702,8 +3702,11 @@ impl Bus {
             audio_filter_on: self.paula.led_filter_enabled(),
             fdd_led_on: self.floppy.activity_led_on(),
             fdd_track: self.floppy.selected_track(),
-            hdd_led: (self.gayle.is_some() || self.ide_a4000.is_some() || self.has_scsi_device())
-                .then_some(self.emulated_cck < self.hdd_led_until_cck),
+            hdd_led: (self.gayle.is_some()
+                || self.ide_a4000.is_some()
+                || self.has_scsi_device()
+                || self.has_filesys_mount())
+            .then_some(self.emulated_cck < self.hdd_led_until_cck),
             cd_led: self
                 .cdtv
                 .as_ref()
@@ -3776,6 +3779,18 @@ impl Bus {
                         | crate::zorro_device::BoardDevice::A4091(_)
                 )
             })
+    }
+
+    /// Whether a host-folder filesystem board serves at least one mount. Such
+    /// a board has no disk controller, but its packet traffic rides the HDD
+    /// LED like any other Zorro storage device.
+    fn has_filesys_mount(&self) -> bool {
+        self.devices.iter().any(|d| {
+            matches!(
+                d,
+                crate::zorro_device::BoardDevice::Filesys(f) if f.has_mounts()
+            )
+        })
     }
 
     /// Whether an RTG board is driving the display (native chipset output

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -9513,6 +9513,29 @@ fn front_panel_hdd_led_follows_gayle_activity_with_hold() {
 }
 
 #[test]
+fn front_panel_hdd_led_present_for_filesys_mount() {
+    let mut bus = empty_bus();
+    // No storage controller and no filesys mount: no HDD LED at all.
+    assert_eq!(bus.front_panel_status().hdd_led, None);
+
+    // A host-folder filesystem board with a mount lights the HDD LED like
+    // any other storage device, even without a real disk controller.
+    let mount = crate::filesys::MountSpec {
+        path: std::env::temp_dir(),
+        volume: "Work".to_string(),
+        boot_pri: 0,
+        readonly: true,
+    };
+    bus.attach_devices(vec![crate::zorro_device::BoardDevice::Filesys(
+        crate::filesys::FilesysBoard::new(vec![mount]),
+    )]);
+    assert_eq!(bus.front_panel_status().hdd_led, Some(false));
+
+    bus.note_hdd_activity();
+    assert_eq!(bus.front_panel_status().hdd_led, Some(true));
+}
+
+#[test]
 fn front_panel_reports_host_output_volume() {
     let mut bus = empty_bus();
 

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -335,6 +335,10 @@ pub struct FilesysBoard {
     /// too: writes latch into the image (with side effects for the
     /// doorbells), so the read side is plain memory at any size/alignment.
     image: Vec<u8>,
+    /// Set when a DosPacket is handled, drained by `take_activity` to blink
+    /// the HDD LED. Transient: not part of the save state.
+    #[serde(skip)]
+    activity: bool,
 }
 
 impl FilesysBoard {
@@ -347,6 +351,12 @@ impl FilesysBoard {
         };
         board.set_mounts(mounts);
         board
+    }
+
+    /// Whether the board serves at least one mount, which is what gives the
+    /// machine an HDD LED even with no real disk controller.
+    pub fn has_mounts(&self) -> bool {
+        !self.units.is_empty()
     }
 
     /// `[machine] rom_scsi_device_disable`: unlink the ROM's scsi.device at
@@ -1612,6 +1622,9 @@ impl FilesysBoard {
             return;
         };
         let port = self.units.get(unit).and_then(|u| u.port).unwrap_or(0);
+        // Any packet touching a mount is host filesystem traffic: blink the
+        // HDD LED, mirroring a real filesystem handler's disk access.
+        self.activity = true;
         let mut guest_op = None;
         let (res1, res2, dp_type) = self.with_guest_bus(host, base, |board, bus| {
             let dp_type = bus.read_long(pkt + 8) as i32;
@@ -1710,6 +1723,10 @@ impl ZorroDevice for FilesysBoard {
     }
 
     fn tick(&mut self, _cck: u32, _host: &mut DeviceHost) {}
+
+    fn take_activity(&mut self) -> bool {
+        std::mem::take(&mut self.activity)
+    }
 
     fn reset(&mut self) {
         // Power-on state: per-boot structures dropped, mounts kept. The next


### PR DESCRIPTION
## Summary

A `[[filesys]]` host-folder mount serves guest disk traffic through DosPacket
doorbell writes, but never reported any activity. As a result the green HDD
activity LED stayed dark during host-folder I/O, and on a machine with no real
disk controller (Gayle/IDE/SCSI) the HDD LED row was hidden entirely.

This wires the filesystem board into the existing HDD-LED activity path:

- `FilesysBoard` now sets a transient activity flag whenever it handles a
  DosPacket (`ring_doorbell`) and drains it via `take_activity()`. The existing
  Zorro write path already calls `take_activity()` → `note_hdd_activity()`, so
  this lights the standard ~100 ms HDD LED hold with no changes to the CPU or UI.
- `front_panel_status()` now surfaces the HDD LED when a filesys mount is
  present (new `has_filesys_mount()` helper), matching how Gayle/IDE/SCSI
  controllers present it — so filesys-only machines get the LED row at all.
- `docs/guide/ui.md` updated to note the filesys mount as an HDD-LED source.

The activity flag is `#[serde(skip)]`, so save states are unaffected.

## Test plan

- [x] `cargo build --release`, `cargo clippy` (no new warnings), `cargo fmt --check`
- [x] New unit test `front_panel_hdd_led_present_for_filesys_mount` (LED absent
      with no controller/mount, `Some(false)` once a mount is attached,
      `Some(true)` after activity)
- [x] Existing `front_panel_hdd_led_follows_gayle_activity_with_hold` still passes
- [x] Windowed run with a `[[filesys]]` mount: HDD LED row appears and blinks
      green while accessing the mounted volume (LEDs are host-window chrome, not
      visible in headless screenshots)

closes #319