### PR TITLE
launcher: (another) minor visual refinement 

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -50,7 +50,7 @@ range checks as the equivalent TOML fields:
 | `--floppy-speed PERCENT` | `[floppy] speed` | `100` (real), `200`, `400`, `800`, or `0` (turbo) |
 | `--floppy-bridge DFN NAME` | `[floppy.dfN] bridge` | drive a physical floppy drive: `drawbridge`, `greaseweazle`, `supercardpro`, `off` |
 | `--floppy-bridge-port DFN PORT` | `[floppy.dfN] bridge_port` | that interface's serial port (default: auto-detect) |
-| `--floppy-bridge-cable DFN SEL` | `[floppy.dfN] bridge_cable` | drive select: `a`/`b` (PC cable) or `0`-`3` (Shugart) |
+| `--floppy-bridge-cable DFN SEL` | `[floppy.dfN] bridge_cable` | drive select: `a`/`b` (IBM PC cable) or `0`-`3` (Shugart) |
 | `--floppy-bridge-mode DFN MODE` | `[floppy.dfN] bridge_mode` | how tracks are captured: `normal`, `compatible`, `stalling` |
 | `--floppy-bridge-density DFN D` | `[floppy.dfN] bridge_density` | force a density: `auto`, `dd`, `hd` |
 | `--floppy-bridge-speed DFN PCT` | `[floppy.dfN] bridge_speed` | serve captured tracks at `100`, `125`, `150`, `175`, or `200` percent of real speed |

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -335,7 +335,7 @@ The layout is:
   beneath it: serial mode and MIDI endpoints; the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
-  and the A2065 Ethernet board -- Not fitted, Isolated, Loopback, NAT, or
+  and the A2065 Ethernet board -- None, Isolated, Loopback, NAT, or
   Bridged; Bridged adds a host-adapter row. NAT and Bridged show a warning
   because host-clocked traffic makes input recordings and save-state replays
   non-reproducible while it flows),
@@ -343,11 +343,11 @@ The layout is:
   WASM plugin board's declared options),
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
-  sounds and volume), **Video** (start fullscreen, status bar, overscan, pixel
-  aspect, screen tint, deinterlace, phosphor, CRT shader, shader strength and
-  monitor bezel),
+  sounds and volume), **Video** (start fullscreen, status bar, monitor bezel,
+  overscan, pixel aspect, deinterlace, screen tint, phosphor, CRT shader and
+  shader strength),
   and **Emulation**
-  (power-on, warp speed, pacing, realtime priority) -- opening on Audio, and
+  (power-on, realtime priority, pacing, warp speed) -- opening on Audio, and
   switched freely between the three.
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
   buttons flip a toggle, and the **Browse** and **Clear** buttons set or remove
@@ -368,7 +368,7 @@ The layout is:
   column's **Bootable** box is ticked by default; clearing it greys that row's
   priority and writes the -128 "disabled" sentinel, so the volume mounts but
   never boots.
-  A drive with no image, or a CD image, is greyed ("no drive" / "CD-ROM").
+  A drive with no image, or a CD image, is greyed ("No drive" / "CD-ROM").
   Drives you add here with no priority of their own cascade so they do not tie:
   the first is 0 (just under DF0:'s 5), and each later one drops below the
   floppies -- -35, -40, -45. A drive already carrying a priority in the config
@@ -391,7 +391,7 @@ The layout is:
 
 The Boot Priority sub-page: an A1200 whose IDE master boots at priority 5, its
 slave with the Bootable box cleared (priority greyed), and the empty SCSI units
-greyed "no drive". A greyed **Info:** label heads a note on the valid priority
+greyed "No drive". A greyed **Info:** label heads a note on the valid priority
 range.
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1083,7 +1083,7 @@ fn print_help() {
         "--floppy-bridge DFN NAME       drive a physical floppy drive on DFN over NAME:\n  \
          \x20                            drawbridge, greaseweazle, supercardpro, or off\n  \
          --floppy-bridge-port DFN PORT  serial port of that interface (default: auto-detect)\n  \
-         --floppy-bridge-cable DFN SEL  drive select on the cable: a/b (PC) or 0-3 (Shugart)\n  \
+         --floppy-bridge-cable DFN SEL  drive select on the cable: a/b (IBM PC) or 0-3 (Shugart)\n  \
          --floppy-bridge-mode DFN MODE  how tracks are captured: normal, compatible, stalling\n  \
          --floppy-bridge-density DFN D  force a density: auto, dd, or hd\n  \
          --floppy-bridge-speed DFN PCT  serve captured tracks at 100, 125, 150, 175, or 200%\n  \

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -694,14 +694,14 @@ const ETHERNET_ROWS: [Row; 2] = [
 const VIDEO_ROWS: [Row; 10] = [
     row(F::StartFullscreen, "Start fullscreen", Toggle),
     row(F::ShowStatusBar, "Status bar", Toggle),
+    row(F::Bezel, "Monitor bezel", Toggle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
-    row(F::Tint, "Screen tint", Cycle),
     row(F::Deinterlace, "Deinterlace", Toggle),
+    row(F::Tint, "Screen tint", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
     row(F::Shader, "CRT shader", Cycle),
     row(F::ShaderStrength, "Shader strength", Cycle),
-    row(F::Bezel, "Monitor bezel", Toggle),
 ];
 const AUDIO_ROWS: [Row; 6] = [
     row(F::AudioDevice, "Audio output", Cycle),
@@ -712,10 +712,10 @@ const AUDIO_ROWS: [Row; 6] = [
     row(F::FloppyVolume, "Floppy volume", Cycle),
 ];
 const EMULATION_ROWS: [Row; 4] = [
-    row(F::PowerOn, "Power on at start", Toggle),
-    row(F::Warp, "Warp speed", Cycle),
-    row(F::PacingBudget, "Pacing budget", Cycle),
+    row(F::PowerOn, "Power on startup", Toggle),
     row(F::RealtimePriority, "Realtime priority", Toggle),
+    row(F::PacingBudget, "Pacing budget", Cycle),
+    row(F::Warp, "Warp speed", Cycle),
 ];
 const INPUT_ROWS: [Row; 5] = [
     row(F::Port1Device, "Port 1", Cycle),
@@ -2179,7 +2179,7 @@ impl MachineSetup {
             }
             // Shader strength only feeds the shader pass, which does not run when
             // the shader is off.
-            F::ShaderStrength => reason(self.shader != ShaderMode::None, "shader off"),
+            F::ShaderStrength => reason(self.shader != ShaderMode::None, "Disabled"),
             // A boot priority or read-only flag is meaningless without a
             // directory to mount.
             F::Filesys0Boot | F::Filesys1Boot | F::Filesys2Boot | F::Filesys3Boot => {
@@ -2199,7 +2199,7 @@ impl MachineSetup {
             | F::ScsiUnit6Boot => {
                 let drive = Self::boot_field_drive(field).expect("boot field");
                 match self.path(drive) {
-                    None => Some("no drive"),
+                    None => Some("No drive"),
                     Some(p) if crate::config::is_cd_image_path(p) => Some("CD-ROM"),
                     Some(_) => None,
                 }
@@ -2221,7 +2221,7 @@ impl MachineSetup {
             // attached or selected, only the Interface row stays live -- the
             // rest describe hardware that is not present.
             #[cfg(feature = "floppybridge")]
-            F::BridgeDevice => reason(self.bridge_edit().is_some(), "no drive"),
+            F::BridgeDevice => reason(self.bridge_edit().is_some(), "No drive"),
             #[cfg(feature = "floppybridge")]
             F::BridgeCable
             | F::BridgeDensity
@@ -2276,7 +2276,7 @@ impl MachineSetup {
             }
             // Neither mouse row does anything unless a port holds a mouse.
             F::MouseSensitivity | F::MouseCapture => {
-                reason(self.port_devices.contains(&PortDevice::Mouse), "no mouse")
+                reason(self.port_devices.contains(&PortDevice::Mouse), "No mouse")
             }
             _ => None,
         }
@@ -2502,7 +2502,7 @@ impl MachineSetup {
             },
             F::Phosphor => {
                 if self.phosphor <= 0.0 {
-                    "Off".to_string()
+                    "Disabled".to_string()
                 } else {
                     format!("{:.2}", self.phosphor)
                 }
@@ -2516,13 +2516,15 @@ impl MachineSetup {
                 None => "Automatic".to_string(),
                 Some(p) => p,
             },
+            // Named as the drive's own jumpers are: A/B on an IBM PC cable,
+            // DS0..DS3 on a Shugart one.
             F::BridgeCable => match self.bridge_edit().map(|c| c.cable) {
-                Some(BridgeCable::DriveA) => "PC drive A".to_string(),
-                Some(BridgeCable::DriveB) => "PC drive B".to_string(),
-                Some(BridgeCable::Shugart0) => "Shugart 0".to_string(),
-                Some(BridgeCable::Shugart1) => "Shugart 1".to_string(),
-                Some(BridgeCable::Shugart2) => "Shugart 2".to_string(),
-                Some(BridgeCable::Shugart3) => "Shugart 3".to_string(),
+                Some(BridgeCable::DriveA) => "Drive A (IBM)".to_string(),
+                Some(BridgeCable::DriveB) => "Drive B (IBM)".to_string(),
+                Some(BridgeCable::Shugart0) => "DS0 (Shugart)".to_string(),
+                Some(BridgeCable::Shugart1) => "DS1 (Shugart)".to_string(),
+                Some(BridgeCable::Shugart2) => "DS2 (Shugart)".to_string(),
+                Some(BridgeCable::Shugart3) => "DS3 (Shugart)".to_string(),
                 None => "(none)".to_string(),
             },
             F::BridgeDensity => match self.bridge_edit().map(|c| c.density) {
@@ -2541,7 +2543,7 @@ impl MachineSetup {
                 format!("{}%", self.bridge_edit().map_or(100, |c| c.speed))
             }
             F::Shader => match self.shader {
-                ShaderMode::None => "Off".to_string(),
+                ShaderMode::None => "Disabled".to_string(),
                 ShaderMode::Scanlines => "Scanlines".to_string(),
                 ShaderMode::Mask => "Mask".to_string(),
                 // Named for the monitor the preset is modelled on; the path
@@ -2600,7 +2602,7 @@ impl MachineSetup {
                 .unwrap_or_else(|| "Default".to_string()),
             F::SamplerGain => sampler_gain_label(self.sampler_gain_db),
             F::Ethernet => match self.a2065_net.as_ref() {
-                None => "Not fitted".to_string(),
+                None => "None".to_string(),
                 Some(NetConfig::None) => "Isolated".to_string(),
                 Some(NetConfig::Loopback) => "Loopback".to_string(),
                 Some(NetConfig::Nat) => "NAT".to_string(),
@@ -2641,7 +2643,7 @@ impl MachineSetup {
             | F::ScsiUnit3Boot
             | F::ScsiUnit4Boot
             | F::ScsiUnit5Boot
-            | F::ScsiUnit6Boot => drive_bootpri_label(self.drive_bootpri(field)),
+            | F::ScsiUnit6Boot => drive_bootpri_label(self.effective_bootpri(field)),
             F::Filesys0ReadOnly
             | F::Filesys1ReadOnly
             | F::Filesys2ReadOnly
@@ -3282,8 +3284,9 @@ impl MachineSetup {
         }
     }
 
-    /// Flip a drive's Bootable box. Clearing it keeps the priority number (shown
-    /// greyed) so re-ticking restores it within the session.
+    /// Flip a drive's Bootable box. Clearing it shows the -128 sentinel the
+    /// config will store, while keeping the priority underneath so re-ticking
+    /// restores it within the session.
     pub fn toggle_drive_boot(&mut self, field: LauncherField) {
         let off = self.drive_boot_off(field);
         self.set_drive_boot_off(field, !off);
@@ -3411,6 +3414,16 @@ impl MachineSetup {
 
     pub fn set_bridge_edit_drive(&mut self, idx: usize) {
         self.bridge_edit_drive = idx.min(3);
+    }
+
+    /// Whether the bridge page is editing a bay with an interface actually
+    /// selected and attached. Only then does that interface's own set of
+    /// capabilities decide anything: with none there is nothing to have an
+    /// opinion, and the rows it would shape have nothing to show.
+    pub fn bridge_interface_selected(&self) -> bool {
+        self.bridge_edit().is_some()
+            && !self.df_bridge_none[self.bridge_edit_drive]
+            && self.bridge_status == BridgeStatus::Attached
     }
 
     /// The settings being shown on the FloppyBridge page.
@@ -4264,6 +4277,32 @@ mod tests {
         }
     }
 
+    /// Drive select is shaped by the interface, so it only answers to one
+    /// when there is one: attached and chosen. That is what separates a row
+    /// greyed with its steppers (this interface has no drive-select line)
+    /// from one blanked entirely (there is no interface to ask).
+    #[cfg(feature = "floppybridge")]
+    #[test]
+    fn drive_select_answers_to_an_interface_only_when_there_is_one() {
+        let mut setup = MachineSetup::default();
+        setup.set_drive_bridged(0, true);
+        setup.set_bridge_edit_drive(0);
+
+        setup.bridge_status = BridgeStatus::NoInterface;
+        setup.df_bridge_none[0] = false;
+        assert!(!setup.bridge_interface_selected(), "nothing attached");
+
+        setup.bridge_status = BridgeStatus::Attached;
+        setup.df_bridge_none[0] = true;
+        assert!(!setup.bridge_interface_selected(), "interface set to None");
+
+        setup.df_bridge_none[0] = false;
+        assert!(setup.bridge_interface_selected(), "attached and chosen");
+
+        setup.set_drive_bridged(0, false);
+        assert!(!setup.bridge_interface_selected(), "no bay at all");
+    }
+
     /// A bridged bay only names its interface when one is actually attached:
     /// with nothing plugged in the media row says so, whatever the bay is
     /// configured for.
@@ -4785,7 +4824,7 @@ mod tests {
         s.port_devices = [PortDevice::Joystick, PortDevice::Joystick];
         assert_eq!(
             s.disabled_reason(LauncherField::MouseCapture),
-            Some("no mouse")
+            Some("No mouse")
         );
     }
 
@@ -4799,7 +4838,7 @@ mod tests {
         s.port_devices = [PortDevice::Joystick, PortDevice::Joystick];
         assert_eq!(
             s.disabled_reason(LauncherField::MouseSensitivity),
-            Some("no mouse")
+            Some("No mouse")
         );
 
         // A mouse in either port re-enables it.
@@ -5052,12 +5091,12 @@ mod tests {
         use LauncherField as F;
         let mut s = MachineSetup::default();
         // The shader is off by default, so its strength does nothing and greys.
-        assert_eq!(s.value_label(F::Shader), "Off");
-        assert_eq!(s.disabled_reason(F::ShaderStrength), Some("shader off"));
+        assert_eq!(s.value_label(F::Shader), "Disabled");
+        assert_eq!(s.disabled_reason(F::ShaderStrength), Some("Disabled"));
         assert!(!s.applies(F::ShaderStrength));
         // Turning a shader on makes the strength editable again.
         s.cycle(F::Shader, true); // Off -> the first real shader
-        assert_ne!(s.value_label(F::Shader), "Off");
+        assert_ne!(s.value_label(F::Shader), "Disabled");
         assert_eq!(s.disabled_reason(F::ShaderStrength), None);
     }
 
@@ -5083,7 +5122,7 @@ mod tests {
         assert!(setup.has_boot_priority_rows());
         assert!(!MachineSetup::default().has_boot_priority_rows());
         // No slave image, so its boot row is greyed and inert.
-        assert_eq!(setup.disabled_reason(F::IdeSlaveBoot), Some("no drive"));
+        assert_eq!(setup.disabled_reason(F::IdeSlaveBoot), Some("No drive"));
 
         // The arrows step the live priority and re-emit it.
         setup.cycle(F::IdeMasterBoot, true); // 5 -> 6
@@ -5095,17 +5134,19 @@ mod tests {
         assert_eq!(setup.value_label(F::IdeMasterBoot), "0");
         assert_eq!(setup.to_raw().ide.master.as_ref().unwrap().bootpri, None);
 
-        // Clearing the Bootable box writes the -128 sentinel but keeps the
-        // priority number for the greyed display; re-ticking restores it.
+        // Clearing the Bootable box writes the -128 sentinel and shows it, so
+        // the greyed row says what the config will hold; the priority is kept
+        // underneath, and re-ticking restores it.
         setup.set_drive_bootpri(F::IdeMasterBoot, Some(6));
         setup.toggle_drive_boot(F::IdeMasterBoot);
         assert!(setup.drive_boot_off(F::IdeMasterBoot));
-        assert_eq!(setup.value_label(F::IdeMasterBoot), "6");
+        assert_eq!(setup.value_label(F::IdeMasterBoot), "-128");
         assert_eq!(
             setup.to_raw().ide.master.as_ref().unwrap().bootpri,
             Some(-128)
         );
         setup.toggle_drive_boot(F::IdeMasterBoot);
+        assert_eq!(setup.value_label(F::IdeMasterBoot), "6");
         assert_eq!(setup.to_raw().ide.master.as_ref().unwrap().bootpri, Some(6));
     }
 
@@ -5191,7 +5232,7 @@ mod tests {
     #[test]
     fn a2065_board_cycles_and_round_trips() {
         let mut s = MachineSetup::default();
-        assert_eq!(s.value_label(LauncherField::Ethernet), "Not fitted");
+        assert_eq!(s.value_label(LauncherField::Ethernet), "None");
         assert!(s.to_raw().a2065.net.is_none());
         assert!(!s.ethernet_breaks_determinism());
 
@@ -5219,7 +5260,7 @@ mod tests {
             // Where the NAT cannot come up the picker skips straight past it.
             s.cycle(LauncherField::Ethernet, true);
         }
-        assert_eq!(s.value_label(LauncherField::Ethernet), "Not fitted");
+        assert_eq!(s.value_label(LauncherField::Ethernet), "None");
     }
 
     #[test]
@@ -5617,12 +5658,12 @@ mod tests {
     fn shader_cycles_the_presets_and_round_trips_through_raw() {
         let mut s = MachineSetup::default();
         // Off is the baseline, so nothing is written for it.
-        assert_eq!(s.value_label(LauncherField::Shader), "Off");
+        assert_eq!(s.value_label(LauncherField::Shader), "Disabled");
         assert_eq!(s.to_raw().display.shader, None);
 
         // With no user shader configured the picker offers the presets only,
         // and wraps straight back to Off.
-        for expected in ["Scanlines", "Mask", "CRT (1084)", "Off"] {
+        for expected in ["Scanlines", "Mask", "CRT (1084)", "Disabled"] {
             s.cycle(LauncherField::Shader, true);
             assert_eq!(s.value_label(LauncherField::Shader), expected);
         }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4613,6 +4613,11 @@ const LAUNCH_ROW_H: usize = 26;
 const LAUNCH_LABEL_W: usize = 150;
 const LAUNCH_ARROW_W: usize = 24;
 const LAUNCH_VALUE_W: usize = 132;
+/// The priority column's value box. Narrower than the general one, which is
+/// sized for device names: the widest thing here is "No drive", against a
+/// priority otherwise (down to the "-128" that a cleared Bootable box
+/// stores), and this leaves a clear margin either side.
+const LAUNCH_BOOTPRI_VALUE_W: usize = 96;
 const LAUNCH_TOGGLE_W: usize = 64;
 const LAUNCH_ACTION_W: usize = 84;
 const LAUNCH_ACTION_H: usize = 22;
@@ -4697,6 +4702,15 @@ fn launcher_status_y(rect: Rect) -> usize {
 
 /// (prev arrow, value field, next arrow) for a cycle row.
 fn launcher_cycle_rects(rect: Rect, row_y: usize) -> (Rect, Rect, Rect) {
+    launcher_stepper_rects(rect, row_y, LAUNCH_VALUE_W)
+}
+
+/// The priority column's `< value >`, on its own narrower value box.
+fn launcher_bootpri_rects(rect: Rect, row_y: usize) -> (Rect, Rect, Rect) {
+    launcher_stepper_rects(rect, row_y, LAUNCH_BOOTPRI_VALUE_W)
+}
+
+fn launcher_stepper_rects(rect: Rect, row_y: usize, value_w: usize) -> (Rect, Rect, Rect) {
     let y = row_y + 2;
     let cx = launcher_control_x(rect);
     let prev = Rect {
@@ -4708,11 +4722,11 @@ fn launcher_cycle_rects(rect: Rect, row_y: usize) -> (Rect, Rect, Rect) {
     let value = Rect {
         x: prev.x + LAUNCH_ARROW_W,
         y,
-        w: LAUNCH_VALUE_W,
+        w: value_w,
         h: LAUNCH_CONTROL_H,
     };
     let next = Rect {
-        x: value.x + LAUNCH_VALUE_W,
+        x: value.x + value_w,
         y,
         w: LAUNCH_ARROW_W,
         h: LAUNCH_CONTROL_H,
@@ -4760,7 +4774,7 @@ const LAUNCH_NAV_BLOCK_H: usize = LAUNCH_TAB_H + 14;
 /// The Status column's clickable area (the "Bootable" label plus its tick box),
 /// sitting to the right of the priority stepper on a Boot Priority row.
 fn launcher_bootable_rect(rect: Rect, row_y: usize) -> Rect {
-    let (_, _, next) = launcher_cycle_rects(rect, row_y);
+    let (_, _, next) = launcher_bootpri_rects(rect, row_y);
     Rect {
         x: next.x + next.w + 24,
         y: row_y + 2,
@@ -5087,7 +5101,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                     if state.setup.drive_boot_off(r.field) {
                         continue;
                     }
-                    let (prev, value, next) = launcher_cycle_rects(rect, row_y);
+                    let (prev, value, next) = launcher_bootpri_rects(rect, row_y);
                     if prev.contains(pos) {
                         return Some(UiControl::LauncherCycle {
                             field: r.field,
@@ -5299,6 +5313,61 @@ fn draw_launcher_chip(
     draw_panel_text(frame, x, y, label, color, 1, scale);
 }
 
+/// How a row's second column presents when the setting does not apply.
+///
+/// Greying is the signal that a row cannot be reached; what stands in its
+/// place is a per-row judgement, so it is made once, here, rather than spread
+/// across the drawing code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GreyedAs {
+    /// Say why, as text where the control would be: the machine-shaped
+    /// constraints worth explaining ("needs 32-bit CPU").
+    Reason,
+    /// Nothing. The greyed label says enough, and one phrase repeated down a
+    /// page of drive bays or bridge settings says less than silence.
+    Blank,
+    /// The control, dimmed, still showing the setting's own value -- which
+    /// still means something, and will be used again once the row applies.
+    DimmedValue,
+    /// The control, dimmed, with the reason in its value box: there is no
+    /// mouse to be sensitive, and no shader to be strong.
+    DimmedReason,
+}
+
+fn greyed_presentation(r: &launcher::Row, setup: &launcher::MachineSetup) -> GreyedAs {
+    use LauncherField as F;
+    // A priority the machine has no drive to apply.
+    if r.kind == RowKind::Bootpri {
+        return GreyedAs::DimmedReason;
+    }
+    match r.field {
+        F::MouseSensitivity | F::MouseCapture | F::ShaderStrength => GreyedAs::DimmedReason,
+        F::FloppySpeed | F::AudioChannelMode | F::AudioFilter | F::AudioStereoSeparation => {
+            GreyedAs::DimmedValue
+        }
+        // Drive select is shaped by the interface, so it only shows a
+        // selection while there is one to shape it: an attached DrawBridge
+        // has no drive-select line, but with no interface at all there is
+        // nothing to say.
+        F::BridgeCable if setup.bridge_interface_selected() => GreyedAs::DimmedValue,
+        F::ScsiUnit0
+        | F::ScsiUnit1
+        | F::ScsiUnit2
+        | F::ScsiUnit3
+        | F::ScsiUnit4
+        | F::ScsiUnit5
+        | F::ScsiUnit6
+        | F::BridgeDevice
+        | F::BridgePort
+        | F::BridgeCable
+        | F::BridgeDensity
+        | F::BridgeSpeed
+        | F::BridgeServeSpeed
+        | F::BridgeAutoCache => GreyedAs::Blank,
+        _ => GreyedAs::Reason,
+    }
+}
+
 fn draw_launcher_row(
     frame: &mut [u8],
     rect: Rect,
@@ -5374,42 +5443,27 @@ fn draw_launcher_row(
         1,
         scale,
     );
-    // Greyed: explain why instead of drawing controls (e.g. "needs 32-bit CPU").
-    // Some rows are the exception. The shaping rows -- channel mode,
-    // separation, mouse sensitivity -- are merely inapplicable (audio
-    // disabled, separation in mono, no mouse in either port), and a bridge
-    // setting the chosen interface does not implement is not a thing to
-    // explain either: the greyed label alone says enough, so column 2 is left
-    // blank rather than repeating "not on this interface" down the page.
-    let blank_when_greyed = matches!(
-        r.field,
-        LauncherField::AudioChannelMode
-            | LauncherField::AudioStereoSeparation
-            | LauncherField::MouseSensitivity
-            | LauncherField::MouseCapture
-            | LauncherField::ShaderStrength
-            | LauncherField::BridgeDevice
-            | LauncherField::BridgePort
-            | LauncherField::BridgeCable
-            | LauncherField::BridgeDensity
-            | LauncherField::BridgeSpeed
-            | LauncherField::BridgeServeSpeed
-            | LauncherField::BridgeAutoCache
-            | LauncherField::FloppySpeed
-    );
+    let greyed_as = reason.map(|_| greyed_presentation(r, setup));
+    let greyed_shows_reason = greyed_as == Some(GreyedAs::DimmedReason);
+    let disabled = reason.is_some();
     if let Some(reason) = reason {
-        if !blank_when_greyed {
-            draw_panel_text(
-                frame,
-                launcher_control_x(rect),
-                row_y + 8,
-                reason,
-                PANEL_TEXT_DIM,
-                1,
-                scale,
-            );
+        if !matches!(
+            greyed_as,
+            Some(GreyedAs::DimmedValue | GreyedAs::DimmedReason)
+        ) {
+            if greyed_as != Some(GreyedAs::Blank) {
+                draw_panel_text(
+                    frame,
+                    launcher_control_x(rect),
+                    row_y + 8,
+                    reason,
+                    PANEL_TEXT_DIM,
+                    1,
+                    scale,
+                );
+            }
+            return;
         }
-        return;
     }
     match r.kind {
         // Drawn above with an early return.
@@ -5420,7 +5474,7 @@ fn draw_launcher_row(
                 frame,
                 prev,
                 "<",
-                true,
+                !disabled,
                 hover
                     == Some(UiControl::LauncherCycle {
                         field: r.field,
@@ -5432,7 +5486,7 @@ fn draw_launcher_row(
                 frame,
                 next,
                 ">",
-                true,
+                !disabled,
                 hover
                     == Some(UiControl::LauncherCycle {
                         field: r.field,
@@ -5442,17 +5496,28 @@ fn draw_launcher_row(
             );
             // Clip a long value (e.g. a wordy MIDI device name) to the box so
             // it cannot spill over the ">" stepper.
-            let text = truncate_to_width(&setup.value_label(r.field), value.w);
+            let shown = match reason {
+                Some(reason) if greyed_shows_reason => reason.to_string(),
+                _ => setup.value_label(r.field),
+            };
+            let text = truncate_to_width(&shown, value.w);
             let tw = text.chars().count() * font::GLYPH_W;
             let tx = value.x + value.w.saturating_sub(tw) / 2;
-            draw_panel_text(frame, tx, value.y + 6, &text, PANEL_TEXT_HILIGHT, 1, scale);
+            let color = if disabled {
+                PANEL_TEXT_DIM
+            } else {
+                PANEL_TEXT_HILIGHT
+            };
+            draw_panel_text(frame, tx, value.y + 6, &text, color, 1, scale);
         }
         RowKind::Bootpri => {
             // Priority column: a `< value >` stepper whose value is also a text
             // field. Greyed and inert while the Bootable box (drawn last) is
-            // cleared -- the number stays visible so re-ticking restores it.
-            let disabled = setup.drive_boot_off(r.field);
-            let (prev, value, next) = launcher_cycle_rects(rect, row_y);
+            // cleared, where it shows the -128 the config will store, and
+            // greyed as a whole on a row with no drive to boot, where the box
+            // says so in place of a priority.
+            let disabled = disabled || setup.drive_boot_off(r.field);
+            let (prev, value, next) = launcher_bootpri_rects(rect, row_y);
             draw_text_button(
                 frame,
                 prev,
@@ -5485,7 +5550,9 @@ fn draw_launcher_row(
                 scale,
             );
             let editing = state.editing() == Some(EditTarget::DriveBootpri(r.field));
-            let text = if editing {
+            let text = if let Some(reason) = reason.filter(|_| greyed_shows_reason) {
+                reason.to_string()
+            } else if editing {
                 format!("{}_", state.edit_buffer())
             } else {
                 setup.value_label(r.field)
@@ -5509,7 +5576,11 @@ fn draw_launcher_row(
                 cell.x,
                 cell.y + 6,
                 BOOTABLE_LABEL,
-                PANEL_TEXT,
+                if reason.is_some() {
+                    PANEL_TEXT_DIM
+                } else {
+                    PANEL_TEXT
+                },
                 1,
                 scale,
             );


### PR DESCRIPTION
Visual pass over the machine-configuration screen. Visual refinement only, no behaviour changes.

**Greyed rows keep their controls.** A row that does not apply used to lose its whole second column; now the stepper and value stay, dimmed, so it still reads as the setting it is. Where the value still means something it stays (channel mode, stereo separation, audio filter, drive speed); where it does not, the reason takes its place — `No mouse`, `Disabled`, `No drive`. Rows where one phrase would just repeat down the page stay blank: the empty SCSI units, and bridge settings an interface does not implement.

**Wording.** A2065 reads `None` when unfitted, matching serial and parallel. Phosphor and CRT shader read `Disabled` rather than `Off`. Drive select names each option as the drive's own jumpers do — `Drive A (IBM)`, `DS0 (Shugart)` — and keeps its steppers when the interface has no drive-select line.

**Layout.** The boot-priority value box is narrower than the general one, which is sized for device names; the Status column follows it. Video leads with its toggles, then the geometry rows, then the picture treatment; Emulation runs power on, realtime priority, pacing, warp.
