### PR TITLE
Add cross-platform bridged networking

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,10 +16,12 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "packaging/appimage/**"
+      - "packaging/linux/**"
       - ".github/workflows/appimage.yml"
   pull_request:
     paths:
       - "packaging/appimage/**"
+      - "packaging/linux/**"
       - ".github/workflows/appimage.yml"
 
 concurrency:
@@ -51,14 +53,23 @@ jobs:
         run: ./packaging/appimage/build-appimage.sh
       - name: Locate artifact
         id: artifact
-        run: echo "path=$(ls Copperline-*.AppImage | head -n1)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "path=$(ls Copperline-*.AppImage | head -n1)" >> "$GITHUB_OUTPUT"
+          echo "helper=$(ls Copperline-*-net-helper.tar.gz | head -n1)" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@v7
         with:
           name: copperline-appimage
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
+      - uses: actions/upload-artifact@v7
+        with:
+          name: copperline-linux-net-helper
+          path: ${{ steps.artifact.outputs.helper }}
+          if-no-files-found: error
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ steps.artifact.outputs.path }}
+          files: |
+            ${{ steps.artifact.outputs.path }}
+            ${{ steps.artifact.outputs.helper }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -493,10 +493,12 @@ dependencies = [
  "gilrs",
  "hound",
  "libc",
+ "libloading",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "pcap",
  "pixels",
  "png",
  "rfd",
@@ -912,12 +914,33 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2159,6 +2182,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcap"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2eecc2ddc671ec563b5b39f846556aade68a65d1afb14d8fe6b30b0457d75"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.2.8",
+ "libc",
+ "libloading",
+ "pkg-config",
+ "regex",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,7 +2568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.13.0",
- "errno",
+ "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -2543,7 +2581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.13.0",
- "errno",
+ "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
@@ -3708,6 +3746,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,6 +3769,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -3848,6 +3908,19 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -3968,6 +4041,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -3983,6 +4062,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4016,6 +4101,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -4031,6 +4122,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4067,6 +4164,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,15 @@ publish = false
 default-run = "copperline"
 
 [features]
-default = ["midi", "frontend", "wasm-boards", "control", "ctl-bin", "net-nat"]
+default = [
+    "midi",
+    "frontend",
+    "wasm-boards",
+    "control",
+    "ctl-bin",
+    "net-nat",
+    "net-bridge",
+]
 display-plan-trace = []
 # Local investigation switches that deliberately alter timing or rendering.
 # Normal builds keep these environment-variable overrides inert so release
@@ -58,6 +66,11 @@ control = ["dep:serde_json"]
 # a slirp-style virtual gateway giving the guest outbound IPv4 with no host
 # privileges. Uses std::net + threads, so browser builds compile it out.
 net-nat = ["dep:smoltcp"]
+# Direct attachment of an emulated NIC to a host Ethernet adapter
+# (`net = "bridge"`). Linux uses AF_PACKET (with the narrowly privileged
+# copperline-net-helper when an unprivileged open is denied), macOS uses the
+# system libpcap, and Windows loads an installed Npcap at runtime.
+net-bridge = ["dep:pcap", "dep:libloading"]
 # The `copperline-ctl` command-line client for the control protocol.
 ctl-bin = ["dep:serde_json"]
 
@@ -122,6 +135,13 @@ zerocopy = { version = "0.8", features = ["derive"] }
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = ["NSApplication", "NSImage"] }
 objc2-foundation = { version = "0.3", default-features = false, features = ["NSData"] }
+pcap = { version = "2.4", optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+# Npcap is deliberately not linked at build time: the bridge backend loads it
+# from a trusted system directory only when selected, so NAT-only installs do
+# not acquire a runtime DLL dependency.
+libloading = { version = "0.8", optional = true }
 
 # Optional realtime-priority feature: cross-platform thread scheduling control.
 # Only used off macOS -- the macOS path uses the libc pthread QoS API directly
@@ -151,6 +171,11 @@ required-features = ["bench-bin"]
 name = "copperline-ctl"
 path = "src/bin/copperline-ctl.rs"
 required-features = ["ctl-bin"]
+
+[[bin]]
+name = "copperline-net-helper"
+path = "src/bin/copperline-net-helper.rs"
+required-features = ["net-bridge"]
 
 [dev-dependencies]
 # Compile WAT to wasm bytes in the WASM-plugin-host tests, so golden test

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ release needs resolved first. Release steps for every channel are in
 | Floppy / ADF / DMS / SCP | DF0-DF3 standard DD ADF read/write, read-only ADZ/DMS, UAE extended ADF, initial read-only SCP flux import, track-timed disk DMA, CIA drive lines, index FLAG, DSKLEN/DSKBYTR/DSKSYNC/DSKDAT, per-drive multi-disk playlists with a swap key. |
 | Hard disks | Gayle IDE (A600/A1200) and A4000 motherboard IDE; SCSI via the A2091 (Zorro II DMAC + WD33C93A), A4091 (Zorro III 53C710 with SCRIPTS), or A3000 Super DMAC; RDB HDFs, bare partition hardfiles, and host-directory volumes. |
 | Host filesystem | `[[filesys]]` mounts serve host directories live as AmigaDOS volumes (read/write, `.uaem` attribute sidecars, Latin-1 name mapping). |
-| Expansion | Zorro II/III autoconfig chain, TOML-described RAM boards, WASM plugin boards (registers/interrupts/DMA in a sandboxed module), A2065 Ethernet (Am7990 LANCE) with host network backends. |
+| Expansion | Zorro II/III autoconfig chain, TOML-described RAM boards, WASM plugin boards (registers/interrupts/DMA in a sandboxed module), A2065 Ethernet (Am7990 LANCE) with loopback, userspace NAT, and direct host-adapter bridge backends. |
 | Agnus VPOSR / VHPOSR | Beam counters advanced per colour clock; PAL and NTSC timing (including NTSC long/short lines). |
 | Agnus Copper | Beam-scheduled OCS Copper with COP1/COP2 jumps, WAIT, SKIP, DMAEN/COPEN gating, and chip-bus grants. |
 | Agnus blitter | Scheduled per-slot engine: normal/line/fill modes, hardware per-word channel bus sequences (including the area-fill idle C slot), BBUSY/BZERO, BLTPRI "nasty" vs CPU starvation-yield arbitration, blit-done IRQ. |

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -242,13 +242,17 @@ slow = "512K"
 # A2065 Ethernet board (Am7990 LANCE, driven by the SANA-II a2065.device).
 # net picks the host network backend: "nat" is a slirp-style userspace NAT
 # giving the guest outbound IPv4 with no host privileges (guest 10.0.2.15/24,
-# gateway 10.0.2.2, DNS 10.0.2.3, DHCP built in); "loopback" echoes
-# transmitted frames back (self-contained); "none" leaves the NIC isolated.
+# gateway 10.0.2.2, DNS 10.0.2.3, DHCP built in); "bridge" attaches complete
+# Ethernet frames directly to the named host adapter (LAN DHCP/static config
+# in the guest; Wi-Fi best-effort); "loopback" echoes transmitted frames back
+# (self-contained); "none" leaves the NIC isolated.
 # Omit the section for no board. Host networking is non-deterministic, so a
 # fitted NIC breaks byte-identical replay/save-state determinism while
 # traffic flows.
 # [a2065]
 # net = "nat"
+# interface = "en0"       # required only for net = "bridge"; list with
+#                         # copperline --list-net-interfaces
 
 
 # RTG graphics card: high-resolution, high-colour screens via Picasso96.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -71,7 +71,8 @@ profile in a config file.
 The audio, serial, parallel, and network surface has matching per-run flags
 too -- `--audio-device`, `--audio-channel-mode`, `--audio-filter`,
 `--audio-stereo-separation`, `--serial`, `--midi-in`, `--midi-out`,
-`--parallel`, `--sampler-audio-input`, `--sampler-input-gain`, `--a2065-net` --
+`--parallel`, `--sampler-audio-input`, `--sampler-input-gain`, `--a2065-net`,
+`--a2065-interface` --
 described with their `[audio]`, `[serial]`, `[parallel]`, and `[a2065]` keys
 below.
 
@@ -1290,7 +1291,8 @@ assigns addresses.
 
 ```toml
 [a2065]
-net = "nat"   # or "loopback"; "none" for an isolated NIC
+net = "nat"   # or "bridge", "loopback"; "none" for an isolated NIC
+# interface = "en0"  # required for "bridge"
 ```
 
 Fits a Commodore A2065 Ethernet board (Am7990 LANCE) on the Zorro chain;
@@ -1303,6 +1305,16 @@ host network backend:
   macOS, and Windows. Configure the guest's TCP/IP stack with IP
   `10.0.2.15`, netmask `255.255.255.0`, gateway `10.0.2.2`, DNS `10.0.2.3`
   (or let it BOOTP/DHCP). Outbound only, IPv4 only.
+- `"bridge"` -- attaches complete Ethernet frames directly to `interface`, so
+  the Amiga is a separate station on the physical LAN and can accept inbound
+  connections from LAN peers. Use `copperline --list-net-interfaces` for exact
+  identifiers, or `--a2065-interface NAME` (which implies the bridge backend).
+  Configure the guest by DHCP from the real LAN or with an address appropriate
+  to that LAN. The guest can reach peers and the router; communication with the
+  host's own IP is adapter/OS-dependent and is not guaranteed. Frames keep the
+  Amiga's source MAC, so Wi-Fi is best-effort: many access points reject a
+  second source MAC behind one wireless station. Copperline reports adapter,
+  driver, and permission failures at startup instead of falling back to NAT.
 - `"loopback"` -- echoes transmitted frames back (self-contained, useful
   for driver bring-up).
 - `"none"` -- the NIC is fitted but isolated.
@@ -1310,8 +1322,10 @@ host network backend:
 Omit the section entirely for no board. Note that host networking is
 inherently non-deterministic: inbound frames arrive on the host's
 schedule, not the emulated clock, so a NIC board breaks byte-identical
-replay and save-state determinism while traffic flows. See [](../zorro)
-for the board details and the NAT's limitations.
+replay and save-state determinism while traffic flows. A save state stores the
+bridge adapter identifier and must be restored on a host where that adapter can
+be opened. See [](../zorro) for board details, platform bridge setup, and the
+NAT's limitations.
 
 ## `[rtg]` -- RTG graphics card
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -324,9 +324,10 @@ The layout is:
   beneath it: serial mode and MIDI endpoints; the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
-  and the A2065 Ethernet board -- Not fitted, Isolated, Loopback, or NAT, with
-  a warning when NAT is selected, since its host-clocked traffic makes input
-  recordings and save-state replays non-reproducible while it flows),
+  and the A2065 Ethernet board -- Not fitted, Isolated, Loopback, NAT, or
+  Bridged; Bridged adds a host-adapter row. NAT and Bridged show a warning
+  because host-clocked traffic makes input recordings and save-state replays
+  non-reproducible while it flows),
   *Zorro* (extra autoconfig boards by metadata file, with a config panel for a
   WASM plugin board's declared options),
   and *A/V & Emu*, split by a row of category buttons at the top into

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -52,7 +52,7 @@ src/
   dirfs.rs          # host directory -> in-memory FFS partition image
   filesys.rs        # host directories mounted live as AmigaDOS volumes
   a2065.rs          # A2065 Zorro II Ethernet board (Am7990 LANCE)
-  net.rs            # host networking backends for emulated Ethernet
+  net/              # loopback, userspace NAT, and host-adapter bridge backends
   cdrom.rs          # CD image (BIN/CUE) parsing
   cdtv.rs           # CDTV DMAC + Matshita drive model
   akiko.rs          # CD32 Akiko (C2P, NVRAM, Chinon drive)

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -230,7 +230,7 @@ guest could construct on its own (`..`, embedded separators) are
 blocked. A `readonly`
 mount refuses writes with the standard write-protection error.
 
-## A2065 Ethernet (`a2065.rs`, `net.rs`)
+## A2065 Ethernet (`a2065.rs`, `net/`)
 
 The `[a2065]` option fits a Commodore A2065: a Zorro II board carrying an
 Am7990 LANCE and 32 KiB of on-board RAM, driven by the AmigaOS SANA-II
@@ -258,6 +258,17 @@ breaks byte-identical replay while traffic flows; save states record only
 the chosen backend and bring up a fresh one on load (flows die; the
 guest's TCP retransmits). The board and backend story, including the WASM
 plugin `net` capability, is covered in [](../zorro).
+
+The `bridge` backend (`net/bridge/`, `net-bridge` build feature) uses the
+same bounded worker boundary but carries unmodified Ethernet frames to a
+selected physical adapter: AF_PACKET on Linux, system libpcap/BPF on macOS,
+and runtime-loaded Npcap on Windows. A platform filter and a second software
+guard admit only the guest station address and multicast/broadcast, while
+guest-source capture echo is discarded. The LANCE's init-block PADR updates
+that filter. Linux's companion process owns only `CAP_NET_RAW`, validates an
+interface request, and passes a bound descriptor with `SCM_RIGHTS`; it never
+handles a frame. Backend construction is fallible so bridge errors abort
+machine startup or state restoration rather than changing connectivity.
 
 ## CDTV (`cdtv.rs`, `cdrom.rs`)
 

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -94,6 +94,9 @@ dma  = true             # capabilities, all default false:
 int2 = true             #   dma  -> the dma_read/dma_write host imports
 int6 = false            #   int2 -> may assert INT2 (PORTS)
                         #   int6 -> may assert INT6 (EXTER)
+# A NIC plugin may also request the shared host networking capability:
+# net = "bridge"         # none / loopback / nat / bridge
+# net_interface = "en0" # required for bridge
 ```
 
 WASM is chosen because a module's entire mutable state lives in its linear
@@ -183,19 +186,21 @@ config:
 
 ```toml
 [a2065]
-net = "nat"   # host network backend; "loopback", or "none" for isolation
+net = "nat"   # "bridge", "loopback", or "none" for isolation
+# interface = "en0"  # required for "bridge"
 ```
 
 (`--a2065-net BACKEND` is the matching per-run flag, and the launcher's
-**I/O Ports** tab has the same picker under its **Ethernet:** heading, with a
-warning shown when the non-deterministic NAT backend is selected.)
+**I/O Ports** tab has the same picker under its **Ethernet:** heading. Bridged
+mode adds a live host-adapter picker. `--list-net-interfaces` prints the stable
+names accepted by `[a2065] interface` and `--a2065-interface`.)
 
 Unlike the DMAC boards, the LANCE does not master the Amiga bus: its init
 block, descriptor rings, and packet buffers live in the board's own 32 KiB RAM
 (which the CPU reaches through the board window), so the board is self-contained
 and owns its host network backend directly.
 
-Host network backends live in `src/net/` behind the `NetBackend` trait. Two are
+Host network backends live in `src/net/` behind the `NetBackend` trait. Three are
 built in:
 
 - **`nat`** -- userspace NAT (`src/net/nat/`, behind the default-on `net-nat`
@@ -219,10 +224,34 @@ built in:
   NAT is up, not that the target is reachable.
 - **`loopback`** -- transmitted frames are queued straight back; useful for a
   self-contained demo, driver bring-up, and tests.
+- **`bridge`** -- direct layer-2 attachment to one host adapter. The guest's
+  frames go to the adapter unchanged (destination through payload, no FCS), and
+  receive filters admit its station MAC plus broadcast/multicast. There is no
+  protocol translation and no managed TAP device: LAN DHCP, ARP, IPv4, and IPv6
+  work as they do for a physical station. LAN peers and the router can reach
+  the guest; the host's own IP is not guaranteed to be reachable through the
+  same adapter. Wi-Fi is explicitly best-effort because many access points do
+  not accept the guest's additional source MAC.
 
-A host TAP bridge would slot in behind `make_backend` the same way but is not
-implemented; TAP would require host privileges and per-OS interface setup,
-which is exactly what `nat` avoids.
+  - **Windows:** install [Npcap](https://npcap.com/). Copperline loads it from
+    the Windows system directory only when a bridge is selected; NAT-only
+    installs do not depend on Npcap.
+  - **macOS:** Copperline uses the system packet-capture interface. The account
+    must be allowed to open `/dev/bpf` (commonly through the machine's
+    `access_bpf` setup).
+  - **Linux:** Copperline first tries AF_PACKET directly. Normal desktop users
+    install the companion with `copperline --install-net-helper`, log out and
+    back in once to activate membership in `copperline-net`, then use the
+    per-user systemd socket. Only the root-owned helper binary receives
+    `CAP_NET_RAW`; it opens/binds/filters a socket and passes the descriptor to
+    Copperline, never pumps frames and never runs as root. `--net-helper-status`
+    and `--uninstall-net-helper` inspect/remove it. Flatpak users install the
+    published Linux helper companion on the host; the sandbox can access only
+    `$XDG_RUNTIME_DIR/copperline-net-helper/control.sock`.
+
+Bridge open failures are fatal to startup and save-state restoration; Copperline
+never silently substitutes NAT or isolation. If an adapter disappears while
+running, the worker logs link loss and disconnects the guest.
 
 **Networking is non-deterministic.** Inbound frames arrive on the host's
 schedule, not the emulated clock, so a fitted A2065 (or any `net`-capable WASM

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -36,6 +36,19 @@ cargo build --release --locked
 echo "==> Staging AppDir"
 rm -rf "$appdir"
 install -Dm755 target/release/copperline "$appdir/usr/bin/copperline"
+# The AppImage cannot retain file capabilities itself. Ship the narrowly
+# privileged Linux bridge helper and its setup/unit files inside the image;
+# `copperline --install-net-helper` copies the helper to /usr/libexec and gives
+# only that copy CAP_NET_RAW.
+net_helper_dir="$appdir/usr/libexec/copperline"
+install -Dm755 target/release/copperline-net-helper \
+  "$net_helper_dir/copperline-net-helper"
+install -Dm755 packaging/linux/copperline-net-helper-setup \
+  "$net_helper_dir/copperline-net-helper-setup"
+install -Dm644 packaging/linux/copperline-net-helper.service \
+  "$net_helper_dir/copperline-net-helper.service"
+install -Dm644 packaging/linux/copperline-net-helper.socket \
+  "$net_helper_dir/copperline-net-helper.socket"
 
 # Bundled AROS open-source Kickstart replacement (default boot ROM).
 # romsearch.rs looks under <prefix>/share/copperline/aros relative to the
@@ -76,4 +89,20 @@ export OUTPUT="${OUTPUT:-Copperline-$VERSION-$arch.AppImage}"
   --icon-file "$appdir/usr/share/icons/hicolor/256x256/apps/dev.copperline.Copperline.png" \
   --output appimage
 
-echo "==> Built $OUTPUT"
+# Standalone host-helper companion for Flatpak users (and native installs
+# that do not use the AppImage). It contains no emulator or ROM assets.
+helper_bundle="Copperline-$VERSION-$arch-net-helper"
+helper_stage="$repo_root/target/$helper_bundle"
+rm -rf "$helper_stage"
+mkdir -p "$helper_stage"
+install -m755 target/release/copperline-net-helper \
+  "$helper_stage/copperline-net-helper"
+install -m755 packaging/linux/copperline-net-helper-setup \
+  "$helper_stage/copperline-net-helper-setup"
+install -m644 packaging/linux/copperline-net-helper.service \
+  "$helper_stage/copperline-net-helper.service"
+install -m644 packaging/linux/copperline-net-helper.socket \
+  "$helper_stage/copperline-net-helper.socket"
+tar -C "$repo_root/target" -czf "$repo_root/$helper_bundle.tar.gz" "$helper_bundle"
+
+echo "==> Built $OUTPUT and $helper_bundle.tar.gz"

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -38,6 +38,13 @@ flatpak run org.flatpak.Builder --force-clean --user --install \
 flatpak run dev.copperline.Copperline
 ```
 
+Bridged Ethernet is deliberately split across the sandbox boundary. Install
+the `Copperline-*-net-helper.tar.gz` companion from the same release on the
+host, run `./copperline-net-helper-setup install`, then log out and back in.
+The Flatpak has network namespace access and can see only the helper's exact
+per-user runtime socket; it is never granted raw host devices or capabilities.
+User-mode NAT needs no companion.
+
 The manifest's source is `type: dir path: ../..`, so it builds the checked-out
 tree (this is also what CI validates). Build from a clean checkout: a `dir`
 source copies the whole tree, including any large uncommitted ROM/disk images

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -1224,6 +1224,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/errno/errno-0.2.8.crate",
+        "sha256": "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1",
+        "dest": "cargo/vendor/errno-0.2.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.2.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/errno/errno-0.3.14.crate",
         "sha256": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb",
         "dest": "cargo/vendor/errno-0.3.14"
@@ -1232,6 +1245,19 @@
         "type": "inline",
         "contents": "{\"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\", \"files\": {}}",
         "dest": "cargo/vendor/errno-0.3.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/errno-dragonfly/errno-dragonfly-0.1.2.crate",
+        "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+        "dest": "cargo/vendor/errno-dragonfly-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-dragonfly-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2844,6 +2870,19 @@
         "type": "inline",
         "contents": "{\"package\": \"2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1\", \"files\": {}}",
         "dest": "cargo/vendor/parking_lot_core-0.9.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pcap/pcap-2.4.0.crate",
+        "sha256": "bbd2eecc2ddc671ec563b5b39f846556aade68a65d1afb14d8fe6b30b0457d75",
+        "dest": "cargo/vendor/pcap-2.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbd2eecc2ddc671ec563b5b39f846556aade68a65d1afb14d8fe6b30b0457d75\", \"files\": {}}",
+        "dest": "cargo/vendor/pcap-2.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4721,6 +4760,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
+        "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        "dest": "cargo/vendor/winapi-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.11.crate",
         "sha256": "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22",
         "dest": "cargo/vendor/winapi-util-0.1.11"
@@ -4729,6 +4794,19 @@
         "type": "inline",
         "contents": "{\"package\": \"c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22\", \"files\": {}}",
         "dest": "cargo/vendor/winapi-util-0.1.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4903,6 +4981,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.36.1.crate",
+        "sha256": "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2",
+        "dest": "cargo/vendor/windows-sys-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.36.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate",
         "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0",
         "dest": "cargo/vendor/windows-sys-0.45.0"
@@ -5059,6 +5150,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.36.1.crate",
+        "sha256": "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.36.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.2.crate",
         "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2"
@@ -5093,6 +5197,19 @@
         "type": "inline",
         "contents": "{\"package\": \"b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006\", \"files\": {}}",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.36.1.crate",
+        "sha256": "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6",
+        "dest": "cargo/vendor/windows_i686_gnu-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5163,6 +5280,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.36.1.crate",
+        "sha256": "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024",
+        "dest": "cargo/vendor/windows_i686_msvc-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.36.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.2.crate",
         "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060",
         "dest": "cargo/vendor/windows_i686_msvc-0.42.2"
@@ -5197,6 +5327,19 @@
         "type": "inline",
         "contents": "{\"package\": \"1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.36.1.crate",
+        "sha256": "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5275,6 +5418,19 @@
         "type": "inline",
         "contents": "{\"package\": \"0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.36.1.crate",
+        "sha256": "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/packaging/flatpak/dev.copperline.Copperline.yaml
+++ b/packaging/flatpak/dev.copperline.Copperline.yaml
@@ -37,6 +37,11 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
+  # Bridged Ethernet uses only a host-created, per-user AF_PACKET descriptor
+  # passed over this exact runtime socket. The sandbox gets no raw device and
+  # no broad /run access; --share=network lets it use the passed descriptor.
+  - --share=network
+  - --filesystem=xdg-run/copperline-net-helper
   # GPU acceleration for the wgpu/pixels render path.
   - --device=dri
   # Game controllers (gilrs reads /dev/input via udev).

--- a/packaging/linux/copperline-net-helper-setup
+++ b/packaging/linux/copperline-net-helper-setup
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Install/remove the Linux bridge capability helper. This script is shipped
+# beside copperline-net-helper in AppImages and companion release archives.
+set -eu
+
+helper_group=copperline-net
+install_dir=/usr/libexec/copperline
+helper_target="$install_dir/copperline-net-helper"
+unit_dir=/usr/lib/systemd/user
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+helper_source="$script_dir/copperline-net-helper"
+service_source="$script_dir/copperline-net-helper.service"
+socket_source="$script_dir/copperline-net-helper.socket"
+
+usage() {
+    echo "usage: $0 install|uninstall|status" >&2
+    exit 2
+}
+
+root_install() {
+    source=$1
+    service=$2
+    socket=$3
+    user=$4
+    if ! getent group "$helper_group" >/dev/null; then
+        groupadd --system "$helper_group"
+    fi
+    usermod -a -G "$helper_group" "$user"
+    install -d -o root -g root -m 0755 "$install_dir" "$unit_dir"
+    install -o root -g root -m 0755 "$source" "$helper_target"
+    install -o root -g root -m 0644 "$service" \
+        "$unit_dir/copperline-net-helper.service"
+    install -o root -g root -m 0644 "$socket" \
+        "$unit_dir/copperline-net-helper.socket"
+    setcap cap_net_raw=ep "$helper_target"
+}
+
+root_uninstall() {
+    rm -f "$helper_target" \
+        "$unit_dir/copperline-net-helper.service" \
+        "$unit_dir/copperline-net-helper.socket"
+    rmdir "$install_dir" 2>/dev/null || true
+}
+
+case "${1:-}" in
+    --root-install)
+        [ "$(id -u)" -eq 0 ] || exit 1
+        [ "$#" -eq 5 ] || usage
+        root_install "$2" "$3" "$4" "$5"
+        ;;
+    --root-uninstall)
+        [ "$(id -u)" -eq 0 ] || exit 1
+        root_uninstall
+        ;;
+    install)
+        [ "$#" -eq 1 ] || usage
+        [ -x "$helper_source" ] || {
+            echo "missing helper binary beside setup script: $helper_source" >&2
+            exit 1
+        }
+        command -v pkexec >/dev/null || {
+            echo "pkexec is required to install the capability helper" >&2
+            exit 1
+        }
+        command -v setcap >/dev/null || {
+            echo "setcap is required (normally provided by libcap)" >&2
+            exit 1
+        }
+        login_user=$(id -un)
+        pkexec "$0" --root-install "$helper_source" "$service_source" \
+            "$socket_source" "$login_user"
+        systemctl --user daemon-reload
+        systemctl --user enable --now copperline-net-helper.socket
+        echo "Installed $helper_target with cap_net_raw only."
+        echo "Added $login_user to $helper_group."
+        if ! id -nG | tr ' ' '\n' | grep -qx "$helper_group"; then
+            echo "Log out and back in before using bridged networking."
+        fi
+        ;;
+    uninstall)
+        [ "$#" -eq 1 ] || usage
+        systemctl --user disable --now copperline-net-helper.socket 2>/dev/null || true
+        systemctl --user stop copperline-net-helper.service 2>/dev/null || true
+        pkexec "$0" --root-uninstall
+        systemctl --user daemon-reload
+        echo "Removed the Copperline network helper (the $helper_group group was retained)."
+        ;;
+    status)
+        [ "$#" -eq 1 ] || usage
+        if [ -x "$helper_target" ]; then
+            echo "helper: installed at $helper_target"
+            getcap "$helper_target" 2>/dev/null || true
+        else
+            echo "helper: not installed"
+        fi
+        if id -nG | tr ' ' '\n' | grep -qx "$helper_group"; then
+            echo "group: current user is a member of $helper_group"
+        else
+            echo "group: current user is not an active member of $helper_group"
+        fi
+        systemctl --user is-enabled copperline-net-helper.socket 2>/dev/null \
+            || echo "socket: not enabled"
+        systemctl --user is-active copperline-net-helper.socket 2>/dev/null \
+            || echo "socket: not active"
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/packaging/linux/copperline-net-helper.service
+++ b/packaging/linux/copperline-net-helper.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Copperline per-user raw Ethernet descriptor helper
+Documentation=https://copperlinehq.github.io/Copperline/guide/configuration.html
+Requires=copperline-net-helper.socket
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/copperline/copperline-net-helper --serve
+StandardInput=null
+NoNewPrivileges=no
+CapabilityBoundingSet=CAP_NET_RAW
+RestrictAddressFamilies=AF_UNIX AF_PACKET
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+
+[Install]
+Also=copperline-net-helper.socket

--- a/packaging/linux/copperline-net-helper.socket
+++ b/packaging/linux/copperline-net-helper.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Copperline per-user network helper socket
+
+[Socket]
+ListenStream=%t/copperline-net-helper/control.sock
+SocketMode=0600
+DirectoryMode=0700
+RemoveOnStop=true
+
+[Install]
+WantedBy=sockets.target

--- a/packaging/macos/README.txt
+++ b/packaging/macos/README.txt
@@ -39,4 +39,13 @@ own Kickstart ROM and disk/hard-disk images, and launch from a terminal with:
 
 Run that binary with --help for the full command-line surface.
 
+Bridged Ethernet
+----------------
+User-mode NAT needs no setup. Direct bridged Ethernet uses macOS's system
+packet-capture devices. If Copperline reports that it cannot open /dev/bpf,
+grant your account BPF access using your organisation's normal packet-capture
+setup (commonly the access_bpf group), then log out and back in. Run
+"copperline --list-net-interfaces" for adapter names. Wi-Fi bridging is
+best-effort because many access points reject the Amiga's separate source MAC.
+
 Copperline is licensed under GPL-3.0-or-later; see LICENSE.txt.

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -30,6 +30,14 @@ own Kickstart ROM and disk/hard-disk images, and launch with:
 
 Run "copperline.exe --help" for the full command-line surface.
 
+Bridged Ethernet
+----------------
+User-mode NAT works with no additional software. Direct bridged Ethernet
+requires Npcap from https://npcap.com/; Copperline loads it only when a bridge
+backend is selected. Use "copperline.exe --list-net-interfaces" to find the
+exact adapter identifier. Wi-Fi bridging is best-effort because many access
+points reject frames carrying the Amiga's separate source MAC address.
+
 Troubleshooting
 ---------------
 If Copperline crashes, it writes the crash details to copperline-crash.txt

--- a/src/a2065.rs
+++ b/src/a2065.rs
@@ -35,6 +35,7 @@
 
 use crate::net::{make_backend, NetBackend, NetConfig};
 use crate::zorro_device::{DeviceHost, ZorroDevice};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 const REG_RDP: u32 = 0x4000;
@@ -123,11 +124,16 @@ pub struct A2065 {
 }
 
 impl A2065 {
-    pub fn new(net_config: NetConfig) -> Self {
+    pub fn new(net_config: NetConfig) -> Result<Self> {
         // A locally-administered MAC (02:..) derived from a fixed prefix; a
         // real board reads this from a PROM.
         let mac = [0x02, 0x00, 0x10, 0x00, 0x00, 0x01];
-        Self {
+        let mut net =
+            make_backend(&net_config, Some(mac)).context("bringing up A2065 network backend")?;
+        if let Some(backend) = net.as_mut() {
+            backend.set_guest_mac(mac);
+        }
+        Ok(Self {
             mac,
             ram: vec![0u8; RAM_SIZE],
             net_config,
@@ -147,16 +153,20 @@ impl A2065 {
             tx_cur: 0,
             running: false,
             activity: false,
-            net: make_backend(net_config),
-        }
+            net,
+        })
     }
 
     /// Reattach the live network backend after a save-state load (the backend
     /// is a host resource and is brought up fresh, like an audio sink).
-    fn ensure_backend(&mut self) {
-        if self.net.is_none() {
-            self.net = make_backend(self.net_config);
+    pub(crate) fn reattach_backend(&mut self) -> Result<()> {
+        let mut backend = make_backend(&self.net_config, Some(self.mac))
+            .context("restoring A2065 network backend")?;
+        if let Some(backend) = backend.as_mut() {
+            backend.set_guest_mac(self.mac);
         }
+        self.net = backend;
+        Ok(())
     }
 
     // ----- board RAM word access (big-endian) ----------------------------
@@ -194,6 +204,9 @@ impl A2065 {
             // PADR is stored low-byte-first per word in LANCE order.
             self.mac[i as usize * 2] = w as u8;
             self.mac[i as usize * 2 + 1] = (w >> 8) as u8;
+        }
+        if let Some(net) = self.net.as_mut() {
+            net.set_guest_mac(self.mac);
         }
         // +$10 RDRA[15:0], +$12 (RLEN<<13) | RDRA[23:16].
         let rdra_lo = self.ram_word(iadr + 0x10);
@@ -464,7 +477,6 @@ impl ZorroDevice for A2065 {
 
     fn tick(&mut self, _cck: u32, _host: &mut DeviceHost) {
         // Pull any inbound frames the backend has queued into the RX ring.
-        self.ensure_backend();
         while self.running {
             let frame = match self.net.as_mut().and_then(|n| n.poll()) {
                 Some(f) => f,
@@ -498,7 +510,15 @@ impl ZorroDevice for A2065 {
         self.mode = 0;
         self.running = false;
         self.ram.fill(0);
-        self.net = make_backend(self.net_config);
+        if let Err(error) = self.reattach_backend() {
+            // reattach_backend constructs the replacement before touching
+            // self.net, so a failed bridge reopen can retain the existing
+            // connection instead of silently changing to an isolated NIC.
+            log::error!(
+                "a2065: reset could not reopen network backend; keeping the existing backend: \
+                 {error:#}"
+            );
+        }
     }
 
     fn kind(&self) -> &'static str {
@@ -634,7 +654,7 @@ mod tests {
 
     #[test]
     fn rap_selects_csr_and_init_done_sets_idon() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings(&mut board, &mut mem);
 
@@ -647,7 +667,7 @@ mod tests {
 
     #[test]
     fn transmit_descriptor_is_sent_to_the_backend() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         let (tx_buf, _rx) = set_up_rings(&mut board, &mut mem);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -700,7 +720,7 @@ mod tests {
 
     #[test]
     fn inbound_frame_lands_in_rx_ring_and_raises_int() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings(&mut board, &mut mem);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -725,7 +745,7 @@ mod tests {
 
     #[test]
     fn stop_clears_running_and_int() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings(&mut board, &mut mem);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -849,7 +869,7 @@ mod tests {
 
     #[test]
     fn tx_frame_chains_across_descriptors() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, 0, 0, 256, 1);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -881,7 +901,7 @@ mod tests {
 
     #[test]
     fn rx_frame_chains_across_buffers() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, 0, 2, 128, 0);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -922,7 +942,7 @@ mod tests {
 
     #[test]
     fn rx_without_free_descriptor_sets_miss() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, 0, 0, 256, 0);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -945,7 +965,7 @@ mod tests {
 
     #[test]
     fn rx_out_of_chained_buffers_sets_buff() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, 0, 0, 128, 0);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -967,7 +987,7 @@ mod tests {
     #[test]
     fn mode_loop_returns_tx_frames_to_own_receiver() {
         // No backend at all: internal loopback never reaches the wire.
-        let mut board = A2065::new(NetConfig::None);
+        let mut board = A2065::new(NetConfig::None).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, MODE_LOOP, 0, 256, 0);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -988,7 +1008,7 @@ mod tests {
 
     #[test]
     fn mode_dtx_drx_disable_the_engines() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, MODE_DTX | MODE_DRX, 0, 256, 0);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -1011,7 +1031,7 @@ mod tests {
 
     #[test]
     fn rx_appends_fcs_to_short_frame() {
-        let mut board = A2065::new(NetConfig::Loopback);
+        let mut board = A2065::new(NetConfig::Loopback).unwrap();
         let mut mem = host_mem();
         set_up_rings_geom(&mut board, &mut mem, 0, 0, 256, 0);
         write_csr(&mut board, &mut mem, 0, CSR0_INIT);
@@ -1032,7 +1052,7 @@ mod tests {
 
     #[test]
     fn mac_prom_is_readable_at_even_bytes() {
-        let mut board = A2065::new(NetConfig::None);
+        let mut board = A2065::new(NetConfig::None).unwrap();
         let mut mem = host_mem();
         let mut host = DeviceHost::new(&mut mem);
         assert_eq!(board.read(0, 1, &mut host), 0x02);

--- a/src/bin/copperline-net-helper.rs
+++ b/src/bin/copperline-net-helper.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#[cfg(target_os = "linux")]
+fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        Some("--serve") if args.next().is_none() => copperline::net::bridge::linux::run_helper(),
+        _ => anyhow::bail!(
+            "copperline-net-helper is an internal capability helper; \
+             Copperline starts it automatically"
+        ),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!("copperline-net-helper is only used on Linux")
+}

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3871,7 +3871,14 @@ impl Bus {
     /// audio/serial sinks, serial observer, and the open blitter trace file. The realtime
     /// device-clock anchor needs no carry-over -- it deserializes as None
     /// and `realtime_cck_due` re-anchors to the host clock on first use.
-    pub(crate) fn adopt_host_resources(&mut self, live: &mut Bus) {
+    pub(crate) fn adopt_host_resources(&mut self, live: &mut Bus) -> anyhow::Result<()> {
+        // Open fallible resources before moving anything out of the live bus,
+        // preserving apply_state's all-or-nothing contract on bridge failure.
+        for device in &mut self.devices {
+            if let crate::zorro_device::BoardDevice::A2065(board) = device {
+                board.reattach_backend()?;
+            }
+        }
         std::mem::swap(&mut self.paula.serial, &mut live.paula.serial);
         std::mem::swap(
             &mut self.paula.serial_observer,
@@ -3883,6 +3890,7 @@ impl Bus {
         // Drive speed is host configuration, not machine state: a loaded
         // state keeps the running session's setting.
         self.floppy.set_speed_percent(live.floppy.speed_percent());
+        Ok(())
     }
 
     pub(crate) fn reset_transient_video_after_state_load(&mut self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1694,9 +1694,12 @@ pub struct ConfigOverrides {
     /// Freeze the seeded RTC (`--rtc-frozen`). Same as
     /// `[machine] rtc_frozen`.
     pub rtc_frozen: Option<bool>,
-    /// A2065 Ethernet backend (`--a2065-net`): "none", "loopback", or "nat".
+    /// A2065 Ethernet backend (`--a2065-net`): "none", "loopback", "nat", or
+    /// "bridge".
     /// Same parser as `[a2065] net`; setting it fits the board.
     pub a2065_net: Option<String>,
+    /// Host adapter for bridged A2065 networking (`--a2065-interface`).
+    pub a2065_interface: Option<String>,
     /// Open fullscreen at start (`--full-screen` / `--windowed`). Same as
     /// `[display] full_screen`.
     pub full_screen: Option<bool>,
@@ -1740,6 +1743,7 @@ impl ConfigOverrides {
             && self.rtc_time.is_none()
             && self.rtc_frozen.is_none()
             && self.a2065_net.is_none()
+            && self.a2065_interface.is_none()
             && self.full_screen.is_none()
             && self.status_bar.is_none()
     }
@@ -1862,6 +1866,18 @@ impl ConfigOverrides {
         }
         if let Some(net) = &self.a2065_net {
             raw.a2065.net = Some(net.clone());
+            if !matches!(
+                net.trim().to_ascii_lowercase().as_str(),
+                "bridge" | "bridged"
+            ) {
+                raw.a2065.interface = None;
+            }
+        }
+        if let Some(interface) = &self.a2065_interface {
+            raw.a2065.interface = Some(interface.clone());
+            if self.a2065_net.is_none() {
+                raw.a2065.net = Some("bridge".to_string());
+            }
         }
         if let Some(full_screen) = self.full_screen {
             raw.display.full_screen = Some(full_screen);
@@ -2245,10 +2261,13 @@ pub(crate) struct RawScsi {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawA2065 {
-    /// Host network backend: "loopback" (self-contained), or "none" for an
+    /// Host network backend: "loopback", "nat", "bridge", or "none" for an
     /// isolated NIC. Absent means no A2065 board is fitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) net: Option<String>,
+    /// Host adapter identifier used by `net = "bridge"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) interface: Option<String>,
 }
 
 /// `[rtg]` graphics card: an RTG board on the Zorro chain.
@@ -2997,14 +3016,23 @@ impl TryFrom<RawConfig> for Config {
             errors.push(anyhow!("[scsi] rom_odd needs rom (the even EPROM half)"));
         }
 
-        let a2065_net = match &raw.a2065.net {
-            None => None,
-            Some(s) => Some(crate::net::parse_net_config(s).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "[a2065] net = {:?} is not a known backend (expected \"none\", \"loopback\", or \"nat\")",
-                    s
-                )
-            })?),
+        let a2065_net = match (&raw.a2065.net, &raw.a2065.interface) {
+            (None, None) => None,
+            (None, Some(_)) => {
+                return Err(anyhow!(
+                    "[a2065] interface needs net = \"bridge\" (or use --a2065-interface)"
+                ));
+            }
+            (Some(s), interface) => {
+                let config = crate::net::parse_net_config(s, interface.as_deref())
+                    .map_err(|error| anyhow::anyhow!("[a2065] {error}"))?;
+                if interface.is_some() && !matches!(&config, crate::net::NetConfig::Bridge { .. }) {
+                    return Err(anyhow!(
+                        "[a2065] interface applies only to net = \"bridge\""
+                    ));
+                }
+                Some(config)
+            }
         };
 
         // The A500 Rev 6A is both the "A500" profile and the no-profile
@@ -7309,6 +7337,64 @@ mod tests {
         };
         let cfg = load_overrides(&overrides)?;
         assert_eq!(cfg.serial.mode, SerialMode::Stdout);
+        Ok(())
+    }
+
+    #[test]
+    fn a2065_bridge_requires_and_preserves_interface() -> Result<()> {
+        let cfg = parse_config(
+            r#"
+            [a2065]
+            net = "bridge"
+            interface = "en-test"
+            "#,
+        )?;
+        assert_eq!(
+            cfg.a2065_net,
+            Some(crate::net::NetConfig::Bridge {
+                interface: "en-test".to_string()
+            })
+        );
+
+        let missing = parse_config("[a2065]\nnet = \"bridge\"\n").unwrap_err();
+        assert!(
+            missing.to_string().contains("needs an interface"),
+            "{missing:#}"
+        );
+        let stray = parse_config("[a2065]\ninterface = \"en-test\"\n").unwrap_err();
+        assert!(stray.to_string().contains("needs net"), "{stray:#}");
+        let conflict =
+            parse_config("[a2065]\nnet = \"nat\"\ninterface = \"en-test\"\n").unwrap_err();
+        assert!(
+            conflict.to_string().contains("applies only"),
+            "{conflict:#}"
+        );
+
+        let overrides = ConfigOverrides {
+            a2065_interface: Some("eth-test".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            load_overrides(&overrides)?.a2065_net,
+            Some(crate::net::NetConfig::Bridge {
+                interface: "eth-test".to_string()
+            })
+        );
+
+        // Replacing a file's bridge backend from the CLI also clears the
+        // now-inapplicable carried interface.
+        let mut raw: RawConfig =
+            toml::from_str("[a2065]\nnet = \"bridge\"\ninterface = \"en-test\"\n")?;
+        ConfigOverrides {
+            a2065_net: Some("nat".to_string()),
+            ..Default::default()
+        }
+        .apply_to(&mut raw);
+        assert!(raw.a2065.interface.is_none());
+        assert_eq!(
+            Config::try_from(raw)?.a2065_net,
+            Some(crate::net::NetConfig::Nat)
+        );
         Ok(())
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1349,7 +1349,7 @@ impl M68kMachine {
         let dcache: Option<Box<crate::cache::CpuCache>> = deserialize_component(r, "dcache")?;
         let mut bus: Bus = deserialize_component(r, "bus")?;
 
-        bus.adopt_host_resources(&mut self.bus.bus);
+        bus.adopt_host_resources(&mut self.bus.bus)?;
         bus.adopt_ui_debug_state(&mut self.bus.bus);
         bus.reset_transient_video_after_state_load();
         bus.reset_transient_diagnostics_after_state_load();

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2020,15 +2020,26 @@ pub fn build_machine(
         devices.push(crate::zorro_device::BoardDevice::Filesys(board));
     }
     // A2065 Ethernet board (in-tree LANCE NIC): networking is non-deterministic.
-    if let Some(net_config) = cfg.a2065_net {
+    if let Some(net_config) = &cfg.a2065_net {
         let slot = devices.len();
         zorro.add_board(crate::zorro::BoardSpec::a2065(slot))?;
-        info!(
-            "a2065: Ethernet board on the Zorro chain (slot {slot}), net backend {net_config:?} \
-             -- networking is non-deterministic, replay/save-state reproducibility not guaranteed"
-        );
+        if matches!(
+            net_config,
+            crate::net::NetConfig::Nat | crate::net::NetConfig::Bridge { .. }
+        ) {
+            info!(
+                "a2065: Ethernet board on the Zorro chain (slot {slot}), net backend \
+                 {net_config:?} -- host networking is non-deterministic, replay/save-state \
+                 reproducibility not guaranteed"
+            );
+        } else {
+            info!(
+                "a2065: Ethernet board on the Zorro chain (slot {slot}), net backend \
+                 {net_config:?}"
+            );
+        }
         devices.push(crate::zorro_device::BoardDevice::A2065(
-            crate::a2065::A2065::new(net_config),
+            crate::a2065::A2065::new(net_config.clone())?,
         ));
     }
     // RTG board (`[rtg] card`): the Z3660.card P96 driver drives RTG screens

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,10 @@ pub struct CliArgs {
     pub list_midi: bool,
     /// `--list-audio-devices`: print the host audio output devices and exit.
     pub list_audio_devices: bool,
+    /// `--list-net-interfaces`: print adapters usable for bridging and exit.
+    pub list_net_interfaces: bool,
+    /// Linux companion helper setup action: install, uninstall, or status.
+    pub net_helper_action: Option<String>,
     /// `--sampler-list-audio-inputs`: print the host audio input devices (for
     /// `--sampler-audio-input`) and exit.
     pub list_sampler_inputs: bool,
@@ -328,6 +332,8 @@ where
     let mut calibrate_gamepad = false;
     let mut list_midi = false;
     let mut list_audio_devices = false;
+    let mut list_net_interfaces = false;
+    let mut net_helper_action: Option<String> = None;
     let mut list_sampler_inputs = false;
     let mut overrides = ConfigOverrides::default();
     let mut args = args.into_iter().peekable();
@@ -341,6 +347,27 @@ where
             }
             "--list-audio-devices" => {
                 list_audio_devices = true;
+            }
+            "--list-net-interfaces" => {
+                list_net_interfaces = true;
+            }
+            "--install-net-helper" => {
+                if net_helper_action.is_some() {
+                    return Err(anyhow!("only one network-helper action may be requested"));
+                }
+                net_helper_action = Some("install".to_string());
+            }
+            "--uninstall-net-helper" => {
+                if net_helper_action.is_some() {
+                    return Err(anyhow!("only one network-helper action may be requested"));
+                }
+                net_helper_action = Some("uninstall".to_string());
+            }
+            "--net-helper-status" => {
+                if net_helper_action.is_some() {
+                    return Err(anyhow!("only one network-helper action may be requested"));
+                }
+                net_helper_action = Some("status".to_string());
             }
             "--sampler-list-audio-inputs" => {
                 list_sampler_inputs = true;
@@ -483,8 +510,14 @@ where
             }
             "--a2065-net" => {
                 overrides.a2065_net = Some(args.next().ok_or_else(|| {
-                    anyhow!("--a2065-net requires a backend (none/loopback/nat)")
+                    anyhow!("--a2065-net requires a backend (none/loopback/nat/bridge)")
                 })?);
+            }
+            "--a2065-interface" => {
+                overrides.a2065_interface = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--a2065-interface requires an adapter name"))?,
+                );
             }
             "--midi-out" => {
                 overrides.midi_out = Some(
@@ -910,6 +943,16 @@ where
             "--control-token/--control-info require --control or --control-gui"
         ));
     }
+    if overrides.a2065_interface.is_some()
+        && overrides
+            .a2065_net
+            .as_deref()
+            .is_some_and(|net| !matches!(net.to_ascii_lowercase().as_str(), "bridge" | "bridged"))
+    {
+        return Err(anyhow!(
+            "--a2065-interface conflicts with an explicit non-bridge --a2065-net"
+        ));
+    }
     Ok(CliArgs {
         config_path,
         rom_path,
@@ -940,6 +983,8 @@ where
         calibrate_gamepad,
         list_midi,
         list_audio_devices,
+        list_net_interfaces,
+        net_helper_action,
         list_sampler_inputs,
         overrides,
     })
@@ -1055,6 +1100,10 @@ fn print_help() {
          --audio-filter MODE            Paula filter: auto (default), on, or off\n  \
          --audio-stereo-separation PCT  stereo width 0-100 (100 default, 0 = mono)\n  \
          --list-audio-devices           list host audio output devices and exit\n  \
+         --list-net-interfaces          list adapters usable for bridged Ethernet and exit\n  \
+         --install-net-helper           install Linux bridge helper (CAP_NET_RAW only)\n  \
+         --uninstall-net-helper         remove the Linux bridge helper\n  \
+         --net-helper-status            report Linux bridge-helper status\n  \
          --audio-wav PATH               dump mixed stereo audio to a 32-bit float WAV file\n  \
          \x20                            instead of live output\n  \
          --profile-live-audio SECS      run a no-window Paula-to-cpal profile workload;\n  \
@@ -1065,8 +1114,9 @@ fn print_help() {
          \x20                            tcp-connect, or pty\n  \
          --serial-connect HOST:PORT     dial a remote TCP service (a telnet BBS) with the\n  \
          \x20                            serial port (implies --serial tcp-connect)\n  \
-         --a2065-net BACKEND            fit an A2065 Ethernet board: none, loopback, or\n  \
-         \x20                            nat (user-mode NAT, no host privileges)\n  \
+         --a2065-net BACKEND            fit an A2065 Ethernet board: none, loopback, nat,\n  \
+         \x20                            or bridge (direct attachment to a host adapter)\n  \
+         --a2065-interface NAME         bridge adapter; implies --a2065-net bridge\n  \
          --parallel DEVICE              parallel port: none, printer, or sampler\n  \
          --sampler-audio-input NAME     sampler host capture device (implies --parallel sampler)\n  \
          --sampler-input-gain DB        sampler input gain in dB (implies --parallel sampler)\n  \
@@ -1436,6 +1486,111 @@ fn print_audio_output_devices() -> Result<()> {
     Ok(())
 }
 
+/// Print exact adapter identifiers accepted by bridged networking.
+fn print_net_interfaces() -> Result<()> {
+    #[cfg(all(feature = "net-bridge", not(target_arch = "wasm32")))]
+    {
+        println!("Network interfaces (for --a2065-interface / [a2065] interface):");
+        let interfaces = copperline::net::bridge::list_interfaces()?;
+        if interfaces.is_empty() {
+            println!("  (none found)");
+        }
+        for interface in interfaces {
+            let mut state = Vec::new();
+            if interface.up {
+                state.push("up");
+            } else {
+                state.push("down");
+            }
+            if interface.running {
+                state.push("running");
+            }
+            if interface.loopback {
+                state.push("loopback");
+            }
+            if interface.wireless {
+                state.push("wireless; bridging is best-effort");
+            }
+            println!("  {}\t[{}]", interface.label(), state.join(", "));
+        }
+        Ok(())
+    }
+    #[cfg(not(all(feature = "net-bridge", not(target_arch = "wasm32"))))]
+    {
+        anyhow::bail!("this build has no native bridged-networking support")
+    }
+}
+
+fn run_net_helper_setup(action: &str) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("FLATPAK_ID").is_some() {
+            if action == "status" {
+                #[cfg(feature = "net-bridge")]
+                {
+                    let socket = copperline::net::bridge::linux::helper_socket_path()?;
+                    if socket.exists() {
+                        println!("host helper socket is visible at {}", socket.display());
+                        return Ok(());
+                    }
+                    anyhow::bail!(
+                        "host helper socket is not visible at {}; install and enable \
+                         the Linux network-helper companion on the host",
+                        socket.display()
+                    );
+                }
+                #[cfg(not(feature = "net-bridge"))]
+                anyhow::bail!("this build has no bridged-networking support");
+            }
+            anyhow::bail!(
+                "the Flatpak cannot install a host capability binary from \
+                 inside its sandbox; download the Copperline Linux network-helper \
+                 companion archive, then run its copperline-net-helper-setup {action}"
+            );
+        }
+        let executable = std::env::current_exe()?;
+        let mut candidates = vec![
+            executable.with_file_name("copperline-net-helper-setup"),
+            executable
+                .parent()
+                .and_then(Path::parent)
+                .map(|prefix| {
+                    prefix
+                        .join("libexec")
+                        .join("copperline")
+                        .join("copperline-net-helper-setup")
+                })
+                .unwrap_or_default(),
+            PathBuf::from("packaging/linux/copperline-net-helper-setup"),
+        ];
+        if let Some(appdir) = std::env::var_os("APPDIR") {
+            candidates.insert(
+                0,
+                PathBuf::from(appdir).join("usr/libexec/copperline/copperline-net-helper-setup"),
+            );
+        }
+        let setup = candidates
+            .into_iter()
+            .find(|path| path.is_file())
+            .ok_or_else(|| {
+                anyhow!(
+                    "copperline-net-helper-setup was not found; use the Linux \
+                     network-helper companion archive from the Copperline release"
+                )
+            })?;
+        let status = std::process::Command::new(&setup).arg(action).status()?;
+        if !status.success() {
+            anyhow::bail!("{} {action} failed with {status}", setup.display());
+        }
+        Ok(())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = action;
+        anyhow::bail!("the capability helper is only used for bridged networking on Linux")
+    }
+}
+
 /// Print the host audio input devices for `--sampler-list-audio-inputs`. These
 /// are the names `--sampler-audio-input` and `[parallel] sampler_input` match
 /// against.
@@ -1509,6 +1664,12 @@ fn main() -> Result<()> {
     }
     if cli.list_audio_devices {
         return print_audio_output_devices();
+    }
+    if cli.list_net_interfaces {
+        return print_net_interfaces();
+    }
+    if let Some(action) = cli.net_helper_action.as_deref() {
+        return run_net_helper_setup(action);
     }
     if cli.list_sampler_inputs {
         return print_sampler_input_devices();
@@ -2012,6 +2173,19 @@ mod tests {
             &parse(&["--screenshot-after", "5", "out.png"]).unwrap()
         ));
         assert!(!launcher_requested(&parse(&["--noaudio"]).unwrap()));
+    }
+
+    #[test]
+    fn bridge_cli_interface_implies_bridge_and_rejects_conflicts() {
+        let args = parse(&["--a2065-interface", "en-test"]).unwrap();
+        assert_eq!(args.overrides.a2065_interface.as_deref(), Some("en-test"));
+        assert!(args.overrides.a2065_net.is_none());
+
+        let args = parse(&["--a2065-net", "bridge", "--a2065-interface", "en-test"]).unwrap();
+        assert_eq!(args.overrides.a2065_net.as_deref(), Some("bridge"));
+
+        let error = parse(&["--a2065-net", "nat", "--a2065-interface", "en-test"]).unwrap_err();
+        assert!(error.to_string().contains("conflicts"), "{error:#}");
     }
 
     fn temp_script(name: &str, contents: &str) -> PathBuf {

--- a/src/net/bridge/linux.rs
+++ b/src/net/bridge/linux.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Linux AF_PACKET bridge and the FD-passing capability helper protocol.
+
+use super::{AdapterIo, HostInterface};
+use anyhow::{anyhow, bail, Context, Result};
+use std::ffi::{CStr, CString};
+use std::io::{Read, Write};
+use std::mem::{size_of, zeroed};
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const ETH_P_ALL: u16 = 0x0003;
+const HELPER_MAGIC: &[u8; 8] = b"CLNETFD1";
+const MAX_INTERFACE_LEN: usize = libc::IFNAMSIZ - 1;
+
+pub(super) fn list_interfaces() -> Result<Vec<HostInterface>> {
+    let mut out = Vec::new();
+    let interfaces = unsafe { libc::if_nameindex() };
+    if interfaces.is_null() {
+        return Err(std::io::Error::last_os_error()).context("if_nameindex");
+    }
+    let mut current = interfaces;
+    while unsafe { (*current).if_index } != 0 {
+        let name = unsafe { CStr::from_ptr((*current).if_name) }
+            .to_string_lossy()
+            .into_owned();
+        let flags = interface_flags(&name).unwrap_or(0);
+        let wireless = Path::new("/sys/class/net")
+            .join(&name)
+            .join("wireless")
+            .exists();
+        out.push(HostInterface {
+            name,
+            description: None,
+            up: flags & libc::IFF_UP != 0,
+            running: flags & libc::IFF_RUNNING != 0,
+            loopback: flags & libc::IFF_LOOPBACK != 0,
+            wireless,
+        });
+        current = unsafe { current.add(1) };
+    }
+    unsafe { libc::if_freenameindex(interfaces) };
+    Ok(out)
+}
+
+fn interface_flags(name: &str) -> Result<i32> {
+    let socket = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM | libc::SOCK_CLOEXEC, 0) };
+    if socket < 0 {
+        return Err(std::io::Error::last_os_error()).context("opening ioctl socket");
+    }
+    let name = CString::new(name)?;
+    let mut ifr: libc::ifreq = unsafe { zeroed() };
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            name.as_ptr(),
+            ifr.ifr_name.as_mut_ptr(),
+            name.as_bytes_with_nul().len(),
+        );
+    }
+    let rc = unsafe { libc::ioctl(socket, libc::SIOCGIFFLAGS, &mut ifr) };
+    let error = std::io::Error::last_os_error();
+    unsafe { libc::close(socket) };
+    if rc < 0 {
+        return Err(error).context("SIOCGIFFLAGS");
+    }
+    Ok(unsafe { ifr.ifr_ifru.ifru_flags } as i32)
+}
+
+pub(super) fn open(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<LinuxAdapter> {
+    match open_packet_socket(interface, guest_mac) {
+        Ok(fd) => Ok(LinuxAdapter { fd }),
+        Err(direct_error)
+            if matches!(
+                direct_error
+                    .downcast_ref::<std::io::Error>()
+                    .and_then(std::io::Error::raw_os_error),
+                Some(libc::EPERM | libc::EACCES)
+            ) =>
+        {
+            let fd = request_helper_fd(interface, guest_mac).with_context(|| {
+                format!(
+                    "direct AF_PACKET access was denied ({direct_error:#}); \
+                     install/start copperline-net-helper"
+                )
+            })?;
+            Ok(LinuxAdapter { fd })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) struct LinuxAdapter {
+    fd: OwnedFd,
+}
+
+impl AdapterIo for LinuxAdapter {
+    fn send(&mut self, frame: &[u8]) -> Result<()> {
+        let sent = unsafe {
+            libc::send(
+                self.fd.as_raw_fd(),
+                frame.as_ptr().cast(),
+                frame.len(),
+                libc::MSG_NOSIGNAL,
+            )
+        };
+        if sent < 0 {
+            return Err(std::io::Error::last_os_error()).context("AF_PACKET send");
+        }
+        if sent as usize != frame.len() {
+            bail!("AF_PACKET short send ({sent} of {} bytes)", frame.len());
+        }
+        Ok(())
+    }
+
+    fn receive(&mut self) -> Result<Option<Vec<u8>>> {
+        let mut frame = vec![0u8; 65_535];
+        let received = unsafe {
+            libc::recv(
+                self.fd.as_raw_fd(),
+                frame.as_mut_ptr().cast(),
+                frame.len(),
+                0,
+            )
+        };
+        if received < 0 {
+            let error = std::io::Error::last_os_error();
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+            ) {
+                return Ok(None);
+            }
+            return Err(error).context("AF_PACKET receive");
+        }
+        frame.truncate(received as usize);
+        Ok(Some(frame))
+    }
+
+    fn set_guest_mac(&mut self, mac: [u8; 6]) -> Result<()> {
+        attach_filter(self.fd.as_raw_fd(), Some(mac))
+    }
+}
+
+use std::os::fd::AsRawFd;
+
+fn attach_filter(fd: RawFd, guest_mac: Option<[u8; 6]>) -> Result<()> {
+    // Kernel guard: admit the guest destination and Ethernet group addresses.
+    // Source-MAC echo suppression is repeated in the worker.
+    const BPF_LD: u16 = 0x00;
+    const BPF_H: u16 = 0x08;
+    const BPF_W: u16 = 0x00;
+    const BPF_B: u16 = 0x10;
+    const BPF_ABS: u16 = 0x20;
+    const BPF_JMP: u16 = 0x05;
+    const BPF_JEQ: u16 = 0x10;
+    const BPF_JSET: u16 = 0x40;
+    const BPF_K: u16 = 0x00;
+    const BPF_RET: u16 = 0x06;
+
+    let instruction = |code, jt, jf, k| libc::sock_filter { code, jt, jf, k };
+    let mut instructions = if let Some(mac) = guest_mac {
+        let first = u32::from(u16::from_be_bytes([mac[0], mac[1]]));
+        let rest = u32::from_be_bytes([mac[2], mac[3], mac[4], mac[5]]);
+        vec![
+            instruction(BPF_LD | BPF_H | BPF_ABS, 0, 0, 0),
+            instruction(BPF_JMP | BPF_JEQ | BPF_K, 0, 2, first),
+            instruction(BPF_LD | BPF_W | BPF_ABS, 0, 0, 2),
+            instruction(BPF_JMP | BPF_JEQ | BPF_K, 2, 0, rest),
+            instruction(BPF_LD | BPF_B | BPF_ABS, 0, 0, 0),
+            instruction(BPF_JMP | BPF_JSET | BPF_K, 0, 1, 1),
+            instruction(BPF_RET | BPF_K, 0, 0, 65_535),
+            instruction(BPF_RET | BPF_K, 0, 0, 0),
+        ]
+    } else {
+        // Before a generic plugin NIC transmits its first frame (and reveals
+        // its source MAC), multicast/broadcast is the only useful ingress.
+        vec![
+            instruction(BPF_LD | BPF_B | BPF_ABS, 0, 0, 0),
+            instruction(BPF_JMP | BPF_JSET | BPF_K, 0, 1, 1),
+            instruction(BPF_RET | BPF_K, 0, 0, 65_535),
+            instruction(BPF_RET | BPF_K, 0, 0, 0),
+        ]
+    };
+    let program = libc::sock_fprog {
+        len: instructions.len() as u16,
+        filter: instructions.as_mut_ptr(),
+    };
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_ATTACH_FILTER,
+            (&program as *const libc::sock_fprog).cast(),
+            size_of::<libc::sock_fprog>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error()).context("attaching AF_PACKET receive filter");
+    }
+    Ok(())
+}
+
+fn open_packet_socket(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<OwnedFd> {
+    if interface.len() > MAX_INTERFACE_LEN {
+        bail!("interface name is too long: {interface:?}");
+    }
+    let name = CString::new(interface).context("interface name contains a NUL")?;
+    let index = unsafe { libc::if_nametoindex(name.as_ptr()) };
+    if index == 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("network interface {interface:?} was not found"));
+    }
+    let raw = unsafe {
+        libc::socket(
+            libc::AF_PACKET,
+            libc::SOCK_RAW | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC,
+            i32::from(ETH_P_ALL.to_be()),
+        )
+    };
+    if raw < 0 {
+        return Err(std::io::Error::last_os_error()).context("opening AF_PACKET socket");
+    }
+    let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+
+    let address = libc::sockaddr_ll {
+        sll_family: libc::AF_PACKET as u16,
+        sll_protocol: ETH_P_ALL.to_be(),
+        sll_ifindex: index as i32,
+        sll_hatype: 0,
+        sll_pkttype: 0,
+        sll_halen: 0,
+        sll_addr: [0; 8],
+    };
+    let rc = unsafe {
+        libc::bind(
+            fd.as_raw_fd(),
+            (&address as *const libc::sockaddr_ll).cast(),
+            size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("binding AF_PACKET socket to {interface:?}"));
+    }
+
+    let membership = libc::packet_mreq {
+        mr_ifindex: index as i32,
+        mr_type: libc::PACKET_MR_PROMISC as u16,
+        mr_alen: 0,
+        mr_address: [0; 8],
+    };
+    let rc = unsafe {
+        libc::setsockopt(
+            fd.as_raw_fd(),
+            libc::SOL_PACKET,
+            libc::PACKET_ADD_MEMBERSHIP,
+            (&membership as *const libc::packet_mreq).cast(),
+            size_of::<libc::packet_mreq>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("enabling promiscuous capture on {interface:?}"));
+    }
+    attach_filter(fd.as_raw_fd(), guest_mac)?;
+    Ok(fd)
+}
+
+/// Per-user helper control socket.
+pub fn helper_socket_path() -> Result<PathBuf> {
+    if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
+        return Ok(PathBuf::from(runtime)
+            .join("copperline-net-helper")
+            .join("control.sock"));
+    }
+    Ok(PathBuf::from(format!(
+        "/run/user/{}/copperline-net-helper/control.sock",
+        unsafe { libc::geteuid() }
+    )))
+}
+
+fn request_helper_fd(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<OwnedFd> {
+    if interface.len() > MAX_INTERFACE_LEN {
+        bail!("interface name is too long: {interface:?}");
+    }
+    let path = helper_socket_path()?;
+    let mut stream = match UnixStream::connect(&path) {
+        Ok(stream) => stream,
+        Err(first_error) => {
+            start_helper().with_context(|| {
+                format!(
+                    "connecting to helper socket {} failed: {first_error}",
+                    path.display()
+                )
+            })?;
+            let mut connected = None;
+            for _ in 0..20 {
+                std::thread::sleep(Duration::from_millis(25));
+                if let Ok(stream) = UnixStream::connect(&path) {
+                    connected = Some(stream);
+                    break;
+                }
+            }
+            connected.ok_or_else(|| {
+                anyhow!(
+                    "helper did not create its control socket at {}",
+                    path.display()
+                )
+            })?
+        }
+    };
+    stream.write_all(HELPER_MAGIC)?;
+    stream.write_all(&(interface.len() as u16).to_be_bytes())?;
+    stream.write_all(interface.as_bytes())?;
+    stream.write_all(&guest_mac.unwrap_or([0; 6]))?;
+    receive_fd(&stream)
+}
+
+fn start_helper() -> Result<()> {
+    let current = std::env::current_exe().context("locating Copperline executable")?;
+    // Prefer the systemd user socket installed by the companion setup. It is
+    // also the path Flatpak uses: connecting to the exported runtime socket
+    // activates this host service without granting the sandbox raw devices.
+    let systemd_started = std::process::Command::new("systemctl")
+        .args(["--user", "start", "copperline-net-helper.socket"])
+        .status()
+        .is_ok_and(|status| status.success());
+    if systemd_started {
+        return Ok(());
+    }
+    let sibling = current.with_file_name("copperline-net-helper");
+    let system = PathBuf::from("/usr/libexec/copperline/copperline-net-helper");
+    let helper = if system.exists() { &system } else { &sibling };
+    std::process::Command::new(helper)
+        .arg("--serve")
+        .spawn()
+        .with_context(|| {
+            format!(
+                "starting {}; run `copperline --install-net-helper` first",
+                helper.display()
+            )
+        })?;
+    Ok(())
+}
+
+fn receive_fd(stream: &UnixStream) -> Result<OwnedFd> {
+    let mut byte = 0u8;
+    let mut iov = libc::iovec {
+        iov_base: (&mut byte as *mut u8).cast(),
+        iov_len: 1,
+    };
+    let mut control = [0u8; 64];
+    let mut message: libc::msghdr = unsafe { zeroed() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control.len();
+    let received = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut message, 0) };
+    if received < 0 {
+        return Err(std::io::Error::last_os_error()).context("receiving helper response");
+    }
+    if byte != 0 {
+        let mut text = String::new();
+        (&mut &*stream).read_to_string(&mut text).ok();
+        bail!("network helper rejected request: {}", text.trim());
+    }
+    let header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    if header.is_null()
+        || unsafe { (*header).cmsg_level } != libc::SOL_SOCKET
+        || unsafe { (*header).cmsg_type } != libc::SCM_RIGHTS
+    {
+        bail!("network helper response carried no AF_PACKET file descriptor");
+    }
+    let raw = unsafe { *libc::CMSG_DATA(header).cast::<RawFd>() };
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// Run the narrowly scoped per-user capability helper. The executable should
+/// be root-owned with only `cap_net_raw=ep`; it never handles Ethernet frames,
+/// and passes one configured AF_PACKET descriptor per validated request.
+pub fn run_helper() -> Result<()> {
+    ensure_helper_group()?;
+    if systemd_listener_available() {
+        let listener = unsafe { UnixListener::from_raw_fd(3) };
+        return serve_connections(listener);
+    }
+    let path = helper_socket_path()?;
+    let directory = path
+        .parent()
+        .ok_or_else(|| anyhow!("helper socket has no parent directory"))?;
+    std::fs::create_dir_all(directory)
+        .with_context(|| format!("creating {}", directory.display()))?;
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o700))?;
+    if path.exists() {
+        match UnixStream::connect(&path) {
+            Ok(_) => bail!("network helper is already running"),
+            Err(_) => std::fs::remove_file(&path)
+                .with_context(|| format!("removing stale {}", path.display()))?,
+        }
+    }
+    let listener =
+        UnixListener::bind(&path).with_context(|| format!("binding {}", path.display()))?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    serve_connections(listener)
+}
+
+fn serve_connections(listener: UnixListener) -> Result<()> {
+    for connection in listener.incoming() {
+        let mut stream = connection?;
+        if let Err(error) = serve_request(&mut stream) {
+            let _ = stream.write_all(&[1]);
+            let _ = writeln!(stream, "{error:#}");
+        }
+    }
+    Ok(())
+}
+
+fn systemd_listener_available() -> bool {
+    std::env::var("LISTEN_PID")
+        .ok()
+        .and_then(|pid| pid.parse::<u32>().ok())
+        == Some(std::process::id())
+        && std::env::var("LISTEN_FDS").ok().as_deref() == Some("1")
+}
+
+fn ensure_helper_group() -> Result<()> {
+    let name = CString::new("copperline-net").unwrap();
+    let group = unsafe { libc::getgrnam(name.as_ptr()) };
+    if group.is_null() {
+        bail!(
+            "the copperline-net group is missing; run \
+             `copperline --install-net-helper`"
+        );
+    }
+    let target = unsafe { (*group).gr_gid };
+    if unsafe { libc::getegid() } == target {
+        return Ok(());
+    }
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count < 0 {
+        return Err(std::io::Error::last_os_error()).context("reading supplementary groups");
+    }
+    let mut groups = vec![0 as libc::gid_t; count as usize];
+    if unsafe { libc::getgroups(count, groups.as_mut_ptr()) } < 0 {
+        return Err(std::io::Error::last_os_error()).context("reading supplementary groups");
+    }
+    if !groups.contains(&target) {
+        bail!(
+            "this user is not in the copperline-net group; log out and back in \
+             after installing the helper"
+        );
+    }
+    Ok(())
+}
+
+fn serve_request(stream: &mut UnixStream) -> Result<()> {
+    let mut magic = [0u8; HELPER_MAGIC.len()];
+    stream.read_exact(&mut magic)?;
+    if &magic != HELPER_MAGIC {
+        bail!("unsupported helper protocol");
+    }
+    let mut length = [0u8; 2];
+    stream.read_exact(&mut length)?;
+    let length = usize::from(u16::from_be_bytes(length));
+    if length == 0 || length > MAX_INTERFACE_LEN {
+        bail!("invalid interface name length");
+    }
+    let mut name = vec![0u8; length];
+    stream.read_exact(&mut name)?;
+    let name = std::str::from_utf8(&name).context("interface name is not UTF-8")?;
+    let mut mac = [0u8; 6];
+    stream.read_exact(&mut mac)?;
+    let mac = (mac != [0; 6]).then_some(mac);
+    let fd = open_packet_socket(name, mac)?;
+    send_fd(stream, fd.as_raw_fd())
+}
+
+fn send_fd(stream: &UnixStream, fd: RawFd) -> Result<()> {
+    let mut byte = 0u8;
+    let mut iov = libc::iovec {
+        iov_base: (&mut byte as *mut u8).cast(),
+        iov_len: 1,
+    };
+    let space = unsafe { libc::CMSG_SPACE(size_of::<RawFd>() as u32) } as usize;
+    let mut control = vec![0u8; space];
+    let mut message: libc::msghdr = unsafe { zeroed() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control.len();
+    let header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    unsafe {
+        (*header).cmsg_level = libc::SOL_SOCKET;
+        (*header).cmsg_type = libc::SCM_RIGHTS;
+        (*header).cmsg_len = libc::CMSG_LEN(size_of::<RawFd>() as u32) as usize;
+        *libc::CMSG_DATA(header).cast::<RawFd>() = fd;
+    }
+    let sent = unsafe { libc::sendmsg(stream.as_raw_fd(), &message, libc::MSG_NOSIGNAL) };
+    if sent < 0 {
+        return Err(std::io::Error::last_os_error()).context("sending AF_PACKET descriptor");
+    }
+    Ok(())
+}

--- a/src/net/bridge/linux.rs
+++ b/src/net/bridge/linux.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 const ETH_P_ALL: u16 = 0x0003;
 const HELPER_MAGIC: &[u8; 8] = b"CLNETFD1";
 const MAX_INTERFACE_LEN: usize = libc::IFNAMSIZ - 1;
+const MAX_FRAME_LEN: usize = 65_535;
 
 pub(super) fn list_interfaces() -> Result<Vec<HostInterface>> {
     let mut out = Vec::new();
@@ -71,7 +72,7 @@ fn interface_flags(name: &str) -> Result<i32> {
 
 pub(super) fn open(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<LinuxAdapter> {
     match open_packet_socket(interface, guest_mac) {
-        Ok(fd) => Ok(LinuxAdapter { fd }),
+        Ok(fd) => Ok(LinuxAdapter::new(fd)),
         Err(direct_error)
             if matches!(
                 direct_error
@@ -86,7 +87,7 @@ pub(super) fn open(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<LinuxA
                      install/start copperline-net-helper"
                 )
             })?;
-            Ok(LinuxAdapter { fd })
+            Ok(LinuxAdapter::new(fd))
         }
         Err(error) => Err(error),
     }
@@ -94,6 +95,16 @@ pub(super) fn open(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<LinuxA
 
 pub(super) struct LinuxAdapter {
     fd: OwnedFd,
+    receive_buffer: Box<[u8]>,
+}
+
+impl LinuxAdapter {
+    fn new(fd: OwnedFd) -> Self {
+        Self {
+            fd,
+            receive_buffer: vec![0; MAX_FRAME_LEN].into_boxed_slice(),
+        }
+    }
 }
 
 impl AdapterIo for LinuxAdapter {
@@ -107,7 +118,17 @@ impl AdapterIo for LinuxAdapter {
             )
         };
         if sent < 0 {
-            return Err(std::io::Error::last_os_error()).context("AF_PACKET send");
+            let error = std::io::Error::last_os_error();
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+            ) {
+                // The worker is deliberately non-blocking. A saturated socket
+                // or interrupted send is ordinary Ethernet loss, just like a
+                // full bounded TX channel, rather than a link failure.
+                return Ok(());
+            }
+            return Err(error).context("AF_PACKET send");
         }
         if sent as usize != frame.len() {
             bail!("AF_PACKET short send ({sent} of {} bytes)", frame.len());
@@ -116,12 +137,11 @@ impl AdapterIo for LinuxAdapter {
     }
 
     fn receive(&mut self) -> Result<Option<Vec<u8>>> {
-        let mut frame = vec![0u8; 65_535];
         let received = unsafe {
             libc::recv(
                 self.fd.as_raw_fd(),
-                frame.as_mut_ptr().cast(),
-                frame.len(),
+                self.receive_buffer.as_mut_ptr().cast(),
+                self.receive_buffer.len(),
                 0,
             )
         };
@@ -135,8 +155,7 @@ impl AdapterIo for LinuxAdapter {
             }
             return Err(error).context("AF_PACKET receive");
         }
-        frame.truncate(received as usize);
-        Ok(Some(frame))
+        Ok(Some(self.receive_buffer[..received as usize].to_vec()))
     }
 
     fn set_guest_mac(&mut self, mac: [u8; 6]) -> Result<()> {

--- a/src/net/bridge/macos.rs
+++ b/src/net/bridge/macos.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::{mac_filter, AdapterIo, HostInterface};
+use anyhow::{bail, Context, Result};
+use pcap::{Active, Capture, Device, Error as PcapError, Linktype};
+
+pub(super) fn list_interfaces() -> Result<Vec<HostInterface>> {
+    Ok(Device::list()?
+        .into_iter()
+        .map(|device| HostInterface {
+            name: device.name,
+            description: device.desc,
+            up: device.flags.is_up(),
+            running: device.flags.is_running(),
+            loopback: device.flags.is_loopback(),
+            wireless: device.flags.is_wireless(),
+        })
+        .collect())
+}
+
+pub(super) fn open(interface: &str, _guest_mac: Option<[u8; 6]>) -> Result<MacAdapter> {
+    let capture = Capture::from_device(interface)
+        .with_context(|| format!("libpcap did not find adapter {interface:?}"))?
+        .promisc(true)
+        .immediate_mode(true)
+        .snaplen(65_535)
+        .timeout(1)
+        .open()
+        .with_context(|| {
+            format!(
+                "libpcap could not open {interface:?}; on macOS the user must \
+                 have access to /dev/bpf (normally through the access_bpf group)"
+            )
+        })?;
+    if capture.get_datalink() != Linktype::ETHERNET {
+        bail!(
+            "adapter {interface:?} does not expose Ethernet frames through libpcap \
+             (link type {:?})",
+            capture.get_datalink()
+        );
+    }
+    Ok(MacAdapter {
+        capture: capture.setnonblock()?,
+    })
+}
+
+pub(super) struct MacAdapter {
+    capture: Capture<Active>,
+}
+
+impl AdapterIo for MacAdapter {
+    fn send(&mut self, frame: &[u8]) -> Result<()> {
+        self.capture.sendpacket(frame).map_err(Into::into)
+    }
+
+    fn receive(&mut self) -> Result<Option<Vec<u8>>> {
+        match self.capture.next_packet() {
+            Ok(packet) => Ok(Some(packet.data.to_vec())),
+            Err(PcapError::NoMorePackets | PcapError::TimeoutExpired) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn set_guest_mac(&mut self, mac: [u8; 6]) -> Result<()> {
+        self.capture.filter(&mac_filter(mac), true)?;
+        Ok(())
+    }
+}

--- a/src/net/bridge/mod.rs
+++ b/src/net/bridge/mod.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Direct host-adapter Ethernet bridge.
+//!
+//! The emulator thread never blocks on host I/O. A small worker owns the
+//! platform capture/injection handle and exchanges complete Ethernet frames
+//! with the emulated board over bounded channels. Receive filtering is
+//! applied in the platform capture engine where possible and repeated here as
+//! a safety boundary.
+
+use super::NetBackend;
+use anyhow::{Context, Result};
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+pub mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "linux")]
+use linux as platform;
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(target_os = "windows")]
+use windows as platform;
+
+/// One adapter selectable for direct bridging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostInterface {
+    /// Stable platform identifier accepted by `interface = "..."`.
+    pub name: String,
+    /// Human-facing description, when the platform provides one.
+    pub description: Option<String>,
+    pub up: bool,
+    pub running: bool,
+    pub loopback: bool,
+    pub wireless: bool,
+}
+
+impl HostInterface {
+    /// Concise label for CLI and launcher pickers.
+    pub fn label(&self) -> String {
+        match self.description.as_deref() {
+            Some(description) if description != self.name => {
+                format!("{description} [{}]", self.name)
+            }
+            _ => self.name.clone(),
+        }
+    }
+}
+
+/// Enumerate adapters available to the bridge backend.
+pub fn list_interfaces() -> Result<Vec<HostInterface>> {
+    let mut interfaces = platform::list_interfaces()
+        .context("enumerating host network interfaces for bridged networking")?;
+    interfaces.sort_by(|a, b| {
+        b.running
+            .cmp(&a.running)
+            .then_with(|| b.up.cmp(&a.up))
+            .then_with(|| a.loopback.cmp(&b.loopback))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(interfaces)
+}
+
+trait AdapterIo: Send {
+    fn send(&mut self, frame: &[u8]) -> Result<()>;
+    fn receive(&mut self) -> Result<Option<Vec<u8>>>;
+    fn set_guest_mac(&mut self, mac: [u8; 6]) -> Result<()>;
+}
+
+const TO_ADAPTER_CAPACITY: usize = 256;
+const TO_GUEST_CAPACITY: usize = 512;
+const MAX_RX_BURST: usize = 128;
+
+enum Command {
+    Frame(Vec<u8>),
+    GuestMac([u8; 6]),
+}
+
+/// Emulator-side handle for a direct adapter bridge.
+pub struct BridgeBackend {
+    to_adapter: Option<mpsc::SyncSender<Command>>,
+    from_adapter: mpsc::Receiver<Vec<u8>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    guest_mac: Option<[u8; 6]>,
+}
+
+impl BridgeBackend {
+    /// Open `interface` synchronously, then hand it to a non-blocking worker.
+    /// Opening before the thread starts is intentional: configuration,
+    /// permission, and missing-driver errors reach the startup caller.
+    pub fn new(interface: &str, guest_mac: Option<[u8; 6]>) -> Result<Self> {
+        let mut adapter = platform::open(interface, guest_mac)
+            .with_context(|| format!("opening bridge interface {interface:?}"))?;
+        if let Some(mac) = guest_mac {
+            adapter
+                .set_guest_mac(mac)
+                .context("installing initial bridge receive filter")?;
+        } else {
+            // Generic plugin NICs reveal their address in their first TX
+            // frame. Until then, an all-zero unicast placeholder leaves only
+            // multicast/broadcast useful and keeps platform capture bounded.
+            adapter
+                .set_guest_mac([0; 6])
+                .context("installing initial multicast bridge receive filter")?;
+        }
+
+        let (in_tx, in_rx) = mpsc::sync_channel(TO_ADAPTER_CAPACITY);
+        let (out_tx, out_rx) = mpsc::sync_channel(TO_GUEST_CAPACITY);
+        let interface_name = interface.to_string();
+        let thread = std::thread::Builder::new()
+            .name("a2065-bridge".into())
+            .spawn(move || run_worker(&interface_name, adapter, guest_mac, in_rx, out_tx))
+            .context("starting bridge worker thread")?;
+        Ok(Self {
+            to_adapter: Some(in_tx),
+            from_adapter: out_rx,
+            thread: Some(thread),
+            guest_mac,
+        })
+    }
+}
+
+impl NetBackend for BridgeBackend {
+    fn send(&mut self, frame: &[u8]) {
+        if let Some(tx) = &self.to_adapter {
+            // A2065 supplies PADR explicitly. A generic WASM NIC has no
+            // separate MAC-setting import, so learn its station address from
+            // the first transmitted Ethernet frame.
+            if frame.len() >= 12 {
+                let mut source = [0u8; 6];
+                source.copy_from_slice(&frame[6..12]);
+                if source[0] & 1 == 0
+                    && source != [0; 6]
+                    && self.guest_mac != Some(source)
+                    && tx.try_send(Command::GuestMac(source)).is_ok()
+                {
+                    self.guest_mac = Some(source);
+                }
+            }
+            // A full queue is ordinary Ethernet loss, never an emulator stall.
+            let _ = tx.try_send(Command::Frame(frame.to_vec()));
+        }
+    }
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        self.from_adapter.try_recv().ok()
+    }
+
+    fn set_guest_mac(&mut self, mac: [u8; 6]) {
+        if let Some(tx) = &self.to_adapter {
+            if tx.try_send(Command::GuestMac(mac)).is_ok() {
+                self.guest_mac = Some(mac);
+            }
+        }
+    }
+}
+
+impl Drop for BridgeBackend {
+    fn drop(&mut self) {
+        self.to_adapter = None;
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_worker(
+    interface: &str,
+    mut adapter: impl AdapterIo,
+    mut guest_mac: Option<[u8; 6]>,
+    in_rx: mpsc::Receiver<Command>,
+    out_tx: mpsc::SyncSender<Vec<u8>>,
+) {
+    loop {
+        match in_rx.recv_timeout(Duration::from_millis(1)) {
+            Ok(command) => {
+                if !handle_command(interface, &mut adapter, &mut guest_mac, command) {
+                    break;
+                }
+                while let Ok(command) = in_rx.try_recv() {
+                    if !handle_command(interface, &mut adapter, &mut guest_mac, command) {
+                        return;
+                    }
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+
+        for _ in 0..MAX_RX_BURST {
+            match adapter.receive() {
+                Ok(Some(frame)) => {
+                    if accept_frame(&frame, guest_mac) && out_tx.try_send(frame).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    log::error!(
+                        "bridge interface {interface:?} went down: {error}; \
+                         guest link is now disconnected"
+                    );
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn handle_command(
+    interface: &str,
+    adapter: &mut impl AdapterIo,
+    guest_mac: &mut Option<[u8; 6]>,
+    command: Command,
+) -> bool {
+    match command {
+        Command::Frame(frame) => {
+            if let Err(error) = adapter.send(&frame) {
+                log::error!(
+                    "bridge interface {interface:?} transmit failed: {error}; \
+                     guest link is now disconnected"
+                );
+                return false;
+            }
+        }
+        Command::GuestMac(mac) => {
+            *guest_mac = Some(mac);
+            if let Err(error) = adapter.set_guest_mac(mac) {
+                log::error!(
+                    "bridge interface {interface:?} receive-filter update failed: {error}; \
+                     guest link is now disconnected"
+                );
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Accept frames addressed to the guest plus all Ethernet multicast/broadcast
+/// traffic. Frames sourced by the guest are suppressed to avoid capture echo.
+fn accept_frame(frame: &[u8], guest_mac: Option<[u8; 6]>) -> bool {
+    if frame.len() < 14 {
+        return false;
+    }
+    if guest_mac.is_some_and(|mac| frame[6..12] == mac) {
+        return false;
+    }
+    frame[0] & 1 != 0 || guest_mac.is_some_and(|mac| frame[..6] == mac)
+}
+
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
+fn mac_filter(mac: [u8; 6]) -> String {
+    format!(
+        "(ether dst {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x} or ether multicast) \
+         and not ether src {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        mac[0],
+        mac[1],
+        mac[2],
+        mac[3],
+        mac[4],
+        mac[5],
+        mac[0],
+        mac[1],
+        mac[2],
+        mac[3],
+        mac[4],
+        mac[5]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAC: [u8; 6] = [0x02, 0, 0x10, 0, 0, 1];
+
+    fn frame(dst: [u8; 6], src: [u8; 6]) -> Vec<u8> {
+        let mut frame = vec![0; 60];
+        frame[..6].copy_from_slice(&dst);
+        frame[6..12].copy_from_slice(&src);
+        frame
+    }
+
+    #[test]
+    fn software_filter_accepts_guest_and_group_destinations() {
+        assert!(accept_frame(&frame(MAC, [1; 6]), Some(MAC)));
+        assert!(accept_frame(&frame([0xff; 6], [1; 6]), Some(MAC)));
+        assert!(accept_frame(
+            &frame([0x01, 0, 0x5e, 0, 0, 1], [1; 6]),
+            Some(MAC)
+        ));
+        assert!(!accept_frame(
+            &frame([0x02, 3, 4, 5, 6, 7], [1; 6]),
+            Some(MAC)
+        ));
+    }
+
+    #[test]
+    fn software_filter_suppresses_guest_capture_echo_and_junk() {
+        assert!(!accept_frame(&frame([0xff; 6], MAC), Some(MAC)));
+        assert!(!accept_frame(&[0; 13], Some(MAC)));
+        assert!(accept_frame(&frame([0xff; 6], [1; 6]), None));
+    }
+
+    #[test]
+    fn pcap_filter_contains_both_mac_directions() {
+        let filter = mac_filter(MAC);
+        assert!(filter.contains("ether dst 02:00:10:00:00:01"));
+        assert!(filter.contains("not ether src 02:00:10:00:00:01"));
+    }
+}

--- a/src/net/bridge/windows.rs
+++ b/src/net/bridge/windows.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Runtime-loaded Npcap bridge.
+//!
+//! Npcap's SDK DLL is not redistributable with Copperline's normal release.
+//! Keeping every entry point behind `libloading` means NAT-only users have no
+//! `wpcap.dll` process dependency. Only absolute paths beneath the Windows
+//! system directory are considered.
+
+use super::{mac_filter, AdapterIo, HostInterface};
+use anyhow::{anyhow, bail, Context, Result};
+use libloading::Library;
+use std::ffi::{c_char, c_int, c_uchar, c_uint, c_void, CStr, CString};
+use std::path::PathBuf;
+use std::ptr;
+use std::sync::Arc;
+
+const PCAP_ERRBUF_SIZE: usize = 256;
+const DLT_EN10MB: c_int = 1;
+const PCAP_IF_LOOPBACK: c_uint = 0x1;
+const PCAP_IF_UP: c_uint = 0x2;
+const PCAP_IF_RUNNING: c_uint = 0x4;
+const PCAP_IF_WIRELESS: c_uint = 0x8;
+
+type Pcap = c_void;
+
+#[repr(C)]
+struct PcapIf {
+    next: *mut PcapIf,
+    name: *mut c_char,
+    description: *mut c_char,
+    addresses: *mut c_void,
+    flags: c_uint,
+}
+
+#[repr(C)]
+struct Timeval {
+    tv_sec: i32,
+    tv_usec: i32,
+}
+
+#[repr(C)]
+struct PcapPacketHeader {
+    ts: Timeval,
+    caplen: c_uint,
+    len: c_uint,
+}
+
+#[repr(C)]
+struct BpfInsn {
+    code: u16,
+    jt: u8,
+    jf: u8,
+    k: c_uint,
+}
+
+#[repr(C)]
+struct BpfProgram {
+    bf_len: c_uint,
+    bf_insns: *mut BpfInsn,
+}
+
+type FindAllDevs = unsafe extern "C" fn(*mut *mut PcapIf, *mut c_char) -> c_int;
+type FreeAllDevs = unsafe extern "C" fn(*mut PcapIf);
+type Create = unsafe extern "C" fn(*const c_char, *mut c_char) -> *mut Pcap;
+type SetInt = unsafe extern "C" fn(*mut Pcap, c_int) -> c_int;
+type Activate = unsafe extern "C" fn(*mut Pcap) -> c_int;
+type SetNonblock = unsafe extern "C" fn(*mut Pcap, c_int, *mut c_char) -> c_int;
+type Datalink = unsafe extern "C" fn(*mut Pcap) -> c_int;
+type Compile =
+    unsafe extern "C" fn(*mut Pcap, *mut BpfProgram, *const c_char, c_int, c_uint) -> c_int;
+type SetFilter = unsafe extern "C" fn(*mut Pcap, *mut BpfProgram) -> c_int;
+type FreeCode = unsafe extern "C" fn(*mut BpfProgram);
+type NextEx =
+    unsafe extern "C" fn(*mut Pcap, *mut *const PcapPacketHeader, *mut *const c_uchar) -> c_int;
+type SendPacket = unsafe extern "C" fn(*mut Pcap, *const c_uchar, c_int) -> c_int;
+type GetErr = unsafe extern "C" fn(*mut Pcap) -> *const c_char;
+type Close = unsafe extern "C" fn(*mut Pcap);
+
+struct Api {
+    _library: Library,
+    findalldevs: FindAllDevs,
+    freealldevs: FreeAllDevs,
+    create: Create,
+    set_snaplen: SetInt,
+    set_promisc: SetInt,
+    set_timeout: SetInt,
+    set_immediate_mode: Option<SetInt>,
+    activate: Activate,
+    setnonblock: SetNonblock,
+    datalink: Datalink,
+    compile: Compile,
+    setfilter: SetFilter,
+    freecode: FreeCode,
+    next_ex: NextEx,
+    sendpacket: SendPacket,
+    geterr: GetErr,
+    close: Close,
+}
+
+impl Api {
+    fn load() -> Result<Arc<Self>> {
+        let system = windows_system_directory()?;
+        let candidates = [
+            system.join("Npcap").join("wpcap.dll"),
+            system.join("wpcap.dll"),
+        ];
+        let mut failures = Vec::new();
+        for path in candidates {
+            match unsafe { Self::load_from(&path) } {
+                Ok(api) => return Ok(Arc::new(api)),
+                Err(error) => failures.push(format!("{}: {error}", path.display())),
+            }
+        }
+        bail!(
+            "Npcap is required for bridged networking but wpcap.dll could not \
+             be loaded from the Windows system directory. Install Npcap from \
+             https://npcap.com/ (WinPcap API-compatible mode is supported). {}",
+            failures.join("; ")
+        )
+    }
+
+    unsafe fn load_from(path: &std::path::Path) -> Result<Self> {
+        let library =
+            unsafe { Library::new(path) }.with_context(|| format!("loading {}", path.display()))?;
+        macro_rules! symbol {
+            ($name:literal, $ty:ty) => {
+                *unsafe { library.get::<$ty>(concat!($name, "\0").as_bytes()) }
+                    .with_context(|| format!("Npcap lacks {}", $name))?
+            };
+        }
+        let set_immediate_mode = unsafe {
+            library
+                .get::<SetInt>(b"pcap_set_immediate_mode\0")
+                .ok()
+                .map(|symbol| *symbol)
+        };
+        Ok(Self {
+            findalldevs: symbol!("pcap_findalldevs", FindAllDevs),
+            freealldevs: symbol!("pcap_freealldevs", FreeAllDevs),
+            create: symbol!("pcap_create", Create),
+            set_snaplen: symbol!("pcap_set_snaplen", SetInt),
+            set_promisc: symbol!("pcap_set_promisc", SetInt),
+            set_timeout: symbol!("pcap_set_timeout", SetInt),
+            set_immediate_mode,
+            activate: symbol!("pcap_activate", Activate),
+            setnonblock: symbol!("pcap_setnonblock", SetNonblock),
+            datalink: symbol!("pcap_datalink", Datalink),
+            compile: symbol!("pcap_compile", Compile),
+            setfilter: symbol!("pcap_setfilter", SetFilter),
+            freecode: symbol!("pcap_freecode", FreeCode),
+            next_ex: symbol!("pcap_next_ex", NextEx),
+            sendpacket: symbol!("pcap_sendpacket", SendPacket),
+            geterr: symbol!("pcap_geterr", GetErr),
+            close: symbol!("pcap_close", Close),
+            _library: library,
+        })
+    }
+}
+
+fn windows_system_directory() -> Result<PathBuf> {
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetSystemDirectoryW(buffer: *mut u16, size: u32) -> u32;
+    }
+    let mut buffer = vec![0u16; 32_768];
+    let length =
+        unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len().try_into().unwrap()) };
+    if length == 0 || length as usize >= buffer.len() {
+        bail!("GetSystemDirectoryW failed");
+    }
+    buffer.truncate(length as usize);
+    Ok(PathBuf::from(String::from_utf16(&buffer)?))
+}
+
+pub(super) fn list_interfaces() -> Result<Vec<HostInterface>> {
+    let api = Api::load()?;
+    let mut first = ptr::null_mut();
+    let mut error = [0 as c_char; PCAP_ERRBUF_SIZE];
+    let rc = unsafe { (api.findalldevs)(&mut first, error.as_mut_ptr()) };
+    if rc != 0 {
+        bail!("Npcap interface enumeration failed: {}", error_text(&error));
+    }
+    struct Guard<'a>(&'a Api, *mut PcapIf);
+    impl Drop for Guard<'_> {
+        fn drop(&mut self) {
+            unsafe { (self.0.freealldevs)(self.1) };
+        }
+    }
+    let _guard = Guard(&api, first);
+    let mut out = Vec::new();
+    let mut current = first;
+    while !current.is_null() {
+        let item = unsafe { &*current };
+        if !item.name.is_null() {
+            let name = unsafe { CStr::from_ptr(item.name) }
+                .to_string_lossy()
+                .into_owned();
+            let description = (!item.description.is_null()).then(|| {
+                unsafe { CStr::from_ptr(item.description) }
+                    .to_string_lossy()
+                    .into_owned()
+            });
+            out.push(HostInterface {
+                name,
+                description,
+                up: item.flags & PCAP_IF_UP != 0,
+                running: item.flags & PCAP_IF_RUNNING != 0,
+                loopback: item.flags & PCAP_IF_LOOPBACK != 0,
+                wireless: item.flags & PCAP_IF_WIRELESS != 0,
+            });
+        }
+        current = item.next;
+    }
+    Ok(out)
+}
+
+pub(super) fn open(interface: &str, _guest_mac: Option<[u8; 6]>) -> Result<WindowsAdapter> {
+    let api = Api::load()?;
+    let name = CString::new(interface).context("interface name contains a NUL")?;
+    let mut error = [0 as c_char; PCAP_ERRBUF_SIZE];
+    let handle = unsafe { (api.create)(name.as_ptr(), error.as_mut_ptr()) };
+    if handle.is_null() {
+        bail!(
+            "Npcap could not create adapter {interface:?}: {}",
+            error_text(&error)
+        );
+    }
+    let mut adapter = WindowsAdapter { api, handle };
+    adapter.configure(interface)?;
+    Ok(adapter)
+}
+
+pub(super) struct WindowsAdapter {
+    api: Arc<Api>,
+    handle: *mut Pcap,
+}
+
+// The handle is owned and used only by the bridge worker after construction.
+unsafe impl Send for WindowsAdapter {}
+
+impl WindowsAdapter {
+    fn configure(&mut self, interface: &str) -> Result<()> {
+        for (name, setter, value) in [
+            ("snapshot length", self.api.set_snaplen, 65_535),
+            ("promiscuous mode", self.api.set_promisc, 1),
+            ("read timeout", self.api.set_timeout, 1),
+        ] {
+            if unsafe { setter(self.handle, value) } != 0 {
+                bail!("Npcap rejected {name} for {interface:?}: {}", self.error());
+            }
+        }
+        if let Some(set_immediate) = self.api.set_immediate_mode {
+            if unsafe { set_immediate(self.handle, 1) } != 0 {
+                bail!(
+                    "Npcap rejected immediate mode for {interface:?}: {}",
+                    self.error()
+                );
+            }
+        }
+        if unsafe { (self.api.activate)(self.handle) } < 0 {
+            bail!("Npcap could not activate {interface:?}: {}", self.error());
+        }
+        if unsafe { (self.api.datalink)(self.handle) } != DLT_EN10MB {
+            bail!("Npcap adapter {interface:?} does not expose Ethernet frames");
+        }
+        let mut error = [0 as c_char; PCAP_ERRBUF_SIZE];
+        if unsafe { (self.api.setnonblock)(self.handle, 1, error.as_mut_ptr()) } != 0 {
+            bail!(
+                "Npcap could not make {interface:?} non-blocking: {}",
+                error_text(&error)
+            );
+        }
+        Ok(())
+    }
+
+    fn error(&self) -> String {
+        let text = unsafe { (self.api.geterr)(self.handle) };
+        if text.is_null() {
+            return "unknown error".to_string();
+        }
+        unsafe { CStr::from_ptr(text) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+impl AdapterIo for WindowsAdapter {
+    fn send(&mut self, frame: &[u8]) -> Result<()> {
+        let length: c_int = frame
+            .len()
+            .try_into()
+            .map_err(|_| anyhow!("Ethernet frame is too large"))?;
+        if unsafe { (self.api.sendpacket)(self.handle, frame.as_ptr(), length) } != 0 {
+            bail!("Npcap send failed: {}", self.error());
+        }
+        Ok(())
+    }
+
+    fn receive(&mut self) -> Result<Option<Vec<u8>>> {
+        let mut header = ptr::null();
+        let mut bytes = ptr::null();
+        match unsafe { (self.api.next_ex)(self.handle, &mut header, &mut bytes) } {
+            1 => {
+                if header.is_null() || bytes.is_null() {
+                    bail!("Npcap returned an empty packet");
+                }
+                let length = unsafe { (*header).caplen as usize };
+                Ok(Some(unsafe {
+                    std::slice::from_raw_parts(bytes, length).to_vec()
+                }))
+            }
+            0 => Ok(None),
+            -1 => bail!("Npcap receive failed: {}", self.error()),
+            -2 => bail!("Npcap capture ended"),
+            result => bail!("Npcap returned unexpected receive status {result}"),
+        }
+    }
+
+    fn set_guest_mac(&mut self, mac: [u8; 6]) -> Result<()> {
+        let filter = CString::new(mac_filter(mac)).unwrap();
+        let mut program = BpfProgram {
+            bf_len: 0,
+            bf_insns: ptr::null_mut(),
+        };
+        if unsafe { (self.api.compile)(self.handle, &mut program, filter.as_ptr(), 1, 0xffff_ffff) }
+            != 0
+        {
+            bail!("Npcap could not compile receive filter: {}", self.error());
+        }
+        let result = unsafe { (self.api.setfilter)(self.handle, &mut program) };
+        unsafe { (self.api.freecode)(&mut program) };
+        if result != 0 {
+            bail!("Npcap could not install receive filter: {}", self.error());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WindowsAdapter {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { (self.api.close)(self.handle) };
+            self.handle = ptr::null_mut();
+        }
+    }
+}
+
+fn error_text(buffer: &[c_char]) -> String {
+    unsafe { CStr::from_ptr(buffer.as_ptr()) }
+        .to_string_lossy()
+        .into_owned()
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -15,19 +15,22 @@
 //! only the board's chosen backend ([`NetConfig`]) and brings up a fresh
 //! backend on load (in-flight frames are dropped; the guest's TCP retransmits).
 //!
-//! Two backends are built in: [`LoopbackBackend`] (frames echo back to the
+//! Three backends are built in: [`LoopbackBackend`] (frames echo back to the
 //! sender, for tests and a self-contained two-station demo) and, behind the
 //! `net-nat` build feature, the userspace NAT in [`nat`] -- a slirp-style
 //! virtual gateway (guest 10.0.2.15, gateway 10.0.2.2, DNS 10.0.2.3) that
 //! gives the guest outbound IPv4 through ordinary host sockets, with no host
-//! privileges. [`NetConfig::None`] brings up no backend at all, which is how
-//! an isolated NIC (one with the capability but no host connectivity) is
-//! expressed. A host TAP bridge would also slot in behind [`make_backend`]
-//! under a build feature, but is not implemented.
+//! privileges. Behind `net-bridge`, [`bridge`] attaches complete Ethernet
+//! frames directly to a selected host adapter. [`NetConfig::None`] brings up
+//! no backend at all, which is how an isolated NIC (one with the capability
+//! but no host connectivity) is expressed.
 
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 
+#[cfg(all(feature = "net-bridge", not(target_arch = "wasm32")))]
+pub mod bridge;
 #[cfg(all(feature = "net-nat", not(target_arch = "wasm32")))]
 pub mod nat;
 
@@ -39,12 +42,17 @@ pub trait NetBackend: Send {
 
     /// Return the next inbound Ethernet frame for the guest, if any.
     fn poll(&mut self) -> Option<Vec<u8>>;
+
+    /// Update the station address used by a backend's receive filter. The
+    /// LANCE learns this from its initialization block after the host backend
+    /// has already opened.
+    fn set_guest_mac(&mut self, _mac: [u8; 6]) {}
 }
 
 /// Which host backend a NIC board uses. Recorded in the board's config (and
 /// save state) so the board is self-contained; the live backend it names is a
 /// host resource brought up fresh by [`make_backend`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum NetConfig {
     /// No connectivity: transmits are dropped, nothing is ever received.
     #[default]
@@ -56,9 +64,16 @@ pub enum NetConfig {
     /// Userspace NAT: a virtual gateway NATs the guest's IPv4 onto ordinary
     /// host sockets (no privileges, outbound only). Needs the `net-nat` build
     /// feature; without it the variant still parses and saves, but no backend
-    /// comes up. The variant stays a unit (no per-flow options) so the config
-    /// remains `Copy`; host port-forwards would need a richer shape.
+    /// comes up.
     Nat,
+    /// Direct layer-2 attachment to a host adapter. Frames retain their guest
+    /// source MAC; therefore wireless adapters are best-effort because many
+    /// access points reject multiple source addresses behind one station.
+    Bridge {
+        /// Stable platform adapter name (for example `eth0`, `en0`, or an
+        /// Npcap `\Device\NPF_{...}` identifier).
+        interface: String,
+    },
 }
 
 /// Whether this build can bring up the userspace NAT backend: the same
@@ -66,19 +81,37 @@ pub enum NetConfig {
 /// (the `net-nat` feature, and never on wasm32). Pickers and warnings key
 /// off this so they track what `make_backend` will actually do.
 pub const NAT_AVAILABLE: bool = cfg!(all(feature = "net-nat", not(target_arch = "wasm32")));
+/// Whether this build includes a native direct-adapter bridge backend.
+pub const BRIDGE_AVAILABLE: bool = cfg!(all(feature = "net-bridge", not(target_arch = "wasm32")));
 
 /// Bring up the live backend a [`NetConfig`] names. `None` means the board has
 /// no host networking (its NIC still works, it just never sees traffic).
-pub fn make_backend(cfg: NetConfig) -> Option<Box<dyn NetBackend>> {
+///
+/// Unlike optional NAT support, selecting a bridge is an explicit request for
+/// a particular host resource. Failure is returned to the caller and must stop
+/// startup/state restoration instead of silently changing network semantics.
+pub fn make_backend(
+    cfg: &NetConfig,
+    guest_mac: Option<[u8; 6]>,
+) -> Result<Option<Box<dyn NetBackend>>> {
+    #[cfg(not(all(feature = "net-bridge", not(target_arch = "wasm32"))))]
+    let _ = guest_mac;
     match cfg {
-        NetConfig::None => None,
-        NetConfig::Loopback => Some(Box::new(LoopbackBackend::default())),
+        NetConfig::None => Ok(None),
+        NetConfig::Loopback => Ok(Some(Box::new(LoopbackBackend::default()))),
         #[cfg(all(feature = "net-nat", not(target_arch = "wasm32")))]
-        NetConfig::Nat => Some(Box::new(nat::NatBackend::new())),
+        NetConfig::Nat => Ok(Some(Box::new(nat::NatBackend::new()))),
         #[cfg(not(all(feature = "net-nat", not(target_arch = "wasm32"))))]
         NetConfig::Nat => {
             log::warn!("net = \"nat\" needs the net-nat build feature; NIC left isolated");
-            None
+            Ok(None)
+        }
+        #[cfg(all(feature = "net-bridge", not(target_arch = "wasm32")))]
+        NetConfig::Bridge { interface } => bridge::BridgeBackend::new(interface, guest_mac)
+            .map(|backend| Some(Box::new(backend) as Box<dyn NetBackend>)),
+        #[cfg(not(all(feature = "net-bridge", not(target_arch = "wasm32"))))]
+        NetConfig::Bridge { .. } => {
+            bail!("net = \"bridge\" needs a native build with the net-bridge feature")
         }
     }
 }
@@ -99,23 +132,35 @@ impl NetBackend for LoopbackBackend {
     }
 }
 
-/// Parse a `net`/`net_backend` config string into a [`NetConfig`].
-pub fn parse_net_config(s: &str) -> Option<NetConfig> {
+/// Parse a `net`/`net_backend` config string into a [`NetConfig`]. A bridge
+/// needs its adapter name in the adjacent `interface`/`net_interface` field.
+pub fn parse_net_config(s: &str, interface: Option<&str>) -> Result<NetConfig> {
     match s.trim().to_ascii_lowercase().as_str() {
-        "none" | "off" | "" => Some(NetConfig::None),
-        "loopback" | "loop" => Some(NetConfig::Loopback),
-        "nat" => Some(NetConfig::Nat),
-        _ => None,
+        "none" | "off" | "" => Ok(NetConfig::None),
+        "loopback" | "loop" => Ok(NetConfig::Loopback),
+        "nat" => Ok(NetConfig::Nat),
+        "bridge" | "bridged" => {
+            let interface = interface.map(str::trim).filter(|s| !s.is_empty()).ok_or_else(|| {
+                anyhow::anyhow!("net = \"bridge\" needs an interface name")
+            })?;
+            Ok(NetConfig::Bridge {
+                interface: interface.to_string(),
+            })
+        }
+        _ => bail!(
+            "net = {s:?} is not a known backend (expected \"none\", \"loopback\", \"nat\", or \"bridge\")"
+        ),
     }
 }
 
 /// The canonical config-file spelling of a [`NetConfig`]: the inverse of
 /// [`parse_net_config`], used when emitting a config from the launcher.
-pub fn net_config_name(cfg: NetConfig) -> &'static str {
+pub fn net_config_name(cfg: &NetConfig) -> &'static str {
     match cfg {
         NetConfig::None => "none",
         NetConfig::Loopback => "loopback",
         NetConfig::Nat => "nat",
+        NetConfig::Bridge { .. } => "bridge",
     }
 }
 
@@ -136,17 +181,29 @@ mod tests {
 
     #[test]
     fn config_parses_known_backends() {
-        assert_eq!(parse_net_config("loopback"), Some(NetConfig::Loopback));
-        assert_eq!(parse_net_config("None"), Some(NetConfig::None));
-        assert_eq!(parse_net_config(""), Some(NetConfig::None));
-        assert_eq!(parse_net_config("nat"), Some(NetConfig::Nat));
-        assert_eq!(parse_net_config("tap0"), None);
+        assert_eq!(
+            parse_net_config("loopback", None).unwrap(),
+            NetConfig::Loopback
+        );
+        assert_eq!(parse_net_config("None", None).unwrap(), NetConfig::None);
+        assert_eq!(parse_net_config("", None).unwrap(), NetConfig::None);
+        assert_eq!(parse_net_config("nat", None).unwrap(), NetConfig::Nat);
+        assert_eq!(
+            parse_net_config("bridge", Some("en0")).unwrap(),
+            NetConfig::Bridge {
+                interface: "en0".into()
+            }
+        );
+        assert!(parse_net_config("bridge", None).is_err());
+        assert!(parse_net_config("tap0", None).is_err());
     }
 
     #[test]
     fn make_backend_brings_up_named_backend() {
-        assert!(make_backend(NetConfig::None).is_none());
-        let mut b = make_backend(NetConfig::Loopback).expect("loopback backend");
+        assert!(make_backend(&NetConfig::None, None).unwrap().is_none());
+        let mut b = make_backend(&NetConfig::Loopback, None)
+            .unwrap()
+            .expect("loopback backend");
         b.send(&[9]);
         assert_eq!(b.poll(), Some(vec![9]));
     }

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -148,7 +148,8 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  41: Paula records the guest /LED bit (led_filter_guest_on) apart from the
 //      effective filter state, for the [audio] audio_filter override; the
 //      override mode itself is a host preference and is not serialized
-pub const STATE_VERSION: u32 = 41;
+//  42: NetConfig gained the Bridge variant and its host interface identifier
+pub const STATE_VERSION: u32 = 42;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -379,6 +379,8 @@ pub enum LauncherField {
     /// The A2065 Ethernet board: absent, or fitted with a chosen host
     /// backend (isolated / loopback / NAT).
     Ethernet,
+    /// Host adapter used while the A2065 backend is bridged.
+    EthernetInterface,
     /// Inert field for a non-interactive [`RowKind::SectionHeader`] row.
     SectionHeader,
     // A/V and emulation
@@ -631,7 +633,10 @@ const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
     row(F::SamplerInput, "  Audio input", Cycle),
     row(F::SamplerGain, "  Input gain", Cycle),
 ];
-const ETHERNET_ROWS: [Row; 1] = [row(F::Ethernet, "  A2065 board", Cycle)];
+const ETHERNET_ROWS: [Row; 2] = [
+    row(F::Ethernet, "  A2065 board", Cycle),
+    row(F::EthernetInterface, "  Host adapter", Cycle),
+];
 // The A/V & Emu tab is split into three categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
 const VIDEO_ROWS: [Row; 10] = [
@@ -906,15 +911,6 @@ const SERIAL_MODES: [SerialMode; 6] = [
     SerialMode::TcpConnect,
     SerialMode::Pty,
 ];
-// `None` = no A2065 fitted; `Some(NetConfig::None)` fits the board with an
-// isolated NIC (the guest sees the hardware but no traffic ever arrives).
-const ETHERNET_CHOICES: [Option<NetConfig>; 4] = [
-    None,
-    Some(NetConfig::None),
-    Some(NetConfig::Loopback),
-    Some(NetConfig::Nat),
-];
-
 /// Stereo-separation presets the picker steps through (percent), ascending so
 /// the right arrow steps up (wrapping 100 -> 0) and the left arrow steps down.
 /// The config/CLI accept any 0-100; an off-grid value snaps to the nearest here.
@@ -1045,6 +1041,8 @@ pub struct MachineSetup {
     /// section: `None` = not fitted, `Some(backend)` fits the board with that
     /// host backend (`NetConfig::None` = fitted but isolated).
     a2065_net: Option<NetConfig>,
+    /// Currently visible host bridge adapters: stable identifier + label.
+    bridge_interfaces: Vec<(String, String)>,
     /// Input device names for the sampler picker: filled when the screen opens
     /// and re-read each time the field is cycled, so a reconnected device
     /// appears.
@@ -1205,7 +1203,8 @@ impl MachineSetup {
             parallel_output: cfg.parallel.printer_output.clone(),
             sampler_input: cfg.parallel.sampler_input.clone(),
             sampler_gain_db: cfg.parallel.sampler_gain_db,
-            a2065_net: cfg.a2065_net,
+            a2065_net: cfg.a2065_net.clone(),
+            bridge_interfaces: Vec::new(),
             // Filled by refresh_sampler_inputs on open, like the audio devices.
             sampler_input_devices: Vec::new(),
             // Left empty here so config construction stays side-effect free; the
@@ -1298,11 +1297,15 @@ impl MachineSetup {
     /// schedule rather than the emulated clock, breaking byte-identical
     /// replay (the I/O Ports tab shows a warning). The loopback backend
     /// echoes frames deterministically and an isolated or absent NIC never
-    /// sees traffic, so only NAT qualifies -- and only in a build that can
-    /// actually bring the NAT up (a loaded config can still name it in one
-    /// that cannot, where `make_backend` leaves the NIC isolated).
+    /// sees traffic, so NAT and a direct adapter bridge qualify.
     pub fn ethernet_breaks_determinism(&self) -> bool {
-        self.a2065_net == Some(NetConfig::Nat) && crate::net::NAT_AVAILABLE
+        matches!(
+            self.a2065_net.as_ref(),
+            Some(NetConfig::Nat) if crate::net::NAT_AVAILABLE
+        ) || matches!(
+            self.a2065_net.as_ref(),
+            Some(NetConfig::Bridge { .. }) if crate::net::BRIDGE_AVAILABLE
+        )
     }
 
     /// Re-read every host device list (MIDI endpoints + audio outputs + sampler
@@ -1314,6 +1317,22 @@ impl MachineSetup {
         self.refresh_midi_endpoints();
         self.refresh_audio_devices();
         self.refresh_sampler_inputs();
+        self.refresh_bridge_interfaces();
+    }
+
+    fn refresh_bridge_interfaces(&mut self) {
+        self.bridge_interfaces.clear();
+        #[cfg(all(feature = "net-bridge", not(target_arch = "wasm32")))]
+        match crate::net::bridge::list_interfaces() {
+            Ok(interfaces) => {
+                self.bridge_interfaces = interfaces
+                    .into_iter()
+                    .filter(|interface| !interface.loopback)
+                    .map(|interface| (interface.name.clone(), interface.label()))
+                    .collect();
+            }
+            Err(error) => log::warn!("launcher: cannot enumerate bridge adapters: {error:#}"),
+        }
     }
 
     /// The bare-profile config this setup is compared against when emitting
@@ -1613,7 +1632,12 @@ impl MachineSetup {
         // emitted whenever it is on (absent key = not fitted).
         raw.a2065.net = self
             .a2065_net
+            .as_ref()
             .map(|n| crate::net::net_config_name(n).to_string());
+        raw.a2065.interface = match self.a2065_net.as_ref() {
+            Some(NetConfig::Bridge { interface }) => Some(interface.clone()),
+            _ => None,
+        };
         // The Audio output picker is one of default / a named device / Disabled.
         // A named device sets output_device; Disabled sets output_enabled=false
         // (the resolved default is true, so it is omitted otherwise).
@@ -1790,6 +1814,9 @@ impl MachineSetup {
             F::Df1Image | F::Df1WriteProtect => self.floppy_drives < 2,
             F::Df2Image | F::Df2WriteProtect => self.floppy_drives < 3,
             F::Df3Image | F::Df3WriteProtect => self.floppy_drives < 4,
+            F::EthernetInterface => {
+                !matches!(self.a2065_net.as_ref(), Some(NetConfig::Bridge { .. }))
+            }
             _ => false,
         }
     }
@@ -2192,11 +2219,21 @@ impl MachineSetup {
                 .clone()
                 .unwrap_or_else(|| "Default".to_string()),
             F::SamplerGain => sampler_gain_label(self.sampler_gain_db),
-            F::Ethernet => match self.a2065_net {
+            F::Ethernet => match self.a2065_net.as_ref() {
                 None => "Not fitted".to_string(),
                 Some(NetConfig::None) => "Isolated".to_string(),
                 Some(NetConfig::Loopback) => "Loopback".to_string(),
                 Some(NetConfig::Nat) => "NAT".to_string(),
+                Some(NetConfig::Bridge { .. }) => "Bridged".to_string(),
+            },
+            F::EthernetInterface => match self.a2065_net.as_ref() {
+                Some(NetConfig::Bridge { interface }) => self
+                    .bridge_interfaces
+                    .iter()
+                    .find(|(name, _)| name == interface)
+                    .map(|(_, label)| label.clone())
+                    .unwrap_or_else(|| format!("{interface} (unavailable)")),
+                _ => "—".to_string(),
             },
             F::AudioDevice => self.audio_output.label().to_string(),
             F::AudioChannelMode => match self.audio_channel_mode {
@@ -2453,13 +2490,48 @@ impl MachineSetup {
                     cycle_floats(&SAMPLER_GAIN_STEPS, self.sampler_gain_db as f64, forward) as f32;
             }
             F::Ethernet => {
-                // NAT is only on offer when this build can bring it up;
-                // otherwise the choice would fit a board that never connects.
-                let choices: Vec<Option<NetConfig>> = ETHERNET_CHOICES
-                    .into_iter()
-                    .filter(|c| crate::net::NAT_AVAILABLE || *c != Some(NetConfig::Nat))
-                    .collect();
-                self.a2065_net = cycle_slice(&choices, self.a2065_net, forward);
+                let mut choices = vec![None, Some(NetConfig::None), Some(NetConfig::Loopback)];
+                if crate::net::NAT_AVAILABLE {
+                    choices.push(Some(NetConfig::Nat));
+                }
+                if crate::net::BRIDGE_AVAILABLE {
+                    let interface = match self.a2065_net.as_ref() {
+                        Some(NetConfig::Bridge { interface }) => Some(interface.clone()),
+                        _ => self.bridge_interfaces.first().map(|(name, _)| name.clone()),
+                    };
+                    if let Some(interface) = interface {
+                        choices.push(Some(NetConfig::Bridge { interface }));
+                    }
+                }
+                let current = self.a2065_net.clone();
+                let index = choices
+                    .iter()
+                    .position(|item| *item == current)
+                    .unwrap_or(0);
+                let next = if forward {
+                    (index + 1) % choices.len()
+                } else {
+                    (index + choices.len() - 1) % choices.len()
+                };
+                self.a2065_net = choices[next].clone();
+            }
+            F::EthernetInterface => {
+                if let Some(NetConfig::Bridge { interface }) = self.a2065_net.as_mut() {
+                    if !self.bridge_interfaces.is_empty() {
+                        let index = self
+                            .bridge_interfaces
+                            .iter()
+                            .position(|(name, _)| name == interface)
+                            .unwrap_or(0);
+                        let next = if forward {
+                            (index + 1) % self.bridge_interfaces.len()
+                        } else {
+                            (index + self.bridge_interfaces.len() - 1)
+                                % self.bridge_interfaces.len()
+                        };
+                        *interface = self.bridge_interfaces[next].0.clone();
+                    }
+                }
             }
             F::AudioDevice => {
                 // Re-read on each step so a device connected since the screen
@@ -4229,7 +4301,7 @@ mod tests {
         if crate::net::NAT_AVAILABLE {
             s.cycle(LauncherField::Ethernet, true);
             assert_eq!(s.value_label(LauncherField::Ethernet), "NAT");
-            // Only NAT carries traffic on the host's schedule.
+            // NAT carries traffic on the host's schedule.
             assert!(s.ethernet_breaks_determinism());
             assert_eq!(s.to_raw().a2065.net.as_deref(), Some("nat"));
             s.cycle(LauncherField::Ethernet, true);
@@ -4250,6 +4322,40 @@ mod tests {
         let s = MachineSetup::from_raw(&raw).unwrap();
         assert_eq!(s.value_label(LauncherField::Ethernet), "NAT");
         assert_eq!(s.ethernet_breaks_determinism(), crate::net::NAT_AVAILABLE);
+    }
+
+    #[test]
+    fn a2065_bridge_interface_picker_round_trips() {
+        let mut raw = RawConfig::default();
+        raw.a2065.net = Some("bridge".to_string());
+        raw.a2065.interface = Some("en-test".to_string());
+        let mut setup = MachineSetup::from_raw(&raw).unwrap();
+        setup.bridge_interfaces = vec![
+            ("en-test".to_string(), "Ethernet A (en-test)".to_string()),
+            ("en-next".to_string(), "Ethernet B (en-next)".to_string()),
+        ];
+        assert_eq!(setup.value_label(F::Ethernet), "Bridged");
+        assert_eq!(
+            setup.value_label(F::EthernetInterface),
+            "Ethernet A (en-test)"
+        );
+        assert!(!setup.row_hidden(F::EthernetInterface));
+        assert_eq!(
+            setup.ethernet_breaks_determinism(),
+            crate::net::BRIDGE_AVAILABLE
+        );
+
+        setup.cycle(F::EthernetInterface, true);
+        let saved = setup.to_raw();
+        assert_eq!(saved.a2065.net.as_deref(), Some("bridge"));
+        assert_eq!(saved.a2065.interface.as_deref(), Some("en-next"));
+        let restored = MachineSetup::from_raw(&saved).unwrap();
+        assert_eq!(
+            restored.a2065_net,
+            Some(NetConfig::Bridge {
+                interface: "en-next".to_string()
+            })
+        );
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5904,9 +5904,9 @@ fn draw_launcher(
             );
         }
     }
-    // The NAT backend delivers inbound traffic on the host's schedule, not
-    // the emulated clock, so warn that runs stop being reproducible the
-    // moment packets flow (loopback and an isolated NIC stay deterministic).
+    // NAT and bridged backends deliver inbound traffic on the host's schedule,
+    // so warn that runs stop being reproducible the moment packets flow
+    // (loopback and an isolated NIC stay deterministic).
     if state.tab == LauncherTab::IoPorts && setup.ethernet_breaks_determinism() {
         let note_top = launcher_row_y(
             rect,
@@ -5922,7 +5922,7 @@ fn draw_launcher(
             frame,
             launcher_pane_x(rect),
             note_top,
-            "Warning: NAT networking is non-deterministic.",
+            "Warning: host networking is non-deterministic.",
             PANEL_TEXT_ACCENT,
             1,
             scale,

--- a/src/wasmboard.rs
+++ b/src/wasmboard.rs
@@ -122,7 +122,8 @@ impl WasmRuntime {
             HostCtx {
                 mem: 0,
                 name: manifest.name.clone(),
-                net: make_backend(manifest.net),
+                net: make_backend(&manifest.net, None)
+                    .with_context(|| format!("opening network backend for {}", manifest.name))?,
                 config: manifest.config.clone(),
                 resources: resources.clone(),
             },

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -678,9 +678,11 @@ struct RawBoardMeta {
     dma: Option<bool>,
     int2: Option<bool>,
     int6: Option<bool>,
-    /// Host network backend ("none"/"loopback"/"nat"); presence grants the
+    /// Host network backend ("none"/"loopback"/"nat"/"bridge"); presence grants the
     /// `net` capability (the net_send/net_recv imports).
     net: Option<String>,
+    /// Host adapter identifier for `net = "bridge"`.
+    net_interface: Option<String>,
     /// Default plugin settings (free-form key/value).
     config: Option<toml::Table>,
     /// Config option schema, for the launcher's config panel.
@@ -822,15 +824,17 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
             spec.validate()
                 .with_context(|| format!("{}: invalid board", path.display()))?;
             let net = match &raw.net {
-                Some(s) => crate::net::parse_net_config(s).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "{}: net = {:?} is not a known backend (expected \"none\", \"loopback\", or \"nat\")",
-                        path.display(),
-                        s
-                    )
-                })?,
-                None => NetConfig::None,
+                Some(s) => crate::net::parse_net_config(s, raw.net_interface.as_deref())
+                    .with_context(|| format!("{}: invalid network backend", path.display()))?,
+                None if raw.net_interface.is_none() => NetConfig::None,
+                None => bail!("{}: net_interface needs net = \"bridge\"", path.display()),
             };
+            if raw.net_interface.is_some() && !matches!(&net, NetConfig::Bridge { .. }) {
+                bail!(
+                    "{}: net_interface applies only to net = \"bridge\"",
+                    path.display()
+                );
+            }
             let options = parse_options(&raw.option, path)?;
             let default_config = build_default_config(raw.config.as_ref(), &options, path);
             let manifest = WasmManifest {


### PR DESCRIPTION
## Summary

- add a shared direct layer-2 bridge backend with Linux AF_PACKET, macOS libpcap/BPF, and runtime-loaded Windows Npcap transports
- expose bridge adapter selection through TOML, CLI, the launcher, and WASM board metadata; preserve adapter identity in save states and fail clearly when it cannot be reopened
- add the CAP_NET_RAW-only Linux descriptor helper, AppImage/Flatpak integration, platform setup guidance, and updated networking documentation

Bridge mode passes complete Ethernet frames without replacing the existing user-mode NAT backend. Receive filtering is applied in the host capture layer and repeated in the bounded worker. Wi-Fi is supported on a best-effort basis, and bridge failures never silently fall back to NAT or isolation.

## Platform setup

- Windows loads an installed Npcap only when bridge mode is selected
- macOS uses the system packet capture interface and requires normal BPF access
- Linux uses AF_PACKET directly when permitted, otherwise the per-user helper opens, binds, filters, and passes a descriptor with SCM_RIGHTS; only the helper binary receives CAP_NET_RAW

## Verification

- cargo test --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check
- Linux and Windows cross-target bridge checks and clippy
- wasm32 no-default-feature check
- live macOS adapter enumeration and bridged headless run
- invalid-adapter startup failure with no fallback
- bridged save-state creation and restoration against the same adapter