### PR TITLE
web: open IPF images in the browser build

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -357,6 +357,23 @@ impl WebEmu {
         vec!["PAL".to_string(), "NTSC".to_string()]
     }
 
+    /// The floppy image file extensions this build can open, without their
+    /// dots ("adf", "ipf", ...), straight from the core's own list.
+    ///
+    /// [`WebEmu::insert_floppy`] decides by signature and never looks at the
+    /// name, but a file picker cannot sniff: `<input type="file" accept=...>`
+    /// hides everything it does not list, so a filter naming fewer formats
+    /// than the core reads locks a visitor out of images this build would
+    /// have loaded. The page fills the picker (and the `#df0list` folder
+    /// filter) from here so the two cannot drift apart. Like `models`, its
+    /// presence is also the feature test for older bundles.
+    pub fn floppy_formats() -> Vec<String> {
+        copperline::floppy::IMAGE_EXTENSIONS
+            .iter()
+            .map(|ext| (*ext).to_string())
+            .collect()
+    }
+
     /// The running machine's profile name ("A500", "A1200", ...), or
     /// undefined for a machine no profile describes -- the model-less
     /// default constructor's machine, or a custom-shaped machine restored
@@ -815,9 +832,10 @@ impl WebEmu {
         self.set_cd32_buttons_port(2, play, rwd, ffw, green, yellow);
     }
 
-    /// Insert a floppy image (ADF/ADZ/DMS/extended ADF, optionally
-    /// gzip/zip-packed) from bytes. Always write-protected: the browser has
-    /// nowhere to write changes back to.
+    /// Insert a floppy image from bytes: every format the core reads
+    /// (ADF/ADZ, extended ADF, DMS, IPF, SCP, optionally gzip/zip-packed),
+    /// recognised by signature rather than by name. Always write-protected:
+    /// the browser has nowhere to write changes back to.
     pub fn insert_floppy(&mut self, drive: u8, bytes: Vec<u8>, name: &str) -> Result<(), JsValue> {
         self.emu
             .bus_mut()

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -456,6 +456,7 @@ async function load() {
     showBuildInfo();
     populateMachineSelect();
     populateVideoSelect();
+    applyDiskFormats();
   } catch (e) {
     setLoadStatus(`failed to load the emulator: ${e.message ?? e}`);
     console.error(e);
@@ -5448,10 +5449,66 @@ function updateStatusDisks() {
 // http.server) is scraped for links with a matching extension instead.
 // An empty or unreachable folder hides the select.
 
-const DISK_LIST_EXT = /\.(adf|adz|dms|scp|zip|gz)$/i;
 // Raw ROM images only: a list pick feeds load_rom directly, which takes
 // uncompressed 256/512 KiB images.
 const KICK_LIST_EXT = /\.(rom|bin)$/i;
+
+// The floppy formats this wasm bundle reads, from WebEmu.floppy_formats():
+// extensions without their dots, in menu order. insert_floppy decides by
+// signature and never reads the name, so nothing on the insert path needs
+// this - but a file picker and a scraped directory listing have only names
+// to go on, and both hide what they do not list. Taking the list from the
+// build is what keeps them from offering less than the core reads (an IPF
+// greyed out in the picker of a bundle that decodes IPF perfectly well).
+// Null until the module is up, and on a bundle too old to say.
+let diskFormats = null;
+
+// Called once the wasm module is ready (load()): point the disk picker and
+// the optional DF0 list at the formats this build reads. A shell's
+// hand-written accept attribute is a list the wasm can outgrow, and it did
+// - which is why the glue rewrites it rather than trusting it. Only a
+// picker that already carries one is touched, so a shell that deliberately
+// filters nothing keeps offering every file, and iOS (which drops the
+// attribute at the top of this file, because its document picker greys out
+// extensions it does not know) stays unfiltered too. A bundle without
+// floppy_formats leaves the picker alone and hides the list, the way the
+// machine and video selects hide themselves.
+function applyDiskFormats() {
+  try {
+    diskFormats = WebEmu.floppy_formats?.() ?? null;
+  } catch {
+    diskFormats = null;
+  }
+  const diskListSelect = $('df0list');
+  if (!diskFormats?.length) {
+    diskFormats = null;
+    if (diskListSelect) diskListSelect.hidden = true;
+    return;
+  }
+  const picker = $('df0');
+  if (picker.hasAttribute('accept')) {
+    picker.accept = diskFormats.map((ext) => `.${ext}`).join(',');
+  }
+  if (diskListSelect) {
+    const listExt = new RegExp(`\\.(${diskFormats.join('|')})$`, 'i');
+    loadFolderList(diskListSelect, 'adf/', listExt, 'DF0 from list...', false, insertDiskFromUrl);
+  }
+}
+
+// What the DF0-from-URL prompt promises, from the same list: the image
+// formats by name, then the two packers as what they are. Before the
+// module is up (or on a bundle that cannot say) it promises nothing rather
+// than a list that might be wrong.
+function diskUrlPrompt() {
+  if (!diskFormats?.length) return 'Disk image URL:';
+  const packers = { gz: 'gzip', zip: 'zip' };
+  const images = diskFormats.filter((ext) => !(ext in packers));
+  const packed = diskFormats.filter((ext) => ext in packers).map((ext) => packers[ext]);
+  const names = images.map((ext) => ext.toUpperCase()).join('/');
+  return packed.length
+    ? `Disk image URL (${names}, ${packed.join(' or ')} packed):`
+    : `Disk image URL (${names}):`;
+}
 
 async function folderListEntries(folder, extensions) {
   // A manifest wins when the site ships one; a missing or invalid one
@@ -5547,11 +5604,6 @@ async function loadFolderList(select, defaultSrc, extensions, placeholder, sameO
   });
 }
 
-const diskListSelect = $('df0list');
-if (diskListSelect) {
-  loadFolderList(diskListSelect, 'adf/', DISK_LIST_EXT, 'DF0 from list...', false, insertDiskFromUrl);
-}
-
 // The hosted page's server carries no ROMs, so its kick/ folder lists
 // nothing and the select hides; a self-hosted shell that serves its
 // owner's ROMs next to the page gets a one-click ROM chooser.
@@ -5562,9 +5614,7 @@ if (kickListSelect) {
 
 // Optional in the page shell: older shells have no URL button.
 $('df0url')?.addEventListener('click', () => {
-  const url = window.prompt(
-    'Disk image URL (ADF/ADZ/DMS/SCP, gzip or zip packed):',
-  );
+  const url = window.prompt(diskUrlPrompt());
   if (url && url.trim()) insertDiskFromUrl(url.trim());
 });
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -30,10 +30,16 @@ pre-boot choice is stashed and applied when the machine starts (the boot
 button relabels to show which ROM it will use), and a post-boot pick swaps
 the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, IPF,
 and SCP, plain or gzip/zip packed -- and are always write-protected, since
-the browser has no filesystem to write changes back to. On iOS the pickers
-offer every file rather than filtering by extension, because the system
-document picker greys out extensions it does not recognise, which would
-lock out `.adf` and friends.
+the browser has no filesystem to write changes back to. A file picker
+cannot sniff content, though: it filters by extension and hides whatever
+the filter leaves out, which is how an `.ipf` stayed greyed out in a
+bundle that decodes IPF perfectly well. So the glue rewrites the disk
+picker's filter from the running build's own format list instead of
+leaving it as the page shell's hand-written HTML spelled it. A shell that
+ships no filter at all still offers every file, and on iOS the pickers
+filter nothing either, because the system document picker greys out
+extensions it does not recognise, which would lock out `.adf` and
+friends.
 
 A Kickstart that fits is also *remembered*: the image goes into the
 browser's own storage (IndexedDB, never uploaded anywhere), and the next
@@ -510,6 +516,16 @@ fitted Agnus crystal, not the live BEAMCON0 bit ECS software can flip);
 CPU, chipset, video standard, RAM, ROM fingerprint -- for bug reports
 and diagnostics.
 
+`insert_floppy(drive, bytes, name)` takes any format the core reads --
+ADF/ADZ, extended ADF, DMS, IPF, SCP, plain or gzip/zip packed -- decided
+by signature, so the name it is given is only a label. The static
+`WebEmu.floppy_formats()` lists the extensions those formats conventionally
+carry (`["adf", "adz", ...]`, no dots) for the one thing a page cannot
+decide by content: a file input's `accept` filter, and any list it scrapes
+by name. Building the filter from it is what stops a picker hiding an image
+the build would happily read; its absence is the feature test on an older
+bundle.
+
 Input goes through `key_event(event.code, pressed)` (returns whether the key
 mapped, for `preventDefault`), `mouse_delta(dx, dy)` and
 `mouse_button(button, pressed)`. `key_raw(rawkey, pressed)` is the same
@@ -700,8 +716,10 @@ elements, and pages without them are untouched:
   `<folder>/index.json` -- a JSON array of file names, or of
   `{name, url}` objects with URLs resolved against the folder. Without a
   manifest, a server directory listing of the folder (nginx `autoindex`,
-  Apache, `python -m http.server`) is scraped for disk-image links
-  instead. If the folder yields nothing, the select hides itself.
+  Apache, `python -m http.server`) is scraped for links whose extension
+  the build reads (`WebEmu.floppy_formats()`, the same list the disk
+  picker filters on). If the folder yields nothing, the select hides
+  itself, as it does on a bundle too old to name its formats.
 - `#kicklist` (a `<select>`): the same list pattern for Kickstart ROMs.
   The folder is the select's `data-src` attribute (default `kick/`), with
   the same manifest-or-directory-listing contract as `#df0list`: a

--- a/src/floppy.rs
+++ b/src/floppy.rs
@@ -166,6 +166,18 @@ const UAE_EXT2_SIGNATURE: &[u8; 8] = b"UAE-1ADF";
 const SCP_SIGNATURE: &[u8; 3] = b"SCP";
 const GZIP_SIGNATURE: &[u8; 2] = &[0x1F, 0x8B];
 const ZIP_SIGNATURE: &[u8; 4] = &[0x50, 0x4b, 0x03, 0x04];
+
+/// The file extensions floppy images conventionally carry, in menu order.
+///
+/// The loader itself never looks at a name: [`FloppyImage::from_bytes`]
+/// decides by signature, which is why an oddly-named image still opens. This
+/// list exists only for the places that must offer a *name* filter and cannot
+/// sniff -- the desktop file dialogs and the browser page's file picker, both
+/// of which hide whatever they do not list. It lives beside the decoder so
+/// that adding a format to `decode_floppy_payload` and forgetting the filters
+/// is a one-line fix rather than a format that silently cannot be picked.
+pub const IMAGE_EXTENSIONS: &[&str] = &["adf", "adz", "dms", "ipf", "scp", "gz", "zip"];
+
 const STANDARD_EXTERNAL_DRIVE_ID: u32 = 0xFFFF_FFFF;
 const SCP_TRACK_TABLE_OFFSET: usize = 0x10;
 const SCP_EXTENDED_TRACK_TABLE_OFFSET: usize = 0x80;
@@ -5216,6 +5228,47 @@ mod tests {
         assert!(tracks[1..].iter().all(Option::is_none));
 
         let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    /// A host with no filesystem inserts bytes rather than a path: the
+    /// browser build's picker, drop target and `?df0=` fetch all land in
+    /// `insert_disk_image_bytes`, which sniffs the signature exactly as the
+    /// filesystem loader does. IPF is the case worth pinning, because the
+    /// format arrives as raw MFM instead of sectors and the only thing that
+    /// ever knew it apart from an ADF was the CAPS signature.
+    #[test]
+    fn ipf_bytes_insert_without_a_filesystem_and_stay_write_protected() -> Result<()> {
+        let cfg = FloppyConfig {
+            bridges: std::array::from_fn(|_| None),
+            speed: 100,
+            drives: [None, None, None, None],
+        };
+        let mut controller = FloppyController::from_config(&cfg)?;
+        controller.insert_disk_image_bytes(
+            0,
+            crate::ipf::tests::amigados_ipf_image(),
+            PathBuf::from("promo.ipf"),
+            true,
+        )?;
+
+        let image = controller.drives[0]
+            .image
+            .as_ref()
+            .expect("the IPF bytes should have loaded");
+        assert!(image.write_protected);
+        let FloppyImageData::Tracks(tracks) = &image.data else {
+            panic!("an IPF should decode to per-track raw MFM, not a sector image");
+        };
+        let Some(FloppyTrackImage::RawMfm { bit_len, .. }) = &tracks[0] else {
+            panic!("cylinder 0 head 0 should hold a raw MFM revolution");
+        };
+        assert_eq!(*bit_len, crate::ipf::tests::AMIGADOS_TRACK_BITS);
+        // The label a filesystem-less host passes is what the page shows.
+        assert_eq!(
+            controller.inserted_disk_name(0).as_deref(),
+            Some("promo.ipf")
+        );
         Ok(())
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3858,7 +3858,7 @@ fn display_file_name(path: &std::path::Path) -> String {
 /// sheets/hard disks/ROMs have no shared magic worth probing here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DroppedMediaKind {
-    /// Anything the floppy loader may accept (adf/adz/dms/scp/gz/zip and
+    /// Anything the floppy loader may accept (floppy::IMAGE_EXTENSIONS and
     /// unknown extensions): FloppyImage::from_bytes sniffs the content and
     /// rejects what it cannot read, surfacing a clean OSD failure.
     Floppy,
@@ -7058,10 +7058,9 @@ impl App {
             LauncherField::Df0Image
             | LauncherField::Df1Image
             | LauncherField::Df2Image
-            | LauncherField::Df3Image => dialog.add_filter(
-                "Floppy images",
-                &["adf", "adz", "dms", "scp", "gz", "ipf", "zip"],
-            ),
+            | LauncherField::Df3Image => {
+                dialog.add_filter("Floppy images", crate::floppy::IMAGE_EXTENSIONS)
+            }
             // Only formats CdImage::load takes: a cue sheet, a bare ISO,
             // or a CHD (a raw .bin is a cue sheet's payload, not loadable
             // alone).
@@ -9783,10 +9782,7 @@ impl App {
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
             .set_title(format!("Load DF{drive_idx} disk image(s)"))
-            .add_filter(
-                "Amiga disk images",
-                &["adf", "adz", "dms", "scp", "gz", "ipf", "zip"],
-            )
+            .add_filter("Amiga disk images", crate::floppy::IMAGE_EXTENSIONS)
             .pick_files();
 
         // The modal file dialog blocks this (the main/emulation) thread, so


### PR DESCRIPTION
## Root cause

The wasm core has decoded IPF ever since `src/ipf.rs` landed, and the
browser build carries it: `pub mod ipf` is unconditional, the decoder's
only dependency is `flate2`'s CRC, and `insert_floppy` goes straight to
`FloppyImage::from_bytes`, which decides by signature (`CAPS`) and never
looks at the file name. Drag-and-drop and `?df0=<url>` therefore already
worked with an IPF.

The **file picker** could not reach one. `<input type="file" accept=...>`
can only filter by extension and hides everything it does not list, and
the page shell's hand-written attribute still spelled the pre-IPF set:

```
$ curl -s https://copperline.dev/try/ | grep -o 'id="df0"[^>]*'
id="df0" type="file" accept=".adf,.adz,.dms,.gz,.zip,.scp" hidden
```

So an `.ipf` was greyed out by a bundle that reads IPF perfectly well.
The optional `#df0list` folder scrape in `try.js` carried the same stale
list (`/\.(adf|adz|dms|scp|zip|gz)$/i`). Neither the core, nor a feature
gate, nor a wasm-incompatible dependency, nor `config.rs`'s
`validate_floppy_image_path` (which already accepts `CAPS`, and which the
browser never reaches anyway) was involved.

Two lists of formats maintained by hand, in a repository that ships the
page glue precisely so it cannot drift from the API it drives.

## The fix

Give the list one home next to the decoder that owns it,
`floppy::IMAGE_EXTENSIONS`, and have everything that must filter by
*name* read it from there:

- both desktop `rfd` dialogs (which duplicated the list, and did already
  include `ipf`);
- a new static `WebEmu.floppy_formats()`, from which `try.js` builds the
  picker's `accept` attribute and the `#df0list` folder filter.

The glue rewrites an `accept` the shell shipped rather than trusting it,
so hand-written page HTML can no longer lag behind the wasm. A shell that
ships no filter at all keeps offering every file, and iOS keeps filtering
nothing (it drops the attribute already, because its document picker
greys out extensions it does not know). A bundle without
`floppy_formats` leaves the picker alone and hides the list, the way the
machine and video selects already hide themselves. The DF0-from-URL
prompt names the same formats.

No new files, so the publish workflow's copy list is unchanged.

## Tested

- `cargo test`: green (2323 lib tests, 0 failed), including a new
  `floppy::tests::ipf_bytes_insert_without_a_filesystem_and_stay_write_protected`
  covering the browser's only insert route -- IPF bytes with no
  filesystem anywhere, landing as write-protected raw MFM under the
  label the host passed.
- `cargo clippy --all-targets`, `cargo fmt --check`: clean.
- `cargo check --target wasm32-unknown-unknown --locked` and
  `cargo fmt --check` in `crates/copperline-web`, plus `npm test` in
  `www` (2 passing): clean.
- Full wasm build (`cargo build --release --target wasm32-unknown-unknown`
  plus `wasm-bindgen 0.2.126 --target web`) and the bundle served against
  a local copy of the real `/try` page shell in Chrome: after load,
  `#df0`'s accept reads `.adf,.adz,.dms,.ipf,.scp,.gz,.zip` (the shell's
  HTML says `.adf,.adz,.dms,.gz,.zip,.scp`), a 1 MB
  `Lemmings (Europe) (Promo).ipf` goes through the picker, and the page
  reports `booted AROS on the A500 - DF0: lemmings-promo.ipf
  (write-protected)` with the front-panel strip reading the name back out
  of the core.
- The same bundle driven from Node (`wasm-bindgen --target nodejs`) with
  that IPF: `floppy_formats()` returns `adf,adz,dms,ipf,scp,gz,zip`, the
  guest reads the disk (the head visits cylinders 0-27 over 25 emulated
  seconds), and the presentation buffer holds the Lemmings title screen.

Not verified: nothing on iOS/Safari (no device here) -- that path is
unchanged, the picker there still carries no filter.
