### PR TITLE
cdrom: add CHD CD image support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +424,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chd"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e16e43ebc68e33e0c66f7158ca00f0a6eb2c1241556a8ceb36deaeb4299986"
+dependencies = [
+ "arrayvec",
+ "bitreader",
+ "byteorder",
+ "claxon",
+ "crc",
+ "flate2",
+ "lzma-rs-perf-exp",
+ "num-derive",
+ "num-traits",
+ "ruzstd",
+ "text_io",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +452,12 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "clipboard-win"
@@ -487,6 +521,7 @@ dependencies = [
  "arboard",
  "bincode",
  "cc",
+ "chd",
  "cpal",
  "env_logger",
  "flate2",
@@ -907,6 +942,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1196,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1734,6 +1785,16 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lzma-rs-perf-exp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38435c1305548bb408c98242841c3cf161246323e72a3e4433787f3c05bf18ee"
+dependencies = [
+ "byteorder",
+ "crc",
+]
 
 [[package]]
 name = "m68k"
@@ -2819,6 +2880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,6 +3158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8d3ca3b06292094e03841d8995e910712d2a10b5869c8f9725385b29761115"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,6 +3345,12 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "ultraviolet"
@@ -4612,6 +4694,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,9 @@ smoltcp = { version = "0.12", default-features = false, features = [
 # optional realtime-priority feature (see src/priority.rs).
 libc = "0.2"
 zerocopy = { version = "0.8", features = ["derive"] }
+# CHD (MAME "Compressed Hunks of Data") CD images (src/cdrom/chd.rs). Pure
+# Rust, so it builds for wasm32 browser targets like the rest of the core.
+chd = "0.3"
 
 # macOS dock icon: winit's with_window_icon is a no-op on macOS, so the dock
 # icon must be set at runtime via NSApplication. These objc2 versions match the

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -174,9 +174,9 @@ model = "68000"
 # extended_rom = "cdtv-extended.rom"
 
 
-# CD image (BIN/CUE, single- or multi-file; MODE1/2048, MODE1/2352,
-# and AUDIO tracks), mounted on the machine's CD controller (CD32
-# Akiko or CDTV DMAC). insert_delay inserts the disc that many
+# CD image (BIN/CUE, single- or multi-file, with MODE1/2048, MODE1/2352,
+# and AUDIO tracks; a bare .iso; or a chdman v5 .chd), mounted on the
+# machine's CD controller (CD32 Akiko or CDTV DMAC). insert_delay inserts the disc that many
 # emulated seconds after power-on instead of at boot: some CDTV discs
 # (e.g. Xenon II) only boot when inserted after the boot screen, on
 # real hardware too.
@@ -280,8 +280,8 @@ slow = "512K"
 # autoboots on Kickstart 1.3+, so it does not depend on the Kickstart IDE
 # driver (which only probes the master on stock 3.1). Drive paths accept the
 # same images as [ide]: RDB HDFs, bare partition hardfiles, or host
-# directories. A path ending in .cue or .iso attaches a SCSI CD-ROM drive
-# at that ID instead (read-only; mount it in the guest with a CD filesystem
+# directories. A path ending in .cue, .iso, or .chd attaches a SCSI CD-ROM
+# drive at that ID instead (read-only; mount it in the guest with a CD filesystem
 # pointed at the controller's scsi.device and that unit number). CD audio
 # tracks play through the machine's audio output, and discs swap at runtime
 # (status-bar CD buttons, drag-and-drop, --insert-cd-after).

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -15,6 +15,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +48,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -56,6 +83,31 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chd"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e16e43ebc68e33e0c66f7158ca00f0a6eb2c1241556a8ceb36deaeb4299986"
+dependencies = [
+ "arrayvec",
+ "bitreader",
+ "byteorder",
+ "claxon",
+ "crc",
+ "flate2",
+ "lzma-rs-perf-exp",
+ "num-derive",
+ "num-traits",
+ "ruzstd",
+ "text_io",
+]
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -84,6 +136,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "cc",
+ "chd",
  "flate2",
  "hound",
  "libc",
@@ -113,6 +166,21 @@ dependencies = [
  "log",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -168,6 +236,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -240,6 +309,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lzma-rs-perf-exp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38435c1305548bb408c98242841c3cf161246323e72a3e4433787f3c05bf18ee"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "m68k"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +341,26 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -388,6 +487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8d3ca3b06292094e03841d8995e910712d2a10b5869c8f9725385b29761115"
+
+[[package]]
 name = "thread-priority"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +632,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "unicode-ident"
@@ -728,3 +848,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1242,9 +1242,9 @@ appears in the status bar on IDE machines. On the `A4000` profile the same
 `$DD2020` (no Gayle involved; Kickstart's `scsi.device` drives it the same
 way).
 
-CD images (`.cue`/`.iso`) are rejected here: the emulated IDE port speaks
-plain ATA, not ATAPI. Attach CD-ROM drives as `[scsi]` units instead (see
-below).
+CD images (`.cue`/`.iso`/`.chd`) are rejected here: the emulated IDE port
+speaks plain ATA, not ATAPI. Attach CD-ROM drives as `[scsi]` units instead
+(see below).
 
 ## `[scsi]` -- SCSI controllers
 
@@ -1255,7 +1255,7 @@ rom = "a2091-v6.6.rom"       # boot ROM image (a2091/a4091; the a3000 needs none
 # rom_odd = "a2091-odd.rom"  # a2091 only: split even/odd EPROM dumps
 unit0 = "workbench.hdf"      # SCSI IDs 0-6
 unit1 = "data.hdf"
-unit2 = "game.cue"           # a .cue or .iso attaches a CD-ROM drive
+unit2 = "game.cue"           # a .cue, .iso, or .chd attaches a CD-ROM drive
 # unit3..unit6 = ...
 ```
 
@@ -1295,12 +1295,12 @@ in-memory FFS volumes -- including the
 directory mount's volume name and the synthesized partition's boot
 priority. The HDD activity LED covers SCSI traffic too.
 
-A `unitN` path ending in `.cue` or `.iso` attaches a **SCSI CD-ROM
-drive** at that ID instead of a hard disk: a read-only removable SCSI-2
-target (INQUIRY device type 5) serving 2048-byte blocks, with the full
-READ TOC / READ CD / mode-page surface CD filesystems expect. Cue/bin
-images may mix data and audio tracks; a bare `.iso` is a single data
-track. The drive answers on the host adapter's `scsi.device` like any
+A `unitN` path ending in `.cue`, `.iso`, or `.chd` attaches a **SCSI
+CD-ROM drive** at that ID instead of a hard disk: a read-only removable
+SCSI-2 target (INQUIRY device type 5) serving 2048-byte blocks, with the
+full READ TOC / READ CD / mode-page surface CD filesystems expect.
+Cue/bin and CHD images may mix data and audio tracks; a bare `.iso` is a
+single data track. The drive answers on the host adapter's `scsi.device` like any
 other unit, so mount it the way you would on real hardware: a
 `DOSDrivers` mount entry (or MountList) pointing `CDFileSystem` --
 CacheCDFS, AsimCDFS, and AmiCDROM work the same way -- at the controller's
@@ -1312,10 +1312,10 @@ emulated time (as if the drive's analogue output were cabled to the
 machine), the sub-channel reports the live playback position, and the
 debugger's Audio tab shows the stream on its CD-DA row with the play
 state, track, and position. Discs swap at runtime like CDTV/CD32 media:
-the status bar's CD load/eject buttons, dropping a `.cue`/`.iso` on the
-window, the scheduled `--insert-cd-after SECS PATH` flag, or the control
-protocol's `media.cd.insert` all eject the current disc, run the tray
-for a second of emulated time, and mount the new one with a
+the status bar's CD load/eject buttons, dropping a `.cue`/`.iso`/`.chd`
+on the window, the scheduled `--insert-cd-after SECS PATH` flag, or the
+control protocol's `media.cd.insert` all eject the current disc, run the
+tray for a second of emulated time, and mount the new one with a
 medium-change unit attention for the guest's filesystem to notice.
 
 ## `[[filesys]]` -- host directories as live volumes
@@ -1384,6 +1384,9 @@ insert_delay = 0.0        # emulated seconds after power-on to insert
 # nvram = "cd32-nvram.bin" # CD32 save-game EEPROM backing file (default)
 ```
 
+`image` takes a BIN/CUE cue sheet, a bare `.iso` (single data track), or
+a `.chd` -- MAME's compressed CHD CD format (v5, as chdman's `createcd`
+writes: LZMA/Deflate/FLAC-compressed hunks with data and audio tracks).
 The disc mounts on the machine's CD controller: Akiko on CD32, the DMAC on
 CDTV. `insert_delay` inserts the disc some emulated seconds after power-on
 with the proper media-change notification; some CDTV discs only boot when

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -84,7 +84,7 @@ deterministically:
 | `--floppy-drives COUNT` | Connect `COUNT` floppy drives (`1` to `4`), so scheduled inserts can target empty external drives |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--defer-disk-insert SECS DFN` | Start with the configured drive empty, then insert its configured image |
-| `--insert-cd-after SECS PATH` | Swap the CD image (`.cue`/`.iso`) in the machine's CD drive (CDTV, CD32, or a SCSI CD-ROM unit) |
+| `--insert-cd-after SECS PATH` | Swap the CD image (`.cue`/`.iso`/`.chd`) in the machine's CD drive (CDTV, CD32, or a SCSI CD-ROM unit) |
 | `--script FILE` | Run scripted-input directives from a file (below) |
 | `--record-input PATH` | Record all machine-bound input for the whole run; the script is written to PATH on exit |
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -83,8 +83,8 @@ Status Bar*):
   drive, and changing it is done by hand (see [](floppybridge)).
 - **CD controls** on machines with a CD drive (CDTV, CD32, or a SCSI
   CD-ROM unit): a CD button that loads (or swaps) a CD image
-  (`.cue`/`.iso`) with the proper media-change notification, and a CD
-  eject button. These do not appear on machines without a CD drive.
+  (`.cue`/`.iso`/`.chd`) with the proper media-change notification, and a
+  CD eject button. These do not appear on machines without a CD drive.
 - **Joystick toggle** (just left of the volume control): a gamepad or
   keyboard icon showing which source drives the joystick port. Click it to
   flip between gamepad-only and keyboard joystick emulation; see
@@ -140,8 +140,8 @@ Disk images can be dropped anywhere on the emulator window:
   (`1`-`4`), or press `Esc` to cancel. Dropping several floppies at once
   queues them all as the target drive's swap playlist, exactly like a
   multi-selection in the disk dialog.
-- **CD images** (`.cue`/`.iso`) mount in the machine's CD drive (CDTV,
-  CD32, or a SCSI CD-ROM unit), with the media-change notification.
+- **CD images** (`.cue`/`.iso`/`.chd`) mount in the machine's CD drive
+  (CDTV, CD32, or a SCSI CD-ROM unit), with the media-change notification.
 - **Hard disk images and Kickstart ROMs** cannot be swapped at runtime; a
   notice points at the machine-configuration screen, which also refuses
   drops while it is open.
@@ -578,7 +578,8 @@ not silently mixed in. Two caveats:
   hard drive *after* the snapshot are still visible after restoring --
   treat a state as a CPU/chipset snapshot, not a disk backup. In-memory
   volumes (directory-as-HDD) and floppy images are embedded whole.
-- CD images are likewise reopened by path; keep the cue/bin where it was.
+- CD images are likewise reopened by path; keep the cue/bin (or CHD)
+  where it was.
 
 ### Quick-save slots
 

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -418,6 +418,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitreader/bitreader-0.3.11.crate",
+        "sha256": "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066",
+        "dest": "cargo/vendor/bitreader-0.3.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066\", \"files\": {}}",
+        "dest": "cargo/vendor/bitreader-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/block2/block2-0.5.1.crate",
         "sha256": "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f",
         "dest": "cargo/vendor/block2-0.5.1"
@@ -600,6 +613,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chd/chd-0.3.4.crate",
+        "sha256": "03e16e43ebc68e33e0c66f7158ca00f0a6eb2c1241556a8ceb36deaeb4299986",
+        "dest": "cargo/vendor/chd-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03e16e43ebc68e33e0c66f7158ca00f0a6eb2c1241556a8ceb36deaeb4299986\", \"files\": {}}",
+        "dest": "cargo/vendor/chd-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.8.1.crate",
         "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
         "dest": "cargo/vendor/clang-sys-1.8.1"
@@ -608,6 +634,19 @@
         "type": "inline",
         "contents": "{\"package\": \"0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4\", \"files\": {}}",
         "dest": "cargo/vendor/clang-sys-1.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/claxon/claxon-0.4.3.crate",
+        "sha256": "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688",
+        "dest": "cargo/vendor/claxon-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688\", \"files\": {}}",
+        "dest": "cargo/vendor/claxon-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1141,6 +1180,32 @@
         "type": "inline",
         "contents": "{\"package\": \"004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0\", \"files\": {}}",
         "dest": "cargo/vendor/cranelift-srcgen-0.132.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc/crc-3.4.0.crate",
+        "sha256": "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d",
+        "dest": "cargo/vendor/crc-3.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d\", \"files\": {}}",
+        "dest": "cargo/vendor/crc-3.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc-catalog/crc-catalog-2.5.0.crate",
+        "sha256": "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853",
+        "dest": "cargo/vendor/crc-catalog-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853\", \"files\": {}}",
+        "dest": "cargo/vendor/crc-catalog-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2337,6 +2402,19 @@
         "type": "inline",
         "contents": "{\"package\": \"953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a\", \"files\": {}}",
         "dest": "cargo/vendor/log-0.4.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lzma-rs-perf-exp/lzma-rs-perf-exp-0.2.1.crate",
+        "sha256": "38435c1305548bb408c98242841c3cf161246323e72a3e4433787f3c05bf18ee",
+        "dest": "cargo/vendor/lzma-rs-perf-exp-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38435c1305548bb408c98242841c3cf161246323e72a3e4433787f3c05bf18ee\", \"files\": {}}",
+        "dest": "cargo/vendor/lzma-rs-perf-exp-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3694,6 +3772,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ruzstd/ruzstd-0.8.3.crate",
+        "sha256": "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8",
+        "dest": "cargo/vendor/ruzstd-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8\", \"files\": {}}",
+        "dest": "cargo/vendor/ruzstd-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/safe_arch/safe_arch-0.7.4.crate",
         "sha256": "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323",
         "dest": "cargo/vendor/safe_arch-0.7.4"
@@ -4084,6 +4175,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/text_io/text_io-0.1.13.crate",
+        "sha256": "4d8d3ca3b06292094e03841d8995e910712d2a10b5869c8f9725385b29761115",
+        "dest": "cargo/vendor/text_io-0.1.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d8d3ca3b06292094e03841d8995e910712d2a10b5869c8f9725385b29761115\", \"files\": {}}",
+        "dest": "cargo/vendor/text_io-0.1.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
         "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
         "dest": "cargo/vendor/thiserror-1.0.69"
@@ -4313,6 +4417,19 @@
         "type": "inline",
         "contents": "{\"package\": \"d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31\", \"files\": {}}",
         "dest": "cargo/vendor/ttf-parser-0.25.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/twox-hash/twox-hash-2.1.3.crate",
+        "sha256": "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9",
+        "dest": "cargo/vendor/twox-hash-2.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9\", \"files\": {}}",
+        "dest": "cargo/vendor/twox-hash-2.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5938,6 +6055,19 @@
         "type": "inline",
         "contents": "{\"package\": \"0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639\", \"files\": {}}",
         "dest": "cargo/vendor/zerocopy-derive-0.8.50",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zlib-rs/zlib-rs-0.6.7.crate",
+        "sha256": "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12",
+        "dest": "cargo/vendor/zlib-rs-0.6.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12\", \"files\": {}}",
+        "dest": "cargo/vendor/zlib-rs-0.6.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/cdrom.rs
+++ b/src/cdrom.rs
@@ -8,12 +8,15 @@
 //! per second regardless of each track's sector size; the disc address
 //! space is the concatenation of all files in cue order. A bare `.iso`
 //! image (2048-byte cooked data sectors, no cue sheet) loads as a
-//! single-track data disc.
+//! single-track data disc, and a `.chd` loads through the compressed
+//! CHD backend in the `chd` child module.
 
 use anyhow::{bail, Context, Result};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+
+mod chd;
 
 pub const SECTORS_PER_SECOND: u32 = 75;
 pub const DATA_SECTOR_BYTES: usize = 2048;
@@ -69,32 +72,57 @@ struct Extent {
 
 #[derive(Debug)]
 pub struct CdImage {
+    tracks: Vec<CdTrack>,
+    total_sectors: u32,
+    backend: Backend,
+}
+
+/// Sector storage behind a `CdImage`: plain image files addressed by
+/// extent (BIN/CUE, bare ISO), or a compressed CHD hunk store.
+#[derive(Debug)]
+enum Backend {
+    Bin(BinBackend),
+    Chd(Box<chd::ChdImage>),
+}
+
+/// The plain-file backend shared by BIN/CUE and bare ISO images.
+#[derive(Debug)]
+struct BinBackend {
     files: Vec<File>,
     /// Host path of each entry in `files`, kept so a save state can
     /// reattach the (read-only) image files on load.
     paths: Vec<PathBuf>,
-    tracks: Vec<CdTrack>,
     extents: Vec<Extent>,
-    total_sectors: u32,
 }
 
-/// Serde shadow of `CdImage`: the image files are read-only, so only their
-/// paths are stored and deserialization reopens them.
+/// Serde shadow of `CdImage`: the image files are read-only, so only
+/// their paths are stored and deserialization reopens them (a CHD also
+/// re-reads its header and track metadata).
 #[derive(serde::Serialize, serde::Deserialize)]
-struct CdImageState {
-    paths: Vec<PathBuf>,
-    tracks: Vec<CdTrack>,
-    extents: Vec<Extent>,
-    total_sectors: u32,
+enum CdImageState {
+    Bin {
+        paths: Vec<PathBuf>,
+        tracks: Vec<CdTrack>,
+        extents: Vec<Extent>,
+        total_sectors: u32,
+    },
+    Chd {
+        path: PathBuf,
+    },
 }
 
 impl serde::Serialize for CdImage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        CdImageState {
-            paths: self.paths.clone(),
-            tracks: self.tracks.clone(),
-            extents: self.extents.clone(),
-            total_sectors: self.total_sectors,
+        match &self.backend {
+            Backend::Bin(bin) => CdImageState::Bin {
+                paths: bin.paths.clone(),
+                tracks: self.tracks.clone(),
+                extents: bin.extents.clone(),
+                total_sectors: self.total_sectors,
+            },
+            Backend::Chd(chd) => CdImageState::Chd {
+                path: chd.path().to_path_buf(),
+            },
         }
         .serialize(serializer)
     }
@@ -102,20 +130,36 @@ impl serde::Serialize for CdImage {
 
 impl<'de> serde::Deserialize<'de> for CdImage {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let state = CdImageState::deserialize(deserializer)?;
-        let mut files = Vec::with_capacity(state.paths.len());
-        for path in &state.paths {
-            files.push(File::open(path).map_err(|e| {
-                serde::de::Error::custom(format!("reopening CD image {}: {e}", path.display()))
-            })?);
+        match CdImageState::deserialize(deserializer)? {
+            CdImageState::Bin {
+                paths,
+                tracks,
+                extents,
+                total_sectors,
+            } => {
+                let mut files = Vec::with_capacity(paths.len());
+                for path in &paths {
+                    files.push(File::open(path).map_err(|e| {
+                        serde::de::Error::custom(format!(
+                            "reopening CD image {}: {e}",
+                            path.display()
+                        ))
+                    })?);
+                }
+                Ok(Self {
+                    tracks,
+                    total_sectors,
+                    backend: Backend::Bin(BinBackend {
+                        files,
+                        paths,
+                        extents,
+                    }),
+                })
+            }
+            CdImageState::Chd { path } => Self::load_chd(&path).map_err(|e| {
+                serde::de::Error::custom(format!("reopening CD image {}: {e:#}", path.display()))
+            }),
         }
-        Ok(Self {
-            files,
-            paths: state.paths,
-            tracks: state.tracks,
-            extents: state.extents,
-            total_sectors: state.total_sectors,
-        })
     }
 }
 
@@ -131,18 +175,27 @@ struct RawTrack {
 }
 
 impl CdImage {
-    /// Load a CD image: a cue sheet (with its BINARY file(s)), or a bare
-    /// `.iso` data image.
+    /// Load a CD image: a cue sheet (with its BINARY file(s)), a bare
+    /// `.iso` data image, or a `.chd`.
     pub fn load(path: &Path) -> Result<Self> {
-        let is_iso = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|e| e.eq_ignore_ascii_case("iso"));
-        if is_iso {
+        let ext = path.extension().and_then(|e| e.to_str());
+        if ext.is_some_and(|e| e.eq_ignore_ascii_case("chd")) {
+            Self::load_chd(path)
+        } else if ext.is_some_and(|e| e.eq_ignore_ascii_case("iso")) {
             Self::load_iso(path)
         } else {
             Self::load_cue(path)
         }
+    }
+
+    /// Load a CHD (MAME "Compressed Hunks of Data") CD image.
+    fn load_chd(path: &Path) -> Result<Self> {
+        let (backend, tracks, total_sectors) = chd::ChdImage::load(path)?;
+        Ok(Self {
+            tracks,
+            total_sectors,
+            backend: Backend::Chd(Box::new(backend)),
+        })
     }
 
     /// Load a bare data image as one MODE1/2048 track.
@@ -161,23 +214,25 @@ impl CdImage {
         }
         let sectors = (len / DATA_SECTOR_BYTES as u64) as u32;
         Ok(Self {
-            files: vec![file],
-            paths: vec![path.to_path_buf()],
             tracks: vec![CdTrack {
                 number: 1,
                 kind: TrackKind::Mode1_2048,
                 start_sector: 0,
                 sector_count: sectors,
             }],
-            extents: vec![Extent {
-                disc_start: 0,
-                sector_count: sectors,
-                sector_bytes: DATA_SECTOR_BYTES,
-                file_index: 0,
-                byte_offset: 0,
-                kind: TrackKind::Mode1_2048,
-            }],
             total_sectors: sectors,
+            backend: Backend::Bin(BinBackend {
+                files: vec![file],
+                paths: vec![path.to_path_buf()],
+                extents: vec![Extent {
+                    disc_start: 0,
+                    sector_count: sectors,
+                    sector_bytes: DATA_SECTOR_BYTES,
+                    file_index: 0,
+                    byte_offset: 0,
+                    kind: TrackKind::Mode1_2048,
+                }],
+            }),
         })
     }
 
@@ -373,11 +428,13 @@ impl CdImage {
         }
 
         Ok(Self {
-            files,
-            paths,
             tracks,
-            extents,
             total_sectors: disc,
+            backend: Backend::Bin(BinBackend {
+                files,
+                paths,
+                extents,
+            }),
         })
     }
 
@@ -390,20 +447,21 @@ impl CdImage {
         self.total_sectors
     }
 
-    fn extent_for_sector(&self, sector: u32) -> Option<&Extent> {
-        self.extents
-            .iter()
-            .find(|e| sector >= e.disc_start && sector < e.disc_start + e.sector_count)
+    /// The track kind covering `sector`, if it is on the disc.
+    fn sector_kind(&self, sector: u32) -> Option<TrackKind> {
+        match &self.backend {
+            Backend::Bin(bin) => bin.extent_for_sector(sector).map(|e| e.kind),
+            Backend::Chd(chd) => chd.sector_kind(sector),
+        }
     }
 
-    fn read_raw(&mut self, extent_index: usize, sector: u32, buf: &mut [u8]) -> Result<()> {
-        let extent = &self.extents[extent_index];
-        let in_extent = u64::from(sector - extent.disc_start);
-        let offset = extent.byte_offset + in_extent * extent.sector_bytes as u64;
-        let file = &mut self.files[extent.file_index];
-        file.seek(SeekFrom::Start(offset))?;
-        file.read_exact(buf)?;
-        Ok(())
+    /// Read the stored payload of `sector`: `buf` must be the track
+    /// kind's `sector_bytes()` long, and comes back in disc byte order.
+    fn read_payload(&mut self, sector: u32, buf: &mut [u8]) -> Result<()> {
+        match &mut self.backend {
+            Backend::Bin(bin) => bin.read_payload(sector, buf),
+            Backend::Chd(chd) => chd.read_payload(sector, buf),
+        }
     }
 
     /// Read the 2048 bytes of user data in a data sector. Fails on audio
@@ -413,30 +471,18 @@ impl CdImage {
         sector: u32,
         buf: &mut [u8; DATA_SECTOR_BYTES],
     ) -> Result<()> {
-        let (index, kind) = {
-            let extent = self
-                .extent_for_sector(sector)
-                .with_context(|| format!("sector {sector} beyond end of disc"))?;
-            if !extent.kind.is_data() {
-                bail!("sector {sector} is in an audio track");
-            }
-            (
-                self.extents
-                    .iter()
-                    .position(|e| std::ptr::eq(e, extent))
-                    .unwrap(),
-                extent.kind,
-            )
-        };
+        let kind = self
+            .sector_kind(sector)
+            .with_context(|| format!("sector {sector} beyond end of disc"))?;
         match kind {
-            TrackKind::Mode1_2048 => self.read_raw(index, sector, buf),
+            TrackKind::Mode1_2048 => self.read_payload(sector, buf),
             TrackKind::Mode1_2352 => {
                 let mut raw = [0u8; RAW_SECTOR_BYTES];
-                self.read_raw(index, sector, &mut raw)?;
+                self.read_payload(sector, &mut raw)?;
                 buf.copy_from_slice(&raw[16..16 + DATA_SECTOR_BYTES]);
                 Ok(())
             }
-            TrackKind::Audio => unreachable!(),
+            TrackKind::Audio => bail!("sector {sector} is in an audio track"),
         }
     }
 
@@ -446,42 +492,27 @@ impl CdImage {
         sector: u32,
         buf: &mut [u8; RAW_SECTOR_BYTES],
     ) -> Result<()> {
-        let index = {
-            let extent = self
-                .extent_for_sector(sector)
-                .with_context(|| format!("sector {sector} beyond end of disc"))?;
-            if extent.kind.is_data() {
-                bail!("sector {sector} is in a data track");
-            }
-            self.extents
-                .iter()
-                .position(|e| std::ptr::eq(e, extent))
-                .unwrap()
-        };
-        self.read_raw(index, sector, buf)
+        let kind = self
+            .sector_kind(sector)
+            .with_context(|| format!("sector {sector} beyond end of disc"))?;
+        if kind.is_data() {
+            bail!("sector {sector} is in a data track");
+        }
+        self.read_payload(sector, buf)
     }
 
     /// Read one full 2352-byte raw frame at `sector`, whatever the track
     /// type: raw images are copied through; cooked (2048-byte) data
     /// sectors get a synthesized sync + BCD MSF header (zero EDC/ECC).
     pub fn read_raw_sector(&mut self, sector: u32, buf: &mut [u8; RAW_SECTOR_BYTES]) -> Result<()> {
-        let (index, kind) = {
-            let extent = self
-                .extent_for_sector(sector)
-                .with_context(|| format!("sector {sector} beyond end of disc"))?;
-            (
-                self.extents
-                    .iter()
-                    .position(|e| std::ptr::eq(e, extent))
-                    .unwrap(),
-                extent.kind,
-            )
-        };
+        let kind = self
+            .sector_kind(sector)
+            .with_context(|| format!("sector {sector} beyond end of disc"))?;
         match kind {
-            TrackKind::Mode1_2352 | TrackKind::Audio => self.read_raw(index, sector, buf),
+            TrackKind::Mode1_2352 | TrackKind::Audio => self.read_payload(sector, buf),
             TrackKind::Mode1_2048 => {
                 let mut data = [0u8; DATA_SECTOR_BYTES];
-                self.read_raw(index, sector, &mut data)?;
+                self.read_payload(sector, &mut data)?;
                 buf.fill(0);
                 buf[1..11].fill(0xFF);
                 let msf = sector + LEADIN_SECTORS;
@@ -497,8 +528,7 @@ impl CdImage {
 
     /// Whether `sector` falls inside an audio track region.
     pub fn is_audio_sector(&self, sector: u32) -> bool {
-        self.extent_for_sector(sector)
-            .is_some_and(|e| !e.kind.is_data())
+        self.sector_kind(sector).is_some_and(|k| !k.is_data())
     }
 
     /// One-line TOC summary for the log.
@@ -512,6 +542,29 @@ impl CdImage {
             audio,
             self.total_sectors()
         )
+    }
+}
+
+impl BinBackend {
+    fn extent_for_sector(&self, sector: u32) -> Option<&Extent> {
+        self.extents
+            .iter()
+            .find(|e| sector >= e.disc_start && sector < e.disc_start + e.sector_count)
+    }
+
+    fn read_payload(&mut self, sector: u32, buf: &mut [u8]) -> Result<()> {
+        let index = self
+            .extents
+            .iter()
+            .position(|e| sector >= e.disc_start && sector < e.disc_start + e.sector_count)
+            .with_context(|| format!("sector {sector} beyond end of disc"))?;
+        let extent = &self.extents[index];
+        let in_extent = u64::from(sector - extent.disc_start);
+        let offset = extent.byte_offset + in_extent * extent.sector_bytes as u64;
+        let file = &mut self.files[extent.file_index];
+        file.seek(SeekFrom::Start(offset))?;
+        file.read_exact(buf)?;
+        Ok(())
     }
 }
 

--- a/src/cdrom/chd.rs
+++ b/src/cdrom/chd.rs
@@ -88,11 +88,15 @@ impl ChdImage {
         }
         let unit_bytes = chd.header().unit_bytes();
         let hunk_bytes = chd.header().hunk_size();
-        if unit_bytes as usize != FRAME_BYTES || !(hunk_bytes as usize).is_multiple_of(FRAME_BYTES)
+        // The zero-hunk check guards the frames_per_hunk divisions below;
+        // the chd crate also rejects such headers, but do not rely on it.
+        if unit_bytes as usize != FRAME_BYTES
+            || hunk_bytes == 0
+            || !(hunk_bytes as usize).is_multiple_of(FRAME_BYTES)
         {
             bail!(
-                "{}: not a CD-ROM CHD (unit size {unit_bytes}, expected {FRAME_BYTES}-byte \
-                 CD frames)",
+                "{}: not a CD-ROM CHD (unit {unit_bytes} bytes, hunk {hunk_bytes} bytes; \
+                 expected hunks of whole {FRAME_BYTES}-byte CD frames)",
                 path.display()
             );
         }
@@ -356,12 +360,19 @@ mod tests {
         data: &[u8],
         metas: &[([u8; 4], Vec<u8>)],
     ) {
-        let hunk_count = data.len().div_ceil(hunk_bytes as usize);
+        // hunk_bytes == 0 writes a (broken) header that loading must
+        // reject; avoid dividing by it here.
+        let hunk_count = match hunk_bytes {
+            0 => 0,
+            _ => data.len().div_ceil(hunk_bytes as usize),
+        };
         let map_offset = 124u64;
         let meta_offset = map_offset + 4 * hunk_count as u64;
         let metas_len: u64 = metas.iter().map(|(_, v)| 16 + v.len() as u64).sum();
-        let data_start =
-            (meta_offset + metas_len).div_ceil(u64::from(hunk_bytes)) * u64::from(hunk_bytes);
+        let data_start = match hunk_bytes {
+            0 => meta_offset + metas_len,
+            _ => (meta_offset + metas_len).div_ceil(u64::from(hunk_bytes)) * u64::from(hunk_bytes),
+        };
 
         let mut out = Vec::new();
         out.extend_from_slice(b"MComprHD");
@@ -607,6 +618,18 @@ mod tests {
         write_chd_v5(&path, 4096, 512, &[0u8; 8192], &[]);
         let err = CdImage::load(&path).unwrap_err();
         assert!(err.to_string().contains("not a CD-ROM CHD"), "{err:#}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn zero_hunk_size_is_rejected_not_divided_by() {
+        let path = temp_path("zerohunk.chd");
+        // The unit size claims CD frames but the hunk size is zero:
+        // without the load-time guard, reading a sector would divide by
+        // frames_per_hunk == 0.
+        write_chd_v5(&path, 0, FRAME_BYTES as u32, &[], &[]);
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(format!("{err:#}").contains("CHD"), "{err:#}");
         let _ = std::fs::remove_file(&path);
     }
 

--- a/src/cdrom/chd.rs
+++ b/src/cdrom/chd.rs
@@ -1,0 +1,653 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! CHD (MAME "Compressed Hunks of Data") CD image backend.
+//!
+//! A CD-ROM CHD stores the disc as compressed hunks of 2448-byte frames
+//! (2352 bytes of sector data followed by 96 bytes of subcode), with each
+//! track's frames padded to a multiple of 4 in the hunk stream, and one
+//! `CHT2` (or older `CHTR`) metadata entry per track describing its type,
+//! length, and pregap/postgap. A pregap whose PGTYPE carries chdman's `V`
+//! prefix is stored in the frame stream and counted in FRAMES; other
+//! pregaps and all postgaps are not stored and read back as zero fill,
+//! but still occupy logical disc addresses, exactly as MAME lays the
+//! disc out. CD-DA frames are stored with big-endian samples and are
+//! swapped back to the little-endian disc byte order on read.
+
+use super::{CdTrack, TrackKind, DATA_SECTOR_BYTES, RAW_SECTOR_BYTES};
+use anyhow::{anyhow, bail, Context, Result};
+use chd::metadata::{KnownMetadata, Metadata};
+use chd::Chd;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+/// One CD frame slot in a CHD: sector data plus subcode.
+const FRAME_BYTES: usize = RAW_SECTOR_BYTES + 96;
+/// chdman pads each track's frames to this boundary in the hunk stream.
+const TRACK_PADDING: u32 = 4;
+
+pub(super) struct ChdImage {
+    chd: Chd<BufReader<File>>,
+    path: PathBuf,
+    regions: Vec<Region>,
+    frames_per_hunk: u32,
+    /// Decompressed contents of hunk `cached_hunk`.
+    hunk_buf: Vec<u8>,
+    /// Scratch buffer for compressed hunk bytes, kept between reads.
+    comp_buf: Vec<u8>,
+    cached_hunk: Option<u32>,
+}
+
+impl std::fmt::Debug for ChdImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChdImage")
+            .field("path", &self.path)
+            .field("regions", &self.regions)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A contiguous run of same-kind sectors on the logical disc: a track's
+/// stored frames, or an unstored pregap/postgap.
+#[derive(Debug)]
+struct Region {
+    disc_start: u32,
+    sector_count: u32,
+    kind: TrackKind,
+    /// CHD frame holding the region's first sector; `None` for unstored
+    /// gap sectors, which read as zero fill.
+    chd_frame: Option<u32>,
+}
+
+/// One track's `CHT2`/`CHTR` metadata, as written by chdman.
+#[derive(Debug)]
+struct RawTrack {
+    number: u8,
+    kind: TrackKind,
+    /// Frames stored in the CHD (includes the pregap only when stored).
+    frames: u32,
+    pregap: u32,
+    /// PGTYPE carried chdman's `V` prefix: the pregap frames are in the
+    /// file and counted in `frames`.
+    pregap_stored: bool,
+    postgap: u32,
+}
+
+impl ChdImage {
+    /// Open a CHD CD image and lay its tracks out on the logical disc.
+    pub(super) fn load(path: &Path) -> Result<(Self, Vec<CdTrack>, u32)> {
+        let file =
+            File::open(path).with_context(|| format!("opening CD image {}", path.display()))?;
+        let mut chd = Chd::open(BufReader::new(file), None)
+            .map_err(|e| anyhow!("{}: not a readable CHD image: {e}", path.display()))?;
+        if chd.header().has_parent() {
+            bail!(
+                "{}: delta CHD with a parent is not supported; flatten it with chdman",
+                path.display()
+            );
+        }
+        let unit_bytes = chd.header().unit_bytes();
+        let hunk_bytes = chd.header().hunk_size();
+        if unit_bytes as usize != FRAME_BYTES || !(hunk_bytes as usize).is_multiple_of(FRAME_BYTES)
+        {
+            bail!(
+                "{}: not a CD-ROM CHD (unit size {unit_bytes}, expected {FRAME_BYTES}-byte \
+                 CD frames)",
+                path.display()
+            );
+        }
+
+        let entries: Vec<Metadata> = chd
+            .metadata_refs()
+            .try_into()
+            .map_err(|e| anyhow!("{}: reading CHD metadata: {e}", path.display()))?;
+        let mut raw_tracks = Vec::new();
+        for entry in &entries {
+            if entry.metatag == KnownMetadata::CdRomTrack as u32
+                || entry.metatag == KnownMetadata::CdRomTrack2 as u32
+            {
+                let text = std::str::from_utf8(&entry.value)
+                    .map(|s| s.trim_end_matches('\0'))
+                    .map_err(|_| anyhow!("{}: CHD track metadata is not text", path.display()))?;
+                raw_tracks.push(
+                    parse_track_metadata(text)
+                        .with_context(|| format!("{}: {text:?}", path.display()))?,
+                );
+            } else if entry.metatag == KnownMetadata::CdRomOld as u32
+                || entry.metatag == KnownMetadata::GdRomOld as u32
+                || entry.metatag == KnownMetadata::GdRomTrack as u32
+            {
+                bail!(
+                    "{}: only CHT2/CHTR CD track metadata is supported; re-create the \
+                     CHD with a current chdman",
+                    path.display()
+                );
+            }
+        }
+        if raw_tracks.is_empty() {
+            bail!("{}: no CD tracks in CHD metadata", path.display());
+        }
+        raw_tracks.sort_by_key(|t| t.number);
+        for (i, track) in raw_tracks.iter().enumerate() {
+            if usize::from(track.number) != i + 1 {
+                bail!(
+                    "{}: track numbers are not contiguous from 1 (found track {})",
+                    path.display(),
+                    track.number
+                );
+            }
+        }
+
+        // Lay the tracks out. The logical disc inserts unstored pregaps
+        // and postgaps as addressable zero-fill regions; the CHD frame
+        // stream advances by the stored frames plus chdman's padding.
+        let mut regions = Vec::new();
+        let mut tracks = Vec::with_capacity(raw_tracks.len());
+        let mut disc = 0u32;
+        let mut chd_frame = 0u32;
+        let overflow = || anyhow!("{}: CHD track table overflows", path.display());
+        for track in &raw_tracks {
+            let region_start = disc;
+            if track.pregap_stored && track.pregap > track.frames {
+                bail!(
+                    "{}: track {} pregap ({}) exceeds its stored frames ({})",
+                    path.display(),
+                    track.number,
+                    track.pregap,
+                    track.frames
+                );
+            }
+            if !track.pregap_stored && track.pregap > 0 {
+                regions.push(Region {
+                    disc_start: disc,
+                    sector_count: track.pregap,
+                    kind: track.kind,
+                    chd_frame: None,
+                });
+                disc = disc.checked_add(track.pregap).ok_or_else(overflow)?;
+            }
+            if track.frames > 0 {
+                regions.push(Region {
+                    disc_start: disc,
+                    sector_count: track.frames,
+                    kind: track.kind,
+                    chd_frame: Some(chd_frame),
+                });
+                disc = disc.checked_add(track.frames).ok_or_else(overflow)?;
+            }
+            if track.postgap > 0 {
+                regions.push(Region {
+                    disc_start: disc,
+                    sector_count: track.postgap,
+                    kind: track.kind,
+                    chd_frame: None,
+                });
+                disc = disc.checked_add(track.postgap).ok_or_else(overflow)?;
+            }
+            tracks.push(CdTrack {
+                number: track.number,
+                kind: track.kind,
+                start_sector: region_start + track.pregap,
+                sector_count: disc - (region_start + track.pregap),
+            });
+            let stored_end = chd_frame.checked_add(track.frames).ok_or_else(overflow)?;
+            if u64::from(stored_end) > chd.header().unit_count() {
+                bail!(
+                    "{}: track {} claims CHD frames past the end of the image",
+                    path.display(),
+                    track.number
+                );
+            }
+            let padding = (TRACK_PADDING - track.frames % TRACK_PADDING) % TRACK_PADDING;
+            chd_frame = stored_end.checked_add(padding).ok_or_else(overflow)?;
+        }
+
+        let frames_per_hunk = hunk_bytes / FRAME_BYTES as u32;
+        let hunk_buf = chd.get_hunksized_buffer();
+        Ok((
+            Self {
+                chd,
+                path: path.to_path_buf(),
+                regions,
+                frames_per_hunk,
+                hunk_buf,
+                comp_buf: Vec::new(),
+                cached_hunk: None,
+            },
+            tracks,
+            disc,
+        ))
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn region_for_sector(&self, sector: u32) -> Option<&Region> {
+        self.regions
+            .iter()
+            .find(|r| sector >= r.disc_start && sector < r.disc_start + r.sector_count)
+    }
+
+    pub(super) fn sector_kind(&self, sector: u32) -> Option<TrackKind> {
+        self.region_for_sector(sector).map(|r| r.kind)
+    }
+
+    /// Read the stored payload of `sector`: `buf` is
+    /// `kind.sector_bytes()` long, and comes back in disc byte order.
+    pub(super) fn read_payload(&mut self, sector: u32, buf: &mut [u8]) -> Result<()> {
+        let (frame, kind) = {
+            let region = self
+                .region_for_sector(sector)
+                .with_context(|| format!("sector {sector} beyond end of disc"))?;
+            match region.chd_frame {
+                // Unstored pregap/postgap: zero fill (digital silence).
+                None => {
+                    buf.fill(0);
+                    return Ok(());
+                }
+                Some(first) => (first + (sector - region.disc_start), region.kind),
+            }
+        };
+        debug_assert!(matches!(buf.len(), DATA_SECTOR_BYTES | RAW_SECTOR_BYTES));
+        self.load_hunk(frame / self.frames_per_hunk)?;
+        let offset = (frame % self.frames_per_hunk) as usize * FRAME_BYTES;
+        buf.copy_from_slice(&self.hunk_buf[offset..offset + buf.len()]);
+        if kind == TrackKind::Audio {
+            // CHD stores CD-DA samples big-endian; the disc byte order
+            // (and every consumer here) is little-endian.
+            for pair in buf.chunks_exact_mut(2) {
+                pair.swap(0, 1);
+            }
+        }
+        Ok(())
+    }
+
+    fn load_hunk(&mut self, hunk: u32) -> Result<()> {
+        if self.cached_hunk == Some(hunk) {
+            return Ok(());
+        }
+        self.cached_hunk = None;
+        self.chd
+            .hunk(hunk)
+            .and_then(|mut h| h.read_hunk_in(&mut self.comp_buf, &mut self.hunk_buf))
+            .map_err(|e| anyhow!("{}: reading CHD hunk {hunk}: {e}", self.path.display()))?;
+        self.cached_hunk = Some(hunk);
+        Ok(())
+    }
+}
+
+/// Map a chdman track TYPE string to a track kind.
+fn track_kind(name: &str, number: u8) -> Result<TrackKind> {
+    match name {
+        "MODE1" | "MODE1/2048" => Ok(TrackKind::Mode1_2048),
+        "MODE1_RAW" | "MODE1/2352" => Ok(TrackKind::Mode1_2352),
+        "AUDIO" => Ok(TrackKind::Audio),
+        other => bail!("track {number} type {other:?} is not supported (MODE1, MODE1_RAW, AUDIO)"),
+    }
+}
+
+/// Parse one `CHT2`/`CHTR` text entry, e.g.
+/// `TRACK:1 TYPE:MODE1_RAW SUBTYPE:NONE FRAMES:2208 PREGAP:0
+/// PGTYPE:MODE1 PGSUB:NONE POSTGAP:0` (`CHTR` stops after FRAMES).
+fn parse_track_metadata(text: &str) -> Result<RawTrack> {
+    let mut number = None;
+    let mut kind_name = None;
+    let mut frames = None;
+    let mut pregap = 0u32;
+    let mut pgtype = "";
+    let mut postgap = 0u32;
+    for word in text.split_whitespace() {
+        let Some((key, value)) = word.split_once(':') else {
+            continue;
+        };
+        match key {
+            "TRACK" => number = Some(value.parse::<u8>().context("bad TRACK number")?),
+            "TYPE" => kind_name = Some(value),
+            "FRAMES" => frames = Some(value.parse::<u32>().context("bad FRAMES count")?),
+            "PREGAP" => pregap = value.parse().context("bad PREGAP length")?,
+            "PGTYPE" => pgtype = value,
+            "POSTGAP" => postgap = value.parse().context("bad POSTGAP length")?,
+            // SUBTYPE/PGSUB (subcode layout) do not matter here: the
+            // subcode bytes of each frame are simply never read.
+            _ => {}
+        }
+    }
+    let number = number.context("track metadata without TRACK field")?;
+    if number == 0 {
+        bail!("track number 0 is invalid");
+    }
+    let kind_name = kind_name.context("track metadata without TYPE field")?;
+    Ok(RawTrack {
+        number,
+        kind: track_kind(kind_name, number)?,
+        frames: frames.context("track metadata without FRAMES field")?,
+        pregap,
+        pregap_stored: pregap > 0 && pgtype.starts_with('V'),
+        postgap,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CdImage;
+    use super::*;
+    use crate::cdrom::TrackKind;
+
+    fn temp_path(name: &str) -> PathBuf {
+        static UNIQUE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = UNIQUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "copperline-chd-{}-{unique}-{name}",
+            std::process::id()
+        ))
+    }
+
+    /// Two frames per hunk, so a handful of frames spans several hunks.
+    const HUNK_BYTES: u32 = 2 * FRAME_BYTES as u32;
+
+    /// Write a minimal uncompressed CHD v5: 124-byte header, raw hunk
+    /// map (one big-endian u32 per hunk, the hunk's file offset in
+    /// hunk-size units), a metadata chain, and hunk-aligned data.
+    fn write_chd_v5(
+        path: &Path,
+        hunk_bytes: u32,
+        unit_bytes: u32,
+        data: &[u8],
+        metas: &[([u8; 4], Vec<u8>)],
+    ) {
+        let hunk_count = data.len().div_ceil(hunk_bytes as usize);
+        let map_offset = 124u64;
+        let meta_offset = map_offset + 4 * hunk_count as u64;
+        let metas_len: u64 = metas.iter().map(|(_, v)| 16 + v.len() as u64).sum();
+        let data_start =
+            (meta_offset + metas_len).div_ceil(u64::from(hunk_bytes)) * u64::from(hunk_bytes);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"MComprHD");
+        out.extend_from_slice(&124u32.to_be_bytes());
+        out.extend_from_slice(&5u32.to_be_bytes());
+        out.extend_from_slice(&[0u8; 16]); // four codecs: none (uncompressed)
+        out.extend_from_slice(&(data.len() as u64).to_be_bytes());
+        out.extend_from_slice(&map_offset.to_be_bytes());
+        out.extend_from_slice(&meta_offset.to_be_bytes());
+        out.extend_from_slice(&hunk_bytes.to_be_bytes());
+        out.extend_from_slice(&unit_bytes.to_be_bytes());
+        out.extend_from_slice(&[0u8; 60]); // raw/combined/parent SHA1s
+        assert_eq!(out.len(), 124);
+
+        for hunk in 0..hunk_count as u64 {
+            let entry = data_start / u64::from(hunk_bytes) + hunk;
+            out.extend_from_slice(&(entry as u32).to_be_bytes());
+        }
+        let mut next = meta_offset;
+        for (i, (tag, value)) in metas.iter().enumerate() {
+            next += 16 + value.len() as u64;
+            out.extend_from_slice(tag);
+            out.extend_from_slice(&(0x01u32 << 24 | value.len() as u32).to_be_bytes());
+            let next_field = if i + 1 == metas.len() { 0 } else { next };
+            out.extend_from_slice(&next_field.to_be_bytes());
+            out.extend_from_slice(value);
+        }
+        out.resize(data_start as usize, 0);
+        out.extend_from_slice(data);
+        out.resize(data_start as usize + hunk_count * hunk_bytes as usize, 0);
+        std::fs::write(path, out).unwrap();
+    }
+
+    fn cht2(text: &str) -> ([u8; 4], Vec<u8>) {
+        let mut value = text.as_bytes().to_vec();
+        value.push(0);
+        (*b"CHT2", value)
+    }
+
+    /// A 2448-byte frame slot with `payload` at the front of the sector
+    /// data area and zeroed subcode.
+    fn frame(payload: &[u8]) -> Vec<u8> {
+        let mut f = vec![0u8; FRAME_BYTES];
+        f[..payload.len()].copy_from_slice(payload);
+        f
+    }
+
+    /// Data track frames padded to chdman's 4-frame track boundary.
+    fn track_frames(frames: &[Vec<u8>]) -> Vec<u8> {
+        let mut out: Vec<u8> = frames.concat();
+        let padding = (TRACK_PADDING as usize - frames.len() % TRACK_PADDING as usize)
+            % TRACK_PADDING as usize;
+        out.extend(std::iter::repeat_n(0u8, padding * FRAME_BYTES));
+        out
+    }
+
+    /// Track 1: MODE1 data, 4 frames filled with the sector number.
+    /// Track 2: AUDIO, 5 frames (2 of stored `VAUDIO` pregap), stored
+    /// byte-swapped as chdman writes CD-DA.
+    fn write_mixed_disc(path: &Path) {
+        let mut data = Vec::new();
+        data.extend(track_frames(
+            &(0..4u8)
+                .map(|s| frame(&[s; DATA_SECTOR_BYTES]))
+                .collect::<Vec<_>>(),
+        ));
+        data.extend(track_frames(
+            &(0..5u8)
+                .map(|s| {
+                    // Big-endian sample 0x00A0+s: LE on the wire is
+                    // [0xA0+s, 0x00], stored swapped as [0x00, 0xA0+s].
+                    let sample = [0x00, 0xA0 + s];
+                    frame(&sample.repeat(RAW_SECTOR_BYTES / 2))
+                })
+                .collect::<Vec<_>>(),
+        ));
+        write_chd_v5(
+            path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[
+                cht2(
+                    "TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:4 PREGAP:0 PGTYPE:MODE1 \
+                     PGSUB:NONE POSTGAP:0",
+                ),
+                cht2(
+                    "TRACK:2 TYPE:AUDIO SUBTYPE:NONE FRAMES:5 PREGAP:2 PGTYPE:VAUDIO \
+                     PGSUB:NONE POSTGAP:0",
+                ),
+            ],
+        );
+    }
+
+    #[test]
+    fn mixed_disc_lays_out_stored_pregap_and_swaps_audio() {
+        let path = temp_path("mixed.chd");
+        write_mixed_disc(&path);
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.total_sectors(), 9);
+        let tracks = image.tracks();
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks[0].kind, TrackKind::Mode1_2048);
+        assert_eq!(tracks[0].start_sector, 0);
+        assert_eq!(tracks[0].sector_count, 4);
+        // INDEX 01 sits past the two stored pregap sectors.
+        assert_eq!(tracks[1].kind, TrackKind::Audio);
+        assert_eq!(tracks[1].start_sector, 6);
+        assert_eq!(tracks[1].sector_count, 3);
+
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        for sector in 0..4 {
+            image.read_data_sector(sector, &mut data).unwrap();
+            assert!(data.iter().all(|&b| b == sector as u8), "sector {sector}");
+        }
+        assert!(image.read_data_sector(5, &mut data).is_err());
+        assert!(!image.is_audio_sector(3));
+        assert!(image.is_audio_sector(4));
+
+        // Audio comes back in disc (little-endian) byte order, pregap
+        // sectors included.
+        let mut audio = [0u8; RAW_SECTOR_BYTES];
+        for sector in 4..9u32 {
+            image.read_audio_sector(sector, &mut audio).unwrap();
+            let sample = [0xA0 + (sector - 4) as u8, 0x00];
+            assert!(
+                audio.chunks_exact(2).all(|c| c == sample),
+                "sector {sector}"
+            );
+        }
+        assert!(image.read_audio_sector(9, &mut audio).is_err());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn virtual_pregap_and_postgap_read_as_zero_fill() {
+        let path = temp_path("virtualpg.chd");
+        let mut data = Vec::new();
+        data.extend(track_frames(
+            &(0..4u8)
+                .map(|s| frame(&[s; DATA_SECTOR_BYTES]))
+                .collect::<Vec<_>>(),
+        ));
+        data.extend(track_frames(
+            &(0..4u8)
+                .map(|s| frame(&[0x00, 0xB0 + s].repeat(RAW_SECTOR_BYTES / 2)))
+                .collect::<Vec<_>>(),
+        ));
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[
+                cht2(
+                    "TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:4 PREGAP:0 PGTYPE:MODE1 \
+                     PGSUB:NONE POSTGAP:0",
+                ),
+                // No `V` prefix: the two pregap frames are not stored,
+                // and neither is the postgap frame.
+                cht2(
+                    "TRACK:2 TYPE:AUDIO SUBTYPE:NONE FRAMES:4 PREGAP:2 PGTYPE:AUDIO \
+                     PGSUB:NONE POSTGAP:1",
+                ),
+            ],
+        );
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.total_sectors(), 11);
+        assert_eq!(image.tracks()[1].start_sector, 6);
+        assert_eq!(image.tracks()[1].sector_count, 5);
+
+        let mut audio = [0u8; RAW_SECTOR_BYTES];
+        for gap in [4, 5, 10] {
+            assert!(image.is_audio_sector(gap), "sector {gap}");
+            image.read_audio_sector(gap, &mut audio).unwrap();
+            assert!(audio.iter().all(|&b| b == 0), "sector {gap}");
+        }
+        for sector in 6..10u32 {
+            image.read_audio_sector(sector, &mut audio).unwrap();
+            let sample = [0xB0 + (sector - 6) as u8, 0x00];
+            assert!(
+                audio.chunks_exact(2).all(|c| c == sample),
+                "sector {sector}"
+            );
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn chtr_metadata_and_raw_data_track_skip_sector_header() {
+        let path = temp_path("raw.chd");
+        let mut raw = vec![0xEEu8; 16];
+        raw.extend(std::iter::repeat_n(0x42u8, RAW_SECTOR_BYTES - 16));
+        let data = track_frames(&[frame(&raw), frame(&raw)]);
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[(
+                *b"CHTR",
+                b"TRACK:1 TYPE:MODE1_RAW SUBTYPE:NONE FRAMES:2\0".to_vec(),
+            )],
+        );
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.tracks()[0].kind, TrackKind::Mode1_2352);
+        assert_eq!(image.total_sectors(), 2);
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        image.read_data_sector(1, &mut data).unwrap();
+        assert!(data.iter().all(|&b| b == 0x42));
+        let mut full = [0u8; RAW_SECTOR_BYTES];
+        image.read_raw_sector(0, &mut full).unwrap();
+        assert_eq!(full.as_slice(), raw.as_slice());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn serde_reopens_chd_and_serves_same_sectors() {
+        let path = temp_path("serde.chd");
+        write_mixed_disc(&path);
+        let mut image = CdImage::load(&path).unwrap();
+        let encoded = bincode::serialize(&image).unwrap();
+        let mut restored: CdImage = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(restored.total_sectors(), image.total_sectors());
+        let mut a = [0u8; RAW_SECTOR_BYTES];
+        let mut b = [0u8; RAW_SECTOR_BYTES];
+        for sector in 4..9 {
+            image.read_audio_sector(sector, &mut a).unwrap();
+            restored.read_audio_sector(sector, &mut b).unwrap();
+            assert_eq!(a, b, "sector {sector}");
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let err = bincode::deserialize::<CdImage>(&encoded)
+            .expect_err("deserializing with the CHD gone must fail");
+        assert!(err.to_string().contains("reopening CD image"));
+    }
+
+    #[test]
+    fn non_cd_chd_is_rejected() {
+        let path = temp_path("harddisk.chd");
+        // A hard-disk-shaped CHD: 512-byte units, no CD track metadata.
+        write_chd_v5(&path, 4096, 512, &[0u8; 8192], &[]);
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(err.to_string().contains("not a CD-ROM CHD"), "{err:#}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unsupported_track_type_is_rejected() {
+        let path = temp_path("mode2.chd");
+        let data = track_frames(&[frame(&[0u8; RAW_SECTOR_BYTES])]);
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[cht2(
+                "TRACK:1 TYPE:MODE2_RAW SUBTYPE:NONE FRAMES:1 PREGAP:0 PGTYPE:MODE1 \
+                 PGSUB:NONE POSTGAP:0",
+            )],
+        );
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(format!("{err:#}").contains("not supported"), "{err:#}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn track_claiming_frames_past_the_image_is_rejected() {
+        let path = temp_path("overrun.chd");
+        let data = track_frames(&[frame(&[0u8; DATA_SECTOR_BYTES])]);
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[cht2(
+                "TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:500 PREGAP:0 PGTYPE:MODE1 \
+                 PGSUB:NONE POSTGAP:0",
+            )],
+        );
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("past the end of the image"),
+            "{err:#}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -782,14 +782,16 @@ pub const HARDFILE_DEFAULT_BOOT_PRI: i8 = 0;
 /// the same sentinel `[[filesys]] bootpri` uses.
 pub const BOOT_PRI_NEVER: i8 = -128;
 
-/// Whether a drive-image path names a CD image (a cue sheet or a bare ISO).
-/// On the SCSI bus such an entry attaches a CD-ROM drive instead of a hard
-/// disk; the file extension is the format signal, exactly as it is for the
-/// hard-drive back ends (HDF vs. directory).
+/// Whether a drive-image path names a CD image (a cue sheet, a bare ISO,
+/// or a CHD). On the SCSI bus such an entry attaches a CD-ROM drive
+/// instead of a hard disk; the file extension is the format signal,
+/// exactly as it is for the hard-drive back ends (HDF vs. directory).
 pub fn is_cd_image_path(path: &std::path::Path) -> bool {
-    path.extension()
-        .and_then(|e| e.to_str())
-        .is_some_and(|e| e.eq_ignore_ascii_case("cue") || e.eq_ignore_ascii_case("iso"))
+    path.extension().and_then(|e| e.to_str()).is_some_and(|e| {
+        e.eq_ignore_ascii_case("cue")
+            || e.eq_ignore_ascii_case("iso")
+            || e.eq_ignore_ascii_case("chd")
+    })
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1192,7 +1192,7 @@ fn print_help() {
          \x20                            insert PATH into DFN after SECS seconds\n  \
          --defer-disk-insert SECS DFN   start with configured DFN empty, then insert\n  \
          \x20                            its configured disk image after SECS seconds\n  \
-         --insert-cd-after SECS PATH    swap the CD image (cue/iso) in the machine's CD\n  \
+         --insert-cd-after SECS PATH    swap the CD image (cue/iso/chd) in the machine's CD\n  \
          \x20                            drive (CDTV, CD32, or a SCSI CD-ROM unit) after\n  \
          \x20                            SECS seconds\n  \
          --audio                        enable real-time stereo audio output via cpal (default)\n  \

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -160,7 +160,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      (Bus::cpu_chip_clock_phase). The layout is unchanged, but the field
 //      now feeds chip-access synchronisation, so a state written before the
 //      change would resume with a stale phase
-pub const STATE_VERSION: u32 = 46;
+//  47: CdImage's serde shadow became a backend enum (plain image files vs
+//      CHD) to carry the new CHD CD image support
+pub const STATE_VERSION: u32 = 47;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3613,7 +3613,7 @@ enum DroppedMediaKind {
     /// unknown extensions): FloppyImage::from_bytes sniffs the content and
     /// rejects what it cannot read, surfacing a clean OSD failure.
     Floppy,
-    /// A CD image (cue sheet or bare ISO) for the CD drive.
+    /// A CD image (cue sheet, bare ISO, or CHD) for the CD drive.
     Cd,
     /// Hard disk images cannot be hot-attached; point at the config screen.
     HardDisk,
@@ -3626,7 +3626,7 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
         .extension()
         .map(|e| e.to_string_lossy().to_ascii_lowercase());
     match ext.as_deref() {
-        Some("cue") | Some("iso") => DroppedMediaKind::Cd,
+        Some("cue") | Some("iso") | Some("chd") => DroppedMediaKind::Cd,
         Some("hdf") | Some("img") => DroppedMediaKind::HardDisk,
         Some("rom") => DroppedMediaKind::Rom,
         _ => DroppedMediaKind::Floppy,
@@ -6170,12 +6170,13 @@ impl App {
                 "Floppy images",
                 &["adf", "adz", "dms", "scp", "gz", "ipf", "zip"],
             ),
-            // Only formats CdImage::load takes: a cue sheet or a bare ISO
-            // (a raw .bin is a cue sheet's payload, not loadable alone).
-            LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso"]),
+            // Only formats CdImage::load takes: a cue sheet, a bare ISO,
+            // or a CHD (a raw .bin is a cue sheet's payload, not loadable
+            // alone).
+            LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "chd"]),
             LauncherField::Cd32Nvram => dialog.add_filter("NVRAM images", &["bin", "nv", "sav"]),
-            // SCSI units take hard disks or CD images (a cue/iso attaches a
-            // CD-ROM drive at that ID).
+            // SCSI units take hard disks or CD images (a cue/iso/chd
+            // attaches a CD-ROM drive at that ID).
             LauncherField::ScsiUnit0
             | LauncherField::ScsiUnit1
             | LauncherField::ScsiUnit2
@@ -6184,7 +6185,7 @@ impl App {
             | LauncherField::ScsiUnit5
             | LauncherField::ScsiUnit6 => dialog
                 .add_filter("Hard disk images", &["hdf", "img", "bin"])
-                .add_filter("CD images", &["cue", "iso"]),
+                .add_filter("CD images", &["cue", "iso", "chd"]),
             _ => dialog.add_filter("Hard disk images", &["hdf", "img", "bin"]),
         };
         if let Some(dir) = start_dir {
@@ -8760,7 +8761,7 @@ impl App {
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
             .set_title("Load CD image")
-            .add_filter("CD images", &["cue", "iso"])
+            .add_filter("CD images", &["cue", "iso", "chd"])
             .pick_file();
 
         // Re-baseline pacing after the modal dialog, as for floppies.
@@ -8800,7 +8801,7 @@ impl App {
 
     /// Route files dropped on the window: floppy images to a drive
     /// (directly, or via the chooser panel when several drives could take
-    /// them), a CD image (cue/iso) to the CD drive, and everything else to
+    /// them), a CD image (cue/iso/chd) to the CD drive, and everything else to
     /// an explanatory notice. winit reports drops with no cursor position,
     /// so the target drive can only be picked after the fact.
     fn handle_dropped_files(&mut self, files: Vec<PathBuf>) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -122,6 +122,7 @@ baselines to maintain.
 | `picasso2_workbench_opens_640x480x16` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-16.hdf` (same, default 640x480x16 screen) |
 | `picasso2plus_workbench_opens_with_gd5428_revision` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2.hdf` (same installation booted against the Picasso II+ identity) |
 | `picasso2_p96cts_reports_all_modes_clean` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
+| `chd_cd32_disc_serves_iso9660_data_and_smooth_audio` | `Pinball Fantasies (EU).chd` (a chdman v5 CD32 disc with a MODE1_RAW data track and CD audio tracks) |
 
 ## Obtaining the assets legally
 

--- a/tests/chd_cd.rs
+++ b/tests/chd_cd.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Asset-gated checks of the CHD CD backend against a real chdman image
+//! (a CD32 game disc with one MODE1_RAW data track and CD audio tracks;
+//! Pinball Fantasies is the local regression example). The unit tests in
+//! `src/cdrom/chd.rs` cover layout and byte order with synthesized
+//! uncompressed CHDs; this test proves the compressed-codec path: hunk
+//! decompression, frame addressing, and CD-DA byte order on real data.
+
+use copperline::cdrom::{CdImage, DATA_SECTOR_BYTES, RAW_SECTOR_BYTES};
+
+/// The integration-test asset directory (see `tests/README.md`):
+/// `COPPERLINE_TEST_ASSETS`, else `test-assets/` under the repo root,
+/// else the repo root itself.
+fn asset(name: &str) -> Option<std::path::PathBuf> {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dir = match std::env::var_os("COPPERLINE_TEST_ASSETS") {
+        Some(d) => std::path::PathBuf::from(d),
+        None => {
+            let d = root.join("test-assets");
+            if d.is_dir() {
+                d
+            } else {
+                root
+            }
+        }
+    };
+    let path = dir.join(name);
+    path.is_file().then_some(path)
+}
+
+/// Lag-1 autocorrelation of the left channel of little-endian CD-DA
+/// samples: near 1 for band-limited audio, near 0 for the byte-shuffled
+/// noise a byte-order mistake produces.
+fn lag1_autocorrelation(sectors: &[[u8; RAW_SECTOR_BYTES]]) -> f64 {
+    let samples: Vec<f64> = sectors
+        .iter()
+        .flat_map(|s| s.chunks_exact(4))
+        .map(|frame| f64::from(i16::from_le_bytes([frame[0], frame[1]])))
+        .collect();
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let num: f64 = samples
+        .windows(2)
+        .map(|w| (w[0] - mean) * (w[1] - mean))
+        .sum();
+    let den: f64 = samples.iter().map(|s| (s - mean) * (s - mean)).sum();
+    num / den
+}
+
+#[test]
+#[ignore = "needs a local CD32 game CHD (see tests/README.md)"]
+fn chd_cd32_disc_serves_iso9660_data_and_smooth_audio() {
+    let Some(path) = asset("Pinball Fantasies (EU).chd") else {
+        eprintln!("skipping: CD32 game CHD not in the asset directory");
+        return;
+    };
+    let mut image = CdImage::load(&path).expect("CHD loads");
+
+    let tracks = image.tracks().to_vec();
+    assert!(tracks[0].kind.is_data(), "track 1 is the data track");
+    let audio_track = tracks
+        .iter()
+        .find(|t| !t.kind.is_data())
+        .expect("disc has a CD audio track");
+
+    // The ISO9660 primary volume descriptor sits at LBA 16 of the data
+    // track: decompressed user data must carry the standard identifier.
+    let mut pvd = [0u8; DATA_SECTOR_BYTES];
+    image.read_data_sector(16, &mut pvd).expect("PVD reads");
+    assert_eq!(&pvd[1..6], b"CD001", "ISO9660 identifier at LBA 16");
+
+    // Pull a second of audio from inside the first audio track (well past
+    // the pregap, where the music has started) and check it decodes to
+    // smooth PCM in disc byte order rather than byte-swapped noise.
+    let mut sectors = vec![[0u8; RAW_SECTOR_BYTES]; 75];
+    let start = audio_track.start_sector + 300;
+    let mut peak = 0i16;
+    for (i, sector) in sectors.iter_mut().enumerate() {
+        image
+            .read_audio_sector(start + i as u32, sector)
+            .expect("audio sector reads");
+        for frame in sector.chunks_exact(2) {
+            peak = peak.max(i16::from_le_bytes([frame[0], frame[1]]).saturating_abs());
+        }
+    }
+    assert!(peak > 1000, "audio window is not silence (peak {peak})");
+    let corr = lag1_autocorrelation(&sectors);
+    assert!(
+        corr > 0.5,
+        "CD-DA does not decode to smooth audio (lag-1 autocorrelation {corr:.3})"
+    );
+}


### PR DESCRIPTION
Closes #374.

CD images in MAME's CHD ("Compressed Hunks of Data") v5 format now load everywhere a `.cue`/`.iso` does: `[cd] image`, SCSI `unitN` (attaches a CD-ROM drive), `--insert-cd-after`, window drag-and-drop, and the load dialogs.

## Implementation

- New backend `src/cdrom/chd.rs` on the pure-Rust [`chd`](https://crates.io/crates/chd) crate (BSD-3, all-Rust codec deps, so wasm browser builds are unaffected). `libchdman-rs`, suggested on the issue, was evaluated and passed over: it is an FFI wrapper around MAME's C++ core with prebuilt static archives, which would add a C++ toolchain dependency and break the wasm target.
- `CdImage` keeps its public sector API and dispatches through a backend enum (plain image files vs CHD hunks), so Akiko (CD32), the CDTV DMAC, and the SCSI CD-ROM target gain CHD support without changes.
- The disc layout follows MAME's `cdrom.cpp` exactly: 2448-byte frames (2352 data + 96 subcode), tracks padded to 4-frame boundaries in the hunk stream, `CHT2`/`CHTR` per-track metadata, chdman's `V`-prefixed PGTYPE marking pregaps that are stored in FRAMES (INDEX 01 = region start + pregap), and unstored pre/postgaps occupying logical addresses as zero fill. CD-DA frames are stored big-endian in a CHD and are byteswapped back to little-endian disc order on read. A one-hunk cache keeps 75-sector/s audio streaming cheap.
- Save states: `CdImage`'s serde shadow became a backend enum and a CHD reattaches by path on load, so `STATE_VERSION` bumps to 47.
- Docs updated: configuration.md (`[cd]`, `[scsi]`, IDE note), ui.md (dialogs/drops/save states), headless.md (`--insert-cd-after`), `copperline.example.toml`, tests/README.md.

## Verification

- Unit tests synthesize minimal uncompressed CHD v5 images (header + raw map + metadata chain) covering mixed data/audio layout, stored and virtual pregaps, postgaps, audio byte order, CHTR metadata, serde reopen, and rejection of non-CD CHDs, MODE2 tracks, and frame overruns.
- Byte-exact against MAME: every raw sector (41658) of a real CD32 game CHD (Pinball Fantasies EU) compares equal to `chdman extractcd` output read through the existing bin/cue backend, and a full boot renders pixel-identical frames from the CHD and the extracted cue.
- The asset-gated `tests/chd_cd.rs` exercises the compressed-codec path on that real image: ISO9660 `CD001` signature decoded from the data track, and CD-DA decoding to smooth little-endian PCM.
- CD32 boots the disc headlessly to gameplay with CD audio playing, and a save state written with the CHD mounted resumes byte-identically.
- `cargo test` (2152 passed), `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all clean.