### PR TITLE
Feature/floppybridge

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -24,3 +24,12 @@ does.
 Thank you to:
 
 - Lee Hobson
+
+## Bundled third-party code
+
+- **FloppyBridge**, by Rob Smith
+  ([RobSmithDev](https://amiga.robsmithdev.co.uk/winuae)), is what lets a
+  floppy bay drive a physical 3.5" drive over a DrawBridge, a Greaseweazle, or
+  a Supercard Pro. Its sources are vendored in `vendor/floppybridge` and
+  compiled into the emulator, under MPL-2.0 or GPL-2.0-or-later; see
+  `vendor/floppybridge/README.md` for the exact revision.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "bincode",
+ "cc",
  "copperline-m68k",
  "cpal",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,20 @@ publish = false
 # `copperline-bench` bin target exists.
 default-run = "copperline"
 
+[build-dependencies]
+# Compiles the vendored FloppyBridge sources; see build.rs.
+cc = "1"
+
 [features]
-default = ["midi", "frontend", "wasm-boards", "control", "ctl-bin", "net-nat"]
+default = [
+    "midi",
+    "frontend",
+    "wasm-boards",
+    "control",
+    "ctl-bin",
+    "net-nat",
+    "floppybridge",
+]
 display-plan-trace = []
 # Local investigation switches that deliberately alter timing or rendering.
 # Normal builds keep these environment-variable overrides inert so release
@@ -60,6 +72,13 @@ control = ["dep:serde_json"]
 net-nat = ["dep:smoltcp"]
 # The `copperline-ctl` command-line client for the control protocol.
 ctl-bin = ["dep:serde_json"]
+# Real floppy drives through Rob Smith's FloppyBridge (src/floppybridge/): a
+# DrawBridge, Greaseweazle, or Supercard Pro standing in for a disk image on any
+# drive. On, build.rs compiles the vendored bridge (vendor/floppybridge) into the
+# binary, so nothing has to be installed for a physical drive to work. Off, none
+# of it is built -- neither the C++ nor the Rust side -- which is what browser
+# builds (--no-default-features) want.
+floppybridge = []
 
 [dependencies]
 # Path-only dependency on the in-tree fork (crates/m68k). No version requirement

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,84 @@ fn main() {
     println!("cargo:rustc-env=COPPERLINE_DISPLAY_VERSION={display_version}");
 
     set_windows_main_thread_stack();
+    build_floppybridge();
+}
+
+/// Compile the vendored FloppyBridge into the emulator, so a build produces a
+/// binary that can drive a real floppy drive with nothing else to install.
+///
+/// Upstream ships this as a shared library to be loaded at run time. Copperline
+/// links it instead: a user should not have to fetch a second file to use a
+/// feature the build claims to have, and keeping the two in one binary removes
+/// a whole class of "which copy is it loading" problems. Updating upstream is a
+/// maintainer's job, and a wholesale copy -- see vendor/floppybridge/README.md.
+fn build_floppybridge() {
+    if std::env::var_os("CARGO_FEATURE_FLOPPYBRIDGE").is_none() {
+        return;
+    }
+    let dir = Path::new("vendor/floppybridge/src");
+    // Upstream's own source list, minus two files: `floppybridge_lib.cpp` is
+    // the client-side loader for the shared build, which linking directly
+    // replaces, and `ADFBridge.cpp` backs a bridge onto an ADF file, which is
+    // what Copperline's own image path already does. Amiberry compiles the
+    // same twelve.
+    const SOURCES: [&str; 12] = [
+        "ArduinoFloppyBridge.cpp",
+        "ArduinoInterface.cpp",
+        "CommonBridgeTemplate.cpp",
+        "FloppyBridge.cpp",
+        "GreaseWeazleBridge.cpp",
+        "GreaseWeazleInterface.cpp",
+        "RotationExtractor.cpp",
+        "SerialIO.cpp",
+        "SuperCardProBridge.cpp",
+        "SuperCardProInterface.cpp",
+        "ftdi.cpp",
+        "pll.cpp",
+    ];
+    println!("cargo:rerun-if-changed=vendor/floppybridge/src");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .std("c++17")
+        .include(dir)
+        // Excludes the WinUAE dialogs, their resource script, and the update
+        // check, none of which Copperline uses; see the vendor README.
+        .define("FLOPPYBRIDGE_NO_GUI", None)
+        .warnings(false);
+    if target_os == "windows" {
+        // `windows.h` defines `min` and `max` as macros unless told not to,
+        // which turns every `std::min(` in the sources into `std::(`. Upstream
+        // builds from a Visual Studio project that sets this; nothing here uses
+        // the macros.
+        build.define("NOMINMAX", None);
+    }
+    if target_env == "msvc" {
+        // The sources use the standard library's containers and threads, so
+        // they need real unwinding. MSVC does not enable it by default and
+        // warns that any exception would terminate instead.
+        build.flag("/EHsc");
+    }
+    for source in SOURCES {
+        build.file(dir.join(source));
+    }
+    build.compile("floppybridge");
+
+    // What the sources need beyond libc. Windows names its own through
+    // `#pragma comment(lib, ...)`, so MSVC picks those up without help.
+    if target_os != "windows" {
+        println!("cargo:rustc-link-lib=dylib=dl");
+    }
+    // The C++ runtime the bridge's threads and containers are built against.
+    match target_os.as_str() {
+        "macos" | "ios" => println!("cargo:rustc-link-lib=dylib=c++"),
+        "windows" => {}
+        _ => println!("cargo:rustc-link-lib=dylib=stdc++"),
+    }
 }
 
 /// Give the Windows binaries the same ~8 MiB main-thread stack that Linux and

--- a/build.rs
+++ b/build.rs
@@ -50,8 +50,7 @@ fn build_floppybridge() {
     // Upstream's own source list, minus two files: `floppybridge_lib.cpp` is
     // the client-side loader for the shared build, which linking directly
     // replaces, and `ADFBridge.cpp` backs a bridge onto an ADF file, which is
-    // what Copperline's own image path already does. Amiberry compiles the
-    // same twelve.
+    // what Copperline's own image path already does.
     const SOURCES: [&str; 12] = [
         "ArduinoFloppyBridge.cpp",
         "ArduinoInterface.cpp",

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -594,4 +594,4 @@ floppy_sounds_volume = 100
 #                                # wait for the index and is appreciably
 #                                # quicker; stalling blocks the emulated machine
 # bridge_smart_speed = false
-# bridge_auto_cache = false      # read ahead while the drive is idle
+# bridge_auto_cache = false      # cache disk data while the drive is idle

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -589,9 +589,9 @@ floppy_sounds_volume = 100
 # bridge_port = "/dev/ttyACM0"   # omit to auto-detect the interface
 # bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
 # bridge_density = "auto"        # auto/dd/hd
-# bridge_mode = "normal"         # normal/compatible/stalling, named as Amiberry
-#                                # names them. normal, the default, skips the
-#                                # wait for the index and is appreciably
-#                                # quicker; stalling blocks the emulated machine
+# bridge_mode = "normal"         # normal/compatible/stalling. normal, the
+#                                # default, skips the wait for the index and is
+#                                # appreciably quicker; stalling blocks the
+#                                # emulated machine until each track is ready
 # bridge_smart_speed = false
 # bridge_auto_cache = false      # cache disk data while the drive is idle

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -569,3 +569,29 @@ floppy_sounds_volume = 100
 # [floppy.df0]
 # path = "Workbench.adf"
 # write_protected = true
+#
+# A bay can drive a real 3.5" floppy drive instead, over a DrawBridge,
+# Greaseweazle, or Supercard Pro, reading and writing genuine Amiga disks.
+# Rob Smith's FloppyBridge is built into Copperline, so there is nothing to
+# install. A bay takes either a bridge or an image, never both: the disk in
+# the drive is its media.
+#
+# Writing to a real disk needs the disk's own tab open *and*
+# write_protected = false -- two independent things to get wrong before
+# anything is laid on physical media. The status bar's eject and swap do
+# nothing for a bridged bay, a machine with one is paced to wall-clock time
+# even headless, and such a run is not reproducible. See the "Real floppy
+# drives" chapter of the guide.
+#
+# [floppy.df0]
+# bridge = "greaseweazle"        # drawbridge/greaseweazle/supercardpro/off
+# write_protected = true
+# bridge_port = "/dev/ttyACM0"   # omit to auto-detect the interface
+# bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
+# bridge_density = "auto"        # auto/dd/hd
+# bridge_mode = "normal"         # normal/compatible/stalling, named as Amiberry
+#                                # names them. normal, the default, skips the
+#                                # wait for the index and is appreciably
+#                                # quicker; stalling blocks the emulated machine
+# bridge_smart_speed = false
+# bridge_auto_cache = false      # read ahead while the drive is idle

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -42,6 +42,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +83,7 @@ version = "0.13.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "cc",
  "copperline-m68k",
  "flate2",
  "hound",
@@ -149,6 +160,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -415,6 +432,12 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -177,6 +177,7 @@ authoritative list. The most useful ones:
 | `COPPERLINE_TRACE_BLITTER` | Path to a JSONL trace of blitter starts, forced finishes, DMACONR polls, and completion IRQ latches; start records include minterm/control registers, DMA/display context, FMODE, and all eight bitplane pointers |
 | `COPPERLINE_DIAG_POLLSTATS` | At every screenshot and frame dump, log the most-read CIA and custom registers -- what a stuck guest is busy-polling |
 | `COPPERLINE_DIAG_DISK` | Disk DMA state changes (DSKLEN writes) |
+| `COPPERLINE_DIAG_FLOPPYBRIDGE` | Everything a physical floppy drive does: every head move with the cylinder the drive reports being on, every track handed over (bit and word count, how long it took, how many attempts, and the cell timing derived from its length), the first wait on a track that is not ready yet with the drive's state, and every track written. The timing is the useful part -- a healthy DD track is one revolution, so around 200ms, and the bit count falling as the head moves outward is the disk's own data rate, not a fault |
 | `COPPERLINE_DIAG_AUDIO_NOTES` | Paula channel note on/off events |
 | `COPPERLINE_DIAG_CRASH` | CPU empty-RAM execution and low-memory blitter write context |
 | `COPPERLINE_DIAG_GAYLE` / `COPPERLINE_DIAG_CDTV` | Gayle IDE / CDTV controller traffic |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -47,6 +47,14 @@ range checks as the equivalent TOML fields:
 | `--accelerator SIZE` | `[memory] accelerator` | CPU-slot RAM at `$08000000` (32-bit CPUs): `0` to `128M` |
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
 | `--floppy-speed PERCENT` | `[floppy] speed` | `100` (real), `200`, `400`, `800`, or `0` (turbo) |
+| `--floppy-bridge DFN NAME` | `[floppy.dfN] bridge` | drive a physical floppy drive: `drawbridge`, `greaseweazle`, `supercardpro`, `off` |
+| `--floppy-bridge-port DFN PORT` | `[floppy.dfN] bridge_port` | that interface's serial port (default: auto-detect) |
+| `--floppy-bridge-cable DFN SEL` | `[floppy.dfN] bridge_cable` | drive select: `a`/`b` (PC cable) or `0`-`3` (Shugart) |
+| `--floppy-bridge-mode DFN MODE` | `[floppy.dfN] bridge_mode` | how tracks are captured: `normal`, `compatible`, `stalling` |
+| `--floppy-bridge-density DFN D` | `[floppy.dfN] bridge_density` | force a density: `auto`, `dd`, `hd` |
+| `--floppy-bridge-smart-speed DFN` | `[floppy.dfN] bridge_smart_speed = true` | let the interface slow the drive between accesses |
+| `--floppy-bridge-read-ahead DFN` | `[floppy.dfN] bridge_auto_cache = true` | read tracks ahead while the drive is idle |
+| `--floppy-bridge-writable DFN` | `[floppy.dfN] write_protected = false` | allow writing to the real disk |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 | `--mouse-sensitivity N` | `[input] mouse_sensitivity` | `0`-`100` host mouse speed (`50` default = 1:1) |
 | `--mouse-capture MODE` | `[input] mouse_capture` | When the host mouse is grabbed: `click` (default), `auto`, `manual` |
@@ -1051,6 +1059,34 @@ A `paths` playlist lets multi-disk software that only drives DF0: run
 without a second drive: the first entry is the boot disk and the disk-swap
 shortcut (`Cmd+D` on macOS, `Alt+D` on Linux/Windows) or the status-bar
 swap button cycles to the next image, wrapping around.
+
+### A real drive on a bay
+
+A bay can be given a physical 3.5" drive instead of an image, over a
+DrawBridge, Greaseweazle, or Supercard Pro:
+
+```toml
+[floppy.df0]
+bridge = "greaseweazle"      # drawbridge/greaseweazle/supercardpro/off
+write_protected = true       # emulator-level protection, on top of the tab
+# bridge_port = "/dev/ttyACM0"   # omit to auto-detect the interface
+# bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
+# bridge_density = "auto"        # auto/dd/hd
+# bridge_mode = "compatible"     # compatible/stalling
+# bridge_smart_speed = false     # driver-side variable-rate capture
+# bridge_auto_cache = false      # read tracks ahead while the drive is idle
+```
+
+A bay takes either a bridge or an image, never both: the disk in the drive
+is its media, and naming a `path` alongside is an error. `bridge = "off"`
+returns the bay to images and keeps the other bridge settings for later.
+
+Nothing needs installing -- Rob Smith's FloppyBridge is built into Copperline
+-- but it changes how the machine runs in several ways -- writes need both the disk's tab and
+`write_protected = false`, the status bar's eject and swap do nothing for
+that bay, and a machine with a physical drive is paced to wall-clock time and is
+not reproducible. [](floppybridge) covers the whole feature: installing the
+library on each platform, what each option does, and what to expect of it.
 
 ## `[ide]` -- IDE hard disks
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -53,7 +53,7 @@ range checks as the equivalent TOML fields:
 | `--floppy-bridge-mode DFN MODE` | `[floppy.dfN] bridge_mode` | how tracks are captured: `normal`, `compatible`, `stalling` |
 | `--floppy-bridge-density DFN D` | `[floppy.dfN] bridge_density` | force a density: `auto`, `dd`, `hd` |
 | `--floppy-bridge-smart-speed DFN` | `[floppy.dfN] bridge_smart_speed = true` | let the interface slow the drive between accesses |
-| `--floppy-bridge-read-ahead DFN` | `[floppy.dfN] bridge_auto_cache = true` | read tracks ahead while the drive is idle |
+| `--floppy-bridge-auto-cache DFN` | `[floppy.dfN] bridge_auto_cache = true` | cache disk data while the drive is idle |
 | `--floppy-bridge-writable DFN` | `[floppy.dfN] write_protected = false` | allow writing to the real disk |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 | `--mouse-sensitivity N` | `[input] mouse_sensitivity` | `0`-`100` host mouse speed (`50` default = 1:1) |

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -1,0 +1,304 @@
+# Physical floppy drives
+
+Copperline can give any of its four floppy bays a *physical* 3.5" drive instead
+of a disk image, reading and writing genuine Amiga floppies. The drive is
+attached to the host over one of three interfaces, and Rob Smith's
+[FloppyBridge](https://amiga.robsmithdev.co.uk/winuae) library does the
+talking:
+
+| Interface | What it is |
+|---|---|
+| DrawBridge | An Arduino-based reader/writer, by RobSmithDev |
+| Greaseweazle | Keir Fraser's flux reader/writer |
+| Supercard Pro | Jim Drew's flux board |
+
+The emulated machine is not changed by any of this. The bridge supplies the
+MFM the head would be passing over, so Paula, the disk DMA, and
+`trackdisk.device` behave exactly as they do with an ADF -- a real Workbench
+disk boots to the same screen, pixel for pixel, as an image of it.
+
+## What you need
+
+Nothing but the emulator. FloppyBridge is compiled into Copperline from
+`vendor/floppybridge`, so a build that offers a physical drive can actually
+drive one -- there is no library to fetch, install, or keep beside the binary.
+
+```sh
+cargo build --release
+```
+
+The `floppybridge` Cargo feature, on by default, is what includes it. Built
+without it (`--no-default-features`), none of this exists: no **Physical
+drive** tick box in the launcher, no `--floppy-bridge` flags, and a config
+file's `bridge` keys are read and ignored, so the same file stays valid across
+builds.
+
+Keeping upstream current is a maintainer's job, not a user's:
+`vendor/floppybridge/README.md` records the commit vendored and how to move to
+a newer one.
+
+On Linux, install the interface's own udev rules before plugging it in. They
+grant access without root and keep ModemManager from probing the device;
+Greaseweazle ships a `49-greaseweazle.rules` with its
+[host tools](https://github.com/keirf/greaseweazle/wiki/Software-Installation#linux),
+and DrawBridge and Supercard Pro have equivalents.
+
+```sh
+sudo cp 49-greaseweazle.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+```
+
+Failing that, the serial device is usually owned by a group rather than by you
+-- `dialout` on Debian and Ubuntu, `uucp` on Arch -- so an interface the
+launcher lists but refuses to open is nearly always a permissions problem
+rather than a hardware one:
+
+```sh
+sudo usermod -aG dialout "$USER"
+```
+
+## Turning a bay over to a physical drive
+
+From the launcher, the Floppy tab carries a **Physical drive** tick box for
+each bay. Tick it and the bay's media row stops offering a disk image and
+names the interface instead, with a **Configure** button leading to its
+settings. With nothing plugged in the row reads `None`; plug the interface in
+and re-tick the box to pick it up. The Configure page is headed with the
+library it found and its version, which is the quickest way to check which
+build is installed.
+
+From the config file, `bridge` on a bay does the same thing:
+
+```toml
+[floppy.df0]
+bridge = "greaseweazle"      # or "drawbridge", "supercardpro", "off"
+write_protected = true       # emulator-level protection; default true
+# bridge_port = "/dev/ttyACM0"   # omit to auto-detect the interface
+# bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
+# bridge_density = "auto"        # auto/dd/hd
+# bridge_mode = "normal"         # normal/compatible/stalling
+# bridge_smart_speed = false
+# bridge_auto_cache = false
+```
+
+A bay cannot have both a bridge and an image -- the disk in the drive is its
+media -- and saying so is an error rather than a silent preference. Setting
+`bridge = "off"` returns the bay to images while leaving the rest of its
+bridge settings in place.
+
+And from the command line, with no config file at all:
+
+```sh
+copperline --model A500 --floppy-bridge df0 greaseweazle kickstart.rom
+```
+
+| Flag | Config key |
+|---|---|
+| `--floppy-bridge DFN NAME` | `bridge` |
+| `--floppy-bridge-port DFN PORT` | `bridge_port` |
+| `--floppy-bridge-cable DFN SEL` | `bridge_cable` |
+| `--floppy-bridge-mode DFN MODE` | `bridge_mode` |
+| `--floppy-bridge-density DFN D` | `bridge_density` |
+| `--floppy-bridge-smart-speed DFN` | `bridge_smart_speed = true` |
+| `--floppy-bridge-read-ahead DFN` | `bridge_auto_cache = true` |
+| `--floppy-bridge-writable DFN` | `write_protected = false` |
+
+These layer on top of a config file as every other flag does, so
+`--floppy-bridge df0 greaseweazle` turns DF0 over to a physical drive even if
+the file gives it an image -- the flag says the bay *is* a physical drive, so the
+image it displaces is not a conflict. There is deliberately no flag for
+protecting a drive, because that is already the default. The remaining
+options -- density, read mode, smart speed, read ahead, and profiles -- are
+config-file only; they describe a rig rather than a run.
+
+If a bay asks for a physical drive and it cannot be opened, Copperline
+stops with the reason rather than booting a machine with an empty drive
+where you asked for your disk.
+
+### Serial port
+
+Every current interface connects over a serial port, and every one of them
+can be found automatically, which is the default. Name `bridge_port`
+explicitly to pin a particular device when more than one is attached. The
+names are the host's own: `/dev/cu.usbmodem101` on macOS, `/dev/ttyACM0` or
+`/dev/ttyUSB0` on Linux, `COM3` on Windows. The launcher offers the ports the
+library reports.
+
+### Drive select
+
+`bridge_cable` picks which drive on the ribbon the interface selects: `a` or
+`b` for the IBM PC cable convention, `0` to `3` for Shugart. It only applies
+to interfaces that have a drive-select line -- a Greaseweazle does, a
+DrawBridge does not -- and the launcher greys the row for those that do not,
+as reported by the driver itself.
+
+### Read mode
+
+The three modes are named and ordered as Amiberry's drive-type list has
+them, so a setting means the same thing in either emulator. Upstream's own
+enum calls `normal` "Fast"; that spelling is accepted in the config file too.
+
+`normal`, the default, captures wherever the head happens to be, saving the
+wait for the index -- most of a revolution on every track it has not read
+before.
+
+A revolution captured that way does not meet its own tail in the gap between
+two sectors: its two ends are a revolution apart in time, so turning it under
+the head a second time would splice mid-sector and the guest would see a read
+error it could never retry its way out of. So it is good for exactly one pass.
+Once the head has been all the way round, Copperline retires that recording
+and takes the one after it, which is where the head itself would have carried
+on. Successive revolutions are then successive passes of the real head, and
+every join between them is real data.
+
+Booting Workbench 1.3 off a Greaseweazle, that takes the time spent waiting on
+the drive from around 25 seconds to around 14.
+
+`compatible` captures each track from the index pulse, so a revolution
+begins where the real one does and its two ends meet in the sector gap,
+exactly as a captured image's do. Slower, for the reason above; reach for it
+if a disk reads badly without the index to anchor it.
+
+`stalling` also captures from the index, but the driver holds the caller up
+until a track is ready instead of answering "not yet". The wait lands on the
+emulated machine, which stops -- pointer and all -- for as long as it takes.
+
+Amiberry's `turbo` is refused by name and is absent from the launcher's
+list. It is not a read mode at all -- it answers AmigaDOS calls instead of
+reading the disk, which is no use to an emulator that models the drive.
+
+### Read ahead and smart speed
+
+`bridge_auto_cache` reads tracks ahead in the background while the drive is
+idle. It is off by default, as it is upstream and in Amiberry: during a boot
+the drive is never idle, so it buys very little (measurably nothing on a
+Workbench 1.3 boot), and it moves the real head about on its own.
+
+`bridge_smart_speed` lets the driver track a disk whose data rate wanders
+within a track. It changes how the driver captures but not what Copperline
+does with the result: cell timing is derived from the length of the
+revolution handed back, so the per-cell speed it makes available goes unused.
+
+## Write protection
+
+A real disk is protected twice over, and both have to be open before anything
+is written to physical media:
+
+- the disk's own write-protect tab, sensed from the drive; and
+- `write_protected` in the config, which defaults to `true` exactly as it
+  does for an image.
+
+So writing to a real floppy takes a deliberate `write_protected = false`
+*and* an open tab. Both are enforced where the write would reach the platter,
+not merely reported to the guest through the drive's /WPRO line, so a program
+that writes without asking is stopped as well -- and they are the same two
+facts the /WPRO line is built from, rather than a second reading taken at the
+write, which could disagree with what the guest was told.
+
+The driver keeps the tab's last reading and hands it back whatever the motor
+is doing, so the state is good with the platter stopped -- which matters,
+because a drive the guest is not actively reading is stopped nearly all the
+time. With no disk in the drive there is no tab to have an opinion, so only
+the configured protection applies.
+
+In the launcher the same **Write protect** box covers a bay whether it holds
+an image or a physical drive, and it starts ticked.
+
+## What behaves differently
+
+**The disk is not yours to swap from the emulator.** The status bar keeps a
+bridged drive's numbered icon, so you can see the drive is there, but its
+eject and swap buttons do nothing: the disk is in a real drive across the
+room. Swapping it by hand is noticed -- the change line is raised as it would
+be on real hardware -- and the guest re-reads.
+
+**No synthesized drive sounds.** The real drive makes its own noise, so
+Copperline does not add stepper clicks or motor hum on top for that bay. A
+bay in the same machine running an ADF still sounds as it should.
+
+**Powering off releases the drive.** A real drive takes its power from the
+machine, and a bridged one behaves the same way: the power button hands the
+interface back to the host, so it stops turning and another program -- or the
+next machine this window builds -- can have it. Powering back on takes it
+again. If it cannot be reopened, the machine still comes up, with that bay
+empty, and the log says why.
+
+**A bridged machine runs at real time.** The platter turns in wall-clock time
+and cannot be hurried, so a machine with a real drive is paced like an Amiga
+even in a headless run that would otherwise be unthrottled. Left to run free,
+the emulated machine outruns the drive badly enough to spin the motor up and
+down faster than it can reach speed, and the guest sees a drive that answers
+almost nothing.
+
+**A bridged run is not reproducible.** Save states cannot capture the medium,
+and a replayed input recording will not line up. The emulated core is as
+deterministic as ever; it is the disk under it that is not.
+
+## Speed
+
+Reading a track means waiting for the drive to capture a whole revolution,
+which takes as long as a revolution takes -- about 200 ms. A track already in
+hand is served from Copperline's own copy with no drive involvement at all,
+so software that re-reads a track it just read pays nothing.
+
+Booting Workbench 1.3 from a real disk reads about 3.6 tracks a second
+against a physical ceiling of five, and reaches the CLI prompt in the same
+45 seconds the ADF takes. The head follows the emulated stepper, so the
+driver starts capturing while the guest is still settling, and nothing waits
+on the drive with the machine held still: the pointer keeps moving while a
+disk loads, as it does on a real Amiga.
+
+## Troubleshooting
+
+**Nothing is detected, and the drive is definitely there.** On Linux, check
+the serial device's group first (above) -- that is the usual answer. Then
+confirm the interface is one of the three supported, and that no other program
+is holding it open. Starting with `--floppy-bridge df0 greaseweazle` reports
+what it found and refuses to run if it found nothing, which is the quickest
+check.
+
+**"the installed FloppyBridge has no *X* driver"** -- the vendored bridge is
+older than the interface you asked for; a maintainer needs to update it.
+
+**The launcher shows `None` with the interface plugged in** -- the check runs
+when the launcher opens and when a bay is switched over, so untick and re-tick
+**Physical drive** after plugging in.
+
+**What it says at startup.** A bridged bay reports what it took hold of, on
+the same footing as an image being inserted:
+
+```text
+floppy.df0 real drive attached: Greaseweazle on /dev/ttyACM0, 3.5" DD drive, FloppyDriveBridge v1.6
+floppy.df0 disk in the real drive
+floppy.df0 write-protected by the configuration; set write_protected = false to write to the disk
+```
+
+Putting a disk in or taking one out is reported as it happens, as is the
+protection changing and the drive being let go on power off. Nothing here
+needs a debug build or a log filter.
+
+**Reads fail or the guest reports errors** -- check the disk's tab, then that
+`bridge_cable` matches the drive's jumper. Then set
+`COPPERLINE_DIAG_FLOPPYBRIDGE=1`, which turns on the drive's own running
+commentary: every head move, every track handed over with how long it took and
+how many attempts it cost, and the drive's state whenever a track is not ready.
+
+```text
+floppybridge.df0 head to cylinder 40 side 0 (drive at 39)
+floppybridge.df0 waiting for track 80 (cyl 40 side 0) [ready=false disk=true motor=true at_cyl=40]
+floppybridge.df0 track 80 (cyl 40 side 0) read: 99933 bits, 6246 words, 622ms over 137 attempts, 113 cck/word
+```
+
+A healthy track is one revolution, so around 200ms plus whatever the seek
+cost. Far longer, or attempts climbing without a track ever arriving, points
+at the drive or the disk rather than at Copperline. The bit count dropping as
+the head moves outward (101358 at cylinder 0 against 99933 at cylinder 40 in
+the trace above) is the disk's own data rate and is not a fault.
+
+**The interface works once, then needs unplugging.** Check whether its own
+tools can still reach it -- `gw info` for a Greaseweazle. If they cannot
+either, the fault is in the host's USB stack rather than in the emulator.
+
+**The drive stops responding mid-session** -- an interface pulled out stops
+answering, and Copperline says so once in the log. Reconnect it and restart
+the machine.

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -100,7 +100,7 @@ copperline --model A500 --floppy-bridge df0 greaseweazle kickstart.rom
 | `--floppy-bridge-mode DFN MODE` | `bridge_mode` |
 | `--floppy-bridge-density DFN D` | `bridge_density` |
 | `--floppy-bridge-smart-speed DFN` | `bridge_smart_speed = true` |
-| `--floppy-bridge-read-ahead DFN` | `bridge_auto_cache = true` |
+| `--floppy-bridge-auto-cache DFN` | `bridge_auto_cache = true` |
 | `--floppy-bridge-writable DFN` | `write_protected = false` |
 
 These layer on top of a config file as every other flag does, so
@@ -108,7 +108,7 @@ These layer on top of a config file as every other flag does, so
 the file gives it an image -- the flag says the bay *is* a physical drive, so the
 image it displaces is not a conflict. There is deliberately no flag for
 protecting a drive, because that is already the default. The remaining
-options -- density, read mode, smart speed, read ahead, and profiles -- are
+options -- density, read mode, smart speed, auto-cache, and profiles -- are
 config-file only; they describe a rig rather than a run.
 
 If a bay asks for a physical drive and it cannot be opened, Copperline
@@ -175,10 +175,10 @@ Amiberry's `turbo` is refused by name and is absent from the launcher's
 list. It is not a read mode at all -- it answers AmigaDOS calls instead of
 reading the disk, which is no use to an emulator that models the drive.
 
-### Read ahead and smart speed
+### Auto-cache and smart speed
 
-`bridge_auto_cache` reads tracks ahead in the background while the drive is
-idle. It is off by default, as it is upstream and in Amiberry: during a boot
+`bridge_auto_cache` caches disk data in the background while the drive is
+idle -- Amiberry calls the same setting "Auto-Cache". It is off by default, as it is upstream and in Amiberry: during a boot
 the drive is never idle, so it buys very little (measurably nothing on a
 Workbench 1.3 boot), and it moves the real head about on its own.
 

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -134,9 +134,8 @@ as reported by the driver itself.
 
 ### Read mode
 
-The three modes are named and ordered as Amiberry's drive-type list has
-them, so a setting means the same thing in either emulator. Upstream's own
-enum calls `normal` "Fast"; that spelling is accepted in the config file too.
+The driver's own enum calls `normal` "Fast"; that spelling is accepted in the
+config file too.
 
 `normal`, the default, captures wherever the head happens to be, saving the
 wait for the index -- most of a revolution on every track it has not read
@@ -171,22 +170,22 @@ if a disk reads badly without the index to anchor it.
 until a track is ready instead of answering "not yet". The wait lands on the
 emulated machine, which stops -- pointer and all -- for as long as it takes.
 
-Amiberry's `turbo` is refused by name and is absent from the launcher's
-list. It is not a read mode at all -- it answers AmigaDOS calls instead of
-reading the disk, which is no use to an emulator that models the drive.
+The driver's fourth mode, `turbo`, is refused by name and is absent from the
+launcher's list. It is not a read mode at all -- it answers AmigaDOS calls
+instead of reading the disk, which is no use to an emulator that models the
+drive.
 
 ### Auto-cache and smart speed
 
 `bridge_auto_cache` caches disk data in the background while the drive is
-idle -- Amiberry calls the same setting "Auto-Cache". It is off by default, as it is upstream and in Amiberry: during a boot
-the drive is never idle, so it buys very little (measurably nothing on a
-Workbench 1.3 boot), and it moves the real head about on its own.
+idle. It is off by default, as it is in the driver: during a boot the drive is
+never idle, so there is little for it to do, and it moves the real head about
+on its own.
 
 `bridge_smart_speed` lets the driver time each track and, where the data rate
 is uniform -- so nothing is leaning on the timing for copy protection -- offer
-it at a higher speed. Amiberry calls the same setting "dynamically switch on
-Turbo". It changes how the driver captures but not what Copperline
-does with the result: cell timing is derived from the length of the
+it at a higher speed. It changes how the driver captures but not what
+Copperline does with the result: cell timing is derived from the length of the
 revolution handed back, so the per-cell speed it makes available goes unused.
 
 ## Write protection

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -154,6 +154,14 @@ every join between them is real data.
 Booting Workbench 1.3 off a Greaseweazle, that takes the time spent waiting on
 the drive from around 25 seconds to around 14.
 
+The drive cannot always finish a capture in the revolution the guest takes to
+read the last one. When it has nothing newer, the recording just read is used
+again, and the guest meets a splice at the join: the sector straddling it fails
+and is retried, costing a revolution. Ten good sectors out of eleven beat none,
+which is what refusing the stale recording gives -- the guest is handed filler
+and starves. If a disk reads badly this way, `compatible` is the mode with no
+seam to begin with.
+
 `compatible` captures each track from the index pulse, so a revolution
 begins where the real one does and its two ends meet in the sector gap,
 exactly as a captured image's do. Slower, for the reason above; reach for it
@@ -174,8 +182,10 @@ idle. It is off by default, as it is upstream and in Amiberry: during a boot
 the drive is never idle, so it buys very little (measurably nothing on a
 Workbench 1.3 boot), and it moves the real head about on its own.
 
-`bridge_smart_speed` lets the driver track a disk whose data rate wanders
-within a track. It changes how the driver captures but not what Copperline
+`bridge_smart_speed` lets the driver time each track and, where the data rate
+is uniform -- so nothing is leaning on the timing for copy protection -- offer
+it at a higher speed. Amiberry calls the same setting "dynamically switch on
+Turbo". It changes how the driver captures but not what Copperline
 does with the result: cell timing is derived from the length of the
 revolution handed back, so the per-cell speed it makes available goes unused.
 
@@ -203,6 +213,24 @@ the configured protection applies.
 
 In the launcher the same **Write protect** box covers a bay whether it holds
 an image or a physical drive, and it starts ticked.
+
+### What cannot be written
+
+Two writes are refused rather than attempted, and both say so in the log.
+
+A **partial write that does not start at the index** cannot be placed. The
+interface takes a whole track and one bit of positional information: start at
+the index pulse, or start wherever the head happens to be. There is no way to
+say "start 3,000 bits in", so a partial write asking for that would land on
+whichever sector was passing at the time. AmigaDOS writes all eleven sectors
+at once, which is a whole revolution and lands correctly wherever it begins,
+so this refusal should never be seen in ordinary use.
+
+A **drive select the interface does not support** fails the open instead of
+being ignored. Every interface advertises the cable conventions it can drive
+-- a Supercard Pro offers only the IBM PC `a`/`b` pair, for instance -- and a
+rejected selection would otherwise leave it quietly on Drive A, reading and
+writing a different physical drive than the one asked for.
 
 ## What behaves differently
 
@@ -257,7 +285,7 @@ is holding it open. Starting with `--floppy-bridge df0 greaseweazle` reports
 what it found and refuses to run if it found nothing, which is the quickest
 check.
 
-**"the installed FloppyBridge has no *X* driver"** -- the vendored bridge is
+**"the built-in FloppyBridge has no *X* driver"** -- the vendored bridge is
 older than the interface you asked for; a maintainer needs to update it.
 
 **The launcher shows `None` with the interface plugged in** -- the check runs
@@ -268,7 +296,7 @@ when the launcher opens and when a bay is switched over, so untick and re-tick
 the same footing as an image being inserted:
 
 ```text
-floppy.df0 real drive attached: Greaseweazle on /dev/ttyACM0, 3.5" DD drive, FloppyDriveBridge v1.6
+floppy.df0 physical drive attached: Greaseweazle on /dev/ttyACM0, 3.5" DD drive, FloppyDriveBridge v1.6
 floppy.df0 disk in the real drive
 floppy.df0 write-protected by the configuration; set write_protected = false to write to the disk
 ```

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -1,10 +1,9 @@
 # Physical floppy drives
 
 Copperline can give any of its four floppy bays a *physical* 3.5" drive instead
-of a disk image, reading and writing genuine Amiga floppies. The drive is
-attached to the host over one of three interfaces, and Rob Smith's
-[FloppyBridge](https://amiga.robsmithdev.co.uk/winuae) library does the
-talking:
+of a disk image. The drive is attached to the host over one of three interfaces, 
+and Rob Smith's [FloppyBridge](https://amiga.robsmithdev.co.uk/winuae) library 
+does the talking:
 
 | Interface | What it is |
 |---|---|
@@ -14,13 +13,13 @@ talking:
 
 The emulated machine is not changed by any of this. The bridge supplies the
 MFM the head would be passing over, so Paula, the disk DMA, and
-`trackdisk.device` behave exactly as they do with an ADF -- a real Workbench
-disk boots to the same screen, pixel for pixel, as an image of it.
+`trackdisk.device` behave exactly as they do with an ADF.
 
 ## What you need
 
-Nothing but the emulator. FloppyBridge is compiled into Copperline from
-`vendor/floppybridge`, so a build that offers a physical drive can actually
+You need a [DrawBridge](https://amiga.robsmithdev.co.uk/drawbridge), [Greaseweazle](https://github.com/keirf/Greaseweazle), or [Supercard Pro](https://github.com/jimdrew/SupercardPro) interface, a 3.5" floppy drive, and some disks. 
+
+FloppyBridge is compiled into Copperline from `vendor/floppybridge`, so a build that offers a physical drive can actually
 drive one -- there is no library to fetch, install, or keep beside the binary.
 
 ```sh
@@ -30,44 +29,21 @@ cargo build --release
 The `floppybridge` Cargo feature, on by default, is what includes it. Built
 without it (`--no-default-features`), none of this exists: no **Physical
 drive** tick box in the launcher, no `--floppy-bridge` flags, and a config
-file's `bridge` keys are read and ignored, so the same file stays valid across
-builds.
+file's `bridge` keys are read and ignored.
 
-Keeping upstream current is a maintainer's job, not a user's:
 `vendor/floppybridge/README.md` records the commit vendored and how to move to
 a newer one.
 
-On Linux, install the interface's own udev rules before plugging it in. They
-grant access without root and keep ModemManager from probing the device;
-Greaseweazle ships a `49-greaseweazle.rules` with its
-[host tools](https://github.com/keirf/greaseweazle/wiki/Software-Installation#linux),
-and DrawBridge and Supercard Pro have equivalents.
 
-```sh
-sudo cp 49-greaseweazle.rules /etc/udev/rules.d/
-sudo udevadm control --reload-rules
-```
-
-Failing that, the serial device is usually owned by a group rather than by you
--- `dialout` on Debian and Ubuntu, `uucp` on Arch -- so an interface the
-launcher lists but refuses to open is nearly always a permissions problem
-rather than a hardware one:
-
-```sh
-sudo usermod -aG dialout "$USER"
-```
-
-## Turning a bay over to a physical drive
+## Using a physical drive
 
 From the launcher, the Floppy tab carries a **Physical drive** tick box for
 each bay. Tick it and the bay's media row stops offering a disk image and
 names the interface instead, with a **Configure** button leading to its
 settings. With nothing plugged in the row reads `None`; plug the interface in
-and re-tick the box to pick it up. The Configure page is headed with the
-library it found and its version, which is the quickest way to check which
-build is installed.
+and re-tick the box to pick it up.
 
-From the config file, `bridge` on a bay does the same thing:
+You can also define this in your .TOML file;
 
 ```toml
 [floppy.df0]
@@ -119,10 +95,8 @@ where you asked for your disk.
 
 Every current interface connects over a serial port, and every one of them
 can be found automatically, which is the default. Name `bridge_port`
-explicitly to pin a particular device when more than one is attached. The
-names are the host's own: `/dev/cu.usbmodem101` on macOS, `/dev/ttyACM0` or
-`/dev/ttyUSB0` on Linux, `COM3` on Windows. The launcher offers the ports the
-library reports.
+explicitly to pin a particular device when more than one is attached.The 
+launcher offers the ports the library enumerates.
 
 ### Drive select
 
@@ -141,18 +115,6 @@ config file too.
 wait for the index -- most of a revolution on every track it has not read
 before.
 
-A revolution captured that way does not meet its own tail in the gap between
-two sectors: its two ends are a revolution apart in time, so turning it under
-the head a second time would splice mid-sector and the guest would see a read
-error it could never retry its way out of. So it is good for exactly one pass.
-Once the head has been all the way round, Copperline retires that recording
-and takes the one after it, which is where the head itself would have carried
-on. Successive revolutions are then successive passes of the real head, and
-every join between them is real data.
-
-Booting Workbench 1.3 off a Greaseweazle, that takes the time spent waiting on
-the drive from around 25 seconds to around 14.
-
 The drive cannot always finish a capture in the revolution the guest takes to
 read the last one. When it has nothing newer, the recording just read is used
 again, and the guest meets a splice at the join: the sector straddling it fails
@@ -170,17 +132,11 @@ if a disk reads badly without the index to anchor it.
 until a track is ready instead of answering "not yet". The wait lands on the
 emulated machine, which stops -- pointer and all -- for as long as it takes.
 
-The driver's fourth mode, `turbo`, is refused by name and is absent from the
-launcher's list. It is not a read mode at all -- it answers AmigaDOS calls
-instead of reading the disk, which is no use to an emulator that models the
-drive.
-
 ### Auto-cache and smart speed
 
 `bridge_auto_cache` caches disk data in the background while the drive is
-idle. It is off by default, as it is in the driver: during a boot the drive is
-never idle, so there is little for it to do, and it moves the real head about
-on its own.
+idle. It is off by default: during a boot the drive is never idle, so there 
+is little for it to do, and it moves the real head about on its own.
 
 `bridge_smart_speed` lets the driver time each track and, where the data rate
 is uniform -- so nothing is leaning on the timing for copy protection -- offer
@@ -233,15 +189,12 @@ writing a different physical drive than the one asked for.
 
 ## What behaves differently
 
-**The disk is not yours to swap from the emulator.** The status bar keeps a
+**The disk eject button is disabled for a bridged drive.** The status bar keeps a
 bridged drive's numbered icon, so you can see the drive is there, but its
-eject and swap buttons do nothing: the disk is in a real drive across the
-room. Swapping it by hand is noticed -- the change line is raised as it would
-be on real hardware -- and the guest re-reads.
+eject and swap buttons do nothing: Eject/insert disks as you would with an Amiga!
 
-**No synthesized drive sounds.** The real drive makes its own noise, so
-Copperline does not add stepper clicks or motor hum on top for that bay. A
-bay in the same machine running an ADF still sounds as it should.
+**No synthesized drive sounds.** The real drive makes its own noise. A bay in the 
+same machine running an ADF still sounds as it should when enabled.
 
 **Powering off releases the drive.** A real drive takes its power from the
 machine, and a bridged one behaves the same way: the power button hands the

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -17,7 +17,7 @@ MFM the head would be passing over, so Paula, the disk DMA, and
 
 ## What you need
 
-You need a [DrawBridge](https://amiga.robsmithdev.co.uk/drawbridge), [Greaseweazle](https://github.com/keirf/Greaseweazle), or [Supercard Pro](https://github.com/jimdrew/SupercardPro) interface, a 3.5" floppy drive, and some disks. 
+You need a [DrawBridge](https://amiga.robsmithdev.co.uk), [Greaseweazle](https://github.com/keirf/Greaseweazle), or [Supercard Pro](https://www.cbmstuff.com/index.php?route=product/product&product_id=52) interface, a 3.5" floppy drive, and some disks. 
 
 FloppyBridge is compiled into Copperline from `vendor/floppybridge`, so a build that offers a physical drive can actually
 drive one -- there is no library to fetch, install, or keep beside the binary.

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -10,6 +10,10 @@ connect to the host's display server at all, so they work in environments
 without one: SSH sessions, CI runners, and sandboxes that block
 window-server access.
 
+The one exception to both is a machine with a physical floppy drive attached
+(see [](floppybridge)): its platter turns in wall-clock time, so such a run
+is paced to real time rather than unthrottled, and it is not reproducible.
+
 ## Screenshots
 
 ```sh

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -311,7 +311,7 @@ The layout is:
   floppy drive: its media row then names the interface -- or `None` with nothing
   plugged in -- and a **Configure** button opens that drive's own page,
   headed with the installed library and its version, for the serial port,
-  drive select, density, read mode, smart speed and read ahead, greying
+  drive select, density, read mode, smart speed and auto-cache, greying
   whatever the chosen interface does not honour. See [](floppybridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a row of buttons at the top

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -72,7 +72,10 @@ menu item):
   several images to queue a swap playlist for that drive -- plus a swap
   button that cycles to the next queued disk and an eject button. Swap and
   eject grey out when there is nothing to swap to or eject. With three or
-  four drives the clusters stack two-up.
+  four drives the clusters stack two-up. A bay driving a physical floppy drive
+  keeps its numbered disk button, so you can see the drive is there, but
+  loading, swapping and ejecting do nothing for it -- the disk is in a real
+  drive, and changing it is done by hand (see [](floppybridge)).
 - **CD controls** on machines with a CD drive (CDTV, CD32, or a SCSI
   CD-ROM unit): a CD button that loads (or swaps) a CD image
   (`.cue`/`.iso`) with the proper media-change notification, and a CD
@@ -303,7 +306,13 @@ The layout is:
   (Kickstart and
   extended ROM), *Floppy* (drive count and speed, then each wired drive as a
   greyed **DFn:** heading with its indented disk image and write-protect;
-  drives that are not enabled are hidden rather than greyed),
+  drives that are not enabled are hidden rather than greyed. Each drive also
+  carries a **Physical drive** tick box that hands the bay to a physical
+  floppy drive: its media row then names the interface -- or `None` with nothing
+  plugged in -- and a **Configure** button opens that drive's own page,
+  headed with the installed library and its version, for the serial port,
+  drive select, density, read mode, smart speed and read ahead, greying
+  whatever the chosen interface does not honour. See [](floppybridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a row of buttons at the top
   links to three sub-pages: **CD** (image, insert delay, CD32 NVRAM); **Host

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,8 @@ running in Copperline.
   serial/MIDI, and CD options.
 - [](guide/ui) -- the window, status bar, keyboard shortcuts, menus, and
   gamepad calibration.
+- [](guide/floppybridge) -- reading and writing real Amiga floppies in a
+  physical drive, over a DrawBridge, Greaseweazle, or Supercard Pro.
 - [](guide/headless) -- scripted, deterministic runs: screenshots, frame
   dumps, scripted input, and WAV capture.
 - [](guide/browser) -- the same core compiled to WebAssembly, hosted at

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -30,6 +30,7 @@ project:
         - file: guide/getting-started.md
         - file: guide/configuration.md
         - file: guide/ui.md
+        - file: guide/floppybridge.md
         - file: guide/headless.md
         - file: guide/browser.md
     - title: Extending
@@ -64,6 +65,7 @@ project:
         - guide/getting-started.md
         - guide/configuration.md
         - guide/ui.md
+        - guide/floppybridge.md
         - guide/headless.md
         - guide/browser.md
         - zorro.md

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5209,14 +5209,19 @@ impl Bus {
         // it at vpos 0). The ~70 cck that real hardware adds before the handler
         // runs is interrupt RECOGNITION LATENCY, modelled separately (see
         // irq_latency_setting / arm_irq_recognition_latency), not a raise delay.
+        // Once a frame, ask any real drive whether its disk has been swapped or
+        // its write-protect tab moved. Unlike an image, the medium changes
+        // without the emulator being told, and the drive has to be asked even
+        // with the motor stopped -- otherwise a disk put in after boot is never
+        // noticed. Outside the INTREQ test on purpose: that only passes when
+        // VERTB goes from acknowledged to raised, and software which disables
+        // interrupts and polls the beam instead -- trackloaders and demos,
+        // exactly what a real disk gets pointed at -- leaves the bit set for
+        // good. Gated on it, the drive would be asked once and never again.
+        // `pending_vbi` already paces this to once per frame wrap.
+        #[cfg(feature = "floppybridge")]
+        self.floppy.poll_bridge_media();
         if self.paula.intreq & INT_VERTB == 0 {
-            // Once a frame, ask any real drive whether its disk has been
-            // swapped or its write-protect tab moved. Unlike an image, the
-            // medium changes without the emulator being told, and the drive
-            // has to be asked even with the motor stopped -- otherwise a disk
-            // put in after boot is never noticed.
-            #[cfg(feature = "floppybridge")]
-            self.floppy.poll_bridge_media();
             self.paula.intreq |= INT_VERTB;
             if diag_vbi() {
                 log::info!(

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5210,6 +5210,13 @@ impl Bus {
         // runs is interrupt RECOGNITION LATENCY, modelled separately (see
         // irq_latency_setting / arm_irq_recognition_latency), not a raise delay.
         if self.paula.intreq & INT_VERTB == 0 {
+            // Once a frame, ask any real drive whether its disk has been
+            // swapped or its write-protect tab moved. Unlike an image, the
+            // medium changes without the emulator being told, and the drive
+            // has to be asked even with the motor stopped -- otherwise a disk
+            // put in after boot is never noticed.
+            #[cfg(feature = "floppybridge")]
+            self.floppy.poll_bridge_media();
             self.paula.intreq |= INT_VERTB;
             if diag_vbi() {
                 log::info!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1100,7 +1100,9 @@ pub struct FloppyBridgeConfig {
     pub mode: BridgeSpeedMode,
     pub density: BridgeDensity,
     pub cable: BridgeCable,
-    /// Lets the driver track a disk whose data rate wanders within a track.
+    /// Lets the driver time each track and, where the data rate is uniform --
+    /// so nothing is leaning on the timing for copy protection -- offer it at
+    /// a higher speed. Amiberry calls this "dynamically switch on Turbo".
     /// It changes how the driver captures, but not what Copperline does with
     /// the result: cell timing is derived from the length of the revolution it
     /// hands back, so the per-cell speed this makes available goes unused.
@@ -1861,7 +1863,7 @@ pub struct ConfigOverrides {
     /// Force a density rather than sensing it (`--floppy-bridge-density DFN
     /// DENSITY`). Same as `[floppy.dfN] bridge_density`.
     pub floppy_bridge_density: [Option<String>; 4],
-    /// Let the interface slow the drive between accesses
+    /// Let the interface offer uniformly-timed tracks at a higher speed
     /// (`--floppy-bridge-smart-speed DFN`). Same as `[floppy.dfN]
     /// bridge_smart_speed = true`.
     pub floppy_bridge_smart_speed: [bool; 4],
@@ -1982,8 +1984,13 @@ impl ConfigOverrides {
                 // The flag says "this bay is a real drive", so an image the
                 // config file left here would otherwise be a contradiction the
                 // parser rejects. The command line wins, as it does elsewhere.
-                drive.path = None;
-                drive.paths = None;
+                // Except for `off`, whose whole point is to hand the bay back
+                // to images: clearing the path there would take away the very
+                // disk the config file asked for.
+                if !bridge.trim().eq_ignore_ascii_case("off") {
+                    drive.path = None;
+                    drive.paths = None;
+                }
             }
             if let Some(port) = &self.floppy_bridge_port[idx] {
                 drive.bridge_port = Some(port.clone());
@@ -2766,9 +2773,10 @@ pub(crate) struct RawFloppyDrive {
     /// device; name one when two interfaces are plugged in at once.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_port: Option<String>,
-    /// How faithfully to follow the disk's real timing: `fast`,
-    /// `compatible` (the default, and what copy protection needs),
-    /// `turbo`, or `stalling`.
+    /// How each track is captured: `normal` (the default; `fast` is accepted
+    /// as upstream's own name for it), `compatible`, or `stalling`. `turbo` is
+    /// refused by name -- it answers AmigaDOS calls rather than reading the
+    /// disk.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_mode: Option<String>,
     /// Force a density instead of sensing it: `auto`, `dd`, or `hd`.
@@ -2778,8 +2786,8 @@ pub(crate) struct RawFloppyDrive {
     /// `0`..`3` (Shugart).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_cable: Option<String>,
-    /// Let the driver switch to turbo between accesses where it judges it
-    /// safe. Off by default, as it can upset copy protection.
+    /// Let the driver offer tracks whose data rate is uniform at a higher
+    /// speed. Off by default, as it can upset copy protection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_smart_speed: Option<bool>,
     /// Let the driver read ahead into other cylinders while the disk is

--- a/src/config.rs
+++ b/src/config.rs
@@ -1042,7 +1042,7 @@ pub enum BridgeSpeedMode {
     /// followed it, as the head itself would have carried on into. Reads the
     /// same disks as `Compatible` and reaches a Workbench 1.3 desktop
     /// appreciably sooner.
-    /// The default, as it is in Amiberry.
+    /// The default.
     #[default]
     Normal,
     /// Captures each track from the index, so a revolution begins where the
@@ -1050,7 +1050,6 @@ pub enum BridgeSpeedMode {
     /// as a captured image's do. Waiting for the index costs most of a
     /// revolution on every track, which is why `Normal` is the default; reach
     /// for this one if a disk reads badly without the index to anchor it.
-    /// Amiberry calls this Compatible too.
     Compatible,
     /// As `Compatible`, but the driver holds the caller up until the track is
     /// ready instead of answering "not yet". The wait lands on the emulated
@@ -1102,13 +1101,12 @@ pub struct FloppyBridgeConfig {
     pub cable: BridgeCable,
     /// Lets the driver time each track and, where the data rate is uniform --
     /// so nothing is leaning on the timing for copy protection -- offer it at
-    /// a higher speed. Amiberry calls this "dynamically switch on Turbo".
-    /// It changes how the driver captures, but not what Copperline does with
+    /// a higher speed. It changes how the driver captures, but not what Copperline does with
     /// the result: cell timing is derived from the length of the revolution it
     /// hands back, so the per-cell speed this makes available goes unused.
     pub smart_speed: bool,
     /// Read tracks ahead in the background while the drive is otherwise idle.
-    /// Off by default, as upstream and Amiberry have it. It buys little during
+    /// Off by default, as the driver has it. It buys little during
     /// a boot -- the drive is never idle then -- and moves the real head about
     /// on its own.
     pub auto_cache: bool,
@@ -4407,8 +4405,8 @@ fn parse_floppy_bridge(idx: usize, spec: &str, raw: &RawFloppyDrive) -> Result<F
         None => BridgeSpeedMode::default(),
         Some(s) if s.eq_ignore_ascii_case("compatible") => BridgeSpeedMode::Compatible,
         Some(s) if s.eq_ignore_ascii_case("stalling") => BridgeSpeedMode::Stalling,
-        // Upstream's enum calls this one Fast; Amiberry's drive-type list, and
-        // so Copperline's, calls it Normal. Both spellings are accepted.
+        // The driver's own enum calls this one Fast. Copperline calls it
+        // normal; both spellings are accepted.
         Some(s) if s.eq_ignore_ascii_case("normal") || s.eq_ignore_ascii_case("fast") => {
             BridgeSpeedMode::Normal
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -997,9 +997,145 @@ impl Default for AudioConfig {
     }
 }
 
+/// Which FloppyBridge driver backs a bridged drive.
+///
+/// Named rather than indexed so a config file does not depend on the order the
+/// installed library happens to enumerate its drivers in; the name is resolved
+/// to an index when the drive is opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BridgeDriver {
+    /// Rob Smith's Arduino-based DrawBridge.
+    DrawBridge,
+    /// Keir Fraser's Greaseweazle.
+    #[default]
+    Greaseweazle,
+    /// Jim Drew's Supercard Pro.
+    SupercardPro,
+}
+
+impl BridgeDriver {
+    /// The substring that identifies this driver in the library's own list.
+    pub fn match_token(self) -> &'static str {
+        match self {
+            BridgeDriver::DrawBridge => "drawbridge",
+            BridgeDriver::Greaseweazle => "greaseweazle",
+            BridgeDriver::SupercardPro => "supercard",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            BridgeDriver::DrawBridge => "DrawBridge",
+            BridgeDriver::Greaseweazle => "Greaseweazle",
+            BridgeDriver::SupercardPro => "Supercard Pro",
+        }
+    }
+}
+
+/// How hard the driver works to reproduce the disk's real timing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BridgeSpeedMode {
+    /// Captures wherever the head happens to be, saving the wait for the index
+    /// -- most of a revolution per track. A revolution that begins mid-track
+    /// has its two ends a revolution apart in time, so it cannot be turned
+    /// under the head twice: once round, Copperline fetches the recording that
+    /// followed it, as the head itself would have carried on into. Reads the
+    /// same disks as `Compatible` and reaches a Workbench 1.3 desktop
+    /// appreciably sooner.
+    /// The default, as it is in Amiberry.
+    #[default]
+    Normal,
+    /// Captures each track from the index, so a revolution begins where the
+    /// real one does and its two ends meet in the gap between sectors, exactly
+    /// as a captured image's do. Waiting for the index costs most of a
+    /// revolution on every track, which is why `Normal` is the default; reach
+    /// for this one if a disk reads badly without the index to anchor it.
+    /// Amiberry calls this Compatible too.
+    Compatible,
+    /// As `Compatible`, but the driver holds the caller up until the track is
+    /// ready instead of answering "not yet". The wait lands on the emulated
+    /// machine, which stops -- pointer and all -- for as long as it takes.
+    Stalling,
+}
+
+/// Whether to force a density rather than sensing it from the disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BridgeDensity {
+    #[default]
+    Auto,
+    Dd,
+    Hd,
+}
+
+/// Which drive the interface selects on the cable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BridgeCable {
+    /// IBM PC cabling, drive A: the usual case for a PC drive on a
+    /// Greaseweazle or DrawBridge.
+    #[default]
+    DriveA,
+    DriveB,
+    /// Shugart cabling, for a real Amiga drive.
+    Shugart0,
+    Shugart1,
+    Shugart2,
+    Shugart3,
+}
+
+/// A real drive attached to one floppy bay, from `[floppy.dfN] bridge = ...`.
+///
+/// Held apart from [`FloppyDriveConfig`] because a bridged drive has no image
+/// path: whichever of the two is present for a bay supplies its media.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FloppyBridgeConfig {
+    pub driver: BridgeDriver,
+    /// Emulator-level write protection, on top of the disk's own tab.
+    /// Defaults to true, exactly as it does for an image, so writing to a real
+    /// disk takes a deliberate `write_protected = false` as well as the tab
+    /// being open -- two independent things to get wrong before anything is
+    /// laid on physical media.
+    pub write_protected: bool,
+    /// `None` auto-detects the interface, which every current driver supports.
+    pub port: Option<String>,
+    pub mode: BridgeSpeedMode,
+    pub density: BridgeDensity,
+    pub cable: BridgeCable,
+    /// Lets the driver track a disk whose data rate wanders within a track.
+    /// It changes how the driver captures, but not what Copperline does with
+    /// the result: cell timing is derived from the length of the revolution it
+    /// hands back, so the per-cell speed this makes available goes unused.
+    pub smart_speed: bool,
+    /// Read tracks ahead in the background while the drive is otherwise idle.
+    /// Off by default, as upstream and Amiberry have it. It buys little during
+    /// a boot -- the drive is never idle then -- and moves the real head about
+    /// on its own.
+    pub auto_cache: bool,
+}
+
+impl Default for FloppyBridgeConfig {
+    fn default() -> Self {
+        Self {
+            driver: BridgeDriver::default(),
+            // Protected unless told otherwise, matching both the parser and an
+            // image-backed drive. A derived `Default` would make this false and
+            // quietly hand out a writable real disk.
+            write_protected: true,
+            port: None,
+            mode: BridgeSpeedMode::default(),
+            density: BridgeDensity::default(),
+            cable: BridgeCable::default(),
+            smart_speed: false,
+            auto_cache: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FloppyConfig {
     pub drives: [Option<FloppyDriveConfig>; 4],
+    /// Real drives, by bay. A bay with a bridge here has no entry in
+    /// `drives`: the physical disk is its media.
+    pub bridges: [Option<FloppyBridgeConfig>; 4],
     /// Emulated drive speed as a data-rate percentage: 100 (real speed),
     /// 200/400/800 (that many times faster), or 0 for turbo, where DMA
     /// transfers complete almost instantly. Values above 100 keep the full
@@ -1012,6 +1148,7 @@ impl Default for FloppyConfig {
     fn default() -> Self {
         Self {
             drives: std::array::from_fn(|_| None),
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
         }
     }
@@ -1703,6 +1840,34 @@ pub struct ConfigOverrides {
     /// Show the status bar at start (`--show-status-bar` /
     /// `--hide-status-bar`). Same as `[display] status_bar`.
     pub status_bar: Option<bool>,
+    /// A real floppy drive on a bay (`--floppy-bridge DFN INTERFACE`), by bay.
+    /// Same values as `[floppy.dfN] bridge`.
+    pub floppy_bridge: [Option<String>; 4],
+    /// The interface's serial port (`--floppy-bridge-port DFN PORT`). Same as
+    /// `[floppy.dfN] bridge_port`; unset auto-detects.
+    pub floppy_bridge_port: [Option<String>; 4],
+    /// Which drive on the cable to select (`--floppy-bridge-cable DFN CABLE`).
+    /// Same as `[floppy.dfN] bridge_cable`.
+    pub floppy_bridge_cable: [Option<String>; 4],
+    /// Drop the emulator's own write protection on a bay
+    /// (`--floppy-bridge-writable DFN`), leaving only the disk's tab between
+    /// the guest and the platter. Same as `[floppy.dfN] write_protected =
+    /// false`; there is deliberately no flag the other way, because protected
+    /// is already the default.
+    pub floppy_bridge_writable: [bool; 4],
+    /// How the interface captures a track (`--floppy-bridge-mode DFN MODE`).
+    /// Same as `[floppy.dfN] bridge_mode`.
+    pub floppy_bridge_mode: [Option<String>; 4],
+    /// Force a density rather than sensing it (`--floppy-bridge-density DFN
+    /// DENSITY`). Same as `[floppy.dfN] bridge_density`.
+    pub floppy_bridge_density: [Option<String>; 4],
+    /// Let the interface slow the drive between accesses
+    /// (`--floppy-bridge-smart-speed DFN`). Same as `[floppy.dfN]
+    /// bridge_smart_speed = true`.
+    pub floppy_bridge_smart_speed: [bool; 4],
+    /// Read tracks ahead while the drive is idle (`--floppy-bridge-read-ahead
+    /// DFN`). Same as `[floppy.dfN] bridge_auto_cache = true`.
+    pub floppy_bridge_read_ahead: [bool; 4],
 }
 
 impl ConfigOverrides {
@@ -1720,6 +1885,14 @@ impl ConfigOverrides {
             && self.accelerator.is_none()
             && self.floppy_drives.is_none()
             && self.floppy_speed.is_none()
+            && self.floppy_bridge.iter().all(Option::is_none)
+            && self.floppy_bridge_port.iter().all(Option::is_none)
+            && self.floppy_bridge_cable.iter().all(Option::is_none)
+            && self.floppy_bridge_mode.iter().all(Option::is_none)
+            && self.floppy_bridge_density.iter().all(Option::is_none)
+            && !self.floppy_bridge_smart_speed.iter().any(|v| *v)
+            && !self.floppy_bridge_read_ahead.iter().any(|v| *v)
+            && !self.floppy_bridge_writable.iter().any(|w| *w)
             && self.joystick.is_none()
             && self.mouse_sensitivity.is_none()
             && self.mouse_capture.is_none()
@@ -1782,6 +1955,57 @@ impl ConfigOverrides {
         }
         if let Some(speed) = self.floppy_speed {
             raw.floppy.speed = Some(speed);
+        }
+        for idx in 0..4 {
+            if self.floppy_bridge[idx].is_none()
+                && self.floppy_bridge_port[idx].is_none()
+                && self.floppy_bridge_cable[idx].is_none()
+                && !self.floppy_bridge_writable[idx]
+                && self.floppy_bridge_mode[idx].is_none()
+                && self.floppy_bridge_density[idx].is_none()
+                && !self.floppy_bridge_smart_speed[idx]
+                && !self.floppy_bridge_read_ahead[idx]
+            {
+                continue;
+            }
+            // A bay named on the command line gets a table if it had none, so
+            // a bridge can be asked for with no config file at all.
+            let drive = match idx {
+                0 => &mut raw.floppy.df0,
+                1 => &mut raw.floppy.df1,
+                2 => &mut raw.floppy.df2,
+                _ => &mut raw.floppy.df3,
+            }
+            .get_or_insert_with(RawFloppyDrive::default);
+            if let Some(bridge) = &self.floppy_bridge[idx] {
+                drive.bridge = Some(bridge.clone());
+                // The flag says "this bay is a real drive", so an image the
+                // config file left here would otherwise be a contradiction the
+                // parser rejects. The command line wins, as it does elsewhere.
+                drive.path = None;
+                drive.paths = None;
+            }
+            if let Some(port) = &self.floppy_bridge_port[idx] {
+                drive.bridge_port = Some(port.clone());
+            }
+            if let Some(cable) = &self.floppy_bridge_cable[idx] {
+                drive.bridge_cable = Some(cable.clone());
+            }
+            if self.floppy_bridge_writable[idx] {
+                drive.write_protected = Some(false);
+            }
+            if let Some(mode) = &self.floppy_bridge_mode[idx] {
+                drive.bridge_mode = Some(mode.clone());
+            }
+            if let Some(density) = &self.floppy_bridge_density[idx] {
+                drive.bridge_density = Some(density.clone());
+            }
+            if self.floppy_bridge_smart_speed[idx] {
+                drive.bridge_smart_speed = Some(true);
+            }
+            if self.floppy_bridge_read_ahead[idx] {
+                drive.bridge_auto_cache = Some(true);
+            }
         }
         if let Some(joystick) = &self.joystick {
             raw.input.joystick = Some(joystick.clone());
@@ -2532,6 +2756,36 @@ pub(crate) struct RawFloppyDrive {
     pub(crate) paths: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) write_protected: Option<bool>,
+    /// Attach a real drive to this bay instead of an image, over a
+    /// DrawBridge/Greaseweazle/Supercard Pro: `drawbridge`, `greaseweazle`,
+    /// `supercardpro`, or `profile:N` to use one of the FloppyBridge
+    /// library's own saved profiles.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge: Option<String>,
+    /// Serial port the interface is on. Omitted, the driver finds its own
+    /// device; name one when two interfaces are plugged in at once.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge_port: Option<String>,
+    /// How faithfully to follow the disk's real timing: `fast`,
+    /// `compatible` (the default, and what copy protection needs),
+    /// `turbo`, or `stalling`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge_mode: Option<String>,
+    /// Force a density instead of sensing it: `auto`, `dd`, or `hd`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge_density: Option<String>,
+    /// Which drive on the cable to select: `a`/`b` (IBM PC cabling) or
+    /// `0`..`3` (Shugart).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge_cable: Option<String>,
+    /// Let the driver switch to turbo between accesses where it judges it
+    /// safe. Off by default, as it can upset copy protection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge_smart_speed: Option<bool>,
+    /// Let the driver read ahead into other cylinders while the disk is
+    /// idle. Off by default: it keeps the real drive working continuously.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bridge_auto_cache: Option<bool>,
 }
 
 /// Convert a parsed `[ide]`/`[scsi]` drive entry into a `DriveImage`,
@@ -4031,10 +4285,43 @@ fn parse_floppy(raw: RawFloppy) -> Result<(FloppyConfig, [bool; 4], [Vec<PathBuf
         None => [true, false, false, false],
     };
     let mut playlists: [Vec<PathBuf>; 4] = std::array::from_fn(|_| Vec::new());
+    #[cfg_attr(not(feature = "floppybridge"), allow(unused_mut))]
+    let mut bridges: [Option<FloppyBridgeConfig>; 4] = std::array::from_fn(|_| None);
     for (idx, raw_drive) in raws.into_iter().enumerate() {
         let Some(raw_drive) = raw_drive else {
             continue;
         };
+
+        // A physical drive takes the bay instead of an image. A build without
+        // the feature has no way to drive one, so the keys are read and
+        // ignored rather than rejected: a config file shared between builds
+        // stays valid, it just does nothing here.
+        #[cfg(not(feature = "floppybridge"))]
+        let _ = &raw_drive.bridge;
+        #[cfg(feature = "floppybridge")]
+        if let Some(spec) = raw_drive.bridge.as_deref() {
+            let spec = spec.trim();
+            if !spec.eq_ignore_ascii_case("off") && !spec.is_empty() {
+                if raw_drive.path.is_some() || raw_drive.paths.is_some() {
+                    bail!(
+                        "floppy.df{idx} has both a bridge and a disk image; a physical drive \
+                         supplies its own media, so give one or the other"
+                    );
+                }
+                bridges[idx] = Some(parse_floppy_bridge(idx, spec, &raw_drive)?);
+                if let Some(count) = connected_count {
+                    if !connected[idx] {
+                        bail!(
+                            "[floppy] drives = {count} leaves floppy.df{idx} disconnected, \
+                             but floppy.df{idx} has a bridge configured"
+                        );
+                    }
+                } else {
+                    connected[idx] = true;
+                }
+                continue;
+            }
+        }
         // Combine `path` (single) and `paths` (playlist) into one ordered
         // list, with `path` first when both are present.
         let mut raw_images: Vec<String> = Vec::new();
@@ -4080,7 +4367,89 @@ fn parse_floppy(raw: RawFloppy) -> Result<(FloppyConfig, [bool; 4], [Vec<PathBuf
         });
         playlists[idx] = images;
     }
-    Ok((FloppyConfig { drives, speed }, connected, playlists))
+    Ok((
+        FloppyConfig {
+            drives,
+            bridges,
+            speed,
+        },
+        connected,
+        playlists,
+    ))
+}
+
+/// Parse one bay's `bridge = ...` plus its `bridge_*` settings.
+#[cfg(feature = "floppybridge")]
+fn parse_floppy_bridge(idx: usize, spec: &str, raw: &RawFloppyDrive) -> Result<FloppyBridgeConfig> {
+    let driver = match spec
+        .to_ascii_lowercase()
+        .replace([' ', '-', '_'], "")
+        .as_str()
+    {
+        "drawbridge" | "arduino" => BridgeDriver::DrawBridge,
+        "greaseweazle" | "gw" => BridgeDriver::Greaseweazle,
+        "supercardpro" | "scp" => BridgeDriver::SupercardPro,
+        _ => bail!(
+            "floppy.df{idx} bridge = \"{spec}\" is not a known interface \
+             (drawbridge, greaseweazle, supercardpro)"
+        ),
+    };
+
+    let mode = match raw.bridge_mode.as_deref().map(str::trim) {
+        None => BridgeSpeedMode::default(),
+        Some(s) if s.eq_ignore_ascii_case("compatible") => BridgeSpeedMode::Compatible,
+        Some(s) if s.eq_ignore_ascii_case("stalling") => BridgeSpeedMode::Stalling,
+        // Upstream's enum calls this one Fast; Amiberry's drive-type list, and
+        // so Copperline's, calls it Normal. Both spellings are accepted.
+        Some(s) if s.eq_ignore_ascii_case("normal") || s.eq_ignore_ascii_case("fast") => {
+            BridgeSpeedMode::Normal
+        }
+        // "turbo" is not a read mode: it intercepts AmigaDOS calls rather
+        // than reading the disk, which is not something an emulator modelling
+        // the hardware can use. Refused by name rather than quietly
+        // substituted, so a config carried over from another emulator says
+        // what happened.
+        Some(s) if s.eq_ignore_ascii_case("turbo") => bail!(
+            "floppy.df{idx} bridge_mode = \"{s}\" answers AmigaDOS calls instead of \
+             reading the disk, which Copperline has no use for: it models the drive. \
+             Use compatible, fast or stalling."
+        ),
+        Some(s) => bail!("floppy.df{idx} unknown bridge_mode {s:?}"),
+    };
+    let density = match raw.bridge_density.as_deref().map(str::trim) {
+        None => BridgeDensity::Auto,
+        Some(s) if s.eq_ignore_ascii_case("auto") => BridgeDensity::Auto,
+        Some(s) if s.eq_ignore_ascii_case("dd") => BridgeDensity::Dd,
+        Some(s) if s.eq_ignore_ascii_case("hd") => BridgeDensity::Hd,
+        Some(s) => bail!("floppy.df{idx} bridge_density = \"{s}\" is not one of auto, dd, hd"),
+    };
+    let cable = match raw.bridge_cable.as_deref().map(str::trim) {
+        None => BridgeCable::default(),
+        Some(s) if s.eq_ignore_ascii_case("a") => BridgeCable::DriveA,
+        Some(s) if s.eq_ignore_ascii_case("b") => BridgeCable::DriveB,
+        Some("0") => BridgeCable::Shugart0,
+        Some("1") => BridgeCable::Shugart1,
+        Some("2") => BridgeCable::Shugart2,
+        Some("3") => BridgeCable::Shugart3,
+        Some(s) => bail!("floppy.df{idx} bridge_cable = \"{s}\" is not one of a, b, 0, 1, 2, 3"),
+    };
+    let port = raw
+        .bridge_port
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    Ok(FloppyBridgeConfig {
+        driver,
+        write_protected: raw.write_protected.unwrap_or(true),
+        port,
+        mode,
+        density,
+        cable,
+        smart_speed: raw.bridge_smart_speed.unwrap_or(false),
+        auto_cache: raw.bridge_auto_cache.unwrap_or(false),
+    })
 }
 
 fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
@@ -4613,6 +4982,7 @@ mod tests {
                     path: Some("game.adf".to_string()),
                     paths: None,
                     write_protected: Some(true),
+                    ..RawFloppyDrive::default()
                 }),
                 ..RawFloppy::default()
             },
@@ -6456,6 +6826,126 @@ mod tests {
         assert!(!text.contains("name"), "{text}");
         let parsed: RawIde = toml::from_str(&text).unwrap();
         assert_eq!(parsed, prioritised);
+    }
+
+    // A build without the feature has no bridges to configure: the keys are
+    // read and ignored, so there is nothing here to assert.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_parses_and_defaults() -> Result<()> {
+        let cfg = parse_config(
+            r#"
+            [floppy.df0]
+            bridge = "greaseweazle"
+            [floppy.df1]
+            bridge = "DrawBridge"
+            bridge_port = "/dev/tty.usbmodem1111301"
+            bridge_mode = "stalling"
+            bridge_density = "hd"
+            bridge_cable = "b"
+            bridge_smart_speed = true
+        "#,
+        )?;
+        let df0 = cfg.floppy.bridges[0].as_ref().expect("df0 bridged");
+        assert_eq!(df0.driver, BridgeDriver::Greaseweazle);
+        // Unset options take the defaults: auto-detect the interface, read
+        // without waiting for the index, sense the density, no read-ahead.
+        assert_eq!(df0.port, None);
+        assert_eq!(df0.mode, BridgeSpeedMode::Normal);
+        assert_eq!(df0.density, BridgeDensity::Auto);
+        assert!(!df0.smart_speed && !df0.auto_cache);
+
+        let df1 = cfg.floppy.bridges[1].as_ref().expect("df1 bridged");
+        assert_eq!(df1.driver, BridgeDriver::DrawBridge);
+        assert_eq!(df1.port.as_deref(), Some("/dev/tty.usbmodem1111301"));
+        assert_eq!(df1.mode, BridgeSpeedMode::Stalling);
+        assert_eq!(df1.density, BridgeDensity::Hd);
+        assert_eq!(df1.cable, BridgeCable::DriveB);
+        assert!(df1.smart_speed);
+
+        // Bridging a bay wires the drive in, and leaves it with no image.
+        assert!(cfg.floppy.drives[0].is_none());
+        assert!(cfg.floppy_connected[0] && cfg.floppy_connected[1]);
+        Ok(())
+    }
+
+    // A build without the feature has no bridges to configure: the keys are
+    // read and ignored, so there is nothing here to assert.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_rejects_conflicts_and_typos() {
+        // A real drive brings its own disk, so an image alongside it is a
+        // contradiction rather than a fallback.
+        let err = parse_config(
+            r#"
+            [floppy.df0]
+            bridge = "greaseweazle"
+            path = "game.adf"
+        "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("bridge and a disk image"), "{err}");
+
+        let err = parse_config(
+            r#"
+            [floppy.df0]
+            bridge = "greasewheel"
+        "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("not a known interface"), "{err}");
+
+        // `off` is how a bay keeps its bridge settings but goes back to images:
+        // the image is then parsed normally, so the only complaint left is the
+        // missing file rather than anything about bridges.
+        let err = parse_config(
+            r#"
+            [floppy.df0]
+            bridge = "off"
+            path = "game.adf"
+        "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            !err.contains("bridge"),
+            "bridge = off is not a bridge: {err}"
+        );
+
+        // "turbo" is not a read mode at all -- it intercepts AmigaDOS calls --
+        // so it is named in the refusal rather than silently swapped for one
+        // that works, and a config brought over from another emulator
+        // explains itself.
+        // "fast" is a read mode Copperline can use now that it chains
+        // consecutive recordings, so it parses.
+        assert_eq!(
+            parse_config(
+                r#"
+                [floppy.df0]
+                bridge = "greaseweazle"
+                bridge_mode = "normal"
+            "#
+            )
+            .unwrap()
+            .floppy
+            .bridges[0]
+                .as_ref()
+                .unwrap()
+                .mode,
+            BridgeSpeedMode::Normal
+        );
+        let err = parse_config(
+            r#"
+                [floppy.df0]
+                bridge = "greaseweazle"
+                bridge_mode = "turbo"
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("instead of"), "{err}");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1867,9 +1867,9 @@ pub struct ConfigOverrides {
     /// (`--floppy-bridge-smart-speed DFN`). Same as `[floppy.dfN]
     /// bridge_smart_speed = true`.
     pub floppy_bridge_smart_speed: [bool; 4],
-    /// Read tracks ahead while the drive is idle (`--floppy-bridge-read-ahead
+    /// Cache disk data while the drive is idle (`--floppy-bridge-auto-cache
     /// DFN`). Same as `[floppy.dfN] bridge_auto_cache = true`.
-    pub floppy_bridge_read_ahead: [bool; 4],
+    pub floppy_bridge_auto_cache: [bool; 4],
 }
 
 impl ConfigOverrides {
@@ -1893,7 +1893,7 @@ impl ConfigOverrides {
             && self.floppy_bridge_mode.iter().all(Option::is_none)
             && self.floppy_bridge_density.iter().all(Option::is_none)
             && !self.floppy_bridge_smart_speed.iter().any(|v| *v)
-            && !self.floppy_bridge_read_ahead.iter().any(|v| *v)
+            && !self.floppy_bridge_auto_cache.iter().any(|v| *v)
             && !self.floppy_bridge_writable.iter().any(|w| *w)
             && self.joystick.is_none()
             && self.mouse_sensitivity.is_none()
@@ -1966,7 +1966,7 @@ impl ConfigOverrides {
                 && self.floppy_bridge_mode[idx].is_none()
                 && self.floppy_bridge_density[idx].is_none()
                 && !self.floppy_bridge_smart_speed[idx]
-                && !self.floppy_bridge_read_ahead[idx]
+                && !self.floppy_bridge_auto_cache[idx]
             {
                 continue;
             }
@@ -2010,7 +2010,7 @@ impl ConfigOverrides {
             if self.floppy_bridge_smart_speed[idx] {
                 drive.bridge_smart_speed = Some(true);
             }
-            if self.floppy_bridge_read_ahead[idx] {
+            if self.floppy_bridge_auto_cache[idx] {
                 drive.bridge_auto_cache = Some(true);
             }
         }
@@ -2790,7 +2790,7 @@ pub(crate) struct RawFloppyDrive {
     /// speed. Off by default, as it can upset copy protection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_smart_speed: Option<bool>,
-    /// Let the driver read ahead into other cylinders while the disk is
+    /// Let the driver cache other cylinders while the disk is
     /// idle. Off by default: it keeps the real drive working continuously.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_auto_cache: Option<bool>,
@@ -6857,7 +6857,7 @@ mod tests {
         let df0 = cfg.floppy.bridges[0].as_ref().expect("df0 bridged");
         assert_eq!(df0.driver, BridgeDriver::Greaseweazle);
         // Unset options take the defaults: auto-detect the interface, read
-        // without waiting for the index, sense the density, no read-ahead.
+        // without waiting for the index, sense the density, no auto-cache.
         assert_eq!(df0.port, None);
         assert_eq!(df0.mode, BridgeSpeedMode::Normal);
         assert_eq!(df0.density, BridgeDensity::Auto);

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1288,6 +1288,17 @@ impl Emulator {
     /// Re-enabling re-anchors the pacing clock so the emulator does not
     /// sprint to catch up the time spent in warp.
     pub fn set_paced(&mut self, paced: bool) {
+        // A physical drive's platter turns in wall-clock time and cannot be
+        // hurried, so a bridged machine stays paced whatever asks otherwise --
+        // warp, the benchmark runner, the GDB stub, the control server. Left
+        // unthrottled the guest outruns the drive: the motor is spun up and
+        // down faster than it can reach speed, and tracks are stepped past
+        // before the drive has captured them. Enforced here rather than at
+        // each caller so no future runner can quietly opt out of it.
+        #[cfg(feature = "floppybridge")]
+        if !paced && self.bus().floppy.has_bridged_drive() {
+            return;
+        }
         if self.paced == paced {
             return;
         }
@@ -1957,8 +1968,6 @@ pub(crate) fn attach_floppy_bridges(floppy: &mut FloppyController, cfg: &Config)
                  misconfigured; please report it."
             );
         }
-        // Resolve the driver by name against what this library actually
-        // offers, so the config does not depend on enumeration order.
         // Resolve the driver by name against what the bridge actually
         // offers, so the config does not depend on enumeration order.
         let token = bridge_cfg.driver.match_token();

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1930,6 +1930,123 @@ fn open_scsi_target(
     }
 }
 
+/// Open every drive the config bridges to real hardware.
+///
+/// Failing to open one is fatal rather than a warning: a bay configured as a
+/// real drive has no image to fall back on, so carrying on would silently boot
+/// a machine with an empty drive where the user asked for their disk.
+#[cfg(feature = "floppybridge")]
+pub(crate) fn attach_floppy_bridges(floppy: &mut FloppyController, cfg: &Config) -> Result<()> {
+    use crate::config::{BridgeCable, BridgeDensity, BridgeSpeedMode};
+    use crate::floppybridge::{
+        self, Bridge, BridgeConfig, BridgeDensityMode, BridgeMode, DriveSelection,
+    };
+
+    for (idx, bridge_cfg) in cfg.floppy.bridges.iter().enumerate() {
+        let Some(bridge_cfg) = bridge_cfg else {
+            continue;
+        };
+        // The bridge is compiled into this binary, so it cannot be missing --
+        // the link would have failed. This is a failsafe against it being
+        // present but not working: a vendored build that produced stubs, or a
+        // future upstream that drops a driver Copperline still offers.
+        if floppybridge::drivers().is_empty() {
+            anyhow::bail!(
+                "floppy.df{idx} asks for a physical drive, but the built-in FloppyBridge \
+                 reports no interfaces at all. This build is broken rather than \
+                 misconfigured; please report it."
+            );
+        }
+        // Resolve the driver by name against what this library actually
+        // offers, so the config does not depend on enumeration order.
+        // Resolve the driver by name against what the bridge actually
+        // offers, so the config does not depend on enumeration order.
+        let token = bridge_cfg.driver.match_token();
+        let driver = floppybridge::drivers()
+            .into_iter()
+            .find(|d| {
+                d.name
+                    .to_ascii_lowercase()
+                    .replace([' ', '-', '_'], "")
+                    .contains(token)
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "floppy.df{idx}: the built-in FloppyBridge has no {} driver",
+                    bridge_cfg.driver.label()
+                )
+            })?;
+        let open = BridgeConfig {
+            driver: driver.index,
+            mode: match bridge_cfg.mode {
+                BridgeSpeedMode::Compatible => BridgeMode::Compatible,
+                BridgeSpeedMode::Normal => BridgeMode::Fast,
+                BridgeSpeedMode::Stalling => BridgeMode::Stalling,
+            },
+            density: match bridge_cfg.density {
+                BridgeDensity::Auto => BridgeDensityMode::Auto,
+                BridgeDensity::Dd => BridgeDensityMode::DdOnly,
+                BridgeDensity::Hd => BridgeDensityMode::HdOnly,
+            },
+            drive: match bridge_cfg.cable {
+                BridgeCable::DriveA => DriveSelection::DriveA,
+                BridgeCable::DriveB => DriveSelection::DriveB,
+                BridgeCable::Shugart0 => DriveSelection::Drive0,
+                BridgeCable::Shugart1 => DriveSelection::Drive1,
+                BridgeCable::Shugart2 => DriveSelection::Drive2,
+                BridgeCable::Shugart3 => DriveSelection::Drive3,
+            },
+            port: bridge_cfg.port.clone(),
+            smart_speed: bridge_cfg.smart_speed,
+            auto_cache: bridge_cfg.auto_cache,
+        };
+        let bridge = Bridge::open(&open)
+            .map_err(|e| anyhow!("floppy.df{idx}: could not open the physical drive: {e}"))?;
+        // Name the port as well as the interface: with auto-detect on, the
+        // library does not report back which one it took, so say so from the
+        // ports it can see -- unambiguous when there is only one, and honest
+        // rather than guessing when there is not.
+        let port = match bridge_cfg.port.as_deref() {
+            Some(port) => port.to_string(),
+            None => {
+                let seen = floppybridge::com_ports();
+                match seen.len() {
+                    1 => format!("{} (auto-detected)", seen[0]),
+                    _ => "auto-detected".to_string(),
+                }
+            }
+        };
+        let drive_type = match bridge.drive_type() {
+            floppybridge::DriveType::Dd35 => "3.5\" DD",
+            floppybridge::DriveType::Dd35Hd => "3.5\" HD",
+            floppybridge::DriveType::Sd525 => "5.25\" SD",
+        };
+        let version = match floppybridge::version() {
+            Some((major, minor)) => format!("FloppyDriveBridge v{major}.{minor}"),
+            None => "FloppyDriveBridge".to_string(),
+        };
+        log::info!(
+            "floppy.df{idx} physical drive attached: {} on {port}, {drive_type} drive, {version}",
+            bridge_cfg.driver.label(),
+        );
+        // Whether there is anything in it is the next thing anyone wants to
+        // know, and unlike an image nobody told us either way.
+        if bridge.disk_in_drive() {
+            log::info!("floppy.df{idx} disk in the physical drive");
+        } else {
+            log::info!("floppy.df{idx} no disk in the physical drive");
+        }
+        if bridge_cfg.write_protected {
+            log::info!(
+                "floppy.df{idx} write-protected by the configuration; \
+                 set write_protected = false to write to the disk"
+            );
+        }
+        floppy.attach_bridge(idx, bridge, bridge_cfg.write_protected)?;
+    }
+    Ok(())
+}
+
 pub fn build_machine(
     cfg: &Config,
     audio: Box<dyn AudioSink>,
@@ -2107,6 +2224,8 @@ pub fn build_machine(
     };
     let mut floppy = FloppyController::from_config(&cfg.floppy)?;
     floppy.set_connected_drives(cfg.floppy_connected);
+    #[cfg(feature = "floppybridge")]
+    attach_floppy_bridges(&mut floppy, cfg)?;
     let serial = build_serial_sink(cfg)?;
     let mut paula = Paula::new(serial, audio);
     paula

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -505,6 +505,18 @@ impl FloppyController {
             "invalid floppy drive df{}",
             drive_idx
         );
+        // A bay is either a real drive or an image, never both: the bridge
+        // keeps supplying the track under the head, so an image mounted on top
+        // would be reported as inserted and then never read. The status bar
+        // greys its own buttons, but scheduled inserts, drag-and-drop and the
+        // control protocol all arrive here instead, so the invariant belongs
+        // where every route passes.
+        #[cfg(feature = "floppybridge")]
+        ensure!(
+            !self.drives[drive_idx].is_bridged(),
+            "floppy.df{drive_idx} is a physical drive; take the drive off the bay before \
+             using a disk image in it"
+        );
         let config = FloppyDriveConfig {
             path,
             write_protected,
@@ -535,6 +547,18 @@ impl FloppyController {
             "invalid floppy drive df{}",
             drive_idx
         );
+        // A bay is either a real drive or an image, never both: the bridge
+        // keeps supplying the track under the head, so an image mounted on top
+        // would be reported as inserted and then never read. The status bar
+        // greys its own buttons, but scheduled inserts, drag-and-drop and the
+        // control protocol all arrive here instead, so the invariant belongs
+        // where every route passes.
+        #[cfg(feature = "floppybridge")]
+        ensure!(
+            !self.drives[drive_idx].is_bridged(),
+            "floppy.df{drive_idx} is a physical drive; take the drive off the bay before \
+             using a disk image in it"
+        );
         let image = FloppyImage::from_bytes(bytes, label, write_protected)
             .with_context(|| format!("loading floppy.df{} image", drive_idx))?;
         self.idle_cache = false;
@@ -550,6 +574,18 @@ impl FloppyController {
             drive_idx < self.drives.len(),
             "invalid floppy drive df{}",
             drive_idx
+        );
+        // A bay is either a real drive or an image, never both: the bridge
+        // keeps supplying the track under the head, so an image mounted on top
+        // would be reported as inserted and then never read. The status bar
+        // greys its own buttons, but scheduled inserts, drag-and-drop and the
+        // control protocol all arrive here instead, so the invariant belongs
+        // where every route passes.
+        #[cfg(feature = "floppybridge")]
+        ensure!(
+            !self.drives[drive_idx].is_bridged(),
+            "floppy.df{drive_idx} is a physical drive; take the drive off the bay before \
+             using a disk image in it"
         );
         self.idle_cache = false;
         self.drives[drive_idx].eject_image();
@@ -583,6 +619,14 @@ impl FloppyController {
         // whatever it last saw in this drive.
         drive.set_disk_change(true);
         Ok(())
+    }
+
+    /// Whether any bay is a physical drive. Such a machine cannot be run
+    /// faster than real time: the platter turns at its own speed and nothing
+    /// the emulator does will hurry it.
+    #[cfg(feature = "floppybridge")]
+    pub fn has_bridged_drive(&self) -> bool {
+        self.drives.iter().any(|d| d.bridge.is_some())
     }
 
     /// Let go of every real drive, closing the device and handing the port
@@ -1911,21 +1955,21 @@ impl FloppyController {
                 drive.bridge_attempts = 0;
             }
             drive.bridge_attempts = drive.bridge_attempts.saturating_add(1);
-            let bridge = drive.bridge.as_mut().expect("checked above");
+            // Retire the spent recording so the driver promotes the capture
+            // that followed it, if one has finished. When none has, it hands
+            // the same revolution back, and Copperline uses it: the guest gets
+            // a splice at the join and retries the sector that straddles it,
+            // which costs a revolution. Refusing it instead was tried and is
+            // worse -- the drive cannot finish a capture every revolution, so
+            // the guest is handed filler and starves. Ten good sectors beat
+            // none. `compatible` is the mode that has no seam to begin with.
             if spent {
-                bridge.switch_buffer(side);
+                if let Some(bridge) = drive.bridge.as_mut() {
+                    bridge.switch_buffer(side);
+                }
             }
-            let previous = spent.then(|| drive.cached.revs.first().map(|r| r.words.clone()));
             let bridge = drive.bridge.as_mut().expect("checked above");
-            if let Some((words, bits)) = bridge
-                .read_track(cylinder, side)
-                // Retiring a recording only promotes the next one if the driver
-                // has finished capturing it. Ask too soon and the same
-                // revolution comes back, and running the head into it again is
-                // the splice the whole exercise is meant to avoid -- a sector
-                // the guest has to retry. Wait for one that is genuinely new.
-                .filter(|(words, _)| previous.flatten().is_none_or(|p| p != *words))
-            {
+            if let Some((words, bits)) = bridge.read_track(cylinder, side) {
                 // The bridge hands back one whole revolution as a packed MFM
                 // stream plus the bit it wrapped at, which is what TrackRev
                 // holds. Because it is a real revolution, fitting it to one
@@ -2263,10 +2307,6 @@ impl FloppyDrive {
         self.cached = CachedTrack::default();
     }
 
-    /// Whether there is anything under the head: a mounted image, or a real
-    /// disk in a bridged drive. The drive's status lines key off this, so a
-    /// bridge reports empty until a disk is actually inserted, exactly as an
-    /// empty drive does.
     /// Whether this drive is a real one on a bridge.
     fn is_bridged(&self) -> bool {
         #[cfg(feature = "floppybridge")]
@@ -2279,6 +2319,10 @@ impl FloppyDrive {
         }
     }
 
+    /// Whether there is anything under the head: a mounted image, or a real
+    /// disk in a bridged drive. The drive's status lines key off this, so a
+    /// bridge reports empty until a disk is actually inserted, exactly as an
+    /// empty drive does.
     fn has_media(&self) -> bool {
         #[cfg(feature = "floppybridge")]
         if self.bridge.is_some() {

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -14,6 +14,10 @@ use anyhow::{bail, ensure, Context, Result};
 use flate2::read::{DeflateDecoder, GzDecoder};
 use flate2::CrcReader;
 use log::{debug, warn};
+// The bridge's retry path traces, and its media reporting is worth an info
+// line; both are compiled out with the feature.
+#[cfg(feature = "floppybridge")]
+use log::{info, trace};
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
@@ -53,6 +57,19 @@ const DMACON_DISK: u16 = 1 << 4;
 const DMACON_DMAEN: u16 = 1 << 9;
 
 const MOTOR_READY_CCK: u32 = PAULA_CLOCK_HZ / 4;
+/// Whether `COPPERLINE_DIAG_FLOPPYBRIDGE` asked for the physical drive's own
+/// running commentary. Snapshotted, like every other diagnostic switch.
+#[cfg(feature = "floppybridge")]
+fn bridge_diag() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| crate::envcfg::flag("COPPERLINE_DIAG_FLOPPYBRIDGE"))
+}
+
+/// How long to leave a bridged drive alone after it says a track is not ready
+/// yet. The physical capture takes a revolution either way, so this only
+/// decides how often we ask -- see `ensure_track`.
+#[cfg(feature = "floppybridge")]
+const BRIDGE_POLL_INTERVAL_CCK: u64 = (PAULA_CLOCK_HZ / 1_000) as u64;
 const DISK_STATUS_SETTLE_CCK: u32 = PAULA_CLOCK_HZ / 1_000;
 const INDEX_PULSE_CCK: u32 = PAULA_CLOCK_HZ / 250;
 const INDEX_FLAG_SYNC_CCK: u32 = 1;
@@ -539,6 +556,173 @@ impl FloppyController {
         Ok(())
     }
 
+    /// Put a real drive on `drive_idx`, replacing any mounted image. The
+    /// bridge supplies the track under the head from then on.
+    #[cfg(feature = "floppybridge")]
+    pub fn attach_bridge(
+        &mut self,
+        drive_idx: usize,
+        bridge: crate::floppybridge::Bridge,
+        write_protected: bool,
+    ) -> Result<()> {
+        ensure!(
+            drive_idx < self.drives.len(),
+            "invalid floppy drive df{drive_idx}"
+        );
+        self.idle_cache = false;
+        let drive = &mut self.drives[drive_idx];
+        drive.eject_image();
+        // Either protection is enough to keep the disk read-only.
+        drive.bridge_write_protected = write_protected;
+        drive.bridge_tab_write_protected = bridge.write_protected();
+        drive.bridge_media = bridge.disk_in_drive();
+        drive.write_protected_target =
+            write_protected || (drive.bridge_media && drive.bridge_tab_write_protected);
+        drive.bridge = Some(bridge);
+        // Announce the swap so the guest re-reads rather than trusting
+        // whatever it last saw in this drive.
+        drive.set_disk_change(true);
+        Ok(())
+    }
+
+    /// Let go of every real drive, closing the device and handing the port
+    /// back to the host.
+    ///
+    /// This is what powering the machine off has to do. A `Bridge` holds the
+    /// interface open for as long as it exists, and the library keeps its
+    /// worker running behind it -- so a machine that merely stopped stepping
+    /// would leave the real drive clicking away as though the Amiga were still
+    /// on, and nothing else could open the device. Dropping the bridge closes
+    /// it, exactly as cutting the power to a real drive would.
+    ///
+    /// The bays revert to empty image-backed drives, so a machine that carries
+    /// on running simply has nothing in them.
+    #[cfg(feature = "floppybridge")]
+    pub fn release_bridges(&mut self) {
+        for (idx, drive) in self.drives.iter_mut().enumerate() {
+            if drive.bridge.take().is_none() {
+                continue;
+            }
+            info!("floppy.df{idx} physical drive released (interface handed back to the host)");
+            drive.bridge_media = false;
+            drive.cached_track = None;
+            drive.cached = CachedTrack::default();
+            drive.bridge_filler_track = None;
+            drive.bridge_tracks.clear();
+            drive.eject_image();
+            self.idle_cache = false;
+        }
+    }
+
+    /// Whether this drive is backed by a real drive.
+    #[cfg(feature = "floppybridge")]
+    pub fn is_bridged(&self, drive_idx: usize) -> bool {
+        self.drives
+            .get(drive_idx)
+            .is_some_and(|d| d.bridge.is_some())
+    }
+
+    /// Point a bridged drive's real head where the emulated one is.
+    ///
+    /// A real drive's head follows the stepper, so a bridged one does too. It
+    /// also buys back most of the wait for a track: the driver starts capturing
+    /// the moment the head arrives, so by the time the guest gets round to
+    /// reading, the revolution is often already in hand. The library coalesces
+    /// queued moves, so a trackloader sweeping across the disk does not pile up
+    /// a seek per cylinder.
+    #[cfg(feature = "floppybridge")]
+    fn sync_bridge_head(&mut self, idx: usize) {
+        let side = self.side != 0;
+        let Some(drive) = self.drives.get_mut(idx) else {
+            return;
+        };
+        let cylinder = drive.cylinder;
+        if let Some(bridge) = drive.bridge.as_mut() {
+            if bridge_diag() {
+                info!(
+                    "floppybridge.df{idx} head to cylinder {cylinder} side {} (drive at {})",
+                    u8::from(side),
+                    bridge.current_cylinder(),
+                );
+            }
+            bridge.seek(cylinder, side);
+        }
+    }
+
+    /// Notice a disk swapped by hand in a bridged drive. Unlike an image, the
+    /// medium can change without the emulator being told, so the frontend
+    /// polls this (once a frame is ample) to raise the change line.
+    #[cfg(feature = "floppybridge")]
+    pub fn poll_bridge_media(&mut self) {
+        for (idx, drive) in self.drives.iter_mut().enumerate() {
+            let Some(bridge) = drive.bridge.as_mut() else {
+                continue;
+            };
+            // An interface pulled out mid-session stops answering rather than
+            // reporting anything useful, and the guest just sees a drive that
+            // has gone quiet. Say it once, so the reason is in the log.
+            let working = bridge.is_working();
+            if !working && !drive.bridge_reported_failed {
+                warn!(
+                    "floppy.df{idx} the physical drive's interface has stopped responding \
+                     (unplugged?); this drive will not read or write until it is \
+                     reconnected and the machine restarted"
+                );
+            }
+            drive.bridge_reported_failed = !working;
+            let changed = bridge.take_disk_changed();
+            let had_media = drive.bridge_media;
+            drive.bridge_media = bridge.disk_in_drive();
+            // A disk going in or coming out of a real drive is the one media
+            // change nothing in the emulator asked for, so it is worth saying
+            // as plainly as an image being inserted.
+            if drive.bridge_media != had_media {
+                if drive.bridge_media {
+                    info!("floppy.df{idx} disk inserted (physical drive)");
+                } else {
+                    info!("floppy.df{idx} disk ejected (physical drive)");
+                }
+            }
+            // Sample the drive before the borrow is needed elsewhere. The
+            // driver keeps the tab's last reading and hands it back whatever
+            // the motor is doing, so this is good with the platter stopped --
+            // which is just as well, because a drive the guest is not actively
+            // reading is stopped nearly all the time.
+            let sensed_tab = bridge.write_protected();
+            if changed {
+                drive.cached_track = None;
+                drive.cached = CachedTrack::default();
+                drive.bridge_filler_track = None;
+                drive.bridge_tracks.clear();
+                drive.set_disk_change(true);
+                self.idle_cache = false;
+            }
+            drive.bridge_tab_write_protected = sensed_tab;
+            // With no disk in the drive there is no tab to have an opinion,
+            // and announcing one reads as though something were in there.
+            // The configured protection still stands on its own.
+            let write_protected = drive.bridge_write_protected
+                || (drive.bridge_media && drive.bridge_tab_write_protected);
+            if write_protected != drive.write_protected_target {
+                // Which of the two protections is in force decides whether
+                // opening the tab will help, so name it rather than just
+                // reporting the outcome.
+                if write_protected {
+                    let reason = if drive.bridge_write_protected {
+                        "the configuration"
+                    } else {
+                        "the disk's tab"
+                    };
+                    info!("floppy.df{idx} disk is write-protected by {reason} (physical drive)");
+                } else {
+                    info!("floppy.df{idx} disk is writable (physical drive)");
+                }
+                drive.set_write_protected(write_protected);
+                self.idle_cache = false;
+            }
+        }
+    }
+
     pub fn reset_external_drives(&mut self) {
         self.idle_cache = false;
         for drive in self.drives.iter_mut().skip(1) {
@@ -558,6 +742,7 @@ impl FloppyController {
         // DSKSIDE is active-low on Amiga drives: 0 selects the upper
         // head, which maps to odd ADF tracks. Lower/even is selected
         // when the bit is high.
+        let side_changed = self.side != if val & CIAB_DSKSIDE == 0 { 1 } else { 0 };
         self.side = if val & CIAB_DSKSIDE == 0 { 1 } else { 0 };
 
         for idx in 0..self.drives.len() {
@@ -595,8 +780,16 @@ impl FloppyController {
                 // outward pulses with the /TRK0 sensor at cylinder 0
                 // (a silent poll, which NoClick patches rely on), and
                 // pulses faster than the mechanism move nothing.
-                if stepper_fired {
+                // A real drive on a bridge makes its own noise across the
+                // room; synthesizing a second click on top would be a drive
+                // heard twice. Per drive, so an image in the next bay still
+                // clicks as it should.
+                if stepper_fired && !self.drives[idx].is_bridged() {
                     self.sound_steps = self.sound_steps.saturating_add(1);
+                }
+                #[cfg(feature = "floppybridge")]
+                if stepper_fired {
+                    self.sync_bridge_head(idx);
                 }
             }
 
@@ -605,8 +798,14 @@ impl FloppyController {
             }
         }
         if let Some(idx) = self.selected_drive() {
+            #[cfg(feature = "floppybridge")]
+            if side_changed {
+                self.sync_bridge_head(idx);
+            }
             self.ensure_track(idx, self.track_for_drive(idx));
         }
+        #[cfg(not(feature = "floppybridge"))]
+        let _ = side_changed;
     }
 
     pub fn set_dskpt_high(&mut self, val: u16) {
@@ -1231,7 +1430,7 @@ impl FloppyController {
         }
         let idx = self.selected_drive()?;
         let drive = &self.drives[idx];
-        if drive.image.is_none() || !drive.motor_on {
+        if !drive.has_media() || !drive.motor_on {
             return None;
         }
         let rev = drive.cur_rev()?;
@@ -1266,6 +1465,11 @@ impl FloppyController {
     /// ramp instead of switching.
     pub fn motor_spin_levels(&self) -> [f32; 4] {
         std::array::from_fn(|idx| {
+            // Silent for a bridged drive: the real platter is spinning in the
+            // room, so a synthesized motor on top would double it.
+            if self.drives[idx].is_bridged() {
+                return 0.0;
+            }
             self.drives[idx].motor_cck.min(MOTOR_READY_CCK) as f32 / MOTOR_READY_CCK as f32
         })
     }
@@ -1301,11 +1505,11 @@ impl FloppyController {
         // TODO: media-less and motor-off drives should also arm and idle
         // (real Paula would wait for sync forever); they keep the instant
         // completion until the software relying on it is characterized.
-        if self.drives[idx].image.is_none() || !self.drives[idx].motor_on {
+        if !self.drives[idx].has_media() || !self.drives[idx].motor_on {
             if crate::envcfg::flag("COPPERLINE_DIAG_DISK") {
                 log::info!(
-                    "disk-dma refused: df{idx} image={} motor_on={} motor_cck={}",
-                    self.drives[idx].image.is_some(),
+                    "disk-dma refused: df{idx} media={} motor_on={} motor_cck={}",
+                    self.drives[idx].has_media(),
                     self.drives[idx].motor_on,
                     self.drives[idx].motor_cck,
                 );
@@ -1455,6 +1659,72 @@ impl FloppyController {
             return;
         }
         let drive = &mut self.drives[drive_idx];
+
+        // A bridged drive writes the MFM straight back to the real disk, laid
+        // down from the head position the guest started writing at -- the same
+        // place a real drive would have begun putting cells on the platter.
+        // Read before the drive is borrowed to write through, so the guard
+        // below and the /WPRO line the guest was given are the same two facts.
+        #[cfg(feature = "floppybridge")]
+        let (config_protected, tab_protected) = (
+            drive.bridge_write_protected,
+            drive.bridge_tab_write_protected,
+        );
+        #[cfg(feature = "floppybridge")]
+        if let Some(bridge) = drive.bridge.as_mut() {
+            // Two separate protections, and this is the last point either can
+            // stop physical media being written. The emulated /WPRO line has
+            // already told the guest not to try -- but a program that writes
+            // anyway, or a guest that ignores the line, must not reach the
+            // platter, so both are checked here rather than trusted to the
+            // machine above.
+            //
+            // Deliberately the same two the /WPRO line is built from, rather
+            // than asking the drive again: a second reading taken here can
+            // disagree with the one the guest was given, and then a disk the
+            // machine calls protected is the one being written to.
+            if config_protected {
+                warn!(
+                    "floppy.df{drive_idx} write ignored: this drive is write-protected in the \
+                     configuration (write_protected = false to allow writing to a real disk)"
+                );
+                return;
+            }
+            if tab_protected {
+                warn!("floppy.df{drive_idx} write ignored: the disk's own tab is closed");
+                return;
+            }
+            let cylinder = (track / SIDES) as u8;
+            let side = !track.is_multiple_of(SIDES);
+            let start_bit = write_start_word * 16 + write_start_bit as usize;
+            if bridge.write_track(cylinder, side, write_words, start_bit) {
+                if bridge_diag() {
+                    info!(
+                        "floppybridge.df{drive_idx} track {track} (cyl {cylinder} side {}) \
+                         written: {} words from bit {start_bit}, queued to the platter",
+                        u8::from(side),
+                        write_words.len(),
+                    );
+                } else {
+                    debug!(
+                        "floppy.df{drive_idx} bridge wrote {} words to track {track} \
+                         at bit {start_bit}",
+                        write_words.len()
+                    );
+                }
+            } else {
+                warn!("floppy.df{drive_idx} bridge write of track {track} was rejected");
+            }
+            // Re-read on the next access: what is on the platter now is
+            // whatever the drive actually managed to lay down, which is not
+            // necessarily what was asked for.
+            drive.cached_track = None;
+            if let Some(known) = drive.bridge_tracks.get_mut(track) {
+                *known = None;
+            }
+            return;
+        }
+
         let Some(image) = drive.image.as_mut() else {
             return;
         };
@@ -1555,11 +1825,198 @@ impl FloppyController {
     }
 
     fn ensure_track(&mut self, idx: usize, track: usize) {
-        let drive = &mut self.drives[idx];
-        if drive.cached_track == Some(track) {
+        // A physical drive has one head, and it is where the guest's stepper
+        // put it. `tick` asks for the DMA's track as well as the head's, and
+        // when a transfer outlives a step those two disagree -- so asking for
+        // both drags the real head between them, tick after tick, reading
+        // nothing useful either way. Only fetch what the head is over; the
+        // transfer gets what is passing under it, as it would on hardware.
+        #[cfg(feature = "floppybridge")]
+        if self.drives[idx].is_bridged() && track != self.track_for_drive(idx) {
             return;
         }
-        drive.cached = CachedTrack::default();
+        let drive = &mut self.drives[idx];
+        // A revolution the head has already been all the way round is spent:
+        // a physical one that did not start at the index cannot be turned
+        // again, because its two ends are a revolution apart in time and the
+        // join between them falls inside a sector. Fall through and fetch the
+        // recording that followed it instead.
+        #[cfg(feature = "floppybridge")]
+        let spent = drive.bridge_rev_spent;
+        #[cfg(not(feature = "floppybridge"))]
+        let spent = false;
+        if drive.cached_track == Some(track) && !spent {
+            return;
+        }
+        // Filler already turning under the head for this very track stays: it
+        // is what keeps the platter moving while the capture finishes, and
+        // rebuilding it every tick would be the opposite of cheap.
+        #[cfg(feature = "floppybridge")]
+        let keep_filler = drive.bridge_filler_track == Some(track);
+        #[cfg(not(feature = "floppybridge"))]
+        let keep_filler = false;
+        if !keep_filler {
+            drive.cached = CachedTrack::default();
+        }
+
+        // A bridged drive reads the track off the real disk instead. The head
+        // is already on its way: it followed the emulated stepper when the
+        // guest moved it (see `sync_bridge_head`), and the driver names the
+        // track it wants again here in case nothing stepped at all.
+        #[cfg(feature = "floppybridge")]
+        if drive.bridge.is_some() {
+            // A real drive only reads while the platter is turning, and drive
+            // select alone gets us here with the motor still off. Leave the
+            // track uncached until it is up to speed, which retries.
+            if !drive.motor_on || drive.motor_cck < MOTOR_READY_CCK {
+                return;
+            }
+            // Read off this disk before? Hand back what it said then. The
+            // platter cannot have changed underneath without the change line
+            // saying so or a write going through, and both empty this, so
+            // another rotation would only fetch the same bits again. A spent
+            // revolution is the exception: handing that back is precisely the
+            // same recording over again, which is what it may not be.
+            if let Some(known) = drive
+                .bridge_tracks
+                .get(track)
+                .filter(|_| !spent)
+                .and_then(Option::as_ref)
+            {
+                drive.cached = known.clone();
+                drive.cached_track = Some(track);
+                drive.bridge_filler_track = None;
+                drive.bridge_wait_since_cck = 0;
+                drive.bridge_attempts = 0;
+                drive.clamp_head();
+                return;
+            }
+            // This runs from `tick`, so a track that is not ready would
+            // otherwise be asked for millions of times a second. The driver
+            // needs a whole revolution -- around 200ms -- to capture one, so
+            // pausing a millisecond between attempts costs nothing measurable
+            // and leaves the emulated machine to get on with it.
+            if drive.elapsed_cck < drive.bridge_poll_cck {
+                return;
+            }
+            let cylinder = (track / SIDES) as u8;
+            let side = !track.is_multiple_of(SIDES);
+            // Time this track, not "everything since the last success". A seek
+            // walks through every cylinder on the way and asks for each in
+            // turn, so a timer that only reset on a completed read counted the
+            // whole journey against whichever track happened to end it.
+            if drive.bridge_wait_since_cck == 0 || drive.bridge_wait_track != Some(track) {
+                drive.bridge_wait_since_cck = drive.elapsed_cck.max(1);
+                drive.bridge_wait_track = Some(track);
+                drive.bridge_attempts = 0;
+            }
+            drive.bridge_attempts = drive.bridge_attempts.saturating_add(1);
+            let bridge = drive.bridge.as_mut().expect("checked above");
+            if spent {
+                bridge.switch_buffer(side);
+            }
+            let previous = spent.then(|| drive.cached.revs.first().map(|r| r.words.clone()));
+            let bridge = drive.bridge.as_mut().expect("checked above");
+            if let Some((words, bits)) = bridge
+                .read_track(cylinder, side)
+                // Retiring a recording only promotes the next one if the driver
+                // has finished capturing it. Ask too soon and the same
+                // revolution comes back, and running the head into it again is
+                // the splice the whole exercise is meant to avoid -- a sector
+                // the guest has to retry. Wait for one that is genuinely new.
+                .filter(|(words, _)| previous.flatten().is_none_or(|p| p != *words))
+            {
+                // The bridge hands back one whole revolution as a packed MFM
+                // stream plus the bit it wrapped at, which is what TrackRev
+                // holds. Because it is a real revolution, fitting it to one
+                // rotation gives the disk's own data rate: a slightly long or
+                // short track -- a drive running off-speed -- stays
+                // self-consistent, exactly as a captured image does.
+                let word_cck = Self::word_cck_for_track_words(words.len());
+                // How long the drive took, and how many times it had to be
+                // asked, is what separates a disk the head cannot read from an
+                // interface that is slow: a healthy DD track is one revolution,
+                // so about 200ms. Worth an info line when diagnosing a drive,
+                // and debug otherwise.
+                let waited_ms = drive
+                    .elapsed_cck
+                    .saturating_sub(drive.bridge_wait_since_cck)
+                    * 1000
+                    / PAULA_CLOCK_HZ as u64;
+                log::log!(
+                    if bridge_diag() {
+                        log::Level::Info
+                    } else {
+                        log::Level::Debug
+                    },
+                    "floppybridge.df{idx} track {track} (cyl {cylinder} side {}) read: \
+                     {bits} bits, {} words, {waited_ms}ms over {} attempt{}, \
+                     {word_cck} cck/word",
+                    u8::from(side),
+                    words.len(),
+                    drive.bridge_attempts,
+                    if drive.bridge_attempts == 1 { "" } else { "s" },
+                );
+                drive.bridge_wait_since_cck = 0;
+                drive.bridge_attempts = 0;
+                drive.cached.revs = vec![TrackRev::new(words, bits, word_cck)];
+                drive.bridge_rev_spent = false;
+                drive.cached_track = Some(track);
+                drive.bridge_filler_track = None;
+                if drive.bridge_tracks.len() <= track {
+                    drive.bridge_tracks.resize(track + 1, None);
+                }
+                drive.bridge_tracks[track] = Some(drive.cached.clone());
+                // A track that read is proof of a disk, whatever the sense line
+                // says a moment later.
+                drive.bridge_media = true;
+                drive.clamp_head();
+            } else {
+                // Leave the track uncached so the next access tries again. A
+                // read comes back empty while the platter is still coming up to
+                // speed, or before the driver has captured a revolution --
+                // transient states a real drive simply retries through.
+                // Caching that would wedge the drive on a disk that is there.
+                drive.bridge_poll_cck = drive.elapsed_cck + BRIDGE_POLL_INTERVAL_CCK;
+                if bridge_diag() && drive.bridge_attempts == 1 {
+                    info!(
+                        "floppybridge.df{idx} waiting for track {track} (cyl {cylinder} side {}) \
+                         [ready={} disk={} motor={} at_cyl={}]",
+                        u8::from(side),
+                        bridge.is_ready(),
+                        bridge.disk_in_drive(),
+                        bridge.motor_running(),
+                        bridge.current_cylinder(),
+                    );
+                }
+                trace!(
+                    "floppy.df{idx} bridge: track {track} not ready, will retry \
+                     (ready={} disk={} motor={} at_cyl={} want_cyl={} working={})",
+                    bridge.is_ready(),
+                    bridge.disk_in_drive(),
+                    bridge.motor_running(),
+                    bridge.current_cylinder(),
+                    cylinder,
+                    bridge.is_working(),
+                );
+                // Keep the head over something. Stopping the platter until the
+                // capture lands makes the guest pay the capture and then its
+                // own rotational wait one after the other; turning over filler
+                // means the two overlap, which is how a drive that has data
+                // the moment it arrives behaves.
+                if drive.bridge_filler_track != Some(track) {
+                    let nominal = encoded_track_words();
+                    drive.cached.revs = vec![TrackRev::filler(
+                        nominal * 16,
+                        Self::word_cck_for_track_words(nominal),
+                    )];
+                    drive.bridge_filler_track = Some(track);
+                    drive.clamp_head();
+                }
+            }
+            return;
+        }
+
         if let Some(image) = drive.image.as_ref() {
             if let Some(stream) = image.track_stream(track) {
                 drive.cached.revs = stream.revs;
@@ -1603,6 +2060,84 @@ impl FloppyController {
 #[derive(serde::Serialize, serde::Deserialize)]
 struct FloppyDrive {
     image: Option<FloppyImage>,
+    /// A real drive standing in for the image, over a DrawBridge/Greaseweazle/
+    /// Supercard Pro. Mutually exclusive with `image`: whichever is present
+    /// supplies the track under the head.
+    ///
+    /// Skipped by the save-state serialiser because a physical disk cannot be
+    /// snapshotted -- a state saved with a bridge attached reloads as an empty
+    /// drive, which is also why a bridged run is not reproducible.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge: Option<crate::floppybridge::Bridge>,
+    /// Last known answer to "is there a disk in the real drive", refreshed
+    /// deliberately rather than polled per status read (see `has_media`).
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_media: bool,
+    /// The config's own write protection for a bridged drive, held so the
+    /// live tab state can be re-combined with it as the drive is polled.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_write_protected: bool,
+    /// The disk's own write-protect tab, refreshed each time the drive is
+    /// polled. The driver keeps the last reading and hands it back whatever
+    /// the motor is doing, so this is good with the platter stopped -- which
+    /// is most of the time. Both the /WPRO line the guest sees and the guard
+    /// on the write itself come from here, so the two cannot disagree.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_tab_write_protected: bool,
+    /// `elapsed_cck` before which not to ask the bridge for a track again,
+    /// after it said it had none ready.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_poll_cck: u64,
+    /// Whether the interface going quiet has already been reported, so an
+    /// unplugged drive says so once rather than once a frame.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_reported_failed: bool,
+    /// The track `cached` is holding filler for, while the interface captures
+    /// it. `None` once the real revolution lands, so it is never mistaken for
+    /// data and the cache is not rebuilt on every tick.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_filler_track: Option<usize>,
+    /// Revolutions already captured from the disk in a physical drive, by
+    /// track.
+    ///
+    /// Capturing one costs a rotation of the platter -- about 200ms -- and the
+    /// guest revisits tracks constantly: booting Workbench 1.3 reads 63
+    /// distinct tracks 189 times, one of them fourteen times over. Keeping
+    /// what has already been read turns every return trip into a memory copy.
+    /// The whole disk is only a couple of megabytes, so nothing is evicted;
+    /// what does empty it is the disk changing or a track being written, since
+    /// those are the only ways what is on the platter stops matching. A drive
+    /// whose captures are not index-aligned reads past this once its
+    /// revolution is spent -- see [`Self::bridge_rev_spent`].
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_tracks: Vec<Option<CachedTrack>>,
+    /// Which track [`Self::bridge_wait_since_cck`] is timing.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_wait_track: Option<usize>,
+    /// The revolution in hand has been turned all the way round. Only ever set
+    /// for a physical drive whose captures do not start at the index: those
+    /// cannot be turned twice, so the next one has to be fetched.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_rev_spent: bool,
+    /// `elapsed_cck` when the drive was first asked for the track it is
+    /// currently working on, and how many times it has been asked since. Only
+    /// read to report how long a track took; 0 means "not waiting".
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_wait_since_cck: u64,
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_attempts: u32,
     cylinder: u8,
     motor_on: bool,
     motor_cck: u32,
@@ -1641,7 +2176,31 @@ struct FloppyDrive {
 impl Default for FloppyDrive {
     fn default() -> Self {
         Self {
+            #[cfg(feature = "floppybridge")]
+            bridge_wait_track: None,
+            #[cfg(feature = "floppybridge")]
+            bridge_rev_spent: false,
             image: None,
+            #[cfg(feature = "floppybridge")]
+            bridge: None,
+            #[cfg(feature = "floppybridge")]
+            bridge_media: false,
+            #[cfg(feature = "floppybridge")]
+            bridge_write_protected: true,
+            #[cfg(feature = "floppybridge")]
+            bridge_tab_write_protected: true,
+            #[cfg(feature = "floppybridge")]
+            bridge_poll_cck: 0,
+            #[cfg(feature = "floppybridge")]
+            bridge_reported_failed: false,
+            #[cfg(feature = "floppybridge")]
+            bridge_filler_track: None,
+            #[cfg(feature = "floppybridge")]
+            bridge_tracks: Vec::new(),
+            #[cfg(feature = "floppybridge")]
+            bridge_wait_since_cck: 0,
+            #[cfg(feature = "floppybridge")]
+            bridge_attempts: 0,
             cylinder: 0,
             motor_on: false,
             motor_cck: 0,
@@ -1704,8 +2263,37 @@ impl FloppyDrive {
         self.cached = CachedTrack::default();
     }
 
+    /// Whether there is anything under the head: a mounted image, or a real
+    /// disk in a bridged drive. The drive's status lines key off this, so a
+    /// bridge reports empty until a disk is actually inserted, exactly as an
+    /// empty drive does.
+    /// Whether this drive is a real one on a bridge.
+    fn is_bridged(&self) -> bool {
+        #[cfg(feature = "floppybridge")]
+        {
+            self.bridge.is_some()
+        }
+        #[cfg(not(feature = "floppybridge"))]
+        {
+            false
+        }
+    }
+
+    fn has_media(&self) -> bool {
+        #[cfg(feature = "floppybridge")]
+        if self.bridge.is_some() {
+            // Deliberately the cached answer, not a fresh query. This is read
+            // from the drive's status lines constantly, and asking the device
+            // each time lets a momentary false during a seek drop /RDY
+            // mid-transfer, which the guest sees as the disk being yanked out
+            // from under it. Refreshed by poll_bridge_media.
+            return self.bridge_media;
+        }
+        self.image.is_some()
+    }
+
     fn ready(&self) -> bool {
-        self.image.is_some() && self.motor_on && self.motor_cck >= MOTOR_READY_CCK
+        self.has_media() && self.motor_on && self.motor_cck >= MOTOR_READY_CCK
     }
 
     fn rdy_line_asserted(&self) -> bool {
@@ -1766,6 +2354,22 @@ impl FloppyDrive {
         if self.motor_on == on {
             return;
         }
+        // Follow the motor line on the real drive: it has to be spinning
+        // before a track can be read, and parking it when the guest drops
+        // the line keeps the physical drive from running continuously.
+        #[cfg(feature = "floppybridge")]
+        if let Some(bridge) = self.bridge.as_mut() {
+            // The library takes a surface here as well, which it would switch
+            // to. Which one is passed does not matter: every read and write
+            // names the side it wants, so the next track operation sets it
+            // regardless, and the drive itself only has one motor.
+            bridge.set_motor(false, on);
+            // The cached track is deliberately kept across a motor stop. Every
+            // fresh capture starts at a different point of the revolution, so
+            // re-reading shifts the whole track under a guest that is part way
+            // through it; the disk has not changed, so the copy in hand is
+            // still what is on the platter.
+        }
         self.motor_on = on;
         // Disk rotational inertia: a motor-off does not stop the platter
         // instantly. The spin-up accumulator is preserved here and decays
@@ -1780,7 +2384,7 @@ impl FloppyDrive {
     fn step(&mut self, inward: bool) -> bool {
         // The change latch clears on the step PULSE itself (an electrical
         // edge), whether or not the mechanism accepts it.
-        if self.image.is_some() {
+        if self.has_media() {
             self.set_disk_change(false);
         }
         // The stepper ignores pulses spaced closer than the mechanism can
@@ -1980,6 +2584,13 @@ impl FloppyDrive {
         if self.rotation_bit >= bit_len {
             self.rotation_bit = 0;
             self.rotation_rev = (self.rotation_rev + 1) % self.rev_count();
+            // A capture that did not begin at the index is good for exactly one
+            // pass under the head. Mark it done; `ensure_track` replaces it
+            // with the recording that followed rather than turning it again.
+            #[cfg(feature = "floppybridge")]
+            if self.bridge.as_ref().is_some_and(|b| !b.index_aligned()) {
+                self.bridge_rev_spent = true;
+            }
             // A single-word (or shorter) track is too short to raise an index.
             bit_len > 16
         } else {
@@ -2042,6 +2653,24 @@ struct TrackRev {
 }
 
 impl TrackRev {
+    /// A revolution of cells that carry no data, for a physical drive that has
+    /// arrived at a track the interface has not finished capturing.
+    ///
+    /// Solid ones, which is what the hardware reads off unwritten media and
+    /// what the FloppyBridge library itself hands back before a buffer is
+    /// ready. It cannot match a sync word, so nothing is recovered from it --
+    /// the point is only that the platter keeps turning while the capture
+    /// completes, so the guest's own rotational wait overlaps it rather than
+    /// starting afterwards.
+    #[cfg(feature = "floppybridge")]
+    fn filler(bit_len: usize, word_cck: u32) -> Self {
+        Self {
+            words: vec![0xFFFF; bit_len.div_ceil(16)],
+            bit_len,
+            word_cck: word_cck.max(1),
+        }
+    }
+
     fn new(words: Vec<u16>, bit_len: usize, word_cck: u32) -> Self {
         let bit_len = bit_len.min(words.len() * 16);
         Self {
@@ -4000,6 +4629,7 @@ mod tests {
         }
         let path = temp_adz(&adf)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4031,6 +4661,7 @@ mod tests {
         let ext_image = fs::read(&ext_path)?;
         let path = temp_gzip("test.ext.adf.gz", &ext_image)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4069,6 +4700,7 @@ mod tests {
         image.extend_from_slice(&0u32.to_be_bytes());
         fs::write(&path, image)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4098,6 +4730,7 @@ mod tests {
         let first = temp_adf()?;
         let second = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4138,6 +4771,7 @@ mod tests {
         let first = temp_adf()?;
         let second = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4231,6 +4865,7 @@ mod tests {
         let protected = temp_adf()?;
         let writable = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4265,6 +4900,7 @@ mod tests {
     fn cia_status_reflects_write_protect_track0_and_ready() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4291,6 +4927,7 @@ mod tests {
     fn cia_status_ready_line_tracks_motor_spinup_and_off() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4357,6 +4994,7 @@ mod tests {
     fn side_select_maps_lower_head_to_even_adf_tracks() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4544,6 +5182,7 @@ mod tests {
     fn track_zero_line_follows_head_position() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4797,6 +5436,7 @@ mod tests {
     fn dskbytr_byte_valid_tracks_new_rotation_words() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -4837,6 +5477,7 @@ mod tests {
         let raw_words = [0x1234, 0xABCD];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5040,6 +5681,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5082,6 +5724,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5115,6 +5758,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5155,6 +5799,7 @@ mod tests {
         let raw_words = [0x1234, DEFAULT_DSKSYNC];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5204,6 +5849,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5238,6 +5884,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5270,6 +5917,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5315,6 +5963,7 @@ mod tests {
     ) -> Result<(FloppyController, PathBuf)> {
         let path = temp_ext2_raw(raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5481,6 +6130,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: SPEED_TURBO,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5517,6 +6167,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: SPEED_TURBO,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5553,6 +6204,7 @@ mod tests {
             let raw_words = [0x1234, 0x5678];
             let path = temp_ext2_raw(&raw_words)?;
             let cfg = FloppyConfig {
+                bridges: std::array::from_fn(|_| None),
                 speed,
                 drives: [
                     Some(FloppyDriveConfig {
@@ -5584,6 +6236,7 @@ mod tests {
         let raw_words = [0x1234, 0x5678];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5636,6 +6289,7 @@ mod tests {
     fn dsksync_write_latches_current_word_match() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5665,6 +6319,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5696,6 +6351,7 @@ mod tests {
     fn read_dma_sync_irq_does_not_require_wordsync() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5738,6 +6394,7 @@ mod tests {
     fn wordsync_skips_initial_sync_then_transfers_repeated_sync_word() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5789,6 +6446,7 @@ mod tests {
         let raw_words = [0xAA44u16, 0x8955, 0x1234, 0x5678, 0x0000];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5835,6 +6493,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5885,6 +6544,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5931,6 +6591,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -5977,6 +6638,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6018,6 +6680,7 @@ mod tests {
         let track2 = [0xAAAA, 0xBBBB];
         let path = temp_ext2_raw_tracks(&[(0, &track0), (2, &track2)])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6071,6 +6734,7 @@ mod tests {
         let track0 = [0x1111u16, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw_tracks(&[(0, &track0)])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6123,6 +6787,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6166,6 +6831,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6204,6 +6870,7 @@ mod tests {
         let raw_words = [0x1111, DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6249,6 +6916,7 @@ mod tests {
         let raw_words = [DEFAULT_DSKSYNC, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6292,6 +6960,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6332,6 +7001,7 @@ mod tests {
     fn selected_drive_index_pulse_latches_once_per_wrap() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6366,6 +7036,7 @@ mod tests {
     fn selected_drive_index_pulse_has_fixed_width() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6404,6 +7075,7 @@ mod tests {
     fn motor_off_drive_does_not_emit_index_pulse() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6434,6 +7106,7 @@ mod tests {
     fn next_index_pulse_reports_selected_drive_time() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6468,6 +7141,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA, 0x5555, 0xA144];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6499,6 +7173,7 @@ mod tests {
     fn uae_extended_adf_raw_track_preserves_odd_byte_payload() -> Result<()> {
         let path = temp_ext2_track(1, 20, &[0x12, 0x34, 0xA0])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6584,6 +7259,7 @@ mod tests {
         let raw_words: [u16; 4] = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw_revolutions(&raw_words, 32, 2)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6633,6 +7309,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA];
         let path = temp_scp_raw_revolutions(&[&raw_words], 32)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6665,6 +7342,7 @@ mod tests {
     fn scp_flux_decode_resolves_variable_intervals_to_cells() -> Result<()> {
         let path = temp_scp_flux_entries(&[60, 100, 80], 3)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6701,6 +7379,7 @@ mod tests {
         let rev1 = [0x5555, 0xA144];
         let path = temp_scp_raw_revolutions(&[&rev0, &rev1], 32)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6753,6 +7432,7 @@ mod tests {
             SCP_FLAG_INDEX | SCP_FLAG_EXTENDED_MODE,
         )?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6787,6 +7467,7 @@ mod tests {
         fs::write(&path, &image)?;
 
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6819,6 +7500,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA];
         let path = temp_scp_raw_revolutions_with_flags(&[&raw_words], 32, 0)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6859,6 +7541,7 @@ mod tests {
         fs::write(&path, &image)?;
 
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -6960,6 +7643,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7000,6 +7684,7 @@ mod tests {
         let raw_words = [0x4489];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7032,6 +7717,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7074,6 +7760,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7119,6 +7806,7 @@ mod tests {
         track_data[0..BYTES_PER_SECTOR].fill(0x5A);
         let path = temp_ext2_amigados(&track_data)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7153,6 +7841,7 @@ mod tests {
         payload.resize(0x31f0, 0);
         let path = temp_ext2_track(0, (track_data.len() * 8) as u32, &payload)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7212,6 +7901,7 @@ mod tests {
     fn writable_extended_adf_amigados_track_persists_sector_updates() -> Result<()> {
         let path = temp_ext2_amigados(&vec![0u8; SECTORS_PER_TRACK * BYTES_PER_SECTOR])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7278,6 +7968,7 @@ mod tests {
             2,
         )?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7337,6 +8028,7 @@ mod tests {
         let raw_words = [0x4489, 0x2AAA, 0x5555, 0xA144];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7404,6 +8096,7 @@ mod tests {
         let raw_words = [0x0000, 0x0000, 0x0000, 0x0000];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7450,6 +8143,7 @@ mod tests {
         let raw_words = [0x0000, 0x0000];
         let path = temp_ext2_raw_revolutions(&raw_words, 20, 1)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7500,6 +8194,7 @@ mod tests {
     fn writable_extended_adf_raw_track_preserves_partial_word_tail() -> Result<()> {
         let path = temp_ext2_track(1, 20, &[0xFF, 0xFF, 0xF0])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7554,6 +8249,7 @@ mod tests {
         let raw_words = [0xFFFF];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7599,6 +8295,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7644,6 +8341,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7691,6 +8389,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7748,6 +8447,7 @@ mod tests {
         let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
         let path = temp_ext2_raw(&raw_words)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7800,6 +8500,7 @@ mod tests {
         let track2 = [0xFFFF, 0xFFFF];
         let path = temp_ext2_raw_tracks(&[(0, &track0), (2, &track2)])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7852,6 +8553,7 @@ mod tests {
     fn writable_legacy_extended_adf_raw_track_persists_word_stream() -> Result<()> {
         let path = temp_ext1_raw(&[0x4489, 0x1111, 0x2222])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7908,6 +8610,7 @@ mod tests {
     fn writable_legacy_extended_adf_raw_track_overwrites_sync_boundary() -> Result<()> {
         let path = temp_ext1_raw(&[0x4489, 0x1111, 0x2222])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -7958,6 +8661,7 @@ mod tests {
     fn writable_legacy_extended_adf_raw_track_preserves_odd_payload_length() -> Result<()> {
         let path = temp_ext1_raw_payload(0x4489, &[0x12, 0x34, 0xA0])?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -8007,6 +8711,7 @@ mod tests {
     fn write_dma_decodes_and_persists_track() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -8048,6 +8753,7 @@ mod tests {
     fn floppy_turbo_bursts_write_dma_and_persists_track() -> Result<()> {
         let path = temp_adf()?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: SPEED_TURBO,
             drives: [
                 Some(FloppyDriveConfig {
@@ -8188,6 +8894,7 @@ mod tests {
         let path = temp_path("full-track-dma-checksum.adf");
         fs::write(&path, &adf)?;
         let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
@@ -8268,7 +8975,11 @@ mod tests {
             path: adf.clone(),
             write_protected: true,
         });
-        let ctrl = FloppyController::from_config(&FloppyConfig { drives, speed: 100 })?;
+        let ctrl = FloppyController::from_config(&FloppyConfig {
+            drives,
+            bridges: std::array::from_fn(|_| None),
+            speed: 100,
+        })?;
         assert!(ctrl.drive_connected(1));
         assert!(ctrl.disk_inserted(1));
         let _ = fs::remove_file(&adf);

--- a/src/floppybridge/ffi.rs
+++ b/src/floppybridge/ffi.rs
@@ -190,6 +190,10 @@ extern "C" {
     /// successive recordings rather than the same one over again.
     pub(super) fn DRIVER_mfmSwitchBuffer(handle: BridgeDriverHandle, side: bool);
 
+    /// The current track's length in bits -- the wrap point, and the largest
+    /// position `getMFMBit` or a write may name.
+    pub(super) fn DRIVER_maxMFMBitPosition(handle: BridgeDriverHandle) -> c_int;
+
     /// Hand one MFM word to the drive at the rotational position the head
     /// would be passing over, mirroring how a real write lays cells down as
     /// the platter turns.

--- a/src/floppybridge/ffi.rs
+++ b/src/floppybridge/ffi.rs
@@ -27,8 +27,8 @@ pub(super) type BridgeDriverHandle = *mut c_void;
 /// How hard the driver works to stay faithful to the disk's real timing.
 ///
 /// `Fast`, `Compatible` and `Stalling` are all read modes and Copperline
-/// offers all three -- as Normal, Compatible and Stalling, which is what
-/// Amiberry's drive-type list calls them. The first two differ only in whether
+/// offers all three, the first under the name `normal`. The first two differ
+/// only in whether
 /// the capture waits for the index: `Compatible` does, so a revolution begins
 /// where the real one does; `Fast` does not, which is quicker but leaves the
 /// revolution's two ends meeting mid-sector -- handled by reading the following

--- a/src/floppybridge/ffi.rs
+++ b/src/floppybridge/ffi.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Raw bindings to FloppyBridge's C ABI.
+//!
+//! FloppyBridge (<https://amiga.robsmithdev.co.uk/winuae>) is Rob Smith's
+//! driver for talking to a physical floppy drive through a DrawBridge, a
+//! Greaseweazle, or a Supercard Pro. It exposes a flat C ABI in two halves:
+//! `BRIDGE_*` manages the bridge and its drivers, and `DRIVER_*` drives one
+//! open device through an opaque handle. Several handles
+//! can be open at once, which is what lets each Amiga drive have its own.
+//!
+//! The implementation is vendored in `vendor/floppybridge` and compiled into
+//! the emulator by `build.rs`, so these are ordinary linked calls. The
+//! signatures are reproduced from upstream's `floppybridge_common.h`, which it
+//! releases into the public domain (Unlicense) precisely so other projects can
+//! bind to them.
+//!
+//! Everything in this file is `unsafe` by nature: the signatures must match the
+//! C side exactly or calls are undefined behaviour. The safe wrapper in the
+//! parent module is the only thing the rest of Copperline talks to.
+
+use std::ffi::{c_char, c_int, c_uint, c_void};
+
+/// An open device. Opaque to us; `DRIVER_*` calls carry it back to the library.
+pub(super) type BridgeDriverHandle = *mut c_void;
+
+/// How hard the driver works to stay faithful to the disk's real timing.
+///
+/// `Fast`, `Compatible` and `Stalling` are all read modes and Copperline
+/// offers all three -- as Normal, Compatible and Stalling, which is what
+/// Amiberry's drive-type list calls them. The first two differ only in whether
+/// the capture waits for the index: `Compatible` does, so a revolution begins
+/// where the real one does; `Fast` does not, which is quicker but leaves the
+/// revolution's two ends meeting mid-sector -- handled by reading the following
+/// recording rather than looping the same one. `TurboAmigaDos` is not a read
+/// mode at all, answering AmigaDOS calls instead of the disk, and is never
+/// asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+pub enum BridgeMode {
+    Fast = 0,
+    #[default]
+    Compatible = 1,
+    TurboAmigaDos = 2,
+    Stalling = 3,
+}
+
+/// Whether to force a density rather than sensing it from the disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+pub enum BridgeDensityMode {
+    #[default]
+    Auto = 0,
+    DdOnly = 1,
+    HdOnly = 2,
+}
+
+/// Which drive on the cable the interface should select. The `DriveA`/`DriveB`
+/// pair is the IBM PC cable convention; `Drive0`..`Drive3` are Shugart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+pub enum DriveSelection {
+    #[default]
+    DriveA = 0,
+    DriveB = 1,
+    Drive0 = 2,
+    Drive1 = 3,
+    Drive2 = 4,
+    Drive3 = 5,
+}
+
+/// What a driver supports beyond the common set, as a bitmask in
+/// [`BridgeDriverRaw::config_options`]. Used to grey the options a given
+/// interface cannot honour.
+pub mod config_option {
+    pub const AUTO_CACHE: u32 = 0x01;
+    pub const COM_PORT: u32 = 0x02;
+    pub const AUTO_DETECT_COMPORT: u32 = 0x04;
+    pub const DRIVE_AB_CABLE: u32 = 0x08;
+    pub const SMART_SPEED: u32 = 0x10;
+    pub const SUPPORTS_SHUGART: u32 = 0x20;
+}
+
+/// Static description of one driver (DrawBridge, Greaseweazle, ...). The
+/// pointers belong to the library and stay valid while it is loaded.
+#[repr(C)]
+pub(super) struct BridgeDriverRaw {
+    pub name: *const c_char,
+    pub url: *const c_char,
+    pub manufacturer: *const c_char,
+    pub driver_author: *const c_char,
+    pub config_options: c_uint,
+}
+
+/// Version and update information for the library itself.
+#[repr(C)]
+pub(super) struct BridgeAboutRaw {
+    pub about: *const c_char,
+    pub url: *const c_char,
+    pub major_version: c_uint,
+    pub minor_version: c_uint,
+    pub is_beta: c_uint,
+    pub is_update_available: c_uint,
+    pub update_major_version: c_uint,
+    pub update_minor_version: c_uint,
+}
+
+// The bridge's exported entry points.
+//
+// These are compiled into the emulator from `vendor/floppybridge`, not loaded
+// from anywhere, so they link like any other native call. Upstream declares
+// them `extern "C"` (`_cdecl` on Windows, the platform default elsewhere),
+// which is what Rust's `extern "C"` means on every target Copperline builds
+// for.
+//
+// Only the calls Copperline makes are declared. The two Windows-only dialog
+// entry points are deliberately absent, and are compiled out of the vendored
+// sources entirely: bridges are configured through Copperline's own launcher
+// and config file on every platform.
+#[allow(non_snake_case)]
+extern "C" {
+    // --- library ---
+    pub(super) fn BRIDGE_About(allow_check_for_updates: bool, output: *mut *mut BridgeAboutRaw);
+    pub(super) fn BRIDGE_NumDrivers() -> c_uint;
+    pub(super) fn BRIDGE_GetDriverInfo(index: c_uint, out: *mut *mut BridgeDriverRaw) -> bool;
+    pub(super) fn BRIDGE_EnumComports(output: *mut c_char, size: *mut c_uint) -> bool;
+
+    // --- lifecycle ---
+    /// Create from a driver index directly. Preferred over synthesizing a
+    /// config string, whose field layout is upstream's private business.
+    pub(super) fn BRIDGE_CreateDriver(index: c_uint, out: *mut BridgeDriverHandle) -> bool;
+    pub(super) fn BRIDGE_Open(handle: BridgeDriverHandle, error: *mut *mut c_char) -> bool;
+    pub(super) fn BRIDGE_Close(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn BRIDGE_FreeDriver(handle: BridgeDriverHandle) -> bool;
+
+    // --- per-driver settings ---
+    pub(super) fn BRIDGE_DriverSetMode(handle: BridgeDriverHandle, mode: u8) -> bool;
+    pub(super) fn BRIDGE_DriverSetDensityMode(handle: BridgeDriverHandle, density: u8) -> bool;
+    pub(super) fn BRIDGE_DriverSetCurrentComPort(
+        handle: BridgeDriverHandle,
+        port: *mut c_char,
+    ) -> bool;
+    pub(super) fn BRIDGE_DriverSetAutoDetectComPort(
+        handle: BridgeDriverHandle,
+        auto_detect: bool,
+    ) -> bool;
+    pub(super) fn BRIDGE_DriverSetCable2(handle: BridgeDriverHandle, drive: u8) -> bool;
+    pub(super) fn BRIDGE_DriverSetSmartSpeedEnabled(
+        handle: BridgeDriverHandle,
+        enabled: bool,
+    ) -> bool;
+    pub(super) fn BRIDGE_DriverSetAutoCache(handle: BridgeDriverHandle, enabled: bool) -> bool;
+
+    // --- drive state ---
+    pub(super) fn DRIVER_isStillWorking(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn DRIVER_isReady(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn DRIVER_isDiskInDrive(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn DRIVER_hasDiskChanged(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn DRIVER_isWriteProtected(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn DRIVER_getMaxCylinder(handle: BridgeDriverHandle) -> u8;
+    pub(super) fn DRIVER_getCurrentCylinderNumber(handle: BridgeDriverHandle) -> u8;
+    pub(super) fn DRIVER_gotoCylinder(handle: BridgeDriverHandle, cylinder: c_int, side: bool);
+    pub(super) fn DRIVER_setMotorStatus(handle: BridgeDriverHandle, side: bool, on: bool);
+    pub(super) fn DRIVER_isMotorRunning(handle: BridgeDriverHandle) -> bool;
+    pub(super) fn DRIVER_setSurface(handle: BridgeDriverHandle, side: bool);
+    pub(super) fn DRIVER_getDriveTypeID(handle: BridgeDriverHandle) -> u8;
+
+    /// Copy the whole live revolution of a track out in one call: side,
+    /// cylinder, whether to resync to the index (which the library ignores
+    /// here -- the capture mode decides it), the buffer's size in bytes, and
+    /// the buffer. The MFM lands packed MSB-first, and the return is the
+    /// revolution's length in bits, or 0 when the driver has not finished
+    /// capturing one yet.
+    ///
+    /// The driver reads the disk continuously in the background, so this never
+    /// waits for the platter -- with one exception, the `Stalling` bridge mode,
+    /// whose whole purpose is to hold the caller until data arrives.
+    pub(super) fn DRIVER_getTrack(
+        handle: BridgeDriverHandle,
+        side: bool,
+        cylinder: c_uint,
+        resync: bool,
+        buffer_bytes: c_int,
+        buffer: *mut c_void,
+    ) -> c_int;
+
+    /// Retire the revolution just read and promote the next recording of the
+    /// same track. Upstream calls this when a full revolution has been
+    /// consumed, so a caller reading revolution after revolution gets
+    /// successive recordings rather than the same one over again.
+    pub(super) fn DRIVER_mfmSwitchBuffer(handle: BridgeDriverHandle, side: bool);
+
+    /// Hand one MFM word to the drive at the rotational position the head
+    /// would be passing over, mirroring how a real write lays cells down as
+    /// the platter turns.
+    pub(super) fn DRIVER_writeShortToBuffer(
+        handle: BridgeDriverHandle,
+        side: bool,
+        cylinder: c_uint,
+        data: u16,
+        position: c_int,
+    );
+    /// Commit the words fed so far to the platter. Returns the track's new
+    /// length in bits.
+    pub(super) fn DRIVER_commitWriteBuffer(
+        handle: BridgeDriverHandle,
+        side: bool,
+        cylinder: c_uint,
+    ) -> c_uint;
+}

--- a/src/floppybridge/mod.rs
+++ b/src/floppybridge/mod.rs
@@ -1,0 +1,810 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Real floppy drives, through Rob Smith's FloppyBridge library.
+//!
+//! A *bridge* replaces one Amiga drive's disk image with a physical 3.5"
+//! drive attached over a DrawBridge, a Greaseweazle, or a Supercard Pro. The
+//! emulated machine is unchanged: the bridge only supplies the MFM the head
+//! would be passing over, so Paula, the disk DMA, and trackdisk.device all
+//! behave exactly as they do with an image.
+//!
+//! # How it attaches
+//!
+//! The library reads the disk continuously on its own thread and keeps the
+//! track under the head captured and ready. [`Bridge::read_track`] takes a
+//! whole finished revolution from it in one call, packed MFM plus the length
+//! it wrapped at -- which is the shape a captured revolution already has in
+//! [`crate::floppy`], so the existing rotation, PLL, and sync-word machinery
+//! reads a real disk with no special case in the hot path.
+//!
+//! Nothing here waits on the drive. A track that has not been captured yet
+//! comes back as `None` and the caller asks again, exactly as it already did
+//! while the motor spun up. Blocking instead would stop the emulated Amiga --
+//! CPU, sprites, pointer and all -- every time the head moved, which is the
+//! one thing a real drive never does to a real Amiga.
+//!
+//! Because a revolution is served whole, it has to start where the real one
+//! does. That is why the bridge is opened in the library's `Compatible` mode,
+//! which captures from the index: a stream anchored anywhere else would wrap
+//! in the middle of a sector rather than in the gap between two, and the guest
+//! would see disk errors. Upstream's faster index-less modes suit an emulator
+//! that streams cells continuously off the drive, which this is not.
+//!
+//! Writing goes the same way round: [`Bridge::write_track`] hands the MFM over
+//! a word at a time at the rotational position the head would be passing, as a
+//! real drive lays cells down, and commits it to the platter -- without waiting
+//! for the platter to take it, for the same reason reads do not wait.
+//!
+//! # Where it comes from
+//!
+//! FloppyBridge is compiled into the emulator from `vendor/floppybridge`, so a
+//! build that says it supports a physical drive can actually drive one, with
+//! nothing to download and nothing to install. Upstream ships it as a shared
+//! library to be loaded at run time; Copperline links it instead, because a
+//! user should not have to fetch a second file to use a feature the build
+//! claims to have.
+//!
+//! Keeping upstream current is a maintainer's job and close to a wholesale
+//! copy: `vendor/floppybridge/README.md` records the commit vendored and the
+//! handful of local changes, all of them Windows or Linux build differences
+//! rather than behaviour.
+//!
+//! Turning the `floppybridge` Cargo feature off, which is on by default,
+//! compiles all of this out -- the C++ included.
+//!
+//! # Determinism
+//!
+//! A real drive spins in wall-clock time and the disk under it can be swapped
+//! by hand, so a run using a bridge is *not* reproducible: save states cannot
+//! capture the medium, and a replayed input recording will not line up. Nor can
+//! the machine be run faster than the platter turns, so a bridged machine is
+//! paced to wall-clock time even in a headless run that would otherwise be
+//! unthrottled -- see `main`. As with NAT networking, the constraint is
+//! documented rather than enforced by a flag: the emulated core is as
+//! deterministic as ever, it is the disk under it that is not.
+
+mod ffi;
+
+use std::ffi::{c_char, c_int, c_uint, c_void, CStr, CString};
+use std::sync::{Mutex, OnceLock};
+
+use log::warn;
+
+pub use ffi::{config_option, BridgeDensityMode, BridgeMode, DriveSelection};
+
+/// The largest string the library will write into a caller-provided buffer.
+/// Upstream's own `BRIDGE_STRING_MAX_LENGTH`.
+const STRING_MAX: usize = 255;
+
+/// Bytes to allow for one captured revolution. Upstream sizes its own track
+/// buffers at `MFM_BUFFER_MAX_TRACK_LENGTH` (0x3A00 * 2), so nothing longer
+/// than this can come back: a DD revolution is around 12.7K of MFM and an HD
+/// one twice that, leaving plenty of room for a drive running off-speed.
+const MAX_TRACK_BYTES: usize = 0x3A00 * 2;
+
+/// Serialises calls into the library itself.
+///
+/// The `BRIDGE_*` half works through state the library owns process-wide: the
+/// port scan fills a file-scope vector on the sizing call and reads it back on
+/// the next, and the driver query hands out pointers into storage that belongs
+/// to the library.
+/// None of that survives two threads at once -- reliably enough that the test
+/// suite aborted with SIGABRT whenever two of these ran together -- and the
+/// launcher does exactly that, asking what is plugged in while a machine is
+/// running.
+///
+/// Per-drive `DRIVER_*` calls are deliberately not covered: each belongs to one
+/// [`Bridge`] owned by the emulation thread, and the library serialises its own
+/// worker behind them. Only [`Bridge::open`] takes this, because creating a
+/// driver goes through the `BRIDGE_*` half.
+static LIB_LOCK: Mutex<()> = Mutex::new(());
+
+/// Take the library lock, ignoring poisoning: a panic in another thread's
+/// query leaves the library no more broken than it already was, and refusing
+/// to look at the hardware ever again would be the worse failure.
+fn lib_lock() -> std::sync::MutexGuard<'static, ()> {
+    LIB_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Copy a bridge-owned C string. The pointers handed back belong to the bridge
+/// and several are documented as invalid after the next call, so everything
+/// crossing into Copperline is copied immediately.
+///
+/// # Safety
+/// `ptr` must be null or a valid NUL-terminated string.
+unsafe fn owned_string(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+}
+
+/// The bridge's version, as `(major, minor)`.
+///
+/// Asked once and remembered: what is linked in cannot change under us, and
+/// the launcher puts this in a heading.
+pub fn version() -> Option<(u32, u32)> {
+    static VERSION: OnceLock<Option<(u32, u32)>> = OnceLock::new();
+    *VERSION.get_or_init(|| {
+        let _guard = lib_lock();
+        let mut out: *mut ffi::BridgeAboutRaw = std::ptr::null_mut();
+        // `false`: never let the bridge phone home for an update check.
+        unsafe { ffi::BRIDGE_About(false, &mut out) };
+        if out.is_null() {
+            return None;
+        }
+        let about = unsafe { &*out };
+        Some((about.major_version as u32, about.minor_version as u32))
+    })
+}
+
+/// The physical drive an interface reports being attached to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriveType {
+    /// A plain 3.5" double-density drive: the normal Amiga case.
+    Dd35,
+    /// A 3.5" high-density drive, which can also read DD media.
+    Dd35Hd,
+    /// A 5.25" single-density drive.
+    Sd525,
+}
+
+/// One driver the library offers, by index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverInfo {
+    pub index: u32,
+    pub name: String,
+    pub manufacturer: String,
+    pub url: String,
+    /// Bitmask of [`config_option`] flags this driver honours.
+    pub config_options: u32,
+}
+
+impl DriverInfo {
+    pub fn supports(&self, option: u32) -> bool {
+        self.config_options & option != 0
+    }
+}
+
+/// Every driver the loaded library offers (DrawBridge, Greaseweazle, ...).
+/// Empty when no library is loaded.
+pub fn drivers() -> Vec<DriverInfo> {
+    let _guard = lib_lock();
+    let count = unsafe { ffi::BRIDGE_NumDrivers() };
+    (0..count)
+        .filter_map(|index| {
+            let mut raw: *mut ffi::BridgeDriverRaw = std::ptr::null_mut();
+            if !unsafe { ffi::BRIDGE_GetDriverInfo(index, &mut raw) } || raw.is_null() {
+                return None;
+            }
+            let d = unsafe { &*raw };
+            Some(DriverInfo {
+                index,
+                name: unsafe { owned_string(d.name) },
+                manufacturer: unsafe { owned_string(d.manufacturer) },
+                url: unsafe { owned_string(d.url) },
+                config_options: d.config_options as u32,
+            })
+        })
+        .collect()
+}
+
+/// Whether an interface the library recognises is plugged in right now.
+///
+/// The port scan below only reports ports the library believes carry a
+/// supported board, so an empty list means there is nothing to drive a real
+/// disk with. Scanning walks the host's serial bus, so this is sampled at
+/// deliberate moments -- a bay being switched over to a real drive -- rather
+/// than every frame.
+pub fn interface_connected() -> bool {
+    let _guard = lib_lock();
+    !com_ports_locked().is_empty()
+}
+
+/// Serial ports the library can see, for the drivers that need one named.
+pub fn com_ports() -> Vec<String> {
+    let _guard = lib_lock();
+    com_ports_locked()
+}
+
+/// The scan itself. Split out because the caller may already hold the lock,
+/// which is not re-entrant.
+fn com_ports_locked() -> Vec<String> {
+    // Upstream fills a caller-provided buffer with NUL-separated names and
+    // reports the size it wanted; ask twice so a long list is never truncated.
+    let mut size: c_uint = 0;
+    unsafe { ffi::BRIDGE_EnumComports(std::ptr::null_mut(), &mut size) };
+    let cap = (size as usize).max(STRING_MAX * 8);
+    let mut buffer = vec![0u8; cap];
+    let mut size = cap as c_uint;
+    if !unsafe { ffi::BRIDGE_EnumComports(buffer.as_mut_ptr() as *mut c_char, &mut size) } {
+        return Vec::new();
+    }
+    buffer
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect()
+}
+
+/// Everything needed to open one real drive.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BridgeConfig {
+    /// Which driver to open, by the index [`drivers`] reported it at.
+    pub driver: u32,
+    pub mode: BridgeMode,
+    pub density: BridgeDensityMode,
+    pub drive: DriveSelection,
+    /// Which serial port the interface is on. `None` -- the default -- lets the
+    /// driver find its own device, which every current driver supports
+    /// ([`config_option::AUTO_DETECT_COMPORT`]); name one to pin it, which
+    /// matters when two interfaces are plugged in at once.
+    pub port: Option<String>,
+    pub smart_speed: bool,
+    pub auto_cache: bool,
+}
+
+/// One open real drive.
+///
+/// Not `Clone`: the handle owns a physical device. Dropping it closes and frees
+/// the driver, which parks the motor.
+pub struct Bridge {
+    handle: ffi::BridgeDriverHandle,
+    max_cylinder: u8,
+    /// Scratch for whole-track reads, kept between calls so polling for a
+    /// track does not churn a 29K allocation each time round.
+    capture: Vec<u8>,
+    /// Whether captures begin at the index. When they do, a revolution's two
+    /// ends meet in the sector gap and it can be turned under the head over
+    /// and over, as an image's track is. When they do not, the join falls
+    /// mid-sector and the only safe way through it is forwards, into the
+    /// recording that actually followed.
+    index_aligned: bool,
+}
+
+// SAFETY: the handle is only ever touched through `&mut self` from the
+// emulation thread; the library serialises its own worker internally.
+unsafe impl Send for Bridge {}
+
+impl Bridge {
+    /// Open a real drive. `Err` carries the library's own message, which names
+    /// the actual fault (no such port, device not responding, ...).
+    ///
+    /// No `Bridge` exists until the device is open, deliberately: dropping one
+    /// takes the same lock this holds, so a half-built bridge going out of
+    /// scope on the error path would deadlock against it.
+    pub fn open(config: &BridgeConfig) -> Result<Self, String> {
+        // Creating a driver goes through the bridge's own shared state.
+        let _guard = lib_lock();
+        let mut handle: ffi::BridgeDriverHandle = std::ptr::null_mut();
+
+        let created = unsafe { ffi::BRIDGE_CreateDriver(config.driver as c_uint, &mut handle) };
+        if !created || handle.is_null() {
+            return Err("FloppyBridge refused the configuration".to_string());
+        }
+
+        // Settings have to be in place before the device is opened.
+        apply(handle, config);
+
+        let mut err: *mut c_char = std::ptr::null_mut();
+        if !unsafe { ffi::BRIDGE_Open(handle, &mut err) } {
+            let message = unsafe { owned_string(err) };
+            // The driver exists even though the device would not open, so hand
+            // it back rather than leaving it stranded in the bridge.
+            unsafe { ffi::BRIDGE_FreeDriver(handle) };
+            return Err(if message.is_empty() {
+                "could not open the drive".to_string()
+            } else {
+                message
+            });
+        }
+
+        Ok(Self {
+            handle,
+            // Only meaningful once the device is open, and it decides how far
+            // the head is allowed to travel.
+            max_cylinder: unsafe { ffi::DRIVER_getMaxCylinder(handle) },
+            capture: vec![0u8; MAX_TRACK_BYTES],
+            index_aligned: matches!(
+                config.mode,
+                ffi::BridgeMode::Compatible | ffi::BridgeMode::Stalling
+            ),
+        })
+    }
+
+    /// Whether the device is still responding. False once it is unplugged,
+    /// which is how a bridge drive reports itself broken rather than hanging.
+    pub fn is_working(&self) -> bool {
+        unsafe { ffi::DRIVER_isStillWorking(self.handle) }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        unsafe { ffi::DRIVER_isReady(self.handle) }
+    }
+
+    pub fn disk_in_drive(&self) -> bool {
+        unsafe { ffi::DRIVER_isDiskInDrive(self.handle) }
+    }
+
+    /// Consumes the library's disk-changed latch.
+    pub fn take_disk_changed(&mut self) -> bool {
+        unsafe { ffi::DRIVER_hasDiskChanged(self.handle) }
+    }
+
+    /// Whether the disk's write-protect tab is closed. Answered from the
+    /// driver's last reading, which it keeps across the motor stopping, so
+    /// this does not need the drive spun up to be meaningful.
+    pub fn write_protected(&self) -> bool {
+        unsafe { ffi::DRIVER_isWriteProtected(self.handle) }
+    }
+
+    /// The head's real cylinder, which is what the status bar's track counter
+    /// shows for a bridged drive.
+    pub fn current_cylinder(&self) -> u8 {
+        unsafe { ffi::DRIVER_getCurrentCylinderNumber(self.handle) }
+    }
+
+    /// Keep the head inside what the drive can actually reach. The guest can
+    /// step past the last cylinder -- trackdisk does it to find track 0, and a
+    /// confused loader can do it anywhere -- and a real head just sits against
+    /// the stop rather than travelling somewhere that does not exist.
+    fn clamp_cylinder(&self, cylinder: u8) -> u8 {
+        cylinder.min(self.max_cylinder.saturating_sub(1))
+    }
+
+    /// The kind of drive the interface reports, which is what decides whether
+    /// HD media can be read at all.
+    pub fn drive_type(&self) -> DriveType {
+        match unsafe { ffi::DRIVER_getDriveTypeID(self.handle) } {
+            1 => DriveType::Dd35Hd,
+            2 => DriveType::Sd525,
+            _ => DriveType::Dd35,
+        }
+    }
+
+    pub fn motor_running(&self) -> bool {
+        unsafe { ffi::DRIVER_isMotorRunning(self.handle) }
+    }
+
+    /// Spin the real drive up or down to follow the emulated motor line.
+    pub fn set_motor(&mut self, side: bool, on: bool) {
+        unsafe { ffi::DRIVER_setMotorStatus(self.handle, side, on) }
+    }
+
+    /// Move the head, following the emulated drive's stepper.
+    pub fn seek(&mut self, cylinder: u8, side: bool) {
+        let cylinder = self.clamp_cylinder(cylinder);
+        unsafe { ffi::DRIVER_gotoCylinder(self.handle, cylinder as i32, side) }
+    }
+
+    /// Whether a captured revolution can be turned under the head more than
+    /// once. Index-aligned captures can: their two ends meet in the gap
+    /// between sectors, as an image's track does. A capture that began
+    /// wherever the head happened to be cannot, and has to be followed by the
+    /// recording that came after it.
+    pub fn index_aligned(&self) -> bool {
+        self.index_aligned
+    }
+
+    /// Retire the revolution just consumed so the next read returns the next
+    /// recording of the track, making successive revolutions continuous the
+    /// way the cells coming off a real head are.
+    pub fn switch_buffer(&mut self, side: bool) {
+        unsafe { ffi::DRIVER_mfmSwitchBuffer(self.handle, side) }
+    }
+
+    /// Take the current revolution of `cylinder`/`side`, if the driver has one.
+    ///
+    /// Returns the bit stream packed MSB-first into 16-bit words, plus its
+    /// length in bits, where the head loops back round. That is exactly one
+    /// captured revolution as [`crate::floppy`] stores it. In `Compatible` that
+    /// boundary is the index; in `Fast` it is wherever the capture began.
+    ///
+    /// Never waits. The driver reads the disk continuously in the background,
+    /// so either a finished revolution is sitting there or it is not, and
+    /// `None` simply means "not yet": the caller asks again a moment later
+    /// while the machine keeps running. Blocking here instead would stop the
+    /// emulated Amiga -- mouse, screen and all -- for as long as the platter
+    /// takes to come round, which is exactly the freeze a real drive does not
+    /// cause. (The one exception is the `Stalling` bridge mode, where holding
+    /// the caller up until data arrives is the mode's entire purpose.)
+    pub fn read_track(&mut self, cylinder: u8, side: bool) -> Option<(Vec<u16>, usize)> {
+        let cylinder = self.clamp_cylinder(cylinder);
+        // The driver positions the head itself as part of this call, so there
+        // is no separate seek to get wrong, and asking for a track it is
+        // already on costs nothing.
+        let bits = unsafe {
+            ffi::DRIVER_getTrack(
+                self.handle,
+                side,
+                cylinder as c_uint,
+                false,
+                self.capture.len() as c_int,
+                self.capture.as_mut_ptr() as *mut c_void,
+            )
+        };
+        if bits <= 0 {
+            return None;
+        }
+        // Trust the buffer over the reported length: the driver copies only
+        // what fits and still reports the track's full length, so a revolution
+        // longer than anything the library itself can hold would otherwise be
+        // read off the end of the capture.
+        let bits = (bits as usize).min(self.capture.len() * 8);
+        let bytes = &self.capture[..bits.div_ceil(8)];
+        let words = bytes
+            .chunks(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair.get(1).copied().unwrap_or(0)]))
+            .collect();
+        Some((words, bits))
+    }
+
+    /// Lay `words` of MFM down on the real disk, starting at bit `start_bit`
+    /// of the track.
+    ///
+    /// The words go over one at a time at the rotational position the head
+    /// would be passing, which is how a real drive writes and what the driver
+    /// expects; committing then flushes them to the platter. `start_bit` is
+    /// the emulated head position where the guest began writing, so a partial
+    /// write lands exactly where it was aimed rather than at the index.
+    ///
+    /// Returns false if the disk cannot be written, leaving the platter
+    /// untouched.
+    pub fn write_track(
+        &mut self,
+        cylinder: u8,
+        side: bool,
+        words: &[u16],
+        start_bit: usize,
+    ) -> bool {
+        if words.is_empty() {
+            return false;
+        }
+        if self.write_protected() {
+            return false;
+        }
+        let cylinder = self.clamp_cylinder(cylinder);
+        unsafe {
+            ffi::DRIVER_setSurface(self.handle, side);
+            for (i, word) in words.iter().enumerate() {
+                ffi::DRIVER_writeShortToBuffer(
+                    self.handle,
+                    side,
+                    cylinder as c_uint,
+                    *word,
+                    (start_bit + i * 16) as c_int,
+                );
+            }
+            // Nothing has touched the disk yet: this is what commits it.
+            let new_len = ffi::DRIVER_commitWriteBuffer(self.handle, side, cylinder as c_uint);
+            if new_len == 0 {
+                warn!("floppybridge: the drive rejected the write of cylinder {cylinder}");
+                return false;
+            }
+        }
+        // Deliberately not waiting for the platter to take it. The driver lays
+        // the cells down on its own thread as the disk turns, exactly as a real
+        // drive does, and the caller drops its cached copy of the track: the
+        // next read asks the driver again, and gets nothing back until the
+        // freshly written track has been re-captured. Waiting here would stop
+        // the emulated machine dead for a whole revolution on every write.
+        true
+    }
+}
+
+/// Push the settings onto a driver that has been created but not yet opened. A free function because it runs before
+/// there is a [`Bridge`] to call it on.
+fn apply(handle: ffi::BridgeDriverHandle, config: &BridgeConfig) {
+    unsafe {
+        ffi::BRIDGE_DriverSetMode(handle, config.mode as u8);
+        ffi::BRIDGE_DriverSetDensityMode(handle, config.density as u8);
+        ffi::BRIDGE_DriverSetCable2(handle, config.drive as u8);
+        ffi::BRIDGE_DriverSetSmartSpeedEnabled(handle, config.smart_speed);
+        ffi::BRIDGE_DriverSetAutoCache(handle, config.auto_cache);
+        // Auto-detect unless a port is named, so the common case is
+        // plug-in-and-go and an explicit port always wins.
+        ffi::BRIDGE_DriverSetAutoDetectComPort(handle, config.port.is_none());
+        if let Some(port) = config.port.as_deref() {
+            if let Ok(port) = CString::new(port) {
+                ffi::BRIDGE_DriverSetCurrentComPort(handle, port.as_ptr() as *mut c_char);
+            }
+        }
+    }
+}
+
+impl Drop for Bridge {
+    fn drop(&mut self) {
+        // Closing and freeing are `BRIDGE_*` calls, so they take the same lock
+        // the rest of that half does. Both null-check, which is what makes the
+        // half-built bridge left by a failed `open` safe to drop.
+        let _guard = lib_lock();
+        unsafe {
+            ffi::BRIDGE_Close(self.handle);
+            ffi::BRIDGE_FreeDriver(self.handle);
+        }
+    }
+}
+
+impl std::fmt::Debug for Bridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Bridge")
+            .field("max_cylinder", &self.max_cylinder)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Which interface the hardware tests below expect to be attached. They
+    /// never fall back to another one: each driver speaks its own protocol,
+    /// and opening a board with the wrong one can leave it needing to be
+    /// unplugged before it will answer again.
+    const INTERFACE: &str = "greaseweazle";
+
+    /// Every query here is reached from config parsing and from the launcher,
+    /// on machines with no interface plugged in and no intention of using one.
+    /// None of them may depend on hardware being present.
+    #[test]
+    fn queries_are_safe_with_no_hardware() {
+        // The bridge is linked in, so it always answers.
+        assert!(!drivers().is_empty(), "the bridge offers its drivers");
+        assert!(version().is_some(), "and reports its version");
+        // These simply describe a host with nothing attached.
+        let _ = com_ports();
+        let _ = interface_connected();
+    }
+
+    /// Print what a real library reports. Ignored by default because it needs
+    /// one installed; run it to check a setup:
+    ///     cargo test --release floppybridge_inventory -- --ignored --nocapture
+    #[test]
+    #[ignore = "needs a FloppyBridge library installed"]
+    fn floppybridge_inventory() {
+        println!("bridge: compiled in from vendor/floppybridge");
+        if let Some((major, minor)) = version() {
+            println!("version: {major}.{minor}");
+        }
+        for d in drivers() {
+            println!(
+                "driver {}: {} by {} (options {:#04x})",
+                d.index, d.name, d.manufacturer, d.config_options
+            );
+        }
+        println!("ports: {:?}", com_ports());
+    }
+
+    /// Read cylinder 0 off a real disk and report what the MFM looks like:
+    /// how many AmigaDOS sync marks are in it and how they are spaced. That
+    /// separates "the stream is good, the emulator's timing is wrong" from
+    /// "the bytes crossing the FFI are not what we think they are".
+    ///
+    ///     cargo test --release floppybridge_track_probe -- --ignored --nocapture
+    /// Watch the drive's status lines with the motor stopped and running, to
+    /// see what the driver actually reports rather than what it is assumed to.
+    /// Write protection is the one that matters: Copperline gates real writes
+    /// on it, and a reading taken at the wrong moment either refuses a disk
+    /// that is writable or, worse, allows one that is not.
+    ///
+    ///     cargo test --release floppybridge_status_probe -- --ignored --nocapture
+    #[test]
+    #[ignore = "needs a FloppyBridge device attached"]
+    fn floppybridge_status_probe() {
+        let driver = drivers()
+            .into_iter()
+            .find(|d| d.name.to_ascii_lowercase().contains(INTERFACE))
+            .unwrap_or_else(|| panic!("no {INTERFACE} driver in this library"));
+        let mut bridge = Bridge::open(&BridgeConfig {
+            driver: driver.index,
+            ..Default::default()
+        })
+        .expect("open the drive");
+
+        let sample = |bridge: &mut Bridge, phase: &str| {
+            for _ in 0..8 {
+                println!(
+                    "{phase:>10}  disk={:<5} ready={:<5} motor={:<5} wp={}",
+                    bridge.disk_in_drive(),
+                    bridge.is_ready(),
+                    bridge.motor_running(),
+                    bridge.write_protected(),
+                );
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+        };
+
+        sample(&mut bridge, "motor off");
+        bridge.set_motor(false, true);
+        sample(&mut bridge, "motor on");
+        bridge.seek(1, false);
+        sample(&mut bridge, "after seek");
+        bridge.set_motor(false, false);
+        sample(&mut bridge, "stopped");
+    }
+
+    #[test]
+    #[ignore = "needs a FloppyBridge device with a disk in the drive"]
+    fn floppybridge_track_probe() {
+        let driver = drivers()
+            .into_iter()
+            .find(|d| d.name.to_ascii_lowercase().contains(INTERFACE))
+            .unwrap_or_else(|| panic!("no {INTERFACE} driver in this library"));
+        println!("using driver {}: {}", driver.index, driver.name);
+
+        let mut bridge = Bridge::open(&BridgeConfig {
+            driver: driver.index,
+            ..Default::default()
+        })
+        .expect("open the drive");
+
+        // Spin up and let the platter reach speed, as the emulator does.
+        bridge.set_motor(false, true);
+        std::thread::sleep(std::time::Duration::from_millis(1200));
+        println!(
+            "disk={} ready={} wp={} type={:?}",
+            bridge.disk_in_drive(),
+            bridge.is_ready(),
+            bridge.write_protected(),
+            bridge.drive_type()
+        );
+
+        // `read_track` never waits, so poll it the way the emulator does. A
+        // capture takes a revolution; a couple of seconds is generous.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let (words, bits) = loop {
+            if let Some(track) = bridge.read_track(0, false) {
+                break track;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no track came back within three seconds (disk in the drive?)"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+        println!("captured {bits} bits in {} words", words.len());
+
+        // AmigaDOS marks every sector with the MFM sync word 0x4489. A good
+        // DD track has 11 of them, evenly spaced about one sector apart.
+        let bit_at = |i: usize| words[(i / 16) % words.len()] & (1 << (15 - (i % 16))) != 0;
+        let mut syncs = Vec::new();
+        let mut window: u16 = 0;
+        for i in 0..bits {
+            window = (window << 1) | u16::from(bit_at(i));
+            if i >= 15 && window == 0x4489 {
+                syncs.push(i - 15);
+            }
+        }
+        println!("found {} sync marks (0x4489)", syncs.len());
+        if let Some(first) = syncs.first() {
+            println!("first sync at bit {first}");
+            let gaps: Vec<usize> = syncs.windows(2).map(|w| w[1] - w[0]).collect();
+            println!("gaps between syncs: {:?}", &gaps[..gaps.len().min(14)]);
+        }
+        // A readable AmigaDOS track has a sync per sector. Fewer means the
+        // stream reaching us is not the disk's MFM.
+        assert!(
+            syncs.len() >= 11,
+            "expected at least 11 AmigaDOS sync marks, found {} -- the MFM crossing \
+             the FFI does not look like the disk's",
+            syncs.len()
+        );
+
+        // Decode each sector header. AmigaDOS splits every long into its odd
+        // and even MFM bits, so a header that reads back with a sane format
+        // byte, track and sector number proves the stream is not just
+        // sync-shaped but genuinely decodable in the order we present it.
+        let long_at = |start: usize| -> u32 {
+            let mut v = 0u32;
+            for k in 0..32 {
+                v = (v << 1) | u32::from(bit_at(start + k));
+            }
+            v
+        };
+        let mut decoded = Vec::new();
+        for &s in &syncs {
+            // Skip the sync pair to reach the info long.
+            let info_start = s + 32;
+            if info_start + 64 > bits {
+                continue;
+            }
+            let odd = long_at(info_start);
+            let even = long_at(info_start + 32);
+            let info = ((odd & 0x5555_5555) << 1) | (even & 0x5555_5555);
+            let [format, track_no, sector, to_gap] = info.to_be_bytes();
+            if format == 0xFF {
+                decoded.push((track_no, sector, to_gap));
+            }
+        }
+        println!("decoded {} sector headers", decoded.len());
+        for (t, s, g) in decoded.iter().take(13) {
+            println!("  track {t} sector {s} (sectors to gap {g})");
+        }
+        assert!(
+            decoded.len() >= 11,
+            "only {} sector headers decoded; the MFM is sync-shaped but not \
+             AmigaDOS-decodable as presented",
+            decoded.len()
+        );
+
+        // With the tab open, a write must be refused before anything is queued.
+        // Checked here rather than in its own test because it is the one part
+        // of the write path that can be exercised without risking a disk.
+        if bridge.write_protected() {
+            let unchanged = words.clone();
+            assert!(
+                !bridge.write_track(0, false, &words, 0),
+                "a write-protected disk must refuse the write"
+            );
+            let (after, _) = bridge.read_track(0, false).expect("re-read cylinder 0");
+            assert_eq!(
+                after, unchanged,
+                "a refused write must leave the platter untouched"
+            );
+            println!("write-protect: write refused and the track is unchanged");
+        } else {
+            println!("write-protect: disk is writable, skipping the refusal check");
+        }
+    }
+
+    /// Every driver the library reports is usable: it has a name and an index
+    /// we can hand back to `Source::Driver`.
+    /// Powering the machine off drops the bridge and powering it back on
+    /// opens a new one, so the device has to be genuinely released by the
+    /// drop -- not merely forgotten about -- or the second open is refused
+    /// with the port still in use.
+    #[test]
+    #[ignore = "needs a real interface attached"]
+    fn a_dropped_bridge_hands_the_device_back() {
+        // Deliberately no fallback to another driver: opening a board with a
+        // different interface's protocol can leave it wedged until it is
+        // physically unplugged.
+        let driver = drivers()
+            .into_iter()
+            .find(|d| d.name.to_ascii_lowercase().contains(INTERFACE))
+            .unwrap_or_else(|| panic!("no {INTERFACE} driver in this library"));
+        let open = || {
+            Bridge::open(&BridgeConfig {
+                driver: driver.index,
+                ..Default::default()
+            })
+        };
+
+        let first = open().expect("open the drive");
+        drop(first);
+        // Immediately, with no grace period: this is a power button being
+        // pressed twice, or Run from the configuration screen.
+        let second = open().expect("re-open the drive after releasing it");
+        drop(second);
+    }
+
+    /// The library keeps its `BRIDGE_*` state process-wide -- one shared port
+    /// vector, one profile cache -- so the queries have to be serialised on
+    /// this side. Without that, this does not fail: it aborts the process,
+    /// which is how the problem was found.
+    #[test]
+    fn library_queries_survive_being_asked_from_several_threads() {
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    for _ in 0..8 {
+                        let _ = com_ports();
+                        let _ = drivers();
+                        let _ = interface_connected();
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().expect("a query thread panicked");
+        }
+    }
+
+    #[test]
+    fn reported_drivers_are_well_formed() {
+        for (i, d) in drivers().iter().enumerate() {
+            assert_eq!(d.index as usize, i, "driver indices are dense and ordered");
+            assert!(!d.name.is_empty(), "driver {i} has a name");
+        }
+    }
+}

--- a/src/floppybridge/mod.rs
+++ b/src/floppybridge/mod.rs
@@ -565,7 +565,7 @@ fn apply(handle: ffi::BridgeDriverHandle, config: &BridgeConfig) -> Vec<&'static
             refused.push("smart speed");
         }
         if !ffi::BRIDGE_DriverSetAutoCache(handle, config.auto_cache) {
-            refused.push("read ahead");
+            refused.push("auto-cache");
         }
         // Auto-detect unless a port is named, so the common case is
         // plug-in-and-go and an explicit port always wins.

--- a/src/floppybridge/mod.rs
+++ b/src/floppybridge/mod.rs
@@ -80,6 +80,10 @@ const STRING_MAX: usize = 255;
 /// buffers at `MFM_BUFFER_MAX_TRACK_LENGTH` (0x3A00 * 2), so nothing longer
 /// than this can come back: a DD revolution is around 12.7K of MFM and an HD
 /// one twice that, leaving plenty of room for a drive running off-speed.
+/// How close to the index a write has to start for the driver to place it
+/// there. Upstream's own figure, from `commitWriteBuffer`.
+const INDEX_WRITE_SLACK_BITS: usize = 30;
+
 const MAX_TRACK_BYTES: usize = 0x3A00 * 2;
 
 /// Serialises calls into the library itself.
@@ -167,7 +171,8 @@ impl DriverInfo {
 }
 
 /// Every driver the loaded library offers (DrawBridge, Greaseweazle, ...).
-/// Empty when no library is loaded.
+/// Empty only if the bridge reports no drivers at all, which should not
+/// happen: the library is linked in, not looked for.
 pub fn drivers() -> Vec<DriverInfo> {
     let _guard = lib_lock();
     let count = unsafe { ffi::BRIDGE_NumDrivers() };
@@ -284,7 +289,23 @@ impl Bridge {
         }
 
         // Settings have to be in place before the device is opened.
-        apply(handle, config);
+        // The drive select decides which physical drive on the cable is
+        // spoken to, so a driver that will not take it must not be opened
+        // anyway -- it would quietly use Drive A instead.
+        let refused = apply(handle, config);
+        if refused.contains(&"drive select") {
+            unsafe { ffi::BRIDGE_FreeDriver(handle) };
+            return Err(format!(
+                "this interface does not support the {:?} drive select",
+                config.drive
+            ));
+        }
+        if !refused.is_empty() {
+            warn!(
+                "floppybridge: the interface would not take {}; its own default stands instead",
+                refused.join(", "),
+            );
+        }
 
         let mut err: *mut c_char = std::ptr::null_mut();
         if !unsafe { ffi::BRIDGE_Open(handle, &mut err) } {
@@ -464,6 +485,32 @@ impl Bridge {
             return false;
         }
         let cylinder = self.clamp_cylinder(cylinder);
+        // The driver takes a rotational position per word, but only the first
+        // survives: `commitWriteBuffer` reduces it to a `writeFromIndex`
+        // boolean -- true within 30 bits of the index -- and the worker lays
+        // the cells down either from the index pulse or from wherever the head
+        // happens to be when it runs. There is no third option, so a write
+        // that has to start anywhere else cannot be placed, and letting it go
+        // would put the guest's sector on top of an unrelated one.
+        //
+        // Two shapes are safe. A write from the index is placed exactly. A
+        // whole revolution overwrites the track entire, so where it begins
+        // does not matter -- which is what AmigaDOS does, writing all eleven
+        // sectors at once. Anything else is refused rather than gambled with:
+        // this is somebody's real disk.
+        let track_bits = unsafe { ffi::DRIVER_maxMFMBitPosition(self.handle) }.max(0) as usize;
+        let from_index =
+            start_bit <= INDEX_WRITE_SLACK_BITS || start_bit + INDEX_WRITE_SLACK_BITS >= track_bits;
+        let whole_revolution = track_bits > 0 && words.len() * 16 + 16 >= track_bits;
+        if !from_index && !whole_revolution {
+            warn!(
+                "floppybridge: refusing a partial write of {} words at bit {start_bit} of \
+                 {track_bits} on cylinder {cylinder}: the interface can only start a write at \
+                 the index or wherever the head is, so this one would land on another sector",
+                words.len(),
+            );
+            return false;
+        }
         unsafe {
             ffi::DRIVER_setSurface(self.handle, side);
             for (i, word) in words.iter().enumerate() {
@@ -494,13 +541,32 @@ impl Bridge {
 
 /// Push the settings onto a driver that has been created but not yet opened. A free function because it runs before
 /// there is a [`Bridge`] to call it on.
-fn apply(handle: ffi::BridgeDriverHandle, config: &BridgeConfig) {
+///
+/// Returns the settings the driver would not take. Most of these are
+/// preferences, and a driver that cannot honour one carries on sensibly with
+/// its default -- but the drive select is not a preference. Every driver
+/// advertises the cable conventions it supports, and one that refuses the
+/// requested selection silently keeps Drive A: the open then succeeds against
+/// a different physical drive than the one asked for, which is the sort of
+/// thing that is only noticed after writing to the wrong disk.
+fn apply(handle: ffi::BridgeDriverHandle, config: &BridgeConfig) -> Vec<&'static str> {
+    let mut refused = Vec::new();
     unsafe {
-        ffi::BRIDGE_DriverSetMode(handle, config.mode as u8);
-        ffi::BRIDGE_DriverSetDensityMode(handle, config.density as u8);
-        ffi::BRIDGE_DriverSetCable2(handle, config.drive as u8);
-        ffi::BRIDGE_DriverSetSmartSpeedEnabled(handle, config.smart_speed);
-        ffi::BRIDGE_DriverSetAutoCache(handle, config.auto_cache);
+        if !ffi::BRIDGE_DriverSetMode(handle, config.mode as u8) {
+            refused.push("read mode");
+        }
+        if !ffi::BRIDGE_DriverSetDensityMode(handle, config.density as u8) {
+            refused.push("density");
+        }
+        if !ffi::BRIDGE_DriverSetCable2(handle, config.drive as u8) {
+            refused.push("drive select");
+        }
+        if !ffi::BRIDGE_DriverSetSmartSpeedEnabled(handle, config.smart_speed) {
+            refused.push("smart speed");
+        }
+        if !ffi::BRIDGE_DriverSetAutoCache(handle, config.auto_cache) {
+            refused.push("read ahead");
+        }
         // Auto-detect unless a port is named, so the common case is
         // plug-in-and-go and an explicit port always wins.
         ffi::BRIDGE_DriverSetAutoDetectComPort(handle, config.port.is_none());
@@ -510,6 +576,7 @@ fn apply(handle: ffi::BridgeDriverHandle, config: &BridgeConfig) {
             }
         }
     }
+    refused
 }
 
 impl Drop for Bridge {
@@ -560,7 +627,7 @@ mod tests {
     /// one installed; run it to check a setup:
     ///     cargo test --release floppybridge_inventory -- --ignored --nocapture
     #[test]
-    #[ignore = "needs a FloppyBridge library installed"]
+    #[ignore = "lists what the built-in bridge offers; run it to see the drivers"]
     fn floppybridge_inventory() {
         println!("bridge: compiled in from vendor/floppybridge");
         if let Some((major, minor)) = version() {
@@ -747,8 +814,6 @@ mod tests {
         }
     }
 
-    /// Every driver the library reports is usable: it has a name and an index
-    /// we can hand back to `Source::Driver`.
     /// Powering the machine off drops the bridge and powering it back on
     /// opens a new one, so the device has to be genuinely released by the
     /// drop -- not merely forgotten about -- or the second open is refused

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,11 @@ pub mod emulator;
 pub mod envcfg;
 pub mod filesys;
 pub mod floppy;
+// Physical floppy drives over a DrawBridge/Greaseweazle/Supercard Pro, through
+// the vendored FloppyBridge. Gated because it compiles C++ and talks to a
+// serial port, neither of which a wasm32 browser build can do.
+#[cfg(feature = "floppybridge")]
+pub mod floppybridge;
 #[cfg(feature = "frontend")]
 pub mod gamepad;
 pub mod gary;

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,11 +484,11 @@ where
                 overrides.floppy_bridge_smart_speed[idx] = true;
             }
             #[cfg(feature = "floppybridge")]
-            "--floppy-bridge-read-ahead" => {
-                const USAGE: &str = "--floppy-bridge-read-ahead requires DFN";
+            "--floppy-bridge-auto-cache" => {
+                const USAGE: &str = "--floppy-bridge-auto-cache requires DFN";
                 let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
-                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-read-ahead")?;
-                overrides.floppy_bridge_read_ahead[idx] = true;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-auto-cache")?;
+                overrides.floppy_bridge_auto_cache[idx] = true;
             }
             #[cfg(feature = "floppybridge")]
             "--floppy-bridge-writable" => {
@@ -1034,7 +1034,7 @@ fn print_help() {
          --floppy-bridge-mode DFN MODE  how tracks are captured: normal, compatible, stalling\n  \
          --floppy-bridge-density DFN D  force a density: auto, dd, or hd\n  \
          --floppy-bridge-smart-speed DFN  let the interface slow the drive between accesses\n  \
-         --floppy-bridge-read-ahead DFN   read tracks ahead while the drive is idle\n  \
+         --floppy-bridge-auto-cache DFN   cache disk data while the drive is idle\n  \
          --floppy-bridge-writable DFN   let the guest write to the physical disk (which is\n  \
          \x20                            write-protected unless asked otherwise)\n  ";
     #[cfg(not(feature = "floppybridge"))]
@@ -2440,7 +2440,7 @@ mod tests {
             "dd",
             "--floppy-bridge-smart-speed",
             "df1",
-            "--floppy-bridge-read-ahead",
+            "--floppy-bridge-auto-cache",
             "df1",
         ])?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,6 +430,73 @@ where
                     .ok_or_else(|| anyhow!("--floppy-drives requires COUNT (1-4)"))?;
                 overrides.floppy_drives = Some(parse_floppy_drive_count(&value)?);
             }
+            // Absent from a build without the feature, so an unknown-argument
+            // error names it rather than the flag quietly doing nothing.
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge" => {
+                const USAGE: &str = "--floppy-bridge requires DFN INTERFACE \
+                                     (drawbridge, greaseweazle, supercardpro, or off)";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge")?;
+                let interface = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                overrides.floppy_bridge[idx] = Some(interface);
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-port" => {
+                const USAGE: &str = "--floppy-bridge-port requires DFN PORT";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-port")?;
+                overrides.floppy_bridge_port[idx] =
+                    Some(args.next().ok_or_else(|| anyhow!(USAGE))?);
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-cable" => {
+                const USAGE: &str = "--floppy-bridge-cable requires DFN CABLE \
+                                     (a or b for a PC cable, 0-3 for Shugart)";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-cable")?;
+                overrides.floppy_bridge_cable[idx] =
+                    Some(args.next().ok_or_else(|| anyhow!(USAGE))?);
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-mode" => {
+                const USAGE: &str = "--floppy-bridge-mode requires DFN MODE \
+                                     (normal, compatible, or stalling)";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-mode")?;
+                overrides.floppy_bridge_mode[idx] =
+                    Some(args.next().ok_or_else(|| anyhow!(USAGE))?);
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-density" => {
+                const USAGE: &str = "--floppy-bridge-density requires DFN DENSITY \
+                                     (auto, dd, or hd)";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-density")?;
+                overrides.floppy_bridge_density[idx] =
+                    Some(args.next().ok_or_else(|| anyhow!(USAGE))?);
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-smart-speed" => {
+                const USAGE: &str = "--floppy-bridge-smart-speed requires DFN";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-smart-speed")?;
+                overrides.floppy_bridge_smart_speed[idx] = true;
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-read-ahead" => {
+                const USAGE: &str = "--floppy-bridge-read-ahead requires DFN";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-read-ahead")?;
+                overrides.floppy_bridge_read_ahead[idx] = true;
+            }
+            #[cfg(feature = "floppybridge")]
+            "--floppy-bridge-writable" => {
+                const USAGE: &str = "--floppy-bridge-writable requires DFN";
+                let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-writable")?;
+                overrides.floppy_bridge_writable[idx] = true;
+            }
             "--floppy-speed" | "--fdd-speed" => {
                 let value = args.next().ok_or_else(|| {
                     anyhow!("--floppy-speed requires PERCENT (100, 200, 400, 800, or 0 for turbo)")
@@ -956,6 +1023,22 @@ fn print_help() {
                 --list-midi                    list host MIDI endpoints and exit\n  ";
     #[cfg(not(feature = "midi"))]
     let midi = "";
+    // A build without the feature cannot attach a physical drive at all, so
+    // the flags are not listed and not accepted.
+    #[cfg(feature = "floppybridge")]
+    let floppy_bridge =
+        "--floppy-bridge DFN NAME       drive a physical floppy drive on DFN over NAME:\n  \
+         \x20                            drawbridge, greaseweazle, supercardpro, or off\n  \
+         --floppy-bridge-port DFN PORT  serial port of that interface (default: auto-detect)\n  \
+         --floppy-bridge-cable DFN SEL  drive select on the cable: a/b (PC) or 0-3 (Shugart)\n  \
+         --floppy-bridge-mode DFN MODE  how tracks are captured: normal, compatible, stalling\n  \
+         --floppy-bridge-density DFN D  force a density: auto, dd, or hd\n  \
+         --floppy-bridge-smart-speed DFN  let the interface slow the drive between accesses\n  \
+         --floppy-bridge-read-ahead DFN   read tracks ahead while the drive is idle\n  \
+         --floppy-bridge-writable DFN   let the guest write to the physical disk (which is\n  \
+         \x20                            write-protected unless asked otherwise)\n  ";
+    #[cfg(not(feature = "floppybridge"))]
+    let floppy_bridge = "";
     eprintln!(
         "copperline - Amiga emulator\n\
          \n\
@@ -978,7 +1061,7 @@ fn print_help() {
          \x20                            CPUs), e.g. 0, 32M, 128M\n  \
          --floppy-drives COUNT          wired floppy drives, 1-4 (DF0 plus externals)\n  \
          --floppy-speed PERCENT         drive speed: 100, 200, 400, 800, or 0 (turbo)\n  \
-         --rtc-time TIME                seed the battery clock (implies fitting one) with\n  \
+         {floppy_bridge}--rtc-time TIME                seed the battery clock (implies fitting one) with\n  \
          \x20                            Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"; it then\n  \
          \x20                            ticks in emulated time, so runs are deterministic\n  \
          --rtc-frozen                   stop the seeded clock at --rtc-time exactly\n  \
@@ -1605,7 +1688,17 @@ fn main() -> Result<()> {
         || cli.benchmark_until.is_some()
         || cli.gdb.is_some()
         || cli.control.is_some();
-    let paced = !headless_capture;
+    // A real drive on a bridge is the exception: its platter turns in
+    // wall-clock time and cannot be hurried. Left unthrottled, the emulated
+    // machine outruns it -- spinning the motor up and down faster than it can
+    // reach speed, and stepping past tracks before the drive has captured
+    // them -- so the guest sees a drive that answers almost nothing. Pace a
+    // bridged machine like a real Amiga, whatever else was asked for.
+    let bridged = cfg.floppy.bridges.iter().any(Option::is_some);
+    let paced = !headless_capture || bridged;
+    if bridged && headless_capture {
+        info!("emulation timing: paced to wall-clock because a physical floppy drive is attached");
+    }
     info!("emulation timing: deterministic core, paced={paced}");
     let mut emu = emulator::build_machine(&cfg, audio, paced, cli.load_state.is_some())?;
     if let Some(path) = &cli.load_state {
@@ -2317,6 +2410,86 @@ mod tests {
         ])?;
         let err = validate_gdb_args(&args).unwrap_err();
         assert!(err.to_string().contains("--screenshot-after"), "{err:#}");
+        Ok(())
+    }
+
+    /// A real drive can be asked for entirely from the command line, with no
+    /// config file: the flags have to create the bay's table, not just fill
+    /// one in.
+    // The flags only exist in a build that can attach a physical drive.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_flags_configure_a_bay_with_no_config_file() -> Result<()> {
+        let args = parse(&[
+            "--floppy-bridge",
+            "df1",
+            "greaseweazle",
+            "--floppy-bridge-port",
+            "df1",
+            "/dev/ttyACM0",
+            "--floppy-bridge-cable",
+            "df1",
+            "b",
+            "--floppy-bridge-writable",
+            "df1",
+            "--floppy-bridge-mode",
+            "df1",
+            "compatible",
+            "--floppy-bridge-density",
+            "df1",
+            "dd",
+            "--floppy-bridge-smart-speed",
+            "df1",
+            "--floppy-bridge-read-ahead",
+            "df1",
+        ])?;
+
+        let raw = Config::load_raw(None, &args.overrides)?;
+        let cfg = Config::try_from(raw)?;
+        let bridge = cfg.floppy.bridges[1].as_ref().expect("df1 bridged");
+        assert_eq!(
+            bridge.driver,
+            copperline::config::BridgeDriver::Greaseweazle
+        );
+        assert_eq!(bridge.port.as_deref(), Some("/dev/ttyACM0"));
+        assert_eq!(bridge.cable, copperline::config::BridgeCable::DriveB);
+        assert!(!bridge.write_protected);
+        assert_eq!(bridge.mode, copperline::config::BridgeSpeedMode::Compatible);
+        assert_eq!(bridge.density, copperline::config::BridgeDensity::Dd);
+        assert!(bridge.smart_speed);
+        assert!(bridge.auto_cache);
+        // Untouched bays stay as they were.
+        assert!(cfg.floppy.bridges[0].is_none());
+        Ok(())
+    }
+
+    /// The flag means "this bay is a real drive", so it displaces an image the
+    /// config file put there rather than colliding with it -- a bay cannot
+    /// hold both, and the command line wins.
+    // The flags only exist in a build that can attach a physical drive.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_flag_replaces_a_configured_image() -> Result<()> {
+        let path = std::env::temp_dir().join(format!(
+            "copperline-bridge-cli-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &path,
+            "[floppy.df0]\npath = \"workbench.adf\"\nwrite_protected = true\n",
+        )?;
+
+        let args = parse(&["--floppy-bridge", "df0", "greaseweazle"])?;
+        let raw = Config::load_raw(Some(&path), &args.overrides)?;
+        let cfg = Config::try_from(raw)?;
+        let _ = std::fs::remove_file(&path);
+
+        assert!(cfg.floppy.bridges[0].is_some(), "the bay is a real drive");
+        assert!(cfg.floppy.drives[0].is_none(), "and has no image left");
         Ok(())
     }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -990,9 +990,9 @@ const BRIDGE_CABLES: [BridgeCable; 6] = [
 ];
 const BRIDGE_DENSITIES: [BridgeDensity; 3] =
     [BridgeDensity::Auto, BridgeDensity::Dd, BridgeDensity::Hd];
-// Ordered as Amiberry's drive-type list has them, so the two read the same.
-// Its Turbo is absent: that one answers AmigaDOS calls instead of reading the
-// disk, so there is nothing for a drive model to do with it.
+// The driver's fourth mode, Turbo, is absent: it answers AmigaDOS calls
+// instead of reading the disk, so there is nothing for a drive model to do
+// with it.
 const BRIDGE_SPEEDS: [BridgeSpeedMode; 3] = [
     BridgeSpeedMode::Normal,
     BridgeSpeedMode::Compatible,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -3185,9 +3185,9 @@ impl MachineSetup {
             return false;
         };
         let token = cfg.driver.match_token();
-        // With no library there is nothing to ask, so leave every row live
-        // rather than greying the page out on a machine that simply has not
-        // installed it yet.
+        // The bridge is linked in, so it always has drivers to describe. If it
+        // ever answers with none there is nothing to ask, and leaving every row
+        // live is better than greying out a page the user cannot then fix.
         let drivers = crate::floppybridge::drivers();
         if drivers.is_empty() {
             return true;

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -23,7 +23,8 @@ use crate::bus::PortDevice;
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
-    format_size, machine_profile_defaults, AudioFilterMode, ChannelMode, Chipset, Config, CpuModel,
+    format_size, machine_profile_defaults, AudioFilterMode, BridgeCable, BridgeDensity,
+    BridgeDriver, BridgeSpeedMode, ChannelMode, Chipset, Config, CpuModel, FloppyBridgeConfig,
     JoystickInputMode, MachineModel, MouseCapture, Overscan, PacingBudget, ParallelDevice,
     PixelAspect, RawConfig, RawDrive, RawFilesysMount, RawFloppyDrive, RawZorroBoard, RtgCard,
     ScsiController, SerialMode, ShaderMode, Tint, WarpSpeed, BOOT_PRI_NEVER,
@@ -170,6 +171,8 @@ pub enum LauncherTab {
     Rom,
     Floppy,
     Storage,
+    /// FloppyBridge settings for one bay, reached from its Configure button.
+    FloppyBridge,
     BootPriority,
     HostFs,
     Cd,
@@ -211,6 +214,7 @@ impl LauncherTab {
             LauncherTab::Memory => "Memory",
             LauncherTab::Rom => "ROM",
             LauncherTab::Floppy => "Floppy",
+            LauncherTab::FloppyBridge => "FloppyBridge",
             LauncherTab::Storage => "Storage",
             LauncherTab::BootPriority => "Boot Priority",
             LauncherTab::HostFs => "Host Mounts",
@@ -232,6 +236,7 @@ impl LauncherTab {
             LauncherTab::Cd | LauncherTab::HostFs | LauncherTab::BootPriority => {
                 LauncherTab::Storage
             }
+            LauncherTab::FloppyBridge => LauncherTab::Floppy,
             LauncherTab::AvVideo | LauncherTab::AvEmulation => LauncherTab::AvAudio,
             other => other,
         }
@@ -245,6 +250,7 @@ impl LauncherTab {
             LauncherTab::Cd | LauncherTab::HostFs | LauncherTab::BootPriority => {
                 Some(LauncherTab::Storage)
             }
+            LauncherTab::FloppyBridge => Some(LauncherTab::Floppy),
             _ => None,
         }
     }
@@ -323,6 +329,26 @@ pub enum LauncherField {
     Df2WriteProtect,
     Df3Image,
     Df3WriteProtect,
+    // The per-drive "use a real drive" tick boxes, and the settings behind the
+    // Configure button they reveal. The settings are one set of rows shown for
+    // whichever bay is being configured, rather than four copies.
+    Df0Bridge,
+    Df1Bridge,
+    Df2Bridge,
+    Df3Bridge,
+    /// The greyed heading naming the installed library and its version. Inert:
+    /// it labels the page rather than editing anything.
+    BridgeLibrary,
+    /// A line of the explanation shown in place of the settings when there is
+    /// no library to apply them to. Inert, and shared by every such line.
+    BridgeLibraryHelp,
+    BridgeDevice,
+    BridgePort,
+    BridgeCable,
+    BridgeDensity,
+    BridgeSpeed,
+    BridgeSmartSpeed,
+    BridgeAutoCache,
     // Hard disk
     IdeMaster,
     IdeSlave,
@@ -433,6 +459,12 @@ pub enum RowKind {
     /// The greyed `Drive` / `Priority` / `Status` column titles above the Boot
     /// Priority rows. Non-interactive; its `field` is inert.
     BootpriHeader,
+    /// A floppy drive's media row: an image path with Browse/Clear, or the
+    /// real interface in use with a Configure button once bridged.
+    FloppyMedia,
+    /// The pair of tick boxes under a drive: write protect, and whether the
+    /// bay uses a real drive. Its `field` is the drive's write-protect field.
+    FloppyFlags,
 }
 
 /// One settings row: a label, the field it edits, and how to edit it.
@@ -542,21 +574,39 @@ const ROM_ROWS: [Row; 2] = [
 // Each drive is a greyed "DFn:" heading with its settings indented under it. The
 // heading is keyed on the drive's image field so `row_hidden` drops it along
 // with the drive's rows when the drive is not wired in.
+// Each wired drive is a greyed "DFn:" heading, its media row, then the two
+// tick boxes that share a line beneath. The media row shows an image path with
+// Browse/Clear, or -- once FloppyBridge is ticked -- the real interface in use
+// with a Configure button onto its settings.
 const FLOPPY_ROWS: [Row; 14] = [
     row(F::FloppyDrives, "Drives", Cycle),
     row(F::FloppySpeed, "Drive speed", Cycle),
     row(F::Df0Image, "DF0:", RowKind::SectionHeader),
-    row(F::Df0Image, "  Disk image", PathRow),
-    row(F::Df0WriteProtect, "  Write-protect", Toggle),
+    row(F::Df0Image, "  Disk image", RowKind::FloppyMedia),
+    row(F::Df0WriteProtect, "", RowKind::FloppyFlags),
     row(F::Df1Image, "DF1:", RowKind::SectionHeader),
-    row(F::Df1Image, "  Disk image", PathRow),
-    row(F::Df1WriteProtect, "  Write-protect", Toggle),
+    row(F::Df1Image, "  Disk image", RowKind::FloppyMedia),
+    row(F::Df1WriteProtect, "", RowKind::FloppyFlags),
     row(F::Df2Image, "DF2:", RowKind::SectionHeader),
-    row(F::Df2Image, "  Disk image", PathRow),
-    row(F::Df2WriteProtect, "  Write-protect", Toggle),
+    row(F::Df2Image, "  Disk image", RowKind::FloppyMedia),
+    row(F::Df2WriteProtect, "", RowKind::FloppyFlags),
     row(F::Df3Image, "DF3:", RowKind::SectionHeader),
-    row(F::Df3Image, "  Disk image", PathRow),
-    row(F::Df3WriteProtect, "  Write-protect", Toggle),
+    row(F::Df3Image, "  Disk image", RowKind::FloppyMedia),
+    row(F::Df3WriteProtect, "", RowKind::FloppyFlags),
+];
+/// The FloppyBridge settings page, shown for whichever bay was configured.
+#[cfg(feature = "floppybridge")]
+const FLOPPY_BRIDGE_ROWS: [Row; 8] = [
+    // Inert: the label is built from the loaded library's version (see
+    // `bridge_library_heading`), so the text here is never drawn.
+    row(F::BridgeLibrary, "", RowKind::SectionHeader),
+    row(F::BridgeDevice, "Interface", Cycle),
+    row(F::BridgePort, "Serial port", Cycle),
+    row(F::BridgeCable, "Drive select", Cycle),
+    row(F::BridgeDensity, "Density", Cycle),
+    row(F::BridgeSpeed, "Read mode", Cycle),
+    row(F::BridgeSmartSpeed, "Smart speed", Toggle),
+    row(F::BridgeAutoCache, "Read ahead", Toggle),
 ];
 const STORAGE_ROWS: [Row; 12] = [
     row(F::IdeMaster, "IDE master", Drive),
@@ -686,6 +736,12 @@ pub fn rows(
         LauncherTab::Memory => Cow::Borrowed(&MEMORY_ROWS),
         LauncherTab::Rom => Cow::Borrowed(&ROM_ROWS),
         LauncherTab::Floppy => Cow::Borrowed(&FLOPPY_ROWS),
+        // Unreachable without the feature: nothing offers a way in, since the
+        // tick box that turns a bay over is not drawn either.
+        #[cfg(not(feature = "floppybridge"))]
+        LauncherTab::FloppyBridge => Cow::Borrowed(&[]),
+        #[cfg(feature = "floppybridge")]
+        LauncherTab::FloppyBridge => Cow::Borrowed(&FLOPPY_BRIDGE_ROWS),
         // The Storage tab shows the IDE/SCSI options (the common case). Its
         // sub-page links are a fixed nav row at the top (see the panel code),
         // in the same place as each sub-page's Back button, so they are not part
@@ -858,6 +914,90 @@ const Z3_PRESETS: [usize; 8] = [
 const OVERSCANS: [Overscan; 2] = [Overscan::Tv, Overscan::Full];
 const PIXEL_ASPECTS: [PixelAspect; 2] = [PixelAspect::Tv, PixelAspect::Square];
 const TINTS: [Tint; 5] = [Tint::None, Tint::Bw, Tint::Green, Tint::Amber, Tint::Sepia];
+/// How close a bay is to actually having a physical drive behind it.
+///
+/// The two ways it can fail look identical from the outside but need opposite
+/// fixes -- install the library, or plug the interface in -- so the launcher
+/// keeps them apart rather than saying "None" to both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeStatus {
+    /// Nothing the bridge recognises is plugged in. The bridge itself is
+    /// always there in a build with the feature, and a build without one never
+    /// shows a bay that could ask.
+    NoInterface,
+    /// An interface the bridge recognises is attached.
+    Attached,
+}
+
+/// What the bridge can see of the host right now.
+fn bridge_status() -> BridgeStatus {
+    #[cfg(feature = "floppybridge")]
+    if crate::floppybridge::interface_connected() {
+        return BridgeStatus::Attached;
+    }
+    BridgeStatus::NoInterface
+}
+
+/// Config-file spellings for the bridge settings, matching what the parser
+/// accepts.
+fn bridge_driver_name(d: BridgeDriver) -> &'static str {
+    match d {
+        BridgeDriver::DrawBridge => "drawbridge",
+        BridgeDriver::Greaseweazle => "greaseweazle",
+        BridgeDriver::SupercardPro => "supercardpro",
+    }
+}
+
+fn bridge_cable_name(c: BridgeCable) -> &'static str {
+    match c {
+        BridgeCable::DriveA => "a",
+        BridgeCable::DriveB => "b",
+        BridgeCable::Shugart0 => "0",
+        BridgeCable::Shugart1 => "1",
+        BridgeCable::Shugart2 => "2",
+        BridgeCable::Shugart3 => "3",
+    }
+}
+
+fn bridge_density_name(d: BridgeDensity) -> &'static str {
+    match d {
+        BridgeDensity::Auto => "auto",
+        BridgeDensity::Dd => "dd",
+        BridgeDensity::Hd => "hd",
+    }
+}
+
+fn bridge_mode_name(m: BridgeSpeedMode) -> &'static str {
+    match m {
+        BridgeSpeedMode::Compatible => "compatible",
+        BridgeSpeedMode::Normal => "normal",
+        BridgeSpeedMode::Stalling => "stalling",
+    }
+}
+
+const BRIDGE_DRIVERS: [BridgeDriver; 3] = [
+    BridgeDriver::DrawBridge,
+    BridgeDriver::Greaseweazle,
+    BridgeDriver::SupercardPro,
+];
+const BRIDGE_CABLES: [BridgeCable; 6] = [
+    BridgeCable::DriveA,
+    BridgeCable::DriveB,
+    BridgeCable::Shugart0,
+    BridgeCable::Shugart1,
+    BridgeCable::Shugart2,
+    BridgeCable::Shugart3,
+];
+const BRIDGE_DENSITIES: [BridgeDensity; 3] =
+    [BridgeDensity::Auto, BridgeDensity::Dd, BridgeDensity::Hd];
+// Ordered as Amiberry's drive-type list has them, so the two read the same.
+// Its Turbo is absent: that one answers AmigaDOS calls instead of reading the
+// disk, so there is nothing for a drive model to do with it.
+const BRIDGE_SPEEDS: [BridgeSpeedMode; 3] = [
+    BridgeSpeedMode::Normal,
+    BridgeSpeedMode::Compatible,
+    BridgeSpeedMode::Stalling,
+];
 const AUDIO_FILTER_MODES: [AudioFilterMode; 3] = [
     AudioFilterMode::Auto,
     AudioFilterMode::On,
@@ -980,6 +1120,17 @@ pub struct MachineSetup {
     /// image is a one-element list.
     df_playlists: [Vec<PathBuf>; 4],
     df_write_protected: [bool; 4],
+    /// A real drive on this bay instead of an image. `None` is the ordinary
+    /// image-backed drive.
+    df_bridge: [Option<FloppyBridgeConfig>; 4],
+    /// Which bay the FloppyBridge settings page is showing. The page itself is
+    /// one set of rows; this says whose values they are.
+    bridge_edit_drive: usize,
+    /// What the library could see the last time we looked. Sampled when the
+    /// launcher opens and whenever a bay is switched over to a physical drive,
+    /// so a board plugged in mid-session is picked up by unticking and
+    /// re-ticking the box rather than by a scan every frame.
+    bridge_status: BridgeStatus,
     // Hard disk. Each drive's optional volume-name override (directory mounts
     // only) sits in the matching `*_name` slot, paralleling the path slot. Boot
     // priority is edited on the Boot Priority sub-page and split across two
@@ -1117,10 +1268,13 @@ impl MachineSetup {
     /// "no boot ROM = AROS" distinction, and the `[[zorro]]` board paths.
     pub fn from_raw(raw: &RawConfig) -> Result<Self> {
         let cfg: Config = raw.clone().try_into()?;
+        // One tick box governs both kinds of bay, so read it from whichever
+        // of the two a bay actually has.
         let df_write_protected = std::array::from_fn(|i| {
             cfg.floppy.drives[i]
                 .as_ref()
                 .map(|d| d.write_protected)
+                .or_else(|| cfg.floppy.bridges[i].as_ref().map(|b| b.write_protected))
                 .unwrap_or(true)
         });
         let connected = cfg.floppy_connected.iter().filter(|&&c| c).count().max(1) as u8;
@@ -1150,6 +1304,9 @@ impl MachineSetup {
             floppy_speed: cfg.floppy.speed,
             df_playlists: cfg.floppy_playlists.clone(),
             df_write_protected,
+            df_bridge: std::array::from_fn(|i| cfg.floppy.bridges[i].clone()),
+            bridge_edit_drive: 0,
+            bridge_status: bridge_status(),
             ide_master: cfg.ide.master.as_ref().map(|d| d.path.clone()),
             ide_master_name: cfg.ide.master.as_ref().and_then(|d| d.volume_name.clone()),
             ide_master_bootpri: boot_priority_of(raw.ide.master.as_ref().and_then(|d| d.bootpri)),
@@ -1649,6 +1806,28 @@ impl MachineSetup {
     }
 
     fn floppy_drive_raw(&self, idx: usize) -> Option<RawFloppyDrive> {
+        // A bay using a real drive writes its interface and settings instead
+        // of an image; only the settings that differ from the cautious
+        // defaults are emitted, so a saved config stays readable.
+        if let Some(bridge) = self.df_bridge[idx].as_ref() {
+            let default = FloppyBridgeConfig::default();
+            return Some(RawFloppyDrive {
+                bridge: Some(bridge_driver_name(bridge.driver).to_string()),
+                bridge_port: bridge.port.clone(),
+                bridge_cable: (bridge.cable != default.cable)
+                    .then(|| bridge_cable_name(bridge.cable).to_string()),
+                bridge_density: (bridge.density != default.density)
+                    .then(|| bridge_density_name(bridge.density).to_string()),
+                bridge_mode: (bridge.mode != default.mode)
+                    .then(|| bridge_mode_name(bridge.mode).to_string()),
+                bridge_smart_speed: bridge.smart_speed.then_some(true),
+                bridge_auto_cache: bridge.auto_cache.then_some(true),
+                // Same rule, and the same tick box, as an image: only an
+                // unprotected drive says so.
+                write_protected: (!self.df_write_protected[idx]).then_some(false),
+                ..RawFloppyDrive::default()
+            });
+        }
         let playlist = &self.df_playlists[idx];
         if playlist.is_empty() {
             // A write-protect flag on an empty drive is meaningless, so an
@@ -1663,6 +1842,8 @@ impl MachineSetup {
             // write_protected defaults to true; only an unprotected drive is
             // written explicitly.
             write_protected: (!self.df_write_protected[idx]).then_some(false),
+            // Bridges are emitted by the FloppyBridge page, not the image rows.
+            ..RawFloppyDrive::default()
         })
     }
 
@@ -1893,6 +2074,29 @@ impl MachineSetup {
             // when inactive (see `rows`), so they never need a greyed state.
             // Channel mode and separation shape the output, so they do nothing
             // once audio is disabled; separation also does nothing in mono.
+            #[cfg(feature = "floppybridge")]
+            F::BridgePort => reason(
+                self.bridge_driver_supports(crate::floppybridge::config_option::COM_PORT),
+                "not on this interface",
+            ),
+            #[cfg(feature = "floppybridge")]
+            F::BridgeCable => reason(
+                self.bridge_driver_supports(crate::floppybridge::config_option::DRIVE_AB_CABLE)
+                    || self.bridge_driver_supports(
+                        crate::floppybridge::config_option::SUPPORTS_SHUGART,
+                    ),
+                "not on this interface",
+            ),
+            #[cfg(feature = "floppybridge")]
+            F::BridgeSmartSpeed => reason(
+                self.bridge_driver_supports(crate::floppybridge::config_option::SMART_SPEED),
+                "not on this interface",
+            ),
+            #[cfg(feature = "floppybridge")]
+            F::BridgeAutoCache => reason(
+                self.bridge_driver_supports(crate::floppybridge::config_option::AUTO_CACHE),
+                "not on this interface",
+            ),
             F::AudioChannelMode => reason(self.audio_output.is_enabled(), "off"),
             F::AudioFilter => reason(self.audio_output.is_enabled(), "off"),
             F::AudioStereoSeparation => {
@@ -1924,6 +2128,8 @@ impl MachineSetup {
             F::Df3WriteProtect => self.df_write_protected[3],
             F::FloppySounds => self.floppy_sounds,
             F::StartFullscreen => self.start_fullscreen,
+            F::BridgeSmartSpeed => self.bridge_edit().is_some_and(|c| c.smart_speed),
+            F::BridgeAutoCache => self.bridge_edit().is_some_and(|c| c.auto_cache),
             F::ShowStatusBar => self.show_status_bar,
             F::Deinterlace => self.deinterlace,
             F::Bezel => self.bezel,
@@ -2133,6 +2339,34 @@ impl MachineSetup {
                     format!("{:.2}", self.phosphor)
                 }
             }
+            F::BridgeDevice => self
+                .bridge_edit()
+                .map_or_else(|| "(none)".to_string(), |c| c.driver.label().to_string()),
+            F::BridgePort => match self.bridge_edit().and_then(|c| c.port.clone()) {
+                None => "Automatic".to_string(),
+                Some(p) => p,
+            },
+            F::BridgeCable => match self.bridge_edit().map(|c| c.cable) {
+                Some(BridgeCable::DriveA) => "PC drive A".to_string(),
+                Some(BridgeCable::DriveB) => "PC drive B".to_string(),
+                Some(BridgeCable::Shugart0) => "Shugart 0".to_string(),
+                Some(BridgeCable::Shugart1) => "Shugart 1".to_string(),
+                Some(BridgeCable::Shugart2) => "Shugart 2".to_string(),
+                Some(BridgeCable::Shugart3) => "Shugart 3".to_string(),
+                None => "(none)".to_string(),
+            },
+            F::BridgeDensity => match self.bridge_edit().map(|c| c.density) {
+                Some(BridgeDensity::Auto) => "Automatic".to_string(),
+                Some(BridgeDensity::Dd) => "DD only".to_string(),
+                Some(BridgeDensity::Hd) => "HD only".to_string(),
+                None => "(none)".to_string(),
+            },
+            F::BridgeSpeed => match self.bridge_edit().map(|c| c.mode) {
+                Some(BridgeSpeedMode::Compatible) => "Compatible".to_string(),
+                Some(BridgeSpeedMode::Normal) => "Normal".to_string(),
+                Some(BridgeSpeedMode::Stalling) => "Stalling".to_string(),
+                None => "(none)".to_string(),
+            },
             F::Shader => match self.shader {
                 ShaderMode::None => "Off".to_string(),
                 ShaderMode::Scanlines => "Scanlines".to_string(),
@@ -2254,7 +2488,8 @@ impl MachineSetup {
             // Path/drive fields: the file name, or a placeholder.
             F::Rom => self.path_label(field, "(bundled AROS)"),
             _ if rows_contains_kind(field, RowKind::Path)
-                || rows_contains_kind(field, RowKind::Drive) =>
+                || rows_contains_kind(field, RowKind::Drive)
+                || rows_contains_kind(field, RowKind::FloppyMedia) =>
             {
                 self.path_label(field, "(none)")
             }
@@ -2354,6 +2589,14 @@ impl MachineSetup {
             F::Z3Ram => self.z3_ram = cycle_nearest(&Z3_PRESETS, self.z3_ram, forward),
             F::FloppyDrives => {
                 self.floppy_drives = step_u8(self.floppy_drives, forward, 1, 4);
+                // A bay that is no longer fitted has no business holding a
+                // physical drive open: the row is gone from the page, so
+                // nothing would say why the interface was busy the next time
+                // it was asked for.
+                #[cfg(feature = "floppybridge")]
+                for bay in self.df_bridge.iter_mut().skip(self.floppy_drives as usize) {
+                    *bay = None;
+                }
             }
             F::FloppySpeed => {
                 self.floppy_speed = cycle_slice(&FLOPPY_SPEEDS, self.floppy_speed, forward)
@@ -2476,6 +2719,39 @@ impl MachineSetup {
             F::AudioFilter => {
                 self.audio_filter = cycle_slice(&AUDIO_FILTER_MODES, self.audio_filter, forward)
             }
+            F::BridgeDevice => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.driver = cycle_slice(&BRIDGE_DRIVERS, c.driver, forward);
+                }
+            }
+            F::BridgePort => {
+                let options = self.bridge_port_options();
+                if let Some(c) = self.bridge_edit_mut() {
+                    let idx = options.iter().position(|p| *p == c.port).unwrap_or(0);
+                    let n = options.len();
+                    let next = if forward {
+                        (idx + 1) % n
+                    } else {
+                        (idx + n - 1) % n
+                    };
+                    c.port = options[next].clone();
+                }
+            }
+            F::BridgeCable => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.cable = cycle_slice(&BRIDGE_CABLES, c.cable, forward);
+                }
+            }
+            F::BridgeDensity => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.density = cycle_slice(&BRIDGE_DENSITIES, c.density, forward);
+                }
+            }
+            F::BridgeSpeed => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.mode = cycle_slice(&BRIDGE_SPEEDS, c.mode, forward);
+                }
+            }
             F::AudioStereoSeparation => {
                 self.audio_stereo_separation = cycle_nearest(
                     &STEREO_SEPARATION_STEPS,
@@ -2520,6 +2796,15 @@ impl MachineSetup {
             F::Fpu => self.fpu = !self.fpu,
             F::Icache => self.icache = !self.icache,
             F::Dcache => self.dcache = !self.dcache,
+            F::Df0WriteProtect | F::Df1WriteProtect | F::Df2WriteProtect | F::Df3WriteProtect
+                if Self::drive_protect_bay(field).is_some() =>
+            {
+                let bay = Self::drive_protect_bay(field).expect("checked above");
+                self.df_write_protected[bay] = !self.df_write_protected[bay];
+                if let Some(bridge) = self.df_bridge[bay].as_mut() {
+                    bridge.write_protected = self.df_write_protected[bay];
+                }
+            }
             F::Df0WriteProtect => self.df_write_protected[0] = !self.df_write_protected[0],
             F::Df1WriteProtect => self.df_write_protected[1] = !self.df_write_protected[1],
             F::Df2WriteProtect => self.df_write_protected[2] = !self.df_write_protected[2],
@@ -2530,6 +2815,16 @@ impl MachineSetup {
             F::Deinterlace => self.deinterlace = !self.deinterlace,
             F::Bezel => self.bezel = !self.bezel,
             F::PowerOn => self.power_on = !self.power_on,
+            F::BridgeSmartSpeed => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.smart_speed = !c.smart_speed;
+                }
+            }
+            F::BridgeAutoCache => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.auto_cache = !c.auto_cache;
+                }
+            }
             F::RealtimePriority => self.realtime_priority = !self.realtime_priority,
             _ => {}
         }
@@ -2773,6 +3068,156 @@ impl MachineSetup {
             .take_while(|r| r.field != field)
             .filter(|r| self.boot_field_applies(r.field))
             .count()
+    }
+
+    /// The bay a `DfNImage` field belongs to.
+    pub fn drive_image_bay(field: LauncherField) -> Option<usize> {
+        Some(match field {
+            F::Df0Image => 0,
+            F::Df1Image => 1,
+            F::Df2Image => 2,
+            F::Df3Image => 3,
+            _ => return None,
+        })
+    }
+
+    /// The bay a `DfNWriteProtect` field belongs to.
+    pub fn drive_protect_bay(field: LauncherField) -> Option<usize> {
+        Some(match field {
+            F::Df0WriteProtect => 0,
+            F::Df1WriteProtect => 1,
+            F::Df2WriteProtect => 2,
+            F::Df3WriteProtect => 3,
+            _ => return None,
+        })
+    }
+
+    /// The `DfNBridge` tick box for a bay.
+    pub fn drive_bridge_field(idx: usize) -> LauncherField {
+        match idx {
+            0 => F::Df0Bridge,
+            1 => F::Df1Bridge,
+            2 => F::Df2Bridge,
+            _ => F::Df3Bridge,
+        }
+    }
+
+    /// Whether this bay uses a real drive rather than an image.
+    pub fn drive_bridged(&self, idx: usize) -> bool {
+        self.df_bridge.get(idx).is_some_and(Option::is_some)
+    }
+
+    /// Turn a bay over to a physical drive, or back to images. Switching to a
+    /// bridge clears the image: the disk in the drive is the media now.
+    ///
+    /// Without the feature there is no such thing as a bridged bay -- no tick
+    /// box offers one, the config file's keys are ignored -- and this refuses
+    /// as well, so no path can leave a bay in a state the build cannot honour.
+    #[cfg(feature = "floppybridge")]
+    pub fn set_drive_bridged(&mut self, idx: usize, on: bool) {
+        if idx >= self.df_bridge.len() || self.drive_bridged(idx) == on {
+            return;
+        }
+        if on {
+            self.df_playlists[idx].clear();
+            self.df_bridge[idx] = Some(FloppyBridgeConfig::default());
+            // Look again now: this is the moment the user expects to be told
+            // whether there is anything on the other end.
+            self.bridge_status = bridge_status();
+            // Wire the bay in, as choosing an image would.
+            self.floppy_drives = self.floppy_drives.max(idx as u8 + 1);
+        } else {
+            self.df_bridge[idx] = None;
+        }
+    }
+
+    #[cfg(not(feature = "floppybridge"))]
+    pub fn set_drive_bridged(&mut self, _idx: usize, _on: bool) {}
+
+    /// The interface a bridged bay is set to use, for its media row. Naming one
+    /// that is not there would suggest the bay is ready to run when it is not,
+    /// so what is missing is named instead -- and which of the two it is
+    /// decides whether the fix is installing software or plugging in hardware.
+    pub fn drive_bridge_label(&self, idx: usize) -> String {
+        let Some(cfg) = self.df_bridge.get(idx).and_then(Option::as_ref) else {
+            return "(none)".to_string();
+        };
+        match self.bridge_status {
+            BridgeStatus::NoInterface => "None".to_string(),
+            BridgeStatus::Attached => cfg.driver.label().to_string(),
+        }
+    }
+
+    /// What the library can see, for the FloppyBridge page's heading.
+    pub fn bridge_status(&self) -> BridgeStatus {
+        self.bridge_status
+    }
+
+    /// Which bay the settings page is editing.
+    pub fn bridge_edit_drive(&self) -> usize {
+        self.bridge_edit_drive
+    }
+
+    pub fn set_bridge_edit_drive(&mut self, idx: usize) {
+        self.bridge_edit_drive = idx.min(3);
+    }
+
+    /// The settings being shown on the FloppyBridge page.
+    fn bridge_edit(&self) -> Option<&FloppyBridgeConfig> {
+        self.df_bridge[self.bridge_edit_drive].as_ref()
+    }
+
+    fn bridge_edit_mut(&mut self) -> Option<&mut FloppyBridgeConfig> {
+        self.df_bridge[self.bridge_edit_drive].as_mut()
+    }
+
+    /// Whether the interface this page is editing honours one of the library's
+    /// optional settings, as that driver itself reports.
+    ///
+    /// Each driver advertises what it supports, and they differ: a Greaseweazle
+    /// takes a drive-select cable and smart speed, a DrawBridge answers to a
+    /// different set. Offering a switch the hardware ignores is how a user ends
+    /// up believing they changed something, so the ones it does not honour are
+    /// greyed with the interface's name against them.
+    #[cfg(feature = "floppybridge")]
+    fn bridge_driver_supports(&self, option: u32) -> bool {
+        let Some(cfg) = self.bridge_edit() else {
+            return false;
+        };
+        let token = cfg.driver.match_token();
+        // With no library there is nothing to ask, so leave every row live
+        // rather than greying the page out on a machine that simply has not
+        // installed it yet.
+        let drivers = crate::floppybridge::drivers();
+        if drivers.is_empty() {
+            return true;
+        }
+        drivers
+            .iter()
+            .find(|d| {
+                d.name
+                    .to_ascii_lowercase()
+                    .replace([' ', '-', '_'], "")
+                    .contains(token)
+            })
+            .is_none_or(|d| d.supports(option))
+    }
+
+    /// Serial ports the installed library can see, with "Automatic" first --
+    /// the default, and what every current interface supports. The names are
+    /// the host's own, so `/dev/cu.usbmodem101` on macOS, `/dev/ttyACM0` on
+    /// Linux, `COM3` on Windows.
+    fn bridge_port_options(&self) -> Vec<Option<String>> {
+        #[cfg(feature = "floppybridge")]
+        {
+            std::iter::once(None)
+                .chain(crate::floppybridge::com_ports().into_iter().map(Some))
+                .collect()
+        }
+        #[cfg(not(feature = "floppybridge"))]
+        {
+            vec![None]
+        }
     }
 
     pub fn zorro_boards(&self) -> &[ZorroBoardSetup] {
@@ -3430,6 +3875,131 @@ fn pacing_name(pacing: PacingBudget) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The interfaces genuinely differ in what they honour, and the page says
+    /// so: a DrawBridge has no drive-select line on its cable, a Greaseweazle
+    /// does. Only meaningful with the library installed -- without it there is
+    /// nothing to ask, and every row deliberately stays live.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn bridge_rows_grey_what_the_interface_does_not_support() {
+        if crate::floppybridge::drivers().is_empty() {
+            return;
+        }
+        let mut setup = MachineSetup::default();
+        setup.set_drive_bridged(0, true);
+        setup.set_bridge_edit_drive(0);
+
+        for (driver, cable_greyed) in [
+            (crate::config::BridgeDriver::Greaseweazle, false),
+            (crate::config::BridgeDriver::DrawBridge, true),
+        ] {
+            setup.df_bridge[0].as_mut().expect("bridged").driver = driver;
+            assert_eq!(
+                setup.disabled_reason(F::BridgeCable).is_some(),
+                cable_greyed,
+                "drive select on {driver:?}"
+            );
+            // Every interface here talks over a serial port and can read ahead.
+            assert!(setup.disabled_reason(F::BridgePort).is_none());
+            assert!(setup.disabled_reason(F::BridgeAutoCache).is_none());
+        }
+    }
+
+    /// A bridged bay only names its interface when one is actually attached:
+    /// with nothing plugged in the media row says so, whatever the bay is
+    /// configured for.
+    // A build without the feature has no bridges to configure: the keys are
+    // read and ignored, so there is nothing here to assert.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn a_bridged_bay_names_its_interface_only_when_one_is_attached() {
+        let mut setup = MachineSetup::default();
+        setup.set_drive_bridged(0, true);
+
+        setup.bridge_status = BridgeStatus::Attached;
+        assert_eq!(
+            setup.drive_bridge_label(0),
+            crate::config::BridgeDriver::default().label()
+        );
+
+        setup.bridge_status = BridgeStatus::NoInterface;
+        assert_eq!(setup.drive_bridge_label(0), "None");
+
+        // An image-backed bay is not a bridge at all, connected or not.
+        assert_eq!(setup.drive_bridge_label(1), "(none)");
+    }
+
+    /// The write-protect box governs a real drive as well as an image, and it
+    /// starts ticked: a bay handed a physical disk must not come up writable
+    /// because nobody said otherwise.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn dropping_a_drive_releases_the_physical_one_it_was_holding() {
+        let mut setup = MachineSetup {
+            floppy_drives: 2,
+            ..Default::default()
+        };
+        setup.set_drive_bridged(1, true);
+        assert!(setup.df_bridge[1].is_some(), "df1 bridged");
+
+        // Take the machine back to one drive. df1's row goes off the page, so
+        // if it kept the bridge nothing would explain why the interface was
+        // busy the next time a bay asked for it.
+        setup.cycle(F::FloppyDrives, false);
+        assert_eq!(setup.floppy_drives, 1);
+        assert!(setup.df_bridge[1].is_none(), "df1 released the drive");
+
+        // df0 is still fitted, so anything set on it stays put.
+        setup.set_drive_bridged(0, true);
+        setup.floppy_drives = 2;
+        setup.cycle(F::FloppyDrives, false);
+        assert!(setup.df_bridge[0].is_some(), "df0 kept its bridge");
+    }
+
+    // A build without the feature has no bridges to configure: the keys are
+    // read and ignored, so there is nothing here to assert.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn write_protect_governs_a_bridged_bay_and_survives_a_round_trip() {
+        let mut setup = MachineSetup::default();
+        setup.set_drive_bridged(0, true);
+        assert!(
+            setup.toggle_value(F::Df0WriteProtect),
+            "protected by default"
+        );
+
+        let cfg = setup.build_config().expect("valid");
+        let bridge = cfg.floppy.bridges[0].as_ref().expect("bridged");
+        assert!(bridge.write_protected);
+
+        // Untick it, and both the emitted config and the bay's own copy follow.
+        setup.toggle(F::Df0WriteProtect);
+        assert!(!setup.toggle_value(F::Df0WriteProtect));
+        assert!(
+            !setup.df_bridge[0]
+                .as_ref()
+                .expect("bridged")
+                .write_protected
+        );
+        let cfg = setup.build_config().expect("valid");
+        assert!(
+            !cfg.floppy.bridges[0]
+                .as_ref()
+                .expect("bridged")
+                .write_protected
+        );
+
+        // And it comes back the same way, rather than reverting to protected.
+        let reloaded = MachineSetup::from_raw(&setup.to_raw()).expect("round trip");
+        assert!(!reloaded.toggle_value(F::Df0WriteProtect));
+        assert!(
+            !reloaded.df_bridge[0]
+                .as_ref()
+                .expect("bridged")
+                .write_protected
+        );
+    }
 
     fn write_board_manifest() -> PathBuf {
         let path = std::env::temp_dir().join(format!(

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -606,7 +606,7 @@ const FLOPPY_BRIDGE_ROWS: [Row; 8] = [
     row(F::BridgeDensity, "Density", Cycle),
     row(F::BridgeSpeed, "Read mode", Cycle),
     row(F::BridgeSmartSpeed, "Smart speed", Toggle),
-    row(F::BridgeAutoCache, "Read ahead", Toggle),
+    row(F::BridgeAutoCache, "Auto-cache", Toggle),
 ];
 const STORAGE_ROWS: [Row; 12] = [
     row(F::IdeMaster, "IDE master", Drive),
@@ -3900,7 +3900,7 @@ mod tests {
                 cable_greyed,
                 "drive select on {driver:?}"
             );
-            // Every interface here talks over a serial port and can read ahead.
+            // Every interface here talks over a serial port and can auto-cache.
             assert!(setup.disabled_reason(F::BridgePort).is_none());
             assert!(setup.disabled_reason(F::BridgeAutoCache).is_none());
         }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -1165,6 +1165,10 @@ pub enum UiControl {
     LauncherDriveBootpriEdit(LauncherField),
     /// Boot Priority page: toggle a drive's Bootable box.
     LauncherDriveBootToggle(LauncherField),
+    /// Floppy tab: turn a bay over to a real drive, or back to images.
+    LauncherDriveBridgeToggle(usize),
+    /// Floppy tab: open the FloppyBridge settings for a bay.
+    LauncherBridgeConfigure(usize),
     /// Configuration screen: add a Zorro metadata board file.
     LauncherZorroAdd,
     /// Configuration screen: remove the Zorro board at this index.
@@ -4776,6 +4780,65 @@ fn launcher_bootable_box(cell: Rect) -> Rect {
 
 const BOOTABLE_LABEL: &str = "Bootable";
 
+/// The heading above the FloppyBridge settings: upstream's own name for the
+/// library, and which version of it is installed. Nothing else in the launcher
+/// says which build is in use, and it is the first thing worth knowing when a
+/// drive misbehaves.
+fn bridge_library_heading() -> String {
+    #[cfg(feature = "floppybridge")]
+    if let Some((major, minor)) = crate::floppybridge::version() {
+        return format!("FloppyDriveBridge v{major}.{minor}:");
+    }
+    "FloppyDriveBridge:".to_string()
+}
+
+const WRITE_PROTECT_LABEL: &str = "Write protect:";
+const PHYSICAL_DRIVE_LABEL: &str = "Physical drive:";
+
+/// The two tick-box cells under a floppy drive: write protect on the left,
+/// the real-drive switch level with the value column so the eye can run down
+/// the tab.
+fn launcher_floppy_flag_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
+    let y = row_y + 2;
+    let protect = Rect {
+        // Indented to sit under the media row's label, which carries its own
+        // two leading spaces, so the drive's two lines start together.
+        x: launcher_pane_x(rect) + 2 * font::GLYPH_W,
+        y,
+        w: WRITE_PROTECT_LABEL.len() * font::GLYPH_W + 8 + 12,
+        h: LAUNCH_CONTROL_H,
+    };
+    let bridge = Rect {
+        x: launcher_control_x(rect) + LAUNCH_ARROW_W,
+        y,
+        w: PHYSICAL_DRIVE_LABEL.len() * font::GLYPH_W + 8 + 12,
+        h: LAUNCH_CONTROL_H,
+    };
+    (protect, bridge)
+}
+
+/// The tick box inside one of those cells, after its label.
+fn launcher_flag_box(cell: Rect, label: &str) -> Rect {
+    Rect {
+        x: cell.x + label.len() * font::GLYPH_W + 8,
+        y: cell.y + (cell.h.saturating_sub(12)) / 2,
+        w: 12,
+        h: 12,
+    }
+}
+
+/// The Configure button on a bridged drive's media row, where Browse sits on
+/// an image-backed one.
+fn launcher_bridge_configure_rect(rect: Rect, row_y: usize) -> Rect {
+    let (browse, clear) = launcher_path_rects(rect, row_y);
+    Rect {
+        x: browse.x,
+        y: browse.y,
+        w: browse.w + 4 + clear.w,
+        h: browse.h,
+    }
+}
+
 /// (Browse, Clear) buttons for a path row, just after the fixed-width value
 /// column ([`LAUNCH_PATH_VALUE_W`]) rather than out at the panel's right edge.
 fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
@@ -5054,6 +5117,40 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         return Some(UiControl::LauncherClear(r.field));
                     }
                 }
+                RowKind::FloppyMedia => {
+                    let drive = launcher::MachineSetup::drive_image_bay(r.field);
+                    if let Some(bay) = drive {
+                        if state.setup.drive_bridged(bay) {
+                            // Bridged: one Configure button where Browse and
+                            // Clear would be. There is no image to pick.
+                            if launcher_bridge_configure_rect(rect, row_y).contains(pos) {
+                                return Some(UiControl::LauncherBridgeConfigure(bay));
+                            }
+                            continue;
+                        }
+                    }
+                    let (browse, clear) = launcher_path_rects(rect, row_y);
+                    if browse.contains(pos) {
+                        return Some(UiControl::LauncherBrowse(r.field));
+                    }
+                    if clear.contains(pos) {
+                        return Some(UiControl::LauncherClear(r.field));
+                    }
+                }
+                RowKind::FloppyFlags => {
+                    let (protect, _bridge) = launcher_floppy_flag_rects(rect, row_y);
+                    if protect.contains(pos) {
+                        return Some(UiControl::LauncherToggle(r.field));
+                    }
+                    // A build without the feature has no physical-drive box to
+                    // hit: the whole thing is absent rather than inert.
+                    #[cfg(feature = "floppybridge")]
+                    if _bridge.contains(pos) {
+                        if let Some(bay) = launcher::MachineSetup::drive_protect_bay(r.field) {
+                            return Some(UiControl::LauncherDriveBridgeToggle(bay));
+                        }
+                    }
+                }
                 RowKind::Drive => {
                     let (browse, clear) = launcher_path_rects(rect, row_y);
                     if browse.contains(pos) {
@@ -5216,11 +5313,20 @@ fn draw_launcher_row(
     // A section heading is a greyed, non-interactive label grouping the rows
     // below it (the Serial:/Parallel: sections of the I/O Ports tab).
     if r.kind == RowKind::SectionHeader {
+        // The FloppyBridge page's heading names the installed library, so its
+        // text is not the one in the row table.
+        let heading;
+        let text = if r.field == LauncherField::BridgeLibrary {
+            heading = bridge_library_heading();
+            &heading
+        } else {
+            r.label
+        };
         draw_panel_text(
             frame,
             launcher_pane_x(rect),
             row_y + 8,
-            r.label,
+            text,
             PANEL_TEXT_DIM,
             1,
             scale,
@@ -5244,20 +5350,36 @@ fn draw_launcher_row(
     } else {
         PANEL_TEXT_DIM
     };
+    // A bay on a real drive says so in place of "Disk image": there is no
+    // image, and the row's value is the interface rather than a file.
+    let label = if r.kind == RowKind::FloppyMedia
+        && launcher::MachineSetup::drive_image_bay(r.field)
+            .is_some_and(|bay| setup.drive_bridged(bay))
+    {
+        // Matches the tick box that turned it on, and fits the label column
+        // where the full "FloppyDriveBridge" would run into the value. Which
+        // version of the library is installed is named on the Configure page,
+        // where there is room for it.
+        "  FloppyBridge"
+    } else {
+        r.label
+    };
     draw_panel_text(
         frame,
         launcher_pane_x(rect),
         row_y + 8,
-        r.label,
+        label,
         label_color,
         1,
         scale,
     );
     // Greyed: explain why instead of drawing controls (e.g. "needs 32-bit CPU").
-    // The shaping rows are the exception -- channel mode, separation and mouse
-    // sensitivity are merely inapplicable (audio disabled, separation in mono,
-    // or no mouse in either port), so the greyed label alone says enough and
-    // column 2 is left blank.
+    // Some rows are the exception. The shaping rows -- channel mode,
+    // separation, mouse sensitivity -- are merely inapplicable (audio
+    // disabled, separation in mono, no mouse in either port), and a bridge
+    // setting the chosen interface does not implement is not a thing to
+    // explain either: the greyed label alone says enough, so column 2 is left
+    // blank rather than repeating "not on this interface" down the page.
     let blank_when_greyed = matches!(
         r.field,
         LauncherField::AudioChannelMode
@@ -5265,6 +5387,10 @@ fn draw_launcher_row(
             | LauncherField::MouseSensitivity
             | LauncherField::MouseCapture
             | LauncherField::ShaderStrength
+            | LauncherField::BridgePort
+            | LauncherField::BridgeCable
+            | LauncherField::BridgeSmartSpeed
+            | LauncherField::BridgeAutoCache
     );
     if let Some(reason) = reason {
         if !blank_when_greyed {
@@ -5405,6 +5531,97 @@ fn draw_launcher_row(
                     ),
                     PANEL_TEXT_HILIGHT,
                     scale,
+                );
+            }
+        }
+        RowKind::FloppyMedia => {
+            let bay = launcher::MachineSetup::drive_image_bay(r.field);
+            let bridged = bay.is_some_and(|b| setup.drive_bridged(b));
+            let value_x = launcher_control_x(rect);
+            let (browse, clear) = launcher_path_rects(rect, row_y);
+            if bridged {
+                let bay = bay.expect("bridged implies a bay");
+                let text = setup.drive_bridge_label(bay);
+                draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
+                let button = launcher_bridge_configure_rect(rect, row_y);
+                draw_text_button(
+                    frame,
+                    button,
+                    "Configure",
+                    true,
+                    hover == Some(UiControl::LauncherBridgeConfigure(bay)),
+                    scale,
+                );
+            } else {
+                let avail = browse.x.saturating_sub(value_x + 8);
+                let text = truncate_to_width(&setup.value_label(r.field), avail);
+                draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
+                draw_text_button(
+                    frame,
+                    browse,
+                    "Browse",
+                    true,
+                    hover == Some(UiControl::LauncherBrowse(r.field)),
+                    scale,
+                );
+                draw_text_button(
+                    frame,
+                    clear,
+                    "Clear",
+                    true,
+                    hover == Some(UiControl::LauncherClear(r.field)),
+                    scale,
+                );
+            }
+        }
+        RowKind::FloppyFlags => {
+            #[cfg_attr(not(feature = "floppybridge"), allow(unused_variables))]
+            let bay = launcher::MachineSetup::drive_protect_bay(r.field);
+            #[cfg_attr(not(feature = "floppybridge"), allow(unused_variables))]
+            let (protect_cell, bridge_cell) = launcher_floppy_flag_rects(rect, row_y);
+            let mut tick = |cell: Rect, label: &str, on: bool, hot: bool| {
+                draw_panel_text(frame, cell.x, cell.y + 6, label, PANEL_TEXT, 1, scale);
+                let box_rect = launcher_flag_box(cell, label);
+                fill_rect(
+                    frame,
+                    scale_rect(box_rect, scale),
+                    if hot { BUTTON_FACE_HOVER } else { ENTRY_BG },
+                    scale,
+                );
+                draw_outline(frame, box_rect, BUTTON_EDGE_LIGHT, scale);
+                if on {
+                    fill_rect(
+                        frame,
+                        scale_rect(
+                            Rect {
+                                x: box_rect.x + 3,
+                                y: box_rect.y + 3,
+                                w: 6,
+                                h: 6,
+                            },
+                            scale,
+                        ),
+                        PANEL_TEXT_HILIGHT,
+                        scale,
+                    );
+                }
+            };
+            tick(
+                protect_cell,
+                WRITE_PROTECT_LABEL,
+                setup.toggle_value(r.field),
+                hover == Some(UiControl::LauncherToggle(r.field)),
+            );
+            // Only drawn where a physical drive can actually be attached; a
+            // build without the feature leaves the write-protect box alone on
+            // the row rather than offering a switch that does nothing.
+            #[cfg(feature = "floppybridge")]
+            if let Some(bay) = bay {
+                tick(
+                    bridge_cell,
+                    PHYSICAL_DRIVE_LABEL,
+                    setup.drive_bridged(bay),
+                    hover == Some(UiControl::LauncherDriveBridgeToggle(bay)),
                 );
             }
         }
@@ -9147,5 +9364,62 @@ mod tests {
         };
         draw(&mut frame, scale, &ui, None, None, false, false, labels());
         save(&frame, "launcher-floppy");
+
+        // The Floppy tab with DF1 turned over to a real drive: its media row
+        // shows the interface and a Configure button, and its Physical drive box
+        // is ticked while DF0 stays an ordinary image drive.
+        let mut frame = vec![0u8; w * h * 4];
+        let mut setup = launcher::MachineSetup::default();
+        while setup.value_label(LauncherField::FloppyDrives) != "2" {
+            setup.cycle(LauncherField::FloppyDrives, true);
+        }
+        setup.set_path(
+            LauncherField::Df0Image,
+            std::path::PathBuf::from("workbench.adf"),
+        );
+        setup.set_drive_bridged(1, true);
+        let mut state = LauncherState::new(setup);
+        state.tab = LauncherTab::Floppy;
+        let ui = UiState {
+            menu_open: false,
+            menu_scroll: 0,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None, false, false, labels());
+        save(&frame, "launcher-floppy-bridge");
+
+        // The FloppyBridge settings page reached from Configure, on an
+        // interface with no drive-select line: that row greys, and its value
+        // column stays empty rather than explaining itself. Only exists in a
+        // build with the feature -- without it no bay can be bridged, so there
+        // is no such page to draw.
+        #[cfg(feature = "floppybridge")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut setup = launcher::MachineSetup::default();
+            setup.set_drive_bridged(0, true);
+            setup.set_bridge_edit_drive(0);
+            // Bounded: cycling is a fixed-length ring, so a value that never
+            // arrives is a bug to report, not a reason to spin forever.
+            let interfaces = 8;
+            let mut found = false;
+            for _ in 0..interfaces {
+                if setup.value_label(LauncherField::BridgeDevice) == "DrawBridge" {
+                    found = true;
+                    break;
+                }
+                setup.cycle(LauncherField::BridgeDevice, true);
+            }
+            assert!(found, "the DrawBridge interface is one of the choices");
+            let mut state = LauncherState::new(setup);
+            state.tab = LauncherTab::FloppyBridge;
+            let ui = UiState {
+                menu_open: false,
+                menu_scroll: 0,
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None, false, false, labels());
+            save(&frame, "launcher-floppybridge-page");
+        }
     }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4041,12 +4041,29 @@ impl App {
 
     /// Removable-media status for the bar controls: which drives exist,
     /// what is inserted, and whether a CD drive is fitted this session.
+    /// Whether this drive is backed by a real one on a bridge.
+    fn drive_is_bridged(&self, idx: usize) -> bool {
+        #[cfg(feature = "floppybridge")]
+        {
+            self.emu.bus().floppy.is_bridged(idx)
+        }
+        #[cfg(not(feature = "floppybridge"))]
+        {
+            let _ = idx;
+            false
+        }
+    }
+
     fn media_bar(&self) -> MediaBar {
         let bus = self.emu.bus();
         let drives = std::array::from_fn(|idx| DriveBar {
             connected: bus.floppy.drive_connected(idx),
             inserted: bus.floppy.disk_inserted(idx),
             multi: self.disk_playlists[idx].len() > 1,
+            #[cfg(feature = "floppybridge")]
+            bridged: bus.floppy.is_bridged(idx),
+            #[cfg(not(feature = "floppybridge"))]
+            bridged: false,
         });
         let cd = bus.cd_drive_present().then(|| bus.cd_disc_inserted());
         MediaBar { drives, cd }
@@ -4379,6 +4396,12 @@ impl App {
                 self.ui.menu_scroll = 0;
                 self.request_redraw();
             }
+            // A bridged drive's media is a real disk in a real drive: it is
+            // loaded, swapped, and ejected by hand. The buttons stay drawn so
+            // the drive is visibly there and numbered, but they do nothing.
+            BarControl::DriveLoad(idx) if self.drive_is_bridged(idx) => {}
+            BarControl::DriveSwap(idx) if self.drive_is_bridged(idx) => {}
+            BarControl::DriveEject(idx) if self.drive_is_bridged(idx) => {}
             BarControl::DriveLoad(idx) => self.load_drive_disks_from_dialog(idx),
             BarControl::DriveSwap(idx) => self.swap_drive_disk(idx),
             BarControl::DriveEject(idx) => self.eject_drive_disk(idx),
@@ -4596,6 +4619,21 @@ impl App {
             UiControl::LauncherDriveBootpriEdit(field) => {
                 if let Some(state) = self.launcher_state_mut() {
                     state.begin_edit_drive_bootpri(field);
+                }
+            }
+            UiControl::LauncherDriveBridgeToggle(bay) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.edit_cancel();
+                    let on = !state.setup.drive_bridged(bay);
+                    state.setup.set_drive_bridged(bay, on);
+                    state.status = None;
+                }
+            }
+            UiControl::LauncherBridgeConfigure(bay) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.setup.set_bridge_edit_drive(bay);
+                    state.tab = crate::video::launcher::LauncherTab::FloppyBridge;
+                    state.status = None;
                 }
             }
             UiControl::LauncherDriveBootToggle(field) => {
@@ -5815,6 +5853,13 @@ impl App {
                     return;
                 }
             };
+        // Let go of any real floppy drive the outgoing machine holds before
+        // building the new one. The interface can only be open once, and the
+        // machine being replaced is not dropped until `run_machine` swaps it
+        // in -- so without this the new machine tries to open a device its
+        // predecessor still owns, and is told it is in use.
+        #[cfg(feature = "floppybridge")]
+        self.emu.bus_mut().floppy.release_bridges();
         // The launcher boots a fresh machine, never a save state, so a real
         // ROM is required here.
         let emu = match crate::emulator::build_machine(&cfg, audio, true, false) {
@@ -5822,6 +5867,11 @@ impl App {
             Err(e) => {
                 warn!("run failed: {e:#}");
                 self.set_launcher_status(StatusMessage::err(short_status_error(&e)));
+                // The machine that is staying put had its drives taken away
+                // above; give them back rather than leaving it with empty bays
+                // because a different configuration failed to build.
+                #[cfg(feature = "floppybridge")]
+                self.attach_configured_bridges();
                 return;
             }
         };
@@ -8971,9 +9021,36 @@ impl App {
         } else {
             self.powered_on = true;
             self.sync_live_audio_suspension();
+            #[cfg(feature = "floppybridge")]
+            self.attach_configured_bridges();
             info!("power button: machine powered on (cold boot)");
         }
         self.request_redraw();
+    }
+
+    /// Open the real floppy drives this machine's configuration asks for.
+    ///
+    /// Powering off let go of them, so powering back on has to take them
+    /// again. A drive that will not open is logged rather than refused: the
+    /// machine comes up with an empty bay, which is what an Amiga with a dead
+    /// drive does, and the alternative is a power button that does nothing.
+    #[cfg(feature = "floppybridge")]
+    fn attach_configured_bridges(&mut self) {
+        let raw = self.machine_config.clone();
+        let cfg = match crate::config::Config::try_from(raw) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                warn!("could not re-read the configuration to open the physical drives: {e:#}");
+                return;
+            }
+        };
+        if !cfg.floppy.bridges.iter().any(Option::is_some) {
+            return;
+        }
+        let floppy = &mut self.emu.bus_mut().floppy;
+        if let Err(e) = crate::emulator::attach_floppy_bridges(floppy, &cfg) {
+            warn!("physical floppy drive not available: {e:#}");
+        }
     }
 
     /// Toggle host-level pause. Pausing freezes the emulator in place
@@ -9000,6 +9077,13 @@ impl App {
         self.powered_on = false;
         self.paused = false;
         self.sync_live_audio_suspension();
+        // A real drive is powered by the machine: with the Amiga off it stops,
+        // and the interface belongs to the host again. Holding it open would
+        // leave it clicking as though the machine were still running, and
+        // nothing else -- including the next machine this window builds --
+        // could open it.
+        #[cfg(feature = "floppybridge")]
+        self.emu.bus_mut().floppy.release_bridges();
         info!("power button: machine powered off (cold boot state)");
         #[cfg(feature = "control")]
         self.control_complete_pending("pause", "power state changed");

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4039,8 +4039,6 @@ impl App {
         self.request_redraw();
     }
 
-    /// Removable-media status for the bar controls: which drives exist,
-    /// what is inserted, and whether a CD drive is fitted this session.
     /// Whether this drive is backed by a real one on a bridge.
     fn drive_is_bridged(&self, idx: usize) -> bool {
         #[cfg(feature = "floppybridge")]
@@ -4054,6 +4052,8 @@ impl App {
         }
     }
 
+    /// Removable-media status for the bar controls: which drives exist,
+    /// what is inserted, and whether a CD drive is fitted this session.
     fn media_bar(&self) -> MediaBar {
         let bus = self.emu.bus();
         let drives = std::array::from_fn(|idx| DriveBar {

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -67,7 +67,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
             draw_swap_button(
                 frame,
                 scale_rect(rect, texture_scale),
-                drive.multi,
+                drive.multi && !drive.bridged,
                 hover == Some(BarControl::DriveSwap(idx)),
                 texture_scale,
             );
@@ -76,7 +76,9 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
             draw_eject_button(
                 frame,
                 scale_rect(rect, texture_scale),
-                drive.inserted,
+                // Greyed on a bridged drive: the disk is in a real drive and
+                // comes out by hand, not from here.
+                drive.inserted && !drive.bridged,
                 hover == Some(BarControl::DriveEject(idx)),
                 texture_scale,
             );
@@ -162,6 +164,10 @@ pub(super) struct DriveBar {
     pub(super) inserted: bool,
     /// More than one image is queued for this drive (enables swap).
     pub(super) multi: bool,
+    /// Backed by a real drive on a bridge. The buttons still draw, so the
+    /// drive is visibly there and numbered, but there is no media for the
+    /// emulator to load, swap, or eject -- the disk is in someone's hand.
+    pub(super) bridged: bool,
 }
 
 /// Removable-media status for the bar: the floppy drives plus the CD

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -45,6 +45,7 @@ fn single_drive_media() -> MediaBar {
         connected: true,
         inserted: true,
         multi: false,
+        bridged: false,
     };
     MediaBar { drives, cd: None }
 }
@@ -56,6 +57,7 @@ fn media(connected: usize, cd: Option<bool>) -> MediaBar {
             connected: true,
             inserted: true,
             multi: false,
+            bridged: false,
         };
     }
     MediaBar { drives, cd }
@@ -1629,6 +1631,40 @@ fn status_bar_draws_disk_image_button_next_to_track_counter() {
     assert_eq!(
         pixel(&frame, button.x + 12, button.y + 12, scale),
         DISK_BODY_SHADOW.to_le_bytes()
+    );
+}
+
+#[test]
+fn status_bar_greys_swap_and_eject_on_a_bridged_drive() {
+    // A real drive's disk is loaded and ejected by hand, so the buttons stay
+    // drawn -- the drive is still visibly there, and numbered -- but dim,
+    // because there is nothing here for them to do.
+    let scale = 1;
+    let mut bar = single_drive_media();
+    bar.drives[0].multi = true;
+    bar.drives[0].inserted = true;
+    bar.drives[0].bridged = true;
+    let layout = bar_layout(&bar);
+    let swap = layout.drive_swap[0].expect("a bridged drive still shows its buttons");
+    let eject = layout.drive_eject[0].expect("a bridged drive still shows its buttons");
+    assert!(
+        layout.drive_load[0].is_some(),
+        "the disk icon stays, so the drive reads as present"
+    );
+
+    let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+    let mut v = view(FrontPanelStatus::default(), true, false);
+    v.media = bar;
+    draw_status_bar(&mut frame, &v, scale);
+    assert_eq!(
+        pixel(&frame, swap.x + 5, swap.y + 8, scale),
+        BUTTON_GLYPH_DISABLED.to_le_bytes(),
+        "swap is dim on a bridged drive even with a playlist"
+    );
+    assert_eq!(
+        pixel(&frame, eject.x + 5, eject.y + 15, scale),
+        BUTTON_GLYPH_DISABLED.to_le_bytes(),
+        "eject is dim on a bridged drive even with a disk in"
     );
 }
 

--- a/vendor/floppybridge/GPL2.txt
+++ b/vendor/floppybridge/GPL2.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/vendor/floppybridge/MPL2.txt
+++ b/vendor/floppybridge/MPL2.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -1,0 +1,101 @@
+# FloppyBridge (vendored)
+
+Rob Smith's FloppyBridge, which is what lets a Copperline floppy bay drive a
+real 3.5" drive over a DrawBridge, a Greaseweazle, or a Supercard Pro.
+
+- Upstream: <https://github.com/RobSmithDev/FloppyDriveBridge>
+- Vendored from commit `710fa15cb200303f8c4bde1c931786175f301a68` (2024-08-07),
+  which reports itself as version 1.6.
+- Licence: MPL-2.0 or GPL-2.0-or-later (see `MPL2.txt` and `GPL2.txt`), with
+  the ABI headers under the Unlicense. Both are compatible with Copperline's
+  GPL-3.0-or-later.
+
+These sources are compiled straight into the emulator by `build.rs`, so
+`cargo build` produces a binary that drives a real drive with nothing to
+install and nothing to download. `src/floppybridge/` on the Rust side calls
+into them directly.
+
+## Updating
+
+Copy `floppybridge/*` and `windows/FloppyBridge.{cpp,h}` plus `windows/resource.h`
+from a newer upstream checkout into `src/`, then re-apply the changes below and
+update the commit recorded above. They are small, confined to four files, and
+every one is a Windows build-configuration difference rather than a change in
+behaviour.
+
+`build.rs` picks the files it compiles by name; a release that adds or renames
+a source file needs that list updated too, and will say so by failing to link.
+
+## Local changes
+
+Upstream builds these as a DLL from a Visual Studio project, which defines
+`UNICODE` and compiles WinUAE's configuration dialogs in. Copperline compiles
+them with `cc` into a non-UNICODE binary and drives them from its own launcher,
+so a handful of Windows-only lines need adjusting. Every one is marked
+`COPPERLINE:` in the source, or listed here.
+
+`build.rs` also passes what upstream's own Visual Studio project sets and `cc`
+does not: `NOMINMAX`, without which `windows.h`'s `min`/`max` macros turn every
+`std::min(` in the sources into `std::(`, and `/EHsc`, without which MSVC
+compiles the standard library's containers and threads with no unwinding and
+warns that any exception would terminate. The one project setting deliberately
+not matched is its Unicode character set -- see below.
+
+`FLOPPYBRIDGE_NO_GUI`, defined by `build.rs`, excludes what Copperline does not
+use. Amiberry excludes the same code the same way, keyed on `AMIBERRY`; its
+Windows builds are what give confidence this is the right seam to cut.
+
+### `FloppyBridge.cpp` -- the DLL front-end
+
+On Windows this file also carries the native configuration dialogs, their
+resource script, and a DnsQuery update check. Compiling them would drag in two
+more source files and a `.rc` needing a resource compiler, for code that would
+never run -- Copperline always asks for `BRIDGE_About` with update checking
+off.
+
+1. the `bridgeProfileListEditor.h` / `bridgeProfileEditor.h` / `WinDNS.h`
+   includes and the `Dnsapi.lib` pragma;
+2. `BridgeProfileListEditor::shouldAutoCheckForUpdates()` in `handleAbout`;
+3. the DnsQuery update check itself, which on Windows now compiles to nothing
+   rather than falling through to the Unix path below it;
+4. the `BRIDGE_ShowConfigDialog` / profile-list dialog entry points;
+5. `FindWindow` with `L""` literals becomes `FindWindowA` with narrow ones.
+
+### `SerialIO.cpp` -- the blocking open on Linux
+
+Opening a tty blocks until carrier detect is asserted, unless `CLOCAL` is
+already set on the device. The sources set `CLOCAL` immediately after opening,
+which is too late, so an interface that never raises DCD -- a Greaseweazle over
+USB CDC among them -- hangs in `open()` for good, with nothing to report
+because the call does not return. Upstream sidesteps this on macOS by opening
+with `O_NDELAY` and nowhere else.
+
+Copperline opens non-blocking everywhere and leaves the flag set, which is
+exactly what upstream already does on macOS. Clearing it after the open looks
+tidier -- reads would then wait on the `VMIN`/`VTIME` timeout rather than
+returning empty -- but that timeout is configured by `configurePort()`, which
+the interfaces call only *after* the open returns. In between, a blocking
+descriptor carries the default `VMIN=1`/`VTIME=0`: wait for a byte, forever. The
+handshake reads in that window, so a device that answers slowly wedges the open
+instead of failing it.
+
+### Wide literals passed to TCHAR-generic Win32 calls
+
+Upstream's project builds with `CharacterSet: Unicode`, so its `L""` literals
+match the `*W` variants these calls resolve to. Copperline does not define
+`UNICODE`, which would make the opposite mismatch possible wherever the sources
+pass narrow strings, so each of these becomes an explicit `*A` call with a
+narrow literal instead -- exactly as Amiberry does:
+
+- `ArduinoFloppyBridge.cpp`: `RegQueryValueEx` / `RegSetValueEx` (2 calls)
+- `GreaseWeazleBridge.cpp`: the same pair, twice over (4 calls)
+- `ftdi.cpp`: `LoadLibrary("FTD2XX.DLL")`
+- `SerialIO.cpp`: `SetupDiGetDeviceProperty` (2 calls). This one has no ANSI
+  variant at all -- the SDK declares only `SetupDiGetDevicePropertyW` and
+  defines the plain name as a macro for it under `UNICODE` -- so without that
+  the identifier simply does not exist. The data it reads is wide either way.
+
+`ADFBridge.cpp` and `floppybridge_lib.cpp` have more of these, and more `TCHAR`
+use besides, but neither is compiled: the first backs a bridge onto an ADF
+file, which Copperline's own image path already does, and the second is the
+client-side loader for the shared build, which linking directly replaces.

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -19,9 +19,11 @@ into them directly.
 
 Copy `floppybridge/*` and `windows/FloppyBridge.{cpp,h}` plus `windows/resource.h`
 from a newer upstream checkout into `src/`, then re-apply the changes below and
-update the commit recorded above. They are small, confined to four files, and
-every one is a Windows build-configuration difference rather than a change in
-behaviour.
+update the commit recorded above. They are small, confined to five files --
+`ArduinoFloppyBridge.cpp`, `FloppyBridge.cpp`, `GreaseWeazleBridge.cpp`,
+`SerialIO.cpp` and `ftdi.cpp` -- and every one is a build or platform
+difference rather than a change in behaviour. Every other vendored file is
+byte-identical to the commit above.
 
 `build.rs` picks the files it compiles by name; a release that adds or renames
 a source file needs that list updated too, and will say so by failing to link.

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -44,8 +44,10 @@ warns that any exception would terminate. The one project setting deliberately
 not matched is its Unicode character set -- see below.
 
 `FLOPPYBRIDGE_NO_GUI`, defined by `build.rs`, excludes what Copperline does not
-use. Amiberry excludes the same code the same way, keyed on `AMIBERRY`; its
-Windows builds are what give confidence this is the right seam to cut.
+use: the Windows-only configuration dialogs and the update check, which belong
+to upstream's DLL front-end and which Copperline never calls. Bridges are
+configured through Copperline's own launcher and config file on every
+platform.
 
 ### `FloppyBridge.cpp` -- the DLL front-end
 
@@ -87,7 +89,7 @@ Upstream's project builds with `CharacterSet: Unicode`, so its `L""` literals
 match the `*W` variants these calls resolve to. Copperline does not define
 `UNICODE`, which would make the opposite mismatch possible wherever the sources
 pass narrow strings, so each of these becomes an explicit `*A` call with a
-narrow literal instead -- exactly as Amiberry does:
+narrow literal instead:
 
 - `ArduinoFloppyBridge.cpp`: `RegQueryValueEx` / `RegSetValueEx` (2 calls)
 - `GreaseWeazleBridge.cpp`: the same pair, twice over (4 calls)

--- a/vendor/floppybridge/src/ADFBridge.cpp
+++ b/vendor/floppybridge/src/ADFBridge.cpp
@@ -1,0 +1,265 @@
+#include "floppybridge_abstract.h"
+#include "ADFBridge.h"
+#include "RotationExtractor.h"
+#include <windows.h>
+
+
+/*****************************************************************************
+ * ADFBridge - THIS IS NOT MEANT TO BE USED IN PRODUCTION
+ * THIS IS PURELY FOR TESTING THE 'BRIDGE' INTERFACE WITH A KNOWN WORKING FILE
+ ****************************************************************************/
+
+
+#define MFM_MASK    0x55555555L		
+#define AMIGA_WORD_SYNC  0x4489							 // Disk SYNC code for the Amiga start of sector
+#define SECTOR_BYTES	512								 // Number of bytes in a decoded sector
+#define NUM_SECTORS_PER_TRACK 11						 // Number of sectors per track
+#define RAW_SECTOR_SIZE (8+56+SECTOR_BYTES+SECTOR_BYTES)      // Size of a sector, *Including* the sector sync word longs
+#define ADF_TRACK_SIZE (SECTOR_BYTES*NUM_SECTORS_PER_TRACK)   // Bytes required for a single track
+
+typedef unsigned char RawEncodedSector[RAW_SECTOR_SIZE];
+typedef unsigned char RawDecodedSector[SECTOR_BYTES];
+typedef RawDecodedSector RawDecodedTrack[NUM_SECTORS_PER_TRACK];
+typedef unsigned char RawMFMData[SECTOR_BYTES + SECTOR_BYTES];
+
+
+typedef struct alignas(1) {
+	unsigned char filler1[4];  // Padding at the start of the track.  This will be set to 0xaa
+	// Raw sector data
+	RawEncodedSector sectors[NUM_SECTORS_PER_TRACK];   // 11968 bytes
+	// Blank "Filler" gap content. (this may get overwritten by the sectors a little)
+	unsigned char filler2[696];
+} FullDiskTrack;
+typedef struct alignas(8) {
+	unsigned char trackFormat;        // This will be 0xFF for Amiga
+	unsigned char trackNumber;        // Current track number (this is actually (tracknumber*2) + side
+	unsigned char sectorNumber;       // The sector we just read (0 to 11)
+	unsigned char sectorsRemaining;   // How many more sectors remain until the gap (0 to 10)
+
+	unsigned long sectorLabel[4];     // OS Recovery Data, we ignore this
+
+	unsigned long headerChecksum;	  // Read from the header, header checksum
+	unsigned long dataChecksum;		  // Read from the header, data checksum
+
+	unsigned long headerChecksumCalculated;   // The header checksum we calculate
+	unsigned long dataChecksumCalculated;     // The data checksum we calculate
+
+	RawDecodedSector data;          // decoded sector data
+
+	RawMFMData rawSector;   // raw track data, for analysis of invalid sectors
+} DecodedSector;
+struct DecodedTrack {
+	// A list of valid sectors where the checksums are OK
+	std::vector<DecodedSector> validSectors;
+	// A list of sectors found with invalid checksums.  These are used if ignore errors is triggered
+	// We keep copies of each one so we can perform a statistical analysis to see if we can get a working one based on which bits are mostly set the same
+	std::vector<DecodedSector> invalidSectors[NUM_SECTORS_PER_TRACK];
+};
+
+
+
+// MFM encoding algorithm part 1 - this just writes the actual data bits in the right places
+// *input;	RAW data buffer (size == data_size) 
+// *output;	MFM encoded buffer (size == data_size*2) 
+// Returns the checksum calculated over the data
+unsigned long encodeMFMdataPart1(const unsigned long* input, unsigned long* output, const unsigned int data_size) {
+	unsigned long chksum = 0L;
+	unsigned int count;
+
+	unsigned long* outputOdd = output;
+	unsigned long* outputEven = (unsigned long*)(((unsigned char*)output) + data_size);
+
+	// Encode over two passes.  First split out the odd and even data, then encode the MFM values, the /4 is because we're working in longs, not bytes
+	for (count = 0; count < data_size / 4; count++) {
+		*outputEven = *input & MFM_MASK;
+		*outputOdd = ((*input) >> 1) & MFM_MASK;
+		outputEven++;
+		outputOdd++;
+		input++;
+	}
+
+	// Checksum calculator
+	// Encode over two passes.  First split out the odd and even data, then encode the MFM values, the /4 is because we're working in longs, not bytes
+	for (count = 0; count < (data_size / 4) * 2; count++) {
+		chksum ^= *output;
+		output++;
+	}
+
+	return chksum & MFM_MASK;
+}
+
+
+// Encode a sector into the correct format for disk
+void encodeSector(const unsigned int trackNumber, const ADFBridge::DiskSurface surface, const unsigned int sectorNumber, const RawDecodedSector& input, RawEncodedSector& encodedSector, unsigned char& lastByte) {
+	// Sector Start
+	encodedSector[0] = (lastByte & 1) ? 0x2A : 0xAA;
+	encodedSector[1] = 0xAA;
+	encodedSector[2] = 0xAA;
+	encodedSector[3] = 0xAA;
+	// Sector Sync
+	encodedSector[4] = 0x44;
+	encodedSector[5] = 0x89;
+	encodedSector[6] = 0x44;
+	encodedSector[7] = 0x89;
+
+	// MFM Encoded header
+	DecodedSector header;
+	memset(&header, 0, sizeof(header));
+
+	header.trackFormat = 0xFF;
+	header.trackNumber = (trackNumber << 1) | ((surface == ADFBridge::DiskSurface::dsUpper) ? 1 : 0);
+	header.sectorNumber = sectorNumber;
+	header.sectorsRemaining = NUM_SECTORS_PER_TRACK - sectorNumber;  //1..11
+
+
+	header.headerChecksumCalculated = encodeMFMdataPart1((const unsigned long*)&header, (unsigned long*)&encodedSector[8], 4);
+	// Then theres the 16 bytes of the volume label that isnt used anyway
+	header.headerChecksumCalculated ^= encodeMFMdataPart1((const unsigned long*)&header.sectorLabel, (unsigned long*)&encodedSector[16], 16);
+	// Thats 40 bytes written as everything doubles (8+4+4+16+16). - Encode the header checksum
+	encodeMFMdataPart1((const unsigned long*)&header.headerChecksumCalculated, (unsigned long*)&encodedSector[48], 4);
+	// And move on to the data section.  Next should be the checksum, but we cant encode that until we actually know its value!
+	header.dataChecksumCalculated = encodeMFMdataPart1((const unsigned long*)&input, (unsigned long*)&encodedSector[64], SECTOR_BYTES);
+	// And add the checksum
+	encodeMFMdataPart1((const unsigned long*)&header.dataChecksumCalculated, (unsigned long*)&encodedSector[56], 4);
+
+	// Now fill in the MFM clock bits
+	bool lastBit = encodedSector[7] & (1 << 0);
+	bool thisBit = lastBit;
+
+	// Clock bits are bits 7, 5, 3 and 1
+	// Data is 6, 4, 2, 0
+	for (int count = 8; count < RAW_SECTOR_SIZE; count++) {
+		for (int bit = 7; bit >= 1; bit -= 2) {
+			lastBit = thisBit;
+			thisBit = encodedSector[count] & (1 << (bit - 1));
+
+			if (!(lastBit || thisBit)) {
+				// Encode a 1!
+				encodedSector[count] |= (1 << bit);
+			}
+		}
+	}
+
+	lastByte = encodedSector[RAW_SECTOR_SIZE - 1];
+}
+
+ADFBridge::ADFBridge(int flags, const bool canStall, const bool useIndex) {
+	HANDLE fle = CreateFile(L"file.adf", GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
+
+	RawDecodedTrack track;
+
+	int surfaceIndex = 0;
+	int currentTrack = 0;
+	FullDiskTrack disktrack;
+
+	memset(disktrack.filler1, 0xAA, sizeof(disktrack.filler1));  // Pad with "0"s which as an MFM encoded byte is 0xAA
+	memset(disktrack.filler2, 0xAA, sizeof(disktrack.filler2));  // Pad with "0"s which as an MFM encoded byte is 0xAA
+
+	DWORD read;
+	while (ReadFile(fle, &track, sizeof(track), &read, NULL)) {
+		if (read != sizeof(track)) break;
+		DiskSurface surface = (surfaceIndex == 1) ? DiskSurface::dsUpper : DiskSurface::dsLower;
+
+		unsigned char lastByte = disktrack.filler1[sizeof(disktrack.filler1) - 1];
+		for (unsigned int sector = 0; sector < NUM_SECTORS_PER_TRACK; sector++)
+			encodeSector(currentTrack, surface, sector, track[sector], disktrack.sectors[sector], lastByte);
+		if (lastByte & 1) disktrack.filler2[0] = 0x2F; else disktrack.filler2[0] = 0xFF;
+		unsigned char* buffer = (unsigned char*)&disktrack;
+		memcpy_s(m_mfmRead[currentTrack][(int)surface].mfmBuffer, MFM_BUFFER_MAX_TRACK_LENGTH, &disktrack, sizeof(disktrack));
+		m_mfmRead[currentTrack][(int)surface].amountReadInBits = sizeof(disktrack) * 8;
+		// Goto the next surface/track
+		surfaceIndex++;
+		if (surfaceIndex > 1) {
+			surfaceIndex = 0;
+			currentTrack++;
+		}
+		// But there is a physical limit
+		if (currentTrack > 81) break;
+
+	}
+
+	CloseHandle(fle);
+}
+
+ADFBridge::~ADFBridge() {
+
+}
+
+// Call to start the system up
+bool ADFBridge::initialise() {
+	return true;
+}
+
+// This is called prior to closing down, but shoudl reverse initialise
+void ADFBridge::shutdown() {
+}
+
+// Returns TRUE when the last command requested has completed
+bool ADFBridge::isReady()  { 
+	return m_isMotorRunning && (GetTickCount()- m_turnOnTime > 800);
+};
+
+
+// While not doing anything else, the library should be continuously streaming the current track if the motor is on.  mfmBufferPosition is in BITS 
+bool ADFBridge::getMFMBit(const int mfmPositionBits) {
+	// Internally manage loops until the data is ready
+	const int mfmPositionByte = mfmPositionBits >> 3;
+	int mfmPositionBit = 7- (mfmPositionBits & 7);
+
+	return (m_mfmRead[m_currentTrack][(int)m_floppySide].mfmBuffer[mfmPositionByte] & (1 << mfmPositionBit)) != 0;
+}
+
+// Set the status of the motor. 
+void ADFBridge::setMotorStatus(bool side, bool turnOn) {
+	if ((!m_isMotorRunning) && (turnOn)) m_turnOnTime = GetTickCount();
+	m_isMotorRunning = turnOn;
+}
+
+// Return the maximum size of the internal track buffer in BITS
+int ADFBridge::maxMFMBitPosition() {
+	return m_mfmRead[m_currentTrack][(int)m_floppySide].amountReadInBits;
+}
+
+// This is called to switch to a different copy of the track so multiple revolutions can ve read
+void ADFBridge::mfmSwitchBuffer(bool side) {
+	m_floppySide = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+}
+
+// Seek to a specific track
+void ADFBridge::gotoCylinder(int trackNumber, bool side) {
+	m_floppySide = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+	m_currentTrack = trackNumber;
+}
+
+// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+// Should perform the same operations as setCurrentCylinder in terms of diskchange etc but without changing the current cylinder
+// Return FALSE if this is not supported by the bridge
+void ADFBridge::handleNoClickStep(bool side) {
+	m_floppySide = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+}
+
+
+// Submits a single WORD of data received during a DMA transfer to the disk buffer.  This needs to be saved.  It is usually flushed when commitWriteBuffer is called
+// You should reset this buffer if side or track changes.  mfmPosition is provided purely for any index sync you may wish to do
+void ADFBridge::writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) {
+}
+
+// Requests that any data received via writeShortToBuffer be saved to disk. The side and track should match against what you have been collected
+// and the buffer should be reset upon completion.  You should return the new tracklength (maxMFMBitPosition) with optional padding if needed
+unsigned int ADFBridge::commitWriteBuffer(bool side, unsigned int track) {
+	m_floppySide = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+	m_currentTrack = track;
+	return maxMFMBitPosition();
+}
+
+// Return TRUE if we're at the INDEX marker
+bool ADFBridge::isMFMPositionAtIndex(int mfmPositionBits) {
+	return mfmPositionBits == 0;
+}
+
+bool ADFBridge::resetDrive(int trackNumber) {
+	m_currentTrack = trackNumber;
+	m_isMotorRunning = false;
+	return true;
+};
+

--- a/vendor/floppybridge/src/ADFBridge.h
+++ b/vendor/floppybridge/src/ADFBridge.h
@@ -1,0 +1,65 @@
+#pragma once
+/*****************************************************************************
+ * ADFBridge - THIS IS NOT MEANT TO BE USED IN PRODUCTION
+ * THIS IS PURELY FOR TESTING THE 'BRIDGE' INTERFACE WITH A KNOWN WORKING FILE
+ ****************************************************************************/
+
+
+
+#include <thread>
+#include <functional>
+#include <queue>
+#include <mutex>
+#include <tchar.h>
+
+#include "floppybridge_abstract.h"
+
+
+#define MFM_BUFFER_MAX_TRACK_LENGTH			0x3800
+#define MAX_CYLINDER_BRIDGE 82
+class ADFBridge : public FloppyDiskBridge {
+public:
+	enum class DiskSurface { dsUpper = 1, dsLower = 0 };
+
+private:
+	struct MFMCache {
+		unsigned char mfmBuffer[MFM_BUFFER_MAX_TRACK_LENGTH];
+		int amountReadInBits = 1024;
+	};
+	// Cache of entire disk (or what we have so far)
+	MFMCache m_mfmRead[MAX_CYLINDER_BRIDGE][2];
+	int m_currentTrack = 0;
+	bool m_isMotorRunning = false;
+	DiskSurface m_floppySide = DiskSurface::dsLower;
+	unsigned int m_turnOnTime = 0;
+public:
+	ADFBridge(int flags, const bool canStall, const bool useIndex);
+	virtual ~ADFBridge();
+	virtual bool initialise() override final;
+	virtual void shutdown() override final;
+	virtual const TCHAR* getDriveIDName() override final {
+		return L"ADFBridge";
+	}
+	virtual DriveTypeID getDriveTypeID() override final { return DriveTypeID::dti35DD; };
+	virtual unsigned int getLastErrorMessage(TCHAR* errorMessage, unsigned int length) override { return 0; };
+	virtual bool isAtCylinder0() override final { return m_currentTrack == 0; }
+	virtual unsigned char getMaxCylinder() override final { return MAX_CYLINDER_BRIDGE; };
+	virtual bool isMotorRunning() override final { return m_isMotorRunning; };
+	virtual void handleNoClickStep(bool side) override final;
+	virtual bool isReady() override;
+	virtual bool isDiskInDrive() override final { return true; };
+	virtual bool hasDiskChanged() override final { return false; };
+	virtual unsigned char getCurrentCylinderNumber() override final { return m_currentTrack; };
+	virtual bool isWriteProtected() override final { return true; };
+	virtual int getMFMSpeed(const int mfmPositionBits) override { return 1000; }
+	virtual bool getMFMBit(const int mfmPositionBits) override;
+	virtual void setMotorStatus(bool side, bool turnOn) override final;
+	virtual int maxMFMBitPosition() override final;
+	virtual void mfmSwitchBuffer(bool side) override final;
+	virtual void gotoCylinder(int trackNumber, bool side) override final;
+	virtual void writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) override final;
+	virtual unsigned int commitWriteBuffer(bool side, unsigned int track) override final;
+	virtual bool isMFMPositionAtIndex(int mfmPositionBits) override final;
+	virtual bool resetDrive(int trackNumber) override final;
+};
+

--- a/vendor/floppybridge/src/ArduinoFloppyBridge.cpp
+++ b/vendor/floppybridge/src/ArduinoFloppyBridge.cpp
@@ -1,0 +1,336 @@
+/* DrawBridge (Arduino Reader/Writer) Bridge for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/ 
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// This class provides an interface between WinUAE and the Arduino Floppy Reader/Writer aka DrawBridge //
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// ROMTYPE_ARDUINOREADER_WRITER must be defined for this to work
+
+#include "floppybridge_config.h"
+
+#ifdef ROMTYPE_ARDUINOREADER_WRITER
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "ArduinoFloppyBridge.h"
+#include "ArduinoInterface.h"
+
+
+static const FloppyDiskBridge::BridgeDriver DriverArduinoFloppy = {
+	"DrawBridge aka Arduino Reader/Writer", "https://amiga.robsmithdev.co.uk", "RobSmithDev", "RobSmithDev", CONFIG_OPTIONS_COMPORT | CONFIG_OPTIONS_COMPORT_AUTODETECT | CONFIG_OPTIONS_SMARTSPEED | CONFIG_OPTIONS_AUTOCACHE
+};
+
+// Flags from WINUAE
+ArduinoFloppyDiskBridge::ArduinoFloppyDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool enableAutoCache, bool useSmartSpeed, bool autoDetectComPort, char* comPort) :
+	CommonBridgeTemplate(bridgeMode, bridgeDensity, enableAutoCache, useSmartSpeed), m_comPort(autoDetectComPort ? "" : comPort) {
+}
+
+// This is for the static version
+ArduinoFloppyDiskBridge::ArduinoFloppyDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, int uaeSettings) :
+	CommonBridgeTemplate(bridgeMode, bridgeDensity, false, false) {
+
+	if (uaeSettings > 0) {
+		char buffer[20];
+#ifdef _WIN32
+		sprintf_s(buffer, "COM%i", uaeSettings);
+#else		
+		snprintf(buffer, 20, "COM%i", uaeSettings);
+#endif
+		m_comPort = buffer;
+	}
+	else m_comPort = "";
+}
+
+
+ArduinoFloppyDiskBridge::~ArduinoFloppyDiskBridge() {
+}
+
+// If your device supports being able to abort a disk read, mid-read then implement this
+void ArduinoFloppyDiskBridge::abortDiskReading() {
+	m_io.abortReadStreaming();
+};
+
+// A manual way to detect a disk change event
+bool ArduinoFloppyDiskBridge::attemptToDetectDiskChange() {
+	return getDiskChangeStatus(true);
+}
+
+// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+bool ArduinoFloppyDiskBridge::supportsDiskChange() {
+	return m_io.getFirwareVersion().fullControlMod;
+}
+
+// Called when the class is about to shut down
+void ArduinoFloppyDiskBridge::closeInterface() {
+	// Turn everything off
+	m_io.enableReading(false);
+	m_io.closePort();
+}
+
+// Returns the COM port number to use
+std::wstring ArduinoFloppyDiskBridge::getComPort() {
+	// 0 means auto-detect.
+	if (m_comPort.length()) {
+		std::wstring widePort;
+		quicka2w(m_comPort, widePort);
+		return widePort;
+	}
+
+	// Returns a list of ports this could be available on
+	std::vector<std::wstring> portsAvailable;
+	ArduinoFloppyReader::ArduinoInterface::enumeratePorts(portsAvailable);
+
+	for (const std::wstring& port : portsAvailable)
+		if (ArduinoFloppyReader::ArduinoInterface::isPortCorrect(port)) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(200));
+			return port;
+		}
+	
+	return L"";
+}
+
+// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+bool ArduinoFloppyDiskBridge::openInterface(std::string& errorMessage) {
+
+	const std::wstring prt = getComPort();
+	if (prt.empty()) {
+		errorMessage = "The serial port could not be found or detected.  Please try re-connecting the interface.";
+		return false;
+	}
+
+	ArduinoFloppyReader::DiagnosticResponse error = m_io.openPort(prt);
+	if (error == ArduinoFloppyReader::DiagnosticResponse::drOK) {
+		m_currentCylinder = 0;
+
+		// See which version it is
+		ArduinoFloppyReader::FirmwareVersion fv = m_io.getFirwareVersion();
+		if ((fv.major <= 1) && (fv.minor < 8)) {
+			// Must be at least V1.8
+			char buf[20];
+#ifdef _WIN32			
+			sprintf_s(buf, "%i.%i.%i", fv.major, fv.minor, fv.buildNumber);
+#else
+			sprintf(buf, "%i.%i.%i", fv.major, fv.minor, fv.buildNumber);
+#endif			
+			errorMessage = "DrawBridge aka Arduino Floppy Reader/Writer Firmware is Out Of Date\n\nWinUAE requires V1.8 (and ideally with the modded circuit design).\n\n";
+			errorMessage += "You are currently using V" + std::string(buf) + ".  Please update the firmware.";
+		}
+		else {
+#ifdef _WIN32
+
+			if (!fv.fullControlMod) {
+				DWORD hasBeenSeen = 0;
+				DWORD dataSize = sizeof(hasBeenSeen);
+				
+				HKEY key = 0;
+				if (SUCCEEDED(RegCreateKeyExA(HKEY_CURRENT_USER, "Software\\RobSmithDev\\ArduinoReaderWriter", 0, NULL, 0, KEY_READ | KEY_WRITE | KEY_SET_VALUE | KEY_CREATE_SUB_KEY, NULL, &key, NULL)))
+					if (!RegQueryValueExA(key, "WarningShown", NULL, NULL, (LPBYTE)&hasBeenSeen, &dataSize)) dataSize = 0;
+
+				if (!hasBeenSeen) {
+					hasBeenSeen = 1;
+					if (key) RegSetValueExA(key, "WarningShown", NULL, REG_DWORD, (LPBYTE)&hasBeenSeen, sizeof(hasBeenSeen));
+					errorMessage = "DrawBridge aka Arduino Reader / Writer hasn't had the 'hardware mod' applied for optimal WinUAE Support.\nThis mod is highly recommended for best experience and will reduce disk access.";
+				}
+				if (key) RegCloseKey(key);
+			}
+#endif
+			m_io.findTrack0();
+			return true;
+		}
+	}
+	else {
+		errorMessage = m_io.getLastErrorStr();
+	}
+
+	return false;
+}
+
+// Return TRUE if the drive is still connected and working
+bool ArduinoFloppyDiskBridge::isStillWorking() {
+	return !m_wasIOError;
+}
+
+
+// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+void ArduinoFloppyDiskBridge::checkDiskType() {
+	bool capacity;
+
+	if (m_io.checkDiskCapacity(capacity) == ArduinoFloppyReader::DiagnosticResponse::drOK) {
+		m_isHDDisk = capacity;
+		m_io.setDiskCapacity(m_isHDDisk);
+	}
+	else {
+		m_isHDDisk = false;
+		m_io.setDiskCapacity(m_isHDDisk);
+	}
+}
+
+// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+void ArduinoFloppyDiskBridge::forceDiskDensity(bool forceHD) {
+	m_isHDDisk = forceHD;
+	m_io.setDiskCapacity(m_isHDDisk);
+}
+
+const FloppyDiskBridge::BridgeDriver* ArduinoFloppyDiskBridge::staticBridgeInformation() {
+	return &DriverArduinoFloppy;
+}
+
+// Get the name of the drive
+const FloppyDiskBridge::BridgeDriver* ArduinoFloppyDiskBridge::_getDriverInfo() {
+	return staticBridgeInformation();
+}
+
+// Duplicate of the one below, but here for consistency - Returns the name of interface.  This pointer should remain valid after the class is destroyed
+const FloppyDiskBridge::DriveTypeID ArduinoFloppyDiskBridge::_getDriveTypeID() {
+	return m_isHDDisk ? DriveTypeID::dti35HD : DriveTypeID::dti35DD;
+}
+
+// Called to switch which head is being used right now.  Returns success or not
+bool ArduinoFloppyDiskBridge::setActiveSurface(const DiskSurface activeSurface) {
+	return m_io.selectSurface(activeSurface == DiskSurface::dsUpper ? ArduinoFloppyReader::DiskSurface::dsUpper : ArduinoFloppyReader::DiskSurface::dsLower) == ArduinoFloppyReader::DiagnosticResponse::drOK;
+}
+
+// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+bool ArduinoFloppyDiskBridge::setMotorStatus(const bool switchedOn) {
+	return m_io.enableReading(switchedOn, false, true) == ArduinoFloppyReader::DiagnosticResponse::drOK;
+}
+
+// Called to ask the drive what the current write protect status is - return true if its write protected
+bool ArduinoFloppyDiskBridge::checkWriteProtectStatus(const bool forceCheck) {
+	return m_io.checkIfDiskIsWriteProtected(forceCheck) == ArduinoFloppyReader::DiagnosticResponse::drWriteProtected;
+}
+
+// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+bool ArduinoFloppyDiskBridge::getDiskChangeStatus(const bool forceCheck) {
+	if ((forceCheck) && (m_io.getFirwareVersion().fullControlMod)) {
+		if (m_currentCylinder == 0) {
+			if (performNoClickSeek()) {
+				return m_io.isDiskInDrive();
+			}
+		}
+	}
+
+	// Perform the check, if required
+	switch (m_io.checkForDisk(forceCheck)) {
+	case ArduinoFloppyReader::DiagnosticResponse::drNoDiskInDrive: return false;
+	case ArduinoFloppyReader::DiagnosticResponse::drOK: return true;
+	case ArduinoFloppyReader::DiagnosticResponse::drOldFirmware: return false;
+	default:m_wasIOError = true; return false;
+	}
+}
+
+// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+// Return FALSE if this is not supported by the bridge
+bool ArduinoFloppyDiskBridge::performNoClickSeek() {
+	// Claim we did it anyway
+	if (!m_io.getFirwareVersion().fullControlMod) return true;
+
+	switch (m_io.performNoClickSeek()) {
+	case ArduinoFloppyReader::DiagnosticResponse::drOK:
+		updateLastManualCheckTime();
+		return true;
+	case ArduinoFloppyReader::DiagnosticResponse::drOldFirmware:
+		return false;
+	case ArduinoFloppyReader::DiagnosticResponse::drReadResponseFailed:
+	case ArduinoFloppyReader::DiagnosticResponse::drSendFailed:
+	case ArduinoFloppyReader::DiagnosticResponse::drSendParameterFailed:		
+		m_wasIOError = true;
+		return false;
+	}
+
+	return false;
+}
+
+// Trigger a seek to the requested cylinder, this can block until complete
+bool ArduinoFloppyDiskBridge::setCurrentCylinder(const unsigned int cylinder) {
+	m_currentCylinder = cylinder;
+
+	// No need if its busy
+	bool ignoreDiskCheck = isMotorRunning() && !isReady();
+
+	// If we don't support disk change then don't allow the hardware to check for a disk as it takes time, unless it's due anyway
+	if (!m_io.getFirwareVersion().fullControlMod) ignoreDiskCheck |= !isReadyForManualDiskCheck();
+
+	// Go! - and don't ask
+	ArduinoFloppyReader::DiagnosticResponse dr = m_io.selectTrack(cylinder, ArduinoFloppyReader::TrackSearchSpeed::tssVeryFast, ignoreDiskCheck);
+	if (dr != ArduinoFloppyReader::DiagnosticResponse::drOK) dr = m_io.selectTrack(cylinder, ArduinoFloppyReader::TrackSearchSpeed::tssFast, ignoreDiskCheck);
+	if (dr != ArduinoFloppyReader::DiagnosticResponse::drOK) dr = m_io.selectTrack(cylinder, ArduinoFloppyReader::TrackSearchSpeed::tssNormal, ignoreDiskCheck);
+	if (dr != ArduinoFloppyReader::DiagnosticResponse::drOK) dr = m_io.selectTrack(cylinder, ArduinoFloppyReader::TrackSearchSpeed::tssNormal, ignoreDiskCheck);
+	if (dr == ArduinoFloppyReader::DiagnosticResponse::drOK) {
+		if (!ignoreDiskCheck) updateLastManualCheckTime();
+		setWriteProtectStatus(m_io.checkIfDiskIsWriteProtected(false) == ArduinoFloppyReader::DiagnosticResponse::drWriteProtected);
+
+		return true;
+	}
+
+	return false;
+}
+
+// Called when data should be read from the drive.
+//		pll:           supplied if you use it
+//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+// Returns: ReadResponse, explains its self
+CommonBridgeTemplate::ReadResponse ArduinoFloppyDiskBridge::readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+	std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) {
+	
+	ArduinoFloppyReader::DiagnosticResponse result = m_io.readRotation(*pll.rotationExtractor(), maxBufferSize, buffer, indexMarker,
+		[&onRotation](RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits) -> bool {
+			return onRotation(*mfmData, dataLengthInBits);
+		}, true);
+		
+	switch (result) {
+		case ArduinoFloppyReader::DiagnosticResponse::drOK: return ReadResponse::rrOK;
+		case ArduinoFloppyReader::DiagnosticResponse::drNoDiskInDrive: return ReadResponse::rrNoDiskInDrive;
+		default:  return ReadResponse::rrError;
+	}
+}
+
+// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+//		pll:           required 
+// Returns: ReadResponse, explains its self
+CommonBridgeTemplate::ReadResponse ArduinoFloppyDiskBridge::readLinearData(PLL::BridgePLL& pll) {
+	ArduinoFloppyReader::DiagnosticResponse result = m_io.readData(pll);
+
+	switch (result) {
+	case ArduinoFloppyReader::DiagnosticResponse::drOK: return ReadResponse::rrOK;
+	case ArduinoFloppyReader::DiagnosticResponse::drNoDiskInDrive: return ReadResponse::rrNoDiskInDrive;
+	default:  return ReadResponse::rrError;
+	}
+}
+
+// Called when a cylinder revolution should be written to the disk.
+// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+//					numBytes						Number of bits in the buffer to write
+//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+//					suggestUsingPrecompensation		A suggestion that you might want to use write pre-compensation, optional
+// Returns TRUE if success, or false if it fails.  Largely doesn't matter as most stuff should verify with a read straight after
+bool ArduinoFloppyDiskBridge::writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation) {
+	switch (m_io.writeCurrentTrackPrecomp(rawMFMData, (numBits + 7) / 8, writeFromIndex, suggestUsingPrecompensation)) {
+	case ArduinoFloppyReader::DiagnosticResponse::drOK: return true;
+	case ArduinoFloppyReader::DiagnosticResponse::drWriteProtected: setWriteProtectStatus(true); return false;
+	default: return false;
+	}
+}
+
+#endif

--- a/vendor/floppybridge/src/ArduinoFloppyBridge.h
+++ b/vendor/floppybridge/src/ArduinoFloppyBridge.h
@@ -1,0 +1,145 @@
+#ifndef ARDUINO_FLOPPY_BRIDGE
+#define ARDUINO_FLOPPY_BRIDGE
+/* DrawBridge (Arduino Reader/Writer) Bridge for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// This class provides an interface between WinUAE and the Arduino Floppy Reader/Writer aka DrawBridge //
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// ROMTYPE_ARDUINOREADER_WRITER must be defined for this to work
+
+
+#ifdef ROMTYPE_ARDUINOREADER_WRITER
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "ArduinoInterface.h"
+#include "pll.h"
+
+class ArduinoFloppyDiskBridge : public CommonBridgeTemplate {
+private:
+	// Which com port should we use? or blank for automatic
+	std::string m_comPort;
+
+	// type of disk inserted
+	bool m_isHDDisk = false;
+
+	// Used to detect disconnection of DrawBridge while in use
+	bool m_wasIOError = false;
+
+	// Hardware connection
+	ArduinoFloppyReader::ArduinoInterface m_io;
+
+	// Returns the serial port to use
+	std::wstring getComPort();
+
+	// Remember where we are
+	int m_currentCylinder = 0;
+protected:
+	// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+	virtual void checkDiskType() override;
+
+	// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+	virtual void forceDiskDensity(bool forceHD) override;
+
+	// If your device supports being able to abort a disk read, mid-read then implement this
+	virtual void abortDiskReading() override;
+
+	// Return TRUE if the drive is still connected and working
+	virtual bool isStillWorking() override;
+
+	// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+	virtual bool supportsDiskChange() override;
+
+	// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+	// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+	virtual bool getDiskChangeStatus(const bool forceCheck) override;
+
+	// Called when the class is about to shut down
+	virtual void closeInterface() override;
+
+	// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+	virtual bool openInterface(std::string& errorMessage) override;
+
+	// Called to ask the drive what the current write protect status is - return true if its write protected.  If forceCheck is true you should actually check the drive, 
+	// else use the last status checked which was probably from a SEEK setCurrentCylinder call.  If you can ONLY get this information here then you should always force check
+	virtual bool checkWriteProtectStatus(const bool forceCheck) override;
+
+	// Get the name of the drive
+	virtual const BridgeDriver* _getDriverInfo() override;
+
+	// Duplicate of the one below, but here for consistency - Returns the name of interface.  This pointer should remain valid after the class is destroyed
+	virtual const DriveTypeID _getDriveTypeID() override;
+
+	// Called to switch which head is being used right now.  Returns success or not
+	virtual bool setActiveSurface(const DiskSurface activeSurface) override;
+
+	// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+	virtual bool setMotorStatus(const bool switchedOn) override;
+
+	// Trigger a seek to the requested cylinder, this can block until complete
+	virtual bool setCurrentCylinder(const unsigned int cylinder) override;
+
+	// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+	// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+	// Return FALSE if this is not supported by the bridge
+	virtual bool performNoClickSeek() override;
+
+	// Called when data should be read from the drive.
+	//		pll:           supplied if you use it
+	//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+	// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+	//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+	//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+		std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) override;
+
+	// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+	//		pll:           required 
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readLinearData(PLL::BridgePLL& pll) override;
+
+	// Called when a cylinder revolution should be written to the disk.
+	// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+	//					numBytes						Number of bits in the buffer to write
+	//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+	//					suggestUsingPrecompensation		A suggestion that you might want to use write precompensation, optional
+	// Returns TRUE if success, or false if it fails.  Largely doesn't matter as most stuff should verify with a read straight after
+	virtual bool writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation) override;
+
+	// A manual way to check for disk change.  This is simulated by issuing a read message and seeing if there's any data.  Returns TRUE if data or an INDEX pulse was detected
+	// It's virtual as the default method issues a read and looks for data.  If you have a better implementation then override this
+	virtual bool attemptToDetectDiskChange() override;
+
+public:
+	ArduinoFloppyDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool enableAutoCache, bool useSmartSpeed, bool autoDetectComPort, char* comPort);
+
+	// This is for the static version
+	ArduinoFloppyDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, int uaeSettings);
+
+	virtual ~ArduinoFloppyDiskBridge();
+
+	static const BridgeDriver* staticBridgeInformation();
+};
+
+
+
+#endif
+#endif

--- a/vendor/floppybridge/src/ArduinoInterface.cpp
+++ b/vendor/floppybridge/src/ArduinoInterface.cpp
@@ -1,0 +1,2867 @@
+/* ArduinoFloppyReaderWriter aka DrawBridge
+*
+* Copyright (C) 2017-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Library General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Library General Public License for more details.
+*
+* You should have received a copy of the GNU Library General Public
+* License along with this library; if not, see http://www.gnu.org/licenses/
+*/
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Class to manage the communication between the computer and the Arduino    V2.5     //
+////////////////////////////////////////////////////////////////////////////////////////
+//
+// Purpose:
+// The class handles the command interface to the arduino.  It doesn't do any decoding
+// Just open ports, switch motors on and off, seek to tracks etc.
+//
+//
+//
+
+#include "ArduinoInterface.h"
+#include <sstream>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include "RotationExtractor.h"
+#include <mutex>
+#include <math.h>
+#ifndef _WIN32
+#include <string.h>
+#endif
+
+using namespace ArduinoFloppyReader;
+
+// Command that the ARDUINO Sketch understands
+#define COMMAND_VERSION            '?'
+#define COMMAND_REWIND             '.'
+#define COMMAND_GOTOTRACK          '#'
+#define COMMAND_HEAD0              '['
+#define COMMAND_HEAD1              ']'
+#define COMMAND_READTRACK          '<'
+#define COMMAND_ENABLE             '+'
+#define COMMAND_DISABLE            '-'
+#define COMMAND_WRITETRACK         '>'
+#define COMMAND_ENABLEWRITE        '~'
+#define COMMAND_DIAGNOSTICS        '&'
+#define COMMAND_ERASETRACK		   'X'
+#define COMMAND_SWITCHTO_DD		   'D'   // Requires Firmware V1.6
+#define COMMAND_SWITCHTO_HD		   'H'   // Requires Firmware V1.6
+
+// New commands for more direct control of the drive.  Some of these are more efficient or don't turn the disk motor on for modded hardware
+#define COMMAND_READTRACKSTREAM    '{'    // Requires Firmware V1.8
+#define COMMAND_WRITETRACKPRECOMP  '}'    // Requires Firmware V1.8
+#define COMMAND_CHECKDISKEXISTS    '^'    // Requires Firmware V1.8 (and modded hardware for fast version)
+#define COMMAND_ISWRITEPROTECTED   '$'    // Requires Firmware V1.8
+#define COMMAND_ENABLE_NOWAIT      '*'    // Requires Firmware V1.8
+#define COMMAND_GOTOTRACK_REPORT   '='	  // Requires Firmware V1.8
+#define COMMAND_DO_NOCLICK_SEEK    'O'    // Requires Firmware V1.8a
+
+#define COMMAND_CHECK_DENSITY      'T'    // Requires Firmware V1.9
+#define COMMAND_TEST_RPM           'P'    // Requires Firmware V1.9
+#define COMMAND_CHECK_FEATURES     '@'    // Requires Firmware V1.9
+#define COMMAND_READTRACKSTREAM_HIGHPRECISION 'F' // Requires Firmware V1.9
+#define COMMAND_READTRACKSTREAM_FLUX          'L'   // Requires Firmware V1.9.22
+#define COMMAND_READTRACKSTREAM_HALFPLL       'l'   // Requires Firmware V1.9.22
+#define COMMAND_EEPROM_READ        'E'    // Read a value from the eeprom
+#define COMMAND_EEPROM_WRITE       'e'    // Write a value to the eeprom
+#define COMMAND_RESET              'R'    // Reset
+#define COMMAND_WRITEFLUX          'Y'    // Requires Firmware V1.9.22
+#define COMMAND_ERASEFLUX          'w'    // Requires Firmware V1.9.18
+
+#define SPECIAL_ABORT_CHAR		   'x'
+
+// Convert the last executed command that had an error to a string
+std::string lastCommandToName(LastCommand cmd) {
+	switch (cmd) {
+	case LastCommand::lcOpenPort:		return "OpenPort";
+	case LastCommand::lcGetVersion:		return "GetVersion";
+	case LastCommand::lcEnableWrite:	return "EnableWrite";
+	case LastCommand::lcRewind:			return "Rewind";
+	case LastCommand::lcDisableMotor:	return "DisableMotor";
+	case LastCommand::lcEnableMotor:	return "EnableMotor";
+	case LastCommand::lcGotoTrack:		return "GotoTrack";
+	case LastCommand::lcSelectSurface:	return "SelectSurface";
+	case LastCommand::lcReadTrack:		return "ReadTrack";
+	case LastCommand::lcWriteTrack:		return "WriteTrack";
+	case LastCommand::lcRunDiagnostics:	return "RunDiagnostics";
+	case LastCommand::lcSwitchDiskMode: return "SetCapacity";
+	case LastCommand::lcReadTrackStream: return "ReadTrackStream";
+	case LastCommand::lcCheckDiskInDrive: return "CheckDiskInDrive";
+	case LastCommand::lcCheckDiskWriteProtected: return "CheckDiskWriteProtected";
+	case LastCommand::lcEraseTrack:		return "EraseTrack";
+	case LastCommand::lcNoClickCheck:	return "NoClickCheck";
+	case LastCommand::lcCheckDensity:	return "CheckDensity";
+	case LastCommand::lcMeasureRPM:		return "MeasureRPM";
+	case LastCommand::lcEEPROMRead:	    return "EEPROM Read";
+	case LastCommand::lcEEPROMWrite:	return "EEPROM Write";
+	case LastCommand::lcWriteFlux:		return "Write Flux";
+	case LastCommand::lcEraseFlux:		return "Erase Flux";
+	default:							return "Unknown";
+	}
+}
+
+// Uses the above fields to constructor a suitable error message, hopefully useful in diagnosing the issue
+const std::string ArduinoInterface::getLastErrorStr() const {
+	std::stringstream tmp;
+	switch (m_lastError) {
+	case DiagnosticResponse::drOldFirmware: return "The Arduino/DrawBridge is running an older version of the firmware/sketch.  Please re-upload.";
+	case DiagnosticResponse::drOK: return "Last command completed successfully.";
+	case DiagnosticResponse::drPortInUse: return "The specified COM port is currently in use by another application.";
+	case DiagnosticResponse::drPortNotFound: return "The specified COM port was not found.";
+	case DiagnosticResponse::drAccessDenied: return "The operating system denied access to the specified COM port.";
+	case DiagnosticResponse::drComportConfigError: return "We were unable to configure the COM port using the SetCommConfig() command.";
+	case DiagnosticResponse::drBaudRateNotSupported: return "The COM port does not support the 2M baud rate required by this application.";
+	case DiagnosticResponse::drErrorReadingVersion: return "An error occurred attempting to read the version of the sketch running on the Arduino.";
+	case DiagnosticResponse::drErrorMalformedVersion: return "The Arduino returned an unexpected string when version was requested.  This could be a baud rate mismatch or incorrect loaded sketch.";
+	case DiagnosticResponse::drCTSFailure: return "Diagnostics reports the CTS line is not connected correctly or is not behaving correctly.";
+	case DiagnosticResponse::drTrackRangeError: return "An error occurred attempting to go to a track number that was out of allowed range.";
+	case DiagnosticResponse::drWriteProtected: return "Unable to write to the disk.  The disk is write protected.";
+	case DiagnosticResponse::drPortError: return "An unknown error occurred attempting to open access to the specified COM port.";
+	case DiagnosticResponse::drDiagnosticNotAvailable: return "CTS diagnostic not available, command GetCommModemStatus failed to execute.";
+	case DiagnosticResponse::drSelectTrackError: return "Arduino reported an error seeking to a specific track.";
+	case DiagnosticResponse::drTrackWriteResponseError: return "Error receiving status from Arduino after a track write operation.";
+	case DiagnosticResponse::drSendDataFailed: return "Error sending track data to be written to disk.  This could be a COM timeout.";
+	case DiagnosticResponse::drRewindFailure: return "Arduino was unable to find track 0.  This could be a wiring fault or power supply failure.";
+	case DiagnosticResponse::drNoDiskInDrive: return "No disk in drive";
+	case DiagnosticResponse::drMediaTypeMismatch: if (m_lastCommand == LastCommand::lcWriteFlux)
+		return "Write Flux only supports DD disks and data"; else return "An attempt to read or write had an incorrect amount of data given the DD/HD media used";
+	case DiagnosticResponse::drWriteTimeout: return "The Arduino could not receive the data quick enough to write to disk. Try connecting via USB2 and not using a USB hub.\n\nIf this still does not work, turn off precomp if you are using it.";
+	case DiagnosticResponse::drFramingError: return "The Arduino received bad data from the PC. This could indicate poor connectivity, bad baud rate matching or damaged cables.";
+	case DiagnosticResponse::drSerialOverrun: return "The Arduino received data faster than it could handle. This could either be a fault with the CTS connection or the USB/serial interface is faulty";
+	case DiagnosticResponse::drUSBSerialBad: return "The USB->Serial converter being used isn't suitable and doesn't run consistently fast enough.  Please ensure you use a genuine FTDI adapter.";
+	case DiagnosticResponse::drError:	tmp << "Arduino responded with an error running the " << lastCommandToName(m_lastCommand) << " command.";
+		return tmp.str();
+
+	case DiagnosticResponse::drReadResponseFailed:
+		switch (m_lastCommand) {
+		case LastCommand::lcGotoTrack: return "Unable to read response from Arduino after requesting to go to a specific track";
+		case LastCommand::lcReadTrack: return "Gave up trying to read a full track from the disk.";
+		case LastCommand::lcWriteTrack: return "Unable to read response to requesting to write a track.";
+		default: tmp << "Error reading response from the Arduino while running command " << lastCommandToName(m_lastCommand) << ".";
+			return tmp.str();
+		}
+
+	case DiagnosticResponse::drSendFailed:
+		if (m_lastCommand == LastCommand::lcGotoTrack)
+			return "Unable to send the complete select track command to the Arduino.";
+		else {
+			tmp << "Error sending the command " << lastCommandToName(m_lastCommand) << " to the Arduino.";
+			return tmp.str();
+		}
+
+	case DiagnosticResponse::drSendParameterFailed:	tmp << "Unable to send a parameter while executing the " << lastCommandToName(m_lastCommand) << " command.";
+		return tmp.str();
+	case DiagnosticResponse::drStatusError: tmp << "An unknown response was was received from the Arduino while executing the " << lastCommandToName(m_lastCommand) << " command.";
+		return tmp.str();
+
+	default: return "Unknown error.";
+	}
+}
+
+// Constructor for this class
+ArduinoInterface::ArduinoInterface() {
+	m_abortStreaming = true;
+	m_version = { 0,0,false };
+	m_lastError = DiagnosticResponse::drOK;
+	m_lastCommand = LastCommand::lcGetVersion;
+	m_inWriteMode = false;
+	m_isWriteProtected = false;
+	m_diskInDrive = false;
+	m_isHDMode = false;
+	m_abortSignalled = false;
+	m_isStreaming = false;
+}
+
+// Free me
+ArduinoInterface::~ArduinoInterface() {
+	if (m_tempBuffer) free(m_tempBuffer);
+	abortReadStreaming();
+	closePort();
+}
+
+// Checks if the disk is write protected.  If forceCheck=false then the last cached version is returned.  This is also updated by checkForDisk() as well as this function
+DiagnosticResponse ArduinoInterface::checkIfDiskIsWriteProtected(bool forceCheck) {
+	// Test manually
+	m_lastCommand = LastCommand::lcCheckDiskWriteProtected;
+
+	if (!forceCheck) {
+		return m_isWriteProtected ? DiagnosticResponse::drWriteProtected : DiagnosticResponse::drOK;
+	}
+
+	// If no hardware support then return no change
+	if (m_version.major == 1 && m_version.minor < 8) {
+		m_lastError = DiagnosticResponse::drOldFirmware;
+		return m_lastError;
+	}
+
+	// Send and update flag
+	m_lastError = checkForDisk(true);
+	if (m_lastError == DiagnosticResponse::drStatusError || m_lastError == DiagnosticResponse::drOK) {
+
+		if (m_isWriteProtected)  m_lastError = DiagnosticResponse::drWriteProtected;
+	}
+
+	return m_lastError;
+}
+
+// This only works normally after the motor has been stepped in one direction or another.  This requires the 'advanced' configuration
+DiagnosticResponse ArduinoInterface::checkForDisk(bool forceCheck) {
+	// Test manually	
+	m_lastCommand = LastCommand::lcCheckDiskInDrive;
+
+	if (!forceCheck) {
+		return m_diskInDrive ? DiagnosticResponse::drOK : DiagnosticResponse::drNoDiskInDrive;
+	}
+
+
+	// If no hardware support then return no change
+	if (m_version.major == 1 && m_version.minor < 8) {
+		m_lastError = DiagnosticResponse::drOldFirmware;
+		return m_lastError;
+	}
+
+	char response;
+	m_lastError = runCommand(COMMAND_CHECKDISKEXISTS, '\0', &response);
+	if (m_lastError == DiagnosticResponse::drStatusError || m_lastError == DiagnosticResponse::drOK) {
+		if (response == '#') {
+			m_lastError = DiagnosticResponse::drNoDiskInDrive;
+			m_diskInDrive = false;
+		}
+		else {
+			if (response == '1') m_diskInDrive = true; else {
+				m_lastError = DiagnosticResponse::drReadResponseFailed;
+				return m_lastError;
+			}
+		}
+
+		// Also read the write protect status
+		if (!deviceRead(&response, 1, true)) {
+			m_lastError = DiagnosticResponse::drReadResponseFailed;
+			return m_lastError;
+		}
+
+		if (response == '1' || response == '#') m_isWriteProtected = response == '1';
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+	return m_lastError;
+}
+
+// Check if an index pulse can be detected from the drive
+DiagnosticResponse ArduinoInterface::testIndexPulse() {
+	m_lastCommand = LastCommand::lcRunDiagnostics;
+
+	// Port opened.  We need to check what happens as the pin is toggled
+	m_lastError = runCommand(COMMAND_DIAGNOSTICS, '3');
+
+	return m_lastError;
+}
+
+// Guess if the drive is actually a PLUS Mode drive
+DiagnosticResponse ArduinoInterface::guessPlusMode(bool& isProbablyPlus) {
+	m_lastCommand = LastCommand::lcRunDiagnostics;
+
+	// Port opened.  We need to check what happens as the pin is toggled
+	char response = '0';
+	m_lastError = runCommand(COMMAND_DIAGNOSTICS, '6', &response);
+	isProbablyPlus = response != '0';
+
+	if (m_lastError == DiagnosticResponse::drError) m_lastError = DiagnosticResponse::drOK;
+
+	return m_lastError;
+}
+
+// Check if data can be detected from the drive
+DiagnosticResponse ArduinoInterface::testDataPulse() {
+	m_lastCommand = LastCommand::lcRunDiagnostics;
+
+	// Port opened.  We need to check what happens as the pin is toggled
+	m_lastError = runCommand(COMMAND_DIAGNOSTICS, '4');
+
+	return m_lastError;
+}
+
+// Check if the USB to Serial device can keep up properly
+DiagnosticResponse ArduinoInterface::testTransferSpeed() {
+	m_lastCommand = LastCommand::lcRunDiagnostics;
+
+	// Port opened.  We need to receive about 10 * 256 bytes of data and verify its all valid
+	m_lastError = runCommand(COMMAND_DIAGNOSTICS, '5');
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	applyCommTimeouts(true);
+
+	unsigned char buffer[256];
+	for (int a = 0; a <= 10; a++) {
+		unsigned long read;
+
+		read = m_comPort.read(buffer, sizeof buffer);
+
+		// With the timeouts we have this shouldn't happen
+		if (read != sizeof buffer) {
+			m_lastError = DiagnosticResponse::drUSBSerialBad;
+			applyCommTimeouts(false);
+			return m_lastError;
+		}
+
+		for (size_t c = 0; c < read; c++) {
+			if (buffer[c] != c) {
+				m_lastError = DiagnosticResponse::drUSBSerialBad;
+				applyCommTimeouts(false);
+				return m_lastError;
+			}
+		}
+	}
+
+	applyCommTimeouts(false);
+	return m_lastError;
+}
+
+// Check CTS status by asking the device to set it and then checking what happened
+DiagnosticResponse ArduinoInterface::testCTS() {
+
+	for (int a = 1; a <= 10; a++) {
+		// Port opened.  We need to check what happens as the pin is toggled
+		m_lastError = runCommand(COMMAND_DIAGNOSTICS, a & 1 ? '1' : '2');
+		if (m_lastError != DiagnosticResponse::drOK) {
+			m_lastCommand = LastCommand::lcRunDiagnostics;
+			closePort();
+			return m_lastError;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+		bool ctsStatus = m_comPort.getCTSStatus();
+
+		// This doesn't actually run a command, this switches the CTS line back to its default setting
+		m_lastError = runCommand(COMMAND_DIAGNOSTICS);
+
+		if (ctsStatus ^ ((a & 1) != 0)) {
+			// If we get here then the CTS value isn't what it should be
+			closePort();
+			m_lastError = DiagnosticResponse::drCTSFailure;
+			return m_lastError;
+		}
+		// Pass.  Try the other state
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+
+	return DiagnosticResponse::drOK;
+}
+
+// Attempts to verify if the reader/writer is running on this port
+bool ArduinoInterface::isPortCorrect(const std::wstring& portName) {
+	// Attempts to verify if the reader/writer is running on this port
+	SerialIO port;
+	std::string version;
+	DiagnosticResponse dr = internalOpenPort(portName, false, true, version, port);
+	port.closePort();
+	return dr == DiagnosticResponse::drOK;
+}
+
+// Attempt to sync and get version
+DiagnosticResponse ArduinoInterface::attemptToSync(std::string& versionString, SerialIO& port) {
+	char buffer[10];
+
+	// Send 'Version' Request 
+	buffer[0] = SPECIAL_ABORT_CHAR;
+	buffer[1] = COMMAND_RESET;   // Reset
+	buffer[2] = COMMAND_VERSION;
+
+	unsigned long size = port.write(&buffer[0], 3);
+	if (size != 3) {
+		// Couldn't write to device
+		port.closePort();
+		return DiagnosticResponse::drPortError;
+	}
+
+	memset(buffer, 0, sizeof buffer);
+	int counterNoData = 0;
+	int counterData = 0;
+	int bytesRead = 0;
+
+	// Keep a rolling buffer looking for the 1Vxxx response
+	std::chrono::time_point<std::chrono::steady_clock> startTime = std::chrono::steady_clock::now();
+	for (;;) {
+		const auto timePassed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - startTime).count();
+
+		// Timeout after 8 seconds
+		if (timePassed >= 8)
+			return DiagnosticResponse::drPortError;
+
+		size = port.read(&buffer[4], 1);
+		bytesRead += size;
+		// Was something read?
+		if (size) {
+
+			if (buffer[0] == '1' && buffer[1] == 'V' && (buffer[2] >= '1' && buffer[2] <= '9') && (buffer[3] == ',' || buffer[3] == '.') && (buffer[4] >= '0' && buffer[4] <= '9')) {
+
+				// Success
+				port.purgeBuffers();
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+				port.purgeBuffers();
+				versionString = &buffer[1];
+				return DiagnosticResponse::drOK;
+			}
+			else {
+				if (bytesRead) bytesRead--;
+			}
+
+			// Move backwards
+			for (int a = 0; a < 4; a++) buffer[a] = buffer[a + 1];
+
+			if (counterData++ > 2048) {
+				port.closePort();
+				return DiagnosticResponse::drErrorMalformedVersion;
+			}
+		}
+		else {
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			if (counterNoData++ > 120) {
+				port.closePort();
+				return DiagnosticResponse::drErrorReadingVersion;
+			}
+			if (counterNoData % 7 == 6 && bytesRead == 0) {
+				// Give it a kick
+				buffer[0] = COMMAND_VERSION;
+				size = port.write(&buffer[0], 1);
+				if (size != 1) {
+					// Couldn't write to device
+					port.closePort();
+					return DiagnosticResponse::drPortError;
+				}
+			}
+		}
+	}
+}
+
+// Attempts to verify if the reader/writer is running on this port
+DiagnosticResponse ArduinoInterface::internalOpenPort(const std::wstring& portName, bool enableCTSflowcontrol, bool triggerReset, std::string& versionString, SerialIO& port) {
+	switch (port.openPort(portName)) {
+	case SerialIO::Response::rInUse:return DiagnosticResponse::drPortInUse;
+	case SerialIO::Response::rNotFound:return DiagnosticResponse::drPortNotFound;
+	case SerialIO::Response::rOK: break;
+	default: return DiagnosticResponse::drPortError;
+	}
+
+	// Configure the port
+	SerialIO::Configuration config;
+	config.baudRate = 2000000;
+	config.ctsFlowControl = enableCTSflowcontrol;
+
+	if (port.configurePort(config) != SerialIO::Response::rOK)
+	{
+		port.closePort();
+		return DiagnosticResponse::drPortError;
+	}
+
+	port.setBufferSizes(16, 16);
+	port.setReadTimeouts(10, 250);
+	port.setWriteTimeouts(2000, 200);
+
+	// Try to get the version
+	DiagnosticResponse response = attemptToSync(versionString, port);
+	if (response != DiagnosticResponse::drOK) {
+		// It failed. Issue a reset if we're allowed and try again
+		if (triggerReset) {
+			port.setDTR(false);
+			port.setRTS(false);
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			port.setDTR(true);
+			port.setRTS(true);
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			port.closePort();
+			std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+			// Now re-connect and try again
+			if (port.openPort(portName) != SerialIO::Response::rOK) return DiagnosticResponse::drPortError;
+
+			response = attemptToSync(versionString, port);
+			if (response != DiagnosticResponse::drOK) {
+				port.closePort();
+				return response;
+			}
+		}
+		else {
+			port.closePort();
+			return response;
+		}
+	}
+
+	return response;
+}
+
+// Attempts to open the reader running on the COM port number provided.  Port MUST support 2M baud
+DiagnosticResponse ArduinoInterface::openPort(const std::wstring& portName, bool enableCTSflowcontrol) {
+	m_lastCommand = LastCommand::lcOpenPort;
+	closePort();
+
+	// Quickly force streaming to be aborted
+	m_abortStreaming = true;
+
+	std::string versionString;
+	m_lastError = internalOpenPort(portName, enableCTSflowcontrol, true, versionString, m_comPort);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	// it's possible there's still redundant data in the buffer
+	char buffer[2];
+	int counter = 0;
+	while (m_comPort.getBytesWaiting()) {
+		unsigned long size = m_comPort.read(buffer, 1);
+		if (size < 1)
+			if (counter++ >= 5) break;
+	}
+
+	// Possibly a bit overkill
+	m_comPort.setBufferSizes(RAW_TRACKDATA_LENGTH_DD * 2, RAW_TRACKDATA_LENGTH_DD);
+
+	m_version.major = versionString[1] - '0';
+	m_version.minor = versionString[3] - '0';
+	m_version.fullControlMod = versionString[2] == ',';
+
+	// Check features
+	m_version.deviceFlags1 = 0;
+	m_version.deviceFlags2 = 0;
+	m_version.buildNumber = 0;
+
+	if ((m_version.major > 1) || ((m_version.major == 1) && (m_version.minor >= 9))) {
+		m_lastError = runCommand(COMMAND_CHECK_FEATURES);
+		if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+		if (!deviceRead(&m_version.deviceFlags1, 1)) {
+			m_lastError = DiagnosticResponse::drErrorReadingVersion;
+			return m_lastError;
+		}
+		if (!deviceRead(&m_version.deviceFlags2, 1)) {
+			m_lastError = DiagnosticResponse::drErrorReadingVersion;
+			return m_lastError;
+		}
+		if (!deviceRead(&m_version.buildNumber, 1)) {
+			m_lastError = DiagnosticResponse::drErrorReadingVersion;
+			return m_lastError;
+		}
+	}
+
+	// Switch to normal timeouts
+	applyCommTimeouts(false);
+
+	// Ok, success
+	return m_lastError;
+}
+
+// Apply and change the timeouts on the com port
+void ArduinoInterface::applyCommTimeouts(bool shortTimeouts) {
+	if (shortTimeouts) {
+		m_comPort.setReadTimeouts(5, 12);
+	}
+	else {
+		m_comPort.setReadTimeouts(2000, 200);
+	}
+	m_comPort.setWriteTimeouts(2000, 200);
+}
+
+// Closes the port down
+void ArduinoInterface::closePort() {
+	LastCommand old = m_lastCommand;
+	if (m_comPort.isPortOpen()) {
+		// Force the drive to power down
+		enableReading(false);
+		// And close the handle
+		m_comPort.closePort();
+	}
+	m_inWriteMode = false;
+	m_isWriteProtected = false;
+	m_diskInDrive = false;
+	m_lastCommand = old;
+}
+
+// Returns true if the track actually contains some data, else its considered blank or unformatted
+bool ArduinoInterface::trackContainsData(const RawTrackDataDD& trackData) const {
+	int zerocount = 0, ffcount = 0;
+	unsigned char lastByte = trackData[0];
+	for (unsigned int counter = 1; counter < RAW_TRACKDATA_LENGTH_DD; counter++) {
+		if (trackData[counter] == lastByte) {
+			switch (lastByte) {
+			case 0xFF: ffcount++; zerocount = 0; break;
+			case 0x00: ffcount = 0; zerocount++; break;
+			default: zerocount = 0; ffcount = 0;
+			}
+		}
+		else {
+			lastByte = trackData[counter];
+			zerocount = 0; ffcount = 0;
+		}
+	}
+
+	// More than this in a row and its bad
+	return ffcount < 20 && zerocount < 20;
+}
+
+// Turns on and off the writing interface.  If irError is returned the disk is write protected
+DiagnosticResponse ArduinoInterface::enableWriting(const bool enable, const bool reset) {
+
+	if (enable) {
+		m_lastCommand = LastCommand::lcEnableWrite;
+
+		// Enable the device
+		m_lastError = runCommand(COMMAND_ENABLEWRITE);
+		if (m_lastError == DiagnosticResponse::drError) {
+			m_lastError = DiagnosticResponse::drWriteProtected;
+			return m_lastError;
+		}
+		if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+		m_inWriteMode = true;
+
+		// Reset?
+		if (reset) {
+			// And rewind to the first track
+			m_lastError = findTrack0();
+			if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+			// Lets know where we are
+			return selectSurface(DiskSurface::dsUpper);
+		}
+		m_lastError = DiagnosticResponse::drOK;
+		return m_lastError;
+	}
+	else {
+		m_lastCommand = LastCommand::lcDisableMotor;
+
+		// Disable the device
+		m_lastError = runCommand(COMMAND_DISABLE);
+		if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+		m_inWriteMode = false;
+
+		return m_lastError;
+	}
+}
+
+// Seek to track 0
+DiagnosticResponse ArduinoInterface::findTrack0() {
+	m_lastCommand = LastCommand::lcRewind;
+
+	// And rewind to the first track
+	char status = '0';
+	m_lastError = runCommand(COMMAND_REWIND, '\000', &status);
+	if (m_lastError != DiagnosticResponse::drOK) {
+		if (status == '#') return DiagnosticResponse::drRewindFailure;
+	}
+	return m_lastError;
+}
+
+// Turns on and off the reading interface
+DiagnosticResponse ArduinoInterface::enableReading(const bool enable, const bool reset, const bool dontWait) {
+	m_inWriteMode = false;
+	if (enable) {
+		m_lastCommand = LastCommand::lcEnableMotor;
+
+		// Enable the device
+		m_lastError = runCommand(dontWait ? COMMAND_ENABLE_NOWAIT : COMMAND_ENABLE);
+		if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+		// Reset?
+		if (reset) {
+			m_lastError = findTrack0();
+			if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+			// Lets know where we are
+			return selectSurface(DiskSurface::dsUpper);
+		}
+		m_lastError = DiagnosticResponse::drOK;
+		m_inWriteMode = m_version.fullControlMod;
+		return m_lastError;
+
+	}
+	else {
+		m_lastCommand = LastCommand::lcDisableMotor;
+
+		// Disable the device
+		m_lastError = runCommand(COMMAND_DISABLE);
+
+		return m_lastError;
+	}
+}
+
+// Query the RPM of the drive
+DiagnosticResponse ArduinoInterface::measureDriveRPM(float& rpm) {
+	m_lastCommand = LastCommand::lcMeasureRPM;
+
+	bool isV19 = (m_version.major > 1) || ((m_version.major == 1) && (m_version.minor >= 9));
+	if (!isV19) return DiagnosticResponse::drOldFirmware;
+
+	// Query the RPM
+	m_lastError = runCommand(COMMAND_TEST_RPM);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	// Now we read bytes until we get an '\n' or a max of 10
+	char buffer[11];
+	int index = 0;
+	int failCount = 0;
+	memset(buffer, 0, sizeof buffer);
+
+	// Read RPM
+	while (index < 10) {
+		if (deviceRead(&buffer[index], 1)) {
+			if (buffer[index] == '\n') {
+				buffer[index] = '\0';
+				break;
+			}
+			index++;
+		}
+		else
+			if (failCount++ > 10) break;
+	}
+
+	// And output it as a float
+	rpm = (float)atof(buffer);
+
+	if (rpm < 10) m_lastError = DiagnosticResponse::drNoDiskInDrive;
+
+	return m_lastError;
+}
+
+// Checks to see what the density of the current disk is most likely to be.  Ideally this should be done while at track 0, probably lower head
+DiagnosticResponse ArduinoInterface::checkDiskCapacity(bool& isHD) {
+	m_lastCommand = LastCommand::lcCheckDensity;
+
+	bool isV19 = (m_version.major > 1) || ((m_version.major == 1) && (m_version.minor >= 9));
+	if (!isV19) return DiagnosticResponse::drOldFirmware;
+
+	if ((m_version.deviceFlags1 & FLAGS_DENSITYDETECT_ENABLED) == 0) {
+		isHD = false;
+		return DiagnosticResponse::drOK;
+	}
+
+	// Query the density
+	m_lastError = runCommand(COMMAND_CHECK_DENSITY);
+	if (m_lastError != DiagnosticResponse::drOK) {
+		return m_lastError;
+	}
+
+	// And read the type
+	char status;
+	if (!deviceRead(&status, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	// 'x' means no disk in drive
+	switch (status) {
+	case 'x':
+		// m_diskInDrive = false;
+		// We're not going to update the disk in drive flag, just use it as an OK error
+		m_lastError = DiagnosticResponse::drNoDiskInDrive;
+		break;
+
+	case 'H':
+		m_diskInDrive = true;
+		isHD = true;
+		m_lastError = DiagnosticResponse::drOK;
+		break;
+
+	case 'D':
+		m_diskInDrive = true;
+		isHD = false;
+		m_lastError = DiagnosticResponse::drOK;
+		break;
+	}
+
+	return m_lastError;
+}
+
+// Check and switch to HD disk
+DiagnosticResponse ArduinoInterface::setDiskCapacity(bool switchToHD_Disk) {
+	m_lastCommand = LastCommand::lcSwitchDiskMode;
+
+	m_lastError = runCommand(switchToHD_Disk ? COMMAND_SWITCHTO_HD : COMMAND_SWITCHTO_DD);
+
+	if (m_lastError == DiagnosticResponse::drOK) m_isHDMode = switchToHD_Disk;
+
+	return m_lastError;
+}
+
+// If the drive is on track 0, this does a test seek to -1 if supported
+DiagnosticResponse ArduinoInterface::performNoClickSeek() {
+	// And send the command and track.  This is sent as ASCII text as a result of terminal testing.  Easier to see whats going on
+	bool isV18 = (m_version.major > 1) || ((m_version.major == 1) && (m_version.minor >= 8));
+	if (!isV18) return DiagnosticResponse::drOldFirmware;
+	if (!m_version.fullControlMod) return DiagnosticResponse::drOldFirmware;
+
+	m_lastCommand = LastCommand::lcNoClickCheck;
+
+	m_lastError = runCommand(COMMAND_DO_NOCLICK_SEEK);
+	if (m_lastError == DiagnosticResponse::drOK) {
+		// Read extended data
+		char status;
+		if (!deviceRead(&status, 1, true)) {
+			m_lastError = DiagnosticResponse::drReadResponseFailed;
+			return m_lastError;
+		}
+		// 'x' means we didn't check it
+		if (status != 'x') m_diskInDrive = status == '1';
+
+		// Also read the write protect status
+		if (!deviceRead(&status, 1, true)) {
+			m_lastError = DiagnosticResponse::drReadResponseFailed;
+			return m_lastError;
+		}
+		m_isWriteProtected = status == '1';
+	}
+
+	return m_lastError;
+}
+
+// Select the track, this makes the motor seek to this position
+DiagnosticResponse ArduinoInterface::selectTrack(const unsigned char trackIndex, const TrackSearchSpeed searchSpeed, bool ignoreDiskInsertCheck) {
+	m_lastCommand = LastCommand::lcGotoTrack;
+
+	if (trackIndex > 83) {
+		m_lastError = DiagnosticResponse::drTrackRangeError;
+		return m_lastError; // no chance, it can't be done.
+	}
+
+	// And send the command and track.  This is sent as ASCII text as a result of terminal testing.  Easier to see whats going on
+	bool isV18 = (m_version.major > 1) || ((m_version.major == 1) && (m_version.minor >= 8));
+	char buf[8];
+	if (isV18) {
+		char flags = (int)searchSpeed;
+		if (!ignoreDiskInsertCheck) flags |= 4;
+#ifdef _WIN32		
+		sprintf_s(buf, "%c%02i%c", COMMAND_GOTOTRACK_REPORT, trackIndex, flags);
+#else
+		sprintf(buf, "%c%02i%c", COMMAND_GOTOTRACK_REPORT, trackIndex, flags);
+#endif	
+	}
+	else {
+#ifdef _WIN32			
+		sprintf_s(buf, "%c%02i", COMMAND_GOTOTRACK, trackIndex);
+#else		
+		sprintf(buf, "%c%02i", COMMAND_GOTOTRACK, trackIndex);
+#endif	
+	}
+
+	// Send track number. 
+	if (!deviceWrite(buf, (unsigned int)strlen(buf))) {
+		m_lastError = DiagnosticResponse::drSendFailed;
+		return m_lastError;
+	}
+
+	// Get result
+	char result;
+
+	if (!deviceRead(&result, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	switch (result) {
+	case '2': m_lastError = DiagnosticResponse::drOK; break; // already at track.  No op needed.  V1.8 only
+	case '1': m_lastError = DiagnosticResponse::drOK;
+		if (isV18) {
+			// Read extended data
+			char status;
+			if (!deviceRead(&status, 1, true)) {
+				m_lastError = DiagnosticResponse::drReadResponseFailed;
+				return m_lastError;
+			}
+			// 'x' means we didn't check it
+			if (status != 'x') m_diskInDrive = status == '1';
+
+			// Also read the write protect status
+			if (!deviceRead(&status, 1, true)) {
+				m_lastError = DiagnosticResponse::drReadResponseFailed;
+				return m_lastError;
+			}
+			m_isWriteProtected = status == '1';
+		}
+		break;
+	case '0':    m_lastError = DiagnosticResponse::drSelectTrackError;
+		break;
+	default:	 m_lastError = DiagnosticResponse::drStatusError;
+		break;
+	}
+
+	return m_lastError;
+}
+
+// Erases the current track by writing 0xAA to it
+DiagnosticResponse ArduinoInterface::eraseCurrentTrack() {
+	m_lastCommand = LastCommand::lcEraseTrack;
+	m_lastError = runCommand(COMMAND_ERASETRACK);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	char result;
+	if (!deviceRead(&result, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (result == 'N') {
+		m_lastError = DiagnosticResponse::drWriteProtected;
+		return m_lastError;
+	}
+
+	// Check result
+	if (!deviceRead(&result, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (result != '1') {
+		m_lastError = DiagnosticResponse::drError;
+		return m_lastError;
+	}
+
+	return m_lastError;
+}
+
+
+// Choose which surface of the disk to read from
+DiagnosticResponse ArduinoInterface::selectSurface(const DiskSurface side) {
+	m_lastCommand = LastCommand::lcSelectSurface;
+
+	m_lastError = runCommand(side == DiskSurface::dsUpper ? COMMAND_HEAD0 : COMMAND_HEAD1);
+
+	return m_lastError;
+}
+
+void writeBit(unsigned char* output, int& pos, int& bit, int value, const int maxLength) {
+	if (pos >= maxLength) return;
+
+	output[pos] <<= 1;
+	output[pos] |= value;
+	bit++;
+	if (bit >= 8) {
+		pos++;
+		bit = 0;
+	}
+}
+
+void unpack(const unsigned char* data, unsigned char* output, const int maxLength) {
+	int pos = 0;
+	size_t index = 0;
+	int p2 = 0;
+	memset(output, 0, maxLength);
+	while (pos < maxLength) {
+		// Each byte contains four pairs of bits that identify an MFM sequence to be encoded
+
+		for (int b = 6; b >= 0; b -= 2) {
+			switch ((data[index] >> b) & 3) {
+			case 0:
+				// This can't happen, its invalid data but we account for 4 '0' bits
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 0, maxLength);
+				break;
+			case 1: // This is an '01'
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 1, maxLength);
+				break;
+			case 2: // This is an '001'
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 1, maxLength);
+				break;
+			case 3: // this is an '0001'
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 0, maxLength);
+				writeBit(output, pos, p2, 1, maxLength);
+				break;
+			}
+		}
+		index++;
+		if (index >= (size_t)maxLength) return;
+	}
+	// There will be left-over data
+}
+
+// Read RAW data from the current track and surface 
+DiagnosticResponse ArduinoInterface::readCurrentTrack(RawTrackDataDD& trackData, const bool readFromIndexPulse) {
+	return readCurrentTrack(&trackData, RAW_TRACKDATA_LENGTH_DD, readFromIndexPulse);
+}
+
+// Reads just enough data to fulfill most extractions needed, but doesnt care about rotation position or index - pll should have the LinearExtractor configured
+DiagnosticResponse ArduinoInterface::readData(PLL::BridgePLL& pll) {
+	pll.rotationExtractor()->reset(m_isHDMode);
+	LinearExtractor* linearExtractor = dynamic_cast<LinearExtractor*>(pll.rotationExtractor());
+	if (!linearExtractor) return DiagnosticResponse::drError;
+
+	if (!m_tempBuffer) {
+		m_tempBuffer = malloc(RAW_TRACKDATA_LENGTH_HD);
+		if (!m_tempBuffer) return DiagnosticResponse::drError;
+	}
+
+	const uint32_t sizeRequired = m_isHDMode ? RAW_TRACKDATA_LENGTH_HD : RAW_TRACKDATA_LENGTH_DD;
+	DiagnosticResponse response = readCurrentTrack(m_tempBuffer, sizeRequired, false);
+	if (response != DiagnosticResponse::drOK) return response;
+	linearExtractor->copyToBuffer(m_tempBuffer, sizeRequired);
+	return response;
+	
+	m_lastCommand = LastCommand::lcReadTrackStream;
+
+	if (m_version.major == 1 && m_version.minor < 8) {
+		m_lastError = DiagnosticResponse::drOldFirmware;
+		return m_lastError;
+	}
+
+	const bool highPrecisionMode = !m_isHDMode && m_version.deviceFlags1 & FLAGS_HIGH_PRECISION_SUPPORT;
+	char mode = highPrecisionMode ? COMMAND_READTRACKSTREAM_HIGHPRECISION : COMMAND_READTRACKSTREAM;
+
+	if (mode == COMMAND_READTRACKSTREAM_HIGHPRECISION && m_version.deviceFlags1 & FLAGS_FLUX_READ) mode = COMMAND_READTRACKSTREAM_HALFPLL;
+	m_lastError = runCommand(mode);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+	m_isStreaming = true;
+
+	applyCommTimeouts(true);
+	unsigned char tempReadBuffer[4096] = { 0 };
+
+	// Let the class know we're doing some streaming stuff
+	m_abortStreaming = false;
+	m_abortSignalled = false;
+
+	// Number of times we failed to read anything
+	int32_t readFail = 0;
+
+	// Sliding window for abort
+	char slidingWindow[5] = { 0,0,0,0,0 };
+	bool timeout = false;
+	bool dataState = false;
+	bool isFirstByte = true;
+	unsigned char mfmSequences = 0;
+
+	MFMExtractionTarget* extractor = pll.rotationExtractor();
+
+	for (;;) {
+
+		// More efficient to read several bytes in one go		
+		unsigned int bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof tempReadBuffer) bytesAvailable = sizeof tempReadBuffer;
+		unsigned int bytesRead = m_comPort.read(tempReadBuffer, bytesAvailable);
+		for (size_t a = 0; a < bytesRead; a++) {
+			const unsigned char byteRead = tempReadBuffer[a];
+			if (m_abortSignalled) {
+				// Make space
+				for (int s = 0; s < 4; s++) slidingWindow[s] = slidingWindow[s + 1];
+				// Append the new byte
+				slidingWindow[4] = byteRead;
+
+				// Watch the sliding window for the pattern we need
+				if (slidingWindow[0] == 'X' && slidingWindow[1] == 'Y' && slidingWindow[2] == 'Z' && slidingWindow[3] == SPECIAL_ABORT_CHAR && slidingWindow[4] == '1') {
+					m_isStreaming = false;
+					m_comPort.purgeBuffers();
+					m_lastError = timeout ? DiagnosticResponse::drError : DiagnosticResponse::drOK;
+					applyCommTimeouts(false);
+					return m_lastError;
+				}
+			}
+			else {
+				unsigned char tmp;
+				RotationExtractor::MFMSequenceInfo sequence{};
+				if (m_isHDMode) {
+					for (int i = 6; i >= 0; i -= 2) {
+						tmp = byteRead >> i & 0x03;
+						sequence.mfm = (RotationExtractor::MFMSequence)((tmp == 0x03 ? 0 : tmp) + 1);
+						sequence.timeNS = 2000 + (unsigned int)sequence.mfm * 2000;
+						extractor->submitSequence(sequence, tmp == 0x03);
+					}
+				}
+				else {
+					if (highPrecisionMode) {
+						if (isFirstByte) {
+							// Throw away the first byte
+							isFirstByte = false;
+							if (byteRead != 0xC3) {
+								// This should never happen.
+								abortReadStreaming();
+							}
+						}
+						else {
+							if (dataState) {
+
+								if (mode == COMMAND_READTRACKSTREAM_HALFPLL) {
+									const int32_t sequences[4] = { (mfmSequences >> 6) & 0x03, (mfmSequences >> 4) & 0x03, (mfmSequences >> 2) & 0x03, mfmSequences & 0x03 };
+
+									// First remove any flux time that us 000 as thats always fixed
+									int32_t readSpeed = (unsigned int)(byteRead & 0x7F) * 2000 / 128;
+
+									// Output the fluxes
+									for (int a = 0; a < 4; a++) {
+										if (sequences[a] == 0) {
+											sequence.mfm = RotationExtractor::MFMSequence::mfm000;
+											sequence.timeNS = 5000 + readSpeed;
+										}
+										else {
+											sequence.mfm = (RotationExtractor::MFMSequence)sequences[a];
+											sequence.timeNS = 1000 + readSpeed + (((int)sequence.mfm) * 2000);
+										}
+										sequence.pllTimeNS = sequence.timeNS;
+										extractor->submitSequence(sequence, ((byteRead & 0x80) != 0) && (a == 0));
+									}
+
+								}
+								else {
+									int32_t readSpeed = (unsigned int)(byteRead & 0x7F) * 2000 / 128;
+									tmp = mfmSequences >> 6 & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor->submitSequence(sequence, (byteRead & 0x80) != 0);
+
+									tmp = mfmSequences >> 4 & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor->submitSequence(sequence, false);
+
+									tmp = mfmSequences >> 2 & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor->submitSequence(sequence, false);
+
+									tmp = mfmSequences & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor->submitSequence(sequence, false);
+								}
+
+								dataState = false;
+							}
+							else {
+								// in 'false' mode we get the flux data
+								dataState = true;
+								mfmSequences = byteRead;
+							}
+						}
+					}
+					else {
+						unsigned short readSpeed = (unsigned long long)((unsigned int)((byteRead & 0x07) * 16) * 2000) / 128;
+
+						// Now packet up the data in the format the rotation extractor expects it to be in
+						tmp = byteRead >> 5 & 0x03;
+						sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+						sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + readSpeed;
+
+						extractor->submitSequence(sequence, (byteRead & 0x80) != 0);
+
+						tmp = byteRead >> 3 & 0x03;
+						sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+						sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + readSpeed;
+
+						extractor->submitSequence(sequence, false);
+					}
+				}
+
+				// Is it ready to extract? - takes 15-16ms to abort so take that into account
+				if ((extractor->canExtract() || extractor->totalTimeReceived()>(220000000 - 14000000))) {
+					if (!m_abortSignalled) abortReadStreaming();
+				}				
+			}
+		}
+		if (bytesRead < 1) {
+			readFail++;
+			if (readFail > 30) {
+				m_abortStreaming = false; // force the 'abort' command to be sent
+				abortReadStreaming();
+				m_lastError = DiagnosticResponse::drReadResponseFailed;
+				m_isStreaming = false;
+				applyCommTimeouts(false);
+				return m_lastError;
+			}
+			else {
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+		else {
+			readFail = 0;
+		}
+	}
+}
+
+// Read RAW data from the current track and surface HD mode
+DiagnosticResponse ArduinoInterface::readCurrentTrack(void* trackData, const int dataLength, const bool readFromIndexPulse) {
+	m_lastCommand = LastCommand::lcReadTrack;
+
+	// Length must be one of the two types
+	if (dataLength == RAW_TRACKDATA_LENGTH_DD && m_isHDMode) {
+		m_lastError = DiagnosticResponse::drMediaTypeMismatch;
+		return m_lastError;
+	}
+	if (dataLength == RAW_TRACKDATA_LENGTH_HD && !m_isHDMode) {
+		m_lastError = DiagnosticResponse::drMediaTypeMismatch;
+		return m_lastError;
+	}
+
+	RawTrackDataHD* tmp = (RawTrackDataHD*)malloc(sizeof(RawTrackDataHD));
+	if (!tmp) {
+		m_lastError = DiagnosticResponse::drError;
+		return m_lastError;
+	}
+
+	if (m_isHDMode) {
+		m_lastCommand = LastCommand::lcReadTrackStream;
+
+		m_lastError = runCommand(COMMAND_READTRACKSTREAM);
+		// Allow command retry
+		if (m_lastError != DiagnosticResponse::drOK) {
+			// Clear the buffer
+			m_lastError = runCommand(COMMAND_READTRACKSTREAM);
+			if (m_lastError != DiagnosticResponse::drOK) {
+				free(tmp);
+				return m_lastError;
+			}
+		}
+
+		// Number of times we failed to read anything
+		int readFail = 0;
+
+		// Buffer to read into
+		unsigned char tempReadBuffer[64] = { 0 };
+
+		// Sliding window for abort
+		char slidingWindow[5] = { 0,0,0,0,0 };
+		bool timeout = false;
+
+		unsigned int writePosition = 0;
+		m_isStreaming = true;
+		m_abortStreaming = false;
+		m_abortSignalled = false;
+
+		// We know what this is, but the A
+		applyCommTimeouts(true);
+
+		while (m_isStreaming) {
+
+			// More efficient to read several bytes in one go		
+			unsigned long bytesAvailable = m_comPort.getBytesWaiting();
+			if (bytesAvailable < 1) bytesAvailable = 1;
+			if (bytesAvailable > sizeof tempReadBuffer) bytesAvailable = sizeof tempReadBuffer;
+			unsigned long bytesRead = m_comPort.read(tempReadBuffer, m_abortSignalled ? 1 : bytesAvailable);
+
+			for (size_t a = 0; a < bytesRead; a++) {
+				if (m_abortSignalled) {
+					// Make space
+					for (int s = 0; s < 4; s++) slidingWindow[s] = slidingWindow[s + 1];
+					// Append the new byte
+					slidingWindow[4] = tempReadBuffer[a];
+
+					// Watch the sliding window for the pattern we need
+					if (slidingWindow[0] == 'X' && slidingWindow[1] == 'Y' && slidingWindow[2] == 'Z' && slidingWindow[3] == SPECIAL_ABORT_CHAR && slidingWindow[4] == '1') {
+						m_isStreaming = false;
+						m_comPort.purgeBuffers();
+						m_lastError = timeout ? DiagnosticResponse::drNoDiskInDrive : DiagnosticResponse::drOK;
+						applyCommTimeouts(false);
+						bytesRead = 0;
+					}
+				}
+				else {
+					// HD Mode
+					unsigned char tmp2;
+					unsigned char outputByte = 0;
+
+					for (int i = 6; i >= 0; i -= 2) {
+						// Convert to other format
+						tmp2 = tempReadBuffer[a] >> i & 0x03;
+						if (tmp2 == 3) tmp2 = 0;
+
+						outputByte <<= 2;
+						outputByte |= tmp2 + 1;
+					}
+
+					(*tmp)[writePosition] = outputByte;
+					writePosition++;
+					if (writePosition >= (size_t)dataLength) {
+						abortReadStreaming();
+					}
+				}
+			}
+			if (bytesRead < 1) {
+				readFail++;
+				if (readFail > 30) {
+					m_abortStreaming = false; // force the 'abort' command to be sent
+					abortReadStreaming();
+					m_lastError = DiagnosticResponse::drReadResponseFailed;
+					m_isStreaming = false;
+					free(tmp);
+					applyCommTimeouts(false);
+					// Force a check for disk
+					checkForDisk(true);
+					return m_lastError;
+				}
+				else std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+	}
+	else {
+
+		m_lastError = runCommand(COMMAND_READTRACK);
+
+		// Allow command retry
+		if (m_lastError != DiagnosticResponse::drOK) {
+			// Clear the buffer
+			deviceRead(tmp, dataLength);
+			m_lastError = runCommand(COMMAND_READTRACK);
+			if (m_lastError != DiagnosticResponse::drOK) {
+				free(tmp);
+				return m_lastError;
+			}
+		}
+
+		unsigned char signalPulse = readFromIndexPulse ? 1 : 0;
+		if (!deviceWrite(&signalPulse, 1)) {
+			m_lastError = DiagnosticResponse::drSendParameterFailed;
+			free(tmp);
+			return m_lastError;
+		}
+
+		// Keep reading until he hit dataLength or a null byte is received
+		int bytePos = 0;
+		int readFail = 0;
+		for (;;) {
+			unsigned char value;
+			if (deviceRead(&value, 1, true)) {
+				if (value == 0) break; else
+					if (bytePos < dataLength) (*tmp)[bytePos++] = value;
+			}
+			else {
+				readFail++;
+				if (readFail > 4) {
+					free(tmp);
+					m_lastError = DiagnosticResponse::drReadResponseFailed;
+					return m_lastError;
+				}
+			}
+		}
+	}
+
+	unpack(*tmp, (unsigned char*)trackData, dataLength);
+	free(tmp);
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+
+#ifndef _WIN32
+#define USE_THREADDED_READER
+#endif
+
+// Reads a complete rotation of the disk, and returns it using the callback function which can return FALSE to stop
+// An instance of RotationExtractor is required.  This is purely to save on re-allocations.  It is internally reset each time
+DiagnosticResponse ArduinoInterface::readRotation(MFMExtractionTarget& extractor, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns, std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation, bool useHalfPLL) {
+	m_lastCommand = LastCommand::lcReadTrackStream;
+
+	if (m_version.major == 1 && m_version.minor < 8) {
+		m_lastError = DiagnosticResponse::drOldFirmware;
+		return m_lastError;
+	}
+
+	// Who would do this, right?
+	if (maxOutputSize < 1 || !firstOutputBuffer) {
+		m_lastError = DiagnosticResponse::drError;
+		return m_lastError;
+	}
+
+	const bool highPrecisionMode = !m_isHDMode && m_version.deviceFlags1 & FLAGS_HIGH_PRECISION_SUPPORT;
+	char mode = highPrecisionMode ? COMMAND_READTRACKSTREAM_HIGHPRECISION : COMMAND_READTRACKSTREAM;
+
+	if (mode == COMMAND_READTRACKSTREAM_HIGHPRECISION && m_version.deviceFlags1 & FLAGS_FLUX_READ && useHalfPLL) mode = COMMAND_READTRACKSTREAM_HALFPLL;
+
+	
+	m_lastError = runCommand(mode);
+
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	m_isStreaming = true;
+
+
+#ifdef USE_THREADDED_READER
+	std::mutex safetyLock;
+	// I was using a deque, but its much faster to just keep switching between two vectors
+	std::vector<unsigned char> readBuffer;
+	readBuffer.reserve(4096);
+	std::vector<unsigned char> tempReadBuffer;
+	tempReadBuffer.reserve(4096);
+#ifdef _WIN32
+	m_comPort.setReadTimeouts(100, 0);  // match linux
+#endif
+	std::thread* backgroundReader = new std::thread([this, &readBuffer, &safetyLock]() {
+#ifdef _WIN32
+		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+#endif
+		unsigned char buffer[1024];  // the LINUX serial buffer is only 512 bytes anyway
+		while (m_isStreaming) {
+			uint32_t waiting = m_comPort.justRead(buffer, 1024);
+			if (waiting>0) {
+				safetyLock.lock();				
+				readBuffer.insert(readBuffer.end(), buffer, buffer+waiting);
+				safetyLock.unlock();
+			} else
+				std::this_thread::sleep_for(std::chrono::microseconds(200));
+		}
+	});
+
+
+#else
+	applyCommTimeouts(true);
+	unsigned char tempReadBuffer[2048] = { 0 };
+#endif
+
+	// Let the class know we're doing some streaming stuff
+	m_abortStreaming = false;
+	m_abortSignalled = false;
+
+	// Number of times we failed to read anything
+	int32_t readFail = 0;
+
+	// Reset ready for extraction
+	extractor.reset(m_isHDMode);
+
+	// Remind it if the 'index' data we want to sync to
+	extractor.setIndexSequence(startBitPatterns);
+
+	// Sliding window for abort
+	char slidingWindow[5] = { 0,0,0,0,0 };
+	bool timeout = false;
+	bool dataState = false;
+	bool isFirstByte = true;
+	unsigned char mfmSequences = 0;
+
+	for (;;) {
+
+		// More efficient to read several bytes in one go		
+#ifdef USE_THREADDED_READER
+		tempReadBuffer.resize(0); // should be just as fast as clear, but just in case
+		safetyLock.lock();
+		std::swap(tempReadBuffer, readBuffer);
+		safetyLock.unlock();
+
+		unsigned int bytesRead = tempReadBuffer.size();
+		
+		if (bytesRead < 1) std::this_thread::sleep_for(std::chrono::milliseconds(20)); 
+		for (const unsigned char byteRead : tempReadBuffer) {
+#else
+		unsigned int bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof tempReadBuffer) bytesAvailable = sizeof tempReadBuffer;
+		unsigned int bytesRead = m_comPort.read(tempReadBuffer, m_abortSignalled ? 1 : bytesAvailable);
+		for (size_t a = 0; a < bytesRead; a++) {
+			const unsigned char byteRead = tempReadBuffer[a];
+#endif
+			if (m_abortSignalled) {
+				// Make space
+				for (int s = 0; s < 4; s++) slidingWindow[s] = slidingWindow[s + 1];
+				// Append the new byte
+				slidingWindow[4] = byteRead;
+
+				// Watch the sliding window for the pattern we need
+				if (slidingWindow[0] == 'X' && slidingWindow[1] == 'Y' && slidingWindow[2] == 'Z' && slidingWindow[3] == SPECIAL_ABORT_CHAR && slidingWindow[4] == '1') {
+					m_isStreaming = false;
+#ifdef USE_THREADDED_READER
+					if (backgroundReader) {
+						if (backgroundReader->joinable()) backgroundReader->join();
+						delete backgroundReader;
+					}
+#endif
+					m_comPort.purgeBuffers();
+					m_lastError = timeout ? DiagnosticResponse::drError : DiagnosticResponse::drOK;
+					applyCommTimeouts(false);
+					return m_lastError;
+				}
+			}
+			else {
+				unsigned char tmp;
+				RotationExtractor::MFMSequenceInfo sequence{};
+				if (m_isHDMode) {
+					for (int i = 6; i >= 0; i -= 2) {
+						tmp = byteRead >> i & 0x03;
+						sequence.mfm = (RotationExtractor::MFMSequence)((tmp == 0x03 ? 0 : tmp)+1);
+						sequence.timeNS = 2000 + (unsigned int)sequence.mfm * 2000;
+						extractor.submitSequence(sequence, tmp == 0x03);
+					}
+				}
+				else {
+					if (highPrecisionMode) {
+						if (isFirstByte) {
+							// Throw away the first byte
+							isFirstByte = false;
+							if (byteRead != 0xC3) {
+								// This should never happen.
+								abortReadStreaming();
+							}
+						}
+						else {
+							if (dataState) {
+
+								if (mode == COMMAND_READTRACKSTREAM_HALFPLL) {
+									const int32_t sequences[4] = { (mfmSequences >> 6) & 0x03, (mfmSequences >> 4) & 0x03, (mfmSequences >> 2) & 0x03, mfmSequences & 0x03 };
+
+									// First remove any flux time that us 000 as thats always fixed
+									int32_t readSpeed = (unsigned int)(byteRead & 0x7F) * 2000 / 128;
+
+									// Output the fluxes
+									for (int a = 0; a < 4; a++) {
+										if (sequences[a] == 0) {
+											sequence.mfm = RotationExtractor::MFMSequence::mfm000;
+											sequence.timeNS = 5000 + readSpeed;
+										}
+										else {
+											sequence.mfm = (RotationExtractor::MFMSequence)sequences[a];
+											sequence.timeNS = 1000 + readSpeed + (((int)sequence.mfm) * 2000);
+										}
+										sequence.pllTimeNS = sequence.timeNS;
+										extractor.submitSequence(sequence, ((byteRead & 0x80) != 0) && (a==0));
+									}
+
+								}
+								else {
+									int32_t readSpeed = (unsigned int)(byteRead & 0x7F) * 2000 / 128;
+									tmp = mfmSequences >> 6 & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor.submitSequence(sequence, (byteRead & 0x80) != 0);
+
+									tmp = mfmSequences >> 4 & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor.submitSequence(sequence, false);
+
+									tmp = mfmSequences >> 2 & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor.submitSequence(sequence, false);
+
+									tmp = mfmSequences & 0x03;
+									sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+									sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + (sequence.mfm == RotationExtractor::MFMSequence::mfm000 ? -2000 : readSpeed);
+									extractor.submitSequence(sequence, false);
+								}
+
+								dataState = false;
+							}
+							else {
+								// in 'false' mode we get the flux data
+								dataState = true;
+								mfmSequences = byteRead;
+							}
+						}
+					}
+					else {
+						unsigned short readSpeed = (unsigned long long)((unsigned int)((byteRead & 0x07) * 16) * 2000) / 128;
+
+						// Now packet up the data in the format the rotation extractor expects it to be in
+						tmp = byteRead >> 5 & 0x03;
+						sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+						sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + readSpeed;
+
+						extractor.submitSequence(sequence, (byteRead & 0x80) != 0);
+
+						tmp = byteRead >> 3 & 0x03;
+						sequence.mfm = tmp == 0 ? RotationExtractor::MFMSequence::mfm000 : (RotationExtractor::MFMSequence)(tmp);
+						sequence.timeNS = 1000 + (unsigned int)sequence.mfm * 2000 + readSpeed;
+
+						extractor.submitSequence(sequence, false);
+					}
+				}
+
+
+				// Is it ready to extract?
+				if (extractor.canExtract()) {
+					unsigned int bits = 0;
+					// Go!
+					if (extractor.extractRotation(firstOutputBuffer, bits, maxOutputSize)) {
+						m_diskInDrive = true;
+
+						if (!onRotation(&firstOutputBuffer, bits)) {
+							// And if the callback says so we stop.
+							abortReadStreaming();
+						}
+						// Always save this back
+						extractor.getIndexSequence(startBitPatterns);
+					}
+				}
+				else {
+					if (extractor.totalTimeReceived() > (m_isHDMode ? 1200000000U : 600000000U)) {
+						// No data, stop
+						abortReadStreaming();
+						timeout = true;
+					}
+				}
+			}
+		}
+		if (bytesRead < 1) {
+			readFail++;
+			if (readFail > 30) {
+				m_abortStreaming = false; // force the 'abort' command to be sent
+				abortReadStreaming();
+				m_lastError = DiagnosticResponse::drReadResponseFailed;
+				m_isStreaming = false;
+#ifdef USE_THREADDED_READER
+				if (backgroundReader) {
+					if (backgroundReader->joinable()) backgroundReader->join();
+					delete backgroundReader;
+				}
+#endif
+				applyCommTimeouts(false);
+				return m_lastError;
+			}
+			else {
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+		else {
+			readFail = 0;
+		}
+	}
+}
+
+// This is experiment and as such is not currently in use
+#define MAX_FLUX_SIGNAL           31
+
+// RAW Counter Values
+#define MIN_FLUX_ALLOWED          48                      // in 62.5 time 
+#define MAX_FLUX_ALLOWED          (MIN_FLUX_ALLOWED+61)   // in 62.5 time - comes out as '30'
+#define MAX_FLUX_REPEAT           (MAX_FLUX_ALLOWED-7)    // in 62.5 time - comes out as '26'
+#define FLUX_REPEAT_OFFSET        (MAX_FLUX_REPEAT-MIN_FLUX_ALLOWED)    // The amount MAX_FLUX_SIGNAL represents in clock ticks, which is 3625ns
+
+// Reads a complete rotation of the disk, and returns it using the callback function which can return FALSE to stop
+// An instance of PLL is required.  This is purely to save on re-allocations.  It is internally reset each time
+DiagnosticResponse ArduinoInterface::readFlux(PLL::BridgePLL& pll, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns, std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation) {
+	m_lastCommand = LastCommand::lcReadTrackStream;
+
+	if (!(m_version.deviceFlags1 & FLAGS_FLUX_READ) || m_isHDMode) {
+		// Fall back if not supported
+		return readRotation(*pll.rotationExtractor(), maxOutputSize, firstOutputBuffer, startBitPatterns, onRotation, false);
+	}
+
+	// Who would do this, right?
+	if (maxOutputSize < 1 || !firstOutputBuffer) {
+		m_lastError = DiagnosticResponse::drError;
+		return m_lastError;
+	}
+
+	m_lastError = runCommand(COMMAND_READTRACKSTREAM_FLUX);
+	if (m_lastError != DiagnosticResponse::drOK)
+		return m_lastError;
+	
+	// Let the class know we're doing some streaming stuff
+	m_isStreaming = true;
+	m_abortStreaming = false;
+	m_abortSignalled = false;
+
+	// Number of times we failed to read anything
+	int readFail = 0;
+
+	// Buffer to read into
+	unsigned char tempReadBuffer[2048] = { 0 };
+
+	// Sliding window for abort
+	char slidingWindow[5] = { 0,0,0,0,0 };
+	bool timeout = false;
+	bool dataState = false;
+	bool indexDetected = false;
+	unsigned char byte1 = 0;
+	applyCommTimeouts(true);
+
+	uint32_t fluxSoFar = 0;
+
+	pll.prepareExtractor(false, startBitPatterns);
+
+	for (;;) {
+
+		// More efficient to read several bytes in one go		
+		unsigned long bytesAvailable, bytesRead = 0;		
+		bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof tempReadBuffer) bytesAvailable = sizeof tempReadBuffer;
+		bytesRead = m_comPort.read(tempReadBuffer, m_abortSignalled ? 1 : bytesAvailable);
+
+		for (size_t a = 0; a < bytesRead; a++) {
+			if (m_abortSignalled) {
+				// Make space
+				for (int s = 0; s < 4; s++) slidingWindow[s] = slidingWindow[s + 1];
+				// Append the new byte
+				slidingWindow[4] = tempReadBuffer[a];
+
+				// Watch the sliding window for the pattern we need
+				if (slidingWindow[0] == 'X' && slidingWindow[1] == 'Y' && slidingWindow[2] == 'Z' && slidingWindow[3] == SPECIAL_ABORT_CHAR && slidingWindow[4] == '1') {
+					m_isStreaming = false;					
+					m_comPort.purgeBuffers();
+					m_lastError = timeout ? DiagnosticResponse::drError : DiagnosticResponse::drOK;
+					applyCommTimeouts(false);
+					return m_lastError;
+				}
+			}
+			else {
+				unsigned char byteRead = tempReadBuffer[a];
+
+				if (dataState) {
+
+					uint32_t flux[3];
+					flux[0] = byte1 & 0x1F;
+					flux[1] = (byte1 >> 5) | ((byteRead >> 2) & 0x18);
+					flux[2] = byteRead & 0x1F;
+					indexDetected |= (byteRead & 0x80) != 0;
+
+					for (int a = 0; a < 3; a++) {
+						switch (flux[a]) {
+						case MAX_FLUX_SIGNAL:
+							fluxSoFar += (uint32_t)(62.5f * FLUX_REPEAT_OFFSET);
+							break;
+						default:
+							fluxSoFar += (uint32_t)((flux[a] * 2 + MIN_FLUX_ALLOWED) * 62.5f);
+							pll.submitFlux(fluxSoFar, indexDetected);
+							indexDetected = false;
+							fluxSoFar = 0;
+						}
+					}
+
+					dataState = false;
+				}
+				else {
+					// in 'false' mode we get the flux data
+					dataState = true;
+					byte1 = byteRead;
+				}
+
+
+				// Is it ready to extract?
+				if (pll.canExtract()) {
+					unsigned int bits = 0;
+					// Go!
+					if (pll.extractRotation(firstOutputBuffer, bits, maxOutputSize)) {
+						m_diskInDrive = true;
+
+						if (!onRotation(&firstOutputBuffer, bits)) {
+							// And if the callback says so we stop.
+							abortReadStreaming();
+						}
+						// Always save this back
+						pll.getIndexSequence(startBitPatterns);
+					}
+				}
+				else {
+					if (pll.totalTimeReceived() > (m_isHDMode ? 1200000000U : 600000000U)) {
+						// No data, stop
+						abortReadStreaming();
+						timeout = true;
+					}
+				}
+			}
+		}
+		if (bytesRead < 1) {
+			readFail++;
+			if (readFail > 30) {
+				m_abortStreaming = false; // force the 'abort' command to be sent
+				abortReadStreaming();
+				m_lastError = DiagnosticResponse::drReadResponseFailed;
+				m_isStreaming = false;
+				applyCommTimeouts(false);
+				return m_lastError;
+			}
+			else {
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+		else {
+			readFail = 0;
+		}
+	}
+}
+
+// Stops the read streaming immediately and any data in the buffer will be discarded.
+bool ArduinoInterface::abortReadStreaming() {
+	if (m_version.major == 1 && m_version.minor < 8) {
+		return false;
+	}
+
+
+	if (!m_isStreaming) return true;
+
+	// Prevent two things doing this at once, and thus ending with two bytes being written
+	std::lock_guard<std::mutex> lock(m_protectAbort);
+
+	if (!m_abortStreaming) {
+		// We know what this is, but the Arduino doesn't
+		unsigned char command = SPECIAL_ABORT_CHAR;
+
+		m_abortSignalled = true;
+
+		// Send a byte.  This triggers the 'abort' on the Arduino
+		if (!deviceWrite(&command, 1)) {
+			return false;
+		}
+
+	}
+	m_abortStreaming = true;
+	return true;
+}
+
+// Read a bit from the data provided
+inline int readBit(const unsigned char* buffer, const unsigned int maxLength, int& pos, int& bit) {
+	if (pos >= (int)maxLength) {
+		bit--;
+		if (bit < 0) {
+			bit = 7;
+			pos++;
+		}
+		return bit & 1 ? 0 : 1;
+	}
+
+	int ret = buffer[pos] >> bit & 1;
+	bit--;
+	if (bit < 0) {
+		bit = 7;
+		pos++;
+	}
+
+	return ret;
+}
+
+
+
+
+// HD - a bit like the precomp as its more accurate, but no precomp
+DiagnosticResponse ArduinoInterface::writeCurrentTrackHD(const unsigned char* mfmData, const unsigned short numBytes, const bool writeFromIndexPulse) {
+	m_lastCommand = LastCommand::lcWriteTrack;
+
+	if (m_version.major == 1 && m_version.minor < 9) return DiagnosticResponse::drOldFirmware;
+
+	// First step is we need to re-encode the supplied buffer into a packed format 
+	// Each nybble looks like: wwxxyyzz, each group is a code which is the transition time
+
+	// *4 is a worse case situation, ie: if everything was a 01.  The +128 is for any extra padding
+	const unsigned int maxOutSize = numBytes * 4 + 16;
+	unsigned char* outputBuffer = (unsigned char*)malloc(maxOutSize);
+
+	if (!outputBuffer) {
+		m_lastError = DiagnosticResponse::drSendParameterFailed;
+		return m_lastError;
+	}
+
+	// Original data was written from MSB down to LSB
+	int pos = 0;
+	int bit = 7;
+	unsigned int outputPos = 0;
+	unsigned char sequence = 0xAA;  // start at 10101010
+	unsigned char* output = outputBuffer;
+
+	// Re-encode the data into our format.  
+	while (pos < numBytes) {
+		*output = 0;
+
+		for (int i = 0; i < 4; i++) {
+			int b, count = 0;
+
+			// See how many zero bits there are before we hit a 1
+			do {
+				b = readBit(mfmData, numBytes, pos, bit);
+				sequence = ((sequence << 1) & 0x7F) | b;
+				count++;
+			} while ((sequence & 0x08) == 0 && pos < numBytes + 8);
+
+			// Validate range
+			if (count < 2) count = 2;  // <2 would be a 11 sequence, not allowed
+			if (count > 4) count = 4;  // max we support 01, 001 and 0001
+			switch (i) {
+			case 1:
+			case 3:
+				*output |= (count - 1) << (i * 2);
+				break;
+			case 0:
+				*output |= (count - 1) << (2 * 2);
+				break;
+			case 2:
+				*output |= (count - 1) << (0 * 2);
+				break;
+			}
+
+		}
+
+		output++;
+		outputPos++;
+		if (outputPos >= maxOutSize - 1) {
+			// should never happen
+			free(outputBuffer);
+			m_lastError = DiagnosticResponse::drSendParameterFailed;
+			return m_lastError;
+		}
+	}
+
+	// 0 means stop
+	*output = 0;
+	outputPos++;
+
+	m_lastError = internalWriteTrack(outputBuffer, outputPos, writeFromIndexPulse, false);
+
+	free(outputBuffer);
+
+	return m_lastError;
+}
+
+#define PRECOMP_NONE 0x00
+#define PRECOMP_ERLY 0x04   
+#define PRECOMP_LATE 0x08   
+
+/* If we have a look at the previous and next three bits, assume the current is a '1', then these are the only valid combinations that could be allowed
+	I have chosen the PRECOMP rule based on trying to get the current '1' as far away as possible from the nearest '1'
+
+	   LAST		 CURRENT      NEXT			PRECOMP			Hex Value
+	0	0	0    	1	   0	0	0		Normal
+	0	0	0    	1	   0	0	1       Early			0x09
+	0	0	0    	1	   0	1	0       Early			0x0A
+	0	1	0    	1	   0	0	0       Late			0x28
+	0	1	0    	1	   0	0	1       Late			0x29
+	0	1	0    	1	   0	1	0       Normal
+	1	0	0    	1	   0	0	0       Late			0x48
+	1	0	0    	1	   0	0	1       Normal
+	1	0	0    	1	   0	1	0       Early			0x4A
+*/
+
+// The precomp version of the above. Don't use the above function directly to write precomp mode, it wont work.  Data must be passed with an 0xAA each side at least
+DiagnosticResponse ArduinoInterface::writeCurrentTrackPrecomp(const unsigned char* mfmData, const unsigned short numBytes, const bool writeFromIndexPulse, bool usePrecomp) {
+	m_lastCommand = LastCommand::lcWriteTrack;
+
+	if (m_version.major == 1 && m_version.minor < 8) return DiagnosticResponse::drOldFirmware;
+
+	if (m_isHDMode) return writeCurrentTrackHD(mfmData, numBytes, writeFromIndexPulse);
+
+	// First step is we need to re-encode the supplied buffer into a packed format with precomp pre-calculated.
+	// Each nybble looks like: xxyy
+	// where xx is: 0=no precomp, 1=-ve, 2=+ve
+	//		 yy is: 0: 4us,		1: 6us,		2: 8us,		3: 10us
+
+	// *4 is a worse case situation, ie: if everything was a 01.  The +128 is for any extra padding
+	const unsigned int maxOutSize = numBytes * 4 + 16;
+	unsigned char* outputBuffer = (unsigned char*)malloc(maxOutSize);
+
+	if (!outputBuffer) {
+		m_lastError = DiagnosticResponse::drSendParameterFailed;
+		return m_lastError;
+	}
+
+	// Original data was written from MSB downto LSB
+	int pos = 0;
+	int bit = 7;
+	unsigned int outputPos = 0;
+	unsigned char sequence = 0xAA;  // start at 10101010
+	unsigned char* output = outputBuffer;
+	int lastCount = 2;
+
+	// Re-encode the data into our format and apply precomp.  The +8 is to ensure there's some padding around the edge which will come out as 010101 etc
+	while (pos < numBytes) {
+		*output = 0;
+
+		for (int i = 0; i < 2; i++) {
+			int b, count = 0;
+
+			// See how many zero bits there are before we hit a 1
+			do {
+				b = readBit(mfmData, numBytes, pos, bit);
+				sequence = ((sequence << 1) & 0x7F) | b;
+				count++;
+			} while ((sequence & 0x08) == 0 && pos < numBytes + 8);
+
+			// Validate range
+			if (count < 2) count = 2;  // <2 would be a 11 sequence, not allowed
+			if (count > 5) count = 5;  // max we support 01, 001, 0001, 00001
+
+			// Write to stream. Based on the rules above we apply some precomp
+			int precomp = 0;
+			if (usePrecomp) {
+				const unsigned char BitSeq5 = (sequence & 0x3E);  // extract these bits 00111110 - bit 3 is the ACTUAL bit
+				// The actual idea is that the magnetic fields will repel each other, so we push them closer hoping they will land in the correct spot!
+				switch (BitSeq5) {
+				case 0x28:     // xx10100x
+					precomp = PRECOMP_ERLY;
+					break;
+				case 0x0A:     // xx00101x
+					precomp = PRECOMP_LATE;
+					break;
+				default:
+					precomp = PRECOMP_NONE;
+					break;				
+				}
+			} else precomp = PRECOMP_NONE;
+
+			*output |= ((lastCount - 2) | precomp) << (i * 4);
+			lastCount = count;
+		}
+
+		output++;
+		outputPos++;
+		if (outputPos >= maxOutSize) {
+			// should never happen
+			free(outputBuffer);
+			m_lastError = DiagnosticResponse::drSendParameterFailed;
+			return m_lastError;
+		}
+	}
+
+	m_lastError = internalWriteTrack(outputBuffer, outputPos, writeFromIndexPulse, true);
+
+	free(outputBuffer);
+
+	return m_lastError;
+}
+
+// Writes RAW data onto the current track
+DiagnosticResponse ArduinoInterface::writeCurrentTrack(const unsigned char* data, const unsigned short numBytes, const bool writeFromIndexPulse) {
+	// recomp not supported for HD currently
+	if (m_isHDMode) return writeCurrentTrackHD(data, numBytes, writeFromIndexPulse);
+
+	return internalWriteTrack(data, numBytes, writeFromIndexPulse, false);
+}
+
+// Writes RAW data onto the current track
+DiagnosticResponse ArduinoInterface::internalWriteTrack(const unsigned char* data, const unsigned short numBytes, const bool writeFromIndexPulse, bool usePrecomp) {
+	m_lastCommand = LastCommand::lcWriteTrack;
+
+	// Fall back if older firmware
+	if (m_version.major == 1 && m_version.minor < 8 && usePrecomp) {
+		return DiagnosticResponse::drOldFirmware;
+	}
+
+	m_lastError = runCommand(m_isHDMode ? COMMAND_WRITETRACK : usePrecomp ? COMMAND_WRITETRACKPRECOMP : COMMAND_WRITETRACK);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	unsigned char chr;
+	if (!deviceRead(&chr, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	// 'N' means NO Writing, aka write protected
+	if (chr == 'N') {
+		m_lastError = DiagnosticResponse::drWriteProtected;
+		return m_lastError;
+	}
+	if (chr != 'Y') {
+		m_lastError = DiagnosticResponse::drStatusError;
+		return m_lastError;
+	}
+
+	// HD doesn't need the length as the data is null terminated
+	if (!m_isHDMode) {
+		// Now we send the number of bytes we're planning on transmitting
+		unsigned char b = numBytes >> 8;
+		if (!deviceWrite(&b, 1)) {
+			m_lastError = DiagnosticResponse::drSendParameterFailed;
+			return m_lastError;
+		}
+		b = numBytes & 0xFF;
+		if (!deviceWrite(&b, 1)) {
+			m_lastError = DiagnosticResponse::drSendParameterFailed;
+			return m_lastError;
+		}
+	}
+
+	// Explain if we want index pulse sync writing (slower and not required by normal AmigaDOS disks)
+	unsigned char b = writeFromIndexPulse ? 1 : 0;
+	if (!deviceWrite(&b, 1)) {
+		m_lastError = DiagnosticResponse::drSendParameterFailed;
+		return m_lastError;
+	}
+
+	unsigned char response;
+	if (!deviceRead(&response, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (response != '!') {
+		m_lastError = DiagnosticResponse::drStatusError;
+
+		return m_lastError;
+	}
+
+	if (!deviceWrite((const void*)data, numBytes)) {
+		m_lastError = DiagnosticResponse::drSendDataFailed;
+		return m_lastError;
+	}
+
+	if (!deviceRead(&response, 1, true)) {
+		m_lastError = DiagnosticResponse::drTrackWriteResponseError;
+		return m_lastError;
+	}
+
+	// If this is a '1' then the Arduino didn't miss a single bit!
+	if (response != '1') {
+		switch (response) {
+		case 'X': m_lastError = DiagnosticResponse::drWriteTimeout;  break;
+		case 'Y': m_lastError = DiagnosticResponse::drFramingError; break;
+		case 'Z': m_lastError = DiagnosticResponse::drSerialOverrun; break;
+		default:
+			m_lastError = DiagnosticResponse::drStatusError;
+			break;
+		}
+		return m_lastError;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+
+
+
+// Removes all flux transitions from the current track
+DiagnosticResponse ArduinoInterface::eraseFluxOnTrack() {
+	m_lastCommand = LastCommand::lcEraseFlux;
+
+	if (((m_version.major == 1) && (m_version.minor < 9)) || ((m_version.minor == 9) && (m_version.buildNumber < 18))) {
+		m_lastError = DiagnosticResponse::drOldFirmware;
+		return m_lastError;
+	}
+	m_lastError = runCommand(COMMAND_ERASEFLUX);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	char result;
+	if (!deviceRead(&result, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (result == 'N') {
+		m_lastError = DiagnosticResponse::drWriteProtected;
+		return m_lastError;
+	}
+
+	// Check result
+	if (!deviceRead(&result, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (result != '1') {
+		m_lastError = DiagnosticResponse::drError;
+		return m_lastError;
+	}
+
+	return m_lastError;
+}
+
+#define FLUX_OFFSET				44     // Minimum timer value
+#define FLUX_MULTIPLIER_TIME_DB	125    // Our flux writing resolution in nanoseconds
+#define FLUX_MINIMUM_NS         (DWORD)(FLUX_OFFSET*62.5f)
+
+#define FLUX_MINIMUM_DB		   (FLUX_MINIMUM_NS / FLUX_MULTIPLIER_TIME_DB)  // Minimum time in DB time
+
+#define FLUX_NOFLUX_OFFSET      5    // Starting value when 'no flux' is written. 
+#define FLUX_MINSAFE_OFFSET     5    // This is also the safe minimum per byte so we don't overrun the serial port
+
+#define FLUX_MINIMUM_PER_8_NS   ((FLUX_MINIMUM_DB + FLUX_MINSAFE_OFFSET) * 8)		// Minimum time per 8 flux timings allowed in total in ns
+#define FLUX_TIME_10000NS_DB    ((10000/FLUX_MULTIPLIER_TIME_DB)-FLUX_MINIMUM_DB)   // DB number for 10000ns (10us)
+
+#define FLUX_REPEAT_BLANK_DB    29    // The highest single amount of delay before a flux. This DOES NOT include FLUX_MINIMUM_DB
+#define FLUX_REPEAT_COUNTER     (FLUX_MINIMUM_DB+FLUX_MINSAFE_OFFSET)
+
+#define FLUX_SPECIAL_CODE_BLANK 30    // This special code causes DB to skip 3125ns of time without a flux transition.
+#define FLUX_SPECIAL_CODE_END   31    // This special code causes the writing to finish
+#define FLUX_JITTER				2        // Amount of time taken off of the revolution time in case there's some jitter (x FLUX_MULTIPLIER_TIME)
+#define BIT(x)					(1 << x)  // Quick mapping of a bit to bitmask for that bit
+#define BITSET(byte, x)			(byte & BIT(x)) // Quick check of bit set
+#define GET_BIT_IF_SET(byte,inputBit,outputBit) (BITSET(byte, inputBit)?BIT(outputBit):0)   // If inputBit in byte is set then returns outputBit as a mask
+
+// Structure to store temporary groupings of flux before encoding
+struct Times8 {
+	union {
+		uint8_t times[8];
+		struct {
+			uint8_t a, b, c, d, e, f, g, h;
+		};
+	};
+	DWORD numUsed;
+};
+
+// Returns the TOTAL timing for a converted DB time value. If you multiply this by FLUX_MULTIPLIER_TIME_DB you get actual flux time in NS 
+inline DWORD getDBTime(uint8_t dbTime) {
+	if (dbTime <= FLUX_REPEAT_BLANK_DB) return dbTime + FLUX_MINIMUM_DB;
+	return FLUX_NOFLUX_OFFSET + FLUX_MINIMUM_DB;
+}
+
+// Checks that the block will not get written so fast that we'll have an issue with the serial port.  This works in DB timescales
+// Returns the number of extra timing values that were needed to be added to make this meet minimum requirements
+DWORD validateBlock(Times8& block) {
+	DWORD timingsAdjusted = 0;
+	DWORD totalTime = 0;
+	int numUnder = 0;
+	for (size_t i = 0; i < block.numUsed; i++) {
+		totalTime += getDBTime(block.times[i]);
+		if (block.times[i] < FLUX_MINSAFE_OFFSET) numUnder++;
+	}
+
+	// Ok, an issue, so we'll have to fix some of the slower flux times, this isn't ideal
+	if (totalTime < FLUX_MINIMUM_PER_8_NS) {
+		DWORD fixAmountNeeded = (DWORD)ceil((float)(FLUX_MINIMUM_PER_8_NS - totalTime) / (float)numUnder);
+		for (size_t i = 0; i < block.numUsed; i++)
+			if (block.times[i] < FLUX_MINSAFE_OFFSET) {
+				block.times[i] += (uint8_t)fixAmountNeeded;
+				totalTime += fixAmountNeeded;
+				timingsAdjusted++;
+				// Only do what we have to
+				if (totalTime >= FLUX_MINIMUM_PER_8_NS) break;
+			}
+
+		// Still too low?
+		if (fixAmountNeeded) {
+			for (size_t i = 0; i < block.numUsed; i++)
+				if (block.times[i] < FLUX_REPEAT_BLANK_DB) {
+					block.times[i] += (uint8_t)fixAmountNeeded;
+					totalTime += fixAmountNeeded;
+					timingsAdjusted++;
+					// Only do what we have to
+					if (totalTime >= FLUX_MINIMUM_PER_8_NS) break;
+				}
+		}
+	}
+
+	return timingsAdjusted;
+}
+
+// Append a fluxTime to a block. fluxTime is in DB time. timingsExtra is a running count of extra data that was needed to make blocks valid
+void appendToBlock(DWORD fluxTime, DWORD& timingsExtra, Times8& currentBlock, std::vector<Times8>& output) {
+	DWORD timingsAdjusted = 0;
+	// Add extra blocks if this is longer than the 'don't write' repeat interval
+	while (fluxTime > FLUX_REPEAT_BLANK_DB) {
+		// Re-claim some time
+		if (timingsExtra && fluxTime > FLUX_REPEAT_BLANK_DB + 1) {
+			fluxTime--;
+			timingsExtra--;
+		}
+
+		currentBlock.times[currentBlock.numUsed++] = FLUX_SPECIAL_CODE_BLANK;
+		if (currentBlock.numUsed >= 8) {
+			timingsAdjusted += validateBlock(currentBlock);
+			output.push_back(currentBlock);
+			currentBlock.numUsed = 0;
+		}
+		fluxTime -= FLUX_REPEAT_COUNTER;
+	}
+
+	// Re-claim some time
+	if (timingsExtra && fluxTime > FLUX_MINSAFE_OFFSET) {
+		fluxTime--;
+		timingsExtra--;
+	}
+
+	// Don't forget the actual data
+	currentBlock.times[currentBlock.numUsed++] = (uint8_t)fluxTime;
+	if (currentBlock.numUsed >= 8) {
+		timingsAdjusted += validateBlock(currentBlock);
+		output.push_back(currentBlock);
+		currentBlock.numUsed = 0;
+	}
+}
+
+// Writes the flux timings (in nanoseconds) to the drive.  The Drive RPM is needed to compensate and correct the flux times.
+DiagnosticResponse ArduinoInterface::writeFlux(const std::vector<DWORD>& fluxTimes, const DWORD offsetFromIndex, const float driveRPM, bool compensateFluxTimings, bool terminateAtIndex) {
+	m_lastCommand = LastCommand::lcWriteFlux;
+
+	if ((m_version.major == 1) && ((m_version.minor < 9) || ((m_version.minor == 9) && (m_version.buildNumber < 22)))) {
+		m_lastError = DiagnosticResponse::drOldFirmware;
+		return m_lastError;
+	}
+	if (m_isHDMode) {
+		m_lastError = DiagnosticResponse::drMediaTypeMismatch;
+		return m_lastError;
+	}
+
+	// Assume this is an unformatted track
+	if (fluxTimes.empty()) {
+		m_lastError = eraseFluxOnTrack();
+		return m_lastError;
+	}
+
+	// Step 1: calculate the total flux length and convert into DB time values
+	DWORD totalFluxTime = 0;
+	bool existsOver10000 = false;
+	bool existsUnderMinimum = false;
+	std::vector<DWORD> dbTime;
+	int hdStyleCount = 0;
+	int ddStyleCount = 0;
+
+	DWORD fluxTimeCounters[7] = { 0,0,0,0,0,0,0 };
+	DWORD totalCounter = 0;
+
+	for (DWORD t : fluxTimes) {
+		if (t < 1000) continue;  // skip really fast ones
+		if (t > 4500) ddStyleCount++;
+		if (t < 3500) hdStyleCount++;
+		DWORD tmp = (t + 1000) / 2000;
+		if (t < FLUX_MINIMUM_NS)
+			t = FLUX_MINIMUM_NS;
+		t = (t - FLUX_MINIMUM_NS + FLUX_MULTIPLIER_TIME_DB / 2) / FLUX_MULTIPLIER_TIME_DB;
+		dbTime.push_back(t);
+		totalFluxTime += t + FLUX_MINIMUM_DB;
+		if (t > FLUX_TIME_10000NS_DB) existsOver10000 = true;
+		if (t < FLUX_MINSAFE_OFFSET) existsUnderMinimum = true;
+		if (tmp < 7) {
+			fluxTimeCounters[tmp]++;  // keep a counter of which types of flux are in the image
+			totalCounter++;
+		}
+	}
+
+	// We cant write this.
+	if (hdStyleCount > ddStyleCount) {
+		bool unformatted = true;
+
+		// This picks up 'unformatted track' simulation output from HxC and replaces it with a proper unformatted track, if that's what it is.
+		int percentageAllowed = 50;
+		for (size_t i = 1; i < 6; i++) {
+			int percentageOfFlux = fluxTimeCounters[i] * 100 / totalCounter;
+			if ((int)abs(percentageOfFlux - percentageAllowed) <= (int)(percentageAllowed + (7 - i))) {
+				// Within the allowed window of 'randomness' for unformatted
+				percentageAllowed /= 2;
+				continue;
+			}
+			else {
+				// Out of range, probably not an unformatted track
+				unformatted = false;
+				break;
+			}
+		}
+
+		// This is an unformatted track.  We can write that easily
+		if (unformatted) {
+			m_lastError = eraseFluxOnTrack();
+			return m_lastError;
+		}
+
+		m_lastError = DiagnosticResponse::drMediaTypeMismatch;
+		return m_lastError;
+	}
+
+	// Step 2: calculate the time taken for a full revolution in nanoseconds
+	const uint64_t rpmNanoSeconds = (uint64_t)(60000000000.0f / driveRPM);
+	// Convert it to DB time
+	const uint64_t rpmInDBTime = rpmNanoSeconds / FLUX_MULTIPLIER_TIME_DB - FLUX_JITTER;
+
+	// Step 3: Make the data fit the revolution
+	if (compensateFluxTimings) {
+		if (totalFluxTime < rpmInDBTime - 100) {
+			// No, not really. First, lets increase all the really slow pulses under FLUX_MINSAFE_OFFSET
+			while (totalFluxTime < rpmInDBTime - 100) {
+				bool madeChanges = false;
+				for (DWORD& t : dbTime) {
+					if (t < FLUX_MINSAFE_OFFSET) {
+						t++;
+						totalFluxTime++;
+						madeChanges = true;
+
+						if (t < FLUX_MINSAFE_OFFSET) existsUnderMinimum = true;
+						if (totalFluxTime >= rpmInDBTime - 100) break;
+					}
+				}
+				if (!existsUnderMinimum) break;
+				if (!madeChanges) break;
+			}			
+		}
+		else {
+			if (totalFluxTime > rpmInDBTime - 10) {
+				// Do we have too much data?  First, lets shorten some of the really long flux transitions, ie: over 10000ns
+				if (existsOver10000) {
+					while (totalFluxTime >= rpmInDBTime) {
+						existsOver10000 = false;
+						for (DWORD& t : dbTime) {
+							if (t > FLUX_TIME_10000NS_DB) {
+								t--;
+								totalFluxTime--;
+
+								if (t > FLUX_TIME_10000NS_DB) existsOver10000 = true;
+								if (totalFluxTime < rpmInDBTime - 10) break;
+							}
+						}
+						if (!existsOver10000) break;
+					}
+				}
+
+				// Are we still over?
+				if (totalFluxTime >= rpmInDBTime) {
+					// Drop every sample over FLUX_MINSAFE_OFFSET down by one
+					for (DWORD& t : dbTime) {
+						if (t > FLUX_MINSAFE_OFFSET) {
+							t--;
+							totalFluxTime--;
+							if (totalFluxTime < rpmInDBTime) break;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// We now should have data that approx matches a revolution of disk data. Lets convert it into DB packets.
+	// Step 4: Group into blocks of 8 flux times that do not exceed the rules of that block
+	std::vector<Times8> fluxTimesGrouped;
+	Times8 block;
+	block.numUsed = 0;
+	DWORD timingsOver = 0;
+	uint8_t firstFlux;
+
+	// Extract FirstFlux.  This is a special one just to kick-start the process
+	if (dbTime[0] > FLUX_REPEAT_BLANK_DB) {
+		dbTime[0] -= FLUX_REPEAT_COUNTER;
+		firstFlux = FLUX_SPECIAL_CODE_BLANK;
+	}
+	else {
+		firstFlux = (uint8_t)dbTime[0];
+		dbTime.erase(dbTime.begin());
+	}
+
+	for (const DWORD& t : dbTime) appendToBlock(t, timingsOver, block, fluxTimesGrouped);
+	// Don't forget the final block
+	if (block.numUsed) {
+		// Add the special break codes
+		for (int i = block.numUsed; i < 8; i++) block.times[i] = FLUX_SPECIAL_CODE_END;
+		timingsOver += validateBlock(block);
+		fluxTimesGrouped.push_back(block);
+	}
+	else {
+		// Add a block with the BREAK code in it
+		block.numUsed = 8;
+		for (int i = 0; i < 8; i++) block.times[i] = FLUX_SPECIAL_CODE_END;
+		fluxTimesGrouped.push_back(block);
+	}
+
+	// Hmm, this could be an issue
+	if (timingsOver >= FLUX_JITTER && compensateFluxTimings) {
+		// We'll look at the blocks of 8, and see if there's any we can shorten.  Its rare though
+		for (Times8& block : fluxTimesGrouped) {
+			DWORD total = 0;
+			// See how long this block is
+			for (size_t a = 0; a < block.numUsed; a++) total += getDBTime(block.times[a]);
+			// Does it have some "space"
+			if (total > FLUX_MINIMUM_PER_8_NS) {
+				// Re-claim from this
+				for (size_t a = 0; a < block.numUsed; a++) {
+					if (block.times[a] && block.times[a] <= FLUX_REPEAT_BLANK_DB) {
+						total--;
+						block.times[a]--;
+						timingsOver--;
+						if (!total) break;
+						if (!timingsOver) break;
+					}
+				}
+			}
+			// Stop if we succeeded
+			if (!timingsOver) break;
+		}
+	}
+
+	// Now convert the blocks of 8, into packed data of 5 bytes for DB according to the following schema:
+	//    Bit :  7   6   5   4   3   2   1   0  
+	// Byte 1 : D4  C4  B4  A4  A3  A2  A1  A0
+	// Byte 2 : C3  C2  C1  C0  B3  B2  B1  B0
+	// Byte 3 : E3  E2  E1  E0  D3  D2  D1  D0
+	// Byte 4 : E4  H4  G4  F4  F3  F2  F1  F0
+	// Byte 5 : H3  H2  H1  H0  G3  G2  G1  G0
+	std::vector<uint8_t> flux;
+	flux.push_back(firstFlux);   // special value to get it started
+
+	for (const Times8& block : fluxTimesGrouped) {
+		flux.push_back((block.a & 0x1F) | GET_BIT_IF_SET(block.b, 4, 5) | GET_BIT_IF_SET(block.c, 4, 6) | GET_BIT_IF_SET(block.d, 4, 7));
+		flux.push_back((block.b & 0x0F) | ((block.c & 0x0F) << 4));
+		flux.push_back((block.d & 0x0F) | ((block.e & 0x0F) << 4));
+		flux.push_back((block.f & 0x1F) | GET_BIT_IF_SET(block.g, 4, 5) | GET_BIT_IF_SET(block.h, 4, 6) | GET_BIT_IF_SET(block.e, 4, 7));
+		flux.push_back((block.g & 0x0F) | ((block.h & 0x0F) << 4));
+	}
+
+	m_lastError = runCommand(COMMAND_WRITEFLUX);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	unsigned char chr;
+	if (!deviceRead(&chr, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	// 'N' means NO Writing, aka write protected
+	if (chr == 'N') {
+		m_lastError = DiagnosticResponse::drWriteProtected;
+		return m_lastError;
+	}
+	if (chr != 'Y') {
+		m_lastError = DiagnosticResponse::drStatusError;
+		return m_lastError;
+	}
+
+	// Send the offset from index in ARDUINO ticks
+	uint32_t t = (uint32_t)ceil((float)offsetFromIndex / (driveRPM / 300.0f) / 62.5f);
+	// Send the three bytes containing this.
+	unsigned char amount[4];
+	amount[0] = t & 0xFF;
+	amount[1] = t >> 8 & 0xFF;
+	amount[2] = t >> 16 & 0xFF;
+	amount[3] = terminateAtIndex ? 1 : 0;   // flags
+	if (!deviceWrite((const void*)amount, 4)) {
+		m_lastError = DiagnosticResponse::drSendDataFailed;
+		return m_lastError;
+	}
+
+	// Send the actual data
+	if (!deviceWrite((const void*)flux.data(), (unsigned int)flux.size())) {
+		m_lastError = DiagnosticResponse::drSendDataFailed;
+		return m_lastError;
+	}
+
+	unsigned char response;
+	if (!deviceRead(&response, 1, true)) {
+		m_lastError = DiagnosticResponse::drTrackWriteResponseError;
+		return m_lastError;
+	}
+
+	// If this is a '1' then the Arduino didn't miss a single bit!
+	if ((response != '1') && (response != 'I')) {
+		switch (response) {
+		case 'X': m_lastError = DiagnosticResponse::drWriteTimeout;  break;
+		case 'Y': m_lastError = DiagnosticResponse::drFramingError; break;
+		case 'Z': m_lastError = DiagnosticResponse::drSerialOverrun; break;
+		default:
+			m_lastError = DiagnosticResponse::drStatusError;
+			break;
+		}
+		return m_lastError;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+
+// Returns a list of ports this could be available on
+void ArduinoInterface::enumeratePorts(std::vector<std::wstring>& portList) {
+	portList.clear();
+	std::vector<SerialIO::SerialPortInformation> prts;
+
+	SerialIO prt;
+	prt.enumSerialPorts(prts);
+
+	for (const SerialIO::SerialPortInformation& port : prts) {
+		// Skip CH340 boards
+		if ((port.vid == 0x1a86) && (port.pid == 0x7523)) continue;
+
+		// Skip any Greaseweazle boards 
+		if ((port.vid == 0x1209) && (port.pid == 0x4d69)) continue;
+		if ((port.vid == 0x1209) && (port.pid == 0x0001)) continue;
+		if (port.productName == L"Greaseweazle") continue;
+		if (port.instanceID.find(L"\\GW") != std::wstring::npos) continue;
+
+		// Skip Supercard pro
+		if (port.portName.find(L"SCP-JIM") != std::wstring::npos) continue;
+		if (port.portName.find(L"Supercard Pro") != std::wstring::npos) continue;
+
+		portList.push_back(port.portName);
+	}
+}
+
+// Reset reason information
+DiagnosticResponse ArduinoInterface::getResetReason(bool& WD, bool& BOD, bool& ExtReset, bool& PowerOn) {
+	if ((m_version.major > 1) || ((m_version.major == 1) && (m_version.minor > 9)) || ((m_version.major == 1) && (m_version.minor == 9) && (m_version.buildNumber >= 26))) {
+		// TODO
+		return DiagnosticResponse::drOldFirmware;
+	}
+	return DiagnosticResponse::drOldFirmware;
+}
+DiagnosticResponse ArduinoInterface::clearResetReason() {
+	if ((m_version.major > 1) || ((m_version.major == 1) && (m_version.minor > 9)) || ((m_version.major == 1) && (m_version.minor == 9) && (m_version.buildNumber >= 26))) {
+		// TODO
+		return DiagnosticResponse::drOldFirmware;
+	}
+	return DiagnosticResponse::drOldFirmware;
+}
+
+// Run a command that returns 1 or 0 for its response
+DiagnosticResponse ArduinoInterface::runCommand(const char command, const char parameter, char* actualResponse) {
+	unsigned char response;
+
+	// Pause for I/O
+	std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+	// Send the command
+	if (!deviceWrite(&command, 1)) {
+		m_lastError = DiagnosticResponse::drSendFailed;
+		return m_lastError;
+	}
+
+	// Only send the parameter if its not NULL
+	if (parameter != '\0')
+		if (!deviceWrite(&parameter, 1)) {
+			m_lastError = DiagnosticResponse::drSendParameterFailed;
+			return m_lastError;
+		}
+
+	// And read the response
+	if (!deviceRead(&response, 1, true)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (actualResponse) *actualResponse = response;
+
+	// Evaluate the response
+	switch (response) {
+	case '1': m_lastError = DiagnosticResponse::drOK;
+		break;
+	case '0': m_lastError = DiagnosticResponse::drError;
+		break;
+	default:  m_lastError = DiagnosticResponse::drStatusError;
+		break;
+	}
+	return m_lastError;
+}
+
+// Read a desired number of bytes into the target pointer
+bool ArduinoInterface::deviceRead(void* target, const unsigned int numBytes, const bool failIfNotAllRead) {
+	if (!m_comPort.isPortOpen()) return false;
+
+	unsigned long read = m_comPort.read(target, numBytes);
+
+	if (read < numBytes) {
+		if (failIfNotAllRead) return false;
+
+		// Clear the unread bytes
+		char* target2 = (char*)target + read;
+		memset(target2, 0, numBytes - read);
+	}
+
+	return true;
+}
+
+// Writes a desired number of bytes from the the pointer
+bool ArduinoInterface::deviceWrite(const void* source, const unsigned int numBytes) {
+	return m_comPort.write(source, numBytes) == numBytes;
+}
+
+// Read a byte from the user eeprom area
+DiagnosticResponse ArduinoInterface::eepromRead(unsigned char position, unsigned char& value) {
+	m_lastCommand = LastCommand::lcEEPROMRead;
+
+	// Fall back if older firmware
+	if ((m_version.major == 1) && (m_version.minor < 9)) {
+		return DiagnosticResponse::drOldFirmware;
+	}
+
+	m_lastError = runCommand(COMMAND_EEPROM_READ);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	if (!deviceWrite(&position, 1)) {
+		m_lastError = DiagnosticResponse::drWriteTimeout;
+		return m_lastError;
+	}
+
+	if (!deviceRead(&value, 1)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+// Write a byte to the user eeprom area
+DiagnosticResponse ArduinoInterface::eepromWrite(unsigned char position, unsigned char value) {
+	m_lastCommand = LastCommand::lcEEPROMWrite;
+
+	// Fall back if older firmware
+	if ((m_version.major == 1) && (m_version.minor < 9)) {
+		return DiagnosticResponse::drOldFirmware;
+	}
+
+	m_lastError = runCommand(COMMAND_EEPROM_WRITE);
+	if (m_lastError != DiagnosticResponse::drOK) return m_lastError;
+
+	if (!deviceWrite(&position, 1)) {
+		m_lastError = DiagnosticResponse::drWriteTimeout;
+		return m_lastError;
+	}
+
+	if (!deviceWrite(&value, 1)) {
+		m_lastError = DiagnosticResponse::drWriteTimeout;
+		return m_lastError;
+	}
+
+	if (!deviceRead(&value, 1)) {
+		m_lastError = DiagnosticResponse::drReadResponseFailed;
+		return m_lastError;
+	}
+
+	if (value != '1') {
+		m_lastError = DiagnosticResponse::drError;
+		return m_lastError;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_IsAdvancedController(bool& enabled) {
+	unsigned char ret[4];
+
+	for (int a = 0; a < 4; a++) {
+		DiagnosticResponse r = eepromRead(a, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	enabled = (ret[0] == 0x52) && (ret[1] == 0x6F) && (ret[2] == 0x62) && (ret[3] == 0x53);
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_IsDrawbridgePlusMode(bool& enabled) {
+	unsigned char ret[2];
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromRead(a + 4, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	enabled = (ret[0] == 0x2B) && (ret[1] == 0xB2);
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+
+DiagnosticResponse ArduinoInterface::eeprom_IsDensityDetectDisabled(bool& enabled) {
+	unsigned char ret[2];
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromRead(a + 6, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	enabled = (ret[0] == 0x44) && (ret[1] == 0x53);
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_IsSlowSeekMode(bool& enabled) {
+	unsigned char ret[2];
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromRead(a + 8, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	enabled = (ret[0] == 0x53) && (ret[1] == 0x77);
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_IsIndexAlignMode(bool& enabled) {
+	unsigned char ret[2];
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromRead(a + 10, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	enabled = (ret[0] == 0x69) && (ret[1] == 0x61);
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_SetAdvancedController(bool enabled) {
+	unsigned char ret[4];
+
+	if (enabled) {
+		ret[0] = 0x52;
+		ret[1] = 0x6F;
+		ret[2] = 0x62;
+		ret[3] = 0x53;
+	}
+	else memset(ret, 0, 4);
+
+	for (int a = 0; a < 4; a++) {
+		DiagnosticResponse r = eepromWrite(a, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_SetDrawbridgePlusMode(bool enabled) {
+	unsigned char ret[2];
+
+	if (enabled) {
+		ret[0] = 0x2B;
+		ret[1] = 0xB2;
+	}
+	else memset(ret, 0, 2);
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromWrite(a + 4, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_SetDensityDetectDisabled(bool enabled) {
+	unsigned char ret[2];
+
+	if (enabled) {
+		ret[0] = 0x44;
+		ret[1] = 0x53;
+	}
+	else memset(ret, 0, 2);
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromWrite(a + 6, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+DiagnosticResponse ArduinoInterface::eeprom_SetSlowSeekMode(bool enabled) {
+	unsigned char ret[2];
+
+	if (enabled) {
+		ret[0] = 0x53;
+		ret[1] = 0x77;
+	}
+	else memset(ret, 0, 2);
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromWrite(a + 8, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+
+DiagnosticResponse ArduinoInterface::eeprom_SetIndexAlignMode(bool enabled) {
+	unsigned char ret[2];
+
+	if (enabled) {
+		ret[0] = 0x69;
+		ret[1] = 0x61;
+	}
+	else memset(ret, 0, 2);
+
+	for (int a = 0; a < 2; a++) {
+		DiagnosticResponse r = eepromWrite(a + 10, ret[a]);
+		if (r != DiagnosticResponse::drOK) return r;
+	}
+
+	m_lastError = DiagnosticResponse::drOK;
+	return m_lastError;
+}
+
+

--- a/vendor/floppybridge/src/ArduinoInterface.h
+++ b/vendor/floppybridge/src/ArduinoInterface.h
@@ -1,0 +1,346 @@
+#ifndef ARDUINO_FLOPPY_READER_WRITER_INTERFACE
+#define ARDUINO_FLOPPY_READER_WRITER_INTERFACE
+/* ArduinoFloppyReaderWriter aka DrawBridge
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Class to manage the communication between the computer and the Arduino    V2.7     //
+////////////////////////////////////////////////////////////////////////////////////////
+//
+// Purpose:
+// The class handles the command interface to the arduino.  It doesn't do any decoding
+// Just open ports, switch motors on and off, seek to tracks etc.
+//
+//
+//
+
+#include <string>
+#include <functional>
+#include <vector>
+#include <mutex>
+
+#include "RotationExtractor.h"
+#include "pll.h"
+#include "SerialIO.h"
+
+// Paula on the Amiga used to find the SYNC then read 1900 WORDS. (12868 bytes)
+// As the PC is doing the SYNC we need to read more than this to allow a further overlap
+// This number must match what the sketch in the Arduino is set to. 
+#define RAW_TRACKDATA_LENGTH_DD (0x1900*2+0x440)
+#define RAW_TRACKDATA_LENGTH_HD (2*RAW_TRACKDATA_LENGTH_DD)
+// With the disk spinning at 300rpm, and data rate of 500kbps, for a full revolution we should receive 12500 bytes of data (12.5k)
+// The above buffer assumes a full Paula data capture plus the size of a sector.
+
+
+#define FLAGS_HIGH_PRECISION_SUPPORT   (1 << 0)
+#define FLAGS_DISKCHANGE_SUPPORT	   (1 << 1)
+#define FLAGS_DRAWBRIDGE_PLUSMODE	   (1 << 2)
+#define FLAGS_DENSITYDETECT_ENABLED    (1 << 3)
+#define FLAGS_SLOWSEEKING_MODE		   (1 << 4)
+#define FLAGS_INDEX_ALIGN_MODE		   (1 << 5)
+#define FLAGS_FLUX_READ				   (1 << 6)
+#define FLAGS_FIRMWARE_BETA            (1 << 7)
+
+namespace ArduinoFloppyReader {
+
+	// Array to hold data from a floppy disk read
+	typedef unsigned char RawTrackDataDD[RAW_TRACKDATA_LENGTH_DD];
+	typedef unsigned char RawTrackDataHD[RAW_TRACKDATA_LENGTH_HD];
+
+	// Sketch firmware version
+	struct FirmwareVersion {
+		unsigned char major, minor;
+		bool fullControlMod;
+
+		// Extra in V1.9
+		unsigned char deviceFlags1;
+		unsigned char deviceFlags2;
+		unsigned char buildNumber;
+	};
+
+	// Represent which side of the disk we're looking at
+	enum class DiskSurface {
+		dsUpper,            // The upper side of the disk
+		dsLower             // The lower side of the disk
+	};
+
+	// Speed at which the head will seek to a track
+	enum class TrackSearchSpeed {
+		tssSlow = 0,
+		tssNormal = 1,
+		tssFast = 2,
+		tssVeryFast = 3
+	};
+
+	// Diagnostic responses from the interface
+	enum class DiagnosticResponse {
+		drOK,
+
+		// Responses from openPort
+		drPortInUse,
+		drPortNotFound,
+		drPortError,
+		drAccessDenied,
+		drComportConfigError,
+		drBaudRateNotSupported,
+		drErrorReadingVersion,
+		drErrorMalformedVersion,
+		drOldFirmware,
+
+		// Responses from commands
+		drSendFailed,
+		drSendParameterFailed,
+		drReadResponseFailed,
+		drWriteTimeout,
+		drSerialOverrun,
+		drFramingError,
+		drError,
+
+		// Response from selectTrack
+		drTrackRangeError,
+		drSelectTrackError,
+		drWriteProtected,
+		drStatusError,
+		drSendDataFailed,
+		drTrackWriteResponseError,
+
+		// Returned if there is no disk in the drive
+		drNoDiskInDrive,
+
+		drDiagnosticNotAvailable,
+		drUSBSerialBad,
+		drCTSFailure,
+		drRewindFailure,
+
+		drMediaTypeMismatch
+	};
+
+	enum class LastCommand {
+		lcOpenPort,
+		lcGetVersion,
+		lcEnableWrite,
+		lcRewind,
+		lcDisableMotor,
+		lcEnableMotor,
+		lcGotoTrack,
+		lcSelectSurface,
+		lcReadTrack,
+		lcWriteTrack,
+		lcRunDiagnostics,
+		lcSwitchDiskMode,
+		lcReadTrackStream,
+		lcCheckDiskInDrive,
+		lcCheckDiskWriteProtected,
+		lcEraseTrack,
+		lcNoClickCheck,
+		lcCheckDensity,
+		lcMeasureRPM,
+		lcEEPROMRead,
+		lcEEPROMWrite,
+		lcWriteFlux,
+		lcEraseFlux
+	};
+
+	class ArduinoInterface {
+	private:
+		// Windows handle to the serial port device
+		SerialIO		m_comPort;
+		FirmwareVersion m_version;
+		bool			m_inWriteMode;
+		LastCommand		m_lastCommand;
+		DiagnosticResponse m_lastError;
+		bool			m_abortStreaming;
+		bool			m_isWriteProtected;
+		bool			m_diskInDrive;
+		bool			m_abortSignalled;
+		bool			m_isStreaming;
+		bool			m_isHDMode;
+		std::mutex		m_protectAbort;
+		void*			m_tempBuffer = nullptr;
+
+		// Read a desired number of bytes into the target pointer
+		bool deviceRead(void* target, const unsigned int numBytes, const bool failIfNotAllRead = false);
+		// Writes a desired number of bytes from the the pointer
+		bool deviceWrite(const void* source, const unsigned int numBytes);
+
+		// Version of the above where the command has a parameter on the end (as long as its not char 0)
+		DiagnosticResponse runCommand(const char command, const char parameter = '\0', char* actualResponse = nullptr);
+
+		// Apply and change the timeouts on the com port
+		void applyCommTimeouts(bool shortTimeouts);
+
+		// Attempts to write a sector back to the disk.  This must be pre-formatted and MFM encoded correctly depending on usePrecomp
+		DiagnosticResponse internalWriteTrack(const unsigned char* data, const unsigned short numBytes, const bool writeFromIndexPulse, bool usePrecomp);
+
+		// Attempts to verify if the reader/writer is running on this port
+		static DiagnosticResponse internalOpenPort(const std::wstring& portName, bool enableCTSflowcontrol, bool triggerReset, std::string& versionString, SerialIO& port);
+
+		// Attempt to sync and get version
+		static DiagnosticResponse attemptToSync(std::string& versionString, SerialIO& port);
+
+		// HD - a bit like the precomp as its more accurate, but no precomp
+		DiagnosticResponse writeCurrentTrackHD(const unsigned char* mfmData, const unsigned short numBytes, const bool writeFromIndexPulse);
+
+		// Read from the EEPROM
+		DiagnosticResponse eepromRead(unsigned char position, unsigned char& value);
+
+		// Write to the eeprom
+		DiagnosticResponse eepromWrite(unsigned char position, unsigned char value);
+	public:
+		// Constructor for this class
+		ArduinoInterface();
+
+		// Free me
+		~ArduinoInterface();
+
+		const LastCommand getLastFailedCommand() const { return m_lastCommand; }
+		const DiagnosticResponse getLastError() const { return m_lastError; }
+
+		// Uses the above fields to constructor a suitable error message, hopefully useful in diagnosing the issue
+		const std::string getLastErrorStr() const;
+
+		const bool isOpen() const { return m_comPort.isPortOpen(); }
+		const bool isInWriteMode() const { return m_inWriteMode; }
+
+		// Returns a list of ports this could be available on
+		static void enumeratePorts(std::vector<std::wstring>& portList);
+
+		// Returns TRUE if there is a disk in the drive.   This is ONLY updated by checkForDisk or checkIfDiskIsWriteProtected
+		bool isDiskInDrive() const { return m_diskInDrive; }
+
+		// Get the current firmware version.  Only valid if openPort is successful
+		const FirmwareVersion getFirwareVersion() const { return m_version; }
+
+		// Turns on and off the reading interface.  For the new modded firmware this also allows writing as such the function below is no longer needed
+		DiagnosticResponse enableReading(const bool enable, const bool reset = true, const bool dontWait = false);
+
+		// Turns on and off the reading interface. If irError is returned the disk is write protected.  This is no longer needed if you are using the new modded firmware
+		DiagnosticResponse  enableWriting(const bool enable, const bool reset = true);
+
+		// Attempts to open the reader running on the COM port number provided.  Port MUST support 2M baud
+		DiagnosticResponse openPort(const std::wstring& portName, bool enableCTSflowcontrol = true);
+
+		// Attempts to verify if the reader/writer is running on this port
+		static bool isPortCorrect(const std::wstring& portName);
+
+		// Checks if the disk is write protected.  If forceCheck=false then the last cached version is returned.  This is also updated by checkForDisk() as well as this function
+		DiagnosticResponse checkIfDiskIsWriteProtected(bool forceCheck);
+
+		// Seek to track 0
+		DiagnosticResponse findTrack0();
+
+		// Check to see if a disk is inserted in the drive. If forceCheck then the last cached version is returned, which is also updated by diskStepOnce.
+		DiagnosticResponse checkForDisk(bool forceCheck);
+
+		// Reads a complete rotation of the disk, and returns it using the callback function which can return FALSE to stop
+		// An instance of BridgePLL is required.  
+		DiagnosticResponse readRotation(MFMExtractionTarget& extractor, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns, std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation, bool useHalfPLL);
+		// Same as the above, but this uses the newer much more accurate flux read
+		DiagnosticResponse readFlux(PLL::BridgePLL& pll, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns, std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation);
+
+		// Reset reason information
+		DiagnosticResponse getResetReason(bool& WD, bool& BOD, bool& ExtReset, bool& PowerOn);
+		DiagnosticResponse clearResetReason();
+
+		// Stops the read streaming immediately and any data in the buffer will be discarded. The above function will exit when the Arduino has also stopped streaming data
+		bool abortReadStreaming();
+
+		// Returns TRUE if the disk si currently streaming data
+		bool isStreaming() { return m_isStreaming; }
+
+		// Check if an index pulse can be detected from the drive
+		DiagnosticResponse testIndexPulse();
+
+		// Check if data can be detected from the drive
+		DiagnosticResponse testDataPulse();
+
+		// Query the RPM of the drive
+		DiagnosticResponse measureDriveRPM(float& rpm);
+
+		// Checks to see what the density of the current disk is most likely to be, Ideally this should be done while at track 0, probably lower head
+		DiagnosticResponse checkDiskCapacity(bool& isHD);
+
+		// Check and switch to HD disk
+		DiagnosticResponse setDiskCapacity(bool switchToHD_Disk);
+
+		// Guess if the drive is actually a PLUS Mode drive
+		DiagnosticResponse guessPlusMode(bool& isProbablyPlus);
+
+		// Select the track, this makes the motor seek to this position
+		DiagnosticResponse  selectTrack(const unsigned char trackIndex, const TrackSearchSpeed searchSpeed = TrackSearchSpeed::tssNormal, bool ignoreDiskInsertCheck = false);
+
+		// If the drive is on track 0, this does a test seek to -1 if supported
+		DiagnosticResponse performNoClickSeek();
+
+		// Choose which surface of the disk to read from
+		DiagnosticResponse  selectSurface(const DiskSurface side);
+
+		// Reads just enough data to fulfill most extractions needed, but doesnt care about rotation position or index - pll should have the LinearExtractor configured
+		DiagnosticResponse readData(PLL::BridgePLL& pll);
+
+		// Read RAW data from the current track and surface selected - this works properly with the HD and DD options
+		// dataLength must be either RAW_TRACKDATA_LENGTH or RAW_TRACKDATA_LENGTH_HD.  If you mismatch the type then the function will return an error
+		DiagnosticResponse  readCurrentTrack(void* trackData, const int dataLength, const bool readFromIndexPulse);
+
+		// Read RAW data from the current track and surface selected in DD
+		DiagnosticResponse  readCurrentTrack(RawTrackDataDD& trackData, const bool readFromIndexPulse);
+
+		// Attempts to write a track back to the disk.  This must be pre-formatted and MFM encoded correctly
+		DiagnosticResponse  writeCurrentTrack(const unsigned char* data, const unsigned short numBytes, const bool writeFromIndexPulse);
+		// The precomp version of the above. 
+		DiagnosticResponse  writeCurrentTrackPrecomp(const unsigned char* mfmData, const unsigned short numBytes, const bool writeFromIndexPulse, bool usePrecomp);
+
+		// Writes the flux timings (in nanoseconds) to the drive.  The Drive RPM is needed tp compensate and correct the flux times (if enabled).
+		DiagnosticResponse writeFlux(const std::vector<DWORD>& fluxTimes, const DWORD offsetFromIndex, const float driveRPM, bool compensateFluxTimings, bool terminateAtIndex = false);
+
+		// Removes all flux transitions from the current track
+		DiagnosticResponse eraseFluxOnTrack();
+
+		// Erases the current track by writing 0xAA to it
+		DiagnosticResponse eraseCurrentTrack();
+
+		// Check CTS status - you must open with CTS disabled for this to work
+		DiagnosticResponse testCTS();
+
+		// Check if the USB to Serial device can keep up properly
+		DiagnosticResponse testTransferSpeed();
+
+		// Returns true if the track actually contains some data, else its considered blank or unformatted
+		bool trackContainsData(const RawTrackDataDD& trackData) const;
+
+		// Closes the port down
+		void closePort();
+
+		// Check the EEPROM setting for advanced controller
+		DiagnosticResponse eeprom_IsAdvancedController(bool& enabled);
+		DiagnosticResponse eeprom_IsDrawbridgePlusMode(bool& enabled);
+		DiagnosticResponse eeprom_IsDensityDetectDisabled(bool& enabled);
+		DiagnosticResponse eeprom_IsSlowSeekMode(bool& enabled);
+		DiagnosticResponse eeprom_IsIndexAlignMode(bool& enabled);
+
+		// Check the EEPROM setting for advanced controller
+		DiagnosticResponse eeprom_SetAdvancedController(bool enabled);
+		DiagnosticResponse eeprom_SetDrawbridgePlusMode(bool enabled);
+		DiagnosticResponse eeprom_SetDensityDetectDisabled(bool enabled);
+		DiagnosticResponse eeprom_SetSlowSeekMode(bool enabled);
+		DiagnosticResponse eeprom_SetIndexAlignMode(bool enabled);
+	};
+};
+
+
+#endif

--- a/vendor/floppybridge/src/CommonBridgeTemplate.cpp
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.cpp
@@ -1,0 +1,1709 @@
+/* CommonBridgeTemplate for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// As both the implementations (as far as the "bridge" is concerned are almost identical
+// I have merged the common parts into this class so only the differences are in the 
+// respective ones.  This is a good template for future devices to base off of
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+
+
+#include <thread>
+#include <functional>
+#include <queue>
+#include <chrono>
+#include <cstring>
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "RotationExtractor.h"
+#include "SerialIO.h"
+
+#ifdef HIGH_RESOLUTION_MODE
+HIGH_RESOLUTION_MODE is not required and just uses up more memory(revolution extractor)
+#endif
+
+
+#ifdef OUTPUT_TIME_IN_NS
+OUTPUT_TIME_IN_NS should not be set(revolution extractor)
+#endif
+
+
+// Assume a disk rotates every at 300rpm.
+// Assume the bitcel size is 2uSec
+// This means 5 revolutions per second
+// Each revolution is 200 milliseconds
+// 200ms / 2uSec = 100000 bits
+// 100000 bits is 12500 bytes
+// Assume the drive spin speed tolerance is +/- 3%, so 
+// Biggest this can be is: 12886 bytes (-3 %)
+// Perfect this can be is: 12500 bytes 
+// Smallest this can be is: 12135 bytes (+3 %)
+#define THEORETICAL_MINIMUM_TRACK_LENGTH			12134
+
+// Speed to report to WinUAE while in 'garbage' mode (1000 is normal, *should* be between 700 (fast) and 3000 (slow))
+// This "cheat" makes things a little more reliable with some loaders.  Not sure why.
+#define DRIVE_GARBAGE_SPEED							6000
+
+// The 'bit' to return during this garbage time.  
+#define DRIVE_GARBAGE_VALUE							1
+
+// Auto-sense the disk, just like Amiga OS will, be do this if it hasn't 
+#define DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL	3000
+
+// We need to poll the drive once theres a disk in there to know when it's been removed.  This is the poll interval
+#define DISKCHANGE_ONCE_INSERTED_CHECK_INTERVAL		500
+
+// Auto-sense the disk, just like Amiga OS will, be do this if it hasn't - Fast mode used for no-click check
+#define DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL_FAST	250
+
+// We need to poll the drive once theres a disk in there to know when it's been removed.   - Fast mode used for no-click check
+#define DISKCHANGE_ONCE_INSERTED_CHECK_INTERVAL_FAST	250
+
+
+// Auto-sense the disk, just like Amiga OS will, be do this if it hasn't - this is for non dick change hardware
+#define DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL_NODSKCHG 3000
+
+// We need to poll the drive once theres a disk in there to know when its been removed.   this is for disk change compatible hardware
+#define DISKCHANGE_ONCE_INSERTED_CHECK_INTERVAL_NODSKCHG 3000
+
+// The cylinder number that precomp should begin at
+#define WRITE_PRECOMP_START 40
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <pthread.h>
+#include <sched.h>
+#endif
+
+// Flags from WINUAE
+CommonBridgeTemplate::CommonBridgeTemplate(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool shouldAutoCache, bool useSmartSpeed) :
+	m_currentWriteStartMfmPosition(0), m_delayStreaming(false), m_driveResetStatus(false), m_driveStreamingData(false), m_isCurrentlyHeadCheating(false), m_inHDMode(false),
+	m_control(nullptr), m_currentTrack(0), m_actualCurrentCylinder(0), m_writeProtected(false), m_diskInDrive(false), m_firstTrackMode(false), m_autocacheModifiedCurrentCylinder(false),
+	m_bridgeMode(bridgeMode), m_bridgeDensity(bridgeDensity), m_motorSpinningUp(false), m_motorIsReady(false), m_isMotorRunning(false), m_autoCacheMotorStatus(false), m_useSmartSpeed(useSmartSpeed),
+	m_readBufferAvailable(false), m_floppySide(DiskSurface::dsLower), m_actualFloppySide(DiskSurface::dsLower), m_shouldAutoCache(shouldAutoCache), m_pll(true, true), m_readLoops(0),
+	m_lastSeek(std::chrono::steady_clock::now()) {
+
+	memset(&m_mfmRead, 0, sizeof(m_mfmRead));;
+	m_pll.setRotationExtractor(&m_extractor);
+}
+
+// Change to a different bridge-mode (in real-time)
+void CommonBridgeTemplate::changeBridgeMode(FloppyBridge::BridgeMode bridgeMode) {
+	m_bridgeMode = bridgeMode;
+}
+
+// Change to a different bridge-density (in real-time)
+void CommonBridgeTemplate::changeBridgeDensity(FloppyBridge::BridgeDensityMode bridgeDensity) {
+	m_bridgeDensity = bridgeDensity;
+}
+
+// Quick confirmation from UAE that we're actually on the same side
+void CommonBridgeTemplate::setSurface(bool side) {
+	switchDiskSide(side);
+}
+
+// Free
+CommonBridgeTemplate::~CommonBridgeTemplate() {
+	terminate();
+}
+
+// If it returns TRUE, this is the next cylinder and side that should be cached in the background because there is NO data for it
+bool CommonBridgeTemplate::getNextTrackToAutoCache(int& cylinder, DiskSurface& side) {
+	if (!m_shouldAutoCache) return false;
+
+	// Plan is cache track 0-10, 40-50, and then fill in.
+	for (cylinder = 0; cylinder < 10; cylinder++) {
+		for (int s = 0; s < 2; s++) {
+			if (!m_mfmRead[cylinder][s].current.ready) {
+				side = (DiskSurface)s;
+				return true;
+			}
+		}
+	}
+
+	// Now the 40-50
+	for (cylinder = 40; cylinder < 50; cylinder++) {
+		for (int s = 0; s < 2; s++) {
+			if (!m_mfmRead[cylinder][s].current.ready) {
+				side = (DiskSurface)s;
+				return true;
+			}
+		}
+	}
+
+	// Now fill in the rest
+	for (cylinder = 10; cylinder < 40; cylinder++) {
+		for (int s = 0; s < 2; s++) {
+			if (!m_mfmRead[cylinder][s].current.ready) {
+				side = (DiskSurface)s;
+				return true;
+			}
+		}
+	}
+
+	for (cylinder = 50; cylinder < 80; cylinder++) {
+		for (int s = 0; s < 2; s++) {
+			if (!m_mfmRead[cylinder][s].current.ready) {
+				side = (DiskSurface)s;
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+// Handle disk side change
+void CommonBridgeTemplate::switchDiskSide(const bool side) {
+	// Just to be 100% sure this is working right
+	DiskSurface incommingSide = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+
+	if (incommingSide != m_floppySide) {
+		resetWriteBuffer();
+		m_floppySide = incommingSide;
+		if (!m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+			std::lock_guard lock(m_readBufferAvailableLock);
+			m_readBufferAvailable = false;
+		}
+		queueCommand(QueueCommand::qcSelectDiskSide, side, !m_isCurrentlyHeadCheating);
+	}
+}
+
+// Add a command for the thread to process
+void CommonBridgeTemplate::queueCommand(const QueueCommand command, const int optionI, const bool shouldAbortStreaming) {
+	QueueInfo info{};
+	info.command = command;
+	info.option.i = optionI;
+
+	pushOntoQueue(info, shouldAbortStreaming);
+}
+
+// Add a command for the thread to process
+void CommonBridgeTemplate::queueCommand(const QueueCommand command, const bool optionB, const bool shouldAbortStreaming) {
+	QueueInfo info{};
+	info.command = command;
+	info.option.b = optionB;
+
+	pushOntoQueue(info, shouldAbortStreaming);
+}
+
+// Add to queue
+void CommonBridgeTemplate::pushOntoQueue(const QueueInfo& info, const bool shouldAbortStreaming, bool insertAtStart) {
+	{
+		std::lock_guard lock(m_queueProtect);
+		if (insertAtStart) m_queue.push_front(info); else m_queue.push_back(info);
+	}
+
+	// A little sneaky trick.  If there's a command to move on, but we have like 90% of the data and we don't have a complete reading for that track yet, it makes sense to carry on and finish it.
+	if ((m_driveStreamingData) && ((m_bridgeMode == FloppyBridge::BridgeMode::bmStalling) || m_extractor.isNearlyReady()) && (!m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].current.ready)) return;
+	if (m_firstTrackMode) return;  // don't stop me now
+
+	// Make it drop out of streaming if that's what its doing
+	if (shouldAbortStreaming && (!m_writeCompletePending) && (!m_writePending)) abortDiskReading();
+}
+
+// Process the queue.  Return TRUE if the thread should quit
+bool CommonBridgeTemplate::processQueue() {
+	QueueInfo cmd{};
+
+	{
+		std::lock_guard lock(m_queueProtect);
+		// Check the statue again under lock to *make sure* it actually contains something
+		if (m_queue.empty()) return false;
+
+		cmd = m_queue.front();
+		m_queue.pop_front();
+	}
+
+	// Special exit condition
+	if (cmd.command == QueueCommand::qcTerminate) {
+		return true;
+	}
+
+	processCommand(cmd);
+
+	return false;
+}
+
+// Returns TRUE if we should be making a manual check for the presence of a disk
+bool CommonBridgeTemplate::isReadyForManualDiskCheck() {
+	const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_lastDiskCheckTime).count();
+	
+	if (supportsDiskChange()) {
+		if ((m_currentTrack == 0) && (m_directMode)) {
+			return ((timePassed > DISKCHANGE_ONCE_INSERTED_CHECK_INTERVAL_FAST) && (m_diskInDrive)) ||
+				((timePassed > DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL_FAST) && (!m_diskInDrive));
+		} else
+		return ((timePassed > DISKCHANGE_ONCE_INSERTED_CHECK_INTERVAL) && (m_diskInDrive)) ||
+			   ((timePassed > DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL) && (!m_diskInDrive));
+	}
+	else {
+		// This version we cant detect disk change to easily.  So we do it less often as it impacts the disk more.
+		return ((timePassed > DISKCHANGE_ONCE_INSERTED_CHECK_INTERVAL_NODSKCHG) && (m_diskInDrive)) ||
+			   ((timePassed > DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL_NODSKCHG) && (!m_diskInDrive));
+	}
+}
+
+// The main thread
+void CommonBridgeTemplate::mainThread() {
+	m_lastDiskCheckTime = std::chrono::steady_clock::now();
+
+	for (;;) {
+		// Extract processing needed?
+		poll();
+
+		// Check if the motor should be disabled.
+		checkMotorOff();
+
+		bool lastDiskState = m_diskInDrive;
+		bool diskInDrive = m_diskInDrive;
+
+		{
+			bool autoCachingRequired = false;
+			if (m_shouldAutoCache && (!m_directMode)) {
+				int nextCylinder;
+				DiskSurface nextSurface;
+				autoCachingRequired = getNextTrackToAutoCache(nextCylinder, nextSurface);
+			}
+		}
+		
+		if (!m_queue.empty()) {
+			if (processQueue())
+				return;
+		}
+		else {
+			// Trigger background reading if we're not busy
+			if (m_motorIsReady) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(2));
+				const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_delayStreamingStart).count();
+				if ((!m_delayStreaming) || ((m_delayStreaming) && (timePassed > 100)))
+					handleBackgroundDiskRead();
+			}
+			else {
+				handleBackgroundCaching();
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			}			
+
+
+			// If the queue is empty, the motor isn't on, and we think there's a disk in the drive we periodically check as we don't have any other way to find out
+			if (isReadyForManualDiskCheck() && m_queue.empty()) {
+
+				// Monitor for disk
+				if (!supportsDiskChange()) {
+					diskInDrive = attemptToDetectDiskChange();
+				}
+				else {
+					// This may cause the drive to temporarily step
+					diskInDrive = getDiskChangeStatus(true);
+				}
+				m_lastDiskCheckTime = std::chrono::steady_clock::now();
+
+				m_writeProtected = checkWriteProtectStatus(false);
+			}
+		}
+
+		if (m_motorSpinningUp) {
+			const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_motorSpinningUpStart).count();
+			if (timePassed >= getDriveSpinupTime()) {
+				m_firstTrackMode = !(m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].current.ready || m_mfmRead[m_actualCurrentCylinder][1-(int)m_actualFloppySide].current.ready);
+				m_motorSpinningUp = false;
+				m_motorIsReady = true;
+			}
+		}
+
+
+		if (supportsDiskChange()) 
+			diskInDrive = getDiskChangeStatus(false);
+
+		if (lastDiskState != diskInDrive) {
+			// Erase track cache 
+			if (!diskInDrive) {
+				resetMFMCache();
+				m_inHDMode = false;
+			}
+			else {
+				m_writeProtected = checkWriteProtectStatus(true);
+				// Request the type of disk before we let the OS know a disk has actually been inserted
+				internalCheckDiskDensity(true);
+			}
+
+			m_diskInDrive = diskInDrive;
+		}
+	}
+}
+
+// Internally check the disk density
+void CommonBridgeTemplate::internalCheckDiskDensity(bool newDiskInserted) {
+	switch (m_bridgeDensity) {
+	case FloppyBridge::BridgeDensityMode::bdmAuto:
+		// Run the test
+		if (m_diskInDrive || newDiskInserted) {
+			// To do this properly we should be on track 0, lower side.
+			setCurrentCylinder(0);
+			setActiveSurface(DiskSurface::dsLower);
+
+			checkDiskType();
+
+			// Revert
+			setActiveSurface(m_actualFloppySide);
+			setCurrentCylinder(m_actualCurrentCylinder);
+		}
+		else {
+			forceDiskDensity(false);
+		}
+		break;
+
+	case FloppyBridge::BridgeDensityMode::bdmDDOnly:
+		forceDiskDensity(false);
+		break;
+
+	case FloppyBridge::BridgeDensityMode::bdmHDOnly:
+		forceDiskDensity(true);
+		break;
+	}
+	m_inHDMode = _getDriveTypeID() == DriveTypeID::dti35HD;
+}
+
+// Reset the previously setup queue
+void CommonBridgeTemplate::resetMFMCache() {
+	std::lock_guard lock(m_switchBufferLock);
+
+	for (int a = 0; a < MAX_CYLINDER_BRIDGE; a++)
+		for (int c = 0; c < 2; c++) {
+			m_mfmRead[a][c].startBitPatterns.valid = false;
+			memset(&m_mfmRead[a][c].next, 0, sizeof(m_mfmRead[a][c].next));
+			memset(&m_mfmRead[a][c].current, 0, sizeof(m_mfmRead[a][c].current));
+			memset(&m_mfmRead[a][c].last, 0, sizeof(m_mfmRead[a][c].last));
+		}
+	resetWriteBuffer();
+	m_extractor.newDisk(m_inHDMode);
+	m_pll.reset();
+	
+	std::lock_guard lockbuff(m_readBufferAvailableLock);
+	m_readBufferAvailable = false;
+
+	m_writePending = false;
+	m_writeComplete = false;
+	m_lastWroteTo = -1;
+}
+
+// Scans the MFM data to see if this track should allow smart speed or not based on timing data
+void CommonBridgeTemplate::checkSmartSpeed(const int cylinder, const DiskSurface side, MFMCache& track) {
+	// By default, say "no"
+	track.supportsSmartSpeed = false;
+
+	// Typically copy protection is on the first 3 tracks anyway
+	if (cylinder <= 3) return;    // this actually isn't needed for Lemmings etc, the code below catches it!
+
+	// Step 1: Find the average speed
+#ifdef HIGH_RESOLUTION_MODE
+	uint64_t total = 0;
+	for (unsigned int mfmPositionBits = 0; mfmPositionBits < track.amountReadInBits; mfmPositionBits++) {
+		const int mfmPositionBit = 7 - (mfmPositionBits & 7);
+		total += track.mfmBuffer[mfmPositionBits>>3].speed[mfmPositionBit];
+	}
+	total /= track.amountReadInBits;
+#else
+	uint64_t total = 0;
+	unsigned int totalBytes = (track.amountReadInBits + 7) / 8;
+	for (unsigned int byte = 0; byte < totalBytes; byte++)
+		total += track.mfmBuffer[byte].speed;
+	total /= totalBytes;
+#endif
+	// total=100 means exact proper normal speed
+
+	// If a little too far out?
+	if (total > 120) return;
+	if (total < 80) return;
+
+	// Step 2: Scan the data and see how much differs from this
+	unsigned int differ = 0;
+	const int threshold = 4;
+#ifdef HIGH_RESOLUTION_MODE
+	for (unsigned int mfmPositionBits = 0; mfmPositionBits < track.amountReadInBits; mfmPositionBits++) {
+		const int mfmPositionBit = 7 - (mfmPositionBits & 7);
+		if (abs((int)track.mfmBuffer[mfmPositionBits >> 3].speed[mfmPositionBit] - (int)total) > threshold) differ++;
+	}
+	total /= track.amountReadInBits;
+#else
+	for (unsigned int byte = 0; byte < totalBytes; byte++)
+		if (abs((int)track.mfmBuffer[byte].speed - (int)total) > threshold) differ++;
+#endif
+
+	if (differ > 75) return;
+
+	track.supportsSmartSpeed = true;
+}
+
+// Save a new disk side and switch it in if it can be
+void CommonBridgeTemplate::saveNextBuffer(const int cylinder, const DiskSurface side) {
+
+	// Save the new buffer
+	{
+		std::lock_guard lock(m_switchBufferLock);
+		if (m_mfmRead[cylinder][(int)side].next.amountReadInBits) {
+			m_mfmRead[cylinder][(int)side].next.ready = true;
+		}
+		else {
+			// Shouldn't be able to ever get here
+			m_mfmRead[cylinder][(int)side].next.ready = false;
+		}
+	}
+
+	// Stop of the above blocked the buffer
+	if (!m_mfmRead[cylinder][(int)side].next.ready) return;
+
+	// Check if this track should allow smartSpeed
+	if (m_useSmartSpeed) {
+		checkSmartSpeed(cylinder, side, m_mfmRead[cylinder][(int)side].next);
+	}
+
+	// Go live now?
+	if (!m_mfmRead[cylinder][(int)side].current.ready) {
+
+		internalSwitchCylinder(cylinder, side);
+
+		// This test *should* always be true
+		if ((cylinder == m_currentTrack) && (side == m_floppySide)) {
+			std::lock_guard lock(m_readBufferAvailableLock);
+			m_readBufferAvailable = true;
+			m_readBufferAvailableFlag.notify_one();
+		}
+	}
+}
+
+// Handle reading the disk data in the background while the queue is idle
+void CommonBridgeTemplate::handleBackgroundDiskRead() {
+	// Disabled in Direct mode
+	if (m_directMode && (!m_firstTrackMode)) return;
+
+	// Don't do anything until the motor is ready.  The flag that checks for disk change will also report spin ready status if the drive hasn't spun up properly yet
+	if (!((m_motorIsReady) && (!m_motorSpinningUp))) {
+		if (m_shouldAutoCache) handleBackgroundCaching();
+		return;
+	}
+
+	// If we already have the next buffer full then stop
+	if (m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next.ready) {
+		if (m_shouldAutoCache) handleBackgroundCaching();
+		return;
+	}
+
+	// Make sure the right surface is selected
+	if (!setActiveSurface(m_actualFloppySide)) return;
+	bool flipSide = false;
+
+	// Restore the correct cylinder
+	if (m_autocacheModifiedCurrentCylinder) {
+		if (!setCurrentCylinder(m_actualCurrentCylinder)) return;
+		m_autocacheModifiedCurrentCylinder = false;
+	}
+
+	uint32_t trackRead = 0;
+
+	// Switch this depending on whats going on
+	m_extractor.setAlwaysUseIndex(m_firstTrackMode || (m_bridgeMode == FloppyBridge::BridgeMode::bmCompatible) || (m_bridgeMode == FloppyBridge::BridgeMode::bmStalling));
+
+	{
+		// Scope it
+		MFMCache& trackData = m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next;
+		trackData.amountReadInBits = 0;
+		trackData.ready = false;
+
+		m_driveStreamingData = true;
+		bool revolutionExtracted = false;
+
+		// Grab full revolutions if possible.
+		ReadResponse r =  readData(m_pll, MFM_BUFFER_MAX_TRACK_LENGTH, trackData.mfmBuffer, m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].startBitPatterns,
+			[this, &trackData, &flipSide, &revolutionExtracted, &trackRead](RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits) -> bool {
+				trackData.amountReadInBits = dataLengthInBits;
+
+				saveNextBuffer(m_actualCurrentCylinder, m_actualFloppySide);
+				revolutionExtracted = true;
+				trackRead++;
+
+				// Stop!
+				if (m_directMode) return false;
+
+				// This is a little cache prediction, but could cause issues with things needing to re-read the same track over and over.  However eventually it will continue anyway
+				if (m_bridgeMode != FloppyBridge::BridgeMode::bmStalling && m_bridgeMode != FloppyBridge::BridgeMode::bmCompatible && !m_inHDMode || m_firstTrackMode) {
+					// So, as a little speed up.  Is the other side of this track in memory?
+					if (!m_mfmRead[m_actualCurrentCylinder][1 - (int)m_actualFloppySide].current.ready) {
+						// No.  Is anything else going on?
+						if (m_queue.empty()) {
+							// No. 
+							flipSide = true;
+							return false;
+						}
+					}
+				}
+				
+				// If we have everything then stop
+				if (!m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next.ready) return false;
+
+				// Stop if too many
+				if (trackRead >= 10) return false;
+				m_readLoops++;
+
+				// Else read another revolution
+				return !m_queue.empty();
+			});
+		switch (r) {
+			case ReadResponse::rrNoDiskInDrive:
+				 m_diskInDrive = false;
+				 m_delayStreaming = true;
+				 m_delayStreamingStart = std::chrono::steady_clock::now();
+				 resetMFMCache();
+				 m_inHDMode = false;
+				 break;
+
+			case ReadResponse::rrOK:
+				if (!m_diskInDrive) {
+					m_diskInDrive = true;
+					m_delayStreaming = false;
+					m_lastDiskCheckTime = std::chrono::steady_clock::now();
+					m_inHDMode = false;
+				}
+				else {
+					if ((revolutionExtracted) && (!m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next.ready)) {
+
+						// Try for a re-play
+						MFMCache& trackData = m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next;
+						trackData.amountReadInBits = 0;
+						trackData.ready = false;
+
+						m_pll.rePlayData(MFM_BUFFER_MAX_TRACK_LENGTH, trackData.mfmBuffer, m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].startBitPatterns,
+							[this, &trackData, &flipSide, &revolutionExtracted](RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits) -> bool {
+								trackData.amountReadInBits = dataLengthInBits;
+								saveNextBuffer(m_actualCurrentCylinder, m_actualFloppySide);
+								return false;
+							});
+					}
+
+				}
+				break;
+		}
+	}
+
+	// Did the reader want us to flip sides?
+	if (flipSide && m_diskInDrive) {
+		DiskSurface flipSurface = m_actualFloppySide == DiskSurface::dsLower ? DiskSurface::dsUpper : DiskSurface::dsLower;
+		MFMCache& trackData = m_mfmRead[m_actualCurrentCylinder][(int)flipSurface].next;
+
+		// Switch the read head
+		if ((!trackData.ready) && (setActiveSurface(flipSurface))) {
+
+			// If there still isn't any jobs to do, then start reading it.
+			if (m_queue.empty()) {
+				trackData.amountReadInBits = 0;
+
+				// Let the world know what we're doing.
+				m_isCurrentlyHeadCheating = true;
+
+				unsigned int oldRevolutionTime = m_extractor.getRevolutionTime();
+				if (m_firstTrackMode) m_extractor.newDisk(m_inHDMode);
+				bool trackWasRead = false;
+
+				// and go for it
+				ReadResponse r = readData(m_pll, MFM_BUFFER_MAX_TRACK_LENGTH, trackData.mfmBuffer, m_mfmRead[m_actualCurrentCylinder][(int)flipSurface].startBitPatterns,
+					[this, flipSurface, &trackData, &trackWasRead](RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits) -> bool {
+						trackData.amountReadInBits = dataLengthInBits;
+						saveNextBuffer(m_actualCurrentCylinder, flipSurface);
+						trackWasRead = true;
+						// We only want an initial one.
+						return false;
+
+					});
+				switch (r) {
+				case ReadResponse::rrNoDiskInDrive:
+					m_diskInDrive = false;
+					m_delayStreaming = true;
+					m_delayStreamingStart = std::chrono::steady_clock::now();
+					m_inHDMode = false;
+					resetMFMCache();
+					break;
+
+				case ReadResponse::rrOK:
+					if (!m_diskInDrive) {
+						m_diskInDrive = true;
+						m_delayStreaming = false;
+						m_lastDiskCheckTime = std::chrono::steady_clock::now();
+						m_inHDMode = false;
+					}
+					else {
+						if (m_firstTrackMode) {
+							if (trackWasRead) {
+								// Average the speed of both revolutions
+								unsigned int newSpeed = m_extractor.getRevolutionTime();
+								m_extractor.setRevolutionTime((newSpeed + oldRevolutionTime) / 2);
+							}
+							else {
+								// Apply the first one... This shouldn't happen
+								m_extractor.setRevolutionTime(oldRevolutionTime);
+							}
+						}
+
+						if (!m_mfmRead[m_actualCurrentCylinder][(int)flipSurface].next.ready) {
+							// Try for a re-play
+							trackData = m_mfmRead[m_actualCurrentCylinder][(int)flipSurface].next;
+							trackData.amountReadInBits = 0;
+							trackData.ready = false;
+
+							m_pll.rePlayData(MFM_BUFFER_MAX_TRACK_LENGTH, trackData.mfmBuffer, m_mfmRead[m_actualCurrentCylinder][(int)flipSurface].startBitPatterns,
+								[this, &trackData, &flipSurface](RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits) -> bool {
+									trackData.amountReadInBits = dataLengthInBits;
+									saveNextBuffer(m_actualCurrentCylinder, flipSurface);
+									return false;
+								});
+						}
+					}
+					break;
+				}				
+
+				m_isCurrentlyHeadCheating = false;
+			}
+		}
+	}
+
+	// Reset this flag if we have the first cylinder recorded with at least 1 revolution
+	if (m_firstTrackMode) m_firstTrackMode = !(m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].current.ready || m_mfmRead[m_actualCurrentCylinder][1 - (int)m_actualFloppySide].current.ready);
+
+	// Stopped streaming
+	m_driveStreamingData = false;
+
+	// Just flag this so we don't get an immediate check - but only for the first 5 reads
+	if (m_readLoops<5) m_lastDiskCheckTime = std::chrono::steady_clock::now();
+}
+
+// Return TRUE if we're at the INDEX marker - we fake the start of the buffer being where the index marker is.
+bool CommonBridgeTemplate::isMFMPositionAtIndex(int mfmPositionBits) {
+	if (m_directMode) return 0;
+
+	if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+		return (mfmPositionBits == 0) || (mfmPositionBits == m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits);
+	}
+	return mfmPositionBits == 0;
+}
+
+// Return the maximum size of the internal track buffer in BITS
+int CommonBridgeTemplate::maxMFMBitPosition() {
+	if (m_directMode) return 0;
+
+	if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready)
+		if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits)
+			return m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits;
+
+	// If there is no buffer ready, it's difficult to tell WinUAE what it wants to know, as we don't either.  So we supply a absolute MINIMUM that *should* be available on a disk
+	// As this is dynamically read each time it *shouldn't* be a problem and by the time it hopefully reaches it the buffer will have gone live
+	return std::max(THEORETICAL_MINIMUM_TRACK_LENGTH * 8, m_mfmRead[m_currentTrack][(int)m_floppySide].next.amountReadInBits);
+}
+
+// This is called to switch to a different copy of the track so multiple revolutions can be read
+void CommonBridgeTemplate::mfmSwitchBuffer(bool side) {
+	if (m_directMode) return;
+
+	switchDiskSide(side);
+	internalSwitchCylinder(m_currentTrack, m_floppySide);
+}
+
+// This is called to switch to a different copy of the track so multiple revolutions can be read
+void CommonBridgeTemplate::internalSwitchCylinder(const int cylinder, const DiskSurface side) {
+	std::lock_guard lock(m_switchBufferLock);
+
+	// Is there a new one?
+	if (m_mfmRead[cylinder][(int)side].next.ready) {
+		// New one is ready.  If the current one is valid swap it to old
+		if (m_mfmRead[cylinder][(int)side].current.ready) {
+			m_mfmRead[cylinder][(int)side].last = m_mfmRead[cylinder][(int)side].current;
+		}
+
+		// and replace it
+		m_mfmRead[cylinder][(int)side].current = m_mfmRead[cylinder][(int)side].next;
+		m_mfmRead[cylinder][(int)side].next.amountReadInBits = 0;
+		m_mfmRead[cylinder][(int)side].next.ready = false;
+	} else // No new one? Do we have an old one we're cycling around?
+		if (m_mfmRead[cylinder][(int)side].last.ready) {
+			std::swap(m_mfmRead[cylinder][(int)side].current,m_mfmRead[cylinder][(int)side].last);
+		}
+
+	if (m_writeCompletePending) {
+		std::lock_guard write_lock(m_writeLockCompleteFlag);
+		m_writeCompletePending = false;
+		m_writeComplete = true;
+		m_lastWroteTo = (cylinder * 2) + ((int)side);
+	}
+	else m_lastWroteTo = -1;
+}
+
+// Get the speed at this position.  1000=100%.  
+int CommonBridgeTemplate::getMFMSpeed(const int mfmPositionBits) {
+	if (m_directMode) return 1000;
+	if (mfmPositionBits < 0) return DRIVE_GARBAGE_SPEED;
+	if (!isReady()) return DRIVE_GARBAGE_SPEED;
+
+	if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+		if (m_lastWroteTo == ((m_currentTrack * 2) + (int)m_floppySide)) {
+			// We just write to this, but to help with any re-tries, we'll slow this down
+			if (m_mfmRead[m_currentTrack][(int)m_floppySide].next.ready) m_lastWroteTo = -1; else {
+				// Force normal speed
+				return 1000;
+			}
+		}
+
+		// This shouldn't happen
+		if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits < 1) return 1000;
+
+		if (m_inHDMode) return 100; else
+			if ((m_bridgeMode == FloppyBridge::BridgeMode::bmTurboAmigaDOS) || (((m_bridgeMode == FloppyBridge::BridgeMode::bmFast) || (m_bridgeMode == FloppyBridge::BridgeMode::bmCompatible)) && (m_mfmRead[m_currentTrack][(int)m_floppySide].current.supportsSmartSpeed))) return 100;
+
+		const int modPositionBit = mfmPositionBits % m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits;
+
+		// Get the 'bit' we're reading
+		const int mfmPositionByte = modPositionBit >> 3;
+
+#ifdef HIGH_RESOLUTION_MODE
+		const int mfmPositionBit = 7 - (modPositionBit & 7);
+		int speed = (10 * (int)(m_mfmRead[m_currentTrack][(int)m_floppySide].current.mfmBuffer[mfmPositionByte].speed[mfmPositionBit]));
+#else
+		int speed = (10 * (int)(m_mfmRead[m_currentTrack][(int)m_floppySide].current.mfmBuffer[mfmPositionByte].speed));
+#endif
+		if (speed < 700)  speed = 700;
+		if (speed > 3000)  speed = 3000;
+		
+		return speed;
+	}
+
+	return DRIVE_GARBAGE_SPEED;
+}
+
+// Returns TRUE if data is ready and available
+bool CommonBridgeTemplate::isMFMDataAvailable() {
+	if (m_directMode) return false;
+	if (m_bridgeMode == FloppyBridge::BridgeMode::bmStalling) return true;
+	return m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready;
+}
+
+// Requests an entire track of data.  Returns 0 if the track is not available
+// The return value is the wrap point in bits (last byte is shifted to MSB) or in Direct mode, just the number of bits received
+// resyncRotation is ignored in direct mode
+int CommonBridgeTemplate::getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) {
+	if (m_directMode) {
+		threadLockControl(true);
+
+		// Goto the correct track
+		if ((m_actualCurrentCylinder != track) || (m_currentTrack != track)) {
+			if (!setCurrentCylinder(track)) {
+				threadLockControl(false);
+				return false;
+			}
+			m_actualCurrentCylinder = track;
+			m_currentTrack = track;
+			m_autocacheModifiedCurrentCylinder = false;
+			m_lastWroteTo = -1;
+		}
+
+		// Do the write
+		DiskSurface _side = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+		if (m_actualFloppySide != _side) {
+			m_actualFloppySide = _side;
+			setActiveSurface(_side);
+		}
+
+		m_linearExtractor.setOutputBuffer(output, bufferSizeInBytes);
+		// Switch to linear extractor
+		m_pll.setRotationExtractor(&m_linearExtractor);
+
+		ReadResponse r = readLinearData(m_pll);
+		// put it back!
+		m_pll.setRotationExtractor(&m_extractor);
+
+		// Prevent disk check while we're doing this
+		m_lastDiskCheckTime = std::chrono::steady_clock::now();
+
+		// Release thread
+		threadLockControl(false);
+
+		// Finalise the output and get the mumber of bits
+		return m_linearExtractor.finaliseAndGetNumBits();
+	}
+
+	// Be in the right place
+	gotoCylinder(track, side);
+
+	if (m_bridgeMode != FloppyBridge::BridgeMode::bmStalling) {
+		if (!isReady()) return 0;
+	}
+	else {
+		if (!m_motorIsReady) return 0;
+		if (!m_diskInDrive) return 0;
+	}
+	if (bufferSizeInBytes < 1) return 0;
+
+	if (!m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+		if (m_bridgeMode == FloppyBridge::BridgeMode::bmStalling) {
+			const unsigned int DelayBetweenChecksMS = 5;
+			const auto TimeToWait = std::chrono::milliseconds(450);
+
+			// Try to wait
+			std::unique_lock<std::mutex> lck(m_readBufferAvailableLock);
+			m_readBufferAvailableFlag.wait_for(lck, TimeToWait, [this] { return m_readBufferAvailable; });
+
+			if (!m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) return 0;
+		} else 
+			return 0;
+	}
+	RotationExtractor::MFMSample* sample = m_mfmRead[m_currentTrack][(int)m_floppySide].current.mfmBuffer;
+
+	const int bitsRemaining = m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits;
+	const int bytesToCopy = std::min((bitsRemaining + 7) / 8, bufferSizeInBytes);
+	unsigned char* outByte = (unsigned char*)output;
+	
+	for (int byte = 0; byte < bytesToCopy; byte++) {
+		*outByte++ = sample->mfmData;
+		sample++;
+	}
+	
+	return bitsRemaining;
+}
+
+// Read a single bit from the data stream.   this should call triggerReadWriteAtIndex where appropriate
+bool CommonBridgeTemplate::getMFMBit(const int mfmPositionBits) {
+	if (m_directMode) return false;
+
+	if (m_bridgeMode != FloppyBridge::BridgeMode::bmStalling) {
+		if (!isReady()) return DRIVE_GARBAGE_VALUE;
+	} else {
+		if (!m_motorIsReady) return DRIVE_GARBAGE_VALUE;
+		if (!m_diskInDrive) return DRIVE_GARBAGE_VALUE;
+		//if (!m_motorSpinningUp) return DRIVE_GARBAGE_VALUE;
+	}
+	if (mfmPositionBits < 0) return false; // weird, but this shouldn't happen
+
+	if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+		// This shouldn't happen
+		if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits < 1) return DRIVE_GARBAGE_VALUE;
+
+		const int modPositionBit = mfmPositionBits % m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits;
+		// Internally manage loops until the data is ready
+		const int mfmPositionByte = modPositionBit >> 3;
+		const int mfmPositionBit = 7 - (modPositionBit & 7);
+
+		return (m_mfmRead[m_currentTrack][(int)m_floppySide].current.mfmBuffer[mfmPositionByte].mfmData & (1 << mfmPositionBit)) != 0;
+	}
+
+	// Given the reading is quick enough mostly this is ok.  It kinda simulates the drive settling time, just a little extended
+	if (m_bridgeMode != FloppyBridge::BridgeMode::bmStalling) return DRIVE_GARBAGE_VALUE;
+
+	// Allow a little bit of head settling time
+	if ((!m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) && (!m_writePending)) {
+		const auto timePassedSinceSeek = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_lastSeek).count();
+		if (timePassedSinceSeek < 5) 
+			return 0;
+	}
+	
+	// Try to wait for the data.  A full revolution should be about 200ms, but given its trying to INDEX align, worse case this could be approx 400ms.
+	// Average should be 300ms based on starting to read when the head is at least half way from the index.
+	const unsigned int DelayBetweenChecksMS = 5;
+	const auto DelayBetweenChecks = std::chrono::milliseconds(DelayBetweenChecksMS);
+
+	// Extra time if data was written.
+	const unsigned int dataWaitTime = (m_writePending || m_delayStreaming) ? 1500 : 450;
+
+	for (unsigned int a = 0; a < 450 / DelayBetweenChecksMS; a++) {
+		// Causes a delay of 5ms or until a buffer is made live
+		{
+			std::unique_lock<std::mutex> lck(m_readBufferAvailableLock);
+			m_readBufferAvailableFlag.wait_for(lck, DelayBetweenChecks, [this] { return m_readBufferAvailable; });
+		}
+
+		// No full buffer ready yet.
+		if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+			if (m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits < 1) return 0;
+			const int modPositionBit = mfmPositionBits % m_mfmRead[m_currentTrack][(int)m_floppySide].current.amountReadInBits;
+			// Internally manage loops until the data is ready
+			const int mfmPositionByte = modPositionBit >> 3;
+			const int mfmPositionBit = 7 - (modPositionBit & 7);
+			// If a buffer is available, go for it!
+			return (m_mfmRead[m_currentTrack][(int)m_floppySide].current.mfmBuffer[mfmPositionByte].mfmData & (1 << mfmPositionBit)) != 0;
+		}
+	}
+
+	// If we get here, we give up and return nothing. So we behave like no data
+	return 0;
+}
+
+// Called if you do something which is classed as a manual check for disk presence etc
+void CommonBridgeTemplate::updateLastManualCheckTime() {
+	m_lastDiskCheckTime = std::chrono::steady_clock::now();
+}
+
+// Returns TRUE when the last command requested has completed
+bool CommonBridgeTemplate::isReady() { 
+	// All of these cause "not ready"
+	return (m_motorIsReady) && (!m_motorSpinningUp) && (m_diskInDrive) && (!m_firstTrackMode);
+};
+
+// Handle caching track data in the background
+void CommonBridgeTemplate::handleBackgroundCaching() {
+	if (!m_shouldAutoCache) return;
+	if (m_directMode) return;
+	if (!m_queue.empty()) return;
+	if (m_lastWroteTo >= 0) return;  // don't do this if a write is happening
+	if (!m_diskInDrive) {
+		// Turn off the motor if its not needed and we started it
+		if (m_motorIsReady || m_motorSpinningUp) return;
+		if (m_autoCacheMotorStatus) {
+			m_autoCacheMotorStatus = false;
+			setMotorStatus(false);
+		}
+		return;
+	}
+
+	const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_delayStreamingStart).count();
+	if ((m_delayStreaming) && (timePassed < 100)) return;
+
+	// Check if we should do this
+	int nextCylinder;
+	DiskSurface nextSurface;
+	if (!getNextTrackToAutoCache(nextCylinder, nextSurface)) {
+		// Nothing left to cache.
+		
+		if (m_motorIsReady || m_motorSpinningUp) return;
+		// Turn off the motor if its not needed and we started it
+		if (m_autoCacheMotorStatus) {
+			m_autoCacheMotorStatus = false;
+			setMotorStatus(false);
+		}
+		return;
+	}
+
+	// Does the OS think the motor is already running?
+	if (!m_motorIsReady) {
+		// It's on a spin-up.  Stop. It's the OS's turn now
+		if (m_motorSpinningUp) return;
+
+		// Have we internally turned the motor on?
+		if (!m_autoCacheMotorStatus) {
+			m_autoCacheMotorStatus = true;
+			setMotorStatus(true);
+			m_autoCacheMotorStart = std::chrono::steady_clock::now();
+		}
+	}
+
+	// We can finally do something.
+	if ((m_autoCacheMotorStatus) && (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_autoCacheMotorStart).count() > getDriveSpinupTime())) {
+		// Lets read a single rotation
+		if (!setActiveSurface(nextSurface)) return;
+		if (!setCurrentCylinder(nextCylinder)) return;
+		m_autocacheModifiedCurrentCylinder = true;
+		m_extractor.setAlwaysUseIndex(true);
+
+		// Scope it
+		MFMCache& trackData = m_mfmRead[nextCylinder][(int)nextSurface].next;
+		trackData.amountReadInBits = 0;
+		trackData.ready = false;
+
+		m_driveStreamingData = true;
+		bool revolutionExtracted = false;
+
+		// Grab full revolutions if possible.
+		ReadResponse r = readData(m_pll, MFM_BUFFER_MAX_TRACK_LENGTH, trackData.mfmBuffer, m_mfmRead[nextCylinder][(int)nextSurface].startBitPatterns,
+			[this, &revolutionExtracted , &trackData, nextCylinder, nextSurface](RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits) -> bool {
+				trackData.amountReadInBits = dataLengthInBits;
+
+				saveNextBuffer(nextCylinder, nextSurface);
+				revolutionExtracted = true;
+
+				// Stop
+				return false;
+
+			});
+
+		// Re-play the data with jitter
+		if (revolutionExtracted) {
+			m_pll.rePlayData(MFM_BUFFER_MAX_TRACK_LENGTH, trackData.mfmBuffer, m_mfmRead[nextCylinder][(int)nextSurface].startBitPatterns,
+				[this, &trackData, nextCylinder, nextSurface](RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits) -> bool {
+					trackData.amountReadInBits = dataLengthInBits;
+
+					saveNextBuffer(nextCylinder, nextSurface);
+
+					// Stop
+					return false;
+
+				});
+		}
+
+		switch (r) {
+		case ReadResponse::rrNoDiskInDrive:
+			m_diskInDrive = false;
+			m_delayStreaming = true;
+			m_delayStreamingStart = std::chrono::steady_clock::now();
+			resetMFMCache();
+			m_inHDMode = false;
+			break;
+
+		case ReadResponse::rrOK:
+			if (!m_diskInDrive) {
+				m_diskInDrive = true;
+				m_delayStreaming = false;
+				m_lastDiskCheckTime = std::chrono::steady_clock::now();
+				m_inHDMode = false;
+			}
+			break;
+		}
+		m_driveStreamingData = false;
+		m_lastDiskCheckTime = std::chrono::steady_clock::now();
+	}	
+}
+
+// Manage motor status
+void CommonBridgeTemplate::internalSetMotorStatus(bool enabled) {
+	if (m_shouldAutoCache) {
+		// Do something different here
+		if (enabled) {
+			if (m_autoCacheMotorStatus) {
+				// Do nothing, its coming online anyway
+				return;
+			}
+			else {
+				setMotorStatus(true);
+				m_autoCacheMotorStatus = true;
+				m_autoCacheMotorStart = std::chrono::steady_clock::now();
+			}
+		}
+		else {
+			// Switch off the motor eh?
+			int c;
+			DiskSurface s;
+			// Is there still data to be read?
+			if (getNextTrackToAutoCache(c, s)) {
+				// Ignore it.
+			}
+			else {
+				// Turn off the motor
+				m_autoCacheMotorStatus = false;
+				setMotorStatus(false);
+			}
+		}
+	} 
+	else {
+		setMotorStatus(enabled);
+		m_autoCacheMotorStatus = false;
+	}
+}
+
+// Check if the motor should be turned off
+void CommonBridgeTemplate::checkMotorOff() {
+	if (!m_motorTurnOffEnabled) return;
+
+	const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_motorTurnOffStart).count();
+	// Time passed.  We can turn the drive back off
+	if (timePassed >= getDriveSpinupTime()) {
+		m_motorTurnOffEnabled = false;
+
+		QueueInfo cmd{};
+		cmd.command = QueueCommand::qcMotorOff;
+		cmd.option.b = false;
+		pushOntoQueue(cmd, true, true);
+	}
+}
+
+// Handle processing the command
+void CommonBridgeTemplate::processCommand(const QueueInfo& info) {
+	// See what command is being ran
+	switch (info.command) {
+	case QueueCommand::qcResetDrive:
+		// Delete all future writes
+		{
+			std::lock_guard lock(m_pendingWriteLock);
+			m_pendingTrackWrites.clear();
+		}
+		m_writePending = false;
+		m_writeComplete = true;
+		m_autoCacheMotorStatus = false;
+		setMotorStatus(false);
+		internalSetMotorStatus(false);
+		m_autoCacheMotorStatus = false;
+		m_firstTrackMode = false;
+		m_motorTurnOffEnabled = false;
+		m_motorSpinningUp = false;
+		m_writeCompletePending = false;
+		m_motorIsReady = false;
+		m_driveLockReleased = true;
+		m_driveLockReady = false;
+		m_isMotorRunning = false;		
+		m_readLoops = 0;
+		m_lastSeek = std::chrono::steady_clock::now();
+		resetMFMCache();
+		// Get some real disk status values
+		if (supportsDiskChange()) {
+			m_diskInDrive = getDiskChangeStatus(true);
+		}
+		else {
+			m_diskInDrive = attemptToDetectDiskChange();
+		}
+		{
+			std::lock_guard lock(m_driveResetStatusFlagLock);
+			m_driveResetStatus = true;
+			m_driveResetStatusFlag.notify_one();
+		}
+		break;
+
+	case QueueCommand::qcMotorOn:
+		m_motorTurnOffEnabled = false;
+		internalSetMotorStatus(true);
+		m_firstTrackMode = false;
+		m_motorSpinningUp = true;
+		m_motorSpinningUpStart = std::chrono::steady_clock::now();
+		m_readLoops = 0;
+		break;
+
+	case QueueCommand::qcNoClickSeek:
+		if (m_actualCurrentCylinder == 0) {
+			// If it fails, simulate it
+			if (!performNoClickSeek()) {
+				setCurrentCylinder(1);
+				setCurrentCylinder(0);
+				m_readLoops = 0;
+			}
+		}
+		break;
+
+	case QueueCommand::qcGotoToTrack:
+		// Now supports side switch too
+		{	const DiskSurface newSide = (info.option.i & 1) ? DiskSurface::dsUpper : DiskSurface::dsLower;
+			if (m_actualFloppySide != newSide) {
+				m_actualFloppySide = newSide;
+				setActiveSurface(m_actualFloppySide);
+			}
+		}		
+		setCurrentCylinder(info.option.i >> 1);
+		m_actualCurrentCylinder = info.option.i >> 1;
+		m_autocacheModifiedCurrentCylinder = false;
+		m_lastWroteTo = -1;
+		m_readLoops = 0;
+		break;
+
+	case QueueCommand::qcMotorOffDelay:
+		m_motorTurnOffEnabled = true;
+		m_motorTurnOffStart = std::chrono::steady_clock::now();
+		break;
+
+	case QueueCommand::qcMotorOff:
+		m_motorTurnOffEnabled = false;
+		internalSetMotorStatus(false);
+		m_motorSpinningUp = false;
+		m_motorIsReady = false;
+		m_lastWroteTo = -1;
+		m_readLoops = 0;
+		break;
+
+	case QueueCommand::qcSelectDiskSide:
+		m_actualFloppySide = info.option.b ? DiskSurface::dsUpper : DiskSurface::dsLower;
+		setActiveSurface(m_actualFloppySide);
+		m_lastWroteTo = -1;
+		m_readLoops = 0;
+		break;
+
+	// When we get here we signal we're here and wait to be released
+	case QueueCommand::qcDirectLock:
+		{
+			std::lock_guard lock(m_directModeReadyLock);
+			m_driveLockReady = true;
+			m_driveLockReleased = false;
+			m_directModeReady.notify_one();
+		}
+		{
+			std::unique_lock lck(m_directModeReadyLock);
+			m_directModeRelease.wait(lck, [this] { return m_driveLockReleased; });
+		}
+		break;
+
+	case QueueCommand::writeMFMData:
+		// Grab the item
+		TrackToWrite track;
+		{
+			std::lock_guard lock(m_pendingWriteLock);
+			if (m_pendingTrackWrites.empty()) return;
+			track = m_pendingTrackWrites.front();
+			m_pendingTrackWrites.erase(m_pendingTrackWrites.begin());
+		}
+		// Is there data to write?
+		if (track.floppyBufferSizeBits) {
+			if (m_actualCurrentCylinder != track.trackNumber) {
+				m_actualCurrentCylinder = track.trackNumber;
+				setCurrentCylinder(track.trackNumber);
+			}
+			if (m_actualFloppySide != track.side) {
+				m_actualFloppySide = track.side;
+				setActiveSurface(track.side);
+			}
+			// This isn't great.  IF this fails it might be hard for WinUAE to know.
+			writeData(track.mfmBuffer, track.floppyBufferSizeBits, track.writeFromIndex, m_actualCurrentCylinder >= WRITE_PRECOMP_START);				
+			// Wipe the copies of the previous version of this
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].current.ready = false;
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].last.ready = false;
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next.ready = false;
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].current.supportsSmartSpeed = false;
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].last.supportsSmartSpeed = false;
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].next.supportsSmartSpeed = false;
+			m_mfmRead[m_actualCurrentCylinder][(int)m_actualFloppySide].startBitPatterns.valid = false;
+			m_delayStreaming = false;
+			// Delay the completion until we've read a track back
+			m_writeCompletePending = true;
+			m_writePending = false;
+		}
+
+		break;
+
+	default:
+		break;
+	}
+}
+
+// For direct mode, allows you to lock the main thread queue so you can directly use the drive
+void CommonBridgeTemplate::threadLockControl(bool enter) {
+	if (!m_directMode) return;
+
+	if (!m_control) return;
+
+	if (enter) {
+		std::chrono::time_point<std::chrono::steady_clock> startTime = std::chrono::steady_clock::now();;
+
+		if (!m_driveLockReleased) return;
+		// Reset flags
+		{
+			std::lock_guard lock(m_directModeReadyLock);
+			m_driveLockReady = false;
+		}
+
+		// Queue the request for exclusive access
+		queueCommand(QueueCommand::qcDirectLock);
+		// Wait for it
+		std::unique_lock lck(m_directModeReadyLock);
+		m_directModeReady.wait(lck, [this] { return m_driveLockReady; });
+
+
+		const auto timePassedSinceSeek = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
+	} else {
+		std::chrono::time_point<std::chrono::steady_clock> startTime = std::chrono::steady_clock::now();;
+
+		if (!m_driveLockReady) return;
+		// Notify we're done
+		std::lock_guard lock(m_directModeReadyLock);
+		m_driveLockReleased = true;
+		m_directModeRelease.notify_one();
+
+		const auto timePassedSinceSeek = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
+	}
+}
+
+// This is called prior to closing down, but should reverse initialise
+void CommonBridgeTemplate::shutdown() {
+	terminate();
+	closeInterface();
+}
+
+// Called to reverse initialise.  This will automatically be called in the destructor too.
+void CommonBridgeTemplate::terminate() {
+
+	if (m_control) {
+		queueCommand(QueueCommand::qcTerminate);
+
+		if (m_control->joinable())
+			m_control->join();
+
+		delete m_control;
+		m_control = nullptr;
+	}
+
+	m_lastError = "";
+}
+
+// Startup.  This will display an error message if there's an issue with the interface
+bool CommonBridgeTemplate::initialise() {
+	// Stop first
+	if (m_control) shutdown();
+
+	// Setup some initial values
+	m_currentTrack = 0;
+	m_isMotorRunning = false;
+	m_motorIsReady = false;
+	m_writeProtected = true;
+	m_diskInDrive = false;
+	m_inHDMode = false;
+	m_autoCacheMotorStatus = false;
+	m_actualFloppySide = DiskSurface::dsLower;
+	m_floppySide = DiskSurface::dsLower;
+	m_actualCurrentCylinder = m_currentTrack;
+
+	// Clear down the queue
+	{
+		std::lock_guard lock(m_queueProtect);
+		m_queue.clear();
+	}
+	
+	m_lastError = "";
+
+	// Setup
+	if (openInterface(m_lastError)) {
+		setMotorStatus(false);
+		internalSetMotorStatus(false);
+		m_autoCacheMotorStatus = false;
+		setActiveSurface(m_actualFloppySide);
+		setCurrentCylinder(0);
+
+		// Get some real disk status values
+		if (supportsDiskChange()) {
+			m_diskInDrive = getDiskChangeStatus(true);
+		}
+		else {
+			m_diskInDrive = attemptToDetectDiskChange();
+		}
+		m_writeProtected = checkWriteProtectStatus(true);
+		// Request the type of disk before we let the OS know a disk has actually been inserted
+		internalCheckDiskDensity(false); 
+
+		// Startup the thread
+		m_control = new std::thread([this]() {
+#ifdef _WIN32
+			SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+#else
+			struct sched_param sch;
+			int policy;
+			pthread_getschedparam(pthread_self(), &policy, &sch);
+			policy = SCHED_RR;
+			sch.sched_priority = sched_get_priority_max(policy); // boost priority
+			pthread_setschedparam(pthread_self(), policy, &sch);
+#endif
+			this->mainThread();
+		});
+
+		// Success
+		return true;
+	}
+
+	return false;
+}
+
+// Call to get the last error message.  Length is the size of the buffer in TCHARs, the function returns the size actually needed
+const char* CommonBridgeTemplate::getLastErrorMessage() {
+	return m_lastError.c_str();
+}
+
+// Reset the drive.  This should reset it to the state it would be at power up
+bool CommonBridgeTemplate::resetDrive(int trackNumber) {
+	// Delete all future writes
+	{
+		std::lock_guard lock(m_pendingWriteLock);
+		m_pendingTrackWrites.clear();
+	} 
+
+	// Reset flag
+	{
+		std::lock_guard lock(m_driveResetStatusFlagLock);
+		m_driveResetStatus = false;
+	}
+	queueCommand(QueueCommand::qcResetDrive);
+
+	// Wait for the reset to occur.  At this point we know the queue is also clear
+	std::unique_lock lck(m_driveResetStatusFlagLock);
+	m_driveResetStatusFlag.wait(lck, [this] { return m_driveResetStatus; });
+
+	// Ready
+	return true;
+}
+
+// Set the status of the motor. 
+void CommonBridgeTemplate::setMotorStatus(bool side, bool turnOn) {
+	switchDiskSide(side);
+
+	if (m_isMotorRunning == turnOn) return;
+	m_isMotorRunning = turnOn;
+
+	m_motorIsReady = false;
+	m_motorSpinningUp = false;
+
+	if (turnOn) {
+		{
+			// Remove any turn off commands in the queue
+			std::lock_guard lock(m_queueProtect);
+			if (!m_queue.empty()) {
+				switch (m_queue.back().command) {
+				case QueueCommand::qcMotorOff:
+				case QueueCommand::qcMotorOffDelay:
+					m_queue.back().command = QueueCommand::qcNOP;
+					break;
+				}
+			}
+		}
+	
+		queueCommand(QueueCommand::qcMotorOn);
+	}
+	else {
+		queueCommand(QueueCommand::qcMotorOffDelay);
+	}
+
+}
+
+// Handle the drive stepping to track -1 - this is used to 'no-click' detect the disk
+void CommonBridgeTemplate::handleNoClickStep(bool side) {
+	switchDiskSide(side);
+
+	queueCommand(QueueCommand::qcNoClickSeek);
+	m_lastSeek = std::chrono::steady_clock::now();
+}
+
+// Seek to a specific track
+void CommonBridgeTemplate::gotoCylinder(int trackNumber, bool side) {
+	if (m_currentTrack == trackNumber) {
+		switchDiskSide(side);
+		return;
+	}
+	m_floppySide = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+	resetWriteBuffer();
+	m_currentTrack = trackNumber;
+
+	bool queueUpdated = false;
+
+	// We want to see if there are other 'goto track' commands in the queue just before this one.  If there is, we can replace them
+	{
+		std::lock_guard lock(m_queueProtect);
+		if (!m_queue.empty()) {
+			if (m_queue.back().command == QueueCommand::qcGotoToTrack) {
+				m_queue.back().option.i = (trackNumber * 2) + (side ? 1 : 0);
+				queueUpdated = true;
+				if (!m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+					std::lock_guard lock(m_readBufferAvailableLock);
+					m_readBufferAvailable = false;
+				}
+			}
+		}
+	}
+
+	// Nope? Well we'll just add it then
+	if (!queueUpdated) {
+		if (!m_mfmRead[m_currentTrack][(int)m_floppySide].current.ready) {
+			std::lock_guard lock(m_readBufferAvailableLock);
+			m_readBufferAvailable = false;
+		}
+
+		queueCommand(QueueCommand::qcGotoToTrack, (trackNumber * 2) + (side ? 1 : 0), true);
+	}
+
+	m_lastSeek = std::chrono::steady_clock::now();
+}
+
+// Reset and clear out any data we have received thus far
+void CommonBridgeTemplate::resetWriteBuffer() {
+	m_currentWriteTrack.writeFromIndex = false;
+	m_currentWriteTrack.floppyBufferSizeBits = 0;
+	m_currentWriteTrack.trackNumber = -1;
+	m_currentWriteStartMfmPosition = 0;
+}
+
+// A special mode that DISABLES FloppyBridge from auto-reading tracks and allows writeMFMTrackToBuffer and getMFMTrack to operate directly.
+bool CommonBridgeTemplate::setDirectMode(bool directModeEnable) {
+	m_directMode = directModeEnable;
+	abortDiskReading();
+	threadLockControl(true);
+	threadLockControl(false);
+	resetMFMCache();
+
+	// Wait for queue to empty
+	for (;;) {
+		{
+			std::lock_guard lock(m_queueProtect);
+			if (m_queue.empty()) return true;
+		}
+#ifdef _WIN32
+		Sleep(100);
+#else
+		usleep(100000);
+#endif
+	}
+
+	return true;
+}
+
+#include <algorithm>
+#include <cstring>
+
+// write data to the MFM track buffer to be written to disk - poll isWriteComplete to check for completion
+bool CommonBridgeTemplate::writeMFMTrackToBuffer(bool side, unsigned int track, bool writeFromIndex, int sizeInBytes, void* mfmData) {
+	if (m_directMode) {
+		threadLockControl(true);
+
+		// Goto the correct track
+		if ((m_actualCurrentCylinder != track) || (m_currentTrack != track)) {
+			if (!setCurrentCylinder(track)) {
+				threadLockControl(false);
+				return false;
+			}
+			m_actualCurrentCylinder = track;
+			m_currentTrack = track;
+			m_autocacheModifiedCurrentCylinder = false;
+			m_lastWroteTo = -1;
+		}
+
+		// Do the write
+		DiskSurface _side = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+		if (m_actualFloppySide != _side) {
+			m_actualFloppySide = _side;
+			setActiveSurface(_side);
+		}
+			
+		bool ret = writeData((const unsigned char*)mfmData, sizeInBytes * 8, writeFromIndex, m_actualCurrentCylinder >= WRITE_PRECOMP_START);
+		// Delay the completion until we've read a track back
+		m_writeCompletePending = false;
+		m_writePending = false;
+		m_writeComplete = true;
+
+		// Prevent disk check while we're doing this
+		m_lastDiskCheckTime = std::chrono::steady_clock::now();
+
+		// Release thread
+		threadLockControl(false);
+
+		return ret;
+	}
+
+
+	gotoCylinder(track, side);
+
+	// Prevent background reading while we're busy
+	m_delayStreaming = true;
+	m_delayStreamingStart = std::chrono::steady_clock::now();
+	abortDiskReading();
+
+	sizeInBytes = std::min(sizeInBytes, (MFM_BUFFER_MAX_TRACK_LENGTH * 8) - 16);
+#ifdef _WIN32
+	memcpy_s(m_currentWriteTrack.mfmBuffer, sizeof(m_currentWriteTrack.mfmBuffer), mfmData, sizeInBytes);
+#else
+	memcpy(m_currentWriteTrack.mfmBuffer, mfmData, sizeInBytes);
+#endif
+	m_currentWriteTrack.floppyBufferSizeBits = sizeInBytes * 8;
+
+	m_writePending = false;
+	m_writeComplete = false;
+	m_writeCompletePending = false;
+
+	m_currentWriteTrack.trackNumber = track;
+	m_currentWriteTrack.side = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+	m_currentWriteStartMfmPosition = writeFromIndex ? 0 : 31;
+
+	return commitWriteBuffer(side, track) > 0;
+}
+
+// Submits a single WORD of data received during a DMA transfer to the disk buffer.  This needs to be saved.  It is usually flushed when commitWriteBuffer is called
+// You should reset this buffer if side or track changes
+void CommonBridgeTemplate::writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) {
+	gotoCylinder(track, side);
+
+	// Prevent background reading while we're busy
+	m_delayStreaming = true;
+	m_delayStreamingStart = std::chrono::steady_clock::now();
+	abortDiskReading();	
+
+	// Check there is enough space left.  Bytes to bits, then 16 bits for the next block of data
+	if (m_currentWriteTrack.floppyBufferSizeBits < (MFM_BUFFER_MAX_TRACK_LENGTH * 8) - 16) {
+		if (m_currentWriteTrack.floppyBufferSizeBits == 0) {
+			m_writePending = false;
+			m_writeComplete = false;
+			m_writeCompletePending = false;
+
+			m_currentWriteTrack.trackNumber = track;
+			m_currentWriteTrack.side = side ? DiskSurface::dsUpper : DiskSurface::dsLower;
+			m_currentWriteStartMfmPosition = mfmPosition;
+		}
+		m_currentWriteTrack.mfmBuffer[m_currentWriteTrack.floppyBufferSizeBits >> 3] = mfmData >> 8;
+		m_currentWriteTrack.mfmBuffer[(m_currentWriteTrack.floppyBufferSizeBits >> 3) + 1] = mfmData & 0xFF;
+		m_currentWriteTrack.floppyBufferSizeBits += 16;
+	}	
+}
+ 
+// Return TRUE if there is data ready to be committed to disk
+bool CommonBridgeTemplate::isReadyToWrite() {
+	return (m_currentWriteTrack.floppyBufferSizeBits);
+}
+
+// Requests that any data received via writeShortToBuffer be saved to disk. The side and track should match against what you have been collected
+// and the buffer should be reset upon completion.  You should return the new track length (maxMFMBitPosition) with optional padding if needed
+unsigned int CommonBridgeTemplate::commitWriteBuffer(bool side, unsigned int track) {
+	gotoCylinder(track, side);
+
+	// Prevent background reading while we're busy
+	m_delayStreaming = true;
+	m_delayStreamingStart = std::chrono::steady_clock::now();
+	abortDiskReading();
+
+	// If there was data?
+	if ((m_currentWriteTrack.floppyBufferSizeBits) && (m_currentWriteTrack.trackNumber == track) && (m_currentWriteTrack.side == (side ? DiskSurface::dsUpper : DiskSurface::dsLower))) {
+		// Roughly accurate	
+		m_currentWriteTrack.writeFromIndex = (m_currentWriteStartMfmPosition <= 30) || (m_currentWriteStartMfmPosition >= maxMFMBitPosition() - 30);
+
+		// Add a small amount of data to the end
+		if (m_currentWriteTrack.floppyBufferSizeBits < (MFM_BUFFER_MAX_TRACK_LENGTH * 8) - 16) {
+			m_currentWriteTrack.mfmBuffer[m_currentWriteTrack.floppyBufferSizeBits >> 3] = 0x55;
+			m_currentWriteTrack.mfmBuffer[(m_currentWriteTrack.floppyBufferSizeBits >> 3) + 1] = 0x55;
+			m_currentWriteTrack.floppyBufferSizeBits += 8;
+		}
+
+		{
+			std::lock_guard lock(m_pendingWriteLock);
+			m_pendingTrackWrites.push_back(m_currentWriteTrack);
+			m_writePending = true;
+			queueCommand(QueueCommand::writeMFMData);
+			{
+				std::lock_guard lock2(m_switchBufferLock);
+
+				// Prevent old data being read back by WinUAE
+				MFMCaches* cache = &m_mfmRead[track][(int)m_floppySide];
+				cache->current.ready = false;
+				cache->last.ready = false;
+				cache->next.ready = false;
+				cache->startBitPatterns.valid = false;
+			}
+		}
+	}
+
+	resetWriteBuffer();
+
+	return maxMFMBitPosition();
+}
+
+// Returns TRUE if commitWriteBuffer has been called but not written to disk yet
+bool CommonBridgeTemplate::isWritePending() {
+	return m_writePending;
+}
+
+// Returns TRUE if a write is no longer pending.  This should only return TRUE the first time, and then should reset
+bool CommonBridgeTemplate::isWriteComplete() {
+	std::lock_guard lock(m_writeLockCompleteFlag);
+
+	bool ret = m_writeComplete;
+	m_writeComplete = false;
+	
+	return ret;
+}
+
+

--- a/vendor/floppybridge/src/CommonBridgeTemplate.h
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.h
@@ -1,0 +1,554 @@
+#ifndef COMMON_BRIDGE_TEMPLATE
+#define COMMON_BRIDGE_TEMPLATE
+/* CommonBridgeTemplate for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+* 
+* This library is multi-licensed under the terms of the Mozilla Public 
+* License Version 2.0 as published by Mozilla Corporation and the 
+* GNU General Public License, version 2 or later, as published by the 
+* Free Software Foundation.
+* 
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+*/
+
+/*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// As both the implementations (as far as the "bridge" is concerned are almost identical
+// I have merged the common parts into this class so only the differences are in the 
+// respective ones.  This is a good template for future devices to base off of
+//////////////////////////////////////////////////////////////////////////////////////////
+// Everything in protected needs implementing, but that's a lot less logic than on your own
+// All the thread sync and WinUAE i/o is done for you in this class
+
+#include <string>
+#include <thread>
+#include <functional>
+#include <queue>
+#include <vector>
+#include <deque>
+#include <mutex>
+#include <condition_variable>
+#include "floppybridge_abstract.h"
+#include "RotationExtractor.h"
+#include "floppybridge_common.h"
+#include "pll.h"
+
+// Maximum data we can receive.  
+#define MFM_BUFFER_MAX_TRACK_LENGTH			(0x3A00 * 2)
+
+// Max number of cylinders we can offer
+#define MAX_CYLINDER_BRIDGE 84
+
+
+// Bit-mask of options that can be configured in BridgeDriver::configOptions
+#define CONFIG_OPTIONS_AUTOCACHE            1
+#define CONFIG_OPTIONS_COMPORT				2
+#define CONFIG_OPTIONS_COMPORT_AUTODETECT	4
+#define CONFIG_OPTIONS_DRIVE_AB				8
+#define CONFIG_OPTIONS_SMARTSPEED			16
+#define CONFIG_OPTIONS_DRIVE_123			32
+
+
+// Some of the functions in FloppyDiskBridge are implemented, some not.
+class CommonBridgeTemplate : public FloppyDiskBridge {
+protected:
+	// Type of queue message
+	enum class QueueCommand { qcTerminate, qcMotorOn, qcMotorOff, qcMotorOffDelay, writeMFMData, qcGotoToTrack, qcSelectDiskSide, qcResetDrive, qcNoClickSeek, qcDirectLock, qcNOP};
+
+	// Represent which side of the disk we're looking at.  
+	enum class DiskSurface {
+		dsUpper = 1,            // The upper side of the disk
+		dsLower = 0				// The lower side of the disk
+	};
+
+	// Possible responses from the read command
+	enum class ReadResponse { rrOK, rrError, rrNoDiskInDrive };
+
+	// So you can change the status of this as you detect it, for example, after a seek, or surface change, or after disk change effect
+	void setWriteProtectStatus(const bool isWriteProtected) { m_writeProtected = isWriteProtected; }
+
+	// Returns TRUE if we should be making a manual check for the presence of a disk
+	bool isReadyForManualDiskCheck();
+
+	// Called if you do something which is classed as a manual check for disk presence etc
+	void updateLastManualCheckTime();
+
+private:
+	// Data to hold in the queue
+	struct QueueInfo {
+		QueueCommand command;
+		union {
+			int i;
+			bool b;
+		} option;
+	};
+
+	// Track data to write
+	struct TrackToWrite {
+		// Which track to write it to
+		unsigned char mfmBuffer[MFM_BUFFER_MAX_TRACK_LENGTH];
+
+		// Which side to write it to
+		DiskSurface side;
+
+		// Which track to write to
+		unsigned char trackNumber;
+
+		// Size of the above buffer in bits
+		unsigned int floppyBufferSizeBits;
+
+		// Should we start writing from the INDEX pulse?
+		bool writeFromIndex;
+	};
+
+	// Protect the above vector in the multi-threaded environment
+	std::mutex m_pendingWriteLock;
+	std::mutex m_writeLockCompleteFlag;
+
+	// A list of writes that still need to happen to a disk
+	std::vector<TrackToWrite> m_pendingTrackWrites;
+
+	// The current track being written to (or more accurately read from WinUAE)
+	TrackToWrite m_currentWriteTrack;
+
+	// The last track that was written to, this is cylinder*2 + side
+	int m_lastWroteTo = -1;
+
+	// For extracting rotations from disks
+	RotationExtractor m_extractor;
+
+	// For doing the same as above, but no searching for rotations, just get the data
+	LinearExtractor m_linearExtractor;
+
+	// In direct mode FloppyBridge doesnt do some functions in the background
+	// Its useful if you're using FloppyBridge just for direct access to the interfaces
+	bool m_directMode;
+	std::mutex m_directModeReadyLock;
+	std::condition_variable m_directModeReady;
+	std::condition_variable m_directModeRelease;
+	bool m_driveLockReleased = true;
+	bool m_driveLockReady = false;
+
+	// PLL for running data through
+	PLL::BridgePLL m_pll;
+
+	// Current stored position for receiving data t be written from WinUAE
+	int m_currentWriteStartMfmPosition;
+
+	// If we should pause streaming data from the disk
+	bool m_delayStreaming;
+
+	// When the above delay started
+	std::chrono::time_point<std::chrono::steady_clock> m_delayStreamingStart;
+
+	// Set to TRUE if the motor will be turned off shortly
+	bool m_motorTurnOffEnabled;
+
+	// When the above flag became true
+	std::chrono::time_point<std::chrono::steady_clock> m_motorTurnOffStart;
+
+	// An Event to wait for the drive reset operation to happen (the queue will be clear afterwards)
+	std::mutex m_driveResetStatusFlagLock;
+	std::condition_variable m_driveResetStatusFlag;
+	bool m_driveResetStatus;
+
+	// An event to signal if the drive is currently being read
+	bool m_driveStreamingData;
+
+	// This flag gets set if we're being sneaky and reading the opposite disk side
+	bool m_isCurrentlyHeadCheating;
+
+	// Cache of drive read data
+	struct MFMCache {
+		// Buffer for current data.  This is a circular buffer
+		RotationExtractor::MFMSample mfmBuffer[MFM_BUFFER_MAX_TRACK_LENGTH];
+
+		// If this is a complete revolution or not
+		bool ready;
+
+		// Size fo the mfm data we actually have (in bits) so far
+		int amountReadInBits;
+
+		// If the data on this track looks like it should support smart speed
+		bool supportsSmartSpeed;
+	};
+
+	// Current disk cache history
+	struct MFMCaches {
+		// Currently being read by WinUAE version of this track
+		MFMCache current;
+		// The last buffer we swapped out.  We keep several buffers on the go to combat 'weak transitions' and also help with disk errors
+		MFMCache last;
+		// The track we're about to read in
+		MFMCache next;
+		// For tracking what the index looks like
+		RotationExtractor::IndexSequenceMarker startBitPatterns;
+	};
+
+	// Cache of entire disk (or what we have so far)
+	MFMCaches m_mfmRead[MAX_CYLINDER_BRIDGE][2];
+
+	// The main thread
+	std::thread* m_control;
+
+	// Current mode that the bridge operates in
+	FloppyBridge::BridgeMode m_bridgeMode;
+
+	// Hwo to handle HD and DD disks
+	FloppyBridge::BridgeDensityMode m_bridgeDensity;
+
+	// If we're currently in HD mode
+	bool m_inHDMode;
+
+	// Enables auto-caching in the background while the drive is idle
+	bool m_shouldAutoCache;
+
+	// Auto-cache data
+	std::chrono::time_point<std::chrono::steady_clock> m_autoCacheMotorStart;
+	bool m_autoCacheMotorStatus;
+	bool m_autocacheModifiedCurrentCylinder;
+
+	// The track we tell WinUAE we're on
+	int m_currentTrack;
+
+	// The actual track we're on
+	int m_actualCurrentCylinder;
+
+	// For reporting to WinUAE if the disk is write protected
+	bool m_writeProtected;
+
+	// True if a write has been committed but hasn't completed yet
+	bool m_writePending;
+
+	// True if a write has completed.  
+	bool m_writeComplete;
+
+	// When we're about to say its completed
+	bool m_writeCompletePending;
+
+	// For reporting to WinUAE if there's a disk in the drive
+	bool m_diskInDrive;
+
+	// This is set to TRUE to inform the system we're going to read the first cylinder (both sides) before we officially tell UAE the drive is ready.
+	bool m_firstTrackMode;
+
+	// If Smart Speed should be used
+	bool m_useSmartSpeed;
+
+	// Set to true while the motor is spinning up, but not there yet
+	bool m_motorSpinningUp;
+
+	// Set to when the motor started spinning up
+	std::chrono::time_point<std::chrono::steady_clock> m_motorSpinningUpStart;
+
+	// When the last seek operation occured
+	std::chrono::time_point<std::chrono::steady_clock> m_lastSeek;
+
+	// Number of reads since step or head change
+	uint32_t m_readLoops;
+
+	// Set to true once the motor is spun up
+	bool m_motorIsReady;
+
+	// Bool flag from what WinUAE has asked of us regarding motor status
+	bool m_isMotorRunning;
+
+	// When we last checked to see if a disk was still in the drive (you cant tell without moving the head)
+	std::chrono::time_point<std::chrono::steady_clock> m_lastDiskCheckTime;
+
+	// A queue to hold the commands to process on the thread
+	std::deque<QueueInfo> m_queue;
+
+	// A lock to prevent the queue being accessed in two places at once
+	std::mutex m_queueProtect;
+
+	// A lock to prevent buffer switch being accessed or changed in two places at once
+	std::mutex m_switchBufferLock;
+
+	// An event that is set the moment data is available
+	std::mutex m_readBufferAvailableLock;
+	std::condition_variable m_readBufferAvailableFlag;
+	bool m_readBufferAvailable;
+
+	// Error messages
+	std::string m_lastError;
+
+	// The side WinUAE think's we're on
+	DiskSurface m_floppySide;
+
+	// The side we're actually on
+	DiskSurface m_actualFloppySide;
+
+	// If it returns TRUE, this is the next cylinder and side that should be cached in the background
+	bool getNextTrackToAutoCache(int& cylinder, DiskSurface& side);
+
+	// Manage motor status
+	void internalSetMotorStatus(bool enabled);
+
+	// Handle caching track data in the background
+	void handleBackgroundCaching();
+
+	// The main thread
+	void mainThread();
+
+	// Add a command for the thread to process
+	void queueCommand(const QueueCommand command, const bool optionB, const bool shouldAbortStreaming = true);
+	void queueCommand(const QueueCommand command, const int optionI = 0, const bool shouldAbortStreaming = true);
+
+	// Push a specific message onto the queue
+	void pushOntoQueue(const QueueInfo& info, const bool shouldAbortStreaming = true, bool insertAtStart = false);
+
+	// Handle processing the command
+	void processCommand(const QueueInfo& info);
+
+	// Handle background reading
+	void handleBackgroundDiskRead();
+
+	// Reset the current MFM buffer used by readMFMBit()
+	void resetMFMCache();
+
+	// Called to reverse initialise.  This will automatically be called in the destructor too.
+	void terminate();
+
+	// Handle disk side change
+	void switchDiskSide(const bool side);
+
+	// Process the queue.  Return TRUE if the thread should quit
+	bool processQueue();
+
+	// This is called to switch to a different copy of the track so multiple revolutions can ve read
+	void internalSwitchCylinder(const int cylinder, const DiskSurface side);
+
+	// Save a new disk side and switch it in if it can be
+	void saveNextBuffer(const int cylinder, const DiskSurface side);
+
+	// Reset and clear out any data we have received thus far
+	void resetWriteBuffer();
+
+	// Internally check the disk density
+	void internalCheckDiskDensity(bool newDiskInserted);
+
+	// Scans the MFM data to see if this track should allow smart speed or not based on timing data
+	void checkSmartSpeed(const int cylinder, const DiskSurface side, MFMCache& track);
+
+	// Check if the motor should be turned off
+	void checkMotorOff();
+
+	// For direct mode, allows you to lock the main thread queue so you can directly use the drive
+	void threadLockControl(bool enter);
+protected:
+	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Stuff that you need to implement in your derived class, a lot less than on the original bridge - These are all allowed to block as they're called from a thread
+	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+	// Return the number of milliseconds required for the disk to spin up.  You *may* need to override this
+	virtual const unsigned int getDriveSpinupTime() { return 500; }
+
+	// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+	virtual void checkDiskType() {}
+
+	// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+	virtual void forceDiskDensity(bool forceHD) {}
+
+	// If your device supports being able to abort a disk read, mid-read then implement this
+	virtual void abortDiskReading() {}
+
+	// This is called by the main thread in case you need to do anything specific at regular intervals
+	virtual void poll() {}
+
+	// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+	virtual bool supportsDiskChange()  = 0;
+
+	// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+	// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+	virtual bool getDiskChangeStatus(const bool forceCheck)  = 0;
+
+	// Called when the class is about to shut down
+	virtual void closeInterface()  = 0;
+
+	// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+	virtual bool openInterface(std::string& errorMessage)  = 0;
+
+	// Called to ask the drive what the current write protect status is - return true if its write protected.  If forceCheck is true you should actually check the drive, 
+	// else use the last status checked which was probably from a SEEK setCurrentCylinder call.  If you can ONLY get this information here then you should always force check
+	virtual bool checkWriteProtectStatus(const bool forceCheck)  = 0;
+
+	// Get the name of the drive
+	virtual const BridgeDriver* _getDriverInfo()  = 0;
+
+	// Return the type of the drive
+	virtual const DriveTypeID _getDriveTypeID()  = 0;
+
+	// Called to switch which head is being used right now.  Returns success or not
+	virtual bool setActiveSurface(const DiskSurface activeSurface)  = 0;
+
+	// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+	virtual bool setMotorStatus(const bool switchedOn)  = 0;
+
+	// Trigger a seek to the requested cylinder, this can block until complete
+	virtual bool setCurrentCylinder(const unsigned int cylinder)  = 0;
+
+	// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+	// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+	// Return FALSE if this is not supported by the bridge
+	virtual bool performNoClickSeek() = 0;
+
+	// Called when data should be read from the drive.
+	//		pll:           To handle all of your reading and writing, if needed
+	//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+	// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+	//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+	//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+		std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation)  = 0;
+
+	// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+	//		pll:           required 
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readLinearData(PLL::BridgePLL& pll) = 0;
+
+	// Called when a cylinder revolution should be written to the disk.
+	// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+	//					numBytes						Number of bits in the buffer to write
+	//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+	//					suggestUsingPrecompensation		A suggestion that you might want to use write pre-compensation, optional
+	// Returns TRUE if success, or false if it fails.  Largely doesn't matter as most stuff should verify with a read straight after
+	virtual bool writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation)  = 0;
+
+	// A manual way to check for disk change.  This is simulated by issuing a read message and seeing if there's any data.  Returns TRUE if data or an INDEX pulse was detected
+	// It's virtual as the default method issues a read and looks for data.  If you have a better implementation then override this
+	virtual bool attemptToDetectDiskChange()  = 0;
+
+public:
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// All the public functions are already implemented for you
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// 
+	// Flags from WINUAE
+	CommonBridgeTemplate(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool shouldAutoCache, bool useSmartSpeed);
+	virtual ~CommonBridgeTemplate();
+
+	// Change to a different bridge-mode (in real-time)
+	void changeBridgeMode(FloppyBridge::BridgeMode bridgeMode);
+
+	// Change to a different bridge-density (in real-time)
+	void changeBridgeDensity(FloppyBridge::BridgeDensityMode bridgeDensity);
+
+	// Call to start the system up
+	virtual bool initialise() override final;
+
+	// This is called prior to closing down, but should reverse initialise
+	virtual void shutdown() override final;
+
+	// Returns the name of interface.  This pointer should remain valid after the class is destroyed
+	virtual const BridgeDriver* getDriverInfo() override final { return _getDriverInfo(); }
+
+	// Return the type of disk connected
+	virtual DriveTypeID getDriveTypeID() override final { return _getDriveTypeID(); }
+
+	// Call to get the last error message.  If the string is empty there was no error
+	virtual const char* getLastErrorMessage() override final;
+
+	// Return TRUE if the drive is currently on cylinder 0
+	virtual bool isAtCylinder0() override final { return m_currentTrack == 0; }
+
+	// Return the number of cylinders the drive supports.
+	virtual unsigned char getMaxCylinder() override final { return MAX_CYLINDER_BRIDGE; }
+
+	// Return true if the motor is spinning
+	virtual bool isMotorRunning() override final { return m_isMotorRunning; }
+
+	// Returns TRUE when the last command requested has completed
+	virtual bool isReady() override;
+
+	// Return TRUE if there is a disk in the drive, else return false.  Some drives don't detect this until the head moves once
+	virtual bool isDiskInDrive() override final { return m_diskInDrive; }
+
+	// Check if the disk has changed.  Basically returns FALSE if there's no disk in the drive
+	virtual bool hasDiskChanged() override final { return !m_diskInDrive; }
+
+	// Returns the currently selected side
+	virtual bool getCurrentSide() override final { return m_floppySide == DiskSurface::dsUpper; }
+
+	// Return the current track number we're on
+	virtual unsigned char getCurrentCylinderNumber() override final { return m_currentTrack; }
+
+	// Return TRUE if the currently inserted disk is write protected
+	virtual bool isWriteProtected() override final { return m_writeProtected; }
+
+	// Get the speed at this position.  1000=100%.  
+	virtual int getMFMSpeed(const int mfmPositionBits) override final;
+
+	// Returns TRUE if data is ready and available
+	virtual bool isMFMDataAvailable() override final;
+
+	// Requests an entire track of data.  Returns 0 if the track is not available
+	// The return value is the wrap point in bits (last byte is shifted to MSB)
+	virtual int getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) override final;
+
+	// write data to the MFM track buffer to be written to disk - poll isWriteComplete to check for completion
+	virtual bool writeMFMTrackToBuffer(bool side, unsigned int track, bool writeFromIndex, int sizeInBytes, void* mfmData) override final;
+
+	// A special mode that DISABLES FloppyBridge from auto-reading tracks and allows writeMFMTrackToBuffer and getMFMTrack to operate directly.
+	virtual bool setDirectMode(bool directModeEnable) override final;
+
+	// While not doing anything else, the library should be continuously streaming the current track if the motor is on.  mfmBufferPosition is in BITS 
+	virtual bool getMFMBit(const int mfmPositionBits) override final;
+
+	// Set the status of the motor. 
+	virtual void setMotorStatus(bool side, bool turnOn) override final;
+
+	// Return the maximum size of the internal track buffer in BITS
+	virtual int maxMFMBitPosition() override final;
+
+	// This is called to switch to a different copy of the track so multiple revolutions can ve read
+	virtual void mfmSwitchBuffer(bool side) override final;
+
+	// Quick confirmation from UAE that we're actually on the same side
+	virtual void setSurface(bool side) override final;
+
+	// Seek to a specific track
+	virtual void gotoCylinder(int trackNumber, bool side) override final;
+
+	// Handle the drive stepping to track -1 - this is used to 'no-click' detect the disk
+	virtual void handleNoClickStep(bool side) override final;
+
+	// Submits a single WORD of data received during a DMA transfer to the disk buffer.  This needs to be saved.  It is usually flushed when commitWriteBuffer is called
+	// You should reset this buffer if side or track changes.  mfmPosition is provided purely for any index sync you may wish to do
+	virtual void writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) override final;
+
+	// Requests that any data received via writeShortToBuffer be saved to disk. The side and track should match against what you have been collected
+	// and the buffer should be reset upon completion.  You should return the new track length (maxMFMBitPosition) with optional padding if needed
+	virtual unsigned int commitWriteBuffer(bool side, unsigned int track) override final;
+
+	// Returns TRUE if commitWriteBuffer has been called but not written to disk yet
+	virtual bool isWritePending() override final;
+
+	// Returns TRUE if a write is no longer pending.  This should only return TRUE the first time, and then should reset
+	virtual bool isWriteComplete() override final;
+
+	// Return TRUE if there is data ready to be committed to disk
+	virtual bool isReadyToWrite() override final;
+
+	// Return TRUE if we're at the INDEX marker
+	virtual bool isMFMPositionAtIndex(int mfmPositionBits) override final;
+
+	// Reset the drive.  This should reset it to the state it would be at power up
+	virtual bool resetDrive(int trackNumber) override final;
+
+	// Set to TRUE if turbo writing is allowed (this is a sneaky DMA bypass trick)
+	virtual bool canTurboWrite() { return true; }
+
+};
+
+#endif

--- a/vendor/floppybridge/src/FloppyBridge.cpp
+++ b/vendor/floppybridge/src/FloppyBridge.cpp
@@ -1,0 +1,1057 @@
+/* FloppyBridge DLL for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+/*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+#include <cstring>
+#include "FloppyBridge.h"
+#include "resource.h"
+
+
+// For compatibility with older methods
+#define ROMTYPE_ARDUINOREADER_WRITER
+#define ROMTYPE_GREASEWEAZLEREADER_WRITER
+#define ROMTYPE_SUPERCARDPRO_WRITER
+
+#include "ArduinoFloppyBridge.h"
+#include "GreaseWeazleBridge.h"
+#include "SuperCardProBridge.h"
+
+/* COPPERLINE: this file is upstream's DLL front-end, and on Windows it also
+   carries WinUAE's native configuration dialogs, their resource script, and a
+   DnsQuery update check. Copperline compiles these sources straight into the
+   emulator and drives them through its own launcher, so none of that is
+   wanted -- and excluding it means the build needs no resource compiler.
+   FLOPPYBRIDGE_NO_GUI is defined by build.rs. Amiberry excludes the same code
+   the same way (their macro is AMIBERRY). See ../README.md. */
+#ifdef _WIN32
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#include <WinSock2.h>
+#ifndef FLOPPYBRIDGE_NO_GUI
+#include "bridgeProfileListEditor.h"
+#include "bridgeProfileEditor.h"
+#include <WinDNS.h>
+#pragma comment(lib, "Dnsapi.lib")
+#endif
+HINSTANCE hInstance;
+
+#else
+#include <netdb.h>
+#endif 
+ 
+#include <unordered_map>
+
+
+
+static FloppyBridge::BridgeAbout BridgeInformation = { "FloppyBridge, Copyright(C) 2021-2024 RobSmithDev", "https://amiga.robsmithdev.co.uk/winuae", 1, 6, 0, 0, 0};
+static FloppyBridge::BridgeAbout BridgeInformationUpdate = { "FloppyBridge UPDATE AVAILABLE, Copyright(C) 2021-2024 RobSmithDev", "https://amiga.robsmithdev.co.uk/winuae", 1, 6, 0, 0, 0 };
+static bool hasUpdateChecked = false;
+static bool enableUsageNotifications = true;
+
+std::vector<SerialIO::SerialPortInformation> serialports;
+#ifdef _WIN32
+std::vector<HBITMAP> bridgeLogos;
+#endif
+std::unordered_map<unsigned int, BridgeConfig*> profileList;
+FloppyBridge::FloppyBridgeProfileInformationDLL* profileCache = nullptr;
+std::string profileStringExported;
+
+
+bool BridgeConfig::fromString(char* serialisedOptions) {
+    // Validate
+    if (strlen(serialisedOptions) < 7) return false;
+    std::string tmp = serialisedOptions;
+
+    size_t pos = tmp.find('[');
+    if (pos == std::string::npos) return false;
+    if (pos) {
+#ifdef _WIN32
+        strcpy_s(profileName, 128, (char*)tmp.substr(0, pos).c_str());
+#else
+        strcpy(profileName, (char*)tmp.substr(0, pos).c_str());
+#endif
+        tmp = tmp.substr(pos);
+    }
+    else {
+        profileName[0] = '\0';
+    }
+
+    if ((tmp[0] != '[') || (tmp[tmp.length() - 1] != ']')) return false;
+    tmp = tmp.substr(1, tmp.length() - 2);
+
+    // Split out
+    std::vector<std::string> params;
+    pos = tmp.find('|');
+    while (pos != std::string::npos) {
+        params.push_back(tmp.substr(0, pos));
+        tmp = tmp.substr(pos + 1);
+        pos = tmp.find('|');
+    }
+    params.push_back(tmp);
+
+    // Parse
+    if (params.size() < 5) return false;
+
+    // Validate it's for this bridge
+    bridgeIndex = atoi(params[0].c_str());
+
+    unsigned int i = atoi(params[1].c_str());
+    autoCache = (i & 1) != 0;
+    driveCable = (FloppyBridge::DriveSelection)(((i & 2)>>1) | ((i & 48) >> 3));
+    autoDetectComPort = (i & 4) != 0;
+    smartSpeed = (i & 8) != 0;
+#ifdef _WIN32
+    strcpy_s(comPortToUse, sizeof(comPortToUse) - 1, params[2].c_str());
+#else
+    strcpy(comPortToUse, params[2].c_str());
+#endif
+
+    i = atoi(params[3].c_str());
+    if (i > (unsigned int)FloppyBridge::BridgeMode::bmMax) return false;
+    bridgeMode = (FloppyBridge::BridgeMode)i;
+
+    i = atoi(params[4].c_str());
+    if (i > (unsigned int)FloppyBridge::BridgeDensityMode::bdmMax) return false;
+    bridgeDensity = (FloppyBridge::BridgeDensityMode)i;
+
+    return true;
+}
+
+void BridgeConfig::toString(char** serialisedOptions) {
+    unsigned int i = (unsigned int)driveCable;
+
+    unsigned int flags = (autoCache ? 1 : 0) | ((i & 1) << 1) | ((i & 6) << 3) | (autoDetectComPort ? 4 : 0) | (smartSpeed ? 8 : 0);
+
+    std::string tmp;
+    tmp = std::string(profileName) + "[" + std::to_string(bridgeIndex) + "|" + std::to_string(flags) + "|" + std::string(comPortToUse) + "|" + std::to_string((unsigned int)bridgeMode) + "|" + std::to_string((unsigned int)bridgeDensity) + "]";
+#ifdef _WIN32
+    strcpy_s(lastSerialise, sizeof(lastSerialise) - 1, tmp.c_str());
+#else
+    strcpy(lastSerialise, tmp.c_str());
+#endif
+
+    (*serialisedOptions) = lastSerialise;
+};
+
+// Returns a pointer to information about the project
+void handleAbout(bool checkForUpdates, FloppyBridge::BridgeAbout** output) {
+#if defined(_WIN32) && !defined(FLOPPYBRIDGE_NO_GUI)
+    checkForUpdates |= BridgeProfileListEditor::shouldAutoCheckForUpdates();
+#endif
+    if ((checkForUpdates) && (!hasUpdateChecked)) {
+        hasUpdateChecked = true;
+
+/* COPPERLINE: the whole update check goes with the dialogs -- it needs
+   WinDNS.h, which the no-GUI build does not include, and Copperline never asks
+   for it (BRIDGE_About is always called with checkForUpdates false). */
+#if defined(_WIN32) && !defined(FLOPPYBRIDGE_NO_GUI)
+        // Start winsock
+        WSADATA data;
+        WSAStartup(MAKEWORD(2, 0), &data);
+
+        DNS_RECORD* dnsRecord;
+        std::wstring versionString;
+
+        // Look up TXT record 
+        DNS_STATUS error = DnsQuery(L"floppybridge-amiga.robsmithdev.co.uk", DNS_TYPE_TEXT, DNS_QUERY_BYPASS_CACHE, NULL, &dnsRecord, NULL);
+        if (!error) {
+            const DNS_RECORD* record = dnsRecord;
+            while (record) {
+                if (record->wType == DNS_TYPE_TEXT) {
+                    const DNS_TXT_DATAW* pData = &record->Data.TXT;
+                    for (DWORD string = 0; string < pData->dwStringCount; string++) {
+                        const std::wstring text = pData->pStringArray[string];
+                        if ((text.length() >= 9) && (text.substr(0, 2) == L"v=")) versionString = text.substr(2);
+                    }
+                }
+                record = record->pNext;
+            }
+            DnsRecordListFree(dnsRecord, DnsFreeRecordList);  //DnsFreeRecordListDeep
+        }
+
+        if (!versionString.empty()) {
+            // A little hacky to convert a.b.c.d into an array
+            sockaddr_in tmp;
+            INT len = sizeof(tmp);
+            if (WSAStringToAddress((wchar_t*)versionString.c_str(), AF_INET, NULL, (sockaddr*)&tmp, &len) == 0) {
+                const in_addr add = tmp.sin_addr;
+                BridgeInformationUpdate.updateMajorVersion = add.S_un.S_un_b.s_b1;
+                BridgeInformationUpdate.updateMinorVersion = add.S_un.S_un_b.s_b2;
+                BridgeInformation.isUpdateAvailable = ((BridgeInformation.majorVersion < BridgeInformation.updateMajorVersion) ||
+                    ((BridgeInformation.majorVersion == BridgeInformation.updateMajorVersion) && (BridgeInformation.minorVersion < BridgeInformation.updateMinorVersion))) ? 1 : 0;
+                BridgeInformationUpdate.isUpdateAvailable = BridgeInformation.isUpdateAvailable;;
+            }
+        }
+/* COPPERLINE: on Windows with the GUI excluded there is no update check at
+   all, rather than falling through to the Unix one. */
+#elif !defined(_WIN32)
+        // Fetch version from 'A' record in the DNS record - this is probably not used by anything anyway
+        hostent* address = gethostbyname("floppybridge-amiga.robsmithdev.co.uk");
+        if ((address) && (address->h_addrtype == AF_INET)) {
+            if (address->h_addr_list[0] != 0) {
+                in_addr add = *((in_addr*)address->h_addr_list[0]);
+                uint32_t bytes = htonl(add.s_addr);
+                BridgeInformationUpdate.updateMajorVersion = bytes >> 24;
+                BridgeInformationUpdate.updateMinorVersion = (bytes >> 16) & 0xFF;
+
+                BridgeInformation.isUpdateAvailable = ((BridgeInformation.majorVersion < BridgeInformation.updateMajorVersion) ||
+                    ((BridgeInformation.majorVersion == BridgeInformation.updateMajorVersion) && (BridgeInformation.minorVersion < BridgeInformation.updateMinorVersion))) ? 1 : 0;
+                BridgeInformationUpdate.isUpdateAvailable = BridgeInformation.isUpdateAvailable;;
+            }
+        }
+#endif
+    }
+#ifdef _WIN32
+    if (output) 
+        if (BridgeInformationUpdate.isUpdateAvailable) *output = (FloppyBridge::BridgeAbout*)&BridgeInformationUpdate; else *output = (FloppyBridge::BridgeAbout*)&BridgeInformation;
+
+#else
+    if (output) *output = (FloppyBridge::BridgeAbout*)&BridgeInformation;
+#endif 
+}
+
+// Get driver information
+bool handleGetDriverInfo(unsigned int driverIndex, FloppyDiskBridge::BridgeDriver** driverInformation) {
+    if (driverIndex >= MAX_NUM_DRIVERS) return false;
+    if (!driverInformation) return false;
+
+    switch (driverIndex) {
+    case 0: *driverInformation = (FloppyDiskBridge::BridgeDriver*)ArduinoFloppyDiskBridge::staticBridgeInformation(); break;
+    case 1: *driverInformation = (FloppyDiskBridge::BridgeDriver*)GreaseWeazleDiskBridge::staticBridgeInformation();  break;
+    case 2: *driverInformation = (FloppyDiskBridge::BridgeDriver*)SupercardProDiskBridge::staticBridgeInformation(); break;
+    default: return false;
+    }
+    return true;
+}
+
+extern "C" {
+
+    // Returns a pointer to information about the project
+    FLOPPYBRIDGE_API void CALLING_CONVENSION BRIDGE_About(bool checkForUpdates, FloppyBridge::BridgeAbout** output) {
+        handleAbout(checkForUpdates, output);
+    }
+
+    // Returns the number of 'Bridge' Drivers available 
+    FLOPPYBRIDGE_API unsigned int CALLING_CONVENSION BRIDGE_NumDrivers(void) {
+        return MAX_NUM_DRIVERS;
+    }
+
+    // Used to turn on or off the windows messages used to disable the virtual drive system while this is in use.
+    // Defaults to TRUE which is what it should do!    
+    FLOPPYBRIDGE_API void CALLING_CONVENSION BRIDGE_EnableUsageNotifications(bool enable) {
+        enableUsageNotifications = enable;
+    }
+
+    // Enumerates the com ports and returns how many of them were found.  
+    // You must call this twice.  the first call output=null (triggers enumeration, and buffers size inc null terminator is copied to outputLength)
+    // Second call you supply suitable buffer (and populate outputLength) and result is copied. String is a null terminated list of strings
+    // Returns if successfully copied or not
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_EnumComports(char* output, unsigned int* outputLength) {
+        if (!output) SerialIO::enumSerialPorts(serialports);
+
+        if (!outputLength) return false;
+
+        size_t lengthRequired = 1; // final null terminator
+        std::string tmp;
+        for (const SerialIO::SerialPortInformation& port : serialports) {
+            quickw2a(port.portName, tmp);
+            lengthRequired += tmp.length() + 1;
+        }
+
+        if (output) {
+            // Enough space now?
+            if (lengthRequired > *outputLength) return false;
+
+            for (const SerialIO::SerialPortInformation& port : serialports) {
+                quickw2a(port.portName, tmp);
+
+                // Copy name
+#ifdef _WIN32
+                memcpy_s(output, lengthRequired, tmp.c_str(), tmp.length());
+#else
+                memcpy(output, tmp.c_str(), tmp.length());
+#endif
+                lengthRequired -= tmp.length();
+
+                // Add separator
+                output += tmp.length();
+                *output = '\0'; output++;
+                lengthRequired--;
+            }
+            // Add terminator
+            *output = '\0'; output++;
+
+            return true;
+        }
+        else {
+            *outputLength = (unsigned int)lengthRequired;
+            return false;
+        }
+    }
+
+    // Returns a pointer to a string which is a serialised result of all of the config options chosen
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_GetConfigString(BridgeOpened* bridgeDriverHandle, char** serialisedOptions) {
+        if (!bridgeDriverHandle) return false;
+        if (!serialisedOptions) return false;
+
+        bridgeDriverHandle->config.toString(serialisedOptions);
+        return true;
+    }
+    // Applies the settings in a serialised string of settings obtained from the above function
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_SetConfigFromString(BridgeOpened* bridgeDriverHandle, char* serialisedOptions) {
+        if (!bridgeDriverHandle) return false;
+        if (!serialisedOptions) return false;
+
+        return bridgeDriverHandle->config.fromString(serialisedOptions);
+    }
+
+    // Used to signal to the virtual drive system that we're going to be using it so let go.
+    void releaseVirtualDrives(bool release, int controllerType) {
+        if (!enableUsageNotifications) return;
+#ifdef _WIN32
+        HWND remoteWindow = FindWindowA("VIRTUALDRIVE_CONTROLLER_CLASS", "DiskFlashback Tray Control");
+        if (remoteWindow) {
+            // Signal to release all interfaces of this type
+            SendMessage(remoteWindow, WM_USER + 2, (controllerType & 0x7FFF) | (release ? 0 : 0x8000), (LPARAM)GetCurrentProcessId());
+        }
+#endif
+    }
+     
+
+#if defined(_WIN32) && !defined(FLOPPYBRIDGE_NO_GUI)
+    // Displays the config dialog (modal) for Floppy Bridge profiles.  
+    // *If* you pass a profile ID, the dialog will jump to editing that profile, or return FALSE if it was not found.
+    // Returns FALSE if cancel was pressed
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_ShowConfigDialog(HWND hwndParent, unsigned int* profileID) {
+        if (profileID) {
+            auto f = profileList.find(*profileID);
+            if (f == profileList.end()) return false;
+
+            // This doesn't modify what's passed unless it returns TRUE
+            BridgeProfileEditor editor(hInstance, hwndParent, bridgeLogos, f->second);
+            return editor.doModal();
+        }
+
+        // Make a backup of the profiles first
+        std::unordered_map<unsigned int, BridgeConfig*> backupProfiles;
+        for (auto f : profileList) {
+            char* tmpStr;
+            BridgeConfig* tmp = new BridgeConfig();
+
+            f.second->toString(&tmpStr);
+            tmp->fromString(tmpStr);
+
+            backupProfiles.insert(std::make_pair(f.first, tmp));
+        }
+
+        BridgeProfileListEditor editor(hInstance, hwndParent, bridgeLogos, profileList);
+        if (editor.doModal()) {
+            // Success. Delete the backup
+            for (auto f : backupProfiles) delete f.second;
+
+            return true;
+        } 
+        else {
+            // Restore the list from the backup.  Step 1: Erase the current list
+            for (auto f : profileList) delete f.second;
+            // And overwrite it from the backup
+            profileList = backupProfiles;
+
+            return false;
+        }
+    }
+#endif
+
+    // Retrieve a list of all of the profiles currently loaded that can be used.
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_GetAllProfiles(FloppyBridge::FloppyBridgeProfileInformationDLL** profiles, unsigned int* numProfiles) {
+        if (profileCache) free(profileCache);
+        if (!numProfiles) return false;
+        if (!profiles) return false;
+        profileCache = (FloppyBridge::FloppyBridgeProfileInformationDLL*)malloc(sizeof(FloppyBridge::FloppyBridgeProfileInformationDLL) * profileList.size());
+        if (!profileCache) return false;
+
+        FloppyBridge::FloppyBridgeProfileInformationDLL* output = profileCache;
+        for (auto& profile : profileList) {
+            output->name = profile.second->profileName;
+            output->bridgeMode = profile.second->bridgeMode;
+            output->bridgeDensityMode = profile.second->bridgeDensity;
+            output->profileID = profile.first;
+            output->driverIndex = profile.second->bridgeIndex;
+            profile.second->toString(&output->profileConfig);
+            
+            output++;
+        }
+
+        *profiles = profileCache;
+        *numProfiles = (unsigned int)profileList.size();
+        return true;
+    }
+
+    // Imports all profiles into memory from the supplied string.  This will erase any currently in memory
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_ImportProfilesFromString(char* profilesConfigString) {
+        if (!profilesConfigString) return false;
+
+        // Free memory
+        for (auto p : profileList) delete p.second;
+        profileList.clear();
+
+        std::string tmp = profilesConfigString;
+
+        // Do until we run out of string
+        while (tmp.length()) {
+            // Find the BAR
+            size_t pos = tmp.find('|');
+            if (pos == std::string::npos) break;
+
+            // ProfileID must be >0
+            unsigned int profileID = atoi(tmp.substr(0, pos).c_str());
+            if (profileID == 0) break;
+
+            tmp = tmp.substr(pos + 1);
+
+            // Extract just this profile
+            pos = tmp.find(']');
+            if (pos == std::string::npos) break;
+            
+            BridgeConfig* config = new BridgeConfig();
+            if (config->fromString((char*)tmp.substr(0, pos+1).c_str())) {
+                profileList.insert(std::make_pair(profileID, config));
+            }
+            else delete config;
+            tmp = tmp.substr(pos + 1);
+        }
+
+        return true;
+    }
+
+    // Exports all profiles and returns a pointer to the string.  This pointer is only valid while the driver is loaded and until this is called again
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_ExportProfilesToString(char** profilesConfigString) {
+        if (!profilesConfigString) return false;
+        profileStringExported = "";
+
+        for (auto& profile : profileList) {
+            profileStringExported += std::to_string(profile.first) + "|";
+            char* tmp;
+            profile.second->toString(&tmp);
+            profileStringExported += tmp;
+        }
+
+        *profilesConfigString = (char*)profileStringExported.c_str();
+        return true;
+    }
+
+    // Returns a pointer to a string containing the details for a profile
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_GetProfileConfigFromString(unsigned int profileID, char** profilesConfigString) {
+        if (!profilesConfigString) return false;
+        const auto f = profileList.find(profileID);
+        if (f == profileList.end()) return false;
+
+        f->second->toString(profilesConfigString);
+        return true;
+    }
+
+    // Updates a profile from the supplied string
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_SetProfileConfigFromString(unsigned int profileID, char* profilesConfigString) {
+        if (!profilesConfigString) return false;
+        auto f = profileList.find(profileID);
+        if (f == profileList.end()) return false;
+
+        return f->second->fromString(profilesConfigString);
+    }
+
+    // Updates a profile name from the supplied string
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_SetProfileName(unsigned int profileID, char* profileName) {
+        if (!profileName) return false;
+        auto f = profileList.find(profileID);
+        if (f == profileList.end()) return false;
+
+#ifdef _WIN32
+        strcpy_s(f->second->profileName, 128, profileName);
+#else
+        strncpy(f->second->profileName, profileName, 128);
+#endif
+        return true;
+    }
+
+    // Creates a new profile and returns its unique ID
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_CreateNewProfile(unsigned int driverIndex, unsigned int* profileID) {
+        if (!profileID) return false;
+        if (driverIndex >= BRIDGE_NumDrivers()) return false;
+
+        *profileID = 1;
+        while (profileList.find(*profileID) != profileList.end()) (*profileID)++;
+
+        BridgeConfig* config = new BridgeConfig();
+        config->bridgeIndex = driverIndex;
+
+        profileList.insert(std::make_pair(*profileID, config));
+
+        return true;
+    }
+
+    // Deletes a profile by ID.
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DeleteProfile(unsigned int profileID) {
+        auto f = profileList.find(profileID);
+        
+        if (f == profileList.end()) return false;
+
+        delete f->second;
+        profileList.erase(f);
+
+        return true;
+    }
+    
+    // Return information about a driver.  Returns FALSE if not available
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_GetDriverInfo(unsigned int driverIndex, FloppyDiskBridge::BridgeDriver** driverInformation) {
+        return handleGetDriverInfo(driverIndex, driverInformation);
+    }
+
+    // Creates an instance of a driver.  At this point it is not configured, just initialized
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_Close(BridgeOpened* bridgeDriverHandle) {
+        if (bridgeDriverHandle) {
+            if (bridgeDriverHandle->bridge) {
+                bridgeDriverHandle->bridge->shutdown();
+
+                // Restore virtual drives
+                releaseVirtualDrives(false, bridgeDriverHandle->config.bridgeIndex);
+
+                delete bridgeDriverHandle->bridge;
+                bridgeDriverHandle->bridge = nullptr;
+
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Creates an instance of a driver.  At this point it is not configured, just initialized
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_CreateDriver(unsigned int driverIndex, BridgeOpened** bridgeDriverHandle) {
+        if (driverIndex >= BRIDGE_NumDrivers()) return false;
+        if (!bridgeDriverHandle) return false;
+        *bridgeDriverHandle = new BridgeOpened;
+
+        // Reset to defaults
+        (*bridgeDriverHandle)->config.autoDetectComPort = true;
+        memset((*bridgeDriverHandle)->config.comPortToUse, 0, sizeof((*bridgeDriverHandle)->config.comPortToUse));
+        (*bridgeDriverHandle)->config.bridgeIndex = driverIndex;
+
+        BRIDGE_GetDriverInfo(driverIndex, &(*bridgeDriverHandle)->driverDetails);
+
+        return true;
+    }
+
+    // Creates an instance of a driver from a config string.  This will automatically choose the correct driver index
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_CreateDriverFromConfigString(char* configString, BridgeOpened** bridgeDriverHandle) {
+        if (!bridgeDriverHandle) return false;
+        if (!configString) return false;
+        if (strlen(configString) < 7) return false;
+
+        std::string tmp = configString;
+        if ((tmp[0] != '[') || (tmp[tmp.length() - 1] != ']')) return false;
+        tmp = tmp.substr(1, tmp.length() - 2);
+
+        size_t pos = tmp.find('|');
+        if (pos == std::string::npos) return false;
+        tmp = tmp.substr(0, pos);
+
+        if (tmp.length() < 1) return false;
+        unsigned int i = atoi(tmp.c_str());
+        if (i >= BRIDGE_NumDrivers()) return false;
+
+        if (!BRIDGE_CreateDriver(i, bridgeDriverHandle)) return false;
+        if (!BRIDGE_SetConfigFromString(*bridgeDriverHandle, configString)) {
+            BRIDGE_Close(*bridgeDriverHandle);
+            *bridgeDriverHandle = nullptr;
+            return false;
+        }
+
+        return true;
+    }
+
+    // Creates an instance of a driver from a config string.  This will automatically choose the correct driver index
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_CreateDriverFromProfileID(unsigned int profileID, BridgeOpened** bridgeDriverHandle) {
+        if (!bridgeDriverHandle) return false;
+        auto f = profileList.find(profileID);
+        if (f == profileList.end()) return false;
+
+        if (!BRIDGE_CreateDriver(f->second->bridgeIndex, bridgeDriverHandle)) return false;
+
+        char* config;
+        f->second->toString(&config);
+
+        if (!(*bridgeDriverHandle)->config.fromString(config)) {
+            BRIDGE_Close(*bridgeDriverHandle);
+            *bridgeDriverHandle = nullptr;
+            return false;
+        }
+
+        return true;
+    }
+
+    // Opens the driver for this bridge selection.  If it returns false, errorMessage is a pointer to the error, if TRUE, then errorMessage may be set to a warning message for compatability issues
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_Open(BridgeOpened* bridgeDriverHandle, char** errorMessage) {
+        if (bridgeDriverHandle->config.bridgeIndex >= BRIDGE_NumDrivers()) return false;
+
+        // Make sure it's not already open
+        BRIDGE_Close(bridgeDriverHandle);
+
+        releaseVirtualDrives(true, bridgeDriverHandle->config.bridgeIndex);
+
+#ifdef _WIN32
+        HCURSOR lastCursor = SetCursor(LoadCursor(0, IDC_WAIT));
+#endif
+        memset(bridgeDriverHandle->lastMessage, 0, sizeof(bridgeDriverHandle->lastMessage));
+
+        switch (bridgeDriverHandle->config.bridgeIndex) {
+        case 0: bridgeDriverHandle->bridge = new ArduinoFloppyDiskBridge(bridgeDriverHandle->config.bridgeMode, bridgeDriverHandle->config.bridgeDensity, bridgeDriverHandle->config.autoCache, bridgeDriverHandle->config.smartSpeed, bridgeDriverHandle->config.autoDetectComPort, bridgeDriverHandle->config.comPortToUse); break;
+        case 1: bridgeDriverHandle->bridge = new GreaseWeazleDiskBridge(bridgeDriverHandle->config.bridgeMode, bridgeDriverHandle->config.bridgeDensity, bridgeDriverHandle->config.autoCache, bridgeDriverHandle->config.smartSpeed, bridgeDriverHandle->config.autoDetectComPort, bridgeDriverHandle->config.comPortToUse, bridgeDriverHandle->config.driveCable); break;
+        case 2: bridgeDriverHandle->bridge = new SupercardProDiskBridge(bridgeDriverHandle->config.bridgeMode, bridgeDriverHandle->config.bridgeDensity, bridgeDriverHandle->config.autoCache, bridgeDriverHandle->config.smartSpeed, bridgeDriverHandle->config.autoDetectComPort, bridgeDriverHandle->config.comPortToUse, bridgeDriverHandle->config.driveCable == FloppyBridge::DriveSelection::dsDriveB); break;
+        default: return false;
+        }
+
+        // Try to open the device.  Returns FALSE if it fails and sets the error message
+        bool result = bridgeDriverHandle->bridge->initialise();
+
+#ifdef _WIN32
+        SetCursor(lastCursor);
+#endif
+
+        // If the device opens successfully, the error message is actually a warning message instead
+        const char* error = bridgeDriverHandle->bridge->getLastErrorMessage();
+#ifdef _WIN32	
+        strcpy_s(bridgeDriverHandle->lastMessage, sizeof(bridgeDriverHandle->lastMessage) - 1, error);
+#else
+        strcpy(bridgeDriverHandle->lastMessage, error);
+#endif
+
+        if (errorMessage)
+            if (strlen(bridgeDriverHandle->lastMessage)) *errorMessage = bridgeDriverHandle->lastMessage; else *errorMessage = NULL;
+
+        if (!result) {
+            // Restore virtual drive
+            releaseVirtualDrives(false, bridgeDriverHandle->config.bridgeIndex);
+
+            delete bridgeDriverHandle->bridge;
+            bridgeDriverHandle->bridge = nullptr;
+        }
+
+        return result;
+    }
+
+    // Returns the driverIndex used to open the driver
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_GetDriverIndex(BridgeOpened* bridgeDriverHandle, unsigned int* driverIndex) {
+        if (!bridgeDriverHandle) return false;
+        if (!driverIndex) return false;
+        *driverIndex = bridgeDriverHandle->config.bridgeIndex;
+        return true;
+    }
+
+    // Not normally used, and doesnt do anythin if the driver is connected either
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_SetDriverIndex(BridgeOpened* bridgeDriverHandle, unsigned int driverIndex) {
+        if (!bridgeDriverHandle) return false;
+        if ((driverIndex<0) || (driverIndex >= MAX_NUM_DRIVERS)) return false;
+        if (bridgeDriverHandle->config.bridgeIndex != driverIndex) {
+            bridgeDriverHandle->config.bridgeIndex = driverIndex;
+            BRIDGE_GetDriverInfo(driverIndex, &bridgeDriverHandle->driverDetails);
+        }
+        return true;
+    }
+
+    // Creates an instance of a driver.  At this point it is not configured, just initialized
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_FreeDriver(BridgeOpened* bridgeDriverHandle) {
+        if (!bridgeDriverHandle) return false;
+        if (bridgeDriverHandle->bridge) {
+            releaseVirtualDrives(false, bridgeDriverHandle->config.bridgeIndex);
+            bridgeDriverHandle->bridge->shutdown();
+            delete bridgeDriverHandle->bridge;
+        }
+        delete bridgeDriverHandle;
+        return true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////// These must be called before opening the driver, but can also be called after ////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Get the currently selected mode
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetMode(BridgeOpened* bridgeDriverHandle, FloppyBridge::BridgeMode* bridgeMode) {
+        if (!bridgeDriverHandle) return false;
+        if (!bridgeMode) return false;
+        *bridgeMode = bridgeDriverHandle->config.bridgeMode;
+        return true;
+    }
+    // Set the currently selected mode.  This can also be changed *while* the driver is running
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetMode(BridgeOpened* bridgeDriverHandle, FloppyBridge::BridgeMode bridgeMode) {
+        if (!bridgeDriverHandle) return false;
+        if (bridgeMode > FloppyBridge::BridgeMode::bmMax) return false;
+        bridgeDriverHandle->config.bridgeMode = bridgeMode;
+        if (bridgeDriverHandle->bridge) bridgeDriverHandle->bridge->changeBridgeMode(bridgeMode);
+        return true;
+    }
+    // Get the current DD/HD mode
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetDensityMode(BridgeOpened* bridgeDriverHandle, FloppyBridge::BridgeDensityMode* densityMode) {
+        if (!bridgeDriverHandle) return false;
+        if (!densityMode) return false;
+        *densityMode = bridgeDriverHandle->config.bridgeDensity;
+        return true;
+    }
+    // Get the current DD/HD mode.  This can also be changed *while* the driver is running
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetDensityMode(BridgeOpened* bridgeDriverHandle, FloppyBridge::BridgeDensityMode densityMode) {
+        if (!bridgeDriverHandle) return false;
+        if (densityMode > FloppyBridge::BridgeDensityMode::bdmMax) return false;
+        bridgeDriverHandle->config.bridgeDensity = densityMode;
+        if (bridgeDriverHandle->bridge) bridgeDriverHandle->bridge->changeBridgeDensity(densityMode);
+        return true;
+    }
+    // Returns if the driver currently has Smart Speed enabled which can dynamically switch between normal and turbo disk speed without breaking copy protection
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetSmartSpeedEnabled(BridgeOpened* bridgeDriverHandle, bool* enabled) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_SMARTSPEED)) return false;
+        if (!enabled) return false;
+        (*enabled) = bridgeDriverHandle->config.smartSpeed;
+        return true;
+    }
+    //  Sets if the driver can dynamically switch between normal and turbo disk speed without breaking copy protectionThis can be set while the bridge is in use
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetSmartSpeedEnabled(BridgeOpened* bridgeDriverHandle, bool enabled) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_SMARTSPEED)) return false;
+        bridgeDriverHandle->config.smartSpeed = enabled;
+        return true;
+    }
+    // Gets if the driver should continue to cache other cylinders while the drive isn't being used
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetAutoCache(BridgeOpened* bridgeDriverHandle, bool* isAutoCache) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_AUTOCACHE)) return false;
+        if (!isAutoCache) return false;
+        (*isAutoCache) = bridgeDriverHandle->config.autoCache;
+        return true;
+    }
+    // Sets if the driver should continue to cache other cylinders while the drive isn't being used
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetAutoCache(BridgeOpened* bridgeDriverHandle, bool isAutoCache) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_AUTOCACHE)) return false;
+        bridgeDriverHandle->config.autoCache = isAutoCache;
+        return true;
+    }
+
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////// These must be called before opening the driver ////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Get the currently selected COM device for the driver.  You must *not* modify this string
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetCurrentComPort(BridgeOpened* bridgeDriverHandle, char** comPort) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_COMPORT)) return false;
+        if (!comPort) return false;
+        *comPort = bridgeDriverHandle->config.comPortToUse;
+        return true;
+    }
+    // Set the currently selected COM device for the driver
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetCurrentComPort(BridgeOpened* bridgeDriverHandle, char* comPort) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_COMPORT)) return false;
+        if (!comPort) return false;
+        if (strlen(comPort) > 120) return false;  // don't overflow
+#ifdef _WIN32	
+        strcpy_s(bridgeDriverHandle->config.comPortToUse, sizeof(bridgeDriverHandle->config.comPortToUse) - 1, comPort);
+#else
+        strcpy(bridgeDriverHandle->config.comPortToUse, comPort);
+#endif	
+        return true;
+    }
+    // Get the "auto-detect" com port option for the driver
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetAutoDetectComPort(BridgeOpened* bridgeDriverHandle, bool* autoDetectComPort) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_COMPORT_AUTODETECT)) return false;
+        if (!autoDetectComPort) return false;
+        (*autoDetectComPort) = bridgeDriverHandle->config.autoDetectComPort;
+        return true;
+    }
+    // Set the "auto-detect" com port option for the driver
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetAutoDetectComPort(BridgeOpened* bridgeDriverHandle, bool autoDetectComPort) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_COMPORT_AUTODETECT)) return false;
+        bridgeDriverHandle->config.autoDetectComPort = autoDetectComPort;
+        return true;
+    }
+    // Get the cable on the drive where the floppy drive is (A or B) - Obsolete
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetCable(BridgeOpened* bridgeDriverHandle, bool* isOnB) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_DRIVE_AB)) return false;
+        if (!isOnB) return false;
+        (*isOnB) = bridgeDriverHandle->config.driveCable == FloppyBridge::DriveSelection::dsDriveB;
+        return true;
+    }
+    // Set the cable on the drive where the floppy drive is (A or B) - Obsolete
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetCable(BridgeOpened* bridgeDriverHandle, bool isOnB) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_DRIVE_AB)) return false;
+        bridgeDriverHandle->config.driveCable = isOnB ? FloppyBridge::DriveSelection::dsDriveB : FloppyBridge::DriveSelection::dsDriveA;
+        return true;
+    }
+    // Get the cable on the drive where the floppy drive is (A, B, 0, 1 or 2)
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverGetCable2(BridgeOpened* bridgeDriverHandle, FloppyBridge::DriveSelection* driveSelection) {
+        if (!bridgeDriverHandle) return false;
+        if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_DRIVE_AB)) return false;
+        if (!driveSelection) return false;
+        *driveSelection = bridgeDriverHandle->config.driveCable;
+        return true;
+    }
+    // Set the cable on the drive where the floppy drive is (A, B, 0, 1 or 2)
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION BRIDGE_DriverSetCable2(BridgeOpened* bridgeDriverHandle, FloppyBridge::DriveSelection driveSelection) {
+        if (!bridgeDriverHandle) return false;
+        if ((driveSelection == FloppyBridge::DriveSelection::dsDriveA) || (driveSelection == FloppyBridge::DriveSelection::dsDriveB)) {
+            if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_DRIVE_AB)) return false;
+        }
+        else {
+            if (!(bridgeDriverHandle->driverDetails->configOptions & CONFIG_OPTIONS_DRIVE_123)) return false;
+        }
+        bridgeDriverHandle->config.driveCable = driveSelection;
+        return true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////// Actual Bridge I/O ///////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+    // Return the 'bit cell' time in uSec.  Standard DD Amiga disks this would be 2uS, HD disks would be 1us I guess, but mainly used for =4 for SD I think
+    FLOPPYBRIDGE_API unsigned char CALLING_CONVENSION DRIVER_getBitSpeed(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getBitSpeed();
+        }
+        return 2;
+    }
+    FLOPPYBRIDGE_API FloppyDiskBridge::DriveTypeID CALLING_CONVENSION DRIVER_getDriveTypeID(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getDriveTypeID();
+        }
+        return FloppyDiskBridge::DriveTypeID::dti35DD;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_resetDrive(BridgeOpened* bridgeDriverHandle, int trackNumber) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->resetDrive(trackNumber);
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isAtCylinder0(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isAtCylinder0();
+        }
+        return true;
+    }
+    FLOPPYBRIDGE_API unsigned char CALLING_CONVENSION DRIVER_getMaxCylinder(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getMaxCylinder();
+        }
+        return 80;
+    }
+    FLOPPYBRIDGE_API void CALLING_CONVENSION DRIVER_gotoCylinder(BridgeOpened* bridgeDriverHandle, int cylinderNumber, bool side) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            bridgeDriverHandle->bridge->gotoCylinder(cylinderNumber, side);
+        }
+    }
+    FLOPPYBRIDGE_API void CALLING_CONVENSION DRIVER_handleNoClickStep(BridgeOpened* bridgeDriverHandle, bool side) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            bridgeDriverHandle->bridge->handleNoClickStep(side);
+        } 
+    }
+    FLOPPYBRIDGE_API unsigned char CALLING_CONVENSION DRIVER_getCurrentCylinderNumber(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getCurrentCylinderNumber();
+        }
+        return 0;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_getCurrentSide(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getCurrentSide();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isStillWorking(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isStillWorking();
+        }
+        return false;
+    }
+
+    FLOPPYBRIDGE_API void CALLING_CONVENSION DRIVER_setMotorStatus(BridgeOpened* bridgeDriverHandle, bool side, bool turnOn) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            bridgeDriverHandle->bridge->setMotorStatus(side, turnOn);
+        }
+    }
+
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isMotorRunning(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isMotorRunning();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isReady(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isReady();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isDiskInDrive(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isDiskInDrive();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_hasDiskChanged(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->hasDiskChanged();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isMFMPositionAtIndex(BridgeOpened* bridgeDriverHandle, int mfmPositionBits) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isMFMPositionAtIndex(mfmPositionBits);
+        }
+        return mfmPositionBits == 0;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isMFMDataAvailable(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isMFMDataAvailable();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_getMFMBit(BridgeOpened* bridgeDriverHandle, int mfmPositionBits) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getMFMBit(mfmPositionBits);
+        }
+        return 1;
+    }
+    FLOPPYBRIDGE_API int CALLING_CONVENSION DRIVER_setDirectMode(BridgeOpened* bridgeDriverHandle, bool directMode) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->setDirectMode(directMode);
+        }
+        return 1;
+    }
+    FLOPPYBRIDGE_API int CALLING_CONVENSION DRIVER_getTrack(BridgeOpened* bridgeDriverHandle, bool side, unsigned int track, bool resyncIndex, int bufferSizeInBytes, void* data) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getMFMTrack(side, track, resyncIndex, bufferSizeInBytes, data);
+        }
+        return 1;
+    }
+    FLOPPYBRIDGE_API int CALLING_CONVENSION DRIVER_putTrack(BridgeOpened* bridgeDriverHandle, bool side, unsigned int track, bool writeFromIndex, int bufferSizeInBytes, void* data) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->writeMFMTrackToBuffer(side, track, writeFromIndex, bufferSizeInBytes, data);
+        }
+        return 1;
+    }
+    FLOPPYBRIDGE_API int CALLING_CONVENSION DRIVER_getMFMSpeed(BridgeOpened* bridgeDriverHandle, int mfmPositionBits) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->getMFMSpeed(mfmPositionBits);
+        }
+        return 1000;
+    }
+    FLOPPYBRIDGE_API void CALLING_CONVENSION DRIVER_mfmSwitchBuffer(BridgeOpened* bridgeDriverHandle, bool side) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            bridgeDriverHandle->bridge->mfmSwitchBuffer(side);
+        }
+    }
+    FLOPPYBRIDGE_API void CALLING_CONVENSION DRIVER_setSurface(BridgeOpened* bridgeDriverHandle, bool side) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            bridgeDriverHandle->bridge->setSurface(side);
+        }
+    }
+    FLOPPYBRIDGE_API int CALLING_CONVENSION DRIVER_maxMFMBitPosition(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->maxMFMBitPosition();
+        }
+        return 6000;
+    }
+    FLOPPYBRIDGE_API void CALLING_CONVENSION DRIVER_writeShortToBuffer(BridgeOpened* bridgeDriverHandle, bool side, unsigned int track, unsigned short mfmData, int mfmPosition) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->writeShortToBuffer(side, track, mfmData, mfmPosition);
+        }
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isWriteProtected(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isWriteProtected();
+        }
+        return true;
+    }
+    FLOPPYBRIDGE_API unsigned int CALLING_CONVENSION DRIVER_commitWriteBuffer(BridgeOpened* bridgeDriverHandle, bool side, unsigned int track) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->commitWriteBuffer(side, track);
+        }
+        return 6000;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isWritePending(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isWritePending();
+        }
+        return false;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isWriteComplete(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isWriteComplete();
+        }
+        return true;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_canTurboWrite(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->canTurboWrite();
+        }
+        return true;
+    }
+    FLOPPYBRIDGE_API bool CALLING_CONVENSION DRIVER_isReadyToWrite(BridgeOpened* bridgeDriverHandle) {
+        if ((bridgeDriverHandle) && (bridgeDriverHandle->bridge)) {
+            return bridgeDriverHandle->bridge->isReadyToWrite();
+        }
+        return false;
+    }
+}
+
+#ifdef _WIN32
+
+BOOL WINAPI DllMain(
+    HINSTANCE hinstDLL,  // handle to DLL module
+    DWORD fdwReason,     // reason for calling function
+    LPVOID lpReserved)  // reserved
+{
+    // Perform actions based on the reason for calling.
+    switch (fdwReason)
+    {
+    case DLL_PROCESS_ATTACH:
+        hInstance = hinstDLL;
+        if (bridgeLogos.size() < 1) {
+            bridgeLogos.push_back((HBITMAP)LoadImage(hInstance, MAKEINTRESOURCE(IDB_BRIDGELOGO0), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+            bridgeLogos.push_back((HBITMAP)LoadImage(hInstance, MAKEINTRESOURCE(IDB_BRIDGELOGO1), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+            bridgeLogos.push_back((HBITMAP)LoadImage(hInstance, MAKEINTRESOURCE(IDB_BRIDGELOGO2), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+            bridgeLogos.push_back((HBITMAP)LoadImage(hInstance, MAKEINTRESOURCE(IDB_SMALLLOGO0), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+            bridgeLogos.push_back((HBITMAP)LoadImage(hInstance, MAKEINTRESOURCE(IDB_SMALLLOGO1), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
+            bridgeLogos.push_back((HBITMAP)LoadImage(hInstance, MAKEINTRESOURCE(IDB_SMALLLOGO2), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));           
+        }
+        break;
+
+    case DLL_PROCESS_DETACH:
+        // Perform any necessary cleanup.
+        break;
+    }
+    return TRUE;  // Successful DLL_PROCESS_ATTACH.
+}
+
+#endif

--- a/vendor/floppybridge/src/FloppyBridge.h
+++ b/vendor/floppybridge/src/FloppyBridge.h
@@ -1,0 +1,94 @@
+/* FloppyBridge DLL for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the FLOPPYBRIDGE_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// FLOPPYBRIDGE_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+// Windows Header Files
+#include <windows.h>
+
+#define CALLING_CONVENSION _cdecl
+#define FLOPPYBRIDGE_API __declspec(dllexport) 
+
+#else
+
+#define CALLING_CONVENSION
+#define FLOPPYBRIDGE_API 
+
+#endif 
+
+#define BRIDGEDRIVERHANDLE
+#include "floppybridge_common.h"
+
+#include "CommonBridgeTemplate.h"
+
+#define MAX_NUM_DRIVERS     3
+
+
+// Config for a bridge setup
+class BridgeConfig {
+private:
+	// Last serialisation of the below data, made when you call toString()
+	char lastSerialise[255] = { 0 };
+public:
+	// Which type of interface to open
+	unsigned int bridgeIndex = 0;
+
+	// The settings that will be used to open the above bridge
+	FloppyBridge::BridgeMode bridgeMode = FloppyBridge::BridgeMode::bmFast;
+	FloppyBridge::BridgeDensityMode bridgeDensity = FloppyBridge::BridgeDensityMode::bdmAuto;
+
+	// This isn't saved with fromString and toString
+	char profileName[128] = { 0 };
+
+	// Not all of these settings are used.
+	char comPortToUse[128] = { 0 };
+	bool autoDetectComPort = true;
+	FloppyBridge::DriveSelection driveCable = FloppyBridge::DriveSelection::dsDriveA;
+	bool autoCache = false;
+	bool smartSpeed = false;
+
+	// Serialising into a nice string
+	bool fromString(char* string);
+	void toString(char** serialisedOptions);  //the pointer returned is actually lastSerialise
+};
+
+
+
+// This is private, from the outside of the DLL its just a pointer to this
+struct BridgeOpened {
+	/// Details about the driver
+	FloppyDiskBridge::BridgeDriver* driverDetails = nullptr;
+
+	// The bridge, when created.
+	CommonBridgeTemplate* bridge = nullptr;
+
+	// Last error/warning message received
+	char lastMessage[255] = { 0 };
+
+	// Currently active config
+	BridgeConfig config;
+};

--- a/vendor/floppybridge/src/GreaseWeazleBridge.cpp
+++ b/vendor/floppybridge/src/GreaseWeazleBridge.cpp
@@ -1,0 +1,334 @@
+/* WinUAE Greaseweazle Interface for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+ 
+#include "floppybridge_config.h"
+
+#ifdef ROMTYPE_GREASEWEAZLEREADER_WRITER
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "GreaseWeazleBridge.h"
+#include "GreaseWeazleInterface.h"
+
+
+using namespace GreaseWeazle;
+
+
+static const FloppyDiskBridge::BridgeDriver DriverGreaseweazleFloppy = {
+	"Greaseweazle", "https://github.com/keirf/Greaseweazle", "Keir Fraser", "RobSmithDev", CONFIG_OPTIONS_COMPORT | CONFIG_OPTIONS_COMPORT_AUTODETECT | CONFIG_OPTIONS_DRIVE_AB | CONFIG_OPTIONS_DRIVE_123 | CONFIG_OPTIONS_SMARTSPEED | CONFIG_OPTIONS_AUTOCACHE
+};
+
+// Flags from WINUAE
+GreaseWeazleDiskBridge::GreaseWeazleDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool enableAutoCache, bool useSmartSpeed, bool autoDetectComPort, char* comPort, FloppyBridge::DriveSelection drive) :
+	CommonBridgeTemplate(bridgeMode, bridgeDensity, enableAutoCache, useSmartSpeed), m_useDrive(drive), m_comPort(autoDetectComPort ? "" : comPort) {
+}
+
+// This is for the static version
+GreaseWeazleDiskBridge::GreaseWeazleDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, int uaeSettings) :
+	CommonBridgeTemplate(bridgeMode, bridgeDensity, false, false), m_useDrive((FloppyBridge::DriveSelection)((uaeSettings & 0x0F) == 0)), m_comPort("") {
+}
+
+
+GreaseWeazleDiskBridge::~GreaseWeazleDiskBridge() {
+}
+
+// If your device supports being able to abort a disk read, mid-read then implement this
+void GreaseWeazleDiskBridge::abortDiskReading() {
+	m_io.abortReadStreaming();
+};
+
+// A manual way to detect a disk change event
+bool GreaseWeazleDiskBridge::attemptToDetectDiskChange() {
+	switch (m_io.checkForDisk(true)) {
+	case GWResponse::drOK: return true;
+	case GWResponse::drNoDiskInDrive: return false;
+	default: return isDiskInDrive();
+	}
+}
+
+// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+bool GreaseWeazleDiskBridge::supportsDiskChange() {
+	return m_io.supportsDiskChange();
+}
+
+// Called when the class is about to shut down
+void GreaseWeazleDiskBridge::closeInterface() {
+	// Turn everything off
+	m_io.enableMotor(false);
+	m_io.closePort();
+}
+
+// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+bool GreaseWeazleDiskBridge::openInterface(std::string& errorMessage) {
+
+	GWResponse error = m_io.openPort(m_comPort, (GreaseWeazle::DriveSelection)m_useDrive);
+
+	if (error == GWResponse::drOK) {
+		if (m_io.findTrack0() == GWResponse::drRewindFailure) {
+			errorMessage = "Failed to find track 0 (usually when IBM PC/Shugart drive A-B/0-3 Selection is incorrect)";
+			m_io.closePort();
+			return false;
+		}
+		m_currentCylinder = 0;
+
+		if (!m_io.supportsDiskChange()) {
+#ifdef _WIN32			
+			DWORD hasBeenSeen = 0;
+			DWORD dataSize = sizeof(hasBeenSeen);
+			HKEY key = 0;
+
+			if (m_io.currentBusType() == GreaseWeazle::BusType::Shugart) {
+				if (SUCCEEDED(RegCreateKeyExA(HKEY_CURRENT_USER, "Software\\RobSmithDev\\GreaseWeazleSupport", 0, NULL, 0, KEY_READ | KEY_WRITE | KEY_SET_VALUE | KEY_CREATE_SUB_KEY, NULL, &key, NULL)))
+					if (!RegQueryValueExA(key, "WarningShownShugart", NULL, NULL, (LPBYTE)&hasBeenSeen, &dataSize)) dataSize = 0;
+
+				if (!hasBeenSeen) {
+					hasBeenSeen = 1;
+					if (key) RegSetValueExA(key, "WarningShownShugart", NULL, REG_DWORD, (LPBYTE)&hasBeenSeen, sizeof(hasBeenSeen));
+					errorMessage = "Greaseweazle boards cannot read the DiskChange pin from this type of drive and so will be simulated.\nThis is not optimal and will result in a higher amount of disk access.\nI highly recommend using an IBM/PC drive instead.";
+				}
+			}
+			else {
+				if (SUCCEEDED(RegCreateKeyExA(HKEY_CURRENT_USER, "Software\\RobSmithDev\\GreaseWeazleSupport", 0, NULL, 0, KEY_READ | KEY_WRITE | KEY_SET_VALUE | KEY_CREATE_SUB_KEY, NULL, &key, NULL)))
+					if (!RegQueryValueExA(key, "WarningShown", NULL, NULL, (LPBYTE)&hasBeenSeen, &dataSize)) dataSize = 0;
+
+				if (!hasBeenSeen) {
+					hasBeenSeen = 1;
+					if (key) RegSetValueExA(key, "WarningShown", NULL, REG_DWORD, (LPBYTE)&hasBeenSeen, sizeof(hasBeenSeen));
+					errorMessage = "The Greaseweazle board you are using does not support access to the DISK CHANGE pin and so will be simulated.\nThis is not optimal and will result in a higher amount of disk access.\nIf you are sure that it does, please update its firmware.";
+				}
+			}
+			if (key) RegCloseKey(key);
+#endif			
+		}
+
+		return true;
+	}
+	else {
+		switch (error) {
+		case GWResponse::drPortNotFound: errorMessage = "Greaseweazle board was not detected."; break;
+		case GWResponse::drPortInUse: errorMessage = "Greaseweazle board is already in use."; break;
+		case GWResponse::drPortError: errorMessage = "Unknown error connecting to your Greaseweazle board."; break;
+		case GWResponse::drComportConfigError: errorMessage = "Error configuring communication with your Greaseweazle board."; break;
+		case GWResponse::drErrorMalformedVersion: errorMessage = "Error communicating with your Greaseweazle board. Please unplug it and re-connect it."; break;
+		case GWResponse::drOldFirmware: errorMessage = "Your Greaseweazle firmware is too old. V0.27 or newer is required."; break;
+		case GWResponse::drInUpdateMode: errorMessage = "Your Greaseweazle is currently in update mode.  Please restore it to normal mode."; break;
+		case GWResponse::drError: errorMessage = "Unable to select the drive on your Greaseweazle."; break;
+		default: errorMessage = "An unknown error occurred connecting to your Greaseweazle."; break;
+		}
+	}
+
+	return false;
+}
+
+const FloppyDiskBridge::BridgeDriver* GreaseWeazleDiskBridge::staticBridgeInformation() {
+	return &DriverGreaseweazleFloppy;
+}
+
+// Get the name of the drive
+const FloppyDiskBridge::BridgeDriver* GreaseWeazleDiskBridge::_getDriverInfo() {
+	return staticBridgeInformation();
+}
+
+// Duplicate of the one below, but here for consistency - Returns the name of interface.  This pointer should remain valid after the class is destroyed
+const FloppyDiskBridge::DriveTypeID GreaseWeazleDiskBridge::_getDriveTypeID() {
+	return m_isHDDisk ? DriveTypeID::dti35HD : DriveTypeID::dti35DD;
+}
+
+// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+void GreaseWeazleDiskBridge::checkDiskType() {
+	bool capacity;
+
+	if (m_io.checkDiskCapacity(capacity) == GWResponse::drOK) {
+		m_isHDDisk = capacity;
+		m_io.setDiskCapacity(m_isHDDisk);
+	}
+	else {
+		m_isHDDisk = false;
+		m_io.setDiskCapacity(m_isHDDisk);
+	}
+}
+
+// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+void GreaseWeazleDiskBridge::forceDiskDensity(bool forceHD) {
+	m_isHDDisk = forceHD;
+	m_io.setDiskCapacity(m_isHDDisk);
+}
+
+
+// Called to switch which head is being used right now.  Returns success or not
+bool GreaseWeazleDiskBridge::setActiveSurface(const DiskSurface activeSurface) {
+	return m_io.selectSurface(activeSurface == DiskSurface::dsUpper ? GreaseWeazle::DiskSurface::dsUpper : GreaseWeazle::DiskSurface::dsLower) ==
+		GWResponse::drOK;
+}
+
+// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+bool GreaseWeazleDiskBridge::setMotorStatus(const bool switchedOn) {
+	m_motorIsEnabled = switchedOn;
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+	return m_io.enableMotor(switchedOn, true) == GWResponse::drOK;
+}
+
+// Called to ask the drive what the current write protect status is - return true if its write protected
+bool GreaseWeazleDiskBridge::checkWriteProtectStatus(const bool forceCheck) {
+	return m_io.isWriteProtected();
+}
+
+// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+bool GreaseWeazleDiskBridge::getDiskChangeStatus(const bool forceCheck) {
+	// We actually trigger a SEEK operation to ensure this is right
+	if (forceCheck) {
+		switch (m_io.checkForDisk(forceCheck)) {
+		case GWResponse::drNoDiskInDrive:
+			if ((m_currentCylinder == 0) && (m_io.supportsDiskChange())) {
+				m_io.performNoClickSeek();
+			}
+			else {
+				m_io.selectTrack((m_currentCylinder > 40) ? m_currentCylinder - 1 : m_currentCylinder + 1, TrackSearchSpeed::tssNormal, true);
+				m_io.selectTrack(m_currentCylinder, TrackSearchSpeed::tssNormal, true);
+			}
+			break;
+		case GWResponse::drError:
+			m_wasIOError = true;
+			return false;
+		}
+	}
+
+	switch (m_io.checkForDisk(forceCheck)) {
+	case GWResponse::drOK: return true;
+	case GWResponse::drNoDiskInDrive: return false;
+	case GWResponse::drError:m_wasIOError = true; return false;
+	default: return isDiskInDrive();
+	}
+}
+
+// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+// Return FALSE if this is not supported by the bridge
+bool GreaseWeazleDiskBridge::performNoClickSeek() {
+	// Claim we did it anyway
+	if (!m_io.supportsDiskChange()) return true;
+
+	switch (m_io.performNoClickSeek()) {
+		case GWResponse::drOK:
+			updateLastManualCheckTime();
+			return true;
+		case GWResponse::drOldFirmware:
+			return false;
+		case GWResponse::drError:
+			m_wasIOError = true;
+			return false;
+
+	}
+	return false;
+}
+
+
+// Trigger a seek to the requested cylinder, this can block until complete
+bool GreaseWeazleDiskBridge::setCurrentCylinder(const unsigned int cylinder) {
+	m_currentCylinder = cylinder;
+
+	// No need if its busy
+	bool ignoreDiskCheck = (isMotorRunning()) && (!isReady());
+
+	// If we don't support disk change then don't allow the hardware to check for a disk as it takes time, unless it's due anyway
+	if (!supportsDiskChange()) ignoreDiskCheck |= !isReadyForManualDiskCheck();
+
+	// Go!
+	if (m_io.selectTrack(cylinder, TrackSearchSpeed::tssNormal, ignoreDiskCheck) == GWResponse::drOK) {
+		if (!ignoreDiskCheck) updateLastManualCheckTime();	
+		return true;
+	}
+
+	return false;
+}
+
+// Called when data should be read from the drive.
+//		rotationExtractor: supplied if you use it
+//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+// Returns: ReadResponse, explains its self
+CommonBridgeTemplate::ReadResponse GreaseWeazleDiskBridge::readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+	std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) {
+	GWResponse result = m_io.readRotation(pll, maxBufferSize, buffer, indexMarker,
+	                                      [&onRotation](RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits) -> bool {
+		                                      return onRotation(*mfmData, dataLengthInBits);
+	                                      });
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+
+	switch (result) {
+	case GWResponse::drOK: return ReadResponse::rrOK;
+	case GWResponse::drNoDiskInDrive: return ReadResponse::rrNoDiskInDrive;
+	default:  return ReadResponse::rrError;
+	}	
+}
+
+// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+//		pll:           required 
+// Returns: ReadResponse, explains its self
+CommonBridgeTemplate::ReadResponse GreaseWeazleDiskBridge::readLinearData(PLL::BridgePLL& pll) {
+	GWResponse result = m_io.readData(pll);
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+
+	switch (result) {
+	case GWResponse::drOK: return ReadResponse::rrOK;
+	case GWResponse::drNoDiskInDrive: return ReadResponse::rrNoDiskInDrive;
+	default:  return ReadResponse::rrError;
+	}
+}
+
+
+
+// Called when a cylinder revolution should be written to the disk.
+// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+//					numBytes						Number of bits in the buffer to write
+//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+//					suggestUsingPrecompensation		A suggestion that you might want to use write pre-compensation, optional
+// Returns TRUE if success, or false if it fails.  Largely doesn't matter as most stuff should verify with a read straight after
+bool GreaseWeazleDiskBridge::writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation) {
+	GWResponse response = m_io.writeCurrentTrackPrecomp(rawMFMData, (numBits + 7) / 8, writeFromIndex, suggestUsingPrecompensation);
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+
+	switch (response) {
+	case GWResponse::drOK: return true;
+	case GWResponse::drWriteProtected: setWriteProtectStatus(true); return false;
+	default:  return false;
+	}
+}
+
+// Return TRUE if the drive is still connected and working
+bool GreaseWeazleDiskBridge::isStillWorking() {
+	return !m_wasIOError;
+}
+
+// This is called by the main thread incase you need to do anything specific at regular intervals
+void GreaseWeazleDiskBridge::poll() {
+	// GW has a watchdog timeout and after a while the motor will switch off after inactivity.  We can't allow this as doesn't work for how the Amiga might do things
+	if (m_motorIsEnabled) {
+		const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_motorTurnOnTime).count();
+		if (timePassed > (unsigned int)(m_io.getMotorTimeout()/2)) {
+			m_io.enableMotor(true, true);
+			m_motorTurnOnTime = std::chrono::steady_clock::now();
+		}
+	}
+}
+
+
+#endif

--- a/vendor/floppybridge/src/GreaseWeazleBridge.h
+++ b/vendor/floppybridge/src/GreaseWeazleBridge.h
@@ -1,0 +1,150 @@
+#ifndef GREASEWEAZLE_FLOPPY_BRIDGE
+#define GREASEWEAZLE_FLOPPY_BRIDGE
+/* WinUAE Greaseweazle Interface for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+//
+// ROMTYPE_GREASEWEAZLEREADER_WRITER must be defined for this to work
+
+
+#ifdef ROMTYPE_GREASEWEAZLEREADER_WRITER
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "GreaseWeazleInterface.h"
+#include "pll.h"
+
+class GreaseWeazleDiskBridge : public CommonBridgeTemplate {
+private:
+	// When the motor last switched on	
+	std::chrono::time_point<std::chrono::steady_clock> m_motorTurnOnTime;
+	bool m_motorIsEnabled = false;
+
+	// Which com port should we use? or blank for automatic
+	std::string m_comPort;
+
+	// Used to detect disconnection of Greaseweazle while in use
+	bool m_wasIOError = false;
+
+	// Which drive to use
+	FloppyBridge::DriveSelection m_useDrive;
+
+	// Is this a HD disk?
+	bool m_isHDDisk = false;
+
+	// Hardware connection
+	GreaseWeazle::GreaseWeazleInterface m_io;
+
+	// Remember where we are
+	int m_currentCylinder = 0;
+
+protected:
+	// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+	virtual void checkDiskType() override;
+
+	// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+	virtual void forceDiskDensity(bool forceHD) override;
+
+	// This is called by the main thread in case you need to do anything specific at regular intervals
+	virtual void poll() override;
+
+	// Return TRUE if the drive is still connected and working
+	virtual bool isStillWorking() override;
+
+	// If your device supports being able to abort a disk read, mid-read then implement this
+	virtual void abortDiskReading() override;
+
+	// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+	virtual bool supportsDiskChange() override;
+
+	// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+	// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+	virtual bool getDiskChangeStatus(const bool forceCheck) override;
+
+	// Called when the class is about to shut down
+	virtual void closeInterface() override;
+
+	// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+	virtual bool openInterface(std::string& errorMessage) override;
+
+	// Called to ask the drive what the current write protect status is - return true if its write protected.  If forceCheck is true you should actually check the drive, 
+	// else use the last status checked which was probably from a SEEK setCurrentCylinder call.  If you can ONLY get this information here then you should always force check
+	virtual bool checkWriteProtectStatus(const bool forceCheck) override;
+
+	// Get the name of the drive
+	virtual const BridgeDriver* _getDriverInfo() override;
+
+	// Duplicate of the one below, but here for consistency - Returns the name of interface.  This pointer should remain valid after the class is destroyed
+	virtual const DriveTypeID _getDriveTypeID() override;
+
+	// Called to switch which head is being used right now.  Returns success or not
+	virtual bool setActiveSurface(const DiskSurface activeSurface) override;
+
+	// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+	virtual bool setMotorStatus(const bool switchedOn) override;
+
+	// Trigger a seek to the requested cylinder, this can block until complete
+	virtual bool setCurrentCylinder(const unsigned int cylinder) override;
+
+	// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+	// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+	// Return FALSE if this is not supported by the bridge
+	virtual bool performNoClickSeek() override;
+
+	// Called when data should be read from the drive.
+	//		pll:           supplied if you use it
+	//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+	// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+	//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+	//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+		std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) override;
+
+	// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+	//		pll:           required 
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readLinearData(PLL::BridgePLL& pll) override;
+
+	// Called when a cylinder revolution should be written to the disk.
+	// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+	//					numBytes						Number of bits in the buffer to write
+	//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+	//					suggestUsingPrecompensation		A suggestion that you might want to use write precompensation, optional
+	// Returns TRUE if success, or false if it fails.  Largely doesnt matter as most stuff should verify with a read straight after
+	virtual bool writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation) override;
+
+	// A manual way to check for disk change.  This is simulated by issuing a read message and seeing if there's any data.  Returns TRUE if data or an INDEX pulse was detected
+	// It's virtual as the default method issues a read and looks for data.  If you have a better implementation then override this
+	virtual bool attemptToDetectDiskChange() override;
+
+public:
+	GreaseWeazleDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool enableAutoCache, bool useSmartSpeed, bool autoDetectComPort, char* comPort, FloppyBridge::DriveSelection drive);
+
+	// This is for the static version
+	GreaseWeazleDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, int uaeSettings);
+
+	virtual ~GreaseWeazleDiskBridge();
+
+	static const BridgeDriver* staticBridgeInformation();
+};
+
+
+
+#endif
+#endif

--- a/vendor/floppybridge/src/GreaseWeazleInterface.cpp
+++ b/vendor/floppybridge/src/GreaseWeazleInterface.cpp
@@ -1,0 +1,1110 @@
+/* Greaseweazle C++ Interface for reading and writing Amiga Disks
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* Based on the excellent code by Keir Fraser <keir.xen@gmail.com>
+* https://github.com/keirf/Greaseweazle/
+* 
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+#include <sstream>
+#include <vector>
+#include <queue>
+#include <cstring>
+#include "GreaseWeazleInterface.h"
+#include "RotationExtractor.h"
+#include "pll.h"
+
+#define ONE_NANOSECOND 1000000000UL
+#define BITCELL_SIZE_IN_NS 2000L
+
+#define PIN_DISKCHG_IBMPC	34
+#define PIN_DISKCHG_SHUGART 2     // Greaseweazle cannot read from this pin
+#define PIN_WRPROT			28
+
+using namespace GreaseWeazle;
+
+enum class GetInfo { Firmware = 0, BandwidthStats = 1 };
+// ## Cmd.{Get,Set}Params indexes
+enum class Params { Delays = 0 };
+// ## Flux read stream opcodes, preceded by 0xFF byte
+enum class FluxOp { Index = 1, Space = 2, Astable = 3};
+
+#pragma pack(1) 
+
+/* CMD_READ_FLUX */
+struct GWReadFlux {
+	/* Maximum ticks to read for (or 0, for no limit). */
+	uint32_t ticks;
+	/* Maximum index pulses to read (or 0, for no limit). */
+	uint16_t max_index;
+	/* Linger time, in ticks, to continue reading after @max_index pulses. */
+	uint32_t max_index_linger; /* default: 500 microseconds */
+};
+
+/* CMD_WRITE_FLUX */
+struct GWWriteFlux {
+	/* If non-zero, start the write at the index pulse. */
+	unsigned char cue_at_index;
+	/* If non-zero, terminate the write at the next index pulse. */
+	unsigned char terminate_at_index;
+};
+
+#pragma pack()
+
+struct Sequence {
+	unsigned char sequence;
+	uint16_t speed;     // speed compared to what it should be (for this sequence)
+	bool atIndex;			// At index
+};
+
+// We're working in nanoseconds
+struct PLLData {
+	uint32_t freq = 0;			  // sample frequency in Hz
+	uint32_t ticks = 0;
+	bool indexHit = false;
+};
+
+
+// Constructor for this class
+GreaseWeazleInterface::GreaseWeazleInterface() : m_currentBusType(BusType::IBMPC), m_currentDriveIndex(0), m_diskInDrive(false),
+												 m_isWriteProtected(true)
+{
+	memset(&m_gwVersionInformation, 0, sizeof(m_gwVersionInformation));
+	memset(&m_gwDriveDelays, 0, sizeof(m_gwDriveDelays));
+}
+
+// Free me
+GreaseWeazleInterface::~GreaseWeazleInterface() {
+	closePort();
+}
+			
+// Search and find the Greaseweazle COM port
+std::wstring findPortNumber() {
+	std::vector<SerialIO::SerialPortInformation> portList;
+	SerialIO::enumSerialPorts(portList);
+
+	// Scan for items
+	std::wstring bestPort;
+	int maxScore = 0;
+
+	for (const SerialIO::SerialPortInformation& port : portList) {
+		int score = 0;
+
+		// Check Greaseweazle official VID/PID 
+		if ((port.vid == 0x1209) && (port.pid == 0x4d69)) score += 20;
+		else // old shared Test PID. It's not guaranteed to be Greaseweazle.
+			if ((port.vid == 0x1209) && (port.pid == 0x0001)) {
+				score += 10;
+			}
+		if (port.productName == L"Greaseweazle") score += 10;
+		if (port.instanceID.find(L"\\GW") != std::wstring::npos) score += 10;
+#ifdef __APPLE__
+		if (port.portName.find(L".usbmodem") != std::wstring::npos) score += 10;
+#endif		
+
+		// Keep this port if its achieved a place on our high score table
+		if (score > maxScore) {
+			maxScore = score;
+			bestPort = port.portName;
+		}
+	}
+
+	return bestPort;
+}
+
+// Attempts to open the reader running on the COM port provided (or blank for auto-detect)
+GWResponse GreaseWeazleInterface::openPort(const std::string& comPort, DriveSelection drive) {
+	closePort();
+
+	m_motorIsEnabled = false;
+
+	m_inHDMode = false;
+
+	std::wstring wComPort;
+	quicka2w(comPort, wComPort);
+
+	// Find and detect the port
+	std::wstring gwPortNumber = wComPort.length() ? wComPort : findPortNumber();
+
+	// If no device detected?
+	if (gwPortNumber.empty()) return GWResponse::drPortNotFound;
+
+	switch (m_comPort.openPort(gwPortNumber)) {
+	case SerialIO::Response::rInUse:return GWResponse::drPortInUse;
+	case SerialIO::Response::rNotFound:return GWResponse::drPortNotFound;
+	case SerialIO::Response::rOK: break;
+	default: return GWResponse::drPortError;
+	}
+
+	// Configure the port
+	SerialIO::Configuration config;
+	config.baudRate = 9600;
+	config.ctsFlowControl = false;
+
+	if (m_comPort.configurePort(config) != SerialIO::Response::rOK) return GWResponse::drPortError;
+
+	applyCommTimeouts(false);
+
+	m_comPort.purgeBuffers();
+
+	// Lets ask GW it's firmware version
+	Ack response = Ack::Okay;
+	if (!sendCommand(Cmd::GetInfo, (unsigned char)GetInfo::Firmware, response)) {
+		m_comPort.purgeBuffers();
+
+		if (!sendCommand(Cmd::GetInfo, (unsigned char)GetInfo::Firmware, response)) {
+			closePort();
+			return GWResponse::drErrorMalformedVersion;
+		}
+	};
+	unsigned long read = m_comPort.read(&m_gwVersionInformation, sizeof(m_gwVersionInformation));
+	if (read != 32) {
+		closePort();
+		return GWResponse::drErrorMalformedVersion;
+	}
+	if ((m_gwVersionInformation.major == 0) && (m_gwVersionInformation.minor < 27)) {
+		closePort();
+		return GWResponse::drOldFirmware;
+	}
+	if (m_gwVersionInformation.is_main_firmware == 0) {
+		closePort();
+		return GWResponse::drInUpdateMode;
+	}
+
+	// Reset it
+	if (!sendCommand(Cmd::Reset, nullptr, 0, response)) {
+		closePort();
+		return GWResponse::drErrorMalformedVersion;
+	};
+
+	// Now get the drive delays
+	if (!sendCommand(Cmd::GetParams, (unsigned char)Params::Delays, response, sizeof(m_gwDriveDelays))) {
+		closePort();
+		return GWResponse::drErrorMalformedVersion;
+	};
+
+	read = m_comPort.read(&m_gwDriveDelays, sizeof(m_gwDriveDelays));
+	if (read != sizeof(m_gwDriveDelays)) {
+		closePort();
+		return GWResponse::drErrorMalformedVersion;
+	};
+
+	// Select the drive we want to communicate with
+	switch (drive) {
+	case DriveSelection::dsA:
+		m_currentBusType = BusType::IBMPC;
+		m_currentDriveIndex = 0;
+		break;
+	case DriveSelection::dsB:
+		m_currentBusType = BusType::IBMPC;
+		m_currentDriveIndex = 1;
+		break;
+	case DriveSelection::ds0:
+		m_currentBusType = BusType::Shugart;
+		m_currentDriveIndex = 0;
+		break;
+	case DriveSelection::ds1:
+		m_currentBusType = BusType::Shugart;
+		m_currentDriveIndex = 1;
+		break;
+	case DriveSelection::ds2:
+		m_currentBusType = BusType::Shugart;
+		m_currentDriveIndex = 2;
+		break;
+	case DriveSelection::ds3:
+		m_currentBusType = BusType::Shugart;
+		m_currentDriveIndex = 3;
+		break;
+	}
+	
+	if (!sendCommand(Cmd::SetBusType, (unsigned char)m_currentBusType, response)) {
+		closePort();
+		return GWResponse::drError;
+	}
+
+	// Do an initial probe to see whats available
+	checkPins();
+
+	// Firmware doesnt support the pin command
+	if (!m_pinWrProtectAvailable) {
+		closePort();
+		return GWResponse::drOldFirmware;
+	}
+
+	// Ok, success
+	return GWResponse::drOK;
+}
+
+// Change the drive delays as required
+bool GreaseWeazleInterface::updateDriveDelays() {
+	unsigned char buffer[11];
+	buffer[0] = (unsigned char)Params::Delays;
+#ifdef _WIN32	
+	memcpy_s(buffer + 1, 10, &m_gwDriveDelays, sizeof(m_gwDriveDelays));
+#else
+	memcpy(buffer + 1, &m_gwDriveDelays, sizeof(m_gwDriveDelays));
+#endif	
+
+	Ack response = Ack::Okay;
+	if (!sendCommand(Cmd::SetParams, buffer, 11, response)) return false;
+
+	return true;
+}
+
+// Trigger drive select
+bool GreaseWeazleInterface::selectDrive(bool select) {
+	Ack response = Ack::Okay;
+
+	if (select == m_selectStatus) return true;
+
+	if (select) {
+		if (sendCommand(Cmd::Select, m_currentDriveIndex, response)) {
+			m_selectStatus = select;
+			return true;
+		}
+	}
+	else {
+		if (sendCommand(Cmd::Deselect, nullptr, 0, response)) {
+			m_selectStatus = select;
+			return true;
+		}
+	}
+	return false;
+}
+
+// Apply and change the timeouts on the com port
+void GreaseWeazleInterface::applyCommTimeouts(bool shortTimeouts) {
+	m_comPort.setWriteTimeouts(2000, 200);
+
+	if (shortTimeouts) {
+		m_comPort.setReadTimeouts(15, 5);
+	}
+	else {
+		m_comPort.setReadTimeouts(2000, 200);
+	}		
+}
+
+// Closes the port down
+void GreaseWeazleInterface::closePort() {
+	enableMotor(false);
+	
+	m_comPort.closePort();
+}
+
+// Turns on and off the reading interface
+GWResponse GreaseWeazleInterface::enableMotor(const bool enable, const bool dontWait) {
+	Ack response = Ack::Okay;
+
+	std::vector<unsigned char> params;
+
+	unsigned int delay = dontWait ? 10 : 750;
+	if (delay != m_gwDriveDelays.motor_delay) {
+		m_gwDriveDelays.motor_delay = delay;
+		updateDriveDelays();
+	}
+	
+	unsigned char buffer[2] = { m_currentDriveIndex, ((unsigned char)(enable ? 1 : 0)) };
+	if (!sendCommand(Cmd::Motor, buffer, 2, response)) {
+		return GWResponse::drError;
+	}
+
+	if (response == Ack::Okay) {
+		m_motorIsEnabled = enable;
+		if (m_motorIsEnabled) selectDrive(true);
+	}
+
+	return (response == Ack::Okay) ? GWResponse::drOK : GWResponse::drError;
+}
+
+GWResponse GreaseWeazleInterface::performNoClickSeek() {
+	Ack response = Ack::Okay;
+
+	selectDrive(true);
+	sendCommand(Cmd::NoClickStep, nullptr, 0, response);
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	if (response == Ack::BadCommand) return GWResponse::drError;
+	if (response == Ack::Okay) {
+		if (!checkPins()) return GWResponse::drError;
+
+		return GWResponse::drOK;
+	} 
+	else return GWResponse::drOldFirmware;
+}
+
+// Select the track, this makes the motor seek to this position
+GWResponse GreaseWeazleInterface::selectTrack(const unsigned char trackIndex, const TrackSearchSpeed searchSpeed, bool ignoreDiskInsertCheck) {
+	if (trackIndex > 81) {
+		return GWResponse::drTrackRangeError; // no chance, it can't be done.
+	}
+
+	uint16_t newSpeed = m_gwDriveDelays.step_delay;
+	switch (searchSpeed) {
+		case TrackSearchSpeed::tssSlow:		newSpeed = 5000;  break;
+		case TrackSearchSpeed::tssNormal:	newSpeed = 3000;  break;
+		case TrackSearchSpeed::tssFast:		newSpeed = 3000;  break;
+		case TrackSearchSpeed::tssVeryFast: newSpeed = 3000;  break;
+	}
+	if (newSpeed != m_gwDriveDelays.step_delay) {
+		m_gwDriveDelays.step_delay = newSpeed;
+		updateDriveDelays();
+	}	
+
+	selectDrive(true);
+
+	Ack response = Ack::Okay;
+	sendCommand(Cmd::Seek, trackIndex, response);
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	// We have to check for a disk manually
+	if (!ignoreDiskInsertCheck) {
+		checkForDisk(true);
+	}
+
+	switch (response) {
+	case Ack::NoTrk0: return GWResponse::drRewindFailure;
+	case Ack::Okay: checkPins();  return GWResponse::drOK;
+	default: return GWResponse::drSelectTrackError;
+	}
+}
+
+// Checks the pins from boards that support it
+bool GreaseWeazleInterface::checkPins() {
+	Ack response;
+	selectDrive(true);
+
+	if ((!sendCommand(Cmd::GetPin, PIN_WRPROT, response)) || (response != Ack::Okay)) {
+		m_pinWrProtectAvailable = false;
+		if (response == Ack::BadCommand) return false;
+	}
+	else {
+		unsigned char value = 0;
+		unsigned long read = m_comPort.read(&value, 1);
+		if (read == 1) {
+			m_pinWrProtectAvailable = true;
+			m_isWriteProtected = value == 0;
+		}
+	}
+
+	if (m_currentBusType == BusType::Shugart) {
+		m_pinDskChangeAvailable = false; // not supported by Greaseweazle on Pin 2
+	}
+	else {
+		if ((!sendCommand(Cmd::GetPin, PIN_DISKCHG_IBMPC, response)) || (response != Ack::Okay)) {
+			m_pinDskChangeAvailable = false;
+			if (response == Ack::BadCommand) return false;
+		}
+		else {
+			unsigned char value = 0;
+			unsigned long read = m_comPort.read(&value, 1);
+			if (read == 1) {
+				m_pinDskChangeAvailable = true;
+				m_diskInDrive = value == 1;
+			}
+		}
+	}
+
+	if (!m_motorIsEnabled) selectDrive(false);
+	return true;
+}
+
+// Search for track 0
+GWResponse GreaseWeazleInterface::findTrack0() {
+	return selectTrack(0, TrackSearchSpeed::tssFast, true);
+}
+
+// Choose which surface of the disk to read from
+GWResponse GreaseWeazleInterface::selectSurface(const DiskSurface side) {
+	Ack response = Ack::Okay;
+	sendCommand(Cmd::Head, (side == DiskSurface::dsUpper ? 1 : 0), response);
+
+	return (response == Ack::Okay) ? GWResponse::drOK : GWResponse::drError;
+}
+
+// send a command out to the GW and receive its response.  Returns FALSE on error
+bool GreaseWeazleInterface::sendCommand(Cmd command, void* params, unsigned int paramsLength, Ack& response, unsigned char extraResponseSize) {
+	std::vector<unsigned char> data;
+	data.resize(paramsLength + 2);
+	data[0] = (unsigned char)command;
+	data[1] = 2 + paramsLength + (extraResponseSize>0 ? 1 : 0);
+	if ((params) && (paramsLength)) {
+#ifdef _WIN32		
+		memcpy_s(((unsigned char*)data.data()) + 2, paramsLength, params, paramsLength);
+#else
+		memcpy(((unsigned char*)data.data()) + 2, params, paramsLength);
+#endif		
+	}
+	if (extraResponseSize>0) data.push_back(extraResponseSize);
+
+	// Write request
+	unsigned long written = (unsigned long)m_comPort.write(data.data(), (unsigned int)data.size());
+	if (written != data.size()) {
+		response = Ack::BadCommand;
+		return false;
+	}
+	
+	// Read response
+	unsigned char responseMsg[2];
+	unsigned long read = m_comPort.read(&responseMsg, 2);
+	if (read != 2) {
+		if (read == 0) {
+			// Try again
+			read = m_comPort.read(&responseMsg, 2);
+		}
+		if (read != 2) {
+			response = Ack::BadCommand;
+			return false;
+		}
+	}
+
+	response = (Ack)responseMsg[1];
+
+	// Was it the response to the command we issued?
+	if (responseMsg[0] != (unsigned char)command) {
+		response = Ack::BadCommand;
+		return false;
+	}
+
+	return true;
+}
+bool GreaseWeazleInterface::sendCommand(Cmd command, const std::vector<unsigned char>& params, Ack& response, unsigned char extraResponseSize) {
+	return sendCommand(command, (void*)params.data(), (unsigned int)params.size(), response, extraResponseSize);
+}
+bool GreaseWeazleInterface::sendCommand(Cmd command, unsigned char param, Ack& response, unsigned char extraResponseSize) {
+	return sendCommand(command, (void*)(&param), 1, response, extraResponseSize);
+}
+
+// Taken from optimised.c and modified
+static int read_28bit(std::queue<unsigned char>& queue) {
+	int x;
+	x = queue.front() >> 1;  queue.pop();
+	x |= (queue.front() & 0xfe) << 6; queue.pop();
+	x |= (queue.front() & 0xfe) << 13; queue.pop();
+	x |= (queue.front() & 0xfe) << 20; queue.pop();
+
+	return x;
+}
+
+// Convert from nSec to TICKS
+static unsigned int nSecToTicks(unsigned int nSec, unsigned int sampleFrequency) {
+	return ((unsigned long long)nSec * (unsigned long long)sampleFrequency) / (unsigned long long)ONE_NANOSECOND;
+}
+
+// Convert from TICKS to nSec
+static unsigned int ticksToNSec(unsigned int ticks, unsigned int sampleFrequency) {
+	return ((unsigned long long)ticks * ONE_NANOSECOND) / (unsigned long long)sampleFrequency;
+}
+
+// Look at the stream and count up the types of data
+void countSampleTypes(PLLData& pllData, std::queue<unsigned char>& queue, unsigned int& hdBits, unsigned int& ddBits) {
+	while (!queue.empty()) {
+
+		unsigned char i = queue.front();
+		if (i == 255) {
+			if (queue.size() < 6) return;
+			queue.pop();
+
+			// Get opcode
+			switch ((FluxOp)queue.front()) {
+			case FluxOp::Index:
+				queue.pop();
+				read_28bit(queue);
+				break;
+
+			case FluxOp::Space:
+				queue.pop();
+				pllData.ticks += read_28bit(queue);
+				break;
+
+			default:
+				queue.pop();
+				break;
+			}
+		}
+		else {
+			if (i < 250) {
+				pllData.ticks += (int)i;
+				queue.pop();
+			}
+			else {
+				if (queue.size() < 2) return;
+				queue.pop();
+				pllData.ticks += (250 + (((unsigned int)i) - 250) * 255) + (queue.front() - 1);
+				queue.pop();
+			}
+
+			// Work out the actual time this tick took in nanoSeconds.
+			unsigned int tickInNS = ticksToNSec(pllData.ticks, pllData.freq);
+			if (tickInNS > BITCELL_SIZE_IN_NS) {
+				if (tickInNS < 3000) hdBits++; 
+				if ((tickInNS > 4500) && (tickInNS < 8000)) ddBits++;
+				pllData.ticks = 0;
+			}
+		}
+	}
+}
+
+// Test the inserted disk and see if its HD or not
+GWResponse GreaseWeazleInterface::checkDiskCapacity(bool& isHD) {
+	GWReadFlux header{};
+	header.ticks = 0;
+	header.max_index = 1;
+	header.max_index_linger = nSecToTicks(50, m_gwVersionInformation.sample_freq);
+
+	bool alreadySpun = m_motorIsEnabled;
+	if (!alreadySpun)
+		if (enableMotor(true, false) != GWResponse::drOK) return GWResponse::drError;
+
+	selectDrive(true);
+
+	// Write request
+	Ack response = Ack::Okay;
+	if (!sendCommand(Cmd::ReadFlux, (void*)&header, sizeof(header), response)) {
+		selectDrive(false);
+		return GWResponse::drError;
+	}
+
+	// Buffer to read into
+	unsigned char tempReadBuffer[64] = { 0 };
+	bool zeroDetected = false;
+	unsigned int failCount = 0;
+
+	// Read the flux data
+	PLLData pllData;
+	pllData.freq = m_gwVersionInformation.sample_freq;
+	unsigned int hdBits = 0;
+	unsigned int ddBits = 0;
+
+	std::queue<unsigned char> queue;
+
+	do {
+		// More efficient to read several bytes in one go		
+		unsigned long bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof(tempReadBuffer)) bytesAvailable = sizeof(tempReadBuffer);
+		unsigned long bytesRead = m_comPort.read(tempReadBuffer, m_shouldAbortReading ? 1 : bytesAvailable);
+		if (bytesRead < 1) {
+			failCount++;
+			if (failCount > 10) break;
+		}
+		else failCount = 0;
+
+		if (bytesRead) {
+
+			for (unsigned int a = 0; a < bytesRead; a++) {
+				queue.push(tempReadBuffer[a]);
+				zeroDetected |= tempReadBuffer[a] == 0;
+			}
+
+			// Look at the stream and count up the types of data
+			countSampleTypes(pllData, queue, hdBits, ddBits);
+		}		
+	} while (!zeroDetected);
+
+	// Check for errors
+	response = Ack::Okay;
+	sendCommand(Cmd::GetFluxStatus, nullptr, 0, response);
+
+	selectDrive(false);
+
+	if (!alreadySpun) enableMotor(false, false);
+
+	isHD = (hdBits > ddBits);
+	return GWResponse::drOK;
+}
+
+// Read RAW data from the current track and surface 
+GWResponse GreaseWeazleInterface::checkForDisk(bool force) {
+	if (force)
+		if (!checkPins()) return GWResponse::drError;
+
+	if (m_pinDskChangeAvailable) {
+		return m_diskInDrive ? GWResponse::drOK : GWResponse::drNoDiskInDrive;
+	}
+
+	if (force) {
+		GWReadFlux header;
+		header.ticks = 0;
+		header.max_index = 2;
+		header.max_index_linger = 0;
+
+		bool alreadySpun = m_motorIsEnabled;
+		if (!alreadySpun)
+			if (enableMotor(true, false) != GWResponse::drOK) return GWResponse::drOK;
+
+		selectDrive(true);
+
+		// Write request
+		Ack response = Ack::Okay;
+		if (!sendCommand(Cmd::ReadFlux, (void*)&header, sizeof(header), response)) {
+			selectDrive(false);
+			if (response == Ack::BadCommand) return GWResponse::drError;
+			return GWResponse::drOK;
+		}
+
+		for (;;) {
+			// Read a single byte
+			unsigned char byte;
+			if (m_comPort.read(&byte, 1))
+				if (byte == 0) break;
+		};
+
+		// Check for errors
+		response = Ack::Okay;
+		sendCommand(Cmd::GetFluxStatus, nullptr, 0, response);
+		if (response == Ack::BadCommand) return GWResponse::drError;
+		selectDrive(false);
+
+		if (!alreadySpun) enableMotor(false, false);
+
+		m_diskInDrive = response != Ack::NoIndex;
+	}
+	return m_diskInDrive ? GWResponse::drOK : GWResponse::drNoDiskInDrive;
+}
+
+// Read a bit from the MFM data provided
+inline int readBit(const unsigned char* buffer, const unsigned int maxLength, int& pos, int& bit) {
+	if (pos >= (int)maxLength) {
+		bit--;
+		if (bit < 0) {
+			bit = 7;
+			pos++;
+		}
+		return (bit & 1) ? 0 : 1;
+	}
+
+	int ret = (buffer[pos] >> bit) & 1;
+	bit--;
+	if (bit < 0) {
+		bit = 7;
+		pos++;
+	}
+
+	return ret;
+}
+
+// Write 28bit value ot the output
+void write28bit(int value, std::vector<unsigned char>& output) {
+	output.push_back(1 | ((value << 1) & 255));
+	output.push_back(1 | ((value >> 6) & 255));
+	output.push_back(1 | ((value >> 13) & 255));
+	output.push_back(1 | ((value >> 20) & 255));
+}
+
+// Write data to the disk
+GWResponse GreaseWeazleInterface::writeCurrentTrackPrecomp(const unsigned char* mfmData, const uint16_t numBytes, const bool writeFromIndexPulse, bool usePrecomp) {
+	std::vector<unsigned char> outputBuffer;
+
+	// Original data was written from MSB down to LSB
+	int pos = 0;
+	int bit = 7;
+	unsigned char sequence = 0xAA;  // start at 10101010
+
+	const int nfa_thresh = (int)((float)150e-6 * (float)m_gwVersionInformation.sample_freq);
+	const int nfa_period = (int)((float)1.25e-6 * (float)m_gwVersionInformation.sample_freq);
+	const int precompTime = m_inHDMode ? 70 : 140;   // Amiga default precomp amount (140ns)
+	int extraTimeFromPrevious = 0;
+
+	// Re-encode the data into our format and apply precomp. 
+	while (pos < numBytes+8) {
+		int b, count = 0;
+
+		// See how many zero bits there are before we hit a 1
+		do {
+			b = readBit(mfmData, numBytes, pos, bit);
+			sequence = ((sequence << 1) & 0x7F) | b;
+			count++;
+		} while (((sequence & 0x08) == 0) && (pos < numBytes + 8));  // the +8 is for safety
+
+		// Validate range
+		if (count < 1) count = 1;  //
+		if (count > 5) count = 5;  // max we support 01, 001, 0001, 00001
+		
+		// Calculate the time for this in nanoseconds
+		int timeInNS = extraTimeFromPrevious + (count * (m_inHDMode ? 1000 : 2000));     // 2=4000, 3=6000, 4=8000, (5=10000 although is isn't strictly allowed)
+
+		if (usePrecomp) {
+			const unsigned char BitSeq5 = (sequence & 0x3E);  // extract these bits 00111110 - bit 3 is the ACTUAL bit
+			// Updated from https://github.com/keirf/greaseweazle/blob/master/src/greaseweazle/track.py
+			// The actual idea is that the magnetic fields will repel each other, so we push them closer hoping they will land in the correct spot!
+			switch (BitSeq5) {
+			case 0x28:     // xx10100x
+				timeInNS -= precompTime;
+				extraTimeFromPrevious = precompTime;
+				break;
+			case 0x0A:     // xx00101x
+				timeInNS += precompTime;
+				extraTimeFromPrevious = -precompTime;
+				break;
+			default: 
+				{
+					const unsigned char BitSeq3 = (sequence & 0x1C);  // extract these bits 00011100 - bit 3 is the ACTUAL bit
+					switch (BitSeq3) {
+					case 0x18:   // xxx110xx
+						timeInNS -= precompTime;
+						extraTimeFromPrevious = precompTime;
+						break;
+					case 0x0C:   // xxx011xx
+						timeInNS += precompTime;
+						extraTimeFromPrevious = precompTime;
+						break;
+					default:
+						extraTimeFromPrevious = 0;
+						break;
+					}
+					break;
+				}
+			}
+		}
+
+		const int ticks = nSecToTicks(timeInNS, m_gwVersionInformation.sample_freq);
+		
+		// Encode for GW
+		if (ticks>0) {
+			if (ticks < 250) {
+				outputBuffer.push_back(ticks);
+			}
+			else {
+				if (ticks > nfa_thresh) {
+					outputBuffer.push_back(255);
+					outputBuffer.push_back((unsigned char)FluxOp::Space);   // Space
+					write28bit(ticks, outputBuffer);
+					outputBuffer.push_back(255);
+					outputBuffer.push_back((unsigned char)FluxOp::Astable);   // Space
+					outputBuffer.push_back(nfa_period);
+				}
+				else {
+					unsigned int high = (ticks - 250) / 255;
+					if (high < 5) {
+						outputBuffer.push_back(250 + high);
+						outputBuffer.push_back(1 + (ticks - 250) % 255);
+					}
+					else {
+						outputBuffer.push_back(255);
+						outputBuffer.push_back((unsigned char)FluxOp::Space);   // Space
+						write28bit(ticks - 249, outputBuffer);
+						outputBuffer.push_back(249);
+					}
+				}
+			}
+		}
+	}
+	
+	outputBuffer.push_back(0); // finish	
+
+	selectDrive(true);
+
+	// Header
+	GWWriteFlux header;
+	header.cue_at_index = writeFromIndexPulse ? 1 : 0;
+	header.terminate_at_index = 0;
+
+	// Write request
+	Ack response = Ack::Okay;
+	if (!sendCommand(Cmd::WriteFlux, (void*)&header, sizeof(header), response)) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		return GWResponse::drReadResponseFailed;
+	}
+
+	switch (response) {
+		case Ack::Wrprot:
+			if (!m_motorIsEnabled) selectDrive(false);
+			return GWResponse::drWriteProtected;
+
+		case Ack::Okay: 
+			break;
+
+		default:
+			if (!m_motorIsEnabled) selectDrive(false);
+			return GWResponse::drReadResponseFailed;
+	}
+
+	// Write it
+	unsigned long write = m_comPort.write(outputBuffer.data(), (unsigned int)outputBuffer.size());
+	if (write != outputBuffer.size()) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		return GWResponse::drReadResponseFailed;
+	}
+
+	// Sync with GW
+	unsigned char sync;
+	unsigned long read = m_comPort.read(&sync, 1);
+	if (read != 1) {
+		selectDrive(false);
+		return GWResponse::drReadResponseFailed;
+	}
+
+	// Check the value of SYNC
+	response = Ack::Okay;
+	sendCommand(Cmd::GetFluxStatus, nullptr, 0, response);
+
+	selectDrive(false);
+
+	switch (response) {
+	case Ack::FluxUnderflow: return GWResponse::drSerialOverrun;
+	case Ack::Wrprot: m_isWriteProtected = true;  return GWResponse::drWriteProtected;
+	case Ack::Okay: return GWResponse::drOK;
+	default: return GWResponse::drReadResponseFailed;
+	}
+}
+
+// Process queue and work out whats going on
+inline void unpackStreamQueue(std::queue<unsigned char>& queue, PLLData& pllData, PLL::BridgePLL& pll, bool isHDMode) {
+	// Run until theres not enough data left to process
+	while (!queue.empty()) {
+
+		unsigned char i = queue.front();
+		if (i == 255) {
+			if (queue.size() < 6) return;
+			queue.pop();
+
+			// Get opcode
+			switch ((FluxOp)queue.front()) {
+			case FluxOp::Index:
+				queue.pop();
+				read_28bit(queue);
+				pllData.indexHit = true;
+				break;
+
+			case FluxOp::Space:
+				queue.pop();
+				pllData.ticks += read_28bit(queue);
+				break;
+
+			default:
+				queue.pop();
+				break;
+			}
+		}
+		else {
+			if (i < 250) {
+				pllData.ticks += (int32_t)i;
+				queue.pop();
+			}
+			else {
+				if (queue.size() < 2) return;
+				queue.pop();				
+				pllData.ticks += (250 + (((int32_t)i) - 250) * 255) + ((int32_t)queue.front() - 1);
+				queue.pop();
+			}
+
+			// Work out the actual time this tick took in nanoSeconds.
+			uint32_t tickInNS = ticksToNSec(pllData.ticks, pllData.freq);
+
+			// This is how the Amiga expects it
+			if (isHDMode) tickInNS *= 2;
+
+			pll.submitFlux(tickInNS, pllData.indexHit);
+			pllData.indexHit = false;
+			pllData.ticks = 0;
+		}
+	}
+
+}
+
+// Reads "enough" data to extract data from the disk. This doesnt care about creating a perfect revolution - pll should have the LinearExtractor configured
+GWResponse GreaseWeazleInterface::readData(PLL::BridgePLL& pll) {
+	GWReadFlux header;
+
+	// 220ms is long enough for even the worst drives. If a revolution takes longer than this then theres a problem anyway
+	header.ticks = nSecToTicks(220 * 1000 * 1000, m_gwVersionInformation.sample_freq);
+	header.max_index = 0;
+	header.max_index_linger = 0;
+
+	m_shouldAbortReading = false;
+
+	// Sample storage
+	std::queue<unsigned char> queue;
+
+	// Reset ready for extraction	
+	pll.rotationExtractor()->reset(m_inHDMode);
+
+	selectDrive(true);
+
+	// Write request
+	Ack response = Ack::Okay;
+	if (!sendCommand(Cmd::ReadFlux, (void*)&header, sizeof(header), response)) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		return GWResponse::drReadResponseFailed;
+	}
+	int32_t failCount = 0;
+
+	// Buffer to read into
+	unsigned char tempReadBuffer[64] = { 0 };
+	bool zeroDetected = false;
+
+	applyCommTimeouts(true);
+
+	PLLData pllData;
+	pllData.freq = m_gwVersionInformation.sample_freq;
+
+	do {
+		// More efficient to read several bytes in one go		
+		uint32_t bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof(tempReadBuffer)) bytesAvailable = sizeof(tempReadBuffer);
+		uint32_t bytesRead = m_comPort.read(tempReadBuffer, m_shouldAbortReading ? 1 : bytesAvailable);
+		if (bytesRead < 1) {
+			failCount++;
+			if (failCount > 10) break;
+		}
+		else failCount = 0;
+
+		// If theres this many we can process as this is the maximum we need to process
+		if ((!m_shouldAbortReading) && (bytesRead)) {
+
+			for (uint32_t a = 0; a < bytesRead; a++) {
+				queue.push(tempReadBuffer[a]);
+				zeroDetected |= tempReadBuffer[a] == 0;
+			}
+
+			unpackStreamQueue(queue, pllData, pll, m_inHDMode);			
+		}
+		else {
+			for (uint32_t a = 0; a < bytesRead; a++) zeroDetected |= tempReadBuffer[a] == 0;
+		}
+	} while (!zeroDetected);
+
+	applyCommTimeouts(false);
+
+	// Check for errors
+	response = Ack::Okay;
+	sendCommand(Cmd::GetFluxStatus, nullptr, 0, response);
+
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	// Update this flag
+	m_diskInDrive = response != Ack::NoIndex;
+
+	switch (response) {
+	case Ack::FluxOverflow: return GWResponse::drSerialOverrun;
+	case Ack::NoIndex: return GWResponse::drNoDiskInDrive;
+	case Ack::Okay: return GWResponse::drOK;
+	default: return  GWResponse::drReadResponseFailed;
+	}
+}
+
+// Reads a complete rotation of the disk, and returns it using the callback function which can return FALSE to stop
+// An instance of RotationExtractor is required.  This is purely to save on re-allocations.  It is internally reset each time
+// This is slower than the above because this one focuses on an accurate rotation image of the data rather than just a stream
+GWResponse GreaseWeazleInterface::readRotation(PLL::BridgePLL& pll, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns,
+	std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation) {	
+	GWReadFlux header;
+
+	const uint32_t extraTime = OVERLAP_SEQUENCE_MATCHES * (OVERLAP_EXTRA_BUFFER) * 8000;  // this is approx 49mS
+	if ((pll.rotationExtractor()->isInIndexMode()) || (!pll.rotationExtractor()->hasLearntRotationSpeed())) {
+		header.ticks = 0;
+		header.max_index = 1;
+		header.max_index_linger = nSecToTicks((210 * 1000 * 1000) + extraTime, m_gwVersionInformation.sample_freq);
+	}
+	else {
+		header.ticks = nSecToTicks((210 * 1000 * 1000) + extraTime, m_gwVersionInformation.sample_freq);
+		header.max_index = 0;
+		header.max_index_linger = 0;
+	}
+	
+	m_shouldAbortReading = false;
+
+	// Sample storage
+	std::queue<unsigned char> queue;
+
+	// Reset ready for extraction
+	pll.prepareExtractor(m_inHDMode, startBitPatterns);
+
+	selectDrive(true);
+
+	// Write request
+	Ack response = Ack::Okay;
+	if (!sendCommand(Cmd::ReadFlux, (void*)&header, sizeof(header), response)) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		return GWResponse::drReadResponseFailed;
+	}
+	int32_t failCount = 0;
+
+	// Buffer to read into
+	unsigned char tempReadBuffer[64] = { 0 };
+	bool zeroDetected = false;
+
+	applyCommTimeouts(true);
+
+	PLLData pllData;
+	pllData.freq = m_gwVersionInformation.sample_freq;
+
+	do {
+		// More efficient to read several bytes in one go		
+		uint32_t bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof(tempReadBuffer)) bytesAvailable = sizeof(tempReadBuffer);
+		uint32_t bytesRead = m_comPort.read(tempReadBuffer, m_shouldAbortReading ? 1 : bytesAvailable);
+		if (bytesRead<1) {
+			failCount++;
+			if (failCount > 10) break;
+		}
+		else failCount = 0;
+
+		// If theres this many we can process as this is the maximum we need to process
+		if ((!m_shouldAbortReading) && (bytesRead)) {
+
+			for (uint32_t a = 0; a < bytesRead; a++) {
+				queue.push(tempReadBuffer[a]);
+				zeroDetected |= tempReadBuffer[a] == 0;
+			}
+
+			unpackStreamQueue(queue, pllData, pll, m_inHDMode);
+
+			// Is it ready to extract?
+			if (pll.canExtract()) {
+				uint32_t bits = 0;
+				// Go!
+				if (pll.extractRotation(firstOutputBuffer, bits, maxOutputSize)) {
+					if (!onRotation(&firstOutputBuffer, bits)) {
+						// And if the callback says so we stop. - unsupported at present
+						abortReadStreaming();
+					}
+					// Always save this back
+					pll.getIndexSequence(startBitPatterns);
+				}
+			}
+		}
+		else {
+			for (uint32_t a = 0; a < bytesRead; a++) zeroDetected |= tempReadBuffer[a] == 0;
+		}
+	} while (!zeroDetected);
+
+	applyCommTimeouts(false);
+
+	// Check for errors
+	response = Ack::Okay;
+	sendCommand(Cmd::GetFluxStatus, nullptr, 0, response);
+
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	// Update this flag
+	m_diskInDrive = response != Ack::NoIndex;
+
+	switch (response) {
+	case Ack::FluxOverflow: return GWResponse::drSerialOverrun;
+	case Ack::NoIndex: return GWResponse::drNoDiskInDrive;
+	case Ack::Okay: return GWResponse::drOK;
+	default: return  GWResponse::drReadResponseFailed;
+	}
+}
+
+// Attempt to abort reading
+void GreaseWeazleInterface::abortReadStreaming() {
+	m_shouldAbortReading = true;
+}
+

--- a/vendor/floppybridge/src/GreaseWeazleInterface.h
+++ b/vendor/floppybridge/src/GreaseWeazleInterface.h
@@ -1,0 +1,247 @@
+#ifndef GREASEWEAZLE_INTERFACE
+#define GREASEWEAZLE_INTERFACE
+/* Greaseweazle C++ Interface for reading and writing Amiga Disks
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* Based on the excellent code by Keir Fraser <keir.xen@gmail.com>
+* https://github.com/keirf/Greaseweazle/
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+#include <string>
+#include <functional>
+#include <vector>
+#include "RotationExtractor.h"
+#include "SerialIO.h"
+#include "pll.h"
+
+namespace GreaseWeazle {
+
+	// Represent which side of the disk we're looking at
+	enum class DiskSurface {
+		dsUpper,            // The upper side of the disk
+		dsLower             // The lower side of the disk
+	};
+
+	// Speed at which the head will seek to a track
+	enum class TrackSearchSpeed {
+		tssSlow,
+		tssNormal,
+		tssFast,
+		tssVeryFast
+	};
+
+	// Command set
+	enum class Cmd {
+		GetInfo = 0,
+		Update = 1,
+		Seek = 2,
+		Head = 3,
+		SetParams = 4,
+		GetParams = 5,
+		Motor = 6,
+		ReadFlux = 7,
+		WriteFlux = 8,
+		GetFluxStatus = 9,
+		GetIndexTimes = 10,
+		SwitchFwMode = 11,
+		Select = 12,
+		Deselect = 13,
+		SetBusType = 14,
+		SetPin = 15,
+		Reset = 16,
+		EraseFlux = 17,
+		SourceBytes = 18,
+		SinkBytes = 19,
+		GetPin = 20,
+		TestMode = 21,
+		NoClickStep = 22
+	};
+
+	// Command responses/acknowledgments
+	enum class Ack {
+		Okay = 0,
+		BadCommand = 1,
+		NoIndex = 2,
+		NoTrk0 = 3,
+		FluxOverflow = 4,
+		FluxUnderflow = 5,
+		Wrprot = 6,
+		NoUnit = 7,
+		NoBus = 8,
+		BadUnit = 9,
+		BadPin = 10,
+		BadCylinder = 11
+	};
+
+
+	// Diagnostic responses from the interface
+	enum class GWResponse {
+		drOK,
+
+		// Responses from openPort
+		drPortInUse,
+		drPortNotFound,
+		drPortError,
+		drAccessDenied,
+		drComportConfigError,
+		drErrorMalformedVersion,
+		drOldFirmware,
+		drInUpdateMode,
+
+		// Responses from commands
+		drReadResponseFailed,
+		drSerialOverrun,
+		drError,
+
+		// Response from selectTrack
+		drTrackRangeError,
+		drSelectTrackError,
+		drWriteProtected,
+
+		// Returned if there is no disk in the drive
+		drNoDiskInDrive,
+
+		drRewindFailure,
+	};
+
+
+#pragma pack(1)
+	// <4BI3B21x
+	struct GWVersionInformation  {
+		unsigned char major, minor, is_main_firmware, max_cmd;
+		uint32_t sample_freq;   // sample_freq * 1e-6 = Mhz
+		unsigned char hw_model, hw_submodel, usb_speed;
+
+		unsigned char padding[21];
+	};
+
+	// <5H
+	struct GWDriveDelays {
+		uint16_t select_delay, step_delay;			// in uSec
+		uint16_t seek_settle_delay, motor_delay, watchdog_delay;  // in mSec
+	};
+
+	// ## Cmd.SetBusType values
+	enum class BusType { Invalid = 0, IBMPC = 1, Shugart = 2 };
+
+	enum class DriveSelection { dsA=0, dsB=1, ds0=2, ds1=3, ds2=4, ds3=5 };
+		
+#pragma pack()
+
+
+
+	class GreaseWeazleInterface {
+	private:
+		// Windows handle to the serial port device
+		SerialIO		m_comPort;
+		BusType			m_currentBusType;
+		unsigned char	m_currentDriveIndex;
+		bool			m_diskInDrive;
+		bool			m_motorIsEnabled;
+		bool			m_shouldAbortReading = false;
+		bool			m_pinDskChangeAvailable = false;
+		bool			m_pinWrProtectAvailable = false;
+		bool			m_isWriteProtected = false;
+		bool			m_selectStatus = false;
+		bool			m_inHDMode = false;
+
+		// Version information read during openPort
+		GWVersionInformation m_gwVersionInformation{};
+
+		// Delay settings
+		GWDriveDelays m_gwDriveDelays{};
+
+		// Apply and change the timeouts on the com port
+		void applyCommTimeouts(bool shortTimeouts);
+
+		// send a command out to the GW and receive its response.  Returns FALSE on error
+		bool sendCommand(Cmd command, const std::vector<unsigned char>& params, Ack& response, unsigned char extraResponseSize = 0);
+		bool sendCommand(Cmd command, void* params, unsigned int paramsLength, Ack& response, unsigned char extraResponseSize = 0);
+		bool sendCommand(Cmd command, unsigned char param, Ack& response, unsigned char extraResponseSize = 0);
+
+		// Update the delay counts from m_gwDriveDelays
+		bool updateDriveDelays();
+
+		// Trigger selecting this drive
+		bool selectDrive(bool select);
+
+		// Polls for the state of pins on the board
+		bool checkPins();
+	public:
+		// Constructor for this class
+		GreaseWeazleInterface();
+
+		// Free me
+		~GreaseWeazleInterface();
+
+		const bool isOpen() const { return m_comPort.isPortOpen(); }
+
+		// Returns the timr before the motor switches back off
+		int getMotorTimeout() const { return m_gwDriveDelays.watchdog_delay; }
+
+		bool supportsDiskChange() const { return m_pinDskChangeAvailable; }
+		BusType currentBusType() const { return m_currentBusType; };
+		bool isWriteProtected() const { return m_isWriteProtected; }
+
+		// Change the disk capacity we're using
+		void setDiskCapacity(bool hd) { m_inHDMode = hd; }
+
+		// Test the inserted disk and see if its HD or not
+		GWResponse checkDiskCapacity(bool& isHD);
+
+		// Attempts to open the reader running on the COM port provided (or blank for auto-detect)
+		GWResponse openPort(const std::string& comPort, DriveSelection drive);
+
+		// Reads a complete rotation of the disk, and returns it using the callback function which can return FALSE to stop
+		// An instance of BridgePLL is required.  This is purely to save on re-allocations.  It is internally reset each time
+		GWResponse readRotation(PLL::BridgePLL& pll, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns,
+			std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation);
+
+		// Reads "enough" data to extract data from the disk. This doesn't care about creating a perfect revolution - pll should have the LinearExtractor configured
+		GWResponse readData(PLL::BridgePLL& pll);
+
+		// Turns on and off the reading interface.  dontWait disables the GW timeout waiting, so you must instead.  Returns drOK, drError, 
+		GWResponse enableMotor(const bool enable, const bool dontWait = false);
+
+		// Seek to track 0 - Can return drRewindFailure, drSelectTrackError, drOK
+		GWResponse findTrack0();
+
+		// Select the track, this makes the motor seek to this position. Can return drRewindFailure, drSelectTrackError, drOK, drTrackRangeError
+		GWResponse selectTrack(const unsigned char trackIndex, const TrackSearchSpeed searchSpeed = TrackSearchSpeed::tssNormal, bool ignoreDiskInsertCheck = false);
+
+		// Special command that asks GW to do a 'seek to track -1' which isnt allowed but can be used for disk detection
+		GWResponse performNoClickSeek();
+
+		// Choose which surface of the disk to read from.  Can return drError or drOK
+		GWResponse selectSurface(const DiskSurface side);
+
+		// Write data to the disk.  Can return drReadResponseFailed, drWriteProtected, drSerialOverrun, drWriteProtected, drOK
+		GWResponse writeCurrentTrackPrecomp(const unsigned char* mfmData, const uint16_t numBytes, const bool writeFromIndexPulse, bool usePrecomp);
+
+		// Attempt to abort reading
+		void abortReadStreaming();
+
+		// Check if a disk is present in the drive
+		GWResponse checkForDisk(bool force);
+
+		// Closes the port down
+		void closePort();
+	};
+
+};
+
+#endif

--- a/vendor/floppybridge/src/RotationExtractor.cpp
+++ b/vendor/floppybridge/src/RotationExtractor.cpp
@@ -1,0 +1,580 @@
+/* ArduinoFloppyReader (and writer) - Rotation Extractor
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Class to manage finding *exact* disk revolutions                                   //
+////////////////////////////////////////////////////////////////////////////////////////
+//
+// Purpose:
+// The class attempts to guess where an exact disk revolution occurs, and then re-aligns
+// it such that it starts at the index pulse.  This means we dont need to wait for an index
+// pulse to work out a revolution of the disk.  The first time a disk is used we calculate
+// the time of a single revolution and then use that as a guide to how long a revolution will
+// take in the future.
+//
+// This isn't 100% perfect but does seem to work.
+
+#include "RotationExtractor.h"
+#include <cstring>
+
+RotationExtractor::RotationExtractor() : m_sequences(new MFMSequenceInfo[MAX_REVOLUTION_SEQUENCES]),
+										 m_initialSequences(
+											 new MFMSequenceInfo[OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER])
+{
+}
+RotationExtractor::~RotationExtractor() {
+	delete[] m_sequences;
+	delete[] m_initialSequences;
+}
+
+
+// Finds the overlap between the start of the data and where we currently are.  The returned position is where the NEXT revolution starts
+uint32_t RotationExtractor::getOverlapPosition(uint32_t& numberOfBadMatches) const {
+	numberOfBadMatches = 0;
+
+	int bestScore = OVERLAP_SEQUENCE_MATCHES / 2;     // must have *some* kind of match to be worthy
+	uint32_t bestScoreIndex = m_revolutionReadyAt;
+
+	// Working back from the mid-point
+	for (uint32_t midPoint = 0; midPoint < OVERLAP_SEQUENCE_MATCHES * (OVERLAP_EXTRA_BUFFER - 1); midPoint++) {
+
+		// Count the number of matching sequences
+		int scoreL = 0;
+		int scoreR = 0;
+		const int startPositionR = m_revolutionReadyAt + midPoint;
+		const int startPositionL = m_revolutionReadyAt - midPoint;
+
+		if (startPositionL + OVERLAP_SEQUENCE_MATCHES >= (int32_t)m_sequencePos) continue;
+		if (startPositionR + OVERLAP_SEQUENCE_MATCHES >= (int32_t)m_sequencePos) {
+			if (startPositionL >= 0) {
+				for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES; pos++) {
+					if (m_indexSequence.sequences[pos] == m_sequences[startPositionL + pos].mfm) scoreL++;
+				}
+			}
+			else continue;
+		}
+		else {
+			if (startPositionL >= 0) {
+				for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES; pos++) {
+					if (m_sequences[pos].mfm == m_sequences[startPositionR + pos].mfm) scoreR++;
+					if (m_sequences[pos].mfm == m_sequences[startPositionL + pos].mfm) scoreL++;
+				}
+			}
+			else {
+			for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES; pos++) {
+					if (m_sequences[pos].mfm == m_sequences[startPositionR + pos].mfm) scoreR++;
+				}
+			}
+		}
+
+		// A perfect score short-circuits the rest of the loop		
+		if (scoreL > bestScore) {
+			bestScore = scoreL;
+			bestScoreIndex = startPositionL;
+		}
+		if (scoreR > bestScore) {
+			bestScore = scoreR;
+			bestScoreIndex = startPositionR;
+		}
+
+		if (bestScore == OVERLAP_SEQUENCE_MATCHES) return bestScoreIndex;
+	}
+
+	// If we got here then there wasn't a perfect match.  This would only happen if:
+	// 1. The drive speed is broken!
+	// 2. The overlap is unformatted, in which case it doesn't really matter anyway
+	// 3. The disk/head is damaged or dirty, so then there's no hope anyway
+
+	numberOfBadMatches = OVERLAP_SEQUENCE_MATCHES - bestScore;
+
+	return bestScoreIndex;
+}
+
+// Finds the true start position of the INDEX pulse based on previous revolutions.  This is a lot like the above function
+uint32_t RotationExtractor::getTrueIndexPosition(const uint32_t nextRevolutionStart, const uint32_t startingPoint)
+{
+	// Where to start from
+	const uint32_t firstPoint = startingPoint == INDEX_NOT_FOUND ? (m_sequenceIndex == INDEX_NOT_FOUND ? 0 : m_sequenceIndex) : startingPoint;
+
+	// First. Do we actually have a 'index marker' buffer?
+	if (!m_indexSequence.valid) {
+		// Not valid means we make it, and take our index as "true"
+		m_indexSequence.valid = true;
+		for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES_INDEXMODE; pos++)
+			m_indexSequence.sequences[pos] = m_sequences[(firstPoint + pos) % nextRevolutionStart].mfm;
+
+		return firstPoint;
+	}
+
+	int bestScore = OVERLAP_SEQUENCE_MATCHES_INDEXMODE / 4;     // must have *some* kind of match to be worthy
+	uint32_t bestScoreIndex = firstPoint;
+
+	// Working back from the mid-point
+	for (uint32_t midPoint = 0; midPoint < OVERLAP_SEQUENCE_MATCHES_INDEXMODE * (OVERLAP_EXTRA_BUFFER - 1); midPoint++) {
+
+		// Count the number of matching sequences
+		int scoreL = 0;
+		int scoreR = 0;
+		const int startPositionR = firstPoint + midPoint;
+		const int startPositionL = firstPoint - midPoint;
+
+		// If this happens then nothing is going to work
+		if (startPositionL + OVERLAP_SEQUENCE_MATCHES_INDEXMODE >= (int32_t)m_sequencePos) continue;
+		if (startPositionR + OVERLAP_SEQUENCE_MATCHES_INDEXMODE >= (int32_t)m_sequencePos) {
+			if (startPositionL >= 0) {
+				for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES_INDEXMODE; pos++) {
+					if (m_indexSequence.sequences[pos] == m_sequences[startPositionL + pos].mfm) scoreL++;
+				}
+			}
+			else continue;
+		}
+		else {
+			if (startPositionL >= 0) {
+				for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES_INDEXMODE; pos++) {
+					if (m_indexSequence.sequences[pos] == m_sequences[startPositionR + pos].mfm) scoreR++;
+					if (m_indexSequence.sequences[pos] == m_sequences[startPositionL + pos].mfm) scoreL++;
+				}
+			}
+			else {
+				for (uint32_t pos = 0; pos < OVERLAP_SEQUENCE_MATCHES_INDEXMODE; pos++) {
+					if (m_indexSequence.sequences[pos] == m_sequences[startPositionR + pos].mfm) scoreR++;
+				}
+			}
+		}
+
+		// A perfect score short-circuits the rest of the loop		
+		if (scoreL > bestScore) {
+			bestScore = scoreL;
+			bestScoreIndex = startPositionL;
+		}
+		if (scoreR > bestScore) {
+			bestScore = scoreR;
+			bestScoreIndex = startPositionR;
+		}
+
+		if (bestScore == OVERLAP_SEQUENCE_MATCHES_INDEXMODE) return bestScoreIndex;
+	}
+
+	// If we got here then there wasn't a perfect match.  This would only happen if:
+	// 1. The drive speed is broken!
+	// 2. The overlap is unformatted, in which case it doesn't really matter anyway
+	// 3. The disk/head is damaged or dirty, so then there's no hope anyway
+	return bestScoreIndex;
+}
+
+// Write a bit into the stream
+inline void writeStreamBit(RotationExtractor::MFMSample* output, uint32_t& pos, uint32_t& bit, bool value, const unsigned short valuespeed, const uint32_t maxLength) {
+	if (pos >= maxLength) return;
+
+	output[pos].mfmData <<= 1;
+	if (value) output[pos].mfmData |= 1;
+
+#ifdef OUTPUT_TIME_IN_NS
+	output[pos].bittime[7 - bit] = valuespeed;
+#else
+#ifdef HIGH_RESOLUTION_MODE
+	output[pos].speed[7 - bit] = valuespeed;
+#else
+	if (bit == 0) output[pos].speed = valuespeed; else  output[pos].speed += valuespeed;
+#endif
+#endif
+
+	bit++;
+	if (bit >= 8) {
+#ifndef OUTPUT_TIME_IN_NS
+#ifndef HIGH_RESOLUTION_MODE
+		output[pos].speed /= 8;
+#endif
+#endif
+		pos++;
+		bit = 0;
+	}
+}
+
+// Submit a single sequence to the list
+void RotationExtractor::submitSequence(const MFMSequenceInfo& sequence, const bool isIndex, const bool discardEarlySamples) {
+	// we reject the first 20uSec of data.  Makes things so much more stable
+	if (discardEarlySamples) {
+		m_timeReceived += sequence.timeNS;
+		if (m_timeReceived < 20000) return;
+	}
+
+	// And stop if we have too much.  Shouldn't happen
+	if (m_sequencePos >= MAX_REVOLUTION_SEQUENCES) 
+		return;
+
+	// See if we can calculate the time it takes to get a single revolution from the disk
+	if ((m_revolutionTime == 0) && (!m_useIndex) && (!m_useSimpleMode)) {
+		if (isIndex) {
+			if (m_sequenceIndex == INDEX_NOT_FOUND) m_sequenceIndex = 0; else m_nextSequenceIndex = m_sequencePos;
+		}
+
+		if (m_sequenceIndex != INDEX_NOT_FOUND) {
+			// Store the sequence only if we found the first index
+			m_sequences[m_sequencePos++] = sequence;
+			m_currentTime += sequence.timeNS;
+
+			if (m_nextSequenceIndex == INDEX_NOT_FOUND)
+				m_revolutionTimeCounting += sequence.timeNS;
+			else {
+				m_revolutionTime = m_revolutionTimeCounting;
+
+				// Set the nearly complete marker to be at 90%.  That would only need approx another 20ms to complete
+				m_revolutionTimeNearlyComplete = (uint32_t)(m_revolutionTime * 0.9f);
+			}
+		}
+		return;
+	}
+
+	// Handle index search
+	if (isIndex) {
+		if (m_sequenceIndex == INDEX_NOT_FOUND) {
+			m_sequenceIndex = m_sequencePos;
+		}
+		else {
+			m_nextSequenceIndex = m_sequencePos;
+		}
+	}
+
+	// Do different things depending on the mode in use
+	if (m_useIndex) {
+		if (m_sequenceIndex == INDEX_NOT_FOUND) {
+			// Store the data in the circular buffer
+			m_initialSequences[m_initialSequencesWritePos] = sequence;
+			m_initialSequencesWritePos = (m_initialSequencesWritePos + 1) % (OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER);
+			if (m_initialSequencesLength < OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER) m_initialSequencesLength++;
+			m_revolutionReady = false;
+		}
+		else {
+			// Was the FIRST index detected?
+			if ((isIndex) && (m_nextSequenceIndex == INDEX_NOT_FOUND) && (m_initialSequencesLength == OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER)) {
+				// Ok, shunt the buffer we have onto the output, this is a short buffer of samples collected before INDEX was detected.
+				m_sequencePos = m_initialSequencesLength;
+				m_sequenceIndex = m_initialSequencesLength;
+
+				// Go through all of them
+				while (m_initialSequencesLength) {
+					// Wind back one
+					m_initialSequencesLength--;
+					// Handle wrap-around buffer
+					if (m_initialSequencesWritePos == 0) m_initialSequencesWritePos = (OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER) - 1; else m_initialSequencesWritePos--;
+					// Save it
+					m_sequences[m_initialSequencesLength] = m_initialSequences[m_initialSequencesWritePos];
+				}
+				m_initialSequencesLength = 0;
+			}
+
+			// Store as normal
+			m_sequences[m_sequencePos++] = sequence;
+
+			// Check if ready
+			if (m_nextSequenceIndex != INDEX_NOT_FOUND) {
+				if (m_sequencePos > m_nextSequenceIndex + (OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER)) {
+					m_revolutionReadyAt = m_nextSequenceIndex;
+					m_revolutionReady = true;
+				}
+			}
+		}
+	}
+	else {
+		m_sequences[m_sequencePos++] = sequence;
+		m_currentTime += (uint32_t)sequence.timeNS;
+
+		// This is a sneaky check-ahead for a full rotation, like a virtual index marker
+		if (m_currentTime >= m_revolutionTime) {
+			if (m_revolutionReadyAt == INDEX_NOT_FOUND) 
+				m_revolutionReadyAt = m_sequencePos; 
+			else
+				if (m_sequencePos > m_revolutionReadyAt + (OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER))
+					m_revolutionReady = true;
+		}
+	}
+}
+
+
+// Reset this back to "empty"
+void RotationExtractor::reset(bool isHD) {
+	m_indexSequence.valid = false;
+	m_revolutionReadyAt = INDEX_NOT_FOUND;
+	m_sequencePos = 0;
+	m_sequenceIndex = INDEX_NOT_FOUND;
+	m_nextSequenceIndex = INDEX_NOT_FOUND;
+	m_currentTime = 0;
+	m_revolutionReady = false;
+	m_initialSequencesLength = 0;
+	m_initialSequencesWritePos = 0;
+	m_timeReceived = 0;
+	m_isHD = isHD;
+}
+
+// Extracts a single rotation and updates the buffer to remove it.  Returns FALSE if no rotation is available
+bool RotationExtractor::extractRotation(MFMSample* output, uint32_t& outputBits, const uint32_t maxBufferSizeBytes, const bool usePLLTime) {
+	// Step 0: check if we're possibly ready
+	if (!canExtract()) return false;
+
+	if (m_useIndex) {
+		if (m_sequenceIndex == INDEX_NOT_FOUND) 
+			return false;
+		if (m_nextSequenceIndex == INDEX_NOT_FOUND) 
+			return false;
+		if (m_sequenceIndex > m_nextSequenceIndex) {
+			uint32_t s = m_sequenceIndex;
+			m_sequenceIndex = m_nextSequenceIndex;
+			m_nextSequenceIndex = s;
+		}
+
+		// Step 1: Find where the first index position is
+		uint32_t revolutionStart = m_useSimpleMode ? m_sequenceIndex : getTrueIndexPosition(INDEX_NOT_FOUND, m_sequenceIndex);
+
+		// Step 2: find out where the next one is
+		uint32_t nextRevolutionStart = m_useSimpleMode ? m_nextSequenceIndex : getTrueIndexPosition(INDEX_NOT_FOUND, m_nextSequenceIndex);
+
+		// This *should* never happen.
+		if (nextRevolutionStart < revolutionStart) {
+			uint32_t tmp = revolutionStart;
+			revolutionStart = nextRevolutionStart;
+			nextRevolutionStart = tmp;
+		}
+
+		// Markers
+		uint32_t outputStreamPos = 0;
+		uint32_t outputStreamBit = 0;
+		uint32_t totalSamples = nextRevolutionStart - revolutionStart;
+		// Work out revolution time anyway
+		uint32_t rTime = 0;
+
+		// Step 3: output.  Data goes from 0 to nextRevolutionStart-1, but we need to output from indexPosition
+		for (uint32_t pos = 0; pos < totalSamples; pos++) {
+			const MFMSequenceInfo& sequence = m_sequences[(pos + revolutionStart) % m_sequencePos];
+			rTime += sequence.timeNS;
+			
+#ifdef OUTPUT_TIME_IN_NS
+			const uint32_t bitTime = (usePLLTime ? sequence.pllTimeNS : sequence.timeNS) / ((sequence.mfm == MFMSequence::mfm000) ? 3 : (uint32_t)sequence.mfm + 1);
+
+			// And write the output stream
+			uint32_t bitsToWrite = (uint32_t)sequence.mfm;
+			if (bitsToWrite > 3)
+				bitsToWrite = 3;
+			for (uint32_t s = 0; s < bitsToWrite; s++)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, false, bitTime, maxBufferSizeBytes);
+			if (sequence.mfm != MFMSequence::mfm000)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, true, bitTime, maxBufferSizeBytes);
+#else
+			const uint32_t speed = ((uint32_t)(usePLLTime ? sequence.pllTimeNS : sequence.timeNS) * 100) / (((uint32_t)sequence.mfm + 2) * 2000);
+
+			// And write the output stream
+			uint32_t bitsToWrite = (uint32_t)sequence.mfm;
+			if (bitsToWrite > 3) 
+				bitsToWrite = 3;
+			for (uint32_t s = 0; s < bitsToWrite; s++)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, false, speed, maxBufferSizeBytes);
+			if (sequence.mfm != MFMSequence::mfm000)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, true, speed, maxBufferSizeBytes);
+#endif
+		}
+		// Need to shift the last ones onto place
+		if (outputStreamBit && (outputStreamPos < maxBufferSizeBytes)) {
+			output[outputStreamPos].mfmData <<= (8 - outputStreamBit);
+#ifndef OUTPUT_TIME_IN_NS
+#ifndef HIGH_RESOLUTION_MODE
+			output[outputStreamPos].speed /= outputStreamBit;
+#endif
+#endif
+		}
+		if (m_revolutionTime == 0) {
+			m_revolutionTime = rTime;
+			m_revolutionTimeNearlyComplete = (uint32_t)(m_revolutionTime * 0.9f);
+		}
+		m_timeReceived -= rTime;
+
+		// Calculate how much we wrote
+		outputBits = (outputStreamPos * 8) + outputStreamBit;
+
+		// Now shift the remaining data so that the next revolution starts at 0
+		for (uint32_t pos = 0; pos < m_sequencePos - nextRevolutionStart; pos++)
+			m_sequences[pos] = m_sequences[(pos + nextRevolutionStart) % m_sequencePos];
+
+		// And mark it
+		if (m_nextSequenceIndex > nextRevolutionStart) m_sequenceIndex = m_nextSequenceIndex - nextRevolutionStart; else m_sequenceIndex = 0;
+		m_nextSequenceIndex = INDEX_NOT_FOUND;
+
+		// And account for the shift
+		if (nextRevolutionStart > m_sequencePos) // this IF shouldn't be needed
+			m_sequencePos = 0;
+		else  m_sequencePos -= nextRevolutionStart;
+	}
+	else {
+
+		// Step 1: Find the overlap between the start of the data and the end of the data
+		uint32_t numBadValues = 0;
+
+		uint32_t nextRevolutionStart = getOverlapPosition(numBadValues);
+		if (nextRevolutionStart < 1) 
+			return false;
+
+		// If the overlap is poor, switch to overlap detection using the indexes - if this is in the GAP its ok, but there's no way to tell
+		if (numBadValues >= MAX_BAD_VALUES_BEFORE_SWITCH) {
+			m_useIndex = true;
+			if (m_nextSequenceIndex == INDEX_NOT_FOUND) m_revolutionReady = false;
+			m_initialSequencesLength = 0;
+			return false;
+		}
+
+		// Step 2: wind it back to the INDEX position
+		uint32_t indexPosition = getTrueIndexPosition(nextRevolutionStart);
+
+		// This shouldn't be needed
+		if (nextRevolutionStart > m_sequencePos) nextRevolutionStart = m_sequencePos;
+
+		// Markers
+		uint32_t outputStreamPos = 0;
+		uint32_t outputStreamBit = 0;
+
+		// Step 3: output.  Data goes from 0 to nextRevolutionStart-1, but we need to output from indexPosition
+		for (uint32_t pos = 0; pos < nextRevolutionStart; pos++) {
+			const MFMSequenceInfo& sequence = m_sequences[(pos + indexPosition) % nextRevolutionStart];
+			m_currentTime -= (uint32_t)sequence.timeNS;
+			m_timeReceived -= (uint32_t)sequence.timeNS;
+
+#ifdef OUTPUT_TIME_IN_NS
+			const uint32_t bitTime = (usePLLTime ? sequence.pllTimeNS : sequence.timeNS) / ((sequence.mfm == MFMSequence::mfm000) ? 3 : (uint32_t)sequence.mfm + 1);
+
+			// And write the output stream
+			uint32_t bitsToWrite = (uint32_t)sequence.mfm;
+			if (bitsToWrite > 3) bitsToWrite = 3;
+			for (uint32_t s = 0; s < bitsToWrite; s++)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, false, bitTime, maxBufferSizeBytes);
+			if (sequence.mfm != MFMSequence::mfm000)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, true, bitTime, maxBufferSizeBytes);
+
+#else
+			const uint32_t speed = ((uint32_t)(usePLLTime ? sequence.pllTimeNS : sequence.timeNS) * 100) / (((uint32_t)sequence.mfm + 2) * 2000);
+
+			// And write the output stream
+			uint32_t bitsToWrite = (uint32_t)sequence.mfm;
+			if (bitsToWrite > 3) bitsToWrite = 3;
+			for (uint32_t s = 0; s < bitsToWrite; s++)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, false, speed, maxBufferSizeBytes);
+			if (sequence.mfm != MFMSequence::mfm000)
+				writeStreamBit(output, outputStreamPos, outputStreamBit, true, speed, maxBufferSizeBytes);
+#endif
+		}
+		// Need to shift the last ones onto place
+		if (outputStreamBit && (outputStreamPos < maxBufferSizeBytes)) {
+			output[outputStreamPos].mfmData <<= (8 - outputStreamBit);
+#ifndef OUTPUT_TIME_IN_NS
+#ifndef HIGH_RESOLUTION_MODE
+			output[outputStreamPos].speed /= outputStreamBit;
+#endif
+#endif
+		}
+
+		// Calculate how much we wrote
+		outputBits = (outputStreamPos * 8) + outputStreamBit;
+
+		// Now it's extracted we need to remove it.  First. Shift or reset the index marker
+		if ((m_nextSequenceIndex != INDEX_NOT_FOUND) && (m_nextSequenceIndex >= nextRevolutionStart)) m_sequenceIndex = m_nextSequenceIndex - nextRevolutionStart; else m_sequenceIndex = INDEX_NOT_FOUND;
+		m_nextSequenceIndex = INDEX_NOT_FOUND;
+
+		// Now shift the remaining data
+		for (uint32_t pos = 0; pos < m_sequencePos - nextRevolutionStart; pos++)
+			m_sequences[pos] = m_sequences[pos + nextRevolutionStart];
+
+		// And account for the shift
+		m_sequencePos -= nextRevolutionStart;
+	}
+
+	m_revolutionReadyAt = INDEX_NOT_FOUND;
+	m_revolutionReady = false;
+	m_initialSequencesLength = 0;
+	m_initialSequencesWritePos = 0;
+
+	// and success!
+	return true;
+}
+
+
+// Reset this back to "empty"
+void LinearExtractor::reset(bool isHD) {
+	m_totalTime = 0;
+	m_currentPosition = m_outputBuffer;
+	m_outputStreamPos = 0;
+	m_outputStreamBit = 0;
+}
+
+// Set where the data should be saved to
+void LinearExtractor::setOutputBuffer(void* outputBuffer, const uint32_t bufferSizeInBytes) {
+	m_outputBuffer = (uint8_t*)outputBuffer;
+	reset(false);
+	m_totalSize = bufferSizeInBytes;
+}
+
+// Write a 0 or 1 to the bit stream
+inline void LinearExtractor::writeLinearBit(const bool value) {
+	if (!m_currentPosition) return;
+	(*m_currentPosition) <<= 1;
+	if (value) *m_currentPosition |= 1; 
+	m_outputStreamBit++;
+	if (m_outputStreamBit >= 8) {
+		m_outputStreamBit = 0;
+		m_outputStreamPos++;
+		if (m_outputStreamPos >= m_totalSize)
+			m_currentPosition = nullptr;
+		else m_currentPosition++;
+	}
+}
+
+// Copies the supplied buffer directly in
+void LinearExtractor::copyToBuffer(void* data, const uint32_t dataSize) {
+	uint32_t amountToCopy = dataSize;
+	if (amountToCopy > m_totalSize) amountToCopy = m_totalSize;
+	if (!m_outputBuffer) return;
+	if (!data) return;
+#ifdef _WIN32
+	memcpy_s(m_outputBuffer, m_totalSize, data, amountToCopy);
+#else
+	memcpy(m_outputBuffer, data, amountToCopy);
+#endif
+	m_outputStreamPos = dataSize;
+	m_outputStreamBit = 0;
+	m_currentPosition = nullptr;
+}
+
+
+// Submit a single sequence to the list - abstract function
+void LinearExtractor::submitSequence(const MFMSequenceInfo& sequence, bool isIndex, bool discardEarlySamples) {
+	if (!m_currentPosition) return;
+
+	m_totalTime += sequence.timeNS;
+
+	// And write the output stream
+	uint32_t bitsToWrite = (uint32_t)sequence.mfm;
+	if (bitsToWrite > 3) bitsToWrite = 3;
+	for (uint32_t s = 0; s < bitsToWrite; s++) writeLinearBit(false);
+	if (sequence.mfm != MFMSequence::mfm000) writeLinearBit(true);
+}
+
+// Finalise the buffer (shifting the bits for the current byte into place) and returns the total number of bits received
+uint32_t LinearExtractor::finaliseAndGetNumBits() {
+	// Shift the remaining bits into place
+	if (m_outputStreamBit && m_currentPosition) {
+		(*m_currentPosition) <<= 8 - m_outputStreamBit;
+		m_currentPosition = nullptr;
+	}
+	return (m_outputStreamPos * 8) + m_outputStreamBit;
+}

--- a/vendor/floppybridge/src/RotationExtractor.h
+++ b/vendor/floppybridge/src/RotationExtractor.h
@@ -1,0 +1,288 @@
+#ifndef READERWRITER_ROTATION_EXTRACTOR
+#define READERWRITER_ROTATION_EXTRACTOR
+/* ArduinoFloppyReader (and writer) - Rotation Extractor
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Class to manage finding *exact* disk revolutions                                   //
+////////////////////////////////////////////////////////////////////////////////////////
+//
+// Purpose:
+// The class attempts to guess where an exact disk revolution occurs, and then re-aligns
+// it such that it starts at the index pulse.  This means we don't need to wait for an index
+// pulse to work out a revolution of the disk.  The first time a disk is used we calculate
+// the time of a single revolution and then use that as a guide to how long a revolution will
+// take in the future.
+//
+// This isn't 100% perfect but does seem to work.
+
+// With this defined you get speed data per bit.  Undefined, per 8 bits.  Nothing seems to notice much
+// Inside *UAE it uses one speed value for 16 bits of MFM data so that's probably why.
+// and besides, with this *undefined* we save about 700k of ram
+//#define HIGH_RESOLUTION_MODE
+
+// Instead of outputting "speed" or "density" values this will output bit-times in ns
+//#define OUTPUT_TIME_IN_NS
+
+// So worse case is the disk takes 210ms to spin, and every sequence is VERY fast, and every sequence is 01, this number is highly unlikely though
+// The x2 is for HD disks
+#define MAX_REVOLUTION_SEQUENCES		(120000 * 2)
+
+// Number of sequences to match to find the index overlap position or the rotation overlap position
+// The higher the number, the more chance of perfect revolution alignment, but higher processing required at the end of each revolution
+#define OVERLAP_SEQUENCE_MATCHES				1024
+
+// When looking for overlap for indexes it doesn't need anywhere near as much data checking
+#define OVERLAP_SEQUENCE_MATCHES_INDEXMODE		1024
+
+// How many incorrect alignment values are allowed before switching to index mode
+#define MAX_BAD_VALUES_BEFORE_SWITCH            4
+
+// Extra window either side.  this allows more of a search range
+#define OVERLAP_EXTRA_BUFFER			6
+
+// Signal for index was not found
+#define INDEX_NOT_FOUND					0xFFFFFFFF
+
+#include <stdint.h>
+
+// A class that can receive data 
+class MFMExtractionTarget {
+public:
+	// Enum for the possible sequences we support - mfm1 is not normally allowed.
+	enum class MFMSequence : unsigned char { mfm1 = 0, mfm01 = 1, mfm001 = 2, mfm0001 = 3, mfm000 = 4 };
+
+	// A single sequence of MFM data
+	struct MFMSequenceInfo {
+		// *real* Total time it took to read this in NS
+		uint16_t timeNS;
+
+		// Total time (pll adjusted)
+		uint16_t pllTimeNS;
+
+		// The MFM sequence discovered
+		MFMSequence mfm;
+	};
+
+	// Decoded version of the above
+	struct MFMSample {
+#ifdef OUTPUT_TIME_IN_NS
+		// This is the time for each 'bit' 
+		uint16_t bittime[8];
+#else
+#ifdef HIGH_RESOLUTION_MODE
+		// This is the speed of each 'bit' as a %
+		uint16_t speed[8];
+#else
+		// This is the average speed of all 8 bits as a %
+		uint16_t speed;
+#endif
+#endif
+
+		// This is the raw MFM bit-data
+		unsigned char mfmData;
+	};
+
+	// Struct for tracking what the index start looks like so we get it perfect (or at least consistent)
+	struct IndexSequenceMarker {
+		// Sequences found
+		MFMSequence sequences[OVERLAP_SEQUENCE_MATCHES_INDEXMODE];
+
+		// If this is actually valid
+		bool valid = false;
+	};
+
+	// Return the total amount of time data received so far
+	[[nodiscard]] virtual uint32_t totalTimeReceived() const = 0;
+
+	// Get and set the sequence identified as data round the INDEX pulse so that next time we get consistent revolution starting points
+	virtual void setIndexSequence(const IndexSequenceMarker& sequence) = 0;
+	virtual void getIndexSequence(IndexSequenceMarker& sequence) const = 0;
+
+	// Reset this back to "empty"
+	virtual void reset(bool isHD) = 0;
+
+	// Submit a single sequence to the list - abstract function
+	virtual void submitSequence(const MFMSequenceInfo& sequence, bool isIndex, bool discardEarlySamples = true) = 0;
+
+	// Returns TRUE if we are readt to extract (eg: full revolution or buffer full)
+	[[nodiscard]] virtual bool canExtract() const = 0;
+
+	// Returns TRUE if this has learnt the time of a disk revolution
+	[[nodiscard]] virtual bool hasLearntRotationSpeed() const = 0;
+
+	// Returns TRUE if we're in INDEX mode
+	[[nodiscard]] virtual bool isInIndexMode() const = 0;
+
+	// Extracts the data we have so far. Might need canExtract to be true depending on the implementation
+	[[nodiscard]] virtual bool extractRotation(MFMSample* output, uint32_t& outputBits, uint32_t maxBufferSizeBytes, bool usePLLTime = false) = 0;
+
+	// I want the destructor virtual
+	virtual ~MFMExtractionTarget() {};
+};
+
+
+// Class to extract a single rotation from an incoming mfm data sequence and ensure it's a perfect MFM rotation
+class RotationExtractor : public MFMExtractionTarget  {
+private:
+	// How long a revolution is
+	uint32_t m_revolutionTime = 0;
+	// An amount of time whereby we 'nearly' have a complete revolution of data
+	uint32_t m_revolutionTimeNearlyComplete = 0;
+	// Used while working out the above
+	uint32_t m_revolutionTimeCounting = 0;
+	// Where the first index pulse was discovered
+	uint32_t m_sequenceIndex = INDEX_NOT_FOUND;
+	// Where the second index pulse was discovered
+	uint32_t m_nextSequenceIndex = INDEX_NOT_FOUND;
+	// Where we were when we reached m_revolutionTime worth of data
+	uint32_t m_revolutionReadyAt = INDEX_NOT_FOUND;
+	// And a flag to set this as good
+	bool m_revolutionReady = false;
+	// Is simple mode enabled?
+	bool m_useSimpleMode = false;
+	// Is this an HD disk?
+	bool m_isHD = false;
+	// If we should always use the index marker when finding revolutions
+	bool m_useIndex = false;
+	// Current amount of data in the buffer in ns
+	uint32_t m_currentTime = 0;
+	// Current position of the buffer
+	uint32_t m_sequencePos = 0;
+	// Used to track exactly how much data has been submitted
+	uint32_t m_timeReceived = 0;
+	// Sequences received thus far
+	MFMSequenceInfo* m_sequences; // [MAX_REVOLUTION_SEQUENCES] ;
+	// In index mode, this holds the initial sequences before the first index marker
+	MFMSequenceInfo* m_initialSequences; // [OVERLAP_SEQUENCE_MATCHES * OVERLAP_EXTRA_BUFFER] ;
+	// Length of the above datat in use
+	uint32_t m_initialSequencesLength = 0;
+	// Where we're writing to as its a circular buffer
+	uint32_t m_initialSequencesWritePos = 0;
+	// Sequences discovered around the index marker
+	IndexSequenceMarker m_indexSequence;
+
+	// Finds the overlap between the start of the data and where we currently are
+	uint32_t getOverlapPosition(uint32_t& numberOfBadMatches) const;
+
+	// is almost identical
+	uint32_t getTrueIndexPosition(uint32_t nextRevolutionStart,
+		uint32_t startingPoint = INDEX_NOT_FOUND);
+public:
+	RotationExtractor();
+	virtual ~RotationExtractor();
+
+	// Get and set the sequence identified as data round the INDEX pulse so that next time we get consistent revolution starting points
+	virtual void setIndexSequence(const IndexSequenceMarker& sequence) override { m_indexSequence = sequence; }
+	virtual void getIndexSequence(IndexSequenceMarker& sequence) const override { sequence = m_indexSequence; }
+
+	// Reset this back to "empty"
+	virtual void reset(bool isHD) override;
+
+	// Return TRUE if we're in HD mode
+	[[nodiscard]] bool isHD() const { return m_isHD; }
+
+	// Signal new disk, or maybe a motor restarted.  Need to re-calculate rotation speed.  In HD mode, the data must be fed in at DD speeds (4, 6 and 8us)
+	void newDisk(bool isHD) {
+		reset(isHD);
+		m_revolutionTime = 0;
+		m_revolutionTimeCounting = 0;
+		m_revolutionTimeNearlyComplete = 0;
+	}
+
+	// Return the current revolution time
+	[[nodiscard]] uint32_t getRevolutionTime() const { return m_revolutionTime; }
+
+	// Set the current revolution time
+	void setRevolutionTime(const uint32_t time) { m_revolutionTime = time; m_revolutionTimeNearlyComplete = (uint32_t)(time * 0.9f); }
+
+	// Return the total amount of time data received so far
+	[[nodiscard]] virtual uint32_t totalTimeReceived() const override { return m_timeReceived; };
+
+	// Returns TRUE if this has learnt the time of a disk revolution
+	[[nodiscard]] bool hasLearntRotationSpeed() const override { return m_revolutionTime > (m_isHD ? 300000000U : 150000000U); }
+
+	// Returns TRUE if we're in INDEX mode
+	[[nodiscard]] bool isInIndexMode() const override { return m_useIndex; }
+
+	// Sets the code so it always uses the index marker when finding revolutions
+	void setAlwaysUseIndex(bool useIndex) { m_useIndex = useIndex; }
+
+	// In simple mode, the rotation is matched purely on Index pulses alone, the data is not matched. Index mode must be enabled. This is fine for SCP reading etc
+	void setSimpleMode(bool simpleMode) { m_useSimpleMode = simpleMode; }
+
+	// If this is about to spit out a revolution in a very small amount of time
+	[[nodiscard]] bool isNearlyReady() const { return (m_revolutionTimeNearlyComplete) && (m_currentTime >= m_revolutionTimeNearlyComplete) && (!m_useIndex); }
+
+	// Submit a single sequence to the list
+	virtual void submitSequence(const MFMSequenceInfo& sequence, bool isIndex, bool discardEarlySamples = true) override;
+
+	// Returns TRUE if we should be able to extract a revolution
+	[[nodiscard]] virtual bool canExtract() const override { return (m_revolutionReadyAt != INDEX_NOT_FOUND) && (m_revolutionReady) && (m_sequencePos>100); }
+
+	// Extracts a single rotation and updates the buffer to remove it.  Returns FALSE if no rotation is available
+	// If calculateSpeedFactor is true, we're in INDEX mode, and HIGH_RESOLUTION_MODE is defined then this will output time in NS rather than the speed factor value
+	[[nodiscard]] virtual bool extractRotation(MFMSample* output, uint32_t& outputBits, uint32_t maxBufferSizeBytes, bool usePLLTime = false) override;
+};
+
+
+// Simple class to just receive that data being sent from the PLL into a linear MFM buffer. It doesn't try to find rotations 
+class LinearExtractor : public MFMExtractionTarget {
+private:
+	uint8_t* m_outputBuffer = nullptr;
+	uint8_t* m_currentPosition = nullptr;
+	uint32_t m_outputStreamPos = 0;
+	uint32_t m_outputStreamBit = 0;
+	uint32_t m_totalSize = 0;
+	uint32_t m_totalTime = 0;
+
+	// Write a 0 or 1 to the bit stream
+	inline void writeLinearBit(const bool value);
+public: 
+	// Dont care about this
+	virtual void setIndexSequence(const IndexSequenceMarker& sequence) override {};
+	virtual void getIndexSequence(IndexSequenceMarker& sequence) const override {};
+	virtual bool hasLearntRotationSpeed() const override { return true; };
+	virtual bool isInIndexMode() const override { return false; };
+	virtual bool extractRotation(MFMSample* output, uint32_t& outputBits, uint32_t maxBufferSizeBytes, bool usePLLTime = false) override { return false; };
+
+	// Returns TRUE if we are readt to extract (eg: full revolution or buffer full)
+	virtual bool canExtract() const override { return m_outputStreamPos >= m_totalSize; };
+
+	// Set where the data should be saved to
+	void setOutputBuffer(void* outputBuffer, const uint32_t bufferSizeInBytes);
+
+	// Finalise the buffer (shifting the bits for the current byte into place) and returns the total number of bits received
+	uint32_t finaliseAndGetNumBits();
+
+	// Return the total amount of time data received so far
+	virtual uint32_t totalTimeReceived() const override { return m_totalTime; };
+
+	// Reset this back to "empty"
+	virtual void reset(bool isHD) override;
+
+	// Copies the supplied buffer directly in
+	void copyToBuffer(void* data, const uint32_t dataSize);
+
+	// Submit a single sequence to the list - abstract function
+	virtual void submitSequence(const MFMSequenceInfo& sequence, bool isIndex, bool discardEarlySamples = true) override;
+};
+
+
+
+#endif

--- a/vendor/floppybridge/src/SerialIO.cpp
+++ b/vendor/floppybridge/src/SerialIO.cpp
@@ -1,0 +1,946 @@
+/* Serial/IO Library
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+* 
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Class to manage the communication between the computer and a serial port           //
+////////////////////////////////////////////////////////////////////////////////////////
+//
+//
+
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+
+
+#include "SerialIO.h"
+
+#ifdef _WIN32
+#include <SetupAPI.h>
+#include <Devpropdef.h>
+#include "RotationExtractor.h"
+#pragma comment(lib, "setupapi.lib")
+static const DEVPROPKEY DEVPKEY_Device_BusReportedDeviceDesc2 = { {0x540b947e, 0x8b40, 0x45bc, 0xa8, 0xa2, 0x6a, 0x0b, 0x89, 0x4c, 0xbd, 0xa2}, 4 };
+static const DEVPROPKEY DEVPKEY_Device_InstanceId2 = { {0x78c34fc8, 0x104a, 0x4aca, 0x9e, 0xa4, 0x52, 0x4d, 0x52, 0x99, 0x6e, 0x57}, 256 };
+#ifndef GUID_DEVINTERFACE_COMPORT
+DEFINE_GUID(GUID_DEVINTERFACE_COMPORT,0x86e0d1e0, 0x8089, 0x11d0, 0x9c, 0xe4, 0x08, 0x00, 0x3e, 0x30, 0x1f, 0x73);
+#endif
+
+// OS X, sigurbjornl, 20220208
+#elif defined __MACH__
+
+#include <sys/stat.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <cstring>
+#include <term.h>
+#include <sys/termios.h>
+#include <sys/ioctl.h>
+#include <IOKit/serial/ioss.h>
+#ifndef TIOCINQ
+#ifdef FIONREAD
+#define TIOCINQ FIONREAD
+#else
+#define TIOCINQ 0x541B
+#endif
+#endif
+
+#else
+#include <sys/stat.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <cstring>
+#include <linux/serial.h>
+
+#endif
+
+#include <string>
+#include <codecvt>
+#include <locale>
+#include <algorithm>
+
+using convert_t = std::codecvt_utf8<wchar_t>;
+static std::wstring_convert<convert_t, wchar_t> strconverter;
+
+void quickw2a(const std::wstring& wstr, std::string& str) {
+	str = strconverter.to_bytes(wstr);
+}
+void quicka2w(const std::string& str, std::wstring& wstr) {
+	wstr = strconverter.from_bytes(str);
+}
+
+// Constructor etc
+SerialIO::SerialIO() {
+}
+
+SerialIO::~SerialIO() {
+#ifdef FTDI_D2XX_AVAILABLE
+	m_ftdi.FT_Close();
+#endif
+	closePort();
+}
+
+// Returns TRUE if the port is open
+bool SerialIO::isPortOpen() const {
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) return true;
+#endif
+#ifdef _WIN32
+	return m_portHandle != INVALID_HANDLE_VALUE;
+#else
+	return m_portHandle != -1;
+#endif
+
+	return false;
+}
+
+// Purge any data left in the buffer
+void SerialIO::purgeBuffers() {
+	if (!isPortOpen()) return;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		m_ftdi.FT_Purge(true, true);
+		return;
+	}
+#endif
+
+#ifdef _WIN32
+	PurgeComm(m_portHandle, PURGE_RXCLEAR | PURGE_TXCLEAR);
+#else
+	tcflush(m_portHandle, TCIOFLUSH);
+#endif
+}
+
+// Sets the status of the DTR line
+void SerialIO::setRTS(bool enableRTS) {
+	if (!isPortOpen()) return;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		if (enableRTS) m_ftdi.FT_SetRts(); else m_ftdi.FT_ClrRts();
+		return;
+	}
+#endif
+
+#ifdef _WIN32
+	EscapeCommFunction(m_portHandle, enableRTS ? SETRTS : CLRRTS);
+#else
+	int pinToControl = TIOCM_RTS;
+	ioctl(m_portHandle, enableRTS ? TIOCMBIS : TIOCMBIC, &pinToControl);
+#endif
+}
+
+// Sets the status of the DTR line
+void SerialIO::setDTR(bool enableDTR) {
+	if (!isPortOpen()) return;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		if (enableDTR) m_ftdi.FT_SetDtr(); else m_ftdi.FT_ClrDtr();
+		return;
+	}
+#endif
+
+#ifdef _WIN32
+	EscapeCommFunction(m_portHandle, enableDTR ? SETDTR : CLRDTR);
+#else
+	int pinToControl = TIOCM_DTR;
+	ioctl(m_portHandle, enableDTR ? TIOCMBIS : TIOCMBIC, &pinToControl);
+#endif
+}
+
+// Returns the status of the CTS pin
+bool SerialIO::getCTSStatus() {
+	if (!isPortOpen()) return false;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		ULONG status;
+		if (m_ftdi.FT_GetModemStatus(&status) != FTDI::FT_STATUS::FT_OK) return false;
+		return (status & FT_MODEM_STATUS_CTS) != 0;
+	}
+#endif
+
+#ifdef _WIN32
+	DWORD mask = 0;
+	if (!GetCommModemStatus(m_portHandle, &mask)) return false;
+	return (mask & MS_CTS_ON) != 0;
+#else
+	int status;
+	ioctl(m_portHandle, TIOCMGET, &status);
+	return (status & TIOCM_CTS) != 0;
+#endif
+
+	return false;
+}
+
+// Returns a list of serial ports discovered on the system
+void SerialIO::enumSerialPorts(std::vector<SerialPortInformation>& serialPorts) {
+	serialPorts.clear();
+
+#ifdef FTDI_D2XX_AVAILABLE
+	// Add in the FTDI ports detected
+	DWORD numDevs;
+	FTDI::FTDIInterface ftdi;
+	FTDI::FT_STATUS status = ftdi.FT_CreateDeviceInfoList(&numDevs);
+	if ((status == FTDI::FT_STATUS::FT_OK) && (numDevs)) {
+		FTDI::FT_DEVICE_LIST_INFO_NODE* devList = (FTDI::FT_DEVICE_LIST_INFO_NODE*)malloc(sizeof(FTDI::FT_DEVICE_LIST_INFO_NODE) * numDevs);
+		if (devList) {
+
+			status = ftdi.FT_GetDeviceInfoList(devList, &numDevs);
+			if (status == FTDI::FT_STATUS::FT_OK) {
+				for (unsigned int index = 0; index < numDevs; index++) {
+					SerialPortInformation info;
+					info.instanceID = std::to_wstring(devList[index].LocId);
+					info.pid = devList[index].ID & 0xFFFF;
+					info.vid = devList[index].ID >> 16;
+					quicka2w(devList[index].Description, info.productName);
+
+					// Ensure no duplicate port numbers names
+					int portIndex = 0;
+					do {
+						// Create name
+						std::string tmp = FTDI_PORT_PREFIX;
+						if (portIndex) tmp += std::to_string(portIndex) + "-";
+						portIndex++;
+						tmp += std::string(devList[index].SerialNumber);
+
+						// Convert to wide
+						quicka2w(tmp, info.portName);
+
+						// Finish it
+						info.portName += L" (" + info.productName + L")";
+						info.ftdiIndex = index;
+
+						// Test if one with this name already exists
+					} while (std::find_if(serialPorts.begin(), serialPorts.end(), [&info](const SerialPortInformation& port)->bool {
+						return (info.portName == port.portName);
+					}) != serialPorts.end());
+
+					// Save
+					serialPorts.push_back(info);
+				}
+			}
+			free(devList);
+		}
+	}
+#endif
+
+
+#ifdef _WIN32
+	std::vector<GUID> toSearch;
+
+	// Check normal COMPORTS guids
+	toSearch.push_back(GUID_DEVINTERFACE_COMPORT);
+
+	DWORD requiredSize = 8;
+	std::vector< GUID> tmp(8);
+	// Check 'PORTS' Guids
+	if (SetupDiClassGuidsFromNameA("Ports", (LPGUID)tmp.data(), requiredSize, &requiredSize)) {
+		if (requiredSize > 8) {
+			tmp.resize(requiredSize);
+			if (!SetupDiClassGuidsFromNameA("Ports", (LPGUID)tmp.data(), requiredSize, &requiredSize)) requiredSize = 0;
+		}
+		// Don't add duplicates
+		for (size_t c = 0; c < requiredSize; c++)
+			if (std::find(toSearch.begin(), toSearch.end(), tmp[c]) == toSearch.end())
+				toSearch.push_back(tmp[c]);
+	}
+	requiredSize = 8;
+	tmp.resize(8);
+	// Check 'MODEM' Guids
+	if (SetupDiClassGuidsFromNameA("Modem", (LPGUID)tmp.data(), requiredSize, &requiredSize)) {
+		if (requiredSize > 8) {
+			tmp.resize(requiredSize);
+			if (!SetupDiClassGuidsFromNameA("Modem", (LPGUID)tmp.data(), requiredSize, &requiredSize)) requiredSize = 0;
+		}
+		// Don't add duplicates
+		for (size_t c = 0; c < requiredSize; c++)
+			if (std::find(toSearch.begin(), toSearch.end(), tmp[c]) == toSearch.end())
+				toSearch.push_back(tmp[c]);
+	}
+
+	for (GUID g : toSearch) {
+		// Query for hardware
+		HDEVINFO hDevInfoSet = SetupDiGetClassDevs(&g, nullptr, nullptr, DIGCF_PRESENT);
+		if (hDevInfoSet == INVALID_HANDLE_VALUE) return;
+
+		// Scan for items
+		DWORD devIndex = 0;
+		SP_DEVINFO_DATA devInfo;
+		devInfo.cbSize = sizeof(SP_DEVINFO_DATA);
+
+		// Enum devices
+		while (SetupDiEnumDeviceInfo(hDevInfoSet, devIndex, &devInfo)) {
+			HKEY key = SetupDiOpenDevRegKey(hDevInfoSet, &devInfo, DICS_FLAG_GLOBAL, 0, DIREG_DEV, KEY_READ);
+			if (key != INVALID_HANDLE_VALUE) {
+
+				WCHAR name[128];
+				DWORD nameLength = 128;
+
+				// Get the COM Port Name
+				if (RegQueryValueExW(key, L"PortName", NULL, NULL, (LPBYTE)name, &nameLength) == ERROR_SUCCESS) {
+					SerialPortInformation port;
+					port.portName = name;
+
+					// Check it starts with COM
+					if ((port.portName.length() >= 4) && (port.portName.substr(0, 3) == L"COM")) {
+						// Get the hardware ID
+						nameLength = 128;
+						DWORD dwType;
+						if (SetupDiGetDeviceRegistryPropertyW(hDevInfoSet, &devInfo, SPDRP_HARDWAREID, &dwType, (LPBYTE)name, 128, &nameLength)) {
+							std::wstring deviceString = name;
+							int a = (int)deviceString.find(L"VID_");
+							if (a != std::wstring::npos) port.vid = wcstol(deviceString.substr(a + 4).c_str(), NULL, 16);
+							a = (int)deviceString.find(L"PID_");
+							if (a != std::wstring::npos) port.pid = wcstol(deviceString.substr(a + 4).c_str(), NULL, 16);
+						}
+
+						// Description
+						DWORD type;
+						if (SetupDiGetDevicePropertyW(hDevInfoSet, &devInfo, &DEVPKEY_Device_BusReportedDeviceDesc2, &type, (PBYTE)name, 128, 0, 0)) port.productName = name;
+
+						// Instance
+						if (SetupDiGetDevicePropertyW(hDevInfoSet, &devInfo, &DEVPKEY_Device_InstanceId2, &type, (PBYTE)name, 128, 0, 0)) port.instanceID = name;
+
+						// Don't add any duplicates
+						if (std::find_if(serialPorts.begin(), serialPorts.end(), [&port](SerialPortInformation search)->bool {
+							return search.portName == port.portName;
+						}) == serialPorts.end()) serialPorts.push_back(port);
+					}
+				}
+				RegCloseKey(key);
+			}
+
+			devIndex++;
+		}
+
+		SetupDiDestroyDeviceInfoList(hDevInfoSet);
+	}
+
+#else
+#ifdef __APPLE__
+	DIR* dir = opendir("/dev");
+#else
+	DIR* dir = opendir("/sys/class/tty");
+#endif	
+	if (!dir) return;
+	dirent* entry;
+	struct stat statbuf{};
+
+	while ((entry = readdir(dir))) {
+#ifdef __APPLE__
+		std::string tmp = entry->d_name;
+		if (tmp.substr(0,7) != "tty.usb") continue;
+		std::string name = "/dev/" + std::string(entry->d_name);
+		SerialPortInformation prt;
+		quicka2w(name, prt.portName);
+		serialPorts.push_back(prt);
+#else		
+		std::string deviceRoot = "/sys/class/tty/" + std::string(entry->d_name);
+		if (lstat(deviceRoot.c_str(), &statbuf) == -1) continue;
+		if (!S_ISLNK(statbuf.st_mode)) deviceRoot += "/device";
+		char target[PATH_MAX];
+		int len = readlink(deviceRoot.c_str(), target, sizeof(target));
+		if ((len <= 0) || (len >= PATH_MAX-1)) continue;
+		target[len] = '\0';
+		if (strstr(target, "virtual")) continue;
+		if (strstr(target, "bluetooth")) continue;
+
+		if (strstr(target, "usb")) {
+			std::string name = "/dev/" + std::string(entry->d_name);
+
+			SerialPortInformation prt;
+			quicka2w(name, prt.portName);
+
+			std::string dirName = "/sys/class/tty/" + std::string(entry->d_name) + "/device/";
+			std::string subDir;
+
+			for (int i = 0; i < 5; i++) {
+				subDir += "../";
+				std::string vidPath = dirName + "/";
+				vidPath.append(subDir + "/idVendor");
+
+				int file = open(vidPath.c_str(), O_RDONLY | O_CLOEXEC);
+				if (file == -1) continue;
+				FILE* fle = fdopen(file, "r");
+				int count = fscanf(fle, "%4x", &prt.vid);
+				fclose(fle);
+				if (count != 1) continue;
+
+				vidPath = dirName + "/";
+				vidPath.append(subDir + "/idProduct");
+				file = open(vidPath.c_str(), O_RDONLY | O_CLOEXEC);
+				if (file == -1) continue;
+				fle = fdopen(file, "r");
+				count = fscanf(fle, "%4x", &prt.pid);
+				fclose(fle);
+				if (count != 1) continue;
+
+				vidPath = dirName + "/";
+				vidPath.append(subDir + "/product");
+				file = open(vidPath.c_str(), O_RDONLY | O_CLOEXEC);
+				if (file == -1) continue;
+				fle = fdopen(file, "r");
+				char* p;
+				if ((p = fgets(target, sizeof(target), fle))) {
+					if (p[strlen(p) - 1] == '\n') p[strlen(p) - 1] = '\0';
+					quicka2w(target, prt.productName);
+				}
+				fclose(fle);
+
+				vidPath = dirName + "/";
+				vidPath.append(subDir + "/serial");
+				file = open(vidPath.c_str(), O_RDONLY | O_CLOEXEC);
+				if (file == -1) continue;
+				fle = fdopen(file, "r");
+				if ((p = fgets(target, sizeof(target), fle))) quicka2w(target, prt.instanceID);
+				fclose(fle);
+
+				serialPorts.push_back(prt);
+				break;
+			}
+		}
+#endif
+	}
+	closedir(dir);
+#endif
+
+	std::sort(serialPorts.begin(), serialPorts.end(), [](const SerialPortInformation& a, const SerialPortInformation& b)->int {
+		return a.portName < b.portName;
+	});
+}
+
+// Attempt ot change the size of the buffers used by the OS
+void SerialIO::setBufferSizes(const unsigned int rxSize, const unsigned int txSize) {
+	if (!isPortOpen()) return;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		// Larger than this size actually causes slowdowns.  This doesn't work the same as below.  Below is a buffer in Windows.  This is on the USB device I think
+		m_ftdi.FT_SetUSBParameters(rxSize < 256 ? rxSize : 256, txSize);
+		return;
+	}
+#endif
+
+#ifdef _WIN32
+	SetupComm(m_portHandle, rxSize, txSize);
+#endif
+}
+
+// Open a port by name
+SerialIO::Response SerialIO::openPort(const std::wstring& portName) {
+	closePort();
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (portName.length() > std::string(FTDI_PORT_PREFIX).length()) {
+		std::wstring prefix;
+		quicka2w(FTDI_PORT_PREFIX, prefix);
+		// Is it FTDI?
+		if (portName.substr(0, prefix.length()) == prefix) {
+			std::vector<SerialPortInformation> serialPorts;
+			enumSerialPorts(serialPorts);
+
+			// See if it exists
+			auto f = std::find_if(serialPorts.begin(), serialPorts.end(), [&portName](const SerialPortInformation& serialport)-> bool {
+				return portName == serialport.portName;
+			});
+
+			// was it found?
+			if (f != serialPorts.end()) {
+				switch (m_ftdi.FT_Open(f->ftdiIndex)) {
+					case FTDI::FT_STATUS::FT_OK: break;
+					case FTDI::FT_STATUS::FT_DEVICE_NOT_OPENED: return Response::rInUse;
+					case FTDI::FT_STATUS::FT_DEVICE_NOT_FOUND: return Response::rNotFound;
+					default: return Response::rUnknownError;
+				}
+				updateTimeouts();
+
+				return Response::rOK;
+			} else return Response::rNotFound;
+		}
+	}
+#endif
+
+#ifdef _WIN32
+	std::wstring path = L"\\\\.\\" + portName;
+	m_portHandle = CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, 0);
+	if (m_portHandle == INVALID_HANDLE_VALUE) {
+		switch (GetLastError()) {
+		case ERROR_FILE_NOT_FOUND:  return Response::rNotFound;
+		case ERROR_ACCESS_DENIED:   return Response::rInUse;
+		default: return Response::rUnknownError;
+		}
+	}
+	updateTimeouts();
+	return Response::rOK;
+#else
+	std::string apath;
+	quickw2a(portName, apath);
+/* COPPERLINE: opening a tty blocks until carrier detect is asserted unless
+   CLOCAL is already set on the device -- and CLOCAL is set below, after the
+   open, which is too late. A USB CDC interface that never raises DCD (a
+   Greaseweazle among them) therefore hangs here forever, with nothing to
+   report because the call simply does not return. macOS avoided it by opening
+   non-blocking; do the same everywhere.
+
+   The flag stays set, exactly as it does on macOS. Clearing it after the open
+   looks tidier -- reads would then wait on the VMIN/VTIME timeout rather than
+   returning empty -- but that timeout is configured by configurePort(), which
+   the interfaces call only after this function returns. In between, a blocking
+   descriptor carries the default VMIN=1/VTIME=0: wait for a byte, forever. The
+   handshake reads in that window, so a device that answers slowly, or not at
+   all, wedges the open instead of failing it. */
+	m_portHandle = open(apath.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
+	if (m_portHandle == -1) {
+		switch (errno) {
+		case ENOENT: return Response::rNotFound;
+		case EBUSY: return Response::rInUse;
+		default: return Response::rUnknownError;
+		}
+	}
+
+#ifdef HAVE_FLOCK
+	flock(m_portHandle, LOCK_EX | LOCK_NB);
+#endif
+#ifdef TIOCEXCL
+	ioctl(m_portHandle, TIOCEXCL);
+#endif
+
+	updateTimeouts();
+	return Response::rOK;
+#endif
+
+	return Response::rNotImplemented;
+}
+
+// Shuts the port down
+void SerialIO::closePort() {
+	if (!isPortOpen()) return;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		m_ftdi.FT_Close();
+		return;
+	}
+#endif
+
+#ifdef _WIN32
+	CloseHandle(m_portHandle);
+	m_portHandle = INVALID_HANDLE_VALUE;
+
+#else
+	if (m_portHandle>=0) close(m_portHandle);
+	m_portHandle = -1;
+#endif
+}
+
+// Changes the configuration on the port
+SerialIO::Response SerialIO::configurePort(const Configuration& configuration) {
+	if (!isPortOpen()) return Response::rUnknownError;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		if (m_ftdi.FT_SetFlowControl(configuration.ctsFlowControl ? FT_FLOW_RTS_CTS : FT_FLOW_NONE, 0, 0) != FTDI::FT_STATUS::FT_OK) return SerialIO::Response::rUnknownError;
+		if (m_ftdi.FT_SetDataCharacteristics(FTDI::FT_BITS::_8, FTDI::FT_STOP_BITS::_1, FTDI::FT_PARITY::NONE) != FTDI::FT_STATUS::FT_OK) return SerialIO::Response::rUnknownError;
+		if (m_ftdi.FT_SetBaudRate(configuration.baudRate) != FTDI::FT_STATUS::FT_OK) return SerialIO::Response::rUnknownError;
+		m_ftdi.FT_SetLatencyTimer(2);
+		m_ftdi.FT_ClrDtr();
+		m_ftdi.FT_ClrRts();
+		return SerialIO::Response::rOK;
+	}
+#endif
+
+#ifdef _WIN32
+	// Configure the port
+	COMMCONFIG config;
+	DWORD comConfigSize = sizeof(config);
+	memset(&config, 0, sizeof(config));
+
+	GetCommConfig(m_portHandle, &config, &comConfigSize);
+	config.dwSize = sizeof(config);
+	config.dcb.DCBlength = sizeof(config.dcb);
+	config.dcb.BaudRate = configuration.baudRate;
+	config.dcb.ByteSize = 8;
+	config.dcb.fBinary = true;
+	config.dcb.Parity = false;
+	config.dcb.fOutxCtsFlow = configuration.ctsFlowControl;
+	config.dcb.fOutxDsrFlow = false;
+	config.dcb.fDtrControl = DTR_CONTROL_ENABLE;
+	config.dcb.fDsrSensitivity = false;
+	config.dcb.fNull = false;
+	config.dcb.fTXContinueOnXoff = false;
+	config.dcb.fRtsControl = RTS_CONTROL_ENABLE;
+	config.dcb.fAbortOnError = false;
+	config.dcb.StopBits = 0;
+	config.dcb.fOutX = 0;
+	config.dcb.fInX = 0;
+	config.dcb.fErrorChar = 0;
+	config.dcb.fAbortOnError = 0;
+	config.dcb.fInX = 0;
+	return SetCommConfig(m_portHandle, &config, sizeof(config)) ? Response::rOK : Response::rUnknownError;
+
+#else
+	if (tcgetattr(m_portHandle, &term) < 0) return Response::rUnknownError;
+#ifdef cfmakeraw
+	cfmakeraw(&term);
+#endif
+	term.c_iflag &= ~ (IXON | IXOFF | IXANY | IGNBRK | BRKINT | PARMRK | INPCK | ISTRIP | INLCR | IGNCR | ICRNL);
+	term.c_lflag &= ~ (ISIG | ICANON | ECHO | ECHOE | ECHONL | IEXTEN);
+	term.c_oflag &= ~ (OPOST | ONLCR | OCRNL | ONOCR | ONLRET);
+	term.c_cflag &= ~(HUPCL | CSIZE | PARENB | PARODD | CSTOPB);
+	term.c_cflag |= CREAD | CLOCAL | CS8;
+	term.c_iflag |= IGNPAR;
+
+#ifdef XCASE
+	term.c_lflag &= ~XCASE;
+#endif
+#ifdef IUTF8
+	term.c_iflag &= ~IUTF8;
+#endif
+#ifdef CMSPAR
+	term.c_cflag &= ~CMSPAR;
+#endif
+#ifdef IMAXBEL
+	term.c_iflag &= ~IMAXBEL;
+#endif
+#ifdef IUCLC
+	term.c_iflag &= ~IUCLC;
+#endif
+#ifdef OLCUC
+	term.c_oflag &= ~OLCUC;
+#endif
+#ifdef NLDLY
+	term.c_oflag &= ~NLDLY;
+#endif
+#ifdef CRDLY
+	term.c_oflag &= ~CRDLY;
+#endif
+#ifdef TABDLY
+	term.c_oflag &= ~TABDLY;
+#endif
+#ifdef BSDLY
+	term.c_oflag &= ~BSDLY;
+#endif
+#ifdef VTDLY
+	term.c_oflag &= ~VTDLY;
+#endif
+#ifdef FFDLY
+	term.c_oflag &= ~FFDLY;
+#endif
+#ifdef OFILL
+	term.c_oflag &= ~OFILL;
+#endif
+
+	term.c_cc[VMIN] = 0;
+	term.c_cc[VTIME] = 1;
+
+	int ctsRtsFlags = 0;
+#ifdef CRTSCTS
+	ctsRtsFlags = CRTSCTS;
+#else
+#ifdef CNEW_RTSCTS
+	ctsRtsFlags  = CNEW_RTSCTS;
+#else
+	ctsRtsFlags = CCTS_OFLOW;
+#endif
+#endif
+	if (configuration.ctsFlowControl) term.c_cflag |= ctsRtsFlags; else term.c_cflag &= ~ctsRtsFlags;
+
+	// Now try to set the baud rate
+	int baud = configuration.baudRate;
+#ifdef __APPLE__
+	if (ioctl(m_portHandle, IOSSIOSPEED, &baud) == -1) return Response::rUnknownError;
+#else
+	if (baud == 9600) {
+		term.c_cflag &= ~CBAUD;
+		term.c_cflag |= B9600;
+	} else {
+#if defined(BOTHER) && defined(HAVE_STRUCT_TERMIOS2)
+	term.c_cflag &= ~CBAUD;
+	term.c_cflag |= BOTHER;
+	term.c_ispeed = configuration.baudRate;
+	term.c_ospeed = configuration.baudRate;
+	if (ioctl(m_portHandle, TCSETS2, &term) < 0) return Response::rUnknownError;
+#else
+	term.c_cflag &= ~CBAUD;
+	term.c_cflag |= CBAUDEX;
+	if (cfsetspeed(&term, baud) < 0) return Response::rUnknownError;
+#endif
+	}
+#endif
+	// Apply that nonsense
+	tcflush (m_portHandle, TCIFLUSH);
+	if (tcsetattr(m_portHandle, TCSANOW, &term) != 0) return Response::rUnknownError;
+#ifdef ASYNC_LOW_LATENCY
+	struct serial_struct serial;
+	ioctl(m_portHandle, TIOCGSERIAL, &serial);
+	serial.flags |= ASYNC_LOW_LATENCY;
+	ioctl(m_portHandle, TIOCSSERIAL, &serial);
+#endif
+#ifdef __APPLE__
+	if (ioctl(m_portHandle, IOSSIOSPEED, &baud) == -1) return Response::rUnknownError;
+#endif
+	setDTR(true);
+	setRTS(true);
+
+	return Response::rOK;
+#endif
+
+	return Response::rNotImplemented;
+}
+
+// Check if we wrre quick enough reading the data
+bool SerialIO::checkForOverrun() {
+	if (!isPortOpen()) return false;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		ULONG status;
+		if (m_ftdi.FT_GetModemStatus(&status) != FTDI::FT_STATUS::FT_OK) return false;
+		return (status & (FT_MODEM_STATUS_OE | FT_MODEM_STATUS_FE)) != 0;
+	}
+#endif
+
+#ifdef _WIN32
+	DWORD errors=0;
+	COMSTAT comstatbuffer;
+
+	if (!ClearCommError(m_portHandle, &errors, &comstatbuffer)) return 0;
+	return (errors & (CE_OVERRUN | CE_FRAME | CE_RXOVER)) != 0;
+#else
+	return false;
+#endif
+}
+
+// Returns the number of bytes waiting to be read
+unsigned int SerialIO::getBytesWaiting() {
+	if (!isPortOpen()) return 0;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		DWORD queueSize = 0;
+		if (m_ftdi.FT_GetQueueStatus(&queueSize) != FTDI::FT_STATUS::FT_OK) return 0;
+		return queueSize;
+	}
+#endif
+
+#ifdef _WIN32
+	DWORD errors;
+	COMSTAT comstatbuffer;
+
+	if (!ClearCommError(m_portHandle, &errors, &comstatbuffer)) return 0;
+	return comstatbuffer.cbInQue;
+#else
+	int waiting;
+	if (ioctl(m_portHandle, TIOCINQ, &waiting) < 0) return 0;
+	return (unsigned int)waiting;
+#endif
+}
+
+// Attempts to write some data to the port.  Returns how much it actually wrote.
+// If writeAll is not TRUE then it will write what it can until it times out
+unsigned int SerialIO::write(const void* data, unsigned int dataLength) {
+	if ((data == nullptr) || (dataLength == 0)) return 0;
+	if (!isPortOpen()) return 0;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		m_ftdi.FT_SetTimeouts(m_readTimeout + (m_readTimeoutMultiplier * dataLength), m_writeTimeout + (m_writeTimeoutMultiplier * dataLength));
+
+		DWORD written = 0;
+		if (m_ftdi.FT_Write((LPVOID)data, dataLength, &written) != FTDI::FT_STATUS::FT_OK) written = 0;
+		return written;
+	}
+#endif
+
+#ifdef _WIN32
+	DWORD written = 0;
+	if (!WriteFile(m_portHandle, data, dataLength, &written, NULL)) written = 0;
+	return written;
+#else
+	unsigned int totalTime = m_writeTimeout + (m_writeTimeoutMultiplier * dataLength);
+
+	struct timeval timeout;
+	timeout.tv_sec = totalTime / 1000;
+	timeout.tv_usec = (totalTime - (timeout.tv_sec * 1000)) * 1000;
+
+	size_t written = 0;
+	unsigned char* buffer = (unsigned char*)data;
+
+	fd_set fds;
+
+	FD_ZERO(&fds);
+	FD_SET(m_portHandle, &fds);
+
+	// Write with a timeout
+	while (written < dataLength) {
+		if ((timeout.tv_sec < 1) && (timeout.tv_usec < 1)) break;
+
+		int result = select(m_portHandle + 1, NULL, &fds, NULL, &timeout);
+		if (result < 0) {
+			if (errno == EINTR || errno == EAGAIN) continue; else return 0;
+		}
+		else if (result == 0) break;
+
+		result = ::write(m_portHandle, buffer, dataLength - written);
+
+		if (result < 0) {
+			if (errno == EINTR || errno == EAGAIN) continue; else return 0;
+		}
+
+		written += result;
+		buffer += result;
+	}
+
+	return written;
+#endif
+
+	return 0;
+}
+
+// A very simple, uncluttered version of the below, mainly for linux
+unsigned int SerialIO::justRead(void* data, unsigned int dataLength) {
+	if ((data == nullptr) || (dataLength == 0)) return 0;
+	if (!isPortOpen()) return 0;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		m_ftdi.FT_SetTimeouts(m_readTimeout + (m_readTimeoutMultiplier * dataLength), m_writeTimeout + (m_writeTimeoutMultiplier * dataLength));
+
+		DWORD dataRead = 0;
+		if (m_ftdi.FT_Read((LPVOID)data, dataLength, &dataRead) != FTDI::FT_STATUS::FT_OK) dataRead = 0;
+		return dataRead;
+	}
+#endif
+
+#ifdef _WIN32
+	DWORD read = 0;
+	if (!ReadFile(m_portHandle, data, dataLength, &read, NULL)) read = 0;
+	return read;
+#else
+	int result = ::read(m_portHandle, data, dataLength);
+
+	if (result < 0) return 0;
+
+	return (unsigned int)result;
+
+
+#endif
+
+	return 0;
+
+}
+
+// Attempts to read some data from the port.  Returns how much it actually read.
+// Returns how much it actually read
+unsigned int SerialIO::read(void* data, unsigned int dataLength) {
+	if ((data == nullptr) || (dataLength == 0)) return 0;
+	if (!isPortOpen()) return 0;
+
+#ifdef FTDI_D2XX_AVAILABLE
+	if (m_ftdi.isOpen()) {
+		m_ftdi.FT_SetTimeouts(m_readTimeout + (m_readTimeoutMultiplier * dataLength), m_writeTimeout + (m_writeTimeoutMultiplier * dataLength));
+
+		DWORD dataRead = 0;
+		if (m_ftdi.FT_Read((LPVOID)data, dataLength, &dataRead) != FTDI::FT_STATUS::FT_OK) dataRead = 0;
+		return dataRead;
+	}
+#endif
+
+#ifdef _WIN32
+	DWORD read = 0;
+	if (!ReadFile(m_portHandle, data, dataLength, &read, NULL)) read = 0;
+	return read;
+#else
+	unsigned int totalTime = m_readTimeout + (m_readTimeoutMultiplier * dataLength);
+
+	struct timeval timeout;
+	timeout.tv_sec = totalTime / 1000;
+	timeout.tv_usec = (totalTime - (timeout.tv_sec * 1000)) * 1000;
+
+	size_t read = 0;
+	unsigned char* buffer = (unsigned char*)data;
+
+	fd_set fds;
+	FD_ZERO(&fds);
+	FD_SET(m_portHandle, &fds);
+
+	while (read < dataLength) {
+		if ((timeout.tv_sec < 1) && (timeout.tv_usec < 1)) {
+			break;
+		}
+
+		int result = select(m_portHandle + 1, &fds, NULL, NULL, &timeout);
+
+		if (result < 0) {
+			if (errno == EINTR || errno == EAGAIN) continue; else return 0;
+		}
+		else if (result == 0) break;
+		result = ::read(m_portHandle, buffer, dataLength - read);
+
+		if (result < 0) {
+			if (errno == EINTR || errno == EAGAIN) continue; else return 0;
+		}
+		read += result;
+		buffer += result;
+	}
+
+	return read;
+
+
+#endif
+
+	return 0;
+}
+
+// Update timeouts
+void SerialIO::updateTimeouts() {
+	if (!isPortOpen()) return;
+
+#ifdef _WIN32
+	COMMTIMEOUTS tm;
+	tm.ReadTotalTimeoutConstant = m_readTimeout;
+	tm.ReadTotalTimeoutMultiplier = m_readTimeoutMultiplier;
+	tm.ReadIntervalTimeout = 0;
+	tm.WriteTotalTimeoutConstant = m_writeTimeout;
+	tm.WriteTotalTimeoutMultiplier = m_writeTimeoutMultiplier;
+	SetCommTimeouts(m_portHandle, &tm);
+#endif
+}
+
+// Sets the read timeouts. The actual timeout is calculated as waitTimetimeout + (multiplier * num bytes)
+void SerialIO::setReadTimeouts(unsigned int waitTimetimeout, unsigned int multiplier) {
+	m_readTimeout = waitTimetimeout;
+	m_readTimeoutMultiplier = multiplier;
+
+	updateTimeouts();
+}
+
+// Sets the write timeouts. The actual timeout is calculated as waitTimetimeout + (multiplier * num bytes)
+void SerialIO::setWriteTimeouts(unsigned int waitTimetimeout, unsigned int multiplier) {
+	m_writeTimeout = waitTimetimeout;
+	m_writeTimeoutMultiplier = multiplier;
+
+	updateTimeouts();
+}

--- a/vendor/floppybridge/src/SerialIO.h
+++ b/vendor/floppybridge/src/SerialIO.h
@@ -1,0 +1,154 @@
+#ifndef DISKREADERWRITER_SERIAL_IO
+#define DISKREADERWRITER_SERIAL_IO
+/* ArduinoFloppyReader (and writer)
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Class to manage the communication between the computer and a serial port           //
+////////////////////////////////////////////////////////////////////////////////////////
+//
+//
+
+#include <string>
+#include <vector>
+#include <stdint.h>
+
+#ifdef _WIN32
+#ifdef USING_MFC
+#include <afxwin.h>
+#else
+#include <Windows.h>
+#endif
+#else
+#include <termios.h>
+#endif
+
+#include "ftdi.h"
+
+#define FTDI_PORT_PREFIX "FTDI:"
+
+extern void quickw2a(const std::wstring& wstr, std::string& str);
+extern void quicka2w(const std::string& str, std::wstring& wstr);
+
+
+class SerialIO {
+private:
+	unsigned int m_readTimeout = 0, m_readTimeoutMultiplier = 0;
+	unsigned int m_writeTimeout = 0, m_writeTimeoutMultiplier = 0;
+#ifdef FTDI_D2XX_AVAILABLE
+	FTDI::FTDIInterface m_ftdi;
+#endif
+
+#ifdef _WIN32
+	HANDLE m_portHandle = INVALID_HANDLE_VALUE;
+#else
+	int m_portHandle = -1;
+#ifdef HAVE_STRUCT_TERMIOS2
+	struct termios2 term;
+#else
+	struct termios term;
+#endif
+#endif
+
+	// Update timeouts
+	void updateTimeouts();
+
+public:
+	// Definition of a serial port
+	struct SerialPortInformation {
+		// The "file" name of the port
+		std::wstring portName;
+		// Port details
+		unsigned int vid = 0, pid = 0;
+		// Product name
+		std::wstring productName;
+		// Instance ID
+		std::wstring instanceID;
+#ifdef FTDI_D2XX_AVAILABLE
+		// Set if this is an FTDI device index
+		int ftdiIndex = -1;
+#endif
+	};
+
+	// Configuration settings for the port
+	struct Configuration {
+		unsigned int baudRate	= 9600;		
+		bool ctsFlowControl		= false;
+	};
+
+	enum class Response { rOK, rInUse, rNotFound, rUnknownError, rNotImplemented };
+
+	// Constructor etc
+	SerialIO();
+	virtual ~SerialIO();
+
+	// Sets the status of the DTR line
+	void setDTR(bool enableDTR);
+
+	// Sets the status of the RTS line
+	void setRTS(bool enableRTS);
+
+	// Returns the status of the CTS pin
+	bool getCTSStatus();
+
+	// Returns TRUE if the port is open
+	bool isPortOpen() const;
+
+	// Returns a list of serial ports discovered on the system
+	static void enumSerialPorts(std::vector<SerialPortInformation>& serialPorts);
+
+	// Purge any data left in the buffer
+	void purgeBuffers();
+
+	// Returns the number of bytes waiting to be read
+	unsigned int getBytesWaiting();
+
+	// Check if we were quick enough reading the data
+	bool checkForOverrun();
+
+	// Open a port by name
+	Response openPort(const std::wstring& portName);
+
+	// Shuts the port down
+	void closePort();
+
+	// Attempt ot change the size of the buffers used by the OS
+	void setBufferSizes(const unsigned int rxSize, const unsigned int txSize);
+
+	// Changes the configuration on the port
+	Response configurePort(const Configuration& configuration);
+
+	// Attempts to write some data to the port.  Returns how much it actually wrote.
+	unsigned int write(const void* data, unsigned int dataLength);
+
+	// Attempts to read some data from the port.  Returns how much it actually read.
+	// Returns how mcuh it actually read
+	unsigned int read(void* data, unsigned int dataLength);
+
+	// A very simple, uncluttered version of the above, mainly for linux
+	unsigned int justRead(void* data, unsigned int dataLength);
+
+	// Sets the read timeouts. The actual timeout is calculated as waitTimetimeout + (multiplier * num bytes)
+	void setReadTimeouts(unsigned int waitTimetimeout, unsigned int multiplier);
+
+	// Sets the write timeouts. The actual timeout is calculated as waitTimetimeout + (multiplier * num bytes)
+	void setWriteTimeouts(unsigned int waitTimetimeout, unsigned int multiplier);
+};
+ 
+
+#endif

--- a/vendor/floppybridge/src/SuperCardProBridge.cpp
+++ b/vendor/floppybridge/src/SuperCardProBridge.cpp
@@ -1,0 +1,283 @@
+/* WinUAE Supercard Pro Interface for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+#include "floppybridge_config.h"
+
+#ifdef ROMTYPE_SUPERCARDPRO_WRITER
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "SuperCardProBridge.h"
+#include "SuperCardProInterface.h"
+
+
+using namespace SuperCardPro;
+
+
+static const FloppyDiskBridge::BridgeDriver DriverSupercardProFloppy = {
+	"SuperCard Pro", "https://www.cbmstuff.com/", "Jim Drew", "RobSmithDev", CONFIG_OPTIONS_COMPORT | CONFIG_OPTIONS_COMPORT_AUTODETECT | CONFIG_OPTIONS_DRIVE_AB | CONFIG_OPTIONS_SMARTSPEED | CONFIG_OPTIONS_AUTOCACHE
+};
+
+
+// Flags from WINUAE
+SupercardProDiskBridge::SupercardProDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool enableAutoCache, bool useSmartSpeed, bool autoDetectComPort, char* comPort, bool driveOnB) :
+	CommonBridgeTemplate(bridgeMode, bridgeDensity, enableAutoCache, useSmartSpeed), m_comPort(autoDetectComPort ? comPort : ""), m_useDriveA(!driveOnB) {
+}
+
+// This is for the static version
+SupercardProDiskBridge::SupercardProDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, int uaeSettings) :
+	CommonBridgeTemplate(bridgeMode, bridgeDensity, false, false), m_useDriveA((uaeSettings & 0x0F) == 0), m_comPort("") {
+}
+
+
+SupercardProDiskBridge::~SupercardProDiskBridge() {
+}
+
+// If your device supports being able to abort a disk read, mid-read then implement this
+void SupercardProDiskBridge::abortDiskReading() {
+	m_io.abortReadStreaming();
+};
+
+// A manual way to detect a disk change event
+bool SupercardProDiskBridge::attemptToDetectDiskChange() {
+	switch (m_io.checkForDisk(true)) {
+	case SCPErr::scpOK: return true;
+	case SCPErr::scpNoDiskInDrive: return false;
+	case SCPErr::scpUnknownError: m_wasIOError = true; return false;
+	default: return isDiskInDrive();
+	}
+}
+
+// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+bool SupercardProDiskBridge::supportsDiskChange() {
+	return true;
+}
+
+// Return TRUE if the drive is still connected and working
+bool SupercardProDiskBridge::isStillWorking() {
+	return !m_wasIOError;
+}
+
+// Called when the class is about to shut down
+void SupercardProDiskBridge::closeInterface() {
+	// Turn everything off
+	m_io.enableMotor(false);
+	m_io.closePort();
+}
+
+// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+bool SupercardProDiskBridge::openInterface(std::string& errorMessage) {
+	SCPErr error = m_io.openPort(m_useDriveA);
+
+	if (error == SCPErr::scpOK) {
+		m_io.findTrack0();
+		m_currentCylinder = 0;
+		return true;
+	}
+	else {
+		switch (error) {
+		case SCPErr::scpFirmwareTooOld: errorMessage = "SuperCard Pro firmware must be updated to V1.3"; break;
+		case SCPErr::scpNotFound: errorMessage = "SuperCard Pro board was not detected."; break;
+		case SCPErr::scpInUse: errorMessage = "SuperCard Pro board is already in use."; break;
+		default: errorMessage = "An unknown error occurred connecting to your SuperCard Pro."; break;
+		}
+	}
+
+	return false;
+}
+
+
+const FloppyDiskBridge::BridgeDriver* SupercardProDiskBridge::staticBridgeInformation() {
+	return &DriverSupercardProFloppy;
+}
+
+// Get the name of the drive
+const FloppyDiskBridge::BridgeDriver* SupercardProDiskBridge::_getDriverInfo() {
+	return staticBridgeInformation();
+}
+
+// Duplicate of the one below, but here for consistency - Returns the name of interface.  This pointer should remain valid after the class is destroyed
+const FloppyDiskBridge::DriveTypeID SupercardProDiskBridge::_getDriveTypeID() {
+	return m_isHDDisk ? DriveTypeID::dti35HD : DriveTypeID::dti35DD;
+}
+
+// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+void SupercardProDiskBridge::checkDiskType() {
+	bool capacity;
+
+	// Check capacity
+	if (m_io.checkDiskCapacity(capacity)) {
+		m_isHDDisk = capacity;
+		m_io.selectDiskDensity(m_isHDDisk);
+	}
+	else {
+		m_isHDDisk = false;
+		m_io.selectDiskDensity(m_isHDDisk);
+	}
+}
+
+
+// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+void SupercardProDiskBridge::forceDiskDensity(bool forceHD) {
+	m_isHDDisk = forceHD;
+	m_io.selectDiskDensity(m_isHDDisk);
+}
+
+
+// Called to switch which head is being used right now.  Returns success or not
+bool SupercardProDiskBridge::setActiveSurface(const DiskSurface activeSurface) {
+	return m_io.selectSurface(activeSurface == DiskSurface::dsUpper ? SuperCardPro::DiskSurface::dsUpper : SuperCardPro::DiskSurface::dsLower);
+}
+
+// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+bool SupercardProDiskBridge::setMotorStatus(const bool switchedOn) {
+	m_motorIsEnabled = switchedOn;
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+	return m_io.enableMotor(switchedOn, true);
+}
+
+// Called to ask the drive what the current write protect status is - return true if its write protected
+bool SupercardProDiskBridge::checkWriteProtectStatus(const bool forceCheck) {
+	return m_io.isWriteProtected();
+}
+
+// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+bool SupercardProDiskBridge::getDiskChangeStatus(const bool forceCheck) {
+	// We actually trigger a SEEK operation to ensure this is right
+	if (forceCheck) {
+		switch (m_io.checkForDisk(forceCheck)) {
+		case SCPErr::scpNoDiskInDrive:
+			if (m_currentCylinder == 0) {
+				m_io.performNoClickSeek();
+			}
+			else {
+				m_io.selectTrack((m_currentCylinder > 40) ? m_currentCylinder - 1 : m_currentCylinder + 1, true);
+				m_io.selectTrack(m_currentCylinder, true);
+			}
+			break;
+		case SCPErr::scpUnknownError: m_wasIOError = true; return false;
+		}
+	}
+
+	switch (m_io.checkForDisk(forceCheck)) {
+	case SCPErr::scpOK: return true;
+	case SCPErr::scpNoDiskInDrive: return false;
+	case SCPErr::scpUnknownError: m_wasIOError = true; return false;
+	default: return isDiskInDrive();
+	}
+}
+
+// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+// Return FALSE if this is not supported by the bridge
+bool SupercardProDiskBridge::performNoClickSeek() {
+	if (m_io.performNoClickSeek()) {
+		updateLastManualCheckTime();
+		return true;
+	}
+	return false;
+}
+
+
+// Trigger a seek to the requested cylinder, this can block until complete
+bool SupercardProDiskBridge::setCurrentCylinder(const unsigned int cylinder) {
+	m_currentCylinder = cylinder;
+
+	// No need if its busy
+	bool ignoreDiskCheck = (isMotorRunning()) && (!isReady());
+
+	// Go!
+	if (m_io.selectTrack(cylinder, ignoreDiskCheck)) {
+		if (!ignoreDiskCheck) updateLastManualCheckTime();	
+		return true;
+	}
+
+	return false;
+}
+
+// Called when data should be read from the drive.
+//		pll:           supplied if you use it
+//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+// Returns: ReadResponse, explains its self
+CommonBridgeTemplate::ReadResponse SupercardProDiskBridge::readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+	std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) {
+	SCPErr result = m_io.readRotation(pll, maxBufferSize, buffer, indexMarker,
+	                                  [&onRotation](RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits) -> bool {
+		                                  return onRotation(*mfmData, dataLengthInBits);
+	                                  });
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+	
+	switch (result) {
+	case SCPErr::scpOK: return ReadResponse::rrOK;
+	case SCPErr::scpNoDiskInDrive: return ReadResponse::rrNoDiskInDrive;
+	default:  return ReadResponse::rrError;
+	}	
+}
+
+
+// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+//		pll:           required 
+// Returns: ReadResponse, explains its self
+CommonBridgeTemplate::ReadResponse SupercardProDiskBridge::readLinearData(PLL::BridgePLL& pll) {
+	SCPErr result = m_io.readData(pll);
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+
+	switch (result) {
+		case SCPErr::scpOK: return ReadResponse::rrOK;
+		case SCPErr::scpNoDiskInDrive: return ReadResponse::rrNoDiskInDrive;
+		default:  return ReadResponse::rrError;
+	}
+}
+
+
+// Called when a cylinder revolution should be written to the disk.
+// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+//					numBytes						Number of bits in the buffer to write
+//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+//					suggestUsingPrecompensation		A suggestion that you might want to use write pre-compensation, optional
+// Returns TRUE if success, or false if it fails.  Largely doesn't matter as most stuff should verify with a read straight after
+bool SupercardProDiskBridge::writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation) {
+	SCPErr response = m_io.writeCurrentTrackPrecomp(rawMFMData, (numBits + 7) / 8, writeFromIndex, suggestUsingPrecompensation);
+
+	m_motorTurnOnTime = std::chrono::steady_clock::now();
+
+	switch (response) {
+	case SCPErr::scpOK: return true;
+	case SCPErr::scpWriteProtected: setWriteProtectStatus(true); return false;
+	default:  return false;
+	}
+}
+
+// This is called by the main thread in case you need to do anything specific at regular intervals
+void SupercardProDiskBridge::poll() {
+	// SCP has a watchdog timeout and after a while the motor will switch off after inactivity.  We can't allow this as doesn't work for how the Amiga might do things
+	if (m_motorIsEnabled) {
+		const auto timePassed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_motorTurnOnTime).count();
+		if (timePassed > (m_io.getMotorIdleTimeoutTime() / 2)) {
+			m_io.enableMotor(true, true); 
+			m_motorTurnOnTime = std::chrono::steady_clock::now();
+		}
+	}
+}
+
+
+#endif

--- a/vendor/floppybridge/src/SuperCardProBridge.h
+++ b/vendor/floppybridge/src/SuperCardProBridge.h
@@ -1,0 +1,150 @@
+#ifndef SUPERCARDPRO_FLOPPY_BRIDGE
+#define SUPERCARDPRO_FLOPPY_BRIDGE
+/* WinUAE Supercard Pro Interface for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+//
+// ROMTYPE_SUPERCARDPRO_WRITER must be defined for this to work
+
+#ifdef ROMTYPE_SUPERCARDPRO_WRITER
+
+#include "floppybridge_abstract.h"
+#include "CommonBridgeTemplate.h"
+#include "SuperCardProInterface.h"
+#include "pll.h"
+
+
+class SupercardProDiskBridge : public CommonBridgeTemplate {
+private:
+	// When the motor last switched on	
+	std::chrono::time_point<std::chrono::steady_clock> m_motorTurnOnTime;
+	bool m_motorIsEnabled = false;
+
+	// Which com port should we use? or blank for automatic
+	std::string m_comPort;
+
+	// Used to detect disconnection of SupercardPRO while in use
+	bool m_wasIOError = false;
+	
+	// Which drive to use
+	bool m_useDriveA = false;
+
+	// Is this a HD disk?
+	bool m_isHDDisk = false;
+
+	// Hardware connection
+	SuperCardPro::SCPInterface m_io;
+
+	// Remember where we are
+	int m_currentCylinder = 0;
+
+protected:
+	// Called when a disk is inserted so that you can (re)populate the response to _getDriveTypeID()
+	virtual void checkDiskType() override;
+
+	// Called to force into DD or HD mode.  Overrides checkDiskType() until checkDiskType() is called again
+	virtual void forceDiskDensity(bool forceHD) override;
+
+	// This is called by the main thread in case you need to do anything specific at regular intervals
+	virtual void poll() override;
+
+	// Return TRUE if the drive is still connected and working
+	virtual bool isStillWorking() override;
+
+	// If your device supports being able to abort a disk read, mid-read then implement this
+	virtual void abortDiskReading() override;
+
+	// If your device supports the DiskChange option then return TRUE here.  If not, then the code will simulate it
+	virtual bool supportsDiskChange() override;
+
+	// If the above is TRUE then this is called to get the status of the DiskChange line.  Basically, this is TRUE if there is a disk in the drive.
+	// If force is true you should re-check, if false, then you are allowed to return a cached value from the last disk operation (eg: seek)
+	virtual bool getDiskChangeStatus(const bool forceCheck) override;
+
+	// Called when the class is about to shut down
+	virtual void closeInterface() override;
+
+	// Called to start the interface, you should update any error messages if it fails.  This needs to be ready to see to any cylinder and so should already know where cylinder 0 is
+	virtual bool openInterface(std::string& errorMessage) override;
+
+	// Called to ask the drive what the current write protect status is - return true if its write protected.  If forceCheck is true you should actually check the drive, 
+	// else use the last status checked which was probably from a SEEK setCurrentCylinder call.  If you can ONLY get this information here then you should always force check
+	virtual bool checkWriteProtectStatus(const bool forceCheck) override;
+
+	// Get the name of the drive
+	virtual const BridgeDriver* _getDriverInfo() override;
+
+	// Duplicate of the one below, but here for consistency - Returns the name of interface.  This pointer should remain valid after the class is destroyed
+	virtual const DriveTypeID _getDriveTypeID() override;
+
+	// Called to switch which head is being used right now.  Returns success or not
+	virtual bool setActiveSurface(const DiskSurface activeSurface) override;
+
+	// Set the status of the motor on the drive. The motor should maintain this status until switched off or reset.  This should *NOT* wait for the motor to spin up
+	virtual bool setMotorStatus(const bool switchedOn) override;
+
+	// Trigger a seek to the requested cylinder, this can block until complete
+	virtual bool setCurrentCylinder(const unsigned int cylinder) override;
+
+	// If we're on track 0, this is the emulator trying to seek to track -1.  We catch this as a special case.  
+	// Should perform the same operations as setCurrentCylinder in terms of disk change etc but without changing the current cylinder
+	// Return FALSE if this is not supported by the bridge
+	virtual bool performNoClickSeek() override;
+
+	// Called when data should be read from the drive.
+	//		pll:		   supplied if you use it
+	//		maxBufferSize: Maximum number of RotationExtractor::MFMSample in the buffer.  If we're trying to detect a disk, this might be set VERY LOW
+	// 	    buffer:		   Where to save to.  When a buffer is saved, position 0 MUST be where the INDEX pulse is.  RevolutionExtractor will do this for you
+	//		indexMarker:   Used by rotationExtractor if you use it, to help be consistent where the INDEX position is read back at
+	//		onRotation: A function you should call for each complete revolution received.  If the function returns FALSE then you should abort reading, else keep sending revolutions
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readData(PLL::BridgePLL& pll, const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+		std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) override;
+
+	// Called for a direct read. This does not match up a rotation and should be used with the pll initialized with the LinearExtractor
+	//		pll:           required 
+	// Returns: ReadResponse, explains its self
+	virtual ReadResponse readLinearData(PLL::BridgePLL& pll) override;
+
+	// Called when a cylinder revolution should be written to the disk.
+	// Parameters are:	rawMFMData						The raw data to be written.  This is an actual MFM stream, going from MSB to LSB for each byte
+	//					numBytes						Number of bits in the buffer to write
+	//					writeFromIndex					If an attempt should be made to write this from the INDEX pulse rather than just a random position
+	//					suggestUsingPrecompensation		A suggestion that you might want to use write pre-compensation, optional
+	// Returns TRUE if success, or false if it fails.  Largely doesnt matter as most stuff should verify with a read straight after
+	virtual bool writeData(const unsigned char* rawMFMData, const unsigned int numBits, const bool writeFromIndex, const bool suggestUsingPrecompensation) override;
+
+	// A manual way to check for disk change.  This is simulated by issuing a read message and seeing if there's any data.  Returns TRUE if data or an INDEX pulse was detected
+	// It's virtual as the default method issues a read and looks for data.  If you have a better implementation then override this
+	virtual bool attemptToDetectDiskChange() override;
+
+public:
+	SupercardProDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, bool enableAutoCache, bool useSmartSpeed, bool autoDetectComPort, char* comPort, bool driveOnB);
+
+	// This is for the static version
+	SupercardProDiskBridge(FloppyBridge::BridgeMode bridgeMode, FloppyBridge::BridgeDensityMode bridgeDensity, int uaeSettings);
+
+
+	virtual ~SupercardProDiskBridge();
+
+	static const BridgeDriver* staticBridgeInformation();
+};
+
+
+#endif
+#endif

--- a/vendor/floppybridge/src/SuperCardProInterface.cpp
+++ b/vendor/floppybridge/src/SuperCardProInterface.cpp
@@ -1,0 +1,1056 @@
+/* Supercard Pro C++ Interface for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* Based on the documentation and hardware by Jim Drew at
+* https://www.cbmstuff.com/
+* 
+* This requires firmware V1.3
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+#include <sstream>
+#include <vector>
+#include <queue>
+#include <cstring>
+#include <thread>
+#include <deque>
+#include "SuperCardProInterface.h"
+#include "pll.h"
+#include "RotationExtractor.h"
+#ifdef _WIN32
+#include <winsock.h>
+#pragma comment(lib,"Ws2_32.lib")
+#else
+#include <arpa/inet.h>
+#endif
+
+#define MOTOR_AUTOOFF_DELAY 10000
+
+#define BITCELL_SIZE_IN_NS 2000L
+
+#define BIT_READ_FROM_INDEX         (1 << 0)
+
+
+#define STREAMFLAGS_RAWFLUX				(0 << 4)
+
+#define STREAMFLAGS_RESOLUTION_25NS     (0 << 2)
+#define STREAMFLAGS_RESOLUTION_50NS     (1 << 2)
+#define STREAMFLAGS_RESOLUTION_100NS    (2 << 2)
+#define STREAMFLAGS_RESOLUTION_200NS    (3 << 2)
+
+#define FLAGS_BITSIZE_8BIT        (1 << 1)
+#define FLAGS_BITSIZE_16BIT       (0 << 1)
+
+#define STREAMFLAGS_IMMEDIATEREAD       (0 << 0)
+#define STREAMFLAGS_STREAMFROMINDEX     (1 << 0)
+
+using namespace SuperCardPro;
+
+
+// Constructor for this class
+SCPInterface::SCPInterface() {
+	m_diskInDrive = false;
+	m_isWriteProtected = true;
+	m_abortSignalled = false;
+	m_isStreaming = false;
+	m_abortStreaming = true;
+}
+
+// Free me
+SCPInterface::~SCPInterface() {
+	abortReadStreaming();
+	closePort();
+}
+
+bool SCPInterface::sendCommand(const SCPCommand command, SCPResponse& response) {
+	return sendCommand(command, NULL, 0, response);
+}
+
+bool SCPInterface::sendCommand(const SCPCommand command, const unsigned char parameter, SCPResponse& response) {
+	return sendCommand(command, &parameter, 1, response);
+}
+
+bool SCPInterface::sendCommand(const SCPCommand command, const unsigned char* payload, const unsigned char payloadLength, SCPResponse& response, bool readResponse) {
+	std::vector<unsigned char> packet;
+	packet.push_back((unsigned char)command);
+	packet.push_back(payloadLength);
+
+	if ((payloadLength) && (payload)) {
+		packet.resize(2 + payloadLength);
+		unsigned char* target = ((unsigned char*)packet.data()) + 2;
+#ifdef _WIN32
+		memcpy_s(target, payloadLength, payload, payloadLength);
+#else
+		memcpy(target, payload, payloadLength);
+#endif
+	}
+	unsigned char checksum = 0x4A;
+	for (const unsigned char data : packet) checksum += data;
+	packet.push_back(checksum);
+
+	if (m_comPort.write(packet.data(), (unsigned int)packet.size()) != packet.size()) {
+		response = SCPResponse::pr_writeError;
+		return false;
+	}
+
+	if (readResponse) {
+		SCPCommand cmdReply;
+		if (m_comPort.read(&cmdReply, 1)!=1) return false;
+		if (m_comPort.read(&response, 1)!=1) return false;
+	}
+
+	return true;
+}
+
+
+// Attempts to open the reader running on the COM port number provided.  Port MUST support 2M baud
+SCPErr SCPInterface::openPort(bool useDriveA) {
+	closePort();
+	m_useDriveA = useDriveA;
+
+	m_selectStatus = false;
+	m_motorIsEnabled = false;
+
+	std::vector<SerialIO::SerialPortInformation> ports;
+	SerialIO::enumSerialPorts(ports);
+
+	// Find the port
+	for (const SerialIO::SerialPortInformation& port : ports) {
+		if ((port.portName.find(L"SCP-JIM") != std::wstring::npos) || (port.portName.find(L"Supercard Pro") != std::wstring::npos)) {
+			switch (m_comPort.openPort(port.portName)) {
+			case SerialIO::Response::rInUse:return SCPErr::scpInUse;
+			case SerialIO::Response::rNotFound:return SCPErr::scpNotFound;
+			case SerialIO::Response::rOK: break;
+			default: return SCPErr::scpUnknownError;
+			}
+		}
+		if (m_comPort.isPortOpen()) break;
+	}
+	if (!m_comPort.isPortOpen()) SCPErr::scpNotFound;
+
+	// Configure the port
+	SerialIO::Configuration config;
+	config.baudRate = 9600;
+	config.ctsFlowControl = false;
+
+	if (m_comPort.configurePort(config) != SerialIO::Response::rOK) return SCPErr::scpUnknownError;
+
+	applyCommTimeouts(false);
+
+	m_comPort.purgeBuffers();
+
+	// Lookup what firmware this is running
+	SCPResponse response;
+	if (!sendCommand(SCPCommand::DoCMD_SCPInfo, response)) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	if (response != SCPResponse::pr_Ok) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	unsigned char data[2];
+	if (m_comPort.read(data, 2) != 2) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	m_firmwareVersion.hardwareVersion = data[0] >> 4;
+	m_firmwareVersion.hardwareRevision = data[0] & 0xFF;
+	m_firmwareVersion.firmwareVersion = data[1] >> 4;
+	m_firmwareVersion.firmwareRevision = data[1] & 0xFF;
+
+	// Check we're on v1.3 of the firmware
+	if ((m_firmwareVersion.firmwareVersion <= 1) && (m_firmwareVersion.firmwareRevision < 3)) {
+		m_comPort.closePort();
+		return SCPErr::scpFirmwareTooOld;
+	}
+
+	// Turn everything off
+	sendCommand(SCPCommand::DoCMD_MTRAOFF, response);  
+	if (response != SCPResponse::pr_Ok) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	sendCommand(SCPCommand::DoCMD_MTRBOFF, response);
+	if (response != SCPResponse::pr_Ok) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	sendCommand(SCPCommand::DoCMD_DSELA, response);
+	if (response != SCPResponse::pr_Ok) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	sendCommand(SCPCommand::DoCMD_DSELB, response);
+	if (response != SCPResponse::pr_Ok) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+
+	if (!findTrack0()) {
+		m_comPort.closePort();
+		return SCPErr::scpUnknownError;
+	}
+	m_currentTrack = 0;
+
+	// Ok, success
+	return SCPErr::scpOK;
+}
+
+// Trigger drive select
+bool SCPInterface::selectDrive(bool select) {
+	SCPResponse response;
+
+	if (select == m_selectStatus) return true;
+
+	if (select) {
+		if (sendCommand(m_useDriveA ? SCPCommand::DoCMD_SELA : SCPCommand::DoCMD_SELB, response)) {
+			m_selectStatus = select;
+			return true;
+		}
+	}
+	else {
+		if (sendCommand(m_useDriveA ? SCPCommand::DoCMD_DSELA : SCPCommand::DoCMD_DSELB, response)) {
+			m_selectStatus = select;
+			return true;
+		}
+	}
+	return false;
+}
+
+// Apply and change the timeouts on the com port
+void SCPInterface::applyCommTimeouts(bool shortTimeouts) {
+	m_comPort.setWriteTimeouts(2000, 200);
+
+	if (shortTimeouts) {
+		m_comPort.setReadTimeouts(15, 5);
+	}
+	else {
+		m_comPort.setReadTimeouts(2000, 200);
+	}		
+}
+
+// Closes the port down
+void SCPInterface::closePort() {
+	enableMotor(false);
+	
+	m_comPort.closePort();
+}
+
+// Returns the motor idle (auto switch off) time
+unsigned int SCPInterface::getMotorIdleTimeoutTime() {
+	return MOTOR_AUTOOFF_DELAY;
+}
+
+
+// Turns on and off the reading interface
+bool SCPInterface::enableMotor(const bool enable, const bool dontWait) {
+	SCPResponse response;
+	
+	if (enable) {
+		uint16_t payload[5];		
+
+		if (dontWait) {
+			payload[0] = htons(1000);   // Drive select delay (microseconds)
+			payload[1] = htons(5000);   // Step command delay (microseconds)
+			payload[2] = htons(150);      // Motor on delay (milliseconds) - for some reason if less than 100 then seeking doesnt work properly
+			payload[3] = htons(5);      // Track Seek Delay (Milliseconds)
+			payload[4] = htons(MOTOR_AUTOOFF_DELAY);   // Before turning off the motor automatically (milliseconds)
+		}
+		else {
+			payload[0] = htons(1000);   // Drive select delay (microseconds)
+			payload[1] = htons(5000);   // Step command delay (microseconds)
+			payload[2] = htons(750);      // Motor on delay (milliseconds)
+			payload[3] = htons(15);   // Track Seek Delay (Milliseconds)
+			payload[4] = htons(20000);   // Before turning off the motor automatically (milliseconds)
+		}
+
+		if (!sendCommand(SCPCommand::DoCMD_SETPARAMS, (unsigned char*)payload, sizeof(payload), response)) return false;
+
+		if (!sendCommand(m_useDriveA ? SCPCommand::DoCMD_MTRAON : SCPCommand::DoCMD_MTRBON, response)) return false;
+
+		// make the light come on too
+		selectDrive(true);
+
+		if (!dontWait) std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+		m_motorIsEnabled = enable;
+		return true;
+	}
+	else {
+		m_motorIsEnabled = false;
+		return sendCommand(m_useDriveA ? SCPCommand::DoCMD_MTRAOFF : SCPCommand::DoCMD_MTRBOFF, response);
+	}
+}
+
+// Do the 'no-click' seek
+bool SCPInterface::performNoClickSeek() {
+	if (m_currentTrack == 0) {
+		SCPResponse response;
+
+		selectDrive(true);
+		bool ret = sendCommand(SCPCommand::DoCMD_STEPOUT, response);
+		if (!m_motorIsEnabled) selectDrive(false);
+
+		checkPins();
+
+		return ret;
+	}
+	else {
+		return false;
+	}
+}
+
+// Select the track, this makes the motor seek to this position
+bool SCPInterface::selectTrack(const unsigned char trackIndex, bool ignoreDiskInsertCheck) {
+	//if (m_currentTrack < 0) return false;
+	if (trackIndex < 0) return false;
+	if (trackIndex > 83) return false;
+
+
+	selectDrive(true);
+	SCPResponse response;
+	bool ret = sendCommand(SCPCommand::DoCMD_STEPTO, trackIndex, response );
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	if (ret && (response == SCPResponse::pr_Ok)) {
+		m_currentTrack = trackIndex;
+
+		// We have to check for a disk manually
+		if (!ignoreDiskInsertCheck) {
+			checkForDisk(true);
+		}
+
+		checkPins();
+
+		return true;
+	}
+	else return false;
+}
+
+// Checks the pins from boards that support it
+bool SCPInterface::checkPins() {
+	SCPResponse response;
+
+	selectDrive(true);
+	bool ret = sendCommand(SCPCommand::DoCMD_STATUS, response);	
+
+	if (!ret) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		return false;
+	}
+
+	unsigned char bytes[2];
+	if (m_comPort.read(bytes, 2) != 2) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		return false;
+	}
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	uint16_t status = (bytes[1] | (bytes[0] << 8));
+	m_isWriteProtected = (status & (1 << 7)) == 0;
+	m_diskInDrive = (status & (1 << 6)) !=0;
+	m_isAtTrack0 = (status & (1 << 5)) == 0;
+	return true;
+}
+
+// Search for track 0
+bool SCPInterface::findTrack0() {
+	SCPResponse response;
+
+	selectDrive(true);
+	bool ret = sendCommand(SCPCommand::DoCMD_SEEK0, response);
+	if (!m_motorIsEnabled) selectDrive(false);
+	
+	return ret;
+}
+
+// Choose which surface of the disk to read from
+bool SCPInterface::selectSurface(const DiskSurface side) {
+	SCPResponse response;
+
+	selectDrive(true);
+	bool ret = sendCommand(SCPCommand::DoCMD_SIDE, (side == DiskSurface::dsUpper) ? 1 : 0, response);
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	return ret;
+}
+
+// Read RAW data from the current track and surface 
+SCPErr SCPInterface::checkForDisk(bool force) {
+	if (force) 
+		if (!checkPins()) return SCPErr::scpUnknownError;
+
+	return m_diskInDrive ? SCPErr::scpOK : SCPErr::scpNoDiskInDrive;
+}
+
+// Read a bit from the MFM data provided
+inline int readBit(const unsigned char* buffer, const unsigned int maxLength, int& pos, int& bit) {
+	if (pos >= (int)maxLength) {
+		bit--;
+		if (bit < 0) {
+			bit = 7;
+			pos++;
+		}
+		return (bit & 1) ? 0 : 1;
+	}
+
+	int ret = (buffer[pos] >> bit) & 1;
+	bit--;
+	if (bit < 0) {
+		bit = 7;
+		pos++;
+	}
+
+	return ret;
+}
+
+// Write data to the disk
+SCPErr SCPInterface::writeCurrentTrackPrecomp(const unsigned char* mfmData, const unsigned short numBytes, const bool writeFromIndexPulse, bool usePrecomp) {
+	std::vector<uint16_t> outputBuffer;
+
+	// Original data was written from MSB downto LSB
+	int pos = 0;
+	int bit = 7;
+	unsigned char sequence = 0xAA;  // start at 10101010
+	const int precompTime = 140;   // Amiga default precomp amount (140ns)
+	int extraTimeFromPrevious = 0;
+
+	// Re-encode the data into our format and apply precomp.  The +1 is to ensure there's some padding around the edge 
+	while (pos < numBytes + 1) {
+		int b, count = 0;
+
+		// See how many zero bits there are before we hit a 1
+		do {
+			b = readBit(mfmData, numBytes, pos, bit);
+			sequence = ((sequence << 1) & 0x7F) | b;
+			count++;
+		} while (((sequence & 0x08) == 0) && (pos < numBytes + 8));
+
+		// Validate range
+		if (count < 1) count = 1;  
+		if (count > 5) count = 5;  // max we support 01, 001, 0001, 00001
+		
+		// Calculate the time for this in nanoseconds
+		int timeInNS = extraTimeFromPrevious + (count * 2000);     // 2=4000, 3=6000, 4=8000, (5=10000 although is isn't strictly allowed)
+
+		if (usePrecomp) {
+			const unsigned char BitSeq5 = (sequence & 0x3E);  // extract these bits 00111110 - bit 3 is the ACTUAL bit
+			// Updated from https://github.com/keirf/greaseweazle/blob/master/src/greaseweazle/track.py
+			// The actual idea is that the magnetic fields will repel each other, so we push them closer hoping they will land in the correct spot!
+			switch (BitSeq5) {
+			case 0x28:     // xx10100x
+				timeInNS -= precompTime;
+				extraTimeFromPrevious = precompTime;
+				break;
+			case 0x0A:     // xx00101x
+				timeInNS += precompTime;
+				extraTimeFromPrevious = -precompTime;
+				break;
+			default:
+			{
+				const unsigned char BitSeq3 = (sequence & 0x1C);  // extract these bits 00011100 - bit 3 is the ACTUAL bit
+				switch (BitSeq3) {
+				case 0x18:   // xxx110xx
+					timeInNS -= precompTime;
+					extraTimeFromPrevious = precompTime;
+					break;
+				case 0x0C:   // xxx011xx
+					timeInNS += precompTime;
+					extraTimeFromPrevious = precompTime;
+					break;
+				default:
+					extraTimeFromPrevious = 0;
+					break;
+				}
+				break;
+			}
+			}
+		}
+		
+		if (m_isHDMode) timeInNS /= 2;
+
+		// convert for SCP
+		timeInNS /= 25;
+		while (timeInNS > 65535) {
+			outputBuffer.push_back(0);
+			timeInNS -= 65536;
+		}
+		outputBuffer.push_back(htons(timeInNS));
+	}	
+
+	struct writeheader {
+		uint32_t ramOffset;
+		uint32_t transferLength;
+	} ;
+
+	writeheader header;
+	header.ramOffset = 0;
+	header.transferLength = htonl((u_long)outputBuffer.size() * 2UL);
+
+	// Write the above to the RAM on the SCP
+	SCPResponse response;
+	if (!sendCommand(SCPCommand::DoCMD_LOADRAM_USB,(unsigned char*) &header, sizeof(header), response, false)) return SCPErr::scpUnknownError;
+
+	// Now send the data
+	if (m_comPort.write(outputBuffer.data(), (unsigned int)(outputBuffer.size() * 2)) != outputBuffer.size() * 2) 
+		return SCPErr::scpUnknownError;
+
+	// Now read the response
+	SCPCommand cmdReply;
+	if (!m_comPort.read(&cmdReply, 1)) return SCPErr::scpUnknownError;
+	if (cmdReply != SCPCommand::DoCMD_LOADRAM_USB) return SCPErr::scpUnknownError;
+	if (!m_comPort.read(&response, 1)) return SCPErr::scpUnknownError;
+	if (response != SCPResponse::pr_Ok) return SCPErr::scpUnknownError;
+
+	// Now ask the drive to write it
+	selectDrive(true);
+
+	unsigned char buffer[5];
+	header.transferLength = htonl((u_long)outputBuffer.size());
+	memcpy(buffer, &header.transferLength, 4);
+	buffer[4] = FLAGS_BITSIZE_16BIT | (writeFromIndexPulse ? BIT_READ_FROM_INDEX : 0);
+
+	if (!sendCommand(SCPCommand::DoCMD_WRITEFLUX, buffer, 5, response, true)) return SCPErr::scpUnknownError;
+	if (!m_motorIsEnabled) selectDrive(false);
+
+	if (response == SCPResponse::pr_WPEnabled) {
+		m_isWriteProtected = true;
+		return SCPErr::scpWriteProtected;
+	}
+	m_isWriteProtected = false;
+
+	return SCPErr::scpOK;
+}
+
+// Switch the density mode
+bool SCPInterface::selectDiskDensity(bool hdMode) {
+	m_isHDMode = hdMode;
+	return true;
+}
+
+
+#ifndef _WIN32
+#define USE_THREADDED_READER_SCP
+#endif
+
+
+// Test if its an HD disk
+bool SCPInterface::checkDiskCapacity(bool& isHD) {
+	SCPResponse response;
+
+	bool alreadySpun = m_motorIsEnabled;
+	if (!alreadySpun)
+		if (!enableMotor(true, false)) return false;
+
+	// Issue a read-request
+	selectDrive(true);
+
+	// Request real-time flux stream, 8-bit resolution, and 50ns timings.
+	const unsigned char payload[1] = { STREAMFLAGS_RESOLUTION_50NS | FLAGS_BITSIZE_16BIT | STREAMFLAGS_IMMEDIATEREAD | STREAMFLAGS_RAWFLUX };
+	bool ret = sendCommand(SCPCommand::DoCMD_STARTSTREAM, payload, 1, response);
+	if (!ret) {
+		if ((response == SCPResponse::pr_NotReady) || (response == SCPResponse::pr_NoDisk)) {
+			m_diskInDrive = false;
+			return false;
+		}
+		return false;
+	}
+
+
+
+#ifdef USE_THREADDED_READER_SCP
+	std::mutex safetyLock;
+	// I was using a deque, but its much faster to just keep switching between two vectors
+	std::vector<unsigned char> readBuffer;
+	readBuffer.reserve(4096);
+	std::vector<unsigned char> tempReadBuffer;
+	tempReadBuffer.reserve(4096);
+#ifdef _WIN32
+	m_comPort.setReadTimeouts(100, 0);  // match linux
+#endif
+	std::thread* backgroundReader = new std::thread([this, &readBuffer, &safetyLock]() {
+#ifdef _WIN32
+		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+#endif
+		unsigned char buffer[1024];  // the LINUX serial buffer is only 512 bytes anyway
+		while (m_isStreaming) {
+			uint32_t waiting = m_comPort.justRead(buffer, 1024);
+			if (waiting>0) {
+				safetyLock.lock();				
+				readBuffer.insert(readBuffer.end(), buffer, buffer+waiting);
+				safetyLock.unlock();
+			} else
+				std::this_thread::sleep_for(std::chrono::microseconds(200));
+		}
+	});
+
+
+#else
+	applyCommTimeouts(true);
+	unsigned char tempReadBuffer[2048] = { 0 };
+#endif
+
+	m_isStreaming = true;
+	m_abortStreaming = false;
+	m_abortSignalled = false;
+
+	// Number of times we failed to read anything
+	int readFail = 0;
+
+	// Sliding window for abort
+	unsigned char slidingWindow[4] = { 0,0,0,0 };
+	bool timeout = false;
+	bool dataState = false;
+	bool isFirstByte = true;
+	unsigned char mfmSequences = 0;
+	int hitIndex = 0;
+	uint32_t tickInNS = 0;
+
+	unsigned int nsCounting = 0;
+	unsigned int hdBits = 0;
+	unsigned int ddBits = 0;
+
+	for (;;) {
+
+		// More efficient to read several bytes in one go		
+#ifdef USE_THREADDED_READER_SCP
+		tempReadBuffer.resize(0); // should be just as fast as clear, but just in case
+		safetyLock.lock();
+		std::swap(tempReadBuffer, readBuffer);
+		safetyLock.unlock();
+
+		unsigned int bytesRead = tempReadBuffer.size();
+
+		if (bytesRead < 1) std::this_thread::sleep_for(std::chrono::milliseconds(20));
+		for (const unsigned char byteRead : tempReadBuffer) {
+#else
+		unsigned int bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof(tempReadBuffer)) bytesAvailable = sizeof(tempReadBuffer);
+		unsigned int bytesRead = m_comPort.read(tempReadBuffer, m_abortSignalled ? 1 : bytesAvailable);
+		for (size_t a = 0; a < bytesRead; a++) {
+			const unsigned char byteRead = tempReadBuffer[a];
+#endif
+			if (m_abortSignalled) {
+				for (int s = 0; s < 3; s++) slidingWindow[s] = slidingWindow[s + 1];
+				slidingWindow[3] = byteRead;
+
+				// Watch the sliding window for the pattern we need
+				if ((slidingWindow[0] == 0xDE) && (slidingWindow[1] == 0xAD) && (slidingWindow[2] == (unsigned char)SCPCommand::DoCMD_STOPSTREAM)) {
+					m_isStreaming = false;
+					m_comPort.purgeBuffers();
+
+					applyCommTimeouts(false);
+					if (!alreadySpun) enableMotor(false, false);
+
+					isHD = (hdBits > ddBits);
+#ifdef USE_THREADDED_READER_SCP
+					if (backgroundReader) {
+						if (backgroundReader->joinable()) backgroundReader->join();
+						delete backgroundReader;
+					}
+#endif
+					if (timeout) return false;
+					if (slidingWindow[3] == (unsigned char)SCPResponse::pr_Overrun) return false;
+					return true;
+				}
+			}
+			else {
+
+				switch (byteRead) {
+				case 0xFF:
+					hitIndex = 1; break;
+				case 0x00:
+					if (hitIndex == 1) hitIndex = 2; else tickInNS += m_isHDMode ? (256 * 100) : (256 * 50);
+				default:
+					tickInNS += byteRead * 50;
+					// Enough bit-cells?
+					if (tickInNS > BITCELL_SIZE_IN_NS) {
+						if (tickInNS < 3000) hdBits++;
+						if ((tickInNS > 4500) && (tickInNS < 8000)) ddBits++;
+
+						if ((hdBits + ddBits > 10000) && (!m_abortStreaming)) 
+							abortReadStreaming();
+						tickInNS = 0;
+						hitIndex = 0;
+					}
+				}
+			}
+		}
+		if (bytesRead < 1) {
+			readFail++;
+			if (readFail > 20) {
+				if (!m_abortStreaming) {
+					abortReadStreaming();
+					readFail = 0;
+					m_diskInDrive = false;
+				}
+				else {
+					isHD = (hdBits > ddBits);
+					applyCommTimeouts(false);
+					if (!alreadySpun) enableMotor(false, false);
+					m_isStreaming = false;
+#ifdef USE_THREADDED_READER_SCP
+					if (backgroundReader) {
+						if (backgroundReader->joinable()) backgroundReader->join();
+						delete backgroundReader;
+					}
+#endif
+					return false;
+				}
+			}
+			else {
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+		else {
+			readFail = 0;
+		}
+	}
+}
+
+// Reads a complete rotation of the disk, and returns it using the callback function which can return FALSE to stop
+// An instance of PLL is required which contains a rotation extractor.  This is purely to save on re-allocations.  It is internally reset each time
+SCPErr SCPInterface::readRotation(PLL::BridgePLL& pll, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns,
+	std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation) {
+	SCPResponse response;
+
+	pll.prepareExtractor(m_isHDMode, startBitPatterns);
+
+	// Issue a read-request
+	selectDrive(true);
+
+	// Request real-time flux stream, 8-bit resolution, and 50ns timings.
+	const unsigned char payload[1] = { STREAMFLAGS_RESOLUTION_50NS | FLAGS_BITSIZE_8BIT | STREAMFLAGS_IMMEDIATEREAD | STREAMFLAGS_RAWFLUX };
+	bool ret = sendCommand(SCPCommand::DoCMD_STARTSTREAM, payload, 1, response);
+	if (!ret) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		if ((response == SCPResponse::pr_NotReady) || (response == SCPResponse::pr_NoDisk)) {
+			m_diskInDrive = false;
+			return SCPErr::scpNoDiskInDrive;
+		}
+		return SCPErr::scpUnknownError;
+	}
+	
+
+#ifdef USE_THREADDED_READER_SCP
+	std::mutex safetyLock;
+	// I was using a deque, but its much faster to just keep switching between two vectors
+	std::vector<unsigned char> readBuffer;
+	readBuffer.reserve(4096);
+	std::vector<unsigned char> tempReadBuffer;
+	tempReadBuffer.reserve(4096);
+#ifdef _WIN32
+	m_comPort.setReadTimeouts(100, 0);  // match linux
+#endif
+	std::thread* backgroundReader = new std::thread([this, &readBuffer, &safetyLock]() {
+#ifdef _WIN32
+		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+#else
+		struct sched_param sch;
+		int policy;
+		if (pthread_getschedparam(pthread_self(), &policy, &sch) == 0) {
+			policy = SCHED_FIFO;
+			sch.sched_priority = sched_get_priority_max(policy); // boost priority
+			pthread_setschedparam(pthread_self(), policy, &sch);
+		}
+#endif
+		unsigned char buffer[1024];  // the LINUX serial buffer is only 512 bytes anyway
+		while (m_isStreaming) {
+			uint32_t waiting = m_comPort.justRead(buffer, 1024);
+			if (waiting > 0) {
+				safetyLock.lock();
+				readBuffer.insert(readBuffer.end(), buffer, buffer + waiting);
+				safetyLock.unlock();
+}
+			else
+				std::this_thread::sleep_for(std::chrono::microseconds(200));
+		}
+	});
+
+
+#else
+	applyCommTimeouts(true);
+	unsigned char tempReadBuffer[2048] = { 0 };
+#endif
+
+	m_isStreaming = true;
+	m_abortStreaming = false;
+	m_abortSignalled = false;
+	
+	// Number of times we failed to read anything
+	int readFail = 0;
+
+	pll.prepareExtractor(m_isHDMode, startBitPatterns);
+
+	// Sliding window for abort
+	unsigned char slidingWindow[4] = { 0,0,0,0 };
+	bool timeout = false;
+	bool dataState = false;
+	bool isFirstByte = true;
+	unsigned char mfmSequences = 0;
+	int hitIndex = 0;
+	uint32_t tickInNS = 0;
+
+	for (;;) {
+
+		// More efficient to read several bytes in one go	
+#ifdef USE_THREADDED_READER_SCP
+		tempReadBuffer.resize(0); // should be just as fast as clear, but just in case
+		safetyLock.lock();
+		std::swap(tempReadBuffer, readBuffer);
+		safetyLock.unlock();
+
+		unsigned int bytesRead = tempReadBuffer.size();
+
+		if (bytesRead < 1) std::this_thread::sleep_for(std::chrono::milliseconds(20));
+		for (const unsigned char byteRead : tempReadBuffer) {
+#else
+		unsigned int bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof(tempReadBuffer)) bytesAvailable = sizeof(tempReadBuffer);
+		unsigned int bytesRead = m_comPort.read(tempReadBuffer, m_abortSignalled ? 1 : bytesAvailable);
+		for (size_t a = 0; a < bytesRead; a++) {
+			const unsigned char byteRead = tempReadBuffer[a];
+#endif
+			if (m_abortSignalled) {
+				for (int s = 0; s < 3; s++) slidingWindow[s] = slidingWindow[s + 1];
+				slidingWindow[3] = byteRead;
+
+				// Watch the sliding window for the pattern we need
+				if ((slidingWindow[0] == 0xDE) && (slidingWindow[1] == 0xAD) && (slidingWindow[2] == (unsigned char)SCPCommand::DoCMD_STOPSTREAM)) {
+					m_isStreaming = false;
+#ifdef USE_THREADDED_READER_SCP
+					if (backgroundReader) {
+						if (backgroundReader->joinable()) backgroundReader->join();
+						delete backgroundReader;
+					}
+#endif
+					m_comPort.purgeBuffers();
+					applyCommTimeouts(false);
+					if (!m_diskInDrive) return SCPErr::scpNoDiskInDrive;
+					if (timeout) return SCPErr::scpUnknownError;
+					if (slidingWindow[3] == (unsigned char)SCPResponse::pr_Overrun) return SCPErr::scpOverrun;
+					return SCPErr::scpOK;
+				}
+			}
+			else {
+				switch (byteRead) {
+				case 0xFF:
+					hitIndex = 1; 
+					break;
+				case 0x00: 
+					if (hitIndex == 1) hitIndex = 2; else {
+						tickInNS += m_isHDMode ? (256 * 100) : (256 * 50);
+						hitIndex = 0;
+					}
+					break;
+				default:
+					pll.submitFlux(tickInNS + (m_isHDMode ? (byteRead * 100UL) : (byteRead * 50UL)), hitIndex == 2);
+					tickInNS = 0;
+					hitIndex = 0;
+					break;
+				}
+
+				// Is it ready to extract?
+				if (pll.canExtract()) {
+					unsigned int bits = 0;
+					// Go!
+					if (pll.extractRotation(firstOutputBuffer, bits, maxOutputSize, true)) {
+						m_diskInDrive = true;
+
+						if (!onRotation(&firstOutputBuffer, bits)) {
+							// And if the callback says so we stop.
+							abortReadStreaming();
+						}
+						// Always save this back
+						pll.getIndexSequence(startBitPatterns);
+					}
+				}
+				else {
+					if (pll.totalTimeReceived() > (m_isHDMode ? 1200000000U : 600000000U)) {
+						// No data, stop
+						abortReadStreaming();
+						timeout = true;
+					}
+				}
+			}
+		}
+		if (bytesRead < 1) {
+			readFail++;
+			if (readFail > 30) {
+				if (!m_abortStreaming) {
+					abortReadStreaming();
+					readFail = 0;
+					m_diskInDrive = false;
+				}
+				else {
+					m_isStreaming = false;
+#ifdef USE_THREADDED_READER_SCP
+					if (backgroundReader) {
+						if (backgroundReader->joinable()) backgroundReader->join();
+						delete backgroundReader;
+					}
+#endif
+					applyCommTimeouts(false);
+					return SCPErr::scpUnknownError;
+				}
+			}
+			else {
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+		else {
+			readFail = 0;
+		}
+	}
+}
+
+// Reads just enough data to fulfill most extractions needed, but doesnt care about rotation position or index - pll should have the LinearExtractor configured
+SCPErr SCPInterface::readData(PLL::BridgePLL& pll) {
+	SCPResponse response;
+
+	pll.rotationExtractor()->reset(m_isHDMode);
+
+	// Issue a read-request
+	selectDrive(true);
+
+	// Request real-time flux stream, 8-bit resolution, and 50ns timings.
+	const unsigned char payload[1] = { STREAMFLAGS_RESOLUTION_50NS | FLAGS_BITSIZE_8BIT | STREAMFLAGS_IMMEDIATEREAD | STREAMFLAGS_RAWFLUX };
+	bool ret = sendCommand(SCPCommand::DoCMD_STARTSTREAM, payload, 1, response);
+	if (!ret) {
+		if (!m_motorIsEnabled) selectDrive(false);
+		if ((response == SCPResponse::pr_NotReady) || (response == SCPResponse::pr_NoDisk)) {
+			m_diskInDrive = false;
+			return SCPErr::scpNoDiskInDrive;
+		}
+		return SCPErr::scpUnknownError;
+	}
+
+	applyCommTimeouts(true);
+	unsigned char tempReadBuffer[4096] = { 0 };
+
+	m_isStreaming = true;
+	m_abortStreaming = false;
+	m_abortSignalled = false;
+
+	// Number of times we failed to read anything
+	int readFail = 0;
+
+	// Sliding window for abort
+	unsigned char slidingWindow[4] = { 0,0,0,0 };
+	bool timeout = false;
+	bool dataState = false;
+	bool isFirstByte = true;
+	unsigned char mfmSequences = 0;
+	int hitIndex = 0;
+	uint32_t tickInNS = 0;
+
+	for (;;) {
+
+		// More efficient to read several bytes in one go	
+		unsigned int bytesAvailable = m_comPort.getBytesWaiting();
+		if (bytesAvailable < 1) bytesAvailable = 1;
+		if (bytesAvailable > sizeof(tempReadBuffer)) bytesAvailable = sizeof(tempReadBuffer);
+		unsigned int bytesRead = m_comPort.read(tempReadBuffer, m_abortSignalled ? 1 : bytesAvailable);
+		for (size_t a = 0; a < bytesRead; a++) {
+			const unsigned char byteRead = tempReadBuffer[a];
+
+			if (m_abortSignalled) {
+				for (int s = 0; s < 3; s++) slidingWindow[s] = slidingWindow[s + 1];
+				slidingWindow[3] = byteRead;
+
+				// Watch the sliding window for the pattern we need
+				if ((slidingWindow[0] == 0xDE) && (slidingWindow[1] == 0xAD) && (slidingWindow[2] == (unsigned char)SCPCommand::DoCMD_STOPSTREAM)) {
+					m_isStreaming = false;
+					m_comPort.purgeBuffers();
+					applyCommTimeouts(false);
+					if (!m_diskInDrive) return SCPErr::scpNoDiskInDrive;
+					if (timeout) return SCPErr::scpUnknownError;
+					if (slidingWindow[3] == (unsigned char)SCPResponse::pr_Overrun) return SCPErr::scpOverrun;
+					return SCPErr::scpOK;
+				}
+			}
+			else {
+				switch (byteRead) {
+				case 0xFF:
+					hitIndex = 1;
+					break;
+				case 0x00:
+					if (hitIndex == 1) hitIndex = 2; else {
+						tickInNS += m_isHDMode ? (256 * 100) : (256 * 50);
+						hitIndex = 0;
+					}
+					break;
+				default:
+					pll.submitFlux(tickInNS + (m_isHDMode ? (byteRead * 100UL) : (byteRead * 50UL)), hitIndex == 2);
+					tickInNS = 0;
+					hitIndex = 0;
+					break;
+				}
+
+				// Is it ready to extract?
+				if ((pll.canExtract()) || (pll.totalTimeReceived() > 220000000)) {
+					if (!m_abortSignalled) abortReadStreaming();
+				} 
+				else
+				if (pll.totalTimeReceived() > (m_isHDMode ? 1200000000U : 600000000U)) {
+					// No data, stop
+					abortReadStreaming();
+					timeout = true;
+				}
+			}
+		}
+		if (bytesRead < 1) {
+			readFail++;
+			if (readFail > 30) {
+				if (!m_abortStreaming) {
+					abortReadStreaming();
+					readFail = 0;
+					m_diskInDrive = false;
+				}
+				else {
+					m_isStreaming = false;
+					applyCommTimeouts(false);
+					return SCPErr::scpUnknownError;
+				}
+			}
+			else {
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		}
+		else {
+			readFail = 0;
+		}
+	}
+}
+
+// Stops the read streaming immediately and any data in the buffer will be discarded.
+bool SCPInterface::abortReadStreaming() {
+	// Prevent two things doing this at once, and thus ending with two bytes being written
+	std::lock_guard<std::mutex> lock(m_protectAbort);
+	if (!m_isStreaming) return true;
+
+	if (!m_abortStreaming) {
+		SCPResponse response;
+		m_abortSignalled = true;
+		if (!sendCommand(SCPCommand::DoCMD_STOPSTREAM, NULL, 0, response, false))  return false;
+	}
+	m_abortStreaming = true;
+	return true;
+}
+

--- a/vendor/floppybridge/src/SuperCardProInterface.h
+++ b/vendor/floppybridge/src/SuperCardProInterface.h
@@ -1,0 +1,222 @@
+#ifndef SUPERCARDPRO_INTERFACE
+#define SUPERCARDPRO_INTERFACE
+/* Supercard Pro C++ Interface for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* Based on the documentation and hardware by Jim Drew at
+* https://www.cbmstuff.com/
+*
+* This requires firmware V1.3
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+
+
+#include <string>
+#include <functional>
+#include <vector>
+#include <mutex>
+#include "RotationExtractor.h"
+#include "SerialIO.h"
+#include "pll.h"
+
+namespace SuperCardPro {
+
+	// Represent which side of the disk we're looking at
+	enum class DiskSurface {
+		dsUpper,            // The upper side of the disk
+		dsLower             // The lower side of the disk
+	};
+
+	// Potential responses from the SCP
+	enum class SCPResponse : unsigned char {
+		pr_Unused = 0x00,			// not used(to disallow NULL responses)
+		pr_BadCommand = 0x01,		// bad command
+		pr_CommandErr = 0x02,		// command error(bad structure, etc.)
+		pr_Checksum = 0x03,			// packet checksum failed
+		pr_Timeout = 0x04,			// USB timeout
+		pr_NoTrk0 = 0x05,			// track zero never found(possibly no drive online)
+		pr_NoDriveSel = 0x06,		// no drive selected
+		pr_NoMotorSel = 0x07,		// motor not enabled(required for read or write)
+		pr_NotReady = 0x08,			// drive not ready(disk change is high)
+		pr_NoIndex = 0x09,			// no index pulse detected
+		pr_ZeroRevs = 0x0A,			// zero revolutions chosen
+		pr_ReadTooLong = 0x0B,		// read data was more than RAM would hold
+		pr_BadLength = 0x0C,		// invalid length value
+		pr_Reserved1 = 0x0D,		// reserved for future use
+		pr_BoundaryOdd = 0x0E,		// location boundary is odd
+		pr_WPEnabled = 0x0F,		// disk is write protected
+		pr_BadRAM = 0x10,			// RAM test failed
+		pr_NoDisk = 0x11,			// no disk in drive
+		pr_BadBaud = 0x12,			// bad baud rate selected
+		pr_BadCmdOnPort = 0x13,		// command is not available for this type of port
+		pr_NoStream = 0x14,			// stream attempted to be stop when it was not occurring!
+		pr_Overrun = 0x15,			// buffer overrun occurred
+		pr_Ok = 0x4F,				// packet good(letter 'O' for OK)
+
+
+		pr_writeError = 0xFF		// Used internally
+	};
+
+	enum class SCPCommand : unsigned char {
+		DoCMD_SELA = 0x80, // select drive A
+		DoCMD_SELB = 0x81, // select drive B
+		DoCMD_DSELA = 0x82, // deselect drive A
+		DoCMD_DSELB = 0x83, // deselect drive B
+
+		DoCMD_MTRAON = 0x84, // turn motor A on
+		DoCMD_MTRBON = 0x85, // turn motor B on
+		DoCMD_MTRAOFF = 0x86, // turn motor A off
+		DoCMD_MTRBOFF = 0x87, // turn motor B off
+
+		DoCMD_SEEK0 = 0x88, // seek track 0
+		DoCMD_STEPTO = 0x89, // step to specified track
+		DoCMD_STEPIN = 0x8A, // step towards inner(higher) track
+		DoCMD_STEPOUT = 0x8B, // step towards outer(lower) track
+
+		DoCMD_SELDENS = 0x8C, // select density
+
+		DoCMD_SIDE = 0x8D, // select side
+		DoCMD_STATUS = 0x8E, // get drive status
+		DoCMD_GETPARAMS = 0x90, // get parameters
+		DoCMD_SETPARAMS = 0x91, // set parameters
+		DoCMD_RAMTEST = 0x92, // do RAM test
+		DoCMD_SETPIN33 = 0x93, // set pin 33 of floppy connector
+		DoCMD_READFLUX = 0xA0, // read flux level
+		DoCMD_GETFLUXINFO = 0xA1, // get info for last flux read
+		DoCMD_WRITEFLUX = 0xA2, // write flux level
+		DoCMD_SENDRAM_USB = 0xA9, // send data from buffer to USB
+		DoCMD_LOADRAM_USB = 0xAA, // get data from USB and store in buffer
+		DoCMD_SENDRAM_232 = 0xAB, // send data from buffer to the serial port
+		DoCMD_LOADRAM_232 = 0xAC, // get data from the serial port and store in buffer
+		DoCMD_STARTSTREAM = 0xAE, // start streaming flux data from the drive (requires firmware 1.3)
+		DoCMD_STOPSTREAM = 0xAF, // Stop an active stream
+		DoCMD_SCPInfo = 0xD0, // get info about SCP hardware / firmware
+		DoCMD_SETBAUD1 = 0xD1, // sets the baud rate of port labeled RS232, // 1
+		DoCMD_SETBAUD2 = 0xD2 // sets the baud rate of port labeled RS232, // 2
+	};
+
+	enum class SCPErr {
+		scpOK,
+		scpNotFound,
+		scpInUse,
+		scpNoDiskInDrive,
+		scpWriteProtected,
+		scpFirmwareTooOld,
+		scpOverrun,
+		scpUnknownError
+	};
+
+	class SCPInterface {
+	private:
+		// Windows handle to the serial port device
+		SerialIO		m_comPort;
+		bool			m_diskInDrive;
+		bool			m_motorIsEnabled = false;
+		bool			m_isWriteProtected = false;
+		bool			m_useDriveA = false;
+		bool			m_isAtTrack0 = false;
+		int				m_currentTrack = -1;
+		bool			m_isHDMode = false;
+		bool			m_selectStatus = false;
+		std::mutex      m_protectAbort;
+		bool			m_abortStreaming = false;
+		bool			m_abortSignalled = true;
+		bool			m_isStreaming = false;
+
+		struct {
+			unsigned char hardwareVersion =0, hardwareRevision =0;
+			unsigned char firmwareVersion =0, firmwareRevision =0;
+		} m_firmwareVersion;
+
+		// Apply and change the timeouts on the com port
+		void applyCommTimeouts(bool shortTimeouts);
+		
+		// Trigger selecting this drive
+		bool selectDrive(bool select);
+
+		// Polls for the state of pins on the board
+		bool checkPins();
+
+		// Various variants
+		bool sendCommand(const SCPCommand command, SCPResponse& response);
+		bool sendCommand(const SCPCommand command, const unsigned char parameter, SCPResponse& response);
+		bool sendCommand(const SCPCommand command, const unsigned char* payload, const unsigned char payloadLength, SCPResponse& response, bool readResponse = true);
+
+		// Read ram from the SCP
+		//bool readSCPRam(const unsigned int offset, const unsigned int length);
+	public:
+		// Constructor for this class
+		SCPInterface();
+
+		// Free me
+		~SCPInterface();
+
+		const bool isOpen() const { return m_comPort.isPortOpen(); };
+
+		bool isWriteProtected() const { return m_isWriteProtected; };
+
+		// Attempts to open the reader running on the COM port number provided.  
+		SCPErr openPort(bool useDriveA);
+
+		// Reads a complete rotation of the disk, and returns it using the callback function whcih can return FALSE to stop
+		// An instance of PLL is required which contains a rotation extractor.  This is purely to save on re-allocations.  It is internally reset each time
+		SCPErr readRotation(PLL::BridgePLL& pll, const unsigned int maxOutputSize, RotationExtractor::MFMSample* firstOutputBuffer, RotationExtractor::IndexSequenceMarker& startBitPatterns,
+			std::function<bool(RotationExtractor::MFMSample** mfmData, const unsigned int dataLengthInBits)> onRotation);
+
+		// Reads just enough data to fulfill most extractions needed, but doesnt care about rotation position or index - pll should have the LinearExtractor configured
+		SCPErr readData(PLL::BridgePLL& pll);
+
+		// Turns on and off the reading interface.  dontWait disables the GW timeout waiting, so you must instead.  
+		bool enableMotor(const bool enable, const bool dontWait = false);
+
+		// Seek to track 0 - Can return drRewindFailure, drSelectTrackError, drOK
+		bool findTrack0();
+
+		// Test if its an HD disk
+		bool checkDiskCapacity(bool& isHD);
+
+		// Select the track, this makes the motor seek to this position. Can return drRewindFailure, drSelectTrackError, drOK, drTrackRangeError
+		bool selectTrack(const unsigned char trackIndex, bool ignoreDiskInsertCheck = false);
+
+		// Special command that asks to do a 'seek to track -1' which isnt allowed but can be used for disk detection
+		bool performNoClickSeek();
+
+		// Choose which surface of the disk to read from.  Can return drError or drOK
+		bool selectSurface(const DiskSurface side);
+
+		// Write data to the disk.  Can return drReadResponseFailed, drWriteProtected, drSerialOverrun, drWriteProtected, drOK
+		SCPErr writeCurrentTrackPrecomp(const unsigned char* mfmData, const unsigned short numBytes, const bool writeFromIndexPulse, bool usePrecomp);
+
+		// Attempt to abort reading
+		bool abortReadStreaming();
+
+		// Check if  adisk is present in the drive
+		SCPErr checkForDisk(bool force);
+
+		// Closes the port down
+		void closePort();
+
+		// Switch the density mode
+		bool selectDiskDensity(bool hdMode);
+
+		// Returns the motor iddle (auto switch off) time
+		unsigned int getMotorIdleTimeoutTime();
+	};
+
+};
+
+#endif

--- a/vendor/floppybridge/src/floppybridge_abstract.h
+++ b/vendor/floppybridge/src/floppybridge_abstract.h
@@ -1,0 +1,196 @@
+/* floppybridge_abstract
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This library defines a standard interface for connecting physical disk drives to *UAE
+*
+* Derived classes must be implemented so they are unlikely to cause a delay in any function
+* as doing so would cause audio and mouse cursors to stutter
+*
+* This is free and unencumbered released into the public domain.
+* See the file COPYING for more details, or visit <http://unlicense.org>.
+*
+*/
+
+
+/*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+#pragma once
+
+#include <functional>
+#include <cstddef>
+
+#ifdef _WIN32
+#include <tchar.h>
+#else
+#ifndef TCHAR
+#ifdef _UNICODE
+#define TCHAR wchar_t
+#define _T(x) L ##x
+#else
+#define TCHAR char
+#define _T(x) x
+#endif
+#endif
+#endif
+
+
+
+class FloppyDiskBridge {
+public:
+
+	// Driver information
+	struct BridgeDriver {
+		// Details about the driver
+		const char* name;
+		const char* url;
+		const char* manufacturer;
+		const char* driverAuthor;
+
+		// Which options in configuration it can support, aside from the standard ones
+		const unsigned int configOptions;
+	};
+
+	// Definition of the type of drive
+	enum class DriveTypeID : unsigned char { dti35DD = 0, dti35HD = 1, dti5255SD = 2 };
+
+	FloppyDiskBridge() {}
+	// This is just to force this being virtual
+	virtual ~FloppyDiskBridge() {}
+
+	// Call to start the system up.  Return false if it fails
+	virtual bool initialise() = 0;
+
+	// This is called prior to closing down, but should reverse initialise
+	virtual void shutdown() {}
+
+	// Returns the name of interface.  This pointer should remain valid *after* the class is destroyed so should be static
+	virtual const BridgeDriver* getDriverInfo() = 0;
+
+	// Return the 'bit cell' time in uSec.  Standard DD Amiga disks this would be 2uS, HD disks would be 1us I guess, but mainly used for =4 for SD I think
+	virtual unsigned char getBitSpeed() { return 2; }
+
+	// Return the type of disk connected.  This is used to tell WinUAE if we're DD or HD.  This must return INSTANTLY
+	virtual DriveTypeID getDriveTypeID() = 0;
+
+	// Call to get the last error message.  If the board initialised this may return a compatibility warning instead
+	virtual const char* getLastErrorMessage() { return NULL; }
+
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+
+	// Reset the drive.  This should reset it to the state it would be at powerup, ie: motor switched off etc.  The current cylinder number can be 'unknown' at this point
+	virtual bool resetDrive(int trackNumber) = 0;
+
+
+
+
+	/////////////////////// Head movement Controls //////////////////////////////////////////
+	// Return TRUE if the drive is currently on cylinder 0
+	virtual bool isAtCylinder0() = 0;
+
+	// Return the number of cylinders the drive supports.  Eg: 80 or 82 (or 40)
+	virtual unsigned char getMaxCylinder() = 0;
+
+	// Seek to a specific cylinder
+	virtual void gotoCylinder(int cylinderNumber, bool side) = 0;
+
+	// Handle the drive stepping to track -1 - this is used to 'no-click' detect the disk
+	virtual void handleNoClickStep(bool side) = 0;
+
+	// Return the current cylinder number we're on
+	virtual unsigned char getCurrentCylinderNumber() = 0;
+
+
+
+	/////////////////////// Drive Motor Controls /////////////////////////////////////////////
+	// Return true if the motor is spinning, but not necessarily up to speed
+	virtual bool isMotorRunning() = 0;
+
+	// Turn on and off the motor
+	virtual void setMotorStatus(bool side, bool turnOn) = 0;
+
+	// Returns TRUE if the drive is ready (ie: the motor has spun up to speed to speed)
+	virtual bool isReady() = 0;
+
+	// Returns the currently selected side
+	virtual bool getCurrentSide() = 0;
+
+	/////////////////////// Disk Detection ///////////////////////////////////////////////////
+	// Return TRUE if there is a disk in the drive.  This is usually called after gotoCylinder
+	virtual bool isDiskInDrive() = 0;
+
+	// Check if the disk has changed.  Basically returns FALSE if there's no disk in the drive
+	virtual bool hasDiskChanged() = 0;
+
+	// Return TRUE if the drive is still connected and working
+	virtual bool isStillWorking() { return true; };
+
+	/////////////////////// Reading Data /////////////////////////////////////////////////////
+	// Return TRUE if we're at the INDEX marker/sensor.  mfmPositionBits is in BITS
+	virtual bool isMFMPositionAtIndex(int mfmPositionBits) = 0;
+
+	// Returns TRUE if data is ready and available
+	virtual bool isMFMDataAvailable() = 0;
+
+	// This returns a single MFM bit at the position provided
+	virtual bool getMFMBit(const int mfmPositionBits) = 0;
+
+	// Requests an entire track of data.  Returns 0 if the track is not available
+	// The return value is the wrap point in bits (last byte is shifted to MSB)
+	virtual int getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) = 0;
+
+	// write data to the MFM track buffer to be written to disk - poll isWriteComplete to check for completion
+	virtual bool writeMFMTrackToBuffer(bool side, unsigned int track, bool writeFromIndex, int sizeInBytes, void* mfmData) = 0;
+
+	// A special mode that DISABLES FloppyBridge from auto-reading tracks and allows writeMFMTrackToBuffer and getMFMTrack to operate directly.
+	virtual bool setDirectMode(bool directModeEnable) = 0;
+
+	// This asks the time taken to read the bit at mfmPositionBits.  1000=100%, <1000 data is read faster, >1000 data is read slower.
+	// This number is used in a loop (scaled) starting with a number, and decrementing by this number.
+	// Each loop a single bit is read.  So the smaller the number, the more loops that occur, and the more bits that are read
+	virtual int getMFMSpeed(const int mfmPositionBits) = 0;
+
+	// This is called in both modes.  It is called when WinUAE detects a full revolution of data has been read.  This could allow you to switch to a different recording of the same cylinder if needed.
+	virtual void mfmSwitchBuffer(bool side) = 0;
+
+	// Quick confirmation from UAE that we're actually on the same side
+	virtual void setSurface(bool side) = 0;
+
+	// Return the maximum size of bits available in this revolution.  This is the maximum passed to getMFMBit
+	virtual int maxMFMBitPosition() = 0;
+
+	/////////////////////// Writing Data /////////////////////////////////////////////////////
+
+	// Submits a single WORD of data received during a DMA transfer to the disk buffer.  This needs to be saved.  It is usually flushed when commitWriteBuffer is called
+	// You should reset this buffer if side or track changes, mfmPosition is provided purely for any index sync you may wish to do
+	virtual void writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) = 0;
+
+	// Return TRUE if the currently inserted disk is write protected
+	virtual bool isWriteProtected() = 0;
+
+	// Requests that any data received via writeShortToBuffer be saved to disk. The side and track should match against what you have been collected
+	// and the buffer should be reset upon completion.  You should return the new track length (maxMFMBitPosition) with optional padding if needed
+	virtual unsigned int commitWriteBuffer(bool side, unsigned int track) = 0;
+
+	// Returns TRUE if commitWriteBuffer has been called but not written to disk yet
+	virtual bool isWritePending() = 0;
+
+	// Returns TRUE if a write is no longer pending.  This should only return TRUE the first time, and then should reset
+	virtual bool isWriteComplete() = 0;
+
+	// Set to TRUE if turbo writing is allowed (this is a sneaky DMA bypass trick)
+	virtual bool canTurboWrite() = 0;
+
+	// Return TRUE if there is data ready to be committed to disk
+	virtual bool isReadyToWrite() = 0;
+};
+
+

--- a/vendor/floppybridge/src/floppybridge_common.h
+++ b/vendor/floppybridge/src/floppybridge_common.h
@@ -1,0 +1,81 @@
+/* floppybridge_common
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* Shared class between the dll and class to connect to it.
+*
+* This is free and unencumbered released into the public domain
+* But please don't remove the above information
+*
+* For more details visit <http://unlicense.org>.
+*
+*/
+#pragma once
+
+
+typedef void* BridgeDriverHandle;
+
+namespace FloppyBridge {
+
+	// Type of bridge mode
+	enum class BridgeMode : unsigned char {
+		bmFast = 0,
+		bmCompatible = 1,
+		bmTurboAmigaDOS = 2,
+		bmStalling = 3,
+		bmMax = 3
+	};
+
+	// How to use disk density
+	enum class BridgeDensityMode : unsigned char {
+		bdmAuto = 0,
+		bdmDDOnly = 1,
+		bdmHDOnly = 2,
+		bdmMax = 2
+	};
+
+	// Used to select the drive connected
+	enum class DriveSelection : unsigned char {
+		dsDriveA = 0,     // IBM PC
+		dsDriveB = 1,
+		dsDrive0 = 2,     // SHUGART
+		dsDrive1 = 3,
+		dsDrive2 = 4,
+		dsDrive3 = 5
+	};
+
+
+	// Used by BRIDGE_About
+	struct BridgeAbout {
+		const char* about;
+		const char* url;
+		unsigned int majorVersion, minorVersion;
+		unsigned int isBeta;
+		unsigned int isUpdateAvailable;
+		unsigned int updateMajorVersion, updateMinorVersion;
+	};
+
+
+	// Information about a floppy bridge profile
+	struct FloppyBridgeProfileInformationDLL {
+		// Unique ID of this profile
+		unsigned int profileID;
+
+		// Driver Index, in case it's shown on the GUI
+		unsigned int driverIndex;
+
+		// Some basic information
+		BridgeMode bridgeMode;
+		BridgeDensityMode bridgeDensityMode;
+
+		// Profile name
+		char* name;
+
+		// Pointer to the Configuration data for this profile. - Be careful. Assume this pointer is invalid after calling *any* of the *profile* functions apart from getAllProfiles
+		char* profileConfig;
+	};
+
+
+
+};

--- a/vendor/floppybridge/src/floppybridge_config.h
+++ b/vendor/floppybridge/src/floppybridge_config.h
@@ -1,0 +1,31 @@
+#ifndef FLOPPY_BRIDGE_CONFIG_H
+#define FLOPPY_BRIDGE_CONFIG_H
+/* floppybridge_config
+*
+* Copyright (C) 2021-2022 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This library defines which interfaces are enabled within *UAE
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*
+* This is free and unencumbered released into the public domain.
+* See the file COPYING for more details, or visit <http://unlicense.org>.
+*
+*/
+
+// DrawBridge aka Arduino floppy reader/writer
+#define ROMTYPE_ARDUINOREADER_WRITER			ROMTYPE_FLOPYBRDGE0
+#include "ArduinoFloppyBridge.h"
+
+// GreaseWeazle floppy reader/writer
+#define ROMTYPE_GREASEWEAZLEREADER_WRITER		ROMTYPE_FLOPYBRDGE1
+#include "GreaseWeazleBridge.h"
+
+// Supercard Pro floppy reader/writer
+#define ROMTYPE_SUPERCARDPRO_WRITER				ROMTYPE_FLOPYBRDGE2
+#include "SuperCardProBridge.h"
+
+#endif

--- a/vendor/floppybridge/src/floppybridge_lib.cpp
+++ b/vendor/floppybridge/src/floppybridge_lib.cpp
@@ -1,0 +1,906 @@
+/* floppybridge_lib
+*
+* Copyright (C) 2021-2023 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This class connects to the external FloppyBridge DLL library rather than
+* having all the code compiled in. That library is maintained at
+* https://amiga.robsmithdev.co.uk/winuae
+*
+* This is free and unencumbered released into the public domain
+* But please don't remove the above information
+*
+* For more details visit <http://unlicense.org>.
+*
+*/
+
+#include "floppybridge_lib.h"
+#include <string>
+#include <codecvt>
+#include <locale>
+#include <algorithm>
+#include <cstring>
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
+#ifdef _WIN32
+#include <Windows.h>
+#ifdef WINUAE
+HMODULE WIN32_LoadLibrary(const TCHAR*);
+#endif
+#define CALLING_CONVENSION _cdecl
+#define GETFUNC GetProcAddress
+#else
+#define CALLING_CONVENSION
+#define GETFUNC dlsym
+#endif
+
+#ifdef _WIN64
+#define MODULENAME _T("FloppyBridge_x64.dll")
+#else
+#ifdef _WIN32
+#define MODULENAME _T("FloppyBridge.dll")
+#else
+#define MODULENAME "libfloppybridge.so"
+#endif
+#endif
+
+#ifdef _WIN32
+HMODULE hBridgeDLLHandle = 0;
+#else
+void* hBridgeDLLHandle = nullptr;
+#endif
+
+
+// Bridge library function definitions
+typedef void 			 (CALLING_CONVENSION* _BRIDGE_About)(bool allowCheckForUpdates, FloppyBridge::BridgeAbout** output);
+typedef unsigned int 	 (CALLING_CONVENSION* _BRIDGE_NumDrivers)(void);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_GetDriverInfo)(unsigned int driverIndex, FloppyDiskBridge::BridgeDriver** driverInformation);
+#ifdef _WIN32
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_ShowConfigDialog)(HWND hwndParent, unsigned int* profileID);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_EnableUsageNotifications)(bool enabled);
+#endif
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_GetAllProfiles)(FloppyBridge::FloppyBridgeProfileInformationDLL** profiles, unsigned int* numProfiles);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_ImportProfilesFromString)(char* profilesConfigString);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_ExportProfilesToString)(char** profilesConfigString);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_GetProfileConfigFromString)(unsigned int profileID, char** configString);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_SetProfileConfigFromString)(unsigned int profileID, char* configString);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_SetProfileName)(unsigned int profileID, char* name);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_CreateNewProfile)(unsigned int driverIndex, unsigned int* profileID);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_DeleteProfile)(unsigned int profileID);
+typedef bool		 	 (CALLING_CONVENSION* _BRIDGE_EnumComports)(char* output, unsigned int* bufferSize);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_CreateDriver)(unsigned int driverIndex, BridgeDriverHandle* bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_CreateDriverFromConfigString)(char* config, BridgeDriverHandle* bridgeDriverHandle);
+typedef bool			 (CALLING_CONVENSION* _BRIDGE_CreateDriverFromProfileID)(unsigned int profileID, BridgeDriverHandle* bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_Close)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_Open)(BridgeDriverHandle bridgeDriverHandle, char** errorMessage);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_GetDriverIndex)(BridgeDriverHandle bridgeDriverHandle, unsigned int* driverIndex);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_SetDriverIndex)(BridgeDriverHandle bridgeDriverHandle, int driverIndex);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_FreeDriver)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_GetConfigString)(BridgeDriverHandle bridgeDriverHandle, char** config);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_SetConfigFromString)(BridgeDriverHandle bridgeDriverHandle, char* config);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetAutoCache)(BridgeDriverHandle bridgeDriverHandle, bool* isAutoCacheMode);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetAutoCache)(BridgeDriverHandle bridgeDriverHandle, bool isAutoCacheMode);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetMode)(BridgeDriverHandle bridgeDriverHandle, FloppyBridge::BridgeMode* bridgeMode);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetMode)(BridgeDriverHandle bridgeDriverHandle, FloppyBridge::BridgeMode bridgeMode);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetDensityMode)(BridgeDriverHandle bridgeDriverHandle, FloppyBridge::BridgeDensityMode* densityMode);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetDensityMode)(BridgeDriverHandle bridgeDriverHandle, FloppyBridge::BridgeDensityMode densityMode);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetCurrentComPort)(BridgeDriverHandle bridgeDriverHandle, char** comPort);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetCurrentComPort)(BridgeDriverHandle bridgeDriverHandle, char* comPort);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetAutoDetectComPort)(BridgeDriverHandle bridgeDriverHandle, bool* autoDetectComPort);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetAutoDetectComPort)(BridgeDriverHandle bridgeDriverHandle, bool autoDetectComPort);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetCable)(BridgeDriverHandle bridgeDriverHandle, bool* isOnB);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetCable)(BridgeDriverHandle bridgeDriverHandle, bool isOnB);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetCable2)(BridgeDriverHandle bridgeDriverHandle, FloppyBridge::DriveSelection* driveSelection);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetCable2)(BridgeDriverHandle bridgeDriverHandle, FloppyBridge::DriveSelection driveSelection);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverGetSmartSpeedEnabled)(BridgeDriverHandle bridgeDriverHandle, bool* enabled);
+typedef bool 			 (CALLING_CONVENSION* _BRIDGE_DriverSetSmartSpeedEnabled)(BridgeDriverHandle bridgeDriverHandle, bool enabled);
+typedef unsigned char 	 (CALLING_CONVENSION* _DRIVER_getBitSpeed)(BridgeDriverHandle bridgeDriverHandle);
+typedef FloppyDiskBridge::DriveTypeID (CALLING_CONVENSION* _DRIVER_getDriveTypeID)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_resetDrive)(BridgeDriverHandle bridgeDriverHandle, int trackNumber);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isAtCylinder0)(BridgeDriverHandle bridgeDriverHandle);
+typedef unsigned char 	 (CALLING_CONVENSION* _DRIVER_getMaxCylinder)(BridgeDriverHandle bridgeDriverHandle);
+typedef void 			 (CALLING_CONVENSION* _DRIVER_gotoCylinder)(BridgeDriverHandle bridgeDriverHandle, int cylinderNumber, bool side);
+typedef void 			 (CALLING_CONVENSION* _DRIVER_handleNoClickStep)(BridgeDriverHandle bridgeDriverHandle, bool side);
+typedef unsigned char 	 (CALLING_CONVENSION* _DRIVER_getCurrentCylinderNumber)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isMotorRunning)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_getCurrentSide)(BridgeDriverHandle bridgeDriverHandle);
+typedef void 			 (CALLING_CONVENSION* _DRIVER_setMotorStatus)(BridgeDriverHandle bridgeDriverHandle, bool side, bool turnOn);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isReady)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isDiskInDrive)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_hasDiskChanged)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isStillWorking)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isMFMPositionAtIndex)(BridgeDriverHandle bridgeDriverHandle, int mfmPositionBits);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isMFMDataAvailable)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_getMFMBit)(BridgeDriverHandle bridgeDriverHandle, int mfmPositionBits);
+typedef int 			 (CALLING_CONVENSION* _DRIVER_getMFMSpeed)(BridgeDriverHandle bridgeDriverHandle, int mfmPositionBits);
+typedef void 			 (CALLING_CONVENSION* _DRIVER_mfmSwitchBuffer)(BridgeDriverHandle bridgeDriverHandle, bool side);
+typedef void 			 (CALLING_CONVENSION* _DRIVER_setSurface)(BridgeDriverHandle bridgeDriverHandle, bool side);
+typedef int 			 (CALLING_CONVENSION* _DRIVER_maxMFMBitPosition)(BridgeDriverHandle bridgeDriverHandle);
+typedef void 			 (CALLING_CONVENSION* _DRIVER_writeShortToBuffer)(BridgeDriverHandle bridgeDriverHandle, bool side, unsigned int track, unsigned short mfmData, int mfmPosition);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isWriteProtected)(BridgeDriverHandle bridgeDriverHandle);
+typedef unsigned int 	 (CALLING_CONVENSION* _DRIVER_commitWriteBuffer)(BridgeDriverHandle bridgeDriverHandle, bool side, unsigned int track);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isWritePending)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isWriteComplete)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_canTurboWrite)(BridgeDriverHandle bridgeDriverHandle);
+typedef bool 			 (CALLING_CONVENSION* _DRIVER_isReadyToWrite)(BridgeDriverHandle bridgeDriverHandle);
+typedef int 			 (CALLING_CONVENSION* _DRIVER_getTrack)(BridgeDriverHandle bridgeDriverHandle, bool side, unsigned int track, bool resyncRotation, int bufferSizeInBytes, void* data);
+typedef int 			 (CALLING_CONVENSION* _DRIVER_putTrack)(BridgeDriverHandle bridgeDriverHandle, bool side, unsigned int track, bool writeFromIndex, int bufferSizeInBytes, void* data);
+typedef int 			 (CALLING_CONVENSION* _DRIVER_setDirectMode)(BridgeDriverHandle bridgeDriverHandle, bool directMode);
+
+
+
+// Library function pointers
+_BRIDGE_About	BRIDGE_About = nullptr;
+_BRIDGE_NumDrivers	BRIDGE_NumDrivers = nullptr;
+_BRIDGE_EnumComports	BRIDGE_EnumComports = nullptr;
+_BRIDGE_GetDriverInfo	BRIDGE_GetDriverInfo = nullptr;
+_BRIDGE_CreateDriver	BRIDGE_CreateDriver = nullptr;
+_BRIDGE_Close	BRIDGE_Close = nullptr;
+_BRIDGE_Open	BRIDGE_Open = nullptr;
+_BRIDGE_CreateDriverFromProfileID BRIDGE_CreateDriverFromProfileID = nullptr;
+_BRIDGE_GetAllProfiles BRIDGE_GetAllProfiles = nullptr;
+_BRIDGE_ImportProfilesFromString BRIDGE_ImportProfilesFromString = nullptr;
+_BRIDGE_ExportProfilesToString BRIDGE_ExportProfilesToString = nullptr;
+_BRIDGE_GetProfileConfigFromString BRIDGE_GetProfileConfigFromString = nullptr;
+_BRIDGE_SetProfileConfigFromString BRIDGE_SetProfileConfigFromString = nullptr;
+_BRIDGE_SetProfileName BRIDGE_SetProfileName = nullptr;
+_BRIDGE_CreateNewProfile BRIDGE_CreateNewProfile = nullptr;
+_BRIDGE_DeleteProfile BRIDGE_DeleteProfile = nullptr;
+#ifdef _WIN32
+_BRIDGE_ShowConfigDialog BRIDGE_ShowConfigDialog = nullptr;
+_BRIDGE_EnableUsageNotifications BRIDGE_EnableUsageNotifications = nullptr;
+#endif
+_BRIDGE_GetDriverIndex BRIDGE_GetDriverIndex = nullptr;
+_BRIDGE_SetDriverIndex BRIDGE_SetDriverIndex = nullptr;
+_BRIDGE_FreeDriver	BRIDGE_FreeDriver = nullptr;
+_BRIDGE_DriverGetMode	BRIDGE_DriverGetMode = nullptr;
+_BRIDGE_DriverSetMode	BRIDGE_DriverSetMode = nullptr;
+_BRIDGE_DriverGetDensityMode	BRIDGE_DriverGetDensityMode = nullptr;
+_BRIDGE_DriverSetDensityMode	BRIDGE_DriverSetDensityMode = nullptr;
+_BRIDGE_DriverGetCurrentComPort	BRIDGE_DriverGetCurrentComPort = nullptr;
+_BRIDGE_DriverSetCurrentComPort	BRIDGE_DriverSetCurrentComPort = nullptr;
+_BRIDGE_DriverGetAutoDetectComPort	BRIDGE_DriverGetAutoDetectComPort = nullptr;
+_BRIDGE_DriverSetAutoDetectComPort	BRIDGE_DriverSetAutoDetectComPort = nullptr;
+_BRIDGE_DriverGetCable	BRIDGE_DriverGetCable = nullptr;
+_BRIDGE_DriverSetCable	BRIDGE_DriverSetCable = nullptr;
+_BRIDGE_DriverGetCable2	BRIDGE_DriverGetCable2 = nullptr;
+_BRIDGE_DriverSetCable2	BRIDGE_DriverSetCable2 = nullptr;
+_BRIDGE_DriverGetAutoCache BRIDGE_DriverGetAutoCache = nullptr;
+_BRIDGE_DriverSetAutoCache BRIDGE_DriverSetAutoCache = nullptr;
+_BRIDGE_DriverGetSmartSpeedEnabled BRIDGE_DriverGetSmartSpeedEnabled = nullptr;
+_BRIDGE_DriverSetSmartSpeedEnabled BRIDGE_DriverSetSmartSpeedEnabled = nullptr;
+_BRIDGE_GetConfigString BRIDGE_GetConfigString = nullptr;
+_BRIDGE_SetConfigFromString BRIDGE_SetConfigFromString = nullptr;
+_BRIDGE_CreateDriverFromConfigString BRIDGE_CreateDriverFromConfigString = nullptr;
+_DRIVER_getBitSpeed	DRIVER_getBitSpeed = nullptr;
+_DRIVER_getDriveTypeID	DRIVER_getDriveTypeID = nullptr;
+_DRIVER_resetDrive	DRIVER_resetDrive = nullptr;
+_DRIVER_isAtCylinder0	DRIVER_isAtCylinder0 = nullptr;
+_DRIVER_getCurrentSide DRIVER_getCurrentSide = nullptr;
+_DRIVER_getMaxCylinder	DRIVER_getMaxCylinder = nullptr;
+_DRIVER_gotoCylinder	DRIVER_gotoCylinder = nullptr;
+_DRIVER_handleNoClickStep	DRIVER_handleNoClickStep = nullptr;
+_DRIVER_getCurrentCylinderNumber	DRIVER_getCurrentCylinderNumber = nullptr;
+_DRIVER_isMotorRunning	DRIVER_isMotorRunning = nullptr;
+_DRIVER_setMotorStatus	DRIVER_setMotorStatus = nullptr;
+_DRIVER_isReady	DRIVER_isReady = nullptr;
+_DRIVER_isDiskInDrive	DRIVER_isDiskInDrive = nullptr;
+_DRIVER_hasDiskChanged	DRIVER_hasDiskChanged = nullptr;
+_DRIVER_isMFMPositionAtIndex	DRIVER_isMFMPositionAtIndex = nullptr;
+_DRIVER_isMFMDataAvailable	DRIVER_isMFMDataAvailable = nullptr;
+_DRIVER_getMFMBit	DRIVER_getMFMBit = nullptr;
+_DRIVER_getMFMSpeed	DRIVER_getMFMSpeed = nullptr;
+_DRIVER_mfmSwitchBuffer	DRIVER_mfmSwitchBuffer = nullptr;
+_DRIVER_setSurface	DRIVER_setSurface = nullptr;
+_DRIVER_maxMFMBitPosition	DRIVER_maxMFMBitPosition = nullptr;
+_DRIVER_writeShortToBuffer	DRIVER_writeShortToBuffer = nullptr;
+_DRIVER_isWriteProtected	DRIVER_isWriteProtected = nullptr;
+_DRIVER_commitWriteBuffer	DRIVER_commitWriteBuffer = nullptr;
+_DRIVER_isWritePending	DRIVER_isWritePending = nullptr;
+_DRIVER_isWriteComplete	DRIVER_isWriteComplete = nullptr;
+_DRIVER_canTurboWrite	DRIVER_canTurboWrite = nullptr;
+_DRIVER_isReadyToWrite	DRIVER_isReadyToWrite = nullptr;
+_DRIVER_getTrack DRIVER_getTrack = nullptr;
+_DRIVER_putTrack DRIVER_putTrack = nullptr;
+_DRIVER_setDirectMode DRIVER_setDirectMode = nullptr;
+_DRIVER_isStillWorking DRIVER_isStillWorking = nullptr;
+
+
+// Sets up the bridge.  We assume it will persist while the application is open.
+void prepareBridge() {
+	if (hBridgeDLLHandle) return;
+
+#ifdef WIN32
+#ifdef WINUAE
+	hBridgeDLLHandle = WIN32_LoadLibrary(MODULENAME);
+#else
+#ifdef _UNICODE
+	hBridgeDLLHandle = LoadLibraryW(MODULENAME);
+#else
+	hBridgeDLLHandle = LoadLibraryA(MODULENAME);
+#endif
+#endif
+#else
+	hBridgeDLLHandle = dlopen(MODULENAME, RTLD_NOW);
+#endif
+
+	// Did it open?
+	if (!hBridgeDLLHandle) return;
+
+	BRIDGE_About = (_BRIDGE_About)GETFUNC(hBridgeDLLHandle, "BRIDGE_About");
+	BRIDGE_NumDrivers = (_BRIDGE_NumDrivers)GETFUNC(hBridgeDLLHandle, "BRIDGE_NumDrivers");
+	BRIDGE_EnumComports = (_BRIDGE_EnumComports)GETFUNC(hBridgeDLLHandle, "BRIDGE_EnumComports");
+	BRIDGE_GetDriverInfo = (_BRIDGE_GetDriverInfo)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetDriverInfo");
+	BRIDGE_CreateDriver = (_BRIDGE_CreateDriver)GETFUNC(hBridgeDLLHandle, "BRIDGE_CreateDriver");
+	BRIDGE_GetDriverIndex = (_BRIDGE_GetDriverIndex)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetDriverIndex");
+	BRIDGE_SetDriverIndex = (_BRIDGE_SetDriverIndex)GETFUNC(hBridgeDLLHandle, "BRIDGE_SetDriverIndex");
+#ifdef _WIN32
+	BRIDGE_ShowConfigDialog = (_BRIDGE_ShowConfigDialog)GETFUNC(hBridgeDLLHandle, "BRIDGE_ShowConfigDialog");
+	BRIDGE_EnableUsageNotifications = (_BRIDGE_EnableUsageNotifications)GETFUNC(hBridgeDLLHandle, "BRIDGE_EnableUsageNotifications");
+#endif
+	BRIDGE_Close = (_BRIDGE_Close)GETFUNC(hBridgeDLLHandle, "BRIDGE_Close");
+	BRIDGE_Open = (_BRIDGE_Open)GETFUNC(hBridgeDLLHandle, "BRIDGE_Open");
+	BRIDGE_CreateDriverFromProfileID = (_BRIDGE_CreateDriverFromProfileID)GETFUNC(hBridgeDLLHandle, "BRIDGE_CreateDriverFromProfileID");
+	BRIDGE_GetAllProfiles = (_BRIDGE_GetAllProfiles)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetAllProfiles");
+	BRIDGE_ImportProfilesFromString = (_BRIDGE_ImportProfilesFromString)GETFUNC(hBridgeDLLHandle, "BRIDGE_ImportProfilesFromString");
+	BRIDGE_ExportProfilesToString = (_BRIDGE_ExportProfilesToString)GETFUNC(hBridgeDLLHandle, "BRIDGE_ExportProfilesToString");
+	BRIDGE_GetProfileConfigFromString = (_BRIDGE_GetProfileConfigFromString)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetProfileConfigFromString");
+	BRIDGE_SetProfileConfigFromString = (_BRIDGE_SetProfileConfigFromString)GETFUNC(hBridgeDLLHandle, "BRIDGE_SetProfileConfigFromString");
+	BRIDGE_SetProfileName = (_BRIDGE_SetProfileName)GETFUNC(hBridgeDLLHandle, "BRIDGE_SetProfileName");	
+	BRIDGE_CreateNewProfile = (_BRIDGE_CreateNewProfile)GETFUNC(hBridgeDLLHandle, "BRIDGE_CreateNewProfile");
+	BRIDGE_DeleteProfile = (_BRIDGE_DeleteProfile)GETFUNC(hBridgeDLLHandle, "BRIDGE_DeleteProfile");
+	BRIDGE_FreeDriver = (_BRIDGE_FreeDriver)GETFUNC(hBridgeDLLHandle, "BRIDGE_FreeDriver");
+	BRIDGE_DriverGetAutoCache = (_BRIDGE_DriverGetAutoCache)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetAutoCache");
+	BRIDGE_DriverSetAutoCache = (_BRIDGE_DriverSetAutoCache)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetAutoCache");
+	BRIDGE_GetConfigString = (_BRIDGE_GetConfigString)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetConfigString");
+	BRIDGE_SetConfigFromString = (_BRIDGE_SetConfigFromString)GETFUNC(hBridgeDLLHandle, "BRIDGE_SetConfigFromString");
+	BRIDGE_CreateDriverFromConfigString = (_BRIDGE_CreateDriverFromConfigString)GETFUNC(hBridgeDLLHandle, "BRIDGE_CreateDriverFromConfigString");
+	BRIDGE_DriverGetMode = (_BRIDGE_DriverGetMode)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetMode");
+	BRIDGE_DriverSetMode = (_BRIDGE_DriverSetMode)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetMode");
+	BRIDGE_DriverGetDensityMode = (_BRIDGE_DriverGetDensityMode)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetDensityMode");
+	BRIDGE_DriverSetDensityMode = (_BRIDGE_DriverSetDensityMode)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetDensityMode");
+	BRIDGE_DriverGetCurrentComPort = (_BRIDGE_DriverGetCurrentComPort)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetCurrentComPort");
+	BRIDGE_DriverSetCurrentComPort = (_BRIDGE_DriverSetCurrentComPort)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetCurrentComPort");
+	BRIDGE_DriverGetAutoDetectComPort = (_BRIDGE_DriverGetAutoDetectComPort)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetAutoDetectComPort");
+	BRIDGE_DriverSetAutoDetectComPort = (_BRIDGE_DriverSetAutoDetectComPort)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetAutoDetectComPort");
+	BRIDGE_DriverGetSmartSpeedEnabled = (_BRIDGE_DriverGetSmartSpeedEnabled)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetSmartSpeedEnabled");
+	BRIDGE_DriverSetSmartSpeedEnabled = (_BRIDGE_DriverSetSmartSpeedEnabled)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetSmartSpeedEnabled");
+	BRIDGE_DriverGetCable = (_BRIDGE_DriverGetCable)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetCable");
+	BRIDGE_DriverSetCable = (_BRIDGE_DriverSetCable)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetCable");
+	BRIDGE_DriverGetCable2 = (_BRIDGE_DriverGetCable2)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverGetCable2");
+	BRIDGE_DriverSetCable2 = (_BRIDGE_DriverSetCable2)GETFUNC(hBridgeDLLHandle, "BRIDGE_DriverSetCable2");
+	DRIVER_getBitSpeed = (_DRIVER_getBitSpeed)GETFUNC(hBridgeDLLHandle, "DRIVER_getBitSpeed");
+	DRIVER_getCurrentSide = (_DRIVER_getCurrentSide)GETFUNC(hBridgeDLLHandle, "DRIVER_getCurrentSide");
+	DRIVER_getDriveTypeID = (_DRIVER_getDriveTypeID)GETFUNC(hBridgeDLLHandle, "DRIVER_getDriveTypeID");
+	DRIVER_resetDrive = (_DRIVER_resetDrive)GETFUNC(hBridgeDLLHandle, "DRIVER_resetDrive");
+	DRIVER_isAtCylinder0 = (_DRIVER_isAtCylinder0)GETFUNC(hBridgeDLLHandle, "DRIVER_isAtCylinder0");
+	DRIVER_getMaxCylinder = (_DRIVER_getMaxCylinder)GETFUNC(hBridgeDLLHandle, "DRIVER_getMaxCylinder");
+	DRIVER_gotoCylinder = (_DRIVER_gotoCylinder)GETFUNC(hBridgeDLLHandle, "DRIVER_gotoCylinder");
+	DRIVER_handleNoClickStep = (_DRIVER_handleNoClickStep)GETFUNC(hBridgeDLLHandle, "DRIVER_handleNoClickStep");
+	DRIVER_getCurrentCylinderNumber = (_DRIVER_getCurrentCylinderNumber)GETFUNC(hBridgeDLLHandle, "DRIVER_getCurrentCylinderNumber");
+	DRIVER_isMotorRunning = (_DRIVER_isMotorRunning)GETFUNC(hBridgeDLLHandle, "DRIVER_isMotorRunning");
+	DRIVER_setMotorStatus = (_DRIVER_setMotorStatus)GETFUNC(hBridgeDLLHandle, "DRIVER_setMotorStatus");
+	DRIVER_isReady = (_DRIVER_isReady)GETFUNC(hBridgeDLLHandle, "DRIVER_isReady");
+	DRIVER_isDiskInDrive = (_DRIVER_isDiskInDrive)GETFUNC(hBridgeDLLHandle, "DRIVER_isDiskInDrive");
+	DRIVER_hasDiskChanged = (_DRIVER_hasDiskChanged)GETFUNC(hBridgeDLLHandle, "DRIVER_hasDiskChanged");
+	DRIVER_isMFMPositionAtIndex = (_DRIVER_isMFMPositionAtIndex)GETFUNC(hBridgeDLLHandle, "DRIVER_isMFMPositionAtIndex");
+	DRIVER_isMFMDataAvailable = (_DRIVER_isMFMDataAvailable)GETFUNC(hBridgeDLLHandle, "DRIVER_isMFMDataAvailable");
+	DRIVER_getMFMBit = (_DRIVER_getMFMBit)GETFUNC(hBridgeDLLHandle, "DRIVER_getMFMBit");
+	DRIVER_getMFMSpeed = (_DRIVER_getMFMSpeed)GETFUNC(hBridgeDLLHandle, "DRIVER_getMFMSpeed");
+	DRIVER_mfmSwitchBuffer = (_DRIVER_mfmSwitchBuffer)GETFUNC(hBridgeDLLHandle, "DRIVER_mfmSwitchBuffer");
+	DRIVER_setSurface = (_DRIVER_setSurface)GETFUNC(hBridgeDLLHandle, "DRIVER_setSurface");
+	DRIVER_maxMFMBitPosition = (_DRIVER_maxMFMBitPosition)GETFUNC(hBridgeDLLHandle, "DRIVER_maxMFMBitPosition");
+	DRIVER_writeShortToBuffer = (_DRIVER_writeShortToBuffer)GETFUNC(hBridgeDLLHandle, "DRIVER_writeShortToBuffer");
+	DRIVER_isWriteProtected = (_DRIVER_isWriteProtected)GETFUNC(hBridgeDLLHandle, "DRIVER_isWriteProtected");
+	DRIVER_commitWriteBuffer = (_DRIVER_commitWriteBuffer)GETFUNC(hBridgeDLLHandle, "DRIVER_commitWriteBuffer");
+	DRIVER_isWritePending = (_DRIVER_isWritePending)GETFUNC(hBridgeDLLHandle, "DRIVER_isWritePending");
+	DRIVER_isWriteComplete = (_DRIVER_isWriteComplete)GETFUNC(hBridgeDLLHandle, "DRIVER_isWriteComplete");
+	DRIVER_canTurboWrite = (_DRIVER_canTurboWrite)GETFUNC(hBridgeDLLHandle, "DRIVER_canTurboWrite");
+	DRIVER_isReadyToWrite = (_DRIVER_isReadyToWrite)GETFUNC(hBridgeDLLHandle, "DRIVER_isReadyToWrite");
+	DRIVER_getTrack = (_DRIVER_getTrack)GETFUNC(hBridgeDLLHandle, "DRIVER_getTrack");
+	DRIVER_putTrack = (_DRIVER_putTrack)GETFUNC(hBridgeDLLHandle, "DRIVER_putTrack");
+	DRIVER_setDirectMode = (_DRIVER_setDirectMode)GETFUNC(hBridgeDLLHandle, "DRIVER_setDirectMode");
+	DRIVER_isStillWorking = (_DRIVER_isStillWorking)GETFUNC(hBridgeDLLHandle, "DRIVER_isStillWorking");
+
+	// Test a few
+	if ((!BRIDGE_About) || (!BRIDGE_NumDrivers) || (!BRIDGE_DeleteProfile)) {
+#ifdef WIN32
+		if (hBridgeDLLHandle) FreeLibrary(hBridgeDLLHandle);
+		hBridgeDLLHandle = 0;
+#else
+		if (hBridgeDLLHandle) dlclose(hBridgeDLLHandle);
+		hBridgeDLLHandle = nullptr;
+#endif
+	}
+}
+
+// character conversions
+using convert_t = std::codecvt_utf8<wchar_t>;
+static std::wstring_convert<convert_t, wchar_t> strconverter;
+
+void _quickw2a(const std::wstring& wstr, std::string& str) {
+	str = strconverter.to_bytes(wstr);
+}
+void _quicka2w(const std::string& str, std::wstring& wstr) {
+	wstr = strconverter.from_bytes(str);
+}
+
+// Copy or convert a char* to a TCHAR
+void _char2TChar(const char* input, TCHAR* output, unsigned maxLength) {
+#ifdef _UNICODE
+	std::wstring outputw;
+	_quicka2w(input, outputw);
+#ifdef _WIN32
+	wcscpy_s(output, maxLength, outputw.c_str());
+#else
+	wcscpy(output, outputw.c_str());
+#endif
+#else
+#ifdef _WIN32
+	strcpy_s(output, maxLength, input);
+#else
+	strcpy(output, input);
+#endif
+#endif
+}
+
+#ifdef _UNICODE
+std::vector<std::wstring> memoryPortList;
+#else
+std::vector<std::string> memoryPortList;
+#endif
+std::vector<std::string> stringListsForProfiles;
+
+
+/*********** STATIC FUNCTIONS ************************/
+
+// Returns TRUE if the floppy bridge library has been loaded and is ready to be queried
+bool FloppyBridgeAPI::isAvailable() {
+	prepareBridge();
+	return hBridgeDLLHandle != 0;
+}
+
+// Populates bridgeInformation with information about the Bridge DLL. This should be called and shown somewhere
+// As it contains update and support information too
+bool FloppyBridgeAPI::getBridgeDriverInformation(bool allowCheckForUpdates, BridgeInformation& bridgeInformation) {
+	if (!isAvailable()) {
+		// Populate some basics
+		memset(&bridgeInformation, 0, sizeof(bridgeInformation));
+		_char2TChar("FloppyBridge Driver Not Installed.", bridgeInformation.about, BRIDGE_STRING_MAX_LENGTH - 1);
+		_char2TChar("https://amiga.robsmithdev.co.uk/winuae", bridgeInformation.url, BRIDGE_STRING_MAX_LENGTH - 1);
+		return false;
+	}
+	
+	FloppyBridge::BridgeAbout* info = nullptr;
+	BRIDGE_About(allowCheckForUpdates, &info);
+	if (!info) return false;
+
+	bridgeInformation.isBeta = info->isBeta != 0;
+	bridgeInformation.isUpdateAvailable = info->isUpdateAvailable != 0;
+
+	bridgeInformation.majorVersion = info->majorVersion;
+	bridgeInformation.minorVersion = info->minorVersion;
+	bridgeInformation.updateMajorVersion = info->updateMajorVersion;
+	bridgeInformation.updateMinorVersion = info->updateMinorVersion;
+
+	_char2TChar(info->about, bridgeInformation.about, BRIDGE_STRING_MAX_LENGTH - 1);
+	_char2TChar(info->url, bridgeInformation.url, BRIDGE_STRING_MAX_LENGTH - 1);
+	return true;
+}
+
+// Populates driverList with a list of available floppy bridge drivers that could be created
+void FloppyBridgeAPI::getDriverList(std::vector<DriverInformation>& driverList) {
+	driverList.clear();
+
+	if (!isAvailable()) return;
+
+	unsigned int total = BRIDGE_NumDrivers();
+	if (total < 1) return;
+
+	BridgeDriver* info = nullptr;
+	for (unsigned int index = 0; index < total; index++) {
+		if (BRIDGE_GetDriverInfo(index, &info)) {
+
+			DriverInformation infoOut{};
+
+			_char2TChar(info->name, infoOut.name, BRIDGE_STRING_MAX_LENGTH - 1);
+			_char2TChar(info->url, infoOut.url, BRIDGE_STRING_MAX_LENGTH - 1);
+			_char2TChar(info->manufacturer, infoOut.manufacturer, BRIDGE_STRING_MAX_LENGTH - 1);
+			_char2TChar(info->driverAuthor, infoOut.driverAuthor, BRIDGE_STRING_MAX_LENGTH - 1);
+			infoOut.configOptions = info->configOptions;
+			infoOut.driverIndex = index;
+
+			driverList.push_back(infoOut);
+		}
+	}
+}
+
+// Creates a driver.  If it fails, it will return NULL.  It should only fail if the index is invalid.
+FloppyBridgeAPI* FloppyBridgeAPI::createDriver(unsigned int driverIndex) {
+	if (!isAvailable()) return nullptr;
+
+	BridgeDriverHandle driverHandle = nullptr;
+
+	if (!BRIDGE_CreateDriver(driverIndex, &driverHandle)) return nullptr;
+
+	// Create the class and return it.
+	return new FloppyBridgeAPI(driverIndex, driverHandle);
+}
+
+// Creates a driver from a config string previously saved.  This will auto-select the driverIndex.
+FloppyBridgeAPI* FloppyBridgeAPI::createDriverFromString(const char* config) {
+	if (!isAvailable()) return nullptr;
+
+	BridgeDriverHandle driverHandle = nullptr;
+
+	if (!BRIDGE_CreateDriverFromConfigString((char*)config, &driverHandle)) return nullptr;
+
+	unsigned int driverIndex;
+	if (!BRIDGE_GetDriverIndex(driverHandle, &driverIndex)) {
+		BRIDGE_FreeDriver(driverHandle);
+		return nullptr;
+	}
+
+	return new FloppyBridgeAPI(driverIndex, driverHandle);
+}
+
+// Populates portList with a list of serial port devices that you can use with setComPort() below
+void FloppyBridgeAPI::enumCOMPorts(std::vector<const TCHAR*>& portList) {
+	portList.clear();
+
+	if (!isAvailable()) return;
+
+	unsigned int sizeNeeded = 0;
+	BRIDGE_EnumComports(NULL, &sizeNeeded);
+
+	char* tmp = (char*)malloc(sizeNeeded);
+	if (!tmp) return;
+
+	if (BRIDGE_EnumComports(tmp, &sizeNeeded)) {
+		char* str = tmp;
+		TCharString opString;
+
+		memoryPortList.clear();
+
+		while (*str) {
+			_char2TChar(str, opString, BRIDGE_STRING_MAX_LENGTH);
+			memoryPortList.emplace_back(opString);
+			str += strlen(str) + 1;  // skip pas the null terminator
+		}
+
+		for (auto& string : memoryPortList)
+			portList.push_back(string.c_str());
+	}
+	free(tmp);
+}
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Profile based management
+
+
+// Creates the driver instance from a profile ID.  You need to call importProfilesFromString() before using this function
+FloppyBridgeAPI* FloppyBridgeAPI::createDriverFromProfileID(unsigned int profileID) {
+	if (!isAvailable()) return nullptr;
+
+	BridgeDriverHandle driverHandle = nullptr;
+
+	if (!BRIDGE_CreateDriverFromProfileID(profileID, &driverHandle)) return nullptr;
+
+	unsigned int driverIndex;
+	if (!BRIDGE_GetDriverIndex(driverHandle, &driverIndex)) {
+		BRIDGE_FreeDriver(driverHandle);
+		return nullptr;
+	}
+
+	return new FloppyBridgeAPI(driverIndex, driverHandle);
+}
+
+// Retrieve a list of all of the profiles currently loaded that can be used.
+bool FloppyBridgeAPI::getAllProfiles(std::vector<FloppyBridgeProfileInformation>& profileList) {
+	if (!isAvailable()) return false;
+
+	profileList.clear();
+	stringListsForProfiles.clear();
+
+	FloppyBridge::FloppyBridgeProfileInformationDLL* profile = nullptr;
+	unsigned int numProfiles = 0;
+
+	if (!BRIDGE_GetAllProfiles(&profile, &numProfiles)) return false;
+	
+	while (numProfiles) {
+		FloppyBridgeProfileInformation p{};
+		p.driverIndex = profile->driverIndex;
+		p.profileID = profile->profileID;
+
+		p.bridgeMode = profile->bridgeMode;
+		p.bridgeDensityMode = profile->bridgeDensityMode;
+
+		_char2TChar(profile->name, p.name, BRIDGE_STRING_MAX_LENGTH);
+		stringListsForProfiles.push_back(profile->profileConfig);
+		profileList.push_back(p);
+		numProfiles--;
+		profile++;
+	}
+
+	// Just populate the strings.. This was in case vector resizes etc changed memory locations
+	for (size_t pos = 0; pos < profileList.size(); pos++)
+		profileList[pos].profileConfig = stringListsForProfiles[pos].c_str();
+
+	return true;
+}
+
+// Imports all profiles into memory from the supplied string.  This will erase any currently in memory
+bool FloppyBridgeAPI::importProfilesFromString(const char* profilesString) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_ImportProfilesFromString((char*)profilesString);
+}
+
+// Exports all profiles and returns a pointer to the string.  This pointer is only valid while the driver is loaded and until this is called again
+bool FloppyBridgeAPI::exportProfilesToString(char** profilesString) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_ExportProfilesToString(profilesString);
+}
+
+// Returns a pointer to a string containing the details for a profile
+bool FloppyBridgeAPI::getProfileConfigAsString(unsigned int profileID, char** config) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_GetProfileConfigFromString(profileID, config);
+}
+
+// Creates a new profile and returns its unique ID
+bool FloppyBridgeAPI::createNewProfile(unsigned int driverIndex, unsigned int* profileID) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_CreateNewProfile(driverIndex, profileID);
+}
+
+
+// Updates a profile from the supplied string
+bool FloppyBridgeAPI::setProfileConfigFromString(unsigned int profileID, const char* config) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_SetProfileConfigFromString(profileID, (char*)config);
+}
+
+// Updates a profile from the supplied string
+bool FloppyBridgeAPI::setProfileName(unsigned int profileID, const char* name) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_SetProfileName(profileID, (char*)name);
+}
+
+// Deletes a profile by ID.
+bool FloppyBridgeAPI::deleteProfile(unsigned int profileID) {
+	if (!isAvailable()) return false;
+
+	return BRIDGE_DeleteProfile(profileID);
+}
+
+
+#ifdef _WIN32
+// By default FloppyBridge will inform DiskFlashback when it wants the drive. Use this to turn that feature off
+void FloppyBridgeAPI::enableUsageNotifications(bool enable) {
+	if (!isAvailable()) return;
+
+	BRIDGE_EnableUsageNotifications(enable);
+}
+
+
+// Displays the config dialog (modal) for Floppy Bridge profiles.  
+// *If* you pass a profile ID, the dialog will jump to editing that profile, or return FALSE if it was not found.
+// Returns FALSE if cancel was pressed
+bool FloppyBridgeAPI::showProfileConfigDialog(HWND hwndParent, unsigned int* profileID) {
+	if (!isAvailable()) return false;
+	 
+	return BRIDGE_ShowConfigDialog(hwndParent, profileID);
+}
+#endif
+
+/*********** CLASS FUNCTIONS ************************/
+
+// Don't call this. You should use the static createDriver member to create it.
+FloppyBridgeAPI::FloppyBridgeAPI(unsigned int driverIndex, BridgeDriverHandle handle) : FloppyDiskBridge(), m_handle(handle), m_driverIndex(driverIndex) {
+}
+
+FloppyBridgeAPI::~FloppyBridgeAPI() {	
+	BRIDGE_FreeDriver(m_handle);
+}
+
+/************** CONFIG RELATED FUNCTIONS *************************************/
+// Returns a pointer to a string containing the current config.  This can be used with setConfigFromString() or createDriverFromString()
+bool FloppyBridgeAPI::getConfigAsString(char** config) const
+{
+	return BRIDGE_GetConfigString(m_handle, config);
+}
+// Applies the config to the currently driver.  Returns TRUE if successful.
+bool FloppyBridgeAPI::setConfigFromString(const char* config) const
+{
+	return BRIDGE_SetConfigFromString(m_handle, (char*)config);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// This for setting and getting the driver index in use. Shouldnt normally be changed while in use
+bool FloppyBridgeAPI::getDriverIndex(int& driverIndex) const {
+	driverIndex = m_driverIndex;
+	return true;
+}
+
+// Set it
+bool FloppyBridgeAPI::setDriverIndex(const int driverIndex) {
+	if (BRIDGE_SetDriverIndex(m_handle, driverIndex)) {
+		m_driverIndex = driverIndex;
+		return true;
+	}
+	return false;
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Return the current bridge mode selected
+bool FloppyBridgeAPI::getBridgeMode(FloppyBridge::BridgeMode* mode) const
+{
+	return BRIDGE_DriverGetMode(m_handle, mode);
+}
+// Set the currently active bridge mode.  This can be set while the bridge is in use
+bool FloppyBridgeAPI::setBridgeMode(const FloppyBridge::BridgeMode newMode) const
+{
+	return BRIDGE_DriverSetMode(m_handle, newMode);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Return the current bridge density mode selected
+bool FloppyBridgeAPI::getBridgeDensityMode(FloppyBridge::BridgeDensityMode* mode) const
+{
+	return BRIDGE_DriverGetDensityMode(m_handle, mode);
+}
+// Set the currently active bridge density mode.  This can be set while the bridge is in use
+bool FloppyBridgeAPI::setBridgeDensityMode(const FloppyBridge::BridgeDensityMode newMode) const
+{
+	return BRIDGE_DriverSetDensityMode(m_handle, newMode);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// These require ConfigOption_AutoCache bit set in DriverInformation::configOptions
+// Returns if auto-disk caching (while the drive is idle) mode is enabled
+bool FloppyBridgeAPI::getAutoCacheMode(bool* autoCacheMode) const
+{
+	return BRIDGE_DriverGetAutoCache(m_handle, autoCacheMode);
+}
+// Sets if auto-disk caching (while the drive is idle) mode is enabled.  This can be set while the bridge is in use
+bool FloppyBridgeAPI::setAutoCacheMode(const bool autoCacheMode) const
+{
+	return BRIDGE_DriverSetAutoCache(m_handle, autoCacheMode);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// These require ConfigOption_ComPort bit set in DriverInformation::configOptions
+// Returns the currently selected COM port.  This port is only used if auto detect com port is false
+bool FloppyBridgeAPI::getComPort(TCharString* comPort) const
+{
+	char* port = nullptr;
+	if (!BRIDGE_DriverGetCurrentComPort(m_handle, &port)) return false;
+	if (!port) return false;
+	
+	_char2TChar(port, *comPort, BRIDGE_STRING_MAX_LENGTH - 1);
+	return true;
+}
+// Sets the com port to use.  This port is only used if auto detect com port is false.
+bool FloppyBridgeAPI::setComPort(const TCHAR* comPort) const
+{
+	if (!comPort) return false;
+	
+#ifdef _UNICODE
+	std::string comPortA;
+	_quickw2a(comPort, comPortA);
+	return BRIDGE_DriverSetCurrentComPort(m_handle, (char*)comPortA.c_str());
+#else
+	return BRIDGE_DriverSetCurrentComPort(m_handle, comPort);
+#endif
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// These require ConfigOption_AutoDetectComport bit set in DriverInformation::configOptions
+// Returns if com port auto-detect is enabled
+bool FloppyBridgeAPI::getComPortAutoDetect(bool* autoDetect) const
+{
+	return BRIDGE_DriverGetAutoDetectComPort(m_handle, autoDetect);
+}
+// Sets if auto-detect com port should be used
+bool FloppyBridgeAPI::setComPortAutoDetect(const bool autoDetect) const
+{
+	return BRIDGE_DriverSetAutoDetectComPort(m_handle, autoDetect);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// These require ConfigOption_DriveABCable bit set in DriverInformation::configOptions
+// Returns if the driver should use a drive connected as Drive B (true) on the cable rather than Drive A (false)
+bool FloppyBridgeAPI::getDriveCableSelection(bool* connectToDriveB) const
+{
+	return BRIDGE_DriverGetCable(m_handle, connectToDriveB);
+}
+// Sets if the driver should use a drive connected as Drive B (true) on the cable rather than Drive A (false)
+bool FloppyBridgeAPI::setDriveCableSelection(const bool connectToDriveB) const
+{
+	return BRIDGE_DriverSetCable(m_handle, connectToDriveB);
+}
+
+// New versions! = connectToDrive 
+bool FloppyBridgeAPI::getDriveCableSelection(FloppyBridge::DriveSelection* connectToDrive) const 
+{
+	return BRIDGE_DriverGetCable2(m_handle, connectToDrive);
+}
+
+// Sets if the driver should use a drive connected as Drive B (true) on the cable rather than Drive A (false)
+bool FloppyBridgeAPI::setDriveCableSelection(const FloppyBridge::DriveSelection connectToDrive) const
+{
+	return BRIDGE_DriverSetCable2(m_handle, connectToDrive);
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// These require ConfigOption_SmartSpeed bit set in DriverInformation::configOptions
+// Returns if the driver currently has Smart Speed enabled which can dynamically switch between normal and turbo disk speed without breaking copy protection
+bool FloppyBridgeAPI::getSmartSpeedEnabled(bool* enabled) const
+{
+	return BRIDGE_DriverGetSmartSpeedEnabled(m_handle, enabled);
+}
+//  Sets if the driver can dynamically switch between normal and turbo disk speed without breaking copy protectionThis can be set while the bridge is in use
+bool FloppyBridgeAPI::setSmartSpeedEnabled(const bool enabled) const
+{
+	return BRIDGE_DriverSetSmartSpeedEnabled(m_handle, enabled);
+}
+
+/******************* BRIDGE Functions for UAE **********************************/
+
+bool FloppyBridgeAPI::initialise() {
+	if (m_isOpen) shutdown();
+
+	memset(m_error, 0, sizeof(m_error));
+	memset(m_warning, 0, sizeof(m_warning));
+
+	char* msg;
+	m_isOpen = BRIDGE_Open(m_handle, &msg);
+
+	if (m_isOpen) {
+		if (msg) _char2TChar(msg, m_warning, BRIDGE_STRING_MAX_LENGTH-1);
+		return true;
+	}
+	else {
+		if (msg) _char2TChar(msg, m_error, BRIDGE_STRING_MAX_LENGTH - 1);
+		return false;
+	}
+}
+void FloppyBridgeAPI::shutdown() {
+	if (m_isOpen) {
+		BRIDGE_Close(m_handle);
+		m_isOpen = false;
+	}
+	FloppyDiskBridge::shutdown();
+}
+
+
+//virtual const BridgeDriver* getDriverInfo() override;
+unsigned char FloppyBridgeAPI::getBitSpeed() {
+	return DRIVER_getBitSpeed(m_handle);
+}
+FloppyDiskBridge::DriveTypeID FloppyBridgeAPI::getDriveTypeID() {
+	return DRIVER_getDriveTypeID(m_handle);
+}
+const char* FloppyBridgeAPI::getLastErrorMessage() {
+#ifdef _UNICODE
+	_quickw2a(m_error, m_lastErrorAnsi);
+	return m_lastErrorAnsi.c_str();
+#else
+	return m_error;
+#endif
+}
+const FloppyDiskBridge::BridgeDriver* FloppyBridgeAPI::getDriverInfo() {
+	if (BRIDGE_GetDriverInfo(m_driverIndex, &m_driverInfo)) return m_driverInfo;
+	return nullptr;
+}
+const unsigned int FloppyBridgeAPI::getDriverTypeIndex() const {
+	return m_driverIndex;
+}
+bool FloppyBridgeAPI::isStillWorking() {
+	return DRIVER_isStillWorking(m_handle);
+}
+bool FloppyBridgeAPI::resetDrive(int trackNumber) {
+	return DRIVER_resetDrive(m_handle, trackNumber);
+}
+bool FloppyBridgeAPI::isAtCylinder0() {
+	return DRIVER_isAtCylinder0(m_handle);
+}
+unsigned char FloppyBridgeAPI::getMaxCylinder() {
+	return DRIVER_getMaxCylinder(m_handle);
+}
+void FloppyBridgeAPI::gotoCylinder(int cylinderNumber, bool side) {
+	DRIVER_gotoCylinder(m_handle, cylinderNumber, side);
+}
+void FloppyBridgeAPI::handleNoClickStep(bool side) {
+	DRIVER_handleNoClickStep(m_handle, side);
+}
+unsigned char FloppyBridgeAPI::getCurrentCylinderNumber() {
+	return DRIVER_getCurrentCylinderNumber(m_handle);
+}
+bool FloppyBridgeAPI::isMotorRunning() {
+	return DRIVER_isMotorRunning(m_handle);
+}
+void FloppyBridgeAPI::setMotorStatus(bool side, bool turnOn) {
+	DRIVER_setMotorStatus(m_handle, side, turnOn);
+}
+bool FloppyBridgeAPI::getCurrentSide() {
+	return DRIVER_getCurrentSide(m_handle);
+}
+bool FloppyBridgeAPI::isReady() {
+	return DRIVER_isReady(m_handle);
+}
+bool FloppyBridgeAPI::isDiskInDrive() {
+	return DRIVER_isDiskInDrive(m_handle);
+}
+bool FloppyBridgeAPI::hasDiskChanged() {
+	return DRIVER_hasDiskChanged(m_handle);
+}
+bool FloppyBridgeAPI::isMFMPositionAtIndex(int mfmPositionBits) {
+	return DRIVER_isMFMPositionAtIndex(m_handle, mfmPositionBits);
+}
+bool FloppyBridgeAPI::isMFMDataAvailable() {
+	return DRIVER_isMFMDataAvailable(m_handle);
+}
+bool FloppyBridgeAPI::getMFMBit(const int mfmPositionBits) {
+	return DRIVER_getMFMBit(m_handle, mfmPositionBits);
+}
+int FloppyBridgeAPI::getMFMSpeed(const int mfmPositionBits) {
+	return DRIVER_getMFMSpeed(m_handle, mfmPositionBits);
+}
+void FloppyBridgeAPI::mfmSwitchBuffer(bool side) {
+	DRIVER_mfmSwitchBuffer(m_handle, side);
+}
+void FloppyBridgeAPI::setSurface(bool side) {
+	DRIVER_setSurface(m_handle, side);
+}
+int FloppyBridgeAPI::maxMFMBitPosition() {
+	return DRIVER_maxMFMBitPosition(m_handle);
+}
+void FloppyBridgeAPI::writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) {
+	DRIVER_writeShortToBuffer(m_handle, side, track, mfmData, mfmPosition);
+}
+int FloppyBridgeAPI::getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) {
+	return DRIVER_getTrack(m_handle, side, track, resyncRotation, bufferSizeInBytes, output);
+}
+bool FloppyBridgeAPI::setDirectMode(bool directModeEnable) {
+	return DRIVER_setDirectMode(m_handle, directModeEnable);
+}
+bool FloppyBridgeAPI::writeMFMTrackToBuffer(bool side, unsigned int track, bool writeFromIndex, int sizeInBytes, void* mfmData) {
+	return DRIVER_putTrack(m_handle, side, track, writeFromIndex, sizeInBytes, mfmData);
+}
+bool FloppyBridgeAPI::isWriteProtected() {
+	return DRIVER_isWriteProtected(m_handle);
+}
+unsigned int FloppyBridgeAPI::commitWriteBuffer(bool side, unsigned int track) {
+	return DRIVER_commitWriteBuffer(m_handle, side, track);
+}
+bool FloppyBridgeAPI::isWritePending() {
+	return DRIVER_isWritePending(m_handle);
+}
+bool FloppyBridgeAPI::isWriteComplete() {
+	return DRIVER_isWriteComplete(m_handle);
+}
+bool FloppyBridgeAPI::canTurboWrite() {
+	return DRIVER_canTurboWrite(m_handle);
+}
+bool FloppyBridgeAPI::isReadyToWrite() {
+	return DRIVER_isReadyToWrite(m_handle);
+}

--- a/vendor/floppybridge/src/floppybridge_lib.h
+++ b/vendor/floppybridge/src/floppybridge_lib.h
@@ -1,0 +1,324 @@
+/* floppybridge_lib
+*
+* Copyright (C) 2021-2023 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This class connects to the external FloppyBridge DLL library rather than
+* having all the code compiled in. That library is maintained at 
+* https://amiga.robsmithdev.co.uk/winuae
+*
+* This is free and unencumbered released into the public domain
+* But please don't remove the above information
+* 
+* For more details visit <http://unlicense.org>.
+*
+*/
+
+#pragma once
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+
+#include "floppybridge_abstract.h"
+#include "floppybridge_common.h"
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include <vector>
+#include <string>
+
+
+#define BRIDGE_STRING_MAX_LENGTH 255
+typedef TCHAR TCharString[BRIDGE_STRING_MAX_LENGTH];
+
+
+
+// Class to access the 'floppybridge' via a DLL but using the same interface
+class FloppyBridgeAPI : public FloppyDiskBridge {
+public:
+
+	// How to use disk density
+	enum class BridgeDensityMode : unsigned char {
+		bdmAuto = 0,						// Auto-detect the type of disk when its inserted
+		bdmDDOnly = 1,						// Always detect all inserted disks as DD
+		bdmHDOnly = 2,						// Always detect all inserted disks as HD
+		bdmMax = 2
+	};
+
+	// Information about the bridge driver DLL that was loaded.
+	struct BridgeInformation {
+		// Information about the bridge
+		TCharString about;
+		// A url where you can get support/download updates from
+		TCharString url;
+		// The current version
+		unsigned int majorVersion, minorVersion;
+		// Is this version a beta build?
+		bool isBeta;
+		// Is there an update to this version available?
+		bool isUpdateAvailable;
+		// The version number of the update/latest version available
+		unsigned int updateMajorVersion, updateMinorVersion;
+	};
+
+	// These bitmasks are used with DriverInformation::configOptions
+	static const unsigned int ConfigOption_AutoCache			= 0x01;	// The driver can cache data from other cylinders while the disk isn't in use
+	static const unsigned int ConfigOption_ComPort				= 0x02;	// The driver requires a COM port selection
+	static const unsigned int ConfigOption_AutoDetectComport	= 0x04;	// The driver supports automatic com port detection and selection
+	static const unsigned int ConfigOption_DriveABCable			= 0x08;	// The driver allows you to specify using cable select for Drive A or Drive B
+	static const unsigned int ConfigOption_SmartSpeed			= 0x10;	// The driver supports dynamically switching between normal and Turbo hopefully without breaking copy protection
+	static const unsigned int ConfigOption_SupportsShugartMode  = 0x20; // The driver supports Shugart modes as well as IBM PC modes
+
+	// Information about a Bridge Driver (eg: DrawBridge, Greaseweazle etc)
+	struct DriverInformation {
+		// Used to identify the type of driver.  Use this to create the device or multiple instances of the device (possibly on different COM ports)
+		unsigned int driverIndex;
+
+		// Details about the driver
+		TCharString name;
+		TCharString url;
+		TCharString manufacturer;
+		TCharString driverAuthor;
+
+		// A bitmask of which options in configuration the driver can support, aside from the standard ones. See the ConfigOption_ consts above
+		unsigned int configOptions;
+	};
+
+	// Information about a floppy bridge profile
+	struct FloppyBridgeProfileInformation {
+		// Unique ID of this profile
+		unsigned int profileID;
+
+		// Driver Index, in case it's shown on the GUI
+		unsigned int driverIndex;
+
+		// Some basic information
+		FloppyBridge::BridgeMode bridgeMode;
+		FloppyBridge::BridgeDensityMode bridgeDensityMode;
+
+		// Profile name
+		TCharString name;
+
+		// Pointer to the Configuration data for this profile. - Be careful. Assume this pointer is invalid after calling *any* of the *profile* functions apart from getAllProfiles
+		const char* profileConfig;
+	};
+	
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Static functions for accessing parts of the API before creating an instance of this 
+	// Route is: choose driver, create driver, configure it, then set the "bridge" variable in UAE to the created instance and it will do the rest
+
+	// Returns TRUE if the floppy bridge library has been loaded and is ready to be queried.  All functions are safe to call regardless the return value
+	static bool isAvailable();
+
+	// Populates bridgeInformation with information about the Bridge DLL. This should be called and shown somewhere
+	// As it contains update and support information too.  If this returns FALSE it will still contain basic information such as a URL to get the DLL from.
+	static bool getBridgeDriverInformation(bool allowCheckForUpdates, BridgeInformation& bridgeInformation);
+
+	// Creates a driver instance.  If it fails, it will return NULL.  It should only fail if the index is invalid.
+	static FloppyBridgeAPI* createDriver(unsigned int driverIndex);
+
+	// Create a driver instance from a config string previously saved.  This will auto-select the driverIndex.
+	static FloppyBridgeAPI* createDriverFromString(const char* config);
+
+	// Creates the driver instance from a profile ID.  You need to call importProfilesFromString() before using this function
+	static FloppyBridgeAPI* createDriverFromProfileID(unsigned int profileID);
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Direct management
+
+	// Populates driverList with a list of available floppy bridge drivers that could be created
+	static void getDriverList(std::vector<DriverInformation>& driverList);
+
+	// Populates portList with a list of serial port devices that you can use with setComPort() below
+	// NOTE: The TCHARs in the vector are only valid until this function is called again
+	static void enumCOMPorts(std::vector<const TCHAR*>& portList);
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Profile based management
+
+	// Displays the config dialog (modal) for Floppy Bridge profiles.  
+	// *If* you pass a profile ID, the dialog will jump to editing that profile, or return FALSE if it was not found.
+	// Returns FALSE if cancel was pressed
+#ifdef _WIN32
+	static bool showProfileConfigDialog(HWND hwndParent, unsigned int* profileID = nullptr);
+#endif
+
+	// Retrieve a list of all of the profiles currently loaded that can be used.
+	static bool getAllProfiles(std::vector<FloppyBridgeProfileInformation>& profileList);
+
+	// Imports all profiles into memory from the supplied string.  This will erase any currently in memory
+	static bool importProfilesFromString(const char* profilesString);
+
+	// Exports all profiles and returns a pointer to the string.  This pointer is only valid while the driver is loaded and until this is called again
+	static bool exportProfilesToString(char** profilesString);
+
+	// Returns a pointer to a string containing the details for a profile
+	static bool getProfileConfigAsString(unsigned int profileID, char** config);
+
+	// Updates a profile from the supplied string
+	static bool setProfileConfigFromString(unsigned int profileID, const char* config);
+
+	// Updates a profile name the supplied string
+	static bool setProfileName(unsigned int profileID, const char* name);
+
+	// Creates a new profile and returns its unique ID
+	static bool createNewProfile(unsigned int driverIndex, unsigned int* profileID);
+
+	// Deletes a profile by ID.
+	static bool deleteProfile(unsigned int profileID);
+
+#ifdef _WIN32
+	// By default FloppyBridge will inform DiskFlashback when it wants the drive. Use this to turn that feature off
+	static void enableUsageNotifications(bool enable);
+#endif
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Functions for configuring the driver once it has been created.	
+	// Returns a pointer to a string containing the current config.  This can be used with setConfigFromString() or createDriverFromString()
+	bool getConfigAsString(char** config) const;
+	// Applies the config to the currently driver.  Returns TRUE if successful.
+	bool setConfigFromString(const char* config) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// This for setting and getting the driver index in use. Shouldnt normally be changed while in use
+	bool getDriverIndex(int& driverIndex) const;
+	// Set it
+	bool setDriverIndex(const int driverIndex);
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Return the current bridge mode selected
+	bool getBridgeMode(FloppyBridge::BridgeMode* mode) const;
+	// Set the currently active bridge mode.  This can be set while the bridge is in use
+	bool setBridgeMode(const FloppyBridge::BridgeMode newMode) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Return the current bridge density mode selected
+	bool getBridgeDensityMode(FloppyBridge::BridgeDensityMode* mode) const;
+	// Set the currently active bridge density mode.  This can be set while the bridge is in use
+	bool setBridgeDensityMode(const FloppyBridge::BridgeDensityMode newMode) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// These require ConfigOption_AutoCache bit set in DriverInformation::configOptions
+	// Returns if auto-disk caching (while the drive is idle) mode is enabled
+	bool getAutoCacheMode(bool* autoCacheMode) const;
+	// Sets if auto-disk caching (while the drive is idle) mode is enabled.  This can be set while the bridge is in use
+	bool setAutoCacheMode(const bool autoCacheMode) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// These require ConfigOption_ComPort bit set in DriverInformation::configOptions
+	// Returns the currently selected COM port.  This port is only used if auto detect com port is false
+	bool getComPort(TCharString* comPort) const;
+	// Sets the com port to use.  This port is only used if auto detect com port is false.
+	bool setComPort(const TCHAR* comPort) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// These require ConfigOption_AutoDetectComport bit set in DriverInformation::configOptions
+	// Returns if com port auto-detect is enabled
+	bool getComPortAutoDetect(bool* autoDetect) const;
+	// Sets if auto-detect com port should be used
+	bool setComPortAutoDetect(const bool autoDetect) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// DEPRECATED: These require ConfigOption_DriveABCable bit set in DriverInformation::configOptions
+	// Returns if the driver should use a drive connected as Drive B (true) on the cable rather than Drive A (false)
+	bool getDriveCableSelection(bool* connectToDriveB) const;
+	// Sets if the driver should use a drive connected as Drive B (true) on the cable rather than Drive A (false)
+	bool setDriveCableSelection(const bool connectToDriveB) const;
+
+	// New versions! = connectToDrive 
+	bool getDriveCableSelection(FloppyBridge::DriveSelection* connectToDrive) const;
+	// Sets if the driver should use a drive connected as Drive B (true) on the cable rather than Drive A (false)
+	bool setDriveCableSelection(const FloppyBridge::DriveSelection connectToDrive) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// These require ConfigOption_SmartSpeed bit set in DriverInformation::configOptions
+	// Returns if the driver currently has Smart Speed enabled which can dynamically switch between normal and turbo disk speed without breaking copy protection
+	bool getSmartSpeedEnabled(bool* enabled) const;
+	//  Sets if the driver can dynamically switch between normal and turbo disk speed without breaking copy protectionThis can be set while the bridge is in use
+	bool setSmartSpeedEnabled(const bool enabled) const;
+
+
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Functions required by UAE - see floppybridge_abstract for more details
+	FloppyBridgeAPI(unsigned int driverIndex, BridgeDriverHandle handle); // Don't call this. You should use the static createDriver member to create it.
+	virtual ~FloppyBridgeAPI();
+	virtual bool initialise() override;
+	virtual void shutdown() override;
+	virtual const BridgeDriver* getDriverInfo() override;	
+	virtual unsigned char getBitSpeed() override;
+	virtual DriveTypeID getDriveTypeID() override;
+	virtual bool isStillWorking() override;
+	virtual const char* getLastErrorMessage() override;
+	virtual bool resetDrive(int trackNumber) override;
+	virtual bool isAtCylinder0() override;
+	virtual unsigned char getMaxCylinder() override;
+	virtual void gotoCylinder(int cylinderNumber, bool side) override;
+	virtual void handleNoClickStep(bool side) override;
+	virtual unsigned char getCurrentCylinderNumber() override;
+	virtual bool isMotorRunning() override;
+	virtual void setMotorStatus(bool side, bool turnOn) override;
+	virtual bool isReady() override;
+	virtual bool isDiskInDrive() override;
+	virtual bool hasDiskChanged() override;
+	virtual bool getCurrentSide() override;
+	virtual bool isMFMPositionAtIndex(int mfmPositionBits) override;
+	virtual bool isMFMDataAvailable() override;
+	virtual bool getMFMBit(const int mfmPositionBits) override;
+	virtual int getMFMSpeed(const int mfmPositionBits) override;
+	virtual void mfmSwitchBuffer(bool side) override;
+	virtual void setSurface(bool side) override;
+	virtual int maxMFMBitPosition() override;
+	virtual void writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition)  override;
+	virtual int getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) override;
+	virtual bool setDirectMode(bool directModeEnable) override;
+	virtual bool writeMFMTrackToBuffer(bool side, unsigned int track, bool writeFromIndex, int sizeInBytes, void* mfmData) override;
+	virtual bool isWriteProtected() override;
+	virtual unsigned int commitWriteBuffer(bool side, unsigned int track)  override;
+	virtual bool isWritePending() override;
+	virtual bool isWriteComplete() override;
+	virtual bool canTurboWrite() override;
+	virtual bool isReadyToWrite() override;
+	const unsigned int getDriverTypeIndex() const;
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+private:
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Private stuff
+	BridgeDriverHandle m_handle;				// Handle to loaded driver
+	unsigned int m_driverIndex;					// Index of that driver
+	TCharString m_error = { 0 };				// Last error
+	TCharString m_warning = { 0 };				// Last warning
+	BridgeDriver* m_driverInfo{};					// Pointer to the driver info if retrieved
+#ifdef _UNICODE
+	std::string m_lastErrorAnsi;				// Non-unicode version of the last error
+#endif
+	bool m_isOpen = false;						// If the driver is 'open' (ie connected to the drive) or not
+};

--- a/vendor/floppybridge/src/ftdi.cpp
+++ b/vendor/floppybridge/src/ftdi.cpp
@@ -1,0 +1,457 @@
+/* ArduinoFloppyReader (and writer)
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+/*
+  This is a FTDI driver class, based on the FTDI2XX.h file from FTDI.
+  This library dynamically loads the DLL/SO rather than static linking to it.
+*/
+#include "ftdi.h"
+
+#ifdef FTDI_D2XX_AVAILABLE
+
+using namespace FTDI;
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
+// Based on the FTDI2XX.h file, but with dynamic loading
+
+static int libraryLoadCounter = 0;
+
+// Purge rx and tx buffers
+#define FT_PURGE_RX         1
+#define FT_PURGE_TX         2
+
+#ifdef _WIN32
+#define CALLING_CONVENTION WINAPI
+#define GETFUNC GetProcAddress
+#else
+#define CALLING_CONVENTION
+#define GETFUNC dlsym
+#endif
+
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_Open)(int deviceNumber, FT_HANDLE *pHandle) ;
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_OpenEx)(LPVOID pArg1, DWORD Flags, FT_HANDLE *pHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_ListDevices)( LPVOID pArg1, LPVOID pArg2, DWORD Flags);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_Close)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_GetComPortNumber)(FT_HANDLE ftHandle, LPLONG lplComPortNumber);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_Read)(FT_HANDLE ftHandle, LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesReturned);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_Write)(FT_HANDLE ftHandle, LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesWritten);	 
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_IoCtl)(FT_HANDLE ftHandle, DWORD dwIoControlCode, LPVOID lpInBuf, DWORD nInBufSize, LPVOID lpOutBuf, DWORD nOutBufSize, LPDWORD lpBytesReturned, LPOVERLAPPED lpOverlapped);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetBaudRate)(FT_HANDLE ftHandle, ULONG BaudRate);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetDivisor)(FT_HANDLE ftHandle, USHORT Divisor);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetDataCharacteristics)(FT_HANDLE ftHandle, UCHAR WordLength, UCHAR StopBits, UCHAR Parity);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetFlowControl)(FT_HANDLE ftHandle, USHORT FlowControl, UCHAR XonChar, UCHAR XoffChar);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_ResetDevice)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetDtr)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_ClrDtr)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetRts)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_ClrRts)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_GetModemStatus)(FT_HANDLE ftHandle,ULONG *pModemStatus);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetChars)(FT_HANDLE ftHandle,UCHAR EventChar,UCHAR EventCharEnabled,UCHAR ErrorChar,UCHAR ErrorCharEnabled);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_Purge)(FT_HANDLE ftHandle,ULONG Mask);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetTimeouts)(FT_HANDLE ftHandle,ULONG ReadTimeout,ULONG WriteTimeout);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_GetQueueStatus)(FT_HANDLE ftHandle,DWORD *dwRxBytes);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetEventNotification)(FT_HANDLE ftHandle,DWORD Mask,LPVOID Param);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_GetEventStatus)(FT_HANDLE ftHandle,DWORD *dwEventDWord);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_GetStatus)(FT_HANDLE ftHandle,DWORD *dwRxBytes,DWORD *dwTxBytes,DWORD *dwEventDWord);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetBreakOn)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetBreakOff)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_SetWaitMask)(FT_HANDLE ftHandle,DWORD Mask);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION *_FT_WaitOnMask)(FT_HANDLE ftHandle,DWORD *Mask);
+
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_CreateDeviceInfoList)(LPDWORD lpdwNumDevs);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_GetDeviceInfoList)(FT_DEVICE_LIST_INFO_NODE* pDest, LPDWORD lpdwNumDevs);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_GetDeviceInfoDetail)(DWORD dwIndex, LPDWORD lpdwFlags, LPDWORD lpdwType, LPDWORD lpdwID, LPDWORD lpdwLocId, char* pcSerialNumber, char* pcDescription, FT_HANDLE* ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_GetDriverVersion)(FT_HANDLE ftHandle, LPDWORD lpdwDriverVersion);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_GetLibraryVersion)(LPDWORD lpdwDLLVersion);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_ResetPort)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_CyclePort)(FT_HANDLE ftHandle);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_GetComPortNumber)(FT_HANDLE ftHandle, LPLONG port);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_SetUSBParameters)(FT_HANDLE ftHandle, DWORD dwInTransferSize, DWORD dwOutTransferSize);
+typedef FTDI::FT_STATUS (CALLING_CONVENTION* _FT_SetLatencyTimer)(FT_HANDLE ftHandle, UCHAR ucTimer);
+
+_FT_Open	FT_Open = nullptr;
+_FT_OpenEx	FT_OpenEx = nullptr;
+_FT_ListDevices	FT_ListDevices = nullptr;
+_FT_Close	FT_Close = nullptr;
+_FT_Read	FT_Read = nullptr;
+_FT_Write	FT_Write = nullptr;
+_FT_IoCtl 	FT_IoCtl = nullptr;
+_FT_SetBaudRate	FT_SetBaudRate = nullptr;
+_FT_SetDivisor	FT_SetDivisor = nullptr;
+_FT_SetDataCharacteristics	FT_SetDataCharacteristics = nullptr;
+_FT_SetFlowControl	FT_SetFlowControl = nullptr;
+_FT_ResetDevice	FT_ResetDevice = nullptr;
+_FT_SetDtr	FT_SetDtr = nullptr;
+_FT_ClrDtr	FT_ClrDtr = nullptr;
+_FT_SetRts	FT_SetRts = nullptr;
+_FT_ClrRts	FT_ClrRts = nullptr;
+_FT_GetModemStatus	FT_GetModemStatus = nullptr;
+_FT_SetChars	FT_SetChars = nullptr;
+_FT_Purge	FT_Purge = nullptr;
+_FT_SetTimeouts	FT_SetTimeouts = nullptr;
+_FT_GetQueueStatus	FT_GetQueueStatus = nullptr;
+_FT_SetEventNotification	FT_SetEventNotification = nullptr;
+_FT_GetEventStatus	FT_GetEventStatus = nullptr;
+_FT_GetStatus	FT_GetStatus = nullptr;
+_FT_SetBreakOn	FT_SetBreakOn = nullptr;
+_FT_SetBreakOff	FT_SetBreakOff = nullptr;
+_FT_SetWaitMask	FT_SetWaitMask = nullptr;
+_FT_WaitOnMask	FT_WaitOnMask = nullptr;
+
+_FT_CreateDeviceInfoList FT_CreateDeviceInfoList = nullptr;
+_FT_GetDeviceInfoList FT_GetDeviceInfoList = nullptr;
+_FT_GetDeviceInfoDetail FT_GetDeviceInfoDetail = nullptr;
+_FT_GetDriverVersion FT_GetDriverVersion = nullptr;
+_FT_GetLibraryVersion FT_GetLibraryVersion = nullptr;
+_FT_ResetPort FT_ResetPort = nullptr;
+_FT_CyclePort FT_CyclePort = nullptr;
+_FT_GetComPortNumber FT_GetComPortNumber = nullptr;
+_FT_SetUSBParameters FT_SetUSBParameters = nullptr;
+_FT_SetLatencyTimer FT_SetLatencyTimer = nullptr;
+
+#ifdef _WIN32
+HMODULE m_dll = 0;
+#else
+void* m_dll = nullptr;
+#endif
+
+
+void initFTDILibrary() {
+	libraryLoadCounter++;
+	if (libraryLoadCounter == 1) {
+#ifdef WIN32
+		m_dll = LoadLibraryA("FTD2XX.DLL");
+#else
+		m_dll = dlopen("libftd2xx.so", RTLD_NOW);
+#endif
+		if (m_dll) {
+			FT_Open = (_FT_Open)GETFUNC(m_dll, "FT_Open");
+			FT_OpenEx = (_FT_OpenEx)GETFUNC(m_dll, "FT_OpenEx");
+			FT_ListDevices = (_FT_ListDevices)GETFUNC(m_dll, "FT_ListDevices");
+			FT_Close = (_FT_Close)GETFUNC(m_dll, "FT_Close");
+			FT_Read = (_FT_Read)GETFUNC(m_dll, "FT_Read");
+			FT_Write = (_FT_Write)GETFUNC(m_dll, "FT_Write");
+			FT_IoCtl = (_FT_IoCtl)GETFUNC(m_dll, "FT_IoCtl ");
+			FT_SetBaudRate = (_FT_SetBaudRate)GETFUNC(m_dll, "FT_SetBaudRate");
+			FT_SetDivisor = (_FT_SetDivisor)GETFUNC(m_dll, "FT_SetDivisor");
+			FT_SetDataCharacteristics = (_FT_SetDataCharacteristics)GETFUNC(m_dll, "FT_SetDataCharacteristics");
+			FT_SetFlowControl = (_FT_SetFlowControl)GETFUNC(m_dll, "FT_SetFlowControl");
+			FT_ResetDevice = (_FT_ResetDevice)GETFUNC(m_dll, "FT_ResetDevice");
+			FT_SetDtr = (_FT_SetDtr)GETFUNC(m_dll, "FT_SetDtr");
+			FT_ClrDtr = (_FT_ClrDtr)GETFUNC(m_dll, "FT_ClrDtr");
+			FT_SetRts = (_FT_SetRts)GETFUNC(m_dll, "FT_SetRts");
+			FT_ClrRts = (_FT_ClrRts)GETFUNC(m_dll, "FT_ClrRts");
+			FT_GetModemStatus = (_FT_GetModemStatus)GETFUNC(m_dll, "FT_GetModemStatus");
+			FT_SetChars = (_FT_SetChars)GETFUNC(m_dll, "FT_SetChars");
+			FT_Purge = (_FT_Purge)GETFUNC(m_dll, "FT_Purge");
+			FT_SetTimeouts = (_FT_SetTimeouts)GETFUNC(m_dll, "FT_SetTimeouts");
+			FT_GetQueueStatus = (_FT_GetQueueStatus)GETFUNC(m_dll, "FT_GetQueueStatus");
+			FT_SetEventNotification = (_FT_SetEventNotification)GETFUNC(m_dll, "FT_SetEventNotification");
+			FT_GetEventStatus = (_FT_GetEventStatus)GETFUNC(m_dll, "FT_GetEventStatus");
+			FT_GetStatus = (_FT_GetStatus)GETFUNC(m_dll, "FT_GetStatus");
+			FT_SetBreakOn = (_FT_SetBreakOn)GETFUNC(m_dll, "FT_SetBreakOn");
+			FT_SetBreakOff = (_FT_SetBreakOff)GETFUNC(m_dll, "FT_SetBreakOff");
+			FT_SetWaitMask = (_FT_SetWaitMask)GETFUNC(m_dll, "FT_SetWaitMask");
+			FT_WaitOnMask = (_FT_WaitOnMask)GETFUNC(m_dll, "FT_WaitOnMask");
+			FT_CreateDeviceInfoList = (_FT_CreateDeviceInfoList)GETFUNC(m_dll, "FT_CreateDeviceInfoList");
+			FT_GetDeviceInfoList = (_FT_GetDeviceInfoList)GETFUNC(m_dll, "FT_GetDeviceInfoList");
+			FT_GetDeviceInfoDetail = (_FT_GetDeviceInfoDetail)GETFUNC(m_dll, "FT_GetDeviceInfoDetail");
+			FT_GetDriverVersion = (_FT_GetDriverVersion)GETFUNC(m_dll, "FT_GetDriverVersion");
+			FT_GetLibraryVersion = (_FT_GetLibraryVersion)GETFUNC(m_dll, "FT_GetLibraryVersion");
+			FT_ResetPort = (_FT_ResetPort)GETFUNC(m_dll, "FT_ResetPort");
+			FT_CyclePort = (_FT_CyclePort)GETFUNC(m_dll, "FT_CyclePort");
+			FT_GetComPortNumber = (_FT_GetComPortNumber)GETFUNC(m_dll, "FT_GetComPortNumber");
+			FT_SetUSBParameters = (_FT_SetUSBParameters)GETFUNC(m_dll, "FT_SetUSBParameters");
+			FT_SetLatencyTimer = (_FT_SetLatencyTimer)GETFUNC(m_dll, "FT_SetLatencyTimer");
+		}
+	}
+}
+
+
+void freeFTDILibrary() {
+	if (libraryLoadCounter) {
+		libraryLoadCounter--;
+		if (libraryLoadCounter == 0) {
+#ifdef WIN32
+			if (m_dll) FreeLibrary(m_dll);
+			m_dll = 0;
+#else
+			if (m_dll) dlclose(m_dll);
+			m_dll = nullptr;
+#endif
+			FT_Open = nullptr;
+			FT_OpenEx = nullptr;
+			FT_ListDevices = nullptr;
+			FT_Close = nullptr;
+			FT_Read = nullptr;
+			FT_Write = nullptr;
+			FT_IoCtl = nullptr;
+			FT_SetBaudRate = nullptr;
+			FT_SetDivisor = nullptr;
+			FT_SetDataCharacteristics = nullptr;
+			FT_SetFlowControl = nullptr;
+			FT_ResetDevice = nullptr;
+			FT_SetDtr = nullptr;
+			FT_ClrDtr = nullptr;
+			FT_SetRts = nullptr;
+			FT_ClrRts = nullptr;
+			FT_GetModemStatus = nullptr;
+			FT_SetChars = nullptr;
+			FT_Purge = nullptr;
+			FT_SetTimeouts = nullptr;
+			FT_GetQueueStatus = nullptr;
+			FT_SetEventNotification = nullptr;
+			FT_GetEventStatus = nullptr;
+			FT_GetStatus = nullptr;
+			FT_SetBreakOn = nullptr;
+			FT_SetBreakOff = nullptr;
+			FT_SetWaitMask = nullptr;
+			FT_WaitOnMask = nullptr;
+			FT_CreateDeviceInfoList = nullptr;
+			FT_GetDeviceInfoList = nullptr;
+			FT_GetDeviceInfoDetail = nullptr;
+			FT_GetDriverVersion = nullptr;
+			FT_GetLibraryVersion = nullptr;
+			FT_ResetPort = nullptr;
+			FT_CyclePort = nullptr;
+			FT_GetComPortNumber = nullptr;
+			FT_SetUSBParameters = nullptr;
+			FT_SetLatencyTimer = nullptr;
+		}
+	}
+}
+
+FTDIInterface::FTDIInterface() {
+	initFTDILibrary();
+}
+
+FTDIInterface::~FTDIInterface() {
+	FT_Close(); 
+
+	freeFTDILibrary();
+}
+
+FTDI::FT_STATUS FTDIInterface::FT_Open(int deviceNumber) {
+	FT_Close(); 
+
+	if (::FT_Open) {
+		FTDI::FT_STATUS status = ::FT_Open(deviceNumber, &m_handle);
+		if (status != FTDI::FT_STATUS::FT_OK) m_handle = 0;
+		return status;
+	}
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_OpenEx(LPVOID pArg1, DWORD Flags) { 
+	if (::FT_OpenEx) {
+		FTDI::FT_STATUS status = ::FT_OpenEx(pArg1, Flags, &m_handle);
+		if (status != FTDI::FT_STATUS::FT_OK) m_handle = 0;
+		return status;
+	}
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_ListDevices(LPVOID pArg1, LPVOID pArg2, DWORD Flags) { 
+	if (::FT_ListDevices) return ::FT_ListDevices(pArg1, pArg2, Flags);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_Close() {
+	if (::FT_Close) {
+		FTDI::FT_STATUS ret;
+		if (m_handle) ret = ::FT_Close(m_handle); else ret = FTDI::FT_STATUS::FT_OK;
+		m_handle = 0;
+		return ret;
+	}
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_Read(LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesReturned) { 
+	if ((::FT_Read) && (m_handle)) return ::FT_Read(m_handle, lpBuffer, nBufferSize, lpBytesReturned);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_Write(LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesWritten) { 
+	if ((::FT_Write) && (m_handle)) return ::FT_Write(m_handle, lpBuffer, nBufferSize, lpBytesWritten);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_IoCtl(DWORD dwIoControlCode, LPVOID lpInBuf, DWORD nInBufSize, LPVOID lpOutBuf, DWORD nOutBufSize, LPDWORD lpBytesReturned, LPOVERLAPPED lpOverlapped) { 
+	if ((::FT_IoCtl) && (m_handle)) return ::FT_IoCtl(m_handle, dwIoControlCode, lpInBuf, nInBufSize, lpOutBuf, nOutBufSize, lpBytesReturned, lpOverlapped);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetBaudRate(ULONG BaudRate) { 
+	if ((::FT_SetBaudRate) && (m_handle)) return ::FT_SetBaudRate(m_handle, BaudRate);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetDivisor(USHORT Divisor) { 
+	if ((::FT_SetDivisor) && (m_handle)) return ::FT_SetDivisor(m_handle, Divisor);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetDataCharacteristics(FT_BITS WordLength, FT_STOP_BITS StopBits, FT_PARITY Parity) {
+	if ((::FT_SetDataCharacteristics) && (m_handle)) return ::FT_SetDataCharacteristics(m_handle, (UCHAR)WordLength, (UCHAR)StopBits, (UCHAR)Parity);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetFlowControl(USHORT FlowControl, UCHAR XonChar, UCHAR XoffChar) { 
+	if ((::FT_SetFlowControl) && (m_handle)) return ::FT_SetFlowControl(m_handle, FlowControl, XonChar, XoffChar);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_ResetDevice() { 
+	if ((::FT_ResetDevice) && (m_handle)) return ::FT_ResetDevice(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetDtr() { 
+	if ((::FT_SetDtr) && (m_handle)) return ::FT_SetDtr(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_ClrDtr() { 
+	if ((::FT_ClrDtr) && (m_handle)) return ::FT_ClrDtr(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetRts() { 
+	if ((::FT_SetRts) && (m_handle)) return ::FT_SetRts(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_ClrRts() { 
+	if ((::FT_ClrRts) && (m_handle)) return ::FT_ClrRts(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetModemStatus(ULONG* pModemStatus) { 
+	if ((::FT_GetModemStatus) && (m_handle)) return ::FT_GetModemStatus(m_handle, pModemStatus);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetChars(UCHAR EventChar, UCHAR EventCharEnabled, UCHAR ErrorChar, UCHAR ErrorCharEnabled) { 
+	if ((::FT_SetChars) && (m_handle)) return ::FT_SetChars(m_handle, EventChar, EventCharEnabled, ErrorChar, ErrorCharEnabled);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_Purge(bool purgeRX, bool purgeTX) { 
+	if ((::FT_Purge) && (m_handle)) return ::FT_Purge(m_handle, (purgeRX ? FT_PURGE_RX : 0) | (purgeTX ? FT_PURGE_TX : 0));
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetTimeouts(ULONG ReadTimeout, ULONG WriteTimeout) { 
+	if ((::FT_SetTimeouts) && (m_handle)) return ::FT_SetTimeouts(m_handle, ReadTimeout, WriteTimeout);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetQueueStatus(DWORD* dwRxBytes) {
+	if ((::FT_GetQueueStatus) && (m_handle)) return ::FT_GetQueueStatus(m_handle, dwRxBytes);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetEventNotification(DWORD Mask, LPVOID Param) { 
+	if ((::FT_SetEventNotification) && (m_handle)) return ::FT_SetEventNotification(m_handle, Mask, Param);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetEventStatus(DWORD* dwEventDWord) {
+	if ((::FT_GetEventStatus) && (m_handle)) return ::FT_GetEventStatus(m_handle, dwEventDWord);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetStatus(DWORD* dwRxBytes, DWORD* dwTxBytes, DWORD* dwEventDWord) { 
+	if ((::FT_GetStatus) && (m_handle)) return ::FT_GetStatus(m_handle, dwRxBytes, dwTxBytes, dwEventDWord);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetBreakOn() { 
+	if ((::FT_SetBreakOn) && (m_handle)) return ::FT_SetBreakOn(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetBreakOff() { 
+	if ((::FT_SetBreakOff) && (m_handle)) return ::FT_SetBreakOff(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetWaitMask(DWORD Mask) { 
+	if ((::FT_SetWaitMask) && (m_handle)) return ::FT_SetWaitMask(m_handle, Mask);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_WaitOnMask(DWORD* Mask) { 
+	if ((::FT_WaitOnMask) && (m_handle)) return ::FT_WaitOnMask(m_handle, Mask);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_CreateDeviceInfoList(LPDWORD lpdwNumDevs) {
+	if (::FT_CreateDeviceInfoList) return ::FT_CreateDeviceInfoList(lpdwNumDevs);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetDeviceInfoList(FT_DEVICE_LIST_INFO_NODE* pDest, LPDWORD lpdwNumDevs) {
+	if (::FT_GetDeviceInfoList) return ::FT_GetDeviceInfoList(pDest, lpdwNumDevs);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetComPortNumber(FT_HANDLE handle, LPLONG port) {
+	if ((::FT_GetComPortNumber) && (handle)) return ::FT_GetComPortNumber(handle, port);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+}
+
+FTDI::FT_STATUS FTDIInterface::FT_GetDeviceInfoDetail(DWORD dwIndex, LPDWORD lpdwFlags, LPDWORD lpdwType, LPDWORD lpdwID, LPDWORD lpdwLocId, char* pcSerialNumber, char* pcDescription, FT_HANDLE* handle) {
+	if (::FT_GetDeviceInfoDetail) return ::FT_GetDeviceInfoDetail(dwIndex, lpdwFlags, lpdwType, lpdwID, lpdwLocId, pcSerialNumber, pcDescription, handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetDriverVersion(LPDWORD lpdwDriverVersion) {
+	if ((::FT_GetDriverVersion) && (m_handle)) return ::FT_GetDriverVersion(m_handle, lpdwDriverVersion);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_GetLibraryVersion(LPDWORD lpdwDLLVersion) {
+	if ((::FT_GetLibraryVersion) && (m_handle)) return ::FT_GetLibraryVersion(lpdwDLLVersion);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_ResetPort() {
+	if ((::FT_ResetPort) && (m_handle)) return ::FT_ResetPort(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_CyclePort() {
+	if ((::FT_CyclePort) && (m_handle)) return ::FT_CyclePort(m_handle);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+};
+
+FTDI::FT_STATUS FTDIInterface::FT_SetUSBParameters(DWORD dwInTransferSize, DWORD dwOutTransferSize) {
+	if ((::FT_SetUSBParameters) && (m_handle)) return ::FT_SetUSBParameters(m_handle, dwInTransferSize, dwOutTransferSize);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+}
+
+FTDI::FT_STATUS FTDIInterface::FT_SetLatencyTimer(UCHAR ucTimer) {
+	if ((::FT_SetLatencyTimer) && (m_handle)) return ::FT_SetLatencyTimer(m_handle, ucTimer);
+	return FTDI::FT_STATUS::FT_DRIVER_NOT_AVAILABLE;
+}
+
+#endif

--- a/vendor/floppybridge/src/ftdi.h
+++ b/vendor/floppybridge/src/ftdi.h
@@ -1,0 +1,277 @@
+/* ArduinoFloppyReader (and writer)
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+/*
+  This is a FTDI driver class, based on the FTDI2XX.h file from FTDI.
+  This library dynamically loads the DLL rather than static linking to it.
+*/
+
+#ifndef FTDI_CLASS_H
+#define FTDI_CLASS_H
+
+#define FTDI_D2XX_AVAILABLE
+
+#ifdef FTDI_D2XX_AVAILABLE
+
+namespace FTDI {	
+
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <dlfcn.h>
+#include <stdint.h>
+#ifndef DWORD
+#define DWORD uint32_t
+#endif
+#ifndef LPDWORD
+#define LPDWORD uint32_t*
+#endif
+#ifndef ULONG
+#define ULONG uint32_t
+#endif
+#ifndef LONG
+#define LONG int32_t
+#endif
+#ifndef LPLONG
+#define LPLONG int32_t*
+#endif
+#ifndef UCHAR
+#define UCHAR unsigned char
+#endif
+#ifndef USHORT
+#define USHORT uint16_t
+#endif
+#ifndef LPVOID
+#define LPVOID void*
+#endif
+#ifndef LPOVERLAPPED
+#define LPOVERLAPPED void*
+#endif
+#endif
+
+	typedef void* FT_HANDLE;
+
+	// Device status
+	enum class FT_STATUS : DWORD {
+		FT_OK = 0,
+		FT_INVALID_HANDLE = 1,
+		FT_DEVICE_NOT_FOUND = 2,
+		FT_DEVICE_NOT_OPENED = 3,
+		FT_IO_ERROR = 4,
+		FT_INSUFFICIENT_RESOURCES = 5,
+		FT_INVALID_PARAMETER = 6,
+		FT_INVALID_BAUD_RATE = 7,
+		FT_DEVICE_NOT_OPENED_FOR_ERASE = 8,
+		FT_DEVICE_NOT_OPENED_FOR_WRITE = 9,
+		FT_FAILED_TO_WRITE_DEVICE = 10,
+		FT_EEPROM_READ_FAILED = 11,
+		FT_EEPROM_WRITE_FAILED = 12,
+		FT_EEPROM_ERASE_FAILED = 13,
+		FT_EEPROM_NOT_PRESENT = 14,
+		FT_EEPROM_NOT_PROGRAMMED = 15,
+		FT_INVALID_ARGS = 16,
+		FT_NOT_SUPPORTED = 17,
+		FT_OTHER_ERROR = 18,
+		FT_DRIVER_NOT_AVAILABLE 
+	};
+
+	#define FT_SUCCESS(status) ((status) == FT_OK)
+
+	// FT_OpenEx Flags
+	enum class FT_OPENEX : UCHAR {
+		BY_SERIAL_NUMBER = 1,
+		BY_DESCRIPTION = 2,
+		BY_LOCATION = 4
+	};
+
+	// FT_ListDevices Flags (used in conjunction with FT_OpenEx Flags
+	#define FT_LIST_NUMBER_ONLY			0x80000000
+	#define FT_LIST_BY_INDEX			0x40000000
+	#define FT_LIST_ALL					0x20000000
+
+	#define FT_LIST_MASK (FT_LIST_NUMBER_ONLY|FT_LIST_BY_INDEX|FT_LIST_ALL)
+
+	// Device type
+	enum class FT_DEVICE : DWORD {		
+		_232BM = 0,
+		_232AM = 1,
+		_100AX = 2,
+		_UNKNOWN = 3,
+		_2232C = 4,
+		_232R = 5,
+		_2232H = 6,
+		_4232H = 7,
+		_232H = 8,
+		_X_SERIES = 9
+	};
+
+	// Common Baud Rates
+	#define FT_BAUD_300			300
+	#define FT_BAUD_600			600
+	#define FT_BAUD_1200		1200
+	#define FT_BAUD_2400		2400
+	#define FT_BAUD_4800		4800
+	#define FT_BAUD_9600		9600
+	#define FT_BAUD_14400		14400
+	#define FT_BAUD_19200		19200
+	#define FT_BAUD_38400		38400
+	#define FT_BAUD_57600		57600
+	#define FT_BAUD_115200		115200
+	#define FT_BAUD_230400		230400
+	#define FT_BAUD_460800		460800
+	#define FT_BAUD_921600		921600
+
+	#define FT_MODEM_STATUS_BI		0x01			// Break Interrupt
+	#define FT_MODEM_STATUS_OE		0x02			// Overrun Error
+	#define FT_MODEM_STATUS_PE		0x04			// Parity Error
+	#define FT_MODEM_STATUS_FE		0x08			// Framing Error
+	#define FT_MODEM_STATUS_CTS		0x10			// Clear to Send
+	#define FT_MODEM_STATUS_DSR		0x20			// Data Set Ready
+	#define FT_MODEM_STATUS_RI		0x40			// Ring Indicator
+	#define FT_MODEM_STATUS_DCD		0x80			// Data Carrier Detect
+
+	// Word Lengths
+	enum class FT_BITS : UCHAR {
+		_8 = 8,
+		_7 = 7,
+		_6 = 6,
+		_5 = 5
+	};
+	
+	// Stop Bits
+	enum class FT_STOP_BITS : UCHAR {
+		_1	 = 0,
+		_1_5 = 1,
+		_2	 = 2 
+	};
+
+	// Parity
+	enum class FT_PARITY : UCHAR {
+		NONE  = 0,
+		ODD   = 1,
+		EVEN  = 2,
+		MARK  = 3,
+		SPACE = 4
+	};
+
+	// Flow Control
+	#define FT_FLOW_NONE        0x0000
+	#define FT_FLOW_RTS_CTS     0x0100
+	#define FT_FLOW_DTR_DSR     0x0200
+	#define FT_FLOW_XON_XOFF    0x0400
+	
+	// Events
+	typedef void (*PFT_EVENT_HANDLER)(DWORD,DWORD);
+
+	#define FT_EVENT_RXCHAR		    1
+	#define FT_EVENT_MODEM_STATUS   2
+	#define FT_EVENT_LINE_STATUS    4
+
+	// FT_DEVICE_LIST_INFO_NODE
+	typedef struct _ft_device_list_info_node {
+		DWORD Flags;
+		DWORD Type;
+		DWORD ID;
+		DWORD LocId;
+		char SerialNumber[16];
+		char Description[64];
+		FT_HANDLE ftHandle;
+	} FT_DEVICE_LIST_INFO_NODE;
+
+	// Driver Type
+	enum class FT_DTIVER_TYPE : DWORD {
+		D2XX = 0,
+		VCP = 1
+	};
+
+	// Timeouts
+	#define FT_DEFAULT_RX_TIMEOUT   300
+	#define FT_DEFAULT_TX_TIMEOUT   300
+
+
+	class FTDIInterface {
+	private:
+		FT_HANDLE m_handle = 0;
+	public:
+
+		FTDIInterface();
+		~FTDIInterface();
+
+		// Return TRUE if the port is open
+		bool isOpen() const { return m_handle != 0; };
+
+		FT_STATUS FT_Open(int deviceNumber);
+		FT_STATUS FT_OpenEx(LPVOID pArg1, DWORD Flags);
+
+		FT_STATUS FT_ListDevices(LPVOID pArg1, LPVOID pArg2, DWORD Flags);
+
+		FT_STATUS FT_Close();
+
+		FT_STATUS FT_Read(LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesReturned);
+		FT_STATUS FT_Write(LPVOID lpBuffer, DWORD nBufferSize, LPDWORD lpBytesWritten);
+
+		FT_STATUS FT_IoCtl(DWORD dwIoControlCode, LPVOID lpInBuf, DWORD nInBufSize, LPVOID lpOutBuf, DWORD nOutBufSize, LPDWORD lpBytesReturned, LPOVERLAPPED lpOverlapped);
+
+		FT_STATUS FT_SetBaudRate(ULONG BaudRate);
+		FT_STATUS FT_SetDivisor(USHORT Divisor);
+		FT_STATUS FT_SetTimeouts(ULONG ReadTimeout, ULONG WriteTimeout);
+
+		FT_STATUS FT_SetDataCharacteristics(FT_BITS WordLength, FT_STOP_BITS StopBits, FT_PARITY Parity);
+		FT_STATUS FT_SetFlowControl(USHORT FlowControl, UCHAR XonChar, UCHAR XoffChar);
+
+		FT_STATUS FT_ResetDevice();
+		FT_STATUS FT_GetQueueStatus(DWORD* dwRxBytes);
+
+		FT_STATUS FT_SetDtr();
+		FT_STATUS FT_ClrDtr();
+		FT_STATUS FT_SetRts();
+		FT_STATUS FT_ClrRts();
+
+		FT_STATUS FT_GetModemStatus(ULONG* pModemStatus);
+
+		FT_STATUS FT_SetChars(UCHAR EventChar, UCHAR EventCharEnabled, UCHAR ErrorChar, UCHAR ErrorCharEnabled);
+
+		FT_STATUS FT_Purge(bool purgeRX, bool purgeTX);
+
+
+		FT_STATUS FT_SetEventNotification(DWORD Mask,LPVOID Param);
+		FT_STATUS FT_GetEventStatus(DWORD* dwEventDWord);
+		FT_STATUS FT_GetStatus(DWORD* dwRxBytes, DWORD* dwTxBytes, DWORD* dwEventDWord);
+
+		FT_STATUS FT_SetBreakOn();
+		FT_STATUS FT_SetBreakOff();
+
+		FT_STATUS FT_SetWaitMask(DWORD Mask);
+		FT_STATUS FT_WaitOnMask(DWORD* Mask);
+
+		FT_STATUS FT_CreateDeviceInfoList(LPDWORD lpdwNumDevs);
+		FT_STATUS FT_GetDeviceInfoList(FT_DEVICE_LIST_INFO_NODE* pDest, LPDWORD lpdwNumDevs);
+		FT_STATUS FT_GetDeviceInfoDetail(DWORD dwIndex, LPDWORD lpdwFlags, LPDWORD lpdwType, LPDWORD lpdwID, LPDWORD lpdwLocId, char* pcSerialNumber, char* pcDescription, FT_HANDLE* handle);
+		FT_STATUS FT_GetDriverVersion(LPDWORD lpdwDriverVersion);
+		FT_STATUS FT_GetLibraryVersion(LPDWORD lpdwDLLVersion);
+		FT_STATUS FT_ResetPort();
+		FT_STATUS FT_CyclePort();
+		FT_STATUS FT_GetComPortNumber(FT_HANDLE handle, LPLONG port);
+		FT_STATUS FT_SetUSBParameters(DWORD dwInTransferSize, DWORD dwOutTransferSize);
+		FT_STATUS FT_SetLatencyTimer(UCHAR ucTimer);
+	};
+};
+
+#endif
+#endif

--- a/vendor/floppybridge/src/pll.cpp
+++ b/vendor/floppybridge/src/pll.cpp
@@ -1,0 +1,195 @@
+/* Dynamic PLL for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+/*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+// This is an improved PLL designed, which is more like a real drive.
+// This is roughly based on PLL design in scp.cpp (UAE) by Keir Fraser
+// This also can record the data supplied and re-play it with a small amount
+// of jitter.  This allows more than revolution of data to be instantly available
+// which may help with unformatted areas and weak-bits, although I have switched it
+// off as its quite experimental
+
+
+
+#include "pll.h"
+
+using namespace PLL;
+
+#define CLOCK_CENTRE  2000   /* 2000ns = 2us */
+#define CLOCK_MAX_ADJ 10     /* +/- 10% adjustment */
+#define CLOCK_MIN ((CLOCK_CENTRE * (100 - CLOCK_MAX_ADJ)) / 100)
+#define CLOCK_MAX ((CLOCK_CENTRE * (100 + CLOCK_MAX_ADJ)) / 100)
+
+// Constructor
+BridgePLL::BridgePLL(bool enabled, bool enableReplay) : m_enabled(enabled)
+#ifdef ENABLE_REPLY
+, m_useReplay(enableReplay)
+#endif 
+{
+    reset();
+}
+
+// Reset the PLL
+void BridgePLL::reset() {
+    m_clock = CLOCK_CENTRE;
+    m_nFluxSoFar = 0; 
+    m_indexFound = false;
+    m_latency = 0;
+    m_totalRealFlux = 0;
+    m_prevLatency = 0;
+#ifdef ENABLE_REPLY
+    m_fluxReplayData.clear();
+#endif
+}
+
+// Prepare this to be used, by preparing the rotation extractor
+void BridgePLL::prepareExtractor(bool isHD, const RotationExtractor::IndexSequenceMarker& indexSequence) {
+#ifdef ENABLE_REPLY
+    m_fluxReplayData.clear();
+#endif
+    m_extractor->reset(isHD);
+    m_extractor->setIndexSequence(indexSequence);
+}
+
+// Re-plays the data back into the rotation extractor
+void BridgePLL::rePlayData(const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+        std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation) {
+#ifdef ENABLE_REPLY
+    if (!m_useReplay) return;
+    m_useReplay = false;
+
+    m_clock = CLOCK_CENTRE;
+    m_nFluxSoFar = 0;
+    m_indexFound = false;
+    m_latency = 0;
+    m_totalRealFlux = 0;
+    m_prevLatency = 0;
+
+    m_extractor->reset(m_extractor->isHD());
+    m_extractor->setIndexSequence(indexMarker);
+
+    for (const ReplayData& data : m_fluxReplayData) {
+
+        if (data.fluxTime>250) 
+            submitFlux(data.fluxTime + (rand() % 100) - 50, data.isIndex);
+        else submitFlux(data.fluxTime, data.isIndex);
+
+        // Is it ready to extract?
+        if (canExtract()) {
+            unsigned int bits = 0;
+            // Go!
+            if (extractRotation(buffer, bits, maxBufferSize)) {
+                if (!onRotation(buffer, bits)) {
+                    // And if the callback says so we stop.                    
+                    break;
+                }
+            }
+        }        
+    }
+    m_useReplay = true;
+#endif
+}
+
+// Submit flux to the PLL
+void BridgePLL::submitFlux(uint32_t timeInNanoSeconds, bool isAtIndex) {
+#ifdef ENABLE_REPLY
+    if (m_useReplay) {
+        m_fluxReplayData.push_back({ (uint32_t)timeInNanoSeconds, isAtIndex });
+    }
+#endif
+
+    m_indexFound |= isAtIndex;
+
+    // Add on the next flux
+    m_nFluxSoFar += (int32_t)timeInNanoSeconds;
+    m_totalRealFlux += timeInNanoSeconds;
+    if (m_nFluxSoFar < (m_clock / 2)) return;
+
+    // Work out how many zeros, and remaining flux
+    const int clockedZeros = (m_nFluxSoFar - (m_clock / 2)) / m_clock;
+    m_nFluxSoFar -= ((clockedZeros + 1) * m_clock);
+    
+    if (m_enabled) {
+        m_latency += ((clockedZeros + 1) * m_clock);
+
+        // PLL: Adjust clock frequency according to phase mismatch.
+        if ((clockedZeros >= 1) && (clockedZeros <= 3)) {
+            // In sync: adjust base clock by 10% of phase mismatch.
+            m_clock += (m_nFluxSoFar / (int)(clockedZeros + 1)) / 10;
+        }
+        else {
+            // Out of sync: adjust base clock towards centre.
+            m_clock += (CLOCK_CENTRE - m_clock) / 10;
+        }
+
+        // Clamp the clock's adjustment range.
+        m_clock = std::max(CLOCK_MIN, std::min(CLOCK_MAX, m_clock));
+
+        // Authentic PLL: Do not snap the timing window to each flux transition.
+        const uint32_t new_flux = m_nFluxSoFar / 2;
+        m_latency += m_nFluxSoFar - new_flux;
+        m_nFluxSoFar = new_flux;
+        // This actually works ok if m_totalRealFlux is used instead of m_latency - m_prevLatency but we'll leave it there for good measure
+        addToExtractor(clockedZeros, m_latency - m_prevLatency, m_totalRealFlux);
+        m_prevLatency = m_latency;
+    }
+    else {
+        m_nFluxSoFar = 0;
+        // This actually works ok if m_totalRealFlux is used instead of m_latency - m_prevLatency but we'll leave it there for good measure
+        addToExtractor(clockedZeros, m_totalRealFlux, m_totalRealFlux);
+    }
+
+    m_totalRealFlux = 0;
+}
+
+// Add data to the Rotation Extractor
+void BridgePLL::addToExtractor(unsigned int numZeros, unsigned int pllTimeInNS, unsigned int realTimeInNS) {
+    if (numZeros < 0) numZeros = 0;
+
+    // More than 3 zeros.  This is not normal MFM, but is allowed
+    if (numZeros >= 4) {
+        unsigned int realTimePerBitcell = realTimeInNS / (numZeros + 1);
+        unsigned int pllTimePerBitcell = pllTimeInNS / (numZeros + 1);
+
+        // Based on the rules we can't output a sequence this big and times must be accurate so we output as many 000's as possible
+        while (numZeros > 3) {
+            RotationExtractor::MFMSequenceInfo sample;
+            sample.mfm = RotationExtractor::MFMSequence::mfm000;
+            sample.timeNS = realTimePerBitcell * 3;
+            sample.pllTimeNS = pllTimePerBitcell * 3;
+            realTimeInNS -= sample.timeNS;
+            pllTimeInNS -= sample.pllTimeNS;
+            m_extractor->submitSequence(sample, m_indexFound);
+            m_indexFound = false;
+            numZeros -= 3;
+        }
+    }
+
+    RotationExtractor::MFMSequenceInfo sample;
+    sample.mfm = (RotationExtractor::MFMSequence)numZeros;
+    sample.timeNS = realTimeInNS;
+    sample.pllTimeNS = pllTimeInNS;
+
+    m_extractor->submitSequence(sample, m_indexFound);
+    m_indexFound = false;
+}

--- a/vendor/floppybridge/src/pll.h
+++ b/vendor/floppybridge/src/pll.h
@@ -1,0 +1,114 @@
+#ifndef FLOPPYBRIDGE_PLL
+#define FLOPPYBRIDGE_PLL
+/* Dynamic PLL for *UAE
+*
+* Copyright (C) 2021-2024 Robert Smith (@RobSmithDev)
+* https://amiga.robsmithdev.co.uk
+*
+* This file is multi-licensed under the terms of the Mozilla Public
+* License Version 2.0 as published by Mozilla Corporation and the
+* GNU General Public License, version 2 or later, as published by the
+* Free Software Foundation.
+*
+* MPL2: https://www.mozilla.org/en-US/MPL/2.0/
+* GPL2: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+/*
+* This file, along with currently active and supported interfaces
+* are maintained from by GitHub repo at
+* https://github.com/RobSmithDev/FloppyDriveBridge
+*/
+
+// This is an improved PLL designed, which is more like a real drive.
+// This is roughly based on PLL design in scp.cpp (UAE) by Keir Fraser
+// This also can record the data supplied and re-play it with a small amount
+// of jitter.  This allows more than revolution of data to be instantly available
+// which may help with unformatted areas and weak-bits, although I have switched it
+// off as its quite experimental
+
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+#include <stdint.h>
+#include "RotationExtractor.h"
+#include <queue>
+#include <functional>
+
+
+
+namespace PLL {
+
+	class BridgePLL {
+	private:
+#ifdef ENABLE_REPLY
+		struct ReplayData {
+			uint32_t fluxTime;
+			bool isIndex;
+		};
+#endif
+		const bool m_enabled;
+
+		// Rotation extractor
+		MFMExtractionTarget* m_extractor = nullptr;
+
+		// Clock
+		int32_t m_clock = 0;
+		int32_t m_latency = 0;
+		int32_t m_prevLatency = 0;
+		int32_t m_totalRealFlux = 0;
+
+		// Current flux total in nanoseconds
+		int32_t m_nFluxSoFar = 0;
+
+#ifdef ENABLE_REPLY
+		// If re-play is enabled
+		bool m_useReplay;
+
+		// For storing all flux data so far for "reply with jitter"
+		std::vector<ReplayData> m_fluxReplayData;
+#endif
+		// If the index was discovered
+		bool m_indexFound = false;
+
+		// Add data to the Rotation Extractor
+		void addToExtractor(unsigned int numZeros, unsigned int pllTimeInNS, unsigned int realTimeInNS);
+
+	public:
+		// Make me - if disabled this behaves very basic which might be useful for extraction of flux to SCP
+		BridgePLL(bool enabled, bool enableReplay);
+
+		// Submit flux to the PLL
+		void submitFlux(uint32_t timeInNanoSeconds, bool isAtIndex);
+
+		// Reset the PLL
+		void reset();
+
+		// Prepare this to be used, by preparing the rotation extractor
+		void prepareExtractor(bool isHD, const RotationExtractor::IndexSequenceMarker& indexSequence);
+
+		// Change the rotation extractor
+		void setRotationExtractor(MFMExtractionTarget* extractor) { m_extractor = extractor; }
+
+		// Re-plays the data back into the rotation extractor but with (random) +/- 64ns of jitter
+		void rePlayData(const unsigned int maxBufferSize, RotationExtractor::MFMSample* buffer, RotationExtractor::IndexSequenceMarker& indexMarker,
+			std::function<bool(RotationExtractor::MFMSample* mfmData, const unsigned int dataLengthInBits)> onRotation);
+
+		// Return the active rotation extractor
+		MFMExtractionTarget* rotationExtractor() { return m_extractor; }
+
+		// Pass on some functions from the extractor
+		bool canExtract() { return m_extractor->canExtract(); }
+		bool extractRotation(RotationExtractor::MFMSample* output, unsigned int& outputBits, const unsigned int maxBufferSizeBytes, const bool usePLLTime = false) { return m_extractor->extractRotation(output, outputBits, maxBufferSizeBytes, usePLLTime); }
+		void getIndexSequence(RotationExtractor::IndexSequenceMarker& sequence) const { m_extractor->getIndexSequence(sequence); }
+		unsigned int totalTimeReceived() const { return m_extractor->totalTimeReceived(); }
+	};
+};
+
+
+#endif

--- a/vendor/floppybridge/src/resource.h
+++ b/vendor/floppybridge/src/resource.h
@@ -1,0 +1,47 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by Resource.rc
+//
+#define IDB_BRIDGELOGO0                 101
+#define IDB_BRIDGELOGO1                 102
+#define IDB_BRIDGELOGO2                 103
+#define IDD_PROFILEEDITOR               104
+#define IDD_PROFILELISTEDITOR           109
+#define IDB_DONATE                      110
+#define IDB_SMALLLOGO0                  111
+#define IDB_SMALLLOGO1                  112
+#define IDB_SMALLLOGO3                  113
+#define IDB_SMALLLOGO2                  113
+#define IDC_LIST1                       1001
+#define IDCREATE                        1004
+#define IDC_PROFILENAME                 1004
+#define IDEDIT                          1005
+#define IDC_DRIVER                      1005
+#define IDDELETE                        1006
+#define IDC_MODE                        1006
+#define IDCREATE2                       1007
+#define IDC_DISKTYPE                    1007
+#define IDC_SMART                       1008
+#define IDC_CABLE                       1009
+#define IDC_COMPORT                     1010
+#define IDC_AUTOCACHE                   1011
+#define IDC_URL                         1012
+#define IDC_AUTODETECT                  1013
+#define IDC_URL_MAIN                    1014
+#define IDC_AUTOCHECK                   1015
+#define IDC_URL2                        1015
+#define IDC_UPDATENOW                   1016
+#define IDC_DONATE                      1017
+#define IDC_PROFILELIST_TITLE           1200
+#define IDC_CHECKUPDATES                1202
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        114
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1018
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif


### PR DESCRIPTION
# Physical floppy drives: read and write real Amiga disks

Any of Copperline's four floppy bays can drive a physical 3.5" drive instead of a disk image, reading and writing real Amiga floppies over a DrawBridge, a Greaseweazle, or a Supercard Pro. Rob Smith's [FloppyBridge](https://amiga.robsmithdev.co.uk/winuae) talks to the hardware, and is vendored and compiled in, so `cargo build --release` produces a binary that drives a real drive.

The emulated machine is unchanged. The bridge only supplies the MFM the head would be passing over, so Paula, the disk DMA and `trackdisk.device` behave exactly as they do with an ADF.

## Using it

Each drive on the launcher's Floppy tab has a **Physical drive** tick box. Tick it and the media row names the interface — or `None` with nothing plugged in — with a **Configure** button leading to that drive's page for serial port, drive select, density, read mode, smart speed and read ahead. Options the chosen interface does not implement are greyed, as the driver itself reports them.

Every setting is available three ways — launcher, config file, and command line:

```toml
[floppy.df0]
bridge = "greaseweazle"      # drawbridge/greaseweazle/supercardpro/off
write_protected = true       # emulator-level protection; default true
# bridge_mode = "normal"         # normal/compatible/stalling
# bridge_port = "/dev/ttyACM0"   # omit to auto-detect
# bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
# bridge_density = "auto"        # auto/dd/hd
```

```sh
copperline --model A500 --floppy-bridge df0 greaseweazle kickstart.rom
```

plus `--floppy-bridge-port`, `--floppy-bridge-cable`, `--floppy-bridge-mode`, `--floppy-bridge-density`, `--floppy-bridge-smart-speed`, `--floppy-bridge-read-ahead` and `--floppy-bridge-writable`. A bay takes either a bridge or an image, never both.

`normal` is the default; `compatible` captures from the index, for a disk that reads badly without it; `stalling` blocks the emulated machine until each track is ready.

## Write protection

Double protection, both have to be open before anything reaches the platter: the disk's own write-protect tab, and `write_protected` in the config, which defaults to `true` as it does for an image. Both are enforced where the write would happen rather than merely reported through the drive's /WPRO line, and both come from the same reading the line is built from, so a disk the machine calls protected can never be the one being written.

## What behaves differently

- **No eject or swap** — the disk is in a real drive, changed by hand. A disk going in or coming out raises the change line.
- **No synthesized drive sounds** for that bay; the real drive makes its own.
- **Wall-clock pacing** — the platter cannot be hurried, so even a headless run is paced like an Amiga.
- **Not reproducible** — save states cannot capture the medium and input recordings will not line up. The core is as deterministic as ever; the disk under it is not.

## Vendor packaging 

Upstream ships FloppyBridge as a shared library to load at run time. Copperline links it from `vendor/floppybridge` instead. `vendor/floppybridge/README.md` records the commit vendored (`710fa15c`, reporting itself as 1.6), the licences (MPL-2.0 or GPL-2.0-or-later, both compatible with GPL-3), and every local change. `build.rs` compiles twelve sources with `cc`.

Turning the `floppybridge` feature off removes all of it rather than leaving it inert: no tick box, no `--floppy-bridge` flags in `--help` or the parser, and a config file's `bridge` keys are read and ignored so the same file stays valid across builds.

## Local changes to the vendored sources

Both are build or platform differences, not behaviour. Each is marked `COPPERLINE:` in the source and listed in the vendor README.

**Windows.** Upstream builds from a Visual Studio project that sets `NOMINMAX` and `CharacterSet: Unicode`; `cc` sets neither. Both now come from `build.rs`, and the calls that only exist under `UNICODE` are named explicitly — seven `L""` literals reaching TCHAR-generic calls, plus `SetupDiGetDeviceProperty`, which has no ANSI variant at all. The WinUAE config dialogs and a DnsQuery update check are excluded behind `FLOPPYBRIDGE_NO_GUI`, so the build needs no resource compiler. Amiberry cuts the same seam.

**Linux — likely an upstream bug.** Opening a tty blocks until carrier detect is asserted unless `CLOCAL` is already set, and the sources set `CLOCAL` immediately *after* opening. A USB CDC interface that never raises DCD — a Greaseweazle among them — hangs in `open()` forever. Upstream sidesteps this on macOS by passing `O_NDELAY` and nowhere else, which is why it only appears on Linux. Confirmed by `stty -F /dev/ttyACM0 clocal`, which turns the hang into a normal handshake. Worth reporting upstream; it appears to be latent in Amiberry's vendored copy too but would need to test. 

## Testing

Verified against real hardware (the best that I can) — a Greaseweazle V4.1 and a Workbench 1.3 disk — on macOS throughout, and on Windows 11 on ARM. Reads were A/B tested against the same disk as an ADF. A hardware probe test decodes the captured MFM and asserts eleven AmigaDOS sector headers in order, so the stream crossing the FFI is provably the disk's. A second probe reports the drive's status lines with the motor stopped and running:

```sh
cargo test --release floppybridge_status_probe -- --ignored --nocapture
```

Both feature configurations build and test clean, with clippy and rustfmt clean in each.

## Still to be tested

**Linux.** On the only Linux machine available — Ubuntu 24.04 in a Parallels VM on Apple silicon — the Greaseweazle works for one session and then refuses to talk until physically replugged. This is not Copperline's doing: the vendor's own `gw info` reproduces it identically with Copperline never involved, no software reset recovers it, and `dmesg` fills with `xhci_hcd ... Event dma ... not part of TD`. The same board is fine natively on macOS and under the same hypervisor on Windows. It wants confirming on real Linux hardware before Linux is called done.

**Other interfaces.** Only a Greaseweazle has been on the end of this. DrawBridge and Supercard Pro are wired up and their driver-reported capabilities drive the UI, but neither has been exercised against real hardware.

<img width="717" height="614" alt="Screenshot 2026-07-29 at 00 33 34" src="https://github.com/user-attachments/assets/3c4c9853-2ea4-4c95-9a48-82a11ef97a87" />
<img width="722" height="618" alt="Screenshot 2026-07-29 at 00 33 45" src="https://github.com/user-attachments/assets/55e471e9-2eb5-4dcb-b5a4-9ccd14c73e75" />
<img width="717" height="618" alt="Screenshot 2026-07-29 at 00 33 57" src="https://github.com/user-attachments/assets/cde014b2-abf2-4cf2-9e1f-e6dde030a226" />

