### PR TITLE
floppy: various bug fixes/improvements to bridge mode 

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -565,6 +565,8 @@ floppy_sounds_volume = 100
 # for turbo (disk DMA transfers complete almost instantly). Mechanics
 # (motor spin-up, stepping) always run at real speed. Faster-than-real
 # loading is a compatibility trade-off; some software times its loading.
+# Applies to image-backed bays only: a physical drive's data rate is the
+# disk's own, so bridged bays always run at real speed.
 #
 # [floppy]
 # drives = 2

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -599,5 +599,5 @@ floppy_sounds_volume = 100
 #                                # default, skips the wait for the index and is
 #                                # appreciably quicker; stalling blocks the
 #                                # emulated machine until each track is ready
-# bridge_smart_speed = false
+# bridge_speed = 100             # serve captured tracks at 100/125/150%
 # bridge_auto_cache = false      # cache disk data while the drive is idle

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -565,8 +565,7 @@ floppy_sounds_volume = 100
 # for turbo (disk DMA transfers complete almost instantly). Mechanics
 # (motor spin-up, stepping) always run at real speed. Faster-than-real
 # loading is a compatibility trade-off; some software times its loading.
-# Applies to image-backed bays only: a physical drive's data rate is the
-# disk's own, so bridged bays always run at real speed.
+# Image-backed bays only; a physical drive has its own bridge_speed.
 #
 # [floppy]
 # drives = 2

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1047,9 +1047,7 @@ emulators: the operating system and most loaders tolerate them, but
 software that times its own loading against the beam, CIA timers, or music
 playback can break. The setting can be changed live from the runtime menu
 ("Floppy Speed") without restarting the machine. It applies to image-backed
-bays only: a physical drive on a bridge delivers cells at the disk's own
-rate, so bridged bays always run at real speed, and the launcher greys the
-Drive speed row when every fitted bay is physical.
+bays only; a physical drive has its own `bridge_speed`.
 
 Supported image formats: standard 901120-byte DD ADF, gzip-compressed
 images (ADZ), single file ZIP archives, DMS archives, UAE extended ADF, and

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -52,7 +52,7 @@ range checks as the equivalent TOML fields:
 | `--floppy-bridge-cable DFN SEL` | `[floppy.dfN] bridge_cable` | drive select: `a`/`b` (PC cable) or `0`-`3` (Shugart) |
 | `--floppy-bridge-mode DFN MODE` | `[floppy.dfN] bridge_mode` | how tracks are captured: `normal`, `compatible`, `stalling` |
 | `--floppy-bridge-density DFN D` | `[floppy.dfN] bridge_density` | force a density: `auto`, `dd`, `hd` |
-| `--floppy-bridge-smart-speed DFN` | `[floppy.dfN] bridge_smart_speed = true` | let the interface slow the drive between accesses |
+| `--floppy-bridge-speed DFN PCT` | `[floppy.dfN] bridge_speed` | serve captured tracks at `100`, `125`, or `150` percent of real speed |
 | `--floppy-bridge-auto-cache DFN` | `[floppy.dfN] bridge_auto_cache = true` | cache disk data while the drive is idle |
 | `--floppy-bridge-writable DFN` | `[floppy.dfN] write_protected = false` | allow writing to the real disk |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
@@ -1080,7 +1080,7 @@ write_protected = true       # emulator-level protection, on top of the tab
 # bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
 # bridge_density = "auto"        # auto/dd/hd
 # bridge_mode = "compatible"     # compatible/stalling
-# bridge_smart_speed = false     # driver-side variable-rate capture
+# bridge_speed = 100             # serve captured tracks at 100/125/150% of real speed
 # bridge_auto_cache = false      # read tracks ahead while the drive is idle
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1046,7 +1046,10 @@ Faster-than-real speeds are a compatibility trade-off, exactly as in other
 emulators: the operating system and most loaders tolerate them, but
 software that times its own loading against the beam, CIA timers, or music
 playback can break. The setting can be changed live from the runtime menu
-("Floppy Speed") without restarting the machine.
+("Floppy Speed") without restarting the machine. It applies to image-backed
+bays only: a physical drive on a bridge delivers cells at the disk's own
+rate, so bridged bays always run at real speed, and the launcher greys the
+Drive speed row when every fitted bay is physical.
 
 Supported image formats: standard 901120-byte DD ADF, gzip-compressed
 images (ADZ), single file ZIP archives, DMS archives, UAE extended ADF, and

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -258,16 +258,16 @@ deterministic as ever; it is the disk under it that is not.
 ## Speed
 
 Reading a track means waiting for the drive to capture a whole revolution,
-which takes as long as a revolution takes -- about 200 ms. A track already in
-hand is served from Copperline's own copy with no drive involvement at all,
-so software that re-reads a track it just read pays nothing.
+which takes as long as a revolution takes -- about 200 ms. A faithful
+recording -- index-aligned, or verified clean -- is kept and served from
+Copperline's own copy with no drive involvement at all, so software that
+re-reads such a track pays nothing, and `bridge_speed` can serve the
+recovered cells faster than the platter turns.
 
-Booting Workbench 1.3 from a real disk reads about 3.6 tracks a second
-against a physical ceiling of five, and reaches the CLI prompt in the same
-45 seconds the ADF takes. The head follows the emulated stepper, so the
-driver starts capturing while the guest is still settling, and nothing waits
-on the drive with the machine held still: the pointer keeps moving while a
-disk loads, as it does on a real Amiga.
+The head follows the emulated stepper, so the driver starts capturing while
+the guest is still settling, and nothing waits on the drive with the machine
+held still: the pointer keeps moving while a disk loads, as it does on a
+real Amiga.
 
 ## Troubleshooting
 

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -163,6 +163,12 @@ touch the platter twice. What auto-cache adds is the tracks the guest has
 minute or so, reading the rest of the disk once, then spins down. Later
 reads of anything it reached are served instantly.
 
+While the guest is actively loading, the cacher contends with it for the
+head -- each of its excursions costs a seek away and back -- so loading is
+audibly busier and somewhat slower than with auto-cache off. It pays for
+itself on what comes after: revisits, browsing, and a re-boot from the same
+disk.
+
 ## Write protection
 
 A real disk is protected twice over, and both have to be open before anything

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -157,6 +157,12 @@ tolerate it, but software that times its own loading can notice.
 idle. It is off by default: during a boot the drive is never idle, so there 
 is little for it to do, and it moves the real head about on its own.
 
+Every track the guest reads is kept in memory regardless -- re-reads never
+touch the platter twice. What auto-cache adds is the tracks the guest has
+*not* asked for: once the guest goes quiet, the drive carries on for up to a
+minute or so, reading the rest of the disk once, then spins down. Later
+reads of anything it reached are served instantly.
+
 ## Write protection
 
 A real disk is protected twice over, and both have to be open before anything

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -163,6 +163,11 @@ touch the platter twice. What auto-cache adds is the tracks the guest has
 minute or so, reading the rest of the disk once, then spins down. Later
 reads of anything it reached are served instantly.
 
+It stays out of the guest's way: while the guest is actively using the drive
+the cacher holds off, resuming a couple of seconds after the last access, so
+a loading game sounds -- and loads -- exactly as it does with auto-cache
+off.
+
 ## Write protection
 
 A real disk is protected twice over, and both have to be open before anything

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -115,6 +115,17 @@ config file too.
 wait for the index -- most of a revolution on every track it has not read
 before.
 
+A capture that begins away from the index has its two ends joined by the
+driver where the recording repeats, and that join is not always perfect.
+Copperline therefore verifies each capture before trusting it: one that
+decodes as a complete AmigaDOS track with every checksum passing -- join
+included -- is kept and replayed like an image's track, and anything less is
+served to the guest exactly once. A damaged or unrecognised recording is never
+shown twice: the retry the guest makes reaches the recording that followed,
+which is what recovering on a real drive means. The cost falls only where the
+verdict is less than clean -- a format the scan does not recognise is re-read
+from the disk when the guest returns to it, rather than answered from memory.
+
 The drive cannot always finish a capture in the revolution the guest takes to
 read the last one. When it has nothing newer, the recording just read is used
 again, and the guest meets a splice at the join: the sector straddling it fails

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -43,11 +43,6 @@ names the interface instead, with a **Configure** button leading to its
 settings. With nothing plugged in the row reads `Not connected`; plug the
 interface in and re-tick the box to pick it up.
 
-The Configure page's Interface row also offers **None** -- selected
-automatically when a bay is bridged with nothing attached. A bay whose
-interface is None keeps its tick box and its settings, but runs (and saves)
-as an ordinary unbridged bay until an interface is chosen.
-
 You can also define this in your .TOML file;
 
 ```toml
@@ -102,11 +97,7 @@ Every current interface connects over a serial port, and every one of them
 can be found automatically, which is the default. Name `bridge_port`
 explicitly to pin a particular device when more than one is attached.
 
-The launcher's list starts with **Automatic**, then the ports the library's
-own scan names, then every other serial device the host has. The long tail
-matters: an interface on a serial chip the scan does not recognise -- a
-DrawBridge built on an Arduino clone, say -- can still be pointed at by
-hand.
+The launcher lists **Automatic**, then every serial device the host has.
 
 ### Drive select
 
@@ -127,14 +118,11 @@ before.
 
 A capture that begins away from the index has its two ends joined by the
 driver where the recording repeats, and that join is not always perfect.
-Copperline therefore verifies each capture before trusting it: one that
-decodes as a complete AmigaDOS track with every checksum passing -- join
-included -- is kept and replayed like an image's track, and anything less is
-served to the guest exactly once. A damaged or unrecognised recording is never
-shown twice: the retry the guest makes reaches the recording that followed,
-which is what recovering on a real drive means. The cost falls only where the
-verdict is less than clean -- a format the scan does not recognise is re-read
-from the disk when the guest returns to it, rather than answered from memory.
+Copperline verifies each capture: one that decodes as a complete AmigaDOS
+track with every checksum passing is kept and replayed like an image's
+track; anything less -- damaged, or a format the scan does not recognise --
+is served once and fetched afresh on the next visit, so a retry always
+reads new data.
 
 The drive cannot always finish a capture in the revolution the guest takes to
 read the last one. When it has nothing newer, the recording just read is used
@@ -155,13 +143,10 @@ emulated machine, which stops -- pointer and all -- for as long as it takes.
 
 ### Bridge speed and auto-cache
 
-`bridge_speed` serves each captured revolution at `100` (real, the default),
-`125`, or `150` percent of the platter's real speed. The capture itself is
-untouched -- reading a track off the disk still takes as long as a revolution
-takes -- but the recovered cells reach the guest proportionally faster, so
-rotational waits on tracks already in hand shrink. The trade is the same as
-the image drives' `[floppy] speed`: the operating system and most loaders
-tolerate it, but software that times its own loading can notice.
+`bridge_speed` serves captured tracks at `100` (real, the default), `125`,
+or `150` percent of real speed. Capturing still takes a full revolution;
+only the serving is faster. The trade is the same as `[floppy] speed`:
+software that times its own loading can notice.
 
 `bridge_auto_cache` caches disk data in the background while the drive is
 idle. It is off by default: during a boot the drive is never idle, so there 
@@ -174,10 +159,8 @@ minute or so, reading the rest of the disk once, then spins down. Later
 reads of anything it reached are served instantly.
 
 While the guest is actively loading, the cacher contends with it for the
-head -- each of its excursions costs a seek away and back -- so loading is
-audibly busier and somewhat slower than with auto-cache off. It pays for
-itself on what comes after: revisits, browsing, and a re-boot from the same
-disk.
+head, so loading is audibly busier and somewhat slower than with auto-cache
+off.
 
 ## Write protection
 
@@ -231,11 +214,8 @@ eject and swap buttons do nothing: Eject/insert disks as you would with an Amiga
 **No synthesized drive sounds.** The real drive makes its own noise. A bay in the 
 same machine running an ADF still sounds as it should when enabled.
 
-**The `[floppy] speed` option does not apply.** It shapes how fast a track is
-served from an image; a physical drive's data rate is the disk's own, and
-turbo cannot spin a real platter forward in zero time. Image bays in the same
-machine still honour it, and the launcher greys the Drive speed row when every
-fitted bay is physical.
+**The `[floppy] speed` option does not apply.** A physical drive is served
+at the disk's own rate; `bridge_speed` is its speed option.
 
 **Powering off releases the drive.** A real drive takes its power from the
 machine, and a bridged one behaves the same way: the power button hands the

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -163,11 +163,6 @@ touch the platter twice. What auto-cache adds is the tracks the guest has
 minute or so, reading the rest of the disk once, then spins down. Later
 reads of anything it reached are served instantly.
 
-It stays out of the guest's way: while the guest is actively using the drive
-the cacher holds off, resuming a couple of seconds after the last access, so
-a loading game sounds -- and loads -- exactly as it does with auto-cache
-off.
-
 ## Write protection
 
 A real disk is protected twice over, and both have to be open before anything

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -53,7 +53,7 @@ write_protected = true       # emulator-level protection; default true
 # bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
 # bridge_density = "auto"        # auto/dd/hd
 # bridge_mode = "normal"         # normal/compatible/stalling
-# bridge_smart_speed = false
+# bridge_speed = 100             # serve captured tracks at 100/125/150%
 # bridge_auto_cache = false
 ```
 
@@ -75,7 +75,7 @@ copperline --model A500 --floppy-bridge df0 greaseweazle kickstart.rom
 | `--floppy-bridge-cable DFN SEL` | `bridge_cable` |
 | `--floppy-bridge-mode DFN MODE` | `bridge_mode` |
 | `--floppy-bridge-density DFN D` | `bridge_density` |
-| `--floppy-bridge-smart-speed DFN` | `bridge_smart_speed = true` |
+| `--floppy-bridge-speed DFN PCT` | `bridge_speed = PCT` |
 | `--floppy-bridge-auto-cache DFN` | `bridge_auto_cache = true` |
 | `--floppy-bridge-writable DFN` | `write_protected = false` |
 
@@ -84,7 +84,7 @@ These layer on top of a config file as every other flag does, so
 the file gives it an image -- the flag says the bay *is* a physical drive, so the
 image it displaces is not a conflict. There is deliberately no flag for
 protecting a drive, because that is already the default. The remaining
-options -- density, read mode, smart speed, auto-cache, and profiles -- are
+options -- density, read mode, bridge speed, auto-cache, and profiles -- are
 config-file only; they describe a rig rather than a run.
 
 If a bay asks for a physical drive and it cannot be opened, Copperline
@@ -143,17 +143,19 @@ if a disk reads badly without the index to anchor it.
 until a track is ready instead of answering "not yet". The wait lands on the
 emulated machine, which stops -- pointer and all -- for as long as it takes.
 
-### Auto-cache and smart speed
+### Bridge speed and auto-cache
+
+`bridge_speed` serves each captured revolution at `100` (real, the default),
+`125`, or `150` percent of the platter's real speed. The capture itself is
+untouched -- reading a track off the disk still takes as long as a revolution
+takes -- but the recovered cells reach the guest proportionally faster, so
+rotational waits on tracks already in hand shrink. The trade is the same as
+the image drives' `[floppy] speed`: the operating system and most loaders
+tolerate it, but software that times its own loading can notice.
 
 `bridge_auto_cache` caches disk data in the background while the drive is
 idle. It is off by default: during a boot the drive is never idle, so there 
 is little for it to do, and it moves the real head about on its own.
-
-`bridge_smart_speed` lets the driver time each track and, where the data rate
-is uniform -- so nothing is leaning on the timing for copy protection -- offer
-it at a higher speed. It changes how the driver captures but not what
-Copperline does with the result: cell timing is derived from the length of the
-revolution handed back, so the per-cell speed it makes available goes unused.
 
 ## Write protection
 

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -207,6 +207,12 @@ eject and swap buttons do nothing: Eject/insert disks as you would with an Amiga
 **No synthesized drive sounds.** The real drive makes its own noise. A bay in the 
 same machine running an ADF still sounds as it should when enabled.
 
+**The `[floppy] speed` option does not apply.** It shapes how fast a track is
+served from an image; a physical drive's data rate is the disk's own, and
+turbo cannot spin a real platter forward in zero time. Image bays in the same
+machine still honour it, and the launcher greys the Drive speed row when every
+fitted bay is physical.
+
 **Powering off releases the drive.** A real drive takes its power from the
 machine, and a bridged one behaves the same way: the power button hands the
 interface back to the host, so it stops turning and another program -- or the

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -40,8 +40,13 @@ a newer one.
 From the launcher, the Floppy tab carries a **Physical drive** tick box for
 each bay. Tick it and the bay's media row stops offering a disk image and
 names the interface instead, with a **Configure** button leading to its
-settings. With nothing plugged in the row reads `None`; plug the interface in
-and re-tick the box to pick it up.
+settings. With nothing plugged in the row reads `Not connected`; plug the
+interface in and re-tick the box to pick it up.
+
+The Configure page's Interface row also offers **None** -- selected
+automatically when a bay is bridged with nothing attached. A bay whose
+interface is None keeps its tick box and its settings, but runs (and saves)
+as an ordinary unbridged bay until an interface is chosen.
 
 You can also define this in your .TOML file;
 
@@ -95,8 +100,13 @@ where you asked for your disk.
 
 Every current interface connects over a serial port, and every one of them
 can be found automatically, which is the default. Name `bridge_port`
-explicitly to pin a particular device when more than one is attached.The 
-launcher offers the ports the library enumerates.
+explicitly to pin a particular device when more than one is attached.
+
+The launcher's list starts with **Automatic**, then the ports the library's
+own scan names, then every other serial device the host has. The long tail
+matters: an interface on a serial chip the scan does not recognise -- a
+DrawBridge built on an Arduino clone, say -- can still be pointed at by
+hand.
 
 ### Drive select
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -317,8 +317,10 @@ The layout is:
   headed with the installed library and its version, for the serial port,
   drive select, density, read mode, bridge speed and auto-cache, greying
   whatever the chosen interface does not honour. With no interface attached
-  at all, everything on the page greys except the Interface row itself.
-  See [](floppybridge)),
+  at all, everything on the page greys except the Interface row itself,
+  which then reads **None** and leaves the bay running as unbridged until
+  an interface is chosen; the port list carries every serial device the
+  host has, not just the ones the library recognises. See [](floppybridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a row of buttons at the top
   links to three sub-pages: **CD** (image, insert delay, CD32 NVRAM); **Host

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -315,7 +315,7 @@ The layout is:
   floppy drive: its media row then names the interface -- or `None` with nothing
   plugged in -- and a **Configure** button opens that drive's own page,
   headed with the installed library and its version, for the serial port,
-  drive select, density, read mode, smart speed and auto-cache, greying
+  drive select, density, read mode, bridge speed and auto-cache, greying
   whatever the chosen interface does not honour. See [](floppybridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a row of buttons at the top

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -316,7 +316,9 @@ The layout is:
   plugged in -- and a **Configure** button opens that drive's own page,
   headed with the installed library and its version, for the serial port,
   drive select, density, read mode, bridge speed and auto-cache, greying
-  whatever the chosen interface does not honour. See [](floppybridge)),
+  whatever the chosen interface does not honour. With no interface attached
+  at all, everything on the page greys except the Interface row itself.
+  See [](floppybridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a row of buttons at the top
   links to three sub-pages: **CD** (image, insert delay, CD32 NVRAM); **Host

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -316,11 +316,7 @@ The layout is:
   plugged in -- and a **Configure** button opens that drive's own page,
   headed with the installed library and its version, for the serial port,
   drive select, density, read mode, bridge speed and auto-cache, greying
-  whatever the chosen interface does not honour. With no interface attached
-  at all, everything on the page greys except the Interface row itself,
-  which then reads **None** and leaves the bay running as unbridged until
-  an interface is chosen; the port list carries every serial device the
-  host has, not just the ones the library recognises. See [](floppybridge)),
+  whatever the chosen interface does not honour. See [](floppybridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a row of buttons at the top
   links to three sub-pages: **CD** (image, insert delay, CD32 NVRAM); **Host

--- a/src/config.rs
+++ b/src/config.rs
@@ -1099,12 +1099,13 @@ pub struct FloppyBridgeConfig {
     pub mode: BridgeSpeedMode,
     pub density: BridgeDensity,
     pub cable: BridgeCable,
-    /// Lets the driver time each track and, where the data rate is uniform --
-    /// so nothing is leaning on the timing for copy protection -- offer it at
-    /// a higher speed. It changes how the driver captures, but not what Copperline does with
-    /// the result: cell timing is derived from the length of the revolution it
-    /// hands back, so the per-cell speed this makes available goes unused.
-    pub smart_speed: bool,
+    /// How fast a captured revolution is served to the guest, as a
+    /// percentage of the platter's real speed: `100` (real, the default),
+    /// `125`, or `150`. Serving faster shortens rotational waits on tracks
+    /// already in hand; the physical capture itself still takes as long as a
+    /// revolution takes, and the same caveat applies as to `[floppy] speed`
+    /// -- software that times its own loading can notice.
+    pub speed: u16,
     /// Read tracks ahead in the background while the drive is otherwise idle.
     /// Off by default, as the driver has it. It buys little during
     /// a boot -- the drive is never idle then -- and moves the real head about
@@ -1124,7 +1125,7 @@ impl Default for FloppyBridgeConfig {
             mode: BridgeSpeedMode::default(),
             density: BridgeDensity::default(),
             cable: BridgeCable::default(),
-            smart_speed: false,
+            speed: 100,
             auto_cache: false,
         }
     }
@@ -1864,10 +1865,10 @@ pub struct ConfigOverrides {
     /// Force a density rather than sensing it (`--floppy-bridge-density DFN
     /// DENSITY`). Same as `[floppy.dfN] bridge_density`.
     pub floppy_bridge_density: [Option<String>; 4],
-    /// Let the interface offer uniformly-timed tracks at a higher speed
-    /// (`--floppy-bridge-smart-speed DFN`). Same as `[floppy.dfN]
-    /// bridge_smart_speed = true`.
-    pub floppy_bridge_smart_speed: [bool; 4],
+    /// Serve captured tracks at a percentage of real speed
+    /// (`--floppy-bridge-speed DFN PERCENT`). Same as `[floppy.dfN]
+    /// bridge_speed`.
+    pub floppy_bridge_speed: [Option<u16>; 4],
     /// Cache disk data while the drive is idle (`--floppy-bridge-auto-cache
     /// DFN`). Same as `[floppy.dfN] bridge_auto_cache = true`.
     pub floppy_bridge_auto_cache: [bool; 4],
@@ -1893,7 +1894,7 @@ impl ConfigOverrides {
             && self.floppy_bridge_cable.iter().all(Option::is_none)
             && self.floppy_bridge_mode.iter().all(Option::is_none)
             && self.floppy_bridge_density.iter().all(Option::is_none)
-            && !self.floppy_bridge_smart_speed.iter().any(|v| *v)
+            && self.floppy_bridge_speed.iter().all(Option::is_none)
             && !self.floppy_bridge_auto_cache.iter().any(|v| *v)
             && !self.floppy_bridge_writable.iter().any(|w| *w)
             && self.joystick.is_none()
@@ -1967,7 +1968,7 @@ impl ConfigOverrides {
                 && !self.floppy_bridge_writable[idx]
                 && self.floppy_bridge_mode[idx].is_none()
                 && self.floppy_bridge_density[idx].is_none()
-                && !self.floppy_bridge_smart_speed[idx]
+                && self.floppy_bridge_speed[idx].is_none()
                 && !self.floppy_bridge_auto_cache[idx]
             {
                 continue;
@@ -2009,8 +2010,8 @@ impl ConfigOverrides {
             if let Some(density) = &self.floppy_bridge_density[idx] {
                 drive.bridge_density = Some(density.clone());
             }
-            if self.floppy_bridge_smart_speed[idx] {
-                drive.bridge_smart_speed = Some(true);
+            if let Some(speed) = self.floppy_bridge_speed[idx] {
+                drive.bridge_speed = Some(speed);
             }
             if self.floppy_bridge_auto_cache[idx] {
                 drive.bridge_auto_cache = Some(true);
@@ -2803,10 +2804,10 @@ pub(crate) struct RawFloppyDrive {
     /// `0`..`3` (Shugart).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_cable: Option<String>,
-    /// Let the driver offer tracks whose data rate is uniform at a higher
-    /// speed. Off by default, as it can upset copy protection.
+    /// Serve captured tracks at this percentage of real speed: 100 (the
+    /// default), 125, or 150.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) bridge_smart_speed: Option<bool>,
+    pub(crate) bridge_speed: Option<u16>,
     /// Let the driver cache other cylinders while the disk is
     /// idle. Off by default: it keeps the real drive working continuously.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4474,6 +4475,15 @@ fn parse_floppy_bridge(idx: usize, spec: &str, raw: &RawFloppyDrive) -> Result<F
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
+    let speed = match raw.bridge_speed {
+        None => 100,
+        Some(p @ (100 | 125 | 150)) => p,
+        Some(other) => bail!(
+            "floppy.df{idx} bridge_speed = {other} is not a supported serving \
+             speed (100, 125, or 150)"
+        ),
+    };
+
     Ok(FloppyBridgeConfig {
         driver,
         write_protected: raw.write_protected.unwrap_or(true),
@@ -4481,7 +4491,7 @@ fn parse_floppy_bridge(idx: usize, spec: &str, raw: &RawFloppyDrive) -> Result<F
         mode,
         density,
         cable,
-        smart_speed: raw.bridge_smart_speed.unwrap_or(false),
+        speed,
         auto_cache: raw.bridge_auto_cache.unwrap_or(false),
     })
 }
@@ -6879,7 +6889,7 @@ mod tests {
             bridge_mode = "stalling"
             bridge_density = "hd"
             bridge_cable = "b"
-            bridge_smart_speed = true
+            bridge_speed = 125
         "#,
         )?;
         let df0 = cfg.floppy.bridges[0].as_ref().expect("df0 bridged");
@@ -6889,7 +6899,8 @@ mod tests {
         assert_eq!(df0.port, None);
         assert_eq!(df0.mode, BridgeSpeedMode::Normal);
         assert_eq!(df0.density, BridgeDensity::Auto);
-        assert!(!df0.smart_speed && !df0.auto_cache);
+        assert_eq!(df0.speed, 100);
+        assert!(!df0.auto_cache);
 
         let df1 = cfg.floppy.bridges[1].as_ref().expect("df1 bridged");
         assert_eq!(df1.driver, BridgeDriver::DrawBridge);
@@ -6897,12 +6908,30 @@ mod tests {
         assert_eq!(df1.mode, BridgeSpeedMode::Stalling);
         assert_eq!(df1.density, BridgeDensity::Hd);
         assert_eq!(df1.cable, BridgeCable::DriveB);
-        assert!(df1.smart_speed);
+        assert_eq!(df1.speed, 125);
 
         // Bridging a bay wires the drive in, and leaves it with no image.
         assert!(cfg.floppy.drives[0].is_none());
         assert!(cfg.floppy_connected[0] && cfg.floppy_connected[1]);
         Ok(())
+    }
+
+    /// Only the three supported serving speeds are accepted, by name in the
+    /// error so a typo explains itself.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_speed_rejects_unsupported_values() {
+        let err = parse_config(
+            r#"
+            [floppy.df0]
+            bridge = "greaseweazle"
+            bridge_speed = 120
+        "#,
+        )
+        .expect_err("120 is not a supported serving speed");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("bridge_speed"), "unexpected error: {msg}");
+        assert!(msg.contains("125"), "names the accepted values: {msg}");
     }
 
     // A build without the feature has no bridges to configure: the keys are

--- a/src/config.rs
+++ b/src/config.rs
@@ -1085,6 +1085,11 @@ pub enum BridgeCable {
 ///
 /// Held apart from [`FloppyDriveConfig`] because a bridged drive has no image
 /// path: whichever of the two is present for a bay supplies its media.
+/// Serving speeds a bridged bay accepts, as percentages of the platter's
+/// real speed. Shared by the config parser, the CLI, and the launcher's
+/// cycle row so all three offer the same set.
+pub const SUPPORTED_BRIDGE_SPEED_PERCENTS: [u16; 3] = [100, 125, 150];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FloppyBridgeConfig {
     pub driver: BridgeDriver,
@@ -4477,7 +4482,7 @@ fn parse_floppy_bridge(idx: usize, spec: &str, raw: &RawFloppyDrive) -> Result<F
 
     let speed = match raw.bridge_speed {
         None => 100,
-        Some(p @ (100 | 125 | 150)) => p,
+        Some(p) if SUPPORTED_BRIDGE_SPEED_PERCENTS.contains(&p) => p,
         Some(other) => bail!(
             "floppy.df{idx} bridge_speed = {other} is not a supported serving \
              speed (100, 125, or 150)"

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2006,7 +2006,6 @@ pub(crate) fn attach_floppy_bridges(floppy: &mut FloppyController, cfg: &Config)
                 BridgeCable::Shugart3 => DriveSelection::Drive3,
             },
             port: bridge_cfg.port.clone(),
-            smart_speed: bridge_cfg.smart_speed,
             auto_cache: bridge_cfg.auto_cache,
         };
         let bridge = Bridge::open(&open)
@@ -2051,7 +2050,7 @@ pub(crate) fn attach_floppy_bridges(floppy: &mut FloppyController, cfg: &Config)
                  set write_protected = false to write to the disk"
             );
         }
-        floppy.attach_bridge(idx, bridge, bridge_cfg.write_protected)?;
+        floppy.attach_bridge(idx, bridge, bridge_cfg.write_protected, bridge_cfg.speed)?;
     }
     Ok(())
 }

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -1936,6 +1936,14 @@ impl FloppyController {
                 drive.clamp_head();
                 return;
             }
+            // While the head is still travelling (or ringing after the last
+            // step) the guest cannot recover data anyway -- `head_bit` holds
+            // read-data back for exactly this window -- so asking the real
+            // drive for anything mid-seek only makes it abort a capture it
+            // will immediately restart. Stay quiet until the head settles.
+            if drive.seek_settle_cck > 0 {
+                return;
+            }
             // This runs from `tick`, so a track that is not ready would
             // otherwise be asked for millions of times a second. The driver
             // needs a whole revolution -- around 200ms -- to capture one, so

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -395,6 +395,25 @@ impl FloppyController {
         self.speed_percent == SPEED_TURBO
     }
 
+    /// The data-rate multiple `drive_idx` actually runs at. `[floppy] speed`
+    /// shapes how fast a track is served from an image; a physical drive's
+    /// data rate is the disk's own, and accelerating the emulated side of it
+    /// only makes the guest outrun the cells the drive is delivering. A
+    /// bridged bay therefore always runs at real speed.
+    fn drive_speed_multiplier(&self, drive_idx: usize) -> u32 {
+        if self.drives[drive_idx].is_bridged() {
+            1
+        } else {
+            self.speed_multiplier()
+        }
+    }
+
+    /// Whether turbo applies to `drive_idx`: never to a bridged bay, whose
+    /// platter cannot be spun forward in zero time.
+    fn drive_turbo(&self, drive_idx: usize) -> bool {
+        self.turbo() && !self.drives[drive_idx].is_bridged()
+    }
+
     pub fn cia_a_status_bits(&self) -> u8 {
         let Some(idx) = self.selected_drive() else {
             return CIAA_DSKCHANGE | CIAA_DSKPROT | CIAA_DSKTRACK0 | CIAA_DSKRDY;
@@ -1127,8 +1146,9 @@ impl FloppyController {
         // shifter, sync detection, DSKBYTR, and DMA pacing) sees a whole
         // multiple of the elapsed time, leaving every per-cell decision
         // bit-identical to real speed. Mechanics (motor, seek, settle, index
-        // pulse width) above tick at real time regardless.
-        let data_cck = cck.saturating_mul(self.speed_multiplier());
+        // pulse width) above tick at real time regardless. A bridged bay is
+        // excluded: its data rate belongs to the real disk.
+        let data_cck = cck.saturating_mul(self.drive_speed_multiplier(idx));
         let mut irq = match active_dma {
             Some((dma_idx, _, true)) if dma_idx == idx => {
                 self.tick_write_dma(idx, data_cck, is_selected, chip_ram)
@@ -1168,6 +1188,12 @@ impl FloppyController {
             return false;
         }
         let (idx, write) = (dma.drive, dma.write);
+        // A physical platter cannot be spun forward in zero time: a burst
+        // against a bridged bay would hand the guest cells the drive has not
+        // delivered. That transfer stays on real-time pacing.
+        if self.drives[idx].is_bridged() {
+            return false;
+        }
         // Mechanics stay honest: a drive that is still spinning up or whose
         // head is settling after a step delivers no stable cells, so the
         // burst waits for it like real-time pacing would.
@@ -1409,7 +1435,7 @@ impl FloppyController {
     /// already spent) would pin STOP-state fast-forward to single steps for
     /// the whole spin-up, so those cases keep the normal-paced deadline.
     fn scale_prediction(&self, drive_idx: usize, cck: u32) -> u32 {
-        if self.turbo() {
+        if self.drive_turbo(drive_idx) {
             if self.turbo_grace_cck > 0 {
                 return cck.min(self.turbo_grace_cck).max(1);
             }
@@ -1419,7 +1445,7 @@ impl FloppyController {
             }
             return cck.max(1);
         }
-        (cck / self.speed_multiplier()).max(1)
+        (cck / self.drive_speed_multiplier(drive_idx)).max(1)
     }
 
     pub fn next_completion_cck(&self, dmacon: u16) -> Option<u32> {
@@ -1490,7 +1516,7 @@ impl FloppyController {
         // The platter spins at the data-rate multiple; turbo bursts do not
         // move the index prediction (they are bounded by the completion
         // prediction above, which already caps the fast-forward).
-        Some((raw / self.speed_multiplier()).max(1))
+        Some((raw / self.drive_speed_multiplier(idx)).max(1))
     }
 
     pub fn dma_active(&self, dmacon: u16) -> bool {

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -117,6 +117,11 @@ pub const SUPPORTED_SPEED_PERCENTS: [u16; 4] = [100, 200, 400, 800];
 /// `[floppy] speed` value selecting turbo mode.
 pub const SPEED_TURBO: u16 = 0;
 
+#[cfg(feature = "floppybridge")]
+fn default_bridge_speed_percent() -> u16 {
+    100
+}
+
 fn default_speed_percent() -> u16 {
     100
 }
@@ -612,13 +617,16 @@ impl FloppyController {
     }
 
     /// Put a real drive on `drive_idx`, replacing any mounted image. The
-    /// bridge supplies the track under the head from then on.
+    /// bridge supplies the track under the head from then on. `speed_percent`
+    /// is the serving speed from `[floppy.dfN] bridge_speed`, already
+    /// validated to 100, 125, or 150.
     #[cfg(feature = "floppybridge")]
     pub fn attach_bridge(
         &mut self,
         drive_idx: usize,
         bridge: crate::floppybridge::Bridge,
         write_protected: bool,
+        speed_percent: u16,
     ) -> Result<()> {
         ensure!(
             drive_idx < self.drives.len(),
@@ -633,6 +641,7 @@ impl FloppyController {
         drive.bridge_media = bridge.disk_in_drive();
         drive.write_protected_target =
             write_protected || (drive.bridge_media && drive.bridge_tab_write_protected);
+        drive.bridge_speed_percent = speed_percent.max(100);
         drive.bridge = Some(bridge);
         // Announce the swap so the guest re-reads rather than trusting
         // whatever it last saw in this drive.
@@ -2016,6 +2025,9 @@ impl FloppyController {
                     bridge.switch_buffer(side);
                 }
             }
+            // Read before the bridge is borrowed: the serving fit below needs
+            // it in both the capture and filler paths.
+            let serve_percent = u32::from(drive.bridge_speed_percent.max(100));
             let bridge = drive.bridge.as_mut().expect("checked above");
             if let Some((words, bits)) = bridge.read_track(cylinder, side) {
                 // The bridge hands back one whole revolution as a packed MFM
@@ -2024,7 +2036,10 @@ impl FloppyController {
                 // rotation gives the disk's own data rate: a slightly long or
                 // short track -- a drive running off-speed -- stays
                 // self-consistent, exactly as a captured image does.
-                let word_cck = Self::word_cck_for_track_words(words.len());
+                // `bridge_speed` compresses that fit, serving the same cells
+                // in proportionally less time.
+                let word_cck =
+                    (Self::word_cck_for_track_words(words.len()) * 100 / serve_percent).max(1);
                 // Whether this recording can be trusted beyond a single pass.
                 // An index-aligned capture can by construction. An index-less
                 // one is assembled by pattern-matching where the revolution
@@ -2125,7 +2140,7 @@ impl FloppyController {
                     let nominal = encoded_track_words();
                     drive.cached.revs = vec![TrackRev::filler(
                         nominal * 16,
-                        Self::word_cck_for_track_words(nominal),
+                        (Self::word_cck_for_track_words(nominal) * 100 / serve_percent).max(1),
                     )];
                     drive.bridge_filler_track = Some(track);
                     drive.bridge_rev_seamless = false;
@@ -2254,6 +2269,13 @@ struct FloppyDrive {
     #[cfg(feature = "floppybridge")]
     #[serde(skip)]
     bridge_rev_seamless: bool,
+    /// Serving speed for this bay, a percentage of the platter's real speed
+    /// (`bridge_speed`: 100, 125, or 150). Compresses the cck-per-word fit
+    /// when a captured revolution is served; the physical capture itself is
+    /// untouched, so only rotational waits shrink.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip, default = "default_bridge_speed_percent")]
+    bridge_speed_percent: u16,
     /// `elapsed_cck` when the drive was first asked for the track it is
     /// currently working on, and how many times it has been asked since. Only
     /// read to report how long a track took; 0 means "not waiting".
@@ -2307,6 +2329,8 @@ impl Default for FloppyDrive {
             bridge_rev_spent: false,
             #[cfg(feature = "floppybridge")]
             bridge_rev_seamless: true,
+            #[cfg(feature = "floppybridge")]
+            bridge_speed_percent: 100,
             image: None,
             #[cfg(feature = "floppybridge")]
             bridge: None,

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -1764,7 +1764,7 @@ impl FloppyController {
             // necessarily what was asked for.
             drive.cached_track = None;
             if let Some(known) = drive.bridge_tracks.get_mut(track) {
-                *known = None;
+                *known = BridgeTrack::Unknown;
             }
             return;
         }
@@ -1915,20 +1915,21 @@ impl FloppyController {
             if !drive.motor_on || drive.motor_cck < MOTOR_READY_CCK {
                 return;
             }
-            // Read off this disk before? Hand back what it said then. The
-            // platter cannot have changed underneath without the change line
-            // saying so or a write going through, and both empty this, so
-            // another rotation would only fetch the same bits again. A spent
-            // revolution is the exception: handing that back is precisely the
-            // same recording over again, which is what it may not be.
-            if let Some(known) = drive
-                .bridge_tracks
-                .get(track)
-                .filter(|_| !spent)
-                .and_then(Option::as_ref)
+            // Read off this disk before, and proven faithful? Hand back what
+            // it said then. The platter cannot have changed underneath
+            // without the change line saying so or a write going through, and
+            // both empty this, so another rotation would only fetch the same
+            // bits again. Only a kept recording qualifies: one that is
+            // index-aligned or verified clean, so its two ends genuinely meet
+            // and it can turn under the head like an image's track. A spent
+            // revolution is the exception even then: handing that back is
+            // precisely the same recording over again.
+            if let Some(BridgeTrack::Kept(known)) =
+                drive.bridge_tracks.get(track).filter(|_| !spent)
             {
                 drive.cached = known.clone();
                 drive.cached_track = Some(track);
+                drive.bridge_rev_seamless = true;
                 drive.bridge_filler_track = None;
                 drive.bridge_wait_since_cck = 0;
                 drive.bridge_attempts = 0;
@@ -1963,7 +1964,20 @@ impl FloppyController {
             // worse -- the drive cannot finish a capture every revolution, so
             // the guest is handed filler and starves. Ten good sectors beat
             // none. `compatible` is the mode that has no seam to begin with.
-            if spent {
+            //
+            // A return visit to a track whose recording was served but not
+            // kept is the same situation: what the driver still holds is the
+            // recording the guest already saw (and may have rejected), so
+            // retire it too -- the retry deserves the recording that
+            // followed, not the one that failed it.
+            // Once per wait, not once per poll: repeated switching while the
+            // drive is still capturing just cycles the two stale recordings.
+            let revisit_unverified = drive.cached_track != Some(track)
+                && matches!(
+                    drive.bridge_tracks.get(track),
+                    Some(BridgeTrack::Unverified)
+                );
+            if (spent || revisit_unverified) && drive.bridge_attempts == 1 {
                 if let Some(bridge) = drive.bridge.as_mut() {
                     bridge.switch_buffer(side);
                 }
@@ -1977,6 +1991,25 @@ impl FloppyController {
                 // short track -- a drive running off-speed -- stays
                 // self-consistent, exactly as a captured image does.
                 let word_cck = Self::word_cck_for_track_words(words.len());
+                // Whether this recording can be trusted beyond a single pass.
+                // An index-aligned capture can by construction. An index-less
+                // one is assembled by pattern-matching where the revolution
+                // repeats, and on a small fraction of captures that match is
+                // ambiguous and splices duplicated flux mid-track -- damage
+                // that is the capture's, not the disk's. A capture that
+                // decodes as a complete AmigaDOS track with every checksum
+                // passing (read as the ring it will be served as) is proven
+                // faithful, join included; anything else is served once and
+                // fetched afresh next time, so a retry always reaches new
+                // flux. Formats the scan does not recognise are simply never
+                // kept in index-less mode, which costs a re-read on revisit
+                // and never costs correctness.
+                let scan = crate::floppybridge::scan::scan_revolution(&words, bits);
+                let keep = bridge.index_aligned()
+                    || matches!(
+                        scan,
+                        crate::floppybridge::scan::RevolutionScan::CleanAmigaDos { .. }
+                    );
                 // How long the drive took, and how many times it had to be
                 // asked, is what separates a disk the head cannot read from an
                 // interface that is slow: a healthy DD track is one revolution,
@@ -1995,22 +2028,28 @@ impl FloppyController {
                     },
                     "floppybridge.df{idx} track {track} (cyl {cylinder} side {}) read: \
                      {bits} bits, {} words, {waited_ms}ms over {} attempt{}, \
-                     {word_cck} cck/word",
+                     {word_cck} cck/word, {scan:?}{}",
                     u8::from(side),
                     words.len(),
                     drive.bridge_attempts,
                     if drive.bridge_attempts == 1 { "" } else { "s" },
+                    if keep { "" } else { ", serving once" },
                 );
                 drive.bridge_wait_since_cck = 0;
                 drive.bridge_attempts = 0;
                 drive.cached.revs = vec![TrackRev::new(words, bits, word_cck)];
                 drive.bridge_rev_spent = false;
+                drive.bridge_rev_seamless = keep;
                 drive.cached_track = Some(track);
                 drive.bridge_filler_track = None;
                 if drive.bridge_tracks.len() <= track {
-                    drive.bridge_tracks.resize(track + 1, None);
+                    drive.bridge_tracks.resize(track + 1, BridgeTrack::Unknown);
                 }
-                drive.bridge_tracks[track] = Some(drive.cached.clone());
+                drive.bridge_tracks[track] = if keep {
+                    BridgeTrack::Kept(drive.cached.clone())
+                } else {
+                    BridgeTrack::Unverified
+                };
                 // A track that read is proof of a disk, whatever the sense line
                 // says a moment later.
                 drive.bridge_media = true;
@@ -2055,6 +2094,7 @@ impl FloppyController {
                         Self::word_cck_for_track_words(nominal),
                     )];
                     drive.bridge_filler_track = Some(track);
+                    drive.bridge_rev_seamless = false;
                     drive.clamp_head();
                 }
             }
@@ -2148,31 +2188,38 @@ struct FloppyDrive {
     #[cfg(feature = "floppybridge")]
     #[serde(skip)]
     bridge_filler_track: Option<usize>,
-    /// Revolutions already captured from the disk in a physical drive, by
-    /// track.
+    /// What is known about each track of the disk in a physical drive.
     ///
-    /// Capturing one costs a rotation of the platter -- about 200ms -- and the
-    /// guest revisits tracks constantly: booting Workbench 1.3 reads 63
-    /// distinct tracks 189 times, one of them fourteen times over. Keeping
-    /// what has already been read turns every return trip into a memory copy.
-    /// The whole disk is only a couple of megabytes, so nothing is evicted;
-    /// what does empty it is the disk changing or a track being written, since
-    /// those are the only ways what is on the platter stops matching. A drive
-    /// whose captures are not index-aligned reads past this once its
-    /// revolution is spent -- see [`Self::bridge_rev_spent`].
+    /// Capturing a revolution costs a rotation of the platter -- about 200ms
+    /// -- and the guest revisits tracks constantly: booting Workbench 1.3
+    /// reads 63 distinct tracks 189 times, one of them fourteen times over.
+    /// Keeping what has already been read turns every return trip into a
+    /// memory copy. The whole disk is only a couple of megabytes, so nothing
+    /// is evicted; what does empty it is the disk changing or a track being
+    /// written, since those are the only ways what is on the platter stops
+    /// matching. Only faithful recordings are kept, though -- see
+    /// [`BridgeTrack`] for what qualifies and why.
     #[cfg(feature = "floppybridge")]
     #[serde(skip)]
-    bridge_tracks: Vec<Option<CachedTrack>>,
+    bridge_tracks: Vec<BridgeTrack>,
     /// Which track [`Self::bridge_wait_since_cck`] is timing.
     #[cfg(feature = "floppybridge")]
     #[serde(skip)]
     bridge_wait_track: Option<usize>,
     /// The revolution in hand has been turned all the way round. Only ever set
-    /// for a physical drive whose captures do not start at the index: those
-    /// cannot be turned twice, so the next one has to be fetched.
+    /// for a physical drive serving a recording that cannot be trusted twice
+    /// -- see [`Self::bridge_rev_seamless`] -- so the next one is fetched.
     #[cfg(feature = "floppybridge")]
     #[serde(skip)]
     bridge_rev_spent: bool,
+    /// Whether the revolution under the head closes on itself: index-aligned,
+    /// verified clean, or restored from a kept recording. A revolution that
+    /// does not is good for exactly one pass -- its ends were read a rotation
+    /// apart, and any imperfection in how they were joined must not be shown
+    /// to the guest twice.
+    #[cfg(feature = "floppybridge")]
+    #[serde(skip)]
+    bridge_rev_seamless: bool,
     /// `elapsed_cck` when the drive was first asked for the track it is
     /// currently working on, and how many times it has been asked since. Only
     /// read to report how long a track took; 0 means "not waiting".
@@ -2224,6 +2271,8 @@ impl Default for FloppyDrive {
             bridge_wait_track: None,
             #[cfg(feature = "floppybridge")]
             bridge_rev_spent: false,
+            #[cfg(feature = "floppybridge")]
+            bridge_rev_seamless: true,
             image: None,
             #[cfg(feature = "floppybridge")]
             bridge: None,
@@ -2628,11 +2677,12 @@ impl FloppyDrive {
         if self.rotation_bit >= bit_len {
             self.rotation_bit = 0;
             self.rotation_rev = (self.rotation_rev + 1) % self.rev_count();
-            // A capture that did not begin at the index is good for exactly one
+            // A revolution that does not close on itself -- neither
+            // index-aligned nor verified clean -- is good for exactly one
             // pass under the head. Mark it done; `ensure_track` replaces it
             // with the recording that followed rather than turning it again.
             #[cfg(feature = "floppybridge")]
-            if self.bridge.as_ref().is_some_and(|b| !b.index_aligned()) {
+            if self.bridge.is_some() && !self.bridge_rev_seamless {
                 self.bridge_rev_spent = true;
             }
             // A single-word (or shorter) track is too short to raise an index.
@@ -2793,6 +2843,25 @@ impl TrackRev {
 #[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
 struct CachedTrack {
     revs: Vec<TrackRev>,
+}
+
+/// What a physical drive's track is known to hold. Only a faithful recording
+/// -- one whose two ends genuinely meet, so it can turn under the head like an
+/// image's track -- is worth remembering: an index-aligned capture is faithful
+/// by construction, and an index-less one only once it has been verified
+/// clean. An index-less capture that cannot be verified is served exactly once
+/// and marked, so a return visit asks the drive for the recording that
+/// followed it rather than being shown the same one again.
+#[cfg(feature = "floppybridge")]
+#[derive(Clone, Default)]
+enum BridgeTrack {
+    /// Never read since the disk went in.
+    #[default]
+    Unknown,
+    /// Served once, but not a recording to be trusted twice.
+    Unverified,
+    /// A faithful recording, replayable indefinitely.
+    Kept(CachedTrack),
 }
 
 impl CachedTrack {

--- a/src/floppybridge/ffi.rs
+++ b/src/floppybridge/ffi.rs
@@ -77,6 +77,10 @@ pub mod config_option {
     pub const COM_PORT: u32 = 0x02;
     pub const AUTO_DETECT_COMPORT: u32 = 0x04;
     pub const DRIVE_AB_CABLE: u32 = 0x08;
+    /// Upstream's smart-speed capability bit, mirrored so the bitmask stays
+    /// documented position for position. Copperline has no smart-speed
+    /// setting: its only effect upstream is on a speed channel
+    /// (`getMFMSpeed`) that Copperline never reads.
     pub const SMART_SPEED: u32 = 0x10;
     pub const SUPPORTS_SHUGART: u32 = 0x20;
 }
@@ -145,10 +149,6 @@ extern "C" {
         auto_detect: bool,
     ) -> bool;
     pub(super) fn BRIDGE_DriverSetCable2(handle: BridgeDriverHandle, drive: u8) -> bool;
-    pub(super) fn BRIDGE_DriverSetSmartSpeedEnabled(
-        handle: BridgeDriverHandle,
-        enabled: bool,
-    ) -> bool;
     pub(super) fn BRIDGE_DriverSetAutoCache(handle: BridgeDriverHandle, enabled: bool) -> bool;
 
     // --- drive state ---

--- a/src/floppybridge/mod.rs
+++ b/src/floppybridge/mod.rs
@@ -247,7 +247,6 @@ pub struct BridgeConfig {
     /// ([`config_option::AUTO_DETECT_COMPORT`]); name one to pin it, which
     /// matters when two interfaces are plugged in at once.
     pub port: Option<String>,
-    pub smart_speed: bool,
     pub auto_cache: bool,
 }
 
@@ -562,9 +561,6 @@ fn apply(handle: ffi::BridgeDriverHandle, config: &BridgeConfig) -> Vec<&'static
         }
         if !ffi::BRIDGE_DriverSetCable2(handle, config.drive as u8) {
             refused.push("drive select");
-        }
-        if !ffi::BRIDGE_DriverSetSmartSpeedEnabled(handle, config.smart_speed) {
-            refused.push("smart speed");
         }
         if !ffi::BRIDGE_DriverSetAutoCache(handle, config.auto_cache) {
             refused.push("auto-cache");

--- a/src/floppybridge/mod.rs
+++ b/src/floppybridge/mod.rs
@@ -196,19 +196,22 @@ pub fn drivers() -> Vec<DriverInfo> {
         .collect()
 }
 
-/// Whether an interface the library recognises is plugged in right now.
+/// Whether anything that could be an interface is plugged in right now.
 ///
-/// The port scan below only reports ports the library believes carry a
-/// supported board, so an empty list means there is nothing to drive a real
-/// disk with. Scanning walks the host's serial bus, so this is sampled at
-/// deliberate moments -- a bay being switched over to a real drive -- rather
-/// than every frame.
+/// The port scan below reports the host's USB serial devices, not boards it
+/// has identified -- no current interface can be told apart without opening
+/// it -- so a non-empty list means "possibly", and an empty one means there
+/// is nothing to drive a real disk with. Scanning walks the host's serial
+/// bus, so this is sampled at deliberate moments -- a bay being switched
+/// over to a real drive -- rather than every frame.
 pub fn interface_connected() -> bool {
     let _guard = lib_lock();
     !com_ports_locked().is_empty()
 }
 
-/// Serial ports the library can see, for the drivers that need one named.
+/// Serial ports the library can see -- the host's USB serial devices, which
+/// on macOS means the `tty.usb*`-prefixed ones only. The launcher widens
+/// this with the host's own list for the chips that convention misses.
 pub fn com_ports() -> Vec<String> {
     let _guard = lib_lock();
     com_ports_locked()

--- a/src/floppybridge/mod.rs
+++ b/src/floppybridge/mod.rs
@@ -23,12 +23,13 @@
 //! CPU, sprites, pointer and all -- every time the head moved, which is the
 //! one thing a real drive never does to a real Amiga.
 //!
-//! Because a revolution is served whole, it has to start where the real one
-//! does. That is why the bridge is opened in the library's `Compatible` mode,
-//! which captures from the index: a stream anchored anywhere else would wrap
-//! in the middle of a sector rather than in the gap between two, and the guest
-//! would see disk errors. Upstream's faster index-less modes suit an emulator
-//! that streams cells continuously off the drive, which this is not.
+//! Because a revolution is served whole, its two ends matter. A capture made
+//! in the library's `Compatible` mode starts at the index, so its ends meet in
+//! the gap between sectors and it can turn under the head indefinitely. The
+//! default `normal` mode captures wherever the head happens to be and the
+//! driver joins the ends where the recording repeats -- a join that is not
+//! always perfect, which is why [`scan`] verifies each such capture before the
+//! emulator trusts it beyond a single pass.
 //!
 //! Writing goes the same way round: [`Bridge::write_track`] hands the MFM over
 //! a word at a time at the rotational position the head would be passing, as a
@@ -64,6 +65,7 @@
 //! deterministic as ever, it is the disk under it that is not.
 
 mod ffi;
+pub mod scan;
 
 use std::ffi::{c_char, c_int, c_uint, c_void, CStr, CString};
 use std::sync::{Mutex, OnceLock};

--- a/src/floppybridge/scan.rs
+++ b/src/floppybridge/scan.rs
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Verifying a captured revolution before the emulator trusts it.
+//!
+//! A capture in the driver's index-less mode is assembled by pattern-matching
+//! where the revolution repeats, and on a small fraction of captures that
+//! match is ambiguous -- the cut lands a few dozen bits long and duplicated
+//! flux is spliced into the middle of the stream. The result decodes as a
+//! perfectly healthy track with exactly one sector's payload failing its
+//! checksum, which is not what the head passed over. Serving it once is
+//! harmless (the guest retries, as it would a genuine bad read); remembering
+//! it is not, because every retry would then be handed the same damage.
+//!
+//! This scan is how the emulator tells the two apart: a capture that decodes
+//! as a complete AmigaDOS track with every checksum passing is a faithful
+//! recording -- including across its own wrap point, since the scan reads the
+//! capture as the ring the emulator serves -- and can be kept and turned under
+//! the head indefinitely, exactly like an image's track. Anything less is
+//! served as it stands but fetched afresh when the track is wanted again.
+//!
+//! The scan is format-aware but not title-aware: AmigaDOS's sector layout and
+//! checksums are properties of the format on the platter, published in the
+//! hardware manuals, not of any program. A disk that is not AmigaDOS at all
+//! (a custom trackloader, a protection track) simply reports
+//! [`RevolutionScan::Unrecognised`] and is never judged.
+
+const MASK: u32 = 0x5555_5555;
+
+/// A DD AmigaDOS track carries 11 sectors, an HD track 22.
+const DD_SECTORS: usize = 11;
+const HD_SECTORS: usize = 22;
+
+/// What a captured revolution decoded as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevolutionScan {
+    /// A complete AmigaDOS track: the expected sector count for its density,
+    /// every header present and every checksum -- header and data -- passing,
+    /// read as a ring. A faithful recording of the platter.
+    CleanAmigaDos {
+        /// Sectors decoded (11 for DD, 22 for HD).
+        sectors: usize,
+    },
+    /// Recognisably AmigaDOS, but incomplete or failing a checksum: a sector
+    /// missing, or a payload that does not match its own checksum. One of
+    /// these per capture, mid-track, is the signature of a spliced capture.
+    DamagedAmigaDos {
+        /// Sectors whose header and data both check out.
+        good: usize,
+        /// The sector count the density implies (11 or 22).
+        expected: usize,
+    },
+    /// Not enough AmigaDOS structure to judge either way. Custom formats and
+    /// protection tracks land here and are deliberately not second-guessed.
+    Unrecognised,
+}
+
+/// Read one bit of the capture, as the ring the emulator serves it as.
+#[inline]
+fn bit_at(words: &[u16], bit_len: usize, i: usize) -> bool {
+    let i = i % bit_len;
+    words[i / 16] & (1 << (15 - (i % 16))) != 0
+}
+
+/// The 32 bits starting at `start`, crossing the wrap if needed.
+fn long_at(words: &[u16], bit_len: usize, start: usize) -> u32 {
+    let mut v = 0u32;
+    for k in 0..32 {
+        v = (v << 1) | u32::from(bit_at(words, bit_len, start + k));
+    }
+    v
+}
+
+/// Recombine an odd/even MFM long pair into the data long it encodes.
+#[inline]
+fn deinterleave(odd: u32, even: u32) -> u32 {
+    ((odd & MASK) << 1) | (even & MASK)
+}
+
+/// Decode every AmigaDOS sector in a captured revolution and classify the
+/// capture. `words` is the packed MFM, `bit_len` the ring length in bits.
+///
+/// The layout, from each pair of 0x4489 sync words: info long, label
+/// (4 longs), header checksum, data checksum, data (128 longs), each as MFM
+/// odd bits then even bits. Both checksums are the XOR of the masked MFM
+/// longs of the region they cover.
+pub fn scan_revolution(words: &[u16], bit_len: usize) -> RevolutionScan {
+    if bit_len < 64 || words.is_empty() || words.len() * 16 < bit_len {
+        return RevolutionScan::Unrecognised;
+    }
+
+    // Every sync-word position, found with a rolling 16-bit window over the
+    // ring (the extra 15 bits close the window across the wrap).
+    let mut syncs = Vec::new();
+    let mut window: u16 = 0;
+    for i in 0..bit_len + 15 {
+        window = (window << 1) | u16::from(bit_at(words, bit_len, i));
+        if i >= 15 && window == 0x4489 {
+            syncs.push((i - 15) % bit_len);
+        }
+    }
+
+    // A sector body follows a pair of adjacent syncs; step past both. Track
+    // which sector numbers arrived intact so a splice that lands in a header
+    // (removing the sector entirely) counts as damage, not as a short format.
+    let mut headers_valid = 0usize;
+    let mut good = [false; HD_SECTORS];
+    for &s in &syncs {
+        let next_is_sync = syncs.contains(&((s + 16) % bit_len));
+        let prev_is_sync = syncs.contains(&((s + bit_len - 16) % bit_len));
+        if !next_is_sync || prev_is_sync {
+            continue;
+        }
+        let body = s + 32;
+        let info_odd = long_at(words, bit_len, body);
+        let info_even = long_at(words, bit_len, body + 32);
+        let info = deinterleave(info_odd, info_even);
+        let [format, _track, sector, _to_gap] = info.to_be_bytes();
+        if format != 0xFF || sector as usize >= HD_SECTORS {
+            continue;
+        }
+
+        let mut hsum = (info_odd & MASK) ^ (info_even & MASK);
+        for l in 0..8 {
+            hsum ^= long_at(words, bit_len, body + 64 + l * 32) & MASK;
+        }
+        let stored_h = deinterleave(
+            long_at(words, bit_len, body + 320),
+            long_at(words, bit_len, body + 352),
+        );
+        if hsum != stored_h {
+            continue;
+        }
+        headers_valid += 1;
+
+        let data_start = body + 448;
+        let mut dsum = 0u32;
+        for l in 0..256 {
+            dsum ^= long_at(words, bit_len, data_start + l * 32) & MASK;
+        }
+        let stored_d = deinterleave(
+            long_at(words, bit_len, body + 384),
+            long_at(words, bit_len, body + 416),
+        );
+        if dsum == stored_d {
+            good[sector as usize] = true;
+        }
+    }
+
+    // The density decides the expected count: a DD capture cannot hold 22
+    // sectors, and an HD capture with only 11 intact is missing half.
+    let expected = if headers_valid > DD_SECTORS {
+        HD_SECTORS
+    } else {
+        DD_SECTORS
+    };
+    let good = good.iter().filter(|g| **g).count();
+
+    if good == expected {
+        RevolutionScan::CleanAmigaDos { sectors: good }
+    } else if headers_valid + 1 >= expected {
+        // Enough intact headers that this is unmistakably an AmigaDOS track;
+        // anything short of complete-and-verified is damage. `+ 1` because a
+        // splice can land in a header and take a whole sector with it.
+        RevolutionScan::DamagedAmigaDos { good, expected }
+    } else {
+        RevolutionScan::Unrecognised
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build one MFM sector as bits: sync pair, then the odd/even split
+    /// regions with correct checksums. Clock bits are left clear except in
+    /// the literal sync words, which is all the scan looks at.
+    fn encode_sector(track: u8, sector: u8, payload: &[u8; 512]) -> Vec<bool> {
+        let mut bits = Vec::new();
+        let mut push_word = |bits: &mut Vec<bool>, w: u16| {
+            for k in (0..16).rev() {
+                bits.push(w & (1 << k) != 0);
+            }
+        };
+        let push_long = |bits: &mut Vec<bool>, l: u32| {
+            for k in (0..32).rev() {
+                bits.push(l & (1 << k) != 0);
+            }
+        };
+        // Inter-sector gap and the sync pair.
+        push_word(&mut bits, 0x2AAA);
+        push_word(&mut bits, 0x4489);
+        push_word(&mut bits, 0x4489);
+
+        let info = u32::from_be_bytes([0xFF, track, sector, 1]);
+        let info_odd = (info >> 1) & MASK;
+        let info_even = info & MASK;
+        let label = [0u32; 4];
+        let label_odd = [0u32; 4];
+        let label_even = [0u32; 4];
+
+        let mut hsum = info_odd ^ info_even;
+        for l in 0..4 {
+            hsum ^= label_odd[l] ^ label_even[l];
+        }
+
+        let mut data_longs = [0u32; 128];
+        for (i, chunk) in payload.chunks(4).enumerate() {
+            data_longs[i] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+        let data_odd: Vec<u32> = data_longs.iter().map(|l| (l >> 1) & MASK).collect();
+        let data_even: Vec<u32> = data_longs.iter().map(|l| l & MASK).collect();
+        let mut dsum = 0u32;
+        for l in data_odd.iter().chain(data_even.iter()) {
+            dsum ^= l;
+        }
+
+        push_long(&mut bits, info_odd);
+        push_long(&mut bits, info_even);
+        for l in label_odd {
+            push_long(&mut bits, l);
+        }
+        for l in label_even {
+            push_long(&mut bits, l);
+        }
+        push_long(&mut bits, (hsum >> 1) & MASK);
+        push_long(&mut bits, hsum & MASK);
+        push_long(&mut bits, (dsum >> 1) & MASK);
+        push_long(&mut bits, dsum & MASK);
+        for l in &data_odd {
+            push_long(&mut bits, *l);
+        }
+        for l in &data_even {
+            push_long(&mut bits, *l);
+        }
+        bits
+    }
+
+    /// A full synthetic DD track, with a trailing gap, packed into words.
+    fn encode_track(track: u8) -> (Vec<u16>, usize) {
+        let mut bits = Vec::new();
+        for sector in 0..11u8 {
+            let mut payload = [0u8; 512];
+            payload[0] = sector;
+            payload[511] = track;
+            bits.extend(encode_sector(track, sector, &payload));
+        }
+        // Track gap.
+        for _ in 0..700 {
+            bits.push(false);
+            bits.push(true);
+        }
+        pack(&bits)
+    }
+
+    fn pack(bits: &[bool]) -> (Vec<u16>, usize) {
+        let mut words = vec![0u16; bits.len().div_ceil(16)];
+        for (i, b) in bits.iter().enumerate() {
+            if *b {
+                words[i / 16] |= 1 << (15 - (i % 16));
+            }
+        }
+        (words, bits.len())
+    }
+
+    fn flip_bit(words: &mut [u16], i: usize) {
+        words[i / 16] ^= 1 << (15 - (i % 16));
+    }
+
+    #[test]
+    fn a_clean_track_scans_clean() {
+        let (words, bit_len) = encode_track(40);
+        assert_eq!(
+            scan_revolution(&words, bit_len),
+            RevolutionScan::CleanAmigaDos { sectors: 11 }
+        );
+    }
+
+    /// The emulator serves a capture as a ring, so the scan must decode one
+    /// whose sectors straddle the wrap -- a coherent index-less capture looks
+    /// exactly like this.
+    #[test]
+    fn a_rotated_ring_still_scans_clean() {
+        let (words, bit_len) = encode_track(40);
+        let rot = bit_len / 3;
+        let mut bits = Vec::with_capacity(bit_len);
+        for i in 0..bit_len {
+            let j = (i + rot) % bit_len;
+            bits.push(words[j / 16] & (1 << (15 - (j % 16))) != 0);
+        }
+        let (rotated, bit_len) = pack(&bits);
+        assert_eq!(
+            scan_revolution(&rotated, bit_len),
+            RevolutionScan::CleanAmigaDos { sectors: 11 }
+        );
+    }
+
+    #[test]
+    fn a_flipped_payload_bit_is_damage() {
+        let (mut words, bit_len) = encode_track(40);
+        // Inside the first sector's data region: past gap+syncs (48 bits),
+        // info (64), label (256), checksums (128), into data -- offset chosen
+        // to land on a data (even-mask) bit, not a clock bit.
+        flip_bit(&mut words, 48 + 64 + 256 + 128 + 101);
+        assert_eq!(
+            scan_revolution(&words, bit_len),
+            RevolutionScan::DamagedAmigaDos {
+                good: 10,
+                expected: 11
+            }
+        );
+    }
+
+    #[test]
+    fn a_broken_header_is_damage_not_a_short_format() {
+        let (mut words, bit_len) = encode_track(40);
+        // Inside the first sector's info long, on a data (even-mask) bit: the
+        // header checksum fails, the sector vanishes entirely, and ten intact
+        // headers remain.
+        flip_bit(&mut words, 48 + 11);
+        assert_eq!(
+            scan_revolution(&words, bit_len),
+            RevolutionScan::DamagedAmigaDos {
+                good: 10,
+                expected: 11
+            }
+        );
+    }
+
+    /// The splice signature seen on hardware: duplicated flux inserted
+    /// mid-stream shifts everything after it, corrupting the sector it lands
+    /// in while later sectors recover at their own sync marks.
+    #[test]
+    fn inserted_bits_mid_sector_are_damage() {
+        let (words, bit_len) = encode_track(40);
+        let mut bits: Vec<bool> = (0..bit_len)
+            .map(|i| words[i / 16] & (1 << (15 - (i % 16))) != 0)
+            .collect();
+        // Duplicate 30 bits inside sector 5's payload.
+        let sector_len = bits.len() / 11;
+        let at = sector_len * 5 + 1000;
+        let dup: Vec<bool> = bits[at..at + 30].to_vec();
+        for (k, b) in dup.into_iter().enumerate() {
+            bits.insert(at + k, b);
+        }
+        let (words, bit_len) = pack(&bits);
+        let scan = scan_revolution(&words, bit_len);
+        assert!(
+            matches!(scan, RevolutionScan::DamagedAmigaDos { .. }),
+            "expected damage, got {scan:?}"
+        );
+    }
+
+    #[test]
+    fn noise_is_unrecognised() {
+        let mut words = vec![0u16; 6000];
+        for (i, w) in words.iter_mut().enumerate() {
+            *w = (i as u16).wrapping_mul(0x9E37) ^ 0x5A5A;
+        }
+        assert_eq!(scan_revolution(&words, 96000), RevolutionScan::Unrecognised);
+    }
+
+    #[test]
+    fn an_empty_capture_is_unrecognised() {
+        assert_eq!(scan_revolution(&[], 0), RevolutionScan::Unrecognised);
+    }
+}

--- a/src/floppybridge/scan.rs
+++ b/src/floppybridge/scan.rs
@@ -176,7 +176,7 @@ mod tests {
     /// the literal sync words, which is all the scan looks at.
     fn encode_sector(track: u8, sector: u8, payload: &[u8; 512]) -> Vec<bool> {
         let mut bits = Vec::new();
-        let mut push_word = |bits: &mut Vec<bool>, w: u16| {
+        let push_word = |bits: &mut Vec<bool>, w: u16| {
             for k in (0..16).rev() {
                 bits.push(w & (1 << k) != 0);
             }
@@ -194,7 +194,7 @@ mod tests {
         let info = u32::from_be_bytes([0xFF, track, sector, 1]);
         let info_odd = (info >> 1) & MASK;
         let info_even = info & MASK;
-        let label = [0u32; 4];
+        // An empty label area, as AmigaDOS leaves it.
         let label_odd = [0u32; 4];
         let label_even = [0u32; 4];
 

--- a/src/floppybridge/scan.rs
+++ b/src/floppybridge/scan.rs
@@ -30,6 +30,12 @@ const MASK: u32 = 0x5555_5555;
 const DD_SECTORS: usize = 11;
 const HD_SECTORS: usize = 22;
 
+/// Above this many bits, a revolution came off HD media. HD packs cells at
+/// twice the DD rate, so a DD revolution measures around 100,000 bits and an
+/// HD one around 200,000: the gap is wide enough that a drive running well
+/// off speed still lands on the right side of it.
+const HD_BIT_THRESHOLD: usize = 150_000;
+
 /// What a captured revolution decoded as.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RevolutionScan {
@@ -146,9 +152,11 @@ pub fn scan_revolution(words: &[u16], bit_len: usize) -> RevolutionScan {
         }
     }
 
-    // The density decides the expected count: a DD capture cannot hold 22
-    // sectors, and an HD capture with only 11 intact is missing half.
-    let expected = if headers_valid > DD_SECTORS {
+    // The density decides the expected count, and it is read from the
+    // revolution's own length rather than from how many headers survived:
+    // an HD track holding exactly eleven readable sectors is half missing,
+    // which counting headers would report as a whole DD track.
+    let expected = if bit_len > HD_BIT_THRESHOLD {
         HD_SECTORS
     } else {
         DD_SECTORS
@@ -237,15 +245,21 @@ mod tests {
 
     /// A full synthetic DD track, with a trailing gap, packed into words.
     fn encode_track(track: u8) -> (Vec<u16>, usize) {
+        encode_track_of(track, 11, 700)
+    }
+
+    /// `sectors` encoded sectors, then a gap of `gap_cells` cells -- enough
+    /// of a knob to build an HD-length revolution as well as a DD one.
+    fn encode_track_of(track: u8, sectors: u8, gap_cells: usize) -> (Vec<u16>, usize) {
         let mut bits = Vec::new();
-        for sector in 0..11u8 {
+        for sector in 0..sectors {
             let mut payload = [0u8; 512];
             payload[0] = sector;
             payload[511] = track;
             bits.extend(encode_sector(track, sector, &payload));
         }
         // Track gap.
-        for _ in 0..700 {
+        for _ in 0..gap_cells {
             bits.push(false);
             bits.push(true);
         }
@@ -347,6 +361,31 @@ mod tests {
         assert!(
             matches!(scan, RevolutionScan::DamagedAmigaDos { .. }),
             "expected damage, got {scan:?}"
+        );
+    }
+
+    /// An HD revolution carrying only eleven readable sectors is half
+    /// missing, not a whole DD track: the density comes from the
+    /// revolution's length, which damage does not change.
+    #[test]
+    fn a_half_lost_hd_track_is_not_a_clean_dd_one() {
+        // Eleven good sectors, padded out to an HD-length revolution.
+        let (words, bit_len) = encode_track_of(40, 11, 60_000);
+        assert!(bit_len > HD_BIT_THRESHOLD, "an HD-length capture");
+        assert!(
+            !matches!(
+                scan_revolution(&words, bit_len),
+                RevolutionScan::CleanAmigaDos { .. }
+            ),
+            "half a track must never scan clean"
+        );
+
+        // And a genuine HD track still does.
+        let (words, bit_len) = encode_track_of(40, 22, 8_000);
+        assert!(bit_len > HD_BIT_THRESHOLD, "an HD-length capture");
+        assert_eq!(
+            scan_revolution(&words, bit_len),
+            RevolutionScan::CleanAmigaDos { sectors: 22 }
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,11 +504,13 @@ where
                     Some(args.next().ok_or_else(|| anyhow!(USAGE))?);
             }
             #[cfg(feature = "floppybridge")]
-            "--floppy-bridge-smart-speed" => {
-                const USAGE: &str = "--floppy-bridge-smart-speed requires DFN";
+            "--floppy-bridge-speed" => {
+                const USAGE: &str = "--floppy-bridge-speed requires DFN PERCENT (100, 125, or 150)";
                 let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
-                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-smart-speed")?;
-                overrides.floppy_bridge_smart_speed[idx] = true;
+                let percent_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
+                let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-speed")?;
+                let percent: u16 = percent_s.parse().map_err(|_| anyhow!(USAGE))?;
+                overrides.floppy_bridge_speed[idx] = Some(percent);
             }
             #[cfg(feature = "floppybridge")]
             "--floppy-bridge-auto-cache" => {
@@ -1078,7 +1080,7 @@ fn print_help() {
          --floppy-bridge-cable DFN SEL  drive select on the cable: a/b (PC) or 0-3 (Shugart)\n  \
          --floppy-bridge-mode DFN MODE  how tracks are captured: normal, compatible, stalling\n  \
          --floppy-bridge-density DFN D  force a density: auto, dd, or hd\n  \
-         --floppy-bridge-smart-speed DFN  let the interface slow the drive between accesses\n  \
+         --floppy-bridge-speed DFN PCT  serve captured tracks at 100/125/150% of real speed\n  \
          --floppy-bridge-auto-cache DFN   cache disk data while the drive is idle\n  \
          --floppy-bridge-writable DFN   let the guest write to the physical disk (which is\n  \
          \x20                            write-protected unless asked otherwise)\n  ";
@@ -2612,8 +2614,9 @@ mod tests {
             "--floppy-bridge-density",
             "df1",
             "dd",
-            "--floppy-bridge-smart-speed",
+            "--floppy-bridge-speed",
             "df1",
+            "125",
             "--floppy-bridge-auto-cache",
             "df1",
         ])?;
@@ -2630,7 +2633,7 @@ mod tests {
         assert!(!bridge.write_protected);
         assert_eq!(bridge.mode, copperline::config::BridgeSpeedMode::Compatible);
         assert_eq!(bridge.density, copperline::config::BridgeDensity::Dd);
-        assert!(bridge.smart_speed);
+        assert_eq!(bridge.speed, 125);
         assert!(bridge.auto_cache);
         // Untouched bays stay as they were.
         assert!(cfg.floppy.bridges[0].is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,8 +509,7 @@ where
                 let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let percent_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-speed")?;
-                let percent: u16 = percent_s.parse().map_err(|_| anyhow!(USAGE))?;
-                overrides.floppy_bridge_speed[idx] = Some(percent);
+                overrides.floppy_bridge_speed[idx] = Some(parse_floppy_bridge_speed(&percent_s)?);
             }
             #[cfg(feature = "floppybridge")]
             "--floppy-bridge-auto-cache" => {
@@ -1247,6 +1246,16 @@ fn parse_floppy_speed(s: &str) -> Result<u16> {
     if speed != copperline::floppy::SPEED_TURBO
         && !copperline::floppy::SUPPORTED_SPEED_PERCENTS.contains(&speed)
     {
+        return Err(anyhow!(MSG));
+    }
+    Ok(speed)
+}
+
+#[cfg(feature = "floppybridge")]
+fn parse_floppy_bridge_speed(s: &str) -> Result<u16> {
+    const MSG: &str = "--floppy-bridge-speed PERCENT must be 100, 125, or 150";
+    let speed: u16 = s.trim().parse().map_err(|_| anyhow!(MSG))?;
+    if !copperline::config::SUPPORTED_BRIDGE_SPEED_PERCENTS.contains(&speed) {
         return Err(anyhow!(MSG));
     }
     Ok(speed)
@@ -2587,6 +2596,17 @@ mod tests {
         let err = validate_gdb_args(&args).unwrap_err();
         assert!(err.to_string().contains("--screenshot-after"), "{err:#}");
         Ok(())
+    }
+
+    /// An unsupported serving speed is refused where it is typed, naming
+    /// the values that work, rather than surfacing later from config parsing.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_speed_flag_refuses_an_unsupported_percentage() {
+        let err = parse(&["--floppy-bridge-speed", "df0", "120"])
+            .expect_err("120 is not a supported serving speed");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("100, 125, or 150"), "unexpected error: {msg}");
     }
 
     /// A real drive can be asked for entirely from the command line, with no

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -4149,8 +4149,10 @@ mod tests {
     #[cfg(feature = "floppybridge")]
     #[test]
     fn drive_speed_greys_when_every_fitted_bay_is_physical() {
-        let mut setup = MachineSetup::default();
-        setup.floppy_drives = 2;
+        let mut setup = MachineSetup {
+            floppy_drives: 2,
+            ..Default::default()
+        };
         assert_eq!(setup.disabled_reason(F::FloppySpeed), None);
 
         setup.set_drive_bridged(0, true);

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2063,6 +2063,14 @@ impl MachineSetup {
             F::Df1Image | F::Df1WriteProtect => reason(self.floppy_drives >= 2, "drive off"),
             F::Df2Image | F::Df2WriteProtect => reason(self.floppy_drives >= 3, "drive off"),
             F::Df3Image | F::Df3WriteProtect => reason(self.floppy_drives >= 4, "drive off"),
+            // Drive speed shapes how fast a track is served from an image; a
+            // real drive's data rate is the disk's own. With every fitted bay
+            // physical there is nothing for it to act on.
+            F::FloppySpeed => {
+                let any_image = self.floppy_drives == 0
+                    || (0..self.floppy_drives as usize).any(|i| self.df_bridge[i].is_none());
+                reason(any_image, "no image drives")
+            }
             // Shader strength only feeds the shader pass, which does not run when
             // the shader is off.
             F::ShaderStrength => reason(self.shader != ShaderMode::None, "shader off"),
@@ -3976,6 +3984,37 @@ mod tests {
             assert!(setup.disabled_reason(F::BridgePort).is_none());
             assert!(setup.disabled_reason(F::BridgeAutoCache).is_none());
         }
+    }
+
+    /// Drive speed acts on image bays only, so the row greys exactly when
+    /// every fitted bay is physical: one image bay anywhere keeps it live.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn drive_speed_greys_when_every_fitted_bay_is_physical() {
+        let mut setup = MachineSetup::default();
+        setup.floppy_drives = 2;
+        assert_eq!(setup.disabled_reason(F::FloppySpeed), None);
+
+        setup.set_drive_bridged(0, true);
+        assert_eq!(
+            setup.disabled_reason(F::FloppySpeed),
+            None,
+            "df1 is still an image bay"
+        );
+
+        setup.set_drive_bridged(1, true);
+        assert!(
+            setup.disabled_reason(F::FloppySpeed).is_some(),
+            "every fitted bay is physical"
+        );
+
+        // An unfitted bay's state does not count: df2 is not wired in.
+        setup.floppy_drives = 3;
+        assert_eq!(
+            setup.disabled_reason(F::FloppySpeed),
+            None,
+            "df2 is a fitted image bay again"
+        );
     }
 
     /// A bridged bay only names its interface when one is actually attached:

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -934,6 +934,75 @@ pub enum BridgeStatus {
     Attached,
 }
 
+/// Every serial device the host offers beyond the library's own scan. macOS:
+/// the callout (`cu.*`) devices -- the class made for originating
+/// connections, and the one that still names chips the scan's `tty.usb*`
+/// filter misses (an Arduino clone on a CH340 mounts as `tty.wchusbserial*`).
+/// Linux: the USB serial classes. Windows: nothing extra -- the library
+/// already walks every COM port through SetupAPI.
+#[cfg(feature = "floppybridge")]
+fn host_serial_ports() -> Vec<String> {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let Ok(dir) = std::fs::read_dir("/dev") else {
+            return Vec::new();
+        };
+        let wanted = |name: &str| {
+            if cfg!(target_os = "macos") {
+                name.starts_with("cu.")
+            } else {
+                name.starts_with("ttyACM") || name.starts_with("ttyUSB")
+            }
+        };
+        let mut ports: Vec<String> = dir
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| wanted(n))
+            .map(|n| format!("/dev/{n}"))
+            .collect();
+        ports.sort();
+        ports
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+/// "Automatic", then the library's scan in its own order, then the host
+/// devices it did not name. A macOS device counts as already named when the
+/// scan lists its `tty.` twin: `cu.usbmodem101` and `tty.usbmodem101` are
+/// one port, and the scan's spelling wins.
+fn merge_port_lists(library: Vec<String>, host: Vec<String>) -> Vec<Option<String>> {
+    let mut out: Vec<Option<String>> = std::iter::once(None)
+        .chain(library.iter().cloned().map(Some))
+        .collect();
+    for port in host {
+        let twin = port
+            .strip_prefix("/dev/cu.")
+            .map(|rest| format!("/dev/tty.{rest}"));
+        let named = library
+            .iter()
+            .any(|l| *l == port || twin.as_deref() == Some(l.as_str()));
+        if !named {
+            out.push(Some(port));
+        }
+    }
+    out
+}
+
+/// The combined port list, or the bare "Automatic" without the feature.
+fn sample_bridge_ports() -> Vec<Option<String>> {
+    #[cfg(feature = "floppybridge")]
+    {
+        merge_port_lists(crate::floppybridge::com_ports(), host_serial_ports())
+    }
+    #[cfg(not(feature = "floppybridge"))]
+    {
+        vec![None]
+    }
+}
+
 /// What the bridge can see of the host right now.
 fn bridge_status() -> BridgeStatus {
     #[cfg(feature = "floppybridge")]
@@ -1122,6 +1191,12 @@ pub struct MachineSetup {
     /// A real drive on this bay instead of an image. `None` is the ordinary
     /// image-backed drive.
     df_bridge: [Option<FloppyBridgeConfig>; 4],
+    /// The bay's interface is set to "None": still a physical-drive bay in
+    /// the launcher, but with no interface to drive it -- the run and the
+    /// written config treat it as unbridged. Selected automatically when a
+    /// bay is bridged with nothing attached, so the page tells the truth
+    /// from the first look.
+    df_bridge_none: [bool; 4],
     /// Which bay the FloppyBridge settings page is showing. The page itself is
     /// one set of rows; this says whose values they are.
     bridge_edit_drive: usize,
@@ -1130,6 +1205,12 @@ pub struct MachineSetup {
     /// so a board plugged in mid-session is picked up by unticking and
     /// re-ticking the box rather than by a scan every frame.
     bridge_status: BridgeStatus,
+    /// The serial ports on offer -- "Automatic", the library's scan, then
+    /// every host serial device the scan did not name. Sampled with
+    /// `bridge_status` at deliberate moments (opening the launcher, bridging
+    /// a bay, entering the configure page): the scan walks the serial bus,
+    /// which is not a per-frame activity.
+    bridge_ports: Vec<Option<String>>,
     // Hard disk. Each drive's optional volume-name override (directory mounts
     // only) sits in the matching `*_name` slot, paralleling the path slot. Boot
     // priority is edited on the Boot Priority sub-page and split across two
@@ -1306,8 +1387,12 @@ impl MachineSetup {
             df_playlists: cfg.floppy_playlists.clone(),
             df_write_protected,
             df_bridge: std::array::from_fn(|i| cfg.floppy.bridges[i].clone()),
+            // A config that names a bridge names an interface; "None" is a
+            // launcher-session state, never read from a file.
+            df_bridge_none: [false; 4],
             bridge_edit_drive: 0,
             bridge_status: bridge_status(),
+            bridge_ports: sample_bridge_ports(),
             ide_master: cfg.ide.master.as_ref().map(|d| d.path.clone()),
             ide_master_name: cfg.ide.master.as_ref().and_then(|d| d.volume_name.clone()),
             ide_master_bootpri: boot_priority_of(raw.ide.master.as_ref().and_then(|d| d.bootpri)),
@@ -1836,7 +1921,10 @@ impl MachineSetup {
         // A bay using a real drive writes its interface and settings instead
         // of an image; only the settings that differ from the cautious
         // defaults are emitted, so a saved config stays readable.
-        if let Some(bridge) = self.df_bridge[idx].as_ref() {
+        if let Some(bridge) = self.df_bridge[idx]
+            .as_ref()
+            .filter(|_| !self.df_bridge_none[idx])
+        {
             let default = FloppyBridgeConfig::default();
             return Some(RawFloppyDrive {
                 bridge: Some(bridge_driver_name(bridge.driver).to_string()),
@@ -2122,22 +2210,35 @@ impl MachineSetup {
             #[cfg(feature = "floppybridge")]
             F::BridgeDevice => reason(self.bridge_edit().is_some(), "no drive"),
             #[cfg(feature = "floppybridge")]
-            F::BridgePort
-            | F::BridgeCable
+            F::BridgeCable
             | F::BridgeDensity
             | F::BridgeSpeed
             | F::BridgeServeSpeed
             | F::BridgeAutoCache
                 if self.bridge_edit().is_none()
+                    || self.df_bridge_none[self.bridge_edit_drive]
                     || self.bridge_status == BridgeStatus::NoInterface =>
             {
                 Some("no interface")
             }
+            // The port row outlives the attachment check the rest answer to:
+            // an interface on a chip the library's scan does not name still
+            // has to be pointable-at by hand. It greys when the interface is
+            // "None", and when there is genuinely nothing to point at --
+            // the list holding only "Automatic".
             #[cfg(feature = "floppybridge")]
-            F::BridgePort => reason(
-                self.bridge_driver_supports(crate::floppybridge::config_option::COM_PORT),
-                "not on this interface",
-            ),
+            F::BridgePort => {
+                if self.bridge_edit().is_none() || self.df_bridge_none[self.bridge_edit_drive] {
+                    Some("no interface")
+                } else if self.bridge_ports.len() <= 1 {
+                    Some("no ports")
+                } else {
+                    reason(
+                        self.bridge_driver_supports(crate::floppybridge::config_option::COM_PORT),
+                        "not on this interface",
+                    )
+                }
+            }
             #[cfg(feature = "floppybridge")]
             F::BridgeCable => reason(
                 self.bridge_driver_supports(crate::floppybridge::config_option::DRIVE_AB_CABLE)
@@ -2392,9 +2493,11 @@ impl MachineSetup {
                     format!("{:.2}", self.phosphor)
                 }
             }
-            F::BridgeDevice => self
-                .bridge_edit()
-                .map_or_else(|| "(none)".to_string(), |c| c.driver.label().to_string()),
+            F::BridgeDevice => match self.bridge_edit() {
+                None => "(none)".to_string(),
+                Some(_) if self.df_bridge_none[self.bridge_edit_drive] => "None".to_string(),
+                Some(c) => c.driver.label().to_string(),
+            },
             F::BridgePort => match self.bridge_edit().and_then(|c| c.port.clone()) {
                 None => "Automatic".to_string(),
                 Some(p) => p,
@@ -2821,8 +2924,32 @@ impl MachineSetup {
                 self.audio_filter = cycle_slice(&AUDIO_FILTER_MODES, self.audio_filter, forward)
             }
             F::BridgeDevice => {
-                if let Some(c) = self.bridge_edit_mut() {
-                    c.driver = cycle_slice(&BRIDGE_DRIVERS, c.driver, forward);
+                // "None" sits before the first driver in the cycle: from it,
+                // forward reaches the first interface, backward the last.
+                let bay = self.bridge_edit_drive;
+                if self.bridge_edit().is_some() {
+                    if self.df_bridge_none[bay] {
+                        self.df_bridge_none[bay] = false;
+                        let end = if forward {
+                            BRIDGE_DRIVERS[0]
+                        } else {
+                            BRIDGE_DRIVERS[BRIDGE_DRIVERS.len() - 1]
+                        };
+                        if let Some(c) = self.bridge_edit_mut() {
+                            c.driver = end;
+                        }
+                    } else {
+                        let (first, last) =
+                            (BRIDGE_DRIVERS[0], BRIDGE_DRIVERS[BRIDGE_DRIVERS.len() - 1]);
+                        let at_edge = self
+                            .bridge_edit()
+                            .is_some_and(|c| c.driver == if forward { last } else { first });
+                        if at_edge {
+                            self.df_bridge_none[bay] = true;
+                        } else if let Some(c) = self.bridge_edit_mut() {
+                            c.driver = cycle_slice(&BRIDGE_DRIVERS, c.driver, forward);
+                        }
+                    }
                 }
             }
             F::BridgePort => {
@@ -3225,10 +3352,15 @@ impl MachineSetup {
             // Look again now: this is the moment the user expects to be told
             // whether there is anything on the other end.
             self.bridge_status = bridge_status();
+            self.bridge_ports = sample_bridge_ports();
+            // With nothing on the other end, the honest interface is "None";
+            // the row is there to change once something is plugged in.
+            self.df_bridge_none[idx] = self.bridge_status == BridgeStatus::NoInterface;
             // Wire the bay in, as choosing an image would.
             self.floppy_drives = self.floppy_drives.max(idx as u8 + 1);
         } else {
             self.df_bridge[idx] = None;
+            self.df_bridge_none[idx] = false;
         }
     }
 
@@ -3243,8 +3375,11 @@ impl MachineSetup {
         let Some(cfg) = self.df_bridge.get(idx).and_then(Option::as_ref) else {
             return "(none)".to_string();
         };
+        if self.df_bridge_none[idx] {
+            return "Not connected".to_string();
+        }
         match self.bridge_status {
-            BridgeStatus::NoInterface => "None".to_string(),
+            BridgeStatus::NoInterface => "Not connected".to_string(),
             BridgeStatus::Attached => cfg.driver.label().to_string(),
         }
     }
@@ -3304,16 +3439,17 @@ impl MachineSetup {
             .is_none_or(|d| d.supports(option))
     }
 
-    /// Serial ports the installed library can see, with "Automatic" first --
-    /// the default, and what every current interface supports. The names are
-    /// the host's own, so `/dev/cu.usbmodem101` on macOS, `/dev/ttyACM0` on
-    /// Linux, `COM3` on Windows.
+    /// Serial ports to offer, "Automatic" first -- the default, and what
+    /// every current interface supports. The library's own scan leads, then
+    /// every other serial device the host has, so an interface on a chip the
+    /// scan's naming misses -- an Arduino clone mounting as
+    /// `tty.wchusbserial*` on macOS, say -- can still be picked by hand. The
+    /// names are the host's own: `/dev/cu.usbmodem101` on macOS,
+    /// `/dev/ttyACM0` on Linux, `COM3` on Windows.
     fn bridge_port_options(&self) -> Vec<Option<String>> {
         #[cfg(feature = "floppybridge")]
         {
-            std::iter::once(None)
-                .chain(crate::floppybridge::com_ports().into_iter().map(Some))
-                .collect()
+            self.bridge_ports.clone()
         }
         #[cfg(not(feature = "floppybridge"))]
         {
@@ -3990,10 +4126,11 @@ mod tests {
         let mut setup = MachineSetup::default();
         setup.set_drive_bridged(0, true);
         setup.set_bridge_edit_drive(0);
-        // Capability greying is only reachable with an interface attached;
-        // without one the whole page greys first (see
+        // Capability greying is only reachable with an interface attached and
+        // selected; without one the whole page greys first (see
         // `bridge_page_greys_without_an_interface`).
         setup.bridge_status = BridgeStatus::Attached;
+        setup.df_bridge_none[0] = false;
 
         for (driver, cable_greyed) in [
             (crate::config::BridgeDriver::Greaseweazle, false),
@@ -4052,8 +4189,9 @@ mod tests {
         let mut setup = MachineSetup::default();
         setup.set_drive_bridged(0, true);
         setup.set_bridge_edit_drive(0);
+        // The port row answers to its own rules (tested below): it must stay
+        // pickable for an interface the library's scan cannot name.
         let all = [
-            F::BridgePort,
             F::BridgeCable,
             F::BridgeDensity,
             F::BridgeSpeed,
@@ -4061,6 +4199,7 @@ mod tests {
             F::BridgeAutoCache,
         ];
 
+        setup.df_bridge_none[0] = false;
         setup.bridge_status = BridgeStatus::NoInterface;
         assert_eq!(setup.disabled_reason(F::BridgeDevice), None);
         for f in all {
@@ -4075,6 +4214,27 @@ mod tests {
         for f in [F::BridgeDensity, F::BridgeSpeed, F::BridgeServeSpeed] {
             assert_eq!(setup.disabled_reason(f), None, "{f:?} greyed with one");
         }
+
+        // An interface of "None" greys the page whatever is attached, the
+        // port row included.
+        setup.df_bridge_none[0] = true;
+        assert_eq!(setup.disabled_reason(F::BridgeDevice), None);
+        for f in all {
+            assert!(
+                setup.disabled_reason(f).is_some(),
+                "{f:?} live with interface None"
+            );
+        }
+        assert!(setup.disabled_reason(F::BridgePort).is_some());
+        setup.df_bridge_none[0] = false;
+
+        // The port row greys exactly when there is nothing to point at:
+        // a list of just "Automatic". Pinned, not sampled -- the machine
+        // running this test has its own serial devices.
+        setup.bridge_ports = vec![None];
+        assert!(setup.disabled_reason(F::BridgePort).is_some());
+        setup.bridge_ports = vec![None, Some("/dev/cu.wchusbserial1420".to_string())];
+        assert_eq!(setup.disabled_reason(F::BridgePort), None);
 
         // The bay un-bridged underneath the page: nothing left to edit.
         setup.set_drive_bridged(0, false);
@@ -4094,6 +4254,7 @@ mod tests {
     fn a_bridged_bay_names_its_interface_only_when_one_is_attached() {
         let mut setup = MachineSetup::default();
         setup.set_drive_bridged(0, true);
+        setup.df_bridge_none[0] = false;
 
         setup.bridge_status = BridgeStatus::Attached;
         assert_eq!(
@@ -4102,10 +4263,60 @@ mod tests {
         );
 
         setup.bridge_status = BridgeStatus::NoInterface;
-        assert_eq!(setup.drive_bridge_label(0), "None");
+        assert_eq!(setup.drive_bridge_label(0), "Not connected");
+
+        // An interface of "None" reads the same: nothing is on the bay
+        // either way.
+        setup.bridge_status = BridgeStatus::Attached;
+        setup.df_bridge_none[0] = true;
+        assert_eq!(setup.drive_bridge_label(0), "Not connected");
 
         // An image-backed bay is not a bridge at all, connected or not.
         assert_eq!(setup.drive_bridge_label(1), "(none)");
+    }
+
+    /// An interface of "None" keeps the tick box and the page, but the built
+    /// config -- what a run uses and what a save writes -- carries no bridge:
+    /// the bay is effectively unbridged until an interface is chosen.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn a_none_interface_builds_an_unbridged_bay() {
+        let mut setup = MachineSetup::default();
+        setup.set_drive_bridged(0, true);
+        setup.df_bridge_none[0] = true;
+        let cfg = setup.build_config().expect("valid");
+        assert!(cfg.floppy.bridges[0].is_none(), "no bridge in the config");
+
+        setup.df_bridge_none[0] = false;
+        let cfg = setup.build_config().expect("valid");
+        assert!(
+            cfg.floppy.bridges[0].is_some(),
+            "an interface brings it back"
+        );
+    }
+
+    /// "Automatic" leads, the library's scan keeps its order, and host
+    /// devices join only when the scan did not already name them -- a macOS
+    /// `cu.` device counts as named when its `tty.` twin is listed.
+    #[test]
+    fn port_lists_merge_without_duplicates() {
+        let merged = merge_port_lists(
+            vec!["/dev/tty.usbmodem1101".to_string()],
+            vec![
+                "/dev/cu.Bluetooth-Incoming-Port".to_string(),
+                "/dev/cu.usbmodem1101".to_string(),
+                "/dev/cu.wchusbserial1420".to_string(),
+            ],
+        );
+        assert_eq!(
+            merged,
+            vec![
+                None,
+                Some("/dev/tty.usbmodem1101".to_string()),
+                Some("/dev/cu.Bluetooth-Incoming-Port".to_string()),
+                Some("/dev/cu.wchusbserial1420".to_string()),
+            ]
+        );
     }
 
     /// The write-protect box governs a real drive as well as an image, and it
@@ -4142,6 +4353,9 @@ mod tests {
     fn write_protect_governs_a_bridged_bay_and_survives_a_round_trip() {
         let mut setup = MachineSetup::default();
         setup.set_drive_bridged(0, true);
+        // Pin an interface: a hardware-less host auto-selects "None", which
+        // deliberately keeps the bridge out of the built config.
+        setup.df_bridge_none[0] = false;
         assert!(
             setup.toggle_value(F::Df0WriteProtect),
             "protected by default"

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2112,6 +2112,27 @@ impl MachineSetup {
             // when inactive (see `rows`), so they never need a greyed state.
             // Channel mode and separation shape the output, so they do nothing
             // once audio is disabled; separation also does nothing in mono.
+            // The bridge page follows what is actually there. A loaded config
+            // can pull the bay out from under the page, leaving nothing to
+            // edit: every row greys, the Interface one included. With the bay
+            // bridged but no interface attached (the media row's "None"),
+            // only the Interface row is worth touching -- the rest describe
+            // hardware that is not present, the serial port included, since
+            // its list is empty and "Automatic" alone is not a choice.
+            #[cfg(feature = "floppybridge")]
+            F::BridgeDevice => reason(self.bridge_edit().is_some(), "no drive"),
+            #[cfg(feature = "floppybridge")]
+            F::BridgePort
+            | F::BridgeCable
+            | F::BridgeDensity
+            | F::BridgeSpeed
+            | F::BridgeServeSpeed
+            | F::BridgeAutoCache
+                if self.bridge_edit().is_none()
+                    || self.bridge_status == BridgeStatus::NoInterface =>
+            {
+                Some("no interface")
+            }
             #[cfg(feature = "floppybridge")]
             F::BridgePort => reason(
                 self.bridge_driver_supports(crate::floppybridge::config_option::COM_PORT),
@@ -3969,6 +3990,10 @@ mod tests {
         let mut setup = MachineSetup::default();
         setup.set_drive_bridged(0, true);
         setup.set_bridge_edit_drive(0);
+        // Capability greying is only reachable with an interface attached;
+        // without one the whole page greys first (see
+        // `bridge_page_greys_without_an_interface`).
+        setup.bridge_status = BridgeStatus::Attached;
 
         for (driver, cable_greyed) in [
             (crate::config::BridgeDriver::Greaseweazle, false),
@@ -4015,6 +4040,48 @@ mod tests {
             None,
             "df2 is a fitted image bay again"
         );
+    }
+
+    /// The bridge page follows what is there: with nothing attached only the
+    /// Interface row stays live, and with the bay pulled out from under the
+    /// page (a loaded config can do that) every row greys, Interface included.
+    /// With an interface attached the rows answer to the driver as before.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn bridge_page_greys_without_an_interface() {
+        let mut setup = MachineSetup::default();
+        setup.set_drive_bridged(0, true);
+        setup.set_bridge_edit_drive(0);
+        let all = [
+            F::BridgePort,
+            F::BridgeCable,
+            F::BridgeDensity,
+            F::BridgeSpeed,
+            F::BridgeServeSpeed,
+            F::BridgeAutoCache,
+        ];
+
+        setup.bridge_status = BridgeStatus::NoInterface;
+        assert_eq!(setup.disabled_reason(F::BridgeDevice), None);
+        for f in all {
+            assert!(
+                setup.disabled_reason(f).is_some(),
+                "{f:?} live with no interface"
+            );
+        }
+
+        setup.bridge_status = BridgeStatus::Attached;
+        assert_eq!(setup.disabled_reason(F::BridgeDevice), None);
+        for f in [F::BridgeDensity, F::BridgeSpeed, F::BridgeServeSpeed] {
+            assert_eq!(setup.disabled_reason(f), None, "{f:?} greyed with one");
+        }
+
+        // The bay un-bridged underneath the page: nothing left to edit.
+        setup.set_drive_bridged(0, false);
+        assert!(setup.disabled_reason(F::BridgeDevice).is_some());
+        for f in all {
+            assert!(setup.disabled_reason(f).is_some(), "{f:?} live with no bay");
+        }
     }
 
     /// A bridged bay only names its interface when one is actually attached:

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -4123,10 +4123,13 @@ mod tests {
         setup.set_drive_bridged(0, true);
         setup.set_bridge_edit_drive(0);
         // Capability greying is only reachable with an interface attached and
-        // selected; without one the whole page greys first (see
-        // `bridge_page_greys_without_an_interface`).
+        // selected, and with a port to pick; without either the page greys
+        // first (see `bridge_page_greys_without_an_interface`). Pinned rather
+        // than sampled: what a test machine has attached is not this test's
+        // subject.
         setup.bridge_status = BridgeStatus::Attached;
         setup.df_bridge_none[0] = false;
+        setup.bridge_ports = vec![None, Some("/dev/ttyACM0".to_string())];
 
         for (driver, cable_greyed) in [
             (crate::config::BridgeDriver::Greaseweazle, false),

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -347,7 +347,7 @@ pub enum LauncherField {
     BridgeCable,
     BridgeDensity,
     BridgeSpeed,
-    BridgeSmartSpeed,
+    BridgeServeSpeed,
     BridgeAutoCache,
     // Hard disk
     IdeMaster,
@@ -607,7 +607,7 @@ const FLOPPY_BRIDGE_ROWS: [Row; 8] = [
     row(F::BridgeCable, "Drive select", Cycle),
     row(F::BridgeDensity, "Density", Cycle),
     row(F::BridgeSpeed, "Read mode", Cycle),
-    row(F::BridgeSmartSpeed, "Smart speed", Toggle),
+    row(F::BridgeServeSpeed, "Bridge speed", Cycle),
     row(F::BridgeAutoCache, "Auto-cache", Toggle),
 ];
 const STORAGE_ROWS: [Row; 12] = [
@@ -1009,6 +1009,9 @@ const AUDIO_FILTER_MODES: [AudioFilterMode; 3] = [
     AudioFilterMode::Off,
 ];
 const FLOPPY_SPEEDS: [u16; 5] = [100, 200, 400, 800, crate::floppy::SPEED_TURBO];
+/// Serving speeds a bridged bay offers: real, and two faster-than-real
+/// steps. Percentages of the platter's real speed.
+const BRIDGE_SERVE_SPEEDS: [u16; 3] = [100, 125, 150];
 const PACINGS: [PacingBudget; 2] = [PacingBudget::Cycles, PacingBudget::Instructions];
 const WARPS: [WarpSpeed; 5] = [
     WarpSpeed::X2,
@@ -1844,7 +1847,7 @@ impl MachineSetup {
                     .then(|| bridge_density_name(bridge.density).to_string()),
                 bridge_mode: (bridge.mode != default.mode)
                     .then(|| bridge_mode_name(bridge.mode).to_string()),
-                bridge_smart_speed: bridge.smart_speed.then_some(true),
+                bridge_speed: (bridge.speed != 100).then_some(bridge.speed),
                 bridge_auto_cache: bridge.auto_cache.then_some(true),
                 // Same rule, and the same tick box, as an image: only an
                 // unprotected drive says so.
@@ -2123,11 +2126,6 @@ impl MachineSetup {
                 "not on this interface",
             ),
             #[cfg(feature = "floppybridge")]
-            F::BridgeSmartSpeed => reason(
-                self.bridge_driver_supports(crate::floppybridge::config_option::SMART_SPEED),
-                "not on this interface",
-            ),
-            #[cfg(feature = "floppybridge")]
             F::BridgeAutoCache => reason(
                 self.bridge_driver_supports(crate::floppybridge::config_option::AUTO_CACHE),
                 "not on this interface",
@@ -2163,7 +2161,6 @@ impl MachineSetup {
             F::Df3WriteProtect => self.df_write_protected[3],
             F::FloppySounds => self.floppy_sounds,
             F::StartFullscreen => self.start_fullscreen,
-            F::BridgeSmartSpeed => self.bridge_edit().is_some_and(|c| c.smart_speed),
             F::BridgeAutoCache => self.bridge_edit().is_some_and(|c| c.auto_cache),
             F::ShowStatusBar => self.show_status_bar,
             F::Deinterlace => self.deinterlace,
@@ -2402,6 +2399,9 @@ impl MachineSetup {
                 Some(BridgeSpeedMode::Stalling) => "Stalling".to_string(),
                 None => "(none)".to_string(),
             },
+            F::BridgeServeSpeed => {
+                format!("{}%", self.bridge_edit().map_or(100, |c| c.speed))
+            }
             F::Shader => match self.shader {
                 ShaderMode::None => "Off".to_string(),
                 ShaderMode::Scanlines => "Scanlines".to_string(),
@@ -2832,6 +2832,11 @@ impl MachineSetup {
                     c.mode = cycle_slice(&BRIDGE_SPEEDS, c.mode, forward);
                 }
             }
+            F::BridgeServeSpeed => {
+                if let Some(c) = self.bridge_edit_mut() {
+                    c.speed = cycle_slice(&BRIDGE_SERVE_SPEEDS, c.speed, forward);
+                }
+            }
             F::AudioStereoSeparation => {
                 self.audio_stereo_separation = cycle_nearest(
                     &STEREO_SEPARATION_STEPS,
@@ -2895,11 +2900,6 @@ impl MachineSetup {
             F::Deinterlace => self.deinterlace = !self.deinterlace,
             F::Bezel => self.bezel = !self.bezel,
             F::PowerOn => self.power_on = !self.power_on,
-            F::BridgeSmartSpeed => {
-                if let Some(c) = self.bridge_edit_mut() {
-                    c.smart_speed = !c.smart_speed;
-                }
-            }
             F::BridgeAutoCache => {
                 if let Some(c) = self.bridge_edit_mut() {
                     c.auto_cache = !c.auto_cache;
@@ -3255,10 +3255,10 @@ impl MachineSetup {
     /// optional settings, as that driver itself reports.
     ///
     /// Each driver advertises what it supports, and they differ: a Greaseweazle
-    /// takes a drive-select cable and smart speed, a DrawBridge answers to a
-    /// different set. Offering a switch the hardware ignores is how a user ends
-    /// up believing they changed something, so the ones it does not honour are
-    /// greyed with the interface's name against them.
+    /// takes a drive-select cable, a DrawBridge answers to a different set.
+    /// Offering a switch the hardware ignores is how a user ends up believing
+    /// they changed something, so the ones it does not honour are greyed with
+    /// the interface's name against them.
     #[cfg(feature = "floppybridge")]
     fn bridge_driver_supports(&self, option: u32) -> bool {
         let Some(cfg) = self.bridge_edit() else {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1194,8 +1194,7 @@ pub struct MachineSetup {
     /// The bay's interface is set to "None": still a physical-drive bay in
     /// the launcher, but with no interface to drive it -- the run and the
     /// written config treat it as unbridged. Selected automatically when a
-    /// bay is bridged with nothing attached, so the page tells the truth
-    /// from the first look.
+    /// bay is bridged with nothing attached.
     df_bridge_none: [bool; 4],
     /// Which bay the FloppyBridge settings page is showing. The page itself is
     /// one set of rows; this says whose values they are.
@@ -1207,9 +1206,8 @@ pub struct MachineSetup {
     bridge_status: BridgeStatus,
     /// The serial ports on offer -- "Automatic", the library's scan, then
     /// every host serial device the scan did not name. Sampled with
-    /// `bridge_status` at deliberate moments (opening the launcher, bridging
-    /// a bay, entering the configure page): the scan walks the serial bus,
-    /// which is not a per-frame activity.
+    /// `bridge_status` (launcher open, a bay switched to a physical drive):
+    /// the scan walks the serial bus, which is not a per-frame activity.
     bridge_ports: Vec<Option<String>>,
     // Hard disk. Each drive's optional volume-name override (directory mounts
     // only) sits in the matching `*_name` slot, paralleling the path slot. Boot
@@ -2200,13 +2198,11 @@ impl MachineSetup {
             // when inactive (see `rows`), so they never need a greyed state.
             // Channel mode and separation shape the output, so they do nothing
             // once audio is disabled; separation also does nothing in mono.
-            // The bridge page follows what is actually there. A loaded config
-            // can pull the bay out from under the page, leaving nothing to
-            // edit: every row greys, the Interface one included. With the bay
-            // bridged but no interface attached (the media row's "None"),
-            // only the Interface row is worth touching -- the rest describe
-            // hardware that is not present, the serial port included, since
-            // its list is empty and "Automatic" alone is not a choice.
+            // The bridge page follows what is there. A loaded config can
+            // pull the bay out from under the page: every row greys, the
+            // Interface one included. With the bay bridged but no interface
+            // attached or selected, only the Interface row stays live -- the
+            // rest describe hardware that is not present.
             #[cfg(feature = "floppybridge")]
             F::BridgeDevice => reason(self.bridge_edit().is_some(), "no drive"),
             #[cfg(feature = "floppybridge")]
@@ -2221,11 +2217,11 @@ impl MachineSetup {
             {
                 Some("no interface")
             }
-            // The port row outlives the attachment check the rest answer to:
-            // an interface on a chip the library's scan does not name still
-            // has to be pointable-at by hand. It greys when the interface is
-            // "None", and when there is genuinely nothing to point at --
-            // the list holding only "Automatic".
+            // The port row stays live while there is a port to pick, even
+            // with nothing recognised as attached: an interface on a serial
+            // chip the scan does not name is selected by hand. It greys with
+            // the interface set to None, and with nothing to pick (a list of
+            // just "Automatic").
             #[cfg(feature = "floppybridge")]
             F::BridgePort => {
                 if self.bridge_edit().is_none() || self.df_bridge_none[self.bridge_edit_drive] {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1078,9 +1078,8 @@ const AUDIO_FILTER_MODES: [AudioFilterMode; 3] = [
     AudioFilterMode::Off,
 ];
 const FLOPPY_SPEEDS: [u16; 5] = [100, 200, 400, 800, crate::floppy::SPEED_TURBO];
-/// Serving speeds a bridged bay offers: real, and two faster-than-real
-/// steps. Percentages of the platter's real speed.
-const BRIDGE_SERVE_SPEEDS: [u16; 3] = [100, 125, 150];
+// The bridge speed row cycles the same set the config and CLI accept.
+use crate::config::SUPPORTED_BRIDGE_SPEED_PERCENTS as BRIDGE_SERVE_SPEEDS;
 const PACINGS: [PacingBudget; 2] = [PacingBudget::Cycles, PacingBudget::Instructions];
 const WARPS: [WarpSpeed; 5] = [
     WarpSpeed::X2,

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5387,8 +5387,12 @@ fn draw_launcher_row(
             | LauncherField::MouseSensitivity
             | LauncherField::MouseCapture
             | LauncherField::ShaderStrength
+            | LauncherField::BridgeDevice
             | LauncherField::BridgePort
             | LauncherField::BridgeCable
+            | LauncherField::BridgeDensity
+            | LauncherField::BridgeSpeed
+            | LauncherField::BridgeServeSpeed
             | LauncherField::BridgeAutoCache
             | LauncherField::FloppySpeed
     );

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5389,8 +5389,8 @@ fn draw_launcher_row(
             | LauncherField::ShaderStrength
             | LauncherField::BridgePort
             | LauncherField::BridgeCable
-            | LauncherField::BridgeSmartSpeed
             | LauncherField::BridgeAutoCache
+            | LauncherField::FloppySpeed
     );
     if let Some(reason) = reason {
         if !blank_when_greyed {

--- a/tests/bridge_capture_probe.rs
+++ b/tests/bridge_capture_probe.rs
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Hardware probes for the floppy-bridge capture path.
+//!
+//! All `#[ignore]`d: they need a FloppyBridge interface (a Greaseweazle in
+//! practice) with an AmigaDOS disk in the drive. There is one drive, so run
+//! one test at a time:
+//!
+//! ```sh
+//! cargo test --release --test bridge_capture_probe -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! `bridge_decoder_smoke` validates the sector decoder against a single
+//! `compatible`-mode capture of cylinder 0. `bridge_seek_capture_soak` mimics
+//! a boot's scattered access pattern -- seek away, seek back, capture -- and
+//! decodes every capture, to measure how often a capture arrives with a
+//! damaged sector and where the damage sits. Knobs, all environment variables:
+//!
+//! - `PROBE_MODE`: `normal` (default) or `compatible`
+//! - `PROBE_CAPTURES`: total captures to take (default 120)
+//! - `PROBE_TARGETS`: comma-separated `cyl:side` list to cycle through
+//!   (default `54:0,57:0,58:1`, the tracks that failed during scored boots)
+//! - `PROBE_AWAY`: how many cylinders to seek away between captures (default 20)
+//! - `PROBE_SEEK`: `pulse` (default; one-cylinder seeks 3 ms apart, as the
+//!   emulated stepper drives the bridge) or `direct` (one seek to the target)
+
+#![cfg(feature = "floppybridge")]
+
+use std::time::{Duration, Instant};
+
+use copperline::floppybridge::{drivers, Bridge, BridgeConfig, BridgeMode};
+
+const MASK: u32 = 0x5555_5555;
+
+/// One decoded AmigaDOS sector and where it sits in the capture.
+#[derive(Debug)]
+struct Sector {
+    /// Bit position of the first sync word of the pair.
+    start_bit: usize,
+    track: u8,
+    sector: u8,
+    header_ok: bool,
+    data_ok: bool,
+}
+
+struct Scan {
+    bit_len: usize,
+    syncs: usize,
+    sectors: Vec<Sector>,
+}
+
+impl Scan {
+    fn sectors_ok(&self) -> usize {
+        self.sectors
+            .iter()
+            .filter(|s| s.header_ok && s.data_ok)
+            .count()
+    }
+
+    fn bad(&self) -> Vec<&Sector> {
+        self.sectors
+            .iter()
+            .filter(|s| !(s.header_ok && s.data_ok))
+            .collect()
+    }
+}
+
+/// Read one bit of the capture, as a ring.
+fn bit_at(words: &[u16], bit_len: usize, i: usize) -> bool {
+    let i = i % bit_len;
+    words[i / 16] & (1 << (15 - (i % 16))) != 0
+}
+
+fn long_at(words: &[u16], bit_len: usize, start: usize) -> u32 {
+    let mut v = 0u32;
+    for k in 0..32 {
+        v = (v << 1) | u32::from(bit_at(words, bit_len, start + k));
+    }
+    v
+}
+
+/// Decode an odd/even MFM long pair into its data long.
+fn deinterleave(odd: u32, even: u32) -> u32 {
+    ((odd & MASK) << 1) | (even & MASK)
+}
+
+/// Decode every AmigaDOS sector in a captured revolution, treating the capture
+/// as the ring the emulator serves. Follows the on-disk layout: two 0x4489
+/// sync words, then odd/even split info (1 long), label (4 longs), header
+/// checksum, data checksum, data (128 longs). Checksums are the XOR of the
+/// masked MFM longs of the region they cover.
+fn decode(words: &[u16], bit_len: usize) -> Scan {
+    // Find every sync word position.
+    let mut syncs = Vec::new();
+    let mut window: u16 = 0;
+    for i in 0..bit_len + 15 {
+        window = (window << 1) | u16::from(bit_at(words, bit_len, i));
+        if i >= 15 && window == 0x4489 {
+            syncs.push((i - 15) % bit_len);
+        }
+    }
+
+    // A sector begins at a 0x4489 immediately followed by another. Walk the
+    // pairs; a lone sync (the first of a pair found again at the ring end) is
+    // skipped by the distance check.
+    let mut sectors = Vec::new();
+    for &s in &syncs {
+        // The word after this sync must also be a sync, and the one before
+        // must not be (otherwise `s` is the second of the pair).
+        let next_is_sync = syncs.contains(&((s + 16) % bit_len));
+        let prev_is_sync = syncs.contains(&((s + bit_len - 16) % bit_len));
+        if !next_is_sync || prev_is_sync {
+            continue;
+        }
+        let body = s + 32; // past both sync words
+        let info_odd = long_at(words, bit_len, body);
+        let info_even = long_at(words, bit_len, body + 32);
+        let info = deinterleave(info_odd, info_even);
+        let [format, track, sector, _to_gap] = info.to_be_bytes();
+        if format != 0xFF || sector >= 11 {
+            continue;
+        }
+
+        // Header checksum covers info + label as masked MFM longs.
+        let mut hsum = (info_odd & MASK) ^ (info_even & MASK);
+        for l in 0..8 {
+            hsum ^= long_at(words, bit_len, body + 64 + l * 32) & MASK;
+        }
+        let stored_h = deinterleave(
+            long_at(words, bit_len, body + 320),
+            long_at(words, bit_len, body + 352),
+        );
+        let header_ok = hsum == stored_h;
+
+        // Data checksum covers the 256 MFM longs of the payload.
+        let data_start = body + 448;
+        let mut dsum = 0u32;
+        for l in 0..256 {
+            dsum ^= long_at(words, bit_len, data_start + l * 32) & MASK;
+        }
+        let stored_d = deinterleave(
+            long_at(words, bit_len, body + 384),
+            long_at(words, bit_len, body + 416),
+        );
+        let data_ok = dsum == stored_d;
+
+        sectors.push(Sector {
+            start_bit: s,
+            track,
+            sector,
+            header_ok,
+            data_ok,
+        });
+    }
+
+    Scan {
+        bit_len,
+        syncs: syncs.len(),
+        sectors,
+    }
+}
+
+fn env_or(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+fn open_bridge(mode: BridgeMode) -> Bridge {
+    let driver = drivers()
+        .into_iter()
+        .find(|d| d.name.to_ascii_lowercase().contains("greaseweazle"))
+        .expect("no greaseweazle driver in this build");
+    Bridge::open(&BridgeConfig {
+        driver: driver.index,
+        mode,
+        ..Default::default()
+    })
+    .expect("open the drive")
+}
+
+fn spin_up(bridge: &mut Bridge) {
+    bridge.set_motor(false, true);
+    let deadline = Instant::now() + Duration::from_secs(4);
+    while !bridge.is_ready() {
+        assert!(Instant::now() < deadline, "drive never became ready");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Move the head the way the emulated stepper does: one cylinder per seek,
+/// 3 ms apart, so the driver sees the same command stream a boot produces.
+fn seek_pulsed(bridge: &mut Bridge, from: u8, to: u8, side: bool) {
+    let mut at = from;
+    while at != to {
+        at = if to > at { at + 1 } else { at - 1 };
+        bridge.seek(at, side);
+        std::thread::sleep(Duration::from_millis(3));
+    }
+}
+
+fn poll_track(bridge: &mut Bridge, cyl: u8, side: bool) -> Option<(Vec<u16>, usize, u128)> {
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(4);
+    loop {
+        if let Some((words, bits)) = bridge.read_track(cyl, side) {
+            return Some((words, bits, started.elapsed().as_millis()));
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// One capture of cylinder 0 in `compatible` mode, decoded and printed.
+/// Proves the decoder against an index-aligned capture before the soak's
+/// results can mean anything.
+#[test]
+#[ignore = "needs a FloppyBridge device with an AmigaDOS disk inserted"]
+fn bridge_decoder_smoke() {
+    let mut bridge = open_bridge(BridgeMode::Compatible);
+    spin_up(&mut bridge);
+    let (words, bits, waited) = poll_track(&mut bridge, 0, false).expect("no capture");
+    let scan = decode(&words, bits);
+    println!(
+        "cyl 0 lower: {} bits in {waited}ms, {} syncs, {}/{} sectors clean",
+        scan.bit_len,
+        scan.syncs,
+        scan.sectors_ok(),
+        scan.sectors.len(),
+    );
+    for s in &scan.sectors {
+        println!(
+            "  t{} s{:>2} at bit {:>6}  header={} data={}",
+            s.track, s.sector, s.start_bit, s.header_ok, s.data_ok
+        );
+    }
+    assert_eq!(scan.sectors.len(), 11, "expected 11 sectors");
+    assert_eq!(scan.sectors_ok(), 11, "expected all sectors clean");
+}
+
+/// The soak: capture repeatedly across seeks and score every capture.
+#[test]
+#[ignore = "needs a FloppyBridge device with an AmigaDOS disk inserted"]
+fn bridge_seek_capture_soak() {
+    let mode = match env_or("PROBE_MODE", "normal").as_str() {
+        "compatible" => BridgeMode::Compatible,
+        _ => BridgeMode::Fast,
+    };
+    let captures: usize = env_or("PROBE_CAPTURES", "120").parse().unwrap();
+    let away: u8 = env_or("PROBE_AWAY", "20").parse().unwrap();
+    let pulse = env_or("PROBE_SEEK", "pulse") == "pulse";
+    let targets: Vec<(u8, bool)> = env_or("PROBE_TARGETS", "54:0,57:0,58:1")
+        .split(',')
+        .map(|t| {
+            let (c, s) = t.split_once(':').expect("cyl:side");
+            (c.trim().parse().unwrap(), s.trim() == "1")
+        })
+        .collect();
+
+    println!(
+        "mode={mode:?} captures={captures} away={away} seek={}",
+        if pulse { "pulse" } else { "direct" }
+    );
+
+    let mut bridge = open_bridge(mode);
+    spin_up(&mut bridge);
+
+    let mut damaged = 0usize;
+    let mut timeouts = 0usize;
+    let mut at: u8 = 0;
+    for n in 0..captures {
+        let (cyl, side) = targets[n % targets.len()];
+        // Seek away first so every capture follows real head movement, the
+        // way trackdisk's retry-with-recalibrate reaches a track.
+        let park = if cyl >= away { cyl - away } else { cyl + away };
+        if pulse {
+            seek_pulsed(&mut bridge, at, park, side);
+        } else {
+            bridge.seek(park, side);
+        }
+        // Let the driver begin (and then abandon) a capture there, as it
+        // does between a boot's seeks.
+        std::thread::sleep(Duration::from_millis(60));
+        if pulse {
+            seek_pulsed(&mut bridge, park, cyl, side);
+        } else {
+            bridge.seek(cyl, side);
+        }
+        at = cyl;
+        // Give the background thread time to land a capture that began just
+        // after the seek -- the case under test -- then retire whatever was
+        // current so the fresh one is served.
+        std::thread::sleep(Duration::from_millis(700));
+        bridge.switch_buffer(side);
+
+        let Some((words, bits, waited)) = poll_track(&mut bridge, cyl, side) else {
+            timeouts += 1;
+            println!("#{n:>4} cyl {cyl} side {}: TIMEOUT", u8::from(side));
+            continue;
+        };
+        let scan = decode(&words, bits);
+        let ok = scan.sectors_ok();
+        if ok < scan.sectors.len() || scan.sectors.len() < 11 {
+            damaged += 1;
+            let spans: Vec<String> = scan
+                .bad()
+                .iter()
+                .map(|s| {
+                    format!(
+                        "t{} s{} at {} ({}h/{}d)",
+                        s.track,
+                        s.sector,
+                        s.start_bit,
+                        u8::from(s.header_ok),
+                        u8::from(s.data_ok)
+                    )
+                })
+                .collect();
+            println!(
+                "#{n:>4} cyl {cyl} side {}: {ok}/{} in {bits} bits, {waited}ms  BAD {spans:?}",
+                u8::from(side),
+                scan.sectors.len(),
+            );
+        } else {
+            println!(
+                "#{n:>4} cyl {cyl} side {}: 11/11 in {bits} bits, {waited}ms",
+                u8::from(side)
+            );
+        }
+    }
+
+    println!("\nsummary: mode={mode:?} captures={captures} damaged={damaged} timeouts={timeouts}");
+}

--- a/tests/bridge_capture_probe.rs
+++ b/tests/bridge_capture_probe.rs
@@ -19,7 +19,8 @@
 //! - `PROBE_MODE`: `normal` (default) or `compatible`
 //! - `PROBE_CAPTURES`: total captures to take (default 120)
 //! - `PROBE_TARGETS`: comma-separated `cyl:side` list to cycle through
-//!   (default `54:0,57:0,58:1`, the tracks that failed during scored boots)
+//!   (default `54:0,57:0,58:1`, tracks that read marginally on the
+//!   reference disk)
 //! - `PROBE_AWAY`: how many cylinders to seek away between captures (default 20)
 //! - `PROBE_SEEK`: `pulse` (default; one-cylinder seeks 3 ms apart, as the
 //!   emulated stepper drives the bridge) or `direct` (one seek to the target)

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -99,22 +99,6 @@ cylinder and surface whenever the flag is up, exactly as the read path does.
 This is a behavioural fix, not a build difference, and is worth carrying
 upstream.
 
-### `CommonBridgeTemplate.cpp` -- auto-cache fighting an active guest
-
-The cacher's only scheduling guard was an empty command queue, checked as
-each excursion starts. The moment the track the host is on has its buffers
-full, the cacher seeks away to its next target -- while the guest is still
-consuming that track and about to ask for the next one, whose demand then
-aborts the cacher's capture and drags the head back. During a load, every
-guest track cost two extra seeks and an aborted capture, audibly thrashing
-the drive and slowing the very reads the cache exists to serve. The
-host-facing entry points (seek, motor, surface, buffer switch, track read,
-the write calls) now stamp `m_lastHostActivity`, and `handleBackgroundCaching`
-waits until that is `AUTOCACHE_HOLDOFF_TIME` (2 s) old before moving the
-head. Status queries deliberately do not stamp it, and the cacher's own
-internal calls bypass the host-facing entry points, so it does not hold
-itself off. Also behavioural, also worth carrying upstream.
-
 ### Wide literals passed to TCHAR-generic Win32 calls
 
 Upstream's project builds with `CharacterSet: Unicode`, so its `L""` literals

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -99,6 +99,22 @@ cylinder and surface whenever the flag is up, exactly as the read path does.
 This is a behavioural fix, not a build difference, and is worth carrying
 upstream.
 
+### `CommonBridgeTemplate.cpp` -- auto-cache fighting an active guest
+
+The cacher's only scheduling guard was an empty command queue, checked as
+each excursion starts. The moment the track the host is on has its buffers
+full, the cacher seeks away to its next target -- while the guest is still
+consuming that track and about to ask for the next one, whose demand then
+aborts the cacher's capture and drags the head back. During a load, every
+guest track cost two extra seeks and an aborted capture, audibly thrashing
+the drive and slowing the very reads the cache exists to serve. The
+host-facing entry points (seek, motor, surface, buffer switch, track read,
+the write calls) now stamp `m_lastHostActivity`, and `handleBackgroundCaching`
+waits until that is `AUTOCACHE_HOLDOFF_TIME` (2 s) old before moving the
+head. Status queries deliberately do not stamp it, and the cacher's own
+internal calls bypass the host-facing entry points, so it does not hold
+itself off. Also behavioural, also worth carrying upstream.
+
 ### Wide literals passed to TCHAR-generic Win32 calls
 
 Upstream's project builds with `CharacterSet: Unicode`, so its `L""` literals

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -19,11 +19,13 @@ into them directly.
 
 Copy `floppybridge/*` and `windows/FloppyBridge.{cpp,h}` plus `windows/resource.h`
 from a newer upstream checkout into `src/`, then re-apply the changes below and
-update the commit recorded above. They are small, confined to five files --
-`ArduinoFloppyBridge.cpp`, `FloppyBridge.cpp`, `GreaseWeazleBridge.cpp`,
-`SerialIO.cpp` and `ftdi.cpp` -- and every one is a build or platform
-difference rather than a change in behaviour. Every other vendored file is
-byte-identical to the commit above.
+update the commit recorded above. They are small, confined to six files --
+`ArduinoFloppyBridge.cpp`, `CommonBridgeTemplate.cpp`, `FloppyBridge.cpp`,
+`GreaseWeazleBridge.cpp`, `SerialIO.cpp` and `ftdi.cpp`. All but one are build
+or platform differences rather than changes in behaviour; the exception is the
+auto-cache write fix in `CommonBridgeTemplate.cpp` below, which corrects a
+real-disk corruption bug and should be dropped once upstream carries an
+equivalent. Every other vendored file is byte-identical to the commit above.
 
 `build.rs` picks the files it compiles by name; a release that adds or renames
 a source file needs that list updated too, and will say so by failing to link.
@@ -82,6 +84,20 @@ the interfaces call only *after* the open returns. In between, a blocking
 descriptor carries the default `VMIN=1`/`VTIME=0`: wait for a byte, forever. The
 handshake reads in that window, so a device that answers slowly wedges the open
 instead of failing it.
+
+### `CommonBridgeTemplate.cpp` -- a write while auto-cache holds the head
+
+Background caching (`handleBackgroundCaching`) seeks the physical head and
+selects surfaces without updating `m_actualCurrentCylinder` or
+`m_actualFloppySide`; it raises `m_autocacheModifiedCurrentCylinder` so the
+next reader restores the head first. `handleBackgroundDiskRead` checks the
+flag; the `writeMFMData` handler did not, so with auto-cache enabled a queued
+write could find the bookkeeping already "on" its target cylinder, skip the
+seek, and lay the track down wherever the cacher had left the head --
+corrupting an unrelated track of a real disk. The handler now restores the
+cylinder and surface whenever the flag is up, exactly as the read path does.
+This is a behavioural fix, not a build difference, and is worth carrying
+upstream.
 
 ### Wide literals passed to TCHAR-generic Win32 calls
 

--- a/vendor/floppybridge/README.md
+++ b/vendor/floppybridge/README.md
@@ -94,7 +94,7 @@ next reader restores the head first. `handleBackgroundDiskRead` checks the
 flag; the `writeMFMData` handler did not, so with auto-cache enabled a queued
 write could find the bookkeeping already "on" its target cylinder, skip the
 seek, and lay the track down wherever the cacher had left the head --
-corrupting an unrelated track of a real disk. The handler now restores the
+corrupting an unrelated track of a real disk. The handler restores the
 cylinder and surface whenever the flag is up, exactly as the read path does.
 This is a behavioural fix, not a build difference, and is worth carrying
 upstream.

--- a/vendor/floppybridge/src/CommonBridgeTemplate.cpp
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.cpp
@@ -65,10 +65,6 @@ OUTPUT_TIME_IN_NS should not be set(revolution extractor)
 #define DRIVE_GARBAGE_VALUE							1
 
 // Auto-sense the disk, just like Amiga OS will, be do this if it hasn't 
-/* COPPERLINE: how long the host must leave the drive alone before
-   background caching may move the head, in milliseconds. */
-#define AUTOCACHE_HOLDOFF_TIME						2000
-
 #define DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL	3000
 
 // We need to poll the drive once theres a disk in there to know when it's been removed.  This is the poll interval
@@ -104,9 +100,7 @@ CommonBridgeTemplate::CommonBridgeTemplate(FloppyBridge::BridgeMode bridgeMode, 
 	m_control(nullptr), m_currentTrack(0), m_actualCurrentCylinder(0), m_writeProtected(false), m_diskInDrive(false), m_firstTrackMode(false), m_autocacheModifiedCurrentCylinder(false),
 	m_bridgeMode(bridgeMode), m_bridgeDensity(bridgeDensity), m_motorSpinningUp(false), m_motorIsReady(false), m_isMotorRunning(false), m_autoCacheMotorStatus(false), m_useSmartSpeed(useSmartSpeed),
 	m_readBufferAvailable(false), m_floppySide(DiskSurface::dsLower), m_actualFloppySide(DiskSurface::dsLower), m_shouldAutoCache(shouldAutoCache), m_pll(true, true), m_readLoops(0),
-	m_lastSeek(std::chrono::steady_clock::now()),
-	/* COPPERLINE: aged so an idle guest at open does not delay caching */
-	m_lastHostActivity(std::chrono::steady_clock::now() - std::chrono::milliseconds(AUTOCACHE_HOLDOFF_TIME)) {
+	m_lastSeek(std::chrono::steady_clock::now()) {
 
 	memset(&m_mfmRead, 0, sizeof(m_mfmRead));;
 	m_pll.setRotationExtractor(&m_extractor);
@@ -124,8 +118,6 @@ void CommonBridgeTemplate::changeBridgeDensity(FloppyBridge::BridgeDensityMode b
 
 // Quick confirmation from UAE that we're actually on the same side
 void CommonBridgeTemplate::setSurface(bool side) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	switchDiskSide(side);
 }
 
@@ -727,8 +719,6 @@ int CommonBridgeTemplate::maxMFMBitPosition() {
 
 // This is called to switch to a different copy of the track so multiple revolutions can be read
 void CommonBridgeTemplate::mfmSwitchBuffer(bool side) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	if (m_directMode) return;
 
 	switchDiskSide(side);
@@ -816,8 +806,6 @@ bool CommonBridgeTemplate::isMFMDataAvailable() {
 // The return value is the wrap point in bits (last byte is shifted to MSB) or in Direct mode, just the number of bits received
 // resyncRotation is ignored in direct mode
 int CommonBridgeTemplate::getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	if (m_directMode) {
 		threadLockControl(true);
 
@@ -980,11 +968,6 @@ void CommonBridgeTemplate::handleBackgroundCaching() {
 	if (m_directMode) return;
 	if (!m_queue.empty()) return;
 	if (m_lastWroteTo >= 0) return;  // don't do this if a write is happening
-	/* COPPERLINE: while the host is actively using the drive, caching a
-	   different cylinder just steals the head from it -- every excursion
-	   costs two seeks and an aborted capture. Wait for the guest to go
-	   quiet before reading ahead on its behalf. */
-	if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_lastHostActivity).count() < AUTOCACHE_HOLDOFF_TIME) return;
 	if (!m_diskInDrive) {
 		// Turn off the motor if its not needed and we started it
 		if (m_motorIsReady || m_motorSpinningUp) return;
@@ -1468,8 +1451,6 @@ bool CommonBridgeTemplate::resetDrive(int trackNumber) {
 
 // Set the status of the motor. 
 void CommonBridgeTemplate::setMotorStatus(bool side, bool turnOn) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	switchDiskSide(side);
 
 	if (m_isMotorRunning == turnOn) return;
@@ -1510,8 +1491,6 @@ void CommonBridgeTemplate::handleNoClickStep(bool side) {
 
 // Seek to a specific track
 void CommonBridgeTemplate::gotoCylinder(int trackNumber, bool side) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	if (m_currentTrack == trackNumber) {
 		switchDiskSide(side);
 		return;
@@ -1654,8 +1633,6 @@ bool CommonBridgeTemplate::writeMFMTrackToBuffer(bool side, unsigned int track, 
 // Submits a single WORD of data received during a DMA transfer to the disk buffer.  This needs to be saved.  It is usually flushed when commitWriteBuffer is called
 // You should reset this buffer if side or track changes
 void CommonBridgeTemplate::writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	gotoCylinder(track, side);
 
 	// Prevent background reading while we're busy
@@ -1688,8 +1665,6 @@ bool CommonBridgeTemplate::isReadyToWrite() {
 // Requests that any data received via writeShortToBuffer be saved to disk. The side and track should match against what you have been collected
 // and the buffer should be reset upon completion.  You should return the new track length (maxMFMBitPosition) with optional padding if needed
 unsigned int CommonBridgeTemplate::commitWriteBuffer(bool side, unsigned int track) {
-	/* COPPERLINE: the host is using the drive -- hold background caching off */
-	m_lastHostActivity = std::chrono::steady_clock::now();
 	gotoCylinder(track, side);
 
 	// Prevent background reading while we're busy

--- a/vendor/floppybridge/src/CommonBridgeTemplate.cpp
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.cpp
@@ -65,6 +65,10 @@ OUTPUT_TIME_IN_NS should not be set(revolution extractor)
 #define DRIVE_GARBAGE_VALUE							1
 
 // Auto-sense the disk, just like Amiga OS will, be do this if it hasn't 
+/* COPPERLINE: how long the host must leave the drive alone before
+   background caching may move the head, in milliseconds. */
+#define AUTOCACHE_HOLDOFF_TIME						2000
+
 #define DISKCHANGE_BEFORE_INSERTED_CHECK_INTERVAL	3000
 
 // We need to poll the drive once theres a disk in there to know when it's been removed.  This is the poll interval
@@ -100,7 +104,9 @@ CommonBridgeTemplate::CommonBridgeTemplate(FloppyBridge::BridgeMode bridgeMode, 
 	m_control(nullptr), m_currentTrack(0), m_actualCurrentCylinder(0), m_writeProtected(false), m_diskInDrive(false), m_firstTrackMode(false), m_autocacheModifiedCurrentCylinder(false),
 	m_bridgeMode(bridgeMode), m_bridgeDensity(bridgeDensity), m_motorSpinningUp(false), m_motorIsReady(false), m_isMotorRunning(false), m_autoCacheMotorStatus(false), m_useSmartSpeed(useSmartSpeed),
 	m_readBufferAvailable(false), m_floppySide(DiskSurface::dsLower), m_actualFloppySide(DiskSurface::dsLower), m_shouldAutoCache(shouldAutoCache), m_pll(true, true), m_readLoops(0),
-	m_lastSeek(std::chrono::steady_clock::now()) {
+	m_lastSeek(std::chrono::steady_clock::now()),
+	/* COPPERLINE: aged so an idle guest at open does not delay caching */
+	m_lastHostActivity(std::chrono::steady_clock::now() - std::chrono::milliseconds(AUTOCACHE_HOLDOFF_TIME)) {
 
 	memset(&m_mfmRead, 0, sizeof(m_mfmRead));;
 	m_pll.setRotationExtractor(&m_extractor);
@@ -118,6 +124,8 @@ void CommonBridgeTemplate::changeBridgeDensity(FloppyBridge::BridgeDensityMode b
 
 // Quick confirmation from UAE that we're actually on the same side
 void CommonBridgeTemplate::setSurface(bool side) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	switchDiskSide(side);
 }
 
@@ -719,6 +727,8 @@ int CommonBridgeTemplate::maxMFMBitPosition() {
 
 // This is called to switch to a different copy of the track so multiple revolutions can be read
 void CommonBridgeTemplate::mfmSwitchBuffer(bool side) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	if (m_directMode) return;
 
 	switchDiskSide(side);
@@ -806,6 +816,8 @@ bool CommonBridgeTemplate::isMFMDataAvailable() {
 // The return value is the wrap point in bits (last byte is shifted to MSB) or in Direct mode, just the number of bits received
 // resyncRotation is ignored in direct mode
 int CommonBridgeTemplate::getMFMTrack(bool side, unsigned int track, bool resyncRotation, const int bufferSizeInBytes, void* output) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	if (m_directMode) {
 		threadLockControl(true);
 
@@ -968,6 +980,11 @@ void CommonBridgeTemplate::handleBackgroundCaching() {
 	if (m_directMode) return;
 	if (!m_queue.empty()) return;
 	if (m_lastWroteTo >= 0) return;  // don't do this if a write is happening
+	/* COPPERLINE: while the host is actively using the drive, caching a
+	   different cylinder just steals the head from it -- every excursion
+	   costs two seeks and an aborted capture. Wait for the guest to go
+	   quiet before reading ahead on its behalf. */
+	if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_lastHostActivity).count() < AUTOCACHE_HOLDOFF_TIME) return;
 	if (!m_diskInDrive) {
 		// Turn off the motor if its not needed and we started it
 		if (m_motorIsReady || m_motorSpinningUp) return;
@@ -1451,6 +1468,8 @@ bool CommonBridgeTemplate::resetDrive(int trackNumber) {
 
 // Set the status of the motor. 
 void CommonBridgeTemplate::setMotorStatus(bool side, bool turnOn) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	switchDiskSide(side);
 
 	if (m_isMotorRunning == turnOn) return;
@@ -1491,6 +1510,8 @@ void CommonBridgeTemplate::handleNoClickStep(bool side) {
 
 // Seek to a specific track
 void CommonBridgeTemplate::gotoCylinder(int trackNumber, bool side) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	if (m_currentTrack == trackNumber) {
 		switchDiskSide(side);
 		return;
@@ -1633,6 +1654,8 @@ bool CommonBridgeTemplate::writeMFMTrackToBuffer(bool side, unsigned int track, 
 // Submits a single WORD of data received during a DMA transfer to the disk buffer.  This needs to be saved.  It is usually flushed when commitWriteBuffer is called
 // You should reset this buffer if side or track changes
 void CommonBridgeTemplate::writeShortToBuffer(bool side, unsigned int track, unsigned short mfmData, int mfmPosition) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	gotoCylinder(track, side);
 
 	// Prevent background reading while we're busy
@@ -1665,6 +1688,8 @@ bool CommonBridgeTemplate::isReadyToWrite() {
 // Requests that any data received via writeShortToBuffer be saved to disk. The side and track should match against what you have been collected
 // and the buffer should be reset upon completion.  You should return the new track length (maxMFMBitPosition) with optional padding if needed
 unsigned int CommonBridgeTemplate::commitWriteBuffer(bool side, unsigned int track) {
+	/* COPPERLINE: the host is using the drive -- hold background caching off */
+	m_lastHostActivity = std::chrono::steady_clock::now();
 	gotoCylinder(track, side);
 
 	// Prevent background reading while we're busy

--- a/vendor/floppybridge/src/CommonBridgeTemplate.cpp
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.cpp
@@ -1249,6 +1249,22 @@ void CommonBridgeTemplate::processCommand(const QueueInfo& info) {
 		}
 		// Is there data to write?
 		if (track.floppyBufferSizeBits) {
+			/* COPPERLINE: background caching moves the physical head and
+			   surface without updating m_actualCurrentCylinder or
+			   m_actualFloppySide, raising m_autocacheModifiedCurrentCylinder
+			   for the next reader to restore from. handleBackgroundDiskRead
+			   does; this path did not, so the bookkeeping comparisons below
+			   could match while the real head sat wherever the cacher left
+			   it, and the write landed on that cylinder and side instead --
+			   corrupting an unrelated track of a real disk. Restore the head
+			   explicitly whenever the cacher has moved it. */
+			if (m_autocacheModifiedCurrentCylinder) {
+				m_actualCurrentCylinder = track.trackNumber;
+				setCurrentCylinder(track.trackNumber);
+				m_actualFloppySide = track.side;
+				setActiveSurface(track.side);
+				m_autocacheModifiedCurrentCylinder = false;
+			}
 			if (m_actualCurrentCylinder != track.trackNumber) {
 				m_actualCurrentCylinder = track.trackNumber;
 				setCurrentCylinder(track.trackNumber);

--- a/vendor/floppybridge/src/CommonBridgeTemplate.h
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.h
@@ -253,12 +253,6 @@ private:
 	// When the last seek operation occured
 	std::chrono::time_point<std::chrono::steady_clock> m_lastSeek;
 
-	/* COPPERLINE: when the host last used the drive (seek, motor, surface,
-	   buffer switch, track read, write). Background caching holds off until
-	   this is a couple of seconds old, so it never fights an actively loading
-	   guest for the head -- see handleBackgroundCaching. */
-	std::chrono::time_point<std::chrono::steady_clock> m_lastHostActivity;
-
 	// Number of reads since step or head change
 	uint32_t m_readLoops;
 

--- a/vendor/floppybridge/src/CommonBridgeTemplate.h
+++ b/vendor/floppybridge/src/CommonBridgeTemplate.h
@@ -253,6 +253,12 @@ private:
 	// When the last seek operation occured
 	std::chrono::time_point<std::chrono::steady_clock> m_lastSeek;
 
+	/* COPPERLINE: when the host last used the drive (seek, motor, surface,
+	   buffer switch, track read, write). Background caching holds off until
+	   this is a couple of seconds old, so it never fights an actively loading
+	   guest for the head -- see handleBackgroundCaching. */
+	std::chrono::time_point<std::chrono::steady_clock> m_lastHostActivity;
+
 	// Number of reads since step or head change
 	uint32_t m_readLoops;
 


### PR DESCRIPTION
# Physical floppy drives: reliability and speed follow-up

Follow-up to #327. Fixes the read errors `normal` mode could raise on a healthy disk, fixes a data-corruption bug in auto-cache, and rounds off the bridge's options and launcher page. Verified against a Greaseweazle V4.1 with a Workbench 1.3 disk: scored A500 boots, a scripted A600 open-the-disk-from-the-desktop harness, and a hardware probe that captures and checksums revolutions directly (`tests/bridge_capture_probe.rs`).

## Fixes

- **`normal`-mode read errors.** An index-less capture is assembled by the driver pattern-matching where the revolution repeats, and on a small fraction of captures (13 of 400 measured) that match resolves a few dozen bits long, splicing duplicated flux mid-track — one sector then fails its checksum, and the capture was being cached and re-served to every retry. Copperline now verifies each capture as the ring it will be served as: verified-clean (or index-aligned) recordings are kept and replayed like an image's track, anything less is served exactly once and refetched, so the guest's own retry reaches fresh flux. 17/17 scored runs clean, including five that recovered from damaged captures mid-run.
- **Auto-cache could write a track to the wrong cylinder.** The background cacher moves the physical head without updating the bookkeeping the write handler trusts, so a write queued while it was walking the disk could land wherever the head happened to be — corrupting an unrelated track of a real disk. The one behavioural change to `vendor/floppybridge` (marked `COPPERLINE:`, recorded in the vendor README, worth carrying upstream): the write handler restores the head first, as the read path always has. Verified on real media.
- **`[floppy] speed` no longer reaches bridged bays** (data-path multiplier, turbo bursts, and both event-horizon predictions): a physical drive's data rate is the disk's own. The launcher greys the Drive speed row when every fitted bay is physical.

## Improvements

- **The bridge waits out the head settle** before asking the drive for a track, instead of naming every intermediate track of a multi-step seek and making the driver abort and restart its capture each time.
- **`bridge_speed = 100 | 125 | 150`** (config, `--floppy-bridge-speed`, and the drive's launcher page): serves each captured revolution at that percentage of real speed. The capture still takes a revolution; the recovered cells reach the guest faster.
- **Launcher:** the bridge page greys when its bay is gone or no interface is attached; the Interface row offers **None** (auto-selected when nothing is plugged in) and the Floppy tab reads **Not connected**; the serial-port list offers every host serial device.
- **`bridge_smart_speed` is removed.** Its only effect in the library is on a speed channel (`getMFMSpeed`) Copperline never reads, so the option could not do anything here.

All read modes and options were exercised on hardware: `normal`, `compatible`, `stalling`, auto-cache, and the serving speeds. DrawBridge and Supercard Pro remain untested against real hardware, as in #327.