### PR TITLE
chipset: fetch bitplanes 7 and 8 in the AGA lo-res fetch unit

### DIFF
--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -66,6 +66,13 @@ transition cannot accidentally reuse an ordinary interior line. A
 mid-row BPLCON0 change switches the fetch-unit slot layout from its commit
 clock; word addressing is unit-based, so late-enabled planes keep their
 word positions and earlier words stay zero.
+The lo-res fetch unit is eight colour clocks with eight usable DMA slots.
+OCS/ECS Agnus drives six of them (slot order 4,6,2,3,5,1 at unit offsets
+1,2,3,5,6,7), leaving offsets 0 and 4 free for the Copper/blitter/CPU --
+which is why lo-res tops out at six bitplanes there. Alice drives those two
+remaining slots once BPLCON0 asks for more than six planes (plane 8 at
+offset 0, plane 7 at offset 4, giving the full order 8,4,6,2,7,3,5,1), so an
+eight-bitplane AGA lo-res screen leaves no spare bitplane slot in the unit.
 Wide-FMODE (quantum > 1) fetches keep the memoized value-window plan: the
 effective DDF window, fetch cadence, and per-plane fetch-order mask live in
 a `BitplaneSlotPlan` keyed on the register inputs (`BitplaneSlotKey`,

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -3196,6 +3196,52 @@ fn ocs_bitplane_dma_capture_extends_equal_ddf_window_to_hard_stop() {
 }
 
 #[test]
+fn aga_lores_eight_plane_dma_capture_fetches_all_eight_streams() {
+    // FMODE=0 lo-res with BPLCON0 BPU3 set: Alice schedules all eight
+    // plane streams inside the eight-colour-clock fetch unit (plane 8 in
+    // the slot OCS/ECS leaves free at unit offset 0, plane 7 at offset 4),
+    // so every plane's words reach Denise. A screen whose colours come
+    // from the upper half of the 256-entry palette needs plane 8's bit.
+    let mut bus = empty_bus();
+    bus.set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x2C;
+    bus.agnus.hpos = 0x30;
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x2DC1;
+    bus.denise.ddfstrt = 0x0038;
+    bus.denise.ddfstop = 0x0040;
+    bus.denise.bplcon0 = 0x0210; // BPU3 | COLOR: eight lo-res bitplanes
+    for plane in 0..8 {
+        let ptr = 0x0200 + plane as u32 * 0x0100;
+        bus.denise.bplpt[plane] = ptr;
+        bus.display_dma_bplpt[plane] = ptr;
+        write_chip_word(&mut bus, ptr as usize, 0x1000 | plane as u16);
+        write_chip_word(&mut bus, ptr as usize + 2, 0x2000 | plane as u16);
+    }
+
+    bus.advance_chipset(0x0050 - 0x0030);
+
+    let row = bus.frame_captured_bitplane_rows()[0].as_ref().unwrap();
+    assert_eq!(row.nplanes, 8);
+    assert_eq!(row.words_per_row, 2);
+    for plane in 0..8 {
+        assert_eq!(
+            row.planes[plane],
+            vec![0x1000 | plane as u16, 0x2000 | plane as u16],
+            "plane {} fetched both words",
+            plane + 1
+        );
+        assert_eq!(
+            bus.display_dma_bplpt[plane],
+            0x0200 + plane as u32 * 0x0100 + 4,
+            "plane {} pointer advanced twice",
+            plane + 1
+        );
+    }
+}
+
+#[test]
 fn wide_fmode_dma_capture_packs_lores_slots_in_fetch_units() {
     // Lores FMODE=3 (32-cck fetch units) with DDFSTRT $30 / DDFSTOP
     // $D0: Agnus runs six 32-cck units from the DDFSTRT comparator and

--- a/src/chipset/ddf_sequencer.rs
+++ b/src/chipset/ddf_sequencer.rs
@@ -123,10 +123,22 @@ fn unit_slot(bplcon0: u16, aga: bool, counter: u8) -> Option<u8> {
             _ => has(1),
         }
     } else {
+        // Lo-res: the fetch unit is eight colour clocks with eight usable
+        // DMA slots. OCS/ECS Agnus drives six of them (planes 1-6) and
+        // leaves unit offsets 0 and 4 free for the CPU/Copper/blitter,
+        // which is why a lo-res screen tops out at six bitplanes there.
+        // Alice drives those two remaining slots as well once BPLCON0's
+        // BPU3 (or BPU=7) asks for more than six planes: plane 8 takes
+        // offset 0 and plane 7 offset 4, giving the full lo-res order
+        // 8,4,6,2,7,3,5,1 and leaving no spare bitplane slot in the unit.
+        // `bitplane_dma_planes` caps OCS/ECS at six planes, so `has(7)` and
+        // `has(8)` can only fire on Alice.
         match counter {
+            0 => has(8),
             1 => has(4),
             2 => has(6),
             3 => has(2),
+            4 => has(7),
             5 => has(3),
             6 => has(5),
             7 => has(1),
@@ -718,6 +730,85 @@ mod tests {
             );
             assert_eq!(fetches.last().map(|f| f.cck), Some(0xA7), "line {line}");
         }
+    }
+
+    /// Unit offset (0..7) of every slot in the first complete fetch unit,
+    /// paired with the 1-based plane number Agnus drives there.
+    fn first_unit_slot_order(fetches: &[DdfFetch], unit_ord: u16) -> Vec<(u8, u8)> {
+        fetches
+            .iter()
+            .filter(|f| f.unit_ord == unit_ord)
+            .map(|f| (f.counter, f.plane + 1))
+            .collect()
+    }
+
+    #[test]
+    fn ocs_lores_leaves_two_free_slots_in_every_fetch_unit() {
+        // OCS/ECS Agnus drives six of the eight lo-res unit slots; offsets
+        // 0 and 4 stay free for the CPU/Copper/blitter, which is why lo-res
+        // tops out at six bitplanes there. BPU=6, lo-res, COLOR on.
+        for ecs in [false, true] {
+            let mut state = ready_state(0x6200);
+            let fetches = walk_static(ecs, 0x38, 0xD0, &mut state);
+            assert_eq!(
+                first_unit_slot_order(&fetches, 1),
+                vec![(1, 4), (2, 6), (3, 2), (5, 3), (6, 5), (7, 1)],
+                "ecs={ecs}"
+            );
+            for plane in 0..6 {
+                assert_eq!(words_for_plane(&fetches, plane), 20, "ecs={ecs}");
+            }
+        }
+    }
+
+    #[test]
+    fn aga_lores_eight_planes_drive_every_slot_of_the_fetch_unit() {
+        // Alice fills the two slots OCS/ECS leaves free: plane 8 at unit
+        // offset 0 and plane 7 at offset 4, completing the lo-res order
+        // 8,4,6,2,7,3,5,1. An eight-bitplane lo-res screen therefore leaves
+        // no spare bitplane slot in the eight-colour-clock unit.
+        // BPLCON0 BPU3 (bit 4) selects eight planes with BPU2-0 clear.
+        let mut state = ready_state(0x0210);
+        let signals = line_signals(0x38, 0xD0, LINE, &[]);
+        let fetches = walk_line(true, true, &signals, &mut state);
+        assert_eq!(
+            first_unit_slot_order(&fetches, 1),
+            vec![
+                (0, 8),
+                (1, 4),
+                (2, 6),
+                (3, 2),
+                (4, 7),
+                (5, 3),
+                (6, 5),
+                (7, 1)
+            ]
+        );
+        for plane in 0..8 {
+            assert_eq!(
+                words_for_plane(&fetches, plane),
+                20,
+                "plane {} fetches a full row",
+                plane + 1
+            );
+        }
+        // Every plane takes its modulo exactly once, in the final unit.
+        assert_eq!(fetches.iter().filter(|f| f.apply_modulo).count(), 8);
+    }
+
+    #[test]
+    fn aga_lores_seven_planes_keep_the_first_unit_slot_free() {
+        // BPU=7 with BPU3 clear is seven planes: plane 7 takes unit offset
+        // 4, offset 0 stays free because there is no plane 8 to drive it.
+        let mut state = ready_state(0x7200);
+        let signals = line_signals(0x38, 0xD0, LINE, &[]);
+        let fetches = walk_line(true, true, &signals, &mut state);
+        assert_eq!(
+            first_unit_slot_order(&fetches, 1),
+            vec![(1, 4), (2, 6), (3, 2), (4, 7), (5, 3), (6, 5), (7, 1)]
+        );
+        assert_eq!(words_for_plane(&fetches, 6), 20, "plane 7 fetches");
+        assert_eq!(words_for_plane(&fetches, 7), 0, "no plane 8 stream");
     }
 
     #[test]

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -2578,13 +2578,26 @@ fn apply_render_events_and_collect_display_plan_events_with_visible_line0(
     let cpu_palette_beam_timed = cpu_palette_writes_are_beam_timed(events, visible_line0);
 
     if !cpu_palette_beam_timed {
+        // Lisa decodes each COLORxx write against the BPLCON3 latch standing
+        // at that write: BANK (bits 15-13) selects the block of 32 colour-table
+        // entries and LOCT (bit 9) the nibble half. A palette load that
+        // switches banks between writes therefore has to be resolved write by
+        // write, so carry BPLCON3 through the recorded (beam-ordered) events
+        // rather than resolving the whole frame against its opening value --
+        // otherwise every bank of a CPU-loaded 256-colour table collapses onto
+        // the bank that happened to be selected when the frame began. The
+        // register is a single latch, so a Copper write to it moves the
+        // decode for the CPU's next colour write just as the CPU's own does.
+        let mut bplcon3 = state.bplcon3;
         for event in events {
             let off = event.offset & 0x01FE;
-            if matches!(event.source, BeamWriteSource::Cpu) && matches!(off, 0x180..=0x1BE) {
+            if off == 0x106 {
+                bplcon3 = event.value;
+            } else if matches!(event.source, BeamWriteSource::Cpu) && matches!(off, 0x180..=0x1BE) {
                 let idx = ((off - 0x180) / 2) as usize;
                 if idx < 32 {
                     let value = color_register_value(event.value);
-                    let (entry, loct) = palette_entry_for_write(state.bplcon3, control.aga(), idx);
+                    let (entry, loct) = palette_entry_for_write(bplcon3, control.aga(), idx);
                     palette.write_entry(usize::from(entry), loct, value);
                     state.palette.write_entry(usize::from(entry), loct, value);
                 }

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -2008,6 +2008,92 @@ fn cpu_palette_writes_before_visible_area_update_frame_base() {
 }
 
 #[test]
+fn cpu_banked_palette_load_lands_each_write_in_its_bplcon3_bank() {
+    // Lisa resolves a COLORxx write against the BPLCON3 latch standing at
+    // that write: BANK (bits 15-13) selects the block of 32 colour-table
+    // entries and LOCT (bit 9) the nibble half (LOCT=0 writes both halves,
+    // LOCT=1 the low nibbles only). A CPU load of the 256-entry table walks
+    // BANK across the blocks and toggles LOCT between writes, all inside
+    // vertical blank before the display starts, so each write has to be
+    // resolved against the BPLCON3 value in force when it happened. Resolving
+    // the whole load against the value the frame opened with collapses every
+    // bank onto that one and destroys the entries it aliases over.
+    const LOCT: u16 = 0x0200;
+    let mut state = blank_state();
+    state.agnus_revision = AgnusRevision::AgaAlice;
+    let mut base_palettes = [state.palette; FB_HEIGHT];
+    let mut palette_segments = vec![Vec::new(); FB_HEIGHT];
+    let mut base_controls = [ControlState::from_render_state(&state); FB_HEIGHT];
+    let mut control_segments = vec![Vec::new(); FB_HEIGHT];
+    let mut manual_bpl_segments = Vec::new();
+
+    // (BANK, COLORxx index, high-nibble word, low-nibble word). BANK 0, the
+    // bank the frame opens in, is deliberately never selected.
+    let loads = [
+        (1usize, 0usize, 0x0123u16, 0x0456u16),
+        (2, 15, 0x0789, 0x0ABC),
+        (7, 31, 0x0FED, 0x0CBA),
+    ];
+    let vblank_line = (PAL_VISIBLE_LINE0 - 20) as u32;
+    let hpos = COPPER_WAIT_HPOS_FB0 as u32;
+    let mut events = Vec::new();
+    for (bank, idx, hi, lo) in loads {
+        let bank_bits = BPLCON3_PF2OF_DEFAULT | ((bank as u16) << 13);
+        let color = 0x180 + (idx as u16) * 2;
+        events.push(cpu_event(vblank_line, hpos, 0x106, bank_bits));
+        events.push(cpu_event(vblank_line, hpos, color, hi));
+        events.push(cpu_event(vblank_line, hpos, 0x106, bank_bits | LOCT));
+        events.push(cpu_event(vblank_line, hpos, color, lo));
+    }
+
+    apply_render_events(
+        &mut state,
+        &events,
+        &mut base_palettes,
+        &mut palette_segments,
+        &mut base_controls,
+        &mut control_segments,
+        &mut manual_bpl_segments,
+    );
+
+    assert!(palette_segments.iter().all(Vec::is_empty));
+    for (bank, idx, hi, lo) in loads {
+        let entry = bank * 32 + idx;
+        // The 8-bit components are the high nibble from the LOCT=0 write and
+        // the low nibble from the LOCT=1 write.
+        let expected_rgb24 = (u32::from(hi >> 8 & 0xF) << 20)
+            | (u32::from(lo >> 8 & 0xF) << 16)
+            | (u32::from(hi >> 4 & 0xF) << 12)
+            | (u32::from(lo >> 4 & 0xF) << 8)
+            | (u32::from(hi & 0xF) << 4)
+            | u32::from(lo & 0xF);
+        assert_eq!(
+            state.palette.entry(entry).latch(),
+            hi,
+            "bank {bank} COLOR{idx:02} latch"
+        );
+        assert_eq!(
+            state.palette.entry(entry).rgb24(),
+            expected_rgb24,
+            "bank {bank} COLOR{idx:02} merged 24-bit value"
+        );
+        assert_eq!(
+            base_palettes[0].entry(entry).rgb24(),
+            expected_rgb24,
+            "bank {bank} COLOR{idx:02} in the frame base palette"
+        );
+    }
+    // Bank 0 was never selected, so none of the load may land there.
+    for (_, idx, _, _) in loads {
+        assert_eq!(
+            state.palette.entry(idx).latch(),
+            0x0103,
+            "bank 0 COLOR{idx:02} untouched"
+        );
+    }
+}
+
+#[test]
 fn ddf_overscan_fetches_still_advance_bitplane_pointers() {
     let state = RenderState {
         ddfstrt: 0x0038,


### PR DESCRIPTION
## Eight-bitplane AGA lo-res screens fetched only six planes

The lo-res fetch unit is eight colour clocks wide with eight usable DMA
slots. OCS/ECS Agnus drives six of them -- unit offsets 1, 2, 3, 5, 6, 7
carrying planes 4, 6, 2, 3, 5, 1 -- and leaves offsets 0 and 4 to the
CPU/Copper/blitter, which is exactly why a lo-res screen tops out at six
bitplanes on OCS/ECS. Alice drives those two remaining slots as well once
BPLCON0 asks for more than six planes: plane 8 takes offset 0 and plane 7
offset 4, so the full AGA lo-res order is 8, 4, 6, 2, 7, 3, 5, 1 and an
eight-bitplane lo-res screen leaves no spare bitplane slot in the unit.

`unit_slot()` in the DDF sequencer carried only the six OCS/ECS offsets.
Planes 7 and 8 were therefore never fetched on an AGA lo-res screen: every
pixel index came out below 0x80, the upper half of the 256-entry colour
table was unreachable, and the display drew in the wrong colours. OCS/ECS
is unaffected by construction -- `bitplane_dma_planes` caps those Agnus
revisions at six planes, so the two added slots can only fire on Alice.

### Evidence

Pinball Fantasies (CD32) is the regression example: its 8-bitplane lo-res
table renders in a mangled palette. Measured on the in-game frame at 74
emulated seconds, the rendered framebuffer contained **0 pixels with a
colour index >= 0x80 before the fix and ~128k after**, i.e. planes 7 and 8
contributed nothing at all.

The palette store itself was already correct and was ruled out first: the
frame's colour table reconstructed from the recorded COLORxx write log is
byte-identical to the one the renderer holds, and this title loads its
palette from the Copper rather than the CPU, so no CPU-write path was
involved in the corruption.

## Second fix: CPU palette pre-pass resolved every write against the frame-start BPLCON3

While auditing the palette store, a separate defect turned up in the replay
renderer's pre-pass for CPU-written palettes. Lisa resolves a COLORxx write
against the BPLCON3 latch standing at that write: BANK (bits 15-13) selects
the block of 32 colour-table entries, LOCT (bit 9) the nibble half (LOCT=0
writes both halves, LOCT=1 the low nibbles only). The pre-pass resolved
every colour write in the frame against the BPLCON3 value the frame opened
with, while the mid-frame path already tracked the register correctly.

A CPU load that walks BANK across the eight blocks during vertical blank
therefore collapsed onto the opening bank: the frame's base palette lost
every entry outside that bank and kept whatever the collapsed writes left
over the entries they aliased onto. The pre-pass now carries BPLCON3
through the recorded (beam-ordered) events, so each write lands in the bank
and nibble half in force when it happened. The register is a single latch,
so a Copper write to it moves the decode for the CPU's next colour write
exactly as a CPU write does.

## Tests

- `aga_lores_eight_plane_dma_capture_fetches_all_eight_streams` (`src/bus/tests.rs`) --
  end-to-end DMA capture: all eight plane streams reach Denise and every
  pointer advances.
- `aga_lores_eight_planes_drive_every_slot_of_the_fetch_unit`
  (`src/chipset/ddf_sequencer.rs`) -- asserts the full 8, 4, 6, 2, 7, 3, 5, 1
  slot order and one modulo per plane.
- `aga_lores_seven_planes_keep_the_first_unit_slot_free` -- BPU=7 puts plane 7
  at offset 4 and leaves offset 0 free.
- `ocs_lores_leaves_two_free_slots_in_every_fetch_unit` -- OCS and ECS keep
  offsets 0 and 4 free (the six-plane lo-res limit).
- `cpu_banked_palette_load_lands_each_write_in_its_bplcon3_bank`
  (`src/video/bitplane/tests.rs`) -- synthetic vertical-blank load with BANK
  switches and LOCT hi/lo pairs interleaved with COLORxx writes; entries land
  in their own banks with correctly merged 24-bit values, and the bank the
  frame opened in stays untouched.

`docs/internals/timing.md` gains the lo-res fetch-unit slot order.

## No-regression evidence

- Full unit suite, `cargo clippy --all-targets --all-features -- -D warnings`
  and `cargo fmt --check` all clean.
- 12-frame dumps of Roots II (AGA), Zool (AGA) and Inside the Machine are
  byte-identical to the pre-change build.
- The Pinball Fantasies table-select menu at 40 emulated seconds is
  byte-identical to its pre-change rendering; the in-game frame at 74s now
  matches the reference.
