### PR TITLE
web: weak-host performance - render stride, frame reuse, simd128 + wasm-opt

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -41,12 +41,25 @@ jobs:
           V=$(sed -n 's/^wasm-bindgen = "=\(.*\)"$/\1/p' crates/copperline-web/Cargo.toml)
           test -n "$V"
           cargo install wasm-bindgen-cli --version "$V" --locked
+      - name: Install binaryen
+        run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Build the web crate
         working-directory: crates/copperline-web
+        # simd128: every wasm-capable browser has had fixed-width SIMD for
+        # years, and the render passes vectorize measurably (+6% whole-run
+        # on an Ice Lake laptop). wasm-opt -O3 then shrinks the bundle by
+        # about 13%. Fat LTO was measured too and is deliberately absent:
+        # it regresses the wasm build under V8 even though the native
+        # profile documents it as a win, so the crate keeps thin LTO.
         run: |
-          cargo build --release --target wasm32-unknown-unknown --locked
+          RUSTFLAGS="-C target-feature=+simd128" \
+            cargo build --release --target wasm32-unknown-unknown --locked
           wasm-bindgen --target web --out-dir pkg \
             target/wasm32-unknown-unknown/release/copperline_web.wasm
+          wasm-opt -O3 \
+            --enable-simd --enable-bulk-memory --enable-sign-ext \
+            --enable-mutable-globals --enable-nontrapping-float-to-int \
+            pkg/copperline_web_bg.wasm -o pkg/copperline_web_bg.wasm
           test -s pkg/copperline_web_bg.wasm
       - name: Check out the website repository
         uses: actions/checkout@v7

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -241,6 +241,13 @@ pub struct WebEmu {
     /// previous presentation geometry instead of snapping to the full
     /// framebuffer, so the canvas does not jump at every mode change.
     presentation_latch: present_common::PresentationLatch,
+    /// Exact previous-frame reuse, the desktop render cache's detector via
+    /// the same path the benchmark uses: a frame whose render input matches
+    /// the previous one skips the whole render/present pipeline, since the
+    /// present buffer already shows it. A static screen then costs no
+    /// render at all. Replaced whenever the machine or the presentation
+    /// settings change under it.
+    repeated_frame_detector: bitplane::RepeatedFrameDetector,
 }
 
 #[wasm_bindgen]
@@ -297,6 +304,7 @@ impl WebEmu {
             serial,
             overscan: Overscan::Tv,
             presentation_latch: present_common::PresentationLatch::default(),
+            repeated_frame_detector: bitplane::RepeatedFrameDetector::default(),
         })
     }
 
@@ -432,7 +440,17 @@ impl WebEmu {
             return;
         }
         let visible_start_vpos = self.emu.bus().frame_visible_start_vpos();
-        bitplane::render(self.emu.bus_mut(), &mut self.fb);
+        // A frame identical to the previous render needs no pipeline at
+        // all: the present buffer already shows it, and the detector
+        // carries the frame's CLXDAT so collisions still accumulate.
+        if bitplane::render_reusing_previous(
+            self.emu.bus_mut(),
+            &mut self.fb,
+            &mut self.repeated_frame_detector,
+        ) {
+            self.last_rendered_frame = Some(emulated_frame);
+            return;
+        }
         let geometry = self.emu.bus().frame_geometry();
         let canvas_scale = self.emu.bus().frame_canvas_scale();
         let base = self.emu.bus().frame_render_base();
@@ -864,6 +882,9 @@ impl WebEmu {
         // timeline, so it starts over too.
         self.last_rendered_frame = None;
         self.presentation_latch.reset();
+        // The reuse detector's snapshot belongs to the replaced machine;
+        // the repaint below must render, not match against it.
+        self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         self.render_completed_frame();
         self.presentation_stale = false;
         Ok(())
@@ -878,6 +899,7 @@ impl WebEmu {
         self.mouse_remainder = (0.0, 0.0);
         self.mouse_pending = (0, 0);
         self.presentation_latch.reset();
+        self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         Ok(())
     }
 
@@ -908,9 +930,12 @@ impl WebEmu {
         }
         self.overscan = overscan;
         // Judge the new mode's geometry fresh rather than from decisions
-        // latched under the old one.
+        // latched under the old one. The reuse detector resets with it:
+        // the frame's content has not changed, but its presentation has,
+        // so the repaint below must run the pipeline, not match.
         self.presentation_latch.reset();
         self.last_rendered_frame = None;
+        self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         self.render_completed_frame();
     }
 

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -532,7 +532,9 @@ async function boot() {
         const nowMs = performance.now();
         if (
           keepRunningHidden ||
-          (!document.hidden && nowMs - lastRafMs > RAF_STARVED_MS)
+          (!document.hidden &&
+            nowMs - lastRafMs > RAF_STARVED_MS &&
+            avgStepMs < STEP_OVERLOAD_MS)
         ) {
           stepMachine(nowMs, true);
         }
@@ -654,6 +656,17 @@ let lastRafMs = 0;
 // step regardless, which simply leaves the behavior they always had.
 const RENDER_SKIP_ENTER_MS = 15;
 const RENDER_SKIP_EXIT_MS = 11;
+// The starved-rAF fallback exists for a THROTTLED host: animation frames
+// withheld from a machine that is cheap to step. On an OVERLOADED host -
+// the machine itself eating more than the worklet's ~29 ms report
+// interval per step - stepping on every report leaves the main thread no
+// idle at all: the page (input, the stat line, devtools) freezes solid
+// while emulated time barely gains, because the wall-paced core cannot
+// exceed the host's throughput however often it is called. Past this
+// step cost the fallback stands down and rAF alone drives the machine,
+// keeping the page usable through the worst stretches (a 68020 decrunch
+// on a slow host) at whatever rate the host can actually sustain.
+const STEP_OVERLOAD_MS = 25;
 let avgStepMs = 0;
 let renderSkipActive = false;
 let renderDeferredLastTick = false;

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -639,6 +639,25 @@ let audioGateClosed = false;
 const RAF_STARVED_MS = 50;
 let lastRafMs = 0;
 
+// Adaptive render stride for hosts that cannot afford a frame render
+// every emulated frame. The wasm-side presentation render is a large
+// share of a step's cost (about 45% on an Ice Lake laptop), and a host
+// saturated by it drops animation frames until the pacer starts
+// forgiving deficits - slow motion, the worst possible degradation.
+// When the moving average of a step's cost nears the 60 Hz frame
+// budget, alternate ticks step with the render deferred (the same
+// run_hidden + stale-repaint path the off-tick clocks use), trading
+// display rate for guaranteed real-time emulation and audio. The
+// hysteresis keeps the mode from flapping on the threshold, and the
+// stride never exceeds every-other-tick, so the picture keeps at least
+// half the tick rate. Old bundles without run_hidden render every
+// step regardless, which simply leaves the behavior they always had.
+const RENDER_SKIP_ENTER_MS = 15;
+const RENDER_SKIP_EXIT_MS = 11;
+let avgStepMs = 0;
+let renderSkipActive = false;
+let renderDeferredLastTick = false;
+
 function maxFramesForQueue() {
   const limit = audioGateClosed ? AUDIO_GATE_OPEN_MS : AUDIO_GATE_CLOSE_MS;
   audioGateClosed = queuedMs > limit;
@@ -693,10 +712,18 @@ function presentFrame() {
 function stepMachine(nowMs, deferRender) {
   try {
     const max = maxFramesForQueue();
+    const stepStart = performance.now();
     const stepped =
       deferRender && typeof emu.run_hidden === 'function'
         ? emu.run_hidden(nowMs, max)
         : emu.run(nowMs, max);
+    // Rolling cost of a step, the render-stride controller's signal.
+    // Idle steps (nothing to advance) pull it down, which is right:
+    // they mean the host is keeping up.
+    avgStepMs = avgStepMs * 0.9 + (performance.now() - stepStart) * 0.1;
+    renderSkipActive = renderSkipActive
+      ? avgStepMs > RENDER_SKIP_EXIT_MS
+      : avgStepMs > RENDER_SKIP_ENTER_MS;
     framesThisSecond += stepped;
     if (stepped > 0) presentDirty = true;
   } catch (e) {
@@ -727,7 +754,8 @@ function stepMachine(nowMs, deferRender) {
       `${framesThisSecond} fps (${presentsThisSecond} shown, ${ticksThisSecond} ticks) | ` +
       `${emu.emulated_seconds().toFixed(1)}s emulated | ` +
       `audio ${queuedMs.toFixed(0)} ms` +
-      (audioUnderruns > 0 ? ` (${audioUnderruns} underruns)` : '');
+      (audioUnderruns > 0 ? ` (${audioUnderruns} underruns)` : '') +
+      (renderSkipActive ? ' | render 1/2' : '');
     framesThisSecond = 0;
     ticksThisSecond = 0;
     presentsThisSecond = 0;
@@ -747,9 +775,18 @@ function tick(nowMs) {
   pumpGamepads();
   syncCapsLed();
   pumpHostKeys();
-  if (!stepMachine(nowMs, false)) return;
+  // Under sustained overload, defer the frame render on alternate ticks
+  // (see the render-stride notes above): the machine keeps real time on
+  // a host that cannot afford a render per frame, and only the shown
+  // rate degrades - never the emulation or its audio.
+  const deferRender = renderSkipActive && !renderDeferredLastTick;
+  if (!stepMachine(nowMs, deferRender)) return;
+  renderDeferredLastTick = deferRender;
   presentFrame();
-  if (presentDirty) {
+  // A deferred tick blits the previous picture again; the flag rides
+  // through to the rendering tick whose blit really shows something
+  // new, so "shown" stays the count of fresh pictures on the canvas.
+  if (presentDirty && !deferRender) {
     presentsThisSecond++;
     presentDirty = false;
   }
@@ -5344,7 +5381,6 @@ async function startup() {
   const bgRunPref = storedPref(BG_RUN_STORAGE_KEY);
   if (bgRunPref !== null) bgRunToggle.checked = bgRunPref === 'on';
   else if (typeof cfg.background_run === 'boolean') bgRunToggle.checked = cfg.background_run;
-
   const fetches = [];
   const linkedDisk =
     pageParams.get('df0') ?? (typeof cfg.df0 === 'string' ? cfg.df0 : null);

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -351,6 +351,9 @@ through wasm-bindgen; the page's JavaScript drives everything from
   [the presentation internals](../internals/video.md)). Border-only frames
   keep the previous frame's geometry, as on the desktop, so the canvas
   does not switch shape across the blanks a screen change produces.
+  A frame whose render input exactly matches the previous one skips the
+  render pipeline entirely (the desktop render cache's reuse detector),
+  so a static screen costs no render work at all.
   There is no wgpu in the build, which keeps the wasm
   around 1.4 MiB (about 0.6 MiB over the wire).
 - **Audio**: Paula's 44.1 kHz stereo mix is drained once per animation frame

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -376,6 +376,13 @@ through wasm-bindgen; the page's JavaScript drives everything from
   that finds the last animation frame more than ~50 ms stale steps the
   machine itself, keeping emulation and audio real time while rAF is left
   to blit the newest frame at whatever rate the compositor manages.
+  On a host too slow to afford a frame render per emulated frame (the
+  render is roughly half a step's cost), the pacer degrades the picture
+  before it degrades the machine: when a step's rolling cost nears the
+  60 Hz frame budget, alternate ticks step with the render deferred, so
+  emulation and audio hold real time and only the displayed rate halves.
+  The stat line shows `render 1/2` while this is active, and the mode
+  disengages (with hysteresis) as soon as the host keeps up again.
 - **Input**: `KeyboardEvent.code` strings map to Amiga raw keycodes with the
   same table as the desktop frontend (winit's `KeyCode` names *are* the W3C
   code strings); the mouse uses Pointer Lock for relative motion, with a

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -354,8 +354,8 @@ through wasm-bindgen; the page's JavaScript drives everything from
   A frame whose render input exactly matches the previous one skips the
   render pipeline entirely (the desktop render cache's reuse detector),
   so a static screen costs no render work at all.
-  There is no wgpu in the build, which keeps the wasm
-  around 1.4 MiB (about 0.6 MiB over the wire).
+  There is no wgpu in the build, which keeps the wasm-opt'd wasm
+  around 2.1 MiB (about 0.8 MiB over the wire).
 - **Audio**: Paula's 44.1 kHz stereo mix is drained once per animation frame
   and posted to an `AudioWorklet` as transferred `Float32Array` chunks. The
   build is single threaded -- no SharedArrayBuffer, so no COOP/COEP headers

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -5292,7 +5292,254 @@ fn apply_programmable_blanking(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Bounds of the fast interior of one control run, if it has one:
+/// `(x_lo, x_hi, f0, planes_mask)` with `x_lo`/`x_hi` on the output pixel
+/// grid and `f0` the prepared-pixel index of `x_lo`'s sample. The interior
+/// is where the per-pixel loop's every decision is provably constant, so
+/// eligibility mirrors that loop's branches one for one; anything outside -
+/// scroll lead-in, the DDFSTOP hold pixel one past the fetch span, window
+/// edges - is left to the per-pixel code.
+#[allow(clippy::too_many_arguments)]
+fn fast_playfield_run_interior(
+    plan: &DenisePlannedPlayfieldLine<'_>,
+    x: usize,
+    run_stop: usize,
+    bpl_output_start_x: usize,
+    pixel_repeat: usize,
+    native_per_pixel: usize,
+    pixel_fetch_start_native_x: usize,
+    native_x_offset: usize,
+    min_fetch_x: usize,
+    delays: &[i32; 8],
+    nplanes: usize,
+    ham_mode: bool,
+    shres: bool,
+    canvas_scale: usize,
+    have_indexed_outputs: bool,
+    ham_diag_active: bool,
+    window_open: bool,
+    line_visible: bool,
+    control: ControlState,
+) -> Option<(usize, usize, usize, u8)> {
+    // Below this many samples the setup outweighs the tight loop.
+    const MIN_FAST_SAMPLES: i64 = 16;
+
+    let available_planes = nplanes.min(8);
+    // genlock_transparent is constant false when the ZD clock overrides it
+    // or no keying mode is enabled at all; only then can the alpha be
+    // folded into the run.
+    let genlock_inert = control.zd_clock_enabled()
+        || (!control.color_key_enabled() && !control.bitplane_key_enabled());
+    if ham_mode
+        || shres
+        || !have_indexed_outputs
+        || ham_diag_active
+        || !window_open
+        || !line_visible
+        || !genlock_inert
+        || canvas_scale != 1
+        || native_per_pixel != 1
+        || plan.pixels.is_none()
+        || available_planes < 2
+        || delays[0] != delays[1]
+        || active_debug_plane_mask() != u8::MAX
+    {
+        return None;
+    }
+    let planes_mask = if available_planes == 8 {
+        u8::MAX
+    } else {
+        ((1u16 << available_planes) - 1) as u8
+    };
+    let delay = i64::from(delays[0]);
+    let pr = pixel_repeat as i64;
+    let x_start = plan.x_start as i64;
+    let pfsn = pixel_fetch_start_native_x as i64;
+    let nxo = native_x_offset as i64;
+
+    // q is the sample index on the output grid: x_k = x_start + q * repeat,
+    // native_x = q - pfsn + nxo, fetch_x = native_x - delay. The loop below
+    // steps x from x_start in whole repeats, so every x it visits has an
+    // exact q.
+    let q_of_x_ceil = |v: i64| -> i64 { (v - x_start + pr - 1).div_euclid(pr) };
+    let q_lo = q_of_x_ceil(x as i64)
+        .max(q_of_x_ceil(bpl_output_start_x as i64))
+        .max(pfsn)
+        .max(min_fetch_x as i64 + delay + pfsn - nxo);
+
+    // Exclusive: the last sample must keep every repeated pixel inside the
+    // display span, stay inside the run, and fetch strictly inside the
+    // prepared span (the DDFSTOP hold pixel sits one past it).
+    let q_hi = ((run_stop as i64 - 1 - x_start).div_euclid(pr))
+        .min((plan.x_stop as i64 - pr - x_start).div_euclid(pr))
+        .min(plan.fetched_pixels as i64 - 1 + delay + pfsn - nxo)
+        + 1;
+
+    if q_hi - q_lo < MIN_FAST_SAMPLES {
+        return None;
+    }
+    let f0 = q_lo - pfsn + nxo - delay;
+    debug_assert!(f0 >= min_fetch_x as i64);
+    let x_lo = x_start + q_lo * pr;
+    let x_hi = x_start + q_hi * pr;
+    Some((x_lo as usize, x_hi as usize, f0 as usize, planes_mask))
+}
+
+/// The interior itself: one prepared byte, two table loads, and the stores
+/// per sample. Mirrors the per-pixel loop's visible-sample body exactly for
+/// the constant case the eligibility check proved: opaque alpha (genlock
+/// inert), unconditional collision store, playfield mask store only when a
+/// playfield is present, and the indexed resolver's held-colour seeding
+/// (the last colour of the run, exactly as the per-pixel calls would leave
+/// it).
+#[allow(clippy::too_many_arguments)]
+fn render_fast_playfield_run(
+    idx_bytes: &[u8],
+    planes_mask: u8,
+    outputs: &[DenisePlayfieldOutput; 256],
+    collision_table: &[CollisionPixel; 256],
+    fb: &mut [u32],
+    playfield_mask: &mut [u8],
+    collision_pixels: &mut [CollisionPixel],
+    clxdat: &mut u16,
+    ham_color: &mut u32,
+    y: usize,
+    x_lo: usize,
+    pixel_repeat: usize,
+    out_w: usize,
+    canvas_scale: usize,
+) {
+    debug_assert_eq!(canvas_scale, 1);
+    let row_fb = y * FB_WIDTH;
+    let row_out = y * out_w;
+    let mut clx = *clxdat;
+    let mut last_color = *ham_color;
+    for (i, &byte) in idx_bytes.iter().enumerate() {
+        let idx = usize::from(byte & planes_mask);
+        let output = outputs[idx];
+        let collision = collision_table[idx];
+        clx |= collision.clxdat_bits();
+        last_color = output.color;
+        let pixel = rgb24_to_rgba8_alpha(output.color, true);
+        let x = x_lo + i * pixel_repeat;
+        let fb_idx = row_fb + x;
+        let out_base = row_out + x;
+        let pf = collision.playfield_mask();
+        for dx in 0..pixel_repeat {
+            collision_pixels[fb_idx + dx] = collision;
+            if pf != 0 {
+                playfield_mask[fb_idx + dx] = pf;
+            }
+            fb[out_base + dx] = pixel;
+        }
+    }
+    *clxdat = clx;
+    *ham_color = last_color;
+}
+
 fn render_planned_playfield_line(
+    plan: &DenisePlannedPlayfieldLine<'_>,
+    fb: &mut [u32],
+    playfield_mask: &mut [u8],
+    collision_pixels: &mut [CollisionPixel],
+    collision_lookup: &mut CollisionLookup,
+    indexed_output_cache: &mut IndexedOutputCache,
+    clxdat: &mut u16,
+    palette: Palette,
+    palette_segments: &[PaletteSegment],
+    segment_idx: usize,
+    pixel_control: ControlState,
+    control_segments: &[ControlSegment],
+    control_segment_idx: usize,
+    base_scroll_bplcon1: u16,
+    base_ham_bplcon0: u16,
+    suppress_prefetch_scroll_fill: bool,
+    bpl_output_start_x: usize,
+    h_row: &HWindowRow,
+    visible_line0: i32,
+    emulated_seconds: f64,
+    emulated_frames: u64,
+) {
+    render_planned_playfield_line_impl(
+        true,
+        plan,
+        fb,
+        playfield_mask,
+        collision_pixels,
+        collision_lookup,
+        indexed_output_cache,
+        clxdat,
+        palette,
+        palette_segments,
+        segment_idx,
+        pixel_control,
+        control_segments,
+        control_segment_idx,
+        base_scroll_bplcon1,
+        base_ham_bplcon0,
+        suppress_prefetch_scroll_fill,
+        bpl_output_start_x,
+        h_row,
+        visible_line0,
+        emulated_seconds,
+        emulated_frames,
+    );
+}
+
+/// Scalar-only variant: the oracle the differential regression test holds
+/// the fast interior path against, pixel for pixel.
+#[cfg(test)]
+fn render_planned_playfield_line_scalar(
+    plan: &DenisePlannedPlayfieldLine<'_>,
+    fb: &mut [u32],
+    playfield_mask: &mut [u8],
+    collision_pixels: &mut [CollisionPixel],
+    collision_lookup: &mut CollisionLookup,
+    indexed_output_cache: &mut IndexedOutputCache,
+    clxdat: &mut u16,
+    palette: Palette,
+    palette_segments: &[PaletteSegment],
+    segment_idx: usize,
+    pixel_control: ControlState,
+    control_segments: &[ControlSegment],
+    control_segment_idx: usize,
+    base_scroll_bplcon1: u16,
+    base_ham_bplcon0: u16,
+    suppress_prefetch_scroll_fill: bool,
+    bpl_output_start_x: usize,
+    h_row: &HWindowRow,
+    visible_line0: i32,
+    emulated_seconds: f64,
+    emulated_frames: u64,
+) {
+    render_planned_playfield_line_impl(
+        false,
+        plan,
+        fb,
+        playfield_mask,
+        collision_pixels,
+        collision_lookup,
+        indexed_output_cache,
+        clxdat,
+        palette,
+        palette_segments,
+        segment_idx,
+        pixel_control,
+        control_segments,
+        control_segment_idx,
+        base_scroll_bplcon1,
+        base_ham_bplcon0,
+        suppress_prefetch_scroll_fill,
+        bpl_output_start_x,
+        h_row,
+        visible_line0,
+        emulated_seconds,
+        emulated_frames,
+    );
+}
+
+fn render_planned_playfield_line_impl(
+    fast_runs: bool,
     plan: &DenisePlannedPlayfieldLine<'_>,
     fb: &mut [u32],
     playfield_mask: &mut [u8],
@@ -5444,7 +5691,73 @@ fn render_planned_playfield_line(
         let collision_table =
             collision_lookup.table(pixel_control.clxcon, pixel_control.clxcon2, collision_dual);
 
+        // The interior of a run where every per-pixel decision is constant:
+        // single-tap sampling (all planes share one BPLCON1 delay), indexed
+        // (non-HAM) colour resolution, classic canvas, genlock inert, no
+        // debug plane isolation, the whole pixel inside the open window and
+        // the fetch span. There the sampler collapses to
+        // `pixels[fetch_x] & mask` and the loop body to two table loads and
+        // the stores, which is where the render spends its time on real
+        // content. All edges - scroll lead-in, the DDFSTOP hold pixel,
+        // window, segment and fetch-span boundaries - keep the per-pixel
+        // loop below, which runs before and after the interior unchanged.
+        let fast_interior = if fast_runs {
+            fast_playfield_run_interior(
+                plan,
+                x,
+                run_stop,
+                bpl_output_start_x,
+                pixel_repeat,
+                native_per_pixel,
+                pixel_fetch_start_native_x,
+                native_x_offset,
+                min_fetch_x,
+                &delays,
+                nplanes,
+                ham_mode,
+                shres,
+                canvas_scale,
+                indexed_outputs.is_some(),
+                ham_diag.is_some(),
+                window_open,
+                line_visible,
+                pixel_control,
+            )
+        } else {
+            None
+        };
+
         loop {
+            if let Some((fast_x_lo, fast_x_hi, fast_f0, fast_mask)) = fast_interior {
+                if x == fast_x_lo {
+                    let outputs = indexed_outputs.expect("fast interior requires indexed outputs");
+                    render_fast_playfield_run(
+                        &plan.pixels.expect("fast interior requires prepared pixels")
+                            [fast_f0..fast_f0 + (fast_x_hi - fast_x_lo) / pixel_repeat],
+                        fast_mask,
+                        outputs,
+                        collision_table,
+                        fb,
+                        playfield_mask,
+                        collision_pixels,
+                        clxdat,
+                        &mut ham_color,
+                        plan.y,
+                        fast_x_lo,
+                        pixel_repeat,
+                        out_w,
+                        canvas_scale,
+                    );
+                    let samples = (fast_x_hi - fast_x_lo) / pixel_repeat;
+                    let native_after = (fast_f0 + samples) as i32 + delays[0];
+                    next_ham_native_x = next_ham_native_x.max(native_after.max(0) as usize);
+                    x = fast_x_hi;
+                    if x >= run_stop {
+                        break;
+                    }
+                    continue;
+                }
+            }
             let output_native_x = ((x - plan.x_start) / pixel_repeat) * native_per_pixel;
             let Some(relative_native_x) = output_native_x.checked_sub(pixel_fetch_start_native_x)
             else {

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -5291,7 +5291,6 @@ fn apply_programmable_blanking(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Bounds of the fast interior of one control run, if it has one:
 /// `(x_lo, x_hi, f0, planes_mask)` with `x_lo`/`x_hi` on the output pixel
 /// grid and `f0` the prepared-pixel index of `x_lo`'s sample. The interior

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -8319,7 +8319,7 @@ fn fast_playfield_interior_matches_scalar_oracle() {
             fetched_pixels,
         );
 
-        let mut render = |fast: bool| {
+        let render = |fast: bool| {
             let mut fb = vec![0u32; FB_PIXELS];
             let mut pf_mask = vec![0u8; FB_PIXELS];
             let mut collisions = vec![CollisionPixel::default(); FB_PIXELS];

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -8221,3 +8221,214 @@ fn fetch_origin_below_hard_start_stays_linear_in_ddfstrt() {
     assert_eq!(mk(0x10).native_x_offset(false, 2), 80);
     assert_eq!(mk(0x10).fetch_start_native_x(false, 2), 0);
 }
+
+/// Differential regression oracle for the fast interior run: randomized
+/// planes, scroll, palette, collision enables, window edges, priorities,
+/// and mid-line control/palette segments, rendered by the production
+/// (fast-run) line renderer and the scalar per-pixel oracle, must agree
+/// byte for byte in every output the line renderer produces. HAM and
+/// dual-playfield cases ride along to prove the fallback stays engaged
+/// where the fast path must not.
+#[test]
+fn fast_playfield_interior_matches_scalar_oracle() {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut rand = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+
+    const BPLCON0_POOL: [u16; 10] = [
+        0x1000, 0x2000, 0x3000, 0x4000, 0x5000, 0x6000, // 1-6 planes, lores
+        0x9000, 0xC000, // 1 and 4 planes, hires
+        0x6400, // dual playfield, 6 planes
+        0x5800, // HAM6: the fallback must stay engaged and identical
+    ];
+    const DIW_POOL: [(u16, u16); 3] = [
+        (0x2C81, 0x2CC1), // standard PAL window
+        (0x2C91, 0x2CB1), // inset window
+        (0x2CA1, 0x2CA9), // very narrow window
+    ];
+    const BPLCON2_POOL: [u16; 4] = [0x0000, 0x0024, 0x0040, 0x0067];
+
+    for case in 0..400u32 {
+        let r = rand();
+        let bplcon0 = BPLCON0_POOL[(r as usize) % BPLCON0_POOL.len()];
+        let (diwstrt, diwstop) = DIW_POOL[((r >> 8) as usize) % DIW_POOL.len()];
+        let control = ControlState {
+            dmacon: DMACON_DMAEN | DMACON_BPLEN,
+            bplcon0,
+            bplcon1: ((r >> 24) & 0xFF) as u16,
+            bplcon2: BPLCON2_POOL[((r >> 32) as usize) % BPLCON2_POOL.len()],
+            clxcon: (r >> 16) as u16,
+            clxcon2: (r >> 40) as u16,
+            diwstrt,
+            diwstop,
+            ddfstrt: 0x0038,
+            ddfstop: 0x00D0,
+            ..ControlState::default()
+        };
+        let (x0, x1) = control.display_window_x();
+        let x1 = x1.min(FB_WIDTH);
+
+        let words = 10 + ((r >> 48) as usize % 12);
+        let fetched_pixels = words * 16;
+        let nplanes = control.nplanes().max(1);
+        let planes: Vec<Vec<u16>> = (0..nplanes)
+            .map(|_| (0..words).map(|_| rand() as u16).collect())
+            .collect();
+        let mut prepared = Vec::new();
+        prepare_planar_row_pixels(&planes, fetched_pixels, &mut prepared);
+
+        // Mid-line writes: a scroll change and a palette write make the
+        // renderer split the line into several runs, exercising the
+        // interior bounds against segment edges.
+        let mut control_segments = Vec::new();
+        if r & 0x1000_0000_0000_0000 != 0 {
+            let mut changed = control;
+            changed.bplcon1 = ((r >> 52) & 0xFF) as u16;
+            control_segments.push(ControlSegment {
+                x: x0 + 40 + (r as usize % 96),
+                control: changed,
+            });
+        }
+        let mut palette_segments = Vec::new();
+        if r & 0x2000_0000_0000_0000 != 0 {
+            palette_segments.push(PaletteSegment {
+                x: x0 + 24 + ((r >> 6) as usize % 128),
+                entry: ((r >> 12) & 0x1F) as u8,
+                loct: false,
+                value: (r >> 44) as u16 & 0x0FFF,
+            });
+        }
+
+        let mut palette = Palette::new();
+        for entry in 0..32 {
+            palette.write_ocs(entry, (rand() & 0x0FFF) as u16);
+        }
+        let suppress = r & 0x4000_0000_0000_0000 != 0;
+        let bpl_output_start_x = x0 + [0usize, 6, 34][((r >> 58) as usize) % 3];
+
+        let plan = DenisePlannedPlayfieldLine::with_prepared_pixels(
+            0,
+            x0,
+            x1,
+            &planes,
+            &prepared,
+            fetched_pixels,
+        );
+
+        let mut render = |fast: bool| {
+            let mut fb = vec![0u32; FB_PIXELS];
+            let mut pf_mask = vec![0u8; FB_PIXELS];
+            let mut collisions = vec![CollisionPixel::default(); FB_PIXELS];
+            let mut clxdat = 0u16;
+            let f = if fast {
+                render_planned_playfield_line
+            } else {
+                render_planned_playfield_line_scalar
+            };
+            f(
+                &plan,
+                &mut fb,
+                &mut pf_mask,
+                &mut collisions,
+                &mut CollisionLookup::new(),
+                &mut IndexedOutputCache::default(),
+                &mut clxdat,
+                palette,
+                &palette_segments,
+                0,
+                control,
+                &control_segments,
+                0,
+                control.bplcon1,
+                control.bplcon0,
+                suppress,
+                bpl_output_start_x,
+                &h_row_for(control),
+                PAL_VISIBLE_LINE0,
+                0.0,
+                0,
+            );
+            (fb, pf_mask, collisions, clxdat)
+        };
+
+        let (fast_fb, fast_pf, fast_col, fast_clx) = render(true);
+        let (oracle_fb, oracle_pf, oracle_col, oracle_clx) = render(false);
+
+        assert_eq!(fast_clx, oracle_clx, "case {case}: clxdat diverged");
+        assert_eq!(fast_fb, oracle_fb, "case {case}: framebuffer diverged");
+        assert_eq!(fast_pf, oracle_pf, "case {case}: playfield mask diverged");
+        assert!(
+            fast_col
+                .iter()
+                .map(|c| c.0)
+                .eq(oracle_col.iter().map(|c| c.0)),
+            "case {case}: collision pixels diverged"
+        );
+    }
+}
+
+/// The oracle above would pass vacuously if the eligibility check always
+/// fell back to the scalar loop; a plain 4-plane lores screen must
+/// actually produce a fast interior covering most of its window.
+#[test]
+fn fast_playfield_interior_engages_for_standard_screens() {
+    let control = ControlState {
+        dmacon: DMACON_DMAEN | DMACON_BPLEN,
+        bplcon0: 0x4000,
+        diwstrt: 0x2C81,
+        diwstop: 0x2CC1,
+        ddfstrt: 0x0038,
+        ddfstop: 0x00D0,
+        ..ControlState::default()
+    };
+    let (x0, x1) = control.display_window_x();
+    let words = 20;
+    let fetched_pixels = words * 16;
+    let planes: Vec<Vec<u16>> = (0..4).map(|_| vec![0xA55A; words]).collect();
+    let mut prepared = Vec::new();
+    prepare_planar_row_pixels(&planes, fetched_pixels, &mut prepared);
+    let plan = DenisePlannedPlayfieldLine::with_prepared_pixels(
+        0,
+        x0,
+        x1.min(FB_WIDTH),
+        &planes,
+        &prepared,
+        fetched_pixels,
+    );
+
+    let pixel_repeat = control.framebuffer_pixel_repeat();
+    let diw_h_start = control.diw_h_start();
+    let delays = std::array::from_fn(|plane| control.sample_delay_for_plane(plane));
+    let interior = fast_playfield_run_interior(
+        &plan,
+        x0,
+        plan.x_stop,
+        x0,
+        pixel_repeat,
+        control.native_samples_per_framebuffer_pixel(),
+        control.fetch_start_native_x(diw_h_start, pixel_repeat),
+        control.native_x_offset(diw_h_start, pixel_repeat),
+        0,
+        &delays,
+        4,
+        false,
+        false,
+        1,
+        true,
+        false,
+        true,
+        true,
+        control,
+    );
+    let (fast_lo, fast_hi, _f0, mask) = interior.expect("standard screen must qualify");
+    assert_eq!(mask, 0x0F);
+    assert!(
+        fast_hi - fast_lo >= (plan.x_stop - x0) / 2,
+        "interior {fast_lo}..{fast_hi} should cover most of {x0}..{}",
+        plan.x_stop
+    );
+}


### PR DESCRIPTION
Three measured wins for hosts that cannot afford the browser build's full per-frame cost, from an investigation on a 4-core Ice Lake i5 (2020 13" MacBook Pro) where an A1200 workload saturated the main thread into slow motion. Stacked on #397 (whose worklet-clock machinery the stride reuses); it retargets to main when that merges.

**Adaptive render stride.** The wasm-side presentation render is ~45% of a step's cost on that machine. When the rolling step cost nears the 60 Hz frame budget, alternate ticks now step with the render deferred (the `run_hidden` + stale-repaint path from #397): emulation and audio hold real time and only the shown rate degrades, never below half the tick rate, with hysteresis and a `render 1/2` stat tag. On State of the Art's dancer the machine went from 32 ticks/s at 96.7% busy to a full 61-tick loop at ratio 1.000.

**Exact previous-frame reuse.** The desktop's threaded render cache skips re-rendering identical frames; the web build rendered unconditionally. `render_completed_frame` now uses the same `render_reusing_previous` + `RepeatedFrameDetector` pair as the benchmark binary, with detector resets wherever a repaint must not match (state load, cold reset, overscan switch). A static screen costs no render at all.

**simd128 + wasm-opt in the published build.** +6% whole-run from render autovectorization (matched pair), -13% bundle from `wasm-opt -O3`. Fat LTO was measured and deliberately rejected: it regresses wasm under V8 despite being a native-build win.

Verified end to end on the Ice Lake machine: eon (A1200, Kickstart 3.1) runs at ratio 1.000-1.001 with a steady audio queue, including quick-save/quick-load into the new bundle.

| Ice Lake i5, unthrottled speed vs real time | with render | core only |
|---|---|---|
| A500 AROS boot screen | 1.52x | 2.79x |
| A1200 State of the Art dancer | 1.08x | 1.38x |