### PR TITLE
video: add a 1084-style monitor bezel pass ([display] bezel)

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -366,6 +366,9 @@ video = "PAL"
 # shader-processed, so captures stay comparable whatever is set here.
 # shader_strength: how strongly the shader is mixed in, 0.0-1.0 (default
 # 1.0, the preset's full effect); 0.0 leaves the picture visually untouched.
+# bezel: frame the picture with a 1084-style monitor front bezel (default
+# false; Cmd/Alt+M toggles it live). Composes with any shader setting, and
+# like it is a window-display effect only: captures never include the frame.
 # tint: screen tint over the window image. "none" (default, full colour),
 # "bw" (black and white), "green" or "amber" (monochrome-monitor
 # phosphor), or "sepia". Like shader, a window-display effect only:
@@ -381,6 +384,7 @@ video = "PAL"
 # phosphor = 0.4
 # shader = "none"
 # shader_strength = 1.0
+# bezel = false
 # tint = "none"
 # full_screen = false
 # status_bar = true

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -553,6 +553,24 @@ frames coming from an RTG board's scanout (see `[rtg]` below), and for
 programmable multisync scan modes -- a 31 kHz scanout has no 15 kHz line
 structure to reproduce.
 
+`bezel` (default `false`) frames the window's picture with a monitor-style
+front bezel, also in the spirit of the 1084: the picture scales down into
+the rounded opening of a procedurally drawn plastic face -- warm-grey
+moulding, a dark recess around the tube face, rounded case corners and the
+power LED on the wider bottom band. The frame is drawn at the window's
+resolution, so it stays sharp at any size, and the picture keeps its aspect
+inside the opening. It is independent of `shader` and composes with any
+preset: with `"crt"` the bowed tube face sits inside the opening for the
+full monitor look. Cmd+M (macOS) / Alt+M toggles it live for the rest of
+the session without touching the config; the launcher's *Monitor bezel* row
+(*A/V & Emu*, *Video*) writes it, and `COPPERLINE_BEZEL=1|0` overrides the
+config for a single run.
+
+Like the shader pass, the bezel is presentation and nothing else: captures
+never include it, and it is skipped while a menu or overlay panel is open
+and for RTG scanout frames. Unlike the shader it does stay on for
+programmable multisync scans -- a frame has no line structure to get wrong.
+
 `tint` recolours the picture like the phosphor of a monochrome monitor:
 `"bw"` (black and white), `"green"` and `"amber"` (the two classic
 monochrome phosphors), or `"sepia"`; `"none"` (the default; `"off"` is

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -23,6 +23,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
 | `Cmd+K` | `Alt+K` | Open the [debugger console](../debugger/console) |
 | `Cmd+J` | `Alt+J` | Toggle joystick input mode: gamepad / keyboard (also the status-bar icon) |
+| `Cmd+M` | `Alt+M` | Toggle the 1084-style monitor bezel around the picture (`[display] bezel` sets the start-up value) |
 | `Cmd+Shift+A` | `Alt+Shift+A` | Cycle the audio output: Default, each host device, then Disabled (also the menu's Audio Out item) |
 | `Cmd+A` | `Alt+A` | Cycle Paula's audio filter: auto, on, off (also the menu's Audio Filter item) |
 | `Cmd+Shift++` / `Cmd+Shift+-` | `Alt+Shift++` / `Alt+Shift+-` | Raise / lower the parallel-port sampler input gain (only when a sampler is attached; also the menu's Sampler Gain item) |
@@ -326,7 +327,8 @@ The layout is:
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
   sounds and volume), **Video** (start fullscreen, status bar, overscan, pixel
-  aspect, screen tint, deinterlace, phosphor, CRT shader and shader strength),
+  aspect, screen tint, deinterlace, phosphor, CRT shader, shader strength and
+  monitor bezel),
   and **Emulation**
   (power-on, warp speed, pacing, realtime priority) -- opening on Audio, and
   switched freely between the three.

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,6 +224,13 @@ pub struct Config {
     /// (the preset's full effect, the default). A single knob for every
     /// preset so the effect can be dialled back without editing shaders.
     pub shader_strength: f32,
+    /// Draw a monitor-style front bezel around the window picture
+    /// (`[display] bezel`): the display shrinks into the rounded opening of
+    /// a procedural plastic frame in the spirit of the 1084 the Amiga
+    /// shipped with. Independent of `shader`, and a presentation stage like
+    /// it: screenshots, frame dumps, recordings and headless runs never
+    /// include the bezel.
+    pub bezel: bool,
     /// Screen tint applied to the window image: the phosphor colour of a
     /// monochrome monitor, or a sepia treatment. See [`Tint`].
     pub tint: Tint,
@@ -1478,6 +1485,7 @@ impl Default for Config {
             phosphor: 0.0,
             shader: ShaderMode::None,
             shader_strength: 1.0,
+            bezel: false,
             tint: Tint::None,
             full_screen: false,
             status_bar: true,
@@ -1971,6 +1979,9 @@ pub(crate) struct RawDisplay {
     /// Shader mix, 0.0 (invisible) to 1.0 (full effect, the default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) shader_strength: Option<f32>,
+    /// Monitor-style front bezel around the window picture (default false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bezel: Option<bool>,
     /// Screen tint: "none" (default), "bw", "green", "amber", or "sepia".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) tint: Option<String>,
@@ -2817,6 +2828,7 @@ impl TryFrom<RawConfig> for Config {
                 defaults.shader_strength
             }
         };
+        let bezel = raw.display.bezel.unwrap_or(defaults.bezel);
         let tint = match raw.display.tint.as_deref() {
             None => defaults.tint,
             Some(s) => parse_tint(s)?,
@@ -3243,6 +3255,7 @@ impl TryFrom<RawConfig> for Config {
             phosphor,
             shader,
             shader_strength,
+            bezel,
             tint,
             full_screen,
             status_bar,
@@ -4250,6 +4263,19 @@ pub fn resolve_shader_strength(from_config: f32) -> f32 {
     }
 }
 
+/// Resolve the monitor bezel: the `COPPERLINE_BEZEL` env var (0/false/off/no
+/// disables, anything else enables) overrides the `[display] bezel` config
+/// for one run.
+pub fn resolve_bezel(from_config: bool) -> bool {
+    match crate::envcfg::var("COPPERLINE_BEZEL") {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => from_config,
+    }
+}
+
 /// Resolve the screen tint: the `COPPERLINE_TINT` env var (a tint name)
 /// overrides the `[display] tint` config for one run.
 pub fn resolve_tint(from_config: Tint) -> Tint {
@@ -5071,6 +5097,19 @@ mod tests {
             "#,
         )?;
         assert_eq!(cfg.shader, ShaderMode::Crt);
+        Ok(())
+    }
+
+    #[test]
+    fn display_bezel_parses_and_defaults_to_off() -> Result<()> {
+        assert!(!parse_config("")?.bezel);
+        let cfg = parse_config(
+            r#"
+            [display]
+            bezel = true
+            "#,
+        )?;
+        assert!(cfg.bezel);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1690,6 +1690,7 @@ fn main() -> Result<()> {
         config::resolve_phosphor(cfg.phosphor),
         config::resolve_shader(cfg.shader.clone()),
         config::resolve_shader_strength(cfg.shader_strength),
+        config::resolve_bezel(cfg.bezel),
         config::resolve_tint(cfg.tint),
         cfg.full_screen,
         !cfg.status_bar,
@@ -1807,6 +1808,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_phosphor(0.0),
         config::resolve_shader(config::ShaderMode::None),
         config::resolve_shader_strength(1.0),
+        config::resolve_bezel(false),
         config::resolve_tint(config::Tint::None),
         // The config-screen placeholder is always a normal windowed UI.
         false,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -393,6 +393,7 @@ pub enum LauncherField {
     Phosphor,
     Shader,
     ShaderStrength,
+    Bezel,
     StartFullscreen,
     ShowStatusBar,
     FloppySounds,
@@ -633,7 +634,7 @@ const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
 const ETHERNET_ROWS: [Row; 1] = [row(F::Ethernet, "  A2065 board", Cycle)];
 // The A/V & Emu tab is split into three categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
-const VIDEO_ROWS: [Row; 9] = [
+const VIDEO_ROWS: [Row; 10] = [
     row(F::StartFullscreen, "Start fullscreen", Toggle),
     row(F::ShowStatusBar, "Status bar", Toggle),
     row(F::Overscan, "Overscan", Cycle),
@@ -643,6 +644,7 @@ const VIDEO_ROWS: [Row; 9] = [
     row(F::Phosphor, "Phosphor", Cycle),
     row(F::Shader, "CRT shader", Cycle),
     row(F::ShaderStrength, "Shader strength", Cycle),
+    row(F::Bezel, "Monitor bezel", Toggle),
 ];
 const AUDIO_ROWS: [Row; 6] = [
     row(F::AudioDevice, "Audio output", Cycle),
@@ -1078,6 +1080,8 @@ pub struct MachineSetup {
     shader_custom: Option<PathBuf>,
     /// Shader mix, 0.0 to 1.0 ([display] shader_strength).
     shader_strength: f32,
+    /// Monitor-style front bezel around the picture ([display] bezel).
+    bezel: bool,
     /// Screen tint ([display] tint).
     tint: Tint,
     /// Open fullscreen at start ([display] full_screen).
@@ -1227,6 +1231,7 @@ impl MachineSetup {
                 _ => None,
             },
             shader_strength: cfg.shader_strength,
+            bezel: cfg.bezel,
             tint: cfg.tint,
             start_fullscreen: cfg.full_screen,
             show_status_bar: cfg.status_bar,
@@ -1525,6 +1530,9 @@ impl MachineSetup {
         if (self.shader_strength - base.shader_strength).abs() > 1e-6 {
             raw.display.shader_strength = Some(self.shader_strength);
         }
+        if self.bezel != base.bezel {
+            raw.display.bezel = Some(self.bezel);
+        }
         if self.tint != base.tint {
             raw.display.tint = Some(tint_name(self.tint).to_string());
         }
@@ -1714,6 +1722,7 @@ impl MachineSetup {
         // "Custom" again.
         self.shader = base.shader.clone();
         self.shader_strength = base.shader_strength;
+        self.bezel = base.bezel;
         self.tint = base.tint;
         self.start_fullscreen = base.full_screen;
         self.show_status_bar = base.status_bar;
@@ -1917,6 +1926,7 @@ impl MachineSetup {
             F::StartFullscreen => self.start_fullscreen,
             F::ShowStatusBar => self.show_status_bar,
             F::Deinterlace => self.deinterlace,
+            F::Bezel => self.bezel,
             F::PowerOn => self.power_on,
             F::RealtimePriority => self.realtime_priority,
             _ => false,
@@ -2518,6 +2528,7 @@ impl MachineSetup {
             F::StartFullscreen => self.start_fullscreen = !self.start_fullscreen,
             F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
             F::Deinterlace => self.deinterlace = !self.deinterlace,
+            F::Bezel => self.bezel = !self.bezel,
             F::PowerOn => self.power_on = !self.power_on,
             F::RealtimePriority => self.realtime_priority = !self.realtime_priority,
             _ => {}
@@ -3727,6 +3738,23 @@ mod tests {
         s.cycle(LauncherField::Tint, false);
         assert_eq!(s.value_label(LauncherField::Tint), "Sepia");
         assert_eq!(s.to_raw().display.tint, Some("sepia".to_string()));
+    }
+
+    #[test]
+    fn bezel_round_trips_through_raw() {
+        let mut s = MachineSetup::default();
+        // Off is the baseline, so nothing is written for it.
+        assert!(!s.toggle_value(LauncherField::Bezel));
+        assert_eq!(s.to_raw().display.bezel, None);
+
+        s.toggle(LauncherField::Bezel);
+        assert!(s.toggle_value(LauncherField::Bezel));
+        assert_eq!(s.to_raw().display.bezel, Some(true));
+
+        // The written config has to load back into the same setting.
+        assert!(s.build_config().expect("valid config").bezel);
+        let reloaded = MachineSetup::from_raw(&s.to_raw()).expect("valid raw");
+        assert!(reloaded.toggle_value(LauncherField::Bezel));
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -2452,7 +2452,7 @@ fn shortcuts_panel_height() -> usize {
         + 10
 }
 
-const SHORTCUT_ROWS: [(&str, &str, bool); 21] = [
+const SHORTCUT_ROWS: [(&str, &str, bool); 22] = [
     ("Q", "Quit", true),
     ("S", "Save screenshot", true),
     ("R", "Record video on/off", true),
@@ -2466,6 +2466,7 @@ const SHORTCUT_ROWS: [(&str, &str, bool); 21] = [
     ("B", "Debugger", true),
     ("K", "Console", true),
     ("J", "Joystick input mode", true),
+    ("M", "Monitor bezel on/off", true),
     ("Shift+A", "Cycle audio output", true),
     ("F", "Fullscreen on/off", true),
     ("Shift+F", "Status bar on/off", true),

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -788,6 +788,9 @@ pub struct App {
     /// How strongly the shader pass is mixed in, 0.0 to 1.0 ([display]
     /// shader_strength).
     shader_strength: f32,
+    /// Monitor-bezel pass in effect ([display] bezel, Cmd/Alt+M).
+    /// Presentation only, like the shader pass: captures never include it.
+    bezel: bool,
     /// Screen tint in effect ([display] tint). Presentation only, applied
     /// to the chipset display region of the window frame: captures and
     /// RTG board scanout are never tinted.
@@ -966,6 +969,10 @@ struct Render {
     /// window, whatever preset is selected: the pass is skipped per frame,
     /// not per session, so the menu can turn it on live.
     crt_shader: crt_shader::CrtShader,
+    /// The optional monitor-bezel pass drawn under the CRT pass (see
+    /// [`bezel`]). Built with the window whatever the setting, like the
+    /// CRT pass, so the Cmd/Alt+M toggle works live.
+    bezel_shader: bezel::BezelShader,
     /// True while the host window is minimized (Windows delivers a 0x0
     /// Resized). Presenting while minimized deadlocks on Windows: DWM stops
     /// consuming swapchain frames, so once the in-flight buffers fill,
@@ -1130,6 +1137,7 @@ impl App {
         phosphor: f32,
         shader: crate::config::ShaderMode,
         shader_strength: f32,
+        bezel: bool,
         tint: crate::config::Tint,
         start_fullscreen: bool,
         hide_status_bar: bool,
@@ -1298,6 +1306,7 @@ impl App {
                 _ => None,
             },
             shader_strength,
+            bezel,
             tint,
             tint_lut: tint_lut(tint),
             start_fullscreen,
@@ -2486,6 +2495,7 @@ impl ApplicationHandler for App {
             rtg_texture::RtgTexture::new(pixels.device(), pixels.render_texture_format());
         let mut crt_shader =
             crt_shader::CrtShader::new(pixels.device(), pixels.render_texture_format());
+        let bezel_shader = bezel::BezelShader::new(pixels.device(), pixels.render_texture_format());
         // A user shader can only be compiled once the device exists (too
         // early for `reload_custom_shader`, which needs the built `Render`).
         // A bad one drops back to no shader rather than failing the session:
@@ -2510,6 +2520,7 @@ impl ApplicationHandler for App {
             texture_scale,
             rtg_texture,
             crt_shader,
+            bezel_shader,
             minimized: false,
         });
         // After the window exists, so the overlay has somewhere to be drawn.
@@ -2618,6 +2629,11 @@ impl ApplicationHandler for App {
                         if host_shortcut_modifier_pressed(self.modifiers) =>
                     {
                         self.cycle_joystick_input_mode()
+                    }
+                    (KeyCode::KeyM, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers) =>
+                    {
+                        self.toggle_bezel()
                     }
                     (KeyCode::KeyF, ElementState::Pressed)
                         if host_shortcut_modifier_pressed(self.modifiers)
@@ -3070,6 +3086,15 @@ impl ApplicationHandler for App {
                         && !self.ui.active()
                         && self.rtg_present_dims.is_none()
                         && !self.present_programmable;
+                    // The bezel is content-agnostic (a frame has no 15 kHz
+                    // structure to get wrong), so unlike the CRT pass it
+                    // stays on for programmable multisync scans. It shares
+                    // the other two suspensions: an open overlay must not
+                    // be overdrawn, and RTG scanout reaches the surface
+                    // through its own texture, which this pass does not
+                    // sample.
+                    let bezel_active =
+                        self.bezel && !self.ui.active() && self.rtg_present_dims.is_none();
                     if let Some((w, h)) = self.rtg_present_dims.filter(|_| rtg_gpu) {
                         r.rtg_texture.upload(
                             r.pixels.device(),
@@ -3177,10 +3202,18 @@ impl ApplicationHandler for App {
                             rtg.render(encoder, target, (cx as f32, cy as f32, cw as f32, disp_h));
                             Ok(())
                         })
-                    } else if crt_active {
+                    } else if crt_active || bezel_active {
                         // Draw the composited buffer, then re-draw the display
-                        // rect through the shader. One CRT beam pass per
-                        // emulated field line the copy above actually shows.
+                        // rect. Bezel alone: one pass draws the frame with the
+                        // picture scaled into its opening. Preset alone: the
+                        // pass covers the display rect. Both: the preset paints
+                        // the picture into the opening first and the bezel
+                        // frames it on top in frame-only mode -- the plastic
+                        // overlaps the tube face, so the frame's rounded
+                        // corners and recess clip the preset's square viewport
+                        // rather than being buried under it. One CRT beam pass
+                        // per emulated field line the copy above actually
+                        // shows.
                         let scanlines = crt_scanline_count(
                             self.present_rows,
                             present_height(),
@@ -3194,9 +3227,10 @@ impl ApplicationHandler for App {
                         let kind = self.crt_shader_kind;
                         let strength = self.shader_strength;
                         // The closure is FnOnce and captures `r`, so the
-                        // shader has to be split out of it as a separate
-                        // borrow rather than reached through `r` inside.
+                        // shaders have to be split out of it as separate
+                        // borrows rather than reached through `r` inside.
                         let crt = &mut r.crt_shader;
+                        let bezel_shader = &mut r.bezel_shader;
                         r.pixels.render_with(|encoder, target, ctx| {
                             ctx.scaling_renderer.render(encoder, target);
                             let (uniforms, viewport) = crt_shader::uniforms_for(
@@ -3208,16 +3242,41 @@ impl ApplicationHandler for App {
                                 (ctx.texture_extent.width, ctx.texture_extent.height),
                                 scanlines,
                             );
-                            crt.render(
-                                &ctx.device,
-                                &ctx.queue,
-                                &ctx.texture,
-                                encoder,
-                                target,
-                                viewport,
-                                kind,
-                                uniforms,
-                            );
+                            if bezel_active {
+                                let opening = bezel::opening_rect(viewport);
+                                if crt_active {
+                                    crt.render(
+                                        &ctx.device,
+                                        &ctx.queue,
+                                        &ctx.texture,
+                                        encoder,
+                                        target,
+                                        opening,
+                                        kind,
+                                        uniforms.with_viewport(opening),
+                                    );
+                                }
+                                bezel_shader.render(
+                                    &ctx.device,
+                                    &ctx.queue,
+                                    &ctx.texture,
+                                    encoder,
+                                    target,
+                                    viewport,
+                                    bezel::uniforms_from(&uniforms, viewport, opening, crt_active),
+                                );
+                            } else {
+                                crt.render(
+                                    &ctx.device,
+                                    &ctx.queue,
+                                    &ctx.texture,
+                                    encoder,
+                                    target,
+                                    viewport,
+                                    kind,
+                                    uniforms,
+                                );
+                            }
                             Ok(())
                         })
                     } else {
@@ -5845,6 +5904,7 @@ impl App {
             r.crt_shader.clear_custom();
         }
         self.shader_strength = crate::config::resolve_shader_strength(cfg.shader_strength);
+        self.bezel = crate::config::resolve_bezel(cfg.bezel);
         self.set_tint(crate::config::resolve_tint(cfg.tint));
         self.ui.menu_open = false;
         self.ui.panel = None;
@@ -8481,6 +8541,17 @@ impl App {
         self.request_redraw();
     }
 
+    /// Cmd/Alt+M: toggle the monitor-bezel pass for the rest of the run
+    /// (the config file default is unchanged; set `[display] bezel` to
+    /// make it stick).
+    fn toggle_bezel(&mut self) {
+        self.bezel = !self.bezel;
+        let label = if self.bezel { "on" } else { "off" };
+        info!("monitor bezel: {label}");
+        self.show_osd(format!("Monitor bezel: {label}"));
+        self.request_redraw();
+    }
+
     /// Menu "Screen Tint": step through the tints for the rest of the run
     /// (the config file default is unchanged; set `[display] tint` to make
     /// it stick).
@@ -9183,6 +9254,7 @@ impl App {
     }
 }
 
+mod bezel;
 mod console;
 #[cfg(feature = "control")]
 mod control;

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -742,6 +742,10 @@ mod tests {
                 let info = reader.next_frame(&mut buf).expect("png frame");
                 let (w, h) = (info.width, info.height);
                 let rgba: Vec<[u8; 4]> = match info.color_type {
+                    // Source alpha is deliberately forced opaque: the
+                    // texture stands in for the composited display
+                    // buffer, which has no transparency, and the pass
+                    // samples it as an opaque monitor picture.
                     png::ColorType::Rgba => buf
                         .chunks_exact(4)
                         .map(|c| [c[0], c[1], c[2], 255])

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -1,0 +1,836 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The optional monitor-bezel pass: a procedural plastic front frame in
+//! the spirit of the 1084, drawn over the display rect on the GPU with
+//! the picture re-sampled into the rounded opening the frame leaves.
+//!
+//! Runs inside the `pixels` `render_with` pass after the scaling
+//! renderer, on the same viewport the CRT pass uses (the display sub-rect
+//! of the letterboxed clip rect), and samples only the display region of
+//! the backing texture, so the status bar underneath is neither read nor
+//! overdrawn. On its own, one pass draws both the frame and the picture
+//! scaled into the opening. With a CRT preset active the preset draws the
+//! picture first, re-aimed at the opening's bounding box
+//! ([`super::crt_shader::CrtUniforms::with_viewport`]), and the bezel
+//! follows in frame-only mode, discarding the opening interior: the
+//! plastic overlaps the tube face like the real moulding, so the frame's
+//! rounded corners and recess clip the preset's square viewport rather
+//! than being buried under it.
+//!
+//! Purely a presentation stage, like the CRT pass: screenshots, frame
+//! dumps, recordings and headless runs never include the bezel. Unlike
+//! the CRT presets it is not user-replaceable and carries no strength
+//! knob: it is either drawn or skipped.
+
+use pixels::wgpu;
+use zerocopy::{Immutable, IntoBytes};
+
+use super::crt_shader;
+
+/// The bezel WGSL source, embedded like the preset sources.
+const BEZEL_WGSL: &str = include_str!("shaders/bezel.wgsl");
+
+/// Fraction of the display rect the picture keeps when the bezel is on;
+/// the rest becomes the plastic frame. Both axes scale by this one
+/// factor, so the picture keeps its aspect.
+pub(super) const OPENING_SCALE: f32 = 0.85;
+
+/// How the freed height splits around the opening: the top margin takes
+/// this share and the bottom band the rest, so the bottom comes out
+/// wider than the top like the 1084's face.
+const TOP_SHARE: f32 = 0.42;
+
+/// Size of the uniform block, in bytes. The shared bind group layout pins
+/// its `min_binding_size` to the CRT block's 64 bytes, so this block must
+/// stay the same size to build against it.
+const UNIFORM_BYTES: u64 = std::mem::size_of::<BezelUniforms>() as u64;
+
+/// The uniform block `shaders/bezel.wgsl` sees. Mirrors the WGSL struct
+/// exactly; `#[repr(C)]` with 16-byte-aligned members only.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, IntoBytes, Immutable)]
+pub(super) struct BezelUniforms {
+    /// Display sub-rect of the source texture in UV space: xy origin, zw
+    /// size. The status bar lives below it and is never sampled.
+    src_rect: [f32; 4],
+    /// xy: viewport size in physical pixels. zw: source display region
+    /// in texels.
+    size: [f32; 4],
+    /// Picture opening within the viewport, in viewport UV: xy origin,
+    /// zw size.
+    opening: [f32; 4],
+    /// x: 1 = frame-only (leave the opening interior to the preset that
+    /// painted it), 0 = full. yzw: reserved.
+    params: [f32; 4],
+}
+
+/// The picture opening the bezel leaves inside a display viewport rect
+/// (physical surface pixels): scaled by [`OPENING_SCALE`] about both
+/// axes, centred horizontally, sitting high by [`TOP_SHARE`].
+pub(super) fn opening_rect(viewport: (f32, f32, f32, f32)) -> (f32, f32, f32, f32) {
+    let (x, y, w, h) = viewport;
+    let ow = w * OPENING_SCALE;
+    let oh = h * OPENING_SCALE;
+    (x + (w - ow) * 0.5, y + (h - oh) * TOP_SHARE, ow, oh)
+}
+
+/// Build the bezel uniforms for one presented frame from the CRT pass's
+/// uniforms for the same frame (which already carry the source mapping
+/// and the display viewport size) plus the two rects in physical surface
+/// pixels. `frame_only` is set when a preset has already painted the
+/// opening interior, so the pass leaves it untouched. Pure arithmetic,
+/// unit testable on its own.
+pub(super) fn uniforms_from(
+    crt: &crt_shader::CrtUniforms,
+    viewport: (f32, f32, f32, f32),
+    opening: (f32, f32, f32, f32),
+    frame_only: bool,
+) -> BezelUniforms {
+    let (vx, vy, vw, vh) = viewport;
+    let (ox, oy, ow, oh) = opening;
+    let w = vw.max(1.0);
+    let h = vh.max(1.0);
+    BezelUniforms {
+        src_rect: crt.src_rect,
+        size: crt.size,
+        opening: [(ox - vx) / w, (oy - vy) / h, ow / w, oh / h],
+        params: [if frame_only { 1.0 } else { 0.0 }, 0.0, 0.0, 0.0],
+    }
+}
+
+/// The bezel pass: one fixed pipeline and the bindings it needs.
+pub(super) struct BezelShader {
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    uniforms: wgpu::Buffer,
+    pipeline: wgpu::RenderPipeline,
+    bind_group: Option<wgpu::BindGroup>,
+    /// The texture the current bind group views, compared by identity:
+    /// `pixels` recreates its backing texture on a buffer resize, and the
+    /// stale view has to be dropped with it.
+    bound_texture: Option<wgpu::Texture>,
+}
+
+impl BezelShader {
+    pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let bind_group_layout = crt_shader::shader_bind_group_layout(device);
+        let pipeline = crt_shader::build_pipeline(
+            device,
+            &bind_group_layout,
+            BEZEL_WGSL,
+            "bezel_shader",
+            target_format,
+        );
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("bezel_shader_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+        let uniforms = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bezel_shader_uniforms"),
+            size: UNIFORM_BYTES,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Self {
+            bind_group_layout,
+            sampler,
+            uniforms,
+            pipeline,
+            bind_group: None,
+            bound_texture: None,
+        }
+    }
+
+    /// Draw the bezel over the `(x, y, w, h)` viewport rect of `target`
+    /// (physical surface pixels), sampling `src_texture` through
+    /// `uniforms.src_rect`.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn render(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        src_texture: &wgpu::Texture,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        viewport: (f32, f32, f32, f32),
+        uniforms: BezelUniforms,
+    ) {
+        let (x, y, w, h) = viewport;
+        if w < 1.0 || h < 1.0 {
+            return;
+        }
+        if self.bound_texture.as_ref() != Some(src_texture) {
+            let view = src_texture.create_view(&wgpu::TextureViewDescriptor::default());
+            self.bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("bezel_shader_bg"),
+                layout: &self.bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&self.sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: self.uniforms.as_entire_binding(),
+                    },
+                ],
+            }));
+            self.bound_texture = Some(src_texture.clone());
+        }
+        let Some(bind_group) = &self.bind_group else {
+            return;
+        };
+        queue.write_buffer(&self.uniforms, 0, uniforms.as_bytes());
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("bezel_shader_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.set_viewport(x, y, w, h, 0.0, 1.0);
+        pass.draw(0..3, 0..1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ShaderKind;
+
+    // --- WGSL validation and geometry (no GPU) --------------------------
+
+    #[test]
+    fn the_bezel_source_validates() {
+        if let Err(e) = crt_shader::validate_wgsl_source(BEZEL_WGSL) {
+            panic!("bezel shader failed validation:\n{e}");
+        }
+    }
+
+    /// The bezel is not a preset: it must not carry the preset contract
+    /// markers, or the contract test would be expected to cover it.
+    #[test]
+    fn the_bezel_is_not_a_contract_preset() {
+        assert!(!BEZEL_WGSL.contains("--- begin shared contract ---"));
+    }
+
+    /// The shared bind group layout pins `min_binding_size` to the CRT
+    /// block's 64 bytes; this block must stay that size to build against
+    /// it.
+    #[test]
+    fn the_uniform_block_matches_the_shared_layout() {
+        assert_eq!(
+            std::mem::size_of::<BezelUniforms>(),
+            std::mem::size_of::<crt_shader::CrtUniforms>()
+        );
+    }
+
+    #[test]
+    fn the_opening_keeps_the_picture_aspect_and_sits_high() {
+        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, 716.0, 537.0));
+        // Both axes scale by the one factor, so the picture is not
+        // stretched.
+        assert!((ow / 716.0 - OPENING_SCALE).abs() < 1e-6);
+        assert!((oh / 537.0 - OPENING_SCALE).abs() < 1e-6);
+        // Centred horizontally, with the bottom band wider than the top
+        // margin like the 1084's face.
+        assert!((ox - (716.0 - ow) * 0.5).abs() < 1e-3);
+        let top = oy;
+        let bottom = 537.0 - (oy + oh);
+        assert!(top > 0.0, "top margin missing: {top}");
+        assert!(
+            bottom > top,
+            "bottom band ({bottom}) not wider than top ({top})"
+        );
+    }
+
+    #[test]
+    fn a_letterboxed_viewport_offsets_the_opening() {
+        let flat = opening_rect((0.0, 0.0, 640.0, 480.0));
+        let off = opening_rect((12.0, 34.0, 640.0, 480.0));
+        assert_eq!(off.0, flat.0 + 12.0);
+        assert_eq!(off.1, flat.1 + 34.0);
+        assert_eq!(off.2, flat.2);
+        assert_eq!(off.3, flat.3);
+    }
+
+    #[test]
+    fn uniforms_carry_the_source_mapping_and_the_opening_in_viewport_uv() {
+        let (crt, viewport) = crt_shader::uniforms_for(
+            ShaderKind::None,
+            0.0,
+            (12, 34, 640, 512),
+            537,
+            581,
+            (716, 581),
+            537.0,
+        );
+        let opening = opening_rect(viewport);
+        let u = uniforms_from(&crt, viewport, opening, false);
+        assert_eq!(u.src_rect, crt.src_rect);
+        assert_eq!(u.size, crt.size);
+        // The opening is expressed relative to the viewport, so the
+        // letterbox offset must cancel out.
+        assert!((u.opening[0] - (1.0 - OPENING_SCALE) * 0.5).abs() < 1e-6);
+        assert!((u.opening[2] - OPENING_SCALE).abs() < 1e-6);
+        assert!((u.opening[3] - OPENING_SCALE).abs() < 1e-6);
+        assert_eq!(u.params[0], 0.0);
+        // Frame-only mode differs in nothing but the flag.
+        let frame = uniforms_from(&crt, viewport, opening, true);
+        assert_eq!(frame.params[0], 1.0);
+        assert_eq!(frame.opening, u.opening);
+    }
+
+    /// Re-aiming the CRT pass at the opening changes only its viewport
+    /// size: the source mapping stays, so the preset draws the same
+    /// picture into the smaller rect.
+    #[test]
+    fn retargeting_the_crt_pass_keeps_its_source_mapping() {
+        let (crt, viewport) = crt_shader::uniforms_for(
+            ShaderKind::Crt,
+            1.0,
+            (0, 0, 716, 581),
+            537,
+            581,
+            (716, 581),
+            537.0,
+        );
+        let opening = opening_rect(viewport);
+        let re = crt.with_viewport(opening);
+        assert_eq!(re.src_rect, crt.src_rect);
+        assert_eq!(re.params, crt.params);
+        assert_eq!(re.size[0], opening.2);
+        assert_eq!(re.size[1], opening.3);
+        assert_eq!(re.size[2..], crt.size[2..]);
+    }
+
+    // --- offscreen render (needs a GPU adapter) -------------------------
+
+    const TEX: u32 = 64;
+    const DISPLAY_ROWS: u32 = 48;
+    const GREY: u8 = 128;
+    /// Magnification of the render target over the source, as a real
+    /// window magnifies the composited buffer. Big enough that the frame's
+    /// trim zones (recess, bevel, plastic band) are pixels wide.
+    const SCALE: u32 = 4;
+    const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+    /// Target clear colour; pure blue survives the sRGB encode exactly,
+    /// so any surviving sentinel pixel inside the viewport means the pass
+    /// left a hole, and any outside means it overdrew its viewport.
+    const SENTINEL: [u8; 4] = [0, 0, 255, 255];
+
+    /// A device, or `None` on a machine with no usable adapter (headless
+    /// CI): the render tests then pass without asserting anything.
+    fn gpu() -> Option<(wgpu::Device, wgpu::Queue)> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter =
+            match crt_shader::poll_once(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::LowPower,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })) {
+                Some(Ok(adapter)) => adapter,
+                _ => return None,
+            };
+        match crt_shader::poll_once(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("bezel_shader_test"),
+            ..Default::default()
+        })) {
+            Some(Ok(pair)) => Some(pair),
+            _ => None,
+        }
+    }
+
+    /// The `pixels` backing texture in miniature: `DISPLAY_ROWS` rows of
+    /// the given texels (or flat grey) with a magenta "status bar" below.
+    fn source_texture(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        width: u32,
+        height: u32,
+        display_rows: u32,
+        display: &dyn Fn(u32, u32) -> [u8; 4],
+    ) -> wgpu::Texture {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("bezel_shader_test_src"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let mut texels = vec![0u8; (width * height * 4) as usize];
+        for y in 0..height {
+            for x in 0..width {
+                let px = if y < display_rows {
+                    display(x, y)
+                } else {
+                    [255, 0, 255, 255]
+                };
+                let off = ((y * width + x) * 4) as usize;
+                texels[off..off + 4].copy_from_slice(&px);
+            }
+        }
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &texels,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(width * 4),
+                rows_per_image: Some(height),
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        texture
+    }
+
+    /// Read an RGBA8 render target back into per-pixel bytes.
+    fn read_back(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: wgpu::CommandEncoder,
+        target: &wgpu::Texture,
+        dim: (u32, u32),
+    ) -> Vec<[u8; 4]> {
+        let (w, h) = dim;
+        let padded = (w * 4).div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+            * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let readback = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bezel_shader_test_readback"),
+            size: (padded * h) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut encoder = encoder;
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded),
+                    rows_per_image: Some(h),
+                },
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(Some(encoder.finish()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        readback.slice(..).map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("poll");
+        rx.recv().expect("map callback").expect("buffer mapped");
+        let mapped = readback.slice(..).get_mapped_range();
+        let mut px = Vec::with_capacity((w * h) as usize);
+        for y in 0..h {
+            let base = (y * padded) as usize;
+            for x in 0..w {
+                let off = base + (x * 4) as usize;
+                px.push([
+                    mapped[off],
+                    mapped[off + 1],
+                    mapped[off + 2],
+                    mapped[off + 3],
+                ]);
+            }
+        }
+        drop(mapped);
+        readback.unmap();
+        px
+    }
+
+    /// Clear a sentinel target and render as the window does: the bezel
+    /// alone in one full pass, or, with a preset, the preset retargeted
+    /// at the opening first and the bezel framing it on top in
+    /// frame-only mode. Read the result back.
+    fn render_bezel(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        src: &wgpu::Texture,
+        crt_kind: Option<ShaderKind>,
+    ) -> (Vec<[u8; 4]>, u32, u32) {
+        let dim = TEX * SCALE;
+        let rows = DISPLAY_ROWS * SCALE;
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("bezel_shader_test_target"),
+            size: wgpu::Extent3d {
+                width: dim,
+                height: dim,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        drop(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("bezel_shader_test_clear"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: 0.0,
+                        g: 0.0,
+                        b: 1.0,
+                        a: 1.0,
+                    }),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        }));
+        let (crt_uniforms, viewport) = crt_shader::uniforms_for(
+            crt_kind.unwrap_or(ShaderKind::None),
+            1.0,
+            (0, 0, dim, dim),
+            DISPLAY_ROWS as usize,
+            TEX as usize,
+            (TEX, TEX),
+            DISPLAY_ROWS as f32,
+        );
+        assert_eq!(viewport, (0.0, 0.0, dim as f32, rows as f32));
+        let opening = opening_rect(viewport);
+        if let Some(kind) = crt_kind {
+            let mut crt = crt_shader::CrtShader::new(device, FORMAT);
+            crt.render(
+                device,
+                queue,
+                src,
+                &mut encoder,
+                &view,
+                opening,
+                kind,
+                crt_uniforms.with_viewport(opening),
+            );
+        }
+        let mut shader = BezelShader::new(device, FORMAT);
+        shader.render(
+            device,
+            queue,
+            src,
+            &mut encoder,
+            &view,
+            viewport,
+            uniforms_from(&crt_uniforms, viewport, opening, crt_kind.is_some()),
+        );
+        (
+            read_back(device, queue, encoder, &target, (dim, dim)),
+            dim,
+            rows,
+        )
+    }
+
+    fn at(px: &[[u8; 4]], dim: u32, x: u32, y: u32) -> [u8; 4] {
+        px[(y * dim + x) as usize]
+    }
+
+    #[test]
+    fn the_bezel_covers_the_display_rect_and_nothing_below() {
+        let Some((device, queue)) = gpu() else {
+            eprintln!("skipping: no GPU adapter");
+            return;
+        };
+        let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
+        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(&device, &queue, &src, None);
+        for y in 0..rows {
+            for x in 0..dim {
+                let p = at(&px, dim, x, y);
+                assert_ne!(p, SENTINEL, "hole in the pass at ({x}, {y})");
+                assert!(
+                    !(p[0] > 180 && p[1] < 80 && p[2] > 180),
+                    "status-bar magenta bled into the display at ({x}, {y}): {p:?}"
+                );
+            }
+        }
+        for y in rows..dim {
+            for x in 0..dim {
+                assert_eq!(
+                    at(&px, dim, x, y),
+                    SENTINEL,
+                    "pass wrote outside its viewport at ({x}, {y})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_picture_fills_the_opening_and_the_frame_is_plastic() {
+        let Some((device, queue)) = gpu() else {
+            eprintln!("skipping: no GPU adapter");
+            return;
+        };
+        let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
+        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(&device, &queue, &src, None);
+
+        // Centre of the opening: the flat grey source, resampled 1:1 in
+        // colour terms.
+        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        let centre = at(&px, dim, (ox + ow * 0.5) as u32, (oy + oh * 0.5) as u32);
+        for (c, v) in centre[..3].iter().enumerate() {
+            assert!(
+                v.abs_diff(GREY) <= 3,
+                "channel {c} at the opening centre is {v}, not the source grey: {centre:?}"
+            );
+        }
+
+        // Middle of the left band: warm plastic, not the grey source and
+        // not black. Warm means the red channel clearly leads the blue.
+        let band = at(&px, dim, 10, (oy + oh * 0.5) as u32);
+        assert!(
+            band[0] > band[2] + 6,
+            "left band is not warm plastic: {band:?}"
+        );
+        assert!(
+            (120..=245).contains(&band[0]),
+            "left band brightness out of range: {band:?}"
+        );
+
+        // The case corners are rounded off to the letterbox black.
+        for (x, y) in [(0, 0), (dim - 1, 0), (0, rows - 1), (dim - 1, rows - 1)] {
+            let p = at(&px, dim, x, y);
+            assert!(
+                p[0] < 16 && p[1] < 16 && p[2] < 16,
+                "case corner at ({x}, {y}) is not dark: {p:?}"
+            );
+        }
+
+        // The power LED glows green on the bottom band, right of centre.
+        let led_x = (0.91 * dim as f32) as i32;
+        let led_y = ((oy + oh + rows as f32) * 0.5) as i32;
+        let found = (-3..=3).any(|dy| {
+            (-3..=3).any(|dx| {
+                let p = at(&px, dim, (led_x + dx) as u32, (led_y + dy) as u32);
+                p[1] > p[0].saturating_add(50) && p[1] > p[2].saturating_add(50)
+            })
+        });
+        assert!(found, "no green power LED near ({led_x}, {led_y})");
+    }
+
+    /// The window pairs the bezel with a preset by re-aiming the preset at
+    /// the opening; the combined result must still be framed (plastic band
+    /// intact) with the preset's scanline structure inside the opening.
+    #[test]
+    fn a_crt_preset_lands_inside_the_opening() {
+        let Some((device, queue)) = gpu() else {
+            eprintln!("skipping: no GPU adapter");
+            return;
+        };
+        let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
+        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(&device, &queue, &src, Some(ShaderKind::Scanlines));
+
+        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        // Scanlines modulate the opening interior: one column of it must
+        // not be flat.
+        let x = (ox + ow * 0.5) as u32;
+        let y0 = (oy + oh * 0.25) as u32;
+        let y1 = (oy + oh * 0.75) as u32;
+        let (mut min, mut max) = (255u8, 0u8);
+        for y in y0..y1 {
+            let v = at(&px, dim, x, y)[1];
+            min = min.min(v);
+            max = max.max(v);
+        }
+        assert!(
+            max - min > 10,
+            "no scanline structure inside the opening (min {min}, max {max})"
+        );
+
+        // The plastic band survives the preset pass untouched.
+        let band = at(&px, dim, 10, (oy + oh * 0.5) as u32);
+        assert!(
+            band[0] > band[2] + 6,
+            "left band lost its plastic after the preset pass: {band:?}"
+        );
+
+        // The frame is drawn on top of the preset: at the opening's
+        // bounding-box corner -- inside the preset's square viewport but
+        // outside the rounded opening -- the plastic lip must show, not
+        // the preset's off-face black. This is the layering the
+        // frame-only pass exists for: the moulding overlaps the tube.
+        let corner = at(&px, dim, ox as u32, oy as u32);
+        assert!(
+            corner[0] > 100 && corner[0] > corner[2] + 6,
+            "opening corner shows the preset instead of the frame: {corner:?}"
+        );
+    }
+
+    /// Not a check: renders the bezel (optionally with the CRT preset the
+    /// window would pair it with) over a source image and writes a PNG for
+    /// eyeballing look changes. Runs only when
+    /// COPPERLINE_BEZEL_PREVIEW_OUT names the output file; with
+    /// COPPERLINE_BEZEL_PREVIEW_SRC set, that PNG becomes the picture
+    /// (its full height, no status bar), otherwise a test card is used.
+    /// COPPERLINE_BEZEL_PREVIEW_SHADER=crt adds the preset pass.
+    #[test]
+    #[ignore = "preview dump; set COPPERLINE_BEZEL_PREVIEW_OUT"]
+    fn dump_bezel_preview_png() {
+        let Ok(out) = std::env::var("COPPERLINE_BEZEL_PREVIEW_OUT") else {
+            eprintln!("skipping: COPPERLINE_BEZEL_PREVIEW_OUT not set");
+            return;
+        };
+        let Some((device, queue)) = gpu() else {
+            eprintln!("skipping: no GPU adapter");
+            return;
+        };
+        let with_crt = std::env::var("COPPERLINE_BEZEL_PREVIEW_SHADER").is_ok();
+        let (src, w, h) = match std::env::var("COPPERLINE_BEZEL_PREVIEW_SRC") {
+            Ok(path) => {
+                let decoder = png::Decoder::new(std::fs::File::open(&path).expect("open src"));
+                let mut reader = decoder.read_info().expect("png info");
+                let mut buf = vec![0; reader.output_buffer_size()];
+                let info = reader.next_frame(&mut buf).expect("png frame");
+                let (w, h) = (info.width, info.height);
+                let rgba: Vec<[u8; 4]> = match info.color_type {
+                    png::ColorType::Rgba => buf
+                        .chunks_exact(4)
+                        .map(|c| [c[0], c[1], c[2], 255])
+                        .collect(),
+                    png::ColorType::Rgb => buf
+                        .chunks_exact(3)
+                        .map(|c| [c[0], c[1], c[2], 255])
+                        .collect(),
+                    other => panic!("unsupported source colour type {other:?}"),
+                };
+                let tex = source_texture(&device, &queue, w, h, h, &move |x, y| {
+                    rgba[(y * w + x) as usize]
+                });
+                (tex, w, h)
+            }
+            Err(_) => {
+                let card = |x: u32, y: u32| {
+                    let bar = (x * 8 / TEX) as u8;
+                    [bar * 32, 255 - bar * 32, (y * 4) as u8, 255]
+                };
+                (
+                    source_texture(&device, &queue, TEX, TEX, TEX, &card),
+                    TEX,
+                    TEX,
+                )
+            }
+        };
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("bezel_preview_target"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let (crt_uniforms, viewport) = crt_shader::uniforms_for(
+            if with_crt {
+                ShaderKind::Crt
+            } else {
+                ShaderKind::None
+            },
+            1.0,
+            (0, 0, w, h),
+            h as usize,
+            h as usize,
+            (w, h),
+            (h / 2) as f32,
+        );
+        let opening = opening_rect(viewport);
+        if with_crt {
+            let mut crt = crt_shader::CrtShader::new(&device, FORMAT);
+            crt.render(
+                &device,
+                &queue,
+                &src,
+                &mut encoder,
+                &view,
+                opening,
+                ShaderKind::Crt,
+                crt_uniforms.with_viewport(opening),
+            );
+        }
+        let mut shader = BezelShader::new(&device, FORMAT);
+        shader.render(
+            &device,
+            &queue,
+            &src,
+            &mut encoder,
+            &view,
+            viewport,
+            uniforms_from(&crt_uniforms, viewport, opening, with_crt),
+        );
+        let px = read_back(&device, &queue, encoder, &target, (w, h));
+        let file = std::fs::File::create(&out).expect("create preview");
+        let mut enc = png::Encoder::new(std::io::BufWriter::new(file), w, h);
+        enc.set_color(png::ColorType::Rgba);
+        enc.set_depth(png::BitDepth::Eight);
+        let mut writer = enc.write_header().expect("png header");
+        let bytes: Vec<u8> = px.iter().flatten().copied().collect();
+        writer.write_image_data(&bytes).expect("png data");
+        eprintln!("bezel preview written to {out}");
+    }
+}

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -58,14 +58,26 @@ const UNIFORM_BYTES: u64 = std::mem::size_of::<CrtUniforms>() as u64;
 pub(super) struct CrtUniforms {
     /// Display sub-rect of the source texture in UV space: xy origin, zw
     /// size. The status bar lives below it and is never sampled.
-    src_rect: [f32; 4],
+    pub(super) src_rect: [f32; 4],
     /// xy: viewport size in physical pixels. zw: source display region
     /// in texels.
-    size: [f32; 4],
+    pub(super) size: [f32; 4],
     /// x: strength 0..1. y: scanline count. z: mask kind. w: curvature.
-    params: [f32; 4],
+    pub(super) params: [f32; 4],
     /// x: vignette 0..1. yzw: reserved.
-    params2: [f32; 4],
+    pub(super) params2: [f32; 4],
+}
+
+impl CrtUniforms {
+    /// Re-aim a frame's uniforms at a smaller viewport (the bezel
+    /// opening): the source mapping is unchanged, but the pixel-keyed
+    /// phosphor mask and the AA arithmetic follow the pass's own
+    /// viewport size.
+    pub(super) fn with_viewport(mut self, viewport: (f32, f32, f32, f32)) -> Self {
+        self.size[0] = viewport.2;
+        self.size[1] = viewport.3;
+        self
+    }
 }
 
 /// Preset pipeline slots, in the order [`CrtShader::presets`] holds them.
@@ -88,10 +100,48 @@ pub(super) struct CrtShader {
     bound_texture: Option<wgpu::Texture>,
 }
 
+/// The binding layout every window pass shares: a display texture, a
+/// linear sampler and a 64-byte uniform block. The bezel pass declares the
+/// same bindings with its own uniform contents, so it builds against this
+/// too.
+pub(super) fn shader_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("crt_shader_bgl"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(UNIFORM_BYTES),
+                },
+                count: None,
+            },
+        ],
+    })
+}
+
 /// Build one shader pipeline against the shared bind group layout. All
-/// presets and user shaders use the same entry points and target state,
-/// so this is the only place a pipeline is created.
-fn build_pipeline(
+/// presets and user shaders (and the bezel pass) use the same entry points
+/// and target state, so this is the only place a pipeline is created.
+pub(super) fn build_pipeline(
     device: &wgpu::Device,
     layout: &wgpu::BindGroupLayout,
     source: &str,
@@ -139,7 +189,7 @@ fn build_pipeline(
 
 /// Poll a future exactly once on a no-op waker, for the wgpu-core futures
 /// that are already resolved when they are handed back.
-fn poll_once<F: Future>(fut: F) -> Option<F::Output> {
+pub(super) fn poll_once<F: Future>(fut: F) -> Option<F::Output> {
     let mut fut = std::pin::pin!(fut);
     let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
     match fut.as_mut().poll(&mut cx) {
@@ -150,37 +200,7 @@ fn poll_once<F: Future>(fut: F) -> Option<F::Output> {
 
 impl CrtShader {
     pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("crt_shader_bgl"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: wgpu::BufferSize::new(UNIFORM_BYTES),
-                    },
-                    count: None,
-                },
-            ],
-        });
+        let bind_group_layout = shader_bind_group_layout(device);
         let presets = [
             build_pipeline(
                 device,
@@ -399,7 +419,7 @@ fn read_shader_file(path: &Path) -> Result<String, String> {
 /// Parse and validate WGSL, and check it declares the entry points the
 /// pass calls. Pure CPU work: no device is needed, so a shader can be
 /// checked before any GPU resources exist.
-fn validate_wgsl_source(src: &str) -> Result<(), String> {
+pub(super) fn validate_wgsl_source(src: &str) -> Result<(), String> {
     use wgpu::naga;
     let module = naga::front::wgsl::parse_str(src).map_err(|e| e.emit_to_string(src))?;
     let mut validator = naga::valid::Validator::new(

--- a/src/video/window/shaders/bezel.wgsl
+++ b/src/video/window/shaders/bezel.wgsl
@@ -6,10 +6,16 @@
 // with a dark recess between the tube face and the plastic, a bevelled
 // inner lip, a moulded outer edge and the power LED on the bottom band.
 //
-// Not a window-shader preset: it is not user-replaceable, runs before any
-// preset (which then re-draws the picture inside the opening), and its
-// uniform block is its own, so it deliberately does not carry the shared
-// contract prologue of shaders/{scanlines,mask,crt}.wgsl.
+// Two modes, selected by params.x. Alone (0), this one pass draws both
+// the frame and the picture. Under a CRT preset (1, frame-only), the
+// preset has already painted the picture into the opening's bounding box
+// and this pass runs after it, discarding the opening interior and
+// drawing just the frame on top -- the moulding overlaps the tube face,
+// so its rounded corners and recess clip the preset's square viewport.
+//
+// Not a window-shader preset: it is not user-replaceable, and its uniform
+// block is its own, so it deliberately does not carry the shared contract
+// prologue of shaders/{scanlines,mask,crt}.wgsl.
 
 struct BezelUniforms {
     // Display sub-rect of src_tex in UV space: xy origin, zw size. The

--- a/src/video/window/shaders/bezel.wgsl
+++ b/src/video/window/shaders/bezel.wgsl
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Monitor-bezel pass: a procedural plastic front frame in the spirit of
+// the 1084 the Amiga shipped with. The pass covers the whole display rect;
+// the picture is re-sampled to fill the rounded opening the frame leaves,
+// with a dark recess between the tube face and the plastic, a bevelled
+// inner lip, a moulded outer edge and the power LED on the bottom band.
+//
+// Not a window-shader preset: it is not user-replaceable, runs before any
+// preset (which then re-draws the picture inside the opening), and its
+// uniform block is its own, so it deliberately does not carry the shared
+// contract prologue of shaders/{scanlines,mask,crt}.wgsl.
+
+struct BezelUniforms {
+    // Display sub-rect of src_tex in UV space: xy origin, zw size. The
+    // status bar sits below the display in the same texture and must
+    // never be sampled, so all sampling goes through this rect.
+    src_rect: vec4<f32>,
+    // xy: viewport size in physical pixels.
+    // zw: source display region in texels.
+    size: vec4<f32>,
+    // Picture opening within the viewport, in viewport UV: xy origin,
+    // zw size. Same aspect as the viewport, so the picture is scaled,
+    // not stretched.
+    opening: vec4<f32>,
+    // x: 1 = frame-only (a CRT preset has already painted the opening;
+    // leave its interior untouched), 0 = full (paint the picture too).
+    // yzw: reserved, zero.
+    params: vec4<f32>,
+};
+
+@group(0) @binding(0) var src_tex: texture_2d<f32>;
+@group(0) @binding(1) var src_samp: sampler;
+@group(0) @binding(2) var<uniform> u: BezelUniforms;
+
+struct VOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VOut {
+    // Fullscreen triangle: the viewport restricts it to the display rect.
+    let tc = vec2<f32>(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VOut;
+    out.uv = tc;
+    out.pos = vec4<f32>(tc * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+    return out;
+}
+
+// Sample the display region only, with the clamp inset by half a texel so
+// a linear sample on the boundary never blends in the status bar's first
+// row (see sample_display in the preset contract for the derivation).
+fn sample_display(uv: vec2<f32>) -> vec4<f32> {
+    let half_texel = 0.5 * u.src_rect.zw / max(u.size.zw, vec2<f32>(1.0));
+    let lo = u.src_rect.xy + half_texel;
+    let hi = u.src_rect.xy + u.src_rect.zw - half_texel;
+    let tc = clamp(u.src_rect.xy + uv * u.src_rect.zw, lo, hi);
+    return textureSample(src_tex, src_samp, tc);
+}
+
+// Signed distance to a rounded rectangle centred on the origin, in the
+// units of p; negative inside.
+fn rounded_rect(p: vec2<f32>, half: vec2<f32>, r: f32) -> f32 {
+    let q = abs(p) - half + vec2<f32>(r);
+    return length(max(q, vec2<f32>(0.0))) + min(max(q.x, q.y), 0.0) - r;
+}
+
+// Per-pixel hash in -0.5..0.5, for the moulded plastic grain.
+fn grain(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453) - 0.5;
+}
+
+// The front-face plastic, a warm Commodore grey (linear light).
+const PLASTIC: vec3<f32> = vec3<f32>(0.585, 0.560, 0.500);
+
+@fragment
+fn fs_main(in: VOut) -> @location(0) vec4<f32> {
+    let vp = u.size.xy;
+    let px = in.uv * vp;
+
+    // Opening geometry in physical pixels.
+    let o_org = u.opening.xy * vp;
+    let o_size = u.opening.zw * vp;
+    let o_half = max(o_size * 0.5, vec2<f32>(1.0));
+    let centre = o_org + o_half;
+    let p = px - centre;
+    // Trim widths scale with the opening so the frame keeps its
+    // proportions at any window size, with pixel floors so nothing
+    // vanishes in a tiny window.
+    let unit = min(o_size.x, o_size.y);
+    let r_open = 0.055 * unit;
+    let recess = max(0.016 * unit, 2.0);
+    let bevel = max(0.022 * unit, 2.0);
+
+    let d = rounded_rect(p, o_half, r_open);
+    let aa = max(fwidth(d), 1e-4);
+
+    // Frame-only pass: a CRT preset has already painted the opening
+    // interior (drawn before this pass, on the opening's bounding box),
+    // so leave every interior fragment to it and repaint just the frame,
+    // whose rounded corners and recess must sit on top of the preset's
+    // square viewport -- the plastic overlaps the tube, not the other way
+    // round.
+    if u.params.x > 0.5 && d < 0.0 {
+        discard;
+    }
+
+    // Vertical position through the opening, -1 at its top edge to +1 at
+    // its bottom: the shading key for room light falling from above.
+    let dir_y = clamp(p.y / o_half.y, -1.0, 1.0);
+
+    // The picture, scaled to fill the opening.
+    let pic_uv = clamp((in.uv - u.opening.xy) / max(u.opening.zw, vec2<f32>(1e-4)),
+                       vec2<f32>(0.0), vec2<f32>(1.0));
+    let picture = sample_display(pic_uv).rgb;
+
+    // The unlit gap where the tube face sits behind the plastic: nearly
+    // black, catching a little light along its lower run.
+    let gap = vec3<f32>(0.012) * (1.0 + 0.8 * dir_y) + vec3<f32>(0.004);
+
+    // Front-face plastic: lit from above, so it shades down slightly
+    // toward the bottom band, with a faint moulding grain.
+    var plastic = PLASTIC * (1.0 - 0.10 * in.uv.y);
+    plastic *= 1.0 + 0.03 * grain(floor(px));
+
+    // The bevelled lip sloping into the recess: in shadow above the
+    // opening, catching the light below it.
+    let lip = smoothstep(recess, recess + bevel, d);
+    plastic *= mix(1.0 + 0.22 * dir_y, 1.0, lip);
+
+    // Moulded outer edge of the case: the face rolls off into shadow just
+    // inside the outline, and outside it is whatever backs the window
+    // (the letterbox black), so the corners read as a rounded cabinet.
+    let v_half = vp * 0.5;
+    let d_case = rounded_rect(px - v_half, v_half, 0.05 * min(vp.x, vp.y));
+    let aa_case = max(fwidth(d_case), 1e-4);
+    plastic *= 1.0 - 0.35 * smoothstep(-6.0, 0.0, d_case);
+
+    // Power LED on the right of the bottom band, in a small dark well.
+    let band_mid_y = (o_org.y + o_size.y + recess + vp.y) * 0.5;
+    let led_pos = vec2<f32>(0.91 * vp.x, band_mid_y);
+    let led_d = length(px - led_pos);
+    let led_r = max(0.007 * unit, 1.5);
+    let well = 1.0 - smoothstep(led_r + 1.0, led_r + 3.0, led_d);
+    let led = 1.0 - smoothstep(led_r - 1.0, led_r + 1.0, led_d);
+    plastic = mix(plastic, vec3<f32>(0.03, 0.03, 0.03), well);
+    plastic = mix(plastic, vec3<f32>(0.06, 0.55, 0.10), led);
+
+    // Compose by signed distance: picture, recess gap, then plastic, each
+    // join antialiased over about a pixel.
+    var col = mix(picture, gap, clamp(d / aa + 0.5, 0.0, 1.0));
+    col = mix(col, plastic, smoothstep(recess - aa, recess + aa, d));
+    col = mix(col, vec3<f32>(0.0), clamp(d_case / aa_case + 0.5, 0.0, 1.0));
+    return vec4<f32>(col, 1.0);
+}

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2740,6 +2740,7 @@ fn test_app_with_audio_cpu_and_program(
         0.0,
         crate::config::ShaderMode::None,
         1.0,
+        false,
         crate::config::Tint::None,
         false,
         false,


### PR DESCRIPTION
## Summary

A procedural monitor-style front bezel around the window picture, in the spirit of the 1084 (from a reference photo): warm-grey moulded plastic with grain and top-lit shading, a dark recess around the tube face, a bevelled inner lip, rounded case corners, a wider bottom band and the power LED. Fully procedural WGSL, no texture assets, so the frame stays sharp at any window size; the picture keeps its aspect and scales to 85% into the rounded opening.

- `[display] bezel = true` / `COPPERLINE_BEZEL=1|0`, live toggle on **Cmd/Alt+M**, and a *Monitor bezel* toggle row on the launcher's *Video* category.
- A separate pass from the CRT presets (`src/video/window/bezel.rs` + `shaders/bezel.wgsl`): not under the shared window-shader contract, not user-replaceable, and composes with every shader mode including off.
- Layering matches the real part - the moulding overlaps the tube. Bezel alone: one pass draws frame plus picture. With a CRT preset: the preset paints the picture into the opening's bounding box first, then the bezel draws in frame-only mode (interior fragments discarded) so its rounded corners and recess clip the preset's square viewport instead of being buried under its off-face black corners.
- Presentation only, like the shader pass: captures never include the frame; suspended while a menu/panel is open and for RTG scanout; stays on for programmable multisync scans (a frame is content-agnostic).
- Deliberately **no window-menu item**: the menu sits exactly at its no-scroll budget, and one more item would push MIDI-only/sampler-only sessions into the scrolling fallback that `the_menu_fits_on_screen_with_every_optional_item_shown` forbids.
- Docs: `docs/guide/configuration.md`, `docs/guide/ui.md` (shortcut + launcher row), `copperline.example.toml`.

Shared plumbing extracted rather than duplicated: `crt_shader` now exposes its bind-group layout and pipeline builder, and `CrtUniforms::with_viewport` re-aims a preset at the opening.

## Test plan

- 12 new unit tests: opening geometry (aspect preserved, bottom band wider, letterbox offsets), uniform mapping and the frame-only flag, WGSL validation, uniform-block size against the shared layout.
- Offscreen GPU render tests (skip cleanly without an adapter): full coverage of the display viewport and nothing drawn below it, the picture filling the opening, plastic band / case corners / LED present, the status bar never sampled, and - the layering regression - warm plastic at the opening's bounding-box corner where a preset's square viewport used to leave black.
- An ignored `dump_bezel_preview_png` test (`COPPERLINE_BEZEL_PREVIEW_OUT/_SRC/_SHADER`) renders the pass over any screenshot for look tuning.
- `cargo test` (2009 passed), `cargo clippy --all-targets` and `cargo fmt --check` clean; verified in the real window against a Workbench 3.1 boot, bezel alone and combined with the `crt` preset.