### PR TITLE
floppy: faster bridge serving speeds, state disk write protection in CLI

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -598,5 +598,5 @@ floppy_sounds_volume = 100
 #                                # default, skips the wait for the index and is
 #                                # appreciably quicker; stalling blocks the
 #                                # emulated machine until each track is ready
-# bridge_speed = 100             # serve captured tracks at 100/125/150%
+# bridge_speed = 125             # 100, 125, 150, 175, or 200 percent
 # bridge_auto_cache = false      # cache disk data while the drive is idle

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -52,7 +52,7 @@ range checks as the equivalent TOML fields:
 | `--floppy-bridge-cable DFN SEL` | `[floppy.dfN] bridge_cable` | drive select: `a`/`b` (PC cable) or `0`-`3` (Shugart) |
 | `--floppy-bridge-mode DFN MODE` | `[floppy.dfN] bridge_mode` | how tracks are captured: `normal`, `compatible`, `stalling` |
 | `--floppy-bridge-density DFN D` | `[floppy.dfN] bridge_density` | force a density: `auto`, `dd`, `hd` |
-| `--floppy-bridge-speed DFN PCT` | `[floppy.dfN] bridge_speed` | serve captured tracks at `100`, `125`, or `150` percent of real speed |
+| `--floppy-bridge-speed DFN PCT` | `[floppy.dfN] bridge_speed` | serve captured tracks at `100`, `125`, `150`, `175`, or `200` percent of real speed |
 | `--floppy-bridge-auto-cache DFN` | `[floppy.dfN] bridge_auto_cache = true` | cache disk data while the drive is idle |
 | `--floppy-bridge-writable DFN` | `[floppy.dfN] write_protected = false` | allow writing to the real disk |
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
@@ -1078,7 +1078,7 @@ write_protected = true       # emulator-level protection, on top of the tab
 # bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
 # bridge_density = "auto"        # auto/dd/hd
 # bridge_mode = "compatible"     # compatible/stalling
-# bridge_speed = 100             # serve captured tracks at 100/125/150% of real speed
+# bridge_speed = 125             # 100, 125, 150, 175, or 200 percent of real speed
 # bridge_auto_cache = false      # read tracks ahead while the drive is idle
 ```
 

--- a/docs/guide/floppybridge.md
+++ b/docs/guide/floppybridge.md
@@ -53,7 +53,7 @@ write_protected = true       # emulator-level protection; default true
 # bridge_cable = "a"             # a/b (IBM PC) or 0..3 (Shugart)
 # bridge_density = "auto"        # auto/dd/hd
 # bridge_mode = "normal"         # normal/compatible/stalling
-# bridge_speed = 100             # serve captured tracks at 100/125/150%
+# bridge_speed = 125             # 100, 125, 150, 175, or 200 percent
 # bridge_auto_cache = false
 ```
 
@@ -143,10 +143,11 @@ emulated machine, which stops -- pointer and all -- for as long as it takes.
 
 ### Bridge speed and auto-cache
 
-`bridge_speed` serves captured tracks at `100` (real, the default), `125`,
-or `150` percent of real speed. Capturing still takes a full revolution;
-only the serving is faster. The trade is the same as `[floppy] speed`:
-software that times its own loading can notice.
+`bridge_speed` serves captured tracks at `100`, `125` (the default), `150`,
+`175`, or `200` percent of real speed. Capturing still takes a full
+revolution; only the serving is faster, so the gain lands on tracks already
+in hand. As with `[floppy] speed`, software that times its own loading can
+notice.
 
 `bridge_auto_cache` caches disk data in the background while the drive is
 idle. It is off by default: during a boot the drive is never idle, so there 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1088,7 +1088,10 @@ pub enum BridgeCable {
 /// Serving speeds a bridged bay accepts, as percentages of the platter's
 /// real speed. Shared by the config parser, the CLI, and the launcher's
 /// cycle row so all three offer the same set.
-pub const SUPPORTED_BRIDGE_SPEED_PERCENTS: [u16; 3] = [100, 125, 150];
+pub const SUPPORTED_BRIDGE_SPEED_PERCENTS: [u16; 5] = [100, 125, 150, 175, 200];
+
+/// The serving speed a bridged bay uses unless told otherwise.
+pub const DEFAULT_BRIDGE_SPEED_PERCENT: u16 = 125;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FloppyBridgeConfig {
@@ -1105,11 +1108,11 @@ pub struct FloppyBridgeConfig {
     pub density: BridgeDensity,
     pub cable: BridgeCable,
     /// How fast a captured revolution is served to the guest, as a
-    /// percentage of the platter's real speed: `100` (real, the default),
-    /// `125`, or `150`. Serving faster shortens rotational waits on tracks
-    /// already in hand; the physical capture itself still takes as long as a
-    /// revolution takes, and the same caveat applies as to `[floppy] speed`
-    /// -- software that times its own loading can notice.
+    /// percentage of the platter's real speed: `100`, `125` (the default),
+    /// `150`, `175`, or `200`. Serving faster shortens rotational waits on
+    /// tracks already in hand; capturing one still takes a full revolution.
+    /// As with `[floppy] speed`, software that times its own loading can
+    /// notice.
     pub speed: u16,
     /// Read tracks ahead in the background while the drive is otherwise idle.
     /// Off by default, as the driver has it. It buys little during
@@ -1130,7 +1133,7 @@ impl Default for FloppyBridgeConfig {
             mode: BridgeSpeedMode::default(),
             density: BridgeDensity::default(),
             cable: BridgeCable::default(),
-            speed: 100,
+            speed: DEFAULT_BRIDGE_SPEED_PERCENT,
             auto_cache: false,
         }
     }
@@ -2809,8 +2812,8 @@ pub(crate) struct RawFloppyDrive {
     /// `0`..`3` (Shugart).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_cable: Option<String>,
-    /// Serve captured tracks at this percentage of real speed: 100 (the
-    /// default), 125, or 150.
+    /// Serve captured tracks at this percentage of real speed: 100,
+    /// 125 (the default), 150, 175, or 200.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bridge_speed: Option<u16>,
     /// Let the driver cache other cylinders while the disk is
@@ -4481,11 +4484,11 @@ fn parse_floppy_bridge(idx: usize, spec: &str, raw: &RawFloppyDrive) -> Result<F
         .map(str::to_string);
 
     let speed = match raw.bridge_speed {
-        None => 100,
+        None => DEFAULT_BRIDGE_SPEED_PERCENT,
         Some(p) if SUPPORTED_BRIDGE_SPEED_PERCENTS.contains(&p) => p,
         Some(other) => bail!(
             "floppy.df{idx} bridge_speed = {other} is not a supported serving \
-             speed (100, 125, or 150)"
+             speed (100, 125, 150, 175, or 200)"
         ),
     };
 
@@ -6904,7 +6907,7 @@ mod tests {
         assert_eq!(df0.port, None);
         assert_eq!(df0.mode, BridgeSpeedMode::Normal);
         assert_eq!(df0.density, BridgeDensity::Auto);
-        assert_eq!(df0.speed, 100);
+        assert_eq!(df0.speed, DEFAULT_BRIDGE_SPEED_PERCENT);
         assert!(!df0.auto_cache);
 
         let df1 = cfg.floppy.bridges[1].as_ref().expect("df1 bridged");
@@ -6921,22 +6924,42 @@ mod tests {
         Ok(())
     }
 
-    /// Only the three supported serving speeds are accepted, by name in the
-    /// error so a typo explains itself.
+    /// Only the listed serving speeds are accepted, by name in the error so
+    /// a typo explains itself. A value between two of them is still refused.
     #[cfg(feature = "floppybridge")]
     #[test]
     fn floppy_bridge_speed_rejects_unsupported_values() {
-        let err = parse_config(
-            r#"
-            [floppy.df0]
-            bridge = "greaseweazle"
-            bridge_speed = 120
-        "#,
-        )
-        .expect_err("120 is not a supported serving speed");
-        let msg = format!("{err:#}");
-        assert!(msg.contains("bridge_speed"), "unexpected error: {msg}");
-        assert!(msg.contains("125"), "names the accepted values: {msg}");
+        for bad in [120, 160, 250] {
+            let err = parse_config(&format!(
+                r#"
+                [floppy.df0]
+                bridge = "greaseweazle"
+                bridge_speed = {bad}
+            "#
+            ))
+            .expect_err("not a supported serving speed");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("bridge_speed"), "unexpected error: {msg}");
+            assert!(msg.contains("125"), "names the accepted values: {msg}");
+        }
+    }
+
+    /// Every listed speed parses back as itself, the fastest included.
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn floppy_bridge_speed_accepts_every_listed_value() -> Result<()> {
+        for want in SUPPORTED_BRIDGE_SPEED_PERCENTS {
+            let cfg = parse_config(&format!(
+                r#"
+                [floppy.df0]
+                bridge = "greaseweazle"
+                bridge_speed = {want}
+            "#
+            ))?;
+            let df0 = cfg.floppy.bridges[0].as_ref().expect("df0 bridged");
+            assert_eq!(df0.speed, want);
+        }
+        Ok(())
     }
 
     // A build without the feature has no bridges to configure: the keys are

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -619,7 +619,7 @@ impl FloppyController {
     /// Put a real drive on `drive_idx`, replacing any mounted image. The
     /// bridge supplies the track under the head from then on. `speed_percent`
     /// is the serving speed from `[floppy.dfN] bridge_speed`, already
-    /// validated to 100, 125, or 150.
+    /// validated against `SUPPORTED_BRIDGE_SPEED_PERCENTS`.
     #[cfg(feature = "floppybridge")]
     pub fn attach_bridge(
         &mut self,
@@ -745,22 +745,36 @@ impl FloppyController {
             let changed = bridge.take_disk_changed();
             let had_media = drive.bridge_media;
             drive.bridge_media = bridge.disk_in_drive();
-            // A disk going in or coming out of a real drive is the one media
-            // change nothing in the emulator asked for, so it is worth saying
-            // as plainly as an image being inserted.
-            if drive.bridge_media != had_media {
-                if drive.bridge_media {
-                    info!("floppy.df{idx} disk inserted (physical drive)");
-                } else {
-                    info!("floppy.df{idx} disk ejected (physical drive)");
-                }
-            }
             // Sample the drive before the borrow is needed elsewhere. The
             // driver keeps the tab's last reading and hands it back whatever
             // the motor is doing, so this is good with the platter stopped --
             // which is just as well, because a drive the guest is not actively
             // reading is stopped nearly all the time.
             let sensed_tab = bridge.write_protected();
+            // A disk going in or coming out of a real drive is the one media
+            // change nothing in the emulator asked for, so it is worth saying
+            // as plainly as an image being inserted. A drive the
+            // configuration protects cannot be written to whatever the tab
+            // says, so the tab is only worth reporting on a drive that could
+            // otherwise take a write.
+            if drive.bridge_media != had_media {
+                if drive.bridge_media {
+                    if drive.bridge_write_protected {
+                        info!("floppy.df{idx} disk inserted (physical drive)");
+                    } else {
+                        info!(
+                            "floppy.df{idx} disk inserted (physical drive), {}",
+                            if sensed_tab {
+                                "write-protected by the disk's tab"
+                            } else {
+                                "writable"
+                            }
+                        );
+                    }
+                } else {
+                    info!("floppy.df{idx} disk ejected (physical drive)");
+                }
+            }
             if changed {
                 drive.cached_track = None;
                 drive.cached = CachedTrack::default();
@@ -778,16 +792,21 @@ impl FloppyController {
             if write_protected != drive.write_protected_target {
                 // Which of the two protections is in force decides whether
                 // opening the tab will help, so name it rather than just
-                // reporting the outcome.
-                if write_protected {
-                    let reason = if drive.bridge_write_protected {
-                        "the configuration"
+                // reporting the outcome. An insertion has already said this,
+                // and an empty drive has no disk to say it about.
+                if drive.bridge_media && drive.bridge_media == had_media {
+                    if write_protected {
+                        let reason = if drive.bridge_write_protected {
+                            "the configuration"
+                        } else {
+                            "the disk's tab"
+                        };
+                        info!(
+                            "floppy.df{idx} disk is write-protected by {reason} (physical drive)"
+                        );
                     } else {
-                        "the disk's tab"
-                    };
-                    info!("floppy.df{idx} disk is write-protected by {reason} (physical drive)");
-                } else {
-                    info!("floppy.df{idx} disk is writable (physical drive)");
+                        info!("floppy.df{idx} disk is writable (physical drive)");
+                    }
                 }
                 drive.set_write_protected(write_protected);
                 self.idle_cache = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,7 +505,8 @@ where
             }
             #[cfg(feature = "floppybridge")]
             "--floppy-bridge-speed" => {
-                const USAGE: &str = "--floppy-bridge-speed requires DFN PERCENT (100, 125, or 150)";
+                const USAGE: &str =
+                    "--floppy-bridge-speed requires DFN PERCENT (100, 125, 150, 175, or 200)";
                 let drive_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let percent_s = args.next().ok_or_else(|| anyhow!(USAGE))?;
                 let idx = parse_floppy_drive_idx(&drive_s, "--floppy-bridge-speed")?;
@@ -1079,7 +1080,7 @@ fn print_help() {
          --floppy-bridge-cable DFN SEL  drive select on the cable: a/b (PC) or 0-3 (Shugart)\n  \
          --floppy-bridge-mode DFN MODE  how tracks are captured: normal, compatible, stalling\n  \
          --floppy-bridge-density DFN D  force a density: auto, dd, or hd\n  \
-         --floppy-bridge-speed DFN PCT  serve captured tracks at 100/125/150% of real speed\n  \
+         --floppy-bridge-speed DFN PCT  serve captured tracks at 100, 125, 150, 175, or 200%\n  \
          --floppy-bridge-auto-cache DFN   cache disk data while the drive is idle\n  \
          --floppy-bridge-writable DFN   let the guest write to the physical disk (which is\n  \
          \x20                            write-protected unless asked otherwise)\n  ";
@@ -1253,7 +1254,7 @@ fn parse_floppy_speed(s: &str) -> Result<u16> {
 
 #[cfg(feature = "floppybridge")]
 fn parse_floppy_bridge_speed(s: &str) -> Result<u16> {
-    const MSG: &str = "--floppy-bridge-speed PERCENT must be 100, 125, or 150";
+    const MSG: &str = "--floppy-bridge-speed PERCENT must be 100, 125, 150, 175, or 200";
     let speed: u16 = s.trim().parse().map_err(|_| anyhow!(MSG))?;
     if !copperline::config::SUPPORTED_BRIDGE_SPEED_PERCENTS.contains(&speed) {
         return Err(anyhow!(MSG));
@@ -2606,7 +2607,10 @@ mod tests {
         let err = parse(&["--floppy-bridge-speed", "df0", "120"])
             .expect_err("120 is not a supported serving speed");
         let msg = format!("{err:#}");
-        assert!(msg.contains("100, 125, or 150"), "unexpected error: {msg}");
+        assert!(
+            msg.contains("100, 125, 150, 175, or 200"),
+            "unexpected error: {msg}"
+        );
     }
 
     /// A real drive can be asked for entirely from the command line, with no

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1932,7 +1932,8 @@ impl MachineSetup {
                     .then(|| bridge_density_name(bridge.density).to_string()),
                 bridge_mode: (bridge.mode != default.mode)
                     .then(|| bridge_mode_name(bridge.mode).to_string()),
-                bridge_speed: (bridge.speed != 100).then_some(bridge.speed),
+                bridge_speed: (bridge.speed != crate::config::DEFAULT_BRIDGE_SPEED_PERCENT)
+                    .then_some(bridge.speed),
                 bridge_auto_cache: bridge.auto_cache.then_some(true),
                 // Same rule, and the same tick box, as an image: only an
                 // unprotected drive says so.


### PR DESCRIPTION
# Physical floppy drives: faster serving speeds, and the write-protect tab on insertion

Two small additions to the bridge, both on the drive's own settings.

## Serving speed

`bridge_speed` now offers `100`, `125`, `150`, `175` and `200` percent of real speed, with `125` as the "balanced" default. It scales how fast a captured revolution is served to the guest — capturing one still takes a full revolution, so the gain lands on tracks already in hand. Available from the config file, `--floppy-bridge-speed DFN PCT`, and the Bridge speed row on the drive's launcher page. As with `[floppy] speed`, software that times its own loading can notice.

The accepted set lives in one constant shared by the config parser, the CLI, and the launcher, so all three offer the same values and the CLI refuses anything else where it is typed.

Tested on a Greaseweazle V4.1 across the range, including `175` and `200`, with no read errors. How far a given setup goes will vary — the disk's format and condition, any copy protection leaning on timing, and the drive itself all have a say — so the slower settings still remain. 

## The disk's write-protect tab

Inserting a disk into a bridged drive reports whether it can be written to:

```
floppy.df0 disk inserted (physical drive), writable
```

or `write-protected by the disk's tab` when the tab is closed.

The tab only decides anything on a bay the configuration leaves writable, so it is only reported there; a bay protected by `write_protected` logs the plain insertion line. The standalone protection message is left for changes that happen while a disk is in the drive, rather than firing about an empty one.