### PR TITLE
window: re-sync the surface to the host window before every draw

### DIFF
--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -449,6 +449,20 @@ surface: the field is presented at a TV-like 4:3 aspect plus the
 is fed from `present_fb`, the post-processed presentation buffer produced by
 either the render worker or the synchronous fallback.
 
+Every redraw first re-syncs the surface to the host window's current size
+(`resync_surface_size`), rather than trusting the Resized event to have
+arrived first. `pixels` rebuilds its swapchain from the size the last
+`resize_surface` gave it, and retries the acquire in a loop with no bound,
+so a surface left behind by a resize the app has not seen yet is a hang and
+not a misdraw: a driver that rejects the mismatched extent (Mesa's X11
+Vulkan WSI answers `VK_ERROR_OUT_OF_DATE_KHR`) sends that loop round
+forever, and because it runs inside the event callback it also starves the
+Resized event that would have corrected the size. Entering or leaving
+fullscreen is the common way in, the window manager resizing the window a
+moment before the event is delivered. Both window kinds record the size
+their surface was configured with, and all resizes go through the wrappers
+that keep that record in step.
+
 The frontend-independent half of this pass lives in
 `video/present_common.rs`: the post-render pipeline (vertical/horizontal
 recentring, the TV bezel mask, programmable-scan presentation) plus the

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1012,6 +1012,25 @@ struct Render {
     /// the window can never be restored (which is what would unblock the
     /// present). Skip all rendering until a nonzero resize restores it.
     minimized: bool,
+    /// The physical surface size `pixels` was last configured with, so a
+    /// redraw can tell that the host window has outgrown it (see
+    /// `resync_surface_size`).
+    surface_size: (u32, u32),
+}
+
+impl Render {
+    /// Resize the presentation surface, recording the size it was configured
+    /// with. Every resize goes through here (the first configure is
+    /// `build_pixels_for_window`'s, whose size this struct is built with):
+    /// `pixels` reconfigures its swapchain from its own copy of this size and
+    /// nothing else can correct it, so the record must never lag behind what
+    /// `pixels` holds.
+    fn resize_surface(&mut self, size: PhysicalSize<u32>) -> Result<(), pixels::TextureError> {
+        let (width, height) = (size.width.max(1), size.height.max(1));
+        self.pixels.resize_surface(width, height)?;
+        self.surface_size = (width, height);
+        Ok(())
+    }
 }
 
 struct ToolWindow {
@@ -1021,6 +1040,18 @@ struct ToolWindow {
     cursor_pos: Option<(i32, i32)>,
     /// Same Windows minimized-present deadlock hazard as Render::minimized.
     minimized: bool,
+    /// Same configured-surface-size record as Render::surface_size.
+    surface_size: (u32, u32),
+}
+
+impl ToolWindow {
+    /// Tool-window counterpart of `Render::resize_surface`.
+    fn resize_surface(&mut self, size: PhysicalSize<u32>) -> Result<(), pixels::TextureError> {
+        let (width, height) = (size.width.max(1), size.height.max(1));
+        self.pixels.resize_surface(width, height)?;
+        self.surface_size = (width, height);
+        Ok(())
+    }
 }
 
 /// Frame-loop repaints of the tool windows (debugger, frame analyzer) are
@@ -2508,6 +2539,7 @@ impl ApplicationHandler for App {
             crt_shader,
             bezel_shader,
             minimized: false,
+            surface_size: (inner.width.max(1), inner.height.max(1)),
         });
         // After the window exists, so the overlay has somewhere to be drawn.
         if let Some(msg) = shader_error {
@@ -3004,6 +3036,7 @@ impl ApplicationHandler for App {
                 self.apply_surface_size(size);
             }
             WindowEvent::RedrawRequested => {
+                self.resync_surface_size();
                 if self.render.as_ref().is_some_and(|r| r.minimized) {
                     return;
                 }
@@ -4350,6 +4383,7 @@ impl App {
             *self.tool_window_slot(kind) = None;
             return;
         };
+        self.resync_tool_surface_size(kind);
         if kind == ToolPanelKind::FrameAnalyzer {
             self.ensure_analyzer_underlay();
         }
@@ -5654,12 +5688,14 @@ impl App {
             texture_width(texture_scale),
             texture_height(texture_scale)
         );
+        let inner = window.inner_size();
         *self.tool_window_slot(kind) = Some(ToolWindow {
             window,
             pixels,
             texture_scale,
             cursor_pos: None,
             minimized: false,
+            surface_size: (inner.width.max(1), inner.height.max(1)),
         });
         self.request_redraw();
     }
@@ -8865,7 +8901,7 @@ impl App {
             if let Err(e) = sync_main_present_scaling(r, (size.width, size.height)) {
                 warn!("resize texture buffer for new surface size failed: {e}");
             }
-            if let Err(e) = r.pixels.resize_surface(size.width, size.height) {
+            if let Err(e) = r.resize_surface(size) {
                 warn!("resize surface failed: {e}");
             }
         }
@@ -8878,6 +8914,44 @@ impl App {
         self.request_redraw();
     }
 
+    /// Bring the surface up to the host window's current size before drawing,
+    /// when a resize has not reached us as a Resized event yet.
+    ///
+    /// `pixels` reconfigures its swapchain from the size the last
+    /// `resize_surface` gave it, and its render retries the acquire in an
+    /// unbounded loop: on a driver that rejects a swapchain whose extent
+    /// disagrees with the window (Mesa's X11 Vulkan WSI returns
+    /// VK_ERROR_OUT_OF_DATE_KHR), a stale size makes that loop rebuild the
+    /// swapchain forever instead of hanging on to a wrongly-scaled frame.
+    /// Rendering runs inside the event callback, so the loop also starves the
+    /// Resized event that would have corrected the size: the window never
+    /// comes back, and the churn goes on until the display server runs the
+    /// client out of resource ids. Entering or leaving fullscreen is the
+    /// common way in, the window manager resizing the window a moment before
+    /// the event reaches us (issue #362, upstream parasyte/pixels#460).
+    fn resync_surface_size(&mut self) {
+        let Some(r) = self.render.as_ref() else {
+            return;
+        };
+        let Some(size) = surface_resize_for_draw(r.surface_size, r.window.inner_size()) else {
+            return;
+        };
+        self.apply_surface_size(size);
+    }
+
+    /// Tool-window counterpart of `resync_surface_size`, for the same reason:
+    /// these windows are freely resizable too.
+    fn resync_tool_surface_size(&mut self, kind: ToolPanelKind) {
+        let Some(tool) = self.tool_window(kind) else {
+            return;
+        };
+        let Some(size) = surface_resize_for_draw(tool.surface_size, tool.window.inner_size())
+        else {
+            return;
+        };
+        self.apply_tool_surface_size(kind, size);
+    }
+
     /// Tool-window counterpart of `apply_surface_size`, shared by that window's
     /// Resized event and the synchronous `request_inner_size` path.
     fn apply_tool_surface_size(&mut self, kind: ToolPanelKind, size: PhysicalSize<u32>) {
@@ -8887,7 +8961,7 @@ impl App {
             if tool.minimized {
                 return;
             }
-            let _ = tool.pixels.resize_surface(size.width, size.height);
+            let _ = tool.resize_surface(size);
         }
         self.request_redraw();
     }
@@ -9056,10 +9130,7 @@ impl App {
                 // re-apply the current surface size: that is what recomputes
                 // the scaling matrix and the clip rect the cursor mapping,
                 // the shader passes and the RTG pass all read.
-                if let Err(e) = r
-                    .pixels
-                    .resize_surface(size.width.max(1), size.height.max(1))
-                {
+                if let Err(e) = r.resize_surface(size) {
                     warn!("resize surface for display scaling failed: {e}");
                 }
             }

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -506,6 +506,22 @@ pub(super) fn resync_render_scale(
     }
 }
 
+/// The size a redraw has to apply to the presentation surface before it draws,
+/// or `None` when the surface already matches the host window and the frame can
+/// go out as it stands.
+///
+/// A resize that has not reached the app as a Resized event yet leaves `pixels`
+/// configured for the old size, and it rebuilds the swapchain from that stored
+/// size alone, in a retry loop with no bound -- see `App::resync_surface_size`
+/// for what that costs. A 0x0 window is reported like any other mismatch, so
+/// the caller's minimized guard gets to see it.
+pub(super) fn surface_resize_for_draw(
+    configured: (u32, u32),
+    inner: PhysicalSize<u32>,
+) -> Option<PhysicalSize<u32>> {
+    ((inner.width, inner.height) != configured).then_some(inner)
+}
+
 pub(super) fn build_pixels_for_window(
     window: Arc<Window>,
     texture_scale: usize,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -6916,3 +6916,29 @@ fn integer_scaling_fits_in_whole_canvas_pixels() {
     assert_eq!(plan(false, 2.0, (3024, 1964)), (2, false));
     assert_eq!(plan(false, 1.0, (3024, 1964)), (1, false));
 }
+
+/// A redraw that finds the host window at a size the surface was not
+/// configured for re-applies it before drawing, whether the window grew or
+/// shrank. A window manager resizing the window a moment before the Resized
+/// event reaches us -- the fullscreen toggle's ordinary case -- otherwise
+/// leaves `pixels` rebuilding a swapchain the driver rejects, in a retry loop
+/// that never ends and never lets the corrective event through (issue #362).
+#[test]
+fn draw_re_applies_a_surface_size_the_window_has_moved_past() {
+    let resize = |configured, (w, h)| {
+        super::surface_resize_for_draw(configured, winit::dpi::PhysicalSize::new(w, h))
+            .map(|size| (size.width, size.height))
+    };
+
+    // Matching sizes draw as they stand: no swapchain rebuild per frame.
+    assert_eq!(resize((1432, 1162), (1432, 1162)), None);
+    // Fullscreen entered (and left again) ahead of the event.
+    assert_eq!(resize((1432, 1162), (3024, 1964)), Some((3024, 1964)));
+    assert_eq!(resize((3024, 1964), (1432, 1162)), Some((1432, 1162)));
+    // One axis alone is a mismatch too.
+    assert_eq!(resize((1432, 1162), (1432, 900)), Some((1432, 900)));
+    // A minimized window is reported like any other mismatch, so the caller's
+    // minimized guard sees the 0x0 rather than the surface keeping its old
+    // size unnoticed.
+    assert_eq!(resize((1432, 1162), (0, 0)), Some((0, 0)));
+}


### PR DESCRIPTION
Fixes #362.

## The hang

The reporter's gdb dump has the main thread here:

```
#3  poll () from libc.so.6
#6  xcb_wait_for_reply () from libxcb.so.1
#7  xcb_generate_id () from libxcb.so.1
#8  ?? () from libvulkan_radeon.so
#11 ...NativeSurface as ...Surface>::create_swapchain ()
#13 wgpu::api::surface::Surface::configure ()
#14 pixels::Pixels::render ()
#15 <copperline::video::window::App as winit::application::ApplicationHandler>::window_event ()
```

Every other thread is idle, so nothing in the emulator core is involved: the
main thread is stuck building a Vulkan swapchain from inside the winit event
callback.

`pixels::Pixels::render_with` retries the acquire in a loop with no bound, and
each retry reconfigures the surface from `self.surface_size` -- a cached value
that only `resize_surface()` updates. On our side that came from the `Resized`
event alone. So between the window manager resizing the X window and the event
reaching us, the surface stays configured for the old geometry, Mesa's X11
Vulkan WSI answers `VK_ERROR_OUT_OF_DATE_KHR` for a swapchain whose extent
disagrees with the window, and the loop rebuilds the same wrong swapchain
forever. Since it never returns, the event loop can no longer deliver the
`Resized` event that would have fixed the size: the loop cannot break itself.
A fullscreen toggle is the ordinary way to get the events in that order, which
is why it is intermittent rather than constant.

Two numbers in the dump show how long it had been spinning:

- it is blocked in `xcb_generate_id`, which only round-trips (XC-MISC
  `GetXIDRange`) once the client has burned its entire XID space. That is
  0x1FFFFF ids and a Mesa X11 swapchain costs about ten of them, so on the
  order of 200k swapchains had been created and dropped.
- the live `WSI swapchain q` / `WSI swapchain e` threads (Mesa spawns a pair
  per swapchain under FIFO) have LWP numbers ~431,000 above the process's own
  threads, which is the same ~215k swapchains counted a different way.

So it is not a deadlock, it churns swapchains flat out until the X connection
wedges on XID allocation.

## The fix

- `Render` and `ToolWindow` record the physical size their surface was last
  configured with, and every resize goes through a wrapper that keeps that
  record in step with what `pixels` holds.
- `resync_surface_size` / `resync_tool_surface_size` run at the top of each
  redraw and re-apply `window.inner_size()` when it has moved past the
  surface, instead of trusting the `Resized` event to have arrived first. The
  reconfigure inside the retry loop then always uses live geometry and
  converges.

A regression test pins the decision, including that a 0x0 window still reports
a mismatch so the minimized guard sees it rather than the surface quietly
keeping its old size. `docs/internals/video.md` documents the invariant.

## Residual

If the window is resized between that check and the acquire, the loop is
unbounded again, and an application cannot do anything about it from outside
(`surface_size` is private and `Pixels` holds no window handle to query).
Reported upstream as parasyte/pixels#460 with an offer to bound the retry
there.

## Testing

`cargo test --all-features` (2137 pass), clippy and fmt clean, release build
fine, headless screenshot unchanged. Also ran a real windowed session with
`--control-gui`, captured through CCP and confirmed no per-frame resize churn.
The X11 hang itself does not reproduce on macOS: Metal accepts the mismatched
extent instead of returning `Outdated`, which is why this only bites on Linux.
