### PR TITLE
floppy: read IPF images with a direct CAPS decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ against real hardware.
   uncached execution totals from the MC68020 User's Manual per instruction.
 - **Peripherals**: a bit-timed keyboard (6500/1 MCU), mouse, USB gamepad
   (via the pure-Rust `gilrs`, no SDL2), 4-channel Paula audio, floppy
-  (ADF / ADZ / ZIP / DMS, read-only SCP, or a real 3.5" drive over
+  (ADF / ADZ / ZIP / DMS, read-only IPF and SCP, or a real 3.5" drive over
   DrawBridge / Greaseweazle / Supercard Pro via the bundled FloppyBridge,
   `docs/guide/floppybridge.md`), Gayle and A4000 IDE, SCSI (A2091,
   A4091, or the A3000's onboard Super DMAC), CDTV/CD32 CD, A2065 Ethernet,
@@ -201,7 +201,7 @@ video = "PAL"         # PAL or NTSC
 # drives = 2           # wired mechanisms, 1-4; default is DF0 only
 
 [floppy.df0]
-path = "AmigaTestKit.adf"   # DD ADF / ADZ / DMS / SCP; omit for no disk
+path = "AmigaTestKit.adf"   # DD ADF / ADZ / DMS / IPF / SCP; omit for no disk
 ```
 
 The full reference -- every key, machine profiles, Zorro boards, CD/HDD
@@ -337,7 +337,7 @@ channel are in
 | Paula serial | SERDAT through a one-word transmit buffer and timed shift register, out to stdout, a TCP port, a pseudo-terminal, or -- with the default `midi` feature -- bridged to host MIDI in/out; SERDATR reports TBE/TSRE/RBF, and serial receive is fed from the selected input. |
 | Paula audio | 4-channel DMA/sample playback, stereo mix, LED filter. |
 | Paula DMACON / INTENA / INTREQ | IRQ bits are stored and delivered through manual M68K autovectors with modelled 68000 interrupt-recognition latency; audio and disk DMA raise completion IRQs. |
-| Floppy / ADF / DMS / SCP | DF0-DF3 standard DD ADF read/write, read-only ADZ/DMS, UAE extended ADF, initial read-only SCP flux import, track-timed disk DMA, CIA drive lines, index FLAG, DSKLEN/DSKBYTR/DSKSYNC/DSKDAT, per-drive multi-disk playlists with a swap key, and real 3.5" drives through FloppyBridge (DrawBridge / Greaseweazle / Supercard Pro). |
+| Floppy / ADF / DMS / IPF / SCP | DF0-DF3 standard DD ADF read/write, read-only ADZ/DMS, UAE extended ADF, read-only IPF (decoded natively, no capsimg) and SCP flux import, track-timed disk DMA, CIA drive lines, index FLAG, DSKLEN/DSKBYTR/DSKSYNC/DSKDAT, per-drive multi-disk playlists with a swap key, and real 3.5" drives through FloppyBridge (DrawBridge / Greaseweazle / Supercard Pro). |
 | Hard disks | Gayle IDE (A600/A1200) and A4000 motherboard IDE; SCSI via the A2091 (Zorro II DMAC + WD33C93A), A4091 (Zorro III 53C710 with SCRIPTS), or A3000 Super DMAC; RDB HDFs, bare partition hardfiles, and host-directory volumes. |
 | Host filesystem | `[[filesys]]` mounts serve host directories live as AmigaDOS volumes (read/write, `.uaem` attribute sidecars, Latin-1 name mapping). |
 | Expansion | Zorro II/III autoconfig chain, TOML-described RAM boards, WASM plugin boards (registers/interrupts/DMA in a sandboxed module), A2065 Ethernet (Am7990 LANCE) with loopback, userspace NAT, and direct host-adapter bridge backends. |

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -587,8 +587,8 @@ floppy_sounds_volume = 100
 # to wire empty external mechanisms as well (1-4 total drives). Missing
 # [floppy.dfN] tables mean no disk in that drive. Supported images:
 # DD ADF (901120 bytes), ADZ/gzip, single file ZIP archives, DMS, UAE extended
-# ADF, and read-only SCP flux captures. DMS/gzip/SCP are always treated as
-# write-protected.
+# ADF, and read-only IPF and SCP images. DMS/gzip/IPF/SCP are always treated
+# as write-protected.
 #
 # Drive speed: 100 (real, the default), 200/400/800 (that many percent of
 # real speed; the whole data path stays bit-identical, just faster), or 0

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -28,8 +28,8 @@ works with no files of your own; the **Kickstart ROM** and **DF0 disk**
 pickers load local images instead. Both work before or after boot: a
 pre-boot choice is stashed and applied when the machine starts (the boot
 button relabels to show which ROM it will use), and a post-boot pick swaps
-the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, and
-SCP, plain or gzip/zip packed -- and are always write-protected, since
+the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, IPF,
+and SCP, plain or gzip/zip packed -- and are always write-protected, since
 the browser has no filesystem to write changes back to. On iOS the pickers
 offer every file rather than filtering by extension, because the system
 document picker greys out extensions it does not recognise, which would

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1138,14 +1138,23 @@ bays only; a physical drive has its own `bridge_speed`.
 
 Supported image formats: standard 901120-byte DD ADF, gzip-compressed
 images (ADZ), single file ZIP archives, DMS archives, UAE extended ADF, and
-read-only SCP flux images. DMS, gzip, and SCP images are decoded at load time
-and always treated as write-protected; set `write_protected = false` on a plain
-ADF to allow write-through updates to the image file.
+read-only IPF and SCP images. DMS, gzip, IPF, and SCP images are decoded at
+load time and always treated as write-protected; set `write_protected = false`
+on a plain ADF to allow write-through updates to the image file.
 
-The loader deliberately rejects IPF/CAPS images. Useful support would require
-either a direct IPF parser or an optional SPS/CAPS library, with its licensing,
-platform packaging, and dynamic-loading strategy settled before it becomes a
-dependency. The browser frontend shares this decoder, so it rejects IPF too.
+IPF (the SPS/CAPS preservation format) is decoded by Copperline itself rather
+than through the closed-source `capsimg` library, so every build reads IPF on
+every platform with nothing to install. Because an IPF preserves the encoded
+track -- sync marks, gaps, and sector headers, not just sector contents -- it
+carries the custom trackloaders and copy protections that an ADF cannot
+express. Each track is decoded to the revolution of MFM the head would pass
+over and read back through the same path as a flux capture. Two limits are
+worth knowing: tracks recorded with a variable cell *rate* (the Copylock,
+Speedlock, and Brierley density models) are decoded with uniform 2 us cells,
+which is logged at load time and leaves a protection that measures cell timing
+seeing the wrong answer; and weak ("flakey") bits are replayed as the single
+deterministic revolution the file stores rather than varying per revolution.
+The browser frontend shares this decoder, so it reads IPF too.
 
 A `paths` playlist lets multi-disk software that only drives DF0: run
 without a second drive: the first entry is the boot disk and the disk-swap

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -181,7 +181,7 @@ path = "MyGame.adf"
 ```
 
 Copperline accepts plain ADF images, gzip-compressed images, single file ZIP
-archives, DMS archives, UAE extended ADFs, and read-only SCP flux images.
+archives, DMS archives, UAE extended ADFs, and read-only IPF and SCP images.
 In a windowed session you can also just drag a disk image onto the window
 to insert it -- see [](ui#drag-and-drop).
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -134,7 +134,7 @@ headless runs (see [](../debugger/control)).
 
 Disk images can be dropped anywhere on the emulator window:
 
-- **Floppy images** (ADF/ADZ/DMS/SCP, gzip or zip packed): with one
+- **Floppy images** (ADF/ADZ/DMS/IPF/SCP, gzip or zip packed): with one
   connected drive the disk is inserted immediately. With several, a drive
   chooser opens over the display -- click a drive, press its number
   (`1`-`4`), or press `Esc` to cancel. Dropping several floppies at once

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -268,7 +268,8 @@ DMA drains Paula's recovered 16-bit disk word phase even when DSKLEN is
 armed between disk-word boundaries; WORDSYNC is the explicit mode that
 realigns framing to a matched sync word before transfer. Supported image
 formats: ADF (read/write), gzip ADZ, single file ZIP, DMS (decompressed by
- `dms.rs`), UAE extended ADF, and read-only SCP flux images.
+ `dms.rs`), UAE extended ADF, and read-only IPF (decoded by `ipf.rs`) and SCP
+images.
 Connected mechanisms with no media keep the active-low disk-change line
 asserted; a step pulse only clears that latch once media is actually
 present, so guest software sees a no-disk condition rather than unreadable
@@ -278,9 +279,26 @@ Standard ADF and AmigaDOS tracks are synthesized as one PAL-sized
 revolution: 11 sectors occupy 5984 MFM words, and the generated revolution
 is 6334 16-bit MFM words so the index gap matches normal Amiga floppy
 timing. This matters for raw loaders that DMA a fixed-size window and make
-their own assumptions about the post-sector gap. UAE extended raw tracks
-and SCP flux captures keep their stored track length and per-revolution
-timing instead of using this synthetic geometry.
+their own assumptions about the post-sector gap. UAE extended raw tracks,
+IPF tracks, and SCP flux captures keep their stored track length and
+per-revolution timing instead of using this synthetic geometry.
+
+IPF images are decoded by `ipf.rs` rather than the closed-source `capsimg`
+library. The format stores each track as blocks of *stream samples*: sync
+marks and raw runs are already-encoded MFM written through untouched (which
+is how an address mark keeps its illegal clocking), while data and gap
+samples hold decoded bytes the loader MFM-encodes, setting the clock bit
+only between two zero data bits. Block gaps are filled either from a single
+repeated byte or from forward and backward gap streams whose loop samples
+stretch to meet at the write splice in the middle. Each track is checked
+against the bit counts its descriptors declare and then rotated so the
+revolution starts at the index, matching the shape a flux capture already
+has. Two modelling gaps remain: the variable cell-*rate* density profiles
+(Copylock, Speedlock, Brierley) decode with uniform 2 us cells and log a
+warning, and weak bits replay as the one deterministic revolution the file
+stores rather than varying per revolution -- `FloppyTrackImage::RawMfm` can
+already carry both (`bitcell_ns` and multiple revolutions) when the
+per-protection profiles are modelled.
 
 The synthesized drive sounds ([](../guide/configuration)) are driven by
 this model's real state transitions -- motor spin-up, seeks, the

--- a/src/config.rs
+++ b/src/config.rs
@@ -4797,6 +4797,7 @@ fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
         || sig[..4] == [0x50, 0x4b, 0x03, 0x04]
         || &sig[..3] == b"SCP"
         || &sig[..4] == b"DMS!"
+        || &sig[..4] == b"CAPS"
         || &sig == b"UAE-1ADF"
         || &sig == b"UAE--ADF"
     {
@@ -4805,7 +4806,7 @@ fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
 
     bail!(
         "floppy.df{} image {} is {} bytes, expected {} bytes (standard DD ADF),
-        gzip-compressed supported image, UAE extended ADF, SCP, DMS or single file ZIP",
+        gzip-compressed supported image, UAE extended ADF, IPF, SCP, DMS or single file ZIP",
         idx,
         path.display(),
         meta.len(),
@@ -7767,6 +7768,25 @@ mod tests {
         ))?;
         let df0 = cfg.floppy.drives[0].as_ref().unwrap();
         assert_eq!(df0.path, adf);
+        let _ = fs::remove_file(df0.path.clone());
+        Ok(())
+    }
+
+    #[test]
+    fn ipf_floppy_path_is_accepted() -> Result<()> {
+        let ipf = temp_path("test.ipf");
+        // The bare CAPS signature chunk an IPF opens with.
+        fs::write(&ipf, b"CAPS\x00\x00\x00\x0c")?;
+        let cfg = parse_config(&format!(
+            r#"
+            [floppy.df0]
+            path = "{}"
+            "#,
+            toml_path(&ipf)
+        ))?;
+        let df0 = cfg.floppy.drives[0].as_ref().unwrap();
+        assert_eq!(df0.path, ipf);
+        assert!(df0.write_protected);
         let _ = fs::remove_file(df0.path.clone());
         Ok(())
     }

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -10,6 +10,7 @@
 use crate::chipset::paula::PAULA_CLOCK_HZ;
 use crate::config::{FloppyConfig, FloppyDriveConfig};
 use crate::dms;
+use crate::ipf;
 use anyhow::{bail, ensure, Context, Result};
 use flate2::read::{DeflateDecoder, GzDecoder};
 use flate2::CrcReader;
@@ -153,7 +154,6 @@ const DISK_WRITE_LOST_BITS: usize = 3;
 const DEFAULT_DSKSYNC: u16 = 0x4489;
 const UAE_EXT1_SIGNATURE: &[u8; 8] = b"UAE--ADF";
 const UAE_EXT2_SIGNATURE: &[u8; 8] = b"UAE-1ADF";
-const IPF_SIGNATURE: &[u8; 4] = b"CAPS";
 const SCP_SIGNATURE: &[u8; 3] = b"SCP";
 const GZIP_SIGNATURE: &[u8; 2] = &[0x1F, 0x8B];
 const ZIP_SIGNATURE: &[u8; 4] = &[0x50, 0x4b, 0x03, 0x04];
@@ -3130,16 +3130,19 @@ fn decode_floppy_payload(
         let data = dms::decode_dms_adf(&packed)
             .with_context(|| format!("decoding DMS {}", path.display()))?;
         (FloppyImageData::StandardAdf(data), true)
-    } else if packed.starts_with(IPF_SIGNATURE) {
-        bail!(
-            "IPF/CAPS floppy image {} is not supported: Copperline treats IPF as an explicit non-goal for the built-in loader until support is implemented as a direct IPF parser or optional SPS/CAPS library integration with licensing and platform packaging reviewed",
-            path.display()
-        );
+    } else if ipf::is_ipf(&packed) {
+        // IPF preserves the written track rather than its sectors, so there is
+        // nothing to write back into: it is always read-only.
+        (
+            decode_ipf_image(&packed)
+                .with_context(|| format!("decoding IPF {}", path.display()))?,
+            true,
+        )
     } else if packed.starts_with(SCP_SIGNATURE) {
         (decode_scp_flux_image(&packed)?, true)
     } else {
         bail!(
-            "floppy image {} is {} bytes; expected {} bytes (ADF), gzip-compressed supported image, UAE extended ADF, SCP, or DMS",
+            "floppy image {} is {} bytes; expected {} bytes (ADF), gzip-compressed supported image, UAE extended ADF, IPF, SCP, or DMS",
             path.display(),
             packed.len(),
             ADF_SIZE
@@ -3372,6 +3375,29 @@ fn decode_uae_legacy_extended_adf(data: &[u8]) -> Result<FloppyImageData> {
         }
     }
     Ok(FloppyImageData::Tracks(out))
+}
+
+/// An IPF stores the encoded track itself, so each of its tracks arrives as a
+/// finished revolution of MFM -- the same shape a flux capture takes, and read
+/// back through the same path.
+fn decode_ipf_image(data: &[u8]) -> Result<FloppyImageData> {
+    let tracks = ipf::decode(data)?
+        .into_iter()
+        .map(|track| {
+            track.map(|track| FloppyTrackImage::RawMfm {
+                stored_len: track.words.len() * 2,
+                words: track.words,
+                bit_len: track.bit_len,
+                // The format describes one canonical revolution, and its cell
+                // rate is the nominal 2 us that `word_cck_for_track_words`
+                // already paces a raw track at.
+                revolutions: 1,
+                legacy_sync: None,
+                bitcell_ns: None,
+            })
+        })
+        .collect();
+    Ok(FloppyImageData::Tracks(tracks))
 }
 
 fn decode_scp_flux_image(data: &[u8]) -> Result<FloppyImageData> {
@@ -4896,22 +4922,20 @@ mod tests {
         Ok(())
     }
 
+    /// An IPF describes the written track rather than its sectors, so it
+    /// arrives as a raw MFM revolution and can never be written back to.
     #[test]
-    #[ignore = "IPF/CAPS support is an explicit non-goal until a direct parser or optional external library strategy is chosen"]
-    fn ipf_caps_images_fail_with_explicit_strategy() -> Result<()> {
+    fn ipf_images_load_as_raw_mfm_tracks_and_are_write_protected() -> Result<()> {
         let path = temp_path("test.ipf");
-        let mut image = Vec::new();
-        image.extend_from_slice(IPF_SIGNATURE);
-        image.extend_from_slice(&12u32.to_be_bytes());
-        image.extend_from_slice(&0u32.to_be_bytes());
-        fs::write(&path, image)?;
+        fs::write(&path, crate::ipf::tests::amigados_ipf_image())?;
         let cfg = FloppyConfig {
             bridges: std::array::from_fn(|_| None),
             speed: 100,
             drives: [
                 Some(FloppyDriveConfig {
                     path: path.clone(),
-                    write_protected: true,
+                    // An IPF overrides a writable configuration.
+                    write_protected: false,
                 }),
                 None,
                 None,
@@ -4919,13 +4943,22 @@ mod tests {
             ],
         };
 
-        let err = FloppyController::from_config(&cfg)
-            .err()
-            .expect("IPF/CAPS images should fail with the recorded strategy");
-        let message = format!("{err:#}");
-        assert!(message.contains("IPF/CAPS floppy image"));
-        assert!(message.contains("explicit non-goal"));
-        assert!(message.contains("SPS/CAPS library integration"));
+        let controller = FloppyController::from_config(&cfg)?;
+        let image = controller.drives[0]
+            .image
+            .as_ref()
+            .expect("the IPF should have loaded");
+        assert!(image.write_protected);
+        let FloppyImageData::Tracks(tracks) = &image.data else {
+            panic!("an IPF should decode to per-track raw MFM, not a sector image");
+        };
+        let Some(FloppyTrackImage::RawMfm { bit_len, words, .. }) = &tracks[0] else {
+            panic!("cylinder 0 head 0 should hold a raw MFM revolution");
+        };
+        assert_eq!(*bit_len, crate::ipf::tests::AMIGADOS_TRACK_BITS);
+        assert_eq!(words.len(), (*bit_len as usize).div_ceil(16));
+        // The track the fixture describes is the only formatted one.
+        assert!(tracks[1..].iter().all(Option::is_none));
 
         let _ = fs::remove_file(path);
         Ok(())

--- a/src/ipf.rs
+++ b/src/ipf.rs
@@ -1,0 +1,1420 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! IPF (Interchangeable Preservation Format) floppy images.
+//!
+//! IPF is the SPS/CAPS preservation format: rather than sector contents it
+//! stores the *encoded* track -- every MFM cell the head passes over, sector
+//! headers, sync marks, gaps and all -- which is why it preserves the custom
+//! trackloaders and copy protections that an ADF cannot express.
+//!
+//! # What the format stores
+//!
+//! A file is a sequence of chunks, each a four-character name, a big-endian
+//! total length, and a CRC-32 of the chunk taken with the CRC field zeroed:
+//!
+//! - `CAPS` -- the file signature, a bare header.
+//! - `INFO` -- media type, the encoder that produced the file, and the
+//!   cylinder/side range covered.
+//! - `IMGE` -- one per track, describing its geometry: how many bits the
+//!   revolution holds, how many of them are block data and how many gap,
+//!   where the first block starts relative to the index, and a *data key*
+//!   naming the `DATA` chunk that carries the content.
+//! - `DATA` -- the content for one track. Uniquely among the chunks, its
+//!   payload continues past the length in its header: a data area of
+//!   `dataSize` further bytes follows, holding the block descriptors and then
+//!   the gap and data streams they point at.
+//!
+//! A track is a series of *blocks* -- an AmigaDOS sector, or one whole custom
+//! track for a trackloader that does its own thing. Each block is a data
+//! stream of `block_bits` encoded MFM bits followed by a gap of `gap_bits`.
+//!
+//! # How a stream becomes cells
+//!
+//! Both stream kinds are a run of samples terminated by a nul byte. A sample
+//! opens with a type byte whose low five bits are the type and whose top three
+//! say how many big-endian bytes of length follow.
+//!
+//! In a data stream the types are sync (1), data (2), gap (3), raw (4) and
+//! weak (5). Sync and raw are already-encoded MFM written through untouched --
+//! that is how an address mark like `4489 4489` keeps its illegal clocking --
+//! while data and gap hold decoded bytes that this decoder MFM-encodes,
+//! setting the clock bit only between two zero data bits. So a sample's
+//! contribution is its bit count for raw kinds and twice that for encoded
+//! kinds, and the sum across the stream is exactly the `block_bits` the
+//! descriptor promised, which [`decode`] checks track by track.
+//!
+//! Gap streams are richer, because a gap is where the write splice falls and
+//! its length depends on how fast the drive that wrote it was turning. A gap
+//! may be filled from a single repeated byte, or from a forward stream, a
+//! backward stream, or both, each with an optional *loop sample* that stretches
+//! to take up whatever slack is left. Two streams meet in the middle of the
+//! gap, which is where a real splice sits.
+//!
+//! # Why a direct parser
+//!
+//! The reference decoder is SPS's closed-source `capsimg` shared library.
+//! Copperline decodes IPF itself so that a build which says it reads IPF
+//! actually does, on every platform, with nothing to download -- the same
+//! reasoning that vendors FloppyBridge in [`crate::floppybridge`] rather than
+//! dlopen-ing it.
+//!
+//! # What comes out
+//!
+//! One whole revolution per track as packed MFM, in the same shape a flux
+//! capture already takes in [`crate::floppy`] -- so the rotation, PLL and
+//! sync-word machinery reads an IPF with no special case in the hot path.
+//! The revolution is rotated to start at the index, as a capture does, using
+//! the start position the `IMGE` records.
+
+use anyhow::{bail, ensure, Context, Result};
+use flate2::Crc;
+use log::warn;
+
+const CAPS_SIGNATURE: &[u8; 4] = b"CAPS";
+const CHUNK_HEADER_LEN: usize = 12;
+const INFO_BODY_LEN: usize = 84;
+const IMGE_BODY_LEN: usize = 68;
+const DATA_BODY_LEN: usize = 16;
+const BLOCK_DESCRIPTOR_LEN: usize = 32;
+
+/// Cylinder 83 side 1 is the highest track the format describes for Amiga
+/// media, matching the 168 slots the SCP loader keeps.
+const MAX_TRACKS: usize = 2 * 84;
+
+/// A revolution longer than this is a corrupt descriptor rather than a disk:
+/// a 300 RPM DD revolution is close to 100,000 cells.
+const MAX_TRACK_BITS: usize = 1_000_000;
+
+// INFO encoder identifiers.
+const ENCODER_CAPS: u32 = 1;
+
+// INFO media types.
+const MEDIA_FLOPPY: u32 = 1;
+
+// IMGE signal types: the cell rate the track was recorded at.
+const SIGNAL_2US_CELLS: u32 = 1;
+
+// IMGE cell-density models. Anything past `AUTO` varies the cell rate across
+// the track to defeat copiers, and needs a per-protection timing model.
+const DENSITY_NOISE: u32 = 1;
+const DENSITY_AUTO: u32 = 2;
+
+// Data-stream sample types.
+const DATA_SYNC: u8 = 1;
+const DATA_DATA: u8 = 2;
+const DATA_GAP: u8 = 3;
+const DATA_RAW: u8 = 4;
+const DATA_WEAK: u8 = 5;
+
+// Gap-stream sample types.
+const GAP_LENGTH: u8 = 1;
+const GAP_DATA: u8 = 2;
+
+// Block descriptor flags. Only an SPS-encoded file sets them.
+const BLOCK_FLAG_FWGAP: u32 = 1 << 0;
+const BLOCK_FLAG_BWGAP: u32 = 1 << 1;
+const BLOCK_FLAG_BIT_LENGTHS: u32 = 1 << 2;
+
+/// One decoded revolution: packed MFM words, MSB first, and the exact bit
+/// length it wraps at.
+#[derive(Debug)]
+pub struct IpfTrack {
+    pub words: Vec<u16>,
+    pub bit_len: u32,
+}
+
+/// True when `data` opens with the IPF/CAPS file signature.
+pub fn is_ipf(data: &[u8]) -> bool {
+    data.starts_with(CAPS_SIGNATURE)
+}
+
+/// Decode a whole IPF file into per-track revolutions, indexed by
+/// `cylinder * 2 + head`. Tracks the image leaves unformatted come back as
+/// `None`, which is how [`crate::floppy`] already spells "no medium here".
+pub fn decode(data: &[u8]) -> Result<Vec<Option<IpfTrack>>> {
+    ensure!(is_ipf(data), "missing IPF/CAPS signature");
+
+    let mut info: Option<Info> = None;
+    let mut images: Vec<Imge> = Vec::new();
+    let mut areas: Vec<(u32, &[u8])> = Vec::new();
+
+    for chunk in Chunks::new(data) {
+        let chunk = chunk?;
+        match &chunk.name {
+            b"CAPS" => {}
+            b"INFO" => {
+                ensure!(info.is_none(), "IPF image has more than one INFO chunk");
+                info = Some(Info::parse(chunk.body)?);
+            }
+            b"IMGE" => images.push(Imge::parse(chunk.body)?),
+            b"DATA" => {
+                let (key, area) = parse_data(chunk.body, chunk.extra)?;
+                areas.push((key, area));
+            }
+            // Unknown chunks are skipped: the container is self-describing and
+            // a newer writer may add its own without invalidating the tracks.
+            _ => {}
+        }
+    }
+
+    let info = info.context("IPF image has no INFO chunk")?;
+    ensure!(
+        info.media_type == MEDIA_FLOPPY,
+        "IPF media type {} is not a floppy disk",
+        info.media_type
+    );
+    ensure!(!images.is_empty(), "IPF image describes no tracks");
+
+    let mut tracks: Vec<Option<IpfTrack>> = (0..MAX_TRACKS).map(|_| None).collect();
+    let mut unsupported_density = None;
+    for imge in &images {
+        let index = imge.track_index()?;
+        ensure!(
+            tracks[index].is_none(),
+            "IPF image describes cylinder {} head {} twice",
+            imge.cylinder,
+            imge.head
+        );
+        if let Some(density) = imge.unsupported_density() {
+            unsupported_density.get_or_insert(density);
+        }
+        let area = areas
+            .iter()
+            .find(|(key, _)| *key == imge.data_key)
+            .map(|(_, area)| *area);
+        tracks[index] = decode_track(imge, area, &info).with_context(|| {
+            format!("decoding IPF cylinder {} head {}", imge.cylinder, imge.head)
+        })?;
+    }
+
+    if let Some(density) = unsupported_density {
+        // The cells are still decoded, and every byte of them is right; it is
+        // only the varying cell *rate* that is missing, so the disk loads and
+        // just the timing check of the protection sees the wrong answer.
+        // TODO: model the per-protection density profiles (Copylock,
+        // Speedlock, Brierley) as a per-cell bitcell_ns track profile, which
+        // FloppyTrackImage::RawMfm can already carry.
+        warn!(
+            "IPF image uses cell-density model {density}, whose variable cell timing is not \
+             modelled; the track data is decoded with uniform 2 us cells, so a protection \
+             that measures cell timing may not pass"
+        );
+    }
+
+    ensure!(
+        tracks.iter().any(|t| t.is_some()),
+        "IPF image contains no formatted tracks"
+    );
+    Ok(tracks)
+}
+
+/// A chunk: name, the body covered by the length field, and -- for `DATA` --
+/// the data area that trails it.
+struct Chunk<'a> {
+    name: [u8; 4],
+    body: &'a [u8],
+    extra: &'a [u8],
+}
+
+struct Chunks<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Chunks<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn next_chunk(&mut self) -> Result<Option<Chunk<'a>>> {
+        if self.pos >= self.data.len() {
+            return Ok(None);
+        }
+        ensure!(
+            self.pos + CHUNK_HEADER_LEN <= self.data.len(),
+            "IPF chunk header at offset {} is truncated",
+            self.pos
+        );
+        let header = &self.data[self.pos..self.pos + CHUNK_HEADER_LEN];
+        let name: [u8; 4] = header[0..4].try_into().expect("four-byte chunk name");
+        let len = read_be_u32(&header[4..8]) as usize;
+        let crc = read_be_u32(&header[8..12]);
+        ensure!(
+            len >= CHUNK_HEADER_LEN,
+            "IPF chunk {} declares a {len}-byte length, shorter than its header",
+            name_str(&name)
+        );
+        let end = self
+            .pos
+            .checked_add(len)
+            .context("IPF chunk length overflow")?;
+        ensure!(
+            end <= self.data.len(),
+            "IPF chunk {} at offset {} runs past the end of the file",
+            name_str(&name),
+            self.pos
+        );
+
+        // The stored CRC covers the chunk with its own CRC field zeroed.
+        let mut sum = Crc::new();
+        sum.update(&self.data[self.pos..self.pos + 8]);
+        sum.update(&[0, 0, 0, 0]);
+        sum.update(&self.data[self.pos + CHUNK_HEADER_LEN..end]);
+        ensure!(
+            sum.sum() == crc,
+            "IPF chunk {} CRC mismatch: expected {crc:08X}, got {:08X}",
+            name_str(&name),
+            sum.sum()
+        );
+
+        let body = &self.data[self.pos + CHUNK_HEADER_LEN..end];
+        // A DATA chunk's data area follows the chunk and is not counted in the
+        // chunk length, so the walk has to step over it as well.
+        let extra_len = if &name == b"DATA" {
+            ensure!(
+                body.len() >= 4,
+                "IPF DATA chunk is too short to hold its data-area size"
+            );
+            read_be_u32(&body[0..4]) as usize
+        } else {
+            0
+        };
+        let extra_end = end
+            .checked_add(extra_len)
+            .context("IPF data area length overflow")?;
+        ensure!(
+            extra_end <= self.data.len(),
+            "IPF data area at offset {end} runs past the end of the file"
+        );
+        let extra = &self.data[end..extra_end];
+
+        self.pos = extra_end;
+        Ok(Some(Chunk { name, body, extra }))
+    }
+}
+
+impl<'a> Iterator for Chunks<'a> {
+    type Item = Result<Chunk<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.next_chunk() {
+            Ok(Some(chunk)) => Some(Ok(chunk)),
+            Ok(None) => None,
+            Err(err) => {
+                // Stop after reporting: the walk cannot resynchronise.
+                self.pos = self.data.len();
+                Some(Err(err))
+            }
+        }
+    }
+}
+
+struct Info {
+    media_type: u32,
+    encoder_type: u32,
+    encoder_rev: u32,
+}
+
+impl Info {
+    fn parse(body: &[u8]) -> Result<Self> {
+        ensure!(body.len() >= INFO_BODY_LEN, "IPF INFO chunk is truncated");
+        Ok(Self {
+            media_type: read_be_u32(&body[0..4]),
+            encoder_type: read_be_u32(&body[4..8]),
+            encoder_rev: read_be_u32(&body[8..12]),
+        })
+    }
+
+    /// Block flags and the gap streams they point at exist only in a file the
+    /// SPS encoder wrote. A CAPS-encoded file spends the same two descriptor
+    /// words on the block and gap byte counts, so there is no gap-stream
+    /// offset to follow and the flags field is defined to read as zero -- as
+    /// it is for encoder release 1.
+    fn block_flags_meaningful(&self) -> bool {
+        self.encoder_type != ENCODER_CAPS && self.encoder_rev != 1
+    }
+}
+
+struct Imge {
+    cylinder: u32,
+    head: u32,
+    density: u32,
+    signal_type: u32,
+    start_bit_pos: u32,
+    gap_bits: u32,
+    track_bits: u32,
+    block_count: u32,
+    data_key: u32,
+}
+
+impl Imge {
+    fn parse(body: &[u8]) -> Result<Self> {
+        ensure!(body.len() >= IMGE_BODY_LEN, "IPF IMGE chunk is truncated");
+        Ok(Self {
+            cylinder: read_be_u32(&body[0..4]),
+            head: read_be_u32(&body[4..8]),
+            density: read_be_u32(&body[8..12]),
+            signal_type: read_be_u32(&body[12..16]),
+            start_bit_pos: read_be_u32(&body[24..28]),
+            gap_bits: read_be_u32(&body[32..36]),
+            track_bits: read_be_u32(&body[36..40]),
+            block_count: read_be_u32(&body[40..44]),
+            data_key: read_be_u32(&body[52..56]),
+        })
+    }
+
+    fn track_index(&self) -> Result<usize> {
+        ensure!(self.head < 2, "IPF track head {} is not 0 or 1", self.head);
+        let index = (self.cylinder as usize)
+            .checked_mul(2)
+            .and_then(|c| c.checked_add(self.head as usize))
+            .context("IPF track index overflow")?;
+        ensure!(
+            index < MAX_TRACKS,
+            "IPF cylinder {} head {} is outside the {MAX_TRACKS}-track range Copperline models",
+            self.cylinder,
+            self.head
+        );
+        Ok(index)
+    }
+
+    /// The density models past `AUTO` vary the cell rate across the track.
+    fn unsupported_density(&self) -> Option<u32> {
+        match self.density {
+            DENSITY_NOISE | DENSITY_AUTO => None,
+            other => Some(other),
+        }
+    }
+}
+
+/// A `DATA` chunk: the data key it answers to, and its data area.
+fn parse_data<'a>(body: &'a [u8], extra: &'a [u8]) -> Result<(u32, &'a [u8])> {
+    ensure!(body.len() >= DATA_BODY_LEN, "IPF DATA chunk is truncated");
+    let size = read_be_u32(&body[0..4]) as usize;
+    let bit_size = read_be_u32(&body[4..8]) as usize;
+    let crc = read_be_u32(&body[8..12]);
+    let key = read_be_u32(&body[12..16]);
+    ensure!(
+        extra.len() == size,
+        "IPF data area for key {key} is {} bytes, not the {size} the chunk declares",
+        extra.len()
+    );
+    ensure!(
+        bit_size == size * 8,
+        "IPF data area for key {key} declares {bit_size} bits for {size} bytes"
+    );
+    let mut sum = Crc::new();
+    sum.update(extra);
+    ensure!(
+        sum.sum() == crc,
+        "IPF data area for key {key} CRC mismatch: expected {crc:08X}, got {:08X}",
+        sum.sum()
+    );
+    Ok((key, extra))
+}
+
+/// One block descriptor out of the head of a data area.
+struct Block {
+    block_bits: usize,
+    gap_bits: usize,
+    /// SPS only: where this block's gap streams sit in the data area.
+    gap_offset: usize,
+    flags: u32,
+    gap_value: u8,
+    data_offset: usize,
+}
+
+impl Block {
+    fn parse(area: &[u8], index: usize, flags_meaningful: bool) -> Result<Self> {
+        let start = index * BLOCK_DESCRIPTOR_LEN;
+        let end = start + BLOCK_DESCRIPTOR_LEN;
+        ensure!(
+            end <= area.len(),
+            "IPF block descriptor {index} runs past the data area"
+        );
+        let d = &area[start..end];
+        Ok(Self {
+            block_bits: read_be_u32(&d[0..4]) as usize,
+            gap_bits: read_be_u32(&d[4..8]) as usize,
+            gap_offset: read_be_u32(&d[8..12]) as usize,
+            flags: if flags_meaningful {
+                read_be_u32(&d[20..24])
+            } else {
+                0
+            },
+            // The gap fill value is a byte held in a big-endian word.
+            gap_value: d[27],
+            data_offset: read_be_u32(&d[28..32]) as usize,
+        })
+    }
+
+    fn sample_lengths_in_bits(&self) -> bool {
+        self.flags & BLOCK_FLAG_BIT_LENGTHS != 0
+    }
+}
+
+fn decode_track(imge: &Imge, area: Option<&[u8]>, info: &Info) -> Result<Option<IpfTrack>> {
+    // An unformatted track carries no blocks and no cells: the head passes
+    // over noise, which is the same nothing a drive with no image reads.
+    if imge.block_count == 0 || imge.track_bits == 0 {
+        return Ok(None);
+    }
+    ensure!(
+        imge.signal_type == SIGNAL_2US_CELLS,
+        "IPF signal type {} is not the 2 us cell rate of an Amiga DD disk",
+        imge.signal_type
+    );
+    let track_bits = imge.track_bits as usize;
+    ensure!(
+        track_bits <= MAX_TRACK_BITS,
+        "IPF track length {track_bits} bits exceeds the {MAX_TRACK_BITS}-bit limit"
+    );
+    let area = area.with_context(|| format!("IPF data key {} has no DATA chunk", imge.data_key))?;
+
+    // MFM sets a cell's clock bit only when the data bits either side of it
+    // are zero, so the very first clock of the revolution depends on the last
+    // data bit of the revolution before it -- the same one, since the track
+    // loops. Encode once to learn that bit, then again with it in hand.
+    let seed = encode_blocks(imge, area, info, false)?.1;
+    let (bits, _) = encode_blocks(imge, area, info, seed)?;
+    ensure!(
+        bits.len() == track_bits,
+        "IPF track holds {} bits, not the {track_bits} its descriptor declares",
+        bits.len()
+    );
+
+    // The blocks were laid out from the first one; the descriptor says how far
+    // past the index that block begins, so rotating by it puts the revolution
+    // back the way the head met it.
+    let start = imge.start_bit_pos as usize % track_bits;
+    let mut words = vec![0u16; track_bits.div_ceil(16)];
+    for (i, bit) in bits.iter().enumerate() {
+        if *bit {
+            let pos = (start + i) % track_bits;
+            words[pos / 16] |= 0x8000 >> (pos % 16);
+        }
+    }
+
+    Ok(Some(IpfTrack {
+        words,
+        bit_len: imge.track_bits,
+    }))
+}
+
+/// Encode every block of a track back to back, returning the cells and the
+/// last decoded data bit written (the seed the next revolution starts from).
+fn encode_blocks(imge: &Imge, area: &[u8], info: &Info, seed: bool) -> Result<(Vec<bool>, bool)> {
+    let flags_meaningful = info.block_flags_meaningful();
+    let mut out: Vec<bool> = Vec::with_capacity(imge.track_bits as usize);
+    let mut prev = seed;
+    let mut total_gap = 0usize;
+
+    for index in 0..imge.block_count as usize {
+        let block = Block::parse(area, index, flags_meaningful)?;
+        let start = out.len();
+        if block.block_bits > 0 {
+            decode_data_stream(area, &block, &mut out, &mut prev)
+                .with_context(|| format!("in block {index} data stream"))?;
+            let written = out.len() - start;
+            ensure!(
+                written == block.block_bits,
+                "IPF block {index} produced {written} bits, not the {} it declares",
+                block.block_bits
+            );
+        }
+        if block.gap_bits > 0 {
+            fill_gap(area, &block, &mut out, &mut prev)
+                .with_context(|| format!("in block {index} gap"))?;
+            total_gap += block.gap_bits;
+        }
+    }
+
+    ensure!(
+        total_gap == imge.gap_bits as usize,
+        "IPF track gap totals {total_gap} bits, not the {} the track declares",
+        imge.gap_bits
+    );
+    Ok((out, prev))
+}
+
+/// Walk a data stream, appending the cells each sample stands for.
+fn decode_data_stream(
+    area: &[u8],
+    block: &Block,
+    out: &mut Vec<bool>,
+    prev: &mut bool,
+) -> Result<()> {
+    let mut pos = block.data_offset;
+    loop {
+        let Some((kind, size, next)) = read_sample_header(area, pos)? else {
+            return Ok(());
+        };
+        let in_bits = block.sample_lengths_in_bits();
+        let bits = if in_bits { size } else { size * 8 };
+        // A bit-counted sample is padded out so the next one starts on a byte
+        // boundary.
+        let bytes = bits.div_ceil(8);
+        let end = next
+            .checked_add(bytes)
+            .context("IPF data sample length overflow")?;
+        ensure!(
+            end <= area.len(),
+            "IPF data sample runs past the end of the data area"
+        );
+        let sample = &area[next..end];
+
+        match kind {
+            // Already-encoded cells: written through exactly as stored, which
+            // is what keeps a sync mark's illegal clocking intact.
+            DATA_SYNC | DATA_RAW => push_raw(out, prev, sample, bits),
+            // Weak cells read back differently every revolution on real media.
+            // Copperline reads a deterministic revolution, so the stored
+            // sample is written through as it stands.
+            // TODO: carry the weak spans through to FloppyTrackImage::RawMfm
+            // as extra revolutions with the fuzzy runs varied per revolution.
+            DATA_WEAK => push_raw(out, prev, sample, bits),
+            // Decoded payload: one cell per data bit, the clock bit set only
+            // where it separates two zero data bits.
+            DATA_DATA | DATA_GAP => {
+                for i in 0..bits {
+                    let data = sample[i / 8] & (0x80 >> (i % 8)) != 0;
+                    out.push(!*prev && !data);
+                    out.push(data);
+                    *prev = data;
+                }
+            }
+            other => bail!("unknown IPF data sample type {other}"),
+        }
+        pos = end;
+    }
+}
+
+/// Fill a block's gap, from a repeated byte or from its gap streams.
+fn fill_gap(area: &[u8], block: &Block, out: &mut Vec<bool>, prev: &mut bool) -> Result<()> {
+    let budget = block.gap_bits;
+    let has_forward = block.flags & BLOCK_FLAG_FWGAP != 0;
+    let has_backward = block.flags & BLOCK_FLAG_BWGAP != 0;
+
+    if !has_forward && !has_backward {
+        // No streams: repeat the descriptor's gap byte. The writer laid the
+        // gap down from both ends at once, so the splice falls in the middle;
+        // the trailing half is aligned to the gap's end rather than its start.
+        let sample = byte_bits(block.gap_value);
+        let half = budget / 2;
+        fill_mfm(out, prev, &sample, half);
+        fill_mfm_end_aligned(out, prev, &sample, budget - half);
+        return Ok(());
+    }
+
+    let mut pos = block.gap_offset;
+    // Offset zero lands inside the block descriptors, so it means the block
+    // claimed gap streams without saying where they are.
+    ensure!(
+        pos > 0,
+        "IPF block declares gap streams but gives no gap-stream offset"
+    );
+    ensure!(
+        pos < area.len(),
+        "IPF gap-stream offset {pos} is outside the {}-byte data area",
+        area.len()
+    );
+    let forward = if has_forward {
+        let (stream, next) = GapStream::parse(area, pos)?;
+        pos = next;
+        Some(stream)
+    } else {
+        None
+    };
+    let backward = if has_backward {
+        let (stream, _) = GapStream::parse(area, pos)?;
+        Some(stream)
+    } else {
+        None
+    };
+
+    let fwd_fixed = forward.as_ref().map_or(0, GapStream::fixed_bits);
+    let bwd_fixed = backward.as_ref().map_or(0, GapStream::fixed_bits);
+
+    // Share the gap out between the fixed parts. Where they overflow it they
+    // are evenly truncated, and whatever one stream leaves unused goes to the
+    // other.
+    let half = budget / 2;
+    let mut fwd = fwd_fixed.min(half);
+    let mut bwd = bwd_fixed.min(budget - half);
+    fwd += (fwd_fixed - fwd).min(budget - fwd - bwd);
+    bwd += (bwd_fixed - bwd).min(budget - fwd - bwd);
+
+    // Whatever is left over is taken up by the loop samples: both streams
+    // stretch to meet in the middle, or the only one that can stretch fills it.
+    let slack = budget - fwd - bwd;
+    let fwd_loops = forward.as_ref().is_some_and(GapStream::can_loop);
+    let bwd_loops = backward.as_ref().is_some_and(GapStream::can_loop);
+    let (fwd_slack, bwd_slack) = match (fwd_loops, bwd_loops) {
+        (true, true) => (slack / 2, slack - slack / 2),
+        (true, false) => (slack, 0),
+        (false, true) => (0, slack),
+        // Nothing can stretch, so the gap byte makes up the difference.
+        (false, false) => (0, 0),
+    };
+    let unfilled = slack - fwd_slack - bwd_slack;
+
+    if let Some(stream) = &forward {
+        stream.emit_fixed(out, prev, fwd, false);
+        stream.emit_loop(out, prev, fwd_slack, false);
+    }
+    if unfilled > 0 {
+        fill_mfm(out, prev, &byte_bits(block.gap_value), unfilled);
+    }
+    if let Some(stream) = &backward {
+        stream.emit_loop(out, prev, bwd_slack, true);
+        stream.emit_fixed(out, prev, bwd, true);
+    }
+    Ok(())
+}
+
+/// A gap stream: its fixed-length samples, plus the sample that stretches to
+/// take up the slack, if it has one.
+struct GapStream {
+    /// Decoded-bit length and the decoded bits to repeat, per sample.
+    fixed: Vec<(usize, Vec<bool>)>,
+    loop_sample: Option<Vec<bool>>,
+    /// An explicit zero-length loop sample forbids stretching outright.
+    loop_disabled: bool,
+}
+
+impl GapStream {
+    /// Samples pair an optional length with the data to repeat; the one that
+    /// arrives without a length is the loop sample. Lengths here are always in
+    /// bits, whatever the block's flags say about the data stream.
+    fn parse(area: &[u8], mut pos: usize) -> Result<(Self, usize)> {
+        let mut fixed = Vec::new();
+        let mut loop_sample = None;
+        let mut loop_disabled = false;
+        let mut pending: Option<usize> = None;
+        loop {
+            let Some((kind, size, next)) = read_sample_header(area, pos)? else {
+                return Ok((
+                    Self {
+                        fixed,
+                        loop_sample,
+                        loop_disabled,
+                    },
+                    pos + 1,
+                ));
+            };
+            match kind {
+                GAP_LENGTH => {
+                    pos = next;
+                    pending = Some(size);
+                }
+                GAP_DATA => {
+                    let bytes = size.div_ceil(8);
+                    let end = next
+                        .checked_add(bytes)
+                        .context("IPF gap sample length overflow")?;
+                    ensure!(
+                        end <= area.len(),
+                        "IPF gap sample runs past the end of the data area"
+                    );
+                    let sample = bits_of(&area[next..end], size);
+                    match pending.take() {
+                        Some(length) => fixed.push((length, sample)),
+                        None if size == 0 => loop_disabled = true,
+                        None => loop_sample = Some(sample),
+                    }
+                    pos = end;
+                }
+                other => bail!("unknown IPF gap sample type {other}"),
+            }
+        }
+    }
+
+    /// How many cells the fixed samples lay down: each decoded bit is one MFM
+    /// cell, and a cell is two bits.
+    fn fixed_bits(&self) -> usize {
+        self.fixed.iter().map(|(len, _)| len * 2).sum()
+    }
+
+    /// A stream stretches from its explicit loop sample or, failing that, by
+    /// repeating the last sample it holds.
+    fn can_loop(&self) -> bool {
+        !self.loop_disabled && (self.loop_sample.is_some() || !self.fixed.is_empty())
+    }
+
+    fn emit_fixed(&self, out: &mut Vec<bool>, prev: &mut bool, budget: usize, from_end: bool) {
+        if budget == 0 {
+            return;
+        }
+        let mut bits = Vec::with_capacity(budget);
+        let mut scratch = *prev;
+        for (len, sample) in &self.fixed {
+            fill_mfm(&mut bits, &mut scratch, sample, len * 2);
+        }
+        // A backward stream is laid down towards the gap's end, so it is the
+        // tail of it that survives truncation.
+        emit_slice(out, prev, &bits, budget, from_end);
+    }
+
+    fn emit_loop(&self, out: &mut Vec<bool>, prev: &mut bool, budget: usize, from_end: bool) {
+        if budget == 0 {
+            return;
+        }
+        // Without an explicit loop sample the decoder repeats the last sample
+        // it came across -- the first one, for a stream applied in reverse.
+        let sample = self.loop_sample.clone().unwrap_or_else(|| {
+            let pick = if from_end {
+                self.fixed.first()
+            } else {
+                self.fixed.last()
+            };
+            pick.map(|(_, s)| s.clone()).unwrap_or_default()
+        });
+        if from_end {
+            fill_mfm_end_aligned(out, prev, &sample, budget);
+        } else {
+            fill_mfm(out, prev, &sample, budget);
+        }
+    }
+}
+
+/// Append `budget` cells from `bits`, taking them from its end when the
+/// content is aligned to the end of the run rather than its start.
+fn emit_slice(out: &mut Vec<bool>, prev: &mut bool, bits: &[bool], budget: usize, from_end: bool) {
+    let slice = if bits.len() <= budget {
+        bits
+    } else if from_end {
+        &bits[bits.len() - budget..]
+    } else {
+        &bits[..budget]
+    };
+    out.extend_from_slice(slice);
+    // Cells alternate clock and data, so the last data bit is the last
+    // even-indexed one written.
+    if let Some(last) = slice
+        .len()
+        .checked_sub(if slice.len() % 2 == 0 { 1 } else { 2 })
+    {
+        *prev = slice[last];
+    }
+    // A short run is padded to the budget so the gap still comes out the
+    // declared length.
+    for _ in slice.len()..budget {
+        out.push(false);
+    }
+}
+
+/// MFM-encode `sample`, repeating it until `budget` cells have been written.
+fn fill_mfm(out: &mut Vec<bool>, prev: &mut bool, sample: &[bool], budget: usize) {
+    if budget == 0 {
+        return;
+    }
+    if sample.is_empty() {
+        for _ in 0..budget {
+            out.push(false);
+        }
+        return;
+    }
+    let target = out.len() + budget;
+    let mut i = 0;
+    while out.len() < target {
+        let data = sample[i % sample.len()];
+        out.push(!*prev && !data);
+        if out.len() == target {
+            // The gap ended between a cell's clock and its data bit.
+            break;
+        }
+        out.push(data);
+        *prev = data;
+        i += 1;
+    }
+}
+
+/// As [`fill_mfm`], but with the repeat aligned so the sample ends flush with
+/// the end of the run -- how a gap written backwards from the next block sits.
+fn fill_mfm_end_aligned(out: &mut Vec<bool>, prev: &mut bool, sample: &[bool], budget: usize) {
+    if budget == 0 {
+        return;
+    }
+    if sample.is_empty() {
+        for _ in 0..budget {
+            out.push(false);
+        }
+        return;
+    }
+    // Generate a whole number of repeats past the budget, then keep the tail.
+    let period = sample.len() * 2;
+    let generated = budget.div_ceil(period) * period + period;
+    let mut bits = Vec::with_capacity(generated);
+    let mut scratch = *prev;
+    fill_mfm(&mut bits, &mut scratch, sample, generated);
+    emit_slice(out, prev, &bits, budget, true);
+}
+
+/// Read a sample header: its type and length, and where its data starts.
+/// `None` at the nul byte that ends a stream.
+fn read_sample_header(area: &[u8], pos: usize) -> Result<Option<(u8, usize, usize)>> {
+    ensure!(
+        pos < area.len(),
+        "IPF stream runs past the end of the data area"
+    );
+    let header = area[pos];
+    if header == 0 {
+        return Ok(None);
+    }
+    // The top three bits count the length bytes that follow; the low five are
+    // the sample type.
+    let width = (header >> 5) as usize;
+    let kind = header & 0x1f;
+    let start = pos + 1;
+    let end = start
+        .checked_add(width)
+        .context("IPF sample header overflow")?;
+    ensure!(
+        end <= area.len(),
+        "IPF sample length field runs past the end of the data area"
+    );
+    let mut size = 0usize;
+    for byte in &area[start..end] {
+        size = size
+            .checked_mul(256)
+            .and_then(|s| s.checked_add(*byte as usize))
+            .context("IPF sample length overflow")?;
+    }
+    Ok(Some((kind, size, end)))
+}
+
+/// Write already-encoded cells through unchanged.
+fn push_raw(out: &mut Vec<bool>, prev: &mut bool, sample: &[u8], bits: usize) {
+    for i in 0..bits {
+        let bit = sample[i / 8] & (0x80 >> (i % 8)) != 0;
+        out.push(bit);
+        // Cells alternate clock and data; the run is a whole number of bytes,
+        // so it ends on a data bit.
+        if i % 2 == 1 {
+            *prev = bit;
+        }
+    }
+}
+
+fn byte_bits(value: u8) -> Vec<bool> {
+    (0..8).rev().map(|i| value & (1 << i) != 0).collect()
+}
+
+fn bits_of(bytes: &[u8], count: usize) -> Vec<bool> {
+    (0..count)
+        .map(|i| bytes[i / 8] & (0x80 >> (i % 8)) != 0)
+        .collect()
+}
+
+fn read_be_u32(bytes: &[u8]) -> u32 {
+    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+fn name_str(name: &[u8; 4]) -> String {
+    String::from_utf8_lossy(name).to_string()
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    /// The revolution an AmigaDOS track occupies in the fixture below, and in
+    /// the SPS releases it is modelled on: 11 sectors and the index gap.
+    pub(crate) const AMIGADOS_TRACK_BITS: u32 = 100_128;
+    const SECTOR_BYTES: usize = 540;
+    /// Two gap bytes and a doubled sync mark ahead of the sector payload.
+    const BLOCK_BITS: usize = 2 * 16 + 4 * 8 + SECTOR_BYTES * 16;
+    const SECTORS: usize = 11;
+    const GAP_BITS: usize = AMIGADOS_TRACK_BITS as usize - SECTORS * BLOCK_BITS;
+
+    // -- fixture construction ------------------------------------------------
+
+    /// Wrap a body as a chunk, filling in the CRC the decoder checks.
+    fn chunk(name: &[u8; 4], body: &[u8], extra: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(CHUNK_HEADER_LEN + body.len() + extra.len());
+        out.extend_from_slice(name);
+        out.extend_from_slice(&((CHUNK_HEADER_LEN + body.len()) as u32).to_be_bytes());
+        out.extend_from_slice(&[0; 4]);
+        out.extend_from_slice(body);
+        let mut crc = Crc::new();
+        crc.update(&out);
+        let sum = crc.sum().to_be_bytes();
+        out[8..12].copy_from_slice(&sum);
+        out.extend_from_slice(extra);
+        out
+    }
+
+    fn info_body(encoder: u32, encoder_rev: u32) -> Vec<u8> {
+        let mut body = vec![0u8; INFO_BODY_LEN];
+        body[0..4].copy_from_slice(&MEDIA_FLOPPY.to_be_bytes());
+        body[4..8].copy_from_slice(&encoder.to_be_bytes());
+        body[8..12].copy_from_slice(&encoder_rev.to_be_bytes());
+        body
+    }
+
+    #[derive(Clone, Copy)]
+    struct Track {
+        density: u32,
+        signal: u32,
+        start_bit: u32,
+        data_bits: u32,
+        gap_bits: u32,
+        track_bits: u32,
+        blocks: u32,
+    }
+
+    impl Default for Track {
+        fn default() -> Self {
+            Self {
+                density: DENSITY_AUTO,
+                signal: SIGNAL_2US_CELLS,
+                start_bit: 0,
+                data_bits: 0,
+                gap_bits: 0,
+                track_bits: 0,
+                blocks: 1,
+            }
+        }
+    }
+
+    fn imge_body(track: &Track, key: u32) -> Vec<u8> {
+        let mut body = vec![0u8; IMGE_BODY_LEN];
+        let put = |body: &mut Vec<u8>, at: usize, value: u32| {
+            body[at..at + 4].copy_from_slice(&value.to_be_bytes());
+        };
+        put(&mut body, 8, track.density);
+        put(&mut body, 12, track.signal);
+        put(&mut body, 16, track.track_bits / 8);
+        put(&mut body, 20, track.start_bit / 8);
+        put(&mut body, 24, track.start_bit);
+        put(&mut body, 28, track.data_bits);
+        put(&mut body, 32, track.gap_bits);
+        put(&mut body, 36, track.track_bits);
+        put(&mut body, 40, track.blocks);
+        put(&mut body, 52, key);
+        body
+    }
+
+    fn data_chunk(key: u32, area: &[u8]) -> Vec<u8> {
+        let mut body = Vec::with_capacity(DATA_BODY_LEN);
+        body.extend_from_slice(&(area.len() as u32).to_be_bytes());
+        body.extend_from_slice(&((area.len() * 8) as u32).to_be_bytes());
+        let mut crc = Crc::new();
+        crc.update(area);
+        body.extend_from_slice(&crc.sum().to_be_bytes());
+        body.extend_from_slice(&key.to_be_bytes());
+        chunk(b"DATA", &body, area)
+    }
+
+    fn block_descriptor(
+        block_bits: usize,
+        gap_bits: usize,
+        gap_offset: usize,
+        flags: u32,
+        gap_value: u8,
+        data_offset: usize,
+    ) -> Vec<u8> {
+        let mut d = vec![0u8; BLOCK_DESCRIPTOR_LEN];
+        d[0..4].copy_from_slice(&(block_bits as u32).to_be_bytes());
+        d[4..8].copy_from_slice(&(gap_bits as u32).to_be_bytes());
+        d[8..12].copy_from_slice(&(gap_offset as u32).to_be_bytes());
+        d[20..24].copy_from_slice(&flags.to_be_bytes());
+        d[27] = gap_value;
+        d[28..32].copy_from_slice(&(data_offset as u32).to_be_bytes());
+        d
+    }
+
+    /// A stream sample: the type byte carries the width of the length field in
+    /// its top three bits.
+    fn sample(kind: u8, size: usize, data: &[u8]) -> Vec<u8> {
+        let width = if size < 0x100 {
+            1
+        } else if size < 0x1_0000 {
+            2
+        } else {
+            4
+        };
+        let mut out = vec![(width as u8) << 5 | kind];
+        out.extend_from_slice(&size.to_be_bytes()[size_of::<usize>() - width..]);
+        out.extend_from_slice(data);
+        out
+    }
+
+    /// Assemble a one-track image around a ready-made data area.
+    fn image(track: Track, area: &[u8], encoder: u32, encoder_rev: u32) -> Vec<u8> {
+        let mut out = chunk(CAPS_SIGNATURE, &[], &[]);
+        out.extend_from_slice(&chunk(b"INFO", &info_body(encoder, encoder_rev), &[]));
+        out.extend_from_slice(&chunk(b"IMGE", &imge_body(&track, 1), &[]));
+        out.extend_from_slice(&data_chunk(1, area));
+        out
+    }
+
+    /// A track shaped like a real AmigaDOS one: eleven sectors, each opening
+    /// with gap bytes and a doubled `4489` sync mark, and an index gap.
+    pub(crate) fn amigados_ipf_image() -> Vec<u8> {
+        let payload: Vec<u8> = (0..SECTOR_BYTES).map(|i| (i % 251) as u8).collect();
+        let mut stream = sample(DATA_GAP, 2, &[0, 0]);
+        stream.extend_from_slice(&sample(DATA_SYNC, 4, &[0x44, 0x89, 0x44, 0x89]));
+        stream.extend_from_slice(&sample(DATA_DATA, SECTOR_BYTES, &payload));
+        stream.push(0);
+
+        let descriptors = SECTORS * BLOCK_DESCRIPTOR_LEN;
+        let mut area = Vec::new();
+        for sector in 0..SECTORS {
+            area.extend_from_slice(&block_descriptor(
+                BLOCK_BITS,
+                if sector == SECTORS - 1 { GAP_BITS } else { 0 },
+                0,
+                0,
+                0,
+                descriptors + sector * stream.len(),
+            ));
+        }
+        for _ in 0..SECTORS {
+            area.extend_from_slice(&stream);
+        }
+
+        let track = Track {
+            // The index falls inside the gap, as it does on a written disk.
+            start_bit: 2372,
+            data_bits: (SECTORS * BLOCK_BITS) as u32,
+            gap_bits: GAP_BITS as u32,
+            track_bits: AMIGADOS_TRACK_BITS,
+            blocks: SECTORS as u32,
+            ..Track::default()
+        };
+        image(track, &area, ENCODER_CAPS, 1)
+    }
+
+    // -- helpers over a decoded revolution -----------------------------------
+
+    fn bits(track: &IpfTrack) -> Vec<bool> {
+        (0..track.bit_len as usize)
+            .map(|i| track.words[i / 16] & (0x8000 >> (i % 16)) != 0)
+            .collect()
+    }
+
+    fn only_track(image: &[u8]) -> IpfTrack {
+        let mut tracks = decode(image).expect("the fixture should decode");
+        tracks[0]
+            .take()
+            .expect("cylinder 0 head 0 should be present")
+    }
+
+    /// Strip the clock bits: every second cell bit is the data one.
+    fn data_bits(cells: &[bool]) -> Vec<bool> {
+        cells.iter().skip(1).step_by(2).copied().collect()
+    }
+
+    /// MFM never writes two flux transitions in a row. Anything encoded by
+    /// this decoder must hold to that -- only a stored sync mark may not.
+    fn assert_mfm_legal(cells: &[bool]) {
+        for pair in cells.windows(2) {
+            assert!(
+                !(pair[0] && pair[1]),
+                "adjacent set cells are not legal MFM"
+            );
+        }
+    }
+
+    /// `count` data bits of `byte` repeated, entered `phase` bits in.
+    fn repeating_data_bits(byte: u8, phase: usize, count: usize) -> Vec<bool> {
+        (0..count)
+            .map(|i| byte & (0x80 >> ((i + phase) % 8)) != 0)
+            .collect()
+    }
+
+    // -- tests ---------------------------------------------------------------
+
+    #[test]
+    fn amigados_track_decodes_to_its_declared_revolution() {
+        let track = only_track(&amigados_ipf_image());
+        assert_eq!(track.bit_len, AMIGADOS_TRACK_BITS);
+        assert_eq!(
+            track.words.len(),
+            (AMIGADOS_TRACK_BITS as usize).div_ceil(16)
+        );
+    }
+
+    /// A sync mark is stored already encoded precisely because its clocking is
+    /// illegal MFM; passing it through an encoder would destroy it.
+    #[test]
+    fn sync_samples_are_written_through_unencoded() {
+        let track = only_track(&amigados_ipf_image());
+        let cells = bits(&track);
+        let marks = (0..cells.len() - 32)
+            .filter(|&i| {
+                (0..16).all(|b| cells[i + b] == (0x4489 & (0x8000 >> b) != 0))
+                    && (0..16).all(|b| cells[i + 16 + b] == (0x4489 & (0x8000 >> b) != 0))
+            })
+            .count();
+        assert_eq!(marks, SECTORS, "every sector should keep its doubled sync");
+    }
+
+    /// The first block starts where the descriptor says it does relative to
+    /// the index, which is what puts the index inside the gap.
+    #[test]
+    fn the_revolution_is_rotated_to_start_at_the_index() {
+        let track = only_track(&amigados_ipf_image());
+        let cells = bits(&track);
+        // Block 0 opens with two MFM-encoded nul bytes, then the sync mark.
+        let sync_at = 2372 + 32;
+        assert!((0..16).all(|b| cells[sync_at + b] == (0x4489 & (0x8000 >> b) != 0)));
+    }
+
+    #[test]
+    fn encoded_payload_sets_the_clock_bit_only_between_zero_data_bits() {
+        // One block: four decoded bytes, no gap.
+        let payload = [0x00u8, 0xff, 0x0f, 0xa5];
+        let mut stream = sample(DATA_DATA, payload.len(), &payload);
+        stream.push(0);
+        let mut area = block_descriptor(payload.len() * 16, 0, 0, 0, 0, BLOCK_DESCRIPTOR_LEN);
+        area.extend_from_slice(&stream);
+        let track = Track {
+            data_bits: (payload.len() * 16) as u32,
+            track_bits: (payload.len() * 16) as u32,
+            ..Track::default()
+        };
+        let decoded = only_track(&image(track, &area, ENCODER_CAPS, 1));
+        let cells = bits(&decoded);
+        assert_mfm_legal(&cells);
+
+        // The data bits come back out exactly as they went in.
+        let recovered = data_bits(&cells);
+        let expected: Vec<bool> = payload
+            .iter()
+            .flat_map(|b| (0..8).map(move |i| b & (0x80 >> i) != 0))
+            .collect();
+        assert_eq!(recovered, expected);
+    }
+
+    #[test]
+    fn raw_samples_bypass_the_encoder() {
+        let raw = [0xaau8, 0x55];
+        let mut stream = sample(DATA_RAW, raw.len(), &raw);
+        stream.push(0);
+        let mut area = block_descriptor(raw.len() * 8, 0, 0, 0, 0, BLOCK_DESCRIPTOR_LEN);
+        area.extend_from_slice(&stream);
+        let track = Track {
+            data_bits: (raw.len() * 8) as u32,
+            track_bits: (raw.len() * 8) as u32,
+            ..Track::default()
+        };
+        let decoded = only_track(&image(track, &area, ENCODER_CAPS, 1));
+        assert_eq!(decoded.words[0], 0xaa55);
+    }
+
+    /// A gap with no streams of its own repeats the descriptor's gap byte.
+    #[test]
+    fn a_gap_without_streams_repeats_its_gap_byte() {
+        let gap_bits = 320;
+        let area = block_descriptor(0, gap_bits, 0, 0, 0x4e, BLOCK_DESCRIPTOR_LEN);
+        let track = Track {
+            gap_bits: gap_bits as u32,
+            track_bits: gap_bits as u32,
+            ..Track::default()
+        };
+        let decoded = only_track(&image(track, &area, ENCODER_CAPS, 1));
+        let cells = bits(&decoded);
+        assert_eq!(cells.len(), gap_bits);
+        assert_mfm_legal(&cells);
+        assert_eq!(
+            data_bits(&cells),
+            repeating_data_bits(0x4e, 0, gap_bits / 2)
+        );
+    }
+
+    /// The worked example from the format notes: a forward and a backward gap
+    /// stream whose fixed parts fill the gap exactly, with no looping.
+    #[test]
+    fn paired_gap_streams_fill_the_gap_from_both_ends() {
+        let gap_bits = 832;
+        let streams: &[u8] = &[
+            0x41, 0x01, 0x40, 0x22, 0x08, 0x4e, 0x00, // forward: 0x140 bits of 0x4e
+            0x21, 0x60, 0x22, 0x08, 0x00, 0x00, // backward: 0x60 bits of 0x00
+        ];
+        let mut area = block_descriptor(
+            0,
+            gap_bits,
+            BLOCK_DESCRIPTOR_LEN,
+            BLOCK_FLAG_FWGAP | BLOCK_FLAG_BWGAP,
+            0,
+            0,
+        );
+        area.extend_from_slice(streams);
+        let track = Track {
+            gap_bits: gap_bits as u32,
+            track_bits: gap_bits as u32,
+            ..Track::default()
+        };
+        let decoded = only_track(&image(track, &area, ENCODER_SPS_TEST, 2));
+        let cells = bits(&decoded);
+        assert_eq!(cells.len(), gap_bits);
+        assert_mfm_legal(&cells);
+
+        // 0x140 decoded bits of 0x4e forwards, then 0x60 of nul backwards.
+        let recovered = data_bits(&cells);
+        assert_eq!(recovered[..0x140], repeating_data_bits(0x4e, 0, 0x140)[..]);
+        assert!(recovered[0x140..].iter().all(|bit| !bit));
+        assert_eq!(recovered.len(), 0x140 + 0x60);
+    }
+
+    /// The second worked example: loop samples stretch to meet in the middle
+    /// of a gap the fixed samples cannot fill on their own.
+    #[test]
+    fn gap_loop_samples_stretch_to_meet_in_the_middle() {
+        let gap_bits = 2520;
+        let streams: &[u8] = &[
+            0x22, 0x08, 0x4e, 0x00, // forward: loop sample 0x4e
+            0x22, 0x08, 0x4e, // backward: loop sample 0x4e, then
+            0x21, 0x60, 0x22, 0x08, 0x00, 0x00, // 0x60 bits of 0x00
+        ];
+        let mut area = block_descriptor(
+            0,
+            gap_bits,
+            BLOCK_DESCRIPTOR_LEN,
+            BLOCK_FLAG_FWGAP | BLOCK_FLAG_BWGAP,
+            0,
+            0,
+        );
+        area.extend_from_slice(streams);
+        let track = Track {
+            gap_bits: gap_bits as u32,
+            track_bits: gap_bits as u32,
+            ..Track::default()
+        };
+        let decoded = only_track(&image(track, &area, ENCODER_SPS_TEST, 2));
+        let cells = bits(&decoded);
+        assert_eq!(cells.len(), gap_bits);
+        assert_mfm_legal(&cells);
+
+        // The nul sample sits against the next block, and 0x4e fills the rest.
+        let recovered = data_bits(&cells);
+        let (looped, fixed) = recovered.split_at(recovered.len() - 0x60);
+        assert!(fixed.iter().all(|bit| !bit));
+        assert_eq!(looped.len(), (gap_bits - 2 * 0x60) / 2);
+
+        // The two loops meet in the middle of the gap, which is where the
+        // write splice falls: each is aligned to the end it was written from,
+        // so the repeated byte picks up a new phase across the join.
+        let (forward, backward) = looped.split_at(looped.len() / 2);
+        assert_eq!(forward, repeating_data_bits(0x4e, 0, forward.len()));
+        let phase = (8 - backward.len() % 8) % 8;
+        assert_eq!(backward, repeating_data_bits(0x4e, phase, backward.len()));
+    }
+
+    /// The outer cylinders of a real release are left unformatted: they carry
+    /// no blocks and no cells, and must read as no medium rather than as a
+    /// track of zeroes, which would look like a formatted but empty disk.
+    #[test]
+    fn unformatted_tracks_hold_no_medium() {
+        // Cylinder 0 head 0 is formatted; head 1 is bare, as cylinder 83 is on
+        // the disk this was modelled on.
+        let bare = Track {
+            density: DENSITY_NOISE,
+            blocks: 0,
+            ..Track::default()
+        };
+        let mut out = amigados_ipf_image();
+        let mut body = imge_body(&bare, 2);
+        body[4..8].copy_from_slice(&1u32.to_be_bytes());
+        out.extend_from_slice(&chunk(b"IMGE", &body, &[]));
+        out.extend_from_slice(&data_chunk(2, &[]));
+
+        let tracks = decode(&out).expect("a partly formatted image is still usable");
+        assert!(tracks[0].is_some());
+        assert!(tracks[1].is_none());
+    }
+
+    #[test]
+    fn an_image_with_nothing_formatted_is_rejected() {
+        let bare = Track {
+            density: DENSITY_NOISE,
+            blocks: 0,
+            ..Track::default()
+        };
+        let mut out = chunk(CAPS_SIGNATURE, &[], &[]);
+        out.extend_from_slice(&chunk(b"INFO", &info_body(ENCODER_CAPS, 1), &[]));
+        out.extend_from_slice(&chunk(b"IMGE", &imge_body(&bare, 1), &[]));
+        out.extend_from_slice(&data_chunk(1, &[]));
+        let err = decode(&out).expect_err("an image with no formatted track is not usable");
+        assert!(format!("{err:#}").contains("no formatted tracks"));
+    }
+
+    #[test]
+    fn a_corrupt_chunk_is_rejected() {
+        let mut image = amigados_ipf_image();
+        // Flip a byte inside the INFO chunk body.
+        let info = CHUNK_HEADER_LEN + 20;
+        image[info] ^= 0xff;
+        let err = decode(&image).expect_err("a chunk whose CRC fails should be rejected");
+        assert!(format!("{err:#}").contains("CRC mismatch"));
+    }
+
+    #[test]
+    fn a_corrupt_data_area_is_rejected() {
+        let mut image = amigados_ipf_image();
+        let last = image.len() - 1;
+        image[last] ^= 0xff;
+        let err = decode(&image).expect_err("a data area whose CRC fails should be rejected");
+        assert!(format!("{err:#}").contains("CRC mismatch"));
+    }
+
+    /// The stream must lay down exactly the cells the descriptor promised;
+    /// a mismatch means the samples were read the wrong way.
+    #[test]
+    fn a_block_shorter_than_it_declares_is_rejected() {
+        let payload = [0x00u8; 4];
+        let mut stream = sample(DATA_DATA, payload.len(), &payload);
+        stream.push(0);
+        // Claim one byte more than the stream carries.
+        let mut area = block_descriptor(payload.len() * 16 + 16, 0, 0, 0, 0, BLOCK_DESCRIPTOR_LEN);
+        area.extend_from_slice(&stream);
+        let track = Track {
+            data_bits: (payload.len() * 16 + 16) as u32,
+            track_bits: (payload.len() * 16 + 16) as u32,
+            ..Track::default()
+        };
+        let err = decode(&image(track, &area, ENCODER_CAPS, 1))
+            .expect_err("a short block should be rejected");
+        assert!(format!("{err:#}").contains("bits, not the"));
+    }
+
+    #[test]
+    fn a_high_density_signal_is_rejected() {
+        let mut image_bytes = amigados_ipf_image();
+        // Rewrite the IMGE signal type, then repair the chunk CRC.
+        let imge = CHUNK_HEADER_LEN + (CHUNK_HEADER_LEN + INFO_BODY_LEN);
+        let body = imge + CHUNK_HEADER_LEN;
+        image_bytes[body + 12..body + 16].copy_from_slice(&2u32.to_be_bytes());
+        let end = body + IMGE_BODY_LEN;
+        image_bytes[imge + 8..imge + 12].copy_from_slice(&[0; 4]);
+        let mut crc = Crc::new();
+        crc.update(&image_bytes[imge..end]);
+        let sum = crc.sum().to_be_bytes();
+        image_bytes[imge + 8..imge + 12].copy_from_slice(&sum);
+
+        let err = decode(&image_bytes).expect_err("an HD cell rate is not an Amiga DD disk");
+        assert!(format!("{err:#}").contains("signal type"));
+    }
+
+    /// Files the CAPS encoder wrote spend the flags word on other fields, so
+    /// the decoder must not read gap streams out of them.
+    const ENCODER_SPS_TEST: u32 = 2;
+
+    #[test]
+    fn caps_encoded_files_ignore_the_block_flags() {
+        let caps = Info {
+            media_type: MEDIA_FLOPPY,
+            encoder_type: ENCODER_CAPS,
+            encoder_rev: 1,
+        };
+        assert!(!caps.block_flags_meaningful());
+        let sps = Info {
+            media_type: MEDIA_FLOPPY,
+            encoder_type: ENCODER_SPS_TEST,
+            encoder_rev: 2,
+        };
+        assert!(sps.block_flags_meaningful());
+    }
+}

--- a/src/ipf.rs
+++ b/src/ipf.rs
@@ -325,11 +325,22 @@ impl Info {
         })
     }
 
-    /// Block flags and the gap streams they point at exist only in a file the
-    /// SPS encoder wrote. A CAPS-encoded file spends the same two descriptor
-    /// words on the block and gap byte counts, so there is no gap-stream
-    /// offset to follow and the flags field is defined to read as zero -- as
-    /// it is for encoder release 1.
+    /// Whether a block descriptor's flags word can be believed. Reading gap
+    /// streams out of it needs two separate fields to be defined, and each
+    /// condition here guards one of them:
+    ///
+    /// - the encoder *type* fixes the descriptor's union: a CAPS-encoded file
+    ///   spends the word an SPS one uses for the gap-stream offset on the
+    ///   block's byte count instead, so there is no offset to follow even if
+    ///   the flags asked for one;
+    /// - the encoder *release* fixes the flags word itself, which release 1
+    ///   leaves undefined and which is therefore read as zero.
+    ///
+    /// So the flags are only acted on when both hold. Erring this way costs at
+    /// most the gap fill -- a gap whose streams are skipped is still laid down
+    /// at its declared length from the descriptor's gap byte -- whereas
+    /// trusting the word too readily would send the parser chasing a
+    /// gap-stream offset that is really a byte count.
     fn block_flags_meaningful(&self) -> bool {
         self.encoder_type != ENCODER_CAPS && self.encoder_rev != 1
     }
@@ -788,8 +799,8 @@ fn emit_slice(out: &mut Vec<bool>, prev: &mut bool, bits: &[bool], budget: usize
         &bits[..budget]
     };
     out.extend_from_slice(slice);
-    // Cells alternate clock and data, so the last data bit is the last
-    // even-indexed one written.
+    // A cell is a clock bit then a data bit, so the data bits are the odd
+    // indices and the last one is the end of the last whole cell.
     if let Some(last) = slice
         .len()
         .checked_sub(if slice.len() % 2 == 0 { 1 } else { 2 })
@@ -888,8 +899,10 @@ fn push_raw(out: &mut Vec<bool>, prev: &mut bool, sample: &[u8], bits: usize) {
     for i in 0..bits {
         let bit = sample[i / 8] & (0x80 >> (i % 8)) != 0;
         out.push(bit);
-        // Cells alternate clock and data; the run is a whole number of bytes,
-        // so it ends on a data bit.
+        // A cell is a clock bit then a data bit, so every odd index is a data
+        // bit and the last one to land is what the next encoded sample follows
+        // on from. A bit-counted sample may stop part way through a cell, which
+        // simply leaves the preceding data bit standing.
         if i % 2 == 1 {
             *prev = bit;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod heatmap;
 pub mod ide_a4000;
 pub mod inputrec;
 pub mod inputsched;
+pub mod ipf;
 // Host-keyboard controller bindings: a frontend concern (it speaks winit key
 // codes and produces the same `JoystickState` the gamepad reader does), so it
 // rides the same feature gate as `gamepad`. The autofire policy that pairs

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8672,7 +8672,7 @@ impl App {
             .set_title(format!("Load DF{drive_idx} disk image(s)"))
             .add_filter(
                 "Amiga disk images",
-                &["adf", "adz", "dms", "scp", "gz", "zip"],
+                &["adf", "adz", "dms", "scp", "gz", "ipf", "zip"],
             )
             .pick_files();
 


### PR DESCRIPTION
An IPF preserves the *encoded* track rather than its sectors -- sync marks, gaps and sector headers, every cell the head passes over -- which is what carries the custom trackloaders and copy protections an ADF cannot express. The loader rejected them outright, deferring the choice between a direct parser and the closed-source `capsimg` library.

This decodes them directly, so a build that says it reads IPF does, on every platform, with nothing to download -- the same reasoning that vendors FloppyBridge rather than dlopen-ing it.

## How it works

`src/ipf.rs` walks the chunk container and rebuilds each track from its block descriptors:

- Chunk CRCs are checked (each covers itself with its own CRC field zeroed), and the walk steps over the data area that trails a `DATA` chunk uncounted by its length -- the one place the container breaks its own rule.
- **Sync and raw** samples are already-encoded MFM and go through untouched, which is how an address mark keeps its illegal clocking. **Data and gap** samples hold decoded bytes that get MFM-encoded, clock bit set only between two zero data bits.
- Block gaps fill either from a repeated byte or from forward and backward gap streams, whose loop samples stretch to meet at the write splice in the middle of the gap.
- Every track is checked against the bit counts its descriptors declare, then rotated so the revolution starts at the index -- the shape a flux capture already has, so the rotation, PLL and sync-word machinery reads an IPF with no special case in the hot path.

The format stores one canonical revolution and nothing to write back into, so an IPF always inserts write-protected.

## Modelling gaps (logged at load)

- Tracks recorded with a varying cell *rate* (Copylock, Speedlock, Brierley density models) decode with uniform 2 us cells. The data is right; a protection that measures cell timing is not.
- Weak bits replay as the single stored revolution rather than varying per revolution.

`FloppyTrackImage::RawMfm` already carries `bitcell_ns` and multiple revolutions, so both are expressible when the per-protection profiles are modelled.

## Also fixed

`config.rs` validated floppy paths against a signature allowlist with no CAPS entry, so an `.ipf` named in a TOML was refused before the loader ever saw it. The runtime disk picker was missing the extension too.

## Verification

Against a Shadow of the Beast / Blood Money demo IPF:

- All chunk and data-area CRCs pass; all 160 formatted tracks decode to exactly the bit counts they declare.
- Cylinder 0 head 0 yields 11 AmigaDOS sectors with every header and data checksum valid and a `DOS\0` bootblock.
- The disk boots to its menu and runs both previews on an A500 with Kickstart 1.3. The previews load through the single-block custom tracks -- the part an ADF cannot hold.

The index rotation was the one interpretive choice: reading `startBitPos` as the offset from the index to block 0 puts the index inside the gap on all 160 tracks, where the opposite direction puts it inside sector data on all 160.

15 unit tests in `ipf.rs` (including the two worked gap-stream examples from the format notes, which pin exact output for the paired-stream and loop-sample cases), plus loader and config coverage. Full suite green, clippy and fmt clean.
