### PR TITLE
web: two-line stat readout; document the display checkbox hooks

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -996,14 +996,19 @@ function stepMachine(nowMs, deferRender) {
     const timedFrames = Math.max(1, framesThisSecond);
     // Two lines: the rates the visitor watches, then the host-cost
     // breakdown. A shell renders the split with `white-space: pre-line`
-    // on #stat; elsewhere the newline collapses to a space, which is the
-    // old single-line look. One long nowrap line ran off a 13" screen.
+    // on #stat (one long nowrap line ran off a 13" screen); on any style
+    // that collapses the newline to a space, the second line starts with
+    // the ` | ` separator instead, so the collapsed rendering is exactly
+    // the historical single line.
+    const statKeepsNewline = /pre|preserve|break-spaces/.test(
+      getComputedStyle(statLine).whiteSpace,
+    );
     statLine.textContent =
       `${framesThisSecond} fps (${presentsThisSecond} shown, ${ticksThisSecond} ticks) | ` +
       `${emu.emulated_seconds().toFixed(1)}s emulated | ` +
       `audio ${queuedMs.toFixed(0)} ms` +
       (audioUnderruns > 0 ? ` (${audioUnderruns} underruns)` : '') +
-      '\n' +
+      (statKeepsNewline ? '\n' : '\n| ') +
       `host ${[
         `core ${(coreMsThisSecond / timedFrames).toFixed(1)}`,
         `render ${(rustRenderMsThisSecond / timedFrames).toFixed(1)}`,

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -994,18 +994,23 @@ function stepMachine(nowMs, deferRender) {
 
   if (nowMs - lastStatUpdate >= 1000) {
     const timedFrames = Math.max(1, framesThisSecond);
+    // Two lines: the rates the visitor watches, then the host-cost
+    // breakdown. A shell renders the split with `white-space: pre-line`
+    // on #stat; elsewhere the newline collapses to a space, which is the
+    // old single-line look. One long nowrap line ran off a 13" screen.
     statLine.textContent =
       `${framesThisSecond} fps (${presentsThisSecond} shown, ${ticksThisSecond} ticks) | ` +
       `${emu.emulated_seconds().toFixed(1)}s emulated | ` +
       `audio ${queuedMs.toFixed(0)} ms` +
       (audioUnderruns > 0 ? ` (${audioUnderruns} underruns)` : '') +
-      (renderSkipActive ? ' | render 1/2' : '') +
-      ` | host ${[
+      '\n' +
+      `host ${[
         `core ${(coreMsThisSecond / timedFrames).toFixed(1)}`,
         `render ${(rustRenderMsThisSecond / timedFrames).toFixed(1)}`,
         `upload ${(uploadMsThisSecond / timedFrames).toFixed(1)}`,
         `shader ${(shaderMsThisSecond / timedFrames).toFixed(1)}`,
-      ].join(' + ')} ms/frame`;
+      ].join(' + ')} ms/frame` +
+      (renderSkipActive ? ' | render 1/2' : '');
     framesThisSecond = 0;
     ticksThisSecond = 0;
     presentsThisSecond = 0;

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -657,6 +657,16 @@ elements, and pages without them are untouched:
   canvas under the 2D fallback) and baked into screenshots. Always on,
   self-inserting, and remembered in the browser like `#overscan`; it
   never touches the wasm, so it works with any bundle.
+- `#deinterlace` and `#phosphor` (checkboxes): the **Deinterlace** and
+  **Phosphor persistence** options described under
+  [Using the hosted page](#using-the-hosted-page). Always on like
+  `#floppy-speed`: without the elements two labelled checkboxes insert
+  themselves below the canvas shell. Both are viewing preferences the
+  glue remembers in the browser, and each hides itself on a wasm bundle
+  without the matching call (`set_deinterlace` / `set_phosphor`) -- for
+  a shell-hosted checkbox the input element is hidden, so a shell can
+  drop the whole labelled row with a
+  `.row:has(> input[hidden]) { display: none }` rule.
 - `#monitor` (a `<select>` with option values `1084`, `crt`, `bezel`,
   and `plain`): the monitor presentation (**Monitor** on the hosted
   page), the desktop window's CRT shader preset and 1084 bezel rendered


### PR DESCRIPTION
The host-timing split added in #407 made the browser stat line long enough to run off a 13" laptop. The glue now emits it as two lines - the rates the visitor watches, then the host-cost breakdown - and a page shell opts into the split with `white-space: pre-line` on `#stat` (the newline collapses back to the single-line look everywhere else, so existing shells are unchanged).

Also adds the missing page-shell hooks documentation for the `#deinterlace` and `#phosphor` checkboxes: shell-hosted form, per-browser memory, and the hidden-input contract a shell uses to collapse the labelled row on a wasm bundle without the matching call.

Verified in Chrome against a staged copperline.dev/try with the sidebar-hosted checkboxes (companion site PR): two-line stat beside the quick-row buttons on wide viewports, wrapping to a right-aligned block at 13" column widths; deinterlace/phosphor toggling live through `WebEmu` and remembered across visits. `node --check` clean on the glue.