### PR TITLE
launcher: type the serial TCP addresses in the I/O Ports tab

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1061,9 +1061,14 @@ With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
 console. `--serial MODE` overrides the mode per run,
 `--serial-connect HOST:PORT` sets the dial-out target (and implies
 `mode = "tcp-connect"`), and `--midi-out NAME`/`--midi-in NAME` imply
-`mode = "midi"`. The launcher's **I/O Ports** tab (Serial section) and the
-in-window **MIDI In / MIDI Out** menu items select the MIDI endpoints
-interactively.
+`mode = "midi"`. The launcher's **I/O Ports** tab (Serial section) sets all
+of this interactively: **Device / Mode** picks the mode, and the mode brings
+its own address box with it -- **Connect** under `tcp-connect` for the
+remote to dial, **Listen** under `tcp` for the local bind address (it shows
+the `127.0.0.1:1234` default until something else is typed). Either box
+takes a `host:port`, with an IPv6 literal in brackets
+(`[::1]:1337`); clearing it unsets the key. The in-window
+**MIDI In / MIDI Out** menu items select the MIDI endpoints.
 
 The browser build has its own serial transport (the page bridges the port
 to a WebSocket); see [the browser chapter](browser.md).

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -453,7 +453,10 @@ The layout is:
   **Parallel:** / **Ethernet:** headings, with each port's options indented
   beneath it: serial mode and MIDI endpoints, with the emulated MT-32's ROM
   images, front panel and display style when it is the chosen output (see
-  [The MT-32](mt32.md)); the
+  [The MT-32](mt32.md)), and, for the two TCP modes, the address box that
+  mode needs -- **Connect** (`tcp-connect`) for the `host:port` to dial, or
+  **Listen** (`tcp`) for the local bind address, each typed into by clicking
+  it; the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
   and the A2065 Ethernet and HostSocket bsdsocket.library boards, each --

--- a/src/config.rs
+++ b/src/config.rs
@@ -779,13 +779,18 @@ pub struct SerialConfig {
     pub mt32_panel: bool,
     /// How that panel's display is lit.
     pub mt32_lcd: Mt32Lcd,
-    /// TCP listen address for [`SerialMode::Tcp`]; `None` means the
-    /// default `127.0.0.1:1234` (the port UAE's `TCP:` serial uses).
+    /// TCP listen address for [`SerialMode::Tcp`]; `None` means
+    /// [`SERIAL_TCP_DEFAULT_LISTEN`].
     pub listen: Option<String>,
     /// Remote `host:port` for [`SerialMode::TcpConnect`]. Required in that
     /// mode (there is no sensible default host to dial).
     pub connect: Option<String>,
 }
+
+/// Where [`SerialMode::Tcp`] listens with no `[serial] listen` of its own:
+/// the loopback interface on the port UAE's `TCP:` serial device uses, so a
+/// terminal pointed at either lands in the same place.
+pub const SERIAL_TCP_DEFAULT_LISTEN: &str = "127.0.0.1:1234";
 
 /// How the MT-32's front-panel display is lit.
 ///

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2032,13 +2032,17 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
             "[serial] mode = \"midi\" needs a build with --features midi"
         )),
         SerialMode::Tcp => Ok(Box::new(crate::serial::TcpSerialSink::listen(
-            cfg.serial.listen.as_deref().unwrap_or("127.0.0.1:1234"),
+            cfg.serial
+                .listen
+                .as_deref()
+                .unwrap_or(crate::config::SERIAL_TCP_DEFAULT_LISTEN),
         )?)),
         SerialMode::TcpConnect => {
             let addr = cfg.serial.connect.as_deref().ok_or_else(|| {
                 anyhow!(
                     "[serial] mode = \"tcp-connect\" needs a remote address: set \
-                     [serial] connect = \"host:port\" or pass --serial-connect"
+                     [serial] connect = \"host:port\", pass --serial-connect, \
+                     or fill in the launcher's I/O Ports > Serial > Connect box"
                 )
             })?;
             Ok(Box::new(crate::serial::TcpSerialSink::connect(addr)?))

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -4735,9 +4735,10 @@ pub enum EditTarget {
     SerialAddr(LauncherField),
 }
 
-/// The most an address box accepts. Long enough for a fully qualified name
-/// and a port, short enough that a mashed key never fills the buffer.
-const SERIAL_ADDR_MAX: usize = 96;
+/// The most an address box accepts: a DNS name is up to 253 characters
+/// (254 with a trailing root dot), and ":65535" is six more. Anything
+/// longer cannot be a host:port, so the box stops there.
+const SERIAL_ADDR_MAX: usize = 260;
 
 /// Why a typed serial address is not the `host:port` the TCP modes need,
 /// or `None` when it is one.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -472,9 +472,18 @@ pub enum LauncherField {
     WhdloadGame,
     WhdloadKickstarts,
     WhdloadLibrary,
-    // Serial (MIDI). Present only with the `midi` feature.
+    // Serial. Present only with the `midi` feature, the only build carrying
+    // serial rows at all.
     #[cfg(feature = "midi")]
     SerialMode,
+    /// The remote `host:port` the port dials in `tcp-connect` mode, typed
+    /// into the Serial section's Connect box.
+    #[cfg(feature = "midi")]
+    SerialConnect,
+    /// The local address the port binds in `tcp` mode, typed into the
+    /// Serial section's Listen box.
+    #[cfg(feature = "midi")]
+    SerialListen,
     #[cfg(feature = "midi")]
     MidiOut,
     Mt32ControlRom,
@@ -822,6 +831,19 @@ const WHDLOAD_ROWS: [Row; 3] = [
 // read as belonging to their `Serial:` / `Parallel:` / `Ethernet:` port.
 #[cfg(feature = "midi")]
 const SERIAL_ROWS_BASE: [Row; 1] = [row(F::SerialMode, "  Device / Mode", Cycle)];
+// The two TCP modes each carry one address, and only one: dialling out needs
+// somewhere to dial, listening needs somewhere to bind. Each box shows only
+// under the mode it belongs to, so neither mode offers the other's address.
+#[cfg(feature = "midi")]
+const SERIAL_ROWS_TCP_CONNECT: [Row; 2] = [
+    row(F::SerialMode, "  Device / Mode", Cycle),
+    row(F::SerialConnect, "  Connect", RowKind::Text),
+];
+#[cfg(feature = "midi")]
+const SERIAL_ROWS_TCP_LISTEN: [Row; 2] = [
+    row(F::SerialMode, "  Device / Mode", Cycle),
+    row(F::SerialListen, "  Listen", RowKind::Text),
+];
 #[cfg(feature = "midi")]
 const SERIAL_ROWS_MIDI: [Row; 3] = [
     row(F::SerialMode, "  Device / Mode", Cycle),
@@ -1032,7 +1054,11 @@ fn serial_rows(serial_mode: SerialMode, midi_out_is_mt32: bool) -> &'static [Row
     #[cfg(feature = "midi")]
     {
         if serial_mode != SerialMode::Midi {
-            return &SERIAL_ROWS_BASE;
+            return match serial_mode {
+                SerialMode::TcpConnect => &SERIAL_ROWS_TCP_CONNECT,
+                SerialMode::Tcp => &SERIAL_ROWS_TCP_LISTEN,
+                _ => &SERIAL_ROWS_BASE,
+            };
         }
         #[cfg(feature = "mt32")]
         if midi_out_is_mt32 {
@@ -1661,11 +1687,13 @@ pub struct MachineSetup {
     serial_mode: SerialMode,
     midi_out: Option<String>,
     midi_in: Option<String>,
-    /// TCP listen address for `mode = "tcp"`; carried so the override
-    /// round-trips through a launcher save even though no tab edits it.
+    /// TCP listen address for `mode = "tcp"`, typed into the Listen box the
+    /// Serial section shows in that mode. `None` binds the default
+    /// ([`crate::config::SERIAL_TCP_DEFAULT_LISTEN`]).
     serial_listen: Option<String>,
-    /// Dial-out address for `mode = "tcp-connect"`; carried like
-    /// `serial_listen` (no tab edits it, a save must not drop it).
+    /// Dial-out address for `mode = "tcp-connect"`, typed into the Connect
+    /// box that mode shows. `None` there has nothing to dial, and the run
+    /// says so rather than the launcher refusing the mode.
     serial_connect: Option<String>,
     /// The Centronics parallel-port device (None/Printer/Sampler), edited in the
     /// I/O Ports tab's Parallel section.
@@ -2006,6 +2034,28 @@ impl MachineSetup {
 
     pub fn parallel_device(&self) -> ParallelDevice {
         self.parallel_device
+    }
+
+    /// The address one of the serial TCP boxes holds, or `None` while it is
+    /// unset (the run then dials nothing and binds the default).
+    #[cfg(feature = "midi")]
+    pub fn serial_addr(&self, field: LauncherField) -> Option<&str> {
+        match field {
+            F::SerialConnect => self.serial_connect.as_deref(),
+            F::SerialListen => self.serial_listen.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Store what was typed into one of the serial TCP boxes. `None` clears
+    /// the key from a saved config rather than writing an empty address.
+    #[cfg(feature = "midi")]
+    pub fn set_serial_addr(&mut self, field: LauncherField, addr: Option<String>) {
+        match field {
+            F::SerialConnect => self.serial_connect = addr,
+            F::SerialListen => self.serial_listen = addr,
+            _ => {}
+        }
     }
 
     /// Whether the selected Ethernet backend carries traffic on the host's
@@ -3173,6 +3223,20 @@ impl MachineSetup {
                 SerialMode::TcpConnect => "TCP connect".to_string(),
                 SerialMode::Pty => "PTY".to_string(),
             },
+            // The dial-out address has no default -- there is no host to
+            // guess -- so an empty box says what it wants instead.
+            #[cfg(feature = "midi")]
+            F::SerialConnect => self
+                .serial_connect
+                .clone()
+                .unwrap_or_else(|| "(host:port)".to_string()),
+            // The listen address does have a default, so an empty box shows
+            // the address the run would actually bind.
+            #[cfg(feature = "midi")]
+            F::SerialListen => self
+                .serial_listen
+                .clone()
+                .unwrap_or_else(|| crate::config::SERIAL_TCP_DEFAULT_LISTEN.to_string()),
             #[cfg(feature = "midi")]
             F::MidiOut => {
                 if self.midi_out_is_mt32() {
@@ -3480,15 +3544,10 @@ impl MachineSetup {
             }
             #[cfg(feature = "midi")]
             F::SerialMode => {
-                // tcp-connect is only on offer when the config already
-                // carries a dial-out address (the launcher has no editor
-                // for it, and the mode fails at Run without one) -- same
-                // pattern as the printer's capture path below.
-                let choices: Vec<SerialMode> = SERIAL_MODES
-                    .into_iter()
-                    .filter(|m| self.serial_connect.is_some() || *m != SerialMode::TcpConnect)
-                    .collect();
-                self.serial_mode = cycle_slice(&choices, self.serial_mode, forward)
+                // Every mode is on offer: choosing tcp-connect brings its
+                // Connect box with it, so the address the mode needs can be
+                // typed here rather than only in a hand-written config.
+                self.serial_mode = cycle_slice(&SERIAL_MODES, self.serial_mode, forward)
             }
             #[cfg(feature = "midi")]
             F::MidiOut => {
@@ -4672,6 +4731,38 @@ pub enum EditTarget {
     DriveBootpri(LauncherField),
     /// A word typed on a Create Image page: a volume name or a device name.
     NewImageText(LauncherField),
+    /// A `host:port` typed into the Serial section's Connect or Listen box.
+    SerialAddr(LauncherField),
+}
+
+/// The most an address box accepts. Long enough for a fully qualified name
+/// and a port, short enough that a mashed key never fills the buffer.
+const SERIAL_ADDR_MAX: usize = 96;
+
+/// Why a typed serial address is not the `host:port` the TCP modes need,
+/// or `None` when it is one.
+///
+/// Nothing here resolves a name or opens a socket: that happens at Run, and
+/// a host that is merely down should not stop the address being typed. What
+/// it does catch is the shape, so a missing or unreadable port is refused
+/// while the box still has the focus to fix it in.
+fn serial_addr_error(addr: &str) -> Option<String> {
+    let Some((host, port)) = addr.rsplit_once(':') else {
+        return Some(format!("\"{addr}\" has no port: type host:port"));
+    };
+    // An IPv6 literal is full of colons, so it is written in brackets and
+    // only the colon after the closing one separates the port.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    if host.is_empty() {
+        return Some(format!("\"{addr}\" has no host: type host:port"));
+    }
+    if port.parse::<u16>().is_err() {
+        return Some(format!("\"{port}\" is not a port number (0-65535)"));
+    }
+    None
 }
 
 /// The largest size the box accepts, in whichever unit is showing.
@@ -5031,6 +5122,31 @@ impl LauncherState {
         )
     }
 
+    /// Whether a field is one of the Serial section's TCP address boxes.
+    /// They share the Create Image pages' free-text widget but hold machine
+    /// configuration, so the drawing and click paths have to tell them apart.
+    pub fn is_serial_addr(field: LauncherField) -> bool {
+        #[cfg(feature = "midi")]
+        {
+            matches!(field, F::SerialConnect | F::SerialListen)
+        }
+        #[cfg(not(feature = "midi"))]
+        {
+            let _ = field;
+            false
+        }
+    }
+
+    /// Whether the value box for `field` is the one being typed into. Both
+    /// the Create Image boxes and the serial address boxes are drawn by the
+    /// same widget, so it asks this one question of either.
+    pub fn typing_in_value_box(&self, field: LauncherField) -> bool {
+        matches!(
+            self.editing,
+            Some(EditTarget::NewImageText(f) | EditTarget::SerialAddr(f)) if f == field
+        )
+    }
+
     /// The filesystem a Create Image row is about: the floppy page's or the
     /// hard-drive page's, whichever row asked.
     pub fn workshop_fs_of(&self, field: LauncherField) -> Option<crate::diskimage::FileSystem> {
@@ -5327,6 +5443,23 @@ impl LauncherState {
         self.status = None;
     }
 
+    /// Focus a serial TCP address box, seeding the buffer with the address
+    /// it holds. An unset box starts empty rather than from what it shows:
+    /// the default listen address and the "(host:port)" prompt are both
+    /// placeholders, not values to be typed over.
+    pub fn begin_edit_serial_addr(&mut self, field: LauncherField) {
+        if !Self::is_serial_addr(field) {
+            return;
+        }
+        self.edit_buffer.clear();
+        #[cfg(feature = "midi")]
+        if let Some(addr) = self.setup.serial_addr(field) {
+            self.edit_buffer.push_str(addr);
+        }
+        self.editing = Some(EditTarget::SerialAddr(field));
+        self.status = None;
+    }
+
     pub fn new(setup: MachineSetup) -> Self {
         let mut setup = setup;
         // Read the host devices as the screen opens so the pickers show what is
@@ -5413,6 +5546,15 @@ impl LauncherState {
                     return;
                 }
                 self.edit_buffer.push(c);
+                return;
+            }
+        }
+        // An address is a run of printable characters with no spaces in it:
+        // a name or a numeric literal, a colon, and a port. Brackets and
+        // colons are in there for IPv6, so nothing narrower than "graphic"
+        // would do.
+        if let EditTarget::SerialAddr(_) = target {
+            if !c.is_ascii_graphic() || self.edit_buffer.chars().count() >= SERIAL_ADDR_MAX {
                 return;
             }
         }
@@ -5541,6 +5683,30 @@ impl LauncherState {
                 self.edit_buffer.clear();
                 return;
             }
+            EditTarget::SerialAddr(field) => {
+                // An emptied box means "unset": the dial-out address goes
+                // away, and the listen address returns to the default. A
+                // typed one has to be a host:port or it keeps the focus,
+                // the same as a rejected drive name -- the mode is bound to
+                // fail at Run otherwise, and this is where it can be fixed.
+                let typed = self.edit_buffer.trim();
+                let addr = if typed.is_empty() {
+                    None
+                } else {
+                    if let Some(err) = serial_addr_error(typed) {
+                        self.status = Some(StatusMessage::err(err));
+                        return;
+                    }
+                    Some(typed.to_string())
+                };
+                #[cfg(feature = "midi")]
+                self.setup.set_serial_addr(field, addr);
+                #[cfg(not(feature = "midi"))]
+                let _ = (field, addr);
+                self.editing = None;
+                self.edit_buffer.clear();
+                return;
+            }
             EditTarget::BoardOption { .. } => {}
         }
         self.editing = None;
@@ -5550,8 +5716,10 @@ impl LauncherState {
                 self.setup.zorro_option_set(board, opt, value)
             }
             EditTarget::DriveName(field) => self.setup.set_drive_name(field, value),
-            // Both commit above and return, so nothing is left to do here.
-            EditTarget::DriveBootpri(_) | EditTarget::NewImageText(_) => {}
+            // These commit above and return, so nothing is left to do here.
+            EditTarget::DriveBootpri(_)
+            | EditTarget::NewImageText(_)
+            | EditTarget::SerialAddr(_) => {}
         }
     }
 
@@ -5585,9 +5753,18 @@ fn cpu_is_32bit(cpu: CpuModel) -> bool {
 /// raw tables cover every classifiable field.
 fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
     #[cfg(all(feature = "midi", feature = "mt32"))]
-    let serial: &[&[Row]] = &[&SERIAL_ROWS_MIDI, &SERIAL_ROWS_MT32];
+    let serial: &[&[Row]] = &[
+        &SERIAL_ROWS_MIDI,
+        &SERIAL_ROWS_MT32,
+        &SERIAL_ROWS_TCP_CONNECT,
+        &SERIAL_ROWS_TCP_LISTEN,
+    ];
     #[cfg(all(feature = "midi", not(feature = "mt32")))]
-    let serial: &[&[Row]] = &[&SERIAL_ROWS_MIDI];
+    let serial: &[&[Row]] = &[
+        &SERIAL_ROWS_MIDI,
+        &SERIAL_ROWS_TCP_CONNECT,
+        &SERIAL_ROWS_TCP_LISTEN,
+    ];
     #[cfg(not(feature = "midi"))]
     let serial: &[&[Row]] = &[];
     let sources: &[&[Row]] = &[
@@ -7505,8 +7682,9 @@ mod tests {
 
     #[test]
     fn serial_tcp_listen_round_trips_through_raw() {
-        // A launcher save must not drop the [serial] listen override, which
-        // no tab edits (regression: it was absent from MachineSetup/to_raw).
+        // A launcher save must not drop the [serial] listen override, whether
+        // or not the tab that edits it was ever opened (regression: it was
+        // absent from MachineSetup/to_raw altogether).
         let mut raw = RawConfig::default();
         raw.serial.mode = Some("tcp".into());
         raw.serial.listen = Some("0.0.0.0:2323".into());
@@ -7518,30 +7696,168 @@ mod tests {
 
     #[cfg(feature = "midi")]
     #[test]
-    fn serial_mode_cycle_offers_tcp_connect_only_with_an_address() {
-        // The launcher has no editor for the dial-out address, so without
-        // one in the loaded config the mode would always fail at Run;
-        // cycling skips it (same pattern as the printer capture path).
+    fn serial_mode_cycle_always_offers_tcp_connect() {
+        // tcp-connect used to be skipped unless the loaded config already
+        // carried a dial-out address, because nothing here could type one.
+        // The Connect box can, so every mode is now reachable from the
+        // picker whatever the config arrived holding.
         let mut setup = MachineSetup {
             serial_mode: SerialMode::Tcp,
-            ..Default::default()
-        };
-        setup.cycle(LauncherField::SerialMode, true);
-        assert_eq!(setup.serial_mode, SerialMode::Pty);
-
-        let mut setup = MachineSetup {
-            serial_mode: SerialMode::Tcp,
-            serial_connect: Some("bbs.example.com:1337".into()),
             ..Default::default()
         };
         setup.cycle(LauncherField::SerialMode, true);
         assert_eq!(setup.serial_mode, SerialMode::TcpConnect);
+
+        // And the picker walks the whole list either way round.
+        let mut seen: Vec<SerialMode> = Vec::new();
+        for _ in 0..SERIAL_MODES.len() * 2 {
+            if !seen.contains(&setup.serial_mode) {
+                seen.push(setup.serial_mode);
+            }
+            setup.cycle(LauncherField::SerialMode, false);
+        }
+        assert_eq!(seen.len(), SERIAL_MODES.len());
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn serial_address_rows_appear_only_in_their_tcp_mode() {
+        let has = |mode, field| {
+            rows(LauncherTab::IoPorts, ParallelDevice::None, mode, false)
+                .iter()
+                .any(|r| r.field == field)
+        };
+        // Dialling out needs somewhere to dial; listening needs somewhere to
+        // bind. Neither mode carries the other's address, and the modes with
+        // no address at all show neither box.
+        assert!(has(SerialMode::TcpConnect, LauncherField::SerialConnect));
+        assert!(!has(SerialMode::TcpConnect, LauncherField::SerialListen));
+        assert!(has(SerialMode::Tcp, LauncherField::SerialListen));
+        assert!(!has(SerialMode::Tcp, LauncherField::SerialConnect));
+        for mode in [SerialMode::Off, SerialMode::Stdout, SerialMode::Midi] {
+            assert!(!has(mode, LauncherField::SerialConnect));
+            assert!(!has(mode, LauncherField::SerialListen));
+        }
+        // Both boxes are free-text rows, so the panel draws and hit-tests
+        // them with the value-box widget.
+        for (mode, field) in [
+            (SerialMode::TcpConnect, LauncherField::SerialConnect),
+            (SerialMode::Tcp, LauncherField::SerialListen),
+        ] {
+            let r = rows(LauncherTab::IoPorts, ParallelDevice::None, mode, false);
+            let found = r.iter().find(|r| r.field == field).unwrap();
+            assert_eq!(found.kind, RowKind::Text);
+            assert!(LauncherState::is_serial_addr(field));
+        }
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn typing_a_serial_connect_address_sets_it_and_round_trips() {
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.setup.serial_mode = SerialMode::TcpConnect;
+        state.begin_edit_serial_addr(LauncherField::SerialConnect);
+        assert_eq!(state.edit_buffer(), "", "an unset box starts empty");
+        for c in "bbs.example.com:1337".chars() {
+            state.edit_push(c);
+        }
+        state.edit_commit();
+        assert!(state.editing().is_none());
+        assert_eq!(
+            state.setup.serial_connect.as_deref(),
+            Some("bbs.example.com:1337")
+        );
+        // What was typed is what a Save writes.
+        let raw = state.setup.to_raw();
+        assert_eq!(raw.serial.mode.as_deref(), Some("tcp-connect"));
+        assert_eq!(raw.serial.connect.as_deref(), Some("bbs.example.com:1337"));
+
+        // Re-opening the box starts from the address it holds, not from a
+        // placeholder, so an edit is a correction rather than a retype.
+        state.begin_edit_serial_addr(LauncherField::SerialConnect);
+        assert_eq!(state.edit_buffer(), "bbs.example.com:1337");
+        state.edit_cancel();
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn a_serial_address_without_a_port_keeps_the_focus() {
+        let mut state = LauncherState::new(MachineSetup::default());
+        for bad in ["bbs.example.com", "bbs.example.com:sixty", ":1337"] {
+            state.begin_edit_serial_addr(LauncherField::SerialConnect);
+            for c in bad.chars() {
+                state.edit_push(c);
+            }
+            state.edit_commit();
+            assert_eq!(
+                state.editing(),
+                Some(EditTarget::SerialAddr(LauncherField::SerialConnect)),
+                "{bad} was accepted"
+            );
+            assert!(state.status.is_some(), "{bad} was refused silently");
+            assert_eq!(state.setup.serial_connect, None);
+            state.edit_cancel();
+        }
+        // A bracketed IPv6 literal is a host:port even though it is full of
+        // colons: only the one after the closing bracket separates the port.
+        state.begin_edit_serial_addr(LauncherField::SerialConnect);
+        for c in "[::1]:1337".chars() {
+            state.edit_push(c);
+        }
+        state.edit_commit();
+        assert!(state.editing().is_none());
+        assert_eq!(state.setup.serial_connect.as_deref(), Some("[::1]:1337"));
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn emptying_a_serial_address_box_unsets_it() {
+        let mut state = LauncherState::new(MachineSetup {
+            serial_mode: SerialMode::Tcp,
+            serial_listen: Some("0.0.0.0:2323".into()),
+            ..Default::default()
+        });
+        // The box shows what is bound; emptying it returns to the default,
+        // which is what the value column then shows.
+        assert_eq!(
+            state.setup.value_label(LauncherField::SerialListen),
+            "0.0.0.0:2323"
+        );
+        state.begin_edit_serial_addr(LauncherField::SerialListen);
+        for _ in 0..64 {
+            state.edit_backspace();
+        }
+        state.edit_commit();
+        assert_eq!(state.setup.serial_listen, None);
+        assert_eq!(
+            state.setup.value_label(LauncherField::SerialListen),
+            crate::config::SERIAL_TCP_DEFAULT_LISTEN
+        );
+        assert!(state.setup.to_raw().serial.listen.is_none());
+    }
+
+    #[cfg(feature = "midi")]
+    #[test]
+    fn a_serial_address_box_takes_only_printable_characters() {
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.begin_edit_serial_addr(LauncherField::SerialListen);
+        // A space is not part of an address, and neither is a control code.
+        for c in "127.0.0.1 :\t12\n34".chars() {
+            state.edit_push(c);
+        }
+        assert_eq!(state.edit_buffer(), "127.0.0.1:1234");
+        // And the box has an end: a stuck key cannot grow it without bound.
+        for _ in 0..SERIAL_ADDR_MAX * 2 {
+            state.edit_push('9');
+        }
+        assert_eq!(state.edit_buffer().chars().count(), SERIAL_ADDR_MAX);
+        state.edit_cancel();
     }
 
     #[test]
     fn serial_tcp_connect_round_trips_through_raw() {
-        // Same contract as the listen override: the dial-out address has no
-        // launcher editor, so loading and saving must carry it unchanged.
+        // Same contract as the listen override: loading and saving carry the
+        // dial-out address unchanged when nothing retypes it.
         let mut raw = RawConfig::default();
         raw.serial.mode = Some("tcp-connect".into());
         raw.serial.connect = Some("bbs.example.com:1337".into());

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -758,6 +758,8 @@ pub enum UiControl {
     LauncherDriveNameEdit(LauncherField),
     /// A free-text box on a Create Image page (a volume or device name).
     LauncherNewImageEdit(LauncherField),
+    /// A serial TCP address box on the I/O Ports tab (Connect or Listen).
+    LauncherSerialAddrEdit(LauncherField),
     /// The Create button on a Create Image page.
     LauncherNewImageCreate(LauncherField),
     /// The MB/GB written beside the hard-drive size, which swaps on click.
@@ -4191,6 +4193,10 @@ const LAUNCH_CLEAR_W: usize = 54;
 const LAUNCH_PATH_VALUE_W: usize = 216;
 /// Width of the editable volume-name box on a drive row.
 const LAUNCH_NAME_W: usize = 96;
+/// Width of the serial TCP address box. Far wider than a volume name's,
+/// because a host name and a port together are a long string and the port
+/// is at the far end of it -- the part a reader most needs to see.
+const LAUNCH_ADDR_W: usize = LAUNCH_PATH_VALUE_W;
 const LAUNCH_REMOVE_W: usize = 70;
 const LAUNCH_CONTROL_H: usize = 20;
 
@@ -4338,13 +4344,18 @@ fn launcher_nav_rows(slots: usize) -> usize {
     slots.max(1).div_ceil(LAUNCH_NAV_PER_ROW)
 }
 
-/// A free-text value box on a Create Image row: where a value would sit, at
-/// the width a volume or device name needs.
-fn launcher_text_rect(rect: Rect, row_y: usize) -> Rect {
+/// A free-text value box: where a value would sit, at the width its content
+/// needs -- a volume or device name on a Create Image row, or the longer
+/// `host:port` of a serial address on the I/O Ports tab.
+fn launcher_text_rect(rect: Rect, row_y: usize, field: LauncherField) -> Rect {
     Rect {
         x: launcher_pane_x(rect) + LAUNCH_LABEL_W,
         y: row_y + (LAUNCH_ROW_H - LAUNCH_CONTROL_H) / 2,
-        w: LAUNCH_NAME_W,
+        w: if LauncherState::is_serial_addr(field) {
+            LAUNCH_ADDR_W
+        } else {
+            LAUNCH_NAME_W
+        },
         h: LAUNCH_CONTROL_H,
     }
 }
@@ -4422,8 +4433,10 @@ fn indefinite_article(size: &str) -> &'static str {
     }
 }
 
-/// Draw a workshop value box: what the setting holds, or what is being
-/// typed into it, with a caret while it has the focus.
+/// Draw a free-text/number value box: what the setting holds, or what is
+/// being typed into it, with a caret while it has the focus. Used by the
+/// Create Image pages and by the Serial section's TCP address boxes, so it
+/// reads the value through `row_value` rather than from either store.
 fn draw_launcher_value_box(
     frame: &mut [u8],
     box_rect: Rect,
@@ -4440,15 +4453,23 @@ fn draw_launcher_value_box(
         BUTTON_EDGE_LIGHT,
         scale,
     );
-    let typing = state.editing() == Some(EditTarget::NewImageText(field));
+    let typing = state.typing_in_value_box(field);
     let (text, color) = if typing {
         (format!("{}_", state.edit_buffer()), PANEL_TEXT_HILIGHT)
     } else if disabled {
-        (state.workshop_value(field), PANEL_TEXT_DIM)
+        (state.row_value(field), PANEL_TEXT_DIM)
     } else {
-        (state.workshop_value(field), PANEL_TEXT)
+        (state.row_value(field), PANEL_TEXT)
     };
-    let shown = truncate_to_width(&text, box_rect.w.saturating_sub(8));
+    let avail = box_rect.w.saturating_sub(8);
+    // A value that is too long loses its head while it is being typed and
+    // its tail otherwise: what matters when typing is where the caret is,
+    // and it is at the end.
+    let shown = if typing {
+        clip_text_tail(&text, avail)
+    } else {
+        truncate_to_width(&text, avail)
+    };
     // A short figure between two arrows reads as belonging to them when it
     // is centred, and as a stray left-aligned word when it is not.
     let x = if centred {
@@ -4990,8 +5011,14 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                 // Non-interactive rows.
                 RowKind::SectionHeader | RowKind::BootpriHeader => {}
                 RowKind::Text => {
-                    if launcher_text_rect(rect, row_y).contains(pos) {
-                        return Some(UiControl::LauncherNewImageEdit(r.field));
+                    if launcher_text_rect(rect, row_y, r.field).contains(pos) {
+                        // The same widget serves two stores: a Create Image
+                        // word, and a serial address on the machine.
+                        return Some(if LauncherState::is_serial_addr(r.field) {
+                            UiControl::LauncherSerialAddrEdit(r.field)
+                        } else {
+                            UiControl::LauncherNewImageEdit(r.field)
+                        });
                     }
                 }
                 RowKind::Size => {
@@ -5617,12 +5644,13 @@ fn truncate_to_width(text: &str, avail_px: usize) -> String {
     format!("{kept}~")
 }
 
-/// Clip a path to `avail_px`, keeping the TAIL and prefixing an ASCII "..."
+/// Clip `text` to `avail_px`, keeping the TAIL and prefixing an ASCII "..."
 /// when it does not fit -- for a host directory the meaningful end (the leaf
-/// dir) stays visible. The bitmap font is ASCII-only, so a real ellipsis
-/// glyph cannot be drawn; "..." is the closest it can render. Mirrors
-/// [`truncate_to_width`], which keeps the head instead.
-fn clip_path_tail(text: &str, avail_px: usize) -> String {
+/// dir) stays visible, and for a field being typed into it is the caret. The
+/// bitmap font is ASCII-only, so a real ellipsis glyph cannot be drawn; "..."
+/// is the closest it can render. Mirrors [`truncate_to_width`], which keeps
+/// the head instead.
+fn clip_text_tail(text: &str, avail_px: usize) -> String {
     let max_chars = avail_px / font::GLYPH_W;
     let len = text.chars().count();
     if len <= max_chars {
@@ -5668,7 +5696,7 @@ pub(super) fn clip_path_to_chars(text: &str, max_chars: usize) -> String {
         prefixed
     } else {
         // The file name alone does not fit; fall back to a plain tail clip.
-        clip_path_tail(name, max_chars * font::GLYPH_W)
+        clip_text_tail(name, max_chars * font::GLYPH_W)
     }
 }
 
@@ -5875,7 +5903,7 @@ fn draw_launcher_row(
         RowKind::Text => {
             draw_launcher_value_box(
                 frame,
-                launcher_text_rect(rect, row_y),
+                launcher_text_rect(rect, row_y, r.field),
                 state,
                 r.field,
                 disabled,
@@ -7552,6 +7580,9 @@ mod tests {
                             launcher_toggle_rect(rect, row_y),
                             launcher_drive_name_rect(rect, row_y),
                             launcher_bootable_rect(rect, row_y),
+                            // The widest of these: a serial address box is
+                            // sized for a host name and a port.
+                            launcher_text_rect(rect, row_y, r.field),
                         ];
                         for b in boxes {
                             let label = r.label;
@@ -8147,6 +8178,46 @@ mod tests {
         assert_eq!(ui.control_at(body), Some(UiControl::PanelBody));
         // Outside the panel: nothing.
         assert_eq!(ui.control_at((0, 0)), None);
+    }
+
+    /// Clicking a serial address box opens *that* edit, not the Create Image
+    /// one the free-text widget was first built for.
+    #[cfg(feature = "midi")]
+    #[test]
+    fn the_serial_address_box_hit_tests_to_its_own_edit() {
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::IoPorts;
+        while state.setup.serial_mode() != crate::config::SerialMode::TcpConnect {
+            state.setup.cycle(LauncherField::SerialMode, true);
+        }
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: menu::MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        let Some(Panel::Launcher(state)) = ui.panel.as_ref() else {
+            unreachable!()
+        };
+        let rect = panel_rect(ui.panel.as_ref().unwrap());
+        let index = launcher::rows(
+            state.tab,
+            state.setup.parallel_device(),
+            state.setup.serial_mode(),
+            state.setup.midi_out_is_mt32(),
+        )
+        .iter()
+        .filter(|r| !state.setup.row_hidden(r.field))
+        .position(|r| r.field == LauncherField::SerialConnect)
+        .expect("no Connect row in tcp-connect mode");
+        let row_y = launcher_row_y(rect, index);
+        let box_rect = launcher_text_rect(rect, row_y, LauncherField::SerialConnect);
+        assert_eq!(
+            ui.control_at((box_rect.x as i32 + 4, box_rect.y as i32 + 4)),
+            Some(UiControl::LauncherSerialAddrEdit(
+                LauncherField::SerialConnect
+            ))
+        );
     }
 
     #[test]
@@ -9341,6 +9412,31 @@ mod tests {
         };
         draw(&mut frame, scale, &ui, None, None);
         save(&frame, "launcher-printer");
+
+        // I/O Ports with the serial port dialling out: the Connect address
+        // box the tcp-connect mode brings with it, mid-edit so the caret and
+        // the highlight show too.
+        #[cfg(feature = "midi")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.tab = LauncherTab::IoPorts;
+            while state.setup.serial_mode() != crate::config::SerialMode::TcpConnect {
+                state.setup.cycle(LauncherField::SerialMode, true);
+            }
+            state.begin_edit_serial_addr(LauncherField::SerialConnect);
+            for c in "bbs.example.com:1337".chars() {
+                state.edit_push(c);
+            }
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-serial-tcp");
+        }
 
         // The Host Folder sub-page reached from the Storage tab.
         let mut frame = vec![0u8; w * h * 4];

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5779,15 +5779,17 @@ impl App {
             UiControl::LauncherCycle { field, forward } => {
                 if let Some(state) = self.launcher_state_mut() {
                     // Reaching for another control ends the typing, the way
-                    // Enter does: what is in the box counts.
+                    // Enter does: what is in the box counts. A value the
+                    // commit refuses keeps the focus and blocks the click --
+                    // cycling on regardless could hide the very row being
+                    // edited (the serial mode carries its address box).
                     state.edit_commit();
-                    let refused = state.editing().is_some();
-                    if LauncherState::is_workshop(field) {
-                        state.workshop_cycle(field, forward);
-                    } else {
-                        state.setup.cycle(field, forward);
-                    }
-                    if !refused {
+                    if state.editing().is_none() {
+                        if LauncherState::is_workshop(field) {
+                            state.workshop_cycle(field, forward);
+                        } else {
+                            state.setup.cycle(field, forward);
+                        }
                         state.status = None;
                     }
                 }
@@ -5795,13 +5797,12 @@ impl App {
             UiControl::LauncherToggle(field) => {
                 if let Some(state) = self.launcher_state_mut() {
                     state.edit_commit();
-                    let refused = state.editing().is_some();
-                    if LauncherState::is_workshop(field) {
-                        state.workshop_toggle_flip(field);
-                    } else {
-                        state.setup.toggle(field);
-                    }
-                    if !refused {
+                    if state.editing().is_none() {
+                        if LauncherState::is_workshop(field) {
+                            state.workshop_toggle_flip(field);
+                        } else {
+                            state.setup.toggle(field);
+                        }
                         state.status = None;
                     }
                 }
@@ -7421,9 +7422,16 @@ impl App {
     }
 
     fn launcher_save(&mut self) {
-        // Capture a name/option typed but not yet committed with Enter.
+        // Capture a name/option typed but not yet committed with Enter. A
+        // value the commit refuses keeps the focus and blocks the save:
+        // writing the file anyway would silently save the previous value
+        // while the box shows the rejected one.
         if let Some(state) = self.launcher_state_mut() {
             state.edit_commit();
+            if state.editing().is_some() {
+                self.request_redraw();
+                return;
+            }
         }
         let toml = match self.launcher_state().map(|s| s.setup.to_toml()) {
             Some(Ok(text)) => text,
@@ -7462,9 +7470,16 @@ impl App {
     /// machine-construction errors all stay in the panel as a status line;
     /// only success swaps the live machine.
     fn launcher_run(&mut self) {
-        // Capture a name/option typed but not yet committed with Enter.
+        // Capture a name/option typed but not yet committed with Enter. A
+        // value the commit refuses keeps the focus and blocks the run,
+        // which would otherwise boot against the previous value while the
+        // box shows the rejected one.
         if let Some(state) = self.launcher_state_mut() {
             state.edit_commit();
+            if state.editing().is_some() {
+                self.request_redraw();
+                return;
+            }
         }
         let raw = match self.launcher_state().map(|s| s.setup.to_raw()) {
             Some(raw) => raw,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5823,6 +5823,17 @@ impl App {
                     state.begin_edit_new_image(field);
                 }
             }
+            UiControl::LauncherSerialAddrEdit(field) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    // Reaching for the other address box ends the typing in
+                    // this one, the way Enter does; an address it refuses
+                    // keeps the focus where the mistake is.
+                    state.edit_commit();
+                    if state.editing().is_none() {
+                        state.begin_edit_serial_addr(field);
+                    }
+                }
+            }
             UiControl::LauncherNewImageCreate(field) => self.launcher_create_image(field),
             UiControl::LauncherFsFamily { field, family } => {
                 if let Some(state) = self.launcher_state_mut() {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3461,6 +3461,48 @@ fn launcher_panel_edits_machine_setup() {
     assert!(state.setup.build_config().is_ok());
 }
 
+/// A value the commit refuses keeps the focus AND blocks the click that
+/// interrupted the typing: cycling the serial mode away would hide the very
+/// box being fixed, and Save/Run would quietly act on the previous value.
+#[cfg(feature = "midi")]
+#[test]
+fn a_rejected_serial_address_blocks_the_control_it_interrupted() {
+    use crate::config::SerialMode;
+    use crate::video::launcher::{EditTarget, LauncherField};
+
+    let mut app = test_app();
+    app.open_launcher();
+    // Dial the serial port out and type an address with no port in it.
+    match app.ui.panel.as_mut() {
+        Some(Panel::Launcher(state)) => {
+            while state.setup.serial_mode() != SerialMode::TcpConnect {
+                state.setup.cycle(LauncherField::SerialMode, true);
+            }
+            state.begin_edit_serial_addr(LauncherField::SerialConnect);
+            for c in "no-port".chars() {
+                state.edit_push(c);
+            }
+        }
+        _ => panic!("launcher did not open"),
+    }
+    // The mode-cycle click commits the box first; the refusal wins.
+    app.activate_ui_control(UiControl::LauncherCycle {
+        field: LauncherField::SerialMode,
+        forward: true,
+    });
+    match &app.ui.panel {
+        Some(Panel::Launcher(state)) => {
+            assert_eq!(state.setup.serial_mode(), SerialMode::TcpConnect);
+            assert_eq!(
+                state.editing(),
+                Some(EditTarget::SerialAddr(LauncherField::SerialConnect))
+            );
+            assert!(state.status.is_some(), "the rejection is explained");
+        }
+        _ => panic!("launcher closed unexpectedly"),
+    }
+}
+
 #[test]
 fn launcher_run_keeps_panel_open_on_error() {
     use crate::video::launcher::LauncherField;


### PR DESCRIPTION
The machine-configuration screen's serial section offered the TCP modes but no way to type either address: `tcp-connect` was skipped in the Device / Mode cycle unless the loaded config already carried a dial-out address (the old workaround for having no editor), and the `tcp` listen bind could only be set in a hand-written TOML.

## What changed

- The I/O Ports tab now shows a free-text address box under the mode that needs it: **Connect** (`host:port` to dial) under `tcp-connect`, **Listen** (local bind address, showing the `127.0.0.1:1234` default while unset) under `tcp`. Neither mode offers the other's address, and the modes with no address show neither box.
- The Device / Mode cycle offers every mode again; the tcp-connect gate is gone.
- Commit validates the shape only -- `rsplit_once(':')`, non-empty host, `u16` port, bracketed IPv6 (`[::1]:1337`) accepted -- because a host that is merely down must not block typing. A rejected address keeps the focus with a status message saying what is wrong; an emptied box unsets the key (Listen returns to the default). Resolution and connection stay at emulator start, where the "needs a remote address" error now also names the Connect box.
- Plumbing: the Create Image pages' value-box widget is generalized to serve machine fields. The hit-test routes serial address fields to their own `UiControl`/`EditTarget`, the box reads through `row_value`, and while typing the *tail* is clipped instead of the head so the caret stays visible in a long address. `127.0.0.1:1234` is now a named constant (`SERIAL_TCP_DEFAULT_LISTEN`) shared by the launcher placeholder and the emulator.

`MachineSetup::serial_connect`/`serial_listen` already existed and round-tripped through save/load; this is purely the missing editor.

## Tests

Six new launcher tests (mode cycle sweep, rows-per-mode, type-and-round-trip, reject-keeps-focus + IPv6 accept, empty-unsets, printable-only + length cap) and a ui.rs hit-test test, plus a `launcher-serial-tcp` state in the panel preview render. Full suite green (2351 passed), clippy and fmt clean. Feature sweeps: `--no-default-features --features frontend` (no midi) and `--features frontend,midi` (no mt32) both check clean, and the wasm crate still builds.

## Docs

`docs/guide/configuration.md` (`[serial]` launcher paragraph) and `docs/guide/ui.md` (I/O Ports tab) updated in the same change.
