### PR TITLE
Fix the two AGA games from #416: banked CPU palette writes and out-of-range playfield priority

### DIFF
--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -142,6 +142,10 @@ cannot change at runtime (see [](../internals/architecture)).
   channel is the signature of a stale display latch: the shadow shows what
   software last wrote, the hardware view what Denise would actually
   serialize, and the latter drives the DMA-idle latched redisplay.
+  `COPPERLINE_DBG_FRAMESTATE_FULLPAL=1` extends the palette line to all 256
+  AGA entries as 24-bit colours, sixteen per row -- whole banks unexpectedly
+  black is the signature of banked COLOR writes not landing where BPLCON3
+  aimed them.
 
 ## Diagnostic knobs
 
@@ -165,6 +169,7 @@ authoritative list. The most useful ones:
 | `COPPERLINE_DIAG_DISPLAY` | Display-register change log |
 | `COPPERLINE_DIAG_CAPROW` | `=all`, `=V`, or `=START:END`: per-line bitplane capture state at DDF start, including DMACON, current and DDF-anchor BPLCON0, FMODE/DIW/DDF, effective fetch window, unit/period/quantum, words/row, modulos, and all BPLxPTs -- separates wrong-pointer from wrong-decode display bugs |
 | `COPPERLINE_DIAG_PALETTE_ROW` | `=all`, `=V`, or `=START:END`: log beam-timed COLOR writes for selected beam lines, including source, framebuffer x, palette entry, LOCT, value, and BPLCON3; the setting is cached after first use |
+| `COPPERLINE_DIAG_PALSTORE` | Log every COLOR and BPLCON3 write as the register store applies it: beam position, CPU/Copper source, value, the BPLCON3 latch decoding the write, the resolved AGA palette entry, and the entry's pre-write 24-bit colour -- the store-side companion of `COPPERLINE_DIAG_PALETTE_ROW` (which shows the render replay's view of the same writes) |
 | `COPPERLINE_DIAG_HAM_PIXELS` | `=BEAMY,X0,X1[,STEP]`: sample DMA playfield HAM pixels on one beam line, including framebuffer/native x, selected bitplane index, active/fetched state, HAM hold colour before/after, output latch, plane count, fetched width, BPLCON1 delays, DIW/DDF, and display window; pairs with `COPPERLINE_DBG_AFTER` / `COPPERLINE_DBG_UNTIL` and is cached after first use |
 | `COPPERLINE_DIAG_MANUAL_BPL_PIXELS` | `=BEAMY,X0,X1[,STEP]`: sample CPU/Copper BPLDAT replay pixels on one beam line, including source x/native bit, selected index, HAM seed/output state, output latch, BPLCON0/BPLCON1, and display window; cached after first use |
 | `COPPERLINE_DIAG_FRAME_PIXELS` | `=BEAMY,X0,X1[,STEP]`: sample final framebuffer pixels after playfield, manual BPLDAT replay, sprites, and final blanking so post-decode overwrites can be isolated; cached after first use |

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -201,6 +201,26 @@ bits are gated on the AGA revision; pre-AGA chips never carry bitplanes
 7/8 and keep the exact three-bit decode. Denise state is not rendered live
 -- writes become beam events that the [video pipeline](video) replays.
 
+BPLCON2's PF1P/PF2P priority codes behave differently on the two chip
+generations, and the split is where the evidence is. Denise draws a dual
+playfield field transparent when its code is programmed out of range (5-7):
+the winning field collapses to the background instead of revealing the
+field behind it. That is photographed on an A500 (vAmigaTS
+Denise/Registers/BPLCON0/invprio1 runs PF2 code 7 and the real machine
+shows background between the bars).
+
+Lisa does not inherit it. Alfred Chicken runs its whole in-game display at
+BPLCON2 = 0x003F -- both codes 7 -- and draws an eight-plane dual playfield
+on real AGA hardware, which the Denise rule would blank to the background
+colour. The quirk reached us from an OCS/ECS-only reference, so it never
+carried evidence about Lisa in the first place; WinUAE, which does model
+AGA, resolves the playfield colour from the plane bits alone and uses the
+codes only to mask sprites. On both chips the code still saturates in the
+sprite comparison, where it counts the sprite pairs passing in front of the
+playfield: 101/110/111 behave as 100. No AGA photo of invprio1 exists yet
+to confirm Lisa ignores out-of-range codes entirely rather than differing
+some other way.
+
 The ECS DIWHIGH high bits only stay in force until the next DIWSTRT or
 DIWSTOP write, which re-arms the OCS-implicit high bits derived from the
 low DIWSTRT/DIWSTOP values. Software that programmed a wide window through

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -1037,6 +1037,17 @@ impl Bus {
                 false
             }
             0x106 => {
+                if crate::envcfg::flag("COPPERLINE_DIAG_PALSTORE") {
+                    log::info!(
+                        "palstore f={} v={} h={} src={} BPLCON3={:#06X} enabled={}",
+                        self.emulated_frames,
+                        self.agnus.vpos,
+                        self.agnus.hpos,
+                        beam_write_source_name(source),
+                        val,
+                        self.bplcon3_write_enabled(),
+                    );
+                }
                 // ECS Denise only latches BPLCON3 while BPLCON0 bit 0
                 // (ENBPLCN3/ECSENA) is set; OCS Denise has no BPLCON3.
                 if self.bplcon3_write_enabled() {
@@ -1229,6 +1240,23 @@ impl Bus {
                         source
                     };
                     self.record_render_write(off, val, render_source);
+                    if crate::envcfg::flag("COPPERLINE_DIAG_PALSTORE") {
+                        let bank =
+                            crate::chipset::denise::Palette::bank_from_bplcon3(self.denise.bplcon3);
+                        let entry = bank * 32 + (idx & 31);
+                        log::info!(
+                            "palstore f={} v={} h={} src={} COLOR{:02}={:#06X} bplcon3={:#06X} entry={} pre={:#08X}",
+                            self.emulated_frames,
+                            self.agnus.vpos,
+                            self.agnus.hpos,
+                            beam_write_source_name(source),
+                            idx,
+                            color,
+                            self.denise.bplcon3,
+                            entry,
+                            self.denise.palette.rgb24(entry),
+                        );
+                    }
                     if self.denise_is_lisa() {
                         // AGA: BPLCON3 BANK/LOCT route the write into the
                         // 256-entry store. Bank 0 with LOCT clear is the

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -1503,6 +1503,10 @@ impl Bus {
         };
         if matches!(source, BeamWriteSource::CpuCopperIrq)
             && matches!(offset & 0x01FE, 0x180..=0x1BE)
+            // Same scoping as write_cpu_palette_snapshot: only bank-0
+            // LOCT-clear writes belong to the split-palette pattern the
+            // bottom-palette replay reconstructs.
+            && self.cpu_palette_write_bank_loct() == (0, false)
         {
             let (target_vpos, target_hpos) = self.cpu_palette_target_beam.unwrap_or((vpos, hpos));
             if target_vpos >= CPU_COPPER_BOTTOM_PALETTE_MIN_VPOS {
@@ -1667,28 +1671,58 @@ impl Bus {
         }
     }
 
+    /// BPLCON3 BANK/LOCT routing for a CPU COLORxx write, as Lisa decodes
+    /// it. Pre-AGA Denise has no banking: everything lands on bank 0 with
+    /// both nibble planes written.
+    pub(super) fn cpu_palette_write_bank_loct(&self) -> (usize, bool) {
+        if self.denise_is_lisa() {
+            (
+                crate::chipset::denise::Palette::bank_from_bplcon3(self.denise.bplcon3),
+                crate::chipset::denise::Palette::loct_from_bplcon3(self.denise.bplcon3),
+            )
+        } else {
+            (0, false)
+        }
+    }
+
     pub(super) fn write_cpu_palette_snapshot(&mut self, idx: usize, color: u16) {
+        // Lisa decodes every COLORxx write against the BPLCON3 latch standing
+        // at the write (BANK selects the 32-entry block, LOCT the nibble
+        // half), so the CPU-write shadow must decode identically: resolving
+        // bank-blind would collapse a banked palette upload onto entries
+        // 0..31, and a frame later seeded from this shadow would show bank 0
+        // holding the last-written bank with every other bank black.
+        let (bank, loct) = self.cpu_palette_write_bank_loct();
         let target = self.cpu_palette_target;
         match target {
             CpuPaletteTarget::Top => {
-                self.beam_top_palette.write_ocs(idx, color);
+                self.beam_top_palette.write_banked(bank, idx, loct, color);
             }
             CpuPaletteTarget::Bottom => {
-                self.beam_top_palette.write_ocs(idx, color);
-                let target_vpos = self
-                    .cpu_palette_target_beam
-                    .map(|(vpos, _)| vpos)
-                    .unwrap_or(self.agnus.vpos);
-                if target_vpos >= CPU_COPPER_BOTTOM_PALETTE_MIN_VPOS {
-                    self.beam_bottom_palette.write_ocs(idx, color);
-                    self.beam_bottom_palette_valid = true;
-                }
-                self.cpu_palette_target_writes = self.cpu_palette_target_writes.saturating_add(1);
-                if idx == 15 || idx == 31 || self.cpu_palette_target_writes >= 16 {
-                    self.commit_pending_bottom_palette_events();
-                    self.cpu_palette_target = CpuPaletteTarget::Top;
-                    self.cpu_palette_target_writes = 0;
-                    self.cpu_palette_target_beam = None;
+                self.beam_top_palette.write_banked(bank, idx, loct, color);
+                // The bottom-palette reconstruction models the classic
+                // split-palette pattern: a copper interrupt near the display
+                // bottom whose handler rewrites the OCS-visible palette
+                // (bank 0, LOCT clear). A banked or low-nibble AGA write is
+                // not that pattern; letting one latch the bottom palette
+                // would replay wrong values into carry-forward frames.
+                if bank == 0 && !loct {
+                    let target_vpos = self
+                        .cpu_palette_target_beam
+                        .map(|(vpos, _)| vpos)
+                        .unwrap_or(self.agnus.vpos);
+                    if target_vpos >= CPU_COPPER_BOTTOM_PALETTE_MIN_VPOS {
+                        self.beam_bottom_palette.write_ocs(idx, color);
+                        self.beam_bottom_palette_valid = true;
+                    }
+                    self.cpu_palette_target_writes =
+                        self.cpu_palette_target_writes.saturating_add(1);
+                    if idx == 15 || idx == 31 || self.cpu_palette_target_writes >= 16 {
+                        self.commit_pending_bottom_palette_events();
+                        self.cpu_palette_target = CpuPaletteTarget::Top;
+                        self.cpu_palette_target_writes = 0;
+                        self.cpu_palette_target_beam = None;
+                    }
                 }
             }
         }

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -2976,6 +2976,54 @@ fn cpu_palette_writes_snapshot_top_and_status_palettes_by_interrupt_source() {
 }
 
 #[test]
+fn cpu_palette_snapshot_routes_aga_banked_writes_by_bplcon3() {
+    // Lisa decodes every COLORxx write against the BPLCON3 latch standing at
+    // the write: BANK (bits 15-13) selects the 32-entry block and LOCT
+    // (bit 9) the nibble half. The CPU-write shadow palette must decode the
+    // same way, or an 8-bank CPU palette upload (Bubble and Squeak's level
+    // fade) collapses onto entries 0..31: bank 0 ends up holding the
+    // last-written bank and a frame later seeded from the shadow shows every
+    // other bank black.
+    let mut bus = empty_bus();
+    bus.set_chipset_revisions(AgnusRevision::AgaAlice, DeniseRevision::AgaLisa);
+
+    // Bank 0 high nibbles, then low nibbles via LOCT.
+    assert!(!bus.custom_write(0x106, 2, 0x0000));
+    assert!(!bus.custom_write(0x182, 2, 0x0123));
+    assert!(!bus.custom_write(0x106, 2, 0x0200));
+    assert!(!bus.custom_write(0x182, 2, 0x0456));
+    // Bank 1 (BPLCON3 BANK=001): must land on entry 33, not entry 1.
+    assert!(!bus.custom_write(0x106, 2, 0x2000));
+    assert!(!bus.custom_write(0x182, 2, 0x0789));
+
+    assert_eq!(bus.beam_top_palette[1], 0x0123, "bank 0 high word");
+    assert_eq!(
+        bus.beam_top_palette.rgb24(1),
+        0x14_25_36,
+        "bank 0 24-bit colour from high+low nibble writes"
+    );
+    assert_eq!(bus.beam_top_palette[33], 0x0789, "bank 1 entry");
+
+    // A banked write inside a copper-interrupt window is not the OCS
+    // split-palette pattern: it must not latch the bottom palette or record
+    // replay events.
+    bus.agnus.vpos = 0xD4;
+    bus.delivered_irq_pending = INT_COPER;
+    assert!(!bus.custom_write(0x09C, 2, INT_COPER as u64));
+    assert!(!bus.custom_write(0x184, 2, 0x0AAA));
+    assert_eq!(bus.beam_top_palette[34], 0x0AAA);
+    assert!(!bus.beam_bottom_palette_valid);
+    assert!(bus.frame_bottom_palette_events().is_empty());
+
+    // The same write with bank 0 / LOCT clear selected is the classic
+    // pattern and still latches.
+    assert!(!bus.custom_write(0x106, 2, 0x0000));
+    assert!(!bus.custom_write(0x186, 2, 0x0BBB));
+    assert_eq!(bus.beam_bottom_palette[3], 0x0BBB);
+    assert!(bus.beam_bottom_palette_valid);
+}
+
+#[test]
 fn intreq_palette_target_uses_delivered_interrupt_when_coper_and_vertb_clear_together() {
     let mut bus = empty_bus();
 

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -1075,6 +1075,16 @@ impl FloppyController {
 
         if val & DSKLEN_DMAEN == 0 {
             if let Some(dma) = self.dma.take() {
+                if crate::envcfg::flag("COPPERLINE_DIAG_DISK") {
+                    log::info!(
+                        "disk-dma teardown df{} track={} write={} remaining={} wait_sync={}",
+                        dma.drive,
+                        dma.track,
+                        dma.write,
+                        dma.remaining,
+                        dma.wait_sync,
+                    );
+                }
                 if dma.write && !dma.write_words.is_empty() {
                     self.finish_write_dma(dma);
                 }
@@ -1749,9 +1759,18 @@ impl FloppyController {
         if crate::envcfg::flag("COPPERLINE_DIAG_DISK") {
             let secs = self.drives[idx].elapsed_cck as f64 / PAULA_CLOCK_HZ as f64;
             log::info!(
-                "disk-dma secs={secs:.5} df{idx} track={track} cyl={} write={write} words={remaining} rotbit={}",
+                "disk-dma secs={secs:.5} df{idx} track={track} cyl={} write={write} words={remaining} rotbit={} cached_track={:?} revs={} rev0_words={} settle={}",
                 self.drives[idx].cylinder,
                 self.drives[idx].rotation_bit,
+                self.drives[idx].cached_track,
+                self.drives[idx].cached.revs.len(),
+                self.drives[idx]
+                    .cached
+                    .revs
+                    .first()
+                    .map(|rev| rev.words.len())
+                    .unwrap_or(0),
+                self.drives[idx].seek_settle_cck,
             );
         }
         false
@@ -1811,6 +1830,17 @@ impl FloppyController {
     }
 
     fn finish_dma(&mut self, dma: DiskDma) {
+        if crate::envcfg::flag("COPPERLINE_DIAG_DISK") {
+            log::info!(
+                "disk-dma finish df{} track={} write={} remaining={} wait_sync={} dskpt={:#08X}",
+                dma.drive,
+                dma.track,
+                dma.write,
+                dma.remaining,
+                dma.wait_sync,
+                self.dskpt,
+            );
+        }
         self.dsklen &= !DSKLEN_DMAEN;
         if dma.write && !dma.write_words.is_empty() {
             self.finish_write_dma(dma);

--- a/src/video/bitplane/diag.rs
+++ b/src/video/bitplane/diag.rs
@@ -66,6 +66,19 @@ pub(super) fn maybe_log_frame_state(
         .map(|i| format!("{:03x}", state.palette[i]))
         .collect();
     log::info!("  pal0-15=[{}]", pal.join(" "));
+    if crate::envcfg::flag("COPPERLINE_DBG_FRAMESTATE_FULLPAL") {
+        for row in 0..16 {
+            let entries: Vec<String> = (row * 16..row * 16 + 16)
+                .map(|i| format!("{:06x}", state.palette.rgb24(i) & 0x00FF_FFFF))
+                .collect();
+            log::info!(
+                "  pal{:3}-{:3}=[{}]",
+                row * 16,
+                row * 16 + 15,
+                entries.join(" ")
+            );
+        }
+    }
     let spr_lines = captured_sprite_lines;
     let mut per_sprite = [0u32; 8];
     let (mut ymin, mut ymax) = (i32::MAX, i32::MIN);

--- a/src/video/bitplane/output.rs
+++ b/src/video/bitplane/output.rs
@@ -510,11 +510,15 @@ pub(super) fn dual_playfield_pixel(idx: u8, control: ControlState) -> (u8, usize
     // Lisa does not inherit the quirk. Alfred Chicken (AGA) programs
     // BPLCON2 = 0x003F -- both codes 7 -- for its whole in-game display and
     // draws an eight-plane dual playfield on real hardware, which the
-    // Denise behaviour would blank to the background colour. There is no
-    // AGA photo of invprio1 to check the ECS case against, so the split is
-    // drawn where the evidence is: Denise keeps the photographed quirk,
-    // Lisa resolves the colour independently of the code.
-    // TODO: photograph invprio1 on an A1200 to confirm Lisa ignores
+    // Denise behaviour would blank to the background colour. The quirk
+    // reached us from an OCS/ECS-only reference, so it never carried
+    // evidence about Lisa; WinUAE, which does model AGA, resolves the
+    // playfield colour from the plane bits alone and uses the priority
+    // codes only to mask sprites. So the split is drawn where the evidence
+    // is: the photographed Denise case keeps the quirk, and Lisa resolves
+    // the colour independently of the code.
+    // TODO: the Lisa side rests on the game plus WinUAE, with no photograph
+    // of its own; shoot invprio1 on an A1200 to confirm Lisa ignores
     // out-of-range codes entirely rather than differing in some other way.
     if !control.aga() && control.playfield_priority_code(winner) > 4 {
         return (0, 0);

--- a/src/video/bitplane/output.rs
+++ b/src/video/bitplane/output.rs
@@ -501,12 +501,22 @@ pub(super) fn dual_playfield_pixel(idx: u8, control: ControlState) -> (u8, usize
         (_, pf2) if control.pf2_priority() => (2, 2, pf2_offset + pf2 as usize),
         (pf1, _) => (1, 1, pf1 as usize),
     };
-    // A playfield whose BPLCON2 priority code is programmed out of range
-    // (> 4) is drawn transparent: the winning field's pixels collapse to the
-    // background rather than showing the field behind it (vAmiga zPF returns
-    // 0 for codes 5-7, which masks that field's index to 0). Real software
-    // only uses codes 0-4, so valid dual-playfield content is unaffected.
-    if control.playfield_priority_code(winner) > 4 {
+    // Denise draws a field transparent when its BPLCON2 priority code is
+    // programmed out of range (5-7): the winning field's pixels collapse to
+    // the background instead of revealing the field behind it. Photographed
+    // on an A500 (vAmigaTS Denise/Registers/BPLCON0/invprio1, PF2 code 7,
+    // where the real machine shows background between the bars).
+    //
+    // Lisa does not inherit the quirk. Alfred Chicken (AGA) programs
+    // BPLCON2 = 0x003F -- both codes 7 -- for its whole in-game display and
+    // draws an eight-plane dual playfield on real hardware, which the
+    // Denise behaviour would blank to the background colour. There is no
+    // AGA photo of invprio1 to check the ECS case against, so the split is
+    // drawn where the evidence is: Denise keeps the photographed quirk,
+    // Lisa resolves the colour independently of the code.
+    // TODO: photograph invprio1 on an A1200 to confirm Lisa ignores
+    // out-of-range codes entirely rather than differing in some other way.
+    if !control.aga() && control.playfield_priority_code(winner) > 4 {
         return (0, 0);
     }
     (pf_mask, color_idx)

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -5418,15 +5418,16 @@ fn dual_playfield_uses_separate_palette_banks_and_priority() {
 }
 
 #[test]
-fn dual_playfield_out_of_range_priority_draws_the_field_transparent() {
+fn dual_playfield_out_of_range_priority_draws_the_field_transparent_on_denise() {
     // A dual playfield whose BPLCON2 priority code is programmed out of range
-    // (5-7) is drawn transparent: the winning field's pixels collapse to the
-    // background instead of revealing the field behind it (vAmiga zPF returns
-    // 0 for codes 5-7). vAmigaTS Denise/BPLCON0/invprio. Valid codes (0-4)
-    // are unaffected, so real dual-playfield content is unchanged.
+    // (5-7) is drawn transparent on Denise: the winning field's pixels
+    // collapse to the background instead of revealing the field behind it.
+    // Photographed on an A500 (vAmigaTS Denise/Registers/BPLCON0/invprio1,
+    // PF2 code 7, background visible between the bars). Valid codes (0-4) are
+    // unaffected, so real dual-playfield content is unchanged.
     let invalid_pf2 = ControlState {
         bplcon0: 0x6400, // 4 planes, dual playfield
-        bplcon2: 0x0038, // PF2 priority code 7 (invalid), PF1 code 0
+        bplcon2: 0x0038, // PF2 priority code 7 (out of range), PF1 code 0
         bplcon3: BPLCON3_PF2OF_DEFAULT,
         ..ControlState::default()
     };
@@ -5441,6 +5442,53 @@ fn dual_playfield_out_of_range_priority_draws_the_field_transparent() {
         ..invalid_pf2
     };
     assert_eq!(dual_playfield_pixel(0b0000_0010, valid), (2, 9));
+}
+
+#[test]
+fn dual_playfield_out_of_range_priority_still_draws_on_lisa() {
+    // Lisa does not inherit Denise's out-of-range-priority quirk. Alfred
+    // Chicken programs BPLCON2 = 0x003F -- both codes 7 -- for its whole
+    // in-game display and draws an eight-plane dual playfield on real AGA
+    // hardware; blanking it there left the level invisible (issue #416).
+    let aga = ControlState {
+        bplcon0: 0x6400,
+        bplcon2: 0x003F, // both priority codes 7
+        bplcon3: BPLCON3_PF2OF_DEFAULT,
+        agnus_revision: AgnusRevision::AgaAlice,
+        ..ControlState::default()
+    };
+    assert_eq!(dual_playfield_pixel(0b0000_0010, aga), (2, 9));
+    assert_eq!(dual_playfield_pixel(0b0000_0001, aga), (1, 1));
+    assert_eq!(dual_playfield_pixel(0, aga), (0, 0));
+
+    // The same pixels resolve identically with an in-range code, which is
+    // what "the code does not affect colour resolution on Lisa" means.
+    let aga_valid = ControlState {
+        bplcon2: 0x0004,
+        ..aga
+    };
+    assert_eq!(dual_playfield_pixel(0b0000_0010, aga_valid), (2, 9));
+    assert_eq!(dual_playfield_pixel(0b0000_0001, aga_valid), (1, 1));
+
+    // On either chip the code still saturates in the sprite comparison,
+    // where it counts the sprite pairs that pass in front of the playfield:
+    // 5-7 put all four pairs in front exactly as 4 does, while 3 leaves the
+    // last pair behind.
+    for code in 4u16..=7 {
+        let control = ControlState {
+            bplcon2: code,
+            ..aga
+        };
+        for group in 0..4 {
+            assert!(
+                sprite_has_priority(group * 2, 1, control),
+                "code {code} group {group}"
+            );
+        }
+    }
+    let code_three = ControlState { bplcon2: 3, ..aga };
+    assert!(sprite_has_priority(4, 1, code_three));
+    assert!(!sprite_has_priority(6, 1, code_three));
 }
 
 #[test]


### PR DESCRIPTION
Fixes the two AGA games reported in #416. They turned out to be unrelated bugs
in different subsystems, so they are separate commits.

## Bubble and Squeak: the CPU palette shadow ignored BPLCON3 banking

The game CPU-uploads a 228-entry palette on every fade frame, interleaving
BPLCON3 bank/LOCT selects with the COLOR writes. The register store and the
beam-event replay both decoded that correctly, but a third copy did not: the
CPU-write shadow (`beam_top_palette`) that feeds the copper-interrupt
split-palette heuristic wrote entries bank-blind. Once `beam_bottom_palette_valid`
latches, the renderer reseeds its frame palette from that shadow every frame, so
bank 0 ended up holding whichever bank was written last and banks 1-7 read black.

The shadow now decodes BANK/LOCT exactly as Lisa does, and the bottom-palette
latch accepts only bank-0/LOCT-clear writes, which is the OCS split-palette
pattern that machinery actually models. Banked AGA writes already replayed
beam-accurately.

Note for testers: save states captured before this fix carry the corrupted
shadow inside them, so they still render wrong until the game's next palette
fade. Fresh runs are correct.

## Alfred Chicken: out-of-range BPLCON2 priority blanked the playfield on AGA

A dual-playfield field whose BPLCON2 priority code is out of range (5-7) is
drawn transparent on Denise -- the winning field collapses to the background
rather than revealing the field behind it. That is photographed on real
hardware (vAmigaTS `Denise/Registers/BPLCON0/invprio1`, PF2 code 7, background
visible between the bars), and this PR keeps it.

The resolver applied it to every chipset, though. Alfred Chicken runs its whole
in-game display at `BPLCON2 = 0x003F` -- both codes 7 -- so every pixel of its
eight-plane dual playfield collapsed to the background. The level was drawn into
the bitplanes, fetched, and decoded to the right palette indices, then discarded
at the very last step, leaving a black screen with only the sprites and the
four-plane status bar visible.

The rule reached us from an OCS/ECS-only reference, so it never carried any
evidence about Lisa. WinUAE, which does model AGA, resolves the playfield colour
from the plane bits alone and uses the priority codes only to mask sprites. The
split is therefore drawn where the evidence is: Denise keeps the photographed
quirk, Lisa resolves colour independently of the code. On both chips the code
still saturates in the sprite comparison (101/110/111 behave as 100), which
`sprite_has_priority` already did with `min(4)`.

There is no AGA photo of invprio1 to check Lisa against directly, so the code
carries a TODO asking for one.

## Testing

- Full unit suite, plus a new test per chipset for the priority behaviour.
- 27 golden render probes, and the asset-gated image_regression / mb_ram /
  picasso2 suites.
- `invprio1.adf` rendered on an emulated A500: byte-identical to the previous
  build, and matching the hardware photo.
- Alfred Chicken and Bubble and Squeak verified from cold boot through their
  full disk-swap sequences, not just from save states.
- A/B sweep against a build without the priority change over eight configured
  titles (roots-aga, roots-ecs, zool, tomato, phooey, cd32, kick12, os39): all
  byte-identical, with Alfred Chicken as the positive control confirming the
  sweep is sensitive.
- clippy and fmt clean.

Second Samurai is also mentioned in #416 but is not in my library, so it is
untested here; if it shares the `BPLCON2` pattern it will be fixed by the same
commit.
