### PR TITLE
window: add a performance overlay (issue #370)

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -394,6 +394,10 @@ video = "PAL"
 # bezel: frame the picture with a 1084-style monitor front bezel (default
 # false; Cmd/Alt+M toggles it live). Composes with any shader setting, and
 # like it is a window-display effect only: captures never include the frame.
+# perf_overlay: show the performance overlay at start (default false; also
+# --perf-overlay, and Cmd/Alt+P toggles it live): emulated fps, speed
+# factor, per-frame emulation cost, host utilisation, audio health, and
+# pacer slips in the top-right of the display. Captures never include it.
 # tint: screen tint over the window image. "none" (default, full colour),
 # "bw" (black and white), "green" or "amber" (monochrome-monitor
 # phosphor), or "sepia". Like shader, a window-display effect only:
@@ -413,6 +417,7 @@ video = "PAL"
 # shader = "none"
 # shader_strength = 1.0
 # bezel = false
+# perf_overlay = false
 # tint = "none"
 # menu_scale = "1x"
 # full_screen = false

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -189,6 +189,16 @@ file rather than being pushed through the bounded notification stream.
 
 Session: `hello {token?}`, `auth {token}`, `status`, `shutdown`.
 
+Besides the run state and timeline position, `status` reports the
+always-on performance counters: `host_busy_ms` (cumulative host
+milliseconds of emulation work, pacing sleeps excluded), `pacer_slips`
+(times the real-time pacer dropped emulated time after falling past its
+catch-up limit), `audio_lead_ms`, and `audio_underrun_frames`. The busy
+and slip counters reset with a guest reset. They are cumulative, so a
+client derives rates the way the window's performance overlay does: call
+`status` twice and divide the deltas by the wall time between the calls
+(emulated fps from `frame`, host utilisation from `host_busy_ms`).
+
 Execution: `continue`, `step {n?}`, `step_over`, `step_out`,
 `step_copper`, `step_frame {n?}`,
 `run_until {pc | vpos[,hpos] | frame | cck | seconds | stable_frames}`,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -648,6 +648,18 @@ never include it, and it is skipped while a menu or overlay panel is open
 and for RTG scanout frames. Unlike the shader it does stay on for
 programmable multisync scans -- a frame has no line structure to get wrong.
 
+`perf_overlay` (default `false`) shows the performance overlay at start: a
+live readout of emulated fps, speed factor, per-frame emulation cost, host
+utilisation, audio health, and pacer slips in the top-right corner of the
+display, one line per data point (see
+[the window chapter](ui.md#performance-overlay) for what each line means).
+Cmd+P (macOS) / Alt+P toggles it live for the rest of the session without
+touching the config, `--perf-overlay` shows it for one run, and
+`COPPERLINE_PERF_OVERLAY=1|0` overrides the config for a single run; the
+launcher's *Perf overlay* row (*A/V & Emu*, *Video*) writes it. Like the
+transient message overlay it is presentation only: screenshots, frame
+dumps, and recordings never include it.
+
 `tint` recolours the picture like the phosphor of a monochrome monitor:
 `"bw"` (black and white), `"green"` and `"amber"` (the two classic
 monochrome phosphors), or `"sepia"`; `"none"` (the default; `"off"` is

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -31,6 +31,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+Shift+>` / `Cmd+Shift+<` | `Alt+Shift+>` / `Alt+Shift+<` | Raise / lower the host mouse sensitivity (also the launcher's Input tab) |
 | `Cmd+F` | `Alt+F` | Toggle fullscreen on / off |
 | `Cmd+Shift+F` | `Alt+Shift+F` | Show / hide the status bar |
+| `Cmd+P` | `Alt+P` | Toggle the [performance overlay](#performance-overlay) (`[display] perf_overlay` sets the start-up value) |
 | `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |
 | `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Cmd+Z` | `Alt+Z` | Rewind the machine one step (needs `[emulation] rewind` or *Emulation Settings > Rewind*) |
@@ -95,6 +96,39 @@ Status Bar*):
 - **Pause / power / reboot buttons.** Pause freezes emulation while staying
   powered; power cold-boots (clears RAM) or powers off back to the test
   screen; reboot is a warm reset.
+
+## Performance overlay
+
+`Cmd+P` (macOS) / `Alt+P`, *Video Settings > Performance*, or
+`[display] perf_overlay = true` shows a live emulation-performance readout
+in the top-right corner of the display, one line per data point at the
+menu's font size (it follows *Menu Size*), refreshed twice a second:
+
+| Line | Meaning |
+|---|---|
+| `50.0 fps` | Emulated video frames retired per host second: 50 (PAL) or 60 (NTSC) when the machine holds real time, lower when the host cannot keep up, far higher under Warp Speed |
+| `x1.00` | Speed factor: emulated seconds advanced per host second (the effective multiplier under Warp Speed) |
+| `emu 3.2 ms` | Host milliseconds of emulation work per emulated frame, pacing sleeps excluded |
+| `host 16%` | Share of host wall time spent emulating. In real-time mode this is the share of the frame budget (20.0 ms PAL, 16.7 ms NTSC) used per frame |
+| `audio 148 ms` | Live audio output lead -- the cushion that absorbs host scheduling hiccups (steady state is about 150 ms) |
+| `xrun 0` | Audio underrun frames per second: the audible symptom of the host falling behind |
+| `slip 0` | Times the pacer fell hopelessly behind real time (over ~100 ms, e.g. a host stall) and dropped emulated time instead of chasing it, since the last guest reset |
+
+Copperline never skips frames to keep pace: when the host cannot sustain
+real time the machine slows down (fps and the speed factor fall below
+nominal while `host` sits near 100%), and only a stall beyond the pacer's
+catch-up limit drops emulated time, counted by `slip`. Under Warp Speed
+the presentation shows one frame per burst, but every emulated frame is
+still computed.
+
+Like the transient message overlay, the readout is painted into the
+presentation only: screenshots, frame dumps, and recordings never include
+it. While a video recording is running the block steps below the `REC`
+badge. `COPPERLINE_PERF_OVERLAY=1|0` overrides the config for a single
+run, and `--perf-overlay` shows it from the command line; the launcher's
+*Perf overlay* row (*A/V & Emu*, *Video*) makes it stick. The same
+counters are exported through the control protocol's `status` reply for
+headless runs (see [](../debugger/control)).
 
 ## Drag and drop
 
@@ -232,6 +266,10 @@ tool window or overlay.
   needed, exactly as when resizing the window.
 - **Status Bar** (also `Cmd+Shift+F` / `Alt+Shift+F`): show or hide the
   status bar. Handy alongside fullscreen for a clean, chrome-free picture.
+- **Performance** (also `Cmd+P` / `Alt+P`): show or hide the
+  [performance overlay](#performance-overlay). Session-only; the start-up
+  value is `[display] perf_overlay` (see
+  [Configuration](configuration.md)).
 
 ### Input Settings
 
@@ -404,8 +442,8 @@ The layout is:
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
   sounds and volume), **Video** (start fullscreen, status bar, monitor bezel,
-  menu size, overscan, pixel aspect, scaling, deinterlace, screen tint,
-  phosphor, CRT shader and shader strength),
+  perf overlay, menu size, overscan, pixel aspect, scaling, deinterlace,
+  screen tint, phosphor, CRT shader and shader strength),
   and **Emulation**
   (power-on, realtime priority, pacing, warp speed) -- opening on Audio, and
   switched freely between the three.

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,6 +244,11 @@ pub struct Config {
     /// it: screenshots, frame dumps, recordings and headless runs never
     /// include the bezel.
     pub bezel: bool,
+    /// Show the performance overlay at start (`[display] perf_overlay`, or
+    /// `--perf-overlay`): a live emulation-performance readout in the
+    /// top-right of the display. The `Cmd+P` / `Alt+P` toggle flips it live
+    /// without affecting this start-up value.
+    pub perf_overlay: bool,
     /// Screen tint applied to the window image: the phosphor colour of a
     /// monochrome monitor, or a sepia treatment. See [`Tint`].
     pub tint: Tint,
@@ -1791,6 +1796,7 @@ impl Default for Config {
             shader: ShaderMode::None,
             shader_strength: 1.0,
             bezel: false,
+            perf_overlay: false,
             tint: Tint::None,
             menu_scale: MenuScale::Normal,
             full_screen: false,
@@ -2015,6 +2021,9 @@ pub struct ConfigOverrides {
     /// Show the status bar at start (`--show-status-bar` /
     /// `--hide-status-bar`). Same as `[display] status_bar`.
     pub status_bar: Option<bool>,
+    /// Show the performance overlay at start (`--perf-overlay`). Same as
+    /// `[display] perf_overlay`.
+    pub perf_overlay: Option<bool>,
     /// How large the pop-up menu is drawn (`--menu-scale`). Same values as
     /// `[display] menu_scale`.
     pub menu_scale: Option<String>,
@@ -2095,6 +2104,7 @@ impl ConfigOverrides {
             && self.a2065_interface.is_none()
             && self.full_screen.is_none()
             && self.status_bar.is_none()
+            && self.perf_overlay.is_none()
             && self.menu_scale.is_none()
     }
 
@@ -2294,6 +2304,9 @@ impl ConfigOverrides {
         if let Some(status_bar) = self.status_bar {
             raw.display.status_bar = Some(status_bar);
         }
+        if let Some(perf_overlay) = self.perf_overlay {
+            raw.display.perf_overlay = Some(perf_overlay);
+        }
         if let Some(menu_scale) = &self.menu_scale {
             raw.display.menu_scale = Some(menu_scale.clone());
         }
@@ -2424,6 +2437,9 @@ pub(crate) struct RawDisplay {
     /// Monitor-style front bezel around the window picture (default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bezel: Option<bool>,
+    /// Performance overlay in the top-right of the display (default false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) perf_overlay: Option<bool>,
     /// Screen tint: "none" (default), "bw", "green", "amber", or "sepia".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) tint: Option<String>,
@@ -3319,6 +3335,7 @@ impl TryFrom<RawConfig> for Config {
             }
         };
         let bezel = raw.display.bezel.unwrap_or(defaults.bezel);
+        let perf_overlay = raw.display.perf_overlay.unwrap_or(defaults.perf_overlay);
         let tint = match raw.display.tint.as_deref() {
             None => defaults.tint,
             Some(s) => parse_tint(s)?,
@@ -3775,6 +3792,7 @@ impl TryFrom<RawConfig> for Config {
             shader,
             shader_strength,
             bezel,
+            perf_overlay,
             tint,
             menu_scale,
             full_screen,
@@ -4945,6 +4963,19 @@ pub fn resolve_bezel(from_config: bool) -> bool {
     }
 }
 
+/// Resolve the performance overlay: the `COPPERLINE_PERF_OVERLAY` env var
+/// (0/false/off/no disables, anything else enables) overrides the
+/// `[display] perf_overlay` config for one run.
+pub fn resolve_perf_overlay(from_config: bool) -> bool {
+    match crate::envcfg::var("COPPERLINE_PERF_OVERLAY") {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => from_config,
+    }
+}
+
 /// Resolve the screen tint: the `COPPERLINE_TINT` env var (a tint name)
 /// overrides the `[display] tint` config for one run.
 pub fn resolve_tint(from_config: Tint) -> Tint {
@@ -5792,6 +5823,27 @@ mod tests {
             "#,
         )?;
         assert!(cfg.bezel);
+        Ok(())
+    }
+
+    #[test]
+    fn display_perf_overlay_parses_and_defaults_to_off() -> Result<()> {
+        assert!(!parse_config("")?.perf_overlay);
+        let cfg = parse_config(
+            r#"
+            [display]
+            perf_overlay = true
+            "#,
+        )?;
+        assert!(cfg.perf_overlay);
+
+        let mut raw = RawConfig::default();
+        ConfigOverrides {
+            perf_overlay: Some(true),
+            ..Default::default()
+        }
+        .apply_to(&mut raw);
+        assert_eq!(raw.display.perf_overlay, Some(true));
         Ok(())
     }
 

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -2153,6 +2153,10 @@ fn reverse_result(emu: &Emulator, outcome: ReverseOutcome<String>) -> Result<Val
 
 fn status_value(emu: &Emulator, ctx: &SessionCtx) -> Value {
     let bus = emu.bus();
+    // Cumulative counters: a client derives rates (emulated fps, host
+    // utilisation) from the deltas between two status calls.
+    let perf = emu.perf_counters();
+    let audio = bus.live_audio_status();
     json!({
         "state": if ctx.running { "running" } else { "paused" },
         "pending_resume": ctx.pending,
@@ -2168,6 +2172,10 @@ fn status_value(emu: &Emulator, ctx: &SessionCtx) -> Value {
         "cck": bus.emulated_cck(),
         "seconds": bus.emulated_seconds(),
         "retired_instructions": emu.retired_instructions(),
+        "host_busy_ms": perf.busy.as_secs_f64() * 1000.0,
+        "pacer_slips": perf.pacer_slips,
+        "audio_lead_ms": audio.output_lead_seconds * 1000.0,
+        "audio_underrun_frames": audio.callback_underrun_frames,
     })
 }
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -381,6 +381,23 @@ pub struct EmuStats {
     pub slices: u64,
     pub instructions: u64,
     pub started_at: Option<crate::timebase::Instant>,
+    /// Host time spent emulating in `step_real`, real-time pacing sleeps
+    /// excluded. Cleared with the rest of the stats on a guest reset.
+    pub busy: Duration,
+    /// Times the real-time pacer fell beyond the catch-up limit and dropped
+    /// emulated time by re-anchoring instead of chasing the deficit (the
+    /// self-heal in `sleep_until_realtime_device_time`).
+    pub pacer_slips: u32,
+}
+
+/// Snapshot of the always-on performance counters behind the window's
+/// performance overlay and the control protocol's `status` report:
+/// cumulative host emulation time (pacing sleeps excluded) and pacer slip
+/// events, both since the last guest reset.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PerfCounters {
+    pub busy: Duration,
+    pub pacer_slips: u32,
 }
 
 impl Emulator {
@@ -1336,6 +1353,15 @@ impl Emulator {
         self.bus_mut().reset_profile_stats();
     }
 
+    /// The always-on performance counters (see [`PerfCounters`]). Cleared,
+    /// like the rest of the stats, by a guest reset.
+    pub fn perf_counters(&self) -> PerfCounters {
+        PerfCounters {
+            busy: self.stats.busy,
+            pacer_slips: self.stats.pacer_slips,
+        }
+    }
+
     /// Execute exactly `count` CPU instructions (interactive debugger
     /// single-step). The cycle-exact core advances the chipset in lockstep,
     /// so device state stays consistent; no wall-clock pacing is applied.
@@ -1528,6 +1554,9 @@ impl Emulator {
     }
 
     fn step_real(&mut self) -> Result<()> {
+        // Host cost of this frame for the performance overlay: everything
+        // in this call except the real-time pacing sleep.
+        let busy_started = Instant::now();
         let mut remaining = self.instruction_budget();
         // Cycle-step while the CPU is actively executing so every chip
         // register write lands at the correct beam position (one
@@ -1551,9 +1580,12 @@ impl Emulator {
         }
         // Pace presentation to wall-clock only for the interactive window;
         // headless runs advance the deterministic core unthrottled.
-        if self.paced {
-            self.sleep_until_realtime_device_time();
-        }
+        let slept = if self.paced {
+            self.sleep_until_realtime_device_time()
+        } else {
+            Duration::ZERO
+        };
+        self.stats.busy += busy_started.elapsed().saturating_sub(slept);
         Ok(())
     }
 
@@ -1722,10 +1754,13 @@ impl Emulator {
         instructions_for_cck_value(cck, self.cpu_cycles_per_instruction)
     }
 
-    fn sleep_until_realtime_device_time(&mut self) {
+    /// Returns the host time actually slept, so the caller can subtract it
+    /// from the frame's busy-time accounting.
+    fn sleep_until_realtime_device_time(&mut self) -> Duration {
         let Some(started_at) = self.stats.started_at else {
-            return;
+            return Duration::ZERO;
         };
+        let mut slept = Duration::ZERO;
         let now = Instant::now();
         let live_audio_lead_seconds = self.bus().live_audio_output_lead_seconds();
         let target = realtime_device_time_target(
@@ -1739,6 +1774,7 @@ impl Emulator {
             let elapsed = sleep_started.elapsed();
             self.audio_profile.record_sleep(elapsed);
             self.real_pacing_profile.record_sleep(elapsed);
+            slept = elapsed;
         } else {
             if let Some(lag) = target.and_then(|target| now.checked_duration_since(target)) {
                 if lag > Duration::ZERO {
@@ -1753,6 +1789,7 @@ impl Emulator {
                     // resume pacing from "now" instead of sprinting to catch
                     // up. The overrun telemetry above is still recorded.
                     if lag > realtime_catchup_limit(live_audio_lead_seconds) {
+                        self.stats.pacer_slips = self.stats.pacer_slips.saturating_add(1);
                         if let Some(anchor) = self.stats.started_at {
                             self.stats.started_at = Some(anchor + lag);
                         }
@@ -1765,6 +1802,7 @@ impl Emulator {
         let cpu_chip_slots = self.bus().cpu_granted_chip_slots();
         self.real_pacing_profile
             .log_if_due(audio_status, cpu_chip_slots);
+        slept
     }
 
     fn execute_cpu_slice(&mut self, chunk: usize) -> Result<ExecutedSlice> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,6 +419,9 @@ where
             "--hide-status-bar" => {
                 overrides.status_bar = Some(false);
             }
+            "--perf-overlay" => {
+                overrides.perf_overlay = Some(true);
+            }
             "--cpu-clock" => {
                 let mhz: f64 = next_arg(
                     &mut args,
@@ -1209,6 +1212,8 @@ fn print_help() {
          \x20                            combine with COPPERLINE_AUDIO_PROFILE=1 for counters\n  \
          --full-screen / --windowed     open fullscreen / windowed at start (default: windowed)\n  \
          --show-status-bar / --hide-status-bar  status bar at start (default: shown)\n  \
+         --perf-overlay                 show the performance overlay at start\n  \
+         \x20                            (Cmd/Alt+P toggles it live)\n  \
          --menu-scale SIZE              size of the pop-up menu: 1x (default) or 2x\n  \
          --serial MODE                  Paula serial port: off, stdout, midi, tcp,\n  \
          \x20                            tcp-connect, or pty\n  \
@@ -1979,6 +1984,7 @@ fn main() -> Result<()> {
         config::resolve_shader(cfg.shader.clone()),
         config::resolve_shader_strength(cfg.shader_strength),
         config::resolve_bezel(cfg.bezel),
+        config::resolve_perf_overlay(cfg.perf_overlay),
         config::resolve_tint(cfg.tint),
         cfg.full_screen,
         !cfg.status_bar,
@@ -2104,6 +2110,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_shader(config::ShaderMode::None),
         config::resolve_shader_strength(1.0),
         config::resolve_bezel(false),
+        config::resolve_perf_overlay(false),
         config::resolve_tint(config::Tint::None),
         // The config-screen placeholder is always a normal windowed UI.
         false,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -425,6 +425,7 @@ pub enum LauncherField {
     Shader,
     ShaderStrength,
     Bezel,
+    PerfOverlay,
     MenuScale,
     StartFullscreen,
     ShowStatusBar,
@@ -694,10 +695,11 @@ const ETHERNET_ROWS: [Row; 2] = [
 ];
 // The A/V & Emu tab is split into three categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
-const VIDEO_ROWS: [Row; 12] = [
+const VIDEO_ROWS: [Row; 13] = [
     row(F::StartFullscreen, "Start fullscreen", Toggle),
     row(F::ShowStatusBar, "Status bar", Toggle),
     row(F::Bezel, "Monitor bezel", Toggle),
+    row(F::PerfOverlay, "Perf overlay", Toggle),
     row(F::MenuScale, "Menu size", Cycle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
@@ -1334,6 +1336,8 @@ pub struct MachineSetup {
     shader_strength: f32,
     /// Monitor-style front bezel around the picture ([display] bezel).
     bezel: bool,
+    /// Performance overlay in the top-right ([display] perf_overlay).
+    perf_overlay: bool,
     /// How large the pop-up menu is drawn ([display] menu_scale).
     menu_scale: MenuScale,
     /// Screen tint ([display] tint).
@@ -1500,6 +1504,7 @@ impl MachineSetup {
             },
             shader_strength: cfg.shader_strength,
             bezel: cfg.bezel,
+            perf_overlay: cfg.perf_overlay,
             menu_scale: cfg.menu_scale,
             tint: cfg.tint,
             start_fullscreen: cfg.full_screen,
@@ -1831,6 +1836,9 @@ impl MachineSetup {
         if self.bezel != base.bezel {
             raw.display.bezel = Some(self.bezel);
         }
+        if self.perf_overlay != base.perf_overlay {
+            raw.display.perf_overlay = Some(self.perf_overlay);
+        }
         if self.tint != base.tint {
             raw.display.tint = Some(tint_name(self.tint).to_string());
         }
@@ -2060,6 +2068,7 @@ impl MachineSetup {
         self.shader = base.shader.clone();
         self.shader_strength = base.shader_strength;
         self.bezel = base.bezel;
+        self.perf_overlay = base.perf_overlay;
         self.tint = base.tint;
         self.menu_scale = base.menu_scale;
         self.start_fullscreen = base.full_screen;
@@ -2350,6 +2359,7 @@ impl MachineSetup {
             F::ShowStatusBar => self.show_status_bar,
             F::Deinterlace => self.deinterlace,
             F::Bezel => self.bezel,
+            F::PerfOverlay => self.perf_overlay,
             F::PowerOn => self.power_on,
             F::RealtimePriority => self.realtime_priority,
             _ => false,
@@ -3112,6 +3122,7 @@ impl MachineSetup {
             F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
             F::Deinterlace => self.deinterlace = !self.deinterlace,
             F::Bezel => self.bezel = !self.bezel,
+            F::PerfOverlay => self.perf_overlay = !self.perf_overlay,
             F::PowerOn => self.power_on = !self.power_on,
             F::BridgeAutoCache => {
                 if let Some(c) = self.bridge_edit_mut() {

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -46,6 +46,7 @@ pub enum MenuAction {
     SetMenuScale(MenuScale),
     ToggleFullscreen,
     ToggleStatusBar,
+    TogglePerfOverlay,
 
     // Input.
     SetPortDevice(usize, PortDevice),
@@ -388,6 +389,7 @@ impl MenuNav {
 pub struct MenuState<'a> {
     pub fullscreen: bool,
     pub status_bar_hidden: bool,
+    pub perf_overlay: bool,
     pub warp: bool,
     pub warp_speed: WarpSpeed,
     pub rewind: bool,
@@ -577,6 +579,7 @@ fn video_rows(s: &MenuState) -> Vec<MenuRow> {
             MenuAction::ToggleStatusBar,
             !s.status_bar_hidden,
         ),
+        MenuRow::toggle("Performance", MenuAction::TogglePerfOverlay, s.perf_overlay),
     ]
 }
 
@@ -924,6 +927,7 @@ mod tests {
         MenuState {
             fullscreen: false,
             status_bar_hidden: false,
+            perf_overlay: false,
             warp: false,
             warp_speed: WarpSpeed::Max,
             rewind: false,

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -1986,7 +1986,7 @@ fn shortcuts_panel_height() -> usize {
         + 10
 }
 
-const SHORTCUT_ROWS: [(&str, &str, bool); 23] = [
+const SHORTCUT_ROWS: [(&str, &str, bool); 24] = [
     ("Q", "Quit", true),
     ("E", "Open the menu", true),
     ("S", "Save screenshot", true),
@@ -2005,6 +2005,7 @@ const SHORTCUT_ROWS: [(&str, &str, bool); 23] = [
     ("Shift+A", "Cycle audio output", true),
     ("F", "Fullscreen on/off", true),
     ("Shift+F", "Status bar on/off", true),
+    ("P", "Performance overlay on/off", true),
     ("W", "Warp speed on/off", true),
     ("Shift+W", "Warp limit (2x..Max)", true),
     ("Z", "Rewind one step", true),
@@ -8209,6 +8210,7 @@ mod tests {
         let rows = menu::build(&menu::MenuState {
             fullscreen: false,
             status_bar_hidden: false,
+            perf_overlay: false,
             warp: false,
             warp_speed: WarpSpeed::Max,
             rewind: false,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3192,7 +3192,6 @@ impl ApplicationHandler for App {
                 let osd = self.active_osd_text();
                 let ui_hover = self.cursor_pos.and_then(|p| self.main_ui_control_at(p));
                 let recording = self.recorder.is_some();
-                let perf_lines = self.perf_overlay.then(|| self.perf.lines.clone());
                 let ui_data = self.build_panel_view_data();
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
@@ -3286,8 +3285,8 @@ impl ApplicationHandler for App {
                         // the badge never appears in the recorded file.
                         draw_record_badge(frame, r.texture_scale);
                     }
-                    if let Some(lines) = &perf_lines {
-                        draw_perf_overlay(frame, lines, r.texture_scale, recording);
+                    if self.perf_overlay {
+                        draw_perf_overlay(frame, &self.perf.lines, r.texture_scale, recording);
                     }
                     if let Some(text) = &osd {
                         draw_osd(frame, text, r.texture_scale);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -435,6 +435,111 @@ struct Osd {
     expires_at: Instant,
 }
 
+/// How often the performance overlay resamples its counters. Twice a
+/// second keeps the numbers readable; per-frame updates flicker.
+const PERF_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Live readout state behind the performance overlay (Cmd/Alt+P,
+/// `[display] perf_overlay`): the formatted lines drawn each frame plus
+/// the counter baseline the next sample's deltas are taken against.
+#[derive(Default)]
+struct PerfOverlay {
+    lines: Vec<String>,
+    /// Bumped whenever `lines` changes so `MainRedrawState` repaints.
+    revision: u64,
+    baseline: Option<PerfBaseline>,
+}
+
+/// One sample of the cumulative counters the overlay derives rates from.
+struct PerfBaseline {
+    at: Instant,
+    /// Whether the machine was advancing when this sample was taken. Rates
+    /// across a pause/resume boundary would mix running and idle time, so a
+    /// flip publishes the idle readout and re-baselines instead.
+    running: bool,
+    emulated_frames: u64,
+    emulated_seconds: f64,
+    busy: std::time::Duration,
+    audio_underrun_frames: u64,
+}
+
+/// The numbers behind one refresh of the performance overlay, derived from
+/// counter deltas by `perf_readout` and formatted by `perf_overlay_lines`.
+/// Kept as plain values so both steps are testable.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+struct PerfReadout {
+    /// Emulated video frames retired per host second.
+    fps: f64,
+    /// Emulated seconds advanced per host second (1.0 = locked to real time).
+    speed: f64,
+    /// Host milliseconds of emulation work per emulated frame (pacing
+    /// sleeps excluded).
+    emu_frame_ms: f64,
+    /// Share of host wall time spent emulating, in percent. In paced mode
+    /// this equals `emu_frame_ms` over the frame period (20.0 ms PAL,
+    /// 16.7 ms NTSC): the share of the host frame budget used.
+    host_percent: f64,
+    /// Live audio output lead in milliseconds (the underrun cushion).
+    audio_lead_ms: f64,
+    /// Audio underrun frames per host second.
+    audio_underruns_per_s: f64,
+    /// Pacer catch-up events since the last guest reset: the machine fell
+    /// hopelessly behind real time and dropped emulated time. Frames are
+    /// never skipped in paced mode; this counts the only case where time is.
+    pacer_slips: u32,
+}
+
+fn perf_readout(
+    base: &PerfBaseline,
+    current: &PerfBaseline,
+    audio_lead_ms: f64,
+    pacer_slips: u32,
+) -> PerfReadout {
+    let dt = current.at.duration_since(base.at).as_secs_f64();
+    if dt <= 0.0 {
+        return PerfReadout {
+            audio_lead_ms,
+            pacer_slips,
+            ..Default::default()
+        };
+    }
+    // Counters that moved backwards (a guest reset cleared the stats, a
+    // timeline jump rewound the machine) saturate to an empty window; the
+    // next sample is taken against the fresh values.
+    let frames = current.emulated_frames.saturating_sub(base.emulated_frames) as f64;
+    let busy = current.busy.saturating_sub(base.busy).as_secs_f64();
+    let emulated = (current.emulated_seconds - base.emulated_seconds).max(0.0);
+    let underruns = current
+        .audio_underrun_frames
+        .saturating_sub(base.audio_underrun_frames) as f64;
+    PerfReadout {
+        fps: frames / dt,
+        speed: emulated / dt,
+        emu_frame_ms: if frames > 0.0 {
+            busy * 1000.0 / frames
+        } else {
+            0.0
+        },
+        host_percent: busy / dt * 100.0,
+        audio_lead_ms,
+        audio_underruns_per_s: underruns / dt,
+        pacer_slips,
+    }
+}
+
+/// One line per data point, top to bottom as drawn.
+fn perf_overlay_lines(r: &PerfReadout) -> Vec<String> {
+    vec![
+        format!("{:.1} fps", r.fps),
+        format!("x{:.2}", r.speed),
+        format!("emu {:.1} ms", r.emu_frame_ms),
+        format!("host {:.0}%", r.host_percent),
+        format!("audio {:.0} ms", r.audio_lead_ms),
+        format!("xrun {:.0}", r.audio_underruns_per_s),
+        format!("slip {}", r.pacer_slips),
+    ]
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct KeyPressSpec {
     pub secs: f32,
@@ -827,6 +932,12 @@ pub struct App {
     /// Monitor-bezel pass in effect ([display] bezel, Cmd/Alt+M).
     /// Presentation only, like the shader pass: captures never include it.
     bezel: bool,
+    /// Performance overlay in effect ([display] perf_overlay, Cmd/Alt+P):
+    /// a live emulation-performance readout in the top-right of the
+    /// display. Presentation only, like the OSD: captures never include it.
+    perf_overlay: bool,
+    /// The overlay's formatted lines and sampling baseline.
+    perf: PerfOverlay,
     /// Screen tint in effect ([display] tint). Presentation only, applied
     /// to the chipset display region of the window frame: captures and
     /// RTG board scanout are never tinted.
@@ -1125,6 +1236,9 @@ struct MainRedrawState {
     recording: bool,
     input_recording: bool,
     warp: bool,
+    /// The performance overlay's line revision (0 while hidden), so a
+    /// resample repaints an otherwise static frame.
+    perf_revision: u64,
 }
 
 struct RenderWorker {
@@ -1229,6 +1343,7 @@ impl App {
         shader: crate::config::ShaderMode,
         shader_strength: f32,
         bezel: bool,
+        perf_overlay: bool,
         tint: crate::config::Tint,
         start_fullscreen: bool,
         hide_status_bar: bool,
@@ -1401,6 +1516,8 @@ impl App {
             },
             shader_strength,
             bezel,
+            perf_overlay,
+            perf: PerfOverlay::default(),
             tint,
             tint_lut: tint_lut(tint),
             start_fullscreen,
@@ -2667,6 +2784,11 @@ impl ApplicationHandler for App {
                     {
                         self.toggle_bezel()
                     }
+                    (KeyCode::KeyP, ElementState::Pressed)
+                        if host_shortcut_modifier_pressed(self.modifiers) =>
+                    {
+                        self.toggle_perf_overlay()
+                    }
                     (KeyCode::KeyF, ElementState::Pressed)
                         if host_shortcut_modifier_pressed(self.modifiers)
                             && self.modifiers.shift_key() =>
@@ -3070,6 +3192,7 @@ impl ApplicationHandler for App {
                 let osd = self.active_osd_text();
                 let ui_hover = self.cursor_pos.and_then(|p| self.main_ui_control_at(p));
                 let recording = self.recorder.is_some();
+                let perf_lines = self.perf_overlay.then(|| self.perf.lines.clone());
                 let ui_data = self.build_panel_view_data();
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
@@ -3162,6 +3285,9 @@ impl ApplicationHandler for App {
                         // Painted into the presentation texture only, so
                         // the badge never appears in the recorded file.
                         draw_record_badge(frame, r.texture_scale);
+                    }
+                    if let Some(lines) = &perf_lines {
+                        draw_perf_overlay(frame, lines, r.texture_scale, recording);
                     }
                     if let Some(text) = &osd {
                         draw_osd(frame, text, r.texture_scale);
@@ -3426,6 +3552,9 @@ impl ApplicationHandler for App {
             }
             self.refresh_tool_windows_paced(event_loop);
         }
+        // Resample the performance overlay after the step so its revision
+        // is current when the redraw decision below is taken.
+        self.update_perf_overlay(running);
         // While powered off, leave the parked test screen in place; the
         // emulator is not advancing, so there is no new frame to show.
         let mut rendered = self.powered_on && self.render_emulated_frame_if_needed();
@@ -4090,6 +4219,11 @@ impl App {
             recording: self.recorder.is_some(),
             input_recording: self.input_recorder.is_some(),
             warp: !self.emu.paced(),
+            perf_revision: if self.perf_overlay {
+                self.perf.revision
+            } else {
+                0
+            },
         }
     }
 
@@ -4449,6 +4583,7 @@ impl App {
         let state = MenuState {
             fullscreen,
             status_bar_hidden: crate::video::status_bar_hidden(),
+            perf_overlay: self.perf_overlay,
             warp: !self.emu.paced(),
             warp_speed: self.warp_speed,
             rewind: self.rewind_armed,
@@ -4637,6 +4772,7 @@ impl App {
             }
             A::ToggleFullscreen => self.toggle_fullscreen(),
             A::ToggleStatusBar => self.toggle_status_bar(),
+            A::TogglePerfOverlay => self.toggle_perf_overlay(),
 
             A::SetPortDevice(port, device) => {
                 self.hot_plug_port_device(port, device);
@@ -6390,6 +6526,8 @@ impl App {
         }
         self.shader_strength = crate::config::resolve_shader_strength(cfg.shader_strength);
         self.bezel = crate::config::resolve_bezel(cfg.bezel);
+        self.perf_overlay = crate::config::resolve_perf_overlay(cfg.perf_overlay);
+        self.perf = PerfOverlay::default();
         self.set_tint(crate::config::resolve_tint(cfg.tint));
         crate::video::set_menu_scale(cfg.menu_scale);
         self.ui.menu_open = false;
@@ -9019,6 +9157,63 @@ impl App {
         info!("monitor bezel: {label}");
         self.show_osd(format!("Monitor bezel: {label}"));
         self.request_redraw();
+    }
+
+    /// Cmd/Alt+P: toggle the performance overlay for the rest of the run
+    /// (the config file default is unchanged; set `[display] perf_overlay`
+    /// to make it stick).
+    fn toggle_perf_overlay(&mut self) {
+        self.perf_overlay = !self.perf_overlay;
+        self.perf = PerfOverlay::default();
+        let label = if self.perf_overlay { "on" } else { "off" };
+        info!("performance overlay: {label}");
+        self.show_osd(format!("Performance overlay: {label}"));
+        self.request_redraw();
+    }
+
+    /// Resample the performance overlay counters and reformat its lines
+    /// when the interval has elapsed. A run-state flip (pause, power-off,
+    /// halt) publishes the idle readout immediately and re-baselines, so
+    /// rates are never computed across the boundary.
+    fn update_perf_overlay(&mut self, running: bool) {
+        if !self.perf_overlay {
+            return;
+        }
+        let now = Instant::now();
+        if let Some(base) = &self.perf.baseline {
+            if base.running == running && now.duration_since(base.at) < PERF_SAMPLE_INTERVAL {
+                return;
+            }
+        }
+        let audio = self.emu.bus().live_audio_status();
+        let counters = self.emu.perf_counters();
+        let current = PerfBaseline {
+            at: now,
+            running,
+            emulated_frames: self.emu.bus().emulated_frames(),
+            emulated_seconds: self.emu.bus().emulated_seconds(),
+            busy: counters.busy,
+            audio_underrun_frames: audio.callback_underrun_frames,
+        };
+        let audio_lead_ms = audio.output_lead_seconds * 1000.0;
+        let readout = match &self.perf.baseline {
+            Some(base) if base.running == running && running => {
+                perf_readout(base, &current, audio_lead_ms, counters.pacer_slips)
+            }
+            // First sample after enabling, a run-state flip, or an idle
+            // machine: rates are zero by definition, only the levels show.
+            _ => PerfReadout {
+                audio_lead_ms,
+                pacer_slips: counters.pacer_slips,
+                ..Default::default()
+            },
+        };
+        self.perf.baseline = Some(current);
+        let lines = perf_overlay_lines(&readout);
+        if lines != self.perf.lines {
+            self.perf.lines = lines;
+            self.perf.revision = self.perf.revision.wrapping_add(1);
+        }
     }
 
     /// Install a screen tint and its presentation table together.

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1744,6 +1744,67 @@ pub(super) fn draw_record_badge(frame: &mut [u8], texture_scale: usize) {
     );
 }
 
+/// Right-aligned performance readout in the top-right of the display
+/// (Cmd/Alt+P, `[display] perf_overlay`): one line per data point, same
+/// font size as the menus (it follows the Menu Size setting, so it stays
+/// small at the default 1x rather than taking the larger OSD size).
+/// Painted into the presentation texture only, like the record badge, so
+/// captures never include it; while a recording badge is up the block
+/// starts below it instead of fighting for the corner.
+pub(super) fn draw_perf_overlay(
+    frame: &mut [u8],
+    lines: &[String],
+    texture_scale: usize,
+    below_record_badge: bool,
+) {
+    let s = texture_scale;
+    let px = crate::video::menu_scale().factor() * s;
+    let pad = 4 * s;
+    let margin = 8 * s;
+    let line_gap = 2 * s;
+
+    let text_h = font::text_height(px);
+    let text_w = lines
+        .iter()
+        .map(|line| font::text_width(line, px))
+        .max()
+        .unwrap_or(0);
+    if text_w == 0 {
+        return;
+    }
+    let box_w = text_w + 2 * pad;
+    let box_h = lines.len() * text_h + lines.len().saturating_sub(1) * line_gap + 2 * pad;
+    let box_x = (FB_WIDTH * s).saturating_sub(margin + box_w);
+    let record_badge_h = font::text_height(2 * s) + 2 * (4 * s);
+    let box_y = if below_record_badge {
+        margin + record_badge_h + 4 * s
+    } else {
+        margin
+    };
+
+    fill_rect_blend(
+        frame,
+        Rect {
+            x: box_x,
+            y: box_y,
+            w: box_w,
+            h: box_h,
+        },
+        OSD_BG,
+        0.68,
+        s,
+    );
+    let fw = texture_width(s);
+    let fh = texture_height(s);
+    let mut y = box_y + pad;
+    for line in lines {
+        let x = box_x + pad + text_w - font::text_width(line, px);
+        font::draw_text(frame, fw, fh, x + s, y + s, line, OSD_SHADOW, px);
+        font::draw_text(frame, fw, fh, x, y, line, OSD_TEXT, px);
+        y += text_h + line_gap;
+    }
+}
+
 pub(super) fn draw_osd(frame: &mut [u8], text: &str, texture_scale: usize) {
     let s = texture_scale;
     let px = 2 * s; // font pixel -> device pixels

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2869,6 +2869,7 @@ fn test_app_with_audio_cpu_and_program(
         crate::config::ShaderMode::None,
         1.0,
         false,
+        false,
         crate::config::Tint::None,
         false,
         false,
@@ -6941,4 +6942,143 @@ fn draw_re_applies_a_surface_size_the_window_has_moved_past() {
     // minimized guard sees the 0x0 rather than the surface keeping its old
     // size unnoticed.
     assert_eq!(resize((1432, 1162), (0, 0)), Some((0, 0)));
+}
+
+// --- Performance overlay (issue #370) ---
+
+#[test]
+fn perf_readout_derives_rates_from_counter_deltas() {
+    let t0 = std::time::Instant::now();
+    let base = super::PerfBaseline {
+        at: t0,
+        running: true,
+        emulated_frames: 1000,
+        emulated_seconds: 20.0,
+        busy: std::time::Duration::from_millis(100),
+        audio_underrun_frames: 0,
+    };
+    let current = super::PerfBaseline {
+        at: t0 + std::time::Duration::from_secs(2),
+        running: true,
+        // 100 frames and 2.0 emulated seconds in 2 s host: 50 fps, x1.00.
+        emulated_frames: 1100,
+        emulated_seconds: 22.0,
+        // 800 ms of busy time over 100 frames: 8 ms/frame, 40% of the host.
+        busy: std::time::Duration::from_millis(900),
+        // 10 underrun frames over the window: 5 per second.
+        audio_underrun_frames: 10,
+    };
+    let r = super::perf_readout(&base, &current, 150.0, 3);
+    assert!((r.fps - 50.0).abs() < 1e-9);
+    assert!((r.speed - 1.0).abs() < 1e-9);
+    assert!((r.emu_frame_ms - 8.0).abs() < 1e-9);
+    assert!((r.host_percent - 40.0).abs() < 1e-9);
+    assert!((r.audio_lead_ms - 150.0).abs() < 1e-9);
+    assert!((r.audio_underruns_per_s - 5.0).abs() < 1e-9);
+    assert_eq!(r.pacer_slips, 3);
+}
+
+#[test]
+fn perf_readout_saturates_counters_that_moved_backwards() {
+    // A guest reset cleared the cumulative stats mid-window; the readout
+    // reports an empty window instead of going negative.
+    let t0 = std::time::Instant::now();
+    let base = super::PerfBaseline {
+        at: t0,
+        running: true,
+        emulated_frames: 1000,
+        emulated_seconds: 20.0,
+        busy: std::time::Duration::from_millis(500),
+        audio_underrun_frames: 10,
+    };
+    let current = super::PerfBaseline {
+        at: t0 + std::time::Duration::from_secs(1),
+        running: true,
+        emulated_frames: 5,
+        emulated_seconds: 0.1,
+        busy: std::time::Duration::from_millis(2),
+        audio_underrun_frames: 0,
+    };
+    let r = super::perf_readout(&base, &current, 0.0, 0);
+    assert!(r.fps >= 0.0 && r.fps <= 5.0);
+    assert!(r.speed >= 0.0);
+    assert_eq!(r.host_percent, 0.0);
+    assert_eq!(r.audio_underruns_per_s, 0.0);
+}
+
+#[test]
+fn perf_overlay_lines_format_one_data_point_per_line() {
+    let r = super::PerfReadout {
+        fps: 49.96,
+        speed: 0.999,
+        emu_frame_ms: 3.21,
+        host_percent: 16.4,
+        audio_lead_ms: 148.3,
+        audio_underruns_per_s: 0.0,
+        pacer_slips: 2,
+    };
+    assert_eq!(
+        super::perf_overlay_lines(&r),
+        vec![
+            "50.0 fps",
+            "x1.00",
+            "emu 3.2 ms",
+            "host 16%",
+            "audio 148 ms",
+            "xrun 0",
+            "slip 2",
+        ]
+    );
+}
+
+#[test]
+fn perf_overlay_draws_top_right_and_steps_below_the_record_badge() {
+    let scale = 1;
+    let lines = vec!["50.0 fps".to_string(), "slip 0".to_string()];
+    let margin = 8;
+    let probe_x = crate::video::FB_WIDTH - margin - 1;
+    let probe_y = margin + 2;
+
+    let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+    super::draw_perf_overlay(&mut frame, &lines, scale, false);
+    // The backing box reaches the top-right margin corner...
+    assert_ne!(pixel(&frame, probe_x, probe_y, scale), [0, 0, 0, 0]);
+    // ...and the top-left of the display is untouched.
+    assert_eq!(pixel(&frame, margin, probe_y, scale), [0, 0, 0, 0]);
+
+    // With the record badge up the block starts below it, leaving the
+    // badge's corner rows alone.
+    let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+    super::draw_perf_overlay(&mut frame, &lines, scale, true);
+    assert_eq!(pixel(&frame, probe_x, probe_y, scale), [0, 0, 0, 0]);
+
+    // Nothing to draw is a no-op, not a stray empty box.
+    let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
+    super::draw_perf_overlay(&mut frame, &[], scale, false);
+    assert!(frame.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn perf_counters_accrue_busy_time_and_reset_with_the_guest() {
+    let mut app = test_app();
+    app.emu.step_frame().expect("step");
+    let counters = app.emu.perf_counters();
+    assert!(counters.busy > std::time::Duration::ZERO);
+    assert_eq!(counters.pacer_slips, 0);
+    // A guest reset clears the counters with the rest of the stats.
+    app.emu.keyboard_reset().expect("reset");
+    let counters = app.emu.perf_counters();
+    assert_eq!(counters.busy, std::time::Duration::ZERO);
+    assert_eq!(counters.pacer_slips, 0);
+}
+
+#[test]
+fn pacer_counts_a_slip_when_it_reanchors_past_the_catchup_limit() {
+    let mut app = test_app();
+    app.emu.set_paced(true);
+    // Pretend the run started long ago: the pacer sees a hopeless lag,
+    // re-anchors instead of sleeping, and counts the dropped time.
+    app.emu.stats.started_at = Some(std::time::Instant::now() - std::time::Duration::from_secs(10));
+    app.emu.step_frame().expect("step");
+    assert_eq!(app.emu.perf_counters().pacer_slips, 1);
 }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -6948,23 +6948,23 @@ fn draw_re_applies_a_surface_size_the_window_has_moved_past() {
 
 #[test]
 fn perf_readout_derives_rates_from_counter_deltas() {
-    let t0 = std::time::Instant::now();
+    let t0 = crate::timebase::Instant::now();
     let base = super::PerfBaseline {
         at: t0,
         running: true,
         emulated_frames: 1000,
         emulated_seconds: 20.0,
-        busy: std::time::Duration::from_millis(100),
+        busy: crate::timebase::Duration::from_millis(100),
         audio_underrun_frames: 0,
     };
     let current = super::PerfBaseline {
-        at: t0 + std::time::Duration::from_secs(2),
+        at: t0 + crate::timebase::Duration::from_secs(2),
         running: true,
         // 100 frames and 2.0 emulated seconds in 2 s host: 50 fps, x1.00.
         emulated_frames: 1100,
         emulated_seconds: 22.0,
         // 800 ms of busy time over 100 frames: 8 ms/frame, 40% of the host.
-        busy: std::time::Duration::from_millis(900),
+        busy: crate::timebase::Duration::from_millis(900),
         // 10 underrun frames over the window: 5 per second.
         audio_underrun_frames: 10,
     };
@@ -6982,21 +6982,21 @@ fn perf_readout_derives_rates_from_counter_deltas() {
 fn perf_readout_saturates_counters_that_moved_backwards() {
     // A guest reset cleared the cumulative stats mid-window; the readout
     // reports an empty window instead of going negative.
-    let t0 = std::time::Instant::now();
+    let t0 = crate::timebase::Instant::now();
     let base = super::PerfBaseline {
         at: t0,
         running: true,
         emulated_frames: 1000,
         emulated_seconds: 20.0,
-        busy: std::time::Duration::from_millis(500),
+        busy: crate::timebase::Duration::from_millis(500),
         audio_underrun_frames: 10,
     };
     let current = super::PerfBaseline {
-        at: t0 + std::time::Duration::from_secs(1),
+        at: t0 + crate::timebase::Duration::from_secs(1),
         running: true,
         emulated_frames: 5,
         emulated_seconds: 0.1,
-        busy: std::time::Duration::from_millis(2),
+        busy: crate::timebase::Duration::from_millis(2),
         audio_underrun_frames: 0,
     };
     let r = super::perf_readout(&base, &current, 0.0, 0);
@@ -7063,12 +7063,12 @@ fn perf_counters_accrue_busy_time_and_reset_with_the_guest() {
     let mut app = test_app();
     app.emu.step_frame().expect("step");
     let counters = app.emu.perf_counters();
-    assert!(counters.busy > std::time::Duration::ZERO);
+    assert!(counters.busy > crate::timebase::Duration::ZERO);
     assert_eq!(counters.pacer_slips, 0);
     // A guest reset clears the counters with the rest of the stats.
     app.emu.keyboard_reset().expect("reset");
     let counters = app.emu.perf_counters();
-    assert_eq!(counters.busy, std::time::Duration::ZERO);
+    assert_eq!(counters.busy, crate::timebase::Duration::ZERO);
     assert_eq!(counters.pacer_slips, 0);
 }
 
@@ -7078,7 +7078,8 @@ fn pacer_counts_a_slip_when_it_reanchors_past_the_catchup_limit() {
     app.emu.set_paced(true);
     // Pretend the run started long ago: the pacer sees a hopeless lag,
     // re-anchors instead of sleeping, and counts the dropped time.
-    app.emu.stats.started_at = Some(std::time::Instant::now() - std::time::Duration::from_secs(10));
+    app.emu.stats.started_at =
+        Some(crate::timebase::Instant::now() - crate::timebase::Duration::from_secs(10));
     app.emu.step_frame().expect("step");
     assert_eq!(app.emu.perf_counters().pacer_slips, 1);
 }


### PR DESCRIPTION
Closes #370.

`Cmd+P` (macOS) / `Alt+P`, *Video Settings > Performance*, `[display] perf_overlay`, `--perf-overlay`, or `COPPERLINE_PERF_OVERLAY=1` shows a live emulation-performance readout in the top-right corner of the display: right-aligned, one line per data point at the menu font size (it follows *Menu Size*), refreshed twice a second.

| Line | Meaning |
|---|---|
| `50.0 fps` | Emulated video frames retired per host second |
| `x1.00` | Speed factor: emulated seconds per host second (the effective multiplier under warp) |
| `emu 3.2 ms` | Host ms of emulation work per emulated frame, pacing sleeps excluded |
| `host 16%` | Share of host wall time spent emulating; in real-time mode, the share of the frame budget used per frame |
| `audio 148 ms` | Live audio output lead (the underrun cushion) |
| `xrun 0` | Audio underrun frames per second |
| `slip 0` | Pacer catch-up events that dropped emulated time, since the last guest reset |

The `slip` line is the answer to the issue's footnote: Copperline never skips frames in paced mode -- when the host cannot keep up the machine slows down (fps and the speed factor fall while `host` sits near 100%), and only a stall beyond the pacer's ~100 ms catch-up limit drops emulated time, which this counts.

## Implementation

- Two always-on counters in `EmuStats` (cleared by every guest-reset path): busy time, measured in `step_real` as elapsed minus the pacing sleep (`sleep_until_realtime_device_time` now returns the slept duration), and pacer slips, counted at the catch-up re-anchor site. Two `Instant` reads per emulated frame, via `crate::timebase`, so headless and wasm builds are unaffected.
- The window samples the counters at 2 Hz and derives rates from deltas (`perf_readout` / `perf_overlay_lines`, both pure and unit-tested). Counters that move backwards (guest reset, timeline jump) saturate to an empty window; a pause/resume flip re-baselines instead of computing rates across the boundary. `host %` is busy/wall over the window, which is self-calibrating for PAL/NTSC and stays meaningful under warp.
- Drawing (`draw_perf_overlay` in statusbar.rs) follows `draw_record_badge`: painted into the presentation texture only, so screenshots, frame dumps, and recordings never include it, and the block steps below the `REC` badge while recording. Repaints are keyed by a line revision in `MainRedrawState`.
- Toggle surface mirrors the bezel: menu row, shortcut, config key, env override, CLI flag, launcher row (persisted to the TOML).
- The control protocol's `status` reply now reports `host_busy_ms`, `pacer_slips`, `audio_lead_ms`, and `audio_underrun_frames`, so headless clients can derive the same rates from two calls.

Docs updated: `docs/guide/ui.md` (shortcut table, Video Settings row, a new Performance overlay section), `docs/guide/configuration.md`, `docs/debugger/control.md`, `copperline.example.toml`.

## Testing

- 7 new unit tests: readout derivation, backwards-counter saturation, line formatting, top-right/below-badge/empty drawing, busy-counter accrual and guest-reset clearing, and the pacer slip count.
- Full suite, `cargo clippy`, and `cargo fmt --check` all clean.