### PR TITLE
web: split the try-page fps readout into stepped, shown, and tick rates

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -488,6 +488,14 @@ async function boot() {
       audioCtx.close().catch(() => {});
       audioNode = null;
     }
+    // The queue/underrun readouts belong to the worklet that reports them.
+    // Carried across a rebuild, a stale queuedMs over the pacing threshold
+    // would gate the fresh machine's stepping until the new worklet's first
+    // report - which never comes while autoplay policy holds the context
+    // suspended - and old underruns would sit in the stat line as if the
+    // new stack had already stuttered.
+    queuedMs = 0;
+    audioUnderruns = 0;
     audioCtx = new AudioContext({ sampleRate: 44100 });
     await audioCtx.audioWorklet.addModule('./audio-worklet.js');
     audioNode = new AudioWorkletNode(audioCtx, 'copperline-audio', {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -54,6 +54,15 @@ let queuedMs = 0;
 let running = false;
 let paused = false;
 let framesThisSecond = 0;
+// Diagnostic split of the fps figure. fps counts frames *stepped*, but a
+// tick that steps more than one frame blits only the last, so "shown"
+// (ticks that stepped at least once, each blitting one new picture) is the
+// true output rate and "ticks" is the rAF callback rate. 60 fps with 30
+// shown over 60 ticks means the audio gate is duty-cycling production;
+// 30 shown over 30 ticks means the browser halved the rAF cadence.
+let ticksThisSecond = 0;
+let presentsThisSecond = 0;
+let audioUnderruns = 0;
 let lastStatUpdate = 0;
 // Size of the last presented frame in emulated pixels. Under the monitor
 // path the canvas backing store is display-resolution, so pointer scaling
@@ -486,6 +495,7 @@ async function boot() {
     });
     audioNode.port.onmessage = (e) => {
       if (typeof e.data?.queuedMs === 'number') queuedMs = e.data.queuedMs;
+      if (typeof e.data?.underruns === 'number') audioUnderruns = e.data.underruns;
     };
     audioNode.connect(audioCtx.destination);
     // Autoplay policies can leave the context suspended, and resume() may
@@ -607,8 +617,11 @@ function tick(nowMs) {
   pumpGamepads();
   syncCapsLed();
   pumpHostKeys();
+  ticksThisSecond++;
   try {
-    framesThisSecond += emu.run(nowMs, maxFramesForQueue());
+    const stepped = emu.run(nowMs, maxFramesForQueue());
+    framesThisSecond += stepped;
+    if (stepped > 0) presentsThisSecond++;
   } catch (e) {
     running = false;
     setLoadStatus(`emulator error: ${e.message ?? e}`);
@@ -637,10 +650,13 @@ function tick(nowMs) {
 
   if (nowMs - lastStatUpdate >= 1000) {
     statLine.textContent =
-      `${framesThisSecond} fps | ` +
+      `${framesThisSecond} fps (${presentsThisSecond} shown, ${ticksThisSecond} ticks) | ` +
       `${emu.emulated_seconds().toFixed(1)}s emulated | ` +
-      `audio ${queuedMs.toFixed(0)} ms`;
+      `audio ${queuedMs.toFixed(0)} ms` +
+      (audioUnderruns > 0 ? ` (${audioUnderruns} underruns)` : '');
     framesThisSecond = 0;
+    ticksThisSecond = 0;
+    presentsThisSecond = 0;
     lastStatUpdate = nowMs;
     updateStatusDisks();
   }


### PR DESCRIPTION
## Summary

The /try page sometimes drops up to half its output frames while the stat line still reads a full 60 fps. The counter counts frames *stepped* by `emu.run()`, but `run()` renders only the latest completed frame per call and the page blits once per rAF tick — so a tick that steps two frames silently discards one while counting both. The emulated clock keeps real time either way, which is all the old figure actually measured.

This adds diagnostic counters to the stat line so the failure mode can be identified from the readout alone, without touching the pacer:

```
60 fps (58 shown, 60 ticks) | 12.3s emulated | audio 62 ms
```

- **fps** — unchanged: emulated frames stepped per second.
- **shown** — ticks that stepped at least one frame; each blits exactly one new picture, so this is the true output rate.
- **ticks** — rAF callbacks per second.
- **underruns** — the worklet already reported its underrun count with the queue depth, but the page ignored it; now surfaced after the audio figure when nonzero.

## Interpreting the readout

- `60 fps (30 shown, 60 ticks)` — the audio-queue gate (`queuedMs > 150 ? 0 : 5`) is duty-cycling production: step 0 while the queue is over the threshold, then step 2 to repay the accumulated wall-clock deficit. Expect the audio figure parked near 150 ms. This happens when the audio device clock runs slower than `performance.now()` (device-dependent, hence no apparent pattern).
- `60 fps (30 shown, 30 ticks)` — the browser halved the rAF cadence (energy saver, low-power mode, or the compositor missing vsync).
- `50 fps (50 shown, 60 ticks)` — normal for a PAL machine on a 60 Hz display; the idle ticks stepped nothing because the emulated clock was already on target.

A pacer fix (re-anchoring while the gate is closed, plus hysteresis) can follow once the readout confirms which case is being hit in the wild.

## Testing

- `node --check` passes on the edited `try.js`.
- The stat-line format is not part of the documented page surface (`docs/guide/browser.md` covers the LED strip and captions, not `#stat`), so no docs change.