### PR TITLE
web: step from the audio clock when animation frames starve

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -54,14 +54,20 @@ let queuedMs = 0;
 let running = false;
 let paused = false;
 let framesThisSecond = 0;
-// Diagnostic split of the fps figure. fps counts frames *stepped*, but a
-// tick that steps more than one frame blits only the last, so "shown"
-// (ticks that stepped at least once, each blitting one new picture) is the
-// true output rate and "ticks" is the rAF callback rate. 60 fps with 30
-// shown over 60 ticks means the audio gate is duty-cycling production;
-// 30 shown over 30 ticks means the browser halved the rAF cadence.
+// Diagnostic split of the fps figure. fps counts frames *stepped*; a blit
+// shows only the newest of them, so "shown" (blits that had a fresh
+// picture to show) is the true output rate and "ticks" is the rAF
+// callback rate alone (audio-clock fallback steps are not ticks). 60 fps
+// with 30 shown over 60 ticks means the audio gate is duty-cycling
+// production; 30 shown over 30 ticks means the browser halved the rAF
+// cadence, with the machine still stepping in real time.
 let ticksThisSecond = 0;
 let presentsThisSecond = 0;
+// Set when a step renders a frame the canvas has not blitted yet, cleared
+// by the blit that shows it. Steps can happen off the rAF tick (hidden
+// background running, the starved-rAF fallback), so "shown" counts blits
+// of fresh pictures rather than assuming step and blit share a tick.
+let presentDirty = false;
 let audioUnderruns = 0;
 let lastStatUpdate = 0;
 // Size of the last presented frame in emulated pixels. Under the monitor
@@ -497,6 +503,7 @@ async function boot() {
     queuedMs = 0;
     audioUnderruns = 0;
     audioGateClosed = false;
+    presentDirty = false;
     audioCtx = new AudioContext({ sampleRate: 44100 });
     await audioCtx.audioWorklet.addModule('./audio-worklet.js');
     audioNode = new AudioWorkletNode(audioCtx, 'copperline-audio', {
@@ -505,13 +512,22 @@ async function boot() {
     audioNode.port.onmessage = (e) => {
       if (typeof e.data?.queuedMs === 'number') queuedMs = e.data.queuedMs;
       if (typeof e.data?.underruns === 'number') audioUnderruns = e.data.underruns;
-      // Background running: while the page is hidden the worklet's queue
-      // reports (one every ~29 ms) are the clock that rAF stopped being.
-      // Input pumps and presentation stay out: there is nothing to show
+      // The worklet's queue reports (one every ~29 ms) are a clock the
+      // browser never throttles, and they step the machine whenever rAF
+      // cannot. Hidden with run-in-background on, they are the only clock:
+      // input pumps and presentation stay out, there is nothing to show
       // and nobody at the controls, but audio plays on and the serial
-      // bridge keeps flowing.
-      if (keepRunningHidden && running && !paused && emu) {
-        stepMachine(performance.now(), true);
+      // bridge keeps flowing. Visible but starved of animation frames (an
+      // unfocused window on a power-saving host), they keep the machine
+      // and its audio real time between the rAF ticks that still arrive,
+      // each of which blits the newest frame; only the displayed rate
+      // degrades to whatever the compositor manages.
+      if (running && !paused && emu) {
+        const nowMs = performance.now();
+        if (keepRunningHidden) stepMachine(nowMs, true);
+        else if (!document.hidden && nowMs - lastRafMs > RAF_STARVED_MS) {
+          stepMachine(nowMs, false);
+        }
       }
     };
     audioNode.connect(audioCtx.destination);
@@ -576,6 +592,9 @@ async function boot() {
     // is a machine to type into: raised at page load it would cover half
     // the boot overlay with nothing behind it to receive the keys.
     if (HAS_KEY_RAW && storedPref(KB_OPEN_STORAGE_KEY) === 'on') openKeyboard();
+    // Prime the starvation clock: until the first animation frame lands,
+    // the worklet must not read the epoch as an already-starved rAF.
+    lastRafMs = performance.now();
     requestAnimationFrame(tick);
   } catch (e) {
     setLoadStatus(`boot failed: ${e.message ?? e}`);
@@ -600,6 +619,15 @@ async function boot() {
 const AUDIO_GATE_CLOSE_MS = 150;
 const AUDIO_GATE_OPEN_MS = 90;
 let audioGateClosed = false;
+
+// The starved-rAF fallback's threshold: how stale the last animation
+// frame may be before a worklet queue report steps the machine itself.
+// Above the ~33 ms gap of a merely halved (30 Hz) cadence, which the
+// normal tick absorbs by stepping twice; well under the ~100 ms deficit
+// the pacer forgives, past which lost wall time becomes lost emulated
+// time (the slow motion and underruns a starved window shows today).
+const RAF_STARVED_MS = 50;
+let lastRafMs = 0;
 
 function maxFramesForQueue() {
   const limit = audioGateClosed ? AUDIO_GATE_OPEN_MS : AUDIO_GATE_CLOSE_MS;
@@ -645,12 +673,12 @@ function presentFrame() {
 }
 
 // Advance the machine to nowMs and ship what it produced (audio, serial):
-// the half of a tick shared by the visible rAF loop and hidden background
-// stepping. Returns false when the machine crashed and the caller's loop
+// the half of a tick shared by the visible rAF loop and the worklet's
+// off-tick stepping (hidden background running, the starved-rAF
+// fallback). Returns false when the machine crashed and the caller's loop
 // must stop. Hidden stepping skips the wasm-side frame render (nobody can
 // see it); the first visible run repaints unconditionally after that.
 function stepMachine(nowMs, hidden) {
-  ticksThisSecond++;
   try {
     const max = maxFramesForQueue();
     const stepped =
@@ -658,7 +686,7 @@ function stepMachine(nowMs, hidden) {
         ? emu.run_hidden(nowMs, max)
         : emu.run(nowMs, max);
     framesThisSecond += stepped;
-    if (stepped > 0) presentsThisSecond++;
+    if (stepped > 0) presentDirty = true;
   } catch (e) {
     running = false;
     setLoadStatus(`emulator error: ${e.message ?? e}`);
@@ -700,6 +728,8 @@ function stepMachine(nowMs, hidden) {
 function tick(nowMs) {
   if (!running) return;
   if (paused) return; // resumePause() restarts the loop
+  lastRafMs = nowMs;
+  ticksThisSecond++;
   // Polled, not event-driven: the Gamepad API reports button state only
   // when asked, so this is where a controller reaches the machine.
   pumpGamepads();
@@ -707,6 +737,10 @@ function tick(nowMs) {
   pumpHostKeys();
   if (!stepMachine(nowMs, false)) return;
   presentFrame();
+  if (presentDirty) {
+    presentsThisSecond++;
+    presentDirty = false;
+  }
   updateStatusLeds();
   requestAnimationFrame(tick);
 }
@@ -718,7 +752,10 @@ function tick(nowMs) {
 // browsers never throttle, so the worklet's queue reports (which arrive as
 // messages, not timers, and so keep flowing) clock the machine while rAF
 // is asleep. That needs a running AudioContext: with autoplay still
-// locked there is no clock, and the machine sleeps as before.
+// locked there is no clock, and the machine sleeps as before. (The
+// starved-rAF fallback in the report handler leans on the same clock for
+// a page that is visible but throttled; that one is not an option,
+// because nobody wants slow motion they can see.)
 let keepRunningHidden = false;
 
 document.addEventListener('visibilitychange', () => {
@@ -3047,6 +3084,9 @@ function setPaused(next) {
     // Nothing elapsed for the guest while paused; start pacing from now.
     emu.resync_clock?.();
     setLoadStatus('running');
+    // A queue report can beat the first animation frame; the pre-pause
+    // lastRafMs must not read as starvation.
+    lastRafMs = performance.now();
     requestAnimationFrame(tick);
   }
 }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -63,10 +63,13 @@ let framesThisSecond = 0;
 // cadence, with the machine still stepping in real time.
 let ticksThisSecond = 0;
 let presentsThisSecond = 0;
-// Set when a step renders a frame the canvas has not blitted yet, cleared
+// Set when a step produced a frame the canvas has not shown yet, cleared
 // by the blit that shows it. Steps can happen off the rAF tick (hidden
-// background running, the starved-rAF fallback), so "shown" counts blits
-// of fresh pictures rather than assuming step and blit share a tick.
+// background running, the starved-rAF fallback) with the wasm-side
+// render deferred; the next rendering run repaints before the blit, so
+// the flag still marks a genuinely fresh picture, and "shown" counts
+// blits of fresh pictures rather than assuming step and blit share a
+// tick.
 let presentDirty = false;
 let audioUnderruns = 0;
 let lastStatUpdate = 0;
@@ -521,12 +524,17 @@ async function boot() {
       // unfocused window on a power-saving host), they keep the machine
       // and its audio real time between the rAF ticks that still arrive,
       // each of which blits the newest frame; only the displayed rate
-      // degrades to whatever the compositor manages.
+      // degrades to whatever the compositor manages. Both cases defer
+      // the wasm-side frame render: the blit waits on the next rAF tick
+      // regardless, and rendering per queue report would spend exactly
+      // the headroom a starving host is not giving us.
       if (running && !paused && emu) {
         const nowMs = performance.now();
-        if (keepRunningHidden) stepMachine(nowMs, true);
-        else if (!document.hidden && nowMs - lastRafMs > RAF_STARVED_MS) {
-          stepMachine(nowMs, false);
+        if (
+          keepRunningHidden ||
+          (!document.hidden && nowMs - lastRafMs > RAF_STARVED_MS)
+        ) {
+          stepMachine(nowMs, true);
         }
       }
     };
@@ -578,6 +586,11 @@ async function boot() {
     );
     overlay.style.display = 'none';
     showBugLink(false);
+    // Primed before running flips on: the starvation fallback is gated
+    // on running, so no queue report can read the epoch (or a previous
+    // machine's stamp) as an already-starved rAF before the first
+    // animation frame lands.
+    lastRafMs = performance.now();
     running = true;
     // A reboot from a paused machine must not start the new one paused.
     paused = false;
@@ -592,9 +605,6 @@ async function boot() {
     // is a machine to type into: raised at page load it would cover half
     // the boot overlay with nothing behind it to receive the keys.
     if (HAS_KEY_RAW && storedPref(KB_OPEN_STORAGE_KEY) === 'on') openKeyboard();
-    // Prime the starvation clock: until the first animation frame lands,
-    // the worklet must not read the epoch as an already-starved rAF.
-    lastRafMs = performance.now();
     requestAnimationFrame(tick);
   } catch (e) {
     setLoadStatus(`boot failed: ${e.message ?? e}`);
@@ -676,13 +686,15 @@ function presentFrame() {
 // the half of a tick shared by the visible rAF loop and the worklet's
 // off-tick stepping (hidden background running, the starved-rAF
 // fallback). Returns false when the machine crashed and the caller's loop
-// must stop. Hidden stepping skips the wasm-side frame render (nobody can
-// see it); the first visible run repaints unconditionally after that.
-function stepMachine(nowMs, hidden) {
+// must stop. Off-tick steps defer the wasm-side frame render (a hidden
+// page never blits, a starved one not before its next rAF tick); the
+// first rendering run repaints even when it steps nothing itself, so a
+// deferred picture is never blitted stale.
+function stepMachine(nowMs, deferRender) {
   try {
     const max = maxFramesForQueue();
     const stepped =
-      hidden && typeof emu.run_hidden === 'function'
+      deferRender && typeof emu.run_hidden === 'function'
         ? emu.run_hidden(nowMs, max)
         : emu.run(nowMs, max);
     framesThisSecond += stepped;

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -246,6 +246,15 @@ been unlocked (any click or key press does it): the audio pipeline is
 what clocks the machine while the page cannot see it, so with audio still
 suspended the machine sleeps as before.
 
+A page that stays visible but is starved of animation frames -- an
+unfocused window on a host bent on saving power (Windows "efficiency
+mode" is the classic) -- keeps real time the same way, and needs no
+option: the audio pipeline steps the machine between whatever animation
+frames still arrive, so emulation and sound never slow down and only the
+displayed frame rate drops to what the browser delivers. This too needs
+unlocked audio; with the AudioContext still suspended there is no
+fallback clock, and a starved page slows down as the browser dictates.
+
 (browser-save-states)=
 ### Save states
 
@@ -361,7 +370,12 @@ through wasm-bindgen; the page's JavaScript drives everything from
   (messages, which background tabs still receive; only timers are
   throttled) clock the machine in rAF's place: the real-time audio
   pipeline never stops, so the tab keeps running the way a video tab
-  keeps playing, skipping only the frame rendering nobody can see.
+  keeps playing, skipping only the frame rendering nobody can see. The
+  same clock backstops a visible page whose animation frames are being
+  throttled (an unfocused window under a power-saving OS): a queue report
+  that finds the last animation frame more than ~50 ms stale steps the
+  machine itself, keeping emulation and audio real time while rAF is left
+  to blit the newest frame at whatever rate the compositor manages.
 - **Input**: `KeyboardEvent.code` strings map to Amiga raw keycodes with the
   same table as the desktop frontend (winit's `KeyCode` names *are* the W3C
   code strings); the mouse uses Pointer Lock for relative motion, with a


### PR DESCRIPTION
A visible but unfocused window can be starved of animation frames by a power-saving host - Windows "efficiency mode" parks the unfocused browser on efficiency cores, Chrome drops the renderer's priority, and its Energy Saver halves the rAF cadence outright. Past a halving, the 5-frame burst cap and the pacer's 100 ms deficit forgiveness turn that into visible slow motion with a starving audio queue - the field report behind #395's "still open" case - and none of the hidden-tab machinery helps, because the page never hides.

#395 proved the worklet's ~29 ms queue reports are a clock the browser never throttles. This leans on the same clock while visible: a queue report that finds the last animation frame more than 50 ms stale steps the machine itself, and rAF is left to blit the newest frame at whatever rate the compositor still delivers. Emulation, audio, and the serial bridge stay real time; only the displayed rate degrades. The 50 ms threshold sits above a merely halved 30 Hz cadence (which normal burst stepping absorbs) and well under the deficit-forgiveness horizon. There is no option for this, unlike running hidden: nobody wants slow motion they can see.

The stat counters stay honest about the split: "ticks" now counts only rAF callbacks, and "shown" counts blits that had a fresh picture to show (dirty flag set by stepping, cleared by the blit), since a picture can now be produced between blits. A starved machine reads e.g. `61 fps (6 shown, 6 ticks)`: full-rate emulation, 6 Hz compositor.

JS-only - no wasm export changes, so the fix also works against an already-deployed bundle.

Verified end to end in an occluded Chrome tab with `document.hidden` overridden and rAF shimmed to ~6.4 Hz:

| scenario | emulated/wall ratio | audio queue |
|---|---|---|
| starved rAF, fallback active | 1.001 over 46 s | steady ~47 ms, no underruns |
| same rig, fallback guard blocked | 0.464 | drained to 1 ms, +121 underruns |
| healthy ~42 Hz cadence | 1.001, fallback dormant | stable |
| pause / resume under starvation | frozen exactly / 1.005 | - |