### PR TITLE
web: audio-gate hysteresis and an option to run while hidden

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -214,6 +214,10 @@ pub struct WebEmu {
     /// [`Self::present_crt_lines`].
     present_crt_lines: f32,
     last_rendered_frame: Option<u64>,
+    /// Frames were stepped by `run_hidden` (which renders nothing) since
+    /// the last render, so the presentation buffer is behind the machine.
+    /// The next rendering `run` repaints even if it steps no frames.
+    presentation_stale: bool,
     /// Wall-clock/emulated-time pair the pacer chases from; None until the
     /// first `run` call after (re)boot.
     anchor: Option<(f64, f64)>,
@@ -286,6 +290,7 @@ impl WebEmu {
             present_rows: 0,
             present_crt_lines: 0.0,
             last_rendered_frame: None,
+            presentation_stale: false,
             anchor: None,
             mouse_remainder: (0.0, 0.0),
             mouse_pending: (0, 0),
@@ -373,6 +378,19 @@ impl WebEmu {
     /// forgiven by re-anchoring, so a backgrounded tab resumes at real time
     /// instead of fast-forwarding.
     pub fn run(&mut self, now_ms: f64, max_frames: u32) -> Result<u32, JsValue> {
+        self.run_paced(now_ms, max_frames, true)
+    }
+
+    /// `run` for a hidden page: step the machine and queue its audio, but
+    /// skip rendering the presentation buffer nobody can see. The first
+    /// rendering `run` after hidden stepping repaints even if it stepped
+    /// no frames itself, so a tab that kept running in the background
+    /// shows the current picture the moment it is visible again.
+    pub fn run_hidden(&mut self, now_ms: f64, max_frames: u32) -> Result<u32, JsValue> {
+        self.run_paced(now_ms, max_frames, false)
+    }
+
+    fn run_paced(&mut self, now_ms: f64, max_frames: u32, render: bool) -> Result<u32, JsValue> {
         let (anchor_wall, anchor_emu) = *self
             .anchor
             .get_or_insert((now_ms, self.emu.bus().emulated_seconds()));
@@ -391,8 +409,13 @@ impl WebEmu {
         if target - self.emu.bus().emulated_seconds() > MAX_CATCHUP_SECONDS {
             self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
         }
-        if stepped > 0 {
-            self.render_completed_frame();
+        if render {
+            if stepped > 0 || self.presentation_stale {
+                self.render_completed_frame();
+                self.presentation_stale = false;
+            }
+        } else if stepped > 0 {
+            self.presentation_stale = true;
         }
         Ok(stepped)
     }
@@ -842,6 +865,7 @@ impl WebEmu {
         self.last_rendered_frame = None;
         self.presentation_latch.reset();
         self.render_completed_frame();
+        self.presentation_stale = false;
         Ok(())
     }
 

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -496,6 +496,7 @@ async function boot() {
     // new stack had already stuttered.
     queuedMs = 0;
     audioUnderruns = 0;
+    audioGateClosed = false;
     audioCtx = new AudioContext({ sampleRate: 44100 });
     await audioCtx.audioWorklet.addModule('./audio-worklet.js');
     audioNode = new AudioWorkletNode(audioCtx, 'copperline-audio', {
@@ -504,6 +505,14 @@ async function boot() {
     audioNode.port.onmessage = (e) => {
       if (typeof e.data?.queuedMs === 'number') queuedMs = e.data.queuedMs;
       if (typeof e.data?.underruns === 'number') audioUnderruns = e.data.underruns;
+      // Background running: while the page is hidden the worklet's queue
+      // reports (one every ~29 ms) are the clock that rAF stopped being.
+      // Input pumps and presentation stay out: there is nothing to show
+      // and nobody at the controls, but audio plays on and the serial
+      // bridge keeps flowing.
+      if (keepRunningHidden && running && !paused && emu) {
+        stepMachine(performance.now(), true);
+      }
     };
     audioNode.connect(audioCtx.destination);
     // Autoplay policies can leave the context suspended, and resume() may
@@ -578,13 +587,31 @@ async function boot() {
 
 // --- main loop -----------------------------------------------------------
 
+// The audio clock is the master: while the worklet has plenty queued, the
+// gate closes and stepping pauses, locking production to the audio
+// device's consumption rate. Two things keep the gate from chopping the
+// output. Hysteresis: it closes past 150 ms but reopens only under 90 ms,
+// because with a single threshold a queue riding it flips the gate every
+// report. And the pacer re-anchors while the gate is closed, so the pause
+// is forgiven rather than owed: repaid, the reopening tick steps several
+// frames at once and blits only the last, dropping the rest from the
+// output while the fps counter (which counts stepped frames) still reads
+// full rate.
+const AUDIO_GATE_CLOSE_MS = 150;
+const AUDIO_GATE_OPEN_MS = 90;
+let audioGateClosed = false;
+
 function maxFramesForQueue() {
-  // The audio clock is the master: when the worklet has plenty queued, skip
-  // stepping this tick (the pacer forgives deficits past 100 ms, so this
-  // locks production to the audio device's consumption rate). Otherwise step
-  // freely to the wall clock - the burst cap only bounds a single tick's
-  // catch-up work after rAF throttling.
-  return queuedMs > 150 ? 0 : 5;
+  const limit = audioGateClosed ? AUDIO_GATE_OPEN_MS : AUDIO_GATE_CLOSE_MS;
+  audioGateClosed = queuedMs > limit;
+  if (audioGateClosed) {
+    emu.resync_clock?.();
+    return 0;
+  }
+  // Step freely to the wall clock - the burst cap only bounds a single
+  // tick's catch-up work after rAF throttling (the pacer forgives
+  // deficits past 100 ms).
+  return 5;
 }
 
 // Blit whatever the core last rendered onto the canvas. Called once per
@@ -617,17 +644,19 @@ function presentFrame() {
   ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
 }
 
-function tick(nowMs) {
-  if (!running) return;
-  if (paused) return; // resumePause() restarts the loop
-  // Polled, not event-driven: the Gamepad API reports button state only
-  // when asked, so this is where a controller reaches the machine.
-  pumpGamepads();
-  syncCapsLed();
-  pumpHostKeys();
+// Advance the machine to nowMs and ship what it produced (audio, serial):
+// the half of a tick shared by the visible rAF loop and hidden background
+// stepping. Returns false when the machine crashed and the caller's loop
+// must stop. Hidden stepping skips the wasm-side frame render (nobody can
+// see it); the first visible run repaints unconditionally after that.
+function stepMachine(nowMs, hidden) {
   ticksThisSecond++;
   try {
-    const stepped = emu.run(nowMs, maxFramesForQueue());
+    const max = maxFramesForQueue();
+    const stepped =
+      hidden && typeof emu.run_hidden === 'function'
+        ? emu.run_hidden(nowMs, max)
+        : emu.run(nowMs, max);
     framesThisSecond += stepped;
     if (stepped > 0) presentsThisSecond++;
   } catch (e) {
@@ -643,10 +672,8 @@ function tick(nowMs) {
     showBugLink(true);
     syncWakeLock();
     console.error(e);
-    return;
+    return false;
   }
-
-  presentFrame();
 
   const audio = emu.take_audio();
   if (audio.length > 0 && audioNode) {
@@ -654,7 +681,6 @@ function tick(nowMs) {
   }
 
   pumpSerial();
-  updateStatusLeds();
 
   if (nowMs - lastStatUpdate >= 1000) {
     statLine.textContent =
@@ -668,16 +694,52 @@ function tick(nowMs) {
     lastStatUpdate = nowMs;
     updateStatusDisks();
   }
+  return true;
+}
+
+function tick(nowMs) {
+  if (!running) return;
+  if (paused) return; // resumePause() restarts the loop
+  // Polled, not event-driven: the Gamepad API reports button state only
+  // when asked, so this is where a controller reaches the machine.
+  pumpGamepads();
+  syncCapsLed();
+  pumpHostKeys();
+  if (!stepMachine(nowMs, false)) return;
+  presentFrame();
+  updateStatusLeds();
   requestAnimationFrame(tick);
 }
+
+// A hidden tab gets no animation frames, so by default the machine sleeps
+// with the page: audio is suspended and nothing steps. With the
+// run-in-background box ticked, a hidden tab keeps running the way a video
+// tab keeps playing - the real-time audio pipeline is the one thing
+// browsers never throttle, so the worklet's queue reports (which arrive as
+// messages, not timers, and so keep flowing) clock the machine while rAF
+// is asleep. That needs a running AudioContext: with autoplay still
+// locked there is no clock, and the machine sleeps as before.
+let keepRunningHidden = false;
 
 document.addEventListener('visibilitychange', () => {
   // The browser drops a screen wake lock when the page hides; re-request
   // it when a still-running machine comes back into view.
   syncWakeLock();
   if (!audioCtx) return;
-  if (document.hidden) audioCtx.suspend();
-  else audioCtx.resume();
+  if (document.hidden) {
+    keepRunningHidden =
+      bgRunToggle.checked && running && !paused && audioCtx.state === 'running';
+    if (!keepRunningHidden) audioCtx.suspend();
+  } else {
+    const kept = keepRunningHidden;
+    keepRunningHidden = false;
+    audioCtx.resume();
+    // A machine that slept through the hide starts pacing from now: the
+    // guest owes the wall clock nothing, and catching up would burst
+    // frames whose audio lands in a queue that never drained while
+    // hidden, spiking it over the gate.
+    if (!kept && emu && running && !paused) emu.resync_clock?.();
+  }
 });
 
 // --- screen wake lock --------------------------------------------------
@@ -3734,6 +3796,20 @@ monoAudioToggle?.addEventListener('change', () => {
   if (emu) emu.set_mono_audio(monoAudioToggle.checked);
 });
 
+// The run-in-background choice: ticked, a hidden tab keeps the machine
+// running (and audible) the way a video tab keeps playing; unticked (the
+// default), a hidden tab sleeps as it always has. Always available, the
+// machine select's pattern: a page shell can host its own checkbox
+// #background-run, and without one the control inserts itself below the
+// canvas. The visitor's choice is remembered per browser; the config
+// file's background_run is the starting point for first-time visitors.
+const BG_RUN_STORAGE_KEY = 'copperline-background-run';
+const bgRunToggle =
+  $('background-run') ?? buildToggleControl('background-run', 'Run in background');
+bgRunToggle.addEventListener('change', () => {
+  storePref(BG_RUN_STORAGE_KEY, bgRunToggle.checked ? 'on' : 'off');
+});
+
 // The floppy drive speed control, always visible: a page shell can host
 // its own <select id="floppy-speed"> (option values 100/200/400/800 for
 // percent, 0 for turbo) wherever its control bar wants it; without one
@@ -3816,6 +3892,23 @@ function buildSettingControl(id, labelText) {
   row.appendChild(sel);
   shell.insertAdjacentElement('afterend', row);
   return sel;
+}
+
+// The checkbox variant of buildSettingControl: the same self-inserted
+// labelled row, with the box ahead of its label as checkboxes read.
+function buildToggleControl(id, labelText) {
+  const row = document.createElement('label');
+  row.style.cssText =
+    'display:inline-flex;align-items:center;gap:0.45rem;margin:0.4rem 0.6rem 0.4rem 0;' +
+    'font:600 0.8rem "IBM Plex Mono",ui-monospace,monospace;' +
+    'color:rgba(255,255,255,0.75);cursor:pointer;';
+  const box = document.createElement('input');
+  box.type = 'checkbox';
+  box.id = id;
+  row.appendChild(box);
+  row.appendChild(document.createTextNode(labelText));
+  shell.insertAdjacentElement('afterend', row);
+  return box;
 }
 const machineShellSel = $('machine');
 const machineSel = machineShellSel ?? buildSettingControl('machine', 'Machine');
@@ -5145,6 +5238,8 @@ const pageParams = new URLSearchParams(location.search);
 //                                    (1084|crt|bezel|plain, default 1084);
 //                                    same visitor rule
 //     "joy": "keys",                 off|keys|cd32|touch
+//     "background_run": true,        starting run-in-background choice;
+//                                    same visitor rule
 //     "serial_url": "wss://...",     preset the BBS gateway input
 //     "serial_raw": true,            preset the raw checkbox
 //     "autoboot": true               power on once everything is loaded
@@ -5184,6 +5279,13 @@ async function startup() {
     if (monoAudioToggle) monoAudioToggle.checked = cfg.mono_audio;
     else configMonoAudio = cfg.mono_audio;
   }
+  // Run-in-background: the visitor's own remembered choice first (a
+  // per-browser behavior preference, the overscan rule), then the config
+  // file's starting point; neither disturbs a shell checkbox's own
+  // initial state.
+  const bgRunPref = storedPref(BG_RUN_STORAGE_KEY);
+  if (bgRunPref !== null) bgRunToggle.checked = bgRunPref === 'on';
+  else if (typeof cfg.background_run === 'boolean') bgRunToggle.checked = cfg.background_run;
 
   const fetches = [];
   const linkedDisk =

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -727,8 +727,14 @@ document.addEventListener('visibilitychange', () => {
   syncWakeLock();
   if (!audioCtx) return;
   if (document.hidden) {
+    // The toggle is read through the DOM rather than its const, which is
+    // declared further down the file: a handler must not couple to
+    // evaluation order (with the box not built yet, this reads unticked).
     keepRunningHidden =
-      bgRunToggle.checked && running && !paused && audioCtx.state === 'running';
+      !!$('background-run')?.checked &&
+      running &&
+      !paused &&
+      audioCtx.state === 'running';
     if (!keepRunningHidden) audioCtx.suspend();
   } else {
     const kept = keepRunningHidden;
@@ -5281,8 +5287,8 @@ async function startup() {
   }
   // Run-in-background: the visitor's own remembered choice first (a
   // per-browser behavior preference, the overscan rule), then the config
-  // file's starting point; neither disturbs a shell checkbox's own
-  // initial state.
+  // file's starting point; a shell checkbox's own initial state stands
+  // only when neither says otherwise.
   const bgRunPref = storedPref(BG_RUN_STORAGE_KEY);
   if (bgRunPref !== null) bgRunToggle.checked = bgRunPref === 'on';
   else if (typeof cfg.background_run === 'boolean') bgRunToggle.checked = cfg.background_run;

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -237,6 +237,15 @@ Audio starts with the boot click, but a browser autoplay policy can keep
 the AudioContext suspended anyway; the boot never waits for it. The
 emulator runs silent and the next click or key press unlocks the sound.
 
+Hiding the tab normally puts the machine to sleep with the page, exactly
+where it was until the tab returns. Ticking **Run in background** keeps
+it running -- and audible -- the way a video tab keeps playing, so a long
+render or a BBS transfer carries on while you read something else. The
+choice is remembered per browser. Running hidden needs the sound to have
+been unlocked (any click or key press does it): the audio pipeline is
+what clocks the machine while the page cannot see it, so with audio still
+suspended the machine sleeps as before.
+
 (browser-save-states)=
 ### Save states
 
@@ -341,9 +350,18 @@ through wasm-bindgen; the page's JavaScript drives everything from
   are needed and any static host (GitHub Pages included) can serve it.
 - **Pacing**: each animation frame steps the core up to the wall clock, with
   the audio queue as the master clock -- when the worklet reports more than
-  ~150 ms buffered, stepping pauses for a tick. Deficits past 100 ms (a
-  backgrounded tab, a GC pause) are forgiven rather than fast-forwarded,
-  mirroring the native pacer's re-anchor behaviour.
+  ~150 ms buffered, stepping pauses until the queue drains back under
+  ~90 ms (hysteresis, so a queue riding one threshold cannot flip the gate
+  every report), and the pacer re-anchors while it waits, so the pause is
+  forgiven rather than repaid as a burst that would drop frames from the
+  output. Deficits past 100 ms (a backgrounded tab, a GC pause) are
+  forgiven the same way, mirroring the native pacer's re-anchor behaviour.
+  A hidden tab normally sleeps -- no animation frames, audio suspended --
+  but with the run-in-background option on, the worklet's queue reports
+  (messages, which background tabs still receive; only timers are
+  throttled) clock the machine in rAF's place: the real-time audio
+  pipeline never stops, so the tab keeps running the way a video tab
+  keeps playing, skipping only the frame rendering nobody can see.
 - **Input**: `KeyboardEvent.code` strings map to Amiga raw keycodes with the
   same table as the desktop frontend (winit's `KeyCode` names *are* the W3C
   code strings); the mouse uses Pointer Lock for relative motion, with a
@@ -535,6 +553,16 @@ elements, and pages without them are untouched:
   boot, so a shell can default to mono by shipping the box checked.
   Without the element the output stays stereo unless the
   [configuration file](#browser-page-config) sets `mono_audio`.
+- `#background-run` (checkbox): keeps the machine running -- and audible
+  -- while the tab is hidden, clocked by the audio pipeline the way a
+  video tab keeps playing; unticked (the default), a hidden tab sleeps as
+  it always has. Like `#machine` it is always on: without the element a
+  labelled checkbox inserts itself below the canvas shell. The visitor's
+  choice is remembered per browser, and the
+  [configuration file](#browser-page-config)'s `background_run` is the
+  starting point for first-time visitors. Running hidden needs unlocked
+  audio: while the AudioContext is still suspended there is no clock, and
+  the machine sleeps as before.
 - `#machine` (a `<select>`): hosts the machine model control, letting the
   page place and style it. Like `#floppy-speed` it is always on: without
   the element a labelled select inserts itself below the canvas shell
@@ -693,6 +721,7 @@ per URL, and anything the visitor changes by hand wins as usual:
   "tint": "green",
   "monitor": "plain",
   "joy": "keys",
+  "background_run": true,
   "serial_url": "wss://bbs.example.com:8443/",
   "serial_raw": false,
   "autoboot": true
@@ -714,7 +743,10 @@ the glue remembers, and a visitor's own remembered choice wins over the
 file. `serial_url` and `serial_raw` preset the
 serial bridge's inputs and therefore need those elements: a shell
 without them has no connect button to dial with either. `joy` picks the
-starting joystick mode. `autoboot: true` powers the machine on by itself once the
+starting joystick mode. `background_run` starts first-time visitors with
+the run-in-background box ticked (a per-browser preference the glue
+remembers, so as with the viewing choices a visitor's own remembered
+choice wins over the file). `autoboot: true` powers the machine on by itself once the
 emulator, the ROM, and any configured disk have loaded -- the whole
 recipe for a page dedicated to one demo or a BBS: name the disk, set
 `autoboot`, and a visitor lands in the running machine. Browsers keep


### PR DESCRIPTION
## Summary

Follow-up to #393, closing out the frame-drop investigation. The new stat counters confirmed the audio-gate duty cycle in the wild: switching Chrome tabs away and back spikes the audio queue to ~200 ms, `shown` drops to ~20 while `fps` stays at full rate, and it takes a while to recover. This PR fixes that mechanism and adds the discussed opt-in "like video" mode that keeps a hidden tab running instead of sleeping.

## The fix

The gate (`queuedMs > 150 ? 0 : 5`) had no hysteresis and let the wall-clock deficit accumulate while closed, so a spiked queue settled into a step-0 / step-2-blit-1 duty cycle - half the output silently dropped. Three changes:

- **Hysteresis**: the gate closes past 150 ms queued and reopens under 90 ms, so a queue riding one threshold cannot flip it every report.
- **Re-anchor while gated**: the pacer forgives the pause instead of repaying it as a multi-frame burst, so reopening steps one frame per tick and `shown` stays equal to `fps`.
- **Resync on tab return**: a machine that slept through a hide starts pacing from now. Previously the return burst up to 5 frames and posted ~100 ms of audio into a queue that never drained while hidden - the tab-switch trigger for the whole failure.

## Run in background

New option: a hidden tab can keep the machine running - and audible - the way a video tab keeps playing. Browsers never throttle the real-time audio pipeline, and the worklet's queue reports arrive as messages (only timers are throttled), so those ~29 ms reports clock the machine while rAF is asleep. Details:

- `#background-run` checkbox, self-inserting below the canvas like the machine select; a shell can host its own. Remembered per browser; `background_run` in `copperline.json` presets first-time visitors. Default off.
- New `run_hidden` wasm export steps without rendering the presentation buffer nobody can see; the first visible `run` repaints unconditionally (`presentation_stale`), so the picture is current the moment the tab returns.
- Needs unlocked audio: with the AudioContext still suspended there is no clock, and the machine sleeps as before. Serial keeps flowing while hidden, so a BBS transfer survives a tab switch.

Docs updated in `docs/guide/browser.md` (page behavior, shell hooks, config key, internals pacing note).

## Verification

Tested end to end against a staged copy of the site with this build, driven in an occluded Chrome tab (which never fires rAF - normally a nuisance, here the perfect rig):

- Background mode, rAF disabled entirely: emulated time held wall rate at **ratio 1.000 over 20 s**, stat line showing the predicted ~35 worklet wakeups/s; handing back to the rAF loop was burst-free.
- Option off: a 13 s hide advanced emulated time by **0.00 s**, and the return resynced with the audio queue flat at ~75 ms - previously this exact sequence produced the ~200 ms spike and the duty cycle.
- Checkbox persistence round-trips through localStorage; `run_hidden` feature-detected so an older bundle degrades gracefully.
- `node --check`, `cargo clippy --target wasm32-unknown-unknown`, and `cargo fmt --check` clean on the web crate.

Retro32's report (drops with the queue never above 80 ms) is *not* this mechanism - that still looks like rAF-cadence halving on his machine and needs the #393 counters on his build to confirm.