### PR TITLE
build(flatpak): update Freedesktop SDK to 25.08

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -45,7 +45,7 @@ jobs:
     # The flatpak-github-actions image ships flatpak-builder, the Freedesktop
     # runtime/SDK matching the manifest, and flatpak-builder-lint.
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
       options: --privileged
     steps:
       - uses: actions/checkout@v7

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -28,8 +28,8 @@ CI (`.github/workflows/flatpak.yml`) fails if the committed file is stale.
 ## Build and test locally (on Linux)
 
 ```sh
-flatpak install flathub org.freedesktop.Platform//24.08 \
-    org.freedesktop.Sdk//24.08 org.freedesktop.Sdk.Extension.rust-stable//24.08
+flatpak install flathub org.freedesktop.Platform//25.08 \
+    org.freedesktop.Sdk//25.08 org.freedesktop.Sdk.Extension.rust-stable//25.08
 
 flatpak run org.flatpak.Builder --force-clean --user --install \
     --install-deps-from=flathub --repo=repo builddir \

--- a/packaging/flatpak/dev.copperline.Copperline.yaml
+++ b/packaging/flatpak/dev.copperline.Copperline.yaml
@@ -12,8 +12,8 @@
 # dependency already inside the source tree, so it needs no special handling.
 #
 # Local build and test:
-#   flatpak install flathub org.freedesktop.Platform//24.08 \
-#       org.freedesktop.Sdk//24.08 org.freedesktop.Sdk.Extension.rust-stable//24.08
+#   flatpak install flathub org.freedesktop.Platform//25.08 \
+#       org.freedesktop.Sdk//25.08 org.freedesktop.Sdk.Extension.rust-stable//25.08
 #   flatpak run org.flatpak.Builder --force-clean --user --install \
 #       --install-deps-from=flathub --repo=repo builddir \
 #       packaging/flatpak/dev.copperline.Copperline.yaml
@@ -26,7 +26,7 @@
 #       repo repo
 id: dev.copperline.Copperline
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
## Summary

- update the Flatpak runtime and SDK extension from Freedesktop 24.08 to 25.08
- use the matching `freedesktop-25.08` GitHub Actions builder image
- update the documented local Flatpak installation commands

## Root cause

Freedesktop 24.08 currently supplies Rust 1.89. That is older than the Rust 1.93 MSRV required by the dependency update in #342, so its offline Flatpak build stops before compilation. The current Freedesktop 25.08 SDK source pins Rust 1.95.

## Validation

- `actionlint .github/workflows/flatpak.yml`
- confirmed `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08` publishes amd64 and arm64 images
- confirmed no 24.08 references remain in the Flatpak manifest, workflow, or setup documentation

This is a prerequisite for #342.

Closes #344
