### PR TITLE
Optimize stable chipset and render frame paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ winit = { version = "0.30", optional = true }
 anyhow = "1"
 log = "0.4"
 env_logger = { version = "0.11", optional = true }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", optional = true }
 serde-big-array = "0.5"
 bincode = "1"
@@ -205,4 +205,9 @@ needless_range_loop = "allow"
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+# Copperline's hottest paths cross the CPU/bus/chipset/render module
+# boundaries. Whole-program optimization is measurably worthwhile here:
+# the AROS benchmark is about 10% faster core-only and 7% faster with
+# rendering than thin LTO, and the resulting executable is smaller.
+lto = "fat"
+codegen-units = 1

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -134,8 +134,10 @@ The flow of a frame:
 4. Render-relevant register writes (by Copper or CPU) are recorded as
    beam-position events. At the frame boundary, the bus turns the completed
    frame's events, chip-RAM snapshot, display geometry, and Agnus blanking
-   latches into an owned `RenderInput`; the renderer replays that snapshot,
-   never the live chipset state ([](video)).
+   latches into an owned `RenderInput` envelope. Large immutable RAM and
+   bitplane-row snapshots are reference-counted across the handoff; the
+   renderer replays that frozen data, never the live chipset state
+   ([](video)).
 5. In the default path `window.rs` sends `RenderInput` to the
    `copperline-render` worker while the main thread advances the next frame.
    The worker paints into a CPU framebuffer, owns the deinterlacer history,
@@ -152,9 +154,10 @@ The flow of a frame:
 So an interactive run uses three host threads: the **main thread** (event
 loop, core, and pacer), the **`copperline-render` worker**, and the
 **cpal audio callback** that cpal owns. Only the last two cross a thread
-boundary with the main thread, and both do so through owned data (a
-`RenderInput`/presentation buffer over a channel, and a lock-free sample ring
-buffer) rather than shared mutable state. The pacer and the audio callback are
+boundary with the main thread, and both do so through an owned
+`RenderInput`/presentation-buffer envelope (with immutable shared frame
+snapshots) and a lock-free sample ring buffer rather than shared mutable
+state. The pacer and the audio callback are
 latency-critical and can optionally be given above-normal scheduling priority
 (`[emulation] realtime_priority`, `src/priority.rs`); see
 [](timing) for what that does per platform.

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -50,12 +50,19 @@ lines fetch on alternating rasters with the picture sitting linearly left
 of the standard grid (its early words run through the left border). The
 renderer honours this through the captured run geometry: a below-$18 run
 origin keeps its raw fetch grid, and a line without a captured fetch
-paints nothing (vAmigaTS Agnus/DDF/DDF/oldhwstop3/4 A500 photos). The
-per-line fetch table is rebuilt when DDFSTRT/DDFSTOP/BPLCON0/DMACON/DIW
-writes land (DDF writes commit to the comparators four colour clocks after
-the write slot; an old DDFSTOP still fires on its commit clock, an old
-DDFSTRT does not - vAmiga's sequencer semantics, hardware-verified in
-aggregate by the vAmigaTS Agnus/DDF/DDF/oldhwstop1-4 A500 photos). A
+paints nothing (vAmigaTS Agnus/DDF/DDF/oldhwstop3/4 A500 photos). For a
+line with no mid-line sequencer writes, the walked fetch plan is keyed on
+the complete carried flop state, masked DDF registers, line geometry,
+chip revision and hard-stop mode. An identical key reuses the preceding
+line's immutable slots and end state; the ordinary static walk is
+allocation-free. DDFSTRT/DDFSTOP/BPLCON0/DMACON/DIW writes invalidate that
+plan and rebuild the affected line (DDF writes commit to the comparators
+four colour clocks after the write slot; an old DDFSTOP still fires on its
+commit clock, an old DDFSTRT does not - vAmiga's sequencer semantics,
+hardware-verified in aggregate by the vAmigaTS
+Agnus/DDF/DDF/oldhwstop1-4 A500 photos). Because the complete initial state
+is in the key, a run carried across horizontal blanking or a vertical-window
+transition cannot accidentally reuse an ordinary interior line. A
 mid-row BPLCON0 change switches the fetch-unit slot layout from its commit
 clock; word addressing is unit-based, so late-enabled planes keep their
 word positions and earlier words stay zero.

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -29,6 +29,11 @@ decoded through EHB / HAM / HAM8 / dual-playfield rules (the pixel
 pipeline carries 24-bit colour end to end; OCS/ECS paths keep their exact
 12-bit maths and expand by nibble), composited with the eight sprites
 under playfield priority, and CLXDAT collisions are accumulated.
+The CLXCON/CLXCON2 playfield classification is a frame-local 256-entry
+truth table retained across scanlines and rebuilt when its control key
+changes. Each framebuffer collision entry is packed into one byte; this
+is only a representation change, and the same playfield-presence and
+match bits feed sprite priority and CLXDAT.
 For DMA-fetched HAM playfields, the display window gates framebuffer output
 and collision recording, but the low-res Denise phase can still seed the HAM
 component history just before DIW: when the window opens to the right of the
@@ -303,9 +308,13 @@ At frame end, `Bus::begin_new_beam_frame` freezes the just-finished frame:
 the render-event journal, chip-RAM snapshot, captured bitplane/sprite DMA
 rows, palette split, display geometry, frame line count, framebuffer start
 line, and Agnus programmable blanking latches become the source for
-`RenderInput::from_bus`. `render_from_input` consumes only that owned
-bundle, so the main thread can start emulating frame N+1 while the worker
-renders frame N.
+`RenderInput::from_bus`. The large immutable chip-RAM and captured-bitplane
+bundles use shared ownership between the bus and `RenderInput`; queueing a
+worker job therefore does not copy the full RAM image or deep-clone every
+plane row. A completed job releases those references before the next frame
+wrap so the RAM allocation normally returns to the capture side.
+`render_from_input` consumes only this frozen bundle, so the main thread can
+start emulating frame N+1 while the worker renders frame N.
 
 `window.rs` starts a persistent `copperline-render` worker by default.
 `COPPERLINE_THREADED_RENDER=0` (also `false`, `off`, or `no`) disables the
@@ -343,7 +352,11 @@ field of its own parity, and the woven line against its own
 predecessor), and the per-pixel motion mask is dilated one pixel
 sideways so dithered moving art bobs as a region instead of weaving and
 interpolating on alternate pixels.
-Progressive content is line-doubled without history.
+Progressive content is line-doubled without history. With phosphor
+persistence off, the common progressive path writes those doubled rows
+directly into the frontend-owned presentation buffer instead of filling
+the deinterlacer's intermediate output and then copying the complete
+frame. Interlaced and phosphor-blended frames retain the history buffer.
 `[display] deinterlace = false` (or the `COPPERLINE_DEINTERLACE=0` env
 override) falls back to plain line doubling; like phosphor, the setting
 travels in every render job.

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -206,11 +206,12 @@ fn main() -> Result<()> {
         over_budget,
         sorted.len()
     );
-    // Keep the deinterlacer's output observable so the render path cannot be
-    // optimized out entirely.
+    // Keep the actual presentation buffer observable so the direct render
+    // path cannot be optimized out entirely.
     if args.render {
-        let checksum: u64 = deinterlacer.output()[..FB_WIDTH]
+        let checksum: u64 = presentation_fb
             .iter()
+            .take(FB_WIDTH)
             .map(|&px| px as u64)
             .sum();
         println!("bench render checksum: {checksum:#x}");

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -123,6 +123,7 @@ fn main() -> Result<()> {
 
     let mut fb = vec![0u32; MAX_CANVAS_PIXELS];
     let mut deinterlacer = Deinterlacer::new();
+    let mut presentation_fb = Vec::new();
     let mut last_rendered: Option<u64> = None;
     let mut rendered_frames: u64 = 0;
 
@@ -153,13 +154,14 @@ fn main() -> Result<()> {
                     Overscan::Tv,
                 );
                 let base = emu.bus().frame_render_base();
-                deinterlacer.push_field(
+                deinterlacer.present_field_into(
                     &fb,
                     field_rows,
                     FB_WIDTH * canvas_scale,
                     base.bplcon0 & 0x0004 != 0,
                     base.long_field,
                     !geometry.programmable,
+                    &mut presentation_fb,
                 );
                 last_rendered = Some(emulated_frame);
                 rendered_frames += 1;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -823,11 +823,11 @@ pub struct Bus {
     last_frame_beam_bottom_palette: Palette,
     last_frame_beam_bottom_palette_valid: bool,
     current_frame_chip_ram: Vec<u8>,
-    last_frame_chip_ram: Vec<u8>,
+    last_frame_chip_ram: std::sync::Arc<Vec<u8>>,
     current_frame_chip_ram_writes: Vec<BeamChipRamWrite>,
     last_frame_chip_ram_writes: Vec<BeamChipRamWrite>,
     current_frame_bitplane_rows: Vec<Option<CapturedBitplaneRow>>,
-    last_frame_bitplane_rows: Vec<Option<CapturedBitplaneRow>>,
+    last_frame_bitplane_rows: std::sync::Arc<Vec<Option<CapturedBitplaneRow>>>,
     current_frame_sprite_lines: Vec<CapturedSpriteLine>,
     current_frame_sprite_lines_by_y: Vec<Vec<CapturedSpriteLine>>,
     current_frame_sprite_collision_sources: Vec<Option<Vec<LiveSpriteCollisionSource>>>,
@@ -947,6 +947,11 @@ pub struct Bus {
     /// state, never serialized.
     #[serde(skip)]
     wave_on: bool,
+    /// Combined zero-observer gate for the per-colour-clock arbitration path.
+    /// The individual diagnostics remain independently controlled; this folds
+    /// their four normally-false branches into one.
+    #[serde(skip)]
+    chip_bus_observers_on: bool,
     #[serde(skip)]
     pub(crate) wave_pc_trigger: bool,
     #[serde(skip)]
@@ -2470,11 +2475,11 @@ impl Bus {
             last_frame_beam_bottom_palette: Palette::new(),
             last_frame_beam_bottom_palette_valid: false,
             current_frame_chip_ram,
-            last_frame_chip_ram: Vec::new(),
+            last_frame_chip_ram: std::sync::Arc::new(Vec::new()),
             current_frame_chip_ram_writes: Vec::new(),
             last_frame_chip_ram_writes: Vec::new(),
             current_frame_bitplane_rows: empty_captured_bitplane_rows(),
-            last_frame_bitplane_rows: empty_captured_bitplane_rows(),
+            last_frame_bitplane_rows: std::sync::Arc::new(empty_captured_bitplane_rows()),
             current_frame_sprite_lines: Vec::new(),
             current_frame_sprite_lines_by_y: empty_captured_sprite_lines_by_y(),
             current_frame_sprite_collision_sources: empty_sprite_collision_sources(),
@@ -2525,6 +2530,7 @@ impl Bus {
             current_frame_bus_trace: FrameBusTrace::default(),
             last_frame_bus_trace: None,
             wave_on: false,
+            chip_bus_observers_on: false,
             wave_pc_trigger: false,
             wave: None,
             ui_reg_watches: Vec::new(),
@@ -2576,6 +2582,7 @@ impl Bus {
             uhres_dual_warned: false,
             dbg_ext_cck_x100: external_access_cck_x100_setting(),
         };
+        bus.refresh_chip_bus_observers();
         bus.configure_chip_dma_masks();
         // Re-derive the per-frame capture buffers from the same helper the
         // reset paths use, rather than trusting the struct literal above to
@@ -3554,11 +3561,11 @@ impl Bus {
         self.current_frame_chip_ram.clear();
         self.current_frame_chip_ram
             .extend_from_slice(&self.mem.chip_ram);
-        self.last_frame_chip_ram.clear();
+        self.last_frame_chip_ram = std::sync::Arc::new(Vec::new());
         self.current_frame_chip_ram_writes.clear();
         self.last_frame_chip_ram_writes.clear();
         self.current_frame_bitplane_rows = empty_captured_bitplane_rows();
-        self.last_frame_bitplane_rows = empty_captured_bitplane_rows();
+        self.last_frame_bitplane_rows = std::sync::Arc::new(empty_captured_bitplane_rows());
         self.current_frame_sprite_lines.clear();
         clear_captured_sprite_lines_by_y(&mut self.current_frame_sprite_lines_by_y);
         self.current_frame_sprite_collision_sources = empty_sprite_collision_sources();
@@ -3935,6 +3942,7 @@ impl Bus {
         self.dbg_slotmap_on = crate::envcfg::flag("COPPERLINE_DIAG_SLOTMAP");
         self.dbg_slotmap_dumped = false;
         self.bus_accounting = BusAccounting::from_env();
+        self.refresh_chip_bus_observers();
     }
 
     pub fn emulated_seconds(&self) -> f64 {
@@ -5389,6 +5397,7 @@ impl Bus {
             return;
         }
         self.frame_analyzer_enabled = enabled;
+        self.refresh_chip_bus_observers();
         if enabled {
             self.reset_current_frame_bus_trace(true);
         } else {
@@ -5461,6 +5470,20 @@ impl Bus {
         }
     }
 
+    /// Shared ownership of the immutable completed-frame RAM snapshot. The
+    /// render worker keeps this allocation alive while the next frame runs,
+    /// avoiding a second full chip-RAM copy when a [`RenderInput`] is queued.
+    pub(crate) fn frame_chip_ram_shared(&self) -> std::sync::Arc<Vec<u8>> {
+        if !crate::envcfg::flag("COPPERLINE_RENDER_LIVE_CHIP_RAM")
+            && self.last_frame_render_base.is_some()
+            && self.last_frame_chip_ram.len() == self.mem.chip_ram.len()
+        {
+            std::sync::Arc::clone(&self.last_frame_chip_ram)
+        } else {
+            std::sync::Arc::new(self.frame_chip_ram().to_vec())
+        }
+    }
+
     pub fn frame_chip_ram_writes(&self) -> &[BeamChipRamWrite] {
         if crate::envcfg::flag("COPPERLINE_RENDER_LIVE_CHIP_RAM") {
             return &[];
@@ -5482,6 +5505,22 @@ impl Bus {
             &self.last_frame_bitplane_rows
         } else {
             &self.current_frame_bitplane_rows
+        }
+    }
+
+    /// Shared ownership of the completed frame's captured DMA rows. Each row
+    /// owns up to eight plane vectors, so sharing the immutable bundle avoids
+    /// thousands of small deep-clone allocations per queued render.
+    pub(crate) fn frame_captured_bitplane_rows_shared(
+        &self,
+    ) -> std::sync::Arc<Vec<Option<CapturedBitplaneRow>>> {
+        if !crate::envcfg::flag("COPPERLINE_RENDER_LIVE_CHIP_RAM")
+            && self.last_frame_render_base.is_some()
+            && self.last_frame_bitplane_rows.len() == MAX_VISIBLE_LINES
+        {
+            std::sync::Arc::clone(&self.last_frame_bitplane_rows)
+        } else {
+            std::sync::Arc::new(self.frame_captured_bitplane_rows().to_vec())
         }
     }
 

--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -35,10 +35,29 @@ pub(super) enum DdfSeqWriteKind {
     BmapenClr,
 }
 
+/// Complete input identity for a scanline with no mid-line sequencer writes.
+///
+/// The carried flop state is part of the key: lines only share a plan once
+/// the sequencer itself has reached the same state, including unusual runs
+/// carried through horizontal blanking. Vertical-window changes are folded
+/// into `state.bpv`, so entering or leaving the display cannot reuse an
+/// interior line by accident.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DdfSeqStaticKey {
+    state: DdfState,
+    line_ccks: u16,
+    ddfstrt: u16,
+    ddfstop: u16,
+    hard_stop: u16,
+    aga: bool,
+    ecs: bool,
+}
+
 /// One line's walked bitplane fetch table.
 #[derive(Clone)]
 pub(super) struct DdfSeqLine {
     pub vpos: u32,
+    static_key: Option<DdfSeqStaticKey>,
     /// Plane index + 1 fetching at each colour clock; 0 = no bitplane slot.
     pub plane_at: [u8; DDF_SEQ_MAX_LINE_CCKS],
     /// The plane's modulo applies after the fetch at this colour clock
@@ -68,6 +87,57 @@ pub(super) struct DdfSeqLine {
     pub end_state: DdfState,
 }
 
+impl DdfSeqLine {
+    fn empty(vpos: u32, state: DdfState, static_key: Option<DdfSeqStaticKey>) -> Self {
+        Self {
+            vpos,
+            static_key,
+            plane_at: [0; DDF_SEQ_MAX_LINE_CCKS],
+            modulo_at: [false; DDF_SEQ_MAX_LINE_CCKS],
+            words_per_plane: [0; 8],
+            words_per_row: 0,
+            dma_planes: 0,
+            word_idx_at: [0; DDF_SEQ_MAX_LINE_CCKS],
+            first_fetch_cck: None,
+            run_origin_cck: None,
+            end_state: state,
+        }
+    }
+
+    fn record_fetch(&mut self, fetch: seq::DdfFetch, shres: bool, hires: bool, carried: bool) {
+        let idx = usize::from(fetch.cck);
+        if idx >= DDF_SEQ_MAX_LINE_CCKS {
+            return;
+        }
+        let plane = usize::from(fetch.plane).min(7);
+        self.plane_at[idx] = fetch.plane + 1;
+        self.modulo_at[idx] = fetch.apply_modulo;
+        // Word addressing is unit-based: a plane enabled mid-line keeps
+        // fetching into its unit's word position, leaving earlier words
+        // zero (matching the hardware's per-unit pointer cadence).
+        self.word_idx_at[idx] = if shres {
+            fetch.unit_ord * 4 + u16::from(fetch.counter >> 1)
+        } else if hires {
+            fetch.unit_ord * 2 + u16::from(fetch.counter >= 4)
+        } else {
+            fetch.unit_ord
+        };
+        self.words_per_plane[plane] = self.words_per_plane[plane].max(self.word_idx_at[idx] + 1);
+        if self.first_fetch_cck.is_none() {
+            self.first_fetch_cck = Some(fetch.cck);
+            if !carried {
+                self.run_origin_cck = Some(fetch.cck.saturating_sub(u16::from(fetch.counter)));
+            }
+        }
+    }
+
+    fn finish(&mut self, state: DdfState) {
+        self.end_state = state;
+        self.words_per_row = self.words_per_plane.iter().copied().max().unwrap_or(0);
+        self.dma_planes = self.plane_at.iter().copied().max().unwrap_or(0);
+    }
+}
+
 /// Read-mostly projection of `DdfSeqLine` for the per-colour-clock paths.
 ///
 /// A packed slot holds the plane number plus one in bits 0..3, the modulo
@@ -81,6 +151,11 @@ pub(super) struct DdfSeqHotLine {
     words_per_row: std::cell::Cell<u16>,
     dma_planes: std::cell::Cell<u8>,
     run_origin_cck: std::cell::Cell<Option<u16>>,
+    /// Identity of the slot array currently stored in `slot_at`. A line
+    /// rollover invalidates the vpos but deliberately retains this identity,
+    /// allowing an identical static plan to publish the new line without
+    /// rewriting all 232 cells.
+    static_key: std::cell::Cell<Option<DdfSeqStaticKey>>,
 }
 
 impl DdfSeqHotLine {
@@ -92,6 +167,7 @@ impl DdfSeqHotLine {
             words_per_row: std::cell::Cell::new(0),
             dma_planes: std::cell::Cell::new(0),
             run_origin_cck: std::cell::Cell::new(None),
+            static_key: std::cell::Cell::new(None),
         }
     }
 
@@ -101,17 +177,21 @@ impl DdfSeqHotLine {
 
     fn refresh(&self, line: &DdfSeqLine) {
         self.valid.set(false);
-        for (cck, slot) in self.slot_at.iter().enumerate() {
-            let mut packed = u16::from(line.plane_at[cck]);
-            if line.modulo_at[cck] {
-                packed |= DDF_SEQ_SLOT_MODULO;
+        let slots_unchanged = line.static_key.is_some() && self.static_key.get() == line.static_key;
+        if !slots_unchanged {
+            for (cck, slot) in self.slot_at.iter().enumerate() {
+                let mut packed = u16::from(line.plane_at[cck]);
+                if line.modulo_at[cck] {
+                    packed |= DDF_SEQ_SLOT_MODULO;
+                }
+                packed |= line.word_idx_at[cck] << DDF_SEQ_SLOT_WORD_SHIFT;
+                slot.set(packed);
             }
-            packed |= line.word_idx_at[cck] << DDF_SEQ_SLOT_WORD_SHIFT;
-            slot.set(packed);
         }
         self.words_per_row.set(line.words_per_row);
         self.dma_planes.set(line.dma_planes);
         self.run_origin_cck.set(line.run_origin_cck);
+        self.static_key.set(line.static_key);
         self.vpos.set(line.vpos);
         self.valid.set(true);
     }
@@ -216,6 +296,55 @@ impl Bus {
         } else {
             self.denise.bplcon0
         };
+        // BEAMCON0.HARDDIS relaxes the hardwired stop position.
+        let (_, hard_stop) = crate::chipset::agnus::ddf_hard_bounds(self.harddis_active());
+
+        if writes.is_empty() {
+            let aga = self.aga_enabled();
+            let ecs = self.ddf_seq_ecs_rules();
+            let ddfstrt = self.denise.ddfstrt & mask;
+            let ddfstop = self.denise.ddfstop & mask;
+            let key = DdfSeqStaticKey {
+                state,
+                line_ccks,
+                ddfstrt,
+                ddfstop,
+                hard_stop,
+                aga,
+                ecs,
+            };
+
+            // Stable display bands commonly repeat this exact state for
+            // hundreds of lines. The walk's slots and end state are pure
+            // functions of the key, so carry the previous line's fixed
+            // arrays forward and only retag its beam row.
+            if let Ok(cached) = self.ddf_seq_line.try_borrow() {
+                if let Some(cached) = cached.as_ref().filter(|line| line.static_key == Some(key)) {
+                    let mut line = cached.clone();
+                    line.vpos = vpos;
+                    return line;
+                }
+            }
+
+            drop(writes);
+            let carried = state.bprun;
+            let shres = crate::chipset::agnus::bitplane_shres(state.bplcon0);
+            let hires = crate::chipset::agnus::bitplane_hires(state.bplcon0);
+            let mut line = DdfSeqLine::empty(vpos, state, Some(key));
+            seq::walk_static_line_into(
+                aga,
+                ecs,
+                ddfstrt,
+                ddfstop,
+                hard_stop,
+                line_ccks,
+                &mut state,
+                |fetch| line.record_fetch(fetch, shres, hires, carried),
+            );
+            line.finish(state);
+            return line;
+        }
+
         let mut strt_writes: Vec<(u16, u16)> = Vec::new();
         let mut stop_writes: Vec<(u16, u16)> = Vec::new();
         let mut extra: Vec<DdfSignal> = Vec::new();
@@ -292,9 +421,7 @@ impl Bus {
 
         // The static strt/stop strobes are already covered by the log-based
         // reconstruction above, so pass never-matching values to the default
-        // list builder and merge everything through `extra`. BEAMCON0.HARDDIS
-        // relaxes the hardwired stop position.
-        let (_, hard_stop) = crate::chipset::agnus::ddf_hard_bounds(self.harddis_active());
+        // list builder and merge everything through `extra`.
         let signals =
             seq::line_signals_with_hard_stop(0xFFFF, 0xFFFF, hard_stop, line_ccks, &extra);
         // A line that begins with BPRUN already up continues a run carried
@@ -308,49 +435,13 @@ impl Bus {
             &mut state,
         );
 
-        let mut line = DdfSeqLine {
-            vpos,
-            plane_at: [0; DDF_SEQ_MAX_LINE_CCKS],
-            modulo_at: [false; DDF_SEQ_MAX_LINE_CCKS],
-            words_per_plane: [0; 8],
-            words_per_row: 0,
-            dma_planes: 0,
-            word_idx_at: [0; DDF_SEQ_MAX_LINE_CCKS],
-            first_fetch_cck: None,
-            run_origin_cck: None,
-            end_state: state,
-        };
+        let mut line = DdfSeqLine::empty(vpos, state, None);
         let shres = crate::chipset::agnus::bitplane_shres(state.bplcon0);
         let hires = crate::chipset::agnus::bitplane_hires(state.bplcon0);
-        for f in &fetches {
-            let idx = usize::from(f.cck);
-            if idx >= DDF_SEQ_MAX_LINE_CCKS {
-                continue;
-            }
-            let plane = usize::from(f.plane).min(7);
-            line.plane_at[idx] = f.plane + 1;
-            line.modulo_at[idx] = f.apply_modulo;
-            // Word addressing is unit-based: a plane enabled mid-line keeps
-            // fetching into its unit's word position, leaving earlier words
-            // zero (matching the hardware's per-unit pointer cadence).
-            line.word_idx_at[idx] = if shres {
-                f.unit_ord * 4 + u16::from(f.counter >> 1)
-            } else if hires {
-                f.unit_ord * 2 + u16::from(f.counter >= 4)
-            } else {
-                f.unit_ord
-            };
-            line.words_per_plane[plane] =
-                line.words_per_plane[plane].max(line.word_idx_at[idx] + 1);
-            if line.first_fetch_cck.is_none() {
-                line.first_fetch_cck = Some(f.cck);
-                if !run_carried_in {
-                    line.run_origin_cck = Some(f.cck.saturating_sub(u16::from(f.counter)));
-                }
-            }
+        for fetch in fetches {
+            line.record_fetch(fetch, shres, hires, run_carried_in);
         }
-        line.words_per_row = line.words_per_plane.iter().copied().max().unwrap_or(0);
-        line.dma_planes = line.plane_at.iter().copied().max().unwrap_or(0);
+        line.finish(state);
         line
     }
 
@@ -603,7 +694,9 @@ impl Bus {
             self.denise.bplcon0,
         ));
         self.ddf_seq_writes.borrow_mut().clear();
-        self.ddf_seq_invalidate_line();
+        // Keep the completed line as the candidate for static-plan reuse.
+        // Only its vpos publication becomes stale at the rollover.
+        self.ddf_seq_hot_line.invalidate();
     }
 }
 
@@ -632,6 +725,30 @@ mod tests {
         // Plane 1 fetches at the end of each unit ($3F, $47, ...).
         assert_eq!(table.plane_at[0x3F], 1);
         assert_eq!(table.plane_at[0x38], 0);
+    }
+
+    #[test]
+    fn identical_static_scanline_reuses_the_complete_plan_key() {
+        let mut bus = empty_bus();
+        bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+        bus.denise.diwstrt = 0x2C81;
+        bus.denise.diwstop = 0xF4C1;
+        bus.denise.ddfstrt = 0x0038;
+        bus.denise.ddfstop = 0x00D0;
+        bus.denise.bplcon0 = 0x4200;
+        bus.agnus.vpos = 0x50;
+        bus.ddf_seq_on_line_rollover(0x4F);
+
+        let first = (*bus.ddf_seq_line_table()).clone();
+        let first_key = first.static_key.expect("ordinary line has a static key");
+        bus.ddf_seq_on_line_rollover(0x50);
+        bus.agnus.vpos = 0x51;
+        let second = bus.ddf_seq_line_table();
+
+        assert_eq!(second.static_key, Some(first_key));
+        assert_eq!(second.plane_at, first.plane_at);
+        assert_eq!(second.word_idx_at, first.word_idx_at);
+        assert_eq!(second.end_state, first.end_state);
     }
 
     #[test]

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -83,42 +83,8 @@ impl Bus {
             );
         }
         self.last_chip_bus_owner = owner;
-        if self.bus_accounting.enabled {
-            self.bus_accounting
-                .record_cck(owner, cck, self.blitter.busy);
-            if matches!(owner, ChipBusOwner::Bitplane) {
-                let v = self.agnus.vpos as usize;
-                if v < self.dbg_bpl_cck.len() {
-                    self.dbg_bpl_cck[v] += cck;
-                }
-            }
-        }
-        if self.dbg_slotmap_on {
-            let v = self.agnus.vpos as usize;
-            let h = self.agnus.hpos as usize;
-            if self.dbg_slotmap.is_empty() {
-                self.dbg_slotmap = vec![vec![b'.'; 256]; 320];
-            }
-            if v < self.dbg_slotmap.len() {
-                let code = chip_bus_owner_code(owner);
-                let row = &mut self.dbg_slotmap[v];
-                let end = (h + cck as usize).min(row.len());
-                for slot in row.iter_mut().take(end).skip(h) {
-                    *slot = code;
-                }
-            }
-        }
-        if self.frame_analyzer_enabled {
-            self.current_frame_bus_trace.record(
-                self.agnus.vpos,
-                hpos,
-                cck,
-                owner,
-                self.blitter.busy,
-            );
-        }
-        if self.wave_on {
-            self.wave_tap_quantum(owner);
+        if self.chip_bus_observers_on {
+            self.observe_chip_bus_quantum(owner, cck, hpos);
         }
         // The Copper was already stepped above (or is held without fetching at
         // the end-of-line lockout); only drive the other owners here.
@@ -185,6 +151,57 @@ impl Bus {
             }
         }
         (cck, tick)
+    }
+
+    pub(super) fn refresh_chip_bus_observers(&mut self) {
+        self.chip_bus_observers_on = self.bus_accounting.enabled
+            || self.dbg_slotmap_on
+            || self.frame_analyzer_enabled
+            || self.wave_on;
+    }
+
+    /// Observer fan-out is outlined from the ordinary arbitration path. It is
+    /// deliberately cold relative to emulation: even an interactive debugger
+    /// spends most of its lifetime with no bus trace or waveform armed.
+    #[cold]
+    fn observe_chip_bus_quantum(&mut self, owner: ChipBusOwner, cck: u32, hpos: u32) {
+        if self.bus_accounting.enabled {
+            self.bus_accounting
+                .record_cck(owner, cck, self.blitter.busy);
+            if matches!(owner, ChipBusOwner::Bitplane) {
+                let v = self.agnus.vpos as usize;
+                if v < self.dbg_bpl_cck.len() {
+                    self.dbg_bpl_cck[v] += cck;
+                }
+            }
+        }
+        if self.dbg_slotmap_on {
+            let v = self.agnus.vpos as usize;
+            let h = self.agnus.hpos as usize;
+            if self.dbg_slotmap.is_empty() {
+                self.dbg_slotmap = vec![vec![b'.'; 256]; 320];
+            }
+            if v < self.dbg_slotmap.len() {
+                let code = chip_bus_owner_code(owner);
+                let row = &mut self.dbg_slotmap[v];
+                let end = (h + cck as usize).min(row.len());
+                for slot in row.iter_mut().take(end).skip(h) {
+                    *slot = code;
+                }
+            }
+        }
+        if self.frame_analyzer_enabled {
+            self.current_frame_bus_trace.record(
+                self.agnus.vpos,
+                hpos,
+                cck,
+                owner,
+                self.blitter.busy,
+            );
+        }
+        if self.wave_on {
+            self.wave_tap_quantum(owner);
+        }
     }
 
     /// Step the Copper through one eligible color clock and apply any register

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -52,36 +52,39 @@ impl Bus {
             self.current_frame_chip_ram_writes.clear();
             self.last_frame_beam_bottom_palette_events.clear();
         }
-        // Promote the just-finished frame's chip-RAM snapshot to `last` by
-        // swapping buffers instead of copying 2 MB. `capture_current_frame_
+        // Promote the just-finished frame's chip-RAM snapshot to immutable
+        // shared ownership without copying 2 MB. `capture_current_frame_
         // display_start` already filled `current_frame_chip_ram` for any frame
-        // that reached its display window, so move that buffer across and
-        // recycle the old `last` buffer as the next `current`. A frame that
-        // never displayed (no capture taken) has no meaningful snapshot, so
-        // fall back to a live copy for the renderer's blank/border output.
-        if promote_render_frame
+        // that reached its display window. The old shared buffer becomes the
+        // next mutable capture buffer once the renderer has released it. A
+        // frame that never displayed has no meaningful snapshot, so fall back
+        // to a live copy for the renderer's blank/border output.
+        let completed_chip_ram = if promote_render_frame
             && self.current_frame_display_snapshot_taken
             && self.current_frame_chip_ram.len() == self.mem.chip_ram.len()
         {
-            std::mem::swap(
-                &mut self.last_frame_chip_ram,
-                &mut self.current_frame_chip_ram,
-            );
+            std::mem::take(&mut self.current_frame_chip_ram)
         } else if promote_render_frame {
-            self.last_frame_chip_ram.clear();
-            self.last_frame_chip_ram
-                .extend_from_slice(&self.mem.chip_ram);
+            self.mem.chip_ram.clone()
         } else {
-            self.last_frame_chip_ram.clear();
-        }
+            Vec::new()
+        };
+        let old_chip_ram = std::mem::replace(
+            &mut self.last_frame_chip_ram,
+            std::sync::Arc::new(completed_chip_ram),
+        );
+        // The renderer normally drops its shared reference before the next
+        // frame wrap, letting the old allocation return to the capture side.
+        // If it is still in flight, correctness wins: start with a fresh Vec.
+        self.current_frame_chip_ram = std::sync::Arc::try_unwrap(old_chip_ram).unwrap_or_default();
         let current_bitplane_rows = std::mem::replace(
             &mut self.current_frame_bitplane_rows,
             empty_captured_bitplane_rows(),
         );
         self.last_frame_bitplane_rows = if promote_render_frame {
-            current_bitplane_rows
+            std::sync::Arc::new(current_bitplane_rows)
         } else {
-            empty_captured_bitplane_rows()
+            std::sync::Arc::new(empty_captured_bitplane_rows())
         };
         self.last_frame_sprite_lines = if promote_render_frame {
             std::mem::take(&mut self.current_frame_sprite_lines)

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -4893,7 +4893,7 @@ fn lowres_fallback_fetches_ignore_chip_ram_writes_after_plane_slot() {
     snapshot.bplpt[0] = 0x0100;
     snapshot.bplpt[1] = 0x0200;
     bus.last_frame_render_base = Some(snapshot);
-    bus.last_frame_chip_ram = vec![0; bus.mem.chip_ram.len()];
+    bus.last_frame_chip_ram = std::sync::Arc::new(vec![0; bus.mem.chip_ram.len()]);
     bus.last_frame_chip_ram_writes
         .push(BeamChipRamWrite::from_bytes(
             RENDER_VISIBLE_START_VPOS,
@@ -4925,8 +4925,8 @@ fn lowres_fallback_fetches_ignore_pointer_writes_after_plane_slot() {
     snapshot.bplpt[0] = 0x0100;
     snapshot.bplpt[1] = 0x0200;
     bus.last_frame_render_base = Some(snapshot);
-    bus.last_frame_chip_ram = vec![0; bus.mem.chip_ram.len()];
-    bus.last_frame_chip_ram[0x0300] = 0x80;
+    bus.last_frame_chip_ram = std::sync::Arc::new(vec![0; bus.mem.chip_ram.len()]);
+    std::sync::Arc::make_mut(&mut bus.last_frame_chip_ram)[0x0300] = 0x80;
     bus.last_frame_render_events.push(BeamRegisterWrite {
         vpos: RENDER_VISIBLE_START_VPOS,
         hpos: 0x40,
@@ -5932,13 +5932,13 @@ fn state_load_resets_transient_video_latches() {
         value: 0x0FFF,
         source: BeamWriteSource::Copper,
     });
-    bus.last_frame_chip_ram = vec![0xA5; bus.mem.chip_ram.len()];
+    bus.last_frame_chip_ram = std::sync::Arc::new(vec![0xA5; bus.mem.chip_ram.len()]);
     bus.last_frame_chip_ram_writes
         .push(BeamChipRamWrite::from_bytes(0x2C, 0x40, 0x0100, &[0x12]));
     bus.current_frame_chip_ram.clear();
     bus.current_frame_chip_ram_writes
         .push(BeamChipRamWrite::from_bytes(0x2C, 0x40, 0x0100, &[0x34]));
-    bus.last_frame_bitplane_rows[0] = Some(CapturedBitplaneRow {
+    std::sync::Arc::make_mut(&mut bus.last_frame_bitplane_rows)[0] = Some(CapturedBitplaneRow {
         nplanes: 1,
         words_per_row: 1,
         fetch_origin_cck: None,

--- a/src/bus/wave.rs
+++ b/src/bus/wave.rs
@@ -31,6 +31,7 @@ impl Bus {
         self.wave_pc_trigger = matches!(capture.trigger(), Trigger::Pc(_));
         let immediate = matches!(capture.trigger(), Trigger::Now);
         self.wave_on = true;
+        self.refresh_chip_bus_observers();
         self.wave = Some(Box::new(capture));
         if immediate {
             self.wave_fire();
@@ -42,6 +43,7 @@ impl Bus {
     /// final status. None when no capture exists.
     pub fn wave_stop(&mut self) -> Option<WaveStatus> {
         self.wave_on = false;
+        self.refresh_chip_bus_observers();
         self.wave_pc_trigger = false;
         let mut wave = self.wave.take()?;
         wave.finish();
@@ -74,6 +76,7 @@ impl Bus {
     /// zero-cost path. The finished capture stays around for status queries.
     fn wave_finish(&mut self) {
         self.wave_on = false;
+        self.refresh_chip_bus_observers();
         self.wave_pc_trigger = false;
         if let Some(wave) = self.wave.as_deref_mut() {
             wave.finish();

--- a/src/chipset/ddf_sequencer.rs
+++ b/src/chipset/ddf_sequencer.rs
@@ -309,7 +309,7 @@ fn walk_span(
     stop: u16,
     state: &mut DdfState,
     unit_ord: &mut Option<u16>,
-    fetches: &mut Vec<DdfFetch>,
+    emit: &mut impl FnMut(DdfFetch),
 ) {
     for j in start..stop {
         let counter = (state.cnt << 1) | (j & 1) as u8;
@@ -337,7 +337,7 @@ fn walk_span(
 
         if state.bprun {
             if let Some(plane) = unit_slot(state.bplcon0, aga, counter) {
-                fetches.push(DdfFetch {
+                emit(DdfFetch {
                     cck: j,
                     plane,
                     unit_ord: unit_ord.unwrap_or(0),
@@ -413,25 +413,77 @@ pub fn walk_line(
     state: &mut DdfState,
 ) -> Vec<DdfFetch> {
     let mut fetches = Vec::new();
+    walk_line_into(aga, ecs, signals, state, |fetch| fetches.push(fetch));
+    fetches
+}
+
+/// Allocation-free form of [`walk_line`]. The caller consumes each fetch
+/// while the sequencer walks the line, which lets hot users build their
+/// fixed-size slot tables without first materializing a temporary vector.
+pub fn walk_line_into(
+    aga: bool,
+    ecs: bool,
+    signals: &[DdfSignal],
+    state: &mut DdfState,
+    mut emit: impl FnMut(DdfFetch),
+) {
     let mut cycle = 0u16;
     let mut unit_ord: Option<u16> = None;
     for signal in signals {
-        walk_span(
-            aga,
-            ecs,
-            cycle,
-            signal.cck,
-            state,
-            &mut unit_ord,
-            &mut fetches,
-        );
+        walk_span(aga, ecs, cycle, signal.cck, state, &mut unit_ord, &mut emit);
         process_signal(ecs, signal, state);
         if signal.bits & sig::DONE != 0 {
             break;
         }
         cycle = signal.cck;
     }
-    fetches
+}
+
+/// Walk a line whose DDF/control registers do not change mid-line.
+///
+/// The five possible strobes fit on the stack. Coincident strobes are merged
+/// before the walk exactly as in [`line_signals_with_hard_stop`], avoiding
+/// both the signal-list and fetch-list allocations on ordinary scanlines.
+pub fn walk_static_line_into(
+    aga: bool,
+    ecs: bool,
+    ddfstrt: u16,
+    ddfstop: u16,
+    hard_stop_cck: u16,
+    line_ccks: u16,
+    state: &mut DdfState,
+    emit: impl FnMut(DdfFetch),
+) {
+    const EMPTY: DdfSignal = DdfSignal {
+        cck: 0,
+        bits: 0,
+        bplcon0: 0,
+    };
+    let mut signals = [EMPTY; 5];
+    let mut len = 0usize;
+    let mut push = |cck: u16, bits: u32| {
+        if let Some(existing) = signals[..len].iter_mut().find(|signal| signal.cck == cck) {
+            existing.bits |= bits;
+        } else {
+            signals[len] = DdfSignal {
+                cck,
+                bits,
+                bplcon0: 0,
+            };
+            len += 1;
+        }
+    };
+    push(DDF_HARD_START_CCK, sig::SHW);
+    if ddfstrt < line_ccks {
+        push(ddfstrt, sig::BPHSTART);
+    }
+    if ddfstop < line_ccks {
+        push(ddfstop, sig::BPHSTOP);
+    }
+    push(hard_stop_cck, sig::RHW);
+    push(line_ccks, sig::DONE);
+    signals[..len].sort_unstable_by_key(|signal| signal.cck);
+    walk_line_into(aga, ecs, &signals[..len], state, emit);
 }
 
 #[cfg(test)]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3526,9 +3526,9 @@ pub struct RenderInput {
     current_render_events: Vec<BeamRegisterWrite>,
     bottom_palette_events: Vec<BeamRegisterWrite>,
     top_palette_end: Palette,
-    chip_ram: Vec<u8>,
+    chip_ram: std::sync::Arc<Vec<u8>>,
     chip_ram_writes: Vec<BeamChipRamWrite>,
-    captured_bitplane_rows: Vec<Option<CapturedBitplaneRow>>,
+    captured_bitplane_rows: std::sync::Arc<Vec<Option<CapturedBitplaneRow>>>,
     captured_sprite_lines: Vec<CapturedSpriteLine>,
     held_sprites: [Option<HeldSpriteLine>; 8],
     sprite_display_enable_x_by_y: Vec<Option<usize>>,
@@ -3563,9 +3563,9 @@ impl RenderInput {
             current_render_events: bus.current_render_events().to_vec(),
             bottom_palette_events: bus.frame_bottom_palette_events().to_vec(),
             top_palette_end: bus.frame_top_palette_end(),
-            chip_ram: bus.frame_chip_ram().to_vec(),
+            chip_ram: bus.frame_chip_ram_shared(),
             chip_ram_writes: bus.frame_chip_ram_writes().to_vec(),
-            captured_bitplane_rows: bus.frame_captured_bitplane_rows().to_vec(),
+            captured_bitplane_rows: bus.frame_captured_bitplane_rows_shared(),
             captured_sprite_lines: bus.frame_captured_sprite_lines().to_vec(),
             held_sprites: bus.frame_held_sprites(),
             sprite_display_enable_x_by_y: bus.frame_sprite_display_enable_x_by_y().to_vec(),
@@ -3603,12 +3603,9 @@ impl RenderInput {
             bus.frame_bottom_palette_events(),
         );
         self.top_palette_end = bus.frame_top_palette_end();
-        copy_into(&mut self.chip_ram, bus.frame_chip_ram());
+        self.chip_ram = bus.frame_chip_ram_shared();
         copy_into(&mut self.chip_ram_writes, bus.frame_chip_ram_writes());
-        copy_into(
-            &mut self.captured_bitplane_rows,
-            bus.frame_captured_bitplane_rows(),
-        );
+        self.captured_bitplane_rows = bus.frame_captured_bitplane_rows_shared();
         copy_into(
             &mut self.captured_sprite_lines,
             bus.frame_captured_sprite_lines(),
@@ -3671,6 +3668,22 @@ impl RenderInput {
             &self.frame_render_events,
         )
     }
+
+    /// Drop large shared frame snapshots once a render has completed while
+    /// keeping this bundle's reusable event/sprite allocations. Releasing the
+    /// RAM reference before the next beam-frame wrap lets the capture side
+    /// reclaim its Vec instead of allocating another chip-RAM-sized buffer.
+    pub(crate) fn release_shared_frame_data(&mut self) {
+        static EMPTY_CHIP_RAM: OnceLock<std::sync::Arc<Vec<u8>>> = OnceLock::new();
+        static EMPTY_BITPLANE_ROWS: OnceLock<std::sync::Arc<Vec<Option<CapturedBitplaneRow>>>> =
+            OnceLock::new();
+
+        self.chip_ram =
+            std::sync::Arc::clone(EMPTY_CHIP_RAM.get_or_init(|| std::sync::Arc::new(Vec::new())));
+        self.captured_bitplane_rows = std::sync::Arc::clone(
+            EMPTY_BITPLANE_ROWS.get_or_init(|| std::sync::Arc::new(Vec::new())),
+        );
+    }
 }
 
 /// Outputs of `render_from_input`. Render timing is always recorded back on
@@ -3698,10 +3711,16 @@ pub fn render(bus: &mut Bus, fb: &mut [u32]) {
             Some(input) => input.refill_from_bus(bus),
             None => *scratch = Some(RenderInput::from_bus(bus)),
         }
-        let input = scratch.as_ref().expect("scratch render input present");
-        let result = render_from_input(input, fb);
+        let result = {
+            let input = scratch.as_ref().expect("scratch render input present");
+            render_from_input(input, fb)
+        };
         bus.denise.or_clxdat(result.clxdat);
         bus.record_video_render_frame(result.timing);
+        scratch
+            .as_mut()
+            .expect("scratch render input present")
+            .release_shared_frame_data();
     });
 }
 
@@ -3720,8 +3739,14 @@ pub fn render_display_only(bus: &Bus, fb: &mut [u32]) {
             Some(input) => input.refill_from_bus(bus),
             None => *scratch = Some(RenderInput::from_bus(bus)),
         }
-        let input = scratch.as_ref().expect("scratch render input present");
-        let _ = render_from_input(input, fb);
+        {
+            let input = scratch.as_ref().expect("scratch render input present");
+            let _ = render_from_input(input, fb);
+        }
+        scratch
+            .as_mut()
+            .expect("scratch render input present")
+            .release_shared_frame_data();
     });
 }
 
@@ -4082,6 +4107,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
     let mut next_bitplane_data_event = 0usize;
     let mut playfield_mask = vec![0u8; FB_WIDTH * rows];
     let mut collision_pixels = vec![CollisionPixel::default(); FB_WIDTH * rows];
+    let mut collision_lookup = CollisionLookup::new();
     let mut clxdat = 0u16;
     let mut dma_output_start_x_by_line = vec![None; rows];
 
@@ -4490,6 +4516,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 fb,
                 &mut playfield_mask,
                 &mut collision_pixels,
+                &mut collision_lookup,
                 &mut clxdat,
                 palette,
                 segments,
@@ -4762,6 +4789,7 @@ fn render_planned_playfield_line(
     fb: &mut [u32],
     playfield_mask: &mut [u8],
     collision_pixels: &mut [CollisionPixel],
+    collision_lookup: &mut CollisionLookup,
     clxdat: &mut u16,
     mut palette: Palette,
     palette_segments: &[PaletteSegment],
@@ -4799,14 +4827,6 @@ fn render_planned_playfield_line(
     // ([`DENISE_HAM_SELECT_PIPELINE_FB`]).
     let mut ham_bplcon0 = base_ham_bplcon0;
     let mut ham_segment_idx = 0usize;
-    // Playfield-collision classification (clxcon_planes_match) depends only on
-    // the bitplane index and the constant control fields (CLXCON/CLXCON2, plane
-    // count, dual-playfield), so memoize it per control run as a 256-entry
-    // table indexed by the sample index. This lifts a per-plane matching loop
-    // out of the per-pixel path; the table is rebuilt only when those control
-    // inputs change.
-    let mut collision_key: Option<(u16, u16, bool, usize)> = None;
-    let mut collision_table = [CollisionPixel::default(); 256];
     // The loop runs in segment-bounded chunks: control, scroll, and palette
     // segments apply at pixel boundaries (x stepping by pixel_repeat), so
     // between two boundaries every control-derived value is constant and is
@@ -4917,23 +4937,8 @@ fn render_planned_playfield_line(
         };
 
         let collision_dual = pixel_control.dual_playfield();
-        let collision_key_now = (
-            pixel_control.clxcon,
-            pixel_control.clxcon2,
-            collision_dual,
-            nplanes,
-        );
-        if collision_key != Some(collision_key_now) {
-            collision_table = std::array::from_fn(|idx| {
-                collision_pixel(
-                    idx as u8,
-                    pixel_control.clxcon,
-                    pixel_control.clxcon2,
-                    collision_dual,
-                )
-            });
-            collision_key = Some(collision_key_now);
-        }
+        let collision_table =
+            collision_lookup.table(pixel_control.clxcon, pixel_control.clxcon2, collision_dual);
 
         loop {
             let output_native_x = ((x - plan.x_start) / pixel_repeat) * native_per_pixel;
@@ -5061,7 +5066,7 @@ fn render_planned_playfield_line(
             // written pixel) is equivalent: a visible sample writes at least
             // one in-window pixel.
             let collision = collision_table[sample.idx as usize];
-            let pf_mask = u8::from(collision.pf1) | (u8::from(collision.pf2) << 1);
+            let pf_mask = collision.playfield_mask();
             *clxdat |= collision.clxdat_bits();
             for dx in 0..pixel_repeat {
                 let pixel_x = x + dx;
@@ -5129,16 +5134,70 @@ fn left_edge_blank_pixels(control: ControlState) -> usize {
 }
 
 #[derive(Clone, Copy, Default)]
-struct CollisionPixel {
-    pf1: bool,
-    pf2: bool,
-    pf1_match: bool,
-    pf2_match: bool,
-}
+#[repr(transparent)]
+struct CollisionPixel(u8);
 
 impl CollisionPixel {
+    const PF1: u8 = 1 << 0;
+    const PF2: u8 = 1 << 1;
+    const PF1_MATCH: u8 = 1 << 2;
+    const PF2_MATCH: u8 = 1 << 3;
+
+    fn new(pf1: bool, pf2: bool, pf1_match: bool, pf2_match: bool) -> Self {
+        Self(
+            u8::from(pf1) * Self::PF1
+                + u8::from(pf2) * Self::PF2
+                + u8::from(pf1_match) * Self::PF1_MATCH
+                + u8::from(pf2_match) * Self::PF2_MATCH,
+        )
+    }
+
+    fn playfield_mask(self) -> u8 {
+        self.0 & (Self::PF1 | Self::PF2)
+    }
+
+    fn pf1_match(self) -> bool {
+        self.0 & Self::PF1_MATCH != 0
+    }
+
+    fn pf2_match(self) -> bool {
+        self.0 & Self::PF2_MATCH != 0
+    }
+
     fn clxdat_bits(self) -> u16 {
-        u16::from(self.pf1_match && self.pf2_match)
+        u16::from(
+            self.0 & (Self::PF1_MATCH | Self::PF2_MATCH) == (Self::PF1_MATCH | Self::PF2_MATCH),
+        )
+    }
+}
+
+/// Frame-local collision truth table. CLXCON normally remains unchanged for
+/// the whole display, so retaining the table across scanlines replaces tens
+/// of thousands of repeated per-plane comparisons with byte lookups. A
+/// mid-frame CLXCON change updates the key and rebuilds before its first
+/// affected sample.
+struct CollisionLookup {
+    key: Option<(u16, u16, bool)>,
+    table: [CollisionPixel; 256],
+}
+
+impl CollisionLookup {
+    fn new() -> Self {
+        Self {
+            key: None,
+            table: [CollisionPixel::default(); 256],
+        }
+    }
+
+    fn table(&mut self, clxcon: u16, clxcon2: u16, dual_playfield: bool) -> &[CollisionPixel; 256] {
+        let key = (clxcon, clxcon2, dual_playfield);
+        if self.key != Some(key) {
+            self.table = std::array::from_fn(|idx| {
+                collision_pixel(idx as u8, clxcon, clxcon2, dual_playfield)
+            });
+            self.key = Some(key);
+        }
+        &self.table
     }
 }
 
@@ -5146,16 +5205,16 @@ fn collision_pixel(idx: u8, clxcon: u16, clxcon2: u16, dual_playfield: bool) -> 
     let even_match = clxcon_planes_match(idx, clxcon, clxcon2, 1);
     let odd_match_raw = clxcon_planes_match(idx, clxcon, clxcon2, 0);
     let odd_match = odd_match_raw && (dual_playfield || even_match);
-    CollisionPixel {
-        pf1: dual_playfield && idx & 0b010101 != 0,
-        pf2: if dual_playfield {
+    CollisionPixel::new(
+        dual_playfield && idx & 0b010101 != 0,
+        if dual_playfield {
             idx & 0b101010 != 0
         } else {
             idx != 0
         },
-        pf1_match: odd_match,
-        pf2_match: even_match,
-    }
+        odd_match,
+        even_match,
+    )
 }
 
 fn clxcon_planes_match(idx: u8, clxcon: u16, clxcon2: u16, first_plane: usize) -> bool {
@@ -5201,7 +5260,7 @@ fn record_generated_playfield_collision_pixel(
         control.clxcon2,
         control.dual_playfield(),
     );
-    let pf_mask = u8::from(collision.pf1) | (u8::from(collision.pf2) << 1);
+    let pf_mask = collision.playfield_mask();
     if pf_mask != 0 {
         playfield_mask[fb_idx] = pf_mask;
     }

--- a/src/video/bitplane/sprite.rs
+++ b/src/video/bitplane/sprite.rs
@@ -1635,10 +1635,10 @@ pub(super) fn generated_sprite_collision_bits(
         }
     }
     let collision = collision_pixels[fb_idx];
-    if collision.pf1_match {
+    if collision.pf1_match() {
         clxdat |= 1 << (group + 1);
     }
-    if collision.pf2_match {
+    if collision.pf2_match() {
         clxdat |= 1 << (group + 5);
     }
     sprite_group_mask[fb_idx] |= bit;
@@ -1673,10 +1673,10 @@ pub(super) fn generated_sprite_pair_collision_bits(
         }
     }
     let collision = collision_pixels[fb_idx];
-    if collision.pf1_match {
+    if collision.pf1_match() {
         clxdat |= 1 << (group + 1);
     }
-    if collision.pf2_match {
+    if collision.pf2_match() {
         clxdat |= 1 << (group + 5);
     }
     sprite_group_mask[fb_idx] |= bit;

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -1541,6 +1541,7 @@ fn late_lowres_ddf_stop_hold_keeps_left_origin_unadvanced() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -5785,23 +5786,23 @@ fn sprite_dma_reuse_stops_at_null_control_block() {
 #[test]
 fn collision_pixel_honors_clxcon_match_bits() {
     let collision = collision_pixel(0b000011, 0x00C3, 0, false);
-    assert!(collision.pf1_match);
-    assert!(collision.pf2_match);
+    assert!(collision.pf1_match());
+    assert!(collision.pf2_match());
 
     let mismatch = collision_pixel(0b000010, 0x00C3, 0, false);
-    assert!(!mismatch.pf1_match);
-    assert!(mismatch.pf2_match);
+    assert!(!mismatch.pf1_match());
+    assert!(mismatch.pf2_match());
 }
 
 #[test]
 fn collision_pixel_single_playfield_odd_match_requires_even_match() {
     let single = collision_pixel(0b000001, 0x0083, 0, false);
-    assert!(!single.pf1_match);
-    assert!(!single.pf2_match);
+    assert!(!single.pf1_match());
+    assert!(!single.pf2_match());
 
     let dual = collision_pixel(0b000001, 0x0083, 0, true);
-    assert!(dual.pf1_match);
-    assert!(!dual.pf2_match);
+    assert!(dual.pf1_match());
+    assert!(!dual.pf2_match());
 }
 
 /// Plan 3.4: AGA planes 7-8 collision control comes from CLXCON2
@@ -5810,27 +5811,27 @@ fn collision_pixel_single_playfield_odd_match_requires_even_match() {
 fn collision_pixel_planes_7_and_8_use_clxcon2() {
     // Plane 7 (bit 6) enabled, must be set: pixel with bit 6 matches.
     let hit = collision_pixel(0b0100_0000, 0, 0x0041, false);
-    assert!(hit.pf1_match);
+    assert!(hit.pf1_match());
     let miss = collision_pixel(0, 0, 0x0041, false);
-    assert!(!miss.pf1_match);
+    assert!(!miss.pf1_match());
 
     // Plane 8 (bit 7) enabled, must be clear: a set bit 7 mismatches.
     let even_hit = collision_pixel(0, 0, 0x0080, false);
-    assert!(even_hit.pf2_match);
+    assert!(even_hit.pf2_match());
     let even_miss = collision_pixel(0b1000_0000, 0, 0x0080, false);
-    assert!(!even_miss.pf2_match);
+    assert!(!even_miss.pf2_match());
 
     // With CLXCON2 clear, planes 7-8 never gate the match (and the
     // sprite-enable bits of CLXCON are not misread for them).
     let ignore = collision_pixel(0b1100_0000, 0xF000, 0, false);
-    assert!(ignore.pf1_match && ignore.pf2_match);
+    assert!(ignore.pf1_match() && ignore.pf2_match());
 }
 
 #[test]
 fn collision_pixel_disabled_planes_match_continuously() {
     let collision = collision_pixel(0, 0, 0, false);
-    assert!(collision.pf1_match);
-    assert!(collision.pf2_match);
+    assert!(collision.pf1_match());
+    assert!(collision.pf2_match());
     assert_eq!(collision.clxdat_bits(), 1);
 }
 
@@ -5843,14 +5844,14 @@ fn collision_match_gates_on_enabled_planes_beyond_the_bpu_count() {
     // `(dBuffer & enbp) == (mvbp & enbp)`). Copperline previously only checked
     // planes up to the fetched count and so spuriously matched.
     let all_planes_match_one = collision_pixel(0b000001, 0x0FFF, 0, false);
-    assert!(!all_planes_match_one.pf1_match);
-    assert!(!all_planes_match_one.pf2_match);
+    assert!(!all_planes_match_one.pf1_match());
+    assert!(!all_planes_match_one.pf2_match());
 
     // Setting the absent planes' match value to 0 (CLXCON 0x0FC1) lets the
     // zero-read absent planes match, so the one-plane pixel collides.
     let only_plane1_match = collision_pixel(0b000001, 0x0FC1, 0, false);
-    assert!(only_plane1_match.pf1_match);
-    assert!(only_plane1_match.pf2_match);
+    assert!(only_plane1_match.pf1_match());
+    assert!(only_plane1_match.pf2_match());
 }
 
 #[test]
@@ -5967,6 +5968,7 @@ fn planned_ham_dma_uses_current_bitplane_sample_at_fetch_edge() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6016,6 +6018,7 @@ fn planned_ham_dma_advances_hold_through_edge_fetch_phase() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6063,6 +6066,7 @@ fn planned_ham_dma_ignores_extra_early_ddf_history_before_diw() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6116,6 +6120,7 @@ fn bplcon1_write_at_diw_right_edge_does_not_retap_current_ham_line() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6181,6 +6186,7 @@ fn ham_select_lands_in_the_colour_write_domain() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6223,6 +6229,7 @@ fn bplcon2_color_key_uses_color_register_transparency_bit() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6263,6 +6270,7 @@ fn bplcon2_bitplane_key_uses_selected_bitplane_sample() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6303,6 +6311,7 @@ fn bplcon3_zdclken_disables_internal_genlock_keys() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         palette,
         &[],
@@ -6339,6 +6348,7 @@ fn planned_playfield_line_feeds_clxdat_from_rendered_dual_playfield_sample() {
         &mut fb,
         &mut playfield_mask,
         &mut collision_pixels,
+        &mut CollisionLookup::new(),
         &mut clxdat,
         Palette::new(),
         &[],
@@ -6358,8 +6368,7 @@ fn planned_playfield_line_feeds_clxdat_from_rendered_dual_playfield_sample() {
 
     assert_eq!(clxdat & 0x0001, 0x0001);
     assert_eq!(&playfield_mask[68..70], &[0x03, 0x03]);
-    assert!(collision_pixels[68].pf1);
-    assert!(collision_pixels[68].pf2);
+    assert_eq!(collision_pixels[68].playfield_mask(), 0b11);
 }
 
 #[test]
@@ -7705,12 +7714,7 @@ fn sprite_collisions_use_beam_timed_clxcon_control() {
     playfield_mask[0] = 0x02;
     playfield_mask[1] = 0x02;
     let mut collision_pixels = vec![CollisionPixel::default(); FB_PIXELS];
-    collision_pixels[0] = CollisionPixel {
-        pf1: false,
-        pf2: true,
-        pf1_match: false,
-        pf2_match: true,
-    };
+    collision_pixels[0] = CollisionPixel::new(false, true, false, true);
     collision_pixels[1] = collision_pixels[0];
     let mut fb = vec![rgb12_to_rgba8(0); FB_PIXELS];
     let captured = [CapturedSpriteLine {

--- a/src/video/deinterlace.rs
+++ b/src/video/deinterlace.rs
@@ -365,6 +365,61 @@ impl Deinterlacer {
         self.have[parity] = true;
         self.present_with_phosphor();
     }
+
+    /// Present a field directly into an owned frontend buffer.
+    ///
+    /// The overwhelmingly common standard progressive path needs neither
+    /// weave history nor phosphor history. Writing its doubled rows straight
+    /// to the frontend buffer avoids first filling `self.out` and then copying
+    /// the whole 570-line image once more. Interlaced or phosphor-blended
+    /// frames retain the history-dependent [`Self::push_field`] path and copy
+    /// its result, so their output is unchanged.
+    #[doc(hidden)]
+    pub fn present_field_into(
+        &mut self,
+        field: &[u32],
+        rows: usize,
+        width: usize,
+        lace: bool,
+        long_field: bool,
+        double_rows: bool,
+        destination: &mut Vec<u32>,
+    ) -> (usize, usize) {
+        debug_assert!(field.len() >= rows * width);
+        let rows = rows.clamp(1, MAX_VISIBLE_LINES);
+        let direct = self.phosphor_alpha == 0 && (!lace || !self.enabled);
+        if direct {
+            if rows != self.field_rows || width != self.field_width {
+                self.field_rows = rows;
+                self.field_width = width;
+            }
+            self.have = [false; 2];
+            self.have2 = [false; 2];
+            self.out_width = width;
+            if !lace && !double_rows {
+                let active = rows * width;
+                destination.resize(active, 0);
+                destination.copy_from_slice(&field[..active]);
+                self.out_rows = rows;
+            } else {
+                let active = rows * width * 2;
+                destination.resize(active, 0);
+                for y in 0..rows {
+                    let row = &field[y * width..(y + 1) * width];
+                    destination[2 * y * width..(2 * y + 1) * width].copy_from_slice(row);
+                    destination[(2 * y + 1) * width..(2 * y + 2) * width].copy_from_slice(row);
+                }
+                self.out_rows = rows * 2;
+            }
+            return (self.out_rows, self.out_width);
+        }
+
+        self.push_field(field, rows, width, lace, long_field, double_rows);
+        let active = self.out_rows * self.out_width;
+        destination.resize(active, 0);
+        destination.copy_from_slice(&self.output()[..active]);
+        (self.out_rows, self.out_width)
+    }
 }
 
 /// Channel-wise average of two packed RGBA pixels.
@@ -411,6 +466,31 @@ mod tests {
             assert_eq!(out_row(&d, 2 * y), y as u32 + 1);
             assert_eq!(out_row(&d, 2 * y + 1), y as u32 + 1);
         }
+    }
+
+    #[test]
+    fn direct_progressive_presentation_matches_deinterlacer_output() {
+        let field: Vec<u32> = (0..FB_PIXELS).map(|idx| 0xFF00_0000 | idx as u32).collect();
+        let mut reference = Deinterlacer::with_options(true, 0.0);
+        reference.push_field(&field, FB_HEIGHT, FB_WIDTH, false, true, true);
+
+        let mut direct = Deinterlacer::with_options(true, 0.0);
+        let mut destination = Vec::new();
+        let dims = direct.present_field_into(
+            &field,
+            FB_HEIGHT,
+            FB_WIDTH,
+            false,
+            true,
+            true,
+            &mut destination,
+        );
+
+        assert_eq!(dims, (reference.output_rows(), reference.output_width()));
+        assert_eq!(
+            destination,
+            reference.output()[..reference.output_rows() * reference.output_width()]
+        );
     }
 
     #[test]

--- a/src/video/deinterlace.rs
+++ b/src/video/deinterlace.rs
@@ -385,8 +385,8 @@ impl Deinterlacer {
         double_rows: bool,
         destination: &mut Vec<u32>,
     ) -> (usize, usize) {
-        debug_assert!(field.len() >= rows * width);
         let rows = rows.clamp(1, MAX_VISIBLE_LINES);
+        debug_assert!(field.len() >= rows * width);
         let direct = self.phosphor_alpha == 0 && (!lace || !self.enabled);
         if direct {
             if rows != self.field_rows || width != self.field_width {
@@ -491,6 +491,27 @@ mod tests {
             destination,
             reference.output()[..reference.output_rows() * reference.output_width()]
         );
+    }
+
+    #[test]
+    fn direct_presentation_clamps_rows_before_validating_input() {
+        let width = 4;
+        let field = vec![0xFF12_3456; MAX_VISIBLE_LINES * width];
+        let mut direct = Deinterlacer::with_options(true, 0.0);
+        let mut destination = Vec::new();
+
+        let dims = direct.present_field_into(
+            &field,
+            MAX_VISIBLE_LINES + 1,
+            width,
+            false,
+            true,
+            false,
+            &mut destination,
+        );
+
+        assert_eq!(dims, (MAX_VISIBLE_LINES, width));
+        assert_eq!(destination, field);
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6706,15 +6706,17 @@ impl App {
             self.overscan,
         );
         let base = self.emu.bus().frame_render_base();
-        self.deinterlacer.push_field(
+        let (rows, width) = self.deinterlacer.present_field_into(
             &self.fb,
             field_rows,
             FB_WIDTH * canvas_scale,
             base.bplcon0 & 0x0004 != 0,
             base.long_field,
             !geometry.programmable,
+            &mut self.present_fb,
         );
-        self.refresh_present_from_deinterlacer();
+        self.present_rows = rows;
+        self.present_width = width;
         self.request_redraw();
     }
 
@@ -9145,7 +9147,9 @@ impl App {
     fn apply_threaded_render_result(&mut self, result: RenderWorkerResult) -> bool {
         // Only one job is in flight at a time, so the returned snapshot is
         // always the freshest one to recycle.
-        self.render_recycle_input = Some(result.input);
+        let mut input = result.input;
+        input.release_shared_frame_data();
+        self.render_recycle_input = Some(input);
         if result.generation != self.render_generation {
             if self.render_recycle_fb.is_empty() {
                 self.render_recycle_fb = result.presentation_fb;
@@ -9347,15 +9351,17 @@ impl App {
         let base = self.emu.bus().frame_render_base();
         // Standard 15 kHz fields line-double / weave to 2x rows; a
         // programmable progressive scan already carries every line.
-        self.deinterlacer.push_field(
+        let (rows, width) = self.deinterlacer.present_field_into(
             &self.fb,
             field_rows,
             FB_WIDTH * canvas_scale,
             base.bplcon0 & 0x0004 != 0,
             base.long_field,
             !geometry.programmable,
+            &mut self.present_fb,
         );
-        self.refresh_present_from_deinterlacer();
+        self.present_rows = rows;
+        self.present_width = width;
         self.present_tv_aperture_rows =
             self.presentation_latch
                 .resolve_tv_aperture(standard_tv_aperture_frame(

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -46,19 +46,15 @@ pub(super) fn render_job_to_presentation(
         overscan,
     );
     let base = input.render_base();
-    deinterlacer.push_field(
+    let (present_rows, present_width) = deinterlacer.present_field_into(
         fb,
         field_rows,
         canvas_width,
         base.bplcon0 & 0x0004 != 0,
         base.long_field,
         !geometry.programmable,
+        &mut presentation_fb,
     );
-    let present_rows = deinterlacer.output_rows();
-    let present_width = deinterlacer.output_width();
-    let active = present_rows * present_width;
-    presentation_fb.resize(active, 0);
-    presentation_fb.copy_from_slice(&deinterlacer.output()[..active]);
     RenderWorkerResult {
         generation,
         emulated_frame: input.emulated_frames(),


### PR DESCRIPTION
## Summary

This is the second accuracy-preserving performance pass after #334. It removes repeated work from stable chipset and presentation paths without changing the event-driven timing model:

- reuse the complete DDF fetch plan and end state across identical static scanlines, with an allocation-free ordinary sequencer walk
- move completed chip RAM and captured bitplane rows into immutable shared frame snapshots instead of copying/deep-cloning them into each render job
- write progressive, non-phosphor presentation directly into the frontend buffer
- retain a packed CLXCON/CLXCON2 collision truth table across scanlines
- collapse inactive chip-bus diagnostics behind one gate and outline the enabled observer path
- enable full release LTO with one codegen unit

The DDF reuse key contains the complete carried sequencer state, masked DDF registers, line geometry, hard-stop mode, and chip revisions. Mid-line DDF/control writes continue through the dynamic rebuild path. Interlace and phosphor presentation retain the history-buffer path.

## Performance

### Framework Core Ultra 1, A1200 + 8 MiB fast RAM

`AmigaSYS3PlusAGA.hdf`, 60.007 emulated seconds, full render/presentation pipeline. Three alternating baseline/branch pairs were run from fresh disposable HDF copies; figures are medians.

| | #334 baseline | This branch | Change |
|---|---:|---:|---:|
| Wall time | 41.541 s | 35.510 s | -14.5% |
| Realtime | x1.44 | x1.69 | +17.4% |
| Frame p50 | 9.94 ms | 8.55 ms | -14.0% |
| Frame p95 | 15.63 ms | 13.50 ms | -13.6% |
| Frames over 20 ms | 7 | 0 | -100% |

All runs produced render checksum `0xdf2000000`.

### Apple M5, bundled AROS

Thirty emulated seconds; the branch values are medians of three runs.

| Path | Pre-change wall | This branch wall | Change |
|---|---:|---:|---:|
| Core only | 3.381 s | 2.884 s | -14.7% |
| Render + presentation | 6.488 s | 5.419 s | -16.5% |

All rendered runs produced checksum `0x2c934000000`.

Full LTO increases a clean release build's link time, but was approximately 10% faster core-only and 7% faster rendered than thin LTO in the isolated profile comparison, while reducing the benchmark executable from 13 MiB to 9.7 MiB on macOS.

## Validation

- `cargo test --locked` — all non-ignored tests passed, including 2,035 library tests and all 24 timing/golden probes
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- identical AROS and A1200/HDF render checksums before and after
