### PR TITLE
cli: let --screenshot-after and --save-state-after repeat

### DIFF
--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -24,6 +24,21 @@ is paced to real time rather than unthrottled, and it is not reproducible.
 `--screenshot-after SECS PATH` emulates for SECS *emulated* seconds, saves
 the framebuffer as a PNG, and exits.
 
+The flag repeats, so one run can capture several moments; the run ends
+once the latest of them has been saved. Order on the command line does not
+matter, and a capture that comes due while an earlier one is still waiting
+for its frame is not lost:
+
+```sh
+./target/release/copperline --config copperline.example.toml --noaudio \
+  --screenshot-after 10 /tmp/menu.png \
+  --screenshot-after 30 /tmp/level.png \
+  --screenshot-after 60 /tmp/boss.png
+```
+
+Use `--dump-frames` instead when the moments are consecutive frames rather
+than points spread across a run.
+
 ## Frame dumps
 
 For frame-to-frame rendering glitches, dump consecutive rendered frames:
@@ -57,6 +72,9 @@ investigation.
   --load-state /tmp/snapshot-120s.clstate \
   --screenshot-after 125 /tmp/scene.png
 ```
+
+`--save-state-after` repeats too, so one pass can leave snapshots at
+several points to iterate from later.
 
 The core is deterministic, so a resumed run is byte-identical to an
 uninterrupted one -- screenshots from either path can be compared

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,16 @@ pub struct CliArgs {
     /// `--whdload GAME`: stage a WHDLoad package (.lha archive or
     /// directory) and boot straight into it (src/whdload.rs).
     pub whdload: Option<PathBuf>,
-    pub screenshot_after: Option<(f32, PathBuf)>,
+    /// `--screenshot-after SECS PATH`: save the framebuffer after SECS
+    /// emulated seconds. Repeatable, like the scheduled-input flags: every
+    /// occurrence is captured, and the run ends once the last one has
+    /// fired.
+    pub screenshot_after: Vec<(f32, PathBuf)>,
     /// `--save-state-after SECS PATH`: write a save state of the whole
     /// machine after SECS emulated seconds, then keep running (combine
     /// with --screenshot-after/--dump-frames to bound the run).
-    pub save_state_after: Option<(f32, PathBuf)>,
+    /// Repeatable, like `--screenshot-after`.
+    pub save_state_after: Vec<(f32, PathBuf)>,
     /// `--load-state PATH`: restore a save state before entering the
     /// event loop, resuming from its emulated timeline.
     pub load_state: Option<PathBuf>,
@@ -311,8 +316,8 @@ where
     let mut config_path: Option<PathBuf> = None;
     let mut rom_path: Option<PathBuf> = None;
     let mut whdload: Option<PathBuf> = None;
-    let mut screenshot_after: Option<(f32, PathBuf)> = None;
-    let mut save_state_after: Option<(f32, PathBuf)> = None;
+    let mut screenshot_after: Vec<(f32, PathBuf)> = Vec::new();
+    let mut save_state_after: Vec<(f32, PathBuf)> = Vec::new();
     let mut load_state: Option<PathBuf> = None;
     let mut benchmark_until: Option<f32> = None;
     let mut gdb: Option<gdbstub::Config> = None;
@@ -889,14 +894,14 @@ where
                 let secs: f32 =
                     next_arg(&mut args, USAGE, "--screenshot-after SECS must be a number")?;
                 let path = args.next().ok_or_else(|| anyhow!(USAGE))?;
-                screenshot_after = Some((secs, PathBuf::from(path)));
+                screenshot_after.push((secs, PathBuf::from(path)));
             }
             "--save-state-after" => {
                 const USAGE: &str = "--save-state-after requires SECS PATH";
                 let secs: f32 =
                     next_arg(&mut args, USAGE, "--save-state-after SECS must be a number")?;
                 let path = args.next().ok_or_else(|| anyhow!(USAGE))?;
-                save_state_after = Some((secs, PathBuf::from(path)));
+                save_state_after.push((secs, PathBuf::from(path)));
             }
             "--load-state" => {
                 let v = args
@@ -1466,12 +1471,12 @@ fn validate_benchmark_args(cli: &CliArgs) -> Result<()> {
         return Ok(());
     }
 
-    if cli.screenshot_after.is_some() {
+    if !cli.screenshot_after.is_empty() {
         return Err(anyhow!(
             "--benchmark-until cannot be combined with --screenshot-after"
         ));
     }
-    if cli.save_state_after.is_some() {
+    if !cli.save_state_after.is_empty() {
         return Err(anyhow!(
             "--benchmark-until cannot be combined with --save-state-after"
         ));
@@ -1519,10 +1524,10 @@ fn validate_gdb_args(cli: &CliArgs) -> Result<()> {
     if cli.benchmark_until.is_some() {
         return Err(anyhow!("--gdb cannot be combined with --benchmark-until"));
     }
-    if cli.screenshot_after.is_some() {
+    if !cli.screenshot_after.is_empty() {
         return Err(anyhow!("--gdb cannot be combined with --screenshot-after"));
     }
-    if cli.save_state_after.is_some() {
+    if !cli.save_state_after.is_empty() {
         return Err(anyhow!("--gdb cannot be combined with --save-state-after"));
     }
     if cli.frame_dump.is_some() {
@@ -1581,12 +1586,12 @@ fn validate_control_args(cli: &CliArgs) -> Result<()> {
     // The headless server owns the machine like --gdb does; the windowed
     // App (which fires the scheduled/capture flags) never runs. Input
     // recording IS supported: the server journals injected input itself.
-    if cli.screenshot_after.is_some() {
+    if !cli.screenshot_after.is_empty() {
         return Err(anyhow!(
             "--control cannot be combined with --screenshot-after (use capture.screenshot)"
         ));
     }
-    if cli.save_state_after.is_some() {
+    if !cli.save_state_after.is_empty() {
         return Err(anyhow!(
             "--control cannot be combined with --save-state-after (use state.save)"
         ));
@@ -2094,7 +2099,7 @@ fn main() -> Result<()> {
     // Headless capture runs (screenshot / frame dump) advance the
     // deterministic core unthrottled; the interactive window paces to
     // wall-clock time. The emulated result is identical either way.
-    let headless_capture = cli.screenshot_after.is_some()
+    let headless_capture = !cli.screenshot_after.is_empty()
         || cli.frame_dump.is_some()
         || cli.benchmark_until.is_some()
         || cli.gdb.is_some()
@@ -2174,7 +2179,7 @@ fn main() -> Result<()> {
     // --control-gui keeps the windowed path: it explicitly asks for an
     // interactive session.
     let windowless_capture =
-        (cli.screenshot_after.is_some() || cli.frame_dump.is_some()) && cli.control_gui.is_none();
+        (!cli.screenshot_after.is_empty() || cli.frame_dump.is_some()) && cli.control_gui.is_none();
     #[cfg_attr(not(feature = "control"), allow(unused_mut))]
     let mut app = App::new(
         emu,
@@ -2305,8 +2310,8 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
     let mut app = App::new(
         emu,
         false,
-        None,
-        None,
+        Vec::new(),
+        Vec::new(),
         None,
         Vec::new(),
         Vec::new(),
@@ -2357,8 +2362,8 @@ fn launcher_requested(cli: &CliArgs) -> bool {
         && cli.whdload.is_none()
         && cli.overrides.is_empty()
         && !Path::new("copperline.toml").exists()
-        && cli.screenshot_after.is_none()
-        && cli.save_state_after.is_none()
+        && cli.screenshot_after.is_empty()
+        && cli.save_state_after.is_empty()
         && cli.frame_dump.is_none()
         && cli.benchmark_until.is_none()
         && cli.gdb.is_none()
@@ -2530,6 +2535,57 @@ mod tests {
             &parse(&["--screenshot-after", "5", "out.png"]).unwrap()
         ));
         assert!(!launcher_requested(&parse(&["--noaudio"]).unwrap()));
+    }
+
+    #[test]
+    fn capture_flags_accumulate_instead_of_overwriting() {
+        // --screenshot-after and --save-state-after repeat like the
+        // scheduled-input flags: a run can bracket several moments. They
+        // used to parse into a single slot, so a second occurrence silently
+        // replaced the first and the earlier capture never fired.
+        let args = parse(&[
+            "--screenshot-after",
+            "5",
+            "early.png",
+            "--screenshot-after",
+            "10",
+            "late.png",
+            "--save-state-after",
+            "7",
+            "mid.clstate",
+            "--save-state-after",
+            "9",
+            "end.clstate",
+        ])
+        .unwrap();
+
+        let shots: Vec<_> = args
+            .screenshot_after
+            .iter()
+            .map(|(secs, path)| (*secs, path.to_string_lossy().into_owned()))
+            .collect();
+        assert_eq!(
+            shots,
+            vec![(5.0, "early.png".to_owned()), (10.0, "late.png".to_owned())]
+        );
+
+        let states: Vec<_> = args
+            .save_state_after
+            .iter()
+            .map(|(secs, path)| (*secs, path.to_string_lossy().into_owned()))
+            .collect();
+        assert_eq!(
+            states,
+            vec![
+                (7.0, "mid.clstate".to_owned()),
+                (9.0, "end.clstate".to_owned())
+            ]
+        );
+
+        // A single occurrence still parses to exactly one entry.
+        let args = parse(&["--screenshot-after", "5", "out.png"]).unwrap();
+        assert_eq!(args.screenshot_after.len(), 1);
+        assert!(args.save_state_after.is_empty());
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -860,12 +860,16 @@ pub struct App {
     /// stays powered on, so the last rendered frame is held on screen and
     /// emulation resumes from the same point when unpaused.
     paused: bool,
-    auto_shot: Option<(f32, PathBuf)>,
-    pending_auto_shot: Option<(f32, PathBuf)>,
-    /// Scheduled --save-state-after capture: write a save state once
-    /// emulated time reaches the deadline, then keep running.
-    auto_save_state: Option<(f32, PathBuf)>,
-    pending_auto_save_state: Option<(f32, PathBuf)>,
+    /// Scheduled --screenshot-after captures, earliest deadline first.
+    /// The flag repeats, so a run can bracket several moments; the run
+    /// ends once the last of them has been saved.
+    auto_shot: Vec<(f32, PathBuf)>,
+    pending_auto_shot: Vec<(f32, PathBuf)>,
+    /// Scheduled --save-state-after captures, earliest deadline first:
+    /// write a save state once emulated time reaches each deadline, then
+    /// keep running. Repeats like --screenshot-after.
+    auto_save_state: Vec<(f32, PathBuf)>,
+    pending_auto_save_state: Vec<(f32, PathBuf)>,
     frame_dump: Option<FrameDumpState>,
     pending_frame_dump: Option<FrameDumpSpec>,
     auto_keys: Vec<ScheduledKey>,
@@ -1411,8 +1415,8 @@ impl App {
     pub fn new(
         emu: Emulator,
         power_on: bool,
-        screenshot_after: Option<(f32, PathBuf)>,
-        save_state_after: Option<(f32, PathBuf)>,
+        screenshot_after: Vec<(f32, PathBuf)>,
+        save_state_after: Vec<(f32, PathBuf)>,
         frame_dump: Option<FrameDumpSpec>,
         press_after: Vec<KeyPressSpec>,
         click_after: Vec<(f32, MouseButtonKind, u32, u8)>,
@@ -1456,8 +1460,8 @@ impl App {
         // Headless capture runs drive themselves off emulated time, so a
         // powered-off start would simply hang. Force power on for those.
         let powered_on = power_on
-            || screenshot_after.is_some()
-            || save_state_after.is_some()
+            || !screenshot_after.is_empty()
+            || !save_state_after.is_empty()
             || frame_dump.is_some();
         let render_worker = threaded_render_enabled().then(|| {
             info!("threaded render pipeline enabled");
@@ -1540,9 +1544,9 @@ impl App {
             cpu_halted: false,
             powered_on,
             paused: false,
-            auto_shot: None,
+            auto_shot: Vec::new(),
             pending_auto_shot: screenshot_after,
-            auto_save_state: None,
+            auto_save_state: Vec::new(),
             pending_auto_save_state: save_state_after,
             frame_dump: None,
             pending_frame_dump: frame_dump,
@@ -2222,7 +2226,7 @@ impl App {
     /// without window-server access.
     pub fn run_headless(mut self) -> Result<()> {
         self.arm_scheduled_events();
-        if self.auto_shot.is_none() && self.frame_dump.is_none() {
+        if self.auto_shot.is_empty() && self.frame_dump.is_none() {
             return Err(anyhow!(
                 "windowless capture run needs --screenshot-after or --dump-frames"
             ));
@@ -2258,22 +2262,28 @@ impl App {
     /// scheduling would fire at the wrong emulated point or never fire at
     /// all before the run exits.
     fn arm_scheduled_events(&mut self) {
-        if let Some((secs, path)) = self.pending_auto_shot.take() {
+        for (secs, path) in std::mem::take(&mut self.pending_auto_shot) {
             info!(
                 "auto-screenshot armed: will save {} after {:.1}s emulated time",
                 path.display(),
                 secs
             );
-            self.auto_shot = Some((secs.max(0.0), path));
+            self.auto_shot.push((secs.max(0.0), path));
         }
-        if let Some((secs, path)) = self.pending_auto_save_state.take() {
+        // Deadline order, not command-line order, so the run ends on the
+        // latest capture however the flags were written. The sort is
+        // stable, so captures sharing a deadline keep their given order.
+        self.auto_shot.sort_by(|(a, _), (b, _)| a.total_cmp(b));
+        for (secs, path) in std::mem::take(&mut self.pending_auto_save_state) {
             info!(
                 "auto-save-state armed: will save {} after {:.1}s emulated time",
                 path.display(),
                 secs
             );
-            self.auto_save_state = Some((secs.max(0.0), path));
+            self.auto_save_state.push((secs.max(0.0), path));
         }
+        self.auto_save_state
+            .sort_by(|(a, _), (b, _)| a.total_cmp(b));
         if let Some(spec) = self.pending_frame_dump.take() {
             info!(
                 "frame dump armed: will save {} frames to {} after {:.1}s emulated time",
@@ -2571,38 +2581,58 @@ impl App {
     /// end the run: a state save is a capture along the way, not the end
     /// of a verification run.
     fn fire_auto_save_state(&mut self) {
-        let Some((secs, path)) = self.auto_save_state.take() else {
-            return;
-        };
-        if self.emu.bus().emulated_seconds() < secs as f64 {
-            self.auto_save_state = Some((secs, path));
+        if self.auto_save_state.is_empty() {
             return;
         }
-        match self.emu.save_state(&path) {
-            Ok(()) => info!("auto-save-state saved: {}", path.display()),
-            Err(e) => warn!("auto-save-state failed ({}): {e:#}", path.display()),
+        let now = self.emu.bus().emulated_seconds();
+        // Deadline-ordered, so everything still pending starts at the first
+        // entry that is not due yet.
+        let due = self
+            .auto_save_state
+            .iter()
+            .take_while(|(secs, _)| now >= *secs as f64)
+            .count();
+        for (_, path) in self.auto_save_state.drain(..due).collect::<Vec<_>>() {
+            match self.emu.save_state(&path) {
+                Ok(()) => info!("auto-save-state saved: {}", path.display()),
+                Err(e) => warn!("auto-save-state failed ({}): {e:#}", path.display()),
+            }
         }
     }
 
-    /// Fire the scheduled --screenshot-after capture once its emulated
-    /// timestamp has passed. Returns true when the screenshot has been
-    /// saved and the run is complete (both loops exit on it); the capture
-    /// stays armed while the target frame is still being rendered.
+    /// Fire every scheduled --screenshot-after capture whose emulated
+    /// timestamp has passed. Returns true when the last one has been saved
+    /// and the run is complete (both loops exit on it); captures stay armed
+    /// while the target frame is still being rendered, and a run with more
+    /// captures still pending keeps going.
     fn fire_auto_shot(&mut self) -> bool {
-        let Some((secs, path)) = self.auto_shot.take() else {
+        if self.auto_shot.is_empty() {
             return false;
-        };
-        if self.emu.bus().emulated_seconds() < secs as f64 {
-            self.auto_shot = Some((secs, path));
+        }
+        let now = self.emu.bus().emulated_seconds();
+        // Deadline-ordered, so everything still pending starts at the first
+        // entry that is not due yet.
+        let due = self
+            .auto_shot
+            .iter()
+            .take_while(|(secs, _)| now >= *secs as f64)
+            .count();
+        if due == 0 {
             return false;
         }
         let emulated_frame = self.emu.bus().emulated_frames();
         self.finish_render_for_current_frame();
         if self.last_rendered_emulated_frame != Some(emulated_frame) {
-            self.auto_shot = Some((secs, path));
             return false;
         }
-        self.save_screenshot(&path);
+        // Captures that came due together all describe this frame, so they
+        // all get it rather than drifting a frame apart.
+        for (_, path) in self.auto_shot.drain(..due).collect::<Vec<_>>() {
+            self.save_screenshot(&path);
+        }
+        if !self.auto_shot.is_empty() {
+            return false;
+        }
         self.emu.report_stats();
         self.emu.bus().poll_stats.dump_top("at screenshot");
         // Evaluate an untargeted reverse watchpoint at run end.
@@ -2649,7 +2679,7 @@ impl ApplicationHandler for App {
         // screen and removes the vsync present gate, letting the run
         // advance as fast as the host allows. Emulated state is identical.
         let headless_capture =
-            self.pending_auto_shot.is_some() || self.pending_frame_dump.is_some();
+            !self.pending_auto_shot.is_empty() || self.pending_frame_dump.is_some();
         // Start fullscreen only for an interactive window ([display] full_screen
         // / --full-screen); a headless capture window stays hidden and windowed.
         let fullscreen =
@@ -3652,7 +3682,7 @@ impl ApplicationHandler for App {
         // frame per loop (request_redraw is skipped below), and every captured
         // frame must be rendered, so warp's output frame-skip burst must not
         // apply there.
-        let headless_capture = self.auto_shot.is_some() || self.frame_dump.is_some();
+        let headless_capture = !self.auto_shot.is_empty() || self.frame_dump.is_some();
         // Run one scheduler quantum. Rebuild the host framebuffer only
         // when Agnus has crossed into a new frame; the expensive renderer
         // reconstructs a completed hardware frame, not an instruction slice.

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2934,8 +2934,8 @@ fn test_app_with_audio_cpu_and_program(
     super::App::new(
         emu,
         true,
-        None,
-        None,
+        Vec::new(),
+        Vec::new(),
         None,
         Vec::new(),
         Vec::new(),
@@ -6516,7 +6516,7 @@ fn temp_capture_path(name: &str) -> PathBuf {
 fn windowless_screenshot_run_saves_png_and_exits() {
     let path = temp_capture_path("shot.png");
     let mut app = test_app();
-    app.pending_auto_shot = Some((0.04, path.clone()));
+    app.pending_auto_shot = vec![(0.04, path.clone())];
     app.run_headless().expect("windowless screenshot run");
     let data = std::fs::read(&path).expect("screenshot file written");
     assert!(
@@ -6525,6 +6525,37 @@ fn windowless_screenshot_run_saves_png_and_exits() {
         data.len()
     );
     std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn windowless_run_saves_every_scheduled_screenshot_before_exiting() {
+    // Repeated --screenshot-after captures all fire, and the run ends on
+    // the latest one rather than the last one written on the command line.
+    let early = temp_capture_path("multi-early.png");
+    let late = temp_capture_path("multi-late.png");
+    let state = temp_capture_path("multi.clstate");
+    let mut app = test_app();
+    app.pending_auto_shot = vec![(0.12, late.clone()), (0.04, early.clone())];
+    app.pending_auto_save_state = vec![(0.08, state.clone())];
+    app.run_headless().expect("windowless multi-capture run");
+
+    for path in [&early, &late] {
+        let data = std::fs::read(path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+        assert!(
+            data.starts_with(b"\x89PNG\r\n\x1a\n"),
+            "{} should be a PNG, got {} bytes",
+            path.display(),
+            data.len()
+        );
+    }
+    assert!(
+        state.exists(),
+        "a save state scheduled between two screenshots still fires"
+    );
+
+    std::fs::remove_file(&early).ok();
+    std::fs::remove_file(&late).ok();
+    std::fs::remove_file(&state).ok();
 }
 
 #[test]
@@ -6548,7 +6579,7 @@ fn windowless_run_fires_scheduled_input_and_flushes_recording() {
     let shot = temp_capture_path("input-shot.png");
     let script = temp_capture_path("session.clscript");
     let mut app = test_app();
-    app.pending_auto_shot = Some((0.2, shot.clone()));
+    app.pending_auto_shot = vec![(0.2, shot.clone())];
     app.pending_auto_keys.push(super::KeyPressSpec {
         secs: 0.04,
         rawkey: 0x45,


### PR DESCRIPTION
`--screenshot-after` and `--save-state-after` each parsed into a single
`Option`, so passing either more than once silently overwrote: only the last
occurrence armed. A run written with four `--screenshot-after` flags looked
like it worked, wrote one file, and said nothing about the three captures it
had dropped.

That is inconsistent with every other scheduled flag -- `--press-after`,
`--joy-after`, `--insert-disk-after` and friends all repeat -- so it is easy
to walk into, and the failure presents as the emulator missing a moment
rather than the command line being wrong. I hit it while sampling scenes for
issue #416 and lost captures without noticing.

## What changed

Both flags now collect every occurrence. The captures are held in deadline
order rather than command-line order, which gives two useful properties:

- a run ends on the latest screenshot however the flags were written, so
  `--screenshot-after 60 late.png --screenshot-after 10 early.png` behaves
  the way it reads;
- captures that come due together all describe the frame they fired on,
  rather than drifting a frame apart.

A save state scheduled between two screenshots still fires, and a single
occurrence behaves exactly as before.

## Testing

- New `capture_flags_accumulate_instead_of_overwriting` parse test: two of
  each flag land as two entries in command-line order, and one occurrence
  still yields exactly one.
- New `windowless_run_saves_every_scheduled_screenshot_before_exiting`
  window test: both screenshots and an interleaved save state are written,
  with the entries deliberately given out of order.
- End to end against the real binary: three `--screenshot-after` flags in
  one run arm and save all three; an out-of-order pair plus an interleaved
  `--save-state-after` fires in deadline order and the run ends at the
  latest capture.
- Full unit suite, 27 golden render probes, clippy and fmt clean.

Docs: `docs/guide/headless.md` now states that both flags repeat, with an
example, and points at `--dump-frames` for consecutive frames.
