### PR TITLE
web: let a page shell ship the keyboard buttons pre-hidden

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -3470,15 +3470,26 @@ const devKeyboardBtn = $('devkeyboard');
 pauseBtn?.addEventListener('click', togglePause);
 screenshotBtn?.addEventListener('click', copyScreenshot);
 // Hidden rather than degraded on a bundle that predates key_raw: the keys
-// are rawkeys, and there is no half of this that still works.
+// are rawkeys, and there is no half of this that still works. Inline as
+// well as by the attribute, for the same shell-stylesheet reason as the
+// device-keys button below.
 if (HAS_KEY_RAW) keyboardBtn?.addEventListener('click', toggleKeyboard);
-else if (keyboardBtn) keyboardBtn.hidden = true;
+else if (keyboardBtn) {
+  keyboardBtn.hidden = true;
+  keyboardBtn.style.display = 'none';
+}
 // The device keyboard is offered where there is one to offer. A screen
 // without touch already has the real thing plugged in, and routing it
 // through a text field would only lose every key the field cannot
 // describe -- which is most of an Amiga keyboard.
-if (HAS_KEY_RAW && hasTouch) devKeyboardBtn?.addEventListener('click', toggleHostKeyboard);
-else if (devKeyboardBtn) {
+if (HAS_KEY_RAW && hasTouch && devKeyboardBtn) {
+  // A shell can ship the button hidden so a desktop never shows it, not
+  // even for the moment before this module loads; the touch screens the
+  // button serves un-hide it here.
+  devKeyboardBtn.hidden = false;
+  devKeyboardBtn.style.display = '';
+  devKeyboardBtn.addEventListener('click', toggleHostKeyboard);
+} else if (devKeyboardBtn) {
   // Only a shell-provided button can reach here (the self-inserted one is
   // not built at all off a touch screen), and it goes away inline as well
   // as by the attribute: `[hidden]` is a user-agent rule, so a shell whose

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -674,7 +674,10 @@ elements, and pages without them are untouched:
   fullscreen overlay carries a copy of it labelled Type -- but only where
   there is a keyboard to raise. On a screen without touch, or a wasm bundle
   without `key_raw`, neither is built at all and a shell that provided the
-  button has it hidden. It shares `--cl-kbd-h` with `#keyboard`,
+  button has it hidden; a shell may also ship the button with the `hidden`
+  attribute already set, so a desktop never shows it even for the moment
+  before the glue loads, and the glue un-hides it on the touch screens it
+  serves. It shares `--cl-kbd-h` with `#keyboard`,
   publishing how much of the viewport the device keyboard covers. The
   off-screen field it focuses is built by the glue and lives inside
   `#shell`, so no input element is needed in the shell.


### PR DESCRIPTION
The copperline.dev try page now hosts `#keyboard` and `#devkeyboard` in its own themed control row instead of letting the glue self-insert them below the canvas (that page-shell change lives in the website repository, alongside sizing the monitor to tall displays). Two small glue changes support it:

- The `#keyboard` fallback hide (a bundle without `key_raw`) now goes inline as well as by the `hidden` attribute, for the same reason `#devkeyboard`'s always has: a shell stylesheet that gives its buttons a `display` rule out-ranks the attribute's user-agent rule and would leave a dead control on the page.
- A shell can ship `#devkeyboard` with the `hidden` attribute already set, so a desktop never shows it - not even for the moment before the module (and the wasm import behind it) loads - and the glue un-hides it on the touch screens the button serves. Previously the glue only ever hid it, so a pre-hidden button could never appear.

The shell-hooks list in `docs/guide/browser.md` documents the pre-hidden option. Verified in the browser against the updated page shell: the button stays hidden on desktop, and the themed Keyboard button raises and dismisses the on-screen A600 keyboard. `node --check` clean on try.js.