### PR TITLE
web: stop the ready boot button scrolling the page to itself

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -437,7 +437,10 @@ async function load() {
     console.error(e);
   }
   refreshBootButton();
-  if (!bootBtn.disabled) bootBtn.focus();
+  // The ROMs land without any user gesture, so a plain focus() would scroll
+  // the button into view and yank an embedding page (retro32.com) to its
+  // middle. preventScroll keeps the keyboard affordance without the jump.
+  if (!bootBtn.disabled) bootBtn.focus({ preventScroll: true });
 }
 
 // --- boot ----------------------------------------------------------------

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -650,7 +650,7 @@ debits a per-frame instruction budget one of two ways, selected by
   tails, chip-bus grants and contention waits -- so the slice's elapsed bus
   CCK is the true hardware cost (`real_slice_accounting` in
   `src/emulator.rs`). Because the m68k core's 68000 cycle totals are exact
-  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.5.0#validation--testing),
+  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.5.2#validation--testing),
   this matches a stock PAL 68000.
 - `instructions`: a flat cycles-per-instruction quota
   (`COPPERLINE_REAL_CPU_CPI`, default 4.0), debited by retired


### PR DESCRIPTION
Reported by Retro32: loading https://retro32.com/bbs-copperline/ jumps the page to its middle on its own, no interaction required.

## Cause

`loadRoms()` finishes the background AROS ROM download, enables the Power On button, and focuses it:

```js
refreshBootButton();
if (!bootBtn.disabled) bootBtn.focus();
```

That path runs off the download completion, not off a user gesture, and a bare `focus()` asks the browser to scroll the target into view. `#boot` sits in the `.controls` block below the canvas and status bar -- about halfway down an embedding page -- so the viewport gets yanked there while the visitor is still reading the top.

## Fix

`focus({ preventScroll: true })`. The button still takes keyboard focus, so Enter/Space keep firing Power On for anyone tabbing in; the viewport stays put.

I swept the rest of the page glue for the same class of bug (`focus`, `scrollIntoView`, `autofocus` across `www/*.{js,html,css}`). The only other `focus()` is the soft-keyboard host field, which already passes `preventScroll: true` and is gesture-driven anyway. Nothing else in the bundle can move the scroll position.

## Also here

`docs/internals/timing.md` had one straggling `m68k-v0.5.0` link to the SingleStepTests corpus. `docs/internals/cpu.md` was moved to `v0.5.2` in the version bump but this link was missed; `Cargo.toml` and `Cargo.lock` are both on 0.5.2.

## Testing

Not run in a browser -- verifying end to end needs a local wasm build of the demo, and this is a one-line option on a well-understood API. `node --check` passes on the modified `try.js`.

Note `try.js` is the source of truth published to the website repo by `.github/workflows/wasm-demo.yml`; Retro32's page picks the fix up when that workflow next republishes, not at merge.