### PR TITLE
cpu: transfer a memory bit field at the width it spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe82d60d6d94251df67281046732a6cff60950f7434800a950af6b43bf74282"
+checksum = "ad5d9c86aa821297e93fe0d4968c0f3eeef07073a58e8dc1e62b1d58b9fe48a1"
 dependencies = [
  "cranelift-codegen 0.132.3",
  "cranelift-frontend 0.132.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8848c156b8d1d933818ea1db767f20822514fae307a51aea9f4b8c31e03ec367"
+checksum = "6fe82d60d6d94251df67281046732a6cff60950f7434800a950af6b43bf74282"
 dependencies = [
  "cranelift-codegen 0.132.3",
  "cranelift-frontend 0.132.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ ctl-bin = ["dep:serde_json"]
 floppybridge = []
 
 [dependencies]
-m68k = { version = "0.7.0", features = ["serde"] }
+m68k = { version = "0.7.1", features = ["serde"] }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ ctl-bin = ["dep:serde_json"]
 floppybridge = []
 
 [dependencies]
-m68k = { version = "0.5.2", features = ["serde"] }
+m68k = { version = "0.7.0", features = ["serde"] }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.5.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8848c156b8d1d933818ea1db767f20822514fae307a51aea9f4b8c31e03ec367"
+checksum = "ad5d9c86aa821297e93fe0d4968c0f3eeef07073a58e8dc1e62b1d58b9fe48a1"
 dependencies = [
  "serde",
 ]

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -3,7 +3,7 @@
 ## The wrapper and the bus adapter
 
 `M68kMachine` (`src/cpu.rs`) wraps the published pure-Rust
-[`m68k` 0.7 core](https://docs.rs/crate/m68k/0.7.0). The core sees
+[`m68k` 0.7 core](https://docs.rs/crate/m68k/0.7.1). The core sees
 the machine through an adapter implementing its `AddressBus` trait, so
 every CPU-visible access -- RAM, ROM, custom registers, CIA, RTC,
 autoconfig, Gayle, Akiko -- routes into the shared `Bus` and is billed in
@@ -23,7 +23,7 @@ fits a 68881/68882 to any 020/030 (and is on by default for the 68040,
 whose FPU is on-die): the `m68k` core executes the 6888x instruction
 set in true 80-bit extended precision via a pure-Rust software floating-
 point engine
-([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/fpu/softfloat.rs)).
+([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/fpu/softfloat.rs)).
 Arithmetic (add, sub,
 mul, div, sqrt, and the single-accuracy FSGLMUL/FSGLDIV, which round the
 mantissa to 24 bits but keep the extended exponent range -- gcc -m68040
@@ -41,13 +41,13 @@ whose saved FPU frame carries a foreign size) are all modelled. The transcendent
 FASIN/FACOS/FATAN, the hyperbolics, FETOX/FETOXM1/FTWOTOX/FTENTOX,
 FLOGN/FLOGNP1/FLOG2/FLOG10) and FSINCOS run in extended precision too: a
 double-`FloatX80` ("double-double", ~128-bit) layer
-([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/fpu/dd.rs))
+([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/fpu/dd.rs))
 evaluates Taylor/atanh series over reduced
 ranges and rounds the result to extended under the FPCR mode, setting INEX
 and the domain flags (OPERR/DZ). Accuracy is validated against an
 arbitrary-precision oracle (the pure-Rust `astro-float`, a dev-only
 dependency;
-[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/tests/fpu_accuracy.rs)):
+[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/tests/fpu_accuracy.rs)):
 every function is within
 1 ULP across a wide sweep and all four rounding modes, and round-to-nearest
 is correctly rounded in practice. They are not chip-bit-exact -- the real
@@ -57,7 +57,7 @@ quotient byte. This covers Kickstart's
 detection and per-task FPU context switching. The
 68000's per-instruction cycle counts in the `m68k` core have been
 corrected to exact totals across the SingleStepTests 68000 cycle corpus
-([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.7.0#validation--testing)),
+([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.7.1#validation--testing)),
 which is what makes
 cycle-budgeted pacing trustworthy.
 
@@ -127,7 +127,7 @@ precise.
 
 The 68000's two-word instruction prefetch queue (IRD/IRC) is modelled in
 the `m68k` core
-([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/cpu.rs)):
+([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/core/cpu.rs)):
 the
 next opcode is fetched before the current instruction finishes, so
 self-modifying code that overwrites the *next* instruction executes the
@@ -189,13 +189,13 @@ DBcc loop mode: a DBcc that branches -4 back to a loopable one-word
 instruction holds the body/DBcc pair in the prefetch queue and re-executes
 it with no instruction fetches until the condition turns true, the counter
 expires, or an exception intervenes (`loop_mode` in
-[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/cpu.rs);
+[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/core/cpu.rs);
 the loopable set and the DBcc entry/exit arms live in
-[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/decode.rs)).
+[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/core/decode.rs)).
 A looping DBcc iteration costs 6 internal
 clocks and touches the bus only for the body's operands, which is what
 makes tight copy/clear loops measurably faster on a real 68010.
-[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/tests/loop_mode_timing_tests.rs)
+[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/tests/loop_mode_timing_tests.rs)
 pins engagement, the
 68000's non-engagement, and the no-fetch iteration cost.
 
@@ -219,7 +219,7 @@ the STOP itself, so the handler's RTE re-executes it; a pending trace
 (T set in the SR the instruction started with) has priority and recovers
 from the stop, while a T bit loaded *by* STOP does not fire while
 stopped.
-[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/tests/stop_and_68010_timing_tests.rs)
+[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/tests/stop_and_68010_timing_tests.rs)
 pins all of these.
 
 ## Caches
@@ -303,7 +303,7 @@ shares the 040's three-level walker and TC[15] enable; PTEST is gone
 faulting with the format $4 frame.
 
 **Timing.**
-[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/timing_060.rs)
+[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/core/timing_060.rs)
 replaces the 020+
 scaling formula for the 060: every opcode word classifies (a build-once
 64K table over a pure function) into the MC68060UM Chapter 10 dispatch
@@ -345,7 +345,7 @@ instruction cache, a three-stage pipeline, execution overlap, dynamic bus
 sizing, and alignment-dependent transfers, so an opcode does not have one
 context-free cycle count.
 
-[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/timing_020.rs)
+[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.1/src/core/timing_020.rs)
 transcribes the integer timing tables
 from section 8.2 of the
 [MC68020 User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68020UM.pdf).
@@ -375,16 +375,30 @@ as a byte, word, three-byte or long (MC68020UM 5.3.1), so a memory bit field
 is one transfer of whatever it spans rather than a composed sequence. The
 three-byte case has no equivalent in the 68000 the `AddressBus` grew up
 around, so the m68k core carries a dedicated three-byte transfer (0.7.0) and
-`M68kMachine` overrides it to bill one access. Composing that span from a
-word plus a byte instead billed two, which `timing-test/bfprobe.asm` row 10
-(`bfextu (a0){4:16}`) measured as a 0.5% overcharge against a real A1200 --
-visible only on the 32-bit chip bus, where a span within four bytes is one
-cycle but a word and a byte are two. The other bit-field spans, and the
-`BFSET` pair driving SANITY Roots II AGA's "DIE" dissolve (issue #371), were
-already right; that row was the outlier. The same reasoning keeps the access
-from touching a byte beyond the field, which on a memory-mapped register or
-at the end of a mapped region would be observable rather than merely
-mistimed.
+`M68kMachine` overrides it.
+
+What that transfer costs is then decided by the addressed port, which is
+dynamic bus sizing: the processor requests the whole operand and the port
+answers with its own width. A 32-bit port takes all three bytes in one cycle;
+a 16-bit port makes the processor run a word cycle and then a byte cycle for
+the remainder. Copperline splits on that boundary. Plain memory is a byte
+array whichever width it answers at, so it takes the sized access and
+`grant_cpu_bus_access_at` bills it by port width -- one Alice slot on AGA, two
+on a 16-bit Agnus. Every device port is 16 bits and keeps the split cycles,
+which is both what the silicon runs and what keeps each register's own
+read/write side effects: a device decodes a register per access, so a single
+three-byte read of `$DFFxxx` would name no register and would drop the third
+byte rather than fetching it from the next one.
+
+Billing the composed pair everywhere instead over-charged the 32-bit case,
+which `timing-test/bfprobe.asm` row 10 (`bfextu (a0){4:16}`) measured as a
+0.5% overcharge against a real A1200 -- visible only on the 32-bit chip bus,
+where a span within four bytes is one cycle but a word and a byte are two. The
+other bit-field spans, and the `BFSET` pair driving SANITY Roots II AGA's
+"DIE" dissolve (issue #371), were already right; that row was the outlier.
+Sizing the access to the span also keeps it off the byte beyond the field,
+which on a memory-mapped register or at the end of a mapped region would be
+observable rather than merely mistimed.
 
 A taken branch pays a pipeline-refill charge on top of its table entry. The
 section-8.2 entries are written for an instruction whose successor is already

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -3,7 +3,7 @@
 ## The wrapper and the bus adapter
 
 `M68kMachine` (`src/cpu.rs`) wraps the published pure-Rust
-[`m68k` 0.5 core](https://docs.rs/crate/m68k/0.5.2). The core sees
+[`m68k` 0.7 core](https://docs.rs/crate/m68k/0.7.0). The core sees
 the machine through an adapter implementing its `AddressBus` trait, so
 every CPU-visible access -- RAM, ROM, custom registers, CIA, RTC,
 autoconfig, Gayle, Akiko -- routes into the shared `Bus` and is billed in
@@ -23,7 +23,7 @@ fits a 68881/68882 to any 020/030 (and is on by default for the 68040,
 whose FPU is on-die): the `m68k` core executes the 6888x instruction
 set in true 80-bit extended precision via a pure-Rust software floating-
 point engine
-([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/fpu/softfloat.rs)).
+([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/fpu/softfloat.rs)).
 Arithmetic (add, sub,
 mul, div, sqrt, and the single-accuracy FSGLMUL/FSGLDIV, which round the
 mantissa to 24 bits but keep the extended exponent range -- gcc -m68040
@@ -41,13 +41,13 @@ whose saved FPU frame carries a foreign size) are all modelled. The transcendent
 FASIN/FACOS/FATAN, the hyperbolics, FETOX/FETOXM1/FTWOTOX/FTENTOX,
 FLOGN/FLOGNP1/FLOG2/FLOG10) and FSINCOS run in extended precision too: a
 double-`FloatX80` ("double-double", ~128-bit) layer
-([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/fpu/dd.rs))
+([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/fpu/dd.rs))
 evaluates Taylor/atanh series over reduced
 ranges and rounds the result to extended under the FPCR mode, setting INEX
 and the domain flags (OPERR/DZ). Accuracy is validated against an
 arbitrary-precision oracle (the pure-Rust `astro-float`, a dev-only
 dependency;
-[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/tests/fpu_accuracy.rs)):
+[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/tests/fpu_accuracy.rs)):
 every function is within
 1 ULP across a wide sweep and all four rounding modes, and round-to-nearest
 is correctly rounded in practice. They are not chip-bit-exact -- the real
@@ -57,7 +57,7 @@ quotient byte. This covers Kickstart's
 detection and per-task FPU context switching. The
 68000's per-instruction cycle counts in the `m68k` core have been
 corrected to exact totals across the SingleStepTests 68000 cycle corpus
-([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.5.2#validation--testing)),
+([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.7.0#validation--testing)),
 which is what makes
 cycle-budgeted pacing trustworthy.
 
@@ -127,7 +127,7 @@ precise.
 
 The 68000's two-word instruction prefetch queue (IRD/IRC) is modelled in
 the `m68k` core
-([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/core/cpu.rs)):
+([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/cpu.rs)):
 the
 next opcode is fetched before the current instruction finishes, so
 self-modifying code that overwrites the *next* instruction executes the
@@ -189,13 +189,13 @@ DBcc loop mode: a DBcc that branches -4 back to a loopable one-word
 instruction holds the body/DBcc pair in the prefetch queue and re-executes
 it with no instruction fetches until the condition turns true, the counter
 expires, or an exception intervenes (`loop_mode` in
-[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/core/cpu.rs);
+[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/cpu.rs);
 the loopable set and the DBcc entry/exit arms live in
-[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/core/decode.rs)).
+[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/decode.rs)).
 A looping DBcc iteration costs 6 internal
 clocks and touches the bus only for the body's operands, which is what
 makes tight copy/clear loops measurably faster on a real 68010.
-[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/tests/loop_mode_timing_tests.rs)
+[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/tests/loop_mode_timing_tests.rs)
 pins engagement, the
 68000's non-engagement, and the no-fetch iteration cost.
 
@@ -219,7 +219,7 @@ the STOP itself, so the handler's RTE re-executes it; a pending trace
 (T set in the SR the instruction started with) has priority and recovers
 from the stop, while a T bit loaded *by* STOP does not fire while
 stopped.
-[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/tests/stop_and_68010_timing_tests.rs)
+[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/tests/stop_and_68010_timing_tests.rs)
 pins all of these.
 
 ## Caches
@@ -303,7 +303,7 @@ shares the 040's three-level walker and TC[15] enable; PTEST is gone
 faulting with the format $4 frame.
 
 **Timing.**
-[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/core/timing_060.rs)
+[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/timing_060.rs)
 replaces the 020+
 scaling formula for the 060: every opcode word classifies (a build-once
 64K table over a pure function) into the MC68060UM Chapter 10 dispatch
@@ -345,7 +345,7 @@ instruction cache, a three-stage pipeline, execution overlap, dynamic bus
 sizing, and alignment-dependent transfers, so an opcode does not have one
 context-free cycle count.
 
-[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.5.2/src/core/timing_020.rs)
+[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.7.0/src/core/timing_020.rs)
 transcribes the integer timing tables
 from section 8.2 of the
 [MC68020 User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68020UM.pdf).
@@ -368,6 +368,23 @@ instruction executes, then advances only the unconsumed part of the table
 total. An A1200 chip-RAM access can therefore extend an instruction through
 Alice arbitration; selecting a smaller CPU total cannot erase a bus wait
 that already happened.
+
+Because the billing follows the accesses, an operand has to reach the bus at
+the width the processor actually transfers it. The 68020/030 size an operand
+as a byte, word, three-byte or long (MC68020UM 5.3.1), so a memory bit field
+is one transfer of whatever it spans rather than a composed sequence. The
+three-byte case has no equivalent in the 68000 the `AddressBus` grew up
+around, so the m68k core carries a dedicated three-byte transfer (0.7.0) and
+`M68kMachine` overrides it to bill one access. Composing that span from a
+word plus a byte instead billed two, which `timing-test/bfprobe.asm` row 10
+(`bfextu (a0){4:16}`) measured as a 0.5% overcharge against a real A1200 --
+visible only on the 32-bit chip bus, where a span within four bytes is one
+cycle but a word and a byte are two. The other bit-field spans, and the
+`BFSET` pair driving SANITY Roots II AGA's "DIE" dissolve (issue #371), were
+already right; that row was the outlier. The same reasoning keeps the access
+from touching a byte beyond the field, which on a memory-mapped register or
+at the end of a mapped region would be observable rather than merely
+mistimed.
 
 A taken branch pays a pipeline-refill charge on top of its table entry. The
 section-8.2 entries are written for an instruction whose successor is already

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -657,7 +657,7 @@ debits a per-frame instruction budget one of two ways, selected by
   tails, chip-bus grants and contention waits -- so the slice's elapsed bus
   CCK is the true hardware cost (`real_slice_accounting` in
   `src/emulator.rs`). Because the m68k core's 68000 cycle totals are exact
-  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.7.0#validation--testing),
+  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.7.1#validation--testing),
   this matches a stock PAL 68000.
 - `instructions`: a flat cycles-per-instruction quota
   (`COPPERLINE_REAL_CPU_CPI`, default 4.0), debited by retired

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -657,7 +657,7 @@ debits a per-frame instruction budget one of two ways, selected by
   tails, chip-bus grants and contention waits -- so the slice's elapsed bus
   CCK is the true hardware cost (`real_slice_accounting` in
   `src/emulator.rs`). Because the m68k core's 68000 cycle totals are exact
-  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.5.2#validation--testing),
+  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.7.0#validation--testing),
   this matches a stock PAL 68000.
 - `instructions`: a flat cycles-per-instruction quota
   (`COPPERLINE_REAL_CPU_CPI`, default 4.0), debited by retired

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2420,14 +2420,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/m68k/m68k-0.5.2.crate",
-        "sha256": "8848c156b8d1d933818ea1db767f20822514fae307a51aea9f4b8c31e03ec367",
-        "dest": "cargo/vendor/m68k-0.5.2"
+        "url": "https://static.crates.io/crates/m68k/m68k-0.7.1.crate",
+        "sha256": "ad5d9c86aa821297e93fe0d4968c0f3eeef07073a58e8dc1e62b1d58b9fe48a1",
+        "dest": "cargo/vendor/m68k-0.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8848c156b8d1d933818ea1db767f20822514fae307a51aea9f4b8c31e03ec367\", \"files\": {}}",
-        "dest": "cargo/vendor/m68k-0.5.2",
+        "contents": "{\"package\": \"ad5d9c86aa821297e93fe0d4968c0f3eeef07073a58e8dc1e62b1d58b9fe48a1\", \"files\": {}}",
+        "dest": "cargo/vendor/m68k-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3724,6 +3724,27 @@ impl AddressBus for CpuBus {
         Ok(())
     }
 
+    fn try_read_three_bytes(&mut self, address: u32) -> Result<u32, BusFault> {
+        self.check_injected_fault(address, 3, false)?;
+        Ok(self.read_three_bytes(address))
+    }
+
+    fn try_write_three_bytes(&mut self, address: u32, value: u32) -> Result<(), BusFault> {
+        self.check_injected_fault(address, 3, true)?;
+        self.write_three_bytes(address, value);
+        Ok(())
+    }
+
+    fn read_three_bytes(&mut self, address: u32) -> u32 {
+        self.sample_ipl();
+        self.read_sized(address, 3, CpuBusAccessKind::Read)
+    }
+
+    fn write_three_bytes(&mut self, address: u32, value: u32) {
+        self.sample_ipl();
+        self.write_sized(address, 3, value);
+    }
+
     fn try_read_immediate_word(&mut self, address: u32) -> Result<u16, BusFault> {
         self.check_injected_fault(address, 2, false)?;
         Ok(self.read_immediate_word(address))
@@ -4465,6 +4486,101 @@ mod tests {
         let _ = bus.read_immediate_word(0);
         let (cck, _) = bus.bus.take_slice_bus_advance();
         assert!(cck >= 2);
+    }
+
+    #[test]
+    fn three_byte_operand_costs_one_alice_slot_not_a_word_plus_a_byte() {
+        // The 020/030 size an operand as a byte, word, three-byte or long
+        // (MC68020UM 5.3.1), so a memory bit field spanning three bytes is a
+        // single transfer. Alice moves anything up to a longword in one bus
+        // slot, so on AGA that costs exactly what a long costs -- and strictly
+        // less than the word-plus-byte pair the core composes when the bus
+        // offers no three-byte transfer.
+        //
+        // Regression: timing-test/bfprobe.asm row 10 (`bfextu (a0){4:16}`)
+        // measured the composed form billing the extra slot, reading 0.5% high
+        // against a real A1200 while every other bit-field span matched.
+        use crate::chipset::agnus::AgnusRevision;
+        use crate::chipset::denise::DeniseRevision;
+
+        let cost = |access: &mut dyn FnMut(&mut CpuBus)| -> u32 {
+            let mut bus = CpuBus {
+                bus: test_bus(reset_rom(0, 0)),
+                address_mask: ADDRESS_MASK_24BIT,
+                dbg_memw_addr: None,
+                dbg_memw_hit: None,
+                icache: None,
+                dcache: None,
+                dbg_irq_window: None,
+                last_fetch_cache_hit: false,
+                instruction_fetches_cached: false,
+                sampled_irq_level: 0,
+                ipl_sample_held: false,
+                diag_current_pc: 0,
+                jit_enabled: false,
+            };
+            bus.bus
+                .set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
+            bus.bus.set_cpu_bus_arbitration_enabled(true);
+            // Same starting slot for every case, so the comparison is of slots
+            // consumed rather than of where in the line the access began.
+            bus.bus.agnus.hpos = 0x040;
+            access(&mut bus);
+            bus.bus.take_slice_bus_advance().0
+        };
+
+        // A longword-aligned three-byte field, entirely inside one longword.
+        let three = cost(&mut |bus| {
+            let _ = bus.read_three_bytes(CHIP_RAM_BASE as u32);
+        });
+        let long = cost(&mut |bus| {
+            let _ = bus.read_long(CHIP_RAM_BASE as u32);
+        });
+        let composed = cost(&mut |bus| {
+            let _ = bus.read_word(CHIP_RAM_BASE as u32);
+            let _ = bus.read_byte(CHIP_RAM_BASE as u32 + 2);
+        });
+
+        assert_eq!(
+            three, long,
+            "a three-byte operand inside one longword must cost what a long costs on Alice"
+        );
+        assert!(
+            three < composed,
+            "three-byte transfer ({three} cck) must beat the composed word+byte ({composed} cck)"
+        );
+    }
+
+    #[test]
+    fn three_byte_operand_moves_exactly_three_bytes() {
+        // The transfer must not touch the byte past the field: on a
+        // memory-mapped register or at the end of a mapped region that byte is
+        // observable, not merely mistimed.
+        let mut bus = CpuBus {
+            bus: test_bus(reset_rom(0, 0)),
+            address_mask: ADDRESS_MASK_24BIT,
+            dbg_memw_addr: None,
+            dbg_memw_hit: None,
+            icache: None,
+            dcache: None,
+            dbg_irq_window: None,
+            last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
+            sampled_irq_level: 0,
+            ipl_sample_held: false,
+            diag_current_pc: 0,
+            jit_enabled: false,
+        };
+        let base = CHIP_RAM_BASE as u32;
+        write_chip_long(&mut bus.bus, base, 0x1122_3344);
+        assert_eq!(bus.read_three_bytes(base), 0x0011_2233);
+
+        bus.write_three_bytes(base, 0x00AA_BBCC);
+        assert_eq!(
+            read_chip_long(&bus.bus, base),
+            0xAABB_CC44,
+            "the fourth byte must be untouched"
+        );
     }
 
     #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3291,6 +3291,39 @@ impl CpuBus {
         value
     }
 
+    /// Whether a three-byte operand at `address` lands entirely inside plain
+    /// memory, and so can be moved as one sized access.
+    ///
+    /// This is the 68020's dynamic bus sizing decided in advance. The
+    /// processor requests the whole operand and the addressed port answers
+    /// with its own width: a 32-bit port (Alice chip RAM, local fast RAM)
+    /// takes all three bytes in one cycle, while a 16-bit port makes the
+    /// processor run a word cycle and then a byte cycle for the remainder.
+    /// Plain memory is a byte array whichever width it answers at, so a
+    /// single sized access carries the right data and `grant_cpu_bus_access_at`
+    /// already bills it by port width. Every device port on an Amiga is 16
+    /// bits, and a device decodes a register per access rather than a byte
+    /// range -- one three-byte read of $DFFxxx is not a register -- so those
+    /// keep the split cycles, which is both what the silicon runs and what
+    /// preserves each register's own read/write side effects.
+    ///
+    /// A span crossing out of a region also lands here: `region_offset` only
+    /// matches when the whole operand fits, so the split path handles the
+    /// halves through their own decodes.
+    fn three_byte_operand_is_plain_memory(&self, address: u32) -> bool {
+        self.classify_plain_memory(self.mask(address), 3).is_some()
+    }
+
+    fn read_three_bytes_plain(&mut self, address: u32) -> u32 {
+        self.sample_ipl();
+        self.read_sized(address, 3, CpuBusAccessKind::Read)
+    }
+
+    fn write_three_bytes_plain(&mut self, address: u32, value: u32) {
+        self.sample_ipl();
+        self.write_sized(address, 3, value);
+    }
+
     fn write_sized(&mut self, address: u32, size: usize, value: u32) {
         let addr = self.mask(address);
         self.note_cpu_data_bus(addr, size, value);
@@ -3725,24 +3758,41 @@ impl AddressBus for CpuBus {
     }
 
     fn try_read_three_bytes(&mut self, address: u32) -> Result<u32, BusFault> {
+        if !self.three_byte_operand_is_plain_memory(address) {
+            let hi = self.try_read_word(address)? as u32;
+            let lo = self.try_read_byte(address.wrapping_add(2))? as u32;
+            return Ok((hi << 8) | lo);
+        }
         self.check_injected_fault(address, 3, false)?;
-        Ok(self.read_three_bytes(address))
+        Ok(self.read_three_bytes_plain(address))
     }
 
     fn try_write_three_bytes(&mut self, address: u32, value: u32) -> Result<(), BusFault> {
+        if !self.three_byte_operand_is_plain_memory(address) {
+            self.try_write_word(address, (value >> 8) as u16)?;
+            return self.try_write_byte(address.wrapping_add(2), value as u8);
+        }
         self.check_injected_fault(address, 3, true)?;
-        self.write_three_bytes(address, value);
+        self.write_three_bytes_plain(address, value);
         Ok(())
     }
 
     fn read_three_bytes(&mut self, address: u32) -> u32 {
-        self.sample_ipl();
-        self.read_sized(address, 3, CpuBusAccessKind::Read)
+        if !self.three_byte_operand_is_plain_memory(address) {
+            let hi = self.read_word(address) as u32;
+            let lo = self.read_byte(address.wrapping_add(2)) as u32;
+            return (hi << 8) | lo;
+        }
+        self.read_three_bytes_plain(address)
     }
 
     fn write_three_bytes(&mut self, address: u32, value: u32) {
-        self.sample_ipl();
-        self.write_sized(address, 3, value);
+        if !self.three_byte_operand_is_plain_memory(address) {
+            self.write_word(address, (value >> 8) as u16);
+            self.write_byte(address.wrapping_add(2), value as u8);
+            return;
+        }
+        self.write_three_bytes_plain(address, value);
     }
 
     fn try_read_immediate_word(&mut self, address: u32) -> Result<u16, BusFault> {
@@ -4548,6 +4598,52 @@ mod tests {
         assert!(
             three < composed,
             "three-byte transfer ({three} cck) must beat the composed word+byte ({composed} cck)"
+        );
+    }
+
+    #[test]
+    fn three_byte_operand_over_custom_registers_splits_into_word_and_byte() {
+        // Dynamic bus sizing: the chipset answers a three-byte request at its
+        // own 16-bit width, so the processor runs a word cycle and then a byte
+        // cycle. That matters beyond timing here, because a device decodes a
+        // register per access -- a single three-byte read of $DFFxxx would name
+        // no register, so the second half has to be its own access or the third
+        // byte never comes from INTREQR at all.
+        let mut bus = CpuBus {
+            bus: test_bus(reset_rom(0, 0)),
+            address_mask: ADDRESS_MASK_24BIT,
+            dbg_memw_addr: None,
+            dbg_memw_hit: None,
+            icache: None,
+            dcache: None,
+            dbg_irq_window: None,
+            last_fetch_cache_hit: false,
+            instruction_fetches_cached: false,
+            sampled_irq_level: 0,
+            ipl_sample_held: false,
+            diag_current_pc: 0,
+            jit_enabled: false,
+        };
+        // INTENA/INTREQ, whose read ports INTENAR ($01C) and INTREQR ($01E) are
+        // adjacent and beam-independent, so the pair reads back deterministically.
+        bus.bus.custom_write(0x09A, 2, 0x8000 | 0x4020);
+        bus.bus.custom_write(0x09C, 2, 0x8000 | 0x2000);
+
+        let base = CUSTOM_BASE + 0x01C;
+        let composed =
+            ((bus.read_word(base) as u32) << 8) | u32::from(bus.read_byte(base.wrapping_add(2)));
+        let three = bus.read_three_bytes(base);
+
+        assert_eq!(
+            three, composed,
+            "a three-byte span over a 16-bit port must read what its word and byte cycles read"
+        );
+        // A single sized access would reach custom_read as one 3-byte read,
+        // which names no register and answers with just the word at `base`.
+        assert_ne!(
+            three,
+            u32::from(bus.read_word(base)),
+            "INTENAR alone is a dropped third byte, not a three-byte operand"
         );
     }
 

--- a/timing-test/bfprobe.asm
+++ b/timing-test/bfprobe.asm
@@ -47,10 +47,14 @@
 ; disk and fwdprobe exactly, validating the run. Copperline = with the
 ; m68k crate's bit-field operand and timing model calibrated to this
 ; column (m68k-rs PR #60; an unfixed crate reads far off on the memory
-; rows). FS-UAE 3.2.35 for reference. Row 10 is the one row Copperline
-; misses on the high side: AddressBus has no three-byte transfer, so the
-; crate composes that span from a word and a byte and the host bills the
-; extra access. Every other row is within 0.3%.
+; rows). FS-UAE 3.2.35 for reference. Every row is within 0.3%.
+;
+; Row 10 read 2D11 (28.17) until m68k 0.7.0: AddressBus had no
+; three-byte transfer, so the crate composed that span from a word and a
+; byte and the host billed the extra access. The crate now carries a
+; three-byte operand transfer and Copperline bills it as one access, so
+; the three-byte span costs what the one-, two- and four-byte spans do,
+; which is what the real column says it should.
 ;
 ;              REAL A1200           Copperline           FS-UAE
 ;   row  0     0E6B  9.01 clk       0E6C  9.02 clk       1006 10.02 clk
@@ -63,7 +67,7 @@
 ;   row  7     46E4 44.32           4677 44.05           3A22 36.35
 ;   row  8     2CF3 28.10           2CD1 28.02           204C 20.19
 ;   row  9     2696 24.12           266A 24.02           1337 12.01
-;   row 10     2CF2 28.10           2D11 28.17           204C 20.19
+;   row 10     2CF2 28.10           2CD1 28.02           204C 20.19
 ;   row 11     2CF2 28.10           2CD1 28.02           204C 20.19
 ;   row 12     872A 84.51           86D1 84.29           6D42 68.31
 ;   row 13     872C 84.51           86D3 84.29           6D43 68.31

--- a/timing-test/bfprobe.asm
+++ b/timing-test/bfprobe.asm
@@ -52,7 +52,9 @@
 ; Row 10 read 2D11 (28.17) until m68k 0.7.0: AddressBus had no
 ; three-byte transfer, so the crate composed that span from a word and a
 ; byte and the host billed the extra access. The crate now carries a
-; three-byte operand transfer and Copperline bills it as one access, so
+; three-byte operand transfer, and the host sizes it by the addressed
+; port the way dynamic bus sizing does -- one access to the 32-bit chip
+; RAM these rows target, still a word plus a byte to any 16-bit port. So
 ; the three-byte span costs what the one-, two- and four-byte spans do,
 ; which is what the real column says it should.
 ;


### PR DESCRIPTION
Bumps `m68k` to the released 0.7.0 and lands the AddressBus override that was
waiting on it.

The 68020/030 size an operand as a byte, word, three-byte or long
(MC68020UM 5.3.1), so a memory bit field spanning three bytes is one operand
transfer. `AddressBus` had no three-byte cycle, so the core composed that span
from a word and a byte and Copperline billed both -- two chip-bus accesses
where the hardware charges one. m68k 0.7.0 adds the transfer; this overrides
the four methods to bill it as a single sized access.

## What measures it

`timing-test/bfprobe.asm` row 10 (`bfextu (a0){4:16}`) is the only three-byte
span on the disk, and its header already named this as the one row Copperline
missed. On a real A1200 every field span within four bytes costs the same,
because Alice moves anything up to a longword in one slot:

| | before | after | real A1200 |
|---|---|---|---|
| row 10 | `2D11` (28.17 clk) | `2CD1` (28.02) | `2CF2` (28.10) |

The other thirteen rows are byte-identical, so this moves exactly the row the
model says it should and nothing else. A 16-bit chip port cannot distinguish
the two models at all -- there a word plus a byte and a three-byte operand both
cost two cycles -- which is noted in the probe header.

Holding the access to the spanned width also keeps it off the byte past the
field. On a memory-mapped register, or at the end of a mapped region, that byte
is observable rather than merely mistimed.

## Verification

- `bfprobe` on A1200/AGA: row 10 corrected, rows 0-9 and 11-13 unchanged.
- Main A1200 timing disk (`tt-a1200.toml`): rebuilt at 0.5.2 and at 0.7.0 and
  diffed -- **all 32 rows byte-identical**, so the version bump carries no
  timing drift of its own.
- `cargo test --release`: 2192 unit tests plus the 26 golden renders, green.
- `cargo clippy --all-targets` and `cargo fmt --check` clean; the `cpu-jit`
  feature still builds against 0.7.0.

Two regression tests in `src/cpu.rs` pin the behaviour: the three-byte operand
costs one Alice slot (equal to a long, strictly less than the composed
word+byte), and it moves exactly three bytes without disturbing the fourth.

0.6.0/0.7.0 also add instruction-boundary and interrupt-entry cycle hooks.
Those are additive and not adopted here -- `slice_preempted` still covers what
the run loop needs.

Docs updated in the same change: `docs/internals/cpu.md` gains the operand-width
model beside the existing operand-billing paragraph, and the stale claim in the
`bfprobe` header is rewritten to record what the row read before 0.7.0 and why.

Fixes #371 