### PR TITLE
web: add a dismiss chip to the on-screen keyboard

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1974,6 +1974,7 @@ function ensureKeyboard() {
   }
 
   grid.appendChild(buildLegendChip());
+  grid.appendChild(buildCloseChip());
   wireKeyboardPointers(root);
   applyKbdLegends();
   // Measured rather than derived: the padding carries
@@ -2151,6 +2152,30 @@ function buildLegendChip() {
   chip.setAttribute('role', 'button');
   chip.tabIndex = -1;
   kbdLegendChip = chip;
+  return chip;
+}
+
+// Putting the keyboard away has to work from the keyboard: in fullscreen
+// the page's toggle is gone and the bar needs a tap to summon, which is the
+// moment a visitor most wants the picture back. It shares the notch with
+// the legend switch, in the slot above it - the one farthest from the
+// cursor keys a game is hammering, so a missed arrow cannot fold the
+// keyboard away mid-play.
+function buildCloseChip() {
+  const chip = document.createElement('div');
+  chip.style.cssText =
+    'position:absolute;box-sizing:border-box;cursor:pointer;' +
+    'left:calc(15.5 * var(--cl-u));top:calc(2.6 * var(--cl-u));' +
+    'width:calc(var(--cl-u) - 4px);height:calc(0.8 * var(--cl-u));' +
+    'display:flex;align-items:center;justify-content:center;' +
+    'border-radius:4px;border:1px solid rgba(255,255,255,0.3);' +
+    'color:rgba(255,255,255,0.75);' +
+    'font:600 calc(0.4 * var(--cl-u)) "IBM Plex Mono",ui-monospace,monospace;';
+  chip.textContent = '\u00d7'; // multiplication sign: the X every font draws
+  chip.dataset.closeChip = '1';
+  chip.setAttribute('role', 'button');
+  chip.setAttribute('aria-label', 'Hide keyboard');
+  chip.tabIndex = -1;
   return chip;
 }
 
@@ -2367,6 +2392,14 @@ function wireKeyboardPointers(root) {
     if (e.target.closest('[data-legend-chip]')) {
       e.preventDefault();
       setKbdLegends(kbdLegends === 'uk' ? 'us' : 'uk');
+      return;
+    }
+    if (e.target.closest('[data-close-chip]')) {
+      // Acting on the down, like every key here, means the strip is gone
+      // before the finger lifts; closeKeyboard releases anything still
+      // held, and this pointer was never in the map, so nothing dangles.
+      e.preventDefault();
+      closeKeyboard();
       return;
     }
     const cell = e.target.closest('[data-k]');

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -2434,6 +2434,20 @@ function wireKeyboardPointers(root) {
   root.addEventListener('pointerup', up);
   root.addEventListener('pointercancel', up);
   root.addEventListener('lostpointercapture', up);
+  // Assistive tech activates a button with a synthesized click, never a
+  // pointer sequence, so without this the chips' button role would be a
+  // promise the pointerdown handler breaks. Only the chips: they are taps,
+  // where the keys need a press and a release. Real pointers are filtered
+  // by detail - a hardware click counts its presses, a simulated one
+  // reports 0 - so a mouse click cannot run a chip twice.
+  root.addEventListener('click', (e) => {
+    if (e.detail !== 0) return;
+    if (e.target.closest('[data-legend-chip]')) {
+      setKbdLegends(kbdLegends === 'uk' ? 'us' : 'uk');
+    } else if (e.target.closest('[data-close-chip]')) {
+      closeKeyboard();
+    }
+  });
 }
 
 // --- keyboard open / close -------------------------------------------------

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -121,7 +121,9 @@ Controls:
   latches the way the hardware does -- the keyboard MCU owns that lamp --
   and the cap lights with it. Unlike the physical keyboard, the on-screen
   keys are never captured by the joystick modes below: an on-screen Amiga
-  keyboard always types.
+  keyboard always types. The keyboard carries its own dismiss button -- the
+  small x in the cursor notch, above the UK/US switch -- so it can be put
+  away in fullscreen without reaching for the page's toggle.
 - **Device keyboard**: the **Device keys** button raises the phone or
   tablet's own keyboard instead, for when typing matters more than reaching
   every Amiga key -- a BBS session, a filename, a high-score name -- and


### PR DESCRIPTION
Closing the drawn A600 previously needed the page's **Hide keys** toggle, which is off screen in fullscreen - exactly where a phone visitor spends the session - so putting the keyboard away cost a bar-summoning tap first.

This gives the keyboard its own dismiss button: an `x` chip in the cursor-cluster notch, sharing the key-free slot with the UK/US legend switch and styled like it. It takes the top slot, the position farthest from the cursor keys, so a missed arrow during a game cannot fold the keyboard away mid-play.

The tap runs the normal `closeKeyboard()` path on pointerdown, like every key on the strip: held keys are released into the guest, the letterbox height (`--cl-kbd-h`) returns to 0, the page/fullscreen button labels update, and the closed state is remembered per browser.

Verified in Chrome against a staged copy of the /try page: the chip sits cleanly in the notch (beside Return, below Del, clear of the cursor keys), and tapping it hides the strip, restores `--cl-kbd-h: 0px`, relabels the toggle and stores the preference.

Docs: the on-screen keyboard section of `docs/guide/browser.md` now mentions the dismiss button.