### PR TITLE
Optimize DDF arbitration and bitplane rendering hot paths

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1113,6 +1113,12 @@ pub struct Bus {
     /// The current line's walked fetch table (rebuilt on demand).
     #[serde(skip)]
     ddf_seq_line: std::cell::RefCell<Option<ddf_line::DdfSeqLine>>,
+    /// Compact mirror of the current DDF table's slot data. The arbiter and
+    /// capture loop query this on every colour clock; keeping the immutable
+    /// per-slot values in Cells avoids a dynamic RefCell borrow on that path
+    /// while `ddf_seq_line` remains the authoritative lazy table.
+    #[serde(skip)]
+    ddf_seq_hot_line: ddf_line::DdfSeqHotLine,
     bus_accounting: BusAccounting,
     /// Latches once BEAMCON0.DUAL (A2024/UHRES) is first seen set, so the
     /// "not emulated" warning is logged a single time, not per write.
@@ -2565,6 +2571,7 @@ impl Bus {
             ddf_seq_line_start_ctl: std::cell::Cell::new((false, 0)),
             ddf_seq_writes: std::cell::RefCell::new(Vec::new()),
             ddf_seq_line: std::cell::RefCell::new(None),
+            ddf_seq_hot_line: ddf_line::DdfSeqHotLine::new(),
             bus_accounting: BusAccounting::from_env(),
             uhres_dual_warned: false,
             dbg_ext_cck_x100: external_access_cck_x100_setting(),

--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -14,6 +14,9 @@ use crate::chipset::ddf_sequencer::{self as seq, DdfSignal, DdfState};
 
 /// Widest line the fetch table covers (PAL 227, NTSC long 228).
 pub(super) const DDF_SEQ_MAX_LINE_CCKS: usize = 232;
+const DDF_SEQ_SLOT_PLANE_MASK: u16 = 0x000F;
+const DDF_SEQ_SLOT_MODULO: u16 = 0x0010;
+const DDF_SEQ_SLOT_WORD_SHIFT: u32 = 5;
 
 /// A DDFSTRT/DDFSTOP/BPLCON0/DMACON write that reached the sequencer during
 /// the current line, at the colour clock where it takes effect.
@@ -63,6 +66,65 @@ pub(super) struct DdfSeqLine {
     /// Sequencer state after the line's walk (becomes the next line's
     /// initial state).
     pub end_state: DdfState,
+}
+
+/// Read-mostly projection of `DdfSeqLine` for the per-colour-clock paths.
+///
+/// A packed slot holds the plane number plus one in bits 0..3, the modulo
+/// flag in bit 4, and the word index above it. The line walk bounds the word
+/// index far below the remaining eleven bits. `valid` is published last so a
+/// reader never observes a partially refreshed projection.
+pub(super) struct DdfSeqHotLine {
+    valid: std::cell::Cell<bool>,
+    vpos: std::cell::Cell<u32>,
+    slot_at: [std::cell::Cell<u16>; DDF_SEQ_MAX_LINE_CCKS],
+    words_per_row: std::cell::Cell<u16>,
+    dma_planes: std::cell::Cell<u8>,
+    run_origin_cck: std::cell::Cell<Option<u16>>,
+}
+
+impl DdfSeqHotLine {
+    pub(super) fn new() -> Self {
+        Self {
+            valid: std::cell::Cell::new(false),
+            vpos: std::cell::Cell::new(0),
+            slot_at: std::array::from_fn(|_| std::cell::Cell::new(0)),
+            words_per_row: std::cell::Cell::new(0),
+            dma_planes: std::cell::Cell::new(0),
+            run_origin_cck: std::cell::Cell::new(None),
+        }
+    }
+
+    fn is_current(&self, vpos: u32) -> bool {
+        self.valid.get() && self.vpos.get() == vpos
+    }
+
+    fn refresh(&self, line: &DdfSeqLine) {
+        self.valid.set(false);
+        for (cck, slot) in self.slot_at.iter().enumerate() {
+            let mut packed = u16::from(line.plane_at[cck]);
+            if line.modulo_at[cck] {
+                packed |= DDF_SEQ_SLOT_MODULO;
+            }
+            packed |= line.word_idx_at[cck] << DDF_SEQ_SLOT_WORD_SHIFT;
+            slot.set(packed);
+        }
+        self.words_per_row.set(line.words_per_row);
+        self.dma_planes.set(line.dma_planes);
+        self.run_origin_cck.set(line.run_origin_cck);
+        self.vpos.set(line.vpos);
+        self.valid.set(true);
+    }
+
+    fn invalidate(&self) {
+        self.valid.set(false);
+    }
+}
+
+impl Default for DdfSeqHotLine {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Bus {
@@ -296,22 +358,38 @@ impl Bus {
     pub(super) fn ddf_seq_line_table(&self) -> std::cell::Ref<'_, DdfSeqLine> {
         {
             let cached = self.ddf_seq_line.borrow();
-            if cached
-                .as_ref()
-                .is_some_and(|line| line.vpos == self.agnus.vpos)
-            {
+            if let Some(line) = cached.as_ref().filter(|line| line.vpos == self.agnus.vpos) {
+                if !self.ddf_seq_hot_line.is_current(line.vpos) {
+                    self.ddf_seq_hot_line.refresh(line);
+                }
                 return std::cell::Ref::map(cached, |line| line.as_ref().unwrap());
             }
         }
         let built = self.ddf_seq_build_line();
+        self.ddf_seq_hot_line.refresh(&built);
         *self.ddf_seq_line.borrow_mut() = Some(built);
         std::cell::Ref::map(self.ddf_seq_line.borrow(), |line| line.as_ref().unwrap())
+    }
+
+    fn ddf_seq_ensure_hot_line(&self) {
+        if !self.ddf_seq_hot_line.is_current(self.agnus.vpos) {
+            drop(self.ddf_seq_line_table());
+        }
+    }
+
+    pub(super) fn ddf_seq_slot_active_at(&self, hpos: u32) -> bool {
+        let Some(slot) = self.ddf_seq_hot_line.slot_at.get(hpos as usize) else {
+            return false;
+        };
+        self.ddf_seq_ensure_hot_line();
+        slot.get() & DDF_SEQ_SLOT_PLANE_MASK != 0
     }
 
     /// Invalidate the current line's table (a register write changed the
     /// remaining signals). Already-consumed word counters are preserved by
     /// the capture loop keying on colour clocks, not indices.
     pub(super) fn ddf_seq_invalidate_line(&self) {
+        self.ddf_seq_hot_line.invalidate();
         *self.ddf_seq_line.borrow_mut() = None;
     }
 
@@ -428,24 +506,20 @@ impl Bus {
             // must not skew the visible rows' pointer progression).
             return;
         };
-        // This runs on every chip-bus quantum (a single colour clock), so the
-        // table stays behind its borrow: copying the ~1KB slot arrays out per
-        // quantum was a measured hot spot, dominated by blank lines that then
-        // fetched nothing. The line-constant aggregates are precomputed at
-        // build time; a mid-loop re-borrow rebuilds from unchanged inputs, so
-        // it yields the same table.
+        // This runs on every chip-bus quantum (a single colour clock). Use the
+        // compact hot-line projection: the authoritative table is still built
+        // lazily, but steady-state slot reads need neither a dynamic borrow nor
+        // a copy of its ~1KB arrays.
         let end = new_hpos.min(DDF_SEQ_MAX_LINE_CCKS as u32);
-        let (words_per_row, dma_planes, run_origin) = {
-            let table = self.ddf_seq_line_table();
-            if !(old_hpos..end).any(|hpos| table.plane_at[hpos as usize] != 0) {
-                return;
-            }
-            (
-                usize::from(table.words_per_row),
-                usize::from(table.dma_planes),
-                table.run_origin_cck,
-            )
-        };
+        self.ddf_seq_ensure_hot_line();
+        if !(old_hpos..end).any(|hpos| {
+            self.ddf_seq_hot_line.slot_at[hpos as usize].get() & DDF_SEQ_SLOT_PLANE_MASK != 0
+        }) {
+            return;
+        }
+        let words_per_row = usize::from(self.ddf_seq_hot_line.words_per_row.get());
+        let dma_planes = usize::from(self.ddf_seq_hot_line.dma_planes.get());
+        let run_origin = self.ddf_seq_hot_line.run_origin_cck.get();
         if words_per_row == 0 {
             return;
         }
@@ -453,18 +527,14 @@ impl Bus {
         let mut slots = 0usize;
         let mut rows_started = 0usize;
         for hpos in old_hpos..end {
-            let (plane, word_idx, apply_modulo) = {
-                let table = self.ddf_seq_line_table();
-                let slot = table.plane_at[hpos as usize];
-                if slot == 0 {
-                    continue;
-                }
-                (
-                    usize::from(slot - 1),
-                    usize::from(table.word_idx_at[hpos as usize]),
-                    table.modulo_at[hpos as usize],
-                )
-            };
+            let packed = self.ddf_seq_hot_line.slot_at[hpos as usize].get();
+            let slot = packed & DDF_SEQ_SLOT_PLANE_MASK;
+            if slot == 0 {
+                continue;
+            }
+            let plane = usize::from(slot - 1);
+            let word_idx = usize::from(packed >> DDF_SEQ_SLOT_WORD_SHIFT);
+            let apply_modulo = packed & DDF_SEQ_SLOT_MODULO != 0;
             if plane == 0 {
                 self.record_sprite_display_enable_for_bitplane_dma(vpos);
             }

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -834,9 +834,7 @@ impl Bus {
             // FMODE=0: the walked DDF sequencer table owns the decision
             // (vertical window, comparator flops, stop drains, carried runs).
             let _ = vpos;
-            let table = self.ddf_seq_line_table();
-            return (hpos as usize) < super::ddf_line::DDF_SEQ_MAX_LINE_CCKS
-                && table.plane_at[hpos as usize] != 0;
+            return self.ddf_seq_slot_active_at(hpos);
         }
         // Bitplane DMA only runs inside the vertical display window (set at
         // DIWSTRT.V, cleared at DIWSTOP.V), so the top-border and vertical-

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1469,15 +1469,41 @@ struct DeniseBitplaneSample {
     active: bool,
 }
 
+fn prepare_planar_row_pixels(
+    plane_words: &[Vec<u16>],
+    fetched_pixels: usize,
+    pixels: &mut Vec<u8>,
+) {
+    pixels.clear();
+    pixels.resize(fetched_pixels, 0);
+    for (plane, words) in plane_words.iter().enumerate().take(8) {
+        let plane_bit = 1u8 << plane;
+        for (word_idx, word) in words.iter().copied().enumerate() {
+            let pixel_base = word_idx * 16;
+            if pixel_base >= fetched_pixels {
+                break;
+            }
+            let word_pixels = (fetched_pixels - pixel_base).min(16);
+            for bit in 0..word_pixels {
+                if word & (1 << (15 - bit)) != 0 {
+                    pixels[pixel_base + bit] |= plane_bit;
+                }
+            }
+        }
+    }
+}
+
 struct DenisePlannedPlayfieldLine<'a> {
     y: usize,
     x_start: usize,
     x_stop: usize,
     plane_words: &'a [Vec<u16>],
+    pixels: Option<&'a [u8]>,
     fetched_pixels: usize,
 }
 
 impl<'a> DenisePlannedPlayfieldLine<'a> {
+    #[cfg(test)]
     fn new(
         y: usize,
         x_start: usize,
@@ -1490,6 +1516,26 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
             x_start,
             x_stop,
             plane_words,
+            pixels: None,
+            fetched_pixels,
+        }
+    }
+
+    fn with_prepared_pixels(
+        y: usize,
+        x_start: usize,
+        x_stop: usize,
+        plane_words: &'a [Vec<u16>],
+        pixels: &'a [u8],
+        fetched_pixels: usize,
+    ) -> Self {
+        debug_assert_eq!(pixels.len(), fetched_pixels);
+        Self {
+            y,
+            x_start,
+            x_stop,
+            plane_words,
+            pixels: Some(pixels),
             fetched_pixels,
         }
     }
@@ -1527,6 +1573,102 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
     }
 
     fn sample_prepared_with_final_fetch_hold(
+        &self,
+        nplanes: usize,
+        delays: &[i32; 8],
+        min_fetch_x: usize,
+        native_x: usize,
+        hold_final_fetch_sample: bool,
+    ) -> DeniseBitplaneSample {
+        if let Some(pixels) = self.pixels {
+            return self.sample_pixels_with_final_fetch_hold(
+                pixels,
+                nplanes,
+                delays,
+                min_fetch_x,
+                native_x,
+                hold_final_fetch_sample,
+            );
+        }
+        self.sample_plane_words_with_final_fetch_hold(
+            nplanes,
+            delays,
+            min_fetch_x,
+            native_x,
+            hold_final_fetch_sample,
+        )
+    }
+
+    fn sample_pixels_with_final_fetch_hold(
+        &self,
+        pixels: &[u8],
+        nplanes: usize,
+        delays: &[i32; 8],
+        min_fetch_x: usize,
+        native_x: usize,
+        hold_final_fetch_sample: bool,
+    ) -> DeniseBitplaneSample {
+        let available_planes = nplanes.min(self.plane_words.len()).min(8);
+        debug_assert_eq!(pixels.len(), self.fetched_pixels);
+        debug_assert!(
+            (2..available_planes).all(|plane| delays[plane] == delays[plane & 1]),
+            "all planes in a playfield must share its BPLCON1 delay"
+        );
+
+        let (pf1_active, pf1_fetch_x) = if available_planes != 0 {
+            self.sample_fetch_x(delays[0], min_fetch_x, native_x, hold_final_fetch_sample)
+        } else {
+            (false, None)
+        };
+        let (pf2_active, pf2_fetch_x) = if available_planes >= 2 {
+            self.sample_fetch_x(delays[1], min_fetch_x, native_x, hold_final_fetch_sample)
+        } else {
+            (false, None)
+        };
+
+        let mut idx = 0u8;
+        if let Some(fetch_x) = pf1_fetch_x {
+            idx |= pixels[fetch_x] & 0x55;
+        }
+        if let Some(fetch_x) = pf2_fetch_x {
+            idx |= pixels[fetch_x] & 0xAA;
+        }
+        let plane_mask = if available_planes == 8 {
+            u8::MAX
+        } else {
+            ((1u16 << available_planes) - 1) as u8
+        };
+        DeniseBitplaneSample {
+            idx: idx & plane_mask,
+            nplanes,
+            active: pf1_active || pf2_active,
+        }
+    }
+
+    fn sample_fetch_x(
+        &self,
+        delay: i32,
+        min_fetch_x: usize,
+        native_x: usize,
+        hold_final_fetch_sample: bool,
+    ) -> (bool, Option<usize>) {
+        if (native_x as i32) < delay {
+            return (true, None);
+        }
+        let fetch_x = (native_x as i32 - delay) as usize;
+        if fetch_x < min_fetch_x {
+            return (true, None);
+        }
+        if fetch_x < self.fetched_pixels {
+            return (true, Some(fetch_x));
+        }
+        if hold_final_fetch_sample && self.fetched_pixels > 0 && fetch_x == self.fetched_pixels {
+            return (true, Some(self.fetched_pixels - 1));
+        }
+        (false, None)
+    }
+
+    fn sample_plane_words_with_final_fetch_hold(
         &self,
         nplanes: usize,
         delays: &[i32; 8],
@@ -3993,6 +4135,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
             }
         }
         let mut row_words: [Vec<u16>; 8] = std::array::from_fn(|_| Vec::new());
+        let mut row_pixels = Vec::new();
         // COPPERLINE_DBG_EXPORT_PLANES exports each bitplane and a composite
         // color-index image for every rendered frame in the requested
         // emulated-seconds window. It uses the exact per-line plane words the
@@ -4290,11 +4433,13 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 words_per_row,
                 dma_planes.min(nplanes),
             );
-            let line_plan = DenisePlannedPlayfieldLine::new(
+            prepare_planar_row_pixels(&row_words[..nplanes], fetched_pixels, &mut row_pixels);
+            let line_plan = DenisePlannedPlayfieldLine::with_prepared_pixels(
                 y,
                 x_start,
                 x_stop,
                 &row_words[..nplanes],
+                &row_pixels,
                 fetched_pixels,
             );
             let bpl_output_start_x = dma_output_start_x.unwrap_or(0);
@@ -4779,7 +4924,7 @@ fn render_planned_playfield_line(
                         plan.sample_prepared(nplanes, &delays, min_fetch_x, next_ham_native_x);
                     denise_playfield_output(
                         output_control,
-                        palette,
+                        &palette,
                         skipped.idx & plane_mask,
                         &mut ham_color,
                     );
@@ -4791,7 +4936,7 @@ fn render_planned_playfield_line(
                     let sample = plan.sample_prepared(nplanes, &delays, min_fetch_x, native_x);
                     denise_playfield_output(
                         output_control,
-                        palette,
+                        &palette,
                         sample.idx & plane_mask,
                         &mut ham_color,
                     );
@@ -4811,7 +4956,7 @@ fn render_planned_playfield_line(
                 let right = plan.sample_prepared(nplanes, &delays, min_fetch_x, native_x + 1);
                 let (left_out, right_out) = denise_shres_playfield_output_pair(
                     output_control,
-                    palette,
+                    &palette,
                     left.idx & plane_mask,
                     right.idx & plane_mask,
                     &mut ham_color,
@@ -4832,7 +4977,7 @@ fn render_planned_playfield_line(
                 let ham_before = ham_color;
                 let output = denise_playfield_output(
                     output_control,
-                    palette,
+                    &palette,
                     sample.idx & plane_mask,
                     &mut ham_color,
                 );
@@ -5251,7 +5396,7 @@ fn draw_manual_bpl_word(
                 .unwrap_or_default();
             let (left_out, right_out) = denise_shres_playfield_output_pair(
                 source_control,
-                source_palette,
+                &source_palette,
                 left_sample.idx & plane_mask,
                 right_sample.idx & plane_mask,
                 ham_color,
@@ -5262,7 +5407,7 @@ fn draw_manual_bpl_word(
             )
         } else {
             let output =
-                denise_playfield_output(source_control, source_palette, output_idx, ham_color);
+                denise_playfield_output(source_control, &source_palette, output_idx, ham_color);
             *ham_select = masked_idx;
             (output, None)
         };
@@ -5331,7 +5476,7 @@ fn draw_manual_bpl_word(
                     let mut pixel_ham = *ham_color;
                     let output = denise_aga_playfield_output(
                         source_control,
-                        pixel_palette,
+                        &pixel_palette,
                         masked_idx,
                         &mut pixel_ham,
                     );
@@ -5348,7 +5493,7 @@ fn draw_manual_bpl_word(
                 } else {
                     (
                         rgb12_to_rgb24(palette_index_to_rgb12(
-                            pixel_palette,
+                            &pixel_palette,
                             masked_idx,
                             source_control.extra_half_brite(),
                         )),

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1469,6 +1469,27 @@ struct DeniseBitplaneSample {
     active: bool,
 }
 
+const fn build_planar_byte_lanes() -> [u64; 256] {
+    let mut table = [0u64; 256];
+    let mut byte = 0usize;
+    while byte < table.len() {
+        let mut bit = 0usize;
+        while bit < 8 {
+            if byte & (0x80 >> bit) != 0 {
+                table[byte] |= 1u64 << (bit * 8);
+            }
+            bit += 1;
+        }
+        byte += 1;
+    }
+    table
+}
+
+/// Each source bit becomes the low bit of its corresponding output-byte lane.
+/// Multiplying by a plane mask moves those lane bits into the requested colour
+/// index bit without carries between lanes.
+const PLANAR_BYTE_LANES: [u64; 256] = build_planar_byte_lanes();
+
 fn prepare_planar_row_pixels(
     plane_words: &[Vec<u16>],
     fetched_pixels: usize,
@@ -1476,17 +1497,36 @@ fn prepare_planar_row_pixels(
 ) {
     pixels.clear();
     pixels.resize(fetched_pixels, 0);
-    for (plane, words) in plane_words.iter().enumerate().take(8) {
-        let plane_bit = 1u8 << plane;
-        for (word_idx, word) in words.iter().copied().enumerate() {
-            let pixel_base = word_idx * 16;
-            if pixel_base >= fetched_pixels {
-                break;
-            }
-            let word_pixels = (fetched_pixels - pixel_base).min(16);
+    let full_words = fetched_pixels / 16;
+    for word_idx in 0..full_words {
+        let mut high_pixels = 0u64;
+        let mut low_pixels = 0u64;
+        for (plane, words) in plane_words.iter().enumerate().take(8) {
+            let Some(&word) = words.get(word_idx) else {
+                continue;
+            };
+            let plane_bit = u64::from(1u8 << plane);
+            high_pixels |= PLANAR_BYTE_LANES[usize::from((word >> 8) as u8)] * plane_bit;
+            low_pixels |= PLANAR_BYTE_LANES[usize::from(word as u8)] * plane_bit;
+        }
+        let pixel_base = word_idx * 16;
+        pixels[pixel_base..pixel_base + 8].copy_from_slice(&high_pixels.to_le_bytes());
+        pixels[pixel_base + 8..pixel_base + 16].copy_from_slice(&low_pixels.to_le_bytes());
+    }
+
+    // Production fetches are whole words. Keep the partial-word path for
+    // bounded diagnostic inputs and the differential regression oracle.
+    let tail_base = full_words * 16;
+    if tail_base < fetched_pixels {
+        let word_pixels = fetched_pixels - tail_base;
+        for (plane, words) in plane_words.iter().enumerate().take(8) {
+            let Some(&word) = words.get(full_words) else {
+                continue;
+            };
+            let plane_bit = 1u8 << plane;
             for bit in 0..word_pixels {
                 if word & (1 << (15 - bit)) != 0 {
-                    pixels[pixel_base + bit] |= plane_bit;
+                    pixels[tail_base + bit] |= plane_bit;
                 }
             }
         }

--- a/src/video/bitplane/output.rs
+++ b/src/video/bitplane/output.rs
@@ -204,7 +204,7 @@ pub(super) fn color_rgb12(color_latch: u16) -> u16 {
     color_latch & COLOR_RGB_MASK
 }
 
-pub(super) fn palette_index_to_rgb12(palette: Palette, idx: u8, extra_half_brite: bool) -> u16 {
+pub(super) fn palette_index_to_rgb12(palette: &Palette, idx: u8, extra_half_brite: bool) -> u16 {
     let color = color_rgb12(palette[(idx as usize) & 0x1F]);
     if extra_half_brite && idx & 0x20 != 0 {
         half_brite_rgb12(color)
@@ -237,7 +237,7 @@ pub(super) fn rgb24_blend_halves(a: u32, b: u32) -> u32 {
 /// [`denise_shres_playfield_output`].
 pub(super) fn denise_shres_playfield_output_pair(
     control: ControlState,
-    palette: Palette,
+    palette: &Palette,
     left_idx: u8,
     right_idx: u8,
     ham_color: &mut u32,
@@ -263,7 +263,7 @@ pub(super) fn blend_shres_outputs(
 
 pub(super) fn denise_playfield_output(
     control: ControlState,
-    palette: Palette,
+    palette: &Palette,
     idx: u8,
     ham_color: &mut u32,
 ) -> DenisePlayfieldOutput {
@@ -346,7 +346,7 @@ pub(super) fn denise_playfield_output(
 /// nibbles), and EHB halving in 8-bit component space.
 pub(super) fn denise_aga_playfield_output(
     control: ControlState,
-    palette: Palette,
+    palette: &Palette,
     idx: u8,
     ham_color: &mut u32,
 ) -> DenisePlayfieldOutput {
@@ -401,7 +401,7 @@ pub(super) fn denise_aga_playfield_output(
 /// (the low two bits hold their previous value). The set operation looks
 /// up base palette entry `idx >> 2` (0-63). Hires HAM8 content is the
 /// regression example for the bit assignment.
-pub(super) fn ham8_rgb24(palette: Palette, idx: u8, previous: u32) -> u32 {
+pub(super) fn ham8_rgb24(palette: &Palette, idx: u8, previous: u32) -> u32 {
     let value = u32::from(idx & 0xFC);
     match idx & 0x03 {
         0 => palette.rgb24(usize::from(idx >> 2)) & 0x00FF_FFFF,
@@ -456,7 +456,7 @@ pub(super) fn half_brite_rgb12(color: u16) -> u16 {
     (r << 8) | (g << 4) | b
 }
 
-pub(super) fn ham6_rgb12(palette: Palette, idx: u8, previous: u16) -> u16 {
+pub(super) fn ham6_rgb12(palette: &Palette, idx: u8, previous: u16) -> u16 {
     let data = (idx & 0x0F) as u16;
     match idx >> 4 {
         0 => color_rgb12(palette[data as usize]),

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -1389,6 +1389,66 @@ fn ddfstrt_positions_first_lowres_bitplane_word_relative_to_diwstrt() {
 }
 
 #[test]
+fn prepared_planar_pixels_match_word_sampler_for_all_playfield_taps() {
+    let plane_words = (0..8)
+        .map(|plane| {
+            (0..3)
+                .map(|word| 0x8421u16.rotate_left((plane * 3 + word * 5) as u32))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    // Use a partial final word as well as full words so the prepared row's
+    // explicit fetched-pixel bound is covered by the comparison.
+    let fetched_pixels = 43;
+    let mut pixels = Vec::new();
+    prepare_planar_row_pixels(&plane_words, fetched_pixels, &mut pixels);
+    let word_plan = DenisePlannedPlayfieldLine::new(0, 0, 128, &plane_words, fetched_pixels);
+    let pixel_plan = DenisePlannedPlayfieldLine::with_prepared_pixels(
+        0,
+        0,
+        128,
+        &plane_words,
+        &pixels,
+        fetched_pixels,
+    );
+    let delay_sets: [[i32; 8]; 3] = [
+        [0; 8],
+        std::array::from_fn(|plane| if plane & 1 == 0 { 3 } else { 11 }),
+        std::array::from_fn(|plane| if plane & 1 == 0 { -16 } else { 5 }),
+    ];
+
+    for nplanes in 0..=8 {
+        for delays in &delay_sets {
+            for min_fetch_x in [0, 7, 47] {
+                for native_x in 0..=64 {
+                    for hold_final_fetch_sample in [false, true] {
+                        let expected = word_plan.sample_prepared_with_final_fetch_hold(
+                            nplanes,
+                            delays,
+                            min_fetch_x,
+                            native_x,
+                            hold_final_fetch_sample,
+                        );
+                        let actual = pixel_plan.sample_prepared_with_final_fetch_hold(
+                            nplanes,
+                            delays,
+                            min_fetch_x,
+                            native_x,
+                            hold_final_fetch_sample,
+                        );
+                        assert_eq!(
+                            actual, expected,
+                            "nplanes={nplanes} delays={delays:?} min_fetch_x={min_fetch_x} \
+                             native_x={native_x} hold={hold_final_fetch_sample}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn late_lowres_ddf_reaches_diwstop_with_undelayed_planes_active() {
     // Low-res FMODE=0 with DDFSTRT=$50 and DDFSTOP=$D0 fetches 17 words.
     // When DIWSTOP is placed exactly at the completed DDF row's right edge,
@@ -2058,8 +2118,8 @@ fn ehb_palette_indexes_use_half_bright_base_color() {
     palette.write_ocs(3, 0x0E86);
 
     assert_eq!(half_brite_rgb12(0x0E86), 0x0743);
-    assert_eq!(palette_index_to_rgb12(palette, 0x23, true), 0x0743);
-    assert_eq!(palette_index_to_rgb12(palette, 0x23, false), 0x0E86);
+    assert_eq!(palette_index_to_rgb12(&palette, 0x23, true), 0x0743);
+    assert_eq!(palette_index_to_rgb12(&palette, 0x23, false), 0x0E86);
 }
 
 fn render_sprite_dma_test_frame(
@@ -5148,11 +5208,11 @@ fn single_playfield_out_of_range_priority_eliminates_low_bitplanes() {
     // Planes 1,2,5 set: the invalid priority eliminates planes 1-2, leaving
     // the plane-5-only index, so the pixel matches a valid render of 0x10.
     let mut h = 0u32;
-    let invalid_13 = denise_playfield_output(invalid, palette, 0x13, &mut h);
+    let invalid_13 = denise_playfield_output(invalid, &palette, 0x13, &mut h);
     let mut h = 0u32;
-    let valid_10 = denise_playfield_output(valid, palette, 0x10, &mut h);
+    let valid_10 = denise_playfield_output(valid, &palette, 0x10, &mut h);
     let mut h = 0u32;
-    let valid_13 = denise_playfield_output(valid, palette, 0x13, &mut h);
+    let valid_13 = denise_playfield_output(valid, &palette, 0x13, &mut h);
     assert_eq!(invalid_13.color, valid_10.color);
     assert_ne!(invalid_13.color, valid_13.color);
     assert_eq!(invalid_13.pf_mask, 0);
@@ -6346,17 +6406,17 @@ fn ham8_control_bits_are_the_two_lowest_planes() {
     palette.write_entry(5, true, 0x0456); // 24-bit entry 5 = 0x142536
                                           // Set: control bits (pixel bits 0-1) = 00, palette index in the
                                           // top six bits.
-    let set = ham8_rgb24(palette, 5 << 2, 0);
+    let set = ham8_rgb24(&palette, 5 << 2, 0);
     assert_eq!(set, 0x0014_2536);
     // Modify blue (01): value bits replace the top six bits of the
     // component, the low two bits hold.
-    let blue = ham8_rgb24(palette, 0b1010_1001, set);
+    let blue = ham8_rgb24(&palette, 0b1010_1001, set);
     assert_eq!(blue, 0x0014_25AA); // 0xA8 | (0x36 & 0x03)
                                    // Modify red (10).
-    let red = ham8_rgb24(palette, 0b1111_1110, blue);
+    let red = ham8_rgb24(&palette, 0b1111_1110, blue);
     assert_eq!(red, 0x00FC_25AA);
     // Modify green (11).
-    let green = ham8_rgb24(palette, 0b0100_0111, red);
+    let green = ham8_rgb24(&palette, 0b0100_0111, red);
     assert_eq!(green, 0x00FC_45AA); // 0x44 | (0x25 & 0x03)
 }
 
@@ -6373,7 +6433,7 @@ fn denise_playfield_output_selects_ehb_ham_and_dual_playfield_colors() {
         ..ControlState::default()
     };
     assert_eq!(
-        denise_playfield_output(ehb, palette, 0x21, &mut ham_color),
+        denise_playfield_output(ehb, &palette, 0x21, &mut ham_color),
         DenisePlayfieldOutput {
             color: rgb12_to_rgb24(0x0743),
             color_latch: 0x0E86,
@@ -6386,7 +6446,7 @@ fn denise_playfield_output_selects_ehb_ham_and_dual_playfield_colors() {
         ..ControlState::default()
     };
     assert_eq!(
-        denise_playfield_output(ham, palette, 0x2F, &mut ham_color).color,
+        denise_playfield_output(ham, &palette, 0x2F, &mut ham_color).color,
         rgb12_to_rgb24(0x0F43)
     );
 
@@ -6396,7 +6456,7 @@ fn denise_playfield_output_selects_ehb_ham_and_dual_playfield_colors() {
         ..ControlState::default()
     };
     assert_eq!(
-        denise_playfield_output(dual, palette, 0x02, &mut ham_color),
+        denise_playfield_output(dual, &palette, 0x02, &mut ham_color),
         DenisePlayfieldOutput {
             color: rgb12_to_rgb24(0x0456),
             color_latch: 0x0456,
@@ -6428,7 +6488,7 @@ fn ham_dual_playfield_runs_the_resolved_index_through_ham() {
     // the plain dual-playfield path would.
     let mut ham_color = rgb12_to_rgb24(0x0ABC);
     assert_eq!(
-        denise_playfield_output(control, palette, 0x02, &mut ham_color),
+        denise_playfield_output(control, &palette, 0x02, &mut ham_color),
         DenisePlayfieldOutput {
             color: rgb12_to_rgb24(0x0456),
             color_latch: 0x0456,
@@ -6441,7 +6501,7 @@ fn ham_dual_playfield_runs_the_resolved_index_through_ham() {
     // so only the blue nibble of the held colour changes.
     let mut ham_color = rgb12_to_rgb24(0x0ABC);
     assert_eq!(
-        denise_playfield_output(control, palette, 0x12, &mut ham_color).color,
+        denise_playfield_output(control, &palette, 0x12, &mut ham_color).color,
         rgb12_to_rgb24(0x0AB4),
     );
 }
@@ -6462,7 +6522,7 @@ fn aga_playfield_output_resolves_ham8_ehb_and_bplam() {
     let mut ham = 0u32;
 
     // Plain palette lookup composes high and low nibbles.
-    let out = denise_playfield_output(aga, palette, 0x01, &mut ham);
+    let out = denise_playfield_output(aga, &palette, 0x01, &mut ham);
     assert_eq!(out.color, 0x0014_2536);
 
     // HAM8 with 8 planes: control bits live in the two lowest planes,
@@ -6472,9 +6532,9 @@ fn aga_playfield_output_resolves_ham8_ehb_and_bplam() {
         ..aga
     };
     ham = 0x00AA_BBCC;
-    let out = denise_playfield_output(ham8, palette, (0x3F << 2) | 0x01, &mut ham);
+    let out = denise_playfield_output(ham8, &palette, (0x3F << 2) | 0x01, &mut ham);
     assert_eq!(out.color, 0x00AA_BBFC, "blue := 111111<<2 | old low bits");
-    let out = denise_playfield_output(ham8, palette, (0x15 << 2) | 0x02, &mut ham);
+    let out = denise_playfield_output(ham8, &palette, (0x15 << 2) | 0x02, &mut ham);
     assert_eq!(
         out.color, 0x0056_BBFC,
         "red := 010101<<2 | old low-bit pair"
@@ -6486,7 +6546,7 @@ fn aga_playfield_output_resolves_ham8_ehb_and_bplam() {
         ..aga
     };
     let mut ham2 = 0u32;
-    let out = denise_playfield_output(masked, palette, 0x00, &mut ham2);
+    let out = denise_playfield_output(masked, &palette, 0x00, &mut ham2);
     assert_eq!(out.color, 0x0014_2536);
 
     // AGA EHB: entry halved per 8-bit component.
@@ -6499,7 +6559,7 @@ fn aga_playfield_output_resolves_ham8_ehb_and_bplam() {
         ..ControlState::default()
     };
     let mut ham3 = 0u32;
-    let out = denise_playfield_output(ehb, ehb_palette, 0x21, &mut ham3);
+    let out = denise_playfield_output(ehb, &ehb_palette, 0x21, &mut ham3);
     assert_eq!(out.color, (0x00FE_FEFE >> 1) & 0x007F_7F7F);
 }
 
@@ -6514,7 +6574,7 @@ fn shres_playfield_output_resolves_each_35ns_sample_through_the_palette() {
 
     // A solid run of colour 1 keeps colour 1: each 35 ns half resolves
     // palette[1], never a pair-encoded entry.
-    let (left, right) = denise_shres_playfield_output_pair(control, palette, 1, 1, &mut ham_color);
+    let (left, right) = denise_shres_playfield_output_pair(control, &palette, 1, 1, &mut ham_color);
     assert_eq!(
         blend_shres_outputs(left, right),
         DenisePlayfieldOutput {
@@ -6526,7 +6586,7 @@ fn shres_playfield_output_resolves_each_35ns_sample_through_the_palette() {
     // A background/colour-1 pair blends the two resolved colours into the
     // 70 ns framebuffer pixel (the classic-pitch canvas path); a 35 ns
     // canvas emits the halves separately.
-    let (left, right) = denise_shres_playfield_output_pair(control, palette, 0, 1, &mut ham_color);
+    let (left, right) = denise_shres_playfield_output_pair(control, &palette, 0, 1, &mut ham_color);
     assert_eq!(left.color, rgb12_to_rgb24(0x0000));
     assert_eq!(right.color, rgb12_to_rgb24(0x00F0));
     assert_eq!(
@@ -6581,12 +6641,12 @@ fn aga_shres_playfield_output_keeps_four_plane_indices() {
     let mut ham_color = 0;
 
     let (left, right) =
-        denise_shres_playfield_output_pair(control, palette, 14, 14, &mut ham_color);
+        denise_shres_playfield_output_pair(control, &palette, 14, 14, &mut ham_color);
     assert_eq!(
         blend_shres_outputs(left, right).color,
         palette.rgb24(14) & 0x00FF_FFFF
     );
-    let (left, right) = denise_shres_playfield_output_pair(control, palette, 7, 7, &mut ham_color);
+    let (left, right) = denise_shres_playfield_output_pair(control, &palette, 7, 7, &mut ham_color);
     assert_eq!(
         blend_shres_outputs(left, right).color,
         palette.rgb24(7) & 0x00FF_FFFF
@@ -6694,11 +6754,11 @@ fn ham6_pixels_modify_previous_rgb_components() {
     let mut palette = Palette::new();
     palette.write_ocs(3, 0x0123);
 
-    let direct = ham6_rgb12(palette, 0x03, 0x0FFF);
+    let direct = ham6_rgb12(&palette, 0x03, 0x0FFF);
     assert_eq!(direct, 0x0123);
-    assert_eq!(ham6_rgb12(palette, 0x14, direct), 0x0124);
-    assert_eq!(ham6_rgb12(palette, 0x25, direct), 0x0523);
-    assert_eq!(ham6_rgb12(palette, 0x36, direct), 0x0163);
+    assert_eq!(ham6_rgb12(&palette, 0x14, direct), 0x0124);
+    assert_eq!(ham6_rgb12(&palette, 0x25, direct), 0x0523);
+    assert_eq!(ham6_rgb12(&palette, 0x36, direct), 0x0163);
 }
 
 #[test]

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -1389,6 +1389,14 @@ fn ddfstrt_positions_first_lowres_bitplane_word_relative_to_diwstrt() {
 }
 
 #[test]
+fn planar_byte_lane_table_expands_every_byte_msb_first() {
+    for byte in u8::MIN..=u8::MAX {
+        let expected = std::array::from_fn(|bit| u8::from(byte & (0x80 >> bit) != 0));
+        assert_eq!(PLANAR_BYTE_LANES[usize::from(byte)].to_le_bytes(), expected);
+    }
+}
+
+#[test]
 fn prepared_planar_pixels_match_word_sampler_for_all_playfield_taps() {
     let plane_words = (0..8)
         .map(|plane| {


### PR DESCRIPTION
## Summary

- add a compact DDF hot-line projection for the per-color-clock FMODE0 path while retaining the authoritative arbitration table
- preconvert fetched planar words into chunky rows and reuse parity/playfield delay taps during rendering
- replace per-byte planar expansion with a word-at-a-time lookup-table conversion
- pass palette data by reference rather than copying it through the render path
- add differential and exhaustive tests covering delays, clipping, partial words, hold behavior, plane counts, and lookup expansion

## Performance

Measured with release builds on an Intel Core Ultra 5 125H Linux laptop, pinned to one P-core.

| Workload | Before | After | Change |
|---|---:|---:|---:|
| Bundled AROS, core only, 20 emulated seconds | 4.003 s | 3.710 s | -7.3% |
| Bundled AROS, rendered, 20 emulated seconds | 8.729 s | 7.704 s median | -11.7% |

The rendered checksum remained exactly `0x2c934000000` across all AROS runs.

For the planar lookup-table commit specifically, an A1200/AGA workload with 8 MiB fast RAM retired 365.7B instructions instead of 418.1B (-12.5%) and used 94.7B cycles instead of 102.4B (-7.6%). Its rendered checksum remained exactly `0xdf2000000`.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --locked`
- `cargo check --no-default-features --features bench-bin --locked`
- Linux release build of Copperline and `copperline-bench`
- deterministic rendered-checksum comparisons for both benchmark workloads

No CI performance gate is included here; that work is intentionally being considered separately.