### PR TITLE
window: serialize the offscreen GPU tests on one shared device helper (issue #366)

### DIFF
--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -341,26 +341,10 @@ mod tests {
     /// left a hole, and any outside means it overdrew its viewport.
     const SENTINEL: [u8; 4] = [0, 0, 255, 255];
 
-    /// A device, or `None` on a machine with no usable adapter (headless
-    /// CI): the render tests then pass without asserting anything.
-    fn gpu() -> Option<(wgpu::Device, wgpu::Queue)> {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
-        let adapter =
-            match crt_shader::poll_once(instance.request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::LowPower,
-                force_fallback_adapter: false,
-                compatible_surface: None,
-            })) {
-                Some(Ok(adapter)) => adapter,
-                _ => return None,
-            };
-        match crt_shader::poll_once(adapter.request_device(&wgpu::DeviceDescriptor {
-            label: Some("bezel_shader_test"),
-            ..Default::default()
-        })) {
-            Some(Ok(pair)) => Some(pair),
-            _ => None,
-        }
+    /// A serialized device, or `None` without a usable hardware adapter:
+    /// see `crt_shader::test_gpu`.
+    fn gpu() -> Option<(crt_shader::GpuTestGuard, wgpu::Device, wgpu::Queue)> {
+        crt_shader::test_gpu("bezel_shader_test")
     }
 
     /// The `pixels` backing texture in miniature: `display_rows` rows of
@@ -586,7 +570,7 @@ mod tests {
 
     #[test]
     fn the_bezel_covers_the_display_rect_and_nothing_below() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -616,7 +600,7 @@ mod tests {
 
     #[test]
     fn the_picture_fills_the_opening_and_the_frame_is_plastic() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -670,7 +654,7 @@ mod tests {
 
     #[test]
     fn the_badge_prints_on_the_left_of_the_bottom_band() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -722,7 +706,7 @@ mod tests {
     /// intact) with the preset's scanline structure inside the opening.
     #[test]
     fn a_crt_preset_lands_inside_the_opening() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -781,7 +765,7 @@ mod tests {
             eprintln!("skipping: COPPERLINE_BEZEL_PREVIEW_OUT not set");
             return;
         };
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -343,7 +343,7 @@ mod tests {
 
     /// A serialized device, or `None` without a usable hardware adapter:
     /// see `crt_shader::test_gpu`.
-    fn gpu() -> Option<(crt_shader::GpuTestGuard, wgpu::Device, wgpu::Queue)> {
+    fn gpu() -> Option<crt_shader::TestGpu> {
         crt_shader::test_gpu("bezel_shader_test")
     }
 
@@ -570,13 +570,13 @@ mod tests {
 
     #[test]
     fn the_bezel_covers_the_display_rect_and_nothing_below() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
-        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(&device, &queue, &src, None);
+        let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(device, queue, &src, None);
         for y in 0..rows {
             for x in 0..dim {
                 let p = at(&px, dim, x, y);
@@ -600,13 +600,13 @@ mod tests {
 
     #[test]
     fn the_picture_fills_the_opening_and_the_frame_is_plastic() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
-        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(&device, &queue, &src, None);
+        let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(device, queue, &src, None);
 
         // Centre of the opening: the flat grey source, resampled 1:1 in
         // colour terms.
@@ -654,13 +654,13 @@ mod tests {
 
     #[test]
     fn the_badge_prints_on_the_left_of_the_bottom_band() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
-        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(&device, &queue, &src, None);
+        let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(device, queue, &src, None);
 
         // The badge rect as the shader lays it out: left-aligned with the
         // opening, vertically centred in the bottom band, 59x8 font pixels
@@ -706,13 +706,13 @@ mod tests {
     /// intact) with the preset's scanline structure inside the opening.
     #[test]
     fn a_crt_preset_lands_inside_the_opening() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
-        let src = source_texture(&device, &queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(&device, &queue, &src, Some(ShaderKind::Scanlines));
+        let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
+        let (px, dim, rows) = render_bezel(device, queue, &src, Some(ShaderKind::Scanlines));
 
         let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
         // Scanlines modulate the opening interior: one column of it must
@@ -765,10 +765,10 @@ mod tests {
             eprintln!("skipping: COPPERLINE_BEZEL_PREVIEW_OUT not set");
             return;
         };
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         let with_crt = std::env::var("COPPERLINE_BEZEL_PREVIEW_SHADER").is_ok();
         let (src, w, h) = match std::env::var("COPPERLINE_BEZEL_PREVIEW_SRC") {
             Ok(path) => {
@@ -792,7 +792,7 @@ mod tests {
                         .collect(),
                     other => panic!("unsupported source colour type {other:?}"),
                 };
-                let tex = source_texture(&device, &queue, w, h, h, &move |x, y| {
+                let tex = source_texture(device, queue, w, h, h, &move |x, y| {
                     rgba[(y * w + x) as usize]
                 });
                 (tex, w, h)
@@ -803,7 +803,7 @@ mod tests {
                     [bar * 32, 255 - bar * 32, (y * 4) as u8, 255]
                 };
                 (
-                    source_texture(&device, &queue, TEX, TEX, TEX, &card),
+                    source_texture(device, queue, TEX, TEX, TEX, &card),
                     TEX,
                     TEX,
                 )
@@ -841,10 +841,10 @@ mod tests {
         );
         let opening = opening_rect(viewport);
         if with_crt {
-            let mut crt = crt_shader::CrtShader::new(&device, FORMAT);
+            let mut crt = crt_shader::CrtShader::new(device, FORMAT);
             crt.render(
-                &device,
-                &queue,
+                device,
+                queue,
                 &src,
                 &mut encoder,
                 &view,
@@ -853,17 +853,17 @@ mod tests {
                 crt_uniforms.with_viewport(opening),
             );
         }
-        let mut shader = BezelShader::new(&device, FORMAT);
+        let mut shader = BezelShader::new(device, FORMAT);
         shader.render(
-            &device,
-            &queue,
+            device,
+            queue,
             &src,
             &mut encoder,
             &view,
             viewport,
             uniforms_from(&crt_uniforms, viewport, opening, with_crt),
         );
-        let px = read_back(&device, &queue, encoder, &target, (w, h));
+        let px = read_back(device, queue, encoder, &target, (w, h));
         let file = std::fs::File::create(&out).expect("create preview");
         let mut enc = png::Encoder::new(std::io::BufWriter::new(file), w, h);
         enc.set_color(png::ColorType::Rgba);

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -199,6 +199,58 @@ pub(super) fn poll_once<F: Future>(fut: F) -> Option<F::Output> {
     }
 }
 
+/// A guard on the process-wide GPU-test lock: the offscreen render tests
+/// hold one for the life of their device.
+#[cfg(test)]
+pub(super) type GpuTestGuard = std::sync::MutexGuard<'static, ()>;
+
+/// A device for an offscreen render test, or `None` on a machine with no
+/// usable adapter (headless CI) or only a software rasterizer: the render
+/// tests then pass without asserting anything.
+///
+/// The guard serializes GPU use across the window shader suites (this
+/// module, bezel, rtg_texture): the harness runs tests on parallel
+/// threads, and concurrent D3D12 device create/render/teardown cycles
+/// against the Windows CI runners' WARP rasterizer have taken the whole
+/// test process down with STATUS_ACCESS_VIOLATION (issue #366).
+#[cfg(test)]
+pub(super) fn test_gpu(label: &str) -> Option<(GpuTestGuard, wgpu::Device, wgpu::Queue)> {
+    static GPU_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let guard = GPU_TESTS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = match poll_once(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::LowPower,
+        force_fallback_adapter: false,
+        compatible_surface: None,
+    })) {
+        Some(Ok(adapter)) => adapter,
+        _ => return None,
+    };
+    // Software rasterizers do not render these passes the way real
+    // hardware does: DX12 WARP on the Windows CI runners puts flat-grey
+    // pixels up to 14 8-bit steps off the source, far beyond the
+    // tolerances real adapters need, so pixel asserts against it test
+    // WARP, not the shaders. Skip them like a missing adapter; the
+    // render tests run for real on the macOS CI runners' Metal GPU and
+    // on developer machines.
+    if adapter.get_info().device_type == wgpu::DeviceType::Cpu {
+        eprintln!(
+            "skipping: software rasterizer ({})",
+            adapter.get_info().name
+        );
+        return None;
+    }
+    match poll_once(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some(label),
+        ..Default::default()
+    })) {
+        Some(Ok((device, queue))) => Some((guard, device, queue)),
+        _ => None,
+    }
+}
+
 impl CrtShader {
     pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
         let bind_group_layout = shader_bind_group_layout(device);
@@ -821,39 +873,10 @@ fn fs_main() -> @location(0) vec4<f32> {
         }
     }
 
-    /// A device, or `None` on a machine with no usable adapter (headless
-    /// CI): the render tests then pass without asserting anything.
-    fn gpu() -> Option<(wgpu::Device, wgpu::Queue)> {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
-        let adapter = match poll_once(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::LowPower,
-            force_fallback_adapter: false,
-            compatible_surface: None,
-        })) {
-            Some(Ok(adapter)) => adapter,
-            _ => return None,
-        };
-        // Software rasterizers do not render these passes the way real
-        // hardware does: DX12 WARP on the Windows CI runners puts flat-grey
-        // pixels up to 14 8-bit steps off the source, far beyond the
-        // tolerances real adapters need, so pixel asserts against it test
-        // WARP, not the shaders. Skip them like a missing adapter; the
-        // render tests run for real on the macOS CI runners' Metal GPU and
-        // on developer machines.
-        if adapter.get_info().device_type == wgpu::DeviceType::Cpu {
-            eprintln!(
-                "skipping: software rasterizer ({})",
-                adapter.get_info().name
-            );
-            return None;
-        }
-        match poll_once(adapter.request_device(&wgpu::DeviceDescriptor {
-            label: Some("crt_shader_test"),
-            ..Default::default()
-        })) {
-            Some(Ok(pair)) => Some(pair),
-            _ => None,
-        }
+    /// A serialized device, or `None` without a usable hardware adapter:
+    /// see `test_gpu`.
+    fn gpu() -> Option<(GpuTestGuard, wgpu::Device, wgpu::Queue)> {
+        test_gpu("crt_shader_test")
     }
 
     /// The `pixels` backing texture, in miniature: `DISPLAY_ROWS` of flat
@@ -1069,7 +1092,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn presets_render_the_display_region_only() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1096,7 +1119,7 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// whole bottom of the picture.
     #[test]
     fn a_magnified_display_never_blends_in_the_status_bar() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1120,7 +1143,7 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// partly dimmed, so anything the clamp picked up shows through.
     #[test]
     fn the_crt_warp_never_reaches_the_status_bar() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1155,7 +1178,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn scanlines_modulate_rows_periodically() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1218,7 +1241,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn the_mask_preset_colours_pixels_into_triads() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1271,7 +1294,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn the_crt_preset_darkens_the_corners() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1311,7 +1334,7 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// bowed picture on every bright border.
     #[test]
     fn the_crt_face_edge_is_hard_at_partial_strength() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1357,7 +1380,7 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// instead of holding a view of the old one.
     #[test]
     fn a_new_source_texture_rebuilds_the_bind_group() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1402,7 +1425,7 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// the target keeps whatever the scaling renderer put there.
     #[test]
     fn a_disabled_pass_leaves_the_target_untouched() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };
@@ -1426,7 +1449,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn a_custom_shader_loads_and_a_broken_one_does_not() {
-        let Some((device, _queue)) = gpu() else {
+        let Some((_gpu, device, _queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -199,24 +199,42 @@ pub(super) fn poll_once<F: Future>(fut: F) -> Option<F::Output> {
     }
 }
 
-/// A guard on the process-wide GPU-test lock: the offscreen render tests
-/// hold one for the life of their device.
+/// A GPU-test device holding the process-wide GPU-test lock for its
+/// lifetime. The lock lives in a private field so a test cannot keep the
+/// device while releasing its turn; borrow the device and queue through
+/// the accessors.
 #[cfg(test)]
-pub(super) type GpuTestGuard = std::sync::MutexGuard<'static, ()>;
+pub(super) struct TestGpu {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+}
 
-/// A device for an offscreen render test, or `None` on a machine with no
-/// usable adapter (headless CI) or only a software rasterizer: the render
-/// tests then pass without asserting anything.
+#[cfg(test)]
+impl TestGpu {
+    pub(super) fn device(&self) -> &wgpu::Device {
+        &self.device
+    }
+
+    pub(super) fn queue(&self) -> &wgpu::Queue {
+        &self.queue
+    }
+}
+
+/// A device for an offscreen render test, or `None` when the machine has
+/// no usable hardware adapter (headless CI, a software rasterizer, or a
+/// failed device request); the reason is printed and the render tests
+/// then pass without asserting anything.
 ///
-/// The guard serializes GPU use across the window shader suites (this
+/// The handle serializes GPU use across the window shader suites (this
 /// module, bezel, rtg_texture): the harness runs tests on parallel
 /// threads, and concurrent D3D12 device create/render/teardown cycles
 /// against the Windows CI runners' WARP rasterizer have taken the whole
 /// test process down with STATUS_ACCESS_VIOLATION (issue #366).
 #[cfg(test)]
-pub(super) fn test_gpu(label: &str) -> Option<(GpuTestGuard, wgpu::Device, wgpu::Queue)> {
+pub(super) fn test_gpu(label: &str) -> Option<TestGpu> {
     static GPU_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let guard = GPU_TESTS
+    let lock = GPU_TESTS
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
@@ -226,7 +244,10 @@ pub(super) fn test_gpu(label: &str) -> Option<(GpuTestGuard, wgpu::Device, wgpu:
         compatible_surface: None,
     })) {
         Some(Ok(adapter)) => adapter,
-        _ => return None,
+        _ => {
+            eprintln!("skipping: no GPU adapter");
+            return None;
+        }
     };
     // Software rasterizers do not render these passes the way real
     // hardware does: DX12 WARP on the Windows CI runners puts flat-grey
@@ -246,8 +267,15 @@ pub(super) fn test_gpu(label: &str) -> Option<(GpuTestGuard, wgpu::Device, wgpu:
         label: Some(label),
         ..Default::default()
     })) {
-        Some(Ok((device, queue))) => Some((guard, device, queue)),
-        _ => None,
+        Some(Ok((device, queue))) => Some(TestGpu {
+            _lock: lock,
+            device,
+            queue,
+        }),
+        _ => {
+            eprintln!("skipping: GPU device request failed");
+            None
+        }
     }
 }
 
@@ -875,7 +903,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     /// A serialized device, or `None` without a usable hardware adapter:
     /// see `test_gpu`.
-    fn gpu() -> Option<(GpuTestGuard, wgpu::Device, wgpu::Queue)> {
+    fn gpu() -> Option<TestGpu> {
         test_gpu("crt_shader_test")
     }
 
@@ -1092,22 +1120,22 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn presets_render_the_display_region_only() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
 
         for kind in [ShaderKind::Scanlines, ShaderKind::Mask, ShaderKind::Crt] {
             let label = kind.label();
             // Strength 0 leaves the shader arithmetic an identity, so a
             // 1:1 pass reproduces the flat grey exactly.
-            let off = render_preset(&device, &queue, &mut shader, &src, kind, 0.0, 16.0, 1);
+            let off = render_preset(device, queue, &mut shader, &src, kind, 0.0, 16.0, 1);
             off.assert_display_region_only(label);
             assert_flat_grey(&off, &format!("{label} at strength 0"), 2);
 
-            let on = render_preset(&device, &queue, &mut shader, &src, kind, 1.0, 16.0, 1);
+            let on = render_preset(device, queue, &mut shader, &src, kind, 1.0, 16.0, 1);
             on.assert_display_region_only(label);
         }
     }
@@ -1119,16 +1147,16 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// whole bottom of the picture.
     #[test]
     fn a_magnified_display_never_blends_in_the_status_bar() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
 
         for kind in [ShaderKind::Scanlines, ShaderKind::Mask, ShaderKind::Crt] {
             let label = kind.label();
-            let frame = render_preset(&device, &queue, &mut shader, &src, kind, 0.0, 16.0, 2);
+            let frame = render_preset(device, queue, &mut shader, &src, kind, 0.0, 16.0, 2);
             assert_eq!((frame.dim, frame.rows), (TEX * 2, DISPLAY_ROWS * 2));
             frame.assert_display_region_only(label);
             // Every row, the last one included: a magenta blend shows up
@@ -1143,17 +1171,17 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// partly dimmed, so anything the clamp picked up shows through.
     #[test]
     fn the_crt_warp_never_reaches_the_status_bar() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
 
         for scale in [1, 2] {
             let frame = render_preset(
-                &device,
-                &queue,
+                device,
+                queue,
                 &mut shader,
                 &src,
                 ShaderKind::Crt,
@@ -1178,18 +1206,18 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn scanlines_modulate_rows_periodically() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
 
         // 16 lines over 48 output rows: three rows per emulated line, so
         // the raised cosine is sampled at its peak and at both flanks.
         let frame = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &src,
             ShaderKind::Scanlines,
@@ -1221,8 +1249,8 @@ fn fs_main() -> @location(0) vec4<f32> {
         // symmetric profile at Nyquist, not a bug: the line structure only
         // shows once the window is scaled past 2x the emulated lines.
         let flat = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &src,
             ShaderKind::Scanlines,
@@ -1241,15 +1269,15 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn the_mask_preset_colours_pixels_into_triads() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
         let frame = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &src,
             ShaderKind::Mask,
@@ -1294,15 +1322,15 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn the_crt_preset_darkens_the_corners() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
         let frame = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &src,
             ShaderKind::Crt,
@@ -1334,17 +1362,17 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// bowed picture on every bright border.
     #[test]
     fn the_crt_face_edge_is_hard_at_partial_strength() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         // A saturated display colour, so a fractional leak is unmistakable
         // rather than a slightly-off grey.
-        let src = source_texture(&device, &queue, [200, 60, 200, 255]);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let src = source_texture(device, queue, [200, 60, 200, 255]);
+        let mut shader = CrtShader::new(device, FORMAT);
         let frame = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &src,
             ShaderKind::Crt,
@@ -1380,17 +1408,17 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// instead of holding a view of the old one.
     #[test]
     fn a_new_source_texture_rebuilds_the_bind_group() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let mut shader = CrtShader::new(&device, FORMAT);
-        let grey = grey_source(&device, &queue);
-        let green = source_texture(&device, &queue, [0, GREY, 0, 255]);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let mut shader = CrtShader::new(device, FORMAT);
+        let grey = grey_source(device, queue);
+        let green = source_texture(device, queue, [0, GREY, 0, 255]);
 
         let first = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &grey,
             ShaderKind::Scanlines,
@@ -1401,8 +1429,8 @@ fn fs_main() -> @location(0) vec4<f32> {
         assert_flat_grey(&first, "first texture", 2);
 
         let second = render_preset(
-            &device,
-            &queue,
+            device,
+            queue,
             &mut shader,
             &green,
             ShaderKind::Scanlines,
@@ -1425,15 +1453,15 @@ fn fs_main() -> @location(0) vec4<f32> {
     /// the target keeps whatever the scaling renderer put there.
     #[test]
     fn a_disabled_pass_leaves_the_target_untouched() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let src = grey_source(&device, &queue);
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = grey_source(device, queue);
+        let mut shader = CrtShader::new(device, FORMAT);
 
         for kind in [ShaderKind::None, ShaderKind::Custom] {
-            let frame = render_preset(&device, &queue, &mut shader, &src, kind, 1.0, 16.0, 1);
+            let frame = render_preset(device, queue, &mut shader, &src, kind, 1.0, 16.0, 1);
             for y in 0..frame.dim {
                 for x in 0..frame.dim {
                     assert_eq!(
@@ -1449,17 +1477,17 @@ fn fs_main() -> @location(0) vec4<f32> {
 
     #[test]
     fn a_custom_shader_loads_and_a_broken_one_does_not() {
-        let Some((_gpu, device, _queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
-        let mut shader = CrtShader::new(&device, FORMAT);
+        let device = gpu.device();
+        let mut shader = CrtShader::new(device, FORMAT);
         let dir = temp_dir("custom");
 
         let good = dir.join("good.wgsl");
         std::fs::write(&good, CRT_WGSL).expect("write");
         shader
-            .load_custom(&device, FORMAT, &good)
+            .load_custom(device, FORMAT, &good)
             .expect("preset source must load as a custom shader");
         assert!(shader.custom.is_some());
 
@@ -1467,12 +1495,12 @@ fn fs_main() -> @location(0) vec4<f32> {
         assert!(shader.custom.is_none());
 
         shader
-            .load_custom(&device, FORMAT, &good)
+            .load_custom(device, FORMAT, &good)
             .expect("reload after clear");
         let bad = dir.join("bad.wgsl");
         std::fs::write(&bad, "fn nope() -> i32 { return 0; }").expect("write");
         let err = shader
-            .load_custom(&device, FORMAT, &bad)
+            .load_custom(device, FORMAT, &bad)
             .expect_err("no entry points");
         assert!(err.contains("vs_main"), "{err}");
         // A failed load must not leave the previous shader selected.
@@ -1480,7 +1508,7 @@ fn fs_main() -> @location(0) vec4<f32> {
 
         let missing = dir.join("does-not-exist.wgsl");
         let err = shader
-            .load_custom(&device, FORMAT, &missing)
+            .load_custom(device, FORMAT, &missing)
             .expect_err("missing file");
         assert!(err.contains("does-not-exist.wgsl"), "{err}");
 

--- a/src/video/window/rtg_texture.rs
+++ b/src/video/window/rtg_texture.rs
@@ -465,27 +465,14 @@ mod tests {
     const SENTINEL: [u8; 4] = [255, 0, 255, 255];
     const BLACK: [u8; 4] = [0, 0, 0, 255];
 
-    /// A device, or `None` on a machine with no usable adapter (headless
-    /// CI): the render test then passes without asserting anything, as the
-    /// bezel pass's own offscreen tests do.
-    fn gpu() -> Option<(wgpu::Device, wgpu::Queue)> {
-        use super::super::crt_shader::poll_once;
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
-        let adapter = match poll_once(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::LowPower,
-            force_fallback_adapter: false,
-            compatible_surface: None,
-        })) {
-            Some(Ok(adapter)) => adapter,
-            _ => return None,
-        };
-        match poll_once(adapter.request_device(&wgpu::DeviceDescriptor {
-            label: Some("rtg_texture_test"),
-            ..Default::default()
-        })) {
-            Some(Ok(pair)) => Some(pair),
-            _ => None,
-        }
+    /// A serialized device, or `None` without a usable hardware adapter:
+    /// see `crt_shader::test_gpu`.
+    fn gpu() -> Option<(
+        super::super::crt_shader::GpuTestGuard,
+        wgpu::Device,
+        wgpu::Queue,
+    )> {
+        super::super::crt_shader::test_gpu("rtg_texture_test")
     }
 
     /// Draw the 2x2 frame into a `w` x `h` target through the real pass,
@@ -612,7 +599,7 @@ mod tests {
     /// smooth scaling must still stretch the frame across the whole rect.
     #[test]
     fn integer_scaling_lands_the_board_frame_on_whole_pixel_blocks() {
-        let Some((device, queue)) = gpu() else {
+        let Some((_gpu, device, queue)) = gpu() else {
             eprintln!("skipping: no GPU adapter");
             return;
         };

--- a/src/video/window/rtg_texture.rs
+++ b/src/video/window/rtg_texture.rs
@@ -467,11 +467,7 @@ mod tests {
 
     /// A serialized device, or `None` without a usable hardware adapter:
     /// see `crt_shader::test_gpu`.
-    fn gpu() -> Option<(
-        super::super::crt_shader::GpuTestGuard,
-        wgpu::Device,
-        wgpu::Queue,
-    )> {
+    fn gpu() -> Option<super::super::crt_shader::TestGpu> {
         super::super::crt_shader::test_gpu("rtg_texture_test")
     }
 
@@ -599,14 +595,14 @@ mod tests {
     /// smooth scaling must still stretch the frame across the whole rect.
     #[test]
     fn integer_scaling_lands_the_board_frame_on_whole_pixel_blocks() {
-        let Some((_gpu, device, queue)) = gpu() else {
-            eprintln!("skipping: no GPU adapter");
+        let Some(gpu) = gpu() else {
             return;
         };
+        let (device, queue) = (gpu.device(), gpu.queue());
         let (w, h) = (12u32, 8u32);
         let at = |px: &[[u8; 4]], x: u32, y: u32| px[(y * w + x) as usize];
 
-        let px = render_frame(&device, &queue, (w, h), true);
+        let px = render_frame(device, queue, (w, h), true);
         // The margins the picture does not reach are painted black by the
         // pass itself -- the window buffer underneath must not show.
         for y in 0..h {
@@ -640,7 +636,7 @@ mod tests {
         // Smooth scaling is unchanged: the frame is stretched over the
         // whole rect, so the corners hold the corner texels and there is
         // no border at all.
-        let px = render_frame(&device, &queue, (w, h), false);
+        let px = render_frame(device, queue, (w, h), false);
         assert_eq!(at(&px, 0, 0), RED.to_le_bytes());
         assert_eq!(at(&px, 11, 0), GREEN.to_le_bytes());
         assert_eq!(at(&px, 0, 7), BLUE.to_le_bytes());


### PR DESCRIPTION
## Summary

Fixes the intermittent Windows CI crash tracked in #366: the `Unit tests` job has died three times with `STATUS_ACCESS_VIOLATION` (0xC0000005), most recently on the merges of #367 and #376. Reconstructing the in-flight test set from the crashed logs (full analysis in [this comment](https://github.com/CopperlineHQ/Copperline/issues/366#issuecomment-5171643146)) shows every crash died with the bezel/rtg_texture offscreen render tests running concurrently on separate threads, the two merge-commit crashes at the identical schedule point after a 6-7s stall.

The root cause those sets point at: `crt_shader::gpu()` already refuses software rasterizers because WARP does not render the passes faithfully, but the bezel and rtg_texture copies of the helper never picked up that skip. They were therefore the only tests creating D3D12 WARP devices on the runners - up to three concurrent instance/device create-render-teardown cycles at once, which is exactly the kind of load that takes WARP down.

## Changes

- The three per-suite `gpu()` helpers become one shared `crt_shader::test_gpu(label)`, next to the `poll_once` they already shared.
- A process-wide mutex serializes the GPU tests: the guard is returned with the device and held for the life of the test, so concurrent device lifecycle on one adapter is gone entirely.
- The software-rasterizer skip now applies to all three suites, so windows-latest creates no WARP devices at all - matching the policy the crt_shader suite already established. The render tests still run for real on the macOS runners' Metal GPU and on developer machines.

Test-only change; no behavior change in the emulator or the shipped binaries.

## Testing

- `cargo test` clean (2153 passed; the offscreen render tests exercised for real against Metal).
- `cargo clippy --all-targets` and `cargo fmt --check` clean.