### PR TITLE
statusbar: anchor the reset glyph arrowhead to the arc end

### DIFF
--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1545,9 +1545,22 @@ pub(super) fn draw_reset_glyph(frame: &mut [u8], cx: usize, cy: usize, texture_s
         prev = next;
     }
 
-    let unit = radius / 5.5;
-    let tip = |x: f32, y: f32| (ccx + x * unit, ccy + y * unit);
-    let arrow = [tip(-3.9, -4.3), tip(1.0, -6.7), tip(1.0, -1.9)];
+    // Arrowhead anchored to the arc end: base centred on the ring path and
+    // perpendicular to the tangent, tip continuing the direction of travel.
+    // The arc's rounded end cap lands entirely inside the triangle, so the
+    // stroke reads as one arc ending in an arrow.
+    let end = ang(1.0);
+    let ex = ccx + radius * end.cos();
+    let ey = ccy + radius * end.sin();
+    let (tx, ty) = (end.sin(), -end.cos());
+    let (nx, ny) = (end.cos(), end.sin());
+    let half_w = 2.4 * scale;
+    let len = 3.6 * scale;
+    let arrow = [
+        (ex + half_w * nx, ey + half_w * ny),
+        (ex - half_w * nx, ey - half_w * ny),
+        (ex + len * tx, ey + len * ty),
+    ];
     fill_triangle(frame, arrow, RESET_GLYPH, texture_scale);
 }
 

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1547,8 +1547,9 @@ pub(super) fn draw_reset_glyph(frame: &mut [u8], cx: usize, cy: usize, texture_s
 
     // Arrowhead anchored to the arc end: base centred on the ring path and
     // perpendicular to the tangent, tip continuing the direction of travel.
-    // The arc's rounded end cap lands entirely inside the triangle, so the
-    // stroke reads as one arc ending in an arrow.
+    // The forward half of the stroke's rounded end cap falls inside the
+    // triangle and the rear half coincides with the final arc segment's own
+    // stroke, so the glyph reads as one arc ending in an arrowhead.
     let end = ang(1.0);
     let ex = ccx + radius * end.cos();
     let ey = ccy + radius * end.sin();


### PR DESCRIPTION
The reset (reboot) button glyph's arrowhead was drawn at fixed coordinates that did not line up with the arc: its axis sat 1.2 glyph units inside the ring path, its base was buried behind the arc end, and its wings barely cleared the ~3.7-unit-wide stroke. The visible result was a beak poking down-left into the ring interior, so the icon read as a hook curling inward instead of an arrow, especially at texture scales 1 and 2 where the head dissolved into a lump on the ring.

This derives the arrowhead from the arc's end angle instead of hardcoding it: the triangle base is centred on the ring path perpendicular to the tangent (half-width 2.4 units), and the tip extends 3.6 units along the direction of travel. The arc's rounded end cap lands entirely inside the triangle, so the glyph reads as one continuous stroke ending in an arrowhead at every scale.

Verified by dumping the rendered reboot button at texture scales 1, 2, and 4 via a throwaway test (not committed); the arrowhead now caps the arc cleanly at all three. `cargo fmt --check`, `cargo clippy --all-targets`, and the window test suite (224 tests) are clean.