### PR TITLE
web: unlock audio on pointerup, and keep the unlock armed until it lands

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -523,6 +523,14 @@ let audioBuildGeneration = 0;
 let audioUnlockRebuild = false;
 
 function audioUnlock() {
+  // The pause contract holds on this path too: a paused machine's
+  // context stays suspended, and unpausing owns the resume. Returning
+  // WITHOUT disarming keeps the ladder ready for the first unpaused
+  // gesture - which cannot be the unpause tap itself (its pointerup
+  // precedes the click that clears the flag), but setPaused resumes
+  // inside that same activation window, and a resume it cannot land is
+  // exactly what the still-armed ladder is for.
+  if (paused) return;
   if (!audioCtx || audioUnlockRebuild) {
     audioUnlockRebuild = false;
     buildAudioStack(false).catch((e) => console.error('audio rebuild', e));
@@ -533,10 +541,15 @@ function audioUnlock() {
     () => {
       if (audioCtx !== ctx) return; // superseded while settling
       if (ctx.state === 'running') disarmAudioUnlock();
-      else audioUnlockRebuild = true;
+      // A suspended reading here can be the Pause tap's own doing: its
+      // pointerup fires this handler while still unpaused, and the
+      // click's suspend lands before the resume settles. That is the
+      // pause contract at work, not a context beyond resuming, so it
+      // must not arm the escalation.
+      else if (!paused) audioUnlockRebuild = true;
     },
     () => {
-      if (audioCtx === ctx) audioUnlockRebuild = true;
+      if (audioCtx === ctx && !paused) audioUnlockRebuild = true;
     },
   );
 }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -502,19 +502,60 @@ let audioBuildGeneration = 0;
 // rebuilds while the policy holds contexts suspended cannot stack
 // listeners, and firing resumes whatever stack is current rather than
 // the one that happened to be live when the listener was armed.
+//
+// The triggers are pointerup and keydown, never pointerdown, because
+// of how user activation is granted (HTML spec, "activation triggering
+// input event"): a mouse grants it on the down, but a touch grants it
+// at the END of the gesture - a finger's pointerdown carries no
+// activation, so a resume issued there is refused. With the old
+// once-listeners that single refusal also disarmed the unlock, which
+// left an iPhone permanently silent after an iOS audio-session
+// interruption while every desktop test passed (mice activate on the
+// down). By pointerup both input kinds hold activation. The listeners
+// now stay armed until a resume verifiably lands, so a refused attempt
+// never burns the arming.
+//
+// If an in-gesture resume settles with the context still not running,
+// that context is beyond resuming (an iOS session wedge), and the next
+// gesture escalates: it rebuilds the whole stack inside its activation
+// window - the same shape as the boot click, which starts audio
+// reliably even right after an interruption.
+let audioUnlockRebuild = false;
+
 function audioUnlock() {
-  window.removeEventListener('pointerdown', audioUnlock);
-  window.removeEventListener('keydown', audioUnlock);
-  audioCtx?.resume().catch(() => {});
+  if (!audioCtx || audioUnlockRebuild) {
+    audioUnlockRebuild = false;
+    buildAudioStack(false).catch((e) => console.error('audio rebuild', e));
+    return;
+  }
+  const ctx = audioCtx;
+  ctx.resume().then(
+    () => {
+      if (audioCtx !== ctx) return; // superseded while settling
+      if (ctx.state === 'running') disarmAudioUnlock();
+      else audioUnlockRebuild = true;
+    },
+    () => {
+      if (audioCtx === ctx) audioUnlockRebuild = true;
+    },
+  );
 }
 
 function armAudioUnlock() {
-  window.addEventListener('pointerdown', audioUnlock);
+  window.addEventListener('pointerup', audioUnlock);
   window.addEventListener('keydown', audioUnlock);
+}
+
+function disarmAudioUnlock() {
+  window.removeEventListener('pointerup', audioUnlock);
+  window.removeEventListener('keydown', audioUnlock);
 }
 
 async function buildAudioStack(suspendForPause) {
   const gen = ++audioBuildGeneration;
+  // A fresh build restarts the unlock ladder from its first rung: the
+  // escalation verdict belonged to the context being replaced.
+  audioUnlockRebuild = false;
   if (audioCtx) {
     audioNode?.disconnect();
     // Deliberately not awaited: on iOS the context being replaced may be
@@ -596,8 +637,16 @@ async function buildAudioStack(suspendForPause) {
   // Autoplay policies can leave the context suspended, and resume() may
   // not settle without a qualifying gesture; never let that block the
   // boot. Video runs regardless, and the next real interaction unlocks
-  // the sound.
-  ctx.resume().catch(() => {});
+  // the sound. A resume that verifiably lands clears any armed unlock;
+  // the synchronous state check below arms it in the meantime (the
+  // resume is still settling then, and a no-op unlock firing on a
+  // context that made it on its own is harmless).
+  ctx
+    .resume()
+    .then(() => {
+      if (audioCtx === ctx && ctx.state === 'running') disarmAudioUnlock();
+    })
+    .catch(() => {});
   if (ctx.state !== 'running') armAudioUnlock();
 }
 


### PR DESCRIPTION
Follow-up to #402, which rebuilt the audio stack on returning to the foreground but still left a real iPhone silent after an app switch. On-device Web Inspector data pinned the true mechanism, and it was in our unlock listener all along:

## Root cause

- After the return, the rebuilt context sat `suspended` with `currentTime: 0` -- built fine, never started, its gestureless `resume()` refused. That part is by design; the tap was supposed to finish the job.
- **The tap could not work.** User activation on a touch screen is granted at the *end* of the gesture: the HTML spec's activation-triggering events count `pointerdown` only for mice, while a finger's activation arrives at `pointerup`/`touchend`. Our unlock listened on `pointerdown`, so it always fired *before* the tap carried activation, iOS refused the resume -- and the listener had already removed itself, so the first tap permanently burned the unlock.
- Desktop testing could never catch this: a mouse's `pointerdown` **does** grant activation.
- A page reload cures it because the boot click creates the context inside a full activation window -- confirmed on-device.

## Fix

- Unlock triggers are now `pointerup` + `keydown`; by pointerup both touch and mouse gestures hold activation.
- The listeners stay armed until a resume verifiably reaches `running`; a refused attempt no longer costs the arming.
- Escalation ladder: if an in-gesture resume settles with the context still stuck, the next gesture rebuilds the whole stack *inside* its activation window -- the same shape as the boot click the reload evidence proved reliable. Any fresh build resets the ladder.

## Testing

Driven-Chrome harness from a page with no user activation at all (the iPhone's post-interruption state): `pointerdown` is inert; a refused in-gesture resume stays armed and escalates the next `pointerup` into a full rebuild; a landing resume disarms both triggers (resume-call counter reads zero on subsequent fires); the foreground-return rebuild and all #402 flows still pass. The activation grant itself cannot be exercised in the harness (an occluded automation tab receives no real input) -- it rests on the spec semantics and needs the usual iPhone confirmation after the site republish.

Expected behavior on the phone after this lands: switch away, switch back, **first tap brings the sound back** (a second tap covers the pathological case via the rebuild rung).