### PR TITLE
cpu: experimental batch/trace-JIT execution mode ([cpu] jit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -606,7 +606,16 @@ version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd990d8a6304475bbad64534a0d418f5572f44d5f011437e6b9f1ee7d5c2570"
 dependencies = [
- "cranelift-assembler-x64-meta",
+ "cranelift-assembler-x64-meta 0.123.12",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.132.3",
 ]
 
 [[package]]
@@ -615,7 +624,16 @@ version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6"
 dependencies = [
- "cranelift-srcgen",
+ "cranelift-srcgen 0.123.12",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+dependencies = [
+ "cranelift-srcgen 0.132.3",
 ]
 
 [[package]]
@@ -624,7 +642,17 @@ version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7ed173c870c0aea202a9830880156905a028a88df076e35ce383a8acbf90a7"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.123.12",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+dependencies = [
+ "cranelift-entity 0.132.3",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -638,25 +666,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bitset"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+dependencies = [
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "cranelift-codegen"
 version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae93f863f9094ae34d2567f9edb0ae2c41d35228b286598354dd78b198868ebd"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
+ "cranelift-assembler-x64 0.123.12",
+ "cranelift-bforest 0.123.12",
+ "cranelift-bitset 0.123.12",
+ "cranelift-codegen-meta 0.123.12",
+ "cranelift-codegen-shared 0.123.12",
+ "cranelift-control 0.123.12",
+ "cranelift-entity 0.123.12",
+ "cranelift-isle 0.123.12",
+ "gimli 0.32.3",
  "hashbrown 0.15.5",
  "log",
  "pulley-interpreter",
- "regalloc2",
+ "regalloc2 0.12.2",
  "rustc-hash 2.1.2",
  "serde",
  "smallvec",
@@ -665,16 +702,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-codegen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64 0.132.3",
+ "cranelift-bforest 0.132.3",
+ "cranelift-bitset 0.132.3",
+ "cranelift-codegen-meta 0.132.3",
+ "cranelift-codegen-shared 0.132.3",
+ "cranelift-control 0.132.3",
+ "cranelift-entity 0.132.3",
+ "cranelift-isle 0.132.3",
+ "gimli 0.33.0",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "regalloc2 0.15.2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "cranelift-codegen-meta"
 version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae"
 dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
+ "cranelift-assembler-x64-meta 0.123.12",
+ "cranelift-codegen-shared 0.123.12",
+ "cranelift-srcgen 0.123.12",
  "heck",
  "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.132.3",
+ "cranelift-codegen-shared 0.132.3",
+ "cranelift-srcgen 0.132.3",
+ "heck",
 ]
 
 [[package]]
@@ -682,6 +758,12 @@ name = "cranelift-codegen-shared"
 version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b786958bcb79bdb5fbae095af58f0c2da7d7895c475c991f6a6bb5a9c7e6d9"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
 
 [[package]]
 name = "cranelift-control"
@@ -693,14 +775,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-control"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "cranelift-entity"
 version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "017271194ba5e101d626560d0d6767efd341468d1ba0f4d015f19fe64020b65b"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.123.12",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+dependencies = [
+ "cranelift-bitset 0.132.3",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -709,7 +810,19 @@ version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.123.12",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+dependencies = [
+ "cranelift-codegen 0.132.3",
  "log",
  "smallvec",
  "target-lexicon",
@@ -722,12 +835,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75904abbc0e7b46d20f7a49c8042c8a4481c0db4253b99889c723c566295d506"
 
 [[package]]
+name = "cranelift-isle"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7def01f2b14f97421558d1db33e396b97b97ab2ed40dedc8165ba00d13088e6"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.132.3",
+ "cranelift-control 0.132.3",
+ "cranelift-entity 0.132.3",
+ "cranelift-module",
+ "cranelift-native 0.132.3",
+ "libc",
+ "log",
+ "memmap2 0.2.3",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence 45.0.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985df7eceefc91cb75bf7f51b32b7f1739d0fc0e25ddf023b1de407cb3c93d77"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.132.3",
+ "cranelift-control 0.132.3",
+]
+
+[[package]]
 name = "cranelift-native"
 version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.123.12",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+dependencies = [
+ "cranelift-codegen 0.132.3",
  "libc",
  "target-lexicon",
 ]
@@ -737,6 +899,12 @@ name = "cranelift-srcgen"
 version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b"
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
 
 [[package]]
 name = "crc32fast"
@@ -1117,6 +1285,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1415,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1558,6 +1741,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a27246c9d8514907e1fa813761e649d69ba14ba2fd9e9b7747fcf5812f7830"
 dependencies = [
+ "cranelift-codegen 0.132.3",
+ "cranelift-frontend 0.132.3",
+ "cranelift-jit",
+ "cranelift-module",
  "serde",
 ]
 
@@ -1589,6 +1776,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2364,7 +2560,7 @@ version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558181096e0df4984f45cfc3a7087052df4a61c36089b135a08ceca9cbd352fb"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.123.12",
  "log",
  "pulley-macros",
  "wasmtime-internal-math",
@@ -2471,6 +2667,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash 2.1.2",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +2708,18 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "renderdoc-sys"
@@ -2634,7 +2856,7 @@ checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2",
+ "memmap2 0.9.11",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -2776,7 +2998,7 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log",
- "memmap2",
+ "memmap2 0.9.11",
  "rustix 0.38.44",
  "thiserror 1.0.69",
  "wayland-backend",
@@ -3265,7 +3487,7 @@ dependencies = [
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-jit-icache-coherence 36.0.12",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
@@ -3280,9 +3502,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d881c3d6205898a226cc487b117f23b9ed1c7da39952d65bd5eeb6745b3789c"
 dependencies = [
  "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
+ "cranelift-bitset 0.123.12",
+ "cranelift-entity 0.123.12",
+ "gimli 0.32.3",
  "indexmap",
  "log",
  "object",
@@ -3306,6 +3528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-core"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
+]
+
+[[package]]
 name = "wasmtime-internal-cranelift"
 version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,12 +3545,12 @@ checksum = "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
+ "cranelift-codegen 0.123.12",
+ "cranelift-control 0.123.12",
+ "cranelift-entity 0.123.12",
+ "cranelift-frontend 0.123.12",
+ "cranelift-native 0.123.12",
+ "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
  "object",
@@ -3371,6 +3603,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wasmtime-internal-math"
 version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,7 +3637,7 @@ checksum = "d0c005f82c48492b6b44fa19ee5205bd933c4f8baca41e314eca8331dd3c4fd9"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen",
+ "cranelift-codegen 0.123.12",
  "log",
  "object",
 ]
@@ -4213,7 +4457,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "memmap2",
+ "memmap2 0.9.11",
  "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = [
     "net-nat",
     "net-bridge",
     "floppybridge",
+    "cpu-jit",
 ]
 display-plan-trace = []
 # Local investigation switches that deliberately alter timing or rendering.
@@ -58,6 +59,12 @@ frontend = [
 # from `frontend` because it is a core-machine feature, but Cranelift cannot
 # be compiled FOR wasm32, so browser builds turn it off.
 wasm-boards = ["dep:wasmtime"]
+# Native-code compilation of hot CPU traces (the m68k crate's Cranelift trace
+# JIT), used by the `[cpu] jit` fast execution mode. Cranelift cannot be
+# compiled FOR wasm32, so browser builds (--no-default-features) leave it off;
+# `[cpu] jit` still works there through the crate's interpreted trace loop,
+# just without native code generation.
+cpu-jit = ["m68k/jit"]
 # The headless `copperline-bench` benchmark binary (core-only; also builds
 # for wasm32-wasip1). Off by default so native release artifacts are
 # unchanged.

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -101,13 +101,14 @@ model = "68000"
 # dcache = false
 
 # Experimental: fast CPU execution through the m68k core's batch/trace-JIT
-# path. The CPU retires instructions in batches at an approximate cost
-# instead of the cycle-exact timing model, so the machine behaves like one
-# with an accelerator card fitted: much faster, but chip-level races and
-# cycle-counted effects no longer line up. The on-chip cache models are
-# bypassed while it is active. Needs a 68020 or later (the 68000/68010
-# shared-bus float and prefetch semantics require the precise core, so it
-# is ignored there). Off by default.
+# path. The machine behaves like an ideal accelerator at clock_mhz: one
+# instruction per CPU clock with zero-wait fast RAM/ROM (a 50 MHz 68040
+# runs on the order of 50 MIPS; raise clock_mhz for more), but chip-level
+# races and cycle-counted effects no longer line up and the on-chip cache
+# models are bypassed. Chip/slow RAM keep their shared-bus arbitration.
+# Needs a 68020 or later (the 68000/68010 shared-bus float and prefetch
+# semantics require the precise core, so it is ignored there). Off by
+# default.
 # jit = true
 
 # 68060 only: the 68060 dropped MOVEP, CHK2/CMP2, CAS2, misaligned CAS,

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -104,11 +104,11 @@ model = "68000"
 # path. The machine behaves like an ideal accelerator at clock_mhz: one
 # instruction per CPU clock with zero-wait fast RAM/ROM (a 50 MHz 68040
 # runs on the order of 50 MIPS; raise clock_mhz for more), but chip-level
-# races and cycle-counted effects no longer line up and the on-chip cache
-# models are bypassed. Chip/slow RAM keep their shared-bus arbitration.
-# Needs a 68020 or later (the 68000/68010 shared-bus float and prefetch
-# semantics require the precise core, so it is ignored there). Off by
-# default.
+# races and cycle-counted effects no longer line up. Chip/slow RAM keep
+# their shared-bus arbitration, served through the still-active on-chip
+# cache models as on a real accelerator. Needs a 68020 or later (the
+# 68000/68010 shared-bus float and prefetch semantics require the precise
+# core, so it is ignored there). Off by default.
 # jit = true
 
 # 68060 only: the 68060 dropped MOVEP, CHK2/CMP2, CAS2, misaligned CAS,

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -100,6 +100,16 @@ model = "68000"
 # icache = false
 # dcache = false
 
+# Experimental: fast CPU execution through the m68k core's batch/trace-JIT
+# path. The CPU retires instructions in batches at an approximate cost
+# instead of the cycle-exact timing model, so the machine behaves like one
+# with an accelerator card fitted: much faster, but chip-level races and
+# cycle-counted effects no longer line up. The on-chip cache models are
+# bypassed while it is active. Needs a 68020 or later (the 68000/68010
+# shared-bus float and prefetch semantics require the precise core, so it
+# is ignored there). Off by default.
+# jit = true
+
 # 68060 only: the 68060 dropped MOVEP, CHK2/CMP2, CAS2, misaligned CAS,
 # 64-bit MUL/DIV, and most FPU operations beyond basic arithmetic from
 # silicon. "trap" (default) raises the chip's unimplemented-instruction

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -387,18 +387,21 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
   m68k core's batch/trace-JIT path instead of the cycle-exact
   per-instruction model: hot code compiles to native traces and fast-RAM
   accesses run through a zero-cost direct-memory window. The machine
-  behaves like one with an accelerator card fitted -- instructions retire
-  at a flat approximate cost, interrupts are recognized at batch
-  boundaries, and the on-chip cache models are bypassed -- so chip-level
-  races and cycle-counted effects no longer line up; leave it off for
-  anything timing-sensitive (games, demos). Chipset-touching accesses
-  still arbitrate onto the chip bus in order, so displays, blits, and
-  device I/O work normally. Requires a 68020 or later: the 68000/68010
-  share one bus with the chipset and their floating-bus and prefetch
-  semantics need the precise core, so `jit = true` on those models logs a
-  note and stays precise. Known issue: the bundled AROS ROM's boot screen
-  may stay grey under JIT on some 020+ configurations (the guest still
-  runs; Kickstart ROMs are unaffected).
+  behaves like an ideal accelerator running at `clock_mhz`: one
+  instruction per CPU clock with zero-wait fast RAM and ROM, so a 50 MHz
+  68040 delivers on the order of 50 MIPS (raise `clock_mhz` for more).
+  Interrupts are recognized at batch boundaries and the on-chip cache
+  models are bypassed, so chip-level races and cycle-counted effects no
+  longer line up; leave it off for anything timing-sensitive (games,
+  demos). Chip and slow RAM still arbitrate onto the shared chip bus in
+  order -- code that lives entirely in chip RAM sees little JIT benefit
+  -- so displays, blits, and device I/O work normally. Requires a 68020
+  or later: the 68000/68010 share one bus with the chipset and their
+  floating-bus and prefetch semantics need the precise core, so
+  `jit = true` on those models logs a note and stays precise (the
+  launcher greys the toggle). Known issue: the bundled AROS ROM's boot
+  screen may stay grey under JIT on some 020+ configurations (the guest
+  still runs; Kickstart ROMs are unaffected).
 
 ## `[memory]`
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -40,6 +40,7 @@ range checks as the equivalent TOML fields:
 | `--cpu MODEL` | `[cpu] model` | `68000`, `68010`, `68EC020`, `68020`, `68030`, `68040`, `68060` |
 | `--cpu-clock MHZ` | `[cpu] clock_mhz` | a number of MHz |
 | `--fpu` / `--no-fpu` | `[cpu] fpu` | fit / omit a 68881/68882 |
+| `--jit` / `--no-jit` | `[cpu] jit` | experimental fast batch/trace-JIT CPU execution (68020+; not cycle-exact) |
 | `--chip SIZE` | `[memory] chip` | `512K`, `1M`, `2M`, ... |
 | `--fast SIZE` | `[memory] fast` | `0`, `1M`, `4M`, `8M`, ... |
 | `--slow SIZE` | `[memory] slow` | `0`, up to `512K` |
@@ -344,6 +345,8 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
 # unimplemented = "trap"  # 68060 only: "trap" (faithful; the OS needs
 #                   # 68060.library) or "native" (execute the removed
 #                   # instructions directly)
+# jit = true        # experimental: fast batch/trace-JIT CPU execution
+#                   # (68020+; not cycle-exact)
 ```
 
 - `model`: the 68010 models the vector base register, the format-stacking
@@ -380,6 +383,22 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
   animation may pace correctly only with the cache modelled. The data cache
   caches expansion RAM/ROM only, since chip and slow RAM are DMA-visible and
   cache-inhibited as on real Amigas.
+- `jit` (experimental, also `--jit`/`--no-jit`) runs the CPU through the
+  m68k core's batch/trace-JIT path instead of the cycle-exact
+  per-instruction model: hot code compiles to native traces and fast-RAM
+  accesses run through a zero-cost direct-memory window. The machine
+  behaves like one with an accelerator card fitted -- instructions retire
+  at a flat approximate cost, interrupts are recognized at batch
+  boundaries, and the on-chip cache models are bypassed -- so chip-level
+  races and cycle-counted effects no longer line up; leave it off for
+  anything timing-sensitive (games, demos). Chipset-touching accesses
+  still arbitrate onto the chip bus in order, so displays, blits, and
+  device I/O work normally. Requires a 68020 or later: the 68000/68010
+  share one bus with the chipset and their floating-bus and prefetch
+  semantics need the precise core, so `jit = true` on those models logs a
+  note and stays precise. Known issue: the bundled AROS ROM's boot screen
+  may stay grey under JIT on some 020+ configurations (the guest still
+  runs; Kickstart ROMs are unaffected).
 
 ## `[memory]`
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -390,12 +390,12 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
   behaves like an ideal accelerator running at `clock_mhz`: one
   instruction per CPU clock with zero-wait fast RAM and ROM, so a 50 MHz
   68040 delivers on the order of 50 MIPS (raise `clock_mhz` for more).
-  Interrupts are recognized at batch boundaries and the on-chip cache
-  models are bypassed, so chip-level races and cycle-counted effects no
-  longer line up; leave it off for anything timing-sensitive (games,
-  demos). Chip and slow RAM still arbitrate onto the shared chip bus in
-  order -- code that lives entirely in chip RAM sees little JIT benefit
-  -- so displays, blits, and device I/O work normally. Requires a 68020
+  Interrupts are recognized at batch boundaries, so chip-level races and
+  cycle-counted effects no longer line up; leave it off for anything
+  timing-sensitive (games, demos). Chip and slow RAM still arbitrate onto
+  the shared chip bus in order, and the on-chip cache models stay active
+  (as on a real accelerator, they are what lets chip-RAM-resident code
+  run at CPU speed), so displays, blits, and device I/O work normally. Requires a 68020
   or later: the 68000/68010 share one bus with the chipset and their
   floating-bus and prefetch semantics need the precise core, so
   `jit = true` on those models logs a note and stays precise (the

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -305,7 +305,9 @@ The layout is:
   on a machine with no CD drive) are dropped so they cannot block a launch.
 - **Category tabs** (left sidebar). *System* (chipset and Agnus/Denise
   overrides, video standard, RTC, identify board, RTG card), *CPU* (model,
-  FPU, clock, caches), *Memory* (chip/fast/slow/motherboard/Zorro III RAM),
+  FPU, clock, caches, and the experimental not-cycle-exact JIT mode --
+  see `[cpu] jit` in [](configuration)),
+  *Memory* (chip/fast/slow/motherboard/Zorro III RAM),
   *ROM*
   (Kickstart and
   extended ROM), *Floppy* (drive count and speed, then each wired drive as a

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -95,12 +95,23 @@ approximate (`M68kMachine::step_slice_jit`):
   as their real hardware exceptions, mirroring the precise loop's no-op
   HLE policy.
 
+The on-chip cache models stay active under JIT: on a real accelerator it
+is exactly the caches that let chip-RAM-resident code run at CPU speed
+instead of paying chip-bus arbitration on every fetch, so bypassing them
+made a fast-RAM-less Workbench measure 3x slower under JIT than precise.
+A cache hit serves the access with no bus cycle; a miss pays the real
+chip-bus (or zero-wait external) cost. CACR writes inside a batch are
+synced to the models at the batch boundary.
+
 The fastmem window is only offered when nothing intercepts plain fast-RAM
 accesses: cache models, memory-write debug hooks, the heat map, SMC
 detection, and injected bus faults all force every access back onto the
-bus. Arming any per-instruction debug or diagnostic hook (breakpoints,
-watches, traces, `COPPERLINE_DBG_*`) drops the whole slice back to the
-precise loop, so the debugger always sees every instruction.
+bus (so on default 020+ configs, whose caches are modelled, the window
+engages only when the user opts the caches off -- and the core also
+declines it whenever the guest enables the MMU, since fastmem addresses
+are physical). Arming any per-instruction debug or diagnostic hook
+(breakpoints, watches, traces, `COPPERLINE_DBG_*`) drops the whole slice
+back to the precise loop, so the debugger always sees every instruction.
 
 The 68000 and 68010 never take the batch path. On the small-box machines
 every CPU cycle drives the one bus shared with Agnus, and the floating-bus

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -61,6 +61,52 @@ corrected to exact totals across the SingleStepTests 68000 cycle corpus
 which is what makes
 cycle-budgeted pacing trustworthy.
 
+## The batch/JIT execution mode
+
+`[cpu] jit` (experimental, 68020+) swaps the per-instruction precise loop
+for the core's instruction-budgeted batch path
+(`CpuCore::run_batch`): hot straight-line runs and self-loops execute as
+compiled Cranelift traces (the `cpu-jit` cargo feature; without it, wasm
+builds included, the same trace machinery runs interpreted), and the
+largest fast-RAM bank is offered to the core as a zero-cost direct-memory
+window (`AddressBus::fast_mem`). The timing contract is deliberately
+approximate (`M68kMachine::step_slice_jit`):
+
+- every retired instruction is billed a flat 4 CPU clocks, converted to
+  colour clocks at the configured clock ratio, and the chipset is advanced
+  through the excess over the batch's actual bus time -- so the machine
+  behaves like one with an accelerator card fitted;
+- chip-bus accesses still arbitrate into DMA slots through the normal
+  `CpuBus` paths and advance the beam as they land, keeping chipset side
+  effects ordered against display DMA;
+- interrupts are recognized only at batch boundaries (64 instructions),
+  from the live INTENA/INTREQ state; a level the boundary cannot deliver
+  is never left in the core, since the batch would take it as soon as the
+  mask drops without recomputing INTREQ (a spurious handler re-entry);
+- a slice that runs and then executes STOP is billed only its executed
+  time -- the idle period is the next slice's event-bounded fast-forward,
+  exactly like the precise path's STOP handling;
+- traps surfaced by the batch (A-line/F-line/TRAP/BKPT/illegal) are taken
+  as their real hardware exceptions, mirroring the precise loop's no-op
+  HLE policy.
+
+The fastmem window is only offered when nothing intercepts plain fast-RAM
+accesses: cache models, memory-write debug hooks, the heat map, SMC
+detection, and injected bus faults all force every access back onto the
+bus. Arming any per-instruction debug or diagnostic hook (breakpoints,
+watches, traces, `COPPERLINE_DBG_*`) drops the whole slice back to the
+precise loop, so the debugger always sees every instruction.
+
+The 68000 and 68010 never take the batch path. On the small-box machines
+every CPU cycle drives the one bus shared with Agnus, and the floating-bus
+model is prefetch-order dependent: Kickstart's diagnostic-ROM probe
+(`CMPI.W #$1111,(A1)` against unmapped `$F00000`) relies on the prefetch
+queue having fetched the following words so the undriven bus does NOT
+float to the immediate just read. The batch contract runs without
+prefetch, which lands the float on the immediate and false-detects a
+diagnostic ROM. `[cpu] jit` on these models logs a note and stays
+precise.
+
 ## Prefetch
 
 The 68000's two-word instruction prefetch queue (IRD/IRC) is modelled in

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -72,13 +72,18 @@ largest fast-RAM bank is offered to the core as a zero-cost direct-memory
 window (`AddressBus::fast_mem`). The timing contract is deliberately
 approximate (`M68kMachine::step_slice_jit`):
 
-- every retired instruction is billed a flat 4 CPU clocks, converted to
-  colour clocks at the configured clock ratio, and the chipset is advanced
-  through the excess over the batch's actual bus time -- so the machine
-  behaves like one with an accelerator card fitted;
-- chip-bus accesses still arbitrate into DMA slots through the normal
-  `CpuBus` paths and advance the beam as they land, keeping chipset side
-  effects ordered against display DMA;
+- every retired instruction is billed a flat single CPU clock, converted
+  to colour clocks at the configured clock ratio, and fast-RAM/ROM
+  accesses bill nothing (an ideal zero-wait external bus) -- the machine
+  behaves like a perfect pipelined accelerator whose throughput tracks
+  `[cpu] clock_mhz` directly, e.g. ~50 MIPS for a 50 MHz 68040 in fast
+  RAM. This is the deterministic equivalent of a "fastest possible"
+  mode: a truly host-speed CPU would make emulated results depend on the
+  host, which Copperline never allows;
+- chip and slow RAM accesses still arbitrate into DMA slots through the
+  normal `CpuBus` paths and advance the beam as they land (that bus is
+  shared silicon), and CIA/RTC accesses keep their E-clock costs, keeping
+  chipset side effects ordered against display DMA;
 - interrupts are recognized only at batch boundaries (64 instructions),
   from the live INTENA/INTREQ state; a level the boundary cannot deliver
   is never left in the core, since the batch would take it as soon as the

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -795,6 +795,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-assembler-x64/cranelift-assembler-x64-0.132.3.crate",
+        "sha256": "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5",
+        "dest": "cargo/vendor/cranelift-assembler-x64-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-assembler-x64-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-assembler-x64-meta/cranelift-assembler-x64-meta-0.123.12.crate",
         "sha256": "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6",
         "dest": "cargo/vendor/cranelift-assembler-x64-meta-0.123.12"
@@ -803,6 +816,19 @@
         "type": "inline",
         "contents": "{\"package\": \"ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-assembler-x64-meta-0.123.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-assembler-x64-meta/cranelift-assembler-x64-meta-0.132.3.crate",
+        "sha256": "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5",
+        "dest": "cargo/vendor/cranelift-assembler-x64-meta-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-assembler-x64-meta-0.132.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -821,6 +847,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-bforest/cranelift-bforest-0.132.3.crate",
+        "sha256": "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5",
+        "dest": "cargo/vendor/cranelift-bforest-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-bforest-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-bitset/cranelift-bitset-0.123.12.crate",
         "sha256": "800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31",
         "dest": "cargo/vendor/cranelift-bitset-0.123.12"
@@ -829,6 +868,19 @@
         "type": "inline",
         "contents": "{\"package\": \"800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-bitset-0.123.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-bitset/cranelift-bitset-0.132.3.crate",
+        "sha256": "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36",
+        "dest": "cargo/vendor/cranelift-bitset-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-bitset-0.132.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -847,6 +899,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-codegen/cranelift-codegen-0.132.3.crate",
+        "sha256": "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a",
+        "dest": "cargo/vendor/cranelift-codegen-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-codegen-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-codegen-meta/cranelift-codegen-meta-0.123.12.crate",
         "sha256": "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae",
         "dest": "cargo/vendor/cranelift-codegen-meta-0.123.12"
@@ -855,6 +920,19 @@
         "type": "inline",
         "contents": "{\"package\": \"38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-codegen-meta-0.123.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-codegen-meta/cranelift-codegen-meta-0.132.3.crate",
+        "sha256": "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99",
+        "dest": "cargo/vendor/cranelift-codegen-meta-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-codegen-meta-0.132.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -873,6 +951,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-codegen-shared/cranelift-codegen-shared-0.132.3.crate",
+        "sha256": "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47",
+        "dest": "cargo/vendor/cranelift-codegen-shared-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-codegen-shared-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-control/cranelift-control-0.123.12.crate",
         "sha256": "2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5",
         "dest": "cargo/vendor/cranelift-control-0.123.12"
@@ -881,6 +972,19 @@
         "type": "inline",
         "contents": "{\"package\": \"2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-control-0.123.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-control/cranelift-control-0.132.3.crate",
+        "sha256": "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec",
+        "dest": "cargo/vendor/cranelift-control-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-control-0.132.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -899,6 +1003,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-entity/cranelift-entity-0.132.3.crate",
+        "sha256": "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965",
+        "dest": "cargo/vendor/cranelift-entity-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-entity-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-frontend/cranelift-frontend-0.123.12.crate",
         "sha256": "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8",
         "dest": "cargo/vendor/cranelift-frontend-0.123.12"
@@ -907,6 +1024,19 @@
         "type": "inline",
         "contents": "{\"package\": \"f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-frontend-0.123.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-frontend/cranelift-frontend-0.132.3.crate",
+        "sha256": "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367",
+        "dest": "cargo/vendor/cranelift-frontend-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-frontend-0.132.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -925,6 +1055,45 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-isle/cranelift-isle-0.132.3.crate",
+        "sha256": "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e",
+        "dest": "cargo/vendor/cranelift-isle-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-isle-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-jit/cranelift-jit-0.132.3.crate",
+        "sha256": "a7def01f2b14f97421558d1db33e396b97b97ab2ed40dedc8165ba00d13088e6",
+        "dest": "cargo/vendor/cranelift-jit-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a7def01f2b14f97421558d1db33e396b97b97ab2ed40dedc8165ba00d13088e6\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-jit-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-module/cranelift-module-0.132.3.crate",
+        "sha256": "985df7eceefc91cb75bf7f51b32b7f1739d0fc0e25ddf023b1de407cb3c93d77",
+        "dest": "cargo/vendor/cranelift-module-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"985df7eceefc91cb75bf7f51b32b7f1739d0fc0e25ddf023b1de407cb3c93d77\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-module-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-native/cranelift-native-0.123.12.crate",
         "sha256": "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a",
         "dest": "cargo/vendor/cranelift-native-0.123.12"
@@ -938,6 +1107,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-native/cranelift-native-0.132.3.crate",
+        "sha256": "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098",
+        "dest": "cargo/vendor/cranelift-native-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-native-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cranelift-srcgen/cranelift-srcgen-0.123.12.crate",
         "sha256": "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b",
         "dest": "cargo/vendor/cranelift-srcgen-0.123.12"
@@ -946,6 +1128,19 @@
         "type": "inline",
         "contents": "{\"package\": \"93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-srcgen-0.123.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cranelift-srcgen/cranelift-srcgen-0.132.3.crate",
+        "sha256": "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0",
+        "dest": "cargo/vendor/cranelift-srcgen-0.132.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0\", \"files\": {}}",
+        "dest": "cargo/vendor/cranelift-srcgen-0.132.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1518,6 +1713,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7\", \"files\": {}}",
         "dest": "cargo/vendor/gimli-0.32.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gimli/gimli-0.33.0.crate",
+        "sha256": "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c",
+        "dest": "cargo/vendor/gimli-0.33.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c\", \"files\": {}}",
+        "dest": "cargo/vendor/gimli-0.33.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2194,6 +2402,19 @@
         "type": "inline",
         "contents": "{\"package\": \"ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227\", \"files\": {}}",
         "dest": "cargo/vendor/memfd-0.6.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.2.3.crate",
+        "sha256": "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4",
+        "dest": "cargo/vendor/memmap2-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3291,6 +3512,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regalloc2/regalloc2-0.15.2.crate",
+        "sha256": "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85",
+        "dest": "cargo/vendor/regalloc2-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85\", \"files\": {}}",
+        "dest": "cargo/vendor/regalloc2-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/regex/regex-1.12.3.crate",
         "sha256": "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276",
         "dest": "cargo/vendor/regex-1.12.3"
@@ -3325,6 +3559,19 @@
         "type": "inline",
         "contents": "{\"package\": \"dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a\", \"files\": {}}",
         "dest": "cargo/vendor/regex-syntax-0.8.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/region/region-3.0.2.crate",
+        "sha256": "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7",
+        "dest": "cargo/vendor/region-3.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7\", \"files\": {}}",
+        "dest": "cargo/vendor/region-3.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4370,6 +4617,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-internal-core/wasmtime-internal-core-45.0.3.crate",
+        "sha256": "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804",
+        "dest": "cargo/vendor/wasmtime-internal-core-45.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-internal-core-45.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasmtime-internal-cranelift/wasmtime-internal-cranelift-36.0.12.crate",
         "sha256": "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371",
         "dest": "cargo/vendor/wasmtime-internal-cranelift-36.0.12"
@@ -4417,6 +4677,19 @@
         "type": "inline",
         "contents": "{\"package\": \"627d8f57909a4f9bb1dbe57a96229a54b89d5995353d0b321f3cb9a1a118977a\", \"files\": {}}",
         "dest": "cargo/vendor/wasmtime-internal-jit-icache-coherence-36.0.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmtime-internal-jit-icache-coherence/wasmtime-internal-jit-icache-coherence-45.0.3.crate",
+        "sha256": "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b",
+        "dest": "cargo/vendor/wasmtime-internal-jit-icache-coherence-45.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmtime-internal-jit-icache-coherence-45.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,12 @@ pub struct Config {
     pub cpu_dcache: bool,
     /// 68060 unimplemented-instruction policy (faithful traps by default).
     pub cpu_unimplemented: UnimplementedPolicy,
+    /// Fast CPU execution through the m68k core's batch/trace-JIT path
+    /// (`[cpu] jit`). Trades the cycle-exact CPU timing model for host
+    /// speed: instructions retire in batches at an approximate cost, so
+    /// the machine behaves like one with an accelerator card fitted.
+    /// Defaults off.
+    pub cpu_jit: bool,
     pub emulation: Emulation,
     pub chip_ram_bytes: usize,
     pub fast_ram_bytes: usize,
@@ -1564,6 +1570,7 @@ impl Default for Config {
             cpu_icache: false,
             cpu_dcache: false,
             cpu_unimplemented: UnimplementedPolicy::Trap,
+            cpu_jit: false,
             emulation: Emulation {
                 power_on: true,
                 pacing_budget: PacingBudget::Cycles,
@@ -1771,6 +1778,9 @@ pub struct ConfigOverrides {
     pub cpu: Option<String>,
     pub fpu: Option<bool>,
     pub cpu_clock_mhz: Option<f64>,
+    /// Fast CPU execution via the batch/trace-JIT path (`--jit`/`--no-jit`).
+    /// Same semantics as `[cpu] jit`.
+    pub cpu_jit: Option<bool>,
     pub chip: Option<String>,
     pub fast: Option<String>,
     pub slow: Option<String>,
@@ -1887,6 +1897,7 @@ impl ConfigOverrides {
             && self.cpu.is_none()
             && self.fpu.is_none()
             && self.cpu_clock_mhz.is_none()
+            && self.cpu_jit.is_none()
             && self.chip.is_none()
             && self.fast.is_none()
             && self.slow.is_none()
@@ -1944,6 +1955,9 @@ impl ConfigOverrides {
         }
         if let Some(mhz) = self.cpu_clock_mhz {
             raw.cpu.clock_mhz = Some(mhz);
+        }
+        if let Some(jit) = self.cpu_jit {
+            raw.cpu.jit = Some(jit);
         }
         if let Some(chip) = &self.chip {
             raw.memory.chip = Some(chip.clone());
@@ -2557,6 +2571,11 @@ pub(crate) struct RawCpu {
     /// for systems without the library.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) unimplemented: Option<String>,
+    /// Fast CPU execution through the m68k core's batch/trace-JIT path.
+    /// Not cycle-exact: the CPU behaves like an accelerator card. Defaults
+    /// off.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) jit: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -2927,6 +2946,7 @@ impl TryFrom<RawConfig> for Config {
                  (the 68000/68020 have no data cache)"
             ));
         }
+        let cpu_jit = raw.cpu.jit.unwrap_or(false);
         if let Some(speed) = raw.emulation.speed.as_deref() {
             log::warn!(
                 "[emulation] speed = {speed:?} is deprecated and ignored: the \
@@ -3462,6 +3482,7 @@ impl TryFrom<RawConfig> for Config {
             cpu_icache,
             cpu_dcache,
             cpu_unimplemented,
+            cpu_jit,
             emulation,
             chip_ram_bytes,
             fast_ram_bytes,
@@ -5005,6 +5026,7 @@ mod tests {
                 icache: Some(true),
                 dcache: None,
                 unimplemented: None,
+                jit: None,
             },
             memory: RawMemory {
                 chip: Some("2M".to_string()),
@@ -7229,6 +7251,20 @@ mod tests {
         assert!(cfg.fpu, "the full 68060 has its FPU on-die");
         assert!(cfg.cpu_icache && cfg.cpu_dcache, "8 KB caches default on");
         assert_eq!(cfg.cpu_unimplemented, UnimplementedPolicy::Trap);
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_jit_parses_and_defaults_off() -> Result<()> {
+        let cfg = parse_config("")?;
+        assert!(!cfg.cpu_jit, "JIT must be opt-in");
+        let cfg = parse_config(
+            r#"
+            [cpu]
+            jit = true
+            "#,
+        )?;
+        assert!(cfg.cpu_jit);
         Ok(())
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2307,6 +2307,12 @@ impl M68kMachine {
             self.bus.diag_current_pc = self.cpu.pc;
             self.bus.bus.cpu_pc = self.cpu.pc;
             let result = self.cpu.run_batch(&mut self.bus, budget, &[]);
+            if self.bus.icache.is_some() || self.bus.dcache.is_some() {
+                // A CACR write inside the batch (MOVEC) must reach the
+                // cache models -- enables, disables, and flushes -- just
+                // as the precise loop syncs it per instruction.
+                self.apply_cacr_updates();
+            }
             instructions = instructions.saturating_add(result.instructions as usize);
             let mut batch_clocks = result
                 .instructions
@@ -5656,6 +5662,47 @@ mod tests {
         machine.bus_mut().paula.intreq = INT_VERTB;
         machine.step_slice(64)?;
         assert_eq!(machine.d(0), 42, "handler must have run");
+        Ok(())
+    }
+
+    /// A chip-RAM-resident loop under JIT must run at CPU speed once the
+    /// instruction-cache model holds it, not pay chip-bus arbitration on
+    /// every fetch: bypassing the cache models made a fast-RAM-less
+    /// Workbench measure 3x SLOWER under JIT than under the precise core
+    /// (SysInfo Dhrystones 1667 vs 5503 on a 50 MHz 68040).
+    #[test]
+    fn jit_chip_resident_loop_runs_at_cpu_speed_with_icache() -> Result<()> {
+        let program = [
+            0x7001u16, // moveq #1,d0 (CACR.EI, as the OS sets at boot)
+            0x4E7B, 0x0002, // movec d0,cacr
+            0x7263, // moveq #99,d1
+            0x4E71, // nop
+            0x51C9, 0xFFFC, // dbra d1,<nop>
+            0x60FE, // bra.s *
+        ];
+        let run = |icache: bool| -> Result<u32> {
+            let mut machine = machine_with_program_model(0x1000, &program, CpuModel::M68020)?;
+            machine.set_cache_emulation(icache, false);
+            machine.set_jit_enabled(true);
+            let mut retired = 0usize;
+            let mut device_cck = 0u32;
+            while retired < 220 {
+                let slice = machine.step_slice(220 - retired)?;
+                retired += slice.instructions;
+                device_cck += slice.bus_advanced_cck;
+            }
+            Ok(device_cck)
+        };
+        let cached = run(true)?;
+        let cacheless = run(false)?;
+        assert!(
+            cached < 300,
+            "cached chip-resident loop took {cached} cck for 220 instructions"
+        );
+        assert!(
+            cacheless > cached * 2,
+            "cache model should dominate chip-loop speed: cacheless {cacheless} vs cached {cached}"
+        );
         Ok(())
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -12,7 +12,7 @@ use crate::memory::{
 use anyhow::{anyhow, Result};
 use log::{debug, trace};
 use m68k::core::memory::{BusFault, BusFaultKind};
-use m68k::{AddressBus, CpuCore, CpuType, StepResult};
+use m68k::{AddressBus, BatchExit, CpuCore, CpuType, FastMem, StepResult};
 
 pub const CIA_A_BASE: u32 = 0x00BF_E000;
 pub const CIA_A_SIZE: u32 = 0x0000_1000;
@@ -99,6 +99,12 @@ pub struct M68kMachine {
     cpu: CpuCore,
     bus: CpuBus,
     fpu_enabled: bool,
+    /// Fast batch/trace-JIT execution (`[cpu] jit`). When set and no
+    /// per-instruction debug hook is armed, `step_slice` runs the core's
+    /// instruction-budgeted batch path instead of cycle-stepping, billing
+    /// each instruction a flat bus-cycle cost. Configuration, not machine
+    /// state: like `fpu_enabled` it is never serialized.
+    jit_enabled: bool,
     /// Last CACR value pushed into the cache models, so the per-instruction
     /// sync is a single compare when nothing changed.
     last_cacr: u32,
@@ -244,6 +250,21 @@ struct MachineRuntimeState {
 /// a straight-line advance, so only the opcode word is marked.
 const MAX_INSTRUCTION_BYTES: u32 = 12;
 
+/// Instruction budget per `run_batch` call in the JIT slice. Interrupts are
+/// only recognized between batches (plus once inside each batch entry), so
+/// this bounds interrupt latency in JIT mode: 64 instructions at the flat
+/// 4-clock bill is 256 CPU clocks, roughly half a scanline at stock clock.
+/// Larger batches let compiled traces run longer between host round-trips
+/// but delay interrupt delivery; AROS boot at accelerated clock ratios
+/// proved sensitive to latencies beyond about a scanline.
+const JIT_BATCH_INSTRUCTIONS: usize = 64;
+
+/// Flat CPU-clock cost billed per instruction retired by the JIT slice: one
+/// 4-clock 68000 bus cycle. The batch path reports no cycle counts, so this
+/// constant sets the JIT machine's nominal speed -- a stock-clocked 68000
+/// runs at ~1.8 MIPS, and `[cpu] clock_mhz` scales it like any accelerator.
+const JIT_CPU_CLOCKS_PER_INSTRUCTION: u32 = 4;
+
 struct CpuBus {
     bus: Bus,
     address_mask: u32,
@@ -287,6 +308,9 @@ struct CpuBus {
     /// Start PC of the instruction currently inside the core, used only by
     /// `COPPERLINE_DIAG_CPU_SYNC` to filter internal-cycle trace lines.
     diag_current_pc: u32,
+    /// Mirror of `M68kMachine::jit_enabled` so `fast_mem` can gate the
+    /// zero-cost fastmem window without reaching back up to the machine.
+    jit_enabled: bool,
 }
 
 pub fn build(
@@ -325,6 +349,13 @@ impl M68kMachine {
             // host's generic Line-F shim for discrete 68881/68882 absence.
             cpu.pcr |= m68k::PCR_DFP;
         }
+        // A 68020/030 without an attached 68881/68882 routes cpID-1 F-line
+        // opcodes to the Line-F exception inside the core. The precise path
+        // additionally pre-empts them with `force_fpu_line_f_if_needed`
+        // (which also covers the 68040, where the core models FPU absence
+        // via the LC/EC types instead of this flag); the core-side flag is
+        // what makes the batch/JIT path honour a missing FPU.
+        cpu.fpu_present = fpu_enabled;
 
         let mut machine = Self {
             cpu,
@@ -345,8 +376,10 @@ impl M68kMachine {
                 sampled_irq_level: 0,
                 ipl_sample_held: false,
                 diag_current_pc: 0,
+                jit_enabled: false,
             },
             fpu_enabled,
+            jit_enabled: false,
             last_cacr: 0,
             dbg_ipl_main_cyc: 0,
             dbg_ipl_irq_cyc: 0,
@@ -1955,7 +1988,10 @@ impl M68kMachine {
         // sample (e.g. the instruction's own INTREQ clear) is never delivered
         // stale. COPPERLINE_IRQ_LATENCY_CCK=0 disables this together with the
         // IPL pipe (the raw immediate model, used by mechanism tests).
-        if self.bus.bus.irq_latency_setting != 0 && !self.cpu.is_stopped() {
+        // JIT batches run whole stretches of instructions without per-access
+        // IPL latching, so the sampled level can be arbitrarily stale there;
+        // a JIT machine takes the live level instead (the raw model).
+        if self.bus.bus.irq_latency_setting != 0 && !self.cpu.is_stopped() && !self.jit_enabled {
             level = level.min(self.bus.sampled_irq_level);
         }
         // The boundary decision consumed the sample: release any poll-point
@@ -1970,7 +2006,62 @@ impl M68kMachine {
         debug!("overlay disabled (chip RAM mapped at $0)");
     }
 
+    /// Enable the fast batch/trace-JIT execution mode (`[cpu] jit`).
+    pub fn set_jit_enabled(&mut self, on: bool) {
+        self.jit_enabled = on;
+        self.bus.jit_enabled = on;
+        if on && matches!(self.cpu.cpu_type, CpuType::M68000 | CpuType::M68010) {
+            log::info!(
+                "cpu jit: the 68000/68010 shared-bus float model needs the \
+                 precise per-instruction core; [cpu] jit has no effect on \
+                 this CPU (use a 68020 or later)"
+            );
+        }
+    }
+
+    pub fn jit_enabled(&self) -> bool {
+        self.jit_enabled
+    }
+
+    /// Whether `step_slice` may take the batch/JIT path right now: every
+    /// per-instruction debug or diagnostic hook the precise loop services
+    /// must be idle, and the FPU-absence shim must not be needed (the
+    /// 68040 is the one model whose missing FPU only the host shim
+    /// covers; everywhere else the core handles it natively).
+    ///
+    /// The 68000/68010 never take the batch path at all. On the small-box
+    /// machines every CPU cycle drives the one bus shared with Agnus, and
+    /// the floating-bus model (`note_cpu_data_bus`) is PREFETCH-ORDER
+    /// dependent: Kickstart's diagnostic-ROM probe (`CMPI.W #$1111,(A1)`
+    /// against unmapped $F00000) relies on the prefetch queue having
+    /// fetched the following words so the float is NOT the immediate just
+    /// read. The batch contract runs without prefetch, the float lands on
+    /// the immediate, and the probe false-matches -- Kickstart jumps into
+    /// empty space. `[cpu] jit` on these CPUs falls back to the precise
+    /// loop (logged once at build).
+    fn jit_fast_path_ok(&self) -> bool {
+        if matches!(self.cpu.cpu_type, CpuType::M68000 | CpuType::M68010) {
+            return false;
+        }
+        !(self.dbg.is_some()
+            || self.dbg_pc_on
+            || self.dbg_crash_on
+            || self.dbg_sched_on
+            || self.dbg_fc_addr.is_some()
+            || self.dbg_ipl_on
+            || self.dbg_spren_on
+            || self.ui_breaks.armed()
+            || self.ui_pc_history_enabled
+            || self.ui_trace.is_some()
+            || self.bus.bus.wave_pc_trigger
+            || self.bus.bus.smc.is_some()
+            || (!self.fpu_enabled && self.cpu.cpu_type == CpuType::M68040))
+    }
+
     pub fn step_slice(&mut self, count: usize) -> Result<CpuStepSlice> {
+        if self.jit_enabled && self.jit_fast_path_ok() {
+            return self.step_slice_jit(count);
+        }
         self.bus.bus.begin_cpu_slice();
         self.bus.bus.slice_preempted = false;
         self.bus.bus.set_cpu_bus_arbitration_enabled(true);
@@ -2144,6 +2235,146 @@ impl M68kMachine {
         // `refresh_irq_line`, so the last one would otherwise stay pending).
         // This keeps `pending_device_cck` zero at every slice boundary, where
         // save states are taken -- the accumulator is not serialized.
+        self.bus.bus.flush_timed_devices();
+        self.bus.bus.set_cpu_bus_arbitration_enabled(false);
+        let (bus_advanced_cck, _bus_tick) = self.bus.bus.take_slice_bus_advance();
+        if stopped {
+            trace!(
+                "m68k CPU stopped at PC={:#010X} SR={:#06X}",
+                self.pc(),
+                self.sr()
+            );
+        }
+        Ok(CpuStepSlice {
+            instructions,
+            cpu_cycles,
+            cpu_cck,
+            bus_advanced_cck,
+            stopped,
+        })
+    }
+
+    /// Fast execution slice for `[cpu] jit`: run the core's
+    /// instruction-budgeted batch path (natively compiled hot traces with
+    /// the `cpu-jit` build feature, the interpreted trace loop without)
+    /// instead of cycle-stepping one instruction at a time.
+    ///
+    /// The timing contract is deliberately approximate -- the machine
+    /// behaves like one with an accelerator card fitted:
+    /// - every retired instruction is billed a flat
+    ///   `JIT_CPU_CLOCKS_PER_INSTRUCTION` CPU clocks, converted to chipset
+    ///   time at the configured clock ratio exactly like the precise path;
+    /// - chip-bus accesses still arbitrate into DMA slots through `CpuBus`
+    ///   and advance the beam as they land, so chipset side effects stay
+    ///   ordered against display DMA, just not cycle-exactly;
+    /// - accesses inside the fastmem window (the largest fast-RAM bank, see
+    ///   `CpuBus::fast_mem`) cost nothing at all;
+    /// - interrupts are recognized at batch boundaries (and once inside
+    ///   each batch entry), so their latency is bounded by
+    ///   `JIT_BATCH_INSTRUCTIONS` rather than modelled.
+    fn step_slice_jit(&mut self, count: usize) -> Result<CpuStepSlice> {
+        self.bus.bus.begin_cpu_slice();
+        self.bus.bus.slice_preempted = false;
+        self.bus.bus.set_cpu_bus_arbitration_enabled(true);
+
+        let mut instructions = 0usize;
+        let mut cpu_cycles = 0u32;
+        let mut cpu_cck = 0u32;
+        let mut stopped = false;
+
+        while instructions < count {
+            let bus_before = self.bus.bus.slice_bus_advanced_cck();
+            let cpu_cck_before = cpu_cck;
+            if let Some(irq_cycles) = self.service_pending_irq_cycles() {
+                cpu_cycles = cpu_cycles.saturating_add(positive_cpu_cycles(irq_cycles));
+                cpu_cck = cpu_cck.saturating_add(self.charge_cpu_clocks(irq_cycles));
+            }
+            // A level the boundary could not deliver (the CPU is still
+            // inside a handler at that priority) must not ride into the
+            // batch: the batch core would service it the moment RTE drops
+            // the mask WITHOUT recomputing INTREQ, spuriously re-entering
+            // a handler whose request was already cleared. Interrupts are
+            // delivered exclusively at slice boundaries, from live state.
+            self.cpu.set_irq(0);
+            let budget = (count - instructions).min(JIT_BATCH_INSTRUCTIONS) as u32;
+            self.bus.diag_current_pc = self.cpu.pc;
+            self.bus.bus.cpu_pc = self.cpu.pc;
+            let result = self.cpu.run_batch(&mut self.bus, budget, &[]);
+            instructions = instructions.saturating_add(result.instructions as usize);
+            let mut batch_clocks = result
+                .instructions
+                .saturating_mul(JIT_CPU_CLOCKS_PER_INSTRUCTION);
+            let mut exit_stopped = false;
+            match result.exit {
+                BatchExit::BudgetExhausted | BatchExit::WatchedPc { .. } => {}
+                BatchExit::Stopped => exit_stopped = true,
+                // The batch path surfaces traps instead of taking them; the
+                // precise loop's no-op HLE policy is to let every one become
+                // its real hardware exception. Mirror that here, billing the
+                // exception entry and counting the trapping instruction.
+                BatchExit::AlineTrap { .. } => {
+                    let cycles = self.cpu.take_aline_exception(&mut self.bus);
+                    batch_clocks = batch_clocks
+                        .saturating_add(positive_cpu_cycles(cycles))
+                        .saturating_add(JIT_CPU_CLOCKS_PER_INSTRUCTION);
+                    instructions = instructions.saturating_add(1);
+                }
+                BatchExit::FlineTrap { .. } => {
+                    let cycles = self.cpu.take_fline_exception(&mut self.bus);
+                    batch_clocks = batch_clocks
+                        .saturating_add(positive_cpu_cycles(cycles))
+                        .saturating_add(JIT_CPU_CLOCKS_PER_INSTRUCTION);
+                    instructions = instructions.saturating_add(1);
+                }
+                BatchExit::TrapInstruction { trap_num } => {
+                    let cycles = self.cpu.take_trap_exception(&mut self.bus, trap_num);
+                    batch_clocks = batch_clocks
+                        .saturating_add(positive_cpu_cycles(cycles))
+                        .saturating_add(JIT_CPU_CLOCKS_PER_INSTRUCTION);
+                    instructions = instructions.saturating_add(1);
+                }
+                BatchExit::Breakpoint { .. } => {
+                    let cycles = self.cpu.take_bkpt_exception(&mut self.bus);
+                    batch_clocks = batch_clocks
+                        .saturating_add(positive_cpu_cycles(cycles))
+                        .saturating_add(JIT_CPU_CLOCKS_PER_INSTRUCTION);
+                    instructions = instructions.saturating_add(1);
+                }
+                BatchExit::IllegalInstruction { .. } => {
+                    let cycles = self.cpu.take_illegal_exception(&mut self.bus);
+                    batch_clocks = batch_clocks
+                        .saturating_add(positive_cpu_cycles(cycles))
+                        .saturating_add(JIT_CPU_CLOCKS_PER_INSTRUCTION);
+                    instructions = instructions.saturating_add(1);
+                }
+            }
+            cpu_cycles = cpu_cycles.saturating_add(batch_clocks);
+            cpu_cck = cpu_cck.saturating_add(self.charge_cpu_clocks(batch_clocks as i32));
+
+            if self.sync_cck_on {
+                // Advance the chipset through the batch's billed CPU time
+                // beyond what its bus accesses already advanced, exactly as
+                // the precise loop does per instruction.
+                let cpu_cck_iter = cpu_cck.saturating_sub(cpu_cck_before);
+                let bus_iter = self
+                    .bus
+                    .bus
+                    .slice_bus_advanced_cck()
+                    .saturating_sub(bus_before);
+                self.bus
+                    .bus
+                    .advance_cpu_internal_cycles(cpu_cck_iter.saturating_sub(bus_iter));
+            }
+
+            if exit_stopped {
+                stopped = true;
+                break;
+            }
+            if self.bus.bus.slice_preempted {
+                break;
+            }
+        }
+
         self.bus.bus.flush_timed_devices();
         self.bus.bus.set_cpu_bus_arbitration_enabled(false);
         let (bus_advanced_cck, _bus_tick) = self.bus.bus.take_slice_bus_advance();
@@ -3097,6 +3328,15 @@ impl CpuBus {
                 .bus
                 .cia_a_write(u64::from(addr - CIA_A_BASE), size, u64::from(value));
             if effect.disable_overlay {
+                // Gary's overlay flip-flop clears the moment the CIA drives
+                // OVL low: the guest's very next access may already expect
+                // chip RAM at $0. Flip it here rather than only at the slice
+                // boundary -- the batch/JIT path retires many instructions
+                // per slice, so the historical end-of-slice deferral would
+                // leave the bootstrap writing its vectors into the ROM
+                // mirror. The pending flag still ends the slice so the run
+                // loop logs the transition.
+                self.bus.mem.overlay = false;
                 self.bus.overlay_disable_pending = true;
                 self.bus.slice_preempted = true;
             }
@@ -3306,11 +3546,82 @@ impl CpuBus {
             0
         };
     }
+
+    /// The zero-cost guest-RAM window offered to the core's batch/JIT path
+    /// (`AddressBus::fast_mem`): the largest fast-RAM bank fitted -- a
+    /// configured Zorro board, Ramsey motherboard RAM, or CPU-slot
+    /// accelerator RAM. Chip and slow RAM are never offered: their CPU
+    /// accesses arbitrate into chip-bus DMA slots and drive the shared data
+    /// bus, side effects the window contract forbids.
+    ///
+    /// Returns None while anything that intercepts plain fast-RAM accesses
+    /// is armed (cache models, memory-write debug hooks, the heat map, SMC
+    /// detection, injected bus faults) so those features keep seeing every
+    /// access; the batch path then simply routes everything through the
+    /// normal bus methods. Recomputed on every `run_batch` call, so a bank
+    /// that autoconfig places (or a RESET tears down) is picked up at the
+    /// next batch boundary.
+    ///
+    /// A 68000/68010 never gets a window at all: on the small-box machines
+    /// every CPU cycle -- fast RAM included -- drives the one bus shared
+    /// with Agnus, and `note_cpu_data_bus` must latch each transfer so
+    /// undriven (unmapped) reads float to the last driven value. Kickstart
+    /// and AROS memory sizing read exactly those floats, so bypassing the
+    /// latch wedges the boot. The 020+ run fast RAM on their own local
+    /// bus (`cpu_short_bus_cycle`), where the latch is deliberately not
+    /// driven and the window is side-effect free.
+    fn jit_fast_mem(&mut self) -> Option<FastMem> {
+        if !self.jit_enabled
+            || !self.bus.cpu_short_bus_cycle()
+            || self.icache.is_some()
+            || self.dcache.is_some()
+            || self.dbg_memw_addr.is_some()
+            || self.bus.heat_map_armed()
+            || self.bus.smc.is_some()
+            || self.bus.bus_faults_armed()
+        {
+            return None;
+        }
+        let zorro = self.bus.mem.zorro.largest_ram_region();
+        let mb_len = self.bus.mem.mb_ram.len() as u32;
+        let accel_len = self.bus.mem.accel_ram.len() as u32;
+        let zorro_len = zorro.map_or(0, |(_, len, _)| len);
+        let best = zorro_len.max(mb_len).max(accel_len);
+        if best == 0 {
+            return None;
+        }
+        if best == zorro_len {
+            let (base, len, idx) = zorro?;
+            let ram = self.bus.mem.zorro.board_ram_mut(idx);
+            return Some(FastMem {
+                ptr: ram.as_mut_ptr(),
+                base,
+                len,
+            });
+        }
+        if best == mb_len {
+            let base = self.bus.mem.mb_ram_base() as u32;
+            return Some(FastMem {
+                ptr: self.bus.mem.mb_ram.as_mut_ptr(),
+                base,
+                len: mb_len,
+            });
+        }
+        Some(FastMem {
+            ptr: self.bus.mem.accel_ram.as_mut_ptr(),
+            base: ACCEL_RAM_BASE as u32,
+            len: accel_len,
+        })
+    }
 }
 
 impl AddressBus for CpuBus {
     fn last_fetch_was_cached(&self) -> bool {
         self.last_fetch_cache_hit
+    }
+
+    fn fast_mem(&mut self) -> Option<FastMem> {
+        self.jit_fast_mem()
     }
 
     fn begin_instruction_fetches(&mut self) {
@@ -4057,6 +4368,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
 
         assert_eq!(bus.read_long(0), 0x1111_4EF9);
@@ -4085,6 +4397,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
         // Start on a refresh slot (0x003) so the fetch both waits for and then
@@ -4120,6 +4433,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
 
@@ -4167,6 +4481,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
 
         // Warm the opcode longword and a separate extension longword.
@@ -4375,6 +4690,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
         bus.bus.set_cpu_bus_arbitration_enabled(true);
         let fast = FAST_RAM_BASE as u32 + 0x40;
@@ -4424,6 +4740,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
         let before = bus.read_long(ROM_BASE as u32);
         bus.write_long(ROM_BASE as u32, 0xDEAD_BEEF);
@@ -4451,6 +4768,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         };
         // $F00000 with no extended ROM fitted is genuinely undecoded (the
         // chip-register space at $C00000-$DFFFFF is not: Gary mirrors the
@@ -4484,6 +4802,7 @@ mod tests {
             sampled_irq_level: 0,
             ipl_sample_held: false,
             diag_current_pc: 0,
+            jit_enabled: false,
         }
     }
 
@@ -5242,6 +5561,121 @@ mod tests {
         assert_eq!(read_chip_word(machine.bus(), machine.a(7)), 0x2000);
         assert_eq!(read_chip_long(machine.bus(), machine.a(7) + 2), 0x0000_0104);
         assert_eq!(machine.bus().delivered_irq_pending, INT_VERTB);
+        Ok(())
+    }
+
+    /// The JIT slice must produce the same architectural result as the
+    /// precise slice for plain computation: a summing loop in fast RAM
+    /// ends with identical registers and PC. The 68020 exercises the
+    /// batch path (through the fastmem window); the 68000 documents the
+    /// precise fallback (its shared-bus float model rules the batch
+    /// contract out, see `jit_fast_path_ok`).
+    #[test]
+    fn jit_slice_matches_precise_registers_and_pc() -> Result<()> {
+        let program = [
+            0x7000u16, // moveq #0,d0
+            0x7231,    // moveq #49,d1
+            0xD081,    // add.l d1,d0
+            0x51C9, 0xFFFC, // dbra d1,<add>
+            0x60FE, // bra.s *
+        ];
+        let pc = FAST_RAM_BASE as u32 + 0x100;
+        for model in [CpuModel::M68000, CpuModel::M68020, CpuModel::M68030] {
+            let run = |jit: bool| -> Result<(u32, u32, u32)> {
+                let mut machine = machine_with_program_model(pc, &program, model)?;
+                machine.set_jit_enabled(jit);
+                let mut retired = 0usize;
+                // 2 setup + 100 loop instructions; the final bra self-loop
+                // absorbs whatever remains of the budget.
+                while retired < 400 {
+                    retired += machine.step_slice(400 - retired)?.instructions;
+                }
+                Ok((machine.d(0), machine.d(1), machine.pc()))
+            };
+            let precise = run(false)?;
+            let jit = run(true)?;
+            assert_eq!(precise, jit, "{model:?}");
+            assert_eq!(jit.0, 1225, "{model:?}");
+            assert_eq!(jit.2, pc + 10, "{model:?}");
+        }
+        Ok(())
+    }
+
+    /// Traps surfaced by the batch path (which never takes them itself)
+    /// must be raised as real hardware exceptions, mirroring the precise
+    /// path's no-op HLE policy.
+    #[test]
+    fn jit_slice_takes_trap_exceptions() -> Result<()> {
+        let pc = FAST_RAM_BASE as u32 + 0x100;
+        let mut bus = test_bus_with_pc(pc);
+        write_program(&mut bus, pc, &[0x4E40]); // trap #0
+        write_program(&mut bus, 0x0000_0200, &[0x702A, 0x60FE]); // moveq #42,d0; bra.s *
+        write_chip_long(&mut bus, 0x80, 0x0000_0200); // TRAP #0 vector
+        let mut machine = M68kMachine::new(bus, CpuModel::M68020, true)?;
+        machine.set_jit_enabled(true);
+        machine.step_slice(8)?;
+        assert_eq!(machine.d(0), 42);
+        assert_eq!(machine.pc(), 0x0000_0202);
+        Ok(())
+    }
+
+    /// A device interrupt raised while the JIT spins inside the fastmem
+    /// window (no bus accesses at all) is still recognized at the next
+    /// slice boundary and its autovector exception taken.
+    #[test]
+    fn jit_slice_delivers_device_interrupts() -> Result<()> {
+        let pc = FAST_RAM_BASE as u32 + 0x100;
+        let mut bus = test_bus_with_pc(pc);
+        write_program(&mut bus, pc, &[0x46FC, 0x2000, 0x60FE]); // move #$2000,SR; bra.s *
+        write_program(&mut bus, 0x0000_0200, &[0x702A, 0x60FE]); // moveq #42,d0; bra.s *
+        set_autovector(&mut bus, 3, 0x0000_0200);
+        bus.paula.intena = INT_MASTER | INT_VERTB;
+        let mut machine = M68kMachine::new(bus, CpuModel::M68020, true)?;
+        machine.set_jit_enabled(true);
+        machine.step_slice(64)?;
+        assert_eq!(machine.pc(), pc + 4, "spinning with no interrupt pending");
+        machine.bus_mut().paula.intreq = INT_VERTB;
+        machine.step_slice(64)?;
+        assert_eq!(machine.d(0), 42, "handler must have run");
+        Ok(())
+    }
+
+    /// The fastmem window is only offered while nothing intercepts plain
+    /// fast-RAM accesses, and covers the largest fitted fast bank.
+    #[test]
+    fn jit_fast_mem_window_gates_and_bank_choice() -> Result<()> {
+        let mut machine = machine_with_program_model(0x0100, &[0x4E71], CpuModel::M68020)?;
+        // Not offered until JIT mode is on.
+        assert!(machine.bus.jit_fast_mem().is_none());
+        machine.set_jit_enabled(true);
+        let window = machine.bus.jit_fast_mem().expect("zorro fast RAM window");
+        assert_eq!(window.base, FAST_RAM_BASE as u32);
+        assert_eq!(window.len, 64 * 1024);
+        // A memory-write debug hook must force every access back onto the
+        // bus so it keeps seeing them.
+        machine.bus.dbg_memw_addr = Some(0x1234);
+        assert!(machine.bus.jit_fast_mem().is_none());
+        machine.bus.dbg_memw_addr = None;
+        // A bigger motherboard bank wins.
+        machine.bus.bus.mem.fit_mb_ram(2 * 1024 * 1024);
+        let window = machine.bus.jit_fast_mem().expect("motherboard window");
+        assert_eq!(window.base, 0x07E0_0000);
+        assert_eq!(window.len, 2 * 1024 * 1024);
+        Ok(())
+    }
+
+    /// A 68000/68010 must never get a fastmem window: on the small-box
+    /// machines every CPU cycle drives the one bus shared with Agnus, and
+    /// the floating-bus latch (`note_cpu_data_bus`) has to see each
+    /// transfer -- Kickstart/AROS memory sizing reads those floats, and
+    /// bypassing the latch wedges the boot.
+    #[test]
+    fn jit_fast_mem_window_never_offered_on_shared_bus_cpus() -> Result<()> {
+        for model in [CpuModel::M68000, CpuModel::M68010] {
+            let mut machine = machine_with_program_model(0x0100, &[0x4E71], model)?;
+            machine.set_jit_enabled(true);
+            assert!(machine.bus.jit_fast_mem().is_none(), "{model:?}");
+        }
         Ok(())
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -252,18 +252,21 @@ const MAX_INSTRUCTION_BYTES: u32 = 12;
 
 /// Instruction budget per `run_batch` call in the JIT slice. Interrupts are
 /// only recognized between batches (plus once inside each batch entry), so
-/// this bounds interrupt latency in JIT mode: 64 instructions at the flat
-/// 4-clock bill is 256 CPU clocks, roughly half a scanline at stock clock.
-/// Larger batches let compiled traces run longer between host round-trips
-/// but delay interrupt delivery; AROS boot at accelerated clock ratios
-/// proved sensitive to latencies beyond about a scanline.
+/// this bounds interrupt latency in JIT mode to a small fraction of a
+/// scanline of billed time. Larger batches let compiled traces run longer
+/// between host round-trips but delay interrupt delivery; AROS boot at
+/// accelerated clock ratios proved sensitive to latencies beyond about a
+/// scanline.
 const JIT_BATCH_INSTRUCTIONS: usize = 64;
 
-/// Flat CPU-clock cost billed per instruction retired by the JIT slice: one
-/// 4-clock 68000 bus cycle. The batch path reports no cycle counts, so this
-/// constant sets the JIT machine's nominal speed -- a stock-clocked 68000
-/// runs at ~1.8 MIPS, and `[cpu] clock_mhz` scales it like any accelerator.
-const JIT_CPU_CLOCKS_PER_INSTRUCTION: u32 = 4;
+/// Flat CPU-clock cost billed per instruction retired by the JIT slice.
+/// The batch path reports no cycle counts, so this constant sets the JIT
+/// machine's nominal speed: one instruction per clock models an ideal
+/// pipelined accelerator, making guest throughput track `[cpu] clock_mhz`
+/// directly (a 50 MHz 68040 runs ~50 MIPS in fast RAM). Deterministic by
+/// construction -- a truly host-speed "fastest possible" mode would make
+/// emulated results depend on the host, which Copperline never allows.
+const JIT_CPU_CLOCKS_PER_INSTRUCTION: u32 = 1;
 
 struct CpuBus {
     bus: Bus,
@@ -2006,17 +2009,21 @@ impl M68kMachine {
         debug!("overlay disabled (chip RAM mapped at $0)");
     }
 
-    /// Enable the fast batch/trace-JIT execution mode (`[cpu] jit`).
+    /// Enable the fast batch/trace-JIT execution mode (`[cpu] jit`). Inert
+    /// on the 68000/68010: their shared-bus float model needs the precise
+    /// core (see `jit_fast_path_ok`), so neither the batch path nor the
+    /// JIT's zero-wait external billing may engage there.
     pub fn set_jit_enabled(&mut self, on: bool) {
-        self.jit_enabled = on;
-        self.bus.jit_enabled = on;
         if on && matches!(self.cpu.cpu_type, CpuType::M68000 | CpuType::M68010) {
             log::info!(
                 "cpu jit: the 68000/68010 shared-bus float model needs the \
                  precise per-instruction core; [cpu] jit has no effect on \
                  this CPU (use a 68020 or later)"
             );
+            return;
         }
+        self.jit_enabled = on;
+        self.bus.jit_enabled = on;
     }
 
     pub fn jit_enabled(&self) -> bool {
@@ -2821,6 +2828,18 @@ impl CpuBus {
         size.max(1).div_ceil(2) as u32
     }
 
+    /// Bill an external-bus (fast RAM/ROM/WCS) access. In JIT mode the CPU
+    /// models an ideal accelerator with zero-wait external memory -- the
+    /// batch path bills one flat clock per instruction instead -- so these
+    /// accesses cost nothing; chip/slow RAM (shared silicon, arbitrated)
+    /// and the E-clock devices keep their real costs either way.
+    fn bill_external_access(&mut self, size: usize) {
+        if self.jit_enabled {
+            return;
+        }
+        self.bus.cpu_external_access(Self::access_words(size));
+    }
+
     /// Latch the last word the CPU drove onto (or sampled from) the shared
     /// data bus: undriven (unmapped) reads float to this value. A byte
     /// cycle drives one lane while the other keeps its previous charge.
@@ -3017,7 +3036,7 @@ impl CpuBus {
         let addr = self.mask(address);
         match self.classify_plain_memory(addr, size) {
             Some(PlainMemRegion::OverlayRom(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(&self.bus.mem.rom, off, size);
             }
             Some(PlainMemRegion::ChipRam(off)) => {
@@ -3027,20 +3046,20 @@ impl CpuBus {
             Some(PlainMemRegion::ZorroRam(board, off)) => {
                 // Expansion (Zorro) RAM runs at external-bus speed, off the
                 // chip bus, exactly like the old fixed fast RAM mapping.
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(self.bus.mem.zorro.board_ram(board), off, size);
             }
             Some(PlainMemRegion::MbRam(off)) => {
                 // Ramsey-controlled motherboard RAM (A3000/A4000): 32-bit
                 // local RAM off the chip bus, at uncontended external speed
                 // like expansion RAM.
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(&self.bus.mem.mb_ram, off, size);
             }
             Some(PlainMemRegion::AccelRam(off)) => {
                 // CPU-slot (accelerator) fast RAM: local RAM on the CPU
                 // board, off the chip bus, at uncontended external speed.
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(&self.bus.mem.accel_ram, off, size);
             }
             Some(PlainMemRegion::SlowRam(off)) => {
@@ -3053,17 +3072,17 @@ impl CpuBus {
                 return read_be(&self.bus.mem.slow_ram, off, size);
             }
             Some(PlainMemRegion::Rom(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(&self.bus.mem.rom, off, size);
             }
             // A1000 WCS at $FC0000 (empty -> no match on other machines): the
             // 256 KiB writable control store the boot ROM loads Kickstart into.
             Some(PlainMemRegion::Wcs(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(&self.bus.mem.wcs, off, size);
             }
             Some(PlainMemRegion::ExtendedRom(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return read_be(&self.bus.mem.extended_rom, off, size);
             }
             None => {}
@@ -3250,7 +3269,7 @@ impl CpuBus {
         }
         match self.classify_plain_memory(addr, size) {
             Some(PlainMemRegion::OverlayRom(_)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return;
             }
             Some(PlainMemRegion::ChipRam(off)) => {
@@ -3271,17 +3290,17 @@ impl CpuBus {
                 return;
             }
             Some(PlainMemRegion::ZorroRam(board, off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 write_be(self.bus.mem.zorro.board_ram_mut(board), off, size, value);
                 return;
             }
             Some(PlainMemRegion::MbRam(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 write_be(&mut self.bus.mem.mb_ram, off, size, value);
                 return;
             }
             Some(PlainMemRegion::AccelRam(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 write_be(&mut self.bus.mem.accel_ram, off, size, value);
                 return;
             }
@@ -3297,7 +3316,7 @@ impl CpuBus {
                 return;
             }
             Some(PlainMemRegion::Rom(_)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 // A1000: a CPU write anywhere in the boot-ROM window ($F80000-
                 // $FBFFFF) flips the latch to write-protect the WCS. The boot code
                 // does this once the Kickstart image is in place at $FC0000.
@@ -3308,7 +3327,7 @@ impl CpuBus {
             }
             // A1000 WCS at $FC0000: writable until the boot ROM locks the latch.
             Some(PlainMemRegion::Wcs(off)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 if !self.bus.mem.wcs_write_protected {
                     write_be(&mut self.bus.mem.wcs, off, size, value);
                     self.dbg_note_memw(addr, size);
@@ -3316,7 +3335,7 @@ impl CpuBus {
                 return;
             }
             Some(PlainMemRegion::ExtendedRom(_)) => {
-                self.bus.cpu_external_access(Self::access_words(size));
+                self.bill_external_access(size);
                 return;
             }
             None => {}

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2491,14 +2491,14 @@ pub fn build_machine(
         cpu_clocks_per_cck,
         paced,
     )?;
-    // JIT mode bypasses the cache models: its fastmem window writes would
-    // not reach a data-cache model's invalidate path, and cache timing is
-    // meaningless under the JIT's flat instruction billing.
-    let caches_on = !cfg.cpu_jit;
-    emu.set_cache_emulation(cfg.cpu_icache && caches_on, cfg.cpu_dcache && caches_on);
-    if cfg.cpu_jit && (cfg.cpu_icache || cfg.cpu_dcache) {
-        log::info!("cpu jit: on-chip cache models bypassed");
-    }
+    // The cache models stay active under JIT: on a real accelerator it is
+    // exactly the caches that let chip-RAM-resident code run at CPU speed
+    // instead of paying chip-bus arbitration per fetch (SysInfo's
+    // Dhrystone on a fast-RAM-less Workbench regressed 3x without them).
+    // There is no coherence hazard with the fastmem window: the window is
+    // only offered while both cache models are absent (CpuBus::jit_fast_mem),
+    // so cached configs simply run every access through the modelled bus.
+    emu.set_cache_emulation(cfg.cpu_icache, cfg.cpu_dcache);
     emu.set_cpu_jit(cfg.cpu_jit);
     emu.set_machine_descriptor(cfg.descriptor());
     Ok(emu)

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -67,6 +67,10 @@ pub struct Emulator {
     paced: bool,
     cpu_cycles_per_instruction: f64,
     real_pacing_budget_mode: RealPacingBudgetMode,
+    /// Fast batch/trace-JIT CPU execution (`[cpu] jit`). The run loop then
+    /// hands the machine multi-instruction slices instead of cycle-stepping
+    /// one instruction at a time; see `M68kMachine::step_slice_jit`.
+    cpu_jit: bool,
     audio_profile: AudioRuntimeProfile,
     real_pacing_profile: RealPacingProfile,
     /// Monotonic count of retired CPU instructions since power-on -- the
@@ -423,6 +427,7 @@ impl Emulator {
             paced,
             cpu_cycles_per_instruction,
             real_pacing_budget_mode,
+            cpu_jit: false,
             audio_profile: AudioRuntimeProfile::new(),
             real_pacing_profile: RealPacingProfile::new(),
             retired_instructions: 0,
@@ -436,6 +441,24 @@ impl Emulator {
     /// Install the opt-in 68020/030 CACR-controlled cache models.
     pub fn set_cache_emulation(&mut self, icache: bool, dcache: bool) {
         self.machine.set_cache_emulation(icache, dcache);
+    }
+
+    /// Enable the fast batch/trace-JIT CPU mode (`[cpu] jit`). Not
+    /// cycle-exact: the CPU runs like an accelerator card. Forces the
+    /// cycles pacing budget, whose per-slice debit is derived from the
+    /// device time that actually elapsed -- the instruction-count budget
+    /// assumes the calibrated interpreter cost per instruction, which the
+    /// JIT's flat billing deliberately undercuts.
+    pub fn set_cpu_jit(&mut self, on: bool) {
+        self.cpu_jit = on;
+        self.machine.set_jit_enabled(on);
+        if on {
+            self.real_pacing_budget_mode = RealPacingBudgetMode::M68kCycles;
+            log::info!(
+                "cpu jit: batch/trace execution enabled (not cycle-exact, \
+                 accelerator-style timing)"
+            );
+        }
     }
 
     /// Record the shape of the running machine (from the boot `Config`) and
@@ -1549,6 +1572,14 @@ impl Emulator {
     ) -> Result<RealSliceAccounting> {
         let chunk = if *cpu_idle {
             self.idle_fast_forward_chunk(idle_cap)
+        } else if self.cpu_jit {
+            // JIT mode hands the machine a fixed multi-instruction slice;
+            // batching (and interrupt recognition) inside it is handled by
+            // `step_slice_jit`. A fixed size -- never derived from the
+            // caller's budget remainder -- keeps the batch boundaries, and
+            // therefore interrupt delivery, identical for every caller that
+            // replays the same machine state.
+            INSTRUCTIONS_PER_REALTIME_SLICE
         } else {
             1
         };
@@ -1574,8 +1605,14 @@ impl Emulator {
         self.real_pacing_profile.record_slice(&run, accounting);
         // Only a single-instruction slice that came back stopped tells us the
         // CPU is genuinely idle; never batch on the slice right after a
-        // fast-forward, so a wake-up is always stepped.
-        *cpu_idle = run.cpu_stopped && chunk == 1;
+        // fast-forward, so a wake-up is always stepped. The JIT path runs
+        // multi-instruction slices, so there a stopped slice that retired
+        // nothing at all is the equivalent evidence -- without it the idle
+        // fast-forward (whose nap is bounded to the next device event) never
+        // engages and a STOPped guest free-runs past fine-grained device
+        // timing in whole-slice blind naps.
+        *cpu_idle =
+            run.cpu_stopped && (chunk == 1 || (self.cpu_jit && run.actual_instructions == 0));
         Ok(accounting)
     }
 
@@ -1797,14 +1834,29 @@ fn real_slice_accounting(
         // not a whole instruction's worth of time.
         let device_cck = if run.actual_instructions == 0 && requested_instructions == 1 {
             run.actual_cpu_cck.max(1)
+        } else if run.actual_instructions > 0 {
+            // A multi-instruction (JIT) slice that ran and then hit STOP:
+            // its billed time is the device time. Flooring at the requested
+            // span would nap blindly past every device event by the rest of
+            // the slice (thousands of instructions), inflating each Wait()'s
+            // wake-up latency; the idle period belongs to the NEXT slice,
+            // whose fast-forward is bounded to the next device event. The
+            // precise path never reaches here (its stopping slice is a
+            // single-instruction slice, accounted as running).
+            run.actual_cpu_cck
         } else {
             run.actual_cpu_cck.max(cck_for_instructions(
                 requested_instructions,
                 cpu_cycles_per_instruction,
             ))
         };
+        let budget_debit = if run.actual_instructions > 0 {
+            run.actual_instructions
+        } else {
+            requested_instructions.max(1)
+        };
         return RealSliceAccounting {
-            budget_debit: requested_instructions.max(run.actual_instructions).max(1),
+            budget_debit,
             device_cck,
             chip_bus_wait_cck: 0,
             slice_cck: device_cck.max(run.bus_advanced_cck),
@@ -2439,7 +2491,15 @@ pub fn build_machine(
         cpu_clocks_per_cck,
         paced,
     )?;
-    emu.set_cache_emulation(cfg.cpu_icache, cfg.cpu_dcache);
+    // JIT mode bypasses the cache models: its fastmem window writes would
+    // not reach a data-cache model's invalidate path, and cache timing is
+    // meaningless under the JIT's flat instruction billing.
+    let caches_on = !cfg.cpu_jit;
+    emu.set_cache_emulation(cfg.cpu_icache && caches_on, cfg.cpu_dcache && caches_on);
+    if cfg.cpu_jit && (cfg.cpu_icache || cfg.cpu_dcache) {
+        log::info!("cpu jit: on-chip cache models bypassed");
+    }
+    emu.set_cpu_jit(cfg.cpu_jit);
     emu.set_machine_descriptor(cfg.descriptor());
     Ok(emu)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,6 +421,12 @@ where
                 )?;
                 overrides.cpu_clock_mhz = Some(mhz);
             }
+            "--jit" => {
+                overrides.cpu_jit = Some(true);
+            }
+            "--no-jit" => {
+                overrides.cpu_jit = Some(false);
+            }
             "--chip" => {
                 overrides.chip = Some(
                     args.next()
@@ -1098,6 +1104,8 @@ fn print_help() {
          --cpu MODEL                    CPU: 68000, 68010, 68EC020, 68020, 68030, 68040, or 68060\n  \
          --cpu-clock MHZ                CPU clock in MHz (default: the model's stock speed)\n  \
          --fpu / --no-fpu               fit / omit a 68881/68882 (68040/68060 on-die)\n  \
+         --jit / --no-jit               fast batch/trace-JIT CPU execution (not cycle-exact,\n  \
+         \x20                            like an accelerator card; default: off)\n  \
          --chip SIZE                    chip RAM size, e.g. 512K, 1M, 2M\n  \
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
@@ -1741,6 +1749,11 @@ fn main() -> Result<()> {
     // its logs via RUST_LOG.
     if std::env::var_os("RUST_LOG").is_none() {
         log_builder.filter_module("gilrs", log::LevelFilter::Error);
+        // The Cranelift JIT backend logs every compiled trace's full IR
+        // listing at info level; with `[cpu] jit` that floods the log.
+        // RUST_LOG still opts back in for JIT debugging.
+        log_builder.filter_module("cranelift_jit", log::LevelFilter::Warn);
+        log_builder.filter_module("cranelift_codegen", log::LevelFilter::Warn);
     }
     log_builder.init();
 
@@ -2898,11 +2911,13 @@ mod tests {
             "3",
             "--chipset",
             "AGA",
+            "--jit",
         ])?;
         assert_eq!(args.overrides.model.as_deref(), Some("A1200"));
         assert_eq!(args.overrides.cpu.as_deref(), Some("68030"));
         assert_eq!(args.overrides.cpu_clock_mhz, Some(50.0));
         assert_eq!(args.overrides.fpu, Some(true));
+        assert_eq!(args.overrides.cpu_jit, Some(true));
         assert_eq!(args.overrides.chip.as_deref(), Some("2M"));
         assert_eq!(args.overrides.fast.as_deref(), Some("8M"));
         assert_eq!(args.overrides.slow.as_deref(), Some("512K"));

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -561,7 +561,7 @@ const CPU_ROWS: [Row; 6] = [
     row(F::Clock, "Clock", Cycle),
     row(F::Icache, "Instruction cache", Toggle),
     row(F::Dcache, "Data cache", Toggle),
-    row(F::Jit, "JIT (not cycle-exact)", Toggle),
+    row(F::Jit, "JIT accelerator", Toggle),
 ];
 const MEMORY_ROWS: [Row; 6] = [
     row(F::ChipRam, "Chip RAM", Cycle),
@@ -2112,6 +2112,12 @@ impl MachineSetup {
             // both caches; only the 68000 has neither).
             F::Icache => reason(self.cpu.has_instruction_cache(), "needs 68020+"),
             F::Dcache => reason(self.cpu.has_data_cache(), "needs 68030/040"),
+            // The 68000/68010 shared-bus float model needs the precise
+            // core, so the JIT never engages there (see cpu.rs).
+            F::Jit => reason(
+                !matches!(self.cpu, CpuModel::M68000 | CpuModel::M68010),
+                "needs 68020+",
+            ),
             F::Z3Ram => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
             // The CPU-slot space at $08000000 is beyond a 24-bit bus too.
             F::AccelRam => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -860,7 +860,9 @@ const CPUS: [CpuModel; 7] = [
     CpuModel::M68040,
     CpuModel::M68060,
 ];
-const CLOCK_PRESETS: [f64; 8] = [7.09, 14.0, 14.18, 25.0, 28.0, 33.0, 40.0, 50.0];
+const CLOCK_PRESETS: [f64; 10] = [
+    7.09, 14.0, 14.18, 25.0, 28.0, 33.0, 40.0, 50.0, 100.0, 200.0,
+];
 const CHIP_PRESETS: [usize; 4] = [256 * 1024, 512 * 1024, 1024 * 1024, 2 * 1024 * 1024];
 const FAST_PRESETS: [usize; 9] = [
     0,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -308,6 +308,7 @@ pub enum LauncherField {
     Clock,
     Icache,
     Dcache,
+    Jit,
     // Memory
     ChipRam,
     FastRam,
@@ -554,12 +555,13 @@ const SYSTEM_ROWS: [Row; 7] = [
     row(F::Identify, "Identify board", Toggle),
     row(F::Rtg, "RTG card", Cycle),
 ];
-const CPU_ROWS: [Row; 5] = [
+const CPU_ROWS: [Row; 6] = [
     row(F::Cpu, "CPU", Cycle),
     row(F::Fpu, "FPU (68881/2)", Toggle),
     row(F::Clock, "Clock", Cycle),
     row(F::Icache, "Instruction cache", Toggle),
     row(F::Dcache, "Data cache", Toggle),
+    row(F::Jit, "JIT (not cycle-exact)", Toggle),
 ];
 const MEMORY_ROWS: [Row; 6] = [
     row(F::ChipRam, "Chip RAM", Cycle),
@@ -1169,6 +1171,8 @@ pub struct MachineSetup {
     clock_mhz: f64,
     icache: bool,
     dcache: bool,
+    /// Fast batch/trace-JIT CPU execution (`[cpu] jit`); not cycle-exact.
+    jit: bool,
     // Memory (bytes)
     chip_ram: usize,
     fast_ram: usize,
@@ -1371,6 +1375,7 @@ impl MachineSetup {
             clock_mhz: cfg.cpu_clock_mhz,
             icache: cfg.cpu_icache,
             dcache: cfg.cpu_dcache,
+            jit: cfg.cpu_jit,
             chip_ram: cfg.chip_ram_bytes,
             fast_ram: cfg.fast_ram_bytes,
             slow_ram: cfg.slow_ram_bytes,
@@ -1635,6 +1640,9 @@ impl MachineSetup {
         }
         if self.dcache != base.cpu_dcache {
             raw.cpu.dcache = Some(self.dcache);
+        }
+        if self.jit != base.cpu_jit {
+            raw.cpu.jit = Some(self.jit);
         }
         // Memory
         if self.chip_ram != base.chip_ram_bytes {
@@ -2000,6 +2008,7 @@ impl MachineSetup {
         self.clock_mhz = base.cpu_clock_mhz;
         self.icache = base.cpu_icache;
         self.dcache = base.cpu_dcache;
+        self.jit = base.cpu_jit;
         self.chip_ram = base.chip_ram_bytes;
         self.fast_ram = base.fast_ram_bytes;
         self.slow_ram = base.slow_ram_bytes;
@@ -2272,6 +2281,7 @@ impl MachineSetup {
             F::Fpu => self.fpu,
             F::Icache => self.icache,
             F::Dcache => self.dcache,
+            F::Jit => self.jit,
             F::Df0WriteProtect => self.df_write_protected[0],
             F::Df1WriteProtect => self.df_write_protected[1],
             F::Df2WriteProtect => self.df_write_protected[2],
@@ -3024,6 +3034,7 @@ impl MachineSetup {
             F::Fpu => self.fpu = !self.fpu,
             F::Icache => self.icache = !self.icache,
             F::Dcache => self.dcache = !self.dcache,
+            F::Jit => self.jit = !self.jit,
             F::Df0WriteProtect | F::Df1WriteProtect | F::Df2WriteProtect | F::Df3WriteProtect
                 if Self::drive_protect_bay(field).is_some() =>
             {

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -9253,6 +9253,19 @@ mod tests {
         draw(&mut frame, scale, &ui, None, None, false, false, labels());
         save(&frame, "launcher-io-ports");
 
+        // The CPU tab on the default (68000) machine: the JIT accelerator
+        // row is greyed with its "needs 68020+" reason instead of a toggle.
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::Cpu;
+        let ui = UiState {
+            menu_open: false,
+            menu_scroll: 0,
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None, false, false, labels());
+        save(&frame, "launcher-cpu");
+
         // I/O Ports with the A2065 on the NAT backend, to check the
         // non-determinism warning under the rows.
         let mut frame = vec![0u8; w * h * 4];

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -424,6 +424,16 @@ impl ZorroChain {
         None
     }
 
+    /// The largest configured RAM window as (base, len, board index), for
+    /// the CPU's JIT fastmem window. None until autoconfig has placed a
+    /// RAM board.
+    pub fn largest_ram_region(&self) -> Option<(u32, u32, usize)> {
+        self.regions
+            .iter()
+            .max_by_key(|(_, len, _)| *len)
+            .map(|&(base, len, idx)| (base, len, idx))
+    }
+
     /// Configured RAM windows as (base, len) pairs, for the debugger's
     /// memory hunt.
     pub fn ram_regions(&self) -> Vec<(u32, u32)> {


### PR DESCRIPTION
## Summary

Now that Copperline uses the published `m68k` 0.3.1 crate (#342), this adds a runtime option to run the CPU through the crate's batch/trace-JIT path: `[cpu] jit` in the config, `--jit`/`--no-jit` on the CLI, and a **JIT accelerator** toggle on the launcher's CPU tab (greyed with "needs 68020+" on a 68000/68010). A new default cargo feature `cpu-jit` enables `m68k/jit` (Cranelift); browser builds with `--no-default-features` keep the crate's interpreted trace loop, so the option works there too, just without native code generation.

## Execution model (`M68kMachine::step_slice_jit`)

- 64-instruction inner batches through `CpuCore::run_batch`; each retired instruction bills **one CPU clock**, and fast-RAM/ROM accesses are zero-wait, so guest throughput tracks `[cpu] clock_mhz` directly: a 50 MHz 68040 runs ~50 MIPS in fast RAM, and raising `clock_mhz` raises it further. This is the deterministic equivalent of a free-running CPU -- actual host-speed execution would make emulated results host-dependent, which Copperline never allows.
- Chip and slow RAM still arbitrate into DMA slots through `CpuBus` (shared silicon), and CIA/RTC accesses keep their E-clock costs, so displays, blits, and device I/O stay ordered against the beam - just not cycle-exactly.
- The largest fast-RAM bank (Zorro/motherboard/accelerator) is offered to the core as a zero-cost fastmem window; cache models, memory-write debug hooks, the heat map, SMC detection, or injected bus faults all force accesses back onto the bus.
- Interrupts are recognized at batch boundaries from live INTENA/INTREQ state; a level the boundary cannot deliver is never left in the core (the batch would take it at RTE without recomputing INTREQ and spuriously re-enter a finished handler).
- Traps surfaced by the batch (A-line/F-line/TRAP/BKPT/illegal) are taken as their real hardware exceptions, mirroring the precise loop's no-op HLE policy.
- Arming any per-instruction debug or diagnostic hook drops the slice back to the precise loop, so the debugger always sees every instruction.

Measured on a Kickstart 3.1 A1200 boot (30 emulated seconds, headless): the guest retires ~259M instructions under JIT vs ~35M precise (the accelerator effect), at ~4.4x lower host cost per guest instruction.

## 68000/68010 fall back to the precise core

The small-box floating-bus model is prefetch-order dependent: Kickstart's diagnostic-ROM probe (`CMPI.W #$1111,(A1)` against unmapped `$F00000`) relies on the prefetch queue having fetched the following words, so the undriven bus must not float to the immediate just read. The prefetch-less batch contract lands the float on the immediate and false-detects a diagnostic ROM (KS1.3 then jumps into empty space). `set_jit_enabled` is inert on these models (logged): no batch path, no zero-wait billing, precise IPL sampling kept. The launcher greys the toggle with "needs 68020+".

## Supporting fixes (correct for the precise path too)

- The CIA-A overlay disable flips the mapping synchronously at the write, matching Gary's flip-flop, instead of at the slice boundary.
- A slice that runs and then executes STOP bills only its executed time; the idle period is the next slice's event-bounded fast-forward (previously a multi-instruction slice could nap blindly past device events by the rest of its span).
- A zero-instruction stopped JIT slice engages the idle fast-forward machinery.
- `cranelift_jit`/`cranelift_codegen` logging is filtered to warn level by default (each compiled trace logs its full IR at info level); `RUST_LOG` re-enables it.

## Known issue (documented)

The bundled AROS ROM's boot screen can stay grey under JIT on some 020+ configurations - the guest still boots and runs (verified via CCP task-list inspection); Kickstart ROMs are unaffected. Recorded in `docs/guide/configuration.md`.

## Testing

- `cargo test` (2073 lib tests), `cargo clippy`, `cargo fmt --check` all clean.
- New unit tests: JIT-vs-precise architectural equivalence (68020/68030 batch + 68000 fallback), trap-to-exception parity, interrupt delivery across fastmem-window batches, fastmem window gating and bank choice, window never offered on shared-bus CPUs, config parse and CLI override coverage, and a launcher CPU-tab UI preview covering the greyed JIT row.
- Headless verification: KS3.1 A1200 and a 50 MHz 68040 A4000 boot under JIT; KS1.3 A500 and AROS A500 boot via the precise fallback.
- Docs updated: `docs/guide/configuration.md` ([cpu] jit + CLI table), `docs/guide/ui.md` (launcher CPU tab), `docs/internals/cpu.md` (new "batch/JIT execution mode" section).
- `packaging/flatpak/cargo-sources.json` regenerated for the Cranelift additions (fixes the CI sources check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRCdzExVHg1HVUXx7K9AoU