### PR TITLE
window: map cursor hits through the scaling clip rect

### DIFF
--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -183,7 +183,7 @@ authoritative list. The most useful ones:
 | `COPPERLINE_DIAG_GAYLE` / `COPPERLINE_DIAG_CDTV` | Gayle IDE / CDTV controller traffic |
 | `COPPERLINE_DIAG_A2091` | A2091 SCSI board register traffic (DMAC + WD33C93 accesses; the trace that brings up boot-ROM issues) |
 | `COPPERLINE_DIAG_A4091` | A4091 53C710 SCRIPTS execution trace (each instruction the script processor runs) |
-| `COPPERLINE_DIAG_CURSOR` | On every mouse-button press, log the raw host cursor position, the window's scale factor and inner size, the texture supersample factor, the `window_pos_to_pixel` result, and which region (status bar / display / none) the click resolved to; for diagnosing mouse capture on DPI scale changes or mixed-scale monitors |
+| `COPPERLINE_DIAG_CURSOR` | On every mouse-button press, log the raw host cursor position, the window's scale factor and inner size, the texture supersample factor, the scaling clip rect and texture extent the click maps through, the mapped position, and which region (status bar / display / none) the click resolved to; for diagnosing mouse capture on DPI scale changes or mixed-scale monitors |
 | `COPPERLINE_DUMP_BLITMEM=START:END:LO:HI` | Dump chip RAM `[LO,HI)` on every BLTSIZE write between START and END emulated seconds; output goes to `$TMPDIR/copperline-blitdump` unless `COPPERLINE_DUMP_BLITMEM_DIR` is set |
 | `COPPERLINE_DUMP_BUS_ACCOUNTING` | Per-frame chip-bus slot accounting |
 | `COPPERLINE_DUMP_RENDER_META[_VERBOSE]` | Renderer event/fetch metadata |

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3844,7 +3844,7 @@ impl App {
     }
 
     /// COPPERLINE_DIAG_CURSOR: trace how the most recent click maps from host
-    /// physical coordinates through pixels' window_pos_to_pixel into a
+    /// physical coordinates through the scaling renderer's clip rect into a
     /// texture/region hit. The tool for diagnosing mouse capture on DPI scale
     /// changes and mixed-scale monitors (see the ScaleFactorChanged handler):
     /// if a status-bar click logs region=display(->capture), the surface and
@@ -3859,7 +3859,9 @@ impl App {
         let scale_factor = r.window.scale_factor();
         let inner = r.window.inner_size();
         let phys = self.last_cursor_phys;
-        let mapped = phys.map(|p| r.pixels.window_pos_to_pixel((p.x as f32, p.y as f32)));
+        let context = r.pixels.context();
+        let clip = context.scaling_renderer.clip_rect();
+        let texture = (context.texture_extent.width, context.texture_extent.height);
         let pos = phys.and_then(|p| cursor_texture_position(&r.pixels, p, r.texture_scale));
         let region = match pos {
             Some(p) if cursor_in_status_bar(p) => "status_bar",
@@ -3869,11 +3871,13 @@ impl App {
         };
         info!(
             "[DIAG_CURSOR] button={button:?} phys={phys:?} scale_factor={scale_factor:.4} \
-             inner={}x{} texture_scale={} window_pos_to_pixel={mapped:?} mapped_pos={pos:?} \
+             inner={}x{} texture_scale={} clip_rect={clip:?} texture={}x{} mapped_pos={pos:?} \
              region={region} (present_h={} window_present_h={} fb_w={FB_WIDTH})",
             inner.width,
             inner.height,
             r.texture_scale,
+            texture.0,
+            texture.1,
             present_height(),
             window_present_height(),
         );

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -380,7 +380,7 @@ pub(super) fn texture_scale_for_factor(scale_factor: f64) -> usize {
 
 /// React to a host DPI scale-factor change for one window's pixel surface.
 ///
-/// pixels' `window_pos_to_pixel` maps a host click into texture space using
+/// `cursor_texture_position` maps a host click into texture space using
 /// both the surface size (which the following Resized event updates) and the
 /// texture extent (which nothing updated before this). When the supersample
 /// factor changes -- e.g. dragging between a 1x and a 2x monitor -- the texture
@@ -429,6 +429,11 @@ pub(super) fn build_pixels_for_window(
     };
     let mut pixels = builder.build()?;
     pixels.set_scaling_mode(ScalingMode::Fill);
+    // set_scaling_mode only stores the mode; the scaling matrix and clip rect
+    // stay the builder's PixelPerfect ones until a resize recomputes them.
+    // Re-apply the surface size so the cursor mapping and the render scissor
+    // agree with the Fill pass from the first frame, not the first resize.
+    pixels.resize_surface(inner.width.max(1), inner.height.max(1))?;
     Ok(pixels)
 }
 
@@ -449,15 +454,51 @@ pub(in crate::video) fn scale_rect(rect: Rect, scale: usize) -> Rect {
     }
 }
 
+/// Map a host cursor position (surface physical pixels) into a logical canvas
+/// position, or None outside the presented picture.
+///
+/// Deliberately not pixels' `window_pos_to_pixel`: that helper re-centres
+/// through `min(texture, surface) / 2`, which is only correct while the
+/// texture fits inside the surface. The supersampled texture is *larger* than
+/// the surface whenever the rounded texture scale exceeds a fractional host
+/// scale factor (a 2x texture over a 1.5x surface on a 150% desktop), and the
+/// shifted mapping it produces there lands every status-bar click in the
+/// display region, where it takes the mouse capture instead of the control.
+/// Mapping through the scaling renderer's clip rect -- the surface rect the
+/// Fill pass draws the picture into -- holds on both sides of that boundary,
+/// and agrees with the render by construction: the rect derives from the same
+/// surface and texture extents the render pass scissors with.
 pub(super) fn cursor_texture_position(
     pixels: &Pixels<'_>,
     position: winit::dpi::PhysicalPosition<f64>,
     texture_scale: usize,
 ) -> Option<(i32, i32)> {
-    let (x, y) = pixels
-        .window_pos_to_pixel((position.x as f32, position.y as f32))
-        .ok()?;
+    let context = pixels.context();
+    let (x, y) = cursor_position_in_texture(
+        (position.x, position.y),
+        context.scaling_renderer.clip_rect(),
+        (context.texture_extent.width, context.texture_extent.height),
+    )?;
     Some(((x / texture_scale) as i32, (y / texture_scale) as i32))
+}
+
+/// The pure half of [`cursor_texture_position`]: position and clip rect in
+/// surface physical pixels to supersampled-texture pixels.
+pub(super) fn cursor_position_in_texture(
+    position: (f64, f64),
+    clip: (u32, u32, u32, u32),
+    texture: (u32, u32),
+) -> Option<(usize, usize)> {
+    let (clip_x, clip_y, clip_w, clip_h) = clip;
+    if clip_w == 0 || clip_h == 0 {
+        return None;
+    }
+    let x = (position.0 - f64::from(clip_x)) * f64::from(texture.0) / f64::from(clip_w);
+    let y = (position.1 - f64::from(clip_y)) * f64::from(texture.1) / f64::from(clip_h);
+    if x < 0.0 || x >= f64::from(texture.0) || y < 0.0 || y >= f64::from(texture.1) {
+        return None;
+    }
+    Some((x as usize, y as usize))
 }
 
 pub(super) fn cursor_in_status_bar(pos: (i32, i32)) -> bool {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8,24 +8,25 @@ use super::ui::{AnalyzerTab, Panel, UiControl};
 use super::{
     bar_layout, center_present_frame_for_visible_start, center_present_frame_horizontally,
     control_at, copperline_icon_image, copperline_logo_image, copy_present_frame,
-    copy_window_present_frame, draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect,
-    host_shortcut_modifier_pressed, host_to_amiga_rawkey, joystick_toggle_rect, led_row_rect,
-    mask_present_frame_to_tv, paint_test_screen, parse_amiga_key, pause_button_rect,
-    power_button_rect, present_height, presentation_pixels_equal, presentation_source_y_offset,
-    raw_device_qualifier_family_held, raw_device_qualifier_rawkey, rawkey_is_held,
-    rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
-    short_status_error, shorten_status_paths, shot_button_rect, should_render_emulated_frame,
-    standard_window_top_row, status_with_latched_fdd_track, take_integral_mouse_delta,
-    texture_height, texture_width, tint_display_rows, tint_lut, tint_rows_in_place,
-    tv_aperture_source_row, tv_source_h_bounds, volume_percent_from_pos, volume_slider_track_rect,
-    BarControl, DriveBar, JoystickInputMode, MediaBar, PresentationLatch, StatusBarView,
-    ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
-    AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON,
-    DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
-    POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_DIM, POWER_LED_OFF,
-    STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-    TRACK_SEGMENT_ON, TV_CAPTURED_SOURCE_X, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
-    TV_PRESENT_SOURCE_X, TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
+    copy_window_present_frame, cursor_position_in_texture, draw_status_bar, fdd_track_counter_rect,
+    fdd_track_digit_rect, host_shortcut_modifier_pressed, host_to_amiga_rawkey,
+    joystick_toggle_rect, led_row_rect, mask_present_frame_to_tv, paint_test_screen,
+    parse_amiga_key, pause_button_rect, power_button_rect, present_height,
+    presentation_pixels_equal, presentation_source_y_offset, raw_device_qualifier_family_held,
+    raw_device_qualifier_rawkey, rawkey_is_held, rawkey_transition_is_duplicate,
+    reboot_button_rect, repeated_main_key_should_drop, rgba, short_status_error,
+    shorten_status_paths, shot_button_rect, should_render_emulated_frame, standard_window_top_row,
+    status_with_latched_fdd_track, take_integral_mouse_delta, texture_height, texture_width,
+    tint_display_rows, tint_lut, tint_rows_in_place, tv_aperture_source_row, tv_source_h_bounds,
+    volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, JoystickInputMode,
+    MediaBar, PresentationLatch, StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT,
+    AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH,
+    BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL,
+    FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON,
+    POWER_LED_BRIGHT, POWER_LED_DIM, POWER_LED_OFF, STANDARD_PAL_VISIBLE_LINES,
+    STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON,
+    TV_CAPTURED_SOURCE_X, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT, TV_PRESENT_SOURCE_X,
+    TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
@@ -6666,5 +6667,79 @@ fn switching_analyzer_tabs_keeps_the_heat_map_recording() {
     assert_eq!(
         after.census.iter().map(|row| row.cells).sum::<usize>(),
         recorded
+    );
+}
+
+/// At a 150% fractional host scale the supersampled texture (2x logical) is
+/// larger than the surface (1.5x logical): 1432x1162 over 1074x872 for the
+/// default TV canvas, for which the Fill scaler computes a clip rect of
+/// (0, 0, 1074, 871). pixels' own `window_pos_to_pixel` re-centres through
+/// `min(texture, surface) / 2` and shifted every hit 72 logical pixels
+/// up-left in that state -- the whole 44-pixel status bar mapped into the
+/// display region, so bar clicks took the mouse capture instead.
+#[test]
+fn cursor_mapping_reaches_status_bar_at_fractional_scale() {
+    let clip = (0, 0, 1074, 871);
+    let texture = (1432, 1162);
+    let texture_scale = 2;
+
+    // Mid-height of the visible status-bar strip (the bottom 44/581 of the
+    // window): logical y 559 sits inside the bar's 537..581 band.
+    let (x, y) = cursor_position_in_texture((537.0, 839.0), clip, texture).unwrap();
+    assert_eq!((x / texture_scale, y / texture_scale), (358, 559));
+
+    // Near the left edge of the bar: the old mapping pushed this off the
+    // texture's left edge and returned an error (click swallowed).
+    let (x, y) = cursor_position_in_texture((53.7, 839.0), clip, texture).unwrap();
+    assert_eq!((x / texture_scale, y / texture_scale), (35, 559));
+
+    // Top-left of the display: also unmapped before.
+    let (x, y) = cursor_position_in_texture((10.0, 10.0), clip, texture).unwrap();
+    assert_eq!((x / texture_scale, y / texture_scale), (6, 6));
+
+    // The sub-pixel letterbox row under the picture stays outside.
+    assert_eq!(
+        cursor_position_in_texture((537.0, 871.9), clip, texture),
+        None
+    );
+}
+
+/// A texture that fits inside the surface (a 125% host scale rounds to a 1x
+/// texture) is the case pixels' helper handled correctly; the clip-rect
+/// mapping must reproduce it. 716x581 texture in an 895x726 surface: Fill
+/// scales by 726/581 and clips to (0, 0, 894, 726).
+#[test]
+fn cursor_mapping_unchanged_when_texture_fits_surface() {
+    let clip = (0, 0, 894, 726);
+    let texture = (716, 581);
+    assert_eq!(
+        cursor_position_in_texture((447.5, 363.0), clip, texture),
+        Some((358, 290))
+    );
+    // Mid-height of the visible status-bar strip maps into the bar band.
+    assert_eq!(
+        cursor_position_in_texture((447.5, 698.5), clip, texture),
+        Some((358, 558))
+    );
+}
+
+/// A manually resized wide window pillarboxes the picture; clicks in the
+/// side bars are outside the presentation and stay unmapped, while clicks
+/// on the picture land as if the bars were not there. 1432x1162 texture in
+/// a 2000x600 surface: Fill clips to (630, 0, 739, 600).
+#[test]
+fn cursor_mapping_rejects_pillarbox_clicks() {
+    let clip = (630, 0, 739, 600);
+    let texture = (1432, 1162);
+    assert_eq!(
+        cursor_position_in_texture((300.0, 300.0), clip, texture),
+        None
+    );
+    let (x, _) = cursor_position_in_texture((1000.0, 300.0), clip, texture).unwrap();
+    assert_eq!(x, 716);
+    // A zero-area clip (minimized surface) maps nothing.
+    assert_eq!(
+        cursor_position_in_texture((0.0, 0.0), (0, 0, 0, 0), texture),
+        None
     );
 }


### PR DESCRIPTION
## Summary

Fixes the report that the status bar can no longer be clicked under 150% fractional display scaling: every click on the visible bar was mis-mapped into the display region and taken as click-to-capture, so the mouse was grabbed instead of the control being pressed.

## Root cause

pixels' `window_pos_to_pixel` re-centres a click through `min(texture, surface) / 2`, which is only correct while the backing texture fits inside the surface. Our supersampled texture is *larger* than the surface whenever the rounded texture scale exceeds a fractional host scale factor — a 2x texture (1432x1162) over a 1.5x surface (1074x872) on a 150% desktop. The shifted mapping that falls out lands 72 logical pixels short of the 44-pixel status bar, so no part of it was reachable at 150% or 175%, and the left/top edges of the window failed to map at all (clicks swallowed). Latent since the supersampled texture was introduced; any fractional scale in (1.5, 2.0) triggers it on every platform.

## Fix

- `cursor_texture_position` now maps through the scaling renderer's clip rect — the surface rect the Fill pass actually draws the picture into, derived from the same surface and texture extents the render pass scissors with — so the hit test and the picture agree on both sides of the texture/surface size boundary. The pure half (`cursor_position_in_texture`) is unit-testable; the one helper covers the main window and tool windows, and also fixes the partial variant in fullscreen on a monitor with fewer rows than the texture.
- `build_pixels_for_window` re-applies the surface size after `set_scaling_mode(Fill)`: pixels only stores the mode, so the scaling matrix and clip rect stayed the builder's PixelPerfect ones until the first resize event.
- `COPPERLINE_DIAG_CURSOR` logs the clip rect and texture extent the mapping runs through (docs updated).

## Verification

- New regression tests pin the 150% mapping using the exact clip rect a live Fill scaler computes for the default TV canvas — `(0, 0, 1074, 871)`, measured with a standalone winit+pixels probe on a KDE Wayland session at 150% — plus the texture-fits-surface case pixels handled correctly and pillarbox rejection.
- The same probe run with the fixed mapping classifies every sampled point of the visible bar strip as `status_bar` (previously `display(->capture)` or unmapped), and the window centre maps to the exact canvas centre.
- `cargo test` (2051 passing), `cargo clippy`, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
