### PR TITLE
Cache stable display and wide fetch work

### DIFF
--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -69,7 +69,15 @@ word positions and earlier words stay zero.
 Wide-FMODE (quantum > 1) fetches keep the memoized value-window plan: the
 effective DDF window, fetch cadence, and per-plane fetch-order mask live in
 a `BitplaneSlotPlan` keyed on the register inputs (`BitplaneSlotKey`,
-`src/bus.rs`).
+`src/bus.rs`). On a line without a fetch-affecting write, that plan is
+published as a complete per-line slot mask and is also shared with the DMA
+capture path for its stable cadence and row width. The colour-clock arbiter
+therefore performs a bit test, while capture does not re-derive the same DDF
+geometry on every quantum. A mid-line DDF, BPLCON0, DMACON, DIW or FMODE write
+invalidates the publication and selects the existing block-delay-aware
+calculation for the rest of that line. If a delayed BPLCON0 or DMACON change
+crosses the line boundary, the following line also remains dynamic until the
+delayed value has taken effect.
 Wide-FMODE lo-res slots are packed into the first eight CCKs of each
 16/32-CCK fetch unit; the rest of the unit remains available to later
 arbitration priorities.

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -77,7 +77,9 @@ geometry on every quantum. A mid-line DDF, BPLCON0, DMACON, DIW or FMODE write
 invalidates the publication and selects the existing block-delay-aware
 calculation for the rest of that line. If a delayed BPLCON0 or DMACON change
 crosses the line boundary, the following line also remains dynamic until the
-delayed value has taken effect.
+delayed value has taken effect. A restored save state likewise keeps the
+remainder of its partial line dynamic, then republishes from the next
+unchanged line.
 Wide-FMODE lo-res slots are packed into the first eight CCKs of each
 16/32-CCK fetch unit; the rest of the unit remains available to later
 arbitration priorities.

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -119,6 +119,19 @@ BPLCON0 mode decode, display-window edges, fetch-origin quantization,
 per-plane scroll delays) is constant and is computed once per run rather
 than per pixel. The per-pixel decisions inside a run are unchanged -- the
 chunking is a host-CPU optimisation, not a model change.
+History-independent colour modes also resolve their complete 256-entry
+Denise/Lisa index table once for each distinct control-and-palette state in
+the frame. HAM remains on the sequential path because every output depends
+on the preceding colour. Prepared planar rows similarly share a single byte
+lookup when the odd and even BPLCON1 taps have the same delay; the exhaustive
+prepared-pixel/word-sampler comparison covers both that common path and
+separate dual-playfield taps.
+
+The horizontal display-window flip-flop is still the same 9-bit Denise
+counter model. Lines without a mid-line DIW write solve its exact comparator
+transition ticks directly; a changed line replays all 454 ticks. A randomized
+equivalence test compares both paths across counter starts, wrap behaviour,
+window bounds and carried flip-flop state.
 
 BPLCON0 is itself split across two of those timelines. The plane count and
 the resolution bits gate the fetch/serialiser side and stay in the generic
@@ -312,7 +325,10 @@ line, and Agnus programmable blanking latches become the source for
 bundles use shared ownership between the bus and `RenderInput`; queueing a
 worker job therefore does not copy the full RAM image or deep-clone every
 plane row. A completed job releases those references before the next frame
-wrap so the RAM allocation normally returns to the capture side.
+wrap so the RAM allocation normally returns to the capture side. Released
+bitplane rows are kept in a bounded capture-side pool, preserving the eight
+plane-vector allocations across frames while clearing their contents before
+reuse.
 `render_from_input` consumes only this frozen bundle, so the main thread can
 start emulating frame N+1 while the worker renders frame N.
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -599,6 +599,7 @@ struct WideBitplaneHotLine {
     valid: std::cell::Cell<bool>,
     vpos: std::cell::Cell<u32>,
     slot_mask: [std::cell::Cell<u64>; 4],
+    plan: std::cell::Cell<Option<BitplaneSlotPlan>>,
 }
 
 impl WideBitplaneHotLine {
@@ -607,6 +608,7 @@ impl WideBitplaneHotLine {
             valid: std::cell::Cell::new(false),
             vpos: std::cell::Cell::new(0),
             slot_mask: std::array::from_fn(|_| std::cell::Cell::new(0)),
+            plan: std::cell::Cell::new(None),
         }
     }
 
@@ -614,11 +616,13 @@ impl WideBitplaneHotLine {
         self.valid.get() && self.vpos.get() == vpos
     }
 
-    fn publish(&self, vpos: u32, slot_mask: [u64; 4]) {
+    fn publish(&self, vpos: u32, plan: Option<BitplaneSlotPlan>) {
         self.valid.set(false);
+        let slot_mask = plan.map_or([0; 4], |plan| plan.slot_mask);
         for (destination, source) in self.slot_mask.iter().zip(slot_mask) {
             destination.set(source);
         }
+        self.plan.set(plan);
         self.vpos.set(vpos);
         self.valid.set(true);
     }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3992,6 +3992,15 @@ impl Bus {
         self.last_frame_presentation_v_window = self.current_frame_presentation_v_window;
         self.lazy_collision_vpos = self.current_frame_visible_start_vpos;
         self.ocs_same_line_diw_start_blocked_vpos = None;
+        // Per-line wide-FMODE cache eligibility is deliberately not part of
+        // the save-state schema. A restored line may contain a DDF, FMODE or
+        // delayed BPLCON0/DMACON transition, so rebuilding one whole-line mask
+        // from the register value at the restore point could skip the dynamic
+        // path's previous-value/block-boundary handling. Keep the remainder of
+        // this line dynamic; rollover makes an unchanged following line
+        // eligible for publication again.
+        self.wide_bitplane_hot_line.invalidate();
+        self.wide_bitplane_dynamic_vpos.set(Some(self.agnus.vpos));
         self.reset_frame_capture_buffers();
         self.current_frame_render_blocked = self.agnus.vpos != 0 || self.agnus.hpos != 0;
     }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -592,6 +592,48 @@ impl Default for BitplaneSlotPlanCache {
     }
 }
 
+/// Read-mostly wide-FMODE bitplane ownership for one scanline. Lines without
+/// a fetch-affecting register write reuse the plan's complete slot mask
+/// directly; dynamic lines fall back to the block-delay-aware calculation.
+struct WideBitplaneHotLine {
+    valid: std::cell::Cell<bool>,
+    vpos: std::cell::Cell<u32>,
+    slot_mask: [std::cell::Cell<u64>; 4],
+}
+
+impl WideBitplaneHotLine {
+    fn new() -> Self {
+        Self {
+            valid: std::cell::Cell::new(false),
+            vpos: std::cell::Cell::new(0),
+            slot_mask: std::array::from_fn(|_| std::cell::Cell::new(0)),
+        }
+    }
+
+    fn is_current(&self, vpos: u32) -> bool {
+        self.valid.get() && self.vpos.get() == vpos
+    }
+
+    fn publish(&self, vpos: u32, slot_mask: [u64; 4]) {
+        self.valid.set(false);
+        for (destination, source) in self.slot_mask.iter().zip(slot_mask) {
+            destination.set(source);
+        }
+        self.vpos.set(vpos);
+        self.valid.set(true);
+    }
+
+    fn invalidate(&self) {
+        self.valid.set(false);
+    }
+}
+
+impl Default for WideBitplaneHotLine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
 struct DisplaySpriteLineData {
     hstart: i32,
@@ -828,6 +870,11 @@ pub struct Bus {
     last_frame_chip_ram_writes: Vec<BeamChipRamWrite>,
     current_frame_bitplane_rows: Vec<Option<CapturedBitplaneRow>>,
     last_frame_bitplane_rows: std::sync::Arc<Vec<Option<CapturedBitplaneRow>>>,
+    /// Released completed-frame rows retained for their eight plane
+    /// allocations. Transient: captured contents are never reused, only the
+    /// backing capacities.
+    #[serde(skip)]
+    bitplane_row_pool: Vec<CapturedBitplaneRow>,
     current_frame_sprite_lines: Vec<CapturedSpriteLine>,
     current_frame_sprite_lines_by_y: Vec<Vec<CapturedSpriteLine>>,
     current_frame_sprite_collision_sources: Vec<Option<Vec<LiveSpriteCollisionSource>>>,
@@ -1104,6 +1151,13 @@ pub struct Bus {
     /// on each hit while keeping the `&self` owner-selection call graph intact.
     #[serde(skip)]
     bitplane_slot_plan_cache: BitplaneSlotPlanCache,
+    /// Complete slot mask for an unchanged wide-FMODE scanline.
+    #[serde(skip)]
+    wide_bitplane_hot_line: WideBitplaneHotLine,
+    /// Current line once a fetch-affecting register write makes the static
+    /// wide-FMODE mask ineligible.
+    #[serde(skip)]
+    wide_bitplane_dynamic_vpos: std::cell::Cell<Option<u32>>,
     /// Bitplane DDF sequencer flop state at the start of the current line
     /// (see src/bus/ddf_line.rs); carried across lines by the flop walk.
     ddf_seq_line_initial: std::cell::Cell<crate::chipset::ddf_sequencer::DdfState>,
@@ -2480,6 +2534,7 @@ impl Bus {
             last_frame_chip_ram_writes: Vec::new(),
             current_frame_bitplane_rows: empty_captured_bitplane_rows(),
             last_frame_bitplane_rows: std::sync::Arc::new(empty_captured_bitplane_rows()),
+            bitplane_row_pool: Vec::with_capacity(MAX_VISIBLE_LINES),
             current_frame_sprite_lines: Vec::new(),
             current_frame_sprite_lines_by_y: empty_captured_sprite_lines_by_y(),
             current_frame_sprite_collision_sources: empty_sprite_collision_sources(),
@@ -2572,6 +2627,8 @@ impl Bus {
             bitplane_bplcon0_delay: None,
             bitplane_ddfstart_miss: None,
             bitplane_slot_plan_cache: BitplaneSlotPlanCache::new(),
+            wide_bitplane_hot_line: WideBitplaneHotLine::new(),
+            wide_bitplane_dynamic_vpos: std::cell::Cell::new(None),
             ddf_seq_line_initial: std::cell::Cell::new(Default::default()),
             ddf_seq_line_start_regs: std::cell::Cell::new((0, 0)),
             ddf_seq_line_start_ctl: std::cell::Cell::new((false, 0)),
@@ -3566,6 +3623,7 @@ impl Bus {
         self.last_frame_chip_ram_writes.clear();
         self.current_frame_bitplane_rows = empty_captured_bitplane_rows();
         self.last_frame_bitplane_rows = std::sync::Arc::new(empty_captured_bitplane_rows());
+        self.bitplane_row_pool.clear();
         self.current_frame_sprite_lines.clear();
         clear_captured_sprite_lines_by_y(&mut self.current_frame_sprite_lines_by_y);
         self.current_frame_sprite_collision_sources = empty_sprite_collision_sources();
@@ -3694,6 +3752,8 @@ impl Bus {
         self.bitplane_dmacon_delay = None;
         self.bitplane_bplcon0_delay = None;
         self.bitplane_ddfstart_miss = None;
+        self.wide_bitplane_hot_line.invalidate();
+        self.wide_bitplane_dynamic_vpos.set(None);
         self.mem.overlay = true;
         // A 68000 RESET returns the A1000 WCS latch to boot mode (boot ROM at
         // $F80000, WCS writable) without clearing the WCS, so the boot ROM can

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -1083,6 +1083,7 @@ impl Bus {
             // AGA Alice FMODE (write_fmode gates on the revision itself).
             0x1FC => {
                 self.agnus.write_fmode(val);
+                self.ddf_seq_invalidate_line();
                 if crate::envcfg::flag("COPPERLINE_DIAG_DISPLAY") {
                     log::info!(
                         "disp f={} v={} h={} FMODE={:#06X}",

--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -696,7 +696,18 @@ impl Bus {
             self.denise.bplcon0,
         ));
         self.ddf_seq_writes.borrow_mut().clear();
-        self.wide_bitplane_dynamic_vpos.set(None);
+        // A fetch-control write in the last colour clocks can keep Agnus's
+        // delayed BPLCON0/DMACON view live across the line boundary. Do not
+        // publish one whole-line wide-FMODE plan from that transient value;
+        // the dynamic path follows the delayed transition exactly.
+        let delayed_control_crosses_line = self
+            .bitplane_bplcon0_delay
+            .is_some_and(|delay| self.emulated_cck.saturating_sub(delay.changed_at_cck) < 3)
+            || self
+                .bitplane_dmacon_delay
+                .is_some_and(|delay| self.emulated_cck.saturating_sub(delay.changed_at_cck) < 2);
+        self.wide_bitplane_dynamic_vpos
+            .set(delayed_control_crosses_line.then_some(self.agnus.vpos));
         self.wide_bitplane_hot_line.invalidate();
         // Keep the completed line as the candidate for static-plan reuse.
         // Only its vpos publication becomes stale at the rollover.

--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -482,6 +482,8 @@ impl Bus {
     pub(super) fn ddf_seq_invalidate_line(&self) {
         self.ddf_seq_hot_line.invalidate();
         *self.ddf_seq_line.borrow_mut() = None;
+        self.wide_bitplane_hot_line.invalidate();
+        self.wide_bitplane_dynamic_vpos.set(Some(self.agnus.vpos));
     }
 
     /// Record a register write reaching the sequencer this line.
@@ -694,6 +696,8 @@ impl Bus {
             self.denise.bplcon0,
         ));
         self.ddf_seq_writes.borrow_mut().clear();
+        self.wide_bitplane_dynamic_vpos.set(None);
+        self.wide_bitplane_hot_line.invalidate();
         // Keep the completed line as the candidate for static-plan reuse.
         // Only its vpos publication becomes stale at the rollover.
         self.ddf_seq_hot_line.invalidate();

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -855,21 +855,19 @@ impl Bus {
         }
         if hpos < SLOT_MASK_BITS && self.wide_bitplane_dynamic_vpos.get() != Some(vpos) {
             if !self.wide_bitplane_hot_line.is_current(vpos) {
-                let mut slot_mask = [0; 4];
-                if display_window_contains_vpos(
+                let plan = if display_window_contains_vpos(
                     self.denise.diwstrt,
                     self.denise.diwstop,
                     self.effective_diwhigh(),
                     vpos,
                 ) {
                     let bplcon0 = self.effective_bitplane_bplcon0();
-                    if let Some(plan) = self.bitplane_slot_plan_for_bplcon0(bplcon0) {
-                        if !self.bitplane_ddfstart_missed_on_line(vpos, plan.start) {
-                            slot_mask = plan.slot_mask;
-                        }
-                    }
-                }
-                self.wide_bitplane_hot_line.publish(vpos, slot_mask);
+                    self.bitplane_slot_plan_for_bplcon0(bplcon0)
+                        .filter(|plan| !self.bitplane_ddfstart_missed_on_line(vpos, plan.start))
+                } else {
+                    None
+                };
+                self.wide_bitplane_hot_line.publish(vpos, plan);
             }
             return self.wide_bitplane_hot_line.slot_mask[(hpos / 64) as usize].get()
                 & (1u64 << (hpos % 64))

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -853,6 +853,35 @@ impl Bus {
             let _ = vpos;
             return self.ddf_seq_slot_active_at(hpos);
         }
+        if hpos < SLOT_MASK_BITS && self.wide_bitplane_dynamic_vpos.get() != Some(vpos) {
+            if !self.wide_bitplane_hot_line.is_current(vpos) {
+                let mut slot_mask = [0; 4];
+                if display_window_contains_vpos(
+                    self.denise.diwstrt,
+                    self.denise.diwstop,
+                    self.effective_diwhigh(),
+                    vpos,
+                ) {
+                    let bplcon0 = self.effective_bitplane_bplcon0();
+                    if let Some(plan) = self.bitplane_slot_plan_for_bplcon0(bplcon0) {
+                        if !self.bitplane_ddfstart_missed_on_line(vpos, plan.start) {
+                            slot_mask = plan.slot_mask;
+                        }
+                    }
+                }
+                self.wide_bitplane_hot_line.publish(vpos, slot_mask);
+            }
+            return self.wide_bitplane_hot_line.slot_mask[(hpos / 64) as usize].get()
+                & (1u64 << (hpos % 64))
+                != 0;
+        }
+        self.dynamic_bitplane_slot_active_at(vpos, hpos)
+    }
+
+    /// Block-delay-aware fallback for a wide-FMODE line changed by a
+    /// fetch-affecting register write, and for programmable lines beyond the
+    /// precomputed 256-colour-clock mask.
+    pub(super) fn dynamic_bitplane_slot_active_at(&self, vpos: u32, hpos: u32) -> bool {
         // Bitplane DMA only runs inside the vertical display window (set at
         // DIWSTRT.V, cleared at DIWSTOP.V), so the top-border and vertical-
         // blank lines are free for the blitter/CPU. Rejecting this before the

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -81,11 +81,17 @@ impl Bus {
             &mut self.current_frame_bitplane_rows,
             empty_captured_bitplane_rows(),
         );
-        self.last_frame_bitplane_rows = if promote_render_frame {
+        let next_bitplane_rows = if promote_render_frame {
             std::sync::Arc::new(current_bitplane_rows)
         } else {
+            self.recycle_captured_bitplane_rows(current_bitplane_rows);
             std::sync::Arc::new(empty_captured_bitplane_rows())
         };
+        let old_bitplane_rows =
+            std::mem::replace(&mut self.last_frame_bitplane_rows, next_bitplane_rows);
+        if let Ok(rows) = std::sync::Arc::try_unwrap(old_bitplane_rows) {
+            self.recycle_captured_bitplane_rows(rows);
+        }
         self.last_frame_sprite_lines = if promote_render_frame {
             std::mem::take(&mut self.current_frame_sprite_lines)
         } else {
@@ -1284,16 +1290,26 @@ impl Bus {
         };
         if row_needs_init {
             let old_row = self.current_frame_bitplane_rows[fb_y].take();
-            let mut row = CapturedBitplaneRow {
-                nplanes: display_planes,
-                words_per_row,
-                planes: std::array::from_fn(|_| vec![0; words_per_row]),
-                fetch_origin_cck: None,
-            };
+            let mut row = self
+                .bitplane_row_pool
+                .pop()
+                .unwrap_or_else(|| CapturedBitplaneRow {
+                    nplanes: 0,
+                    words_per_row: 0,
+                    planes: std::array::from_fn(|_| Vec::new()),
+                    fetch_origin_cck: None,
+                });
+            row.nplanes = display_planes;
+            row.words_per_row = words_per_row;
+            row.fetch_origin_cck = None;
+            for plane in &mut row.planes {
+                plane.resize(words_per_row, 0);
+                plane.fill(0);
+            }
             for plane in dma_planes..display_planes {
                 row.planes[plane].fill(self.denise.bpldat[plane]);
             }
-            if let Some(old_row) = old_row {
+            if let Some(old_row) = old_row.as_ref() {
                 let copy_planes = old_row.nplanes.min(display_planes).min(8);
                 let copy_words = old_row.words_per_row.min(words_per_row);
                 for plane in 0..copy_planes {
@@ -1302,11 +1318,25 @@ impl Bus {
                 }
             }
             self.current_frame_bitplane_rows[fb_y] = Some(row);
+            if let Some(old_row) =
+                old_row.filter(|_| self.bitplane_row_pool.len() < MAX_VISIBLE_LINES)
+            {
+                self.bitplane_row_pool.push(old_row);
+            }
         }
         if let Some(row) = self.current_frame_bitplane_rows[fb_y].as_mut() {
             row.planes[plane][word_idx] = fetched;
         }
         row_needs_init
+    }
+
+    fn recycle_captured_bitplane_rows(&mut self, rows: Vec<Option<CapturedBitplaneRow>>) {
+        for row in rows.into_iter().flatten() {
+            if self.bitplane_row_pool.len() == MAX_VISIBLE_LINES {
+                break;
+            }
+            self.bitplane_row_pool.push(row);
+        }
     }
 
     pub(super) fn advance_display_dma_ptrs(

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -1039,7 +1039,14 @@ impl Bus {
         // plane; the per-plane cadence stretches to `period` colour clocks
         // and the lores slot sequence spreads across the `unit`-cck block.
         let fmode = self.agnus.fmode();
-        let quantum = bitplane_fetch_quantum(fmode) as usize;
+        let static_plan = (self.wide_bitplane_dynamic_vpos.get() != Some(vpos)
+            && self.wide_bitplane_hot_line.is_current(vpos))
+        .then(|| self.wide_bitplane_hot_line.plan.get())
+        .flatten();
+        let quantum = static_plan.map_or_else(
+            || bitplane_fetch_quantum(fmode) as usize,
+            |plan| plan.quantum as usize,
+        );
         // Wide-FMODE units lengthen the gap between groups of fetched words,
         // but the sequencer is still armed by the DDFSTRT comparator itself.
         // Lores plane-order slots are packed into the first eight cycles of
@@ -1065,26 +1072,40 @@ impl Bus {
             .unwrap_or(display_bplcon0);
         let anchor_mode = BitplaneMode::from_bplcon0(anchor_bplcon0, self.aga_enabled());
         let anchor_dma_planes = anchor_mode.dma_planes();
-        let period = bitplane_fetch_period(anchor_bplcon0, fmode);
-        let unit = bitplane_fetch_unit(anchor_bplcon0, fmode);
+        let period = static_plan.map_or_else(
+            || bitplane_fetch_period(anchor_bplcon0, fmode),
+            |plan| plan.period,
+        );
+        let unit = static_plan.map_or_else(
+            || bitplane_fetch_unit(anchor_bplcon0, fmode),
+            |plan| plan.unit,
+        );
         let started = VideoPipelineStats::probe_timing_sample(
             &mut self.video_pipeline_stats.bitplane_fetch_probes,
             VIDEO_FETCH_TIMING_SAMPLE_RATE,
         );
-        let words_per_row = bitplane_words_per_row(
-            self.agnus.revision(),
-            anchor_bplcon0,
-            self.agnus.fmode(),
-            self.denise.ddfstrt,
-            self.denise.ddfstop,
-            self.harddis_active(),
+        let words_per_row = static_plan.map_or_else(
+            || {
+                bitplane_words_per_row(
+                    self.agnus.revision(),
+                    anchor_bplcon0,
+                    self.agnus.fmode(),
+                    self.denise.ddfstrt,
+                    self.denise.ddfstop,
+                    self.harddis_active(),
+                )
+            },
+            |plan| plan.words_per_row as usize,
         );
         let mut rows_started = 0usize;
         let mut slots = 0usize;
         let mut line_complete = false;
         let mut line_complete_plane_mask = 0u16;
         let addr_mask = self.chip_dma_mask;
-        let hires_like = bitplane_hires(anchor_bplcon0) || bitplane_shres(anchor_bplcon0);
+        let hires_like = static_plan.map_or_else(
+            || bitplane_hires(anchor_bplcon0) || bitplane_shres(anchor_bplcon0),
+            |plan| plan.hires_like,
+        );
         let last_word_idx = words_per_row.saturating_sub(1);
         if diag_caprow().is_some_and(|spec| spec.contains(vpos))
             && old_hpos <= ddfstart

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -209,6 +209,27 @@ fn wide_bitplane_hot_line_matches_dynamic_slot_arbitration() {
     }
 }
 
+#[test]
+fn wide_bitplane_line_stays_dynamic_when_control_delay_crosses_wrap() {
+    let mut bus = empty_bus();
+    bus.set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
+    bus.agnus.write_fmode(0x0003);
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x2C;
+    bus.agnus.hpos = bus.agnus.current_line_cck() - 1;
+    bus.denise.bplcon0 = 0x1000;
+
+    assert!(!bus.write_custom_word_from(0x100, 0x5000, BeamWriteSource::Cpu));
+    bus.advance_chipset(1);
+
+    assert_eq!(bus.agnus.vpos, 0x2D);
+    assert_eq!(
+        bus.wide_bitplane_dynamic_vpos.get(),
+        Some(0x2D),
+        "the next line must follow the delayed BPLCON0 transition dynamically"
+    );
+}
+
 fn render_color_write_x(hpos: u32) -> usize {
     hpos.saturating_sub(RENDER_COLOR_WRITE_HPOS_FB0)
         .saturating_mul(4)

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -10,16 +10,16 @@ use super::{
     framebuffer_x_for_live_collision_hpos, live_bitplane_collision_bits, live_display_window_x,
     live_manual_sprite_collision_sources, live_sprite_playfield_collision_bits_in_range,
     live_sprite_sprite_collision_bits, sprite_hstart_for_fmode, visible_start_vpos_for_diw,
-    BeamChipRamWrite, BeamRegisterWrite, BeamWriteSource, Bus, CapturedBitplaneRow,
-    CapturedSpriteLine, ChipBusOwner, CpuBusAccessKind, DeviceClock, DisplaySpriteDmaState,
-    DisplaySpriteLineData, FrameBusTrace, LiveCollisionControl, LiveCollisionLineReplay,
-    LiveSpriteCollisionSource, PortDevice, RenderRegisterSnapshot, BLITTER_SLOWDOWN_CPU_MISS_LIMIT,
-    BLTCON0_USE_A, BLTCON0_USE_C, BLTCON0_USE_D, BLTCON1_DOFF, BLTCON1_LINE, BPLCON0_ECSENA,
-    BPLCON3_BRDRBLNK, BPLCON3_BRDSPRT, BPLCON3_SPRES_HIRES, DENISE_HPOS_LAG_CCK, DMACON_BLTEN,
-    DMACON_BLTPRI, DMACON_BPLEN, DMACON_SPREN, PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS,
-    RENDER_COPPER_WAIT_HPOS_FB0, RENDER_DIW_HSTART_FB0, RENDER_MIN_OVERSCAN_START_VPOS,
-    RENDER_VISIBLE_LINES, RENDER_VISIBLE_START_VPOS, SPRITE_DMA_SLOT1_HPOS,
-    SPRITE_OUTPUT_DELAY_LORES,
+    BeamChipRamWrite, BeamRegisterWrite, BeamWriteSource, BitplaneBplcon0Delay, Bus,
+    CapturedBitplaneRow, CapturedSpriteLine, ChipBusOwner, CpuBusAccessKind, DeviceClock,
+    DisplaySpriteDmaState, DisplaySpriteLineData, FrameBusTrace, LiveCollisionControl,
+    LiveCollisionLineReplay, LiveSpriteCollisionSource, PortDevice, RenderRegisterSnapshot,
+    BLITTER_SLOWDOWN_CPU_MISS_LIMIT, BLTCON0_USE_A, BLTCON0_USE_C, BLTCON0_USE_D, BLTCON1_DOFF,
+    BLTCON1_LINE, BPLCON0_ECSENA, BPLCON3_BRDRBLNK, BPLCON3_BRDSPRT, BPLCON3_SPRES_HIRES,
+    DENISE_HPOS_LAG_CCK, DMACON_BLTEN, DMACON_BLTPRI, DMACON_BPLEN, DMACON_SPREN,
+    PAL_SPRITE_DMA_FIRST_ACTIVE_VPOS, RENDER_COPPER_WAIT_HPOS_FB0, RENDER_DIW_HSTART_FB0,
+    RENDER_MIN_OVERSCAN_START_VPOS, RENDER_VISIBLE_LINES, RENDER_VISIBLE_START_VPOS,
+    SPRITE_DMA_SLOT1_HPOS, SPRITE_OUTPUT_DELAY_LORES,
 };
 use crate::audio::AudioSink;
 use crate::chipset::agnus::{
@@ -228,6 +228,51 @@ fn wide_bitplane_line_stays_dynamic_when_control_delay_crosses_wrap() {
         Some(0x2D),
         "the next line must follow the delayed BPLCON0 transition dynamically"
     );
+}
+
+#[test]
+fn restored_wide_bitplane_line_reenters_dynamic_arbitration() {
+    let mut bus = empty_bus();
+    bus.set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
+    bus.agnus.write_fmode(0x0003);
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x2C;
+    bus.agnus.hpos = 0x35;
+    bus.emulated_cck = u64::from(bus.agnus.hpos);
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x2DC1;
+    bus.denise.ddfstrt = 0x0030;
+    bus.denise.ddfstop = 0x00D0;
+    bus.denise.bplcon0 = 0;
+    bus.bitplane_bplcon0_delay = Some(BitplaneBplcon0Delay {
+        previous: 0x5000,
+        changed_at_cck: bus.emulated_cck - 3,
+    });
+
+    // Serde-skipped cache state defaults to an apparently static line. At
+    // this point the coarse delay has expired, but the current fetch block
+    // still owns the previous BPLCON0 shape.
+    assert!(bus.bitplane_slot_plan_for_bplcon0(0).is_none());
+    assert!(
+        (bus.agnus.hpos..bus.agnus.current_line_cck())
+            .any(|hpos| bus.dynamic_bitplane_slot_active_at(bus.agnus.vpos, hpos)),
+        "the delayed previous-value fallback should own a remaining slot"
+    );
+
+    bus.reset_transient_video_after_state_load();
+
+    assert_eq!(
+        bus.wide_bitplane_dynamic_vpos.get(),
+        Some(bus.agnus.vpos),
+        "the restored partial line must not publish one static fetch shape"
+    );
+    assert!(!bus.wide_bitplane_hot_line.is_current(bus.agnus.vpos));
+    for hpos in bus.agnus.hpos..bus.agnus.current_line_cck() {
+        assert_eq!(
+            bus.bitplane_slot_active_at(bus.agnus.vpos, hpos),
+            bus.dynamic_bitplane_slot_active_at(bus.agnus.vpos, hpos)
+        );
+    }
 }
 
 fn render_color_write_x(hpos: u32) -> usize {

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -173,6 +173,42 @@ fn bitplane_slot_plan_cache_keeps_recent_fetch_shapes() {
     }
 }
 
+#[test]
+fn wide_bitplane_hot_line_matches_dynamic_slot_arbitration() {
+    let mut bus = empty_bus();
+    bus.set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
+    bus.agnus.write_fmode(0x0003);
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x2C;
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x2DC1;
+    bus.denise.ddfstrt = 0x0030;
+    bus.denise.ddfstop = 0x00D0;
+    bus.denise.bplcon0 = 0x5000;
+
+    for hpos in 0..bus.agnus.current_line_cck() {
+        assert_eq!(
+            bus.bitplane_slot_active_at(bus.agnus.vpos, hpos),
+            bus.dynamic_bitplane_slot_active_at(bus.agnus.vpos, hpos),
+            "wide-FMODE slot mismatch at hpos {hpos:#04x}"
+        );
+    }
+    assert!(bus.wide_bitplane_hot_line.is_current(bus.agnus.vpos));
+
+    bus.ddf_seq_invalidate_line();
+    assert_eq!(
+        bus.wide_bitplane_dynamic_vpos.get(),
+        Some(bus.agnus.vpos),
+        "a mid-line fetch-register change must select the dynamic fallback"
+    );
+    for hpos in 0..bus.agnus.current_line_cck() {
+        assert_eq!(
+            bus.bitplane_slot_active_at(bus.agnus.vpos, hpos),
+            bus.dynamic_bitplane_slot_active_at(bus.agnus.vpos, hpos)
+        );
+    }
+}
+
 fn render_color_write_x(hpos: u32) -> usize {
     hpos.saturating_sub(RENDER_COLOR_WRITE_HPOS_FB0)
         .saturating_mul(4)

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -512,6 +512,113 @@ fn diw_segment_effect_tick(seg_x: usize) -> i32 {
         + H_COUNTER_FB_START_TICK
 }
 
+fn h_counter_match_tick(start: i32, target: i32, free_run: bool) -> Option<i32> {
+    if free_run {
+        let tick = (target - start) & 0x1FF;
+        return (tick < H_COUNTER_TICKS_PER_LINE).then_some(tick);
+    }
+
+    let mut best = None;
+    if (start..H_COUNTER_WRAP).contains(&target) {
+        best = Some(target - start);
+    }
+    if (H_COUNTER_WRAP_TARGET..H_COUNTER_WRAP).contains(&target) {
+        let tick = H_COUNTER_WRAP - start + target - H_COUNTER_WRAP_TARGET;
+        if tick < H_COUNTER_TICKS_PER_LINE && best.is_none_or(|previous| tick < previous) {
+            best = Some(tick);
+        }
+    }
+    best.filter(|&tick| tick < H_COUNTER_TICKS_PER_LINE)
+}
+
+/// Constant-register horizontal-window scan. There are at most two comparator
+/// matches on a line, so solve their ticks directly instead of stepping all
+/// 454 Denise counter positions. Rows with a mid-line DIW write retain the
+/// per-tick replay below.
+fn scan_static_h_window_line(
+    flop: &mut bool,
+    beam_line: i32,
+    is_ecs: bool,
+    hstrt: i32,
+    hstop: i32,
+    mut record: Option<&mut HWindowRow>,
+) {
+    let free_run = beam_line < 9 && !is_ecs;
+    let counter_start = if free_run {
+        (H_COUNTER_LINE_ORIGIN + beam_line * 0x1C6) & 0x1FF
+    } else {
+        H_COUNTER_LINE_ORIGIN - active_canvas_shift_h()
+    };
+    let start_tick = h_counter_match_tick(counter_start, hstrt, free_run);
+    let stop_tick = h_counter_match_tick(counter_start, hstop, free_run);
+    let mut event_ticks = [
+        start_tick.unwrap_or(i32::MAX),
+        stop_tick.unwrap_or(i32::MAX),
+    ];
+    event_ticks.sort_unstable();
+
+    let mut framebuffer_started = false;
+    let mut open_from = None;
+    let mut event_idx = 0;
+    while event_idx < event_ticks.len() {
+        let tick = event_ticks[event_idx];
+        if tick == i32::MAX {
+            break;
+        }
+        while event_idx + 1 < event_ticks.len() && event_ticks[event_idx + 1] == tick {
+            event_idx += 1;
+        }
+        if !framebuffer_started && tick >= H_COUNTER_FB_START_TICK {
+            framebuffer_started = true;
+            if record.is_some() && *flop {
+                open_from = Some(0);
+            }
+        }
+
+        let was_open = *flop;
+        if start_tick == Some(tick) {
+            *flop = true;
+        }
+        if stop_tick == Some(tick) {
+            *flop = false;
+        }
+        if *flop != was_open {
+            if let Some(row) = record.as_deref_mut() {
+                let fb_tick = tick - H_COUNTER_FB_START_TICK;
+                if (0..FB_WIDTH as i32 / 2).contains(&fb_tick) {
+                    let x = (fb_tick * 2) as usize;
+                    if *flop {
+                        open_from = Some(x);
+                        if row.comparator_anchor.is_none() {
+                            row.comparator_anchor = Some(x);
+                        }
+                    } else if let Some(start) = open_from.take() {
+                        if x > start {
+                            row.open_runs.push((start, x));
+                        }
+                    }
+                } else if fb_tick >= FB_WIDTH as i32 / 2 && !*flop {
+                    if let Some(start) = open_from.take() {
+                        row.open_runs.push((start, FB_WIDTH));
+                    }
+                }
+            }
+        }
+        event_idx += 1;
+    }
+
+    if !framebuffer_started && record.is_some() && *flop {
+        open_from = Some(0);
+    }
+    if let Some(row) = record {
+        if let Some(start) = open_from {
+            if FB_WIDTH > start {
+                row.open_runs.push((start, FB_WIDTH));
+            }
+        }
+    }
+}
+
 /// Run the window flip-flop over one beam line, updating `flop` in place.
 /// When `record` is given, [start, end) open spans clipped to the
 /// framebuffer are appended to it.
@@ -523,6 +630,16 @@ fn scan_h_window_line(
     segs: &[ControlSegment],
     mut record: Option<&mut HWindowRow>,
 ) {
+    if segs.is_empty() {
+        return scan_static_h_window_line(
+            flop,
+            beam_line,
+            is_ecs,
+            control.diw_h_start() as i32,
+            control.diw_h_stop() as i32,
+            record,
+        );
+    }
     let free_run = beam_line < 9 && !is_ecs;
     let fb_start_tick = H_COUNTER_FB_START_TICK;
     // On a programmable (VARBEAMEN) scan Denise's counter restarts with
@@ -4224,6 +4341,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         // predecessor was border can suppress BPLCON1 scroll pulling leading
         // same-line pre-fetch samples into view.
         let mut last_playfield_line: Option<usize> = None;
+        let mut indexed_output_cache = IndexedOutputCache::default();
         for y in 0..rows {
             let row_control_segments = &control_segments[y];
             let Some((x_start, x_stop)) = line_display_window_bounds(
@@ -4517,6 +4635,7 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
                 &mut playfield_mask,
                 &mut collision_pixels,
                 &mut collision_lookup,
+                &mut indexed_output_cache,
                 &mut clxdat,
                 palette,
                 segments,
@@ -4790,6 +4909,7 @@ fn render_planned_playfield_line(
     playfield_mask: &mut [u8],
     collision_pixels: &mut [CollisionPixel],
     collision_lookup: &mut CollisionLookup,
+    indexed_output_cache: &mut IndexedOutputCache,
     clxdat: &mut u16,
     mut palette: Palette,
     palette_segments: &[PaletteSegment],
@@ -4926,6 +5046,11 @@ fn render_planned_playfield_line(
         let delays = std::array::from_fn(|plane| sample_control.sample_delay_for_plane(plane));
         let hold_final_fetch_sample = pixel_control.holds_final_lowres_fetch_sample_at_diwstop();
         let ham_mode = output_control.hold_and_modify();
+        let indexed_outputs = if ham_mode {
+            None
+        } else {
+            Some(indexed_output_cache.outputs(output_control, &palette))
+        };
         let ham_history_start_native_x = if ham_mode {
             pixel_control.ham_history_start_native_x(
                 pixel_diw_h_start,
@@ -4999,13 +5124,21 @@ fn render_planned_playfield_line(
             let (sample, output, shres_pair) = if shres {
                 let left = plan.sample_prepared(nplanes, &delays, min_fetch_x, native_x);
                 let right = plan.sample_prepared(nplanes, &delays, min_fetch_x, native_x + 1);
-                let (left_out, right_out) = denise_shres_playfield_output_pair(
-                    output_control,
-                    &palette,
-                    left.idx & plane_mask,
-                    right.idx & plane_mask,
-                    &mut ham_color,
-                );
+                let (left_out, right_out) = if let Some(outputs) = indexed_outputs {
+                    let left_out =
+                        cached_indexed_output(outputs, left.idx & plane_mask, &mut ham_color);
+                    let right_out =
+                        cached_indexed_output(outputs, right.idx & plane_mask, &mut ham_color);
+                    (left_out, right_out)
+                } else {
+                    denise_shres_playfield_output_pair(
+                        output_control,
+                        &palette,
+                        left.idx & plane_mask,
+                        right.idx & plane_mask,
+                        &mut ham_color,
+                    )
+                };
                 (
                     shres_composite_sample(left, right),
                     blend_shres_outputs(left_out, right_out),
@@ -5020,12 +5153,16 @@ fn render_planned_playfield_line(
                     hold_final_fetch_sample,
                 );
                 let ham_before = ham_color;
-                let output = denise_playfield_output(
-                    output_control,
-                    &palette,
-                    sample.idx & plane_mask,
-                    &mut ham_color,
-                );
+                let output = if let Some(outputs) = indexed_outputs {
+                    cached_indexed_output(outputs, sample.idx & plane_mask, &mut ham_color)
+                } else {
+                    denise_playfield_output(
+                        output_control,
+                        &palette,
+                        sample.idx & plane_mask,
+                        &mut ham_color,
+                    )
+                };
                 if let Some(spec) = ham_diag {
                     if x >= spec.x_start
                         && x < spec.x_stop

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1777,6 +1777,23 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
         } else {
             (false, None)
         };
+        let plane_mask = if available_planes == 8 {
+            u8::MAX
+        } else {
+            ((1u16 << available_planes) - 1) as u8
+        };
+        // The usual single-playfield display programs both BPLCON1 scroll
+        // nibbles alike. Every prepared pixel already contains all eight
+        // interleaved plane bits, so the two playfield taps then address the
+        // same byte: do not repeat the range checks and load just to mask its
+        // even and odd bits back together.
+        if available_planes >= 2 && delays[0] == delays[1] {
+            return DeniseBitplaneSample {
+                idx: pf1_fetch_x.map_or(0, |fetch_x| pixels[fetch_x] & plane_mask),
+                nplanes,
+                active: pf1_active,
+            };
+        }
         let (pf2_active, pf2_fetch_x) = if available_planes >= 2 {
             self.sample_fetch_x(delays[1], min_fetch_x, native_x, hold_final_fetch_sample)
         } else {
@@ -1790,11 +1807,6 @@ impl<'a> DenisePlannedPlayfieldLine<'a> {
         if let Some(fetch_x) = pf2_fetch_x {
             idx |= pixels[fetch_x] & 0xAA;
         }
-        let plane_mask = if available_planes == 8 {
-            u8::MAX
-        } else {
-            ((1u16 << available_planes) - 1) as u8
-        };
         DeniseBitplaneSample {
             idx: idx & plane_mask,
             nplanes,

--- a/src/video/bitplane/output.rs
+++ b/src/video/bitplane/output.rs
@@ -7,6 +7,69 @@
 
 use super::*;
 
+const INDEXED_OUTPUT_CACHE_LEN: usize = 8;
+
+struct IndexedOutputCacheEntry {
+    control: ControlState,
+    palette: Palette,
+    outputs: Box<[DenisePlayfieldOutput; 256]>,
+}
+
+/// Small frame-local cache for the indexed (non-HAM) Denise/Lisa colour
+/// resolver. A normal screen reuses one control/palette pair for hundreds of
+/// rows; resolving all possible indices once turns the per-pixel mode,
+/// priority, EHB, BPLAM, and palette branches into one indexed load. Copper
+/// palette/control changes naturally produce another entry, while HAM stays
+/// on the history-dependent resolver.
+#[derive(Default)]
+pub(super) struct IndexedOutputCache {
+    entries: Vec<IndexedOutputCacheEntry>,
+}
+
+impl IndexedOutputCache {
+    pub(super) fn outputs(
+        &mut self,
+        control: ControlState,
+        palette: &Palette,
+    ) -> &[DenisePlayfieldOutput; 256] {
+        debug_assert!(!control.hold_and_modify());
+        if let Some(idx) = self
+            .entries
+            .iter()
+            .position(|entry| entry.control == control && entry.palette == *palette)
+        {
+            return &self.entries[idx].outputs;
+        }
+
+        let outputs = Box::new(std::array::from_fn(|idx| {
+            let mut ignored_history = 0;
+            denise_playfield_output(control, palette, idx as u8, &mut ignored_history)
+        }));
+        if self.entries.len() == INDEXED_OUTPUT_CACHE_LEN {
+            self.entries.remove(0);
+        }
+        self.entries.push(IndexedOutputCacheEntry {
+            control,
+            palette: *palette,
+            outputs,
+        });
+        &self.entries.last().expect("just inserted").outputs
+    }
+}
+
+#[inline(always)]
+pub(super) fn cached_indexed_output(
+    outputs: &[DenisePlayfieldOutput; 256],
+    idx: u8,
+    ham_color: &mut u32,
+) -> DenisePlayfieldOutput {
+    let output = outputs[idx as usize];
+    // The indexed resolver seeds the held colour for a later mid-line switch
+    // into HAM, even though its own output is history-independent.
+    *ham_color = output.color;
+    output
+}
+
 pub(super) fn palette_at_x(mut palette: Palette, segments: &[PaletteSegment], x: usize) -> Palette {
     for seg in segments {
         if seg.x > x {

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -17,6 +17,61 @@ fn h_row_for(control: ControlState) -> HWindowRow {
 }
 
 #[test]
+fn static_h_window_transition_solver_matches_counter_replay() {
+    let mut random = 0xC0_77_E2_11u32;
+    let beam_lines = [0, 1, 8, 9, PAL_VISIBLE_LINE0, 255, 311];
+
+    for case in 0..4096 {
+        random = random.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let hstart = ((random >> 3) & 0x1FF) as u16;
+        random = random.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let hstop = ((random >> 7) & 0x1FF) as u16;
+        let control = ControlState {
+            diwstrt: hstart & 0x00FF,
+            diwstop: hstop & 0x00FF,
+            diwhigh: DiwHigh::ecs_explicit(((hstart >> 8) << 5) | ((hstop >> 8) << 13)),
+            ..ControlState::default()
+        };
+        let beam_line = beam_lines[case % beam_lines.len()];
+        let is_ecs = case & 1 != 0;
+        // A segment whose effect lies beyond the line selects the original
+        // per-tick implementation without changing its comparator values.
+        let inert_segment = [ControlSegment { x: 2000, control }];
+
+        for initial_flop in [false, true] {
+            let mut solved_flop = initial_flop;
+            let mut solved = HWindowRow::default();
+            scan_h_window_line(
+                &mut solved_flop,
+                beam_line,
+                is_ecs,
+                control,
+                &[],
+                Some(&mut solved),
+            );
+
+            let mut replayed_flop = initial_flop;
+            let mut replayed = HWindowRow::default();
+            scan_h_window_line(
+                &mut replayed_flop,
+                beam_line,
+                is_ecs,
+                control,
+                &inert_segment,
+                Some(&mut replayed),
+            );
+
+            assert_eq!(solved_flop, replayed_flop, "case {case}");
+            assert_eq!(solved.open_runs, replayed.open_runs, "case {case}");
+            assert_eq!(
+                solved.comparator_anchor, replayed.comparator_anchor,
+                "case {case}"
+            );
+        }
+    }
+}
+
+#[test]
 fn h_window_flop_carries_open_past_line_with_unreachable_hstart() {
     // Standard window rows, then a late-line DIWSTOP rewrite to $2C00
     // before the standard stop matched: the flip-flop stays open across
@@ -1542,6 +1597,7 @@ fn late_lowres_ddf_stop_hold_keeps_left_origin_unadvanced() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -5969,6 +6025,7 @@ fn planned_ham_dma_uses_current_bitplane_sample_at_fetch_edge() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6019,6 +6076,7 @@ fn planned_ham_dma_advances_hold_through_edge_fetch_phase() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6067,6 +6125,7 @@ fn planned_ham_dma_ignores_extra_early_ddf_history_before_diw() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6121,6 +6180,7 @@ fn bplcon1_write_at_diw_right_edge_does_not_retap_current_ham_line() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6187,6 +6247,7 @@ fn ham_select_lands_in_the_colour_write_domain() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6230,6 +6291,7 @@ fn bplcon2_color_key_uses_color_register_transparency_bit() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6271,6 +6333,7 @@ fn bplcon2_bitplane_key_uses_selected_bitplane_sample() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6312,6 +6375,7 @@ fn bplcon3_zdclken_disables_internal_genlock_keys() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         palette,
         &[],
@@ -6349,6 +6413,7 @@ fn planned_playfield_line_feeds_clxdat_from_rendered_dual_playfield_sample() {
         &mut playfield_mask,
         &mut collision_pixels,
         &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
         &mut clxdat,
         Palette::new(),
         &[],
@@ -6480,6 +6545,56 @@ fn denise_playfield_output_selects_ehb_ham_and_dual_playfield_colors() {
             pf_mask: 2,
         }
     );
+}
+
+#[test]
+fn indexed_output_cache_matches_history_independent_color_resolution() {
+    let mut palette = Palette::new();
+    for idx in 0..palette.len() {
+        let hi = (((idx * 7) as u16) & 0x0F00)
+            | (((idx * 11) as u16) & 0x00F0)
+            | ((idx * 13) as u16 & 0x000F);
+        let lo = (((idx * 3) as u16) & 0x0F00)
+            | (((idx * 5) as u16) & 0x00F0)
+            | ((idx * 9) as u16 & 0x000F);
+        palette.write_entry(idx, false, hi);
+        palette.write_entry(idx, true, lo);
+    }
+    let controls = [
+        ControlState {
+            bplcon0: 0x6000, // OCS EHB
+            ..ControlState::default()
+        },
+        ControlState {
+            bplcon0: 0x2400, // OCS dual playfield
+            bplcon3: BPLCON3_PF2OF_DEFAULT,
+            ..ControlState::default()
+        },
+        ControlState {
+            agnus_revision: AgnusRevision::AgaAlice,
+            bplcon0: 0x0010, // AGA 8-plane indexed
+            bplcon4: 0x5A00, // BPLAM
+            ..ControlState::default()
+        },
+        ControlState {
+            agnus_revision: AgnusRevision::AgaAlice,
+            bplcon0: 0x6000, // AGA EHB
+            ..ControlState::default()
+        },
+    ];
+    let mut cache = IndexedOutputCache::default();
+
+    for control in controls {
+        let outputs = cache.outputs(control, &palette);
+        for idx in u8::MIN..=u8::MAX {
+            let mut expected_history = 0x0012_3456;
+            let expected = denise_playfield_output(control, &palette, idx, &mut expected_history);
+            let mut cached_history = 0x0065_4321;
+            let cached = cached_indexed_output(outputs, idx, &mut cached_history);
+            assert_eq!(cached, expected, "index {idx:#04x}, control {control:?}");
+            assert_eq!(cached_history, expected.color);
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This is the accuracy-preserving follow-up to #335. It removes repeated work from stable display and wide-FMODE paths without changing the cycle-driven timing model:

- cache the complete indexed Denise/Lisa colour result for each stable control/palette state (HAM remains sequential)
- solve unchanged horizontal display-window transitions directly, retaining the tick-by-tick path after live DIW writes
- publish a complete wide-FMODE slot mask and reuse the same stable fetch plan in frame capture
- use one prepared-pixel lookup when the odd/even BPLCON1 taps are equal
- retain and clear a bounded pool of captured bitplane row allocations across frames
- keep the wide-fetch path dynamic after fetch-affecting writes, including delayed BPLCON0/DMACON changes crossing a line boundary
- keep a restored partial wide-FMODE line dynamic until rollover, so skipped cache state cannot hide block-latched transitions

The optimized paths have exhaustive or randomized equivalence coverage against the existing implementations.

## Performance

Full-render `copperline-bench`, A1200 + 8 MiB fast RAM, booting `AmigaSYS3PlusAGA.hdf`, 60 emulated seconds (median of three):

| Host | #335 / phase 2 | This branch | Change |
| --- | ---: | ---: | ---: |
| Framework Ultra 1 Linux | 35.510 s | 27.833 s | -21.6% |
| Apple Silicon macOS, first phase-3 commit | 16.122 s | 15.292 s | -5.1% within this PR |

All final runs produced the same presentation checksum, `0xdf2000000`, and stayed within the 20 ms PAL frame budget.

A final macOS sample confirms the intended reductions: the prepared playfield sampler fell from 859 to 468 top-of-stack samples, and bitplane capture from 398 to 308, relative to the first phase-3 profile.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `cargo build --release`
- `cargo build --release --features bench-bin --bin copperline-bench`
- local and Framework A1200 full-render benchmarks with identical checksums

## Deliberately not included

- A general event-span scheduler was prototyped but made the core-only workload 2.8% slower even after thresholding, so it was removed.
- Native-height GPU presentation was investigated, but the current compositor applies crop, overscan, tint, UI, CRT and bezel semantics to the CPU buffer. Bypassing that path would create visual or capture differences, so this PR leaves it unchanged.
