### PR TITLE
Feature/mt-32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,12 @@ default = [
     "net-nat",
     "net-bridge",
     "floppybridge",
+    "mt32",
     "cpu-jit",
 ]
+# MT-32 emulation through Munt's mt32emu (vendor/munt), reachable as a
+# MIDI-Out target. Off builds carry none of it.
+mt32 = []
 display-plan-trace = []
 # Local investigation switches that deliberately alter timing or rendering.
 # Normal builds keep these environment-variable overrides inert so release

--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,7 @@ fn main() {
 
     set_windows_main_thread_stack();
     build_floppybridge();
+    build_munt();
 }
 
 /// Compile the vendored FloppyBridge into the emulator, so a build produces a
@@ -146,4 +147,86 @@ fn git_output<const N: usize>(args: [&str; N]) -> Option<String> {
     let text = String::from_utf8(output.stdout).ok()?;
     let text = text.trim();
     (!text.is_empty()).then(|| text.to_string())
+}
+
+/// Compile Munt's mt32emu, the MT-32 synthesiser engine, into the
+/// emulator. Vendored whole -- keeping it in step with upstream is the
+/// maintainer's job -- see vendor/munt/README.md.
+fn build_munt() {
+    if std::env::var_os("CARGO_FEATURE_MT32").is_none() {
+        return;
+    }
+    let dir = Path::new("vendor/munt/src");
+    // Upstream's own library source list. The optional resampler adapters are
+    // not among them: MT32EMU_WITH_INTERNAL_RESAMPLER below picks the built-in
+    // one, which is what keeps this free of external dependencies.
+    const SOURCES: [&str; 29] = [
+        "Analog.cpp",
+        "BReverbModel.cpp",
+        "Display.cpp",
+        "File.cpp",
+        "FileStream.cpp",
+        "LA32FloatWaveGenerator.cpp",
+        "LA32Ramp.cpp",
+        "LA32WaveGenerator.cpp",
+        "MidiStreamParser.cpp",
+        "Part.cpp",
+        "Partial.cpp",
+        "PartialManager.cpp",
+        "Poly.cpp",
+        "ROMInfo.cpp",
+        "SampleRateConverter.cpp",
+        "Synth.cpp",
+        "TVA.cpp",
+        "TVF.cpp",
+        "TVP.cpp",
+        "Tables.cpp",
+        "VersionTagging.cpp",
+        "c_interface/c_interface.cpp",
+        "sha1/sha1.cpp",
+        "srchelper/InternalResampler.cpp",
+        "srchelper/srctools/src/FIRResampler.cpp",
+        "srchelper/srctools/src/IIR2xResampler.cpp",
+        "srchelper/srctools/src/LinearResampler.cpp",
+        "srchelper/srctools/src/ResamplerModel.cpp",
+        "srchelper/srctools/src/SincResampler.cpp",
+    ];
+    println!("cargo:rerun-if-changed=vendor/munt/src");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .include(dir)
+        // The built-in sample-rate converter, so the engine renders straight
+        // at the mixer's rate with nothing else to link against.
+        .define("MT32EMU_WITH_INTERNAL_RESAMPLER", "1")
+        .warnings(false);
+    if target_env == "msvc" {
+        // The sources use the standard library's containers, so they need
+        // real unwinding; MSVC does not enable it by default.
+        build.flag("/EHsc");
+        // No standard is asked for here: MSVC has no C++11 setting -- its
+        // lowest is C++14, which its default already meets -- so naming one
+        // earns a "command line warning D9002" from cl for every source.
+    } else {
+        build.std("c++11");
+    }
+    for source in SOURCES {
+        build.file(dir.join(source));
+    }
+    // Copperline's own shim, which formats the engine's diagnostics where
+    // the compiler knows what a va_list is.
+    println!("cargo:rerun-if-changed=src/mt32/print_debug.cpp");
+    build.file("src/mt32/print_debug.cpp");
+    build.compile("mt32emu");
+
+    // The C++ runtime the engine's containers are built against.
+    match target_os.as_str() {
+        "macos" | "ios" => println!("cargo:rustc-link-lib=dylib=c++"),
+        "windows" => {}
+        _ => println!("cargo:rustc-link-lib=dylib=stdc++"),
+    }
 }

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -536,6 +536,8 @@ floppy_sounds_volume = 100
 #   "midi"    serial in/out is bridged to host MIDI endpoints. Needs a build
 #             with the `midi` feature; midi_out/midi_in name the endpoints
 #             (substring match, e.g. a USB interface or a virtual port).
+#             Either may instead be "mt32", the emulated MT-32 built in
+#             rather than anything on the host - see docs/guide/mt32.md.
 #   "tcp"     serial in/out is bridged to a host TCP port, like UAE's "TCP:"
 #             device. listen sets the bind address (default 127.0.0.1:1234);
 #             connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
@@ -554,6 +556,18 @@ floppy_sounds_volume = 100
 # midi_out = "USB MIDI Interface"
 # midi_in = "USB MIDI Interface"
 # listen = "127.0.0.1:1234"
+#
+# The emulated MT-32 (docs/guide/mt32.md). midi_out = "mt32" plays to it
+# instead of a host endpoint; both ROM images are needed, and are yours to
+# supply. midi_in = "mt32" wires its own MIDI OUT back to the machine, which
+# is what a patch editor or librarian needs to read it; that is offered only
+# while it is also the output, since it answers only what it is sent.
+# midi_out = "mt32"
+# midi_in = "mt32"
+# mt32_control_rom = "~/Amiga/MT32_CONTROL.ROM"
+# mt32_pcm_rom = "~/Amiga/MT32_PCM.ROM"
+# mt32_panel = true          # the module's front panel, under the display
+# mt32_lcd = "mt32"          # mt32 (default), jv1080, or oled
 
 
 # Parallel (Centronics) port peripheral. With no section the connector is

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -567,7 +567,7 @@ floppy_sounds_volume = 100
 # mt32_control_rom = "~/Amiga/MT32_CONTROL.ROM"
 # mt32_pcm_rom = "~/Amiga/MT32_PCM.ROM"
 # mt32_panel = true          # the module's front panel, under the display
-# mt32_lcd = "mt32"          # mt32 (default), jv1080, or oled
+# mt32_lcd = "mt32"          # mt32 (default), superjv, sseries, or oled
 
 
 # Parallel (Centronics) port peripheral. With no section the connector is

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -81,7 +81,8 @@ profile in a config file.
 The audio, serial, parallel, and network surface has matching per-run flags
 too -- `--audio-device`, `--audio-channel-mode`, `--audio-filter`,
 `--audio-stereo-separation`, `--serial`, `--midi-in`, `--midi-out`,
-`--parallel`, `--sampler-audio-input`, `--sampler-input-gain`, `--a2065-net`,
+`--mt32-control-rom`, `--mt32-pcm-rom`, `--mt32-panel`, `--parallel`,
+`--sampler-audio-input`, `--sampler-input-gain`, `--a2065-net`,
 `--a2065-interface` --
 described with their `[audio]`, `[serial]`, `[parallel]`, and `[a2065]` keys
 below.
@@ -1011,8 +1012,8 @@ button.
 ```toml
 [serial]
 mode = "stdout"          # off, stdout, midi, tcp, tcp-connect, or pty
-# midi_out = "FluidSynth"  # midi mode: host destination, substring match
-# midi_in = "Keystation"   # midi mode: host source, substring match
+# midi_out = "FluidSynth"  # midi mode: host destination, or "mt32"
+# midi_in = "Keystation"   # midi mode: host source, or "mt32"
 # listen = "127.0.0.1:1234"  # tcp mode: bind address
 # connect = "bbs.example.com:1337"  # tcp-connect mode: remote to dial
 ```
@@ -1026,7 +1027,10 @@ Paula's serial in/out is connected:
 - `midi` -- serial in/out is bridged to host MIDI endpoints. Needs a build
   with the `midi` feature (the default); `midi_out`/`midi_in` name the
   endpoints by case-insensitive substring (a USB interface or a virtual
-  port). `--list-midi` prints the host endpoints.
+  port). `--list-midi` prints the host endpoints. Either may instead be
+  `"mt32"`, which is Copperline's own emulated MT-32 rather than anything
+  on the host, and brings its own `mt32_*` keys with it; see
+  [the MT-32 chapter](mt32.md).
 - `tcp` -- serial in/out is bridged to a host TCP port, like UAE's `TCP:`
   device. `listen` sets the bind address (default `127.0.0.1:1234`);
   connect with e.g. `nc`, `socat`, or a raw-mode telnet client.

--- a/docs/guide/mt32.md
+++ b/docs/guide/mt32.md
@@ -1,0 +1,239 @@
+# The Munt MT-32
+
+Copperline can put an MT-32 on the other end of the Amiga's MIDI cable. The
+sound module is emulated in-process by [Munt](https://github.com/munt/munt)'s
+`mt32emu`, compiled into the binary from `vendor/munt`.
+
+Audio is mixed in beside the Amiga's own four channels, so a game that plays
+MT-32 music and Amiga sound effects gets both.
+
+**Enabling the front panel option gives you a fully featured, meticulously
+detailed virtual MT-32 synthesiser.**
+
+
+## What you need
+
+Two ROM images: a control ROM and a PCM ROM. **Copperline does not ship them
+and never will** -- they are the manufacturer's copyright, and sourcing or supplying
+your own from a unit you own is your affair. Munt's own documentation covers which
+versions exist.
+
+**Examples:**
+
+| Name | Version | SHA-1 |
+|---|---|---|
+| mt32_ctrl_2_07.rom | v2.07 | 47b52adefedaec475c925e54340e37673c11707c |
+| MT32_CONTROL.ROM | v1.07 | b083518fffb7f66b03c23b7eb4f868e62dc5a987 |
+| MT32_PCM.ROM | all | f6b1eebc4b2d200ec6d3d21d51325d5b48c60252 |
+
+The engine identifies a ROM by its size and SHA-1 rather than its filename, so
+a mislabelled or truncated file is refused at load rather than producing a synth
+that sounds subtly wrong.
+
+## Turning it on
+
+The serial port has to be in MIDI mode with the MT-32 as its output. In the
+launcher, that is the **I/O Ports** tab, Serial section: set **Device / Mode**
+to `MIDI`, then **MIDI output** to `Munt MT-32`. Choosing it reveals the rest
+of the rows:
+
+| Row | What it does |
+|---|---|
+| MIDI input | Host source, or `Munt MT-32` -- see [Patch editors](#patch-editors) |
+| Control ROM | Browse to the control ROM image |
+| PCM ROM | Browse to the PCM ROM image |
+| Front panel | Show the module's front panel under the display |
+| Display | Which LCD the panel wears |
+
+The same thing in a config file:
+
+```toml
+[serial]
+mode = "midi"
+midi_out = "mt32"
+mt32_control_rom = "~/Amiga/MT32_CONTROL.ROM"
+mt32_pcm_rom = "~/Amiga/MT32_PCM.ROM"
+mt32_panel = true          # show the front panel
+mt32_lcd = "mt32"          # mt32 (default), superjv, sseries, or oled
+```
+
+`midi_out = "mt32"` is the one value that does not name a host endpoint. Both
+ROM paths must be set: with only one, there is nothing to fit, and Copperline
+says so on the on-screen display rather than playing silence.
+
+On the command line:
+
+```sh
+./target/release/copperline --model A1200 KICK31.ROM \
+  --midi-out mt32 \
+  --mt32-control-rom MT32_CONTROL.ROM --mt32-pcm-rom MT32_PCM.ROM \
+  --mt32-panel
+```
+
+`--midi-out mt32` implies `mode = "midi"`.
+
+## `[serial]` keys
+
+| Key | Values | Meaning |
+|---|---|---|
+| `midi_out` | `"mt32"` | Play to the built-in module instead of a host endpoint |
+| `midi_in` | `"mt32"` | Wire the module's own MIDI OUT back to the machine |
+| `mt32_control_rom` | path | The control ROM image |
+| `mt32_pcm_rom` | path | The PCM ROM image |
+| `mt32_panel` | `true`/`false` | Show the front panel (default `false`) |
+| `mt32_lcd` | `"mt32"`, `"superjv"`, `"sseries"`, `"oled"` | Which LCD the panel wears (default `"mt32"`) |
+
+`mt32_lcd` also takes `1` to `4` for the four styles in that order, and
+spells the first two with a hyphen if you prefer (`mt-32`, `super-jv`).
+
+## Using it
+
+Anything on the Amiga that drives MIDI out of the serial port drives the
+module. That covers rather more than the handful of games with MT-32 support:
+
+- **Games.** ~15 games support the MT-32 -- pick the MT-32 in the game's own setup
+program, the same as you would on hardware.
+- **Sequencers.** OctaMED, Bars and Pipes, Music-X and friends see a synthesiser
+  on the MIDI port and treat it as one. With the front panel up you can set a
+  part's timbre and level while the sequence plays.
+- **Editors and librarians.** See below -- these need the return path.
+
+(patch-editors)=
+### Patch editors
+
+Editor and librarian software (Caged Artist's MT-32 editor, for example)
+reads and writes the module's memory, so it needs MIDI input as well as
+output. Set `midi_in = "mt32"` to wire the module's MIDI OUT back to the
+machine. The module appears in the input list only while it is also the
+selected output.
+
+## The front panel
+
+`mt32_panel = true` adds the module's front panel in a strip under the
+display. The window grows to make room and shrinks when the panel is
+hidden.
+
+- **Left click** presses a button.
+- **Right click** holds a button down, which is how the two- and three-button
+  functions are reached. Up to three can be held.
+
+Pressing the button of the part already shown returns to the main screen.
+
+### Single buttons
+
+| Button | The dial then edits |
+|---|---|
+| PART 1-5, PART R | Which part the three buttons below act on |
+| SOUND GROUP | The part's timbre bank (0-3: the two internal groups, memory, rhythm) |
+| SOUND | The part's timbre within that bank (0-63) |
+| VOLUME | The part's level (0-100) |
+| MASTER VOLUME | The module's volume (0-100) |
+
+### Button combinations
+
+Every two-button function is MASTER VOLUME plus one other: right-click
+MASTER VOLUME, then click the second button.
+
+| Held with | Reaches |
+|---|---|
+| GROUP | Master tune, 427.5 to 452.6 Hz |
+| VOLUME | Reverb mode (0-3) |
+| SOUND | Unit number |
+| PART 1, 2, 3 | Parts 6, 7 and 8, which have no buttons of their own |
+| PART 4 | Overflow assign (confirm with PART 1) |
+| PART 5 | MIDI channels: move parts 1-8 onto channels 1-8 (confirm with PART 1) |
+| PART R | All Reset (confirm with PART 1) |
+
+The last three wait for a confirming press, following the manual's
+three-button procedures. All Reset also accepts PART 2-5 for the partial
+reset that keeps patch memory.
+
+Unit number and Overflow assign behave as on hardware but have no effect
+here: there is a single module, and nothing is connected to its MIDI OUT.
+
+### Bonus button combinations
+
+First power off the unit using the power button.
+
+| Combination | Reaches |
+|---|---|
+| MASTER + Power | Chain Play / Demo - **Requires v2.x ROM** |
+| 1 + 3 + MASTER + POWER | ROM debug / version info |
+
+### The dial
+
+Drag the Select/Volume dial to turn it, or click it to step by one. The
+turn is measured from where you took hold, so the dial does not jump to the
+pointer. Holding a button repeats, from four steps a second up to twenty
+after two seconds.
+
+Values set from the panel are written into the same patch and system memory
+that SysEx reaches, so the engine responds to the panel exactly as it does
+to the guest.
+
+### Power
+
+The power switch is Copperline's addition; the real unit has its switch at
+the back. Switching off shuts down the synthesiser and releases the ROMs.
+Switching on again is a cold start, as on hardware.
+
+### Display styles
+
+| `mt32_lcd` | Looks like |
+|---|---|
+| `mt32` (default) | Dark green backlight, lighter green characters |
+| `superjv` | Deep blue, pale green characters; the blue remains when off |
+| `sseries` | Sky blue, near-black characters; paler when off |
+| `oled` | Black glass, green characters; nothing shown when off |
+
+All styles except the OLED show the unlit dot matrix behind the characters,
+as the real glass does. A part with a note sounding shows a filled cell in
+place of its number, as on the unit.
+
+## In the window
+
+With the serial port in MIDI mode, the menu's **Serial Port** category
+carries **MIDI In** and **MIDI Out**, and, once the module is selected, a
+**Munt MT-32** submenu with the front panel toggle and the display styles.
+Changes take effect immediately.
+
+## Building without it
+
+The `mt32` Cargo feature, on by default, compiles the engine in. To build
+without it:
+
+```sh
+cargo build --release --no-default-features --features midi
+```
+
+The launcher rows and MIDI device entries disappear, and `mt32_*` config
+keys are read and ignored with a warning.
+
+With the feature compiled in, the engine is only instantiated while the
+MT-32 is the selected output, and holds about 2 MiB while running: the two
+ROM images, the sample tables decoded from them, and the reverb and
+resampler buffers. Benchmark results are the same with and without the
+feature.
+
+## Troubleshooting
+
+Errors appear on the on-screen display:
+
+| Message | Meaning |
+|---|---|
+| `Munt MT-32: missing ROM(s)` | One or both ROM paths are unset |
+| `Munt MT-32: invalid ROM(s)` | A file is not a ROM the engine recognises |
+
+`COPPERLINE_MT32_DEBUG=1` logs the engine's activity: what it is sent, what
+it reads and writes, and what it makes of MIDI it cannot parse. Warnings
+about unparseable bytes are normal on a serial line carrying whatever the
+guest sends. `COPPERLINE_MIDI_DEBUG=1` (or `=2` for whole messages) logs
+byte flow at the serial bridge.
+
+## Licensing
+
+`mt32emu` is LGPL-2.1-or-later, compatible with Copperline's
+GPL-3.0-or-later, which is why it can be linked in directly. It contains no
+ROM data; the emulation runs on the images you supply. The vendored copy,
+what was left out of it, and how to update it are described in
+`vendor/munt/README.md`.

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -292,7 +292,9 @@ Shown only when something is on the port.
 
 - **MIDI In / MIDI Out** (serial port in MIDI mode): Paula's serial bridge
   onto the host's MIDI sources and destinations; see the `[serial]` section
-  of [Configuration](configuration.md).
+  of [Configuration](configuration.md). **Munt MT-32** is offered here too,
+  and with it playing, a **Munt MT-32** submenu carries its front panel and
+  display style; see [The Munt MT-32](mt32.md).
 - **Sampler Input / Sampler Gain** (parallel-port sampler attached): the
   sampler's host capture device, and its input gain, which the *Increase* and
   *Decrease* rows step (also `Cmd/Alt+Shift +/-`). Both change live. See the
@@ -430,7 +432,9 @@ The layout is:
   source),
   *I/O Ports* (the serial, parallel, and Ethernet ports under **Serial:** /
   **Parallel:** / **Ethernet:** headings, with each port's options indented
-  beneath it: serial mode and MIDI endpoints; the
+  beneath it: serial mode and MIDI endpoints, with the emulated MT-32's ROM
+  images, front panel and display style when it is the chosen output (see
+  [The Munt MT-32](mt32.md)); the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
   and the A2065 Ethernet board -- None, Isolated, Loopback, NAT, or

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -31,6 +31,7 @@ project:
         - file: guide/configuration.md
         - file: guide/ui.md
         - file: guide/floppybridge.md
+        - file: guide/mt32.md
         - file: guide/headless.md
         - file: guide/browser.md
     - title: Extending

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4125,6 +4125,12 @@ impl Bus {
         self.paula.serial.as_midi()
     }
 
+    /// The same sink shared, for state that is read rather than switched.
+    #[cfg(feature = "midi")]
+    pub fn midi_serial(&self) -> Option<&crate::midi::MidiSerialSink> {
+        self.paula.serial.as_midi_ref()
+    }
+
     pub fn live_audio_output_lead_seconds(&self) -> f64 {
         self.paula.live_audio_output_lead_seconds()
     }

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -416,6 +416,12 @@ pub struct Paula {
     // CD audio samples streamed by the CD controller (CD32 Akiko), mixed
     // into the host output at the shared 44.1 kHz mixer rate.
     cd_audio: CdAudioRing,
+    // Set once the device on the serial port has said it makes no sound
+    // here, which is the usual answer: a machine with nothing on its MIDI
+    // port then costs one predictable branch a sample and nothing else.
+    // Not emulated state -- it is a fact about the host wiring.
+    #[serde(skip)]
+    synth_silent: bool,
     // Synthesized floppy-drive noises (motor/seek/read), mixed into the
     // host frames after the LED filter: the drive is an acoustic source
     // beside the machine, not part of Paula's filtered audio path.
@@ -487,6 +493,7 @@ impl Paula {
             mono_output: false,
             stereo_separation: 1.0,
             cd_audio: CdAudioRing::default(),
+            synth_silent: false,
             drive_sounds: DriveSounds::new(),
             dma_addr_mask: 0x001F_FFFF,
             capture: None,
@@ -715,6 +722,13 @@ impl Paula {
 
     pub fn drive_sounds_mut(&mut self) -> &mut DriveSounds {
         &mut self.drive_sounds
+    }
+
+    /// Ask the serial sink for audio again. The mixer latches "this device
+    /// makes no sound here" so it is not asking once a sample; changing the
+    /// device on the port clears that.
+    pub fn rearm_synth_audio(&mut self) {
+        self.synth_silent = false;
     }
 
     pub fn cd_audio_mut(&mut self) -> &mut CdAudioRing {
@@ -1791,6 +1805,18 @@ impl Paula {
         }
         left += cd_left;
         right += cd_right;
+        // A MIDI device emulated in-process (an MT-32) is line-mixed the same
+        // way, so the Amiga's own voices keep playing under it exactly as
+        // they would beside a real one on the desk.
+        if !self.synth_silent {
+            match self.serial.next_audio_frame() {
+                Some((synth_left, synth_right)) => {
+                    left += synth_left;
+                    right += synth_right;
+                }
+                None => self.synth_silent = true,
+            }
+        }
         if let Some(capture) = &mut self.capture {
             capture.push((left, right));
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -697,12 +697,87 @@ pub struct SerialConfig {
     pub mode: SerialMode,
     pub midi_out: Option<String>,
     pub midi_in: Option<String>,
+    /// The MT-32's two ROM images. Not Copperline's to ship, so the user
+    /// supplies them; without both, `midi_out = "mt32"` has nothing to fit
+    /// and says so.
+    pub mt32_control_rom: Option<PathBuf>,
+    pub mt32_pcm_rom: Option<PathBuf>,
+    /// Show the MT-32's front panel under the status bar (default false).
+    pub mt32_panel: bool,
+    /// How that panel's display is lit.
+    pub mt32_lcd: Mt32Lcd,
     /// TCP listen address for [`SerialMode::Tcp`]; `None` means the
     /// default `127.0.0.1:1234` (the port UAE's `TCP:` serial uses).
     pub listen: Option<String>,
     /// Remote `host:port` for [`SerialMode::TcpConnect`]. Required in that
     /// mode (there is no sensible default host to dial).
     pub connect: Option<String>,
+}
+
+/// How the MT-32's front-panel display is lit.
+///
+/// The engine draws the same twenty characters whichever this is; only the
+/// glass and the characters on it change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Mt32Lcd {
+    /// The unit's own: a dark green backlight under lighter green
+    /// characters. The default, since this is an MT-32. Unlit it goes to
+    /// bare glass, a shade off the surround around it.
+    #[default]
+    Mt32,
+    /// A JV-1080's: deep blue under pale green characters. Unlit the blue
+    /// stays, a shade darker, as that panel does.
+    Jv1080,
+    /// Black glass under the green the status bar's track counter uses, as
+    /// one of the OLED panels sold to replace a tired original looks.
+    Oled,
+}
+
+impl Mt32Lcd {
+    /// Every style, in the order a picker offers them.
+    pub const MENU_ORDER: [Mt32Lcd; 3] = [Mt32Lcd::Mt32, Mt32Lcd::Jv1080, Mt32Lcd::Oled];
+
+    /// Config name, which round-trips through [`parse_mt32_lcd`].
+    pub fn label(self) -> &'static str {
+        match self {
+            Mt32Lcd::Oled => "oled",
+            Mt32Lcd::Mt32 => "mt32",
+            Mt32Lcd::Jv1080 => "jv1080",
+        }
+    }
+
+    /// What a picker shows.
+    pub fn menu_label(self) -> &'static str {
+        match self {
+            Mt32Lcd::Oled => "OLED",
+            Mt32Lcd::Mt32 => "MT-32",
+            Mt32Lcd::Jv1080 => "JV-1080",
+        }
+    }
+}
+
+/// Parse a `[serial] mt32_lcd` value. The numbers are taken as well as the
+/// names, since the styles are as often thought of as first, second, third.
+pub(crate) fn parse_mt32_lcd(s: &str) -> Result<Mt32Lcd> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "mt32" | "mt-32" | "1" => Ok(Mt32Lcd::Mt32),
+        "jv1080" | "jv-1080" | "2" => Ok(Mt32Lcd::Jv1080),
+        "oled" | "3" => Ok(Mt32Lcd::Oled),
+        other => bail!(
+            "[serial] mt32_lcd must be \"mt32\", \"jv1080\" or \"oled\" \
+             (or 1, 2, 3), got \"{other}\""
+        ),
+    }
+}
+
+/// The `[serial] midi_out` value that means the built-in MT-32 rather
+/// than a host endpoint. Matched whole and case-insensitively, so a host
+/// device whose name merely contains it is still reachable.
+pub const MIDI_OUT_MT32: &str = "mt32";
+
+/// Whether a `midi_out` value asks for the built-in MT-32.
+pub fn midi_out_is_mt32(midi_out: Option<&str>) -> bool {
+    midi_out.is_some_and(|name| name.trim().eq_ignore_ascii_case(MIDI_OUT_MT32))
 }
 
 /// Which peripheral is plugged into the Amiga's Centronics parallel port. The
@@ -2029,6 +2104,13 @@ pub struct ConfigOverrides {
     /// How large the pop-up menu is drawn (`--menu-scale`). Same values as
     /// `[display] menu_scale`.
     pub menu_scale: Option<String>,
+    /// MT-32 control and PCM ROM images (`--mt32-control-rom`,
+    /// `--mt32-pcm-rom`). Same as `[serial] mt32_control_rom`/`mt32_pcm_rom`.
+    pub mt32_control_rom: Option<String>,
+    pub mt32_pcm_rom: Option<String>,
+    /// Show the MT-32's front panel (`--mt32-panel`). Same as
+    /// `[serial] mt32_panel`.
+    pub mt32_panel: Option<bool>,
     /// A real floppy drive on a bay (`--floppy-bridge DFN INTERFACE`), by bay.
     /// Same values as `[floppy.dfN] bridge`.
     pub floppy_bridge: [Option<String>; 4],
@@ -2108,6 +2190,9 @@ impl ConfigOverrides {
             && self.status_bar.is_none()
             && self.perf_overlay.is_none()
             && self.menu_scale.is_none()
+            && self.mt32_control_rom.is_none()
+            && self.mt32_pcm_rom.is_none()
+            && self.mt32_panel.is_none()
     }
 
     /// Inject the set overrides into the raw config, replacing the values
@@ -2311,6 +2396,15 @@ impl ConfigOverrides {
         }
         if let Some(menu_scale) = &self.menu_scale {
             raw.display.menu_scale = Some(menu_scale.clone());
+        }
+        if let Some(rom) = &self.mt32_control_rom {
+            raw.serial.mt32_control_rom = Some(rom.clone());
+        }
+        if let Some(rom) = &self.mt32_pcm_rom {
+            raw.serial.mt32_pcm_rom = Some(rom.clone());
+        }
+        if let Some(panel) = self.mt32_panel {
+            raw.serial.mt32_panel = Some(panel);
         }
     }
 }
@@ -2520,6 +2614,18 @@ pub(crate) struct RawSerial {
     /// Host MIDI input endpoint name (substring match); MIDI mode only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) midi_in: Option<String>,
+    /// MT-32 control ROM image; needed when midi_out = "mt32".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mt32_control_rom: Option<String>,
+    /// MT-32 PCM ROM image; needed when midi_out = "mt32".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mt32_pcm_rom: Option<String>,
+    /// Show the MT-32's front panel under the status bar (default false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mt32_panel: Option<bool>,
+    /// Its display: "mt32" (default), "jv1080", or "oled".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mt32_lcd: Option<String>,
     /// TCP listen address; tcp mode only. Defaults to 127.0.0.1:1234.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) listen: Option<String>,
@@ -3397,6 +3503,13 @@ impl TryFrom<RawConfig> for Config {
             },
             midi_out: raw.serial.midi_out.clone(),
             midi_in: raw.serial.midi_in.clone(),
+            mt32_control_rom: raw.serial.mt32_control_rom.as_ref().map(PathBuf::from),
+            mt32_lcd: match raw.serial.mt32_lcd.as_deref() {
+                None => defaults.serial.mt32_lcd,
+                Some(s) => parse_mt32_lcd(s)?,
+            },
+            mt32_pcm_rom: raw.serial.mt32_pcm_rom.as_ref().map(PathBuf::from),
+            mt32_panel: raw.serial.mt32_panel.unwrap_or(defaults.serial.mt32_panel),
             listen: raw.serial.listen.clone(),
             connect: raw.serial.connect.clone(),
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -725,9 +725,13 @@ pub enum Mt32Lcd {
     /// bare glass, a shade off the surround around it.
     #[default]
     Mt32,
-    /// A JV-1080's: deep blue under pale green characters. Unlit the blue
-    /// stays, a shade darker, as that panel does.
-    Jv1080,
+    /// A Super JV's: deep blue under pale green characters. Unlit the
+    /// blue stays, a shade darker, as that panel does.
+    SuperJv,
+    /// An S Series sampler's: a sky-blue backlight with the characters
+    /// almost black on it. Unlit it keeps a paler blue, plainly a lamp
+    /// gone out rather than a dark screen.
+    SSeries,
     /// Black glass under the green the status bar's track counter uses, as
     /// one of the OLED panels sold to replace a tired original looks.
     Oled,
@@ -735,14 +739,20 @@ pub enum Mt32Lcd {
 
 impl Mt32Lcd {
     /// Every style, in the order a picker offers them.
-    pub const MENU_ORDER: [Mt32Lcd; 3] = [Mt32Lcd::Mt32, Mt32Lcd::Jv1080, Mt32Lcd::Oled];
+    pub const MENU_ORDER: [Mt32Lcd; 4] = [
+        Mt32Lcd::Mt32,
+        Mt32Lcd::SuperJv,
+        Mt32Lcd::SSeries,
+        Mt32Lcd::Oled,
+    ];
 
     /// Config name, which round-trips through [`parse_mt32_lcd`].
     pub fn label(self) -> &'static str {
         match self {
             Mt32Lcd::Oled => "oled",
             Mt32Lcd::Mt32 => "mt32",
-            Mt32Lcd::Jv1080 => "jv1080",
+            Mt32Lcd::SuperJv => "superjv",
+            Mt32Lcd::SSeries => "sseries",
         }
     }
 
@@ -751,7 +761,8 @@ impl Mt32Lcd {
         match self {
             Mt32Lcd::Oled => "OLED",
             Mt32Lcd::Mt32 => "MT-32",
-            Mt32Lcd::Jv1080 => "JV-1080",
+            Mt32Lcd::SuperJv => "Super JV",
+            Mt32Lcd::SSeries => "S Series",
         }
     }
 }
@@ -761,11 +772,12 @@ impl Mt32Lcd {
 pub(crate) fn parse_mt32_lcd(s: &str) -> Result<Mt32Lcd> {
     match s.trim().to_ascii_lowercase().as_str() {
         "mt32" | "mt-32" | "1" => Ok(Mt32Lcd::Mt32),
-        "jv1080" | "jv-1080" | "2" => Ok(Mt32Lcd::Jv1080),
-        "oled" | "3" => Ok(Mt32Lcd::Oled),
+        "superjv" | "super-jv" | "2" => Ok(Mt32Lcd::SuperJv),
+        "sseries" | "s-series" | "3" => Ok(Mt32Lcd::SSeries),
+        "oled" | "4" => Ok(Mt32Lcd::Oled),
         other => bail!(
-            "[serial] mt32_lcd must be \"mt32\", \"jv1080\" or \"oled\" \
-             (or 1, 2, 3), got \"{other}\""
+            "[serial] mt32_lcd must be \"mt32\", \"superjv\", \"sseries\" \
+             or \"oled\" (or 1, 2, 3, 4), got \"{other}\""
         ),
     }
 }
@@ -2623,7 +2635,7 @@ pub(crate) struct RawSerial {
     /// Show the MT-32's front panel under the status bar (default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mt32_panel: Option<bool>,
-    /// Its display: "mt32" (default), "jv1080", or "oled".
+    /// Its display: "mt32" (default), "superjv", "sseries", or "oled".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mt32_lcd: Option<String>,
     /// TCP listen address; tcp mode only. Defaults to 127.0.0.1:1234.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1976,10 +1976,36 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
         SerialMode::Off => Ok(Box::new(crate::serial::NullSerialSink)),
         SerialMode::Stdout => Ok(Box::new(StdoutSink::new())),
         #[cfg(feature = "midi")]
-        SerialMode::Midi => Ok(Box::new(crate::midi::MidiSerialSink::open(
-            cfg.serial.midi_out.as_deref(),
-            cfg.serial.midi_in.as_deref(),
-        )?)),
+        SerialMode::Midi => {
+            // "mt32" names the built-in synth, not a host endpoint, so the
+            // host output starts unset and the device is attached below.
+            let wants_mt32 = crate::config::midi_out_is_mt32(cfg.serial.midi_out.as_deref());
+            let host_out = (!wants_mt32)
+                .then_some(cfg.serial.midi_out.as_deref())
+                .flatten();
+            #[allow(unused_mut)]
+            let mut sink =
+                crate::midi::MidiSerialSink::open(host_out, cfg.serial.midi_in.as_deref())?;
+            #[cfg(feature = "mt32")]
+            {
+                sink.set_mt32_roms(crate::mt32::Mt32Roms {
+                    control: cfg.serial.mt32_control_rom.clone(),
+                    pcm: cfg.serial.mt32_pcm_rom.clone(),
+                });
+                if wants_mt32 {
+                    sink.set_output_endpoint(Some(crate::config::MIDI_OUT_MT32));
+                }
+            }
+            #[cfg(not(feature = "mt32"))]
+            if wants_mt32 {
+                log::warn!(
+                    "[serial] midi_out = \"mt32\" needs a build with --features mt32; \
+                     the MIDI output is unset"
+                );
+            }
+            sink.report_wiring();
+            Ok(Box::new(sink))
+        }
         #[cfg(not(feature = "midi"))]
         SerialMode::Midi => Err(anyhow!(
             "[serial] mode = \"midi\" needs a build with --features midi"

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1983,9 +1983,15 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
             let host_out = (!wants_mt32)
                 .then_some(cfg.serial.midi_out.as_deref())
                 .flatten();
+            // Likewise on the way in: "mt32" is the module's own MIDI OUT,
+            // and it only has one while it is also the output.
+            let wants_mt32_in =
+                wants_mt32 && crate::config::midi_out_is_mt32(cfg.serial.midi_in.as_deref());
+            let host_in = (!wants_mt32_in)
+                .then_some(cfg.serial.midi_in.as_deref())
+                .flatten();
             #[allow(unused_mut)]
-            let mut sink =
-                crate::midi::MidiSerialSink::open(host_out, cfg.serial.midi_in.as_deref())?;
+            let mut sink = crate::midi::MidiSerialSink::open(host_out, host_in)?;
             #[cfg(feature = "mt32")]
             {
                 sink.set_mt32_roms(crate::mt32::Mt32Roms {
@@ -1995,12 +2001,24 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
                 if wants_mt32 {
                     sink.set_output_endpoint(Some(crate::config::MIDI_OUT_MT32));
                 }
+                if wants_mt32_in {
+                    sink.set_input_endpoint(Some(crate::config::MIDI_OUT_MT32));
+                }
             }
+            #[cfg(not(feature = "mt32"))]
+            let _ = wants_mt32_in;
             #[cfg(not(feature = "mt32"))]
             if wants_mt32 {
                 log::warn!(
                     "[serial] midi_out = \"mt32\" needs a build with --features mt32; \
                      the MIDI output is unset"
+                );
+            }
+            if crate::config::midi_out_is_mt32(cfg.serial.midi_in.as_deref()) && !wants_mt32_in {
+                log::warn!(
+                    "[serial] midi_in = \"mt32\" needs midi_out = \"mt32\" as well: \
+                     the module answers what it is sent, so with nothing going \
+                     to it there is nothing to hear back; the MIDI input is unset"
                 );
             }
             sink.report_wiring();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub mod keymap;
 pub mod memory;
 #[cfg(feature = "midi")]
 pub mod midi;
+#[cfg(feature = "mt32")]
+pub mod mt32;
 pub mod net;
 pub mod parallel;
 pub mod paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,6 +410,21 @@ where
             "--show-status-bar" => {
                 overrides.status_bar = Some(true);
             }
+            "--mt32-control-rom" => {
+                overrides.mt32_control_rom = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--mt32-control-rom requires a path"))?,
+                );
+            }
+            "--mt32-pcm-rom" => {
+                overrides.mt32_pcm_rom = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--mt32-pcm-rom requires a path"))?,
+                );
+            }
+            "--mt32-panel" => {
+                overrides.mt32_panel = Some(true);
+            }
             "--menu-scale" => {
                 overrides.menu_scale = Some(
                     args.next()
@@ -1078,8 +1093,16 @@ fn print_help() {
     let shortcut = HOST_SHORTCUT_MODIFIER_LABEL;
     // The MIDI endpoint options only do anything in a `midi`-feature build, so
     // list them only there. `--serial` itself is always shown: off/stdout work
-    // in every build, and it names midi as a mode.
-    #[cfg(feature = "midi")]
+    // in every build, and it names midi as a mode. The MT-32 rides with them
+    // when its own feature is in, being reached through `--midi-out`.
+    #[cfg(all(feature = "midi", feature = "mt32"))]
+    let midi = "--midi-out NAME                host MIDI destination, or mt32 (implies --serial midi)\n  \
+                --midi-in NAME                 host MIDI source, or mt32 (implies --serial midi)\n  \
+                --list-midi                    list host MIDI endpoints and exit\n  \
+                --mt32-control-rom PATH        control ROM for the emulated MT-32\n  \
+                --mt32-pcm-rom PATH            PCM ROM for the emulated MT-32\n  \
+                --mt32-panel                   show the MT-32's front panel under the display\n  ";
+    #[cfg(all(feature = "midi", not(feature = "mt32")))]
     let midi = "--midi-out NAME                host MIDI destination (implies --serial midi)\n  \
                 --midi-in NAME                 host MIDI source (implies --serial midi)\n  \
                 --list-midi                    list host MIDI endpoints and exit\n  ";
@@ -1215,6 +1238,10 @@ fn print_help() {
          --perf-overlay                 show the performance overlay at start\n  \
          \x20                            (Cmd/Alt+P toggles it live)\n  \
          --menu-scale SIZE              size of the pop-up menu: 1x (default) or 2x\n  \
+         --mt32-control-rom PATH        Munt MT-32 control ROM (with --mt32-pcm-rom,\n  \
+         \x20                            makes \"mt32\" selectable as the MIDI output)\n  \
+         --mt32-pcm-rom PATH            Munt MT-32 PCM ROM\n  \
+         --mt32-panel                   show the Munt MT-32 front panel\n  \
          --serial MODE                  Paula serial port: off, stdout, midi, tcp,\n  \
          \x20                            tcp-connect, or pty\n  \
          --serial-connect HOST:PORT     dial a remote TCP service (a telnet BBS) with the\n  \
@@ -1951,6 +1978,8 @@ fn main() -> Result<()> {
     video::set_pixel_aspect(config::resolve_pixel_aspect(cfg.pixel_aspect));
     video::set_display_scaling(cfg.scaling);
     video::set_menu_scale(cfg.menu_scale);
+    video::set_mt32_panel_shown(cfg.serial.mt32_panel);
+    video::set_mt32_lcd(cfg.serial.mt32_lcd);
     // Capture runs (--screenshot-after / --dump-frames) never present a
     // frame, so they skip the host window and event loop entirely: winit's
     // event-loop setup registers with the display server, which aborts or

--- a/src/midi/alsa.rs
+++ b/src/midi/alsa.rs
@@ -664,9 +664,6 @@ pub fn open(
         log::info!("midi: input connected from {:?}", ep.name);
         *control.current.lock().unwrap() = Some(ep);
     }
-    if dest.is_none() && control.current.lock().unwrap().is_none() {
-        log::warn!("[serial] mode = midi but no midi_out/midi_in endpoint selected; MIDI is inert");
-    }
 
     let input_thread = {
         let control = Arc::clone(&control);

--- a/src/midi/coremidi.rs
+++ b/src/midi/coremidi.rs
@@ -477,9 +477,6 @@ pub fn open(
         backend.source = src;
         log::info!("midi: input connected to {:?}", backend.input_name());
     }
-    if backend.dest == 0 && backend.source == 0 {
-        log::warn!("[serial] mode = midi but no midi_out/midi_in endpoint selected; MIDI is inert");
-    }
 
     Ok(Box::new(backend))
 }

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -566,6 +566,38 @@ impl MidiSerialSink {
         self.mt32_version.as_deref()
     }
 
+    /// Stop whatever song is playing.
+    #[cfg(feature = "mt32")]
+    pub fn stop_mt32_demo(&mut self) {
+        if let Some(mt32) = self.mt32.as_mut() {
+            mt32.play_demo(None);
+        }
+    }
+
+    /// Whether a demo song is still running.
+    #[cfg(feature = "mt32")]
+    pub fn mt32_demo_playing(&self) -> bool {
+        self.mt32
+            .as_ref()
+            .is_some_and(crate::mt32::Mt32Device::demo_playing)
+    }
+
+    /// Start one of the control ROM's own songs, and say what it is called.
+    /// The image is read here rather than kept: a demo is a rare thing to
+    /// ask for, and the songs are a good deal larger than the answer.
+    #[cfg(feature = "mt32")]
+    pub fn play_mt32_demo(&mut self, track: usize) -> Option<String> {
+        let image = std::fs::read(self.mt32_roms.control.as_deref()?).ok()?;
+        let mut songs = crate::mt32::demo::songs(&image);
+        if songs.is_empty() {
+            return None;
+        }
+        let song = songs.swap_remove(track % songs.len());
+        let title = song.title.clone();
+        self.mt32.as_mut()?.play_demo(Some(song));
+        Some(title)
+    }
+
     /// Point the input at a named host endpoint, at the MT-32's own MIDI
     /// OUT, or at nothing.
     pub fn set_input_endpoint(&mut self, endpoint: Option<&str>) {

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -138,6 +138,20 @@ pub struct MidiSerialSink {
     /// window can say so rather than leaving a silent blank panel.
     #[cfg(feature = "mt32")]
     mt32_fault: Option<String>,
+    /// Whether the MT-32's own MIDI OUT is wired back to the machine, which
+    /// is what a patch editor on the Amiga needs to read the module back.
+    /// Only meaningful while the MT-32 is also the output: it answers what
+    /// it was sent, so with nothing going to it there is nothing to answer.
+    #[cfg(feature = "mt32")]
+    mt32_input: bool,
+    /// Assembles the requests the guest sends to the module.
+    #[cfg(feature = "mt32")]
+    mt32_responder: crate::mt32::reply::Responder,
+    /// The reply waiting to go back to the guest. Paula's receiver drains it
+    /// at the emulated baud rate exactly as it drains the host ring, so a
+    /// dump arrives over the wire at MIDI speed rather than all at once.
+    #[cfg(feature = "mt32")]
+    mt32_reply: std::collections::VecDeque<u8>,
 }
 
 /// The output-device name that means the built-in MT-32 rather than a host
@@ -369,6 +383,12 @@ impl MidiSerialSink {
             mt32_selected: false,
             #[cfg(feature = "mt32")]
             mt32_fault: None,
+            #[cfg(feature = "mt32")]
+            mt32_input: false,
+            #[cfg(feature = "mt32")]
+            mt32_responder: crate::mt32::reply::Responder::default(),
+            #[cfg(feature = "mt32")]
+            mt32_reply: std::collections::VecDeque::new(),
         })
     }
 
@@ -419,7 +439,12 @@ impl MidiSerialSink {
         {
             self.mt32 = None;
             self.mt32_selected = false;
+            // Nothing reaches the module any more, so it has nothing left
+            // to answer: its MIDI OUT goes with its MIDI IN.
+            self.mt32_input = false;
         }
+        #[cfg(feature = "mt32")]
+        self.stop_answering();
         self.backend.set_output(endpoint);
         log::info!("midi: output -> {}", self.output_label());
     }
@@ -468,8 +493,21 @@ impl MidiSerialSink {
             self.attach_mt32();
         } else {
             self.mt32 = None;
+            // A module with no power answers nothing.
+            self.stop_answering();
             log::info!("midi: {MIDI_OUT_MT32_LABEL} switched off");
         }
+    }
+
+    /// Stop answering the machine: nothing half-gathered, nothing half-sent.
+    ///
+    /// Called wherever the module stops being what the guest is talking to,
+    /// so a request begun against the old one cannot finish against the new,
+    /// and a dump cut off partway cannot arrive as a broken message.
+    #[cfg(feature = "mt32")]
+    fn stop_answering(&mut self) {
+        self.mt32_reply.clear();
+        self.mt32_responder = crate::mt32::reply::Responder::default();
     }
 
     /// Why the MT-32 could not be fitted, if it could not. Taken rather than
@@ -509,10 +547,31 @@ impl MidiSerialSink {
         self.mt32_roms = roms;
     }
 
-    /// Point the input at a named host endpoint, or at nothing.
+    /// Point the input at a named host endpoint, at the MT-32's own MIDI
+    /// OUT, or at nothing.
     pub fn set_input_endpoint(&mut self, endpoint: Option<&str>) {
+        #[cfg(feature = "mt32")]
+        if crate::config::midi_out_is_mt32(endpoint) {
+            // Its MIDI OUT and its MIDI IN are the same cable pair to the
+            // same module, so taking the input silences the host source.
+            self.backend.set_input(None);
+            self.mt32_input = true;
+            log::info!("midi: input -> {}", self.input_label());
+            return;
+        }
+        #[cfg(feature = "mt32")]
+        {
+            self.mt32_input = false;
+            self.stop_answering();
+        }
         self.backend.set_input(endpoint);
         log::info!("midi: input -> {}", self.input_label());
+    }
+
+    /// Whether the module's MIDI OUT is the machine's MIDI IN.
+    #[cfg(feature = "mt32")]
+    pub fn mt32_input(&self) -> bool {
+        self.mt32_input
     }
 
     /// Say what the port ended up wired to, once the output is settled.
@@ -542,6 +601,10 @@ impl MidiSerialSink {
 
     /// Current input device name, or "None".
     pub fn input_label(&self) -> String {
+        #[cfg(feature = "mt32")]
+        if self.mt32_input {
+            return MIDI_OUT_MT32_LABEL.to_string();
+        }
         self.backend
             .current_input()
             .unwrap_or_else(|| "None".to_string())
@@ -572,6 +635,14 @@ impl SerialSink for MidiSerialSink {
                 dbg.tx_bytes += 1;
             }
             mt32.write_byte(b);
+            // With its MIDI OUT wired back, a request the guest just
+            // finished is answered from the module's own memory.
+            if self.mt32_input {
+                if let Some(request) = self.mt32_responder.write_byte(b) {
+                    let reply = crate::mt32::reply::answer(mt32.synth(), request);
+                    self.mt32_reply.extend(reply);
+                }
+            }
             return;
         }
         // Map the emit clock onto host time so the byte is scheduled rather
@@ -601,6 +672,15 @@ impl SerialSink for MidiSerialSink {
     }
 
     fn read_byte(&mut self) -> Option<u8> {
+        // The module's own reply comes first: it is answering something the
+        // guest asked for, and a host source is a separate cable anyway.
+        #[cfg(feature = "mt32")]
+        if let Some(b) = self.mt32_reply.pop_front() {
+            if let Some(dbg) = &mut self.debug {
+                dbg.rx_bytes += 1;
+            }
+            return Some(b);
+        }
         let b = self.input.try_pop();
         if let Some(byte) = b {
             if let Some(dbg) = &mut self.debug {
@@ -616,6 +696,10 @@ impl SerialSink for MidiSerialSink {
     }
 
     fn has_pending_input(&self) -> bool {
+        #[cfg(feature = "mt32")]
+        if !self.mt32_reply.is_empty() {
+            return true;
+        }
         !self.input.is_empty()
     }
 

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -125,6 +125,12 @@ pub struct MidiSerialSink {
     /// keeps [`MIDI_OUT_MT32`] out of the picker.
     #[cfg(feature = "mt32")]
     mt32_roms: crate::mt32::Mt32Roms,
+    /// What the control ROM calls itself, read from the image once when the
+    /// pair is configured. The engine keeps its copy of the ROM private, so
+    /// this is read from the file, and read once: it cannot change while
+    /// the machine runs.
+    #[cfg(feature = "mt32")]
+    mt32_version: Option<String>,
     /// The fitted MT-32. Absent costs nothing: no ROMs read, no engine, and
     /// no rendering asked for. Absent while it is switched off, too -- an
     /// unpowered synth is not a quieter synth, it is no synth.
@@ -378,6 +384,8 @@ impl MidiSerialSink {
             #[cfg(feature = "mt32")]
             mt32_roms: crate::mt32::Mt32Roms::default(),
             #[cfg(feature = "mt32")]
+            mt32_version: None,
+            #[cfg(feature = "mt32")]
             mt32: None,
             #[cfg(feature = "mt32")]
             mt32_selected: false,
@@ -544,7 +552,18 @@ impl MidiSerialSink {
     /// the runtime switch both read it.
     #[cfg(feature = "mt32")]
     pub fn set_mt32_roms(&mut self, roms: crate::mt32::Mt32Roms) {
+        self.mt32_version = roms
+            .control
+            .as_deref()
+            .and_then(|path| std::fs::read(path).ok())
+            .and_then(|image| crate::mt32::rom::version_line(&image));
         self.mt32_roms = roms;
+    }
+
+    /// What the control ROM calls itself, for the panel's version screen.
+    #[cfg(feature = "mt32")]
+    pub fn mt32_version(&self) -> Option<&str> {
+        self.mt32_version.as_deref()
     }
 
     /// Point the input at a named host endpoint, at the MT-32's own MIDI

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -435,7 +435,8 @@ impl MidiSerialSink {
         self.mt32_fault = None;
         let Some((control, pcm)) = self.mt32_roms.pair() else {
             log::warn!(
-                "midi: {MIDI_OUT_MT32_LABEL} needs both ROM images;                  set [serial] mt32_control_rom and mt32_pcm_rom"
+                "midi: {MIDI_OUT_MT32_LABEL} needs both ROM images; \
+                 set [serial] mt32_control_rom and mt32_pcm_rom"
             );
             self.mt32_fault = Some("missing ROM(s)".to_string());
             return;
@@ -444,7 +445,6 @@ impl MidiSerialSink {
             Ok(device) => {
                 self.backend.set_output(None);
                 self.mt32 = Some(device);
-                self.mt32_selected = true;
             }
             Err(e) => {
                 log::warn!("midi: {MIDI_OUT_MT32_LABEL} could not be fitted: {e:#}");
@@ -624,6 +624,10 @@ impl SerialSink for MidiSerialSink {
     }
 
     fn as_midi(&mut self) -> Option<&mut MidiSerialSink> {
+        Some(self)
+    }
+
+    fn as_midi_ref(&self) -> Option<&MidiSerialSink> {
         Some(self)
     }
 

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -120,7 +120,33 @@ pub struct MidiSerialSink {
     input: InputConsumer,
     framer: MidiFramer,
     debug: Option<MidiDebug>,
+    /// Where the MT-32's ROMs are, so one can be attached and dropped while
+    /// the machine runs. Empty when none were configured, which is what
+    /// keeps [`MIDI_OUT_MT32`] out of the picker.
+    #[cfg(feature = "mt32")]
+    mt32_roms: crate::mt32::Mt32Roms,
+    /// The fitted MT-32. Absent costs nothing: no ROMs read, no engine, and
+    /// no rendering asked for. Absent while it is switched off, too -- an
+    /// unpowered synth is not a quieter synth, it is no synth.
+    #[cfg(feature = "mt32")]
+    mt32: Option<crate::mt32::Mt32Device>,
+    /// Whether the MT-32 is the chosen output, which it stays across being
+    /// switched off and on again.
+    #[cfg(feature = "mt32")]
+    mt32_selected: bool,
+    /// Why the MT-32 could not be fitted when it was last asked for, so the
+    /// window can say so rather than leaving a silent blank panel.
+    #[cfg(feature = "mt32")]
+    mt32_fault: Option<String>,
 }
+
+/// The output-device name that means the built-in MT-32 rather than a host
+/// endpoint. Shown as [`MIDI_OUT_MT32_LABEL`].
+#[cfg(feature = "mt32")]
+pub use crate::config::MIDI_OUT_MT32;
+
+/// What the MT-32 output is called anywhere a person reads it.
+pub const MIDI_OUT_MT32_LABEL: &str = "Munt MT-32";
 
 /// MIDI Active Sensing status byte.
 pub(crate) const ACTIVE_SENSE: u8 = 0xFE;
@@ -335,6 +361,14 @@ impl MidiSerialSink {
             input,
             framer: MidiFramer::default(),
             debug,
+            #[cfg(feature = "mt32")]
+            mt32_roms: crate::mt32::Mt32Roms::default(),
+            #[cfg(feature = "mt32")]
+            mt32: None,
+            #[cfg(feature = "mt32")]
+            mt32_selected: false,
+            #[cfg(feature = "mt32")]
+            mt32_fault: None,
         })
     }
 
@@ -369,10 +403,110 @@ impl MidiSerialSink {
         log::info!("midi: input -> {}", self.input_label());
     }
 
-    /// Point the output at a named host endpoint, or at nothing.
+    /// Point the output at a named host endpoint, at the built-in MT-32, or
+    /// at nothing.
+    ///
+    /// The MT-32 is fitted here and dropped again when the output moves on,
+    /// so a session that never selects one never reads a ROM or runs an
+    /// engine.
     pub fn set_output_endpoint(&mut self, endpoint: Option<&str>) {
+        #[cfg(feature = "mt32")]
+        if crate::config::midi_out_is_mt32(endpoint) {
+            self.attach_mt32();
+            return;
+        }
+        #[cfg(feature = "mt32")]
+        {
+            self.mt32 = None;
+            self.mt32_selected = false;
+        }
         self.backend.set_output(endpoint);
         log::info!("midi: output -> {}", self.output_label());
+    }
+
+    /// Fit the MT-32, leaving the host output silent: the device on the far
+    /// end of the cable is the one here.
+    #[cfg(feature = "mt32")]
+    fn attach_mt32(&mut self) {
+        if self.mt32.is_some() {
+            return;
+        }
+        self.mt32_selected = true;
+        self.mt32_fault = None;
+        let Some((control, pcm)) = self.mt32_roms.pair() else {
+            log::warn!(
+                "midi: {MIDI_OUT_MT32_LABEL} needs both ROM images;                  set [serial] mt32_control_rom and mt32_pcm_rom"
+            );
+            self.mt32_fault = Some("missing ROM(s)".to_string());
+            return;
+        };
+        match crate::mt32::Mt32Device::open(control, pcm) {
+            Ok(device) => {
+                self.backend.set_output(None);
+                self.mt32 = Some(device);
+                self.mt32_selected = true;
+            }
+            Err(e) => {
+                log::warn!("midi: {MIDI_OUT_MT32_LABEL} could not be fitted: {e:#}");
+                self.mt32_fault = Some("invalid ROM(s)".to_string());
+            }
+        }
+    }
+
+    /// Switch the fitted MT-32 off or on again, leaving it the chosen
+    /// output either way.
+    ///
+    /// Off drops the engine entirely, which is what a real one being switched
+    /// off amounts to; on builds a fresh one, so it comes up with its
+    /// power-on greeting and its defaults, exactly as the hardware does.
+    #[cfg(feature = "mt32")]
+    pub fn set_mt32_power(&mut self, on: bool) {
+        if !self.mt32_selected || on == self.mt32.is_some() {
+            return;
+        }
+        if on {
+            self.attach_mt32();
+        } else {
+            self.mt32 = None;
+            log::info!("midi: {MIDI_OUT_MT32_LABEL} switched off");
+        }
+    }
+
+    /// Why the MT-32 could not be fitted, if it could not. Taken rather than
+    /// borrowed: it is said once, not on every frame.
+    #[cfg(feature = "mt32")]
+    pub fn take_mt32_fault(&mut self) -> Option<String> {
+        self.mt32_fault.take()
+    }
+
+    /// Whether the MT-32 is the chosen output, powered or not.
+    #[cfg(feature = "mt32")]
+    pub fn mt32_selected(&self) -> bool {
+        self.mt32_selected
+    }
+
+    /// Whether an MT-32 could be selected at all.
+    #[cfg(feature = "mt32")]
+    pub fn mt32_available(&self) -> bool {
+        self.mt32_roms.configured()
+    }
+
+    /// The attached MT-32, for the front panel.
+    #[cfg(feature = "mt32")]
+    pub fn mt32(&self) -> Option<&crate::mt32::Mt32Device> {
+        self.mt32.as_ref()
+    }
+
+    #[cfg(feature = "mt32")]
+    pub fn mt32_mut(&mut self) -> Option<&mut crate::mt32::Mt32Device> {
+        self.mt32.as_mut()
+    }
+
+    /// Where the ROMs are. Set once from the configuration; the picker and
+    /// the runtime switch both read it.
+    #[cfg(feature = "mt32")]
+    pub fn set_mt32_roms(&mut self, roms: crate::mt32::Mt32Roms) {
+        self.mt32_roms = roms;
     }
 
     /// Point the input at a named host endpoint, or at nothing.
@@ -381,8 +515,26 @@ impl MidiSerialSink {
         log::info!("midi: input -> {}", self.input_label());
     }
 
+    /// Say what the port ended up wired to, once the output is settled.
+    ///
+    /// Reported here rather than by each backend, because until the MT-32
+    /// has had its chance to attach, "no host endpoint" does not yet mean
+    /// the port is inert.
+    pub fn report_wiring(&self) {
+        let (out, input) = (self.output_label(), self.input_label());
+        if out == "None" && input == "None" {
+            log::warn!("[serial] mode = midi but no endpoint is selected; MIDI is inert");
+        } else {
+            log::info!("midi: out {out}, in {input}");
+        }
+    }
+
     /// Current output device name, or "None".
     pub fn output_label(&self) -> String {
+        #[cfg(feature = "mt32")]
+        if self.mt32_selected {
+            return MIDI_OUT_MT32_LABEL.to_string();
+        }
         self.backend
             .current_output()
             .unwrap_or_else(|| "None".to_string())
@@ -397,10 +549,29 @@ impl MidiSerialSink {
 }
 
 impl SerialSink for MidiSerialSink {
+    fn next_audio_frame(&mut self) -> Option<(f32, f32)> {
+        #[cfg(feature = "mt32")]
+        if let Some(mt32) = &mut self.mt32 {
+            return Some(mt32.next_frame());
+        }
+        None
+    }
+
     fn write_byte(&mut self, b: u8, at_cck: u64) {
         // Faithful by default; only drops Active Sensing when opted in (see
         // strip_active_sense).
         if b == ACTIVE_SENSE && strip_active_sense() {
+            return;
+        }
+        // With an MT-32 attached, it is the device on the far end of the
+        // cable: the bytes go to it rather than out to the host, and no
+        // scheduling is needed because it answers in emulated time.
+        #[cfg(feature = "mt32")]
+        if let Some(mt32) = &mut self.mt32 {
+            if let Some(dbg) = &mut self.debug {
+                dbg.tx_bytes += 1;
+            }
+            mt32.write_byte(b);
             return;
         }
         // Map the emit clock onto host time so the byte is scheduled rather

--- a/src/midi/winmm.rs
+++ b/src/midi/winmm.rs
@@ -799,9 +799,6 @@ pub fn open(
         backend.open_input(id, name.clone())?;
         log::info!("midi: input connected to {name:?}");
     }
-    if backend.out.lock().unwrap().handle == 0 && backend.in_handle.is_null() {
-        log::warn!("[serial] mode = midi but no midi_out/midi_in endpoint selected; MIDI is inert");
-    }
 
     Ok(Box::new(backend))
 }

--- a/src/mt32/demo.rs
+++ b/src/mt32/demo.rs
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The demonstration songs the later control ROMs carry, and playing them.
+//!
+//! A real MT-32 plays these itself: its microcontroller runs the code in the
+//! control ROM, and that code reads the songs out of the same ROM and works
+//! the synthesis chip with them. The engine Copperline uses has no such
+//! microcontroller -- it re-implements what that code *computes* rather than
+//! running it -- so it never touches them, and keeps only the half of the
+//! image the songs are not in.
+//!
+//! The songs are still there, though, and they are ordinary MIDI. So the
+//! part the missing firmware would do is done here: read them out of the
+//! image, and play them into the engine as if a sequencer were sending
+//! them down the cable. Same as the front panel and the dump replies -- the
+//! engine synthesises, Copperline does what the firmware would.
+//!
+//! ## What is in the image
+//!
+//! Only the two-hundred-and-fifty-six-kilobit ROMs (v2.xx) carry them, in
+//! the upper half, one after another:
+//!
+//! ```text
+//!   +0x000  fourteen characters, the title, padded with spaces
+//!   +0x010  how long a tick is, counted on the unit's own timer
+//!   +0x012  the settings it opens with: reverb, rhythm kit, timbres
+//!   +0x120  the performance
+//! ```
+//!
+//! The performance is MIDI with running status, every message followed by
+//! one byte saying how many ticks to wait before the next. `FF` ends it.
+//!
+//! The tick is the unit's own timer rather than anything the song carries:
+//! the gaps between notes land on it unevenly -- thirteen ticks then
+//! fourteen, over and over -- which is what a fixed clock does to music
+//! written against a different one.
+
+/// Where the songs and the settings they want are, all read the way Munt's
+/// own player reads them (`mt32emu_qt/src/DemoPlayer.cpp`).
+const ROM_SIZE: usize = 128 * 1024;
+const SONG_REFS: usize = 0x86E0;
+const SONG_COUNT: usize = 5;
+const TIMBRE_ADDRESSES: usize = 0x8700;
+const TIMBRE_COUNT: usize = 22;
+const PATCH_TABLE_LOW: usize = 0x8800;
+const PATCH_TABLE_HIGH: usize = 0x8900;
+
+/// Inside one song.
+const TITLE: usize = 14;
+const TICK: usize = 0x10;
+const REVERB: usize = 0x12;
+/// Reverb, then how many partials each of the nine parts is promised.
+const REVERB_LEN: usize = 3 + 9;
+const RHYTHM: usize = 0x20;
+const RHYTHM_LEN: usize = 256;
+const STREAM: usize = 0x120;
+
+/// The waits are counted by a timer running at this, divided by the figure
+/// each song carries -- 6250 on every one of them, so eighty a second.
+const TIMER_HZ: f32 = 500_000.0;
+
+/// Where the settings go, as the unit addresses its own memory.
+const ADDR_RHYTHM: u32 = 0x03_0110;
+const ADDR_PATCH_LOW: u32 = 0x05_0000;
+const ADDR_PATCH_HIGH: u32 = 0x05_0200;
+const ADDR_TIMBRE: u32 = 0x08_0000;
+const ADDR_REVERB: u32 = 0x10_0001;
+const ADDR_RESET: u32 = 0x7F_0000;
+
+/// A timbre, and the patches that name them.
+const TIMBRE_COMMON: usize = 14;
+const TIMBRE_MUTE: usize = 12;
+const TIMBRE_PARTIAL: usize = 58;
+const PATCH_SIZE: usize = 8;
+const PATCH_BLOCK: usize = 32 * PATCH_SIZE;
+
+/// Ends the performance, where a wait would go.
+const END: u8 = 0xFF;
+/// Ends it where a message would: the sequencer stopping.
+const STOP: u8 = 0xFC;
+/// A wait of this is the unit's own timing byte, not a message.
+const SYNC: u8 = 0xF8;
+
+/// One message and the wait before it, in ticks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Event {
+    wait: u8,
+    message: Vec<u8>,
+}
+
+/// A demonstration song, read out of a control ROM.
+#[derive(Debug, Clone)]
+pub struct Song {
+    /// What the unit shows while it plays, as the ROM spells it.
+    pub title: String,
+    /// The settings it wants before a note of it is played: its reverb and
+    /// partial reserve, its rhythm kit, the timbres it was written with and
+    /// the patches that name them. Without these the songs that lean on
+    /// their own timbres play in whatever the unit was left in.
+    setup: Vec<u8>,
+    events: Vec<Event>,
+    seconds_per_tick: f32,
+}
+
+impl Song {
+    /// How long it runs, in seconds. Only the check against a real image
+    /// asks: the unit itself just plays until the song runs out.
+    #[cfg(test)]
+    fn seconds(&self) -> f32 {
+        let ticks: u32 = self.events.iter().map(|e| u32::from(e.wait)).sum();
+        ticks as f32 * self.seconds_per_tick
+    }
+}
+
+/// Every song a control ROM carries, in the order the ROM lists them.
+///
+/// Empty for the earlier ROMs, which are half the size and have none: the
+/// unit those came in had no demonstration to play.
+pub fn songs(image: &[u8]) -> Vec<Song> {
+    // Only the later control ROMs, which are twice the size and carry them
+    // in the half the engine does not read.
+    if image.len() != ROM_SIZE {
+        return Vec::new();
+    }
+    (0..SONG_COUNT)
+        .map(|n| {
+            // The ROM keeps a table of where they are, which is also what
+            // puts them in the order the unit numbers them.
+            let at = 2 * usize::from(u16le(image, SONG_REFS + 2 * n)?) + 0x8000;
+            read_song(image, image.get(at..)?)
+        })
+        .collect::<Option<Vec<_>>>()
+        .unwrap_or_default()
+}
+
+fn u16le(image: &[u8], at: usize) -> Option<u16> {
+    Some(u16::from_le_bytes([*image.get(at)?, *image.get(at + 1)?]))
+}
+
+use super::dt1;
+
+fn read_song(image: &[u8], song: &[u8]) -> Option<Song> {
+    let title = String::from_utf8_lossy(song.get(..TITLE)?)
+        .trim()
+        .to_string();
+    let seconds_per_tick = f32::from(u16le(song, TICK)?) / TIMER_HZ;
+
+    // Everything the unit is told before the first note.
+    let mut setup = dt1(ADDR_RESET, &[]);
+    setup.extend(dt1(ADDR_REVERB, song.get(REVERB..REVERB + REVERB_LEN)?));
+    setup.extend(dt1(ADDR_RHYTHM, song.get(RHYTHM..RHYTHM + RHYTHM_LEN)?));
+    for n in 0..TIMBRE_COUNT {
+        setup.extend(dt1(ADDR_TIMBRE + 0x200 * n as u32, &timbre(image, n)?));
+    }
+    for (address, table) in [
+        (ADDR_PATCH_LOW, PATCH_TABLE_LOW),
+        (ADDR_PATCH_HIGH, PATCH_TABLE_HIGH),
+    ] {
+        let mut patches = image.get(table..table + PATCH_BLOCK)?.to_vec();
+        // Some patches name timbre group 5, which the unit has not got;
+        // they mean the ones just loaded into its memory.
+        for patch in patches.chunks_mut(PATCH_SIZE) {
+            if patch[0] == 5 {
+                patch[0] = 2;
+            }
+        }
+        setup.extend(dt1(address, &patches));
+    }
+
+    Some(Song {
+        title,
+        setup,
+        events: read_stream(song.get(STREAM..)?),
+        seconds_per_tick,
+    })
+}
+
+/// One timbre out of the ROM: its common parameters, then four partials,
+/// skipping over the ones it has muted.
+fn timbre(image: &[u8], n: usize) -> Option<Vec<u8>> {
+    let at = usize::from(u16le(image, TIMBRE_ADDRESSES + 2 * n)?);
+    let mute = *image.get(at + TIMBRE_MUTE)?;
+    let mut out = image.get(at..at + TIMBRE_COMMON)?.to_vec();
+    let mut from = at + TIMBRE_COMMON;
+    for partial in 0..4 {
+        if partial != 0 && mute & (1 << partial) != 0 {
+            from += TIMBRE_PARTIAL;
+        }
+        out.extend_from_slice(image.get(from..from + TIMBRE_PARTIAL)?);
+    }
+    Some(out)
+}
+
+/// The performance: a wait, then a message, over and over.
+fn read_stream(at: &[u8]) -> Vec<Event> {
+    let mut events = Vec::new();
+    let mut i = 0;
+    let mut running = 0u8;
+    while let Some(&wait) = at.get(i) {
+        i += 1;
+        if wait == END {
+            break;
+        }
+        // The unit's own timing byte stands in for a message, and still
+        // takes its time: dropping it would run the song short.
+        if wait == SYNC {
+            events.push(Event {
+                wait,
+                message: Vec::new(),
+            });
+            continue;
+        }
+        let Some(&byte) = at.get(i) else { break };
+        i += 1;
+        if byte == STOP {
+            break;
+        }
+        if byte & 0xF0 == 0xF0 {
+            events.push(Event {
+                wait,
+                message: Vec::new(),
+            });
+            continue;
+        }
+        let mut message = Vec::with_capacity(3);
+        if byte & 0x80 != 0 {
+            running = byte;
+            message.push(byte);
+            let Some(&d) = at.get(i) else { break };
+            i += 1;
+            message.push(d);
+        } else if running != 0 {
+            message.push(running);
+            message.push(byte);
+        } else {
+            continue;
+        }
+        // Everything but a program change carries a second byte.
+        if running & 0xF0 != 0xC0 {
+            let Some(&d) = at.get(i) else { break };
+            i += 1;
+            message.push(d);
+        }
+        events.push(Event { wait, message });
+    }
+    events
+}
+
+/// Plays a song into the engine, a frame at a time.
+///
+/// It is driven by rendered frames rather than by the host clock, so a demo
+/// runs in emulated time like everything else: the same frame carries the
+/// same message on every run.
+#[derive(Debug)]
+pub struct Player {
+    song: Song,
+    next: usize,
+    frames_per_tick: f32,
+    in_hand: f32,
+    /// The settings, still to go out ahead of the first note.
+    setup_sent: bool,
+}
+
+impl Player {
+    /// Start `song` at the top, for an engine rendering at `sample_rate`.
+    pub fn new(song: Song, sample_rate: u32) -> Self {
+        let frames_per_tick = sample_rate as f32 * song.seconds_per_tick;
+        Self {
+            song,
+            next: 0,
+            frames_per_tick,
+            in_hand: 0.0,
+            setup_sent: false,
+        }
+    }
+
+    /// Whether the song has run out.
+    pub fn finished(&self) -> bool {
+        self.next >= self.song.events.len()
+    }
+
+    /// Append the bytes due over the next `frames` to `due`, in the order
+    /// they are due.
+    ///
+    /// Several can fall together -- a chord is a run of messages with no
+    /// wait between them -- so they land together, which is also how they
+    /// would arrive down a cable at this speed.
+    pub fn advance(&mut self, frames: usize, due: &mut Vec<u8>) {
+        if !self.setup_sent {
+            self.setup_sent = true;
+            due.extend_from_slice(&self.song.setup);
+        }
+        self.in_hand += frames as f32;
+        while let Some(event) = self.song.events.get(self.next) {
+            let wait = f32::from(event.wait) * self.frames_per_tick;
+            if wait > self.in_hand {
+                break;
+            }
+            self.in_hand -= wait;
+            due.extend_from_slice(&event.message);
+            self.next += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The songs come out of a real image: named, in the order the ROM
+    /// lists them, timed by what each carries, and with the settings they
+    /// want ahead of the first note. Roland's ROMs cannot be committed, so
+    /// this runs only where one is to hand.
+    #[test]
+    #[ignore = "needs a v2.xx control ROM in COPPERLINE_MT32_ROMS"]
+    fn the_songs_come_out_of_a_real_control_rom() {
+        let Some(dir) = std::env::var_os("COPPERLINE_MT32_ROMS").map(std::path::PathBuf::from)
+        else {
+            return;
+        };
+        let mut checked = 0;
+        for entry in std::fs::read_dir(&dir)
+            .expect("the directory opens")
+            .flatten()
+        {
+            let image = std::fs::read(entry.path()).unwrap_or_default();
+            let songs = songs(&image);
+            if songs.is_empty() {
+                continue;
+            }
+            println!("{}:", entry.file_name().to_string_lossy());
+            assert_eq!(songs.len(), SONG_COUNT);
+            // The order is the ROM's own, not the order they sit in it.
+            let names: Vec<&str> = songs.iter().map(|s| s.title.as_str()).collect();
+            assert_eq!(
+                names,
+                [
+                    "Boiler Buster",
+                    "Sinfonia 1",
+                    "Short Demo",
+                    "Adjarre",
+                    "Good Morning"
+                ]
+            );
+            for song in &songs {
+                let secs = song.seconds();
+                println!(
+                    "    {:<16} {:>5} events  {}m{:04.1}s  {} bytes of setup",
+                    song.title,
+                    song.events.len(),
+                    (secs / 60.0) as u32,
+                    secs % 60.0,
+                    song.setup.len()
+                );
+                assert!(song.events.len() > 100, "it has a performance in it");
+                assert!(
+                    (20.0..600.0).contains(&secs),
+                    "it runs for a plausible time: {secs}"
+                );
+                // Every note that starts is stopped: a misread stream would
+                // lose its place and the two would not balance.
+                let (mut on, mut off) = (0u32, 0u32);
+                for e in song.events.iter().filter(|e| !e.message.is_empty()) {
+                    match (e.message[0] & 0xF0, e.message.get(2)) {
+                        (0x90, Some(&0)) | (0x80, _) => off += 1,
+                        (0x90, _) => on += 1,
+                        _ => {}
+                    }
+                }
+                assert!(
+                    on.abs_diff(off) <= 1,
+                    "{on} notes started, {off} stopped -- the stream was misread"
+                );
+                // The setup is whole messages, every one of them a DT1.
+                assert_eq!(song.setup[0], 0xF0);
+                assert_eq!(*song.setup.last().unwrap(), 0xF7);
+                assert_eq!(
+                    song.setup.iter().filter(|&&b| b == 0xF0).count(),
+                    song.setup.iter().filter(|&&b| b == 0xF7).count(),
+                    "every setting is a closed message"
+                );
+            }
+            checked += songs.len();
+        }
+        if checked == 0 {
+            println!(
+                "no v2.xx control ROM in {}, nothing to check",
+                dir.display()
+            );
+        }
+    }
+
+    #[test]
+    fn an_image_with_no_songs_in_it_has_none() {
+        assert!(songs(&[0u8; 0x400]).is_empty(), "far too small");
+        assert!(songs(&[]).is_empty(), "no image at all");
+    }
+
+    #[test]
+    fn a_message_is_built_with_its_address_and_checksum() {
+        let msg = dt1(0x10_0001, &[1, 2, 3]);
+        assert_eq!(msg[..5], [0xF0, 0x41, 0x10, 0x16, 0x12]);
+        assert_eq!(msg[5..8], [0x10, 0x00, 0x01], "the address it is sent to");
+        assert_eq!(*msg.last().unwrap(), 0xF7);
+        let sum: u32 = msg[5..msg.len() - 1].iter().map(|&b| u32::from(b)).sum();
+        assert_eq!(sum % 128, 0, "it adds up");
+    }
+
+    /// A wait comes before its message, and the two ways a song can end are
+    /// both taken.
+    #[test]
+    fn the_performance_reads_wait_then_message() {
+        // wait 0, note on; wait 24, running status; wait 12, program
+        // change (one byte); then the end.
+        let stream = [0, 0x91, 0x3C, 0x64, 24, 0x3E, 0x64, 12, 0xC1, 0x05, END];
+        let events = read_stream(&stream);
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0],
+            Event {
+                wait: 0,
+                message: vec![0x91, 0x3C, 0x64]
+            }
+        );
+        assert_eq!(
+            events[1],
+            Event {
+                wait: 24,
+                message: vec![0x91, 0x3E, 0x64]
+            },
+            "carrying on with the last status"
+        );
+        assert_eq!(
+            events[2],
+            Event {
+                wait: 12,
+                message: vec![0xC1, 0x05]
+            },
+            "a program change carries one byte"
+        );
+        // A Stop ends it just as surely.
+        assert_eq!(read_stream(&[0, 0x91, 0x3C, 0x64, 5, STOP]).len(), 1);
+        // The timing byte carries no message but still takes its time.
+        let timed = read_stream(&[SYNC, SYNC, 0, 0x91, 0x3C, 0x64, END]);
+        assert_eq!(timed.len(), 3);
+        assert!(timed[0].message.is_empty(), "nothing to play, only to wait");
+        assert_eq!(timed[2].message, vec![0x91, 0x3C, 0x64]);
+    }
+}

--- a/src/mt32/ffi.rs
+++ b/src/mt32/ffi.rs
@@ -93,5 +93,6 @@ unsafe extern "C" {
         narrow_lcd: u8,
     ) -> u8;
     pub fn mt32emu_set_main_display_mode(context: Context);
+    pub fn mt32emu_read_memory(context: Context, addr: u32, len: u32, data: *mut u8);
     pub fn mt32emu_play_sysex_now(context: Context, sysex: *const u8, len: u32);
 }

--- a/src/mt32/ffi.rs
+++ b/src/mt32/ffi.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The slice of Munt's C API that Copperline calls.
+//!
+//! Declared by hand rather than generated: it is a dozen functions that have
+//! been stable across the library's 2.x line, and the C API is the one the
+//! library versions deliberately (see `vendor/munt/src/c_interface`).
+
+use std::ffi::{c_char, c_double, c_void};
+
+/// Opaque engine instance.
+pub type Context = *mut c_void;
+
+/// `mt32emu_return_code` values Copperline checks.
+pub const RC_OK: i32 = 0;
+pub const RC_ADDED_CONTROL_ROM: i32 = 1;
+pub const RC_ADDED_PCM_ROM: i32 = 2;
+
+/// `MT32EMU_REPORT_HANDLER_VERSION_0`: the interface declared below.
+pub const REPORT_HANDLER_VERSION_0: u32 = 0;
+
+/// `MT32EMU_AOM_ACCURATE`: the analogue output stage modelled properly,
+/// which is what the resampler then works from.
+pub const AOM_ACCURATE: i32 = 2;
+
+/// `mt32emu_report_handler_i`, a union of one pointer per interface version.
+#[repr(C)]
+pub struct ReportHandler {
+    pub v0: *const ReportHandlerV0,
+}
+
+/// `MT32EMU_REPORT_HANDLER_I_V0`, in the order the header declares it. The
+/// order is the ABI, so a member added upstream must be added here too.
+///
+/// Supplying this is what stops the engine printing its own diagnostics to
+/// stderr: with a null `printDebug` it falls back to its built-in one.
+#[repr(C)]
+pub struct ReportHandlerV0 {
+    pub get_version_id: Option<unsafe extern "C" fn(ReportHandler) -> u32>,
+    /// The engine's own running commentary. The third argument is a C
+    /// `va_list`; see `copperline_mt32_print_debug`.
+    pub print_debug: Option<unsafe extern "C" fn(*mut c_void, *const c_char, *mut c_void)>,
+    pub on_error_control_rom: Option<unsafe extern "C" fn(*mut c_void)>,
+    pub on_error_pcm_rom: Option<unsafe extern "C" fn(*mut c_void)>,
+    pub show_lcd_message: Option<unsafe extern "C" fn(*mut c_void, *const c_char)>,
+    pub on_midi_message_played: Option<unsafe extern "C" fn(*mut c_void)>,
+    pub on_midi_queue_overflow: Option<unsafe extern "C" fn(*mut c_void) -> u8>,
+    pub on_midi_system_realtime: Option<unsafe extern "C" fn(*mut c_void, u8)>,
+    pub on_device_reset: Option<unsafe extern "C" fn(*mut c_void)>,
+    pub on_device_reconfig: Option<unsafe extern "C" fn(*mut c_void)>,
+    pub on_new_reverb_mode: Option<unsafe extern "C" fn(*mut c_void, u8)>,
+    pub on_new_reverb_time: Option<unsafe extern "C" fn(*mut c_void, u8)>,
+    pub on_new_reverb_level: Option<unsafe extern "C" fn(*mut c_void, u8)>,
+    pub on_poly_state_changed: Option<unsafe extern "C" fn(*mut c_void, u8)>,
+    pub on_program_changed:
+        Option<unsafe extern "C" fn(*mut c_void, u8, *const c_char, *const c_char)>,
+}
+
+unsafe extern "C" {
+    /// The report-handler entry, implemented in C (`print_debug.cpp`)
+    /// because it receives a `va_list`. Rust only ever takes its address:
+    /// the third argument is declared as a pointer for want of a type, and
+    /// nothing here calls it or looks at it.
+    pub fn copperline_mt32_print_debug(
+        instance_data: *mut c_void,
+        fmt: *const c_char,
+        args: *mut c_void,
+    );
+
+    pub fn mt32emu_get_library_version_string() -> *const c_char;
+
+    pub fn mt32emu_create_context(
+        report_handler: ReportHandler,
+        instance_data: *mut c_void,
+    ) -> Context;
+    pub fn mt32emu_free_context(context: Context);
+
+    pub fn mt32emu_add_rom_file(context: Context, filename: *const c_char) -> i32;
+
+    pub fn mt32emu_set_stereo_output_samplerate(context: Context, samplerate: c_double);
+    pub fn mt32emu_set_analog_output_mode(context: Context, mode: i32);
+    pub fn mt32emu_get_actual_stereo_output_samplerate(context: Context) -> u32;
+
+    pub fn mt32emu_open_synth(context: Context) -> i32;
+    pub fn mt32emu_close_synth(context: Context);
+
+    pub fn mt32emu_parse_stream(context: Context, stream: *const u8, length: u32);
+    pub fn mt32emu_render_bit16s(context: Context, stream: *mut i16, len: u32);
+
+    pub fn mt32emu_get_display_state(
+        context: Context,
+        target_buffer: *mut c_char,
+        narrow_lcd: u8,
+    ) -> u8;
+    pub fn mt32emu_set_main_display_mode(context: Context);
+    pub fn mt32emu_play_sysex_now(context: Context, sysex: *const u8, len: u32);
+}

--- a/src/mt32/mod.rs
+++ b/src/mt32/mod.rs
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The MT-32, emulated by Munt's mt32emu (see `vendor/munt`).
+//!
+//! Paula's serial bytes go straight into the engine and stereo frames come
+//! back at the mixer's rate, so nothing passes through the host's MIDI stack:
+//! no IAC bus on macOS, no loopMIDI on Windows, no ALSA sequencer client.
+//!
+//! The engine needs two ROM images, a control ROM and a PCM ROM, which are
+//! not Copperline's to ship and so are the user's to supply. Without them the
+//! machine still runs; it simply has nothing on the far end of the cable.
+
+use anyhow::{anyhow, bail, Result};
+use std::ffi::{c_char, CString};
+use std::path::Path;
+
+mod ffi;
+pub mod reply;
+mod sink;
+
+pub use sink::{Mt32Device, Mt32Roms};
+
+/// What the engine puts in a part's place on the main screen while that
+/// part is sounding. On the hardware it is a character the display
+/// controller is given a shape of its own, a filled cell, so it is drawn as
+/// one rather than looked for in a font.
+pub const ACTIVE_PART: char = '\u{1}';
+
+/// How wide the emulated LCD is, in characters. The panel is drawn to this.
+pub const LCD_WIDTH: usize = 20;
+
+/// Whether to log everything the MT-32 does, the engine's own running
+/// commentary included (`COPPERLINE_MT32_DEBUG=1`).
+///
+/// Off, the engine says nothing. It is chatty about MIDI it cannot make
+/// sense of, which on a serial line carrying whatever a guest emits is
+/// ordinary and says nothing about Copperline.
+pub(crate) fn debug_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| crate::envcfg::flag("COPPERLINE_MT32_DEBUG"))
+}
+
+/// Which interface version this handler implements.
+///
+/// The engine calls this one without checking it for null, unlike every
+/// other callback here, so it has to be filled in.
+unsafe extern "C" fn get_version_id(_handler: ffi::ReportHandler) -> u32 {
+    ffi::REPORT_HANDLER_VERSION_0
+}
+
+/// Takes the engine's diagnostics, already formatted by the C shim, and
+/// puts them in the log rather than on the console.
+///
+/// # Safety
+/// Called from `print_debug.cpp` with a null-terminated string.
+#[no_mangle]
+pub unsafe extern "C" fn copperline_mt32_log(text: *const c_char) {
+    if !debug_enabled() || text.is_null() {
+        return;
+    }
+    // SAFETY: null-checked, and the shim passes a terminated buffer.
+    let line = unsafe { std::ffi::CStr::from_ptr(text) }.to_string_lossy();
+    log::debug!("mt32: {}", line.trim_end());
+}
+
+/// The handler the engine reports through. Only `print_debug` is taken:
+/// everything else Copperline wants to know it asks for directly, and a
+/// callback left null keeps the engine's own default.
+static REPORT_HANDLER_V0: ffi::ReportHandlerV0 = ffi::ReportHandlerV0 {
+    get_version_id: Some(get_version_id),
+    print_debug: Some(ffi::copperline_mt32_print_debug),
+    on_error_control_rom: None,
+    on_error_pcm_rom: None,
+    show_lcd_message: None,
+    on_midi_message_played: None,
+    on_midi_queue_overflow: None,
+    on_midi_system_realtime: None,
+    on_device_reset: None,
+    on_device_reconfig: None,
+    on_new_reverb_mode: None,
+    on_new_reverb_time: None,
+    on_new_reverb_level: None,
+    on_poly_state_changed: None,
+    on_program_changed: None,
+};
+
+/// A running MT-32. Dropping it closes the synth and frees the engine.
+pub struct Mt32Synth {
+    context: ffi::Context,
+    /// What the engine reported as its output rate once opened. Asked for
+    /// [`crate::audio::MIX_SAMPLE_RATE`]; kept so a mismatch is visible
+    /// rather than silently detuning everything.
+    sample_rate: u32,
+    /// The engine's samples land here on the way to the mixer's frames,
+    /// kept so rendering does not allocate once a block.
+    scratch: Vec<i16>,
+}
+
+// The engine keeps all its state behind the context pointer and Copperline
+// drives it from one thread (the emulator loop, like the rest of the mixer).
+unsafe impl Send for Mt32Synth {}
+
+impl Mt32Synth {
+    /// Fit an MT-32 with the given ROM images and start it at `sample_rate`.
+    ///
+    /// The engine identifies a ROM by its size and SHA-1 rather than its
+    /// name, so a mislabelled or truncated file is rejected here rather than
+    /// producing a synth that sounds subtly wrong.
+    pub fn open(control_rom: &Path, pcm_rom: &Path, sample_rate: u32) -> Result<Self> {
+        let handler = ffi::ReportHandler {
+            v0: &raw const REPORT_HANDLER_V0,
+        };
+        // SAFETY: the handler is static and outlives the context; its
+        // unfilled callbacks are null, which the engine checks for.
+        let context = unsafe { ffi::mt32emu_create_context(handler, std::ptr::null_mut()) };
+        if context.is_null() {
+            bail!("could not create the MT-32 engine context");
+        }
+        // One owner from here on: every early return below drops `synth`,
+        // which closes and frees the context exactly once. (`close` on a
+        // synth that never opened is a no-op the engine guards.)
+        let mut synth = Self {
+            context,
+            sample_rate: 0,
+            scratch: Vec::new(),
+        };
+
+        synth.add_rom(control_rom, "control")?;
+        synth.add_rom(pcm_rom, "PCM")?;
+
+        // SAFETY: `context` is live, and both calls only record intent for
+        // the `open` below.
+        unsafe {
+            ffi::mt32emu_set_stereo_output_samplerate(context, f64::from(sample_rate));
+            // The analogue output stage the LA32 fed on real hardware. The
+            // accurate model is what the engine resamples from.
+            ffi::mt32emu_set_analog_output_mode(context, ffi::AOM_ACCURATE);
+        }
+
+        // SAFETY: `context` is live and has both ROMs.
+        let rc = unsafe { ffi::mt32emu_open_synth(context) };
+        if rc != ffi::RC_OK {
+            bail!("the MT-32 engine refused to start (code {rc})");
+        }
+        // SAFETY: the synth is open.
+        synth.sample_rate = unsafe { ffi::mt32emu_get_actual_stereo_output_samplerate(context) };
+        Ok(synth)
+    }
+
+    fn add_rom(&self, path: &Path, what: &str) -> Result<()> {
+        let text = path
+            .to_str()
+            .ok_or_else(|| anyhow!("the {what} ROM path is not valid UTF-8: {}", path.display()))?;
+        let c_path = CString::new(text)?;
+        // SAFETY: `context` is live and `c_path` outlives the call.
+        let rc = unsafe { ffi::mt32emu_add_rom_file(self.context, c_path.as_ptr()) };
+        match rc {
+            ffi::RC_ADDED_CONTROL_ROM | ffi::RC_ADDED_PCM_ROM => Ok(()),
+            _ => Err(anyhow!(
+                "{} is not a ROM the MT-32 engine recognises (code {rc}); \
+                 it identifies ROMs by content, not by name",
+                path.display()
+            )),
+        }
+    }
+
+    /// The rate the engine is actually producing at.
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    /// Feed raw MIDI bytes, exactly as they arrived on Paula's serial line.
+    /// Running status and split messages are the engine's problem, which is
+    /// what its stream parser is for.
+    pub fn parse(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        if debug_enabled() {
+            log::debug!("mt32: in {bytes:02X?}");
+        }
+        // SAFETY: `context` is live and the slice is valid for the call.
+        unsafe {
+            ffi::mt32emu_parse_stream(self.context, bytes.as_ptr(), bytes.len() as u32);
+        }
+    }
+
+    /// Render `frames.len()` stereo frames, normalised for the mixer.
+    pub fn render(&mut self, frames: &mut [(f32, f32)]) {
+        if frames.is_empty() {
+            return;
+        }
+        self.scratch.resize(frames.len() * 2, 0);
+        // SAFETY: `context` is live and `scratch` holds two samples per frame,
+        // which is what the engine writes.
+        unsafe {
+            ffi::mt32emu_render_bit16s(
+                self.context,
+                self.scratch.as_mut_ptr(),
+                frames.len() as u32,
+            );
+        }
+        for (frame, pair) in frames.iter_mut().zip(self.scratch.chunks_exact(2)) {
+            *frame = (f32::from(pair[0]) / 32768.0, f32::from(pair[1]) / 32768.0);
+        }
+    }
+
+    /// What the LCD reads and whether the MIDI MESSAGE lamp is lit.
+    ///
+    /// Both come from the engine, which draws the text out of the control
+    /// ROM: the greeting it powers up with, the timbre names it shows on a
+    /// program change, whatever a program puts there over SysEx, and its
+    /// own checksum errors.
+    pub fn display(&self) -> (String, bool) {
+        // The engine documents this as needing room for 20 characters and a
+        // terminator.
+        let mut buffer = [0i8; LCD_WIDTH + 1];
+        // SAFETY: `context` is live and the buffer is the documented size.
+        let led = unsafe {
+            ffi::mt32emu_get_display_state(self.context, buffer.as_mut_ptr().cast::<c_char>(), 0)
+        };
+        // The ROM writes ASCII (plus the filled-cell mark), so the bytes
+        // are characters as they stand.
+        let text = buffer
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8 as char)
+            .collect();
+        (text, led != 0)
+    }
+
+    /// Write into the synth's memory the way the front panel does, as a
+    /// DT1 message.
+    ///
+    /// The panel on the hardware edits the same patch and system memory that
+    /// arrives over SysEx, so driving it this way is what the buttons do --
+    /// and the engine answers by updating its display, exactly as it would
+    /// for a program change from the guest.
+    ///
+    /// `addr` is written as the manual prints it, a byte per pair of hex
+    /// digits, which is what [`addr`] holds and what goes on the wire.
+    pub fn write_memory(&mut self, addr: u32, data: &[u8]) {
+        let msg = dt1(addr, data);
+        if debug_enabled() {
+            log::debug!("mt32: write {addr:06X} <- {data:02X?}");
+        }
+        // SAFETY: `context` is live and the message outlives the call.
+        unsafe {
+            ffi::mt32emu_play_sysex_now(self.context, msg.as_ptr(), msg.len() as u32);
+        }
+    }
+
+    /// Read the synth's memory back, for the dump a librarian asks for.
+    ///
+    /// `addr` is written as the manual prints it, the same way [`addr`] and
+    /// [`write_memory`] take one. False means no memory lives there and
+    /// there is nothing to answer with: the engine leaves the buffer alone
+    /// for an address it does not recognise, which the fill makes visible --
+    /// a byte it did write is seven-bit, so a whole block still reading `FF`
+    /// is one it never touched.
+    ///
+    /// [`write_memory`]: Self::write_memory
+    pub fn read_memory(&self, addr: u32, out: &mut [u8]) -> bool {
+        out.fill(0xFF);
+        // The engine addresses its memory as a flat seven-bit count, which
+        // is what it converts an incoming message's address bytes to.
+        let flat = reply::linear(addr);
+        // SAFETY: `context` is live and the buffer is valid for `out.len()`.
+        unsafe {
+            ffi::mt32emu_read_memory(self.context, flat, out.len() as u32, out.as_mut_ptr());
+        }
+        if out.iter().all(|&b| b == 0xFF) {
+            if debug_enabled() {
+                log::debug!("mt32: read {addr:06X} -- no memory there");
+            }
+            return false;
+        }
+        // Seven bits per byte, so the reply cannot carry a value that would
+        // read as the end of the message.
+        for b in out.iter_mut() {
+            *b &= 0x7F;
+        }
+        if debug_enabled() {
+            log::debug!("mt32: read {addr:06X} -> {} bytes", out.len());
+        }
+        true
+    }
+
+    /// Return the LCD to its main screen, as the Master Volume button does.
+    pub fn show_main_display(&mut self) {
+        if debug_enabled() {
+            log::debug!("mt32: display -> main");
+        }
+        // SAFETY: `context` is live.
+        unsafe { ffi::mt32emu_set_main_display_mode(self.context) };
+    }
+}
+
+impl Drop for Mt32Synth {
+    fn drop(&mut self) {
+        // SAFETY: `context` was created by the engine and is closed once.
+        unsafe {
+            ffi::mt32emu_close_synth(self.context);
+            ffi::mt32emu_free_context(self.context);
+        }
+    }
+}
+
+impl std::fmt::Debug for Mt32Synth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mt32Synth")
+            .field("sample_rate", &self.sample_rate)
+            .finish_non_exhaustive()
+    }
+}
+
+/// One DT1 message -- `F0 41 10 16 12 <addr> <data> <checksum> F7` -- with
+/// `addr` written as the manual prints it, a byte per pair of hex digits.
+/// Everything Copperline writes into the module is built here.
+pub(crate) fn dt1(addr: u32, data: &[u8]) -> Vec<u8> {
+    const HEADER: usize = 5;
+    let mut msg = Vec::with_capacity(HEADER + 3 + data.len() + 2);
+    msg.extend_from_slice(&[0xF0, 0x41, 0x10, 0x16, 0x12]);
+    msg.extend_from_slice(&addr.to_be_bytes()[1..]);
+    msg.extend_from_slice(data);
+    // Everything from the address on adds up to a multiple of 128.
+    let sum: u32 = msg[HEADER..].iter().map(|&b| u32::from(b) & 0x7F).sum();
+    msg.push(((128 - sum % 128) % 128) as u8);
+    msg.push(0xF7);
+    msg
+}
+
+/// Where the panel writes. Addresses are seven bits per byte.
+pub mod addr {
+    /// The system area, in the order the MT-32 lays it out: master tune,
+    /// then the three reverb parameters, then the partial reserve and
+    /// channel tables, then master volume.
+    pub const MASTER_TUNE: u32 = 0x10_0000;
+    pub const REVERB_MODE: u32 = 0x10_0001;
+    /// The nine parts' MIDI channels, 0-16 each (16 being off).
+    pub const CHAN_ASSIGN: u32 = 0x10_000D;
+    /// The system area's master volume, 0-100.
+    pub const MASTER_VOLUME: u32 = 0x10_0016;
+    /// A part's patch: timbre group, then timbre number, then (eight bytes
+    /// in) its output level. Nine parts, sixteen bytes apart.
+    pub const PATCH_TEMP: u32 = 0x03_0000;
+    pub const PATCH_STRIDE: u32 = 0x10;
+    pub const PATCH_TIMBRE_GROUP: u32 = 0;
+    pub const PATCH_TIMBRE_NUMBER: u32 = 1;
+    pub const PATCH_OUTPUT_LEVEL: u32 = 8;
+
+    /// The address of `field` within part `n`'s patch.
+    pub fn patch(n: usize, field: u32) -> u32 {
+        PATCH_TEMP + n as u32 * PATCH_STRIDE + field
+    }
+}
+
+/// The engine's own version string, for the About panel and the log.
+pub(crate) fn engine_version() -> String {
+    // SAFETY: the engine returns a static, null-terminated string.
+    let ptr = unsafe { ffi::mt32emu_get_library_version_string() };
+    if ptr.is_null() {
+        return String::new();
+    }
+    // SAFETY: null-checked above, and the string is static.
+    unsafe { std::ffi::CStr::from_ptr(ptr) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/mt32/mod.rs
+++ b/src/mt32/mod.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 mod ffi;
 pub mod reply;
+pub mod rom;
 mod sink;
 
 pub use sink::{Mt32Device, Mt32Roms};

--- a/src/mt32/mod.rs
+++ b/src/mt32/mod.rs
@@ -11,7 +11,7 @@
 //! machine still runs; it simply has nothing on the far end of the cable.
 
 use anyhow::{anyhow, bail, Result};
-use std::ffi::{c_char, CString};
+use std::ffi::{c_char, c_void, CString};
 use std::path::Path;
 
 pub mod demo;
@@ -65,15 +65,34 @@ pub unsafe extern "C" fn copperline_mt32_log(text: *const c_char) {
     log::debug!("mt32: {}", line.trim_end());
 }
 
-/// The handler the engine reports through. Only `print_debug` is taken:
-/// everything else Copperline wants to know it asks for directly, and a
-/// callback left null keeps the engine's own default.
+/// What a program wrote to the module's display.
+///
+/// The engine's own handler prints this to the console, where it arrives
+/// unstamped and unprefixed among Copperline's log lines. Taking the
+/// callback puts it in the log instead, so everything the module says
+/// reads the same way.
+///
+/// # Safety
+/// Called by the engine with a null-terminated string.
+unsafe extern "C" fn show_lcd_message(_instance: *mut c_void, text: *const c_char) {
+    if text.is_null() {
+        return;
+    }
+    // SAFETY: null-checked, and the engine passes a terminated buffer.
+    let line = unsafe { std::ffi::CStr::from_ptr(text) }.to_string_lossy();
+    log::info!("mt32: display {:?}", line.trim());
+}
+
+/// The handler the engine reports through. Only the display and
+/// `print_debug` are taken: everything else Copperline wants to know it
+/// asks for directly, and a callback left null keeps the engine's own
+/// default.
 static REPORT_HANDLER_V0: ffi::ReportHandlerV0 = ffi::ReportHandlerV0 {
     get_version_id: Some(get_version_id),
     print_debug: Some(ffi::copperline_mt32_print_debug),
     on_error_control_rom: None,
     on_error_pcm_rom: None,
-    show_lcd_message: None,
+    show_lcd_message: Some(show_lcd_message),
     on_midi_message_played: None,
     on_midi_queue_overflow: None,
     on_midi_system_realtime: None,

--- a/src/mt32/mod.rs
+++ b/src/mt32/mod.rs
@@ -14,6 +14,7 @@ use anyhow::{anyhow, bail, Result};
 use std::ffi::{c_char, CString};
 use std::path::Path;
 
+pub mod demo;
 mod ffi;
 pub mod reply;
 pub mod rom;

--- a/src/mt32/print_debug.cpp
+++ b/src/mt32/print_debug.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// The engine reports its diagnostics through a callback taking a C
+// `va_list`. Rust has no stable type for one, and its shape differs by
+// target -- a pointer on Windows and Apple platforms, an array that decays
+// to one on x86-64 Linux, and a struct passed by value on AArch64 Linux --
+// so a Rust declaration that guessed would be wrong somewhere.
+//
+// The formatting therefore happens here, where the compiler knows the ABI,
+// and Rust is handed a finished string.
+
+#include <cstdarg>
+#include <cstdio>
+
+extern "C" {
+
+// Implemented in Rust: takes the formatted line.
+void copperline_mt32_log(const char *text);
+
+// Installed in the engine's report handler; see src/mt32/mod.rs.
+void copperline_mt32_print_debug(void *instance_data, const char *fmt, va_list args) {
+	(void) instance_data;
+	char buf[512];
+	int written = vsnprintf(buf, sizeof buf, fmt, args);
+	if (written > 0) {
+		copperline_mt32_log(buf);
+	}
+}
+
+}

--- a/src/mt32/reply.rs
+++ b/src/mt32/reply.rs
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! What the MT-32 sends back down its MIDI OUT.
+//!
+//! The module has no keyboard, so everything on its MIDI OUT is an answer to
+//! a request: a librarian or editor sends an RQ1 asking for a stretch of
+//! memory, and the module returns it as one or more DT1 blocks. That round
+//! trip is the whole reason a patch editor needs a MIDI IN back to the
+//! Amiga.
+//!
+//! The synthesis engine holds the memory but does not answer for it -- its
+//! `Synth::readSysex` is unimplemented -- so the reply is assembled here from
+//! what the engine will hand over, in the same frame format Copperline
+//! already uses to write to it.
+
+use super::Mt32Synth;
+
+/// What an exclusive message opens with, after `F0`: the manufacturer ID,
+/// then the device number, then the MT-32's model ID.
+const MAKER_ID: u8 = 0x41;
+const MODEL_MT32: u8 = 0x16;
+/// Command bytes: request one, data one.
+const CMD_RQ1: u8 = 0x11;
+const CMD_DT1: u8 = 0x12;
+
+/// Data bytes per reply block. A dump larger than this comes back as several
+/// DT1 messages, as it does from the hardware, so a receiver sees frames of
+/// a size it is built for rather than one enormous one.
+const BLOCK_BYTES: usize = 256;
+
+/// Longest dump that will be answered, 64 KB: comfortably past every area
+/// the module has, and short enough that a request asking for the whole
+/// three-byte address space cannot size the reply.
+const MAX_DUMP_BYTES: u32 = 0x10000;
+
+/// The checksum: the seven-bit two's complement of the sum, so that the
+/// address, the data and the checksum together come to a multiple of 128.
+fn checksum(bytes: &[u8]) -> u8 {
+    let sum: u32 = bytes.iter().map(|&b| u32::from(b) & 0x7F).sum();
+    ((128 - (sum % 128)) % 128) as u8
+}
+
+/// An address as its three seven-bit bytes.
+fn address_bytes(addr: u32) -> [u8; 3] {
+    [
+        ((addr >> 14) & 0x7F) as u8,
+        ((addr >> 7) & 0x7F) as u8,
+        (addr & 0x7F) as u8,
+    ]
+}
+
+/// The engine's flat address for one written the way the manual prints it,
+/// a byte per pair of hex digits (`0x10_0016` is the bytes `10 00 16`).
+///
+/// [`super::addr`] is written that way because that is how it reaches the
+/// engine -- as the three address bytes of a message -- and this is the same
+/// conversion the engine applies on the way in.
+pub fn linear(packed: u32) -> u32 {
+    ((packed & 0x7F_0000) >> 2) | ((packed & 0x7F00) >> 1) | (packed & 0x7F)
+}
+
+/// The address three seven-bit bytes stand for.
+fn address_value(bytes: &[u8]) -> u32 {
+    (u32::from(bytes[0] & 0x7F) << 14)
+        | (u32::from(bytes[1] & 0x7F) << 7)
+        | u32::from(bytes[2] & 0x7F)
+}
+
+/// The address as the manual prints it, a byte per pair of hex digits --
+/// what [`super::addr`] holds, and what [`Mt32Synth::read_memory`] takes.
+fn printed(bytes: [u8; 3]) -> u32 {
+    (u32::from(bytes[0]) << 16) | (u32::from(bytes[1]) << 8) | u32::from(bytes[2])
+}
+
+/// One DT1 message carrying `data` at `addr`.
+fn data_block(device: u8, addr: [u8; 3], data: &[u8]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(10 + data.len());
+    msg.extend_from_slice(&[0xF0, MAKER_ID, device, MODEL_MT32, CMD_DT1]);
+    msg.extend_from_slice(&addr);
+    msg.extend_from_slice(data);
+    let sum = checksum(&msg[5..]);
+    msg.push(sum);
+    msg.push(0xF7);
+    msg
+}
+
+/// A dump request the module recognised: where to read and how much.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Request {
+    device: u8,
+    addr: u32,
+    len: u32,
+}
+
+/// Read an RQ1 out of one complete exclusive message, `F0` to `F7`.
+///
+/// Anything that is not a dump request for this model -- a DT1 going the
+/// other way, another maker's message, a truncated or mis-summed one -- is
+/// not answered, which is what the hardware does with them too.
+fn parse_request(msg: &[u8]) -> Option<Request> {
+    // F0, maker, device, model, command, 3 address, 3 size, checksum, F7.
+    if msg.len() != 13 || msg[0] != 0xF0 || *msg.last()? != 0xF7 {
+        return None;
+    }
+    if msg[1] != MAKER_ID || msg[3] != MODEL_MT32 || msg[4] != CMD_RQ1 {
+        return None;
+    }
+    let body = &msg[5..11];
+    if checksum(body) != msg[11] {
+        return None;
+    }
+    let len = address_value(&body[3..6]);
+    if len == 0 || len > MAX_DUMP_BYTES {
+        return None;
+    }
+    Some(Request {
+        device: msg[2],
+        addr: address_value(&body[0..3]),
+        len,
+    })
+}
+
+/// The reply to one request, as the bytes to put on the wire.
+pub fn answer(synth: &Mt32Synth, request: Request) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut addr = request.addr;
+    let mut left = request.len as usize;
+    let mut buf = vec![0u8; BLOCK_BYTES];
+    while left > 0 {
+        let take = left.min(BLOCK_BYTES);
+        let block = &mut buf[..take];
+        // The wire counts addresses seven bits to the byte, so a block
+        // advances by its own length; the module is asked in the form it
+        // prints them.
+        let bytes = address_bytes(addr);
+        if !synth.read_memory(printed(bytes), block) {
+            // No such region. The hardware answers a bad address with
+            // silence rather than with a block of nothing.
+            break;
+        }
+        out.extend_from_slice(&data_block(request.device, bytes, block));
+        addr += take as u32;
+        left -= take;
+    }
+    out
+}
+
+/// Watches what goes to the MT-32 and produces what comes back.
+///
+/// Exclusive messages arrive a byte at a time from Paula and may be split
+/// across writes, so the message is gathered here before it is read. Only
+/// exclusive traffic is collected: everything else the guest sends is a
+/// channel message the module never answers.
+#[derive(Debug, Default)]
+pub struct Responder {
+    /// The exclusive message being gathered, `F0` onwards.
+    pending: Vec<u8>,
+}
+
+/// Longest exclusive message gathered before giving up on it. Comfortably
+/// past the largest DT1 a guest sends, and short enough that a stream that
+/// never delivers its `F7` cannot grow without bound.
+const MAX_MESSAGE_BYTES: usize = 1024;
+
+impl Responder {
+    /// Take a byte on its way to the module, and report the request it
+    /// completed, if it completed one. [`answer`] turns that into the bytes
+    /// to hand back to the guest.
+    pub fn write_byte(&mut self, b: u8) -> Option<Request> {
+        match b {
+            0xF0 => {
+                self.pending.clear();
+                self.pending.push(b);
+            }
+            0xF7 => {
+                if self.pending.is_empty() {
+                    return None;
+                }
+                self.pending.push(b);
+                let msg = std::mem::take(&mut self.pending);
+                return parse_request(&msg);
+            }
+            // A realtime byte may interrupt an exclusive message without
+            // ending it, so it passes through and the message goes on.
+            0xF8..=0xFF => {}
+            // Any other status byte abandons the message: the guest has
+            // moved on to something else and the `F7` is never coming.
+            0x80..=0xEF => self.pending.clear(),
+            _ => {
+                if !self.pending.is_empty() {
+                    if self.pending.len() >= MAX_MESSAGE_BYTES {
+                        self.pending.clear();
+                    } else {
+                        self.pending.push(b);
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `F0 41 10 16 11 <addr> <size> <checksum> F7`.
+    fn request_bytes(addr: u32, len: u32) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&address_bytes(addr));
+        body.extend_from_slice(&address_bytes(len));
+        let mut msg = vec![0xF0, MAKER_ID, 0x10, MODEL_MT32, CMD_RQ1];
+        msg.extend_from_slice(&body);
+        msg.push(checksum(&body));
+        msg.push(0xF7);
+        msg
+    }
+
+    #[test]
+    fn a_request_is_read_back_out_of_its_bytes() {
+        let msg = request_bytes(linear(super::super::addr::PATCH_TEMP), 16);
+        assert_eq!(
+            parse_request(&msg),
+            Some(Request {
+                device: 0x10,
+                addr: linear(super::super::addr::PATCH_TEMP),
+                len: 16,
+            })
+        );
+    }
+
+    #[test]
+    fn a_request_that_does_not_add_up_is_not_answered() {
+        let mut msg = request_bytes(linear(super::super::addr::PATCH_TEMP), 16);
+        let last = msg.len() - 2;
+        msg[last] ^= 0x01;
+        assert_eq!(parse_request(&msg), None);
+    }
+
+    #[test]
+    fn other_makers_and_the_other_direction_are_left_alone() {
+        // A different maker's ID.
+        let mut other = request_bytes(linear(super::super::addr::PATCH_TEMP), 16);
+        other[1] = 0x43;
+        assert_eq!(parse_request(&other), None);
+
+        // A DT1 going to the module, not a request coming out of it.
+        let mut write = request_bytes(linear(super::super::addr::PATCH_TEMP), 16);
+        write[4] = CMD_DT1;
+        assert_eq!(parse_request(&write), None);
+    }
+
+    #[test]
+    fn an_absurd_length_is_refused() {
+        assert_eq!(parse_request(&request_bytes(0, MAX_DUMP_BYTES + 1)), None);
+        assert_eq!(parse_request(&request_bytes(0, 0)), None);
+    }
+
+    #[test]
+    fn a_block_carries_its_address_and_adds_up() {
+        let block = data_block(0x10, address_bytes(linear(0x03_0000)), &[1, 2, 3]);
+        assert_eq!(block[..5], [0xF0, MAKER_ID, 0x10, MODEL_MT32, CMD_DT1]);
+        assert_eq!(block[5..8], [0x03, 0x00, 0x00]);
+        assert_eq!(block[8..11], [1, 2, 3]);
+        assert_eq!(*block.last().unwrap(), 0xF7);
+        // Address, data and checksum together are a multiple of 128.
+        let sum: u32 = block[5..block.len() - 1]
+            .iter()
+            .map(|&b| u32::from(b))
+            .sum();
+        assert_eq!(sum % 128, 0);
+    }
+
+    #[test]
+    fn a_seven_bit_address_survives_the_round_trip() {
+        for addr in [0, 0xC000, 0x40016, 0x1F_FFFF] {
+            assert_eq!(address_value(&address_bytes(addr)), addr);
+        }
+    }
+
+    #[test]
+    fn the_manual_s_addresses_convert_to_the_engine_s() {
+        // System area, master volume: bytes 10 00 16.
+        assert_eq!(linear(0x10_0016), (0x10 << 14) | 0x16);
+        // Patch temporary area: bytes 03 00 00.
+        assert_eq!(linear(0x03_0000), 0x03 << 14);
+        assert_eq!(address_bytes(linear(0x10_0016)), [0x10, 0x00, 0x16]);
+        // And back again, which is the form the engine is asked in.
+        assert_eq!(printed(address_bytes(linear(0x10_0016))), 0x10_0016);
+    }
+
+    /// Feed a whole message in and report what it asked for.
+    fn feed(responder: &mut Responder, bytes: &[u8]) -> Option<Request> {
+        let mut request = None;
+        for &b in bytes {
+            if let Some(r) = responder.write_byte(b) {
+                request = Some(r);
+            }
+        }
+        request
+    }
+
+    #[test]
+    fn only_exclusive_traffic_is_gathered() {
+        let mut responder = Responder::default();
+        // Note on, note off: nothing to answer, nothing kept.
+        assert!(feed(&mut responder, &[0x91, 0x3C, 0x40, 0x81, 0x3C, 0x00]).is_none());
+        assert!(responder.pending.is_empty());
+    }
+
+    #[test]
+    fn a_request_split_across_writes_still_arrives() {
+        let msg = request_bytes(linear(super::super::addr::MASTER_VOLUME), 1);
+        let mut responder = Responder::default();
+        // A byte at a time is how it comes off Paula's serial line.
+        assert!(feed(&mut responder, &msg[..4]).is_none());
+        assert!(feed(&mut responder, &msg[4..]).is_some());
+    }
+
+    #[test]
+    fn a_clock_byte_through_the_middle_does_not_break_it() {
+        let msg = request_bytes(linear(super::super::addr::MASTER_VOLUME), 1);
+        let mut responder = Responder::default();
+        let mut with_clock = msg[..6].to_vec();
+        with_clock.push(0xF8);
+        with_clock.extend_from_slice(&msg[6..]);
+        assert_eq!(feed(&mut responder, &with_clock), parse_request(&msg));
+    }
+
+    #[test]
+    fn a_status_byte_through_the_middle_abandons_the_message() {
+        let msg = request_bytes(linear(super::super::addr::MASTER_VOLUME), 1);
+        let mut responder = Responder::default();
+        let mut interrupted = msg[..6].to_vec();
+        // A note on: the guest has moved on, and the F7 is never coming.
+        interrupted.extend_from_slice(&[0x91, 0x3C, 0x40]);
+        interrupted.extend_from_slice(&msg[6..]);
+        assert_eq!(feed(&mut responder, &interrupted), None);
+        assert!(responder.pending.is_empty());
+
+        // And the next whole message is still read normally.
+        assert!(feed(&mut responder, &msg).is_some());
+    }
+
+    #[test]
+    fn a_message_that_never_ends_does_not_grow_without_bound() {
+        let mut responder = Responder::default();
+        responder.write_byte(0xF0);
+        for _ in 0..MAX_MESSAGE_BYTES * 3 {
+            responder.write_byte(0x00);
+            assert!(responder.pending.len() <= MAX_MESSAGE_BYTES);
+        }
+    }
+}

--- a/src/mt32/rom.rs
+++ b/src/mt32/rom.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! What Copperline reads out of the control ROM for itself.
+//!
+//! The synthesis engine keeps its own copy of the parts it needs and hands
+//! none of it back, so anything the panel wants to show about the image is
+//! read from the file here. That is not a limitation worked around: the ROM
+//! is on disk and Copperline put it there, so reading it is the direct way
+//! round rather than the long one.
+
+/// How wide the display is, and so how long the fields below are: the unit
+/// writes them straight to the LCD, so they are already exactly one line.
+const LINE: usize = super::LCD_WIDTH;
+
+/// The version and date the control ROM names itself by.
+///
+/// Every image carries it as a ready-made display line -- `MT-32 v2.07
+/// 90-05-23` on the later ROMs, `ver1.07 10 Oct, 87` on the earlier ones,
+/// `CM32/LAPC1.02 891205` on a CM-32L -- so it is found rather than built:
+/// the first twenty printable characters that read as a version.
+///
+/// `None` for an image with no such line, which is what a display that
+/// cannot answer the question shows nothing for.
+pub fn version_line(image: &[u8]) -> Option<String> {
+    image
+        .windows(LINE)
+        .find(|w| w.iter().all(|&b| (0x20..0x7F).contains(&b)) && reads_as_version(w))
+        .map(|w| String::from_utf8_lossy(w).trim().to_string())
+}
+
+/// Whether a run of characters carries a version field: a figure, a point,
+/// then two more, which is how every one of them is written. `X` counts as
+/// a figure -- the unreleased ROMs carry `verX.XX`, the field there and the
+/// number never filled in.
+fn reads_as_version(w: &[u8]) -> bool {
+    let figure = |b: u8| b.is_ascii_digit() || b.eq_ignore_ascii_case(&b'X');
+    w.windows(4)
+        .any(|q| figure(q[0]) && q[1] == b'.' && figure(q[2]) && figure(q[3]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_version_line_is_found_where_the_rom_writes_one() {
+        let mut image = vec![0u8; 0x400];
+        image[0x100..0x114].copy_from_slice(b"MT-32 v2.07 90-05-23");
+        assert_eq!(
+            version_line(&image).as_deref(),
+            Some("MT-32 v2.07 90-05-23")
+        );
+    }
+
+    #[test]
+    fn the_earlier_wording_is_found_too_and_comes_back_trimmed() {
+        let mut image = vec![0u8; 0x400];
+        image[0x80..0x94].copy_from_slice(b" ver1.07 10 Oct, 87 ");
+        assert_eq!(version_line(&image).as_deref(), Some("ver1.07 10 Oct, 87"));
+    }
+
+    #[test]
+    fn an_unreleased_rom_with_its_number_left_blank_still_answers() {
+        let mut image = vec![0u8; 0x400];
+        image[0x80..0x94].copy_from_slice(b"verX.XX  30 Sep, 88 ");
+        assert_eq!(version_line(&image).as_deref(), Some("verX.XX  30 Sep, 88"));
+    }
+
+    #[test]
+    fn text_without_a_version_in_it_is_not_mistaken_for_one() {
+        let mut image = vec![0u8; 0x400];
+        // Twenty printable characters, but nothing that reads as a version.
+        image[0x40..0x54].copy_from_slice(b"MIDI Verify Error   ");
+        assert_eq!(version_line(&image), None);
+    }
+
+    /// Every control ROM on the runner answers, and answers something that
+    /// fits the display. Roland's images cannot be committed, so this looks
+    /// for whatever pair the ROM-backed tests already use.
+    #[test]
+    #[ignore = "needs control ROMs in COPPERLINE_MT32_ROMS"]
+    fn the_real_images_all_name_themselves() {
+        let Some(dir) = std::env::var_os("COPPERLINE_MT32_ROMS").map(std::path::PathBuf::from)
+        else {
+            return;
+        };
+        let mut seen = 0;
+        for entry in std::fs::read_dir(&dir)
+            .expect("the ROM directory opens")
+            .flatten()
+        {
+            let path = entry.path();
+            let name = path.to_string_lossy().to_lowercase();
+            // Whatever the pair is called: a PCM image carries samples and
+            // no such line, and a half image is one side of a control ROM.
+            if !name.ends_with(".rom") || name.contains("pcm") {
+                continue;
+            }
+            let image = std::fs::read(&path).expect("the image reads");
+            if image.len() < 0x10000 {
+                continue;
+            }
+            let line = version_line(&image);
+            println!(
+                "  {:<26} {line:?}",
+                path.file_name().unwrap().to_string_lossy()
+            );
+            let line = line.expect("a control ROM names itself");
+            assert!(line.len() <= super::LINE, "fits the display: {line:?}");
+            seen += 1;
+        }
+        assert!(seen > 0, "no control ROMs found in {}", dir.display());
+    }
+
+    #[test]
+    fn an_image_with_nothing_to_say_says_nothing() {
+        assert_eq!(version_line(&[0u8; 0x400]), None);
+        assert_eq!(version_line(&[]), None);
+    }
+}

--- a/src/mt32/sink.rs
+++ b/src/mt32/sink.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The MT-32 as one of the devices Paula's MIDI output can be pointed at.
+//!
+//! A host endpoint makes its noise on the host; this one makes it here, so
+//! the device is both where the bytes go and where the mixer pulls frames
+//! from. It exists only while it is the selected output: nothing is loaded,
+//! allocated or rendered until then, and picking another device drops it.
+
+use super::Mt32Synth;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+/// How many frames the engine is asked for at a time.
+const BLOCK_FRAMES: usize = 256;
+
+/// An MT-32 attached to the MIDI output.
+pub struct Mt32Device {
+    synth: Mt32Synth,
+    /// The block last rendered, and how much of it the mixer has taken.
+    block: Vec<(f32, f32)>,
+    played: usize,
+    /// Bytes written since the last block. The engine's own parser wants
+    /// them in order and copes with running status and split messages, so
+    /// they are handed over whole rather than framed here.
+    pending: Vec<u8>,
+}
+
+impl Mt32Device {
+    /// Fit an MT-32 with the given ROM pair.
+    pub fn open(control_rom: &Path, pcm_rom: &Path) -> Result<Self> {
+        let synth = Mt32Synth::open(control_rom, pcm_rom, crate::audio::MIX_SAMPLE_RATE)?;
+        log::info!(
+            "midi: Munt MT-32 attached (engine {}, {} Hz)",
+            super::engine_version(),
+            synth.sample_rate()
+        );
+        Ok(Self {
+            synth,
+            block: vec![(0.0, 0.0); BLOCK_FRAMES],
+            played: BLOCK_FRAMES,
+            pending: Vec::new(),
+        })
+    }
+
+    /// Take a byte off the serial line.
+    pub fn write_byte(&mut self, b: u8) {
+        self.pending.push(b);
+    }
+
+    /// The next frame, rendering a fresh block when the last one runs out.
+    ///
+    /// Crossing into the engine once a sample would cost more than the
+    /// synthesis, so it is asked for a block at a time. Everything written
+    /// since the last block lands before the next is rendered, and both
+    /// sides advance on emulated time, so a run is reproducible: the same
+    /// bytes land on the same sample.
+    pub fn next_frame(&mut self) -> (f32, f32) {
+        if self.played == self.block.len() {
+            if !self.pending.is_empty() {
+                let Self { synth, pending, .. } = self;
+                synth.parse(pending);
+                pending.clear();
+            }
+            self.synth.render(&mut self.block);
+            self.played = 0;
+        }
+        let frame = self.block[self.played];
+        self.played += 1;
+        frame
+    }
+
+    /// The synth, for the front panel and the display.
+    pub fn synth(&self) -> &Mt32Synth {
+        &self.synth
+    }
+
+    pub fn synth_mut(&mut self) -> &mut Mt32Synth {
+        &mut self.synth
+    }
+}
+
+impl std::fmt::Debug for Mt32Device {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mt32Device")
+            .field("pending", &self.pending.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Where the MT-32's ROM pair lives, carried so the device can be attached
+/// and dropped at runtime without going back to the configuration.
+#[derive(Debug, Clone, Default)]
+pub struct Mt32Roms {
+    pub control: Option<PathBuf>,
+    pub pcm: Option<PathBuf>,
+}
+
+impl Mt32Roms {
+    /// Both images, when both are configured. One on its own is not enough
+    /// to fit an MT-32 -- the engine needs the pair.
+    pub fn pair(&self) -> Option<(&Path, &Path)> {
+        Some((self.control.as_deref()?, self.pcm.as_deref()?))
+    }
+
+    /// Whether an MT-32 could be attached, so a picker knows to offer one.
+    pub fn configured(&self) -> bool {
+        self.pair().is_some()
+    }
+}

--- a/src/mt32/sink.rs
+++ b/src/mt32/sink.rs
@@ -24,6 +24,8 @@ pub struct Mt32Device {
     /// them in order and copes with running status and split messages, so
     /// they are handed over whole rather than framed here.
     pending: Vec<u8>,
+    /// A song out of the control ROM, playing itself into the engine.
+    demo: Option<super::demo::Player>,
 }
 
 impl Mt32Device {
@@ -40,6 +42,7 @@ impl Mt32Device {
             block: vec![(0.0, 0.0); BLOCK_FRAMES],
             played: BLOCK_FRAMES,
             pending: Vec::new(),
+            demo: None,
         })
     }
 
@@ -57,6 +60,13 @@ impl Mt32Device {
     /// bytes land on the same sample.
     pub fn next_frame(&mut self) -> (f32, f32) {
         if self.played == self.block.len() {
+            // A demo plays by rendered frame, so it keeps emulated time.
+            if let Some(demo) = &mut self.demo {
+                demo.advance(BLOCK_FRAMES, &mut self.pending);
+                if demo.finished() {
+                    self.demo = None;
+                }
+            }
             if !self.pending.is_empty() {
                 let Self { synth, pending, .. } = self;
                 synth.parse(pending);
@@ -68,6 +78,16 @@ impl Mt32Device {
         let frame = self.block[self.played];
         self.played += 1;
         frame
+    }
+
+    /// Play one of the ROM's own songs, or stop.
+    pub fn play_demo(&mut self, song: Option<super::demo::Song>) {
+        self.demo = song.map(|s| super::demo::Player::new(s, self.synth.sample_rate()));
+    }
+
+    /// Whether a song is still running, so the chain knows to move on.
+    pub fn demo_playing(&self) -> bool {
+        self.demo.is_some()
     }
 
     /// The synth, for the front panel and the display.

--- a/src/mt32/tests.rs
+++ b/src/mt32/tests.rs
@@ -442,3 +442,129 @@ fn the_lamp_lights_for_exclusive_messages() {
     }
     assert!(!synth.display().1, "out again afterwards");
 }
+
+/// Render a demo song through the engine and write it out, so it can be
+/// listened to rather than only counted.
+///
+/// The songs are Roland's, so this is not a check that runs anywhere: it is
+/// how the reading of them was confirmed by ear. `COPPERLINE_MT32_DEMO_WAV`
+/// says where to put the audio, and `COPPERLINE_MT32_DEMO` which song.
+#[test]
+#[ignore = "writes audio; needs a v2.xx ROM pair and COPPERLINE_MT32_DEMO_WAV"]
+fn a_demo_song_renders_to_audio() {
+    let (Some(dir), Some(out)) = (
+        std::env::var_os("COPPERLINE_MT32_ROMS").map(std::path::PathBuf::from),
+        std::env::var_os("COPPERLINE_MT32_DEMO_WAV").map(std::path::PathBuf::from),
+    ) else {
+        return;
+    };
+    let control = std::env::var("COPPERLINE_MT32_CONTROL")
+        .unwrap_or_else(|_| "mt32_ctrl_2_07.rom".to_string());
+    let pcm = std::env::var("COPPERLINE_MT32_PCM").unwrap_or_else(|_| "mt32_pcm.rom".to_string());
+    let which: usize = std::env::var("COPPERLINE_MT32_DEMO")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let seconds: f32 = std::env::var("COPPERLINE_MT32_DEMO_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30.0);
+
+    let image = std::fs::read(dir.join(&control)).expect("the control ROM reads");
+    let mut songs = crate::mt32::demo::songs(&image);
+    assert!(!songs.is_empty(), "{control} carries no demo songs");
+    assert!(which < songs.len(), "only {} songs", songs.len());
+    let song = songs.remove(which);
+    println!("rendering {:?} ({:.0}s of it)", song.title, seconds);
+
+    let rate = crate::audio::MIX_SAMPLE_RATE;
+    let mut synth =
+        Mt32Synth::open(&dir.join(&control), &dir.join(&pcm), rate).expect("the pair opens");
+    let mut player = crate::mt32::demo::Player::new(song, rate);
+
+    const BLOCK: usize = 256;
+    let mut block = vec![(0.0f32, 0.0f32); BLOCK];
+    let mut pcm_out: Vec<i16> = Vec::new();
+    let blocks = (seconds * rate as f32 / BLOCK as f32) as usize;
+    let mut due = Vec::new();
+    for _ in 0..blocks {
+        player.advance(BLOCK, &mut due);
+        synth.parse(&due);
+        due.clear();
+        synth.render(&mut block);
+        for &(l, r) in &block {
+            pcm_out.push((l.clamp(-1.0, 1.0) * 32767.0) as i16);
+            pcm_out.push((r.clamp(-1.0, 1.0) * 32767.0) as i16);
+        }
+    }
+    write_wav(&out, rate, &pcm_out).expect("the audio writes");
+    let loud = pcm_out.iter().filter(|s| s.abs() > 600).count();
+    println!(
+        "wrote {} ({} frames, {loud} of them audible)",
+        out.display(),
+        pcm_out.len() / 2
+    );
+    assert!(
+        loud > pcm_out.len() / 20,
+        "it made sound: only {loud} audible samples"
+    );
+}
+
+/// A plain 16-bit stereo WAV, which is all the check above needs.
+#[cfg(test)]
+fn write_wav(path: &std::path::Path, rate: u32, samples: &[i16]) -> std::io::Result<()> {
+    use std::io::Write;
+    let bytes = samples.len() as u32 * 2;
+    let mut f = std::io::BufWriter::new(std::fs::File::create(path)?);
+    f.write_all(b"RIFF")?;
+    f.write_all(&(36 + bytes).to_le_bytes())?;
+    f.write_all(b"WAVEfmt ")?;
+    f.write_all(&16u32.to_le_bytes())?;
+    f.write_all(&1u16.to_le_bytes())?;
+    f.write_all(&2u16.to_le_bytes())?;
+    f.write_all(&rate.to_le_bytes())?;
+    f.write_all(&(rate * 4).to_le_bytes())?;
+    f.write_all(&4u16.to_le_bytes())?;
+    f.write_all(&16u16.to_le_bytes())?;
+    f.write_all(b"data")?;
+    f.write_all(&bytes.to_le_bytes())?;
+    for s in samples {
+        f.write_all(&s.to_le_bytes())?;
+    }
+    Ok(())
+}
+
+/// The demo reaches the mixer: asking the sink for a song makes the frames
+/// Paula pulls carry it.
+#[test]
+#[ignore = "needs a v2.xx ROM pair in COPPERLINE_MT32_ROMS"]
+fn a_demo_plays_out_through_the_mixer() {
+    let Some(dir) = rom_dir() else {
+        return;
+    };
+    let control = dir.join("mt32_ctrl_2_07.rom");
+    if !control.exists() {
+        return;
+    }
+    let mut sink = crate::midi::MidiSerialSink::open(None, None).expect("a sink opens");
+    sink.set_mt32_roms(crate::mt32::Mt32Roms {
+        control: Some(control),
+        pcm: Some(dir.join("mt32_pcm.rom")),
+    });
+    sink.set_output_endpoint(Some(crate::config::MIDI_OUT_MT32));
+    assert!(sink.mt32().is_some(), "the module is fitted");
+
+    let title = sink.play_mt32_demo(2).expect("a song starts");
+    assert_eq!(title, "Short Demo", "the dial's third song");
+
+    // Pull frames the way the mixer does, and listen for it.
+    use crate::serial::SerialSink;
+    let mut peak = 0.0f32;
+    for _ in 0..crate::audio::MIX_SAMPLE_RATE * 4 {
+        if let Some((l, r)) = sink.next_audio_frame() {
+            peak = peak.max(l.abs()).max(r.abs());
+        }
+    }
+    assert!(peak > 0.01, "the demo is audible: peak {peak}");
+    println!("Short Demo reached the mixer, peak {peak:.3}");
+}

--- a/src/mt32/tests.rs
+++ b/src/mt32/tests.rs
@@ -317,6 +317,94 @@ fn the_engine_reports_through_the_log() {
     );
 }
 
+/// The round trip a patch editor depends on: it asks for a stretch of the
+/// module's memory and gets it back, with what it wrote in it.
+///
+/// The engine itself never answers a request -- its `readSysex` is
+/// unimplemented -- so this is the whole of the module's MIDI OUT.
+#[test]
+#[ignore = "needs an MT-32 ROM pair in COPPERLINE_MT32_ROMS"]
+fn the_module_answers_a_request_for_its_memory() {
+    let Some(mut synth) = open_synth() else {
+        return;
+    };
+    // Turn the volume down to something no default would land on.
+    synth.write_memory(addr::MASTER_VOLUME, &[42]);
+
+    let request = {
+        let mut body = vec![0x10, 0x00, 0x16, 0x00, 0x00, 0x01];
+        let sum: u32 = body.iter().map(|&b| u32::from(b)).sum();
+        let mut msg = vec![0xF0, 0x41, 0x10, 0x16, 0x11];
+        msg.append(&mut body);
+        msg.push(((128 - (sum % 128)) % 128) as u8);
+        msg.push(0xF7);
+        msg
+    };
+
+    let mut responder = reply::Responder::default();
+    let mut answered = None;
+    for b in request {
+        if let Some(r) = responder.write_byte(b) {
+            answered = Some(reply::answer(&synth, r));
+        }
+    }
+    let reply = answered.expect("the request was recognised");
+
+    // F0 41 10 16 12 <10 00 16> <volume> <checksum> F7
+    assert_eq!(reply.len(), 11, "one block: {reply:02X?}");
+    assert_eq!(reply[..5], [0xF0, 0x41, 0x10, 0x16, 0x12]);
+    assert_eq!(reply[5..8], [0x10, 0x00, 0x16], "the address it asked for");
+    assert_eq!(reply[8], 42, "the volume that was written");
+    assert_eq!(*reply.last().unwrap(), 0xF7);
+    let sum: u32 = reply[5..reply.len() - 1]
+        .iter()
+        .map(|&b| u32::from(b))
+        .sum();
+    assert_eq!(sum % 128, 0, "the checksum");
+}
+
+/// A dump longer than one block comes back as several, each carrying its own
+/// address, the way the hardware splits one.
+#[test]
+#[ignore = "needs an MT-32 ROM pair in COPPERLINE_MT32_ROMS"]
+fn a_long_dump_comes_back_in_blocks() {
+    let Some(synth) = open_synth() else {
+        return;
+    };
+    // The whole patch temporary area: eight parts of sixteen bytes each,
+    // asked for in one go.
+    let want = 8 * 16;
+    let request = {
+        let addr = [0x03, 0x00, 0x00];
+        let size = [0x00, 0x01, 0x00];
+        let mut body = addr.to_vec();
+        body.extend_from_slice(&size);
+        let sum: u32 = body.iter().map(|&b| u32::from(b)).sum();
+        let mut msg = vec![0xF0, 0x41, 0x10, 0x16, 0x11];
+        msg.append(&mut body);
+        msg.push(((128 - (sum % 128)) % 128) as u8);
+        msg.push(0xF7);
+        msg
+    };
+    assert_eq!(want, 128, "the size bytes above ask for 0x80");
+
+    let mut responder = reply::Responder::default();
+    let mut reply = Vec::new();
+    for b in request {
+        if let Some(r) = responder.write_byte(b) {
+            reply = reply::answer(&synth, r);
+        }
+    }
+    assert!(!reply.is_empty(), "the area answered");
+    // Every message is well formed and every data byte fits in seven bits,
+    // so nothing in the dump can read as the end of a message.
+    assert_eq!(reply[0], 0xF0);
+    assert_eq!(*reply.last().unwrap(), 0xF7);
+    let ends = reply.iter().filter(|&&b| b == 0xF7).count();
+    let starts = reply.iter().filter(|&&b| b == 0xF0).count();
+    assert_eq!(starts, ends, "every message is closed: {starts} vs {ends}");
+}
+
 /// The MIDI MESSAGE lamp answers exclusive messages, not just notes.
 ///
 /// A librarian talks to the module entirely in SysEx, so a lamp that only

--- a/src/mt32/tests.rs
+++ b/src/mt32/tests.rs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Engine tests. The ROMs cannot be committed, so the ones that need a
+//! real MT-32 image are `#[ignore]` and look for the pair under
+//! `COPPERLINE_MT32_ROMS`.
+
+use super::*;
+
+/// Where a local pair of ROMs lives, if the runner has one.
+fn rom_dir() -> Option<std::path::PathBuf> {
+    let dir = std::env::var_os("COPPERLINE_MT32_ROMS")?;
+    let dir = std::path::PathBuf::from(dir);
+    dir.is_dir().then_some(dir)
+}
+
+fn open_synth() -> Option<Mt32Synth> {
+    let dir = rom_dir()?;
+    Some(
+        Mt32Synth::open(
+            &dir.join("MT32_CONTROL.ROM"),
+            &dir.join("MT32_PCM.ROM"),
+            crate::audio::MIX_SAMPLE_RATE,
+        )
+        .expect("the ROM pair opens"),
+    )
+}
+
+/// The engine is linked in and answers, with or without ROMs.
+#[test]
+fn the_engine_reports_its_version() {
+    let version = engine_version();
+    assert!(
+        version.starts_with('2'),
+        "unexpected mt32emu version {version:?}"
+    );
+}
+
+/// A file that is not a ROM is refused, rather than opening a synth that
+/// would sound wrong. The engine identifies ROMs by content.
+#[test]
+fn a_file_that_is_not_a_rom_is_refused() {
+    let dir = std::env::temp_dir().join("copperline-mt32-not-a-rom");
+    std::fs::write(&dir, b"this is not an MT-32 ROM").expect("write scratch file");
+    let err = Mt32Synth::open(&dir, &dir, crate::audio::MIX_SAMPLE_RATE)
+        .expect_err("a text file is not a ROM");
+    assert!(err.to_string().contains("recognises"), "{err}");
+    let _ = std::fs::remove_file(&dir);
+}
+
+/// The engine renders at the mixer's rate, so its frames drop straight into
+/// the mix beside Paula's without any rate matching.
+#[test]
+#[ignore]
+fn the_engine_runs_at_the_mixer_rate() {
+    let Some(synth) = open_synth() else {
+        eprintln!("set COPPERLINE_MT32_ROMS to run this");
+        return;
+    };
+    assert_eq!(synth.sample_rate(), crate::audio::MIX_SAMPLE_RATE);
+}
+
+/// The LCD reads out of the control ROM: the greeting on power-up, and the
+/// timbre the engine names when a program change arrives.
+#[test]
+#[ignore]
+fn the_lcd_shows_what_the_rom_says() {
+    let Some(mut synth) = open_synth() else {
+        eprintln!("set COPPERLINE_MT32_ROMS to run this");
+        return;
+    };
+
+    // The power-up greeting, straight from the control ROM.
+    let (greeting, _) = synth.display();
+    assert!(
+        !greeting.trim().is_empty(),
+        "the LCD should power up with the ROM's greeting"
+    );
+    assert!(
+        greeting.chars().count() <= LCD_WIDTH,
+        "the LCD is {LCD_WIDTH} characters, got {:?}",
+        greeting
+    );
+
+    // A program change names the timbre it selected. Part 1 answers on MIDI
+    // channel 2 -- the MT-32 assigns its parts to channels 2..9 -- and the
+    // engine updates the display while rendering, so give it a second of
+    // frames to get there.
+    let mut frames = vec![(0.0f32, 0.0f32); crate::audio::MIX_SAMPLE_RATE as usize];
+    synth.parse(&[0xC1, 0x30]);
+    synth.render(&mut frames);
+    let (after, led) = synth.display();
+    eprintln!("LCD power-up : {greeting:?}");
+    eprintln!("LCD prog chg : {after:?}  (MIDI MESSAGE lamp: {led})");
+    assert_ne!(
+        after.trim(),
+        greeting.trim(),
+        "a program change should put the timbre name on the LCD"
+    );
+
+    // Master Volume returns it to the main screen.
+    synth.show_main_display();
+    synth.render(&mut frames);
+    let (main, _) = synth.display();
+    eprintln!("LCD main     : {main:?}");
+    assert_ne!(
+        main.trim(),
+        after.trim(),
+        "Master Volume shows the main screen"
+    );
+}
+
+/// A held note makes sound, and silence renders silent -- so the frames the
+/// mixer will be adding are real.
+#[test]
+#[ignore]
+fn a_note_makes_sound_and_silence_does_not() {
+    let Some(mut synth) = open_synth() else {
+        eprintln!("set COPPERLINE_MT32_ROMS to run this");
+        return;
+    };
+    let peak = |frames: &[(f32, f32)]| {
+        frames
+            .iter()
+            .map(|(l, r)| l.abs().max(r.abs()))
+            .fold(0.0f32, f32::max)
+    };
+
+    let mut frames = vec![(0.0f32, 0.0f32); 8192];
+    synth.render(&mut frames);
+    assert_eq!(peak(&frames), 0.0, "an idle MT-32 is silent");
+
+    // Note on, middle C, part 1 -- which listens on MIDI channel 2.
+    synth.parse(&[0x91, 0x3C, 0x64]);
+    synth.render(&mut frames);
+    assert!(peak(&frames) > 0.01, "a held note should be audible");
+}
+
+/// The whole path: bytes onto Paula's serial port, an MT-32 answering them,
+/// and its voice arriving in the mix beside the Amiga's own -- which is what
+/// puts it in a WAV capture and a video recording without either knowing.
+#[test]
+#[ignore]
+fn the_synth_reaches_the_mixer_beside_paula() {
+    use crate::chipset::paula::Paula;
+
+    let Some(dir) = rom_dir() else {
+        eprintln!("set COPPERLINE_MT32_ROMS to run this");
+        return;
+    };
+    // A MIDI sink with the ROMs configured but nothing attached: this is
+    // what a session that never selects an MT-32 costs.
+    let mut sink = crate::midi::MidiSerialSink::open(None, None).expect("a MIDI sink opens");
+    sink.set_mt32_roms(crate::mt32::Mt32Roms {
+        control: Some(dir.join("MT32_CONTROL.ROM")),
+        pcm: Some(dir.join("MT32_PCM.ROM")),
+    });
+    assert!(sink.mt32_available(), "the ROM pair makes one selectable");
+    assert!(
+        sink.mt32().is_none(),
+        "nothing is fitted until it is picked"
+    );
+
+    let frames = std::rc::Rc::new(std::cell::RefCell::new(Vec::<(f32, f32)>::new()));
+    let audio = CollectFrames {
+        frames: std::rc::Rc::clone(&frames),
+    };
+    let mut paula = Paula::new(Box::new(sink), Box::new(audio));
+    paula.set_led_filter_guest(false);
+    let ram = vec![0u8; 64];
+
+    let peak = |f: &[(f32, f32)]| {
+        f.iter()
+            .map(|(l, r)| l.abs().max(r.abs()))
+            .fold(0.0f32, f32::max)
+    };
+
+    // Nothing attached: the mixer asks once, is told there is nothing here,
+    // and stops asking.
+    paula.tick_audio(20_000, 0, &ram);
+    assert_eq!(
+        peak(&frames.borrow()),
+        0.0,
+        "an unselected MT-32 costs nothing"
+    );
+
+    // Select it, which is what the menu does.
+    paula
+        .serial
+        .as_midi()
+        .expect("a MIDI sink")
+        .set_output_endpoint(Some(crate::config::MIDI_OUT_MT32));
+    paula.rearm_synth_audio();
+    frames.borrow_mut().clear();
+
+    // Attached but silent: an MT-32 sitting there is not a noise source.
+    paula.tick_audio(40_000, 0, &ram);
+    assert_eq!(peak(&frames.borrow()), 0.0, "an idle MT-32 adds nothing");
+
+    // Note on, part 1 (MIDI channel 2), straight down the serial line.
+    for byte in [0x91u8, 0x3C, 0x64] {
+        paula.serial.write_byte(byte, 0);
+    }
+    frames.borrow_mut().clear();
+    paula.tick_audio(200_000, 0, &ram);
+    assert!(
+        peak(&frames.borrow()) > 0.01,
+        "the MT-32's voice should arrive in the mix"
+    );
+}
+
+/// Collects mixed stereo frames, so a test can look at what the host would
+/// have heard.
+struct CollectFrames {
+    frames: std::rc::Rc<std::cell::RefCell<Vec<(f32, f32)>>>,
+}
+
+impl crate::audio::AudioSink for CollectFrames {
+    fn push(&mut self, left: f32, right: f32) {
+        self.frames.borrow_mut().push((left, right));
+    }
+    fn flush(&mut self) {}
+}
+
+/// Master Volume is a volume: turning it down makes the same note quieter,
+/// so the panel's dial is moving air rather than only text.
+#[test]
+#[ignore]
+fn master_volume_changes_how_loud_it_is() {
+    let Some(mut synth) = open_synth() else {
+        eprintln!("set COPPERLINE_MT32_ROMS to run this");
+        return;
+    };
+    let peak = |frames: &[(f32, f32)]| {
+        frames
+            .iter()
+            .map(|(l, r)| l.abs().max(r.abs()))
+            .fold(0.0f32, f32::max)
+    };
+    let mut frames = vec![(0.0f32, 0.0f32); 16384];
+
+    // Full volume, a held note.
+    synth.write_memory(addr::MASTER_VOLUME, &[100]);
+    synth.parse(&[0x91, 0x3C, 0x64]);
+    synth.render(&mut frames);
+    let loud = peak(&frames);
+    assert!(loud > 0.01, "the note should be audible at full volume");
+
+    // The same note, turned right down.
+    synth.parse(&[0x81, 0x3C, 0x40]);
+    synth.render(&mut frames);
+    synth.write_memory(addr::MASTER_VOLUME, &[10]);
+    synth.parse(&[0x91, 0x3C, 0x64]);
+    synth.render(&mut frames);
+    let quiet = peak(&frames);
+
+    assert!(
+        quiet < loud / 2.0,
+        "turning master volume down should make it quieter: {loud} -> {quiet}"
+    );
+}
+
+/// Records what is logged, so a test can see where the engine's commentary
+/// went. Installed once; `log` allows only one logger per process.
+struct Capture;
+
+static CAPTURED: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+impl log::Log for Capture {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        if let Ok(mut lines) = CAPTURED.lock() {
+            lines.push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+/// The engine's own commentary reaches the log rather than the console, and
+/// arrives formatted -- which is the part worth proving, since its arguments
+/// come through a C `va_list`.
+#[test]
+#[ignore]
+fn the_engine_reports_through_the_log() {
+    let Some(mut synth) = open_synth() else {
+        eprintln!("set COPPERLINE_MT32_ROMS to run this");
+        return;
+    };
+    if !debug_enabled() {
+        eprintln!("set COPPERLINE_MT32_DEBUG=1 to run this");
+        return;
+    }
+    static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let _ = log::set_logger(&Capture);
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+    CAPTURED.lock().expect("capture").clear();
+
+    // Data bytes with no status byte before them: exactly what makes the
+    // engine complain about running status.
+    synth.parse(&[0x40, 0x41, 0x42, 0x43, 0x44]);
+    let mut frames = vec![(0.0f32, 0.0f32); 4096];
+    synth.render(&mut frames);
+
+    let lines = CAPTURED.lock().expect("capture").clone();
+    let engine: Vec<&String> = lines.iter().filter(|l| l.starts_with("mt32: ")).collect();
+    assert!(
+        !engine.is_empty(),
+        "the engine should have reported through the log, got {lines:?}"
+    );
+    // Formatted, not the raw format string.
+    assert!(
+        engine.iter().all(|l| !l.contains('%')),
+        "the arguments should have been formatted in: {engine:?}"
+    );
+}
+
+/// The MIDI MESSAGE lamp answers exclusive messages, not just notes.
+///
+/// A librarian talks to the module entirely in SysEx, so a lamp that only
+/// lit for note-on would sit dark through the very traffic it is there to
+/// show. The engine holds it lit for a moment after each message, so it is
+/// read while the frames that keep it lit are still being rendered.
+#[test]
+#[ignore = "needs an MT-32 ROM pair in COPPERLINE_MT32_ROMS"]
+fn the_lamp_lights_for_exclusive_messages() {
+    let Some(mut synth) = open_synth() else {
+        return;
+    };
+    let mut frames = vec![(0.0f32, 0.0f32); 64];
+    // Settle: whatever the greeting lit has gone out by now.
+    for _ in 0..600 {
+        synth.render(&mut frames);
+    }
+    assert!(!synth.display().1, "dark with nothing being sent");
+
+    // A DT1 setting the master volume, fed in as bytes off the serial
+    // line: no note, purely exclusive, and by the path Paula uses.
+    let body = [0x10, 0x00, 0x16, 64];
+    let sum: u32 = body.iter().map(|&b| u32::from(b)).sum();
+    let mut sysex = vec![0xF0, 0x41, 0x10, 0x16, 0x12];
+    sysex.extend_from_slice(&body);
+    sysex.push(((128 - (sum % 128)) % 128) as u8);
+    sysex.push(0xF7);
+    synth.parse(&sysex);
+    synth.render(&mut frames);
+    assert!(synth.display().1, "lit by an exclusive message");
+
+    // And it goes out again once the engine's blink has run its course.
+    for _ in 0..600 {
+        synth.render(&mut frames);
+    }
+    assert!(!synth.display().1, "out again afterwards");
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -116,6 +116,12 @@ pub trait SerialSink: Send {
         None
     }
 
+    /// The same sink shared, for reads that only look.
+    #[cfg(feature = "midi")]
+    fn as_midi_ref(&self) -> Option<&crate::midi::MidiSerialSink> {
+        None
+    }
+
     /// One stereo frame of what the device on the far end is sounding, at
     /// the mixer's rate, or `None` from a device that makes no sound here.
     ///

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -116,6 +116,21 @@ pub trait SerialSink: Send {
         None
     }
 
+    /// One stereo frame of what the device on the far end is sounding, at
+    /// the mixer's rate, or `None` from a device that makes no sound here.
+    ///
+    /// Only a device emulated in this process has anything to say: a host
+    /// MIDI endpoint makes its noise on the host, out of the emulator's
+    /// reach. The mixer treats what comes back the way it treats CD audio --
+    /// a line-level source beside Paula's own output, never in place of it.
+    ///
+    /// A `None` is final for the life of the sink, so the mixer asks once and
+    /// then stops. Buffering belongs to whoever implements this, which keeps
+    /// the mixer free of state for a device that is usually not there.
+    fn next_audio_frame(&mut self) -> Option<(f32, f32)> {
+        None
+    }
+
     fn flush(&mut self);
 }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2995,14 +2995,13 @@ impl MachineSetup {
             F::MidiOut => {
                 // Munt MT-32 rides at the end of the output list: it is
                 // always there to be chosen, whatever the host offers.
-                let mut names: Vec<String> = self
+                let names: Vec<String> = self
                     .midi_endpoints
                     .outputs
                     .iter()
                     .map(|e| e.name.clone())
+                    .chain(mt32_endpoint(true))
                     .collect();
-                #[cfg(feature = "mt32")]
-                names.push(crate::config::MIDI_OUT_MT32.to_string());
                 self.midi_out =
                     crate::midi::next_endpoint(self.midi_out.as_deref(), &names, forward);
                 // The MT-32 is only a source while it is the destination,
@@ -3016,20 +3015,17 @@ impl MachineSetup {
             }
             #[cfg(feature = "midi")]
             F::MidiIn => {
-                let mut names: Vec<String> = self
-                    .midi_endpoints
-                    .inputs
-                    .iter()
-                    .map(|e| e.name.clone())
-                    .collect();
                 // The module is a sound module: it has no keyboard, and
                 // what it sends is an answer to what it was sent. So it is
                 // offered as a source only while it is the destination,
                 // which is also the wiring a patch editor needs.
-                #[cfg(feature = "mt32")]
-                if self.midi_out_is_mt32() {
-                    names.push(crate::config::MIDI_OUT_MT32.to_string());
-                }
+                let names: Vec<String> = self
+                    .midi_endpoints
+                    .inputs
+                    .iter()
+                    .map(|e| e.name.clone())
+                    .chain(mt32_endpoint(self.midi_out_is_mt32()))
+                    .collect();
                 self.midi_in = crate::midi::next_endpoint(self.midi_in.as_deref(), &names, forward);
             }
             F::ParallelDevice => {
@@ -4086,6 +4082,14 @@ fn cycle_bootpri(current: i8, forward: bool) -> i8 {
         (idx + n - 1) % n
     };
     BOOTPRI_STEPS[next]
+}
+
+/// The tail a MIDI picker's list carries when the built-in module belongs
+/// on it: the module is not a host endpoint, so it is added rather than
+/// enumerated. Nothing to add on a build without it.
+#[cfg(feature = "midi")]
+fn mt32_endpoint(wanted: bool) -> Option<String> {
+    (wanted && cfg!(feature = "mt32")).then(|| crate::config::MIDI_OUT_MT32.to_string())
 }
 
 fn cycle_slice<T: Copy + PartialEq>(items: &[T], current: T, forward: bool) -> T {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2705,7 +2705,13 @@ impl MachineSetup {
                 self.midi_out.clone().unwrap_or_else(|| "None".to_string())
             }
             #[cfg(feature = "midi")]
-            F::MidiIn => self.midi_in.clone().unwrap_or_else(|| "None".to_string()),
+            F::MidiIn => {
+                #[cfg(feature = "mt32")]
+                if crate::config::midi_out_is_mt32(self.midi_in.as_deref()) {
+                    return crate::midi::MIDI_OUT_MT32_LABEL.to_string();
+                }
+                self.midi_in.clone().unwrap_or_else(|| "None".to_string())
+            }
             F::ParallelDevice => match self.parallel_device {
                 ParallelDevice::None => "None".to_string(),
                 ParallelDevice::Printer => "Printer".to_string(),
@@ -2999,15 +3005,31 @@ impl MachineSetup {
                 names.push(crate::config::MIDI_OUT_MT32.to_string());
                 self.midi_out =
                     crate::midi::next_endpoint(self.midi_out.as_deref(), &names, forward);
+                // The MT-32 is only a source while it is the destination,
+                // so moving the output elsewhere takes the input with it.
+                #[cfg(feature = "mt32")]
+                if !self.midi_out_is_mt32()
+                    && crate::config::midi_out_is_mt32(self.midi_in.as_deref())
+                {
+                    self.midi_in = None;
+                }
             }
             #[cfg(feature = "midi")]
             F::MidiIn => {
-                let names: Vec<String> = self
+                let mut names: Vec<String> = self
                     .midi_endpoints
                     .inputs
                     .iter()
                     .map(|e| e.name.clone())
                     .collect();
+                // The module is a sound module: it has no keyboard, and
+                // what it sends is an answer to what it was sent. So it is
+                // offered as a source only while it is the destination,
+                // which is also the wiring a patch editor needs.
+                #[cfg(feature = "mt32")]
+                if self.midi_out_is_mt32() {
+                    names.push(crate::config::MIDI_OUT_MT32.to_string());
+                }
                 self.midi_in = crate::midi::next_endpoint(self.midi_in.as_deref(), &names, forward);
             }
             F::ParallelDevice => {
@@ -4916,6 +4938,36 @@ mod tests {
         s.cycle(LauncherField::Tint, false);
         assert_eq!(s.value_label(LauncherField::Tint), "Sepia");
         assert_eq!(s.to_raw().display.tint, Some("sepia".to_string()));
+    }
+
+    /// The module is offered as a source only while it is the destination,
+    /// and stops being one the moment the output moves elsewhere.
+    #[test]
+    #[cfg(all(feature = "midi", feature = "mt32"))]
+    fn the_mt32_is_a_midi_source_only_while_it_is_the_destination() {
+        let mut s = MachineSetup {
+            midi_out: Some(crate::config::MIDI_OUT_MT32.to_string()),
+            ..MachineSetup::default()
+        };
+        assert!(s.midi_out_is_mt32());
+
+        // With no host sources at all, the module is still there to pick.
+        s.cycle(LauncherField::MidiIn, true);
+        assert_eq!(
+            s.value_label(LauncherField::MidiIn),
+            crate::midi::MIDI_OUT_MT32_LABEL
+        );
+
+        // Moving the output off the module takes the input with it:
+        // nothing reaches it, so it has nothing left to answer. The module
+        // rides at the end of the output list, so one step wraps to None.
+        s.cycle(LauncherField::MidiOut, true);
+        assert!(!s.midi_out_is_mt32());
+        assert_eq!(s.value_label(LauncherField::MidiIn), "None");
+
+        // And it is no longer among the sources to cycle onto.
+        s.cycle(LauncherField::MidiIn, true);
+        assert_eq!(s.value_label(LauncherField::MidiIn), "None");
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -25,8 +25,8 @@ use crate::chipset::denise::DeniseRevision;
 use crate::config::{
     format_size, machine_profile_defaults, AudioFilterMode, BridgeCable, BridgeDensity,
     BridgeDriver, BridgeSpeedMode, ChannelMode, Chipset, Config, CpuModel, DisplayScaling,
-    FloppyBridgeConfig, JoystickInputMode, MachineModel, MenuScale, MouseCapture, Overscan,
-    PacingBudget, ParallelDevice, PixelAspect, RawConfig, RawDrive, RawFilesysMount,
+    FloppyBridgeConfig, JoystickInputMode, MachineModel, MenuScale, MouseCapture, Mt32Lcd,
+    Overscan, PacingBudget, ParallelDevice, PixelAspect, RawConfig, RawDrive, RawFilesysMount,
     RawFloppyDrive, RawZorroBoard, RtgCard, ScsiController, SerialMode, ShaderMode, Tint,
     WarpSpeed, BOOT_PRI_NEVER,
 };
@@ -397,6 +397,10 @@ pub enum LauncherField {
     SerialMode,
     #[cfg(feature = "midi")]
     MidiOut,
+    Mt32ControlRom,
+    Mt32PcmRom,
+    Mt32Panel,
+    Mt32Lcd,
     #[cfg(feature = "midi")]
     MidiIn,
     // Parallel
@@ -676,6 +680,18 @@ const SERIAL_ROWS_MIDI: [Row; 3] = [
     row(F::MidiIn, "  MIDI input", Cycle),
     row(F::MidiOut, "  MIDI output", Cycle),
 ];
+// Picking Munt MT-32 as the output adds the two ROM images it runs on and
+// its front panel; nothing else needs them, so nothing else shows them.
+#[cfg(all(feature = "midi", feature = "mt32"))]
+const SERIAL_ROWS_MT32: [Row; 7] = [
+    row(F::SerialMode, "  Device / Mode", Cycle),
+    row(F::MidiIn, "  MIDI input", Cycle),
+    row(F::MidiOut, "  MIDI output", Cycle),
+    row(F::Mt32ControlRom, "  Control ROM", PathRow),
+    row(F::Mt32PcmRom, "  PCM ROM", PathRow),
+    row(F::Mt32Panel, "  Front panel", Toggle),
+    row(F::Mt32Lcd, "  Display", Cycle),
+];
 // The sampler input/gain rows appear only when the sampler is the selected
 // device, so None/Printer show just the Device selector.
 const PARALLEL_ROWS_BASE: [Row; 1] = [row(F::ParallelDevice, "  Device", Cycle)];
@@ -743,6 +759,7 @@ pub fn rows(
     tab: LauncherTab,
     parallel_device: ParallelDevice,
     serial_mode: SerialMode,
+    midi_out_is_mt32: bool,
 ) -> Cow<'static, [Row]> {
     match tab {
         LauncherTab::System => Cow::Borrowed(&SYSTEM_ROWS),
@@ -769,7 +786,11 @@ pub fn rows(
         }
         LauncherTab::HostFs => Cow::Borrowed(&HOSTFS_ROWS),
         LauncherTab::Cd => Cow::Borrowed(&CD_ROWS),
-        LauncherTab::IoPorts => Cow::Owned(io_ports_rows(serial_mode, parallel_device)),
+        LauncherTab::IoPorts => Cow::Owned(io_ports_rows(
+            serial_mode,
+            midi_out_is_mt32,
+            parallel_device,
+        )),
         LauncherTab::Input => Cow::Borrowed(&INPUT_ROWS),
         LauncherTab::Zorro => Cow::Borrowed(&[]),
         // A/V & Emu defaults to the Audio category; Video and Emulation are its
@@ -784,9 +805,13 @@ pub fn rows(
 /// only build with serial rows), a `Parallel:` section, then an `Ethernet:`
 /// section, each under a greyed heading and each showing only the rows relevant
 /// to its selected device/mode.
-fn io_ports_rows(serial_mode: SerialMode, parallel_device: ParallelDevice) -> Vec<Row> {
+fn io_ports_rows(
+    serial_mode: SerialMode,
+    midi_out_is_mt32: bool,
+    parallel_device: ParallelDevice,
+) -> Vec<Row> {
     let mut rows = Vec::new();
-    let serial = serial_rows(serial_mode);
+    let serial = serial_rows(serial_mode, midi_out_is_mt32);
     if !serial.is_empty() {
         rows.push(section_header("Serial:"));
         rows.extend_from_slice(serial);
@@ -800,18 +825,22 @@ fn io_ports_rows(serial_mode: SerialMode, parallel_device: ParallelDevice) -> Ve
 
 /// Serial rows for the current mode. Only the `midi` build has any; without it
 /// the Serial section is empty and omitted from the I/O Ports tab.
-fn serial_rows(serial_mode: SerialMode) -> &'static [Row] {
+fn serial_rows(serial_mode: SerialMode, midi_out_is_mt32: bool) -> &'static [Row] {
     #[cfg(feature = "midi")]
     {
-        if serial_mode == SerialMode::Midi {
-            &SERIAL_ROWS_MIDI
-        } else {
-            &SERIAL_ROWS_BASE
+        if serial_mode != SerialMode::Midi {
+            return &SERIAL_ROWS_BASE;
         }
+        #[cfg(feature = "mt32")]
+        if midi_out_is_mt32 {
+            return &SERIAL_ROWS_MT32;
+        }
+        let _ = midi_out_is_mt32;
+        &SERIAL_ROWS_MIDI
     }
     #[cfg(not(feature = "midi"))]
     {
-        let _ = serial_mode;
+        let _ = (serial_mode, midi_out_is_mt32);
         &[]
     }
 }
@@ -1338,6 +1367,12 @@ pub struct MachineSetup {
     bezel: bool,
     /// Performance overlay in the top-right ([display] perf_overlay).
     perf_overlay: bool,
+    /// The MT-32's two ROM images, whether its front panel starts up, and
+    /// how that panel's display is lit.
+    mt32_control_rom: Option<PathBuf>,
+    mt32_pcm_rom: Option<PathBuf>,
+    mt32_panel: bool,
+    mt32_lcd: Mt32Lcd,
     /// How large the pop-up menu is drawn ([display] menu_scale).
     menu_scale: MenuScale,
     /// Screen tint ([display] tint).
@@ -1505,6 +1540,10 @@ impl MachineSetup {
             shader_strength: cfg.shader_strength,
             bezel: cfg.bezel,
             perf_overlay: cfg.perf_overlay,
+            mt32_control_rom: cfg.serial.mt32_control_rom.clone(),
+            mt32_pcm_rom: cfg.serial.mt32_pcm_rom.clone(),
+            mt32_panel: cfg.serial.mt32_panel,
+            mt32_lcd: cfg.serial.mt32_lcd,
             menu_scale: cfg.menu_scale,
             tint: cfg.tint,
             start_fullscreen: cfg.full_screen,
@@ -1560,6 +1599,12 @@ impl MachineSetup {
 
     /// The selected serial mode and parallel device, so the panel can pick the
     /// dynamic Serial/Parallel row sets (see [`rows`]).
+    /// Whether the MIDI output is pointed at the built-in MT-32, which is
+    /// what puts its ROM and panel rows on the I/O Ports tab.
+    pub fn midi_out_is_mt32(&self) -> bool {
+        crate::config::midi_out_is_mt32(self.midi_out.as_deref())
+    }
+
     pub fn serial_mode(&self) -> SerialMode {
         self.serial_mode
     }
@@ -1842,6 +1887,21 @@ impl MachineSetup {
         if self.tint != base.tint {
             raw.display.tint = Some(tint_name(self.tint).to_string());
         }
+        if self.mt32_control_rom != base.serial.mt32_control_rom {
+            raw.serial.mt32_control_rom = self
+                .mt32_control_rom
+                .as_ref()
+                .map(|p| p.display().to_string());
+        }
+        if self.mt32_pcm_rom != base.serial.mt32_pcm_rom {
+            raw.serial.mt32_pcm_rom = self.mt32_pcm_rom.as_ref().map(|p| p.display().to_string());
+        }
+        if self.mt32_panel != base.serial.mt32_panel {
+            raw.serial.mt32_panel = Some(self.mt32_panel);
+        }
+        if self.mt32_lcd != base.serial.mt32_lcd {
+            raw.serial.mt32_lcd = Some(self.mt32_lcd.label().to_string());
+        }
         if self.menu_scale != base.menu_scale {
             raw.display.menu_scale = Some(self.menu_scale.label().to_string());
         }
@@ -2071,6 +2131,10 @@ impl MachineSetup {
         self.perf_overlay = base.perf_overlay;
         self.tint = base.tint;
         self.menu_scale = base.menu_scale;
+        self.mt32_control_rom = base.serial.mt32_control_rom.clone();
+        self.mt32_pcm_rom = base.serial.mt32_pcm_rom.clone();
+        self.mt32_panel = base.serial.mt32_panel;
+        self.mt32_lcd = base.serial.mt32_lcd;
         self.start_fullscreen = base.full_screen;
         self.show_status_bar = base.status_bar;
         self.floppy_sounds = base.audio.floppy_sounds;
@@ -2360,6 +2424,7 @@ impl MachineSetup {
             F::Deinterlace => self.deinterlace,
             F::Bezel => self.bezel,
             F::PerfOverlay => self.perf_overlay,
+            F::Mt32Panel => self.mt32_panel,
             F::PowerOn => self.power_on,
             F::RealtimePriority => self.realtime_priority,
             _ => false,
@@ -2370,6 +2435,8 @@ impl MachineSetup {
     pub fn path(&self, field: LauncherField) -> Option<&Path> {
         match field {
             F::Rom => self.rom.as_deref(),
+            F::Mt32ControlRom => self.mt32_control_rom.as_deref(),
+            F::Mt32PcmRom => self.mt32_pcm_rom.as_deref(),
             F::ExtendedRom => self.extended_rom.as_deref(),
             F::Df0Image => self.df_playlists[0].first().map(PathBuf::as_path),
             F::Df1Image => self.df_playlists[1].first().map(PathBuf::as_path),
@@ -2553,6 +2620,7 @@ impl MachineSetup {
             F::Scaling => self.scaling.label().to_string(),
             F::Tint => self.tint.menu_label().to_string(),
             F::MenuScale => self.menu_scale.menu_label().to_string(),
+            F::Mt32Lcd => self.mt32_lcd.menu_label().to_string(),
             F::Phosphor => {
                 if self.phosphor <= 0.0 {
                     "Disabled".to_string()
@@ -2630,7 +2698,12 @@ impl MachineSetup {
                 SerialMode::Pty => "PTY".to_string(),
             },
             #[cfg(feature = "midi")]
-            F::MidiOut => self.midi_out.clone().unwrap_or_else(|| "None".to_string()),
+            F::MidiOut => {
+                if self.midi_out_is_mt32() {
+                    return crate::midi::MIDI_OUT_MT32_LABEL.to_string();
+                }
+                self.midi_out.clone().unwrap_or_else(|| "None".to_string())
+            }
             #[cfg(feature = "midi")]
             F::MidiIn => self.midi_in.clone().unwrap_or_else(|| "None".to_string()),
             F::ParallelDevice => match self.parallel_device {
@@ -2859,6 +2932,9 @@ impl MachineSetup {
             F::MenuScale => {
                 self.menu_scale = cycle_slice(&MenuScale::MENU_ORDER, self.menu_scale, forward);
             }
+            F::Mt32Lcd => {
+                self.mt32_lcd = cycle_slice(&Mt32Lcd::MENU_ORDER, self.mt32_lcd, forward);
+            }
             F::PixelAspect => {
                 self.pixel_aspect = cycle_slice(&PIXEL_ASPECTS, self.pixel_aspect, forward)
             }
@@ -2910,9 +2986,30 @@ impl MachineSetup {
                 self.serial_mode = cycle_slice(&choices, self.serial_mode, forward)
             }
             #[cfg(feature = "midi")]
-            F::MidiOut => cycle_endpoint(&mut self.midi_out, &self.midi_endpoints.outputs, forward),
+            F::MidiOut => {
+                // Munt MT-32 rides at the end of the output list: it is
+                // always there to be chosen, whatever the host offers.
+                let mut names: Vec<String> = self
+                    .midi_endpoints
+                    .outputs
+                    .iter()
+                    .map(|e| e.name.clone())
+                    .collect();
+                #[cfg(feature = "mt32")]
+                names.push(crate::config::MIDI_OUT_MT32.to_string());
+                self.midi_out =
+                    crate::midi::next_endpoint(self.midi_out.as_deref(), &names, forward);
+            }
             #[cfg(feature = "midi")]
-            F::MidiIn => cycle_endpoint(&mut self.midi_in, &self.midi_endpoints.inputs, forward),
+            F::MidiIn => {
+                let names: Vec<String> = self
+                    .midi_endpoints
+                    .inputs
+                    .iter()
+                    .map(|e| e.name.clone())
+                    .collect();
+                self.midi_in = crate::midi::next_endpoint(self.midi_in.as_deref(), &names, forward);
+            }
             F::ParallelDevice => {
                 // None -> Printer -> Sampler. Selecting Printer reveals its
                 // Output file row (with a Browse button); until a file is set
@@ -3123,6 +3220,7 @@ impl MachineSetup {
             F::Deinterlace => self.deinterlace = !self.deinterlace,
             F::Bezel => self.bezel = !self.bezel,
             F::PerfOverlay => self.perf_overlay = !self.perf_overlay,
+            F::Mt32Panel => self.mt32_panel = !self.mt32_panel,
             F::PowerOn => self.power_on = !self.power_on,
             F::BridgeAutoCache => {
                 if let Some(c) = self.bridge_edit_mut() {
@@ -3146,6 +3244,8 @@ impl MachineSetup {
             && !crate::config::is_cd_image_path(&path);
         match field {
             F::Rom => self.rom = Some(path),
+            F::Mt32ControlRom => self.mt32_control_rom = Some(path),
+            F::Mt32PcmRom => self.mt32_pcm_rom = Some(path),
             F::ExtendedRom => self.extended_rom = Some(path),
             F::Df0Image => self.set_floppy(0, path),
             F::Df1Image => self.set_floppy(1, path),
@@ -3191,6 +3291,8 @@ impl MachineSetup {
         match field {
             F::Rom => self.rom = None,
             F::ExtendedRom => self.extended_rom = None,
+            F::Mt32ControlRom => self.mt32_control_rom = None,
+            F::Mt32PcmRom => self.mt32_pcm_rom = None,
             F::Df0Image => self.df_playlists[0].clear(),
             F::Df1Image => self.df_playlists[1].clear(),
             F::Df2Image => self.df_playlists[2].clear(),
@@ -3781,18 +3883,6 @@ fn cpu_is_32bit(cpu: CpuModel) -> bool {
     )
 }
 
-/// Step a MIDI endpoint selection through "None" then the available endpoints,
-/// storing the chosen device's exact name.
-#[cfg(feature = "midi")]
-fn cycle_endpoint(
-    current: &mut Option<String>,
-    endpoints: &[crate::midi::MidiEndpoint],
-    forward: bool,
-) {
-    let names: Vec<String> = endpoints.iter().map(|e| e.name.clone()).collect();
-    *current = crate::midi::next_endpoint(current.as_deref(), &names, forward);
-}
-
 /// Whether `field` appears anywhere with the given row kind. Used to classify a
 /// field (toggle vs path) without threading the tab through every call, called
 /// per drawn row, so it scans the static row tables directly rather than
@@ -3800,7 +3890,9 @@ fn cycle_endpoint(
 /// add `SectionHeader`/`BootpriHeader` rows, which carry no real field, so the
 /// raw tables cover every classifiable field.
 fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
-    #[cfg(feature = "midi")]
+    #[cfg(all(feature = "midi", feature = "mt32"))]
+    let serial: &[&[Row]] = &[&SERIAL_ROWS_MIDI, &SERIAL_ROWS_MT32];
+    #[cfg(all(feature = "midi", not(feature = "mt32")))]
     let serial: &[&[Row]] = &[&SERIAL_ROWS_MIDI];
     #[cfg(not(feature = "midi"))]
     let serial: &[&[Row]] = &[];
@@ -4827,6 +4919,70 @@ mod tests {
     }
 
     #[test]
+    fn the_mt32_rows_appear_only_when_it_is_the_midi_output() {
+        let midi_rows = |out: Option<&str>| {
+            let s = MachineSetup {
+                midi_out: out.map(str::to_string),
+                ..MachineSetup::default()
+            };
+            rows(
+                LauncherTab::IoPorts,
+                ParallelDevice::None,
+                SerialMode::Midi,
+                s.midi_out_is_mt32(),
+            )
+            .iter()
+            .map(|r| r.field)
+            .collect::<Vec<_>>()
+        };
+
+        // A host endpoint: the ROM pair and the panel are nothing to do with
+        // it, so they are not offered.
+        let host = midi_rows(Some("Some USB Interface"));
+        assert!(host.contains(&LauncherField::MidiOut));
+        assert!(!host.contains(&LauncherField::Mt32ControlRom));
+        assert!(!host.contains(&LauncherField::Mt32Panel));
+
+        // The built-in synth: both ROMs and the panel.
+        let mt32 = midi_rows(Some(crate::config::MIDI_OUT_MT32));
+        assert!(mt32.contains(&LauncherField::Mt32ControlRom));
+        assert!(mt32.contains(&LauncherField::Mt32PcmRom));
+        assert!(mt32.contains(&LauncherField::Mt32Panel));
+    }
+
+    #[test]
+    fn the_mt32_rom_pair_and_panel_round_trip_through_raw() {
+        let mut s = MachineSetup::default();
+        assert_eq!(s.to_raw().serial.mt32_control_rom, None);
+
+        s.set_path(
+            LauncherField::Mt32ControlRom,
+            std::path::PathBuf::from("MT32_CONTROL.ROM"),
+        );
+        s.set_path(
+            LauncherField::Mt32PcmRom,
+            std::path::PathBuf::from("MT32_PCM.ROM"),
+        );
+        s.toggle(LauncherField::Mt32Panel);
+        assert!(s.toggle_value(LauncherField::Mt32Panel));
+
+        let raw = s.to_raw();
+        assert_eq!(
+            raw.serial.mt32_control_rom.as_deref(),
+            Some("MT32_CONTROL.ROM")
+        );
+        assert_eq!(raw.serial.mt32_pcm_rom.as_deref(), Some("MT32_PCM.ROM"));
+        assert_eq!(raw.serial.mt32_panel, Some(true));
+
+        let reloaded = MachineSetup::from_raw(&raw).expect("valid raw");
+        assert_eq!(
+            reloaded.path(LauncherField::Mt32PcmRom),
+            Some(std::path::Path::new("MT32_PCM.ROM"))
+        );
+        assert!(reloaded.toggle_value(LauncherField::Mt32Panel));
+    }
+
+    #[test]
     fn menu_scale_round_trips_through_raw() {
         let mut s = MachineSetup::default();
         // 1x is the baseline, so nothing is written for it. The launcher has
@@ -5149,6 +5305,7 @@ mod tests {
             LauncherTab::Storage,
             ParallelDevice::None,
             SerialMode::default(),
+            false,
         );
         assert_eq!(
             storage.first().map(|r| r.field),
@@ -5162,7 +5319,7 @@ mod tests {
             (LauncherTab::Cd, LauncherField::CdImage),
             (LauncherTab::BootPriority, LauncherField::IdeMasterBoot),
         ] {
-            let page = rows(tab, ParallelDevice::None, SerialMode::default());
+            let page = rows(tab, ParallelDevice::None, SerialMode::default(), false);
             assert!(page.iter().any(|r| r.field == marker));
         }
     }
@@ -5197,7 +5354,7 @@ mod tests {
         assert!(!LauncherTab::System.has_top_nav());
 
         // Each category shows only its own settings; the default is Audio.
-        let page = |t| rows(t, ParallelDevice::None, SerialMode::default());
+        let page = |t| rows(t, ParallelDevice::None, SerialMode::default(), false);
         let audio = page(LauncherTab::AvAudio);
         assert!(audio.iter().any(|r| r.field == F::AudioDevice));
         assert!(audio.iter().all(|r| r.field != F::StartFullscreen));
@@ -5353,7 +5510,12 @@ mod tests {
     #[cfg(feature = "midi")]
     #[test]
     fn io_ports_tab_groups_serial_parallel_and_ethernet_under_headers() {
-        let r = rows(LauncherTab::IoPorts, ParallelDevice::None, SerialMode::Midi);
+        let r = rows(
+            LauncherTab::IoPorts,
+            ParallelDevice::None,
+            SerialMode::Midi,
+            false,
+        );
         let headers: Vec<_> = r
             .iter()
             .filter(|x| x.kind == RowKind::SectionHeader)
@@ -5464,7 +5626,7 @@ mod tests {
     #[test]
     fn parallel_sampler_rows_appear_only_when_selected() {
         let has = |device| {
-            rows(LauncherTab::IoPorts, device, SerialMode::default())
+            rows(LauncherTab::IoPorts, device, SerialMode::default(), false)
                 .iter()
                 .any(|r| r.field == LauncherField::SamplerInput)
         };
@@ -5477,7 +5639,7 @@ mod tests {
     #[test]
     fn midi_rows_appear_only_in_midi_mode() {
         let has = |mode| {
-            rows(LauncherTab::IoPorts, ParallelDevice::None, mode)
+            rows(LauncherTab::IoPorts, ParallelDevice::None, mode, false)
                 .iter()
                 .any(|r| r.field == LauncherField::MidiOut)
         };
@@ -5502,7 +5664,7 @@ mod tests {
         let mut s = MachineSetup::default();
         // The Output file row shows only when the printer is selected.
         let has_output = |device| {
-            rows(LauncherTab::IoPorts, device, SerialMode::default())
+            rows(LauncherTab::IoPorts, device, SerialMode::default(), false)
                 .iter()
                 .any(|r| r.field == LauncherField::ParallelOutput)
         };
@@ -6027,6 +6189,7 @@ mod tests {
             LauncherTab::IoPorts,
             ParallelDevice::None,
             SerialMode::Stdout,
+            false,
         );
         assert!(!serial.iter().any(|r| r.field == LauncherField::MidiOut));
         assert!(!serial.iter().any(|r| r.field == LauncherField::MidiIn));

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -57,6 +57,10 @@ pub enum MenuAction {
     SetMidiInput(String),
     SetMidiOutput(String),
     SetSamplerInput(String),
+    /// Show or hide the MT-32's front panel.
+    ToggleMt32Panel,
+    /// How that panel's display is lit.
+    SetMt32Lcd(crate::config::Mt32Lcd),
     /// Step the gain by one notch, up (+1) or down (-1).
     StepSamplerGain(i8),
 
@@ -421,6 +425,14 @@ pub struct MenuState<'a> {
     pub midi_inputs: &'a [String],
     pub midi_outputs: &'a [String],
     /// Sampler, empty unless one is on the parallel port.
+    /// Whether an MT-32 could be selected (its ROM pair is configured),
+    /// whether it is the device being played, whether its own MIDI OUT is
+    /// wired back to the machine, and whether its panel is up.
+    pub mt32_available: bool,
+    pub mt32_attached: bool,
+    pub mt32_input: bool,
+    pub mt32_panel: bool,
+    pub mt32_lcd: crate::config::Mt32Lcd,
     pub sampler_input: &'a str,
     pub sampler_inputs: &'a [String],
     pub sampler_gain: f32,
@@ -638,26 +650,66 @@ fn input_rows(s: &MenuState) -> Vec<MenuRow> {
 
 fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
     let mut rows = Vec::new();
-    if !s.midi_inputs.is_empty() {
-        rows.push(MenuRow::submenu(
-            "MIDI In",
-            s.midi_inputs
-                .iter()
-                .map(|n| MenuRow::choice(n, MenuAction::SetMidiInput(n.clone()), s.midi_in == n))
-                .collect(),
-        ));
+    // The MT-32 joins the sources only while it is the destination: it has
+    // no keyboard, and what it sends is an answer to what it was sent. That
+    // is also the wiring an editor or librarian on the Amiga needs.
+    if !s.midi_inputs.is_empty() || s.mt32_attached {
+        let mut inputs: Vec<MenuRow> = s
+            .midi_inputs
+            .iter()
+            .map(|n| MenuRow::choice(n, MenuAction::SetMidiInput(n.clone()), s.midi_in == n))
+            .collect();
+        if s.mt32_attached {
+            inputs.push(MenuRow::choice(
+                MT32_LABEL,
+                MenuAction::SetMidiInput(MT32_ENDPOINT.to_string()),
+                s.mt32_input,
+            ));
+        }
+        rows.push(MenuRow::submenu("MIDI In", inputs));
     }
-    if !s.midi_outputs.is_empty() {
+    // The MT-32 is one of the outputs, always offered once its ROMs are
+    // configured -- a machine with no host MIDI devices at all can still
+    // play to it.
+    if !s.midi_outputs.is_empty() || s.mt32_available {
+        let mut outputs: Vec<MenuRow> = s
+            .midi_outputs
+            .iter()
+            .map(|n| MenuRow::choice(n, MenuAction::SetMidiOutput(n.clone()), s.midi_out == n))
+            .collect();
+        if s.mt32_available {
+            outputs.push(MenuRow::choice(
+                MT32_LABEL,
+                MenuAction::SetMidiOutput(MT32_ENDPOINT.to_string()),
+                s.mt32_attached,
+            ));
+        }
+        rows.push(MenuRow::submenu("MIDI Out", outputs));
+    }
+    // The synth's own settings, once it is the device being played.
+    if s.mt32_attached {
+        let displays = crate::config::Mt32Lcd::MENU_ORDER
+            .iter()
+            .map(|d| MenuRow::choice(d.menu_label(), MenuAction::SetMt32Lcd(*d), s.mt32_lcd == *d))
+            .collect();
         rows.push(MenuRow::submenu(
-            "MIDI Out",
-            s.midi_outputs
-                .iter()
-                .map(|n| MenuRow::choice(n, MenuAction::SetMidiOutput(n.clone()), s.midi_out == n))
-                .collect(),
+            MT32_LABEL,
+            vec![
+                MenuRow::toggle("Front Panel", MenuAction::ToggleMt32Panel, s.mt32_panel),
+                // The display is the panel's, so it is offered with it.
+                // No value on the row: the list it opens marks the one in
+                // force, which is the same answer said once.
+                MenuRow::submenu("Display", displays).available(s.mt32_panel),
+            ],
         ));
     }
     rows
 }
+
+/// What the MT-32 output is called in the menu, and the endpoint name that
+/// selects it.
+const MT32_LABEL: &str = "Munt MT-32";
+const MT32_ENDPOINT: &str = crate::config::MIDI_OUT_MT32;
 
 fn parallel_rows(s: &MenuState) -> Vec<MenuRow> {
     vec![
@@ -951,6 +1003,11 @@ mod tests {
             midi_out: "",
             midi_inputs: midi_in,
             midi_outputs: midi_out,
+            mt32_available: false,
+            mt32_attached: false,
+            mt32_input: false,
+            mt32_panel: false,
+            mt32_lcd: crate::config::Mt32Lcd::Oled,
             sampler_input: "",
             sampler_inputs: sampler,
             sampler_gain: 0.0,

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -54,8 +54,9 @@ pub enum MenuAction {
     SetAutofire(u8),
 
     // Serial / parallel, present only when something is on the port.
-    SetMidiInput(String),
-    SetMidiOutput(String),
+    /// `None` unplugs the cable: a MIDI interface with nothing connected.
+    SetMidiInput(Option<String>),
+    SetMidiOutput(Option<String>),
     SetSamplerInput(String),
     /// Show or hide the MT-32's front panel.
     ToggleMt32Panel,
@@ -479,8 +480,9 @@ pub fn build(s: &MenuState) -> Vec<MenuRow> {
     ];
 
     // A port with nothing on it has nothing to set, so it contributes no
-    // category rather than one that opens onto an empty list.
-    if !s.midi_inputs.is_empty() || !s.midi_outputs.is_empty() {
+    // category rather than one that opens onto an empty list. The MT-32
+    // counts: a machine with no host MIDI devices can still play to it.
+    if !s.midi_inputs.is_empty() || !s.midi_outputs.is_empty() || s.mt32_available {
         rows.push(MenuRow::submenu("Serial Port", serial_rows(s)));
     }
     if !s.sampler_inputs.is_empty() {
@@ -654,15 +656,20 @@ fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
     // no keyboard, and what it sends is an answer to what it was sent. That
     // is also the wiring an editor or librarian on the Amiga needs.
     if !s.midi_inputs.is_empty() || s.mt32_attached {
-        let mut inputs: Vec<MenuRow> = s
-            .midi_inputs
-            .iter()
-            .map(|n| MenuRow::choice(n, MenuAction::SetMidiInput(n.clone()), s.midi_in == n))
-            .collect();
+        // None heads the list: an interface with nothing plugged into that
+        // socket, which is how a real one spends most of its life.
+        let mut inputs = vec![MenuRow::choice(
+            "None",
+            MenuAction::SetMidiInput(None),
+            s.midi_in == "None",
+        )];
+        inputs.extend(s.midi_inputs.iter().map(|n| {
+            MenuRow::choice(n, MenuAction::SetMidiInput(Some(n.clone())), s.midi_in == n)
+        }));
         if s.mt32_attached {
             inputs.push(MenuRow::choice(
                 MT32_LABEL,
-                MenuAction::SetMidiInput(MT32_ENDPOINT.to_string()),
+                MenuAction::SetMidiInput(Some(MT32_ENDPOINT.to_string())),
                 s.mt32_input,
             ));
         }
@@ -672,15 +679,22 @@ fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
     // configured -- a machine with no host MIDI devices at all can still
     // play to it.
     if !s.midi_outputs.is_empty() || s.mt32_available {
-        let mut outputs: Vec<MenuRow> = s
-            .midi_outputs
-            .iter()
-            .map(|n| MenuRow::choice(n, MenuAction::SetMidiOutput(n.clone()), s.midi_out == n))
-            .collect();
+        let mut outputs = vec![MenuRow::choice(
+            "None",
+            MenuAction::SetMidiOutput(None),
+            s.midi_out == "None",
+        )];
+        outputs.extend(s.midi_outputs.iter().map(|n| {
+            MenuRow::choice(
+                n,
+                MenuAction::SetMidiOutput(Some(n.clone())),
+                s.midi_out == n,
+            )
+        }));
         if s.mt32_available {
             outputs.push(MenuRow::choice(
                 MT32_LABEL,
-                MenuAction::SetMidiOutput(MT32_ENDPOINT.to_string()),
+                MenuAction::SetMidiOutput(Some(MT32_ENDPOINT.to_string())),
                 s.mt32_attached,
             ));
         }

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -149,6 +149,39 @@ pub fn status_bar_hidden() -> bool {
     STATUS_BAR_HIDDEN.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Whether the MT-32's front panel is shown under the display
+/// (`[serial] mt32_panel`, toggled live from the menu). Main thread only,
+/// like [`SQUARE_PIXEL_ASPECT`]; the atomic only satisfies `static` safety.
+static MT32_PANEL_SHOWN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_mt32_panel_shown(shown: bool) {
+    MT32_PANEL_SHOWN.store(shown, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// How the MT-32's display is lit (`[serial] mt32_lcd`). Held as an index
+/// into [`Mt32Lcd::MENU_ORDER`]; main thread only, like the flags above.
+static MT32_LCD: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+pub fn set_mt32_lcd(style: crate::config::Mt32Lcd) {
+    let index = crate::config::Mt32Lcd::MENU_ORDER
+        .iter()
+        .position(|s| *s == style)
+        .unwrap_or(0);
+    MT32_LCD.store(index as u8, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn mt32_lcd() -> crate::config::Mt32Lcd {
+    let index = usize::from(MT32_LCD.load(std::sync::atomic::Ordering::Relaxed));
+    crate::config::Mt32Lcd::MENU_ORDER
+        .get(index)
+        .copied()
+        .unwrap_or_default()
+}
+
+pub fn mt32_panel_shown() -> bool {
+    MT32_PANEL_SHOWN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// How large the pop-up menu is drawn (`[display] menu_scale`, changed live
 /// from the menu itself). Held as an index into [`MenuScale::MENU_ORDER`];
 /// main thread only, like [`SQUARE_PIXEL_ASPECT`].

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4580,6 +4580,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             state.tab,
             state.setup.parallel_device(),
             state.setup.serial_mode(),
+            state.setup.midi_out_is_mt32(),
         )
         .iter()
         .filter(|r| !state.setup.row_hidden(r.field))
@@ -5618,6 +5619,7 @@ fn draw_launcher(
             state.tab,
             state.setup.parallel_device(),
             state.setup.serial_mode(),
+            state.setup.midi_out_is_mt32(),
         )
         .iter()
         .filter(|r| !state.setup.row_hidden(r.field))
@@ -5664,6 +5666,7 @@ fn draw_launcher(
                 LauncherTab::Input,
                 state.setup.parallel_device(),
                 state.setup.serial_mode(),
+                state.setup.midi_out_is_mt32(),
             )
             .len()
                 + 1,
@@ -5698,6 +5701,7 @@ fn draw_launcher(
                 LauncherTab::BootPriority,
                 state.setup.parallel_device(),
                 state.setup.serial_mode(),
+                state.setup.midi_out_is_mt32(),
             )
             .len()
                 + 1,
@@ -5740,6 +5744,7 @@ fn draw_launcher(
                 LauncherTab::IoPorts,
                 state.setup.parallel_device(),
                 state.setup.serial_mode(),
+                state.setup.midi_out_is_mt32(),
             )
             .len()
                 + 1,
@@ -6351,7 +6356,7 @@ mod tests {
             };
             for &device in &devices {
                 for &mode in &modes {
-                    let rows = launcher::rows(tab, device, mode);
+                    let rows = launcher::rows(tab, device, mode, false);
                     for (i, r) in rows.iter().enumerate() {
                         let row_y = launcher_row_y(rect, i) + row_offset;
                         let (prev, value, next) = launcher_cycle_rects(rect, row_y);
@@ -8077,6 +8082,7 @@ mod tests {
                 LauncherTab::Input,
                 crate::config::ParallelDevice::None,
                 crate::config::SerialMode::default(),
+                false,
             )
             .len()
                 + 1,
@@ -8237,6 +8243,11 @@ mod tests {
             midi_out: "",
             midi_inputs: &none,
             midi_outputs: &none,
+            mt32_available: false,
+            mt32_attached: false,
+            mt32_input: false,
+            mt32_panel: false,
+            mt32_lcd: crate::config::Mt32Lcd::Oled,
             sampler_input: "",
             sampler_inputs: &none,
             sampler_gain: 0.0,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7010,7 +7010,17 @@ impl App {
         #[cfg(feature = "mt32")]
         {
             crate::video::set_mt32_lcd(cfg.serial.mt32_lcd);
-            self.set_mt32_panel_shown(cfg.serial.mt32_panel);
+            // The panel belongs to a module that is both fitted and asked
+            // for: a machine built without one would otherwise keep the
+            // last one's strip, dead and taking up room.
+            let fitted = self
+                .emu
+                .bus_mut()
+                .midi_serial_mut()
+                .is_some_and(|sink| sink.mt32_selected());
+            self.set_mt32_panel_shown(fitted && cfg.serial.mt32_panel);
+            self.mt32_panel.reset();
+            self.tell_panel_the_rom_version();
             self.report_mt32_fault();
         }
         self.ui.menu_open = false;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3132,6 +3132,10 @@ impl ApplicationHandler for App {
                 #[cfg(feature = "mt32")]
                 if !pressed {
                     self.mt32_panel.release_dial();
+                    // The buttons are momentary: one lights while the mouse
+                    // is down on it and comes back out when it lifts.
+                    self.mt32_panel.release_press();
+                    self.request_redraw();
                 }
                 #[cfg(feature = "mt32")]
                 if pressed
@@ -5170,6 +5174,7 @@ impl App {
         let action = panel.press(control, left, pos, rect, powered, self.mt32_synth_mut());
         self.mt32_panel = panel;
         self.apply_mt32_action(action);
+        self.serve_mt32_demo();
         self.request_redraw();
     }
 
@@ -5212,6 +5217,7 @@ impl App {
         self.emu.bus_mut().paula.rearm_synth_audio();
         self.mt32_panel.reset();
         self.tell_panel_the_rom_version();
+        self.serve_mt32_demo();
         let came_up = self
             .emu
             .bus_mut()
@@ -5292,6 +5298,46 @@ impl App {
         }
     }
 
+    /// Start whichever of the ROM's own songs the panel is asking for, and
+    /// tell it what that one is called.
+    #[cfg(feature = "mt32")]
+    fn serve_mt32_demo(&mut self) {
+        // A song that has run out hands on to the next, which is what makes
+        // it a chain.
+        if self.mt32_panel.chain_ran_out(
+            self.emu
+                .bus_mut()
+                .midi_serial_mut()
+                .is_some_and(|sink| sink.mt32_demo_playing()),
+        ) {
+            self.request_redraw();
+        }
+        let Some(want) = self.mt32_panel.demo_want() else {
+            return;
+        };
+        let track = match want {
+            mt32panel::DemoWant::Play(track) => Some(track),
+            mt32panel::DemoWant::Stop => None,
+        };
+        let title = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .map(|sink| match track {
+                Some(track) => sink
+                    .play_mt32_demo(track)
+                    // Only the later ROMs carry them; the earlier units had
+                    // no demonstration to play.
+                    .unwrap_or_else(|| "Needs v2.0x ROM".to_string()),
+                None => {
+                    sink.stop_mt32_demo();
+                    String::new()
+                }
+            })
+            .unwrap_or_default();
+        self.mt32_panel.set_track_title(title);
+    }
+
     /// Hand the panel what the control ROM calls itself, for its version
     /// screen. The engine keeps its copy of the image to itself, so this
     /// comes from the sink, which read it off disk when the pair was
@@ -5311,6 +5357,10 @@ impl App {
     /// What the MT-32's panel should show, when one is attached.
     #[cfg(feature = "mt32")]
     fn mt32_panel_view(&mut self) -> Option<mt32panel::Mt32PanelView> {
+        // A song that runs out hands on to the next, which only happens
+        // while frames are being rendered -- so it is looked at here, as
+        // the panel is drawn, rather than only when something is clicked.
+        self.serve_mt32_demo();
         let sink = self.emu.bus_mut().midi_serial_mut()?;
         if !sink.mt32_selected() {
             return None;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -865,6 +865,15 @@ pub struct App {
     held_rawkeys: [bool; 128],
     raw_device_held_rawkeys: [bool; 128],
     main_window_focused: bool,
+    /// Whether the user has sized the main window themselves, in which case
+    /// the canvas reflows into it instead of the window snapping to the
+    /// canvas. Tracked from the resizes that arrive rather than measured
+    /// from the current size: a snap the platform clamped or rounded reads
+    /// as the user's own drag, and the window would never snap again.
+    window_manually_sized: bool,
+    /// The logical size the last snap asked for, so the resize it causes is
+    /// not counted as the user's.
+    snap_request: Option<(f64, f64)>,
     cursor_pos: Option<(i32, i32)>,
     last_display_cursor_pos: Option<(i32, i32)>,
     /// Most recent raw host cursor position (physical pixels) from the last
@@ -1490,6 +1499,8 @@ impl App {
             held_rawkeys: [false; 128],
             raw_device_held_rawkeys: [false; 128],
             main_window_focused: false,
+            window_manually_sized: false,
+            snap_request: None,
             cursor_pos: None,
             last_display_cursor_pos: None,
             last_cursor_phys: None,
@@ -3158,6 +3169,7 @@ impl ApplicationHandler for App {
                 self.request_redraw();
             }
             WindowEvent::Resized(size) => {
+                self.note_window_resize(size);
                 self.apply_surface_size(size);
             }
             WindowEvent::RedrawRequested => {
@@ -9128,6 +9140,7 @@ impl App {
             return;
         }
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
+        self.snap_request = Some((size.width, size.height));
         if let Some(applied) = window.request_inner_size(size) {
             self.apply_surface_size(applied);
         }
@@ -9144,11 +9157,41 @@ impl App {
         if window.fullscreen().is_some() {
             return false;
         }
-        let scale = window.scale_factor();
-        let inner = window.inner_size();
-        let logical_w = f64::from(inner.width) / scale;
-        let logical_h = f64::from(inner.height) / scale;
-        logical_size_is_canvas(logical_w, logical_h, window_present_height())
+        !self.window_manually_sized
+    }
+
+    /// Classify a resize of the main window: the user's own drag, or the
+    /// window following a canvas change.
+    ///
+    /// A snap asks for the canvas size; what comes back may be clamped by
+    /// the platform or rounded by the scale factor, and that near miss must
+    /// not read as a drag or the window stops following the canvas for the
+    /// rest of the run. A drag onto the canvas size hands it back.
+    fn note_window_resize(&mut self, size: PhysicalSize<u32>) {
+        // Read what is needed and let the borrow go: a drag delivers these
+        // continuously, so this takes nothing it has to hold on to.
+        let Some((fullscreen, scale)) = self
+            .render
+            .as_ref()
+            .map(|r| (r.window.fullscreen().is_some(), r.window.scale_factor()))
+        else {
+            return;
+        };
+        // Fullscreen sizes the window itself; leave the standing verdict.
+        if fullscreen {
+            return;
+        }
+        let logical_w = f64::from(size.width) / scale;
+        let logical_h = f64::from(size.height) / scale;
+        let asked_for = self
+            .snap_request
+            .is_some_and(|(w, h)| (logical_w - w).abs() < 2.0 && (logical_h - h).abs() < 2.0);
+        if asked_for || logical_size_is_canvas(logical_w, logical_h, window_present_height()) {
+            self.snap_request = None;
+            self.window_manually_sized = false;
+            return;
+        }
+        self.window_manually_sized = true;
     }
 
     /// Cmd/Alt+M: toggle the monitor-bezel pass for the rest of the run

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4940,17 +4940,19 @@ impl App {
 
             #[cfg(feature = "midi")]
             A::SetMidiInput(name) => {
-                let mut shown = name.clone();
+                let mut shown = "None".to_string();
                 if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
-                    sink.set_input_endpoint(Some(&name));
+                    sink.set_input_endpoint(name.as_deref());
                     shown = sink.input_label();
                 }
                 self.show_osd(format!("MIDI input: {shown}"));
             }
             #[cfg(feature = "midi")]
             A::SetMidiOutput(name) => {
+                let mut shown = "None".to_string();
                 if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
-                    sink.set_output_endpoint(Some(&name));
+                    sink.set_output_endpoint(name.as_deref());
+                    shown = sink.output_label();
                 }
                 // The device on the port changed, so the mixer has to ask it
                 // for audio again -- an MT-32 just attached, or just left.
@@ -4960,7 +4962,7 @@ impl App {
                     self.sync_mt32_panel();
                     self.report_mt32_fault();
                 }
-                self.show_osd(format!("MIDI output: {name}"));
+                self.show_osd(format!("MIDI output: {shown}"));
             }
             #[cfg(not(feature = "midi"))]
             A::SetMidiInput(_) | A::SetMidiOutput(_) => {}

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -181,7 +181,7 @@ const STATUS_BAR_HEIGHT: usize = 44;
 /// plus the status bar below it unless it is hidden (in which case the display
 /// scales to fill the whole window).
 fn window_present_height() -> usize {
-    present_height() + status_bar_height()
+    present_height() + mt32_panel_height() + status_bar_height()
 }
 
 /// Scanlines the CRT pass draws across the display rect: the emulated field
@@ -227,6 +227,23 @@ fn status_bar_height() -> usize {
     } else {
         STATUS_BAR_HEIGHT
     }
+}
+
+/// Where the status bar starts: below the display, and below the MT-32
+/// panel when one is up. The bar sits at the very bottom either way; the
+/// panel takes the strip immediately above it.
+fn status_bar_top() -> usize {
+    present_height() + mt32_panel_height()
+}
+
+/// The MT-32 panel's height, or 0 while it is not shown. It sits between the
+/// display and the status bar, the way the real unit sits under the monitor.
+fn mt32_panel_height() -> usize {
+    #[cfg(feature = "mt32")]
+    if super::mt32_panel_shown() {
+        return mt32panel::MT32_PANEL_HEIGHT;
+    }
+    0
 }
 const STATUS_LABEL_X: usize = 18;
 const STATUS_LED_X: usize = 58;
@@ -304,8 +321,8 @@ const TV_LIVE_PAD_X: usize = (FB_WIDTH - TV_CAPTURED_WIDTH) / 2;
 // the captured aperture's width that breaks this must rethink the live
 // layout.
 const _: () = assert!(TV_LIVE_PAD_X * 2 + TV_CAPTURED_WIDTH == FB_WIDTH);
-const STATUS_BG: u32 = rgba(28, 28, 26);
-const STATUS_TOP: u32 = rgba(78, 76, 70);
+pub(super) const STATUS_BG: u32 = rgba(28, 28, 26);
+pub(super) const STATUS_TOP: u32 = rgba(78, 76, 70);
 const STATUS_BOTTOM: u32 = rgba(12, 12, 11);
 const LED_BEZEL_DARK: u32 = rgba(8, 8, 7);
 const LED_BEZEL_LIGHT: u32 = rgba(78, 76, 68);
@@ -353,7 +370,7 @@ const CD_HUB: u32 = rgba(120, 124, 130);
 const CD_HOLE: u32 = rgba(24, 24, 26);
 const CAMERA_BODY: u32 = rgba(190, 188, 178);
 const CAMERA_LENS: u32 = rgba(20, 22, 24);
-const STATUS_TEXT: u32 = rgba(174, 170, 154);
+pub(super) const STATUS_TEXT: u32 = rgba(174, 170, 154);
 const VOLUME_FILL: u32 = rgba(44, 178, 94);
 const VOLUME_FILL_HIGHLIGHT: u32 = rgba(128, 244, 150);
 const WINDOW_TITLE: &str = concat!("Copperline ", env!("COPPERLINE_DISPLAY_VERSION"));
@@ -379,6 +396,8 @@ fn mouse_sensitivity_factor(sensitivity: u8) -> f64 {
 const OSD_DURATION: std::time::Duration = std::time::Duration::from_millis(2500);
 /// On-screen overlay colours (packed R,G,B,A in memory order).
 const OSD_TEXT: u32 = rgba(236, 236, 232);
+/// Amber, for a message about something that did not go as asked.
+const OSD_TEXT_WARNING: u32 = rgba(248, 205, 78);
 const OSD_SHADOW: u32 = rgba(0, 0, 0);
 const OSD_BG: u32 = rgba(10, 10, 12);
 const RECORD_DOT: u32 = rgba(229, 56, 48);
@@ -436,6 +455,8 @@ fn window_title_mouse_captured() -> String {
 struct Osd {
     text: String,
     expires_at: Instant,
+    /// Drawn in amber rather than white: something did not go as asked.
+    warning: bool,
 }
 
 /// How often the performance overlay resamples its counters. Twice a
@@ -1016,6 +1037,11 @@ pub struct App {
     rewind_budget_mb: usize,
     rewind_interval_frames: u64,
     rewind_armed: bool,
+    /// The MT-32's front panel: what it is showing and what it believes
+    /// each value to be. The synth has no panel of its own -- on the
+    /// hardware this is firmware -- so it is kept here.
+    #[cfg(feature = "mt32")]
+    mt32_panel: mt32panel::Mt32Panel,
     /// Mapped host keys currently held for keyboard joystick emulation.
     keyboard_joy_held: [keymap::HeldKeys; keymap::MAPPING_COUNT],
     /// Host-key to controller-control bindings, loaded from the per-user
@@ -1251,6 +1277,11 @@ struct MainRedrawState {
     /// The performance overlay's line revision (0 while hidden), so a
     /// resample repaints an otherwise static frame.
     perf_revision: u64,
+    /// The MT-32 panel's face -- its display line and lamp -- folded to a
+    /// fingerprint, so a program writing to the LCD repaints an otherwise
+    /// static frame. Zero while the panel is hidden.
+    #[cfg(feature = "mt32")]
+    mt32_face: u64,
 }
 
 struct RenderWorker {
@@ -1545,6 +1576,8 @@ impl App {
             rewind_budget_mb,
             rewind_interval_frames,
             rewind_armed,
+            #[cfg(feature = "mt32")]
+            mt32_panel: mt32panel::Mt32Panel::default(),
             keyboard_joy_held: [keymap::HeldKeys::default(); keymap::MAPPING_COUNT],
             keymap: keymap::KeyMap::load(),
             autofire_hz,
@@ -2950,6 +2983,14 @@ impl ApplicationHandler for App {
                     .render
                     .as_ref()
                     .and_then(|r| cursor_texture_position(&r.pixels, position, r.texture_scale));
+                // A button held on the dial turns it by following the hand
+                // round the face.
+                #[cfg(feature = "mt32")]
+                if self.mt32_panel.dial_held() {
+                    if let Some(pos) = pos {
+                        self.drag_mt32_dial(pos);
+                    }
+                }
                 if self.mouse_captured {
                     self.cursor_pos = None;
                     self.last_display_cursor_pos = None;
@@ -2975,7 +3016,17 @@ impl ApplicationHandler for App {
                     self.request_redraw();
                 }
                 let layout = bar_layout(&self.media_bar());
+                // The MT-32's buttons light under the pointer as the bar's
+                // do, so they need the same redraw when it crosses one.
+                #[cfg(feature = "mt32")]
+                let mt32_hover_changed =
+                    mt32panel::shown_panel_rect(present_height()).is_some_and(|panel| {
+                        mt32panel::hover_changed(panel, previous_cursor_pos, self.cursor_pos)
+                    });
+                #[cfg(not(feature = "mt32"))]
+                let mt32_hover_changed = false;
                 if bar_hover_changed(&layout, previous_cursor_pos, self.cursor_pos)
+                    || mt32_hover_changed
                     || self.main_ui_hover_changed(previous_cursor_pos, self.cursor_pos)
                 {
                     self.request_redraw();
@@ -3074,6 +3125,30 @@ impl ApplicationHandler for App {
                     // status-bar controls below stay clickable.
                     if self.cursor_pos.is_some_and(cursor_in_display) {
                         return;
+                    }
+                }
+                // The MT-32's panel sits above the status bar and takes its
+                // own clicks, the way the bar does.
+                #[cfg(feature = "mt32")]
+                if !pressed {
+                    self.mt32_panel.release_dial();
+                }
+                #[cfg(feature = "mt32")]
+                if pressed
+                    && !self.mouse_captured
+                    && matches!(button, MouseButton::Left | MouseButton::Right)
+                {
+                    if let (Some(pos), Some(panel)) = (
+                        self.cursor_pos,
+                        mt32panel::shown_panel_rect(present_height()),
+                    ) {
+                        if panel.contains(pos) {
+                            if let Some(control) = mt32panel::control_at(panel, pos) {
+                                let left = button == MouseButton::Left;
+                                self.press_mt32_control(control, left, pos);
+                            }
+                            return;
+                        }
                     }
                 }
                 if pressed
@@ -3207,6 +3282,12 @@ impl ApplicationHandler for App {
                 let osd = self.active_osd_text();
                 let ui_hover = self.cursor_pos.and_then(|p| self.main_ui_control_at(p));
                 let recording = self.recorder.is_some();
+                // The MT-32's panel reads its display live off the engine, so
+                // it is only gathered when the panel is actually up.
+                #[cfg(feature = "mt32")]
+                let mt32_panel = super::mt32_panel_shown()
+                    .then(|| self.mt32_panel_view())
+                    .flatten();
                 let ui_data = self.build_panel_view_data();
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
@@ -3292,6 +3373,10 @@ impl ApplicationHandler for App {
                             }
                         }
                     }
+                    #[cfg(feature = "mt32")]
+                    if let Some(panel) = &mt32_panel {
+                        mt32panel::draw(frame, panel, present_height(), r.texture_scale);
+                    }
                     if !super::status_bar_hidden() {
                         draw_status_bar(frame, &view, r.texture_scale);
                     }
@@ -3303,8 +3388,8 @@ impl ApplicationHandler for App {
                     if self.perf_overlay {
                         draw_perf_overlay(frame, &self.perf.lines, r.texture_scale, recording);
                     }
-                    if let Some(text) = &osd {
-                        draw_osd(frame, text, r.texture_scale);
+                    if let Some((text, warning)) = &osd {
+                        draw_osd(frame, text, *warning, r.texture_scale);
                     }
                     ui::draw(frame, r.texture_scale, &self.ui, ui_hover, ui_data.as_ref());
                     // The drag hint sits on top of everything: the drop will
@@ -3569,6 +3654,16 @@ impl ApplicationHandler for App {
         // Resample the performance overlay after the step so its revision
         // is current when the redraw decision below is taken.
         self.update_perf_overlay(running);
+        #[cfg(feature = "mt32")]
+        {
+            self.repeat_mt32_dial();
+            // A machine booted straight into an MT-32 has its port fitted
+            // before there is a window to say anything on, so the fault is
+            // picked up here instead. Taking it means this says it once.
+            if self.serial_is_midi {
+                self.report_mt32_fault();
+            }
+        }
         // While powered off, leave the parked test screen in place; the
         // emulator is not advancing, so there is no new frame to show.
         let mut rendered = self.powered_on && self.render_emulated_frame_if_needed();
@@ -4223,6 +4318,20 @@ impl App {
                 false
             }
         };
+        #[cfg(feature = "mt32")]
+        let mt32_face = if crate::video::mt32_panel_shown() {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            self.emu
+                .bus()
+                .midi_serial()
+                .and_then(crate::midi::MidiSerialSink::mt32)
+                .map(|mt32| mt32.synth().display())
+                .hash(&mut h);
+            h.finish()
+        } else {
+            0
+        };
         MainRedrawState {
             status,
             media: self.media_bar(),
@@ -4238,6 +4347,8 @@ impl App {
             } else {
                 0
             },
+            #[cfg(feature = "mt32")]
+            mt32_face,
         }
     }
 
@@ -4593,6 +4704,23 @@ impl App {
             crate::audio::AudioOutput::Default => AudioOutputChoice::Default,
         };
 
+        // Whether an MT-32 can be picked, whether it is the one playing, and
+        // whether its own MIDI OUT is wired back to the machine.
+        #[cfg(feature = "mt32")]
+        let (mt32_available, mt32_attached, mt32_input) = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .map_or((false, false, false), |sink| {
+                (
+                    sink.mt32_available(),
+                    sink.mt32().is_some(),
+                    sink.mt32_input(),
+                )
+            });
+        #[cfg(not(feature = "mt32"))]
+        let (mt32_available, mt32_attached, mt32_input) = (false, false, false);
+
         let save_slots = self.save_slot_stamps();
         let state = MenuState {
             fullscreen,
@@ -4624,6 +4752,11 @@ impl App {
             midi_out: &midi_out,
             midi_inputs: &midi_inputs,
             midi_outputs: &midi_outputs,
+            mt32_available,
+            mt32_attached,
+            mt32_input,
+            mt32_panel: crate::video::mt32_panel_shown(),
+            mt32_lcd: crate::video::mt32_lcd(),
             sampler_input: self.sampler.input_device.as_deref().unwrap_or(""),
             sampler_inputs: &sampler_inputs,
             sampler_gain: self.sampler.gain_db,
@@ -4803,20 +4936,50 @@ impl App {
 
             #[cfg(feature = "midi")]
             A::SetMidiInput(name) => {
+                let mut shown = name.clone();
                 if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
                     sink.set_input_endpoint(Some(&name));
+                    shown = sink.input_label();
                 }
-                self.show_osd(format!("MIDI input: {name}"));
+                self.show_osd(format!("MIDI input: {shown}"));
             }
             #[cfg(feature = "midi")]
             A::SetMidiOutput(name) => {
                 if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
                     sink.set_output_endpoint(Some(&name));
                 }
+                // The device on the port changed, so the mixer has to ask it
+                // for audio again -- an MT-32 just attached, or just left.
+                self.emu.bus_mut().paula.rearm_synth_audio();
+                #[cfg(feature = "mt32")]
+                {
+                    self.sync_mt32_panel();
+                    self.report_mt32_fault();
+                }
                 self.show_osd(format!("MIDI output: {name}"));
             }
             #[cfg(not(feature = "midi"))]
             A::SetMidiInput(_) | A::SetMidiOutput(_) => {}
+            #[cfg(feature = "mt32")]
+            A::ToggleMt32Panel => {
+                let shown = !crate::video::mt32_panel_shown();
+                self.set_mt32_panel_shown(shown);
+                self.show_osd(if shown {
+                    "Munt MT-32: front panel shown"
+                } else {
+                    "Munt MT-32: front panel hidden"
+                });
+            }
+            #[cfg(not(feature = "mt32"))]
+            A::ToggleMt32Panel => {}
+            #[cfg(feature = "mt32")]
+            A::SetMt32Lcd(style) => {
+                crate::video::set_mt32_lcd(style);
+                self.show_osd(format!("Munt MT-32: {} display", style.menu_label()));
+                self.request_redraw();
+            }
+            #[cfg(not(feature = "mt32"))]
+            A::SetMt32Lcd(_) => {}
             A::SetSamplerInput(name) => {
                 if self.sampler.enabled {
                     self.sampler.input_device = Some(name.clone());
@@ -4948,6 +5111,224 @@ impl App {
             _ => return false,
         }
         self.request_redraw();
+        true
+    }
+
+    /// Show or hide the MT-32's panel, resizing the presentation to match.
+    ///
+    /// The panel takes height from the canvas, and the draw helpers size
+    /// themselves from the flag, so the two must move together: a taller
+    /// canvas over an unchanged buffer indexes past the end of it. Every
+    /// route in goes through here.
+    #[cfg(feature = "mt32")]
+    fn set_mt32_panel_shown(&mut self, shown: bool) {
+        if shown == crate::video::mt32_panel_shown() {
+            return;
+        }
+        // Decide before the flag flips whether the window still matches the
+        // canvas, so a manual resize survives.
+        let was_canvas_sized = self.window_is_canvas_sized();
+        crate::video::set_mt32_panel_shown(shown);
+        if self.resync_canvas_height() {
+            if was_canvas_sized {
+                self.snap_window_to_canvas();
+            }
+        } else {
+            crate::video::set_mt32_panel_shown(!shown);
+            let _ = self.resync_canvas_height();
+        }
+        self.request_redraw();
+    }
+
+    /// The synth the panel is driving, when one is fitted and switched on.
+    #[cfg(feature = "mt32")]
+    fn mt32_synth_mut(&mut self) -> Option<&mut crate::mt32::Mt32Synth> {
+        Some(
+            self.emu
+                .bus_mut()
+                .midi_serial_mut()?
+                .mt32_mut()?
+                .synth_mut(),
+        )
+    }
+
+    /// A press on the MT-32's front panel. The panel decides what it means;
+    /// anything it cannot reach itself comes back as an action.
+    #[cfg(feature = "mt32")]
+    fn press_mt32_control(&mut self, control: mt32panel::Mt32Control, left: bool, pos: (i32, i32)) {
+        let Some(rect) = mt32panel::shown_panel_rect(present_height()) else {
+            return;
+        };
+        let mut panel = std::mem::take(&mut self.mt32_panel);
+        let action = panel.press(control, left, pos, rect, self.mt32_synth_mut());
+        self.mt32_panel = panel;
+        self.apply_mt32_action(action);
+        self.request_redraw();
+    }
+
+    /// Carry out what the panel asked for.
+    #[cfg(feature = "mt32")]
+    fn apply_mt32_action(&mut self, action: mt32panel::PanelAction) {
+        use mt32panel::PanelAction;
+        match action {
+            PanelAction::None => {}
+            PanelAction::Say(text) => self.show_osd(text),
+            PanelAction::Power(_) => self.toggle_mt32_power(),
+            PanelAction::Recycle => {
+                if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
+                    // Off and on again is what a reset amounts to here: the
+                    // engine comes back at its power-on defaults.
+                    sink.set_mt32_power(false);
+                    sink.set_mt32_power(true);
+                }
+                self.emu.bus_mut().paula.rearm_synth_audio();
+                self.mt32_panel.reset();
+                self.show_osd("Munt MT-32: all reset");
+            }
+        }
+    }
+
+    /// The power switch.
+    #[cfg(feature = "mt32")]
+    fn toggle_mt32_power(&mut self) {
+        let on = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .is_some_and(|sink| sink.mt32().is_some());
+        if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
+            sink.set_mt32_power(!on);
+        }
+        // A fresh synth has to be asked for audio again, and the panel
+        // starts over: a unit just switched on is at its defaults, showing
+        // its greeting.
+        self.emu.bus_mut().paula.rearm_synth_audio();
+        self.mt32_panel.reset();
+        let came_up = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .is_some_and(|sink| sink.mt32().is_some());
+        if !on && !came_up {
+            // Asked to switch on and it did not: say why rather than
+            // claiming it is running.
+            self.report_mt32_fault();
+            return;
+        }
+        self.show_osd(if on {
+            "Munt MT-32: power off"
+        } else {
+            "Munt MT-32: power on"
+        });
+    }
+
+    /// Follow the pointer while a button is held on the dial.
+    #[cfg(feature = "mt32")]
+    fn drag_mt32_dial(&mut self, pos: (i32, i32)) {
+        let Some(rect) = mt32panel::shown_panel_rect(present_height()) else {
+            return;
+        };
+        let mut panel = std::mem::take(&mut self.mt32_panel);
+        panel.drag_dial(pos, rect, self.mt32_synth_mut());
+        self.mt32_panel = panel;
+        self.request_redraw();
+    }
+
+    /// Step the dial on while a button is held still on it.
+    #[cfg(feature = "mt32")]
+    fn repeat_mt32_dial(&mut self) {
+        if !self.mt32_panel.dial_held() {
+            return;
+        }
+        let mut panel = std::mem::take(&mut self.mt32_panel);
+        let moved = panel.repeat_dial(self.mt32_synth_mut());
+        self.mt32_panel = panel;
+        if moved {
+            self.request_redraw();
+        }
+    }
+
+    /// Say why the MT-32 is not there, if it was asked for and could not be
+    /// fitted. Said once: the fault is taken, not borrowed.
+    #[cfg(feature = "mt32")]
+    fn report_mt32_fault(&mut self) {
+        let fault = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .and_then(crate::midi::MidiSerialSink::take_mt32_fault);
+        if let Some(fault) = fault {
+            self.warn_osd(format!("Munt MT-32: {fault}"));
+        }
+    }
+
+    /// Bring the panel into line with what is on the port.
+    ///
+    /// Unplugging the MT-32 takes the panel down with it -- a fascia with no
+    /// instrument behind it is just a blank strip -- and plugging one in
+    /// starts its panel from scratch, so the engine's power-up greeting is
+    /// what shows.
+    #[cfg(feature = "mt32")]
+    fn sync_mt32_panel(&mut self) {
+        // Selected, not powered: switching the unit off leaves its panel
+        // where it is, which is the whole point of having a switch.
+        let selected = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .is_some_and(|sink| sink.mt32_selected());
+        self.mt32_panel.reset();
+        if !selected {
+            self.set_mt32_panel_shown(false);
+        }
+    }
+
+    /// What the MT-32's panel should show, when one is attached.
+    #[cfg(feature = "mt32")]
+    fn mt32_panel_view(&mut self) -> Option<mt32panel::Mt32PanelView> {
+        let sink = self.emu.bus_mut().midi_serial_mut()?;
+        if !sink.mt32_selected() {
+            return None;
+        }
+        // Switched off, the fascia is still there: dark display, no lamp.
+        let (lcd, led) = sink
+            .mt32()
+            .map_or_else(|| (String::new(), false), |mt32| mt32.synth().display());
+        let powered = sink.mt32().is_some();
+        let hover = self
+            .cursor_pos
+            .zip(mt32panel::shown_panel_rect(present_height()))
+            .and_then(|(pos, panel)| mt32panel::hover_at(panel, pos));
+        Some(self.mt32_panel.view(lcd, led, powered, hover))
+    }
+
+    /// Re-plan the presentation after the canvas height changed, and resize
+    /// every buffer that indexes by it. False when the texture could not be
+    /// resized, in which case the caller has to put its flag back: the draw
+    /// helpers size themselves from the flag, so a taller canvas over a
+    /// shorter buffer would index past it.
+    #[cfg(feature = "mt32")]
+    fn resync_canvas_height(&mut self) -> bool {
+        if let Some(r) = self.render.as_mut() {
+            let surface = r.window.inner_size();
+            if let Err(e) = sync_main_present_scaling(r, (surface.width, surface.height)) {
+                warn!("resize texture buffer for the MT-32 panel failed: {e}");
+                return false;
+            }
+        }
+        // Tool windows draw through the same canvas height, so their buffers
+        // follow too. Buffer only: their own window sizes are their business.
+        for kind in ToolPanelKind::ALL {
+            if let Some(tool) = self.tool_window_mut(kind) {
+                if let Err(e) = tool.pixels.resize_buffer(
+                    texture_width(tool.texture_scale) as u32,
+                    texture_height(tool.texture_scale) as u32,
+                ) {
+                    warn!("resize tool texture buffer for the MT-32 panel failed: {e}");
+                }
+                tool.window.request_redraw();
+            }
+        }
         true
     }
 
@@ -6177,7 +6558,13 @@ impl App {
             LauncherField::Rom
             | LauncherField::ExtendedRom
             | LauncherField::ScsiRom
-            | LauncherField::ScsiRomOdd => dialog.add_filter("ROM images", &["rom", "bin"]),
+            | LauncherField::ScsiRomOdd
+            | LauncherField::Mt32ControlRom
+            | LauncherField::Mt32PcmRom => {
+                // Both cases spelled out: ROM dumps are as often shouted as
+                // not, and some hosts match the filter case-sensitively.
+                dialog.add_filter("ROM images", &["rom", "ROM", "bin", "BIN"])
+            }
             LauncherField::Df0Image
             | LauncherField::Df1Image
             | LauncherField::Df2Image
@@ -6545,6 +6932,12 @@ impl App {
         self.perf = PerfOverlay::default();
         self.set_tint(crate::config::resolve_tint(cfg.tint));
         crate::video::set_menu_scale(cfg.menu_scale);
+        #[cfg(feature = "mt32")]
+        {
+            crate::video::set_mt32_lcd(cfg.serial.mt32_lcd);
+            self.set_mt32_panel_shown(cfg.serial.mt32_panel);
+            self.report_mt32_fault();
+        }
         self.ui.menu_open = false;
         self.ui.panel = None;
         self.powered_on = true;
@@ -9146,20 +9539,6 @@ impl App {
         }
     }
 
-    /// Whether the main window is still exactly the presentation canvas size in
-    /// logical points -- i.e. it has not been manually resized (fullscreen
-    /// counts as resized). Lets the status-bar toggle snap an untouched window
-    /// to the new canvas size while leaving a resized one alone.
-    fn window_is_canvas_sized(&self) -> bool {
-        let Some(window) = self.render.as_ref().map(|r| r.window.clone()) else {
-            return false;
-        };
-        if window.fullscreen().is_some() {
-            return false;
-        }
-        !self.window_manually_sized
-    }
-
     /// Classify a resize of the main window: the user's own drag, or the
     /// window following a canvas change.
     ///
@@ -9192,6 +9571,20 @@ impl App {
             return;
         }
         self.window_manually_sized = true;
+    }
+
+    /// Whether the main window still belongs to the canvas rather than to the
+    /// user -- i.e. it has not been manually resized (fullscreen counts as
+    /// resized). Lets a canvas change snap an untouched window to the new
+    /// size while leaving a resized one alone.
+    fn window_is_canvas_sized(&self) -> bool {
+        let Some(window) = self.render.as_ref().map(|r| r.window.clone()) else {
+            return false;
+        };
+        if window.fullscreen().is_some() {
+            return false;
+        }
+        !self.window_manually_sized
     }
 
     /// Cmd/Alt+M: toggle the monitor-bezel pass for the rest of the run
@@ -9604,15 +9997,25 @@ impl App {
         self.osd = Some(Osd {
             text: text.into(),
             expires_at: Instant::now() + OSD_DURATION,
+            warning: false,
         });
         self.request_redraw();
     }
 
     /// The overlay text to draw this frame, or None when nothing is
     /// active. Expired overlays are dropped as a side effect.
-    fn active_osd_text(&mut self) -> Option<String> {
+    /// Say something that did not go as asked, in amber.
+    fn warn_osd(&mut self, text: impl Into<String>) {
+        self.osd = Some(Osd {
+            text: text.into(),
+            expires_at: Instant::now() + OSD_DURATION,
+            warning: true,
+        });
+    }
+
+    fn active_osd_text(&mut self) -> Option<(String, bool)> {
         match &self.osd {
-            Some(osd) if Instant::now() < osd.expires_at => Some(osd.text.clone()),
+            Some(osd) if Instant::now() < osd.expires_at => Some((osd.text.clone(), osd.warning)),
             Some(_) => {
                 self.osd = None;
                 None
@@ -10108,6 +10511,8 @@ mod console;
 mod control;
 mod crt_shader;
 mod host_input;
+#[cfg(feature = "mt32")]
+mod mt32panel;
 mod present;
 mod rtg_texture;
 mod statusbar;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5159,8 +5159,15 @@ impl App {
         let Some(rect) = mt32panel::shown_panel_rect(present_height()) else {
             return;
         };
+        // A unit that is switched off still takes note of what is held on
+        // it, so the panel is told which it is.
+        let powered = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .is_some_and(|sink| sink.mt32().is_some());
         let mut panel = std::mem::take(&mut self.mt32_panel);
-        let action = panel.press(control, left, pos, rect, self.mt32_synth_mut());
+        let action = panel.press(control, left, pos, rect, powered, self.mt32_synth_mut());
         self.mt32_panel = panel;
         self.apply_mt32_action(action);
         self.request_redraw();
@@ -5204,6 +5211,7 @@ impl App {
         // its greeting.
         self.emu.bus_mut().paula.rearm_synth_audio();
         self.mt32_panel.reset();
+        self.tell_panel_the_rom_version();
         let came_up = self
             .emu
             .bus_mut()
@@ -5278,8 +5286,25 @@ impl App {
             .midi_serial_mut()
             .is_some_and(|sink| sink.mt32_selected());
         self.mt32_panel.reset();
+        self.tell_panel_the_rom_version();
         if !selected {
             self.set_mt32_panel_shown(false);
+        }
+    }
+
+    /// Hand the panel what the control ROM calls itself, for its version
+    /// screen. The engine keeps its copy of the image to itself, so this
+    /// comes from the sink, which read it off disk when the pair was
+    /// configured.
+    #[cfg(feature = "mt32")]
+    fn tell_panel_the_rom_version(&mut self) {
+        if let Some(version) = self
+            .emu
+            .bus_mut()
+            .midi_serial_mut()
+            .and_then(|sink| sink.mt32_version().map(str::to_string))
+        {
+            self.mt32_panel.set_version(version);
         }
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -10087,17 +10087,20 @@ impl App {
         self.request_redraw();
     }
 
-    /// The overlay text to draw this frame, or None when nothing is
-    /// active. Expired overlays are dropped as a side effect.
-    /// Say something that did not go as asked, in amber.
+    /// Say something that did not go as asked, in amber. Otherwise as
+    /// [`Self::show_osd`].
+    #[cfg(feature = "mt32")]
     fn warn_osd(&mut self, text: impl Into<String>) {
         self.osd = Some(Osd {
             text: text.into(),
             expires_at: Instant::now() + OSD_DURATION,
             warning: true,
         });
+        self.request_redraw();
     }
 
+    /// The overlay text to draw this frame, or None when nothing is
+    /// active. Expired overlays are dropped as a side effect.
     fn active_osd_text(&mut self) -> Option<(String, bool)> {
         match &self.osd {
             Some(osd) if Instant::now() < osd.expires_at => Some((osd.text.clone(), osd.warning)),

--- a/src/video/window/mt32panel.rs
+++ b/src/video/window/mt32panel.rs
@@ -113,6 +113,26 @@ const DIAL_SHOULDER: f32 = 34.0;
 /// Positions printed on the fascia around the dial, the first at seven
 /// o'clock and the last at five, as the unit marks its travel.
 const DIAL_MARKS: usize = 24;
+/// How many songs the dial cycles in demo mode. The later ROMs all carry
+/// this many; a shorter list simply repeats sooner.
+const DEMO_TRACKS: usize = 5;
+/// How many buttons can be latched at once. The unit's combinations are two
+/// or three; a fourth is a change of mind.
+const HOLD_LIMIT: usize = 3;
+/// Where the rhythm part sits among the nine. Its button is the sixth, but
+/// the part itself comes after the eight melodic ones -- and parts 6, 7 and
+/// 8 have no buttons at all, being reached by holding MASTER VOLUME with
+/// buttons 1, 2 and 3 (manual page 18).
+const RHYTHM_PART: usize = 8;
+
+/// The part a part button selects.
+fn part_for_button(button: usize) -> usize {
+    if button == 5 {
+        RHYTHM_PART
+    } else {
+        button
+    }
+}
 /// How far outside the rim they sit, and what they are printed in: dimmer
 /// than the captions, so they read as marks on the moulding rather than as
 /// another row of labels.
@@ -207,16 +227,10 @@ enum Chord {
 }
 
 impl Chord {
-    /// Whether this one waits for a further press before it takes effect,
-    /// as the manual's three-button procedures do.
-    fn needs_confirming(self) -> bool {
-        matches!(
-            self,
-            Chord::OverflowAssign | Chord::MidiChannels | Chord::AllReset
-        )
-    }
-
-    /// The button held with MASTER VOLUME to reach it.
+    /// The button held with MASTER VOLUME to reach it. Only the test that
+    /// checks the pairs against the manual needs to go this way round; the
+    /// panel itself reads the buttons and asks what they name.
+    #[cfg(test)]
     fn partner(self) -> Mt32Control {
         match self {
             Chord::MasterTune => Mt32Control::Function(Function::SoundGroup),
@@ -227,6 +241,15 @@ impl Chord {
             Chord::MidiChannels => Mt32Control::Part(4),
             Chord::AllReset => Mt32Control::Part(5),
         }
+    }
+
+    /// Whether this one waits for a further press before it takes effect,
+    /// as the manual's three-button procedures do.
+    fn needs_confirming(self) -> bool {
+        matches!(
+            self,
+            Chord::OverflowAssign | Chord::MidiChannels | Chord::AllReset
+        )
     }
 }
 
@@ -618,8 +641,12 @@ fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
     let matrix_h = CELL_ROWS * LCD_PX + CELL_FOOT_GAP + CELL_FOOT_H;
     let tx = lcd.x + LCD_BEZEL + glass_w.saturating_sub(matrix_w) / 2;
     let ty = lcd.y + LCD_BEZEL + glass_h.saturating_sub(matrix_h) / 2;
-    // The engine gives 20 characters; anything longer is its own business.
-    for (i, ch) in view.lcd.chars().take(crate::mt32::LCD_WIDTH).enumerate() {
+    // Every cell of the matrix is there whether anything is written in it
+    // or not, so the line is padded out to the width of the glass rather
+    // than drawn only as far as it happens to reach.
+    let mut line = view.lcd.chars().take(crate::mt32::LCD_WIDTH);
+    for i in 0..crate::mt32::LCD_WIDTH {
+        let ch = line.next().unwrap_or(' ');
         let x = tx + i * font::GLYPH_W * LCD_PX;
         let cell = Rect {
             x,
@@ -1198,86 +1225,54 @@ mod tests {
     }
 
     /// A pair is two buttons held together, so it takes two right clicks
-    /// and starts with MASTER VOLUME. Nothing else can stumble into one.
+    /// The unit's buttons are momentary micro-switches: a plain click
+    /// presses one and it comes straight back out. Only right-clicking
+    /// latches one down, which is how its combinations are made.
     #[test]
-    fn a_pair_takes_two_right_clicks_from_master_volume() {
+    fn the_buttons_are_momentary_and_only_a_right_click_latches_one() {
         let rect = panel_rect(500);
         let master = Mt32Control::Function(Function::MasterVolume);
         let group = Mt32Control::Function(Function::SoundGroup);
         let press = |p: &mut Mt32Panel, c, left| p.press(c, left, (0, 0), rect, true, None);
 
-        // Right, then right: the pair, with both buttons lit and nothing
-        // else.
+        // Right, then right: the pair, and reaching it lets go of both.
         let mut panel = Mt32Panel::default();
         press(&mut panel, master, false);
         press(&mut panel, group, false);
         assert_eq!(panel.mode, Mode::Chord(Chord::MasterTune));
-        assert_eq!(
-            panel.functions_lit(),
-            [true, false, false, true],
-            "only the two that made the pair"
-        );
+        assert!(panel.holding.is_empty(), "reaching it let go of them");
+        assert_eq!(panel.functions_lit(), [false; 4], "nothing left down");
 
-        // Left first: a plain press of MASTER VOLUME, and the next right
-        // click cannot turn it into a pair.
+        // A plain click lights its button only while the mouse is on it,
+        // and the display is what says where the unit got to.
         let mut panel = Mt32Panel::default();
-        press(&mut panel, master, true);
-        press(&mut panel, group, false);
-        assert_eq!(panel.mode, Mode::Function(Function::MasterVolume));
+        press(&mut panel, group, true);
+        assert_eq!(panel.functions_lit(), [true, false, false, false], "down");
+        panel.release_press();
+        assert_eq!(panel.functions_lit(), [false; 4], "and back out again");
+        assert_eq!(panel.mode, Mode::Function(Function::SoundGroup), "it acted");
 
-        // Right first, left second: the second is a press, not a hold.
+        // A plain click mid-combination drops what was latched.
         let mut panel = Mt32Panel::default();
         press(&mut panel, master, false);
+        assert_eq!(panel.holding.len(), 1, "latched");
         press(&mut panel, group, true);
-        assert_eq!(panel.mode, Mode::Function(Function::SoundGroup));
+        assert!(panel.holding.is_empty(), "the plain click let it go");
 
-        // Holding anything but MASTER VOLUME lights nothing: no pair
-        // begins with it.
+        // Right-clicking a latched button lets it go again.
         let mut panel = Mt32Panel::default();
         press(&mut panel, group, false);
-        assert_eq!(panel.mode, Mode::Home);
-        assert_eq!(panel.functions_lit(), [false; 4]);
-        assert_eq!(panel.parts_lit(), [false; 6]);
-    }
+        press(&mut panel, group, false);
+        assert!(panel.holding.is_empty(), "the second let it go");
 
-    /// Nothing is standing on anything until someone presses something,
-    /// and switching the unit off puts it back there.
-    #[test]
-    fn a_panel_at_rest_has_nothing_held_down() {
+        // Three is the most; a fourth is a change of mind.
         let mut panel = Mt32Panel::default();
-        let at_rest = |p: &Mt32Panel| {
-            let view = p.view(String::new(), false, true, None);
-            (view.parts_lit, view.functions_lit)
-        };
-        assert_eq!(
-            at_rest(&panel),
-            ([false; 6], [false; 4]),
-            "just switched on"
-        );
-
-        // Stand on something, and it shows.
-        let rect = panel_rect(500);
-        panel.press(
-            Mt32Control::Function(Function::Volume),
-            true,
-            (0, 0),
-            rect,
-            true,
-            None,
-        );
-        assert_ne!(
-            at_rest(&panel),
-            ([false; 6], [false; 4]),
-            "a button is down"
-        );
-
-        // Off and on again is a fresh unit, whatever was held before.
-        panel.reset();
-        assert_eq!(
-            at_rest(&panel),
-            ([false; 6], [false; 4]),
-            "after a power cycle"
-        );
+        for n in 0..HOLD_LIMIT {
+            press(&mut panel, Mt32Control::Part(n), false);
+        }
+        assert_eq!(panel.holding.len(), HOLD_LIMIT);
+        press(&mut panel, Mt32Control::Part(3), false);
+        assert!(panel.holding.is_empty(), "a fourth drops the lot");
     }
 
     /// Holding buttons on a unit that is off, then switching it on, is how
@@ -1287,13 +1282,14 @@ mod tests {
     fn buttons_held_through_a_power_on_ask_for_a_screen() {
         let rect = panel_rect(500);
         let master = Mt32Control::Function(Function::MasterVolume);
+        let vol = Mt32Control::Function(Function::Volume);
         // The unit is off: right-clicking holds, and any number at once.
         let start = |held: &[Mt32Control]| {
             let mut panel = Mt32Panel::default();
             panel.set_version("MT-32 v2.07 90-05-23".to_string());
-            for (i, &b) in held.iter().enumerate() {
-                // Either button holds one down on a unit that is off.
-                panel.press(b, i % 2 == 0, (0, 0), rect, false, None);
+            for &b in held {
+                // Right-clicking is what latches one, running or not.
+                panel.press(b, false, (0, 0), rect, false, None);
             }
             assert_eq!(panel.holding().len(), held.len(), "all of them are down");
             // And they light while they are held, so the chord can be seen
@@ -1323,8 +1319,59 @@ mod tests {
             "nothing is lit on it"
         );
 
-        // Nothing held, or the wrong set: it just starts.
-        for held in [vec![], vec![master], vec![Mt32Control::Part(0)]] {
+        // MASTER VOLUME on its own: the songs in the ROM. Which one it is
+        // showing is the window's to fill in, so it asks for one.
+        let mut demo = start(&[master]);
+        assert!(demo.playing_demo(), "it came up on ROM Play");
+        assert!(
+            demo.lcd().unwrap_or_default().starts_with("Chain Play"),
+            "offering the chain: {:?}",
+            demo.lcd()
+        );
+        assert_eq!(demo.demo_want(), None, "and waiting to be told");
+
+        // The numbers skip straight to a song; VOLUME replays the one it
+        // is on. SOUND GROUP stops, and it offers the chain again.
+        let press = |p: &mut Mt32Panel, c| p.press(c, true, (0, 0), rect, true, None);
+        press(&mut demo, Mt32Control::Part(2));
+        assert_eq!(demo.demo_want(), Some(DemoWant::Play(2)), "the third song");
+        demo.set_track_title("Adjarre".to_string());
+        assert_eq!(
+            demo.lcd().as_deref(),
+            Some("3:Adjarre       |100"),
+            "numbered as the manual numbers them"
+        );
+        press(&mut demo, vol);
+        assert_eq!(
+            demo.demo_want(),
+            Some(DemoWant::Play(2)),
+            "VOLUME replays it"
+        );
+
+        // A song that runs out rests a moment, then hands on to the next,
+        // round and round.
+        assert!(!demo.chain_ran_out(false), "resting between the two");
+        demo.ended_at = std::time::Instant::now().checked_sub(BETWEEN_SONGS);
+        assert!(demo.chain_ran_out(false), "it moved on");
+        assert_eq!(demo.demo_want(), Some(DemoWant::Play(3)));
+
+        press(&mut demo, Mt32Control::Function(Function::SoundGroup));
+        assert_eq!(demo.demo_want(), Some(DemoWant::Stop));
+        assert!(
+            demo.lcd().unwrap_or_default().starts_with("Chain Play"),
+            "back to offering the chain: {:?}",
+            demo.lcd()
+        );
+
+        // Nothing else on the panel answers while it is playing to itself.
+        press(&mut demo, Mt32Control::Function(Function::MasterVolume));
+        assert_eq!(demo.demo_want(), None, "MASTER VOLUME does nothing here");
+        demo.press(master, false, (0, 0), rect, true, None);
+        assert!(demo.holding.is_empty(), "and nothing latches");
+
+        // Nothing held, or a set that means nothing: it just starts. Only
+        // the buttons the screens use answer at all when it is off.
+        for held in [vec![], vec![Mt32Control::Part(0)]] {
             assert_eq!(start(&held).lcd(), None, "starts normally for {held:?}");
         }
     }
@@ -1432,6 +1479,8 @@ enum Mode {
 pub enum StartMode {
     /// PART 1 + PART 3 + MASTER VOLUME: what the control ROM calls itself.
     Version,
+    /// MASTER VOLUME on its own: the songs in the ROM, if it has any.
+    Demo,
 }
 
 impl StartMode {
@@ -1444,16 +1493,26 @@ impl StartMode {
                 Mt32Control::Part(2),
                 Mt32Control::Function(Function::MasterVolume),
             ],
+            StartMode::Demo => &[Mt32Control::Function(Function::MasterVolume)],
         }
     }
 
     /// Which screen a set of held buttons asks for, if any.
     fn from_held(held: &[Mt32Control]) -> Option<Self> {
-        [StartMode::Version].into_iter().find(|m| {
+        [StartMode::Version, StartMode::Demo].into_iter().find(|m| {
             let want = m.buttons();
             want.len() == held.len() && want.iter().all(|b| held.contains(b))
         })
     }
+}
+
+/// What ROM Play wants of the window, once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DemoWant {
+    /// Start this song, and say what it is called.
+    Play(usize),
+    /// Stop, and go back to what the engine was showing.
+    Stop,
 }
 
 /// A button held on the Select/Volume dial.
@@ -1474,6 +1533,11 @@ struct DialGrab {
 /// How long a button sits on the dial before it starts repeating.
 const DIAL_REPEAT_DELAY: std::time::Duration = std::time::Duration::from_millis(350);
 
+/// How long the chain rests between songs rather than running one straight
+/// into the next: the two hundred and forty ticks Munt's own player leaves,
+/// which at eighty a second is three of them.
+const BETWEEN_SONGS: std::time::Duration = std::time::Duration::from_secs(3);
+
 /// The MT-32's front panel: which part it is showing, which buttons are
 /// down, and what it believes each editable value to be.
 ///
@@ -1482,9 +1546,10 @@ const DIAL_REPEAT_DELAY: std::time::Duration = std::time::Duration::from_millis(
 #[derive(Debug)]
 pub struct Mt32Panel {
     mode: Mode,
-    /// The button being held down, put there by right-clicking it. Only
-    /// MASTER VOLUME leads anywhere, which is the unit's own arrangement.
-    held: Option<Mt32Control>,
+    /// The button a plain click is lighting, until the mouse comes back up.
+    /// The unit's buttons are momentary: one does its work and comes
+    /// straight back out.
+    flash: Option<Mt32Control>,
     /// The part being shown, 0-7 for parts 1-8 and 8 for rhythm.
     part: usize,
     master_volume: u8,
@@ -1496,9 +1561,10 @@ pub struct Mt32Panel {
     /// the unit's other channel arrangement.
     channels_shifted: bool,
     dial: Option<DialGrab>,
-    /// Buttons being held while the unit is off. Held through a power-on
-    /// they ask for a start-up screen, so they are kept apart from `held`,
-    /// which is the one-at-a-time business of a running unit.
+    /// Buttons latched down by right-clicking them, which is the only way
+    /// to get one to stay in: up to three at once, since nothing the unit
+    /// does wants a fourth. Running, they reach a menu; switched off, a
+    /// start-up screen.
     holding: Vec<Mt32Control>,
     /// What the control ROM calls itself, for the screen that shows it.
     /// Empty until the window has read the image.
@@ -1506,13 +1572,20 @@ pub struct Mt32Panel {
     /// The screen the buttons held through a power-on asked for, waiting
     /// for the unit to come up and take it.
     pending_start: Option<StartMode>,
+    /// ROM Play: which song, what it is called while it plays, and what
+    /// the window has still to be told to do about it.
+    track: usize,
+    track_title: String,
+    want: Option<DemoWant>,
+    /// When the song that just finished did, while the chain rests.
+    ended_at: Option<std::time::Instant>,
 }
 
 impl Default for Mt32Panel {
     fn default() -> Self {
         Self {
             mode: Mode::Home,
-            held: None,
+            flash: None,
             part: 0,
             // The engine's own power-on values: full volume, parts at 80,
             // the first timbre, A = 442 Hz, room reverb.
@@ -1526,6 +1599,10 @@ impl Default for Mt32Panel {
             holding: Vec::new(),
             version: String::new(),
             pending_start: None,
+            track: 0,
+            track_title: String::new(),
+            want: None,
+            ended_at: None,
         }
     }
 }
@@ -1552,6 +1629,43 @@ impl Mt32Panel {
     /// keeps its copy to itself.
     pub fn set_version(&mut self, version: String) {
         self.version = version;
+    }
+
+    /// Hand on when a song runs out, which is what makes the chain a
+    /// chain. True when the panel wants drawing again.
+    pub fn chain_ran_out(&mut self, still_playing: bool) -> bool {
+        if still_playing || !self.playing_demo() || self.track_title.is_empty() {
+            return false;
+        }
+        // A moment's rest before the next one, rather than the two running
+        // together.
+        let Some(ended) = self.ended_at else {
+            self.ended_at = Some(std::time::Instant::now());
+            return false;
+        };
+        if ended.elapsed() < BETWEEN_SONGS {
+            return false;
+        }
+        self.ended_at = None;
+        self.track = (self.track + 1) % DEMO_TRACKS;
+        self.want = Some(DemoWant::Play(self.track));
+        true
+    }
+
+    /// What ROM Play wants doing, once.
+    pub fn demo_want(&mut self) -> Option<DemoWant> {
+        self.want.take()
+    }
+
+    /// What the song that started turned out to be called; empty for one
+    /// that stopped, or a ROM with none to play.
+    pub fn set_track_title(&mut self, title: String) {
+        self.track_title = title;
+    }
+
+    /// Whether the unit came up playing its own songs.
+    pub fn playing_demo(&self) -> bool {
+        matches!(self.mode, Mode::Started(StartMode::Demo))
     }
 
     /// Which buttons are being held on a unit that is switched off.
@@ -1585,69 +1699,65 @@ impl Mt32Panel {
         powered: bool,
         synth: Option<&mut crate::mt32::Mt32Synth>,
     ) -> PanelAction {
-        // A unit that is off does nothing except take note of what is being
-        // held on it, and come up into whatever that asks for. This is how
-        // its start-up screens are reached on the hardware: hold the
-        // buttons, then switch it on.
-        if !powered {
-            return self.press_while_off(control);
-        }
         // The dial is not a button: its two clicks step it either way.
         if control == Mt32Control::Dial {
             self.grab_dial(left, pos, rect, synth);
             return PanelAction::None;
         }
+        // The switch takes whatever is latched and lets go of it, the way a
+        // hand comes off the panel to reach it.
         if control == Mt32Control::Power {
+            self.pending_start = (!powered)
+                .then(|| StartMode::from_held(&self.holding))
+                .flatten();
+            self.holding.clear();
             return PanelAction::Power(true);
         }
-        // A start-up screen stays until the unit is asked for something
-        // else, which is any press at all.
+        // ROM Play has the panel to itself: the unit is not doing anything
+        // else, so nothing else answers while it is up.
+        if powered && self.playing_demo() {
+            self.flash = left.then_some(control);
+            self.holding.clear();
+            return self.press_in_rom_play(control);
+        }
+        // Right-clicking latches a button down. That is the only way to get
+        // one to stay in, and what the unit's combinations are made of.
+        if !left {
+            self.latch(control);
+            // Reaching what a combination names lets go of it again.
+            if powered {
+                if let Some(chord) = self.latched_chord() {
+                    self.holding.clear();
+                    return self.enter_chord(chord);
+                }
+            }
+            return PanelAction::None;
+        }
+        // A plain click is momentary: it lights while the mouse is down,
+        // does its work, and drops anything that was latched.
+        self.flash = Some(control);
+        self.holding.clear();
+        if !powered {
+            return PanelAction::None;
+        }
+        // The version screen goes away on any press.
         if matches!(self.mode, Mode::Started(_)) {
             self.release(synth);
             return PanelAction::None;
         }
-
-        // A pair is two buttons held down together, so both presses are
-        // right-clicks: MASTER VOLUME to take hold, then the button it is
-        // held with. A left click is a plain press and lets go of it.
-        let master = Mt32Control::Function(Function::MasterVolume);
-        if !left && self.held == Some(master) && control != master {
-            self.held = None;
-            return match chord_for(control) {
-                Some(chord) => self.enter_chord(chord),
-                None => PanelAction::None,
-            };
-        }
-
         // A pair waiting to be confirmed takes the next part press.
         if let (Mode::Confirm(chord), Mt32Control::Part(n)) = (self.mode, control) {
             return self.confirm_chord(chord, n, synth);
         }
-
-        if !left {
-            // Only MASTER VOLUME leads anywhere held down -- every one of
-            // the unit's pairs starts with it -- so holding anything else
-            // would light a button that could not do anything.
-            if control == master {
-                self.held = if self.held == Some(master) {
-                    None
-                } else {
-                    Some(master)
-                };
-            }
-            return PanelAction::None;
-        }
-
-        self.held = None;
         match control {
             // Pressing what is already showing goes back to the main
-            // screen, which is where the unit rests with nothing lit.
-            Mt32Control::Part(n) if self.part == n && self.mode != Mode::Home => {
+            // screen, which is where the unit rests.
+            Mt32Control::Part(n) if self.part == part_for_button(n) && self.mode != Mode::Home => {
                 self.release(synth);
             }
             Mt32Control::Function(f) if self.mode == Mode::Function(f) => self.release(synth),
             Mt32Control::Part(n) => {
-                self.part = n;
+                self.part = part_for_button(n);
                 self.mode = Mode::Function(Function::Volume);
             }
             Mt32Control::Function(f) => self.mode = Mode::Function(f),
@@ -1656,37 +1766,64 @@ impl Mt32Panel {
         PanelAction::None
     }
 
-    /// A press on a unit that is switched off.
-    ///
-    /// Either button holds one down, and any number can be held at once:
-    /// a unit that is off has no other use for a press, so there is nothing
-    /// for a plain one to mean instead. They light while they are held, the
-    /// way a hand on the panel can be seen. The power switch takes what is
-    /// held and lets go of it, as the hand comes off to reach it.
-    fn press_while_off(&mut self, control: Mt32Control) -> PanelAction {
-        match control {
-            Mt32Control::Power => {
-                self.pending_start = StartMode::from_held(&self.holding);
-                self.holding.clear();
-                PanelAction::Power(true)
-            }
-            Mt32Control::Dial => PanelAction::None,
-            button => {
-                if let Some(i) = self.holding.iter().position(|&h| h == button) {
-                    self.holding.remove(i);
-                } else {
-                    self.holding.push(button);
-                }
-                PanelAction::None
-            }
+    /// Let a plain click's button back out, as the mouse comes up.
+    pub fn release_press(&mut self) {
+        self.flash = None;
+    }
+
+    /// Latch a button down, or let it go if it already is. A fourth drops
+    /// the lot: nothing the unit does takes more than three, so a fourth is
+    /// a change of mind rather than a combination.
+    fn latch(&mut self, button: Mt32Control) {
+        if let Some(i) = self.holding.iter().position(|&h| h == button) {
+            self.holding.remove(i);
+        } else if self.holding.len() >= HOLD_LIMIT {
+            self.holding.clear();
+        } else {
+            self.holding.push(button);
         }
+    }
+
+    /// What is latched, if it names one of the unit's two-button functions:
+    /// MASTER VOLUME and one other, which is what all of them are.
+    fn latched_chord(&self) -> Option<Chord> {
+        let master = Mt32Control::Function(Function::MasterVolume);
+        let [a, b] = self.holding[..] else {
+            return None;
+        };
+        match (a, b) {
+            (m, other) | (other, m) if m == master => chord_for(other),
+            _ => None,
+        }
+    }
+
+    /// A press in ROM Play.
+    ///
+    /// VOLUME plays, the numbers skip straight to a song, SOUND GROUP
+    /// stops, and the dial is the master volume. Nothing else does
+    /// anything: the unit is playing to itself.
+    fn press_in_rom_play(&mut self, control: Mt32Control) -> PanelAction {
+        // Asking for a song is not waiting for one.
+        self.ended_at = None;
+        match control {
+            Mt32Control::Part(n) if n < DEMO_TRACKS => self.track = n,
+            Mt32Control::Function(Function::Volume) => {}
+            Mt32Control::Function(Function::SoundGroup) => {
+                self.track_title.clear();
+                self.want = Some(DemoWant::Stop);
+                return PanelAction::None;
+            }
+            _ => return PanelAction::None,
+        }
+        self.want = Some(DemoWant::Play(self.track));
+        PanelAction::None
     }
 
     /// Let the display go back to the engine, as the unit does when it
     /// returns to its main screen.
     fn release(&mut self, synth: Option<&mut crate::mt32::Mt32Synth>) {
         self.mode = Mode::Home;
-        self.held = None;
+        self.holding.clear();
         if let Some(synth) = synth {
             synth.show_main_display();
         }
@@ -1746,7 +1883,7 @@ impl Mt32Panel {
                     synth.show_main_display();
                 }
                 self.mode = Mode::Home;
-                self.held = None;
+                self.holding.clear();
                 PanelAction::Say(format!(
                     "Munt MT-32: parts 1-8 on channels {}-{}",
                     base + 1,
@@ -1855,6 +1992,9 @@ impl Mt32Panel {
     fn dial_target(&self) -> (u8, u8) {
         let part = self.part;
         match self.mode {
+            // Through the demo the dial is the master volume, wherever in
+            // it the unit has got to.
+            Mode::Started(StartMode::Demo) => (self.master_volume, 100),
             // A pair takes the dial over from either button's own meaning.
             Mode::Chord(Chord::MasterTune) => (self.master_tune, 127),
             Mode::Chord(Chord::ReverbMode) => (self.reverb_mode, 3),
@@ -1873,6 +2013,10 @@ impl Mt32Panel {
         use crate::mt32::addr;
         let part = self.part;
         let (address, value) = match self.mode {
+            Mode::Started(StartMode::Demo) => {
+                self.master_volume = value.min(100);
+                (addr::MASTER_VOLUME, self.master_volume)
+            }
             Mode::Chord(Chord::MasterTune) => {
                 self.master_tune = value.min(127);
                 (addr::MASTER_TUNE, self.master_tune)
@@ -1945,66 +2089,27 @@ impl Mt32Panel {
         }
     }
 
-    /// Which part buttons are lit: the one the panel is standing on, with 1,
-    /// 2 and 3 standing in for parts 6, 7 and 8, plus whichever a pair was
-    /// reached through. Nothing at rest -- the unit has no lamps.
+    /// Which part buttons are lit, and which function buttons.
+    ///
+    /// Only what is physically down: a button latched by right-clicking it,
+    /// or one lighting under a plain click while the mouse is still on it.
+    /// The unit's buttons are momentary and carry no lamps, so where it has
+    /// got to is read off its display, never off the panel.
     fn parts_lit(&self) -> [bool; 6] {
         let mut lit = [false; 6];
-        // Held down on a unit that is off, so a start-up chord can be seen
-        // as it is made rather than felt for.
-        for &down in &self.holding {
+        for down in self.holding.iter().chain(self.flash.iter()) {
             if let Mt32Control::Part(n) = down {
-                lit[n] = true;
+                lit[*n] = true;
             }
-        }
-        if let Some(Mt32Control::Part(n)) = self.held {
-            lit[n] = true;
-        }
-        match self.mode {
-            // Nothing is lit at rest, nor on a screen the unit came up
-            // into: the buttons that asked for it were let go of to reach
-            // the switch.
-            Mode::Home | Mode::Started(_) => {}
-            // A pair or a prompt lights the button it was reached through.
-            Mode::Chord(chord) | Mode::Confirm(chord) => {
-                if let Mt32Control::Part(n) = chord.partner() {
-                    lit[n] = true;
-                }
-            }
-            Mode::Function(f) if f != Function::MasterVolume => {
-                // Parts 1-5 and Rhythm are their own buttons; 6, 7 and 8
-                // show on the buttons that reach them, 1, 2 and 3.
-                let button = match self.part {
-                    p @ 0..=5 => p,
-                    p => p - 5,
-                };
-                lit[button.min(5)] = true;
-            }
-            Mode::Function(_) => {}
         }
         lit
     }
 
-    /// Which function buttons are lit. A pair lights MASTER VOLUME as well
-    /// as its partner, so all of the buttons that reached it are shown.
     fn functions_lit(&self) -> [bool; 4] {
         let mut lit = [false; 4];
-        for &down in &self.holding {
+        for down in self.holding.iter().chain(self.flash.iter()) {
             if let Mt32Control::Function(f) = down {
                 lit[f.index()] = true;
-            }
-        }
-        if let Some(Mt32Control::Function(f)) = self.held {
-            lit[f.index()] = true;
-        }
-        match self.mode {
-            Mode::Home | Mode::Started(_) => {}
-            Mode::Function(f) => lit[f.index()] = true,
-            Mode::Chord(chord) | Mode::Confirm(chord) => {
-                lit[Function::MasterVolume.index()] = true;
-                if let Mt32Control::Function(f) = chord.partner() {
-                    lit[f.index()] = true;
-                }
             }
         }
         lit
@@ -2019,6 +2124,17 @@ impl Mt32Panel {
             // What the unit came up showing, held until it is asked for
             // something else.
             Mode::Started(StartMode::Version) => return Some(self.version.clone()),
+            Mode::Started(StartMode::Demo) => {
+                // It offers the chain until something is playing, then says
+                // which song, numbered as the manual numbers them.
+                let left = match &self.track_title {
+                    t if t.is_empty() => "Chain Play".to_string(),
+                    t => format!("{}:{t}", self.track + 1),
+                };
+                // The volume rides at the right behind the unit's own
+                // delimiter, which is what it shows there.
+                return Some(format!("{left:<16}|{:>3}", self.master_volume));
+            }
             // The unit's own wording, and its own units: the tune reads in
             // hertz across 427.5 to 452.6.
             Mode::Chord(Chord::MasterTune) => {
@@ -2036,8 +2152,8 @@ impl Mt32Panel {
             Mode::Confirm(_) => return Some("Overflow Assign? [1]".to_string()),
             Mode::Function(f) => f,
         };
-        // Parts read 1-5 and R, as they are labelled.
-        let name = if self.part == 5 {
+        // Parts read 1-8, and the rhythm part reads R as it is labelled.
+        let name = if self.part == RHYTHM_PART {
             "R".to_string()
         } else {
             (self.part + 1).to_string()

--- a/src/video/window/mt32panel.rs
+++ b/src/video/window/mt32panel.rs
@@ -1204,7 +1204,7 @@ mod tests {
         let rect = panel_rect(500);
         let master = Mt32Control::Function(Function::MasterVolume);
         let group = Mt32Control::Function(Function::SoundGroup);
-        let press = |p: &mut Mt32Panel, c, left| p.press(c, left, (0, 0), rect, None);
+        let press = |p: &mut Mt32Panel, c, left| p.press(c, left, (0, 0), rect, true, None);
 
         // Right, then right: the pair, with both buttons lit and nothing
         // else.
@@ -1262,6 +1262,7 @@ mod tests {
             true,
             (0, 0),
             rect,
+            true,
             None,
         );
         assert_ne!(
@@ -1277,6 +1278,76 @@ mod tests {
             ([false; 6], [false; 4]),
             "after a power cycle"
         );
+    }
+
+    /// Holding buttons on a unit that is off, then switching it on, is how
+    /// its start-up screens are reached -- and holding the wrong ones just
+    /// starts it normally.
+    #[test]
+    fn buttons_held_through_a_power_on_ask_for_a_screen() {
+        let rect = panel_rect(500);
+        let master = Mt32Control::Function(Function::MasterVolume);
+        // The unit is off: right-clicking holds, and any number at once.
+        let start = |held: &[Mt32Control]| {
+            let mut panel = Mt32Panel::default();
+            panel.set_version("MT-32 v2.07 90-05-23".to_string());
+            for (i, &b) in held.iter().enumerate() {
+                // Either button holds one down on a unit that is off.
+                panel.press(b, i % 2 == 0, (0, 0), rect, false, None);
+            }
+            assert_eq!(panel.holding().len(), held.len(), "all of them are down");
+            // And they light while they are held, so the chord can be seen
+            // being made rather than felt for.
+            let (parts, functions) = (panel.parts_lit(), panel.functions_lit());
+            for &b in held {
+                match b {
+                    Mt32Control::Part(n) => assert!(parts[n], "PART {} is lit", n + 1),
+                    Mt32Control::Function(f) => assert!(functions[f.index()], "{f:?} is lit"),
+                    _ => {}
+                }
+            }
+            // The switch takes what is held and lets go of it.
+            let action = panel.press(Mt32Control::Power, true, (0, 0), rect, false, None);
+            assert!(matches!(action, PanelAction::Power(true)), "it switches on");
+            assert!(panel.holding().is_empty(), "the hand came off the panel");
+            panel.reset();
+            panel
+        };
+
+        // PART 1 + PART 3 + MASTER VOLUME: what the ROM calls itself.
+        let version = start(&[Mt32Control::Part(0), Mt32Control::Part(2), master]);
+        assert_eq!(version.lcd().as_deref(), Some("MT-32 v2.07 90-05-23"));
+        assert_eq!(
+            (version.parts_lit(), version.functions_lit()),
+            ([false; 6], [false; 4]),
+            "nothing is lit on it"
+        );
+
+        // Nothing held, or the wrong set: it just starts.
+        for held in [vec![], vec![master], vec![Mt32Control::Part(0)]] {
+            assert_eq!(start(&held).lcd(), None, "starts normally for {held:?}");
+        }
+    }
+
+    /// A start-up screen holds until the unit is asked for something else.
+    #[test]
+    fn the_next_press_puts_the_start_up_screen_away() {
+        let rect = panel_rect(500);
+        let mut panel = Mt32Panel::default();
+        panel.set_version("MT-32 v2.07 90-05-23".to_string());
+        for b in [
+            Mt32Control::Part(0),
+            Mt32Control::Part(2),
+            Mt32Control::Function(Function::MasterVolume),
+        ] {
+            panel.press(b, false, (0, 0), rect, false, None);
+        }
+        panel.press(Mt32Control::Power, true, (0, 0), rect, false, None);
+        panel.reset();
+        assert!(panel.lcd().is_some(), "showing the version");
+
+        panel.press(Mt32Control::Part(1), true, (0, 0), rect, true, None);
+        assert_eq!(panel.lcd(), None, "back to the engine's own display");
     }
 
     /// The pointer finds each control where it is drawn.
@@ -1347,6 +1418,42 @@ enum Mode {
     /// A pair that wants a further press before it does anything, as the
     /// manual's three-button procedures do.
     Confirm(Chord),
+    /// A screen the unit was started into, holding buttons down while it
+    /// was switched on. It stays until something is pressed.
+    Started(StartMode),
+}
+
+/// What holding buttons down through a power-on reaches.
+///
+/// The unit reads its front panel as it starts and takes what it finds
+/// there as an instruction, which is how its service screens are got at
+/// without a menu to hide them behind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartMode {
+    /// PART 1 + PART 3 + MASTER VOLUME: what the control ROM calls itself.
+    Version,
+}
+
+impl StartMode {
+    /// The buttons held through the power-on that reach it. Order does not
+    /// matter; holding exactly this set and no more is what counts.
+    fn buttons(self) -> &'static [Mt32Control] {
+        match self {
+            StartMode::Version => &[
+                Mt32Control::Part(0),
+                Mt32Control::Part(2),
+                Mt32Control::Function(Function::MasterVolume),
+            ],
+        }
+    }
+
+    /// Which screen a set of held buttons asks for, if any.
+    fn from_held(held: &[Mt32Control]) -> Option<Self> {
+        [StartMode::Version].into_iter().find(|m| {
+            let want = m.buttons();
+            want.len() == held.len() && want.iter().all(|b| held.contains(b))
+        })
+    }
 }
 
 /// A button held on the Select/Volume dial.
@@ -1389,6 +1496,16 @@ pub struct Mt32Panel {
     /// the unit's other channel arrangement.
     channels_shifted: bool,
     dial: Option<DialGrab>,
+    /// Buttons being held while the unit is off. Held through a power-on
+    /// they ask for a start-up screen, so they are kept apart from `held`,
+    /// which is the one-at-a-time business of a running unit.
+    holding: Vec<Mt32Control>,
+    /// What the control ROM calls itself, for the screen that shows it.
+    /// Empty until the window has read the image.
+    version: String,
+    /// The screen the buttons held through a power-on asked for, waiting
+    /// for the unit to come up and take it.
+    pending_start: Option<StartMode>,
 }
 
 impl Default for Mt32Panel {
@@ -1406,6 +1523,9 @@ impl Default for Mt32Panel {
             reverb_mode: 0,
             channels_shifted: false,
             dial: None,
+            holding: Vec::new(),
+            version: String::new(),
+            pending_start: None,
         }
     }
 }
@@ -1413,7 +1533,31 @@ impl Default for Mt32Panel {
 impl Mt32Panel {
     /// Start over, as a unit just switched on is.
     pub fn reset(&mut self) {
-        *self = Self::default();
+        // The version outlives a power cycle: it is what the ROM says, not
+        // anything the unit is doing. A screen asked for on the way up is
+        // what the unit comes up showing.
+        let version = std::mem::take(&mut self.version);
+        let started = self.pending_start.take();
+        *self = Self {
+            version,
+            ..Self::default()
+        };
+        if let Some(mode) = started {
+            self.mode = Mode::Started(mode);
+        }
+    }
+
+    /// Tell the panel what the control ROM calls itself, for the screen
+    /// that shows it. Read from the image by the window, since the engine
+    /// keeps its copy to itself.
+    pub fn set_version(&mut self, version: String) {
+        self.version = version;
+    }
+
+    /// Which buttons are being held on a unit that is switched off.
+    #[cfg(test)]
+    fn holding(&self) -> &[Mt32Control] {
+        &self.holding
     }
 
     /// Let the pointer go, ending any turn of the dial.
@@ -1438,8 +1582,16 @@ impl Mt32Panel {
         left: bool,
         pos: (i32, i32),
         rect: Rect,
+        powered: bool,
         synth: Option<&mut crate::mt32::Mt32Synth>,
     ) -> PanelAction {
+        // A unit that is off does nothing except take note of what is being
+        // held on it, and come up into whatever that asks for. This is how
+        // its start-up screens are reached on the hardware: hold the
+        // buttons, then switch it on.
+        if !powered {
+            return self.press_while_off(control);
+        }
         // The dial is not a button: its two clicks step it either way.
         if control == Mt32Control::Dial {
             self.grab_dial(left, pos, rect, synth);
@@ -1447,6 +1599,12 @@ impl Mt32Panel {
         }
         if control == Mt32Control::Power {
             return PanelAction::Power(true);
+        }
+        // A start-up screen stays until the unit is asked for something
+        // else, which is any press at all.
+        if matches!(self.mode, Mode::Started(_)) {
+            self.release(synth);
+            return PanelAction::None;
         }
 
         // A pair is two buttons held down together, so both presses are
@@ -1496,6 +1654,32 @@ impl Mt32Panel {
             Mt32Control::Dial | Mt32Control::Power => {}
         }
         PanelAction::None
+    }
+
+    /// A press on a unit that is switched off.
+    ///
+    /// Either button holds one down, and any number can be held at once:
+    /// a unit that is off has no other use for a press, so there is nothing
+    /// for a plain one to mean instead. They light while they are held, the
+    /// way a hand on the panel can be seen. The power switch takes what is
+    /// held and lets go of it, as the hand comes off to reach it.
+    fn press_while_off(&mut self, control: Mt32Control) -> PanelAction {
+        match control {
+            Mt32Control::Power => {
+                self.pending_start = StartMode::from_held(&self.holding);
+                self.holding.clear();
+                PanelAction::Power(true)
+            }
+            Mt32Control::Dial => PanelAction::None,
+            button => {
+                if let Some(i) = self.holding.iter().position(|&h| h == button) {
+                    self.holding.remove(i);
+                } else {
+                    self.holding.push(button);
+                }
+                PanelAction::None
+            }
+        }
     }
 
     /// Let the display go back to the engine, as the unit does when it
@@ -1766,11 +1950,21 @@ impl Mt32Panel {
     /// reached through. Nothing at rest -- the unit has no lamps.
     fn parts_lit(&self) -> [bool; 6] {
         let mut lit = [false; 6];
+        // Held down on a unit that is off, so a start-up chord can be seen
+        // as it is made rather than felt for.
+        for &down in &self.holding {
+            if let Mt32Control::Part(n) = down {
+                lit[n] = true;
+            }
+        }
         if let Some(Mt32Control::Part(n)) = self.held {
             lit[n] = true;
         }
         match self.mode {
-            Mode::Home => {}
+            // Nothing is lit at rest, nor on a screen the unit came up
+            // into: the buttons that asked for it were let go of to reach
+            // the switch.
+            Mode::Home | Mode::Started(_) => {}
             // A pair or a prompt lights the button it was reached through.
             Mode::Chord(chord) | Mode::Confirm(chord) => {
                 if let Mt32Control::Part(n) = chord.partner() {
@@ -1795,11 +1989,16 @@ impl Mt32Panel {
     /// as its partner, so all of the buttons that reached it are shown.
     fn functions_lit(&self) -> [bool; 4] {
         let mut lit = [false; 4];
+        for &down in &self.holding {
+            if let Mt32Control::Function(f) = down {
+                lit[f.index()] = true;
+            }
+        }
         if let Some(Mt32Control::Function(f)) = self.held {
             lit[f.index()] = true;
         }
         match self.mode {
-            Mode::Home => {}
+            Mode::Home | Mode::Started(_) => {}
             Mode::Function(f) => lit[f.index()] = true,
             Mode::Chord(chord) | Mode::Confirm(chord) => {
                 lit[Function::MasterVolume.index()] = true;
@@ -1817,6 +2016,9 @@ impl Mt32Panel {
     fn lcd(&self) -> Option<String> {
         let function = match self.mode {
             Mode::Home => return None,
+            // What the unit came up showing, held until it is asked for
+            // something else.
+            Mode::Started(StartMode::Version) => return Some(self.version.clone()),
             // The unit's own wording, and its own units: the tune reads in
             // hertz across 427.5 to 452.6.
             Mode::Chord(Chord::MasterTune) => {

--- a/src/video/window/mt32panel.rs
+++ b/src/video/window/mt32panel.rs
@@ -1,0 +1,1860 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The Munt MT-32's front panel, drawn under the display.
+//!
+//! Laid out the way the unit is: the LCD at the left with the MIDI MESSAGE
+//! lamp beside it, then the six part buttons under an underlined PART, then
+//! the four function buttons, and the Select/Volume dial at the right with
+//! its travel marked out around it. It is a panel for driving the emulated
+//! synth, not a picture of the hardware -- the proportions follow the unit
+//! because that is what makes it legible, and nothing is copied from it.
+
+use super::statusbar::draw_power_glyph_sized;
+use super::statusbar::{draw_rect_bevel, fill_rect};
+use super::Rect;
+use super::{
+    texture_height, texture_width, LED_BEZEL_DARK, LED_BEZEL_LIGHT, POWER_GLYPH_OFF,
+    POWER_GLYPH_ON, STATUS_BOTTOM,
+};
+use crate::video::font;
+
+/// How tall the panel is. Two rows of buttons and their captions need more
+/// than the status bar's 44, and the dial wants to be round with room for
+/// the marks around it.
+pub const MT32_PANEL_HEIGHT: usize = 60;
+
+// The fascia and its buttons are the status bar's, so the two strips read
+// as one piece of chrome rather than two greys that nearly match.
+use super::{BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE, STATUS_BG, STATUS_TEXT, STATUS_TOP};
+const PANEL_FACE: u32 = STATUS_BG;
+const PANEL_EDGE_LIGHT: u32 = STATUS_TOP;
+const PANEL_EDGE_DARK: u32 = STATUS_BOTTOM;
+const CAPTION: u32 = STATUS_TEXT;
+/// The gloss panel the display and its lamp are set into: the fascia is a
+/// matt near-black, and this is the shinier black around the glass, as the
+/// unit has.
+const LCD_SURROUND: u32 = rgba(9, 9, 11);
+const LCD_SURROUND_SHEEN: u32 = rgba(26, 26, 30);
+
+/// What the glass and its characters look like, per style.
+///
+/// Unlit is its own colour: the MT-32's backlight simply goes out, while a
+/// JV-1080 keeps its blue a shade darker.
+struct LcdColours {
+    glass: u32,
+    dark_glass: u32,
+    text: u32,
+    /// The unlit dot matrix behind each character, when the display shows
+    /// one. A shade off the field around it, which is what makes the cells
+    /// countable without competing with the writing over them.
+    cell: Option<u32>,
+}
+
+fn lcd_colours() -> LcdColours {
+    use crate::config::Mt32Lcd;
+    match crate::video::mt32_lcd() {
+        // Lit in the same green as the status bar's track counter, so the
+        // two readouts match. An OLED drives its dots rather than masking
+        // them, so there is no matrix to see behind the characters.
+        Mt32Lcd::Oled => LcdColours {
+            glass: super::TRACK_DISPLAY_BG,
+            dark_glass: rgba(4, 5, 4),
+            text: super::TRACK_SEGMENT_ON,
+            cell: None,
+        },
+        // Lighter green characters over a lit green backlight; black once
+        // that backlight is out.
+        Mt32Lcd::Mt32 => LcdColours {
+            glass: rgba(20, 45, 12),
+            // Unlit it is bare glass rather than a hole: the same green with
+            // the backlight out of it, barely above the surround, so the
+            // panel still reads as having a display in it.
+            dark_glass: rgba(8, 17, 7),
+            text: rgba(198, 222, 107),
+            // The cells sit a shade above the field they are masked out of,
+            // which is what makes them countable at a glance.
+            cell: Some(rgba(38, 68, 22)),
+        },
+        // Deep blue, pale green characters, and the blue stays when it is
+        // off.
+        Mt32Lcd::Jv1080 => LcdColours {
+            glass: rgba(10, 26, 74),
+            dark_glass: rgba(6, 15, 44),
+            // A little brighter than it would otherwise want to be: the
+            // gaps between its dots show deep blue rather than dark green,
+            // which takes more out of the characters than the MT-32's do.
+            text: rgba(184, 240, 110),
+            // There on the unit too, but only just: a shade off the glass,
+            // where the MT-32's own can be counted at a glance.
+            cell: Some(rgba(16, 34, 86)),
+        },
+    }
+}
+/// The MIDI MESSAGE lamp, dark and lit. It is a lamp behind tinted plastic
+/// rather than part of the display, so it keeps its own green whichever
+/// glass the panel is wearing; unlit it is barely green at all.
+const LED_DARK: u32 = rgba(9, 20, 11);
+const LED_LIT: u32 = rgba(52, 206, 74);
+/// A button being held down: darker than its own face, near enough the
+/// fascia that it reads as having gone into the panel rather than changed
+/// colour. Unlit buttons are the status bar's, and so is the dial -- the
+/// same moulding, turned instead of pressed.
+const BUTTON_FACE_PRESSED: u32 = rgba(30, 30, 28);
+/// How far a button lifts under the pointer: within a shade of the step the
+/// status bar's own buttons take, so a hover reads the same wherever on the
+/// window it happens.
+const HOVER_LIFT: f32 = 16.0;
+const DIAL_MARK: u32 = rgba(200, 202, 208);
+/// How far the dome lifts the top of the dial's face above the bottom.
+/// Small on purpose: enough to round it, not enough to read as a sphere.
+const DIAL_DOME: f32 = 14.0;
+/// How much the moulding just inside the rim catches the same light.
+const DIAL_SHOULDER: f32 = 34.0;
+/// Positions printed on the fascia around the dial, the first at seven
+/// o'clock and the last at five, as the unit marks its travel.
+const DIAL_MARKS: usize = 24;
+/// How far outside the rim they sit, and what they are printed in: dimmer
+/// than the captions, so they read as marks on the moulding rather than as
+/// another row of labels.
+const DIAL_MARK_GAP: f32 = 3.0;
+const DIAL_TICK: u32 = rgba(96, 94, 86);
+
+const fn rgba(r: u8, g: u8, b: u8) -> u32 {
+    u32::from_le_bytes([r, g, b, 0xFF])
+}
+
+/// The same colour lifted towards the light (positive) or turned away from
+/// it (negative), which is all the shading on the dial's face amounts to.
+fn shade(colour: u32, by: f32) -> u32 {
+    let [r, g, b, a] = colour.to_le_bytes();
+    let step = |c: u8| (f32::from(c) + by).clamp(0.0, 255.0) as u8;
+    u32::from_le_bytes([step(r), step(g), step(b), a])
+}
+
+/// `from` at 0, `to` at 1. The dial's rim runs between the two edge colours
+/// this way rather than switching between them, so the turn reads as round
+/// instead of as two arcs meeting at a corner.
+fn mix(from: u32, to: u32, t: f32) -> u32 {
+    let t = t.clamp(0.0, 1.0);
+    let (a, b) = (from.to_le_bytes(), to.to_le_bytes());
+    let lerp = |i: usize| (f32::from(a[i]) + (f32::from(b[i]) - f32::from(a[i])) * t) as u8;
+    u32::from_le_bytes([lerp(0), lerp(1), lerp(2), a[3]])
+}
+
+/// Where the dial's travel begins and how far it turns: from seven o'clock,
+/// clockwise round the top, to five o'clock. A value at its maximum -- full
+/// volume, say -- stands at the end of that travel.
+const DIAL_START: f32 = std::f32::consts::PI * 2.0 / 3.0;
+const DIAL_SWEEP: f32 = std::f32::consts::PI * 5.0 / 3.0;
+
+/// The angle the pointer stands at for `value`, a fraction of the travel.
+fn dial_angle(value: f32) -> f32 {
+    DIAL_START + value.clamp(0.0, 1.0) * DIAL_SWEEP
+}
+
+/// What the panel needs to draw itself: the display as the engine reports it,
+/// and which controls are lit.
+#[derive(Debug, Clone, Default)]
+pub struct Mt32PanelView {
+    /// The 20 characters on the LCD.
+    pub lcd: String,
+    /// Whether the MIDI MESSAGE lamp is lit.
+    pub led: bool,
+    /// Which part buttons are lit, and which function buttons. The unit has
+    /// no lamps in its buttons; these say which ones the panel is standing
+    /// on, so a two- or three-button function shows all of them at once.
+    pub parts_lit: [bool; 6],
+    pub functions_lit: [bool; 4],
+    /// Where the dial stands, as a fraction of its travel: 0 at seven
+    /// o'clock, 1 at five.
+    pub dial: f32,
+    /// Whether the synth is switched on. Off leaves the fascia drawn and
+    /// dark, as an unpowered unit looks.
+    pub powered: bool,
+    /// What the pointer is over, so that control can answer to it. The
+    /// power switch and the dial are left out: one is a switch rather than
+    /// a button, and the other already follows the pointer.
+    pub hover: Option<Mt32Control>,
+}
+
+/// What holding MASTER VOLUME and pressing another button reaches.
+///
+/// Every one of the MT-32's two-button functions is MASTER VOLUME plus one
+/// other, so the panel offers them by right-clicking MASTER VOLUME to hold
+/// it and then pressing the other button.
+///
+/// From the owner's manual, pages 15-17. One correction: the manual's text
+/// for Reverb Mode says SOUND GROUP, but its own diagram arrows at VOLUME,
+/// and SOUND GROUP already carries Master Tuning on the page above. The
+/// diagram is followed here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Chord {
+    /// + SOUND GROUP: 427.5 to 452.6 Hz.
+    MasterTune,
+    /// + VOLUME: reverb mode.
+    ReverbMode,
+    /// + SOUND: the unit number a SysEx message addresses.
+    UnitNumber,
+    /// + PART 1/2/3: parts 6, 7 and 8, which have no buttons of their own.
+    ShowPart(usize),
+    /// + PART 4, then PART 1: spill notes past the unit's capacity out of
+    ///   MIDI OUT.
+    OverflowAssign,
+    /// + PART 5, then PART 1: move parts 1-8 down onto channels 1-8.
+    MidiChannels,
+    /// + PART RHYTHM, then PART 1: back to the power-on settings.
+    AllReset,
+}
+
+impl Chord {
+    /// Whether this one waits for a further press before it takes effect,
+    /// as the manual's three-button procedures do.
+    fn needs_confirming(self) -> bool {
+        matches!(
+            self,
+            Chord::OverflowAssign | Chord::MidiChannels | Chord::AllReset
+        )
+    }
+
+    /// The button held with MASTER VOLUME to reach it.
+    fn partner(self) -> Mt32Control {
+        match self {
+            Chord::MasterTune => Mt32Control::Function(Function::SoundGroup),
+            Chord::ReverbMode => Mt32Control::Function(Function::Volume),
+            Chord::UnitNumber => Mt32Control::Function(Function::Sound),
+            Chord::ShowPart(part) => Mt32Control::Part(part - 5),
+            Chord::OverflowAssign => Mt32Control::Part(3),
+            Chord::MidiChannels => Mt32Control::Part(4),
+            Chord::AllReset => Mt32Control::Part(5),
+        }
+    }
+}
+
+/// The four buttons to the right of the part block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Function {
+    SoundGroup,
+    Volume,
+    Sound,
+    MasterVolume,
+}
+
+impl Function {
+    /// Its slot in the panel's lit table.
+    pub fn index(self) -> usize {
+        match self {
+            Function::SoundGroup => 0,
+            Function::Volume => 1,
+            Function::Sound => 2,
+            Function::MasterVolume => 3,
+        }
+    }
+}
+
+/// Something on the panel the pointer can be over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mt32Control {
+    /// A part button, 0-5 (1-5 then Rhythm).
+    Part(usize),
+    Function(Function),
+    /// The dial, turned by dragging across it or clicking either button.
+    Dial,
+    /// The power switch, which is Copperline's, not the unit's: the hardware
+    /// has its at the back, and a panel on screen needs one to hand.
+    Power,
+}
+
+// --- geometry ------------------------------------------------------------
+//
+// Left to right, as on the unit: LCD, lamp, six part buttons, four function
+// buttons, dial. Everything is measured from the panel's own top-left so the
+// whole block can be moved by moving `panel`.
+
+const PAD: usize = 8;
+/// The LCD's characters are drawn double so a 20-character line reads as a
+/// display rather than a caption.
+const LCD_PX: usize = 2;
+/// How far the bezel around the glass is inset, so what sits on the glass
+/// is placed against the glass rather than against the bezel.
+const LCD_BEZEL: usize = 2;
+/// The unlit matrix behind each character, in the character's own cell: the
+/// columns and rows a character can light -- the last column of the cell is
+/// the gap to the next one -- and the shorter block below it, as wide as
+/// the matrix itself, standing in for the row the controller keeps for a
+/// cursor.
+const CELL_COLS: usize = font::GLYPH_W - 1;
+const CELL_ROWS: usize = 7;
+const CELL_FOOT_GAP: usize = 1;
+const CELL_FOOT_H: usize = 2;
+/// How far the rule between one dot and the next falls back towards the
+/// field behind the matrix. The dots are only two pixels across, so this
+/// has to stay small or the grid reads louder than the characters over it.
+const CELL_GRAIN: f32 = 0.35;
+/// The same, for the dots a character is made of. Smaller than the matrix's
+/// own: the grid should be plain on the glass and only felt in the writing.
+const TEXT_GRAIN: f32 = 0.16;
+const LCD_W: usize = crate::mt32::LCD_WIDTH * font::GLYPH_W * LCD_PX + 12;
+const LCD_H: usize = 27;
+const LED_W: usize = 22;
+const LED_H: usize = 8;
+/// What is printed over the lamp, and the column it needs: as wide as the
+/// caption, so the text clears the glass on its left and the buttons on its
+/// right.
+const LED_CAPTION: &str = "MIDI";
+const LED_GROUP_W: usize = 4 * font::GLYPH_W;
+const SQUARE_W: usize = 24;
+const SQUARE_H: usize = 18;
+const RECT_W: usize = 62;
+const RECT_H: usize = 18;
+const ROW_GAP: usize = 4;
+const COL_GAP: usize = 4;
+const GROUP_GAP: usize = 14;
+const DIAL_D: usize = 36;
+/// What is printed over the dial.
+const DIAL_CAPTION: &str = "SEL/VOL";
+/// The power switch: about half a part button, in the bottom corner.
+const POWER_W: usize = 14;
+const POWER_H: usize = 12;
+/// Rows of buttons sit under a caption line, so the block starts below it.
+const CAPTION_H: usize = 8;
+/// How far the rule under PART stops short of the word at either end.
+const RULE_GAP: usize = 3;
+
+/// The panel's rect when it is actually up, and `None` when it is not.
+///
+/// Hit-testing must go through this: with the panel hidden its strip is the
+/// status bar's, and testing it anyway swallows every click on the bar.
+pub fn shown_panel_rect(present_h: usize) -> Option<Rect> {
+    crate::video::mt32_panel_shown().then(|| panel_rect(present_h))
+}
+
+/// The panel's rect within the presentation, sitting between the display and
+/// the status bar.
+pub fn panel_rect(present_h: usize) -> Rect {
+    Rect {
+        x: 0,
+        y: present_h,
+        w: crate::video::FB_WIDTH,
+        h: MT32_PANEL_HEIGHT,
+    }
+}
+
+fn lcd_rect(panel: Rect) -> Rect {
+    Rect {
+        x: panel.x + PAD,
+        y: panel.y + (panel.h - LCD_H) / 2,
+        w: LCD_W,
+        h: LCD_H,
+    }
+}
+
+/// The left edge of the lamp's column.
+fn led_group_x(panel: Rect) -> usize {
+    let lcd = lcd_rect(panel);
+    lcd.x + lcd.w + GROUP_GAP
+}
+
+fn led_rect(panel: Rect) -> Rect {
+    let lcd = lcd_rect(panel);
+    Rect {
+        // Centred on the caption's ink rather than its cell box, which is
+        // wider than the letters in it.
+        x: (led_group_x(panel) + text_ink_centre(LED_CAPTION, 1)).saturating_sub(LED_W / 2),
+        y: lcd.y + lcd.h / 2 - LED_H / 2 + 5,
+        w: LED_W,
+        h: LED_H,
+    }
+}
+
+/// Where the six part buttons start: past the lamp and its caption.
+fn parts_origin(panel: Rect) -> (usize, usize) {
+    let x = led_group_x(panel) + LED_GROUP_W + GROUP_GAP;
+    let block_h = CAPTION_H + 2 * SQUARE_H + ROW_GAP;
+    // A hair below centre, so the captions above the block clear the edge.
+    (x, panel.y + (panel.h - block_h) / 2 + 3)
+}
+
+/// The rect of part button `n` (0-5): three across, two down, 1-3 over 4-R.
+fn part_rect(panel: Rect, n: usize) -> Rect {
+    let (x0, y0) = parts_origin(panel);
+    let (col, row) = (n % 3, n / 3);
+    Rect {
+        x: x0 + col * (SQUARE_W + COL_GAP),
+        y: y0 + CAPTION_H + row * (SQUARE_H + ROW_GAP),
+        w: SQUARE_W,
+        h: SQUARE_H,
+    }
+}
+
+/// The rect of function button `f`: two across, two down.
+fn function_rect(panel: Rect, f: Function) -> Rect {
+    let (x0, y0) = parts_origin(panel);
+    let x = x0 + 3 * (SQUARE_W + COL_GAP) + GROUP_GAP;
+    let (col, row) = match f {
+        Function::SoundGroup => (0, 0),
+        Function::Volume => (1, 0),
+        Function::Sound => (0, 1),
+        Function::MasterVolume => (1, 1),
+    };
+    Rect {
+        x: x + col * (RECT_W + COL_GAP),
+        y: y0 + CAPTION_H + row * (RECT_H + ROW_GAP),
+        w: RECT_W,
+        h: RECT_H,
+    }
+}
+
+/// The dial, at the right of the block.
+fn dial_rect(panel: Rect) -> Rect {
+    // Midway between the buttons on its left and the power switch on its
+    // right, so it sits in the gap rather than against one side of it.
+    let volume = function_rect(panel, Function::Volume);
+    let block_right = volume.x + volume.w;
+    let gap = power_rect(panel).x.saturating_sub(block_right);
+    // Sitting on the block of buttons rather than on the panel, so the
+    // caption above it has the same room to breathe as PART does over
+    // theirs, and the dial still finishes clear of the bottom edge.
+    let top = part_rect(panel, 0).y;
+    let bottom = part_rect(panel, 3).y + SQUARE_H;
+    Rect {
+        x: block_right + gap.saturating_sub(DIAL_D) / 2,
+        y: (top + bottom) / 2 - DIAL_D / 2,
+        w: DIAL_D,
+        h: DIAL_D,
+    }
+}
+
+/// Where `pos` stands along the dial's travel, 0 at seven o'clock and 1 at
+/// five, or `None` when it is in the gap between the two ends.
+fn dial_value_at(panel: Rect, pos: (i32, i32)) -> Option<f32> {
+    let dial = dial_rect(panel);
+    let cx = dial.x as f32 + dial.w as f32 / 2.0;
+    let cy = dial.y as f32 + dial.h as f32 / 2.0;
+    let angle = (pos.1 as f32 - cy).atan2(pos.0 as f32 - cx);
+    // Measured from the start of the travel, going the way it turns.
+    let from_start = (angle - DIAL_START).rem_euclid(std::f32::consts::TAU);
+    (from_start <= DIAL_SWEEP).then(|| from_start / DIAL_SWEEP)
+}
+
+/// What holding MASTER VOLUME and pressing `control` reaches, if anything.
+fn chord_for(control: Mt32Control) -> Option<Chord> {
+    Some(match control {
+        Mt32Control::Function(Function::SoundGroup) => Chord::MasterTune,
+        Mt32Control::Function(Function::Volume) => Chord::ReverbMode,
+        Mt32Control::Function(Function::Sound) => Chord::UnitNumber,
+        // Buttons 1, 2 and 3 stand for parts 6, 7 and 8; the unit has nine
+        // parts and six buttons.
+        Mt32Control::Part(n @ 0..=2) => Chord::ShowPart(n + 5),
+        Mt32Control::Part(3) => Chord::OverflowAssign,
+        Mt32Control::Part(4) => Chord::MidiChannels,
+        Mt32Control::Part(5) => Chord::AllReset,
+        _ => return None,
+    })
+}
+
+/// The power switch, in the bottom right corner past the dial.
+fn power_rect(panel: Rect) -> Rect {
+    Rect {
+        x: panel.x + panel.w - POWER_W - PAD,
+        y: panel.y + panel.h - POWER_H - 6,
+        w: POWER_W,
+        h: POWER_H,
+    }
+}
+
+/// Which control the pointer is over, if any.
+pub fn control_at(panel: Rect, pos: (i32, i32)) -> Option<Mt32Control> {
+    for n in 0..6 {
+        if part_rect(panel, n).contains(pos) {
+            return Some(Mt32Control::Part(n));
+        }
+    }
+    for f in [
+        Function::SoundGroup,
+        Function::Volume,
+        Function::Sound,
+        Function::MasterVolume,
+    ] {
+        if function_rect(panel, f).contains(pos) {
+            return Some(Mt32Control::Function(f));
+        }
+    }
+    if power_rect(panel).contains(pos) {
+        return Some(Mt32Control::Power);
+    }
+    dial_rect(panel).contains(pos).then_some(Mt32Control::Dial)
+}
+
+/// What the pointer is over, of the controls that answer to being hovered.
+///
+/// The switch latches with the power and the dial already follows the hand,
+/// so neither takes a highlight -- which also means neither is worth a
+/// redraw when the pointer crosses it.
+pub fn hover_at(panel: Rect, pos: (i32, i32)) -> Option<Mt32Control> {
+    control_at(panel, pos).filter(|c| matches!(c, Mt32Control::Part(_) | Mt32Control::Function(_)))
+}
+
+/// Whether moving from `previous` to `current` changed which button is lit
+/// under the pointer, and so needs the panel drawn again.
+pub fn hover_changed(
+    panel: Rect,
+    previous: Option<(i32, i32)>,
+    current: Option<(i32, i32)>,
+) -> bool {
+    previous.and_then(|pos| hover_at(panel, pos)) != current.and_then(|pos| hover_at(panel, pos))
+}
+
+// --- drawing -------------------------------------------------------------
+
+/// Draw the panel.
+pub fn draw(frame: &mut [u8], view: &Mt32PanelView, present_h: usize, scale: usize) {
+    let panel = panel_rect(present_h);
+    fill_rect(frame, scaled(panel, scale), PANEL_FACE, scale);
+    draw_rect_bevel(
+        frame,
+        scaled(panel, scale),
+        PANEL_EDGE_LIGHT,
+        PANEL_EDGE_DARK,
+        scale,
+    );
+
+    draw_lcd_surround(frame, panel, scale);
+    draw_lcd(frame, panel, view, scale);
+    draw_led(frame, panel, view.led, scale);
+    draw_parts(frame, panel, view, scale);
+    draw_functions(frame, panel, view, scale);
+    draw_dial(frame, panel, view.dial, scale);
+    draw_power(frame, panel, view.powered, scale);
+}
+
+/// The power switch: the same mark the status bar uses, green lit and red
+/// dark, on a button small enough not to take room from the instrument.
+fn draw_power(frame: &mut [u8], panel: Rect, powered: bool, scale: usize) {
+    let rect = power_rect(panel);
+    // Latching, as the unit's is: in while it is on, out while it is off.
+    draw_button(frame, rect, powered, false, scale);
+    draw_power_glyph_sized(
+        frame,
+        (rect.x + rect.w / 2) * scale,
+        (rect.y + rect.h / 2) * scale - scale,
+        3.5,
+        if powered {
+            POWER_GLYPH_ON
+        } else {
+            POWER_GLYPH_OFF
+        },
+        scale,
+    );
+}
+
+/// The gloss the display and its lamp are set into, squared off against the
+/// block of buttons beside it: the bottom on the underside of their lower
+/// row, the left edge set in by what the caption line leaves at the top,
+/// and the top far enough up that the glass sits in the same depth of gloss
+/// either way.
+fn lcd_surround_rect(panel: Rect) -> Rect {
+    let (right, caption) = (parts_origin(panel).0 - GROUP_GAP / 2, caption_y(panel));
+    let bottom = part_rect(panel, 5).y + SQUARE_H;
+    let left = panel.x + caption.saturating_sub(panel.y);
+    // The bottom is squared off against the buttons, which leaves it deeper
+    // below the glass than the caption line leaves above it. Take the top up
+    // by the difference so the glass sits in the same depth of gloss either
+    // way, without moving the glass or anything around it.
+    let lcd = lcd_rect(panel);
+    let below = bottom.saturating_sub(lcd.y + lcd.h);
+    let top = lcd.y.saturating_sub(below).min(caption);
+    Rect {
+        x: left,
+        y: top,
+        w: right.saturating_sub(left),
+        h: bottom.saturating_sub(top),
+    }
+}
+
+/// Paint it, with a sheen along the top to read as polished rather than
+/// matt, as the unit's is.
+fn draw_lcd_surround(frame: &mut [u8], panel: Rect, scale: usize) {
+    let rect = lcd_surround_rect(panel);
+    fill_rect(frame, scaled(rect, scale), LCD_SURROUND, scale);
+    fill_rect(
+        frame,
+        scaled(
+            Rect {
+                x: rect.x,
+                y: rect.y,
+                w: rect.w,
+                h: 1,
+            },
+            scale,
+        ),
+        LCD_SURROUND_SHEEN,
+        scale,
+    );
+}
+
+fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
+    // The same raised display the status bar's track counter uses: a lit
+    // top-left edge over a dark surround, with the glass inset inside it.
+    let colours = lcd_colours();
+    let lcd = lcd_rect(panel);
+    let glass = if view.powered {
+        colours.glass
+    } else {
+        colours.dark_glass
+    };
+    raised_display(frame, lcd, glass, scale);
+    // With the backlight out there is nothing behind the glass to see, not
+    // even the matrix.
+    if !view.powered {
+        return;
+    }
+    // Centred on the glass rather than on the bezel around it, and on the
+    // whole matrix rather than on the characters alone: the cursor row
+    // below them belongs to the same object, and measuring without it
+    // leaves the line sitting low.
+    let glass_w = lcd.w - 2 * LCD_BEZEL;
+    let glass_h = lcd.h - 2 * LCD_BEZEL;
+    let matrix_w = (crate::mt32::LCD_WIDTH - 1) * font::GLYPH_W * LCD_PX + CELL_COLS * LCD_PX;
+    let matrix_h = CELL_ROWS * LCD_PX + CELL_FOOT_GAP + CELL_FOOT_H;
+    let tx = lcd.x + LCD_BEZEL + glass_w.saturating_sub(matrix_w) / 2;
+    let ty = lcd.y + LCD_BEZEL + glass_h.saturating_sub(matrix_h) / 2;
+    // The engine gives 20 characters; anything longer is its own business.
+    for (i, ch) in view.lcd.chars().take(crate::mt32::LCD_WIDTH).enumerate() {
+        let x = tx + i * font::GLYPH_W * LCD_PX;
+        let cell = Rect {
+            x,
+            y: ty,
+            w: CELL_COLS * LCD_PX,
+            h: CELL_ROWS * LCD_PX,
+        };
+        // Every position shows its own matrix whether anything is lit in it
+        // or not, with the row the controller keeps for a cursor sitting
+        // under it -- which is what gives an LCD its grid of faint blocks.
+        if let Some(unlit) = colours.cell {
+            let foot = Rect {
+                y: cell.y + cell.h + CELL_FOOT_GAP,
+                h: CELL_FOOT_H,
+                ..cell
+            };
+            fill_rect(frame, scaled(cell, scale), unlit, scale);
+            fill_rect(frame, scaled(foot, scale), unlit, scale);
+            // Ruled into its dots, a shade under the block itself. Barely
+            // a difference at all: enough that the matrix has a grain, not
+            // enough to read as lines drawn on it.
+            let grain = mix(unlit, glass, CELL_GRAIN);
+            for block in [cell, foot] {
+                for row in 0..block.h / LCD_PX {
+                    fill_rect(
+                        frame,
+                        scaled(
+                            Rect {
+                                y: block.y + row * LCD_PX + LCD_PX - 1,
+                                h: 1,
+                                ..block
+                            },
+                            scale,
+                        ),
+                        grain,
+                        scale,
+                    );
+                }
+                for col in 0..block.w / LCD_PX {
+                    fill_rect(
+                        frame,
+                        scaled(
+                            Rect {
+                                x: block.x + col * LCD_PX + LCD_PX - 1,
+                                w: 1,
+                                ..block
+                            },
+                            scale,
+                        ),
+                        grain,
+                        scale,
+                    );
+                }
+            }
+        }
+        let solid = ch == crate::mt32::ACTIVE_PART;
+        if solid {
+            // A part with something sounding on it: every dot in the cell
+            // driven at once, which is the shape the controller is given.
+            fill_rect(frame, scaled(cell, scale), colours.text, scale);
+        } else {
+            text(
+                frame,
+                x,
+                ty,
+                ch.encode_utf8(&mut [0; 4]),
+                colours.text,
+                LCD_PX,
+                scale,
+            );
+        }
+        // The characters are made of the same dots as the matrix behind
+        // them, so rule them the same way -- but more faintly. The grid
+        // belongs to the glass; in the writing it should only be felt.
+        if colours.cell.is_some() {
+            let ink_grain = mix(colours.text, glass, TEXT_GRAIN);
+            let glyph = font::glyph(ch);
+            for row in 0..CELL_ROWS {
+                for col in 0..CELL_COLS {
+                    if !solid && glyph[row] & (1 << col) == 0 {
+                        continue;
+                    }
+                    let (dx, dy) = (cell.x + col * LCD_PX, cell.y + row * LCD_PX);
+                    // The dot's own far edges, which is where its neighbour
+                    // begins.
+                    for edge in [
+                        Rect {
+                            x: dx,
+                            y: dy + LCD_PX - 1,
+                            w: LCD_PX,
+                            h: 1,
+                        },
+                        Rect {
+                            x: dx + LCD_PX - 1,
+                            y: dy,
+                            w: 1,
+                            h: LCD_PX,
+                        },
+                    ] {
+                        fill_rect(frame, scaled(edge, scale), ink_grain, scale);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn draw_led(frame: &mut [u8], panel: Rect, lit: bool, scale: usize) {
+    let led = led_rect(panel);
+    raised_display(frame, led, if lit { LED_LIT } else { LED_DARK }, scale);
+    // Printed above the lamp as it is on the fascia, at the head of the
+    // column; the lamp is centred under its ink (see led_rect).
+    text(
+        frame,
+        led_group_x(panel),
+        led.y.saturating_sub(13),
+        LED_CAPTION,
+        CAPTION,
+        1,
+        scale,
+    );
+}
+
+fn draw_parts(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
+    let x0 = parts_origin(panel).0;
+    // The bracket the six buttons sit under, as it is printed on the fascia:
+    // the word underlined out to the edges of the block. The rule sits on
+    // the row the letters' own feet stand on, and stops short of their ink
+    // by the same margin at each end -- measured from the ink, so the gap
+    // beside the T's crossbar matches the one beside the P's stem rather
+    // than opening up under the narrower part of the letter.
+    let block_w = 3 * SQUARE_W + 2 * COL_GAP;
+    let y = caption_y(panel);
+    let label_w = text_w("PART", 1);
+    let label_x = x0 + block_w / 2 - label_w / 2;
+    text(frame, label_x, y, "PART", CAPTION, 1, scale);
+    let (ink_lo, ink_hi) = text_ink_span("PART", 1);
+    let (word_lo, word_hi) = (label_x + ink_lo, label_x + ink_hi);
+    let rule_y = y + text_ink_feet("PART", 1);
+    let (rule_lo, rule_hi) = (word_lo.saturating_sub(RULE_GAP), word_hi + RULE_GAP);
+    for (rx, rw) in [
+        (x0, rule_lo.saturating_sub(x0)),
+        (rule_hi, (x0 + block_w).saturating_sub(rule_hi)),
+    ] {
+        fill_rect(
+            frame,
+            scaled(
+                Rect {
+                    x: rx,
+                    y: rule_y,
+                    w: rw,
+                    h: 1,
+                },
+                scale,
+            ),
+            CAPTION,
+            scale,
+        );
+    }
+    for (n, label) in ["1", "2", "3", "4", "5", "R"].into_iter().enumerate() {
+        let rect = part_rect(panel, n);
+        let hovered = view.hover == Some(Mt32Control::Part(n));
+        draw_button(frame, rect, view.parts_lit[n], hovered, scale);
+        let tx = rect.x + rect.w / 2 - text_w(label, 1) / 2;
+        let ty = rect.y + (rect.h - font::GLYPH_H) / 2;
+        text(frame, tx, ty, label, CAPTION, 1, scale);
+    }
+}
+
+fn draw_functions(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
+    for (f, label) in [
+        (Function::SoundGroup, "GROUP"),
+        (Function::Volume, "VOLUME"),
+        (Function::Sound, "SOUND"),
+        (Function::MasterVolume, "MASTER"),
+    ] {
+        let rect = function_rect(panel, f);
+        let hovered = view.hover == Some(Mt32Control::Function(f));
+        draw_button(frame, rect, view.functions_lit[f.index()], hovered, scale);
+        let tx = rect.x + rect.w / 2 - text_w(label, 1) / 2;
+        let ty = rect.y + (rect.h - font::GLYPH_H) / 2;
+        text(frame, tx, ty, label, CAPTION, 1, scale);
+    }
+}
+
+/// A recessed-bezel display with `face` behind the glass: the treatment the
+/// status bar's track counter and volume track already use, so the panel's
+/// LCD and lamp read as the same kind of object.
+fn raised_display(frame: &mut [u8], rect: Rect, face: u32, scale: usize) {
+    let outer = scaled(rect, scale);
+    fill_rect(frame, outer, LED_BEZEL_DARK, scale);
+    draw_rect_bevel(frame, outer, LED_BEZEL_LIGHT, STATUS_BOTTOM, scale);
+    let inset = LCD_BEZEL * scale;
+    fill_rect(
+        frame,
+        Rect {
+            x: outer.x + inset,
+            y: outer.y + inset,
+            w: outer.w.saturating_sub(inset * 2),
+            h: outer.h.saturating_sub(inset * 2),
+        },
+        face,
+        scale,
+    );
+}
+
+fn draw_button(frame: &mut [u8], rect: Rect, pressed: bool, hovered: bool, scale: usize) {
+    let rect = scaled(rect, scale);
+    // Pressed, the moulding turns over: the light that caught its top and
+    // left now falls past it onto the bottom and right, and the face sits
+    // in its own shadow. Standing proud, the bevel is the way round every
+    // other button on the panel wears it.
+    let (face, near, far) = if pressed {
+        (BUTTON_FACE_PRESSED, BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT)
+    } else {
+        (BUTTON_FACE, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK)
+    };
+    // Under the pointer it lifts, by what the status bar's own buttons lift
+    // by, so the two answer the same way.
+    let face = if hovered {
+        shade(face, HOVER_LIFT)
+    } else {
+        face
+    };
+    fill_rect(frame, rect, face, scale);
+    draw_rect_bevel(frame, rect, near, far, scale);
+}
+
+/// The Select/Volume dial: a round face, its detents marked along the
+/// travel, and a pointer showing where it stands.
+fn draw_dial(frame: &mut [u8], panel: Rect, value: f32, scale: usize) {
+    let dial = dial_rect(panel);
+    let (cx, cy) = (
+        dial.x as f32 + dial.w as f32 / 2.0,
+        dial.y as f32 + dial.h as f32 / 2.0,
+    );
+    let radius = dial.w as f32 / 2.0;
+
+    // The face, as a disc of rows, domed by lifting the top towards the
+    // light and letting the bottom fall away from it. The light comes from
+    // the top left, as it does on the bevel around every button beside it.
+    for y in 0..dial.h {
+        let dy = y as f32 + 0.5 - dial.h as f32 / 2.0;
+        let half = (radius * radius - dy * dy).max(0.0).sqrt();
+        if half < 0.5 {
+            continue;
+        }
+        let row = Rect {
+            x: (cx - half) as usize,
+            y: dial.y + y,
+            w: (half * 2.0) as usize,
+            h: 1,
+        };
+        let dome = shade(BUTTON_FACE, -dy / radius * DIAL_DOME);
+        fill_rect(frame, scaled(row, scale), dome, scale);
+    }
+
+    // The rim, and the shoulder just inside it. Both run between the two
+    // edge colours the buttons are bevelled with, by how squarely that part
+    // of the turn faces the light, so the ring shades round rather than
+    // meeting itself at a corner. Stepped finely enough that it closes.
+    const RIM_STEPS: usize = 256;
+    for i in 0..RIM_STEPS {
+        let angle = i as f32 / RIM_STEPS as f32 * std::f32::consts::TAU;
+        let (sin, cos) = angle.sin_cos();
+        // 1 where the rim turns fully into the light, 0 fully away.
+        let facing = 0.5 - (cos + sin) * std::f32::consts::FRAC_1_SQRT_2 * 0.5;
+        let plot = |frame: &mut [u8], at: f32, colour: u32| {
+            let dot = Rect {
+                x: (cx + cos * at) as usize,
+                y: (cy + sin * at) as usize,
+                w: 1,
+                h: 1,
+            };
+            fill_rect(frame, scaled(dot, scale), colour, scale);
+        };
+        plot(
+            frame,
+            radius - 0.5,
+            mix(BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, facing),
+        );
+        // Inside it the moulding turns back towards the face, so the same
+        // light reaches it faintly: enough to round the edge off.
+        plot(
+            frame,
+            radius - 1.5,
+            shade(BUTTON_FACE, (facing - 0.5) * DIAL_SHOULDER),
+        );
+    }
+    // The travel marked out around it, the way the unit prints it on the
+    // fascia: the first mark at seven o'clock, the last at five, and the
+    // pointer standing against them.
+    for i in 0..DIAL_MARKS {
+        let (sin, cos) = dial_angle(i as f32 / (DIAL_MARKS - 1) as f32).sin_cos();
+        let dot = Rect {
+            x: (cx + cos * (radius + DIAL_MARK_GAP)) as usize,
+            y: (cy + sin * (radius + DIAL_MARK_GAP)) as usize,
+            w: 1,
+            h: 1,
+        };
+        fill_rect(frame, scaled(dot, scale), DIAL_TICK, scale);
+    }
+
+    // The pointer: a mark from half way out to just inside the rim,
+    // stepped in half pixels so it reads as a line rather than a dotted one.
+    let (sin, cos) = dial_angle(value).sin_cos();
+    let (reach, from) = (radius - 4.0, radius / 2.0);
+    let mut r = from;
+    while r <= reach {
+        let dot = Rect {
+            x: (cx + cos * r) as usize,
+            y: (cy + sin * r) as usize,
+            w: 2,
+            h: 2,
+        };
+        fill_rect(frame, scaled(dot, scale), DIAL_MARK, scale);
+        r += 0.5;
+    }
+
+    text(
+        frame,
+        (dial.x + dial.w / 2).saturating_sub(text_ink_centre(DIAL_CAPTION, 1)),
+        caption_y(panel),
+        DIAL_CAPTION,
+        CAPTION,
+        1,
+        scale,
+    );
+}
+
+/// The line the block captions sit on, so PART and SEL/VOL read as one row
+/// of labels across the fascia rather than two.
+fn caption_y(panel: Rect) -> usize {
+    let top = parts_origin(panel).1 + CAPTION_H;
+    panel.y + (top - panel.y).saturating_sub(font::GLYPH_H) / 2
+}
+
+/// Text in the panel font, at `px` whole pixels per font pixel. Coordinates
+/// are the panel's own, so callers work in one space.
+fn text(frame: &mut [u8], x: usize, y: usize, s: &str, color: u32, px: usize, scale: usize) {
+    font::draw_text(
+        frame,
+        texture_width(scale),
+        texture_height(scale),
+        x * scale,
+        y * scale,
+        s,
+        color,
+        px * scale,
+    );
+}
+
+/// How wide `s` is at `px`, counting the cells it occupies.
+fn text_w(s: &str, px: usize) -> usize {
+    s.chars().count() * font::GLYPH_W * px
+}
+
+/// Where the ink of `s` begins and ends, measured from its origin.
+///
+/// A glyph cell is wider than the mark inside it, so anything butted or
+/// centred on the cell box sits visibly off. This looks at which columns
+/// are actually set and works from those instead.
+fn text_ink_span(s: &str, px: usize) -> (usize, usize) {
+    let (mut lo, mut hi) = (usize::MAX, 0);
+    for (cell, ch) in s.chars().enumerate() {
+        let glyph = font::glyph(ch);
+        for col in 0..font::GLYPH_W {
+            if glyph.iter().any(|row| row & (1 << col) != 0) {
+                let x = cell * font::GLYPH_W + col;
+                lo = lo.min(x);
+                hi = hi.max(x);
+            }
+        }
+    }
+    if lo == usize::MAX {
+        return (0, text_w(s, px));
+    }
+    (lo * px, (hi + 1) * px)
+}
+
+/// Where the ink of `s` is centred, measured from its origin.
+fn text_ink_centre(s: &str, px: usize) -> usize {
+    let (lo, hi) = text_ink_span(s, px);
+    (lo + hi) / 2
+}
+
+/// The row the letters of `s` stand on, measured from their origin: where a
+/// rule has to sit to run on from their feet rather than through them or
+/// below them.
+fn text_ink_feet(s: &str, px: usize) -> usize {
+    s.chars()
+        .filter_map(|ch| {
+            let glyph = font::glyph(ch);
+            (0..font::GLYPH_H).rev().find(|&row| glyph[row] != 0)
+        })
+        .max()
+        .unwrap_or(font::GLYPH_H - 1)
+        * px
+}
+
+fn scaled(rect: Rect, scale: usize) -> Rect {
+    Rect {
+        x: rect.x * scale,
+        y: rect.y * scale,
+        w: rect.w * scale,
+        h: rect.h * scale,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Everything fits inside the panel, in the order the unit has it:
+    /// LCD, lamp, parts, functions, dial.
+    #[test]
+    fn the_panel_lays_out_left_to_right_and_fits() {
+        let panel = panel_rect(500);
+        let lcd = lcd_rect(panel);
+        let led = led_rect(panel);
+        let first_part = part_rect(panel, 0);
+        let first_fn = function_rect(panel, Function::SoundGroup);
+        let dial = dial_rect(panel);
+
+        assert!(lcd.x + lcd.w <= led.x, "the lamp sits right of the LCD");
+        assert!(
+            led.x + led.w <= first_part.x,
+            "the parts sit right of the lamp"
+        );
+        assert!(
+            part_rect(panel, 2).x + SQUARE_W <= first_fn.x,
+            "the functions sit right of the parts"
+        );
+        assert!(
+            function_rect(panel, Function::Volume).x + RECT_W <= dial.x,
+            "the dial sits right of the functions"
+        );
+        assert!(
+            dial.x + dial.w <= panel.x + panel.w,
+            "the whole block fits the panel width"
+        );
+
+        for n in 0..6 {
+            let r = part_rect(panel, n);
+            assert!(r.y >= panel.y && r.y + r.h <= panel.y + panel.h, "part {n}");
+        }
+        assert!(dial.y >= panel.y && dial.y + dial.h <= panel.y + panel.h);
+    }
+
+    /// Renders the panel to `target/ui-preview-mt32-panel.png` under
+    /// COPPERLINE_UI_PREVIEW, for looking at while the design settles.
+    #[test]
+    fn the_panel_draws_itself() {
+        use crate::video::window::{present_height, texture_height, texture_width};
+
+        // The drawing helpers clamp against the presentation texture, so the
+        // panel is drawn where it really sits and the strip cropped out.
+        crate::video::set_mt32_panel_shown(true);
+        let scale = 2;
+        let (w, h) = (texture_width(scale), texture_height(scale));
+        let present_h = present_height();
+        let panel = panel_rect(present_h);
+        let (px, py) = (panel.x * scale, panel.y * scale);
+        let (pw, ph) = (panel.w * scale, panel.h * scale);
+
+        for (style, name) in [
+            (crate::config::Mt32Lcd::Oled, "oled"),
+            (crate::config::Mt32Lcd::Mt32, "mt32"),
+            (crate::config::Mt32Lcd::Jv1080, "jv1080"),
+        ] {
+            crate::video::set_mt32_lcd(style);
+            // Once lit, once not: the styles differ in how they go dark.
+            for powered in [true, false] {
+                let mut frame = vec![0u8; w * h * 4];
+                let view = Mt32PanelView {
+                    // Parts 1 and 4 sounding, so the preview shows the
+                    // filled cell the engine asks for as well as the
+                    // characters.
+                    lcd: format!("{a} 2 3 {a} 5 R |vol:100", a = crate::mt32::ACTIVE_PART),
+                    led: powered,
+                    parts_lit: [true, false, false, false, false, false],
+                    functions_lit: [false, false, false, true],
+                    dial: 1.0,
+                    powered,
+                    // Part 2 under the pointer, so the preview shows a
+                    // hover beside a press and a button at rest.
+                    hover: Some(Mt32Control::Part(1)),
+                };
+                draw(&mut frame, &view, present_h, scale);
+
+                let mut strip = Vec::with_capacity(pw * ph * 4);
+                for row in 0..ph {
+                    let start = ((py + row) * w + px) * 4;
+                    strip.extend_from_slice(&frame[start..start + pw * 4]);
+                }
+                // The fascia was painted, rather than the strip staying
+                // transparent.
+                assert_ne!(&strip[0..4], &[0, 0, 0, 0], "{name} should be drawn");
+
+                if !crate::envcfg::flag("COPPERLINE_UI_PREVIEW") {
+                    continue;
+                }
+                let suffix = if powered { "" } else { "-off" };
+                let path = format!("target/ui-preview-mt32-panel-{name}{suffix}.png");
+                let file = std::fs::File::create(&path).unwrap();
+                let mut enc =
+                    png::Encoder::new(std::io::BufWriter::new(file), pw as u32, ph as u32);
+                enc.set_color(png::ColorType::Rgba);
+                enc.set_depth(png::BitDepth::Eight);
+                enc.write_header()
+                    .unwrap()
+                    .write_image_data(&strip)
+                    .unwrap();
+                eprintln!("saved {path}");
+            }
+        }
+        crate::video::set_mt32_lcd(crate::config::Mt32Lcd::Oled);
+        crate::video::set_mt32_panel_shown(false);
+    }
+
+    /// The two-button functions are the ones the manual documents, each on
+    /// the button MASTER VOLUME is held with.
+    #[test]
+    fn the_chords_are_the_ones_the_manual_documents() {
+        assert_eq!(
+            chord_for(Mt32Control::Function(Function::SoundGroup)),
+            Some(Chord::MasterTune)
+        );
+        assert_eq!(
+            chord_for(Mt32Control::Function(Function::Volume)),
+            Some(Chord::ReverbMode)
+        );
+        assert_eq!(
+            chord_for(Mt32Control::Function(Function::Sound)),
+            Some(Chord::UnitNumber)
+        );
+        assert_eq!(chord_for(Mt32Control::Part(5)), Some(Chord::AllReset));
+
+        // Buttons 1-3 reach parts 6-8, which have no buttons of their own.
+        for (button, part) in [(0, 5), (1, 6), (2, 7)] {
+            assert_eq!(
+                chord_for(Mt32Control::Part(button)),
+                Some(Chord::ShowPart(part))
+            );
+        }
+        // The three that want a further press before they do anything.
+        assert_eq!(chord_for(Mt32Control::Part(3)), Some(Chord::OverflowAssign));
+        assert_eq!(chord_for(Mt32Control::Part(4)), Some(Chord::MidiChannels));
+        for chord in [Chord::OverflowAssign, Chord::MidiChannels, Chord::AllReset] {
+            assert!(chord.needs_confirming(), "{chord:?}");
+        }
+        for chord in [Chord::MasterTune, Chord::ReverbMode, Chord::UnitNumber] {
+            assert!(!chord.needs_confirming(), "{chord:?}");
+        }
+
+        // MASTER VOLUME is the button being held, not one to hold it with.
+        assert_eq!(
+            chord_for(Mt32Control::Function(Function::MasterVolume)),
+            None
+        );
+        assert_eq!(chord_for(Mt32Control::Power), None);
+
+        // Every chord names the button it is reached through, and that
+        // button leads back to it.
+        for chord in [
+            Chord::MasterTune,
+            Chord::ReverbMode,
+            Chord::UnitNumber,
+            Chord::ShowPart(5),
+            Chord::OverflowAssign,
+            Chord::MidiChannels,
+            Chord::AllReset,
+        ] {
+            assert_eq!(chord_for(chord.partner()), Some(chord), "{chord:?}");
+        }
+    }
+
+    /// A pair is two buttons held together, so it takes two right clicks
+    /// and starts with MASTER VOLUME. Nothing else can stumble into one.
+    #[test]
+    fn a_pair_takes_two_right_clicks_from_master_volume() {
+        let rect = panel_rect(500);
+        let master = Mt32Control::Function(Function::MasterVolume);
+        let group = Mt32Control::Function(Function::SoundGroup);
+        let press = |p: &mut Mt32Panel, c, left| p.press(c, left, (0, 0), rect, None);
+
+        // Right, then right: the pair, with both buttons lit and nothing
+        // else.
+        let mut panel = Mt32Panel::default();
+        press(&mut panel, master, false);
+        press(&mut panel, group, false);
+        assert_eq!(panel.mode, Mode::Chord(Chord::MasterTune));
+        assert_eq!(
+            panel.functions_lit(),
+            [true, false, false, true],
+            "only the two that made the pair"
+        );
+
+        // Left first: a plain press of MASTER VOLUME, and the next right
+        // click cannot turn it into a pair.
+        let mut panel = Mt32Panel::default();
+        press(&mut panel, master, true);
+        press(&mut panel, group, false);
+        assert_eq!(panel.mode, Mode::Function(Function::MasterVolume));
+
+        // Right first, left second: the second is a press, not a hold.
+        let mut panel = Mt32Panel::default();
+        press(&mut panel, master, false);
+        press(&mut panel, group, true);
+        assert_eq!(panel.mode, Mode::Function(Function::SoundGroup));
+
+        // Holding anything but MASTER VOLUME lights nothing: no pair
+        // begins with it.
+        let mut panel = Mt32Panel::default();
+        press(&mut panel, group, false);
+        assert_eq!(panel.mode, Mode::Home);
+        assert_eq!(panel.functions_lit(), [false; 4]);
+        assert_eq!(panel.parts_lit(), [false; 6]);
+    }
+
+    /// Nothing is standing on anything until someone presses something,
+    /// and switching the unit off puts it back there.
+    #[test]
+    fn a_panel_at_rest_has_nothing_held_down() {
+        let mut panel = Mt32Panel::default();
+        let at_rest = |p: &Mt32Panel| {
+            let view = p.view(String::new(), false, true, None);
+            (view.parts_lit, view.functions_lit)
+        };
+        assert_eq!(
+            at_rest(&panel),
+            ([false; 6], [false; 4]),
+            "just switched on"
+        );
+
+        // Stand on something, and it shows.
+        let rect = panel_rect(500);
+        panel.press(
+            Mt32Control::Function(Function::Volume),
+            true,
+            (0, 0),
+            rect,
+            None,
+        );
+        assert_ne!(
+            at_rest(&panel),
+            ([false; 6], [false; 4]),
+            "a button is down"
+        );
+
+        // Off and on again is a fresh unit, whatever was held before.
+        panel.reset();
+        assert_eq!(
+            at_rest(&panel),
+            ([false; 6], [false; 4]),
+            "after a power cycle"
+        );
+    }
+
+    /// The pointer finds each control where it is drawn.
+    #[test]
+    fn every_control_is_hit_where_it_is_drawn() {
+        let panel = panel_rect(500);
+        let middle = |r: Rect| ((r.x + r.w / 2) as i32, (r.y + r.h / 2) as i32);
+        for n in 0..6 {
+            assert_eq!(
+                control_at(panel, middle(part_rect(panel, n))),
+                Some(Mt32Control::Part(n))
+            );
+        }
+        for f in [
+            Function::SoundGroup,
+            Function::Volume,
+            Function::Sound,
+            Function::MasterVolume,
+        ] {
+            assert_eq!(
+                control_at(panel, middle(function_rect(panel, f))),
+                Some(Mt32Control::Function(f))
+            );
+        }
+        assert_eq!(
+            control_at(panel, middle(dial_rect(panel))),
+            Some(Mt32Control::Dial)
+        );
+        assert_eq!(
+            control_at(panel, middle(power_rect(panel))),
+            Some(Mt32Control::Power)
+        );
+        assert_eq!(
+            control_at(panel, (2, 2)),
+            None,
+            "the fascia is not a control"
+        );
+    }
+}
+
+// --- the panel as a thing that remembers what it is doing ----------------
+
+/// What a press needs the window to do, which the panel cannot reach.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PanelAction {
+    /// Nothing but a redraw.
+    None,
+    /// Put this on the on-screen display.
+    Say(String),
+    /// Switch the unit off, or on.
+    Power(bool),
+    /// Off and on again, which is what a reset amounts to here.
+    Recycle,
+}
+
+/// What the panel is standing on.
+///
+/// The unit's buttons carry no lamps, so nothing is lit at rest; a mode
+/// lights exactly the buttons that reached it, which is one, two or three.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// The main screen. The engine owns the display and nothing is lit.
+    Home,
+    /// One button: it edits the value it names, for the shown part.
+    Function(Function),
+    /// MASTER VOLUME held with one other, editing what that pair names.
+    Chord(Chord),
+    /// A pair that wants a further press before it does anything, as the
+    /// manual's three-button procedures do.
+    Confirm(Chord),
+}
+
+/// A button held on the Select/Volume dial.
+#[derive(Debug)]
+struct DialGrab {
+    /// Which way a repeat steps: left clockwise, right the other way.
+    clockwise: bool,
+    pressed_at: std::time::Instant,
+    last_step: std::time::Instant,
+    /// Where along the travel the hand took hold, and what the value was
+    /// there. A drag moves from the grip rather than jumping to the finger.
+    from_travel: Option<f32>,
+    from_value: u8,
+    /// Set once the hand has moved, which stops the repeat.
+    dragging: bool,
+}
+
+/// How long a button sits on the dial before it starts repeating.
+const DIAL_REPEAT_DELAY: std::time::Duration = std::time::Duration::from_millis(350);
+
+/// The MT-32's front panel: which part it is showing, which buttons are
+/// down, and what it believes each editable value to be.
+///
+/// The synth has no way to read a patch parameter back, so the panel tracks
+/// what it has written -- which is what the hardware's own firmware does.
+#[derive(Debug)]
+pub struct Mt32Panel {
+    mode: Mode,
+    /// The button being held down, put there by right-clicking it. Only
+    /// MASTER VOLUME leads anywhere, which is the unit's own arrangement.
+    held: Option<Mt32Control>,
+    /// The part being shown, 0-7 for parts 1-8 and 8 for rhythm.
+    part: usize,
+    master_volume: u8,
+    part_level: [u8; 9],
+    part_timbre: [(u8, u8); 9],
+    master_tune: u8,
+    reverb_mode: u8,
+    /// Whether parts 1-8 have been moved down onto channels 1-8, which is
+    /// the unit's other channel arrangement.
+    channels_shifted: bool,
+    dial: Option<DialGrab>,
+}
+
+impl Default for Mt32Panel {
+    fn default() -> Self {
+        Self {
+            mode: Mode::Home,
+            held: None,
+            part: 0,
+            // The engine's own power-on values: full volume, parts at 80,
+            // the first timbre, A = 442 Hz, room reverb.
+            master_volume: 100,
+            part_level: [80; 9],
+            part_timbre: [(0, 0); 9],
+            master_tune: 74,
+            reverb_mode: 0,
+            channels_shifted: false,
+            dial: None,
+        }
+    }
+}
+
+impl Mt32Panel {
+    /// Start over, as a unit just switched on is.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Let the pointer go, ending any turn of the dial.
+    pub fn release_dial(&mut self) {
+        self.dial = None;
+    }
+
+    /// Whether a button is being held on the dial.
+    pub fn dial_held(&self) -> bool {
+        self.dial.is_some()
+    }
+
+    /// A press on the panel.
+    ///
+    /// Right-clicking a button holds it down, as a finger would; left
+    /// clicking presses it. Holding MASTER VOLUME and pressing another is
+    /// how every one of the unit's two-button functions is reached, and a
+    /// few of those then wait for a third press.
+    pub fn press(
+        &mut self,
+        control: Mt32Control,
+        left: bool,
+        pos: (i32, i32),
+        rect: Rect,
+        synth: Option<&mut crate::mt32::Mt32Synth>,
+    ) -> PanelAction {
+        // The dial is not a button: its two clicks step it either way.
+        if control == Mt32Control::Dial {
+            self.grab_dial(left, pos, rect, synth);
+            return PanelAction::None;
+        }
+        if control == Mt32Control::Power {
+            return PanelAction::Power(true);
+        }
+
+        // A pair is two buttons held down together, so both presses are
+        // right-clicks: MASTER VOLUME to take hold, then the button it is
+        // held with. A left click is a plain press and lets go of it.
+        let master = Mt32Control::Function(Function::MasterVolume);
+        if !left && self.held == Some(master) && control != master {
+            self.held = None;
+            return match chord_for(control) {
+                Some(chord) => self.enter_chord(chord),
+                None => PanelAction::None,
+            };
+        }
+
+        // A pair waiting to be confirmed takes the next part press.
+        if let (Mode::Confirm(chord), Mt32Control::Part(n)) = (self.mode, control) {
+            return self.confirm_chord(chord, n, synth);
+        }
+
+        if !left {
+            // Only MASTER VOLUME leads anywhere held down -- every one of
+            // the unit's pairs starts with it -- so holding anything else
+            // would light a button that could not do anything.
+            if control == master {
+                self.held = if self.held == Some(master) {
+                    None
+                } else {
+                    Some(master)
+                };
+            }
+            return PanelAction::None;
+        }
+
+        self.held = None;
+        match control {
+            // Pressing what is already showing goes back to the main
+            // screen, which is where the unit rests with nothing lit.
+            Mt32Control::Part(n) if self.part == n && self.mode != Mode::Home => {
+                self.release(synth);
+            }
+            Mt32Control::Function(f) if self.mode == Mode::Function(f) => self.release(synth),
+            Mt32Control::Part(n) => {
+                self.part = n;
+                self.mode = Mode::Function(Function::Volume);
+            }
+            Mt32Control::Function(f) => self.mode = Mode::Function(f),
+            Mt32Control::Dial | Mt32Control::Power => {}
+        }
+        PanelAction::None
+    }
+
+    /// Let the display go back to the engine, as the unit does when it
+    /// returns to its main screen.
+    fn release(&mut self, synth: Option<&mut crate::mt32::Mt32Synth>) {
+        self.mode = Mode::Home;
+        self.held = None;
+        if let Some(synth) = synth {
+            synth.show_main_display();
+        }
+    }
+
+    /// Enter a two-button function. The ones that write settings do so
+    /// through the same system memory a program would; the ones that want a
+    /// further press wait for it.
+    fn enter_chord(&mut self, chord: Chord) -> PanelAction {
+        match chord {
+            Chord::ShowPart(part) => {
+                // Parts 6, 7 and 8 have no buttons of their own.
+                self.part = part;
+                self.mode = Mode::Function(Function::Volume);
+                PanelAction::Say(format!("Munt MT-32: part {}", part + 1))
+            }
+            Chord::UnitNumber => {
+                // The unit number picks which MT-32 a SysEx message is
+                // addressed to. With one synth on a private cable there is
+                // nothing to disambiguate, and the engine offers no way to
+                // change it.
+                self.mode = Mode::Chord(chord);
+                PanelAction::Say("Munt MT-32: unit number is fixed at 1".to_string())
+            }
+            _ if chord.needs_confirming() => {
+                self.mode = Mode::Confirm(chord);
+                PanelAction::None
+            }
+            _ => {
+                self.mode = Mode::Chord(chord);
+                PanelAction::None
+            }
+        }
+    }
+
+    /// The further press a three-button procedure waits for.
+    ///
+    /// The manual's procedures all confirm with PART 1; All Reset takes any
+    /// of 2 to 5 as the lighter reset that spares the patch memory.
+    fn confirm_chord(
+        &mut self,
+        chord: Chord,
+        part: usize,
+        synth: Option<&mut crate::mt32::Mt32Synth>,
+    ) -> PanelAction {
+        use crate::mt32::addr;
+        let confirmed = part == 0;
+        match chord {
+            Chord::AllReset if part <= 4 => PanelAction::Recycle,
+            Chord::MidiChannels if confirmed => {
+                // Parts 1-8 move down onto channels 1-8; rhythm stays on 10.
+                self.channels_shifted = !self.channels_shifted;
+                let base = u8::from(!self.channels_shifted);
+                let channels: Vec<u8> = (0..8).map(|p| base + p).collect();
+                if let Some(synth) = synth {
+                    synth.write_memory(addr::CHAN_ASSIGN, &channels);
+                    synth.show_main_display();
+                }
+                self.mode = Mode::Home;
+                self.held = None;
+                PanelAction::Say(format!(
+                    "Munt MT-32: parts 1-8 on channels {}-{}",
+                    base + 1,
+                    base + 8
+                ))
+            }
+            Chord::OverflowAssign if confirmed => {
+                self.release(synth);
+                // Spilling notes past the unit's capacity needs a second
+                // synth on MIDI OUT, which there is nowhere to put here.
+                PanelAction::Say("Munt MT-32: overflow assign needs a second unit".to_string())
+            }
+            _ => {
+                self.release(synth);
+                PanelAction::None
+            }
+        }
+    }
+
+    // --- the dial --------------------------------------------------------
+
+    /// Take hold of the dial: a click steps it, and holding on repeats.
+    fn grab_dial(
+        &mut self,
+        clockwise: bool,
+        pos: (i32, i32),
+        rect: Rect,
+        synth: Option<&mut crate::mt32::Mt32Synth>,
+    ) {
+        self.step_dial(if clockwise { 1 } else { -1 }, synth);
+        let now = std::time::Instant::now();
+        self.dial = Some(DialGrab {
+            clockwise,
+            pressed_at: now,
+            last_step: now,
+            from_travel: dial_value_at(rect, pos),
+            from_value: self.dial_target().0,
+            dragging: false,
+        });
+    }
+
+    /// Follow the hand round the dial while a button is held.
+    ///
+    /// The turn is measured from where the dial was taken hold of, so it
+    /// moves under the hand instead of snapping to wherever the pointer
+    /// happens to be -- a knob does not jump when you touch it.
+    pub fn drag_dial(
+        &mut self,
+        pos: (i32, i32),
+        rect: Rect,
+        synth: Option<&mut crate::mt32::Mt32Synth>,
+    ) {
+        let Some(grab) = &self.dial else { return };
+        let (Some(from_travel), from_value) = (grab.from_travel, grab.from_value) else {
+            return;
+        };
+        let Some(travel) = dial_value_at(rect, pos) else {
+            return;
+        };
+        let max = f32::from(self.dial_target().1);
+        let moved = ((travel - from_travel) * max).round();
+        if moved == 0.0 {
+            return;
+        }
+        if let Some(grab) = &mut self.dial {
+            grab.dragging = true;
+        }
+        self.set_dial_value((f32::from(from_value) + moved).clamp(0.0, max) as u8, synth);
+    }
+
+    /// Step the dial on while a button is held still on it, accelerating the
+    /// longer it is down, the way a held key repeats. Returns whether it
+    /// moved, so the caller knows to redraw.
+    pub fn repeat_dial(&mut self, synth: Option<&mut crate::mt32::Mt32Synth>) -> bool {
+        let Some(grab) = &self.dial else { return false };
+        if grab.dragging {
+            return false;
+        }
+        let held = grab.pressed_at.elapsed();
+        if held < DIAL_REPEAT_DELAY {
+            return false;
+        }
+        // From four a second up to twenty, reached after two seconds down.
+        let ramp = ((held - DIAL_REPEAT_DELAY).as_secs_f32() / 2.0).clamp(0.0, 1.0);
+        if grab.last_step.elapsed() < std::time::Duration::from_secs_f32(0.25 - 0.2 * ramp) {
+            return false;
+        }
+        let clockwise = grab.clockwise;
+        if let Some(grab) = &mut self.dial {
+            grab.last_step = std::time::Instant::now();
+        }
+        self.step_dial(if clockwise { 1 } else { -1 }, synth);
+        true
+    }
+
+    fn step_dial(&mut self, by: i32, synth: Option<&mut crate::mt32::Mt32Synth>) {
+        let (value, max) = self.dial_target();
+        self.set_dial_value(
+            (i32::from(value) + by).clamp(0, i32::from(max)) as u8,
+            synth,
+        );
+    }
+
+    /// The value the dial is standing on and how high it goes. With nothing
+    /// engaged it shows the master volume, which is what the unit rests on.
+    fn dial_target(&self) -> (u8, u8) {
+        let part = self.part;
+        match self.mode {
+            // A pair takes the dial over from either button's own meaning.
+            Mode::Chord(Chord::MasterTune) => (self.master_tune, 127),
+            Mode::Chord(Chord::ReverbMode) => (self.reverb_mode, 3),
+            Mode::Function(Function::Volume) => (self.part_level[part], 100),
+            Mode::Function(Function::SoundGroup) => (self.part_timbre[part].0, 3),
+            Mode::Function(Function::Sound) => (self.part_timbre[part].1, 63),
+            _ => (self.master_volume, 100),
+        }
+    }
+
+    /// Set the value the dial is on, and write it to the synth.
+    ///
+    /// Each lands as a DT1 message in the same memory a program would
+    /// write, so the engine reacts -- and puts the result on its display.
+    fn set_dial_value(&mut self, value: u8, synth: Option<&mut crate::mt32::Mt32Synth>) {
+        use crate::mt32::addr;
+        let part = self.part;
+        let (address, value) = match self.mode {
+            Mode::Chord(Chord::MasterTune) => {
+                self.master_tune = value.min(127);
+                (addr::MASTER_TUNE, self.master_tune)
+            }
+            // The engine models the four reverb rooms; the unit's 0-10 is a
+            // combination of mode, time and level, of which this is the mode.
+            Mode::Chord(Chord::ReverbMode) => {
+                self.reverb_mode = value.min(3);
+                (addr::REVERB_MODE, self.reverb_mode)
+            }
+            Mode::Function(Function::Volume) => {
+                self.part_level[part] = value.min(100);
+                (
+                    addr::patch(part, addr::PATCH_OUTPUT_LEVEL),
+                    self.part_level[part],
+                )
+            }
+            // Four banks: the two internal groups, then memory and rhythm.
+            Mode::Function(Function::SoundGroup) => {
+                self.part_timbre[part].0 = value.min(3);
+                (
+                    addr::patch(part, addr::PATCH_TIMBRE_GROUP),
+                    self.part_timbre[part].0,
+                )
+            }
+            Mode::Function(Function::Sound) => {
+                self.part_timbre[part].1 = value.min(63);
+                (
+                    addr::patch(part, addr::PATCH_TIMBRE_NUMBER),
+                    self.part_timbre[part].1,
+                )
+            }
+            _ => {
+                self.master_volume = value.min(100);
+                (addr::MASTER_VOLUME, self.master_volume)
+            }
+        };
+        if let Some(synth) = synth {
+            synth.write_memory(address, &[value]);
+        }
+    }
+
+    // --- what it looks like ----------------------------------------------
+
+    /// The panel as it should be drawn, over an engine reporting `lcd` and
+    /// `led`, powered or not.
+    pub fn view(
+        &self,
+        lcd: String,
+        led: bool,
+        powered: bool,
+        hover: Option<Mt32Control>,
+    ) -> Mt32PanelView {
+        let (value, max) = self.dial_target();
+        Mt32PanelView {
+            // With a button engaged the panel owns the display, as the
+            // hardware's firmware does while you are editing; let go of it
+            // and the engine's own display comes back.
+            lcd: self.lcd().unwrap_or(lcd),
+            led,
+            parts_lit: self.parts_lit(),
+            functions_lit: self.functions_lit(),
+            dial: if max == 0 {
+                0.0
+            } else {
+                f32::from(value) / f32::from(max)
+            },
+            powered,
+            hover,
+        }
+    }
+
+    /// Which part buttons are lit: the one the panel is standing on, with 1,
+    /// 2 and 3 standing in for parts 6, 7 and 8, plus whichever a pair was
+    /// reached through. Nothing at rest -- the unit has no lamps.
+    fn parts_lit(&self) -> [bool; 6] {
+        let mut lit = [false; 6];
+        if let Some(Mt32Control::Part(n)) = self.held {
+            lit[n] = true;
+        }
+        match self.mode {
+            Mode::Home => {}
+            // A pair or a prompt lights the button it was reached through.
+            Mode::Chord(chord) | Mode::Confirm(chord) => {
+                if let Mt32Control::Part(n) = chord.partner() {
+                    lit[n] = true;
+                }
+            }
+            Mode::Function(f) if f != Function::MasterVolume => {
+                // Parts 1-5 and Rhythm are their own buttons; 6, 7 and 8
+                // show on the buttons that reach them, 1, 2 and 3.
+                let button = match self.part {
+                    p @ 0..=5 => p,
+                    p => p - 5,
+                };
+                lit[button.min(5)] = true;
+            }
+            Mode::Function(_) => {}
+        }
+        lit
+    }
+
+    /// Which function buttons are lit. A pair lights MASTER VOLUME as well
+    /// as its partner, so all of the buttons that reached it are shown.
+    fn functions_lit(&self) -> [bool; 4] {
+        let mut lit = [false; 4];
+        if let Some(Mt32Control::Function(f)) = self.held {
+            lit[f.index()] = true;
+        }
+        match self.mode {
+            Mode::Home => {}
+            Mode::Function(f) => lit[f.index()] = true,
+            Mode::Chord(chord) | Mode::Confirm(chord) => {
+                lit[Function::MasterVolume.index()] = true;
+                if let Mt32Control::Function(f) = chord.partner() {
+                    lit[f.index()] = true;
+                }
+            }
+        }
+        lit
+    }
+
+    /// The line the panel puts on the display while a button is engaged,
+    /// naming the part and the value being turned. `None` at rest, where the
+    /// engine's own display shows instead.
+    fn lcd(&self) -> Option<String> {
+        let function = match self.mode {
+            Mode::Home => return None,
+            // The unit's own wording, and its own units: the tune reads in
+            // hertz across 427.5 to 452.6.
+            Mode::Chord(Chord::MasterTune) => {
+                let hz = 427.5 + f32::from(self.master_tune) * (452.6 - 427.5) / 127.0;
+                return Some(format!("Master Tune :{hz:5.1}Hz"));
+            }
+            Mode::Chord(Chord::ReverbMode) => {
+                return Some(format!("** Reverb mode  : {}", self.reverb_mode))
+            }
+            Mode::Chord(Chord::UnitNumber) => return Some("Unit Number :    1".to_string()),
+            Mode::Chord(_) => return None,
+            // The prompts the manual shows for the three-button procedures.
+            Mode::Confirm(Chord::AllReset) => return Some("** All Reset OK? [1]".to_string()),
+            Mode::Confirm(Chord::MidiChannels) => return Some("MIDI Channel?    [1]".to_string()),
+            Mode::Confirm(_) => return Some("Overflow Assign? [1]".to_string()),
+            Mode::Function(f) => f,
+        };
+        // Parts read 1-5 and R, as they are labelled.
+        let name = if self.part == 5 {
+            "R".to_string()
+        } else {
+            (self.part + 1).to_string()
+        };
+        Some(match function {
+            Function::MasterVolume => format!("Master vol      {:>3}", self.master_volume),
+            Function::Volume => format!("Part {name}  volume  {:>3}", self.part_level[self.part]),
+            Function::SoundGroup => {
+                format!(
+                    "Part {name}  group    {:>2}",
+                    self.part_timbre[self.part].0 + 1
+                )
+            }
+            Function::Sound => {
+                format!(
+                    "Part {name}  sound    {:>2}",
+                    self.part_timbre[self.part].1 + 1
+                )
+            }
+        })
+    }
+}

--- a/src/video/window/mt32panel.rs
+++ b/src/video/window/mt32panel.rs
@@ -39,7 +39,7 @@ const LCD_SURROUND_SHEEN: u32 = rgba(26, 26, 30);
 /// What the glass and its characters look like, per style.
 ///
 /// Unlit is its own colour: the MT-32's backlight simply goes out, while a
-/// JV-1080 keeps its blue a shade darker.
+/// Super JV keeps its blue a shade darker.
 struct LcdColours {
     glass: u32,
     dark_glass: u32,
@@ -48,6 +48,14 @@ struct LcdColours {
     /// one. A shade off the field around it, which is what makes the cells
     /// countable without competing with the writing over them.
     cell: Option<u32>,
+    /// The matrix with the backlight out. Most glass shows nothing at all
+    /// then; the samplers' keeps its dots faintly, being dark ones on a
+    /// screen rather than lit ones behind it.
+    dark_cell: Option<u32>,
+    /// What the MIDI MESSAGE lamp lights in. It is a lamp behind tinted
+    /// plastic rather than part of the display, so it comes with the panel
+    /// whose glass is being worn.
+    lamp: u32,
 }
 
 fn lcd_colours() -> LcdColours {
@@ -61,6 +69,8 @@ fn lcd_colours() -> LcdColours {
             dark_glass: rgba(4, 5, 4),
             text: super::TRACK_SEGMENT_ON,
             cell: None,
+            dark_cell: None,
+            lamp: LAMP_GREEN,
         },
         // Lighter green characters over a lit green backlight; black once
         // that backlight is out.
@@ -74,10 +84,27 @@ fn lcd_colours() -> LcdColours {
             // The cells sit a shade above the field they are masked out of,
             // which is what makes them countable at a glance.
             cell: Some(rgba(38, 68, 22)),
+            dark_cell: None,
+            lamp: LAMP_GREEN,
+        },
+        // A sky-blue lamp with the characters nearly black on it, which is
+        // the other way round from the rest: dark dots on a lit screen
+        // rather than lit dots on a dark one.
+        Mt32Lcd::SSeries => LcdColours {
+            glass: rgba(96, 170, 220),
+            // Out, the lamp is off but the glass keeps its tint, which on
+            // this one is still plainly blue.
+            dark_glass: rgba(34, 52, 68),
+            text: rgba(24, 28, 34),
+            // The matrix sits under the lamp rather than over it, being
+            // unlit dots on a lit screen.
+            cell: Some(rgba(84, 156, 208)),
+            dark_cell: Some(rgba(30, 46, 60)),
+            lamp: LAMP_RED,
         },
         // Deep blue, pale green characters, and the blue stays when it is
         // off.
-        Mt32Lcd::Jv1080 => LcdColours {
+        Mt32Lcd::SuperJv => LcdColours {
             glass: rgba(10, 26, 74),
             dark_glass: rgba(6, 15, 44),
             // A little brighter than it would otherwise want to be: the
@@ -87,14 +114,19 @@ fn lcd_colours() -> LcdColours {
             // There on the unit too, but only just: a shade off the glass,
             // where the MT-32's own can be counted at a glance.
             cell: Some(rgba(16, 34, 86)),
+            dark_cell: None,
+            lamp: LAMP_GREEN,
         },
     }
 }
-/// The MIDI MESSAGE lamp, dark and lit. It is a lamp behind tinted plastic
-/// rather than part of the display, so it keeps its own green whichever
-/// glass the panel is wearing; unlit it is barely green at all.
+/// The MIDI MESSAGE lamp when it is dark: barely anything at all, the way
+/// an unlit LED behind tinted plastic sits.
 const LED_DARK: u32 = rgba(9, 20, 11);
-const LED_LIT: u32 = rgba(52, 206, 74);
+/// What it lights in. The MT-32's is green; the samplers put a red one in
+/// the same corner of the fascia, so a panel wearing their glass wears
+/// their lamp with it.
+const LAMP_GREEN: u32 = rgba(52, 206, 74);
+const LAMP_RED: u32 = rgba(226, 44, 30);
 /// A button being held down: darker than its own face, near enough the
 /// fascia that it reads as having gone into the panel rather than changed
 /// colour. Unlit buttons are the status bar's, and so is the dial -- the
@@ -620,15 +652,15 @@ fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
     // top-left edge over a dark surround, with the glass inset inside it.
     let colours = lcd_colours();
     let lcd = lcd_rect(panel);
-    let glass = if view.powered {
-        colours.glass
+    let (glass, matrix) = if view.powered {
+        (colours.glass, colours.cell)
     } else {
-        colours.dark_glass
+        (colours.dark_glass, colours.dark_cell)
     };
     raised_display(frame, lcd, glass, scale);
-    // With the backlight out there is nothing behind the glass to see, not
-    // even the matrix.
-    if !view.powered {
+    // With the backlight out there is nothing written, though some glass
+    // still shows the matrix it is written on.
+    if !view.powered && matrix.is_none() {
         return;
     }
     // Centred on the glass rather than on the bezel around it, and on the
@@ -657,7 +689,7 @@ fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
         // Every position shows its own matrix whether anything is lit in it
         // or not, with the row the controller keeps for a cursor sitting
         // under it -- which is what gives an LCD its grid of faint blocks.
-        if let Some(unlit) = colours.cell {
+        if let Some(unlit) = matrix {
             let foot = Rect {
                 y: cell.y + cell.h + CELL_FOOT_GAP,
                 h: CELL_FOOT_H,
@@ -702,6 +734,10 @@ fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
                 }
             }
         }
+        // Nothing is written with the backlight out.
+        if !view.powered {
+            continue;
+        }
         let solid = ch == crate::mt32::ACTIVE_PART;
         if solid {
             // A part with something sounding on it: every dot in the cell
@@ -721,7 +757,7 @@ fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
         // The characters are made of the same dots as the matrix behind
         // them, so rule them the same way -- but more faintly. The grid
         // belongs to the glass; in the writing it should only be felt.
-        if colours.cell.is_some() {
+        if matrix.is_some() {
             let ink_grain = mix(colours.text, glass, TEXT_GRAIN);
             let glyph = font::glyph(ch);
             for row in 0..CELL_ROWS {
@@ -756,7 +792,12 @@ fn draw_lcd(frame: &mut [u8], panel: Rect, view: &Mt32PanelView, scale: usize) {
 
 fn draw_led(frame: &mut [u8], panel: Rect, lit: bool, scale: usize) {
     let led = led_rect(panel);
-    raised_display(frame, led, if lit { LED_LIT } else { LED_DARK }, scale);
+    raised_display(
+        frame,
+        led,
+        if lit { lcd_colours().lamp } else { LED_DARK },
+        scale,
+    );
     // Printed above the lamp as it is on the fascia, at the head of the
     // column; the lamp is centred under its ink (see led_rect).
     text(
@@ -1115,7 +1156,8 @@ mod tests {
         for (style, name) in [
             (crate::config::Mt32Lcd::Oled, "oled"),
             (crate::config::Mt32Lcd::Mt32, "mt32"),
-            (crate::config::Mt32Lcd::Jv1080, "jv1080"),
+            (crate::config::Mt32Lcd::SuperJv, "superjv"),
+            (crate::config::Mt32Lcd::SSeries, "sseries"),
         ] {
             crate::video::set_mt32_lcd(style);
             // Once lit, once not: the styles differ in how they go dark.
@@ -1450,13 +1492,14 @@ pub enum PanelAction {
     Recycle,
 }
 
-/// What the panel is standing on.
+/// What the panel is showing.
 ///
-/// The unit's buttons carry no lamps, so nothing is lit at rest; a mode
-/// lights exactly the buttons that reached it, which is one, two or three.
+/// Nothing on the panel says which of these it is on: the unit's buttons
+/// are momentary and carry no lamps, so its display is the only thing that
+/// tells you where you have got to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
-    /// The main screen. The engine owns the display and nothing is lit.
+    /// The main screen, which the engine owns.
     Home,
     /// One button: it edits the value it names, for the shown part.
     Function(Function),
@@ -1663,8 +1706,8 @@ impl Mt32Panel {
         self.track_title = title;
     }
 
-    /// Whether the unit came up playing its own songs.
-    pub fn playing_demo(&self) -> bool {
+    /// Whether the unit came up into ROM Play.
+    fn playing_demo(&self) -> bool {
         matches!(self.mode, Mode::Started(StartMode::Demo))
     }
 

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -20,7 +20,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
     );
     draw_hline(
         frame,
-        present_height() * texture_scale,
+        status_bar_top() * texture_scale,
         STATUS_TOP,
         texture_scale,
     );
@@ -35,7 +35,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
         draw_text(
             frame,
             STATUS_LABEL_X * texture_scale,
-            (present_height() + led_row_label_y(row, rows.len())) * texture_scale,
+            (status_bar_top() + led_row_label_y(row, rows.len())) * texture_scale,
             spec.label,
             STATUS_TEXT,
             texture_scale,
@@ -114,7 +114,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
         draw_text(
             frame,
             (JOY_TOGGLE_X.saturating_sub(44)) * texture_scale,
-            (present_height() + STATUS_CONTROL_Y + 2) * texture_scale,
+            (status_bar_top() + STATUS_CONTROL_Y + 2) * texture_scale,
             "CCP",
             STATUS_TEXT,
             texture_scale,
@@ -261,13 +261,13 @@ pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
             let row = pos / 2;
             (
                 MEDIA_CLUSTER_X + col * (MEDIA_CLUSTER_W + MEDIA_CLUSTER_GAP),
-                present_height() + MEDIA_STACKED_ROW0_Y + row * MEDIA_STACKED_PITCH,
+                status_bar_top() + MEDIA_STACKED_ROW0_Y + row * MEDIA_STACKED_PITCH,
                 MEDIA_STACKED_H,
             )
         } else {
             (
                 MEDIA_CLUSTER_X + pos * (MEDIA_CLUSTER_W + MEDIA_CLUSTER_GAP),
-                present_height() + STATUS_CONTROL_Y,
+                status_bar_top() + STATUS_CONTROL_Y,
                 STATUS_CONTROL_H,
             )
         };
@@ -287,7 +287,7 @@ pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
         };
         // The CD cluster is load plus eject only; eject takes the slot a
         // drive cluster gives to swap.
-        let (load, eject, _) = cluster(x, present_height() + STATUS_CONTROL_Y, STATUS_CONTROL_H);
+        let (load, eject, _) = cluster(x, status_bar_top() + STATUS_CONTROL_Y, STATUS_CONTROL_H);
         layout.cd_load = Some(load);
         layout.cd_eject = Some(eject);
     }
@@ -340,7 +340,7 @@ pub(super) fn control_at(pos: (i32, i32), layout: &BarLayout) -> Option<BarContr
 pub(super) fn status_bar_rect() -> Rect {
     Rect {
         x: 0,
-        y: present_height(),
+        y: status_bar_top(),
         w: FB_WIDTH,
         h: STATUS_BAR_HEIGHT,
     }
@@ -425,7 +425,7 @@ pub(super) fn led_row_label_y(row: usize, count: usize) -> usize {
 pub(super) fn led_row_rect(row: usize, count: usize) -> Rect {
     Rect {
         x: STATUS_LED_X,
-        y: present_height() + led_row_label_y(row, count) + STATUS_LED_Y_OFFSET,
+        y: status_bar_top() + led_row_label_y(row, count) + STATUS_LED_Y_OFFSET,
         w: STATUS_LED_W,
         h: STATUS_LED_H,
     }
@@ -434,7 +434,7 @@ pub(super) fn led_row_rect(row: usize, count: usize) -> Rect {
 pub(super) fn fdd_track_counter_rect() -> Rect {
     Rect {
         x: 132,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: 58,
         h: STATUS_CONTROL_H,
     }
@@ -453,7 +453,7 @@ pub(super) fn fdd_track_digit_rect(index: usize) -> Rect {
 pub(super) fn shot_button_rect() -> Rect {
     Rect {
         x: SHOT_BUTTON_X,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: SHOT_BUTTON_W,
         h: STATUS_CONTROL_H,
     }
@@ -462,7 +462,7 @@ pub(super) fn shot_button_rect() -> Rect {
 pub(super) fn menu_button_rect() -> Rect {
     Rect {
         x: ui::MENU_BUTTON_X,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: ui::MENU_BUTTON_W,
         h: STATUS_CONTROL_H,
     }
@@ -471,7 +471,7 @@ pub(super) fn menu_button_rect() -> Rect {
 pub(super) fn volume_control_hit_rect() -> Rect {
     Rect {
         x: VOLUME_SLIDER_X - 8,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: VOLUME_SLIDER_W + 16,
         h: STATUS_CONTROL_H,
     }
@@ -480,7 +480,7 @@ pub(super) fn volume_control_hit_rect() -> Rect {
 pub(super) fn joystick_toggle_rect() -> Rect {
     Rect {
         x: JOY_TOGGLE_X,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: JOY_TOGGLE_W,
         h: STATUS_CONTROL_H,
     }
@@ -489,7 +489,7 @@ pub(super) fn joystick_toggle_rect() -> Rect {
 pub(super) fn volume_slider_track_rect() -> Rect {
     Rect {
         x: VOLUME_SLIDER_X,
-        y: present_height() + VOLUME_SLIDER_Y,
+        y: status_bar_top() + VOLUME_SLIDER_Y,
         w: VOLUME_SLIDER_W,
         h: VOLUME_SLIDER_H,
     }
@@ -501,7 +501,7 @@ pub(super) fn volume_slider_knob_rect(percent: u8) -> Rect {
     let center = track.x + range * usize::from(percent.min(100)) / 100;
     Rect {
         x: center.saturating_sub(VOLUME_KNOB_W / 2),
-        y: present_height() + STATUS_CONTROL_Y + (STATUS_CONTROL_H - VOLUME_KNOB_H) / 2,
+        y: status_bar_top() + STATUS_CONTROL_Y + (STATUS_CONTROL_H - VOLUME_KNOB_H) / 2,
         w: VOLUME_KNOB_W,
         h: VOLUME_KNOB_H,
     }
@@ -510,7 +510,7 @@ pub(super) fn volume_slider_knob_rect(percent: u8) -> Rect {
 pub(super) fn reboot_button_rect() -> Rect {
     Rect {
         x: FB_WIDTH - 58,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: 42,
         h: STATUS_CONTROL_H,
     }
@@ -519,7 +519,7 @@ pub(super) fn reboot_button_rect() -> Rect {
 pub(super) fn power_button_rect() -> Rect {
     Rect {
         x: FB_WIDTH - 108,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: 42,
         h: STATUS_CONTROL_H,
     }
@@ -528,7 +528,7 @@ pub(super) fn power_button_rect() -> Rect {
 pub(super) fn pause_button_rect() -> Rect {
     Rect {
         x: FB_WIDTH - 158,
-        y: present_height() + STATUS_CONTROL_Y,
+        y: status_bar_top() + STATUS_CONTROL_Y,
         w: 42,
         h: STATUS_CONTROL_H,
     }
@@ -871,7 +871,7 @@ pub(super) fn draw_shot_button(frame: &mut [u8], rect: Rect, hover: bool, textur
 pub(super) fn draw_speaker_glyph(frame: &mut [u8], texture_scale: usize) {
     let s = texture_scale;
     let x = VOLUME_GLYPH_X * s;
-    let y = (present_height() + STATUS_CONTROL_Y) * s;
+    let y = (status_bar_top() + STATUS_CONTROL_Y) * s;
     let fs = s as f32;
     fill_rect(
         frame,
@@ -1469,11 +1469,25 @@ pub(super) fn draw_power_glyph(
     color: u32,
     texture_scale: usize,
 ) {
+    draw_power_glyph_sized(frame, cx, cy, 5.5, color, texture_scale);
+}
+
+/// The same mark at a chosen radius, for panels with less room than the
+/// status bar. `radius` is in unscaled pixels; the stroke follows it so the
+/// ring keeps its proportions.
+pub(super) fn draw_power_glyph_sized(
+    frame: &mut [u8],
+    cx: usize,
+    cy: usize,
+    radius_px: f32,
+    color: u32,
+    texture_scale: usize,
+) {
     let scale = texture_scale as f32;
     let ccx = cx as f32 + 0.5;
     let ccy = cy as f32 + 0.5 + 0.5 * scale;
-    let radius = 5.5 * scale;
-    let stroke = 1.35 * scale;
+    let radius = radius_px * scale;
+    let stroke = (radius_px / 4.07).max(0.75) * scale;
 
     // Ring, swept clockwise from just right of top all the way around to
     // just left of top, leaving a gap centred on 12 o'clock.
@@ -1805,12 +1819,14 @@ pub(super) fn draw_perf_overlay(
     }
 }
 
-pub(super) fn draw_osd(frame: &mut [u8], text: &str, texture_scale: usize) {
+pub(super) fn draw_osd(frame: &mut [u8], text: &str, warning: bool, texture_scale: usize) {
     let s = texture_scale;
     let px = 2 * s; // font pixel -> device pixels
     let pad = 4 * s;
     let margin = 8 * s;
     let fw = texture_width(s);
+    // Above the MT-32 panel as well as the status bar: the message belongs
+    // over the picture, not over the instrument under it.
     let display_h = present_height() * s;
 
     let text_w = font::text_width(text, px).min(fw.saturating_sub(2 * (margin + pad)));
@@ -1851,7 +1867,7 @@ pub(super) fn draw_osd(frame: &mut [u8], text: &str, texture_scale: usize) {
         text_x,
         text_y,
         text,
-        OSD_TEXT,
+        if warning { OSD_TEXT_WARNING } else { OSD_TEXT },
         px,
     );
 }

--- a/vendor/munt/AUTHORS.txt
+++ b/vendor/munt/AUTHORS.txt
@@ -1,0 +1,93 @@
+Developers
+----------
+
+Dean "Canadacow" Beeler
+ - Original author of the MT-32 emulator.
+
+Jerome "KingGuppy" Fisher
+ - Extensive modifications to the MT-32 emulator. Many bugfixes. Many cool ideas and loads of code.
+   SMF2WAV conversion tool. Cross-platform UI-enabled application. Digital captures, analysis.
+
+"Mok"
+ - Through study of the original ROMs, provided information to greatly increase emulation accuracy.
+
+Tristan
+ - Original author of the ALSA driver.
+
+"SergM"
+ - Improved waveform generation and performance. High-level models of LA32 and reverb chips. Bugfixes.
+   Reimplemented Windows driver. Help with UI-enabled application.
+
+Contributors
+------------
+
+Jonathan Gevaryahu
+ - Sent his MT-32 all the way from Pennsylvania, USA to Australia to get ROM dumps.
+   Help with reverb analysis. LA32 ROM analysing.
+
+"The Guru" (http://unemulated.emuunlim.com/)
+ - Dumped the ROMs of the device above.
+
+Laust "Talus" Brock-Nannestad
+ - Dumped the CM-32L ROMs.
+
+"balrog"
+ - Helping with analysis, obtaining and dumping RWI-modded and v2.04 ROMs, supplying us with his costly logic analyzer. :)
+   LA32 ROM analysing.
+
+"Sarayan"
+ - Reversed some LA32 circuits and internal LA32 ROMs. LA32 ROM analysing.
+
+"IssaUt"
+ - Dumped the MT-32 v2.07 control ROM.
+
+"Cloudschatze"
+ - Dumped the CM-32LN v1.00 control ROM. Helped with analysis of quirks of the 3rd-gen devices.
+
+Martin Lukasek
+ - Dumped the MT-32 v2.06 control ROM.
+
+"sdhizumi"
+ - Dumped the MT-32 v2.03 control ROM.
+
+Also thanks go to Kaminari Redux, NewRisingSun, robertmo, ripsaw8080, Mau1wurf1977 and other inhabitants of VOGONS
+for their suggestions and help with debugging.
+
+Third-party code incorporated in library
+----------------------------------------
+
+The library incorporates a fast C++ implementation of SHA1 algorithm with a small memory footprint
+(https://code.google.com/archive/p/smallsha1/). Copyright (c) 2011, Micael Hildenborg.
+Distributed under the BSD 3-clause license as stated below.
+
+ Copyright (c) 2011, Micael Hildenborg
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Micael Hildenborg nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY Micael Hildenborg ''AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL Micael Hildenborg BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Other code contributions
+------------------------
+
+We are grateful to many other contributors to the library code who submitted pull requests
+at GitHub with bug fixes, suggestions and improvements. See the main code repository
+(https://github.com/munt/munt/) to find detailed information.

--- a/vendor/munt/GPL2.txt
+++ b/vendor/munt/GPL2.txt
@@ -1,0 +1,339 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/vendor/munt/LGPL21.txt
+++ b/vendor/munt/LGPL21.txt
@@ -1,0 +1,504 @@
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/vendor/munt/README.md
+++ b/vendor/munt/README.md
@@ -1,0 +1,44 @@
+# Munt mt32emu (vendored)
+
+`libmt32emu`, the synthesiser engine behind the Munt project, which is what
+lets Copperline answer Paula's MIDI stream as a Roland MT-32 without any
+hardware or any host MIDI plumbing.
+
+- Upstream: <https://github.com/munt/munt>
+- Vendored from commit `6e7c01fba7e1d50c8fa705834889fd0eac136075` (2026-06-22),
+  which describes itself as `munt_2_8_2-10-g6e7c01fb`.
+- Licence: LGPL-2.1-or-later (see `LGPL21.txt`, and `GPL2.txt` for the GPL it
+  refers to). Compatible with Copperline's GPL-3.0-or-later, which is how it
+  can be linked in directly. Authors are credited in `AUTHORS.txt`.
+- The Roland ROMs the engine runs on are **not** here and never will be: they
+  are Roland's copyright, and the user supplies their own.
+
+These sources are compiled straight into the emulator by `build.rs`, so
+`cargo build` produces a binary that speaks MT-32 with nothing to install and
+nothing to download. `src/mt32/` on the Rust side calls into them through the
+library's own C API.
+
+## What was left out
+
+Everything here is byte-identical to that commit. Four things upstream ships
+were simply not copied, none of which the engine needs to run:
+
+- `src/test/` -- the doctest unit suite, which needs doctest and tests
+  upstream's own code rather than ours.
+- `src/srchelper/SoxrAdapter.*` and `src/srchelper/SamplerateAdapter.*` --
+  optional resampler back ends needing libsoxr or libsamplerate. `build.rs`
+  defines `MT32EMU_WITH_INTERNAL_RESAMPLER`, so the built-in one under
+  `src/srchelper/srctools/` is used and there are no external dependencies.
+- `CMakeLists.txt` and the `cmake/` helpers -- `build.rs` compiles the sources
+  directly, as it does for FloppyBridge.
+- `src/config.h.in` is kept for reference, but CMake is what would fill it in.
+  `config.h` beside it is Copperline's static answer: a static build, no
+  version tagging, both API flavours available.
+
+## Updating
+
+Copy `mt32emu/src/*` from a newer upstream checkout over `src/`, restore the
+omissions above, and update the commit recorded here. `build.rs` picks the
+files it compiles by name, so a release that adds or renames a source needs
+that list updated too; a release that changes `config.h.in` needs `config.h`
+re-checked against it.

--- a/vendor/munt/src/Analog.cpp
+++ b/vendor/munt/src/Analog.cpp
@@ -1,0 +1,426 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+
+#include "internals.h"
+
+#include "Analog.h"
+#include "Synth.h"
+
+namespace MT32Emu {
+
+/* FIR approximation of the overall impulse response of the cascade composed of the sample & hold circuit and the low pass filter
+ * of the MT-32 first generation.
+ * The coefficients below are found by windowing the inverse DFT of the 1024 pin frequency response converted to the minimum phase.
+ * The frequency response of the LPF is computed directly, the effect of the S&H is approximated by multiplying the LPF frequency
+ * response by the corresponding sinc. Although, the LPF has DC gain of 3.2, we ignore this in the emulation and use normalised model.
+ * The peak gain of the normalised cascade appears about 1.7 near 11.8 kHz. Relative error doesn't exceed 1% for the frequencies
+ * below 12.5 kHz. In the higher frequency range, the relative error is below 8%. Peak error value is at 16 kHz.
+ */
+static const FloatSample COARSE_LPF_FLOAT_TAPS_MT32[] = {
+	1.272473681f, -0.220267785f, -0.158039905f, 0.179603785f, -0.111484097f, 0.054137498f, -0.023518029f, 0.010997169f, -0.006935698f
+};
+
+// Similar approximation for new MT-32 and CM-32L/LAPC-I LPF. As the voltage controlled amplifier was introduced, LPF has unity DC gain.
+// The peak gain value shifted towards higher frequencies and a bit higher about 1.83 near 13 kHz.
+static const FloatSample COARSE_LPF_FLOAT_TAPS_CM32L[] = {
+	1.340615635f, -0.403331694f, 0.036005517f, 0.066156844f, -0.069672532f, 0.049563806f, -0.031113416f, 0.019169774f, -0.012421368f
+};
+
+static const unsigned int COARSE_LPF_INT_FRACTION_BITS = 14;
+
+// Integer versions of the FIRs above multiplied by (1 << 14) and rounded.
+static const IntSampleEx COARSE_LPF_INT_TAPS_MT32[] = {
+	20848, -3609, -2589, 2943, -1827, 887, -385, 180, -114
+};
+
+static const IntSampleEx COARSE_LPF_INT_TAPS_CM32L[] = {
+	21965, -6608, 590, 1084, -1142, 812, -510, 314, -204
+};
+
+/* Combined FIR that both approximates the impulse response of the analogue circuits of sample & hold and the low pass filter
+ * in the audible frequency range (below 20 kHz) and attenuates unwanted mirror spectra above 28 kHz as well. It is a polyphase
+ * filter intended for resampling the signal to 48 kHz yet for applying high frequency boost.
+ * As with the filter above, the analogue LPF frequency response is obtained for 1536 pin grid for range up to 96 kHz and multiplied
+ * by the corresponding sinc. The result is further squared, windowed and passed to generalised Parks-McClellan routine as a desired response.
+ * Finally, the minimum phase factor is found that's essentially the coefficients below.
+ * Relative error in the audible frequency range doesn't exceed 0.0006%, attenuation in the stopband is better than 100 dB.
+ * This level of performance makes it nearly bit-accurate for standard 16-bit sample resolution.
+ */
+
+// FIR version for MT-32 first generation.
+static const FloatSample ACCURATE_LPF_TAPS_MT32[] = {
+	0.003429281f, 0.025929869f, 0.096587777f, 0.228884848f, 0.372413431f, 0.412386503f, 0.263980018f,
+	-0.014504962f, -0.237394528f, -0.257043496f, -0.103436603f, 0.063996095f, 0.124562333f, 0.083703206f,
+	0.013921662f, -0.033475018f, -0.046239712f, -0.029310921f, 0.00126585f, 0.021060961f, 0.017925605f,
+	0.003559874f, -0.005105248f, -0.005647917f, -0.004157918f, -0.002065664f, 0.00158747f, 0.003762585f,
+	0.001867137f, -0.001090028f, -0.001433979f, -0.00022367f, 4.34308E-05f, -0.000247827f, 0.000157087f,
+	0.000605823f, 0.000197317f, -0.000370511f, -0.000261202f, 9.96069E-05f, 9.85073E-05f, -5.28754E-05f,
+	-1.00912E-05f, 7.69943E-05f, 2.03162E-05f, -5.67967E-05f, -3.30637E-05f, 1.61958E-05f, 1.73041E-05f
+};
+
+// FIR version for new MT-32 and CM-32L/LAPC-I.
+static const FloatSample ACCURATE_LPF_TAPS_CM32L[] = {
+	0.003917452f, 0.030693861f, 0.116424199f, 0.275101674f, 0.43217361f, 0.431247894f, 0.183255659f,
+	-0.174955671f, -0.354240244f, -0.212401714f, 0.072259178f, 0.204655344f, 0.108336211f, -0.039099027f,
+	-0.075138174f, -0.026261906f, 0.00582663f, 0.003052193f, 0.00613657f, 0.017017951f, 0.008732535f,
+	-0.011027427f, -0.012933664f, 0.001158097f, 0.006765958f, 0.00046778f, -0.002191106f, 0.001561017f,
+	0.001842871f, -0.001996876f, -0.002315836f, 0.000980965f, 0.001817454f, -0.000243272f, -0.000972848f,
+	0.000149941f, 0.000498886f, -0.000204436f, -0.000347415f, 0.000142386f, 0.000249137f, -4.32946E-05f,
+	-0.000131231f, 3.88575E-07f, 4.48813E-05f, -1.31906E-06f, -1.03499E-05f, 7.71971E-06f, 2.86721E-06f
+};
+
+// According to the CM-64 PCB schematic, there is a difference in the values of the LPF entrance resistors for the reverb and non-reverb channels.
+// This effectively results in non-unity LPF DC gain for the reverb channel of 0.68 while the LPF has unity DC gain for the LA32 output channels.
+// In emulation, the reverb output gain is multiplied by this factor to compensate for the LPF gain difference.
+static const float CM32L_REVERB_TO_LA32_ANALOG_OUTPUT_GAIN_FACTOR = 0.68f;
+
+static const unsigned int OUTPUT_GAIN_FRACTION_BITS = 8;
+static const float OUTPUT_GAIN_MULTIPLIER = float(1 << OUTPUT_GAIN_FRACTION_BITS);
+
+static const unsigned int COARSE_LPF_DELAY_LINE_LENGTH = 8; // Must be a power of 2
+static const unsigned int ACCURATE_LPF_DELAY_LINE_LENGTH = 16; // Must be a power of 2
+static const unsigned int ACCURATE_LPF_NUMBER_OF_PHASES = 3; // Upsampling factor
+static const unsigned int ACCURATE_LPF_PHASE_INCREMENT_REGULAR = 2; // Downsampling factor
+static const unsigned int ACCURATE_LPF_PHASE_INCREMENT_OVERSAMPLED = 1; // No downsampling
+static const Bit32u ACCURATE_LPF_DELTAS_REGULAR[][ACCURATE_LPF_NUMBER_OF_PHASES] = { { 0, 0, 0 }, { 1, 1, 0 }, { 1, 2, 1 } };
+static const Bit32u ACCURATE_LPF_DELTAS_OVERSAMPLED[][ACCURATE_LPF_NUMBER_OF_PHASES] = { { 0, 0, 0 }, { 1, 0, 0 }, { 1, 0, 1 } };
+
+template <class SampleEx>
+class AbstractLowPassFilter {
+public:
+	static AbstractLowPassFilter<SampleEx> &createLowPassFilter(const AnalogOutputMode mode, const bool oldMT32AnalogLPF);
+
+	virtual ~AbstractLowPassFilter() {}
+	virtual SampleEx process(const SampleEx sample) = 0;
+
+	virtual bool hasNextSample() const {
+		return false;
+	}
+
+	virtual unsigned int getOutputSampleRate() const {
+		return SAMPLE_RATE;
+	}
+
+	virtual unsigned int estimateInSampleCount(const unsigned int outSamples) const {
+		return outSamples;
+	}
+
+	virtual void addPositionIncrement(const unsigned int) {}
+};
+
+template <class SampleEx>
+class NullLowPassFilter : public AbstractLowPassFilter<SampleEx> {
+public:
+	SampleEx process(const SampleEx sample) {
+		return sample;
+	}
+};
+
+template <class SampleEx>
+class CoarseLowPassFilter : public AbstractLowPassFilter<SampleEx> {
+private:
+	const SampleEx * const lpfTaps;
+	SampleEx ringBuffer[COARSE_LPF_DELAY_LINE_LENGTH];
+	unsigned int ringBufferPosition;
+
+public:
+	static inline const SampleEx *getLPFTaps(const bool oldMT32AnalogLPF);
+	static inline SampleEx normaliseSample(const SampleEx sample);
+
+	explicit CoarseLowPassFilter(const bool oldMT32AnalogLPF) :
+		lpfTaps(getLPFTaps(oldMT32AnalogLPF)),
+		ringBufferPosition(0)
+	{
+		Synth::muteSampleBuffer(ringBuffer, COARSE_LPF_DELAY_LINE_LENGTH);
+	}
+
+	SampleEx process(const SampleEx inSample) {
+		static const unsigned int DELAY_LINE_MASK = COARSE_LPF_DELAY_LINE_LENGTH - 1;
+
+		SampleEx sample = lpfTaps[COARSE_LPF_DELAY_LINE_LENGTH] * ringBuffer[ringBufferPosition];
+		ringBuffer[ringBufferPosition] = Synth::clipSampleEx(inSample);
+
+		for (unsigned int i = 0; i < COARSE_LPF_DELAY_LINE_LENGTH; i++) {
+			sample += lpfTaps[i] * ringBuffer[(i + ringBufferPosition) & DELAY_LINE_MASK];
+		}
+
+		ringBufferPosition = (ringBufferPosition - 1) & DELAY_LINE_MASK;
+
+		return normaliseSample(sample);
+	}
+};
+
+class AccurateLowPassFilter : public AbstractLowPassFilter<IntSampleEx>, public AbstractLowPassFilter<FloatSample> {
+private:
+	const FloatSample * const LPF_TAPS;
+	const Bit32u (* const deltas)[ACCURATE_LPF_NUMBER_OF_PHASES];
+	const unsigned int phaseIncrement;
+	const unsigned int outputSampleRate;
+
+	FloatSample ringBuffer[ACCURATE_LPF_DELAY_LINE_LENGTH];
+	unsigned int ringBufferPosition;
+	unsigned int phase;
+
+public:
+	AccurateLowPassFilter(const bool oldMT32AnalogLPF, const bool oversample);
+	FloatSample process(const FloatSample sample);
+	IntSampleEx process(const IntSampleEx sample);
+	bool hasNextSample() const;
+	unsigned int getOutputSampleRate() const;
+	unsigned int estimateInSampleCount(const unsigned int outSamples) const;
+	void addPositionIncrement(const unsigned int positionIncrement);
+};
+
+static inline IntSampleEx normaliseSample(const IntSampleEx sample) {
+	return sample >> OUTPUT_GAIN_FRACTION_BITS;
+}
+
+static inline FloatSample normaliseSample(const FloatSample sample) {
+	return sample;
+}
+
+static inline float getActualReverbOutputGain(const float reverbGain, const bool mt32ReverbCompatibilityMode) {
+	return mt32ReverbCompatibilityMode ? reverbGain : reverbGain * CM32L_REVERB_TO_LA32_ANALOG_OUTPUT_GAIN_FACTOR;
+}
+
+static inline IntSampleEx getIntOutputGain(const float outputGain) {
+	return IntSampleEx(((OUTPUT_GAIN_MULTIPLIER < outputGain) ? OUTPUT_GAIN_MULTIPLIER : outputGain) * OUTPUT_GAIN_MULTIPLIER);
+}
+
+template <class SampleEx>
+class AnalogImpl : public Analog {
+public:
+	AbstractLowPassFilter<SampleEx> &leftChannelLPF;
+	AbstractLowPassFilter<SampleEx> &rightChannelLPF;
+	SampleEx synthGain;
+	SampleEx reverbGain;
+
+	AnalogImpl(const AnalogOutputMode mode, const bool oldMT32AnalogLPF) :
+		leftChannelLPF(AbstractLowPassFilter<SampleEx>::createLowPassFilter(mode, oldMT32AnalogLPF)),
+		rightChannelLPF(AbstractLowPassFilter<SampleEx>::createLowPassFilter(mode, oldMT32AnalogLPF)),
+		synthGain(0),
+		reverbGain(0)
+	{}
+
+	~AnalogImpl() {
+		delete &leftChannelLPF;
+		delete &rightChannelLPF;
+	}
+
+	unsigned int getOutputSampleRate() const {
+		return leftChannelLPF.getOutputSampleRate();
+	}
+
+	Bit32u getDACStreamsLength(const Bit32u outputLength) const {
+		return leftChannelLPF.estimateInSampleCount(outputLength);
+	}
+
+	void setSynthOutputGain(const float synthGain);
+	void setReverbOutputGain(const float reverbGain, const bool mt32ReverbCompatibilityMode);
+
+	bool process(IntSample *outStream, const IntSample *nonReverbLeft, const IntSample *nonReverbRight, const IntSample *reverbDryLeft, const IntSample *reverbDryRight, const IntSample *reverbWetLeft, const IntSample *reverbWetRight, Bit32u outLength);
+	bool process(FloatSample *outStream, const FloatSample *nonReverbLeft, const FloatSample *nonReverbRight, const FloatSample *reverbDryLeft, const FloatSample *reverbDryRight, const FloatSample *reverbWetLeft, const FloatSample *reverbWetRight, Bit32u outLength);
+
+	template <class Sample>
+	void produceOutput(Sample *outStream, const Sample *nonReverbLeft, const Sample *nonReverbRight, const Sample *reverbDryLeft, const Sample *reverbDryRight, const Sample *reverbWetLeft, const Sample *reverbWetRight, Bit32u outLength) {
+		if (outStream == NULL) {
+			leftChannelLPF.addPositionIncrement(outLength);
+			rightChannelLPF.addPositionIncrement(outLength);
+			return;
+		}
+
+		while (0 < (outLength--)) {
+			SampleEx outSampleL;
+			SampleEx outSampleR;
+
+			if (leftChannelLPF.hasNextSample()) {
+				outSampleL = leftChannelLPF.process(0);
+				outSampleR = rightChannelLPF.process(0);
+			} else {
+				SampleEx inSampleL = (SampleEx(*(nonReverbLeft++)) + SampleEx(*(reverbDryLeft++))) * synthGain + SampleEx(*(reverbWetLeft++)) * reverbGain;
+				SampleEx inSampleR = (SampleEx(*(nonReverbRight++)) + SampleEx(*(reverbDryRight++))) * synthGain + SampleEx(*(reverbWetRight++)) * reverbGain;
+
+				outSampleL = leftChannelLPF.process(normaliseSample(inSampleL));
+				outSampleR = rightChannelLPF.process(normaliseSample(inSampleR));
+			}
+
+			*(outStream++) = Synth::clipSampleEx(outSampleL);
+			*(outStream++) = Synth::clipSampleEx(outSampleR);
+		}
+	}
+};
+
+Analog *Analog::createAnalog(const AnalogOutputMode mode, const bool oldMT32AnalogLPF, const RendererType rendererType) {
+	switch (rendererType)
+	{
+	case RendererType_BIT16S:
+		return new AnalogImpl<IntSampleEx>(mode, oldMT32AnalogLPF);
+	case RendererType_FLOAT:
+		return new AnalogImpl<FloatSample>(mode, oldMT32AnalogLPF);
+	default:
+		break;
+	}
+	return NULL;
+}
+
+template<>
+bool AnalogImpl<IntSampleEx>::process(IntSample *outStream, const IntSample *nonReverbLeft, const IntSample *nonReverbRight, const IntSample *reverbDryLeft, const IntSample *reverbDryRight, const IntSample *reverbWetLeft, const IntSample *reverbWetRight, Bit32u outLength) {
+	produceOutput(outStream, nonReverbLeft, nonReverbRight, reverbDryLeft, reverbDryRight, reverbWetLeft, reverbWetRight, outLength);
+	return true;
+}
+
+template<>
+bool AnalogImpl<FloatSample>::process(IntSample *, const IntSample *, const IntSample *, const IntSample *, const IntSample *, const IntSample *, const IntSample *, Bit32u) {
+	return false;
+}
+
+template<>
+bool AnalogImpl<IntSampleEx>::process(FloatSample *, const FloatSample *, const FloatSample *, const FloatSample *, const FloatSample *, const FloatSample *, const FloatSample *, Bit32u) {
+	return false;
+}
+
+template<>
+bool AnalogImpl<FloatSample>::process(FloatSample *outStream, const FloatSample *nonReverbLeft, const FloatSample *nonReverbRight, const FloatSample *reverbDryLeft, const FloatSample *reverbDryRight, const FloatSample *reverbWetLeft, const FloatSample *reverbWetRight, Bit32u outLength) {
+	produceOutput(outStream, nonReverbLeft, nonReverbRight, reverbDryLeft, reverbDryRight, reverbWetLeft, reverbWetRight, outLength);
+	return true;
+}
+
+template<>
+void AnalogImpl<IntSampleEx>::setSynthOutputGain(const float useSynthGain) {
+	synthGain = getIntOutputGain(useSynthGain);
+}
+
+template<>
+void AnalogImpl<IntSampleEx>::setReverbOutputGain(const float useReverbGain, const bool mt32ReverbCompatibilityMode) {
+	reverbGain = getIntOutputGain(getActualReverbOutputGain(useReverbGain, mt32ReverbCompatibilityMode));
+}
+
+template<>
+void AnalogImpl<FloatSample>::setSynthOutputGain(const float useSynthGain) {
+	synthGain = useSynthGain;
+}
+
+template<>
+void AnalogImpl<FloatSample>::setReverbOutputGain(const float useReverbGain, const bool mt32ReverbCompatibilityMode) {
+	reverbGain = getActualReverbOutputGain(useReverbGain, mt32ReverbCompatibilityMode);
+}
+
+template<>
+AbstractLowPassFilter<IntSampleEx> &AbstractLowPassFilter<IntSampleEx>::createLowPassFilter(AnalogOutputMode mode, bool oldMT32AnalogLPF) {
+	switch (mode) {
+	case AnalogOutputMode_COARSE:
+		return *new CoarseLowPassFilter<IntSampleEx>(oldMT32AnalogLPF);
+	case AnalogOutputMode_ACCURATE:
+		return *new AccurateLowPassFilter(oldMT32AnalogLPF, false);
+	case AnalogOutputMode_OVERSAMPLED:
+		return *new AccurateLowPassFilter(oldMT32AnalogLPF, true);
+	default:
+		return *new NullLowPassFilter<IntSampleEx>;
+	}
+}
+
+template<>
+AbstractLowPassFilter<FloatSample> &AbstractLowPassFilter<FloatSample>::createLowPassFilter(AnalogOutputMode mode, bool oldMT32AnalogLPF) {
+	switch (mode) {
+		case AnalogOutputMode_COARSE:
+			return *new CoarseLowPassFilter<FloatSample>(oldMT32AnalogLPF);
+		case AnalogOutputMode_ACCURATE:
+			return *new AccurateLowPassFilter(oldMT32AnalogLPF, false);
+		case AnalogOutputMode_OVERSAMPLED:
+			return *new AccurateLowPassFilter(oldMT32AnalogLPF, true);
+		default:
+			return *new NullLowPassFilter<FloatSample>;
+	}
+}
+
+template<>
+const IntSampleEx *CoarseLowPassFilter<IntSampleEx>::getLPFTaps(const bool oldMT32AnalogLPF) {
+	return oldMT32AnalogLPF ? COARSE_LPF_INT_TAPS_MT32 : COARSE_LPF_INT_TAPS_CM32L;
+}
+
+template<>
+const FloatSample *CoarseLowPassFilter<FloatSample>::getLPFTaps(const bool oldMT32AnalogLPF) {
+	return oldMT32AnalogLPF ? COARSE_LPF_FLOAT_TAPS_MT32 : COARSE_LPF_FLOAT_TAPS_CM32L;
+}
+
+template<>
+IntSampleEx CoarseLowPassFilter<IntSampleEx>::normaliseSample(const IntSampleEx sample) {
+	return sample >> COARSE_LPF_INT_FRACTION_BITS;
+}
+
+template<>
+FloatSample CoarseLowPassFilter<FloatSample>::normaliseSample(const FloatSample sample) {
+	return sample;
+}
+
+AccurateLowPassFilter::AccurateLowPassFilter(const bool oldMT32AnalogLPF, const bool oversample) :
+	LPF_TAPS(oldMT32AnalogLPF ? ACCURATE_LPF_TAPS_MT32 : ACCURATE_LPF_TAPS_CM32L),
+	deltas(oversample ? ACCURATE_LPF_DELTAS_OVERSAMPLED : ACCURATE_LPF_DELTAS_REGULAR),
+	phaseIncrement(oversample ? ACCURATE_LPF_PHASE_INCREMENT_OVERSAMPLED : ACCURATE_LPF_PHASE_INCREMENT_REGULAR),
+	outputSampleRate(SAMPLE_RATE * ACCURATE_LPF_NUMBER_OF_PHASES / phaseIncrement),
+	ringBufferPosition(0),
+	phase(0)
+{
+	Synth::muteSampleBuffer(ringBuffer, ACCURATE_LPF_DELAY_LINE_LENGTH);
+}
+
+FloatSample AccurateLowPassFilter::process(const FloatSample inSample) {
+	static const unsigned int DELAY_LINE_MASK = ACCURATE_LPF_DELAY_LINE_LENGTH - 1;
+
+	FloatSample sample = (phase == 0) ? LPF_TAPS[ACCURATE_LPF_DELAY_LINE_LENGTH * ACCURATE_LPF_NUMBER_OF_PHASES] * ringBuffer[ringBufferPosition] : 0.0f;
+	if (!hasNextSample()) {
+		ringBuffer[ringBufferPosition] = inSample;
+	}
+
+	for (unsigned int tapIx = phase, delaySampleIx = 0; delaySampleIx < ACCURATE_LPF_DELAY_LINE_LENGTH; delaySampleIx++, tapIx += ACCURATE_LPF_NUMBER_OF_PHASES) {
+		sample += LPF_TAPS[tapIx] * ringBuffer[(delaySampleIx + ringBufferPosition) & DELAY_LINE_MASK];
+	}
+
+	phase += phaseIncrement;
+	if (ACCURATE_LPF_NUMBER_OF_PHASES <= phase) {
+		phase -= ACCURATE_LPF_NUMBER_OF_PHASES;
+		ringBufferPosition = (ringBufferPosition - 1) & DELAY_LINE_MASK;
+	}
+
+	return ACCURATE_LPF_NUMBER_OF_PHASES * sample;
+}
+
+IntSampleEx AccurateLowPassFilter::process(const IntSampleEx sample) {
+	return IntSampleEx(process(FloatSample(sample)));
+}
+
+bool AccurateLowPassFilter::hasNextSample() const {
+	return phaseIncrement <= phase;
+}
+
+unsigned int AccurateLowPassFilter::getOutputSampleRate() const {
+	return outputSampleRate;
+}
+
+unsigned int AccurateLowPassFilter::estimateInSampleCount(const unsigned int outSamples) const {
+	Bit32u cycleCount = outSamples / ACCURATE_LPF_NUMBER_OF_PHASES;
+	Bit32u remainder = outSamples - cycleCount * ACCURATE_LPF_NUMBER_OF_PHASES;
+	return cycleCount * phaseIncrement + deltas[remainder][phase];
+}
+
+void AccurateLowPassFilter::addPositionIncrement(const unsigned int positionIncrement) {
+	phase = (phase + positionIncrement * phaseIncrement) % ACCURATE_LPF_NUMBER_OF_PHASES;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/Analog.h
+++ b/vendor/munt/src/Analog.h
@@ -1,0 +1,53 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_ANALOG_H
+#define MT32EMU_ANALOG_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Enumerations.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+/* Analog class is dedicated to perform fair emulation of analogue circuitry of hardware units that is responsible
+ * for processing output signal after the DAC. It appears that the analogue circuit labeled "LPF" on the schematic
+ * also applies audible changes to the signal spectra. There is a significant boost of higher frequencies observed
+ * aside from quite poor attenuation of the mirror spectra above 16 kHz which is due to a relatively low filter order.
+ *
+ * As the final mixing of multiplexed output signal is performed after the DAC, this function is migrated here from Synth.
+ * Saying precisely, mixing is performed within the LPF as the entrance resistors are actually components of a LPF
+ * designed using the multiple feedback topology. Nevertheless, the schematic separates them.
+ */
+class Analog {
+public:
+	static Analog *createAnalog(const AnalogOutputMode mode, const bool oldMT32AnalogLPF, const RendererType rendererType);
+
+	virtual ~Analog() {}
+	virtual unsigned int getOutputSampleRate() const = 0;
+	virtual Bit32u getDACStreamsLength(const Bit32u outputLength) const = 0;
+	virtual void setSynthOutputGain(const float synthGain) = 0;
+	virtual void setReverbOutputGain(const float reverbGain, const bool mt32ReverbCompatibilityMode) = 0;
+
+	virtual bool process(IntSample *outStream, const IntSample *nonReverbLeft, const IntSample *nonReverbRight, const IntSample *reverbDryLeft, const IntSample *reverbDryRight, const IntSample *reverbWetLeft, const IntSample *reverbWetRight, Bit32u outLength) = 0;
+	virtual bool process(FloatSample *outStream, const FloatSample *nonReverbLeft, const FloatSample *nonReverbRight, const FloatSample *reverbDryLeft, const FloatSample *reverbDryRight, const FloatSample *reverbWetLeft, const FloatSample *reverbWetRight, Bit32u outLength) = 0;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_ANALOG_H

--- a/vendor/munt/src/BReverbModel.cpp
+++ b/vendor/munt/src/BReverbModel.cpp
@@ -1,0 +1,664 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "internals.h"
+
+#include "BReverbModel.h"
+#include "Synth.h"
+
+// Analysing of state of reverb RAM address lines gives exact sizes of the buffers of filters used. This also indicates that
+// the reverb model implemented in the real devices consists of three series allpass filters preceded by a non-feedback comb (or a delay with a LPF)
+// and followed by three parallel comb filters
+
+namespace MT32Emu {
+
+// Because LA-32 chip makes it's output available to process by the Boss chip with a significant delay,
+// the Boss chip puts to the buffer the LA32 dry output when it is ready and performs processing of the _previously_ latched data.
+// Of course, the right way would be to use a dedicated variable for this, but our reverb model is way higher level,
+// so we can simply increase the input buffer size.
+static const Bit32u PROCESS_DELAY = 1;
+
+static const Bit32u MODE_3_ADDITIONAL_DELAY = 1;
+static const Bit32u MODE_3_FEEDBACK_DELAY = 1;
+
+// Avoid denormals degrading performance, using biased input
+static const FloatSample BIAS = 1e-20f;
+
+struct BReverbSettings {
+	const Bit32u numberOfAllpasses;
+	const Bit32u * const allpassSizes;
+	const Bit32u numberOfCombs;
+	const Bit32u * const combSizes;
+	const Bit32u * const outLPositions;
+	const Bit32u * const outRPositions;
+	const Bit8u * const filterFactors;
+	const Bit8u * const feedbackFactors;
+	const Bit8u * const dryAmps;
+	const Bit8u * const wetLevels;
+	const Bit8u lpfAmp;
+};
+
+// Default reverb settings for "new" reverb model implemented in CM-32L / LAPC-I.
+// Found by tracing reverb RAM data lines (thanks go to Lord_Nightmare & balrog).
+static const BReverbSettings &getCM32L_LAPCSettings(const ReverbMode mode) {
+	static const Bit32u MODE_0_NUMBER_OF_ALLPASSES = 3;
+	static const Bit32u MODE_0_ALLPASSES[] = {994, 729, 78};
+	static const Bit32u MODE_0_NUMBER_OF_COMBS = 4; // Well, actually there are 3 comb filters, but the entrance LPF + delay can be processed via a hacked comb.
+	static const Bit32u MODE_0_COMBS[] = {705 + PROCESS_DELAY, 2349, 2839, 3632};
+	static const Bit32u MODE_0_OUTL[] = {2349, 141, 1960};
+	static const Bit32u MODE_0_OUTR[] = {1174, 1570, 145};
+	static const Bit8u  MODE_0_COMB_FACTOR[] = {0xA0, 0x60, 0x60, 0x60};
+	static const Bit8u  MODE_0_COMB_FEEDBACK[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98};
+	static const Bit8u  MODE_0_DRY_AMP[] = {0xA0, 0xA0, 0xA0, 0xA0, 0xB0, 0xB0, 0xB0, 0xD0};
+	static const Bit8u  MODE_0_WET_AMP[] = {0x10, 0x30, 0x50, 0x70, 0x90, 0xC0, 0xF0, 0xF0};
+	static const Bit8u  MODE_0_LPF_AMP = 0x60;
+
+	static const Bit32u MODE_1_NUMBER_OF_ALLPASSES = 3;
+	static const Bit32u MODE_1_ALLPASSES[] = {1324, 809, 176};
+	static const Bit32u MODE_1_NUMBER_OF_COMBS = 4; // Same as for mode 0 above
+	static const Bit32u MODE_1_COMBS[] = {961 + PROCESS_DELAY, 2619, 3545, 4519};
+	static const Bit32u MODE_1_OUTL[] = {2618, 1760, 4518};
+	static const Bit32u MODE_1_OUTR[] = {1300, 3532, 2274};
+	static const Bit8u  MODE_1_COMB_FACTOR[] = {0x80, 0x60, 0x60, 0x60};
+	static const Bit8u  MODE_1_COMB_FEEDBACK[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                                              0x28, 0x48, 0x60, 0x70, 0x78, 0x80, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98};
+	static const Bit8u  MODE_1_DRY_AMP[] = {0xA0, 0xA0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xE0};
+	static const Bit8u  MODE_1_WET_AMP[] = {0x10, 0x30, 0x50, 0x70, 0x90, 0xC0, 0xF0, 0xF0};
+	static const Bit8u  MODE_1_LPF_AMP = 0x60;
+
+	static const Bit32u MODE_2_NUMBER_OF_ALLPASSES = 3;
+	static const Bit32u MODE_2_ALLPASSES[] = {969, 644, 157};
+	static const Bit32u MODE_2_NUMBER_OF_COMBS = 4; // Same as for mode 0 above
+	static const Bit32u MODE_2_COMBS[] = {116 + PROCESS_DELAY, 2259, 2839, 3539};
+	static const Bit32u MODE_2_OUTL[] = {2259, 718, 1769};
+	static const Bit32u MODE_2_OUTR[] = {1136, 2128, 1};
+	static const Bit8u  MODE_2_COMB_FACTOR[] = {0, 0x20, 0x20, 0x20};
+	static const Bit8u  MODE_2_COMB_FEEDBACK[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                                              0x30, 0x58, 0x78, 0x88, 0xA0, 0xB8, 0xC0, 0xD0,
+	                                              0x30, 0x58, 0x78, 0x88, 0xA0, 0xB8, 0xC0, 0xD0,
+	                                              0x30, 0x58, 0x78, 0x88, 0xA0, 0xB8, 0xC0, 0xD0};
+	static const Bit8u  MODE_2_DRY_AMP[] = {0xA0, 0xA0, 0xB0, 0xB0, 0xB0, 0xB0, 0xC0, 0xE0};
+	static const Bit8u  MODE_2_WET_AMP[] = {0x10, 0x30, 0x50, 0x70, 0x90, 0xC0, 0xF0, 0xF0};
+	static const Bit8u  MODE_2_LPF_AMP = 0x80;
+
+	static const Bit32u MODE_3_NUMBER_OF_ALLPASSES = 0;
+	static const Bit32u MODE_3_NUMBER_OF_COMBS = 1;
+	static const Bit32u MODE_3_DELAY[] = {16000 + MODE_3_FEEDBACK_DELAY + PROCESS_DELAY + MODE_3_ADDITIONAL_DELAY};
+	static const Bit32u MODE_3_OUTL[] = {400, 624, 960, 1488, 2256, 3472, 5280, 8000};
+	static const Bit32u MODE_3_OUTR[] = {800, 1248, 1920, 2976, 4512, 6944, 10560, 16000};
+	static const Bit8u  MODE_3_COMB_FACTOR[] = {0x68};
+	static const Bit8u  MODE_3_COMB_FEEDBACK[] = {0x68, 0x60};
+	static const Bit8u  MODE_3_DRY_AMP[] = {0x20, 0x50, 0x50, 0x50, 0x50, 0x50, 0x50, 0x50,
+	                                        0x20, 0x50, 0x50, 0x50, 0x50, 0x50, 0x50, 0x50};
+	static const Bit8u  MODE_3_WET_AMP[] = {0x18, 0x18, 0x28, 0x40, 0x60, 0x80, 0xA8, 0xF8};
+
+	static const BReverbSettings REVERB_MODE_0_SETTINGS = {MODE_0_NUMBER_OF_ALLPASSES, MODE_0_ALLPASSES, MODE_0_NUMBER_OF_COMBS, MODE_0_COMBS, MODE_0_OUTL, MODE_0_OUTR, MODE_0_COMB_FACTOR, MODE_0_COMB_FEEDBACK, MODE_0_DRY_AMP, MODE_0_WET_AMP, MODE_0_LPF_AMP};
+	static const BReverbSettings REVERB_MODE_1_SETTINGS = {MODE_1_NUMBER_OF_ALLPASSES, MODE_1_ALLPASSES, MODE_1_NUMBER_OF_COMBS, MODE_1_COMBS, MODE_1_OUTL, MODE_1_OUTR, MODE_1_COMB_FACTOR, MODE_1_COMB_FEEDBACK, MODE_1_DRY_AMP, MODE_1_WET_AMP, MODE_1_LPF_AMP};
+	static const BReverbSettings REVERB_MODE_2_SETTINGS = {MODE_2_NUMBER_OF_ALLPASSES, MODE_2_ALLPASSES, MODE_2_NUMBER_OF_COMBS, MODE_2_COMBS, MODE_2_OUTL, MODE_2_OUTR, MODE_2_COMB_FACTOR, MODE_2_COMB_FEEDBACK, MODE_2_DRY_AMP, MODE_2_WET_AMP, MODE_2_LPF_AMP};
+	static const BReverbSettings REVERB_MODE_3_SETTINGS = {MODE_3_NUMBER_OF_ALLPASSES, NULL, MODE_3_NUMBER_OF_COMBS, MODE_3_DELAY, MODE_3_OUTL, MODE_3_OUTR, MODE_3_COMB_FACTOR, MODE_3_COMB_FEEDBACK, MODE_3_DRY_AMP, MODE_3_WET_AMP, 0};
+
+	static const BReverbSettings * const REVERB_SETTINGS[] = {&REVERB_MODE_0_SETTINGS, &REVERB_MODE_1_SETTINGS, &REVERB_MODE_2_SETTINGS, &REVERB_MODE_3_SETTINGS};
+
+	return *REVERB_SETTINGS[mode];
+}
+
+// Default reverb settings for "old" reverb model implemented in MT-32.
+// Found by tracing reverb RAM data lines (thanks go to Lord_Nightmare & balrog).
+static const BReverbSettings &getMT32Settings(const ReverbMode mode) {
+	static const Bit32u MODE_0_NUMBER_OF_ALLPASSES = 3;
+	static const Bit32u MODE_0_ALLPASSES[] = {994, 729, 78};
+	static const Bit32u MODE_0_NUMBER_OF_COMBS = 4; // Same as above in the new model implementation
+	static const Bit32u MODE_0_COMBS[] = {575 + PROCESS_DELAY, 2040, 2752, 3629};
+	static const Bit32u MODE_0_OUTL[] = {2040, 687, 1814};
+	static const Bit32u MODE_0_OUTR[] = {1019, 2072, 1};
+	static const Bit8u  MODE_0_COMB_FACTOR[] = {0xB0, 0x60, 0x60, 0x60};
+	static const Bit8u  MODE_0_COMB_FEEDBACK[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                                              0x28, 0x48, 0x60, 0x70, 0x78, 0x80, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98};
+	static const Bit8u  MODE_0_DRY_AMP[] = {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+	static const Bit8u  MODE_0_WET_AMP[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x70, 0xA0, 0xE0};
+	static const Bit8u  MODE_0_LPF_AMP = 0x80;
+
+	static const Bit32u MODE_1_NUMBER_OF_ALLPASSES = 3;
+	static const Bit32u MODE_1_ALLPASSES[] = {1324, 809, 176};
+	static const Bit32u MODE_1_NUMBER_OF_COMBS = 4; // Same as above in the new model implementation
+	static const Bit32u MODE_1_COMBS[] = {961 + PROCESS_DELAY, 2619, 3545, 4519};
+	static const Bit32u MODE_1_OUTL[] = {2618, 1760, 4518};
+	static const Bit32u MODE_1_OUTR[] = {1300, 3532, 2274};
+	static const Bit8u  MODE_1_COMB_FACTOR[] = {0x90, 0x60, 0x60, 0x60};
+	static const Bit8u  MODE_1_COMB_FEEDBACK[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                                              0x28, 0x48, 0x60, 0x70, 0x78, 0x80, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98};
+	static const Bit8u  MODE_1_DRY_AMP[] = {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+	static const Bit8u  MODE_1_WET_AMP[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x70, 0xA0, 0xE0};
+	static const Bit8u  MODE_1_LPF_AMP = 0x80;
+
+	static const Bit32u MODE_2_NUMBER_OF_ALLPASSES = 3;
+	static const Bit32u MODE_2_ALLPASSES[] = {969, 644, 157};
+	static const Bit32u MODE_2_NUMBER_OF_COMBS = 4; // Same as above in the new model implementation
+	static const Bit32u MODE_2_COMBS[] = {116 + PROCESS_DELAY, 2259, 2839, 3539};
+	static const Bit32u MODE_2_OUTL[] = {2259, 718, 1769};
+	static const Bit32u MODE_2_OUTR[] = {1136, 2128, 1};
+	static const Bit8u  MODE_2_COMB_FACTOR[] = {0, 0x60, 0x60, 0x60};
+	static const Bit8u  MODE_2_COMB_FEEDBACK[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                                              0x28, 0x48, 0x60, 0x70, 0x78, 0x80, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98,
+	                                              0x28, 0x48, 0x60, 0x78, 0x80, 0x88, 0x90, 0x98};
+	static const Bit8u  MODE_2_DRY_AMP[] = {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+	static const Bit8u  MODE_2_WET_AMP[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x70, 0xA0, 0xE0};
+	static const Bit8u  MODE_2_LPF_AMP = 0x80;
+
+	static const Bit32u MODE_3_NUMBER_OF_ALLPASSES = 0;
+	static const Bit32u MODE_3_NUMBER_OF_COMBS = 1;
+	static const Bit32u MODE_3_DELAY[] = {16000 + MODE_3_FEEDBACK_DELAY + PROCESS_DELAY + MODE_3_ADDITIONAL_DELAY};
+	static const Bit32u MODE_3_OUTL[] = {400, 624, 960, 1488, 2256, 3472, 5280, 8000};
+	static const Bit32u MODE_3_OUTR[] = {800, 1248, 1920, 2976, 4512, 6944, 10560, 16000};
+	static const Bit8u  MODE_3_COMB_FACTOR[] = {0x68};
+	static const Bit8u  MODE_3_COMB_FEEDBACK[] = {0x68, 0x60};
+	static const Bit8u  MODE_3_DRY_AMP[] = {0x10, 0x10, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+	                                        0x10, 0x20, 0x20, 0x10, 0x20, 0x10, 0x20, 0x10};
+	static const Bit8u  MODE_3_WET_AMP[] = {0x08, 0x18, 0x28, 0x40, 0x60, 0x80, 0xA8, 0xF8};
+
+	static const BReverbSettings REVERB_MODE_0_SETTINGS = {MODE_0_NUMBER_OF_ALLPASSES, MODE_0_ALLPASSES, MODE_0_NUMBER_OF_COMBS, MODE_0_COMBS, MODE_0_OUTL, MODE_0_OUTR, MODE_0_COMB_FACTOR, MODE_0_COMB_FEEDBACK, MODE_0_DRY_AMP, MODE_0_WET_AMP, MODE_0_LPF_AMP};
+	static const BReverbSettings REVERB_MODE_1_SETTINGS = {MODE_1_NUMBER_OF_ALLPASSES, MODE_1_ALLPASSES, MODE_1_NUMBER_OF_COMBS, MODE_1_COMBS, MODE_1_OUTL, MODE_1_OUTR, MODE_1_COMB_FACTOR, MODE_1_COMB_FEEDBACK, MODE_1_DRY_AMP, MODE_1_WET_AMP, MODE_1_LPF_AMP};
+	static const BReverbSettings REVERB_MODE_2_SETTINGS = {MODE_2_NUMBER_OF_ALLPASSES, MODE_2_ALLPASSES, MODE_2_NUMBER_OF_COMBS, MODE_2_COMBS, MODE_2_OUTL, MODE_2_OUTR, MODE_2_COMB_FACTOR, MODE_2_COMB_FEEDBACK, MODE_2_DRY_AMP, MODE_2_WET_AMP, MODE_2_LPF_AMP};
+	static const BReverbSettings REVERB_MODE_3_SETTINGS = {MODE_3_NUMBER_OF_ALLPASSES, NULL, MODE_3_NUMBER_OF_COMBS, MODE_3_DELAY, MODE_3_OUTL, MODE_3_OUTR, MODE_3_COMB_FACTOR, MODE_3_COMB_FEEDBACK, MODE_3_DRY_AMP, MODE_3_WET_AMP, 0};
+
+	static const BReverbSettings * const REVERB_SETTINGS[] = {&REVERB_MODE_0_SETTINGS, &REVERB_MODE_1_SETTINGS, &REVERB_MODE_2_SETTINGS, &REVERB_MODE_3_SETTINGS};
+
+	return *REVERB_SETTINGS[mode];
+}
+
+static inline IntSample weirdMul(IntSample sample, Bit8u addMask, Bit8u carryMask) {
+#if MT32EMU_BOSS_REVERB_PRECISE_MODE
+	// This algorithm tries to emulate exactly Boss multiplication operation (at least this is what we see on reverb RAM data lines).
+	Bit8u mask = 0x80;
+	IntSampleEx res = 0;
+	for (int i = 0; i < 8; i++) {
+		IntSampleEx carry = (sample < 0) && (mask & carryMask) > 0 ? sample & 1 : 0;
+		sample >>= 1;
+		res += (mask & addMask) > 0 ? sample + carry : 0;
+		mask >>= 1;
+	}
+	return IntSample(res);
+#else
+	(void)carryMask;
+	return IntSample((IntSampleEx(sample) * addMask) >> 8);
+#endif
+}
+
+static inline FloatSample weirdMul(FloatSample sample, Bit8u addMask, Bit8u carryMask) {
+	(void)carryMask;
+	return sample * addMask / 256.0f;
+}
+
+static inline IntSample halveSample(IntSample sample) {
+	return sample >> 1;
+}
+
+static inline FloatSample halveSample(FloatSample sample) {
+	return 0.5f * sample;
+}
+
+static inline IntSample quarterSample(IntSample sample) {
+#if MT32EMU_BOSS_REVERB_PRECISE_MODE
+	return (sample >> 1) / 2;
+#else
+	return sample >> 2;
+#endif
+}
+
+static inline FloatSample quarterSample(FloatSample sample) {
+	return 0.25f * sample;
+}
+
+static inline IntSample addDCBias(IntSample sample) {
+	return sample;
+}
+
+static inline FloatSample addDCBias(FloatSample sample) {
+	return sample + BIAS;
+}
+
+static inline IntSample addAllpassNoise(IntSample sample) {
+#if MT32EMU_BOSS_REVERB_PRECISE_MODE
+	// This introduces reverb noise which actually makes output from the real Boss chip nondeterministic
+	return sample - 1;
+#else
+	return sample;
+#endif
+}
+
+static inline FloatSample addAllpassNoise(FloatSample sample) {
+	return sample;
+}
+
+/* NOTE:
+ *   Thanks to Mok for discovering, the adder in BOSS reverb chip is found to perform addition with saturation to avoid integer overflow.
+ *   Analysing of the algorithm suggests that the overflow is most probable when the combs output is added below.
+ *   So, despite this isn't actually accurate, we only add the check here for performance reasons.
+ */
+static inline IntSample mixCombs(IntSample out1, IntSample out2, IntSample out3) {
+#if MT32EMU_BOSS_REVERB_PRECISE_MODE
+	return Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(IntSampleEx(out1) + (IntSampleEx(out1) >> 1)) + IntSampleEx(out2)) + (IntSampleEx(out2) >> 1)) + IntSampleEx(out3));
+#else
+	return Synth::clipSampleEx(IntSampleEx(out1) + (IntSampleEx(out1) >> 1) + IntSampleEx(out2) + (IntSampleEx(out2) >> 1) + IntSampleEx(out3));
+#endif
+}
+
+static inline FloatSample mixCombs(FloatSample out1, FloatSample out2, FloatSample out3) {
+	return 1.5f * (out1 + out2) + out3;
+}
+
+template <class Sample>
+class RingBuffer {
+	static inline Sample sampleValueThreshold();
+
+protected:
+	Sample *buffer;
+	const Bit32u size;
+	Bit32u index;
+
+public:
+	RingBuffer(const Bit32u newsize) : size(newsize), index(0) {
+		buffer = new Sample[size];
+	}
+
+	virtual ~RingBuffer() {
+		delete[] buffer;
+		buffer = NULL;
+	}
+
+	Sample next() {
+		if (++index >= size) {
+			index = 0;
+		}
+		return buffer[index];
+	}
+
+	bool isEmpty() const {
+		if (buffer == NULL) return true;
+
+		Sample *buf = buffer;
+		for (Bit32u i = 0; i < size; i++) {
+			if (*buf < -sampleValueThreshold() || *buf > sampleValueThreshold()) return false;
+			buf++;
+		}
+		return true;
+	}
+
+	void mute() {
+		Synth::muteSampleBuffer(buffer, size);
+	}
+};
+
+template<>
+IntSample RingBuffer<IntSample>::sampleValueThreshold() {
+	return 8;
+}
+
+template<>
+FloatSample RingBuffer<FloatSample>::sampleValueThreshold() {
+	return 0.001f;
+}
+
+template <class Sample>
+class AllpassFilter : public RingBuffer<Sample> {
+public:
+	AllpassFilter(const Bit32u useSize) : RingBuffer<Sample>(useSize) {}
+
+	// This model corresponds to the allpass filter implementation of the real CM-32L device
+	// found from sample analysis
+	Sample process(const Sample in) {
+		const Sample bufferOut = this->next();
+
+		// store input - feedback / 2
+		this->buffer[this->index] = in - halveSample(bufferOut);
+
+		// return buffer output + feedforward / 2
+		return bufferOut + halveSample(this->buffer[this->index]);
+	}
+};
+
+template <class Sample>
+class CombFilter : public RingBuffer<Sample> {
+protected:
+	const Bit8u filterFactor;
+	Bit8u feedbackFactor;
+
+public:
+	CombFilter(const Bit32u useSize, const Bit8u useFilterFactor) : RingBuffer<Sample>(useSize), filterFactor(useFilterFactor) {}
+
+	// This model corresponds to the comb filter implementation of the real CM-32L device
+	void process(const Sample in) {
+
+		// the previously stored value
+		const Sample last = this->buffer[this->index];
+
+		// prepare input + feedback
+		const Sample filterIn = in + weirdMul(this->next(), feedbackFactor, 0xF0);
+
+		// store input + feedback processed by a low-pass filter
+		this->buffer[this->index] = weirdMul(last, filterFactor, 0xC0) - filterIn;
+	}
+
+	Sample getOutputAt(const Bit32u outIndex) const {
+		return this->buffer[(this->size + this->index - outIndex) % this->size];
+	}
+
+	void setFeedbackFactor(const Bit8u useFeedbackFactor) {
+		feedbackFactor = useFeedbackFactor;
+	}
+};
+
+template <class Sample>
+class DelayWithLowPassFilter : public CombFilter<Sample> {
+	Bit8u amp;
+
+public:
+	DelayWithLowPassFilter(const Bit32u useSize, const Bit8u useFilterFactor, const Bit8u useAmp)
+		: CombFilter<Sample>(useSize, useFilterFactor), amp(useAmp) {}
+
+	void process(const Sample in) {
+		// the previously stored value
+		const Sample last = this->buffer[this->index];
+
+		// move to the next index
+		this->next();
+
+		// low-pass filter process
+		Sample lpfOut = weirdMul(last, this->filterFactor, 0xFF) + in;
+
+		// store lpfOut multiplied by LPF amp factor
+		this->buffer[this->index] = weirdMul(lpfOut, amp, 0xFF);
+	}
+};
+
+template <class Sample>
+class TapDelayCombFilter : public CombFilter<Sample> {
+	Bit32u outL;
+	Bit32u outR;
+
+public:
+	TapDelayCombFilter(const Bit32u useSize, const Bit8u useFilterFactor) : CombFilter<Sample>(useSize, useFilterFactor) {}
+
+	void process(const Sample in) {
+		// the previously stored value
+		const Sample last = this->buffer[this->index];
+
+		// move to the next index
+		this->next();
+
+		// prepare input + feedback
+		// Actually, the size of the filter varies with the TIME parameter, the feedback sample is taken from the position just below the right output
+		const Sample filterIn = in + weirdMul(this->getOutputAt(outR + MODE_3_FEEDBACK_DELAY), this->feedbackFactor, 0xF0);
+
+		// store input + feedback processed by a low-pass filter
+		this->buffer[this->index] = weirdMul(last, this->filterFactor, 0xF0) - filterIn;
+	}
+
+	Sample getLeftOutput() const {
+		return this->getOutputAt(outL + PROCESS_DELAY + MODE_3_ADDITIONAL_DELAY);
+	}
+
+	Sample getRightOutput() const {
+		return this->getOutputAt(outR + PROCESS_DELAY + MODE_3_ADDITIONAL_DELAY);
+	}
+
+	void setOutputPositions(const Bit32u useOutL, const Bit32u useOutR) {
+		outL = useOutL;
+		outR = useOutR;
+	}
+};
+
+template <class Sample>
+class BReverbModelImpl : public BReverbModel {
+public:
+	AllpassFilter<Sample> **allpasses;
+	CombFilter<Sample> **combs;
+
+	const BReverbSettings &currentSettings;
+	const bool tapDelayMode;
+	Bit8u dryAmp;
+	Bit8u wetLevel;
+
+	BReverbModelImpl(const ReverbMode mode, const bool mt32CompatibleModel) :
+		allpasses(NULL), combs(NULL),
+		currentSettings(mt32CompatibleModel ? getMT32Settings(mode) : getCM32L_LAPCSettings(mode)),
+		tapDelayMode(mode == REVERB_MODE_TAP_DELAY)
+	{}
+
+	~BReverbModelImpl() {
+		close();
+	}
+
+	bool isOpen() const {
+		return combs != NULL;
+	}
+
+	void open() {
+		if (isOpen()) return;
+		if (currentSettings.numberOfAllpasses > 0) {
+			allpasses = new AllpassFilter<Sample>*[currentSettings.numberOfAllpasses];
+			for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
+				allpasses[i] = new AllpassFilter<Sample>(currentSettings.allpassSizes[i]);
+			}
+		}
+		combs = new CombFilter<Sample>*[currentSettings.numberOfCombs];
+		if (tapDelayMode) {
+			*combs = new TapDelayCombFilter<Sample>(*currentSettings.combSizes, *currentSettings.filterFactors);
+		} else {
+			combs[0] = new DelayWithLowPassFilter<Sample>(currentSettings.combSizes[0], currentSettings.filterFactors[0], currentSettings.lpfAmp);
+			for (Bit32u i = 1; i < currentSettings.numberOfCombs; i++) {
+				combs[i] = new CombFilter<Sample>(currentSettings.combSizes[i], currentSettings.filterFactors[i]);
+			}
+		}
+		mute();
+	}
+
+	void close() {
+		if (allpasses != NULL) {
+			for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
+				if (allpasses[i] != NULL) {
+					delete allpasses[i];
+					allpasses[i] = NULL;
+				}
+			}
+			delete[] allpasses;
+			allpasses = NULL;
+		}
+		if (combs != NULL) {
+			for (Bit32u i = 0; i < currentSettings.numberOfCombs; i++) {
+				if (combs[i] != NULL) {
+					delete combs[i];
+					combs[i] = NULL;
+				}
+			}
+			delete[] combs;
+			combs = NULL;
+		}
+	}
+
+	void mute() {
+		if (allpasses != NULL) {
+			for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
+				allpasses[i]->mute();
+			}
+		}
+		if (combs != NULL) {
+			for (Bit32u i = 0; i < currentSettings.numberOfCombs; i++) {
+				combs[i]->mute();
+			}
+		}
+	}
+
+	void setParameters(Bit8u time, Bit8u level) {
+		if (!isOpen()) return;
+		level &= 7;
+		time &= 7;
+		if (tapDelayMode) {
+			TapDelayCombFilter<Sample> *comb = static_cast<TapDelayCombFilter<Sample> *> (*combs);
+			comb->setOutputPositions(currentSettings.outLPositions[time], currentSettings.outRPositions[time & 7]);
+			comb->setFeedbackFactor(currentSettings.feedbackFactors[((level < 3) || (time < 6)) ? 0 : 1]);
+		} else {
+			for (Bit32u i = 1; i < currentSettings.numberOfCombs; i++) {
+				combs[i]->setFeedbackFactor(currentSettings.feedbackFactors[(i << 3) + time]);
+			}
+		}
+		if (time == 0 && level == 0) {
+			dryAmp = wetLevel = 0;
+		} else {
+			if (tapDelayMode && ((time == 0) || (time == 1 && level == 1))) {
+				// Looks like MT-32 implementation has some minor quirks in this mode:
+				// for odd level values, the output level changes sometimes depending on the time value which doesn't seem right.
+				dryAmp = currentSettings.dryAmps[level + 8];
+			} else {
+				dryAmp = currentSettings.dryAmps[level];
+			}
+			wetLevel = currentSettings.wetLevels[level];
+		}
+	}
+
+	bool isActive() const {
+		if (!isOpen()) return false;
+		for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
+			if (!allpasses[i]->isEmpty()) return true;
+		}
+		for (Bit32u i = 0; i < currentSettings.numberOfCombs; i++) {
+			if (!combs[i]->isEmpty()) return true;
+		}
+		return false;
+	}
+
+	bool isMT32Compatible(const ReverbMode mode) const {
+		return &currentSettings == &getMT32Settings(mode);
+	}
+
+	template <class SampleEx>
+	void produceOutput(const Sample *inLeft, const Sample *inRight, Sample *outLeft, Sample *outRight, Bit32u numSamples) {
+		if (!isOpen()) {
+			Synth::muteSampleBuffer(outLeft, numSamples);
+			Synth::muteSampleBuffer(outRight, numSamples);
+			return;
+		}
+
+		while ((numSamples--) > 0) {
+			Sample dry;
+
+			if (tapDelayMode) {
+				dry = halveSample(*(inLeft++)) + halveSample(*(inRight++));
+			} else {
+				dry = quarterSample(*(inLeft++)) + quarterSample(*(inRight++));
+			}
+
+			// Looks like dryAmp doesn't change in MT-32 but it does in CM-32L / LAPC-I
+			dry = weirdMul(addDCBias(dry), dryAmp, 0xFF);
+
+			if (tapDelayMode) {
+				TapDelayCombFilter<Sample> *comb = static_cast<TapDelayCombFilter<Sample> *>(*combs);
+				comb->process(dry);
+				if (outLeft != NULL) {
+					*(outLeft++) = weirdMul(comb->getLeftOutput(), wetLevel, 0xFF);
+				}
+				if (outRight != NULL) {
+					*(outRight++) = weirdMul(comb->getRightOutput(), wetLevel, 0xFF);
+				}
+			} else {
+				DelayWithLowPassFilter<Sample> * const entranceDelay = static_cast<DelayWithLowPassFilter<Sample> *>(combs[0]);
+				// If the output position is equal to the comb size, get it now in order not to loose it
+				Sample link = entranceDelay->getOutputAt(currentSettings.combSizes[0] - 1);
+
+				// Entrance LPF. Note, comb.process() differs a bit here.
+				entranceDelay->process(dry);
+
+				link = allpasses[0]->process(addAllpassNoise(link));
+				link = allpasses[1]->process(link);
+				link = allpasses[2]->process(link);
+
+				// If the output position is equal to the comb size, get it now in order not to loose it
+				Sample outL1 = combs[1]->getOutputAt(currentSettings.outLPositions[0] - 1);
+
+				combs[1]->process(link);
+				combs[2]->process(link);
+				combs[3]->process(link);
+
+				if (outLeft != NULL) {
+					Sample outL2 = combs[2]->getOutputAt(currentSettings.outLPositions[1]);
+					Sample outL3 = combs[3]->getOutputAt(currentSettings.outLPositions[2]);
+					Sample outSample = mixCombs(outL1, outL2, outL3);
+					*(outLeft++) = weirdMul(outSample, wetLevel, 0xFF);
+				}
+				if (outRight != NULL) {
+					Sample outR1 = combs[1]->getOutputAt(currentSettings.outRPositions[0]);
+					Sample outR2 = combs[2]->getOutputAt(currentSettings.outRPositions[1]);
+					Sample outR3 = combs[3]->getOutputAt(currentSettings.outRPositions[2]);
+					Sample outSample = mixCombs(outR1, outR2, outR3);
+					*(outRight++) = weirdMul(outSample, wetLevel, 0xFF);
+				}
+			} // if (tapDelayMode)
+		} // while ((numSamples--) > 0)
+	} // produceOutput
+
+	bool process(const IntSample *inLeft, const IntSample *inRight, IntSample *outLeft, IntSample *outRight, Bit32u numSamples);
+	bool process(const FloatSample *inLeft, const FloatSample *inRight, FloatSample *outLeft, FloatSample *outRight, Bit32u numSamples);
+};
+
+BReverbModel *BReverbModel::createBReverbModel(const ReverbMode mode, const bool mt32CompatibleModel, const RendererType rendererType) {
+	switch (rendererType)
+	{
+	case RendererType_BIT16S:
+		return new BReverbModelImpl<IntSample>(mode, mt32CompatibleModel);
+	case RendererType_FLOAT:
+		return new BReverbModelImpl<FloatSample>(mode, mt32CompatibleModel);
+	default:
+		break;
+	}
+	return NULL;
+}
+
+template <>
+bool BReverbModelImpl<IntSample>::process(const IntSample *inLeft, const IntSample *inRight, IntSample *outLeft, IntSample *outRight, Bit32u numSamples) {
+	produceOutput<IntSampleEx>(inLeft, inRight, outLeft, outRight, numSamples);
+	return true;
+}
+
+template <>
+bool BReverbModelImpl<IntSample>::process(const FloatSample *, const FloatSample *, FloatSample *, FloatSample *, Bit32u) {
+	return false;
+}
+
+template <>
+bool BReverbModelImpl<FloatSample>::process(const IntSample *, const IntSample *, IntSample *, IntSample *, Bit32u) {
+	return false;
+}
+
+template <>
+bool BReverbModelImpl<FloatSample>::process(const FloatSample *inLeft, const FloatSample *inRight, FloatSample *outLeft, FloatSample *outRight, Bit32u numSamples) {
+	produceOutput<FloatSample>(inLeft, inRight, outLeft, outRight, numSamples);
+	return true;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/BReverbModel.h
+++ b/vendor/munt/src/BReverbModel.h
@@ -1,0 +1,48 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_B_REVERB_MODEL_H
+#define MT32EMU_B_REVERB_MODEL_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Enumerations.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+class BReverbModel {
+public:
+	static BReverbModel *createBReverbModel(const ReverbMode mode, const bool mt32CompatibleModel, const RendererType rendererType);
+
+	virtual ~BReverbModel() {}
+	virtual bool isOpen() const = 0;
+	// After construction or a close(), open() must be called at least once before any other call (with the exception of close()).
+	virtual void open() = 0;
+	// May be called multiple times without an open() in between.
+	virtual void close() = 0;
+	virtual void mute() = 0;
+	virtual void setParameters(Bit8u time, Bit8u level) = 0;
+	virtual bool isActive() const = 0;
+	virtual bool isMT32Compatible(const ReverbMode mode) const = 0;
+	virtual bool process(const IntSample *inLeft, const IntSample *inRight, IntSample *outLeft, IntSample *outRight, Bit32u numSamples) = 0;
+	virtual bool process(const FloatSample *inLeft, const FloatSample *inRight, FloatSample *outLeft, FloatSample *outRight, Bit32u numSamples) = 0;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_B_REVERB_MODEL_H

--- a/vendor/munt/src/Display.cpp
+++ b/vendor/munt/src/Display.cpp
@@ -1,0 +1,354 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <cstring>
+
+#include "internals.h"
+
+#include "Display.h"
+#include "Part.h"
+#include "Structures.h"
+#include "Synth.h"
+
+namespace MT32Emu {
+
+/* Details on the emulation model.
+ *
+ * There are four display modes emulated:
+ * - main (Master Volume), set upon startup after showing the welcoming banner;
+ * - program change notification;
+ * - custom display message received via a SysEx;
+ * - error banner (e.g. the MIDI message checksum error).
+ * Stuff like cursor blinking, patch selection mode, test mode, reaction to the front panel buttons, etc. is out of scope, as more
+ * convenient UI/UX solutions are likely desired in applications, if at all.
+ *
+ * Note, despite the LAPC and CM devices come without the LCD and the front panel buttons, the control ROM does support these,
+ * if connected to the main board. That's intended for running the test mode in a service centre, as documented.
+ *
+ * Within the aforementioned scope, the observable hardware behaviour differs noticeably, depending on the control ROM version.
+ * At least three milestones can be identified:
+ * - with MT-32 control ROM V1.06, custom messages are no longer shown unless the display is in the main (Master Volume) mode;
+ * - with MT-32 control ROM V2.04, new function introduced - Display Reset yet added many other changes (taking the full SysEx
+ *   address into account when processing custom messages and special handling of the ASCII control characters are among them);
+ *   all the second-gen devices, including LAPC-I and CM-32L, behave very similarly;
+ * - in the third-gen devices, the LCD support was partially cut down in the control ROM (basically, only the status
+ *   of the test mode, the ROM version and the checksum warnings are shown) - it's not fun, so this is NOT emulated.
+ *
+ * Features of the old-gen units.
+ * - Any message with the first address byte 0x20 is processed and has some effect on the LCD. Messages with any other first
+ *   address byte (e.g. starting with 0x21 or 0x1F7F7F with an overlap) are not considered display-relevant.
+ * - The second and the third address byte are largely irrelevant. Only presence of the second address byte makes an observable
+ *   difference, not the data within.
+ * - Any string received in the custom message is normalised - all ASCII control characters are replaced with spaces, messages
+ *   shorter than 20 bytes are filled up with spaces to the full supported length. However, should a timbre name contain an ASCII
+ *   control character, it is displayed nevertheless, with zero meaning the end-of-string.
+ * - Special message 0x20 (of just 1 address byte) shows the contents of the custom message buffer with either the last received
+ *   message or the empty buffer initially filled with spaces. See the note below about the priorities of the display modes.
+ * - Messages containing two or three bytes with just the address are considered empty and fill the custom message buffer with
+ *   all spaces. The contents of the empty buffer is then shown, depending on the priority of the current display mode.
+ * - Timing: custom messages are shown until an external event occurs like pressing a front panel button, receiving a new custom
+ *   message, program change, etc., and for indefinitely long otherwise. A program change notification is shown for about 1300
+ *   milliseconds; when the timer expires, the display returns to the main mode (irrespective to the current display mode).
+ *   When an error occurs, the warning is shown for a limited time only, similarly to the program change notifications.
+ * - The earlier old-gen devices treat all display modes with equal priority, except the main mode, which has a lower one. This
+ *   makes it possible e.g. to replace the error banner with a custom message or a program change notification, and so on.
+ *   A slightly improved behaviour is observed since the control ROM V1.06, when custom messages were de-prioritised. But still,
+ *   a program change beats an error banner even in the later models.
+ *
+ * Features of the second-gen units.
+ * - All three bytes in SysEx address are now relevant.
+ *   - It is possible to replace individual characters in the custom message buffer which are addressed individually within
+ *     the range 0x200000-0x200013.
+ *   - Writes to higher addresses up to 0x20007F simply make the custom message buffer shown, with either the last received message
+ *     or the empty buffer initially filled with spaces.
+ *   - Writes to address 0x200100 trigger the Display Reset function which resets the display to the main (Master Volume) mode.
+ *     Similarly, showing an error banner is ended. If a program change notification is shown, this function does nothing, however.
+ *   - Writes to other addresses are not considered display-relevant, albeit writing a long string to lower addresses
+ *     (e.g. 0x1F7F7F) that overlaps the display range does result in updating and showing the custom display message.
+ *   - Writing a long string that covers the custom message buffer and address 0x200100 does both things, i.e. updates the buffer
+ *     and triggers the Display Reset function.
+ * - While the display is not in a user interaction mode, custom messages and error banners have the highest display priority.
+ *   As long as these are shown, program change notifications are suppressed. The display only leaves this mode when the Display
+ *   Reset function is triggered or a front panel button is pressed. Notably, when the user enters the menu, all custom messages
+ *   are ignored, including the Display Reset command, but error banners are shown nevertheless.
+ * - Sending cut down messages with partially specified address rather leads to undefined behaviour, except for a two-byte message
+ *   0x20 0x00 which consistently shows the content of the custom message buffer (if priority permits). Otherwise, the behaviour
+ *   depends on the previously submitted address, e.g. the two-byte version of Display Reset may fail depending on the third byte
+ *   of the previous message. One-byte message 0x20 seemingly does Display Reset yet writes a zero character to a position derived
+ *   from the third byte of the preceding message.
+ *
+ * Some notes on the behaviour that is common to all hardware models.
+ * - The display is DM2011 with LSI SED1200D-0A. This unit supports 4 user-programmable characters stored in CGRAM, all 4 get
+ *   loaded at startup. Character #0 is empty (with the cursor underline), #1 is the full block (used to mark active parts),
+ *   #2 is the pipe character (identical to #124 from the CGROM) and #3 is a variation on "down arrow". During normal operation,
+ *   those duplicated characters #2 and #124 are both used in different places and character #3 can only be made visible by adding
+ *   it either to a custom timbre name or a custom message. Character #0 is probably never shown as this code has special meaning
+ *   in the processing routines. For simplicity, we only use characters #124 and #1 in this model.
+ * - When the main mode is active, the current state of the first 5 parts and the rhythm part is represented by replacing the part
+ *   symbol with the full rectangle character (#1 from the CGRAM). For voice parts, the rectangle is shown as long as at least one
+ *   partial is playing in a non-releasing phase on that part. For the rhythm part, the rectangle blinks briefly when a new NoteOn
+ *   message is received on that part (sometimes even when that actually produces no sound).
+ */
+
+static const char MASTER_VOLUME_WITH_DELIMITER[] = "|  0";
+static const char MASTER_VOLUME_WITH_DELIMITER_AND_PREFIX[] = "|vol:  0";
+static const Bit8u RHYTHM_PART_CODE = 'R';
+static const Bit8u FIELD_DELIMITER = '|';
+static const Bit8u ACTIVE_PART_INDICATOR = 1;
+
+static const Bit32u DISPLAYED_VOICE_PARTS_COUNT = 5;
+static const Bit32u SOUND_GROUP_NAME_WITH_DELIMITER_SIZE = 8;
+static const Bit32u MASTER_VOLUME_WITH_DELIMITER_SIZE = sizeof(MASTER_VOLUME_WITH_DELIMITER) - 1;
+static const Bit32u MASTER_VOLUME_WITH_DELIMITER_AND_PREFIX_SIZE = sizeof(MASTER_VOLUME_WITH_DELIMITER_AND_PREFIX) - 1;
+
+// This is the period to show those short blinks of MIDI MESSAGE LED and the rhythm part state.
+// Two related countdowns are initialised to 8 and touched each 10 milliseconds by the software timer 0 interrupt handler.
+static const Bit32u BLINK_TIME_MILLIS = 80;
+static const Bit32u BLINK_TIME_FRAMES = BLINK_TIME_MILLIS * SAMPLE_RATE / 1000;
+
+// This is based on the (free-running) TIMER1 overflow interrupt. The timer is 16-bit and clocked at 500KHz.
+// The message is displayed until 10 overflow interrupts occur. At the standard sample rate, it counts
+// precisely as 41943.04 frame times.
+static const Bit32u SCHEDULED_DISPLAY_MODE_RESET_FRAMES = 41943;
+
+/**
+ * Copies up to lengthLimit characters from possibly null-terminated source to destination. The character of destination located
+ * at the position of the null terminator (if any) in source and the rest of destination are left untouched.
+ */
+static void copyNullTerminatedString(Bit8u *destination, const Bit8u *source, Bit32u lengthLimit) {
+	for (Bit32u i = 0; i < lengthLimit; i++) {
+		Bit8u c = source[i];
+		if (c == 0) break;
+		destination[i] = c;
+	}
+}
+
+Display::Display(Synth &useSynth) :
+	synth(useSynth),
+	lastLEDState(),
+	lcdDirty(),
+	lcdUpdateSignalled(),
+	lastRhythmPartState(),
+	mode(Mode_STARTUP_MESSAGE),
+	midiMessagePlayedSinceLastReset(),
+	rhythmNotePlayedSinceLastReset()
+{
+	scheduleDisplayReset();
+	const Bit8u *startupMessage = &synth.controlROMData[synth.controlROMMap->startupMessage];
+	memcpy(displayBuffer, startupMessage, LCD_TEXT_SIZE);
+	memset(customMessageBuffer, ' ', LCD_TEXT_SIZE);
+	memset(voicePartStates, 0, sizeof voicePartStates);
+}
+
+void Display::checkDisplayStateUpdated(bool &midiMessageLEDState, bool &midiMessageLEDUpdated, bool &lcdUpdated) {
+	midiMessageLEDState = midiMessagePlayedSinceLastReset;
+	maybeResetTimer(midiMessagePlayedSinceLastReset, midiMessageLEDResetTimestamp);
+	// Note, the LED represents activity of the voice parts only.
+	for (Bit32u partIndex = 0; !midiMessageLEDState && partIndex < 8; partIndex++) {
+		midiMessageLEDState = voicePartStates[partIndex];
+	}
+	midiMessageLEDUpdated = lastLEDState != midiMessageLEDState;
+	lastLEDState = midiMessageLEDState;
+
+	if (displayResetScheduled && shouldResetTimer(displayResetTimestamp)) setMainDisplayMode();
+
+	if (lastRhythmPartState != rhythmNotePlayedSinceLastReset && mode == Mode_MAIN) lcdDirty = true;
+	lastRhythmPartState = rhythmNotePlayedSinceLastReset;
+	maybeResetTimer(rhythmNotePlayedSinceLastReset, rhythmStateResetTimestamp);
+
+	lcdUpdated = lcdDirty && !lcdUpdateSignalled;
+	if (lcdUpdated) lcdUpdateSignalled = true;
+}
+
+bool Display::getDisplayState(char *targetBuffer, bool narrowLCD) {
+	if (lcdUpdateSignalled) {
+		lcdDirty = false;
+		lcdUpdateSignalled = false;
+
+		switch (mode) {
+		case Mode_CUSTOM_MESSAGE:
+			if (synth.isDisplayOldMT32Compatible()) {
+				memcpy(displayBuffer, customMessageBuffer, LCD_TEXT_SIZE);
+			} else {
+				copyNullTerminatedString(displayBuffer, customMessageBuffer, LCD_TEXT_SIZE);
+			}
+			break;
+		case Mode_ERROR_MESSAGE: {
+			const Bit8u *sysexErrorMessage = &synth.controlROMData[synth.controlROMMap->sysexErrorMessage];
+			memcpy(displayBuffer, sysexErrorMessage, LCD_TEXT_SIZE);
+			break;
+		}
+		case Mode_PROGRAM_CHANGE: {
+			Bit8u *writePosition = displayBuffer;
+			*writePosition++ = '1' + lastProgramChangePartIndex;
+			*writePosition++ = FIELD_DELIMITER;
+			if (narrowLCD) {
+				writePosition[TIMBRE_NAME_SIZE] = 0;
+			} else {
+				memcpy(writePosition, lastProgramChangeSoundGroupName, SOUND_GROUP_NAME_WITH_DELIMITER_SIZE);
+				writePosition += SOUND_GROUP_NAME_WITH_DELIMITER_SIZE;
+			}
+			copyNullTerminatedString(writePosition, lastProgramChangeTimbreName, TIMBRE_NAME_SIZE);
+			break;
+		}
+		case Mode_MAIN: {
+			Bit8u *writePosition = displayBuffer;
+			for (Bit32u partIndex = 0; partIndex < DISPLAYED_VOICE_PARTS_COUNT; partIndex++) {
+				*writePosition++ = voicePartStates[partIndex] ? ACTIVE_PART_INDICATOR : '1' + partIndex;
+				*writePosition++ = ' ';
+			}
+			*writePosition++ = lastRhythmPartState ? ACTIVE_PART_INDICATOR : RHYTHM_PART_CODE;
+			*writePosition++ = ' ';
+			if (narrowLCD) {
+				memcpy(writePosition, MASTER_VOLUME_WITH_DELIMITER, MASTER_VOLUME_WITH_DELIMITER_SIZE);
+				writePosition += MASTER_VOLUME_WITH_DELIMITER_SIZE;
+				*writePosition = 0;
+			} else {
+				memcpy(writePosition, MASTER_VOLUME_WITH_DELIMITER_AND_PREFIX, MASTER_VOLUME_WITH_DELIMITER_AND_PREFIX_SIZE);
+				writePosition += MASTER_VOLUME_WITH_DELIMITER_AND_PREFIX_SIZE;
+			}
+			Bit32u masterVol = synth.mt32ram.system.masterVol;
+			while (masterVol > 0) {
+				std::div_t result = std::div(masterVol, 10);
+				*--writePosition = '0' + result.rem;
+				masterVol = result.quot;
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	memcpy(targetBuffer, displayBuffer, LCD_TEXT_SIZE);
+	targetBuffer[LCD_TEXT_SIZE] = 0;
+	return lastLEDState;
+}
+
+void Display::setMainDisplayMode() {
+	displayResetScheduled = false;
+	mode = Mode_MAIN;
+	lcdDirty = true;
+}
+
+void Display::midiMessagePlayed() {
+	midiMessagePlayedSinceLastReset = true;
+	midiMessageLEDResetTimestamp = synth.renderedSampleCount + BLINK_TIME_FRAMES;
+}
+
+void Display::rhythmNotePlayed() {
+	rhythmNotePlayedSinceLastReset = true;
+	rhythmStateResetTimestamp = synth.renderedSampleCount + BLINK_TIME_FRAMES;
+	midiMessagePlayed();
+	if (synth.isDisplayOldMT32Compatible() && mode == Mode_CUSTOM_MESSAGE) setMainDisplayMode();
+}
+
+void Display::voicePartStateChanged(Bit8u partIndex, bool activated) {
+	if (mode == Mode_MAIN) lcdDirty = true;
+	voicePartStates[partIndex] = activated;
+	if (synth.isDisplayOldMT32Compatible() && mode == Mode_CUSTOM_MESSAGE) setMainDisplayMode();
+}
+
+void Display::masterVolumeChanged() {
+	if (mode == Mode_MAIN) lcdDirty = true;
+}
+
+void Display::programChanged(Bit8u partIndex) {
+	if (!synth.isDisplayOldMT32Compatible() && (mode == Mode_CUSTOM_MESSAGE || mode == Mode_ERROR_MESSAGE)) return;
+	mode = Mode_PROGRAM_CHANGE;
+	lcdDirty = true;
+	scheduleDisplayReset();
+	lastProgramChangePartIndex = partIndex;
+	const Part *part = synth.getPart(partIndex);
+	lastProgramChangeSoundGroupName = synth.getSoundGroupName(part);
+	memcpy(lastProgramChangeTimbreName, part->getCurrentInstr(), TIMBRE_NAME_SIZE);
+}
+
+void Display::checksumErrorOccurred() {
+	if (mode != Mode_ERROR_MESSAGE) {
+		mode = Mode_ERROR_MESSAGE;
+		lcdDirty = true;
+	}
+	if (synth.isDisplayOldMT32Compatible()) {
+		scheduleDisplayReset();
+	} else {
+		displayResetScheduled = false;
+	}
+}
+
+bool Display::customDisplayMessageReceived(const Bit8u *message, Bit32u startIndex, Bit32u length) {
+	if (synth.isDisplayOldMT32Compatible()) {
+		for (Bit32u i = 0; i < LCD_TEXT_SIZE; i++) {
+			Bit8u c = i < length ? message[i] : ' ';
+			if (c < 32 || 127 < c) c = ' ';
+			customMessageBuffer[i] = c;
+		}
+		if (!synth.controlROMFeatures->quirkDisplayCustomMessagePriority
+			&& (mode == Mode_PROGRAM_CHANGE || mode == Mode_ERROR_MESSAGE)) return false;
+		// Note, real devices keep the display reset timer running.
+	} else {
+		if (startIndex > 0x80) return false;
+		if (startIndex == 0x80) {
+			if (mode != Mode_PROGRAM_CHANGE) setMainDisplayMode();
+			return false;
+		}
+		displayResetScheduled = false;
+		if (startIndex < LCD_TEXT_SIZE) {
+			if (length > LCD_TEXT_SIZE - startIndex) length = LCD_TEXT_SIZE - startIndex;
+			memcpy(customMessageBuffer + startIndex, message, length);
+		}
+	}
+	mode = Mode_CUSTOM_MESSAGE;
+	lcdDirty = true;
+	return true;
+}
+
+void Display::displayControlMessageReceived(const Bit8u *messageBytes, Bit32u length) {
+	Bit8u emptyMessage[] = { 0 };
+	if (synth.isDisplayOldMT32Compatible()) {
+		if (length == 1) {
+			customDisplayMessageReceived(customMessageBuffer, 0, LCD_TEXT_SIZE);
+		} else {
+			customDisplayMessageReceived(emptyMessage, 0, 0);
+		}
+	} else {
+		// Always assume the third byte to be zero for simplicity.
+		if (length == 2) {
+			customDisplayMessageReceived(emptyMessage, messageBytes[1] << 7, 0);
+		} else if (length == 1) {
+			customMessageBuffer[0] = 0;
+			customDisplayMessageReceived(emptyMessage, 0x80, 0);
+		}
+	}
+}
+
+void Display::scheduleDisplayReset() {
+	displayResetTimestamp = synth.renderedSampleCount + SCHEDULED_DISPLAY_MODE_RESET_FRAMES;
+	displayResetScheduled = true;
+}
+
+bool Display::shouldResetTimer(Bit32u scheduledResetTimestamp) {
+	// Deals with wrapping of renderedSampleCount.
+	return Bit32s(scheduledResetTimestamp - synth.renderedSampleCount) < 0;
+}
+
+void Display::maybeResetTimer(bool &timerState, Bit32u scheduledResetTimestamp) {
+	if (timerState && shouldResetTimer(scheduledResetTimestamp)) timerState = false;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/Display.h
+++ b/vendor/munt/src/Display.h
@@ -1,0 +1,91 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_DISPLAY_H
+#define MT32EMU_DISPLAY_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+class Synth;
+
+/** Facilitates emulation of internal state of the MIDI MESSAGE LED and the MT-32 LCD. */
+class Display {
+public:
+	static const unsigned int LCD_TEXT_SIZE = 20;
+
+	enum Mode {
+		Mode_MAIN, // a.k.a. Master Volume
+		Mode_STARTUP_MESSAGE,
+		Mode_PROGRAM_CHANGE,
+		Mode_CUSTOM_MESSAGE,
+		Mode_ERROR_MESSAGE
+	};
+
+	Display(Synth &synth);
+	void checkDisplayStateUpdated(bool &midiMessageLEDState, bool &midiMessageLEDUpdated, bool &lcdUpdated);
+	/** Returns whether the MIDI MESSAGE LED is ON and fills the targetBuffer parameter. */
+	bool getDisplayState(char *targetBuffer, bool narrowLCD);
+	void setMainDisplayMode();
+
+	void midiMessagePlayed();
+	void rhythmNotePlayed();
+	void voicePartStateChanged(Bit8u partIndex, bool activated);
+	void masterVolumeChanged();
+	void programChanged(Bit8u partIndex);
+	void checksumErrorOccurred();
+	bool customDisplayMessageReceived(const Bit8u *message, Bit32u startIndex, Bit32u length);
+	void displayControlMessageReceived(const Bit8u *messageBytes, Bit32u length);
+
+private:
+	typedef Bit8u DisplayBuffer[LCD_TEXT_SIZE];
+
+	static const unsigned int TIMBRE_NAME_SIZE = 10;
+
+	Synth &synth;
+
+	bool lastLEDState;
+	bool lcdDirty;
+	bool lcdUpdateSignalled;
+	bool lastRhythmPartState;
+	bool voicePartStates[8];
+
+	Bit8u lastProgramChangePartIndex;
+	const char *lastProgramChangeSoundGroupName;
+	Bit8u lastProgramChangeTimbreName[TIMBRE_NAME_SIZE];
+
+	Mode mode;
+	Bit32u displayResetTimestamp;
+	bool displayResetScheduled;
+	Bit32u midiMessageLEDResetTimestamp;
+	bool midiMessagePlayedSinceLastReset;
+	Bit32u rhythmStateResetTimestamp;
+	bool rhythmNotePlayedSinceLastReset;
+
+	DisplayBuffer displayBuffer;
+	DisplayBuffer customMessageBuffer;
+
+	void scheduleDisplayReset();
+	bool shouldResetTimer(Bit32u scheduledResetTimestamp);
+	void maybeResetTimer(bool &timerState, Bit32u scheduledResetTimestamp);
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_DISPLAY_H

--- a/vendor/munt/src/Enumerations.h
+++ b/vendor/munt/src/Enumerations.h
@@ -1,0 +1,187 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Using two guards since this file may be included twice with different MT32EMU_C_ENUMERATIONS define. */
+
+#if (!defined MT32EMU_CPP_ENUMERATIONS_H && !defined MT32EMU_C_ENUMERATIONS) || (!defined MT32EMU_C_ENUMERATIONS_H && defined MT32EMU_C_ENUMERATIONS)
+
+#ifdef MT32EMU_C_ENUMERATIONS
+
+#define MT32EMU_C_ENUMERATIONS_H
+
+#define MT32EMU_DAC_INPUT_MODE_NAME mt32emu_dac_input_mode
+#define MT32EMU_DAC_INPUT_MODE(ident) MT32EMU_DAC_##ident
+
+#define MT32EMU_MIDI_DELAY_MODE_NAME mt32emu_midi_delay_mode
+#define MT32EMU_MIDI_DELAY_MODE(ident) MT32EMU_MDM_##ident
+
+#define MT32EMU_ANALOG_OUTPUT_MODE_NAME mt32emu_analog_output_mode
+#define MT32EMU_ANALOG_OUTPUT_MODE(ident) MT32EMU_AOM_##ident
+
+#define MT32EMU_PARTIAL_STATE_NAME mt32emu_partial_state
+#define MT32EMU_PARTIAL_STATE(ident) MT32EMU_PS_##ident
+
+#define MT32EMU_SAMPLERATE_CONVERSION_QUALITY_NAME mt32emu_samplerate_conversion_quality
+#define MT32EMU_SAMPLERATE_CONVERSION_QUALITY(ident) MT32EMU_SRCQ_##ident
+
+#define MT32EMU_RENDERER_TYPE_NAME mt32emu_renderer_type
+#define MT32EMU_RENDERER_TYPE(ident) MT32EMU_RT_##ident
+
+#else /* #ifdef MT32EMU_C_ENUMERATIONS */
+
+#define MT32EMU_CPP_ENUMERATIONS_H
+
+#define MT32EMU_DAC_INPUT_MODE_NAME DACInputMode
+#define MT32EMU_DAC_INPUT_MODE(ident) DACInputMode_##ident
+
+#define MT32EMU_MIDI_DELAY_MODE_NAME MIDIDelayMode
+#define MT32EMU_MIDI_DELAY_MODE(ident) MIDIDelayMode_##ident
+
+#define MT32EMU_ANALOG_OUTPUT_MODE_NAME AnalogOutputMode
+#define MT32EMU_ANALOG_OUTPUT_MODE(ident) AnalogOutputMode_##ident
+
+#define MT32EMU_PARTIAL_STATE_NAME PartialState
+#define MT32EMU_PARTIAL_STATE(ident) PartialState_##ident
+
+#define MT32EMU_SAMPLERATE_CONVERSION_QUALITY_NAME SamplerateConversionQuality
+#define MT32EMU_SAMPLERATE_CONVERSION_QUALITY(ident) SamplerateConversionQuality_##ident
+
+#define MT32EMU_RENDERER_TYPE_NAME RendererType
+#define MT32EMU_RENDERER_TYPE(ident) RendererType_##ident
+
+namespace MT32Emu {
+
+#endif /* #ifdef MT32EMU_C_ENUMERATIONS */
+
+/**
+ * Methods for emulating the connection between the LA32 and the DAC, which involves
+ * some hacks in the real devices for doubling the volume.
+ * See also http://en.wikipedia.org/wiki/Roland_MT-32#Digital_overflow
+ */
+enum MT32EMU_DAC_INPUT_MODE_NAME {
+	/**
+	 * Produces samples at double the volume, without tricks.
+	 * Nicer overdrive characteristics than the DAC hacks (it simply clips samples within range)
+	 * Higher quality than the real devices
+	 */
+	MT32EMU_DAC_INPUT_MODE(NICE),
+
+	/**
+	 * Produces samples that exactly match the bits output from the emulated LA32.
+	 * Nicer overdrive characteristics than the DAC hacks (it simply clips samples within range)
+	 * Much less likely to overdrive than any other mode.
+	 * Half the volume of any of the other modes.
+	 * Perfect for developers while debugging :)
+	 */
+	MT32EMU_DAC_INPUT_MODE(PURE),
+
+	/**
+	 * Re-orders the LA32 output bits as in early generation MT-32s (according to Wikipedia).
+	 * Bit order at DAC (where each number represents the original LA32 output bit number, and XX means the bit is always low):
+	 * 15 13 12 11 10 09 08 07 06 05 04 03 02 01 00 XX
+	 */
+	MT32EMU_DAC_INPUT_MODE(GENERATION1),
+
+	/**
+	 * Re-orders the LA32 output bits as in later generations (personally confirmed on my CM-32L - KG).
+	 * Bit order at DAC (where each number represents the original LA32 output bit number):
+	 * 15 13 12 11 10 09 08 07 06 05 04 03 02 01 00 14
+	 */
+	MT32EMU_DAC_INPUT_MODE(GENERATION2)
+};
+
+/** Methods for emulating the effective delay of incoming MIDI messages introduced by a MIDI interface. */
+enum MT32EMU_MIDI_DELAY_MODE_NAME {
+	/** Process incoming MIDI events immediately. */
+	MT32EMU_MIDI_DELAY_MODE(IMMEDIATE),
+
+	/**
+	 * Delay incoming short MIDI messages as if they where transferred via a MIDI cable to a real hardware unit and immediate sysex processing.
+	 * This ensures more accurate timing of simultaneous NoteOn messages.
+	 */
+	MT32EMU_MIDI_DELAY_MODE(DELAY_SHORT_MESSAGES_ONLY),
+
+	/** Delay all incoming MIDI events as if they where transferred via a MIDI cable to a real hardware unit.*/
+	MT32EMU_MIDI_DELAY_MODE(DELAY_ALL)
+};
+
+/** Methods for emulating the effects of analogue circuits of real hardware units on the output signal. */
+enum MT32EMU_ANALOG_OUTPUT_MODE_NAME {
+	/** Only digital path is emulated. The output samples correspond to the digital signal at the DAC entrance. */
+	MT32EMU_ANALOG_OUTPUT_MODE(DIGITAL_ONLY),
+	/** Coarse emulation of LPF circuit. High frequencies are boosted, sample rate remains unchanged. */
+	MT32EMU_ANALOG_OUTPUT_MODE(COARSE),
+	/**
+	 * Finer emulation of LPF circuit. Output signal is upsampled to 48 kHz to allow emulation of audible mirror spectra above 16 kHz,
+	 * which is passed through the LPF circuit without significant attenuation.
+	 */
+	MT32EMU_ANALOG_OUTPUT_MODE(ACCURATE),
+	/**
+	 * Same as AnalogOutputMode_ACCURATE mode but the output signal is 2x oversampled, i.e. the output sample rate is 96 kHz.
+	 * This makes subsequent resampling easier. Besides, due to nonlinear passband of the LPF emulated, it takes fewer number of MACs
+	 * compared to a regular LPF FIR implementations.
+	 */
+	MT32EMU_ANALOG_OUTPUT_MODE(OVERSAMPLED)
+};
+
+enum MT32EMU_PARTIAL_STATE_NAME {
+	MT32EMU_PARTIAL_STATE(INACTIVE),
+	MT32EMU_PARTIAL_STATE(ATTACK),
+	MT32EMU_PARTIAL_STATE(SUSTAIN),
+	MT32EMU_PARTIAL_STATE(RELEASE)
+};
+
+enum MT32EMU_SAMPLERATE_CONVERSION_QUALITY_NAME {
+	/** Use this only when the speed is more important than the audio quality. */
+	MT32EMU_SAMPLERATE_CONVERSION_QUALITY(FASTEST),
+	MT32EMU_SAMPLERATE_CONVERSION_QUALITY(FAST),
+	MT32EMU_SAMPLERATE_CONVERSION_QUALITY(GOOD),
+	MT32EMU_SAMPLERATE_CONVERSION_QUALITY(BEST)
+};
+
+enum MT32EMU_RENDERER_TYPE_NAME {
+	/** Use 16-bit signed samples in the renderer and the accurate wave generator model based on logarithmic fixed-point computations and LUTs. Maximum emulation accuracy and speed. */
+	MT32EMU_RENDERER_TYPE(BIT16S),
+	/** Use float samples in the renderer and simplified wave generator model. Maximum output quality and minimum noise. */
+	MT32EMU_RENDERER_TYPE(FLOAT)
+};
+
+#ifndef MT32EMU_C_ENUMERATIONS
+
+} // namespace MT32Emu
+
+#endif
+
+#undef MT32EMU_DAC_INPUT_MODE_NAME
+#undef MT32EMU_DAC_INPUT_MODE
+
+#undef MT32EMU_MIDI_DELAY_MODE_NAME
+#undef MT32EMU_MIDI_DELAY_MODE
+
+#undef MT32EMU_ANALOG_OUTPUT_MODE_NAME
+#undef MT32EMU_ANALOG_OUTPUT_MODE
+
+#undef MT32EMU_PARTIAL_STATE_NAME
+#undef MT32EMU_PARTIAL_STATE
+
+#undef MT32EMU_SAMPLERATE_CONVERSION_QUALITY_NAME
+#undef MT32EMU_SAMPLERATE_CONVERSION_QUALITY
+
+#undef MT32EMU_RENDERER_TYPE_NAME
+#undef MT32EMU_RENDERER_TYPE
+
+#endif /* #if (!defined MT32EMU_CPP_ENUMERATIONS_H && !defined MT32EMU_C_ENUMERATIONS) || (!defined MT32EMU_C_ENUMERATIONS_H && defined MT32EMU_C_ENUMERATIONS) */

--- a/vendor/munt/src/File.cpp
+++ b/vendor/munt/src/File.cpp
@@ -1,0 +1,77 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+
+#include "internals.h"
+
+#include "File.h"
+#include "sha1/sha1.h"
+
+namespace MT32Emu {
+
+AbstractFile::AbstractFile() : sha1DigestCalculated(false) {
+	sha1Digest[0] = 0;
+
+	reserved = NULL;
+}
+
+AbstractFile::AbstractFile(const SHA1Digest &useSHA1Digest) : sha1DigestCalculated(true) {
+	memcpy(sha1Digest, useSHA1Digest, sizeof(SHA1Digest) - 1);
+	sha1Digest[sizeof(SHA1Digest) - 1] = 0; // Ensure terminator char.
+
+	reserved = NULL;
+}
+
+const File::SHA1Digest &AbstractFile::getSHA1() {
+	if (sha1DigestCalculated) {
+		return sha1Digest;
+	}
+	sha1DigestCalculated = true;
+
+	size_t size = getSize();
+	if (size == 0) {
+		return sha1Digest;
+	}
+
+	const Bit8u *data = getData();
+	if (data == NULL) {
+		return sha1Digest;
+	}
+
+	unsigned char fileDigest[20];
+
+	sha1::calc(data, int(size), fileDigest);
+	sha1::toHexString(fileDigest, sha1Digest);
+	return sha1Digest;
+}
+
+ArrayFile::ArrayFile(const Bit8u *useData, size_t useSize) : data(useData), size(useSize)
+{}
+
+ArrayFile::ArrayFile(const Bit8u *useData, size_t useSize, const SHA1Digest &useSHA1Digest) : AbstractFile(useSHA1Digest), data(useData), size(useSize)
+{}
+
+size_t ArrayFile::getSize() {
+	return size;
+}
+
+const Bit8u *ArrayFile::getData() {
+	return data;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/File.h
+++ b/vendor/munt/src/File.h
@@ -1,0 +1,73 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_FILE_H
+#define MT32EMU_FILE_H
+
+#include <cstddef>
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+class MT32EMU_EXPORT File {
+public:
+	// Includes terminator char.
+	typedef char SHA1Digest[41];
+
+	virtual ~File() {}
+	virtual size_t getSize() = 0;
+	virtual const Bit8u *getData() = 0;
+	virtual const SHA1Digest &getSHA1() = 0;
+
+	virtual void close() = 0;
+};
+
+class MT32EMU_EXPORT AbstractFile : public File {
+public:
+	const SHA1Digest &getSHA1();
+
+protected:
+	AbstractFile();
+	AbstractFile(const SHA1Digest &sha1Digest);
+
+private:
+	bool sha1DigestCalculated;
+	SHA1Digest sha1Digest;
+
+	// Binary compatibility helper.
+	void *reserved;
+};
+
+class MT32EMU_EXPORT ArrayFile : public AbstractFile {
+public:
+	ArrayFile(const Bit8u *data, size_t size);
+	ArrayFile(const Bit8u *data, size_t size, const SHA1Digest &sha1Digest);
+
+	size_t getSize();
+	const Bit8u *getData();
+	void close() {}
+
+private:
+	const Bit8u *data;
+	size_t size;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_FILE_H

--- a/vendor/munt/src/FileStream.cpp
+++ b/vendor/munt/src/FileStream.cpp
@@ -1,0 +1,103 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if defined MT32EMU_SHARED && defined MT32EMU_INSTALL_DEFAULT_LOCALE
+#include <clocale>
+#endif
+
+#include "internals.h"
+
+#include "FileStream.h"
+
+namespace MT32Emu {
+
+// This initialises C locale with the user-preferred system locale once facilitating access
+// to ROM files with localised pathnames. This is only necessary in rare cases e.g. when building
+// shared library statically linked with C runtime with old MS VC versions, so that the C locale
+// set by the client application does not have effect, and thus such ROM files cannot be opened.
+static inline void configureSystemLocale() {
+#if defined MT32EMU_SHARED && defined MT32EMU_INSTALL_DEFAULT_LOCALE
+	static bool configured = false;
+
+	if (configured) return;
+	configured = true;
+
+	setlocale(LC_ALL, "");
+#endif
+}
+
+using std::ios_base;
+
+FileStream::FileStream() : ifsp(*new std::ifstream), data(NULL), size(0)
+{}
+
+FileStream::~FileStream() {
+	// destructor closes ifsp
+	delete &ifsp;
+	delete[] data;
+}
+
+size_t FileStream::getSize() {
+	if (size != 0) {
+		return size;
+	}
+	if (!ifsp.is_open()) {
+		return 0;
+	}
+	ifsp.seekg(0, ios_base::end);
+	size = size_t(ifsp.tellg());
+	return size;
+}
+
+const Bit8u *FileStream::getData() {
+	if (data != NULL) {
+		return data;
+	}
+	if (!ifsp.is_open()) {
+		return NULL;
+	}
+	if (getSize() == 0) {
+		return NULL;
+	}
+	Bit8u *fileData = new Bit8u[size];
+	if (fileData == NULL) {
+		return NULL;
+	}
+	ifsp.seekg(0);
+	ifsp.read(reinterpret_cast<char *>(fileData), std::streamsize(size));
+	if (size_t(ifsp.tellg()) != size) {
+		delete[] fileData;
+		return NULL;
+	}
+	data = fileData;
+	close();
+	return data;
+}
+
+bool FileStream::open(const char *filename) {
+	configureSystemLocale();
+	ifsp.clear();
+	ifsp.open(filename, ios_base::in | ios_base::binary);
+	return !ifsp.fail();
+}
+
+void FileStream::close() {
+	ifsp.close();
+	ifsp.clear();
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/FileStream.h
+++ b/vendor/munt/src/FileStream.h
@@ -1,0 +1,46 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_FILE_STREAM_H
+#define MT32EMU_FILE_STREAM_H
+
+#include <fstream>
+
+#include "globals.h"
+#include "Types.h"
+#include "File.h"
+
+namespace MT32Emu {
+
+class FileStream : public AbstractFile {
+public:
+	MT32EMU_EXPORT FileStream();
+	MT32EMU_EXPORT ~FileStream();
+	MT32EMU_EXPORT size_t getSize();
+	MT32EMU_EXPORT const Bit8u *getData();
+	MT32EMU_EXPORT bool open(const char *filename);
+	MT32EMU_EXPORT void close();
+
+private:
+	std::ifstream &ifsp;
+	const Bit8u *data;
+	size_t size;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_FILE_STREAM_H

--- a/vendor/munt/src/LA32FloatWaveGenerator.cpp
+++ b/vendor/munt/src/LA32FloatWaveGenerator.cpp
@@ -1,0 +1,365 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "internals.h"
+
+#include "LA32FloatWaveGenerator.h"
+#include "mmath.h"
+#include "Tables.h"
+
+namespace MT32Emu {
+
+static const float MIDDLE_CUTOFF_VALUE = 128.0f;
+static const float RESONANCE_DECAY_THRESHOLD_CUTOFF_VALUE = 144.0f;
+static const float MAX_CUTOFF_VALUE = 240.0f;
+
+static const Bit8u *resAmpDecayFactors;
+
+float LA32FloatWaveGenerator::getPCMSample(unsigned int position) {
+	if (position >= pcmWaveLength) {
+		if (!pcmWaveLooped) {
+			return 0;
+		}
+		position = position % pcmWaveLength;
+	}
+	Bit16s pcmSample = pcmWaveAddress[position];
+	float sampleValue = EXP2F(((pcmSample & 32767) - 32787.0f) / 2048.0f);
+	return ((pcmSample & 32768) == 0) ? sampleValue : -sampleValue;
+}
+
+void LA32FloatWaveGenerator::initSynth(const bool useSawtoothWaveform, const Bit8u usePulseWidth, const Bit8u useResonance) {
+	sawtoothWaveform = useSawtoothWaveform;
+	pulseWidth = usePulseWidth;
+	resonance = useResonance;
+
+	wavePos = 0.0f;
+	lastFreq = 0.0f;
+
+	pcmWaveAddress = NULL;
+	active = true;
+}
+
+void LA32FloatWaveGenerator::initPCM(const Bit16s * const usePCMWaveAddress, const Bit32u usePCMWaveLength, const bool usePCMWaveLooped, const bool usePCMWaveInterpolated) {
+	pcmWaveAddress = usePCMWaveAddress;
+	pcmWaveLength = usePCMWaveLength;
+	pcmWaveLooped = usePCMWaveLooped;
+	pcmWaveInterpolated = usePCMWaveInterpolated;
+
+	pcmPosition = 0.0f;
+	active = true;
+}
+
+// ampVal - Logarithmic amp of the wave generator
+// pitch - Logarithmic frequency of the resulting wave
+// cutoffRampVal - Composed of the base cutoff in range [78..178] left-shifted by 18 bits and the TVF modifier
+float LA32FloatWaveGenerator::generateNextSample(const Bit32u ampVal, const Bit16u pitch, const Bit32u cutoffRampVal) {
+	if (!active) {
+		return 0.0f;
+	}
+
+	float sample = 0.0f;
+
+	// SEMI-CONFIRMED: From sample analysis:
+	// (1) Tested with a single partial playing PCM wave 77 with pitchCoarse 36 and no keyfollow, velocity follow, etc.
+	// This gives results within +/- 2 at the output (before any DAC bitshifting)
+	// when sustaining at levels 156 - 255 with no modifiers.
+	// (2) Tested with a special square wave partial (internal capture ID tva5) at TVA envelope levels 155-255.
+	// This gives deltas between -1 and 0 compared to the real output. Note that this special partial only produces
+	// positive amps, so negative still needs to be explored, as well as lower levels.
+	//
+	// Also still partially unconfirmed is the behaviour when ramping between levels, as well as the timing.
+
+	float amp = EXP2F(ampVal / -1024.0f / 4096.0f);
+	float freq = EXP2F(pitch / 4096.0f - 16.0f) * SAMPLE_RATE;
+
+	if (isPCMWave()) {
+		// Render PCM waveform
+		int len = pcmWaveLength;
+		int intPCMPosition = int(pcmPosition);
+		if (intPCMPosition >= len && !pcmWaveLooped) {
+			// We're now past the end of a non-looping PCM waveform so it's time to die.
+			deactivate();
+			return 0.0f;
+		}
+		float positionDelta = freq * 2048.0f / SAMPLE_RATE;
+
+		// Linear interpolation
+		float firstSample = getPCMSample(intPCMPosition);
+		// We observe that for partial structures with ring modulation the interpolation is not applied to the slave PCM partial.
+		// It's assumed that the multiplication circuitry intended to perform the interpolation on the slave PCM partial
+		// is borrowed by the ring modulation circuit (or the LA32 chip has a similar lack of resources assigned to each partial pair).
+		if (pcmWaveInterpolated) {
+			sample = firstSample + (getPCMSample(intPCMPosition + 1) - firstSample) * (pcmPosition - intPCMPosition);
+		} else {
+			sample = firstSample;
+		}
+
+		float newPCMPosition = pcmPosition + positionDelta;
+		if (pcmWaveLooped) {
+			newPCMPosition = fmod(newPCMPosition, float(pcmWaveLength));
+		}
+		pcmPosition = newPCMPosition;
+	} else {
+		// Render synthesised waveform
+		wavePos *= lastFreq / freq;
+		lastFreq = freq;
+
+		float resAmp = EXP2F(1.0f - (32 - resonance) / 4.0f);
+		{
+			//static const float resAmpFactor = EXP2F(-7);
+			//resAmp = EXP2I(resonance << 10) * resAmpFactor;
+		}
+
+		// The cutoffModifier may not be supposed to be directly added to the cutoff -
+		// it may for example need to be multiplied in some way.
+		// The 240 cutoffVal limit was determined via sample analysis (internal Munt capture IDs: glop3, glop4).
+		// More research is needed to be sure that this is correct, however.
+		float cutoffVal = cutoffRampVal / 262144.0f;
+		if (cutoffVal > MAX_CUTOFF_VALUE) {
+			cutoffVal = MAX_CUTOFF_VALUE;
+		}
+
+		// Wave length in samples
+		float waveLen = SAMPLE_RATE / freq;
+
+		// Init cosineLen
+		float cosineLen = 0.5f * waveLen;
+		if (cutoffVal > MIDDLE_CUTOFF_VALUE) {
+			cosineLen *= EXP2F((cutoffVal - MIDDLE_CUTOFF_VALUE) / -16.0f); // found from sample analysis
+		}
+
+		// Start playing in center of first cosine segment
+		// relWavePos is shifted by a half of cosineLen
+		float relWavePos = wavePos + 0.5f * cosineLen;
+		if (relWavePos > waveLen) {
+			relWavePos -= waveLen;
+		}
+
+		// Ratio of positive segment to wave length
+		float pulseLen = 0.5f;
+		if (pulseWidth > 128) {
+			pulseLen = EXP2F((64 - pulseWidth) / 64.0f);
+			//static const float pulseLenFactor = EXP2F(-192 / 64);
+			//pulseLen = EXP2I((256 - pulseWidthVal) << 6) * pulseLenFactor;
+		}
+		pulseLen *= waveLen;
+
+		float hLen = pulseLen - cosineLen;
+
+		// Ignore pulsewidths too high for given freq
+		if (hLen < 0.0f) {
+			hLen = 0.0f;
+		}
+
+		// Correct resAmp for cutoff in range 50..66
+		if ((cutoffVal >= MIDDLE_CUTOFF_VALUE) && (cutoffVal < RESONANCE_DECAY_THRESHOLD_CUTOFF_VALUE)) {
+			resAmp *= sin(FLOAT_PI * (cutoffVal - MIDDLE_CUTOFF_VALUE) / 32.0f);
+		}
+
+		// Produce filtered square wave with 2 cosine waves on slopes
+
+		// 1st cosine segment
+		if (relWavePos < cosineLen) {
+			sample = -cos(FLOAT_PI * relWavePos / cosineLen);
+		} else
+
+		// high linear segment
+		if (relWavePos < (cosineLen + hLen)) {
+			sample = 1.f;
+		} else
+
+		// 2nd cosine segment
+		if (relWavePos < (2 * cosineLen + hLen)) {
+			sample = cos(FLOAT_PI * (relWavePos - (cosineLen + hLen)) / cosineLen);
+		} else {
+
+		// low linear segment
+			sample = -1.f;
+		}
+
+		if (cutoffVal < MIDDLE_CUTOFF_VALUE) {
+
+			// Attenuate samples below cutoff 50
+			// Found by sample analysis
+			sample *= EXP2F(-0.125f * (MIDDLE_CUTOFF_VALUE - cutoffVal));
+		} else {
+
+			// Add resonance sine. Effective for cutoff > 50 only
+			float resSample = 1.0f;
+
+			// Resonance decay speed factor
+			float resAmpDecayFactor = resAmpDecayFactors[resonance >> 2];
+
+			// Now relWavePos counts from the middle of first cosine
+			relWavePos = wavePos;
+
+			// negative segments
+			if (!(relWavePos < (cosineLen + hLen))) {
+				resSample = -resSample;
+				relWavePos -= cosineLen + hLen;
+
+				// From the digital captures, the decaying speed of the resonance sine is found a bit different for the positive and the negative segments
+				resAmpDecayFactor += 0.25f;
+			}
+
+			// Resonance sine WG
+			resSample *= sin(FLOAT_PI * relWavePos / cosineLen);
+
+			// Resonance sine amp
+			float resAmpFadeLog2 = -0.125f * resAmpDecayFactor * (relWavePos / cosineLen); // seems to be exact
+			float resAmpFade = EXP2F(resAmpFadeLog2);
+
+			// Now relWavePos set negative to the left from center of any cosine
+			relWavePos = wavePos;
+
+			// negative segment
+			if (!(wavePos < (waveLen - 0.5f * cosineLen))) {
+				relWavePos -= waveLen;
+			} else
+
+			// positive segment
+			if (!(wavePos < (hLen + 0.5f * cosineLen))) {
+				relWavePos -= cosineLen + hLen;
+			}
+
+			// To ensure the output wave has no breaks, two different windows are applied to the beginning and the ending of the resonance sine segment
+			if (relWavePos < 0.5f * cosineLen) {
+				float syncSine = sin(FLOAT_PI * relWavePos / cosineLen);
+				if (relWavePos < 0.0f) {
+					// The window is synchronous square sine here
+					resAmpFade *= syncSine * syncSine;
+				} else {
+					// The window is synchronous sine here
+					resAmpFade *= syncSine;
+				}
+			}
+
+			sample += resSample * resAmp * resAmpFade;
+		}
+
+		// sawtooth waves
+		if (sawtoothWaveform) {
+			sample *= cos(FLOAT_2PI * wavePos / waveLen);
+		}
+
+		wavePos++;
+
+		// wavePos isn't supposed to be > waveLen
+		if (wavePos > waveLen) {
+			wavePos -= waveLen;
+		}
+	}
+
+	// Multiply sample with current TVA value
+	sample *= amp;
+	return sample;
+}
+
+void LA32FloatWaveGenerator::deactivate() {
+	active = false;
+}
+
+bool LA32FloatWaveGenerator::isActive() const {
+	return active;
+}
+
+bool LA32FloatWaveGenerator::isPCMWave() const {
+	return pcmWaveAddress != NULL;
+}
+
+void LA32FloatPartialPair::initTables(const Tables &tables) {
+	resAmpDecayFactors = tables.resAmpDecayFactors;
+}
+
+void LA32FloatPartialPair::init(const bool useRingModulated, const bool useMixed) {
+	ringModulated = useRingModulated;
+	mixed = useMixed;
+	masterOutputSample = 0.0f;
+	slaveOutputSample = 0.0f;
+}
+
+void LA32FloatPartialPair::initSynth(const PairType useMaster, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance) {
+	if (useMaster == MASTER) {
+		master.initSynth(sawtoothWaveform, pulseWidth, resonance);
+	} else {
+		slave.initSynth(sawtoothWaveform, pulseWidth, resonance);
+	}
+}
+
+void LA32FloatPartialPair::initPCM(const PairType useMaster, const Bit16s *pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped) {
+	if (useMaster == MASTER) {
+		master.initPCM(pcmWaveAddress, pcmWaveLength, pcmWaveLooped, true);
+	} else {
+		slave.initPCM(pcmWaveAddress, pcmWaveLength, pcmWaveLooped, !ringModulated);
+	}
+}
+
+void LA32FloatPartialPair::generateNextSample(const PairType useMaster, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff) {
+	if (useMaster == MASTER) {
+		masterOutputSample = master.generateNextSample(amp, pitch, cutoff);
+	} else {
+		slaveOutputSample = slave.generateNextSample(amp, pitch, cutoff);
+	}
+}
+
+static inline float produceDistortedSample(float sample) {
+	if (sample < -1.0f) {
+		return sample + 2.0f;
+	} else if (1.0f < sample) {
+		return sample - 2.0f;
+	}
+	return sample;
+}
+
+float LA32FloatPartialPair::nextOutSample() {
+	// Note, LA32FloatWaveGenerator produces each sample normalised in terms of a single playing partial,
+	// so the unity sample corresponds to the internal LA32 logarithmic fixed-point unity sample.
+	// However, each logarithmic sample is then unlogged to a 14-bit signed integer value, i.e. the max absolute value is 8192.
+	// Thus, considering that samples are further mapped to a 16-bit signed integer,
+	// we apply a conversion factor 0.25 to produce properly normalised float samples.
+	if (!ringModulated) {
+		return 0.25f * (masterOutputSample + slaveOutputSample);
+	}
+	/*
+	 * SEMI-CONFIRMED: Ring modulation model derived from sample analysis of specially constructed patches which exploit distortion.
+	 * LA32 ring modulator found to produce distorted output in case if the absolute value of maximal amplitude of one of the input partials exceeds 8191.
+	 * This is easy to reproduce using synth partials with resonance values close to the maximum. It looks like an integer overflow happens in this case.
+	 * As the distortion is strictly bound to the amplitude of the complete mixed square + resonance wave in the linear space,
+	 * it is reasonable to assume the ring modulation is performed also in the linear space by sample multiplication.
+	 * Most probably the overflow is caused by limited precision of the multiplication circuit as the very similar distortion occurs with panning.
+	 */
+	float ringModulatedSample = produceDistortedSample(masterOutputSample) * produceDistortedSample(slaveOutputSample);
+	return 0.25f * (mixed ? masterOutputSample + ringModulatedSample : ringModulatedSample);
+}
+
+void LA32FloatPartialPair::deactivate(const PairType useMaster) {
+	if (useMaster == MASTER) {
+		master.deactivate();
+		masterOutputSample = 0.0f;
+	} else {
+		slave.deactivate();
+		slaveOutputSample = 0.0f;
+	}
+}
+
+bool LA32FloatPartialPair::isActive(const PairType useMaster) const {
+	return useMaster == MASTER ? master.isActive() : slave.isActive();
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/LA32FloatWaveGenerator.h
+++ b/vendor/munt/src/LA32FloatWaveGenerator.h
@@ -1,0 +1,134 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_LA32_FLOAT_WAVE_GENERATOR_H
+#define MT32EMU_LA32_FLOAT_WAVE_GENERATOR_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Types.h"
+#include "LA32WaveGenerator.h"
+
+namespace MT32Emu {
+
+/**
+ * LA32WaveGenerator is aimed to represent the exact model of LA32 wave generator.
+ * The output square wave is created by adding high / low linear segments in-between
+ * the rising and falling cosine segments. Basically, it's very similar to the phase distortion synthesis.
+ * Behaviour of a true resonance filter is emulated by adding decaying sine wave.
+ * The beginning and the ending of the resonant sine is multiplied by a cosine window.
+ * To synthesise sawtooth waves, the resulting square wave is multiplied by synchronous cosine wave.
+ */
+class LA32FloatWaveGenerator {
+	//***************************************************************************
+	//  The local copy of partial parameters below
+	//***************************************************************************
+
+	bool active;
+
+	// True means the resulting square wave is to be multiplied by the synchronous cosine
+	bool sawtoothWaveform;
+
+	// Values in range [1..31]
+	// Value 1 corresponds to the minimum resonance
+	Bit8u resonance;
+
+	// Processed value in range [0..255]
+	// Values in range [0..128] have no effect and the resulting wave remains symmetrical
+	// Value 255 corresponds to the maximum possible asymmetric of the resulting wave
+	Bit8u pulseWidth;
+
+	// Logarithmic PCM sample start address
+	const Bit16s *pcmWaveAddress;
+
+	// Logarithmic PCM sample length
+	Bit32u pcmWaveLength;
+
+	// true for looped logarithmic PCM samples
+	bool pcmWaveLooped;
+
+	// false for slave PCM partials in the structures with the ring modulation
+	bool pcmWaveInterpolated;
+
+	//***************************************************************************
+	// Internal variables below
+	//***************************************************************************
+
+	float wavePos;
+	float lastFreq;
+	float pcmPosition;
+
+	float getPCMSample(unsigned int position);
+
+public:
+	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
+	void initSynth(const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+
+	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
+	void initPCM(const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped, const bool pcmWaveInterpolated);
+
+	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
+	float generateNextSample(const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
+
+	// Deactivate the WG engine
+	void deactivate();
+
+	// Return active state of the WG engine
+	bool isActive() const;
+
+	// Return true if the WG engine generates PCM wave samples
+	bool isPCMWave() const;
+}; // class LA32FloatWaveGenerator
+
+class LA32FloatPartialPair : public LA32PartialPair {
+	LA32FloatWaveGenerator master;
+	LA32FloatWaveGenerator slave;
+	bool ringModulated;
+	bool mixed;
+	float masterOutputSample;
+	float slaveOutputSample;
+
+public:
+	static void initTables(const Tables &tables);
+
+	// ringModulated should be set to false for the structures with mixing or stereo output
+	// ringModulated should be set to true for the structures with ring modulation
+	// mixed is used for the structures with ring modulation and indicates whether the master partial output is mixed to the ring modulator output
+	void init(const bool ringModulated, const bool mixed);
+
+	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
+	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+
+	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
+	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped);
+
+	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
+	void generateNextSample(const PairType master, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
+
+	// Perform mixing / ring modulation and return the result
+	float nextOutSample();
+
+	// Deactivate the WG engine
+	void deactivate(const PairType master);
+
+	// Return active state of the WG engine
+	bool isActive(const PairType master) const;
+}; // class LA32FloatPartialPair
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_LA32_FLOAT_WAVE_GENERATOR_H

--- a/vendor/munt/src/LA32Ramp.cpp
+++ b/vendor/munt/src/LA32Ramp.cpp
@@ -1,0 +1,170 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+Some notes on this class:
+
+This emulates the LA-32's implementation of "ramps". A ramp in this context is a smooth transition from one value to another, handled entirely within the LA-32.
+The LA-32 provides this feature for amplitude and filter cutoff values.
+
+The 8095 starts ramps on the LA-32 by setting two values in memory-mapped registers:
+
+(1) The target value (between 0 and 255) for the ramp to end on. This is represented by the "target" argument to startRamp().
+(2) The speed at which that value should be approached. This is represented by the "increment" argument to startRamp().
+
+Once the ramp target value has been hit, the LA-32 raises an interrupt.
+
+Note that the starting point of the ramp is whatever internal value the LA-32 had when the registers were set. This is usually the end point of a previously completed ramp.
+
+Our handling of the "target" and "increment" values is based on sample analysis and a little guesswork.
+Here's what we're pretty confident about:
+ - The most significant bit of "increment" indicates the direction that the LA32's current internal value ("current" in our emulation) should change in.
+   Set means downward, clear means upward.
+ - The lower 7 bits of "increment" indicate how quickly "current" should be changed.
+ - If "increment" is 0, no change to "current" is made and no interrupt is raised. [SEMI-CONFIRMED by sample analysis]
+ - Otherwise, if the MSb is set:
+    - If "current" already corresponds to a value <= "target", "current" is set immediately to the equivalent of "target" and an interrupt is raised.
+    - Otherwise, "current" is gradually reduced (at a rate determined by the lower 7 bits of "increment"), and once it reaches the equivalent of "target" an interrupt is raised.
+ - Otherwise (the MSb is unset):
+    - If "current" already corresponds to a value >= "target", "current" is set immediately to the equivalent of "target" and an interrupt is raised.
+    - Otherwise, "current" is gradually increased (at a rate determined by the lower 7 bits of "increment"), and once it reaches the equivalent of "target" an interrupt is raised.
+
+We haven't fully explored:
+ - Values when ramping between levels (though this is probably correct).
+ - Transition timing (may not be 100% accurate, especially for very fast ramps).
+*/
+
+#include "internals.h"
+
+#include "LA32Ramp.h"
+#include "Tables.h"
+
+namespace MT32Emu {
+
+// SEMI-CONFIRMED from sample analysis.
+const unsigned int TARGET_SHIFTS = 18;
+const unsigned int MAX_CURRENT = 0xFF << TARGET_SHIFTS;
+
+// We simulate the delay in handling "target was reached" interrupts by waiting
+// this many samples before setting interruptRaised.
+// FIXME: This should vary with the sample rate, but doesn't.
+// SEMI-CONFIRMED: Since this involves asynchronous activity between the LA32
+// and the 8095, a good value is hard to pin down.
+// This one matches observed behaviour on a few digital captures I had handy,
+// and should be double-checked. We may also need a more sophisticated delay
+// scheme eventually.
+const int INTERRUPT_TIME = 7;
+
+static const Bit16u *exp9;
+
+void LA32Ramp::initTables(const Tables &tables) {
+	exp9 = tables.exp9;
+}
+
+LA32Ramp::LA32Ramp() :
+	current(0),
+	largeTarget(0),
+	largeIncrement(0),
+	interruptCountdown(0),
+	interruptRaised(false) {
+}
+
+void LA32Ramp::startRamp(Bit8u target, Bit8u increment) {
+	// CONFIRMED: From sample analysis, this appears to be very accurate.
+	if (increment == 0) {
+		largeIncrement = 0;
+	} else {
+		// Three bits in the fractional part, no need to interpolate
+		// (unsigned int)(EXP2F(((increment & 0x7F) + 24) / 8.0f) + 0.125f)
+		Bit32u expArg = increment & 0x7F;
+		largeIncrement = 8191 - exp9[~(expArg << 6) & 511];
+		largeIncrement <<= expArg >> 3;
+		largeIncrement += 64;
+		largeIncrement >>= 9;
+	}
+	descending = (increment & 0x80) != 0;
+	if (descending) {
+		// CONFIRMED: From sample analysis, descending increments are slightly faster
+		largeIncrement++;
+	}
+
+	largeTarget = target << TARGET_SHIFTS;
+	interruptCountdown = 0;
+	interruptRaised = false;
+}
+
+Bit32u LA32Ramp::nextValue() {
+	if (interruptCountdown > 0) {
+		if (--interruptCountdown == 0) {
+			interruptRaised = true;
+		}
+	} else if (largeIncrement != 0) {
+		// CONFIRMED from sample analysis: When increment is 0, the LA32 does *not* change the current value at all (and of course doesn't fire an interrupt).
+		if (descending) {
+			// Lowering current value
+			if (largeIncrement > current) {
+				current = largeTarget;
+				interruptCountdown = INTERRUPT_TIME;
+			} else {
+				current -= largeIncrement;
+				if (current <= largeTarget) {
+					current = largeTarget;
+					interruptCountdown = INTERRUPT_TIME;
+				}
+			}
+		} else {
+			// Raising current value
+			if (MAX_CURRENT - current < largeIncrement) {
+				current = largeTarget;
+				interruptCountdown = INTERRUPT_TIME;
+			} else {
+				current += largeIncrement;
+				if (current >= largeTarget) {
+					current = largeTarget;
+					interruptCountdown = INTERRUPT_TIME;
+				}
+			}
+		}
+	}
+	return current;
+}
+
+bool LA32Ramp::checkInterrupt() {
+	bool wasRaised = interruptRaised;
+	interruptRaised = false;
+	return wasRaised;
+}
+
+void LA32Ramp::reset() {
+	current = 0;
+	largeTarget = 0;
+	largeIncrement = 0;
+	descending = false;
+	interruptCountdown = 0;
+	interruptRaised = false;
+}
+
+// This is actually beyond the LA32 ramp interface.
+// Instead of polling the current value, MCU receives an interrupt when a ramp completes.
+// However, this is a simple way to work around the specific behaviour of TVA
+// when in sustain phase which one normally wants to avoid.
+// See TVA::recalcSustain() for details.
+bool LA32Ramp::isBelowCurrent(Bit8u target) const {
+	return Bit32u(target << TARGET_SHIFTS) < current;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/LA32Ramp.h
+++ b/vendor/munt/src/LA32Ramp.h
@@ -1,0 +1,51 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_LA32RAMP_H
+#define MT32EMU_LA32RAMP_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+struct Tables;
+
+class LA32Ramp {
+private:
+	Bit32u current;
+	unsigned int largeTarget;
+	unsigned int largeIncrement;
+	bool descending;
+
+	int interruptCountdown;
+	bool interruptRaised;
+
+public:
+	static void initTables(const Tables &tables);
+
+	LA32Ramp();
+	void startRamp(Bit8u target, Bit8u increment);
+	Bit32u nextValue();
+	bool checkInterrupt();
+	void reset();
+	bool isBelowCurrent(Bit8u target) const;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_LA32RAMP_H

--- a/vendor/munt/src/LA32WaveGenerator.cpp
+++ b/vendor/munt/src/LA32WaveGenerator.cpp
@@ -1,0 +1,439 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "internals.h"
+
+#include "LA32WaveGenerator.h"
+#include "Tables.h"
+
+namespace MT32Emu {
+
+static const Bit32u SINE_SEGMENT_RELATIVE_LENGTH = 1 << 18;
+static const Bit32u MIDDLE_CUTOFF_VALUE = 128 << 18;
+static const Bit32u RESONANCE_DECAY_THRESHOLD_CUTOFF_VALUE = 144 << 18;
+static const Bit32u MAX_CUTOFF_VALUE = 240 << 18;
+static const LogSample SILENCE = {65535, LogSample::POSITIVE};
+
+// These two tables are accessed extremely often. Keeping the direct pointers here significantly improves performance in most cases.
+static const Bit16u *exp9;
+static const Bit16u *logsin9;
+// This is accessed less often, but it's still on the critical path.
+static const Bit8u *resAmpDecayFactors;
+
+namespace LA32Utilites {
+
+static inline Bit16u interpolateExp(const Bit16u fract) {
+	Bit16u expTabIndex = fract >> 3;
+	Bit16u extraBits = ~fract & 7;
+	Bit16u expTabEntry2 = 8191 - exp9[expTabIndex];
+	Bit16u expTabEntry1 = expTabIndex == 0 ? 8191 : (8191 - exp9[expTabIndex - 1]);
+	return expTabEntry2 + (((expTabEntry1 - expTabEntry2) * extraBits) >> 3);
+}
+
+static inline Bit16s unlog(const LogSample &logSample) {
+	//Bit16s sample = (Bit16s)EXP2F(13.0f - logSample.logValue / 4096.0f);
+	Bit32u intLogValue = logSample.logValue >> 12;
+	Bit16u fracLogValue = logSample.logValue & 4095;
+	Bit16s sample = interpolateExp(fracLogValue) >> intLogValue;
+	return logSample.sign == LogSample::POSITIVE ? sample : -sample;
+}
+
+static inline void addLogSamples(LogSample &logSample1, const LogSample &logSample2) {
+	Bit32u logSampleValue = logSample1.logValue + logSample2.logValue;
+	logSample1.logValue = logSampleValue < 65536 ? Bit16u(logSampleValue) : 65535;
+	logSample1.sign = logSample1.sign == logSample2.sign ? LogSample::POSITIVE : LogSample::NEGATIVE;
+}
+
+} // namespace LA32Utilites
+
+Bit32u LA32WaveGenerator::getSampleStep() {
+	// sampleStep = EXP2F(pitch / 4096.0f + 4.0f)
+	Bit32u sampleStep = LA32Utilites::interpolateExp(~pitch & 4095);
+	sampleStep <<= pitch >> 12;
+	sampleStep >>= 8;
+	sampleStep &= ~1;
+	return sampleStep;
+}
+
+Bit32u LA32WaveGenerator::getResonanceWaveLengthFactor(Bit32u effectiveCutoffValue) {
+	// resonanceWaveLengthFactor = (Bit32u)EXP2F(12.0f + effectiveCutoffValue / 4096.0f);
+	Bit32u resonanceWaveLengthFactor = LA32Utilites::interpolateExp(~effectiveCutoffValue & 4095);
+	resonanceWaveLengthFactor <<= effectiveCutoffValue >> 12;
+	return resonanceWaveLengthFactor;
+}
+
+Bit32u LA32WaveGenerator::getHighLinearLength(Bit32u effectiveCutoffValue) {
+	// Ratio of positive segment to wave length
+	Bit32u effectivePulseWidthValue = 0;
+	if (pulseWidth > 128) {
+		effectivePulseWidthValue = (pulseWidth - 128) << 6;
+	}
+
+	Bit32u highLinearLength = 0;
+	// highLinearLength = EXP2F(19.0f - effectivePulseWidthValue / 4096.0f + effectiveCutoffValue / 4096.0f) - 2 * SINE_SEGMENT_RELATIVE_LENGTH;
+	if (effectivePulseWidthValue < effectiveCutoffValue) {
+		Bit32u expArg = effectiveCutoffValue - effectivePulseWidthValue;
+		highLinearLength = LA32Utilites::interpolateExp(~expArg & 4095);
+		highLinearLength <<= 7 + (expArg >> 12);
+		highLinearLength -= 2 * SINE_SEGMENT_RELATIVE_LENGTH;
+	}
+	return highLinearLength;
+}
+
+void LA32WaveGenerator::computePositions(Bit32u highLinearLength, Bit32u lowLinearLength, Bit32u resonanceWaveLengthFactor) {
+	// Assuming 12-bit multiplication used here
+	squareWavePosition = resonanceSinePosition = (wavePosition >> 8) * (resonanceWaveLengthFactor >> 4);
+	if (squareWavePosition < SINE_SEGMENT_RELATIVE_LENGTH) {
+		phase = POSITIVE_RISING_SINE_SEGMENT;
+		return;
+	}
+	squareWavePosition -= SINE_SEGMENT_RELATIVE_LENGTH;
+	if (squareWavePosition < highLinearLength) {
+		phase = POSITIVE_LINEAR_SEGMENT;
+		return;
+	}
+	squareWavePosition -= highLinearLength;
+	if (squareWavePosition < SINE_SEGMENT_RELATIVE_LENGTH) {
+		phase = POSITIVE_FALLING_SINE_SEGMENT;
+		return;
+	}
+	squareWavePosition -= SINE_SEGMENT_RELATIVE_LENGTH;
+	resonanceSinePosition = squareWavePosition;
+	if (squareWavePosition < SINE_SEGMENT_RELATIVE_LENGTH) {
+		phase = NEGATIVE_FALLING_SINE_SEGMENT;
+		return;
+	}
+	squareWavePosition -= SINE_SEGMENT_RELATIVE_LENGTH;
+	if (squareWavePosition < lowLinearLength) {
+		phase = NEGATIVE_LINEAR_SEGMENT;
+		return;
+	}
+	squareWavePosition -= lowLinearLength;
+	phase = NEGATIVE_RISING_SINE_SEGMENT;
+}
+
+void LA32WaveGenerator::advancePosition() {
+	wavePosition += getSampleStep();
+	wavePosition %= 4 * SINE_SEGMENT_RELATIVE_LENGTH;
+
+	Bit32u effectiveCutoffValue = (cutoffVal > MIDDLE_CUTOFF_VALUE) ? (cutoffVal - MIDDLE_CUTOFF_VALUE) >> 10 : 0;
+	Bit32u resonanceWaveLengthFactor = getResonanceWaveLengthFactor(effectiveCutoffValue);
+	Bit32u highLinearLength = getHighLinearLength(effectiveCutoffValue);
+	Bit32u lowLinearLength = (resonanceWaveLengthFactor << 8) - 4 * SINE_SEGMENT_RELATIVE_LENGTH - highLinearLength;
+	computePositions(highLinearLength, lowLinearLength, resonanceWaveLengthFactor);
+
+	resonancePhase = ResonancePhase(((resonanceSinePosition >> 18) + (phase > POSITIVE_FALLING_SINE_SEGMENT ? 2 : 0)) & 3);
+}
+
+void LA32WaveGenerator::generateNextSquareWaveLogSample() {
+	Bit32u logSampleValue;
+	switch (phase) {
+		case POSITIVE_RISING_SINE_SEGMENT:
+		case NEGATIVE_FALLING_SINE_SEGMENT:
+			logSampleValue = logsin9[(squareWavePosition >> 9) & 511];
+			break;
+		case POSITIVE_FALLING_SINE_SEGMENT:
+		case NEGATIVE_RISING_SINE_SEGMENT:
+			logSampleValue = logsin9[~(squareWavePosition >> 9) & 511];
+			break;
+		case POSITIVE_LINEAR_SEGMENT:
+		case NEGATIVE_LINEAR_SEGMENT:
+		default:
+			logSampleValue = 0;
+			break;
+	}
+	logSampleValue <<= 2;
+	logSampleValue += amp >> 10;
+	if (cutoffVal < MIDDLE_CUTOFF_VALUE) {
+		logSampleValue += (MIDDLE_CUTOFF_VALUE - cutoffVal) >> 9;
+	}
+
+	squareLogSample.logValue = logSampleValue < 65536 ? Bit16u(logSampleValue) : 65535;
+	squareLogSample.sign = phase < NEGATIVE_FALLING_SINE_SEGMENT ? LogSample::POSITIVE : LogSample::NEGATIVE;
+}
+
+void LA32WaveGenerator::generateNextResonanceWaveLogSample() {
+	Bit32u logSampleValue;
+	if (resonancePhase == POSITIVE_FALLING_RESONANCE_SINE_SEGMENT || resonancePhase == NEGATIVE_RISING_RESONANCE_SINE_SEGMENT) {
+		logSampleValue = logsin9[~(resonanceSinePosition >> 9) & 511];
+	} else {
+		logSampleValue = logsin9[(resonanceSinePosition >> 9) & 511];
+	}
+	logSampleValue <<= 2;
+	logSampleValue += amp >> 10;
+
+	// From the digital captures, the decaying speed of the resonance sine is found a bit different for the positive and the negative segments
+	Bit32u decayFactor = phase < NEGATIVE_FALLING_SINE_SEGMENT ? resAmpDecayFactor : resAmpDecayFactor + 1;
+	// Unsure about resonanceSinePosition here. It's possible that dedicated counter & decrement are used. Although, cutoff is finely ramped, so maybe not.
+	logSampleValue += resonanceAmpSubtraction + (((resonanceSinePosition >> 4) * decayFactor) >> 8);
+
+	// To ensure the output wave has no breaks, two different windows are applied to the beginning and the ending of the resonance sine segment
+	if (phase == POSITIVE_RISING_SINE_SEGMENT || phase == NEGATIVE_FALLING_SINE_SEGMENT) {
+		// The window is synchronous sine here
+		logSampleValue += logsin9[(squareWavePosition >> 9) & 511] << 2;
+	} else if (phase == POSITIVE_FALLING_SINE_SEGMENT || phase == NEGATIVE_RISING_SINE_SEGMENT) {
+		// The window is synchronous square sine here
+		logSampleValue += logsin9[~(squareWavePosition >> 9) & 511] << 3;
+	}
+
+	if (cutoffVal < MIDDLE_CUTOFF_VALUE) {
+		// For the cutoff values below the cutoff middle point, it seems the amp of the resonance wave is exponentially decayed
+		logSampleValue += 31743 + ((MIDDLE_CUTOFF_VALUE - cutoffVal) >> 9);
+	} else if (cutoffVal < RESONANCE_DECAY_THRESHOLD_CUTOFF_VALUE) {
+		// For the cutoff values below this point, the amp of the resonance wave is sinusoidally decayed
+		Bit32u sineIx = (cutoffVal - MIDDLE_CUTOFF_VALUE) >> 13;
+		logSampleValue += logsin9[sineIx] << 2;
+	}
+
+	// After all the amp decrements are added, it should be safe now to adjust the amp of the resonance wave to what we see on captures
+	logSampleValue -= 1 << 12;
+
+	resonanceLogSample.logValue = logSampleValue < 65536 ? Bit16u(logSampleValue) : 65535;
+	resonanceLogSample.sign = resonancePhase < NEGATIVE_FALLING_RESONANCE_SINE_SEGMENT ? LogSample::POSITIVE : LogSample::NEGATIVE;
+}
+
+void LA32WaveGenerator::generateNextSawtoothCosineLogSample(LogSample &logSample) const {
+	Bit32u sawtoothCosinePosition = wavePosition + (1 << 18);
+	if ((sawtoothCosinePosition & (1 << 18)) > 0) {
+		logSample.logValue = logsin9[~(sawtoothCosinePosition >> 9) & 511];
+	} else {
+		logSample.logValue = logsin9[(sawtoothCosinePosition >> 9) & 511];
+	}
+	logSample.logValue <<= 2;
+	logSample.sign = ((sawtoothCosinePosition & (1 << 19)) == 0) ? LogSample::POSITIVE : LogSample::NEGATIVE;
+}
+
+void LA32WaveGenerator::pcmSampleToLogSample(LogSample &logSample, const Bit16s pcmSample) const {
+	Bit32u logSampleValue = (32787 - (pcmSample & 32767)) << 1;
+	logSampleValue += amp >> 10;
+	logSample.logValue = logSampleValue < 65536 ? Bit16u(logSampleValue) : 65535;
+	logSample.sign = pcmSample < 0 ? LogSample::NEGATIVE : LogSample::POSITIVE;
+}
+
+void LA32WaveGenerator::generateNextPCMWaveLogSamples() {
+	// This should emulate the ladder we see in the PCM captures for pitches 01, 02, 07, etc.
+	// The most probable cause is the factor in the interpolation formula is one bit less
+	// accurate than the sample position counter
+	pcmInterpolationFactor = (wavePosition & 255) >> 1;
+	Bit32u pcmWaveTableIx = wavePosition >> 8;
+	pcmSampleToLogSample(firstPCMLogSample, pcmWaveAddress[pcmWaveTableIx]);
+	if (pcmWaveInterpolated) {
+		pcmWaveTableIx++;
+		if (pcmWaveTableIx < pcmWaveLength) {
+			pcmSampleToLogSample(secondPCMLogSample, pcmWaveAddress[pcmWaveTableIx]);
+		} else {
+			if (pcmWaveLooped) {
+				pcmWaveTableIx -= pcmWaveLength;
+				pcmSampleToLogSample(secondPCMLogSample, pcmWaveAddress[pcmWaveTableIx]);
+			} else {
+				secondPCMLogSample = SILENCE;
+			}
+		}
+	} else {
+		secondPCMLogSample = SILENCE;
+	}
+	// pcmSampleStep = (Bit32u)EXP2F(pitch / 4096.0f + 3.0f);
+	Bit32u pcmSampleStep = LA32Utilites::interpolateExp(~pitch & 4095);
+	pcmSampleStep <<= pitch >> 12;
+	// Seeing the actual lengths of the PCM wave for pitches 00..12,
+	// the pcmPosition counter can be assumed to have 8-bit fractions
+	pcmSampleStep >>= 9;
+	wavePosition += pcmSampleStep;
+	if (wavePosition >= (pcmWaveLength << 8)) {
+		if (pcmWaveLooped) {
+			wavePosition -= pcmWaveLength << 8;
+		} else {
+			deactivate();
+		}
+	}
+}
+
+void LA32WaveGenerator::initSynth(const bool useSawtoothWaveform, const Bit8u usePulseWidth, const Bit8u useResonance) {
+	sawtoothWaveform = useSawtoothWaveform;
+	pulseWidth = usePulseWidth;
+	resonance = useResonance;
+
+	wavePosition = 0;
+
+	squareWavePosition = 0;
+	phase = POSITIVE_RISING_SINE_SEGMENT;
+
+	resonanceSinePosition = 0;
+	resonancePhase = POSITIVE_RISING_RESONANCE_SINE_SEGMENT;
+	resonanceAmpSubtraction = (32 - resonance) << 10;
+	resAmpDecayFactor = resAmpDecayFactors[resonance >> 2] << 2;
+
+	pcmWaveAddress = NULL;
+	active = true;
+}
+
+void LA32WaveGenerator::initPCM(const Bit16s * const usePCMWaveAddress, const Bit32u usePCMWaveLength, const bool usePCMWaveLooped, const bool usePCMWaveInterpolated) {
+	pcmWaveAddress = usePCMWaveAddress;
+	pcmWaveLength = usePCMWaveLength;
+	pcmWaveLooped = usePCMWaveLooped;
+	pcmWaveInterpolated = usePCMWaveInterpolated;
+
+	wavePosition = 0;
+	active = true;
+}
+
+void LA32WaveGenerator::generateNextSample(const Bit32u useAmp, const Bit16u usePitch, const Bit32u useCutoffVal) {
+	if (!active) {
+		return;
+	}
+
+	amp = useAmp;
+	pitch = usePitch;
+
+	if (isPCMWave()) {
+		generateNextPCMWaveLogSamples();
+		return;
+	}
+
+	// The 240 cutoffVal limit was determined via sample analysis (internal Munt capture IDs: glop3, glop4).
+	// More research is needed to be sure that this is correct, however.
+	cutoffVal = (useCutoffVal > MAX_CUTOFF_VALUE) ? MAX_CUTOFF_VALUE : useCutoffVal;
+
+	generateNextSquareWaveLogSample();
+	generateNextResonanceWaveLogSample();
+	if (sawtoothWaveform) {
+		LogSample cosineLogSample;
+		generateNextSawtoothCosineLogSample(cosineLogSample);
+		LA32Utilites::addLogSamples(squareLogSample, cosineLogSample);
+		LA32Utilites::addLogSamples(resonanceLogSample, cosineLogSample);
+	}
+	advancePosition();
+}
+
+LogSample LA32WaveGenerator::getOutputLogSample(const bool first) const {
+	if (!isActive()) {
+		return SILENCE;
+	}
+	if (isPCMWave()) {
+		return first ? firstPCMLogSample : secondPCMLogSample;
+	}
+	return first ? squareLogSample : resonanceLogSample;
+}
+
+void LA32WaveGenerator::deactivate() {
+	active = false;
+}
+
+bool LA32WaveGenerator::isActive() const {
+	return active;
+}
+
+bool LA32WaveGenerator::isPCMWave() const {
+	return pcmWaveAddress != NULL;
+}
+
+Bit32u LA32WaveGenerator::getPCMInterpolationFactor() const {
+	return pcmInterpolationFactor;
+}
+
+void LA32IntPartialPair::initTables(const Tables &tables) {
+	exp9 = tables.exp9;
+	logsin9 = tables.logsin9;
+	resAmpDecayFactors = tables.resAmpDecayFactors;
+}
+
+void LA32IntPartialPair::init(const bool useRingModulated, const bool useMixed) {
+	ringModulated = useRingModulated;
+	mixed = useMixed;
+}
+
+void LA32IntPartialPair::initSynth(const PairType useMaster, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance) {
+	if (useMaster == MASTER) {
+		master.initSynth(sawtoothWaveform, pulseWidth, resonance);
+	} else {
+		slave.initSynth(sawtoothWaveform, pulseWidth, resonance);
+	}
+}
+
+void LA32IntPartialPair::initPCM(const PairType useMaster, const Bit16s *pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped) {
+	if (useMaster == MASTER) {
+		master.initPCM(pcmWaveAddress, pcmWaveLength, pcmWaveLooped, true);
+	} else {
+		slave.initPCM(pcmWaveAddress, pcmWaveLength, pcmWaveLooped, !ringModulated);
+	}
+}
+
+void LA32IntPartialPair::generateNextSample(const PairType useMaster, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff) {
+	if (useMaster == MASTER) {
+		master.generateNextSample(amp, pitch, cutoff);
+	} else {
+		slave.generateNextSample(amp, pitch, cutoff);
+	}
+}
+
+Bit16s LA32IntPartialPair::unlogAndMixWGOutput(const LA32WaveGenerator &wg) {
+	if (!wg.isActive()) {
+		return 0;
+	}
+	Bit16s firstSample = LA32Utilites::unlog(wg.getOutputLogSample(true));
+	Bit16s secondSample = LA32Utilites::unlog(wg.getOutputLogSample(false));
+	if (wg.isPCMWave()) {
+		return Bit16s(firstSample + (((Bit32s(secondSample) - Bit32s(firstSample)) * wg.getPCMInterpolationFactor()) >> 7));
+	}
+	return firstSample + secondSample;
+}
+
+static inline Bit16s produceDistortedSample(Bit16s sample) {
+	return ((sample & 0x2000) == 0) ? Bit16s(sample & 0x1fff) : Bit16s(sample | ~0x1fff);
+}
+
+Bit16s LA32IntPartialPair::nextOutSample() {
+	if (!ringModulated) {
+		return unlogAndMixWGOutput(master) + unlogAndMixWGOutput(slave);
+	}
+
+	Bit16s masterSample = unlogAndMixWGOutput(master); // Store master partial sample for further mixing
+
+	/* SEMI-CONFIRMED from sample analysis:
+	 * We observe that for partial structures with ring modulation the interpolation is not applied to the slave PCM partial.
+	 * It's assumed that the multiplication circuitry intended to perform the interpolation on the slave PCM partial
+	 * is borrowed by the ring modulation circuit (or the LA32 chip has a similar lack of resources assigned to each partial pair).
+	 */
+	Bit16s slaveSample = slave.isPCMWave() ? LA32Utilites::unlog(slave.getOutputLogSample(true)) : unlogAndMixWGOutput(slave);
+
+	/* SEMI-CONFIRMED: Ring modulation model derived from sample analysis of specially constructed patches which exploit distortion.
+	 * LA32 ring modulator found to produce distorted output in case if the absolute value of maximal amplitude of one of the input partials exceeds 8191.
+	 * This is easy to reproduce using synth partials with resonance values close to the maximum. It looks like an integer overflow happens in this case.
+	 * As the distortion is strictly bound to the amplitude of the complete mixed square + resonance wave in the linear space,
+	 * it is reasonable to assume the ring modulation is performed also in the linear space by sample multiplication.
+	 * Most probably the overflow is caused by limited precision of the multiplication circuit as the very similar distortion occurs with panning.
+	 */
+	Bit16s ringModulatedSample = Bit16s((Bit32s(produceDistortedSample(masterSample)) * Bit32s(produceDistortedSample(slaveSample))) >> 13);
+
+	return mixed ? masterSample + ringModulatedSample : ringModulatedSample;
+}
+
+void LA32IntPartialPair::deactivate(const PairType useMaster) {
+	if (useMaster == MASTER) {
+		master.deactivate();
+	} else {
+		slave.deactivate();
+	}
+}
+
+bool LA32IntPartialPair::isActive(const PairType useMaster) const {
+	return useMaster == MASTER ? master.isActive() : slave.isActive();
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/LA32WaveGenerator.h
+++ b/vendor/munt/src/LA32WaveGenerator.h
@@ -1,0 +1,263 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_LA32_WAVE_GENERATOR_H
+#define MT32EMU_LA32_WAVE_GENERATOR_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+struct Tables;
+
+/**
+ * LA32 performs wave generation in the log-space that allows replacing multiplications by cheap additions
+ * It's assumed that only low-bit multiplications occur in a few places which are unavoidable like these:
+ * - interpolation of exponent table (obvious, a delta value has 4 bits)
+ * - computation of resonance amp decay envelope (the table contains values with 1-2 "1" bits except the very first value 31 but this case can be found using inversion)
+ * - interpolation of PCM samples (obvious, the wave position counter is in the linear space, there is no log() table in the chip)
+ * and it seems to be implemented in the same way as in the Boss chip, i.e. right shifted additions which involved noticeable precision loss
+ * Subtraction is supposed to be replaced by simple inversion
+ * As the logarithmic sine is always negative, all the logarithmic values are treated as decrements
+ */
+struct LogSample {
+	// 16-bit fixed point value, includes 12-bit fractional part
+	// 4-bit integer part allows to present any 16-bit sample in the log-space
+	// Obviously, the log value doesn't contain the sign of the resulting sample
+	Bit16u logValue;
+	enum {
+		POSITIVE,
+		NEGATIVE
+	} sign;
+};
+
+/**
+ * LA32WaveGenerator is aimed to represent the exact model of LA32 wave generator.
+ * The output square wave is created by adding high / low linear segments in-between
+ * the rising and falling cosine segments. Basically, it's very similar to the phase distortion synthesis.
+ * Behaviour of a true resonance filter is emulated by adding decaying sine wave.
+ * The beginning and the ending of the resonant sine is multiplied by a cosine window.
+ * To synthesise sawtooth waves, the resulting square wave is multiplied by synchronous cosine wave.
+ */
+class LA32WaveGenerator {
+	//***************************************************************************
+	//  The local copy of partial parameters below
+	//***************************************************************************
+
+	bool active;
+
+	// True means the resulting square wave is to be multiplied by the synchronous cosine
+	bool sawtoothWaveform;
+
+	// Logarithmic amp of the wave generator
+	Bit32u amp;
+
+	// Logarithmic frequency of the resulting wave
+	Bit16u pitch;
+
+	// Values in range [1..31]
+	// Value 1 corresponds to the minimum resonance
+	Bit8u resonance;
+
+	// Processed value in range [0..255]
+	// Values in range [0..128] have no effect and the resulting wave remains symmetrical
+	// Value 255 corresponds to the maximum possible asymmetric of the resulting wave
+	Bit8u pulseWidth;
+
+	// Composed of the base cutoff in range [78..178] left-shifted by 18 bits and the TVF modifier
+	Bit32u cutoffVal;
+
+	// Logarithmic PCM sample start address
+	const Bit16s *pcmWaveAddress;
+
+	// Logarithmic PCM sample length
+	Bit32u pcmWaveLength;
+
+	// true for looped logarithmic PCM samples
+	bool pcmWaveLooped;
+
+	// false for slave PCM partials in the structures with the ring modulation
+	bool pcmWaveInterpolated;
+
+	//***************************************************************************
+	// Internal variables below
+	//***************************************************************************
+
+	// Relative position within either the synth wave or the PCM sampled wave
+	// 0 - start of the positive rising sine segment of the square wave or start of the PCM sample
+	// 1048576 (2^20) - end of the negative rising sine segment of the square wave
+	// For PCM waves, the address of the currently playing sample equals (wavePosition / 256)
+	Bit32u wavePosition;
+
+	// Relative position within a square wave phase:
+	// 0             - start of the phase
+	// 262144 (2^18) - end of a sine phase in the square wave
+	Bit32u squareWavePosition;
+
+	// Relative position within the positive or negative wave segment:
+	// 0 - start of the corresponding positive or negative segment of the square wave
+	// 262144 (2^18) - corresponds to end of the first sine phase in the square wave
+	// The same increment sampleStep is used to indicate the current position
+	// since the length of the resonance wave is always equal to four square wave sine segments.
+	Bit32u resonanceSinePosition;
+
+	// The amp of the resonance sine wave grows with the resonance value
+	// As the resonance value cannot change while the partial is active, it is initialised once
+	Bit32u resonanceAmpSubtraction;
+
+	// The decay speed of resonance sine wave, depends on the resonance value
+	Bit32u resAmpDecayFactor;
+
+	// Fractional part of the pcmPosition
+	Bit32u pcmInterpolationFactor;
+
+	// Current phase of the square wave
+	enum {
+		POSITIVE_RISING_SINE_SEGMENT,
+		POSITIVE_LINEAR_SEGMENT,
+		POSITIVE_FALLING_SINE_SEGMENT,
+		NEGATIVE_FALLING_SINE_SEGMENT,
+		NEGATIVE_LINEAR_SEGMENT,
+		NEGATIVE_RISING_SINE_SEGMENT
+	} phase;
+
+	// Current phase of the resonance wave
+	enum ResonancePhase {
+		POSITIVE_RISING_RESONANCE_SINE_SEGMENT,
+		POSITIVE_FALLING_RESONANCE_SINE_SEGMENT,
+		NEGATIVE_FALLING_RESONANCE_SINE_SEGMENT,
+		NEGATIVE_RISING_RESONANCE_SINE_SEGMENT
+	} resonancePhase;
+
+	// Resulting log-space samples of the square and resonance waves
+	LogSample squareLogSample;
+	LogSample resonanceLogSample;
+
+	// Processed neighbour log-space samples of the PCM wave
+	LogSample firstPCMLogSample;
+	LogSample secondPCMLogSample;
+
+	//***************************************************************************
+	// Internal methods below
+	//***************************************************************************
+
+	Bit32u getSampleStep();
+	Bit32u getResonanceWaveLengthFactor(Bit32u effectiveCutoffValue);
+	Bit32u getHighLinearLength(Bit32u effectiveCutoffValue);
+
+	void computePositions(Bit32u highLinearLength, Bit32u lowLinearLength, Bit32u resonanceWaveLengthFactor);
+	void advancePosition();
+
+	void generateNextSquareWaveLogSample();
+	void generateNextResonanceWaveLogSample();
+	void generateNextSawtoothCosineLogSample(LogSample &logSample) const;
+
+	void pcmSampleToLogSample(LogSample &logSample, const Bit16s pcmSample) const;
+	void generateNextPCMWaveLogSamples();
+
+public:
+	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
+	void initSynth(const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+
+	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
+	void initPCM(const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped, const bool pcmWaveInterpolated);
+
+	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
+	void generateNextSample(const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
+
+	// WG output in the log-space consists of two components which are to be added (or ring modulated) in the linear-space afterwards
+	LogSample getOutputLogSample(const bool first) const;
+
+	// Deactivate the WG engine
+	void deactivate();
+
+	// Return active state of the WG engine
+	bool isActive() const;
+
+	// Return true if the WG engine generates PCM wave samples
+	bool isPCMWave() const;
+
+	// Return current PCM interpolation factor
+	Bit32u getPCMInterpolationFactor() const;
+}; // class LA32WaveGenerator
+
+// LA32PartialPair contains a structure of two partials being mixed / ring modulated
+class LA32PartialPair {
+public:
+	enum PairType {
+		MASTER,
+		SLAVE
+	};
+
+	virtual ~LA32PartialPair() {}
+
+	// ringModulated should be set to false for the structures with mixing or stereo output
+	// ringModulated should be set to true for the structures with ring modulation
+	// mixed is used for the structures with ring modulation and indicates whether the master partial output is mixed to the ring modulator output
+	virtual void init(const bool ringModulated, const bool mixed) = 0;
+
+	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
+	virtual void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance) = 0;
+
+	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
+	virtual void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped) = 0;
+
+	// Deactivate the WG engine
+	virtual void deactivate(const PairType master) = 0;
+}; // class LA32PartialPair
+
+class LA32IntPartialPair : public LA32PartialPair {
+	LA32WaveGenerator master;
+	LA32WaveGenerator slave;
+	bool ringModulated;
+	bool mixed;
+
+	static Bit16s unlogAndMixWGOutput(const LA32WaveGenerator &wg);
+
+public:
+	static void initTables(const Tables &tables);
+
+	// ringModulated should be set to false for the structures with mixing or stereo output
+	// ringModulated should be set to true for the structures with ring modulation
+	// mixed is used for the structures with ring modulation and indicates whether the master partial output is mixed to the ring modulator output
+	void init(const bool ringModulated, const bool mixed);
+
+	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
+	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+
+	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
+	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped);
+
+	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
+	void generateNextSample(const PairType master, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
+
+	// Perform mixing / ring modulation of WG output and return the result
+	// Although, LA32 applies panning itself, we assume it is applied in the mixer, not within a pair
+	Bit16s nextOutSample();
+
+	// Deactivate the WG engine
+	void deactivate(const PairType master);
+
+	// Return active state of the WG engine
+	bool isActive(const PairType master) const;
+}; // class LA32IntPartialPair
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_LA32_WAVE_GENERATOR_H

--- a/vendor/munt/src/MemoryRegion.h
+++ b/vendor/munt/src/MemoryRegion.h
@@ -1,0 +1,132 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_MEMORY_REGION_H
+#define MT32EMU_MEMORY_REGION_H
+
+#include <cstddef>
+
+#include "globals.h"
+#include "Types.h"
+#include "Structures.h"
+
+namespace MT32Emu {
+
+enum MemoryRegionType {
+	MR_PatchTemp, MR_RhythmTemp, MR_TimbreTemp, MR_Patches, MR_Timbres, MR_System, MR_Display, MR_Reset
+};
+
+class Synth;
+
+class MemoryRegion {
+private:
+	Bit8u *realMemory;
+	Bit8u *maxTable;
+public:
+	MemoryRegionType type;
+	Bit32u startAddr, entrySize, entries;
+
+	MemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable, MemoryRegionType useType, Bit32u useStartAddr, Bit32u useEntrySize, Bit32u useEntries) {
+		realMemory = useRealMemory;
+		maxTable = useMaxTable;
+		type = useType;
+		startAddr = useStartAddr;
+		entrySize = useEntrySize;
+		entries = useEntries;
+	}
+	int lastTouched(Bit32u addr, Bit32u len) const {
+		return (offset(addr) + len - 1) / entrySize;
+	}
+	int firstTouchedOffset(Bit32u addr) const {
+		return offset(addr) % entrySize;
+	}
+	int firstTouched(Bit32u addr) const {
+		return offset(addr) / entrySize;
+	}
+	Bit32u regionEnd() const {
+		return startAddr + entrySize * entries;
+	}
+	bool contains(Bit32u addr) const {
+		return addr >= startAddr && addr < regionEnd();
+	}
+	int offset(Bit32u addr) const {
+		return addr - startAddr;
+	}
+	Bit32u getClampedLen(Bit32u addr, Bit32u len) const {
+		if (addr + len > regionEnd())
+			return regionEnd() - addr;
+		return len;
+	}
+	Bit32u next(Bit32u addr, Bit32u len) const {
+		if (addr + len > regionEnd()) {
+			return regionEnd() - addr;
+		}
+		return 0;
+	}
+	Bit8u getMaxValue(int off) const {
+		if (maxTable == NULL)
+			return 0xFF;
+		return maxTable[off % entrySize];
+	}
+	Bit8u *getRealMemory() const {
+		return realMemory;
+	}
+	bool isReadable() const {
+		return getRealMemory() != NULL;
+	}
+	void read(unsigned int entry, unsigned int off, Bit8u *dst, unsigned int len) const;
+	void write(unsigned int entry, unsigned int off, const Bit8u *src, unsigned int len, bool init = false) const;
+}; // class MemoryRegion
+
+class PatchTempMemoryRegion : public MemoryRegion {
+public:
+	PatchTempMemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable) : MemoryRegion(useRealMemory, useMaxTable, MR_PatchTemp, MT32EMU_MEMADDR(0x030000), sizeof(MemParams::PatchTemp), 9) {}
+};
+class RhythmTempMemoryRegion : public MemoryRegion {
+public:
+	RhythmTempMemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable) : MemoryRegion(useRealMemory, useMaxTable, MR_RhythmTemp, MT32EMU_MEMADDR(0x030110), sizeof(MemParams::RhythmTemp), 85) {}
+};
+class TimbreTempMemoryRegion : public MemoryRegion {
+public:
+	TimbreTempMemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable) : MemoryRegion(useRealMemory, useMaxTable, MR_TimbreTemp, MT32EMU_MEMADDR(0x040000), sizeof(TimbreParam), 8) {}
+};
+class PatchesMemoryRegion : public MemoryRegion {
+public:
+	PatchesMemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable) : MemoryRegion(useRealMemory, useMaxTable, MR_Patches, MT32EMU_MEMADDR(0x050000), sizeof(PatchParam), 128) {}
+};
+class TimbresMemoryRegion : public MemoryRegion {
+public:
+	TimbresMemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable) : MemoryRegion(useRealMemory, useMaxTable, MR_Timbres, MT32EMU_MEMADDR(0x080000), sizeof(MemParams::PaddedTimbre), 64) {}
+};
+class SystemMemoryRegion : public MemoryRegion {
+public:
+	SystemMemoryRegion(Bit8u *useRealMemory, Bit8u *useMaxTable) : MemoryRegion(useRealMemory, useMaxTable, MR_System, MT32EMU_MEMADDR(0x100000), sizeof(MemParams::System), 1) {}
+};
+class DisplayMemoryRegion : public MemoryRegion {
+public:
+	// Note, we set realMemory to NULL despite the real devices buffer inbound strings. However, it is impossible to retrieve them.
+	// This entrySize permits emulation of handling a 20-byte display message sent to an old-gen device at address 0x207F7F.
+	DisplayMemoryRegion() : MemoryRegion(NULL, NULL, MR_Display, MT32EMU_MEMADDR(0x200000), 0x4013, 1) {}
+};
+class ResetMemoryRegion : public MemoryRegion {
+public:
+	ResetMemoryRegion() : MemoryRegion(NULL, NULL, MR_Reset, MT32EMU_MEMADDR(0x7F0000), 0x3FFF, 1) {}
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_MEMORY_REGION_H

--- a/vendor/munt/src/MidiEventQueue.h
+++ b/vendor/munt/src/MidiEventQueue.h
@@ -1,0 +1,73 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_MIDI_EVENT_QUEUE_H
+#define MT32EMU_MIDI_EVENT_QUEUE_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+/**
+ * Simple queue implementation using a ring buffer to store incoming MIDI event before the synth actually processes it.
+ * It is intended to:
+ * - get rid of prerenderer while retaining graceful partial abortion
+ * - add fair emulation of the MIDI interface delays
+ * - extend the synth interface with the default implementation of a typical rendering loop.
+ * THREAD SAFETY:
+ * It is safe to use either in a single thread environment or when there are only two threads - one performs only reading
+ * and one performs only writing. More complicated usage requires external synchronisation.
+ */
+class MidiEventQueue {
+public:
+	class SysexDataStorage;
+
+	struct MidiEvent {
+		const Bit8u *sysexData;
+		union {
+			Bit32u sysexLength;
+			Bit32u shortMessageData;
+		};
+		Bit32u timestamp;
+	};
+
+	explicit MidiEventQueue(
+		// Must be a power of 2
+		Bit32u ringBufferSize,
+		Bit32u storageBufferSize
+	);
+	~MidiEventQueue();
+	void reset();
+	bool pushShortMessage(Bit32u shortMessageData, Bit32u timestamp);
+	bool pushSysex(const Bit8u *sysexData, Bit32u sysexLength, Bit32u timestamp);
+	const volatile MidiEvent *peekMidiEvent();
+	void dropMidiEvent();
+	inline bool isEmpty() const;
+
+private:
+	SysexDataStorage &sysexDataStorage;
+
+	MidiEvent * const ringBuffer;
+	const Bit32u ringBufferMask;
+	volatile Bit32u startPosition;
+	volatile Bit32u endPosition;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_MIDI_EVENT_QUEUE_H

--- a/vendor/munt/src/MidiStreamParser.cpp
+++ b/vendor/munt/src/MidiStreamParser.cpp
@@ -1,0 +1,295 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2024 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdio>
+#include <cstring>
+
+#include "internals.h"
+
+#include "MidiStreamParser.h"
+#include "Synth.h"
+
+using namespace MT32Emu;
+
+DefaultMidiStreamParser::DefaultMidiStreamParser(Synth &useSynth, Bit32u initialStreamBufferCapacity) :
+	MidiStreamParser(initialStreamBufferCapacity), synth(useSynth), timestampSet(false) {}
+
+void DefaultMidiStreamParser::setTimestamp(const Bit32u useTimestamp) {
+	timestampSet = true;
+	timestamp = useTimestamp;
+}
+
+void DefaultMidiStreamParser::resetTimestamp() {
+	timestampSet = false;
+}
+
+void DefaultMidiStreamParser::handleShortMessage(const Bit32u message) {
+	do {
+		if (timestampSet) {
+			if (synth.playMsg(message, timestamp)) return;
+		} else {
+			if (synth.playMsg(message)) return;
+		}
+	} while (synth.reportHandler->onMIDIQueueOverflow());
+}
+
+void DefaultMidiStreamParser::handleSysex(const Bit8u *stream, const Bit32u length) {
+	do {
+		if (timestampSet) {
+			if (synth.playSysex(stream, length, timestamp)) return;
+		} else {
+			if (synth.playSysex(stream, length)) return;
+		}
+	} while (synth.reportHandler->onMIDIQueueOverflow());
+}
+
+void DefaultMidiStreamParser::handleSystemRealtimeMessage(const Bit8u realtime) {
+	synth.reportHandler->onMIDISystemRealtime(realtime);
+}
+
+void DefaultMidiStreamParser::printDebug(const char *debugMessage) {
+	synth.printDebug("%s", debugMessage);
+}
+
+MidiStreamParser::MidiStreamParser(Bit32u initialStreamBufferCapacity) :
+	MidiStreamParserImpl(*this, *this, initialStreamBufferCapacity) {}
+
+MidiStreamParserImpl::MidiStreamParserImpl(MidiReceiver &useReceiver, MidiReporter &useReporter, Bit32u initialStreamBufferCapacity) :
+	midiReceiver(useReceiver), midiReporter(useReporter)
+{
+	if (initialStreamBufferCapacity < SYSEX_BUFFER_SIZE) initialStreamBufferCapacity = SYSEX_BUFFER_SIZE;
+	if (MAX_STREAM_BUFFER_SIZE < initialStreamBufferCapacity) initialStreamBufferCapacity = MAX_STREAM_BUFFER_SIZE;
+	streamBufferCapacity = initialStreamBufferCapacity;
+	streamBuffer = new Bit8u[streamBufferCapacity];
+	streamBufferSize = 0;
+	runningStatus = 0;
+
+	reserved = NULL;
+}
+
+MidiStreamParserImpl::~MidiStreamParserImpl() {
+	delete[] streamBuffer;
+}
+
+void MidiStreamParserImpl::parseStream(const Bit8u *stream, Bit32u length) {
+	while (length > 0) {
+		Bit32u parsedMessageLength = 0;
+		if (0xF8 <= *stream) {
+			// Process System Realtime immediately and go on
+			midiReceiver.handleSystemRealtimeMessage(*stream);
+			parsedMessageLength = 1;
+			// No effect on the running status
+		} else if (streamBufferSize > 0) {
+			// Check if there is something in streamBuffer waiting for being processed
+			if (*streamBuffer == 0xF0) {
+				parsedMessageLength = parseSysexFragment(stream, length);
+			} else {
+				parsedMessageLength = parseShortMessageDataBytes(stream, length);
+			}
+		} else {
+			if (*stream == 0xF0) {
+				runningStatus = 0; // SysEx clears the running status
+				parsedMessageLength = parseSysex(stream, length);
+			} else {
+				parsedMessageLength = parseShortMessageStatus(stream);
+			}
+		}
+
+		// Parsed successfully
+		stream += parsedMessageLength;
+		length -= parsedMessageLength;
+	}
+}
+
+void MidiStreamParserImpl::processShortMessage(const Bit32u message) {
+	// Adds running status to the MIDI message if it doesn't contain one
+	Bit8u status = Bit8u(message & 0xFF);
+	if (0xF8 <= status) {
+		midiReceiver.handleSystemRealtimeMessage(status);
+	} else if (processStatusByte(status)) {
+		midiReceiver.handleShortMessage((message << 8) | status);
+	} else if (0x80 <= status) { // If no running status available yet, skip this message
+		midiReceiver.handleShortMessage(message);
+	}
+}
+
+// We deal with SysEx messages below 512 bytes long in most cases. Nevertheless, it seems reasonable to support a possibility
+// to load bulk dumps using a single message. However, this is known to fail with a real device due to limited input buffer size.
+bool MidiStreamParserImpl::checkStreamBufferCapacity(const bool preserveContent) {
+	if (streamBufferSize < streamBufferCapacity) return true;
+	if (streamBufferCapacity < MAX_STREAM_BUFFER_SIZE) {
+		Bit8u *oldStreamBuffer = streamBuffer;
+		streamBufferCapacity = MAX_STREAM_BUFFER_SIZE;
+		streamBuffer = new Bit8u[streamBufferCapacity];
+		if (preserveContent) memcpy(streamBuffer, oldStreamBuffer, streamBufferSize);
+		delete[] oldStreamBuffer;
+		return true;
+	}
+	return false;
+}
+
+// Checks input byte whether it is a status byte. If not, replaces it with running status when available.
+// Returns true if the input byte was changed to running status.
+bool MidiStreamParserImpl::processStatusByte(Bit8u &status) {
+	if (status < 0x80) {
+		// First byte isn't status, try running status
+		if (runningStatus < 0x80) {
+			// No running status available yet
+			midiReporter.printDebug("processStatusByte: No valid running status yet, MIDI message ignored");
+			return false;
+		}
+		status = runningStatus;
+		return true;
+	} else if (status < 0xF0) {
+		// Store current status as running for a Voice message
+		runningStatus = status;
+	} else if (status < 0xF8) {
+		// System Common clears running status
+		runningStatus = 0;
+	} // System Realtime doesn't affect running status
+	return false;
+}
+
+// Returns # of bytes parsed
+Bit32u MidiStreamParserImpl::parseShortMessageStatus(const Bit8u stream[]) {
+	Bit8u status = *stream;
+	Bit32u parsedLength = processStatusByte(status) ? 0 : 1;
+	if (0x80 <= status) { // If no running status available yet, skip one byte
+		*streamBuffer = status;
+		++streamBufferSize;
+	}
+	return parsedLength;
+}
+
+// Returns # of bytes parsed
+Bit32u MidiStreamParserImpl::parseShortMessageDataBytes(const Bit8u stream[], Bit32u length) {
+	const Bit32u shortMessageLength = Synth::getShortMessageLength(*streamBuffer);
+	Bit32u parsedLength = 0;
+
+	// Append incoming bytes to streamBuffer
+	while ((streamBufferSize < shortMessageLength) && (length-- > 0)) {
+		Bit8u dataByte = *(stream++);
+		if (dataByte < 0x80) {
+			// Add data byte to streamBuffer
+			streamBuffer[streamBufferSize++] = dataByte;
+		} else if (dataByte < 0xF8) {
+			// Discard invalid bytes and start over
+			char s[128];
+#ifdef MT32EMU_WITH_STD_SNPRINTF
+			snprintf(
+				s, sizeof s,
+#else
+			sprintf(
+				s,
+#endif
+				"parseShortMessageDataBytes: Invalid short message: status %02x, expected length %i, actual %i -> ignored", *streamBuffer, shortMessageLength, streamBufferSize
+			);
+			midiReporter.printDebug(s);
+			streamBufferSize = 0; // Clear streamBuffer
+			return parsedLength;
+		} else {
+			// Bypass System Realtime message
+			midiReceiver.handleSystemRealtimeMessage(dataByte);
+		}
+		++parsedLength;
+	}
+	if (streamBufferSize < shortMessageLength) return parsedLength; // Still lacks data bytes
+
+	// Assemble short message
+	Bit32u shortMessage = streamBuffer[0];
+	for (Bit32u i = 1; i < shortMessageLength; ++i) {
+		shortMessage |= streamBuffer[i] << (i << 3);
+	}
+	midiReceiver.handleShortMessage(shortMessage);
+	streamBufferSize = 0; // Clear streamBuffer
+	return parsedLength;
+}
+
+// Returns # of bytes parsed
+Bit32u MidiStreamParserImpl::parseSysex(const Bit8u stream[], const Bit32u length) {
+	// Find SysEx length
+	Bit32u sysexLength = 1;
+	while (sysexLength < length) {
+		Bit8u nextByte = stream[sysexLength++];
+		if (0x80 <= nextByte) {
+			if (nextByte == 0xF7) {
+				// End of SysEx
+				midiReceiver.handleSysex(stream, sysexLength);
+				return sysexLength;
+			}
+			if (0xF8 <= nextByte) {
+				// The System Realtime message must be processed right after return
+				// but the SysEx is actually fragmented and to be reconstructed in streamBuffer
+				--sysexLength;
+				break;
+			}
+			// Illegal status byte in SysEx message, aborting
+			midiReporter.printDebug("parseSysex: SysEx message lacks end-of-sysex (0xf7), ignored");
+			// Continue parsing from that point
+			return sysexLength - 1;
+		}
+	}
+
+	// Store incomplete SysEx message for further processing
+	streamBufferSize = sysexLength;
+	if (checkStreamBufferCapacity(false)) {
+		memcpy(streamBuffer, stream, sysexLength);
+	} else {
+		// Not enough buffer capacity, don't care about the real buffer content, just mark the first byte
+		*streamBuffer = *stream;
+		streamBufferSize = streamBufferCapacity;
+	}
+	return sysexLength;
+}
+
+// Returns # of bytes parsed
+Bit32u MidiStreamParserImpl::parseSysexFragment(const Bit8u stream[], const Bit32u length) {
+	Bit32u parsedLength = 0;
+	while (parsedLength < length) {
+		Bit8u nextByte = stream[parsedLength++];
+		if (nextByte < 0x80) {
+			// Add SysEx data byte to streamBuffer
+			if (checkStreamBufferCapacity(true)) streamBuffer[streamBufferSize++] = nextByte;
+			continue;
+		}
+		if (0xF8 <= nextByte) {
+			// Bypass System Realtime message
+			midiReceiver.handleSystemRealtimeMessage(nextByte);
+			continue;
+		}
+		if (nextByte != 0xF7) {
+			// Illegal status byte in SysEx message, aborting
+			midiReporter.printDebug("parseSysexFragment: SysEx message lacks end-of-sysex (0xf7), ignored");
+			// Clear streamBuffer and continue parsing from that point
+			streamBufferSize = 0;
+			--parsedLength;
+			break;
+		}
+		// End of SysEx
+		if (checkStreamBufferCapacity(true)) {
+			streamBuffer[streamBufferSize++] = nextByte;
+			midiReceiver.handleSysex(streamBuffer, streamBufferSize);
+			streamBufferSize = 0; // Clear streamBuffer
+			break;
+		}
+		// Encountered streamBuffer overrun
+		midiReporter.printDebug("parseSysexFragment: streamBuffer overrun while receiving SysEx message, ignored. Max allowed size of fragmented SysEx is 32768 bytes.");
+		streamBufferSize = 0; // Clear streamBuffer
+		break;
+	}
+	return parsedLength;
+}

--- a/vendor/munt/src/MidiStreamParser.h
+++ b/vendor/munt/src/MidiStreamParser.h
@@ -1,0 +1,124 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_MIDI_STREAM_PARSER_H
+#define MT32EMU_MIDI_STREAM_PARSER_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+class Synth;
+
+// Interface for a user-supplied class to receive parsed well-formed MIDI messages.
+class MT32EMU_EXPORT MidiReceiver {
+public:
+	// Invoked when a complete short MIDI message is parsed in the input MIDI stream.
+	virtual void handleShortMessage(const Bit32u message) = 0;
+
+	// Invoked when a complete well-formed System Exclusive MIDI message is parsed in the input MIDI stream.
+	virtual void handleSysex(const Bit8u stream[], const Bit32u length) = 0;
+
+	// Invoked when a System Realtime MIDI message is parsed in the input MIDI stream.
+	virtual void handleSystemRealtimeMessage(const Bit8u realtime) = 0;
+
+protected:
+	~MidiReceiver() {}
+};
+
+// Interface for a user-supplied class to receive notifications of input MIDI stream parse errors.
+class MT32EMU_EXPORT MidiReporter {
+public:
+	// Invoked when an error occurs during processing the input MIDI stream.
+	virtual void printDebug(const char *debugMessage) = 0;
+
+protected:
+	~MidiReporter() {}
+};
+
+// Provides a context for parsing a stream of MIDI events coming from a single source.
+// There can be multiple MIDI sources feeding MIDI events to a single Synth object.
+// NOTE: Calls from multiple threads which feed a single Synth object with data must be explicitly synchronised,
+// although, no synchronisation is required with the rendering thread.
+class MT32EMU_EXPORT MidiStreamParserImpl {
+public:
+	// The first two arguments provide for implementations of essential interfaces needed.
+	// The third argument specifies streamBuffer initial capacity. The buffer capacity should be large enough to fit the longest SysEx expected.
+	// If a longer SysEx occurs, streamBuffer is reallocated to the maximum size of MAX_STREAM_BUFFER_SIZE (32768 bytes).
+	// Default capacity is SYSEX_BUFFER_SIZE (1000 bytes) which is enough to fit SysEx messages in common use.
+	MidiStreamParserImpl(MidiReceiver &, MidiReporter &, Bit32u initialStreamBufferCapacity = SYSEX_BUFFER_SIZE);
+	virtual ~MidiStreamParserImpl();
+
+	// Parses a block of raw MIDI bytes. All the parsed MIDI messages are sent in sequence to the user-supplied methods for further processing.
+	// SysEx messages are allowed to be fragmented across several calls to this method. Running status is also handled for short messages.
+	// NOTE: the total length of a SysEx message being fragmented shall not exceed MAX_STREAM_BUFFER_SIZE (32768 bytes).
+	void parseStream(const Bit8u *stream, Bit32u length);
+
+	// Convenience method which accepts a Bit32u-encoded short MIDI message and sends it to the user-supplied method for further processing.
+	// The short MIDI message may contain no status byte, the running status is used in this case.
+	void processShortMessage(const Bit32u message);
+
+private:
+	Bit8u runningStatus;
+	Bit8u *streamBuffer;
+	Bit32u streamBufferCapacity;
+	Bit32u streamBufferSize;
+	MidiReceiver &midiReceiver;
+	MidiReporter &midiReporter;
+
+	// Binary compatibility helper.
+	void *reserved;
+
+	bool checkStreamBufferCapacity(const bool preserveContent);
+	bool processStatusByte(Bit8u &status);
+	Bit32u parseShortMessageStatus(const Bit8u stream[]);
+	Bit32u parseShortMessageDataBytes(const Bit8u stream[], Bit32u length);
+	Bit32u parseSysex(const Bit8u stream[], const Bit32u length);
+	Bit32u parseSysexFragment(const Bit8u stream[], const Bit32u length);
+}; // class MidiStreamParserImpl
+
+// An abstract class that provides a context for parsing a stream of MIDI events coming from a single source.
+class MT32EMU_EXPORT MidiStreamParser : public MidiStreamParserImpl, protected MidiReceiver, protected MidiReporter {
+public:
+	// The argument specifies streamBuffer initial capacity. The buffer capacity should be large enough to fit the longest SysEx expected.
+	// If a longer SysEx occurs, streamBuffer is reallocated to the maximum size of MAX_STREAM_BUFFER_SIZE (32768 bytes).
+	// Default capacity is SYSEX_BUFFER_SIZE (1000 bytes) which is enough to fit SysEx messages in common use.
+	explicit MidiStreamParser(Bit32u initialStreamBufferCapacity = SYSEX_BUFFER_SIZE);
+};
+
+class MT32EMU_EXPORT DefaultMidiStreamParser : public MidiStreamParser {
+public:
+	explicit DefaultMidiStreamParser(Synth &synth, Bit32u initialStreamBufferCapacity = SYSEX_BUFFER_SIZE);
+	void setTimestamp(const Bit32u useTimestamp);
+	void resetTimestamp();
+
+protected:
+	void handleShortMessage(const Bit32u message);
+	void handleSysex(const Bit8u *stream, const Bit32u length);
+	void handleSystemRealtimeMessage(const Bit8u realtime);
+	void printDebug(const char *debugMessage);
+
+private:
+	Synth &synth;
+	bool timestampSet;
+	Bit32u timestamp;
+};
+
+} // namespace MT32Emu
+
+#endif // MT32EMU_MIDI_STREAM_PARSER_H

--- a/vendor/munt/src/Part.cpp
+++ b/vendor/munt/src/Part.cpp
@@ -1,0 +1,756 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2025 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdio>
+#include <cstring>
+
+#include "internals.h"
+
+#include "Part.h"
+#include "Partial.h"
+#include "PartialManager.h"
+#include "Poly.h"
+#include "Synth.h"
+
+namespace MT32Emu {
+
+static const Bit8u PartialStruct[13] = {
+	0, 0, 2, 2, 1, 3,
+	3, 0, 3, 0, 2, 1, 3
+};
+
+static const Bit8u PartialMixStruct[13] = {
+	0, 1, 0, 1, 1, 0,
+	1, 3, 3, 2, 2, 2, 2
+};
+
+const Part *Part::getPart(Synth &synth, Bit8u partNum) {
+	return synth.getPart(partNum);
+}
+
+RhythmPart::RhythmPart(Synth *useSynth, unsigned int usePartNum): Part(useSynth, usePartNum) {
+	strcpy(name, "Rhythm");
+	rhythmTemp = &synth->mt32ram.rhythmTemp[0];
+	refresh();
+}
+
+Part::Part(Synth *useSynth, unsigned int usePartNum) {
+	synth = useSynth;
+	partNum = usePartNum;
+	patchCache[0].dirty = true;
+	holdpedal = false;
+	patchTemp = &synth->mt32ram.patchTemp[partNum];
+	if (usePartNum == 8) {
+		// The Rhythm part doesn't have just a single timbre associated.
+		timbreTemp = NULL;
+	} else {
+#ifdef MT32EMU_WITH_STD_SNPRINTF
+		snprintf(
+			name, sizeof name,
+#else
+		sprintf(
+			name,
+#endif
+			"Part %d", partNum + 1
+		);
+		timbreTemp = &synth->mt32ram.timbreTemp[partNum];
+	}
+	currentInstr[0] = 0;
+	currentInstr[10] = 0;
+	volumeOverride = 255;
+	modulation = 0;
+	expression = 100;
+	pitchBend = 0;
+	activePartialCount = 0;
+	activeNonReleasingPolyCount = 0;
+	memset(patchCache, 0, sizeof(patchCache));
+}
+
+Part::~Part() {
+	while (!activePolys.isEmpty()) {
+		delete activePolys.takeFirst();
+	}
+}
+
+void Part::setDataEntryMSB(unsigned char midiDataEntryMSB) {
+	if (nrpn) {
+		// The last RPN-related control change was for an NRPN,
+		// which the real synths don't support.
+		return;
+	}
+	if (rpn != 0) {
+		// The RPN has been set to something other than 0,
+		// which is the only RPN that these synths support
+		return;
+	}
+	patchTemp->patch.benderRange = midiDataEntryMSB > 24 ? 24 : midiDataEntryMSB;
+	updatePitchBenderRange();
+}
+
+void Part::setNRPN() {
+	nrpn = true;
+}
+
+void Part::setRPNLSB(unsigned char midiRPNLSB) {
+	nrpn = false;
+	rpn = (rpn & 0xFF00) | midiRPNLSB;
+}
+
+void Part::setRPNMSB(unsigned char midiRPNMSB) {
+	nrpn = false;
+	rpn = (rpn & 0x00FF) | (midiRPNMSB << 8);
+}
+
+void Part::setHoldPedal(bool pressed) {
+	if (holdpedal && !pressed) {
+		holdpedal = false;
+		stopPedalHold();
+	} else {
+		holdpedal = pressed;
+	}
+}
+
+Bit32s Part::getPitchBend() const {
+	return pitchBend;
+}
+
+void Part::setBend(unsigned int midiBend) {
+	// CONFIRMED:
+	pitchBend = ((signed(midiBend) - 8192) * pitchBenderRange) >> 14; // PORTABILITY NOTE: Assumes arithmetic shift
+}
+
+Bit8u Part::getModulation() const {
+	return modulation;
+}
+
+void Part::setModulation(unsigned int midiModulation) {
+	modulation = Bit8u(midiModulation);
+}
+
+void Part::resetAllControllers() {
+	modulation = 0;
+	expression = 100;
+	pitchBend = 0;
+	setHoldPedal(false);
+}
+
+void Part::reset() {
+	resetAllControllers();
+	allSoundOff();
+	rpn = 0xFFFF;
+}
+
+void RhythmPart::refresh() {
+	// (Re-)cache all the mapped timbres ahead of time
+	for (unsigned int drumNum = 0; drumNum < synth->controlROMMap->rhythmSettingsCount; drumNum++) {
+		int drumTimbreNum = rhythmTemp[drumNum].timbre;
+		if (drumTimbreNum >= 127) { // 94 on MT-32
+			continue;
+		}
+		PatchCache *cache = drumCache[drumNum];
+		backupCacheToPartials(cache);
+		for (int t = 0; t < 4; t++) {
+			// Common parameters, stored redundantly
+			cache[t].dirty = true;
+			cache[t].reverb = rhythmTemp[drumNum].reverbSwitch > 0;
+		}
+	}
+	updatePitchBenderRange();
+}
+
+void Part::refresh() {
+	backupCacheToPartials(patchCache);
+	for (int t = 0; t < 4; t++) {
+		// Common parameters, stored redundantly
+		patchCache[t].dirty = true;
+		patchCache[t].reverb = patchTemp->patch.reverbSwitch > 0;
+	}
+	memcpy(currentInstr, timbreTemp->common.name, 10);
+	synth->newTimbreSet(partNum);
+	updatePitchBenderRange();
+}
+
+const char *Part::getCurrentInstr() const {
+	return &currentInstr[0];
+}
+
+void RhythmPart::refreshTimbre(unsigned int absTimbreNum) {
+	for (int m = 0; m < 85; m++) {
+		if (rhythmTemp[m].timbre == absTimbreNum - 128) {
+			drumCache[m][0].dirty = true;
+		}
+	}
+}
+
+void Part::refreshTimbre(unsigned int absTimbreNum) {
+	if (getAbsTimbreNum() == absTimbreNum) {
+		memcpy(currentInstr, timbreTemp->common.name, 10);
+		patchCache[0].dirty = true;
+	}
+}
+
+void Part::setPatch(const PatchParam *patch) {
+	patchTemp->patch = *patch;
+}
+
+void RhythmPart::resetTimbre() {
+	synth->printDebug("%s: Attempted to call resetTimbre() - doesn't make sense for rhythm", name);
+}
+
+void Part::resetTimbre() {
+	holdpedal = false;
+	allSoundOff();
+	*timbreTemp = synth->mt32ram.timbres[getAbsTimbreNum()].timbre;
+}
+
+unsigned int RhythmPart::getAbsTimbreNum() const {
+	synth->printDebug("%s: Attempted to call getAbsTimbreNum() - doesn't make sense for rhythm", name);
+	return 0;
+}
+
+unsigned int Part::getAbsTimbreNum() const {
+	return (patchTemp->patch.timbreGroup * 64) + patchTemp->patch.timbreNum;
+}
+
+#if MT32EMU_MONITOR_MIDI > 0
+void RhythmPart::setProgram(unsigned int patchNum) {
+	synth->printDebug("%s: Attempt to set program (%d) on rhythm is invalid", name, patchNum);
+}
+#else
+void RhythmPart::setProgram(unsigned int) { }
+#endif
+
+void Part::setProgram(unsigned int patchNum) {
+	setPatch(&synth->mt32ram.patches[patchNum]);
+	resetTimbre();
+	refresh();
+}
+
+void Part::updatePitchBenderRange() {
+	pitchBenderRange = patchTemp->patch.benderRange * 683;
+}
+
+void Part::backupCacheToPartials(PatchCache cache[4]) {
+	// check if any partials are still playing with the old patch cache
+	// if so then duplicate the cached data from the part to the partial so that
+	// we can change the part's cache without affecting the partial.
+	// We delay this until now to avoid a copy operation with every note played
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		poly->backupCacheToPartials(cache);
+	}
+}
+
+void Part::cacheTimbre(PatchCache cache[4], const TimbreParam *timbre) {
+	backupCacheToPartials(cache);
+	int partialCount = 0;
+	for (int t = 0; t < 4; t++) {
+		if (((timbre->common.partialMute >> t) & 0x1) == 1) {
+			cache[t].playPartial = true;
+			partialCount++;
+		} else {
+			cache[t].playPartial = false;
+			continue;
+		}
+
+		// Calculate and cache common parameters
+		cache[t].srcPartial = timbre->partial[t];
+
+		cache[t].pcm = timbre->partial[t].wg.pcmWave;
+
+		switch (t) {
+		case 0:
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure12)] & 0x2) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure12)];
+			cache[t].structurePosition = 0;
+			cache[t].structurePair = 1;
+			break;
+		case 1:
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure12)] & 0x1) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure12)];
+			cache[t].structurePosition = 1;
+			cache[t].structurePair = 0;
+			break;
+		case 2:
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure34)] & 0x2) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure34)];
+			cache[t].structurePosition = 0;
+			cache[t].structurePair = 3;
+			break;
+		case 3:
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure34)] & 0x1) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure34)];
+			cache[t].structurePosition = 1;
+			cache[t].structurePair = 2;
+			break;
+		default:
+			break;
+		}
+
+		cache[t].partialParam = &timbre->partial[t];
+
+		cache[t].waveform = timbre->partial[t].wg.waveform;
+	}
+	for (int t = 0; t < 4; t++) {
+		// Common parameters, stored redundantly
+		cache[t].dirty = false;
+		cache[t].partialCount = partialCount;
+		cache[t].sustain = (timbre->common.noSustain == 0);
+	}
+	//synth->printDebug("Res 1: %d 2: %d 3: %d 4: %d", cache[0].waveform, cache[1].waveform, cache[2].waveform, cache[3].waveform);
+
+#if MT32EMU_MONITOR_INSTRUMENTS > 0
+	synth->printDebug("%s (%s): Recached timbre", name, currentInstr);
+	for (int i = 0; i < 4; i++) {
+		synth->printDebug(" %d: play=%s, pcm=%s (%d), wave=%d", i, cache[i].playPartial ? "YES" : "NO", cache[i].PCMPartial ? "YES" : "NO", timbre->partial[i].wg.pcmWave, timbre->partial[i].wg.waveform);
+	}
+#endif
+}
+
+const char *Part::getName() const {
+	return name;
+}
+
+void Part::setVolume(unsigned int midiVolume) {
+	// CONFIRMED: This calculation matches the table used in the control ROM
+	patchTemp->outputLevel = Bit8u(midiVolume * 100 / 127);
+	//synth->printDebug("%s (%s): Set volume to %d", name, currentInstr, midiVolume);
+}
+
+Bit8u Part::getVolume() const {
+	return volumeOverride <= 100 ? volumeOverride : patchTemp->outputLevel;
+}
+
+void Part::setVolumeOverride(Bit8u volume) {
+	volumeOverride = volume;
+	// When volume is 0, we want the part to stop producing any sound at all.
+	// For that to achieve, we have to actually stop processing NoteOn MIDI messages; merely
+	// returning 0 volume is not enough - the output may still be generated at a very low level.
+	// But first, we have to stop all the currently playing polys. This behaviour may also help
+	// with performance issues, because parts muted this way barely consume CPU resources.
+	if (volume == 0) allSoundOff();
+}
+
+Bit8u Part::getVolumeOverride() const {
+	return volumeOverride;
+}
+
+Bit8u Part::getExpression() const {
+	return expression;
+}
+
+void Part::setExpression(unsigned int midiExpression) {
+	// CONFIRMED: This calculation matches the table used in the control ROM
+	expression = Bit8u(midiExpression * 100 / 127);
+}
+
+void RhythmPart::setPan(unsigned int midiPan) {
+	// CONFIRMED: This does change patchTemp, but has no actual effect on playback.
+#if MT32EMU_MONITOR_MIDI > 0
+	synth->printDebug("%s: Pointlessly setting pan (%d) on rhythm part", name, midiPan);
+#endif
+	Part::setPan(midiPan);
+}
+
+void Part::setPan(unsigned int midiPan) {
+	// NOTE: Panning is inverted compared to GM.
+
+	if (synth->controlROMFeatures->quirkPanMult) {
+		// MT-32: Divide by 9
+		patchTemp->panpot = Bit8u(midiPan / 9);
+	} else {
+		// CM-32L: Divide by 8.5
+		patchTemp->panpot = Bit8u((midiPan << 3) / 68);
+	}
+
+	//synth->printDebug("%s (%s): Set pan to %d", name, currentInstr, panpot);
+}
+
+/**
+ * Applies key shift to a MIDI key and converts it into an internal key value in the range 12-108.
+ */
+unsigned int Part::midiKeyToKey(unsigned int midiKey) {
+	if (synth->controlROMFeatures->quirkKeyShift) {
+		// NOTE: On MT-32 GEN0, key isn't adjusted, and keyShift is applied further in TVP, unlike newer units:
+		return midiKey;
+	}
+	int key = midiKey + patchTemp->patch.keyShift;
+	if (key < 36) {
+		// After keyShift is applied, key < 36, so move up by octaves
+		while (key < 36) {
+			key += 12;
+		}
+	} else if (key > 132) {
+		// After keyShift is applied, key > 132, so move down by octaves
+		while (key > 132) {
+			key -= 12;
+		}
+	}
+	key -= 24;
+	return key;
+}
+
+void RhythmPart::noteOn(unsigned int midiKey, unsigned int velocity) {
+	if (midiKey < 24 || midiKey > 108) { /*> 87 on MT-32)*/
+		synth->printDebug("%s: Attempted to play invalid key %d (velocity %d)", name, midiKey, velocity);
+		return;
+	}
+	synth->rhythmNotePlayed();
+	unsigned int key = midiKey;
+	unsigned int drumNum = key - 24;
+	int drumTimbreNum = rhythmTemp[drumNum].timbre;
+	const int drumTimbreCount = 64 + synth->controlROMMap->timbreRCount; // 94 on MT-32, 128 on LAPC-I/CM32-L
+	if (drumTimbreNum == 127 || drumTimbreNum >= drumTimbreCount) { // timbre #127 is OFF, no sense to play it
+		synth->printDebug("%s: Attempted to play unmapped key %d (velocity %d)", name, midiKey, velocity);
+		return;
+	}
+	// CONFIRMED: Two special cases described by Mok
+	if (drumTimbreNum == 64 + 6) {
+		noteOff(0);
+		key = 1;
+	} else if (drumTimbreNum == 64 + 7) {
+		// This noteOff(0) is not performed on MT-32, only LAPC-I
+		noteOff(0);
+		key = 0;
+	}
+	int absTimbreNum = drumTimbreNum + 128;
+	TimbreParam *timbre = &synth->mt32ram.timbres[absTimbreNum].timbre;
+	memcpy(currentInstr, timbre->common.name, 10);
+	if (drumCache[drumNum][0].dirty) {
+		cacheTimbre(drumCache[drumNum], timbre);
+	}
+#if MT32EMU_MONITOR_INSTRUMENTS > 0
+	synth->printDebug("%s (%s): Start poly (drum %d, timbre %d): midiKey %u, key %u, velo %u, mod %u, exp %u, bend %u", name, currentInstr, drumNum, absTimbreNum, midiKey, key, velocity, modulation, expression, pitchBend);
+#if MT32EMU_MONITOR_INSTRUMENTS > 1
+	// According to info from Mok, keyShift does not appear to affect anything on rhythm part on LAPC-I, but may do on MT-32 - needs investigation
+	synth->printDebug(" Patch: (timbreGroup %u), (timbreNum %u), (keyShift %u), fineTune %u, benderRange %u, assignMode %u, (reverbSwitch %u)", patchTemp->patch.timbreGroup, patchTemp->patch.timbreNum, patchTemp->patch.keyShift, patchTemp->patch.fineTune, patchTemp->patch.benderRange, patchTemp->patch.assignMode, patchTemp->patch.reverbSwitch);
+	synth->printDebug(" PatchTemp: outputLevel %u, (panpot %u)", patchTemp->outputLevel, patchTemp->panpot);
+	synth->printDebug(" RhythmTemp: timbre %u, outputLevel %u, panpot %u, reverbSwitch %u", rhythmTemp[drumNum].timbre, rhythmTemp[drumNum].outputLevel, rhythmTemp[drumNum].panpot, rhythmTemp[drumNum].reverbSwitch);
+#endif
+#endif
+	playPoly(drumCache[drumNum], &rhythmTemp[drumNum], midiKey, key, velocity);
+}
+
+void Part::noteOn(unsigned int midiKey, unsigned int velocity) {
+	unsigned int key = midiKeyToKey(midiKey);
+	if (patchCache[0].dirty) {
+		cacheTimbre(patchCache, timbreTemp);
+	}
+#if MT32EMU_MONITOR_INSTRUMENTS > 0
+	synth->printDebug("%s (%s): Start poly: midiKey %u, key %u, velo %u, mod %u, exp %u, bend %u", name, currentInstr, midiKey, key, velocity, modulation, expression, pitchBend);
+#if MT32EMU_MONITOR_INSTRUMENTS > 1
+	synth->printDebug(" Patch: timbreGroup %u, timbreNum %u, keyShift %u, fineTune %u, benderRange %u, assignMode %u, reverbSwitch %u", patchTemp->patch.timbreGroup, patchTemp->patch.timbreNum, patchTemp->patch.keyShift, patchTemp->patch.fineTune, patchTemp->patch.benderRange, patchTemp->patch.assignMode, patchTemp->patch.reverbSwitch);
+	synth->printDebug(" PatchTemp: outputLevel %u, panpot %u", patchTemp->outputLevel, patchTemp->panpot);
+#endif
+#endif
+	playPoly(patchCache, NULL, midiKey, key, velocity);
+}
+
+bool Part::abortFirstPoly(unsigned int key) {
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		if (poly->getKey() == key) {
+			return poly->startAbort();
+		}
+	}
+	return false;
+}
+
+bool Part::abortFirstPoly(PolyState polyState) {
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		if (poly->getState() == polyState) {
+			return poly->startAbort();
+		}
+	}
+	return false;
+}
+
+bool Part::abortFirstPolyPreferHeld() {
+	if (abortFirstPoly(POLY_Held)) {
+		return true;
+	}
+	return abortFirstPoly();
+}
+
+bool Part::abortFirstPoly() {
+	if (activePolys.isEmpty()) {
+		return false;
+	}
+	return activePolys.getFirst()->startAbort();
+}
+
+void Part::playPoly(const PatchCache cache[4], const MemParams::RhythmTemp *rhythmTemp, unsigned int midiKey, unsigned int key, unsigned int velocity) {
+	// CONFIRMED: Even in single-assign mode, we don't abort playing polys if the timbre to play is completely muted.
+	unsigned int needPartials = cache[0].partialCount;
+	if (needPartials == 0) {
+		synth->printDebug("%s (%s): Completely muted instrument", name, currentInstr);
+		return;
+	}
+
+	if ((patchTemp->patch.assignMode & 2) == 0) {
+		// Single-assign mode
+		abortFirstPoly(key);
+		if (synth->isAbortingPoly()) return;
+	}
+
+	if (!synth->partialManager->freePartials(needPartials, partNum)) {
+#if MT32EMU_MONITOR_PARTIALS > 0
+		synth->printDebug("%s (%s): Insufficient free partials to play key %d (velocity %d); needed=%d, free=%d, assignMode=%d", name, currentInstr, midiKey, velocity, needPartials, synth->partialManager->getFreePartialCount(), patchTemp->patch.assignMode);
+		synth->printPartialUsage();
+#endif
+		synth->getReportHandler3()->onNoteOnIgnored(needPartials, synth->partialManager->getFreePartialCount());
+		return;
+	}
+	if (synth->isAbortingPoly()) {
+		synth->getReportHandler3()->onPlayingPolySilenced(needPartials, synth->partialManager->getFreePartialCount());
+		return;
+	}
+
+	Poly *poly = synth->partialManager->assignPolyToPart(this);
+	if (poly == NULL) {
+		synth->printDebug("%s (%s): No free poly to play key %d (velocity %d)", name, currentInstr, midiKey, velocity);
+		return;
+	}
+	if (patchTemp->patch.assignMode & 1) {
+		// Priority to data first received
+		activePolys.prepend(poly);
+	} else {
+		activePolys.append(poly);
+	}
+
+	Partial *partials[4];
+	for (int x = 0; x < 4; x++) {
+		if (cache[x].playPartial) {
+			partials[x] = synth->partialManager->allocPartial(partNum);
+			activePartialCount++;
+		} else {
+			partials[x] = NULL;
+		}
+	}
+	poly->reset(key, velocity, cache[0].sustain, partials);
+
+	for (int x = 0; x < 4; x++) {
+		if (partials[x] != NULL) {
+#if MT32EMU_MONITOR_PARTIALS > 2
+			synth->printDebug("%s (%s): Allocated partial %d", name, currentInstr, partials[x]->debugGetPartialNum());
+#endif
+			partials[x]->startPartial(this, poly, &cache[x], rhythmTemp, partials[cache[x].structurePair]);
+		}
+	}
+#if MT32EMU_MONITOR_PARTIALS > 1
+	synth->printPartialUsage();
+#endif
+	synth->reportHandler->onPolyStateChanged(Bit8u(partNum));
+}
+
+void Part::allNotesOff() {
+	// The MIDI specification states - and Mok confirms - that all notes off (0x7B)
+	// should treat the hold pedal as usual.
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		// FIXME: This has special handling of key 0 in NoteOff that Mok has not yet confirmed applies to AllNotesOff.
+		// if (poly->canSustain() || poly->getKey() == 0) {
+		// FIXME: The real devices are found to be ignoring non-sustaining polys while processing AllNotesOff. Need to be confirmed.
+		if (poly->canSustain()) {
+			poly->noteOff(holdpedal);
+		}
+	}
+}
+
+void Part::allSoundOff() {
+	// MIDI "All sound off" (0x78) should release notes immediately regardless of the hold pedal.
+	// This controller is not actually implemented by the synths, though (according to the docs and Mok) -
+	// we're only using this method internally.
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		poly->startDecay();
+	}
+}
+
+void Part::stopPedalHold() {
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		poly->stopPedalHold();
+	}
+}
+
+void RhythmPart::noteOff(unsigned int midiKey) {
+	stopNote(midiKey);
+}
+
+void Part::noteOff(unsigned int midiKey) {
+	stopNote(midiKeyToKey(midiKey));
+}
+
+void Part::stopNote(unsigned int key) {
+#if MT32EMU_MONITOR_INSTRUMENTS > 0
+	synth->printDebug("%s (%s): stopping key %d", name, currentInstr, key);
+#endif
+
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		// Generally, non-sustaining instruments ignore note off. They die away eventually anyway.
+		// Key 0 (only used by special cases on rhythm part) reacts to note off even if non-sustaining or pedal held.
+		if (poly->getKey() == key && (poly->canSustain() || key == 0)) {
+			if (poly->noteOff(holdpedal && key != 0)) {
+				break;
+			}
+		}
+	}
+}
+
+const MemParams::PatchTemp *Part::getPatchTemp() const {
+	return patchTemp;
+}
+
+unsigned int Part::getActivePartialCount() const {
+	return activePartialCount;
+}
+
+const Poly *Part::getFirstActivePoly() const {
+	return activePolys.getFirst();
+}
+
+unsigned int Part::getActiveNonReleasingPartialCount() const {
+	unsigned int activeNonReleasingPartialCount = 0;
+	for (Poly *poly = activePolys.getFirst(); poly != NULL; poly = poly->getNext()) {
+		if (poly->getState() != POLY_Releasing) {
+			activeNonReleasingPartialCount += poly->getActivePartialCount();
+		}
+	}
+	return activeNonReleasingPartialCount;
+}
+
+Synth *Part::getSynth() const {
+	return synth;
+}
+
+void Part::partialDeactivated(Poly *poly) {
+	activePartialCount--;
+	if (!poly->isActive()) {
+		activePolys.remove(poly);
+		synth->partialManager->polyFreed(poly);
+		synth->reportHandler->onPolyStateChanged(Bit8u(partNum));
+	}
+}
+
+void RhythmPart::polyStateChanged(PolyState, PolyState) {}
+
+void Part::polyStateChanged(PolyState oldState, PolyState newState) {
+	switch (newState) {
+	case POLY_Playing:
+		if (activeNonReleasingPolyCount++ == 0) synth->voicePartStateChanged(partNum, true);
+		break;
+	case POLY_Releasing:
+	case POLY_Inactive:
+		if (oldState == POLY_Playing || oldState == POLY_Held) {
+			if (--activeNonReleasingPolyCount == 0) synth->voicePartStateChanged(partNum, false);
+		}
+		break;
+	default:
+		break;
+	}
+#ifdef MT32EMU_TRACE_POLY_STATE_CHANGES
+	synth->printDebug("Part %d: Changed poly state %d->%d, activeNonReleasingPolyCount=%d", partNum, oldState, newState, activeNonReleasingPolyCount);
+#endif
+}
+
+PolyList::PolyList() : firstPoly(NULL), lastPoly(NULL) {}
+
+bool PolyList::isEmpty() const {
+#ifdef MT32EMU_POLY_LIST_DEBUG
+	if ((firstPoly == NULL || lastPoly == NULL) && firstPoly != lastPoly) {
+		printf("PolyList: desynchronised firstPoly & lastPoly pointers\n");
+	}
+#endif
+	return firstPoly == NULL && lastPoly == NULL;
+}
+
+Poly *PolyList::getFirst() const {
+	return firstPoly;
+}
+
+Poly *PolyList::getLast() const {
+	return lastPoly;
+}
+
+void PolyList::prepend(Poly *poly) {
+#ifdef MT32EMU_POLY_LIST_DEBUG
+	if (poly->getNext() != NULL) {
+		printf("PolyList: Non-NULL next field in a Poly being prepended is ignored\n");
+	}
+#endif
+	poly->setNext(firstPoly);
+	firstPoly = poly;
+	if (lastPoly == NULL) {
+		lastPoly = poly;
+	}
+}
+
+void PolyList::append(Poly *poly) {
+#ifdef MT32EMU_POLY_LIST_DEBUG
+	if (poly->getNext() != NULL) {
+		printf("PolyList: Non-NULL next field in a Poly being appended is ignored\n");
+	}
+#endif
+	poly->setNext(NULL);
+	if (lastPoly != NULL) {
+#ifdef MT32EMU_POLY_LIST_DEBUG
+		if (lastPoly->getNext() != NULL) {
+			printf("PolyList: Non-NULL next field in the lastPoly\n");
+		}
+#endif
+		lastPoly->setNext(poly);
+	}
+	lastPoly = poly;
+	if (firstPoly == NULL) {
+		firstPoly = poly;
+	}
+}
+
+Poly *PolyList::takeFirst() {
+	Poly *oldFirst = firstPoly;
+	firstPoly = oldFirst->getNext();
+	if (firstPoly == NULL) {
+#ifdef MT32EMU_POLY_LIST_DEBUG
+		if (lastPoly != oldFirst) {
+			printf("PolyList: firstPoly != lastPoly in a list with a single Poly\n");
+		}
+#endif
+		lastPoly = NULL;
+	}
+	oldFirst->setNext(NULL);
+	return oldFirst;
+}
+
+void PolyList::remove(Poly * const polyToRemove) {
+	if (polyToRemove == firstPoly) {
+		takeFirst();
+		return;
+	}
+	for (Poly *poly = firstPoly; poly != NULL; poly = poly->getNext()) {
+		if (poly->getNext() == polyToRemove) {
+			if (polyToRemove == lastPoly) {
+#ifdef MT32EMU_POLY_LIST_DEBUG
+				if (lastPoly->getNext() != NULL) {
+					printf("PolyList: Non-NULL next field in the lastPoly\n");
+				}
+#endif
+				lastPoly = poly;
+			}
+			poly->setNext(polyToRemove->getNext());
+			polyToRemove->setNext(NULL);
+			break;
+		}
+	}
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/Part.h
+++ b/vendor/munt/src/Part.h
@@ -1,0 +1,162 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2025 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_PART_H
+#define MT32EMU_PART_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Types.h"
+#include "Structures.h"
+
+namespace MT32Emu {
+
+class Poly;
+class Synth;
+
+class PolyList {
+private:
+	Poly *firstPoly;
+	Poly *lastPoly;
+
+public:
+	PolyList();
+	bool isEmpty() const;
+	Poly *getFirst() const;
+	Poly *getLast() const;
+	void prepend(Poly *poly);
+	void append(Poly *poly);
+	Poly *takeFirst();
+	void remove(Poly * const poly);
+};
+
+class Part {
+private:
+	// Direct pointer to sysex-addressable memory dedicated to this part (valid for parts 1-8, NULL for rhythm)
+	TimbreParam *timbreTemp;
+
+	// 0=Part 1, .. 7=Part 8, 8=Rhythm
+	unsigned int partNum;
+
+	bool holdpedal;
+
+	unsigned int activePartialCount;
+	unsigned int activeNonReleasingPolyCount;
+	PatchCache patchCache[4];
+	PolyList activePolys;
+
+	void setPatch(const PatchParam *patch);
+	unsigned int midiKeyToKey(unsigned int midiKey);
+
+	bool abortFirstPoly(unsigned int key);
+
+protected:
+	Synth *synth;
+	// Direct pointer into sysex-addressable memory
+	MemParams::PatchTemp *patchTemp;
+	char name[8]; // "Part 1".."Part 8", "Rhythm"
+	char currentInstr[11];
+	// Values outside the valid range 0..100 imply no override.
+	Bit8u volumeOverride;
+	Bit8u modulation;
+	Bit8u expression;
+	Bit32s pitchBend;
+	bool nrpn;
+	Bit16u rpn;
+	Bit16u pitchBenderRange; // (patchTemp->patch.benderRange * 683) at the time of the last MIDI program change or MIDI data entry.
+
+	void backupCacheToPartials(PatchCache cache[4]);
+	void cacheTimbre(PatchCache cache[4], const TimbreParam *timbre);
+	void playPoly(const PatchCache cache[4], const MemParams::RhythmTemp *rhythmTemp, unsigned int midiKey, unsigned int key, unsigned int velocity);
+	void stopNote(unsigned int key);
+	const char *getName() const;
+
+public:
+	static const Part *getPart(Synth &synth, Bit8u partNum);
+
+	Part(Synth *synth, unsigned int usePartNum);
+	virtual ~Part();
+	void reset();
+	void setDataEntryMSB(unsigned char midiDataEntryMSB);
+	void setNRPN();
+	void setRPNLSB(unsigned char midiRPNLSB);
+	void setRPNMSB(unsigned char midiRPNMSB);
+	void resetAllControllers();
+	virtual void noteOn(unsigned int midiKey, unsigned int velocity);
+	virtual void noteOff(unsigned int midiKey);
+	void allNotesOff();
+	void allSoundOff();
+	Bit8u getVolume() const; // Effective output level, valid range 0..100.
+	void setVolume(unsigned int midiVolume); // Valid range 0..127, as defined for MIDI controller 7.
+	Bit8u getVolumeOverride() const;
+	void setVolumeOverride(Bit8u volumeOverride);
+	Bit8u getModulation() const;
+	void setModulation(unsigned int midiModulation);
+	Bit8u getExpression() const;
+	void setExpression(unsigned int midiExpression);
+	virtual void setPan(unsigned int midiPan);
+	Bit32s getPitchBend() const;
+	void setBend(unsigned int midiBend);
+	virtual void setProgram(unsigned int midiProgram);
+	void setHoldPedal(bool pedalval);
+	void stopPedalHold();
+	void updatePitchBenderRange();
+	virtual void refresh();
+	virtual void refreshTimbre(unsigned int absTimbreNum);
+	virtual void resetTimbre();
+	virtual unsigned int getAbsTimbreNum() const;
+	const char *getCurrentInstr() const;
+	const Poly *getFirstActivePoly() const;
+	unsigned int getActivePartialCount() const;
+	unsigned int getActiveNonReleasingPartialCount() const;
+	Synth *getSynth() const;
+
+	const MemParams::PatchTemp *getPatchTemp() const;
+
+	// This should only be called by Poly
+	void partialDeactivated(Poly *poly);
+	virtual void polyStateChanged(PolyState oldState, PolyState newState);
+
+	// These are rather specialised, and should probably only be used by PartialManager
+	bool abortFirstPoly(PolyState polyState);
+	// Abort the first poly in PolyState_HELD, or if none exists, the first active poly in any state.
+	bool abortFirstPolyPreferHeld();
+	bool abortFirstPoly();
+}; // class Part
+
+class RhythmPart: public Part {
+	// Pointer to the area of the MT-32's memory dedicated to rhythm
+	const MemParams::RhythmTemp *rhythmTemp;
+
+	// This caches the timbres/settings in use by the rhythm part
+	PatchCache drumCache[85][4];
+public:
+	RhythmPart(Synth *synth, unsigned int usePartNum);
+	void refresh();
+	void refreshTimbre(unsigned int timbreNum);
+	void resetTimbre();
+	void noteOn(unsigned int key, unsigned int velocity);
+	void noteOff(unsigned int midiKey);
+	unsigned int getAbsTimbreNum() const;
+	void setPan(unsigned int midiPan);
+	void setProgram(unsigned int patchNum);
+	void polyStateChanged(PolyState oldState, PolyState newState);
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_PART_H

--- a/vendor/munt/src/Partial.cpp
+++ b/vendor/munt/src/Partial.cpp
@@ -1,0 +1,425 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "internals.h"
+
+#include "Partial.h"
+#include "Part.h"
+#include "PartialManager.h"
+#include "Poly.h"
+#include "Synth.h"
+#include "Tables.h"
+#include "TVA.h"
+#include "TVF.h"
+#include "TVP.h"
+
+namespace MT32Emu {
+
+static const Bit8u PAN_NUMERATOR_MASTER[] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7};
+static const Bit8u PAN_NUMERATOR_SLAVE[]  = {0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7};
+
+static const Bit8u *pulseWidth100To255;
+
+// We assume the pan is applied using the same 13-bit multiplier circuit that is also used for ring modulation
+// because of the observed sample overflow, so the panSetting values are likely mapped in a similar way via a LUT.
+// FIXME: Sample analysis suggests that the use of panSetting is linear, but there are some quirks that still need to be resolved.
+static Bit32s getPanFactor(Bit32s panSetting) {
+	static const Bit32u PAN_FACTORS_COUNT = 15;
+	static Bit32s PAN_FACTORS[PAN_FACTORS_COUNT];
+	static bool firstRun = true;
+
+	if (firstRun) {
+		firstRun = false;
+		for (Bit32u i = 1; i < PAN_FACTORS_COUNT; i++) {
+			PAN_FACTORS[i] = Bit32s(0.5 + i * 8192.0 / double(PAN_FACTORS_COUNT - 1));
+		}
+	}
+	return PAN_FACTORS[panSetting];
+}
+
+static bool initTables() {
+	const Tables &tables = Tables::getInstance();
+	pulseWidth100To255 = tables.pulseWidth100To255;
+	LA32IntPartialPair::initTables(tables);
+	LA32FloatPartialPair::initTables(tables);
+	LA32Ramp::initTables(tables);
+	TVA::initTables(tables);
+	TVF::initTables(tables);
+	return true;
+}
+
+static void ensureTables() {
+	static const bool initialised = initTables();
+	(void)initialised;
+}
+
+Partial::Partial(Synth *useSynth, int usePartialIndex) :
+	synth(useSynth), partialIndex(usePartialIndex), sampleNum(0),
+	floatMode(useSynth->getSelectedRendererType() == RendererType_FLOAT) {
+	ensureTables();
+	// Initialisation of tva, tvp and tvf uses 'this' pointer
+	// and thus should not be in the initializer list to avoid a compiler warning
+	tva = new TVA(this, &ampRamp);
+	tvp = new TVP(this);
+	tvf = new TVF(this, &cutoffModifierRamp);
+	ownerPart = -1;
+	poly = NULL;
+	pair = NULL;
+	switch (synth->getSelectedRendererType()) {
+	case RendererType_BIT16S:
+		la32Pair = new LA32IntPartialPair;
+		break;
+	case RendererType_FLOAT:
+		la32Pair = new LA32FloatPartialPair;
+		break;
+	default:
+		la32Pair = NULL;
+	}
+}
+
+Partial::~Partial() {
+	delete la32Pair;
+	delete tva;
+	delete tvp;
+	delete tvf;
+}
+
+// Only used for debugging purposes
+int Partial::debugGetPartialNum() const {
+	return partialIndex;
+}
+
+// Only used for debugging purposes
+Bit32u Partial::debugGetSampleNum() const {
+	return sampleNum;
+}
+
+int Partial::getOwnerPart() const {
+	return ownerPart;
+}
+
+bool Partial::isActive() const {
+	return ownerPart > -1;
+}
+
+const Poly *Partial::getPoly() const {
+	return poly;
+}
+
+void Partial::activate(int part) {
+	// This just marks the partial as being assigned to a part
+	ownerPart = part;
+}
+
+void Partial::deactivate() {
+	if (!isActive()) {
+		return;
+	}
+	ownerPart = -1;
+	synth->partialManager->partialDeactivated(partialIndex);
+	if (poly != NULL) {
+		poly->partialDeactivated(this);
+	}
+#if MT32EMU_MONITOR_PARTIALS > 2
+	synth->printDebug("[+%lu] [Partial %d] Deactivated", sampleNum, partialIndex);
+	synth->printPartialUsage(sampleNum);
+#endif
+	if (isRingModulatingSlave()) {
+		pair->la32Pair->deactivate(LA32PartialPair::SLAVE);
+	} else {
+		la32Pair->deactivate(LA32PartialPair::MASTER);
+		if (hasRingModulatingSlave()) {
+			pair->deactivate();
+			pair = NULL;
+		}
+	}
+	if (pair != NULL) {
+		pair->pair = NULL;
+	}
+}
+
+void Partial::startPartial(const Part *part, Poly *usePoly, const PatchCache *usePatchCache, const MemParams::RhythmTemp *rhythmTemp, Partial *pairPartial) {
+	if (usePoly == NULL || usePatchCache == NULL) {
+		synth->printDebug("[Partial %d] *** Error: Starting partial for owner %d, usePoly=%s, usePatchCache=%s", partialIndex, ownerPart, usePoly == NULL ? "*** NULL ***" : "OK", usePatchCache == NULL ? "*** NULL ***" : "OK");
+		return;
+	}
+	patchCache = usePatchCache;
+	poly = usePoly;
+	mixType = patchCache->structureMix;
+	structurePosition = patchCache->structurePosition;
+
+	Bit8u panSetting = rhythmTemp != NULL ? rhythmTemp->panpot : part->getPatchTemp()->panpot;
+	if (mixType == 3) {
+		if (structurePosition == 0) {
+			panSetting = PAN_NUMERATOR_MASTER[panSetting] << 1;
+		} else {
+			panSetting = PAN_NUMERATOR_SLAVE[panSetting] << 1;
+		}
+		// Do a normal mix independent of any pair partial.
+		mixType = 0;
+		pairPartial = NULL;
+	} else if (!synth->isNicePanningEnabled()) {
+		// Mok wanted an option for smoother panning, and we love Mok.
+		// CONFIRMED by Mok: exactly bytes like this (right shifted) are sent to the LA32.
+		panSetting &= 0x0E;
+	}
+
+	leftPanValue = synth->reversedStereoEnabled ? 14 - panSetting : panSetting;
+	rightPanValue = 14 - leftPanValue;
+
+	if (!floatMode) {
+		leftPanValue = getPanFactor(leftPanValue);
+		rightPanValue = getPanFactor(rightPanValue);
+	}
+
+	// SEMI-CONFIRMED: From sample analysis:
+	// Found that timbres with 3 or 4 partials (i.e. one using two partial pairs) are mixed in two different ways.
+	// Either partial pairs are added or subtracted, it depends on how the partial pairs are allocated.
+	// It seems that partials are grouped into quarters and if the partial pairs are allocated in different quarters the subtraction happens.
+	// Though, this matters little for the majority of timbres, it becomes crucial for timbres which contain several partials that sound very close.
+	// In this case that timbre can sound totally different depending on the way it is mixed up.
+	// Most easily this effect can be displayed with the help of a special timbre consisting of several identical square wave partials (3 or 4).
+	// Say, it is 3-partial timbre. Just play any two notes simultaneously and the polys very probably are mixed differently.
+	// Moreover, the partial allocator retains the last partial assignment it did and all the subsequent notes will sound the same as the last released one.
+	// The situation is better with 4-partial timbres since then a whole quarter is assigned for each poly. However, if a 3-partial timbre broke the normal
+	// whole-quarter assignment or after some partials got aborted, even 4-partial timbres can be found sounding differently.
+	// This behaviour is also confirmed with two more special timbres: one with identical sawtooth partials, and one with PCM wave 02.
+	// For my personal taste, this behaviour rather enriches the sounding and should be emulated.
+	if (!synth->isNicePartialMixingEnabled() && (partialIndex & 4)) {
+		leftPanValue = -leftPanValue;
+		rightPanValue = -rightPanValue;
+	}
+
+	if (patchCache->PCMPartial) {
+		pcmNum = patchCache->pcm;
+		if (synth->controlROMMap->pcmCount > 128) {
+			// CM-32L, etc. support two "banks" of PCMs, selectable by waveform type parameter.
+			if (patchCache->waveform > 1) {
+				pcmNum += 128;
+			}
+		}
+		pcmWave = &synth->pcmWaves[pcmNum];
+	} else {
+		pcmWave = NULL;
+	}
+
+	// CONFIRMED: pulseWidthVal calculation is based on information from Mok
+	pulseWidthVal = (poly->getVelocity() - 64) * (patchCache->srcPartial.wg.pulseWidthVeloSensitivity - 7) + pulseWidth100To255[patchCache->srcPartial.wg.pulseWidth];
+	if (pulseWidthVal < 0) {
+		pulseWidthVal = 0;
+	} else if (pulseWidthVal > 255) {
+		pulseWidthVal = 255;
+	}
+
+	pair = pairPartial;
+	alreadyOutputed = false;
+	tva->reset(part, patchCache->partialParam, rhythmTemp);
+	tvp->reset(part, patchCache->partialParam);
+	tvf->reset(patchCache->partialParam, tvp->getBasePitch());
+
+	LA32PartialPair::PairType pairType;
+	LA32PartialPair *useLA32Pair;
+	if (isRingModulatingSlave()) {
+		pairType = LA32PartialPair::SLAVE;
+		useLA32Pair = pair->la32Pair;
+	} else {
+		pairType = LA32PartialPair::MASTER;
+		la32Pair->init(hasRingModulatingSlave(), mixType == 1);
+		useLA32Pair = la32Pair;
+	}
+	if (isPCM()) {
+		useLA32Pair->initPCM(pairType, &synth->pcmROMData[pcmWave->addr], pcmWave->len, pcmWave->loop);
+	} else {
+		useLA32Pair->initSynth(pairType, (patchCache->waveform & 1) != 0, pulseWidthVal, patchCache->srcPartial.tvf.resonance + 1);
+	}
+	if (!hasRingModulatingSlave()) {
+		la32Pair->deactivate(LA32PartialPair::SLAVE);
+	}
+}
+
+Bit32u Partial::getAmpValue() {
+	// SEMI-CONFIRMED: From sample analysis:
+	// (1) Tested with a single partial playing PCM wave 77 with pitchCoarse 36 and no keyfollow, velocity follow, etc.
+	// This gives results within +/- 2 at the output (before any DAC bitshifting)
+	// when sustaining at levels 156 - 255 with no modifiers.
+	// (2) Tested with a special square wave partial (internal capture ID tva5) at TVA envelope levels 155-255.
+	// This gives deltas between -1 and 0 compared to the real output. Note that this special partial only produces
+	// positive amps, so negative still needs to be explored, as well as lower levels.
+	//
+	// Also still partially unconfirmed is the behaviour when ramping between levels, as well as the timing.
+	// TODO: The tests above were performed using the float model, to be refined
+	Bit32u ampRampVal = 67117056 - ampRamp.nextValue();
+	if (ampRamp.checkInterrupt()) {
+		tva->handleInterrupt();
+	}
+	return ampRampVal;
+}
+
+Bit32u Partial::getCutoffValue() {
+	if (isPCM()) {
+		return 0;
+	}
+	Bit32u cutoffModifierRampVal = cutoffModifierRamp.nextValue();
+	if (cutoffModifierRamp.checkInterrupt()) {
+		tvf->handleInterrupt();
+	}
+	return (tvf->getBaseCutoff() << 18) + cutoffModifierRampVal;
+}
+
+bool Partial::hasRingModulatingSlave() const {
+	return pair != NULL && structurePosition == 0 && (mixType == 1 || mixType == 2);
+}
+
+bool Partial::isRingModulatingSlave() const {
+	return pair != NULL && structurePosition == 1 && (mixType == 1 || mixType == 2);
+}
+
+bool Partial::isRingModulatingNoMix() const {
+	return pair != NULL && ((structurePosition == 1 && mixType == 1) || mixType == 2);
+}
+
+bool Partial::isPCM() const {
+	return pcmWave != NULL;
+}
+
+const ControlROMPCMStruct *Partial::getControlROMPCMStruct() const {
+	if (pcmWave != NULL) {
+		return pcmWave->controlROMPCMStruct;
+	}
+	return NULL;
+}
+
+Synth *Partial::getSynth() const {
+	return synth;
+}
+
+TVA *Partial::getTVA() const {
+	return tva;
+}
+
+void Partial::backupCache(const PatchCache &cache) {
+	if (patchCache == &cache) {
+		cachebackup = cache;
+		patchCache = &cachebackup;
+	}
+}
+
+bool Partial::canProduceOutput() {
+	if (!isActive() || alreadyOutputed || isRingModulatingSlave()) {
+		return false;
+	}
+	if (poly == NULL) {
+		synth->printDebug("[Partial %d] *** ERROR: poly is NULL at Partial::produceOutput()!", partialIndex);
+		return false;
+	}
+	return true;
+}
+
+template <class LA32PairImpl>
+bool Partial::generateNextSample(LA32PairImpl *la32PairImpl) {
+	if (!tva->isPlaying() || !la32PairImpl->isActive(LA32PartialPair::MASTER)) {
+		deactivate();
+		return false;
+	}
+	la32PairImpl->generateNextSample(LA32PartialPair::MASTER, getAmpValue(), tvp->nextPitch(), getCutoffValue());
+	if (hasRingModulatingSlave()) {
+		la32PairImpl->generateNextSample(LA32PartialPair::SLAVE, pair->getAmpValue(), pair->tvp->nextPitch(), pair->getCutoffValue());
+		if (!pair->tva->isPlaying() || !la32PairImpl->isActive(LA32PartialPair::SLAVE)) {
+			pair->deactivate();
+			if (mixType == 2) {
+				deactivate();
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+void Partial::produceAndMixSample(IntSample *&leftBuf, IntSample *&rightBuf, LA32IntPartialPair *la32IntPair) {
+	IntSampleEx sample = la32IntPair->nextOutSample();
+
+	// FIXME: LA32 may produce distorted sound in case if the absolute value of maximal amplitude of the input exceeds 8191
+	// when the panning value is non-zero. Most probably the distortion occurs in the same way it does with ring modulation,
+	// and it seems to be caused by limited precision of the common multiplication circuit.
+	// From analysis of this overflow, it is obvious that the right channel output is actually found
+	// by subtraction of the left channel output from the input.
+	// Though, it is unknown whether this overflow is exploited somewhere.
+
+	IntSampleEx leftOut = ((sample * leftPanValue) >> 13) + IntSampleEx(*leftBuf);
+	IntSampleEx rightOut = ((sample * rightPanValue) >> 13) + IntSampleEx(*rightBuf);
+	*(leftBuf++) = Synth::clipSampleEx(leftOut);
+	*(rightBuf++) = Synth::clipSampleEx(rightOut);
+}
+
+void Partial::produceAndMixSample(FloatSample *&leftBuf, FloatSample *&rightBuf, LA32FloatPartialPair *la32FloatPair) {
+	FloatSample sample = la32FloatPair->nextOutSample();
+	FloatSample leftOut = (sample * leftPanValue) / 14.0f;
+	FloatSample rightOut = (sample * rightPanValue) / 14.0f;
+	*(leftBuf++) += leftOut;
+	*(rightBuf++) += rightOut;
+}
+
+template <class Sample, class LA32PairImpl>
+bool Partial::doProduceOutput(Sample *leftBuf, Sample *rightBuf, Bit32u length, LA32PairImpl *la32PairImpl) {
+	if (!canProduceOutput()) return false;
+	alreadyOutputed = true;
+
+	for (sampleNum = 0; sampleNum < length; sampleNum++) {
+		if (!generateNextSample(la32PairImpl)) break;
+		produceAndMixSample(leftBuf, rightBuf, la32PairImpl);
+	}
+	sampleNum = 0;
+	return true;
+}
+
+bool Partial::produceOutput(IntSample *leftBuf, IntSample *rightBuf, Bit32u length) {
+	if (floatMode) {
+		synth->printDebug("Partial: Invalid call to produceOutput()! Renderer = %d\n", synth->getSelectedRendererType());
+		return false;
+	}
+	return doProduceOutput(leftBuf, rightBuf, length, static_cast<LA32IntPartialPair *>(la32Pair));
+}
+
+bool Partial::produceOutput(FloatSample *leftBuf, FloatSample *rightBuf, Bit32u length) {
+	if (!floatMode) {
+		synth->printDebug("Partial: Invalid call to produceOutput()! Renderer = %d\n", synth->getSelectedRendererType());
+		return false;
+	}
+	return doProduceOutput(leftBuf, rightBuf, length, static_cast<LA32FloatPartialPair *>(la32Pair));
+}
+
+bool Partial::shouldReverb() {
+	if (!isActive()) {
+		return false;
+	}
+	return patchCache->reverb;
+}
+
+void Partial::startAbort() {
+	// This is called when the partial manager needs to terminate partials for re-use by a new Poly.
+	tva->startAbort();
+}
+
+void Partial::startDecayAll() {
+	tva->startDecay();
+	tvp->startDecay();
+	tvf->startDecay();
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/Partial.h
+++ b/vendor/munt/src/Partial.h
@@ -1,0 +1,131 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_PARTIAL_H
+#define MT32EMU_PARTIAL_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Types.h"
+#include "Structures.h"
+#include "LA32Ramp.h"
+#include "LA32WaveGenerator.h"
+#include "LA32FloatWaveGenerator.h"
+
+namespace MT32Emu {
+
+class Part;
+class Poly;
+class Synth;
+class TVA;
+class TVF;
+class TVP;
+struct ControlROMPCMStruct;
+
+// A partial represents one of up to four waveform generators currently playing within a poly.
+class Partial {
+private:
+	Synth *synth;
+	const int partialIndex; // Index of this Partial in the global partial table
+	// Number of the sample currently being rendered by produceOutput(), or 0 if no run is in progress
+	// This is only kept available for debugging purposes.
+	Bit32u sampleNum;
+
+	// Actually, LA-32 receives only 3 bits as a pan setting, but we abuse these to emulate
+	// the inverted partial mixing as well. Also we double the values (making them correspond
+	// to the panpot range) to enable NicePanning mode, with respect to MoK.
+	Bit32s leftPanValue, rightPanValue;
+
+	int ownerPart; // -1 if unassigned
+	int mixType;
+	int structurePosition; // 0 or 1 of a structure pair
+
+	// Only used for PCM partials
+	int pcmNum;
+	// FIXME: Give this a better name (e.g. pcmWaveInfo)
+	PCMWaveEntry *pcmWave;
+
+	// Final pulse width value, with velfollow applied, matching what is sent to the LA32.
+	// Range: 0-255
+	int pulseWidthVal;
+
+	Poly *poly;
+	Partial *pair;
+
+	TVA *tva;
+	TVP *tvp;
+	TVF *tvf;
+
+	LA32Ramp ampRamp;
+	LA32Ramp cutoffModifierRamp;
+
+	// TODO: This should be owned by PartialPair
+	LA32PartialPair *la32Pair;
+	const bool floatMode;
+
+	const PatchCache *patchCache;
+	PatchCache cachebackup;
+
+	Bit32u getAmpValue();
+	Bit32u getCutoffValue();
+
+	template <class Sample, class LA32PairImpl>
+	bool doProduceOutput(Sample *leftBuf, Sample *rightBuf, Bit32u length, LA32PairImpl *la32PairImpl);
+	bool canProduceOutput();
+	template <class LA32PairImpl>
+	bool generateNextSample(LA32PairImpl *la32PairImpl);
+	void produceAndMixSample(IntSample *&leftBuf, IntSample *&rightBuf, LA32IntPartialPair *la32IntPair);
+	void produceAndMixSample(FloatSample *&leftBuf, FloatSample *&rightBuf, LA32FloatPartialPair *la32FloatPair);
+
+public:
+	bool alreadyOutputed;
+
+	Partial(Synth *synth, int debugPartialNum);
+	~Partial();
+
+	int debugGetPartialNum() const;
+	Bit32u debugGetSampleNum() const;
+
+	int getOwnerPart() const;
+	const Poly *getPoly() const;
+	bool isActive() const;
+	void activate(int part);
+	void deactivate(void);
+	void startPartial(const Part *part, Poly *usePoly, const PatchCache *useCache, const MemParams::RhythmTemp *rhythmTemp, Partial *pairPartial);
+	void startAbort();
+	void startDecayAll();
+	bool shouldReverb();
+	bool isRingModulatingNoMix() const;
+	bool hasRingModulatingSlave() const;
+	bool isRingModulatingSlave() const;
+	bool isPCM() const;
+	const ControlROMPCMStruct *getControlROMPCMStruct() const;
+	Synth *getSynth() const;
+	TVA *getTVA() const;
+
+	void backupCache(const PatchCache &cache);
+
+	// Returns true only if data written to buffer
+	// These functions produce processed stereo samples
+	// made from combining this single partial with its pair, if it has one.
+	bool produceOutput(IntSample *leftBuf, IntSample *rightBuf, Bit32u length);
+	bool produceOutput(FloatSample *leftBuf, FloatSample *rightBuf, Bit32u length);
+}; // class Partial
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_PARTIAL_H

--- a/vendor/munt/src/PartialManager.cpp
+++ b/vendor/munt/src/PartialManager.cpp
@@ -1,0 +1,362 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+#include <cstring>
+
+#include "internals.h"
+
+#include "PartialManager.h"
+#include "Part.h"
+#include "Partial.h"
+#include "Poly.h"
+#include "Synth.h"
+
+namespace MT32Emu {
+
+PartialManager *PartialManager::getPartialManager(Synth &synth) {
+	return synth.partialManager;
+}
+
+PartialManager::PartialManager(Synth *useSynth) {
+	synth = useSynth;
+	parts = useSynth->parts;
+	inactivePartialCount = synth->getPartialCount();
+	partialTable = new Partial *[inactivePartialCount];
+	inactivePartials = new int[inactivePartialCount];
+	freePolys = new Poly *[synth->getPartialCount()];
+	firstFreePolyIndex = 0;
+	for (unsigned int i = 0; i < synth->getPartialCount(); i++) {
+		partialTable[i] = new Partial(synth, i);
+		inactivePartials[i] = inactivePartialCount - i - 1;
+		freePolys[i] = new Poly();
+	}
+}
+
+PartialManager::~PartialManager(void) {
+	for (unsigned int i = 0; i < synth->getPartialCount(); i++) {
+		delete partialTable[i];
+		if (freePolys[i] != NULL) delete freePolys[i];
+	}
+	delete[] partialTable;
+	delete[] inactivePartials;
+	delete[] freePolys;
+}
+
+void PartialManager::clearAlreadyOutputed() {
+	for (unsigned int i = 0; i < synth->getPartialCount(); i++) {
+		partialTable[i]->alreadyOutputed = false;
+	}
+}
+
+bool PartialManager::shouldReverb(int i) {
+	return partialTable[i]->shouldReverb();
+}
+
+bool PartialManager::produceOutput(int i, IntSample *leftBuf, IntSample *rightBuf, Bit32u bufferLength) {
+	return partialTable[i]->produceOutput(leftBuf, rightBuf, bufferLength);
+}
+
+bool PartialManager::produceOutput(int i, FloatSample *leftBuf, FloatSample *rightBuf, Bit32u bufferLength) {
+	return partialTable[i]->produceOutput(leftBuf, rightBuf, bufferLength);
+}
+
+void PartialManager::deactivateAll() {
+	for (unsigned int i = 0; i < synth->getPartialCount(); i++) {
+		partialTable[i]->deactivate();
+	}
+}
+
+unsigned int PartialManager::setReserve(Bit8u *rset) {
+	unsigned int pr = 0;
+	for (int x = 0; x <= 8; x++) {
+		numReservedPartialsForPart[x] = rset[x];
+		pr += rset[x];
+	}
+	return pr;
+}
+
+Partial *PartialManager::allocPartial(int partNum) {
+	if (inactivePartialCount > 0) {
+		Partial *partial = partialTable[inactivePartials[--inactivePartialCount]];
+		partial->activate(partNum);
+		return partial;
+	}
+	synth->printDebug("PartialManager Error: No inactive partials to allocate for part %d, current partial state:\n", partNum);
+	for (Bit32u i = 0; i < synth->getPartialCount(); i++) {
+		const Partial *partial = partialTable[i];
+		synth->printDebug("[Partial %d]: activation=%d, owner part=%d\n", i, partial->isActive(), partial->getOwnerPart());
+	}
+	return NULL;
+}
+
+unsigned int PartialManager::getFreePartialCount() {
+	return inactivePartialCount;
+}
+
+// This function is solely used to gather data for debug output at the moment.
+void PartialManager::getPerPartPartialUsage(unsigned int perPartPartialUsage[9]) {
+	memset(perPartPartialUsage, 0, 9 * sizeof(unsigned int));
+	for (unsigned int i = 0; i < synth->getPartialCount(); i++) {
+		if (partialTable[i]->isActive()) {
+			perPartPartialUsage[partialTable[i]->getOwnerPart()]++;
+		}
+	}
+}
+
+const Poly *PartialManager::getAbortingPoly() {
+	return synth->abortingPoly;
+}
+
+// Finds the lowest-priority part that is exceeding its reserved partial allocation and has a poly
+// in POLY_Releasing, then kills its first releasing poly.
+// Parts with higher priority than minPart are not checked.
+// Assumes that getFreePartials() has been called to make numReservedPartialsForPart up-to-date.
+bool PartialManager::abortFirstReleasingPolyWhereReserveExceeded(int minPart) {
+	if (minPart == 8) {
+		// Rhythm is highest priority
+		minPart = -1;
+	}
+	for (int partNum = 7; partNum >= minPart; partNum--) {
+		int usePartNum = partNum == -1 ? 8 : partNum;
+		if (parts[usePartNum]->getActivePartialCount() > numReservedPartialsForPart[usePartNum]) {
+			// This part has exceeded its reserved partial count.
+			// If it has any releasing polys, kill its first one and we're done.
+			if (parts[usePartNum]->abortFirstPoly(POLY_Releasing)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+// Finds the lowest-priority part that is exceeding its reserved partial allocation and has a poly, then kills
+// its first poly in POLY_Held - or failing that, its first poly in any state.
+// Parts with higher priority than minPart are not checked.
+// Assumes that getFreePartials() has been called to make numReservedPartialsForPart up-to-date.
+bool PartialManager::abortFirstPolyPreferHeldWhereReserveExceeded(int minPart) {
+	if (minPart == 8) {
+		// Rhythm is highest priority
+		minPart = -1;
+	}
+	for (int partNum = 7; partNum >= minPart; partNum--) {
+		int usePartNum = partNum == -1 ? 8 : partNum;
+		if (parts[usePartNum]->getActivePartialCount() > numReservedPartialsForPart[usePartNum]) {
+			// This part has exceeded its reserved partial count.
+			// If it has any polys, kill its first (preferably held) one and we're done.
+			if (parts[usePartNum]->abortFirstPolyPreferHeld()) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+bool PartialManager::abortFirstPolyPreferReleasingThenHeldWhereReserveExceeded(int minPartNum) {
+	for (int candidatePartNum = 7; candidatePartNum >= minPartNum; candidatePartNum--) {
+		if (parts[candidatePartNum]->getActivePartialCount() > numReservedPartialsForPart[candidatePartNum]) {
+			return abortFirstPolyOnPartPreferReleasingThenHeld(candidatePartNum);
+		}
+	}
+	return false;
+}
+
+bool PartialManager::abortFirstPolyOnPartPreferReleasingThenHeld(int partNum) {
+	if (parts[partNum]->abortFirstPoly(POLY_Releasing)) {
+		return true;
+	}
+	return parts[partNum]->abortFirstPolyPreferHeld();
+}
+
+bool PartialManager::freePartials(unsigned int needed, int partNum) {
+	// NOTE: Currently, we don't consider peculiarities of partial allocation when a timbre involves structures with ring modulation.
+
+	if (synth->controlROMFeatures->newGenNoteCancellation) {
+		return freePartialsNewGen(needed, partNum);
+	}
+
+	while (!synth->isAbortingPoly() && getFreePartialCount() < needed) {
+		if (parts[partNum]->getActiveNonReleasingPartialCount() + needed > numReservedPartialsForPart[partNum]) {
+			// If priority is given to earlier polys, there's nothing we can do.
+			if (synth->getPart(partNum)->getPatchTemp()->patch.assignMode & 1) return false;
+
+			if (needed <= numReservedPartialsForPart[partNum]) {
+				// No more partials needed than reserved for this part, only attempt to free partials on the same part.
+				abortFirstPolyOnPartPreferReleasingThenHeld(partNum);
+				continue;
+			}
+
+			// More partials desired than reserved, try to borrow some from parts with lesser priority.
+			// NOTE: there's a bug here in the old-gen program, so that the device exhibits undefined behaviour when trying to play
+			// a note on the rhythm part beyond the reserve while none of the voice parts has exceeded their reserve.
+			// We don't emulate this here, assuming that the intention was to traverse all voice parts, then check the rhythm part.
+			if (abortFirstPolyPreferReleasingThenHeldWhereReserveExceeded(partNum < 8 ? partNum : 0)) continue;
+
+			// At this point, old-gen devices try to borrow partials from the rhythm part if it's exceeding the reservation.
+			if (parts[8]->getActivePartialCount() > numReservedPartialsForPart[8]
+				&& abortFirstPolyOnPartPreferReleasingThenHeld(8)) continue;
+
+			// Alas, this one will be muted.
+			return false;
+		}
+
+		// OK, we're not going to exceed the reserve. Reclaim our partials from other parts starting from 7 to 0.
+		if (abortFirstPolyPreferReleasingThenHeldWhereReserveExceeded(0)) continue;
+
+		// Now try the rhythm part.
+		if (parts[8]->getActivePartialCount() > numReservedPartialsForPart[8]
+			&& abortFirstPolyOnPartPreferReleasingThenHeld(8)) continue;
+
+		// Lastly, try to silence a poly on this part.
+		if (abortFirstPolyOnPartPreferReleasingThenHeld(partNum)) continue;
+
+		// Fair enough, there's no room for it.
+		return false;
+	}
+	return true;
+}
+
+bool PartialManager::freePartialsNewGen(unsigned int needed, int partNum) {
+	// CONFIRMED: Barring bugs, this matches the real LAPC-I according to information from Mok.
+
+	// BUG: There's a bug in the LAPC-I implementation:
+	// When allocating for rhythm part, or when allocating for a part that is using fewer partials than it has reserved,
+	// held and playing polys on the rhythm part can potentially be aborted before releasing polys on the rhythm part.
+	// This bug isn't present on MT-32.
+	// I consider this to be a bug because I think that playing polys should always have priority over held polys,
+	// and held polys should always have priority over releasing polys.
+
+	// NOTE: This code generally aborts polys in parts (according to certain conditions) in the following order:
+	// 7, 6, 5, 4, 3, 2, 1, 0, 8 (rhythm)
+	// (from lowest priority, meaning most likely to have polys aborted, to highest priority, meaning least likely)
+
+	if (needed == 0) {
+		return true;
+	}
+
+	if (getFreePartialCount() >= needed) {
+		return true;
+	}
+
+	for (;;) {
+		// Abort releasing polys in non-rhythm parts that have exceeded their partial reservation (working backwards from part 7)
+		if (!abortFirstReleasingPolyWhereReserveExceeded(0)) {
+			break;
+		}
+		if (synth->isAbortingPoly() || getFreePartialCount() >= needed) {
+			return true;
+		}
+	}
+
+	if (parts[partNum]->getActiveNonReleasingPartialCount() + needed > numReservedPartialsForPart[partNum]) {
+		// With the new partials we're freeing for, we would end up using more partials than we have reserved.
+		if (synth->getPart(partNum)->getPatchTemp()->patch.assignMode & 1) {
+			// Priority is given to earlier polys, so just give up
+			return false;
+		}
+		// Only abort held polys in the target part and parts that have a lower priority
+		// (higher part number = lower priority, except for rhythm, which has the highest priority).
+		for (;;) {
+			if (!abortFirstPolyPreferHeldWhereReserveExceeded(partNum)) {
+				break;
+			}
+			if (synth->isAbortingPoly() || getFreePartialCount() >= needed) {
+				return true;
+			}
+		}
+		if (needed > numReservedPartialsForPart[partNum]) {
+			return false;
+		}
+	} else {
+		// At this point, we're certain that we've reserved enough partials to play our poly.
+		// Check all parts from lowest to highest priority to see whether they've exceeded their
+		// reserve, and abort their polys until we have enough free partials or they're within
+		// their reserve allocation.
+		for (;;) {
+			if (!abortFirstPolyPreferHeldWhereReserveExceeded(-1)) {
+				break;
+			}
+			if (synth->isAbortingPoly() || getFreePartialCount() >= needed) {
+				return true;
+			}
+		}
+	}
+
+	// Abort polys in the target part until there are enough free partials for the new one
+	for (;;) {
+		if (!parts[partNum]->abortFirstPolyPreferHeld()) {
+			break;
+		}
+		if (synth->isAbortingPoly() || getFreePartialCount() >= needed) {
+			return true;
+		}
+	}
+
+	// Aww, not enough partials for you.
+	return false;
+}
+
+const Partial *PartialManager::getPartial(unsigned int partialNum) const {
+	if (partialNum > synth->getPartialCount() - 1) {
+		return NULL;
+	}
+	return partialTable[partialNum];
+}
+
+Poly *PartialManager::assignPolyToPart(Part *part) {
+	if (firstFreePolyIndex < synth->getPartialCount()) {
+		Poly *poly = freePolys[firstFreePolyIndex];
+		freePolys[firstFreePolyIndex] = NULL;
+		firstFreePolyIndex++;
+		poly->setPart(part);
+		return poly;
+	}
+	return NULL;
+}
+
+void PartialManager::polyFreed(Poly *poly) {
+	if (0 == firstFreePolyIndex) {
+		synth->printDebug("PartialManager Error: Cannot return freed poly, currently active polys:\n");
+		for (Bit32u partNum = 0; partNum < 9; partNum++) {
+			const Poly *activePoly = synth->getPart(partNum)->getFirstActivePoly();
+			Bit32u polyCount = 0;
+			while (activePoly != NULL) {
+				activePoly = activePoly->getNext();
+				polyCount++;
+			}
+			synth->printDebug("Part: %i, active poly count: %i\n", partNum, polyCount);
+		}
+	} else {
+		firstFreePolyIndex--;
+		freePolys[firstFreePolyIndex] = poly;
+	}
+	poly->setPart(NULL);
+}
+
+void PartialManager::partialDeactivated(int partialIndex) {
+	if (inactivePartialCount < synth->getPartialCount()) {
+		inactivePartials[inactivePartialCount++] = partialIndex;
+		return;
+	}
+	synth->printDebug("PartialManager Error: Cannot return deactivated partial %d, current partial state:\n", partialIndex);
+	for (Bit32u i = 0; i < synth->getPartialCount(); i++) {
+		const Partial *partial = partialTable[i];
+		synth->printDebug("[Partial %d]: activation=%d, owner part=%d\n", i, partial->isActive(), partial->getOwnerPart());
+	}
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/PartialManager.h
+++ b/vendor/munt/src/PartialManager.h
@@ -1,0 +1,73 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_PARTIALMANAGER_H
+#define MT32EMU_PARTIALMANAGER_H
+
+#include "globals.h"
+#include "internals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+class Part;
+class Partial;
+class Poly;
+class Synth;
+
+class PartialManager {
+private:
+	Synth *synth;
+	Part **parts;
+	Poly **freePolys;
+	Partial **partialTable;
+	Bit8u numReservedPartialsForPart[9];
+	Bit32u firstFreePolyIndex;
+	int *inactivePartials; // Holds indices of inactive Partials in the Partial table
+	Bit32u inactivePartialCount;
+
+	bool abortFirstReleasingPolyWhereReserveExceeded(int minPart);
+	bool abortFirstPolyPreferHeldWhereReserveExceeded(int minPart);
+	bool abortFirstPolyPreferReleasingThenHeldWhereReserveExceeded(int minPart);
+	bool abortFirstPolyOnPartPreferReleasingThenHeld(int partNum);
+	bool freePartialsNewGen(unsigned int needed, int partNum);
+
+public:
+	static PartialManager *getPartialManager(Synth &synth);
+
+	PartialManager(Synth *useSynth);
+	~PartialManager();
+	Partial *allocPartial(int partNum);
+	unsigned int getFreePartialCount();
+	void getPerPartPartialUsage(unsigned int perPartPartialUsage[9]);
+	const Poly *getAbortingPoly();
+	bool freePartials(unsigned int needed, int partNum);
+	unsigned int setReserve(Bit8u *rset);
+	void deactivateAll();
+	bool produceOutput(int i, IntSample *leftBuf, IntSample *rightBuf, Bit32u bufferLength);
+	bool produceOutput(int i, FloatSample *leftBuf, FloatSample *rightBuf, Bit32u bufferLength);
+	bool shouldReverb(int i);
+	void clearAlreadyOutputed();
+	const Partial *getPartial(unsigned int partialNum) const;
+	Poly *assignPolyToPart(Part *part);
+	void polyFreed(Poly *poly);
+	void partialDeactivated(int partialIndex);
+}; // class PartialManager
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_PARTIALMANAGER_H

--- a/vendor/munt/src/Poly.cpp
+++ b/vendor/munt/src/Poly.cpp
@@ -1,0 +1,197 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "internals.h"
+
+#include "Poly.h"
+#include "Part.h"
+#include "Partial.h"
+#include "Synth.h"
+
+namespace MT32Emu {
+
+Poly::Poly() {
+	part = NULL;
+	key = 255;
+	velocity = 255;
+	sustain = false;
+	activePartialCount = 0;
+	for (int i = 0; i < 4; i++) {
+		partials[i] = NULL;
+	}
+	state = POLY_Inactive;
+	next = NULL;
+}
+
+void Poly::setPart(Part *usePart) {
+	part = usePart;
+}
+
+void Poly::reset(unsigned int newKey, unsigned int newVelocity, bool newSustain, Partial **newPartials) {
+	if (isActive()) {
+		// This should never happen
+		part->getSynth()->printDebug("Resetting active poly. Active partial count: %i\n", activePartialCount);
+		for (int i = 0; i < 4; i++) {
+			if (partials[i] != NULL && partials[i]->isActive()) {
+				partials[i]->deactivate();
+				activePartialCount--;
+			}
+		}
+		setState(POLY_Inactive);
+	}
+
+	key = newKey;
+	velocity = newVelocity;
+	sustain = newSustain;
+
+	activePartialCount = 0;
+	for (int i = 0; i < 4; i++) {
+		partials[i] = newPartials[i];
+		if (newPartials[i] != NULL) {
+			activePartialCount++;
+			setState(POLY_Playing);
+		}
+	}
+}
+
+bool Poly::noteOff(bool pedalHeld) {
+	// Generally, non-sustaining instruments ignore note off. They die away eventually anyway.
+	// Key 0 (only used by special cases on rhythm part) reacts to note off even if non-sustaining or pedal held.
+	if (state == POLY_Inactive || state == POLY_Releasing) {
+		return false;
+	}
+	if (pedalHeld) {
+		if (state == POLY_Held) {
+			return false;
+		}
+		setState(POLY_Held);
+	} else {
+		startDecay();
+	}
+	return true;
+}
+
+bool Poly::stopPedalHold() {
+	if (state != POLY_Held) {
+		return false;
+	}
+	return startDecay();
+}
+
+bool Poly::startDecay() {
+	if (state == POLY_Inactive || state == POLY_Releasing) {
+		return false;
+	}
+	setState(POLY_Releasing);
+
+	for (int t = 0; t < 4; t++) {
+		Partial *partial = partials[t];
+		if (partial != NULL) {
+			partial->startDecayAll();
+		}
+	}
+	return true;
+}
+
+bool Poly::startAbort() {
+	if (state == POLY_Inactive || part->getSynth()->isAbortingPoly()) {
+		return false;
+	}
+	for (int t = 0; t < 4; t++) {
+		Partial *partial = partials[t];
+		if (partial != NULL) {
+			partial->startAbort();
+			part->getSynth()->abortingPoly = this;
+		}
+	}
+	return true;
+}
+
+void Poly::setState(PolyState newState) {
+	if (state == newState) return;
+	PolyState oldState = state;
+	state = newState;
+	part->polyStateChanged(oldState, newState);
+}
+
+void Poly::backupCacheToPartials(PatchCache cache[4]) {
+	for (int partialNum = 0; partialNum < 4; partialNum++) {
+		Partial *partial = partials[partialNum];
+		if (partial != NULL) {
+			partial->backupCache(cache[partialNum]);
+		}
+	}
+}
+
+/**
+ * Returns the internal key identifier.
+ * For non-rhythm, this is within the range 12 to 108.
+ * For rhythm on MT-32, this is 0 or 1 (special cases) or within the range 24 to 87.
+ * For rhythm on devices with extended PCM sounds (e.g. CM-32L), this is 0, 1 or 24 to 108
+ */
+unsigned int Poly::getKey() const {
+	return key;
+}
+
+unsigned int Poly::getVelocity() const {
+	return velocity;
+}
+
+bool Poly::canSustain() const {
+	return sustain;
+}
+
+PolyState Poly::getState() const {
+	return state;
+}
+
+unsigned int Poly::getActivePartialCount() const {
+	return activePartialCount;
+}
+
+bool Poly::isActive() const {
+	return state != POLY_Inactive;
+}
+
+// This is called by Partial to inform the poly that the Partial has deactivated
+void Poly::partialDeactivated(Partial *partial) {
+	for (int i = 0; i < 4; i++) {
+		if (partials[i] == partial) {
+			partials[i] = NULL;
+			activePartialCount--;
+		}
+	}
+	if (activePartialCount == 0) {
+		setState(POLY_Inactive);
+		if (part->getSynth()->abortingPoly == this) {
+			part->getSynth()->abortingPoly = NULL;
+		}
+	}
+	part->partialDeactivated(this);
+}
+
+Poly *Poly::getNext() const {
+	return next;
+}
+
+void Poly::setNext(Poly *poly) {
+	next = poly;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/Poly.h
+++ b/vendor/munt/src/Poly.h
@@ -1,0 +1,72 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_POLY_H
+#define MT32EMU_POLY_H
+
+#include "globals.h"
+#include "internals.h"
+
+namespace MT32Emu {
+
+class Part;
+class Partial;
+struct PatchCache;
+
+class Poly {
+private:
+	Part *part;
+	unsigned int key;
+	unsigned int velocity;
+	unsigned int activePartialCount;
+	bool sustain;
+
+	PolyState state;
+
+	Partial *partials[4];
+
+	Poly *next;
+
+	void setState(PolyState state);
+
+public:
+	Poly();
+	void setPart(Part *usePart);
+	void reset(unsigned int key, unsigned int velocity, bool sustain, Partial **partials);
+	bool noteOff(bool pedalHeld);
+	bool stopPedalHold();
+	bool startDecay();
+	bool startAbort();
+
+	void backupCacheToPartials(PatchCache cache[4]);
+
+	unsigned int getKey() const;
+	unsigned int getVelocity() const;
+	bool canSustain() const;
+	PolyState getState() const;
+	unsigned int getActivePartialCount() const;
+	bool isActive() const;
+
+	void partialDeactivated(Partial *partial);
+
+	Poly *getNext() const;
+	void setNext(Poly *poly);
+}; // class Poly
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_POLY_H

--- a/vendor/munt/src/ROMInfo.cpp
+++ b/vendor/munt/src/ROMInfo.cpp
@@ -1,0 +1,403 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2024 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+
+#include "internals.h"
+
+#include "File.h"
+#include "ROMInfo.h"
+
+namespace MT32Emu {
+
+namespace {
+
+struct ROMInfoList {
+	const ROMInfo * const *romInfos;
+	const Bit32u itemCount;
+};
+
+struct ROMInfoLists {
+	ROMInfoList mt32_1_04;
+	ROMInfoList mt32_1_05;
+	ROMInfoList mt32_1_06;
+	ROMInfoList mt32_1_07;
+	ROMInfoList mt32_bluer;
+	ROMInfoList mt32_2_03;
+	ROMInfoList mt32_2_04;
+	ROMInfoList mt32_2_06;
+	ROMInfoList mt32_2_07;
+	ROMInfoList cm32l_1_00;
+	ROMInfoList cm32l_1_02;
+	ROMInfoList cm32ln_1_00;
+	ROMInfoList fullROMInfos;
+	ROMInfoList partialROMInfos;
+	ROMInfoList allROMInfos;
+};
+
+}
+
+#define MT32EMU_CALC_ARRAY_LENGTH(x) Bit32u(sizeof (x) / sizeof *(x) - 1)
+
+static const ROMInfoLists &getROMInfoLists() {
+	static const File::SHA1Digest CTRL_MT32_V1_04_A_SHA1 = "9cd4858014c4e8a9dff96053f784bfaac1092a2e";
+	static const File::SHA1Digest CTRL_MT32_V1_04_B_SHA1 = "fe8db469b5bfeb37edb269fd47e3ce6d91014652";
+	static const File::SHA1Digest CTRL_MT32_V1_04_SHA1 = "5a5cb5a77d7d55ee69657c2f870416daed52dea7";
+	static const File::SHA1Digest CTRL_MT32_V1_05_A_SHA1 = "57a09d80d2f7ca5b9734edbe9645e6e700f83701";
+	static const File::SHA1Digest CTRL_MT32_V1_05_B_SHA1 = "52e3c6666db9ef962591a8ee99be0cde17f3a6b6";
+	static const File::SHA1Digest CTRL_MT32_V1_05_SHA1 = "e17a3a6d265bf1fa150312061134293d2b58288c";
+	static const File::SHA1Digest CTRL_MT32_V1_06_A_SHA1 = "cc83bf23cee533097fb4c7e2c116e43b50ebacc8";
+	static const File::SHA1Digest CTRL_MT32_V1_06_B_SHA1 = "bf4f15666bc46679579498386704893b630c1171";
+	static const File::SHA1Digest CTRL_MT32_V1_06_SHA1 = "a553481f4e2794c10cfe597fef154eef0d8257de";
+	static const File::SHA1Digest CTRL_MT32_V1_07_A_SHA1 = "13f06b38f0d9e0fc050b6503ab777bb938603260";
+	static const File::SHA1Digest CTRL_MT32_V1_07_B_SHA1 = "c55e165487d71fa88bd8c5e9c083bc456c1a89aa";
+	static const File::SHA1Digest CTRL_MT32_V1_07_SHA1 = "b083518fffb7f66b03c23b7eb4f868e62dc5a987";
+	static const File::SHA1Digest CTRL_MT32_BLUER_A_SHA1 = "11a6ae5d8b6ee328b371af7f1e40b82125aa6b4d";
+	static const File::SHA1Digest CTRL_MT32_BLUER_B_SHA1 = "e0934320d7cbb5edfaa29e0d01ae835ef620085b";
+	static const File::SHA1Digest CTRL_MT32_BLUER_SHA1 = "7b8c2a5ddb42fd0732e2f22b3340dcf5360edf92";
+
+	static const File::SHA1Digest CTRL_MT32_V2_03_SHA1 = "5837064c9df4741a55f7c4d8787ac158dff2d3ce";
+	static const File::SHA1Digest CTRL_MT32_V2_04_SHA1 = "2c16432b6c73dd2a3947cba950a0f4c19d6180eb";
+	static const File::SHA1Digest CTRL_MT32_V2_06_SHA1 = "2869cf4c235d671668cfcb62415e2ce8323ad4ed";
+	static const File::SHA1Digest CTRL_MT32_V2_07_SHA1 = "47b52adefedaec475c925e54340e37673c11707c";
+	static const File::SHA1Digest CTRL_CM32L_V1_00_SHA1 = "73683d585cd6948cc19547942ca0e14a0319456d";
+	static const File::SHA1Digest CTRL_CM32L_V1_02_SHA1 = "a439fbb390da38cada95a7cbb1d6ca199cd66ef8";
+	static const File::SHA1Digest CTRL_CM32LN_V1_00_SHA1 = "dc1c5b1b90a4646d00f7daf3679733c7badc7077";
+
+	static const File::SHA1Digest PCM_MT32_L_SHA1 = "3a1e19b0cd4036623fd1d1d11f5f25995585962b";
+	static const File::SHA1Digest PCM_MT32_H_SHA1 = "2cadb99d21a6a4a6f5b61b6218d16e9b43f61d01";
+	static const File::SHA1Digest PCM_MT32_SHA1 = "f6b1eebc4b2d200ec6d3d21d51325d5b48c60252";
+	static const File::SHA1Digest PCM_CM32L_H_SHA1 = "3ad889fde5db5b6437cbc2eb6e305312fec3df93";
+	static const File::SHA1Digest PCM_CM32L_SHA1 = "289cc298ad532b702461bfc738009d9ebe8025ea";
+
+	static ROMInfo CTRL_MT32_V1_04_A = {32768, CTRL_MT32_V1_04_A_SHA1, ROMInfo::Control, "ctrl_mt32_1_04_a", "MT-32 Control v1.04", ROMInfo::Mux0, NULL};
+	static ROMInfo CTRL_MT32_V1_04_B = {32768, CTRL_MT32_V1_04_B_SHA1, ROMInfo::Control, "ctrl_mt32_1_04_b", "MT-32 Control v1.04", ROMInfo::Mux1, &CTRL_MT32_V1_04_A};
+	static ROMInfo CTRL_MT32_V1_04 = {65536, CTRL_MT32_V1_04_SHA1, ROMInfo::Control, "ctrl_mt32_1_04", "MT-32 Control v1.04", ROMInfo::Full, NULL};
+	static ROMInfo CTRL_MT32_V1_05_A = {32768, CTRL_MT32_V1_05_A_SHA1, ROMInfo::Control, "ctrl_mt32_1_05_a", "MT-32 Control v1.05", ROMInfo::Mux0, NULL};
+	static ROMInfo CTRL_MT32_V1_05_B = {32768, CTRL_MT32_V1_05_B_SHA1, ROMInfo::Control, "ctrl_mt32_1_05_b", "MT-32 Control v1.05", ROMInfo::Mux1, &CTRL_MT32_V1_05_A};
+	static ROMInfo CTRL_MT32_V1_05 = {65536, CTRL_MT32_V1_05_SHA1, ROMInfo::Control, "ctrl_mt32_1_05", "MT-32 Control v1.05", ROMInfo::Full, NULL};
+	static ROMInfo CTRL_MT32_V1_06_A = {32768, CTRL_MT32_V1_06_A_SHA1, ROMInfo::Control, "ctrl_mt32_1_06_a", "MT-32 Control v1.06", ROMInfo::Mux0, NULL};
+	static ROMInfo CTRL_MT32_V1_06_B = {32768, CTRL_MT32_V1_06_B_SHA1, ROMInfo::Control, "ctrl_mt32_1_06_b", "MT-32 Control v1.06", ROMInfo::Mux1, &CTRL_MT32_V1_06_A};
+	static ROMInfo CTRL_MT32_V1_06 = {65536, CTRL_MT32_V1_06_SHA1, ROMInfo::Control, "ctrl_mt32_1_06", "MT-32 Control v1.06", ROMInfo::Full, NULL};
+	static ROMInfo CTRL_MT32_V1_07_A = {32768, CTRL_MT32_V1_07_A_SHA1, ROMInfo::Control, "ctrl_mt32_1_07_a", "MT-32 Control v1.07", ROMInfo::Mux0, NULL};
+	static ROMInfo CTRL_MT32_V1_07_B = {32768, CTRL_MT32_V1_07_B_SHA1, ROMInfo::Control, "ctrl_mt32_1_07_b", "MT-32 Control v1.07", ROMInfo::Mux1, &CTRL_MT32_V1_07_A};
+	static ROMInfo CTRL_MT32_V1_07 = {65536, CTRL_MT32_V1_07_SHA1, ROMInfo::Control, "ctrl_mt32_1_07", "MT-32 Control v1.07", ROMInfo::Full, NULL};
+	static ROMInfo CTRL_MT32_BLUER_A = {32768, CTRL_MT32_BLUER_A_SHA1, ROMInfo::Control, "ctrl_mt32_bluer_a", "MT-32 Control BlueRidge", ROMInfo::Mux0, NULL};
+	static ROMInfo CTRL_MT32_BLUER_B = {32768, CTRL_MT32_BLUER_B_SHA1, ROMInfo::Control, "ctrl_mt32_bluer_b", "MT-32 Control BlueRidge", ROMInfo::Mux1, &CTRL_MT32_BLUER_A};
+	static ROMInfo CTRL_MT32_BLUER = {65536, CTRL_MT32_BLUER_SHA1, ROMInfo::Control, "ctrl_mt32_bluer", "MT-32 Control BlueRidge", ROMInfo::Full, NULL};
+
+	static const ROMInfo CTRL_MT32_V2_03 = {131072, CTRL_MT32_V2_03_SHA1, ROMInfo::Control, "ctrl_mt32_2_03", "MT-32 Control v2.03", ROMInfo::Full, NULL};
+	static const ROMInfo CTRL_MT32_V2_04 = {131072, CTRL_MT32_V2_04_SHA1, ROMInfo::Control, "ctrl_mt32_2_04", "MT-32 Control v2.04", ROMInfo::Full, NULL};
+	static const ROMInfo CTRL_MT32_V2_06 = {131072, CTRL_MT32_V2_06_SHA1, ROMInfo::Control, "ctrl_mt32_2_06", "MT-32 Control v2.06", ROMInfo::Full, NULL};
+	static const ROMInfo CTRL_MT32_V2_07 = {131072, CTRL_MT32_V2_07_SHA1, ROMInfo::Control, "ctrl_mt32_2_07", "MT-32 Control v2.07", ROMInfo::Full, NULL};
+	static const ROMInfo CTRL_CM32L_V1_00 = {65536, CTRL_CM32L_V1_00_SHA1, ROMInfo::Control, "ctrl_cm32l_1_00", "CM-32L/LAPC-I Control v1.00", ROMInfo::Full, NULL};
+	static const ROMInfo CTRL_CM32L_V1_02 = {65536, CTRL_CM32L_V1_02_SHA1, ROMInfo::Control, "ctrl_cm32l_1_02", "CM-32L/LAPC-I Control v1.02", ROMInfo::Full, NULL};
+	static const ROMInfo CTRL_CM32LN_V1_00 = {65536, CTRL_CM32LN_V1_00_SHA1, ROMInfo::Control, "ctrl_cm32ln_1_00", "CM-32LN/CM-500/LAPC-N Control v1.00", ROMInfo::Full, NULL};
+
+	static ROMInfo PCM_MT32_L = {262144, PCM_MT32_L_SHA1, ROMInfo::PCM, "pcm_mt32_l", "MT-32 PCM ROM", ROMInfo::FirstHalf, NULL};
+	static ROMInfo PCM_MT32_H = {262144, PCM_MT32_H_SHA1, ROMInfo::PCM, "pcm_mt32_h", "MT-32 PCM ROM", ROMInfo::SecondHalf, &PCM_MT32_L};
+	static ROMInfo PCM_MT32 = {524288, PCM_MT32_SHA1, ROMInfo::PCM, "pcm_mt32", "MT-32 PCM ROM", ROMInfo::Full, NULL};
+	// Alias of PCM_MT32 ROM, only useful for pairing with PCM_CM32L_H.
+	static ROMInfo PCM_CM32L_L = {524288, PCM_MT32_SHA1, ROMInfo::PCM, "pcm_cm32l_l", "CM-32L/CM-64/LAPC-I PCM ROM", ROMInfo::FirstHalf, NULL};
+	static ROMInfo PCM_CM32L_H = {524288, PCM_CM32L_H_SHA1, ROMInfo::PCM, "pcm_cm32l_h", "CM-32L/CM-64/LAPC-I PCM ROM", ROMInfo::SecondHalf, &PCM_CM32L_L};
+	static ROMInfo PCM_CM32L = {1048576, PCM_CM32L_SHA1, ROMInfo::PCM, "pcm_cm32l", "CM-32L/CM-64/LAPC-I PCM ROM", ROMInfo::Full, NULL};
+
+	static const ROMInfo * const FULL_ROM_INFOS[] = {
+		&CTRL_MT32_V1_04,
+		&CTRL_MT32_V1_05,
+		&CTRL_MT32_V1_06,
+		&CTRL_MT32_V1_07,
+		&CTRL_MT32_BLUER,
+		&CTRL_MT32_V2_03,
+		&CTRL_MT32_V2_04,
+		&CTRL_MT32_V2_06,
+		&CTRL_MT32_V2_07,
+		&CTRL_CM32L_V1_00,
+		&CTRL_CM32L_V1_02,
+		&CTRL_CM32LN_V1_00,
+		&PCM_MT32,
+		&PCM_CM32L,
+		NULL
+	};
+	static const ROMInfo * const PARTIAL_ROM_INFOS[] = {
+		&CTRL_MT32_V1_04_A, &CTRL_MT32_V1_04_B,
+		&CTRL_MT32_V1_05_A, &CTRL_MT32_V1_05_B,
+		&CTRL_MT32_V1_06_A, &CTRL_MT32_V1_06_B,
+		&CTRL_MT32_V1_07_A, &CTRL_MT32_V1_07_B,
+		&CTRL_MT32_BLUER_A, &CTRL_MT32_BLUER_B,
+		&PCM_MT32_L, &PCM_MT32_H,
+		&PCM_CM32L_L, &PCM_CM32L_H,
+		NULL
+	};
+	static const ROMInfo *ALL_ROM_INFOS[MT32EMU_CALC_ARRAY_LENGTH(FULL_ROM_INFOS) + MT32EMU_CALC_ARRAY_LENGTH(PARTIAL_ROM_INFOS) + 1];
+
+	if (CTRL_MT32_V1_04_A.pairROMInfo == NULL) {
+		CTRL_MT32_V1_04_A.pairROMInfo = &CTRL_MT32_V1_04_B;
+		CTRL_MT32_V1_05_A.pairROMInfo = &CTRL_MT32_V1_05_B;
+		CTRL_MT32_V1_06_A.pairROMInfo = &CTRL_MT32_V1_06_B;
+		CTRL_MT32_V1_07_A.pairROMInfo = &CTRL_MT32_V1_07_B;
+		CTRL_MT32_BLUER_A.pairROMInfo = &CTRL_MT32_BLUER_B;
+		PCM_MT32_L.pairROMInfo = &PCM_MT32_H;
+		PCM_CM32L_L.pairROMInfo = &PCM_CM32L_H;
+
+		memcpy(&ALL_ROM_INFOS[0], FULL_ROM_INFOS, sizeof FULL_ROM_INFOS);
+		memcpy(&ALL_ROM_INFOS[MT32EMU_CALC_ARRAY_LENGTH(FULL_ROM_INFOS)], PARTIAL_ROM_INFOS, sizeof PARTIAL_ROM_INFOS); // Includes NULL terminator.
+	}
+
+	static const ROMInfo * const MT32_V1_04_ROMS[] = {&CTRL_MT32_V1_04, &PCM_MT32, &CTRL_MT32_V1_04_A, &CTRL_MT32_V1_04_B, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V1_05_ROMS[] = {&CTRL_MT32_V1_05, &PCM_MT32, &CTRL_MT32_V1_05_A, &CTRL_MT32_V1_05_B, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V1_06_ROMS[] = {&CTRL_MT32_V1_06, &PCM_MT32, &CTRL_MT32_V1_06_A, &CTRL_MT32_V1_06_B, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V1_07_ROMS[] = {&CTRL_MT32_V1_07, &PCM_MT32, &CTRL_MT32_V1_07_A, &CTRL_MT32_V1_07_B, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_BLUER_ROMS[] = {&CTRL_MT32_BLUER, &PCM_MT32, &CTRL_MT32_BLUER_A, &CTRL_MT32_BLUER_B, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V2_03_ROMS[] = {&CTRL_MT32_V2_03, &PCM_MT32, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V2_04_ROMS[] = {&CTRL_MT32_V2_04, &PCM_MT32, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V2_06_ROMS[] = {&CTRL_MT32_V2_06, &PCM_MT32, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const MT32_V2_07_ROMS[] = {&CTRL_MT32_V2_07, &PCM_MT32, &PCM_MT32_L, &PCM_MT32_H, NULL};
+	static const ROMInfo * const CM32L_V1_00_ROMS[] = {&CTRL_CM32L_V1_00, &PCM_CM32L, &PCM_CM32L_L, &PCM_CM32L_H, NULL};
+	static const ROMInfo * const CM32L_V1_02_ROMS[] = {&CTRL_CM32L_V1_02, &PCM_CM32L, &PCM_CM32L_L, &PCM_CM32L_H, NULL};
+	static const ROMInfo * const CM32LN_V1_00_ROMS[] = {&CTRL_CM32LN_V1_00, &PCM_CM32L, NULL};
+
+	static const ROMInfoLists romInfoLists = {
+		{MT32_V1_04_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V1_04_ROMS)},
+		{MT32_V1_05_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V1_05_ROMS)},
+		{MT32_V1_06_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V1_06_ROMS)},
+		{MT32_V1_07_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V1_07_ROMS)},
+		{MT32_BLUER_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_BLUER_ROMS)},
+		{MT32_V2_03_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V2_03_ROMS)},
+		{MT32_V2_04_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V2_04_ROMS)},
+		{MT32_V2_06_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V2_06_ROMS)},
+		{MT32_V2_07_ROMS, MT32EMU_CALC_ARRAY_LENGTH(MT32_V2_07_ROMS)},
+		{CM32L_V1_00_ROMS, MT32EMU_CALC_ARRAY_LENGTH(CM32L_V1_00_ROMS)},
+		{CM32L_V1_02_ROMS, MT32EMU_CALC_ARRAY_LENGTH(CM32L_V1_02_ROMS)},
+		{CM32LN_V1_00_ROMS, MT32EMU_CALC_ARRAY_LENGTH(CM32LN_V1_00_ROMS)},
+		{FULL_ROM_INFOS, MT32EMU_CALC_ARRAY_LENGTH(FULL_ROM_INFOS)},
+		{PARTIAL_ROM_INFOS, MT32EMU_CALC_ARRAY_LENGTH(PARTIAL_ROM_INFOS)},
+		{ALL_ROM_INFOS, MT32EMU_CALC_ARRAY_LENGTH(ALL_ROM_INFOS)}
+	};
+	return romInfoLists;
+}
+
+static const ROMInfo * const *getKnownROMInfoList() {
+	return getROMInfoLists().allROMInfos.romInfos;
+}
+
+static const ROMInfo *getKnownROMInfoFromList(Bit32u index) {
+	return getKnownROMInfoList()[index];
+}
+
+const ROMInfo *ROMInfo::getROMInfo(File *file) {
+	return getROMInfo(file, getKnownROMInfoList());
+}
+
+const ROMInfo *ROMInfo::getROMInfo(File *file, const ROMInfo * const *romInfos) {
+	size_t fileSize = file->getSize();
+	for (Bit32u i = 0; romInfos[i] != NULL; i++) {
+		const ROMInfo *romInfo = romInfos[i];
+		if (fileSize == romInfo->fileSize && !strcmp(file->getSHA1(), romInfo->sha1Digest)) {
+			return romInfo;
+		}
+	}
+	return NULL;
+}
+
+void ROMInfo::freeROMInfo(const ROMInfo *romInfo) {
+	(void) romInfo;
+}
+
+const ROMInfo **ROMInfo::getROMInfoList(Bit32u types, Bit32u pairTypes) {
+	Bit32u romCount = getROMInfoLists().allROMInfos.itemCount; // Excludes the NULL terminator.
+	const ROMInfo **romInfoList = new const ROMInfo*[romCount + 1];
+	const ROMInfo **currentROMInList = romInfoList;
+	for (Bit32u i = 0; i < romCount; i++) {
+		const ROMInfo *romInfo = getKnownROMInfoFromList(i);
+		if ((types & (1 << romInfo->type)) && (pairTypes & (1 << romInfo->pairType))) {
+			*currentROMInList++ = romInfo;
+		}
+	}
+	*currentROMInList = NULL;
+	return romInfoList;
+}
+
+void ROMInfo::freeROMInfoList(const ROMInfo **romInfoList) {
+	delete[] romInfoList;
+}
+
+const ROMInfo * const *ROMInfo::getAllROMInfos(Bit32u *itemCount) {
+	if (itemCount != NULL) *itemCount = getROMInfoLists().allROMInfos.itemCount;
+	return getROMInfoLists().allROMInfos.romInfos;
+}
+
+const ROMInfo * const *ROMInfo::getFullROMInfos(Bit32u *itemCount) {
+	if (itemCount != NULL) *itemCount = getROMInfoLists().fullROMInfos.itemCount;
+	return getROMInfoLists().fullROMInfos.romInfos;
+}
+
+const ROMInfo * const *ROMInfo::getPartialROMInfos(Bit32u *itemCount) {
+	if (itemCount != NULL) *itemCount = getROMInfoLists().partialROMInfos.itemCount;
+	return getROMInfoLists().partialROMInfos.romInfos;
+}
+
+static File *appendROMFiles(File *romFileLow, File *romFileHigh) {
+	const Bit8u *romDataLow = romFileLow->getData();
+	const Bit8u *romDataHigh = romFileHigh->getData();
+	size_t partSize = romFileLow->getSize();
+	Bit8u *data = new Bit8u[2 * partSize];
+	memcpy(data, romDataLow, partSize);
+	memcpy(data + partSize, romDataHigh, partSize);
+	return new ArrayFile(data, 2 * partSize);
+}
+
+static File *interleaveROMFiles(File *romFileEven, File *romFileOdd) {
+	const Bit8u *romDataEven = romFileEven->getData();
+	const Bit8u *romDataOdd = romFileOdd->getData();
+	size_t partSize = romFileEven->getSize();
+	Bit8u *data = new Bit8u[2 * partSize];
+	Bit8u *writePtr = data;
+	for (size_t romDataIx = 0; romDataIx < partSize; romDataIx++) {
+		*(writePtr++) = romDataEven[romDataIx];
+		*(writePtr++) = romDataOdd[romDataIx];
+	}
+	return new ArrayFile(data, 2 * partSize);
+}
+
+ROMImage::ROMImage(File *useFile, bool useOwnFile, const ROMInfo * const *romInfos) :
+	file(useFile), ownFile(useOwnFile), romInfo(ROMInfo::getROMInfo(file, romInfos))
+{}
+
+ROMImage::~ROMImage() {
+	ROMInfo::freeROMInfo(romInfo);
+	if (ownFile) {
+		const Bit8u *data = file->getData();
+		delete file;
+		delete[] data;
+	}
+}
+
+const ROMImage *ROMImage::makeROMImage(File *file) {
+	return new ROMImage(file, false, getKnownROMInfoList());
+}
+
+const ROMImage *ROMImage::makeROMImage(File *file, const ROMInfo * const *romInfos) {
+	return new ROMImage(file, false, romInfos);
+}
+
+const ROMImage *ROMImage::makeROMImage(File *file1, File *file2) {
+	const ROMInfo * const *partialROMInfos = getROMInfoLists().partialROMInfos.romInfos;
+	const ROMImage *image1 = makeROMImage(file1, partialROMInfos);
+	const ROMImage *image2 = makeROMImage(file2, partialROMInfos);
+	const ROMImage *fullImage = image1->getROMInfo() == NULL || image2->getROMInfo() == NULL ? NULL : mergeROMImages(image1, image2);
+	freeROMImage(image1);
+	freeROMImage(image2);
+	return fullImage;
+}
+
+void ROMImage::freeROMImage(const ROMImage *romImage) {
+	delete romImage;
+}
+
+static File *mergePartialROMs(const ROMImage *romImage1, const ROMImage *romImage2) {
+	if (romImage1->getROMInfo()->pairROMInfo != romImage2->getROMInfo()) {
+		return NULL;
+	}
+	File *romFile1 = romImage1->getFile();
+	File *romFile2 = romImage2->getFile();
+	switch (romImage1->getROMInfo()->pairType) {
+	case ROMInfo::FirstHalf:
+		return appendROMFiles(romFile1, romFile2);
+	case ROMInfo::SecondHalf:
+		return appendROMFiles(romFile2, romFile1);
+	case ROMInfo::Mux0:
+		return interleaveROMFiles(romFile1, romFile2);
+	case ROMInfo::Mux1:
+		return interleaveROMFiles(romFile2, romFile1);
+	default:
+		break;
+	}
+	return NULL;
+}
+
+const ROMImage *ROMImage::mergeROMImages(const ROMImage *romImage1, const ROMImage *romImage2) {
+	File *mergedFile = mergePartialROMs(romImage1, romImage2);
+	if (mergedFile == NULL) return NULL;
+	const ROMImage *mergedROMImage = new ROMImage(mergedFile, true, getKnownROMInfoList());
+	if (mergedROMImage->romInfo == NULL) {
+		freeROMImage(mergedROMImage);
+		return NULL;
+	}
+	return mergedROMImage;
+}
+
+File *ROMImage::getFile() const {
+	return file;
+}
+
+bool ROMImage::isFileUserProvided() const {
+	return !ownFile;
+}
+
+const ROMInfo *ROMImage::getROMInfo() const {
+	return romInfo;
+}
+
+const MachineConfiguration * const *MachineConfiguration::getAllMachineConfigurations(Bit32u *itemCount) {
+	static const ROMInfoLists &romInfoLists = getROMInfoLists();
+	static const MachineConfiguration MT32_1_04 = MachineConfiguration("mt32_1_04", romInfoLists.mt32_1_04.romInfos, romInfoLists.mt32_1_04.itemCount);
+	static const MachineConfiguration MT32_1_05 = MachineConfiguration("mt32_1_05", romInfoLists.mt32_1_05.romInfos, romInfoLists.mt32_1_05.itemCount);
+	static const MachineConfiguration MT32_1_06 = MachineConfiguration("mt32_1_06", romInfoLists.mt32_1_06.romInfos, romInfoLists.mt32_1_06.itemCount);
+	static const MachineConfiguration MT32_1_07 = MachineConfiguration("mt32_1_07", romInfoLists.mt32_1_07.romInfos, romInfoLists.mt32_1_07.itemCount);
+	static const MachineConfiguration MT32_BLUER = MachineConfiguration("mt32_bluer", romInfoLists.mt32_bluer.romInfos, romInfoLists.mt32_bluer.itemCount);
+	static const MachineConfiguration MT32_2_03 = MachineConfiguration("mt32_2_03", romInfoLists.mt32_2_03.romInfos, romInfoLists.mt32_2_03.itemCount);
+	static const MachineConfiguration MT32_2_04 = MachineConfiguration("mt32_2_04", romInfoLists.mt32_2_04.romInfos, romInfoLists.mt32_2_04.itemCount);
+	static const MachineConfiguration MT32_2_06 = MachineConfiguration("mt32_2_06", romInfoLists.mt32_2_06.romInfos, romInfoLists.mt32_2_06.itemCount);
+	static const MachineConfiguration MT32_2_07 = MachineConfiguration("mt32_2_07", romInfoLists.mt32_2_07.romInfos, romInfoLists.mt32_2_07.itemCount);
+	static const MachineConfiguration CM32L_1_00 = MachineConfiguration("cm32l_1_00", romInfoLists.cm32l_1_00.romInfos, romInfoLists.cm32l_1_00.itemCount);
+	static const MachineConfiguration CM32L_1_02 = MachineConfiguration("cm32l_1_02", romInfoLists.cm32l_1_02.romInfos, romInfoLists.cm32l_1_02.itemCount);
+	static const MachineConfiguration CM32LN_1_00 = MachineConfiguration("cm32ln_1_00", romInfoLists.cm32ln_1_00.romInfos, romInfoLists.cm32ln_1_00.itemCount);
+	static const MachineConfiguration * const MACHINE_CONFIGURATIONS[] = {
+		&MT32_1_04, &MT32_1_05, &MT32_1_06, &MT32_1_07, &MT32_BLUER, &MT32_2_03, &MT32_2_04, &MT32_2_06, &MT32_2_07, &CM32L_1_00, &CM32L_1_02, &CM32LN_1_00, NULL
+	};
+
+	if (itemCount != NULL) *itemCount = MT32EMU_CALC_ARRAY_LENGTH(MACHINE_CONFIGURATIONS);
+	return MACHINE_CONFIGURATIONS;
+}
+
+MachineConfiguration::MachineConfiguration(const char *useMachineID, const ROMInfo * const *useROMInfos, Bit32u useROMInfosCount) :
+	machineID(useMachineID), romInfos(useROMInfos), romInfosCount(useROMInfosCount)
+{}
+
+const char *MachineConfiguration::getMachineID() const {
+	return machineID;
+}
+
+const ROMInfo * const *MachineConfiguration::getCompatibleROMInfos(Bit32u *itemCount) const {
+	if (itemCount != NULL) *itemCount = romInfosCount;
+	return romInfos;
+}
+
+} // namespace MT32Emu
+
+#ifdef MT32EMU_WITH_TESTING
+
+#include "test/TestAccessors.h"
+
+using namespace MT32Emu;
+
+File *Test::mergePartialROMs(const ROMImage *romImage1, const ROMImage *romImage2) {
+	return MT32Emu::mergePartialROMs(romImage1, romImage2);
+}
+
+#endif // #ifdef MT32EMU_WITH_TESTING

--- a/vendor/munt/src/ROMInfo.h
+++ b/vendor/munt/src/ROMInfo.h
@@ -1,0 +1,171 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2024 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_ROMINFO_H
+#define MT32EMU_ROMINFO_H
+
+#include <cstddef>
+
+#include "globals.h"
+#include "File.h"
+
+namespace MT32Emu {
+
+// Defines vital info about ROM file to be used by synth and applications
+
+struct ROMInfo {
+public:
+	size_t fileSize;
+	const File::SHA1Digest &sha1Digest;
+	enum Type {PCM, Control, Reverb} type;
+	const char *shortName;
+	const char *description;
+	enum PairType {
+		// Complete ROM image ready to use with Synth.
+		Full,
+		// ROM image contains data that occupies lower addresses. Needs pairing before use.
+		FirstHalf,
+		// ROM image contains data that occupies higher addresses. Needs pairing before use.
+		SecondHalf,
+		// ROM image contains data that occupies even addresses. Needs pairing before use.
+		Mux0,
+		// ROM image contains data that occupies odd addresses. Needs pairing before use.
+		Mux1
+	} pairType;
+	// NULL for Full images or a pointer to the corresponding other image for pairing.
+	const ROMInfo *pairROMInfo;
+
+	// Returns a ROMInfo struct by inspecting the size and the SHA1 hash of the file
+	// among all the known ROMInfos.
+	MT32EMU_EXPORT static const ROMInfo *getROMInfo(File *file);
+
+	// Returns a ROMInfo struct by inspecting the size and the SHA1 hash of the file
+	// among the ROMInfos listed in the NULL-terminated list romInfos.
+	MT32EMU_EXPORT_V(2.5) static const ROMInfo *getROMInfo(File *file, const ROMInfo * const *romInfos);
+
+	// Currently no-op
+	MT32EMU_EXPORT static void freeROMInfo(const ROMInfo *romInfo);
+
+	// Allows retrieving a NULL-terminated list of ROMInfos for a range of types and pairTypes
+	// (specified by bitmasks)
+	// Useful for GUI/console app to output information on what ROMs it supports
+	// The caller must free the returned list with freeROMInfoList when finished.
+	MT32EMU_EXPORT static const ROMInfo **getROMInfoList(Bit32u types, Bit32u pairTypes);
+
+	// Frees the list of ROMInfos given that has been created by getROMInfoList.
+	MT32EMU_EXPORT static void freeROMInfoList(const ROMInfo **romInfos);
+
+	// Returns an immutable NULL-terminated list of all (full and partial) supported ROMInfos.
+	// For convenience, this method also can fill the number of non-NULL items present in the list
+	// if a non-NULL value is provided in optional argument itemCount.
+	MT32EMU_EXPORT_V(2.5) static const ROMInfo * const *getAllROMInfos(Bit32u *itemCount = NULL);
+	// Returns an immutable NULL-terminated list of all supported full ROMInfos.
+	// For convenience, this method also can fill the number of non-NULL items present in the list
+	// if a non-NULL value is provided in optional argument itemCount.
+	MT32EMU_EXPORT_V(2.5) static const ROMInfo * const *getFullROMInfos(Bit32u *itemCount = NULL);
+	// Returns an immutable NULL-terminated list of all supported partial ROMInfos.
+	// For convenience, this method also can fill the number of non-NULL items present in the list
+	// if a non-NULL value is provided in optional argument itemCount.
+	MT32EMU_EXPORT_V(2.5) static const ROMInfo * const *getPartialROMInfos(Bit32u *itemCount = NULL);
+};
+
+// Synth::open() requires a full control ROMImage and a compatible full PCM ROMImage to work
+
+class ROMImage {
+public:
+	// Creates a ROMImage object given a ROMInfo and a File. Keeps a reference
+	// to the File and ROMInfo given, which must be freed separately by the user
+	// after the ROMImage is freed.
+	// CAVEAT: This method always prefers full ROM images over partial ones.
+	// Because the lower half of CM-32L/CM-64/LAPC-I PCM ROM is essentially the full
+	// MT-32 PCM ROM, it is therefore aliased. In this case a partial image can only be
+	// created by the overridden method makeROMImage(File *, const ROMInfo * const *).
+	MT32EMU_EXPORT static const ROMImage *makeROMImage(File *file);
+
+	// Same as the method above but only permits creation of a ROMImage if the file content
+	// matches one of the ROMs described in a NULL-terminated list romInfos. This list can be
+	// created using e.g. method ROMInfo::getROMInfoList.
+	MT32EMU_EXPORT_V(2.5) static const ROMImage *makeROMImage(File *file, const ROMInfo * const *romInfos);
+
+	// Creates a ROMImage object given a couple of files that contain compatible partial ROM images.
+	// The files aren't referenced by the resulting ROMImage and may be freed anytime afterwards.
+	// The file in the resulting image will be automatically freed along with the ROMImage.
+	// If the given files contain incompatible partial images, NULL is returned.
+	MT32EMU_EXPORT_V(2.5) static const ROMImage *makeROMImage(File *file1, File *file2);
+
+	// Must only be done after all Synths using the ROMImage are deleted
+	MT32EMU_EXPORT static void freeROMImage(const ROMImage *romImage);
+
+	// Checks whether the given ROMImages are pairable and merges them into a full image, if possible.
+	// If the check fails, NULL is returned.
+	MT32EMU_EXPORT_V(2.5) static const ROMImage *mergeROMImages(const ROMImage *romImage1, const ROMImage *romImage2);
+
+	MT32EMU_EXPORT File *getFile() const;
+
+	// Returns true in case this ROMImage is built with a user provided File that has to be deallocated separately.
+	// For a ROMImage created via merging two partial ROMImages, this method returns false.
+	MT32EMU_EXPORT_V(2.5) bool isFileUserProvided() const;
+	MT32EMU_EXPORT const ROMInfo *getROMInfo() const;
+
+private:
+	File * const file;
+	const bool ownFile;
+	const ROMInfo * const romInfo;
+
+	ROMImage(File *file, bool ownFile, const ROMInfo * const *romInfos);
+	~ROMImage();
+
+	// Make ROMIMage an identity class.
+	ROMImage(const ROMImage &);
+	ROMImage &operator=(const ROMImage &);
+};
+
+class MachineConfiguration {
+public:
+	// Returns an immutable NULL-terminated list of all supported machine configurations.
+	// For convenience, this method also can fill the number of non-NULL items present in the list
+	// if a non-NULL value is provided in optional argument itemCount.
+	MT32EMU_EXPORT_V(2.5) static const MachineConfiguration * const *getAllMachineConfigurations(Bit32u *itemCount = NULL);
+
+	// Returns a string identifier of this MachineConfiguration.
+	MT32EMU_EXPORT_V(2.5) const char *getMachineID() const;
+
+	// Returns an immutable NULL-terminated list of ROMInfos that are compatible with this
+	// MachineConfiguration. That means the respective ROMImages can be successfully used together
+	// by the emulation engine. Calling ROMInfo::getROMInfo or ROMImage::makeROMImage with this list
+	// supplied enables identification of all files containing desired ROM images while filtering out
+	// any incompatible ones.
+	// For convenience, this method also can fill the number of non-NULL items present in the list
+	// if a non-NULL value is provided in optional argument itemCount.
+	MT32EMU_EXPORT_V(2.5) const ROMInfo * const *getCompatibleROMInfos(Bit32u *itemCount = NULL) const;
+
+private:
+	const char * const machineID;
+	const ROMInfo * const * const romInfos;
+	const Bit32u romInfosCount;
+
+	MachineConfiguration(const char *machineID, const ROMInfo * const *romInfos, Bit32u romInfosCount);
+
+	// Make MachineConfiguration an identity class.
+	MachineConfiguration(const MachineConfiguration &);
+	~MachineConfiguration() {}
+	MachineConfiguration &operator=(const MachineConfiguration &);
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_ROMINFO_H

--- a/vendor/munt/src/SampleRateConverter.cpp
+++ b/vendor/munt/src/SampleRateConverter.cpp
@@ -1,0 +1,128 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "SampleRateConverter.h"
+
+#if MT32EMU_WITH_LIBSOXR_RESAMPLER
+#include "srchelper/SoxrAdapter.h"
+#elif MT32EMU_WITH_LIBSAMPLERATE_RESAMPLER
+#include "srchelper/SamplerateAdapter.h"
+#elif MT32EMU_WITH_INTERNAL_RESAMPLER
+#include "srchelper/InternalResampler.h"
+#endif
+
+#include "Synth.h"
+
+namespace MT32Emu {
+
+static inline void *createDelegate(Synth &synth, double targetSampleRate, SamplerateConversionQuality quality) {
+#if MT32EMU_WITH_LIBSOXR_RESAMPLER
+	return new SoxrAdapter(synth, targetSampleRate, quality);
+#elif MT32EMU_WITH_LIBSAMPLERATE_RESAMPLER
+	return new SamplerateAdapter(synth, targetSampleRate, quality);
+#elif MT32EMU_WITH_INTERNAL_RESAMPLER
+	return new InternalResampler(synth, targetSampleRate, quality);
+#else
+	(void)synth, (void)targetSampleRate, (void)quality;
+	return NULL;
+#endif
+}
+
+AnalogOutputMode SampleRateConverter::getBestAnalogOutputMode(double targetSampleRate) {
+	if (Synth::getStereoOutputSampleRate(AnalogOutputMode_ACCURATE) < targetSampleRate) {
+		return AnalogOutputMode_OVERSAMPLED;
+	} else if (Synth::getStereoOutputSampleRate(AnalogOutputMode_COARSE) < targetSampleRate) {
+		return AnalogOutputMode_ACCURATE;
+	}
+	return AnalogOutputMode_COARSE;
+}
+
+double SampleRateConverter::getSupportedOutputSampleRate(double desiredSampleRate) {
+#if MT32EMU_WITH_LIBSOXR_RESAMPLER || MT32EMU_WITH_LIBSAMPLERATE_RESAMPLER || MT32EMU_WITH_INTERNAL_RESAMPLER
+	return desiredSampleRate > 0 ? desiredSampleRate : 0;
+#else
+	(void)desiredSampleRate;
+	return 0;
+#endif
+}
+
+SampleRateConverter::SampleRateConverter(Synth &useSynth, double targetSampleRate, SamplerateConversionQuality useQuality) :
+	synthInternalToTargetSampleRateRatio(SAMPLE_RATE / targetSampleRate),
+	useSynthDelegate(useSynth.getStereoOutputSampleRate() == targetSampleRate),
+	srcDelegate(useSynthDelegate ? &useSynth : createDelegate(useSynth, targetSampleRate, useQuality))
+{}
+
+SampleRateConverter::~SampleRateConverter() {
+	if (!useSynthDelegate) {
+#if MT32EMU_WITH_LIBSOXR_RESAMPLER
+		delete static_cast<SoxrAdapter *>(srcDelegate);
+#elif MT32EMU_WITH_LIBSAMPLERATE_RESAMPLER
+		delete static_cast<SamplerateAdapter *>(srcDelegate);
+#elif MT32EMU_WITH_INTERNAL_RESAMPLER
+		delete static_cast<InternalResampler *>(srcDelegate);
+#endif
+	}
+}
+
+void SampleRateConverter::getOutputSamples(float *buffer, unsigned int length) {
+	if (useSynthDelegate) {
+		static_cast<Synth *>(srcDelegate)->render(buffer, length);
+		return;
+	}
+
+#if MT32EMU_WITH_LIBSOXR_RESAMPLER
+	static_cast<SoxrAdapter *>(srcDelegate)->getOutputSamples(buffer, length);
+#elif MT32EMU_WITH_LIBSAMPLERATE_RESAMPLER
+	static_cast<SamplerateAdapter *>(srcDelegate)->getOutputSamples(buffer, length);
+#elif MT32EMU_WITH_INTERNAL_RESAMPLER
+	static_cast<InternalResampler *>(srcDelegate)->getOutputSamples(buffer, length);
+#else
+	Synth::muteSampleBuffer(buffer, length);
+#endif
+}
+
+void SampleRateConverter::getOutputSamples(Bit16s *outBuffer, unsigned int length) {
+	static const unsigned int CHANNEL_COUNT = 2;
+
+	if (useSynthDelegate) {
+		static_cast<Synth *>(srcDelegate)->render(outBuffer, length);
+		return;
+	}
+
+	float floatBuffer[CHANNEL_COUNT * MAX_SAMPLES_PER_RUN];
+	while (length > 0) {
+		const unsigned int size = MAX_SAMPLES_PER_RUN < length ? MAX_SAMPLES_PER_RUN : length;
+		getOutputSamples(floatBuffer, size);
+		float *outs = floatBuffer;
+		float *ends = floatBuffer + CHANNEL_COUNT * size;
+		while (outs < ends) {
+			*(outBuffer++) = Synth::convertSample(*(outs++));
+		}
+		length -= size;
+	}
+}
+
+double SampleRateConverter::convertOutputToSynthTimestamp(double outputTimestamp) const {
+	return outputTimestamp * synthInternalToTargetSampleRateRatio;
+}
+
+double SampleRateConverter::convertSynthToOutputTimestamp(double synthTimestamp) const {
+	return synthTimestamp / synthInternalToTargetSampleRateRatio;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/SampleRateConverter.h
+++ b/vendor/munt/src/SampleRateConverter.h
@@ -1,0 +1,75 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_SAMPLE_RATE_CONVERTER_H
+#define MT32EMU_SAMPLE_RATE_CONVERTER_H
+
+#include "globals.h"
+#include "Types.h"
+#include "Enumerations.h"
+
+namespace MT32Emu {
+
+class Synth;
+
+/* SampleRateConverter class allows to convert the synthesiser output to any desired sample rate.
+ * It processes the completely mixed stereo output signal as it passes the analogue circuit emulation,
+ * so emulating the synthesiser output signal passing further through an ADC.
+ * Several conversion quality options are provided which allow to trade-off the conversion speed vs. the passband width.
+ * All the options except FASTEST guarantee full suppression of the aliasing noise in terms of the 16-bit integer samples.
+ */
+class MT32EMU_EXPORT SampleRateConverter {
+public:
+	// Returns the value of AnalogOutputMode for which the output signal may retain its full frequency spectrum
+	// at the sample rate specified by the targetSampleRate argument.
+	static AnalogOutputMode getBestAnalogOutputMode(double targetSampleRate);
+
+	// Returns the sample rate supported by the sample rate conversion implementation currently in effect
+	// that is closest to the one specified by the desiredSampleRate argument.
+	static double getSupportedOutputSampleRate(double desiredSampleRate);
+
+	// Creates a SampleRateConverter instance that converts output signal from the synth to the given sample rate
+	// with the specified conversion quality.
+	SampleRateConverter(Synth &synth, double targetSampleRate, SamplerateConversionQuality quality);
+	~SampleRateConverter();
+
+	// Fills the provided output buffer with the results of the sample rate conversion.
+	// The input samples are automatically retrieved from the synth as necessary.
+	void getOutputSamples(MT32Emu::Bit16s *buffer, unsigned int length);
+
+	// Fills the provided output buffer with the results of the sample rate conversion.
+	// The input samples are automatically retrieved from the synth as necessary.
+	void getOutputSamples(float *buffer, unsigned int length);
+
+	// Returns the number of samples produced at the internal synth sample rate (32000 Hz)
+	// that correspond to the number of samples at the target sample rate.
+	// Intended to facilitate audio time synchronisation.
+	double convertOutputToSynthTimestamp(double outputTimestamp) const;
+
+	// Returns the number of samples produced at the target sample rate
+	// that correspond to the number of samples at the internal synth sample rate (32000 Hz).
+	// Intended to facilitate audio time synchronisation.
+	double convertSynthToOutputTimestamp(double synthTimestamp) const;
+
+private:
+	const double synthInternalToTargetSampleRateRatio;
+	const bool useSynthDelegate;
+	void * const srcDelegate;
+}; // class SampleRateConverter
+
+} // namespace MT32Emu
+
+#endif // MT32EMU_SAMPLE_RATE_CONVERTER_H

--- a/vendor/munt/src/Structures.h
+++ b/vendor/munt/src/Structures.h
@@ -1,0 +1,271 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_STRUCTURES_H
+#define MT32EMU_STRUCTURES_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+// MT32EMU_MEMADDR() converts from sysex-padded, MT32EMU_SYSEXMEMADDR converts to it
+// Roland provides documentation using the sysex-padded addresses, so we tend to use that in code and output
+#define MT32EMU_MEMADDR(x) ((((x) & 0x7f0000) >> 2) | (((x) & 0x7f00) >> 1) | ((x) & 0x7f))
+#define MT32EMU_SYSEXMEMADDR(x) ((((x) & 0x1FC000) << 2) | (((x) & 0x3F80) << 1) | ((x) & 0x7f))
+
+#ifdef _MSC_VER
+#define  MT32EMU_ALIGN_PACKED __declspec(align(1))
+#else
+#define MT32EMU_ALIGN_PACKED __attribute__((packed))
+#endif
+
+// The following structures represent the MT-32's memory
+// Since sysex allows this memory to be written to in blocks of bytes,
+// we keep this packed so that we can copy data into the various
+// banks directly
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#pragma pack(push, 1)
+#else
+#pragma pack(1)
+#endif
+
+struct TimbreParam {
+	struct CommonParam {
+		char name[10];
+		Bit8u partialStructure12;  // 1 & 2  0-12 (1-13)
+		Bit8u partialStructure34;  // 3 & 4  0-12 (1-13)
+		Bit8u partialMute;  // 0-15 (0000-1111)
+		Bit8u noSustain; // ENV MODE 0-1 (Normal, No sustain)
+	} MT32EMU_ALIGN_PACKED common;
+
+	struct PartialParam {
+		struct WGParam {
+			Bit8u pitchCoarse;  // 0-96 (C1,C#1-C9)
+			Bit8u pitchFine;  // 0-100 (-50 to +50 (cents - confirmed by Mok))
+			Bit8u pitchKeyfollow;  // 0-16 (-1, -1/2, -1/4, 0, 1/8, 1/4, 3/8, 1/2, 5/8, 3/4, 7/8, 1, 5/4, 3/2, 2, s1, s2)
+			Bit8u pitchBenderEnabled;  // 0-1 (OFF, ON)
+			Bit8u waveform; // MT-32: 0-1 (SQU/SAW); LAPC-I: WG WAVEFORM/PCM BANK 0 - 3 (SQU/1, SAW/1, SQU/2, SAW/2)
+			Bit8u pcmWave; // 0-127 (1-128)
+			Bit8u pulseWidth; // 0-100
+			Bit8u pulseWidthVeloSensitivity; // 0-14 (-7 - +7)
+		} MT32EMU_ALIGN_PACKED wg;
+
+		struct PitchEnvParam {
+			Bit8u depth; // 0-10
+			Bit8u veloSensitivity; // 0-100
+			Bit8u timeKeyfollow; // 0-4
+			Bit8u time[4]; // 0-100
+			Bit8u level[5]; // 0-100 (-50 - +50) // [3]: SUSTAIN LEVEL, [4]: END LEVEL
+		} MT32EMU_ALIGN_PACKED pitchEnv;
+
+		struct PitchLFOParam {
+			Bit8u rate; // 0-100
+			Bit8u depth; // 0-100
+			Bit8u modSensitivity; // 0-100
+		} MT32EMU_ALIGN_PACKED pitchLFO;
+
+		struct TVFParam {
+			Bit8u cutoff; // 0-100
+			Bit8u resonance; // 0-30
+			Bit8u keyfollow; // -1, -1/2, -1/4, 0, 1/8, 1/4, 3/8, 1/2, 5/8, 3/4, 7/8, 1, 5/4, 3/2, 2
+			Bit8u biasPoint; // 0-127 (<1A-<7C >1A-7C)
+			Bit8u biasLevel; // 0-14 (-7 - +7)
+			Bit8u envDepth; // 0-100
+			Bit8u envVeloSensitivity; // 0-100
+			Bit8u envDepthKeyfollow; // DEPTH KEY FOLL0W 0-4
+			Bit8u envTimeKeyfollow; // TIME KEY FOLLOW 0-4
+			Bit8u envTime[5]; // 0-100
+			Bit8u envLevel[4]; // 0-100 // [3]: SUSTAIN LEVEL
+		} MT32EMU_ALIGN_PACKED tvf;
+
+		struct TVAParam {
+			Bit8u level; // 0-100
+			Bit8u veloSensitivity; // 0-100
+			Bit8u biasPoint1; // 0-127 (<1A-<7C >1A-7C)
+			Bit8u biasLevel1; // 0-12 (-12 - 0)
+			Bit8u biasPoint2; // 0-127 (<1A-<7C >1A-7C)
+			Bit8u biasLevel2; // 0-12 (-12 - 0)
+			Bit8u envTimeKeyfollow; // TIME KEY FOLLOW 0-4
+			Bit8u envTimeVeloSensitivity; // VELOS KEY FOLL0W 0-4
+			Bit8u envTime[5]; // 0-100
+			Bit8u envLevel[4]; // 0-100 // [3]: SUSTAIN LEVEL
+		} MT32EMU_ALIGN_PACKED tva;
+	} MT32EMU_ALIGN_PACKED partial[4]; // struct PartialParam
+} MT32EMU_ALIGN_PACKED; // struct TimbreParam
+
+struct PatchParam {
+	Bit8u timbreGroup; // TIMBRE GROUP  0-3 (group A, group B, Memory, Rhythm)
+	Bit8u timbreNum; // TIMBRE NUMBER 0-63
+	Bit8u keyShift; // KEY SHIFT 0-48 (-24 - +24 semitones)
+	Bit8u fineTune; // FINE TUNE 0-100 (-50 - +50 cents)
+	Bit8u benderRange; // BENDER RANGE 0-24
+	Bit8u assignMode;  // ASSIGN MODE 0-3 (POLY1, POLY2, POLY3, POLY4)
+	Bit8u reverbSwitch;  // REVERB SWITCH 0-1 (OFF,ON)
+	Bit8u dummy; // (DUMMY)
+} MT32EMU_ALIGN_PACKED;
+
+const unsigned int SYSTEM_MASTER_TUNE_OFF = 0;
+const unsigned int SYSTEM_REVERB_MODE_OFF = 1;
+const unsigned int SYSTEM_REVERB_TIME_OFF = 2;
+const unsigned int SYSTEM_REVERB_LEVEL_OFF = 3;
+const unsigned int SYSTEM_RESERVE_SETTINGS_START_OFF = 4;
+const unsigned int SYSTEM_RESERVE_SETTINGS_END_OFF = 12;
+const unsigned int SYSTEM_CHAN_ASSIGN_START_OFF = 13;
+const unsigned int SYSTEM_CHAN_ASSIGN_END_OFF = 21;
+const unsigned int SYSTEM_MASTER_VOL_OFF = 22;
+
+struct MemParams {
+	// NOTE: The MT-32 documentation only specifies PatchTemp areas for parts 1-8.
+	// The LAPC-I documentation specified an additional area for rhythm at the end,
+	// where all parameters but fine tune, assign mode and output level are ignored
+	struct PatchTemp {
+		PatchParam patch;
+		Bit8u outputLevel; // OUTPUT LEVEL 0-100
+		Bit8u panpot; // PANPOT 0-14 (R-L)
+		Bit8u dummyv[6];
+	} MT32EMU_ALIGN_PACKED patchTemp[9];
+
+	struct RhythmTemp {
+		Bit8u timbre; // TIMBRE  0-94 (M1-M64,R1-30,OFF); LAPC-I: 0-127 (M01-M64,R01-R63)
+		Bit8u outputLevel; // OUTPUT LEVEL 0-100
+		Bit8u panpot; // PANPOT 0-14 (R-L)
+		Bit8u reverbSwitch;  // REVERB SWITCH 0-1 (OFF,ON)
+	} MT32EMU_ALIGN_PACKED rhythmTemp[85];
+
+	TimbreParam timbreTemp[8];
+
+	PatchParam patches[128];
+
+	// NOTE: There are only 30 timbres in the "rhythm" bank for MT-32; the additional 34 are for LAPC-I and above
+	struct PaddedTimbre {
+		TimbreParam timbre;
+		Bit8u padding[10];
+	} MT32EMU_ALIGN_PACKED timbres[64 + 64 + 64 + 64]; // Group A, Group B, Memory, Rhythm
+
+	struct System {
+		Bit8u masterTune; // MASTER TUNE 0-127 432.1-457.6Hz
+		Bit8u reverbMode; // REVERB MODE 0-3 (room, hall, plate, tap delay)
+		Bit8u reverbTime; // REVERB TIME 0-7 (1-8)
+		Bit8u reverbLevel; // REVERB LEVEL 0-7 (1-8)
+		Bit8u reserveSettings[9]; // PARTIAL RESERVE (PART 1) 0-32
+		Bit8u chanAssign[9]; // MIDI CHANNEL (PART1) 0-16 (1-16,OFF)
+		Bit8u masterVol; // MASTER VOLUME 0-100
+	} MT32EMU_ALIGN_PACKED system;
+}; // struct MemParams
+
+struct SoundGroup {
+	Bit8u timbreNumberTableAddrLow;
+	Bit8u timbreNumberTableAddrHigh;
+	Bit8u displayPosition;
+	Bit8u name[9];
+	Bit8u timbreCount;
+	Bit8u pad;
+} MT32EMU_ALIGN_PACKED;
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#pragma pack(pop)
+#else
+#pragma pack()
+#endif
+
+struct ControlROMFeatureSet {
+	unsigned int quirkBasePitchOverflow : 1;
+	unsigned int quirkPitchEnvelopeOverflow : 1;
+	unsigned int quirkRingModulationNoMix : 1;
+	unsigned int quirkTVAZeroEnvLevels : 1;
+	unsigned int quirkPanMult : 1;
+	unsigned int quirkKeyShift : 1;
+	unsigned int quirkTVFBaseCutoffLimit : 1;
+	unsigned int quirkFastPitchChanges : 1;
+	unsigned int quirkDisplayCustomMessagePriority : 1;
+	unsigned int oldMT32DisplayFeatures : 1;
+	unsigned int newGenNoteCancellation : 1;
+
+	// Features below don't actually depend on control ROM version, which is used to identify hardware model
+	unsigned int defaultReverbMT32Compatible : 1;
+	unsigned int oldMT32AnalogLPF : 1;
+};
+
+struct ControlROMMap {
+	const char *shortName;
+	const ControlROMFeatureSet &featureSet;
+	Bit16u pcmTable; // 4 * pcmCount bytes
+	Bit16u pcmCount;
+	Bit16u timbreAMap; // 128 bytes
+	Bit16u timbreAOffset;
+	bool timbreACompressed;
+	Bit16u timbreBMap; // 128 bytes
+	Bit16u timbreBOffset;
+	bool timbreBCompressed;
+	Bit16u timbreRMap; // 2 * timbreRCount bytes
+	Bit16u timbreRCount;
+	Bit16u rhythmSettings; // 4 * rhythmSettingsCount bytes
+	Bit16u rhythmSettingsCount;
+	Bit16u reserveSettings; // 9 bytes
+	Bit16u panSettings; // 8 bytes
+	Bit16u programSettings; // 8 bytes
+	Bit16u rhythmMaxTable; // 4 bytes
+	Bit16u patchMaxTable; // 16 bytes
+	Bit16u systemMaxTable; // 23 bytes
+	Bit16u timbreMaxTable; // 72 bytes
+	Bit16u soundGroupsTable; // 14 bytes each entry
+	Bit16u soundGroupsCount;
+	Bit16u startupMessage; // 20 characters + NULL terminator
+	Bit16u sysexErrorMessage; // 20 characters + NULL terminator
+};
+
+struct ControlROMPCMStruct {
+	Bit8u pos;
+	Bit8u len;
+	Bit8u pitchLSB;
+	Bit8u pitchMSB;
+};
+
+struct PCMWaveEntry {
+	Bit32u addr;
+	Bit32u len;
+	bool loop;
+	ControlROMPCMStruct *controlROMPCMStruct;
+};
+
+// This is basically a per-partial, pre-processed combination of timbre and patch/rhythm settings
+struct PatchCache {
+	bool playPartial;
+	bool PCMPartial;
+	int pcm;
+	Bit8u waveform;
+
+	Bit32u structureMix;
+	int structurePosition;
+	int structurePair;
+
+	// The following fields are actually common to all partials in the timbre
+	bool dirty;
+	Bit32u partialCount;
+	bool sustain;
+	bool reverb;
+
+	TimbreParam::PartialParam srcPartial;
+
+	// The following directly points into live sysex-addressable memory
+	const TimbreParam::PartialParam *partialParam;
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_STRUCTURES_H

--- a/vendor/munt/src/Synth.cpp
+++ b/vendor/munt/src/Synth.cpp
@@ -1,0 +1,2922 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdio>
+
+#include "internals.h"
+
+#include "Synth.h"
+#include "Analog.h"
+#include "BReverbModel.h"
+#include "Display.h"
+#include "File.h"
+#include "MemoryRegion.h"
+#include "MidiEventQueue.h"
+#include "Part.h"
+#include "Partial.h"
+#include "PartialManager.h"
+#include "Poly.h"
+#include "ROMInfo.h"
+#include "SysexBuilder.h"
+#include "TVA.h"
+
+#if MT32EMU_MONITOR_SYSEX > 0
+#include "mmath.h"
+#endif
+
+namespace MT32Emu {
+
+// MIDI interface data transfer rate in samples. Used to simulate the transfer delay.
+static const double MIDI_DATA_TRANSFER_RATE = double(SAMPLE_RATE) / 31250.0 * 8.0;
+
+static const Bit8u DEFAULT_MASTER_VOLUME = 100; // Confirmed
+
+static const ControlROMFeatureSet OLD_MT32_ELDER = {
+	true,  // quirkBasePitchOverflow
+	true,  // quirkPitchEnvelopeOverflow
+	true,  // quirkRingModulationNoMix
+	true,  // quirkTVAZeroEnvLevels
+	true,  // quirkPanMult
+	true,  // quirkKeyShift
+	true,  // quirkTVFBaseCutoffLimit
+	false, // quirkFastPitchChanges
+	true,  // quirkDisplayCustomMessagePriority
+	true,  // oldMT32DisplayFeatures
+	false, // newGenNoteCancellation
+	true,  // defaultReverbMT32Compatible
+	true   // oldMT32AnalogLPF
+};
+static const ControlROMFeatureSet OLD_MT32_LATER = {
+	true,  // quirkBasePitchOverflow
+	true,  // quirkPitchEnvelopeOverflow
+	true,  // quirkRingModulationNoMix
+	true,  // quirkTVAZeroEnvLevels
+	true,  // quirkPanMult
+	true,  // quirkKeyShift
+	true,  // quirkTVFBaseCutoffLimit
+	false, // quirkFastPitchChanges
+	false, // quirkDisplayCustomMessagePriority
+	true,  // oldMT32DisplayFeatures
+	false, // newGenNoteCancellation
+	true,  // defaultReverbMT32Compatible
+	true   // oldMT32AnalogLPF
+};
+static const ControlROMFeatureSet NEW_MT32_COMPATIBLE = {
+	false, // quirkBasePitchOverflow
+	false, // quirkPitchEnvelopeOverflow
+	false, // quirkRingModulationNoMix
+	false, // quirkTVAZeroEnvLevels
+	false, // quirkPanMult
+	false, // quirkKeyShift
+	false, // quirkTVFBaseCutoffLimit
+	false, // quirkFastPitchChanges
+	false, // quirkDisplayCustomMessagePriority
+	false, // oldMT32DisplayFeatures
+	true,  // newGenNoteCancellation
+	false, // defaultReverbMT32Compatible
+	false  // oldMT32AnalogLPF
+};
+static const ControlROMFeatureSet CM32LN_COMPATIBLE = {
+	false, // quirkBasePitchOverflow
+	false, // quirkPitchEnvelopeOverflow
+	false, // quirkRingModulationNoMix
+	false, // quirkTVAZeroEnvLevels
+	false, // quirkPanMult
+	false, // quirkKeyShift
+	false, // quirkTVFBaseCutoffLimit
+	true,  // quirkFastPitchChanges
+	false, // quirkDisplayCustomMessagePriority
+	false, // oldMT32DisplayFeatures
+	true,  // newGenNoteCancellation
+	false, // defaultReverbMT32Compatible
+	false  // oldMT32AnalogLPF
+};
+
+static const ControlROMMap ControlROMMaps[] = {
+	//     ID                Features        PCMmap  PCMc  tmbrA  tmbrAO, tmbrAC tmbrB   tmbrBO  tmbrBC tmbrR   trC rhythm rhyC  rsrv   panpot   prog   rhyMax  patMax  sysMax  timMax  sndGrp sGC  stMsg   sErMsg
+	{"ctrl_mt32_1_04",    OLD_MT32_ELDER,    0x3000, 128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200, 30, 0x73A6, 85, 0x57C7, 0x57E2, 0x57D0, 0x5252, 0x525E, 0x526E, 0x520A, 0x7064, 19, 0x217A, 0x4BB6},
+	{"ctrl_mt32_1_05",    OLD_MT32_ELDER,    0x3000, 128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200, 30, 0x7414, 85, 0x57C7, 0x57E2, 0x57D0, 0x5252, 0x525E, 0x526E, 0x520A, 0x70CA, 19, 0x217A, 0x4BB6},
+	{"ctrl_mt32_1_06",    OLD_MT32_LATER,    0x3000, 128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200, 30, 0x7414, 85, 0x57D9, 0x57F4, 0x57E2, 0x5264, 0x5270, 0x5280, 0x521C, 0x70CA, 19, 0x217A, 0x4BBA},
+	{"ctrl_mt32_1_07",    OLD_MT32_LATER,    0x3000, 128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200, 30, 0x73fe, 85, 0x57B1, 0x57CC, 0x57BA, 0x523C, 0x5248, 0x5258, 0x51F4, 0x70B0, 19, 0x217A, 0x4B92},
+	{"ctrl_mt32_bluer",   OLD_MT32_LATER,    0x3000, 128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200, 30, 0x741C, 85, 0x57E5, 0x5800, 0x57EE, 0x5270, 0x527C, 0x528C, 0x5228, 0x70CE, 19, 0x217A, 0x4BC6},
+	{"ctrl_mt32_2_03",  NEW_MT32_COMPATIBLE, 0x8100, 128, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4F49, 0x4F64, 0x4F52, 0x4885, 0x4889, 0x48A2, 0x48B9, 0x5A44, 19, 0x1EF0, 0x4066},
+	{"ctrl_mt32_2_04",  NEW_MT32_COMPATIBLE, 0x8100, 128, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4F5D, 0x4F78, 0x4F66, 0x4899, 0x489D, 0x48B6, 0x48CD, 0x5A58, 19, 0x1EF0, 0x406D},
+	{"ctrl_mt32_2_06",  NEW_MT32_COMPATIBLE, 0x8100, 128, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4F69, 0x4F84, 0x4F72, 0x48A5, 0x48A9, 0x48C2, 0x48D9, 0x5A64, 19, 0x1EF0, 0x4021},
+	{"ctrl_mt32_2_07",  NEW_MT32_COMPATIBLE, 0x8100, 128, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4F81, 0x4F9C, 0x4F8A, 0x48B9, 0x48BD, 0x48D6, 0x48ED, 0x5A78, 19, 0x1EE7, 0x4035},
+	{"ctrl_cm32l_1_00", NEW_MT32_COMPATIBLE, 0x8100, 256, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4F65, 0x4F80, 0x4F6E, 0x48A1, 0x48A5, 0x48BE, 0x48D5, 0x5A6C, 19, 0x1EF0, 0x401D},
+	{"ctrl_cm32l_1_02", NEW_MT32_COMPATIBLE, 0x8100, 256, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4F93, 0x4FAE, 0x4F9C, 0x48CB, 0x48CF, 0x48E8, 0x48FF, 0x5A96, 19, 0x1EE7, 0x4047},
+	{"ctrl_cm32ln_1_00", CM32LN_COMPATIBLE,  0x8100, 256, 0x8000, 0x8000, true,  0x8080, 0x8000, true,  0x8500, 64, 0x8580, 85, 0x4EC7, 0x4EE2, 0x4ED0, 0x47FF, 0x4803, 0x481C, 0x4833, 0x55A2, 19, 0x1F59, 0x3F7C}
+	// (Note that old MT-32 ROMs actually have 86 entries for rhythmTemp)
+};
+
+static const ControlROMMap *getControlROMMap(const char *shortName) {
+	for (unsigned int i = 0; i < sizeof(ControlROMMaps) / sizeof(ControlROMMaps[0]); i++) {
+		if (strcmp(shortName, ControlROMMaps[i].shortName) == 0) {
+			return &ControlROMMaps[i];
+		}
+	}
+	return NULL;
+}
+
+static const PartialState PARTIAL_PHASE_TO_STATE[8] = {
+	PartialState_ATTACK, PartialState_ATTACK, PartialState_ATTACK, PartialState_ATTACK,
+	PartialState_SUSTAIN, PartialState_SUSTAIN, PartialState_RELEASE, PartialState_INACTIVE
+};
+
+static inline PartialState getPartialState(PartialManager *partialManager, unsigned int partialNum) {
+	const Partial *partial = partialManager->getPartial(partialNum);
+	return partial->isActive() ? PARTIAL_PHASE_TO_STATE[partial->getTVA()->getPhase()] : PartialState_INACTIVE;
+}
+
+template <class I, class O>
+static inline void convertSampleFormat(const I *inBuffer, O *outBuffer, const Bit32u len) {
+	if (inBuffer == NULL || outBuffer == NULL) return;
+
+	const I *inBufferEnd = inBuffer + len;
+	while (inBuffer < inBufferEnd) {
+		*(outBuffer++) = Synth::convertSample(*(inBuffer++));
+	}
+}
+
+class Renderer {
+protected:
+	Synth &synth;
+
+	void printDebug(const char *msg) const {
+		synth.printDebug("%s", msg);
+	}
+
+	bool isActivated() const {
+		return synth.activated;
+	}
+
+	bool isAbortingPoly() const {
+		return synth.isAbortingPoly();
+	}
+
+	Analog &getAnalog() const {
+		return *synth.analog;
+	}
+
+	MidiEventQueue &getMidiQueue() {
+		return *synth.midiQueue;
+	}
+
+	PartialManager &getPartialManager() {
+		return *synth.partialManager;
+	}
+
+	BReverbModel &getReverbModel() {
+		return *synth.reverbModel;
+	}
+
+	Bit32u getRenderedSampleCount() {
+		return synth.renderedSampleCount;
+	}
+
+	void incRenderedSampleCount(const Bit32u count) {
+		synth.renderedSampleCount += count;
+	}
+
+	void updateDisplayState();
+
+public:
+	Renderer(Synth &useSynth) : synth(useSynth) {}
+
+	virtual ~Renderer() {}
+
+	virtual void render(IntSample *stereoStream, Bit32u len) = 0;
+	virtual void render(FloatSample *stereoStream, Bit32u len) = 0;
+	virtual void renderStreams(const DACOutputStreams<IntSample> &streams, Bit32u len) = 0;
+	virtual void renderStreams(const DACOutputStreams<FloatSample> &streams, Bit32u len) = 0;
+};
+
+template <class Sample>
+class RendererImpl : public Renderer {
+	// These buffers are used for building the output streams as they are found at the DAC entrance.
+	// The output is mixed down to stereo interleaved further in the analog circuitry emulation.
+	Sample tmpNonReverbLeft[MAX_SAMPLES_PER_RUN], tmpNonReverbRight[MAX_SAMPLES_PER_RUN];
+	Sample tmpReverbDryLeft[MAX_SAMPLES_PER_RUN], tmpReverbDryRight[MAX_SAMPLES_PER_RUN];
+	Sample tmpReverbWetLeft[MAX_SAMPLES_PER_RUN], tmpReverbWetRight[MAX_SAMPLES_PER_RUN];
+
+	const DACOutputStreams<Sample> tmpBuffers;
+	DACOutputStreams<Sample> createTmpBuffers() {
+		DACOutputStreams<Sample> buffers = {
+			tmpNonReverbLeft, tmpNonReverbRight,
+			tmpReverbDryLeft, tmpReverbDryRight,
+			tmpReverbWetLeft, tmpReverbWetRight
+		};
+		return buffers;
+	}
+
+public:
+	RendererImpl(Synth &useSynth) :
+		Renderer(useSynth),
+		tmpBuffers(createTmpBuffers())
+	{}
+
+	void render(IntSample *stereoStream, Bit32u len);
+	void render(FloatSample *stereoStream, Bit32u len);
+	void renderStreams(const DACOutputStreams<IntSample> &streams, Bit32u len);
+	void renderStreams(const DACOutputStreams<FloatSample> &streams, Bit32u len);
+
+	template <class O>
+	void doRenderAndConvert(O *stereoStream, Bit32u len);
+	void doRender(Sample *stereoStream, Bit32u len);
+
+	template <class O>
+	void doRenderAndConvertStreams(const DACOutputStreams<O> &streams, Bit32u len);
+	void doRenderStreams(const DACOutputStreams<Sample> &streams, Bit32u len);
+	void produceLA32Output(Sample *buffer, Bit32u len);
+	void convertSamplesToOutput(Sample *buffer, Bit32u len);
+	void produceStreams(const DACOutputStreams<Sample> &streams, Bit32u len);
+};
+
+class Extensions {
+public:
+	RendererType selectedRendererType;
+	Bit32s masterTunePitchDelta;
+	Bit8u masterVolumeOverride;
+	bool niceAmpRamp;
+	bool nicePanning;
+	bool nicePartialMixing;
+
+	// Here we keep the reverse mapping of assigned parts per MIDI channel.
+	// NOTE: value above 8 means that the channel is not assigned
+	Bit8u chantable[16][9];
+
+	// This stores the index of Part in chantable that failed to play and required partial abortion.
+	Bit32u abortingPartIx;
+
+	bool preallocatedReverbMemory;
+
+	Bit32u midiEventQueueSize;
+	Bit32u midiEventQueueSysexStorageBufferSize;
+
+	Display *display;
+	bool oldMT32DisplayFeatures;
+
+	ReportHandler3 defaultReportHandler;
+	ReportHandler2 *reportHandler2;
+	ReportHandler3 *reportHandler3;
+};
+
+Bit32u Synth::getLibraryVersionInt() {
+	return MT32EMU_CURRENT_VERSION_INT;
+}
+
+const char *Synth::getLibraryVersionString() {
+	return MT32EMU_VERSION;
+}
+
+Bit8u Synth::calcSysexChecksum(const Bit8u *data, const Bit32u len, const Bit8u initChecksum) {
+	unsigned int checksum = -initChecksum;
+	for (unsigned int i = 0; i < len; i++) {
+		checksum -= data[i];
+	}
+	return Bit8u(checksum & 0x7f);
+}
+
+Bit32u Synth::getStereoOutputSampleRate(AnalogOutputMode analogOutputMode) {
+	static const unsigned int SAMPLE_RATES[] = {SAMPLE_RATE, SAMPLE_RATE, SAMPLE_RATE * 3 / 2, SAMPLE_RATE * 3};
+
+	return SAMPLE_RATES[analogOutputMode];
+}
+
+Synth::Synth(ReportHandler *useReportHandler) :
+	mt32ram(*new MemParams),
+	mt32default(*new MemParams),
+	extensions(*new Extensions)
+{
+	opened = false;
+	reverbOverridden = false;
+	partialCount = DEFAULT_MAX_PARTIALS;
+	controlROMMap = NULL;
+	controlROMFeatures = NULL;
+
+	reportHandler = useReportHandler != NULL ? useReportHandler : &extensions.defaultReportHandler;
+	extensions.reportHandler2 = &extensions.defaultReportHandler;
+	extensions.reportHandler3 = &extensions.defaultReportHandler;
+
+	extensions.preallocatedReverbMemory = false;
+	for (int i = REVERB_MODE_ROOM; i <= REVERB_MODE_TAP_DELAY; i++) {
+		reverbModels[i] = NULL;
+	}
+	reverbModel = NULL;
+	analog = NULL;
+	renderer = NULL;
+	setDACInputMode(DACInputMode_NICE);
+	setMIDIDelayMode(MIDIDelayMode_DELAY_SHORT_MESSAGES_ONLY);
+	setOutputGain(1.0f);
+	setReverbOutputGain(1.0f);
+	setReversedStereoEnabled(false);
+	setMasterVolumeOverride(255);
+	setNiceAmpRampEnabled(true);
+	setNicePanningEnabled(false);
+	setNicePartialMixingEnabled(false);
+	selectRendererType(RendererType_BIT16S);
+
+	patchTempMemoryRegion = NULL;
+	rhythmTempMemoryRegion = NULL;
+	timbreTempMemoryRegion = NULL;
+	patchesMemoryRegion = NULL;
+	timbresMemoryRegion = NULL;
+	systemMemoryRegion = NULL;
+	displayMemoryRegion = NULL;
+	resetMemoryRegion = NULL;
+	paddedTimbreMaxTable = NULL;
+
+	partialManager = NULL;
+	pcmWaves = NULL;
+	pcmROMData = NULL;
+	soundGroupNames = NULL;
+	midiQueue = NULL;
+	extensions.midiEventQueueSize = DEFAULT_MIDI_EVENT_QUEUE_SIZE;
+	extensions.midiEventQueueSysexStorageBufferSize = 0;
+	lastReceivedMIDIEventTimestamp = 0;
+	memset(parts, 0, sizeof(parts));
+	renderedSampleCount = 0;
+	extensions.display = NULL;
+	extensions.oldMT32DisplayFeatures = false;
+}
+
+Synth::~Synth() {
+	close(); // Make sure we're closed and everything is freed
+	delete &mt32ram;
+	delete &mt32default;
+	delete &extensions;
+}
+
+void Synth::setReportHandler2(ReportHandler2 *reportHandler2) {
+	if (reportHandler2 != NULL) {
+		reportHandler = reportHandler2;
+		extensions.reportHandler2 = reportHandler2;
+	} else {
+		reportHandler = &extensions.defaultReportHandler;
+		extensions.reportHandler2 = &extensions.defaultReportHandler;
+	}
+	extensions.reportHandler3 = &extensions.defaultReportHandler;
+}
+
+void Synth::setReportHandler3(ReportHandler3 *reportHandler3) {
+	if (reportHandler3 != NULL) {
+		reportHandler = reportHandler3;
+		extensions.reportHandler2 = reportHandler3;
+		extensions.reportHandler3 = reportHandler3;
+	} else {
+		reportHandler = &extensions.defaultReportHandler;
+		extensions.reportHandler2 = &extensions.defaultReportHandler;
+		extensions.reportHandler3 = &extensions.defaultReportHandler;
+	}
+}
+
+ReportHandler3 *Synth::getReportHandler3() {
+	return extensions.reportHandler3;
+}
+
+void ReportHandler::showLCDMessage(const char *data) {
+	printf("WRITE-LCD: %s\n", data);
+}
+
+void ReportHandler::printDebug(const char *fmt, va_list list) {
+	vprintf(fmt, list);
+	printf("\n");
+}
+
+void Synth::rhythmNotePlayed() const {
+	extensions.display->rhythmNotePlayed();
+}
+
+void Synth::voicePartStateChanged(Bit8u partNum, bool partActivated) const {
+	extensions.display->voicePartStateChanged(partNum, partActivated);
+}
+
+void Synth::newTimbreSet(Bit8u partNum) const {
+	const Part *part = getPart(partNum);
+	reportHandler->onProgramChanged(partNum, getSoundGroupName(part), part->getCurrentInstr());
+}
+
+const char *Synth::getSoundGroupName(const Part *part) const {
+	const PatchParam &patch = part->getPatchTemp()->patch;
+	return getSoundGroupName(patch.timbreGroup, patch.timbreNum);
+}
+
+const char *Synth::getSoundGroupName(Bit8u timbreGroup, Bit8u timbreNumber) const {
+	switch (timbreGroup) {
+	case 1:
+		timbreNumber += 64;
+		// Fall-through
+	case 0:
+		return soundGroupNames[soundGroupIx[timbreNumber]];
+	case 2:
+		return soundGroupNames[controlROMMap->soundGroupsCount - 2];
+	case 3:
+		return soundGroupNames[controlROMMap->soundGroupsCount - 1];
+	default:
+		return NULL;
+	}
+}
+
+#define MT32EMU_PRINT_DEBUG \
+	va_list ap; \
+	va_start(ap, fmt); \
+	reportHandler->printDebug(fmt, ap); \
+	va_end(ap);
+
+#if MT32EMU_DEBUG_SAMPLESTAMPS > 0
+static inline void printSamplestamp(ReportHandler *reportHandler, const char *fmt, ...) {
+	MT32EMU_PRINT_DEBUG
+}
+#endif
+
+void Synth::printDebug(const char *fmt, ...) {
+#if MT32EMU_DEBUG_SAMPLESTAMPS > 0
+	printSamplestamp(reportHandler, "[%u]", renderedSampleCount);
+#endif
+	MT32EMU_PRINT_DEBUG
+}
+
+#undef MT32EMU_PRINT_DEBUG
+
+void Synth::setReverbEnabled(bool newReverbEnabled) {
+	if (!opened) return;
+	if (isReverbEnabled() == newReverbEnabled) return;
+	if (newReverbEnabled) {
+		bool oldReverbOverridden = reverbOverridden;
+		reverbOverridden = false;
+		refreshSystemReverbParameters();
+		reverbOverridden = oldReverbOverridden;
+	} else {
+		if (!extensions.preallocatedReverbMemory) {
+			reverbModel->close();
+		}
+		reverbModel = NULL;
+	}
+}
+
+bool Synth::isReverbEnabled() const {
+	return reverbModel != NULL;
+}
+
+void Synth::setReverbOverridden(bool newReverbOverridden) {
+	reverbOverridden = newReverbOverridden;
+}
+
+bool Synth::isReverbOverridden() const {
+	return reverbOverridden;
+}
+
+void Synth::setReverbCompatibilityMode(bool mt32CompatibleMode) {
+	if (!opened || (isMT32ReverbCompatibilityMode() == mt32CompatibleMode)) return;
+	bool oldReverbEnabled = isReverbEnabled();
+	setReverbEnabled(false);
+	for (int i = REVERB_MODE_ROOM; i <= REVERB_MODE_TAP_DELAY; i++) {
+		delete reverbModels[i];
+	}
+	initReverbModels(mt32CompatibleMode);
+	setReverbEnabled(oldReverbEnabled);
+	setReverbOutputGain(reverbOutputGain);
+}
+
+bool Synth::isMT32ReverbCompatibilityMode() const {
+	return opened && (reverbModels[REVERB_MODE_ROOM]->isMT32Compatible(REVERB_MODE_ROOM));
+}
+
+bool Synth::isDefaultReverbMT32Compatible() const {
+	return opened && controlROMFeatures->defaultReverbMT32Compatible;
+}
+
+void Synth::preallocateReverbMemory(bool enabled) {
+	if (extensions.preallocatedReverbMemory == enabled) return;
+	extensions.preallocatedReverbMemory = enabled;
+	if (!opened) return;
+	for (int i = REVERB_MODE_ROOM; i <= REVERB_MODE_TAP_DELAY; i++) {
+		if (enabled) {
+			reverbModels[i]->open();
+		} else if (reverbModel != reverbModels[i]) {
+			reverbModels[i]->close();
+		}
+	}
+}
+
+void Synth::setDACInputMode(DACInputMode mode) {
+	dacInputMode = mode;
+}
+
+DACInputMode Synth::getDACInputMode() const {
+	return dacInputMode;
+}
+
+void Synth::setMIDIDelayMode(MIDIDelayMode mode) {
+	midiDelayMode = mode;
+}
+
+MIDIDelayMode Synth::getMIDIDelayMode() const {
+	return midiDelayMode;
+}
+
+void Synth::setOutputGain(float newOutputGain) {
+	if (newOutputGain < 0.0f) newOutputGain = -newOutputGain;
+	outputGain = newOutputGain;
+	if (analog != NULL) analog->setSynthOutputGain(newOutputGain);
+}
+
+float Synth::getOutputGain() const {
+	return outputGain;
+}
+
+void Synth::setReverbOutputGain(float newReverbOutputGain) {
+	if (newReverbOutputGain < 0.0f) newReverbOutputGain = -newReverbOutputGain;
+	reverbOutputGain = newReverbOutputGain;
+	if (analog != NULL) analog->setReverbOutputGain(newReverbOutputGain, isMT32ReverbCompatibilityMode());
+}
+
+float Synth::getReverbOutputGain() const {
+	return reverbOutputGain;
+}
+
+void Synth::setMasterVolumeOverride(Bit8u volumeOverride) {
+	extensions.masterVolumeOverride = volumeOverride;
+	if (opened && volumeOverride <= DEFAULT_MASTER_VOLUME) {
+		mt32ram.system.masterVol = volumeOverride;
+		refreshSystemMasterVol();
+	}
+}
+
+Bit8u Synth::getMasterVolumeOverride() const {
+	return extensions.masterVolumeOverride;
+}
+
+void Synth::setPartVolumeOverride(Bit8u partNumber, Bit8u volumeOverride) {
+	if (opened && partNumber < 9) {
+		parts[partNumber]->setVolumeOverride(volumeOverride);
+	}
+}
+
+Bit8u Synth::getPartVolumeOverride(Bit8u partNumber) const {
+	return (!opened || partNumber > 8) ? 255 : parts[partNumber]->getVolumeOverride();
+}
+
+void Synth::setReversedStereoEnabled(bool enabled) {
+	reversedStereoEnabled = enabled;
+}
+
+bool Synth::isReversedStereoEnabled() const {
+	return reversedStereoEnabled;
+}
+
+void Synth::setNiceAmpRampEnabled(bool enabled) {
+	extensions.niceAmpRamp = enabled;
+}
+
+bool Synth::isNiceAmpRampEnabled() const {
+	return extensions.niceAmpRamp;
+}
+
+void Synth::setNicePanningEnabled(bool enabled) {
+	extensions.nicePanning = enabled;
+}
+
+bool Synth::isNicePanningEnabled() const {
+	return extensions.nicePanning;
+}
+
+void Synth::setNicePartialMixingEnabled(bool enabled) {
+	extensions.nicePartialMixing = enabled;
+}
+
+bool Synth::isNicePartialMixingEnabled() const {
+	return extensions.nicePartialMixing;
+}
+
+bool Synth::loadControlROM(const ROMImage &controlROMImage) {
+	File *file = controlROMImage.getFile();
+	const ROMInfo *controlROMInfo = controlROMImage.getROMInfo();
+	if ((controlROMInfo == NULL)
+			|| (controlROMInfo->type != ROMInfo::Control)
+			|| (controlROMInfo->pairType != ROMInfo::Full)) {
+#if MT32EMU_MONITOR_INIT
+		printDebug("Invalid Control ROM Info provided");
+#endif
+		return false;
+	}
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Found Control ROM: %s, %s", controlROMInfo->shortName, controlROMInfo->description);
+#endif
+	const Bit8u *fileData = file->getData();
+	memcpy(controlROMData, fileData, CONTROL_ROM_SIZE);
+
+	// Control ROM successfully loaded, now check whether it's a known type
+	controlROMMap = getControlROMMap(controlROMInfo->shortName);
+	if (controlROMMap == NULL) {
+		controlROMFeatures = NULL;
+#if MT32EMU_MONITOR_INIT
+		printDebug("Control ROM failed to load");
+#endif
+		return false;
+	}
+	controlROMFeatures = &controlROMMap->featureSet;
+	return true;
+}
+
+bool Synth::loadPCMROM(const ROMImage &pcmROMImage) {
+	File *file = pcmROMImage.getFile();
+	const ROMInfo *pcmROMInfo = pcmROMImage.getROMInfo();
+	if ((pcmROMInfo == NULL)
+			|| (pcmROMInfo->type != ROMInfo::PCM)
+			|| (pcmROMInfo->pairType != ROMInfo::Full)) {
+		return false;
+	}
+#if MT32EMU_MONITOR_INIT
+	printDebug("Found PCM ROM: %s, %s", pcmROMInfo->shortName, pcmROMInfo->description);
+#endif
+	size_t fileSize = file->getSize();
+	if (fileSize != (2 * pcmROMSize)) {
+#if MT32EMU_MONITOR_INIT
+		printDebug("PCM ROM file has wrong size (expected %d, got %d)", 2 * pcmROMSize, fileSize);
+#endif
+		return false;
+	}
+	const Bit8u *fileData = file->getData();
+	for (size_t i = 0; i < pcmROMSize; i++) {
+		Bit8u s = *(fileData++);
+		Bit8u c = *(fileData++);
+
+		int order[16] = {0, 9, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 8};
+
+		Bit16s log = 0;
+		for (int u = 0; u < 16; u++) {
+			int bit;
+			if (order[u] < 8) {
+				bit = (s >> (7 - order[u])) & 0x1;
+			} else {
+				bit = (c >> (7 - (order[u] - 8))) & 0x1;
+			}
+			log = log | Bit16s(bit << (15 - u));
+		}
+		pcmROMData[i] = log;
+	}
+	return true;
+}
+
+bool Synth::initPCMList(Bit16u mapAddress, Bit16u count) {
+	ControlROMPCMStruct *tps = reinterpret_cast<ControlROMPCMStruct *>(&controlROMData[mapAddress]);
+	for (int i = 0; i < count; i++) {
+		Bit32u rAddr = tps[i].pos * 0x800;
+		Bit32u rLenExp = (tps[i].len & 0x70) >> 4;
+		Bit32u rLen = 0x800 << rLenExp;
+		if (rAddr + rLen > pcmROMSize) {
+			printDebug("Control ROM error: Wave map entry %d points to invalid PCM address 0x%04X, length 0x%04X", i, rAddr, rLen);
+			return false;
+		}
+		pcmWaves[i].addr = rAddr;
+		pcmWaves[i].len = rLen;
+		pcmWaves[i].loop = (tps[i].len & 0x80) != 0;
+		pcmWaves[i].controlROMPCMStruct = &tps[i];
+		//int pitch = (tps[i].pitchMSB << 8) | tps[i].pitchLSB;
+		//bool unaffectedByMasterTune = (tps[i].len & 0x01) == 0;
+		//printDebug("PCM %d: pos=%d, len=%d, pitch=%d, loop=%s, unaffectedByMasterTune=%s", i, rAddr, rLen, pitch, pcmWaves[i].loop ? "YES" : "NO", unaffectedByMasterTune ? "YES" : "NO");
+	}
+	return false;
+}
+
+bool Synth::initCompressedTimbre(TimbresMemoryRegion &tempRegion, Bit16u absTimbreNum, const Bit8u *src, Bit32u srcLen) {
+	// "Compressed" here means that muted partials aren't present in ROM (except in the case of partial 0 being muted).
+	// Instead the data from the previous unmuted partial is used.
+	if (srcLen < sizeof(TimbreParam::CommonParam)) {
+		return false;
+	}
+	TimbreParam *timbre = &mt32ram.timbres[absTimbreNum].timbre;
+	Bit32u timbreNum = absTimbreNum & 0x3F;
+	tempRegion.write(timbreNum, 0, src, sizeof(TimbreParam::CommonParam), true);
+	unsigned int srcPos = sizeof(TimbreParam::CommonParam);
+	unsigned int memPos = sizeof(TimbreParam::CommonParam);
+	for (int t = 0; t < 4; t++) {
+		if (t != 0 && ((timbre->common.partialMute >> t) & 0x1) == 0x00) {
+			// This partial is muted - we'll copy the previously copied partial, then
+			srcPos -= sizeof(TimbreParam::PartialParam);
+		} else if (srcPos + sizeof(TimbreParam::PartialParam) >= srcLen) {
+			return false;
+		}
+		tempRegion.write(timbreNum, memPos, src + srcPos, sizeof(TimbreParam::PartialParam));
+		srcPos += sizeof(TimbreParam::PartialParam);
+		memPos += sizeof(TimbreParam::PartialParam);
+	}
+	return true;
+}
+
+bool Synth::initTimbres(Bit16u mapAddress, Bit16u offset, Bit16u count, Bit16u startTimbre, bool compressed) {
+	const Bit8u *timbreMap = &controlROMData[mapAddress];
+	// We abuse TimbresMemoryRegion with the sole purpose of clamping the timbre parameters by the max table.
+	TimbresMemoryRegion tempRegion(reinterpret_cast<Bit8u *>(mt32ram.timbres + startTimbre), paddedTimbreMaxTable);
+	Bit16u timbreNum = 0;
+	for (Bit16u i = 0; i < count * 2; i += 2) {
+		Bit16u absTimbreNum = startTimbre + timbreNum;
+		Bit16u address = (timbreMap[i + 1] << 8) | timbreMap[i];
+		if (!compressed && (address + offset + sizeof(TimbreParam) > CONTROL_ROM_SIZE)) {
+			printDebug("Control ROM error: Timbre map entry 0x%04x for timbre %d points to invalid timbre address 0x%04x", i, absTimbreNum, address);
+			return false;
+		}
+		address += offset;
+		if (compressed) {
+			if (!initCompressedTimbre(tempRegion, absTimbreNum, &controlROMData[address], CONTROL_ROM_SIZE - address)) {
+				printDebug("Control ROM error: Timbre map entry 0x%04x for timbre %d points to invalid timbre at 0x%04x", i, absTimbreNum, address);
+				return false;
+			}
+		} else {
+			tempRegion.write(timbreNum, 0, &controlROMData[address], sizeof(TimbreParam), true);
+		}
+		timbreNum++;
+	}
+	return true;
+}
+
+void Synth::initReverbModels(bool mt32CompatibleMode) {
+	for (int mode = REVERB_MODE_ROOM; mode <= REVERB_MODE_TAP_DELAY; mode++) {
+		reverbModels[mode] = BReverbModel::createBReverbModel(ReverbMode(mode), mt32CompatibleMode, getSelectedRendererType());
+
+		if (extensions.preallocatedReverbMemory) {
+			reverbModels[mode]->open();
+		}
+	}
+}
+
+void Synth::initSoundGroups(char newSoundGroupNames[][9]) {
+	memcpy(soundGroupIx, &controlROMData[controlROMMap->soundGroupsTable - sizeof(soundGroupIx)], sizeof(soundGroupIx));
+	const SoundGroup *table = reinterpret_cast<SoundGroup *>(&controlROMData[controlROMMap->soundGroupsTable]);
+	for (unsigned int i = 0; i < controlROMMap->soundGroupsCount; i++) {
+		memcpy(&newSoundGroupNames[i][0], table[i].name, sizeof(table[i].name));
+	}
+}
+
+bool Synth::open(const ROMImage &controlROMImage, const ROMImage &pcmROMImage, AnalogOutputMode analogOutputMode) {
+	return open(controlROMImage, pcmROMImage, DEFAULT_MAX_PARTIALS, analogOutputMode);
+}
+
+bool Synth::open(const ROMImage &controlROMImage, const ROMImage &pcmROMImage, Bit32u usePartialCount, AnalogOutputMode analogOutputMode) {
+	if (opened) {
+		return false;
+	}
+	partialCount = usePartialCount;
+	abortingPoly = NULL;
+	extensions.abortingPartIx = 0;
+
+	// This is to help detect bugs
+	memset(&mt32ram, '?', sizeof(mt32ram));
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Loading Control ROM");
+#endif
+	if (!loadControlROM(controlROMImage)) {
+		printDebug("Init Error - Missing or invalid Control ROM image");
+		reportHandler->onErrorControlROM();
+		dispose();
+		return false;
+	}
+
+	initMemoryRegions();
+
+	// 512KB PCM ROM for MT-32, etc.
+	// 1MB PCM ROM for CM-32L, LAPC-I, CM-64, CM-500
+	// Note that the size below is given in samples (16-bit), not bytes
+	pcmROMSize = controlROMMap->pcmCount == 256 ? 512 * 1024 : 256 * 1024;
+	pcmROMData = new Bit16s[pcmROMSize];
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Loading PCM ROM");
+#endif
+	if (!loadPCMROM(pcmROMImage)) {
+		printDebug("Init Error - Missing PCM ROM image");
+		reportHandler->onErrorPCMROM();
+		dispose();
+		return false;
+	}
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Reverb Models");
+#endif
+	bool mt32CompatibleReverb = controlROMFeatures->defaultReverbMT32Compatible;
+#if MT32EMU_MONITOR_INIT
+	printDebug("Using %s Compatible Reverb Models", mt32CompatibleReverb ? "MT-32" : "CM-32L");
+#endif
+	initReverbModels(mt32CompatibleReverb);
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Timbre Bank A");
+#endif
+	if (!initTimbres(controlROMMap->timbreAMap, controlROMMap->timbreAOffset, 0x40, 0, controlROMMap->timbreACompressed)) {
+		dispose();
+		return false;
+	}
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Timbre Bank B");
+#endif
+	if (!initTimbres(controlROMMap->timbreBMap, controlROMMap->timbreBOffset, 0x40, 64, controlROMMap->timbreBCompressed)) {
+		dispose();
+		return false;
+	}
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Timbre Bank R");
+#endif
+	if (!initTimbres(controlROMMap->timbreRMap, 0, controlROMMap->timbreRCount, 192, true)) {
+		dispose();
+		return false;
+	}
+
+	if (controlROMMap->timbreRCount == 30) {
+		// We must initialise all 64 rhythm timbres to avoid undefined behaviour.
+		// SEMI-CONFIRMED: Old-gen MT-32 units likely map timbres 30..59 to 0..29.
+		// Attempts to play rhythm timbres 60..63 exhibit undefined behaviour.
+		// We want to emulate the wrap around, so merely copy the entire set of standard
+		// timbres once more. The last 4 dangerous timbres are zeroed out.
+		memcpy(&mt32ram.timbres[222], &mt32ram.timbres[192], sizeof(*mt32ram.timbres) * 30);
+		memset(&mt32ram.timbres[252], 0, sizeof(*mt32ram.timbres) * 4);
+	}
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Timbre Bank M");
+#endif
+	// CM-64 seems to initialise all bytes in this bank to 0.
+	memset(&mt32ram.timbres[128], 0, sizeof(mt32ram.timbres[128]) * 64);
+
+	partialManager = new PartialManager(this);
+
+	pcmWaves = new PCMWaveEntry[controlROMMap->pcmCount];
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising PCM List");
+#endif
+	initPCMList(controlROMMap->pcmTable, controlROMMap->pcmCount);
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Rhythm Temp");
+#endif
+	memcpy(mt32ram.rhythmTemp, &controlROMData[controlROMMap->rhythmSettings], controlROMMap->rhythmSettingsCount * 4);
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising Patches");
+#endif
+	for (Bit8u i = 0; i < 128; i++) {
+		PatchParam *patch = &mt32ram.patches[i];
+		patch->timbreGroup = i / 64;
+		patch->timbreNum = i % 64;
+		patch->keyShift = 24;
+		patch->fineTune = 50;
+		patch->benderRange = 12;
+		patch->assignMode = 0;
+		patch->reverbSwitch = 1;
+		patch->dummy = 0;
+	}
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("Initialising System");
+#endif
+	// The MT-32 manual claims that "Standard pitch" is 442Hz.
+	mt32ram.system.masterTune = 0x4A; // Confirmed on CM-64
+	mt32ram.system.reverbMode = 0; // Confirmed
+	mt32ram.system.reverbTime = 5; // Confirmed
+	mt32ram.system.reverbLevel = 3; // Confirmed
+	memcpy(mt32ram.system.reserveSettings, &controlROMData[controlROMMap->reserveSettings], 9); // Confirmed
+	for (Bit8u i = 0; i < 9; i++) {
+		// This is the default: {1, 2, 3, 4, 5, 6, 7, 8, 9}
+		// An alternative configuration can be selected by holding "Master Volume"
+		// and pressing "PART button 1" on the real MT-32's frontpanel.
+		// The channel assignment is then {0, 1, 2, 3, 4, 5, 6, 7, 9}
+		mt32ram.system.chanAssign[i] = i + 1;
+	}
+	mt32ram.system.masterVol = DEFAULT_MASTER_VOLUME;
+
+	bool oldReverbOverridden = reverbOverridden;
+	reverbOverridden = false;
+	refreshSystem();
+	resetMasterTunePitchDelta();
+	reverbOverridden = oldReverbOverridden;
+
+	char(*writableSoundGroupNames)[9] = new char[controlROMMap->soundGroupsCount][9];
+	soundGroupNames = writableSoundGroupNames;
+	initSoundGroups(writableSoundGroupNames);
+
+	for (int i = 0; i < 9; i++) {
+		MemParams::PatchTemp *patchTemp = &mt32ram.patchTemp[i];
+
+		// Note that except for the rhythm part, these patch fields will be set in setProgram() below anyway.
+		patchTemp->patch.timbreGroup = 0;
+		patchTemp->patch.timbreNum = 0;
+		patchTemp->patch.keyShift = 24;
+		patchTemp->patch.fineTune = 50;
+		patchTemp->patch.benderRange = 12;
+		patchTemp->patch.assignMode = 0;
+		patchTemp->patch.reverbSwitch = 1;
+		patchTemp->patch.dummy = 0;
+
+		patchTemp->outputLevel = 80;
+		patchTemp->panpot = controlROMData[controlROMMap->panSettings + i];
+		memset(patchTemp->dummyv, 0, sizeof(patchTemp->dummyv));
+		patchTemp->dummyv[1] = 127;
+
+		if (i < 8) {
+			parts[i] = new Part(this, i);
+			parts[i]->setProgram(controlROMData[controlROMMap->programSettings + i]);
+		} else {
+			parts[i] = new RhythmPart(this, i);
+		}
+	}
+
+	// For resetting mt32 mid-execution
+	mt32default = mt32ram;
+
+	midiQueue = new MidiEventQueue(extensions.midiEventQueueSize, extensions.midiEventQueueSysexStorageBufferSize);
+
+	analog = Analog::createAnalog(analogOutputMode, controlROMFeatures->oldMT32AnalogLPF, getSelectedRendererType());
+#if MT32EMU_MONITOR_INIT
+	static const char *ANALOG_OUTPUT_MODES[] = { "Digital only", "Coarse", "Accurate", "Oversampled2x" };
+	printDebug("Using Analog output mode %s", ANALOG_OUTPUT_MODES[analogOutputMode]);
+#endif
+	setOutputGain(outputGain);
+	setReverbOutputGain(reverbOutputGain);
+
+	if (extensions.masterVolumeOverride < DEFAULT_MASTER_VOLUME) {
+		mt32ram.system.masterVol = extensions.masterVolumeOverride;
+		refreshSystemMasterVol();
+	}
+
+	switch (getSelectedRendererType()) {
+		case RendererType_BIT16S:
+			renderer = new RendererImpl<IntSample>(*this);
+#if MT32EMU_MONITOR_INIT
+			printDebug("Using integer 16-bit samples in renderer and wave generator");
+#endif
+			break;
+		case RendererType_FLOAT:
+			renderer = new RendererImpl<FloatSample>(*this);
+#if MT32EMU_MONITOR_INIT
+			printDebug("Using float 32-bit samples in renderer and wave generator");
+#endif
+			break;
+		default:
+			printDebug("Synth: Unknown renderer type %i\n", getSelectedRendererType());
+			dispose();
+			return false;
+	}
+
+	extensions.display = new Display(*this);
+	extensions.oldMT32DisplayFeatures = controlROMFeatures->oldMT32DisplayFeatures;
+
+	opened = true;
+	activated = false;
+
+#if MT32EMU_MONITOR_INIT
+	printDebug("*** Initialisation complete ***");
+#endif
+	return true;
+}
+
+void Synth::dispose() {
+	opened = false;
+
+	delete extensions.display;
+	extensions.display = NULL;
+
+	delete midiQueue;
+	midiQueue = NULL;
+
+	delete renderer;
+	renderer = NULL;
+
+	delete analog;
+	analog = NULL;
+
+	delete partialManager;
+	partialManager = NULL;
+
+	for (int i = 0; i < 9; i++) {
+		delete parts[i];
+		parts[i] = NULL;
+	}
+
+	delete[] soundGroupNames;
+	soundGroupNames = NULL;
+
+	delete[] pcmWaves;
+	pcmWaves = NULL;
+
+	delete[] pcmROMData;
+	pcmROMData = NULL;
+
+	deleteMemoryRegions();
+
+	for (int i = REVERB_MODE_ROOM; i <= REVERB_MODE_TAP_DELAY; i++) {
+		delete reverbModels[i];
+		reverbModels[i] = NULL;
+	}
+	reverbModel = NULL;
+	controlROMFeatures = NULL;
+	controlROMMap = NULL;
+}
+
+void Synth::close() {
+	if (opened) {
+		dispose();
+	}
+}
+
+bool Synth::isOpen() const {
+	return opened;
+}
+
+void Synth::flushMIDIQueue() {
+	if (midiQueue == NULL) return;
+	for (;;) {
+		const volatile MidiEventQueue::MidiEvent *midiEvent = midiQueue->peekMidiEvent();
+		if (midiEvent == NULL) break;
+		if (midiEvent->sysexData == NULL) {
+			playMsgNow(midiEvent->shortMessageData);
+		} else {
+			playSysexNow(midiEvent->sysexData, midiEvent->sysexLength);
+		}
+		midiQueue->dropMidiEvent();
+	}
+	lastReceivedMIDIEventTimestamp = renderedSampleCount;
+}
+
+Bit32u Synth::setMIDIEventQueueSize(Bit32u useSize) {
+	static const Bit32u MAX_QUEUE_SIZE = (1 << 24); // This results in about 256 Mb - much greater than any reasonable value
+
+	if (extensions.midiEventQueueSize == useSize) return useSize;
+
+	// Find a power of 2 that is >= useSize
+	Bit32u binarySize = 1;
+	if (useSize < MAX_QUEUE_SIZE) {
+		// Using simple linear search as this isn't time critical
+		while (binarySize < useSize) binarySize <<= 1;
+	} else {
+		binarySize = MAX_QUEUE_SIZE;
+	}
+	extensions.midiEventQueueSize = binarySize;
+	if (midiQueue != NULL) {
+		flushMIDIQueue();
+		delete midiQueue;
+		midiQueue = new MidiEventQueue(binarySize, extensions.midiEventQueueSysexStorageBufferSize);
+	}
+	return binarySize;
+}
+
+void Synth::configureMIDIEventQueueSysexStorage(Bit32u storageBufferSize) {
+	if (extensions.midiEventQueueSysexStorageBufferSize == storageBufferSize) return;
+
+	extensions.midiEventQueueSysexStorageBufferSize = storageBufferSize;
+	if (midiQueue != NULL) {
+		flushMIDIQueue();
+		delete midiQueue;
+		midiQueue = new MidiEventQueue(extensions.midiEventQueueSize, storageBufferSize);
+	}
+}
+
+Bit32u Synth::getShortMessageLength(Bit32u msg) {
+	if ((msg & 0xF0) == 0xF0) {
+		switch (msg & 0xFF) {
+			case 0xF1:
+			case 0xF3:
+				return 2;
+			case 0xF2:
+				return 3;
+			default:
+				return 1;
+		}
+	}
+	// NOTE: This calculation isn't quite correct
+	// as it doesn't consider the running status byte
+	return ((msg & 0xE0) == 0xC0) ? 2 : 3;
+}
+
+Bit32u Synth::addMIDIInterfaceDelay(Bit32u len, Bit32u timestamp) {
+	Bit32u transferTime =  Bit32u(double(len) * MIDI_DATA_TRANSFER_RATE);
+	// Dealing with wrapping
+	if (Bit32s(timestamp - lastReceivedMIDIEventTimestamp) < 0) {
+		timestamp = lastReceivedMIDIEventTimestamp;
+	}
+	timestamp += transferTime;
+	lastReceivedMIDIEventTimestamp = timestamp;
+	return timestamp;
+}
+
+Bit32u Synth::getInternalRenderedSampleCount() const {
+	return renderedSampleCount;
+}
+
+bool Synth::playMsg(Bit32u msg) {
+	return playMsg(msg, renderedSampleCount);
+}
+
+bool Synth::playMsg(Bit32u msg, Bit32u timestamp) {
+	if ((msg & 0xF8) == 0xF8) {
+		reportHandler->onMIDISystemRealtime(Bit8u(msg & 0xFF));
+		return true;
+	}
+	if (midiQueue == NULL) return false;
+	if (midiDelayMode != MIDIDelayMode_IMMEDIATE) {
+		timestamp = addMIDIInterfaceDelay(getShortMessageLength(msg), timestamp);
+	}
+	if (!activated) activated = true;
+	do {
+		if (midiQueue->pushShortMessage(msg, timestamp)) return true;
+	} while (reportHandler->onMIDIQueueOverflow());
+	return false;
+}
+
+bool Synth::playSysex(const Bit8u *sysex, Bit32u len) {
+	return playSysex(sysex, len, renderedSampleCount);
+}
+
+bool Synth::playSysex(const Bit8u *sysex, Bit32u len, Bit32u timestamp) {
+	if (midiQueue == NULL) return false;
+	if (midiDelayMode == MIDIDelayMode_DELAY_ALL) {
+		timestamp = addMIDIInterfaceDelay(len, timestamp);
+	}
+	if (!activated) activated = true;
+	do {
+		if (midiQueue->pushSysex(sysex, len, timestamp)) return true;
+	} while (reportHandler->onMIDIQueueOverflow());
+	return false;
+}
+
+void Synth::playMsgNow(Bit32u msg) {
+	if (!opened) return;
+
+	Bit8u command = Bit8u((msg & 0x0000F0) >> 4);
+
+	// NOTE: Active sense IS implemented in real hardware. However, realtime processing is clearly out of the library scope.
+	//       It is assumed that realtime consumers of the library respond to these MIDI events as appropriate.
+	if (command == 0x0F) {
+#if MT32EMU_MONITOR_MIDI > 0
+		printDebug("Unsupported MIDI System Common / Realtime: 0x%08x", msg);
+#endif
+		return;
+	}
+
+	if (command < 8) {
+#if MT32EMU_MONITOR_MIDI > 0
+		printDebug("playMsgNow for msg=0x%08x relies on running status; unsupported", msg);
+#endif
+		return;
+	}
+
+	Bit8u chan = Bit8u(msg & 0x00000F);
+	Bit8u data1 = Bit8u((msg & 0x00FF00) >> 8);
+	Bit8u data2 = ((command & 0x0E) == 0x0C) ? 0 : Bit8u((msg & 0xFF0000) >> 16);
+
+	if (data1 > 127 || data2 > 127) {
+#if MT32EMU_MONITOR_MIDI > 0
+		printDebug("playMsgNow for msg=0x%08x with invalid data bytes: chan=%d, command=0x%01x, data1=%d, data2=%d",
+			msg, chan, command, data1, data2);
+#endif
+		return;
+	}
+
+	Bit8u *chanParts = extensions.chantable[chan];
+	if (*chanParts > 8) {
+#if MT32EMU_MONITOR_MIDI > 0
+		printDebug("Play msg on unreg chan %d: command=0x%01x, data1=%d, data2=%d", chan, command, data1, data2);
+#endif
+		return;
+	}
+	for (Bit32u i = extensions.abortingPartIx; i <= 8; i++) {
+		const Bit32u partNum = chanParts[i];
+		if (partNum > 8) break;
+		playUnpackedShortMessage(partNum, command, data1, data2);
+		if (isAbortingPoly()) {
+			extensions.abortingPartIx = i;
+			break;
+		} else if (extensions.abortingPartIx) {
+			extensions.abortingPartIx = 0;
+		}
+	}
+}
+
+void Synth::playMsgOnPart(Bit8u partNum, Bit8u command, Bit8u data1, Bit8u data2) {
+	if (!opened) return;
+
+	if (partNum > 8 || data1 > 127 || data2 > 127) {
+#if MT32EMU_MONITOR_MIDI > 0
+		printDebug("playMsgOnPart with invalid params: part=%d, command=0x%01x, data1=%d, data2=%d", partNum, command, data1, data2);
+#endif
+		return;
+	}
+	playUnpackedShortMessage(partNum, command, data1, data2);
+}
+
+void Synth::playUnpackedShortMessage(Bit8u partNum, Bit8u command, Bit8u data1, Bit8u data2) {
+	if (!activated) activated = true;
+
+	switch (command) {
+	case 0x8:
+		// The MT-32 ignores velocity for note off
+		parts[partNum]->noteOff(data1);
+		break;
+	case 0x9:
+		if (data2 == 0) {
+			// MIDI defines note-on with velocity 0 as being the same as note-off with velocity 40
+			parts[partNum]->noteOff(data1);
+		} else if (parts[partNum]->getVolumeOverride() > 0) {
+			parts[partNum]->noteOn(data1, data2);
+		}
+		break;
+	case 0xB: // Control change
+		switch (data1) {
+		case 0x01:  // Modulation
+			parts[partNum]->setModulation(data2);
+			break;
+		case 0x06:
+			parts[partNum]->setDataEntryMSB(data2);
+			break;
+		case 0x07:  // Set volume
+			parts[partNum]->setVolume(data2);
+			break;
+		case 0x0A:  // Pan
+			parts[partNum]->setPan(data2);
+			break;
+		case 0x0B:
+			parts[partNum]->setExpression(data2);
+			break;
+		case 0x40: // Hold (sustain) pedal
+			parts[partNum]->setHoldPedal(data2 >= 64);
+			break;
+
+		case 0x62:
+		case 0x63:
+			parts[partNum]->setNRPN();
+			break;
+		case 0x64:
+			parts[partNum]->setRPNLSB(data2);
+			break;
+		case 0x65:
+			parts[partNum]->setRPNMSB(data2);
+			break;
+
+		case 0x79: // Reset all controllers
+			parts[partNum]->resetAllControllers();
+			break;
+
+		case 0x7B: // All notes off
+			parts[partNum]->allNotesOff();
+			break;
+
+		case 0x7C:
+		case 0x7D:
+		case 0x7E:
+		case 0x7F:
+			// CONFIRMED:Mok: A real LAPC-I responds to these controllers as follows:
+			parts[partNum]->setHoldPedal(false);
+			parts[partNum]->allNotesOff();
+			break;
+
+		default:
+#if MT32EMU_MONITOR_MIDI > 0
+			printDebug("Unknown MIDI Control code: 0x%02x - data2: 0x%02x", data1, data2);
+#endif
+			return;
+		}
+		extensions.display->midiMessagePlayed();
+		break;
+	case 0xC: // Program change
+		parts[partNum]->setProgram(data1);
+		if (partNum < 8) {
+			extensions.display->midiMessagePlayed();
+			extensions.display->programChanged(partNum);
+		}
+		break;
+	case 0xE: // Pitch bender
+		parts[partNum]->setBend((data2 << 7) | data1);
+		extensions.display->midiMessagePlayed();
+		break;
+	default:
+#if MT32EMU_MONITOR_MIDI > 0
+		printDebug("Unknown Midi command: 0x%01x - %02x - %02x", command, data1, data2);
+#endif
+		return;
+	}
+	reportHandler->onMIDIMessagePlayed();
+}
+
+void Synth::playSysexNow(const Bit8u *sysex, Bit32u len) {
+	if (len < 2) {
+		printDebug("playSysex: Message is too short for sysex (%d bytes)", len);
+	}
+	if (sysex[0] != 0xF0) {
+		printDebug("playSysex: Message lacks start-of-sysex (0xF0)");
+		return;
+	}
+	// Due to some programs (e.g. Java) sending buffers with junk at the end, we have to go through and find the end marker rather than relying on len.
+	Bit32u endPos;
+	for (endPos = 1; endPos < len; endPos++) {
+		if (sysex[endPos] == 0xF7) {
+			break;
+		}
+	}
+	if (endPos == len) {
+		printDebug("playSysex: Message lacks end-of-sysex (0xf7)");
+		return;
+	}
+	playSysexWithoutFraming(sysex + 1, endPos - 1);
+}
+
+void Synth::playSysexWithoutFraming(const Bit8u *sysex, Bit32u len) {
+	if (len < 4) {
+		printDebug("playSysexWithoutFraming: Message is too short (%d bytes)!", len);
+		return;
+	}
+	if (sysex[0] != SYSEX_MANUFACTURER_ROLAND) {
+		printDebug("playSysexWithoutFraming: Header not intended for this device manufacturer: %02x %02x %02x %02x", int(sysex[0]), int(sysex[1]), int(sysex[2]), int(sysex[3]));
+		return;
+	}
+	if (sysex[2] == SYSEX_MDL_D50) {
+		printDebug("playSysexWithoutFraming: Header is intended for model D-50 (not yet supported): %02x %02x %02x %02x", int(sysex[0]), int(sysex[1]), int(sysex[2]), int(sysex[3]));
+		return;
+	} else if (sysex[2] != SYSEX_MDL_MT32) {
+		printDebug("playSysexWithoutFraming: Header not intended for model MT-32: %02x %02x %02x %02x", int(sysex[0]), int(sysex[1]), int(sysex[2]), int(sysex[3]));
+		return;
+	}
+	playSysexWithoutHeader(sysex[1], sysex[3], sysex + 4, len - 4);
+}
+
+void Synth::playSysexWithoutHeader(Bit8u device, Bit8u command, const Bit8u *sysex, Bit32u len) {
+	if (device > 0x10) {
+		// We have device ID 0x10 (default, but changeable, on real MT-32), < 0x10 is for channels
+		printDebug("playSysexWithoutHeader: Message is not intended for this device ID (provided: %02x, expected: 0x10 or channel)", int(device));
+		return;
+	}
+
+	// All models process the checksum before anything else and ignore messages lacking the checksum, or containing the checksum only.
+	if (len < 2) {
+		printDebug("playSysexWithoutHeader: Message is too short (%d bytes)!", len);
+		return;
+	}
+	Bit8u checksum = calcSysexChecksum(sysex, len - 1);
+	if (checksum != sysex[len - 1]) {
+		printDebug("playSysexWithoutHeader: Message checksum is incorrect (provided: %02x, expected: %02x)!", sysex[len - 1], checksum);
+		if (opened) extensions.display->checksumErrorOccurred();
+		return;
+	}
+	len -= 1; // Exclude checksum
+
+	if (command == SYSEX_CMD_EOD) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		printDebug("playSysexWithoutHeader: Ignored unsupported command %02x", command);
+#endif
+		return;
+	}
+	switch (command) {
+	case SYSEX_CMD_WSD:
+#if MT32EMU_MONITOR_SYSEX > 0
+		printDebug("playSysexWithoutHeader: Ignored unsupported command %02x", command);
+#endif
+		break;
+	case SYSEX_CMD_DAT:
+		/* Outcommented until we (ever) actually implement handshake communication
+		if (hasActivePartials()) {
+			printDebug("playSysexWithoutHeader: Got SYSEX_CMD_DAT but partials are active - ignoring");
+			// FIXME: We should send SYSEX_CMD_RJC in this case
+			break;
+		}
+		*/
+		// Fall-through
+	case SYSEX_CMD_DT1:
+		writeSysex(device, sysex, len);
+		break;
+	case SYSEX_CMD_RQD:
+		if (hasActivePartials()) {
+			printDebug("playSysexWithoutHeader: Got SYSEX_CMD_RQD but partials are active - ignoring");
+			// FIXME: We should send SYSEX_CMD_RJC in this case
+			break;
+		}
+		// Fall-through
+	case SYSEX_CMD_RQ1:
+		readSysex(device, sysex, len);
+		break;
+	default:
+		printDebug("playSysexWithoutHeader: Unsupported command %02x", command);
+		return;
+	}
+}
+
+bool SysexBuilder::appendSysex(Bit32u sysexAddress, const Bit8u *data, Bit32u dataLength) {
+	static const Bit8u SYSEX_HEADER[] = { 0xF0, SYSEX_MANUFACTURER_ROLAND, 0x10, SYSEX_MDL_MT32, SYSEX_CMD_DT1 };
+	static const Bit8u SYSEX_TERMINATOR = 0xF7;
+
+	if ((data == NULL && dataLength > 0) || (&writePtr[dataLength + 10] > endPtr)) return false;
+
+	memcpy(writePtr, SYSEX_HEADER, sizeof SYSEX_HEADER);
+	writePtr += sizeof SYSEX_HEADER;
+	const Bit8u *headerEndPtr = writePtr;
+	*(writePtr++) = (sysexAddress >> 16) & 0xFF;
+	*(writePtr++) = (sysexAddress >> 8) & 0xFF;
+	*(writePtr++) = sysexAddress & 0xFF;
+	if (dataLength > 0) {
+		memcpy(writePtr, data, dataLength);
+		writePtr += dataLength;
+	}
+	*(writePtr++) = Synth::calcSysexChecksum(headerEndPtr, dataLength + 3);
+	*(writePtr++) = SYSEX_TERMINATOR;
+	return true;
+}
+
+struct SysexBankBuilder : SysexBuilder {
+	SysexBankBuilder(Bit8u *sysexBank, Bit32u size) : SysexBuilder(sysexBank, size) {}
+
+	bool appendTimbreMemorySysexes(MemParams::PaddedTimbre *timbreMemory) {
+		for (Bit32u timbreIx = 0; timbreIx < 64; timbreIx++) {
+			if (!appendSysex(0x80000 + timbreIx * 0x200, reinterpret_cast<Bit8u *>(&timbreMemory[timbreIx + 128]), sizeof(TimbreParam))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool appendPatchMemorySysexes(PatchParam *patchMemory) {
+		for (Bit32u patchBlockIx = 0; patchBlockIx < 4; patchBlockIx++) {
+			if (!appendSysex(0x50000 + patchBlockIx * 0x200, &patchMemory[patchBlockIx * 32].timbreGroup, sizeof(PatchParam) * 32))
+				return false;
+		}
+		return true;
+	}
+
+	bool appendRhythmSetupSysexes(MemParams::RhythmTemp *rhythmSetup) {
+		return appendSysex(0x30110, &rhythmSetup->timbre, sizeof(MemParams::RhythmTemp) * 64)
+			&& appendSysex(0x30310, &rhythmSetup->timbre, sizeof(MemParams::RhythmTemp) * 21);
+	}
+
+	bool appendTimbreTempSysexes(TimbreParam *timbreTemp) {
+		for (Bit32u timbreIx = 0; timbreIx < 8; timbreIx++) {
+			if (!appendSysex(0x40000 + MT32EMU_SYSEXMEMADDR(timbreIx * 0xF6), reinterpret_cast<Bit8u *>(&timbreTemp[timbreIx]),
+				sizeof(TimbreParam))) return false;
+		}
+		return true;
+	}
+};
+
+Bit32u Synth::dumpSysexBank(Bit8u *sysexBank, Bit32u size) const {
+	static const Bit32u maxBankSize = Bit32u(
+		10 // Reset SysEx, no data.
+		+ sizeof(MemParams::System) + 10
+		+ 64 * (sizeof(TimbreParam) + 10)
+		+ 4 * (32 * sizeof(PatchParam) + 10)
+		+ 64 * sizeof(MemParams::RhythmTemp) + 10
+		+ 21 * sizeof(MemParams::RhythmTemp) + 10
+		+ 9 * sizeof(MemParams::PatchTemp) + 10
+		+ 8 * (sizeof(TimbreParam) + 10)
+	);
+
+	if (!opened) return 0;
+
+	if (sysexBank && size) {
+		SysexBankBuilder builder(sysexBank, size);
+		builder.appendSysex(0x7F0000, NULL, 0)
+			&& builder.appendSysex(0x100000, &mt32ram.system.masterTune, sizeof(MemParams::System))
+			&& builder.appendTimbreMemorySysexes(mt32ram.timbres)
+			&& builder.appendPatchMemorySysexes(mt32ram.patches)
+			&& builder.appendRhythmSetupSysexes(mt32ram.rhythmTemp)
+			&& builder.appendSysex(0x030000, &mt32ram.patchTemp->patch.timbreGroup, sizeof mt32ram.patchTemp)
+			&& builder.appendTimbreTempSysexes(mt32ram.timbreTemp);
+	}
+	return maxBankSize;
+}
+
+Bit32u Synth::applySysexBank(const Bit8u *sysexBank, Bit32u size) {
+	if (!opened) return 0;
+
+	Bit32u sysexesPlayed = 0;
+	const Bit8u *sysexBeginPtr = NULL;
+	const Bit8u *sysexBankEndPtr = sysexBank + size;
+	for (const Bit8u *p = sysexBank; p < sysexBankEndPtr; p++) {
+		if (*p == 0xF0) {
+			sysexBeginPtr = p;
+		} else if (*p == 0xF7 && sysexBeginPtr) {
+			Bit32u sysexLength = Bit32u(p - sysexBeginPtr) + 1;
+			playSysexNow(sysexBeginPtr, sysexLength);
+			sysexBeginPtr = NULL;
+			sysexesPlayed++;
+		}
+	}
+	return sysexesPlayed;
+}
+
+void Synth::readSysex(Bit8u /*device*/, const Bit8u * /*sysex*/, Bit32u /*len*/) const {
+	// NYI
+}
+
+void Synth::writeSysex(Bit8u device, const Bit8u *sysex, Bit32u len) {
+	if (!opened || len < 1) return;
+
+	// This is checked early in the real devices (before any sysex length checks or further processing)
+	if (sysex[0] == 0x7F) {
+		if (!isDisplayOldMT32Compatible()) extensions.display->midiMessagePlayed();
+		reset();
+		return;
+	}
+
+	extensions.display->midiMessagePlayed();
+	reportHandler->onMIDIMessagePlayed();
+
+	if (len < 3) {
+		// A short message of just 1 or 2 bytes may be written to the display area yet it may cause a user-visible effect,
+		// similarly to the reset area.
+		if (sysex[0] == 0x20) {
+			extensions.display->displayControlMessageReceived(sysex, len);
+			return;
+		}
+		printDebug("writeSysex: Message is too short (%d bytes)!", len);
+		return;
+	}
+
+	Bit32u addr = (sysex[0] << 16) | (sysex[1] << 8) | (sysex[2]);
+	addr = MT32EMU_MEMADDR(addr);
+	sysex += 3;
+	len -= 3;
+
+	//printDebug("Sysex addr: 0x%06x", MT32EMU_SYSEXMEMADDR(addr));
+	// NOTE: Please keep both lower and upper bounds in each check, for ease of reading
+
+	// Process channel-specific sysex by converting it to device-global
+	if (device < 0x10) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		printDebug("WRITE-CHANNEL: Channel %d temp area 0x%06x", device, MT32EMU_SYSEXMEMADDR(addr));
+#endif
+		if (/*addr >= MT32EMU_MEMADDR(0x000000) && */addr < MT32EMU_MEMADDR(0x010000)) {
+			addr += MT32EMU_MEMADDR(0x030000);
+			Bit8u *chanParts = extensions.chantable[device];
+			if (*chanParts > 8) {
+#if MT32EMU_MONITOR_SYSEX > 0
+				printDebug(" (Channel not mapped to a part... 0 offset)");
+#endif
+			} else {
+				for (Bit32u partIx = 0; partIx <= 8; partIx++) {
+					if (chanParts[partIx] > 8) break;
+					int offset;
+					if (chanParts[partIx] == 8) {
+#if MT32EMU_MONITOR_SYSEX > 0
+						printDebug(" (Channel mapped to rhythm... 0 offset)");
+#endif
+						offset = 0;
+					} else {
+						offset = chanParts[partIx] * sizeof(MemParams::PatchTemp);
+#if MT32EMU_MONITOR_SYSEX > 0
+						printDebug(" (Setting extra offset to %d)", offset);
+#endif
+					}
+					writeSysexGlobal(addr + offset, sysex, len);
+				}
+				return;
+			}
+		} else if (/*addr >= MT32EMU_MEMADDR(0x010000) && */ addr < MT32EMU_MEMADDR(0x020000)) {
+			addr += MT32EMU_MEMADDR(0x030110) - MT32EMU_MEMADDR(0x010000);
+		} else if (/*addr >= MT32EMU_MEMADDR(0x020000) && */ addr < MT32EMU_MEMADDR(0x030000)) {
+			addr += MT32EMU_MEMADDR(0x040000) - MT32EMU_MEMADDR(0x020000);
+			Bit8u *chanParts = extensions.chantable[device];
+			if (*chanParts > 8) {
+#if MT32EMU_MONITOR_SYSEX > 0
+				printDebug(" (Channel not mapped to a part... 0 offset)");
+#endif
+			} else {
+				for (Bit32u partIx = 0; partIx <= 8; partIx++) {
+					if (chanParts[partIx] > 8) break;
+					int offset;
+					if (chanParts[partIx] == 8) {
+#if MT32EMU_MONITOR_SYSEX > 0
+						printDebug(" (Channel mapped to rhythm... 0 offset)");
+#endif
+						offset = 0;
+					} else {
+						offset = chanParts[partIx] * sizeof(TimbreParam);
+#if MT32EMU_MONITOR_SYSEX > 0
+						printDebug(" (Setting extra offset to %d)", offset);
+#endif
+					}
+					writeSysexGlobal(addr + offset, sysex, len);
+				}
+				return;
+			}
+		} else {
+#if MT32EMU_MONITOR_SYSEX > 0
+			printDebug(" Invalid channel");
+#endif
+			return;
+		}
+	}
+	writeSysexGlobal(addr, sysex, len);
+}
+
+// Process device-global sysex (possibly converted from channel-specific sysex above)
+void Synth::writeSysexGlobal(Bit32u addr, const Bit8u *sysex, Bit32u len) {
+	for (;;) {
+		// Find the appropriate memory region
+		const MemoryRegion *region = findMemoryRegion(addr);
+
+		if (region == NULL) {
+			printDebug("Sysex write to unrecognised address %06x, len %d", MT32EMU_SYSEXMEMADDR(addr), len);
+			// FIXME: Real devices may respond differently to a long SysEx that covers adjacent regions.
+			break;
+		}
+		writeMemoryRegion(region, addr, region->getClampedLen(addr, len), sysex);
+
+		Bit32u next = region->next(addr, len);
+		if (next == 0) {
+			break;
+		}
+		addr += next;
+		sysex += next;
+		len -= next;
+	}
+}
+
+void Synth::readMemory(Bit32u addr, Bit32u len, Bit8u *data) {
+	if (!opened) return;
+	const MemoryRegion *region = findMemoryRegion(addr);
+	if (region != NULL) {
+		readMemoryRegion(region, addr, len, data);
+	}
+}
+
+void Synth::initMemoryRegions() {
+	// Timbre max tables are slightly more complicated than the others, which are used directly from the ROM.
+	// The ROM (sensibly) just has maximums for TimbreParam.commonParam followed by just one TimbreParam.partialParam,
+	// so we produce a table with all partialParams filled out, as well as padding for PaddedTimbre, for quick lookup.
+	paddedTimbreMaxTable = new Bit8u[sizeof(MemParams::PaddedTimbre)];
+	memcpy(&paddedTimbreMaxTable[0], &controlROMData[controlROMMap->timbreMaxTable], sizeof(TimbreParam::CommonParam) + sizeof(TimbreParam::PartialParam)); // commonParam and one partialParam
+	int pos = sizeof(TimbreParam::CommonParam) + sizeof(TimbreParam::PartialParam);
+	for (int i = 0; i < 3; i++) {
+		memcpy(&paddedTimbreMaxTable[pos], &controlROMData[controlROMMap->timbreMaxTable + sizeof(TimbreParam::CommonParam)], sizeof(TimbreParam::PartialParam));
+		pos += sizeof(TimbreParam::PartialParam);
+	}
+	memset(&paddedTimbreMaxTable[pos], 0, 10); // Padding
+	patchTempMemoryRegion = new PatchTempMemoryRegion(reinterpret_cast<Bit8u *>(&mt32ram.patchTemp[0]), &controlROMData[controlROMMap->patchMaxTable]);
+	rhythmTempMemoryRegion = new RhythmTempMemoryRegion(reinterpret_cast<Bit8u *>(&mt32ram.rhythmTemp[0]), &controlROMData[controlROMMap->rhythmMaxTable]);
+	timbreTempMemoryRegion = new TimbreTempMemoryRegion(reinterpret_cast<Bit8u *>(&mt32ram.timbreTemp[0]), paddedTimbreMaxTable);
+	patchesMemoryRegion = new PatchesMemoryRegion(reinterpret_cast<Bit8u *>(&mt32ram.patches[0]), &controlROMData[controlROMMap->patchMaxTable]);
+	timbresMemoryRegion = new TimbresMemoryRegion(reinterpret_cast<Bit8u *>(&mt32ram.timbres[/* Bank M */ 128]), paddedTimbreMaxTable);
+	systemMemoryRegion = new SystemMemoryRegion(reinterpret_cast<Bit8u *>(&mt32ram.system), &controlROMData[controlROMMap->systemMaxTable]);
+	displayMemoryRegion = new DisplayMemoryRegion();
+	resetMemoryRegion = new ResetMemoryRegion();
+}
+
+void Synth::deleteMemoryRegions() {
+	delete patchTempMemoryRegion;
+	patchTempMemoryRegion = NULL;
+	delete rhythmTempMemoryRegion;
+	rhythmTempMemoryRegion = NULL;
+	delete timbreTempMemoryRegion;
+	timbreTempMemoryRegion = NULL;
+	delete patchesMemoryRegion;
+	patchesMemoryRegion = NULL;
+	delete timbresMemoryRegion;
+	timbresMemoryRegion = NULL;
+	delete systemMemoryRegion;
+	systemMemoryRegion = NULL;
+	delete displayMemoryRegion;
+	displayMemoryRegion = NULL;
+	delete resetMemoryRegion;
+	resetMemoryRegion = NULL;
+
+	delete[] paddedTimbreMaxTable;
+	paddedTimbreMaxTable = NULL;
+}
+
+MemoryRegion *Synth::findMemoryRegion(Bit32u addr) {
+	MemoryRegion *regions[] = {
+		patchTempMemoryRegion,
+		rhythmTempMemoryRegion,
+		timbreTempMemoryRegion,
+		patchesMemoryRegion,
+		timbresMemoryRegion,
+		systemMemoryRegion,
+		displayMemoryRegion,
+		resetMemoryRegion,
+		NULL
+	};
+	for (int pos = 0; regions[pos] != NULL; pos++) {
+		if (regions[pos]->contains(addr)) {
+			return regions[pos];
+		}
+	}
+	return NULL;
+}
+
+void Synth::readMemoryRegion(const MemoryRegion *region, Bit32u addr, Bit32u len, Bit8u *data) {
+	unsigned int first = region->firstTouched(addr);
+	//unsigned int last = region->lastTouched(addr, len);
+	unsigned int off = region->firstTouchedOffset(addr);
+	len = region->getClampedLen(addr, len);
+
+	unsigned int m;
+
+	if (region->isReadable()) {
+		region->read(first, off, data, len);
+	} else {
+		// FIXME: We might want to do these properly in future
+		for (m = 0; m < len; m += 2) {
+			data[m] = 0xff;
+			if (m + 1 < len) {
+				data[m+1] = Bit8u(region->type);
+			}
+		}
+	}
+}
+
+void Synth::writeMemoryRegion(const MemoryRegion *region, Bit32u addr, Bit32u len, const Bit8u *data) {
+	unsigned int first = region->firstTouched(addr);
+	unsigned int last = region->lastTouched(addr, len);
+	unsigned int off = region->firstTouchedOffset(addr);
+	switch (region->type) {
+	case MR_PatchTemp:
+		region->write(first, off, data, len);
+		//printDebug("Patch temp: Patch %d, offset %x, len %d", off/16, off % 16, len);
+
+		for (unsigned int i = first; i <= last; i++) {
+			int absTimbreNum = mt32ram.patchTemp[i].patch.timbreGroup * 64 + mt32ram.patchTemp[i].patch.timbreNum;
+			char timbreName[11];
+			memcpy(timbreName, mt32ram.timbres[absTimbreNum].timbre.common.name, 10);
+			timbreName[10] = 0;
+#if MT32EMU_MONITOR_SYSEX > 0
+			printDebug("WRITE-PARTPATCH (%d-%d@%d..%d): %d; timbre=%d (%s), outlevel=%d", first, last, off, off + len, i, absTimbreNum, timbreName, mt32ram.patchTemp[i].outputLevel);
+#endif
+			if (parts[i] != NULL) {
+				if (i != 8) {
+					// Note: Confirmed on CM-64 that we definitely *should* update the timbre here,
+					// but only in the case that the sysex actually writes to those values
+					if (i == first && off > 2) {
+#if MT32EMU_MONITOR_SYSEX > 0
+						printDebug(" (Not updating timbre, since those values weren't touched)");
+#endif
+					} else {
+						parts[i]->resetTimbre();
+					}
+				}
+				parts[i]->refresh();
+			}
+		}
+		break;
+	case MR_RhythmTemp:
+		region->write(first, off, data, len);
+		for (unsigned int i = first; i <= last; i++) {
+			int timbreNum = mt32ram.rhythmTemp[i].timbre;
+			char timbreName[11];
+			if (timbreNum < 94) {
+				memcpy(timbreName, mt32ram.timbres[128 + timbreNum].timbre.common.name, 10);
+				timbreName[10] = 0;
+			} else {
+				strcpy(timbreName, "[None]");
+			}
+#if MT32EMU_MONITOR_SYSEX > 0
+			printDebug("WRITE-RHYTHM (%d-%d@%d..%d): %d; level=%02x, panpot=%02x, reverb=%02x, timbre=%d (%s)", first, last, off, off + len, i, mt32ram.rhythmTemp[i].outputLevel, mt32ram.rhythmTemp[i].panpot, mt32ram.rhythmTemp[i].reverbSwitch, mt32ram.rhythmTemp[i].timbre, timbreName);
+#endif
+		}
+		if (parts[8] != NULL) {
+			parts[8]->refresh();
+		}
+		break;
+	case MR_TimbreTemp:
+		region->write(first, off, data, len);
+		for (unsigned int i = first; i <= last; i++) {
+			char instrumentName[11];
+			memcpy(instrumentName, mt32ram.timbreTemp[i].common.name, 10);
+			instrumentName[10] = 0;
+#if MT32EMU_MONITOR_SYSEX > 0
+			printDebug("WRITE-PARTTIMBRE (%d-%d@%d..%d): timbre=%d (%s)", first, last, off, off + len, i, instrumentName);
+#endif
+			if (parts[i] != NULL) {
+				parts[i]->refresh();
+			}
+		}
+		break;
+	case MR_Patches:
+		region->write(first, off, data, len);
+#if MT32EMU_MONITOR_SYSEX > 0
+		for (unsigned int i = first; i <= last; i++) {
+			PatchParam *patch = &mt32ram.patches[i];
+			int patchAbsTimbreNum = patch->timbreGroup * 64 + patch->timbreNum;
+			char instrumentName[11];
+			memcpy(instrumentName, mt32ram.timbres[patchAbsTimbreNum].timbre.common.name, 10);
+			instrumentName[10] = 0;
+			Bit8u *n = reinterpret_cast<Bit8u *>(patch);
+			printDebug("WRITE-PATCH (%d-%d@%d..%d): %d; timbre=%d (%s) %02X%02X%02X%02X%02X%02X%02X%02X", first, last, off, off + len, i, patchAbsTimbreNum, instrumentName, n[0], n[1], n[2], n[3], n[4], n[5], n[6], n[7]);
+		}
+#endif
+		break;
+	case MR_Timbres:
+		// Timbres
+		region->write(first, off, data, len);
+		for (unsigned int i = first; i <= last; i++) {
+#if MT32EMU_MONITOR_TIMBRES >= 1
+			TimbreParam *timbre = &mt32ram.timbres[i].timbre;
+			char instrumentName[11];
+			memcpy(instrumentName, timbre->common.name, 10);
+			instrumentName[10] = 0;
+			printDebug("WRITE-TIMBRE (%d-%d@%d..%d): %d; name=\"%s\"", first, last, off, off + len, i, instrumentName);
+#if MT32EMU_MONITOR_TIMBRES >= 2
+#define DT(x) printDebug(" " #x ": %d", timbre->x)
+			DT(common.partialStructure12);
+			DT(common.partialStructure34);
+			DT(common.partialMute);
+			DT(common.noSustain);
+
+#define DTP(x) \
+			DT(partial[x].wg.pitchCoarse); \
+			DT(partial[x].wg.pitchFine); \
+			DT(partial[x].wg.pitchKeyfollow); \
+			DT(partial[x].wg.pitchBenderEnabled); \
+			DT(partial[x].wg.waveform); \
+			DT(partial[x].wg.pcmWave); \
+			DT(partial[x].wg.pulseWidth); \
+			DT(partial[x].wg.pulseWidthVeloSensitivity); \
+			DT(partial[x].pitchEnv.depth); \
+			DT(partial[x].pitchEnv.veloSensitivity); \
+			DT(partial[x].pitchEnv.timeKeyfollow); \
+			DT(partial[x].pitchEnv.time[0]); \
+			DT(partial[x].pitchEnv.time[1]); \
+			DT(partial[x].pitchEnv.time[2]); \
+			DT(partial[x].pitchEnv.time[3]); \
+			DT(partial[x].pitchEnv.level[0]); \
+			DT(partial[x].pitchEnv.level[1]); \
+			DT(partial[x].pitchEnv.level[2]); \
+			DT(partial[x].pitchEnv.level[3]); \
+			DT(partial[x].pitchEnv.level[4]); \
+			DT(partial[x].pitchLFO.rate); \
+			DT(partial[x].pitchLFO.depth); \
+			DT(partial[x].pitchLFO.modSensitivity); \
+			DT(partial[x].tvf.cutoff); \
+			DT(partial[x].tvf.resonance); \
+			DT(partial[x].tvf.keyfollow); \
+			DT(partial[x].tvf.biasPoint); \
+			DT(partial[x].tvf.biasLevel); \
+			DT(partial[x].tvf.envDepth); \
+			DT(partial[x].tvf.envVeloSensitivity); \
+			DT(partial[x].tvf.envDepthKeyfollow); \
+			DT(partial[x].tvf.envTimeKeyfollow); \
+			DT(partial[x].tvf.envTime[0]); \
+			DT(partial[x].tvf.envTime[1]); \
+			DT(partial[x].tvf.envTime[2]); \
+			DT(partial[x].tvf.envTime[3]); \
+			DT(partial[x].tvf.envTime[4]); \
+			DT(partial[x].tvf.envLevel[0]); \
+			DT(partial[x].tvf.envLevel[1]); \
+			DT(partial[x].tvf.envLevel[2]); \
+			DT(partial[x].tvf.envLevel[3]); \
+			DT(partial[x].tva.level); \
+			DT(partial[x].tva.veloSensitivity); \
+			DT(partial[x].tva.biasPoint1); \
+			DT(partial[x].tva.biasLevel1); \
+			DT(partial[x].tva.biasPoint2); \
+			DT(partial[x].tva.biasLevel2); \
+			DT(partial[x].tva.envTimeKeyfollow); \
+			DT(partial[x].tva.envTimeVeloSensitivity); \
+			DT(partial[x].tva.envTime[0]); \
+			DT(partial[x].tva.envTime[1]); \
+			DT(partial[x].tva.envTime[2]); \
+			DT(partial[x].tva.envTime[3]); \
+			DT(partial[x].tva.envTime[4]); \
+			DT(partial[x].tva.envLevel[0]); \
+			DT(partial[x].tva.envLevel[1]); \
+			DT(partial[x].tva.envLevel[2]); \
+			DT(partial[x].tva.envLevel[3]);
+
+			DTP(0);
+			DTP(1);
+			DTP(2);
+			DTP(3);
+#undef DTP
+#undef DT
+#endif
+#endif
+			// FIXME:KG: Not sure if the stuff below should be done (for rhythm and/or parts)...
+			// Does the real MT-32 automatically do this?
+			for (unsigned int part = 0; part < 9; part++) {
+				if (parts[part] != NULL) {
+					parts[part]->refreshTimbre(i);
+				}
+			}
+		}
+		break;
+	case MR_System:
+		region->write(0, off, data, len);
+
+		reportHandler->onDeviceReconfig();
+		// FIXME: We haven't properly confirmed any of this behaviour
+		// In particular, we tend to reset things such as reverb even if the write contained
+		// the same parameters as were already set, which may be wrong.
+		// On the other hand, the real thing could be resetting things even when they aren't touched
+		// by the write at all.
+#if MT32EMU_MONITOR_SYSEX > 0
+		printDebug("WRITE-SYSTEM:");
+#endif
+		if (off <= SYSTEM_MASTER_TUNE_OFF && off + len > SYSTEM_MASTER_TUNE_OFF) {
+			refreshSystemMasterTune();
+		}
+		if (off <= SYSTEM_REVERB_LEVEL_OFF && off + len > SYSTEM_REVERB_MODE_OFF) {
+			refreshSystemReverbParameters();
+		}
+		if (off <= SYSTEM_RESERVE_SETTINGS_END_OFF && off + len > SYSTEM_RESERVE_SETTINGS_START_OFF) {
+			refreshSystemReserveSettings();
+		}
+		if (off <= SYSTEM_CHAN_ASSIGN_END_OFF && off + len > SYSTEM_CHAN_ASSIGN_START_OFF) {
+			int firstPart = off - SYSTEM_CHAN_ASSIGN_START_OFF;
+			if(firstPart < 0)
+				firstPart = 0;
+			int lastPart = off + len - SYSTEM_CHAN_ASSIGN_START_OFF;
+			if(lastPart > 8)
+				lastPart = 8;
+			refreshSystemChanAssign(Bit8u(firstPart), Bit8u(lastPart));
+		}
+		if (off <= SYSTEM_MASTER_VOL_OFF && off + len > SYSTEM_MASTER_VOL_OFF) {
+			if (extensions.masterVolumeOverride <= DEFAULT_MASTER_VOLUME) {
+#if MT32EMU_MONITOR_SYSEX > 0
+				printDebug(" Master volume overridden, wanted: %d - ignoring", mt32ram.system.masterVol);
+#endif
+				mt32ram.system.masterVol = extensions.masterVolumeOverride;
+			} else {
+				refreshSystemMasterVol();
+			}
+		}
+		break;
+	case MR_Display:
+		if (len > Display::LCD_TEXT_SIZE) len = Display::LCD_TEXT_SIZE;
+		if (!extensions.display->customDisplayMessageReceived(data, off, len)) break;
+		// Holds zero-terminated string of the maximum length.
+		char buf[Display::LCD_TEXT_SIZE + 1];
+		memcpy(&buf, &data[0], len);
+		buf[len] = 0;
+#if MT32EMU_MONITOR_SYSEX > 0
+		printDebug("WRITE-LCD: %s", buf);
+#endif
+		reportHandler->showLCDMessage(buf);
+		break;
+	case MR_Reset:
+		reset();
+		break;
+	default:
+		break;
+	}
+}
+
+void Synth::refreshSystemMasterTune() {
+	// 171 is ~half a semitone.
+	extensions.masterTunePitchDelta = ((mt32ram.system.masterTune - 64) * 171) >> 6; // PORTABILITY NOTE: Assumes arithmetic shift.
+#if MT32EMU_MONITOR_SYSEX > 0
+	//FIXME:KG: This is just an educated guess.
+	// The LAPC-I documentation claims a range of 427.5Hz-452.6Hz (similar to what we have here)
+	// The MT-32 documentation claims a range of 432.1Hz-457.6Hz
+	float masterTune = 440.0f * EXP2F((mt32ram.system.masterTune - 64.0f) / (128.0f * 12.0f));
+	printDebug(" Master Tune: %f", masterTune);
+#endif
+}
+
+void Synth::refreshSystemReverbParameters() {
+#if MT32EMU_MONITOR_SYSEX > 0
+	printDebug(" Reverb: mode=%d, time=%d, level=%d", mt32ram.system.reverbMode, mt32ram.system.reverbTime, mt32ram.system.reverbLevel);
+#endif
+	if (reverbOverridden) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		printDebug(" (Reverb overridden - ignoring)");
+#endif
+		return;
+	}
+	reportHandler->onNewReverbMode(mt32ram.system.reverbMode);
+	reportHandler->onNewReverbTime(mt32ram.system.reverbTime);
+	reportHandler->onNewReverbLevel(mt32ram.system.reverbLevel);
+
+	BReverbModel *oldReverbModel = reverbModel;
+	if (mt32ram.system.reverbTime == 0 && mt32ram.system.reverbLevel == 0) {
+		// Setting both time and level to 0 effectively disables wet reverb output on real devices.
+		// Take a shortcut in this case to reduce CPU load.
+		reverbModel = NULL;
+	} else {
+		reverbModel = reverbModels[mt32ram.system.reverbMode];
+	}
+	if (reverbModel != oldReverbModel) {
+		if (extensions.preallocatedReverbMemory) {
+			if (isReverbEnabled()) {
+				reverbModel->mute();
+			}
+		} else {
+			if (oldReverbModel != NULL) {
+				oldReverbModel->close();
+			}
+			if (isReverbEnabled()) {
+				reverbModel->open();
+			}
+		}
+	}
+	if (isReverbEnabled()) {
+		reverbModel->setParameters(mt32ram.system.reverbTime, mt32ram.system.reverbLevel);
+	}
+}
+
+void Synth::refreshSystemReserveSettings() {
+	Bit8u *rset = mt32ram.system.reserveSettings;
+#if MT32EMU_MONITOR_SYSEX > 0
+	printDebug(" Partial reserve: 1=%02d 2=%02d 3=%02d 4=%02d 5=%02d 6=%02d 7=%02d 8=%02d Rhythm=%02d", rset[0], rset[1], rset[2], rset[3], rset[4], rset[5], rset[6], rset[7], rset[8]);
+#endif
+	partialManager->setReserve(rset);
+}
+
+void Synth::refreshSystemChanAssign(Bit8u firstPart, Bit8u lastPart) {
+	memset(extensions.chantable, 0xFF, sizeof(extensions.chantable));
+
+	// CONFIRMED: In the case of assigning a MIDI channel to multiple parts,
+	//            the messages received on that MIDI channel are handled by all the parts.
+	for (Bit32u i = 0; i <= 8; i++) {
+		if (parts[i] != NULL && i >= firstPart && i <= lastPart) {
+			// CONFIRMED: Decay is started for all polys, and all controllers are reset, for every part whose assignment was touched by the sysex write.
+			parts[i]->allSoundOff();
+			parts[i]->resetAllControllers();
+		}
+		Bit8u chan = mt32ram.system.chanAssign[i];
+		if (chan > 15) continue;
+		Bit8u *chanParts = extensions.chantable[chan];
+		for (Bit32u j = 0; j <= 8; j++) {
+			if (chanParts[j] > 8) {
+				chanParts[j] = Bit8u(i);
+				break;
+			}
+		}
+	}
+
+#if MT32EMU_MONITOR_SYSEX > 0
+	Bit8u *rset = mt32ram.system.chanAssign;
+	printDebug(" Part assign:     1=%02d 2=%02d 3=%02d 4=%02d 5=%02d 6=%02d 7=%02d 8=%02d Rhythm=%02d", rset[0], rset[1], rset[2], rset[3], rset[4], rset[5], rset[6], rset[7], rset[8]);
+#endif
+}
+
+void Synth::refreshSystemMasterVol() {
+	// Note, this should only occur when the user turns the volume knob. When the master volume is set via a SysEx, display
+	// doesn't actually update on all real devices. However, we anyway update the display, as we don't foresee a dedicated
+	// API for setting the master volume yet it's rather dubious that one really needs this quirk to be fairly emulated.
+	if (opened) extensions.display->masterVolumeChanged();
+#if MT32EMU_MONITOR_SYSEX > 0
+	printDebug(" Master volume: %d", mt32ram.system.masterVol);
+#endif
+}
+
+void Synth::refreshSystem() {
+	refreshSystemMasterTune();
+	refreshSystemReverbParameters();
+	refreshSystemReserveSettings();
+	refreshSystemChanAssign(0, 8);
+	refreshSystemMasterVol();
+}
+
+void Synth::reset() {
+	if (!opened) return;
+#if MT32EMU_MONITOR_SYSEX > 0
+	printDebug("RESET");
+#endif
+	reportHandler->onDeviceReset();
+	partialManager->deactivateAll();
+	mt32ram = mt32default;
+	for (int i = 0; i < 9; i++) {
+		parts[i]->reset();
+		if (i != 8) {
+			parts[i]->setProgram(controlROMData[controlROMMap->programSettings + i]);
+		} else {
+			parts[8]->refresh();
+		}
+	}
+	if (extensions.masterVolumeOverride < DEFAULT_MASTER_VOLUME) {
+		mt32ram.system.masterVol = extensions.masterVolumeOverride;
+	}
+	refreshSystem();
+	resetMasterTunePitchDelta();
+	isActive();
+}
+
+void Synth::resetMasterTunePitchDelta() {
+	// This effectively resets master tune to 440.0Hz.
+	// Despite that the manual claims 442.0Hz is the default setting for master tune,
+	// it doesn't actually take effect upon a reset due to a bug in the reset routine.
+	// CONFIRMED: This bug is present in all supported Control ROMs.
+	extensions.masterTunePitchDelta = 0;
+#if MT32EMU_MONITOR_SYSEX > 0
+	printDebug(" Actual Master Tune reset to 440.0");
+#endif
+}
+
+Bit32s Synth::getMasterTunePitchDelta() const {
+	return extensions.masterTunePitchDelta;
+}
+
+bool Synth::getDisplayState(char *targetBuffer, bool narrowLCD) const {
+	if (!opened) {
+		memset(targetBuffer, ' ', Display::LCD_TEXT_SIZE);
+		targetBuffer[Display::LCD_TEXT_SIZE] = 0;
+		return false;
+	}
+	return extensions.display->getDisplayState(targetBuffer, narrowLCD);
+}
+
+void Synth::setMainDisplayMode() {
+	if (opened) extensions.display->setMainDisplayMode();
+}
+
+
+void Synth::setDisplayCompatibility(bool oldMT32CompatibilityEnabled) {
+	extensions.oldMT32DisplayFeatures = oldMT32CompatibilityEnabled;
+}
+
+bool Synth::isDisplayOldMT32Compatible() const {
+	return extensions.oldMT32DisplayFeatures;
+}
+
+bool Synth::isDefaultDisplayOldMT32Compatible() const {
+	return opened && controlROMFeatures->oldMT32DisplayFeatures;
+}
+
+/** Defines an interface of a class that maintains storage of variable-sized data of SysEx messages. */
+class MidiEventQueue::SysexDataStorage {
+public:
+	static MidiEventQueue::SysexDataStorage *create(Bit32u storageBufferSize);
+
+	virtual ~SysexDataStorage() {}
+	virtual Bit8u *allocate(Bit32u sysexLength) = 0;
+	virtual void reclaimUnused(const Bit8u *sysexData, Bit32u sysexLength) = 0;
+	virtual void dispose(const Bit8u *sysexData, Bit32u sysexLength) = 0;
+};
+
+/** Storage space for SysEx data is allocated dynamically on demand and is disposed lazily. */
+class DynamicSysexDataStorage : public MidiEventQueue::SysexDataStorage {
+public:
+	Bit8u *allocate(Bit32u sysexLength) {
+		return new Bit8u[sysexLength];
+	}
+
+	void reclaimUnused(const Bit8u *, Bit32u) {}
+
+	void dispose(const Bit8u *sysexData, Bit32u) {
+		delete[] sysexData;
+	}
+};
+
+/**
+ * SysEx data is stored in a preallocated buffer, that makes this kind of storage safe
+ * for use in a realtime thread. Additionally, the space retained by a SysEx event,
+ * that has been processed and thus is no longer necessary, is disposed instantly.
+ */
+class BufferedSysexDataStorage : public MidiEventQueue::SysexDataStorage {
+public:
+	explicit BufferedSysexDataStorage(Bit32u useStorageBufferSize) :
+		storageBuffer(new Bit8u[useStorageBufferSize]),
+		storageBufferSize(useStorageBufferSize),
+		startPosition(),
+		endPosition()
+	{}
+
+	~BufferedSysexDataStorage() {
+		delete[] storageBuffer;
+	}
+
+	Bit8u *allocate(Bit32u sysexLength) {
+		Bit32u myStartPosition = startPosition;
+		Bit32u myEndPosition = endPosition;
+
+		// When the free space isn't contiguous, the data is allocated either right after the end position
+		// or at the buffer beginning, wherever it fits.
+		if (myStartPosition > myEndPosition) {
+			if (myStartPosition - myEndPosition <= sysexLength) return NULL;
+		} else if (storageBufferSize - myEndPosition < sysexLength) {
+			// There's not enough free space at the end to place the data block.
+			if (myStartPosition == myEndPosition) {
+				// The buffer is empty -> reset positions to the buffer beginning.
+				if (storageBufferSize <= sysexLength) return NULL;
+				if (myStartPosition != 0) {
+					myStartPosition = 0;
+					// It's OK to write startPosition here non-atomically. We don't expect any
+					// concurrent reads, as there must be no SysEx messages in the queue.
+					startPosition = myStartPosition;
+				}
+			} else if (myStartPosition <= sysexLength) return NULL;
+			myEndPosition = 0;
+		}
+		endPosition = myEndPosition + sysexLength;
+		return storageBuffer + myEndPosition;
+	}
+
+	void reclaimUnused(const Bit8u *sysexData, Bit32u sysexLength) {
+		if (sysexData == NULL) return;
+		Bit32u allocatedPosition = startPosition;
+		if (storageBuffer + allocatedPosition == sysexData) {
+			startPosition = allocatedPosition + sysexLength;
+		} else if (storageBuffer == sysexData) {
+			// Buffer wrapped around.
+			startPosition = sysexLength;
+		}
+	}
+
+	void dispose(const Bit8u *, Bit32u) {}
+
+private:
+	Bit8u * const storageBuffer;
+	const Bit32u storageBufferSize;
+
+	volatile Bit32u startPosition;
+	volatile Bit32u endPosition;
+};
+
+MidiEventQueue::SysexDataStorage *MidiEventQueue::SysexDataStorage::create(Bit32u storageBufferSize) {
+	if (storageBufferSize > 0) {
+		return new BufferedSysexDataStorage(storageBufferSize);
+	} else {
+		return new DynamicSysexDataStorage;
+	}
+}
+
+MidiEventQueue::MidiEventQueue(Bit32u useRingBufferSize, Bit32u storageBufferSize) :
+	sysexDataStorage(*SysexDataStorage::create(storageBufferSize)),
+	ringBuffer(new MidiEvent[useRingBufferSize]), ringBufferMask(useRingBufferSize - 1)
+{
+	for (Bit32u i = 0; i <= ringBufferMask; i++) {
+		ringBuffer[i].sysexData = NULL;
+	}
+	reset();
+}
+
+MidiEventQueue::~MidiEventQueue() {
+	for (Bit32u i = 0; i <= ringBufferMask; i++) {
+		volatile MidiEvent &currentEvent = ringBuffer[i];
+		sysexDataStorage.dispose(currentEvent.sysexData, currentEvent.sysexLength);
+	}
+	delete &sysexDataStorage;
+	delete[] ringBuffer;
+}
+
+void MidiEventQueue::reset() {
+	startPosition = 0;
+	endPosition = 0;
+}
+
+bool MidiEventQueue::pushShortMessage(Bit32u shortMessageData, Bit32u timestamp) {
+	Bit32u newEndPosition = (endPosition + 1) & ringBufferMask;
+	// If ring buffer is full, bail out.
+	if (startPosition == newEndPosition) return false;
+	volatile MidiEvent &newEvent = ringBuffer[endPosition];
+	sysexDataStorage.dispose(newEvent.sysexData, newEvent.sysexLength);
+	newEvent.sysexData = NULL;
+	newEvent.shortMessageData = shortMessageData;
+	newEvent.timestamp = timestamp;
+	endPosition = newEndPosition;
+	return true;
+}
+
+bool MidiEventQueue::pushSysex(const Bit8u *sysexData, Bit32u sysexLength, Bit32u timestamp) {
+	Bit32u newEndPosition = (endPosition + 1) & ringBufferMask;
+	// If ring buffer is full, bail out.
+	if (startPosition == newEndPosition) return false;
+	volatile MidiEvent &newEvent = ringBuffer[endPosition];
+	sysexDataStorage.dispose(newEvent.sysexData, newEvent.sysexLength);
+	Bit8u *dstSysexData = sysexDataStorage.allocate(sysexLength);
+	if (dstSysexData == NULL) return false;
+	memcpy(dstSysexData, sysexData, sysexLength);
+	newEvent.sysexData = dstSysexData;
+	newEvent.sysexLength = sysexLength;
+	newEvent.timestamp = timestamp;
+	endPosition = newEndPosition;
+	return true;
+}
+
+const volatile MidiEventQueue::MidiEvent *MidiEventQueue::peekMidiEvent() {
+	return isEmpty() ? NULL : &ringBuffer[startPosition];
+}
+
+void MidiEventQueue::dropMidiEvent() {
+	if (isEmpty()) return;
+	volatile MidiEvent &unusedEvent = ringBuffer[startPosition];
+	sysexDataStorage.reclaimUnused(unusedEvent.sysexData, unusedEvent.sysexLength);
+	startPosition = (startPosition + 1) & ringBufferMask;
+}
+
+bool MidiEventQueue::isEmpty() const {
+	return startPosition == endPosition;
+}
+
+void Synth::selectRendererType(RendererType newRendererType) {
+	extensions.selectedRendererType = newRendererType;
+}
+
+RendererType Synth::getSelectedRendererType() const {
+	return extensions.selectedRendererType;
+}
+
+Bit32u Synth::getStereoOutputSampleRate() const {
+	return (analog == NULL) ? SAMPLE_RATE : analog->getOutputSampleRate();
+}
+
+void Renderer::updateDisplayState() {
+	bool midiMessageLEDState;
+	bool midiMessageLEDStateUpdated;
+	bool lcdUpdated;
+	synth.extensions.display->checkDisplayStateUpdated(midiMessageLEDState, midiMessageLEDStateUpdated, lcdUpdated);
+	if (midiMessageLEDStateUpdated) synth.extensions.reportHandler2->onMidiMessageLEDStateUpdated(midiMessageLEDState);
+	if (lcdUpdated) synth.extensions.reportHandler2->onLCDStateUpdated();
+}
+
+template <class Sample>
+void RendererImpl<Sample>::doRender(Sample *stereoStream, Bit32u len) {
+	if (!isActivated()) {
+		incRenderedSampleCount(getAnalog().getDACStreamsLength(len));
+		if (!getAnalog().process(NULL, NULL, NULL, NULL, NULL, NULL, stereoStream, len)) {
+			printDebug("RendererImpl: Invalid call to Analog::process()!\n");
+		}
+		Synth::muteSampleBuffer(stereoStream, len << 1);
+		updateDisplayState();
+		return;
+	}
+
+	while (len > 0) {
+		// As in AnalogOutputMode_ACCURATE mode output is upsampled, MAX_SAMPLES_PER_RUN is more than enough for the temp buffers.
+		Bit32u thisPassLen = len > MAX_SAMPLES_PER_RUN ? MAX_SAMPLES_PER_RUN : len;
+		doRenderStreams(tmpBuffers, getAnalog().getDACStreamsLength(thisPassLen));
+		if (!getAnalog().process(stereoStream, tmpNonReverbLeft, tmpNonReverbRight, tmpReverbDryLeft, tmpReverbDryRight, tmpReverbWetLeft, tmpReverbWetRight, thisPassLen)) {
+			printDebug("RendererImpl: Invalid call to Analog::process()!\n");
+			Synth::muteSampleBuffer(stereoStream, len << 1);
+			return;
+		}
+		stereoStream += thisPassLen << 1;
+		len -= thisPassLen;
+	}
+}
+
+template <class Sample>
+template <class O>
+void RendererImpl<Sample>::doRenderAndConvert(O *stereoStream, Bit32u len) {
+	Sample renderingBuffer[MAX_SAMPLES_PER_RUN << 1];
+	while (len > 0) {
+		Bit32u thisPassLen = len > MAX_SAMPLES_PER_RUN ? MAX_SAMPLES_PER_RUN : len;
+		doRender(renderingBuffer, thisPassLen);
+		convertSampleFormat(renderingBuffer, stereoStream, thisPassLen << 1);
+		stereoStream += thisPassLen << 1;
+		len -= thisPassLen;
+	}
+}
+
+template<>
+void RendererImpl<IntSample>::render(IntSample *stereoStream, Bit32u len) {
+	doRender(stereoStream, len);
+}
+
+template<>
+void RendererImpl<IntSample>::render(FloatSample *stereoStream, Bit32u len) {
+	doRenderAndConvert(stereoStream, len);
+}
+
+template<>
+void RendererImpl<FloatSample>::render(IntSample *stereoStream, Bit32u len) {
+	doRenderAndConvert(stereoStream, len);
+}
+
+template<>
+void RendererImpl<FloatSample>::render(FloatSample *stereoStream, Bit32u len) {
+	doRender(stereoStream, len);
+}
+
+template <class S>
+static inline void renderStereo(bool opened, Renderer *renderer, S *stream, Bit32u len) {
+	if (opened) {
+		renderer->render(stream, len);
+	} else {
+		Synth::muteSampleBuffer(stream, len << 1);
+	}
+}
+
+void Synth::render(Bit16s *stream, Bit32u len) {
+	renderStereo(opened, renderer, stream, len);
+}
+
+void Synth::render(float *stream, Bit32u len) {
+	renderStereo(opened, renderer, stream, len);
+}
+
+template <class Sample>
+static inline void advanceStream(Sample *&stream, Bit32u len) {
+	if (stream != NULL) {
+		stream += len;
+	}
+}
+
+template <class Sample>
+static inline void advanceStreams(DACOutputStreams<Sample> &streams, Bit32u len) {
+	advanceStream(streams.nonReverbLeft, len);
+	advanceStream(streams.nonReverbRight, len);
+	advanceStream(streams.reverbDryLeft, len);
+	advanceStream(streams.reverbDryRight, len);
+	advanceStream(streams.reverbWetLeft, len);
+	advanceStream(streams.reverbWetRight, len);
+}
+
+template <class Sample>
+static inline void muteStreams(const DACOutputStreams<Sample> &streams, Bit32u len) {
+	Synth::muteSampleBuffer(streams.nonReverbLeft, len);
+	Synth::muteSampleBuffer(streams.nonReverbRight, len);
+	Synth::muteSampleBuffer(streams.reverbDryLeft, len);
+	Synth::muteSampleBuffer(streams.reverbDryRight, len);
+	Synth::muteSampleBuffer(streams.reverbWetLeft, len);
+	Synth::muteSampleBuffer(streams.reverbWetRight, len);
+}
+
+template <class I, class O>
+static inline void convertStreamsFormat(const DACOutputStreams<I> &inStreams, const DACOutputStreams<O> &outStreams, Bit32u len) {
+	convertSampleFormat(inStreams.nonReverbLeft, outStreams.nonReverbLeft, len);
+	convertSampleFormat(inStreams.nonReverbRight, outStreams.nonReverbRight, len);
+	convertSampleFormat(inStreams.reverbDryLeft, outStreams.reverbDryLeft, len);
+	convertSampleFormat(inStreams.reverbDryRight, outStreams.reverbDryRight, len);
+	convertSampleFormat(inStreams.reverbWetLeft, outStreams.reverbWetLeft, len);
+	convertSampleFormat(inStreams.reverbWetRight, outStreams.reverbWetRight, len);
+}
+
+template <class Sample>
+void RendererImpl<Sample>::doRenderStreams(const DACOutputStreams<Sample> &streams, Bit32u len)
+{
+	DACOutputStreams<Sample> tmpStreams = streams;
+	while (len > 0) {
+		// We need to ensure zero-duration notes will play so add minimum 1-sample delay.
+		Bit32u thisLen = 1;
+		if (!isAbortingPoly()) {
+			const volatile MidiEventQueue::MidiEvent *nextEvent = getMidiQueue().peekMidiEvent();
+			Bit32s samplesToNextEvent = (nextEvent != NULL) ? Bit32s(nextEvent->timestamp - getRenderedSampleCount()) : MAX_SAMPLES_PER_RUN;
+			if (samplesToNextEvent > 0) {
+				thisLen = len > MAX_SAMPLES_PER_RUN ? MAX_SAMPLES_PER_RUN : len;
+				if (thisLen > Bit32u(samplesToNextEvent)) {
+					thisLen = samplesToNextEvent;
+				}
+			} else {
+				if (nextEvent->sysexData == NULL) {
+					synth.playMsgNow(nextEvent->shortMessageData);
+					// If a poly is aborting we don't drop the event from the queue.
+					// Instead, we'll return to it again when the abortion is done.
+					if (!isAbortingPoly()) {
+						getMidiQueue().dropMidiEvent();
+					}
+				} else {
+					synth.playSysexNow(nextEvent->sysexData, nextEvent->sysexLength);
+					getMidiQueue().dropMidiEvent();
+				}
+			}
+		}
+		produceStreams(tmpStreams, thisLen);
+		advanceStreams(tmpStreams, thisLen);
+		len -= thisLen;
+	}
+}
+
+template <class Sample>
+template <class O>
+void RendererImpl<Sample>::doRenderAndConvertStreams(const DACOutputStreams<O> &streams, Bit32u len) {
+	Sample cnvNonReverbLeft[MAX_SAMPLES_PER_RUN], cnvNonReverbRight[MAX_SAMPLES_PER_RUN];
+	Sample cnvReverbDryLeft[MAX_SAMPLES_PER_RUN], cnvReverbDryRight[MAX_SAMPLES_PER_RUN];
+	Sample cnvReverbWetLeft[MAX_SAMPLES_PER_RUN], cnvReverbWetRight[MAX_SAMPLES_PER_RUN];
+
+	const DACOutputStreams<Sample> cnvStreams = {
+		cnvNonReverbLeft, cnvNonReverbRight,
+		cnvReverbDryLeft, cnvReverbDryRight,
+		cnvReverbWetLeft, cnvReverbWetRight
+	};
+
+	DACOutputStreams<O> tmpStreams = streams;
+
+	while (len > 0) {
+		Bit32u thisPassLen = len > MAX_SAMPLES_PER_RUN ? MAX_SAMPLES_PER_RUN : len;
+		doRenderStreams(cnvStreams, thisPassLen);
+		convertStreamsFormat(cnvStreams, tmpStreams, thisPassLen);
+		advanceStreams(tmpStreams, thisPassLen);
+		len -= thisPassLen;
+	}
+}
+
+template<>
+void RendererImpl<IntSample>::renderStreams(const DACOutputStreams<IntSample> &streams, Bit32u len) {
+	doRenderStreams(streams, len);
+}
+
+template<>
+void RendererImpl<IntSample>::renderStreams(const DACOutputStreams<FloatSample> &streams, Bit32u len) {
+	doRenderAndConvertStreams(streams, len);
+}
+
+template<>
+void RendererImpl<FloatSample>::renderStreams(const DACOutputStreams<IntSample> &streams, Bit32u len) {
+	doRenderAndConvertStreams(streams, len);
+}
+
+template<>
+void RendererImpl<FloatSample>::renderStreams(const DACOutputStreams<FloatSample> &streams, Bit32u len) {
+	doRenderStreams(streams, len);
+}
+
+template <class S>
+static inline void renderStreams(bool opened, Renderer *renderer, const DACOutputStreams<S> &streams, Bit32u len) {
+	if (opened) {
+		renderer->renderStreams(streams, len);
+	} else {
+		muteStreams(streams, len);
+	}
+}
+
+void Synth::renderStreams(const DACOutputStreams<Bit16s> &streams, Bit32u len) {
+	MT32Emu::renderStreams(opened, renderer, streams, len);
+}
+
+void Synth::renderStreams(const DACOutputStreams<float> &streams, Bit32u len) {
+	MT32Emu::renderStreams(opened, renderer, streams, len);
+}
+
+void Synth::renderStreams(
+	Bit16s *nonReverbLeft, Bit16s *nonReverbRight,
+	Bit16s *reverbDryLeft, Bit16s *reverbDryRight,
+	Bit16s *reverbWetLeft, Bit16s *reverbWetRight,
+	Bit32u len)
+{
+	DACOutputStreams<IntSample> streams = {
+		nonReverbLeft, nonReverbRight,
+		reverbDryLeft, reverbDryRight,
+		reverbWetLeft, reverbWetRight
+	};
+	renderStreams(streams, len);
+}
+
+void Synth::renderStreams(
+	float *nonReverbLeft, float *nonReverbRight,
+	float *reverbDryLeft, float *reverbDryRight,
+	float *reverbWetLeft, float *reverbWetRight,
+	Bit32u len)
+{
+	DACOutputStreams<FloatSample> streams = {
+		nonReverbLeft, nonReverbRight,
+		reverbDryLeft, reverbDryRight,
+		reverbWetLeft, reverbWetRight
+	};
+	renderStreams(streams, len);
+}
+
+// In GENERATION2 units, the output from LA32 goes to the Boss chip already bit-shifted.
+// In NICE mode, it's also better to increase volume before the reverb processing to preserve accuracy.
+template <>
+void RendererImpl<IntSample>::produceLA32Output(IntSample *buffer, Bit32u len) {
+	switch (synth.getDACInputMode()) {
+		case DACInputMode_GENERATION2:
+			while (len--) {
+				*buffer = (*buffer & 0x8000) | ((*buffer << 1) & 0x7FFE) | ((*buffer >> 14) & 0x0001);
+				++buffer;
+			}
+			break;
+		case DACInputMode_NICE:
+			while (len--) {
+				*buffer = Synth::clipSampleEx(IntSampleEx(*buffer) << 1);
+				++buffer;
+			}
+			break;
+		default:
+			break;
+	}
+}
+
+template <>
+void RendererImpl<IntSample>::convertSamplesToOutput(IntSample *buffer, Bit32u len) {
+	if (synth.getDACInputMode() == DACInputMode_GENERATION1) {
+		while (len--) {
+			*buffer = IntSample((*buffer & 0x8000) | ((*buffer << 1) & 0x7FFE));
+			++buffer;
+		}
+	}
+}
+
+static inline float produceDistortedSample(float sample) {
+	// Here we roughly simulate the distortion caused by the DAC bit shift.
+	if (sample < -1.0f) {
+		return sample + 2.0f;
+	} else if (1.0f < sample) {
+		return sample - 2.0f;
+	}
+	return sample;
+}
+
+template <>
+void RendererImpl<FloatSample>::produceLA32Output(FloatSample *buffer, Bit32u len) {
+	switch (synth.getDACInputMode()) {
+	case DACInputMode_NICE:
+		// Note, we do not do any clamping for floats here to avoid introducing distortions.
+		// This means that the output signal may actually overshoot the unity when the volume is set too high.
+		// We leave it up to the consumer whether the output is to be clamped or properly normalised further on.
+		while (len--) {
+			*buffer *= 2.0f;
+			buffer++;
+		}
+		break;
+	case DACInputMode_GENERATION2:
+		while (len--) {
+			*buffer = produceDistortedSample(2.0f * *buffer);
+			buffer++;
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+template <>
+void RendererImpl<FloatSample>::convertSamplesToOutput(FloatSample *buffer, Bit32u len) {
+	if (synth.getDACInputMode() == DACInputMode_GENERATION1) {
+		while (len--) {
+			*buffer = produceDistortedSample(2.0f * *buffer);
+			buffer++;
+		}
+	}
+}
+
+template <class Sample>
+void RendererImpl<Sample>::produceStreams(const DACOutputStreams<Sample> &streams, Bit32u len) {
+	if (isActivated()) {
+		// Even if LA32 output isn't desired, we proceed anyway with temp buffers
+		Sample *nonReverbLeft = streams.nonReverbLeft == NULL ? tmpNonReverbLeft : streams.nonReverbLeft;
+		Sample *nonReverbRight = streams.nonReverbRight == NULL ? tmpNonReverbRight : streams.nonReverbRight;
+		Sample *reverbDryLeft = streams.reverbDryLeft == NULL ? tmpReverbDryLeft : streams.reverbDryLeft;
+		Sample *reverbDryRight = streams.reverbDryRight == NULL ? tmpReverbDryRight : streams.reverbDryRight;
+
+		Synth::muteSampleBuffer(nonReverbLeft, len);
+		Synth::muteSampleBuffer(nonReverbRight, len);
+		Synth::muteSampleBuffer(reverbDryLeft, len);
+		Synth::muteSampleBuffer(reverbDryRight, len);
+
+		for (unsigned int i = 0; i < synth.getPartialCount(); i++) {
+			if (getPartialManager().shouldReverb(i)) {
+				getPartialManager().produceOutput(i, reverbDryLeft, reverbDryRight, len);
+			} else {
+				getPartialManager().produceOutput(i, nonReverbLeft, nonReverbRight, len);
+			}
+		}
+
+		produceLA32Output(reverbDryLeft, len);
+		produceLA32Output(reverbDryRight, len);
+
+		if (synth.isReverbEnabled()) {
+			if (!getReverbModel().process(reverbDryLeft, reverbDryRight, streams.reverbWetLeft, streams.reverbWetRight, len)) {
+				printDebug("RendererImpl: Invalid call to BReverbModel::process()!\n");
+			}
+			if (streams.reverbWetLeft != NULL) convertSamplesToOutput(streams.reverbWetLeft, len);
+			if (streams.reverbWetRight != NULL) convertSamplesToOutput(streams.reverbWetRight, len);
+		} else {
+			Synth::muteSampleBuffer(streams.reverbWetLeft, len);
+			Synth::muteSampleBuffer(streams.reverbWetRight, len);
+		}
+
+		// Don't bother with conversion if the output is going to be unused
+		if (streams.nonReverbLeft != NULL) {
+			produceLA32Output(nonReverbLeft, len);
+			convertSamplesToOutput(nonReverbLeft, len);
+		}
+		if (streams.nonReverbRight != NULL) {
+			produceLA32Output(nonReverbRight, len);
+			convertSamplesToOutput(nonReverbRight, len);
+		}
+		if (streams.reverbDryLeft != NULL) convertSamplesToOutput(reverbDryLeft, len);
+		if (streams.reverbDryRight != NULL) convertSamplesToOutput(reverbDryRight, len);
+	} else {
+		muteStreams(streams, len);
+	}
+
+	getPartialManager().clearAlreadyOutputed();
+	incRenderedSampleCount(len);
+	updateDisplayState();
+}
+
+void Synth::printPartialUsage(Bit32u sampleOffset) {
+	unsigned int partialUsage[9];
+	partialManager->getPerPartPartialUsage(partialUsage);
+	if (sampleOffset > 0) {
+		printDebug("[+%u] Partial Usage: 1:%02d 2:%02d 3:%02d 4:%02d 5:%02d 6:%02d 7:%02d 8:%02d R: %02d  TOTAL: %02d", sampleOffset, partialUsage[0], partialUsage[1], partialUsage[2], partialUsage[3], partialUsage[4], partialUsage[5], partialUsage[6], partialUsage[7], partialUsage[8], getPartialCount() - partialManager->getFreePartialCount());
+	} else {
+		printDebug("Partial Usage: 1:%02d 2:%02d 3:%02d 4:%02d 5:%02d 6:%02d 7:%02d 8:%02d R: %02d  TOTAL: %02d", partialUsage[0], partialUsage[1], partialUsage[2], partialUsage[3], partialUsage[4], partialUsage[5], partialUsage[6], partialUsage[7], partialUsage[8], getPartialCount() - partialManager->getFreePartialCount());
+	}
+}
+
+bool Synth::hasActivePartials() const {
+	if (!opened) {
+		return false;
+	}
+	for (unsigned int partialNum = 0; partialNum < getPartialCount(); partialNum++) {
+		if (partialManager->getPartial(partialNum)->isActive()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool Synth::isActive() {
+	if (!opened) {
+		return false;
+	}
+	if (!midiQueue->isEmpty() || hasActivePartials()) {
+		return true;
+	}
+	if (isReverbEnabled() && reverbModel->isActive()) {
+		return true;
+	}
+	activated = false;
+	return false;
+}
+
+Bit32u Synth::getPartialCount() const {
+	return partialCount;
+}
+
+void Synth::getPartStates(bool *partStates) const {
+	if (!opened) {
+		memset(partStates, 0, 9 * sizeof(bool));
+		return;
+	}
+	for (int partNumber = 0; partNumber < 9; partNumber++) {
+		const Part *part = parts[partNumber];
+		partStates[partNumber] = part->getActiveNonReleasingPartialCount() > 0;
+	}
+}
+
+Bit32u Synth::getPartStates() const {
+	if (!opened) return 0;
+	bool partStates[9];
+	getPartStates(partStates);
+	Bit32u bitSet = 0;
+	for (int partNumber = 8; partNumber >= 0; partNumber--) {
+		bitSet = (bitSet << 1) | (partStates[partNumber] ? 1 : 0);
+	}
+	return bitSet;
+}
+
+void Synth::getPartialStates(PartialState *partialStates) const {
+	if (!opened) {
+		memset(partialStates, 0, partialCount * sizeof(PartialState));
+		return;
+	}
+	for (unsigned int partialNum = 0; partialNum < partialCount; partialNum++) {
+		partialStates[partialNum] = getPartialState(partialManager, partialNum);
+	}
+}
+
+void Synth::getPartialStates(Bit8u *partialStates) const {
+	if (!opened) {
+		memset(partialStates, 0, ((partialCount + 3) >> 2));
+		return;
+	}
+	for (unsigned int quartNum = 0; (4 * quartNum) < partialCount; quartNum++) {
+		Bit8u packedStates = 0;
+		for (unsigned int i = 0; i < 4; i++) {
+			unsigned int partialNum = (4 * quartNum) + i;
+			if (partialCount <= partialNum) break;
+			PartialState partialState = getPartialState(partialManager, partialNum);
+			packedStates |= (partialState & 3) << (2 * i);
+		}
+		partialStates[quartNum] = packedStates;
+	}
+}
+
+Bit32u Synth::getPlayingNotes(Bit8u partNumber, Bit8u *keys, Bit8u *velocities) const {
+	Bit32u playingNotes = 0;
+	if (opened && (partNumber < 9)) {
+		const Part *part = parts[partNumber];
+		const Poly *poly = part->getFirstActivePoly();
+		while (poly != NULL) {
+			keys[playingNotes] = Bit8u(poly->getKey());
+			velocities[playingNotes] = Bit8u(poly->getVelocity());
+			playingNotes++;
+			poly = poly->getNext();
+		}
+	}
+	return playingNotes;
+}
+
+const char *Synth::getPatchName(Bit8u partNumber) const {
+	return (!opened || partNumber > 8) ? NULL : parts[partNumber]->getCurrentInstr();
+}
+
+bool Synth::getSoundGroupName(char *soundGroupName, Bit8u timbreGroup, Bit8u timbreNumber) const {
+	if (!opened || 63 < timbreNumber) return false;
+	const char *foundGroupName = getSoundGroupName(timbreGroup, timbreNumber);
+	if (foundGroupName == NULL) return false;
+	memcpy(soundGroupName, foundGroupName, 7);
+	soundGroupName[7] = 0;
+	return true;
+}
+
+bool Synth::getSoundName(char *soundName, Bit8u timbreGroup, Bit8u timbreNumber) const {
+	if (!opened || 3 < timbreGroup) return false;
+	Bit8u timbresInGroup = 3 == timbreGroup ? controlROMMap->timbreRCount : 64;
+	if (timbresInGroup <= timbreNumber) return false;
+	TimbreParam::CommonParam &timbreCommon = mt32ram.timbres[timbreGroup * 64 + timbreNumber].timbre.common;
+	if (timbreCommon.partialMute == 0) return false;
+	memcpy(soundName, timbreCommon.name, sizeof timbreCommon.name);
+	soundName[sizeof timbreCommon.name] = 0;
+	return true;
+}
+
+const Part *Synth::getPart(Bit8u partNum) const {
+	if (partNum > 8) {
+		return NULL;
+	}
+	return parts[partNum];
+}
+
+void MemoryRegion::read(unsigned int entry, unsigned int off, Bit8u *dst, unsigned int len) const {
+	off += entry * entrySize;
+	// This method should never be called with out-of-bounds parameters,
+	// or on an unsupported region - seeing any of this debug output indicates a bug in the emulator
+	if (off > entrySize * entries - 1) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		synth->printDebug("read[%d]: parameters start out of bounds: entry=%d, off=%d, len=%d", type, entry, off, len);
+#endif
+		return;
+	}
+	if (off + len > entrySize * entries) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		synth->printDebug("read[%d]: parameters end out of bounds: entry=%d, off=%d, len=%d", type, entry, off, len);
+#endif
+		len = entrySize * entries - off;
+	}
+	Bit8u *src = getRealMemory();
+	if (src == NULL) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		synth->printDebug("read[%d]: unreadable region: entry=%d, off=%d, len=%d", type, entry, off, len);
+#endif
+		return;
+	}
+	memcpy(dst, src + off, len);
+}
+
+void MemoryRegion::write(unsigned int entry, unsigned int off, const Bit8u *src, unsigned int len, bool init) const {
+	unsigned int memOff = entry * entrySize + off;
+	// This method should never be called with out-of-bounds parameters,
+	// or on an unsupported region - seeing any of this debug output indicates a bug in the emulator
+	if (off > entrySize * entries - 1) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		synth->printDebug("write[%d]: parameters start out of bounds: entry=%d, off=%d, len=%d", type, entry, off, len);
+#endif
+		return;
+	}
+	if (off + len > entrySize * entries) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		synth->printDebug("write[%d]: parameters end out of bounds: entry=%d, off=%d, len=%d", type, entry, off, len);
+#endif
+		len = entrySize * entries - off;
+	}
+	Bit8u *dest = getRealMemory();
+	if (dest == NULL) {
+#if MT32EMU_MONITOR_SYSEX > 0
+		synth->printDebug("write[%d]: unwritable region: entry=%d, off=%d, len=%d", type, entry, off, len);
+#endif
+		return;
+	}
+
+	for (unsigned int i = 0; i < len; i++) {
+		Bit8u desiredValue = src[i];
+		Bit8u maxValue = getMaxValue(memOff);
+		// maxValue == 0 means write-protected unless called from initialisation code, in which case it really means the maximum value is 0.
+		if (maxValue != 0 || init) {
+			if (desiredValue > maxValue) {
+#if MT32EMU_MONITOR_SYSEX > 0
+				synth->printDebug("write[%d]: Wanted 0x%02x at %d, but max 0x%02x", type, desiredValue, memOff, maxValue);
+#endif
+				desiredValue = maxValue;
+			}
+			dest[memOff] = desiredValue;
+		} else if (desiredValue != 0) {
+#if MT32EMU_MONITOR_SYSEX > 0
+			// Only output debug info if they wanted to write non-zero, since a lot of things cause this to spit out a lot of debug info otherwise.
+			synth->printDebug("write[%d]: Wanted 0x%02x at %d, but write-protected", type, desiredValue, memOff);
+#endif
+		}
+		memOff++;
+	}
+}
+
+} // namespace MT32Emu
+
+#ifdef MT32EMU_WITH_TESTING
+
+#include "test/TestAccessors.h"
+
+using namespace MT32Emu;
+
+const ControlROMMap *Test::getControlROMMap(const char *shortName) {
+	return MT32Emu::getControlROMMap(shortName);
+}
+
+#endif // #ifdef MT32EMU_WITH_TESTING

--- a/vendor/munt/src/Synth.h
+++ b/vendor/munt/src/Synth.h
@@ -1,0 +1,668 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_SYNTH_H
+#define MT32EMU_SYNTH_H
+
+#include <cstdarg>
+#include <cstddef>
+#include <cstring>
+
+#include "globals.h"
+#include "Types.h"
+#include "Enumerations.h"
+
+namespace MT32Emu {
+
+class Analog;
+class BReverbModel;
+class Extensions;
+class MemoryRegion;
+class MidiEventQueue;
+class Part;
+class Poly;
+class Partial;
+class PartialManager;
+class Renderer;
+class ROMImage;
+
+class PatchTempMemoryRegion;
+class RhythmTempMemoryRegion;
+class TimbreTempMemoryRegion;
+class PatchesMemoryRegion;
+class TimbresMemoryRegion;
+class SystemMemoryRegion;
+class DisplayMemoryRegion;
+class ResetMemoryRegion;
+
+struct ControlROMFeatureSet;
+struct ControlROMMap;
+struct PCMWaveEntry;
+struct MemParams;
+
+const Bit8u SYSEX_MANUFACTURER_ROLAND = 0x41;
+
+const Bit8u SYSEX_MDL_MT32 = 0x16;
+const Bit8u SYSEX_MDL_D50 = 0x14;
+
+const Bit8u SYSEX_CMD_RQ1 = 0x11; // Request data #1
+const Bit8u SYSEX_CMD_DT1 = 0x12; // Data set 1
+const Bit8u SYSEX_CMD_WSD = 0x40; // Want to send data
+const Bit8u SYSEX_CMD_RQD = 0x41; // Request data
+const Bit8u SYSEX_CMD_DAT = 0x42; // Data set
+const Bit8u SYSEX_CMD_ACK = 0x43; // Acknowledge
+const Bit8u SYSEX_CMD_EOD = 0x45; // End of data
+const Bit8u SYSEX_CMD_ERR = 0x4E; // Communications error
+const Bit8u SYSEX_CMD_RJC = 0x4F; // Rejection
+
+// This value isn't quite correct: the new-gen MT-32 control ROMs (ver. 2.XX) are twice as big.
+// Nevertheless, this is still relevant for library internal usage because the higher half
+// of those ROMs only contains the demo songs in all cases.
+const Bit32u CONTROL_ROM_SIZE = 64 * 1024;
+
+// Set of multiplexed output streams appeared at the DAC entrance.
+template <class T>
+struct DACOutputStreams {
+	T *nonReverbLeft;
+	T *nonReverbRight;
+	T *reverbDryLeft;
+	T *reverbDryRight;
+	T *reverbWetLeft;
+	T *reverbWetRight;
+};
+
+// Class for the client to supply callbacks for reporting various errors and information
+class MT32EMU_EXPORT ReportHandler {
+public:
+	virtual ~ReportHandler() {}
+
+	// Callback for debug messages, in vprintf() format
+	virtual void printDebug(const char *fmt, va_list list);
+	// Callbacks for reporting errors
+	virtual void onErrorControlROM() {}
+	virtual void onErrorPCMROM() {}
+	// Callback for reporting about displaying a new custom message on LCD
+	virtual void showLCDMessage(const char *message);
+	// Callback for reporting actual processing of a MIDI message
+	virtual void onMIDIMessagePlayed() {}
+	// Callback for reporting an overflow of the input MIDI queue.
+	// Returns true if a recovery action was taken and yet another attempt to enqueue the MIDI event is desired.
+	virtual bool onMIDIQueueOverflow() { return false; }
+	// Callback invoked when a System Realtime MIDI message is detected at the input.
+	virtual void onMIDISystemRealtime(Bit8u /* systemRealtime */) {}
+	// Callbacks for reporting system events
+	virtual void onDeviceReset() {}
+	virtual void onDeviceReconfig() {}
+	// Callbacks for reporting changes of reverb settings
+	virtual void onNewReverbMode(Bit8u /* mode */) {}
+	virtual void onNewReverbTime(Bit8u /* time */) {}
+	virtual void onNewReverbLevel(Bit8u /* level */) {}
+	// Callbacks for reporting various information
+	virtual void onPolyStateChanged(Bit8u /* partNum */) {}
+	virtual void onProgramChanged(Bit8u /* partNum */, const char * /* soundGroupName */, const char * /* patchName */) {}
+};
+
+// Extends ReportHandler, so that the client may supply callbacks for reporting signals about updated display state.
+class MT32EMU_EXPORT_V(2.6) ReportHandler2 : public ReportHandler {
+public:
+	virtual ~ReportHandler2() {}
+
+	// Invoked to signal about a change of the emulated LCD state. Use method Synth::getDisplayState to retrieve the actual data.
+	// This callback will not be invoked on further changes, until the client retrieves the LCD state.
+	virtual void onLCDStateUpdated() {}
+	// Invoked when the emulated MIDI MESSAGE LED changes state. The ledState parameter represents whether the LED is ON.
+	virtual void onMidiMessageLEDStateUpdated(bool /* ledState */) {}
+};
+
+// Extends ReportHandler for delivering signals about insufficient partials conditions to the client.
+class MT32EMU_EXPORT_V(2.8) ReportHandler3 : public ReportHandler2 {
+public:
+	virtual ~ReportHandler3() {}
+
+	// Invoked in case the NoteOn MIDI message currently being processed cannot be played due to insufficient free partials.
+	virtual void onNoteOnIgnored(Bit32u /* partialsNeeded */, Bit32u /* partialsFree */) {}
+	// Invoked in case the partial allocator starts premature silencing a currently playing poly to free partials necessary
+	// for processing the preceding NoteOn MIDI message.
+	virtual void onPlayingPolySilenced(Bit32u /* partialsNeeded */, Bit32u /* partialsFree */) {}
+};
+
+class Synth {
+friend class DefaultMidiStreamParser;
+friend class Display;
+friend class Part;
+friend class Partial;
+friend class PartialManager;
+friend class Poly;
+friend class Renderer;
+friend class RhythmPart;
+friend class SamplerateAdapter;
+friend class SoxrAdapter;
+friend class TVA;
+friend class TVF;
+friend class TVP;
+
+private:
+	// **************************** Implementation fields **************************
+
+	PatchTempMemoryRegion *patchTempMemoryRegion;
+	RhythmTempMemoryRegion *rhythmTempMemoryRegion;
+	TimbreTempMemoryRegion *timbreTempMemoryRegion;
+	PatchesMemoryRegion *patchesMemoryRegion;
+	TimbresMemoryRegion *timbresMemoryRegion;
+	SystemMemoryRegion *systemMemoryRegion;
+	DisplayMemoryRegion *displayMemoryRegion;
+	ResetMemoryRegion *resetMemoryRegion;
+
+	Bit8u *paddedTimbreMaxTable;
+
+	PCMWaveEntry *pcmWaves; // Array
+
+	const ControlROMFeatureSet *controlROMFeatures;
+	const ControlROMMap *controlROMMap;
+	Bit8u controlROMData[CONTROL_ROM_SIZE];
+	Bit16s *pcmROMData;
+	size_t pcmROMSize; // This is in 16-bit samples, therefore half the number of bytes in the ROM
+
+	Bit8u soundGroupIx[128]; // For each standard timbre
+	const char (*soundGroupNames)[9]; // Array
+
+	Bit32u partialCount;
+	Bit8u nukeme[16]; // FIXME: Nuke it. For binary compatibility only.
+
+	MidiEventQueue *midiQueue;
+	volatile Bit32u lastReceivedMIDIEventTimestamp;
+	volatile Bit32u renderedSampleCount;
+
+	MemParams &mt32ram, &mt32default;
+
+	BReverbModel *reverbModels[4];
+	BReverbModel *reverbModel;
+	bool reverbOverridden;
+
+	MIDIDelayMode midiDelayMode;
+	DACInputMode dacInputMode;
+
+	float outputGain;
+	float reverbOutputGain;
+
+	bool reversedStereoEnabled;
+
+	bool opened;
+	bool activated;
+
+	bool isDefaultReportHandler; // No longer used, retained for binary compatibility only.
+	ReportHandler *reportHandler;
+
+	PartialManager *partialManager;
+	Part *parts[9];
+
+	// When a partial needs to be aborted to free it up for use by a new Poly,
+	// the controller will busy-loop waiting for the sound to finish.
+	// We emulate this by delaying new MIDI events processing until abortion finishes.
+	Poly *abortingPoly;
+
+	Analog *analog;
+	Renderer *renderer;
+
+	// Binary compatibility helper.
+	Extensions &extensions;
+
+	// **************************** Implementation methods **************************
+
+	Bit32u addMIDIInterfaceDelay(Bit32u len, Bit32u timestamp);
+	bool isAbortingPoly() const { return abortingPoly != NULL; }
+
+	void writeSysexGlobal(Bit32u addr, const Bit8u *sysex, Bit32u len);
+	void readSysex(Bit8u channel, const Bit8u *sysex, Bit32u len) const;
+	void initMemoryRegions();
+	void deleteMemoryRegions();
+	MemoryRegion *findMemoryRegion(Bit32u addr);
+	void writeMemoryRegion(const MemoryRegion *region, Bit32u addr, Bit32u len, const Bit8u *data);
+	void readMemoryRegion(const MemoryRegion *region, Bit32u addr, Bit32u len, Bit8u *data);
+
+	bool loadControlROM(const ROMImage &controlROMImage);
+	bool loadPCMROM(const ROMImage &pcmROMImage);
+
+	bool initPCMList(Bit16u mapAddress, Bit16u count);
+	bool initTimbres(Bit16u mapAddress, Bit16u offset, Bit16u timbreCount, Bit16u startTimbre, bool compressed);
+	bool initCompressedTimbre(TimbresMemoryRegion &tempRegion, Bit16u absTimbreNum, const Bit8u *src, Bit32u srcLen);
+	void initReverbModels(bool mt32CompatibleMode);
+	void initSoundGroups(char newSoundGroupNames[][9]);
+
+	void refreshSystemMasterTune();
+	void refreshSystemReverbParameters();
+	void refreshSystemReserveSettings();
+	void refreshSystemChanAssign(Bit8u firstPart, Bit8u lastPart);
+	void refreshSystemMasterVol();
+	void refreshSystem();
+	void reset();
+	void dispose();
+
+	void printPartialUsage(Bit32u sampleOffset = 0);
+
+	void rhythmNotePlayed() const;
+	void voicePartStateChanged(Bit8u partNum, bool activated) const;
+	void newTimbreSet(Bit8u partNum) const;
+	const char *getSoundGroupName(const Part *part) const;
+	const char *getSoundGroupName(Bit8u timbreGroup, Bit8u timbreNumber) const;
+	void printDebug(const char *fmt, ...);
+
+	// partNum should be 0..7 for Part 1..8, or 8 for Rhythm
+	const Part *getPart(Bit8u partNum) const;
+
+	void resetMasterTunePitchDelta();
+	Bit32s getMasterTunePitchDelta() const;
+
+	ReportHandler3 *getReportHandler3();
+
+	void playUnpackedShortMessage(Bit8u partNum, Bit8u command, Bit8u data1, Bit8u data2);
+
+public:
+	static inline Bit16s clipSampleEx(Bit32s sampleEx) {
+		// Clamp values above 32767 to 32767, and values below -32768 to -32768
+		// FIXME: Do we really need this stuff? I think these branches are very well predicted. Instead, this introduces a chain.
+		// The version below is actually a bit faster on my system...
+		//return ((sampleEx + 0x8000) & ~0xFFFF) ? Bit16s((sampleEx >> 31) ^ 0x7FFF) : (Bit16s)sampleEx;
+		return ((-0x8000 <= sampleEx) && (sampleEx <= 0x7FFF)) ? Bit16s(sampleEx) : Bit16s((sampleEx >> 31) ^ 0x7FFF);
+	}
+
+	static inline float clipSampleEx(float sampleEx) {
+		return sampleEx;
+	}
+
+	template <class S>
+	static inline void muteSampleBuffer(S *buffer, Bit32u len) {
+		if (buffer == NULL) return;
+		memset(buffer, 0, len * sizeof(S));
+	}
+
+	static inline void muteSampleBuffer(float *buffer, Bit32u len) {
+		if (buffer == NULL) return;
+		// FIXME: Use memset() where compatibility is guaranteed (if this turns out to be a win)
+		while (len--) {
+			*(buffer++) = 0.0f;
+		}
+	}
+
+	static inline Bit16s convertSample(float sample) {
+		return Synth::clipSampleEx(Bit32s(sample * 32768.0f)); // This multiplier corresponds to normalised floats
+	}
+
+	static inline float convertSample(Bit16s sample) {
+		return float(sample) / 32768.0f; // This multiplier corresponds to normalised floats
+	}
+
+	// Returns library version as an integer in format: 0x00MMmmpp, where:
+	// MM - major version number
+	// mm - minor version number
+	// pp - patch number
+	MT32EMU_EXPORT static Bit32u getLibraryVersionInt();
+	// Returns library version as a C-string in format: "MAJOR.MINOR.PATCH"
+	MT32EMU_EXPORT static const char *getLibraryVersionString();
+
+	MT32EMU_EXPORT static Bit32u getShortMessageLength(Bit32u msg);
+	MT32EMU_EXPORT static Bit8u calcSysexChecksum(const Bit8u *data, const Bit32u len, const Bit8u initChecksum = 0);
+
+	// Returns output sample rate used in emulation of stereo analog circuitry of hardware units.
+	// See comment for AnalogOutputMode.
+	MT32EMU_EXPORT static Bit32u getStereoOutputSampleRate(AnalogOutputMode analogOutputMode);
+
+	// Optionally sets callbacks for reporting various errors, information and debug messages
+	MT32EMU_EXPORT explicit Synth(ReportHandler *useReportHandler = NULL);
+	MT32EMU_EXPORT ~Synth();
+
+	// Sets an implementation of ReportHandler2 interface for reporting various errors, information and debug messages.
+	// If the argument is NULL, the default implementation is installed as a fallback.
+	MT32EMU_EXPORT_V(2.6) void setReportHandler2(ReportHandler2 *reportHandler2);
+	// Sets an implementation of ReportHandler3 interface for reporting various errors, information and debug messages.
+	// If the argument is NULL, the default implementation is installed as a fallback.
+	MT32EMU_EXPORT_V(2.8) void setReportHandler3(ReportHandler3 *reportHandler3);
+
+	// Used to initialise the MT-32. Must be called before any other function.
+	// Returns true if initialization was successful, otherwise returns false.
+	// controlROMImage and pcmROMImage represent full Control and PCM ROM images for use by synth.
+	// usePartialCount sets the maximum number of partials playing simultaneously for this session (optional).
+	// analogOutputMode sets the mode for emulation of analogue circuitry of the hardware units (optional).
+	MT32EMU_EXPORT bool open(const ROMImage &controlROMImage, const ROMImage &pcmROMImage, Bit32u usePartialCount = DEFAULT_MAX_PARTIALS, AnalogOutputMode analogOutputMode = AnalogOutputMode_COARSE);
+
+	// Overloaded method which opens the synth with default partial count.
+	MT32EMU_EXPORT bool open(const ROMImage &controlROMImage, const ROMImage &pcmROMImage, AnalogOutputMode analogOutputMode);
+
+	// Closes the MT-32 and deallocates any memory used by the synthesizer
+	MT32EMU_EXPORT void close();
+
+	// Returns true if the synth is in completely initialized state, otherwise returns false.
+	MT32EMU_EXPORT bool isOpen() const;
+
+	// All the enqueued events are processed by the synth immediately.
+	MT32EMU_EXPORT void flushMIDIQueue();
+
+	// Sets size of the internal MIDI event queue. The queue size is set to the minimum power of 2 that is greater or equal to the size specified.
+	// The queue is flushed before reallocation.
+	// Returns the actual queue size being used.
+	MT32EMU_EXPORT Bit32u setMIDIEventQueueSize(Bit32u requestedSize);
+
+	// Configures the SysEx storage of the internal MIDI event queue.
+	// Supplying 0 in the storageBufferSize argument makes the SysEx data stored
+	// in multiple dynamically allocated buffers per MIDI event. These buffers are only disposed
+	// when a new MIDI event replaces the SysEx event in the queue, thus never on the rendering thread.
+	// This is the default behaviour.
+	// In contrast, when a positive value is specified, SysEx data will be stored in a single preallocated buffer,
+	// which makes this kind of storage safe for use in a realtime thread. Additionally, the space retained
+	// by a SysEx event, that has been processed and thus is no longer necessary, is disposed instantly.
+	// Note, the queue is flushed and recreated in the process so that its size remains intact.
+	MT32EMU_EXPORT void configureMIDIEventQueueSysexStorage(Bit32u storageBufferSize);
+
+	// Returns current value of the global counter of samples rendered since the synth was created (at the native sample rate 32000 Hz).
+	// This method helps to compute accurate timestamp of a MIDI message to use with the methods below.
+	MT32EMU_EXPORT Bit32u getInternalRenderedSampleCount() const;
+
+	// Enqueues a MIDI event for subsequent playback.
+	// The MIDI event will be processed not before the specified timestamp.
+	// The timestamp is measured as the global rendered sample count since the synth was created (at the native sample rate 32000 Hz).
+	// The minimum delay involves emulation of the delay introduced while the event is transferred via MIDI interface
+	// and emulation of the MCU busy-loop while it frees partials for use by a new Poly.
+	// Calls from multiple threads must be synchronised, although, no synchronisation is required with the rendering thread.
+	// The methods return false if the MIDI event queue is full and the message cannot be enqueued.
+
+	// Enqueues a single short MIDI message to play at specified time. The message must contain a status byte and one or two data
+	// bytes (as appropriate for the MIDI command).
+	MT32EMU_EXPORT bool playMsg(Bit32u msg, Bit32u timestamp);
+	// Enqueues a single well formed System Exclusive MIDI message to play at specified time.
+	MT32EMU_EXPORT bool playSysex(const Bit8u *sysex, Bit32u len, Bit32u timestamp);
+
+	// Enqueues a single short MIDI message to be processed ASAP. The message must contain a status byte and one or two data
+	// bytes (as appropriate for the MIDI command).
+	MT32EMU_EXPORT bool playMsg(Bit32u msg);
+	// Enqueues a single well formed System Exclusive MIDI message to be processed ASAP.
+	MT32EMU_EXPORT bool playSysex(const Bit8u *sysex, Bit32u len);
+
+	// WARNING:
+	// The methods below may have no effect while the synth is aborting a poly. They also don't ensure minimum 1-sample delay between
+	// sequential MIDI events, and a sequence of NoteOn and immediately succeeding NoteOff messages is always silent.
+	// A thread that invokes these methods must be explicitly synchronised with the thread performing sample rendering or be the same.
+
+	// Sends a short MIDI message to the synth for immediate playback. The message must contain a status byte and one or two data
+	// bytes (as appropriate for the MIDI command), otherwise it is ignored.
+	// See the WARNING above.
+	MT32EMU_EXPORT void playMsgNow(Bit32u msg);
+	// Sends unpacked short MIDI message to the synth for immediate playback. All the message parameters must be within the supported
+	// range, otherwise the message is ignored.
+	// See the WARNING above.
+	MT32EMU_EXPORT void playMsgOnPart(Bit8u partNum, Bit8u command, Bit8u data1, Bit8u data2);
+
+	// Sends a single well formed System Exclusive MIDI message for immediate processing. The length is in bytes.
+	// See the WARNING above.
+	MT32EMU_EXPORT void playSysexNow(const Bit8u *sysex, Bit32u len);
+	// Sends inner body of a System Exclusive MIDI message for direct processing. The length is in bytes.
+	// See the WARNING above.
+	MT32EMU_EXPORT void playSysexWithoutFraming(const Bit8u *sysex, Bit32u len);
+	// Sends inner body of a System Exclusive MIDI message for direct processing. The length is in bytes.
+	// See the WARNING above.
+	MT32EMU_EXPORT void playSysexWithoutHeader(Bit8u device, Bit8u command, const Bit8u *sysex, Bit32u len);
+	// Sends inner body of a System Exclusive MIDI message for direct processing. The length is in bytes.
+	// See the WARNING above.
+	MT32EMU_EXPORT void writeSysex(Bit8u channel, const Bit8u *sysex, Bit32u len);
+
+	// Stores internal state of the emulated synth into the provided array. The messages within the SysEx bank are ordered so that
+	// they can be replayed back in the same sequence without data loss, provided that the given array has sufficient size.
+	// The SysEx messages written in the array can be re-played using applySysexBank() function or even sent to a real device.
+	// Returns the full length of the SysEx bank in bytes that is needed to fit all the available data.
+	// This function can be used to retrieve the required size of the SysEx bank by supplying NULL sysexBank or zero size arguments,
+	// in which case it does nothing else.
+	MT32EMU_EXPORT_V(2.8) Bit32u dumpSysexBank(Bit8u *sysexBank, Bit32u size) const;
+	// Applies the content of the given SysEx bank to the emulated synth from the provided array. All complete SysEx messages
+	// contained within the sysexBank are played in sequence, any other data is ignored.
+	// Returns the number of played SysEx messages.
+	MT32EMU_EXPORT_V(2.8) Bit32u applySysexBank(const Bit8u *sysexBank, Bit32u size);
+
+	// Allows to disable wet reverb output altogether.
+	MT32EMU_EXPORT void setReverbEnabled(bool reverbEnabled);
+	// Returns whether wet reverb output is enabled.
+	MT32EMU_EXPORT bool isReverbEnabled() const;
+	// Sets override reverb mode. In this mode, emulation ignores sysexes (or the related part of them) which control the reverb parameters.
+	// This mode is in effect until it is turned off. When the synth is re-opened, the override mode is unchanged but the state
+	// of the reverb model is reset to default.
+	MT32EMU_EXPORT void setReverbOverridden(bool reverbOverridden);
+	// Returns whether reverb settings are overridden.
+	MT32EMU_EXPORT bool isReverbOverridden() const;
+	// Forces reverb model compatibility mode. By default, the compatibility mode corresponds to the used control ROM version.
+	// Invoking this method with the argument set to true forces emulation of old MT-32 reverb circuit.
+	// When the argument is false, emulation of the reverb circuit used in new generation of MT-32 compatible modules is enforced
+	// (these include CM-32L and LAPC-I).
+	MT32EMU_EXPORT void setReverbCompatibilityMode(bool mt32CompatibleMode);
+	// Returns whether reverb is in old MT-32 compatibility mode.
+	MT32EMU_EXPORT bool isMT32ReverbCompatibilityMode() const;
+	// Returns whether default reverb compatibility mode is the old MT-32 compatibility mode.
+	MT32EMU_EXPORT bool isDefaultReverbMT32Compatible() const;
+	// If enabled, reverb buffers for all modes are kept around allocated all the time to avoid memory
+	// allocating/freeing in the rendering thread, which may be required for realtime operation.
+	// Otherwise, reverb buffers that are not in use are deleted to save memory (the default behaviour).
+	MT32EMU_EXPORT void preallocateReverbMemory(bool enabled);
+	// Sets new DAC input mode. See DACInputMode for details.
+	MT32EMU_EXPORT void setDACInputMode(DACInputMode mode);
+	// Returns current DAC input mode. See DACInputMode for details.
+	MT32EMU_EXPORT DACInputMode getDACInputMode() const;
+	// Sets new MIDI delay mode. See MIDIDelayMode for details.
+	MT32EMU_EXPORT void setMIDIDelayMode(MIDIDelayMode mode);
+	// Returns current MIDI delay mode. See MIDIDelayMode for details.
+	MT32EMU_EXPORT MIDIDelayMode getMIDIDelayMode() const;
+
+	// Sets output gain factor for synth output channels. Applied to all output samples and unrelated with the synth's Master volume,
+	// it rather corresponds to the gain of the output analog circuitry of the hardware units. However, together with setReverbOutputGain()
+	// it offers to the user a capability to control the gain of reverb and non-reverb output channels independently.
+	MT32EMU_EXPORT void setOutputGain(float gain);
+	// Returns current output gain factor for synth output channels.
+	MT32EMU_EXPORT float getOutputGain() const;
+
+	// Sets output gain factor for the reverb wet output channels. It rather corresponds to the gain of the output
+	// analog circuitry of the hardware units. However, together with setOutputGain() it offers to the user a capability
+	// to control the gain of reverb and non-reverb output channels independently.
+	//
+	// Note: We're currently emulate CM-32L/CM-64 reverb quite accurately and the reverb output level closely
+	// corresponds to the level of digital capture. Although, according to the CM-64 PCB schematic,
+	// there is a difference in the reverb analogue circuit, and the resulting output gain is 0.68
+	// of that for LA32 analogue output. This factor is applied to the reverb output gain.
+	MT32EMU_EXPORT void setReverbOutputGain(float gain);
+	// Returns current output gain factor for reverb wet output channels.
+	MT32EMU_EXPORT float getReverbOutputGain() const;
+
+	// Sets or removes an override for the Master Volume. When the Master Volume is overridden, a SysEx write to the system area
+	// will have no effect on the Master Volume setting, yet a system memory read will return the overridden Master Volume.
+	// To enable the override mode, argument volumeOverride should be in range 0..100. Setting a value outside this range
+	// disables the override mode allowing the Master Volume to change further on (without changing the current volume).
+	// This setting persists synth reopening.
+	MT32EMU_EXPORT_V(2.8) void setMasterVolumeOverride(Bit8u volumeOverride);
+	// Returns the overridden master volume previously set, if any; a value outside the range 0..100 means no override
+	// is currently in effect.
+	MT32EMU_EXPORT_V(2.8) Bit8u getMasterVolumeOverride() const;
+
+	// Sets (or removes) an override for the current volume (output level) on a specific part.
+	// When the part volume is overridden, the MIDI controller Volume (7) on the MIDI channel this part is assigned to
+	// has no effect on the output level of this part. Similarly, the output level value set on this part via a SysEx that
+	// modifies the Patch temp structure is disregarded.
+	// To enable the override mode, argument volumeOverride should be in range 0..100, setting a value outside this range
+	// disables the previously set override, if any.
+	// Note: Setting volumeOverride to 0 mutes the part completely, meaning no sound is generated at all.
+	// This is unlike the behaviour of real devices - setting 0 volume on a part may leave it still producing
+	// sound at a very low level.
+	// Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+	MT32EMU_EXPORT_V(2.6) void setPartVolumeOverride(Bit8u partNumber, Bit8u volumeOverride);
+	// Returns the overridden volume previously set on a specific part; a value outside the range 0..100 means no override
+	// is currently in effect.
+	// Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+	MT32EMU_EXPORT_V(2.6) Bit8u getPartVolumeOverride(Bit8u partNumber) const;
+
+	// Swaps left and right output channels.
+	MT32EMU_EXPORT void setReversedStereoEnabled(bool enabled);
+	// Returns whether left and right output channels are swapped.
+	MT32EMU_EXPORT bool isReversedStereoEnabled() const;
+
+	// Allows to toggle the NiceAmpRamp mode.
+	// In this mode, we want to ensure that amp ramp never jumps to the target
+	// value and always gradually increases or decreases. It seems that real units
+	// do not bother to always check if a newly started ramp leads to a jump.
+	// We also prefer the quality improvement over the emulation accuracy,
+	// so this mode is enabled by default.
+	MT32EMU_EXPORT void setNiceAmpRampEnabled(bool enabled);
+	// Returns whether NiceAmpRamp mode is enabled.
+	MT32EMU_EXPORT bool isNiceAmpRampEnabled() const;
+
+	// Allows to toggle the NicePanning mode.
+	// Despite the Roland's manual specifies allowed panpot values in range 0-14,
+	// the LA-32 only receives 3-bit pan setting in fact. In particular, this
+	// makes it impossible to set the "middle" panning for a single partial.
+	// In the NicePanning mode, we enlarge the pan setting accuracy to 4 bits
+	// making it smoother thus sacrificing the emulation accuracy.
+	// This mode is disabled by default.
+	MT32EMU_EXPORT void setNicePanningEnabled(bool enabled);
+	// Returns whether NicePanning mode is enabled.
+	MT32EMU_EXPORT bool isNicePanningEnabled() const;
+
+	// Allows to toggle the NicePartialMixing mode.
+	// LA-32 is known to mix partials either in-phase (so that they are added)
+	// or in counter-phase (so that they are subtracted instead).
+	// In some cases, this quirk isn't highly desired because a pair of closely
+	// sounding partials may occasionally cancel out.
+	// In the NicePartialMixing mode, the mixing is always performed in-phase,
+	// thus making the behaviour more predictable.
+	// This mode is disabled by default.
+	MT32EMU_EXPORT void setNicePartialMixingEnabled(bool enabled);
+	// Returns whether NicePartialMixing mode is enabled.
+	MT32EMU_EXPORT bool isNicePartialMixingEnabled() const;
+
+	// Selects new type of the wave generator and renderer to be used during subsequent calls to open().
+	// By default, RendererType_BIT16S is selected.
+	// See RendererType for details.
+	MT32EMU_EXPORT void selectRendererType(RendererType);
+	// Returns previously selected type of the wave generator and renderer.
+	// See RendererType for details.
+	MT32EMU_EXPORT RendererType getSelectedRendererType() const;
+
+	// Returns actual sample rate used in emulation of stereo analog circuitry of hardware units.
+	// See comment for render() below.
+	MT32EMU_EXPORT Bit32u getStereoOutputSampleRate() const;
+
+	// Renders samples to the specified output stream as if they were sampled at the analog stereo output.
+	// When AnalogOutputMode is set to ACCURATE (OVERSAMPLED), the output signal is upsampled to 48 (96) kHz in order
+	// to retain emulation accuracy in whole audible frequency spectra. Otherwise, native digital signal sample rate is retained.
+	// getStereoOutputSampleRate() can be used to query actual sample rate of the output signal.
+	// The length is in frames, not bytes (in 16-bit stereo, one frame is 4 bytes). Uses NATIVE byte ordering.
+	MT32EMU_EXPORT void render(Bit16s *stream, Bit32u len);
+	// Same as above but outputs to a float stereo stream.
+	MT32EMU_EXPORT void render(float *stream, Bit32u len);
+
+	// Renders samples to the specified output streams as if they appeared at the DAC entrance.
+	// No further processing performed in analog circuitry emulation is applied to the signal.
+	// NULL may be specified in place of any or all of the stream buffers to skip it.
+	// The length is in samples, not bytes. Uses NATIVE byte ordering.
+	MT32EMU_EXPORT void renderStreams(Bit16s *nonReverbLeft, Bit16s *nonReverbRight, Bit16s *reverbDryLeft, Bit16s *reverbDryRight, Bit16s *reverbWetLeft, Bit16s *reverbWetRight, Bit32u len);
+	MT32EMU_EXPORT void renderStreams(const DACOutputStreams<Bit16s> &streams, Bit32u len);
+	// Same as above but outputs to float streams.
+	MT32EMU_EXPORT void renderStreams(float *nonReverbLeft, float *nonReverbRight, float *reverbDryLeft, float *reverbDryRight, float *reverbWetLeft, float *reverbWetRight, Bit32u len);
+	MT32EMU_EXPORT void renderStreams(const DACOutputStreams<float> &streams, Bit32u len);
+
+	// Returns true when there is at least one active partial, otherwise false.
+	MT32EMU_EXPORT bool hasActivePartials() const;
+
+	// Returns true if the synth is active and subsequent calls to render() may result in non-trivial output (i.e. silence).
+	// The synth is considered active when either there are pending MIDI events in the queue, there is at least one active partial,
+	// or the reverb is (somewhat unreliably) detected as being active.
+	MT32EMU_EXPORT bool isActive();
+
+	// Returns the maximum number of partials playing simultaneously.
+	MT32EMU_EXPORT Bit32u getPartialCount() const;
+
+	// Fills in current states of all the parts into the array provided. The array must have at least 9 entries to fit values for all the parts.
+	// If the value returned for a part is true, there is at least one active non-releasing partial playing on this part.
+	// This info is useful in emulating behaviour of LCD display of the hardware units.
+	MT32EMU_EXPORT void getPartStates(bool *partStates) const;
+
+	// Returns current states of all the parts as a bit set. The least significant bit corresponds to the state of part 1,
+	// total of 9 bits hold the states of all the parts. If the returned bit for a part is set, there is at least one active
+	// non-releasing partial playing on this part. This info is useful in emulating behaviour of LCD display of the hardware units.
+	MT32EMU_EXPORT Bit32u getPartStates() const;
+
+	// Fills in current states of all the partials into the array provided. The array must be large enough to accommodate states of all the partials.
+	MT32EMU_EXPORT void getPartialStates(PartialState *partialStates) const;
+
+	// Fills in current states of all the partials into the array provided. Each byte in the array holds states of 4 partials
+	// starting from the least significant bits. The state of each partial is packed in a pair of bits.
+	// The array must be large enough to accommodate states of all the partials (see getPartialCount()).
+	MT32EMU_EXPORT void getPartialStates(Bit8u *partialStates) const;
+
+	// Fills in information about currently playing notes on the specified part into the arrays provided. The arrays must be large enough
+	// to accommodate data for all the playing notes. The maximum number of simultaneously playing notes cannot exceed the number of partials.
+	// Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+	// Returns the number of currently playing notes on the specified part.
+	MT32EMU_EXPORT Bit32u getPlayingNotes(Bit8u partNumber, Bit8u *keys, Bit8u *velocities) const;
+
+	// Returns name of the patch set on the specified part.
+	// Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+	// The returned value is a null-terminated string which is guaranteed to remain valid until the next call to one of render methods.
+	MT32EMU_EXPORT const char *getPatchName(Bit8u partNumber) const;
+
+	// Retrieves the name of the sound group the timbre identified by arguments timbreGroup and timbreNumber is associated with.
+	// Values 0-3 of timbreGroup correspond to the timbre banks GROUP A, GROUP B, MEMORY and RHYTHM.
+	// For all but the RHYTHM timbre bank, allowed values of timbreNumber are in range 0-63. The number of timbres
+	// contained in the RHYTHM bank depends on the used control ROM version.
+	// The argument soundGroupName must point to an array of at least 8 characters. The result is a null-terminated string.
+	// Returns whether the specified timbre has been found and the result written in soundGroupName.
+	MT32EMU_EXPORT_V(2.7) bool getSoundGroupName(char *soundGroupName, Bit8u timbreGroup, Bit8u timbreNumber) const;
+	// Retrieves the name of the timbre identified by arguments timbreGroup and timbreNumber.
+	// Values 0-3 of timbreGroup correspond to the timbre banks GROUP A, GROUP B, MEMORY and RHYTHM.
+	// For all but the RHYTHM timbre bank, allowed values of timbreNumber are in range 0-63. The number of timbres
+	// contained in the RHYTHM bank depends on the used control ROM version.
+	// The argument soundName must point to an array of at least 11 characters. The result is a null-terminated string.
+	// Returns whether the specified timbre has been found and the result written in soundName.
+	MT32EMU_EXPORT_V(2.7) bool getSoundName(char *soundName, Bit8u timbreGroup, Bit8u timbreNumber) const;
+
+	// Stores internal state of emulated synth into an array provided (as it would be acquired from hardware).
+	// Note, addr parameter is expressed in the linear space and *not* the SysEx address space.
+	MT32EMU_EXPORT void readMemory(Bit32u addr, Bit32u len, Bit8u *data);
+
+	// Retrieves the current state of the emulated MT-32 display facilities.
+	// Typically, the state is updated during the rendering. When that happens, a related callback from ReportHandler2 is invoked.
+	// However, there might be no need to invoke this method after each update, e.g. when the render buffer is just a few milliseconds
+	// long.
+	// The argument targetBuffer must point to an array of at least 21 characters. The result is a null-terminated string.
+	// The optional argument narrowLCD enables a condensed representation of the displayed information in some cases. This is mainly
+	// intended to route the result to a hardware LCD that is only 16 characters wide. Automatic scrolling of longer strings
+	// is not supported.
+	// Returns whether the MIDI MESSAGE LED is ON and fills the targetBuffer parameter.
+	MT32EMU_EXPORT_V(2.6) bool getDisplayState(char *targetBuffer, bool narrowLCD = false) const;
+
+	// Resets the emulated LCD to the main mode (Master Volume). This has the same effect as pressing the Master Volume button
+	// while the display shows some other message. Useful for the new-gen devices as those require a special Display Reset SysEx
+	// to return to the main mode e.g. from showing a custom display message or a checksum error.
+	MT32EMU_EXPORT_V(2.6) void setMainDisplayMode();
+
+	// Permits to select an arbitrary display emulation model that does not necessarily match the actual behaviour implemented
+	// in the control ROM version being used.
+	// Invoking this method with the argument set to true forces emulation of the old-gen MT-32 display features.
+	// Otherwise, emulation of the new-gen devices is enforced (these include CM-32L and LAPC-I as if these were connected to an LCD).
+	MT32EMU_EXPORT_V(2.6) void setDisplayCompatibility(bool oldMT32CompatibilityEnabled);
+	// Returns whether the currently configured features of the emulated display are compatible with the old-gen MT-32 devices.
+	MT32EMU_EXPORT_V(2.6) bool isDisplayOldMT32Compatible() const;
+	// Returns whether the emulated display features configured by default depending on the actual control ROM version
+	// are compatible with the old-gen MT-32 devices.
+	MT32EMU_EXPORT_V(2.6) bool isDefaultDisplayOldMT32Compatible() const;
+}; // class Synth
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_SYNTH_H

--- a/vendor/munt/src/SysexBuilder.h
+++ b/vendor/munt/src/SysexBuilder.h
@@ -1,0 +1,44 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_SYSEX_BUILDER_H
+#define MT32EMU_SYSEX_BUILDER_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+/**
+ * Facilitates creation of a bank of MT-32 compatible SysEx messages.
+ */
+class SysexBuilder {
+	Bit8u *writePtr;
+	const Bit8u * const endPtr;
+
+public:
+	// Initialises the builder to fill SysEx messages into sysexBank of the given size.
+	SysexBuilder(Bit8u *sysexBank, Bit32u size) : writePtr(sysexBank), endPtr(sysexBank + size) {}
+
+	// Wraps the provided data array to be written to sysexAddress into a SysEx message with the header and trailer and appends it
+	// to the SysEx bank if there is enough free space within.
+	bool appendSysex(Bit32u sysexAddress, const Bit8u *data, Bit32u dataLength);
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_SYSEX_BUILDER_H

--- a/vendor/munt/src/TVA.cpp
+++ b/vendor/munt/src/TVA.cpp
@@ -1,0 +1,385 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This class emulates the calculations performed by the 8095 microcontroller in order to configure the LA-32's amplitude ramp for a single partial at each stage of its TVA envelope.
+ * Unless we introduced bugs, it should be pretty much 100% accurate according to Mok's specifications.
+*/
+
+#include "internals.h"
+
+#include "TVA.h"
+#include "Part.h"
+#include "Partial.h"
+#include "Poly.h"
+#include "Synth.h"
+#include "Tables.h"
+
+namespace MT32Emu {
+
+// CONFIRMED: Matches a table in ROM - haven't got around to coming up with a formula for it yet.
+static const Bit8u biasLevelToAmpSubtractionCoeff[13] = {255, 187, 137, 100, 74, 54, 40, 29, 21, 15, 10, 5, 0};
+
+static const Bit8u *envLogarithmicTime;
+static const Bit8u *levelToAmpSubtraction;
+static const Bit8u *masterVolToAmpSubtraction;
+
+void TVA::initTables(const Tables &tables) {
+	envLogarithmicTime = tables.envLogarithmicTime;
+	levelToAmpSubtraction = tables.levelToAmpSubtraction;
+	masterVolToAmpSubtraction = tables.masterVolToAmpSubtraction;
+}
+
+TVA::TVA(const Partial *usePartial, LA32Ramp *useAmpRamp) :
+	partial(usePartial), ampRamp(useAmpRamp), system(&usePartial->getSynth()->mt32ram.system), phase(TVA_PHASE_DEAD) {
+}
+
+void TVA::startRamp(Bit8u newTarget, Bit8u newIncrement, int newPhase) {
+	target = newTarget;
+	phase = newPhase;
+	ampRamp->startRamp(newTarget, newIncrement);
+#if MT32EMU_MONITOR_TVA >= 1
+	partial->getSynth()->printDebug("[+%lu] [Partial %d] TVA,ramp,%x,%s%x,%d", partial->debugGetSampleNum(), partial->debugGetPartialNum(), newTarget, (newIncrement & 0x80) ? "-" : "+", (newIncrement & 0x7F), newPhase);
+#endif
+}
+
+void TVA::end(int newPhase) {
+	phase = newPhase;
+	playing = false;
+#if MT32EMU_MONITOR_TVA >= 1
+	partial->getSynth()->printDebug("[+%lu] [Partial %d] TVA,end,%d", partial->debugGetSampleNum(), partial->debugGetPartialNum(), newPhase);
+#endif
+}
+
+static int multBias(Bit8u biasLevel, int bias) {
+	return (bias * biasLevelToAmpSubtractionCoeff[biasLevel]) >> 5;
+}
+
+static int calcBiasAmpSubtraction(Bit8u biasPoint, Bit8u biasLevel, int key) {
+	if ((biasPoint & 0x40) == 0) {
+		int bias = biasPoint + 33 - key;
+		if (bias > 0) {
+			return multBias(biasLevel, bias);
+		}
+	} else {
+		int bias = biasPoint - 31 - key;
+		if (bias < 0) {
+			bias = -bias;
+			return multBias(biasLevel, bias);
+		}
+	}
+	return 0;
+}
+
+static int calcBiasAmpSubtractions(const TimbreParam::PartialParam *partialParam, int key) {
+	int biasAmpSubtraction1 = calcBiasAmpSubtraction(partialParam->tva.biasPoint1, partialParam->tva.biasLevel1, key);
+	if (biasAmpSubtraction1 > 255) {
+		return 255;
+	}
+	int biasAmpSubtraction2 = calcBiasAmpSubtraction(partialParam->tva.biasPoint2, partialParam->tva.biasLevel2, key);
+	if (biasAmpSubtraction2 > 255) {
+		return 255;
+	}
+	int biasAmpSubtraction = biasAmpSubtraction1 + biasAmpSubtraction2;
+	if (biasAmpSubtraction > 255) {
+		return 255;
+	}
+	return biasAmpSubtraction;
+}
+
+static int calcVeloAmpSubtraction(Bit8u veloSensitivity, unsigned int velocity) {
+	// FIXME:KG: Better variable names
+	int velocityMult = veloSensitivity - 50;
+	int absVelocityMult = velocityMult < 0 ? -velocityMult : velocityMult;
+	velocityMult = signed(unsigned(velocityMult * (signed(velocity) - 64)) << 2);
+	return absVelocityMult - (velocityMult >> 8); // PORTABILITY NOTE: Assumes arithmetic shift
+}
+
+static int calcBasicAmp(const Partial *partial, const MemParams::System *system, const TimbreParam::PartialParam *partialParam, Bit8u partVolume, const MemParams::RhythmTemp *rhythmTemp, int biasAmpSubtraction, int veloAmpSubtraction, Bit8u expression, bool hasRingModQuirk) {
+	int amp = 155;
+
+	if (!(hasRingModQuirk ? partial->isRingModulatingNoMix() : partial->isRingModulatingSlave())) {
+		amp -= masterVolToAmpSubtraction[system->masterVol];
+		if (amp < 0) {
+			return 0;
+		}
+		amp -= levelToAmpSubtraction[partVolume];
+		if (amp < 0) {
+			return 0;
+		}
+		amp -= levelToAmpSubtraction[expression];
+		if (amp < 0) {
+			return 0;
+		}
+		if (rhythmTemp != NULL) {
+			amp -= levelToAmpSubtraction[rhythmTemp->outputLevel];
+			if (amp < 0) {
+				return 0;
+			}
+		}
+	}
+	amp -= biasAmpSubtraction;
+	if (amp < 0) {
+		return 0;
+	}
+	amp -= levelToAmpSubtraction[partialParam->tva.level];
+	if (amp < 0) {
+		return 0;
+	}
+	amp -= veloAmpSubtraction;
+	if (amp < 0) {
+		return 0;
+	}
+	if (amp > 155) {
+		amp = 155;
+	}
+	amp -= partialParam->tvf.resonance >> 1;
+	if (amp < 0) {
+		return 0;
+	}
+	return amp;
+}
+
+static int calcKeyTimeSubtraction(Bit8u envTimeKeyfollow, int key) {
+	if (envTimeKeyfollow == 0) {
+		return 0;
+	}
+	return (key - 60) >> (5 - envTimeKeyfollow); // PORTABILITY NOTE: Assumes arithmetic shift
+}
+
+void TVA::reset(const Part *newPart, const TimbreParam::PartialParam *newPartialParam, const MemParams::RhythmTemp *newRhythmTemp) {
+	part = newPart;
+	partialParam = newPartialParam;
+	rhythmTemp = newRhythmTemp;
+
+	playing = true;
+
+	int key = partial->getPoly()->getKey();
+	int velocity = partial->getPoly()->getVelocity();
+
+	keyTimeSubtraction = calcKeyTimeSubtraction(partialParam->tva.envTimeKeyfollow, key);
+
+	biasAmpSubtraction = calcBiasAmpSubtractions(partialParam, key);
+	veloAmpSubtraction = calcVeloAmpSubtraction(partialParam->tva.veloSensitivity, velocity);
+
+	int newTarget = calcBasicAmp(partial, system, partialParam, part->getVolume(), newRhythmTemp, biasAmpSubtraction, veloAmpSubtraction, part->getExpression(), partial->getSynth()->controlROMFeatures->quirkRingModulationNoMix);
+	int newPhase;
+	if (partialParam->tva.envTime[0] == 0) {
+		// Initially go to the TVA_PHASE_ATTACK target amp, and spend the next phase going from there to the TVA_PHASE_2 target amp
+		// Note that this means that velocity never affects time for this partial.
+		newTarget += partialParam->tva.envLevel[0];
+		newPhase = TVA_PHASE_ATTACK; // The first target used in nextPhase() will be TVA_PHASE_2
+	} else {
+		// Initially go to the base amp determined by TVA level, part volume, etc., and spend the next phase going from there to the full TVA_PHASE_ATTACK target amp.
+		newPhase = TVA_PHASE_BASIC; // The first target used in nextPhase() will be TVA_PHASE_ATTACK
+	}
+
+	ampRamp->reset();//currentAmp = 0;
+
+	// "Go downward as quickly as possible".
+	// Since the current value is 0, the LA32Ramp will notice that we're already at or below the target and trying to go downward,
+	// and therefore jump to the target immediately and raise an interrupt.
+	startRamp(Bit8u(newTarget), 0x80 | 127, newPhase);
+}
+
+void TVA::startAbort() {
+	startRamp(64, 0x80 | 127, TVA_PHASE_RELEASE);
+}
+
+void TVA::startDecay() {
+	if (phase >= TVA_PHASE_RELEASE) {
+		return;
+	}
+	Bit8u newIncrement;
+	if (partialParam->tva.envTime[4] == 0) {
+		newIncrement = 1;
+	} else {
+		newIncrement = -partialParam->tva.envTime[4];
+	}
+	// The next time nextPhase() is called, it will think TVA_PHASE_RELEASE has finished and the partial will be aborted
+	startRamp(0, newIncrement, TVA_PHASE_RELEASE);
+}
+
+void TVA::handleInterrupt() {
+	nextPhase();
+}
+
+void TVA::recalcSustain() {
+	// We get pinged periodically by the pitch code to recalculate our values when in sustain.
+	// This is done so that the TVA will respond to things like MIDI expression and volume changes while it's sustaining, which it otherwise wouldn't do.
+
+	// The check for envLevel[3] == 0 strikes me as slightly dumb. FIXME: Explain why
+	if (phase != TVA_PHASE_SUSTAIN || partialParam->tva.envLevel[3] == 0) {
+		return;
+	}
+	// We're sustaining. Recalculate all the values
+	int newTarget = calcBasicAmp(partial, system, partialParam, part->getVolume(), rhythmTemp, biasAmpSubtraction, veloAmpSubtraction, part->getExpression(), partial->getSynth()->controlROMFeatures->quirkRingModulationNoMix);
+	newTarget += partialParam->tva.envLevel[3];
+
+	// Although we're in TVA_PHASE_SUSTAIN at this point, we cannot be sure that there is no active ramp at the moment.
+	// In case the channel volume or the expression changes frequently, the previously started ramp may still be in progress.
+	// Real hardware units ignore this possibility and rely on the assumption that the target is the current amp.
+	// This is OK in most situations but when the ramp that is currently in progress needs to change direction
+	// due to a volume/expression update, this leads to a jump in the amp that is audible as an unpleasant click.
+	// To avoid that, we compare the newTarget with the the actual current ramp value and correct the direction if necessary.
+	int targetDelta = newTarget - target;
+
+	// Calculate an increment to get to the new amp value in a short, more or less consistent amount of time
+	Bit8u newIncrement;
+	bool descending = targetDelta < 0;
+	if (!descending) {
+		newIncrement = envLogarithmicTime[Bit8u(targetDelta)] - 2;
+	} else {
+		newIncrement = (envLogarithmicTime[Bit8u(-targetDelta)] - 2) | 0x80;
+	}
+	if (part->getSynth()->isNiceAmpRampEnabled() && (descending != ampRamp->isBelowCurrent(newTarget))) {
+		newIncrement ^= 0x80;
+	}
+
+	// Configure so that once the transition's complete and nextPhase() is called, we'll just re-enter sustain phase (or decay phase, depending on parameters at the time).
+	startRamp(newTarget, newIncrement, TVA_PHASE_SUSTAIN - 1);
+}
+
+bool TVA::isPlaying() const {
+	return playing;
+}
+
+int TVA::getPhase() const {
+	return phase;
+}
+
+void TVA::nextPhase() {
+	if (phase >= TVA_PHASE_DEAD || !playing) {
+		partial->getSynth()->printDebug("TVA::nextPhase(): Shouldn't have got here with phase %d, playing=%s", phase, playing ? "true" : "false");
+		return;
+	}
+	int newPhase = phase + 1;
+
+	if (newPhase == TVA_PHASE_DEAD) {
+		end(newPhase);
+		return;
+	}
+
+	bool allLevelsZeroFromNowOn = false;
+	if (partialParam->tva.envLevel[3] == 0) {
+		if (newPhase == TVA_PHASE_4) {
+			allLevelsZeroFromNowOn = true;
+		} else if (!partial->getSynth()->controlROMFeatures->quirkTVAZeroEnvLevels && partialParam->tva.envLevel[2] == 0) {
+			if (newPhase == TVA_PHASE_3) {
+				allLevelsZeroFromNowOn = true;
+			} else if (partialParam->tva.envLevel[1] == 0) {
+				if (newPhase == TVA_PHASE_2) {
+					allLevelsZeroFromNowOn = true;
+				} else if (partialParam->tva.envLevel[0] == 0) {
+					if (newPhase == TVA_PHASE_ATTACK)  { // this line added, missing in ROM - FIXME: Add description of repercussions
+						allLevelsZeroFromNowOn = true;
+					}
+				}
+			}
+		}
+	}
+
+	int newTarget;
+	int newIncrement = 0; // Initialised to please compilers
+	int envPointIndex = phase;
+
+	if (!allLevelsZeroFromNowOn) {
+		newTarget = calcBasicAmp(partial, system, partialParam, part->getVolume(), rhythmTemp, biasAmpSubtraction, veloAmpSubtraction, part->getExpression(), partial->getSynth()->controlROMFeatures->quirkRingModulationNoMix);
+
+		if (newPhase == TVA_PHASE_SUSTAIN || newPhase == TVA_PHASE_RELEASE) {
+			if (partialParam->tva.envLevel[3] == 0) {
+				end(newPhase);
+				return;
+			}
+			if (!partial->getPoly()->canSustain()) {
+				newPhase = TVA_PHASE_RELEASE;
+				newTarget = 0;
+				newIncrement = -partialParam->tva.envTime[4];
+				if (newIncrement == 0) {
+					// We can't let the increment be 0, or there would be no emulated interrupt.
+					// So we do an "upward" increment, which should set the amp to 0 extremely quickly
+					// and cause an "interrupt" to bring us back to nextPhase().
+					newIncrement = 1;
+				}
+			} else {
+				newTarget += partialParam->tva.envLevel[3];
+				newIncrement = 0;
+			}
+		} else {
+			newTarget += partialParam->tva.envLevel[envPointIndex];
+		}
+	} else {
+		newTarget = 0;
+	}
+
+	if ((newPhase != TVA_PHASE_SUSTAIN && newPhase != TVA_PHASE_RELEASE) || allLevelsZeroFromNowOn) {
+		int envTimeSetting = partialParam->tva.envTime[envPointIndex];
+
+		if (newPhase == TVA_PHASE_ATTACK) {
+			envTimeSetting -= (signed(partial->getPoly()->getVelocity()) - 64) >> (6 - partialParam->tva.envTimeVeloSensitivity); // PORTABILITY NOTE: Assumes arithmetic shift
+
+			if (envTimeSetting <= 0 && partialParam->tva.envTime[envPointIndex] != 0) {
+				envTimeSetting = 1;
+			}
+		} else {
+			envTimeSetting -= keyTimeSubtraction;
+		}
+		if (envTimeSetting > 0) {
+			int targetDelta = newTarget - target;
+			if (targetDelta <= 0) {
+				if (targetDelta == 0) {
+					// target and newTarget are the same.
+					// We can't have an increment of 0 or we wouldn't get an emulated interrupt.
+					// So instead make the target one less than it really should be and set targetDelta accordingly.
+					targetDelta = -1;
+					newTarget--;
+					if (newTarget < 0) {
+						// Oops, newTarget is less than zero now, so let's do it the other way:
+						// Make newTarget one more than it really should've been and set targetDelta accordingly.
+						// FIXME (apparent bug in real firmware):
+						// This means targetDelta will be positive just below here where it's inverted, and we'll end up using envLogarithmicTime[-1], and we'll be setting newIncrement to be descending later on, etc..
+						targetDelta = 1;
+						newTarget = -newTarget;
+					}
+				}
+				targetDelta = -targetDelta;
+				newIncrement = envLogarithmicTime[Bit8u(targetDelta)] - envTimeSetting;
+				if (newIncrement <= 0) {
+					newIncrement = 1;
+				}
+				newIncrement = newIncrement | 0x80;
+			} else {
+				// FIXME: The last 22 or so entries in this table are 128 - surely that fucks things up, since that ends up being -128 signed?
+				newIncrement = envLogarithmicTime[Bit8u(targetDelta)] - envTimeSetting;
+				if (newIncrement <= 0) {
+					newIncrement = 1;
+				}
+			}
+		} else {
+			newIncrement = newTarget >= target ? (0x80 | 127) : 127;
+		}
+
+		// FIXME: What's the point of this? It's checked or set to non-zero everywhere above
+		if (newIncrement == 0) {
+			newIncrement = 1;
+		}
+	}
+
+	startRamp(Bit8u(newTarget), Bit8u(newIncrement), newPhase);
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/TVA.h
+++ b/vendor/munt/src/TVA.h
@@ -1,0 +1,102 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_TVA_H
+#define MT32EMU_TVA_H
+
+#include "globals.h"
+#include "Types.h"
+#include "Structures.h"
+
+namespace MT32Emu {
+
+class LA32Ramp;
+class Part;
+class Partial;
+struct Tables;
+
+// Note that when entering nextPhase(), newPhase is set to phase + 1, and the descriptions/names below refer to
+// newPhase's value.
+enum {
+	// In this phase, the base amp (as calculated in calcBasicAmp()) is targeted with an instant time.
+	// This phase is entered by reset() only if time[0] != 0.
+	TVA_PHASE_BASIC = 0,
+
+	// In this phase, level[0] is targeted within time[0], and velocity potentially affects time
+	TVA_PHASE_ATTACK = 1,
+
+	// In this phase, level[1] is targeted within time[1]
+	TVA_PHASE_2 = 2,
+
+	// In this phase, level[2] is targeted within time[2]
+	TVA_PHASE_3 = 3,
+
+	// In this phase, level[3] is targeted within time[3]
+	TVA_PHASE_4 = 4,
+
+	// In this phase, immediately goes to PHASE_RELEASE unless the poly is set to sustain.
+	// Aborts the partial if level[3] is 0.
+	// Otherwise level[3] is continued, no phase change will occur until some external influence (like pedal release)
+	TVA_PHASE_SUSTAIN = 5,
+
+	// In this phase, 0 is targeted within time[4] (the time calculation is quite different from the other phases)
+	TVA_PHASE_RELEASE = 6,
+
+	// It's PHASE_DEAD, Jim.
+	TVA_PHASE_DEAD = 7
+};
+
+class TVA {
+private:
+	const Partial * const partial;
+	LA32Ramp *ampRamp;
+	const MemParams::System * const system;
+
+	const Part *part;
+	const TimbreParam::PartialParam *partialParam;
+	const MemParams::RhythmTemp *rhythmTemp;
+
+	bool playing;
+
+	int biasAmpSubtraction;
+	int veloAmpSubtraction;
+	int keyTimeSubtraction;
+
+	Bit8u target;
+	int phase;
+
+	void startRamp(Bit8u newTarget, Bit8u newIncrement, int newPhase);
+	void end(int newPhase);
+	void nextPhase();
+
+public:
+	static void initTables(const Tables &tables);
+
+	TVA(const Partial *partial, LA32Ramp *ampRamp);
+	void reset(const Part *part, const TimbreParam::PartialParam *partialParam, const MemParams::RhythmTemp *rhythmTemp);
+	void handleInterrupt();
+	void recalcSustain();
+	void startDecay();
+	void startAbort();
+
+	bool isPlaying() const;
+	int getPhase() const;
+}; // class TVA
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_TVA_H

--- a/vendor/munt/src/TVF.cpp
+++ b/vendor/munt/src/TVF.cpp
@@ -1,0 +1,245 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "internals.h"
+
+#include "TVF.h"
+#include "LA32Ramp.h"
+#include "Partial.h"
+#include "Poly.h"
+#include "Synth.h"
+#include "Tables.h"
+
+namespace MT32Emu {
+
+// Note that when entering nextPhase(), newPhase is set to phase + 1, and the descriptions/names below refer to
+// newPhase's value.
+enum {
+	// When this is the target phase, level[0] is targeted within time[0]
+	// Note that this phase is always set up in reset(), not nextPhase()
+	PHASE_ATTACK = 1,
+
+	// When this is the target phase, level[1] is targeted within time[1]
+	PHASE_2 = 2,
+
+	// When this is the target phase, level[2] is targeted within time[2]
+	PHASE_3 = 3,
+
+	// When this is the target phase, level[3] is targeted within time[3]
+	PHASE_4 = 4,
+
+	// When this is the target phase, immediately goes to PHASE_RELEASE unless the poly is set to sustain.
+	// Otherwise level[3] is continued with increment 0 - no phase change will occur until some external influence (like pedal release)
+	PHASE_SUSTAIN = 5,
+
+	// 0 is targeted within time[4] (the time calculation is quite different from the other phases)
+	PHASE_RELEASE = 6,
+
+	// 0 is targeted with increment 0 (thus theoretically staying that way forever)
+	PHASE_DONE = 7
+};
+
+static const Bit8u *envLogarithmicTime;
+
+static int calcBaseCutoff(const TimbreParam::PartialParam *partialParam, Bit32u basePitch, unsigned int key, bool quirkTVFBaseCutoffLimit) {
+	// This table matches the values used by a real LAPC-I.
+	static const Bit8s biasLevelToBiasMult[] = {85, 42, 21, 16, 10, 5, 2, 0, -2, -5, -10, -16, -21, -74, -85};
+	// These values represent unique options with no consistent pattern, so we have to use something like a table in any case.
+	// The table entries, when divided by 21, match approximately what the manual claims:
+	// -1, -1/2, -1/4, 0, 1/8, 1/4, 3/8, 1/2, 5/8, 3/4, 7/8, 1, 5/4, 3/2, 2, s1, s2
+	// Note that the entry for 1/8 is rounded to 2 (from 1/8 * 21 = 2.625), which seems strangely inaccurate compared to the others.
+	static const Bit8s keyfollowMult21[] = {-21, -10, -5, 0, 2, 5, 8, 10, 13, 16, 18, 21, 26, 32, 42, 21, 21};
+	int baseCutoff = keyfollowMult21[partialParam->tvf.keyfollow] - keyfollowMult21[partialParam->wg.pitchKeyfollow];
+	// baseCutoff range now: -63 to 63
+	baseCutoff *= int(key) - 60;
+	// baseCutoff range now: -3024 to 3024
+	int biasPoint = partialParam->tvf.biasPoint;
+	if ((biasPoint & 0x40) == 0) {
+		// biasPoint range here: 0 to 63
+		int bias = biasPoint + 33 - key; // bias range here: -75 to 84
+		if (bias > 0) {
+			bias = -bias; // bias range here: -1 to -84
+			baseCutoff += bias * biasLevelToBiasMult[partialParam->tvf.biasLevel]; // Calculation range: -7140 to 7140
+			// baseCutoff range now: -10164 to 10164
+		}
+	} else {
+		// biasPoint range here: 64 to 127
+		int bias = biasPoint - 31 - key; // bias range here: -75 to 84
+		if (bias < 0) {
+			baseCutoff += bias * biasLevelToBiasMult[partialParam->tvf.biasLevel]; // Calculation range: -6375 to 6375
+			// baseCutoff range now: -9399 to 9399
+		}
+	}
+	// baseCutoff range now: -10164 to 10164
+	baseCutoff += ((partialParam->tvf.cutoff << 4) - 800);
+	// baseCutoff range now: -10964 to 10964
+	if (baseCutoff >= 0) {
+		// FIXME: Potentially bad if baseCutoff ends up below -2056?
+		int pitchDeltaThing = (basePitch >> 4) + baseCutoff - 3584;
+		if (pitchDeltaThing > 0) {
+			baseCutoff -= pitchDeltaThing;
+		}
+	} else if (quirkTVFBaseCutoffLimit) {
+		if (baseCutoff <= -0x400) {
+			baseCutoff = -400;
+		}
+	} else {
+		if (baseCutoff < -2048) {
+			baseCutoff = -2048;
+		}
+	}
+	baseCutoff += 2056;
+	baseCutoff >>= 4; // PORTABILITY NOTE: Hmm... Depends whether it could've been below -2056, but maybe arithmetic shift assumed?
+	if (baseCutoff > 255) {
+		baseCutoff = 255;
+	}
+	return Bit8u(baseCutoff);
+}
+
+void TVF::initTables(const Tables &tables) {
+	envLogarithmicTime = tables.envLogarithmicTime;
+}
+
+TVF::TVF(const Partial *usePartial, LA32Ramp *useCutoffModifierRamp) :
+	partial(usePartial), cutoffModifierRamp(useCutoffModifierRamp) {
+}
+
+void TVF::startRamp(Bit8u newTarget, Bit8u newIncrement, int newPhase) {
+	target = newTarget;
+	phase = newPhase;
+	cutoffModifierRamp->startRamp(newTarget, newIncrement);
+#if MT32EMU_MONITOR_TVF >= 1
+	partial->getSynth()->printDebug("[+%lu] [Partial %d] TVF,ramp,%x,%s%x,%d", partial->debugGetSampleNum(), partial->debugGetPartialNum(), newTarget, (newIncrement & 0x80) ? "-" : "+", (newIncrement & 0x7F), newPhase);
+#endif
+}
+
+void TVF::reset(const TimbreParam::PartialParam *newPartialParam, unsigned int basePitch) {
+	partialParam = newPartialParam;
+
+	unsigned int key = partial->getPoly()->getKey();
+	unsigned int velocity = partial->getPoly()->getVelocity();
+
+	baseCutoff = calcBaseCutoff(newPartialParam, basePitch, key, partial->getSynth()->controlROMFeatures->quirkTVFBaseCutoffLimit);
+#if MT32EMU_MONITOR_TVF >= 1
+	partial->getSynth()->printDebug("[+%lu] [Partial %d] TVF,base,%d", partial->debugGetSampleNum(), partial->debugGetPartialNum(), baseCutoff);
+#endif
+
+	int newLevelMult = velocity * newPartialParam->tvf.envVeloSensitivity;
+	newLevelMult >>= 6;
+	newLevelMult += 109 - newPartialParam->tvf.envVeloSensitivity;
+	newLevelMult += (signed(key) - 60) >> (4 - newPartialParam->tvf.envDepthKeyfollow);
+	if (newLevelMult < 0) {
+		newLevelMult = 0;
+	}
+	newLevelMult *= newPartialParam->tvf.envDepth;
+	newLevelMult >>= 6;
+	if (newLevelMult > 255) {
+		newLevelMult = 255;
+	}
+	levelMult = newLevelMult;
+
+	if (newPartialParam->tvf.envTimeKeyfollow != 0) {
+		keyTimeSubtraction = (signed(key) - 60) >> (5 - newPartialParam->tvf.envTimeKeyfollow);
+	} else {
+		keyTimeSubtraction = 0;
+	}
+
+	int newTarget = (newLevelMult * newPartialParam->tvf.envLevel[0]) >> 8;
+	int envTimeSetting = newPartialParam->tvf.envTime[0] - keyTimeSubtraction;
+	int newIncrement;
+	if (envTimeSetting <= 0) {
+		newIncrement = (0x80 | 127);
+	} else {
+		newIncrement = envLogarithmicTime[newTarget] - envTimeSetting;
+		if (newIncrement <= 0) {
+			newIncrement = 1;
+		}
+	}
+	cutoffModifierRamp->reset();
+	startRamp(newTarget, newIncrement, PHASE_2 - 1);
+}
+
+Bit8u TVF::getBaseCutoff() const {
+	return baseCutoff;
+}
+
+void TVF::handleInterrupt() {
+	nextPhase();
+}
+
+void TVF::startDecay() {
+	if (phase >= PHASE_RELEASE) {
+		return;
+	}
+	if (partialParam->tvf.envTime[4] == 0) {
+		startRamp(0, 1, PHASE_DONE - 1);
+	} else {
+		startRamp(0, -partialParam->tvf.envTime[4], PHASE_DONE - 1);
+	}
+}
+
+void TVF::nextPhase() {
+	int newPhase = phase + 1;
+
+	switch (newPhase) {
+	case PHASE_DONE:
+		startRamp(0, 0, newPhase);
+		return;
+	case PHASE_SUSTAIN:
+	case PHASE_RELEASE:
+		// FIXME: Afaict newPhase should never be PHASE_RELEASE here. And if it were, this is an odd way to handle it.
+		if (!partial->getPoly()->canSustain()) {
+			phase = newPhase; // FIXME: Correct?
+			startDecay(); // FIXME: This should actually start decay even if phase is already 6. Does that matter?
+			return;
+		}
+		startRamp((levelMult * partialParam->tvf.envLevel[3]) >> 8, 0, newPhase);
+		return;
+	default:
+		break;
+	}
+
+	int envPointIndex = phase;
+	int envTimeSetting = partialParam->tvf.envTime[envPointIndex] - keyTimeSubtraction;
+
+	int newTarget = (levelMult * partialParam->tvf.envLevel[envPointIndex]) >> 8;
+	int newIncrement;
+	if (envTimeSetting > 0) {
+		int targetDelta = newTarget - target;
+		if (targetDelta == 0) {
+			if (newTarget == 0) {
+				targetDelta = 1;
+				newTarget = 1;
+			} else {
+				targetDelta = -1;
+				newTarget--;
+			}
+		}
+		newIncrement = envLogarithmicTime[targetDelta < 0 ? -targetDelta : targetDelta] - envTimeSetting;
+		if (newIncrement <= 0) {
+			newIncrement = 1;
+		}
+		if (targetDelta < 0) {
+			newIncrement |= 0x80;
+		}
+	} else {
+		newIncrement = newTarget >= target ? (0x80 | 127) : 127;
+	}
+	startRamp(newTarget, newIncrement, newPhase);
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/TVF.h
+++ b/vendor/munt/src/TVF.h
@@ -1,0 +1,64 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_TVF_H
+#define MT32EMU_TVF_H
+
+#include "globals.h"
+#include "Types.h"
+#include "Structures.h"
+
+namespace MT32Emu {
+
+class LA32Ramp;
+class Partial;
+struct Tables;
+
+class TVF {
+private:
+	const Partial * const partial;
+	LA32Ramp *cutoffModifierRamp;
+	const TimbreParam::PartialParam *partialParam;
+
+	Bit8u baseCutoff;
+	int keyTimeSubtraction;
+	unsigned int levelMult;
+
+	Bit8u target;
+	unsigned int phase;
+
+	void startRamp(Bit8u newTarget, Bit8u newIncrement, int newPhase);
+	void nextPhase();
+
+public:
+	static void initTables(const Tables &tables);
+
+	TVF(const Partial *partial, LA32Ramp *cutoffModifierRamp);
+	void reset(const TimbreParam::PartialParam *partialParam, Bit32u basePitch);
+	// Returns the base cutoff (without envelope modification).
+	// The base cutoff is calculated when reset() is called and remains static
+	// for the lifetime of the partial.
+	// Barring bugs, the number returned is confirmed accurate
+	// (based on specs from Mok).
+	Bit8u getBaseCutoff() const;
+	void handleInterrupt();
+	void startDecay();
+}; // class TVF
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_TVF_H

--- a/vendor/munt/src/TVP.cpp
+++ b/vendor/munt/src/TVP.cpp
@@ -1,0 +1,374 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+
+#include "internals.h"
+
+#include "TVP.h"
+#include "Part.h"
+#include "Partial.h"
+#include "Poly.h"
+#include "Synth.h"
+#include "TVA.h"
+
+namespace MT32Emu {
+
+// FIXME: Add Explanation
+static const Bit16u lowerDurationToDivisor[] = {34078, 37162, 40526, 44194, 48194, 52556, 57312, 62499};
+
+// These values represent unique options with no consistent pattern, so we have to use something like a table in any case.
+// The table matches exactly what the manual claims (when divided by 8192):
+// -1, -1/2, -1/4, 0, 1/8, 1/4, 3/8, 1/2, 5/8, 3/4, 7/8, 1, 5/4, 3/2, 2, s1, s2
+// ...except for the last two entries, which are supposed to be "1 cent above 1" and "2 cents above 1", respectively. They can only be roughly approximated with this integer math.
+static const Bit16s pitchKeyfollowMult[] = {-8192, -4096, -2048, 0, 1024, 2048, 3072, 4096, 5120, 6144, 7168, 8192, 10240, 12288, 16384, 8198, 8226};
+
+// Note: Keys < 60 use keyToPitchTable[60 - key], keys >= 60 use keyToPitchTable[key - 60].
+// FIXME: This table could really be shorter, since we never use e.g. key 127.
+static const Bit16u keyToPitchTable[] = {
+	    0,   341,   683,  1024,  1365,  1707,  2048,  2389,
+	 2731,  3072,  3413,  3755,  4096,  4437,  4779,  5120,
+	 5461,  5803,  6144,  6485,  6827,  7168,  7509,  7851,
+	 8192,  8533,  8875,  9216,  9557,  9899, 10240, 10581,
+	10923, 11264, 11605, 11947, 12288, 12629, 12971, 13312,
+	13653, 13995, 14336, 14677, 15019, 15360, 15701, 16043,
+	16384, 16725, 17067, 17408, 17749, 18091, 18432, 18773,
+	19115, 19456, 19797, 20139, 20480, 20821, 21163, 21504,
+	21845, 22187, 22528, 22869
+};
+
+// We want to do processing 4000 times per second. FIXME: This is pretty arbitrary.
+static const int NOMINAL_PROCESS_TIMER_PERIOD_SAMPLES = SAMPLE_RATE / 4000;
+
+// In all hardware units we emulate, the main clock frequency of the MCU is 12MHz.
+// However, the MCU used in the 3rd-gen sound modules (like CM-500 and LAPC-N)
+// is significantly faster. Importantly, the software timer also works faster,
+// yet this fact has been seemingly missed. To be more specific, the software timer
+// ticks each 8 "state times", and 1 state time equals to 3 clock periods
+// for 8095 and 8098 but 2 clock periods for 80C198. That is, on MT-32 and CM-32L,
+// the software timer tick rate is 12,000,000 / 3 / 8 = 500kHz, but on the 3rd-gen
+// devices it's 12,000,000 / 2 / 8 = 750kHz instead.
+
+// For 1st- and 2nd-gen devices, the timer ticks at 500kHz. This is how much to increment
+// timeElapsed once 16 samples passes. We multiply by 16 to get rid of the fraction
+// and deal with just integers.
+static const int PROCESS_TIMER_TICKS_PER_SAMPLE_X16_1N2_GEN = (500000 << 4) / SAMPLE_RATE;
+// For 3rd-gen devices, the timer ticks at 750kHz. This is how much to increment
+// timeElapsed once 16 samples passes. We multiply by 16 to get rid of the fraction
+// and deal with just integers.
+static const int PROCESS_TIMER_TICKS_PER_SAMPLE_X16_3_GEN = (750000 << 4) / SAMPLE_RATE;
+
+TVP::TVP(const Partial *usePartial) :
+	partial(usePartial),
+	system(&usePartial->getSynth()->mt32ram.system),
+	processTimerTicksPerSampleX16(
+		partial->getSynth()->controlROMFeatures->quirkFastPitchChanges
+		? PROCESS_TIMER_TICKS_PER_SAMPLE_X16_3_GEN
+		: PROCESS_TIMER_TICKS_PER_SAMPLE_X16_1N2_GEN)
+{}
+
+static Bit16s keyToPitch(unsigned int key) {
+	// We're using a table to do: return round_to_nearest_or_even((key - 60) * (4096.0 / 12.0))
+	// Banker's rounding is just slightly annoying to do in C++
+	int k = int(key);
+	Bit16s pitch = keyToPitchTable[abs(k - 60)];
+	return key < 60 ? -pitch : pitch;
+}
+
+static inline Bit32s coarseToPitch(Bit8u coarse) {
+	return (coarse - 36) * 4096 / 12; // One semitone per coarse offset
+}
+
+static inline Bit32s fineToPitch(Bit8u fine) {
+	return (fine - 50) * 4096 / 1200; // One cent per fine offset
+}
+
+static Bit32u calcBasePitch(const Partial *partial, const TimbreParam::PartialParam *partialParam, const MemParams::PatchTemp *patchTemp, unsigned int key, const ControlROMFeatureSet *controlROMFeatures) {
+	Bit32s basePitch = keyToPitch(key);
+	basePitch = (basePitch * pitchKeyfollowMult[partialParam->wg.pitchKeyfollow]) >> 13; // PORTABILITY NOTE: Assumes arithmetic shift
+	basePitch += coarseToPitch(partialParam->wg.pitchCoarse);
+	basePitch += fineToPitch(partialParam->wg.pitchFine);
+	if (controlROMFeatures->quirkKeyShift) {
+		// NOTE:Mok: This is done on MT-32, but not LAPC-I:
+		basePitch += coarseToPitch(patchTemp->patch.keyShift + 12);
+	}
+	basePitch += fineToPitch(patchTemp->patch.fineTune);
+
+	const ControlROMPCMStruct *controlROMPCMStruct = partial->getControlROMPCMStruct();
+	if (controlROMPCMStruct != NULL) {
+		basePitch += (Bit32s(controlROMPCMStruct->pitchMSB) << 8) | Bit32s(controlROMPCMStruct->pitchLSB);
+	} else {
+		if ((partialParam->wg.waveform & 1) == 0) {
+			basePitch += 37133; // This puts Middle C at around 261.64Hz (assuming no other modifications, masterTune of 64, etc.)
+		} else {
+			// Sawtooth waves are effectively double the frequency of square waves.
+			// Thus we add 4096 less than for square waves here, which results in halving the frequency.
+			basePitch += 33037;
+		}
+	}
+
+	// MT-32 GEN0 does 16-bit calculations here, allowing an integer overflow.
+	// This quirk is observable playing the patch defined for timbre "HIT BOTTOM" in Larry 3.
+	// Note, the upper bound isn't checked either.
+	if (controlROMFeatures->quirkBasePitchOverflow) {
+		basePitch = basePitch & 0xffff;
+	} else if (basePitch < 0) {
+		basePitch = 0;
+	} else if (basePitch > 59392) {
+		basePitch = 59392;
+	}
+	return Bit32u(basePitch);
+}
+
+static Bit32u calcVeloMult(Bit8u veloSensitivity, unsigned int velocity) {
+	if (veloSensitivity == 0) {
+		return 21845; // aka floor(4096 / 12 * 64), aka ~64 semitones
+	}
+	unsigned int reversedVelocity = 127 - velocity;
+	unsigned int scaledReversedVelocity;
+	if (veloSensitivity > 3) {
+		// Note that on CM-32L/LAPC-I veloSensitivity is never > 3, since it's clipped to 3 by the max tables.
+		// MT-32 GEN0 has a bug here that leads to unspecified behaviour. We assume it is as follows.
+		scaledReversedVelocity = (reversedVelocity << 8) >> ((3 - veloSensitivity) & 0x1f);
+	} else {
+		scaledReversedVelocity = reversedVelocity << (5 + veloSensitivity);
+	}
+	// When velocity is 127, the multiplier is 21845, aka ~64 semitones (regardless of veloSensitivity).
+	// The lower the velocity, the lower the multiplier. The veloSensitivity determines the amount decreased per velocity value.
+	// The minimum multiplier on CM-32L/LAPC-I (with velocity 0, veloSensitivity 3) is 170 (~half a semitone).
+	return ((32768 - scaledReversedVelocity) * 21845) >> 15;
+}
+
+static Bit32s calcTargetPitchOffsetWithoutLFO(const TimbreParam::PartialParam *partialParam, int levelIndex, unsigned int velocity) {
+	int veloMult = calcVeloMult(partialParam->pitchEnv.veloSensitivity, velocity);
+	int targetPitchOffsetWithoutLFO = partialParam->pitchEnv.level[levelIndex] - 50;
+	targetPitchOffsetWithoutLFO = (targetPitchOffsetWithoutLFO * veloMult) >> (16 - partialParam->pitchEnv.depth); // PORTABILITY NOTE: Assumes arithmetic shift
+	return targetPitchOffsetWithoutLFO;
+}
+
+void TVP::reset(const Part *usePart, const TimbreParam::PartialParam *usePartialParam) {
+	part = usePart;
+	partialParam = usePartialParam;
+	patchTemp = part->getPatchTemp();
+
+	unsigned int key = partial->getPoly()->getKey();
+	unsigned int velocity = partial->getPoly()->getVelocity();
+
+	// FIXME: We're using a per-TVP timer instead of a system-wide one for convenience.
+	timeElapsed = 0;
+	processTimerIncrement = 0;
+
+	basePitch = calcBasePitch(partial, partialParam, patchTemp, key, partial->getSynth()->controlROMFeatures);
+	currentPitchOffset = calcTargetPitchOffsetWithoutLFO(partialParam, 0, velocity);
+	targetPitchOffsetWithoutLFO = currentPitchOffset;
+	phase = 0;
+
+	if (partialParam->pitchEnv.timeKeyfollow) {
+		timeKeyfollowSubtraction = Bit32s(key - 60) >> (5 - partialParam->pitchEnv.timeKeyfollow); // PORTABILITY NOTE: Assumes arithmetic shift
+	} else {
+		timeKeyfollowSubtraction = 0;
+	}
+	lfoPitchOffset = 0;
+	counter = 0;
+	pitch = basePitch;
+
+	// These don't really need to be initialised, but it aids debugging.
+	pitchOffsetChangePerBigTick = 0;
+	targetPitchOffsetReachedBigTick = 0;
+	shifts = 0;
+}
+
+Bit32u TVP::getBasePitch() const {
+	return basePitch;
+}
+
+void TVP::updatePitch() {
+	Bit32s newPitch = basePitch + currentPitchOffset;
+	if (!partial->isPCM() || (partial->getControlROMPCMStruct()->len & 0x01) == 0) { // FIXME: Use !partial->pcmWaveEntry->unaffectedByMasterTune instead
+		// FIXME: There are various bugs not yet emulated
+		// 171 is ~half a semitone.
+		newPitch += partial->getSynth()->getMasterTunePitchDelta();
+	}
+	if ((partialParam->wg.pitchBenderEnabled & 1) != 0) {
+		newPitch += part->getPitchBend();
+	}
+
+	// MT-32 GEN0 does 16-bit calculations here, allowing an integer overflow.
+	// This quirk is exploited e.g. in Colonel's Bequest timbres "Lightning" and "SwmpBackgr".
+	if (partial->getSynth()->controlROMFeatures->quirkPitchEnvelopeOverflow) {
+		newPitch = newPitch & 0xffff;
+	} else if (newPitch < 0) {
+		newPitch = 0;
+	}
+	// This check is present in every unit.
+	if (newPitch > 59392) {
+		newPitch = 59392;
+	}
+	pitch = Bit16u(newPitch);
+
+	// FIXME: We're doing this here because that's what the CM-32L does - we should probably move this somewhere more appropriate in future.
+	partial->getTVA()->recalcSustain();
+}
+
+void TVP::targetPitchOffsetReached() {
+	currentPitchOffset = targetPitchOffsetWithoutLFO + lfoPitchOffset;
+
+	switch (phase) {
+	case 3:
+	case 4:
+	{
+		int newLFOPitchOffset = (part->getModulation() * partialParam->pitchLFO.modSensitivity) >> 7;
+		newLFOPitchOffset = (newLFOPitchOffset + partialParam->pitchLFO.depth) << 1;
+		if (pitchOffsetChangePerBigTick > 0) {
+			// Go in the opposite direction to last time
+			newLFOPitchOffset = -newLFOPitchOffset;
+		}
+		lfoPitchOffset = newLFOPitchOffset;
+		int targetPitchOffset = targetPitchOffsetWithoutLFO + lfoPitchOffset;
+		setupPitchChange(targetPitchOffset, 101 - partialParam->pitchLFO.rate);
+		updatePitch();
+		break;
+	}
+	case 6:
+		updatePitch();
+		break;
+	default:
+		nextPhase();
+	}
+}
+
+void TVP::nextPhase() {
+	phase++;
+	int envIndex = phase == 6 ? 4 : phase;
+
+	targetPitchOffsetWithoutLFO = calcTargetPitchOffsetWithoutLFO(partialParam, envIndex, partial->getPoly()->getVelocity()); // pitch we'll reach at the end
+
+	int changeDuration = partialParam->pitchEnv.time[envIndex - 1];
+	changeDuration -= timeKeyfollowSubtraction;
+	if (changeDuration > 0) {
+		setupPitchChange(targetPitchOffsetWithoutLFO, changeDuration); // changeDuration between 0 and 112 now
+		updatePitch();
+	} else {
+		targetPitchOffsetReached();
+	}
+}
+
+// Shifts val to the left until bit 31 is 1 and returns the number of shifts
+static Bit8u normalise(Bit32u &val) {
+	Bit8u leftShifts;
+	for (leftShifts = 0; leftShifts < 31; leftShifts++) {
+		if ((val & 0x80000000) != 0) {
+			break;
+		}
+		val = val << 1;
+	}
+	return leftShifts;
+}
+
+void TVP::setupPitchChange(int targetPitchOffset, Bit8u changeDuration) {
+	bool negativeDelta = targetPitchOffset < currentPitchOffset;
+	Bit32s pitchOffsetDelta = targetPitchOffset - currentPitchOffset;
+	if (pitchOffsetDelta > 32767 || pitchOffsetDelta < -32768) {
+		pitchOffsetDelta = 32767;
+	}
+	if (negativeDelta) {
+		pitchOffsetDelta = -pitchOffsetDelta;
+	}
+	// We want to maximise the number of bits of the Bit16s "pitchOffsetChangePerBigTick" we use in order to get the best possible precision later
+	Bit32u absPitchOffsetDelta = (pitchOffsetDelta & 0xFFFF) << 16;
+	Bit8u normalisationShifts = normalise(absPitchOffsetDelta); // FIXME: Double-check: normalisationShifts is usually between 0 and 15 here, unless the delta is 0, in which case it's 31
+	absPitchOffsetDelta = absPitchOffsetDelta >> 1; // Make room for the sign bit
+
+	changeDuration--; // changeDuration's now between 0 and 111
+	unsigned int upperDuration = changeDuration >> 3; // upperDuration's now between 0 and 13
+	shifts = normalisationShifts + upperDuration + 2;
+	Bit16u divisor = lowerDurationToDivisor[changeDuration & 7];
+	Bit16s newPitchOffsetChangePerBigTick = ((absPitchOffsetDelta & 0xFFFF0000) / divisor) >> 1; // Result now fits within 15 bits. FIXME: Check nothing's getting sign-extended incorrectly
+	if (negativeDelta) {
+		newPitchOffsetChangePerBigTick = -newPitchOffsetChangePerBigTick;
+	}
+	pitchOffsetChangePerBigTick = newPitchOffsetChangePerBigTick;
+
+	int currentBigTick = timeElapsed >> 8;
+	int durationInBigTicks = divisor >> (12 - upperDuration);
+	if (durationInBigTicks > 32767) {
+		durationInBigTicks = 32767;
+	}
+	// The result of the addition may exceed 16 bits, but wrapping is fine and intended here.
+	targetPitchOffsetReachedBigTick = currentBigTick + durationInBigTicks;
+}
+
+void TVP::startDecay() {
+	phase = 5;
+	lfoPitchOffset = 0;
+	targetPitchOffsetReachedBigTick = timeElapsed >> 8; // FIXME: Afaict there's no good reason for this - check
+}
+
+Bit16u TVP::nextPitch() {
+	// We emulate MCU software timer using these counter and processTimerIncrement variables.
+	// The value of NOMINAL_PROCESS_TIMER_PERIOD_SAMPLES approximates the period in samples
+	// between subsequent firings of the timer that normally occur.
+	// However, accurate emulation is quite complicated because the timer is not guaranteed to fire in time.
+	// This makes pitch variations on real unit non-deterministic and dependent on various factors.
+	if (counter == 0) {
+		timeElapsed = (timeElapsed + processTimerIncrement) & 0x00FFFFFF;
+		// This roughly emulates pitch deviations observed on real units when playing a single partial that uses TVP/LFO.
+		counter = NOMINAL_PROCESS_TIMER_PERIOD_SAMPLES + (rand() & 3);
+		processTimerIncrement = (processTimerTicksPerSampleX16 * counter) >> 4;
+		process();
+	}
+	counter--;
+	return pitch;
+}
+
+void TVP::process() {
+	if (phase == 0) {
+		targetPitchOffsetReached();
+		return;
+	}
+	if (phase == 5) {
+		nextPhase();
+		return;
+	}
+	if (phase > 7) {
+		updatePitch();
+		return;
+	}
+
+	Bit16s negativeBigTicksRemaining = (timeElapsed >> 8) - targetPitchOffsetReachedBigTick;
+	if (negativeBigTicksRemaining >= 0) {
+		// We've reached the time for a phase change
+		targetPitchOffsetReached();
+		return;
+	}
+	// FIXME: Write explanation for this stuff
+	// NOTE: Value of shifts may happily exceed the maximum of 31 specified for the 8095 MCU.
+	// We assume the device performs a shift with the rightmost 5 bits of the counter regardless of argument size,
+	// since shift instructions of any size have the same maximum.
+	int rightShifts = shifts;
+	if (rightShifts > 13) {
+		rightShifts -= 13;
+		negativeBigTicksRemaining = negativeBigTicksRemaining >> (rightShifts & 0x1F); // PORTABILITY NOTE: Assumes arithmetic shift
+		rightShifts = 13;
+	}
+	int newResult = (negativeBigTicksRemaining * pitchOffsetChangePerBigTick) >> (rightShifts & 0x1F); // PORTABILITY NOTE: Assumes arithmetic shift
+	newResult += targetPitchOffsetWithoutLFO + lfoPitchOffset;
+	currentPitchOffset = newResult;
+	updatePitch();
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/TVP.h
+++ b/vendor/munt/src/TVP.h
@@ -1,0 +1,74 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_TVP_H
+#define MT32EMU_TVP_H
+
+#include "globals.h"
+#include "Types.h"
+#include "Structures.h"
+
+namespace MT32Emu {
+
+class Part;
+class Partial;
+
+class TVP {
+private:
+	const Partial * const partial;
+	const MemParams::System * const system; // FIXME: Only necessary because masterTune calculation is done in the wrong place atm.
+
+	const Part *part;
+	const TimbreParam::PartialParam *partialParam;
+	const MemParams::PatchTemp *patchTemp;
+
+	const int processTimerTicksPerSampleX16;
+	int processTimerIncrement;
+	int counter;
+	Bit32u timeElapsed;
+
+	int phase;
+	Bit32u basePitch;
+	Bit32s targetPitchOffsetWithoutLFO;
+	Bit32s currentPitchOffset;
+
+	Bit16s lfoPitchOffset;
+	// In range -12 - 36
+	Bit8s timeKeyfollowSubtraction;
+
+	Bit16s pitchOffsetChangePerBigTick;
+	Bit16u targetPitchOffsetReachedBigTick;
+	unsigned int shifts;
+
+	Bit16u pitch;
+
+	void updatePitch();
+	void setupPitchChange(int targetPitchOffset, Bit8u changeDuration);
+	void targetPitchOffsetReached();
+	void nextPhase();
+	void process();
+public:
+	TVP(const Partial *partial);
+	void reset(const Part *part, const TimbreParam::PartialParam *partialParam);
+	Bit32u getBasePitch() const;
+	Bit16u nextPitch();
+	void startDecay();
+}; // class TVP
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_TVP_H

--- a/vendor/munt/src/Tables.cpp
+++ b/vendor/munt/src/Tables.cpp
@@ -1,0 +1,97 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "internals.h"
+
+#include "Tables.h"
+#include "mmath.h"
+
+namespace MT32Emu {
+
+// UNUSED: const int MIDDLEC = 60;
+
+const Tables &Tables::getInstance() {
+	static const Tables instance;
+	return instance;
+}
+
+Tables::Tables() {
+	for (int lf = 0; lf <= 100; lf++) {
+		// CONFIRMED:KG: This matches a ROM table found by Mok
+		float fVal = (2.0f - LOG10F(float(lf) + 1.0f)) * 128.0f;
+		int val = int(fVal + 1.0);
+		if (val > 255) {
+			val = 255;
+		}
+		levelToAmpSubtraction[lf] = Bit8u(val);
+	}
+
+	envLogarithmicTime[0] = 64;
+	for (int lf = 1; lf <= 255; lf++) {
+		// CONFIRMED:KG: This matches a ROM table found by Mok
+		envLogarithmicTime[lf] = Bit8u(ceil(64.0f + LOG2F(float(lf)) * 8.0f));
+	}
+
+#if 0
+	// The table below is to be used in conjunction with emulation of VCA of newer generation units which is currently missing.
+	// These relatively small values are rather intended to fine-tune the overall amplification of the VCA.
+	// CONFIRMED: Based on a table found by Mok in the LAPC-I control ROM
+	// Note that this matches the MT-32 table, but with the values clamped to a maximum of 8.
+	memset(masterVolToAmpSubtraction, 8, 71);
+	memset(masterVolToAmpSubtraction + 71, 7, 3);
+	memset(masterVolToAmpSubtraction + 74, 6, 4);
+	memset(masterVolToAmpSubtraction + 78, 5, 3);
+	memset(masterVolToAmpSubtraction + 81, 4, 4);
+	memset(masterVolToAmpSubtraction + 85, 3, 3);
+	memset(masterVolToAmpSubtraction + 88, 2, 4);
+	memset(masterVolToAmpSubtraction + 92, 1, 4);
+	memset(masterVolToAmpSubtraction + 96, 0, 5);
+#else
+	// CONFIRMED: Based on a table found by Mok in the MT-32 control ROM
+	masterVolToAmpSubtraction[0] = 255;
+	for (int masterVol = 1; masterVol <= 100; masterVol++) {
+		masterVolToAmpSubtraction[masterVol] = Bit8u(106.31 - 16.0f * LOG2F(float(masterVol)));
+	}
+#endif
+
+	for (int i = 0; i <= 100; i++) {
+		pulseWidth100To255[i] = Bit8u(i * 255 / 100.0f + 0.5f);
+		//synth->printDebug("%d: %d", i, pulseWidth100To255[i]);
+	}
+
+	// The LA32 chip contains an exponent table inside. The table contains 12-bit integer values.
+	// The actual table size is 512 rows. The 9 higher bits of the fractional part of the argument are used as a lookup address.
+	// To improve the precision of computations, the lower bits are supposed to be used for interpolation as the LA32 chip also
+	// contains another 512-row table with inverted differences between the main table values.
+	for (int i = 0; i < 512; i++) {
+		exp9[i] = Bit16u(8191.5f - EXP2F(13.0f + ~i / 512.0f));
+	}
+
+	// There is a logarithmic sine table inside the LA32 chip. The table contains 13-bit integer values.
+	for (int i = 1; i < 512; i++) {
+		logsin9[i] = Bit16u(0.5f - LOG2F(sin((i + 0.5f) / 1024.0f * FLOAT_PI)) * 1024.0f);
+	}
+
+	// The very first value is clamped to the maximum possible 13-bit integer
+	logsin9[0] = 8191;
+
+	// found from sample analysis
+	static const Bit8u resAmpDecayFactorTable[] = {31, 16, 12, 8, 5, 3, 2, 1};
+	resAmpDecayFactors = resAmpDecayFactorTable;
+}
+
+} // namespace MT32Emu

--- a/vendor/munt/src/Tables.h
+++ b/vendor/munt/src/Tables.h
@@ -1,0 +1,64 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_TABLES_H
+#define MT32EMU_TABLES_H
+
+#include "globals.h"
+#include "Types.h"
+
+namespace MT32Emu {
+
+struct Tables {
+	// Ensures a singleton that is immutable yet guaranteed to be initialised orderly.
+	// However, this normally adds some performance penalty, so it should be avoided on the critical path.
+	static const Tables &getInstance();
+
+	// Constant LUTs
+
+	// CONFIRMED: This is used to convert several parameters to amp-modifying values in the TVA envelope:
+	// - PatchTemp.outputLevel
+	// - RhythmTemp.outlevel
+	// - PartialParam.tva.level
+	// - expression
+	// It's used to determine how much to subtract from the amp envelope's target value
+	Bit8u levelToAmpSubtraction[101];
+
+	// CONFIRMED: ...
+	Bit8u envLogarithmicTime[256];
+
+	// CONFIRMED: ...
+	Bit8u masterVolToAmpSubtraction[101];
+
+	// CONFIRMED:
+	Bit8u pulseWidth100To255[101];
+
+	Bit16u exp9[512];
+	Bit16u logsin9[512];
+
+	const Bit8u *resAmpDecayFactors;
+
+private:
+	Tables();
+	Tables(const Tables &);
+	~Tables() {}
+	Tables &operator=(const Tables &);
+}; // struct Tables
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_TABLES_H

--- a/vendor/munt/src/Types.h
+++ b/vendor/munt/src/Types.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_TYPES_H
+#define MT32EMU_TYPES_H
+
+namespace MT32Emu {
+
+typedef unsigned int       Bit32u;
+typedef   signed int       Bit32s;
+typedef unsigned short int Bit16u;
+typedef   signed short int Bit16s;
+typedef unsigned char      Bit8u;
+typedef   signed char      Bit8s;
+
+}
+
+#endif

--- a/vendor/munt/src/VersionTagging.cpp
+++ b/vendor/munt/src/VersionTagging.cpp
@@ -1,0 +1,36 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "globals.h"
+
+#undef MT32EMU_EXPORT_V
+#define MT32EMU_EXPORT_V(symbol_version_tag) MT32EMU_EXPORT_ATTRIBUTE
+
+extern "C" {
+// Here's a list of all tagged minor library versions through global (potentially versioned) symbols.
+// An application that's been linked with an older library version will be able to find a matching tag,
+// while for an application linked with a newer library version there will be no match.
+
+MT32EMU_EXPORT_V(2.5) extern const volatile char mt32emu_2_5 = 0;
+MT32EMU_EXPORT_V(2.6) extern const volatile char mt32emu_2_6 = 0;
+MT32EMU_EXPORT_V(2.7) extern const volatile char mt32emu_2_7 = 0;
+MT32EMU_EXPORT_V(2.8) extern const volatile char mt32emu_2_8 = 0;
+
+#if MT32EMU_VERSION_MAJOR > 2 || MT32EMU_VERSION_MINOR > 8
+#error "Missing version tag definition for current library version"
+#endif
+}

--- a/vendor/munt/src/VersionTagging.h
+++ b/vendor/munt/src/VersionTagging.h
@@ -1,0 +1,63 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_VERSION_TAG_H
+#define MT32EMU_VERSION_TAG_H
+
+#include "globals.h"
+
+/* This is intended to implement a simple check of a shared library version in runtime. Sadly, per-symbol versioning
+ * is unavailable on many platforms, and even where it is, it's still not too easy to maintain for a C++ library.
+ * Therefore, the goal here is just to ensure that the client application quickly bails out when attempted to run
+ * with an older version of shared library, as well as to produce a more readable error message indicating a version mismatch
+ * rather than a report about some missing symbols with unreadable mangled names.
+ * This is an optional feature, since it adds some minor burden to both the library and client applications code,
+ * albeit it is ought to work on platforms that do not implement symbol versioning.
+ */
+
+#define MT32EMU_REALLY_BUILD_VERSION_TAG(major, minor) mt32emu_ ## major ## _ ## minor
+/* This macro expansion step permits resolution the actual version numbers. */
+#define MT32EMU_BUILD_VERSION_TAG(major, minor) MT32EMU_REALLY_BUILD_VERSION_TAG(major, minor)
+#define MT32EMU_VERSION_TAG MT32EMU_BUILD_VERSION_TAG(MT32EMU_VERSION_MAJOR, MT32EMU_VERSION_MINOR)
+
+#undef MT32EMU_EXPORT
+#define MT32EMU_EXPORT MT32EMU_EXPORT_ATTRIBUTE
+
+#if defined(__cplusplus)
+
+extern "C" {
+MT32EMU_EXPORT extern const volatile char MT32EMU_VERSION_TAG;
+}
+// This pulls the external reference in yet prevents it from being optimised out.
+static const volatile char mt32emu_version_tag = MT32EMU_VERSION_TAG;
+
+#else
+
+static void mt32emu_refer_version_tag(void) {
+	MT32EMU_EXPORT extern const volatile char MT32EMU_VERSION_TAG;
+	(void)MT32EMU_VERSION_TAG;
+}
+
+static void (*const volatile mt32emu_refer_version_tag_ref)(void) = mt32emu_refer_version_tag;
+
+#endif
+
+#undef MT32EMU_REALLY_BUILD_VERSION_TAG
+#undef MT32EMU_BUILD_VERSION_TAG
+#undef MT32EMU_VERSION_TAG
+
+#endif

--- a/vendor/munt/src/c_interface/c_interface.cpp
+++ b/vendor/munt/src/c_interface/c_interface.cpp
@@ -1,0 +1,1033 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+
+#include "../globals.h"
+#include "../Types.h"
+#include "../File.h"
+#include "../FileStream.h"
+#include "../ROMInfo.h"
+#include "../Synth.h"
+#include "../MidiStreamParser.h"
+#include "../SampleRateConverter.h"
+
+#include "c_types.h"
+#include "c_interface.h"
+
+using namespace MT32Emu;
+
+namespace MT32Emu {
+
+struct SamplerateConversionState {
+	double outputSampleRate;
+	SamplerateConversionQuality srcQuality;
+	SampleRateConverter *src;
+};
+
+static mt32emu_service_version MT32EMU_C_CALL getSynthVersionID(mt32emu_service_i) {
+	return MT32EMU_SERVICE_VERSION_CURRENT;
+}
+
+static const mt32emu_service_i_v7 SERVICE_VTABLE = {
+	getSynthVersionID,
+	mt32emu_get_supported_report_handler_version,
+	mt32emu_get_supported_midi_receiver_version,
+	mt32emu_get_library_version_int,
+	mt32emu_get_library_version_string,
+	mt32emu_get_stereo_output_samplerate,
+	mt32emu_create_context,
+	mt32emu_free_context,
+	mt32emu_add_rom_data,
+	mt32emu_add_rom_file,
+	mt32emu_get_rom_info,
+	mt32emu_set_partial_count,
+	mt32emu_set_analog_output_mode,
+	mt32emu_open_synth,
+	mt32emu_close_synth,
+	mt32emu_is_open,
+	mt32emu_get_actual_stereo_output_samplerate,
+	mt32emu_flush_midi_queue,
+	mt32emu_set_midi_event_queue_size,
+	mt32emu_set_midi_receiver,
+	mt32emu_parse_stream,
+	mt32emu_parse_stream_at,
+	mt32emu_play_short_message,
+	mt32emu_play_short_message_at,
+	mt32emu_play_msg,
+	mt32emu_play_sysex,
+	mt32emu_play_msg_at,
+	mt32emu_play_sysex_at,
+	mt32emu_play_msg_now,
+	mt32emu_play_msg_on_part,
+	mt32emu_play_sysex_now,
+	mt32emu_write_sysex,
+	mt32emu_set_reverb_enabled,
+	mt32emu_is_reverb_enabled,
+	mt32emu_set_reverb_overridden,
+	mt32emu_is_reverb_overridden,
+	mt32emu_set_reverb_compatibility_mode,
+	mt32emu_is_mt32_reverb_compatibility_mode,
+	mt32emu_is_default_reverb_mt32_compatible,
+	mt32emu_set_dac_input_mode,
+	mt32emu_get_dac_input_mode,
+	mt32emu_set_midi_delay_mode,
+	mt32emu_get_midi_delay_mode,
+	mt32emu_set_output_gain,
+	mt32emu_get_output_gain,
+	mt32emu_set_reverb_output_gain,
+	mt32emu_get_reverb_output_gain,
+	mt32emu_set_reversed_stereo_enabled,
+	mt32emu_is_reversed_stereo_enabled,
+	mt32emu_render_bit16s,
+	mt32emu_render_float,
+	mt32emu_render_bit16s_streams,
+	mt32emu_render_float_streams,
+	mt32emu_has_active_partials,
+	mt32emu_is_active,
+	mt32emu_get_partial_count,
+	mt32emu_get_part_states,
+	mt32emu_get_partial_states,
+	mt32emu_get_playing_notes,
+	mt32emu_get_patch_name,
+	mt32emu_read_memory,
+	mt32emu_get_best_analog_output_mode,
+	mt32emu_set_stereo_output_samplerate,
+	mt32emu_set_samplerate_conversion_quality,
+	mt32emu_select_renderer_type,
+	mt32emu_get_selected_renderer_type,
+	mt32emu_convert_output_to_synth_timestamp,
+	mt32emu_convert_synth_to_output_timestamp,
+	mt32emu_get_internal_rendered_sample_count,
+	mt32emu_set_nice_amp_ramp_enabled,
+	mt32emu_is_nice_amp_ramp_enabled,
+	mt32emu_set_nice_panning_enabled,
+	mt32emu_is_nice_panning_enabled,
+	mt32emu_set_nice_partial_mixing_enabled,
+	mt32emu_is_nice_partial_mixing_enabled,
+	mt32emu_preallocate_reverb_memory,
+	mt32emu_configure_midi_event_queue_sysex_storage,
+	mt32emu_get_machine_ids,
+	mt32emu_get_rom_ids,
+	mt32emu_identify_rom_data,
+	mt32emu_identify_rom_file,
+	mt32emu_merge_and_add_rom_data,
+	mt32emu_merge_and_add_rom_files,
+	mt32emu_add_machine_rom_file,
+	mt32emu_get_display_state,
+	mt32emu_set_main_display_mode,
+	mt32emu_set_display_compatibility,
+	mt32emu_is_display_old_mt32_compatible,
+	mt32emu_is_default_display_old_mt32_compatible,
+	mt32emu_set_part_volume_override,
+	mt32emu_get_part_volume_override,
+	mt32emu_get_sound_group_name,
+	mt32emu_get_sound_name,
+	mt32emu_set_master_volume_override,
+	mt32emu_get_master_volume_override,
+	mt32emu_dump_sysex_bank,
+	mt32emu_apply_sysex_bank
+};
+
+} // namespace MT32Emu
+
+struct mt32emu_data {
+	ReportHandler3 *reportHandler;
+	Synth *synth;
+	const ROMImage *controlROMImage;
+	const ROMImage *pcmROMImage;
+	DefaultMidiStreamParser *midiParser;
+	Bit32u partialCount;
+	AnalogOutputMode analogOutputMode;
+	SamplerateConversionState *srcState;
+};
+
+// Internal C++ utility stuff
+
+namespace MT32Emu {
+
+class DelegatingReportHandlerAdapter : public ReportHandler3 {
+public:
+	DelegatingReportHandlerAdapter(mt32emu_report_handler_i useReportHandler, void *useInstanceData) :
+		delegate(useReportHandler), instanceData(useInstanceData) {}
+
+private:
+	const mt32emu_report_handler_i delegate;
+	void * const instanceData;
+
+	bool isVersionLess(mt32emu_report_handler_version versionID) {
+		return delegate.v0->getVersionID(delegate) < versionID;
+	}
+
+	void printDebug(const char *fmt, va_list list) {
+		if (delegate.v0->printDebug == NULL) {
+			ReportHandler::printDebug(fmt, list);
+		} else {
+			delegate.v0->printDebug(instanceData, fmt, list);
+		}
+	}
+
+	void onErrorControlROM() {
+		if (delegate.v0->onErrorControlROM == NULL) {
+			ReportHandler::onErrorControlROM();
+		} else {
+			delegate.v0->onErrorControlROM(instanceData);
+		}
+	}
+
+	void onErrorPCMROM() {
+		if (delegate.v0->onErrorPCMROM == NULL) {
+			ReportHandler::onErrorPCMROM();
+		} else {
+			delegate.v0->onErrorPCMROM(instanceData);
+		}
+	}
+
+	void showLCDMessage(const char *message) {
+		if (delegate.v0->showLCDMessage == NULL) {
+			ReportHandler::showLCDMessage(message);
+		} else {
+			delegate.v0->showLCDMessage(instanceData, message);
+		}
+	}
+
+	void onMIDIMessagePlayed() {
+		if (delegate.v0->onMIDIMessagePlayed == NULL) {
+			ReportHandler::onMIDIMessagePlayed();
+		} else {
+			delegate.v0->onMIDIMessagePlayed(instanceData);
+		}
+	}
+
+	bool onMIDIQueueOverflow() {
+		if (delegate.v0->onMIDIQueueOverflow == NULL) {
+			return ReportHandler::onMIDIQueueOverflow();
+		}
+		return delegate.v0->onMIDIQueueOverflow(instanceData) != MT32EMU_BOOL_FALSE;
+	}
+
+	void onMIDISystemRealtime(Bit8u systemRealtime) {
+		if (delegate.v0->onMIDISystemRealtime == NULL) {
+			ReportHandler::onMIDISystemRealtime(systemRealtime);
+		} else {
+			delegate.v0->onMIDISystemRealtime(instanceData, systemRealtime);
+		}
+	}
+
+	void onDeviceReset() {
+		if (delegate.v0->onDeviceReset == NULL) {
+			ReportHandler::onDeviceReset();
+		} else {
+			delegate.v0->onDeviceReset(instanceData);
+		}
+	}
+
+	void onDeviceReconfig() {
+		if (delegate.v0->onDeviceReconfig == NULL) {
+			ReportHandler::onDeviceReconfig();
+		} else {
+			delegate.v0->onDeviceReconfig(instanceData);
+		}
+	}
+
+	void onNewReverbMode(Bit8u mode) {
+		if (delegate.v0->onNewReverbMode == NULL) {
+			ReportHandler::onNewReverbMode(mode);
+		} else {
+			delegate.v0->onNewReverbMode(instanceData, mode);
+		}
+	}
+
+	void onNewReverbTime(Bit8u time) {
+		if (delegate.v0->onNewReverbTime == NULL) {
+			ReportHandler::onNewReverbTime(time);
+		} else {
+			delegate.v0->onNewReverbTime(instanceData, time);
+		}
+	}
+
+	void onNewReverbLevel(Bit8u level) {
+		if (delegate.v0->onNewReverbLevel == NULL) {
+			ReportHandler::onNewReverbLevel(level);
+		} else {
+			delegate.v0->onNewReverbLevel(instanceData, level);
+		}
+	}
+
+	void onPolyStateChanged(Bit8u partNum) {
+		if (delegate.v0->onPolyStateChanged == NULL) {
+			ReportHandler::onPolyStateChanged(partNum);
+		} else {
+			delegate.v0->onPolyStateChanged(instanceData, partNum);
+		}
+	}
+
+	void onProgramChanged(Bit8u partNum, const char *soundGroupName, const char *patchName) {
+		if (delegate.v0->onProgramChanged == NULL) {
+			ReportHandler::onProgramChanged(partNum, soundGroupName, patchName);
+		} else {
+			delegate.v0->onProgramChanged(instanceData, partNum, soundGroupName, patchName);
+		}
+	}
+
+	void onLCDStateUpdated() {
+		if (isVersionLess(MT32EMU_REPORT_HANDLER_VERSION_1) || delegate.v1->onLCDStateUpdated == NULL) {
+			ReportHandler2::onLCDStateUpdated();
+		} else {
+			delegate.v1->onLCDStateUpdated(instanceData);
+		}
+	}
+
+	void onMidiMessageLEDStateUpdated(bool ledState) {
+		if (isVersionLess(MT32EMU_REPORT_HANDLER_VERSION_1) || delegate.v1->onMidiMessageLEDStateUpdated == NULL) {
+			ReportHandler2::onMidiMessageLEDStateUpdated(ledState);
+		} else {
+			delegate.v1->onMidiMessageLEDStateUpdated(instanceData, ledState ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE);
+		}
+	}
+
+	void onNoteOnIgnored(Bit32u partialsNeeded, Bit32u partialsFree) {
+		if (isVersionLess(MT32EMU_REPORT_HANDLER_VERSION_2) || delegate.v2->onNoteOnIgnored == NULL) {
+			ReportHandler3::onNoteOnIgnored(partialsNeeded, partialsFree);
+		} else {
+			delegate.v2->onNoteOnIgnored(instanceData, partialsNeeded, partialsFree);
+		}
+	}
+
+	void onPlayingPolySilenced(Bit32u partialsNeeded, Bit32u partialsFree) {
+		if (isVersionLess(MT32EMU_REPORT_HANDLER_VERSION_2) || delegate.v2->onPlayingPolySilenced == NULL) {
+			ReportHandler3::onPlayingPolySilenced(partialsNeeded, partialsFree);
+		} else {
+			delegate.v2->onPlayingPolySilenced(instanceData, partialsNeeded, partialsFree);
+		}
+	}
+};
+
+class DelegatingMidiStreamParser : public DefaultMidiStreamParser {
+public:
+	DelegatingMidiStreamParser(const mt32emu_data *useData, mt32emu_midi_receiver_i useMIDIReceiver, void *useInstanceData) :
+		DefaultMidiStreamParser(*useData->synth), delegate(useMIDIReceiver), instanceData(useInstanceData) {}
+
+protected:
+	mt32emu_midi_receiver_i delegate;
+	void *instanceData;
+
+private:
+	void handleShortMessage(const Bit32u message) {
+		if (delegate.v0->handleShortMessage == NULL) {
+			DefaultMidiStreamParser::handleShortMessage(message);
+		} else {
+			delegate.v0->handleShortMessage(instanceData, message);
+		}
+	}
+
+	void handleSysex(const Bit8u *stream, const Bit32u length) {
+		if (delegate.v0->handleSysex == NULL) {
+			DefaultMidiStreamParser::handleSysex(stream, length);
+		} else {
+			delegate.v0->handleSysex(instanceData, stream, length);
+		}
+	}
+
+	void handleSystemRealtimeMessage(const Bit8u realtime) {
+		if (delegate.v0->handleSystemRealtimeMessage == NULL) {
+			DefaultMidiStreamParser::handleSystemRealtimeMessage(realtime);
+		} else {
+			delegate.v0->handleSystemRealtimeMessage(instanceData, realtime);
+		}
+	}
+};
+
+static void fillROMInfo(mt32emu_rom_info *rom_info, const ROMInfo *controlROMInfo, const ROMInfo *pcmROMInfo) {
+	if (controlROMInfo != NULL) {
+		rom_info->control_rom_id = controlROMInfo->shortName;
+		rom_info->control_rom_description = controlROMInfo->description;
+		rom_info->control_rom_sha1_digest = controlROMInfo->sha1Digest;
+	} else {
+		rom_info->control_rom_id = NULL;
+		rom_info->control_rom_description = NULL;
+		rom_info->control_rom_sha1_digest = NULL;
+	}
+	if (pcmROMInfo != NULL) {
+		rom_info->pcm_rom_id = pcmROMInfo->shortName;
+		rom_info->pcm_rom_description = pcmROMInfo->description;
+		rom_info->pcm_rom_sha1_digest = pcmROMInfo->sha1Digest;
+	} else {
+		rom_info->pcm_rom_id = NULL;
+		rom_info->pcm_rom_description = NULL;
+		rom_info->pcm_rom_sha1_digest = NULL;
+	}
+}
+
+static const MachineConfiguration *findMachineConfiguration(const char *machine_id) {
+	Bit32u configurationCount;
+	const MachineConfiguration * const *configurations = MachineConfiguration::getAllMachineConfigurations(&configurationCount);
+	for (Bit32u i = 0; i < configurationCount; i++) {
+		if (!strcmp(configurations[i]->getMachineID(), machine_id)) return configurations[i];
+	}
+	return NULL;
+}
+
+static mt32emu_return_code identifyROM(mt32emu_rom_info *rom_info, File *romFile, const char *machineID) {
+	const ROMInfo *romInfo;
+	if (machineID == NULL) {
+		romInfo = ROMInfo::getROMInfo(romFile);
+	} else {
+		const MachineConfiguration *configuration = findMachineConfiguration(machineID);
+		if (configuration == NULL) {
+			fillROMInfo(rom_info, NULL, NULL);
+			return MT32EMU_RC_MACHINE_NOT_IDENTIFIED;
+		}
+		romInfo = ROMInfo::getROMInfo(romFile, configuration->getCompatibleROMInfos());
+	}
+	if (romInfo == NULL) {
+		fillROMInfo(rom_info, NULL, NULL);
+		return MT32EMU_RC_ROM_NOT_IDENTIFIED;
+	}
+	if (romInfo->type == ROMInfo::Control) fillROMInfo(rom_info, romInfo, NULL);
+	else if (romInfo->type == ROMInfo::PCM) fillROMInfo(rom_info, NULL, romInfo);
+	else fillROMInfo(rom_info, NULL, NULL);
+	return MT32EMU_RC_OK;
+}
+
+static bool isROMInfoCompatible(const MachineConfiguration *machineConfiguration, const ROMInfo *romInfo) {
+	Bit32u romCount;
+	const ROMInfo * const *compatibleROMInfos = machineConfiguration->getCompatibleROMInfos(&romCount);
+	for (Bit32u i = 0; i < romCount; i++) {
+		if (romInfo == compatibleROMInfos[i]) return true;
+	}
+	return false;
+}
+
+static mt32emu_return_code replaceOrMergeROMImage(const ROMImage *&contextROMImage, const ROMImage *newROMImage, const MachineConfiguration *machineConfiguration, mt32emu_return_code addedFullROM, mt32emu_return_code addedPartialROM) {
+	if (contextROMImage != NULL) {
+		if (machineConfiguration != NULL) {
+			const ROMImage *mergedROMImage = ROMImage::mergeROMImages(contextROMImage, newROMImage);
+			if (mergedROMImage != NULL) {
+				if (newROMImage->isFileUserProvided()) delete newROMImage->getFile();
+				ROMImage::freeROMImage(newROMImage);
+				if (contextROMImage->isFileUserProvided()) delete contextROMImage->getFile();
+				ROMImage::freeROMImage(contextROMImage);
+				contextROMImage = mergedROMImage;
+				return addedFullROM;
+			}
+			if (newROMImage->getROMInfo() == contextROMImage->getROMInfo()
+				|| (newROMImage->getROMInfo()->pairType != ROMInfo::Full
+					&& isROMInfoCompatible(machineConfiguration, contextROMImage->getROMInfo()))) {
+				ROMImage::freeROMImage(newROMImage);
+				return MT32EMU_RC_OK;
+			}
+		}
+		if (contextROMImage->isFileUserProvided()) delete contextROMImage->getFile();
+		ROMImage::freeROMImage(contextROMImage);
+	}
+	contextROMImage = newROMImage;
+	return newROMImage->getROMInfo()->pairType == ROMInfo::Full ? addedFullROM: addedPartialROM;
+}
+
+static mt32emu_return_code addROMFiles(mt32emu_data *data, File *file1, File *file2 = NULL, const MachineConfiguration *machineConfiguration = NULL) {
+	const ROMImage *romImage;
+	if (machineConfiguration != NULL) {
+		romImage = ROMImage::makeROMImage(file1, machineConfiguration->getCompatibleROMInfos());
+	} else {
+		romImage = file2 == NULL ? ROMImage::makeROMImage(file1, ROMInfo::getFullROMInfos()) : ROMImage::makeROMImage(file1, file2);
+	}
+	if (romImage == NULL) return MT32EMU_RC_ROMS_NOT_PAIRABLE;
+	const ROMInfo *info = romImage->getROMInfo();
+	if (info == NULL) {
+		ROMImage::freeROMImage(romImage);
+		return MT32EMU_RC_ROM_NOT_IDENTIFIED;
+	}
+	switch (info->type) {
+	case ROMInfo::Control:
+		return replaceOrMergeROMImage(data->controlROMImage, romImage, machineConfiguration, MT32EMU_RC_ADDED_CONTROL_ROM, MT32EMU_RC_ADDED_PARTIAL_CONTROL_ROM);
+	case ROMInfo::PCM:
+		return replaceOrMergeROMImage(data->pcmROMImage, romImage, machineConfiguration, MT32EMU_RC_ADDED_PCM_ROM, MT32EMU_RC_ADDED_PARTIAL_PCM_ROM);
+	default:
+		ROMImage::freeROMImage(romImage);
+		return MT32EMU_RC_OK; // No support for reverb ROM yet.
+	}
+}
+
+static mt32emu_return_code createFileStream(const char *filename, FileStream *&fileStream) {
+	mt32emu_return_code rc;
+	fileStream = new FileStream;
+	if (!fileStream->open(filename)) {
+		rc = MT32EMU_RC_FILE_NOT_FOUND;
+	} else if (fileStream->getSize() == 0) {
+		rc = MT32EMU_RC_FILE_NOT_LOADED;
+	} else {
+		return MT32EMU_RC_OK;
+	}
+	delete fileStream;
+	fileStream = NULL;
+	return rc;
+}
+
+} // namespace MT32Emu
+
+// C-visible implementation
+
+extern "C" {
+
+mt32emu_service_i MT32EMU_C_CALL mt32emu_get_service_i() {
+	mt32emu_service_i i;
+	i.v7 = &SERVICE_VTABLE;
+	return i;
+}
+
+mt32emu_report_handler_version MT32EMU_C_CALL mt32emu_get_supported_report_handler_version() {
+	return MT32EMU_REPORT_HANDLER_VERSION_CURRENT;
+}
+
+mt32emu_midi_receiver_version MT32EMU_C_CALL mt32emu_get_supported_midi_receiver_version() {
+	return MT32EMU_MIDI_RECEIVER_VERSION_CURRENT;
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_library_version_int() {
+	return Synth::getLibraryVersionInt();
+}
+
+const char * MT32EMU_C_CALL mt32emu_get_library_version_string() {
+	return Synth::getLibraryVersionString();
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_stereo_output_samplerate(const mt32emu_analog_output_mode analog_output_mode) {
+	return Synth::getStereoOutputSampleRate(static_cast<AnalogOutputMode>(analog_output_mode));
+}
+
+mt32emu_analog_output_mode MT32EMU_C_CALL mt32emu_get_best_analog_output_mode(const double target_samplerate) {
+	return mt32emu_analog_output_mode(SampleRateConverter::getBestAnalogOutputMode(target_samplerate));
+}
+
+size_t MT32EMU_C_CALL mt32emu_get_machine_ids(const char **machine_ids, size_t machine_ids_size) {
+	Bit32u configurationCount;
+	const MachineConfiguration * const *configurations = MachineConfiguration::getAllMachineConfigurations(&configurationCount);
+	if (machine_ids != NULL) {
+		for (Bit32u i = 0; i < machine_ids_size; i++) {
+			machine_ids[i] = i < configurationCount ? configurations[i]->getMachineID() : NULL;
+		}
+	}
+	return configurationCount;
+}
+
+size_t MT32EMU_C_CALL mt32emu_get_rom_ids(const char **rom_ids, size_t rom_ids_size, const char *machine_id) {
+	const ROMInfo * const *romInfos;
+	Bit32u romCount;
+	if (machine_id != NULL) {
+		const MachineConfiguration *configuration = findMachineConfiguration(machine_id);
+		if (configuration != NULL) {
+			romInfos = configuration->getCompatibleROMInfos(&romCount);
+		} else {
+			romInfos = NULL;
+			romCount = 0U;
+		}
+	} else {
+		romInfos = ROMInfo::getAllROMInfos(&romCount);
+	}
+	if (rom_ids != NULL) {
+		for (size_t i = 0; i < rom_ids_size; i++) {
+			rom_ids[i] = i < romCount ? romInfos[i]->shortName : NULL;
+		}
+	}
+	return romCount;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_identify_rom_data(mt32emu_rom_info *rom_info, const mt32emu_bit8u *data, size_t data_size, const char *machine_id) {
+	ArrayFile romFile = ArrayFile(data, data_size);
+	return identifyROM(rom_info, &romFile, machine_id);
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_identify_rom_file(mt32emu_rom_info *rom_info, const char *filename, const char *machine_id) {
+	FileStream *fs;
+	mt32emu_return_code rc = createFileStream(filename, fs);
+	if (fs == NULL) return rc;
+	rc = identifyROM(rom_info, fs, machine_id);
+	delete fs;
+	return rc;
+}
+
+mt32emu_context MT32EMU_C_CALL mt32emu_create_context(mt32emu_report_handler_i report_handler, void *instance_data) {
+	mt32emu_data *data = new mt32emu_data;
+	data->synth = new Synth;
+	if (report_handler.v0 != NULL) {
+		data->reportHandler = new DelegatingReportHandlerAdapter(report_handler, instance_data);
+		data->synth->setReportHandler3(data->reportHandler);
+	} else {
+		data->reportHandler = NULL;
+	}
+	data->midiParser = new DefaultMidiStreamParser(*data->synth);
+	data->controlROMImage = NULL;
+	data->pcmROMImage = NULL;
+	data->partialCount = DEFAULT_MAX_PARTIALS;
+	data->analogOutputMode = AnalogOutputMode_COARSE;
+
+	data->srcState = new SamplerateConversionState;
+	data->srcState->outputSampleRate = 0.0;
+	data->srcState->srcQuality = SamplerateConversionQuality_GOOD;
+	data->srcState->src = NULL;
+
+	return data;
+}
+
+void MT32EMU_C_CALL mt32emu_free_context(mt32emu_context data) {
+	if (data == NULL) return;
+
+	delete data->srcState->src;
+	data->srcState->src = NULL;
+	delete data->srcState;
+	data->srcState = NULL;
+
+	if (data->controlROMImage != NULL) {
+		if (data->controlROMImage->isFileUserProvided()) delete data->controlROMImage->getFile();
+		ROMImage::freeROMImage(data->controlROMImage);
+		data->controlROMImage = NULL;
+	}
+	if (data->pcmROMImage != NULL) {
+		if (data->pcmROMImage->isFileUserProvided()) delete data->pcmROMImage->getFile();
+		ROMImage::freeROMImage(data->pcmROMImage);
+		data->pcmROMImage = NULL;
+	}
+	delete data->midiParser;
+	data->midiParser = NULL;
+	delete data->synth;
+	data->synth = NULL;
+	delete data->reportHandler;
+	data->reportHandler = NULL;
+	delete data;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_add_rom_data(mt32emu_context context, const mt32emu_bit8u *data, size_t data_size, const mt32emu_sha1_digest *sha1_digest) {
+	if (sha1_digest == NULL) return addROMFiles(context, new ArrayFile(data, data_size));
+	return addROMFiles(context, new ArrayFile(data, data_size, *sha1_digest));
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_add_rom_file(mt32emu_context context, const char *filename) {
+	FileStream *fs;
+	mt32emu_return_code rc = createFileStream(filename, fs);
+	if (fs != NULL) rc = addROMFiles(context, fs);
+	if (rc <= MT32EMU_RC_OK) delete fs;
+	return rc;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_merge_and_add_rom_data(mt32emu_context context, const mt32emu_bit8u *part1_data, size_t part1_data_size, const mt32emu_sha1_digest *part1_sha1_digest, const mt32emu_bit8u *part2_data, size_t part2_data_size, const mt32emu_sha1_digest *part2_sha1_digest) {
+	ArrayFile *file1 = part1_sha1_digest == NULL ? new ArrayFile(part1_data, part1_data_size) : new ArrayFile(part1_data, part1_data_size, *part1_sha1_digest);
+	ArrayFile *file2 = part2_sha1_digest == NULL ? new ArrayFile(part2_data, part2_data_size) : new ArrayFile(part2_data, part2_data_size, *part2_sha1_digest);
+	mt32emu_return_code rc = addROMFiles(context, file1, file2);
+	delete file1;
+	delete file2;
+	return rc;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_merge_and_add_rom_files(mt32emu_context context, const char *part1_filename, const char *part2_filename) {
+	FileStream *fs1;
+	mt32emu_return_code rc = createFileStream(part1_filename, fs1);
+	if (fs1 != NULL) {
+		FileStream *fs2;
+		rc = createFileStream(part2_filename, fs2);
+		if (fs2 != NULL) {
+			rc = addROMFiles(context, fs1, fs2);
+			delete fs2;
+		}
+		delete fs1;
+	}
+	return rc;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_add_machine_rom_file(mt32emu_context context, const char *machine_id, const char *filename) {
+	const MachineConfiguration *machineConfiguration = findMachineConfiguration(machine_id);
+	if (machineConfiguration == NULL) return MT32EMU_RC_MACHINE_NOT_IDENTIFIED;
+
+	FileStream *fs;
+	mt32emu_return_code rc = createFileStream(filename, fs);
+	if (fs == NULL) return rc;
+	rc = addROMFiles(context, fs, NULL, machineConfiguration);
+	if (rc <= MT32EMU_RC_OK) delete fs;
+	return rc;
+}
+
+void MT32EMU_C_CALL mt32emu_get_rom_info(mt32emu_const_context context, mt32emu_rom_info *rom_info) {
+	const ROMInfo *controlROMInfo = context->controlROMImage == NULL ? NULL : context->controlROMImage->getROMInfo();
+	const ROMInfo *pcmROMInfo = context->pcmROMImage == NULL ? NULL : context->pcmROMImage->getROMInfo();
+	fillROMInfo(rom_info, controlROMInfo, pcmROMInfo);
+}
+
+void MT32EMU_C_CALL mt32emu_set_partial_count(mt32emu_context context, const mt32emu_bit32u partial_count) {
+	context->partialCount = partial_count;
+}
+
+void MT32EMU_C_CALL mt32emu_set_analog_output_mode(mt32emu_context context, const mt32emu_analog_output_mode analog_output_mode) {
+	context->analogOutputMode = static_cast<AnalogOutputMode>(analog_output_mode);
+}
+
+void MT32EMU_C_CALL mt32emu_set_stereo_output_samplerate(mt32emu_context context, const double samplerate) {
+	context->srcState->outputSampleRate = SampleRateConverter::getSupportedOutputSampleRate(samplerate);
+}
+
+void MT32EMU_C_CALL mt32emu_set_samplerate_conversion_quality(mt32emu_context context, const mt32emu_samplerate_conversion_quality quality) {
+	context->srcState->srcQuality = SamplerateConversionQuality(quality);
+}
+
+void MT32EMU_C_CALL mt32emu_select_renderer_type(mt32emu_context context, const mt32emu_renderer_type renderer_type) {
+	context->synth->selectRendererType(static_cast<RendererType>(renderer_type));
+}
+
+mt32emu_renderer_type MT32EMU_C_CALL mt32emu_get_selected_renderer_type(mt32emu_context context) {
+	return static_cast<mt32emu_renderer_type>(context->synth->getSelectedRendererType());
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_open_synth(mt32emu_const_context context) {
+	if ((context->controlROMImage == NULL) || (context->pcmROMImage == NULL)) {
+		return MT32EMU_RC_MISSING_ROMS;
+	}
+	if (!context->synth->open(*context->controlROMImage, *context->pcmROMImage, context->partialCount, context->analogOutputMode)) {
+		return MT32EMU_RC_FAILED;
+	}
+	SamplerateConversionState &srcState = *context->srcState;
+	const double outputSampleRate = (0.0 < srcState.outputSampleRate) ? srcState.outputSampleRate : context->synth->getStereoOutputSampleRate();
+	srcState.src = new SampleRateConverter(*context->synth, outputSampleRate, srcState.srcQuality);
+	return MT32EMU_RC_OK;
+}
+
+void MT32EMU_C_CALL mt32emu_close_synth(mt32emu_const_context context) {
+	context->synth->close();
+	delete context->srcState->src;
+	context->srcState->src = NULL;
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_open(mt32emu_const_context context) {
+	return context->synth->isOpen() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_actual_stereo_output_samplerate(mt32emu_const_context context) {
+	if (context->srcState->src == NULL) {
+		return context->synth->getStereoOutputSampleRate();
+	}
+	return mt32emu_bit32u(0.5 + context->srcState->src->convertSynthToOutputTimestamp(SAMPLE_RATE));
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_convert_output_to_synth_timestamp(mt32emu_const_context context, mt32emu_bit32u output_timestamp) {
+	if (context->srcState->src == NULL) {
+		return output_timestamp;
+	}
+	return mt32emu_bit32u(0.5 + context->srcState->src->convertOutputToSynthTimestamp(output_timestamp));
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_convert_synth_to_output_timestamp(mt32emu_const_context context, mt32emu_bit32u synth_timestamp) {
+	if (context->srcState->src == NULL) {
+		return synth_timestamp;
+	}
+	return mt32emu_bit32u(0.5 + context->srcState->src->convertSynthToOutputTimestamp(synth_timestamp));
+}
+
+void MT32EMU_C_CALL mt32emu_flush_midi_queue(mt32emu_const_context context) {
+	context->synth->flushMIDIQueue();
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_set_midi_event_queue_size(mt32emu_const_context context, const mt32emu_bit32u queue_size) {
+	return context->synth->setMIDIEventQueueSize(queue_size);
+}
+
+void MT32EMU_C_CALL mt32emu_configure_midi_event_queue_sysex_storage(mt32emu_const_context context, const mt32emu_bit32u storage_buffer_size) {
+	context->synth->configureMIDIEventQueueSysexStorage(storage_buffer_size);
+}
+
+void MT32EMU_C_CALL mt32emu_set_midi_receiver(mt32emu_context context, mt32emu_midi_receiver_i midi_receiver, void *instance_data) {
+	delete context->midiParser;
+	context->midiParser = (midi_receiver.v0 != NULL) ? new DelegatingMidiStreamParser(context, midi_receiver, instance_data) : new DefaultMidiStreamParser(*context->synth);
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_internal_rendered_sample_count(mt32emu_const_context context) {
+	return context->synth->getInternalRenderedSampleCount();
+}
+
+void MT32EMU_C_CALL mt32emu_parse_stream(mt32emu_const_context context, const mt32emu_bit8u *stream, mt32emu_bit32u length) {
+	context->midiParser->resetTimestamp();
+	context->midiParser->parseStream(stream, length);
+}
+
+void MT32EMU_C_CALL mt32emu_parse_stream_at(mt32emu_const_context context, const mt32emu_bit8u *stream, mt32emu_bit32u length, mt32emu_bit32u timestamp) {
+	context->midiParser->setTimestamp(timestamp);
+	context->midiParser->parseStream(stream, length);
+}
+
+void MT32EMU_C_CALL mt32emu_play_short_message(mt32emu_const_context context, mt32emu_bit32u message) {
+	context->midiParser->resetTimestamp();
+	context->midiParser->processShortMessage(message);
+}
+
+void MT32EMU_C_CALL mt32emu_play_short_message_at(mt32emu_const_context context, mt32emu_bit32u message, mt32emu_bit32u timestamp) {
+	context->midiParser->setTimestamp(timestamp);
+	context->midiParser->processShortMessage(message);
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_play_msg(mt32emu_const_context context, mt32emu_bit32u msg) {
+	if (!context->synth->isOpen()) return MT32EMU_RC_NOT_OPENED;
+	return (context->synth->playMsg(msg)) ? MT32EMU_RC_OK : MT32EMU_RC_QUEUE_FULL;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_play_sysex(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len) {
+	if (!context->synth->isOpen()) return MT32EMU_RC_NOT_OPENED;
+	return (context->synth->playSysex(sysex, len)) ? MT32EMU_RC_OK : MT32EMU_RC_QUEUE_FULL;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_play_msg_at(mt32emu_const_context context, mt32emu_bit32u msg, mt32emu_bit32u timestamp) {
+	if (!context->synth->isOpen()) return MT32EMU_RC_NOT_OPENED;
+	return (context->synth->playMsg(msg, timestamp)) ? MT32EMU_RC_OK : MT32EMU_RC_QUEUE_FULL;
+}
+
+mt32emu_return_code MT32EMU_C_CALL mt32emu_play_sysex_at(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len, mt32emu_bit32u timestamp) {
+	if (!context->synth->isOpen()) return MT32EMU_RC_NOT_OPENED;
+	return (context->synth->playSysex(sysex, len, timestamp)) ? MT32EMU_RC_OK : MT32EMU_RC_QUEUE_FULL;
+}
+
+void MT32EMU_C_CALL mt32emu_play_msg_now(mt32emu_const_context context, mt32emu_bit32u msg) {
+	context->synth->playMsgNow(msg);
+}
+
+void MT32EMU_C_CALL mt32emu_play_msg_on_part(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u command, mt32emu_bit8u data1, mt32emu_bit8u data2) {
+	context->synth->playMsgOnPart(part_number, command, data1, data2);
+}
+
+void MT32EMU_C_CALL mt32emu_play_sysex_now(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len) {
+	context->synth->playSysexNow(sysex, len);
+}
+
+void MT32EMU_C_CALL mt32emu_write_sysex(mt32emu_const_context context, mt32emu_bit8u channel, const mt32emu_bit8u *sysex, mt32emu_bit32u len) {
+	context->synth->writeSysex(channel, sysex, len);
+}
+
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_dump_sysex_bank(mt32emu_const_context context, mt32emu_bit8u *sysex_bank, mt32emu_bit32u size) {
+	return context->synth->dumpSysexBank(sysex_bank, size);
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_apply_sysex_bank(mt32emu_const_context context, const mt32emu_bit8u *sysex_bank, mt32emu_bit32u size) {
+	return context->synth->applySysexBank(sysex_bank, size);
+}
+
+void MT32EMU_C_CALL mt32emu_set_reverb_enabled(mt32emu_const_context context, const mt32emu_boolean reverb_enabled) {
+	context->synth->setReverbEnabled(reverb_enabled != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_reverb_enabled(mt32emu_const_context context) {
+	return context->synth->isReverbEnabled() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_set_reverb_overridden(mt32emu_const_context context, const mt32emu_boolean reverb_overridden) {
+	context->synth->setReverbOverridden(reverb_overridden != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_reverb_overridden(mt32emu_const_context context) {
+	return context->synth->isReverbOverridden() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_set_reverb_compatibility_mode(mt32emu_const_context context, const mt32emu_boolean mt32_compatible_mode) {
+	context->synth->setReverbCompatibilityMode(mt32_compatible_mode != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_mt32_reverb_compatibility_mode(mt32emu_const_context context) {
+	return context->synth->isMT32ReverbCompatibilityMode() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_default_reverb_mt32_compatible(mt32emu_const_context context) {
+	return context->synth->isDefaultReverbMT32Compatible() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_preallocate_reverb_memory(mt32emu_const_context context, const mt32emu_boolean enabled) {
+	context->synth->preallocateReverbMemory(enabled != MT32EMU_BOOL_FALSE);
+}
+
+void MT32EMU_C_CALL mt32emu_set_dac_input_mode(mt32emu_const_context context, const mt32emu_dac_input_mode mode) {
+	context->synth->setDACInputMode(static_cast<DACInputMode>(mode));
+}
+
+mt32emu_dac_input_mode MT32EMU_C_CALL mt32emu_get_dac_input_mode(mt32emu_const_context context) {
+	return static_cast<mt32emu_dac_input_mode>(context->synth->getDACInputMode());
+}
+
+void MT32EMU_C_CALL mt32emu_set_midi_delay_mode(mt32emu_const_context context, const mt32emu_midi_delay_mode mode) {
+	context->synth->setMIDIDelayMode(static_cast<MIDIDelayMode>(mode));
+}
+
+mt32emu_midi_delay_mode MT32EMU_C_CALL mt32emu_get_midi_delay_mode(mt32emu_const_context context) {
+	return static_cast<mt32emu_midi_delay_mode>(context->synth->getMIDIDelayMode());
+}
+
+void MT32EMU_C_CALL mt32emu_set_output_gain(mt32emu_const_context context, float gain) {
+	context->synth->setOutputGain(gain);
+}
+
+float MT32EMU_C_CALL mt32emu_get_output_gain(mt32emu_const_context context) {
+	return context->synth->getOutputGain();
+}
+
+void MT32EMU_C_CALL mt32emu_set_reverb_output_gain(mt32emu_const_context context, float gain) {
+	context->synth->setReverbOutputGain(gain);
+}
+
+float MT32EMU_C_CALL mt32emu_get_reverb_output_gain(mt32emu_const_context context) {
+	return context->synth->getReverbOutputGain();
+}
+
+void MT32EMU_C_CALL mt32emu_set_master_volume_override(mt32emu_const_context context, mt32emu_bit8u volume_override) {
+	context->synth->setMasterVolumeOverride(volume_override);
+}
+
+mt32emu_bit8u MT32EMU_C_CALL mt32emu_get_master_volume_override(mt32emu_const_context context) {
+	return context->synth->getMasterVolumeOverride();
+}
+
+void MT32EMU_C_CALL mt32emu_set_part_volume_override(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u volume_override) {
+	context->synth->setPartVolumeOverride(part_number, volume_override);
+}
+
+mt32emu_bit8u MT32EMU_C_CALL mt32emu_get_part_volume_override(mt32emu_const_context context, mt32emu_bit8u part_number) {
+	return context->synth->getPartVolumeOverride(part_number);
+}
+
+void MT32EMU_C_CALL mt32emu_set_reversed_stereo_enabled(mt32emu_const_context context, const mt32emu_boolean enabled) {
+	context->synth->setReversedStereoEnabled(enabled != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_reversed_stereo_enabled(mt32emu_const_context context) {
+	return context->synth->isReversedStereoEnabled() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_set_nice_amp_ramp_enabled(mt32emu_const_context context, const mt32emu_boolean enabled) {
+	context->synth->setNiceAmpRampEnabled(enabled != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_nice_amp_ramp_enabled(mt32emu_const_context context) {
+	return context->synth->isNiceAmpRampEnabled() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_set_nice_panning_enabled(mt32emu_const_context context, const mt32emu_boolean enabled) {
+	context->synth->setNicePanningEnabled(enabled != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_nice_panning_enabled(mt32emu_const_context context) {
+	return context->synth->isNicePanningEnabled() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_set_nice_partial_mixing_enabled(mt32emu_const_context context, const mt32emu_boolean enabled) {
+	context->synth->setNicePartialMixingEnabled(enabled != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_nice_partial_mixing_enabled(mt32emu_const_context context) {
+	return context->synth->isNicePartialMixingEnabled() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_render_bit16s(mt32emu_const_context context, mt32emu_bit16s *stream, mt32emu_bit32u len) {
+	if (context->srcState->src != NULL) {
+		context->srcState->src->getOutputSamples(stream, len);
+	} else {
+		context->synth->render(stream, len);
+	}
+}
+
+void MT32EMU_C_CALL mt32emu_render_float(mt32emu_const_context context, float *stream, mt32emu_bit32u len) {
+	if (context->srcState->src != NULL) {
+		context->srcState->src->getOutputSamples(stream, len);
+	} else {
+		context->synth->render(stream, len);
+	}
+}
+
+void MT32EMU_C_CALL mt32emu_render_bit16s_streams(mt32emu_const_context context, const mt32emu_dac_output_bit16s_streams *streams, mt32emu_bit32u len) {
+	context->synth->renderStreams(*reinterpret_cast<const DACOutputStreams<Bit16s> *>(streams), len);
+}
+
+void MT32EMU_C_CALL mt32emu_render_float_streams(mt32emu_const_context context, const mt32emu_dac_output_float_streams *streams, mt32emu_bit32u len) {
+	context->synth->renderStreams(*reinterpret_cast<const DACOutputStreams<float> *>(streams), len);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_has_active_partials(mt32emu_const_context context) {
+	return context->synth->hasActivePartials() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_active(mt32emu_const_context context) {
+	return context->synth->isActive() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_partial_count(mt32emu_const_context context) {
+	return context->synth->getPartialCount();
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_part_states(mt32emu_const_context context) {
+	return context->synth->getPartStates();
+}
+
+void MT32EMU_C_CALL mt32emu_get_partial_states(mt32emu_const_context context, mt32emu_bit8u *partial_states) {
+	context->synth->getPartialStates(partial_states);
+}
+
+mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_playing_notes(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u *keys, mt32emu_bit8u *velocities) {
+	return context->synth->getPlayingNotes(part_number, keys, velocities);
+}
+
+const char * MT32EMU_C_CALL mt32emu_get_patch_name(mt32emu_const_context context, mt32emu_bit8u part_number) {
+	return context->synth->getPatchName(part_number);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_get_sound_group_name(mt32emu_const_context context, char *sound_group_name, mt32emu_bit8u timbre_group, mt32emu_bit8u timbre_number) {
+	return context->synth->getSoundGroupName(sound_group_name, timbre_group, timbre_number) ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_get_sound_name(mt32emu_const_context context, char *sound_name, mt32emu_bit8u timbre_group, mt32emu_bit8u timbre_number) {
+	return context->synth->getSoundName(sound_name, timbre_group, timbre_number) ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_read_memory(mt32emu_const_context context, mt32emu_bit32u addr, mt32emu_bit32u len, mt32emu_bit8u *data) {
+	context->synth->readMemory(addr, len, data);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_get_display_state(mt32emu_const_context context, char *target_buffer, const mt32emu_boolean narrow_lcd) {
+	return context->synth->getDisplayState(target_buffer, narrow_lcd != MT32EMU_BOOL_FALSE) ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+void MT32EMU_C_CALL mt32emu_set_main_display_mode(mt32emu_const_context context) {
+	context->synth->setMainDisplayMode();
+}
+
+void MT32EMU_C_CALL mt32emu_set_display_compatibility(mt32emu_const_context context, mt32emu_boolean old_mt32_compatibility_enabled) {
+	context->synth->setDisplayCompatibility(old_mt32_compatibility_enabled != MT32EMU_BOOL_FALSE);
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_display_old_mt32_compatible(mt32emu_const_context context) {
+	return context->synth->isDisplayOldMT32Compatible() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+mt32emu_boolean MT32EMU_C_CALL mt32emu_is_default_display_old_mt32_compatible(mt32emu_const_context context) {
+	return context->synth->isDefaultDisplayOldMT32Compatible() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+} // extern "C"
+
+#ifdef MT32EMU_WITH_TESTING
+
+#include "../test/TestAccessors.h"
+
+const MachineConfiguration *Test::findMachineConfiguration(const char *machineID) {
+	return MT32Emu::findMachineConfiguration(machineID);
+}
+
+ReportHandler3 *Test::getReportHandlerDelegate(const mt32emu_data *context) {
+	return context->reportHandler;
+}
+
+#endif // #ifdef MT32EMU_WITH_TESTING

--- a/vendor/munt/src/c_interface/c_interface.h
+++ b/vendor/munt/src/c_interface/c_interface.h
@@ -1,0 +1,684 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_C_INTERFACE_H
+#define MT32EMU_C_INTERFACE_H
+
+#include <stddef.h>
+
+#include "../globals.h"
+#include "c_types.h"
+
+#undef MT32EMU_EXPORT
+#undef MT32EMU_EXPORT_V
+#define MT32EMU_EXPORT MT32EMU_EXPORT_ATTRIBUTE
+#define MT32EMU_EXPORT_V(symbol_version_tag) MT32EMU_EXPORT
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* == Context-independent functions == */
+
+/* === Interface handling === */
+
+/** Returns mt32emu_service_i interface. */
+MT32EMU_EXPORT mt32emu_service_i MT32EMU_C_CALL mt32emu_get_service_i(void);
+
+#if MT32EMU_EXPORTS_TYPE == 2
+#undef MT32EMU_EXPORT
+#undef MT32EMU_EXPORT_V
+#define MT32EMU_EXPORT
+#define MT32EMU_EXPORT_V(symbol_version_tag) MT32EMU_EXPORT
+#endif
+
+/**
+ * Returns the version ID of mt32emu_report_handler_i interface the library has been compiled with.
+ * This allows a client to fall-back gracefully instead of silently not receiving expected event reports.
+ */
+MT32EMU_EXPORT mt32emu_report_handler_version MT32EMU_C_CALL mt32emu_get_supported_report_handler_version(void);
+
+/**
+ * Returns the version ID of mt32emu_midi_receiver_version_i interface the library has been compiled with.
+ * This allows a client to fall-back gracefully instead of silently not receiving expected MIDI messages.
+ */
+MT32EMU_EXPORT mt32emu_midi_receiver_version MT32EMU_C_CALL mt32emu_get_supported_midi_receiver_version(void);
+
+/* === Utility === */
+
+/**
+ * Returns library version as an integer in format: 0x00MMmmpp, where:
+ * MM - major version number
+ * mm - minor version number
+ * pp - patch number
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_library_version_int(void);
+
+/**
+ * Returns library version as a C-string in format: "MAJOR.MINOR.PATCH".
+ */
+MT32EMU_EXPORT const char * MT32EMU_C_CALL mt32emu_get_library_version_string(void);
+
+/**
+ * Returns output sample rate used in emulation of stereo analog circuitry of hardware units for particular analog_output_mode.
+ * See comment for mt32emu_analog_output_mode.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_stereo_output_samplerate(const mt32emu_analog_output_mode analog_output_mode);
+
+/**
+ * Returns the value of analog_output_mode for which the output signal may retain its full frequency spectrum
+ * at the sample rate specified by the target_samplerate argument.
+ * See comment for mt32emu_analog_output_mode.
+ */
+MT32EMU_EXPORT mt32emu_analog_output_mode MT32EMU_C_CALL mt32emu_get_best_analog_output_mode(const double target_samplerate);
+
+/* === ROM handling === */
+
+/**
+ * Retrieves a list of identifiers (as C-strings) of supported machines. Argument machine_ids points to the array of size
+ * machine_ids_size to be filled.
+ * Returns the number of identifiers available for retrieval. The size of the target array to be allocated can be found
+ * by passing NULL in argument machine_ids; argument machine_ids_size is ignored in this case.
+ */
+MT32EMU_EXPORT_V(2.5) size_t MT32EMU_C_CALL mt32emu_get_machine_ids(const char **machine_ids, size_t machine_ids_size);
+/**
+ * Retrieves a list of identifiers (as C-strings) of supported ROM images. Argument rom_ids points to the array of size
+ * rom_ids_size to be filled. Optional argument machine_id can be used to indicate a specific machine to retrieve ROM identifiers
+ * for; if NULL, identifiers of all the ROM images supported by the emulation engine are retrieved.
+ * Returns the number of ROM identifiers available for retrieval. The size of the target array to be allocated can be found
+ * by passing NULL in argument rom_ids; argument rom_ids_size is ignored in this case. If argument machine_id contains
+ * an unrecognised value, 0 is returned.
+ */
+MT32EMU_EXPORT_V(2.5) size_t MT32EMU_C_CALL mt32emu_get_rom_ids(const char **rom_ids, size_t rom_ids_size, const char *machine_id);
+
+/**
+ * Identifies a ROM image the provided data array contains by its SHA1 digest. Optional argument machine_id can be used to indicate
+ * a specific machine to identify the ROM image for; if NULL, the ROM image is identified for any supported machine.
+ * A mt32emu_rom_info structure supplied in argument rom_info is filled in accordance with the provided ROM image; unused fields
+ * are filled with NULLs. If the content of the ROM image is not identified successfully (e.g. when the ROM image is incompatible
+ * with the specified machine), all fields of rom_info are filled with NULLs.
+ * Returns MT32EMU_RC_OK upon success or a negative error code otherwise.
+ */
+MT32EMU_EXPORT_V(2.5) mt32emu_return_code MT32EMU_C_CALL mt32emu_identify_rom_data(mt32emu_rom_info *rom_info, const mt32emu_bit8u *data, size_t data_size, const char *machine_id);
+/**
+ * Loads the content of the file specified by argument filename and identifies a ROM image the file contains by its SHA1 digest.
+ * Optional argument machine_id can be used to indicate a specific machine to identify the ROM image for; if NULL, the ROM image
+ * is identified for any supported machine.
+ * A mt32emu_rom_info structure supplied in argument rom_info is filled in accordance with the provided ROM image; unused fields
+ * are filled with NULLs. If the content of the file is not identified successfully (e.g. when the ROM image is incompatible
+ * with the specified machine), all fields of rom_info are filled with NULLs.
+ * Returns MT32EMU_RC_OK upon success or a negative error code otherwise.
+ */
+MT32EMU_EXPORT_V(2.5) mt32emu_return_code MT32EMU_C_CALL mt32emu_identify_rom_file(mt32emu_rom_info *rom_info, const char *filename, const char *machine_id);
+
+/* == Context-dependent functions == */
+
+/** Initialises a new emulation context and installs custom report handler if non-NULL. */
+MT32EMU_EXPORT mt32emu_context MT32EMU_C_CALL mt32emu_create_context(mt32emu_report_handler_i report_handler, void *instance_data);
+
+/** Closes and destroys emulation context. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_free_context(mt32emu_context context);
+
+/**
+ * Adds a new full ROM data image identified by its SHA1 digest to the emulation context replacing previously added ROM of the same
+ * type if any. Argument sha1_digest can be NULL, in this case the digest will be computed using the actual ROM data.
+ * If sha1_digest is set to non-NULL, it is assumed being correct and will not be recomputed.
+ * The provided data array is NOT copied and used directly for efficiency. The caller should not deallocate it while the emulation
+ * context is referring to the ROM data.
+ * This function doesn't immediately change the state of already opened synth. Newly added ROM will take effect upon next call of
+ * mt32emu_open_synth().
+ * Returns positive value upon success.
+ */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_add_rom_data(mt32emu_context context, const mt32emu_bit8u *data, size_t data_size, const mt32emu_sha1_digest *sha1_digest);
+
+/**
+ * Loads a ROM file that contains a full ROM data image, identifies it by the SHA1 digest, and adds it to the emulation context
+ * replacing previously added ROM of the same type if any.
+ * This function doesn't immediately change the state of already opened synth. Newly added ROM will take effect upon next call of
+ * mt32emu_open_synth().
+ * Returns positive value upon success.
+ */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_add_rom_file(mt32emu_context context, const char *filename);
+
+/**
+ * Merges a pair of compatible ROM data image parts into a full image and adds it to the emulation context replacing previously
+ * added ROM of the same type if any. Each partial image is identified by its SHA1 digest. Arguments partN_sha1_digest can be NULL,
+ * in this case the digest will be computed using the actual ROM data. If a non-NULL SHA1 value is provided, it is assumed being
+ * correct and will not be recomputed. The provided data arrays may be deallocated as soon as the function completes.
+ * This function doesn't immediately change the state of already opened synth. Newly added ROM will take effect upon next call of
+ * mt32emu_open_synth().
+ * Returns positive value upon success.
+ */
+MT32EMU_EXPORT_V(2.5) mt32emu_return_code MT32EMU_C_CALL mt32emu_merge_and_add_rom_data(mt32emu_context context, const mt32emu_bit8u *part1_data, size_t part1_data_size, const mt32emu_sha1_digest *part1_sha1_digest, const mt32emu_bit8u *part2_data, size_t part2_data_size, const mt32emu_sha1_digest *part2_sha1_digest);
+
+/**
+ * Loads a pair of files that contains compatible parts of a full ROM image, identifies them by the SHA1 digest, merges these
+ * parts into a full ROM image and adds it to the emulation context replacing previously added ROM of the same type if any.
+ * This function doesn't immediately change the state of already opened synth. Newly added ROM will take effect upon next call of
+ * mt32emu_open_synth().
+ * Returns positive value upon success.
+ */
+MT32EMU_EXPORT_V(2.5) mt32emu_return_code MT32EMU_C_CALL mt32emu_merge_and_add_rom_files(mt32emu_context context, const char *part1_filename, const char *part2_filename);
+
+/**
+ * Loads a file that contains a ROM image of a specific machine, identifies it by the SHA1 digest, and adds it to the emulation
+ * context. The ROM image can only be identified successfully if it is compatible with the specified machine.
+ * Full and partial ROM images are supported and handled according to the following rules:
+ * - a file with any compatible ROM image is added if none (of the same type) exists in the emulation context;
+ * - a file with any compatible ROM image replaces any image of the same type that is incompatible with the specified machine;
+ * - a file with a full ROM image replaces the previously added partial ROM of the same type;
+ * - a file with a partial ROM image is merged with the previously added ROM image if pairable;
+ * - otherwise, the file is ignored.
+ * The described behaviour allows the caller application to traverse a directory with ROM files attempting to add each one in turn.
+ * As soon as both the full control and the full PCM ROM images are added and / or merged, the iteration can be stopped.
+ * This function doesn't immediately change the state of already opened synth. Newly added ROMs will take effect upon next call of
+ * mt32emu_open_synth().
+ * Returns a positive value in case changes have been made, MT32EMU_RC_OK if the file has been ignored or a negative error code
+ * upon failure.
+ */
+MT32EMU_EXPORT_V(2.5) mt32emu_return_code MT32EMU_C_CALL mt32emu_add_machine_rom_file(mt32emu_context context, const char *machine_id, const char *filename);
+
+/**
+ * Fills in mt32emu_rom_info structure with identifiers and descriptions of control and PCM ROM files identified and added to the synth context.
+ * If one of the ROM files is not loaded and identified yet, NULL is returned in the corresponding fields of the mt32emu_rom_info structure.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_get_rom_info(mt32emu_const_context context, mt32emu_rom_info *rom_info);
+
+/**
+ * Allows to override the default maximum number of partials playing simultaneously within the emulation session.
+ * This function doesn't immediately change the state of already opened synth. Newly set value will take effect upon next call of mt32emu_open_synth().
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_partial_count(mt32emu_context context, const mt32emu_bit32u partial_count);
+
+/**
+ * Allows to override the default mode for emulation of analogue circuitry of the hardware units within the emulation session.
+ * This function doesn't immediately change the state of already opened synth. Newly set value will take effect upon next call of mt32emu_open_synth().
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_analog_output_mode(mt32emu_context context, const mt32emu_analog_output_mode analog_output_mode);
+
+/**
+ * Allows to convert the synthesiser output to any desired sample rate. The samplerate conversion
+ * processes the completely mixed stereo output signal as it passes the analogue circuit emulation,
+ * so emulating the synthesiser output signal passing further through an ADC. When the samplerate
+ * argument is set to 0, the default output sample rate is used which depends on the current
+ * mode of analog circuitry emulation. See mt32emu_analog_output_mode.
+ * This function doesn't immediately change the state of already opened synth.
+ * Newly set value will take effect upon next call of mt32emu_open_synth().
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_stereo_output_samplerate(mt32emu_context context, const double samplerate);
+
+/**
+ * Several samplerate conversion quality options are provided which allow to trade-off the conversion speed vs.
+ * the retained passband width. All the options except FASTEST guarantee full suppression of the aliasing noise
+ * in terms of the 16-bit integer samples.
+ * This function doesn't immediately change the state of already opened synth.
+ * Newly set value will take effect upon next call of mt32emu_open_synth().
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_samplerate_conversion_quality(mt32emu_context context, const mt32emu_samplerate_conversion_quality quality);
+
+/**
+ * Selects new type of the wave generator and renderer to be used during subsequent calls to mt32emu_open_synth().
+ * By default, MT32EMU_RT_BIT16S is selected.
+ * See mt32emu_renderer_type for details.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_select_renderer_type(mt32emu_context context, const mt32emu_renderer_type renderer_type);
+
+/**
+ * Returns previously selected type of the wave generator and renderer.
+ * See mt32emu_renderer_type for details.
+ */
+MT32EMU_EXPORT mt32emu_renderer_type MT32EMU_C_CALL mt32emu_get_selected_renderer_type(mt32emu_context context);
+
+/**
+ * Prepares the emulation context to receive MIDI messages and produce output audio data using aforehand added set of ROMs,
+ * and optionally set the maximum partial count and the analog output mode.
+ * Returns MT32EMU_RC_OK upon success.
+ */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_open_synth(mt32emu_const_context context);
+
+/** Closes the emulation context freeing allocated resources. Added ROMs remain unaffected and ready for reuse. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_close_synth(mt32emu_const_context context);
+
+/** Returns true if the synth is in completely initialized state, otherwise returns false. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_open(mt32emu_const_context context);
+
+/**
+ * Returns actual sample rate of the fully processed output stereo signal.
+ * If samplerate conversion is used (i.e. when mt32emu_set_stereo_output_samplerate() has been invoked with a non-zero value),
+ * the returned value is the desired output samplerate rounded down to the closest integer.
+ * Otherwise, the output samplerate is chosen depending on the emulation mode of stereo analog circuitry of hardware units.
+ * See comment for mt32emu_analog_output_mode for more info.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_actual_stereo_output_samplerate(mt32emu_const_context context);
+
+/**
+ * Returns the number of samples produced at the internal synth sample rate (32000 Hz)
+ * that correspond to the given number of samples at the output sample rate.
+ * Intended to facilitate audio time synchronisation.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_convert_output_to_synth_timestamp(mt32emu_const_context context, mt32emu_bit32u output_timestamp);
+
+/**
+ * Returns the number of samples produced at the output sample rate
+ * that correspond to the given number of samples at the internal synth sample rate (32000 Hz).
+ * Intended to facilitate audio time synchronisation.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_convert_synth_to_output_timestamp(mt32emu_const_context context, mt32emu_bit32u synth_timestamp);
+
+/** All the enqueued events are processed by the synth immediately. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_flush_midi_queue(mt32emu_const_context context);
+
+/**
+ * Sets size of the internal MIDI event queue. The queue size is set to the minimum power of 2 that is greater or equal to the size specified.
+ * The queue is flushed before reallocation.
+ * Returns the actual queue size being used.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_set_midi_event_queue_size(mt32emu_const_context context, const mt32emu_bit32u queue_size);
+
+/**
+ * Configures the SysEx storage of the internal MIDI event queue.
+ * Supplying 0 in the storage_buffer_size argument makes the SysEx data stored
+ * in multiple dynamically allocated buffers per MIDI event. These buffers are only disposed
+ * when a new MIDI event replaces the SysEx event in the queue, thus never on the rendering thread.
+ * This is the default behaviour.
+ * In contrast, when a positive value is specified, SysEx data will be stored in a single preallocated buffer,
+ * which makes this kind of storage safe for use in a realtime thread. Additionally, the space retained
+ * by a SysEx event, that has been processed and thus is no longer necessary, is disposed instantly.
+ * Note, the queue is flushed and recreated in the process so that its size remains intact.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_configure_midi_event_queue_sysex_storage(mt32emu_const_context context, const mt32emu_bit32u storage_buffer_size);
+
+/**
+ * Installs custom MIDI receiver object intended for receiving MIDI messages generated by MIDI stream parser.
+ * MIDI stream parser is involved when functions mt32emu_parse_stream() and mt32emu_play_short_message() or the likes are called.
+ * By default, parsed short MIDI messages and System Exclusive messages are sent to the synth input MIDI queue.
+ * This function allows to override default behaviour. If midi_receiver argument is set to NULL, the default behaviour is restored.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_midi_receiver(mt32emu_context context, mt32emu_midi_receiver_i midi_receiver, void *instance_data);
+
+/**
+ * Returns current value of the global counter of samples rendered since the synth was created (at the native sample rate 32000 Hz).
+ * This method helps to compute accurate timestamp of a MIDI message to use with the methods below.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_internal_rendered_sample_count(mt32emu_const_context context);
+
+/* Enqueues a MIDI event for subsequent playback.
+ * The MIDI event will be processed not before the specified timestamp.
+ * The timestamp is measured as the global rendered sample count since the synth was created (at the native sample rate 32000 Hz).
+ * The minimum delay involves emulation of the delay introduced while the event is transferred via MIDI interface
+ * and emulation of the MCU busy-loop while it frees partials for use by a new Poly.
+ * Calls from multiple threads must be synchronised, although, no synchronisation is required with the rendering thread.
+ * onMIDIQueueOverflow callback is invoked when the MIDI event queue is full and the message cannot be enqueued.
+ */
+
+/**
+ * Parses a block of raw MIDI bytes and enqueues parsed MIDI messages for further processing ASAP.
+ * SysEx messages are allowed to be fragmented across several calls to this method. Running status is also handled for short messages.
+ * When a System Realtime MIDI message is parsed, onMIDISystemRealtime callback is invoked.
+ * NOTE: the total length of a SysEx message being fragmented shall not exceed MT32EMU_MAX_STREAM_BUFFER_SIZE (32768 bytes).
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_parse_stream(mt32emu_const_context context, const mt32emu_bit8u *stream, mt32emu_bit32u length);
+
+/**
+ * Parses a block of raw MIDI bytes and enqueues parsed MIDI messages to play at specified time.
+ * SysEx messages are allowed to be fragmented across several calls to this method. Running status is also handled for short messages.
+ * When a System Realtime MIDI message is parsed, onMIDISystemRealtime callback is invoked.
+ * NOTE: the total length of a SysEx message being fragmented shall not exceed MT32EMU_MAX_STREAM_BUFFER_SIZE (32768 bytes).
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_parse_stream_at(mt32emu_const_context context, const mt32emu_bit8u *stream, mt32emu_bit32u length, mt32emu_bit32u timestamp);
+
+/**
+ * Enqueues a single mt32emu_bit32u-encoded short MIDI message with full processing ASAP.
+ * The short MIDI message may contain no status byte, the running status is used in this case.
+ * When the argument is a System Realtime MIDI message, onMIDISystemRealtime callback is invoked.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_play_short_message(mt32emu_const_context context, mt32emu_bit32u message);
+
+/**
+ * Enqueues a single mt32emu_bit32u-encoded short MIDI message to play at specified time with full processing.
+ * The short MIDI message may contain no status byte, the running status is used in this case.
+ * When the argument is a System Realtime MIDI message, onMIDISystemRealtime callback is invoked.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_play_short_message_at(mt32emu_const_context context, mt32emu_bit32u message, mt32emu_bit32u timestamp);
+
+/**
+ * Enqueues a single short MIDI message to be processed ASAP. The message must contain a status byte and one or two data
+ * bytes (as appropriate for the MIDI command).
+ */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_play_msg(mt32emu_const_context context, mt32emu_bit32u msg);
+/** Enqueues a single well formed System Exclusive MIDI message to be processed ASAP. */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_play_sysex(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len);
+
+/**
+ * Enqueues a single short MIDI message to play at specified time. The message must contain a status byte and one or two data
+ * bytes (as appropriate for the MIDI command).
+ */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_play_msg_at(mt32emu_const_context context, mt32emu_bit32u msg, mt32emu_bit32u timestamp);
+/** Enqueues a single well formed System Exclusive MIDI message to play at specified time. */
+MT32EMU_EXPORT mt32emu_return_code MT32EMU_C_CALL mt32emu_play_sysex_at(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len, mt32emu_bit32u timestamp);
+
+/* WARNING:
+ * The methods below may have no effect while the synth is aborting a poly. They also don't ensure minimum 1-sample delay between
+ * sequential MIDI events, and a sequence of NoteOn and immediately succeeding NoteOff messages is always silent.
+ * A thread that invokes these methods must be explicitly synchronised with the thread performing sample rendering or be the same.
+ */
+
+/**
+ * Sends a short MIDI message to the synth for immediate playback. The message must contain a status byte and one or two data
+ * bytes (as appropriate for the MIDI command), otherwise it is ignored.
+ * See the WARNING above.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_play_msg_now(mt32emu_const_context context, mt32emu_bit32u msg);
+/**
+ * Sends unpacked short MIDI message to the synth for immediate playback. All the message parameters must be within the supported
+ * range, otherwise the message is ignored.
+ * Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+ * Argument command should be 8..14 and represents the high 4 bits of the status byte.
+ * See the WARNING above.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_play_msg_on_part(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u command, mt32emu_bit8u data1, mt32emu_bit8u data2);
+
+/**
+ * Sends a single well formed System Exclusive MIDI message for immediate processing. The length is in bytes.
+ * See the WARNING above.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_play_sysex_now(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len);
+/**
+ * Sends inner body of a System Exclusive MIDI message for direct processing. The length is in bytes.
+ * See the WARNING above.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_write_sysex(mt32emu_const_context context, mt32emu_bit8u channel, const mt32emu_bit8u *sysex, mt32emu_bit32u len);
+
+/**
+ * Stores internal state of the emulated synth into the provided array. The messages within the SysEx bank are ordered so that
+ * they can be replayed back in the same sequence without data loss, provided that the given array has sufficient size.
+ * The SysEx messages written in the array can be re-played using applySysexBank() function or even sent to a real device.
+ * Returns the full length of the SysEx bank in bytes that is needed to fit all the available data.
+ * This function can be used to retrieve the required size of the SysEx bank by supplying NULL sysexBank or zero size arguments,
+ * in which case it does nothing else.
+ */
+MT32EMU_EXPORT_V(2.8) mt32emu_bit32u MT32EMU_C_CALL mt32emu_dump_sysex_bank(mt32emu_const_context context, mt32emu_bit8u *sysex_bank, mt32emu_bit32u size);
+/**
+ * Applies the content of the given SysEx bank to the emulated synth from the provided array. All complete SysEx messages
+ * contained within the sysexBank are played in sequence, any other data is ignored.
+ * Returns the number of played SysEx messages.
+ */
+MT32EMU_EXPORT_V(2.8) mt32emu_bit32u MT32EMU_C_CALL mt32emu_apply_sysex_bank(mt32emu_const_context context, const mt32emu_bit8u *sysex_bank, mt32emu_bit32u size);
+
+/** Allows to disable wet reverb output altogether. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_reverb_enabled(mt32emu_const_context context, const mt32emu_boolean reverb_enabled);
+/** Returns whether wet reverb output is enabled. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_reverb_enabled(mt32emu_const_context context);
+/**
+ * Sets override reverb mode. In this mode, emulation ignores sysexes (or the related part of them) which control the reverb parameters.
+ * This mode is in effect until it is turned off. When the synth is re-opened, the override mode is unchanged but the state
+ * of the reverb model is reset to default.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_reverb_overridden(mt32emu_const_context context, const mt32emu_boolean reverb_overridden);
+/** Returns whether reverb settings are overridden. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_reverb_overridden(mt32emu_const_context context);
+/**
+ * Forces reverb model compatibility mode. By default, the compatibility mode corresponds to the used control ROM version.
+ * Invoking this method with the argument set to true forces emulation of old MT-32 reverb circuit.
+ * When the argument is false, emulation of the reverb circuit used in new generation of MT-32 compatible modules is enforced
+ * (these include CM-32L and LAPC-I).
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_reverb_compatibility_mode(mt32emu_const_context context, const mt32emu_boolean mt32_compatible_mode);
+/** Returns whether reverb is in old MT-32 compatibility mode. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_mt32_reverb_compatibility_mode(mt32emu_const_context context);
+/** Returns whether default reverb compatibility mode is the old MT-32 compatibility mode. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_default_reverb_mt32_compatible(mt32emu_const_context context);
+
+/**
+ * If enabled, reverb buffers for all modes are kept around allocated all the time to avoid memory
+ * allocating/freeing in the rendering thread, which may be required for realtime operation.
+ * Otherwise, reverb buffers that are not in use are deleted to save memory (the default behaviour).
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_preallocate_reverb_memory(mt32emu_const_context context, const mt32emu_boolean enabled);
+
+/** Sets new DAC input mode. See mt32emu_dac_input_mode for details. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_dac_input_mode(mt32emu_const_context context, const mt32emu_dac_input_mode mode);
+/** Returns current DAC input mode. See mt32emu_dac_input_mode for details. */
+MT32EMU_EXPORT mt32emu_dac_input_mode MT32EMU_C_CALL mt32emu_get_dac_input_mode(mt32emu_const_context context);
+
+/** Sets new MIDI delay mode. See mt32emu_midi_delay_mode for details. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_midi_delay_mode(mt32emu_const_context context, const mt32emu_midi_delay_mode mode);
+/** Returns current MIDI delay mode. See mt32emu_midi_delay_mode for details. */
+MT32EMU_EXPORT mt32emu_midi_delay_mode MT32EMU_C_CALL mt32emu_get_midi_delay_mode(mt32emu_const_context context);
+
+/**
+ * Sets output gain factor for synth output channels. Applied to all output samples and unrelated with the synth's Master volume,
+ * it rather corresponds to the gain of the output analog circuitry of the hardware units. However, together with mt32emu_set_reverb_output_gain()
+ * it offers to the user a capability to control the gain of reverb and non-reverb output channels independently.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_output_gain(mt32emu_const_context context, float gain);
+/** Returns current output gain factor for synth output channels. */
+MT32EMU_EXPORT float MT32EMU_C_CALL mt32emu_get_output_gain(mt32emu_const_context context);
+
+/**
+ * Sets output gain factor for the reverb wet output channels. It rather corresponds to the gain of the output
+ * analog circuitry of the hardware units. However, together with mt32emu_set_output_gain() it offers to the user a capability
+ * to control the gain of reverb and non-reverb output channels independently.
+ *
+ * Note: We're currently emulate CM-32L/CM-64 reverb quite accurately and the reverb output level closely
+ * corresponds to the level of digital capture. Although, according to the CM-64 PCB schematic,
+ * there is a difference in the reverb analogue circuit, and the resulting output gain is 0.68
+ * of that for LA32 analogue output. This factor is applied to the reverb output gain.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_reverb_output_gain(mt32emu_const_context context, float gain);
+/** Returns current output gain factor for reverb wet output channels. */
+MT32EMU_EXPORT float MT32EMU_C_CALL mt32emu_get_reverb_output_gain(mt32emu_const_context context);
+
+/**
+ * Sets or removes an override for the Master Volume. When the Master Volume is overridden, a SysEx write to the system area
+ * will have no effect on the Master Volume setting, yet a system memory read will return the overridden Master Volume.
+ * To enable the override mode, argument volume_override should be in range 0..100. Setting a value outside this range
+ * disables the override mode allowing the Master Volume to change further on (without changing the current volume).
+ * This setting persists synth reopening.
+ */
+MT32EMU_EXPORT_V(2.8) void MT32EMU_C_CALL mt32emu_set_master_volume_override(mt32emu_const_context context, mt32emu_bit8u volume_override);
+/**
+ * Returns the overridden master volume previously set, if any; a value outside the range 0..100 means no override
+ * is currently in effect.
+ */
+MT32EMU_EXPORT_V(2.8) mt32emu_bit8u MT32EMU_C_CALL mt32emu_get_master_volume_override(mt32emu_const_context context);
+
+/**
+ * Sets (or removes) an override for the current volume (output level) on a specific part.
+ * When the part volume is overridden, the MIDI controller Volume (7) on the MIDI channel this part is assigned to
+ * has no effect on the output level of this part. Similarly, the output level value set on this part via a SysEx that
+ * modifies the Patch temp structure is disregarded.
+ * To enable the override mode, argument volumeOverride should be in range 0..100, setting a value outside this range
+ * disables the previously set override, if any.
+ * Note: Setting volumeOverride to 0 mutes the part completely, meaning no sound is generated at all.
+ * This is unlike the behaviour of real devices - setting 0 volume on a part may leave it still producing
+ * sound at a very low level.
+ * Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+ */
+MT32EMU_EXPORT_V(2.6) void MT32EMU_C_CALL mt32emu_set_part_volume_override(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u volume_override);
+/**
+ * Returns the overridden volume previously set on a specific part; a value outside the range 0..100 means no override
+ * is currently in effect.
+ * Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+ */
+MT32EMU_EXPORT_V(2.6) mt32emu_bit8u MT32EMU_C_CALL mt32emu_get_part_volume_override(mt32emu_const_context context, mt32emu_bit8u part_number);
+
+/** Swaps left and right output channels. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_reversed_stereo_enabled(mt32emu_const_context context, const mt32emu_boolean enabled);
+/** Returns whether left and right output channels are swapped. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_reversed_stereo_enabled(mt32emu_const_context context);
+
+/**
+ * Allows to toggle the NiceAmpRamp mode.
+ * In this mode, we want to ensure that amp ramp never jumps to the target
+ * value and always gradually increases or decreases. It seems that real units
+ * do not bother to always check if a newly started ramp leads to a jump.
+ * We also prefer the quality improvement over the emulation accuracy,
+ * so this mode is enabled by default.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_nice_amp_ramp_enabled(mt32emu_const_context context, const mt32emu_boolean enabled);
+/** Returns whether NiceAmpRamp mode is enabled. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_nice_amp_ramp_enabled(mt32emu_const_context context);
+
+/**
+ * Allows to toggle the NicePanning mode.
+ * Despite the Roland's manual specifies allowed panpot values in range 0-14,
+ * the LA-32 only receives 3-bit pan setting in fact. In particular, this
+ * makes it impossible to set the "middle" panning for a single partial.
+ * In the NicePanning mode, we enlarge the pan setting accuracy to 4 bits
+ * making it smoother thus sacrificing the emulation accuracy.
+ * This mode is disabled by default.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_nice_panning_enabled(mt32emu_const_context context, const mt32emu_boolean enabled);
+/** Returns whether NicePanning mode is enabled. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_nice_panning_enabled(mt32emu_const_context context);
+
+/**
+ * Allows to toggle the NicePartialMixing mode.
+ * LA-32 is known to mix partials either in-phase (so that they are added)
+ * or in counter-phase (so that they are subtracted instead).
+ * In some cases, this quirk isn't highly desired because a pair of closely
+ * sounding partials may occasionally cancel out.
+ * In the NicePartialMixing mode, the mixing is always performed in-phase,
+ * thus making the behaviour more predictable.
+ * This mode is disabled by default.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_set_nice_partial_mixing_enabled(mt32emu_const_context context, const mt32emu_boolean enabled);
+/** Returns whether NicePartialMixing mode is enabled. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_nice_partial_mixing_enabled(mt32emu_const_context context);
+
+/**
+ * Renders samples to the specified output stream as if they were sampled at the analog stereo output at the desired sample rate.
+ * If the output sample rate is not specified explicitly, the default output sample rate is used which depends on the current
+ * mode of analog circuitry emulation. See mt32emu_analog_output_mode.
+ * The length is in frames, not bytes (in 16-bit stereo, one frame is 4 bytes). Uses NATIVE byte ordering.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_render_bit16s(mt32emu_const_context context, mt32emu_bit16s *stream, mt32emu_bit32u len);
+/** Same as above but outputs to a float stereo stream. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_render_float(mt32emu_const_context context, float *stream, mt32emu_bit32u len);
+
+/**
+ * Renders samples to the specified output streams as if they appeared at the DAC entrance.
+ * No further processing performed in analog circuitry emulation is applied to the signal.
+ * NULL may be specified in place of any or all of the stream buffers to skip it.
+ * The length is in samples, not bytes. Uses NATIVE byte ordering.
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_render_bit16s_streams(mt32emu_const_context context, const mt32emu_dac_output_bit16s_streams *streams, mt32emu_bit32u len);
+/** Same as above but outputs to float streams. */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_render_float_streams(mt32emu_const_context context, const mt32emu_dac_output_float_streams *streams, mt32emu_bit32u len);
+
+/** Returns true when there is at least one active partial, otherwise false. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_has_active_partials(mt32emu_const_context context);
+
+/** Returns true if mt32emu_has_active_partials() returns true, or reverb is (somewhat unreliably) detected as being active. */
+MT32EMU_EXPORT mt32emu_boolean MT32EMU_C_CALL mt32emu_is_active(mt32emu_const_context context);
+
+/** Returns the maximum number of partials playing simultaneously. */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_partial_count(mt32emu_const_context context);
+
+/**
+ * Returns current states of all the parts as a bit set. The least significant bit corresponds to the state of part 1,
+ * total of 9 bits hold the states of all the parts. If the returned bit for a part is set, there is at least one active
+ * non-releasing partial playing on this part. This info is useful in emulating behaviour of LCD display of the hardware units.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_part_states(mt32emu_const_context context);
+
+/**
+ * Fills in current states of all the partials into the array provided. Each byte in the array holds states of 4 partials
+ * starting from the least significant bits. The state of each partial is packed in a pair of bits.
+ * The array must be large enough to accommodate states of all the partials.
+ * @see getPartialCount()
+ */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_get_partial_states(mt32emu_const_context context, mt32emu_bit8u *partial_states);
+
+/**
+ * Fills in information about currently playing notes on the specified part into the arrays provided. The arrays must be large enough
+ * to accommodate data for all the playing notes. The maximum number of simultaneously playing notes cannot exceed the number of partials.
+ * Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+ * Returns the number of currently playing notes on the specified part.
+ */
+MT32EMU_EXPORT mt32emu_bit32u MT32EMU_C_CALL mt32emu_get_playing_notes(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u *keys, mt32emu_bit8u *velocities);
+
+/**
+ * Returns name of the patch set on the specified part.
+ * Argument partNumber should be 0..7 for Part 1..8, or 8 for Rhythm.
+ * The returned value is a null-terminated string which is guaranteed to remain valid until the next call to one of functions
+ * that perform sample rendering or immediate SysEx processing (e.g. mt32emu_play_sysex_now).
+ */
+MT32EMU_EXPORT const char * MT32EMU_C_CALL mt32emu_get_patch_name(mt32emu_const_context context, mt32emu_bit8u part_number);
+
+/**
+ * Retrieves the name of the sound group the timbre identified by arguments timbre_group and timbre_number is associated with.
+ * Values 0-3 of timbre_group correspond to the timbre banks GROUP A, GROUP B, MEMORY and RHYTHM.
+ * For all but the RHYTHM timbre bank, allowed values of timbre_number are in range 0-63. The number of timbres
+ * contained in the RHYTHM bank depends on the used control ROM version.
+ * The argument sound_group_name must point to an array of at least 8 characters. The result is a null-terminated string.
+ * Returns whether the specified timbre has been found and the result written in sound_group_name.
+ */
+MT32EMU_EXPORT_V(2.7) mt32emu_boolean MT32EMU_C_CALL mt32emu_get_sound_group_name(mt32emu_const_context context, char *sound_group_name, mt32emu_bit8u timbre_group, mt32emu_bit8u timbre_number);
+/**
+ * Retrieves the name of the timbre identified by arguments timbre_group and timbre_number.
+ * Values 0-3 of timbre_group correspond to the timbre banks GROUP A, GROUP B, MEMORY and RHYTHM.
+ * For all but the RHYTHM timbre bank, allowed values of timbre_number are in range 0-63. The number of timbres
+ * contained in the RHYTHM bank depends on the used control ROM version.
+ * The argument sound_name must point to an array of at least 11 characters. The result is a null-terminated string.
+ * Returns whether the specified timbre has been found and the result written in sound_name.
+ */
+MT32EMU_EXPORT_V(2.7) mt32emu_boolean MT32EMU_C_CALL mt32emu_get_sound_name(mt32emu_const_context context, char *sound_name, mt32emu_bit8u timbreGroup, mt32emu_bit8u timbreNumber);
+
+/** Stores internal state of emulated synth into an array provided (as it would be acquired from hardware). */
+MT32EMU_EXPORT void MT32EMU_C_CALL mt32emu_read_memory(mt32emu_const_context context, mt32emu_bit32u addr, mt32emu_bit32u len, mt32emu_bit8u *data);
+
+/**
+ * Retrieves the current state of the emulated MT-32 display facilities.
+ * Typically, the state is updated during the rendering. When that happens, a related callback from mt32emu_report_handler_i_v1
+ * is invoked. However, there might be no need to invoke this method after each update, e.g. when the render buffer is just
+ * a few milliseconds long.
+ * The argument target_buffer must point to an array of at least 21 characters. The result is a null-terminated string.
+ * The argument narrow_lcd enables a condensed representation of the displayed information in some cases. This is mainly intended
+ * to route the result to a hardware LCD that is only 16 characters wide. Automatic scrolling of longer strings is not supported.
+ * Returns whether the MIDI MESSAGE LED is ON and fills the target_buffer parameter.
+ */
+MT32EMU_EXPORT_V(2.6) mt32emu_boolean MT32EMU_C_CALL mt32emu_get_display_state(mt32emu_const_context context, char *target_buffer, const mt32emu_boolean narrow_lcd);
+
+/**
+ * Resets the emulated LCD to the main mode (Master Volume). This has the same effect as pressing the Master Volume button
+ * while the display shows some other message. Useful for the new-gen devices as those require a special Display Reset SysEx
+ * to return to the main mode e.g. from showing a custom display message or a checksum error.
+ */
+MT32EMU_EXPORT_V(2.6) void MT32EMU_C_CALL mt32emu_set_main_display_mode(mt32emu_const_context context);
+
+/**
+ * Permits to select an arbitrary display emulation model that does not necessarily match the actual behaviour implemented
+ * in the control ROM version being used.
+ * Invoking this method with the argument set to true forces emulation of the old-gen MT-32 display features.
+ * Otherwise, emulation of the new-gen devices is enforced (these include CM-32L and LAPC-I as if these were connected to an LCD).
+ */
+MT32EMU_EXPORT_V(2.6) void MT32EMU_C_CALL mt32emu_set_display_compatibility(mt32emu_const_context context, mt32emu_boolean old_mt32_compatibility_enabled);
+/** Returns whether the currently configured features of the emulated display are compatible with the old-gen MT-32 devices. */
+MT32EMU_EXPORT_V(2.6) mt32emu_boolean MT32EMU_C_CALL mt32emu_is_display_old_mt32_compatible(mt32emu_const_context context);
+/**
+ * Returns whether the emulated display features configured by default depending on the actual control ROM version
+ * are compatible with the old-gen MT-32 devices.
+ */
+MT32EMU_EXPORT_V(2.6) mt32emu_boolean MT32EMU_C_CALL mt32emu_is_default_display_old_mt32_compatible(mt32emu_const_context context);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* #ifndef MT32EMU_C_INTERFACE_H */

--- a/vendor/munt/src/c_interface/c_types.h
+++ b/vendor/munt/src/c_interface/c_types.h
@@ -1,0 +1,485 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_C_TYPES_H
+#define MT32EMU_C_TYPES_H
+
+#include <stdarg.h>
+#include <stddef.h>
+
+#include "../globals.h"
+
+#define MT32EMU_C_ENUMERATIONS
+#include "../Enumerations.h"
+#undef MT32EMU_C_ENUMERATIONS
+
+#ifdef _WIN32
+#  define MT32EMU_C_CALL __cdecl
+#else
+#  define MT32EMU_C_CALL
+#endif
+
+typedef unsigned int       mt32emu_bit32u;
+typedef   signed int       mt32emu_bit32s;
+typedef unsigned short int mt32emu_bit16u;
+typedef   signed short int mt32emu_bit16s;
+typedef unsigned char      mt32emu_bit8u;
+typedef   signed char      mt32emu_bit8s;
+
+typedef char mt32emu_sha1_digest[41];
+
+typedef enum {
+	MT32EMU_BOOL_FALSE, MT32EMU_BOOL_TRUE
+} mt32emu_boolean;
+
+typedef enum {
+	/* Operation completed normally. */
+	MT32EMU_RC_OK = 0,
+	MT32EMU_RC_ADDED_CONTROL_ROM = 1,
+	MT32EMU_RC_ADDED_PCM_ROM = 2,
+	MT32EMU_RC_ADDED_PARTIAL_CONTROL_ROM = 3,
+	MT32EMU_RC_ADDED_PARTIAL_PCM_ROM = 4,
+
+	/* Definite error occurred. */
+	MT32EMU_RC_ROM_NOT_IDENTIFIED = -1,
+	MT32EMU_RC_FILE_NOT_FOUND = -2,
+	MT32EMU_RC_FILE_NOT_LOADED = -3,
+	MT32EMU_RC_MISSING_ROMS = -4,
+	MT32EMU_RC_NOT_OPENED = -5,
+	MT32EMU_RC_QUEUE_FULL = -6,
+	MT32EMU_RC_ROMS_NOT_PAIRABLE = -7,
+	MT32EMU_RC_MACHINE_NOT_IDENTIFIED = -8,
+
+	/* Undefined error occurred. */
+	MT32EMU_RC_FAILED = -100
+} mt32emu_return_code;
+
+/** Emulation context */
+typedef struct mt32emu_data *mt32emu_context;
+typedef const struct mt32emu_data *mt32emu_const_context;
+
+/* Convenience aliases */
+#ifndef __cplusplus
+typedef enum mt32emu_analog_output_mode mt32emu_analog_output_mode;
+typedef enum mt32emu_dac_input_mode mt32emu_dac_input_mode;
+typedef enum mt32emu_midi_delay_mode mt32emu_midi_delay_mode;
+typedef enum mt32emu_partial_state mt32emu_partial_state;
+typedef enum mt32emu_samplerate_conversion_quality mt32emu_samplerate_conversion_quality;
+typedef enum mt32emu_renderer_type mt32emu_renderer_type;
+#endif
+
+/** Contains identifiers and descriptions of ROM files being used. */
+typedef struct {
+	const char *control_rom_id;
+	const char *control_rom_description;
+	const char *control_rom_sha1_digest;
+	const char *pcm_rom_id;
+	const char *pcm_rom_description;
+	const char *pcm_rom_sha1_digest;
+} mt32emu_rom_info;
+
+/** Set of multiplexed output bit16s streams appeared at the DAC entrance. */
+typedef struct {
+	mt32emu_bit16s *nonReverbLeft;
+	mt32emu_bit16s *nonReverbRight;
+	mt32emu_bit16s *reverbDryLeft;
+	mt32emu_bit16s *reverbDryRight;
+	mt32emu_bit16s *reverbWetLeft;
+	mt32emu_bit16s *reverbWetRight;
+} mt32emu_dac_output_bit16s_streams;
+
+/** Set of multiplexed output float streams appeared at the DAC entrance. */
+typedef struct {
+	float *nonReverbLeft;
+	float *nonReverbRight;
+	float *reverbDryLeft;
+	float *reverbDryRight;
+	float *reverbWetLeft;
+	float *reverbWetRight;
+} mt32emu_dac_output_float_streams;
+
+/* === Interface handling === */
+
+/** Report handler interface versions */
+typedef enum {
+	MT32EMU_REPORT_HANDLER_VERSION_0 = 0,
+	MT32EMU_REPORT_HANDLER_VERSION_1 = 1,
+	MT32EMU_REPORT_HANDLER_VERSION_2 = 2,
+	MT32EMU_REPORT_HANDLER_VERSION_CURRENT = MT32EMU_REPORT_HANDLER_VERSION_2
+} mt32emu_report_handler_version;
+
+/** MIDI receiver interface versions */
+typedef enum {
+	MT32EMU_MIDI_RECEIVER_VERSION_0 = 0,
+	MT32EMU_MIDI_RECEIVER_VERSION_CURRENT = MT32EMU_MIDI_RECEIVER_VERSION_0
+} mt32emu_midi_receiver_version;
+
+/** Synth interface versions */
+typedef enum {
+	MT32EMU_SERVICE_VERSION_0 = 0,
+	MT32EMU_SERVICE_VERSION_1 = 1,
+	MT32EMU_SERVICE_VERSION_2 = 2,
+	MT32EMU_SERVICE_VERSION_3 = 3,
+	MT32EMU_SERVICE_VERSION_4 = 4,
+	MT32EMU_SERVICE_VERSION_5 = 5,
+	MT32EMU_SERVICE_VERSION_6 = 6,
+	MT32EMU_SERVICE_VERSION_7 = 7,
+	MT32EMU_SERVICE_VERSION_CURRENT = MT32EMU_SERVICE_VERSION_7
+} mt32emu_service_version;
+
+/* === Report Handler Interface === */
+
+typedef union mt32emu_report_handler_i mt32emu_report_handler_i;
+
+/** Interface for handling reported events (initial version) */
+#define MT32EMU_REPORT_HANDLER_I_V0 \
+	/** Returns the actual interface version ID */ \
+	mt32emu_report_handler_version (MT32EMU_C_CALL *getVersionID)(mt32emu_report_handler_i i); \
+\
+	/** Callback for debug messages, in vprintf() format */ \
+	void (MT32EMU_C_CALL *printDebug)(void *instance_data, const char *fmt, va_list list); \
+	/** Callbacks for reporting errors */ \
+	void (MT32EMU_C_CALL *onErrorControlROM)(void *instance_data); \
+	void (MT32EMU_C_CALL *onErrorPCMROM)(void *instance_data); \
+	/** Callback for reporting about displaying a new custom message on LCD */ \
+	void (MT32EMU_C_CALL *showLCDMessage)(void *instance_data, const char *message); \
+	/** Callback for reporting actual processing of a MIDI message */ \
+	void (MT32EMU_C_CALL *onMIDIMessagePlayed)(void *instance_data); \
+	/**
+	 * Callback for reporting an overflow of the input MIDI queue.
+	 * Returns MT32EMU_BOOL_TRUE if a recovery action was taken
+	 * and yet another attempt to enqueue the MIDI event is desired.
+	 */ \
+	mt32emu_boolean (MT32EMU_C_CALL *onMIDIQueueOverflow)(void *instance_data); \
+	/**
+	 * Callback invoked when a System Realtime MIDI message is detected in functions
+	 * mt32emu_parse_stream and mt32emu_play_short_message and the likes.
+	 */ \
+	void (MT32EMU_C_CALL *onMIDISystemRealtime)(void *instance_data, mt32emu_bit8u system_realtime); \
+	/** Callbacks for reporting system events */ \
+	void (MT32EMU_C_CALL *onDeviceReset)(void *instance_data); \
+	void (MT32EMU_C_CALL *onDeviceReconfig)(void *instance_data); \
+	/** Callbacks for reporting changes of reverb settings */ \
+	void (MT32EMU_C_CALL *onNewReverbMode)(void *instance_data, mt32emu_bit8u mode); \
+	void (MT32EMU_C_CALL *onNewReverbTime)(void *instance_data, mt32emu_bit8u time); \
+	void (MT32EMU_C_CALL *onNewReverbLevel)(void *instance_data, mt32emu_bit8u level); \
+	/** Callbacks for reporting various information */ \
+	void (MT32EMU_C_CALL *onPolyStateChanged)(void *instance_data, mt32emu_bit8u part_num); \
+	void (MT32EMU_C_CALL *onProgramChanged)(void *instance_data, mt32emu_bit8u part_num, const char *sound_group_name, const char *patch_name);
+
+#define MT32EMU_REPORT_HANDLER_I_V1 \
+	/**
+	 * Invoked to signal about a change of the emulated LCD state. Use mt32emu_get_display_state to retrieve the actual data.
+	 * This callback will not be invoked on further changes, until the client retrieves the LCD state.
+	 */ \
+	void (MT32EMU_C_CALL *onLCDStateUpdated)(void *instance_data); \
+	/** Invoked when the emulated MIDI MESSAGE LED changes state. The led_state parameter represents whether the LED is ON. */ \
+	void (MT32EMU_C_CALL *onMidiMessageLEDStateUpdated)(void *instance_data, mt32emu_boolean led_state);
+
+#define MT32EMU_REPORT_HANDLER_I_V2 \
+	/**
+	 * Invoked in case the NoteOn MIDI message currently being processed cannot be played due to insufficient free partials.
+	 */ \
+	void (MT32EMU_C_CALL *onNoteOnIgnored)(void *instance_data, mt32emu_bit32u partials_needed, mt32emu_bit32u partials_free); \
+	/**
+	 * Invoked in case the partial allocator starts premature silencing a currently playing poly to free partials necessary
+	 * for processing the preceding NoteOn MIDI message.
+	 */ \
+	void (MT32EMU_C_CALL *onPlayingPolySilenced)(void *instance_data, mt32emu_bit32u partials_needed, mt32emu_bit32u partials_free);
+
+typedef struct {
+	MT32EMU_REPORT_HANDLER_I_V0
+} mt32emu_report_handler_i_v0;
+
+typedef struct {
+	MT32EMU_REPORT_HANDLER_I_V0
+	MT32EMU_REPORT_HANDLER_I_V1
+} mt32emu_report_handler_i_v1;
+
+typedef struct {
+	MT32EMU_REPORT_HANDLER_I_V0
+	MT32EMU_REPORT_HANDLER_I_V1
+	MT32EMU_REPORT_HANDLER_I_V2
+} mt32emu_report_handler_i_v2;
+
+/**
+ * Extensible interface for handling reported events.
+ * Union intended to view an interface of any subsequent version as any parent interface not requiring a cast.
+ * It is caller's responsibility to check the actual interface version in runtime using the getVersionID() method.
+ */
+union mt32emu_report_handler_i {
+	const mt32emu_report_handler_i_v0 *v0;
+	const mt32emu_report_handler_i_v1 *v1;
+	const mt32emu_report_handler_i_v2 *v2;
+};
+
+#undef MT32EMU_REPORT_HANDLER_I_V0
+#undef MT32EMU_REPORT_HANDLER_I_V1
+#undef MT32EMU_REPORT_HANDLER_I_V2
+
+/* === MIDI Receiver Interface === */
+
+typedef union mt32emu_midi_receiver_i mt32emu_midi_receiver_i;
+
+/** Interface for receiving MIDI messages generated by MIDI stream parser (initial version) */
+typedef struct {
+	/** Returns the actual interface version ID */
+	mt32emu_midi_receiver_version (MT32EMU_C_CALL *getVersionID)(mt32emu_midi_receiver_i i);
+
+	/** Invoked when a complete short MIDI message is parsed in the input MIDI stream. */
+	void (MT32EMU_C_CALL *handleShortMessage)(void *instance_data, const mt32emu_bit32u message);
+
+	/** Invoked when a complete well-formed System Exclusive MIDI message is parsed in the input MIDI stream. */
+	void (MT32EMU_C_CALL *handleSysex)(void *instance_data, const mt32emu_bit8u stream[], const mt32emu_bit32u length);
+
+	/** Invoked when a System Realtime MIDI message is parsed in the input MIDI stream. */
+	void (MT32EMU_C_CALL *handleSystemRealtimeMessage)(void *instance_data, const mt32emu_bit8u realtime);
+} mt32emu_midi_receiver_i_v0;
+
+/**
+ * Extensible interface for receiving MIDI messages.
+ * Union intended to view an interface of any subsequent version as any parent interface not requiring a cast.
+ * It is caller's responsibility to check the actual interface version in runtime using the getVersionID() method.
+ */
+union mt32emu_midi_receiver_i {
+	const mt32emu_midi_receiver_i_v0 *v0;
+};
+
+/* === Service Interface === */
+
+typedef union mt32emu_service_i mt32emu_service_i;
+
+/**
+ * Basic interface that defines all the library services (initial version).
+ * The members closely resemble C functions declared in c_interface.h, and the intention is to provide for easier
+ * access when the library is dynamically loaded in run-time, e.g. as a plugin. This way the client only needs
+ * to bind to mt32emu_get_service_i() function instead of binding to each function it needs to use.
+ * See c_interface.h for parameter description.
+ */
+#define MT32EMU_SERVICE_I_V0 \
+	/** Returns the actual interface version ID */ \
+	mt32emu_service_version (MT32EMU_C_CALL *getVersionID)(mt32emu_service_i i); \
+	mt32emu_report_handler_version (MT32EMU_C_CALL *getSupportedReportHandlerVersionID)(void); \
+	mt32emu_midi_receiver_version (MT32EMU_C_CALL *getSupportedMIDIReceiverVersionID)(void); \
+\
+	mt32emu_bit32u (MT32EMU_C_CALL *getLibraryVersionInt)(void); \
+	const char *(MT32EMU_C_CALL *getLibraryVersionString)(void); \
+\
+	mt32emu_bit32u (MT32EMU_C_CALL *getStereoOutputSamplerate)(const mt32emu_analog_output_mode analog_output_mode); \
+\
+	mt32emu_context (MT32EMU_C_CALL *createContext)(mt32emu_report_handler_i report_handler, void *instance_data); \
+	void (MT32EMU_C_CALL *freeContext)(mt32emu_context context); \
+	mt32emu_return_code (MT32EMU_C_CALL *addROMData)(mt32emu_context context, const mt32emu_bit8u *data, size_t data_size, const mt32emu_sha1_digest *sha1_digest); \
+	mt32emu_return_code (MT32EMU_C_CALL *addROMFile)(mt32emu_context context, const char *filename); \
+	void (MT32EMU_C_CALL *getROMInfo)(mt32emu_const_context context, mt32emu_rom_info *rom_info); \
+	void (MT32EMU_C_CALL *setPartialCount)(mt32emu_context context, const mt32emu_bit32u partial_count); \
+	void (MT32EMU_C_CALL *setAnalogOutputMode)(mt32emu_context context, const mt32emu_analog_output_mode analog_output_mode); \
+	mt32emu_return_code (MT32EMU_C_CALL *openSynth)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *closeSynth)(mt32emu_const_context context); \
+	mt32emu_boolean (MT32EMU_C_CALL *isOpen)(mt32emu_const_context context); \
+	mt32emu_bit32u (MT32EMU_C_CALL *getActualStereoOutputSamplerate)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *flushMIDIQueue)(mt32emu_const_context context); \
+	mt32emu_bit32u (MT32EMU_C_CALL *setMIDIEventQueueSize)(mt32emu_const_context context, const mt32emu_bit32u queue_size); \
+	void (MT32EMU_C_CALL *setMIDIReceiver)(mt32emu_context context, mt32emu_midi_receiver_i midi_receiver, void *instance_data); \
+\
+	void (MT32EMU_C_CALL *parseStream)(mt32emu_const_context context, const mt32emu_bit8u *stream, mt32emu_bit32u length); \
+	void (MT32EMU_C_CALL *parseStream_At)(mt32emu_const_context context, const mt32emu_bit8u *stream, mt32emu_bit32u length, mt32emu_bit32u timestamp); \
+	void (MT32EMU_C_CALL *playShortMessage)(mt32emu_const_context context, mt32emu_bit32u message); \
+	void (MT32EMU_C_CALL *playShortMessageAt)(mt32emu_const_context context, mt32emu_bit32u message, mt32emu_bit32u timestamp); \
+	mt32emu_return_code (MT32EMU_C_CALL *playMsg)(mt32emu_const_context context, mt32emu_bit32u msg); \
+	mt32emu_return_code (MT32EMU_C_CALL *playSysex)(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len); \
+	mt32emu_return_code (MT32EMU_C_CALL *playMsgAt)(mt32emu_const_context context, mt32emu_bit32u msg, mt32emu_bit32u timestamp); \
+	mt32emu_return_code (MT32EMU_C_CALL *playSysexAt)(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len, mt32emu_bit32u timestamp); \
+\
+	void (MT32EMU_C_CALL *playMsgNow)(mt32emu_const_context context, mt32emu_bit32u msg); \
+	void (MT32EMU_C_CALL *playMsgOnPart)(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u command, mt32emu_bit8u data1, mt32emu_bit8u data2); \
+	void (MT32EMU_C_CALL *playSysexNow)(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len); \
+	void (MT32EMU_C_CALL *writeSysex)(mt32emu_const_context context, mt32emu_bit8u channel, const mt32emu_bit8u *sysex, mt32emu_bit32u len); \
+\
+	void (MT32EMU_C_CALL *setReverbEnabled)(mt32emu_const_context context, const mt32emu_boolean reverb_enabled); \
+	mt32emu_boolean (MT32EMU_C_CALL *isReverbEnabled)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setReverbOverridden)(mt32emu_const_context context, const mt32emu_boolean reverb_overridden); \
+	mt32emu_boolean (MT32EMU_C_CALL *isReverbOverridden)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setReverbCompatibilityMode)(mt32emu_const_context context, const mt32emu_boolean mt32_compatible_mode); \
+	mt32emu_boolean (MT32EMU_C_CALL *isMT32ReverbCompatibilityMode)(mt32emu_const_context context); \
+	mt32emu_boolean (MT32EMU_C_CALL *isDefaultReverbMT32Compatible)(mt32emu_const_context context); \
+\
+	void (MT32EMU_C_CALL *setDACInputMode)(mt32emu_const_context context, const mt32emu_dac_input_mode mode); \
+	mt32emu_dac_input_mode (MT32EMU_C_CALL *getDACInputMode)(mt32emu_const_context context); \
+\
+	void (MT32EMU_C_CALL *setMIDIDelayMode)(mt32emu_const_context context, const mt32emu_midi_delay_mode mode); \
+	mt32emu_midi_delay_mode (MT32EMU_C_CALL *getMIDIDelayMode)(mt32emu_const_context context); \
+\
+	void (MT32EMU_C_CALL *setOutputGain)(mt32emu_const_context context, float gain); \
+	float (MT32EMU_C_CALL *getOutputGain)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setReverbOutputGain)(mt32emu_const_context context, float gain); \
+	float (MT32EMU_C_CALL *getReverbOutputGain)(mt32emu_const_context context); \
+\
+	void (MT32EMU_C_CALL *setReversedStereoEnabled)(mt32emu_const_context context, const mt32emu_boolean enabled); \
+	mt32emu_boolean (MT32EMU_C_CALL *isReversedStereoEnabled)(mt32emu_const_context context); \
+\
+	void (MT32EMU_C_CALL *renderBit16s)(mt32emu_const_context context, mt32emu_bit16s *stream, mt32emu_bit32u len); \
+	void (MT32EMU_C_CALL *renderFloat)(mt32emu_const_context context, float *stream, mt32emu_bit32u len); \
+	void (MT32EMU_C_CALL *renderBit16sStreams)(mt32emu_const_context context, const mt32emu_dac_output_bit16s_streams *streams, mt32emu_bit32u len); \
+	void (MT32EMU_C_CALL *renderFloatStreams)(mt32emu_const_context context, const mt32emu_dac_output_float_streams *streams, mt32emu_bit32u len); \
+\
+	mt32emu_boolean (MT32EMU_C_CALL *hasActivePartials)(mt32emu_const_context context); \
+	mt32emu_boolean (MT32EMU_C_CALL *isActive)(mt32emu_const_context context); \
+	mt32emu_bit32u (MT32EMU_C_CALL *getPartialCount)(mt32emu_const_context context); \
+	mt32emu_bit32u (MT32EMU_C_CALL *getPartStates)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *getPartialStates)(mt32emu_const_context context, mt32emu_bit8u *partial_states); \
+	mt32emu_bit32u (MT32EMU_C_CALL *getPlayingNotes)(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u *keys, mt32emu_bit8u *velocities); \
+	const char *(MT32EMU_C_CALL *getPatchName)(mt32emu_const_context context, mt32emu_bit8u part_number); \
+	void (MT32EMU_C_CALL *readMemory)(mt32emu_const_context context, mt32emu_bit32u addr, mt32emu_bit32u len, mt32emu_bit8u *data);
+
+#define MT32EMU_SERVICE_I_V1 \
+	mt32emu_analog_output_mode (MT32EMU_C_CALL *getBestAnalogOutputMode)(const double target_samplerate); \
+	void (MT32EMU_C_CALL *setStereoOutputSampleRate)(mt32emu_context context, const double samplerate); \
+	void (MT32EMU_C_CALL *setSamplerateConversionQuality)(mt32emu_context context, const mt32emu_samplerate_conversion_quality quality); \
+	void (MT32EMU_C_CALL *selectRendererType)(mt32emu_context context, mt32emu_renderer_type renderer_type); \
+	mt32emu_renderer_type (MT32EMU_C_CALL *getSelectedRendererType)(mt32emu_context context); \
+	mt32emu_bit32u (MT32EMU_C_CALL *convertOutputToSynthTimestamp)(mt32emu_const_context context, mt32emu_bit32u output_timestamp); \
+	mt32emu_bit32u (MT32EMU_C_CALL *convertSynthToOutputTimestamp)(mt32emu_const_context context, mt32emu_bit32u synth_timestamp);
+
+#define MT32EMU_SERVICE_I_V2 \
+	mt32emu_bit32u (MT32EMU_C_CALL *getInternalRenderedSampleCount)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setNiceAmpRampEnabled)(mt32emu_const_context context, const mt32emu_boolean enabled); \
+	mt32emu_boolean (MT32EMU_C_CALL *isNiceAmpRampEnabled)(mt32emu_const_context context);
+
+#define MT32EMU_SERVICE_I_V3 \
+	void (MT32EMU_C_CALL *setNicePanningEnabled)(mt32emu_const_context context, const mt32emu_boolean enabled); \
+	mt32emu_boolean (MT32EMU_C_CALL *isNicePanningEnabled)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setNicePartialMixingEnabled)(mt32emu_const_context context, const mt32emu_boolean enabled); \
+	mt32emu_boolean (MT32EMU_C_CALL *isNicePartialMixingEnabled)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *preallocateReverbMemory)(mt32emu_const_context context, const mt32emu_boolean enabled); \
+	void (MT32EMU_C_CALL *configureMIDIEventQueueSysexStorage)(mt32emu_const_context context, const mt32emu_bit32u storage_buffer_size);
+
+#define MT32EMU_SERVICE_I_V4 \
+	size_t (MT32EMU_C_CALL *getMachineIDs)(const char **machine_ids, size_t machine_ids_size); \
+	size_t (MT32EMU_C_CALL *getROMIDs)(const char **rom_ids, size_t rom_ids_size, const char *machine_id); \
+	mt32emu_return_code (MT32EMU_C_CALL *identifyROMData)(mt32emu_rom_info *rom_info, const mt32emu_bit8u *data, size_t data_size, const char *machine_id); \
+	mt32emu_return_code (MT32EMU_C_CALL *identifyROMFile)(mt32emu_rom_info *rom_info, const char *filename, const char *machine_id); \
+\
+	mt32emu_return_code (MT32EMU_C_CALL *mergeAndAddROMData)(mt32emu_context context, const mt32emu_bit8u *part1_data, size_t part1_data_size, const mt32emu_sha1_digest *part1_sha1_digest, const mt32emu_bit8u *part2_data, size_t part2_data_size, const mt32emu_sha1_digest *part2_sha1_digest); \
+	mt32emu_return_code (MT32EMU_C_CALL *mergeAndAddROMFiles)(mt32emu_context context, const char *part1_filename, const char *part2_filename); \
+	mt32emu_return_code (MT32EMU_C_CALL *addMachineROMFile)(mt32emu_context context, const char *machine_id, const char *filename);
+
+#define MT32EMU_SERVICE_I_V5 \
+	mt32emu_boolean (MT32EMU_C_CALL *getDisplayState)(mt32emu_const_context context, char *target_buffer, const mt32emu_boolean narrow_lcd); \
+	void (MT32EMU_C_CALL *setMainDisplayMode)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setDisplayCompatibility)(mt32emu_const_context context, mt32emu_boolean old_mt32_compatibility_enabled); \
+	mt32emu_boolean (MT32EMU_C_CALL *isDisplayOldMT32Compatible)(mt32emu_const_context context); \
+	mt32emu_boolean (MT32EMU_C_CALL *isDefaultDisplayOldMT32Compatible)(mt32emu_const_context context); \
+	void (MT32EMU_C_CALL *setPartVolumeOverride)(mt32emu_const_context context, mt32emu_bit8u part_number, mt32emu_bit8u volume_override); \
+	mt32emu_bit8u (MT32EMU_C_CALL *getPartVolumeOverride)(mt32emu_const_context context, mt32emu_bit8u part_number);
+
+#define MT32EMU_SERVICE_I_V6 \
+	mt32emu_boolean (MT32EMU_C_CALL *getSoundGroupName)(mt32emu_const_context context, char *sound_group_name, mt32emu_bit8u timbre_group, mt32emu_bit8u timbre_number); \
+	mt32emu_boolean (MT32EMU_C_CALL *getSoundName)(mt32emu_const_context context, char *sound_name, mt32emu_bit8u timbre_group, mt32emu_bit8u timbre_number);
+
+#define MT32EMU_SERVICE_I_V7 \
+	void (MT32EMU_C_CALL *setMasterVolumeOverride)(mt32emu_const_context context, mt32emu_bit8u volume_override); \
+	mt32emu_bit8u (MT32EMU_C_CALL *getMasterVolumeOverride)(mt32emu_const_context context); \
+	mt32emu_bit32u (MT32EMU_C_CALL *dumpSysexBank)(mt32emu_const_context context, mt32emu_bit8u *sysex_bank, mt32emu_bit32u size); \
+	mt32emu_bit32u (MT32EMU_C_CALL *applySysexBank)(mt32emu_const_context context, const mt32emu_bit8u *sysex_bank, mt32emu_bit32u size);
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+} mt32emu_service_i_v0;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+} mt32emu_service_i_v1;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+	MT32EMU_SERVICE_I_V2
+} mt32emu_service_i_v2;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+	MT32EMU_SERVICE_I_V2
+	MT32EMU_SERVICE_I_V3
+} mt32emu_service_i_v3;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+	MT32EMU_SERVICE_I_V2
+	MT32EMU_SERVICE_I_V3
+	MT32EMU_SERVICE_I_V4
+} mt32emu_service_i_v4;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+	MT32EMU_SERVICE_I_V2
+	MT32EMU_SERVICE_I_V3
+	MT32EMU_SERVICE_I_V4
+	MT32EMU_SERVICE_I_V5
+} mt32emu_service_i_v5;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+	MT32EMU_SERVICE_I_V2
+	MT32EMU_SERVICE_I_V3
+	MT32EMU_SERVICE_I_V4
+	MT32EMU_SERVICE_I_V5
+	MT32EMU_SERVICE_I_V6
+} mt32emu_service_i_v6;
+
+typedef struct {
+	MT32EMU_SERVICE_I_V0
+	MT32EMU_SERVICE_I_V1
+	MT32EMU_SERVICE_I_V2
+	MT32EMU_SERVICE_I_V3
+	MT32EMU_SERVICE_I_V4
+	MT32EMU_SERVICE_I_V5
+	MT32EMU_SERVICE_I_V6
+	MT32EMU_SERVICE_I_V7
+} mt32emu_service_i_v7;
+
+/**
+ * Extensible interface for all the library services.
+ * Union intended to view an interface of any subsequent version as any parent interface not requiring a cast.
+ * It is caller's responsibility to check the actual interface version in runtime using the getVersionID() method.
+ */
+union mt32emu_service_i {
+	const mt32emu_service_i_v0 *v0;
+	const mt32emu_service_i_v1 *v1;
+	const mt32emu_service_i_v2 *v2;
+	const mt32emu_service_i_v3 *v3;
+	const mt32emu_service_i_v4 *v4;
+	const mt32emu_service_i_v5 *v5;
+	const mt32emu_service_i_v6 *v6;
+	const mt32emu_service_i_v7 *v7;
+};
+
+#undef MT32EMU_SERVICE_I_V0
+#undef MT32EMU_SERVICE_I_V1
+#undef MT32EMU_SERVICE_I_V2
+#undef MT32EMU_SERVICE_I_V3
+#undef MT32EMU_SERVICE_I_V4
+#undef MT32EMU_SERVICE_I_V5
+#undef MT32EMU_SERVICE_I_V6
+#undef MT32EMU_SERVICE_I_V7
+
+#endif /* #ifndef MT32EMU_C_TYPES_H */

--- a/vendor/munt/src/c_interface/cpp_interface.h
+++ b/vendor/munt/src/c_interface/cpp_interface.h
@@ -1,0 +1,645 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2026 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_CPP_INTERFACE_H
+#define MT32EMU_CPP_INTERFACE_H
+
+#include <cstdarg>
+
+#include "../globals.h"
+#include "c_types.h"
+
+#include "../Types.h"
+#include "../Enumerations.h"
+
+#if MT32EMU_API_TYPE == 2
+
+extern "C" {
+
+/** Returns mt32emu_service_i interface. */
+mt32emu_service_i mt32emu_get_service_i();
+
+}
+
+#define mt32emu_get_supported_report_handler_version i.v0->getSupportedReportHandlerVersionID
+#define mt32emu_get_supported_midi_receiver_version i.v0->getSupportedMIDIReceiverVersionID
+#define mt32emu_get_library_version_int i.v0->getLibraryVersionInt
+#define mt32emu_get_library_version_string i.v0->getLibraryVersionString
+#define mt32emu_get_stereo_output_samplerate i.v0->getStereoOutputSamplerate
+#define mt32emu_get_best_analog_output_mode iV1()->getBestAnalogOutputMode
+#define mt32emu_get_machine_ids iV4()->getMachineIDs
+#define mt32emu_get_rom_ids iV4()->getROMIDs
+#define mt32emu_identify_rom_data iV4()->identifyROMData
+#define mt32emu_identify_rom_file iV4()->identifyROMFile
+#define mt32emu_create_context i.v0->createContext
+#define mt32emu_free_context i.v0->freeContext
+#define mt32emu_add_rom_data i.v0->addROMData
+#define mt32emu_add_rom_file i.v0->addROMFile
+#define mt32emu_merge_and_add_rom_data iV4()->mergeAndAddROMData
+#define mt32emu_merge_and_add_rom_files iV4()->mergeAndAddROMFiles
+#define mt32emu_add_machine_rom_file iV4()->addMachineROMFile
+#define mt32emu_get_rom_info i.v0->getROMInfo
+#define mt32emu_set_partial_count i.v0->setPartialCount
+#define mt32emu_set_analog_output_mode i.v0->setAnalogOutputMode
+#define mt32emu_set_stereo_output_samplerate iV1()->setStereoOutputSampleRate
+#define mt32emu_set_samplerate_conversion_quality iV1()->setSamplerateConversionQuality
+#define mt32emu_select_renderer_type iV1()->selectRendererType
+#define mt32emu_get_selected_renderer_type iV1()->getSelectedRendererType
+#define mt32emu_open_synth i.v0->openSynth
+#define mt32emu_close_synth i.v0->closeSynth
+#define mt32emu_is_open i.v0->isOpen
+#define mt32emu_get_actual_stereo_output_samplerate i.v0->getActualStereoOutputSamplerate
+#define mt32emu_convert_output_to_synth_timestamp iV1()->convertOutputToSynthTimestamp
+#define mt32emu_convert_synth_to_output_timestamp iV1()->convertSynthToOutputTimestamp
+#define mt32emu_flush_midi_queue i.v0->flushMIDIQueue
+#define mt32emu_set_midi_event_queue_size i.v0->setMIDIEventQueueSize
+#define mt32emu_configure_midi_event_queue_sysex_storage iV3()->configureMIDIEventQueueSysexStorage
+#define mt32emu_set_midi_receiver i.v0->setMIDIReceiver
+#define mt32emu_get_internal_rendered_sample_count iV2()->getInternalRenderedSampleCount
+#define mt32emu_parse_stream i.v0->parseStream
+#define mt32emu_parse_stream_at i.v0->parseStream_At
+#define mt32emu_play_short_message i.v0->playShortMessage
+#define mt32emu_play_short_message_at i.v0->playShortMessageAt
+#define mt32emu_play_msg i.v0->playMsg
+#define mt32emu_play_sysex i.v0->playSysex
+#define mt32emu_play_msg_at i.v0->playMsgAt
+#define mt32emu_play_sysex_at i.v0->playSysexAt
+#define mt32emu_play_msg_now i.v0->playMsgNow
+#define mt32emu_play_msg_on_part i.v0->playMsgOnPart
+#define mt32emu_play_sysex_now i.v0->playSysexNow
+#define mt32emu_write_sysex i.v0->writeSysex
+#define mt32emu_dump_sysex_bank iV7()->dumpSysexBank
+#define mt32emu_apply_sysex_bank iV7()->applySysexBank
+#define mt32emu_set_reverb_enabled i.v0->setReverbEnabled
+#define mt32emu_is_reverb_enabled i.v0->isReverbEnabled
+#define mt32emu_set_reverb_overridden i.v0->setReverbOverridden
+#define mt32emu_is_reverb_overridden i.v0->isReverbOverridden
+#define mt32emu_set_reverb_compatibility_mode i.v0->setReverbCompatibilityMode
+#define mt32emu_is_mt32_reverb_compatibility_mode i.v0->isMT32ReverbCompatibilityMode
+#define mt32emu_is_default_reverb_mt32_compatible i.v0->isDefaultReverbMT32Compatible
+#define mt32emu_preallocate_reverb_memory iV3()->preallocateReverbMemory
+#define mt32emu_set_dac_input_mode i.v0->setDACInputMode
+#define mt32emu_get_dac_input_mode i.v0->getDACInputMode
+#define mt32emu_set_midi_delay_mode i.v0->setMIDIDelayMode
+#define mt32emu_get_midi_delay_mode i.v0->getMIDIDelayMode
+#define mt32emu_set_output_gain i.v0->setOutputGain
+#define mt32emu_get_output_gain i.v0->getOutputGain
+#define mt32emu_set_reverb_output_gain i.v0->setReverbOutputGain
+#define mt32emu_get_reverb_output_gain i.v0->getReverbOutputGain
+#define mt32emu_set_master_volume_override iV7()->setMasterVolumeOverride
+#define mt32emu_get_master_volume_override iV7()->getMasterVolumeOverride
+#define mt32emu_set_part_volume_override iV5()->setPartVolumeOverride
+#define mt32emu_get_part_volume_override iV5()->getPartVolumeOverride
+#define mt32emu_set_reversed_stereo_enabled i.v0->setReversedStereoEnabled
+#define mt32emu_is_reversed_stereo_enabled i.v0->isReversedStereoEnabled
+#define mt32emu_set_nice_amp_ramp_enabled iV2()->setNiceAmpRampEnabled
+#define mt32emu_is_nice_amp_ramp_enabled iV2()->isNiceAmpRampEnabled
+#define mt32emu_set_nice_panning_enabled iV3()->setNicePanningEnabled
+#define mt32emu_is_nice_panning_enabled iV3()->isNicePanningEnabled
+#define mt32emu_set_nice_partial_mixing_enabled iV3()->setNicePartialMixingEnabled
+#define mt32emu_is_nice_partial_mixing_enabled iV3()->isNicePartialMixingEnabled
+#define mt32emu_render_bit16s i.v0->renderBit16s
+#define mt32emu_render_float i.v0->renderFloat
+#define mt32emu_render_bit16s_streams i.v0->renderBit16sStreams
+#define mt32emu_render_float_streams i.v0->renderFloatStreams
+#define mt32emu_has_active_partials i.v0->hasActivePartials
+#define mt32emu_is_active i.v0->isActive
+#define mt32emu_get_partial_count i.v0->getPartialCount
+#define mt32emu_get_part_states i.v0->getPartStates
+#define mt32emu_get_partial_states i.v0->getPartialStates
+#define mt32emu_get_playing_notes i.v0->getPlayingNotes
+#define mt32emu_get_patch_name i.v0->getPatchName
+#define mt32emu_get_sound_group_name iV6()->getSoundGroupName
+#define mt32emu_get_sound_name iV6()->getSoundName
+#define mt32emu_read_memory i.v0->readMemory
+#define mt32emu_get_display_state iV5()->getDisplayState
+#define mt32emu_set_main_display_mode iV5()->setMainDisplayMode
+#define mt32emu_set_display_compatibility iV5()->setDisplayCompatibility
+#define mt32emu_is_display_old_mt32_compatible iV5()->isDisplayOldMT32Compatible
+#define mt32emu_is_default_display_old_mt32_compatible iV5()->isDefaultDisplayOldMT32Compatible
+
+#else // #if MT32EMU_API_TYPE == 2
+
+#include "c_interface.h"
+
+#endif // #if MT32EMU_API_TYPE == 2
+
+namespace MT32Emu {
+
+namespace CppInterfaceImpl {
+
+static const mt32emu_report_handler_i NULL_REPORT_HANDLER = { NULL };
+static mt32emu_report_handler_i getReportHandlerThunk(mt32emu_report_handler_version);
+static mt32emu_midi_receiver_i getMidiReceiverThunk();
+
+}
+
+/*
+ * The classes below correspond to the interfaces defined in c_types.h and provided for convenience when using C++.
+ * The approach used makes no assumption of any internal class data memory layout, since the C++ standard does not
+ * provide any detail in this area and leaves it up to the implementation. Therefore, this way portability is guaranteed,
+ * despite the implementation may be a little inefficient.
+ * See c_types.h and c_interface.h for description of the corresponding interface methods.
+ */
+
+// Defines the interface for handling reported events (initial version).
+// Corresponds to the mt32emu_report_handler_i_v0 interface.
+class IReportHandler {
+public:
+	virtual void printDebug(const char *fmt, va_list list) = 0;
+	virtual void onErrorControlROM() = 0;
+	virtual void onErrorPCMROM() = 0;
+	virtual void showLCDMessage(const char *message) = 0;
+	virtual void onMIDIMessagePlayed() = 0;
+	virtual bool onMIDIQueueOverflow() = 0;
+	virtual void onMIDISystemRealtime(Bit8u system_realtime) = 0;
+	virtual void onDeviceReset() = 0;
+	virtual void onDeviceReconfig() = 0;
+	virtual void onNewReverbMode(Bit8u mode) = 0;
+	virtual void onNewReverbTime(Bit8u time) = 0;
+	virtual void onNewReverbLevel(Bit8u level) = 0;
+	virtual void onPolyStateChanged(Bit8u part_num) = 0;
+	virtual void onProgramChanged(Bit8u part_num, const char *sound_group_name, const char *patch_name) = 0;
+
+protected:
+	~IReportHandler() {}
+};
+
+// Extends IReportHandler, so that the client may supply callbacks for reporting signals about updated display state.
+// Corresponds to the mt32emu_report_handler_i_v1 interface.
+class IReportHandlerV1 : public IReportHandler {
+public:
+	virtual void onLCDStateUpdated() = 0;
+	virtual void onMidiMessageLEDStateUpdated(bool ledState) = 0;
+
+protected:
+	~IReportHandlerV1() {}
+};
+
+// Extends IReportHandlerV1 for delivering signals about insufficient partials conditions to the client.
+// Corresponds to the mt32emu_report_handler_i_v2 interface.
+class IReportHandlerV2 : public IReportHandlerV1 {
+public:
+	virtual void onNoteOnIgnored(Bit32u partialsNeeded, Bit32u partialsFree) = 0;
+	virtual void onPlayingPolySilenced(Bit32u partialsNeeded, Bit32u partialsFree) = 0;
+
+protected:
+	~IReportHandlerV2() {}
+};
+
+// Defines the interface for receiving MIDI messages generated by MIDI stream parser.
+// Corresponds to the current version of mt32emu_midi_receiver_i interface.
+class IMidiReceiver {
+public:
+	virtual void handleShortMessage(const Bit32u message) = 0;
+	virtual void handleSysex(const Bit8u stream[], const Bit32u length) = 0;
+	virtual void handleSystemRealtimeMessage(const Bit8u realtime) = 0;
+
+protected:
+	~IMidiReceiver() {}
+};
+
+// Defines all the library services.
+// Corresponds to the current version of mt32emu_service_i interface.
+class Service {
+public:
+#if MT32EMU_API_TYPE == 2
+	explicit Service(mt32emu_service_i interface, mt32emu_context context = NULL) : i(interface), c(context) {}
+#else
+	explicit Service(mt32emu_context context = NULL) : c(context) {}
+#endif
+	~Service() { if (c != NULL) mt32emu_free_context(c); }
+
+	// Context-independent methods
+
+#if MT32EMU_API_TYPE == 2
+	mt32emu_service_version getVersionID() { return i.v0->getVersionID(i); }
+#endif
+	mt32emu_report_handler_version getSupportedReportHandlerVersionID() { return mt32emu_get_supported_report_handler_version(); }
+	mt32emu_midi_receiver_version getSupportedMIDIReceiverVersionID() { return mt32emu_get_supported_midi_receiver_version(); }
+
+	Bit32u getLibraryVersionInt() { return mt32emu_get_library_version_int(); }
+	const char *getLibraryVersionString() { return mt32emu_get_library_version_string(); }
+
+	Bit32u getStereoOutputSamplerate(const AnalogOutputMode analog_output_mode) { return mt32emu_get_stereo_output_samplerate(static_cast<mt32emu_analog_output_mode>(analog_output_mode)); }
+	AnalogOutputMode getBestAnalogOutputMode(const double target_samplerate) { return static_cast<AnalogOutputMode>(mt32emu_get_best_analog_output_mode(target_samplerate)); }
+
+	size_t getMachineIDs(const char **machine_ids, size_t machine_ids_size) { return mt32emu_get_machine_ids(machine_ids, machine_ids_size); }
+	size_t getROMIDs(const char **rom_ids, size_t rom_ids_size, const char *machine_id) { return mt32emu_get_rom_ids(rom_ids, rom_ids_size, machine_id); }
+	mt32emu_return_code identifyROMData(mt32emu_rom_info *rom_info, const Bit8u *data, size_t data_size, const char *machine_id) { return mt32emu_identify_rom_data(rom_info, data, data_size, machine_id); }
+	mt32emu_return_code identifyROMFile(mt32emu_rom_info *rom_info, const char *filename, const char *machine_id) { return mt32emu_identify_rom_file(rom_info, filename, machine_id); }
+
+	// Context-dependent methods
+
+	mt32emu_context getContext() { return c; }
+	void createContext(mt32emu_report_handler_i report_handler = CppInterfaceImpl::NULL_REPORT_HANDLER, void *instance_data = NULL) { freeContext(); c = mt32emu_create_context(report_handler, instance_data); }
+	void createContext(IReportHandler &report_handler) { createContext(CppInterfaceImpl::getReportHandlerThunk(MT32EMU_REPORT_HANDLER_VERSION_0), &report_handler); }
+	void createContext(IReportHandlerV1 &report_handler) { createContext(CppInterfaceImpl::getReportHandlerThunk(MT32EMU_REPORT_HANDLER_VERSION_1), &report_handler); }
+	void createContext(IReportHandlerV2 &report_handler) { createContext(CppInterfaceImpl::getReportHandlerThunk(MT32EMU_REPORT_HANDLER_VERSION_2), &report_handler); }
+	void freeContext() { if (c != NULL) { mt32emu_free_context(c); c = NULL; } }
+	mt32emu_return_code addROMData(const Bit8u *data, size_t data_size, const mt32emu_sha1_digest *sha1_digest = NULL) { return mt32emu_add_rom_data(c, data, data_size, sha1_digest); }
+	mt32emu_return_code addROMFile(const char *filename) { return mt32emu_add_rom_file(c, filename); }
+	mt32emu_return_code mergeAndAddROMData(const Bit8u *part1_data, size_t part1_data_size, const Bit8u *part2_data, size_t part2_data_size) { return mt32emu_merge_and_add_rom_data(c, part1_data, part1_data_size, NULL, part2_data, part2_data_size, NULL); }
+	mt32emu_return_code mergeAndAddROMData(const Bit8u *part1_data, size_t part1_data_size, const mt32emu_sha1_digest *part1_sha1_digest, const Bit8u *part2_data, size_t part2_data_size, const mt32emu_sha1_digest *part2_sha1_digest) { return mt32emu_merge_and_add_rom_data(c, part1_data, part1_data_size, part1_sha1_digest, part2_data, part2_data_size, part2_sha1_digest); }
+	mt32emu_return_code mergeAndAddROMFiles(const char *part1_filename, const char *part2_filename) { return mt32emu_merge_and_add_rom_files(c, part1_filename, part2_filename); }
+	mt32emu_return_code addMachineROMFile(const char *machine_id, const char *filename) { return mt32emu_add_machine_rom_file(c, machine_id, filename); }
+	void getROMInfo(mt32emu_rom_info *rom_info) { mt32emu_get_rom_info(c, rom_info); }
+	void setPartialCount(const Bit32u partial_count) { mt32emu_set_partial_count(c, partial_count); }
+	void setAnalogOutputMode(const AnalogOutputMode analog_output_mode) { mt32emu_set_analog_output_mode(c, static_cast<mt32emu_analog_output_mode>(analog_output_mode)); }
+	void setStereoOutputSampleRate(const double samplerate) { mt32emu_set_stereo_output_samplerate(c, samplerate); }
+	void setSamplerateConversionQuality(const SamplerateConversionQuality quality) { mt32emu_set_samplerate_conversion_quality(c, static_cast<mt32emu_samplerate_conversion_quality>(quality)); }
+	void selectRendererType(const RendererType newRendererType) { mt32emu_select_renderer_type(c, static_cast<mt32emu_renderer_type>(newRendererType)); }
+	RendererType getSelectedRendererType() { return static_cast<RendererType>(mt32emu_get_selected_renderer_type(c)); }
+	mt32emu_return_code openSynth() { return mt32emu_open_synth(c); }
+	void closeSynth() { mt32emu_close_synth(c); }
+	bool isOpen() { return mt32emu_is_open(c) != MT32EMU_BOOL_FALSE; }
+	Bit32u getActualStereoOutputSamplerate() { return mt32emu_get_actual_stereo_output_samplerate(c); }
+	Bit32u convertOutputToSynthTimestamp(Bit32u output_timestamp) { return mt32emu_convert_output_to_synth_timestamp(c, output_timestamp); }
+	Bit32u convertSynthToOutputTimestamp(Bit32u synth_timestamp) { return mt32emu_convert_synth_to_output_timestamp(c, synth_timestamp); }
+	void flushMIDIQueue() { mt32emu_flush_midi_queue(c); }
+	Bit32u setMIDIEventQueueSize(const Bit32u queue_size) { return mt32emu_set_midi_event_queue_size(c, queue_size); }
+	void configureMIDIEventQueueSysexStorage(const Bit32u storage_buffer_size) { mt32emu_configure_midi_event_queue_sysex_storage(c, storage_buffer_size); }
+	void setMIDIReceiver(mt32emu_midi_receiver_i midi_receiver, void *instance_data) { mt32emu_set_midi_receiver(c, midi_receiver, instance_data); }
+	void setMIDIReceiver(IMidiReceiver &midi_receiver) { setMIDIReceiver(CppInterfaceImpl::getMidiReceiverThunk(), &midi_receiver); }
+
+	Bit32u getInternalRenderedSampleCount() { return mt32emu_get_internal_rendered_sample_count(c); }
+	void parseStream(const Bit8u *stream, Bit32u length) { mt32emu_parse_stream(c, stream, length); }
+	void parseStream_At(const Bit8u *stream, Bit32u length, Bit32u timestamp) { mt32emu_parse_stream_at(c, stream, length, timestamp); }
+	void playShortMessage(Bit32u message) { mt32emu_play_short_message(c, message); }
+	void playShortMessageAt(Bit32u message, Bit32u timestamp) { mt32emu_play_short_message_at(c, message, timestamp); }
+	mt32emu_return_code playMsg(Bit32u msg) { return mt32emu_play_msg(c, msg); }
+	mt32emu_return_code playSysex(const Bit8u *sysex, Bit32u len) { return mt32emu_play_sysex(c, sysex, len); }
+	mt32emu_return_code playMsgAt(Bit32u msg, Bit32u timestamp) { return mt32emu_play_msg_at(c, msg, timestamp); }
+	mt32emu_return_code playSysexAt(const Bit8u *sysex, Bit32u len, Bit32u timestamp) { return mt32emu_play_sysex_at(c, sysex, len, timestamp); }
+
+	void playMsgNow(Bit32u msg) { mt32emu_play_msg_now(c, msg); }
+	void playMsgOnPart(Bit8u part, Bit8u code, Bit8u note, Bit8u velocity) { mt32emu_play_msg_on_part(c, part, code, note, velocity); }
+	void playSysexNow(const Bit8u *sysex, Bit32u len) { mt32emu_play_sysex_now(c, sysex, len); }
+	void writeSysex(Bit8u channel, const Bit8u *sysex, Bit32u len) { mt32emu_write_sysex(c, channel, sysex, len); }
+
+	Bit32u dumpSysexBank(Bit8u *sysex_bank, Bit32u size) { return mt32emu_dump_sysex_bank(c, sysex_bank, size); }
+	Bit32u applySysexBank(const Bit8u *sysex_bank, Bit32u size) { return mt32emu_apply_sysex_bank(c, sysex_bank, size); }
+
+	void setReverbEnabled(const bool reverb_enabled) { mt32emu_set_reverb_enabled(c, reverb_enabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isReverbEnabled() { return mt32emu_is_reverb_enabled(c) != MT32EMU_BOOL_FALSE; }
+	void setReverbOverridden(const bool reverb_overridden) { mt32emu_set_reverb_overridden(c, reverb_overridden ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isReverbOverridden() { return mt32emu_is_reverb_overridden(c) != MT32EMU_BOOL_FALSE; }
+	void setReverbCompatibilityMode(const bool mt32_compatible_mode) { mt32emu_set_reverb_compatibility_mode(c, mt32_compatible_mode ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isMT32ReverbCompatibilityMode() { return mt32emu_is_mt32_reverb_compatibility_mode(c) != MT32EMU_BOOL_FALSE; }
+	bool isDefaultReverbMT32Compatible() { return mt32emu_is_default_reverb_mt32_compatible(c) != MT32EMU_BOOL_FALSE; }
+	void preallocateReverbMemory(const bool enabled) { mt32emu_preallocate_reverb_memory(c, enabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+
+	void setDACInputMode(const DACInputMode mode) { mt32emu_set_dac_input_mode(c, static_cast<mt32emu_dac_input_mode>(mode)); }
+	DACInputMode getDACInputMode() { return static_cast<DACInputMode>(mt32emu_get_dac_input_mode(c)); }
+
+	void setMIDIDelayMode(const MIDIDelayMode mode) { mt32emu_set_midi_delay_mode(c, static_cast<mt32emu_midi_delay_mode>(mode)); }
+	MIDIDelayMode getMIDIDelayMode() { return static_cast<MIDIDelayMode>(mt32emu_get_midi_delay_mode(c)); }
+
+	void setOutputGain(float gain) { mt32emu_set_output_gain(c, gain); }
+	float getOutputGain() { return mt32emu_get_output_gain(c); }
+	void setReverbOutputGain(float gain) { mt32emu_set_reverb_output_gain(c, gain); }
+	float getReverbOutputGain() { return mt32emu_get_reverb_output_gain(c); }
+
+	void setMasterVolumeOverride(Bit8u volume_override) { mt32emu_set_master_volume_override(c, volume_override); }
+	Bit8u getMasterVolumeOverride() { return mt32emu_get_master_volume_override(c); }
+
+	void setPartVolumeOverride(Bit8u part_number, Bit8u volume_override) { mt32emu_set_part_volume_override(c, part_number, volume_override); }
+	Bit8u getPartVolumeOverride(Bit8u part_number) { return mt32emu_get_part_volume_override(c, part_number); }
+
+	void setReversedStereoEnabled(const bool enabled) { mt32emu_set_reversed_stereo_enabled(c, enabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isReversedStereoEnabled() { return mt32emu_is_reversed_stereo_enabled(c) != MT32EMU_BOOL_FALSE; }
+
+	void setNiceAmpRampEnabled(const bool enabled) { mt32emu_set_nice_amp_ramp_enabled(c, enabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isNiceAmpRampEnabled() { return mt32emu_is_nice_amp_ramp_enabled(c) != MT32EMU_BOOL_FALSE; }
+
+	void setNicePanningEnabled(const bool enabled) { mt32emu_set_nice_panning_enabled(c, enabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isNicePanningEnabled() { return mt32emu_is_nice_panning_enabled(c) != MT32EMU_BOOL_FALSE; }
+
+	void setNicePartialMixingEnabled(const bool enabled) { mt32emu_set_nice_partial_mixing_enabled(c, enabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isNicePartialMixingEnabled() { return mt32emu_is_nice_partial_mixing_enabled(c) != MT32EMU_BOOL_FALSE; }
+
+	void renderBit16s(Bit16s *stream, Bit32u len) { mt32emu_render_bit16s(c, stream, len); }
+	void renderFloat(float *stream, Bit32u len) { mt32emu_render_float(c, stream, len); }
+	void renderBit16sStreams(const mt32emu_dac_output_bit16s_streams *streams, Bit32u len) { mt32emu_render_bit16s_streams(c, streams, len); }
+	void renderFloatStreams(const mt32emu_dac_output_float_streams *streams, Bit32u len) { mt32emu_render_float_streams(c, streams, len); }
+
+	bool hasActivePartials() { return mt32emu_has_active_partials(c) != MT32EMU_BOOL_FALSE; }
+	bool isActive() { return mt32emu_is_active(c) != MT32EMU_BOOL_FALSE; }
+	Bit32u getPartialCount() { return mt32emu_get_partial_count(c); }
+	Bit32u getPartStates() { return mt32emu_get_part_states(c); }
+	void getPartialStates(Bit8u *partial_states) { mt32emu_get_partial_states(c, partial_states); }
+	Bit32u getPlayingNotes(Bit8u part_number, Bit8u *keys, Bit8u *velocities) { return mt32emu_get_playing_notes(c, part_number, keys, velocities); }
+	const char *getPatchName(Bit8u part_number) { return mt32emu_get_patch_name(c, part_number); }
+	bool getSoundGroupName(char *soundGroupName, Bit8u timbreGroup, Bit8u timbreNumber) { return mt32emu_get_sound_group_name(c, soundGroupName, timbreGroup, timbreNumber) != MT32EMU_BOOL_FALSE; }
+	bool getSoundName(char *soundName, Bit8u timbreGroup, Bit8u timbreNumber) { return mt32emu_get_sound_name(c, soundName, timbreGroup, timbreNumber) != MT32EMU_BOOL_FALSE; }
+	void readMemory(Bit32u addr, Bit32u len, Bit8u *data) { mt32emu_read_memory(c, addr, len, data); }
+
+	bool getDisplayState(char *target_buffer, const bool narrow_lcd) { return mt32emu_get_display_state(c, target_buffer, narrow_lcd ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE) != MT32EMU_BOOL_FALSE; }
+	void setMainDisplayMode() { mt32emu_set_main_display_mode(c); }
+
+	void setDisplayCompatibility(const bool oldMT32CompatibilityEnabled) { mt32emu_set_display_compatibility(c, oldMT32CompatibilityEnabled ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE); }
+	bool isDisplayOldMT32Compatible() { return mt32emu_is_display_old_mt32_compatible(c) != MT32EMU_BOOL_FALSE; }
+	bool isDefaultDisplayOldMT32Compatible() { return mt32emu_is_default_display_old_mt32_compatible(c) != MT32EMU_BOOL_FALSE; }
+
+private:
+#if MT32EMU_API_TYPE == 2
+	const mt32emu_service_i i;
+#endif
+	mt32emu_context c;
+
+#if MT32EMU_API_TYPE == 2
+	const mt32emu_service_i_v1 *iV1() { return (getVersionID() < MT32EMU_SERVICE_VERSION_1) ? NULL : i.v1; }
+	const mt32emu_service_i_v2 *iV2() { return (getVersionID() < MT32EMU_SERVICE_VERSION_2) ? NULL : i.v2; }
+	const mt32emu_service_i_v3 *iV3() { return (getVersionID() < MT32EMU_SERVICE_VERSION_3) ? NULL : i.v3; }
+	const mt32emu_service_i_v4 *iV4() { return (getVersionID() < MT32EMU_SERVICE_VERSION_4) ? NULL : i.v4; }
+	const mt32emu_service_i_v5 *iV5() { return (getVersionID() < MT32EMU_SERVICE_VERSION_5) ? NULL : i.v5; }
+	const mt32emu_service_i_v6 *iV6() { return (getVersionID() < MT32EMU_SERVICE_VERSION_6) ? NULL : i.v6; }
+	const mt32emu_service_i_v7 *iV7() { return (getVersionID() < MT32EMU_SERVICE_VERSION_7) ? NULL : i.v7; }
+#endif
+
+	Service(const Service &);            // prevent copy-construction
+	Service& operator=(const Service &); // prevent assignment
+};
+
+namespace CppInterfaceImpl {
+
+static mt32emu_report_handler_version MT32EMU_C_CALL getReportHandlerVersionID(mt32emu_report_handler_i);
+
+static void MT32EMU_C_CALL printDebug(void *instance_data, const char *fmt, va_list list) {
+	static_cast<IReportHandler *>(instance_data)->printDebug(fmt, list);
+}
+
+static void MT32EMU_C_CALL onErrorControlROM(void *instance_data) {
+	static_cast<IReportHandler *>(instance_data)->onErrorControlROM();
+}
+
+static void MT32EMU_C_CALL onErrorPCMROM(void *instance_data) {
+	static_cast<IReportHandler *>(instance_data)->onErrorPCMROM();
+}
+
+static void MT32EMU_C_CALL showLCDMessage(void *instance_data, const char *message) {
+	static_cast<IReportHandler *>(instance_data)->showLCDMessage(message);
+}
+
+static void MT32EMU_C_CALL onMIDIMessagePlayed(void *instance_data) {
+	static_cast<IReportHandler *>(instance_data)->onMIDIMessagePlayed();
+}
+
+static mt32emu_boolean MT32EMU_C_CALL onMIDIQueueOverflow(void *instance_data) {
+	return static_cast<IReportHandler *>(instance_data)->onMIDIQueueOverflow() ? MT32EMU_BOOL_TRUE : MT32EMU_BOOL_FALSE;
+}
+
+static void MT32EMU_C_CALL onMIDISystemRealtime(void *instance_data, mt32emu_bit8u system_realtime) {
+	static_cast<IReportHandler *>(instance_data)->onMIDISystemRealtime(system_realtime);
+}
+
+static void MT32EMU_C_CALL onDeviceReset(void *instance_data) {
+	static_cast<IReportHandler *>(instance_data)->onDeviceReset();
+}
+
+static void MT32EMU_C_CALL onDeviceReconfig(void *instance_data) {
+	static_cast<IReportHandler *>(instance_data)->onDeviceReconfig();
+}
+
+static void MT32EMU_C_CALL onNewReverbMode(void *instance_data, mt32emu_bit8u mode) {
+	static_cast<IReportHandler *>(instance_data)->onNewReverbMode(mode);
+}
+
+static void MT32EMU_C_CALL onNewReverbTime(void *instance_data, mt32emu_bit8u time) {
+	static_cast<IReportHandler *>(instance_data)->onNewReverbTime(time);
+}
+
+static void MT32EMU_C_CALL onNewReverbLevel(void *instance_data, mt32emu_bit8u level) {
+	static_cast<IReportHandler *>(instance_data)->onNewReverbLevel(level);
+}
+
+static void MT32EMU_C_CALL onPolyStateChanged(void *instance_data, mt32emu_bit8u part_num) {
+	static_cast<IReportHandler *>(instance_data)->onPolyStateChanged(part_num);
+}
+
+static void MT32EMU_C_CALL onProgramChanged(void *instance_data, mt32emu_bit8u part_num, const char *sound_group_name, const char *patch_name) {
+	static_cast<IReportHandler *>(instance_data)->onProgramChanged(part_num, sound_group_name, patch_name);
+}
+
+static void MT32EMU_C_CALL onLCDStateUpdated(void *instance_data) {
+	static_cast<IReportHandlerV1 *>(instance_data)->onLCDStateUpdated();
+}
+
+static void MT32EMU_C_CALL onMidiMessageLEDStateUpdated(void *instance_data, mt32emu_boolean led_state) {
+	static_cast<IReportHandlerV1 *>(instance_data)->onMidiMessageLEDStateUpdated(led_state != MT32EMU_BOOL_FALSE);
+}
+
+static void MT32EMU_C_CALL onNoteOnIgnored(void *instance_data, Bit32u partialsNeeded, Bit32u partialsFree) {
+	static_cast<IReportHandlerV2 *>(instance_data)->onNoteOnIgnored(partialsNeeded, partialsFree);
+}
+static void MT32EMU_C_CALL onPlayingPolySilenced(void *instance_data, Bit32u partialsNeeded, Bit32u partialsFree) {
+	static_cast<IReportHandlerV2 *>(instance_data)->onPlayingPolySilenced(partialsNeeded, partialsFree);
+}
+
+#define MT32EMU_REPORT_HANDLER_V0_THUNK \
+	getReportHandlerVersionID, \
+	printDebug, \
+	onErrorControlROM, \
+	onErrorPCMROM, \
+	showLCDMessage, \
+	onMIDIMessagePlayed, \
+	onMIDIQueueOverflow, \
+	onMIDISystemRealtime, \
+	onDeviceReset, \
+	onDeviceReconfig, \
+	onNewReverbMode, \
+	onNewReverbTime, \
+	onNewReverbLevel, \
+	onPolyStateChanged, \
+	onProgramChanged
+
+#define MT32EMU_REPORT_HANDLER_V1_THUNK \
+	onLCDStateUpdated, \
+	onMidiMessageLEDStateUpdated
+
+#define MT32EMU_REPORT_HANDLER_V2_THUNK \
+	onNoteOnIgnored, \
+	onPlayingPolySilenced
+
+static const mt32emu_report_handler_i_v0 REPORT_HANDLER_V0_THUNK = {
+	MT32EMU_REPORT_HANDLER_V0_THUNK
+};
+
+static const mt32emu_report_handler_i_v1 REPORT_HANDLER_V1_THUNK = {
+	MT32EMU_REPORT_HANDLER_V0_THUNK,
+	MT32EMU_REPORT_HANDLER_V1_THUNK
+};
+
+static const mt32emu_report_handler_i_v2 REPORT_HANDLER_V2_THUNK = {
+	MT32EMU_REPORT_HANDLER_V0_THUNK,
+	MT32EMU_REPORT_HANDLER_V1_THUNK,
+	MT32EMU_REPORT_HANDLER_V2_THUNK
+};
+
+#undef MT32EMU_REPORT_HANDLER_THUNK_V0
+#undef MT32EMU_REPORT_HANDLER_THUNK_V1
+#undef MT32EMU_REPORT_HANDLER_THUNK_V2
+
+static mt32emu_report_handler_version MT32EMU_C_CALL getReportHandlerVersionID(mt32emu_report_handler_i thunk) {
+	if (thunk.v0 == &REPORT_HANDLER_V0_THUNK) return MT32EMU_REPORT_HANDLER_VERSION_0;
+	if (thunk.v1 == &REPORT_HANDLER_V1_THUNK) return MT32EMU_REPORT_HANDLER_VERSION_1;
+	return MT32EMU_REPORT_HANDLER_VERSION_CURRENT;
+}
+
+static mt32emu_report_handler_i getReportHandlerThunk(mt32emu_report_handler_version versionID) {
+	mt32emu_report_handler_i thunk;
+	if (versionID == MT32EMU_REPORT_HANDLER_VERSION_0) thunk.v0 = &REPORT_HANDLER_V0_THUNK;
+	else if (versionID == MT32EMU_REPORT_HANDLER_VERSION_1) thunk.v1 = &REPORT_HANDLER_V1_THUNK;
+	else thunk.v2 = &REPORT_HANDLER_V2_THUNK;
+	return thunk;
+}
+
+static mt32emu_midi_receiver_version MT32EMU_C_CALL getMidiReceiverVersionID(mt32emu_midi_receiver_i) {
+	return MT32EMU_MIDI_RECEIVER_VERSION_CURRENT;
+}
+
+static void MT32EMU_C_CALL handleShortMessage(void *instance_data, const mt32emu_bit32u message) {
+	static_cast<IMidiReceiver *>(instance_data)->handleShortMessage(message);
+}
+
+static void MT32EMU_C_CALL handleSysex(void *instance_data, const mt32emu_bit8u stream[], const mt32emu_bit32u length) {
+	static_cast<IMidiReceiver *>(instance_data)->handleSysex(stream, length);
+}
+
+static void MT32EMU_C_CALL handleSystemRealtimeMessage(void *instance_data, const mt32emu_bit8u realtime) {
+	static_cast<IMidiReceiver *>(instance_data)->handleSystemRealtimeMessage(realtime);
+}
+
+static mt32emu_midi_receiver_i getMidiReceiverThunk() {
+	static const mt32emu_midi_receiver_i_v0 MIDI_RECEIVER_V0_THUNK = {
+		getMidiReceiverVersionID,
+		handleShortMessage,
+		handleSysex,
+		handleSystemRealtimeMessage
+	};
+
+	static const mt32emu_midi_receiver_i MIDI_RECEIVER_THUNK = { &MIDI_RECEIVER_V0_THUNK };
+
+	return MIDI_RECEIVER_THUNK;
+}
+
+} // namespace CppInterfaceImpl
+
+} // namespace MT32Emu
+
+#if MT32EMU_API_TYPE == 2
+
+#undef mt32emu_get_supported_report_handler_version
+#undef mt32emu_get_supported_midi_receiver_version
+#undef mt32emu_get_library_version_int
+#undef mt32emu_get_library_version_string
+#undef mt32emu_get_stereo_output_samplerate
+#undef mt32emu_get_best_analog_output_mode
+#undef mt32emu_get_machine_ids
+#undef mt32emu_get_rom_ids
+#undef mt32emu_identify_rom_data
+#undef mt32emu_identify_rom_file
+#undef mt32emu_create_context
+#undef mt32emu_free_context
+#undef mt32emu_add_rom_data
+#undef mt32emu_add_rom_file
+#undef mt32emu_merge_and_add_rom_data
+#undef mt32emu_merge_and_add_rom_files
+#undef mt32emu_add_machine_rom_file
+#undef mt32emu_get_rom_info
+#undef mt32emu_set_partial_count
+#undef mt32emu_set_analog_output_mode
+#undef mt32emu_set_stereo_output_samplerate
+#undef mt32emu_set_samplerate_conversion_quality
+#undef mt32emu_select_renderer_type
+#undef mt32emu_get_selected_renderer_type
+#undef mt32emu_open_synth
+#undef mt32emu_close_synth
+#undef mt32emu_is_open
+#undef mt32emu_get_actual_stereo_output_samplerate
+#undef mt32emu_convert_output_to_synth_timestamp
+#undef mt32emu_convert_synth_to_output_timestamp
+#undef mt32emu_flush_midi_queue
+#undef mt32emu_set_midi_event_queue_size
+#undef mt32emu_configure_midi_event_queue_sysex_storage
+#undef mt32emu_set_midi_receiver
+#undef mt32emu_get_internal_rendered_sample_count
+#undef mt32emu_parse_stream
+#undef mt32emu_parse_stream_at
+#undef mt32emu_play_short_message
+#undef mt32emu_play_short_message_at
+#undef mt32emu_play_msg
+#undef mt32emu_play_sysex
+#undef mt32emu_play_msg_at
+#undef mt32emu_play_sysex_at
+#undef mt32emu_play_msg_now
+#undef mt32emu_play_msg_on_part
+#undef mt32emu_play_sysex_now
+#undef mt32emu_write_sysex
+#undef mt32emu_dump_sysex_bank
+#undef mt32emu_apply_sysex_bank
+#undef mt32emu_set_reverb_enabled
+#undef mt32emu_is_reverb_enabled
+#undef mt32emu_set_reverb_overridden
+#undef mt32emu_is_reverb_overridden
+#undef mt32emu_set_reverb_compatibility_mode
+#undef mt32emu_is_mt32_reverb_compatibility_mode
+#undef mt32emu_is_default_reverb_mt32_compatible
+#undef mt32emu_preallocate_reverb_memory
+#undef mt32emu_set_dac_input_mode
+#undef mt32emu_get_dac_input_mode
+#undef mt32emu_set_midi_delay_mode
+#undef mt32emu_get_midi_delay_mode
+#undef mt32emu_set_output_gain
+#undef mt32emu_get_output_gain
+#undef mt32emu_set_reverb_output_gain
+#undef mt32emu_get_reverb_output_gain
+#undef mt32emu_set_master_volume_override
+#undef mt32emu_get_master_volume_override
+#undef mt32emu_set_part_volume_override
+#undef mt32emu_get_part_volume_override
+#undef mt32emu_set_reversed_stereo_enabled
+#undef mt32emu_is_reversed_stereo_enabled
+#undef mt32emu_set_nice_amp_ramp_enabled
+#undef mt32emu_is_nice_amp_ramp_enabled
+#undef mt32emu_set_nice_panning_enabled
+#undef mt32emu_is_nice_panning_enabled
+#undef mt32emu_set_nice_partial_mixing_enabled
+#undef mt32emu_is_nice_partial_mixing_enabled
+#undef mt32emu_render_bit16s
+#undef mt32emu_render_float
+#undef mt32emu_render_bit16s_streams
+#undef mt32emu_render_float_streams
+#undef mt32emu_has_active_partials
+#undef mt32emu_is_active
+#undef mt32emu_get_partial_count
+#undef mt32emu_get_part_states
+#undef mt32emu_get_partial_states
+#undef mt32emu_get_playing_notes
+#undef mt32emu_get_patch_name
+#undef mt32emu_get_sound_group_name
+#undef mt32emu_get_sound_name
+#undef mt32emu_read_memory
+#undef mt32emu_get_display_state
+#undef mt32emu_set_main_display_mode
+#undef mt32emu_set_display_compatibility
+#undef mt32emu_is_display_old_mt32_compatible
+#undef mt32emu_is_default_display_old_mt32_compatible
+
+#endif // #if MT32EMU_API_TYPE == 2
+
+#endif /* #ifndef MT32EMU_CPP_INTERFACE_H */

--- a/vendor/munt/src/config.h
+++ b/vendor/munt/src/config.h
@@ -1,0 +1,25 @@
+/* Copperline's static answer to config.h.in, which upstream fills in from
+ * CMake. build.rs compiles these sources directly into the emulator, so the
+ * build is always static, unversioned, and offers both API flavours.
+ *
+ * See ../README.md. Everything else under src/ is upstream's, untouched.
+ */
+
+#ifndef MT32EMU_CONFIG_H
+#define MT32EMU_CONFIG_H
+
+#define MT32EMU_VERSION      "2.8.2"
+#define MT32EMU_VERSION_MAJOR 2
+#define MT32EMU_VERSION_MINOR 8
+#define MT32EMU_VERSION_PATCH 2
+
+/* 3: both the C++ and the C API are available. Copperline uses the C one. */
+#define MT32EMU_EXPORTS_TYPE 3
+
+/* Static build: MT32EMU_SHARED stays undefined, so no export attributes. */
+
+/* Version tagging guards a shared object against a mismatched client. There
+ * is no shared object here, so there is nothing to guard. */
+#define MT32EMU_WITH_VERSION_TAGGING 0
+
+#endif /* #ifndef MT32EMU_CONFIG_H */

--- a/vendor/munt/src/config.h.in
+++ b/vendor/munt/src/config.h.in
@@ -1,0 +1,67 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_CONFIG_H
+#define MT32EMU_CONFIG_H
+
+#define MT32EMU_VERSION      "@libmt32emu_VERSION@"
+#define MT32EMU_VERSION_MAJOR @libmt32emu_VERSION_MAJOR@
+#define MT32EMU_VERSION_MINOR @libmt32emu_VERSION_MINOR@
+#define MT32EMU_VERSION_PATCH @libmt32emu_VERSION_PATCH@
+
+/* Library Exports Configuration
+ *
+ * This reflects the API types actually provided by the library build.
+ * 0: The full-featured C++ API is only available in this build. The client application may ONLY use MT32EMU_API_TYPE 0.
+ * 1: The C-compatible API is only available. The library is built as a shared object, only C functions are exported,
+ *    and thus the client application may NOT use MT32EMU_API_TYPE 0.
+ * 2: The C-compatible API is only available. The library is built as a shared object, only the factory function
+ *    is exported, and thus the client application may ONLY use MT32EMU_API_TYPE 2.
+ * 3: All the available API types are provided by the library build.
+ */
+#define MT32EMU_EXPORTS_TYPE @libmt32emu_EXPORTS_TYPE@
+
+/* Type of library build.
+ *
+ * For shared library builds, MT32EMU_SHARED is defined, so that compiler-specific attributes are assigned
+ * to all the exported symbols as appropriate. MT32EMU_SHARED is undefined for static library builds.
+ */
+@libmt32emu_SHARED_DEFINITION@
+
+/* Whether the library is built as a shared object with a version tag to enable runtime version checks. */
+#define MT32EMU_WITH_VERSION_TAGGING @libmt32emu_RUNTIME_VERSION_CHECK@
+
+/* Automatic runtime check of the shared library version in client applications.
+ *
+ * When the shared library is built with version tagging enabled, the client application may rely on an automatic
+ * version check that ensures forward compatibility. See VersionTagging.h for more info.
+ * 0: Disables the automatic runtime version check in the client application. Implied for static library builds
+ *    and when version tagging is not used in a shared object.
+ * 1: Enables an automatic runtime version check in client applications that utilise low-level C++ API,
+ *    i.e. when MT32EMU_API_TYPE 0. Client applications that rely on the C-compatible API are supposed
+ *    to check the version of the shared object by other means (e.g. using versioned C symbols, etc.).
+ * 2: Enables an automatic runtime version check for C++ and C client applications.
+ */
+#if MT32EMU_WITH_VERSION_TAGGING
+#  ifndef MT32EMU_RUNTIME_VERSION_CHECK
+#    define MT32EMU_RUNTIME_VERSION_CHECK @libmt32emu_RUNTIME_VERSION_CHECK@
+#  endif
+#else
+#  undef MT32EMU_RUNTIME_VERSION_CHECK
+#endif
+
+#endif /* #ifndef MT32EMU_CONFIG_H */

--- a/vendor/munt/src/globals.h
+++ b/vendor/munt/src/globals.h
@@ -1,0 +1,154 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_GLOBALS_H
+#define MT32EMU_GLOBALS_H
+
+#include "config.h"
+
+/* Support for compiling shared library.
+ * MT32EMU_SHARED and mt32emu_EXPORTS are defined when building a shared library.
+ * MT32EMU_SHARED should also be defined for Windows platforms that provides for a small performance benefit,
+ * and it _must_ be defined along with MT32EMU_RUNTIME_VERSION_CHECK when using MSVC.
+ */
+#ifdef MT32EMU_SHARED
+#  if defined _WIN32 || defined __CYGWIN__ || defined __OS2__
+#    ifdef _MSC_VER
+#      ifdef mt32emu_EXPORTS
+#        define MT32EMU_EXPORT_ATTRIBUTE _declspec(dllexport)
+#      else /* #ifdef mt32emu_EXPORTS */
+#        define MT32EMU_EXPORT_ATTRIBUTE _declspec(dllimport)
+#      endif /* #ifdef mt32emu_EXPORTS */
+#    else /* #ifdef _MSC_VER */
+#      ifdef mt32emu_EXPORTS
+#        define MT32EMU_EXPORT_ATTRIBUTE __attribute__ ((dllexport))
+#      else /* #ifdef mt32emu_EXPORTS */
+#        define MT32EMU_EXPORT_ATTRIBUTE __attribute__ ((dllimport))
+#      endif /* #ifdef mt32emu_EXPORTS */
+#    endif /* #ifdef _MSC_VER */
+#  else /* #if defined _WIN32 || defined __CYGWIN__ || defined __OS2__ */
+#    ifdef mt32emu_EXPORTS
+#      define MT32EMU_EXPORT_ATTRIBUTE __attribute__ ((visibility("default")))
+#    else /* #ifdef mt32emu_EXPORTS */
+#      define MT32EMU_EXPORT_ATTRIBUTE
+#    endif /* #ifdef mt32emu_EXPORTS */
+#  endif /* #if defined _WIN32 || defined __CYGWIN__ || defined __OS2__ */
+#else /* #ifdef MT32EMU_SHARED */
+#  define MT32EMU_EXPORT_ATTRIBUTE
+#endif /* #ifdef MT32EMU_SHARED */
+
+#if MT32EMU_EXPORTS_TYPE == 1 || MT32EMU_EXPORTS_TYPE == 2
+#define MT32EMU_EXPORT
+#else
+#define MT32EMU_EXPORT MT32EMU_EXPORT_ATTRIBUTE
+#endif
+
+/* Facilitates easier tracking of the library version when an external symbol was introduced.
+ * Particularly useful for shared library builds on POSIX systems that support symbol versioning,
+ * so that the version map file can be generated automatically.
+ */
+#define MT32EMU_EXPORT_V(symbol_version_tag) MT32EMU_EXPORT
+
+/* Helpers for compile-time version checks */
+
+/* Encodes the given version components to a single integer value to simplify further checks. */
+#define MT32EMU_VERSION_INT(major, minor, patch) ((major << 16) | (minor << 8) | patch)
+
+/* The version of this library build, as an integer. */
+#define MT32EMU_CURRENT_VERSION_INT MT32EMU_VERSION_INT(MT32EMU_VERSION_MAJOR, MT32EMU_VERSION_MINOR, MT32EMU_VERSION_PATCH)
+
+/* Compares the current library version with the given version components. Intended for feature checks. */
+#define MT32EMU_VERSION_ATLEAST(major, minor, patch) (MT32EMU_CURRENT_VERSION_INT >= MT32EMU_VERSION_INT(major, minor, patch))
+
+/* Implements a simple version check that ensures full API compatibility of this library build
+ * with the application requirements. The latter can be derived from the versions of used public symbols.
+ *
+ * Note: This macro is intended for a quick compile-time check. To ensure compatibility of an application
+ * linked with a shared library, an automatic version check can be engaged with help of the build option
+ * libmt32emu_WITH_VERSION_TAGGING. For a fine-grained feature checking in run-time, see functions
+ * mt32emu_get_library_version_int and Synth::getLibraryVersionInt.
+ */
+#define MT32EMU_IS_COMPATIBLE(major, minor) (MT32EMU_VERSION_MAJOR == major && MT32EMU_VERSION_MINOR >= minor)
+
+/* Useful constants */
+
+/* Sample rate to use in mixing. With the progress of development, we've found way too many thing dependent.
+ * In order to achieve further advance in emulation accuracy, sample rate made fixed throughout the emulator,
+ * except the emulation of analogue path.
+ * The output from the synth is supposed to be resampled externally in order to convert to the desired sample rate.
+ */
+#define MT32EMU_SAMPLE_RATE 32000
+
+/* The default value for the maximum number of partials playing simultaneously. */
+#define MT32EMU_DEFAULT_MAX_PARTIALS 32
+
+/* The higher this number, the more memory will be used, but the more samples can be processed in one run -
+ * various parts of sample generation can be processed more efficiently in a single run.
+ * A run's maximum length is that given to Synth::render(), so giving a value here higher than render() is ever
+ * called with will give no gain (but simply waste the memory).
+ * Note that this value does *not* in any way impose limitations on the length given to render(), and has no effect
+ * on the generated audio.
+ * This value must be >= 1.
+ */
+#define MT32EMU_MAX_SAMPLES_PER_RUN 4096
+
+/* The default size of the internal MIDI event queue.
+ * It holds the incoming MIDI events before the rendering engine actually processes them.
+ * The main goal is to fairly emulate the real hardware behaviour which obviously
+ * uses an internal MIDI event queue to gather incoming data as well as the delays
+ * introduced by transferring data via the MIDI interface.
+ * This also facilitates building of an external rendering loop
+ * as the queue stores timestamped MIDI events.
+ */
+#define MT32EMU_DEFAULT_MIDI_EVENT_QUEUE_SIZE 1024
+
+/* Maximum allowed size of MIDI parser input stream buffer.
+ * Should suffice for any reasonable bulk dump SysEx, as the h/w units have only 32K of RAM onboard.
+ */
+#define MT32EMU_MAX_STREAM_BUFFER_SIZE 32768
+
+/* This should correspond to the MIDI buffer size used in real h/w devices.
+ * CM-32L control ROM is using 1000 bytes, and MT-32 GEN0 is using only 240 bytes (semi-confirmed by now).
+ */
+#define MT32EMU_SYSEX_BUFFER_SIZE 1000
+
+#if defined(__cplusplus) && MT32EMU_API_TYPE != 1
+
+namespace MT32Emu
+{
+const unsigned int SAMPLE_RATE = MT32EMU_SAMPLE_RATE;
+#undef MT32EMU_SAMPLE_RATE
+
+const unsigned int DEFAULT_MAX_PARTIALS = MT32EMU_DEFAULT_MAX_PARTIALS;
+#undef MT32EMU_DEFAULT_MAX_PARTIALS
+
+const unsigned int MAX_SAMPLES_PER_RUN = MT32EMU_MAX_SAMPLES_PER_RUN;
+#undef MT32EMU_MAX_SAMPLES_PER_RUN
+
+const unsigned int DEFAULT_MIDI_EVENT_QUEUE_SIZE = MT32EMU_DEFAULT_MIDI_EVENT_QUEUE_SIZE;
+#undef MT32EMU_DEFAULT_MIDI_EVENT_QUEUE_SIZE
+
+const unsigned int MAX_STREAM_BUFFER_SIZE = MT32EMU_MAX_STREAM_BUFFER_SIZE;
+#undef MT32EMU_MAX_STREAM_BUFFER_SIZE
+
+const unsigned int SYSEX_BUFFER_SIZE = MT32EMU_SYSEX_BUFFER_SIZE;
+#undef MT32EMU_SYSEX_BUFFER_SIZE
+}
+
+#endif /* #if defined(__cplusplus) && MT32EMU_API_TYPE != 1 */
+
+#endif /* #ifndef MT32EMU_GLOBALS_H */

--- a/vendor/munt/src/internals.h
+++ b/vendor/munt/src/internals.h
@@ -1,0 +1,112 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_INTERNALS_H
+#define MT32EMU_INTERNALS_H
+
+#include "Types.h"
+
+// Debugging
+
+// 0: Standard debug output is not stamped with the rendered sample count
+// 1: Standard debug output is stamped with the rendered sample count
+// NOTE: The "samplestamp" corresponds to the end of the last completed rendering run.
+//       This is important to bear in mind for debug output that occurs during a run.
+#ifndef MT32EMU_DEBUG_SAMPLESTAMPS
+#define MT32EMU_DEBUG_SAMPLESTAMPS 0
+#endif
+
+// 0: No debug output for initialisation progress
+// 1: Debug output for initialisation progress
+#ifndef MT32EMU_MONITOR_INIT
+#define MT32EMU_MONITOR_INIT 0
+#endif
+
+// 0: No debug output for MIDI events
+// 1: Debug output for weird MIDI events
+#ifndef MT32EMU_MONITOR_MIDI
+#define MT32EMU_MONITOR_MIDI 0
+#endif
+
+// 0: No debug output for note on/off
+// 1: Basic debug output for note on/off
+// 2: Comprehensive debug output for note on/off
+#ifndef MT32EMU_MONITOR_INSTRUMENTS
+#define MT32EMU_MONITOR_INSTRUMENTS 0
+#endif
+
+// 0: No debug output for partial allocations
+// 1: Show partial stats when an allocation fails
+// 2: Show partial stats with every new poly
+// 3: Show individual partial allocations/deactivations
+#ifndef MT32EMU_MONITOR_PARTIALS
+#define MT32EMU_MONITOR_PARTIALS 0
+#endif
+
+// 0: No debug output for sysex
+// 1: Basic debug output for sysex
+#ifndef MT32EMU_MONITOR_SYSEX
+#define MT32EMU_MONITOR_SYSEX 0
+#endif
+
+// 0: No debug output for sysex writes to the timbre areas
+// 1: Debug output with the name and location of newly-written timbres
+// 2: Complete dump of timbre parameters for newly-written timbres
+#ifndef MT32EMU_MONITOR_TIMBRES
+#define MT32EMU_MONITOR_TIMBRES 0
+#endif
+
+// 0: No TVA/TVF-related debug output.
+// 1: Shows changes to TVA/TVF target, increment and phase.
+#ifndef MT32EMU_MONITOR_TVA
+#define MT32EMU_MONITOR_TVA 0
+#endif
+#ifndef MT32EMU_MONITOR_TVF
+#define MT32EMU_MONITOR_TVF 0
+#endif
+
+// Configuration
+
+// 0: Maximum speed at the cost of a bit lower emulation accuracy.
+// 1: Maximum achievable emulation accuracy.
+#ifndef MT32EMU_BOSS_REVERB_PRECISE_MODE
+#define MT32EMU_BOSS_REVERB_PRECISE_MODE 0
+#endif
+
+namespace MT32Emu {
+
+typedef Bit16s IntSample;
+typedef Bit32s IntSampleEx;
+typedef float FloatSample;
+
+enum PolyState {
+	POLY_Playing,
+	POLY_Held, // This marks keys that have been released on the keyboard, but are being held by the pedal
+	POLY_Releasing,
+	POLY_Inactive
+};
+
+enum ReverbMode {
+	REVERB_MODE_ROOM,
+	REVERB_MODE_HALL,
+	REVERB_MODE_PLATE,
+	REVERB_MODE_TAP_DELAY
+};
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_INTERNALS_H

--- a/vendor/munt/src/mmath.h
+++ b/vendor/munt/src/mmath.h
@@ -1,0 +1,68 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_MMATH_H
+#define MT32EMU_MMATH_H
+
+#include <cmath>
+
+namespace MT32Emu {
+
+// Mathematical constants
+const double DOUBLE_PI = 3.141592653589793;
+const double DOUBLE_LN_10 = 2.302585092994046;
+const float FLOAT_PI = 3.1415927f;
+const float FLOAT_2PI = 6.2831853f;
+const float FLOAT_LN_2 = 0.6931472f;
+const float FLOAT_LN_10 = 2.3025851f;
+
+static inline float POWF(float x, float y) {
+	return pow(x, y);
+}
+
+static inline float EXPF(float x) {
+	return exp(x);
+}
+
+static inline float EXP2F(float x) {
+#ifdef __APPLE__
+	// on OSX exp2f() is 1.59 times faster than "exp() and the multiplication with FLOAT_LN_2"
+	return exp2f(x);
+#else
+	return exp(FLOAT_LN_2 * x);
+#endif
+}
+
+static inline float EXP10F(float x) {
+	return exp(FLOAT_LN_10 * x);
+}
+
+static inline float LOGF(float x) {
+	return log(x);
+}
+
+static inline float LOG2F(float x) {
+	return log(x) / FLOAT_LN_2;
+}
+
+static inline float LOG10F(float x) {
+	return log10(x);
+}
+
+} // namespace MT32Emu
+
+#endif // #ifndef MT32EMU_MMATH_H

--- a/vendor/munt/src/mt32emu.h
+++ b/vendor/munt/src/mt32emu.h
@@ -1,0 +1,87 @@
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+ * Copyright (C) 2011-2022 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_MT32EMU_H
+#define MT32EMU_MT32EMU_H
+
+#include "config.h"
+
+/* API Configuration */
+
+/* 0: Use full-featured C++ API. Well suitable when the library is to be linked statically.
+ *    When the library is shared, ABI compatibility may be an issue. Therefore, it should
+ *    only be used within a project comprising of several modules to share the library code.
+ * 1: Use C-compatible API. Make the library looks as a regular C library with well-defined ABI.
+ *    This is also crucial when the library is to be linked with modules in a different
+ *    language, either statically or dynamically.
+ * 2: Use plugin-like API via C-interface wrapped in a C++ class. This is mainly intended
+ *    for a shared library being dynamically loaded in run-time. To get access to all the library
+ *    services, a client application only needs to bind with a single factory function.
+ * 3: Use optimised C++ API compatible with the plugin API (type 2). The facade class also wraps
+ *    the C functions but they are invoked directly. This enables the compiler to generate better
+ *    code for the library when linked statically yet being consistent with the plugin-like API.
+ */
+
+#ifdef MT32EMU_API_TYPE
+#  if MT32EMU_API_TYPE == 0 && (MT32EMU_EXPORTS_TYPE == 1 || MT32EMU_EXPORTS_TYPE == 2)
+#    error Incompatible setting MT32EMU_API_TYPE=0
+#  elif MT32EMU_API_TYPE == 1 && (MT32EMU_EXPORTS_TYPE == 0 || MT32EMU_EXPORTS_TYPE == 2)
+#    error Incompatible setting MT32EMU_API_TYPE=1
+#  elif MT32EMU_API_TYPE == 2 && (MT32EMU_EXPORTS_TYPE == 0)
+#    error Incompatible setting MT32EMU_API_TYPE=2
+#  elif MT32EMU_API_TYPE == 3 && (MT32EMU_EXPORTS_TYPE == 0 || MT32EMU_EXPORTS_TYPE == 2)
+#    error Incompatible setting MT32EMU_API_TYPE=3
+#  endif
+#else /* #ifdef MT32EMU_API_TYPE */
+#  if 0 < MT32EMU_EXPORTS_TYPE && MT32EMU_EXPORTS_TYPE < 3
+#    define MT32EMU_API_TYPE MT32EMU_EXPORTS_TYPE
+#  else
+#    define MT32EMU_API_TYPE 0
+#  endif
+#endif /* #ifdef MT32EMU_API_TYPE */
+
+#include "globals.h"
+
+#if !defined(__cplusplus) || MT32EMU_API_TYPE == 1
+
+#include "c_interface/c_interface.h"
+
+#elif MT32EMU_API_TYPE == 2 || MT32EMU_API_TYPE == 3
+
+#include "c_interface/cpp_interface.h"
+
+#else /* #if !defined(__cplusplus) || MT32EMU_API_TYPE == 1 */
+
+#include "Types.h"
+#include "File.h"
+#include "FileStream.h"
+#include "ROMInfo.h"
+#include "Synth.h"
+#include "MidiStreamParser.h"
+#include "SampleRateConverter.h"
+
+#if MT32EMU_RUNTIME_VERSION_CHECK == 1
+#include "VersionTagging.h"
+#endif
+
+#endif /* #if !defined(__cplusplus) || MT32EMU_API_TYPE == 1 */
+
+#if MT32EMU_RUNTIME_VERSION_CHECK == 2
+#include "VersionTagging.h"
+#endif
+
+#endif /* #ifndef MT32EMU_MT32EMU_H */

--- a/vendor/munt/src/mt32emu.pc.in
+++ b/vendor/munt/src/mt32emu.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @libmt32emu_DESCRIPTION_SUMMARY@
+URL: @libmt32emu_URL@
+Version: @libmt32emu_VERSION@
+Requires.private: @libmt32emu_PC_REQUIRES_PRIVATE@
+Libs: -L${libdir} -lmt32emu
+Cflags: -I${includedir}

--- a/vendor/munt/src/sha1/sha1.cpp
+++ b/vendor/munt/src/sha1/sha1.cpp
@@ -1,0 +1,185 @@
+/*
+ Copyright (c) 2011, Micael Hildenborg
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Micael Hildenborg nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY Micael Hildenborg ''AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL Micael Hildenborg BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ Contributors:
+ Gustav
+ Several members in the gamedev.se forum.
+ Gregory Petrosyan
+ */
+
+#include "sha1.h"
+
+namespace sha1
+{
+    namespace // local
+    {
+        // Rotate an integer value to left.
+        inline unsigned int rol(const unsigned int value,
+                const unsigned int steps)
+        {
+            return ((value << steps) | (value >> (32 - steps)));
+        }
+
+        // Sets the first 16 integers in the buffert to zero.
+        // Used for clearing the W buffert.
+        inline void clearWBuffert(unsigned int* buffert)
+        {
+            for (int pos = 16; --pos >= 0;)
+            {
+                buffert[pos] = 0;
+            }
+        }
+
+        void innerHash(unsigned int* result, unsigned int* w)
+        {
+            unsigned int a = result[0];
+            unsigned int b = result[1];
+            unsigned int c = result[2];
+            unsigned int d = result[3];
+            unsigned int e = result[4];
+
+            int round = 0;
+
+            #define sha1macro(func,val) \
+			{ \
+                const unsigned int t = rol(a, 5) + (func) + e + val + w[round]; \
+				e = d; \
+				d = c; \
+				c = rol(b, 30); \
+				b = a; \
+				a = t; \
+			}
+
+            while (round < 16)
+            {
+                sha1macro((b & c) | (~b & d), 0x5a827999)
+                ++round;
+            }
+            while (round < 20)
+            {
+                w[round] = rol((w[round - 3] ^ w[round - 8] ^ w[round - 14] ^ w[round - 16]), 1);
+                sha1macro((b & c) | (~b & d), 0x5a827999)
+                ++round;
+            }
+            while (round < 40)
+            {
+                w[round] = rol((w[round - 3] ^ w[round - 8] ^ w[round - 14] ^ w[round - 16]), 1);
+                sha1macro(b ^ c ^ d, 0x6ed9eba1)
+                ++round;
+            }
+            while (round < 60)
+            {
+                w[round] = rol((w[round - 3] ^ w[round - 8] ^ w[round - 14] ^ w[round - 16]), 1);
+                sha1macro((b & c) | (b & d) | (c & d), 0x8f1bbcdc)
+                ++round;
+            }
+            while (round < 80)
+            {
+                w[round] = rol((w[round - 3] ^ w[round - 8] ^ w[round - 14] ^ w[round - 16]), 1);
+                sha1macro(b ^ c ^ d, 0xca62c1d6)
+                ++round;
+            }
+
+            #undef sha1macro
+
+            result[0] += a;
+            result[1] += b;
+            result[2] += c;
+            result[3] += d;
+            result[4] += e;
+        }
+    } // namespace
+
+    void calc(const void* src, const int bytelength, unsigned char* hash)
+    {
+        // Init the result array.
+        unsigned int result[5] = { 0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0 };
+
+        // Cast the void src pointer to be the byte array we can work with.
+        const unsigned char* sarray = static_cast<const unsigned char*>(src);
+
+        // The reusable round buffer
+        unsigned int w[80];
+
+        // Loop through all complete 64byte blocks.
+        const int endOfFullBlocks = bytelength - 64;
+        int endCurrentBlock;
+        int currentBlock = 0;
+
+        while (currentBlock <= endOfFullBlocks)
+        {
+            endCurrentBlock = currentBlock + 64;
+
+            // Init the round buffer with the 64 byte block data.
+            for (int roundPos = 0; currentBlock < endCurrentBlock; currentBlock += 4)
+            {
+                // This line will swap endian on big endian and keep endian on little endian.
+                w[roundPos++] = static_cast<unsigned int>(sarray[currentBlock + 3])
+                        | (static_cast<unsigned int>(sarray[currentBlock + 2]) << 8)
+                        | (static_cast<unsigned int>(sarray[currentBlock + 1]) << 16)
+                        | (static_cast<unsigned int>(sarray[currentBlock]) << 24);
+            }
+            innerHash(result, w);
+        }
+
+        // Handle the last and not full 64 byte block if existing.
+        endCurrentBlock = bytelength - currentBlock;
+        clearWBuffert(w);
+        int lastBlockBytes = 0;
+        for (;lastBlockBytes < endCurrentBlock; ++lastBlockBytes)
+        {
+            w[lastBlockBytes >> 2] |= static_cast<unsigned int>(sarray[lastBlockBytes + currentBlock]) << ((3 - (lastBlockBytes & 3)) << 3);
+        }
+        w[lastBlockBytes >> 2] |= 0x80 << ((3 - (lastBlockBytes & 3)) << 3);
+        if (endCurrentBlock >= 56)
+        {
+            innerHash(result, w);
+            clearWBuffert(w);
+        }
+        w[15] = bytelength << 3;
+        innerHash(result, w);
+
+        // Store hash in result pointer, and make sure we get in in the correct order on both endian models.
+        for (int hashByte = 20; --hashByte >= 0;)
+        {
+            hash[hashByte] = (result[hashByte >> 2] >> (((3 - hashByte) & 0x3) << 3)) & 0xff;
+        }
+    }
+
+    void toHexString(const unsigned char* hash, char* hexstring)
+    {
+        const char hexDigits[] = { "0123456789abcdef" };
+
+        for (int hashByte = 20; --hashByte >= 0;)
+        {
+            hexstring[hashByte << 1] = hexDigits[(hash[hashByte] >> 4) & 0xf];
+            hexstring[(hashByte << 1) + 1] = hexDigits[hash[hashByte] & 0xf];
+        }
+        hexstring[40] = 0;
+    }
+} // namespace sha1

--- a/vendor/munt/src/sha1/sha1.h
+++ b/vendor/munt/src/sha1/sha1.h
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2011, Micael Hildenborg
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Micael Hildenborg nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY Micael Hildenborg ''AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL Micael Hildenborg BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SHA1_DEFINED
+#define SHA1_DEFINED
+
+namespace sha1
+{
+
+    /**
+     @param src points to any kind of data to be hashed.
+     @param bytelength the number of bytes to hash from the src pointer.
+     @param hash should point to a buffer of at least 20 bytes of size for storing the sha1 result in.
+     */
+    void calc(const void* src, const int bytelength, unsigned char* hash);
+
+    /**
+     @param hash is 20 bytes of sha1 hash. This is the same data that is the result from the calc function.
+     @param hexstring should point to a buffer of at least 41 bytes of size for storing the hexadecimal representation of the hash. A zero will be written at position 40, so the buffer will be a valid zero ended string.
+     */
+    void toHexString(const unsigned char* hash, char* hexstring);
+
+} // namespace sha1
+
+#endif // SHA1_DEFINED

--- a/vendor/munt/src/srchelper/InternalResampler.cpp
+++ b/vendor/munt/src/srchelper/InternalResampler.cpp
@@ -1,0 +1,74 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "InternalResampler.h"
+
+#include "srctools/include/SincResampler.h"
+#include "srctools/include/ResamplerModel.h"
+
+#include "../Synth.h"
+
+using namespace SRCTools;
+
+namespace MT32Emu {
+
+class SynthWrapper : public FloatSampleProvider {
+	Synth &synth;
+
+public:
+	SynthWrapper(Synth &useSynth) : synth(useSynth)
+	{}
+
+	void getOutputSamples(FloatSample *outBuffer, unsigned int size) {
+		synth.render(outBuffer, size);
+	}
+};
+
+static FloatSampleProvider &createModel(Synth &synth, SRCTools::FloatSampleProvider &synthSource, double targetSampleRate, SamplerateConversionQuality quality) {
+	static const double MAX_AUDIBLE_FREQUENCY = 20000.0;
+
+	const double sourceSampleRate = synth.getStereoOutputSampleRate();
+	if (quality != SamplerateConversionQuality_FASTEST) {
+		const bool oversampledMode = synth.getStereoOutputSampleRate() == Synth::getStereoOutputSampleRate(AnalogOutputMode_OVERSAMPLED);
+		// Oversampled input allows to bypass IIR interpolation stage and, in some cases, IIR decimation stage
+		if (oversampledMode && (0.5 * sourceSampleRate) <= targetSampleRate) {
+			// NOTE: In the oversampled mode, the transition band starts at 20kHz and ends at 28kHz
+			double passband = MAX_AUDIBLE_FREQUENCY;
+			double stopband = 0.5 * sourceSampleRate + MAX_AUDIBLE_FREQUENCY;
+			ResamplerStage &resamplerStage = *SincResampler::createSincResampler(sourceSampleRate, targetSampleRate, passband, stopband, ResamplerModel::DEFAULT_DB_SNR, ResamplerModel::DEFAULT_WINDOWED_SINC_MAX_UPSAMPLE_FACTOR);
+			return ResamplerModel::createResamplerModel(synthSource, resamplerStage);
+		}
+	}
+	return ResamplerModel::createResamplerModel(synthSource, sourceSampleRate, targetSampleRate, static_cast<ResamplerModel::Quality>(quality));
+}
+
+} // namespace MT32Emu
+
+using namespace MT32Emu;
+
+InternalResampler::InternalResampler(Synth &synth, double targetSampleRate, SamplerateConversionQuality quality) :
+	synthSource(*new SynthWrapper(synth)),
+	model(createModel(synth, synthSource, targetSampleRate, quality))
+{}
+
+InternalResampler::~InternalResampler() {
+	ResamplerModel::freeResamplerModel(model, synthSource);
+	delete &synthSource;
+}
+
+void InternalResampler::getOutputSamples(float *buffer, unsigned int length) {
+	model.getOutputSamples(buffer, length);
+}

--- a/vendor/munt/src/srchelper/InternalResampler.h
+++ b/vendor/munt/src/srchelper/InternalResampler.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MT32EMU_INTERNAL_RESAMPLER_H
+#define MT32EMU_INTERNAL_RESAMPLER_H
+
+#include "../Enumerations.h"
+
+#include "srctools/include/FloatSampleProvider.h"
+
+namespace MT32Emu {
+
+class Synth;
+
+class InternalResampler {
+public:
+	InternalResampler(Synth &synth, double targetSampleRate, SamplerateConversionQuality quality);
+	~InternalResampler();
+
+	void getOutputSamples(float *buffer, unsigned int length);
+
+private:
+	SRCTools::FloatSampleProvider &synthSource;
+	SRCTools::FloatSampleProvider &model;
+};
+
+} // namespace MT32Emu
+
+#endif // MT32EMU_INTERNAL_RESAMPLER_H

--- a/vendor/munt/src/srchelper/srctools/include/FIRResampler.h
+++ b/vendor/munt/src/srchelper/srctools/include/FIRResampler.h
@@ -1,0 +1,67 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_FIR_RESAMPLER_H
+#define SRCTOOLS_FIR_RESAMPLER_H
+
+#include "ResamplerStage.h"
+
+namespace SRCTools {
+
+typedef FloatSample FIRCoefficient;
+
+static const unsigned int FIR_INTERPOLATOR_CHANNEL_COUNT = 2;
+
+class FIRResampler : public ResamplerStage {
+public:
+	FIRResampler(const unsigned int upsampleFactor, const double downsampleFactor, const FIRCoefficient kernel[], const unsigned int kernelLength);
+	~FIRResampler();
+
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
+	unsigned int estimateInLength(const unsigned int outLength) const;
+
+private:
+	const struct Constants {
+		// Filter coefficients
+		const FIRCoefficient *taps;
+		// Indicates whether to interpolate filter taps
+		bool usePhaseInterpolation;
+		// Size of array of filter coefficients
+		unsigned int numberOfTaps;
+		// Upsampling factor
+		unsigned int numberOfPhases;
+		// Downsampling factor
+		double phaseIncrement;
+		// Index of last delay line element, generally greater than numberOfTaps to form a proper binary mask
+		unsigned int delayLineMask;
+		// Delay line
+		FloatSample(*ringBuffer)[FIR_INTERPOLATOR_CHANNEL_COUNT];
+
+		Constants(const unsigned int upsampleFactor, const double downsampleFactor, const FIRCoefficient kernel[], const unsigned int kernelLength);
+	} constants;
+	// Index of current sample in delay line
+	unsigned int ringBufferPosition;
+	// Current phase
+	double phase;
+
+	bool needNextInSample() const;
+	void addInSamples(const FloatSample *&inSamples);
+	void getOutSamplesStereo(FloatSample *&outSamples);
+}; // class FIRResampler
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_FIR_RESAMPLER_H

--- a/vendor/munt/src/srchelper/srctools/include/FloatSampleProvider.h
+++ b/vendor/munt/src/srchelper/srctools/include/FloatSampleProvider.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_FLOAT_SAMPLE_PROVIDER_H
+#define SRCTOOLS_FLOAT_SAMPLE_PROVIDER_H
+
+namespace SRCTools {
+
+typedef float FloatSample;
+
+/** Interface defines an abstract source of samples. It can either define a single channel stream or a stream with interleaved channels. */
+class FloatSampleProvider {
+public:
+	virtual ~FloatSampleProvider() {}
+
+	virtual void getOutputSamples(FloatSample *outBuffer, unsigned int size) = 0;
+};
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_FLOAT_SAMPLE_PROVIDER_H

--- a/vendor/munt/src/srchelper/srctools/include/IIR2xResampler.h
+++ b/vendor/munt/src/srchelper/srctools/include/IIR2xResampler.h
@@ -1,0 +1,100 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_IIR_2X_RESAMPLER_H
+#define SRCTOOLS_IIR_2X_RESAMPLER_H
+
+#include "ResamplerStage.h"
+
+namespace SRCTools {
+
+static const unsigned int IIR_RESAMPER_CHANNEL_COUNT = 2;
+static const unsigned int IIR_SECTION_ORDER = 2;
+
+typedef FloatSample IIRCoefficient;
+typedef FloatSample BufferedSample;
+
+typedef BufferedSample SectionBuffer[IIR_SECTION_ORDER];
+
+// Non-trivial coefficients of a 2nd-order section of a parallel bank
+// (zero-order numerator coefficient is always zero, zero-order denominator coefficient is always unity)
+struct IIRSection {
+	IIRCoefficient num1;
+	IIRCoefficient num2;
+	IIRCoefficient den1;
+	IIRCoefficient den2;
+};
+
+class IIRResampler : public ResamplerStage {
+public:
+	enum Quality {
+		// Used when providing custom IIR filter coefficients.
+		CUSTOM,
+		// Use fast elliptic filter with symmetric ripple: N=8, Ap=As=-99 dB, fp=0.125, fs = 0.25 (in terms of sample rate)
+		FAST,
+		// Use average elliptic filter with symmetric ripple: N=12, Ap=As=-106 dB, fp=0.193, fs = 0.25 (in terms of sample rate)
+		GOOD,
+		// Use sharp elliptic filter with symmetric ripple: N=18, Ap=As=-106 dB, fp=0.238, fs = 0.25 (in terms of sample rate)
+		BEST
+	};
+
+	// Returns the retained fraction of the passband for the given standard quality value
+	static double getPassbandFractionForQuality(Quality quality);
+
+protected:
+	explicit IIRResampler(const Quality quality);
+	explicit IIRResampler(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]);
+	~IIRResampler();
+
+	const struct Constants {
+		// Coefficient of the 0-order FIR part
+		IIRCoefficient fir;
+		// 2nd-order sections that comprise a parallel bank
+		const IIRSection *sections;
+		// Number of 2nd-order sections
+		unsigned int sectionsCount;
+		// Delay line per channel per section
+		SectionBuffer *buffer;
+
+		Constants(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[], const Quality quality);
+	} constants;
+}; // class IIRResampler
+
+class IIR2xInterpolator : public IIRResampler {
+public:
+	explicit IIR2xInterpolator(const Quality quality);
+	explicit IIR2xInterpolator(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]);
+
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
+	unsigned int estimateInLength(const unsigned int outLength) const;
+
+private:
+	FloatSample lastInputSamples[IIR_RESAMPER_CHANNEL_COUNT];
+	unsigned int phase;
+};
+
+class IIR2xDecimator : public IIRResampler {
+public:
+	explicit IIR2xDecimator(const Quality quality);
+	explicit IIR2xDecimator(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]);
+
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
+	unsigned int estimateInLength(const unsigned int outLength) const;
+};
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_IIR_2X_RESAMPLER_H

--- a/vendor/munt/src/srchelper/srctools/include/LinearResampler.h
+++ b/vendor/munt/src/srchelper/srctools/include/LinearResampler.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_LINEAR_RESAMPLER_H
+#define SRCTOOLS_LINEAR_RESAMPLER_H
+
+#include "ResamplerStage.h"
+
+namespace SRCTools {
+
+static const unsigned int LINEAR_RESAMPER_CHANNEL_COUNT = 2;
+
+class LinearResampler : public ResamplerStage {
+public:
+	LinearResampler(double sourceSampleRate, double targetSampleRate);
+	~LinearResampler() {}
+
+	unsigned int estimateInLength(const unsigned int outLength) const;
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
+
+private:
+	const double inputToOutputRatio;
+	double position;
+	FloatSample lastInputSamples[LINEAR_RESAMPER_CHANNEL_COUNT];
+};
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_LINEAR_RESAMPLER_H

--- a/vendor/munt/src/srchelper/srctools/include/ResamplerModel.h
+++ b/vendor/munt/src/srchelper/srctools/include/ResamplerModel.h
@@ -1,0 +1,63 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_RESAMPLER_MODEL_H
+#define SRCTOOLS_RESAMPLER_MODEL_H
+
+#include "FloatSampleProvider.h"
+
+namespace SRCTools {
+
+class ResamplerStage;
+
+/** Model consists of one or more ResampleStage instances connected in a cascade. */
+namespace ResamplerModel {
+
+// Seems to be a good choice for 16-bit integer samples.
+static const double DEFAULT_DB_SNR = 106;
+
+// When using linear interpolation, oversampling factor necessary to achieve the DEFAULT_DB_SNR is about 256.
+// This figure is the upper estimation, and it can be found by analysing the frequency response of the linear interpolator.
+// When less SNR is desired, this value should also decrease in accordance.
+static const unsigned int DEFAULT_WINDOWED_SINC_MAX_DOWNSAMPLE_FACTOR = 256;
+
+// In the default resampler model, the input to the windowed sinc filter is always at least 2x oversampled during upsampling,
+// so oversampling factor of 128 should be sufficient to achieve the DEFAULT_DB_SNR with linear interpolation.
+static const unsigned int DEFAULT_WINDOWED_SINC_MAX_UPSAMPLE_FACTOR = DEFAULT_WINDOWED_SINC_MAX_DOWNSAMPLE_FACTOR / 2;
+
+
+enum Quality {
+	// Use when the speed is more important than the audio quality.
+	FASTEST,
+	// Use FAST quality setting of the IIR stage (50% of passband retained).
+	FAST,
+	// Use GOOD quality setting of the IIR stage (77% of passband retained).
+	GOOD,
+	// Use BEST quality setting of the IIR stage (95% of passband retained).
+	BEST
+};
+
+FloatSampleProvider &createResamplerModel(FloatSampleProvider &source, double sourceSampleRate, double targetSampleRate, Quality quality);
+FloatSampleProvider &createResamplerModel(FloatSampleProvider &source, ResamplerStage **stages, unsigned int stageCount);
+FloatSampleProvider &createResamplerModel(FloatSampleProvider &source, ResamplerStage &stage);
+
+void freeResamplerModel(FloatSampleProvider &model, FloatSampleProvider &source);
+
+} // namespace ResamplerModel
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_RESAMPLER_MODEL_H

--- a/vendor/munt/src/srchelper/srctools/include/ResamplerStage.h
+++ b/vendor/munt/src/srchelper/srctools/include/ResamplerStage.h
@@ -1,0 +1,38 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_RESAMPLER_STAGE_H
+#define SRCTOOLS_RESAMPLER_STAGE_H
+
+#include "FloatSampleProvider.h"
+
+namespace SRCTools {
+
+/** Interface defines an abstract source of samples. It can either define a single channel stream or a stream with interleaved channels. */
+class ResamplerStage {
+public:
+	virtual ~ResamplerStage() {}
+
+	/** Returns a lower estimation of required number of input samples to produce the specified number of output samples. */
+	virtual unsigned int estimateInLength(const unsigned int outLength) const = 0;
+
+	/** Generates output samples. The arguments are adjusted in accordance with the number of samples processed. */
+	virtual void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) = 0;
+};
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_RESAMPLER_STAGE_H

--- a/vendor/munt/src/srchelper/srctools/include/SincResampler.h
+++ b/vendor/munt/src/srchelper/srctools/include/SincResampler.h
@@ -1,0 +1,46 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRCTOOLS_SINC_RESAMPLER_H
+#define SRCTOOLS_SINC_RESAMPLER_H
+
+#include "FIRResampler.h"
+
+namespace SRCTools {
+
+class ResamplerStage;
+
+namespace SincResampler {
+
+	ResamplerStage *createSincResampler(const double inputFrequency, const double outputFrequency, const double passbandFrequency, const double stopbandFrequency, const double dbSNR, const unsigned int maxUpsampleFactor);
+
+	namespace Utils {
+		void computeResampleFactors(unsigned int &upsampleFactor, double &downsampleFactor, const double inputFrequency, const double outputFrequency, const unsigned int maxUpsampleFactor);
+		unsigned int greatestCommonDivisor(unsigned int a, unsigned int b);
+	}
+
+	namespace KaizerWindow {
+		double estimateBeta(double dbRipple);
+		unsigned int estimateOrder(double dbRipple, double fp, double fs);
+		double bessel(const double x);
+		void windowedSinc(FIRCoefficient kernel[], const unsigned int order, const double fc, const double beta, const double amp);
+	}
+
+} // namespace SincResampler
+
+} // namespace SRCTools
+
+#endif // SRCTOOLS_SINC_RESAMPLER_H

--- a/vendor/munt/src/srchelper/srctools/src/FIRResampler.cpp
+++ b/vendor/munt/src/srchelper/srctools/src/FIRResampler.cpp
@@ -1,0 +1,107 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <cstring>
+
+#include "../include/FIRResampler.h"
+
+using namespace SRCTools;
+
+FIRResampler::Constants::Constants(const unsigned int upsampleFactor, const double downsampleFactor, const FIRCoefficient kernel[], const unsigned int kernelLength) {
+	usePhaseInterpolation = downsampleFactor != floor(downsampleFactor);
+	FIRCoefficient *kernelCopy = new FIRCoefficient[kernelLength];
+	memcpy(kernelCopy, kernel, kernelLength * sizeof(FIRCoefficient));
+	taps = kernelCopy;
+	numberOfTaps = kernelLength;
+	numberOfPhases = upsampleFactor;
+	phaseIncrement = downsampleFactor;
+	unsigned int minDelayLineLength = static_cast<unsigned int>(ceil(double(kernelLength) / upsampleFactor));
+	unsigned int delayLineLength = 2;
+	while (delayLineLength < minDelayLineLength) delayLineLength <<= 1;
+	delayLineMask = delayLineLength - 1;
+	ringBuffer = new FloatSample[delayLineLength][FIR_INTERPOLATOR_CHANNEL_COUNT];
+	FloatSample *s = *ringBuffer;
+	FloatSample *e = ringBuffer[delayLineLength];
+	while (s < e) *(s++) = 0;
+}
+
+FIRResampler::FIRResampler(const unsigned int upsampleFactor, const double downsampleFactor, const FIRCoefficient kernel[], const unsigned int kernelLength) :
+	constants(upsampleFactor, downsampleFactor, kernel, kernelLength),
+	ringBufferPosition(0),
+	phase(constants.numberOfPhases)
+{}
+
+FIRResampler::~FIRResampler() {
+	delete[] constants.ringBuffer;
+	delete[] constants.taps;
+}
+
+void FIRResampler::process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) {
+	while (outLength > 0) {
+		while (needNextInSample()) {
+			if (inLength == 0) return;
+			addInSamples(inSamples);
+			--inLength;
+		}
+		getOutSamplesStereo(outSamples);
+		--outLength;
+	}
+}
+
+unsigned int FIRResampler::estimateInLength(const unsigned int outLength) const {
+	return static_cast<unsigned int>((outLength * constants.phaseIncrement + phase) / constants.numberOfPhases);
+}
+
+bool FIRResampler::needNextInSample() const {
+	return constants.numberOfPhases <= phase;
+}
+
+void FIRResampler::addInSamples(const FloatSample *&inSamples) {
+	ringBufferPosition = (ringBufferPosition - 1) & constants.delayLineMask;
+	for (unsigned int i = 0; i < FIR_INTERPOLATOR_CHANNEL_COUNT; i++) {
+		constants.ringBuffer[ringBufferPosition][i] = *(inSamples++);
+	}
+	phase -= constants.numberOfPhases;
+}
+
+// Optimised for processing stereo interleaved streams
+void FIRResampler::getOutSamplesStereo(FloatSample *&outSamples) {
+	FloatSample leftSample = 0.0;
+	FloatSample rightSample = 0.0;
+	unsigned int delaySampleIx = ringBufferPosition;
+	if (constants.usePhaseInterpolation) {
+		double phaseFraction = phase - floor(phase);
+		unsigned int maxTapIx = phaseFraction == 0 ? constants.numberOfTaps : constants.numberOfTaps - 1;
+		for (unsigned int tapIx = static_cast<unsigned int>(phase); tapIx < maxTapIx; tapIx += constants.numberOfPhases) {
+			FIRCoefficient tap = FIRCoefficient(constants.taps[tapIx] + (constants.taps[tapIx + 1] - constants.taps[tapIx]) * phaseFraction);
+			leftSample += tap * constants.ringBuffer[delaySampleIx][0];
+			rightSample += tap * constants.ringBuffer[delaySampleIx][1];
+			delaySampleIx = (delaySampleIx + 1) & constants.delayLineMask;
+		}
+	} else {
+		// Optimised for rational resampling ratios when phase is always integer
+		for (unsigned int tapIx = static_cast<unsigned int>(phase); tapIx < constants.numberOfTaps; tapIx += constants.numberOfPhases) {
+			FIRCoefficient tap = constants.taps[tapIx];
+			leftSample += tap * constants.ringBuffer[delaySampleIx][0];
+			rightSample += tap * constants.ringBuffer[delaySampleIx][1];
+			delaySampleIx = (delaySampleIx + 1) & constants.delayLineMask;
+		}
+	}
+	*(outSamples++) = leftSample;
+	*(outSamples++) = rightSample;
+	phase += constants.phaseIncrement;
+}

--- a/vendor/munt/src/srchelper/srctools/src/IIR2xResampler.cpp
+++ b/vendor/munt/src/srchelper/srctools/src/IIR2xResampler.cpp
@@ -1,0 +1,229 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstddef>
+
+#include "../include/IIR2xResampler.h"
+
+namespace SRCTools {
+
+	// Avoid denormals degrading performance, using biased input
+	static const BufferedSample BIAS = 1e-20f;
+
+	// Sharp elliptic filter with symmetric ripple: N=18, Ap=As=-106 dB, fp=0.238, fs = 0.25 (in terms of sample rate)
+	static const IIRCoefficient FIR_BEST = 0.0014313792470984f;
+	static const IIRSection SECTIONS_BEST[] = {
+		{ 2.85800356692148000f,-0.2607342682253230f,-0.602478421807085f, 0.109823442522145f },
+		{ -4.39519408383016000f, 1.4651975326003500f,-0.533817668127954f, 0.226045921792036f },
+		{ 0.86638550740991800f,-2.1053851417898500f,-0.429134968401065f, 0.403512574222174f },
+		{ 1.67161485530774000f, 0.7963595880494520f,-0.324989203363446f, 0.580756666711889f },
+		{ -1.19962759276471000f, 0.5873595178851540f,-0.241486447489019f, 0.724264899930934f },
+		{ 0.01631779946479250f,-0.6282334739461620f,-0.182766025706656f, 0.827774001858882f },
+		{ 0.28404415859352400f, 0.1038619997715160f,-0.145276649558926f, 0.898510501923554f },
+		{ -0.08105788424234910f, 0.0781551578108934f,-0.123965846623366f, 0.947105257601873f },
+		{ -0.00872608905948005f,-0.0222098231712466f,-0.115056854360748f, 0.983542001125711f }
+	};
+
+	// Average elliptic filter with symmetric ripple: N=12, Ap=As=-106 dB, fp=0.193, fs = 0.25 (in terms of sample rate)
+	static const IIRCoefficient FIR_GOOD = 0.000891054570268146f;
+	static const IIRSection SECTIONS_GOOD[] = {
+		{ 2.2650157226725700f,-0.4034180565140230f,-0.750061486095301f, 0.157801404511953f },
+		{ -3.2788261989161700f, 1.3952152147542600f,-0.705854270206788f, 0.265564985645774f },
+		{ 0.4397975114813240f,-1.3957634748753100f,-0.639718853965265f, 0.435324134360315f },
+		{ 0.9827040216680520f, 0.1837182774040940f,-0.578569965618418f, 0.615205557837542f },
+		{ -0.3759752818621670f, 0.3266073609399490f,-0.540913588637109f, 0.778264420176574f },
+		{ -0.0253548089519618f,-0.0925779221603846f,-0.537704370375240f, 0.925800083252964f }
+	};
+
+	// Fast elliptic filter with symmetric ripple: N=8, Ap=As=-99 dB, fp=0.125, fs = 0.25 (in terms of sample rate)
+	static const IIRCoefficient FIR_FAST = 0.000882837778745889f;
+	static const IIRSection SECTIONS_FAST[] = {
+		{ 1.215377077431620f,-0.35864455030878000f,-0.972220718789242f, 0.252934735930620f },
+		{ -1.525654419254140f, 0.86784918631245500f,-0.977713689358124f, 0.376580616703668f },
+		{ 0.136094441564220f,-0.50414116798010400f,-1.007004471865290f, 0.584048854845331f },
+		{ 0.180604082285806f,-0.00467624342403851f,-1.093486919012100f, 0.844904524843996f }
+	};
+
+	static inline BufferedSample calcNumerator(const IIRSection &section, const BufferedSample buffer1, const BufferedSample buffer2) {
+		return section.num1 * buffer1 + section.num2 * buffer2;
+	}
+
+	static inline BufferedSample calcDenominator(const IIRSection &section, const BufferedSample input, const BufferedSample buffer1, const BufferedSample buffer2) {
+		return input - section.den1 * buffer1 - section.den2 * buffer2;
+	}
+
+} // namespace SRCTools
+
+using namespace SRCTools;
+
+double IIRResampler::getPassbandFractionForQuality(Quality quality) {
+	switch (quality) {
+	case FAST:
+		return 0.5;
+	case GOOD:
+		return 0.7708;
+	case BEST:
+		return 0.9524;
+	default:
+		return 0;
+	}
+}
+
+IIRResampler::Constants::Constants(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[], const Quality quality) {
+	if (quality == CUSTOM) {
+		sectionsCount = useSectionsCount;
+		fir = useFIR;
+		sections = useSections;
+	} else {
+		unsigned int sectionsSize;
+		switch (quality) {
+		case FAST:
+			fir = FIR_FAST;
+			sections = SECTIONS_FAST;
+			sectionsSize = sizeof(SECTIONS_FAST);
+			break;
+		case GOOD:
+			fir = FIR_GOOD;
+			sections = SECTIONS_GOOD;
+			sectionsSize = sizeof(SECTIONS_GOOD);
+			break;
+		case BEST:
+			fir = FIR_BEST;
+			sections = SECTIONS_BEST;
+			sectionsSize = sizeof(SECTIONS_BEST);
+			break;
+		default:
+			sectionsSize = 0;
+			break;
+		}
+		sectionsCount = (sectionsSize / sizeof(IIRSection));
+	}
+	const unsigned int delayLineSize = IIR_RESAMPER_CHANNEL_COUNT * sectionsCount;
+	buffer = new SectionBuffer[delayLineSize];
+	BufferedSample *s = buffer[0];
+	BufferedSample *e = buffer[delayLineSize];
+	while (s < e) *(s++) = 0;
+}
+
+IIRResampler::IIRResampler(const Quality quality) :
+	constants(0, 0.0f, NULL, quality)
+{}
+
+IIRResampler::IIRResampler(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]) :
+	constants(useSectionsCount, useFIR, useSections, IIRResampler::CUSTOM)
+{}
+
+IIRResampler::~IIRResampler() {
+	delete[] constants.buffer;
+}
+
+IIR2xInterpolator::IIR2xInterpolator(const Quality quality) :
+	IIRResampler(quality),
+	phase(1)
+{
+	for (unsigned int chIx = 0; chIx < IIR_RESAMPER_CHANNEL_COUNT; ++chIx) {
+		lastInputSamples[chIx] = 0;
+	}
+}
+
+IIR2xInterpolator::IIR2xInterpolator(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]) :
+	IIRResampler(useSectionsCount, useFIR, useSections),
+	phase(1)
+{
+	for (unsigned int chIx = 0; chIx < IIR_RESAMPER_CHANNEL_COUNT; ++chIx) {
+		lastInputSamples[chIx] = 0;
+	}
+}
+
+void IIR2xInterpolator::process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) {
+	static const IIRCoefficient INTERPOLATOR_AMP = 2.0;
+
+	while (outLength > 0 && inLength > 0) {
+		SectionBuffer *bufferp = constants.buffer;
+		for (unsigned int chIx = 0; chIx < IIR_RESAMPER_CHANNEL_COUNT; ++chIx) {
+			const FloatSample lastInputSample = lastInputSamples[chIx];
+			const FloatSample inSample = inSamples[chIx];
+			BufferedSample tmpOut = phase == 0 ? 0 : inSample * constants.fir;
+			for (unsigned int i = 0; i < constants.sectionsCount; ++i) {
+				const IIRSection &section = constants.sections[i];
+				SectionBuffer &buffer = *bufferp;
+				// For 2x interpolation, calculation of the numerator reduces to a single multiplication depending on the phase.
+				if (phase == 0) {
+					const BufferedSample numOutSample = section.num1 * lastInputSample;
+					const BufferedSample denOutSample = calcDenominator(section, BIAS + numOutSample, buffer[0], buffer[1]);
+					buffer[1] = denOutSample;
+					tmpOut += denOutSample;
+				} else {
+					const BufferedSample numOutSample = section.num2 * lastInputSample;
+					const BufferedSample denOutSample = calcDenominator(section, BIAS + numOutSample, buffer[1], buffer[0]);
+					buffer[0] = denOutSample;
+					tmpOut += denOutSample;
+				}
+				bufferp++;
+			}
+			*(outSamples++) = FloatSample(INTERPOLATOR_AMP * tmpOut);
+			if (phase > 0) {
+				lastInputSamples[chIx] = inSample;
+			}
+		}
+		outLength--;
+		if (phase > 0) {
+			inSamples += IIR_RESAMPER_CHANNEL_COUNT;
+			inLength--;
+			phase = 0;
+		} else {
+			phase = 1;
+		}
+	}
+}
+
+unsigned int IIR2xInterpolator::estimateInLength(const unsigned int outLength) const {
+	return outLength >> 1;
+}
+
+IIR2xDecimator::IIR2xDecimator(const Quality quality) :
+	IIRResampler(quality)
+{}
+
+IIR2xDecimator::IIR2xDecimator(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]) :
+	IIRResampler(useSectionsCount, useFIR, useSections)
+{}
+
+void IIR2xDecimator::process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) {
+	while (outLength > 0 && inLength > 1) {
+		SectionBuffer *bufferp = constants.buffer;
+		for (unsigned int chIx = 0; chIx < IIR_RESAMPER_CHANNEL_COUNT; ++chIx) {
+			BufferedSample tmpOut = inSamples[chIx] * constants.fir;
+			for (unsigned int i = 0; i < constants.sectionsCount; ++i) {
+				const IIRSection &section = constants.sections[i];
+				SectionBuffer &buffer = *bufferp;
+				// For 2x decimation, calculation of the numerator is not performed for odd output samples which are to be omitted.
+				tmpOut += calcNumerator(section, buffer[0], buffer[1]);
+				buffer[1] = calcDenominator(section, BIAS + inSamples[chIx], buffer[0], buffer[1]);
+				buffer[0] = calcDenominator(section, BIAS + inSamples[chIx + IIR_RESAMPER_CHANNEL_COUNT], buffer[1], buffer[0]);
+				bufferp++;
+			}
+			*(outSamples++) = FloatSample(tmpOut);
+		}
+		outLength--;
+		inLength -= 2;
+		inSamples += 2 * IIR_RESAMPER_CHANNEL_COUNT;
+	}
+}
+
+unsigned int IIR2xDecimator::estimateInLength(const unsigned int outLength) const {
+	return outLength << 1;
+}

--- a/vendor/munt/src/srchelper/srctools/src/LinearResampler.cpp
+++ b/vendor/munt/src/srchelper/srctools/src/LinearResampler.cpp
@@ -1,0 +1,47 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "../include/LinearResampler.h"
+
+using namespace SRCTools;
+
+LinearResampler::LinearResampler(double sourceSampleRate, double targetSampleRate) :
+	inputToOutputRatio(sourceSampleRate / targetSampleRate),
+	position(1.0) // Preload delay line which effectively makes resampler zero phase
+{}
+
+void LinearResampler::process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) {
+	if (inLength == 0) return;
+	while (outLength > 0) {
+		while (1.0 <= position) {
+			position--;
+			inLength--;
+			for (unsigned int chIx = 0; chIx < LINEAR_RESAMPER_CHANNEL_COUNT; ++chIx) {
+				lastInputSamples[chIx] = *(inSamples++);
+			}
+			if (inLength == 0) return;
+		}
+		for (unsigned int chIx = 0; chIx < LINEAR_RESAMPER_CHANNEL_COUNT; chIx++) {
+			*(outSamples++) = FloatSample(lastInputSamples[chIx] + position * (inSamples[chIx] - lastInputSamples[chIx]));
+		}
+		outLength--;
+		position += inputToOutputRatio;
+	}
+}
+
+unsigned int LinearResampler::estimateInLength(const unsigned int outLength) const {
+	return static_cast<unsigned int>(outLength * inputToOutputRatio);
+}

--- a/vendor/munt/src/srchelper/srctools/src/ResamplerModel.cpp
+++ b/vendor/munt/src/srchelper/srctools/src/ResamplerModel.cpp
@@ -1,0 +1,153 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <cstddef>
+
+#include "../include/ResamplerModel.h"
+
+#include "../include/ResamplerStage.h"
+#include "../include/SincResampler.h"
+#include "../include/IIR2xResampler.h"
+#include "../include/LinearResampler.h"
+
+namespace SRCTools {
+
+namespace ResamplerModel {
+
+static const unsigned int CHANNEL_COUNT = 2;
+static const unsigned int MAX_SAMPLES_PER_RUN = 4096;
+
+class CascadeStage : public FloatSampleProvider {
+friend void freeResamplerModel(FloatSampleProvider &model, FloatSampleProvider &source);
+public:
+	CascadeStage(FloatSampleProvider &source, ResamplerStage &resamplerStage);
+
+	void getOutputSamples(FloatSample *outBuffer, unsigned int size);
+
+protected:
+	ResamplerStage &resamplerStage;
+
+private:
+	FloatSampleProvider &source;
+	FloatSample buffer[CHANNEL_COUNT * MAX_SAMPLES_PER_RUN];
+	const FloatSample *bufferPtr;
+	unsigned int size;
+};
+
+class InternalResamplerCascadeStage : public CascadeStage {
+public:
+	InternalResamplerCascadeStage(FloatSampleProvider &useSource, ResamplerStage &useResamplerStage) :
+		CascadeStage(useSource, useResamplerStage)
+	{}
+
+	~InternalResamplerCascadeStage() {
+		delete &resamplerStage;
+	}
+};
+
+} // namespace ResamplerModel
+
+} // namespace SRCTools
+
+using namespace SRCTools;
+
+FloatSampleProvider &ResamplerModel::createResamplerModel(FloatSampleProvider &source, double sourceSampleRate, double targetSampleRate, Quality quality) {
+	if (sourceSampleRate == targetSampleRate) {
+		return source;
+	}
+	if (quality == FASTEST) {
+		return *new InternalResamplerCascadeStage(source, *new LinearResampler(sourceSampleRate, targetSampleRate));
+	}
+	const IIRResampler::Quality iirQuality = static_cast<IIRResampler::Quality>(quality);
+	const double iirPassbandFraction = IIRResampler::getPassbandFractionForQuality(iirQuality);
+	if (sourceSampleRate < targetSampleRate) {
+		ResamplerStage *iir2xInterpolator = new IIR2xInterpolator(iirQuality);
+		FloatSampleProvider &iir2xInterpolatorStage = *new InternalResamplerCascadeStage(source, *iir2xInterpolator);
+
+		if (2.0 * sourceSampleRate == targetSampleRate) {
+			return iir2xInterpolatorStage;
+		}
+
+		double passband = 0.5 * sourceSampleRate * iirPassbandFraction;
+		double stopband = 1.5 * sourceSampleRate;
+		ResamplerStage *sincResampler = SincResampler::createSincResampler(2.0 * sourceSampleRate, targetSampleRate, passband, stopband, DEFAULT_DB_SNR, DEFAULT_WINDOWED_SINC_MAX_UPSAMPLE_FACTOR);
+		return *new InternalResamplerCascadeStage(iir2xInterpolatorStage, *sincResampler);
+	}
+
+	if (sourceSampleRate == 2.0 * targetSampleRate) {
+		ResamplerStage *iir2xDecimator = new IIR2xDecimator(iirQuality);
+		return *new InternalResamplerCascadeStage(source, *iir2xDecimator);
+	}
+
+	double passband = 0.5 * targetSampleRate * iirPassbandFraction;
+	double stopband = 1.5 * targetSampleRate;
+	double sincOutSampleRate = 2.0 * targetSampleRate;
+	const unsigned int maxUpsampleFactor = static_cast<unsigned int>(ceil(DEFAULT_WINDOWED_SINC_MAX_DOWNSAMPLE_FACTOR * sincOutSampleRate / sourceSampleRate));
+	ResamplerStage *sincResampler = SincResampler::createSincResampler(sourceSampleRate, sincOutSampleRate, passband, stopband, DEFAULT_DB_SNR, maxUpsampleFactor);
+	FloatSampleProvider &sincResamplerStage = *new InternalResamplerCascadeStage(source, *sincResampler);
+
+	ResamplerStage *iir2xDecimator = new IIR2xDecimator(iirQuality);
+	return *new InternalResamplerCascadeStage(sincResamplerStage, *iir2xDecimator);
+}
+
+FloatSampleProvider &ResamplerModel::createResamplerModel(FloatSampleProvider &source, ResamplerStage **resamplerStages, unsigned int stageCount) {
+	FloatSampleProvider *prevStage = &source;
+	for (unsigned int i = 0; i < stageCount; i++) {
+		prevStage = new CascadeStage(*prevStage, *(resamplerStages[i]));
+	}
+	return *prevStage;
+}
+
+FloatSampleProvider &ResamplerModel::createResamplerModel(FloatSampleProvider &source, ResamplerStage &stage) {
+	return *new CascadeStage(source, stage);
+}
+
+void ResamplerModel::freeResamplerModel(FloatSampleProvider &model, FloatSampleProvider &source) {
+	FloatSampleProvider *currentStage = &model;
+	while (currentStage != &source) {
+		CascadeStage *cascadeStage = dynamic_cast<CascadeStage *>(currentStage);
+		if (cascadeStage == NULL) return;
+		FloatSampleProvider &prevStage = cascadeStage->source;
+		delete currentStage;
+		currentStage = &prevStage;
+	}
+}
+
+using namespace ResamplerModel;
+
+CascadeStage::CascadeStage(FloatSampleProvider &useSource, ResamplerStage &useResamplerStage) :
+	resamplerStage(useResamplerStage),
+	source(useSource),
+	bufferPtr(buffer),
+	size()
+{}
+
+void CascadeStage::getOutputSamples(FloatSample *outBuffer, unsigned int length) {
+	while (length > 0) {
+		if (size == 0) {
+			size = resamplerStage.estimateInLength(length);
+			if (size < 1) {
+				size = 1;
+			} else if (MAX_SAMPLES_PER_RUN < size) {
+				size = MAX_SAMPLES_PER_RUN;
+			}
+			source.getOutputSamples(buffer, size);
+			bufferPtr = buffer;
+		}
+		resamplerStage.process(bufferPtr, size, outBuffer, length);
+	}
+}

--- a/vendor/munt/src/srchelper/srctools/src/SincResampler.cpp
+++ b/vendor/munt/src/srchelper/srctools/src/SincResampler.cpp
@@ -1,0 +1,136 @@
+/* Copyright (C) 2015-2022 Sergey V. Mikayev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 2.1 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+
+#ifdef SRCTOOLS_SINC_RESAMPLER_DEBUG_LOG
+#include <iostream>
+#endif
+
+#include "../include/SincResampler.h"
+
+#ifndef M_PI
+static const double M_PI = 3.1415926535897932;
+#endif
+
+using namespace SRCTools;
+
+using namespace SincResampler;
+
+using namespace Utils;
+
+void Utils::computeResampleFactors(unsigned int &upsampleFactor, double &downsampleFactor, const double inputFrequency, const double outputFrequency, const unsigned int maxUpsampleFactor) {
+	static const double RATIONAL_RATIO_ACCURACY_FACTOR = 1E15;
+
+	upsampleFactor = static_cast<unsigned int>(outputFrequency);
+	unsigned int downsampleFactorInt = static_cast<unsigned int>(inputFrequency);
+	if ((upsampleFactor == outputFrequency) && (downsampleFactorInt == inputFrequency)) {
+		// Input and output frequencies are integers, try to reduce them
+		const unsigned int gcd = greatestCommonDivisor(upsampleFactor, downsampleFactorInt);
+		if (gcd > 1) {
+			upsampleFactor /= gcd;
+			downsampleFactor = downsampleFactorInt / gcd;
+		} else {
+			downsampleFactor = downsampleFactorInt;
+		}
+		if (upsampleFactor <= maxUpsampleFactor) return;
+	} else {
+		// Try to recover rational resample ratio by brute force
+		double inputToOutputRatio = inputFrequency / outputFrequency;
+		for (unsigned int i = 1; i <= maxUpsampleFactor; ++i) {
+			double testFactor = inputToOutputRatio * i;
+			if (floor(RATIONAL_RATIO_ACCURACY_FACTOR * testFactor + 0.5) == RATIONAL_RATIO_ACCURACY_FACTOR * floor(testFactor + 0.5)) {
+				// inputToOutputRatio found to be rational within the accuracy
+				upsampleFactor = i;
+				downsampleFactor = floor(testFactor + 0.5);
+				return;
+			}
+		}
+	}
+	// Use interpolation of FIR taps as the last resort
+	upsampleFactor = maxUpsampleFactor;
+	downsampleFactor = maxUpsampleFactor * inputFrequency / outputFrequency;
+}
+
+unsigned int Utils::greatestCommonDivisor(unsigned int a, unsigned int b) {
+	while (0 < b) {
+		unsigned int r = a % b;
+		a = b;
+		b = r;
+	}
+	return a;
+}
+
+double KaizerWindow::estimateBeta(double dbRipple) {
+	return 0.1102 * (dbRipple - 8.7);
+}
+
+unsigned int KaizerWindow::estimateOrder(double dbRipple, double fp, double fs) {
+	const double transBW = (fs - fp);
+	return static_cast<unsigned int>(ceil((dbRipple - 8) / (2.285 * 2 * M_PI * transBW)));
+}
+
+double KaizerWindow::bessel(const double x) {
+	static const double EPS = 1.11E-16;
+
+	double sum = 0.0;
+	double f = 1.0;
+	for (unsigned int i = 1;; ++i) {
+		f *= (0.5 * x / i);
+		double f2 = f * f;
+		if (f2 <= sum * EPS) break;
+		sum += f2;
+	}
+	return 1.0 + sum;
+}
+
+void KaizerWindow::windowedSinc(FIRCoefficient kernel[], const unsigned int order, const double fc, const double beta, const double amp) {
+	const double fc_pi = M_PI * fc;
+	const double recipOrder = 1.0 / order;
+	const double mult = 2.0 * fc * amp / bessel(beta);
+	for (int i = order, j = 0; 0 <= i; i -= 2, ++j) {
+		double xw = i * recipOrder;
+		double win = bessel(beta * sqrt(fabs(1.0 - xw * xw)));
+		double xs = i * fc_pi;
+		double sinc = (i == 0) ? 1.0 : sin(xs) / xs;
+		FIRCoefficient imp = FIRCoefficient(mult * sinc * win);
+		kernel[j] = imp;
+		kernel[order - j] = imp;
+	}
+}
+
+ResamplerStage *SincResampler::createSincResampler(const double inputFrequency, const double outputFrequency, const double passbandFrequency, const double stopbandFrequency, const double dbSNR, const unsigned int maxUpsampleFactor) {
+	unsigned int upsampleFactor;
+	double downsampleFactor;
+	computeResampleFactors(upsampleFactor, downsampleFactor, inputFrequency, outputFrequency, maxUpsampleFactor);
+	double baseSamplePeriod = 1.0 / (inputFrequency * upsampleFactor);
+	double fp = passbandFrequency * baseSamplePeriod;
+	double fs = stopbandFrequency * baseSamplePeriod;
+	double fc = 0.5 * (fp + fs);
+	double beta = KaizerWindow::estimateBeta(dbSNR);
+	unsigned int order = KaizerWindow::estimateOrder(dbSNR, fp, fs);
+	const unsigned int kernelLength = order + 1;
+
+#ifdef SRCTOOLS_SINC_RESAMPLER_DEBUG_LOG
+	std::clog << "FIR: " << upsampleFactor << "/" << downsampleFactor << ", N=" << kernelLength << ", NPh=" << kernelLength / double(upsampleFactor) << ", C=" << 0.5 / fc << ", fp=" << fp << ", fs=" << fs << ", M=" << maxUpsampleFactor << std::endl;
+#endif
+
+	FIRCoefficient *windowedSincKernel = new FIRCoefficient[kernelLength];
+	KaizerWindow::windowedSinc(windowedSincKernel, order, fc, beta, upsampleFactor);
+	ResamplerStage *windowedSincStage = new FIRResampler(upsampleFactor, downsampleFactor, windowedSincKernel, kernelLength);
+	delete[] windowedSincKernel;
+	return windowedSincStage;
+}


### PR DESCRIPTION
The internet **loves** the MT-32 - WinUAE and Amiberry have had this for a few years, so I thought it would be good for Copperline to have it too.

* Zero use of any Roland Corporation code, trademark or copyrights!
* Emulation uses the [Munt](https://github.com/munt/munt) MT-32 emulator. This is vendored code similar to FloppyDriveBridge, with zero changes to the actual vendor code, and complies with the developers' LGPL licensing.
* (imo) the implementation in WinUAE/Amiberry is a bit of a half measure and a bit too fiddly to set up. It is cool to hear the ~15 (mostly Sierra On-Line) games playing their soundtracks as the developers intended. The Roland MT-32 was almost as expensive as an Amiga 500 in the late '80s - most people never got to hear one in action.

At its most basic, you choose the MT-32 as a `[serial]` MIDI-out device and point it at your MT-32 Control and PCM ROM files (not shipped with Copperline). That gives you a fully featured MT-32 connected to the Amiga's serial port: the games that support the module, plus any other MIDI software - Music-X, Bars and Pipes, OctaMED, and Caged Artist's MT-32 Editor/Librarian (1988). There are no dependencies and no host MIDI setup - no IAC bus, no loopMIDI, no ALSA routing. Enable it, load the ROMs, and you're good to go.

You can also enable the MT-32 **front panel**, which puts a full-fat MT-32 above the status bar that you control and manipulate like an original unit.

## What's in it

- **MIDI output device**: `midi_out = "mt32"` with `mt32_control_rom` / `mt32_pcm_rom`, set from the launcher's I/O Ports tab, the config file, or CLI flags. ROMs are identified by size and SHA-1, so a wrong file is refused at load. The synth's audio is mixed beside Paula's four channels - a game playing MT-32 music over Amiga sound effects gets both.
- **MIDI input**: `midi_in = "mt32"` wires the module's MIDI OUT back to the machine, which is what editor/librarian software needs to read and write the module's memory. Replies are clocked into Paula's receiver at the emulated baud rate. The module is only offered as an input while it is the output.
- **Front panel**: the unit's buttons and behaviours from the original manual - single buttons, the MASTER VOLUME combinations (master tune, reverb, the hidden parts 6-8, MIDI channel assignment, All Reset with its confirm presses), the Select/Volume dial, and a power switch. The LCD and MIDI MESSAGE lamp are live: what a game writes to the display shows as it plays. Four display styles, from the stock green LCD to an OLED mod.
- **Runtime menu**: MIDI In/Out and the panel/display settings under the Serial Port category, all effective immediately.

## Implementation notes

- Munt's `mt32emu` (2.8.2) is vendored at `vendor/munt` and compiled in by `build.rs`. No changes to the vendored sources; what was trimmed and how to update it are documented in `vendor/munt/README.md`.
- `mt32emu` is LGPL-2.1-or-later, compatible with Copperline's GPL-3.0-or-later. It contains no ROM data - the emulation runs on images the user supplies.
- Everything sits behind the `mt32` cargo feature (default on). Built without it, no trace remains: no launcher rows, no device entries, and `mt32_*` config keys are ignored with a warning.
- The engine is only instantiated while the MT-32 is the selected output, and holds about 2 MiB while running. Benchmark results are unchanged with the feature compiled in.

## Docs

New chapter: `docs/guide/mt32.md` - setup, config keys, the front panel, and troubleshooting. The MIDI sections of the existing docs reference it.

## Testing

- Unit tests for the panel, the SysEx reply path, and the MIDI plumbing run in the normal suite with no ROMs needed.
- ROM-backed integration tests (engine output, display, memory dumps) are `#[ignore]`d and run locally via `COPPERLINE_MT32_ROMS`.
- CI-equivalent gates run clean with and without the `mt32` feature.
- Tested on macOS, Windows and Linux against real titles (King's Quest V and friends) and other MIDI software such as the MT-32 librarian and OctaMED v4.


https://github.com/user-attachments/assets/17c156f4-b005-4bc2-9604-c1b64666113d

<img width="729" height="679" alt="Screenshot 2026-08-04 at 20 08 04" src="https://github.com/user-attachments/assets/90e4a1fe-6b61-40d9-9abc-1a9b6fe4750a" />
<img width="719" height="614" alt="Screenshot 2026-08-04 at 20 06 31" src="https://github.com/user-attachments/assets/287d4dab-fa79-4dcb-9409-b693f69053ac" />
<img width="824" height="738" alt="Screenshot 2026-08-04 at 20 11 40" src="https://github.com/user-attachments/assets/bd21ea5d-61f2-49ab-9a17-a45ef6a3c2b9" />