### PR TITLE
video: redesign the reboot button glyph

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -319,6 +319,7 @@ const BUTTON_GLYPH: u32 = rgba(0, 174, 0);
 const BUTTON_GLYPH_DISABLED: u32 = rgba(96, 94, 86);
 const POWER_GLYPH_ON: u32 = rgba(0, 174, 0);
 const POWER_GLYPH_OFF: u32 = rgba(150, 36, 30);
+const RESET_GLYPH: u32 = rgba(250, 200, 40);
 const DISK_BODY: u32 = rgba(28, 82, 184);
 const DISK_BODY_HIGHLIGHT: u32 = rgba(74, 139, 238);
 const DISK_BODY_SHADOW: u32 = rgba(8, 26, 84);

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1505,77 +1505,43 @@ pub(super) fn draw_power_glyph(
     );
 }
 
+/// The reboot symbol: a near-full ring broken at the upper left with a bold
+/// arrowhead pointing counter-clockwise.
 pub(super) fn draw_reset_glyph(frame: &mut [u8], cx: usize, cy: usize, texture_scale: usize) {
-    let svg_scale = 0.17 * texture_scale as f32;
-    let ox = cx as f32 - 8.5 * texture_scale as f32;
-    let oy = cy as f32 - 8.5 * texture_scale as f32;
-    let map = |x: f32, y: f32| (ox + x * svg_scale, oy + y * svg_scale);
-    let stroke = 1.35 * texture_scale as f32;
+    let scale = texture_scale as f32;
+    let ccx = cx as f32 + 0.5;
+    let ccy = cy as f32 + 0.5;
+    let radius = 5.5 * scale;
+    let stroke = 1.35 * scale;
 
-    let (x0, y0) = map(50.0, 10.0);
-    let (x1, y1) = map(50.0, 45.0);
-    draw_thick_line(frame, x0, y0, x1, y1, stroke, BUTTON_GLYPH, texture_scale);
-
-    draw_cubic(
-        frame,
-        [(20.0, 29.0), (4.0, 52.0), (15.0, 90.0), (50.0, 90.0)],
-        svg_scale,
-        ox,
-        oy,
-        stroke,
-        BUTTON_GLYPH,
-        texture_scale,
-    );
-    draw_cubic(
-        frame,
-        [(50.0, 90.0), (85.0, 90.0), (100.0, 47.0), (74.0, 20.0)],
-        svg_scale,
-        ox,
-        oy,
-        stroke,
-        BUTTON_GLYPH,
-        texture_scale,
-    );
-
-    let arrow = [map(2.0, 21.0), map(31.0, 19.0), map(33.0, 48.0)];
-    fill_triangle(frame, arrow, BUTTON_GLYPH, texture_scale);
-}
-
-pub(super) fn draw_cubic(
-    frame: &mut [u8],
-    p: [(f32, f32); 4],
-    scale: f32,
-    ox: f32,
-    oy: f32,
-    radius: f32,
-    color: u32,
-    texture_scale: usize,
-) {
-    let mut prev = (ox + p[0].0 * scale, oy + p[0].1 * scale);
-    for step in 1..=18 {
-        let t = step as f32 / 18.0;
-        let mt = 1.0 - t;
-        let x = mt * mt * mt * p[0].0
-            + 3.0 * mt * mt * t * p[1].0
-            + 3.0 * mt * t * t * p[2].0
-            + t * t * t * p[3].0;
-        let y = mt * mt * mt * p[0].1
-            + 3.0 * mt * mt * t * p[1].1
-            + 3.0 * mt * t * t * p[2].1
-            + t * t * t * p[3].1;
-        let next = (ox + x * scale, oy + y * scale);
+    let start = 165.0_f32.to_radians();
+    let sweep = 260.0_f32.to_radians();
+    let steps = 28;
+    let ang = |t: f32| start - sweep * t;
+    let mut prev = {
+        let a = ang(0.0);
+        (ccx + radius * a.cos(), ccy + radius * a.sin())
+    };
+    for step in 1..=steps {
+        let a = ang(step as f32 / steps as f32);
+        let next = (ccx + radius * a.cos(), ccy + radius * a.sin());
         draw_thick_line(
             frame,
             prev.0,
             prev.1,
             next.0,
             next.1,
-            radius,
-            color,
+            stroke,
+            RESET_GLYPH,
             texture_scale,
         );
         prev = next;
     }
+
+    let unit = radius / 5.5;
+    let tip = |x: f32, y: f32| (ccx + x * unit, ccy + y * unit);
+    let arrow = [tip(-3.9, -4.3), tip(1.0, -6.7), tip(1.0, -1.9)];
+    fill_triangle(frame, arrow, RESET_GLYPH, texture_scale);
 }
 
 pub(super) fn draw_thick_line(


### PR DESCRIPTION
## Summary
- The status-bar reboot and power buttons were both green rings of the same
  size, so the two adjacent controls were easy to confuse.
- Redraws the reboot control as a golden broken-ring restart symbol with a
  bold counter-clockwise arrowhead — distinct from the green power ring in
  both shape and colour.
- Removes the now-unused `draw_cubic` bézier helper (only the old reset glyph
  used it).

## Test plan
- [x] `cargo build --release`
- [x] `cargo clippy` — no new warnings (6 pre-existing warnings unrelated to this change)
- [x] `cargo fmt --check` — clean
- [x] `cargo test --release --lib video::window` — all window/status-bar tests pass
- [x] Visual check: launch the app and confirm the reboot button shows the
      golden restart glyph, clearly distinct from the green power button beside it
- [x] Confirm clicking reboot still performs a warm reset

Before:
<img width="828" height="725" alt="Screenshot 2026-07-28 at 17 21 46" src="https://github.com/user-attachments/assets/baa69e83-79be-49b7-9901-639198ccad55" />

After:
<img width="784" height="681" alt="Screenshot 2026-07-28 at 17 22 21" src="https://github.com/user-attachments/assets/e0ad9f76-c9bb-435d-aca5-5290e1733328" />


