### PR TITLE
crt: straighten the raster, the bow belongs to the glass

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -4830,11 +4830,14 @@ void main() {
 }
 `;
 
-  // The CRT preset, ported from shaders/crt.wgsl: a bowed tube face,
-  // scanlines that bow with it, an aperture grille and a corner vignette,
-  // faded in together by the strength knob. See the WGSL source for the
-  // derivations (tube geometry from the 1084's Philips M34EAQ10X
-  // datasheet); comments here mark web-port differences only.
+  // The CRT preset, ported from shaders/crt.wgsl: a bowed tube face
+  // cropping a straight raster, scanlines, an aperture grille and a
+  // corner vignette, faded in together by the strength knob. The picture
+  // and scanlines sample the straight coordinate -- a real monitor's
+  // deflection is corrected so the raster is rectilinear on the curved
+  // glass -- and the warp shapes only the face silhouette. See the WGSL
+  // source for the derivations (tube geometry from the 1084's Philips
+  // M34EAQ10X datasheet); comments here mark web-port differences only.
   const FS_CRT = `#version 300 es
 ${FS_COMMON}
 uniform vec4 u_params;  // x: strength, y: scanline count, z: mask kind, w: curvature
@@ -4861,10 +4864,10 @@ void main() {
   vec2 uv = clamp(v_uv, 0.0, 1.0);
   float aspect = u_size.y / max(u_size.x, 1.0);
   vec2 wuv = mix(uv, warp(uv, u_params.w, aspect), strength);
-  vec3 base = sample_display(wuv);
+  vec3 base = sample_display(uv);
 
   float lines = max(u_params.y, 1.0);
-  float profile = 0.5 - 0.5 * cos(TAU * wuv.y * lines);
+  float profile = 0.5 - 0.5 * cos(TAU * uv.y * lines);
   float scan = (FLOOR + (1.0 - FLOOR) * profile) * SCAN_BOOST;
 
   vec2 px = uv * u_size.xy;

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -585,17 +585,20 @@ look a phosphor trail on its own cannot give. Three presets are built in:
   size whatever the Amiga resolution behind it, again
   brightness-compensated.
 - `"crt"` -- the lot, in the spirit of the 1084 the Amiga shipped with: a
-  bowed tube face, scanlines that follow the bow, an aperture grille, and a
-  corner vignette, all faded in together. The face geometry is taken from
-  the datasheet of the 1084's picture tube (the Philips M34EAQ10X): the
-  bow reproduces its published screen-edge arcs -- the top and bottom
-  edges bow about twice as far as the sides, as they do on the real
-  screen -- and the corners are rounded at the scale of its 11.6 mm
-  corner arcs. The picture overscans the face like the real raster
-  overscans the glass, filling it to the edges with the bow deepening the
-  crop toward the rounded corners, and on-face black is lifted by a faint
-  glass glow, the room light a real tube reflects, so the face keeps its
-  silhouette even when the picture is dark.
+  bowed tube face, scanlines, an aperture grille, and a corner vignette,
+  all faded in together. The face geometry is taken from the datasheet of
+  the 1084's picture tube (the Philips M34EAQ10X): the bow reproduces its
+  published screen-edge arcs -- the top and bottom edges bow about twice
+  as far as the sides, as they do on the real screen -- and the corners
+  are rounded at the scale of its 11.6 mm corner arcs. The bow shapes
+  only the face outline, not the picture: a real monitor's deflection is
+  corrected so the raster stays rectilinear on the curved glass, and
+  straight content stays straight here too. The picture overscans the
+  face like the real raster overscans the glass, filling it to the
+  edges, with the bowed outline deepening the crop toward the rounded
+  corners, and on-face black is lifted by a faint glass glow, the room
+  light a real tube reflects, so the face keeps its silhouette even when
+  the picture is dark.
 
 `"none"` (the default; `"off"` is accepted for the same thing) presents the
 picture untouched, and any value ending in `.wgsl` is the path of a shader

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -641,18 +641,20 @@ selection, not a compile.
 than to its edge. On the boundary a linear tap is a 50/50 blend with the
 texel on the far side, which along the bottom edge is the status bar's
 separator hairline; that reaches the picture whenever the display rect is
-magnified (the last fragment row lands past the last texel centre) or a
-preset's curvature warps a coordinate off the face.
+magnified (the last fragment row lands past the last texel centre).
 
-The `crt` preset's bowed face ends at a hard edge: what the bow carries off
-the face is the unlit inside of the tube, opaque black at any strength, and
-only the *area* of that region scales with strength (through the warped
-coordinate, so strength 0 has no off-face region at all and the no-op
-invariant holds). Mixing the black back toward the sample instead would
-leave the region holding a fraction of the edge colour the clamp smears
-there. The boundary is faded to black over about one pixel, keyed to
-`fwidth` of the signed distance to the face, so the curve does not
-staircase.
+The `crt` preset's curvature bows only the face outline, never the
+picture: a real monitor's deflection is corrected so the raster is
+rectilinear on the curved glass, so the picture (and its scanlines) is
+sampled straight and the warped coordinate feeds only the face's signed
+distance. What lies outside the bowed outline is the unlit inside of the
+tube, opaque black at any strength, and only the *area* of that region
+scales with strength (through the warped coordinate, so strength 0 has no
+off-face region at all and the no-op invariant holds). Mixing the black
+back toward the sample instead would leave the region holding a fraction
+of the edge colour the clamp smears there. The boundary is faded to black
+over about one pixel, keyed to `fwidth` of the signed distance to the
+face, so the curve does not staircase.
 
 The scanline count is what the window actually shows, not what the
 framebuffer holds (`crt_scanline_count`). The TV-aperture present path

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -924,6 +924,16 @@ fn fs_main() -> @location(0) vec4<f32> {
         queue: &wgpu::Queue,
         display: [u8; 4],
     ) -> wgpu::Texture {
+        pattern_source(device, queue, |_, _| display)
+    }
+
+    /// Like `source_texture`, but the display region is painted per texel
+    /// by `pattern(x, y)`; the "status bar" rows stay magenta.
+    fn pattern_source(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        pattern: impl Fn(u32, u32) -> [u8; 4],
+    ) -> wgpu::Texture {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("crt_shader_test_src"),
             size: wgpu::Extent3d {
@@ -942,7 +952,7 @@ fn fs_main() -> @location(0) vec4<f32> {
         for y in 0..TEX {
             for x in 0..TEX {
                 let px = if y < DISPLAY_ROWS {
-                    display
+                    pattern(x, y)
                 } else {
                     [255, 0, 255, 255]
                 };
@@ -1175,10 +1185,12 @@ fn fs_main() -> @location(0) vec4<f32> {
         }
     }
 
-    /// The bowed face of the CRT preset pushes sample coordinates past the
-    /// bottom of the display rect. At full strength those pixels are
-    /// blacked out anyway, but at an intermediate strength they are only
-    /// partly dimmed, so anything the clamp picked up shows through.
+    /// The CRT preset's face silhouette runs coordinates past the bottom
+    /// of the display rect, and the picture itself must be sampled
+    /// straight. If a regression routed sampling back through the warped
+    /// frame, at full strength the off-face pixels are blacked out anyway,
+    /// but at an intermediate strength they are only partly dimmed, so
+    /// anything the clamp picked up shows through.
     #[test]
     fn the_crt_warp_never_reaches_the_status_bar() {
         let Some(gpu) = gpu() else {
@@ -1362,6 +1374,71 @@ fn fs_main() -> @location(0) vec4<f32> {
                 "{name} corner ({corner:.1}) should be well below the centre ({centre:.1})"
             );
         }
+    }
+
+    /// A CRT's deflection is corrected so the raster is rectilinear on the
+    /// curved glass: straight content stays straight to the eye, and only
+    /// the face outline bows (the 1084 photo on issue #413). A horizontal
+    /// stripe must therefore peak on the same output row in every lit
+    /// column -- the face crop may swallow it near the corners, never
+    /// bend it.
+    #[test]
+    fn the_crt_raster_stays_rectilinear() {
+        let Some(gpu) = gpu() else {
+            return;
+        };
+        let (device, queue) = (gpu.device(), gpu.queue());
+        // A white stripe on black across source rows 4..8, well inside the
+        // top of the display region so the old sampling bow (about three
+        // output rows of displacement at 2x) would be unmistakable.
+        let src = pattern_source(device, queue, |_, y| {
+            if (4..8).contains(&y) {
+                [255, 255, 255, 255]
+            } else {
+                [0, 0, 0, 255]
+            }
+        });
+        let mut shader = CrtShader::new(device, FORMAT);
+        let frame = render_preset(
+            device,
+            queue,
+            &mut shader,
+            &src,
+            ShaderKind::Crt,
+            1.0,
+            16.0,
+            2,
+        );
+
+        // Per column, the brightest row in the top half of the display.
+        // Scanlines and the grille modulate brightness but are constant
+        // per row and per column respectively, so the peak row tracks
+        // where the stripe landed. Columns the face crop darkened past
+        // recognition are skipped.
+        let mut peaks: Vec<u32> = Vec::new();
+        for x in 0..frame.dim {
+            let mut best = (0.0f32, 0u32);
+            for y in 0..frame.rows / 2 {
+                let l = Frame::luma(frame.at(x, y));
+                if l > best.0 {
+                    best = (l, y);
+                }
+            }
+            if best.0 > 60.0 {
+                peaks.push(best.1);
+            }
+        }
+        assert!(
+            peaks.len() > (frame.dim / 2) as usize,
+            "the stripe should stay lit across most of the face, got {} columns",
+            peaks.len()
+        );
+        let lo = *peaks.iter().min().unwrap();
+        let hi = *peaks.iter().max().unwrap();
+        assert!(
+            hi - lo <= 1,
+            "a horizontal stripe bowed: peak rows span {lo}..={hi}"
+        );
     }
 
     /// The tube face ends at a hard edge: what the bow pushed off it is

--- a/src/video/window/shaders/crt.wgsl
+++ b/src/video/window/shaders/crt.wgsl
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // Full CRT preset, in the spirit of the 1084 the Amiga shipped with: a
-// bowed tube face, scanlines that bow with it, an aperture grille and a
-// corner vignette, all faded in together by the one strength knob.
+// bowed tube face cropping a straight raster, scanlines, an aperture
+// grille and a corner vignette, all faded in together by the one
+// strength knob.
 //
 // The block between the two "shared contract" markers below is the
 // Copperline window-shader contract, byte-identical in every preset and
@@ -94,27 +95,29 @@ const CORNER_RADIUS: f32 = 0.0826;
 // the true black beyond the glass even when the picture itself is dark.
 const GLASS_GLOW: f32 = 0.01;
 
-// Barrel distortion about the centre of the display rect, matched to the
-// 1084's tube (Philips M34EAQ10X, 1986 Philips T08 databook): the face is
-// a section of a sphere (R 640 mm centre blending to R 530 mm at the
-// edge), and the datasheet draws the useful screen (280,8 x 210,6 mm)
-// with barrel-arced edges, R 1545 mm top and bottom, R 1173 mm at the
-// sides. Depth on the face grows with *physical* distance from the
-// centre, so in display-normalised coordinates the y term is weighted by
-// the viewport aspect squared (aspect = height/width, so the weight is
-// *below* one). The bow of an edge comes from how r2 varies while
-// travelling along it: the top edge sweeps the full unweighted x term
-// while a side edge sweeps only the down-weighted y term, so weighting y
-// down bows the top/bottom edges roughly (w/h)^2 as far as the sides --
-// exactly the relation of the datasheet arcs -- and k = 0.30 reproduces
-// the arcs' curvature.
+// The bowed outline of the glass, matched to the 1084's tube (Philips
+// M34EAQ10X, 1986 Philips T08 databook): the face is a section of a
+// sphere (R 640 mm centre blending to R 530 mm at the edge), and the
+// datasheet draws the useful screen (280,8 x 210,6 mm) with barrel-arced
+// edges, R 1545 mm top and bottom, R 1173 mm at the sides. Depth on the
+// face grows with *physical* distance from the centre, so in
+// display-normalised coordinates the y term is weighted by the viewport
+// aspect squared (aspect = height/width, so the weight is *below* one).
+// The bow of an edge comes from how r2 varies while travelling along it:
+// the top edge sweeps the full unweighted x term while a side edge
+// sweeps only the down-weighted y term, so weighting y down bows the
+// top/bottom edges roughly (w/h)^2 as far as the sides -- exactly the
+// relation of the datasheet arcs -- and k = 0.30 reproduces the arcs'
+// curvature.
 //
-// The raster overscans the face, as on the real monitor: the per-axis
-// normalisation rescales the bowed field so the source edge lands exactly
-// on the face's mid-edges. The picture therefore fills the whole face --
-// no black ring between picture and face edge -- and the bow shows as the
-// crop deepening toward the corners, where the source content falls into
-// the rounded-corner clip instead of the visible glass.
+// The warp shapes only the face silhouette that crops the picture; the
+// picture itself is sampled straight. The monitor's deflection is
+// corrected so the raster is rectilinear on the curved glass -- on a
+// real 1084 straight content stays straight to the eye -- and the raster
+// overscans the face, so the visible edge of the picture is the glass
+// boundary: flush at the mid-edges, with the crop deepening toward the
+// corners, where content falls off the barrel-arced outline instead of
+// the visible glass.
 fn warp(uv: vec2<f32>, k: f32, aspect: f32) -> vec2<f32> {
     let c = uv * 2.0 - vec2<f32>(1.0);
     let r2 = c.x * c.x + c.y * c.y * aspect * aspect;
@@ -130,14 +133,16 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     // Height over width of the display rect on screen, for warp and
     // corner geometry that must be circular in physical pixels.
     let aspect = u.size.y / max(u.size.x, 1.0);
-    // Curvature fades in with strength, so strength 0 samples straight
-    // through and every later term collapses to the plain sample.
+    // The picture is sampled straight: deflection correction keeps the
+    // raster rectilinear on the real monitor, so only the face outline
+    // below bows. The warped coordinate fades in with strength, keeping
+    // the strength-0 no-op.
     let wuv = mix(uv, warp(uv, u.params.w, aspect), strength);
-    let base = sample_display(wuv);
+    let base = sample_display(uv);
 
-    // Scanlines follow the bowed geometry.
+    // Scanlines follow the raster, which is straight.
     let lines = max(u.params.y, 1.0);
-    let profile = 0.5 - 0.5 * cos(TAU * wuv.y * lines);
+    let profile = 0.5 - 0.5 * cos(TAU * uv.y * lines);
     let scan = (FLOOR + (1.0 - FLOOR) * profile) * SCAN_BOOST;
 
     // The grille sits on the glass, so it is keyed to physical pixels of
@@ -157,23 +162,24 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
 
     let shaded = mix(base.rgb, base.rgb * scan * grille * vig, strength);
 
-    // Anything the bow pushed off the face is the unlit inside of the
-    // tube, and a real face ends at a hard edge: off-face pixels are
-    // opaque black whatever the strength. Only the *area* of the region
-    // scales, and it already does, through wuv above -- at strength 0 the
-    // bow is flat, nothing falls off the face, and the no-op invariant
-    // holds. Mixing the black back toward `shaded` instead would fill the
-    // region with a fraction of the edge colour the sampler smears there.
+    // Anything outside the barrel-arced face outline is the unlit inside
+    // of the tube, and a real face ends at a hard edge: off-face pixels
+    // are opaque black whatever the strength. Only the *area* of the
+    // region scales, and it already does, through wuv above -- at
+    // strength 0 the bow is flat, nothing lies off the face, and the
+    // no-op invariant holds. Mixing the black back toward `shaded`
+    // instead would fill the region with a fraction of the edge colour
+    // the sampler smears there.
     //
     // The face is a rounded rectangle, not a sharp one: the corner arcs
     // are CORNER_RADIUS of the half-width, like the tube's R 11,6 mm
-    // screen corners. The distance is measured in the warped source frame
-    // (the corner is a property of the screen surface, seen through the
-    // same projection as the picture) and in half-width units on both
-    // axes, so the arc stays circular on screen instead of stretching
-    // with the display aspect. The radius fades with strength like the
-    // bow does, keeping the strength-0 no-op; at radius 0 the expression
-    // reduces to the plain rectangle distance.
+    // screen corners. The distance is measured in the warped frame --
+    // `wuv` runs off the rect toward the screen corners, which is what
+    // bows the silhouette's edges outward on screen -- and in half-width
+    // units on both axes, so the arc stays circular on screen instead of
+    // stretching with the display aspect. The radius fades with strength
+    // like the bow does, keeping the strength-0 no-op; at radius 0 the
+    // expression reduces to the plain rectangle distance.
     //
     // d is a signed distance to the face, positive outside; fwidth
     // rescales it to pixels, so the fade covers about one pixel and the


### PR DESCRIPTION
Fixes #413.

A real 1084 corrects its deflection so the raster is rectilinear on the curved tube face: straight content stays straight to the eye, and only the glass outline bows, as the issue's photo shows. The `crt` preset was sampling the picture -- and keying its scanlines -- through the barrel warp, bending the graphics.

## What changed

- `crt.wgsl` samples the picture and keys the scanlines to the straight coordinate. `warp()` now feeds only the face-silhouette SDF: the curvature (k = 0.30, from the Philips M34EAQ10X datasheet edge arcs) still shapes the glass edge, so the bow shows as the crop deepening toward the corners over a straight raster, flush at the mid-edges with no black ring. The strength-0 no-op invariant and the bezel's opening contour (shared warp math via uniforms) are untouched, so the moulded insert still seats the face exactly.
- New regression test `the_crt_raster_stays_rectilinear`: a horizontal stripe must peak on the same output row in every lit column -- the face crop may swallow it near the corners, never bend it. Verified as a negative control: the old shader fails it with the stripe spanning three rows. Small `pattern_source` test helper added for per-texel source patterns.
- Docs: the `"crt"` bullet in `docs/guide/configuration.md` and the shader-pass section of `docs/internals/video.md` now describe the straight raster. The /try page renders through a WebGL2 GLSL port of the preset (FS_CRT in try.js), not the compiled WGSL -- review caught that the first commit missed it; the port now mirrors the straight-coordinate change line for line.

## Verification

- Full lib suite: 2268 passed.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.
- Existing face-edge, corner-darkening, and bezel contour-agreement tests pass unchanged.
- Crosshatch preview via `dump_bezel_preview_png`: grid lines dead straight, glass outline still arcs, bezel nests as before.
