### PR TITLE
Avoid busy redraw loop in idle launcher

### DIFF
--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -499,6 +499,10 @@ fn repeated_main_key_should_drop(
     }
 }
 
+fn ui_needs_continuous_redraw(running: bool, active: bool) -> bool {
+    running && active
+}
+
 fn raw_device_qualifier_rawkey(code: KeyCode) -> Option<u8> {
     match code {
         KeyCode::ShiftLeft => Some(AMIGA_RAWKEY_LEFT_SHIFT),
@@ -3504,7 +3508,7 @@ impl ApplicationHandler for App {
             let chrome_changed = self.last_main_redraw_state != Some(redraw_state);
             if self.main_presentation_dirty
                 || chrome_changed
-                || self.ui.active()
+                || ui_needs_continuous_redraw(running, self.ui.active())
                 || self.drop_hover
                 || osd_active
                 || calibrating

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -88,7 +88,7 @@ fn host_mapping_includes_amiga_modifiers() {
 }
 
 #[test]
-fn powered_off_ui_does_not_continuously_redraw() {
+fn ui_needs_continuous_redraw_only_when_running_and_active() {
     assert!(!super::ui_needs_continuous_redraw(false, true));
     assert!(super::ui_needs_continuous_redraw(true, true));
     assert!(!super::ui_needs_continuous_redraw(true, false));

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -88,6 +88,13 @@ fn host_mapping_includes_amiga_modifiers() {
 }
 
 #[test]
+fn powered_off_ui_does_not_continuously_redraw() {
+    assert!(!super::ui_needs_continuous_redraw(false, true));
+    assert!(super::ui_needs_continuous_redraw(true, true));
+    assert!(!super::ui_needs_continuous_redraw(true, false));
+}
+
+#[test]
 fn host_repeat_filter_accepts_unheld_amiga_qualifier_press() {
     let mut held = [false; 128];
 


### PR DESCRIPTION
Only keep active UI panels on continuous redraw while the emulated machine is running. Static powered-off panels already request redraws for interaction, while requesting one from about_to_wait immediately wakes ControlFlow::Wait and pegs a CPU core on Linux.

Add regression coverage for powered-off, running, and inactive UI states.