### PR TITLE
bezel: let the picture meet the moulding, and wear it powered off on the web

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -4539,12 +4539,19 @@ function presentMonitorOff() {
   if (!monitorGl) return;
   const gl = monitorGl.gl;
   const size = 16;
-  const dark = new Uint8Array(size * size * 4);
-  for (let i = 3; i < dark.length; i += 4) dark[i] = 255;
   gl.bindTexture(gl.TEXTURE_2D, monitorGl.tex);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, dark);
-  monitorGl.texW = size;
-  monitorGl.texH = size;
+  // The frame path's skip-when-unchanged upload: no real presentation is
+  // ever 16x16, so a cached 16x16 texture is this stand-in already and
+  // repeated calls (a pre-boot window drag resizing every event) redraw
+  // without re-uploading. A context restore resets the cached size, so
+  // the stand-in comes back after a GPU reset.
+  if (monitorGl.texW !== size || monitorGl.texH !== size) {
+    const dark = new Uint8Array(size * size * 4);
+    for (let i = 3; i < dark.length; i += 4) dark[i] = 255;
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, dark);
+    monitorGl.texW = size;
+    monitorGl.texH = size;
+  }
   // The line count only shapes a raster the black screen does not show;
   // the standard PAL count keeps the uniforms honest.
   monitorDraw(size, size, 270);

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1709,6 +1709,9 @@ function exitCssFullscreen() {
   setStyles(canvas, CSS_FS_CANVAS, false);
   document.documentElement.style.overflow = '';
   updateFsUi();
+  // Clearing the border shorthand above also cleared the monitor path's
+  // border hiding; put the windowed chrome back the way the mode wants.
+  syncShellChrome();
 }
 
 function exitFullscreen() {
@@ -1726,10 +1729,13 @@ $('fullscreen').addEventListener('click', () => {
 
 // Real fullscreen carries the same canvas letterbox as the CSS fallback,
 // applied on the state change so it also covers Esc and any other
-// browser-initiated exit.
+// browser-initiated exit. Leaving fullscreen re-syncs the windowed shell
+// chrome (the monitor path's border hiding); entering it is a no-op
+// there, since fullscreen owns the shell's styles.
 document.addEventListener('fullscreenchange', () => {
   setStyles(canvas, CSS_FS_CANVAS, document.fullscreenElement !== null);
   updateFsUi();
+  syncShellChrome();
 });
 
 // --- on-screen keyboard ----------------------------------------------------
@@ -4359,9 +4365,8 @@ void main() {
   vec2 centre = o_org + o_half;
   vec2 p = px - centre;
   float unit = min(o_size.x, o_size.y);
-  float seat = max(0.007 * unit, 1.5);
   float chamfer = max(0.030 * unit, 4.0);
-  float recess = seat + chamfer;
+  float recess = chamfer;
   float bevel = max(0.022 * unit, 2.0);
 
   float k = u_params.y;
@@ -4383,9 +4388,7 @@ void main() {
                       0.0, 1.0);
   vec3 picture = sample_display(pic_uv);
 
-  vec3 seat_col = vec3(0.012) * (1.0 + 0.8 * dir_y) + vec3(0.004);
-
-  float slope = clamp((d - seat) / chamfer, 0.0, 1.0);
+  float slope = clamp(d / chamfer, 0.0, 1.0);
   vec3 insert =
     PLASTIC * 0.88 * (0.45 + 0.40 * slope) * (1.0 + 0.30 * dir_y * (1.0 - 0.5 * slope));
   insert *= 1.0 + 0.03 * grain(floor(px));
@@ -4422,8 +4425,7 @@ void main() {
   }
 
   vec3 inner = u_params.x > 0.5 ? vec3(0.0) : picture;
-  vec3 ring = mix(seat_col, insert, smoothstep(seat - aa, seat + aa, d));
-  vec3 col = mix(inner, ring, clamp(d / aa + 0.5, 0.0, 1.0));
+  vec3 col = mix(inner, insert, clamp(d / aa + 0.5, 0.0, 1.0));
   col = mix(col, plastic, smoothstep(recess - aa, recess + aa, d));
   col = mix(col, vec3(0.0), clamp(d_case / aa_case + 0.5, 0.0, 1.0));
   fragColor = vec4(srgb_encode(col), 1.0);
@@ -4495,29 +4497,18 @@ void main() {
     // The restore starts from a cleared drawing buffer, and a paused page
     // has no ticking loop to repaint it; a running one would also show a
     // blank canvas until its next tick. The rebuild reset the cached
-    // texture size, so this re-uploads the frame it re-presents.
+    // texture size, so this re-uploads the frame it re-presents. With no
+    // machine, the powered-off monitor comes back instead.
     if (emu && running) presentFrame();
+    else if (!emu) presentMonitorOff();
   });
   return renderer;
 }
 
-// Present one frame through the monitor renderer. The backing store
-// follows the element (physical pixels), not the emulated buffer: the CRT
-// pass's scanlines and grille are keyed to output pixels, and at the
-// emulated resolution - two rows per scanline - the raised-cosine beam
-// profile would cancel entirely (its Nyquist point, see the desktop's
-// scanline tests).
+// Present one frame through the monitor renderer: upload the emulator's
+// presentation buffer and draw it as the selected monitor.
 function presentFrameMonitor(width, rows) {
   const gl = monitorGl.gl;
-  const dpr = window.devicePixelRatio || 1;
-  const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
-  const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
-  if (canvas.clientWidth === 0 || canvas.clientHeight === 0) return;
-  if (canvas.width !== w || canvas.height !== h) {
-    canvas.width = w;
-    canvas.height = h;
-  }
-
   // The view must be rebuilt every frame (wasm memory may grow); the
   // texture reallocates only when the presentation size changes.
   const view = new Uint8Array(wasm.memory.buffer, emu.present_ptr(), width * rows * 4);
@@ -4529,13 +4520,52 @@ function presentFrameMonitor(width, rows) {
   } else {
     gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, rows, gl.RGBA, gl.UNSIGNED_BYTE, view);
   }
-
   // The CRT pass suspends when the scan has no 15 kHz line structure to
   // draw (a programmable scan; 0 from the getter), like the desktop's
   // preset, leaving the bezel - which frames any scan - or the plain
   // blit. An older wasm bundle has no getter; half the presented rows is
   // the standard-scan line count.
-  const crtLines = emu.present_crt_lines?.() ?? rows / 2;
+  monitorDraw(width, rows, emu.present_crt_lines?.() ?? rows / 2);
+}
+
+// Draw the selected monitor with a dark, unlit screen: what the page
+// shows before anything boots, so the chosen face fronts the powered-off
+// state too instead of a bare black rectangle. The source is a small
+// black texture through the ordinary passes - a powered-off tube is
+// exactly the glass with no raster, which is what the CRT shader
+// produces from a black picture. Any real frame reallocates the texture,
+// since the stand-in size matches no presentation.
+function presentMonitorOff() {
+  if (!monitorGl) return;
+  const gl = monitorGl.gl;
+  const size = 16;
+  const dark = new Uint8Array(size * size * 4);
+  for (let i = 3; i < dark.length; i += 4) dark[i] = 255;
+  gl.bindTexture(gl.TEXTURE_2D, monitorGl.tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, dark);
+  monitorGl.texW = size;
+  monitorGl.texH = size;
+  // The line count only shapes a raster the black screen does not show;
+  // the standard PAL count keeps the uniforms honest.
+  monitorDraw(size, size, 270);
+}
+
+// Draw whatever is in the source texture as the selected monitor. The
+// backing store follows the element (physical pixels), not the emulated
+// buffer: the CRT pass's scanlines and grille are keyed to output
+// pixels, and at the emulated resolution - two rows per scanline - the
+// raised-cosine beam profile would cancel entirely (its Nyquist point,
+// see the desktop's scanline tests).
+function monitorDraw(width, rows, crtLines) {
+  const gl = monitorGl.gl;
+  const dpr = window.devicePixelRatio || 1;
+  if (canvas.clientWidth === 0 || canvas.clientHeight === 0) return;
+  const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
+  const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w;
+    canvas.height = h;
+  }
   const crtOn = (monitorMode === '1084' || monitorMode === 'crt') && crtLines > 0;
   const bezelOn = monitorMode === '1084' || monitorMode === 'bezel';
   // The effect passes resample through a linear filter like the desktop's
@@ -4609,11 +4639,43 @@ function setMonitorMode(mode, remember) {
   monitorMode = mode;
   monitorSel.value = mode;
   if (remember) storePref(MONITOR_STORAGE_KEY, mode);
+  syncShellChrome();
   // A running page picks the mode up next tick; a paused one has no
-  // ticking loop to repaint, so repaint here.
+  // ticking loop to repaint, so repaint here, and with no machine at all
+  // the choice previews on the powered-off monitor.
   if (emu && running && paused) presentFrame();
+  else if (!emu) presentMonitorOff();
 }
 monitorSel.addEventListener('change', () => setMonitorMode(monitorSel.value, true));
+
+// The page shell draws its own thin border around the canvas; under a
+// bezel mode the monitor's moulded case IS the frame, and a second frame
+// around the plastic reads wrong, so the border hides (kept transparent
+// rather than removed, which would shift the layout). Fullscreen owns
+// the shell's styles while it is up - it strips the border itself - so
+// this only steers the windowed state; the fullscreen exit paths call it
+// to reapply.
+function syncShellChrome() {
+  if (!monitorGl || isFullscreen()) return;
+  const bezelOn = monitorMode === '1084' || monitorMode === 'bezel';
+  shell.style.borderColor = bezelOn ? 'transparent' : '';
+}
+
+// The powered-off monitor fronts the page from the start: drawn now (the
+// module runs with the DOM ready), again on load in case the stylesheet
+// laid the canvas out late, and on resizes while no machine exists. A
+// paused machine repaints on resize too - its loop is not ticking, and
+// the stretched backing store would otherwise blur the frozen picture.
+syncShellChrome();
+presentMonitorOff();
+window.addEventListener('load', () => {
+  if (!emu) presentMonitorOff();
+});
+window.addEventListener('resize', () => {
+  if (!monitorGl) return;
+  if (!emu) presentMonitorOff();
+  else if (running && paused) presentFrame();
+});
 
 // --- status bar --------------------------------------------------------
 // Front-panel status strip mirroring the desktop status bar's LED block:

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -53,7 +53,11 @@ select either half alone, and *Plain* is the undecorated blit the page
 always had -- also what a browser without WebGL2 falls back to (the
 select hides there). As on the desktop, the CRT pass suspends itself on
 programmable scans, which have no 15 kHz line structure to draw; the
-bezel stays.
+bezel stays. The selected monitor fronts the page before anything boots
+too -- the powered-off tube, dark glass in the moulded frame, rather
+than a bare black rectangle -- and while a bezel mode is up the page
+shell's own thin border around the canvas hides, since the moulded case
+is the frame.
 **View** is the desktop's `[display] overscan` knob: *TV* (the
 default) masks the deep horizontal overscan like a CRT bezel and crops
 standard screens (PAL and NTSC alike) to a TV aperture, *Full overscan*
@@ -567,8 +571,12 @@ elements, and pages without them are untouched:
   and `plain`): the monitor presentation (**Monitor** on the hosted
   page), the desktop window's CRT shader preset and 1084 bezel rendered
   through WebGL2. Defaults to `1084` (both together), self-inserting,
-  applied live including to a paused machine, and remembered in the
-  browser like `#overscan`. It hides itself -- and the page keeps its
+  applied live including to a paused machine -- and to the powered-off
+  monitor a page shows before boot -- and remembered in the browser like
+  `#overscan`. While a bezel mode is up the glue makes the shell's
+  border transparent (the moulded case is the frame), restoring it on
+  the other modes; a shell that wants no part of that can simply not
+  style a border. It hides itself -- and the page keeps its
   plain 2D blit -- in a browser without WebGL2.
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
   `800`, and `0` for turbo): hosts the floppy drive speed control, letting

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -669,9 +669,11 @@ mod tests {
 
         // The badge rect as the shader lays it out: left-aligned with the
         // opening, vertically centred in the bottom band, 59x8 font pixels
-        // at 0.34 of the band height.
+        // at 0.34 of the band height. The recess replica is the shader's
+        // insert chamfer, which is where the case face (and the band)
+        // takes over now that no seat ring sits inside it.
         let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
-        let recess = (0.016 * ow.min(oh)).max(2.0);
+        let recess = (0.030 * ow.min(oh)).max(4.0);
         let band_top = oy + oh + recess;
         let badge_h = 0.34 * (rows as f32 - band_top);
         assert!(
@@ -759,7 +761,11 @@ mod tests {
     /// must blend toward the preset's off-face black, not the raw
     /// picture: a bright source used to smear a picture-coloured
     /// hairline around the opening, over the preset output the pass
-    /// discards its interior for.
+    /// discards its interior for. With the insert chamfer meeting the
+    /// picture directly (no unlit seat ring), "no leak" is exactly
+    /// source-independence: everything past the join's half-pixel blend
+    /// must render identically whatever the picture holds, so the frame
+    /// is compared between an all-white and an all-black source.
     #[test]
     fn the_frame_only_join_does_not_leak_the_picture() {
         let Some(gpu) = gpu() else {
@@ -767,8 +773,13 @@ mod tests {
         };
         let (device, queue) = (gpu.device(), gpu.queue());
         let white = |_x: u32, _y: u32| [255, 255, 255, 255];
+        let black = |_x: u32, _y: u32| [0, 0, 0, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &white);
         let (px, dim, rows) = render_bezel(device, queue, &src, Some(ShaderKind::Crt));
+        let dark = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &black);
+        let (px_dark, dim_dark, rows_dark) =
+            render_bezel(device, queue, &dark, Some(ShaderKind::Crt));
+        assert_eq!((dim, rows), (dim_dark, rows_dark));
 
         // The shader's glass-contour distance at a pixel centre: the same
         // warp and rounded rectangle the preset's face uses, driven by
@@ -803,33 +814,32 @@ mod tests {
             (outside + qx.max(qy).min(0.0) - rc) * hx
         };
 
-        // The ring of frame pixels hugging the opening edge is the glass
-        // seat: unlit shadow, always dark (the insert chamfer beyond it
-        // is lit plastic, so the scan stops inside the seat). Any bright
-        // pixel there is the source leaking through the join, which lives
-        // in the first half pixel outside the opening. Whether a straight
-        // edge drops a pixel centre inside that fraction-of-a-pixel band
-        // depends on the window size, but along the corner arcs the
-        // centres sweep every alignment, so the ring as a whole always
-        // catches it.
-        let seat = (0.007 * ow.min(oh)).max(1.5);
+        // The picture may only reach the output through the join's
+        // half-pixel antialias band (the mix weight hits exactly 1.0 past
+        // d = aa / 2, about half a pixel out). Everything beyond it -- the
+        // chamfer's innermost run included -- must not change with the
+        // source; any difference is the picture leaking into the frame.
+        // The margin of 0.6 px keeps legitimately-blended boundary pixels
+        // out of the comparison whatever their sub-pixel alignment.
         let mut checked = 0;
         for y in 0..rows {
             for x in 0..dim {
-                let d = opening_d(x, y);
-                if (0.0..=(seat - 1.0).max(0.6)).contains(&d) {
+                if opening_d(x, y) >= 0.6 {
                     checked += 1;
                     let p = at(&px, dim, x, y);
-                    assert!(
-                        p[0] < 90 && p[1] < 90 && p[2] < 90,
-                        "picture hairline at the opening edge ({x}, {y}), d = {d:.2}: {p:?}"
-                    );
+                    let q = at(&px_dark, dim, x, y);
+                    for c in 0..3 {
+                        assert!(
+                            p[c].abs_diff(q[c]) <= 1,
+                            "frame pixel follows the picture at ({x}, {y}): white {p:?} vs black {q:?}"
+                        );
+                    }
                 }
             }
         }
         assert!(
             checked > 100,
-            "opening ring barely sampled: {checked} pixels"
+            "frame region barely sampled: {checked} pixels"
         );
     }
 

--- a/src/video/window/shaders/bezel.wgsl
+++ b/src/video/window/shaders/bezel.wgsl
@@ -3,11 +3,12 @@
 // Monitor-bezel pass: a procedural plastic front frame in the spirit of
 // the 1084 the Amiga shipped with. The pass covers the whole display rect;
 // the picture is re-sampled to fill the rounded opening the frame leaves,
-// seated by a moulded insert -- a thin glass-seat shadow and a plastic
-// chamfer sloping up to the case front -- inside a bevelled case edge,
-// with a moulded outer edge, the power LED on the bottom band and the
-// Copperline logotype printed on its left, where the 1084 wears its
-// Commodore badge.
+// seated by a moulded insert -- a plastic chamfer sloping from the glass
+// up to the case front, meeting the picture directly, as the real
+// moulding overlaps the tube face and hides its unlit rim -- inside a
+// bevelled case edge, with a moulded outer edge, the power LED on the
+// bottom band and the Copperline logotype printed on its left, where the
+// 1084 wears its Commodore badge.
 //
 // Two modes, selected by params.x. Alone (0), this one pass draws both
 // the frame and the picture. Under a CRT preset (1, frame-only), the
@@ -162,13 +163,14 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     // Trim widths scale with the opening so the frame keeps its
     // proportions at any window size, with pixel floors so nothing
     // vanishes in a tiny window. The ring between the glass and the case
-    // face is the moulded insert that seats the tube: a thin shadow slot
-    // where the glass sits, then a plastic chamfer sloping up to the
-    // case front; `recess` is where the case face takes over.
+    // face is the moulded insert that seats the tube: a plastic chamfer
+    // sloping from the glass up to the case front, whose inner edge meets
+    // the picture directly -- the real moulding overlaps the tube face,
+    // so no unlit rim shows around the glass; `recess` is where the case
+    // face takes over.
     let unit = min(o_size.x, o_size.y);
-    let seat = max(0.007 * unit, 1.5);
     let chamfer = max(0.030 * unit, 4.0);
-    let recess = seat + chamfer;
+    let recess = chamfer;
     let bevel = max(0.022 * unit, 2.0);
 
     // The contour the insert follows is the glass: the active preset's
@@ -212,16 +214,12 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
                        vec2<f32>(0.0), vec2<f32>(1.0));
     let picture = sample_display(pic_uv).rgb;
 
-    // The glass seat: the thin unlit slot where the tube face meets the
-    // insert, catching a little room light along its lower run.
-    let seat_col = vec3<f32>(0.012) * (1.0 + 0.8 * dir_y) + vec3<f32>(0.004);
-
     // The insert chamfer: moulded plastic a step darker than the case
-    // face, sloping up from the glass seat. Deeper is darker, and the
+    // face, sloping up from the glass edge. Deeper is darker, and the
     // slope faces the room light, so its top run sits in its own shadow
     // while its bottom run catches the light -- the cues that read as a
     // part holding the glass in rather than a void behind the case.
-    let slope = clamp((d - seat) / chamfer, 0.0, 1.0);
+    let slope = clamp(d / chamfer, 0.0, 1.0);
     var insert =
         PLASTIC * 0.88 * (0.45 + 0.40 * slope) * (1.0 + 0.30 * dir_y * (1.0 - 0.5 * slope));
     insert *= 1.0 + 0.03 * grain(floor(px));
@@ -269,16 +267,15 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
         }
     }
 
-    // Compose by signed distance: picture, glass seat, insert chamfer,
-    // then case plastic, each join antialiased over about a pixel. In the
+    // Compose by signed distance: picture, insert chamfer, then case
+    // plastic, each join antialiased over about a pixel. In the
     // frame-only pass the inner side of the opening join belongs to the
     // preset underneath, whose face edge there is its off-face black:
     // blending from the raw picture instead smears a picture-coloured
     // hairline around the opening, on top of the preset the pass
     // discarded for.
     let inner = select(picture, vec3<f32>(0.0), u.params.x > 0.5);
-    let ring = mix(seat_col, insert, smoothstep(seat - aa, seat + aa, d));
-    var col = mix(inner, ring, clamp(d / aa + 0.5, 0.0, 1.0));
+    var col = mix(inner, insert, clamp(d / aa + 0.5, 0.0, 1.0));
     col = mix(col, plastic, smoothstep(recess - aa, recess + aa, d));
     col = mix(col, vec3<f32>(0.0), clamp(d_case / aa_case + 0.5, 0.0, 1.0));
     return vec4<f32>(col, 1.0);


### PR DESCRIPTION
Three follow-ups to #384, all maintainer-requested alterations to the 1084 monitor presentation.

## 1. The picture meets the moulded insert (desktop + web)

The bezel seated the tube behind a thin unlit "glass seat" ring, but the real 1084's moulding overlaps the tube face and hides its rim: no black slot shows around the glass. The seat is gone from `shaders/bezel.wgsl` and the try.js GLSL copy alike - the insert chamfer now slopes from the case front straight down to the picture (`recess == chamfer`). A centre-column pixel profile across the top join confirms the change: previously plastic -> near-black slot -> glass; now plastic -> glass in a single antialiased step.

The frame-only leak test asserted the seat's look ("the ring is always dark"), which described the removed ring rather than the property it protected. It now states that property directly - everything past the join's half-pixel blend must render identically whatever the picture holds - by comparing an all-white against an all-black source. The badge test's recess replica follows the shader's chamfer.

## 2. The web page fronts the powered-off monitor

Before anything boots, the page now draws the selected monitor with a dark, unlit screen: the presentation was split out of the frame path and draws the face over a small black texture, which is exactly what a powered-off tube is. Redrawn on mode changes, resizes and context restores while no machine exists, so the boot overlay sits on dark glass in the moulded frame instead of a bare black rectangle.

## 3. The page shell's border hides under a bezel mode

While Monitor is *1084* or *Bezel*, the shell's own thin border is made transparent (layout-preserving) - the moulded case is the frame - and restored on *CRT filter*/*Plain*. Re-synced when leaving fullscreen, whose style teardown clears the border shorthand.

## Testing

- All 17 bezel GPU tests (Metal) and the full 2162-test unit suite pass; clippy and `cargo fmt --check` clean; `node --check` on try.js.
- Desktop join verified via the bezel preview dump (before/after pixel profile).
- Browser-verified against a staged site: powered-off 1084 behind the boot overlay, border toggling with the mode select (computed style checked), and the seatless join after boot.
- docs/guide/browser.md documents the powered-off face and the border behaviour. No wasm rebuild needed (the wasm crate is untouched).