### PR TITLE
video: latch presentation geometry across border-only frames

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -226,6 +226,11 @@ pub struct WebEmu {
     /// masks the deep horizontal overscan like a CRT bezel (the default),
     /// `Full` presents everything Denise produced.
     overscan: Overscan,
+    /// Aperture/recentring decisions latched across border-only frames,
+    /// as on the desktop: the blank frames a screen change emits keep the
+    /// previous presentation geometry instead of snapping to the full
+    /// framebuffer, so the canvas does not jump at every mode change.
+    presentation_latch: present_common::PresentationLatch,
 }
 
 #[wasm_bindgen]
@@ -279,6 +284,7 @@ impl WebEmu {
             mouse_pending: (0, 0),
             serial,
             overscan: Overscan::Tv,
+            presentation_latch: present_common::PresentationLatch::default(),
         })
     }
 
@@ -403,8 +409,11 @@ impl WebEmu {
         // The desktop's recentring shift (window.rs render jobs): full
         // overscan recentres a standard display whose deep left overscan
         // would push the picture right of centre; TV mode is a fixed
-        // aperture and shifts nothing.
-        let h_shift = present_common::presentation_h_shift_for(&base, self.overscan);
+        // aperture and shifts nothing. Latched across border-only frames
+        // like the desktop, so screen changes do not jump.
+        let h_shift = self
+            .presentation_latch
+            .presentation_h_shift(&base, self.overscan);
         let field_rows = present_common::post_process_rendered_field(
             &mut self.fb,
             geometry,
@@ -426,7 +435,10 @@ impl WebEmu {
         let woven_rows = self.deinterlacer.output_rows();
         let woven = self.deinterlacer.output();
         let tv_aperture_rows = if self.overscan == Overscan::Tv {
-            present_common::standard_tv_aperture_rows(geometry, woven_rows, &base)
+            self.presentation_latch
+                .resolve_tv_aperture(present_common::standard_tv_aperture_frame(
+                    geometry, woven_rows, &base,
+                ))
         } else {
             None
         };
@@ -775,8 +787,10 @@ impl WebEmu {
         // The restored frame counter may match or precede the last one
         // presented; forget it so the next render is unconditional, and
         // paint the restored screen now so a paused page shows it without
-        // stepping the machine.
+        // stepping the machine. The presentation latch belongs to the old
+        // timeline, so it starts over too.
         self.last_rendered_frame = None;
+        self.presentation_latch.reset();
         self.render_completed_frame();
         Ok(())
     }
@@ -786,9 +800,10 @@ impl WebEmu {
         self.emu.power_on_reset().map_err(js_err)?;
         self.anchor = None;
         // Motion buffered against the old machine must not replay into the
-        // fresh one.
+        // fresh one, and the presentation latch starts over with it.
         self.mouse_remainder = (0.0, 0.0);
         self.mouse_pending = (0, 0);
+        self.presentation_latch.reset();
         Ok(())
     }
 
@@ -818,6 +833,9 @@ impl WebEmu {
             return;
         }
         self.overscan = overscan;
+        // Judge the new mode's geometry fresh rather than from decisions
+        // latched under the old one.
+        self.presentation_latch.reset();
         self.last_rendered_frame = None;
         self.render_completed_frame();
     }

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -257,7 +257,9 @@ through wasm-bindgen; the page's JavaScript drives everything from
   716-pixel width, as on the desktop, and a programmable super-hi-res scan
   carries its double (1432-pixel, 35 ns pitch) canvas straight to the
   browser canvas (see
-  [the presentation internals](../internals/video.md)).
+  [the presentation internals](../internals/video.md)). Border-only frames
+  keep the previous frame's geometry, as on the desktop, so the canvas
+  does not switch shape across the blanks a screen change produces.
   There is no wgpu in the build, which keeps the wasm
   around 1.4 MiB (about 0.6 MiB over the wire).
 - **Audio**: Paula's 44.1 kHz stereo mix is drained once per animation frame

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -465,7 +465,10 @@ screenshots and `--dump-frames` crop standard TV output to a 692x540
 aperture for reference-emulator comparison; PAL and NTSC scans share the
 one shape because both apertures fill the same 4:3 glass -- an NTSC scan's
 shorter crop (the 200-line standard window plus the same overscan margin)
-is scaled onto the same output rows. `"full"` shows everything, which
+is scaled onto the same output rows. The live window shows a slightly
+narrower cut of the same aperture, clipped to the columns the framebuffer
+actually captures, so the picture sits exactly centred on screen with no
+one-sided black margin. `"full"` shows everything, which
 is useful when debugging display alignment. `COPPERLINE_OVERSCAN=full|tv`
 overrides this for a single run. In both modes the presentation geometry
 holds steady across the blank frames a screen change produces: a frame

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -467,7 +467,11 @@ one shape because both apertures fill the same 4:3 glass -- an NTSC scan's
 shorter crop (the 200-line standard window plus the same overscan margin)
 is scaled onto the same output rows. `"full"` shows everything, which
 is useful when debugging display alignment. `COPPERLINE_OVERSCAN=full|tv`
-overrides this for a single run.
+overrides this for a single run. In both modes the presentation geometry
+holds steady across the blank frames a screen change produces: a frame
+showing only border colour keeps the previous frame's aperture and
+centring instead of snapping to the full framebuffer, so the picture does
+not jump sideways at Kickstart screen changes.
 
 `pixel_aspect` selects how emulated scanlines map to host rows. The default
 `"tv"` presents the field with the non-square pixel aspect of a 4:3 CRT:

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -444,6 +444,22 @@ framebuffer):
   display that genuinely fetches bitplane data into the overscan border is left
   exactly as rendered.
 
+Both content-keyed decisions -- the TV aperture crop and the full-overscan
+recentring shift -- are latched across border-only frames
+(`PresentationLatch` in `present_common.rs`). A frame with no bitplane
+content intersecting the window (registers cleared during boot, or the
+blank frame or two Intuition emits at every screen change while it rebuilds
+the copper list) carries no evidence about the display's layout, so it
+keeps the previous frame's geometry instead of snapping to the full
+framebuffer -- the monitor does not move between screens. The power-on
+default is the stock standard display (aperture on, standard recentring
+shift); a frame that does carry content, including a true-overscan fetch or
+a programmable scan, re-latches the decision, so an overscan demo that
+blanks between parts stays on full-frame presentation throughout. The latch
+resets on presentation discontinuities (machine swap, reset, state load).
+Frame dumps and screenshots share the resolved decision, so a dump's PNG
+dimensions no longer flip between 716x537 and 692x540 across a boot.
+
 ### RTG scanout (Z3660)
 
 When a fitted `[rtg]` board's guest driver switches the display to RTG,

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -419,21 +419,26 @@ framebuffer):
   margin). Both apertures fill the same 4:3 glass, so presentation keeps
   one shape -- a 60 Hz crop's rows are scaled onto the 50 Hz aperture's
   native row count (whole-row selection, no blending) in the saved PNG, and
-  the live window stretches it over the same display rect. The window keeps
-  its 716-pixel 4:3 texture for the status bar and scaling path, but
-  centres the TV aperture inside that texture instead of showing the raw
-  framebuffer origin. True horizontal overscan fetches are not cropped to
-  this aperture: they stay on the full-width TV path so intentional border
-  content remains visible. `COPPERLINE_SHOT_RAW=1` bypasses the PNG crop
-  and writes the raw 716x570 woven framebuffer. A second, narrower aperture
-  (`TV_CAPTURED_*`, 668 wide) clips the same rect to columns the
-  framebuffer actually captures: the reference aperture's right margin
-  reaches 12 columns past the framebuffer's right edge, which the window
-  and PNG paths pad with black bezel. Frontends whose frame should end on
-  real pixels present the captured aperture instead -- the browser canvas
-  hugs its border on every side -- with the margin mirrored from the
-  captured right-overscan width so the standard window stays exactly
-  centred. Its geometry invariants are const-evaluated beside the
+  the live window stretches it over the same display rect. True horizontal
+  overscan fetches are not cropped to this aperture: they stay on the
+  full-width TV path so intentional border content remains visible.
+  `COPPERLINE_SHOT_RAW=1` bypasses the PNG crop and writes the raw 716x570
+  woven framebuffer. A second, narrower aperture (`TV_CAPTURED_*`, 668
+  wide) clips the same rect to columns the framebuffer actually captures:
+  the reference aperture's right margin reaches 12 columns past the
+  framebuffer's right edge, which the PNG path pads with black bezel.
+  Presentation paths whose frame should end on real pixels use the
+  captured aperture instead, with the margin mirrored from the captured
+  right-overscan width so the standard window stays exactly centred: the
+  browser canvas hugs its border on every side, and the desktop's live
+  window centres the captured aperture in its 716-pixel 4:3 texture (kept
+  for the status bar and scaling path) between symmetric black side pads,
+  so the visible raster and the standard window are both dead centre --
+  the reference aperture's one-sided black margin read as an off-centre
+  picture inside the monitor bezel. The pads stay black rather than
+  replicating the crop's edge columns, which carry picture when a display
+  fetches or parks sprites in the deepest overscan. The captured
+  aperture's geometry invariants are const-evaluated beside the
   definitions.
 - **Full-overscan horizontal recentring**: in `"full"` presentation, a standard
   (non-overscan) display is recentred because the framebuffer captures a deep

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -196,71 +196,84 @@ pub fn present_h_shift(diw_h_start: u16, diw_h_stop: u16) -> usize {
     left_border.saturating_sub(right_border) / 2
 }
 
-/// `present_h_shift`, but able to recentre a display that opens its DIW window
-/// into the overscan around a picture it only fetches at standard width.
+/// The recentring shift of the stock full-width display: the power-on
+/// default carried by `PresentationLatch`, so border-only frames before the
+/// first playfield present like the standard display they precede.
+pub(crate) fn standard_present_h_shift() -> usize {
+    present_h_shift(STANDARD_DIW_HSTART as u16, STANDARD_DIW_HSTOP as u16)
+}
+
+/// How one frame's playfield relates horizontally to the standard display
+/// window, for the presentation-geometry decisions (TV aperture crop,
+/// full-overscan recentring).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HorizontalContentClass {
+    /// The visible playfield stays inside the standard window: a TV-style
+    /// aperture can crop the borders without cutting content, and `shift`
+    /// recentres the display inside the overscan field buffer
+    /// ([`present_h_shift`]).
+    Standard { shift: usize },
+    /// Fetched content genuinely reaches into the overscan border: the
+    /// frame must present on the full framebuffer, exactly as rendered.
+    Overscan,
+    /// Border-only frame: no bitplane content intersects the window (no
+    /// valid fetch, or a fetch that misses the window entirely). Such a
+    /// frame carries no evidence about the display's horizontal layout;
+    /// presentation keeps its previous geometry across it
+    /// (`PresentationLatch`) instead of snapping to the full framebuffer,
+    /// so the blank frames a screen change emits while the copper list is
+    /// rebuilt do not make the picture jump.
+    Neutral,
+}
+
+/// Classify one frame's snapshot for presentation geometry.
 ///
 /// A demo can open DIWSTRT/DIWSTOP much wider than the playfield it draws --
-/// Virtual Dreams' "Absolute Inebriation" opens DIW $02..$1FF around a standard
-/// 320-px lo-res picture (DDF $38..$D0) -- where the extra window only reveals
-/// COLOR0 border the TV crops, not content. The bare `present_h_shift` keys off
-/// DIW alone and so declines to recentre any window that reaches into the
-/// overscan, leaving such a picture sitting right-of-centre.
-///
-/// While the DIW window stays inside the standard window, behaviour is
-/// identical to `present_h_shift(diw_h_start, diw_h_stop)` -- the window
-/// (including any COLOR0 border it legitimately shows) is centred as before.
-/// Only when the window reaches into the overscan do we fall back to centring
-/// on the *fetched content* (DDF) clamped to the window: a picture whose fetch
-/// stays within the standard window is recentred like the standard display it
-/// really is, while one that genuinely fetches bitplane data into the border is
-/// still left exactly as rendered (`present_h_shift` returns 0 for it).
-pub fn present_h_shift_for(snapshot: &RenderRegisterSnapshot) -> usize {
+/// Virtual Dreams' "Absolute Inebriation" opens DIW $02..$1FF around a
+/// standard 320-px lo-res picture (DDF $38..$D0) -- where the extra window
+/// only reveals COLOR0 border the TV crops, not content. Wide DIW alone is
+/// therefore not enough to call a frame overscan: while the window stays
+/// inside the standard window the window itself is the content (including
+/// any COLOR0 border it legitimately shows), and beyond that the *fetched
+/// content* (DDF) clamped to the window decides -- a picture whose fetch
+/// stays within the standard window is the standard display it really is,
+/// while one that genuinely fetches bitplane data into the border is true
+/// overscan.
+pub(crate) fn horizontal_content_class(
+    snapshot: &RenderRegisterSnapshot,
+) -> HorizontalContentClass {
     let control = ControlState::from_render_state(&RenderState::from_snapshot(*snapshot));
     let diw_start = control.diw_h_start() as i32;
     let mut diw_stop = control.diw_h_stop() as i32;
     if diw_stop <= diw_start {
         diw_stop += 0x100;
     }
-    // DIW within the standard window: centre on the window itself, exactly as
-    // the bare helper does, so stock and sub-standard displays are unchanged.
+    // DIW within the standard window: the window clips everything the
+    // playfield could show, so the frame is standard whatever the fetch
+    // does, and stock and sub-standard displays centre on the window.
     if diw_start >= STANDARD_DIW_HSTART && diw_stop <= STANDARD_DIW_HSTOP {
-        return present_h_shift(diw_start as u16, diw_stop as u16);
+        return HorizontalContentClass::Standard {
+            shift: present_h_shift(diw_start as u16, diw_stop as u16),
+        };
     }
-    // DIW reaches into the overscan: recentre on the fetched content if it
-    // stays standard, otherwise leave a true overscan display untouched.
+    // DIW reaches into the overscan: judge by the fetched content clamped
+    // to the window. No fetch, or a fetch the window never shows, is a
+    // border-only frame with nothing to judge.
     let Some((content_start, content_stop)) = control.bitplane_content_window_h() else {
-        return 0;
+        return HorizontalContentClass::Neutral;
     };
     let eff_start = diw_start.max(content_start);
     let eff_stop = diw_stop.min(content_stop);
     if eff_stop <= eff_start {
-        return 0;
+        return HorizontalContentClass::Neutral;
     }
-    present_h_shift(eff_start as u16, eff_stop as u16)
-}
-
-/// Whether a TV-style standard PAL aperture can crop the horizontal borders
-/// without cutting fetched playfield content. Wide DIW alone is not enough to
-/// reject the aperture: some software opens DIW into the border around a
-/// standard-width fetch and only exposes COLOR0 there. A fetch that reaches
-/// outside the standard window is true horizontal overscan and must stay on
-/// the full framebuffer.
-pub(crate) fn uses_standard_horizontal_content(snapshot: &RenderRegisterSnapshot) -> bool {
-    let control = ControlState::from_render_state(&RenderState::from_snapshot(*snapshot));
-    let diw_start = control.diw_h_start() as i32;
-    let mut diw_stop = control.diw_h_stop() as i32;
-    if diw_stop <= diw_start {
-        diw_stop += 0x100;
+    if eff_start >= STANDARD_DIW_HSTART && eff_stop <= STANDARD_DIW_HSTOP {
+        HorizontalContentClass::Standard {
+            shift: present_h_shift(eff_start as u16, eff_stop as u16),
+        }
+    } else {
+        HorizontalContentClass::Overscan
     }
-    if diw_start >= STANDARD_DIW_HSTART && diw_stop <= STANDARD_DIW_HSTOP {
-        return true;
-    }
-    let Some((content_start, content_stop)) = control.bitplane_content_window_h() else {
-        return false;
-    };
-    let eff_start = diw_start.max(content_start);
-    let eff_stop = diw_stop.min(content_stop);
-    eff_start >= STANDARD_DIW_HSTART && eff_stop <= STANDARD_DIW_HSTOP && eff_stop > eff_start
 }
 const BPLCON0_ECSENA: u16 = 1 << 0;
 const BPLCON0_SHRES: u16 = 1 << 6;

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -330,49 +330,35 @@ fn ocs_snapshot(diwstrt: u16, diwstop: u16, ddfstrt: u16, ddfstop: u16) -> Rende
 }
 
 #[test]
-fn present_h_shift_for_centres_wide_diw_around_standard_fetch() {
+fn horizontal_class_centres_wide_diw_around_standard_fetch() {
     // Virtual Dreams "Absolute Inebriation": DIW opened wide
     // (DIWSTRT $5702 -> H $02, DIWSTOP $FFFF -> H $1FF) around a standard
     // 320-px lo-res picture (DDF $38..$D0). The open window only reveals
-    // COLOR0 border the TV crops, so the picture must still recentre by the
-    // stock 24px instead of sitting right-of-centre.
+    // COLOR0 border the TV crops, so the frame stays standard and the
+    // picture must still recentre by the stock 24px instead of sitting
+    // right-of-centre.
     assert_eq!(
-        present_h_shift_for(&ocs_snapshot(0x5702, 0xFFFF, 0x0038, 0x00D0)),
-        24
+        horizontal_content_class(&ocs_snapshot(0x5702, 0xFFFF, 0x0038, 0x00D0)),
+        HorizontalContentClass::Standard { shift: 24 }
     );
     // A genuinely centred stock display is unchanged.
     assert_eq!(
-        present_h_shift_for(&ocs_snapshot(0x2C81, 0x2CC1, 0x0038, 0x00D0)),
-        24
+        horizontal_content_class(&ocs_snapshot(0x2C81, 0x2CC1, 0x0038, 0x00D0)),
+        HorizontalContentClass::Standard { shift: 24 }
     );
 }
 
 #[test]
-fn present_h_shift_for_leaves_true_overscan_fetch_untouched() {
+fn horizontal_class_calls_true_overscan_fetch_overscan() {
     // Wide DIW *and* a fetch that reaches into the overscan border
     // (DDFSTRT $30 starts the picture left of the standard window): a real
-    // overscan display, presented exactly as rendered.
+    // overscan display, presented exactly as rendered on the full
+    // framebuffer.
     assert_eq!(
-        present_h_shift_for(&ocs_snapshot(0x5702, 0xFFFF, 0x0030, 0x00D8)),
-        0
+        horizontal_content_class(&ocs_snapshot(0x5702, 0xFFFF, 0x0030, 0x00D8)),
+        HorizontalContentClass::Overscan
     );
-}
-
-#[test]
-fn standard_horizontal_content_accepts_standard_fetch_inside_wide_diw() {
-    // A wide display window around a standard fetch only exposes border
-    // colour in the overscan area, so the TV aperture may still crop it.
-    assert!(uses_standard_horizontal_content(&ocs_snapshot(
-        0x5702, 0xFFFF, 0x0038, 0x00D0
-    )));
-    assert!(uses_standard_horizontal_content(&ocs_snapshot(
-        0x2C81, 0x2CC1, 0x0038, 0x00D0
-    )));
-}
-
-#[test]
-fn standard_horizontal_content_rejects_true_overscan_fetch() {
-    let snapshot = RenderRegisterSnapshot {
+    let aga = RenderRegisterSnapshot {
         agnus_revision: AgnusRevision::AgaAlice,
         bplcon0: 0x8214,
         diwstrt: 0x1D61,
@@ -381,18 +367,41 @@ fn standard_horizontal_content_rejects_true_overscan_fetch() {
         ddfstop: 0x00D8,
         ..RenderRegisterSnapshot::default()
     };
-
-    assert!(!uses_standard_horizontal_content(&snapshot));
+    assert_eq!(
+        horizontal_content_class(&aga),
+        HorizontalContentClass::Overscan
+    );
 }
 
 #[test]
-fn present_h_shift_for_leaves_narrow_late_fetch_untouched() {
+fn horizontal_class_keeps_narrow_late_fetch_in_beam_position() {
     // A normal DIW can be used around a tiny one-word late-DDF object. The
     // fetched object must stay in beam position; presentation centring must
     // not copy its right edge into the deep-left overscan border.
     assert_eq!(
-        present_h_shift_for(&ocs_snapshot(0x3481, 0x24D1, 0x0050, 0x0058)),
-        0
+        horizontal_content_class(&ocs_snapshot(0x3481, 0x24D1, 0x0050, 0x0058)),
+        HorizontalContentClass::Standard { shift: 0 }
+    );
+}
+
+#[test]
+fn horizontal_class_calls_border_only_frames_neutral() {
+    // A frame with no valid fetch at all -- registers cleared, the state a
+    // machine shows for several frames during boot and for a frame or two
+    // at every screen change while the copper list is rebuilt -- carries no
+    // evidence about the display's layout. It must classify neutral so
+    // presentation keeps its previous geometry instead of snapping to the
+    // full framebuffer (the Kickstart 2.05 boot picture-jump regression).
+    assert_eq!(
+        horizontal_content_class(&RenderRegisterSnapshot::default()),
+        HorizontalContentClass::Neutral
+    );
+    // A window that opens only after the fetched content has ended (DIW
+    // H $E1..$1FF into the right overscan, content $B1..$D1) shows border
+    // only: neutral too.
+    assert_eq!(
+        horizontal_content_class(&ocs_snapshot(0x2CE1, 0xFFFF, 0x0050, 0x0058)),
+        HorizontalContentClass::Neutral
     );
 }
 

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -289,14 +289,83 @@ pub fn presentation_source_y_offset(visible_start_vpos: u32) -> usize {
     standard_offset.saturating_sub(overscan_rows_already_visible)
 }
 
-pub fn presentation_h_shift_for(snapshot: &RenderRegisterSnapshot, overscan: Overscan) -> usize {
-    match overscan {
-        // TV mode is an aperture over the emulated framebuffer, matching the
-        // fixed source cutout used by reference emulators. Do not copy pixels
-        // sideways here: a standard hi-res screen already occupies the right
-        // edge of Copperline's 716-pixel cutout.
-        Overscan::Tv => 0,
-        Overscan::Full => bitplane::present_h_shift_for(snapshot),
+/// Presentation-geometry decisions carried across border-only frames.
+///
+/// The TV aperture crop and the full-overscan recentring shift are judged
+/// from each frame's playfield, but a border-only frame has no playfield to
+/// judge -- and screen changes blank the display for a frame or two while
+/// Intuition rebuilds the copper list. Deciding those frames "full
+/// framebuffer" made the whole picture lurch sideways (and rescale) at
+/// every Kickstart screen change, conspicuous inside the monitor bezel's
+/// fixed frame. A border-only frame instead keeps the previous decision --
+/// the monitor does not move between screens -- with the stock standard
+/// display as the power-on default. The two decisions latch independently:
+/// the shift resolves when a frame is submitted for rendering, the
+/// aperture when its presentation comes back, and each is only consumed by
+/// its own overscan mode.
+#[derive(Clone, Debug)]
+pub struct PresentationLatch {
+    standard_aperture: bool,
+    h_shift: usize,
+}
+
+impl Default for PresentationLatch {
+    fn default() -> Self {
+        Self {
+            standard_aperture: true,
+            h_shift: bitplane::standard_present_h_shift(),
+        }
+    }
+}
+
+impl PresentationLatch {
+    /// Back to the power-on default, for presentation discontinuities
+    /// (machine swap, reset, state load).
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// The horizontal recentring shift for one frame under `overscan`,
+    /// latching the decision of any frame that carries content.
+    pub fn presentation_h_shift(
+        &mut self,
+        snapshot: &RenderRegisterSnapshot,
+        overscan: Overscan,
+    ) -> usize {
+        match overscan {
+            // TV mode is an aperture over the emulated framebuffer, matching
+            // the fixed source cutout used by reference emulators. Do not
+            // copy pixels sideways here: a standard hi-res screen already
+            // occupies the right edge of Copperline's 716-pixel cutout.
+            Overscan::Tv => 0,
+            Overscan::Full => match bitplane::horizontal_content_class(snapshot) {
+                bitplane::HorizontalContentClass::Standard { shift } => {
+                    self.h_shift = shift;
+                    shift
+                }
+                bitplane::HorizontalContentClass::Overscan => {
+                    self.h_shift = 0;
+                    0
+                }
+                bitplane::HorizontalContentClass::Neutral => self.h_shift,
+            },
+        }
+    }
+
+    /// Resolve one frame's aperture classification into the crop to apply,
+    /// latching the decision of any frame that carries content.
+    pub fn resolve_tv_aperture(&mut self, frame: TvApertureFrame) -> Option<usize> {
+        match frame {
+            TvApertureFrame::Standard(rows) => {
+                self.standard_aperture = true;
+                Some(rows)
+            }
+            TvApertureFrame::Full => {
+                self.standard_aperture = false;
+                None
+            }
+            TvApertureFrame::Neutral(rows) => self.standard_aperture.then_some(rows),
+        }
     }
 }
 
@@ -318,28 +387,42 @@ pub fn is_standard_presentation(geometry: FrameGeometry, src_rows: usize) -> boo
     !geometry.programmable && src_rows == OUT_HEIGHT
 }
 
-/// TV-aperture crop height in woven rows for this frame, or None when the
-/// frame is not a standard 15 kHz scan rendering the standard horizontal
-/// window (programmable scans and true horizontal-overscan fetches present
-/// on the full framebuffer instead). The height follows the scan the frame
-/// actually ran, not the configured standard: a 312/313-line (50 Hz) field
-/// carries the 256-line standard window, a 262/263-line (60 Hz) field the
-/// 200-line one.
-pub fn standard_tv_aperture_rows(
+/// One frame's TV-aperture classification, resolved into a crop by
+/// [`PresentationLatch::resolve_tv_aperture`]: crop to the standard
+/// aperture (`Standard`), present the full framebuffer (`Full`), or keep
+/// the previous geometry (`Neutral`, a border-only frame with no content
+/// to judge). `Standard` and `Neutral` carry the crop height in woven
+/// rows, which follows the scan the frame actually ran rather than the
+/// configured standard: a 312/313-line (50 Hz) field carries the 256-line
+/// standard window, a 262/263-line (60 Hz) field the 200-line one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TvApertureFrame {
+    Standard(usize),
+    Full,
+    Neutral(usize),
+}
+
+/// Classify one frame for the TV aperture. Programmable scans, frames not
+/// rendered at the standard woven height, and true horizontal-overscan
+/// fetches present on the full framebuffer.
+pub fn standard_tv_aperture_frame(
     geometry: FrameGeometry,
     src_rows: usize,
     snapshot: &RenderRegisterSnapshot,
-) -> Option<usize> {
-    if !is_standard_presentation(geometry, src_rows)
-        || !bitplane::uses_standard_horizontal_content(snapshot)
-    {
-        return None;
+) -> TvApertureFrame {
+    if !is_standard_presentation(geometry, src_rows) {
+        return TvApertureFrame::Full;
     }
-    Some(if geometry.frame_lines >= 312 {
+    let rows = if geometry.frame_lines >= 312 {
         TV_PAL_PRESENT_HEIGHT
     } else {
         TV_NTSC_PRESENT_HEIGHT
-    })
+    };
+    match bitplane::horizontal_content_class(snapshot) {
+        bitplane::HorizontalContentClass::Standard { .. } => TvApertureFrame::Standard(rows),
+        bitplane::HorizontalContentClass::Overscan => TvApertureFrame::Full,
+        bitplane::HorizontalContentClass::Neutral => TvApertureFrame::Neutral(rows),
+    }
 }
 
 #[cfg(test)]
@@ -355,37 +438,147 @@ mod tests {
         assert!(TV_CAPTURED_SOURCE_X >= tv_source_h_bounds().0);
     }
 
+    /// A standard full-width display (stock Kickstart screen).
+    fn standard_snapshot() -> RenderRegisterSnapshot {
+        RenderRegisterSnapshot {
+            bplcon0: 0x5200,
+            diwstrt: 0x2C81,
+            diwstop: 0xF4C1,
+            ddfstrt: 0x38,
+            ddfstop: 0xD0,
+            ..Default::default()
+        }
+    }
+
+    /// A wide-DIW display whose fetch reaches into the overscan border.
+    fn overscan_snapshot() -> RenderRegisterSnapshot {
+        RenderRegisterSnapshot {
+            bplcon0: 0x5200,
+            diwstrt: 0x5702,
+            diwstop: 0xFFFF,
+            ddfstrt: 0x30,
+            ddfstop: 0xD8,
+            ..Default::default()
+        }
+    }
+
+    /// A border-only frame: registers cleared, no fetch (the state a screen
+    /// change or the Kickstart boot blanks present for a few frames).
+    fn blank_snapshot() -> RenderRegisterSnapshot {
+        RenderRegisterSnapshot::default()
+    }
+
     #[test]
     fn tv_aperture_rows_follow_the_scans_field_line_count() {
         // A standard scan's TV aperture is picked by the lines the frame
         // actually ran (BEAMCON0 can retune Agnus mid-session), holding the
         // 256-line standard window of a 50 Hz field and the 200-line window
         // of a 60 Hz field with the same overscan margin.
-        let snapshot = RenderRegisterSnapshot {
-            diwstrt: 0x2C81,
-            diwstop: 0xF4C1,
-            ddfstrt: 0x38,
-            ddfstop: 0xD0,
-            ..Default::default()
-        };
+        let snapshot = standard_snapshot();
         let pal = FrameGeometry::standard(0x1C, 313, false);
         let ntsc = FrameGeometry::standard(0x1C, 262, false);
         assert_eq!(
-            standard_tv_aperture_rows(pal, OUT_HEIGHT, &snapshot),
-            Some(TV_PAL_PRESENT_HEIGHT)
+            standard_tv_aperture_frame(pal, OUT_HEIGHT, &snapshot),
+            TvApertureFrame::Standard(TV_PAL_PRESENT_HEIGHT)
         );
         assert_eq!(
-            standard_tv_aperture_rows(ntsc, OUT_HEIGHT, &snapshot),
-            Some(TV_NTSC_PRESENT_HEIGHT)
+            standard_tv_aperture_frame(ntsc, OUT_HEIGHT, &snapshot),
+            TvApertureFrame::Standard(TV_NTSC_PRESENT_HEIGHT)
         );
         // A programmable scan or a native-height field presents in full.
         let mut programmable = ntsc;
         programmable.programmable = true;
         assert_eq!(
-            standard_tv_aperture_rows(programmable, OUT_HEIGHT, &snapshot),
+            standard_tv_aperture_frame(programmable, OUT_HEIGHT, &snapshot),
+            TvApertureFrame::Full
+        );
+        assert_eq!(
+            standard_tv_aperture_frame(ntsc, 400, &snapshot),
+            TvApertureFrame::Full
+        );
+        // A border-only frame on a standard scan is neutral: it carries the
+        // scan's crop height but no crop decision of its own.
+        assert_eq!(
+            standard_tv_aperture_frame(pal, OUT_HEIGHT, &blank_snapshot()),
+            TvApertureFrame::Neutral(TV_PAL_PRESENT_HEIGHT)
+        );
+    }
+
+    #[test]
+    fn border_only_frames_keep_the_previous_aperture_decision() {
+        // The Kickstart 2.05 boot regression: screen changes emit a frame
+        // or two of border-only display, and deciding those "full
+        // framebuffer" flipped the whole presentation geometry there and
+        // back, lurching the picture sideways at every mode change.
+        let mut latch = PresentationLatch::default();
+        // Power-on default: crop like the stock display the blanks precede.
+        assert_eq!(
+            latch.resolve_tv_aperture(TvApertureFrame::Neutral(TV_PAL_PRESENT_HEIGHT)),
+            Some(TV_PAL_PRESENT_HEIGHT)
+        );
+        assert_eq!(
+            latch.resolve_tv_aperture(TvApertureFrame::Standard(TV_PAL_PRESENT_HEIGHT)),
+            Some(TV_PAL_PRESENT_HEIGHT)
+        );
+        // The blank between two standard screens stays cropped...
+        assert_eq!(
+            latch.resolve_tv_aperture(TvApertureFrame::Neutral(TV_PAL_PRESENT_HEIGHT)),
+            Some(TV_PAL_PRESENT_HEIGHT)
+        );
+        // ...and a neutral frame still follows the current scan's height
+        // (the crop decision is latched, not the row count).
+        assert_eq!(
+            latch.resolve_tv_aperture(TvApertureFrame::Neutral(TV_NTSC_PRESENT_HEIGHT)),
+            Some(TV_NTSC_PRESENT_HEIGHT)
+        );
+        // An overscan demo blanking between parts must NOT snap to the
+        // aperture: full presentation latches across its blanks too.
+        assert_eq!(latch.resolve_tv_aperture(TvApertureFrame::Full), None);
+        assert_eq!(
+            latch.resolve_tv_aperture(TvApertureFrame::Neutral(TV_PAL_PRESENT_HEIGHT)),
             None
         );
-        assert_eq!(standard_tv_aperture_rows(ntsc, 400, &snapshot), None);
+        // A presentation discontinuity restores the power-on default.
+        latch.reset();
+        assert_eq!(
+            latch.resolve_tv_aperture(TvApertureFrame::Neutral(TV_PAL_PRESENT_HEIGHT)),
+            Some(TV_PAL_PRESENT_HEIGHT)
+        );
+    }
+
+    #[test]
+    fn border_only_frames_keep_the_previous_recentring_shift() {
+        let mut latch = PresentationLatch::default();
+        let standard_shift = bitplane::standard_present_h_shift();
+        // Power-on default: the stock display's shift, so the first real
+        // screen does not jump against the blanks before it.
+        assert_eq!(
+            latch.presentation_h_shift(&blank_snapshot(), Overscan::Full),
+            standard_shift
+        );
+        assert_eq!(
+            latch.presentation_h_shift(&standard_snapshot(), Overscan::Full),
+            standard_shift
+        );
+        // A true overscan display presents unshifted, and its blanks keep
+        // that.
+        assert_eq!(
+            latch.presentation_h_shift(&overscan_snapshot(), Overscan::Full),
+            0
+        );
+        assert_eq!(
+            latch.presentation_h_shift(&blank_snapshot(), Overscan::Full),
+            0
+        );
+        // TV mode is a fixed aperture: never shifted, and not latched.
+        assert_eq!(
+            latch.presentation_h_shift(&standard_snapshot(), Overscan::Tv),
+            0
+        );
+        assert_eq!(
+            latch.presentation_h_shift(&blank_snapshot(), Overscan::Full),
+            0
+        );
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -615,6 +615,11 @@ pub struct App {
     /// 15 kHz scan with the standard horizontal window (None otherwise);
     /// applied by the present copy under `Overscan::Tv`.
     present_tv_aperture_rows: Option<usize>,
+    /// Aperture/recentring decisions latched across border-only frames:
+    /// the blank frames a screen change emits keep the previous
+    /// presentation geometry instead of snapping to the full framebuffer,
+    /// so the picture does not jump at every Kickstart mode change.
+    presentation_latch: PresentationLatch,
     /// Whether the presented frame came from a programmable (multisync) scan
     /// rather than a woven 15 kHz one. Those fields reach the presentation
     /// buffer at their native height, so neither the CRT pass nor its
@@ -1038,7 +1043,10 @@ struct RenderWorkerResult {
     presentation_fb: Vec<u32>,
     present_rows: usize,
     present_width: usize,
-    tv_aperture_rows: Option<usize>,
+    /// The frame's aperture classification; the App resolves it through
+    /// its `PresentationLatch` when the result lands, so border-only
+    /// frames keep the previous geometry.
+    tv_aperture: TvApertureFrame,
     programmable: bool,
     /// The job's frame snapshot, handed back for buffer reuse.
     input: bitplane::RenderInput,
@@ -1225,6 +1233,7 @@ impl App {
             rtg_fb: Vec::new(),
             rtg_present_dims: None,
             present_tv_aperture_rows: Some(TV_PAL_PRESENT_HEIGHT),
+            presentation_latch: PresentationLatch::default(),
             present_programmable: false,
             render: None,
             debugger_tool_window: None,
@@ -6616,7 +6625,10 @@ impl App {
     fn rerender_after_debug_view_change(&mut self) {
         let visible_start_vpos = self.emu.bus().frame_visible_start_vpos();
         let h_shift = if self.hcenter {
-            presentation_h_shift_for(&self.emu.bus().frame_render_base(), self.overscan)
+            // Re-resolving the same frame through the latch is idempotent:
+            // the same snapshot yields the same class and the same shift.
+            self.presentation_latch
+                .presentation_h_shift(&self.emu.bus().frame_render_base(), self.overscan)
         } else {
             0
         };
@@ -9032,6 +9044,7 @@ impl App {
         self.render_generation = self.render_generation.wrapping_add(1);
         self.last_rendered_emulated_frame = None;
         self.last_submitted_render_frame = None;
+        self.presentation_latch.reset();
         let _ = self.collect_threaded_render_results(false);
     }
 
@@ -9051,7 +9064,9 @@ impl App {
         self.render_recycle_fb = old;
         self.present_rows = result.present_rows;
         self.present_width = result.present_width;
-        self.present_tv_aperture_rows = result.tv_aperture_rows;
+        self.present_tv_aperture_rows = self
+            .presentation_latch
+            .resolve_tv_aperture(result.tv_aperture);
         self.present_programmable = result.programmable;
         self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(result.emulated_frame);
@@ -9101,7 +9116,8 @@ impl App {
             None => bitplane::RenderInput::from_bus(self.emu.bus()),
         };
         let h_shift = if self.hcenter {
-            presentation_h_shift_for(&input.render_base(), self.overscan)
+            self.presentation_latch
+                .presentation_h_shift(&input.render_base(), self.overscan)
         } else {
             0
         };
@@ -9216,7 +9232,8 @@ impl App {
 
         let visible_start_vpos = self.emu.bus().frame_visible_start_vpos();
         let h_shift = if self.hcenter {
-            presentation_h_shift_for(&self.emu.bus().frame_render_base(), self.overscan)
+            self.presentation_latch
+                .presentation_h_shift(&self.emu.bus().frame_render_base(), self.overscan)
         } else {
             0
         };
@@ -9246,7 +9263,12 @@ impl App {
         );
         self.refresh_present_from_deinterlacer();
         self.present_tv_aperture_rows =
-            standard_tv_aperture_rows(geometry, self.present_rows, &base);
+            self.presentation_latch
+                .resolve_tv_aperture(standard_tv_aperture_frame(
+                    geometry,
+                    self.present_rows,
+                    &base,
+                ));
         self.present_programmable = geometry.programmable;
         self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(emulated_frame);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -285,8 +285,15 @@ const JOY_TOGGLE_W: usize = 22;
 const JOY_TOGGLE_X: usize = VOLUME_GLYPH_X - 2 - JOY_TOGGLE_W;
 // The standard-window and TV-aperture constants live in
 // `video/present_common.rs` with the presentation helpers they anchor
-// (re-exported through `use present::*` below).
-const TV_LIVE_PAD_X: usize = (FB_WIDTH - TV_PRESENT_WIDTH) / 2;
+// (re-exported through `use present::*` below). The live window presents
+// the captured aperture -- every column a real framebuffer pixel, the
+// standard window and the visible raster both exactly centred -- unlike
+// the PNG paths, which keep the wider reference aperture with its
+// black-padded right margin for reference-emulator comparison.
+const TV_LIVE_PAD_X: usize = (FB_WIDTH - TV_CAPTURED_WIDTH) / 2;
+// Symmetric pads are what centres the raster; a change to the captured
+// aperture's width that breaks this must rethink the live layout.
+const _: () = assert!(TV_LIVE_PAD_X * 2 + TV_CAPTURED_WIDTH == FB_WIDTH);
 const STATUS_BG: u32 = rgba(28, 28, 26);
 const STATUS_TOP: u32 = rgba(78, 76, 70);
 const STATUS_BOTTOM: u32 = rgba(12, 12, 11);

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -468,6 +468,17 @@ pub(super) fn copy_window_present_frame(
     }
 }
 
+/// The live-window TV copy presents the captured aperture
+/// (`TV_CAPTURED_*`): the standard window plus the symmetric overscan
+/// margin the framebuffer actually captures, ending exactly on the
+/// framebuffer's edges. Every aperture column is a real pixel and the
+/// visible raster sits exactly centred in the texture -- the wider
+/// reference aperture the PNG paths keep would show its black-padded
+/// right margin as a lopsided band beside the picture (conspicuous
+/// inside the monitor bezel). The symmetric side pads are off-capture
+/// bezel and stay black rather than replicating the edge columns, which
+/// carry picture when a display fetches or parks sprites in the deepest
+/// overscan (the Gen-X logo slide-in streaks).
 pub(super) fn copy_tv_aperture_to_window(
     src_fb: &[u32],
     src_rows: usize,
@@ -483,12 +494,15 @@ pub(super) fn copy_tv_aperture_to_window(
     let dst_stride = texture_width(texture_scale) * 4;
     let present_rows = present_height();
     let out_rows = present_rows * texture_scale;
-    // The aperture reaches a few columns past the framebuffer's right edge;
-    // that uncaptured margin is bezel and must stay black rather than
-    // replicate the edge column (which carries picture when a display
-    // fetches into the deepest overscan).
     let black_px = rgba(0, 0, 0);
     let black = black_px.to_le_bytes();
+    let pixel_at = |row: &[u32], out_x: usize| -> u32 {
+        if (TV_LIVE_PAD_X..TV_LIVE_PAD_X + TV_CAPTURED_WIDTH).contains(&out_x) {
+            row[TV_CAPTURED_SOURCE_X + (out_x - TV_LIVE_PAD_X)]
+        } else {
+            black_px
+        }
+    };
     for y in 0..out_rows {
         let Some(crop_y) = tv_aperture_source_row(y, present_rows, texture_scale, aperture_rows)
         else {
@@ -505,25 +519,13 @@ pub(super) fn copy_tv_aperture_to_window(
             1 => {
                 let dst = &mut frame[dst_off..dst_off + dst_stride];
                 for x in 0..FB_WIDTH {
-                    let crop_x = x.saturating_sub(TV_LIVE_PAD_X).min(TV_PRESENT_WIDTH - 1);
-                    let src_x = TV_PRESENT_SOURCE_X + crop_x;
-                    let pixel = if src_x < FB_WIDTH {
-                        row[src_x]
-                    } else {
-                        black_px
-                    };
+                    let pixel = pixel_at(row, x);
                     dst[x * 4..x * 4 + 4].copy_from_slice(&pixel.to_le_bytes());
                 }
             }
             2 => {
                 for x in 0..FB_WIDTH {
-                    let crop_x = x.saturating_sub(TV_LIVE_PAD_X).min(TV_PRESENT_WIDTH - 1);
-                    let src_x = TV_PRESENT_SOURCE_X + crop_x;
-                    let pixel = if src_x < FB_WIDTH {
-                        row[src_x]
-                    } else {
-                        black_px
-                    };
+                    let pixel = pixel_at(row, x);
                     let pair = pixel as u64 | ((pixel as u64) << 32);
                     unsafe {
                         (frame.as_mut_ptr().add(dst_off + x * 8) as *mut u64).write_unaligned(pair);
@@ -533,16 +535,7 @@ pub(super) fn copy_tv_aperture_to_window(
             _ => {
                 let dst = &mut frame[dst_off..dst_off + dst_stride];
                 for x in 0..FB_WIDTH * texture_scale {
-                    let out_x = x / texture_scale;
-                    let crop_x = out_x
-                        .saturating_sub(TV_LIVE_PAD_X)
-                        .min(TV_PRESENT_WIDTH - 1);
-                    let src_x = TV_PRESENT_SOURCE_X + crop_x;
-                    let pixel = if src_x < FB_WIDTH {
-                        row[src_x]
-                    } else {
-                        black_px
-                    };
+                    let pixel = pixel_at(row, x / texture_scale);
                     dst[x * 4..x * 4 + 4].copy_from_slice(&pixel.to_le_bytes());
                 }
             }
@@ -554,7 +547,7 @@ pub(super) fn copy_tv_aperture_to_window(
 /// aperture crop, or None for rows that fall on the black bezel of the
 /// square-pixel presentation. The square canvas (570 rows) maps woven rows
 /// 1:1, so an aperture shorter than it is centred between black bands --
-/// the vertical counterpart of the TV_LIVE_PAD_X side bands. The 4:3
+/// the vertical counterpart of the black TV_LIVE_PAD_X side pads. The 4:3
 /// canvas (537 rows) is the glass itself, which both standards' apertures
 /// fill: all aperture rows rescale onto the whole output (540 onto 537 for
 /// a 50 Hz scan, 428 for a 60 Hz one).

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -66,7 +66,7 @@ pub(super) fn render_job_to_presentation(
         presentation_fb,
         present_rows,
         present_width,
-        tv_aperture_rows: standard_tv_aperture_rows(geometry, present_rows, &base),
+        tv_aperture: standard_tv_aperture_frame(geometry, present_rows, &base),
         programmable: geometry.programmable,
         input,
     }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -24,8 +24,8 @@ use super::{
     DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
     POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL, POWER_LED_OFF,
     STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-    TRACK_SEGMENT_ON, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT, TV_PRESENT_SOURCE_X,
-    TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
+    TRACK_SEGMENT_ON, TV_CAPTURED_SOURCE_X, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
+    TV_PRESENT_SOURCE_X, TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
@@ -2114,7 +2114,7 @@ fn tint_display_rows_leave_the_status_bar_alone() {
 }
 
 #[test]
-fn tv_window_copy_centres_reference_aperture_in_live_texture() {
+fn tv_window_copy_centres_captured_aperture_in_live_texture() {
     use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
     let scale = 1;
     let mut src = vec![0u32; OUT_PIXELS];
@@ -2126,7 +2126,7 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
     let left_edge = 0x99AA_BBCCu32;
     let right_edge = 0xDDEE_FF00u32;
 
-    src[row_y * FB_WIDTH + TV_PRESENT_SOURCE_X] = left_edge;
+    src[row_y * FB_WIDTH + TV_CAPTURED_SOURCE_X] = left_edge;
     src[row_y * FB_WIDTH + FB_WIDTH - 1] = right_edge;
     src[row_y * FB_WIDTH + standard_left] = left_marker;
     src[row_y * FB_WIDTH + standard_right] = right_marker;
@@ -2142,9 +2142,16 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
         Some(TV_PAL_PRESENT_HEIGHT),
     );
 
-    let dst_standard_left = TV_LIVE_PAD_X + (standard_left - TV_PRESENT_SOURCE_X);
+    // The standard window and the visible raster are both exactly centred:
+    // the captured aperture is symmetric around the standard window and
+    // ends on the framebuffer's edges, so the crop's first and last
+    // columns land mirror-imaged around the texture centre.
+    let dst_standard_left = TV_LIVE_PAD_X + (standard_left - TV_CAPTURED_SOURCE_X);
     let dst_standard_right = dst_standard_left + 320 * 2 - 1;
     assert_eq!(dst_standard_left, FB_WIDTH - 1 - dst_standard_right);
+    let dst_crop_left = TV_LIVE_PAD_X;
+    let dst_crop_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_CAPTURED_SOURCE_X);
+    assert_eq!(dst_crop_left, FB_WIDTH - 1 - dst_crop_right);
     assert_eq!(
         pixel(&frame, dst_standard_left, 0, scale),
         left_marker.to_le_bytes()
@@ -2153,28 +2160,32 @@ fn tv_window_copy_centres_reference_aperture_in_live_texture() {
         pixel(&frame, dst_standard_right, 0, scale),
         right_marker.to_le_bytes()
     );
-    assert_eq!(pixel(&frame, 0, 0, scale), left_edge.to_le_bytes());
-    let dst_fb_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PRESENT_SOURCE_X);
     assert_eq!(
-        pixel(&frame, dst_fb_right, 0, scale),
+        pixel(&frame, dst_crop_left, 0, scale),
+        left_edge.to_le_bytes()
+    );
+    assert_eq!(
+        pixel(&frame, dst_crop_right, 0, scale),
         right_edge.to_le_bytes()
     );
 }
 
 #[test]
-fn tv_window_copy_black_pads_aperture_past_framebuffer() {
+fn tv_window_copy_black_pads_never_replicate_edge_columns() {
     use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
-    // The aperture reaches a few columns past the framebuffer's right edge.
-    // A display fetching into the deepest right overscan fills the
-    // framebuffer's last column; the uncaptured aperture columns are bezel
-    // and must stay black instead of replicating that edge column into
-    // horizontal streaks (Gen-X logo slide-in).
+    // The pads beside the captured aperture are off-capture bezel. A
+    // display fetching or parking sprites in the deepest overscan fills
+    // the crop's edge columns; the pads must stay black instead of
+    // replicating those columns into horizontal streaks (Gen-X logo
+    // slide-in).
     let black = rgba(0, 0, 0).to_le_bytes();
     for scale in 1..=3 {
         let mut src = vec![0u32; OUT_PIXELS];
         let row_y = TV_PRESENT_SOURCE_Y;
-        let edge = 0xDDEE_FF00u32;
-        src[row_y * FB_WIDTH + FB_WIDTH - 1] = edge;
+        let left_edge = 0x99AA_BBCCu32;
+        let right_edge = 0xDDEE_FF00u32;
+        src[row_y * FB_WIDTH + TV_CAPTURED_SOURCE_X] = left_edge;
+        src[row_y * FB_WIDTH + FB_WIDTH - 1] = right_edge;
 
         let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
         copy_window_present_frame(
@@ -2187,17 +2198,30 @@ fn tv_window_copy_black_pads_aperture_past_framebuffer() {
             Some(TV_PAL_PRESENT_HEIGHT),
         );
 
-        let dst_fb_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_PRESENT_SOURCE_X);
+        let dst_crop_left = TV_LIVE_PAD_X;
+        let dst_crop_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_CAPTURED_SOURCE_X);
         assert_eq!(
-            pixel(&frame, dst_fb_right * scale, 0, scale),
-            edge.to_le_bytes(),
+            pixel(&frame, dst_crop_left * scale, 0, scale),
+            left_edge.to_le_bytes(),
+            "scale {scale}: crop's first column should stay visible"
+        );
+        assert_eq!(
+            pixel(&frame, dst_crop_right * scale, 0, scale),
+            right_edge.to_le_bytes(),
             "scale {scale}: framebuffer edge column should stay visible"
         );
-        for x in (dst_fb_right + 1) * scale..FB_WIDTH * scale {
+        for x in 0..dst_crop_left * scale {
             assert_eq!(
                 pixel(&frame, x, 0, scale),
                 black,
-                "scale {scale}: aperture past the framebuffer must be black at {x}"
+                "scale {scale}: left pad must be black at {x}"
+            );
+        }
+        for x in (dst_crop_right + 1) * scale..FB_WIDTH * scale {
+            assert_eq!(
+                pixel(&frame, x, 0, scale),
+                black,
+                "scale {scale}: right pad must be black at {x}"
             );
         }
     }
@@ -2212,7 +2236,7 @@ fn tv_window_copy_preserves_true_overscan_fetches() {
     let standard_crop_edge = 0x5566_7788u32;
 
     src[0] = left_overscan;
-    src[TV_PRESENT_SOURCE_X] = standard_crop_edge;
+    src[TV_CAPTURED_SOURCE_X] = standard_crop_edge;
 
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
     copy_window_present_frame(

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11,15 +11,15 @@ use super::{
     copy_window_present_frame, draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect,
     host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_toggle_rect, led_row_rect,
     mask_present_frame_to_tv, paint_test_screen, parse_amiga_key, pause_button_rect,
-    power_button_rect, present_height, presentation_h_shift_for, presentation_source_y_offset,
+    power_button_rect, present_height, presentation_source_y_offset,
     raw_device_qualifier_family_held, raw_device_qualifier_rawkey, rawkey_is_held,
     rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
     short_status_error, shorten_status_paths, shot_button_rect, should_render_emulated_frame,
     standard_window_top_row, status_with_latched_fdd_track, take_integral_mouse_delta,
     texture_height, texture_width, tint_display_rows, tint_lut, tint_rows_in_place,
     tv_aperture_source_row, tv_source_h_bounds, volume_percent_from_pos, volume_slider_track_rect,
-    BarControl, DriveBar, JoystickInputMode, MediaBar, StatusBarView, ToolPanelKind,
-    AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
+    BarControl, DriveBar, JoystickInputMode, MediaBar, PresentationLatch, StatusBarView,
+    ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
     AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON,
     DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
     POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL, POWER_LED_OFF,
@@ -2467,7 +2467,10 @@ fn tv_presentation_keeps_standard_hires_framebuffer_origin() {
         ..RenderRegisterSnapshot::default()
     };
 
-    assert_eq!(presentation_h_shift_for(&snapshot, Overscan::Tv), 0);
+    assert_eq!(
+        PresentationLatch::default().presentation_h_shift(&snapshot, Overscan::Tv),
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

With the 1084 bezel on, the picture's X position visibly jumped at screen mode changes (reported during a Kickstart 2.05 boot). The bezel was innocent: the TV-aperture crop and the full-overscan recentring shift are decided from each frame's register snapshot, and a **border-only frame** (no bitplane content intersecting the window: DIW/DDF cleared or BPLEN off) classified as "not standard" and presented on the full framebuffer. Screen changes emit exactly such frames for a beam or two while the copper list is rebuilt, so the presentation geometry flipped full <-> aperture and back at every mode change: the raster edges lurched sideways (right edge by 24 px, ~13 px centre shift), the row mapping breathed 537 <-> 540, and the CRT preset's scanline count flipped 285 <-> 270 with it. The bezel's fixed plastic frame just made it obvious.

A border-only frame carries no evidence about the display's horizontal layout, so it now keeps the previous frame's decisions - the monitor does not move between screens:

- `bitplane::horizontal_content_class` replaces `present_h_shift_for` + `uses_standard_horizontal_content` with one tri-state classifier (`Standard { shift }` / `Overscan` / `Neutral`); the Standard and Overscan judgements are unchanged, only the no-content case is new.
- `present_common::PresentationLatch` resolves both decisions per frame, latching the last non-neutral one. Power-on default is the stock display (aperture on, standard shift), matching the existing `present_tv_aperture_rows` initial value. Overscan fetches and programmable scans latch "full", so a demo that blanks between its parts stays on full-frame presentation throughout - no flip traded in.
- Threaded path: the render worker returns the per-frame classification and the App resolves it through the latch when the result lands; the recentring shift resolves at job-submit time (it is applied inside the worker). The latch resets with the render-generation bump (machine swap, reset, state load).
- The browser frontend had the identical canvas-shape flip and gets the same latch, reset on reset/load-state/overscan change.
- Docs: `docs/internals/video.md` (latch model), `docs/guide/configuration.md`, `docs/guide/browser.md`.

One behavioural note for captures: screenshots/dumps of border-only frames in TV mode now save at the aperture shape (692x540) like the screens around them, instead of 716x537.

## Test plan

- New unit tests: the classifier's Neutral cases (cleared registers, a window that opens only after the fetch ends) plus ports of the existing shift/content tests; latch regression tests for the boot sequence (blank -> standard stays cropped), the overscan-demo part change (overscan -> blank stays full), per-scan aperture heights through a neutral frame, TV mode never shifting or latching, and reset restoring the power-on default.
- Reproduced headlessly: a 750-frame Kickstart 2.05 boot dump previously flipped 716x537 -> 692x540 at the first content frame; after the fix all 750 frames share one geometry, and every content frame is **byte-identical** to before. The `COPPERLINE_OVERSCAN=full` variant is stable too (previously the right edge jumped 24 px at the blank -> content transition).
- `cargo test` (2081 passed), `cargo clippy`, `cargo fmt --check` clean; `probe_golden` 24/24 and `image_regression` 10/10 pass without re-blessing; the web crate builds for wasm32-unknown-unknown.

## Second commit: centre the live TV view on the captured aperture

Testing the latch fix under the bezel surfaced a pre-existing centring problem: the live window presented the 692-column *reference* aperture, whose right margin reaches 12 columns past the framebuffer's right edge (padded black) while the left pad replicated the crop's border-colour edge column -- so the visible raster ran edge-to-edge on the left but stopped 24 columns short on the right, reading as an off-centre picture inside the bezel's fixed frame.

The live window now presents the **captured** aperture (`TV_CAPTURED_*`, 668 columns, ending exactly on the framebuffer's edges) centred between symmetric black pads, as the browser front-end already does: every visible column is a real captured pixel, and the raster and the standard window are both dead centre. The pads stay black rather than replicating the crop's edge columns, which carry picture when a display fetches or parks sprites in the deepest overscan (the Gen-X logo slide-in streak regression, still covered by test). PNG screenshots and frame dumps keep the 692x540 reference aperture for reference-emulator comparison -- only the live window layout changes.
