### PR TITLE
bezel: add a 1084 style, and make the frame a choice

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -426,9 +426,11 @@ video = "PAL"
 # shader-processed, so captures stay comparable whatever is set here.
 # shader_strength: how strongly the shader is mixed in, 0.0-1.0 (default
 # 1.0, the preset's full effect); 0.0 leaves the picture visually untouched.
-# bezel: frame the picture with a 1084-style monitor front bezel (default
-# false; Cmd/Alt+M toggles it live). Composes with any shader setting, and
-# like it is a window-display effect only: captures never include the frame.
+# bezel: frame the picture with a monitor front: "off" (default), "1084"
+# (the monitor the Amiga shipped with) or "classic" (the plainer frame
+# Copperline drew first). Cmd/Alt+M turns the chosen one off and back on.
+# Composes with any shader setting, and like it is a window-display effect
+# only: captures never include the frame.
 # perf_overlay: show the performance overlay at start (default false; also
 # --perf-overlay, and Cmd/Alt+P toggles it live): emulated fps, speed
 # factor, per-frame emulation cost, host utilisation, audio health, and
@@ -451,7 +453,7 @@ video = "PAL"
 # phosphor = 0.4
 # shader = "none"
 # shader_strength = 1.0
-# bezel = false
+# bezel = "off"
 # perf_overlay = false
 # tint = "none"
 # menu_scale = "1x"

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -4,7 +4,7 @@
 //! headless core. The page's JS drives everything: it fetches ROM bytes,
 //! constructs a [`WebEmu`], calls [`WebEmu::run`] from requestAnimationFrame,
 //! draws the presentation buffer to a canvas (a WebGL2 monitor pass with
-//! the desktop's CRT shader and 1084 bezel, or a plain ImageData blit
+//! the desktop's CRT shader and Classic bezel, or a plain ImageData blit
 //! without WebGL2), forwards keyboard/mouse events, and ships each frame's
 //! mixed audio to an AudioWorklet. No winit, wgpu, or cpal: the canvas is
 //! the display and the Web Audio API is the sound device, so the wasm

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -19,8 +19,8 @@ import { TelnetSession } from './serial-telnet.js';
 
 const $ = (id) => document.getElementById(id);
 let canvas = $('screen');
-// The monitor presentation - the 1084 CRT shader pass and bezel of the
-// desktop window, on by default (see the display settings section) -
+// The monitor presentation - the desktop window's 1084 CRT shader pass and
+// its Classic bezel, on by default (see the display settings section) -
 // renders through WebGL2; without it the page keeps the plain 2D blit it
 // always had. Decided once here, before anything else touches the canvas:
 // a canvas can only ever hold one kind of context.
@@ -4673,13 +4673,15 @@ tintSel.addEventListener('change', () => setTintMode(tintSel.value, true));
 // --- display: monitor (CRT shader + bezel) -------------------------------
 // The desktop window's 1084 monitor look, ported to WebGL2: the CRT preset
 // (bowed tube face, scanlines, aperture grille, corner vignette - the
-// window's `[display] shader = "crt"`) and the procedural plastic bezel
-// (`[display] bezel`), composed exactly as the desktop composes them: the
-// preset paints the picture into the bezel opening's bounding box first
-// and the bezel frames it on top in frame-only mode, so the moulding's
-// rounded corners and recess clip the preset's square viewport. The GLSL
-// sources in initMonitorGl are line-for-line ports of the desktop's WGSL
-// (src/video/window/shaders/{crt,bezel}.wgsl); keep them in step.
+// window's `[display] shader = "crt"`) and a procedural plastic bezel,
+// composed exactly as the desktop composes them: the preset paints the
+// picture into the bezel opening's bounding box first and the bezel frames
+// it on top in frame-only mode, so the moulding's rounded corners and
+// recess clip the preset's square viewport. The GLSL sources in
+// initMonitorGl are line-for-line ports of the desktop's WGSL
+// (src/video/window/shaders/{crt,bezel_classic}.wgsl); keep them in step.
+// The desktop has since grown a second bezel style (`[display] bezel =
+// "1084"`), which this page does not offer - the port here is Classic.
 //
 // On by default, like nothing else here, because it is the page's face: a
 // visitor's first frame looks like the monitor the Amiga shipped with.
@@ -4888,7 +4890,7 @@ void main() {
 }
 `;
 
-  // The bezel, ported from shaders/bezel.wgsl: the 1084-style plastic
+  // The bezel, ported from shaders/bezel_classic.wgsl: the plastic
   // front frame, with the picture seated in a rounded opening by a
   // moulded insert, the power LED on the bottom band and the Copperline
   // logotype printed on its left. Two modes via u_params.x, exactly as on

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -47,7 +47,8 @@ Five more controls shape what the glass shows without touching the
 machine. **Monitor** is the desktop window's 1084 presentation, on by
 default: the CRT shader preset (bowed tube face, scanlines, aperture
 grille, corner vignette -- the desktop's `[display] shader = "crt"`) with
-the picture seated in the moulded plastic bezel of `[display] bezel`,
+the picture seated in a moulded plastic bezel -- the desktop's Classic
+frame; the page does not offer its 1084 one --
 rendered through WebGL2 at display resolution. *CRT filter* and *Bezel*
 select either half alone, and *Plain* is the undecorated blit the page
 always had -- also what a browser without WebGL2 falls back to (the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -637,21 +637,29 @@ frames coming from an RTG board's scanout (see `[rtg]` below), and for
 programmable multisync scan modes -- a 31 kHz scanout has no 15 kHz line
 structure to reproduce.
 
-`bezel` (default `false`) frames the window's picture with a monitor-style
-front bezel, also in the spirit of the 1084: the picture scales down into
-the rounded opening of a procedurally drawn plastic face -- warm-grey
-moulding, a dark recess around the tube face, rounded case corners, and the
-wider bottom band carrying the power LED and a printed Copperline logotype
-in the spot the 1084 kept its Commodore badge. The frame is drawn at the window's
-resolution, so it stays sharp at any size, and the picture keeps its aspect
-inside the opening. It is independent of `shader` and composes with any
-preset: with `"crt"` the bowed tube face sits inside the opening for the
-full monitor look. Cmd+M (macOS) / Alt+M toggles it live for the rest of
-the session without touching the config; the launcher's *Monitor bezel* row
-(*A/V & Emu*, *Video*) writes it, and `COPPERLINE_BEZEL=1|0` overrides the
-config for a single run.
+`bezel` frames the window's picture with a monitor front, drawn at the
+window's resolution so it stays sharp at any size, with the picture keeping
+its aspect inside the opening. Three settings:
 
-Like the shader pass, the bezel is presentation and nothing else: captures
+- `"off"` (the default) -- no frame; the picture fills the display.
+- `"1084"` -- the monitor the Amiga shipped with: a pale cabinet with a
+  darker moulding sunk around the tube, the model badge, the Copperline
+  name where the 1084 wore its maker's, and a red power lamp.
+- `"classic"` -- the plainer rounded frame Copperline drew before the 1084
+  arrived.
+
+`true` and `false` are still read, from when there was only the one frame
+to turn on; `true` means `"1084"`.
+
+The bezel is independent of `shader` and composes with any preset: with
+`"crt"` the bowed tube face sits inside the opening for the full monitor
+look. Cmd+M (macOS) / Alt+M turns it off and back on to whichever front is
+chosen, for the rest of the session and without touching the config;
+*Video Settings > Monitor Bezel* picks the front, the launcher's *Monitor
+bezel* row (*A/V & Emu*, *Video*) writes it, and `COPPERLINE_BEZEL` (a
+style name, or the old `1`/`0`) overrides the config for a single run.
+
+Like the shader pass, a bezel is presentation and nothing else: captures
 never include it, and it is skipped while a menu or overlay panel is open
 and for RTG scanout frames. Unlike the shader it does stay on for
 programmable multisync scans -- a frame has no line structure to get wrong.

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -24,7 +24,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+B` | `Alt+B` | Open the [debugger window](../debugger/window) |
 | `Cmd+K` | `Alt+K` | Open the [debugger console](../debugger/console) |
 | `Cmd+J` | `Alt+J` | Toggle joystick input mode: gamepad / keyboard (also the status-bar icon) |
-| `Cmd+M` | `Alt+M` | Toggle the 1084-style monitor bezel around the picture (`[display] bezel` sets the start-up value) |
+| `Cmd+M` | `Alt+M` | Turn the monitor bezel off, or back on to the chosen front (*Video Settings > Monitor Bezel* picks it; `[display] bezel` sets the start-up value) |
 | `Cmd+Shift+A` | `Alt+Shift+A` | Cycle the audio output: Default, each host device, then Disabled (also *Audio Settings > Audio Output*) |
 | `Cmd+A` | `Alt+A` | Cycle Paula's audio filter: auto, on, off (also *Audio Settings > Audio Filter*) |
 | `Cmd+Shift++` / `Cmd+Shift+-` | `Alt+Shift++` / `Alt+Shift+-` | Raise / lower the parallel-port sampler input gain (only when a sampler is attached; also *Parallel Port > Sampler Gain*) |
@@ -266,6 +266,16 @@ tool window or overlay.
   needed, exactly as when resizing the window.
 - **Status Bar** (also `Cmd+Shift+F` / `Alt+Shift+F`): show or hide the
   status bar. Handy alongside fullscreen for a clean, chrome-free picture.
+- **Monitor Bezel**: which monitor front the picture sits inside instead
+  of filling the window -- **Disabled**, **1084** (a two-tone cabinet with
+  the tube sunk into its moulding, and the model badge, the Copperline name
+  and the power lamp along the bottom), or **Classic** (the plainer rounded
+  frame Copperline drew first). The picture gets a little smaller to make
+  room for either. `Cmd+M` / `Alt+M` turns the chosen front off and back
+  on; it never changes which. Session-only; the start-up value is
+  `[display] bezel` (see [Configuration](configuration.md)). A window
+  effect only, like the shader: screenshots, frame dumps and recordings
+  never include it.
 - **Performance** (also `Cmd+P` / `Alt+P`): show or hide the
   [performance overlay](#performance-overlay). Session-only; the start-up
   value is `[display] perf_overlay` (see
@@ -445,7 +455,8 @@ The layout is:
   WASM plugin board's declared options),
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
-  sounds and volume), **Video** (start fullscreen, status bar, monitor bezel,
+  sounds and volume), **Video** (start fullscreen, status bar, monitor bezel
+  style,
   perf overlay, menu size, overscan, pixel aspect, scaling, deinterlace,
   screen tint, phosphor, CRT shader and shader strength),
   and **Emulation**

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,13 +261,10 @@ pub struct Config {
     /// (the preset's full effect, the default). A single knob for every
     /// preset so the effect can be dialled back without editing shaders.
     pub shader_strength: f32,
-    /// Draw a monitor-style front bezel around the window picture
-    /// (`[display] bezel`): the display shrinks into the rounded opening of
-    /// a procedural plastic frame in the spirit of the 1084 the Amiga
-    /// shipped with. Independent of `shader`, and a presentation stage like
-    /// it: screenshots, frame dumps, recordings and headless runs never
-    /// include the bezel.
-    pub bezel: bool,
+    /// Which monitor front the window frames the picture with at start
+    /// (`[display] bezel`). The `Cmd+M` / `Alt+M` toggle turns it off and
+    /// back on live without affecting this start-up value.
+    pub bezel: BezelStyle,
     /// Show the performance overlay at start (`[display] perf_overlay`, or
     /// `--perf-overlay`): a live emulation-performance readout in the
     /// top-right of the display. The `Cmd+P` / `Alt+P` toggle flips it live
@@ -484,6 +481,58 @@ impl ShaderKind {
             ShaderKind::Crt => "CRT (1084)",
             ShaderKind::Custom => "Custom",
         }
+    }
+}
+
+/// Which monitor front the window frames the picture with (`[display]
+/// bezel`): the display shrinks into the rounded opening of a procedural
+/// frame drawn on the GPU. Independent of [`ShaderKind`], and a
+/// presentation stage like it: screenshots, frame dumps, recordings and
+/// headless runs never include the bezel.
+///
+/// A style is a shader source plus the opening it leaves, so adding one is
+/// a `.wgsl` file beside the others and an arm here; nothing outside
+/// `video::window::bezel` needs to learn its name.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BezelStyle {
+    /// No frame; the picture fills the display rect. The default. Spelled
+    /// "none" or "off" in the config, and `false` still works.
+    #[default]
+    None,
+    /// The 1084 the Amiga shipped with: a two-tone cabinet with the tube
+    /// sunk into its moulding, model badge, logotype and power lamp.
+    Model1084,
+    /// The plain rounded frame Copperline drew before the 1084 arrived.
+    Classic,
+}
+
+impl BezelStyle {
+    /// Every style, in the order a picker offers them.
+    pub const MENU_ORDER: [BezelStyle; 3] =
+        [BezelStyle::None, BezelStyle::Model1084, BezelStyle::Classic];
+
+    /// Config name, which round-trips through [`parse_bezel`].
+    pub fn label(self) -> &'static str {
+        match self {
+            BezelStyle::None => "off",
+            BezelStyle::Model1084 => "1084",
+            BezelStyle::Classic => "classic",
+        }
+    }
+
+    /// What a picker shows the user. Both pickers read this, so they
+    /// cannot drift apart.
+    pub fn menu_label(self) -> &'static str {
+        match self {
+            BezelStyle::None => "Disabled",
+            BezelStyle::Model1084 => "1084",
+            BezelStyle::Classic => "Classic",
+        }
+    }
+
+    /// Whether a frame is drawn at all.
+    pub fn is_on(self) -> bool {
+        self != BezelStyle::None
     }
 }
 
@@ -2047,7 +2096,7 @@ impl Default for Config {
             phosphor: 0.0,
             shader: ShaderMode::None,
             shader_strength: 1.0,
-            bezel: false,
+            bezel: BezelStyle::None,
             perf_overlay: false,
             tint: Tint::None,
             menu_scale: MenuScale::Normal,
@@ -2717,6 +2766,26 @@ impl RawConfig {
     }
 }
 
+/// `[display] bezel` as it may be written. It named a single frame to turn
+/// on before there was a choice of them, so the boolean it took then is
+/// still accepted: `true` means whichever style that was.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum RawBezel {
+    On(bool),
+    Named(String),
+}
+
+impl RawBezel {
+    fn resolve(&self) -> Result<BezelStyle> {
+        match self {
+            RawBezel::On(true) => Ok(BezelStyle::Model1084),
+            RawBezel::On(false) => Ok(BezelStyle::None),
+            RawBezel::Named(s) => parse_bezel(s),
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawDisplay {
@@ -2745,9 +2814,11 @@ pub(crate) struct RawDisplay {
     /// Shader mix, 0.0 (invisible) to 1.0 (full effect, the default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) shader_strength: Option<f32>,
-    /// Monitor-style front bezel around the window picture (default false).
+    /// Monitor front around the window picture: "off" (default), "1084" or
+    /// "classic". `true`/`false` are still taken, from when there was only
+    /// the one frame to turn on.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) bezel: Option<bool>,
+    pub(crate) bezel: Option<RawBezel>,
     /// Performance overlay in the top-right of the display (default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) perf_overlay: Option<bool>,
@@ -3775,7 +3846,16 @@ impl TryFrom<RawConfig> for Config {
                 defaults.shader_strength
             }
         };
-        let bezel = raw.display.bezel.unwrap_or(defaults.bezel);
+        let bezel = match &raw.display.bezel {
+            None => defaults.bezel,
+            Some(raw) => match raw.resolve() {
+                Ok(style) => style,
+                Err(e) => {
+                    errors.push(e);
+                    defaults.bezel
+                }
+            },
+        };
         let perf_overlay = raw.display.perf_overlay.unwrap_or(defaults.perf_overlay);
         let tint = match raw.display.tint.as_deref() {
             None => defaults.tint,
@@ -4473,6 +4553,19 @@ pub(crate) fn parse_shader(s: &str) -> Result<ShaderMode> {
             "[display] shader must be \"none\", \"scanlines\", \"mask\", \"crt\", \
              or a \".wgsl\" file path, got {:?}",
             s
+        )),
+    }
+}
+
+/// Parse a `[display] bezel` name ("off" is accepted for "none", so
+/// [`BezelStyle::label`] round-trips).
+pub(crate) fn parse_bezel(s: &str) -> Result<BezelStyle> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "none" | "off" => Ok(BezelStyle::None),
+        "1084" => Ok(BezelStyle::Model1084),
+        "classic" => Ok(BezelStyle::Classic),
+        other => Err(anyhow!(
+            "[display] bezel must be \"off\", \"1084\" or \"classic\", got {other:?}"
         )),
     }
 }
@@ -5657,16 +5750,18 @@ pub fn resolve_shader_strength(from_config: f32) -> f32 {
     }
 }
 
-/// Resolve the monitor bezel: the `COPPERLINE_BEZEL` env var (0/false/off/no
-/// disables, anything else enables) overrides the `[display] bezel` config
-/// for one run.
-pub fn resolve_bezel(from_config: bool) -> bool {
-    match crate::envcfg::var("COPPERLINE_BEZEL") {
-        Some(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "0" | "false" | "off" | "no"
-        ),
-        None => from_config,
+/// Resolve the monitor bezel: the `COPPERLINE_BEZEL` env var (a style name,
+/// or the 0/1-style on-off spellings it took when there was only one frame)
+/// overrides the `[display] bezel` config for one run. An unreadable value
+/// leaves the config's choice alone.
+pub fn resolve_bezel(from_config: BezelStyle) -> BezelStyle {
+    let Some(v) = crate::envcfg::var("COPPERLINE_BEZEL") else {
+        return from_config;
+    };
+    match v.trim().to_ascii_lowercase().as_str() {
+        "0" | "false" | "off" | "no" | "none" => BezelStyle::None,
+        "1" | "true" | "on" | "yes" => BezelStyle::Model1084,
+        other => parse_bezel(other).unwrap_or(from_config),
     }
 }
 
@@ -6646,15 +6741,24 @@ mod tests {
     }
 
     #[test]
-    fn display_bezel_parses_and_defaults_to_off() -> Result<()> {
-        assert!(!parse_config("")?.bezel);
-        let cfg = parse_config(
-            r#"
-            [display]
-            bezel = true
-            "#,
-        )?;
-        assert!(cfg.bezel);
+    fn display_bezel_names_a_style_and_defaults_to_off() -> Result<()> {
+        assert_eq!(parse_config("")?.bezel, BezelStyle::None);
+        for (written, want) in [
+            ("\"1084\"", BezelStyle::Model1084),
+            ("\"classic\"", BezelStyle::Classic),
+            ("\"off\"", BezelStyle::None),
+            // The boolean from when there was only one frame to turn on.
+            ("true", BezelStyle::Model1084),
+            ("false", BezelStyle::None),
+        ] {
+            let cfg = parse_config(&format!("[display]\nbezel = {written}\n"))?;
+            assert_eq!(cfg.bezel, want, "bezel = {written}");
+        }
+        // Every style's config name is what it round-trips as.
+        for style in BezelStyle::MENU_ORDER {
+            assert_eq!(parse_bezel(style.label())?, style);
+        }
+        assert!(parse_config("[display]\nbezel = \"1084s\"\n").is_err());
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2287,7 +2287,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_phosphor(0.0),
         config::resolve_shader(config::ShaderMode::None),
         config::resolve_shader_strength(1.0),
-        config::resolve_bezel(false),
+        config::resolve_bezel(config::BezelStyle::None),
         config::resolve_perf_overlay(false),
         config::resolve_tint(config::Tint::None),
         // The config-screen placeholder is always a normal windowed UI.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -23,7 +23,7 @@ use crate::bus::PortDevice;
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
 use crate::config::{
-    format_size, machine_profile_defaults, AudioFilterMode, BridgeCable, BridgeDensity,
+    format_size, machine_profile_defaults, AudioFilterMode, BezelStyle, BridgeCable, BridgeDensity,
     BridgeDriver, BridgeReadMode, ChannelMode, Chipset, Config, CpuModel, DisplayScaling,
     FluxBridgeConfig, JoystickInputMode, MachineModel, MenuScale, MouseCapture, Mt32Lcd, Overscan,
     PacingBudget, ParallelDevice, PixelAspect, RawConfig, RawDrive, RawFilesysMount,
@@ -735,7 +735,7 @@ const ETHERNET_ROWS: [Row; 4] = [
 const VIDEO_ROWS: [Row; 13] = [
     row(F::StartFullscreen, "Start fullscreen", Toggle),
     row(F::ShowStatusBar, "Status bar", Toggle),
-    row(F::Bezel, "Monitor bezel", Toggle),
+    row(F::Bezel, "Monitor bezel", Cycle),
     row(F::PerfOverlay, "Perf overlay", Toggle),
     row(F::MenuScale, "Menu size", Cycle),
     row(F::Overscan, "Overscan", Cycle),
@@ -1551,8 +1551,8 @@ pub struct MachineSetup {
     shader_custom: Option<PathBuf>,
     /// Shader mix, 0.0 to 1.0 ([display] shader_strength).
     shader_strength: f32,
-    /// Monitor-style front bezel around the picture ([display] bezel).
-    bezel: bool,
+    /// Which monitor front frames the picture, if any ([display] bezel).
+    bezel: BezelStyle,
     /// Performance overlay in the top-right ([display] perf_overlay).
     perf_overlay: bool,
     /// The MT-32's two ROM images, whether its front panel starts up, and
@@ -2104,7 +2104,7 @@ impl MachineSetup {
             raw.display.shader_strength = Some(self.shader_strength);
         }
         if self.bezel != base.bezel {
-            raw.display.bezel = Some(self.bezel);
+            raw.display.bezel = Some(crate::config::RawBezel::Named(self.bezel.label().into()));
         }
         if self.perf_overlay != base.perf_overlay {
             raw.display.perf_overlay = Some(self.perf_overlay);
@@ -2695,7 +2695,6 @@ impl MachineSetup {
             F::StartFullscreen => self.start_fullscreen,
             F::ShowStatusBar => self.show_status_bar,
             F::Deinterlace => self.deinterlace,
-            F::Bezel => self.bezel,
             F::PerfOverlay => self.perf_overlay,
             F::Mt32Panel => self.mt32_panel,
             F::PowerOn => self.power_on,
@@ -2892,6 +2891,7 @@ impl MachineSetup {
             },
             F::Scaling => self.scaling.label().to_string(),
             F::Tint => self.tint.menu_label().to_string(),
+            F::Bezel => self.bezel.menu_label().to_string(),
             F::MenuScale => self.menu_scale.menu_label().to_string(),
             F::Mt32Lcd => self.mt32_lcd.menu_label().to_string(),
             F::Phosphor => {
@@ -3226,6 +3226,7 @@ impl MachineSetup {
             F::FloppyVolume => self.floppy_volume = step_u8(self.floppy_volume, forward, 0, 100),
             F::Overscan => self.overscan = cycle_slice(&OVERSCANS, self.overscan, forward),
             F::Tint => self.tint = cycle_slice(&TINTS, self.tint, forward),
+            F::Bezel => self.bezel = cycle_slice(&BezelStyle::MENU_ORDER, self.bezel, forward),
             F::MenuScale => {
                 self.menu_scale = cycle_slice(&MenuScale::MENU_ORDER, self.menu_scale, forward);
             }
@@ -3501,7 +3502,6 @@ impl MachineSetup {
             F::StartFullscreen => self.start_fullscreen = !self.start_fullscreen,
             F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
             F::Deinterlace => self.deinterlace = !self.deinterlace,
-            F::Bezel => self.bezel = !self.bezel,
             F::PerfOverlay => self.perf_overlay = !self.perf_overlay,
             F::Mt32Panel => self.mt32_panel = !self.mt32_panel,
             F::PowerOn => self.power_on = !self.power_on,
@@ -6237,20 +6237,34 @@ mod tests {
     }
 
     #[test]
-    fn bezel_round_trips_through_raw() {
+    fn every_bezel_style_round_trips_through_raw() {
         let mut s = MachineSetup::default();
         // Off is the baseline, so nothing is written for it.
-        assert!(!s.toggle_value(LauncherField::Bezel));
+        assert_eq!(
+            s.value_label(LauncherField::Bezel),
+            BezelStyle::None.menu_label()
+        );
         assert_eq!(s.to_raw().display.bezel, None);
 
-        s.toggle(LauncherField::Bezel);
-        assert!(s.toggle_value(LauncherField::Bezel));
-        assert_eq!(s.to_raw().display.bezel, Some(true));
-
-        // The written config has to load back into the same setting.
-        assert!(s.build_config().expect("valid config").bezel);
-        let reloaded = MachineSetup::from_raw(&s.to_raw()).expect("valid raw");
-        assert!(reloaded.toggle_value(LauncherField::Bezel));
+        // Cycling reaches every style, and each is written, reloaded and
+        // shown back as itself.
+        for _ in 0..BezelStyle::MENU_ORDER.len() {
+            s.cycle(LauncherField::Bezel, true);
+            let style = s.bezel;
+            assert_eq!(
+                s.build_config().expect("valid config").bezel,
+                style,
+                "{} did not survive the config",
+                style.label()
+            );
+            let reloaded = MachineSetup::from_raw(&s.to_raw()).expect("valid raw");
+            assert_eq!(
+                reloaded.value_label(LauncherField::Bezel),
+                style.menu_label()
+            );
+        }
+        // A full turn of the cycle comes back to where it started.
+        assert_eq!(s.bezel, BezelStyle::None);
     }
 
     #[test]

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -16,7 +16,8 @@
 use crate::bus::PortDevice;
 use crate::config::JoystickInputMode;
 use crate::config::{
-    AudioFilterMode, DisplayScaling, MenuScale, PixelAspect, ShaderKind, Tint, WarpSpeed,
+    AudioFilterMode, BezelStyle, DisplayScaling, MenuScale, PixelAspect, ShaderKind, Tint,
+    WarpSpeed,
 };
 
 /// What choosing a leaf does. Everything the menu can do is here, so the
@@ -44,6 +45,7 @@ pub enum MenuAction {
     SetShader(ShaderKind),
     SetTint(Tint),
     SetMenuScale(MenuScale),
+    SetBezel(BezelStyle),
     ToggleFullscreen,
     ToggleStatusBar,
     TogglePerfOverlay,
@@ -394,6 +396,8 @@ impl MenuNav {
 pub struct MenuState<'a> {
     pub fullscreen: bool,
     pub status_bar_hidden: bool,
+    /// Which monitor front the bezel pass is drawing, if any.
+    pub bezel: BezelStyle,
     pub perf_overlay: bool,
     pub warp: bool,
     pub warp_speed: WarpSpeed,
@@ -576,6 +580,11 @@ fn video_rows(s: &MenuState) -> Vec<MenuRow> {
         .map(|t| MenuRow::choice(t.menu_label(), MenuAction::SetTint(*t), s.tint == *t))
         .collect();
 
+    let bezels = BezelStyle::MENU_ORDER
+        .iter()
+        .map(|b| MenuRow::choice(b.menu_label(), MenuAction::SetBezel(*b), s.bezel == *b))
+        .collect();
+
     let sizes = MenuScale::MENU_ORDER
         .iter()
         .map(|m| MenuRow::choice(m.label(), MenuAction::SetMenuScale(*m), s.menu_scale == *m))
@@ -593,6 +602,10 @@ fn video_rows(s: &MenuState) -> Vec<MenuRow> {
             MenuAction::ToggleStatusBar,
             !s.status_bar_hidden,
         ),
+        // No value on the row: the tick in the child list already says
+        // which front is on, and naming it here widens every row in the
+        // category to fit the longest style name.
+        MenuRow::submenu("Monitor Bezel", bezels),
         MenuRow::toggle("Performance", MenuAction::TogglePerfOverlay, s.perf_overlay),
     ]
 }
@@ -993,6 +1006,7 @@ mod tests {
         MenuState {
             fullscreen: false,
             status_bar_hidden: false,
+            bezel: BezelStyle::None,
             perf_overlay: false,
             warp: false,
             warp_speed: WarpSpeed::Max,
@@ -1289,6 +1303,27 @@ mod tests {
         let video = find(&rows, "Video Settings").expect("video");
         let video = video.children().expect("children");
         assert!(!find(video, "Fullscreen").expect("fullscreen").closes_menu());
+        // Every window toggle with a keyboard shortcut is reachable from
+        // the menu too: the shortcut is the shortcut, not the only way.
+        for label in ["Status Bar", "Performance"] {
+            let row = find(video, label).unwrap_or_else(|| panic!("{label} missing"));
+            assert!(row.marks_state(), "{label} is not a toggle");
+            assert!(!row.closes_menu(), "picking {label} closed the menu");
+        }
+        // The bezel's shortcut is an on-off, but the menu picks the front,
+        // so it offers every style with the one in force marked. The row
+        // itself shows no value: the tick says it, and a value column here
+        // would widen the whole category.
+        let bezel = find(video, "Monitor Bezel").expect("monitor bezel");
+        assert_eq!(bezel.value, None, "the bezel row widens its category");
+        let styles = bezel.children().expect("bezel styles");
+        assert_eq!(styles.len(), BezelStyle::MENU_ORDER.len());
+        for (row, style) in styles.iter().zip(BezelStyle::MENU_ORDER) {
+            assert_eq!(row.label, style.menu_label());
+            assert_eq!(row.menu_action(), Some(&MenuAction::SetBezel(style)));
+            assert!(!row.closes_menu(), "picking a bezel style closed the menu");
+        }
+        assert!(styles[0].marked(), "the style in force is not marked");
         let tint = find(video, "Screen Tint").expect("tint");
         for row in tint.children().expect("tints") {
             assert!(!row.closes_menu(), "picking {} closed the menu", row.label);

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -2017,7 +2017,7 @@ const SHORTCUT_ROWS: [(&str, &str, bool); 24] = [
     ("B", "Debugger", true),
     ("K", "Console", true),
     ("J", "Joystick input mode", true),
-    ("M", "Monitor bezel on/off", true),
+    ("M", "Monitor bezel off/on", true),
     ("Shift+A", "Cycle audio output", true),
     ("F", "Fullscreen on/off", true),
     ("Shift+F", "Status bar on/off", true),
@@ -8764,6 +8764,7 @@ mod tests {
         let rows = menu::build(&menu::MenuState {
             fullscreen: false,
             status_bar_hidden: false,
+            bezel: crate::config::BezelStyle::None,
             perf_overlay: false,
             warp: false,
             warp_speed: WarpSpeed::Max,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -14,7 +14,9 @@ use super::{
 };
 use crate::audio::{AudioSink, CpalSink};
 use crate::bus::{BeamWriteSource, FrontPanelStatus, PortDevice, VideoRenderFrameTiming};
-use crate::config::{Config, DisplayScaling, Overscan, PixelAspect, RawConfig, WarpSpeed};
+use crate::config::{
+    BezelStyle, Config, DisplayScaling, Overscan, PixelAspect, RawConfig, WarpSpeed,
+};
 use crate::emulator::Emulator;
 use crate::heatmap;
 use crate::keymap;
@@ -377,6 +379,18 @@ const WINDOW_TITLE: &str = concat!("Copperline ", env!("COPPERLINE_DISPLAY_VERSI
 const COPPERLINE_LOGO_PNG: &[u8] = include_bytes!("../../assets/brand/copperline-logo.png");
 const COPPERLINE_ICON_PNG: &[u8] = include_bytes!("../../assets/brand/copperline-icon.png");
 const MOUSE_MOTION_SCALE: f64 = 1.0;
+
+/// Which front `Cmd/Alt+M` should switch back on for a starting style: the
+/// style itself when one is chosen, and otherwise the default front, so the
+/// shortcut has something to turn on from a session that starts with the
+/// bezel off.
+fn last_bezel_style(style: BezelStyle) -> BezelStyle {
+    if style.is_on() {
+        style
+    } else {
+        BezelStyle::Model1084
+    }
+}
 
 /// Whether a window's logical inner size equals the presentation canvas
 /// (FB_WIDTH x `canvas_height`) within a small rounding tolerance -- i.e. the
@@ -916,6 +930,9 @@ pub struct App {
     /// platform-clamped result is not counted as the user's resize. Bounded
     /// because a window manager may ignore the request entirely.
     snap_request_deadline: Option<Instant>,
+    /// A canvas change that could not size the window because it was
+    /// fullscreen, waiting for the window to come back.
+    snap_when_windowed: bool,
     cursor_pos: Option<(i32, i32)>,
     last_display_cursor_pos: Option<(i32, i32)>,
     /// Most recent raw host cursor position (physical pixels) from the last
@@ -983,9 +1000,15 @@ pub struct App {
     /// How strongly the shader pass is mixed in, 0.0 to 1.0 ([display]
     /// shader_strength).
     shader_strength: f32,
-    /// Monitor-bezel pass in effect ([display] bezel, Cmd/Alt+M).
-    /// Presentation only, like the shader pass: captures never include it.
-    bezel: bool,
+    /// Which monitor front the bezel pass draws, if any ([display] bezel,
+    /// Video Settings). Presentation only, like the shader pass: captures
+    /// never include it.
+    bezel: BezelStyle,
+    /// The style `Cmd/Alt+M` switches back on, so the shortcut is an
+    /// on-off for whichever front was chosen rather than a third way of
+    /// choosing one. Never [`BezelStyle::None`]: turning the bezel off
+    /// leaves this pointing at what was on.
+    bezel_last: BezelStyle,
     /// Performance overlay in effect ([display] perf_overlay, Cmd/Alt+P):
     /// a live emulation-performance readout in the top-right of the
     /// display. Presentation only, like the OSD: captures never include it.
@@ -1173,7 +1196,8 @@ struct Render {
     crt_shader: crt_shader::CrtShader,
     /// The optional monitor-bezel pass drawn under the CRT pass (see
     /// [`bezel`]). Built with the window whatever the setting, like the
-    /// CRT pass, so the Cmd/Alt+M toggle works live.
+    /// CRT pass, so switching style or turning it off works live; each
+    /// style's shader is compiled the first time that style is drawn.
     bezel_shader: bezel::BezelShader,
     /// True while the host window is minimized (Windows delivers a 0x0
     /// Resized). Presenting while minimized deadlocks on Windows: DWM stops
@@ -1406,7 +1430,7 @@ impl App {
         phosphor: f32,
         shader: crate::config::ShaderMode,
         shader_strength: f32,
-        bezel: bool,
+        bezel: BezelStyle,
         perf_overlay: bool,
         tint: crate::config::Tint,
         start_fullscreen: bool,
@@ -1553,6 +1577,7 @@ impl App {
             main_window_focused: false,
             window_manually_sized: false,
             snap_request_deadline: None,
+            snap_when_windowed: false,
             cursor_pos: None,
             last_display_cursor_pos: None,
             last_cursor_phys: None,
@@ -1582,6 +1607,7 @@ impl App {
             },
             shader_strength,
             bezel,
+            bezel_last: last_bezel_style(bezel),
             perf_overlay,
             perf: PerfOverlay::default(),
             tint,
@@ -3356,7 +3382,7 @@ impl ApplicationHandler for App {
                     // through its own texture, which this pass does not
                     // sample.
                     let bezel_active =
-                        self.bezel && !self.ui.active() && self.rtg_present_dims.is_none();
+                        self.bezel.is_on() && !self.ui.active() && self.rtg_present_dims.is_none();
                     if let Some((w, h)) = self.rtg_present_dims.filter(|_| rtg_gpu) {
                         r.rtg_texture.upload(
                             r.pixels.device(),
@@ -3456,7 +3482,7 @@ impl ApplicationHandler for App {
                         // the picture into the opening first and the bezel
                         // frames it on top in frame-only mode -- the plastic
                         // overlaps the tube face, so the frame's rounded
-                        // corners and recess clip the preset's square viewport
+                        // corners and chamfer clip the preset's square viewport
                         // rather than being buried under it. One CRT beam pass
                         // per emulated field line the copy above actually
                         // shows.
@@ -3472,6 +3498,7 @@ impl ApplicationHandler for App {
                         );
                         let kind = self.crt_shader_kind;
                         let strength = self.shader_strength;
+                        let bezel_style = self.bezel;
                         // The closure is FnOnce and captures `r`, so the
                         // shaders have to be split out of it as separate
                         // borrows rather than reached through `r` inside.
@@ -3489,7 +3516,7 @@ impl ApplicationHandler for App {
                                 scanlines,
                             );
                             if bezel_active {
-                                let opening = bezel::opening_rect(viewport);
+                                let opening = bezel::opening_rect(bezel_style, viewport);
                                 if crt_active {
                                     crt.render(
                                         &ctx.device,
@@ -3509,6 +3536,7 @@ impl ApplicationHandler for App {
                                     encoder,
                                     target,
                                     viewport,
+                                    bezel_style,
                                     bezel::uniforms_from(&uniforms, viewport, opening, crt_active),
                                 );
                             } else {
@@ -4766,6 +4794,7 @@ impl App {
         let state = MenuState {
             fullscreen,
             status_bar_hidden: crate::video::status_bar_hidden(),
+            bezel: self.bezel,
             perf_overlay: self.perf_overlay,
             warp: !self.emu.paced(),
             warp_speed: self.warp_speed,
@@ -4960,6 +4989,7 @@ impl App {
             }
             A::ToggleFullscreen => self.toggle_fullscreen(),
             A::ToggleStatusBar => self.toggle_status_bar(),
+            A::SetBezel(style) => self.set_bezel(style),
             A::TogglePerfOverlay => self.toggle_perf_overlay(),
 
             A::SetPortDevice(port, device) => {
@@ -5173,9 +5203,7 @@ impl App {
         let was_canvas_sized = self.window_is_canvas_sized();
         crate::video::set_mt32_panel_shown(shown);
         if self.resync_canvas_height() {
-            if was_canvas_sized {
-                self.snap_window_to_canvas();
-            }
+            self.follow_canvas_change(was_canvas_sized);
         } else {
             crate::video::set_mt32_panel_shown(!shown);
             let _ = self.resync_canvas_height();
@@ -7238,6 +7266,7 @@ impl App {
         }
         self.shader_strength = crate::config::resolve_shader_strength(cfg.shader_strength);
         self.bezel = crate::config::resolve_bezel(cfg.bezel);
+        self.bezel_last = last_bezel_style(self.bezel);
         self.perf_overlay = crate::config::resolve_perf_overlay(cfg.perf_overlay);
         self.perf = PerfOverlay::default();
         self.set_tint(crate::config::resolve_tint(cfg.tint));
@@ -9888,6 +9917,25 @@ impl App {
         }
     }
 
+    /// Follow a canvas-height change with the window, or arrange to when
+    /// fullscreen gives the window back.
+    ///
+    /// `was_canvas_sized` is the verdict taken before the change, so a
+    /// window the user has resized keeps its size. Fullscreen is the other
+    /// way a window is not the canvas's to size, and there the snap cannot
+    /// happen now: the request resizes nothing, and on the way out the
+    /// window returns at the *old* canvas's size, which would then be read
+    /// as a drag and strand it letterboxed for the rest of the run. So it
+    /// is remembered and taken when the window is the canvas's again.
+    fn follow_canvas_change(&mut self, was_canvas_sized: bool) {
+        if was_canvas_sized {
+            self.snap_window_to_canvas();
+        } else if !self.window_manually_sized {
+            // Not the user's, so only fullscreen can be holding it.
+            self.snap_when_windowed = true;
+        }
+    }
+
     /// Classify a resize of the main window: the user's own drag, or the
     /// window following a canvas change.
     ///
@@ -9907,6 +9955,13 @@ impl App {
         };
         // Fullscreen sizes the window itself; leave the standing verdict.
         if fullscreen {
+            return;
+        }
+        // The window is back from fullscreen with a canvas change owing:
+        // this size is the old canvas's, not a drag. Take the snap instead
+        // of classifying it, or the stale size is what gets remembered.
+        if std::mem::take(&mut self.snap_when_windowed) {
+            self.snap_window_to_canvas();
             return;
         }
         let logical_w = f64::from(size.width) / scale;
@@ -9938,14 +9993,27 @@ impl App {
         !self.window_manually_sized
     }
 
-    /// Cmd/Alt+M: toggle the monitor-bezel pass for the rest of the run
-    /// (the config file default is unchanged; set `[display] bezel` to
-    /// make it stick).
+    /// Cmd/Alt+M: turn the monitor bezel off, or back on to whichever
+    /// front was last chosen. Picking a style is the menu's job; this is
+    /// the on-off for the one already picked, so it never changes which.
     fn toggle_bezel(&mut self) {
-        self.bezel = !self.bezel;
-        let label = if self.bezel { "on" } else { "off" };
-        info!("monitor bezel: {label}");
-        self.show_osd(format!("Monitor bezel: {label}"));
+        let style = if self.bezel.is_on() {
+            BezelStyle::None
+        } else {
+            self.bezel_last
+        };
+        self.set_bezel(style);
+    }
+
+    /// Draw a given monitor front for the rest of the run (the config file
+    /// default is unchanged; set `[display] bezel` to make it stick).
+    fn set_bezel(&mut self, style: BezelStyle) {
+        self.bezel = style;
+        if style.is_on() {
+            self.bezel_last = style;
+        }
+        info!("monitor bezel: {}", style.label());
+        self.show_osd(format!("Monitor bezel: {}", style.menu_label()));
         self.request_redraw();
     }
 
@@ -10085,9 +10153,7 @@ impl App {
                 self.apply_tool_surface_size(kind, applied);
             }
         }
-        if was_canvas_sized {
-            self.snap_window_to_canvas();
-        }
+        self.follow_canvas_change(was_canvas_sized);
         self.request_redraw();
     }
 
@@ -10172,9 +10238,7 @@ impl App {
         }
         // Only snap an unresized window to the new canvas size; a resized window
         // keeps its dimensions and the display reflows into it.
-        if was_canvas_sized {
-            self.snap_window_to_canvas();
-        }
+        self.follow_canvas_change(was_canvas_sized);
         self.request_redraw();
         if hidden {
             self.show_osd(format!(

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! The optional monitor-bezel pass: a procedural plastic front frame in
-//! the spirit of the 1084, drawn over the display rect on the GPU with
-//! the picture re-sampled into the rounded opening the frame leaves.
+//! The optional monitor-bezel pass: a procedural monitor front drawn over
+//! the display rect on the GPU, with the picture re-sampled into the
+//! rounded opening the frame leaves.
+//!
+//! One [`BezelStyle`] per frame, each a `shaders/bezel_*.wgsl` source and
+//! the opening it leaves ([`opening_rect`]). They share this pass, its
+//! uniform block and its pipeline cache, so adding a style is a shader
+//! file and two match arms.
 //!
 //! Runs inside the `pixels` `render_with` pass after the scaling
 //! renderer, on the same viewport the CRT pass uses (the display sub-rect
@@ -13,8 +18,8 @@
 //! picture first, re-aimed at the opening's bounding box
 //! ([`super::crt_shader::CrtUniforms::with_viewport`]), and the bezel
 //! follows in frame-only mode, discarding the opening interior: the
-//! plastic overlaps the tube face like the real moulding, so the frame's
-//! rounded corners and recess clip the preset's square viewport rather
+//! moulding overlaps the tube face like the real part, so the frame's
+//! rounded corners and chamfer clip the preset's square viewport rather
 //! than being buried under it.
 //!
 //! Purely a presentation stage, like the CRT pass: screenshots, frame
@@ -26,27 +31,59 @@ use pixels::wgpu;
 use zerocopy::{Immutable, IntoBytes};
 
 use super::crt_shader;
+use crate::config::BezelStyle;
 
-/// The bezel WGSL source, embedded like the preset sources.
-const BEZEL_WGSL: &str = include_str!("shaders/bezel.wgsl");
+/// One WGSL source per style, embedded like the preset sources. A new
+/// style is a file here, an arm in [`source`] and one in [`opening_rect`];
+/// nothing else in the window needs to know it exists.
+const M1084_WGSL: &str = include_str!("shaders/bezel_1084.wgsl");
+const CLASSIC_WGSL: &str = include_str!("shaders/bezel_classic.wgsl");
 
-/// Fraction of the display rect the picture keeps when the bezel is on;
-/// the rest becomes the plastic frame. Both axes scale by this one
-/// factor, so the picture keeps its aspect.
-pub(super) const OPENING_SCALE: f32 = 0.85;
+/// The shader a style draws with. [`BezelStyle::None`] draws nothing, so
+/// the pass is skipped before this is reached; it answers with the default
+/// style's source rather than widening every caller's return type.
+fn source(style: BezelStyle) -> &'static str {
+    match style {
+        BezelStyle::Model1084 | BezelStyle::None => M1084_WGSL,
+        BezelStyle::Classic => CLASSIC_WGSL,
+    }
+}
 
-/// How the freed height splits around the opening: the top margin takes
-/// this share and the bottom band the rest, so the bottom comes out
-/// wider than the top like the 1084's face.
-const TOP_SHARE: f32 = 0.42;
+/// The cabinet's proportions, in units of the picture opening's height:
+/// the moulding is that thick around the tube, measured off a straight-on
+/// photograph of a real 1084. [`FRAME_WEIGHT`] scales all of them
+/// together, trading faithfulness against how much of the window the
+/// picture keeps -- at 1.0 the frame is the real one's and the picture
+/// holds 68% of the window's width; at 0.62 it holds 78%.
+///
+/// These three place the opening. `shaders/bezel_1084.wgsl` reads them
+/// back to place everything else on the front, along with the two below,
+/// so the two sources must agree; a test pins them together.
+const FRAME_WEIGHT: f32 = 0.62;
+const FRAME_TOP: f32 = 0.1905 * FRAME_WEIGHT;
+/// Below the glass, down to the seam the chin panel starts at.
+const FRAME_WELL_BOTTOM: f32 = 0.1293 * FRAME_WEIGHT;
+/// The chin panel: model badge, logotype, power lamp.
+const FRAME_CHIN: f32 = 0.1497 * FRAME_WEIGHT;
+/// The design's side margin, and the cabinet band above the moulding.
+/// Only the shader draws with these: the cabinet fills the viewport, which
+/// leaves more room beside the tube than the design asks for, so the side
+/// margin is not what places the opening (the vertical three do that) and
+/// [`FRAME_SIDE`] only sets how far the moulding reaches beside the glass.
+/// They are here to be pinned to the shader's copies, and to let a test
+/// place what the shader does put there.
+#[cfg(test)]
+const FRAME_SIDE: f32 = 0.2313 * FRAME_WEIGHT;
+#[cfg(test)]
+const FRAME_BAND: f32 = 0.064 * FRAME_WEIGHT;
 
 /// Size of the uniform block, in bytes. The shared bind group layout pins
 /// its `min_binding_size` to the CRT block's 64 bytes, so this block must
 /// stay the same size to build against it.
 const UNIFORM_BYTES: u64 = std::mem::size_of::<BezelUniforms>() as u64;
 
-/// The uniform block `shaders/bezel.wgsl` sees. Mirrors the WGSL struct
-/// exactly; `#[repr(C)]` with 16-byte-aligned members only.
+/// The uniform block every `shaders/bezel_*.wgsl` sees. Mirrors the WGSL
+/// struct exactly; `#[repr(C)]` with 16-byte-aligned members only.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, IntoBytes, Immutable)]
 pub(super) struct BezelUniforms {
@@ -60,20 +97,50 @@ pub(super) struct BezelUniforms {
     /// zw size.
     opening: [f32; 4],
     /// x: 1 = frame-only (leave the opening interior to the preset that
-    /// painted it), 0 = full. y: the active preset's face curvature --
-    /// the insert follows the bowed glass contour it implies, 0 = flat
-    /// rounded opening. zw: reserved.
+    /// painted it), 0 = full. y: the active preset's face curvature,
+    /// faded in with its strength -- the chamfer follows the bowed glass
+    /// contour it implies, 0 = flat rounded opening. z: the radius that
+    /// preset clips its face to, faded the same way, which the aperture
+    /// opens to when it is the wider. w: reserved.
     params: [f32; 4],
 }
 
-/// The picture opening the bezel leaves inside a display viewport rect
-/// (physical surface pixels): scaled by [`OPENING_SCALE`] about both
-/// axes, centred horizontally, sitting high by [`TOP_SHARE`].
-pub(super) fn opening_rect(viewport: (f32, f32, f32, f32)) -> (f32, f32, f32, f32) {
+/// Fraction of the display rect the Classic frame leaves to the picture,
+/// and how the freed height splits around it: the top margin takes this
+/// share and the bottom band the rest. Both axes scale by the one factor,
+/// so the picture keeps its aspect.
+const CLASSIC_OPENING_SCALE: f32 = 0.85;
+const CLASSIC_TOP_SHARE: f32 = 0.42;
+
+/// The picture opening a style leaves inside a display viewport rect
+/// (physical surface pixels), keeping the picture's aspect.
+///
+/// The 1084's cabinet fills the viewport, as a monitor's front fills the
+/// window it stands in. Its shape is a little taller in proportion than
+/// the picture -- a real one's is -- so it cannot hold every margin at the
+/// design's weight at once. The vertical budget wins, because the deep
+/// chin is what the front is recognised by; the slack that leaves goes
+/// into the side pillars, which is where a real cabinet carries it.
+///
+/// Classic scales the rect about both axes instead and sits the opening
+/// high, which is all its frame needs to know.
+pub(super) fn opening_rect(
+    style: BezelStyle,
+    viewport: (f32, f32, f32, f32),
+) -> (f32, f32, f32, f32) {
     let (x, y, w, h) = viewport;
-    let ow = w * OPENING_SCALE;
-    let oh = h * OPENING_SCALE;
-    (x + (w - ow) * 0.5, y + (h - oh) * TOP_SHARE, ow, oh)
+    match style {
+        BezelStyle::Classic => {
+            let ow = w * CLASSIC_OPENING_SCALE;
+            let oh = h * CLASSIC_OPENING_SCALE;
+            (x + (w - ow) * 0.5, y + (h - oh) * CLASSIC_TOP_SHARE, ow, oh)
+        }
+        BezelStyle::Model1084 | BezelStyle::None => {
+            let oh = h / (1.0 + FRAME_TOP + FRAME_WELL_BOTTOM + FRAME_CHIN);
+            let ow = oh * (w / h.max(1.0));
+            (x + (w - ow) * 0.5, y + FRAME_TOP * oh, ow, oh)
+        }
+    }
 }
 
 /// Build the bezel uniforms for one presented frame from the CRT pass's
@@ -92,23 +159,42 @@ pub(super) fn uniforms_from(
     let (ox, oy, ow, oh) = opening;
     let w = vw.max(1.0);
     let h = vh.max(1.0);
+    let strength = crt.params[0].clamp(0.0, 1.0);
     BezelUniforms {
         src_rect: crt.src_rect,
         size: crt.size,
         opening: [(ox - vx) / w, (oy - vy) / h, ow / w, oh / h],
-        // The preset's curvature rides along so the insert can follow
-        // the bowed glass; a flat preset (or none) carries 0 there and
-        // keeps the straight-edged opening.
-        params: [if frame_only { 1.0 } else { 0.0 }, crt.params[3], 0.0, 0.0],
+        // The preset's bowed face rides along so the moulding can seat
+        // it: its curvature, and the radius it clips its corners to.
+        // `crt.wgsl` fades both in with strength, so both are faded here
+        // too -- at half strength the moulding must follow a half-bowed
+        // face, not the full one. Curvature is non-zero for exactly the
+        // one preset that clips a face at all; a flat preset, or none,
+        // carries zeroes and leaves the aperture's own corners to govern.
+        params: [
+            if frame_only { 1.0 } else { 0.0 },
+            crt.params[3] * strength,
+            if crt.params[3] > 0.0 {
+                crt_shader::FACE_CORNER_RADIUS * strength
+            } else {
+                0.0
+            },
+            0.0,
+        ],
     }
 }
 
-/// The bezel pass: one fixed pipeline and the bindings it needs.
+/// The bezel pass: the bindings every style shares, and a pipeline for
+/// each style drawn so far.
 pub(super) struct BezelShader {
     bind_group_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
     uniforms: wgpu::Buffer,
-    pipeline: wgpu::RenderPipeline,
+    target_format: wgpu::TextureFormat,
+    /// One pipeline per style drawn so far. Compiling a shader costs
+    /// milliseconds, so a run pays only for the styles it actually picks,
+    /// and a style switch mid-run pays once.
+    pipelines: Vec<(BezelStyle, wgpu::RenderPipeline)>,
     bind_group: Option<wgpu::BindGroup>,
     /// The texture the current bind group views, compared by identity:
     /// `pixels` recreates its backing texture on a buffer resize, and the
@@ -119,13 +205,6 @@ pub(super) struct BezelShader {
 impl BezelShader {
     pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
         let bind_group_layout = crt_shader::shader_bind_group_layout(device);
-        let pipeline = crt_shader::build_pipeline(
-            device,
-            &bind_group_layout,
-            BEZEL_WGSL,
-            "bezel_shader",
-            target_format,
-        );
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("bezel_shader_sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -145,11 +224,28 @@ impl BezelShader {
         Self {
             bind_group_layout,
             sampler,
+            target_format,
             uniforms,
-            pipeline,
+            pipelines: Vec::new(),
             bind_group: None,
             bound_texture: None,
         }
+    }
+
+    /// The pipeline for a style, compiling its shader the first time.
+    fn pipeline_for(&mut self, device: &wgpu::Device, style: BezelStyle) -> &wgpu::RenderPipeline {
+        if let Some(at) = self.pipelines.iter().position(|(s, _)| *s == style) {
+            return &self.pipelines[at].1;
+        }
+        let pipeline = crt_shader::build_pipeline(
+            device,
+            &self.bind_group_layout,
+            source(style),
+            "bezel_shader",
+            self.target_format,
+        );
+        self.pipelines.push((style, pipeline));
+        &self.pipelines.last().expect("just pushed").1
     }
 
     /// Draw the bezel over the `(x, y, w, h)` viewport rect of `target`
@@ -164,12 +260,16 @@ impl BezelShader {
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         viewport: (f32, f32, f32, f32),
+        style: BezelStyle,
         uniforms: BezelUniforms,
     ) {
         let (x, y, w, h) = viewport;
-        if w < 1.0 || h < 1.0 {
+        if w < 1.0 || h < 1.0 || !style.is_on() {
             return;
         }
+        // Resolve the pipeline first: it may compile a shader, and it
+        // borrows self mutably, which the bind group below does not allow.
+        let _ = self.pipeline_for(device, style);
         if self.bound_texture.as_ref() != Some(src_texture) {
             let view = src_texture.create_view(&wgpu::TextureViewDescriptor::default());
             self.bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -192,7 +292,10 @@ impl BezelShader {
             }));
             self.bound_texture = Some(src_texture.clone());
         }
-        let Some(bind_group) = &self.bind_group else {
+        let (Some(bind_group), Some((_, pipeline))) = (
+            &self.bind_group,
+            self.pipelines.iter().find(|(s, _)| *s == style),
+        ) else {
             return;
         };
         queue.write_buffer(&self.uniforms, 0, uniforms.as_bytes());
@@ -212,7 +315,7 @@ impl BezelShader {
             occlusion_query_set: None,
             multiview_mask: None,
         });
-        pass.set_pipeline(&self.pipeline);
+        pass.set_pipeline(pipeline);
         pass.set_bind_group(0, bind_group, &[]);
         pass.set_viewport(x, y, w, h, 0.0, 1.0);
         pass.draw(0..3, 0..1);
@@ -227,17 +330,25 @@ mod tests {
     // --- WGSL validation and geometry (no GPU) --------------------------
 
     #[test]
-    fn the_bezel_source_validates() {
-        if let Err(e) = crt_shader::validate_wgsl_source(BEZEL_WGSL) {
-            panic!("bezel shader failed validation:\n{e}");
+    fn every_bezel_source_validates() {
+        for style in BezelStyle::MENU_ORDER {
+            if let Err(e) = crt_shader::validate_wgsl_source(source(style)) {
+                panic!("{} bezel shader failed validation:\n{e}", style.label());
+            }
         }
     }
 
     /// The bezel is not a preset: it must not carry the preset contract
     /// markers, or the contract test would be expected to cover it.
     #[test]
-    fn the_bezel_is_not_a_contract_preset() {
-        assert!(!BEZEL_WGSL.contains("--- begin shared contract ---"));
+    fn no_bezel_source_is_a_contract_preset() {
+        for style in BezelStyle::MENU_ORDER {
+            assert!(
+                !source(style).contains("--- begin shared contract ---"),
+                "{} carries the preset contract",
+                style.label()
+            );
+        }
     }
 
     /// The shared bind group layout pins `min_binding_size` to the CRT
@@ -253,27 +364,62 @@ mod tests {
 
     #[test]
     fn the_opening_keeps_the_picture_aspect_and_sits_high() {
-        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, 716.0, 537.0));
+        let (vw, vh) = (716.0_f32, 537.0_f32);
+        let (ox, oy, ow, oh) = opening_rect(BezelStyle::Model1084, (0.0, 0.0, vw, vh));
         // Both axes scale by the one factor, so the picture is not
         // stretched.
-        assert!((ow / 716.0 - OPENING_SCALE).abs() < 1e-6);
-        assert!((oh / 537.0 - OPENING_SCALE).abs() < 1e-6);
-        // Centred horizontally, with the bottom band wider than the top
-        // margin like the 1084's face.
-        assert!((ox - (716.0 - ow) * 0.5).abs() < 1e-3);
+        assert!((ow / oh - vw / vh).abs() < 1e-4, "aspect drifted");
+        // The frame is a frame: the picture keeps most of the window but
+        // not nearly all of it.
+        let kept = ow / vw;
+        assert!((0.6..0.9).contains(&kept), "picture keeps {kept} of width");
+        // Centred, with the chin deeper than the top margin like the
+        // 1084's face.
+        assert!((ox - (vw - ow) * 0.5).abs() < 1e-3);
         let top = oy;
-        let bottom = 537.0 - (oy + oh);
+        let bottom = vh - (oy + oh);
         assert!(top > 0.0, "top margin missing: {top}");
         assert!(
             bottom > top,
-            "bottom band ({bottom}) not wider than top ({top})"
+            "bottom margin ({bottom}) not deeper than top ({top})"
         );
+    }
+
+    /// The cabinet fills the display rect exactly: the vertical margins
+    /// account for the whole height, and the opening leaves a side pillar
+    /// wide enough to draw at every window shape.
+    #[test]
+    fn the_cabinet_fills_the_viewport() {
+        for (w, h) in [
+            (716.0, 537.0),
+            (1920.0, 1080.0),
+            (640.0, 512.0),
+            (97.0, 61.0),
+        ] {
+            let (ox, oy, ow, oh) = opening_rect(BezelStyle::Model1084, (0.0, 0.0, w, h));
+            let used = oy + oh + (FRAME_WELL_BOTTOM + FRAME_CHIN) * oh;
+            assert!(
+                (used - h).abs() < 1e-3,
+                "vertical margins leave {} of {h} unaccounted",
+                h - used
+            );
+            assert!(ox > 0.0, "no side pillar at {w}x{h}");
+            assert!(
+                (ox + ow - (w - ox)).abs() < 1e-3,
+                "pillars uneven at {w}x{h}"
+            );
+            // The moulding sits inside the pillar, not through it.
+            assert!(
+                ox - (FRAME_SIDE - FRAME_BAND) * oh > 0.0,
+                "moulding overruns the cabinet at {w}x{h}"
+            );
+        }
     }
 
     #[test]
     fn a_letterboxed_viewport_offsets_the_opening() {
-        let flat = opening_rect((0.0, 0.0, 640.0, 480.0));
-        let off = opening_rect((12.0, 34.0, 640.0, 480.0));
+        let flat = opening_rect(BezelStyle::Model1084, (0.0, 0.0, 640.0, 480.0));
+        let off = opening_rect(BezelStyle::Model1084, (12.0, 34.0, 640.0, 480.0));
         assert_eq!(off.0, flat.0 + 12.0);
         assert_eq!(off.1, flat.1 + 34.0);
         assert_eq!(off.2, flat.2);
@@ -291,15 +437,17 @@ mod tests {
             (716, 581),
             537.0,
         );
-        let opening = opening_rect(viewport);
+        let opening = opening_rect(BezelStyle::Model1084, viewport);
         let u = uniforms_from(&crt, viewport, opening, false);
         assert_eq!(u.src_rect, crt.src_rect);
         assert_eq!(u.size, crt.size);
         // The opening is expressed relative to the viewport, so the
         // letterbox offset must cancel out.
-        assert!((u.opening[0] - (1.0 - OPENING_SCALE) * 0.5).abs() < 1e-6);
-        assert!((u.opening[2] - OPENING_SCALE).abs() < 1e-6);
-        assert!((u.opening[3] - OPENING_SCALE).abs() < 1e-6);
+        let flat = opening_rect(BezelStyle::Model1084, (0.0, 0.0, viewport.2, viewport.3));
+        assert!((u.opening[0] - flat.0 / viewport.2).abs() < 1e-6);
+        assert!((u.opening[1] - flat.1 / viewport.3).abs() < 1e-6);
+        assert!((u.opening[2] - flat.2 / viewport.2).abs() < 1e-6);
+        assert!((u.opening[3] - flat.3 / viewport.3).abs() < 1e-6);
         assert_eq!(u.params[0], 0.0);
         // Frame-only mode differs in nothing but the flag.
         let frame = uniforms_from(&crt, viewport, opening, true);
@@ -321,7 +469,7 @@ mod tests {
             (716, 581),
             537.0,
         );
-        let opening = opening_rect(viewport);
+        let opening = opening_rect(BezelStyle::Model1084, viewport);
         let re = crt.with_viewport(opening);
         assert_eq!(re.src_rect, crt.src_rect);
         assert_eq!(re.params, crt.params);
@@ -332,14 +480,40 @@ mod tests {
 
     // --- offscreen render (needs a GPU adapter) -------------------------
 
+    /// A scalar constant as a shader source states it. Parsed rather than
+    /// pinned to an exact substring, so only semantic drift fails a test,
+    /// not formatting -- and so a test's replica of the geometry cannot
+    /// drift from the shader it is checking.
+    fn shader_constant(src: &str, name: &str, what: &str) -> f32 {
+        let key = format!("const {name}: f32 =");
+        let at = src
+            .find(&key)
+            .unwrap_or_else(|| panic!("{what}: no {name} constant"));
+        let rest = &src[at + key.len()..];
+        let end = rest.find(';').expect("terminated constant");
+        rest[..end]
+            .trim()
+            .parse()
+            .unwrap_or_else(|e| panic!("{what}: unparsable {name}: {e}"))
+    }
+
+    /// The radius a style's opening actually carries when a preset is
+    /// clipping its picture to a tube face at full strength: every source
+    /// opens to the wider of its own aperture and that face.
+    fn effective_aperture(style: BezelStyle) -> f32 {
+        shader_constant(source(style), "APERTURE_RADIUS", style.label())
+            .max(crt_shader::FACE_CORNER_RADIUS)
+    }
+
     const TEX: u32 = 64;
     const DISPLAY_ROWS: u32 = 48;
     const GREY: u8 = 128;
     /// Magnification of the render target over the source, as a real
-    /// window magnifies the composited buffer. Big enough that the frame's
-    /// trim zones (recess, bevel, plastic band) are pixels wide and the
-    /// bottom band is deep enough for the badge lettering to draw.
-    const SCALE: u32 = 6;
+    /// window magnifies the composited buffer. Big enough that the case
+    /// band, the moulding and its chamfer are all pixels wide and the chin
+    /// panel is deep enough for both lines of lettering to draw (the
+    /// shader drops each below the height it would stop resolving at).
+    const SCALE: u32 = 8;
     const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
     /// Target clear colour; pure blue survives the sRGB encode exactly,
     /// so any surviving sentinel pixel inside the viewport means the pass
@@ -486,6 +660,7 @@ mod tests {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         src: &wgpu::Texture,
+        style: BezelStyle,
         crt_kind: Option<ShaderKind>,
     ) -> (Vec<[u8; 4]>, u32, u32) {
         let dim = TEX * SCALE;
@@ -538,7 +713,7 @@ mod tests {
             DISPLAY_ROWS as f32,
         );
         assert_eq!(viewport, (0.0, 0.0, dim as f32, rows as f32));
-        let opening = opening_rect(viewport);
+        let opening = opening_rect(style, viewport);
         if let Some(kind) = crt_kind {
             let mut crt = crt_shader::CrtShader::new(device, FORMAT);
             crt.render(
@@ -560,6 +735,7 @@ mod tests {
             &mut encoder,
             &view,
             viewport,
+            style,
             uniforms_from(&crt_uniforms, viewport, opening, crt_kind.is_some()),
         );
         (
@@ -573,6 +749,27 @@ mod tests {
         px[(y * dim + x) as usize]
     }
 
+    /// The cabinet rect and the chin seam for a viewport. The cabinet is
+    /// the viewport; only the seam is derived from the opening, exactly as
+    /// `shaders/bezel_1084.wgsl` derives it.
+    fn cabinet_of(dim: u32, rows: u32) -> (f32, f32, f32, f32, f32) {
+        let oh = opening_rect(BezelStyle::Model1084, (0.0, 0.0, dim as f32, rows as f32)).3;
+        (
+            0.0,
+            0.0,
+            dim as f32,
+            rows as f32,
+            rows as f32 - FRAME_CHIN * oh,
+        )
+    }
+
+    /// The moulding's left edge, which the model badge is flush with.
+    fn moulding_left(dim: u32, rows: u32) -> f32 {
+        let (ox, _, _, oh) =
+            opening_rect(BezelStyle::Model1084, (0.0, 0.0, dim as f32, rows as f32));
+        ox - (FRAME_SIDE - FRAME_BAND) * oh
+    }
+
     #[test]
     fn the_bezel_covers_the_display_rect_and_nothing_below() {
         let Some(gpu) = gpu() else {
@@ -581,7 +778,7 @@ mod tests {
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, None);
+        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None);
         for y in 0..rows {
             for x in 0..dim {
                 let p = at(&px, dim, x, y);
@@ -604,18 +801,19 @@ mod tests {
     }
 
     #[test]
-    fn the_picture_fills_the_opening_and_the_frame_is_plastic() {
+    fn the_picture_fills_the_opening_and_the_frame_is_two_tone_plastic() {
         let Some(gpu) = gpu() else {
             return;
         };
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, None);
+        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None);
 
         // Centre of the opening: the flat grey source, resampled 1:1 in
         // colour terms.
-        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        let (ox, oy, ow, oh) =
+            opening_rect(BezelStyle::Model1084, (0.0, 0.0, dim as f32, rows as f32));
         let centre = at(&px, dim, (ox + ow * 0.5) as u32, (oy + oh * 0.5) as u32);
         for (c, v) in centre[..3].iter().enumerate() {
             assert!(
@@ -624,93 +822,107 @@ mod tests {
             );
         }
 
-        // Middle of the left band: warm plastic, not the grey source and
-        // not black. Warm means the red channel clearly leads the blue.
-        let band = at(&px, dim, 10, (oy + oh * 0.5) as u32);
+        // The front is two-tone: a pale cool cabinet with a distinctly
+        // darker moulding clipped into it. Sample the middle of each run
+        // to the left of the tube.
+        let (cx, _, _, _, chin_top) = cabinet_of(dim, rows);
+        let mid_y = (oy + oh * 0.5) as u32;
+        let cabinet = at(&px, dim, (cx + 3.0) as u32, mid_y);
+        let moulding = at(&px, dim, ((cx + ox) * 0.5) as u32, mid_y);
         assert!(
-            band[0] > band[2] + 6,
-            "left band is not warm plastic: {band:?}"
+            cabinet[2] > cabinet[0] + 4,
+            "cabinet is not the cool grey it should be: {cabinet:?}"
         );
         assert!(
-            (120..=245).contains(&band[0]),
-            "left band brightness out of range: {band:?}"
+            (120..=245).contains(&cabinet[0]),
+            "cabinet brightness out of range: {cabinet:?}"
+        );
+        assert!(
+            cabinet[1] > moulding[1] + 20,
+            "moulding ({moulding:?}) is not darker than the cabinet ({cabinet:?})"
         );
 
-        // The case corners are rounded off to the letterbox black.
+        // Outside the cabinet is the letterbox black it is centred in.
         for (x, y) in [(0, 0), (dim - 1, 0), (0, rows - 1), (dim - 1, rows - 1)] {
             let p = at(&px, dim, x, y);
             assert!(
                 p[0] < 16 && p[1] < 16 && p[2] < 16,
-                "case corner at ({x}, {y}) is not dark: {p:?}"
+                "outside the cabinet at ({x}, {y}) is not dark: {p:?}"
             );
         }
 
-        // The power LED glows green on the bottom band, right of centre.
-        let led_x = (0.91 * dim as f32) as i32;
-        let led_y = ((oy + oh + rows as f32) * 0.5) as i32;
+        // The power lamp glows red, in the narrow panel the tube's own
+        // right edge closes: the shader puts that panel's outer joint on
+        // `ox + ow` and the lamp halfway across it.
+        let (_, _, case_w, _, _) = cabinet_of(dim, rows);
+        let led_x = (ox + ow - 0.033 * case_w) as i32;
+        let led_y = (chin_top + 0.24 * (rows as f32 - chin_top)) as i32;
         let found = (-3..=3).any(|dy| {
             (-3..=3).any(|dx| {
                 let p = at(&px, dim, (led_x + dx) as u32, (led_y + dy) as u32);
-                p[1] > p[0].saturating_add(50) && p[1] > p[2].saturating_add(50)
+                p[0] > p[1].saturating_add(60) && p[0] > p[2].saturating_add(60)
             })
         });
-        assert!(found, "no green power LED near ({led_x}, {led_y})");
+        assert!(found, "no red power lamp near ({led_x}, {led_y})");
     }
 
     #[test]
-    fn the_badge_prints_on_the_left_of_the_bottom_band() {
+    fn the_badges_print_on_the_chin_panel() {
         let Some(gpu) = gpu() else {
             return;
         };
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, None);
+        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None);
 
-        // The badge rect as the shader lays it out: left-aligned with the
-        // opening, vertically centred in the bottom band, 59x8 font pixels
-        // at 0.34 of the band height. The recess replica is the shader's
-        // insert chamfer, which is where the case face (and the band)
-        // takes over now that no seat ring sits inside it.
-        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
-        let recess = (0.030 * ow.min(oh)).max(4.0);
-        let band_top = oy + oh + recess;
-        let badge_h = 0.34 * (rows as f32 - band_top);
+        // The chin as the shader lays it out: the model badge at 0.068 of
+        // the cabinet width, the logotype centred at 0.47, both on the
+        // panel's own middle.
+        let (case_x, _, case_w, _, chin_top) = cabinet_of(dim, rows);
+        let chin_h = rows as f32 - chin_top;
         assert!(
-            badge_h >= 5.0,
-            "test target too small for the badge lettering: {badge_h}"
+            chin_h * 0.38 >= 7.0,
+            "test target too small for the chin lettering: {chin_h}"
         );
-        let badge_w = 59.0 * badge_h / 8.0;
-        let band_mid = (band_top + rows as f32) * 0.5;
-        let dark = |x0: u32, x1: u32| {
+        let mid = chin_top + chin_h * 0.5;
+        let ink = |x0: f32, x1: f32| {
             let mut n = 0;
-            for y in (band_mid - 0.5 * badge_h) as u32..=(band_mid + 0.5 * badge_h) as u32 {
-                for x in x0..=x1 {
+            for y in (mid - 0.28 * chin_h) as u32..=(mid + 0.28 * chin_h) as u32 {
+                for x in x0.max(0.0) as u32..=x1.min(dim as f32 - 1.0) as u32 {
                     let p = at(&px, dim, x, y);
-                    if p[0] < 150 && p[1] < 150 && p[2] < 150 {
+                    // Blue ink on pale plastic: the logotype's saturated
+                    // blue and the badge's paler one both read as clearly
+                    // blue and darker than the case around them.
+                    if p[0] < 170 && p[2] > p[0] + 20 {
                         n += 1;
                     }
                 }
             }
             n
         };
-        let ink = dark(ox as u32, (ox + badge_w).ceil() as u32);
-        assert!(
-            ink >= 15,
-            "badge lettering missing from the bottom band: {ink} dark pixels"
-        );
-        // The stretch between the badge and the power LED stays plain
-        // plastic: the lettering must not smear across the band.
-        let plain = dark(
-            (ox + badge_w).ceil() as u32 + 10,
-            (0.85 * dim as f32) as u32,
-        );
-        assert_eq!(plain, 0, "ink east of the badge: {plain} dark pixels");
+        // The badge as the shader lays it out: 43 cells of lettering, the
+        // first of which carries no ink, in a frame with a margin of 1.56
+        // half-caps either side.
+        let bs = chin_h * 0.38 / 13.0;
+        let bcap = 0.5 * 13.0 * bs;
+        let badge_x = moulding_left(dim, rows);
+        let badge_w = (43.0 - 1.0) * bs + 2.0 * bcap * 1.56;
+        let badge = ink(badge_x, badge_x + badge_w);
+        assert!(badge >= 12, "model badge missing: {badge} ink pixels");
+        let mark_w = chin_h * 0.27 * (67.0 / 9.0 + 2.0 * 1.28 * 0.62 + 0.42 * 0.62);
+        let mark_x = case_x + 0.47 * case_w - mark_w * 0.5;
+        let mark = ink(mark_x, mark_x + mark_w);
+        assert!(mark >= 20, "logotype missing: {mark} ink pixels");
+        // The stretch between them stays plain plastic: neither may smear
+        // across the panel.
+        let plain = ink(badge_x + badge_w + 6.0, mark_x - 6.0);
+        assert_eq!(plain, 0, "ink between the badge and the logotype: {plain}");
     }
 
     /// The window pairs the bezel with a preset by re-aiming the preset at
-    /// the opening; the combined result must still be framed (plastic band
-    /// intact) with the preset's scanline structure inside the opening.
+    /// the opening; the combined result must still be framed (the
+    /// moulding intact) with the preset's scanline structure inside it.
     #[test]
     fn a_crt_preset_lands_inside_the_opening() {
         let Some(gpu) = gpu() else {
@@ -719,9 +931,16 @@ mod tests {
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, Some(ShaderKind::Scanlines));
+        let (px, dim, rows) = render_bezel(
+            device,
+            queue,
+            &src,
+            BezelStyle::Model1084,
+            Some(ShaderKind::Scanlines),
+        );
 
-        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        let (ox, oy, ow, oh) =
+            opening_rect(BezelStyle::Model1084, (0.0, 0.0, dim as f32, rows as f32));
         // Scanlines modulate the opening interior: one column of it must
         // not be flat.
         let x = (ox + ow * 0.5) as u32;
@@ -738,11 +957,12 @@ mod tests {
             "no scanline structure inside the opening (min {min}, max {max})"
         );
 
-        // The plastic band survives the preset pass untouched.
-        let band = at(&px, dim, 10, (oy + oh * 0.5) as u32);
+        // The frame survives the preset pass untouched.
+        let (cx, _, _, _, _) = cabinet_of(dim, rows);
+        let band = at(&px, dim, ((cx + ox) * 0.5) as u32, (oy + oh * 0.5) as u32);
         assert!(
-            band[0] > band[2] + 6,
-            "left band lost its plastic after the preset pass: {band:?}"
+            band[1] > 60 && band[1] > band[0] + 2 && band[1] > band[2] + 2,
+            "left moulding lost its plastic after the preset pass: {band:?}"
         );
 
         // The frame is drawn on top of the preset: at the opening's
@@ -752,7 +972,7 @@ mod tests {
         // frame-only pass exists for: the moulding overlaps the tube.
         let corner = at(&px, dim, ox as u32, oy as u32);
         assert!(
-            corner[0] > 100 && corner[0] > corner[2] + 6,
+            corner[1] > 60 && corner[1] > corner[0] + 2 && corner[1] > corner[2] + 2,
             "opening corner shows the preset instead of the frame: {corner:?}"
         );
     }
@@ -761,11 +981,11 @@ mod tests {
     /// must blend toward the preset's off-face black, not the raw
     /// picture: a bright source used to smear a picture-coloured
     /// hairline around the opening, over the preset output the pass
-    /// discards its interior for. With the insert chamfer meeting the
-    /// picture directly (no unlit seat ring), "no leak" is exactly
-    /// source-independence: everything past the join's half-pixel blend
-    /// must render identically whatever the picture holds, so the frame
-    /// is compared between an all-white and an all-black source.
+    /// discards its interior for. With the chamfer meeting the picture
+    /// directly, "no leak" is exactly source-independence: everything
+    /// past the join's half-pixel blend must render identically whatever
+    /// the picture holds, so the frame is compared between an all-white
+    /// and an all-black source.
     #[test]
     fn the_frame_only_join_does_not_leak_the_picture() {
         let Some(gpu) = gpu() else {
@@ -775,17 +995,29 @@ mod tests {
         let white = |_x: u32, _y: u32| [255, 255, 255, 255];
         let black = |_x: u32, _y: u32| [0, 0, 0, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &white);
-        let (px, dim, rows) = render_bezel(device, queue, &src, Some(ShaderKind::Crt));
+        let (px, dim, rows) = render_bezel(
+            device,
+            queue,
+            &src,
+            BezelStyle::Model1084,
+            Some(ShaderKind::Crt),
+        );
         let dark = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &black);
-        let (px_dark, dim_dark, rows_dark) =
-            render_bezel(device, queue, &dark, Some(ShaderKind::Crt));
+        let (px_dark, dim_dark, rows_dark) = render_bezel(
+            device,
+            queue,
+            &dark,
+            BezelStyle::Model1084,
+            Some(ShaderKind::Crt),
+        );
         assert_eq!((dim, rows), (dim_dark, rows_dark));
 
         // The shader's glass-contour distance at a pixel centre: the same
         // warp and rounded rectangle the preset's face uses, driven by
         // the preset's own curvature so the replica tracks the shader
         // whatever value the preset table carries.
-        let (ox, oy, ow, oh) = opening_rect((0.0, 0.0, dim as f32, rows as f32));
+        let (ox, oy, ow, oh) =
+            opening_rect(BezelStyle::Model1084, (0.0, 0.0, dim as f32, rows as f32));
         let k = crt_shader::uniforms_for(
             ShaderKind::Crt,
             1.0,
@@ -799,7 +1031,7 @@ mod tests {
         .params[3];
         let (hx, hy) = (ow * 0.5, oh * 0.5);
         let fa = hy / hx;
-        let rc = 0.0826f32;
+        let rc = effective_aperture(BezelStyle::Model1084);
         let opening_d = |x: u32, y: u32| {
             let cx = (x as f32 + 0.5 - ox - hx) / hx;
             let cy = (y as f32 + 0.5 - oy - hy) / hy;
@@ -843,28 +1075,89 @@ mod tests {
         );
     }
 
-    /// The insert must seat the preset's face exactly: both shaders
-    /// derive the glass contour from the same corner radius, so the two
-    /// sources must carry the same constant.
+    /// The moulding must cover the preset's face: `crt.wgsl` states the
+    /// radius it clips that face to and `crt_shader` mirrors it for the
+    /// bezel to open to, so the two must agree -- and the bezel's own
+    /// aperture must be the tighter of the pair for opening to it to mean
+    /// anything.
     #[test]
-    fn the_bezel_and_the_crt_preset_agree_on_the_corner_radius() {
-        // Parse the value rather than pinning an exact source substring,
-        // so only semantic drift fails the test, not formatting.
-        fn corner_radius_of(src: &str, what: &str) -> f32 {
-            let key = "const CORNER_RADIUS: f32 =";
-            let at = src
-                .find(key)
-                .unwrap_or_else(|| panic!("{what}: no CORNER_RADIUS constant"));
-            let rest = &src[at + key.len()..];
-            let end = rest.find(';').expect("terminated constant");
-            rest[..end]
-                .trim()
-                .parse()
-                .unwrap_or_else(|e| panic!("{what}: unparsable CORNER_RADIUS: {e}"))
+    fn the_aperture_is_never_tighter_than_the_face_it_covers() {
+        let face = shader_constant(
+            include_str!("shaders/crt.wgsl"),
+            "CORNER_RADIUS",
+            "crt.wgsl",
+        );
+        assert_eq!(
+            face,
+            crt_shader::FACE_CORNER_RADIUS,
+            "crt.wgsl's face radius and the constant the bezel opens to drifted apart"
+        );
+        // The plastic overlaps the glass. An aperture tighter than the
+        // face it covers would cut inside it and leave the preset's own
+        // off-face black showing in the opening's corners, so every source
+        // takes the wider of the two -- and every source must therefore
+        // state an aperture for that `max()` to reach.
+        for style in BezelStyle::MENU_ORDER {
+            let src = source(style);
+            let aperture = shader_constant(src, "APERTURE_RADIUS", style.label());
+            assert!(
+                aperture > 0.0,
+                "{}: aperture must be a real radius",
+                style.label()
+            );
+            assert!(
+                src.contains("max(APERTURE_RADIUS, u.params.z)"),
+                "{}: does not open its aperture to the preset's face",
+                style.label()
+            );
+            assert!(
+                effective_aperture(style) >= face,
+                "{}: opening cuts inside the face it covers",
+                style.label()
+            );
         }
-        let bezel = corner_radius_of(BEZEL_WGSL, "bezel.wgsl");
-        let crt = corner_radius_of(include_str!("shaders/crt.wgsl"), "crt.wgsl");
-        assert_eq!(bezel, crt, "insert and face corner radii drifted apart");
+    }
+
+    /// The shader derives the whole cabinet back from the opening this
+    /// module placed, using its own copy of the frame proportions. If the
+    /// two copies drift the frame stops matching its own opening: the
+    /// picture would sit off-centre in a cabinet of the wrong size.
+    #[test]
+    fn the_frame_proportions_match_the_shader() {
+        fn constant(name: &str) -> f32 {
+            let key = format!("const {name}: f32 =");
+            let at = M1084_WGSL
+                .find(&key)
+                .unwrap_or_else(|| panic!("bezel_1084.wgsl: no {name}"));
+            let rest = &M1084_WGSL[at + key.len()..];
+            let end = rest.find(';').expect("terminated constant");
+            // Written as `ratio * FRAME_WEIGHT`, or bare for the weight.
+            rest[..end]
+                .split('*')
+                .map(|t| {
+                    let t = t.trim();
+                    if t == "FRAME_WEIGHT" {
+                        constant("FRAME_WEIGHT")
+                    } else {
+                        t.parse().unwrap_or_else(|e| panic!("{name}: {e}"))
+                    }
+                })
+                .product()
+        }
+        for (name, ours) in [
+            ("FRAME_WEIGHT", FRAME_WEIGHT),
+            ("FRAME_SIDE", FRAME_SIDE),
+            ("FRAME_TOP", FRAME_TOP),
+            ("FRAME_WELL_BOTTOM", FRAME_WELL_BOTTOM),
+            ("FRAME_CHIN", FRAME_CHIN),
+            ("FRAME_BAND", FRAME_BAND),
+        ] {
+            let theirs = constant(name);
+            assert!(
+                (ours - theirs).abs() < 1e-6,
+                "{name}: bezel.rs has {ours}, bezel_1084.wgsl has {theirs}"
+            );
+        }
     }
 
     /// Not a check: renders the bezel (optionally with the CRT preset the
@@ -876,7 +1169,8 @@ mod tests {
     /// Setting COPPERLINE_BEZEL_PREVIEW_SHADER (to any value) adds the
     /// preset pass; COPPERLINE_BEZEL_PREVIEW_BARE instead renders the
     /// preset alone over the full frame, no bezel, for eyeballing the
-    /// preset's own face geometry.
+    /// preset's own face geometry. COPPERLINE_BEZEL_PREVIEW_STYLE names
+    /// the front to draw, defaulting to 1084.
     #[test]
     #[ignore = "preview dump; set COPPERLINE_BEZEL_PREVIEW_OUT"]
     fn dump_bezel_preview_png() {
@@ -889,6 +1183,10 @@ mod tests {
         };
         let (device, queue) = (gpu.device(), gpu.queue());
         let with_crt = std::env::var("COPPERLINE_BEZEL_PREVIEW_SHADER").is_ok();
+        let style = std::env::var("COPPERLINE_BEZEL_PREVIEW_STYLE")
+            .ok()
+            .and_then(|s| crate::config::parse_bezel(&s).ok())
+            .unwrap_or(BezelStyle::Model1084);
         let bare = std::env::var("COPPERLINE_BEZEL_PREVIEW_BARE").is_ok();
         let (src, w, h) = match std::env::var("COPPERLINE_BEZEL_PREVIEW_SRC") {
             Ok(path) => {
@@ -959,7 +1257,7 @@ mod tests {
             (w, h),
             (h / 2) as f32,
         );
-        let opening = opening_rect(viewport);
+        let opening = opening_rect(style, viewport);
         if bare {
             let mut crt = crt_shader::CrtShader::new(device, FORMAT);
             crt.render(
@@ -994,6 +1292,7 @@ mod tests {
                 &mut encoder,
                 &view,
                 viewport,
+                style,
                 uniforms_from(&crt_uniforms, viewport, opening, with_crt),
             );
         }

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -97,11 +97,11 @@ pub(super) struct BezelUniforms {
     /// zw size.
     opening: [f32; 4],
     /// x: 1 = frame-only (leave the opening interior to the preset that
-    /// painted it), 0 = full. y: the active preset's face curvature,
-    /// faded in with its strength -- the chamfer follows the bowed glass
-    /// contour it implies, 0 = flat rounded opening. z: the radius that
-    /// preset clips its face to, faded the same way, which the aperture
-    /// opens to when it is the wider. w: reserved.
+    /// painted it), 0 = full. y: the active preset's face curvature, raw
+    /// -- the chamfer follows the bowed glass contour it implies, 0 = flat
+    /// rounded opening. z: the radius that preset clips its face to, faded
+    /// by strength as the preset fades it, which the aperture opens to
+    /// when it is the wider. w: that strength, to fade the bow by.
     params: [f32; 4],
 }
 
@@ -164,22 +164,29 @@ pub(super) fn uniforms_from(
         src_rect: crt.src_rect,
         size: crt.size,
         opening: [(ox - vx) / w, (oy - vy) / h, ow / w, oh / h],
-        // The preset's bowed face rides along so the moulding can seat
-        // it: its curvature, and the radius it clips its corners to.
-        // `crt.wgsl` fades both in with strength, so both are faded here
-        // too -- at half strength the moulding must follow a half-bowed
-        // face, not the full one. Curvature is non-zero for exactly the
-        // one preset that clips a face at all; a flat preset, or none,
-        // carries zeroes and leaves the aperture's own corners to govern.
+        // The preset's bowed face rides along so the moulding can seat it
+        // at any strength: its curvature, the radius it clips its corners
+        // to, and the strength itself.
+        //
+        // The two fade differently, so both go over as the preset states
+        // them. `crt.wgsl` fades its corner radius linearly, so that one
+        // arrives pre-faded; it fades the bow by mixing *coordinates*
+        // (`mix(uv, warp(uv, k), strength)`), which is not the same curve
+        // as warping by a faded `k` -- `warp` is rational in `k` -- so the
+        // curvature goes over raw and each bezel source mixes the same way.
+        //
+        // Curvature is non-zero for exactly the one preset that clips a
+        // face at all; a flat preset, or none, carries zeroes and leaves
+        // the aperture's own corners to govern.
         params: [
             if frame_only { 1.0 } else { 0.0 },
-            crt.params[3] * strength,
+            crt.params[3],
             if crt.params[3] > 0.0 {
                 crt_shader::FACE_CORNER_RADIUS * strength
             } else {
                 0.0
             },
-            0.0,
+            strength,
         ],
     }
 }
@@ -331,7 +338,7 @@ mod tests {
 
     #[test]
     fn every_bezel_source_validates() {
-        for style in BezelStyle::MENU_ORDER {
+        for style in drawn_styles() {
             if let Err(e) = crt_shader::validate_wgsl_source(source(style)) {
                 panic!("{} bezel shader failed validation:\n{e}", style.label());
             }
@@ -342,7 +349,7 @@ mod tests {
     /// markers, or the contract test would be expected to cover it.
     #[test]
     fn no_bezel_source_is_a_contract_preset() {
-        for style in BezelStyle::MENU_ORDER {
+        for style in drawn_styles() {
             assert!(
                 !source(style).contains("--- begin shared contract ---"),
                 "{} carries the preset contract",
@@ -479,6 +486,14 @@ mod tests {
     }
 
     // --- offscreen render (needs a GPU adapter) -------------------------
+
+    /// The styles that actually draw a frame, which is what the source
+    /// contracts below are about. [`BezelStyle::None`] draws nothing and
+    /// borrows a source to keep [`source`] total, so including it would
+    /// check one file twice and name it "off" when it failed.
+    fn drawn_styles() -> impl Iterator<Item = BezelStyle> {
+        BezelStyle::MENU_ORDER.into_iter().filter(|s| s.is_on())
+    }
 
     /// A scalar constant as a shader source states it. Parsed rather than
     /// pinned to an exact substring, so only semantic drift fails a test,
@@ -662,6 +677,7 @@ mod tests {
         src: &wgpu::Texture,
         style: BezelStyle,
         crt_kind: Option<ShaderKind>,
+        strength: f32,
     ) -> (Vec<[u8; 4]>, u32, u32) {
         let dim = TEX * SCALE;
         let rows = DISPLAY_ROWS * SCALE;
@@ -705,7 +721,7 @@ mod tests {
         }));
         let (crt_uniforms, viewport) = crt_shader::uniforms_for(
             crt_kind.unwrap_or(ShaderKind::None),
-            1.0,
+            strength,
             (0, 0, dim, dim),
             DISPLAY_ROWS as usize,
             TEX as usize,
@@ -778,7 +794,7 @@ mod tests {
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None);
+        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None, 1.0);
         for y in 0..rows {
             for x in 0..dim {
                 let p = at(&px, dim, x, y);
@@ -808,7 +824,7 @@ mod tests {
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None);
+        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None, 1.0);
 
         // Centre of the opening: the flat grey source, resampled 1:1 in
         // colour terms.
@@ -874,7 +890,7 @@ mod tests {
         let (device, queue) = (gpu.device(), gpu.queue());
         let grey = |_x: u32, _y: u32| [GREY, GREY, GREY, 255];
         let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &grey);
-        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None);
+        let (px, dim, rows) = render_bezel(device, queue, &src, BezelStyle::Model1084, None, 1.0);
 
         // The chin as the shader lays it out: the model badge at 0.068 of
         // the cabinet width, the logotype centred at 0.47, both on the
@@ -937,6 +953,7 @@ mod tests {
             &src,
             BezelStyle::Model1084,
             Some(ShaderKind::Scanlines),
+            1.0,
         );
 
         let (ox, oy, ow, oh) =
@@ -988,6 +1005,15 @@ mod tests {
     /// and an all-black source.
     #[test]
     fn the_frame_only_join_does_not_leak_the_picture() {
+        // Full strength, and half: the moulding has to seat the preset's
+        // face at every strength, and the bow and the face's corner radius
+        // fade by different curves on the way there.
+        for strength in [1.0, 0.5] {
+            frame_only_join_is_source_independent(strength);
+        }
+    }
+
+    fn frame_only_join_is_source_independent(strength: f32) {
         let Some(gpu) = gpu() else {
             return;
         };
@@ -1001,6 +1027,7 @@ mod tests {
             &src,
             BezelStyle::Model1084,
             Some(ShaderKind::Crt),
+            strength,
         );
         let dark = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &black);
         let (px_dark, dim_dark, rows_dark) = render_bezel(
@@ -1009,6 +1036,7 @@ mod tests {
             &dark,
             BezelStyle::Model1084,
             Some(ShaderKind::Crt),
+            strength,
         );
         assert_eq!((dim, rows), (dim_dark, rows_dark));
 
@@ -1020,7 +1048,7 @@ mod tests {
             opening_rect(BezelStyle::Model1084, (0.0, 0.0, dim as f32, rows as f32));
         let k = crt_shader::uniforms_for(
             ShaderKind::Crt,
-            1.0,
+            strength,
             (0, 0, dim, rows),
             rows as usize,
             rows as usize,
@@ -1031,15 +1059,19 @@ mod tests {
         .params[3];
         let (hx, hy) = (ow * 0.5, oh * 0.5);
         let fa = hy / hx;
-        let rc = effective_aperture(BezelStyle::Model1084);
+        // The aperture opens to the preset's faded face when that is the
+        // wider, exactly as the shader does.
+        let rc = shader_constant(M1084_WGSL, "APERTURE_RADIUS", "bezel_1084.wgsl")
+            .max(crt_shader::FACE_CORNER_RADIUS * strength);
         let opening_d = |x: u32, y: u32| {
             let cx = (x as f32 + 0.5 - ox - hx) / hx;
             let cy = (y as f32 + 0.5 - oy - hy) / hy;
             let q = k * 0.25;
             let r2 = cx * cx + cy * cy * fa * fa;
             let bow = 1.0 + q * r2;
-            let wx = cx * bow / (1.0 + q);
-            let wy = cy * bow / (1.0 + q * fa * fa) * fa;
+            // Faded by mixing coordinates, as the shader and crt.wgsl do.
+            let wx = cx + (cx * bow / (1.0 + q) - cx) * strength;
+            let wy = (cy + (cy * bow / (1.0 + q * fa * fa) - cy) * strength) * fa;
             let qx = wx.abs() - 1.0 + rc;
             let qy = wy.abs() - fa + rc;
             let outside = (qx.max(0.0).powi(2) + qy.max(0.0).powi(2)).sqrt();
@@ -1075,6 +1107,54 @@ mod tests {
         );
     }
 
+    /// WGSL leaves `smoothstep` undefined when the first edge is not below
+    /// the second, and backends disagree there, so a reversed interval is a
+    /// portability bug that looks fine on the machine it was written on.
+    /// Every edge pair a source states in comparable terms must ascend.
+    #[test]
+    fn every_smoothstep_interval_ascends() {
+        /// An edge as a coefficient and the symbol it scales, so
+        /// `0.26 * h` and `0.10 * h` can be compared and a pair in
+        /// unrelated terms can be skipped rather than guessed at.
+        fn edge(text: &str) -> Option<(f32, &str)> {
+            let (num, sym) = match text.split_once('*') {
+                Some((n, s)) => (n.trim(), s.trim()),
+                None => (text.trim(), ""),
+            };
+            Some((num.parse().ok()?, sym))
+        }
+        for style in drawn_styles() {
+            let src = source(style);
+            for (at, _) in src.match_indices("smoothstep(") {
+                let open = at + "smoothstep(".len();
+                let rest = &src[open..];
+                // Split the call's own arguments: the edges are the first
+                // two, and neither contains a nested call in these sources.
+                let end = rest.find(')').expect("terminated smoothstep");
+                let args: Vec<&str> = rest[..end].split(',').collect();
+                assert!(
+                    args.len() >= 3,
+                    "{}: smoothstep needs 3 arguments",
+                    style.label()
+                );
+                let (Some((lo, lo_sym)), Some((hi, hi_sym))) = (edge(args[0]), edge(args[1]))
+                else {
+                    continue;
+                };
+                if lo_sym != hi_sym {
+                    continue;
+                }
+                assert!(
+                    lo < hi,
+                    "{}: smoothstep({}, {}, ..) is a reversed interval",
+                    style.label(),
+                    args[0].trim(),
+                    args[1].trim()
+                );
+            }
+        }
+    }
+
     /// The moulding must cover the preset's face: `crt.wgsl` states the
     /// radius it clips that face to and `crt_shader` mirrors it for the
     /// bezel to open to, so the two must agree -- and the bezel's own
@@ -1097,7 +1177,7 @@ mod tests {
         // off-face black showing in the opening's corners, so every source
         // takes the wider of the two -- and every source must therefore
         // state an aperture for that `max()` to reach.
-        for style in BezelStyle::MENU_ORDER {
+        for style in drawn_styles() {
             let src = source(style);
             let aperture = shader_constant(src, "APERTURE_RADIUS", style.label());
             assert!(
@@ -1108,6 +1188,15 @@ mod tests {
             assert!(
                 src.contains("max(APERTURE_RADIUS, u.params.z)"),
                 "{}: does not open its aperture to the preset's face",
+                style.label()
+            );
+            // The bow is faded by mixing coordinates, as crt.wgsl fades
+            // it. Warping by a faded curvature is a different curve --
+            // `warp` is rational in the curvature -- so a source that
+            // pre-fades it drifts off the face between strengths.
+            assert!(
+                src.contains("mix(cn, cn * (1.0 + q * r2) / m, u.params.w)"),
+                "{}: does not fade the bow the way crt.wgsl does",
                 style.label()
             );
             assert!(

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -81,6 +81,13 @@ impl CrtUniforms {
 }
 
 /// Preset pipeline slots, in the order [`CrtShader::presets`] holds them.
+/// The corner arcs `shaders/crt.wgsl` clips its tube face to, as a
+/// fraction of the display half-width. Mirrored here so the bezel can open
+/// its aperture wide enough to cover that face -- a moulding narrower than
+/// the glass it overlaps would leave the face's own edge showing in the
+/// corners. A test pins this to the shader's own constant.
+pub(super) const FACE_CORNER_RADIUS: f32 = 0.0826;
+
 const PRESET_SCANLINES: usize = 0;
 const PRESET_MASK: usize = 1;
 const PRESET_CRT: usize = 2;

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -80,7 +80,6 @@ impl CrtUniforms {
     }
 }
 
-/// Preset pipeline slots, in the order [`CrtShader::presets`] holds them.
 /// The corner arcs `shaders/crt.wgsl` clips its tube face to, as a
 /// fraction of the display half-width. Mirrored here so the bezel can open
 /// its aperture wide enough to cover that face -- a moulding narrower than
@@ -88,6 +87,7 @@ impl CrtUniforms {
 /// corners. A test pins this to the shader's own constant.
 pub(super) const FACE_CORNER_RADIUS: f32 = 0.0826;
 
+/// Preset pipeline slots, in the order [`CrtShader::presets`] holds them.
 const PRESET_SCANLINES: usize = 0;
 const PRESET_MASK: usize = 1;
 const PRESET_CRT: usize = 2;

--- a/src/video/window/shaders/bezel_1084.wgsl
+++ b/src/video/window/shaders/bezel_1084.wgsl
@@ -1,0 +1,702 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Monitor-bezel pass: a procedural front frame in the shape of the 1084
+// the Amiga shipped with. Two-tone, as that cabinet is: a pale grey case,
+// and clipped into it a darker grey-green moulding that drops away in a
+// chamfer to the tube it holds. Below the moulding is the chin panel,
+// carrying the model badge, the logotype where the 1084 wears its maker's
+// name, and the red power lamp.
+//
+// The cabinet fills the display rect, as a monitor's front fills the
+// window it stands in. Everything inside it is placed off the picture
+// opening `bezel.rs` chose, in units of that opening's height, by frame
+// proportions measured off a straight-on photograph of a real one (see
+// FRAME_* below).
+//
+// Two modes, selected by params.x. Alone (0), this one pass draws both
+// the frame and the picture. Under a CRT preset (1, frame-only), the
+// preset has already painted the picture into the opening's bounding box
+// and this pass runs after it, discarding the opening interior and
+// drawing just the frame on top -- the moulding overlaps the tube face,
+// so its rounded corners and chamfer clip the preset's square viewport.
+//
+// Not a window-shader preset: it is not user-replaceable, and its uniform
+// block is its own, so it deliberately does not carry the shared contract
+// prologue of shaders/{scanlines,mask,crt}.wgsl.
+
+struct BezelUniforms {
+    // Display sub-rect of src_tex in UV space: xy origin, zw size. The
+    // status bar sits below the display in the same texture and must
+    // never be sampled, so all sampling goes through this rect.
+    src_rect: vec4<f32>,
+    // xy: viewport size in physical pixels.
+    // zw: source display region in texels.
+    size: vec4<f32>,
+    // Picture opening within the viewport, in viewport UV: xy origin,
+    // zw size. Same aspect as the viewport, so the picture is scaled,
+    // not stretched.
+    opening: vec4<f32>,
+    // x: 1 = frame-only (a CRT preset has already painted the opening;
+    // leave its interior untouched), 0 = full (paint the picture too).
+    // y: the active preset's face curvature, faded in with its strength;
+    // the chamfer follows the bowed glass contour it implies, and 0 keeps
+    // the flat rounded opening.
+    // z: the corner radius that preset clips its face to, faded the same
+    // way; the aperture opens to at least this so the moulding covers the
+    // face's own edge. 0 for a preset that does not clip one, or none.
+    // w: reserved, zero.
+    params: vec4<f32>,
+};
+
+@group(0) @binding(0) var src_tex: texture_2d<f32>;
+@group(0) @binding(1) var src_samp: sampler;
+@group(0) @binding(2) var<uniform> u: BezelUniforms;
+
+struct VOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VOut {
+    // Fullscreen triangle: the viewport restricts it to the display rect.
+    let tc = vec2<f32>(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VOut;
+    out.uv = tc;
+    out.pos = vec4<f32>(tc * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+    return out;
+}
+
+// Sample the display region only, with the clamp inset by half a texel so
+// a linear sample on the boundary never blends in the status bar's first
+// row (see sample_display in the preset contract for the derivation).
+fn sample_display(uv: vec2<f32>) -> vec4<f32> {
+    let half_texel = 0.5 * u.src_rect.zw / max(u.size.zw, vec2<f32>(1.0));
+    let lo = u.src_rect.xy + half_texel;
+    let hi = u.src_rect.xy + u.src_rect.zw - half_texel;
+    let tc = clamp(u.src_rect.xy + uv * u.src_rect.zw, lo, hi);
+    return textureSample(src_tex, src_samp, tc);
+}
+
+// Signed distance to a rounded rectangle centred on the origin, in the
+// units of p; negative inside.
+fn rounded_rect(p: vec2<f32>, half: vec2<f32>, r: f32) -> f32 {
+    let q = abs(p) - half + vec2<f32>(r);
+    return length(max(q, vec2<f32>(0.0))) + min(max(q.x, q.y), 0.0) - r;
+}
+
+// Outward unit normal of `rounded_rect` at p. A rounded rect's gradient is
+// exact in closed form, so the chamfer's slope direction needs no screen
+// derivatives.
+fn rounded_rect_grad(p: vec2<f32>, half: vec2<f32>, r: f32) -> vec2<f32> {
+    let s = sign(p + vec2<f32>(1e-6));
+    let q = abs(p) - half + vec2<f32>(r);
+    if q.x > 0.0 && q.y > 0.0 {
+        return normalize(q) * s;
+    }
+    if q.x > q.y {
+        return vec2<f32>(s.x, 0.0);
+    }
+    return vec2<f32>(0.0, s.y);
+}
+
+// Per-pixel hash in -0.5..0.5, for the moulded plastic grain.
+fn grain(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453) - 0.5;
+}
+
+// --- the frame's proportions ------------------------------------------
+//
+// All in units of the opening's height, scaled by FRAME_WEIGHT: the ratios
+// are the real cabinet's, measured off a straight-on photograph, and the
+// weight trades faithfulness against how much of the window the picture
+// keeps. `bezel.rs` places the opening from the vertical three and this
+// pass reads all five back, so the two must agree; a test pins them
+// together.
+const FRAME_WEIGHT: f32 = 0.62;
+const FRAME_TOP: f32 = 0.1905 * FRAME_WEIGHT;
+const FRAME_WELL_BOTTOM: f32 = 0.1293 * FRAME_WEIGHT;
+const FRAME_CHIN: f32 = 0.1497 * FRAME_WEIGHT;
+// The design's side margin. The cabinet is wider than the design here --
+// it fills the window, and the picture's aspect leaves more room beside
+// the tube than the design asks for -- so this no longer says where the
+// opening sits, which falls out of the vertical margins alone. It sets
+// how far the moulding reaches beside the tube; the cabinet's pillar
+// takes whatever is left.
+const FRAME_SIDE: f32 = 0.2313 * FRAME_WEIGHT;
+// The cabinet band showing above the moulding.
+const FRAME_BAND: f32 = 0.064 * FRAME_WEIGHT;
+
+// The moulding's aperture corners, as a fraction of the opening
+// half-width: rounder than the plastic around it, as the glass is. Where
+// a preset clips its picture to a rounded tube face, the aperture opens
+// to that face's radius instead when it is the wider of the two -- the
+// moulding overlaps the glass, so it must never cut inside the face and
+// leave its edge showing in the corners.
+const APERTURE_RADIUS: f32 = 0.068;
+// The cabinet's and the moulding's corner arcs, in opening heights: one
+// radius, so every corner of both matches, top and bottom.
+const R_PLASTIC: f32 = 0.036;
+// How much of the moulding's width is chamfer rather than flat, and how
+// far that chamfer leans back, in radians off the case front.
+const CHAMFER_SPAN: f32 = 0.72;
+const CHAMFER_SLOPE: f32 = 0.80;
+
+// The cabinet and the moulding clipped into it, in linear light: sRGB
+// #bec3c9 and #8b908c, sampled off a photograph of a real one.
+const CASE: vec3<f32> = vec3<f32>(0.5150, 0.5459, 0.5842);
+const MOULDING: vec3<f32> = vec3<f32>(0.2581, 0.2789, 0.2622);
+// The logotype's ink: Pantone 286, the blue the 1084's printing used.
+const INK: vec3<f32> = vec3<f32>(0.0, 0.0331, 0.3516);
+// The model badge reads paler and greyer than the logotype: #7b94bc.
+const BADGE_INK: vec3<f32> = vec3<f32>(0.1946, 0.2874, 0.5029);
+// The lamp and the dark window it sits in.
+const LAMP: vec3<f32> = vec3<f32>(0.72, 0.035, 0.014);
+const LAMP_WELL: vec3<f32> = vec3<f32>(0.014, 0.012, 0.012);
+// Moulded legends: the POWER caption and the standby mark.
+const LEGEND: vec3<f32> = vec3<f32>(0.10, 0.10, 0.095);
+
+// Room light, from above and a little to the left, in front of the glass.
+const LIGHT: vec3<f32> = vec3<f32>(-0.1, -0.5, 0.86);
+
+// A surface's tone relative to a flat front face, which comes out 1.0. The
+// response is deliberately shallow: moulded plastic scatters, so the well
+// reads as a shallow pit, not a chrome trough.
+fn tone(n: vec3<f32>) -> f32 {
+    let l = normalize(LIGHT);
+    return 0.42 + 0.58 * clamp(dot(n, l), 0.0, 1.0) / l.z;
+}
+
+// The normal of a chamfer sloping up from the glass, given the outward
+// direction across it. It leans back against that direction, so the run
+// above the tube shades and the run below catches the light.
+fn chamfer_normal(outward: vec2<f32>, slope: f32) -> vec3<f32> {
+    return vec3<f32>(-outward * sin(slope), cos(slope));
+}
+
+// --- the Copperline mark ----------------------------------------------
+//
+// A narrow C with a bar driven right through it, drawn from signed
+// distances rather than a bitmap so its curve stays clean at any size, and
+// filled in polished copper. `r` is the ring's radius in physical pixels.
+// The logotype's cap height as a fraction of the chin's, and where its
+// middle sits down the panel. The model badge stays on the panel's own
+// centre: the real front carries the plate centred in its section and the
+// maker's badge riding lower.
+const LOGO_CAP: f32 = 0.27;
+const LOGO_DROP: f32 = 0.56;
+
+const MARK_SQUASH: f32 = 0.84;
+const MARK_REACH: f32 = 1.28;
+const MARK_MOUTH: f32 = 0.44;
+const MARK_BAR: f32 = 0.28;
+const MARK_SIDE: f32 = 0.46;
+
+// Coverage of the mark at a fragment, and how far down it the fragment
+// sits, for the metal gradient.
+fn mark_field(d: vec2<f32>, r: f32) -> vec2<f32> {
+    let w = r * 0.50;
+    // The ring, narrowed and with its mouth cut out on the right. Its
+    // stroke carries more weight through the sides than over the top and
+    // under the foot, the way a drawn letter does.
+    let dd = vec2<f32>(d.x / MARK_SQUASH, d.y);
+    let rad = max(length(dd), 1e-4);
+    let wl = w * (1.24 - MARK_SIDE + MARK_SIDE * abs(dd.x / rad));
+    var ring = abs(rad - r) - wl * 0.5;
+    if dd.x > 0.0 && abs(d.y) < r * MARK_MOUTH {
+        ring = 1e6;
+    }
+    // The bar, crossing the whole letter and reaching past both sides.
+    let bar = rounded_rect(d, vec2<f32>(r * MARK_REACH, w * MARK_BAR), w * 0.10);
+    let sd = min(ring, bar);
+    return vec2<f32>(
+        1.0 - smoothstep(-0.5, 0.6, sd),
+        clamp(d.y / (2.0 * r) + 0.5, 0.0, 1.0),
+    );
+}
+
+// One catchlight: a small core with a horizontal and a vertical streak,
+// the glint polished metal throws off a cut edge.
+fn spark(q: vec2<f32>, s: f32, reach: f32) -> f32 {
+    let core = pow(1.0 - clamp(length(q) / s, 0.0, 1.0), 2.2);
+    let across = pow(1.0 - clamp(abs(q.x) / (s * reach), 0.0, 1.0), 2.0)
+        * pow(1.0 - clamp(abs(q.y) / (s * 0.30), 0.0, 1.0), 1.4);
+    let down = pow(1.0 - clamp(abs(q.y) / (s * reach * 0.62), 0.0, 1.0), 2.0)
+        * pow(1.0 - clamp(abs(q.x) / (s * 0.26), 0.0, 1.0), 1.4);
+    return clamp(core + 0.85 * across + 0.85 * down, 0.0, 1.0);
+}
+
+// Both ends of the bar, then a third and quieter one inside the bowl, on
+// the right of the letter's spine. That one is drawn tight so it stays its
+// own point of light rather than smearing into its neighbour.
+fn mark_sparks(d: vec2<f32>, r: f32) -> f32 {
+    let a = spark(d + vec2<f32>(r * MARK_REACH, 0.0), r * 0.34, 3.2);
+    let b = spark(d - vec2<f32>(r * MARK_REACH, 0.0), r * 0.34, 3.2);
+    let c = 0.58 * spark(d + vec2<f32>(r * 0.34, 0.0), r * 0.22, 1.5);
+    return max(max(a, b), c);
+}
+
+// The glint's own colour: a warm near-white, so the spark reads as light
+// on metal rather than a paler paint.
+const SPARK_LIGHT: vec3<f32> = vec3<f32>(1.0, 0.8388, 0.7011);
+
+// Polished copper down the mark: the metal itself, not gold -- a red-brown
+// body with one pink-warm sheen where the surface turns, deepening to a
+// dark oxide at the foot.
+fn copper(t: f32) -> vec3<f32> {
+    let top = vec3<f32>(0.3250, 0.0865, 0.0273);
+    let sheen = vec3<f32>(0.6105, 0.2346, 0.1022);
+    let mid = vec3<f32>(0.2519, 0.0578, 0.0168);
+    let lo = vec3<f32>(0.0759, 0.0168, 0.0048);
+    if t < 0.40 {
+        return mix(top, sheen, smoothstep(0.40, 0.24, t));
+    }
+    if t < 0.60 {
+        return mix(sheen, mid, smoothstep(0.40, 0.60, t));
+    }
+    return mix(mid, lo, smoothstep(0.60, 1.0, t));
+}
+
+// --- lettering ---------------------------------------------------------
+//
+// Three rasterised strings, packed a bit to a cell, LSB-first from the
+// left of each row. Each carries the cap height it was drawn to, so text
+// is sized by its capitals rather than by whatever cell box its face
+// happened to need, and the model badge carries where its ink starts and
+// stops so a frame can centre on the lettering rather than on the bearings
+// its digits happen to have.
+
+// MARK: 67 x 11 cells, cap 9, ink 0..67
+// ..#####.......................................##.##................
+// .##..##.......................................##.##................
+// ##............................................##...................
+// ##.......#####..######..######...#####..##.##.##.##.##.###...#####.
+// ##......##...##.##...##.##...##.##...##.#####.##.##.#######.##...##
+// ##......##...##.##...##.##...##.#######.##....##.##.##...##.#######
+// ##......##...##.##...##.##...##.##......##....##.##.##...##.##.....
+// .##..##.##...##.##...##.##...##.##...##.##....##.##.##...##.##...##
+// ..#####..#####..######..######...#####..##....##.##.##...##..#####.
+// ................##......##.........................................
+// ................##......##.........................................
+const MARK_COLS: i32 = 67;
+const MARK_ROWS: i32 = 11;
+const MARK_CAP: f32 = 9.0;
+const MARK_INK: vec2<f32> = vec2<f32>(0.0, 67.0);
+const MARK: array<vec3<u32>, 11> = array<vec3<u32>, 11>(
+    vec3<u32>(0x0000007cu, 0x0006c000u, 0x00000000u),
+    vec3<u32>(0x00000066u, 0x0006c000u, 0x00000000u),
+    vec3<u32>(0x00000003u, 0x0000c000u, 0x00000000u),
+    vec3<u32>(0x3f3f3e03u, 0xe3b6db3eu, 0x00000003u),
+    vec3<u32>(0x63636303u, 0x37f6df63u, 0x00000006u),
+    vec3<u32>(0x63636303u, 0xf636c37fu, 0x00000007u),
+    vec3<u32>(0x63636303u, 0x3636c303u, 0x00000000u),
+    vec3<u32>(0x63636366u, 0x3636c363u, 0x00000006u),
+    vec3<u32>(0x3f3f3e7cu, 0xe636c33eu, 0x00000003u),
+    vec3<u32>(0x03030000u, 0x00000000u, 0x00000000u),
+    vec3<u32>(0x03030000u, 0x00000000u, 0x00000000u),
+);
+
+// MODEL: 43 x 13 cells, cap 13, ink 1..43
+// ...###.....######......######..........###.
+// ..####....########....########.......#####.
+// .#####...###....###..###....###.....##.###.
+// ...###...###....###..###....###....##..###.
+// ...###...###....###..###....###...##...###.
+// ...###...###....###...########...##########
+// ...###...###....###...########...##########
+// ...###...###....###...########...##########
+// ...###...###....###..###....###........###.
+// ...###...###....###..###....###........###.
+// ...###...###....###..###....###........###.
+// ...###....########....########.........###.
+// ...###.....######......######..........###.
+const MODEL_COLS: i32 = 43;
+const MODEL_ROWS: i32 = 13;
+const MODEL_CAP: f32 = 13.0;
+const MODEL_INK: vec2<f32> = vec2<f32>(1.0, 43.0);
+const MODEL: array<vec2<u32>, 13> = array<vec2<u32>, 13>(
+    vec2<u32>(0x1f81f838u, 0x00000380u),
+    vec2<u32>(0x3fc3fc3cu, 0x000003e0u),
+    vec2<u32>(0x70e70e3eu, 0x000003b0u),
+    vec2<u32>(0x70e70e38u, 0x00000398u),
+    vec2<u32>(0x70e70e38u, 0x0000038cu),
+    vec2<u32>(0x3fc70e38u, 0x000007feu),
+    vec2<u32>(0x3fc70e38u, 0x000007feu),
+    vec2<u32>(0x3fc70e38u, 0x000007feu),
+    vec2<u32>(0x70e70e38u, 0x00000380u),
+    vec2<u32>(0x70e70e38u, 0x00000380u),
+    vec2<u32>(0x70e70e38u, 0x00000380u),
+    vec2<u32>(0x3fc3fc38u, 0x00000380u),
+    vec2<u32>(0x1f81f838u, 0x00000380u),
+);
+
+// CAPTION: 29 x 8 cells, cap 7, ink 0..29
+// ####...###..#...#.#####.####.
+// #...#.#...#.#...#.#.....#...#
+// #...#.#...#.#...#.#.....#...#
+// ####..#...#.#.#.#.####..####.
+// #.....#...#.#.#.#.#.....#.#..
+// #.....#...#.##.##.#.....#..#.
+// #......###..#...#.#####.#...#
+// .............................
+const CAPTION_COLS: i32 = 29;
+const CAPTION_ROWS: i32 = 8;
+const CAPTION_CAP: f32 = 7.0;
+const CAPTION_INK: vec2<f32> = vec2<f32>(0.0, 29.0);
+const CAPTION: array<u32, 8> = array<u32, 8>(
+    0x0f7d138fu,
+    0x11051451u,
+    0x11051451u,
+    0x0f3d544fu,
+    0x05055441u,
+    0x0905b441u,
+    0x117d1381u,
+    0x00000000u,
+);
+
+fn mark_bit(c: i32, r: i32) -> f32 {
+    if c < 0 || c >= MARK_COLS || r < 0 || r >= MARK_ROWS {
+        return 0.0;
+    }
+    var rows = MARK;
+    let bits = rows[r];
+    if c < 32 {
+        return f32((bits.x >> u32(c)) & 1u);
+    }
+    if c < 64 {
+        return f32((bits.y >> u32(c - 32)) & 1u);
+    }
+    return f32((bits.z >> u32(c - 64)) & 1u);
+}
+
+fn model_bit(c: i32, r: i32) -> f32 {
+    if c < 0 || c >= MODEL_COLS || r < 0 || r >= MODEL_ROWS {
+        return 0.0;
+    }
+    var rows = MODEL;
+    let bits = rows[r];
+    if c < 32 {
+        return f32((bits.x >> u32(c)) & 1u);
+    }
+    return f32((bits.y >> u32(c - 32)) & 1u);
+}
+
+fn caption_bit(c: i32, r: i32) -> f32 {
+    if c < 0 || c >= CAPTION_COLS || r < 0 || r >= CAPTION_ROWS {
+        return 0.0;
+    }
+    var rows = CAPTION;
+    return f32((rows[r] >> u32(c)) & 1u);
+}
+
+// A bitmap sampled bilinearly at a continuous position in cells, then
+// taken through a threshold: the printing keeps its weight at any size
+// rather than fading to a smear.
+fn cover(v00: f32, v10: f32, v01: f32, v11: f32, t: vec2<f32>) -> f32 {
+    return smoothstep(0.34, 0.62, mix(mix(v00, v10, t.x), mix(v01, v11, t.x), t.y));
+}
+
+fn mark_sample(q: vec2<f32>) -> f32 {
+    let f = q - vec2<f32>(0.5);
+    let base = floor(f);
+    let t = f - base;
+    let c = i32(base.x);
+    let r = i32(base.y);
+    return cover(
+        mark_bit(c, r), mark_bit(c + 1, r), mark_bit(c, r + 1), mark_bit(c + 1, r + 1), t);
+}
+
+fn model_sample(q: vec2<f32>) -> f32 {
+    let f = q - vec2<f32>(0.5);
+    let base = floor(f);
+    let t = f - base;
+    let c = i32(base.x);
+    let r = i32(base.y);
+    return cover(
+        model_bit(c, r), model_bit(c + 1, r), model_bit(c, r + 1), model_bit(c + 1, r + 1), t);
+}
+
+fn caption_sample(q: vec2<f32>) -> f32 {
+    let f = q - vec2<f32>(0.5);
+    let base = floor(f);
+    let t = f - base;
+    let c = i32(base.x);
+    let r = i32(base.y);
+    return cover(
+        caption_bit(c, r), caption_bit(c + 1, r),
+        caption_bit(c, r + 1), caption_bit(c + 1, r + 1), t);
+}
+
+// Whether a fragment lands on a string's cell box, so the samplers are
+// only paid for where lettering could be.
+fn on_text(q: vec2<f32>, cols: i32, rows: i32) -> bool {
+    return all(q > vec2<f32>(-1.0)) && all(q < vec2<f32>(f32(cols), f32(rows)) + 1.0);
+}
+
+// --- the chin panel ----------------------------------------------------
+//
+// The cabinet below the moulding: the seam it sits on, the panel joints,
+// the engraved model badge, the mark and logotype, and the power lamp.
+fn chin(
+    px: vec2<f32>,
+    case_org: vec2<f32>,
+    case_size: vec2<f32>,
+    moulding_org: vec2<f32>,
+    opening: vec2<f32>,
+    top: f32,
+    base: vec3<f32>,
+) -> vec3<f32> {
+    let h = case_org.y + case_size.y - top;
+    var col = base * 1.02;
+
+    // The seam the moulding sits on: a groove, with the panel's own top
+    // edge catching light just below it.
+    let below = px.y - top;
+    col *= mix(0.46, 1.0, smoothstep(0.0, 0.085 * h, below));
+    col *= 1.0 + 0.07 * smoothstep(0.26 * h, 0.10 * h, below);
+
+    // Vertical joints: the real front is moulded in sections. The power
+    // panel's outer joint meets the tube's own right edge, so the two read
+    // as one design rather than two measurements.
+    let power_right = opening.x + opening.y;
+    let power_left = power_right - 0.066 * case_size.x;
+    let joints = array<f32, 3>(case_org.x + 0.340 * case_size.x, power_left, power_right);
+    for (var i = 0; i < 3; i++) {
+        col *= mix(0.66, 1.0, smoothstep(0.0, 1.5, abs(px.x - joints[i]) - 0.5));
+    }
+
+    let mid = top + h * 0.50;
+
+    // The model badge: its frame starts flush with the moulding's own left
+    // edge, and the lettering sits dead centre in it with a margin either
+    // side just shy of another character's width. Top and bottom it nearly
+    // touches. The margins are quoted against the printed cap height, not
+    // the cell box, so the face's grid does not change the look.
+    let bs = h * 0.38 / MODEL_CAP;
+    let bcap = 0.5 * MODEL_CAP * bs;
+    let ink_w = (MODEL_INK.y - MODEL_INK.x) * bs;
+    let bhalf = vec2<f32>(ink_w * 0.5 + bcap * 1.56, bcap * 1.20);
+    let bc = vec2<f32>(moulding_org.x + bhalf.x, mid);
+    let borg = vec2<f32>(bc.x - ink_w * 0.5 - MODEL_INK.x * bs, mid - bcap);
+    let db = rounded_rect(px - bc, bhalf, bs * 0.8);
+    col *= mix(0.78, 1.0, smoothstep(0.0, 1.4, abs(db) - 0.6));
+    if db < 0.0 {
+        col *= 0.99;
+    }
+    // Gated on the printed height, not the cell size: a finer face has
+    // more cells to the same capital.
+    if 2.0 * bcap >= 7.0 {
+        let q = (px - borg) / bs;
+        if on_text(q, MODEL_COLS, MODEL_ROWS) {
+            // Laid down at full strength so the badge prints the colour it
+            // is given; the glyph's own coverage still softens its edges.
+            col = mix(col, BADGE_INK, model_sample(q));
+        }
+    }
+
+    // The mark and the logotype, where the 1084 wears its maker's badge:
+    // set as one group and centred together.
+    // The mark and the logotype sit a little below the panel's middle and
+    // a little under the badge's size, as the printed one does.
+    let logo_mid = top + h * LOGO_DROP;
+    let ls = h * LOGO_CAP / MARK_CAP;
+    let lw = f32(MARK_COLS) * ls;
+    let mr = h * LOGO_CAP * 0.62;
+    let mark_w = 2.0 * MARK_REACH * mr;
+    let gap = mr * 0.42;
+    let gx = case_org.x + case_size.x * 0.47 - (mark_w + gap + lw) * 0.5;
+    if ls >= 0.6 {
+        let d = px - vec2<f32>(gx + mark_w * 0.5, logo_mid);
+        let m = mark_field(d, mr);
+        if m.x > 0.0 {
+            col = mix(col, copper(m.y), m.x);
+        }
+        let glint = mark_sparks(d, mr);
+        if glint > 0.0 {
+            col = mix(col, SPARK_LIGHT, 0.92 * glint);
+        }
+        let lorg = vec2<f32>(gx + mark_w + gap, logo_mid - 0.5 * MARK_CAP * ls);
+        let q = (px - lorg) / ls;
+        if on_text(q, MARK_COLS, MARK_ROWS) {
+            col = mix(col, INK, 0.95 * mark_sample(q));
+        }
+    }
+
+    // Power: the lamp in its own dark window, with the caption and the
+    // standby mark beneath, in the narrow panel at the right.
+    let pcx = (power_left + power_right) * 0.5;
+    let lamp_c = vec2<f32>(pcx, top + h * 0.24);
+    let lamp_h = max(h * 0.085, 1.0);
+    let win = rounded_rect(px - lamp_c, vec2<f32>(lamp_h * 2.1, lamp_h), lamp_h * 0.4);
+    col = mix(col, LAMP_WELL, 1.0 - smoothstep(-0.7, 0.7, win));
+    let led = rounded_rect(px - lamp_c, vec2<f32>(lamp_h * 1.5, lamp_h * 0.5), lamp_h * 0.25);
+    col = mix(col, LAMP, 1.0 - smoothstep(-0.5, 0.8, led));
+
+    let ps = h * 0.145 / CAPTION_CAP;
+    if ps >= 0.42 {
+        // Below about a cell a pixel the stencil cannot resolve, so it is
+        // let down in weight instead of dropped: a legend too small to
+        // read is still the mark that belongs under the lamp.
+        let weight = 0.7 * mix(0.55, 1.0, smoothstep(0.42, 0.95, ps));
+        let corg = vec2<f32>(pcx - f32(CAPTION_COLS) * ps * 0.5, top + h * 0.46);
+        let q = (px - corg) / ps;
+        if on_text(q, CAPTION_COLS, CAPTION_ROWS) {
+            col = mix(col, LEGEND, weight * caption_sample(q));
+        }
+    }
+
+    // IEC 5009 standby mark: a broken ring with an upright bar.
+    let sr = max(h * 0.13, 1.4);
+    let d = px - vec2<f32>(pcx, top + h * 0.76);
+    let ring = abs(length(d) - sr) - sr * 0.15;
+    let bar = rounded_rect(d + vec2<f32>(0.0, sr * 0.34),
+                           vec2<f32>(sr * 0.14, sr * 0.60), sr * 0.13);
+    var standby = min(ring, bar);
+    if d.y < 0.0 && abs(d.x) < sr * 0.40 {
+        standby = bar;
+    }
+    return mix(col, LEGEND, 0.8 * (1.0 - smoothstep(-0.4, 0.7, standby)));
+}
+
+@fragment
+fn fs_main(in: VOut) -> @location(0) vec4<f32> {
+    let vp = u.size.xy;
+    let px = in.uv * vp;
+
+    // Opening geometry in physical pixels. Everything else on the front
+    // is placed off it, in units of its height.
+    let o_org = u.opening.xy * vp;
+    let o_size = u.opening.zw * vp;
+    let o_half = max(o_size * 0.5, vec2<f32>(1.0));
+    let centre = o_org + o_half;
+    let p = px - centre;
+    let unit = o_size.y;
+
+    // The cabinet fills the display rect, as a monitor's front fills the
+    // window it stands in: every vertical proportion is the design's, and
+    // the slack its narrower shape would have left either side goes into
+    // the side pillars, which is where a real cabinet carries it.
+    let case_org = vec2<f32>(0.0);
+    let case_size = vp;
+    let chin_top = vp.y - FRAME_CHIN * unit;
+
+    // --- the glass contour ---
+    // The same warp as crt.wgsl maps the opening onto the source frame,
+    // where the face is the source rectangle with the tube's rounded
+    // corners, so with the preset's curvature in params.y this distance
+    // coincides with the preset's face boundary exactly -- the moulding
+    // seats the tube whatever its bow -- and at zero curvature it reduces
+    // to a plain rounded opening for the flat presets. Scaling by the
+    // half-width turns source half-width units into approximate pixels;
+    // the warp's local scale varies a few percent around the perimeter, as
+    // a real moulding gap does.
+    let k = u.params.y;
+    let fa = o_half.y / max(o_half.x, 1.0);
+    let cn = p / o_half;
+    let q = k * 0.25;
+    let r2 = cn.x * cn.x + cn.y * cn.y * fa * fa;
+    let m = vec2<f32>(1.0 + q, 1.0 + q * fa * fa);
+    let wc = cn * (1.0 + q * r2) / m;
+    let fh = vec2<f32>(1.0, fa);
+    let gp = wc * fh;
+    let r_aperture = max(APERTURE_RADIUS, u.params.z);
+    let d_glass = rounded_rect(gp, fh, r_aperture) * o_half.x;
+    let n_glass = rounded_rect_grad(gp, fh, r_aperture);
+    let aa = max(fwidth(d_glass), 1e-4);
+
+    // Frame-only pass: a CRT preset has already painted the opening
+    // interior (drawn before this pass, on the opening's bounding box),
+    // so leave every interior fragment to it and repaint just the frame,
+    // whose rounded corners and chamfer must sit on top of the preset's
+    // square viewport -- the plastic overlaps the tube, not the other way
+    // round.
+    if u.params.x > 0.5 && d_glass < 0.0 {
+        discard;
+    }
+
+    // --- the cabinet outline ---
+    // Barely rounded, like the real one: enough to catch the light on a
+    // corner, not enough to read as a lozenge.
+    let c_half = case_size * 0.5;
+    let cp = px - (case_org + c_half);
+    let r_plastic = R_PLASTIC * unit;
+    let d_case = rounded_rect(cp, c_half, r_plastic);
+    let aa_case = max(fwidth(d_case), 1e-4);
+
+    // --- the moulding outline ---
+    // A separate part clipped into the cabinet, its corners echoing the
+    // cabinet's exactly. It keeps its designed run around the tube
+    // whatever the pillars do: inset from the opening by the frame's side
+    // margin less the band the cabinet shows around it, dropped from the
+    // cabinet's top edge by that band, and bottomed by the chin seam.
+    let m_side = (FRAME_SIDE - FRAME_BAND) * unit;
+    let m_org = vec2<f32>(o_org.x - m_side, FRAME_BAND * unit);
+    let m_half = vec2<f32>(o_size.x * 0.5 + m_side, (chin_top - m_org.y) * 0.5);
+    let mp = px - (m_org + m_half);
+    let d_moulding = rounded_rect(mp, m_half, r_plastic);
+
+    // --- the base plastic ---
+    // The cabinet lightens toward the top, where the case rolls over into
+    // its lit top surface, and carries a fine moulding grain throughout.
+    let up = clamp((px.y - case_org.y) / max(case_size.y, 1.0), 0.0, 1.0);
+    let g = 1.0 + 0.018 * grain(floor(px));
+    let case_plastic = CASE * mix(1.06, 0.94, pow(up, 0.75)) * g;
+    let moulding_plastic = MOULDING * mix(1.03, 0.96, up) * g;
+
+    // --- the picture, scaled to fill the opening ---
+    let pic_uv = clamp((in.uv - u.opening.xy) / max(u.opening.zw, vec2<f32>(1e-4)),
+                       vec2<f32>(0.0), vec2<f32>(1.0));
+    let picture = sample_display(pic_uv).rgb;
+
+    // --- the frame surface at this fragment ---
+    var frame: vec3<f32>;
+    if px.y >= chin_top {
+        frame = chin(px, case_org, case_size, m_org,
+                     vec2<f32>(o_org.x, o_size.x), chin_top, case_plastic);
+    } else if d_moulding >= 0.0 {
+        // The cabinet face outside the moulding, and the panel gap the
+        // moulding drops into: a fine dark line, with the cabinet's own
+        // edge catching light just outside it.
+        frame = case_plastic * mix(0.50, 1.0, smoothstep(0.0, 1.8, d_moulding - 0.6));
+        frame *= 1.0 + 0.06 * smoothstep(4.0, 1.8, d_moulding);
+    } else {
+        // Crossing the moulding is measured as a fraction, glass (0) to
+        // gap (1), so the short run below the tube compresses the way the
+        // real part does instead of spilling into the chin.
+        let span = max(d_glass - d_moulding, 1e-3);
+        let t = clamp(d_glass / span, 0.0, 1.0);
+        // The chamfer that holds the tube rolls over into the flat of the
+        // moulding rather than creasing, so the two share one normal that
+        // turns through the join.
+        let roll = smoothstep(CHAMFER_SPAN - 0.04, CHAMFER_SPAN + 0.04, t);
+        let n = normalize(mix(chamfer_normal(n_glass, CHAMFER_SLOPE),
+                              vec3<f32>(0.0, 0.0, 1.0), roll));
+        // Less of the room reaches the foot of the slope than its head.
+        let occ = mix(0.82, 1.0, smoothstep(0.0, CHAMFER_SPAN, t));
+        frame = moulding_plastic * tone(n) * occ;
+        // The cabinet stands proud of the moulding and shades it just
+        // inside the gap.
+        frame *= mix(0.68, 1.0, smoothstep(0.0, 0.026 * unit, -d_moulding));
+        // The contact line where the moulding overlaps the tube.
+        frame *= mix(0.62, 1.0, smoothstep(0.0, 0.008 * unit, d_glass));
+    }
+
+    // The moulded outer edge: the face rolls into shadow just inside the
+    // outline, and outside it is whatever backs the window (the letterbox
+    // black), so the cabinet reads as an object with room behind it.
+    // Whichever edge faces up catches the light coming over the case.
+    let n_case = rounded_rect_grad(cp, c_half, r_plastic);
+    frame *= 1.0 - 0.34 * smoothstep(-0.012 * unit, 0.0, d_case);
+    frame *= 1.0 + 0.42 * max(-n_case.y, 0.0)
+        * smoothstep(-0.018 * unit, -0.004 * unit, d_case);
+
+    // Compose by signed distance: picture, then frame. In the frame-only
+    // pass the inner side of the opening join belongs to the preset
+    // underneath, whose face edge there is its off-face black: blending
+    // from the raw picture instead smears a picture-coloured hairline
+    // around the opening, on top of the preset the pass discarded for.
+    let inner = select(picture, vec3<f32>(0.0), u.params.x > 0.5);
+    var col = mix(inner, frame, clamp(d_glass / aa + 0.5, 0.0, 1.0));
+    col = mix(col, vec3<f32>(0.0), clamp(d_case / aa_case + 0.5, 0.0, 1.0));
+    return vec4<f32>(col, 1.0);
+}

--- a/src/video/window/shaders/bezel_1084.wgsl
+++ b/src/video/window/shaders/bezel_1084.wgsl
@@ -38,13 +38,13 @@ struct BezelUniforms {
     opening: vec4<f32>,
     // x: 1 = frame-only (a CRT preset has already painted the opening;
     // leave its interior untouched), 0 = full (paint the picture too).
-    // y: the active preset's face curvature, faded in with its strength;
-    // the chamfer follows the bowed glass contour it implies, and 0 keeps
-    // the flat rounded opening.
-    // z: the corner radius that preset clips its face to, faded the same
-    // way; the aperture opens to at least this so the moulding covers the
-    // face's own edge. 0 for a preset that does not clip one, or none.
-    // w: reserved, zero.
+    // y: the active preset's face curvature, raw; the chamfer follows the
+    // bowed glass contour it implies, and 0 keeps the flat rounded opening.
+    // z: the corner radius that preset clips its face to, already faded by
+    // its strength (crt.wgsl fades that one linearly); the aperture opens
+    // to at least this so the moulding covers the face's own edge. 0 for a
+    // preset that does not clip one, or none.
+    // w: that strength, which the bow is faded by here.
     params: vec4<f32>,
 };
 
@@ -249,7 +249,7 @@ fn copper(t: f32) -> vec3<f32> {
     let mid = vec3<f32>(0.2519, 0.0578, 0.0168);
     let lo = vec3<f32>(0.0759, 0.0168, 0.0048);
     if t < 0.40 {
-        return mix(top, sheen, smoothstep(0.40, 0.24, t));
+        return mix(top, sheen, 1.0 - smoothstep(0.24, 0.40, t));
     }
     if t < 0.60 {
         return mix(sheen, mid, smoothstep(0.40, 0.60, t));
@@ -453,7 +453,7 @@ fn chin(
     // edge catching light just below it.
     let below = px.y - top;
     col *= mix(0.46, 1.0, smoothstep(0.0, 0.085 * h, below));
-    col *= 1.0 + 0.07 * smoothstep(0.26 * h, 0.10 * h, below);
+    col *= 1.0 + 0.07 * (1.0 - smoothstep(0.10 * h, 0.26 * h, below));
 
     // Vertical joints: the real front is moulded in sections. The power
     // panel's outer joint meets the tube's own right edge, so the two read
@@ -590,13 +590,16 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     // half-width turns source half-width units into approximate pixels;
     // the warp's local scale varies a few percent around the perimeter, as
     // a real moulding gap does.
+    // Faded by mixing coordinates, exactly as crt.wgsl fades its own warp
+    // -- warping by a faded curvature is a different curve, so the two
+    // would drift apart between strengths 0 and 1.
     let k = u.params.y;
     let fa = o_half.y / max(o_half.x, 1.0);
     let cn = p / o_half;
     let q = k * 0.25;
     let r2 = cn.x * cn.x + cn.y * cn.y * fa * fa;
     let m = vec2<f32>(1.0 + q, 1.0 + q * fa * fa);
-    let wc = cn * (1.0 + q * r2) / m;
+    let wc = mix(cn, cn * (1.0 + q * r2) / m, u.params.w);
     let fh = vec2<f32>(1.0, fa);
     let gp = wc * fh;
     let r_aperture = max(APERTURE_RADIUS, u.params.z);
@@ -658,7 +661,7 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
         // moulding drops into: a fine dark line, with the cabinet's own
         // edge catching light just outside it.
         frame = case_plastic * mix(0.50, 1.0, smoothstep(0.0, 1.8, d_moulding - 0.6));
-        frame *= 1.0 + 0.06 * smoothstep(4.0, 1.8, d_moulding);
+        frame *= 1.0 + 0.06 * (1.0 - smoothstep(1.8, 4.0, d_moulding));
     } else {
         // Crossing the moulding is measured as a fraction, glass (0) to
         // gap (1), so the short run below the tube compresses the way the

--- a/src/video/window/shaders/bezel_classic.wgsl
+++ b/src/video/window/shaders/bezel_classic.wgsl
@@ -35,13 +35,13 @@ struct BezelUniforms {
     opening: vec4<f32>,
     // x: 1 = frame-only (a CRT preset has already painted the opening;
     // leave its interior untouched), 0 = full (paint the picture too).
-    // y: the active preset's face curvature, faded in with its strength;
-    // the insert follows the bowed glass contour it implies, and 0 keeps
-    // the flat rounded opening.
-    // z: the corner radius that preset clips its face to, faded the same
-    // way; the opening takes at least this so the plastic covers the
-    // face's own edge. 0 for a preset that does not clip one, or none.
-    // w: reserved, zero.
+    // y: the active preset's face curvature, raw; the insert follows the
+    // bowed glass contour it implies, and 0 keeps the flat rounded opening.
+    // z: the corner radius that preset clips its face to, already faded by
+    // its strength (crt.wgsl fades that one linearly); the opening takes at
+    // least this so the plastic covers the face's own edge. 0 for a preset
+    // that does not clip one, or none.
+    // w: that strength, which the bow is faded by here.
     params: vec4<f32>,
 };
 
@@ -190,13 +190,16 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     // into approximate pixels for the trim widths; the warp's local
     // scale varies a few percent around the perimeter, as a real
     // moulding gap does.
+    // Faded by mixing coordinates, exactly as crt.wgsl fades its own warp
+    // -- warping by a faded curvature is a different curve, so the two
+    // would drift apart between strengths 0 and 1.
     let k = u.params.y;
     let fa = o_half.y / max(o_half.x, 1.0);
     let cn = p / o_half;
     let q = k * 0.25;
     let r2 = cn.x * cn.x + cn.y * cn.y * fa * fa;
     let m = vec2<f32>(1.0 + q, 1.0 + q * fa * fa);
-    let wc = cn * (1.0 + q * r2) / m;
+    let wc = mix(cn, cn * (1.0 + q * r2) / m, u.params.w);
     let fh = vec2<f32>(1.0, fa);
     let d = rounded_rect(wc * fh, fh, max(APERTURE_RADIUS, u.params.z)) * o_half.x;
     let aa = max(fwidth(d), 1e-4);

--- a/src/video/window/shaders/bezel_classic.wgsl
+++ b/src/video/window/shaders/bezel_classic.wgsl
@@ -35,9 +35,13 @@ struct BezelUniforms {
     opening: vec4<f32>,
     // x: 1 = frame-only (a CRT preset has already painted the opening;
     // leave its interior untouched), 0 = full (paint the picture too).
-    // y: the active preset's face curvature; the insert follows the
-    // bowed glass contour it implies, and 0 keeps the flat rounded
-    // opening. zw: reserved, zero.
+    // y: the active preset's face curvature, faded in with its strength;
+    // the insert follows the bowed glass contour it implies, and 0 keeps
+    // the flat rounded opening.
+    // z: the corner radius that preset clips its face to, faded the same
+    // way; the opening takes at least this so the plastic covers the
+    // face's own edge. 0 for a preset that does not clip one, or none.
+    // w: reserved, zero.
     params: vec4<f32>,
 };
 
@@ -86,11 +90,13 @@ fn grain(p: vec2<f32>) -> f32 {
 // The front-face plastic, a warm Commodore grey (linear light).
 const PLASTIC: vec3<f32> = vec3<f32>(0.585, 0.560, 0.500);
 
-// Rounded screen corners as a fraction of the display half-width, the
-// 1084 tube's R 11,6 mm arcs on its 280,8 mm screen. Must match
-// crt.wgsl's CORNER_RADIUS so the insert seats the preset's face
-// exactly; a test pins the two sources together.
-const CORNER_RADIUS: f32 = 0.0826;
+// The opening's corners as a fraction of the display half-width: the 1084
+// tube's R 11,6 mm arcs on its 280,8 mm screen, which is also the radius
+// crt.wgsl clips its face to. Where a preset clips one, the opening takes
+// the wider of the two -- the plastic overlaps the glass, so it must never
+// cut inside the face and leave its edge showing in the corners. A test
+// holds every bezel source to that.
+const APERTURE_RADIUS: f32 = 0.0826;
 
 // "Copperline" logotype for the bottom band: 5x8-pixel glyphs one column
 // apart (baseline row 6, the p descenders on row 7), 59x8 bits in all.
@@ -192,7 +198,7 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     let m = vec2<f32>(1.0 + q, 1.0 + q * fa * fa);
     let wc = cn * (1.0 + q * r2) / m;
     let fh = vec2<f32>(1.0, fa);
-    let d = rounded_rect(wc * fh, fh, CORNER_RADIUS) * o_half.x;
+    let d = rounded_rect(wc * fh, fh, max(APERTURE_RADIUS, u.params.z)) * o_half.x;
     let aa = max(fwidth(d), 1e-4);
 
     // Frame-only pass: a CRT preset has already painted the opening

--- a/src/video/window/shaders/crt.wgsl
+++ b/src/video/window/shaders/crt.wgsl
@@ -82,7 +82,9 @@ const GRILLE_BOOST: f32 = 1.25;
 
 // Rounded screen corners, as a fraction of the display half-width: the
 // 1084's tube has R 11,6 mm corner arcs on a 280,8 mm wide screen
-// (11,6 / 140,4).
+// (11,6 / 140,4). `crt_shader::FACE_CORNER_RADIUS` mirrors this so the
+// bezel can open its aperture wide enough to cover this face; a test pins
+// the two together.
 const CORNER_RADIUS: f32 = 0.0826;
 
 // The glass is never black: room light reflects off the face and the

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2953,7 +2953,7 @@ fn test_app_with_audio_cpu_and_program(
         0.0,
         crate::config::ShaderMode::None,
         1.0,
-        false,
+        crate::config::BezelStyle::None,
         false,
         crate::config::Tint::None,
         false,


### PR DESCRIPTION
## Monitor bezel: add a 1084 style, and make the frame a choice

The bezel was one frame, on or off. It's now a style, so the new 1084 can sit beside the original rather than replace it.

**1084** — drawn (as close as possible) from a photo of a real cabinet: two-tone, tube sunk behind a chamfer, chin panel with the model badge, Copperline mark and wordmark, and a red power lamp.

**Framework** — a style is a `shaders/bezel_*.wgsl` source plus the opening it leaves, so adding one is a file and two match arms. The pass, uniforms and bindings are shared; a style's pipeline compiles the first time it's drawn.

**Surface** — `[display] bezel = "off" | "1084" | "classic"` (the old boolean still reads, `true` = 1084). *Video Settings → Monitor Bezel* picks the front; the launcher row cycles it. `Cmd`/`Alt`+`M` is an on-off for whichever is chosen and never changes which — that submenu is also the fix for the bezel being unreachable from the menu at all, which is where this started.

### Also

- Every bezel source now opens its aperture to `max(own, preset face)`, and gets the preset's bow and face radius faded by shader strength. A frame narrower than the glass it overlaps left the CRT preset's off-face black showing in the corners; below full strength the moulding followed a fully-bowed face.
- A canvas-height change made while fullscreen couldn't size the window, and the window returned at the old size — which was then read as a manual drag and remembered, stranding the picture letterboxed. The snap now defers until fullscreen gives the window back.

`cargo test` 2254 passed, clippy and fmt clean. Both styles verified through the real shaders via the preview dump.

<img width="719" height="616" alt="Screenshot 2026-08-07 at 21 27 40" src="https://github.com/user-attachments/assets/628af18b-fcf9-4054-9672-be4fb8304c5e" />
<img width="718" height="613" alt="Screenshot 2026-08-07 at 21 27 32" src="https://github.com/user-attachments/assets/a0d49030-2f02-4d37-bbc5-2153425a38e8" />
