### PR TITLE
web: reduce redundant WASM render and presentation work

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -87,8 +87,15 @@ jobs:
           cat > pkg-smoke.mjs <<'SMOKE'
           import { readFileSync } from 'fs';
           import init, { WebEmu } from './pkg-smoke-glue.mjs';
-          await init(readFileSync('./pkg/copperline_web_bg.wasm'));
+          await init({ module_or_path: readFileSync('./pkg/copperline_web_bg.wasm') });
           const emu = new WebEmu('A500', 'PAL');
+          if (emu.presentation_revision() !== 0) {
+            throw new Error('fresh presentation revision is not zero');
+          }
+          emu.run(0, 0);
+          if (!Number.isFinite(emu.last_run_core_ms()) || emu.last_run_render_ms() !== 0) {
+            throw new Error('invalid browser host-timing split');
+          }
           console.log('bundle loads:', emu.machine_summary());
           SMOKE
           node pkg-smoke.mjs

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ against real hardware.
   canvas/Web Audio frontend, hosted at
   [copperline.dev/try](https://copperline.dev/try/) -- boots the bundled
   AROS ROM, takes your own Kickstart and disk images, and runs entirely
-  client-side. See `docs/guide/browser.md` for how it works and how to
+  client-side. Exact-repeat frames skip both Rust rendering and browser
+  uploads, and the live stat line splits core, render, upload, and monitor
+  submission cost. See `docs/guide/browser.md` for how it works and how to
   embed it.
 
 ## Requirements

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -23,6 +23,7 @@ use copperline::config::{
 };
 use copperline::emulator::{build_machine, Emulator};
 use copperline::serial::{ChannelSerialHandle, ChannelSerialSink};
+use copperline::timebase::Instant;
 use copperline::video::deinterlace::Deinterlacer;
 use copperline::video::{bitplane, present_common, FB_WIDTH, MAX_CANVAS_PIXELS};
 use wasm_bindgen::prelude::*;
@@ -208,6 +209,11 @@ pub struct WebEmu {
     present: Vec<u32>,
     present_width: usize,
     present_rows: usize,
+    /// Monotonic identity of the bytes and geometry in `present`. The page
+    /// compares this with the last revision it uploaded, so an emulated frame
+    /// that the exact-reuse detector matched does not cross the JS/WebGL
+    /// presentation path again.
+    presentation_revision: u32,
     /// Emulated field lines the presentation buffer shows, for the page's
     /// CRT shader pass; 0 while no frame has rendered or the scan carries
     /// no 15 kHz line structure (a programmable scan). See
@@ -248,6 +254,11 @@ pub struct WebEmu {
     /// render at all. Replaced whenever the machine or the presentation
     /// settings change under it.
     repeated_frame_detector: bitplane::RepeatedFrameDetector,
+    /// Host timings for the most recent `run`/`run_hidden` call. They split
+    /// the page's existing whole-call timer without requiring a second core
+    /// traversal or a profiler-only build.
+    last_run_core_ms: f64,
+    last_run_render_ms: f64,
 }
 
 #[wasm_bindgen]
@@ -295,6 +306,7 @@ impl WebEmu {
             present: Vec::new(),
             present_width: FB_WIDTH,
             present_rows: 0,
+            presentation_revision: 0,
             present_crt_lines: 0.0,
             last_rendered_frame: None,
             presentation_stale: false,
@@ -305,6 +317,8 @@ impl WebEmu {
             overscan: Overscan::Tv,
             presentation_latch: present_common::PresentationLatch::default(),
             repeated_frame_detector: bitplane::RepeatedFrameDetector::default(),
+            last_run_core_ms: 0.0,
+            last_run_render_ms: 0.0,
         })
     }
 
@@ -399,11 +413,14 @@ impl WebEmu {
     }
 
     fn run_paced(&mut self, now_ms: f64, max_frames: u32, render: bool) -> Result<u32, JsValue> {
+        self.last_run_core_ms = 0.0;
+        self.last_run_render_ms = 0.0;
         let (anchor_wall, anchor_emu) = *self
             .anchor
             .get_or_insert((now_ms, self.emu.bus().emulated_seconds()));
         let target = anchor_emu + (now_ms - anchor_wall) / 1000.0;
         let mut stepped = 0u32;
+        let core_started = Instant::now();
         while self.emu.bus().emulated_seconds() < target && stepped < max_frames {
             self.drain_pending_mouse();
             self.emu.step_frame().map_err(js_err)?;
@@ -414,12 +431,15 @@ impl WebEmu {
         if stepped == 0 {
             self.drain_pending_mouse();
         }
+        self.last_run_core_ms = core_started.elapsed().as_secs_f64() * 1000.0;
         if target - self.emu.bus().emulated_seconds() > MAX_CATCHUP_SECONDS {
             self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
         }
         if render {
             if stepped > 0 || self.presentation_stale {
+                let render_started = Instant::now();
                 self.render_completed_frame();
+                self.last_run_render_ms = render_started.elapsed().as_secs_f64() * 1000.0;
                 self.presentation_stale = false;
             }
         } else if stepped > 0 {
@@ -539,6 +559,7 @@ impl WebEmu {
             };
         }
         self.last_rendered_frame = Some(emulated_frame);
+        self.presentation_revision = self.presentation_revision.wrapping_add(1);
     }
 
     /// Presentation buffer: RGBA bytes in memory order, `present_width() x
@@ -548,6 +569,14 @@ impl WebEmu {
     /// every frame.
     pub fn present_ptr(&self) -> *const u32 {
         self.present.as_ptr()
+    }
+
+    /// Identity of the current presentation bytes and geometry. It advances
+    /// only when the renderer writes a new presentation, not merely because
+    /// the emulated machine stepped, so a browser can skip redundant canvas
+    /// uploads and draws without comparing the framebuffer itself.
+    pub fn presentation_revision(&self) -> u32 {
+        self.presentation_revision
     }
 
     pub fn present_rows(&self) -> u32 {
@@ -571,6 +600,20 @@ impl WebEmu {
     /// can change between frames like `present_width`.
     pub fn present_crt_lines(&self) -> f32 {
         self.present_crt_lines
+    }
+
+    /// Host milliseconds spent advancing the emulated machine in the most
+    /// recent `run`/`run_hidden` call, excluding the Rust presentation
+    /// renderer.
+    pub fn last_run_core_ms(&self) -> f64 {
+        self.last_run_core_ms
+    }
+
+    /// Host milliseconds spent in the Rust presentation renderer in the most
+    /// recent `run` call. `run_hidden`, an idle run, and a call that needed no
+    /// repaint report zero.
+    pub fn last_run_render_ms(&self) -> f64 {
+        self.last_run_render_ms
     }
 
     /// Drain the mixed audio: interleaved stereo f32 at 44.1 kHz, one PAL

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -209,10 +209,9 @@ pub struct WebEmu {
     present: Vec<u32>,
     present_width: usize,
     present_rows: usize,
-    /// Monotonic identity of the bytes and geometry in `present`. The page
-    /// compares this with the last revision it uploaded, so an emulated frame
-    /// that the exact-reuse detector matched does not cross the JS/WebGL
-    /// presentation path again.
+    /// Wrapping generation of `present`. The page compares this with the last
+    /// revision it uploaded, so an emulated frame that the exact-reuse
+    /// detector matched does not cross the JS/WebGL presentation path again.
     presentation_revision: u32,
     /// Emulated field lines the presentation buffer shows, for the page's
     /// CRT shader pass; 0 while no frame has rendered or the scan carries
@@ -571,9 +570,9 @@ impl WebEmu {
         self.present.as_ptr()
     }
 
-    /// Identity of the current presentation bytes and geometry. It advances
-    /// only when the renderer writes a new presentation, not merely because
-    /// the emulated machine stepped, so a browser can skip redundant canvas
+    /// Generation of the current presentation buffer. It advances when the
+    /// renderer writes a non-reused presentation, not merely because the
+    /// emulated machine stepped, so a browser can skip exact-reuse canvas
     /// uploads and draws without comparing the framebuffer itself.
     pub fn presentation_revision(&self) -> u32 {
         self.presentation_revision

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -82,6 +82,20 @@ let presentsThisSecond = 0;
 // blits of fresh pictures rather than assuming step and blit share a
 // tick.
 let presentDirty = false;
+// Exact identity exported by current wasm bundles. Unlike presentDirty,
+// this advances only when Rust changed the presentation bytes or geometry,
+// so repeated emulated frames need no canvas upload or monitor draw. Null
+// also forces the first frame of a new machine through.
+let lastPresentationRevision = null;
+// Cumulative host work behind the once-per-second stat line. Rust supplies
+// the core/render split; the page measures the buffer upload and monitor
+// shader submission around the browser calls themselves. Dividing by the
+// emulated frames stepped in the interval makes all four figures directly
+// comparable with the PAL/NTSC frame budget.
+let coreMsThisSecond = 0;
+let rustRenderMsThisSecond = 0;
+let uploadMsThisSecond = 0;
+let shaderMsThisSecond = 0;
 let audioUnderruns = 0;
 let lastStatUpdate = 0;
 // Size of the last presented frame in emulated pixels. Under the monitor
@@ -684,6 +698,11 @@ async function boot() {
 
     await buildAudioStack(false);
     presentDirty = false;
+    lastPresentationRevision = null;
+    coreMsThisSecond = 0;
+    rustRenderMsThisSecond = 0;
+    uploadMsThisSecond = 0;
+    shaderMsThisSecond = 0;
 
     // A fresh machine boots with an empty drive: DF0 holds the pending disk
     // or nothing, never a name left over from before the reboot (a crash
@@ -821,30 +840,40 @@ function maxFramesForQueue() {
 // tick, and again after a save state is loaded: that repaints the restored
 // screen straight away, so a load into a paused machine shows where it
 // resumes instead of the frame from before the load.
-function presentFrame() {
+function presentFrame(force = false) {
   const rows = emu.present_rows();
-  if (rows === 0) return;
+  if (rows === 0) return false;
+  const revision =
+    typeof emu.presentation_revision === 'function' ? emu.presentation_revision() : null;
+  const changed = revision === null ? presentDirty : revision !== lastPresentationRevision;
+  if (!changed && !force) return false;
   // The presentation size follows the emulated display (the cropped TV
   // aperture for a standard PAL screen, the full overscan framebuffer
-  // otherwise), so track both dimensions every frame.
+  // otherwise), so track both dimensions whenever the buffer changes or
+  // an external display change forces a redraw.
   const width = emu.present_width();
   presentSize = { width, rows };
   if (monitorGl) {
-    presentFrameMonitor(width, rows);
-    return;
+    presentFrameMonitor(width, rows, changed);
+  } else {
+    const uploadStart = performance.now();
+    if (canvas.width !== width || canvas.height !== rows) {
+      canvas.width = width;
+      canvas.height = rows;
+    }
+    // The view must be rebuilt after every changed presentation: wasm memory
+    // may grow and the present buffer may reallocate. A forced 2D redraw
+    // (resize while paused) needs the same copy even when the revision held.
+    const view = new Uint8ClampedArray(
+      wasm.memory.buffer,
+      emu.present_ptr(),
+      width * rows * 4,
+    );
+    ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
+    uploadMsThisSecond += performance.now() - uploadStart;
   }
-  if (canvas.width !== width || canvas.height !== rows) {
-    canvas.width = width;
-    canvas.height = rows;
-  }
-  // The view must be rebuilt every frame: wasm memory may grow and the
-  // present buffer may reallocate.
-  const view = new Uint8ClampedArray(
-    wasm.memory.buffer,
-    emu.present_ptr(),
-    width * rows * 4,
-  );
-  ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
+  if (revision !== null) lastPresentationRevision = revision;
+  return changed;
 }
 
 // Advance the machine to nowMs and ship what it produced (audio, serial):
@@ -863,10 +892,22 @@ function stepMachine(nowMs, deferRender) {
       deferRender && typeof emu.run_hidden === 'function'
         ? emu.run_hidden(nowMs, max)
         : emu.run(nowMs, max);
+    const stepElapsed = performance.now() - stepStart;
     // Rolling cost of a step, the render-stride controller's signal.
     // Idle steps (nothing to advance) pull it down, which is right:
     // they mean the host is keeping up.
-    avgStepMs = avgStepMs * 0.9 + (performance.now() - stepStart) * 0.1;
+    avgStepMs = avgStepMs * 0.9 + stepElapsed * 0.1;
+    if (
+      typeof emu.last_run_core_ms === 'function' &&
+      typeof emu.last_run_render_ms === 'function'
+    ) {
+      coreMsThisSecond += emu.last_run_core_ms();
+      rustRenderMsThisSecond += emu.last_run_render_ms();
+    } else {
+      // Compatibility with a page served briefly against an older bundle:
+      // preserve a useful total under "core" until the split getters arrive.
+      coreMsThisSecond += stepElapsed;
+    }
     renderSkipActive = renderSkipActive
       ? avgStepMs > RENDER_SKIP_EXIT_MS
       : avgStepMs > RENDER_SKIP_ENTER_MS;
@@ -896,15 +937,26 @@ function stepMachine(nowMs, deferRender) {
   pumpSerial();
 
   if (nowMs - lastStatUpdate >= 1000) {
+    const timedFrames = Math.max(1, framesThisSecond);
     statLine.textContent =
       `${framesThisSecond} fps (${presentsThisSecond} shown, ${ticksThisSecond} ticks) | ` +
       `${emu.emulated_seconds().toFixed(1)}s emulated | ` +
       `audio ${queuedMs.toFixed(0)} ms` +
       (audioUnderruns > 0 ? ` (${audioUnderruns} underruns)` : '') +
-      (renderSkipActive ? ' | render 1/2' : '');
+      (renderSkipActive ? ' | render 1/2' : '') +
+      ` | host ${[
+        `core ${(coreMsThisSecond / timedFrames).toFixed(1)}`,
+        `render ${(rustRenderMsThisSecond / timedFrames).toFixed(1)}`,
+        `upload ${(uploadMsThisSecond / timedFrames).toFixed(1)}`,
+        `shader ${(shaderMsThisSecond / timedFrames).toFixed(1)}`,
+      ].join(' + ')} ms/frame`;
     framesThisSecond = 0;
     ticksThisSecond = 0;
     presentsThisSecond = 0;
+    coreMsThisSecond = 0;
+    rustRenderMsThisSecond = 0;
+    uploadMsThisSecond = 0;
+    shaderMsThisSecond = 0;
     lastStatUpdate = nowMs;
     updateStatusDisks();
   }
@@ -928,11 +980,11 @@ function tick(nowMs) {
   const deferRender = renderSkipActive && !renderDeferredLastTick;
   if (!stepMachine(nowMs, deferRender)) return;
   renderDeferredLastTick = deferRender;
-  presentFrame();
+  const presentedFresh = presentFrame();
   // A deferred tick blits the previous picture again; the flag rides
   // through to the rendering tick whose blit really shows something
   // new, so "shown" stays the count of fresh pictures on the canvas.
-  if (presentDirty && !deferRender) {
+  if (presentedFresh && !deferRender) {
     presentsThisSecond++;
     presentDirty = false;
   }
@@ -4503,9 +4555,9 @@ function setTintMode(mode, remember) {
   // passes too, so the bezel plastic never turns phosphor-green. A CSS
   // filter on the element would tint frame and all.
   canvas.style.filter = monitorGl ? '' : tintFilter();
-  // A running page picks the shader tint up next tick; a paused one has
-  // no ticking loop to repaint, so repaint here.
-  if (monitorGl && emu && running && paused) presentFrame();
+  // The emulated picture did not change, so the revision-driven tick would
+  // skip it; redraw the held monitor texture with the new uniform now.
+  if (monitorGl && emu && running) presentFrame(true);
 }
 tintSel.addEventListener('change', () => setTintMode(tintSel.value, true));
 
@@ -4928,33 +4980,61 @@ void main() {
     // blank canvas until its next tick. The rebuild reset the cached
     // texture size, so this re-uploads the frame it re-presents. With no
     // machine, the powered-off monitor comes back instead.
-    if (emu && running) presentFrame();
+    if (emu && running) presentFrame(true);
     else if (!emu) presentMonitorOff();
   });
   return renderer;
 }
 
-// Present one frame through the monitor renderer: upload the emulator's
-// presentation buffer and draw it as the selected monitor.
-function presentFrameMonitor(width, rows) {
+// Present one frame through the monitor renderer. A changed Rust
+// presentation uploads new texture bytes; a display-only change (monitor
+// mode, tint, resize, context restoration) redraws the existing texture.
+function presentFrameMonitor(width, rows, changed) {
   const gl = monitorGl.gl;
-  // The view must be rebuilt every frame (wasm memory may grow); the
-  // texture reallocates only when the presentation size changes.
-  const view = new Uint8Array(wasm.memory.buffer, emu.present_ptr(), width * rows * 4);
   gl.bindTexture(gl.TEXTURE_2D, monitorGl.tex);
-  if (monitorGl.texW !== width || monitorGl.texH !== rows) {
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, width, rows, 0, gl.RGBA, gl.UNSIGNED_BYTE, view);
-    monitorGl.texW = width;
-    monitorGl.texH = rows;
-  } else {
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, rows, gl.RGBA, gl.UNSIGNED_BYTE, view);
+  const resized = monitorGl.texW !== width || monitorGl.texH !== rows;
+  if (changed || resized) {
+    const uploadStart = performance.now();
+    // Rebuild the view only for a real upload: wasm memory may grow and the
+    // presentation Vec may reallocate between revisions.
+    const view = new Uint8Array(wasm.memory.buffer, emu.present_ptr(), width * rows * 4);
+    if (resized) {
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.SRGB8_ALPHA8,
+        width,
+        rows,
+        0,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        view,
+      );
+      monitorGl.texW = width;
+      monitorGl.texH = rows;
+    } else {
+      gl.texSubImage2D(
+        gl.TEXTURE_2D,
+        0,
+        0,
+        0,
+        width,
+        rows,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        view,
+      );
+    }
+    uploadMsThisSecond += performance.now() - uploadStart;
   }
   // The CRT pass suspends when the scan has no 15 kHz line structure to
   // draw (a programmable scan; 0 from the getter), like the desktop's
   // preset, leaving the bezel - which frames any scan - or the plain
   // blit. An older wasm bundle has no getter; half the presented rows is
   // the standard-scan line count.
+  const shaderStart = performance.now();
   monitorDraw(width, rows, emu.present_crt_lines?.() ?? rows / 2);
+  shaderMsThisSecond += performance.now() - shaderStart;
 }
 
 // Draw the selected monitor with a dark, unlit screen: what the page
@@ -5076,10 +5156,9 @@ function setMonitorMode(mode, remember) {
   monitorSel.value = mode;
   if (remember) storePref(MONITOR_STORAGE_KEY, mode);
   syncShellChrome();
-  // A running page picks the mode up next tick; a paused one has no
-  // ticking loop to repaint, so repaint here, and with no machine at all
-  // the choice previews on the powered-off monitor.
-  if (emu && running && paused) presentFrame();
+  // The emulated picture did not change, so redraw the held texture now;
+  // with no machine at all the choice previews on the powered-off monitor.
+  if (emu && running) presentFrame(true);
   else if (!emu) presentMonitorOff();
 }
 monitorSel.addEventListener('change', () => setMonitorMode(monitorSel.value, true));
@@ -5100,8 +5179,8 @@ function syncShellChrome() {
 // The powered-off monitor fronts the page from the start: drawn now (the
 // module runs with the DOM ready), again on load in case the stylesheet
 // laid the canvas out late, and on resizes while no machine exists. A
-// paused machine repaints on resize too - its loop is not ticking, and
-// the stretched backing store would otherwise blur the frozen picture.
+// running machine redraws its held texture too: repeated emulated frames
+// deliberately skip the ordinary presentation path now.
 syncShellChrome();
 presentMonitorOff();
 window.addEventListener('load', () => {
@@ -5110,7 +5189,7 @@ window.addEventListener('load', () => {
 window.addEventListener('resize', () => {
   if (!monitorGl) return;
   if (!emu) presentMonitorOff();
-  else if (running && paused) presentFrame();
+  else if (running) presentFrame(true);
 });
 
 // --- status bar --------------------------------------------------------

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -82,10 +82,10 @@ let presentsThisSecond = 0;
 // blits of fresh pictures rather than assuming step and blit share a
 // tick.
 let presentDirty = false;
-// Exact identity exported by current wasm bundles. Unlike presentDirty,
-// this advances only when Rust changed the presentation bytes or geometry,
-// so repeated emulated frames need no canvas upload or monitor draw. Null
-// also forces the first frame of a new machine through.
+// Presentation generation exported by current wasm bundles. Unlike
+// presentDirty, this advances only when Rust writes a non-reused
+// presentation, so exact-reuse frames need no canvas upload or monitor
+// draw. Null also forces the first frame of a new machine through.
 let lastPresentationRevision = null;
 // Cumulative host work behind the once-per-second stat line. Rust supplies
 // the core/render split; the page measures the buffer upload and monitor
@@ -843,10 +843,16 @@ function maxFramesForQueue() {
 function presentFrame(force = false) {
   const rows = emu.present_rows();
   if (rows === 0) return false;
-  const revision =
-    typeof emu.presentation_revision === 'function' ? emu.presentation_revision() : null;
-  const changed = revision === null ? presentDirty : revision !== lastPresentationRevision;
-  if (!changed && !force) return false;
+  const hasPresentationRevision = typeof emu.presentation_revision === 'function';
+  const revision = hasPresentationRevision ? emu.presentation_revision() : null;
+  const changed = hasPresentationRevision
+    ? revision !== lastPresentationRevision
+    : presentDirty;
+  // An older cached bundle has no revision to prove that its held
+  // presentation is unchanged. Preserve the old page's unconditional
+  // copy/upload behaviour, including repaint-only load-state and overscan
+  // calls, while `changed` still keeps the "shown" counter meaningful.
+  if (hasPresentationRevision && !changed && !force) return false;
   // The presentation size follows the emulated display (the cropped TV
   // aperture for a standard PAL screen, the full overscan framebuffer
   // otherwise), so track both dimensions whenever the buffer changes or
@@ -854,7 +860,7 @@ function presentFrame(force = false) {
   const width = emu.present_width();
   presentSize = { width, rows };
   if (monitorGl) {
-    presentFrameMonitor(width, rows, changed);
+    presentFrameMonitor(width, rows, changed || !hasPresentationRevision);
   } else {
     const uploadStart = performance.now();
     if (canvas.width !== width || canvas.height !== rows) {
@@ -872,7 +878,7 @@ function presentFrame(force = false) {
     ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
     uploadMsThisSecond += performance.now() - uploadStart;
   }
-  if (revision !== null) lastPresentationRevision = revision;
+  if (hasPresentationRevision) lastPresentationRevision = revision;
   return changed;
 }
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -360,7 +360,10 @@ through wasm-bindgen; the page's JavaScript drives everything from
   does not switch shape across the blanks a screen change produces.
   A frame whose render input exactly matches the previous one skips the
   render pipeline entirely (the desktop render cache's reuse detector),
-  so a static screen costs no render work at all.
+  so a static screen costs no render work at all. The wasm wrapper exports
+  a presentation revision that advances only when those output bytes or
+  their geometry change; the page therefore also skips the typed-array
+  view, canvas/WebGL texture upload, and monitor draw for an exact repeat.
   There is no wgpu in the build, which keeps the wasm-opt'd wasm
   around 2.1 MiB (about 0.8 MiB over the wire).
 - **Audio**: Paula's 44.1 kHz stereo mix is drained once per animation frame
@@ -392,7 +395,14 @@ through wasm-bindgen; the page's JavaScript drives everything from
   60 Hz frame budget, alternate ticks step with the render deferred, so
   emulation and audio hold real time and only the displayed rate halves.
   The stat line shows `render 1/2` while this is active, and the mode
-  disengages (with hysteresis) as soon as the host keeps up again.
+  disengages (with hysteresis) as soon as the host keeps up again. Its
+  `host core + render + upload + shader` figures split the average host
+  milliseconds per emulated frame over the last reporting interval:
+  `core` is machine advancement, `render` is the Rust framebuffer and
+  presentation pipeline, `upload` is the browser-side canvas copy or WebGL
+  texture submission, and `shader` is the CPU time submitting the selected
+  monitor passes. WebGL commands are asynchronous, so `shader` is main-thread
+  submission cost rather than a synchronous GPU-completion measurement.
 - **Input**: `KeyboardEvent.code` strings map to Amiga raw keycodes with the
   same table as the desktop frontend (winit's `KeyCode` names *are* the W3C
   code strings); the mouse uses Pointer Lock for relative motion, with a
@@ -511,7 +521,10 @@ now forward to the port-taking calls. `reset()` power-cycles,
 from a pause does not sprint through the frames the pause "owed",
 `eject_floppy(n)`
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
-exposes the guest clock for diagnostics.
+exposes the guest clock for diagnostics. `presentation_revision()` identifies
+the current presentation buffer without hashing it, while
+`last_run_core_ms()` and `last_run_render_ms()` split the host cost of the
+most recent paced call for page-side diagnostics.
 
 `save_state()` returns the whole emulated machine as a `Uint8Array` in the
 desktop's `.clstate` format, and `load_state(bytes)` restores one --

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -361,9 +361,10 @@ through wasm-bindgen; the page's JavaScript drives everything from
   A frame whose render input exactly matches the previous one skips the
   render pipeline entirely (the desktop render cache's reuse detector),
   so a static screen costs no render work at all. The wasm wrapper exports
-  a presentation revision that advances only when those output bytes or
-  their geometry change; the page therefore also skips the typed-array
-  view, canvas/WebGL texture upload, and monitor draw for an exact repeat.
+  a presentation revision that advances whenever a non-reused frame is
+  copied into the presentation buffer; the page therefore also skips the
+  typed-array view, canvas/WebGL texture upload, and monitor draw when the
+  exact-reuse detector matches.
   There is no wgpu in the build, which keeps the wasm-opt'd wasm
   around 2.1 MiB (about 0.8 MiB over the wire).
 - **Audio**: Paula's 44.1 kHz stereo mix is drained once per animation frame
@@ -522,7 +523,7 @@ from a pause does not sprint through the frames the pause "owed",
 `eject_floppy(n)`
 and `set_volume_percent(p)` do what they say, and `emulated_seconds()`
 exposes the guest clock for diagnostics. `presentation_revision()` identifies
-the current presentation buffer without hashing it, while
+the current presentation-buffer generation without hashing it, while
 `last_run_core_ms()` and `last_run_render_ms()` split the host cost of the
 most recent paced call for page-side diagnostics.
 

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -360,6 +360,14 @@ reuse.
 `render_from_input` consumes only this frozen bundle, so the main thread can
 start emulating frame N+1 while the worker renders frame N.
 
+Each render thread also retains a `RenderScratch` arena across calls. The
+per-row base palettes and control state, their nested segment vectors, the
+playfield/collision canvases, horizontal-window rows, DMA-output origins and
+manual-HAM selector buffer are cleared and resized in place. This preserves
+their allocations across changing frames and avoids rebuilding several large
+temporary buffers at field rate; thread-local ownership keeps the synchronous
+browser/native paths and the desktop worker independent without locking.
+
 `window.rs` starts a persistent `copperline-render` worker by default.
 `COPPERLINE_THREADED_RENDER=0` (also `false`, `off`, or `no`) disables the
 worker and uses the synchronous wrapper path. The default worker owns a
@@ -395,6 +403,15 @@ does not defeat reuse. A match skips replay and keeps the prior collision and
 presentation result. The two-frame arming step avoids deep-copying captured
 plane data on changing displays. Interlace, phosphor history, and
 time-dependent render diagnostics do not take this shortcut.
+
+The browser wrapper exposes a monotonically wrapping presentation revision.
+It advances only after a non-reused frame has completed post-processing and
+been copied into the page-facing presentation buffer. JavaScript remembers
+the last uploaded revision, so an exact pre-render reuse also suppresses the
+typed-array construction, texture upload and monitor draw. Display-only
+changes such as a resize, tint, monitor mode or WebGL context restoration can
+force a draw of the held texture without pretending the emulated picture
+changed.
 
 After post-processing and deinterlacing, the frontend compares the complete
 active presentation buffer and its geometry with the current one. This is a

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1443,7 +1443,10 @@ pub struct BeamChipRamWrite {
 
 impl BeamChipRamWrite {
     fn from_cpu_write(vpos: u32, hpos: u32, offset: usize, size: usize, value: u32) -> Self {
-        debug_assert!(matches!(size, 1 | 2 | 4));
+        // A 68020+ three-byte operand can cross chip RAM as one dynamically
+        // sized plain-memory transfer. The four-byte record stores that width
+        // directly just like byte, word, and long writes.
+        debug_assert!((1..=4).contains(&size));
         let mut bytes = [0; 4];
         let len = size.min(bytes.len());
         for (idx, byte) in bytes.iter_mut().enumerate().take(len) {

--- a/src/envcfg.rs
+++ b/src/envcfg.rs
@@ -14,22 +14,18 @@
 //! start-up knobs, so that is the intended behaviour. Code that needs a runtime
 //! "do this once" toggle must use its own latch, not `remove_var`.
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use std::ffi::OsStr;
+use std::ffi::OsString;
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::sync::OnceLock;
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn snapshot() -> &'static HashMap<OsString, OsString> {
     static SNAPSHOT: OnceLock<HashMap<OsString, OsString>> = OnceLock::new();
-    // The browser has no process environment and std::env::vars_os() panics
-    // there ("not supported on this platform"); every knob reads as unset.
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    {
-        SNAPSHOT.get_or_init(HashMap::new)
-    }
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    {
-        SNAPSHOT.get_or_init(|| std::env::vars_os().collect())
-    }
+    SNAPSHOT.get_or_init(|| std::env::vars_os().collect())
 }
 
 /// Whether any `COPPERLINE_*` variable is present at all. Every knob this
@@ -40,6 +36,7 @@ fn snapshot() -> &'static HashMap<OsString, OsString> {
 /// default SipHasher millions of times a second only to miss. Cache the
 /// "are any of our knobs set?" answer once and short-circuit the common
 /// no-knobs case to a single bool read.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn any_copperline_var() -> bool {
     static ANY: OnceLock<bool> = OnceLock::new();
     *ANY.get_or_init(|| {
@@ -53,37 +50,72 @@ fn any_copperline_var() -> bool {
 /// True when `name` is one of our knobs and we already know none are set, so
 /// the caller can skip the snapshot hash entirely.
 #[inline]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn definitely_unset(name: &str) -> bool {
     name.starts_with("COPPERLINE") && !any_copperline_var()
 }
 
 /// Whether the variable is set (presence check), like `var_os(..).is_some()`.
-#[inline]
+///
+/// A browser WASM build has no process environment. Its implementation is a
+/// compile-time `false`, rather than a lookup in an empty snapshot, so release
+/// optimization can erase diagnostic branches from per-cycle hot paths.
+#[inline(always)]
 pub fn flag(name: &str) -> bool {
-    if definitely_unset(name) {
-        return false;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let _ = name;
+        false
     }
-    snapshot().contains_key(OsStr::new(name))
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        if definitely_unset(name) {
+            return false;
+        }
+        snapshot().contains_key(OsStr::new(name))
+    }
 }
 
 /// The variable's raw value, like `std::env::var_os`.
-#[inline]
+///
+/// Browser WASM returns `None` at compile time for the same reason as
+/// [`flag`].
+#[inline(always)]
 pub fn var_os(name: &str) -> Option<OsString> {
-    if definitely_unset(name) {
-        return None;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let _ = name;
+        None
     }
-    snapshot().get(OsStr::new(name)).cloned()
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        if definitely_unset(name) {
+            return None;
+        }
+        snapshot().get(OsStr::new(name)).cloned()
+    }
 }
 
 /// The variable's value as UTF-8, like `std::env::var(..).ok()`.
-#[inline]
+///
+/// Browser WASM returns `None` at compile time for the same reason as
+/// [`flag`].
+#[inline(always)]
 pub fn var(name: &str) -> Option<String> {
-    if definitely_unset(name) {
-        return None;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let _ = name;
+        None
     }
-    snapshot()
-        .get(OsStr::new(name))
-        .and_then(|v| v.to_str().map(str::to_owned))
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        if definitely_unset(name) {
+            return None;
+        }
+        snapshot()
+            .get(OsStr::new(name))
+            .and_then(|v| v.to_str().map(str::to_owned))
+    }
 }
 
 /// Parse a diagnostic integer value, accepting decimal or `0x`-prefixed hex.

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -475,13 +475,6 @@ pub(super) struct HWindowRow {
 }
 
 impl HWindowRow {
-    fn full() -> Self {
-        Self {
-            open_runs: vec![(0, FB_WIDTH)],
-            comparator_anchor: None,
-        }
-    }
-
     /// Envelope for consumers that only handle a single span (sprite
     /// windows, scroll bookkeeping): first open edge to last close edge.
     pub(super) fn span(&self) -> (usize, usize) {
@@ -740,15 +733,21 @@ fn scan_h_window_line(
     }
 }
 
-fn compute_h_window_rows(
+fn compute_h_window_rows_into(
+    out: &mut Vec<HWindowRow>,
     base_controls: &[ControlState],
     control_segments: &[Vec<ControlSegment>],
     visible_line0: i32,
-) -> Vec<HWindowRow> {
+) {
     let rows = base_controls.len();
-    let mut out = vec![HWindowRow::default(); rows];
+    out.resize_with(rows, HWindowRow::default);
+    out.truncate(rows);
+    for row in out.iter_mut() {
+        row.open_runs.clear();
+        row.comparator_anchor = None;
+    }
     if rows == 0 {
-        return out;
+        return;
     }
     let is_ecs = base_controls[0].agnus_revision.is_ecs();
     // Vertical sync leaves the flip-flop set (vAmiga vsyncHandler). The
@@ -761,26 +760,34 @@ fn compute_h_window_rows(
     }
     for y in 0..rows {
         let beam_line = visible_line0 + y as i32;
-        let mut row = HWindowRow::default();
         scan_h_window_line(
             &mut flop,
             beam_line,
             is_ecs,
             base_controls[y],
             &control_segments[y],
-            Some(&mut row),
+            Some(&mut out[y]),
         );
         // Software that never programs DIW keeps the pragmatic whole-
         // framebuffer window (matching display_window_x).
         if display_window_unprogrammed(base_controls[y].diwstrt, base_controls[y].diwstop)
             && control_segments[y].is_empty()
         {
-            out[y] = HWindowRow::full();
-        } else {
-            out[y] = row;
+            out[y].open_runs.clear();
+            out[y].open_runs.push((0, FB_WIDTH));
+            out[y].comparator_anchor = None;
         }
     }
-    out
+}
+
+fn compute_h_window_rows(
+    base_controls: &[ControlState],
+    control_segments: &[Vec<ControlSegment>],
+    visible_line0: i32,
+) -> Vec<HWindowRow> {
+    let mut rows = Vec::new();
+    compute_h_window_rows_into(&mut rows, base_controls, control_segments, visible_line0);
+    rows
 }
 
 /// Repaint the horizontal window's closed intervals with border pixels
@@ -4137,6 +4144,25 @@ pub struct RenderResult {
     pub(crate) chip_ram_reads: Option<Vec<ChipRamReadDependency>>,
 }
 
+/// Large renderer work buffers retained per host thread. The browser calls
+/// the synchronous renderer on every presented frame; rebuilding the
+/// row-palette/control grids and the two full collision canvases otherwise
+/// allocates several megabytes per second even though their dimensions are
+/// almost always unchanged.
+#[derive(Default)]
+struct RenderScratch {
+    base_palettes: Vec<Palette>,
+    palette_segments: Vec<Vec<PaletteSegment>>,
+    base_controls: Vec<ControlState>,
+    control_segments: Vec<Vec<ControlSegment>>,
+    manual_bpl_segments: Vec<ManualBplSegment>,
+    playfield_mask: Vec<u8>,
+    collision_pixels: Vec<CollisionPixel>,
+    dma_output_start_x_by_line: Vec<Option<usize>>,
+    h_window_rows: Vec<HWindowRow>,
+    ham_select_pixels: Vec<u8>,
+}
+
 /// Paint the just-finished frame through the synchronous compatibility path.
 /// The render itself is a pure function of the owned snapshot
 /// (`render_from_input`); this wrapper owns the remaining bus coupling.
@@ -4368,6 +4394,22 @@ fn render_from_input_impl(
     fb: &mut [u32],
     track_read_dependencies: bool,
 ) -> RenderResult {
+    thread_local! {
+        static RENDER_SCRATCH: std::cell::RefCell<RenderScratch> =
+            std::cell::RefCell::new(RenderScratch::default());
+    }
+    RENDER_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        render_from_input_with_scratch(input, fb, track_read_dependencies, &mut scratch)
+    })
+}
+
+fn render_from_input_with_scratch(
+    input: &RenderInput,
+    fb: &mut [u32],
+    track_read_dependencies: bool,
+    scratch: &mut RenderScratch,
+) -> RenderResult {
     let render_started = Instant::now();
     ACTIVE_DEBUG_MASKS.with(|masks| masks.set((input.debug_plane_mask, input.debug_sprite_mask)));
     ACTIVE_CANVAS_SHIFT_H.with(|shift| {
@@ -4522,11 +4564,26 @@ fn render_from_input_impl(
         &input.held_sprites,
         &manual_sprite_lines,
     );
-    let mut base_palettes = vec![state.palette; rows];
-    let mut palette_segments = vec![Vec::new(); rows];
-    let mut base_controls = vec![frame_start_control; rows];
-    let mut control_segments = vec![Vec::new(); rows];
-    let mut manual_bpl_segments = Vec::new();
+    let mut base_palettes = std::mem::take(&mut scratch.base_palettes);
+    base_palettes.resize(rows, state.palette);
+    base_palettes.fill(state.palette);
+    let mut palette_segments = std::mem::take(&mut scratch.palette_segments);
+    palette_segments.resize_with(rows, Vec::new);
+    palette_segments.truncate(rows);
+    for segments in &mut palette_segments {
+        segments.clear();
+    }
+    let mut base_controls = std::mem::take(&mut scratch.base_controls);
+    base_controls.resize(rows, frame_start_control);
+    base_controls.fill(frame_start_control);
+    let mut control_segments = std::mem::take(&mut scratch.control_segments);
+    control_segments.resize_with(rows, Vec::new);
+    control_segments.truncate(rows);
+    for segments in &mut control_segments {
+        segments.clear();
+    }
+    let mut manual_bpl_segments = std::mem::take(&mut scratch.manual_bpl_segments);
+    manual_bpl_segments.clear();
     #[cfg(any(test, debug_assertions, feature = "display-plan-trace"))]
     let mut display_frame_plan =
         crate::envcfg::var_os("COPPERLINE_TRACE_DISPLAY_PLAN").map(|_| DisplayFramePlan::new());
@@ -4609,14 +4666,27 @@ fn render_from_input_impl(
     let mut next_bitplane_pointer_event = 0usize;
     let mut bpldat = frame_start_bpldat;
     let mut next_bitplane_data_event = 0usize;
-    let mut playfield_mask = vec![0u8; FB_WIDTH * rows];
-    let mut collision_pixels = vec![CollisionPixel::default(); FB_WIDTH * rows];
+    let collision_len = FB_WIDTH * rows;
+    let mut playfield_mask = std::mem::take(&mut scratch.playfield_mask);
+    playfield_mask.resize(collision_len, 0);
+    playfield_mask.fill(0);
+    let mut collision_pixels = std::mem::take(&mut scratch.collision_pixels);
+    collision_pixels.resize(collision_len, CollisionPixel::default());
+    collision_pixels.fill(CollisionPixel::default());
     let mut collision_lookup = CollisionLookup::new();
     let mut clxdat = 0u16;
-    let mut dma_output_start_x_by_line = vec![None; rows];
+    let mut dma_output_start_x_by_line = std::mem::take(&mut scratch.dma_output_start_x_by_line);
+    dma_output_start_x_by_line.resize(rows, None);
+    dma_output_start_x_by_line.fill(None);
 
     let background_started = Instant::now();
-    let h_window_rows = compute_h_window_rows(&base_controls, &control_segments, visible_line0);
+    let mut h_window_rows = std::mem::take(&mut scratch.h_window_rows);
+    compute_h_window_rows_into(
+        &mut h_window_rows,
+        &base_controls,
+        &control_segments,
+        visible_line0,
+    );
     fill_background_with_visible_line0(
         fb,
         &base_palettes,
@@ -5095,7 +5165,8 @@ fn render_from_input_impl(
         visible_line0,
     );
     render_timing.manual_bpl_segments = manual_bpl_segments.len() as u64;
-    render_manual_bpl_segments_with_visible_line0(
+    let mut ham_select_pixels = std::mem::take(&mut scratch.ham_select_pixels);
+    render_manual_bpl_segments_with_visible_line0_and_scratch(
         &manual_bpl_segments,
         fb,
         &mut playfield_mask,
@@ -5106,6 +5177,7 @@ fn render_from_input_impl(
         &base_controls,
         &control_segments,
         &dma_output_start_x_by_line,
+        &mut ham_select_pixels,
         visible_line0,
         input.emulated_seconds,
         input.emulated_frames,
@@ -5205,6 +5277,16 @@ fn render_from_input_impl(
     );
     render_timing.total_nanos = render_started.elapsed().as_nanos();
     let chip_ram_reads = ram.into_read_dependencies();
+    scratch.base_palettes = base_palettes;
+    scratch.palette_segments = palette_segments;
+    scratch.base_controls = base_controls;
+    scratch.control_segments = control_segments;
+    scratch.manual_bpl_segments = manual_bpl_segments;
+    scratch.playfield_mask = playfield_mask;
+    scratch.collision_pixels = collision_pixels;
+    scratch.dma_output_start_x_by_line = dma_output_start_x_by_line;
+    scratch.h_window_rows = h_window_rows;
+    scratch.ham_select_pixels = ham_select_pixels;
     RenderResult {
         timing: render_timing,
         clxdat,
@@ -6150,10 +6232,47 @@ fn render_manual_bpl_segments_with_visible_line0(
     emulated_seconds: f64,
     emulated_frames: u64,
 ) {
+    let mut ham_select_pixels = Vec::new();
+    render_manual_bpl_segments_with_visible_line0_and_scratch(
+        segments,
+        fb,
+        playfield_mask,
+        collision_pixels,
+        clxdat,
+        base_palettes,
+        palette_segments,
+        base_controls,
+        control_segments,
+        dma_output_start_x_by_line,
+        &mut ham_select_pixels,
+        visible_line0,
+        emulated_seconds,
+        emulated_frames,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_manual_bpl_segments_with_visible_line0_and_scratch(
+    segments: &[ManualBplSegment],
+    fb: &mut [u32],
+    playfield_mask: &mut [u8],
+    collision_pixels: &mut [CollisionPixel],
+    clxdat: &mut u16,
+    base_palettes: &[Palette],
+    palette_segments: &[Vec<PaletteSegment>],
+    base_controls: &[ControlState],
+    control_segments: &[Vec<ControlSegment>],
+    dma_output_start_x_by_line: &[Option<usize>],
+    ham_select_pixels: &mut Vec<u8>,
+    visible_line0: i32,
+    emulated_seconds: f64,
+    emulated_frames: u64,
+) {
     if segments.is_empty() {
         return;
     }
-    let mut ham_select_pixels = vec![0u8; fb.len()];
+    ham_select_pixels.resize(fb.len(), 0);
+    ham_select_pixels.fill(0);
     for seg in segments {
         if seg.line >= base_controls.len() {
             continue;
@@ -6166,7 +6285,7 @@ fn render_manual_bpl_segments_with_visible_line0(
             base_controls,
             control_segments,
         );
-        let mut ham_select = manual_bpl_ham_seed_select(seg, &ham_select_pixels);
+        let mut ham_select = manual_bpl_ham_seed_select(seg, ham_select_pixels);
         let beam_y = visible_line0 + seg.line as i32;
         let diag = manual_bpl_pixel_diag_spec().filter(|spec| {
             spec.beam_y == beam_y && emulated_seconds >= spec.after && emulated_seconds < spec.until
@@ -6184,7 +6303,7 @@ fn render_manual_bpl_segments_with_visible_line0(
             dma_output_start_x_by_line,
             &mut ham_color,
             &mut ham_select,
-            &mut ham_select_pixels,
+            ham_select_pixels,
             visible_line0,
             emulated_seconds,
             emulated_frames,

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -232,6 +232,11 @@ pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
         cd_load: None,
         cd_eject: None,
     };
+    // Pixel aspect is process-global but a layout must use one coherent
+    // origin even if a test changes it concurrently. Live callers are on the
+    // main thread; caching it also avoids re-reading the atomic for every
+    // connected drive.
+    let bar_top = status_bar_top();
     // At most 4 drives, so track membership/position without allocating a
     // Vec on every call (this runs on every mouse-move and frame redraw).
     let connected_count = (0..4).filter(|&idx| media.drives[idx].connected).count();
@@ -261,13 +266,13 @@ pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
             let row = pos / 2;
             (
                 MEDIA_CLUSTER_X + col * (MEDIA_CLUSTER_W + MEDIA_CLUSTER_GAP),
-                status_bar_top() + MEDIA_STACKED_ROW0_Y + row * MEDIA_STACKED_PITCH,
+                bar_top + MEDIA_STACKED_ROW0_Y + row * MEDIA_STACKED_PITCH,
                 MEDIA_STACKED_H,
             )
         } else {
             (
                 MEDIA_CLUSTER_X + pos * (MEDIA_CLUSTER_W + MEDIA_CLUSTER_GAP),
-                status_bar_top() + STATUS_CONTROL_Y,
+                bar_top + STATUS_CONTROL_Y,
                 STATUS_CONTROL_H,
             )
         };
@@ -287,7 +292,7 @@ pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
         };
         // The CD cluster is load plus eject only; eject takes the slot a
         // drive cluster gives to swap.
-        let (load, eject, _) = cluster(x, status_bar_top() + STATUS_CONTROL_Y, STATUS_CONTROL_H);
+        let (load, eject, _) = cluster(x, bar_top + STATUS_CONTROL_Y, STATUS_CONTROL_H);
         layout.cd_load = Some(load);
         layout.cd_eject = Some(eject);
     }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1896,8 +1896,10 @@ fn bar_layout_stacks_three_or_more_drives_two_up() {
     assert!(df0.x >= fdd_track_counter_rect().x + fdd_track_counter_rect().w);
     let cd_eject = stacked.cd_eject.unwrap();
     assert!(cd_eject.x + cd_eject.w <= VOLUME_GLYPH_X);
-    // Stacked buttons stay inside the status bar.
-    assert!(df2.y + df2.h <= present_height() + super::STATUS_BAR_HEIGHT);
+    // Stacked buttons stay inside the same status-bar origin used to build
+    // this layout; another parallel test may change the global pixel aspect.
+    let layout_bar_top = df0.y - super::MEDIA_STACKED_ROW0_Y;
+    assert!(df2.y + df2.h <= layout_bar_top + super::STATUS_BAR_HEIGHT);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain large bitplane renderer work buffers per render thread instead of reallocating them at field rate
- compile process-environment diagnostic lookups out of browser WASM hot paths
- export an exact presentation revision so unchanged frames skip typed-array construction, Canvas 2D copies, WebGL texture uploads, and monitor draws
- split the live host timing into core, Rust render, browser upload, and monitor submission cost
- update browser/video documentation and the optimized-bundle smoke test
- harden two debug/test invariants uncovered by the full validation run

No SharedArrayBuffer, worker, or cross-origin-isolation change is included.

## Measured result

Controlled V8 A/B runs on the 2020 Intel Mac used the same dynamic A500 save state and two runs of each build in alternating order over a 500-frame window.

| Measurement | Baseline | This branch | Change |
| --- | ---: | ---: | ---: |
| Core-only window | 7.9585 s | 7.9620 s | no measurable change |
| Core plus Rust render | 9.648 s | 9.422 s | -2.3% |
| Inferred Rust render component | 1.6895 s | 1.460 s | -13.6% |
| Optimized WASM bundle | 2,253,772 B | 2,130,805 B | -122,967 B / -5.5% |

The dynamic workload advanced the presentation revision on 398 of 500 frames, allowing the browser to avoid 20.4% of uploads and draws. A mostly static boot workload changed on 195 of 500 frames, avoiding 61.0%. The static workload and a plain-versus-monitor comparison showed no meaningful core difference, consistent with the monitor shader not being the main bottleneck.

The native deterministic render checksum remains 0x2c9629e0000.

## Validation

- cargo test --locked
- cargo test --locked -- --test-threads=1
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check
- web-crate cargo fmt --check
- node --check crates/copperline-web/www/try.js
- release wasm32 build with simd128, wasm-bindgen, wasm-opt -O3, and exact optimized-bundle Node smoke load
- local and remote V8 benchmark runs in alternating baseline/branch order
- native release render/checksum comparison