### PR TITLE
1084 CRT look: datasheet face geometry, glass-filling presentation, moulded bezel insert

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -492,17 +492,16 @@ status_bar = true     # show the status bar at start (default true)
 ```
 
 The emulated framebuffer always carries the full overscan field Denise
-produces. `"tv"` masks the deep horizontal overscan margins in black like a
-CRT bezel, presenting the standard window plus 24 lo-res pixels per side
-of TV-style overscan while preserving vertical border colour changes. PNG
-screenshots and `--dump-frames` crop standard TV output to a 692x540
-aperture for reference-emulator comparison; PAL and NTSC scans share the
-one shape because both apertures fill the same 4:3 glass -- an NTSC scan's
-shorter crop (the 200-line standard window plus the same overscan margin)
-is scaled onto the same output rows. The live window shows a slightly
-narrower cut of the same aperture, clipped to the columns the framebuffer
-actually captures, so the picture sits exactly centred on screen with no
-one-sided black margin. `"full"` shows everything, which
+produces. `"tv"` presents what the monitor's glass shows: the captured
+aperture -- the standard window plus the symmetric overscan margin the
+framebuffer captures on its right edge -- fills the whole 4:3 glass, the
+way a real set's raster overscans its screen, so the picture (border
+colour included) reaches every edge with no black bezel columns. The
+live window and PNG screenshots / `--dump-frames` present the same
+716x540 glass; PAL and NTSC scans share the one shape because both
+apertures fill the same glass -- an NTSC scan's shorter crop (the
+200-line standard window plus the same overscan margin) is scaled onto
+the same output rows. `"full"` shows everything, which
 is useful when debugging display alignment. `COPPERLINE_OVERSCAN=full|tv`
 overrides this for a single run. In both modes the presentation geometry
 holds steady across the blank frames a screen change produces: a frame
@@ -592,9 +591,11 @@ look a phosphor trail on its own cannot give. Three presets are built in:
   bow reproduces its published screen-edge arcs -- the top and bottom
   edges bow about twice as far as the sides, as they do on the real
   screen -- and the corners are rounded at the scale of its 11.6 mm
-  corner arcs. On-face black is lifted by a faint glass glow, the room
-  light a real tube reflects, so the face keeps its silhouette even when
-  the picture is dark.
+  corner arcs. The picture overscans the face like the real raster
+  overscans the glass, filling it to the edges with the bow deepening the
+  crop toward the rounded corners, and on-face black is lifted by a faint
+  glass glow, the room light a real tube reflects, so the face keeps its
+  silhouette even when the picture is dark.
 
 `"none"` (the default; `"off"` is accepted for the same thing) presents the
 picture untouched, and any value ending in `.wgsl` is the path of a shader

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -587,7 +587,14 @@ look a phosphor trail on its own cannot give. Three presets are built in:
   brightness-compensated.
 - `"crt"` -- the lot, in the spirit of the 1084 the Amiga shipped with: a
   bowed tube face, scanlines that follow the bow, an aperture grille, and a
-  corner vignette, all faded in together.
+  corner vignette, all faded in together. The face geometry is taken from
+  the datasheet of the 1084's picture tube (the Philips M34EAQ10X): the
+  bow reproduces its published screen-edge arcs -- the top and bottom
+  edges bow about twice as far as the sides, as they do on the real
+  screen -- and the corners are rounded at the scale of its 11.6 mm
+  corner arcs. On-face black is lifted by a faint glass glow, the room
+  light a real tube reflects, so the face keeps its silhouette even when
+  the picture is dark.
 
 `"none"` (the default; `"off"` is accepted for the same thing) presents the
 picture untouched, and any value ending in `.wgsl` is the path of a shader

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -82,75 +82,6 @@ pub fn save_scaled_y(
     save(path, &scaled, width, out_height)
 }
 
-/// Save a rectangular viewport from `fb`, rendering viewport pixels that fall
-/// outside the source as opaque black. A presentation aperture may extend
-/// slightly beyond the emulated capture buffer; the uncaptured margin is
-/// bezel, not picture, so replicating edge pixels there would fabricate
-/// content whenever the display fetches into the deepest overscan.
-///
-/// The crop's `height` rows are resampled onto `out_height` output rows
-/// (centre-aligned whole-row selection, no blending; a no-op when equal).
-/// The TV-aperture screenshot path relies on this: both video standards'
-/// apertures fill the same 4:3 glass, so a 60 Hz crop's rows scale onto the
-/// 50 Hz aperture's native row count.
-pub fn save_cropped_black_padded(
-    path: &Path,
-    fb: &[u32],
-    src_width: usize,
-    src_height: usize,
-    x: usize,
-    y: usize,
-    width: usize,
-    height: usize,
-    out_height: usize,
-) -> Result<()> {
-    let cropped = crop_black_padded(fb, src_width, src_height, x, y, width, height)?;
-    if out_height == height {
-        return save(path, &cropped, width as u32, height as u32);
-    }
-    let mut scaled = Vec::new();
-    scale_y_into(&cropped, width, height, out_height, &mut scaled);
-    save(path, &scaled, width as u32, out_height as u32)
-}
-
-fn crop_black_padded(
-    fb: &[u32],
-    src_width: usize,
-    src_height: usize,
-    x: usize,
-    y: usize,
-    width: usize,
-    height: usize,
-) -> Result<Vec<u32>> {
-    let expected = src_width * src_height;
-    if fb.len() < expected {
-        anyhow::bail!(
-            "framebuffer size mismatch: got {} pixels, expected at least {}x{}={}",
-            fb.len(),
-            src_width,
-            src_height,
-            expected
-        );
-    }
-    if src_width == 0 || src_height == 0 || width == 0 || height == 0 {
-        anyhow::bail!("invalid crop dimensions");
-    }
-
-    // Opaque black in the fb's R,G,B,A memory order.
-    const BLACK: u32 = 0xFF00_0000;
-    let mut cropped = vec![BLACK; width * height];
-    let copy_w = width.min(src_width.saturating_sub(x));
-    for dst_y in 0..height {
-        let src_y = y + dst_y;
-        if src_y >= src_height {
-            break;
-        }
-        let src_row = &fb[src_y * src_width..src_y * src_width + x + copy_w];
-        cropped[dst_y * width..dst_y * width + copy_w].copy_from_slice(&src_row[x..]);
-    }
-    Ok(cropped)
-}
-
 /// Centre-aligned source row for presentation row `y`.
 #[inline]
 pub fn scaled_source_row(y: usize, src_rows: usize, dst_rows: usize) -> usize {
@@ -319,19 +250,5 @@ mod tests {
         let fb = [0x0000_0003, 0x0000_0006, 0x0000_0009];
         downsample_x_into(&fb, 3, 1, 1, &mut out);
         assert_eq!(out, vec![0x0000_0006]);
-    }
-
-    #[test]
-    fn cropped_view_black_pads_outside_source() -> Result<()> {
-        let fb = vec![1, 2, 3, 4, 5, 6];
-        const BLACK: u32 = 0xFF00_0000;
-
-        let cropped = crop_black_padded(&fb, 3, 2, 1, 0, 4, 3)?;
-
-        assert_eq!(
-            cropped,
-            vec![2, 3, BLACK, BLACK, 5, 6, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK]
-        );
-        Ok(())
     }
 }

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -514,8 +514,8 @@ fn horizontal_class_centres_wide_diw_around_standard_fetch() {
 fn horizontal_class_calls_true_overscan_fetch_overscan() {
     // Wide DIW *and* a fetch that reaches into the overscan border
     // (DDFSTRT $30 starts the picture left of the standard window): a real
-    // overscan display, presented exactly as rendered on the full
-    // framebuffer.
+    // overscan display. Full-overscan mode presents it without recentring;
+    // the TV glass crops it like a real set.
     assert_eq!(
         horizontal_content_class(&ocs_snapshot(0x5702, 0xFFFF, 0x0030, 0x00D8)),
         HorizontalContentClass::Overscan

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -459,8 +459,8 @@ mod tests {
         // shows masked black columns. The glass resample blends one column
         // left of the aperture start (its first sample centre sits half an
         // output pixel before the first source centre), so that column must
-        // clear the mask too.
-        assert!(TV_CAPTURED_SOURCE_X - 1 >= tv_source_h_bounds().0);
+        // clear the mask too: the aperture must start strictly inside it.
+        assert!(TV_CAPTURED_SOURCE_X > tv_source_h_bounds().0);
     }
 
     #[test]

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -435,8 +435,14 @@ pub fn standard_tv_aperture_frame(
         TV_NTSC_PRESENT_HEIGHT
     };
     match bitplane::horizontal_content_class(snapshot) {
-        bitplane::HorizontalContentClass::Standard { .. } => TvApertureFrame::Standard(rows),
-        bitplane::HorizontalContentClass::Overscan => TvApertureFrame::Full,
+        // The glass does not move for the content: a display fetching
+        // into the overscan extends past the aperture and the monitor
+        // crops it, exactly as a real set does (overscan = "full" is the
+        // mode for seeing all of it). Only the scan's shape -- the
+        // programmable geometry and native-height fields handled above --
+        // changes what the presentation shows.
+        bitplane::HorizontalContentClass::Standard { .. }
+        | bitplane::HorizontalContentClass::Overscan => TvApertureFrame::Standard(rows),
         bitplane::HorizontalContentClass::Neutral => TvApertureFrame::Neutral(rows),
     }
 }
@@ -550,6 +556,35 @@ mod tests {
         assert_eq!(
             standard_tv_aperture_frame(pal, OUT_HEIGHT, &blank_snapshot()),
             TvApertureFrame::Neutral(TV_PAL_PRESENT_HEIGHT)
+        );
+    }
+
+    #[test]
+    fn overscan_content_keeps_the_glass_aperture() {
+        // A display fetching into the overscan (the CD32 boot screen, demo
+        // loaders) extends past the aperture; the monitor's glass crops it
+        // rather than zooming out to show it -- the glass does not move
+        // for the content. Falling back to the full framebuffer here used
+        // to expose the unpainted capture margins as black bands beside
+        // the picture.
+        let overscan = RenderRegisterSnapshot {
+            agnus_revision: crate::chipset::agnus::AgnusRevision::AgaAlice,
+            bplcon0: 0x8214,
+            diwstrt: 0x1D61,
+            diwstop: 0x37C7,
+            ddfstrt: 0x0028,
+            ddfstop: 0x00D8,
+            ..RenderRegisterSnapshot::default()
+        };
+        assert_eq!(
+            bitplane::horizontal_content_class(&overscan),
+            bitplane::HorizontalContentClass::Overscan,
+            "snapshot must classify as overscan for the assertion to bite"
+        );
+        let pal = FrameGeometry::standard(0x1C, 313, false);
+        assert_eq!(
+            standard_tv_aperture_frame(pal, OUT_HEIGHT, &overscan),
+            TvApertureFrame::Standard(TV_PAL_PRESENT_HEIGHT)
         );
     }
 

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -59,18 +59,16 @@ pub const TV_HORIZONTAL_OVERSCAN_MARGIN: usize = 24 * 2;
 // window.
 pub const TV_VERTICAL_OVERSCAN_MARGIN: usize = 7;
 
-// The reference TV aperture for standard 15 kHz displays, cropped from the
-// woven presentation buffer. Horizontally the two video standards agree --
-// both place the standard 640-wide window at the same colour clocks -- so one
-// cutout (the standard window plus a symmetric 26-column overscan margin)
-// serves 50 Hz and 60 Hz scans alike; its right margin reaches 12 columns
-// past the framebuffer's right edge, which the presentation paths pad with
-// black bezel. Vertically the aperture follows the field line count: a
-// 312/313-line (50 Hz) scan carries the 256-line standard window, a
-// 262/263-line (60 Hz) scan the 200-line one, each cropped with the same
-// symmetric overscan margin.
-pub const TV_PRESENT_WIDTH: usize = STANDARD_PAL_VISIBLE_WIDTH + 2 * 26;
-pub const TV_PRESENT_SOURCE_X: usize = bitplane::STANDARD_VISIBLE_X0 - 26;
+// The TV aperture for standard 15 kHz displays, cropped from the woven
+// presentation buffer. Horizontally both presentation paths (live window
+// and PNG) show the captured aperture (`TV_CAPTURED_*` below) resampled
+// onto the framebuffer-wide 4:3 glass by `tv_glass_sample`; the two video
+// standards agree -- both place the standard 640-wide window at the same
+// colour clocks -- so one cutout serves 50 Hz and 60 Hz scans alike.
+// Vertically the aperture follows the field line count: a 312/313-line
+// (50 Hz) scan carries the 256-line standard window, a 262/263-line
+// (60 Hz) scan the 200-line one, each cropped with the same symmetric
+// overscan margin.
 pub const TV_PRESENT_SOURCE_Y: usize = 18;
 pub const TV_PAL_PRESENT_HEIGHT: usize =
     (STANDARD_PAL_VISIBLE_LINES + 2 * TV_VERTICAL_OVERSCAN_MARGIN) * 2;
@@ -107,10 +105,28 @@ const _: () = {
             - (bitplane::STANDARD_VISIBLE_X0 + STANDARD_PAL_VISIBLE_WIDTH)
             == TV_CAPTURED_MARGIN_X
     );
-    assert!(TV_CAPTURED_SOURCE_X >= TV_PRESENT_SOURCE_X);
     assert!(TV_PRESENT_SOURCE_Y + TV_PAL_PRESENT_HEIGHT <= OUT_HEIGHT);
     assert!(TV_NTSC_PRESENT_HEIGHT < TV_PAL_PRESENT_HEIGHT);
 };
+
+/// One glass pixel of the 4:3 TV presentation: the captured aperture's
+/// `TV_CAPTURED_WIDTH` real columns fill the `FB_WIDTH`-wide glass through
+/// a fractional resample (`blend_rgba`, the programmable-scan idiom), the
+/// way a real set's raster fills its glass. Every glass pixel derives from
+/// real captured pixels -- nothing is padded black -- and the standard
+/// window stays exactly centred because the captured margins are symmetric
+/// by construction. 8.8 fixed point, sampling between texel centres.
+#[inline]
+pub fn tv_glass_sample(row: &[u32], out_x: usize) -> u32 {
+    debug_assert!(row.len() >= FB_WIDTH);
+    let s = (TV_CAPTURED_SOURCE_X as i64) * 256
+        + ((2 * out_x as i64 + 1) * (TV_CAPTURED_WIDTH as i64) * 256) / (2 * FB_WIDTH as i64)
+        - 128;
+    let s = s.clamp(0, (FB_WIDTH as i64 - 1) * 256);
+    let i = (s >> 8) as usize;
+    let frac = (s & 255) as u32;
+    crate::video::blend_rgba(row[i], row[(i + 1).min(FB_WIDTH - 1)], frac)
+}
 
 pub fn post_process_rendered_field(
     fb: &mut [u32],
@@ -434,8 +450,41 @@ mod tests {
         // The const block by the TV_CAPTURED_* definitions pins the
         // aperture geometry at compile time; the mask bounds come from a
         // runtime helper, so check here that a captured-aperture crop never
-        // shows masked black columns.
-        assert!(TV_CAPTURED_SOURCE_X >= tv_source_h_bounds().0);
+        // shows masked black columns. The glass resample blends one column
+        // left of the aperture start (its first sample centre sits half an
+        // output pixel before the first source centre), so that column must
+        // clear the mask too.
+        assert!(TV_CAPTURED_SOURCE_X - 1 >= tv_source_h_bounds().0);
+    }
+
+    #[test]
+    fn tv_glass_resample_spans_the_captured_aperture() {
+        // A row with a marker at each end of the captured aperture: the
+        // glass's first and last pixels must derive from them (the edges
+        // reach the glass), and a marker just outside the aperture must
+        // not appear anywhere.
+        let mut row = vec![0xFF00_0000u32; FB_WIDTH];
+        let first = 0xFF20_4060;
+        let last = 0xFF60_4020;
+        for x in TV_CAPTURED_SOURCE_X..FB_WIDTH {
+            row[x] = 0xFF7F_7F7F;
+        }
+        row[TV_CAPTURED_SOURCE_X] = first;
+        row[FB_WIDTH - 1] = last;
+
+        let g0 = tv_glass_sample(&row, 0);
+        let g_last = tv_glass_sample(&row, FB_WIDTH - 1);
+        // The first glass pixel blends the first captured column with its
+        // left neighbour; the marker must dominate or match.
+        assert_ne!(g0, 0xFF7F_7F7F, "left aperture edge missing from glass");
+        assert_eq!(g_last, last, "right aperture edge missing from glass");
+
+        // The standard window's centre column maps to the glass centre.
+        let mut centre_row = vec![0xFF00_0000u32; FB_WIDTH];
+        let centre_src = TV_CAPTURED_SOURCE_X + TV_CAPTURED_WIDTH / 2;
+        centre_row[centre_src - 1] = 0xFFFF_FFFF;
+        centre_row[centre_src] = 0xFFFF_FFFF;
+        assert_eq!(tv_glass_sample(&centre_row, FB_WIDTH / 2), 0xFFFF_FFFF);
     }
 
     /// A standard full-width display (stock Kickstart screen).

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -292,14 +292,17 @@ const JOY_TOGGLE_W: usize = 22;
 const JOY_TOGGLE_X: usize = VOLUME_GLYPH_X - 2 - JOY_TOGGLE_W;
 // The standard-window and TV-aperture constants live in
 // `video/present_common.rs` with the presentation helpers they anchor
-// (re-exported through `use present::*` below). The live window presents
-// the captured aperture -- every column a real framebuffer pixel, the
-// standard window and the visible raster both exactly centred -- unlike
-// the PNG paths, which keep the wider reference aperture with its
-// black-padded right margin for reference-emulator comparison.
+// (re-exported through `use present::*` below). Both the live window and
+// the PNG paths present the captured aperture -- every glass pixel
+// derives from real framebuffer pixels, the standard window and the
+// visible raster both exactly centred. On the 4:3 canvas the aperture
+// resamples onto the full glass width; the square-pixel canvas keeps
+// unit columns and centres the aperture between these black side pads
+// instead.
 const TV_LIVE_PAD_X: usize = (FB_WIDTH - TV_CAPTURED_WIDTH) / 2;
-// Symmetric pads are what centres the raster; a change to the captured
-// aperture's width that breaks this must rethink the live layout.
+// Symmetric pads are what centres the square-pixel raster; a change to
+// the captured aperture's width that breaks this must rethink the live
+// layout.
 const _: () = assert!(TV_LIVE_PAD_X * 2 + TV_CAPTURED_WIDTH == FB_WIDTH);
 const STATUS_BG: u32 = rgba(28, 28, 26);
 const STATUS_TOP: u32 = rgba(78, 76, 70);

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -750,6 +750,60 @@ mod tests {
         );
     }
 
+    /// The antialiased join at the opening edge in the frame-only pass
+    /// must blend toward the preset's off-face black, not the raw
+    /// picture: a bright source used to smear a picture-coloured
+    /// hairline around the opening, over the preset output the pass
+    /// discards its interior for.
+    #[test]
+    fn the_frame_only_join_does_not_leak_the_picture() {
+        let Some(gpu) = gpu() else {
+            return;
+        };
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let white = |_x: u32, _y: u32| [255, 255, 255, 255];
+        let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &white);
+        let (px, dim, rows) = render_bezel(device, queue, &src, Some(ShaderKind::Crt));
+
+        // The shader's rounded-rect distance to the opening, at a pixel
+        // centre.
+        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        let r_open = 0.055 * ow.min(oh);
+        let opening_d = |x: u32, y: u32| {
+            let qx = (x as f32 + 0.5 - ox - ow * 0.5).abs() - ow * 0.5 + r_open;
+            let qy = (y as f32 + 0.5 - oy - oh * 0.5).abs() - oh * 0.5 + r_open;
+            let outside = (qx.max(0.0).powi(2) + qy.max(0.0).powi(2)).sqrt();
+            outside + qx.max(qy).min(0.0) - r_open
+        };
+
+        // The face's bow keeps the preset's own picture well inside the
+        // opening, so the ring of frame pixels hugging the opening edge
+        // holds only recess gap and off-face black -- all dark. Any
+        // bright pixel is the source leaking through the join. Whether a
+        // straight edge drops a pixel centre inside the leaking
+        // fraction-of-a-pixel band depends on the window size, but along
+        // the corner arcs the centres sweep every alignment, so the ring
+        // as a whole always catches it.
+        let mut checked = 0;
+        for y in 0..rows {
+            for x in 0..dim {
+                let d = opening_d(x, y);
+                if (0.0..=2.0).contains(&d) {
+                    checked += 1;
+                    let p = at(&px, dim, x, y);
+                    assert!(
+                        p[0] < 90 && p[1] < 90 && p[2] < 90,
+                        "picture hairline at the opening edge ({x}, {y}), d = {d:.2}: {p:?}"
+                    );
+                }
+            }
+        }
+        assert!(
+            checked > 100,
+            "opening ring barely sampled: {checked} pixels"
+        );
+    }
+
     /// Not a check: renders the bezel (optionally with the CRT preset the
     /// window would pair it with) over a source image and writes a PNG for
     /// eyeballing look changes. Runs only when
@@ -757,7 +811,9 @@ mod tests {
     /// COPPERLINE_BEZEL_PREVIEW_SRC set, that PNG becomes the picture
     /// (its full height, no status bar), otherwise a test card is used.
     /// Setting COPPERLINE_BEZEL_PREVIEW_SHADER (to any value) adds the
-    /// preset pass.
+    /// preset pass; COPPERLINE_BEZEL_PREVIEW_BARE instead renders the
+    /// preset alone over the full frame, no bezel, for eyeballing the
+    /// preset's own face geometry.
     #[test]
     #[ignore = "preview dump; set COPPERLINE_BEZEL_PREVIEW_OUT"]
     fn dump_bezel_preview_png() {
@@ -770,6 +826,7 @@ mod tests {
         };
         let (device, queue) = (gpu.device(), gpu.queue());
         let with_crt = std::env::var("COPPERLINE_BEZEL_PREVIEW_SHADER").is_ok();
+        let bare = std::env::var("COPPERLINE_BEZEL_PREVIEW_BARE").is_ok();
         let (src, w, h) = match std::env::var("COPPERLINE_BEZEL_PREVIEW_SRC") {
             Ok(path) => {
                 let decoder = png::Decoder::new(std::fs::File::open(&path).expect("open src"));
@@ -827,7 +884,7 @@ mod tests {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         let (crt_uniforms, viewport) = crt_shader::uniforms_for(
-            if with_crt {
+            if with_crt || bare {
                 ShaderKind::Crt
             } else {
                 ShaderKind::None
@@ -840,7 +897,7 @@ mod tests {
             (h / 2) as f32,
         );
         let opening = opening_rect(viewport);
-        if with_crt {
+        if bare {
             let mut crt = crt_shader::CrtShader::new(device, FORMAT);
             crt.render(
                 device,
@@ -848,21 +905,35 @@ mod tests {
                 &src,
                 &mut encoder,
                 &view,
-                opening,
+                viewport,
                 ShaderKind::Crt,
-                crt_uniforms.with_viewport(opening),
+                crt_uniforms,
+            );
+        } else {
+            if with_crt {
+                let mut crt = crt_shader::CrtShader::new(device, FORMAT);
+                crt.render(
+                    device,
+                    queue,
+                    &src,
+                    &mut encoder,
+                    &view,
+                    opening,
+                    ShaderKind::Crt,
+                    crt_uniforms.with_viewport(opening),
+                );
+            }
+            let mut shader = BezelShader::new(device, FORMAT);
+            shader.render(
+                device,
+                queue,
+                &src,
+                &mut encoder,
+                &view,
+                viewport,
+                uniforms_from(&crt_uniforms, viewport, opening, with_crt),
             );
         }
-        let mut shader = BezelShader::new(device, FORMAT);
-        shader.render(
-            device,
-            queue,
-            &src,
-            &mut encoder,
-            &view,
-            viewport,
-            uniforms_from(&crt_uniforms, viewport, opening, with_crt),
-        );
         let px = read_back(device, queue, encoder, &target, (w, h));
         let file = std::fs::File::create(&out).expect("create preview");
         let mut enc = png::Encoder::new(std::io::BufWriter::new(file), w, h);

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -838,15 +838,23 @@ mod tests {
     /// sources must carry the same constant.
     #[test]
     fn the_bezel_and_the_crt_preset_agree_on_the_corner_radius() {
-        let needle = "const CORNER_RADIUS: f32 = 0.0826;";
-        assert!(
-            BEZEL_WGSL.contains(needle),
-            "bezel.wgsl corner radius drifted"
-        );
-        assert!(
-            include_str!("shaders/crt.wgsl").contains(needle),
-            "crt.wgsl corner radius drifted"
-        );
+        // Parse the value rather than pinning an exact source substring,
+        // so only semantic drift fails the test, not formatting.
+        fn corner_radius_of(src: &str, what: &str) -> f32 {
+            let key = "const CORNER_RADIUS: f32 =";
+            let at = src
+                .find(key)
+                .unwrap_or_else(|| panic!("{what}: no CORNER_RADIUS constant"));
+            let rest = &src[at + key.len()..];
+            let end = rest.find(';').expect("terminated constant");
+            rest[..end]
+                .trim()
+                .parse()
+                .unwrap_or_else(|e| panic!("{what}: unparsable CORNER_RADIUS: {e}"))
+        }
+        let bezel = corner_radius_of(BEZEL_WGSL, "bezel.wgsl");
+        let crt = corner_radius_of(include_str!("shaders/crt.wgsl"), "crt.wgsl");
+        assert_eq!(bezel, crt, "insert and face corner radii drifted apart");
     }
 
     /// Not a check: renders the bezel (optionally with the CRT preset the

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -60,7 +60,9 @@ pub(super) struct BezelUniforms {
     /// zw size.
     opening: [f32; 4],
     /// x: 1 = frame-only (leave the opening interior to the preset that
-    /// painted it), 0 = full. yzw: reserved.
+    /// painted it), 0 = full. y: the active preset's face curvature --
+    /// the insert follows the bowed glass contour it implies, 0 = flat
+    /// rounded opening. zw: reserved.
     params: [f32; 4],
 }
 
@@ -94,7 +96,10 @@ pub(super) fn uniforms_from(
         src_rect: crt.src_rect,
         size: crt.size,
         opening: [(ox - vx) / w, (oy - vy) / h, ow / w, oh / h],
-        params: [if frame_only { 1.0 } else { 0.0 }, 0.0, 0.0, 0.0],
+        // The preset's curvature rides along so the insert can follow
+        // the bowed glass; a flat preset (or none) carries 0 there and
+        // keeps the straight-edged opening.
+        params: [if frame_only { 1.0 } else { 0.0 }, crt.params[3], 0.0, 0.0],
     }
 }
 
@@ -765,30 +770,54 @@ mod tests {
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &white);
         let (px, dim, rows) = render_bezel(device, queue, &src, Some(ShaderKind::Crt));
 
-        // The shader's rounded-rect distance to the opening, at a pixel
-        // centre.
+        // The shader's glass-contour distance at a pixel centre: the same
+        // warp and rounded rectangle the preset's face uses, driven by
+        // the preset's own curvature so the replica tracks the shader
+        // whatever value the preset table carries.
         let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
-        let r_open = 0.055 * ow.min(oh);
+        let k = crt_shader::uniforms_for(
+            ShaderKind::Crt,
+            1.0,
+            (0, 0, dim, rows),
+            rows as usize,
+            rows as usize,
+            (dim, rows),
+            1.0,
+        )
+        .0
+        .params[3];
+        let (hx, hy) = (ow * 0.5, oh * 0.5);
+        let fa = hy / hx;
+        let rc = 0.0826f32;
         let opening_d = |x: u32, y: u32| {
-            let qx = (x as f32 + 0.5 - ox - ow * 0.5).abs() - ow * 0.5 + r_open;
-            let qy = (y as f32 + 0.5 - oy - oh * 0.5).abs() - oh * 0.5 + r_open;
+            let cx = (x as f32 + 0.5 - ox - hx) / hx;
+            let cy = (y as f32 + 0.5 - oy - hy) / hy;
+            let q = k * 0.25;
+            let r2 = cx * cx + cy * cy * fa * fa;
+            let bow = 1.0 + q * r2;
+            let wx = cx * bow / (1.0 + q);
+            let wy = cy * bow / (1.0 + q * fa * fa) * fa;
+            let qx = wx.abs() - 1.0 + rc;
+            let qy = wy.abs() - fa + rc;
             let outside = (qx.max(0.0).powi(2) + qy.max(0.0).powi(2)).sqrt();
-            outside + qx.max(qy).min(0.0) - r_open
+            (outside + qx.max(qy).min(0.0) - rc) * hx
         };
 
-        // The face's bow keeps the preset's own picture well inside the
-        // opening, so the ring of frame pixels hugging the opening edge
-        // holds only recess gap and off-face black -- all dark. Any
-        // bright pixel is the source leaking through the join. Whether a
-        // straight edge drops a pixel centre inside the leaking
-        // fraction-of-a-pixel band depends on the window size, but along
-        // the corner arcs the centres sweep every alignment, so the ring
-        // as a whole always catches it.
+        // The ring of frame pixels hugging the opening edge is the glass
+        // seat: unlit shadow, always dark (the insert chamfer beyond it
+        // is lit plastic, so the scan stops inside the seat). Any bright
+        // pixel there is the source leaking through the join, which lives
+        // in the first half pixel outside the opening. Whether a straight
+        // edge drops a pixel centre inside that fraction-of-a-pixel band
+        // depends on the window size, but along the corner arcs the
+        // centres sweep every alignment, so the ring as a whole always
+        // catches it.
+        let seat = (0.007 * ow.min(oh)).max(1.5);
         let mut checked = 0;
         for y in 0..rows {
             for x in 0..dim {
                 let d = opening_d(x, y);
-                if (0.0..=2.0).contains(&d) {
+                if (0.0..=(seat - 1.0).max(0.6)).contains(&d) {
                     checked += 1;
                     let p = at(&px, dim, x, y);
                     assert!(
@@ -801,6 +830,22 @@ mod tests {
         assert!(
             checked > 100,
             "opening ring barely sampled: {checked} pixels"
+        );
+    }
+
+    /// The insert must seat the preset's face exactly: both shaders
+    /// derive the glass contour from the same corner radius, so the two
+    /// sources must carry the same constant.
+    #[test]
+    fn the_bezel_and_the_crt_preset_agree_on_the_corner_radius() {
+        let needle = "const CORNER_RADIUS: f32 = 0.0826;";
+        assert!(
+            BEZEL_WGSL.contains(needle),
+            "bezel.wgsl corner radius drifted"
+        );
+        assert!(
+            include_str!("shaders/crt.wgsl").contains(needle),
+            "crt.wgsl corner radius drifted"
         );
     }
 

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -561,8 +561,11 @@ pub(super) fn uniforms_for(
         ShaderKind::Scanlines => (0.0, 0.0, 0.0),
         // 2: staggered dot/shadow mask.
         ShaderKind::Mask => (2.0, 0.0, 0.0),
-        // 1: aperture grille, with a bowed face and corner falloff.
-        ShaderKind::Crt => (1.0, 0.35, 0.15),
+        // 1: aperture grille, with a bowed face and corner falloff. The
+        // curvature reproduces the screen-edge arcs of the 1084's tube
+        // datasheet (Philips M34EAQ10X) under crt.wgsl's aspect-weighted
+        // warp; the derivation is with the warp function.
+        ShaderKind::Crt => (1.0, 0.30, 0.15),
         // A user shader gets the frame geometry and the two knobs it can
         // sensibly honour; the preset look table means nothing to it.
         ShaderKind::None | ShaderKind::Custom => (0.0, 0.0, 0.0),
@@ -818,7 +821,7 @@ fn fs_main() -> @location(0) vec4<f32> {
         assert_eq!(mask.params2, [0.0; 4]);
 
         let crt = get(ShaderKind::Crt);
-        assert_eq!(crt.params, [0.5, 537.0, 1.0, 0.35]);
+        assert_eq!(crt.params, [0.5, 537.0, 1.0, 0.30]);
         assert_eq!(crt.params2, [0.15, 0.0, 0.0, 0.0]);
 
         let custom = get(ShaderKind::Custom);

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -872,6 +872,13 @@ pub(super) fn tv_aperture_source_row(
 /// shown while the machine is powered off. SMPTE-style colour bars over
 /// a grayscale step wedge: instantly readable as "no signal", and handy
 /// for setting up video capture levels before the machine boots.
+///
+/// The layout is calibrated to the TV glass -- the captured aperture the
+/// presentation shows -- so the bars, wedge and logo sit centred on
+/// screen; the outermost bars and steps extend to the capture edges the
+/// way a signal generator fills the active line around its calibrated
+/// area, so the full-overscan view shows the same card with slightly
+/// wider outer bars.
 pub(super) fn paint_test_screen(fb: &mut [u32]) {
     debug_assert!(fb.len() >= FB_PIXELS);
     const BARS: [u32; 7] = [
@@ -884,29 +891,40 @@ pub(super) fn paint_test_screen(fb: &mut [u32]) {
         rgba(0, 0, 192),     // blue
     ];
     const STEPS: usize = 8;
-    let bars_h = FB_HEIGHT * 4 / 5;
+    // The glass box in field coordinates: the captured aperture's
+    // columns, and its woven row window halved back to field rows.
+    let x0 = TV_CAPTURED_SOURCE_X;
+    let glass_w = TV_CAPTURED_WIDTH;
+    let glass_top = TV_PRESENT_SOURCE_Y / 2;
+    let glass_h = TV_PAL_PRESENT_HEIGHT / 2;
+    let bars_h = glass_top + glass_h * 4 / 5;
     for y in 0..FB_HEIGHT {
         let row = &mut fb[y * FB_WIDTH..(y + 1) * FB_WIDTH];
         if y < bars_h {
             for (x, px) in row.iter_mut().enumerate() {
-                *px = BARS[x * BARS.len() / FB_WIDTH];
+                let xa = x.clamp(x0, x0 + glass_w - 1) - x0;
+                *px = BARS[xa * BARS.len() / glass_w];
             }
         } else {
             for (x, px) in row.iter_mut().enumerate() {
-                let level = (x * STEPS / FB_WIDTH) as u32 * 255 / (STEPS as u32 - 1);
+                let xa = x.clamp(x0, x0 + glass_w - 1) - x0;
+                let level = (xa * STEPS / glass_w) as u32 * 255 / (STEPS as u32 - 1);
                 *px = rgba(level, level, level);
             }
         }
     }
-    draw_test_screen_logo(fb, bars_h);
+    draw_test_screen_logo(fb, glass_top, bars_h);
 }
 
-pub(super) fn draw_test_screen_logo(fb: &mut [u32], bars_h: usize) {
+pub(super) fn draw_test_screen_logo(fb: &mut [u32], glass_top: usize, bars_h: usize) {
     let Some(image) = copperline_logo_image() else {
         return;
     };
-    let x = FB_WIDTH.saturating_sub(image.width) / 2;
-    let y = bars_h.saturating_sub(image.height) / 2;
+    // Centred on the glass, not the capture: the aperture the
+    // presentation shows starts TV_CAPTURED_SOURCE_X columns in and
+    // TV_PRESENT_SOURCE_Y woven rows down.
+    let x = TV_CAPTURED_SOURCE_X + TV_CAPTURED_WIDTH.saturating_sub(image.width) / 2;
+    let y = glass_top + (bars_h - glass_top).saturating_sub(image.height) / 2;
     alpha_blit_rgba(fb, FB_WIDTH, FB_HEIGHT, x, y, image);
 }
 

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -745,7 +745,14 @@ pub(super) fn copy_window_present_frame(
     // the classic canvas width.
     match tv_aperture_rows {
         Some(aperture_rows) if overscan == Overscan::Tv && src_width == FB_WIDTH => {
-            copy_tv_aperture_to_window(src_fb, src_rows, frame, texture_scale, aperture_rows)
+            copy_tv_aperture_to_window(
+                src_fb,
+                src_rows,
+                frame,
+                texture_scale,
+                aperture_rows,
+                present_height(),
+            )
         }
         _ => copy_present_frame(src_fb, src_rows, src_width, frame, texture_scale),
     }
@@ -754,36 +761,40 @@ pub(super) fn copy_window_present_frame(
 /// The live-window TV copy presents the captured aperture
 /// (`TV_CAPTURED_*`): the standard window plus the symmetric overscan
 /// margin the framebuffer actually captures, ending exactly on the
-/// framebuffer's edges. Every aperture column is a real pixel and the
-/// visible raster sits exactly centred in the texture -- the wider
-/// reference aperture the PNG paths keep would show its black-padded
-/// right margin as a lopsided band beside the picture (conspicuous
-/// inside the monitor bezel). The symmetric side pads are off-capture
-/// bezel and stay black rather than replicating the edge columns, which
-/// carry picture when a display fetches or parks sprites in the deepest
-/// overscan (the Gen-X logo slide-in streaks).
+/// framebuffer's edges. On the 4:3 canvas -- the glass itself -- the
+/// aperture's columns resample onto the full texture width
+/// (`tv_glass_sample`), the way a real set's raster fills its glass:
+/// every glass pixel derives from real captured pixels and nothing is
+/// padded black. The square-pixel canvas keeps unit columns instead, so
+/// there the aperture sits centred between off-capture black side pads,
+/// the horizontal counterpart of its vertical bands; the pads stay black
+/// rather than replicating the edge columns, which carry picture when a
+/// display fetches or parks sprites in the deepest overscan (the Gen-X
+/// logo slide-in streaks).
 pub(super) fn copy_tv_aperture_to_window(
     src_fb: &[u32],
     src_rows: usize,
     frame: &mut [u8],
     texture_scale: usize,
     aperture_rows: usize,
+    present_rows: usize,
 ) {
     debug_assert!(src_fb.len() >= src_rows * FB_WIDTH);
-    debug_assert_eq!(
-        frame.len(),
-        texture_width(texture_scale) * texture_height(texture_scale) * 4
-    );
     let dst_stride = texture_width(texture_scale) * 4;
-    let present_rows = present_height();
     let out_rows = present_rows * texture_scale;
+    debug_assert!(frame.len() >= dst_stride * out_rows);
     let black_px = rgba(0, 0, 0);
     let black = black_px.to_le_bytes();
+    let square = present_rows == crate::video::PRESENT_HEIGHT_SQUARE;
     let pixel_at = |row: &[u32], out_x: usize| -> u32 {
-        if (TV_LIVE_PAD_X..TV_LIVE_PAD_X + TV_CAPTURED_WIDTH).contains(&out_x) {
-            row[TV_CAPTURED_SOURCE_X + (out_x - TV_LIVE_PAD_X)]
+        if square {
+            if (TV_LIVE_PAD_X..TV_LIVE_PAD_X + TV_CAPTURED_WIDTH).contains(&out_x) {
+                row[TV_CAPTURED_SOURCE_X + (out_x - TV_LIVE_PAD_X)]
+            } else {
+                black_px
+            }
         } else {
-            black_px
+            tv_glass_sample(row, out_x)
         }
     };
     for y in 0..out_rows {
@@ -1161,19 +1172,22 @@ pub(super) fn save_present_frame(
     if let Some(aperture_rows) = tv_aperture_rows {
         if overscan == Overscan::Tv && src_width == FB_WIDTH {
             // Both standards' apertures fill the same 4:3 glass, so the
-            // saved picture keeps one shape: a 60 Hz crop's rows scale onto
-            // the 50 Hz aperture's native row count.
-            return screenshot::save_cropped_black_padded(
-                path,
-                present_fb,
-                FB_WIDTH,
-                src_rows,
-                TV_PRESENT_SOURCE_X,
-                TV_PRESENT_SOURCE_Y,
-                TV_PRESENT_WIDTH,
-                aperture_rows,
-                TV_GLASS_PRESENT_ROWS,
-            );
+            // saved picture keeps one shape: the captured aperture's
+            // columns resample onto the glass width, exactly like the
+            // live window (`tv_glass_sample`), and a 60 Hz crop's rows
+            // scale onto the 50 Hz aperture's native row count.
+            let mut glass = vec![0u32; FB_WIDTH * TV_GLASS_PRESENT_ROWS];
+            for out_y in 0..TV_GLASS_PRESENT_ROWS {
+                let crop_y =
+                    screenshot::scaled_source_row(out_y, aperture_rows, TV_GLASS_PRESENT_ROWS);
+                let src_y = (TV_PRESENT_SOURCE_Y + crop_y).min(src_rows.saturating_sub(1));
+                let row = &present_fb[src_y * FB_WIDTH..(src_y + 1) * FB_WIDTH];
+                let dst = &mut glass[out_y * FB_WIDTH..(out_y + 1) * FB_WIDTH];
+                for (out_x, px) in dst.iter_mut().enumerate() {
+                    *px = tv_glass_sample(row, out_x);
+                }
+            }
+            return screenshot::save(path, &glass, FB_WIDTH as u32, TV_GLASS_PRESENT_ROWS as u32);
         }
     }
 

--- a/src/video/window/shaders/bezel.wgsl
+++ b/src/video/window/shaders/bezel.wgsl
@@ -3,9 +3,10 @@
 // Monitor-bezel pass: a procedural plastic front frame in the spirit of
 // the 1084 the Amiga shipped with. The pass covers the whole display rect;
 // the picture is re-sampled to fill the rounded opening the frame leaves,
-// with a dark recess between the tube face and the plastic, a bevelled
-// inner lip, a moulded outer edge, the power LED on the bottom band and
-// the Copperline logotype printed on its left, where the 1084 wears its
+// seated by a moulded insert -- a thin glass-seat shadow and a plastic
+// chamfer sloping up to the case front -- inside a bevelled case edge,
+// with a moulded outer edge, the power LED on the bottom band and the
+// Copperline logotype printed on its left, where the 1084 wears its
 // Commodore badge.
 //
 // Two modes, selected by params.x. Alone (0), this one pass draws both
@@ -33,7 +34,9 @@ struct BezelUniforms {
     opening: vec4<f32>,
     // x: 1 = frame-only (a CRT preset has already painted the opening;
     // leave its interior untouched), 0 = full (paint the picture too).
-    // yzw: reserved, zero.
+    // y: the active preset's face curvature; the insert follows the
+    // bowed glass contour it implies, and 0 keeps the flat rounded
+    // opening. zw: reserved, zero.
     params: vec4<f32>,
 };
 
@@ -81,6 +84,12 @@ fn grain(p: vec2<f32>) -> f32 {
 
 // The front-face plastic, a warm Commodore grey (linear light).
 const PLASTIC: vec3<f32> = vec3<f32>(0.585, 0.560, 0.500);
+
+// Rounded screen corners as a fraction of the display half-width, the
+// 1084 tube's R 11,6 mm arcs on its 280,8 mm screen. Must match
+// crt.wgsl's CORNER_RADIUS so the insert seats the preset's face
+// exactly; a test pins the two sources together.
+const CORNER_RADIUS: f32 = 0.0826;
 
 // "Copperline" logotype for the bottom band: 5x8-pixel glyphs one column
 // apart (baseline row 6, the p descenders on row 7), 59x8 bits in all.
@@ -152,13 +161,36 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     let p = px - centre;
     // Trim widths scale with the opening so the frame keeps its
     // proportions at any window size, with pixel floors so nothing
-    // vanishes in a tiny window.
+    // vanishes in a tiny window. The ring between the glass and the case
+    // face is the moulded insert that seats the tube: a thin shadow slot
+    // where the glass sits, then a plastic chamfer sloping up to the
+    // case front; `recess` is where the case face takes over.
     let unit = min(o_size.x, o_size.y);
-    let r_open = 0.055 * unit;
-    let recess = max(0.016 * unit, 2.0);
+    let seat = max(0.007 * unit, 1.5);
+    let chamfer = max(0.030 * unit, 4.0);
+    let recess = seat + chamfer;
     let bevel = max(0.022 * unit, 2.0);
 
-    let d = rounded_rect(p, o_half, r_open);
+    // The contour the insert follows is the glass: the active preset's
+    // bowed face. The same warp as crt.wgsl maps the opening onto the
+    // source frame, where the face is the source rectangle with the
+    // tube's rounded corners, so with the preset's curvature in params.y
+    // this distance coincides with the preset's face boundary exactly --
+    // the insert seats the tube whatever its bow -- and at zero
+    // curvature it reduces to a plain rounded opening for the flat
+    // presets. Scaling by the half-width turns source half-width units
+    // into approximate pixels for the trim widths; the warp's local
+    // scale varies a few percent around the perimeter, as a real
+    // moulding gap does.
+    let k = u.params.y;
+    let fa = o_half.y / max(o_half.x, 1.0);
+    let cn = p / o_half;
+    let q = k * 0.25;
+    let r2 = cn.x * cn.x + cn.y * cn.y * fa * fa;
+    let m = vec2<f32>(1.0 + q, 1.0 + q * fa * fa);
+    let wc = cn * (1.0 + q * r2) / m;
+    let fh = vec2<f32>(1.0, fa);
+    let d = rounded_rect(wc * fh, fh, CORNER_RADIUS) * o_half.x;
     let aa = max(fwidth(d), 1e-4);
 
     // Frame-only pass: a CRT preset has already painted the opening
@@ -180,9 +212,19 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
                        vec2<f32>(0.0), vec2<f32>(1.0));
     let picture = sample_display(pic_uv).rgb;
 
-    // The unlit gap where the tube face sits behind the plastic: nearly
-    // black, catching a little light along its lower run.
-    let gap = vec3<f32>(0.012) * (1.0 + 0.8 * dir_y) + vec3<f32>(0.004);
+    // The glass seat: the thin unlit slot where the tube face meets the
+    // insert, catching a little room light along its lower run.
+    let seat_col = vec3<f32>(0.012) * (1.0 + 0.8 * dir_y) + vec3<f32>(0.004);
+
+    // The insert chamfer: moulded plastic a step darker than the case
+    // face, sloping up from the glass seat. Deeper is darker, and the
+    // slope faces the room light, so its top run sits in its own shadow
+    // while its bottom run catches the light -- the cues that read as a
+    // part holding the glass in rather than a void behind the case.
+    let slope = clamp((d - seat) / chamfer, 0.0, 1.0);
+    var insert =
+        PLASTIC * 0.88 * (0.45 + 0.40 * slope) * (1.0 + 0.30 * dir_y * (1.0 - 0.5 * slope));
+    insert *= 1.0 + 0.03 * grain(floor(px));
 
     // Front-face plastic: lit from above, so it shades down slightly
     // toward the bottom band, with a faint moulding grain.
@@ -227,14 +269,16 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
         }
     }
 
-    // Compose by signed distance: picture, recess gap, then plastic, each
-    // join antialiased over about a pixel. In the frame-only pass the
-    // inner side of the opening join belongs to the preset underneath,
-    // whose face edge there is its off-face black: blending from the raw
-    // picture instead smears a picture-coloured hairline around the
-    // opening, on top of the preset the pass discarded for.
+    // Compose by signed distance: picture, glass seat, insert chamfer,
+    // then case plastic, each join antialiased over about a pixel. In the
+    // frame-only pass the inner side of the opening join belongs to the
+    // preset underneath, whose face edge there is its off-face black:
+    // blending from the raw picture instead smears a picture-coloured
+    // hairline around the opening, on top of the preset the pass
+    // discarded for.
     let inner = select(picture, vec3<f32>(0.0), u.params.x > 0.5);
-    var col = mix(inner, gap, clamp(d / aa + 0.5, 0.0, 1.0));
+    let ring = mix(seat_col, insert, smoothstep(seat - aa, seat + aa, d));
+    var col = mix(inner, ring, clamp(d / aa + 0.5, 0.0, 1.0));
     col = mix(col, plastic, smoothstep(recess - aa, recess + aa, d));
     col = mix(col, vec3<f32>(0.0), clamp(d_case / aa_case + 0.5, 0.0, 1.0));
     return vec4<f32>(col, 1.0);

--- a/src/video/window/shaders/bezel.wgsl
+++ b/src/video/window/shaders/bezel.wgsl
@@ -228,8 +228,13 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     }
 
     // Compose by signed distance: picture, recess gap, then plastic, each
-    // join antialiased over about a pixel.
-    var col = mix(picture, gap, clamp(d / aa + 0.5, 0.0, 1.0));
+    // join antialiased over about a pixel. In the frame-only pass the
+    // inner side of the opening join belongs to the preset underneath,
+    // whose face edge there is its off-face black: blending from the raw
+    // picture instead smears a picture-coloured hairline around the
+    // opening, on top of the preset the pass discarded for.
+    let inner = select(picture, vec3<f32>(0.0), u.params.x > 0.5);
+    var col = mix(inner, gap, clamp(d / aa + 0.5, 0.0, 1.0));
     col = mix(col, plastic, smoothstep(recess - aa, recess + aa, d));
     col = mix(col, vec3<f32>(0.0), clamp(d_case / aa_case + 0.5, 0.0, 1.0));
     return vec4<f32>(col, 1.0);

--- a/src/video/window/shaders/crt.wgsl
+++ b/src/video/window/shaders/crt.wgsl
@@ -99,9 +99,13 @@ const GLASS_GLOW: f32 = 0.01;
 // with barrel-arced edges, R 1545 mm top and bottom, R 1173 mm at the
 // sides. Depth on the face grows with *physical* distance from the
 // centre, so in display-normalised coordinates the y term is weighted by
-// the viewport aspect squared; the top/bottom edges then bow roughly
-// (w/h)^2 as far as the sides, as the datasheet arcs do, and k = 0.30
-// reproduces the arcs' curvature.
+// the viewport aspect squared (aspect = height/width, so the weight is
+// *below* one). The bow of an edge comes from how r2 varies while
+// travelling along it: the top edge sweeps the full unweighted x term
+// while a side edge sweeps only the down-weighted y term, so weighting y
+// down bows the top/bottom edges roughly (w/h)^2 as far as the sides --
+// exactly the relation of the datasheet arcs -- and k = 0.30 reproduces
+// the arcs' curvature.
 //
 // The raster overscans the face, as on the real monitor: the per-axis
 // normalisation rescales the bowed field so the source edge lands exactly

--- a/src/video/window/shaders/crt.wgsl
+++ b/src/video/window/shaders/crt.wgsl
@@ -100,14 +100,21 @@ const GLASS_GLOW: f32 = 0.01;
 // sides. Depth on the face grows with *physical* distance from the
 // centre, so in display-normalised coordinates the y term is weighted by
 // the viewport aspect squared; the top/bottom edges then bow roughly
-// (w/h)^2 as far as the sides, as the datasheet arcs do. With this
-// weighting k = 0.30 reproduces the arcs: the edge midpoints clear the
-// corners by 5.1% of the half-height (top/bottom) and 2.7% of the
-// half-width (sides).
+// (w/h)^2 as far as the sides, as the datasheet arcs do, and k = 0.30
+// reproduces the arcs' curvature.
+//
+// The raster overscans the face, as on the real monitor: the per-axis
+// normalisation rescales the bowed field so the source edge lands exactly
+// on the face's mid-edges. The picture therefore fills the whole face --
+// no black ring between picture and face edge -- and the bow shows as the
+// crop deepening toward the corners, where the source content falls into
+// the rounded-corner clip instead of the visible glass.
 fn warp(uv: vec2<f32>, k: f32, aspect: f32) -> vec2<f32> {
     let c = uv * 2.0 - vec2<f32>(1.0);
     let r2 = c.x * c.x + c.y * c.y * aspect * aspect;
-    return (c * (1.0 + k * r2 * 0.25)) * 0.5 + vec2<f32>(0.5);
+    let bowed = c * (1.0 + k * r2 * 0.25);
+    let m = vec2<f32>(1.0 + k * 0.25, 1.0 + k * 0.25 * aspect * aspect);
+    return (bowed / m) * 0.5 + vec2<f32>(0.5);
 }
 
 @fragment

--- a/src/video/window/shaders/crt.wgsl
+++ b/src/video/window/shaders/crt.wgsl
@@ -80,12 +80,33 @@ const SCAN_BOOST: f32 = 1.15;
 const GRILLE_DIM: f32 = 0.55;
 const GRILLE_BOOST: f32 = 1.25;
 
-// Barrel distortion about the centre of the display rect: the tube face is
-// a section of a sphere, so the picture bows outwards and the corners fall
-// outside the visible rect.
-fn warp(uv: vec2<f32>, k: f32) -> vec2<f32> {
+// Rounded screen corners, as a fraction of the display half-width: the
+// 1084's tube has R 11,6 mm corner arcs on a 280,8 mm wide screen
+// (11,6 / 140,4).
+const CORNER_RADIUS: f32 = 0.0826;
+
+// The glass is never black: room light reflects off the face and the
+// phosphor layer behind it, so a lit-room CRT shows black at roughly a
+// hundredth of full white (linear). Lifting on-face black by that much
+// keeps the face silhouette -- bow, rounded corners -- visible against
+// the true black beyond the glass even when the picture itself is dark.
+const GLASS_GLOW: f32 = 0.01;
+
+// Barrel distortion about the centre of the display rect, matched to the
+// 1084's tube (Philips M34EAQ10X, 1986 Philips T08 databook): the face is
+// a section of a sphere (R 640 mm centre blending to R 530 mm at the
+// edge), and the datasheet draws the useful screen (280,8 x 210,6 mm)
+// with barrel-arced edges, R 1545 mm top and bottom, R 1173 mm at the
+// sides. Depth on the face grows with *physical* distance from the
+// centre, so in display-normalised coordinates the y term is weighted by
+// the viewport aspect squared; the top/bottom edges then bow roughly
+// (w/h)^2 as far as the sides, as the datasheet arcs do. With this
+// weighting k = 0.30 reproduces the arcs: the edge midpoints clear the
+// corners by 5.1% of the half-height (top/bottom) and 2.7% of the
+// half-width (sides).
+fn warp(uv: vec2<f32>, k: f32, aspect: f32) -> vec2<f32> {
     let c = uv * 2.0 - vec2<f32>(1.0);
-    let r2 = dot(c, c);
+    let r2 = c.x * c.x + c.y * c.y * aspect * aspect;
     return (c * (1.0 + k * r2 * 0.25)) * 0.5 + vec2<f32>(0.5);
 }
 
@@ -93,9 +114,12 @@ fn warp(uv: vec2<f32>, k: f32) -> vec2<f32> {
 fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     let strength = clamp(u.params.x, 0.0, 1.0);
     let uv = clamp(in.uv, vec2<f32>(0.0), vec2<f32>(1.0));
+    // Height over width of the display rect on screen, for warp and
+    // corner geometry that must be circular in physical pixels.
+    let aspect = u.size.y / max(u.size.x, 1.0);
     // Curvature fades in with strength, so strength 0 samples straight
     // through and every later term collapses to the plain sample.
-    let wuv = mix(uv, warp(uv, u.params.w), strength);
+    let wuv = mix(uv, warp(uv, u.params.w, aspect), strength);
     let base = sample_display(wuv);
 
     // Scanlines follow the bowed geometry.
@@ -128,12 +152,30 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     // holds. Mixing the black back toward `shaded` instead would fill the
     // region with a fraction of the edge colour the sampler smears there.
     //
-    // d is a signed distance to the face in UV, positive outside; fwidth
+    // The face is a rounded rectangle, not a sharp one: the corner arcs
+    // are CORNER_RADIUS of the half-width, like the tube's R 11,6 mm
+    // screen corners. The distance is measured in the warped source frame
+    // (the corner is a property of the screen surface, seen through the
+    // same projection as the picture) and in half-width units on both
+    // axes, so the arc stays circular on screen instead of stretching
+    // with the display aspect. The radius fades with strength like the
+    // bow does, keeping the strength-0 no-op; at radius 0 the expression
+    // reduces to the plain rectangle distance.
+    //
+    // d is a signed distance to the face, positive outside; fwidth
     // rescales it to pixels, so the fade covers about one pixel and the
     // bowed edge does not staircase. Well inside, face is exactly 1 and
     // the shaded result comes through untouched.
-    let d = max(max(-wuv.x, wuv.x - 1.0), max(-wuv.y, wuv.y - 1.0));
+    let half = vec2<f32>(1.0, aspect);
+    let rc = CORNER_RADIUS * strength;
+    let q = abs((wuv * 2.0 - vec2<f32>(1.0)) * half) - half + vec2<f32>(rc);
+    let d = length(max(q, vec2<f32>(0.0))) + min(max(q.x, q.y), 0.0) - rc;
     let aa = max(fwidth(d), 1e-6);
     let face = 1.0 - clamp(d / aa + 0.5, 0.0, 1.0);
-    return vec4<f32>(shaded * face, 1.0);
+    // The reflection glow is flat -- ambient light, not beam emission --
+    // so it rides on top of the shaded picture untouched by scanlines,
+    // grille or vignette, and fades in with strength like every other
+    // term so strength 0 stays a no-op.
+    let glow = vec3<f32>(GLASS_GLOW * strength);
+    return vec4<f32>((shaded + glow) * face, 1.0);
 }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1520,9 +1520,27 @@ fn test_screen_paints_colour_bars_over_a_grey_wedge() {
     let mut fb = vec![0u32; FB_PIXELS];
     paint_test_screen(&mut fb);
 
-    // Top region: leftmost bar is grey, rightmost is blue.
+    // Top region: leftmost bar is grey, rightmost is blue, and the
+    // pattern extends to the capture edges (the region left of the
+    // glass keeps the first bar's colour).
     assert_eq!(fb[0], rgba(192, 192, 192));
+    assert_eq!(fb[TV_CAPTURED_SOURCE_X - 1], rgba(192, 192, 192));
     assert_eq!(fb[FB_WIDTH - 1], rgba(0, 0, 192));
+
+    // The bars are laid out on the glass: the first bar boundary sits a
+    // seventh of the captured aperture in from its start, so the card
+    // reads centred through the TV presentation.
+    let bar_w = TV_CAPTURED_WIDTH.div_ceil(7);
+    assert_eq!(
+        fb[TV_CAPTURED_SOURCE_X + bar_w - 1],
+        rgba(192, 192, 192),
+        "last column of the first bar"
+    );
+    assert_eq!(
+        fb[TV_CAPTURED_SOURCE_X + bar_w],
+        rgba(192, 192, 0),
+        "first column of the second bar"
+    );
 
     // Bottom region: grey wedge runs from black at the left to white
     // at the right.
@@ -1556,8 +1574,13 @@ fn test_screen_blits_copperline_logo_over_colour_bars() {
         .enumerate()
         .find(|(_, px)| px[3] == 0xFF)
         .expect("opaque logo pixel");
-    let x = FB_WIDTH.saturating_sub(logo.width) / 2 + idx % logo.width;
-    let y = (FB_HEIGHT * 4 / 5).saturating_sub(logo.height) / 2 + idx / logo.width;
+    // Centred on the glass: the captured aperture's columns, and the
+    // aperture's field-row window above the wedge.
+    let glass_top = TV_PRESENT_SOURCE_Y / 2;
+    let bars_h = glass_top + TV_PAL_PRESENT_HEIGHT / 2 * 4 / 5;
+    let x =
+        TV_CAPTURED_SOURCE_X + TV_CAPTURED_WIDTH.saturating_sub(logo.width) / 2 + idx % logo.width;
+    let y = glass_top + (bars_h - glass_top).saturating_sub(logo.height) / 2 + idx / logo.width;
 
     assert_eq!(
         fb[y * FB_WIDTH + x],

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -33,7 +33,7 @@ use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
 use crate::config::{Overscan, Tint, WarpSpeed};
 use crate::heatmap;
-use crate::video::{FB_HEIGHT, FB_PIXELS, FB_WIDTH};
+use crate::video::{FB_PIXELS, FB_WIDTH};
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -9,11 +9,11 @@ use super::ScalingMode;
 use super::{
     bar_layout, center_present_frame_for_visible_start, center_present_frame_horizontally,
     control_at, copperline_icon_image, copperline_logo_image, copy_present_frame,
-    copy_window_present_frame, cursor_position_in_texture, draw_status_bar, fdd_track_counter_rect,
-    fdd_track_digit_rect, host_shortcut_modifier_pressed, host_to_amiga_rawkey,
-    joystick_toggle_rect, led_row_rect, mask_present_frame_to_tv, paint_test_screen,
-    parse_amiga_key, pause_button_rect, plan_present_scaling_for, power_button_rect,
-    present_height, presentation_pixels_equal, presentation_source_y_offset,
+    copy_tv_aperture_to_window, copy_window_present_frame, cursor_position_in_texture,
+    draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect, host_shortcut_modifier_pressed,
+    host_to_amiga_rawkey, joystick_toggle_rect, led_row_rect, mask_present_frame_to_tv,
+    paint_test_screen, parse_amiga_key, pause_button_rect, plan_present_scaling_for,
+    power_button_rect, present_height, presentation_pixels_equal, presentation_source_y_offset,
     raw_device_qualifier_family_held, raw_device_qualifier_rawkey, rawkey_is_held,
     rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
     short_status_error, shorten_status_paths, shot_button_rect, should_render_emulated_frame,
@@ -26,8 +26,8 @@ use super::{
     DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
     POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_DIM, POWER_LED_OFF,
     STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-    TRACK_SEGMENT_ON, TV_CAPTURED_SOURCE_X, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
-    TV_PRESENT_SOURCE_X, TV_PRESENT_SOURCE_Y, TV_PRESENT_WIDTH, VOLUME_FILL, VOLUME_GLYPH_X,
+    TRACK_SEGMENT_ON, TV_CAPTURED_SOURCE_X, TV_CAPTURED_WIDTH, TV_LIVE_PAD_X,
+    TV_PAL_PRESENT_HEIGHT, TV_PRESENT_SOURCE_Y, VOLUME_FILL, VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
@@ -2215,68 +2215,72 @@ fn tint_display_rows_leave_the_status_bar_alone() {
 }
 
 #[test]
-fn tv_window_copy_centres_captured_aperture_in_live_texture() {
+fn tv_window_copy_fills_the_glass_from_the_captured_aperture() {
     use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
     let scale = 1;
     let mut src = vec![0u32; OUT_PIXELS];
     let row_y = TV_PRESENT_SOURCE_Y;
     let standard_left = crate::video::bitplane::STANDARD_VISIBLE_X0;
-    let standard_right = standard_left + 320 * 2 - 1;
-    let left_marker = 0x1122_3344u32;
-    let right_marker = 0x5566_7788u32;
-    let left_edge = 0x99AA_BBCCu32;
-    let right_edge = 0xDDEE_FF00u32;
+    let standard_right = standard_left + 320 * 2;
+    let margin = rgba(40, 40, 40);
+    let window = rgba(200, 120, 40);
 
-    src[row_y * FB_WIDTH + TV_CAPTURED_SOURCE_X] = left_edge;
-    src[row_y * FB_WIDTH + FB_WIDTH - 1] = right_edge;
-    src[row_y * FB_WIDTH + standard_left] = left_marker;
-    src[row_y * FB_WIDTH + standard_right] = right_marker;
+    // Border colour across the captured aperture and its neighbouring
+    // rendered overscan (the resample's first sample reaches one column
+    // left of the aperture, which holds rendered border in production),
+    // with the standard window painted a second colour on top.
+    for x in TV_CAPTURED_SOURCE_X - 1..FB_WIDTH {
+        src[row_y * FB_WIDTH + x] = margin;
+    }
+    for x in standard_left..standard_right {
+        src[row_y * FB_WIDTH + x] = window;
+    }
 
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    copy_window_present_frame(
+    copy_tv_aperture_to_window(
         &src,
         OUT_HEIGHT,
-        FB_WIDTH,
         &mut frame,
         scale,
-        Overscan::Tv,
-        Some(TV_PAL_PRESENT_HEIGHT),
+        TV_PAL_PRESENT_HEIGHT,
+        crate::video::PRESENT_HEIGHT_TV,
     );
 
-    // The standard window and the visible raster are both exactly centred:
-    // the captured aperture is symmetric around the standard window and
-    // ends on the framebuffer's edges, so the crop's first and last
-    // columns land mirror-imaged around the texture centre.
-    let dst_standard_left = TV_LIVE_PAD_X + (standard_left - TV_CAPTURED_SOURCE_X);
-    let dst_standard_right = dst_standard_left + 320 * 2 - 1;
-    assert_eq!(dst_standard_left, FB_WIDTH - 1 - dst_standard_right);
-    let dst_crop_left = TV_LIVE_PAD_X;
-    let dst_crop_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_CAPTURED_SOURCE_X);
-    assert_eq!(dst_crop_left, FB_WIDTH - 1 - dst_crop_right);
-    assert_eq!(
-        pixel(&frame, dst_standard_left, 0, scale),
-        left_marker.to_le_bytes()
-    );
-    assert_eq!(
-        pixel(&frame, dst_standard_right, 0, scale),
-        right_marker.to_le_bytes()
-    );
-    assert_eq!(
-        pixel(&frame, dst_crop_left, 0, scale),
-        left_edge.to_le_bytes()
-    );
-    assert_eq!(
-        pixel(&frame, dst_crop_right, 0, scale),
-        right_edge.to_le_bytes()
+    // On the 4:3 glass the aperture fills the full texture width: the
+    // border colour reaches both glass edges and no column is padded
+    // black -- the raster meets the glass edge like a real overscanned
+    // picture.
+    assert_eq!(pixel(&frame, 0, 0, scale), margin.to_le_bytes());
+    assert_eq!(pixel(&frame, FB_WIDTH - 1, 0, scale), margin.to_le_bytes());
+    let black = rgba(0, 0, 0).to_le_bytes();
+    for x in 0..FB_WIDTH {
+        assert_ne!(
+            pixel(&frame, x, 0, scale),
+            black,
+            "glass column {x} padded black"
+        );
+    }
+
+    // The standard window stays exactly centred: its first and last
+    // purely-window-coloured glass columns mirror around the centre
+    // (boundary columns blend with the border and are neither colour).
+    let is_window = |x: usize| pixel(&frame, x, 0, scale) == window.to_le_bytes();
+    let first = (0..FB_WIDTH).find(|&x| is_window(x)).expect("window");
+    let last = (0..FB_WIDTH).rev().find(|&x| is_window(x)).expect("window");
+    let mirror = FB_WIDTH - 1 - last;
+    assert!(
+        first.abs_diff(mirror) <= 1,
+        "standard window off-centre on the glass: first {first}, last {last}"
     );
 }
 
 #[test]
 fn tv_window_copy_black_pads_never_replicate_edge_columns() {
     use crate::video::deinterlace::{OUT_HEIGHT, OUT_PIXELS};
-    // The pads beside the captured aperture are off-capture bezel. A
-    // display fetching or parking sprites in the deepest overscan fills
-    // the crop's edge columns; the pads must stay black instead of
+    // Square-pixel presentation keeps unit columns, so there the pads
+    // beside the captured aperture are off-capture bezel. A display
+    // fetching or parking sprites in the deepest overscan fills the
+    // crop's edge columns; the pads must stay black instead of
     // replicating those columns into horizontal streaks (Gen-X logo
     // slide-in).
     let black = rgba(0, 0, 0).to_le_bytes();
@@ -2288,39 +2292,42 @@ fn tv_window_copy_black_pads_never_replicate_edge_columns() {
         src[row_y * FB_WIDTH + TV_CAPTURED_SOURCE_X] = left_edge;
         src[row_y * FB_WIDTH + FB_WIDTH - 1] = right_edge;
 
-        let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-        copy_window_present_frame(
+        let rows = crate::video::PRESENT_HEIGHT_SQUARE;
+        let mut frame = vec![0u8; texture_width(scale) * rows * scale * 4];
+        copy_tv_aperture_to_window(
             &src,
             OUT_HEIGHT,
-            FB_WIDTH,
             &mut frame,
             scale,
-            Overscan::Tv,
-            Some(TV_PAL_PRESENT_HEIGHT),
+            TV_PAL_PRESENT_HEIGHT,
+            rows,
         );
 
+        // The square canvas centres the aperture rows between vertical
+        // bands: the marker row is the first content row.
+        let y = (rows - TV_PAL_PRESENT_HEIGHT) / 2 * scale;
         let dst_crop_left = TV_LIVE_PAD_X;
         let dst_crop_right = TV_LIVE_PAD_X + (FB_WIDTH - 1 - TV_CAPTURED_SOURCE_X);
         assert_eq!(
-            pixel(&frame, dst_crop_left * scale, 0, scale),
+            pixel(&frame, dst_crop_left * scale, y, scale),
             left_edge.to_le_bytes(),
             "scale {scale}: crop's first column should stay visible"
         );
         assert_eq!(
-            pixel(&frame, dst_crop_right * scale, 0, scale),
+            pixel(&frame, dst_crop_right * scale, y, scale),
             right_edge.to_le_bytes(),
             "scale {scale}: framebuffer edge column should stay visible"
         );
         for x in 0..dst_crop_left * scale {
             assert_eq!(
-                pixel(&frame, x, 0, scale),
+                pixel(&frame, x, y, scale),
                 black,
                 "scale {scale}: left pad must be black at {x}"
             );
         }
         for x in (dst_crop_right + 1) * scale..FB_WIDTH * scale {
             assert_eq!(
-                pixel(&frame, x, 0, scale),
+                pixel(&frame, x, y, scale),
                 black,
                 "scale {scale}: right pad must be black at {x}"
             );
@@ -2603,14 +2610,23 @@ fn tv_pal_crop_centres_standard_display_in_aperture() {
     let standard_left = crate::video::bitplane::STANDARD_VISIBLE_X0;
     let standard_right = standard_left + 640;
 
-    assert_eq!(TV_PRESENT_WIDTH, 692);
+    assert_eq!(TV_CAPTURED_WIDTH, 668);
     assert_eq!(TV_PAL_PRESENT_HEIGHT, 540);
-    assert_eq!(standard_left - TV_PRESENT_SOURCE_X, 26);
+    assert_eq!(standard_left - TV_CAPTURED_SOURCE_X, 14);
     assert_eq!(
-        TV_PRESENT_WIDTH - (standard_right - TV_PRESENT_SOURCE_X),
-        26
+        TV_CAPTURED_WIDTH - (standard_right - TV_CAPTURED_SOURCE_X),
+        14
     );
     assert_eq!(TV_PRESENT_SOURCE_Y, 18);
+
+    // The glass resample keeps the centring: the symmetric captured
+    // margins place the standard window's edges at exactly mirrored
+    // positions, so their glass mappings mirror too (scaled by the same
+    // FB_WIDTH / TV_CAPTURED_WIDTH factor about the same centre).
+    assert_eq!(
+        standard_left - TV_CAPTURED_SOURCE_X,
+        TV_CAPTURED_SOURCE_X + TV_CAPTURED_WIDTH - standard_right
+    );
 }
 
 #[test]

--- a/tests/vamiga_ts.rs
+++ b/tests/vamiga_ts.rs
@@ -182,13 +182,14 @@ fn run_case(
     }
 
     // A screenshot of any other size means the presentation path changed
-    // shape: 692x540 is the TV-aspect picture area, and COPPERLINE_SHOT_RAW
-    // saves the woven native framebuffer instead (716x570 = the vAmiga
-    // regression cutout with line doubling).
+    // shape: 716x540 is the TV-glass picture (the captured aperture
+    // resampled onto the 4:3 glass), and COPPERLINE_SHOT_RAW saves the
+    // woven native framebuffer instead (716x570 = the vAmiga regression
+    // cutout with line doubling).
     if envcfg::flag("COPPERLINE_SHOT_RAW") {
         assert_png_dimensions(&png_path, 716, 570)?;
     } else {
-        assert_png_dimensions(&png_path, 692, 540)?;
+        assert_png_dimensions(&png_path, 716, 540)?;
     }
     if let Some(baseline_root) = baseline_root {
         let mut expected = baseline_root.join(&case.rel_path);


### PR DESCRIPTION
Makes the CRT preset and bezel match what a real 1084 shows, anchored in the tube's actual datasheet and a real-hardware reference photo, and fixes the presentation chain that was painting black where a 1084 shows picture.

## Face geometry from the tube datasheet

The 1084's picture tube is the Philips M34EAQ10X; its datasheet (1986 Philips T08 databook, pp. 752-755) dimensions the face directly: compound-sphere face R 640/530 mm, useful screen 280.8 x 210.6 mm with barrel-arced edges (R 1545 mm top/bottom, R 1173 mm sides) and R 11.6 mm corners.

- The preset's warp now weights its y term by the viewport aspect squared (depth on the face grows with physical distance from the centre) with k = 0.30, reproducing the published arcs: top/bottom edges bow about twice as far as the sides. The old isotropic warp bowed the sides twice as much as the real tube - the original complaint.
- The face clips to the tube's rounded corners (11.6 / 140.4 of the half-width), circular on screen, faded with strength so strength 0 stays a no-op.
- On-face black lifts by a faint glass glow (~1% of white, a lit-room CRT black level), so the face keeps its silhouette on dark pictures instead of dissolving into the letterbox.

## The picture fills the glass, like a real overscanned raster

On real hardware the raster overscans the glass: every visible point of the face shows picture, border colour included. Two layers fell short:

- The TV presentation padded uncaptured aperture columns with black (12 columns on the right of the PNG reference aperture; 24-column side pads in the live window). Both paths now present the captured aperture resampled onto the full framebuffer-wide 4:3 glass (`tv_glass_sample`, the programmable-scan blend idiom): every glass pixel derives from real captured pixels, the standard window stays centred, pixel aspect stays true 4:3. TV screenshots/frame dumps are now 716x540 (was 692x540) - stored TV-shot baselines need regenerating. The square pixel aspect keeps its unit-column padded layout, which is that mode's contract.
- The preset underscanned, floating the picture inside the face with a black ring. The bowed field is now normalised per axis so the source edges land exactly on the face mid-edges: the picture overscans the face and the bow shows as the crop deepening into the rounded corners.

## Bezel: a moulded insert that follows the glass

The ring between the case and the picture was a flat black recess. It is now the moulded insert that seats the tube - a thin glass-seat shadow plus a plastic chamfer sloping up to the case front, lit from above like the rest of the frame. The insert follows the glass contour: the bezel evaluates the preset's bowed-face SDF (same warp + corner radius as crt.wgsl, curvature passed through a spare uniform), so under the CRT preset the moulding tracks the barrel contour through the corners, while flat presets and the bare bezel keep the straight rounded opening at zero curvature.

Also fixed on the way: the frame-only bezel pass blended its opening-edge antialiasing from the raw picture, smearing a picture-coloured hairline around the opening at some window sizes (subpixel-alignment dependent). The join now blends from the preset's off-face black, with a perimeter-ring regression test that catches the leak at any alignment.

## Verification

- Head-on edge bows, corner symmetry, and boundary luminance verified numerically against the datasheet arcs; renders compared against a real A1000/monitor photo (KS1.3 white fills the picture edge-to-edge, zero black insets on all four sides).
- New regression tests: glass resample span/centring, aperture-vs-mask clearance, frame-only picture-leak (perimeter ring), corner-radius pin across both shader sources.
- Docs updated (configuration.md: overscan presentation, crt preset description). Full unit suite (2160), clippy and fmt clean.