### PR TITLE
control: preserve scheduled input across sessions

### DIFF
--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -336,7 +336,14 @@ red/fire1, blue/fire2, green, yellow, play, rwd, ffw}` (held state,
 replaced wholesale; port defaults to 2), `input.analogue {port?, x, y}`
 (analogue stick/paddle position, 0-255 per axis, the count POTxDAT
 latches; port defaults to 2). Events drive the named port's electrical
-lines whatever device is configured there.
+lines whatever device is configured there. Scheduled input belongs to
+the emulated machine, not to the TCP connection that submitted it: it
+survives client disconnects and fires when a later connection (or the
+windowed emulator) advances past its timestamp. A timestamp already in
+the past is accepted and fires at the next input drain. A successful
+`state.load`, or either warm or cold `machine.reset`, clears all pending
+scheduled input because those operations replace the timeline it was
+aimed at.
 
 `input.mouse_to {x, y, port?, tolerance?, max_frames?}` puts the guest's
 pointer at an absolute position instead: `x` and `y` are presented pixels
@@ -385,7 +392,8 @@ Diagnostic captures: `trace.start {path?, max_lines?}`, `trace.status`,
 `waveform.status`, `waveform.stop`.
 
 State and capture: `state.save {path}`, `state.load {path}` (re-arms
-the reverse-debug ring on the loaded timeline), `capture.screenshot
+the reverse-debug ring on the loaded timeline and clears pending
+scheduled input), `capture.screenshot
 {path?}` (raw framebuffer PNG, 716 pixels wide -- 1432 for a
 programmable super-hi-res scan's 35 ns canvas; with an active RTG
 screen it is the board frame downsampled to 716 at the board's
@@ -398,7 +406,8 @@ motion changing the answer; the reply echoes the rectangle and reports
 the frame's own `width`/`height`, and a rectangle that does not fit
 inside the current frame is `-32602` rather than a silent clamp --
 frame geometry moves with the beam standard and the canvas scale),
-`machine.reset {kind: "warm"|"cold"}`.
+`machine.reset {kind: "warm"|"cold"}` (also clears pending scheduled
+input).
 
 Notifications have no `id`. The subscribed `event.frame`, `event.serial`,
 `event.interrupt`, and `event.media` streams work in both server modes.

--- a/src/chipset/keyboard.rs
+++ b/src/chipset/keyboard.rs
@@ -340,7 +340,8 @@ impl KeyboardMcu {
         std::mem::take(&mut self.system_reset_request)
     }
 
-    fn is_held(&self, rawkey: u8) -> bool {
+    /// Whether the keyboard matrix currently sees `rawkey` held down.
+    pub(crate) fn is_held(&self, rawkey: u8) -> bool {
         let idx = (rawkey & 0x7F) as usize;
         self.held[idx / 64] & (1 << (idx % 64)) != 0
     }

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -18,7 +18,7 @@ use super::exec::{
     CCK_FINE_WINDOW, RUN_BUDGET,
 };
 use super::proto::{self, AuthGate, CtlError, Gate, MAX_LINE_BYTES};
-use super::session::SessionCtx;
+use super::session::{MachineInputState, SessionCtx};
 use super::Config;
 use crate::debugger::DebugStop;
 use crate::emulator::Emulator;
@@ -49,16 +49,17 @@ pub fn run(mut emu: Emulator, config: Config) -> Result<()> {
     emu.debug_ensure_time_travel_anchor()?;
     emu.machine.ui_set_pc_history_enabled(true);
 
-    let mut recorder = config
+    let recorder = config
         .record_input
         .as_ref()
         .map(|_| InputRecorder::new(emu.bus().emulated_seconds()));
+    let mut input = MachineInputState::new(recorder);
 
     loop {
         let (stream, peer) = listener.accept().context("accepting control connection")?;
         log::info!("control: connection from {peer}");
         stream.set_nodelay(true).ok();
-        let mut session = Session::new(emu, stream, &token, &config, recorder.take());
+        let mut session = Session::new(emu, stream, &token, &config, input);
         let end = match session.serve() {
             Ok(end) => end,
             Err(e) => {
@@ -67,8 +68,8 @@ pub fn run(mut emu: Emulator, config: Config) -> Result<()> {
             }
         };
         session.teardown();
-        recorder = session.ctx.recorder.take();
         emu = session.emu;
+        input = session.input;
         match end {
             SessionEnd::Detached => {
                 log::info!("control: client detached; machine paused, listening again");
@@ -76,7 +77,7 @@ pub fn run(mut emu: Emulator, config: Config) -> Result<()> {
             SessionEnd::Killed => break,
         }
     }
-    if let (Some(rec), Some(path)) = (recorder, config.record_input.as_ref()) {
+    if let (Some(rec), Some(path)) = (input.recorder, config.record_input.as_ref()) {
         let events = rec.events_recorded();
         std::fs::write(path, rec.finish())
             .with_context(|| format!("writing input recording {}", path.display()))?;
@@ -218,6 +219,7 @@ struct Session {
     writer: TcpStream,
     gate: AuthGate,
     ctx: SessionCtx,
+    input: MachineInputState,
     reverse_budget_mb: usize,
     reverse_interval_frames: u64,
 }
@@ -228,20 +230,19 @@ impl Session {
         stream: TcpStream,
         token: &str,
         config: &Config,
-        recorder: Option<InputRecorder>,
+        input: MachineInputState,
     ) -> Self {
         let reader = LineReader::new(stream.try_clone().expect("cloning control stream"));
         stream
             .set_write_timeout(Some(Duration::from_millis(250)))
             .ok();
-        let mut ctx = SessionCtx::new();
-        ctx.recorder = recorder;
         Self {
             emu,
             reader,
             writer: stream,
             gate: AuthGate::new(token.to_string()),
-            ctx,
+            ctx: SessionCtx::new(),
+            input,
             reverse_budget_mb: config.reverse_budget_mb,
             reverse_interval_frames: config.reverse_interval_frames,
         }
@@ -348,11 +349,11 @@ impl Session {
                 let now = self.emu.bus().emulated_seconds();
                 let (immediate, later) = cmd.expand(now);
                 for action in immediate {
-                    self.ctx.inject_now(&mut self.emu, action);
+                    self.input.inject_now(&mut self.emu, action);
                 }
                 let scheduled = later.len();
                 for entry in later {
-                    self.ctx.schedule(entry.at_seconds, entry.action);
+                    self.input.schedule(entry.at_seconds, entry.action);
                 }
                 self.write(&proto::ok_line(
                     &id,
@@ -367,7 +368,7 @@ impl Session {
                 tolerance,
                 max_frames,
             } => {
-                let ctx = &mut self.ctx;
+                let input = &mut self.input;
                 let reply = match exec::mouse_to(
                     &mut self.emu,
                     port,
@@ -375,7 +376,7 @@ impl Session {
                     tolerance,
                     max_frames,
                     |emu, action| {
-                        ctx.inject_now(emu, action);
+                        input.inject_now(emu, action);
                     },
                 ) {
                     Ok(value) => proto::ok_line(&id, value),
@@ -457,6 +458,7 @@ impl Session {
             HostOp::StateLoad { path } => {
                 let reply = match self.emu.load_state(&path) {
                     Ok(outcome) => {
+                        self.input.clear_scheduled();
                         // The snapshot ring's positions belong to the old
                         // timeline; re-arm on the loaded one.
                         self.emu.enable_time_travel(
@@ -485,7 +487,10 @@ impl Session {
                     self.emu.power_on_reset()
                 };
                 let reply = match result {
-                    Ok(()) => proto::ok_line(&id, json!({})),
+                    Ok(()) => {
+                        self.input.clear_scheduled();
+                        proto::ok_line(&id, json!({}))
+                    }
                     Err(e) => proto::err_line(&id, &CtlError::internal(format!("{e:#}"))),
                 };
                 self.write(&reply)?;
@@ -498,7 +503,7 @@ impl Session {
     /// reverse replay and record it in the input recording.
     fn note_media_change(&mut self, drive: usize, inserted: Option<&std::path::Path>) {
         self.emu.tt_note_input(ReplayAction::DiskChange);
-        if let (Some(rec), Some(path)) = (self.ctx.recorder.as_mut(), inserted) {
+        if let (Some(rec), Some(path)) = (self.input.recorder.as_mut(), inserted) {
             let secs = self.emu.bus().emulated_seconds();
             rec.record_disk_insert(drive, path, secs);
         }
@@ -565,7 +570,7 @@ impl Session {
             ResumeKind::Step { n } => {
                 for _ in 0..*n {
                     self.emu.debug_step_for_gdb(&mut cpu_idle)?;
-                    self.ctx.apply_due_scheduled(&mut self.emu);
+                    self.input.apply_due_scheduled(&mut self.emu);
                     self.emit_events()?;
                     if let Some((reason, detail)) = self.take_stop() {
                         return stop(reason, detail);
@@ -601,7 +606,7 @@ impl Session {
             ResumeKind::StepFrame { n } => {
                 for _ in 0..*n {
                     self.emu.step_frame()?;
-                    self.ctx.apply_due_scheduled(&mut self.emu);
+                    self.input.apply_due_scheduled(&mut self.emu);
                     self.emit_events()?;
                     if let Some((reason, detail)) = self.take_stop() {
                         return stop(reason, detail);
@@ -711,7 +716,7 @@ impl Session {
                     self.emu.step_frame()?;
                 }
             }
-            self.ctx.apply_due_scheduled(&mut self.emu);
+            self.input.apply_due_scheduled(&mut self.emu);
             self.emit_events()?;
 
             if self.emu.machine.cpu_double_faulted() {
@@ -829,11 +834,11 @@ impl Session {
                     let now = self.emu.bus().emulated_seconds();
                     let (immediate, later) = cmd.expand(now);
                     for action in immediate {
-                        self.ctx.inject_now(&mut self.emu, action);
+                        self.input.inject_now(&mut self.emu, action);
                     }
                     let scheduled = later.len();
                     for entry in later {
-                        self.ctx.schedule(entry.at_seconds, entry.action);
+                        self.input.schedule(entry.at_seconds, entry.action);
                     }
                     self.write(&proto::ok_line(
                         &req.id,
@@ -970,23 +975,22 @@ mod tests {
         }
     }
 
-    /// Run one session against the test emulator: the client closure
-    /// drives it from a spawned thread while the session runs on the
-    /// test thread (the gdbstub `run_session` pattern). Time travel is
-    /// armed like `run()` arms it. Returns the session context and how
-    /// it ended, for post-conditions. The session (and its sockets) is
-    /// dropped before joining the client, exactly as `run()`'s serve
-    /// loop drops it per iteration -- a client waiting for EOF after a
-    /// server-side close would otherwise deadlock the harness.
-    fn run_session(
-        recorder: Option<InputRecorder>,
-        client_fn: impl FnOnce(&mut Client) + Send + 'static,
-    ) -> (SessionCtx, SessionEnd) {
+    fn control_test_emulator() -> Emulator {
         let mut emu = test_emulator();
         emu.enable_time_travel(64, 1);
         emu.debug_ensure_time_travel_anchor().unwrap();
         emu.machine.ui_set_pc_history_enabled(true);
+        emu
+    }
 
+    /// Run one connection against an existing machine and its
+    /// machine-lifetime input state. This is the ownership hand-off the
+    /// real accept loop performs after every disconnect.
+    fn run_machine_session(
+        emu: Emulator,
+        input: MachineInputState,
+        client_fn: impl FnOnce(&mut Client) + Send + 'static,
+    ) -> (Emulator, MachineInputState, SessionCtx, SessionEnd) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = std::thread::spawn(move || {
@@ -995,14 +999,16 @@ mod tests {
         });
         let (stream, _) = listener.accept().unwrap();
         let config = Config::new(":0".into());
-        let mut session = Session::new(emu, stream, TOKEN, &config, recorder);
+        let mut session = Session::new(emu, stream, TOKEN, &config, input);
         let end = session.serve().expect("session should not error");
         session.teardown();
         // Close the session's stream handles NOW: fields matched by
         // `..` in a partial-move destructure live until end of scope,
         // which would be after the join below.
         let Session {
+            emu,
             ctx,
+            input,
             reader,
             writer,
             ..
@@ -1010,7 +1016,21 @@ mod tests {
         drop(reader);
         drop(writer);
         handle.join().expect("client assertions failed");
-        (ctx, end)
+        (emu, input, ctx, end)
+    }
+
+    /// Run one session against a fresh test machine. Time travel is
+    /// armed like `run()` arms it.
+    fn run_session(
+        recorder: Option<InputRecorder>,
+        client_fn: impl FnOnce(&mut Client) + Send + 'static,
+    ) -> (SessionCtx, MachineInputState, SessionEnd) {
+        let (_, input, ctx, end) = run_machine_session(
+            control_test_emulator(),
+            MachineInputState::new(recorder),
+            client_fn,
+        );
+        (ctx, input, end)
     }
 
     fn scratch_path(name: &str) -> std::path::PathBuf {
@@ -1041,7 +1061,7 @@ mod tests {
 
     #[test]
     fn wrong_token_gets_one_error_then_close() {
-        let (_, end) = run_session(None, |c| {
+        let (_, _, end) = run_session(None, |c| {
             let refused = c.call("auth", json!({"token": "wrong"}));
             assert_eq!(refused["error"]["code"], proto::AUTH_FAILED);
             // The server drops the connection after the reply.
@@ -1251,7 +1271,7 @@ mod tests {
 
     #[test]
     fn input_key_is_journaled_and_stamped() {
-        let (ctx, _) = run_session(Some(InputRecorder::new(0.0)), |c| {
+        let (_, mut input, _) = run_session(Some(InputRecorder::new(0.0)), |c| {
             c.auth();
             c.result("step_frame", json!({"n": 1}));
             let applied = c.result("input.key", json!({"rawkey": 0x45, "action": "press"}));
@@ -1261,10 +1281,156 @@ mod tests {
             let tap = c.result("input.key", json!({"rawkey": 0x20, "hold_ms": 50}));
             assert_eq!(tap["scheduled"], 1);
         });
-        let script = ctx.recorder.map(|r| r.finish()).unwrap_or_default();
+        let script = input
+            .recorder
+            .take()
+            .map(|r| r.finish())
+            .unwrap_or_default();
         assert!(
             script.contains("0x45"),
             "recording carries the injected key: {script}"
+        );
+    }
+
+    #[test]
+    fn tap_release_survives_connection_turnover() {
+        let emu = control_test_emulator();
+        let input = MachineInputState::new(Some(InputRecorder::new(0.0)));
+        let (emu, input, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            let tap = c.result(
+                "input.key",
+                json!({"rawkey": 0x12, "action": "tap", "hold_ms": 80}),
+            );
+            assert_eq!(tap["scheduled"], 1);
+        });
+        assert!(
+            emu.bus().keyboard.is_held(0x12),
+            "the first connection applied the down transition"
+        );
+
+        let (emu, mut input, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            c.result("run_until", json!({"seconds": 0.12}));
+        });
+
+        assert!(
+            !emu.bus().keyboard.is_held(0x12),
+            "the next connection must deliver the deferred up transition"
+        );
+        let script = input.recorder.take().unwrap().finish();
+        let tap_line = script
+            .lines()
+            .find(|line| line.contains("0x12"))
+            .expect("the completed tap should be journaled");
+        let recorded_hold: u32 = tap_line.split_whitespace().last().unwrap().parse().unwrap();
+        assert!(
+            (80..=100).contains(&recorded_hold),
+            "the release should land within one PAL frame of 80 ms: {script}"
+        );
+    }
+
+    #[test]
+    fn future_input_from_a_closed_session_fires_under_run_until() {
+        let emu = control_test_emulator();
+        let input = MachineInputState::default();
+        let (emu, input, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            let scheduled = c.result(
+                "input.key",
+                json!({"rawkey": 0x21, "action": "press", "at_seconds": 0.03}),
+            );
+            assert_eq!(scheduled["scheduled"], 1);
+        });
+
+        let (emu, _, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            c.result("run_until", json!({"seconds": 0.04}));
+        });
+
+        assert!(emu.bus().keyboard.is_held(0x21));
+        assert!(
+            emu.bus().emulated_seconds() <= 0.051,
+            "scheduled input should land within one PAL frame of its target: {}",
+            emu.bus().emulated_seconds()
+        );
+    }
+
+    #[test]
+    fn future_input_from_a_closed_session_fires_under_continue() {
+        let emu = control_test_emulator();
+        let input = MachineInputState::default();
+        let (emu, input, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            let scheduled = c.result(
+                "input.key",
+                json!({"rawkey": 0x22, "action": "press", "at_seconds": 0.001}),
+            );
+            assert_eq!(scheduled["scheduled"], 1);
+        });
+
+        let (emu, _, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            c.result("break.add", json!({"kind": "beam", "vpos": 150}));
+            let stop = c.result("continue", json!({}));
+            assert_eq!(stop["reason"], "beam_trap");
+        });
+
+        assert!(emu.bus().keyboard.is_held(0x22));
+        assert!(
+            emu.bus().emulated_frames() <= 1,
+            "the event should be applied in the first continue quantum"
+        );
+    }
+
+    #[test]
+    fn machine_reset_clears_future_input() {
+        let (emu, input, _, _) =
+            run_machine_session(control_test_emulator(), MachineInputState::default(), |c| {
+                c.auth();
+                c.result(
+                    "input.key",
+                    json!({"rawkey": 0x23, "action": "press", "at_seconds": 0.04}),
+                );
+                c.result("machine.reset", json!({"kind": "warm"}));
+                c.result("run_until", json!({"seconds": 0.10}));
+            });
+        assert_eq!(input.pending_count(), 0);
+        assert!(
+            !emu.bus().keyboard.is_held(0x23),
+            "reset must discard input aimed at the replaced timeline"
+        );
+    }
+
+    #[test]
+    fn state_load_clears_future_input() {
+        let path = scratch_path("scheduled-input-load.clstate");
+        let path_for_client = path.clone();
+        let (emu, input, _, _) = run_machine_session(
+            control_test_emulator(),
+            MachineInputState::default(),
+            move |c| {
+                c.auth();
+                c.result(
+                    "state.save",
+                    json!({"path": path_for_client.display().to_string()}),
+                );
+                c.result(
+                    "input.key",
+                    json!({"rawkey": 0x24, "action": "press", "at_seconds": 0.04}),
+                );
+                c.result(
+                    "state.load",
+                    json!({"path": path_for_client.display().to_string()}),
+                );
+                c.result("run_until", json!({"seconds": 0.10}));
+            },
+        );
+        std::fs::remove_file(path).ok();
+        assert_eq!(input.pending_count(), 0);
+        assert!(
+            !emu.bus().keyboard.is_held(0x24),
+            "state load must discard input aimed at the replaced timeline"
         );
     }
 
@@ -1358,7 +1524,7 @@ mod tests {
 
     #[test]
     fn shutdown_ends_the_server() {
-        let (_, end) = run_session(None, |c| {
+        let (_, _, end) = run_session(None, |c| {
             c.auth();
             c.result("shutdown", json!({}));
         });

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Per-connection session state shared by both control-server modes:
-//! server-assigned breakpoint ids over the machine's interactive break
-//! store, input scheduled on the emulated timeline, and the journaling
-//! hooks that keep a control-driven session deterministically
-//! replayable (`tt_note_input` for reverse replay, `InputRecorder` for
-//! `--record-input`).
+//! Control-server state shared by both server modes. [`SessionCtx`] is
+//! per connection (breakpoint ids and observations), while
+//! [`MachineInputState`] follows the emulated machine across connection
+//! turnover and owns deferred input plus the headless recording hook.
 
 use crate::debugger::{BreakCond, WatchSource};
 use crate::emulator::Emulator;
@@ -85,19 +83,85 @@ pub struct ScheduledInput {
     pub action: InputAction,
 }
 
+/// Input state whose lifetime follows the emulated machine rather than
+/// any one control connection.
+pub struct MachineInputState {
+    /// Input waiting for its emulated time, sorted earliest first.
+    scheduled: Vec<ScheduledInput>,
+    /// Journaling recorder owned by the headless driver
+    /// (`--record-input`). The windowed path journals through the App's
+    /// recorder instead and leaves this `None`.
+    pub recorder: Option<InputRecorder>,
+}
+
+impl MachineInputState {
+    pub fn new(recorder: Option<InputRecorder>) -> Self {
+        Self {
+            scheduled: Vec::new(),
+            recorder,
+        }
+    }
+
+    /// Queue `action` for `at_seconds` on the emulated clock, keeping
+    /// the queue sorted by time.
+    pub fn schedule(&mut self, at_seconds: f64, action: InputAction) {
+        self.scheduled.push(ScheduledInput { at_seconds, action });
+        self.scheduled
+            .sort_by(|a, b| a.at_seconds.total_cmp(&b.at_seconds));
+    }
+
+    /// Remove and return every action due at `now`. An action whose
+    /// timestamp is already past remains valid and is returned by the
+    /// next drain.
+    pub fn take_due(&mut self, now: f64) -> Vec<InputAction> {
+        let due_len = self
+            .scheduled
+            .partition_point(|entry| entry.at_seconds <= now);
+        self.scheduled
+            .drain(..due_len)
+            .map(|entry| entry.action)
+            .collect()
+    }
+
+    /// Apply every scheduled action whose time has arrived. Called by
+    /// the headless driver at each quantum boundary.
+    pub fn apply_due_scheduled(&mut self, emu: &mut Emulator) {
+        let now = emu.bus().emulated_seconds();
+        for action in self.take_due(now) {
+            inject_input(emu, &mut self.recorder, action);
+        }
+    }
+
+    /// Apply `action` now, journaled. Returns the emulated time it
+    /// landed at.
+    pub fn inject_now(&mut self, emu: &mut Emulator, action: InputAction) -> f64 {
+        inject_input(emu, &mut self.recorder, action)
+    }
+
+    /// Discard input aimed at the current emulated timeline. Used when
+    /// a reset or state load replaces that timeline.
+    pub fn clear_scheduled(&mut self) {
+        self.scheduled.clear();
+    }
+
+    #[cfg(test)]
+    pub fn pending_count(&self) -> usize {
+        self.scheduled.len()
+    }
+}
+
+impl Default for MachineInputState {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
 /// Session state carried across requests on one connection.
 pub struct SessionCtx {
     /// Server-assigned id -> installed break. Ordered so `break.list`
     /// output is stable.
     breaks: BTreeMap<u32, BreakSpec>,
     next_break_id: u32,
-    /// Input waiting for its emulated time; drained by the driver at
-    /// its command boundary.
-    pub scheduled: Vec<ScheduledInput>,
-    /// Journaling recorder owned by the headless driver
-    /// (`--record-input`); the windowed drain journals through the
-    /// App's recorder instead and leaves this `None`.
-    pub recorder: Option<InputRecorder>,
     /// Host-state flags the driver keeps updated for `status`.
     pub running: bool,
     /// A resume verb's response is still outstanding.
@@ -111,8 +175,6 @@ impl SessionCtx {
         Self {
             breaks: BTreeMap::new(),
             next_break_id: 1,
-            scheduled: Vec::new(),
-            recorder: None,
             running: false,
             pending: false,
             powered_on: true,
@@ -205,35 +267,6 @@ impl SessionCtx {
             BreakSpec::Copper { addr } => emu.bus().ui_copper_breaks().contains(addr),
             BreakSpec::Catch { vector } => emu.machine.ui_breaks().catches.contains(vector),
         }
-    }
-
-    /// Queue `action` for `at_seconds` on the emulated clock, keeping
-    /// the queue sorted by time.
-    pub fn schedule(&mut self, at_seconds: f64, action: InputAction) {
-        self.scheduled.push(ScheduledInput { at_seconds, action });
-        self.scheduled
-            .sort_by(|a, b| a.at_seconds.total_cmp(&b.at_seconds));
-    }
-
-    /// Apply every scheduled action whose time has arrived. Called by
-    /// the headless driver at each quantum boundary (the windowed drain
-    /// maps scheduling onto the App's own scheduled-input lists
-    /// instead).
-    pub fn apply_due_scheduled(&mut self, emu: &mut Emulator) {
-        let now = emu.bus().emulated_seconds();
-        while let Some(first) = self.scheduled.first() {
-            if first.at_seconds > now {
-                break;
-            }
-            let entry = self.scheduled.remove(0);
-            inject_input(emu, &mut self.recorder, entry.action);
-        }
-    }
-
-    /// Apply `action` now, journaled. Returns the emulated time it
-    /// landed at.
-    pub fn inject_now(&mut self, emu: &mut Emulator, action: InputAction) -> f64 {
-        inject_input(emu, &mut self.recorder, action)
     }
 
     pub fn subscribe_events(
@@ -452,46 +485,89 @@ mod tests {
     #[test]
     fn scheduled_input_applies_in_time_order_on_the_emulated_clock() {
         let mut emu = test_emulator();
-        let mut ctx = SessionCtx::new();
+        let mut input = MachineInputState::default();
         // Push out of order; the queue must sort by emulated time.
-        ctx.schedule(
+        input.schedule(
             0.030,
             InputAction::Key {
                 rawkey: 0x22,
                 pressed: false,
             },
         );
-        ctx.schedule(
+        input.schedule(
             0.001,
             InputAction::Key {
                 rawkey: 0x22,
                 pressed: true,
             },
         );
-        assert!(ctx.scheduled[0].at_seconds < ctx.scheduled[1].at_seconds);
+        assert_eq!(input.pending_count(), 2);
 
         // Nothing due at power-on.
-        ctx.apply_due_scheduled(&mut emu);
-        assert_eq!(ctx.scheduled.len(), 2);
+        input.apply_due_scheduled(&mut emu);
+        assert_eq!(input.pending_count(), 2);
 
         // One frame (~0.02s PAL) passes the press but not the release.
         emu.step_frame().unwrap();
-        ctx.apply_due_scheduled(&mut emu);
-        assert_eq!(ctx.scheduled.len(), 1);
+        input.apply_due_scheduled(&mut emu);
+        assert_eq!(input.pending_count(), 1);
 
         emu.step_frame().unwrap();
-        ctx.apply_due_scheduled(&mut emu);
-        assert!(ctx.scheduled.is_empty());
+        input.apply_due_scheduled(&mut emu);
+        assert_eq!(input.pending_count(), 0);
+        assert!(
+            !emu.bus().keyboard.is_held(0x22),
+            "the keyboard MCU observes the final up transition"
+        );
+    }
+
+    #[test]
+    fn already_past_scheduled_input_applies_on_the_next_drain() {
+        let mut emu = test_emulator();
+        emu.step_frame().unwrap();
+        let mut input = MachineInputState::default();
+        input.schedule(
+            0.0,
+            InputAction::Key {
+                rawkey: 0x22,
+                pressed: true,
+            },
+        );
+
+        input.apply_due_scheduled(&mut emu);
+
+        assert!(emu.bus().keyboard.is_held(0x22));
+        assert_eq!(input.pending_count(), 0);
+    }
+
+    #[test]
+    fn scheduled_non_key_action_uses_the_machine_queue() {
+        let mut emu = test_emulator();
+        let mut input = MachineInputState::default();
+        input.schedule(
+            0.001,
+            InputAction::MouseButton {
+                port: 0,
+                index: 0,
+                pressed: true,
+            },
+        );
+
+        emu.step_frame().unwrap();
+        input.apply_due_scheduled(&mut emu);
+
+        assert!(emu.bus().input.ports[0].fire);
+        assert_eq!(input.pending_count(), 0);
     }
 
     #[test]
     fn injected_input_routes_to_the_named_port() {
         use crate::bus::PortDevice;
         let mut emu = test_emulator();
-        let mut ctx = SessionCtx::new();
+        let mut input = MachineInputState::default();
 
         // Mouse motion and buttons land on the named port's lines.
-        ctx.inject_now(
+        input.inject_now(
             &mut emu,
             InputAction::MouseMove {
                 port: 1,
@@ -499,7 +575,7 @@ mod tests {
                 dy: -2,
             },
         );
-        ctx.inject_now(
+        input.inject_now(
             &mut emu,
             InputAction::MouseButton {
                 port: 1,
@@ -513,7 +589,7 @@ mod tests {
         assert_eq!(emu.bus().input.ports[0].counter_x, 0);
 
         // A joystick state on port 1 engages the device there.
-        ctx.inject_now(
+        input.inject_now(
             &mut emu,
             InputAction::Joy {
                 port: 0,
@@ -529,7 +605,7 @@ mod tests {
         assert!(emu.bus().input.ports[0].fire);
 
         // Analogue positions engage the Analogue device and set the pots.
-        ctx.inject_now(
+        input.inject_now(
             &mut emu,
             InputAction::Pot {
                 port: 1,
@@ -544,23 +620,22 @@ mod tests {
     #[test]
     fn injected_input_is_journaled_in_the_recorder() {
         let mut emu = test_emulator();
-        let mut ctx = SessionCtx::new();
-        ctx.recorder = Some(InputRecorder::new(0.0));
-        ctx.inject_now(
+        let mut input = MachineInputState::new(Some(InputRecorder::new(0.0)));
+        input.inject_now(
             &mut emu,
             InputAction::Key {
                 rawkey: 0x45,
                 pressed: true,
             },
         );
-        ctx.inject_now(
+        input.inject_now(
             &mut emu,
             InputAction::Key {
                 rawkey: 0x45,
                 pressed: false,
             },
         );
-        let script = ctx.recorder.take().unwrap().finish();
+        let script = input.recorder.take().unwrap().finish();
         assert!(
             script.contains("key-after") && script.contains("0x45"),
             "recording should carry the injected key: {script}"

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -14,7 +14,7 @@ use crate::control::exec::{
     CCK_FINE_WINDOW, RUN_BUDGET,
 };
 use crate::control::proto::{self, CtlError};
-use crate::control::session::{InputAction, SessionCtx};
+use crate::control::session::{InputAction, MachineInputState, SessionCtx};
 use crate::control::windowed::{ControlHandle, CtlMsg};
 use crate::debugger::DebugStop;
 use serde_json::{json, Value};
@@ -23,6 +23,8 @@ use serde_json::{json, Value};
 pub(super) struct ControlState {
     pub(super) handle: ControlHandle,
     ctx: SessionCtx,
+    /// Deferred input follows the machine across connection turnover.
+    input: MachineInputState,
     pending: Option<PendingResume>,
     /// A `run_until pc` target breakpoint this session planted (and must
     /// remove on completion); `None` when the target address already had
@@ -72,6 +74,7 @@ impl App {
         self.control = Some(ControlState {
             handle,
             ctx: SessionCtx::new(),
+            input: MachineInputState::default(),
             pending: None,
             temp_pc_break: None,
             exit_requested: false,
@@ -264,7 +267,7 @@ impl App {
                 let scheduled = later.len();
                 if let Some(ctl) = self.control.as_mut() {
                     for entry in later {
-                        ctl.ctx.schedule(entry.at_seconds, entry.action);
+                        ctl.input.schedule(entry.at_seconds, entry.action);
                     }
                 }
                 self.control_send(proto::ok_line(
@@ -369,6 +372,9 @@ impl App {
                     return;
                 }
                 let line = if self.load_state_from_path(&path) {
+                    if let Some(ctl) = self.control.as_mut() {
+                        ctl.input.clear_scheduled();
+                    }
                     // The snapshot ring's positions belong to the old
                     // timeline; re-arm on the loaded one.
                     let (budget, interval) = self
@@ -399,6 +405,9 @@ impl App {
                     self.powered_on = true;
                     self.sync_live_audio_suspension();
                     self.request_redraw();
+                }
+                if let Some(ctl) = self.control.as_mut() {
+                    ctl.input.clear_scheduled();
                 }
                 self.control_send(proto::ok_line(&id, json!({})));
             }
@@ -715,16 +724,7 @@ impl App {
             let Some(ctl) = self.control.as_mut() else {
                 return;
             };
-            let mut due = Vec::new();
-            while ctl
-                .ctx
-                .scheduled
-                .first()
-                .is_some_and(|entry| entry.at_seconds <= now)
-            {
-                due.push(ctl.ctx.scheduled.remove(0).action);
-            }
-            due
+            ctl.input.take_due(now)
         };
         for action in due {
             self.control_apply_input(action);

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -6095,6 +6095,104 @@ mod control_drain {
     }
 
     #[test]
+    fn scheduled_tap_survives_windowed_connection_turnover() {
+        let (mut app, cmd_tx, reply_rx) = attached_app();
+        cmd_tx.send(CtlMsg::Connected).unwrap();
+        app.drain_control();
+        push(
+            &cmd_tx,
+            1,
+            "input.key",
+            json!({"rawkey": 0x12, "action": "tap", "hold_ms": 80}),
+        );
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["result"]["scheduled"], 1);
+        assert!(app.emu.bus().keyboard.is_held(0x12));
+
+        cmd_tx.send(CtlMsg::Disconnected).unwrap();
+        app.drain_control();
+        cmd_tx.send(CtlMsg::Connected).unwrap();
+        app.drain_control();
+
+        for _ in 0..6 {
+            app.emu.step_frame().unwrap();
+            app.drain_control();
+        }
+        assert!(
+            !app.emu.bus().keyboard.is_held(0x12),
+            "the replacement connection must deliver the deferred release"
+        );
+    }
+
+    #[test]
+    fn windowed_reset_clears_future_input() {
+        let (mut app, cmd_tx, reply_rx) = attached_app();
+        push(
+            &cmd_tx,
+            1,
+            "input.key",
+            json!({"rawkey": 0x23, "action": "press", "at_seconds": 0.04}),
+        );
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["result"]["scheduled"], 1);
+        push(&cmd_tx, 2, "machine.reset", json!({"kind": "warm"}));
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["id"], 2);
+
+        for _ in 0..6 {
+            app.emu.step_frame().unwrap();
+            app.drain_control();
+        }
+        assert!(
+            !app.emu.bus().keyboard.is_held(0x23),
+            "reset must discard input aimed at the old timeline"
+        );
+    }
+
+    #[test]
+    fn windowed_state_load_clears_future_input() {
+        let (mut app, cmd_tx, reply_rx) = attached_app();
+        let path = std::env::temp_dir().join(format!(
+            "copperline-control-scheduled-{}.clstate",
+            std::process::id()
+        ));
+        push(
+            &cmd_tx,
+            1,
+            "state.save",
+            json!({"path": path.display().to_string()}),
+        );
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["id"], 1);
+        push(
+            &cmd_tx,
+            2,
+            "input.key",
+            json!({"rawkey": 0x24, "action": "press", "at_seconds": 0.04}),
+        );
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["result"]["scheduled"], 1);
+        push(
+            &cmd_tx,
+            3,
+            "state.load",
+            json!({"path": path.display().to_string()}),
+        );
+        app.drain_control();
+        assert_eq!(reply(&reply_rx)["id"], 3);
+
+        for _ in 0..6 {
+            app.emu.step_frame().unwrap();
+            app.drain_control();
+        }
+        std::fs::remove_file(path).ok();
+        assert!(
+            !app.emu.bus().keyboard.is_held(0x24),
+            "state load must discard input aimed at the old timeline"
+        );
+    }
+
+    #[test]
     fn connected_arms_time_travel_and_shutdown_requests_exit() {
         let (mut app, cmd_tx, reply_rx) = attached_app();
         assert!(!app.emu.time_travel_enabled());


### PR DESCRIPTION
## Summary

- move deferred CCP input and the headless recorder into explicit machine-lifetime state
- preserve scheduled taps and future at_seconds events across headless and windowed control-connection turnover
- clear pending scheduled input after warm/cold reset or a successful state load, and document that policy
- add observable regressions for tap release, continue/run_until timing, reset/load clearing, past events, non-key input, and the windowed path

## Verification

- cargo test
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check
- all timing golden probes unchanged
- release one-shot CLI smoke: a tap submitted at 0.0 seconds from one client, followed by run_until 0.2 from a fresh client, recorded as key-after 0.000 0x12 88