### PR TITLE
rtg: emulate Picasso II and Picasso II+

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ against real hardware.
   DrawBridge / Greaseweazle / Supercard Pro via the bundled FloppyBridge,
   `docs/guide/floppybridge.md`), Gayle and A4000 IDE, SCSI (A2091,
   A4091, or the A3000's onboard Super DMAC), CDTV/CD32 CD, A2065 Ethernet,
-  a Z3660 RTG card (high-colour Picasso96 screens), the serial port bridged
-  to host stdout/TCP/PTY/MIDI, a parallel-port printer capture and audio
-  sampler, host directories served live as AmigaDOS volumes, and Zorro
+  Z3660 and Picasso II/II+ RTG cards (high-colour Picasso96 screens), the serial
+  port bridged to host stdout/TCP/PTY/MIDI, a parallel-port printer capture and
+  audio sampler, host directories served live as AmigaDOS volumes, and Zorro
   boards loadable as WASM plugins.
 - **Tooling**: an in-window debugger that can step backwards, an
   interactive chip-bus frame analyzer, a trigger-based VCD waveform export

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -267,10 +267,12 @@ slow = "512K"
 
 
 # RTG graphics card: high-resolution, high-colour screens via Picasso96.
-# Fitted by default on any machine whose CPU has a 32-bit address bus
-# (stock A3000/A4000, or any profile given a 68020+ full-bus CPU).
+# Z3660 is fitted by default on any machine whose CPU has a 32-bit address bus
+# (stock A3000/A4000, or any profile given a 68020+ full-bus CPU). Picasso II
+# and Picasso II+ are opt-in Zorro II cards and work with 24-bit CPUs too.
 # [rtg]
-# card = "z3660"           # or "none"
+# card = "picasso2plus"    # "z3660", "picasso2", "picasso2plus", or "none"
+# vram = "2M"              # Picasso II/II+ only: "1M" or "2M" (default)
 
 
 # SCSI bus with up to seven drives, on any machine model. Preferred over [ide]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1397,21 +1397,32 @@ NAT's limitations.
 
 ```toml
 [rtg]
-card = "z3660"
+card = "picasso2"
+vram = "2M"
 ```
 
-`card` is `"z3660"` or `"none"`; a machine takes at most one. The Z3660 is a
-Zorro III board, so it comes fitted by default on machines whose CPU has a
-32-bit address bus (the A3000 and A4000) and is unavailable on the rest --
-asking for it there is an error, as it is for Zorro III RAM. It gives the
-guest high-resolution,
-high-colour screens through Picasso96. It needs the
-open-source Z3660.card driver installed in the guest (with its monitor in
-`DEVS:Monitors`); with that in place, Z3660 screen modes appear in
-ScreenMode, and the window shows the board's output when a screen is
-opened, switching back to the native Amiga display when it closes.
+`card` is `"picasso2"`, `"picasso2plus"`, `"z3660"`, or `"none"`; a machine
+takes at most one. All three boards give the guest high-resolution,
+high-colour screens through Picasso96.
 
-The board's stock monitor ships with the `DISPLAYCHAIN=NO` tooltype, which
+`"picasso2"` fits a Village Tronic Picasso II with a CL-GD5426 graphics
+controller. `"picasso2plus"` fits the later CL-GD5428 revision, reports its
+distinct autoconfig serial number, and wires vertical blank to INT2. Both are
+Zorro II boards, so they work with 68000/68010 and 24-bit 68EC020 machines as
+well as 32-bit CPUs. `vram` selects either real board's `"1M"` or `"2M"`
+memory configuration and defaults to `"2M"`; it is ignored for other cards.
+Install the Picasso96 `PicassoII.card` driver and its monitor file in the
+guest. The board starts on native Amiga pass-through and switches the
+Copperline display to RTG only while the guest enables a valid Picasso screen.
+
+`"z3660"` is a Zorro III board. It comes fitted by default on machines whose
+CPU has a 32-bit address bus (the A3000 and A4000) and is unavailable on the
+rest; asking for it there is an error, as it is for Zorro III RAM. It needs the
+open-source Z3660.card driver installed in the guest (with its monitor in
+`DEVS:Monitors`). With that in place, Z3660 screen modes appear in ScreenMode,
+and the window shows the board's output when a screen is opened.
+
+The Z3660 board's stock monitor ships with the `DISPLAYCHAIN=NO` tooltype, which
 models the real hardware's separate RTG monitor and never hands the display
 back to the native screen. On a single-window emulator you usually want
 `DISPLAYCHAIN=YES`, so the one window follows whichever screen is active.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ running in Copperline.
   emulator from scripts, CI, and AI agents (`--control`, `copperline-ctl`).
 - [](internals/architecture) -- how the emulator works inside, for
   contributors.
+- [](internals/picasso2) -- the Picasso II/II+ and CL-GD5426/5428 RTG model.
 
 ## Design principles
 

--- a/docs/internals/picasso2.md
+++ b/docs/internals/picasso2.md
@@ -28,7 +28,10 @@ The register model covers the packed-pixel driver path:
 - CL-GD5426/5428 BitBLT video/video and system/video sources, forward and backward
   overlap-safe copy, 8x8 pattern and solid fill, colour expansion, source
   transparency, 8/16/24-bit pixel widths, and all sixteen documented Cirrus
-  raster operations.
+  raster operations. A video-source colour expansion consumes its source as
+  one continuous bit stream -- each row rounds up to the next source byte
+  and the source pitch register is not consulted -- which is what Picasso96
+  relies on for text and its blitter-drawn mouse pointer.
 
 VGA text rendering is intentionally absent. The card powers up behind native
 Amiga pass-through, and Amiga RTG drivers program a packed-pixel mode before
@@ -68,8 +71,8 @@ introduce wall-clock or dynamic environment state.
 The 1 MB configuration advertises and maps a 1 MB memory-space aperture, so
 there is no guest-visible upper-half alias or hole. The II+ model supplies its
 CL-GD5428 part ID, different autoconfig serial, and INT2 vertical blank. The
-physical product-13 segmented configuration, Pablo encoder, VGA text modes,
-and native-resolution headless RTG screenshots remain outside the model.
+physical product-13 segmented configuration, Pablo encoder, and VGA text
+modes remain outside the model.
 
 The implementation was checked against the Cirrus Logic CL-GD542X Technical
 Reference Manual and the independent Cirrus models in 86Box and QEMU. Those

--- a/docs/internals/picasso2.md
+++ b/docs/internals/picasso2.md
@@ -1,0 +1,76 @@
+# Picasso II/II+ and CL-GD5426/5428 model
+
+Copperline's Picasso II family is a hardware model of the Village Tronic Zorro
+II boards, not a Picasso96-aware display API. The guest enumerates the real
+manufacturer/product/serial identities, programs VGA and Cirrus registers,
+writes the linear VRAM aperture, starts BitBLT operations, and controls the
+physical monitor pass-through switch. See [](../zorro) for the two-window
+autoconfig layout and [](video) for presentation.
+
+## Implemented controller surface
+
+`CirrusGd5426` owns all serializable CL-GD5426/5428 chip state: controller
+revision, 1 or 2 MB of VRAM, VGA and extended register files, DAC palettes,
+hidden-DAC access phase, scan position, vertical-interrupt latch, hardware
+cursor, and BitBLT state. The board wrapper adds the two Zorro window decoders,
+revision-specific INT2 wiring, and monitor relay state.
+
+The register model covers the packed-pixel driver path:
+
+- standard sequencer, graphics-controller, CRTC, attribute, miscellaneous
+  output and DAC ports, including mono CRTC/status aliases;
+- SR6 extension locking, extended VCLK registers, extended pitch/start bits,
+  the four-read hidden-DAC protocol, and the Cirrus cursor registers;
+- direct linear writes plus VGA write modes 0-3;
+- 8-bit CLUT, 15-bit RGB 5:5:5, 16-bit RGB 5:6:5, and 24-bit BGR scanout,
+  including pitch, panning start, doublescan, progressive presentation of
+  interlaced modes, palette mask, and cursor composition;
+- CL-GD5426/5428 BitBLT video/video and system/video sources, forward and backward
+  overlap-safe copy, 8x8 pattern and solid fill, colour expansion, source
+  transparency, 8/16/24-bit pixel widths, and all sixteen documented Cirrus
+  raster operations.
+
+VGA text rendering is intentionally absent. The card powers up behind native
+Amiga pass-through, and Amiga RTG drivers program a packed-pixel mode before
+selecting the VGA output.
+
+## Timing and determinism
+
+The selected VCLK numerator, denominator, and post-divider produce the pixel
+clock from the Cirrus controller's 14.318184 MHz reference. CRTC totals derive a frame
+period in Amiga colour clocks. `$3DA` vertical-retrace and display-enable status
+therefore advance only through device `tick` calls; no host or wall clock enters
+the model.
+
+On the II+, crossing the programmed vertical-retrace start latches an interrupt
+when VGA CRTC `$11` enables it. Register-window offset `$1001` gates the latch
+onto the Zorro INT2 line; `$1000` removes it. Writing CRTC `$11` with bit 4 clear
+acknowledges the latch. The original Picasso II follows the same deterministic
+scan clock but has no physical interrupt connection and always reports INT2
+inactive.
+
+BitBLT work is applied deterministically when started (or when the last byte of
+a system-source transfer arrives). GR31 remains busy for 16 colour clocks after
+completion. This short fixed observation window lets polling software see the
+busy transition without making output depend on host execution speed.
+
+Direct CPU access keeps Copperline's existing functional-board timing of two
+colour clocks per word. A board-specific Zorro II bus timing refinement would
+affect broader emulator timing and is deliberately separate work.
+
+## Diagnostics and known gaps
+
+Set `COPPERLINE_DIAG_PICASSO=1` before startup to log VGA port writes, decoded
+mode changes, blit descriptors, hidden-DAC changes, and monitor-switch changes.
+The value is read through Copperline's startup configuration cache and does not
+introduce wall-clock or dynamic environment state.
+
+The 1 MB configuration advertises and maps a 1 MB memory-space aperture, so
+there is no guest-visible upper-half alias or hole. The II+ model supplies its
+CL-GD5428 part ID, different autoconfig serial, and INT2 vertical blank. The
+physical product-13 segmented configuration, Pablo encoder, VGA text modes,
+and native-resolution headless RTG screenshots remain outside the model.
+
+The implementation was checked against the Cirrus Logic CL-GD542X Technical
+Reference Manual and the independent Cirrus models in 86Box and QEMU. Those
+remain the reference when a guest register trace exposes a missing detail.

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -529,13 +529,16 @@ resets on presentation discontinuities (machine swap, reset, state load).
 Frame dumps and screenshots share the resolved decision, so a dump's PNG
 dimensions no longer flip between 716x537 and 692x540 across a boot.
 
-### RTG scanout (Z3660)
+### RTG scanout (Z3660 and Picasso II/II+)
 
 When a fitted `[rtg]` board's guest driver switches the display to RTG,
 the presentation path swaps sources: the board's panned framebuffer
-(decoded from VRAM in the scanout's pixel format, with the board's
-hardware mouse sprite -- including wide and doubled sprites -- composited
-over it in `z3660.rs`) replaces the chipset render. The window presents
+(decoded from VRAM in the scanout's pixel format, with its hardware cursor
+composited over it) replaces the chipset render. Z3660 implements its FPGA
+scanout and sprite in `z3660.rs`; Picasso II/II+ implement the CL-GD5426/5428
+scanout, two-plane cursor, and physical pass-through switch in
+`picasso2/gd5426.rs`.
+The window presents
 that frame at its native resolution through a dedicated GPU texture
 rather than the 716-wide chipset buffer, and the TV aperture crop is
 suppressed -- it is a chipset crop rect, and applying it would show a
@@ -553,6 +556,12 @@ per board row at the board's native height, downsampled horizontally by
 sampling each output pixel's source-span centre so the rightmost source
 columns survive. Screenshots under RTG are therefore 716 wide at the
 board's native row count.
+
+Picasso II and II+ remain on native pass-through after reset. Even after the guest
+writes its VGA-output switch, `rtg_active` requires a running, unblanked
+sequencer and a plausible CRTC mode whose visible rows fit in VRAM. During
+driver mode changes this makes presentation fall back to the native chipset
+frame instead of exposing stale or out-of-bounds VRAM.
 
 `ui.rs` implements the status bar widgets, the pop-up menu, the smaller
 overlay panels (About, Shortcuts, Calibration), and the shared debugger/tool

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -260,7 +260,13 @@ while traffic flows -- the emulator logs this when the board is attached. Save
 states record only the chosen backend and bring up a fresh one on load
 (in-flight frames are dropped; the guest's TCP retransmits).
 
-## Graphics: the Z3660 RTG board
+## Graphics: RTG boards
+
+Copperline fits at most one RTG board through `[rtg]`. Both are functional
+device-backed boards whose guest drivers program real hardware interfaces;
+there is no software-aware virtual framebuffer.
+
+### Z3660
 
 `[rtg] card = "z3660"` fits an in-tree RTG (retargetable graphics) board
 (`src/z3660.rs`) modelled on the Z3660 accelerator's FPGA graphics core,
@@ -280,6 +286,50 @@ stays honest without carrying all 128 MB.
 Like the A2065 it is a device-backed board, not a `[[zorro]]` metadata
 board; the scanout and blitter model live in `z3660.rs` and the
 presentation path is described in [](internals/video).
+
+### Village Tronic Picasso II and II+
+
+`[rtg] card = "picasso2"` fits the 1993 Zorro II card with its CL-GD5426;
+`card = "picasso2plus"` selects the CL-GD5428-based Picasso II+. Both take 1
+or 2 MB of VRAM (`[rtg] vram`). One physical board enumerates as two consecutive
+autoconfig identities under Village Tronic manufacturer 2167 (`$0877`). The
+original reports serial `$00020000`; the II+ reports `$00100000` on both
+identities:
+
+| product | size | autoconfig space | purpose |
+| --- | ---: | --- | --- |
+| 11 | 1 or 2 MB | Zorro II memory | linear VRAM aperture |
+| 12 | 64 KB | Zorro II I/O | VGA registers and monitor switch |
+
+Product 11 has `ERTF_CHAINEDCONFIG` set and is not added to the system free
+memory list; product 12 follows it. Both windows route to one `Picasso2`
+device. Copperline tags the VRAM mapping internally so the shared device can
+distinguish it without changing the common Zorro device interface. Product 13,
+the physical board's jumper-selected segmented mode, is intentionally not
+implemented because Picasso96 does not support it.
+
+The product-12 register window decodes as follows:
+
+| offset | function |
+| --- | --- |
+| `$0000-$0FFF` | VGA I/O ports at the same numeric port address |
+| `$1000-$1FFF` | the same ports with address + 1, for odd ISA byte lanes |
+| `$2000-$7FFF` | unused, reads as open bus and drops writes |
+| `$8xxx`, `$Axxx` | even-address write selects the RTG output |
+| `$9xxx`, `$Bxxx` | even-address write selects native Amiga pass-through |
+
+A 68k word write to `$3C4` therefore supplies the sequencer index in its high
+byte and the `$3C5` data in its low byte. The linear memory aperture preserves
+byte order exactly. Both Cirrus revisions interpret 15/16-bit pixels as
+little-endian words and 24-bit pixels as B, G, R bytes, matching the `*PC` and
+BGR formats advertised by the Picasso96 driver. CRTC part ID `$27` reads `$90`
+on the CL-GD5426 and `$98` on the CL-GD5428.
+
+Only the II+ drives an interrupt line. A write to register-window offset
+`$1001` enables its INT2 output and `$1000` disables it. An enabled VGA
+vertical interrupt latches at the CRTC-programmed retrace edge in emulated
+time; writing CRTC `$11` with bit 4 clear acknowledges it. The original card
+stores the board-enable bit for register compatibility but never asserts INT2.
 
 ## How autoconfig works in Copperline
 
@@ -329,8 +379,9 @@ ways:
   `ZorroChain::device_region_at` and accesses route to the device model on
   the bus (the A2091's registers, boot ROM, and DMA strobes) rather than
   into board RAM;
-- they do not claim the autoconfig memory-space flag (`er_Flags`
-  `ERFF_MEMSPACE` stays clear, as on real I/O boards);
+- ordinary I/O boards do not claim the autoconfig memory-space flag
+  (`ERFF_MEMSPACE`), while a device-backed framebuffer such as Picasso II
+  product 11 can request memory-space placement explicitly;
 - a board may carry a `diag_vec`, which sets `ERTF_DIAGVALID` in
   `er_Type` and emits `er_InitDiagVec` so Kickstart autoboots from the
   DiagArea inside the board window. The A2091 points it at `$2000`, where

--- a/picasso2.example.toml
+++ b/picasso2.example.toml
@@ -1,20 +1,21 @@
-# Picasso II/II+ / Picasso96 Workbench example. Place a licensed Kickstart 3.1 ROM
-# and a bootable RDB HDF with Picasso96's PicassoII.card driver beside this
-# file, or adjust the paths. Headless capture is then deterministic, for example:
+# Picasso II/II+ / Picasso96 Workbench example. Place a licensed A4000
+# Kickstart 3.1 ROM and a bootable HDF with Picasso96's PicassoII.card driver
+# beside this file, or adjust the paths. (The generic A500/A2000 Kickstart 3.1
+# has no big-box SCSI/IDE driver, so a Zorro-slot machine needs its own ROM.)
+# Headless capture is then deterministic, for example:
 #
 #   copperline --config picasso2.example.toml --noaudio \
 #     --screenshot-after 60 /tmp/picasso2.png
 
-rom = "KICK31.ROM"
+rom = "Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom"
 
 [machine]
-profile = "A3000"
+profile = "A4000"
 
 [rtg]
 card = "picasso2"
 # Use "picasso2plus" for the CL-GD5428 revision with INT2 vertical blank.
 vram = "2M"
 
-[scsi]
-controller = "a3000"
-unit0 = "p96-picasso2.hdf"
+[ide]
+master = "p96-picasso2.hdf"

--- a/picasso2.example.toml
+++ b/picasso2.example.toml
@@ -1,0 +1,20 @@
+# Picasso II/II+ / Picasso96 Workbench example. Place a licensed Kickstart 3.1 ROM
+# and a bootable RDB HDF with Picasso96's PicassoII.card driver beside this
+# file, or adjust the paths. Headless capture is then deterministic, for example:
+#
+#   copperline --config picasso2.example.toml --noaudio \
+#     --screenshot-after 60 /tmp/picasso2.png
+
+rom = "KICK31.ROM"
+
+[machine]
+profile = "A3000"
+
+[rtg]
+card = "picasso2"
+# Use "picasso2plus" for the CL-GD5428 revision with INT2 vertical blank.
+vram = "2M"
+
+[scsi]
+controller = "a3000"
+unit0 = "p96-picasso2.hdf"

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3878,16 +3878,18 @@ impl Bus {
     pub fn rtg_active(&self) -> bool {
         self.devices.iter().any(|d| match d {
             crate::zorro_device::BoardDevice::Z3660(z) => z.rtg_active(),
+            crate::zorro_device::BoardDevice::Picasso2(p) => p.rtg_active(),
             _ => false,
         })
     }
 
-    /// Compose the active RTG board frame (Z3660 scanout) into `out` as
+    /// Compose the active RTG board frame into `out` as
     /// presentation pixels, returning its dimensions; `None` while no RTG
     /// board is driving the display (native chipset output shown).
     pub fn rtg_frame(&self, out: &mut Vec<u32>) -> Option<(u32, u32)> {
         self.devices.iter().find_map(|d| match d {
             crate::zorro_device::BoardDevice::Z3660(z) => z.rtg_frame(out),
+            crate::zorro_device::BoardDevice::Picasso2(p) => p.rtg_frame(out),
             _ => None,
         })
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,6 +197,8 @@ pub struct Config {
     /// the Zorro chain and presents RTG screens (all pixel formats, core
     /// blitter ops, hardware mouse sprite) to its Picasso96 driver.
     pub rtg: RtgCard,
+    /// Picasso II/II+ display memory. Ignored by other RTG cards.
+    pub rtg_vram_bytes: usize,
     pub floppy: FloppyConfig,
     /// Which floppy drive slots are electrically present. DF0 is the
     /// internal drive and is always present; DF1-DF3 are external drives
@@ -663,6 +665,11 @@ pub enum RtgCard {
     /// The Z3660 accelerator's FPGA RTG core, driven by the open-source
     /// Z3660.card Picasso96 driver.
     Z3660,
+    /// Village Tronic Picasso II: Zorro II, CL-GD5426, 1 or 2 MB VRAM.
+    Picasso2,
+    /// Village Tronic Picasso II+: Zorro II, CL-GD5428, 1 or 2 MB VRAM,
+    /// with vertical blank wired to INT2.
+    Picasso2Plus,
 }
 
 /// Which SCSI host adapter the `[scsi]` section fits: one of the two Zorro
@@ -1630,6 +1637,7 @@ impl Default for Config {
             scsi: ScsiConfig::default(),
             a2065_net: None,
             rtg: RtgCard::None,
+            rtg_vram_bytes: 2 * 1024 * 1024,
             floppy: FloppyConfig::default(),
             floppy_connected: [true, false, false, false],
             floppy_playlists: std::array::from_fn(|_| Vec::new()),
@@ -2527,10 +2535,12 @@ pub(crate) struct RawA2065 {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawRtg {
-    /// Card to fit: "z3660" (the Z3660's FPGA RTG core, driven by
-    /// Z3660.card) or "none" (the default).
+    /// Card to fit: "z3660", "picasso2", "picasso2plus", or "none".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) card: Option<String>,
+    /// Picasso II/II+ display memory: "1M" or "2M" (default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) vram: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -3245,14 +3255,20 @@ impl TryFrom<RawConfig> for Config {
             Some(raw_card) => match raw_card.trim().to_ascii_lowercase().as_str() {
                 "none" => RtgCard::None,
                 "z3660" => RtgCard::Z3660,
+                "picasso2" => RtgCard::Picasso2,
+                "picasso2plus" | "picasso2+" => RtgCard::Picasso2Plus,
                 _ => {
                     errors.push(anyhow!(
                         "[rtg] card = {raw_card:?} is not known \
-                         (expected \"z3660\" or \"none\")"
+                         (expected \"z3660\", \"picasso2\", \"picasso2plus\", or \"none\")"
                     ));
                     RtgCard::None
                 }
             },
+        };
+        let rtg_vram_bytes = match raw.rtg.vram.as_deref() {
+            None => defaults.rtg_vram_bytes,
+            Some(value) => parse_size(value, "RTG VRAM")?,
         };
 
         let scsi = ScsiConfig {
@@ -3376,7 +3392,7 @@ impl TryFrom<RawConfig> for Config {
         errors.extend(validate_mb_ram(mb_ram_bytes, mem_controller, cpu).err());
         errors.extend(validate_accel_ram(accel_ram_bytes, cpu).err());
         errors.extend(validate_z3_ram(z3_ram_bytes, cpu).err());
-        errors.extend(validate_rtg_card(rtg, cpu).err());
+        errors.extend(validate_rtg_card(rtg, rtg_vram_bytes, cpu).err());
         let board_specs = zorro_boards
             .iter()
             .chain(wasm_boards.iter().map(|w| &w.spec));
@@ -3564,6 +3580,7 @@ impl TryFrom<RawConfig> for Config {
             scsi,
             a2065_net,
             rtg,
+            rtg_vram_bytes,
             floppy,
             floppy_connected,
             floppy_playlists,
@@ -4281,13 +4298,21 @@ fn cpu_has_32bit_bus(cpu: CpuModel) -> bool {
     )
 }
 
-fn validate_rtg_card(rtg: RtgCard, cpu: CpuModel) -> Result<()> {
+fn validate_rtg_card(rtg: RtgCard, vram_bytes: usize, cpu: CpuModel) -> Result<()> {
     if rtg == RtgCard::Z3660 && !cpu_has_32bit_bus(cpu) {
         bail!(
             "[rtg] card = \"z3660\" is a Zorro III board and needs a CPU \
              with a 32-bit address bus (68020/68030/68040/68060); {:?} has \
              a 24-bit bus",
             cpu
+        );
+    }
+    if matches!(rtg, RtgCard::Picasso2 | RtgCard::Picasso2Plus)
+        && !matches!(vram_bytes, 0x10_0000 | 0x20_0000)
+    {
+        bail!(
+            "[rtg] vram for Picasso II cards must be \"1M\" or \"2M\", got {} bytes",
+            vram_bytes
         );
     }
     Ok(())
@@ -5753,6 +5778,10 @@ mod tests {
             assert_eq!(piped.rtc_present, direct.rtc_present, "{model:?} rtc");
             assert_eq!(piped.rtc_chip, direct.rtc_chip, "{model:?} rtc chip");
             assert_eq!(piped.rtg, direct.rtg, "{model:?} rtg");
+            assert_eq!(
+                piped.rtg_vram_bytes, direct.rtg_vram_bytes,
+                "{model:?} RTG VRAM"
+            );
         }
         Ok(())
     }
@@ -7529,7 +7558,34 @@ mod tests {
         // A bare config is a 68000 machine, which cannot host a Zorro III
         // board, so nothing is fitted.
         assert_eq!(parse_config("")?.rtg, RtgCard::None);
+
+        // Picasso II is a Zorro II card and remains valid on the default
+        // 68000 machine. Its fitted memory is part of the resolved config.
+        let picasso = parse_config("[rtg]\ncard = \" Picasso2 \"\nvram = \"1M\"\n")?;
+        assert_eq!(picasso.rtg, RtgCard::Picasso2);
+        assert_eq!(picasso.rtg_vram_bytes, 1024 * 1024);
+        let picasso = parse_config("[rtg]\ncard = \"picasso2\"\n")?;
+        assert_eq!(picasso.rtg_vram_bytes, 2 * 1024 * 1024);
+        let plus = parse_config("[rtg]\ncard = \" Picasso2Plus \"\nvram = \"1M\"\n")?;
+        assert_eq!(plus.rtg, RtgCard::Picasso2Plus);
+        assert_eq!(plus.rtg_vram_bytes, 1024 * 1024);
+        let plus_alias = parse_config("[rtg]\ncard = \"picasso2+\"\n")?;
+        assert_eq!(plus_alias.rtg, RtgCard::Picasso2Plus);
         Ok(())
+    }
+
+    #[test]
+    fn picasso2_rejects_non_hardware_vram_sizes() {
+        let err = parse_config("[rtg]\ncard = \"picasso2\"\nvram = \"3M\"\n").unwrap_err();
+        assert!(
+            err.to_string().contains("must be \"1M\" or \"2M\""),
+            "{err:#}"
+        );
+        let err = parse_config("[rtg]\ncard = \"picasso2plus\"\nvram = \"3M\"\n").unwrap_err();
+        assert!(
+            err.to_string().contains("must be \"1M\" or \"2M\""),
+            "{err:#}"
+        );
     }
 
     /// A machine that can host a Zorro III board gets one fitted by default,

--- a/src/config.rs
+++ b/src/config.rs
@@ -3266,9 +3266,16 @@ impl TryFrom<RawConfig> for Config {
                 }
             },
         };
-        let rtg_vram_bytes = match raw.rtg.vram.as_deref() {
-            None => defaults.rtg_vram_bytes,
-            Some(value) => parse_size(value, "RTG VRAM")?,
+        // Only the Picasso II cards have configurable display memory; other
+        // cards ignore [rtg] vram entirely, so a leftover value must not
+        // fail an unrelated configuration.
+        let rtg_vram_bytes = if matches!(rtg, RtgCard::Picasso2 | RtgCard::Picasso2Plus) {
+            match raw.rtg.vram.as_deref() {
+                None => defaults.rtg_vram_bytes,
+                Some(value) => parse_size(value, "RTG VRAM")?,
+            }
+        } else {
+            defaults.rtg_vram_bytes
         };
 
         let scsi = ScsiConfig {
@@ -7586,6 +7593,18 @@ mod tests {
             err.to_string().contains("must be \"1M\" or \"2M\""),
             "{err:#}"
         );
+    }
+
+    #[test]
+    fn rtg_vram_is_ignored_by_non_picasso_cards() {
+        let cfg = parse_config("[rtg]\ncard = \"none\"\nvram = \"oops\"\n").unwrap();
+        assert_eq!(cfg.rtg, RtgCard::None);
+        assert_eq!(cfg.rtg_vram_bytes, 2 * 1024 * 1024);
+        let cfg =
+            parse_config("[cpu]\nmodel = \"68030\"\n\n[rtg]\ncard = \"z3660\"\nvram = \"3M\"\n")
+                .unwrap();
+        assert_eq!(cfg.rtg, RtgCard::Z3660);
+        assert_eq!(cfg.rtg_vram_bytes, 2 * 1024 * 1024);
     }
 
     /// A machine that can host a Zorro III board gets one fitted by default,

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2229,6 +2229,41 @@ pub fn build_machine(
             crate::z3660::Z3660::new(),
         ));
     }
+    // Village Tronic Picasso II/II+: one physical CL-GD542x device appears as
+    // two consecutive Zorro II identities, linear VRAM first and the 64K VGA
+    // register window second. Both resolve to the same device slot.
+    if matches!(
+        cfg.rtg,
+        crate::config::RtgCard::Picasso2 | crate::config::RtgCard::Picasso2Plus
+    ) {
+        let plus = cfg.rtg == crate::config::RtgCard::Picasso2Plus;
+        let slot = devices.len();
+        let vram_spec = if plus {
+            crate::zorro::BoardSpec::picasso2plus_vram(slot, cfg.rtg_vram_bytes)
+        } else {
+            crate::zorro::BoardSpec::picasso2_vram(slot, cfg.rtg_vram_bytes)
+        };
+        let regs_spec = if plus {
+            crate::zorro::BoardSpec::picasso2plus_regs(slot)
+        } else {
+            crate::zorro::BoardSpec::picasso2_regs(slot)
+        };
+        zorro.add_board(vram_spec)?;
+        zorro.add_board(regs_spec)?;
+        info!(
+            "{}: {} RTG board with {} MB VRAM on the Zorro chain (slot {slot})",
+            if plus { "picasso2plus" } else { "picasso2" },
+            if plus { "CL-GD5428" } else { "CL-GD5426" },
+            cfg.rtg_vram_bytes / (1024 * 1024)
+        );
+        devices.push(crate::zorro_device::BoardDevice::Picasso2(Box::new(
+            if plus {
+                crate::picasso2::Picasso2::new_plus(cfg.rtg_vram_bytes)
+            } else {
+                crate::picasso2::Picasso2::new(cfg.rtg_vram_bytes)
+            },
+        )));
+    }
     // The A1000 has no Kickstart ROM: cfg.rom_path is its 64 KiB bootstrap
     // ROM, and a 256 KiB WCS is allocated for it to load Kickstart into from
     // the Kickstart disk in DF0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub mod midi;
 pub mod net;
 pub mod parallel;
 pub mod paths;
+pub mod picasso2;
 pub mod pointer;
 pub mod priority;
 pub mod ramsey;

--- a/src/picasso2.rs
+++ b/src/picasso2.rs
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Village Tronic Picasso II and Picasso II+ RTG boards.
+//!
+//! The physical card exposes two consecutive Zorro II autoconfig identities:
+//! a linear VRAM aperture (product 11) and a 64 KB VGA-register aperture
+//! (product 12). Both map to this one device; the original and II+ revisions
+//! share those products but advertise different serials. `BoardSpec::window`
+//! tags the VRAM offset in its high nibble so the ordinary `ZorroDevice`
+//! interface can distinguish the apertures.
+
+mod gd5426;
+
+use crate::zorro::DEVICE_WINDOW_SHIFT;
+use crate::zorro_device::{DeviceHost, ZorroDevice};
+pub use gd5426::{CirrusGd5426, DecodedMode, PixelDepth};
+
+const WINDOW_MASK: u32 = (1 << DEVICE_WINDOW_SHIFT) - 1;
+const WINDOW_REGS: u32 = 0;
+const WINDOW_VRAM: u32 = 1;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Picasso2 {
+    chip: CirrusGd5426,
+    plus: bool,
+    show_rtg: bool,
+    interrupt_enabled: bool,
+}
+
+impl Picasso2 {
+    pub fn new(vram_bytes: usize) -> Self {
+        Self {
+            chip: CirrusGd5426::new(vram_bytes),
+            plus: false,
+            show_rtg: false,
+            interrupt_enabled: false,
+        }
+    }
+
+    pub fn new_plus(vram_bytes: usize) -> Self {
+        Self {
+            chip: CirrusGd5426::new_gd5428(vram_bytes),
+            plus: true,
+            show_rtg: false,
+            interrupt_enabled: false,
+        }
+    }
+
+    pub fn rtg_active(&self) -> bool {
+        self.show_rtg && self.chip.video_valid()
+    }
+
+    pub fn rtg_frame(&self, out: &mut Vec<u32>) -> Option<(u32, u32)> {
+        self.show_rtg
+            .then(|| self.chip.compose_frame(out))
+            .flatten()
+    }
+
+    fn read_register_window(&mut self, off: u32, size: usize) -> u32 {
+        let mut value = 0u32;
+        for i in 0..size {
+            value = (value << 8) | u32::from(self.read_register_byte(off + i as u32));
+        }
+        value
+    }
+
+    fn read_register_byte(&mut self, off: u32) -> u8 {
+        if off >= 0x2000 {
+            return 0xff;
+        }
+        let port = if off >= 0x1000 {
+            (off & 0x0fff).saturating_add(1)
+        } else {
+            off
+        };
+        if !(0x3b0..=0x3df).contains(&port) {
+            return 0xff;
+        }
+        self.chip.io_read(port as u16)
+    }
+
+    fn write_register_window(&mut self, off: u32, size: usize, value: u32) {
+        for i in 0..size {
+            let byte = (value >> (8 * (size - 1 - i))) as u8;
+            self.write_register_byte(off + i as u32, byte);
+        }
+    }
+
+    fn write_register_byte(&mut self, off: u32, value: u8) {
+        if off >= 0x8000 {
+            if off & 1 == 0 {
+                match off >> 12 {
+                    0x8 | 0xa => self.set_monitor_switch(true),
+                    0x9 | 0xb => self.set_monitor_switch(false),
+                    _ => {}
+                }
+            }
+            return;
+        }
+        if off == 0x1000 {
+            self.interrupt_enabled = false;
+            return;
+        }
+        if off == 0x1001 {
+            self.interrupt_enabled = true;
+            return;
+        }
+        if off >= 0x2000 {
+            return;
+        }
+        let port = if off >= 0x1000 {
+            (off & 0x0fff).saturating_add(1)
+        } else {
+            off
+        };
+        // POS102 and the 46E8 sleep/wakeup register are board-level no-ops.
+        if (0x3b0..=0x3df).contains(&port) {
+            self.chip.io_write(port as u16, value);
+        }
+    }
+
+    fn set_monitor_switch(&mut self, show_rtg: bool) {
+        if self.show_rtg != show_rtg && crate::envcfg::flag("COPPERLINE_DIAG_PICASSO") {
+            log::info!(
+                "picasso2: monitor switch -> {}",
+                if show_rtg { "VGA" } else { "Amiga" }
+            );
+        }
+        self.show_rtg = show_rtg;
+    }
+}
+
+impl ZorroDevice for Picasso2 {
+    fn read(&mut self, tagged_off: u32, size: usize, _host: &mut DeviceHost) -> u32 {
+        let window = tagged_off >> DEVICE_WINDOW_SHIFT;
+        let off = tagged_off & WINDOW_MASK;
+        match window {
+            WINDOW_REGS => self.read_register_window(off, size),
+            WINDOW_VRAM => self.chip.vram_read(off as usize, size),
+            _ => open_bus(size),
+        }
+    }
+
+    fn write(&mut self, tagged_off: u32, size: usize, value: u32, _host: &mut DeviceHost) {
+        let window = tagged_off >> DEVICE_WINDOW_SHIFT;
+        let off = tagged_off & WINDOW_MASK;
+        match window {
+            WINDOW_REGS => self.write_register_window(off, size, value),
+            WINDOW_VRAM => self.chip.vram_write(off as usize, size, value),
+            _ => {}
+        }
+    }
+
+    fn peek_word(&self, tagged_off: u32) -> Option<u16> {
+        let window = tagged_off >> DEVICE_WINDOW_SHIFT;
+        let off = (tagged_off & WINDOW_MASK) as usize;
+        if window != WINDOW_VRAM || off + 2 > self.chip.vram_len() {
+            return None;
+        }
+        Some(self.chip.vram_read(off, 2) as u16)
+    }
+
+    fn tick(&mut self, cck: u32, _host: &mut DeviceHost) {
+        self.chip.tick(cck);
+    }
+
+    fn int2_line(&self) -> bool {
+        self.plus && self.interrupt_enabled && self.chip.vblank_pending()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.chip.is_idle()
+    }
+
+    fn next_event_cck(&self) -> Option<u32> {
+        self.chip.next_event_cck()
+    }
+
+    fn reset(&mut self) {
+        self.chip.reset();
+        self.show_rtg = false;
+        self.interrupt_enabled = false;
+    }
+
+    fn kind(&self) -> &'static str {
+        if self.plus {
+            "picasso2plus"
+        } else {
+            "picasso2"
+        }
+    }
+}
+
+impl Default for Picasso2 {
+    fn default() -> Self {
+        Self::new(2 * 1024 * 1024)
+    }
+}
+
+fn open_bus(size: usize) -> u32 {
+    match size {
+        1 => 0xff,
+        2 => 0xffff,
+        4 => 0xffff_ffff,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::Memory;
+
+    fn memory() -> Memory {
+        Memory {
+            chip_ram: vec![0; 0x100],
+            slow_ram: Vec::new(),
+            mb_ram: Vec::new(),
+            accel_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    fn regs(off: u32) -> u32 {
+        off
+    }
+
+    fn vram(off: u32) -> u32 {
+        WINDOW_VRAM << DEVICE_WINDOW_SHIFT | off
+    }
+
+    #[test]
+    fn register_word_write_reaches_index_and_data_ports() {
+        let mut board = Picasso2::default();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(regs(0x3c4), 2, 0x0612, &mut host);
+        assert_eq!(board.read(regs(0x3c4), 2, &mut host), 0x0612);
+        board.write(regs(0x3c4), 1, 0x07, &mut host);
+        board.write(regs(0x13c4), 1, 0x01, &mut host);
+        assert_eq!(board.read(regs(0x13c4), 1, &mut host), 0x01);
+    }
+
+    #[test]
+    fn vram_window_is_big_endian_on_the_bus_and_linear_in_storage() {
+        let mut board = Picasso2::default();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(vram(2), 4, 0x1234_5678, &mut host);
+        assert_eq!(board.read(vram(2), 4, &mut host), 0x1234_5678);
+        assert_eq!(board.peek_word(vram(3)), Some(0x3456));
+    }
+
+    #[test]
+    fn monitor_switch_resets_to_native_and_ignores_odd_writes() {
+        let mut board = Picasso2::default();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(regs(0x8001), 1, 0, &mut host);
+        assert!(!board.show_rtg);
+        board.write(regs(0x8000), 1, 0, &mut host);
+        assert!(board.show_rtg);
+        board.write(regs(0x9000), 1, 0, &mut host);
+        assert!(!board.show_rtg);
+        board.write(regs(0xa000), 1, 0, &mut host);
+        assert!(board.show_rtg);
+        board.reset();
+        assert!(!board.show_rtg);
+    }
+
+    #[test]
+    fn monitor_switch_only_presents_a_valid_programmed_mode() {
+        let mut board = Picasso2::default();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(regs(0x8000), 1, 0, &mut host);
+        assert!(!board.rtg_active(), "power-on register state is not video");
+
+        for (port, value) in [
+            (0x3c4, 6),
+            (0x3c5, 0x12),
+            (0x3c4, 0),
+            (0x3c5, 3),
+            (0x3c4, 1),
+            (0x3c5, 0),
+            (0x3c4, 7),
+            (0x3c5, 1),
+            (0x3d4, 1),
+            (0x3d5, 1),
+            (0x3d4, 0x12),
+            (0x3d5, 15),
+            (0x3d4, 0x13),
+            (0x3d5, 2),
+        ] {
+            board.chip.io_write(port, value);
+        }
+        assert!(board.rtg_active());
+        board.chip.io_write(0x3c4, 1);
+        board.chip.io_write(0x3c5, 0x20);
+        assert!(
+            !board.rtg_active(),
+            "sequencer blanking restores native video"
+        );
+    }
+
+    #[test]
+    fn unused_register_and_vram_offsets_are_open_bus() {
+        let mut board = Picasso2::new(1024 * 1024);
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(board.read(regs(0x2000), 1, &mut host), 0xff);
+        assert_eq!(board.read(regs(0x2000), 2, &mut host), 0xffff);
+        assert_eq!(board.read(vram(1024 * 1024), 4, &mut host), 0xffff_ffff);
+    }
+
+    fn program_interrupt_mode(board: &mut Picasso2) {
+        for (port, value) in [
+            (0x3c4, 6),
+            (0x3c5, 0x12),
+            (0x3c4, 0),
+            (0x3c5, 3),
+            (0x3c4, 7),
+            (0x3c5, 1),
+            (0x3d4, 0),
+            (0x3d5, 15),
+            (0x3d4, 1),
+            (0x3d5, 1),
+            (0x3d4, 6),
+            (0x3d5, 20),
+            (0x3d4, 0x10),
+            (0x3d5, 16),
+            // Bit 4 arms vertical interrupts; low bits end retrace at 18.
+            (0x3d4, 0x11),
+            (0x3d5, 0x12),
+            (0x3d4, 0x12),
+            (0x3d5, 15),
+            (0x3d4, 0x13),
+            (0x3d5, 2),
+        ] {
+            board.chip.io_write(port, value);
+        }
+    }
+
+    #[test]
+    fn picasso2plus_latches_int2_at_vblank_and_cr11_acknowledges_it() {
+        let mut plus = Picasso2::new_plus(1024 * 1024);
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        program_interrupt_mode(&mut plus);
+        plus.write(regs(0x1001), 1, 0, &mut host);
+        for _ in 0..200_000 {
+            plus.tick(1, &mut host);
+            if plus.int2_line() {
+                break;
+            }
+        }
+        assert!(plus.int2_line());
+        assert_ne!(plus.chip.io_read(0x3c2) & 0x80, 0);
+
+        let bytes = bincode::serialize(&plus).unwrap();
+        let mut resumed: Picasso2 = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(resumed.kind(), "picasso2plus");
+        assert!(resumed.int2_line());
+        resumed.chip.io_write(0x3d4, 0x27);
+        assert_eq!(resumed.chip.io_read(0x3d5), 0x98);
+
+        for board in [&mut plus, &mut resumed] {
+            board.chip.io_write(0x3d4, 0x11);
+            board.chip.io_write(0x3d5, 0x02);
+            assert!(!board.int2_line());
+            assert_eq!(board.chip.io_read(0x3c2) & 0x80, 0);
+        }
+
+        let mut plain = Picasso2::new(1024 * 1024);
+        program_interrupt_mode(&mut plain);
+        plain.write(regs(0x1001), 1, 0, &mut host);
+        for _ in 0..200_000 {
+            plain.tick(1, &mut host);
+        }
+        assert!(!plain.int2_line());
+    }
+}

--- a/src/picasso2/gd5426.rs
+++ b/src/picasso2/gd5426.rs
@@ -833,46 +833,6 @@ impl CirrusGd5426 {
         src.and_then(|at| self.vram.get(at).copied()).unwrap_or(0)
     }
 
-    fn color_expand_bit(
-        &self,
-        system: Option<&[u8]>,
-        system_pitch: usize,
-        pattern: bool,
-        backwards: bool,
-        src_line: usize,
-        src_start: usize,
-        y: usize,
-        pixel: usize,
-    ) -> u8 {
-        let (byte, bit) = if pattern {
-            (
-                self.vram
-                    .get(src_start.saturating_add(y & 7))
-                    .copied()
-                    .unwrap_or(0),
-                pixel & 7,
-            )
-        } else if let Some(data) = system {
-            (
-                data.get(y * system_pitch + pixel / 8).copied().unwrap_or(0),
-                pixel & 7,
-            )
-        } else {
-            let byte_at = if backwards {
-                src_line.checked_sub(pixel / 8)
-            } else {
-                src_line.checked_add(pixel / 8)
-            };
-            (
-                byte_at
-                    .and_then(|at| self.vram.get(at).copied())
-                    .unwrap_or(0),
-                pixel & 7,
-            )
-        };
-        byte >> (7 - bit) & 1
-    }
-
     fn execute_blit(&mut self, system: Option<&[u8]>) {
         let width = self.blit_width().min(self.vram.len());
         let height = self.blit_height().min(MAX_DIM);
@@ -891,6 +851,13 @@ impl CirrusGd5426 {
             && color_expand
             && mode & BLIT_MODE_TRANSPARENT == 0
             && modeext & BLIT_MODEEXT_SOLID_FILL != 0;
+        // Video-source colour expansion consumes one continuous bit stream:
+        // a row that ends mid-byte rounds up to the next source byte and the
+        // source pitch register is never consulted. Pattern and system-source
+        // expansion address their sources per row instead.
+        let mut expand_addr = src_start;
+        let mut expand_count = 0usize;
+        let expand_span = 8 * pixel_bytes;
 
         for y in 0..height {
             let dst_line = if backwards {
@@ -904,6 +871,34 @@ impl CirrusGd5426 {
                 src_start.saturating_add(y.saturating_mul(src_pitch))
             };
             for x in 0..width {
+                let expand_bit = color_expand.then(|| {
+                    let pixel = x / pixel_bytes;
+                    if pattern {
+                        let byte = self
+                            .vram
+                            .get(src_start.saturating_add(y & 7))
+                            .copied()
+                            .unwrap_or(0);
+                        byte >> (7 - (pixel & 7)) & 1
+                    } else if let Some(data) = system {
+                        let byte = data.get(y * system_pitch + pixel / 8).copied().unwrap_or(0);
+                        byte >> (7 - (pixel & 7)) & 1
+                    } else {
+                        let byte = self.vram.get(expand_addr).copied().unwrap_or(0);
+                        byte >> (7 - expand_count / pixel_bytes) & 1
+                    }
+                });
+                if color_expand && !pattern && system.is_none() {
+                    expand_count += 1;
+                    if expand_count == expand_span {
+                        expand_count = 0;
+                        expand_addr = if backwards {
+                            expand_addr.wrapping_sub(1)
+                        } else {
+                            expand_addr.wrapping_add(1)
+                        };
+                    }
+                }
                 let dst = if backwards {
                     dst_line.checked_sub(x)
                 } else {
@@ -913,19 +908,6 @@ impl CirrusGd5426 {
                     continue;
                 };
                 let component = x % pixel_bytes;
-                let expand_bit = color_expand.then(|| {
-                    let pixel = x / pixel_bytes;
-                    self.color_expand_bit(
-                        system,
-                        system_pitch,
-                        pattern,
-                        backwards,
-                        src_line,
-                        src_start,
-                        y,
-                        pixel,
-                    )
-                });
                 let source = if solid_fill {
                     self.blit_fg_component(component)
                 } else if let Some(bit) = expand_bit {
@@ -982,6 +964,14 @@ impl CirrusGd5426 {
                 let dest = self.vram[dst];
                 let result = apply_rop(self.gfx[0x32], source, dest);
                 self.vram[dst] = result;
+            }
+            if color_expand && !pattern && system.is_none() && expand_count != 0 {
+                expand_count = 0;
+                expand_addr = if backwards {
+                    expand_addr.wrapping_sub(1)
+                } else {
+                    expand_addr.wrapping_add(1)
+                };
             }
         }
     }

--- a/src/picasso2/gd5426.rs
+++ b/src/picasso2/gd5426.rs
@@ -1,0 +1,1554 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Cirrus Logic CL-GD5426/CL-GD5428 graphics controller.
+//!
+//! This is the self-contained chip core used by the Picasso II family. It
+//! models the packed-pixel register paths used by Amiga RTG drivers, direct
+//! linear VRAM, the CL-GD542x BitBLT engine, and the hardware cursor. VGA text
+//! rendering is intentionally absent: the board powers up behind the native
+//! video pass-through and its driver programs a packed-pixel mode from
+//! scratch.
+
+use crate::chipset::paula::PAULA_CLOCK_HZ;
+
+const MAX_DIM: usize = 4096;
+const BLIT_BUSY_CCK: u32 = 16;
+
+const SR_CURSOR_X: u8 = 0x10;
+const SR_CURSOR_Y: u8 = 0x11;
+const SR_CURSOR_ATTR: usize = 0x12;
+const SR_CURSOR_PATTERN: usize = 0x13;
+
+const PART_ID_GD5426: u8 = 0x90;
+const PART_ID_GD5428: u8 = 0x98;
+
+const BLIT_MODE_BACKWARDS: u8 = 0x01;
+const BLIT_MODE_SYSTEM_SOURCE: u8 = 0x04;
+const BLIT_MODE_TRANSPARENT: u8 = 0x08;
+const BLIT_MODE_PIXEL_WIDTH: u8 = 0x30;
+const BLIT_MODE_PATTERN: u8 = 0x40;
+const BLIT_MODE_COLOR_EXPAND: u8 = 0x80;
+const BLIT_MODEEXT_DWORD_GRANULARITY: u8 = 0x01;
+const BLIT_MODEEXT_COLOR_EXPAND_INVERT: u8 = 0x02;
+const BLIT_MODEEXT_SOLID_FILL: u8 = 0x04;
+
+fn diagnostic_enabled() -> bool {
+    crate::envcfg::flag("COPPERLINE_DIAG_PICASSO")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PixelDepth {
+    Clut8,
+    Rgb555,
+    Rgb565,
+    Bgr888,
+}
+
+impl PixelDepth {
+    fn bytes_per_pixel(self) -> usize {
+        match self {
+            Self::Clut8 => 1,
+            Self::Rgb555 | Self::Rgb565 => 2,
+            Self::Bgr888 => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedMode {
+    pub width: usize,
+    pub height: usize,
+    pub pitch: usize,
+    pub start: usize,
+    pub depth: PixelDepth,
+    pub doublescan: bool,
+    pub interlace: bool,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct SystemBlit {
+    expected: usize,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+enum CirrusModel {
+    Gd5426,
+    Gd5428,
+}
+
+impl CirrusModel {
+    fn part_id(self) -> u8 {
+        match self {
+            Self::Gd5426 => PART_ID_GD5426,
+            Self::Gd5428 => PART_ID_GD5428,
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CirrusGd5426 {
+    model: CirrusModel,
+    vram: Vec<u8>,
+    seq: Vec<u8>,
+    gfx: Vec<u8>,
+    crtc: Vec<u8>,
+    attr: Vec<u8>,
+    seq_index: u8,
+    gfx_index: u8,
+    crtc_index: u8,
+    attr_index: u8,
+    attr_data_phase: bool,
+    misc_output: u8,
+    pel_mask: u8,
+    palette: Vec<[u8; 3]>,
+    cursor_palette: Vec<[u8; 3]>,
+    dac_write_index: u8,
+    dac_read_index: u8,
+    dac_component: u8,
+    dac_read_mode: bool,
+    hidden_dac: u8,
+    hidden_dac_reads: u8,
+    cursor_x: u16,
+    cursor_y: u16,
+    frame_phase_cck: u64,
+    vblank_pending: bool,
+    blit_busy_cck: u32,
+    system_blit: Option<SystemBlit>,
+    #[serde(skip, default = "diagnostic_enabled")]
+    diagnostic: bool,
+}
+
+impl CirrusGd5426 {
+    pub fn new(vram_bytes: usize) -> Self {
+        Self::new_model(vram_bytes, CirrusModel::Gd5426)
+    }
+
+    pub fn new_gd5428(vram_bytes: usize) -> Self {
+        Self::new_model(vram_bytes, CirrusModel::Gd5428)
+    }
+
+    fn new_model(vram_bytes: usize, model: CirrusModel) -> Self {
+        debug_assert!(matches!(vram_bytes, 0x10_0000 | 0x20_0000));
+        let mut seq = vec![0; 0x100];
+        // Power-on VCLK values used by the CL-GD542x BIOS reference model.
+        seq[0x0b] = 0x4a;
+        seq[0x0c] = 0x5b;
+        seq[0x0d] = 0x45;
+        seq[0x0e] = 0x7e;
+        seq[0x1b] = 0x2b;
+        seq[0x1c] = 0x2f;
+        seq[0x1d] = 0x30;
+        seq[0x1e] = 0x33;
+        seq[6] = 0x0f;
+
+        let mut gfx = vec![0; 0x100];
+        gfx[8] = 0xff;
+        Self {
+            model,
+            vram: vec![0; vram_bytes],
+            seq,
+            gfx,
+            crtc: vec![0; 0x100],
+            attr: vec![0; 0x40],
+            seq_index: 0,
+            gfx_index: 0,
+            crtc_index: 0,
+            attr_index: 0,
+            attr_data_phase: false,
+            misc_output: 0,
+            pel_mask: 0xff,
+            palette: vec![[0; 3]; 256],
+            cursor_palette: vec![[0; 3]; 16],
+            dac_write_index: 0,
+            dac_read_index: 0,
+            dac_component: 0,
+            dac_read_mode: false,
+            hidden_dac: 0,
+            hidden_dac_reads: 0,
+            cursor_x: 0,
+            cursor_y: 0,
+            frame_phase_cck: 0,
+            vblank_pending: false,
+            blit_busy_cck: 0,
+            system_blit: None,
+            diagnostic: diagnostic_enabled(),
+        }
+    }
+
+    pub fn vram_len(&self) -> usize {
+        self.vram.len()
+    }
+
+    pub fn reset(&mut self) {
+        let vram_bytes = self.vram.len();
+        *self = Self::new_model(vram_bytes, self.model);
+    }
+
+    fn extensions_unlocked(&self) -> bool {
+        self.seq[6] == 0x12
+    }
+
+    fn disarm_hidden_dac(&mut self) {
+        self.hidden_dac_reads = 0;
+    }
+
+    pub fn io_read(&mut self, port: u16) -> u8 {
+        if port != 0x3c6 {
+            self.disarm_hidden_dac();
+        }
+        match port {
+            0x3c0 => self.attr_index | if self.attr_data_phase { 0x20 } else { 0 },
+            0x3c1 => self.attr[self.attr_index as usize & 0x1f],
+            0x3c2 => self.input_status_0(),
+            0x3c4 => {
+                let base = self.seq_index & 0x1f;
+                if self.extensions_unlocked() && base == SR_CURSOR_X {
+                    ((self.cursor_x as u8 & 7) << 5) | SR_CURSOR_X
+                } else if self.extensions_unlocked() && base == SR_CURSOR_Y {
+                    ((self.cursor_y as u8 & 7) << 5) | SR_CURSOR_Y
+                } else {
+                    self.seq_index
+                }
+            }
+            0x3c5 => self.read_sequencer(),
+            0x3c6 => self.read_pel_mask_or_hidden_dac(),
+            0x3c7 => {
+                if self.dac_read_mode {
+                    3
+                } else {
+                    0
+                }
+            }
+            0x3c8 => self.dac_write_index,
+            0x3c9 => self.read_dac_data(),
+            0x3cc => self.misc_output,
+            0x3ce => self.gfx_index,
+            0x3cf => self.read_graphics(),
+            0x3b4 | 0x3d4 => self.crtc_index,
+            0x3b5 | 0x3d5 => self.read_crtc(),
+            0x3ba | 0x3da => {
+                self.attr_data_phase = false;
+                self.input_status_1()
+            }
+            _ => 0xff,
+        }
+    }
+
+    pub fn io_write(&mut self, port: u16, value: u8) {
+        if port != 0x3c6 {
+            self.disarm_hidden_dac();
+        }
+        if self.diagnostic {
+            log::info!("picasso2: VGA port {port:#05x} <- {value:#04x}");
+        }
+        match port {
+            0x3c0 | 0x3c1 => {
+                if self.attr_data_phase {
+                    self.attr[self.attr_index as usize & 0x1f] = value;
+                } else {
+                    self.attr_index = value & 0x1f;
+                }
+                self.attr_data_phase = !self.attr_data_phase;
+            }
+            0x3c2 => self.misc_output = value,
+            0x3c4 => self.seq_index = value,
+            0x3c5 => self.write_sequencer(value),
+            0x3c6 => self.write_pel_mask_or_hidden_dac(value),
+            0x3c7 => {
+                self.dac_read_index = value;
+                self.dac_component = 0;
+                self.dac_read_mode = true;
+            }
+            0x3c8 => {
+                self.dac_write_index = value;
+                self.dac_component = 0;
+                self.dac_read_mode = false;
+            }
+            0x3c9 => self.write_dac_data(value),
+            0x3ce => self.gfx_index = value,
+            0x3cf => self.write_graphics(value),
+            0x3b4 | 0x3d4 => self.crtc_index = value,
+            0x3b5 | 0x3d5 => self.write_crtc(value),
+            _ => {}
+        }
+    }
+
+    fn read_sequencer(&self) -> u8 {
+        let index = self.seq_index & 0x1f;
+        if index == 6 {
+            return if self.extensions_unlocked() {
+                0x12
+            } else {
+                0x0f
+            };
+        }
+        if index > 6 && !self.extensions_unlocked() {
+            return 0xff;
+        }
+        match index {
+            0x0a => {
+                let size = if self.vram.len() == 0x20_0000 {
+                    0x18
+                } else {
+                    0x10
+                };
+                (self.seq[index as usize] & !0x1a) | size
+            }
+            0x0f => {
+                let size = if self.vram.len() == 0x20_0000 {
+                    0x18
+                } else {
+                    0x10
+                };
+                (self.seq[index as usize] & !0x98) | size
+            }
+            0x17 => (self.seq[index as usize] & !(7 << 3)) | (7 << 3),
+            _ => self.seq[index as usize],
+        }
+    }
+
+    fn write_sequencer(&mut self, value: u8) {
+        let raw_index = self.seq_index;
+        let index = raw_index & 0x1f;
+        if index == 6 {
+            self.seq[6] = if value & 0x17 == 0x12 { 0x12 } else { 0x0f };
+            return;
+        }
+        if index > 6 && !self.extensions_unlocked() {
+            return;
+        }
+        self.seq[index as usize] = value;
+        match index {
+            SR_CURSOR_X => self.cursor_x = (u16::from(value) << 3) | u16::from(raw_index >> 5),
+            SR_CURSOR_Y => self.cursor_y = (u16::from(value) << 3) | u16::from(raw_index >> 5),
+            _ => {}
+        }
+        if self.diagnostic && matches!(index, 0 | 1 | 7 | 0x0b..=0x0e | 0x1b..=0x1e) {
+            log::info!(
+                "picasso2: SR{index:02X} <- {value:02X} mode={:?}",
+                self.decode_mode()
+            );
+        }
+    }
+
+    fn read_graphics(&self) -> u8 {
+        let index = self.gfx_index as usize;
+        if index > 8 && !self.extensions_unlocked() {
+            return 0xff;
+        }
+        if index == 0x31 {
+            let mut value = self.gfx[index] & !0x09;
+            if self.blit_busy() {
+                value |= 0x09;
+            }
+            value
+        } else {
+            self.gfx[index]
+        }
+    }
+
+    fn write_graphics(&mut self, value: u8) {
+        let index = self.gfx_index as usize;
+        if index > 8 && !self.extensions_unlocked() {
+            return;
+        }
+        self.gfx[index] = value;
+        if index == 0x31 {
+            if value & 0x04 != 0 {
+                self.system_blit = None;
+                self.blit_busy_cck = 0;
+                self.gfx[0x31] &= !0x0b;
+            } else if value & 0x02 != 0 {
+                self.start_blit();
+            }
+        }
+    }
+
+    fn read_crtc(&self) -> u8 {
+        if self.crtc_index == 0x27 {
+            self.model.part_id()
+        } else if self.crtc_index > 0x18 && !self.extensions_unlocked() {
+            0xff
+        } else {
+            self.crtc[self.crtc_index as usize]
+        }
+    }
+
+    fn write_crtc(&mut self, value: u8) {
+        let index = self.crtc_index as usize;
+        if index > 0x18 && !self.extensions_unlocked() {
+            return;
+        }
+        if self.crtc[0x11] & 0x80 != 0 && index <= 7 {
+            if index == 7 {
+                self.crtc[7] = (self.crtc[7] & !0x10) | (value & 0x10);
+            }
+            return;
+        }
+        // VGA CR11 bit 4 is active-low interrupt clear. Picasso II+ drivers
+        // acknowledge the latched vertical interrupt by writing it clear.
+        if index == 0x11 && value & 0x10 == 0 {
+            self.vblank_pending = false;
+        }
+        if index != 0x27 {
+            self.crtc[index] = value;
+        }
+        if self.diagnostic
+            && matches!(
+                index,
+                0 | 1 | 6 | 7 | 9 | 0x0c | 0x0d | 0x12 | 0x13 | 0x1a | 0x1b
+            )
+        {
+            log::info!(
+                "picasso2: CR{index:02X} <- {value:02X} mode={:?}",
+                self.decode_mode()
+            );
+        }
+    }
+
+    fn read_pel_mask_or_hidden_dac(&mut self) -> u8 {
+        if !self.extensions_unlocked() {
+            return self.pel_mask;
+        }
+        if self.hidden_dac_reads == 4 {
+            self.hidden_dac_reads = 0;
+            self.hidden_dac
+        } else {
+            self.hidden_dac_reads += 1;
+            self.pel_mask
+        }
+    }
+
+    fn write_pel_mask_or_hidden_dac(&mut self, value: u8) {
+        if self.extensions_unlocked() && self.hidden_dac_reads == 4 {
+            self.hidden_dac = value;
+            self.hidden_dac_reads = 0;
+            if self.diagnostic {
+                log::info!(
+                    "picasso2: hidden DAC <- {value:#04x} mode={:?}",
+                    self.decode_mode()
+                );
+            }
+        } else {
+            self.pel_mask = value;
+            self.hidden_dac_reads = 0;
+        }
+    }
+
+    fn write_dac_data(&mut self, value: u8) {
+        let index = self.dac_write_index as usize;
+        let component = self.dac_component as usize;
+        if self.seq[SR_CURSOR_ATTR] & 0x02 != 0 {
+            self.cursor_palette[index & 0x0f][component] = value & 0x3f;
+        } else {
+            self.palette[index][component] = value & 0x3f;
+        }
+        self.dac_component += 1;
+        if self.dac_component == 3 {
+            self.dac_component = 0;
+            self.dac_write_index = self.dac_write_index.wrapping_add(1);
+        }
+    }
+
+    fn read_dac_data(&mut self) -> u8 {
+        let index = self.dac_read_index as usize;
+        let component = self.dac_component as usize;
+        let value = if self.seq[SR_CURSOR_ATTR] & 0x02 != 0 {
+            self.cursor_palette[index & 0x0f][component]
+        } else {
+            self.palette[index][component]
+        };
+        self.dac_component += 1;
+        if self.dac_component == 3 {
+            self.dac_component = 0;
+            self.dac_read_index = self.dac_read_index.wrapping_add(1);
+        }
+        value
+    }
+
+    pub fn decode_mode(&self) -> Option<DecodedMode> {
+        if self.seq[7] & 1 == 0 {
+            return None;
+        }
+        let width = (usize::from(self.crtc[1]) + 1) * 8;
+        let raw_height = usize::from(self.crtc[0x12])
+            | (usize::from(self.crtc[7] & 0x02) << 7)
+            | (usize::from(self.crtc[7] & 0x40) << 3);
+        let doublescan = self.crtc[9] & 0x80 != 0;
+        let height = (raw_height + 1) * if doublescan { 2 } else { 1 };
+        let pitch_units = usize::from(self.crtc[0x13]) | (usize::from(self.crtc[0x1b] & 0x10) << 4);
+        let pitch = pitch_units * 8;
+        let start_units = usize::from(u16::from_be_bytes([self.crtc[0x0c], self.crtc[0x0d]]))
+            | (usize::from(self.crtc[0x1b] & 0x01) << 16)
+            | (usize::from(self.crtc[0x1b] & 0x04) << 15)
+            | (usize::from(self.crtc[0x1b] & 0x08) << 15);
+        let start = (start_units + usize::from((self.crtc[8] & 0x60) >> 5)) * 4;
+        let depth = if self.hidden_dac & 0x80 == 0 {
+            PixelDepth::Clut8
+        } else if self.hidden_dac & 0x40 == 0 {
+            PixelDepth::Rgb555
+        } else {
+            match self.hidden_dac & 0x0f {
+                0 => PixelDepth::Rgb555,
+                1 => PixelDepth::Rgb565,
+                5 => PixelDepth::Bgr888,
+                0x0f => match self.seq[7] & 0x0e {
+                    0x04 => PixelDepth::Bgr888,
+                    0x02 | 0x06 => PixelDepth::Rgb565,
+                    _ => PixelDepth::Clut8,
+                },
+                _ => return None,
+            }
+        };
+        Some(DecodedMode {
+            width,
+            height,
+            pitch,
+            start,
+            depth,
+            doublescan,
+            interlace: self.crtc[0x1a] & 1 != 0,
+        })
+    }
+
+    pub fn video_valid(&self) -> bool {
+        if self.seq[0] & 0x03 != 0x03 || self.seq[1] & 0x20 != 0 {
+            return false;
+        }
+        let Some(mode) = self.decode_mode() else {
+            return false;
+        };
+        if !(16..=MAX_DIM).contains(&mode.width) || !(16..=MAX_DIM).contains(&mode.height) {
+            return false;
+        }
+        let source_height = if mode.doublescan {
+            mode.height / 2
+        } else {
+            mode.height
+        };
+        let row_bytes = mode.width.saturating_mul(mode.depth.bytes_per_pixel());
+        if mode.pitch < row_bytes || source_height == 0 {
+            return false;
+        }
+        mode.start
+            .checked_add((source_height - 1).saturating_mul(mode.pitch))
+            .and_then(|end| end.checked_add(row_bytes))
+            .is_some_and(|end| end <= self.vram.len())
+    }
+
+    pub fn compose_frame(&self, out: &mut Vec<u32>) -> Option<(u32, u32)> {
+        if !self.video_valid() {
+            return None;
+        }
+        let mode = self.decode_mode()?;
+        out.clear();
+        out.reserve(mode.width * mode.height);
+        let bpp = mode.depth.bytes_per_pixel();
+        for y in 0..mode.height {
+            let source_y = if mode.doublescan { y / 2 } else { y };
+            let row = mode.start + source_y * mode.pitch;
+            for x in 0..mode.width {
+                let at = row + x * bpp;
+                let (r, g, b) = match mode.depth {
+                    PixelDepth::Clut8 => {
+                        let p = self.palette[(self.vram[at] & self.pel_mask) as usize];
+                        (dac6(p[0]), dac6(p[1]), dac6(p[2]))
+                    }
+                    PixelDepth::Rgb555 => {
+                        let v = u16::from_le_bytes([self.vram[at], self.vram[at + 1]]);
+                        (
+                            expand5((v >> 10) as u8),
+                            expand5((v >> 5) as u8),
+                            expand5(v as u8),
+                        )
+                    }
+                    PixelDepth::Rgb565 => {
+                        let v = u16::from_le_bytes([self.vram[at], self.vram[at + 1]]);
+                        (
+                            expand5((v >> 11) as u8),
+                            expand6((v >> 5) as u8),
+                            expand5(v as u8),
+                        )
+                    }
+                    PixelDepth::Bgr888 => (self.vram[at + 2], self.vram[at + 1], self.vram[at]),
+                };
+                out.push(rgba_word(r, g, b));
+            }
+        }
+        self.composite_cursor(out, mode.width, mode.height);
+        Some((mode.width as u32, mode.height as u32))
+    }
+
+    fn composite_cursor(&self, out: &mut [u32], width: usize, height: usize) {
+        if self.seq[SR_CURSOR_ATTR] & 1 == 0 || self.vram.len() < 0x4000 {
+            return;
+        }
+        let large = self.seq[SR_CURSOR_ATTR] & 4 != 0;
+        let size = if large { 64 } else { 32 };
+        let slot = if large {
+            usize::from(self.seq[SR_CURSOR_PATTERN] & 0x3c)
+        } else {
+            usize::from(self.seq[SR_CURSOR_PATTERN] & 0x3f)
+        };
+        let base = self.vram.len() - 0x4000 + slot * 256;
+        let bg = palette_word(self.cursor_palette[0]);
+        let fg = palette_word(self.cursor_palette[0x0f]);
+        for y in 0..size {
+            let py = usize::from(self.cursor_y) + y;
+            if py >= height {
+                continue;
+            }
+            for x_byte in 0..size / 8 {
+                let (plane0_at, plane1_at) = if large {
+                    (base + y * 16 + x_byte, base + y * 16 + 8 + x_byte)
+                } else {
+                    (base + y * 4 + x_byte, base + 0x80 + y * 4 + x_byte)
+                };
+                if plane1_at >= self.vram.len() {
+                    return;
+                }
+                let p0 = self.vram[plane0_at];
+                let p1 = self.vram[plane1_at];
+                for bit in 0..8 {
+                    let px = usize::from(self.cursor_x) + x_byte * 8 + bit;
+                    if px >= width {
+                        continue;
+                    }
+                    let b0 = (p0 >> (7 - bit)) & 1;
+                    let b1 = (p1 >> (7 - bit)) & 1;
+                    let at = py * width + px;
+                    match (b0, b1) {
+                        (0, 0) => {}
+                        (0, 1) => out[at] = bg,
+                        (1, 0) => out[at] ^= 0x00ff_ffff,
+                        (1, 1) => out[at] = fg,
+                        _ => unreachable!(),
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn vram_read(&self, off: usize, size: usize) -> u32 {
+        if off
+            .checked_add(size)
+            .is_none_or(|end| end > self.vram.len())
+        {
+            return open_bus(size);
+        }
+        let mut value = 0;
+        for byte in &self.vram[off..off + size] {
+            value = (value << 8) | u32::from(*byte);
+        }
+        value
+    }
+
+    pub fn vram_write(&mut self, off: usize, size: usize, value: u32) {
+        let mut bytes = [0u8; 4];
+        for (i, byte) in bytes[..size.min(4)].iter_mut().enumerate() {
+            *byte = (value >> (8 * (size - 1 - i))) as u8;
+        }
+        if self.system_blit.is_some() {
+            self.feed_system_blit(&bytes[..size.min(4)]);
+            return;
+        }
+        if off
+            .checked_add(size)
+            .is_none_or(|end| end > self.vram.len())
+        {
+            return;
+        }
+        for (i, byte) in bytes[..size.min(4)].iter().copied().enumerate() {
+            self.write_vga_byte(off + i, byte);
+        }
+    }
+
+    fn write_vga_byte(&mut self, off: usize, cpu: u8) {
+        let old = self.vram[off];
+        let mode = self.gfx[5] & 7;
+        let plane = off & 3;
+        let rotate = self.gfx[3] & 7;
+        let rotated = cpu.rotate_right(u32::from(rotate));
+        let set_reset = if self.gfx[1] & (1 << plane) != 0 {
+            if self.gfx[0] & (1 << plane) != 0 {
+                0xff
+            } else {
+                0
+            }
+        } else {
+            rotated
+        };
+        let (source, mask) = match mode {
+            0 => (set_reset, self.gfx[8]),
+            1 => (old, 0xff),
+            2 => (if cpu & (1 << plane) != 0 { 0xff } else { 0 }, self.gfx[8]),
+            3 => {
+                let mask = rotated & self.gfx[8];
+                (
+                    if self.gfx[0] & (1 << plane) != 0 {
+                        0xff
+                    } else {
+                        0
+                    },
+                    mask,
+                )
+            }
+            // Extended write modes 4/5 are color-expansion paths. P96 uses
+            // the BitBLT engine for them; direct writes remain byte stores.
+            _ => (cpu, 0xff),
+        };
+        let rop = match (self.gfx[3] >> 3) & 3 {
+            0 => source,
+            1 => source & old,
+            2 => source | old,
+            _ => source ^ old,
+        };
+        self.vram[off] = (rop & mask) | (old & !mask);
+    }
+
+    fn blit_busy(&self) -> bool {
+        self.blit_busy_cck != 0 || self.system_blit.is_some()
+    }
+
+    fn start_blit(&mut self) {
+        if self.gfx[0x30] & BLIT_MODE_SYSTEM_SOURCE != 0 {
+            let width = self.blit_width();
+            let height = self.blit_height();
+            let expected = self.system_source_pitch(width) * height;
+            self.system_blit = Some(SystemBlit {
+                expected: expected.max(1),
+                bytes: Vec::with_capacity(expected.max(1)),
+            });
+        } else {
+            self.execute_blit(None);
+            self.blit_busy_cck = BLIT_BUSY_CCK;
+        }
+        if self.diagnostic {
+            log::info!(
+                "picasso2: blit {}x{} dst={:#08x} src={:#08x} mode={:#04x} rop={:#04x}",
+                self.blit_width(),
+                self.blit_height(),
+                self.blit_addr(0x28),
+                self.blit_addr(0x2c),
+                self.gfx[0x30],
+                self.gfx[0x32]
+            );
+        }
+    }
+
+    fn feed_system_blit(&mut self, bytes: &[u8]) {
+        let done = if let Some(blit) = self.system_blit.as_mut() {
+            let remaining = blit.expected.saturating_sub(blit.bytes.len());
+            blit.bytes
+                .extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+            blit.bytes.len() >= blit.expected
+        } else {
+            false
+        };
+        if done {
+            let data = self.system_blit.take().map(|b| b.bytes).unwrap_or_default();
+            self.execute_blit(Some(&data));
+            self.blit_busy_cck = BLIT_BUSY_CCK;
+        }
+    }
+
+    fn blit_width(&self) -> usize {
+        ((usize::from(self.gfx[0x21] & 7) << 8) | usize::from(self.gfx[0x20])) + 1
+    }
+
+    fn blit_height(&self) -> usize {
+        ((usize::from(self.gfx[0x23] & 3) << 8) | usize::from(self.gfx[0x22])) + 1
+    }
+
+    fn blit_pitch(&self, low: usize) -> usize {
+        (usize::from(self.gfx[low + 1] & 0x1f) << 8) | usize::from(self.gfx[low])
+    }
+
+    fn blit_addr(&self, low: usize) -> usize {
+        usize::from(self.gfx[low])
+            | (usize::from(self.gfx[low + 1]) << 8)
+            | (usize::from(self.gfx[low + 2] & 0x1f) << 16)
+    }
+
+    fn blit_pixel_bytes(&self) -> usize {
+        match self.gfx[0x30] & BLIT_MODE_PIXEL_WIDTH {
+            0x00 => 1,
+            0x10 => 2,
+            0x20 => 3,
+            _ => 4,
+        }
+    }
+
+    fn system_source_pitch(&self, width: usize) -> usize {
+        if self.gfx[0x30] & BLIT_MODE_COLOR_EXPAND == 0 {
+            return width.next_multiple_of(4);
+        }
+        let pixels = width.div_ceil(self.blit_pixel_bytes());
+        let granularity = if self.gfx[0x33] & BLIT_MODEEXT_DWORD_GRANULARITY != 0 {
+            32
+        } else {
+            8
+        };
+        pixels.next_multiple_of(granularity) / 8
+    }
+
+    fn blit_fg_component(&self, component: usize) -> u8 {
+        self.gfx[[0x01, 0x11, 0x13, 0x15][component.min(3)]]
+    }
+
+    fn blit_bg_component(&self, component: usize) -> u8 {
+        self.gfx[[0x00, 0x10, 0x12, 0x14][component.min(3)]]
+    }
+
+    fn linear_blit_source(
+        &self,
+        system: Option<&[u8]>,
+        system_pitch: usize,
+        pattern: bool,
+        backwards: bool,
+        src_line: usize,
+        src_start: usize,
+        y: usize,
+        x: usize,
+        pixel_bytes: usize,
+    ) -> u8 {
+        if pattern {
+            let row_bytes = 8 * pixel_bytes;
+            let pattern_base = src_start & !3;
+            return self
+                .vram
+                .get(pattern_base + (y & 7) * row_bytes + (x % row_bytes))
+                .copied()
+                .unwrap_or(0);
+        }
+        if let Some(data) = system {
+            return data.get(y * system_pitch + x).copied().unwrap_or(0);
+        }
+        let src = if backwards {
+            src_line.checked_sub(x)
+        } else {
+            src_line.checked_add(x)
+        };
+        src.and_then(|at| self.vram.get(at).copied()).unwrap_or(0)
+    }
+
+    fn color_expand_bit(
+        &self,
+        system: Option<&[u8]>,
+        system_pitch: usize,
+        pattern: bool,
+        backwards: bool,
+        src_line: usize,
+        src_start: usize,
+        y: usize,
+        pixel: usize,
+    ) -> u8 {
+        let (byte, bit) = if pattern {
+            (
+                self.vram
+                    .get(src_start.saturating_add(y & 7))
+                    .copied()
+                    .unwrap_or(0),
+                pixel & 7,
+            )
+        } else if let Some(data) = system {
+            (
+                data.get(y * system_pitch + pixel / 8).copied().unwrap_or(0),
+                pixel & 7,
+            )
+        } else {
+            let byte_at = if backwards {
+                src_line.checked_sub(pixel / 8)
+            } else {
+                src_line.checked_add(pixel / 8)
+            };
+            (
+                byte_at
+                    .and_then(|at| self.vram.get(at).copied())
+                    .unwrap_or(0),
+                pixel & 7,
+            )
+        };
+        byte >> (7 - bit) & 1
+    }
+
+    fn execute_blit(&mut self, system: Option<&[u8]>) {
+        let width = self.blit_width().min(self.vram.len());
+        let height = self.blit_height().min(MAX_DIM);
+        let dst_pitch = self.blit_pitch(0x24);
+        let src_pitch = self.blit_pitch(0x26);
+        let dst_start = self.blit_addr(0x28);
+        let src_start = self.blit_addr(0x2c);
+        let mode = self.gfx[0x30];
+        let backwards = mode & BLIT_MODE_BACKWARDS != 0;
+        let color_expand = mode & BLIT_MODE_COLOR_EXPAND != 0;
+        let pattern = mode & BLIT_MODE_PATTERN != 0;
+        let pixel_bytes = self.blit_pixel_bytes();
+        let system_pitch = self.system_source_pitch(width);
+        let modeext = self.gfx[0x33];
+        let solid_fill = pattern
+            && color_expand
+            && mode & BLIT_MODE_TRANSPARENT == 0
+            && modeext & BLIT_MODEEXT_SOLID_FILL != 0;
+
+        for y in 0..height {
+            let dst_line = if backwards {
+                dst_start.saturating_sub(y.saturating_mul(dst_pitch))
+            } else {
+                dst_start.saturating_add(y.saturating_mul(dst_pitch))
+            };
+            let src_line = if backwards {
+                src_start.saturating_sub(y.saturating_mul(src_pitch))
+            } else {
+                src_start.saturating_add(y.saturating_mul(src_pitch))
+            };
+            for x in 0..width {
+                let dst = if backwards {
+                    dst_line.checked_sub(x)
+                } else {
+                    dst_line.checked_add(x)
+                };
+                let Some(dst) = dst.filter(|at| *at < self.vram.len()) else {
+                    continue;
+                };
+                let component = x % pixel_bytes;
+                let expand_bit = color_expand.then(|| {
+                    let pixel = x / pixel_bytes;
+                    self.color_expand_bit(
+                        system,
+                        system_pitch,
+                        pattern,
+                        backwards,
+                        src_line,
+                        src_start,
+                        y,
+                        pixel,
+                    )
+                });
+                let source = if solid_fill {
+                    self.blit_fg_component(component)
+                } else if let Some(bit) = expand_bit {
+                    if bit != 0 {
+                        self.blit_fg_component(component)
+                    } else {
+                        self.blit_bg_component(component)
+                    }
+                } else {
+                    self.linear_blit_source(
+                        system,
+                        system_pitch,
+                        pattern,
+                        backwards,
+                        src_line,
+                        src_start,
+                        y,
+                        x,
+                        pixel_bytes,
+                    )
+                };
+
+                let transparent = if mode & BLIT_MODE_TRANSPARENT == 0 {
+                    false
+                } else if let Some(bit) = expand_bit {
+                    if modeext & BLIT_MODEEXT_COLOR_EXPAND_INVERT != 0 {
+                        bit != 0
+                    } else {
+                        bit == 0
+                    }
+                } else if pattern {
+                    false
+                } else {
+                    let pixel_base = x - component;
+                    (0..pixel_bytes).all(|c| {
+                        let source = self.linear_blit_source(
+                            system,
+                            system_pitch,
+                            false,
+                            backwards,
+                            src_line,
+                            src_start,
+                            y,
+                            pixel_base + c,
+                            pixel_bytes,
+                        );
+                        let mask = self.gfx[0x38 + c];
+                        (source & !mask) == (self.gfx[0x34 + c] & !mask)
+                    })
+                };
+                if transparent {
+                    continue;
+                }
+                let dest = self.vram[dst];
+                let result = apply_rop(self.gfx[0x32], source, dest);
+                self.vram[dst] = result;
+            }
+        }
+    }
+
+    pub fn tick(&mut self, cck: u32) {
+        let old_phase = self.frame_phase_cck;
+        self.frame_phase_cck = self.frame_phase_cck.wrapping_add(u64::from(cck));
+        if self.model == CirrusModel::Gd5428
+            && self.vertical_interrupt_enabled()
+            && self.crossed_retrace_start(old_phase, self.frame_phase_cck)
+        {
+            self.vblank_pending = true;
+        }
+        self.blit_busy_cck = self.blit_busy_cck.saturating_sub(cck);
+        if self.blit_busy_cck == 0 && self.system_blit.is_none() {
+            self.gfx[0x31] &= !0x0b;
+        }
+    }
+
+    pub fn is_idle(&self) -> bool {
+        self.blit_busy_cck == 0 && self.system_blit.is_none() && self.decode_mode().is_none()
+    }
+
+    pub fn next_event_cck(&self) -> Option<u32> {
+        let blit = (self.blit_busy_cck != 0).then_some(self.blit_busy_cck);
+        let video = self
+            .decode_mode()
+            .is_some()
+            .then(|| self.cck_until_retrace_start());
+        match (blit, video) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(event), None) | (None, Some(event)) => Some(event),
+            (None, None) => None,
+        }
+    }
+
+    pub fn vblank_pending(&self) -> bool {
+        self.vblank_pending
+    }
+
+    fn dot_clock_hz(&self) -> f64 {
+        let clock = usize::from((self.misc_output >> 2) & 3);
+        let n = f64::from(self.seq[0x0b + clock] & 0x7f);
+        let denom_reg = self.seq[0x1b + clock];
+        let d = f64::from((denom_reg & 0x3e) >> 1);
+        let post = if denom_reg & 1 != 0 { 2.0 } else { 1.0 };
+        let mut hz = if n == 0.0 || d == 0.0 {
+            if clock == 0 {
+                25_175_000.0
+            } else {
+                28_322_000.0
+            }
+        } else {
+            14_318_184.0 * n / (d * post)
+        };
+        match self.seq[7] & 0x06 {
+            0x02 => hz /= 2.0,
+            0x04 => hz /= 3.0,
+            _ => {}
+        }
+        hz.max(1.0)
+    }
+
+    fn horizontal_total_pixels(&self) -> u64 {
+        u64::from(self.crtc[0]).saturating_add(5) * 8
+    }
+
+    fn vertical_total_lines(&self) -> u64 {
+        let total = u64::from(self.crtc[6])
+            | (u64::from(self.crtc[7] & 0x01) << 8)
+            | (u64::from(self.crtc[7] & 0x20) << 4);
+        total + 2
+    }
+
+    fn frame_cck(&self) -> u64 {
+        let pixels = self
+            .horizontal_total_pixels()
+            .saturating_mul(self.vertical_total_lines());
+        ((pixels as f64 * f64::from(PAULA_CLOCK_HZ) / self.dot_clock_hz()).round() as u64).max(1)
+    }
+
+    fn retrace_start_cck(&self) -> u64 {
+        let total_lines = self.vertical_total_lines().max(1);
+        let line_cck = (self.frame_cck() / total_lines).max(1);
+        self.retrace_start_line().min(total_lines - 1) * line_cck
+    }
+
+    fn retrace_start_line(&self) -> u64 {
+        u64::from(self.crtc[0x10])
+            | (u64::from(self.crtc[7] & 0x04) << 6)
+            | (u64::from(self.crtc[7] & 0x80) << 2)
+    }
+
+    fn crossed_retrace_start(&self, old: u64, new: u64) -> bool {
+        let frame = u128::from(self.frame_cck().max(1));
+        let phase = u128::from(self.retrace_start_cck()).min(frame - 1);
+        let elapsed = u128::from(new.wrapping_sub(old));
+        let old = u128::from(old);
+        let new = old + elapsed;
+        let base = old - old % frame;
+        let mut next = base + phase;
+        if next <= old {
+            next += frame;
+        }
+        next <= new
+    }
+
+    fn cck_until_retrace_start(&self) -> u32 {
+        let frame = self.frame_cck().max(1);
+        let phase = self.frame_phase_cck % frame;
+        let retrace = self.retrace_start_cck().min(frame - 1);
+        let distance = if phase < retrace {
+            retrace - phase
+        } else {
+            frame - phase + retrace
+        };
+        distance.max(1).min(u64::from(u32::MAX)) as u32
+    }
+
+    fn vertical_interrupt_enabled(&self) -> bool {
+        self.crtc[0x11] & 0x30 == 0x10 && self.gfx[0x17] & 0x04 == 0
+    }
+
+    fn input_status_0(&self) -> u8 {
+        0x10 | if self.vblank_pending && self.vertical_interrupt_enabled() {
+            0x80
+        } else {
+            0
+        }
+    }
+
+    fn input_status_1(&self) -> u8 {
+        let frame = self.frame_cck();
+        let phase = self.frame_phase_cck % frame;
+        let line_cck = (frame / self.vertical_total_lines().max(1)).max(1);
+        let line = phase / line_cck;
+        let retrace_start = self.retrace_start_line();
+        let retrace_len =
+            u64::from((self.crtc[0x11] & 0x0f).wrapping_sub(self.crtc[0x10] & 0x0f) & 0x0f).max(1);
+        let in_retrace = line >= retrace_start && line < retrace_start.saturating_add(retrace_len);
+        let mode = self.decode_mode();
+        let display_lines =
+            mode.map_or(0, |m| if m.doublescan { m.height / 2 } else { m.height }) as u64;
+        let in_display = line < display_lines;
+        (if in_retrace { 0x08 } else { 0 }) | if in_display { 0 } else { 0x01 }
+    }
+}
+
+fn dac6(value: u8) -> u8 {
+    let value = value & 0x3f;
+    (value << 2) | (value >> 4)
+}
+
+fn expand5(value: u8) -> u8 {
+    let value = value & 0x1f;
+    (value << 3) | (value >> 2)
+}
+
+fn expand6(value: u8) -> u8 {
+    let value = value & 0x3f;
+    (value << 2) | (value >> 4)
+}
+
+fn rgba_word(r: u8, g: u8, b: u8) -> u32 {
+    0xff00_0000 | (u32::from(b) << 16) | (u32::from(g) << 8) | u32::from(r)
+}
+
+fn palette_word(rgb: [u8; 3]) -> u32 {
+    rgba_word(dac6(rgb[0]), dac6(rgb[1]), dac6(rgb[2]))
+}
+
+fn open_bus(size: usize) -> u32 {
+    match size {
+        1 => 0xff,
+        2 => 0xffff,
+        4 => 0xffff_ffff,
+        _ => 0,
+    }
+}
+
+/// The CL-GD5426/5428 implement the 16 two-operand Boolean functions using this
+/// sparse set of ROP encodings. Pattern operations feed their pattern byte as
+/// `source`, so the same table covers the S and P rows in the data book.
+fn apply_rop(rop: u8, source: u8, dest: u8) -> u8 {
+    match rop {
+        0x00 => 0,
+        0x05 => source & dest,
+        0x06 => dest,
+        0x09 => source & !dest,
+        0x0b => !dest,
+        0x0d => source,
+        0x0e => 0xff,
+        0x50 => !source & dest,
+        0x59 => source ^ dest,
+        0x6d => source | dest,
+        0x90 => !source | !dest,
+        0x95 => !(source ^ dest),
+        0xad => source | !dest,
+        0xd0 => !source,
+        0xd6 => !source | dest,
+        0xda => !source & !dest,
+        _ => source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unlock(chip: &mut CirrusGd5426) {
+        chip.io_write(0x3c4, 6);
+        chip.io_write(0x3c5, 0x12);
+    }
+
+    fn seq(chip: &mut CirrusGd5426, index: u8, value: u8) {
+        chip.io_write(0x3c4, index);
+        chip.io_write(0x3c5, value);
+    }
+
+    fn crtc(chip: &mut CirrusGd5426, index: u8, value: u8) {
+        chip.io_write(0x3d4, index);
+        chip.io_write(0x3d5, value);
+    }
+
+    fn gfx(chip: &mut CirrusGd5426, index: u8, value: u8) {
+        chip.io_write(0x3ce, index);
+        chip.io_write(0x3cf, value);
+    }
+
+    fn blit_registers(
+        chip: &mut CirrusGd5426,
+        width: usize,
+        height: usize,
+        dst_pitch: usize,
+        src_pitch: usize,
+        dst: usize,
+        src: usize,
+        mode: u8,
+    ) {
+        for (index, value) in [
+            (0x20, (width - 1) as u8),
+            (0x21, ((width - 1) >> 8) as u8),
+            (0x22, (height - 1) as u8),
+            (0x23, ((height - 1) >> 8) as u8),
+            (0x24, dst_pitch as u8),
+            (0x25, (dst_pitch >> 8) as u8),
+            (0x26, src_pitch as u8),
+            (0x27, (src_pitch >> 8) as u8),
+            (0x28, dst as u8),
+            (0x29, (dst >> 8) as u8),
+            (0x2a, (dst >> 16) as u8),
+            (0x2c, src as u8),
+            (0x2d, (src >> 8) as u8),
+            (0x2e, (src >> 16) as u8),
+            (0x30, mode),
+            (0x32, 0x0d),
+        ] {
+            gfx(chip, index, value);
+        }
+    }
+
+    fn start_blit(chip: &mut CirrusGd5426) {
+        gfx(chip, 0x31, 0x02);
+    }
+
+    fn mode(chip: &mut CirrusGd5426, width: usize, height: usize, pitch: usize) {
+        unlock(chip);
+        seq(chip, 0, 3);
+        seq(chip, 1, 0);
+        seq(chip, 7, 1);
+        crtc(chip, 1, (width / 8 - 1) as u8);
+        crtc(chip, 0x12, (height - 1) as u8);
+        let overflow = (if (height - 1) & 0x100 != 0 { 0x02 } else { 0 })
+            | (if (height - 1) & 0x200 != 0 { 0x40 } else { 0 });
+        crtc(chip, 7, overflow);
+        crtc(chip, 0x13, (pitch / 8) as u8);
+    }
+
+    #[test]
+    fn extension_lock_and_hidden_dac_protocol() {
+        let mut chip = CirrusGd5426::new(0x20_0000);
+        chip.io_write(0x3c4, 7);
+        chip.io_write(0x3c5, 1);
+        assert_eq!(chip.io_read(0x3c5), 0xff);
+        unlock(&mut chip);
+        assert_eq!(chip.io_read(0x3c5), 0x12);
+        for _ in 0..4 {
+            assert_eq!(chip.io_read(0x3c6), 0xff);
+        }
+        chip.io_write(0x3c6, 0xc1);
+        for _ in 0..4 {
+            assert_eq!(chip.io_read(0x3c6), 0xff);
+        }
+        assert_eq!(chip.io_read(0x3c6), 0xc1);
+
+        // Any non-$3C6 access abandons a partially armed sequence.
+        assert_eq!(chip.io_read(0x3c6), 0xff);
+        assert_eq!(chip.io_read(0x3c6), 0xff);
+        let _ = chip.io_read(0x3cc);
+        for _ in 0..4 {
+            assert_eq!(chip.io_read(0x3c6), 0xff);
+        }
+        assert_eq!(chip.io_read(0x3c6), 0xc1);
+    }
+
+    #[test]
+    fn captured_640x480_mode_decodes_geometry_pitch_and_pan() {
+        let mut chip = CirrusGd5426::new(0x20_0000);
+        mode(&mut chip, 640, 480, 640);
+        crtc(&mut chip, 0x0c, 0x23);
+        crtc(&mut chip, 0x0d, 0x45);
+        crtc(&mut chip, 0x1b, 0x01);
+        assert_eq!(
+            chip.decode_mode(),
+            Some(DecodedMode {
+                width: 640,
+                height: 480,
+                pitch: 640,
+                start: 0x12345 * 4,
+                depth: PixelDepth::Clut8,
+                doublescan: false,
+                interlace: false,
+            })
+        );
+        assert!(chip.video_valid());
+    }
+
+    #[test]
+    fn scanout_decodes_all_picasso_pixel_formats() {
+        let mut chip = CirrusGd5426::new(0x20_0000);
+        mode(&mut chip, 16, 16, 48);
+        chip.palette[1] = [0x3f, 0, 0];
+        chip.vram[0] = 1;
+        let mut out = Vec::new();
+        assert_eq!(chip.compose_frame(&mut out), Some((16, 16)));
+        assert_eq!(out[0], rgba_word(0xff, 0, 0));
+
+        chip.hidden_dac = 0xc0;
+        chip.vram[0..2].copy_from_slice(&0x7c00u16.to_le_bytes());
+        assert_eq!(chip.compose_frame(&mut out), Some((16, 16)));
+        assert_eq!(out[0], rgba_word(0xff, 0, 0));
+
+        chip.hidden_dac = 0xc1;
+        chip.vram[0..2].copy_from_slice(&0x07e0u16.to_le_bytes());
+        assert_eq!(chip.compose_frame(&mut out), Some((16, 16)));
+        assert_eq!(out[0], rgba_word(0, 0xff, 0));
+
+        chip.hidden_dac = 0xc5;
+        chip.vram[0..3].copy_from_slice(&[0x20, 0x40, 0x80]);
+        assert_eq!(chip.compose_frame(&mut out), Some((16, 16)));
+        assert_eq!(out[0], rgba_word(0x80, 0x40, 0x20));
+    }
+
+    #[test]
+    fn blitter_copies_overlap_in_both_directions_and_reports_busy() {
+        let mut chip = CirrusGd5426::new(0x10_0000);
+        unlock(&mut chip);
+        chip.vram[0..4].copy_from_slice(&[1, 2, 3, 4]);
+        blit_registers(&mut chip, 4, 1, 8, 8, 8, 0, 0);
+        start_blit(&mut chip);
+        assert_eq!(&chip.vram[8..12], &[1, 2, 3, 4]);
+        gfx(&mut chip, 0x31, 0);
+        assert_ne!(chip.io_read(0x3cf) & 0x09, 0);
+        chip.tick(BLIT_BUSY_CCK - 1);
+        assert_ne!(chip.io_read(0x3cf) & 0x09, 0);
+        chip.tick(1);
+        assert_eq!(chip.io_read(0x3cf) & 0x09, 0);
+
+        chip.vram[0..8].copy_from_slice(&[10, 11, 12, 13, 14, 15, 16, 17]);
+        // Backwards starts at the bottom-right byte. This overlapping move is
+        // the direction P96 uses when scrolling toward higher addresses.
+        blit_registers(&mut chip, 6, 1, 8, 8, 7, 5, BLIT_MODE_BACKWARDS);
+        start_blit(&mut chip);
+        assert_eq!(&chip.vram[2..8], &[10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn blitter_solid_fill_handles_truecolor_components() {
+        let mut chip = CirrusGd5426::new(0x10_0000);
+        unlock(&mut chip);
+        gfx(&mut chip, 0x01, 0x11);
+        gfx(&mut chip, 0x11, 0x22);
+        gfx(&mut chip, 0x13, 0x33);
+        gfx(&mut chip, 0x33, BLIT_MODEEXT_SOLID_FILL);
+        blit_registers(
+            &mut chip,
+            6,
+            1,
+            6,
+            0,
+            0x100,
+            0,
+            BLIT_MODE_PATTERN | BLIT_MODE_COLOR_EXPAND | 0x20,
+        );
+        start_blit(&mut chip);
+        assert_eq!(
+            &chip.vram[0x100..0x106],
+            &[0x11, 0x22, 0x33, 0x11, 0x22, 0x33]
+        );
+    }
+
+    #[test]
+    fn blitter_system_color_expand_and_source_transparency() {
+        let mut chip = CirrusGd5426::new(0x10_0000);
+        unlock(&mut chip);
+        gfx(&mut chip, 0x00, 0x10);
+        gfx(&mut chip, 0x01, 0xe0);
+        blit_registers(
+            &mut chip,
+            8,
+            1,
+            8,
+            0,
+            0x100,
+            0,
+            BLIT_MODE_SYSTEM_SOURCE | BLIT_MODE_COLOR_EXPAND,
+        );
+        start_blit(&mut chip);
+        chip.vram_write(0, 1, 0xa0);
+        assert_eq!(
+            &chip.vram[0x100..0x108],
+            &[0xe0, 0x10, 0xe0, 0x10, 0x10, 0x10, 0x10, 0x10]
+        );
+
+        chip.vram[0x20..0x22].copy_from_slice(&[0, 0x7a]);
+        chip.vram[0x120..0x122].copy_from_slice(&[0x55, 0x55]);
+        gfx(&mut chip, 0x34, 0);
+        gfx(&mut chip, 0x38, 0);
+        blit_registers(&mut chip, 2, 1, 2, 2, 0x120, 0x20, BLIT_MODE_TRANSPARENT);
+        start_blit(&mut chip);
+        assert_eq!(&chip.vram[0x120..0x122], &[0x55, 0x7a]);
+    }
+
+    #[test]
+    fn cursor_planes_decode_background_xor_foreground_and_clip() {
+        let mut chip = CirrusGd5426::new(0x10_0000);
+        mode(&mut chip, 16, 16, 16);
+        chip.cursor_palette[0] = [0x3f, 0, 0];
+        chip.cursor_palette[0x0f] = [0, 0x3f, 0];
+        chip.cursor_x = 14;
+        chip.cursor_y = 0;
+        seq(&mut chip, 0x12, 1);
+        let base = chip.vram.len() - 0x4000;
+        chip.vram[base] = 0x60;
+        chip.vram[base + 0x80] = 0xa0;
+        let mut out = Vec::new();
+        assert_eq!(chip.compose_frame(&mut out), Some((16, 16)));
+        assert_eq!(out[14], rgba_word(0xff, 0, 0));
+        assert_eq!(out[15], rgba_word(0xff, 0xff, 0xff));
+    }
+
+    #[test]
+    fn input_status_tracks_programmed_vertical_retrace_in_emulated_time() {
+        let mut chip = CirrusGd5426::new(0x10_0000);
+        mode(&mut chip, 16, 16, 16);
+        crtc(&mut chip, 0, 15);
+        crtc(&mut chip, 6, 20);
+        crtc(&mut chip, 0x10, 16);
+        crtc(&mut chip, 0x11, 2);
+        assert_eq!(chip.io_read(0x3da) & 0x08, 0);
+        let line_cck = chip.frame_cck() / chip.vertical_total_lines();
+        chip.tick((line_cck * 16) as u32);
+        assert_ne!(chip.io_read(0x3da) & 0x08, 0);
+        chip.tick((line_cck * 2) as u32);
+        assert_eq!(chip.io_read(0x3da) & 0x08, 0);
+    }
+
+    #[test]
+    fn controller_revision_selects_the_cr27_part_id() {
+        let mut gd5426 = CirrusGd5426::new(0x10_0000);
+        let mut gd5428 = CirrusGd5426::new_gd5428(0x10_0000);
+        for (chip, expected) in [(&mut gd5426, PART_ID_GD5426), (&mut gd5428, PART_ID_GD5428)] {
+            chip.io_write(0x3d4, 0x27);
+            assert_eq!(chip.io_read(0x3d5), expected);
+        }
+    }
+
+    #[test]
+    fn gd5428_vblank_latch_obeys_vga_enable_and_ack() {
+        let mut chip = CirrusGd5426::new_gd5428(0x10_0000);
+        mode(&mut chip, 16, 16, 16);
+        crtc(&mut chip, 0, 15);
+        crtc(&mut chip, 6, 20);
+        crtc(&mut chip, 0x10, 16);
+        crtc(&mut chip, 0x11, 0x12);
+        assert!(!chip.vblank_pending());
+        assert_eq!(chip.io_read(0x3c2), 0x10);
+
+        let line_cck = chip.frame_cck() / chip.vertical_total_lines();
+        assert_eq!(chip.next_event_cck(), Some((line_cck * 16) as u32));
+        chip.tick((line_cck * 16) as u32);
+        assert!(chip.vblank_pending());
+        assert_eq!(chip.io_read(0x3c2), 0x90);
+
+        crtc(&mut chip, 0x11, 0x02);
+        assert!(!chip.vblank_pending());
+        assert_eq!(chip.io_read(0x3c2), 0x10);
+
+        chip.tick(chip.frame_cck() as u32);
+        assert!(
+            !chip.vblank_pending(),
+            "CR11 bit 4 clear keeps IRQ disarmed"
+        );
+    }
+
+    #[test]
+    fn serde_resumes_mid_hidden_dac_sequence_and_system_blit() {
+        let mut original = CirrusGd5426::new(0x10_0000);
+        unlock(&mut original);
+        original.hidden_dac = 0xc1;
+        blit_registers(&mut original, 1, 1, 1, 0, 0x100, 0, BLIT_MODE_SYSTEM_SOURCE);
+        start_blit(&mut original);
+        original.vram_write(0, 2, 0x7a00);
+        assert_eq!(original.io_read(0x3c6), 0xff);
+        assert_eq!(original.io_read(0x3c6), 0xff);
+
+        let bytes = bincode::serialize(&original).unwrap();
+        let mut resumed: CirrusGd5426 = bincode::deserialize(&bytes).unwrap();
+        for chip in [&mut original, &mut resumed] {
+            assert_eq!(chip.io_read(0x3c6), 0xff);
+            assert_eq!(chip.io_read(0x3c6), 0xff);
+            assert_eq!(chip.io_read(0x3c6), 0xc1);
+            chip.vram_write(0, 2, 0);
+            assert_eq!(chip.vram[0x100], 0x7a);
+            chip.tick(BLIT_BUSY_CCK);
+            assert!(!chip.blit_busy());
+        }
+        assert_eq!(
+            bincode::serialize(&original).unwrap(),
+            bincode::serialize(&resumed).unwrap()
+        );
+    }
+
+    #[test]
+    fn every_documented_rop_matches_boolean_reference() {
+        let rops = [
+            0x00, 0x05, 0x06, 0x09, 0x0b, 0x0d, 0x0e, 0x50, 0x59, 0x6d, 0x90, 0x95, 0xad, 0xd0,
+            0xd6, 0xda,
+        ];
+        for rop in rops {
+            for source in [0x00, 0x35, 0xaa, 0xff] {
+                for dest in [0x00, 0x53, 0xaa, 0xff] {
+                    // The Cirrus encoding is sparse rather than a compact
+                    // four-bit truth table, so spell the documented Boolean
+                    // operation out independently of `apply_rop`.
+                    let expect = match rop {
+                        0x00 => 0,
+                        0x05 => source & dest,
+                        0x06 => dest,
+                        0x09 => source & !dest,
+                        0x0b => !dest,
+                        0x0d => source,
+                        0x0e => 0xff,
+                        0x50 => !source & dest,
+                        0x59 => source ^ dest,
+                        0x6d => source | dest,
+                        0x90 => !source | !dest,
+                        0x95 => !(source ^ dest),
+                        0xad => source | !dest,
+                        0xd0 => !source,
+                        0xd6 => !source | dest,
+                        0xda => !source & !dest,
+                        _ => unreachable!(),
+                    };
+                    assert_eq!(apply_rop(rop, source, dest), expect, "rop {rop:#04x}");
+                }
+            }
+        }
+    }
+}

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -149,7 +149,12 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      effective filter state, for the [audio] audio_filter override; the
 //      override mode itself is a host preference and is not serialized
 //  42: NetConfig gained the Bridge variant and its host interface identifier
-pub const STATE_VERSION: u32 = 42;
+//  43: Zorro BoardSpec gained explicit memory-space, chained-configuration,
+//      and tagged device-window fields; BoardDevice gained Picasso2 and its
+//      complete CL-GD5426/VRAM state
+//  44: Picasso2 and its Cirrus core gained the II+ revision identity and
+//      serializable vertical-blank interrupt latch
+pub const STATE_VERSION: u32 = 44;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -836,7 +836,12 @@ pub const MODELS: [MachineModel; 10] = [
 // --- value preset lists for the cycle/stepper controls -------------------
 
 const CHIPSETS: [Chipset; 3] = [Chipset::Ocs, Chipset::Ecs, Chipset::Aga];
-const RTG_CARDS: [RtgCard; 2] = [RtgCard::None, RtgCard::Z3660];
+const RTG_CARDS: [RtgCard; 4] = [
+    RtgCard::None,
+    RtgCard::Picasso2,
+    RtgCard::Picasso2Plus,
+    RtgCard::Z3660,
+];
 const AGNUS_CHOICES: [Option<AgnusRevision>; 5] = [
     None,
     Some(AgnusRevision::Ocs),
@@ -1167,6 +1172,10 @@ pub struct MachineSetup {
     rtc: bool,
     identify: bool,
     rtg: RtgCard,
+    /// Memory fitted to a configurable RTG board. The launcher currently
+    /// preserves this value from loaded configs; the card selector does not
+    /// need a separate control for the two period-correct Picasso II/II+ sizes.
+    rtg_vram_bytes: usize,
     // CPU
     cpu: CpuModel,
     fpu: bool,
@@ -1372,6 +1381,7 @@ impl MachineSetup {
             rtc: cfg.rtc_present,
             identify: cfg.identify_board,
             rtg: cfg.rtg,
+            rtg_vram_bytes: cfg.rtg_vram_bytes,
             cpu: cfg.cpu,
             fpu: cfg.fpu,
             clock_mhz: cfg.cpu_clock_mhz,
@@ -1625,7 +1635,10 @@ impl MachineSetup {
             raw.identify = Some(self.identify);
         }
         if self.rtg != base.rtg {
-            raw.rtg.card = Some(rtg_card_name(self.rtg).to_ascii_lowercase());
+            raw.rtg.card = Some(rtg_card_value(self.rtg).to_string());
+        }
+        if self.rtg_vram_bytes != base.rtg_vram_bytes {
+            raw.rtg.vram = Some(format_size(self.rtg_vram_bytes));
         }
         // CPU
         if self.cpu != base.cpu {
@@ -2006,6 +2019,7 @@ impl MachineSetup {
         self.rtc = base.rtc_present;
         self.identify = base.identify_board;
         self.rtg = base.rtg;
+        self.rtg_vram_bytes = base.rtg_vram_bytes;
         self.cpu = base.cpu;
         self.fpu = base.fpu;
         self.clock_mhz = base.cpu_clock_mhz;
@@ -2124,8 +2138,9 @@ impl MachineSetup {
             F::Z3Ram => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
             // The CPU-slot space at $08000000 is beyond a 24-bit bus too.
             F::AccelRam => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
-            // The Z3660 is a Zorro III board: same address-reach gate.
-            F::Rtg => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
+            // Picasso II/II+ remain available on a 24-bit CPU. The stepper's
+            // choice list omits the Zorro III-only Z3660 in that case.
+            F::Rtg => None,
             // Motherboard fast RAM hangs off Ramsey, which only the big-box
             // profiles fit, and its bank ends beyond a 24-bit address bus.
             F::MbRam => {
@@ -2732,7 +2747,14 @@ impl MachineSetup {
     pub fn cycle(&mut self, field: LauncherField, forward: bool) {
         match field {
             F::Chipset => self.chipset = cycle_slice(&CHIPSETS, self.chipset, forward),
-            F::Rtg => self.rtg = cycle_slice(&RTG_CARDS, self.rtg, forward),
+            F::Rtg => {
+                let cards = if cpu_is_32bit(self.cpu) {
+                    &RTG_CARDS[..]
+                } else {
+                    &RTG_CARDS[..3]
+                };
+                self.rtg = cycle_slice(cards, self.rtg, forward);
+            }
             F::Agnus => self.agnus = cycle_slice(&AGNUS_CHOICES, self.agnus, forward),
             F::Denise => self.denise = cycle_slice(&DENISE_CHOICES, self.denise, forward),
             F::Video => self.video = cycle_slice(&VIDEO_CHOICES, self.video, forward),
@@ -2749,11 +2771,14 @@ impl MachineSetup {
                     // Zorro III RAM, motherboard RAM, accelerator RAM, and
                     // the Zorro III RTG card all sit beyond a 24-bit bus;
                     // dropping them (rather than just greying their rows)
-                    // keeps the emitted config launchable.
+                    // keeps the emitted config launchable. Picasso II/II+ are
+                    // Zorro II cards and remain fitted.
                     self.z3_ram = 0;
                     self.mb_ram = 0;
                     self.accel_ram = 0;
-                    self.rtg = RtgCard::None;
+                    if self.rtg == RtgCard::Z3660 {
+                        self.rtg = RtgCard::None;
+                    }
                 }
             }
             F::Clock => self.clock_mhz = cycle_floats(&CLOCK_PRESETS, self.clock_mhz, forward),
@@ -4043,7 +4068,18 @@ pub fn model_label(model: MachineModel) -> &'static str {
 fn rtg_card_name(card: RtgCard) -> &'static str {
     match card {
         RtgCard::None => "None",
+        RtgCard::Picasso2 => "Picasso II",
+        RtgCard::Picasso2Plus => "Picasso II+",
         RtgCard::Z3660 => "Z3660",
+    }
+}
+
+fn rtg_card_value(card: RtgCard) -> &'static str {
+    match card {
+        RtgCard::None => "none",
+        RtgCard::Picasso2 => "picasso2",
+        RtgCard::Picasso2Plus => "picasso2plus",
+        RtgCard::Z3660 => "z3660",
     }
 }
 
@@ -4869,10 +4905,38 @@ mod tests {
         assert_eq!(back.rtg, RtgCard::None);
         assert!(s.build_config().is_ok());
 
-        // A 68000 machine cannot host the board, so it has none and the row
-        // still cycles without producing an unbuildable config.
+        // A 68000 machine cannot host Z3660, but its Zorro II bus can host a
+        // Picasso II family. The selector therefore remains live and round-trips the
+        // parser spelling rather than its friendlier display name.
         s.select_model(Some(MachineModel::A500));
         assert_eq!(s.rtg, RtgCard::None);
+        assert_eq!(s.disabled_reason(LauncherField::Rtg), None);
+        s.cycle(LauncherField::Rtg, true);
+        assert_eq!(s.rtg, RtgCard::Picasso2);
+        assert_eq!(s.value_label(LauncherField::Rtg), "Picasso II");
+        let raw = s.to_raw();
+        assert_eq!(raw.rtg.card.as_deref(), Some("picasso2"));
+        assert_eq!(MachineSetup::from_raw(&raw).unwrap().rtg, RtgCard::Picasso2);
+        assert!(s.build_config().is_ok());
+
+        s.cycle(LauncherField::Rtg, true);
+        assert_eq!(s.rtg, RtgCard::Picasso2Plus);
+        assert_eq!(s.value_label(LauncherField::Rtg), "Picasso II+");
+        let raw = s.to_raw();
+        assert_eq!(raw.rtg.card.as_deref(), Some("picasso2plus"));
+        assert_eq!(
+            MachineSetup::from_raw(&raw).unwrap().rtg,
+            RtgCard::Picasso2Plus
+        );
+        assert!(s.build_config().is_ok());
+
+        // A loaded 1 MB board preserves its fitted VRAM when saved.
+        let mut raw = RawConfig::default();
+        raw.rtg.card = Some("picasso2".to_string());
+        raw.rtg.vram = Some("1M".to_string());
+        let s = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(s.rtg_vram_bytes, 1024 * 1024);
+        assert_eq!(s.to_raw().rtg.vram.as_deref(), Some("1M"));
     }
 
     #[test]
@@ -5526,12 +5590,10 @@ mod tests {
             s.disabled_reason(LauncherField::MbRam),
             Some("needs 32-bit CPU")
         );
-        // The profile's Zorro III RTG card is beyond a 24-bit bus too.
+        // The profile's Zorro III RTG card is beyond a 24-bit bus too. The RTG
+        // selector remains live because Picasso II/II+ are still valid choices.
         assert_eq!(s.rtg, RtgCard::None);
-        assert_eq!(
-            s.disabled_reason(LauncherField::Rtg),
-            Some("needs 32-bit CPU")
-        );
+        assert_eq!(s.disabled_reason(LauncherField::Rtg), None);
         // The raw config overrides the profile default back to zero, so
         // this machine still launches.
         assert_eq!(s.to_raw().memory.motherboard.as_deref(), Some("0"));

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8984,14 +8984,26 @@ impl App {
         // modes): the presentation resampler blends adjacent lines, so
         // per-scanline forensics need the unscaled field.
         let src_rows = self.present_rows;
-        let result = save_present_frame(
-            path,
-            &self.present_fb,
-            src_rows,
-            self.present_width,
-            self.overscan,
-            self.present_tv_aperture_rows,
-        );
+        let result = if self.rtg_present_dims.is_some() {
+            // An RTG board's frame already has one presentation row per
+            // board row: save it at that height, matching the control
+            // protocol's capture, instead of scaling to the chipset glass.
+            screenshot::save(
+                path,
+                &self.present_fb[..src_rows * self.present_width],
+                self.present_width as u32,
+                src_rows as u32,
+            )
+        } else {
+            save_present_frame(
+                path,
+                &self.present_fb,
+                src_rows,
+                self.present_width,
+                self.overscan,
+                self.present_tv_aperture_rows,
+            )
+        };
         match result {
             Ok(()) => info!("screenshot saved: {}", path.display()),
             Err(e) => warn!("screenshot save failed ({}): {e:#}", path.display()),

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -378,6 +378,18 @@ impl BoardSpec {
                 self.name
             );
         }
+        // A tagged offset carries the aperture number in bits 31:28, so the
+        // aperture itself must decode entirely below the tag; a larger one
+        // would silently alias into a neighbouring window.
+        if self.window != 0 && self.size_bytes > 1 << DEVICE_WINDOW_SHIFT {
+            bail!(
+                "board {:?}: a window-tagged aperture must fit below the tag bits \
+                 ({} bytes exceeds the {} MiB window)",
+                self.name,
+                self.size_bytes,
+                (1usize << DEVICE_WINDOW_SHIFT) >> 20,
+            );
+        }
         match self.version {
             ZorroVersion::II => {
                 if zorro_ii_size_code(self.size_bytes).is_none() {
@@ -1532,5 +1544,17 @@ mod tests {
         assert_eq!(chain.config_logical_byte(0, 9), Some(0x00));
         assert_eq!(chain.config_logical_byte(1, 6), Some(0x00));
         assert_eq!(chain.config_logical_byte(1, 7), Some(0x10));
+    }
+
+    #[test]
+    fn window_tagged_apertures_must_fit_below_the_tag_bits() {
+        let mut spec = BoardSpec::picasso2_vram(0, 2 * 1024 * 1024);
+        spec.version = ZorroVersion::III;
+        spec.size_bytes = 2 << DEVICE_WINDOW_SHIFT;
+        let err = ZorroChain::default().add_board(spec).unwrap_err();
+        assert!(
+            err.to_string().contains("window-tagged aperture"),
+            "{err:#}"
+        );
     }
 }

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -13,9 +13,9 @@
 //! Boards are described by a [`BoardSpec`]; built-in RAM boards come from
 //! `[memory] fast`/`z3` in the config, and additional boards can be loaded
 //! from TOML metadata files via `[[zorro]]` sections (the "plugin" path:
-//! the autoconfig identity lives in data, not code). Only RAM-backed
-//! boards are implemented today; other backings plug in via
-//! [`BoardBacking`].
+//! the autoconfig identity lives in data, not code). RAM-backed storage and
+//! functional device apertures share the same placement and dispatch path
+//! through [`BoardBacking`].
 
 use crate::net::NetConfig;
 use crate::wasm_manifest::{WasmCaps, WasmManifest};
@@ -35,6 +35,7 @@ const ERT_ZORROII: u8 = 0xC0;
 const ERT_ZORROIII: u8 = 0x80;
 const ERTF_MEMLIST: u8 = 1 << 5;
 const ERTF_DIAGVALID: u8 = 1 << 4;
+const ERTF_CHAINEDCONFIG: u8 = 1 << 3;
 
 // er_Flags fields.
 const ERFF_MEMSPACE: u8 = 1 << 7;
@@ -62,6 +63,27 @@ const PRODUCT_FAST_RAM: u8 = 0x03;
 const PRODUCT_Z3_RAM: u8 = 0x04;
 /// The services board (host filesystem and, later, other guest services).
 const PRODUCT_SERVICES: u8 = 0x05;
+
+/// Village Tronic's registered expansion manufacturer ID.
+pub const PICASSO2_MANUFACTURER_ID: u16 = 2167;
+/// Picasso II linear VRAM aperture. Product 13 is the unsupported segmented
+/// configuration selected by the physical board's jumper.
+pub const PICASSO2_PRODUCT_VRAM: u8 = 11;
+/// Picasso II VGA-register and monitor-switch window.
+pub const PICASSO2_PRODUCT_REGS: u8 = 12;
+#[allow(dead_code)]
+pub const PICASSO2_PRODUCT_SEGMENTED: u8 = 13;
+/// The original Picasso II serial number.
+pub const PICASSO2_SERIAL: u32 = 0x0002_0000;
+/// Picasso II+ serial number. The products stay 11 and 12; Picasso96 uses
+/// this serial to distinguish the CL-GD5428 revision from the original card.
+pub const PICASSO2PLUS_SERIAL: u32 = 0x0010_0000;
+
+/// Device-window offsets carry this tag to distinguish multiple autoconfig
+/// apertures owned by one [`crate::zorro_device::ZorroDevice`]. Physical
+/// in-tree device windows are at most 128 MB, so bits 31:28 are otherwise
+/// clear.
+pub const DEVICE_WINDOW_SHIFT: u32 = 28;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 // "II"/"III" are the bus generations' proper names (roman numerals), not
@@ -97,6 +119,14 @@ pub struct BoardSpec {
     pub backing: BoardBacking,
     /// Link the board space into the system free memory list (ERTF_MEMLIST).
     pub memlist: bool,
+    /// Request placement in autoconfig memory space (ERFF_MEMSPACE). Most
+    /// functional boards are I/O windows, but framebuffer apertures can be
+    /// device-backed memory windows.
+    pub memory_space: bool,
+    /// Another autoconfig identity belonging to this physical board follows.
+    pub chained: bool,
+    /// Logical aperture number passed to a shared device in offset bits 31:28.
+    pub window: u8,
     /// Autoboot: ERTF_DIAGVALID with er_InitDiagVec pointing at the
     /// DiagArea inside the configured board space.
     pub diag_vec: Option<u16>,
@@ -114,6 +144,9 @@ impl BoardSpec {
             size_bytes,
             backing: BoardBacking::Ram,
             memlist: true,
+            memory_space: true,
+            chained: false,
+            window: 0,
             diag_vec: None,
         }
     }
@@ -129,6 +162,9 @@ impl BoardSpec {
             size_bytes,
             backing: BoardBacking::Ram,
             memlist: true,
+            memory_space: true,
+            chained: false,
+            window: 0,
             diag_vec: None,
         }
     }
@@ -152,6 +188,9 @@ impl BoardSpec {
             size_bytes: 0x1_0000,
             backing: BoardBacking::Ram,
             memlist: false,
+            memory_space: true,
+            chained: false,
+            window: 0,
             diag_vec: None,
         }
     }
@@ -169,6 +208,9 @@ impl BoardSpec {
             size_bytes: 0x1_0000,
             backing: BoardBacking::Device(slot),
             memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
             diag_vec: None,
         }
     }
@@ -188,6 +230,9 @@ impl BoardSpec {
             size_bytes: 0x1_0000,
             backing: BoardBacking::Device(slot),
             memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
             diag_vec: Some(0x2000),
         }
     }
@@ -208,6 +253,9 @@ impl BoardSpec {
             size_bytes: 0x0100_0000,
             backing: BoardBacking::Device(slot),
             memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
             diag_vec: Some(0x0200),
         }
     }
@@ -231,6 +279,9 @@ impl BoardSpec {
             size_bytes: 0x1_0000,
             backing: BoardBacking::Device(slot),
             memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
             diag_vec: Some(crate::filesys::DIAG_OFFSET),
         }
     }
@@ -250,11 +301,83 @@ impl BoardSpec {
             size_bytes: crate::z3660::Z3660_WINDOW_BYTES,
             backing: BoardBacking::Device(slot),
             memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
+            diag_vec: None,
+        }
+    }
+
+    /// Picasso II linear framebuffer aperture (product 11). It is a
+    /// device-backed Zorro II memory-space board and is deliberately not
+    /// linked into Exec's free-memory list: Picasso96 owns the VRAM.
+    pub fn picasso2_vram(slot: usize, size_bytes: usize) -> Self {
+        Self::picasso2_vram_with_serial(slot, size_bytes, PICASSO2_SERIAL, "Picasso II VRAM")
+    }
+
+    /// Picasso II+ linear framebuffer aperture. Its product identity and
+    /// layout match the original board; the serial selects the revision.
+    pub fn picasso2plus_vram(slot: usize, size_bytes: usize) -> Self {
+        Self::picasso2_vram_with_serial(slot, size_bytes, PICASSO2PLUS_SERIAL, "Picasso II+ VRAM")
+    }
+
+    fn picasso2_vram_with_serial(slot: usize, size_bytes: usize, serial: u32, name: &str) -> Self {
+        Self {
+            name: name.into(),
+            version: ZorroVersion::II,
+            manufacturer: PICASSO2_MANUFACTURER_ID,
+            product: PICASSO2_PRODUCT_VRAM,
+            serial,
+            size_bytes,
+            backing: BoardBacking::Device(slot),
+            memlist: false,
+            memory_space: true,
+            chained: true,
+            window: 1,
+            diag_vec: None,
+        }
+    }
+
+    /// Picasso II VGA I/O and monitor-switch aperture (product 12).
+    pub fn picasso2_regs(slot: usize) -> Self {
+        Self::picasso2_regs_with_serial(slot, PICASSO2_SERIAL, "Picasso II registers")
+    }
+
+    /// Picasso II+ VGA I/O and monitor-switch aperture (product 12).
+    pub fn picasso2plus_regs(slot: usize) -> Self {
+        Self::picasso2_regs_with_serial(slot, PICASSO2PLUS_SERIAL, "Picasso II+ registers")
+    }
+
+    fn picasso2_regs_with_serial(slot: usize, serial: u32, name: &str) -> Self {
+        Self {
+            name: name.into(),
+            version: ZorroVersion::II,
+            manufacturer: PICASSO2_MANUFACTURER_ID,
+            product: PICASSO2_PRODUCT_REGS,
+            serial,
+            size_bytes: 0x1_0000,
+            backing: BoardBacking::Device(slot),
+            memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
             diag_vec: None,
         }
     }
 
     fn validate(&self) -> Result<()> {
+        if self.window > 0x0f {
+            bail!(
+                "board {:?}: device window tag must fit in four bits",
+                self.name
+            );
+        }
+        if self.window != 0 && !matches!(self.backing, BoardBacking::Device(_)) {
+            bail!(
+                "board {:?}: only device-backed boards may use a window tag",
+                self.name
+            );
+        }
         match self.version {
             ZorroVersion::II => {
                 if zorro_ii_size_code(self.size_bytes).is_none() {
@@ -458,7 +581,8 @@ impl ZorroChain {
         for &(base, len, idx) in &self.device_regions {
             let off = addr.wrapping_sub(base);
             if u64::from(off) + size as u64 <= u64::from(len) {
-                return Some((self.boards[idx].spec.backing, off));
+                let window = u32::from(self.boards[idx].spec.window) << DEVICE_WINDOW_SHIFT;
+                return Some((self.boards[idx].spec.backing, off | window));
             }
         }
         None
@@ -566,20 +690,16 @@ impl ZorroChain {
         let spec = &self.boards[idx].spec;
         let mut rom = [0u8; AUTOCONFIG_ROM_BYTES];
         let memlist = if spec.memlist { ERTF_MEMLIST } else { 0 };
-        // I/O-style device boards do not claim the memory space flag.
-        let memspace = if spec.backing == BoardBacking::Ram {
-            ERFF_MEMSPACE
-        } else {
-            0
-        };
+        let chained = if spec.chained { ERTF_CHAINEDCONFIG } else { 0 };
+        let memspace = if spec.memory_space { ERFF_MEMSPACE } else { 0 };
         match spec.version {
             ZorroVersion::II => {
-                rom[0] = ERT_ZORROII | memlist | zorro_ii_size_code(spec.size_bytes)?;
+                rom[0] = ERT_ZORROII | memlist | chained | zorro_ii_size_code(spec.size_bytes)?;
                 rom[2] = memspace;
             }
             ZorroVersion::III => {
                 let (code, extended) = zorro_iii_size_bits(spec.size_bytes)?;
-                rom[0] = ERT_ZORROIII | memlist | code;
+                rom[0] = ERT_ZORROIII | memlist | chained | code;
                 rom[2] = memspace | ERFF_ZORRO_III | if extended { ERFF_EXTENDED } else { 0 };
             }
         }
@@ -801,6 +921,9 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
                 size_bytes,
                 backing: BoardBacking::Ram,
                 memlist: raw.memlist.unwrap_or(true),
+                memory_space: true,
+                chained: false,
+                window: 0,
                 diag_vec: None,
             };
             spec.validate()
@@ -829,6 +952,9 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
                 size_bytes,
                 backing: BoardBacking::Device(0),
                 memlist: raw.memlist.unwrap_or(false),
+                memory_space: false,
+                chained: false,
+                window: 0,
                 diag_vec: None,
             };
             spec.validate()
@@ -1347,5 +1473,64 @@ mod tests {
 
         // The chain is exhausted: the config window floats.
         assert_eq!(chain.config_read(AUTOCONFIG_BASE, 1), 0xFF);
+    }
+
+    #[test]
+    fn picasso2_chained_identities_share_one_tagged_device() {
+        let mut chain = chain_with(vec![
+            BoardSpec::picasso2_vram(3, 2 * 1024 * 1024),
+            BoardSpec::picasso2_regs(3),
+        ]);
+
+        // Product 11 is a 2 MB Zorro II memory-space aperture and announces
+        // that another identity belonging to this physical board follows.
+        assert_eq!(chain.config_logical_byte(0, 0), Some(0xce));
+        assert_eq!(chain.config_logical_byte(0, 1), Some(PICASSO2_PRODUCT_VRAM));
+        assert_eq!(chain.config_logical_byte(0, 2), Some(ERFF_MEMSPACE));
+        assert_eq!(chain.config_logical_byte(0, 4), Some(0x08));
+        assert_eq!(chain.config_logical_byte(0, 5), Some(0x77));
+        assert_eq!(chain.config_logical_byte(0, 6), Some(0x00));
+        assert_eq!(chain.config_logical_byte(0, 7), Some(0x02));
+
+        chain.config_write(AUTOCONFIG_BASE + EC_BASEADDRESS_PHYS, 1, 0x20);
+        assert_eq!(
+            chain.device_region_at(0x0020_0123, 1),
+            Some((BoardBacking::Device(3), 1 << DEVICE_WINDOW_SHIFT | 0x123))
+        );
+
+        // Product 12 follows as a normal 64 KB I/O aperture with no tag.
+        assert_eq!(chain.config_logical_byte(1, 0), Some(0xc1));
+        assert_eq!(chain.config_logical_byte(1, 1), Some(PICASSO2_PRODUCT_REGS));
+        assert_eq!(chain.config_logical_byte(1, 2), Some(0));
+        chain.config_write(AUTOCONFIG_BASE + EC_BASEADDRESS_PHYS, 1, 0xe9);
+        assert_eq!(
+            chain.device_region_at(0x00e9_03c4, 2),
+            Some((BoardBacking::Device(3), 0x3c4))
+        );
+    }
+
+    #[test]
+    fn picasso2plus_keeps_products_and_uses_revision_serial() {
+        let specs = [
+            BoardSpec::picasso2plus_vram(4, 1024 * 1024),
+            BoardSpec::picasso2plus_regs(4),
+        ];
+        for (spec, product) in specs
+            .iter()
+            .zip([PICASSO2_PRODUCT_VRAM, PICASSO2_PRODUCT_REGS])
+        {
+            assert_eq!(spec.manufacturer, PICASSO2_MANUFACTURER_ID);
+            assert_eq!(spec.product, product);
+            assert_eq!(spec.serial, PICASSO2PLUS_SERIAL);
+            assert_eq!(spec.backing, BoardBacking::Device(4));
+        }
+
+        let chain = chain_with(specs.into());
+        assert_eq!(chain.config_logical_byte(0, 6), Some(0x00));
+        assert_eq!(chain.config_logical_byte(0, 7), Some(0x10));
+        assert_eq!(chain.config_logical_byte(0, 8), Some(0x00));
+        assert_eq!(chain.config_logical_byte(0, 9), Some(0x00));
+        assert_eq!(chain.config_logical_byte(1, 6), Some(0x00));
+        assert_eq!(chain.config_logical_byte(1, 7), Some(0x10));
     }
 }

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -376,10 +376,11 @@ pub enum BoardDevice {
     A2065(crate::a2065::A2065),
     #[cfg(feature = "wasm-boards")]
     Wasm(crate::wasmboard::WasmBoard),
-    // Appended last: bincode encodes variants by index, so inserting
-    // anywhere else would break save states holding the boards above.
+    // Append-only: bincode encodes variants by index, so inserting a new
+    // board anywhere except the end would renumber saved variants.
     Filesys(crate::filesys::FilesysBoard),
     Z3660(crate::z3660::Z3660),
+    Picasso2(Box<crate::picasso2::Picasso2>),
 }
 
 impl ZorroDevice for BoardDevice {
@@ -392,6 +393,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::read(d, off, size, host),
             BoardDevice::Filesys(d) => ZorroDevice::read(d, off, size, host),
             BoardDevice::Z3660(d) => ZorroDevice::read(d, off, size, host),
+            BoardDevice::Picasso2(d) => ZorroDevice::read(d.as_mut(), off, size, host),
         }
     }
 
@@ -404,6 +406,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::Filesys(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::Z3660(d) => ZorroDevice::write(d, off, size, value, host),
+            BoardDevice::Picasso2(d) => ZorroDevice::write(d.as_mut(), off, size, value, host),
         }
     }
 
@@ -416,6 +419,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::peek_word(d, off),
             BoardDevice::Filesys(d) => ZorroDevice::peek_word(d, off),
             BoardDevice::Z3660(d) => ZorroDevice::peek_word(d, off),
+            BoardDevice::Picasso2(d) => ZorroDevice::peek_word(d.as_ref(), off),
         }
     }
 
@@ -428,6 +432,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::tick(d, cck, host),
             BoardDevice::Filesys(d) => ZorroDevice::tick(d, cck, host),
             BoardDevice::Z3660(d) => ZorroDevice::tick(d, cck, host),
+            BoardDevice::Picasso2(d) => ZorroDevice::tick(d.as_mut(), cck, host),
         }
     }
 
@@ -440,6 +445,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::int2_line(d),
             BoardDevice::Filesys(d) => ZorroDevice::int2_line(d),
             BoardDevice::Z3660(d) => ZorroDevice::int2_line(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::int2_line(d.as_ref()),
         }
     }
 
@@ -452,6 +458,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::int6_line(d),
             BoardDevice::Filesys(d) => ZorroDevice::int6_line(d),
             BoardDevice::Z3660(d) => ZorroDevice::int6_line(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::int6_line(d.as_ref()),
         }
     }
 
@@ -464,6 +471,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::is_idle(d),
             BoardDevice::Filesys(d) => ZorroDevice::is_idle(d),
             BoardDevice::Z3660(d) => ZorroDevice::is_idle(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::is_idle(d.as_ref()),
         }
     }
 
@@ -476,6 +484,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::next_event_cck(d),
             BoardDevice::Filesys(d) => ZorroDevice::next_event_cck(d),
             BoardDevice::Z3660(d) => ZorroDevice::next_event_cck(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::next_event_cck(d.as_ref()),
         }
     }
 
@@ -488,6 +497,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::take_activity(d),
             BoardDevice::Filesys(d) => ZorroDevice::take_activity(d),
             BoardDevice::Z3660(d) => ZorroDevice::take_activity(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::take_activity(d.as_mut()),
         }
     }
 
@@ -500,6 +510,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::reset(d),
             BoardDevice::Filesys(d) => ZorroDevice::reset(d),
             BoardDevice::Z3660(d) => ZorroDevice::reset(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::reset(d.as_mut()),
         }
     }
 
@@ -512,6 +523,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Wasm(d) => ZorroDevice::kind(d),
             BoardDevice::Filesys(d) => ZorroDevice::kind(d),
             BoardDevice::Z3660(d) => ZorroDevice::kind(d),
+            BoardDevice::Picasso2(d) => ZorroDevice::kind(d.as_ref()),
         }
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -105,10 +105,10 @@ baselines to maintain.
 | `dblpal_boot_presents_full_programmable_scan` | `KICK31.ROM`, `wb31-dblpal.adf` |
 | `diagrom_menu_preserves_left_margin_text_columns` | `diagrom.rom` |
 | `mmu_library_boot_and_muforce_hits_*` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A1200)[!].rom`, `mmu-test.adf`, `mmu-libs.adf` |
-| `picasso2_workbench_opens_640x480x8` | `KICK31.ROM`, `p96-picasso2.hdf` (WB3.1 + Picasso96, default 640x480x8 screen) |
-| `picasso2_workbench_opens_640x480x16` | `KICK31.ROM`, `p96-picasso2-16.hdf` (same, default 640x480x16 screen) |
-| `picasso2plus_workbench_opens_with_gd5428_revision` | `KICK31.ROM`, `p96-picasso2.hdf` (same installation booted against the Picasso II+ identity) |
-| `picasso2_p96cts_reports_all_modes_clean` | `KICK31.ROM`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
+| `picasso2_workbench_opens_640x480x8` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2.hdf` (WB3.1 + Picasso96, default 640x480x8 screen) |
+| `picasso2_workbench_opens_640x480x16` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-16.hdf` (same, default 640x480x16 screen) |
+| `picasso2plus_workbench_opens_with_gd5428_revision` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2.hdf` (same installation booted against the Picasso II+ identity) |
+| `picasso2_p96cts_reports_all_modes_clean` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
 
 ## Obtaining the assets legally
 
@@ -129,7 +129,10 @@ baselines to maintain.
   translation trees on the 030/040, lazy faults through the resumable
   bus-fault frames, and MuForce hit reporting.
 - **Picasso II/II+ HDFs** are local Workbench 3.1 installations with Picasso96's
-  `PicassoII.card` driver. The `-cts` image's startup sequence runs p96cts for
+  `PicassoII.card` driver (Picasso96 is freeware, from Aminet
+  `driver/gfx/Picasso96.lha`). The boots use an A4000 over motherboard IDE
+  because the generic `KICK31.ROM` has no big-box SCSI/IDE driver. The
+  `-cts` image's startup sequence runs p96cts for
   its 8-, 16-, and 24-bit mode set and writes `PASS` to
   `P96OUT:p96cts.result`; on failure it leaves the suite's diff images in that
   host-mounted output directory.

--- a/tests/README.md
+++ b/tests/README.md
@@ -105,6 +105,10 @@ baselines to maintain.
 | `dblpal_boot_presents_full_programmable_scan` | `KICK31.ROM`, `wb31-dblpal.adf` |
 | `diagrom_menu_preserves_left_margin_text_columns` | `diagrom.rom` |
 | `mmu_library_boot_and_muforce_hits_*` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A1200)[!].rom`, `mmu-test.adf`, `mmu-libs.adf` |
+| `picasso2_workbench_opens_640x480x8` | `KICK31.ROM`, `p96-picasso2.hdf` (WB3.1 + Picasso96, default 640x480x8 screen) |
+| `picasso2_workbench_opens_640x480x16` | `KICK31.ROM`, `p96-picasso2-16.hdf` (same, default 640x480x16 screen) |
+| `picasso2plus_workbench_opens_with_gd5428_revision` | `KICK31.ROM`, `p96-picasso2.hdf` (same installation booted against the Picasso II+ identity) |
+| `picasso2_p96cts_reports_all_modes_clean` | `KICK31.ROM`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
 
 ## Obtaining the assets legally
 
@@ -124,6 +128,11 @@ baselines to maintain.
   the issue #90 regression: mmu.library building and enabling real
   translation trees on the 030/040, lazy faults through the resumable
   bus-fault frames, and MuForce hit reporting.
+- **Picasso II/II+ HDFs** are local Workbench 3.1 installations with Picasso96's
+  `PicassoII.card` driver. The `-cts` image's startup sequence runs p96cts for
+  its 8-, 16-, and 24-bit mode set and writes `PASS` to
+  `P96OUT:p96cts.result`; on failure it leaves the suite's diff images in that
+  host-mounted output directory.
 
 The `*.U12` / `*.U13`-style files in the repo root are split EPROM dumps for
 expansion-board ROMs (e.g. the A2091 SCSI boot ROM) used by other ignored

--- a/tests/picasso2.rs
+++ b/tests/picasso2.rs
@@ -58,13 +58,18 @@ fn asset_dir() -> PathBuf {
     }
 }
 
+/// The generic A500/A2000 Kickstart 3.1 has no A3000/A4000 SCSI driver, so
+/// these boots use an A4000 (a big-box machine with Zorro slots) with its own
+/// ROM and the motherboard IDE port the HDF images were installed against.
+const KICK31_A4000: &str = "Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom";
+
 fn run_picasso_hdf(
     name: &str,
     hdf: &str,
     card: &str,
 ) -> Result<Option<(Image, String)>, Box<dyn std::error::Error>> {
     let assets = asset_dir();
-    let missing: Vec<_> = ["KICK31.ROM", hdf]
+    let missing: Vec<_> = [KICK31_A4000, hdf]
         .into_iter()
         .filter(|file| !assets.join(file).is_file())
         .collect();
@@ -79,18 +84,17 @@ fn run_picasso_hdf(
     std::fs::write(
         &config,
         format!(
-            r#"rom = "KICK31.ROM"
+            r#"rom = "{KICK31_A4000}"
 
 [machine]
-profile = "A3000"
+profile = "A4000"
 
 [rtg]
 card = "{card}"
 vram = "2M"
 
-[scsi]
-controller = "a3000"
-unit0 = "{hdf}"
+[ide]
+master = "{hdf}"
 "#,
         ),
     )?;
@@ -183,7 +187,7 @@ fn picasso2plus_workbench_opens_with_gd5428_revision() -> Result<(), Box<dyn std
 fn picasso2_p96cts_reports_all_modes_clean() -> Result<(), Box<dyn std::error::Error>> {
     let assets = asset_dir();
     let hdf = "p96-picasso2-cts.hdf";
-    let missing: Vec<_> = ["KICK31.ROM", hdf]
+    let missing: Vec<_> = [KICK31_A4000, hdf]
         .into_iter()
         .filter(|file| !assets.join(file).is_file())
         .collect();
@@ -201,18 +205,17 @@ fn picasso2_p96cts_reports_all_modes_clean() -> Result<(), Box<dyn std::error::E
     std::fs::write(
         &config,
         format!(
-            r#"rom = "KICK31.ROM"
+            r#"rom = "{KICK31_A4000}"
 
 [machine]
-profile = "A3000"
+profile = "A4000"
 
 [rtg]
 card = "picasso2"
 vram = "2M"
 
-[scsi]
-controller = "a3000"
-unit0 = "{hdf}"
+[ide]
+master = "{hdf}"
 
 [[filesys]]
 path = {output_toml}

--- a/tests/picasso2.rs
+++ b/tests/picasso2.rs
@@ -1,0 +1,264 @@
+//! Asset-gated Picasso96 boot checks for the Picasso II/II+ hardware model.
+//!
+//! The HDFs are local licensed Workbench/Picasso96 installations and are
+//! never committed. See tests/README.md for lookup and setup conventions.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[allow(dead_code)]
+#[path = "../src/envcfg.rs"]
+mod envcfg;
+
+struct Image {
+    width: u32,
+    height: u32,
+    rgba: Vec<u8>,
+}
+
+impl Image {
+    fn load(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let decoder = png::Decoder::new(File::open(path)?);
+        let mut reader = decoder.read_info()?;
+        let mut bytes = vec![0; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut bytes)?;
+        assert_eq!(info.color_type, png::ColorType::Rgba);
+        assert_eq!(info.bit_depth, png::BitDepth::Eight);
+        Ok(Self {
+            width: info.width,
+            height: info.height,
+            rgba: bytes[..info.buffer_size()].to_vec(),
+        })
+    }
+
+    fn distinct_colors(&self) -> usize {
+        self.rgba
+            .chunks_exact(4)
+            .map(|pixel| [pixel[0], pixel[1], pixel[2], pixel[3]])
+            .collect::<HashSet<_>>()
+            .len()
+    }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn asset_dir() -> PathBuf {
+    if let Some(dir) = envcfg::var_os("COPPERLINE_TEST_ASSETS") {
+        return PathBuf::from(dir);
+    }
+    let local = repo_root().join("test-assets");
+    if local.is_dir() {
+        local
+    } else {
+        repo_root()
+    }
+}
+
+fn run_picasso_hdf(
+    name: &str,
+    hdf: &str,
+    card: &str,
+) -> Result<Option<(Image, String)>, Box<dyn std::error::Error>> {
+    let assets = asset_dir();
+    let missing: Vec<_> = ["KICK31.ROM", hdf]
+        .into_iter()
+        .filter(|file| !assets.join(file).is_file())
+        .collect();
+    if !missing.is_empty() {
+        eprintln!("skipping Picasso II/II+ integration test; missing files: {missing:?}");
+        return Ok(None);
+    }
+
+    let stem = format!("copperline-picasso2-{name}-{}", std::process::id());
+    let config = std::env::temp_dir().join(format!("{stem}.toml"));
+    let screenshot = std::env::temp_dir().join(format!("{stem}.png"));
+    std::fs::write(
+        &config,
+        format!(
+            r#"rom = "KICK31.ROM"
+
+[machine]
+profile = "A3000"
+
+[rtg]
+card = "{card}"
+vram = "2M"
+
+[scsi]
+controller = "a3000"
+unit0 = "{hdf}"
+"#,
+        ),
+    )?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
+        .current_dir(&assets)
+        .env(
+            "RUST_LOG",
+            "copperline=warn,copperline::picasso2=info,copperline::emulator=info",
+        )
+        .env("COPPERLINE_DIAG_PICASSO", "1")
+        .arg("--config")
+        .arg(&config)
+        .arg("--noaudio")
+        .arg("--screenshot-after")
+        .arg("120")
+        .arg(&screenshot)
+        .output()?;
+    let _ = std::fs::remove_file(config);
+    assert!(
+        output.status.success(),
+        "Copperline failed: {}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let image = Image::load(&screenshot)?;
+    let _ = std::fs::remove_file(screenshot);
+    let log = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok(Some((image, log)))
+}
+
+fn assert_workbench_frame(image: &Image) {
+    assert_eq!(image.width, 716, "headless RTG path scales to FB_WIDTH");
+    assert_eq!(image.height, 480, "expected a 640x480 Picasso screen");
+    assert!(
+        image.distinct_colors() >= 8,
+        "expected a nonblank Picasso96 Workbench frame"
+    );
+}
+
+#[test]
+#[ignore = "runs the emulator and requires a local Kickstart/Picasso96 HDF"]
+fn picasso2_workbench_opens_640x480x8() -> Result<(), Box<dyn std::error::Error>> {
+    let Some((image, log)) = run_picasso_hdf("clut8", "p96-picasso2.hdf", "picasso2")? else {
+        return Ok(());
+    };
+    assert_workbench_frame(&image);
+    assert!(
+        log.contains("Clut8"),
+        "diagnostic trace never decoded 8-bit mode"
+    );
+    Ok(())
+}
+
+#[test]
+#[ignore = "runs the emulator and requires a local truecolour Picasso96 HDF"]
+fn picasso2_workbench_opens_640x480x16() -> Result<(), Box<dyn std::error::Error>> {
+    let Some((image, log)) = run_picasso_hdf("rgb565", "p96-picasso2-16.hdf", "picasso2")? else {
+        return Ok(());
+    };
+    assert_workbench_frame(&image);
+    assert!(
+        log.contains("Rgb565"),
+        "diagnostic trace never decoded 16-bit mode"
+    );
+    Ok(())
+}
+
+#[test]
+#[ignore = "runs the emulator and requires a local Picasso96 HDF"]
+fn picasso2plus_workbench_opens_with_gd5428_revision() -> Result<(), Box<dyn std::error::Error>> {
+    let Some((image, log)) = run_picasso_hdf("plus-clut8", "p96-picasso2.hdf", "picasso2plus")?
+    else {
+        return Ok(());
+    };
+    assert_workbench_frame(&image);
+    assert!(
+        log.contains("Clut8"),
+        "diagnostic trace never decoded the II+ screen"
+    );
+    assert!(
+        log.contains("CL-GD5428 RTG board"),
+        "emulator did not instantiate the II+ controller revision"
+    );
+    Ok(())
+}
+
+#[test]
+#[ignore = "runs guest-side p96cts and requires its prepared local HDF"]
+fn picasso2_p96cts_reports_all_modes_clean() -> Result<(), Box<dyn std::error::Error>> {
+    let assets = asset_dir();
+    let hdf = "p96-picasso2-cts.hdf";
+    let missing: Vec<_> = ["KICK31.ROM", hdf]
+        .into_iter()
+        .filter(|file| !assets.join(file).is_file())
+        .collect();
+    if !missing.is_empty() {
+        eprintln!("skipping Picasso II p96cts; missing files: {missing:?}");
+        return Ok(());
+    }
+
+    let stem = format!("copperline-picasso2-p96cts-{}", std::process::id());
+    let output_dir = std::env::temp_dir().join(&stem);
+    let config = std::env::temp_dir().join(format!("{stem}.toml"));
+    let screenshot = std::env::temp_dir().join(format!("{stem}.png"));
+    std::fs::create_dir_all(&output_dir)?;
+    let output_toml = toml::Value::String(output_dir.to_string_lossy().into_owned()).to_string();
+    std::fs::write(
+        &config,
+        format!(
+            r#"rom = "KICK31.ROM"
+
+[machine]
+profile = "A3000"
+
+[rtg]
+card = "picasso2"
+vram = "2M"
+
+[scsi]
+controller = "a3000"
+unit0 = "{hdf}"
+
+[[filesys]]
+path = {output_toml}
+volume = "P96OUT"
+"#,
+        ),
+    )?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
+        .current_dir(&assets)
+        .env("RUST_LOG", "copperline=warn")
+        .arg("--config")
+        .arg(&config)
+        .arg("--noaudio")
+        .arg("--screenshot-after")
+        .arg("600")
+        .arg(&screenshot)
+        .output()?;
+    let _ = std::fs::remove_file(config);
+    let _ = std::fs::remove_file(screenshot);
+    assert!(
+        output.status.success(),
+        "Copperline failed: {}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let marker = output_dir.join("p96cts.result");
+    let result = std::fs::read_to_string(&marker).unwrap_or_else(|error| {
+        panic!(
+            "p96cts did not write {}: {error}; output directory contains {:?}",
+            marker.display(),
+            std::fs::read_dir(&output_dir)
+                .ok()
+                .into_iter()
+                .flatten()
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name())
+                .collect::<Vec<_>>()
+        )
+    });
+    assert_eq!(
+        result.trim(),
+        "PASS",
+        "p96cts reported failures in {output_dir:?}"
+    );
+    let _ = std::fs::remove_dir_all(output_dir);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add Village Tronic Picasso II and Picasso II+ as paired Zorro II autoconfig functions with configurable 1/2 MiB VRAM
- model the CL-GD5426/5428 register paths, packed-pixel scanout, DAC, hardware cursor, BitBLT engine, monitor switch, and II+ INT2 vertical blank
- integrate configuration, launcher selection, presentation, save states, examples, architecture documentation, and asset-gated Picasso96 coverage

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --locked` (2,175 passed; hardware/asset-gated tests ignored as expected)
- `cargo build --release --locked`
- release headless AROS run discovered products 11 and 12 with the II+ serial `$00100000`
- save at 5 seconds and resume to 6 seconds produced byte-identical screenshots

The Picasso96 Workbench and p96cts tests compile but remain ignored unless the local licensed HDF assets described in `tests/README.md` are available.
