### PR TITLE
video: bezel Copperline badge and two-level status-panel power LED

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -680,12 +680,13 @@ impl WebEmu {
             .map_err(js_err)
     }
 
-    /// Power LED: true while Paula's analogue filter is engaged (CIA-A's /LED
-    /// output), which the desktop status bar shows as the PWR LED brightness.
-    /// The front-panel getters below are cheap enough to poll once per
-    /// animation frame.
+    /// Power LED brightness: true while the guest holds CIA-A's /LED line
+    /// engaged (full brightness, Paula's filter on), false once it releases
+    /// it -- the page then shows the dimmed A500 rev 6+ level, never an
+    /// unlit LED, as a running machine is always powered. The front-panel
+    /// getters below are cheap enough to poll once per animation frame.
     pub fn power_led(&self) -> bool {
-        self.emu.bus().front_panel_status().audio_filter_on
+        self.emu.bus().front_panel_status().power_led_bright
     }
 
     /// Floppy activity LED: lit while any drive's motor runs.

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -2767,7 +2767,10 @@ tintSel.addEventListener('change', () => setTintMode(tintSel.value, true));
 
 // The desktop status bar's LED and track-counter palette (window.rs).
 const LED_COLORS = {
-  pwr: ['rgb(232,31,24)', 'rgb(66,12,10)'],
+  // PWR is never dark on a running machine: the pair is the bright
+  // (/LED engaged) and dimmed (released) levels of an A500 rev 6+
+  // board, which dims the LED rather than switching it off.
+  pwr: ['rgb(255,38,28)', 'rgb(150,24,18)'],
   fdd: ['rgb(236,142,28)', 'rgb(72,38,10)'],
   hdd: ['rgb(44,200,80)', 'rgb(14,56,24)'],
   cd: ['rgb(64,170,234)', 'rgb(16,46,70)'],

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -149,7 +149,10 @@ goes, and the same letterbox applies.
 Once a machine boots, a status strip appears below the screen with the
 same front-panel readouts as the desktop [status bar](ui.md): the PWR and
 FDD LEDs (plus HDD/CD on machines fitted with those drives), the floppy
-track counter, and the name of the disk in each connected drive.
+track counter, and the name of the disk in each connected drive. The PWR
+LED shows the desktop bar's two lit levels -- bright with the guest's
+/LED line engaged, dimmed when released -- and is never dark, as a
+running machine is always powered.
 
 What the page has to say -- a screenshot copied, a state saved, a disk
 inserted, something refused -- appears as a caption across the bottom of

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -758,9 +758,11 @@ LED. `"auto"` (the default) lets the guest engage or bypass it as the
 software asks, matching real hardware; `"on"` and `"off"` force it either
 way as a listener override. Unlike the host-output settings above it is
 part of the emulated audio path, so it also affects WAV capture. Also on
-`--audio-filter`, the runtime **Audio Filter** menu item, and Cmd/Alt+A;
-the status-bar PWR LED is lit whenever the machine is powered and burns
-brighter while the filter is engaged.
+`--audio-filter`, the runtime **Audio Filter** menu item, and Cmd/Alt+A.
+The status-bar PWR LED is lit whenever the machine is powered and follows
+the guest's /LED line itself -- full brightness while engaged, dimmed like
+an A500 rev 6+ board while released -- so this override changes what you
+hear, never the LED.
 
 On Linux with PipeWire/PulseAudio, individual sinks are not ALSA devices, so
 only the `default`/`pipewire` route is offered; pick the output in the desktop

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -563,8 +563,9 @@ structure to reproduce.
 `bezel` (default `false`) frames the window's picture with a monitor-style
 front bezel, also in the spirit of the 1084: the picture scales down into
 the rounded opening of a procedurally drawn plastic face -- warm-grey
-moulding, a dark recess around the tube face, rounded case corners and the
-power LED on the wider bottom band. The frame is drawn at the window's
+moulding, a dark recess around the tube face, rounded case corners, and the
+wider bottom band carrying the power LED and a printed Copperline logotype
+in the spot the 1084 kept its Commodore badge. The frame is drawn at the window's
 resolution, so it stays sharp at any size, and the picture keeps its aspect
 inside the opening. It is independent of `shader` and composes with any
 preset: with `"crt"` the bowed tube face sits inside the opening for the

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -64,9 +64,12 @@ menu item):
   or plays CD audio (on a machine whose CD drive is a SCSI CD-ROM unit,
   the LED shows CD-DA playback; its data reads ride the HDD LED with the
   rest of the SCSI bus). A small digital counter shows the current floppy
-  track. The PWR LED is lit whenever the machine is powered and burns
-  brighter while Paula's analogue filter is engaged, as the real /LED line
-  drives it (see the **Audio Filter** menu item).
+  track. The PWR LED is lit whenever the machine is powered, driven by the
+  guest's /LED line the way it drives the LED on an A500 rev 6 or later
+  board: full brightness while the line is engaged (Paula's analogue
+  filter on), dimmed -- not extinguished -- once the software releases it.
+  It follows the pin itself, so the **Audio Filter** menu override changes
+  what you hear, never the LED.
 - **Per-drive floppy controls.** Every connected drive gets a disk button
   (marked with the drive number) that opens a file dialog -- multi-select
   several images to queue a swap playlist for that drive -- plus a swap
@@ -152,7 +155,8 @@ tool window or overlay.
 - **Audio Filter** (also `Cmd+A` / `Alt+A`): cycles Paula's analogue
   low-pass filter through **auto** (guest-driven, the default), **on**, and
   **off**. `on`/`off` force it regardless of what the software asks; `auto`
-  restores hardware behaviour. The PWR LED brightens while it is engaged.
+  restores hardware behaviour. The PWR LED keeps following the guest's
+  /LED line whatever is forced here.
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Joystick Input** (also `Cmd+J` / `Alt+J`, or the status-bar icon):
   toggles between gamepad-only and keyboard joystick emulation.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1701,10 +1701,12 @@ impl BusAccounting {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrontPanelStatus {
-    /// The Paula analogue low-pass filter is engaged. The PWR LED is lit
-    /// whenever the machine is powered; it burns brighter when this is set, as
-    /// the real /LED line does.
-    pub audio_filter_on: bool,
+    /// The guest holds CIA-A's /LED line engaged: the PWR LED burns at
+    /// full brightness, dimmed -- not extinguished -- when released, as
+    /// on an A500 rev 6 or later board. The raw pin state, not the
+    /// effective audio filter: the user's filter override changes the
+    /// mix, never the LED.
+    pub power_led_bright: bool,
     pub fdd_led_on: bool,
     pub fdd_track: Option<u8>,
     /// HDD activity LED: None on machines without an IDE port (no Gayle),
@@ -1719,7 +1721,7 @@ pub struct FrontPanelStatus {
 impl Default for FrontPanelStatus {
     fn default() -> Self {
         Self {
-            audio_filter_on: false,
+            power_led_bright: true,
             fdd_led_on: false,
             fdd_track: None,
             hdd_led: None,
@@ -3699,7 +3701,7 @@ impl Bus {
 
     pub fn front_panel_status(&self) -> FrontPanelStatus {
         FrontPanelStatus {
-            audio_filter_on: self.paula.led_filter_enabled(),
+            power_led_bright: self.paula.led_filter_guest_on(),
             fdd_led_on: self.floppy.activity_led_on(),
             fdd_track: self.floppy.selected_track(),
             hdd_led: (self.gayle.is_some()

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -9217,21 +9217,43 @@ fn bltpri_line_blit_bresenham_cycles_stay_cpu_available_after_warmup() {
 #[test]
 fn front_panel_power_led_follows_cia_a_led_bit() {
     let mut bus = empty_bus();
-    // Filter engaged at power-on (the default /LED state).
-    assert!(bus.front_panel_status().audio_filter_on);
+    // /LED engaged at power-on: the LED starts at full brightness.
+    assert!(bus.front_panel_status().power_led_bright);
 
     // Drive PA1 (/LED) as an output, as the OS does, so the written level
-    // reaches the pin the filter follows.
+    // reaches the pin the LED and the filter follow.
     let ddra = (REG_DDRA as u64) << 8;
     let _ = bus.cia_a_write(ddra, 1, 0x02);
 
     let pra = (REG_PRA as u64) << 8;
-    // Bit 1 high = /LED released = filter bypassed.
+    // Bit 1 high = /LED released = LED dimmed, filter bypassed.
     let _ = bus.cia_a_write(pra, 1, 0x02);
-    assert!(!bus.front_panel_status().audio_filter_on);
-    // Bit 1 low = /LED asserted = filter engaged.
+    assert!(!bus.front_panel_status().power_led_bright);
+    // Bit 1 low = /LED asserted = LED bright, filter engaged.
     let _ = bus.cia_a_write(pra, 1, 0x00);
-    assert!(bus.front_panel_status().audio_filter_on);
+    assert!(bus.front_panel_status().power_led_bright);
+}
+
+#[test]
+fn front_panel_power_led_ignores_the_host_filter_override() {
+    use crate::config::AudioFilterMode;
+    let mut bus = empty_bus();
+    let ddra = (REG_DDRA as u64) << 8;
+    let pra = (REG_PRA as u64) << 8;
+    let _ = bus.cia_a_write(ddra, 1, 0x02);
+    let _ = bus.cia_a_write(pra, 1, 0x02); // /LED released: LED dimmed
+
+    // Forcing the filter on is a host mix preference; the LED stays on
+    // the pin, dimmed, while the effective filter engages.
+    bus.paula.set_led_filter_mode(AudioFilterMode::On);
+    assert!(bus.paula.led_filter_enabled());
+    assert!(!bus.front_panel_status().power_led_bright);
+
+    // And forcing it off never dims a bright LED.
+    let _ = bus.cia_a_write(pra, 1, 0x00); // /LED engaged
+    bus.paula.set_led_filter_mode(AudioFilterMode::Off);
+    assert!(!bus.paula.led_filter_enabled());
+    assert!(bus.front_panel_status().power_led_bright);
 }
 
 #[test]
@@ -9252,12 +9274,14 @@ fn a1000_led_line_does_not_switch_the_audio_filter() {
     assert!(normal.paula.led_filter_enabled());
 
     // The A1000 (identified by its WCS) lacks that circuit: its fixed
-    // filter stays engaged no matter what the LED line does.
+    // filter stays engaged no matter what the LED line does, and its
+    // power LED -- fed straight from the supply -- stays bright.
     let mut a1000 = empty_bus();
     a1000.mem.wcs = vec![0u8; crate::memory::WCS_SIZE];
     let _ = a1000.cia_a_write(ddra, 1, 0x03);
     let _ = a1000.cia_a_write(pra, 1, 0x03); // /LED high: no effect on the filter
     assert!(a1000.paula.led_filter_enabled());
+    assert!(a1000.front_panel_status().power_led_bright);
 }
 
 #[test]

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -681,6 +681,13 @@ impl Paula {
         self.led_filter_enabled
     }
 
+    /// The guest's /LED line itself (CIA-A PRA bit 1: true = engaged).
+    /// What the machine's power LED shows: the user's filter override
+    /// changes the mix, not the pin.
+    pub fn led_filter_guest_on(&self) -> bool {
+        self.led_filter_guest_on
+    }
+
     pub fn set_output_volume_percent(&mut self, percent: u8) {
         self.output_volume = f32::from(percent.min(100)) / 100.0;
     }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -299,12 +299,15 @@ const STATUS_TOP: u32 = rgba(78, 76, 70);
 const STATUS_BOTTOM: u32 = rgba(12, 12, 11);
 const LED_BEZEL_DARK: u32 = rgba(8, 8, 7);
 const LED_BEZEL_LIGHT: u32 = rgba(78, 76, 68);
-// The power LED is lit whenever the machine is powered. POWER_LED_NORMAL is the
-// resting lit red (the filter bypassed, its usual state); it burns to a more
-// intense POWER_LED_BRIGHT while Paula's analogue filter is engaged, as the real
-// /LED line drives it. POWER_LED_OFF is the unpowered bezel.
+// The power LED is lit whenever the machine is powered, driven by CIA-A's
+// /LED line the way it drives the LED on an A500 rev 6 or later board:
+// POWER_LED_BRIGHT while the guest holds /LED engaged (Paula's filter on),
+// falling to the clearly dimmer -- but still lit -- POWER_LED_DIM once it
+// releases the line. Earlier boards extinguished the LED instead; the
+// panel models the common two-level behaviour. POWER_LED_OFF is the
+// unpowered bezel.
 const POWER_LED_BRIGHT: u32 = rgba(255, 38, 28);
-const POWER_LED_NORMAL: u32 = rgba(232, 31, 24);
+const POWER_LED_DIM: u32 = rgba(150, 24, 18);
 const POWER_LED_OFF: u32 = rgba(66, 12, 10);
 const FDD_LED_ON: u32 = rgba(236, 142, 28);
 const FDD_LED_OFF: u32 = rgba(72, 38, 10);

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -332,8 +332,9 @@ mod tests {
     const GREY: u8 = 128;
     /// Magnification of the render target over the source, as a real
     /// window magnifies the composited buffer. Big enough that the frame's
-    /// trim zones (recess, bevel, plastic band) are pixels wide.
-    const SCALE: u32 = 4;
+    /// trim zones (recess, bevel, plastic band) are pixels wide and the
+    /// bottom band is deep enough for the badge lettering to draw.
+    const SCALE: u32 = 6;
     const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
     /// Target clear colour; pure blue survives the sRGB encode exactly,
     /// so any surviving sentinel pixel inside the viewport means the pass
@@ -664,6 +665,55 @@ mod tests {
             })
         });
         assert!(found, "no green power LED near ({led_x}, {led_y})");
+    }
+
+    #[test]
+    fn the_badge_prints_on_the_left_of_the_bottom_band() {
+        let Some((device, queue)) = gpu() else {
+            eprintln!("skipping: no GPU adapter");
+            return;
+        };
+        let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
+        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(&device, &queue, &src, None);
+
+        // The badge rect as the shader lays it out: left-aligned with the
+        // opening, vertically centred in the bottom band, 59x8 font pixels
+        // at 0.34 of the band height.
+        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        let recess = (0.016 * ow.min(oh)).max(2.0);
+        let band_top = oy + oh + recess;
+        let badge_h = 0.34 * (rows as f32 - band_top);
+        assert!(
+            badge_h >= 5.0,
+            "test target too small for the badge lettering: {badge_h}"
+        );
+        let badge_w = 59.0 * badge_h / 8.0;
+        let band_mid = (band_top + rows as f32) * 0.5;
+        let dark = |x0: u32, x1: u32| {
+            let mut n = 0;
+            for y in (band_mid - 0.5 * badge_h) as u32..=(band_mid + 0.5 * badge_h) as u32 {
+                for x in x0..=x1 {
+                    let p = at(&px, dim, x, y);
+                    if p[0] < 150 && p[1] < 150 && p[2] < 150 {
+                        n += 1;
+                    }
+                }
+            }
+            n
+        };
+        let ink = dark(ox as u32, (ox + badge_w).ceil() as u32);
+        assert!(
+            ink >= 15,
+            "badge lettering missing from the bottom band: {ink} dark pixels"
+        );
+        // The stretch between the badge and the power LED stays plain
+        // plastic: the lettering must not smear across the band.
+        let plain = dark(
+            (ox + badge_w).ceil() as u32 + 10,
+            (0.85 * dim as f32) as u32,
+        );
+        assert_eq!(plain, 0, "ink east of the badge: {plain} dark pixels");
     }
 
     /// The window pairs the bezel with a preset by re-aiming the preset at

--- a/src/video/window/shaders/bezel.wgsl
+++ b/src/video/window/shaders/bezel.wgsl
@@ -4,7 +4,9 @@
 // the 1084 the Amiga shipped with. The pass covers the whole display rect;
 // the picture is re-sampled to fill the rounded opening the frame leaves,
 // with a dark recess between the tube face and the plastic, a bevelled
-// inner lip, a moulded outer edge and the power LED on the bottom band.
+// inner lip, a moulded outer edge, the power LED on the bottom band and
+// the Copperline logotype printed on its left, where the 1084 wears its
+// Commodore badge.
 //
 // Two modes, selected by params.x. Alone (0), this one pass draws both
 // the frame and the picture. Under a CRT preset (1, frame-only), the
@@ -80,6 +82,63 @@ fn grain(p: vec2<f32>) -> f32 {
 // The front-face plastic, a warm Commodore grey (linear light).
 const PLASTIC: vec3<f32> = vec3<f32>(0.585, 0.560, 0.500);
 
+// "Copperline" logotype for the bottom band: 5x8-pixel glyphs one column
+// apart (baseline row 6, the p descenders on row 7), 59x8 bits in all.
+// Each row packs LSB-first from the left into a (low, high) word pair:
+// column c sets bit c of x (c < 32) or bit c - 32 of y.
+//
+// .###.................................##....................
+// #...#.................................#.....#..............
+// #......###..####..####...###..#.##....#.........#.##...###.
+// #.....#...#.#...#.#...#.#...#.##..#...#....##...##..#.#...#
+// #.....#...#.#...#.#...#.#####.#.......#.....#...#...#.#####
+// #...#.#...#.#...#.#...#.#.....#.......#.....#...#...#.#....
+// .###...###..####..####...###..#......###...###..#...#..###.
+// ............#.....#........................................
+const BADGE_COLS: i32 = 59;
+const BADGE_ROWS: i32 = 8;
+const BADGE: array<vec2<u32>, 8> = array<vec2<u32>, 8>(
+    vec2<u32>(0x0000000eu, 0x00000060u),
+    vec2<u32>(0x00000011u, 0x00001040u),
+    vec2<u32>(0x4e3cf381u, 0x038d0043u),
+    vec2<u32>(0xd1451441u, 0x04531844u),
+    vec2<u32>(0x5f451441u, 0x07d11040u),
+    vec2<u32>(0x41451451u, 0x00511040u),
+    vec2<u32>(0x4e3cf38eu, 0x039138e0u),
+    vec2<u32>(0x00041000u, 0x00000000u),
+);
+
+// The badge ink, near-black with the printed badge's blue cast.
+const BADGE_INK: vec3<f32> = vec3<f32>(0.030, 0.036, 0.060);
+
+// One bit of the badge bitmap, 0.0 outside it.
+fn badge_bit(c: i32, r: i32) -> f32 {
+    if c < 0 || c >= BADGE_COLS || r < 0 || r >= BADGE_ROWS {
+        return 0.0;
+    }
+    var rows = BADGE;
+    let bits = rows[r];
+    if c < 32 {
+        return f32((bits.x >> u32(c)) & 1u);
+    }
+    return f32((bits.y >> u32(c - 32)) & 1u);
+}
+
+// The bitmap sampled bilinearly at a continuous position in font pixels,
+// so the lettering stays smooth at any window scale.
+fn badge_sample(q: vec2<f32>) -> f32 {
+    let f = q - vec2<f32>(0.5);
+    let base = floor(f);
+    let t = f - base;
+    let c = i32(base.x);
+    let r = i32(base.y);
+    let s00 = badge_bit(c, r);
+    let s10 = badge_bit(c + 1, r);
+    let s01 = badge_bit(c, r + 1);
+    let s11 = badge_bit(c + 1, r + 1);
+    return mix(mix(s00, s10, t.x), mix(s01, s11, t.x), t.y);
+}
+
 @fragment
 fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     let vp = u.size.xy;
@@ -144,7 +203,8 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     plastic *= 1.0 - 0.35 * smoothstep(-6.0, 0.0, d_case);
 
     // Power LED on the right of the bottom band, in a small dark well.
-    let band_mid_y = (o_org.y + o_size.y + recess + vp.y) * 0.5;
+    let band_top = o_org.y + o_size.y + recess;
+    let band_mid_y = (band_top + vp.y) * 0.5;
     let led_pos = vec2<f32>(0.91 * vp.x, band_mid_y);
     let led_d = length(px - led_pos);
     let led_r = max(0.007 * unit, 1.5);
@@ -152,6 +212,20 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     let led = 1.0 - smoothstep(led_r - 1.0, led_r + 1.0, led_d);
     plastic = mix(plastic, vec3<f32>(0.03, 0.03, 0.03), well);
     plastic = mix(plastic, vec3<f32>(0.06, 0.55, 0.10), led);
+
+    // The printed logotype on the left of the bottom band, where the 1084
+    // wears its Commodore badge: left-aligned with the opening, vertically
+    // centred in the band, scaling with the frame. Skipped when the band
+    // is too shallow for the lettering to resolve.
+    let badge_h = 0.34 * (vp.y - band_top);
+    if badge_h >= 5.0 {
+        let badge_org = vec2<f32>(o_org.x, band_mid_y - 0.5 * badge_h);
+        let q = (px - badge_org) * (f32(BADGE_ROWS) / badge_h);
+        let hi = vec2<f32>(f32(BADGE_COLS) + 1.0, f32(BADGE_ROWS) + 1.0);
+        if all(q > vec2<f32>(-1.0)) && all(q < hi) {
+            plastic = mix(plastic, BADGE_INK, 0.92 * badge_sample(q));
+        }
+    }
 
     // Compose by signed distance: picture, recess gap, then plastic, each
     // join antialiased over about a pixel.

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -355,20 +355,21 @@ pub(super) struct LedRowSpec {
 pub(super) fn led_rows(status: &FrontPanelStatus, powered_on: bool) -> Vec<LedRowSpec> {
     let mut rows = vec![
         LedRowSpec {
-            // Lit whenever powered, like a real Amiga; brighter when Paula's
-            // analogue filter is engaged.
+            // Lit whenever powered, like a real Amiga: full brightness
+            // while the guest holds /LED engaged, dimmed -- never off --
+            // once it releases it, as on A500 rev 6 and later boards.
             label: "PWR",
             on: powered_on,
-            on_color: if status.audio_filter_on {
+            on_color: if status.power_led_bright {
                 POWER_LED_BRIGHT
             } else {
-                POWER_LED_NORMAL
+                POWER_LED_DIM
             },
             off_color: POWER_LED_OFF,
-            highlight_on: if status.audio_filter_on {
+            highlight_on: if status.power_led_bright {
                 rgba(255, 120, 108)
             } else {
-                rgba(255, 91, 82)
+                rgba(196, 62, 54)
             },
             highlight_off: rgba(90, 27, 24),
         },

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -22,7 +22,7 @@ use super::{
     ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
     AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON,
     DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
-    POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_NORMAL, POWER_LED_OFF,
+    POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_DIM, POWER_LED_OFF,
     STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
     TRACK_SEGMENT_ON, TV_CAPTURED_SOURCE_X, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
     TV_PRESENT_SOURCE_X, TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
@@ -1300,7 +1300,7 @@ fn status_bar_draws_power_and_fdd_led_states() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: false,
                 fdd_track: Some(5),
                 hdd_led: None,
@@ -1343,7 +1343,7 @@ fn status_bar_draws_power_and_fdd_led_states() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: false,
+                power_led_bright: false,
                 fdd_led_on: true,
                 fdd_track: Some(42),
                 hdd_led: None,
@@ -1362,17 +1362,17 @@ fn status_bar_draws_power_and_fdd_led_states() {
 }
 
 #[test]
-fn power_led_is_lit_normal_or_bright_by_the_audio_filter() {
+fn power_led_is_bright_dim_or_off_by_the_led_line() {
     let scale = 1;
     let power = led_row_rect(0, 2);
     let center = |frame: &[u8]| pixel(frame, power.x + power.w / 2, power.y + power.h / 2, scale);
-    let render = |filter_on: bool, powered: bool| {
+    let render = |led_engaged: bool, powered: bool| {
         let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
         draw_status_bar(
             &mut frame,
             &view(
                 FrontPanelStatus {
-                    audio_filter_on: filter_on,
+                    power_led_bright: led_engaged,
                     fdd_led_on: false,
                     fdd_track: Some(0),
                     hdd_led: None,
@@ -1386,11 +1386,11 @@ fn power_led_is_lit_normal_or_bright_by_the_audio_filter() {
         );
         center(&frame)
     };
-    // Powered: lit at the normal red when bypassed, a more intense red when
-    // the filter is engaged.
+    // Powered: full brightness while the guest holds /LED engaged, dimmed
+    // -- still lit -- once it releases it, as on A500 rev 6+ boards.
     assert_eq!(render(true, true), POWER_LED_BRIGHT.to_le_bytes());
-    assert_eq!(render(false, true), POWER_LED_NORMAL.to_le_bytes());
-    // Unpowered: dark regardless of the filter state.
+    assert_eq!(render(false, true), POWER_LED_DIM.to_le_bytes());
+    // Unpowered: dark regardless of the /LED line.
     assert_eq!(render(true, false), POWER_LED_OFF.to_le_bytes());
 }
 
@@ -1402,7 +1402,7 @@ fn status_bar_extinguishes_power_led_when_host_power_is_off() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: false,
                 fdd_track: Some(0),
                 hdd_led: None,
@@ -1451,7 +1451,7 @@ fn status_bar_power_button_glyph_tracks_power_state() {
             &mut frame,
             &view(
                 FrontPanelStatus {
-                    audio_filter_on: powered_on,
+                    power_led_bright: powered_on,
                     fdd_led_on: false,
                     fdd_track: Some(0),
                     hdd_led: None,
@@ -1555,7 +1555,7 @@ fn status_bar_pause_button_glyph_tracks_pause_state() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: false,
                 fdd_track: Some(0),
                 hdd_led: None,
@@ -1576,7 +1576,7 @@ fn status_bar_pause_button_glyph_tracks_pause_state() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: false,
                 fdd_track: Some(0),
                 hdd_led: None,
@@ -1599,7 +1599,7 @@ fn status_bar_draws_disk_image_button_next_to_track_counter() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: true,
                 fdd_track: Some(5),
                 hdd_led: None,
@@ -1842,7 +1842,7 @@ fn status_bar_draws_volume_control_and_maps_pointer_position() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: true,
                 fdd_track: Some(5),
                 hdd_led: None,
@@ -1872,7 +1872,7 @@ fn status_bar_latches_fdd_track_when_no_drive_is_selected() {
     let mut last_fdd_track = None;
     let status = status_with_latched_fdd_track(
         FrontPanelStatus {
-            audio_filter_on: true,
+            power_led_bright: true,
             fdd_led_on: true,
             fdd_track: Some(42),
             hdd_led: None,
@@ -1886,7 +1886,7 @@ fn status_bar_latches_fdd_track_when_no_drive_is_selected() {
 
     let status = status_with_latched_fdd_track(
         FrontPanelStatus {
-            audio_filter_on: true,
+            power_led_bright: true,
             fdd_led_on: false,
             fdd_track: None,
             hdd_led: None,
@@ -1907,7 +1907,7 @@ fn status_bar_draws_at_hidpi_texture_scale() {
         &mut frame,
         &view(
             FrontPanelStatus {
-                audio_filter_on: true,
+                power_led_bright: true,
                 fdd_led_on: true,
                 fdd_track: Some(159),
                 hdd_led: None,


### PR DESCRIPTION
Two visual tweaks to the presentation layer.

## Copperline badge on the monitor bezel

The bezel's bottom band now wears a printed Copperline logotype in the spot the 1084 keeps its Commodore lettering: a 59x8 bit-packed pixel bitmap drawn by the bezel shader itself (no new textures or bindings; the shared 64-byte uniform layout is untouched), left-aligned with the opening and vertically centred in the band. The bitmap is sampled bilinearly so the lettering scales smoothly with the frame, and it is skipped when the band is too shallow for the text to resolve.

## Status-panel PWR LED dims instead of switching off

The PWR LED is now driven by CIA-A's /LED pin the way it drives the LED on an A500 rev 6 or later board:

- full brightness while the guest holds /LED engaged (Paula's filter on)
- dimmed -- not extinguished -- once it releases the line
- dark only while the machine is powered off

It follows the raw pin (new `Paula::led_filter_guest_on`) rather than the effective filter, so the host audio-filter override changes the mix but never the LED, and the A1000 -- whose LED is fed straight from the supply and has no filter switch on this line -- stays bright regardless. `FrontPanelStatus.audio_filter_on` becomes `power_led_bright` to match.

The browser status strip previously switched its PWR LED fully dark with the filter signal; it now shows the same bright/dimmed pair as the desktop bar (the wasm `pkg/` is untracked and picks this up on the next build).

## Testing

- New GPU render test for the badge (ink present, band otherwise clean) plus the miniature render scale bump it needs
- Status-bar test now asserts bright/dim/off; new bus tests pin that the host filter override never moves the LED and that the A1000's LED stays bright
- Docs updated: configuration.md (bezel + audio_filter), ui.md (LED block, Audio Filter menu item), browser.md (status strip)
- Full suite green (2083 tests), clippy and fmt clean, wasm target compiles