### PR TITLE
serial: don't let an undrained pty block the emulator

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -442,7 +442,28 @@ impl PtySerialSink {
 #[cfg(unix)]
 impl SerialSink for PtySerialSink {
     fn write_byte(&mut self, b: u8, _at_cck: u64) {
-        let _ = self.master.write_all(&[b]);
+        use std::os::fd::AsRawFd;
+        // Drop output the receiver is not draining rather than block the
+        // emulation thread, mirroring TcpSerialSink dropping output with no
+        // client connected -- like an unplugged serial cable. With no terminal
+        // attached, only our keepalive slave holds the pts open and nothing
+        // reads it, so the pty buffer fills and a blocking master write would
+        // wedge the emulator forever. Poll for room first (0 ms) and drop the
+        // byte if there is none.
+        let mut pfd = libc::pollfd {
+            fd: self.master.as_raw_fd(),
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: polling a single valid fd owned by `self.master`, 0 ms.
+        let ready = unsafe { libc::poll(&mut pfd, 1, 0) };
+        // Write only when poll positively reports room. A rare EINTR (or any
+        // poll error) leaves `ready < 0` and simply drops the byte -- correct
+        // for a lossy serial line, and deliberately not an EINTR retry loop
+        // (the pattern that makes programs stop responding to ^C).
+        if ready == 1 && pfd.revents & libc::POLLOUT != 0 {
+            let _ = self.master.write_all(&[b]);
+        }
     }
 
     fn read_byte(&mut self) -> Option<u8> {


### PR DESCRIPTION
`PtySerialSink::write_byte` wrote to a **blocking** master fd. With no terminal attached, only the sink's internal keepalive slave holds the pts open and nothing drains it, so the pty's kernel buffer fills and the next master write blocks the emulation thread forever -- Copperline hangs after enough serial output. `serial = "tcp"` never hits this because it drops output when no client is connected (an unplugged-cable model).

This makes the pty do the same: `poll(POLLOUT, 0)` the master before writing and drop the byte if there is no room, so output the receiver is not draining is discarded rather than wedging the emulator. A rare `EINTR` (or any poll error) drops the byte too, which is correct for a lossy serial line -- deliberately not an `EINTR` retry loop.

Setting `O_NONBLOCK` on the master instead would leak into the reader thread's cloned fd (they share the open file description) and make its blocking `read` hot-spin, so the non-blocking check lives in the write path only.

No dedicated regression test: like the TCP sink's own drop-when-no-client path (also untested), "does not block" is only checkable via a timing/watchdog test that is fragile under CI sandboxes. `pty_sink_round_trips_input_and_output` continues to exercise `write_byte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)