### PR TITLE
ci: pin modern binaryen and smoke-load the bundle before publishing

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -42,7 +42,18 @@ jobs:
           test -n "$V"
           cargo install wasm-bindgen-cli --version "$V" --locked
       - name: Install binaryen
-        run: sudo apt-get update && sudo apt-get install -y binaryen
+        # Pinned from upstream releases, never apt: Ubuntu ships binaryen
+        # 108 (2022), whose wasm-opt mangles the externref table
+        # wasm-bindgen's glue grows at startup - the published bundle then
+        # dies at load with "WebAssembly.Table.grow(): failed to grow
+        # table by 4". Modern binaryen also reads the module's feature
+        # section itself, so the pass needs no --enable flags to keep.
+        run: |
+          V=version_131
+          curl --location --silent --show-error --fail \
+            https://github.com/WebAssembly/binaryen/releases/download/$V/binaryen-$V-x86_64-linux.tar.gz \
+            | tar xz
+          echo "$PWD/binaryen-$V/bin" >> "$GITHUB_PATH"
       - name: Build the web crate
         working-directory: crates/copperline-web
         # simd128: every wasm-capable browser has had fixed-width SIMD for
@@ -57,10 +68,24 @@ jobs:
           wasm-bindgen --target web --out-dir pkg \
             target/wasm32-unknown-unknown/release/copperline_web.wasm
           wasm-opt -O3 \
-            --enable-simd --enable-bulk-memory --enable-sign-ext \
-            --enable-mutable-globals --enable-nontrapping-float-to-int \
             pkg/copperline_web_bg.wasm -o pkg/copperline_web_bg.wasm
           test -s pkg/copperline_web_bg.wasm
+      - name: Smoke-load the optimized bundle
+        # The one check that would have caught a wasm-opt-mangled table:
+        # instantiate the exact glue + binary pair that is about to be
+        # published and build a machine from it. Anything wrong with the
+        # pair fails here, before the site sees it.
+        working-directory: crates/copperline-web
+        run: |
+          cat > pkg-smoke.mjs <<'SMOKE'
+          import { readFileSync } from 'fs';
+          import init, { WebEmu } from './pkg/copperline_web.js';
+          await init(readFileSync('./pkg/copperline_web_bg.wasm'));
+          const emu = new WebEmu('A500', 'PAL');
+          console.log('bundle loads:', emu.machine_summary());
+          SMOKE
+          node pkg-smoke.mjs
+          rm pkg-smoke.mjs
       - name: Check out the website repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -49,6 +49,7 @@ jobs:
         # table by 4". Modern binaryen also reads the module's feature
         # section itself, so the pass needs no --enable flags to keep.
         run: |
+          set -euo pipefail
           V=version_131
           curl --location --silent --show-error --fail \
             https://github.com/WebAssembly/binaryen/releases/download/$V/binaryen-$V-x86_64-linux.tar.gz \
@@ -77,15 +78,21 @@ jobs:
         # pair fails here, before the site sees it.
         working-directory: crates/copperline-web
         run: |
+          set -euo pipefail
+          # The glue is a self-contained ES module behind a .js name, and
+          # wasm-bindgen emits no package.json "type" to say so; a copy
+          # with an .mjs name loads as ESM on every Node version, without
+          # leaning on newer Nodes' syntax detection.
+          cp pkg/copperline_web.js pkg-smoke-glue.mjs
           cat > pkg-smoke.mjs <<'SMOKE'
           import { readFileSync } from 'fs';
-          import init, { WebEmu } from './pkg/copperline_web.js';
+          import init, { WebEmu } from './pkg-smoke-glue.mjs';
           await init(readFileSync('./pkg/copperline_web_bg.wasm'));
           const emu = new WebEmu('A500', 'PAL');
           console.log('bundle loads:', emu.machine_summary());
           SMOKE
           node pkg-smoke.mjs
-          rm pkg-smoke.mjs
+          rm pkg-smoke.mjs pkg-smoke-glue.mjs
       - name: Check out the website repository
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The first published bundle with the #398 wasm-opt pass died at load in every browser: `WebAssembly.Table.grow(): failed to grow table by 4`. Root cause: the runner installs binaryen from apt, which on ubuntu-latest is **binaryen 108 (2022)** - its wasm-opt mangles the externref table that wasm-bindgen's glue grows by 4 at startup. The pass had been validated locally against binaryen 131, where the same commands produce a working bundle; the runner's tool version was the untested variable. Reproduced deterministically in Node with the live site's exact glue+wasm pair, and confirmed fixed with the same pair rebuilt under 131.

Changes:
- Install binaryen pinned from upstream releases (`version_131`) instead of apt. Modern wasm-opt reads the module's feature section itself, so the explicit `--enable-*` list is dropped (it was also missing `--enable-reference-types`, whose absence is what let old binaryen strip the table).
- New smoke-load step: before publishing, CI instantiates the exact glue+binary pair in Node and constructs a `WebEmu` - the check that would have blocked this publish.

The live site is being restored in parallel with a locally built (binaryen 131, smoke-tested) bundle; re-dispatching the workflow after this merges makes CI the source of truth again.