### PR TITLE
Reduce idle and repeated-frame presentation work

### DIFF
--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -689,8 +689,10 @@ node tools/wasi-bench.mjs \
 
 `--render` includes the full per-frame presentation pipeline (render,
 post-process, deinterlace), which is what an interactive frontend pays; the
-report shows the realtime factor and the frame-time distribution against the
-20 ms PAL budget. The same binary builds natively for a
+report shows the realtime factor, the frame-time distribution against the
+20 ms PAL budget, how many final presentation buffers were unchanged, and
+how many conservative input matches skipped rendering entirely. The same
+binary builds natively for a
 direct wasm-versus-native comparison on identical workloads -- the render
 checksums match between the two, which is the determinism contract doing its
 job. As a reference point, on an Apple-Silicon laptop the wasm build ran the

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -240,6 +240,17 @@ check is applied by `Copper::step_eligible_slot`, the single primitive
 shared by the live bus path and the blitter-deadline predictor's cloned
 simulation, so prediction and execution cannot drift apart.
 
+When the 68k is halted in STOP, its idle fast-forward path may encounter a
+Copper in the steady comparator phase of WAIT. It computes that WAIT's exact
+beam/blitter deadline once and leaves the comparator dormant strictly before
+the deadline while the ordinary DMA arbiter continues to own every colour
+clock. The shortcut is capped at the field wrap because the vertical-blank
+COP1LC strobe supersedes a wait that would otherwise extend into the next
+field. Instruction-tail and wake-up cycles remain individually stepped.
+Ordinary CPU-driven advances do not calculate this deadline: their spans are
+only a few colour clocks, so doing the prediction repeatedly would cost more
+than the comparator calls it replaces.
+
 Register writes take effect a fixed number of colour clocks after the
 chip-bus slot that carried them, and the delay is a property of the
 register pipeline, not of the bus master. Denise-boundary registers apply

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -357,6 +357,27 @@ capture paths call `finish_render_for_current_frame` so screenshots, frame
 dumps, recordings, debugger step, and run-to-PC output use the requested
 emulated frame.
 
+Progressive frames have two exact reuse checks. First, two consecutive
+renders with identical lightweight inputs arm a pre-render key containing
+every captured bitplane row, sprite line/latch, register/event stream,
+geometry and blanking input. If replay fetched words from the chip-RAM
+snapshot, the key also retains each timed address/value dependency and
+replays those reads against the next snapshot; unrelated guest RAM therefore
+does not defeat reuse. A match skips replay and keeps the prior collision and
+presentation result. The two-frame arming step avoids deep-copying captured
+plane data on changing displays. Interlace, phosphor history, and
+time-dependent render diagnostics do not take this shortcut.
+
+After post-processing and deinterlacing, the frontend compares the complete
+active presentation buffer and its geometry with the current one. This is a
+word-for-word comparison, not a hash. An exact repeat keeps the current
+buffer and, when the status LEDs/media state and overlays are also unchanged,
+does not request a main-window redraw; that avoids the CPU copy, texture
+upload, and GPU present even when harmless differences in the raw event log
+made the conservative pre-render key reject the frame. Recording still emits
+the duplicate video frame, and status/UI changes still redraw over a held
+Amiga picture.
+
 ## Interlace (`video/deinterlace.rs`)
 
 Interlaced (LACE) content is presented through a motion-adaptive

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -124,8 +124,14 @@ fn main() -> Result<()> {
     let mut fb = vec![0u32; MAX_CANVAS_PIXELS];
     let mut deinterlacer = Deinterlacer::new();
     let mut presentation_fb = Vec::new();
+    let mut next_presentation_fb = Vec::new();
+    let mut present_rows = 0usize;
+    let mut present_width = 0usize;
+    let mut repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
     let mut last_rendered: Option<u64> = None;
     let mut rendered_frames: u64 = 0;
+    let mut reused_frames: u64 = 0;
+    let mut render_skipped_frames: u64 = 0;
 
     let start_emulated = emu.bus().emulated_seconds();
     let target = start_emulated + args.seconds;
@@ -140,29 +146,55 @@ fn main() -> Result<()> {
             let emulated_frame = emu.bus().emulated_frames();
             if present_common::should_render_emulated_frame(last_rendered, emulated_frame) {
                 let visible_start_vpos = emu.bus().frame_visible_start_vpos();
-                bitplane::render(emu.bus_mut(), &mut fb);
-                let geometry = emu.bus().frame_geometry();
-                let canvas_scale = emu.bus().frame_canvas_scale();
-                let field_rows = present_common::post_process_rendered_field(
+                let reused = bitplane::render_reusing_previous(
+                    emu.bus_mut(),
                     &mut fb,
-                    geometry,
-                    canvas_scale,
-                    emu.bus().frame_presentation_h_window(),
-                    emu.bus().frame_presentation_v_window(),
-                    visible_start_vpos,
-                    0,
-                    Overscan::Tv,
+                    &mut repeated_frame_detector,
                 );
-                let base = emu.bus().frame_render_base();
-                deinterlacer.present_field_into(
-                    &fb,
-                    field_rows,
-                    FB_WIDTH * canvas_scale,
-                    base.bplcon0 & 0x0004 != 0,
-                    base.long_field,
-                    !geometry.programmable,
-                    &mut presentation_fb,
-                );
+                if reused {
+                    reused_frames += 1;
+                    render_skipped_frames += 1;
+                } else {
+                    let geometry = emu.bus().frame_geometry();
+                    let canvas_scale = emu.bus().frame_canvas_scale();
+                    let field_rows = present_common::post_process_rendered_field(
+                        &mut fb,
+                        geometry,
+                        canvas_scale,
+                        emu.bus().frame_presentation_h_window(),
+                        emu.bus().frame_presentation_v_window(),
+                        visible_start_vpos,
+                        0,
+                        Overscan::Tv,
+                    );
+                    let base = emu.bus().frame_render_base();
+                    let (next_rows, next_width) = deinterlacer.present_field_into(
+                        &fb,
+                        field_rows,
+                        FB_WIDTH * canvas_scale,
+                        base.bplcon0 & 0x0004 != 0,
+                        base.long_field,
+                        !geometry.programmable,
+                        &mut next_presentation_fb,
+                    );
+                    let active = next_rows * next_width;
+                    let unchanged = present_rows == next_rows
+                        && present_width == next_width
+                        && matches!(
+                            (
+                                presentation_fb.get(..active),
+                                next_presentation_fb.get(..active)
+                            ),
+                            (Some(current), Some(next)) if current == next
+                        );
+                    if unchanged {
+                        reused_frames += 1;
+                    } else {
+                        std::mem::swap(&mut presentation_fb, &mut next_presentation_fb);
+                        present_rows = next_rows;
+                        present_width = next_width;
+                    }
+                }
                 last_rendered = Some(emulated_frame);
                 rendered_frames += 1;
             }
@@ -187,7 +219,10 @@ fn main() -> Result<()> {
         frames as f64 / elapsed.max(f64::EPSILON),
         emulated / elapsed.max(f64::EPSILON),
         if args.render {
-            format!(", {rendered_frames} rendered")
+            format!(
+                ", {rendered_frames} presented ({reused_frames} unchanged, \
+                 {render_skipped_frames} renders skipped)"
+            )
         } else {
             String::new()
         }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4854,12 +4854,12 @@ impl Bus {
         let mut total = AgnusTick::default();
 
         let mut remaining = target_cck;
-        let mut sleeping_copper_deadline = self
-            .sleeping_copper_wakeup_cck()
+        let mut invariant_copper_deadline = self
+            .invariant_copper_deadline_cck()
             .filter(|&deadline| deadline != 0);
         while remaining > 0 {
-            let before_deadline = sleeping_copper_deadline.is_some();
-            let quantum_limit = sleeping_copper_deadline
+            let before_deadline = invariant_copper_deadline.is_some();
+            let quantum_limit = invariant_copper_deadline
                 .map(|deadline| remaining.min(deadline))
                 .unwrap_or(remaining);
             let (cck, tick) = self.advance_one_chip_bus_quantum_limited_inner(
@@ -4869,12 +4869,12 @@ impl Bus {
             );
             remaining = remaining.saturating_sub(cck);
             add_agnus_tick(&mut total, tick);
-            sleeping_copper_deadline = sleeping_copper_deadline
+            invariant_copper_deadline = invariant_copper_deadline
                 .and_then(|deadline| deadline.checked_sub(cck))
                 .filter(|&deadline| deadline != 0);
-            if sleeping_copper_deadline.is_none() {
-                sleeping_copper_deadline = self
-                    .sleeping_copper_wakeup_cck()
+            if invariant_copper_deadline.is_none() {
+                invariant_copper_deadline = self
+                    .invariant_copper_deadline_cck()
                     .filter(|&deadline| deadline != 0);
             }
         }
@@ -5091,11 +5091,12 @@ impl Bus {
         self.copper_wait_wakeup_cck(wait)
     }
 
-    /// Exact deadline for the steady comparator phase of a Copper WAIT.
-    /// Before this point the WAIT state is invariant, so `advance_chipset`
-    /// may leave the per-quantum comparator dormant. The instruction-tail
-    /// and wake-up phases return `None` and retain their exact cycle steps.
-    fn sleeping_copper_wakeup_cck(&self) -> Option<u32> {
+    /// Exact deadline before which the Copper state is invariant: either a
+    /// pending vertical-blank COP1LC restart or the steady comparator phase of
+    /// a WAIT. Before this point `advance_chipset` may leave the per-quantum
+    /// Copper step dormant. Instruction-tail and wake-up phases return `None`
+    /// and retain their exact cycle steps.
+    fn invariant_copper_deadline_cck(&self) -> Option<u32> {
         if !self.copper_dma_enabled() {
             return None;
         }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -312,7 +312,7 @@ const NANOS_PER_SECOND: u128 = 1_000_000_000;
 const VIDEO_FETCH_TIMING_SAMPLE_RATE: u128 = 128;
 const VIDEO_COLLISION_TIMING_SAMPLE_RATE: u128 = 16;
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CapturedBitplaneRow {
     pub nplanes: usize,
     pub words_per_row: usize,
@@ -324,7 +324,7 @@ pub struct CapturedBitplaneRow {
     pub fetch_origin_cck: Option<u16>,
 }
 
-#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CapturedSpriteLine {
     pub sprite: usize,
     pub hstart: i32,
@@ -342,7 +342,7 @@ pub struct CapturedSpriteLine {
     pub attached: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HeldSpriteLine {
     pub line: CapturedSpriteLine,
     pub vstart: i32,
@@ -4845,6 +4845,53 @@ impl Bus {
         total
     }
 
+    /// Long stopped-CPU advance that keeps a steady Copper WAIT dormant up
+    /// to its exact comparator deadline. Ordinary CPU-driven advances are
+    /// deliberately left on [`Self::advance_chipset`]: their spans are only a
+    /// few colour clocks, so calculating a far-future deadline would cost
+    /// more than the comparator calls it replaces.
+    fn advance_chipset_cpu_idle(&mut self, target_cck: u32) -> AgnusTick {
+        let mut total = AgnusTick::default();
+
+        let mut remaining = target_cck;
+        let mut sleeping_copper_deadline = self
+            .sleeping_copper_wakeup_cck()
+            .filter(|&deadline| deadline != 0);
+        while remaining > 0 {
+            let before_deadline = sleeping_copper_deadline.is_some();
+            let quantum_limit = sleeping_copper_deadline
+                .map(|deadline| remaining.min(deadline))
+                .unwrap_or(remaining);
+            let (cck, tick) = self.advance_one_chip_bus_quantum_limited_inner(
+                None,
+                quantum_limit,
+                before_deadline,
+            );
+            remaining = remaining.saturating_sub(cck);
+            add_agnus_tick(&mut total, tick);
+            sleeping_copper_deadline = sleeping_copper_deadline
+                .and_then(|deadline| deadline.checked_sub(cck))
+                .filter(|&deadline| deadline != 0);
+            if sleeping_copper_deadline.is_none() {
+                sleeping_copper_deadline = self
+                    .sleeping_copper_wakeup_cck()
+                    .filter(|&deadline| deadline != 0);
+            }
+        }
+
+        total
+    }
+
+    /// Advance devices while the CPU is halted in STOP. This is the only
+    /// caller that presents spans long enough for the sleeping-Copper
+    /// deadline optimization to pay for itself.
+    pub fn advance_cpu_idle_devices(&mut self, cck: u32) -> AgnusTick {
+        self.flush_timed_devices();
+        let tick = self.advance_chipset_cpu_idle(cck);
+        self.tick_timed_devices(cck, tick);
+        tick
+    }
+
     pub fn advance_devices(&mut self, cck: u32) -> AgnusTick {
         // Apply any color clocks deferred by the CPU access path before ticking
         // this (idle/stopped-CPU or test-driven) span, so device time stays
@@ -5041,6 +5088,29 @@ impl Bus {
             }
             return Some(2);
         };
+        self.copper_wait_wakeup_cck(wait)
+    }
+
+    /// Exact deadline for the steady comparator phase of a Copper WAIT.
+    /// Before this point the WAIT state is invariant, so `advance_chipset`
+    /// may leave the per-quantum comparator dormant. The instruction-tail
+    /// and wake-up phases return `None` and retain their exact cycle steps.
+    fn sleeping_copper_wakeup_cck(&self) -> Option<u32> {
+        if !self.copper_dma_enabled() {
+            return None;
+        }
+        if let Some(cck) = self.cck_until_pending_copper_frame_start() {
+            return Some(cck);
+        }
+        let wait_deadline = self.copper_wait_wakeup_cck(self.copper.sleeping_wait()?)?;
+        // A field wrap stops the current Copper and schedules the vertical-
+        // blank COP1LC strobe. That state transition can precede a wait whose
+        // low-byte vertical target lies in the next field, so never carry a
+        // sleeping-WAIT deadline across the wrap.
+        Some(wait_deadline.min(self.agnus.cck_until_next_frame()))
+    }
+
+    fn copper_wait_wakeup_cck(&self, wait: CopperWait) -> Option<u32> {
         let position_cck = self.cck_until_copper_wait_position(wait)?;
         if position_cck == 0 && wait.blitter_wait_enabled() && self.blitter.busy {
             return self.next_blitter_completion_cck();

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -30,6 +30,21 @@ impl Bus {
         forced_owner: Option<ChipBusOwner>,
         max_cck: u32,
     ) -> (u32, AgnusTick) {
+        self.advance_one_chip_bus_quantum_limited_inner(forced_owner, max_cck, false)
+    }
+
+    /// Shared quantum step. `sleeping_copper_before_deadline` means the
+    /// Copper is in the steady WAIT phase and the exact beam/blitter deadline
+    /// is still strictly ahead of this quantum. The comparator cannot change
+    /// state before that point, so the slot remains free without calling into
+    /// the Copper state machine; instruction tails and wake-up cycles never
+    /// select this path.
+    pub(super) fn advance_one_chip_bus_quantum_limited_inner(
+        &mut self,
+        forced_owner: Option<ChipBusOwner>,
+        max_cck: u32,
+        sleeping_copper_before_deadline: bool,
+    ) -> (u32, AgnusTick) {
         let cck = self.next_chip_bus_quantum().min(max_cck).max(1);
         self.flush_audio_before_audio_dma_slot();
 
@@ -48,9 +63,10 @@ impl Bus {
         };
         let copper_runs = cck >= CHIP_BUS_SLOT_CCK && self.copper_comparator_runs_at(hpos);
         let eligible = copper_runs && fixed_dma_owner.is_none();
-        let copper_took_bus =
-            eligible && self.step_copper_eligible_slot(forced_owner.is_none(), true);
-        if !eligible && copper_runs {
+        let copper_took_bus = eligible
+            && !sleeping_copper_before_deadline
+            && self.step_copper_eligible_slot(forced_owner.is_none(), true);
+        if !eligible && copper_runs && !sleeping_copper_before_deadline {
             // A fixed DMA owner (bitplane/sprite/disk/audio/refresh) holds
             // this color clock, but the Copper's WAIT/SKIP comparator is
             // combinational and keeps running: only instruction fetches need

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -33,17 +33,17 @@ impl Bus {
         self.advance_one_chip_bus_quantum_limited_inner(forced_owner, max_cck, false)
     }
 
-    /// Shared quantum step. `sleeping_copper_before_deadline` means the
-    /// Copper is in the steady WAIT phase and the exact beam/blitter deadline
-    /// is still strictly ahead of this quantum. The comparator cannot change
-    /// state before that point, so the slot remains free without calling into
-    /// the Copper state machine; instruction tails and wake-up cycles never
-    /// select this path.
+    /// Shared quantum step. `copper_invariant_before_deadline` means either a
+    /// steady WAIT comparator or a pending vertical-blank COP1LC restart has
+    /// an exact deadline still strictly ahead of this quantum. The Copper
+    /// state cannot change before that point, so the slot remains free without
+    /// calling into its state machine; instruction tails and wake-up cycles
+    /// never select this path.
     pub(super) fn advance_one_chip_bus_quantum_limited_inner(
         &mut self,
         forced_owner: Option<ChipBusOwner>,
         max_cck: u32,
-        sleeping_copper_before_deadline: bool,
+        copper_invariant_before_deadline: bool,
     ) -> (u32, AgnusTick) {
         let cck = self.next_chip_bus_quantum().min(max_cck).max(1);
         self.flush_audio_before_audio_dma_slot();
@@ -64,9 +64,9 @@ impl Bus {
         let copper_runs = cck >= CHIP_BUS_SLOT_CCK && self.copper_comparator_runs_at(hpos);
         let eligible = copper_runs && fixed_dma_owner.is_none();
         let copper_took_bus = eligible
-            && !sleeping_copper_before_deadline
+            && !copper_invariant_before_deadline
             && self.step_copper_eligible_slot(forced_owner.is_none(), true);
-        if !eligible && copper_runs && !sleeping_copper_before_deadline {
+        if !eligible && copper_runs && !copper_invariant_before_deadline {
             // A fixed DMA owner (bitplane/sprite/disk/audio/refresh) holds
             // this color clock, but the Copper's WAIT/SKIP comparator is
             // combinational and keeps running: only instruction fetches need

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -1692,6 +1692,112 @@ fn next_copper_wakeup_cck_tracks_wait_beam_position() {
     assert_eq!(bus.next_copper_wakeup_cck(), None);
 }
 
+fn advance_chipset_quantum_reference(bus: &mut Bus, target_cck: u32) -> AgnusTick {
+    let mut total = AgnusTick::default();
+    let mut remaining = target_cck;
+    while remaining != 0 {
+        let (cck, tick) = bus.advance_one_chip_bus_quantum_limited(None, remaining);
+        remaining = remaining.saturating_sub(cck);
+        super::add_agnus_tick(&mut total, tick);
+    }
+    total
+}
+
+fn assert_wait_deadline_bus_equivalent(actual: &Bus, expected: &Bus) {
+    assert_eq!(
+        (actual.agnus.vpos, actual.agnus.hpos),
+        (expected.agnus.vpos, expected.agnus.hpos)
+    );
+    assert_eq!(actual.copper.state_label(), expected.copper.state_label());
+    assert_eq!(actual.copper.waiting(), expected.copper.waiting());
+    assert_eq!(actual.copper.pc(), expected.copper.pc());
+    assert_eq!(actual.denise.palette, expected.denise.palette);
+    assert_eq!(actual.data_bus, expected.data_bus);
+    assert_eq!(actual.last_chip_bus_owner, expected.last_chip_bus_owner);
+    assert_eq!(actual.display_dma_bplpt, expected.display_dma_bplpt);
+    assert_eq!(
+        actual.frame_captured_bitplane_rows(),
+        expected.frame_captured_bitplane_rows()
+    );
+    assert_eq!(actual.frame_render_events(), expected.frame_render_events());
+    assert_eq!(actual.paula.intreq, expected.paula.intreq);
+    assert_eq!(actual.emulated_cck, expected.emulated_cck);
+    assert_eq!(actual.emulated_frames, expected.emulated_frames);
+}
+
+fn sleeping_copper_with_display_dma() -> Bus {
+    let mut bus = empty_bus();
+    assert!(!bus.custom_write(0x08E, 2, 0x2C90));
+    assert!(!bus.custom_write(0x090, 2, 0xF4B0));
+    assert!(!bus.custom_write(0x092, 2, 0x0038));
+    assert!(!bus.custom_write(0x094, 2, 0x00D0));
+    assert!(!bus.custom_write(0x100, 2, 0x6600));
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_COPEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x64;
+    bus.agnus.hpos = 0x20;
+    bus.copper.jump(0x0100);
+    write_chip_word(&mut bus, 0x0100, 0x0180);
+    write_chip_word(&mut bus, 0x0102, 0x0456);
+    bus.copper.wait(CopperWait::new(0x6441, 0xFFFE));
+    bus
+}
+
+#[test]
+fn sleeping_copper_deadline_matches_per_quantum_comparator_under_display_dma() {
+    let mut optimized = sleeping_copper_with_display_dma();
+    let mut reference = sleeping_copper_with_display_dma();
+
+    let optimized_tick = optimized.advance_chipset_cpu_idle(0x40);
+    let reference_tick = advance_chipset_quantum_reference(&mut reference, 0x40);
+
+    assert_eq!(
+        (optimized_tick.new_lines, optimized_tick.new_frames),
+        (reference_tick.new_lines, reference_tick.new_frames)
+    );
+    assert_wait_deadline_bus_equivalent(&optimized, &reference);
+    assert_eq!(optimized.denise.palette[0], 0x0456);
+}
+
+#[test]
+fn sleeping_copper_deadline_matches_reference_across_random_beam_spans() {
+    let mut random = 0xC0_77_E2_55u32;
+    for case in 0..512 {
+        random = random.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let vpos = (random >> 12) % PAL_LINES;
+        let hpos = (random & 0xFF) % COLORCLOCKS_PER_LINE;
+        random = random.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let target_vpos = (random >> 16) as u16;
+        let target_hpos = ((random >> 7) & 0xFE) as u16;
+        let wait = CopperWait::new((target_vpos << 8) | target_hpos | 1, 0xFFFE);
+        let span = 1 + (random & 0x7FF);
+
+        let make_bus = || {
+            let mut bus = empty_bus();
+            bus.agnus.dmacon = DMACON_DMAEN | DMACON_COPEN;
+            bus.agnus.vpos = vpos;
+            bus.agnus.hpos = hpos;
+            bus.copper.wait(wait);
+            bus
+        };
+        let mut optimized = make_bus();
+        let mut reference = make_bus();
+        let optimized_tick = optimized.advance_chipset_cpu_idle(span);
+        let reference_tick = advance_chipset_quantum_reference(&mut reference, span);
+
+        assert_eq!(
+            (optimized_tick.new_lines, optimized_tick.new_frames),
+            (reference_tick.new_lines, reference_tick.new_frames),
+            "case {case}"
+        );
+        assert_eq!(
+            optimized.copper.state_label(),
+            reference.copper.state_label(),
+            "case {case}: start ({vpos:#x}, {hpos:#x}), wait ({target_vpos:#x}, {target_hpos:#x}), span {span:#x}"
+        );
+        assert_wait_deadline_bus_equivalent(&optimized, &reference);
+    }
+}
+
 #[test]
 fn next_copper_wakeup_cck_waits_for_vertical_low_byte_rollover_after_line_255() {
     let mut bus = empty_bus();

--- a/src/chipset/copper.rs
+++ b/src/chipset/copper.rs
@@ -466,6 +466,20 @@ impl Copper {
         }
     }
 
+    /// The WAIT comparator's steady sleeping phase. Instruction-tail and
+    /// wake-up phases also carry a `CopperWait`, but still need their
+    /// individual free-cycle transitions; only this phase may be advanced
+    /// directly to the exact comparator deadline.
+    pub fn sleeping_wait(&self) -> Option<CopperWait> {
+        match self.state {
+            CopperState::Waiting {
+                wait,
+                phase: CopperWaitPhase::Waiting,
+            } => Some(wait),
+            _ => None,
+        }
+    }
+
     /// Whether the Copper has halted (illegal register write): it fetches
     /// nothing further until a COPJMP strobe or vertical blank restarts it.
     pub fn is_stopped(&self) -> bool {

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1365,7 +1365,7 @@ impl Emulator {
             );
             if run.cpu_stopped {
                 let idle_cck = accounting.slice_cck.saturating_sub(run.bus_advanced_cck);
-                self.bus_mut().advance_devices(idle_cck);
+                self.bus_mut().advance_cpu_idle_devices(idle_cck);
             }
             self.machine.refresh_irq_line();
         }
@@ -1565,7 +1565,7 @@ impl Emulator {
             // needs nothing here: the cycle-exact core already advanced
             // its full device time through sync/grant as it executed.)
             let idle_cck = accounting.slice_cck.saturating_sub(run.bus_advanced_cck);
-            self.bus_mut().advance_devices(idle_cck);
+            self.bus_mut().advance_cpu_idle_devices(idle_cck);
         }
         // `refresh_irq_line` applies any deferred timed-device color clocks
         // before sampling the interrupt line (see its body), so a device

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3329,18 +3329,37 @@ fn seed_manual_bpl_segments_from_latches(
     }
 }
 
+// A fallback-rendered PAL frame can read roughly 36,000 bitplane words. Keep
+// enough exact dependencies for wide AGA fetches too, while bounding a
+// malformed display's retained previous-frame state to about 2 MiB.
+const RENDER_REUSE_MAX_RAM_READS: usize = 131_072;
+
+#[derive(Clone, Copy)]
+pub(crate) struct ChipRamReadDependency {
+    addr: u32,
+    vpos: u32,
+    hpos: u32,
+    value: u16,
+}
+
 struct TimedChipRam<'a> {
     ram: Cow<'a, [u8]>,
     writes: &'a [BeamChipRamWrite],
     next_write: usize,
+    track_read_dependencies: bool,
+    read_dependencies: Vec<ChipRamReadDependency>,
+    read_dependencies_overflowed: bool,
 }
 
 impl<'a> TimedChipRam<'a> {
-    fn new(ram: &'a [u8], writes: &'a [BeamChipRamWrite]) -> Self {
+    fn new(ram: &'a [u8], writes: &'a [BeamChipRamWrite], track_read_dependencies: bool) -> Self {
         Self {
             ram: Cow::Borrowed(ram),
             writes,
             next_write: 0,
+            track_read_dependencies,
+            read_dependencies: Vec::new(),
+            read_dependencies_overflowed: false,
         }
     }
 
@@ -3366,7 +3385,24 @@ impl<'a> TimedChipRam<'a> {
 
     fn read_word_wrapping(&mut self, addr: u32, vpos: u32, hpos: u32) -> u16 {
         self.replay_through(vpos, hpos);
-        read_chip_word_wrapping(&self.ram, addr)
+        let value = read_chip_word_wrapping(&self.ram, addr);
+        if self.track_read_dependencies && self.read_dependencies.len() < RENDER_REUSE_MAX_RAM_READS
+        {
+            self.read_dependencies.push(ChipRamReadDependency {
+                addr,
+                vpos,
+                hpos,
+                value,
+            });
+        } else if self.track_read_dependencies {
+            self.read_dependencies_overflowed = true;
+        }
+        value
+    }
+
+    fn into_read_dependencies(self) -> Option<Vec<ChipRamReadDependency>> {
+        (self.track_read_dependencies && !self.read_dependencies_overflowed)
+            .then_some(self.read_dependencies)
     }
 }
 
@@ -3677,6 +3713,225 @@ pub struct RenderInput {
     debug_sprite_mask: u8,
 }
 
+/// Exact, compact ownership of every frame-snapshot field that can affect
+/// [`render_from_input`].
+///
+/// The frame capture owns large `Arc` buffers that must be released after the
+/// worker finishes. Keeping an old `RenderInput` alive just to compare the
+/// next frame would pin those buffers and force another chip-RAM-sized
+/// allocation every frame, so this key deep-copies only the captured display
+/// data. Emulated time/frame counters are deliberately absent: they feed
+/// diagnostics, not pixels, and repeated-frame reuse is disabled while any
+/// per-frame render diagnostic is active.
+#[doc(hidden)]
+struct RenderContentPrefix {
+    geometry: FrameGeometry,
+    presentation_h_window: Option<(i32, u32)>,
+    presentation_v_window: Option<(i32, u32)>,
+    visible_start_vpos: u32,
+    palette_split: (Palette, Palette, bool),
+    render_base: RenderRegisterSnapshot,
+    frame_render_events: Vec<BeamRegisterWrite>,
+    current_render_base: RenderRegisterSnapshot,
+    current_render_events: Vec<BeamRegisterWrite>,
+    bottom_palette_events: Vec<BeamRegisterWrite>,
+    top_palette_end: Palette,
+    chip_ram_len: usize,
+    sprite_dma_observed: bool,
+    frame_lines: u32,
+    programmable_vertical_blank: Option<(u32, u32)>,
+    programmable_horizontal_blank: Option<(u32, u32)>,
+    debug_plane_mask: u8,
+    debug_sprite_mask: u8,
+}
+
+impl RenderContentPrefix {
+    fn from_input(input: &RenderInput) -> Self {
+        Self {
+            geometry: input.geometry,
+            presentation_h_window: input.presentation_h_window,
+            presentation_v_window: input.presentation_v_window,
+            visible_start_vpos: input.visible_start_vpos,
+            palette_split: input.palette_split,
+            render_base: input.render_base,
+            frame_render_events: input.frame_render_events.clone(),
+            current_render_base: input.current_render_base,
+            current_render_events: input.current_render_events.clone(),
+            bottom_palette_events: input.bottom_palette_events.clone(),
+            top_palette_end: input.top_palette_end,
+            chip_ram_len: input.chip_ram.len(),
+            sprite_dma_observed: input.sprite_dma_observed,
+            frame_lines: input.frame_lines,
+            programmable_vertical_blank: input.programmable_vertical_blank,
+            programmable_horizontal_blank: input.programmable_horizontal_blank,
+            debug_plane_mask: input.debug_plane_mask,
+            debug_sprite_mask: input.debug_sprite_mask,
+        }
+    }
+
+    fn first_mismatch(&self, input: &RenderInput) -> Option<&'static str> {
+        macro_rules! different {
+            ($field:ident) => {
+                if self.$field != input.$field {
+                    return Some(stringify!($field));
+                }
+            };
+        }
+        different!(geometry);
+        different!(presentation_h_window);
+        different!(presentation_v_window);
+        different!(visible_start_vpos);
+        different!(palette_split);
+        different!(render_base);
+        different!(frame_render_events);
+        different!(current_render_base);
+        different!(current_render_events);
+        different!(bottom_palette_events);
+        different!(top_palette_end);
+        if self.chip_ram_len != input.chip_ram.len() {
+            return Some("chip_ram_len");
+        }
+        different!(sprite_dma_observed);
+        different!(frame_lines);
+        different!(programmable_vertical_blank);
+        different!(programmable_horizontal_blank);
+        different!(debug_plane_mask);
+        different!(debug_sprite_mask);
+        None
+    }
+}
+
+#[doc(hidden)]
+pub struct RenderContentKey {
+    captured_bitplane_rows: Vec<Option<CapturedBitplaneRow>>,
+    captured_sprite_lines: Vec<CapturedSpriteLine>,
+    held_sprites: [Option<HeldSpriteLine>; 8],
+    sprite_display_enable_x_by_y: Vec<Option<usize>>,
+    chip_ram_reads: Vec<ChipRamReadDependency>,
+}
+
+impl RenderContentKey {
+    fn from_input(input: &RenderInput, chip_ram_reads: Vec<ChipRamReadDependency>) -> Self {
+        Self {
+            captured_bitplane_rows: input.captured_bitplane_rows.as_ref().clone(),
+            captured_sprite_lines: input.captured_sprite_lines.clone(),
+            held_sprites: input.held_sprites,
+            sprite_display_enable_x_by_y: input.sprite_display_enable_x_by_y.clone(),
+            chip_ram_reads,
+        }
+    }
+
+    fn first_mismatch(&self, input: &RenderInput) -> Option<&'static str> {
+        macro_rules! different {
+            ($field:ident) => {
+                if self.$field != input.$field {
+                    return Some(stringify!($field));
+                }
+            };
+        }
+        if self.captured_bitplane_rows.as_slice() != input.captured_bitplane_rows.as_slice() {
+            return Some("captured_bitplane_rows");
+        }
+        different!(captured_sprite_lines);
+        different!(held_sprites);
+        different!(sprite_display_enable_x_by_y);
+        let mut ram = TimedChipRam::new(input.chip_ram.as_slice(), &input.chip_ram_writes, false);
+        for dependency in &self.chip_ram_reads {
+            if ram.read_word_wrapping(dependency.addr, dependency.vpos, dependency.hpos)
+                != dependency.value
+            {
+                return Some("chip_ram_read");
+            }
+        }
+        None
+    }
+}
+
+/// Previous-frame detector for exact render reuse. Live chip-RAM fetches are
+/// retained as timed address/value dependencies and replayed against the next
+/// snapshot. Interlaced output carries field history, phosphor is handled by
+/// the presentation caller, and diagnostics can be time-dependent, so those
+/// cases never enter this cache.
+#[derive(Default)]
+#[doc(hidden)]
+pub struct RepeatedFrameDetector {
+    key: Option<RenderContentKey>,
+    previous_prefix: Option<RenderContentPrefix>,
+    clxdat: u16,
+}
+
+impl RepeatedFrameDetector {
+    fn eligible(input: &RenderInput) -> bool {
+        input.render_base.bplcon0 & 0x0004 == 0 && !per_frame_render_diagnostics_active()
+    }
+
+    pub fn can_reuse(&self, input: &RenderInput) -> bool {
+        if !Self::eligible(input) {
+            return false;
+        }
+        let Some(key) = self.key.as_ref() else {
+            return false;
+        };
+        self.previous_prefix
+            .as_ref()
+            .is_some_and(|prefix| prefix.first_mismatch(input).is_none())
+            && key.first_mismatch(input).is_none()
+    }
+
+    pub fn should_track_read_dependencies(&self, input: &RenderInput) -> bool {
+        Self::eligible(input)
+            && self
+                .previous_prefix
+                .as_ref()
+                .is_some_and(|prefix| prefix.first_mismatch(input).is_none())
+    }
+
+    pub fn note_rendered(&mut self, input: &RenderInput, result: &mut RenderResult) {
+        self.clxdat = result.clxdat;
+        let eligible = Self::eligible(input);
+        let prefix_repeated = self.should_track_read_dependencies(input);
+        let prefix = eligible.then(|| RenderContentPrefix::from_input(input));
+        self.key = if prefix_repeated {
+            result
+                .chip_ram_reads
+                .take()
+                .map(|reads| RenderContentKey::from_input(input, reads))
+        } else {
+            None
+        };
+        self.previous_prefix = prefix;
+    }
+
+    pub fn reused_clxdat(&self) -> u16 {
+        self.clxdat
+    }
+
+    pub fn clear(&mut self) {
+        self.key = None;
+        self.previous_prefix = None;
+        self.clxdat = 0;
+    }
+}
+
+fn per_frame_render_diagnostics_active() -> bool {
+    static ACTIVE: OnceLock<bool> = OnceLock::new();
+    *ACTIVE.get_or_init(|| {
+        [
+            "COPPERLINE_DBG_FRAMESTATE",
+            "COPPERLINE_DBG_EXPORT_PLANES",
+            "COPPERLINE_TRACE_DISPLAY_PLAN",
+            "COPPERLINE_DIAG_PALETTE_ROW",
+            "COPPERLINE_DIAG_MANUAL_SPRITES",
+            "COPPERLINE_DIAG_SPRITE_PIXELS",
+            "COPPERLINE_DIAG_HAM_PIXELS",
+            "COPPERLINE_DIAG_MANUAL_BPL_PIXELS",
+            "COPPERLINE_DIAG_FRAME_PIXELS",
+        ]
+        .iter()
+        .any(|name| crate::envcfg::var_os(name).is_some())
+    })
+}
+
 impl RenderInput {
     /// Snapshot the just-finished frame from the bus into an owned bundle.
     pub fn from_bus(bus: &Bus) -> Self {
@@ -3822,6 +4077,7 @@ impl RenderInput {
 pub struct RenderResult {
     pub timing: VideoRenderFrameTiming,
     pub clxdat: u16,
+    pub(crate) chip_ram_reads: Option<Vec<ChipRamReadDependency>>,
 }
 
 /// Paint the just-finished frame through the synchronous compatibility path.
@@ -3851,6 +4107,51 @@ pub fn render(bus: &mut Bus, fb: &mut [u32]) {
             .expect("scratch render input present")
             .release_shared_frame_data();
     });
+}
+
+/// Synchronous render wrapper with exact previous-frame reuse. Returns true
+/// when `fb` already contains the identical progressive frame and no render
+/// was needed. This is primarily the frontend-free benchmark companion to the
+/// threaded window cache; [`render`] preserves its always-render contract.
+#[doc(hidden)]
+pub fn render_reusing_previous(
+    bus: &mut Bus,
+    fb: &mut [u32],
+    detector: &mut RepeatedFrameDetector,
+) -> bool {
+    thread_local! {
+        static REUSED_RENDER_INPUT_SCRATCH: std::cell::RefCell<Option<RenderInput>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    REUSED_RENDER_INPUT_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        match scratch.as_mut() {
+            Some(input) => input.refill_from_bus(bus),
+            None => *scratch = Some(RenderInput::from_bus(bus)),
+        }
+        let input = scratch.as_ref().expect("scratch render input present");
+        if detector.can_reuse(input) {
+            bus.denise.or_clxdat(detector.reused_clxdat());
+            scratch
+                .as_mut()
+                .expect("scratch render input present")
+                .release_shared_frame_data();
+            return true;
+        }
+        let mut result = if detector.should_track_read_dependencies(input) {
+            render_from_input_tracking_reuse(input, fb)
+        } else {
+            render_from_input(input, fb)
+        };
+        detector.note_rendered(input, &mut result);
+        bus.denise.or_clxdat(result.clxdat);
+        bus.record_video_render_frame(result.timing);
+        scratch
+            .as_mut()
+            .expect("scratch render input present")
+            .release_shared_frame_data();
+        false
+    })
 }
 
 /// Render the just-finished frame without the bus feedback of [`render`]:
@@ -3997,6 +4298,19 @@ pub fn sprite_framebuffer_origin(bus: &Bus, sprite: usize) -> Option<(i32, i32)>
 }
 
 pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
+    render_from_input_impl(input, fb, false)
+}
+
+#[doc(hidden)]
+pub fn render_from_input_tracking_reuse(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
+    render_from_input_impl(input, fb, true)
+}
+
+fn render_from_input_impl(
+    input: &RenderInput,
+    fb: &mut [u32],
+    track_read_dependencies: bool,
+) -> RenderResult {
     let render_started = Instant::now();
     ACTIVE_DEBUG_MASKS.with(|masks| masks.set((input.debug_plane_mask, input.debug_sprite_mask)));
     ACTIVE_CANVAS_SHIFT_H.with(|shift| {
@@ -4193,7 +4507,11 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         .map(|segments| segments.len() as u64)
         .sum();
     let frame_ram = input.chip_ram.as_slice();
-    let mut ram = TimedChipRam::new(frame_ram, input.chip_ram_writes.as_slice());
+    let mut ram = TimedChipRam::new(
+        frame_ram,
+        input.chip_ram_writes.as_slice(),
+        track_read_dependencies,
+    );
     let captured_bitplane_rows = input.captured_bitplane_rows.as_slice();
     // Rows whose DMA capture recorded a fetch run diverging from the
     // register-derived DDF window (the sequencer's missed-stop drains and
@@ -4829,9 +5147,11 @@ pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
         visible_line0,
     );
     render_timing.total_nanos = render_started.elapsed().as_nanos();
+    let chip_ram_reads = ram.into_read_dependencies();
     RenderResult {
         timing: render_timing,
         clxdat,
+        chip_ram_reads,
     }
 }
 

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -16,6 +16,113 @@ fn h_row_for(control: ControlState) -> HWindowRow {
     }
 }
 
+fn repeated_frame_test_input() -> RenderInput {
+    let mut row = CapturedBitplaneRow {
+        nplanes: 1,
+        words_per_row: 1,
+        planes: std::array::from_fn(|_| Vec::new()),
+        fetch_origin_cck: None,
+    };
+    row.planes[0].push(0xA55A);
+    RenderInput {
+        geometry: FrameGeometry::standard(PAL_VISIBLE_LINE0 as u32, 312, false),
+        presentation_h_window: None,
+        presentation_v_window: None,
+        visible_start_vpos: PAL_VISIBLE_LINE0 as u32,
+        palette_split: (Palette::default(), Palette::default(), false),
+        render_base: RenderRegisterSnapshot::default(),
+        frame_render_events: Vec::new(),
+        current_render_base: RenderRegisterSnapshot::default(),
+        current_render_events: Vec::new(),
+        bottom_palette_events: Vec::new(),
+        top_palette_end: Palette::default(),
+        chip_ram: std::sync::Arc::new(vec![0; 1024]),
+        chip_ram_writes: Vec::new(),
+        captured_bitplane_rows: std::sync::Arc::new(vec![Some(row)]),
+        captured_sprite_lines: Vec::new(),
+        held_sprites: [None; 8],
+        sprite_display_enable_x_by_y: Vec::new(),
+        sprite_dma_observed: false,
+        frame_lines: 312,
+        programmable_vertical_blank: None,
+        programmable_horizontal_blank: None,
+        emulated_seconds: 1.0,
+        emulated_frames: 50,
+        debug_plane_mask: 0xFF,
+        debug_sprite_mask: 0xFF,
+    }
+}
+
+fn repeated_frame_test_result(chip_ram_reads: Option<Vec<ChipRamReadDependency>>) -> RenderResult {
+    RenderResult {
+        timing: VideoRenderFrameTiming::default(),
+        clxdat: 0x1234,
+        chip_ram_reads,
+    }
+}
+
+#[test]
+fn repeated_frame_detector_ignores_time_but_matches_captured_content_exactly() {
+    let first = repeated_frame_test_input();
+    let mut detector = RepeatedFrameDetector::default();
+    let mut result = repeated_frame_test_result(Some(Vec::new()));
+    detector.note_rendered(&first, &mut result);
+    assert!(!detector.can_reuse(&first));
+    let mut repeated_result = repeated_frame_test_result(Some(Vec::new()));
+    detector.note_rendered(&first, &mut repeated_result);
+
+    let mut same_pixels = repeated_frame_test_input();
+    same_pixels.emulated_seconds = 99.0;
+    same_pixels.emulated_frames = 4_950;
+    // Unobserved RAM is intentionally outside the key: the prior render
+    // proved that all visible words came from exact DMA/register capture.
+    same_pixels.chip_ram = std::sync::Arc::new(vec![0xCC; 1024]);
+    assert!(detector.can_reuse(&same_pixels));
+    assert_eq!(detector.reused_clxdat(), 0x1234);
+
+    std::sync::Arc::make_mut(&mut same_pixels.captured_bitplane_rows)[0]
+        .as_mut()
+        .unwrap()
+        .planes[0][0] ^= 1;
+    assert!(!detector.can_reuse(&same_pixels));
+}
+
+#[test]
+fn repeated_frame_detector_matches_ram_dependencies_and_rejects_incomplete_or_interlaced_keys() {
+    let progressive = repeated_frame_test_input();
+    let mut detector = RepeatedFrameDetector::default();
+    let mut result = repeated_frame_test_result(Some(vec![ChipRamReadDependency {
+        addr: 0,
+        vpos: 44,
+        hpos: 0x38,
+        value: 0,
+    }]));
+    detector.note_rendered(&progressive, &mut result);
+    assert!(!detector.can_reuse(&progressive));
+    let mut repeated_result = repeated_frame_test_result(Some(vec![ChipRamReadDependency {
+        addr: 0,
+        vpos: 44,
+        hpos: 0x38,
+        value: 0,
+    }]));
+    detector.note_rendered(&progressive, &mut repeated_result);
+    assert!(detector.can_reuse(&progressive));
+
+    let mut changed_dependency = repeated_frame_test_input();
+    std::sync::Arc::make_mut(&mut changed_dependency.chip_ram)[0] = 1;
+    assert!(!detector.can_reuse(&changed_dependency));
+
+    let mut incomplete = repeated_frame_test_result(None);
+    detector.note_rendered(&progressive, &mut incomplete);
+    assert!(!detector.can_reuse(&progressive));
+
+    let mut interlaced = repeated_frame_test_input();
+    interlaced.render_base.bplcon0 |= 0x0004;
+    let mut interlaced_result = repeated_frame_test_result(Some(Vec::new()));
+    detector.note_rendered(&interlaced, &mut interlaced_result);
+    assert!(!detector.can_reuse(&interlaced));
+}
+
 #[test]
 fn static_h_window_transition_solver_matches_counter_replay() {
     let mut random = 0xC0_77_E2_11u32;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -770,6 +770,15 @@ pub struct App {
     last_submitted_render_frame: Option<u64>,
     render_generation: u64,
     last_fdd_track: Option<u8>,
+    /// Last status/UI state paired with a requested main-window redraw.
+    /// When both this and the exact presentation pixels are unchanged, the
+    /// existing GPU texture can be held instead of uploaded and presented at
+    /// the emulated field rate.
+    last_main_redraw_state: Option<MainRedrawState>,
+    /// A newly processed frame changed the active presentation buffer. Kept
+    /// separate from the render methods' boolean ("a frame was processed") so
+    /// recordings still receive exact duplicate frames.
+    main_presentation_dirty: bool,
     /// Transient on-screen overlay message (screenshot saved, disk
     /// swapped), or None when nothing is being shown.
     osd: Option<Osd>,
@@ -1050,6 +1059,11 @@ struct RenderWorkerResult {
     generation: u64,
     emulated_frame: u64,
     timing: VideoRenderFrameTiming,
+    /// The worker proved this frame's complete render/presentation inputs
+    /// identical to the previous progressive frame. `presentation_fb` is then
+    /// merely the unused recycle buffer from the job; the main thread keeps
+    /// presenting its current buffer without copying it.
+    reused_previous: bool,
     presentation_fb: Vec<u32>,
     present_rows: usize,
     present_width: usize,
@@ -1060,6 +1074,19 @@ struct RenderWorkerResult {
     programmable: bool,
     /// The job's frame snapshot, handed back for buffer reuse.
     input: bitplane::RenderInput,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct MainRedrawState {
+    status: FrontPanelStatus,
+    media: MediaBar,
+    powered_on: bool,
+    paused: bool,
+    joystick_input_mode: JoystickInputMode,
+    control_connected: bool,
+    recording: bool,
+    input_recording: bool,
+    warp: bool,
 }
 
 struct RenderWorker {
@@ -1077,6 +1104,7 @@ impl RenderWorker {
             .spawn(move || {
                 let mut fb = vec![0u32; MAX_CANVAS_PIXELS];
                 let mut deinterlacer = Deinterlacer::new();
+                let mut repeated_frame_cache = RepeatedPresentationCache::default();
                 let mut last_generation = None;
                 while let Ok(job) = job_rx.recv() {
                     // A generation bump marks a presentation discontinuity
@@ -1084,9 +1112,15 @@ impl RenderWorker {
                     // previous stream may weave or glow into this frame.
                     if last_generation != Some(job.generation) {
                         deinterlacer.reset_history();
+                        repeated_frame_cache.clear();
                         last_generation = Some(job.generation);
                     }
-                    let result = render_job_to_presentation(job, &mut fb, &mut deinterlacer);
+                    let result = render_job_to_presentation(
+                        job,
+                        &mut fb,
+                        &mut deinterlacer,
+                        &mut repeated_frame_cache,
+                    );
                     if result_tx.send(result).is_err() {
                         break;
                     }
@@ -1312,6 +1346,8 @@ impl App {
             last_submitted_render_frame: None,
             render_generation: 0,
             last_fdd_track: None,
+            last_main_redraw_state: None,
+            main_presentation_dirty: true,
             osd: None,
             drop_hover: false,
             pending_dropped_files: Vec::new(),
@@ -3460,10 +3496,23 @@ impl ApplicationHandler for App {
         // Skipping request_redraw for headless capture avoids the vsync gate so
         // the run advances as fast as the host allows; emulated state is
         // identical either way. (`headless_capture` was resolved above, before
-        // the step, to decide the warp burst.) Only the emulator window tracks
-        // every presented frame; tool windows were paced above.
-        if rendered && !headless_capture {
-            self.request_main_redraw();
+        // the step, to decide the warp burst.) When the exact presentation and
+        // the window chrome are both unchanged, retain the existing GPU texture
+        // instead of uploading/presenting it again at the field rate.
+        if !headless_capture {
+            let redraw_state = self.main_redraw_state();
+            let chrome_changed = self.last_main_redraw_state != Some(redraw_state);
+            if self.main_presentation_dirty
+                || chrome_changed
+                || self.ui.active()
+                || self.drop_hover
+                || osd_active
+                || calibrating
+            {
+                self.last_main_redraw_state = Some(redraw_state);
+                self.main_presentation_dirty = false;
+                self.request_main_redraw();
+            }
         }
 
         if self.dump_frame_if_due() {
@@ -4070,6 +4119,34 @@ impl App {
         });
         let cd = bus.cd_drive_present().then(|| bus.cd_disc_inserted());
         MediaBar { drives, cd }
+    }
+
+    fn main_redraw_state(&self) -> MainRedrawState {
+        let mut status = self.emu.bus().front_panel_status();
+        if status.fdd_track.is_none() {
+            status.fdd_track = self.last_fdd_track;
+        }
+        let control_connected = {
+            #[cfg(feature = "control")]
+            {
+                self.control.as_ref().is_some_and(|c| c.handle.connected())
+            }
+            #[cfg(not(feature = "control"))]
+            {
+                false
+            }
+        };
+        MainRedrawState {
+            status,
+            media: self.media_bar(),
+            powered_on: self.powered_on,
+            paused: self.paused,
+            joystick_input_mode: self.joystick_input_mode,
+            control_connected,
+            recording: self.recorder.is_some(),
+            input_recording: self.input_recorder.is_some(),
+            warp: !self.emu.paced(),
+        }
     }
 
     fn main_ui_control_at(&self, pos: (i32, i32)) -> Option<UiControl> {
@@ -9141,6 +9218,8 @@ impl App {
         self.last_rendered_emulated_frame = None;
         self.last_submitted_render_frame = None;
         self.presentation_latch.reset();
+        self.last_main_redraw_state = None;
+        self.main_presentation_dirty = true;
         let _ = self.collect_threaded_render_results(false);
     }
 
@@ -9157,14 +9236,39 @@ impl App {
             return false;
         }
 
+        if result.reused_previous {
+            self.render_recycle_fb = result.presentation_fb;
+            self.last_rendered_emulated_frame = Some(result.emulated_frame);
+            return true;
+        }
+
         self.emu.bus_mut().record_video_render_frame(result.timing);
+        let next_tv_aperture_rows = self
+            .presentation_latch
+            .resolve_tv_aperture(result.tv_aperture);
+        let unchanged = self.rtg_present_dims.is_none()
+            && self.present_tv_aperture_rows == next_tv_aperture_rows
+            && self.present_programmable == result.programmable
+            && presentation_pixels_equal(
+                &self.present_fb,
+                self.present_rows,
+                self.present_width,
+                &result.presentation_fb,
+                result.present_rows,
+                result.present_width,
+            );
+        if unchanged {
+            self.render_recycle_fb = result.presentation_fb;
+            self.last_rendered_emulated_frame = Some(result.emulated_frame);
+            return true;
+        }
+
+        self.main_presentation_dirty = true;
         let old = std::mem::replace(&mut self.present_fb, result.presentation_fb);
         self.render_recycle_fb = old;
         self.present_rows = result.present_rows;
         self.present_width = result.present_width;
-        self.present_tv_aperture_rows = self
-            .presentation_latch
-            .resolve_tv_aperture(result.tv_aperture);
+        self.present_tv_aperture_rows = next_tv_aperture_rows;
         self.present_programmable = result.programmable;
         self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(result.emulated_frame);
@@ -9292,6 +9396,7 @@ impl App {
         // resolution through the RTG texture, while `present_fb` keeps the
         // FB_WIDTH version the screenshot path reads.
         self.rtg_present_dims = Some((native_w, native_h));
+        self.main_presentation_dirty = true;
         self.present_rows = rows;
         self.present_width = FB_WIDTH;
         self.present_tv_aperture_rows = None;
@@ -9351,6 +9456,7 @@ impl App {
         let base = self.emu.bus().frame_render_base();
         // Standard 15 kHz fields line-double / weave to 2x rows; a
         // programmable progressive scan already carries every line.
+        let mut next_present_fb = std::mem::take(&mut self.render_recycle_fb);
         let (rows, width) = self.deinterlacer.present_field_into(
             &self.fb,
             field_rows,
@@ -9358,18 +9464,33 @@ impl App {
             base.bplcon0 & 0x0004 != 0,
             base.long_field,
             !geometry.programmable,
-            &mut self.present_fb,
+            &mut next_present_fb,
         );
-        self.present_rows = rows;
-        self.present_width = width;
-        self.present_tv_aperture_rows =
-            self.presentation_latch
-                .resolve_tv_aperture(standard_tv_aperture_frame(
-                    geometry,
-                    self.present_rows,
-                    &base,
-                ));
-        self.present_programmable = geometry.programmable;
+        let next_tv_aperture_rows = self
+            .presentation_latch
+            .resolve_tv_aperture(standard_tv_aperture_frame(geometry, rows, &base));
+        let unchanged = self.rtg_present_dims.is_none()
+            && self.present_tv_aperture_rows == next_tv_aperture_rows
+            && self.present_programmable == geometry.programmable
+            && presentation_pixels_equal(
+                &self.present_fb,
+                self.present_rows,
+                self.present_width,
+                &next_present_fb,
+                rows,
+                width,
+            );
+        if unchanged {
+            self.render_recycle_fb = next_present_fb;
+        } else {
+            self.main_presentation_dirty = true;
+            let old = std::mem::replace(&mut self.present_fb, next_present_fb);
+            self.render_recycle_fb = old;
+            self.present_rows = rows;
+            self.present_width = width;
+            self.present_tv_aperture_rows = next_tv_aperture_rows;
+            self.present_programmable = geometry.programmable;
+        }
         self.rtg_present_dims = None;
         self.last_rendered_emulated_frame = Some(emulated_frame);
         self.last_submitted_render_frame = Some(emulated_frame);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -9395,6 +9395,15 @@ impl App {
         // The native frame stays in `rtg_fb`; the window presents it at full
         // resolution through the RTG texture, while `present_fb` keeps the
         // FB_WIDTH version the screenshot path reads.
+        if self.rtg_present_dims.is_none() {
+            // Entering RTG is a presentation discontinuity. Advance the
+            // generation so the render worker clears its chipset repeated-
+            // frame and deinterlace history before native output resumes;
+            // otherwise an exact pre-RTG input match could retain this RTG
+            // buffer instead of producing the first returning chipset frame.
+            self.render_generation = self.render_generation.wrapping_add(1);
+            self.presentation_latch.reset();
+        }
         self.rtg_present_dims = Some((native_w, native_h));
         self.main_presentation_dirty = true;
         self.present_rows = rows;

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -14,10 +14,87 @@ use crate::config::Tint;
 // the rest of the window module family keeps its unqualified names.
 pub(super) use crate::video::present_common::*;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct RepeatedPresentationSettings {
+    h_shift: usize,
+    overscan: Overscan,
+    deinterlace: bool,
+}
+
+#[derive(Clone, Copy)]
+struct RepeatedPresentationMetadata {
+    present_rows: usize,
+    present_width: usize,
+    tv_aperture: TvApertureFrame,
+    programmable: bool,
+}
+
+/// Exact previous-frame detector owned by the render worker. The bitplane
+/// detector compares every pixel-affecting captured input; this wrapper also
+/// covers the frontend presentation settings and retains the dimensions that
+/// accompany a reused buffer.
+#[derive(Default)]
+pub(super) struct RepeatedPresentationCache {
+    detector: bitplane::RepeatedFrameDetector,
+    settings: Option<RepeatedPresentationSettings>,
+    metadata: Option<RepeatedPresentationMetadata>,
+}
+
+impl RepeatedPresentationCache {
+    fn can_reuse(
+        &self,
+        input: &bitplane::RenderInput,
+        settings: RepeatedPresentationSettings,
+        phosphor: f32,
+    ) -> Option<RepeatedPresentationMetadata> {
+        // Phosphor deliberately changes the presented pixels on every field
+        // while its trail converges. Interlace is rejected by the bitplane
+        // detector because the deinterlacer's opposite field is history.
+        (phosphor == 0.0 && self.settings == Some(settings) && self.detector.can_reuse(input))
+            .then_some(self.metadata)
+            .flatten()
+    }
+
+    fn note_rendered(
+        &mut self,
+        input: &bitplane::RenderInput,
+        result: &mut bitplane::RenderResult,
+        settings: RepeatedPresentationSettings,
+        phosphor: f32,
+        metadata: RepeatedPresentationMetadata,
+    ) {
+        if phosphor == 0.0 {
+            self.detector.note_rendered(input, result);
+            self.settings = Some(settings);
+            self.metadata = Some(metadata);
+        } else {
+            self.clear();
+        }
+    }
+
+    fn should_track_read_dependencies(
+        &self,
+        input: &bitplane::RenderInput,
+        settings: RepeatedPresentationSettings,
+        phosphor: f32,
+    ) -> bool {
+        phosphor == 0.0
+            && self.settings == Some(settings)
+            && self.detector.should_track_read_dependencies(input)
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.detector.clear();
+        self.settings = None;
+        self.metadata = None;
+    }
+}
+
 pub(super) fn render_job_to_presentation(
     job: RenderJob,
     fb: &mut [u32],
     deinterlacer: &mut Deinterlacer,
+    repeated_frame_cache: &mut RepeatedPresentationCache,
 ) -> RenderWorkerResult {
     let RenderJob {
         generation,
@@ -30,7 +107,32 @@ pub(super) fn render_job_to_presentation(
     } = job;
     deinterlacer.set_deinterlace(deinterlace);
     deinterlacer.set_phosphor(phosphor);
-    let render_result = bitplane::render_from_input(&input, fb);
+    let settings = RepeatedPresentationSettings {
+        h_shift,
+        overscan,
+        deinterlace,
+    };
+    if let Some(metadata) = repeated_frame_cache.can_reuse(&input, settings, phosphor) {
+        return RenderWorkerResult {
+            generation,
+            emulated_frame: input.emulated_frames(),
+            timing: VideoRenderFrameTiming::default(),
+            reused_previous: true,
+            presentation_fb,
+            present_rows: metadata.present_rows,
+            present_width: metadata.present_width,
+            tv_aperture: metadata.tv_aperture,
+            programmable: metadata.programmable,
+            input,
+        };
+    }
+
+    let mut render_result =
+        if repeated_frame_cache.should_track_read_dependencies(&input, settings, phosphor) {
+            bitplane::render_from_input_tracking_reuse(&input, fb)
+        } else {
+            bitplane::render_from_input(&input, fb)
+        };
     let geometry = input.geometry();
     let canvas_scale = input.canvas_scale();
     let canvas_width = FB_WIDTH * canvas_scale;
@@ -55,16 +157,44 @@ pub(super) fn render_job_to_presentation(
         !geometry.programmable,
         &mut presentation_fb,
     );
-    RenderWorkerResult {
-        generation,
-        emulated_frame: input.emulated_frames(),
-        timing: render_result.timing,
-        presentation_fb,
+    let metadata = RepeatedPresentationMetadata {
         present_rows,
         present_width,
         tv_aperture: standard_tv_aperture_frame(geometry, present_rows, &base),
         programmable: geometry.programmable,
+    };
+    repeated_frame_cache.note_rendered(&input, &mut render_result, settings, phosphor, metadata);
+    RenderWorkerResult {
+        generation,
+        emulated_frame: input.emulated_frames(),
+        timing: render_result.timing,
+        reused_previous: false,
+        presentation_fb,
+        present_rows,
+        present_width,
+        tv_aperture: metadata.tv_aperture,
+        programmable: metadata.programmable,
         input,
+    }
+}
+
+pub(super) fn presentation_pixels_equal(
+    current: &[u32],
+    current_rows: usize,
+    current_width: usize,
+    next: &[u32],
+    next_rows: usize,
+    next_width: usize,
+) -> bool {
+    if current_rows != next_rows || current_width != next_width {
+        return false;
+    }
+    let Some(active) = next_rows.checked_mul(next_width) else {
+        return false;
+    };
+    match (current.get(..active), next.get(..active)) {
+        (Some(current), Some(next)) => current == next,
+        _ => false,
     }
 }
 

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11,7 +11,7 @@ use super::{
     copy_window_present_frame, draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect,
     host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_toggle_rect, led_row_rect,
     mask_present_frame_to_tv, paint_test_screen, parse_amiga_key, pause_button_rect,
-    power_button_rect, present_height, presentation_source_y_offset,
+    power_button_rect, present_height, presentation_pixels_equal, presentation_source_y_offset,
     raw_device_qualifier_family_held, raw_device_qualifier_rawkey, rawkey_is_held,
     rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
     short_status_error, shorten_status_paths, shot_button_rect, should_render_emulated_frame,
@@ -2001,6 +2001,26 @@ fn present_frame_copy_scales_texture_rows_at_hidpi() {
         pixel(&frame, 0, present_height() * scale - 1, scale),
         src[(OUT_HEIGHT - 1) * FB_WIDTH].to_le_bytes()
     );
+}
+
+#[test]
+fn exact_presentation_repeat_ignores_unused_capacity_but_not_pixels_or_geometry() {
+    let current = vec![1, 2, 3, 4, 0xAAAA, 0xBBBB];
+    let mut next = vec![1, 2, 3, 4, 0xCCCC, 0xDDDD];
+    assert!(presentation_pixels_equal(&current, 2, 2, &next, 2, 2));
+
+    next[3] ^= 1;
+    assert!(!presentation_pixels_equal(&current, 2, 2, &next, 2, 2));
+    assert!(!presentation_pixels_equal(&current, 2, 2, &current, 1, 4));
+    assert!(!presentation_pixels_equal(&current, 2, 2, &current, 2, 3));
+    assert!(!presentation_pixels_equal(
+        &current[..3],
+        2,
+        2,
+        &next[..3],
+        2,
+        2
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- fast-forward steady Copper WAIT comparator work during long 68k STOP spans, while retaining the normal DMA arbiter and exact wake-up/frame boundaries
- detect exact repeated progressive render inputs, including timed chip-RAM read dependencies, and skip the render/post-process/deinterlace pipeline when safe
- retain exact unchanged final presentation buffers and suppress main-window redraws when the picture and frontend chrome are unchanged
- extend the frontend-free benchmark report and document/test both optimizations

## Performance

All rows are 120 emulated seconds on the Framework Ultra 5 125H, compared immediately against main at aa878f3. Full render includes render, post-process, and deinterlace.

| Workload | Mode | main | branch | Change |
|---|---:|---:|---:|---:|
| A500 bundled AROS | core | 20.782s | 17.060s | -17.9% |
| A500 bundled AROS | full render | 38.002s | 34.799s | -8.4% |
| A1200, 8 MiB fast RAM, AmigaSYS3PlusAGA HDF | core | 34.562s | 34.114s | -1.3% |
| A1200, 8 MiB fast RAM, AmigaSYS3PlusAGA HDF | full render | 49.903s | 44.632s | -10.6% |

The A500 run found 5,305 unchanged presentations out of 6,000 and skipped 252 renders. The A1200/HDF run found 5,804 unchanged presentations out of 5,991 and skipped 2,669 renders. Render checksums were identical to main in both workloads.

The exact final-buffer hold also avoids the interactive texture upload/GPU present for unchanged output; that portion is intentionally not represented by the headless benchmark.

## Validation

- cargo test --quiet: 2,046 passed, 10 ignored; all other targets green
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check
- cargo check --no-default-features --features bench-bin --locked
- release benchmark checksums match main
- 30-second bundled-AROS headless screenshot is byte-identical: SHA-256 74ca491878ff70ebd36453e24e976a6d81ee55f871ed9306409cc05599fa9e6a
- MyST HTML documentation build
- ignored asset-backed image, RAM, and vAmigaTS integration tests pass

The full ignored release run also exercised the hardware probes; its only three failures were the expected Greaseweazle tests with no physical board attached.