### PR TITLE
web: fill a #build-info shell hook with the bundle's tag and commit

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -422,6 +422,7 @@ async function load() {
     setLoadStatus('loading emulator...');
     wasm = await init();
     buildInfo = WebEmu.build_info?.() ?? null;
+    showBuildInfo();
     populateMachineSelect();
     populateVideoSelect();
   } catch (e) {
@@ -5201,6 +5202,32 @@ $('kickurl')?.addEventListener('click', () => {
 
 const BUG_REPORT_URL = 'https://github.com/CopperlineHQ/Copperline/issues/new';
 let buildInfo = null; // the wasm build's tag and commit, known once init resolves
+
+// Optional page-shell hook: a #build-info element is filled with the
+// running bundle's identity once the wasm module is up, so a page can show
+// what is deployed. The "ref (commit)" shape CI bakes into build_info()
+// gets the commit linked to GitHub; anything else ("dev build", or
+// "unknown" for a bundle too old to carry build_info) stays plain text.
+// The element is untouched until the module resolves, so a shell can hide
+// the empty state with :empty.
+function showBuildInfo() {
+  const el = $('build-info');
+  if (!el) return;
+  const info = buildInfo ?? 'unknown';
+  el.textContent = '';
+  const m = /^.+ \(([0-9a-f]{6,40})\)$/.exec(info);
+  if (m) {
+    el.append('build: ');
+    const a = document.createElement('a');
+    a.href = `https://github.com/CopperlineHQ/Copperline/commit/${m[1]}`;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    a.textContent = info;
+    el.appendChild(a);
+  } else {
+    el.append(`build: ${info}`);
+  }
+}
 
 function bugReportHref() {
   const toml = (v) =>

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -719,6 +719,14 @@ elements, and pages without them are untouched:
   track counter, disk names), letting the page own its placement and
   outer styling. Without it the strip inserts itself directly below the
   canvas shell. Either way it fills in once a machine boots.
+- `#build-info` (a container): filled once the wasm module loads with the
+  bundle's build identity -- the tag or branch and commit CI compiled it
+  from (`v0.14.0 (abc123def)`, the commit linked to its GitHub page), or
+  `dev build` for a bundle built outside CI -- so a page can show what is
+  deployed. The element is untouched until the module resolves, so a
+  shell can hide the empty state with `:empty`; without the element
+  nothing is inserted. The same string is what the bug-report link files
+  under its version field.
 - `data-default="keys"` on the `#joy` toggle: the joystick mode the page
   starts in -- `off`, `keys`, `cd32`, or `touch` (the config file's
   `joy` and then `?joy=` in the URL override it).


### PR DESCRIPTION
The wasm has always known its own build identity: `build_info()` bakes `GITHUB_REF_NAME` and `GITHUB_SHA` in at compile time, but the only consumer was the bug-report prefill. This adds an optional `#build-info` page-shell hook so a page can show what is deployed.

- Once the module resolves, the glue fills the element with `build: <ref> (<commit>)`, linking the commit to its GitHub page. A bundle built outside CI shows `build: dev build`; one too old to carry `build_info` shows `build: unknown`.
- The element is untouched until init resolves, so a shell can collapse the empty state with `:empty`; pages without the element see no change.
- Documented in the page-shell hooks list in `docs/guide/browser.md`.

The companion website PR hosts the element at the foot of the try page's new control sidebar. Verified against the currently published pkg: the line renders and (correctly) reports `dev build`, since the bundle currently on the site was republished from a local build rather than the tag workflow.