### PR TITLE
romdb: identify Kickstart ROMs by checksum

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -123,6 +123,21 @@ file boots identically. A 256 KiB Kickstart 1.x part is mirrored across the
 pairs for the 32-bit machines are not accepted; use the matching single-file
 image instead.
 
+Copperline also names the ROM it is given. A ROM file's name is whatever its
+dumper called it, so the image is identified by checksum against a table of
+the released Amiga boot ROMs -- every Kickstart from 1.0 to 3.2.3, the CD32
+Kickstart and extended ROM, the CDTV/A570 extended ROMs and the A1000
+bootstrap -- and the version is reported as, for example,
+`Kickstart 3.1 (40.68) A1200`. Identification survives the same forms the
+loader accepts (byte-swapped dumps, a 256 KiB part stored doubled), and an
+Amiga Forever image still in its `AMIROMTYPE1` container is reported as
+encrypted rather than unknown. The identification appears in the start-up
+`config:` log line, in the About window's `ROM:` line, in the OSD when a ROM
+is fitted from the menu, and under each path row of the machine-configuration
+screen's ROM tab. The bundled AROS ROM reports itself as `bundled AROS`; any
+other image the table does not carry -- DiagROM, a ROM you built yourself --
+simply goes unnamed and boots as usual.
+
 ## `[machine]` -- machine profiles
 
 ```toml

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -373,9 +373,13 @@ Shown only when something is on the port.
   Kickstart, then optionally a second file for the extended ROM (512 KiB at
   $E00000 or 256 KiB at $F00000; Cancel to skip and remove any fitted
   extended ROM). The machine then cold-resets, as if the chip had been
-  swapped and the power cycled.
+  swapped and the power cycled. The OSD names the image it fitted -- the
+  file name plus the Kickstart it was identified as, e.g.
+  `ROM: kick40068.A1200 (Kickstart 3.1 (40.68) A1200)`.
 - **Keyboard Shortcuts...**: the shortcut reference.
-- **About...**: app version plus a summary of the emulated machine, and
+- **About...**: app version plus a summary of the emulated machine -- its
+  `ROM:` line names the boot ROM file and, for a released image, which
+  Kickstart it is (identified by checksum, see [](configuration)) -- and
   credits including Copperline's contributors and Patreon sponsors (see
   `CREDITS.md`). Builds
   made from an untagged git commit append the short commit ID to the version
@@ -424,7 +428,11 @@ The layout is:
   *Memory* (chip/fast/slow/motherboard/Zorro III RAM),
   *ROM*
   (Kickstart and
-  extended ROM), *Floppy* (drive count and speed, then each wired drive as a
+  extended ROM, each with a greyed line under it naming what the chosen
+  image is -- `Kickstart 3.1 (40.68) A1200` -- identified by checksum rather
+  than by file name, and left blank for an image Copperline does not know;
+  see [](configuration)),
+  *Floppy* (drive count and speed, then each wired drive as a
   greyed **DFn:** heading with its indented disk image and write-protect;
   drives that are not enabled are hidden rather than greyed. Each drive also
   carries a **Physical drive** tick box that hands the bay to a physical

--- a/src/config.rs
+++ b/src/config.rs
@@ -5637,6 +5637,29 @@ fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {
     );
 }
 
+/// What a boot-ROM path holds, in words: the Kickstart version an image
+/// checksums to (see [`crate::romdb`]), `"bundled AROS"` for the
+/// open-source ROM Copperline ships in place of a Kickstart, or `None` for
+/// an image no table entry names.
+///
+/// This reads the file, so it belongs on the paths that run once -- the
+/// start-up banner, the About panel, a ROM chosen in the configuration
+/// screen -- and never in a per-frame one.
+pub fn rom_identification(path: &Path) -> Option<String> {
+    // The sentinel survives when no ROM was named and none was resolved
+    // (a save state carries its own ROM image), and the resolved AROS pair
+    // is named by its file names: neither is in the checksum table, and
+    // both are worth saying out loud rather than leaving blank.
+    let aros = path == Path::new(BUNDLED_AROS_ROM)
+        || path.file_name().is_some_and(|name| {
+            name == crate::romsearch::AROS_MAIN_FILE || name == crate::romsearch::AROS_EXT_FILE
+        });
+    if aros {
+        return Some("bundled AROS".to_string());
+    }
+    crate::romdb::describe_file(path).map(|id| id.label().to_string())
+}
+
 /// Emulated-machine summary lines for the About window.
 pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
     let mut lines = Vec::new();
@@ -5666,7 +5689,12 @@ pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
     }
     lines.push(ram);
     if let Some(name) = cfg.rom_path.file_name() {
-        lines.push(format!("ROM: {}", name.to_string_lossy()));
+        // The file name is whatever the dumper called it; the identification
+        // says which Kickstart it actually is.
+        match rom_identification(&cfg.rom_path) {
+            Some(id) => lines.push(format!("ROM: {} ({id})", name.to_string_lossy())),
+            None => lines.push(format!("ROM: {}", name.to_string_lossy())),
+        }
     }
     let drives = cfg
         .floppy_connected
@@ -9845,6 +9873,57 @@ mod tests {
         };
         let err = load_overrides(&overrides).unwrap_err();
         assert!(err.to_string().contains("unknown chipset"), "{err:#}");
+    }
+
+    /// The About window's ROM line names the image as well as the file: the
+    /// checksum table (src/romdb.rs) says which Kickstart a dump is, and the
+    /// ROM Copperline ships in place of one says so.
+    #[test]
+    fn the_about_rom_line_names_the_image_it_can_identify() {
+        // No ROM named: the sentinel is the bundled AROS, whether or not it
+        // has been resolved to a real path yet.
+        let mut cfg = Config::default();
+        assert_eq!(
+            rom_identification(Path::new(BUNDLED_AROS_ROM)).as_deref(),
+            Some("bundled AROS")
+        );
+        assert_eq!(
+            rom_identification(
+                Path::new("/opt/share/copperline/aros")
+                    .join(crate::romsearch::AROS_MAIN_FILE)
+                    .as_path()
+            )
+            .as_deref(),
+            Some("bundled AROS")
+        );
+
+        // A file that is not a known ROM adds nothing to the line.
+        let unknown = temp_path("not-a-rom.rom");
+        fs::write(&unknown, vec![0xA5u8; 4096]).unwrap();
+        assert_eq!(rom_identification(&unknown), None);
+        cfg.rom_path = unknown.clone();
+        let name = unknown.file_name().unwrap().to_string_lossy().into_owned();
+        let lines = about_machine_lines(&cfg);
+        assert!(
+            lines.iter().any(|l| *l == format!("ROM: {name}")),
+            "{lines:?}"
+        );
+        let _ = fs::remove_file(&unknown);
+
+        // A directory, a missing file and an over-large one are all just
+        // unknown rather than an error or a panic.
+        assert_eq!(rom_identification(Path::new("/no/such/rom.rom")), None);
+        assert_eq!(rom_identification(&std::env::temp_dir()), None);
+        let huge = temp_path("huge.rom");
+        fs::write(&huge, vec![0u8; 3 * 1024 * 1024]).unwrap();
+        assert_eq!(rom_identification(&huge), None);
+        let _ = fs::remove_file(&huge);
+
+        // A recognised image: the About line carries the version beside the
+        // file name. The bytes of a real Kickstart are not in the tree, so
+        // the entry is checked through the table the line is built from.
+        let entry = crate::romdb::identify_crc(0x1483A091, 512 * 1024).expect("KS 3.1 A1200");
+        assert_eq!(entry.label, "Kickstart 3.1 (40.68) A1200");
     }
 
     fn temp_adf() -> Result<PathBuf> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5660,6 +5660,15 @@ pub fn rom_identification(path: &Path) -> Option<String> {
     crate::romdb::describe_file(path).map(|id| id.label().to_string())
 }
 
+/// The `ROM:` line the About panel and the ROM-load OSD show: the file's
+/// name, with the identification beside it when the image is a known one.
+pub fn about_rom_line(name: &str, identification: Option<&str>) -> String {
+    match identification {
+        Some(id) => format!("ROM: {name} ({id})"),
+        None => format!("ROM: {name}"),
+    }
+}
+
 /// Emulated-machine summary lines for the About window.
 pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
     let mut lines = Vec::new();
@@ -5691,10 +5700,10 @@ pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
     if let Some(name) = cfg.rom_path.file_name() {
         // The file name is whatever the dumper called it; the identification
         // says which Kickstart it actually is.
-        match rom_identification(&cfg.rom_path) {
-            Some(id) => lines.push(format!("ROM: {} ({id})", name.to_string_lossy())),
-            None => lines.push(format!("ROM: {}", name.to_string_lossy())),
-        }
+        lines.push(about_rom_line(
+            &name.to_string_lossy(),
+            rom_identification(&cfg.rom_path).as_deref(),
+        ));
     }
     let drives = cfg
         .floppy_connected
@@ -9921,9 +9930,15 @@ mod tests {
 
         // A recognised image: the About line carries the version beside the
         // file name. The bytes of a real Kickstart are not in the tree, so
-        // the entry is checked through the table the line is built from.
+        // the composition is exercised through the same helper the panel
+        // uses, fed the label of a real table entry.
         let entry = crate::romdb::identify_crc(0x1483A091, 512 * 1024).expect("KS 3.1 A1200");
         assert_eq!(entry.label, "Kickstart 3.1 (40.68) A1200");
+        assert_eq!(
+            about_rom_line("kick40068.A1200", Some(entry.label)),
+            "ROM: kick40068.A1200 (Kickstart 3.1 (40.68) A1200)"
+        );
+        assert_eq!(about_rom_line("mystery.rom", None), "ROM: mystery.rom");
     }
 
     fn temp_adf() -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub mod priority;
 pub mod ramsey;
 pub mod recorder;
 pub mod regcheck;
+pub mod romdb;
 pub mod romsearch;
 pub mod romtags;
 pub mod rtc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2034,6 +2034,13 @@ fn main() -> Result<()> {
     }
     let disk_insert_after = resolve_disk_insert_after(&mut cfg, cli.disk_insert_after)?;
 
+    // Name the boot ROM in the banner: a Kickstart image is identified by
+    // checksum (src/romdb.rs), so the log says which Kickstart is booting
+    // rather than only which file was opened.
+    let rom = match config::rom_identification(&cfg.rom_path) {
+        Some(id) => format!("{} ({id})", cfg.rom_path.display()),
+        None => cfg.rom_path.display().to_string(),
+    };
     info!(
         "config: cpu={:?} fpu={} cpu_clock={}MHz chip_ram={}K fast_ram={}K slow_ram={}K z3_ram={}K zorro_boards={} chipset={:?} (agnus={:?} denise={:?}) video={:?} rom={} floppy_drives={}",
         cfg.cpu,
@@ -2048,7 +2055,7 @@ fn main() -> Result<()> {
         cfg.agnus_revision,
         cfg.denise_revision,
         cfg.video_standard,
-        cfg.rom_path.display(),
+        rom,
         cfg.floppy_connected
             .iter()
             .filter(|&&connected| connected)

--- a/src/romdb.rs
+++ b/src/romdb.rs
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Kickstart ROM identification by checksum.
+//!
+//! A ROM image is a bare block of 68000 code: nothing inside it says "I am
+//! Kickstart 3.1 for the A1200", and the file names people keep them under
+//! are whatever their dumper or their collection manager chose. Every
+//! released Amiga boot ROM is nonetheless a fixed, known block of bytes, so
+//! the image can be named by its checksum. That is what this module does:
+//! given the bytes of a ROM file it returns a human label such as
+//! "Kickstart 3.1 (40.68) A1200", which the About panel, the start-up
+//! banner, the ROM-load OSD, and the machine-configuration ROM tab show
+//! beside the file name.
+//!
+//! The checksum data (CRC-32 and length per image) is derived from WinUAE's
+//! `rommgr.cpp` ROM table. WinUAE is GPL-2.0-or-later, so the data is
+//! licence-compatible with this GPL-3.0-or-later tree. Only the Amiga boot
+//! ROMs are transcribed: the main Kickstarts, the CD32 Kickstart and
+//! extended ROM, the CDTV/CDTV-CR extended ROMs and the A1000 bootstrap.
+//! The even/odd EPROM halves of the split dumps are left out (they are not
+//! loadable images on their own), as are the non-Amiga boards WinUAE also
+//! carries (Arcadia, ALG, Cubo, DraCo, Casablanca) and the expansion-board
+//! ROMs, which are not boot ROMs.
+//!
+//! Identification keys on (CRC-32, length) after the same normalisation the
+//! ROM load path in `memory.rs` performs, so the forms a real collection
+//! holds all resolve to the canonical image: a byte-swapped EPROM-programmer
+//! dump, a 256 KiB part dumped through a 512 KiB window (and so stored
+//! doubled), or the A1000 bootstrap's 8 KiB part echoed through its 64 KiB
+//! window. Amiga Forever's encrypted images cannot be checksummed at all
+//! without the user's `rom.key`, so they are reported as encrypted rather
+//! than as unknown.
+
+use std::borrow::Cow;
+use std::path::Path;
+
+/// One known ROM image: what to call it, and the (length, CRC-32) pair that
+/// identifies it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RomEntry {
+    /// Human label, e.g. "Kickstart 3.1 (40.68) A1200". Marketing version
+    /// first, the ROM's own revision in parentheses, then the models the
+    /// image was shipped for.
+    pub label: &'static str,
+    /// Length of the canonical image in bytes.
+    pub size: usize,
+    /// CRC-32 of the canonical image.
+    pub crc32: u32,
+}
+
+impl RomEntry {
+    const fn new(label: &'static str, size: usize, crc32: u32) -> Self {
+        Self { label, size, crc32 }
+    }
+}
+
+/// What a ROM image turned out to be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Identified {
+    /// A ROM in the table.
+    Known(&'static RomEntry),
+    /// An Amiga Forever encrypted image: an `AMIROMTYPE1` container whose
+    /// payload is XORed with the adjacent `rom.key`. The bytes cannot be
+    /// checksummed without that key, so this says what the file is rather
+    /// than pretending the ROM is unknown.
+    Encrypted,
+}
+
+impl Identified {
+    /// The text a surface shows for this identification.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Identified::Known(entry) => entry.label,
+            Identified::Encrypted => "Cloanto-encrypted ROM",
+        }
+    }
+}
+
+/// Amiga Forever's scrambled ROM container tag (see `whdload.rs`, which
+/// decodes such images when the user's `rom.key` sits beside them).
+const CLOANTO_TAG: &[u8] = b"AMIROMTYPE1";
+
+/// Largest file [`describe_file`] will read. The biggest image in the table
+/// is the 1 MiB combined CD32 ROM; twice that leaves room for a doubled
+/// dump and the Cloanto tag, and stops the identification reading something
+/// that cannot be a boot ROM at all.
+const MAX_ROM_FILE_BYTES: u64 = 2 * 1024 * 1024 + 16;
+
+/// Whether an image is an Amiga Forever encrypted container.
+pub fn is_encrypted(data: &[u8]) -> bool {
+    data.starts_with(CLOANTO_TAG)
+}
+
+/// Identify a ROM image from its bytes, after normalising byte order and
+/// undoing any whole-image repetition (see the module docs).
+pub fn identify(data: &[u8]) -> Option<&'static RomEntry> {
+    if is_encrypted(data) {
+        return None;
+    }
+    lookup_keys(data)
+        .into_iter()
+        .find_map(|(crc, len)| identify_crc(crc, len))
+}
+
+/// Identify a ROM image, reporting an encrypted container as such.
+pub fn describe(data: &[u8]) -> Option<Identified> {
+    if is_encrypted(data) {
+        return Some(Identified::Encrypted);
+    }
+    identify(data).map(Identified::Known)
+}
+
+/// Identify the ROM image in a file. `None` for a file that cannot be read,
+/// is far too large to be a boot ROM, or is not in the table.
+pub fn describe_file(path: &Path) -> Option<Identified> {
+    let len = std::fs::metadata(path).ok()?.len();
+    if len == 0 || len > MAX_ROM_FILE_BYTES {
+        return None;
+    }
+    describe(&std::fs::read(path).ok()?)
+}
+
+/// The raw table lookup: an exact (CRC-32, length) match, with no
+/// normalisation of its own.
+pub fn identify_crc(crc: u32, len: usize) -> Option<&'static RomEntry> {
+    ROMS.iter().find(|e| e.crc32 == crc && e.size == len)
+}
+
+/// CRC-32 of a buffer, computed the way [`crate::config::RomId`] does it.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = flate2::Crc::new();
+    crc.update(data);
+    crc.sum()
+}
+
+/// Restore big-endian byte order in a byte-swapped image, mirroring
+/// `memory::normalize_rom_byte_order`: an image prepared for an EPROM
+/// programmer opens $xx11 $F94E instead of the $11xx $4EF9 ROM header, and
+/// no big-endian ROM can start that way.
+fn byte_order_normalized(data: &[u8]) -> Cow<'_, [u8]> {
+    let swapped = data.len() >= 4
+        && data.len().is_multiple_of(2)
+        && data[1] == 0x11
+        && data[2..4] == [0xF9, 0x4E];
+    if !swapped {
+        return Cow::Borrowed(data);
+    }
+    let mut out = data.to_vec();
+    for pair in out.chunks_exact_mut(2) {
+        pair.swap(0, 1);
+    }
+    Cow::Owned(out)
+}
+
+/// One half of a buffer that is exactly two identical halves, else `None`.
+/// A 256 KiB part read through a 512 KiB window comes back doubled, and the
+/// A1000's 8 KiB bootstrap is echoed eight times across its 64 KiB window.
+fn halved(data: &[u8]) -> Option<&[u8]> {
+    if data.len() < 2 || !data.len().is_multiple_of(2) {
+        return None;
+    }
+    let (first, second) = data.split_at(data.len() / 2);
+    (first == second).then_some(first)
+}
+
+/// The (CRC-32, length) keys to try for an image, most specific first: the
+/// image as loaded (byte order restored), then each repetition of it undone
+/// in turn. Looking the whole image up first keeps an image that is *itself*
+/// in the table -- the A1000's 64 KiB bootstrap, which is its 8 KiB part
+/// echoed -- identified as the image the user actually holds.
+fn lookup_keys(data: &[u8]) -> Vec<(u32, usize)> {
+    let normalized = byte_order_normalized(data);
+    let mut view: &[u8] = &normalized;
+    let mut keys = vec![(crc32(view), view.len())];
+    while let Some(half) = halved(view) {
+        view = half;
+        keys.push((crc32(view), view.len()));
+    }
+    keys
+}
+
+/// The known Amiga boot ROMs (see the module docs for what is in and what is
+/// out). Order follows WinUAE's table: main Kickstarts oldest first, then the
+/// CD32 pair, the CDTV extended ROMs, and the A1000 bootstrap.
+pub const ROMS: [RomEntry; 67] = [
+    // Pre-release prototype (the "Velvet" development machine).
+    RomEntry::new("Kickstart 23.93 (Velvet prototype)", 131072, 0xADCB44C9),
+    // Kickstart 1.x: 256 KiB parts, mirrored into the 512 KiB ROM window.
+    RomEntry::new("Kickstart 1.0 A1000 (NTSC)", 262144, 0x299790FF),
+    RomEntry::new("Kickstart 1.1 (31.34) A1000 (NTSC)", 262144, 0xD060572A),
+    RomEntry::new("Kickstart 1.1 (31.34) A1000 (PAL)", 262144, 0xEC86DAE2),
+    RomEntry::new("Kickstart 1.2 (33.166) A1000", 262144, 0x9ED783D0),
+    RomEntry::new(
+        "Kickstart 1.2 (33.180) A500/A1000/A2000",
+        262144,
+        0xA6CE1636,
+    ),
+    RomEntry::new("Kickstart 1.3 (34.5) A500/A1000/A2000", 262144, 0xC4F0F55F),
+    RomEntry::new("Kickstart 1.3 (34.5) A3000 (SK)", 262144, 0xE0F37258),
+    // Kickstart 1.4/2.x.
+    RomEntry::new("Kickstart 1.4 (36.16) A3000", 524288, 0xBC0EC13F),
+    RomEntry::new("Kickstart 2.04 (37.175) A500+", 524288, 0xC3BDB240),
+    RomEntry::new("Kickstart 2.05 (37.299) A600", 524288, 0x83028FB5),
+    RomEntry::new("Kickstart 2.05 (37.300) A600HD", 524288, 0x64466C2A),
+    RomEntry::new("Kickstart 2.05 (37.350) A600HD", 524288, 0x43B0DF7B),
+    RomEntry::new("Kickstart 2.04 (37.175) A3000", 524288, 0x234A7233),
+    // Kickstart 3.0/3.1. The Cloanto entries are Amiga Forever's own
+    // re-encoded images of the same ROM, which checksum differently.
+    RomEntry::new("Kickstart 3.0 (39.106) A1200", 524288, 0x6C9B07D2),
+    RomEntry::new("Kickstart 3.0 (39.106) A4000", 524288, 0x9E6AC152),
+    RomEntry::new("Kickstart 3.1 (40.70) A4000", 524288, 0x2B4566F1),
+    RomEntry::new("Kickstart 3.1 (40.63) A500/A600/A2000", 524288, 0xFC24AE0D),
+    RomEntry::new("Kickstart 3.1 (40.68) A1200", 524288, 0x1483A091),
+    RomEntry::new("Kickstart 3.1 (40.68) A3000", 524288, 0xEFB239CC),
+    RomEntry::new("Kickstart 3.1 (40.68) A4000 (Cloanto)", 524288, 0x43B6DD22),
+    RomEntry::new("Kickstart 3.1 (40.68) A4000", 524288, 0xD6BAE334),
+    RomEntry::new("Kickstart 3.1 (40.70) A4000T", 524288, 0x75932C3A),
+    RomEntry::new("Kickstart 3.X (45.57) A4000 (Cloanto)", 524288, 0x3AC99EDC),
+    // Hyperion's OS 3.1.4: two releases of the same 46.143 revision.
+    RomEntry::new("Kickstart 3.1.4-1 (46.143) A1200", 524288, 0xF17FA97F),
+    RomEntry::new("Kickstart 3.1.4-1 (46.143) A3000", 524288, 0x50C3529C),
+    RomEntry::new("Kickstart 3.1.4-1 (46.143) A4000", 524288, 0xD47E18FD),
+    RomEntry::new("Kickstart 3.1.4-1 (46.143) A4000T", 524288, 0x75A2B2A5),
+    RomEntry::new("Kickstart 3.1.4-1 (46.143) A500", 524288, 0xD52B52FD),
+    RomEntry::new("Kickstart 3.1.4-2 (46.143) A1200", 524288, 0xB87506A7),
+    RomEntry::new("Kickstart 3.1.4-2 (46.143) A3000", 524288, 0xBA35F8EB),
+    RomEntry::new("Kickstart 3.1.4-2 (46.143) A4000", 524288, 0x1B84CB33),
+    RomEntry::new("Kickstart 3.1.4-2 (46.143) A4000T", 524288, 0xD6D0EF3E),
+    RomEntry::new("Kickstart 3.1.4-2 (46.143) A500", 524288, 0x568F8786),
+    // Hyperion's OS 3.2 line: marketing version in front, ROM revision in
+    // parentheses (all of 3.2 is 47.x).
+    RomEntry::new("Kickstart 3.2 (47.96) A1200", 524288, 0xBD1FF75E),
+    RomEntry::new("Kickstart 3.2 (47.96) A3000", 524288, 0xF3AF46CC),
+    RomEntry::new("Kickstart 3.2 (47.96) A4000", 524288, 0x9BB8FC93),
+    RomEntry::new("Kickstart 3.2 (47.96) A4000T", 524288, 0x9188A509),
+    RomEntry::new(
+        "Kickstart 3.2 (47.96) A500/A600/A2000/A1000/CDTV",
+        524288,
+        0x8173D7B6,
+    ),
+    RomEntry::new("Kickstart 3.2.1 (47.102) A1200", 524288, 0x2B653371),
+    RomEntry::new("Kickstart 3.2.1 (47.102) A3000", 524288, 0x0078F607),
+    RomEntry::new("Kickstart 3.2.1 (47.102) A4000", 524288, 0xF3CED3B8),
+    RomEntry::new("Kickstart 3.2.1 (47.102) A4000T", 524288, 0xAF3452EC),
+    RomEntry::new(
+        "Kickstart 3.2.1 (47.102) A500/A600/A2000/A1000/CDTV",
+        524288,
+        0x4F078456,
+    ),
+    RomEntry::new("Kickstart 3.2.2 (47.111) A1200", 524288, 0x5C40328A),
+    RomEntry::new("Kickstart 3.2.2 (47.111) A3000", 524288, 0x46335B57),
+    RomEntry::new("Kickstart 3.2.2 (47.111) A4000", 524288, 0x4BEA9798),
+    RomEntry::new("Kickstart 3.2.2 (47.111) A4000T", 524288, 0x36BBCD8A),
+    RomEntry::new(
+        "Kickstart 3.2.2 (47.111) A500/A600/A2000/A1000/CDTV",
+        524288,
+        0xE4458462,
+    ),
+    RomEntry::new("Kickstart 3.2.3 (47.115) A1200", 524288, 0xB18D3B67),
+    RomEntry::new("Kickstart 3.2.3 (47.115) A3000", 524288, 0x74C0B23F),
+    RomEntry::new("Kickstart 3.2.3 (47.115) A4000", 524288, 0xB6A4698E),
+    RomEntry::new("Kickstart 3.2.3 (47.115) A4000T", 524288, 0x588A5E6D),
+    RomEntry::new(
+        "Kickstart 3.2.3 (47.115) A500/A600/A2000/A1000/CDTV",
+        524288,
+        0xE1F50B0B,
+    ),
+    // The Walker prototype's own ROM.
+    RomEntry::new("Kickstart 3.2 (43.1) Walker", 524288, 0x261339F8),
+    // CD32: the Kickstart part, the extended ROM at $E00000, and the two
+    // combined 1 MiB images (the community one and the real 391640-03 dump).
+    RomEntry::new("Kickstart 3.1 (40.60) CD32", 524288, 0x1E62D4A5),
+    RomEntry::new("CD32 extended ROM (40.60)", 524288, 0x87746BE2),
+    RomEntry::new("CD32 Kickstart + extended ROM (40.60)", 1048576, 0xF5D4F3C8),
+    RomEntry::new(
+        "CD32 Kickstart + extended ROM (40.60, 391640-03)",
+        1048576,
+        0xA4FBC94A,
+    ),
+    // CDTV / A570 / CDTV-CR extended ROMs at $F00000.
+    RomEntry::new("CDTV extended ROM v1.0", 262144, 0x42BAA124),
+    RomEntry::new("CDTV extended ROM v2.7", 262144, 0xCEAE68D2),
+    RomEntry::new("CDTV/A570 extended ROM v2.30", 262144, 0x30B54232),
+    RomEntry::new("CDTV extended ROM v47.1", 262144, 0xAB6274E7),
+    RomEntry::new("CDTV-CR extended ROM v3.32", 262144, 0x581A85CF),
+    RomEntry::new("CDTV-CR extended ROM v3.44", 262144, 0x0B7BD64F),
+    // The A1000 has no Kickstart ROM: it bootstraps from this part and
+    // loads Kickstart into writable control store from disk. The 64 KiB
+    // image is the 8 KiB part echoed across its window.
+    RomEntry::new("A1000 bootstrap ROM", 65536, 0x0B1AD2D0),
+    RomEntry::new("A1000 bootstrap ROM (8K part)", 8192, 0x62F11C04),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A synthetic "ROM" body: not a real image, but a deterministic block
+    /// to drive the normalisation with. Deliberately not periodic, so a
+    /// block does not read as its own repeated halves.
+    fn body(len: usize) -> Vec<u8> {
+        (0..len)
+            .map(|i| (i * 7 + 3) as u8 ^ (i >> 8) as u8)
+            .collect()
+    }
+
+    #[test]
+    fn table_entries_are_unique_plausible_and_ascii() {
+        // The lookup key is (size, crc32): two entries sharing one would
+        // make an image identify as whichever came first in the table.
+        let mut keys: Vec<(usize, u32)> = ROMS.iter().map(|e| (e.size, e.crc32)).collect();
+        keys.sort_unstable();
+        let before = keys.len();
+        keys.dedup();
+        assert_eq!(before, keys.len(), "duplicate (size, crc32) in the table");
+        // Every Amiga boot ROM is one of these sizes; anything else is a
+        // transcription slip rather than a real image.
+        const SIZES: [usize; 6] = [8192, 65536, 131072, 262144, 524288, 1048576];
+        for e in &ROMS {
+            assert!(
+                SIZES.contains(&e.size),
+                "{}: implausible ROM size {}",
+                e.label,
+                e.size
+            );
+            assert!(!e.label.is_empty(), "empty label for crc {:08x}", e.crc32);
+            assert!(e.label.is_ascii(), "non-ASCII label {:?}", e.label);
+        }
+    }
+
+    #[test]
+    fn identify_crc_finds_well_known_kickstarts() {
+        assert_eq!(
+            identify_crc(0xC4F0F55F, 262144).map(|e| e.label),
+            Some("Kickstart 1.3 (34.5) A500/A1000/A2000")
+        );
+        assert_eq!(
+            identify_crc(0x1483A091, 524288).map(|e| e.label),
+            Some("Kickstart 3.1 (40.68) A1200")
+        );
+        assert_eq!(
+            identify_crc(0xB18D3B67, 524288).map(|e| e.label),
+            Some("Kickstart 3.2.3 (47.115) A1200")
+        );
+        assert_eq!(
+            identify_crc(0x1E62D4A5, 524288).map(|e| e.label),
+            Some("Kickstart 3.1 (40.60) CD32")
+        );
+        assert_eq!(
+            identify_crc(0x0B1AD2D0, 65536).map(|e| e.label),
+            Some("A1000 bootstrap ROM")
+        );
+        // The same CRC at the wrong length is not that ROM.
+        assert_eq!(identify_crc(0x1483A091, 262144), None);
+        assert_eq!(identify_crc(0, 524288), None);
+    }
+
+    #[test]
+    fn byte_swapped_eprom_images_are_restored() {
+        // A real ROM header: $11xx then JMP absolute long ($4EF9).
+        let mut rom = vec![0x11, 0x14, 0x4E, 0xF9, 0x00, 0xFC, 0x00, 0xD2];
+        assert!(matches!(byte_order_normalized(&rom), Cow::Borrowed(_)));
+        let mut swapped = rom.clone();
+        for pair in swapped.chunks_exact_mut(2) {
+            pair.swap(0, 1);
+        }
+        assert_eq!(&swapped[..4], &[0x14, 0x11, 0xF9, 0x4E]);
+        assert_eq!(byte_order_normalized(&swapped).as_ref(), rom.as_slice());
+        // A payload byte that happens to be $11 does not make an image
+        // byte-swapped: the check is the whole four-byte header.
+        rom[1] = 0x11;
+        rom[2] = 0x00;
+        assert!(matches!(byte_order_normalized(&rom), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn repeated_images_reduce_to_the_part_they_echo() {
+        let part = body(1024);
+        let doubled: Vec<u8> = part.iter().chain(part.iter()).copied().collect();
+        assert_eq!(halved(&doubled), Some(part.as_slice()));
+        assert_eq!(halved(&part), None);
+        assert_eq!(halved(&[]), None);
+        assert_eq!(halved(&[0x11, 0x22, 0x33]), None);
+
+        // Eight echoes (the A1000 bootstrap's shape) unwind to the part,
+        // and the whole image is offered first so an image that is itself
+        // in the table wins.
+        let mut echoed = part.clone();
+        for _ in 0..3 {
+            echoed = echoed.iter().chain(echoed.iter()).copied().collect();
+        }
+        let keys = lookup_keys(&echoed);
+        assert_eq!(keys.first().copied(), Some((crc32(&echoed), echoed.len())));
+        assert!(
+            keys.contains(&(crc32(&part), part.len())),
+            "the echoed part is among the keys tried"
+        );
+        assert_eq!(keys.len(), 4, "8K -> 4K -> 2K -> 1K");
+    }
+
+    #[test]
+    fn byte_swapped_and_doubled_images_share_the_canonical_key() {
+        // A 1 KiB "part" with a plausible ROM header, doubled and then
+        // byte-swapped the way an EPROM-programmer dump of a doubled part
+        // would be: it must still offer the plain part's key.
+        let mut part = body(1024);
+        part[..4].copy_from_slice(&[0x11, 0x14, 0x4E, 0xF9]);
+        let mut image: Vec<u8> = part.iter().chain(part.iter()).copied().collect();
+        for pair in image.chunks_exact_mut(2) {
+            pair.swap(0, 1);
+        }
+        let keys = lookup_keys(&image);
+        assert!(keys.contains(&(crc32(&part), part.len())));
+    }
+
+    #[test]
+    fn cloanto_encrypted_images_are_reported_as_encrypted() {
+        let mut encrypted = CLOANTO_TAG.to_vec();
+        encrypted.extend_from_slice(&body(512));
+        assert!(is_encrypted(&encrypted));
+        assert_eq!(identify(&encrypted), None);
+        assert_eq!(describe(&encrypted), Some(Identified::Encrypted));
+        assert_eq!(
+            describe(&encrypted).map(|id| id.label()),
+            Some("Cloanto-encrypted ROM")
+        );
+        // A plain image is not mistaken for one.
+        assert!(!is_encrypted(&body(512)));
+        assert_eq!(describe(&body(512)), None);
+    }
+
+    #[test]
+    fn unknown_images_identify_as_nothing() {
+        assert_eq!(identify(&body(524288)), None);
+        assert_eq!(identify(&[]), None);
+    }
+
+    #[test]
+    fn known_labels_are_reported_through_identified() {
+        let entry = identify_crc(0x1483A091, 524288).expect("KS 3.1 A1200 is in the table");
+        assert_eq!(Identified::Known(entry).label(), entry.label);
+    }
+}

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -555,6 +555,12 @@ pub enum RowKind {
     /// The greyed `Drive` / `Priority` / `Status` column titles above the Boot
     /// Priority rows. Non-interactive; its `field` is inert.
     BootpriHeader,
+    /// A greyed, non-interactive line under the row it belongs to, carrying
+    /// something looked up rather than set: the ROM tab's identification of
+    /// the chosen image (see [`crate::romdb`]). Its `field` is the row it
+    /// annotates, so it is hidden and greyed along with it, and it draws
+    /// nothing when there is nothing to say.
+    Note,
     /// A floppy drive's media row: an image path with Browse/Clear, or the
     /// real interface in use with a Configure button once bridged.
     FloppyMedia,
@@ -719,9 +725,14 @@ const MEMORY_ROWS: [Row; 6] = [
     row(F::AccelRam, "Accelerator RAM", Cycle),
     row(F::Z3Ram, "Zorro III RAM", Cycle),
 ];
-const ROM_ROWS: [Row; 2] = [
+// Each ROM row is followed by a greyed line naming what the chosen image
+// checksums to ("Kickstart 3.1 (40.68) A1200"), since a ROM file's name says
+// only what its dumper called it.
+const ROM_ROWS: [Row; 4] = [
     row(F::Rom, "Kickstart ROM", PathRow),
+    row(F::Rom, "", RowKind::Note),
     row(F::ExtendedRom, "Extended ROM", PathRow),
+    row(F::ExtendedRom, "", RowKind::Note),
 ];
 // Each drive is a greyed "DFn:" heading with its settings indented under it. The
 // heading is keyed on the drive's image field so `row_hidden` drops it along
@@ -4979,6 +4990,16 @@ impl FsFamily {
     }
 }
 
+/// What a ROM row's chosen image turned out to be, remembered against the
+/// path it was read from. Identification opens and checksums the file, which
+/// a redraw must never do, so it happens only when the path in the field
+/// changes (see [`LauncherState::sync_rom_notes`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RomNote {
+    path: Option<PathBuf>,
+    text: Option<String>,
+}
+
 /// The full interactive state of the open configuration panel.
 #[derive(Debug, Clone)]
 pub struct LauncherState {
@@ -4988,6 +5009,9 @@ pub struct LauncherState {
     pub workshop: ImageWorkshop,
     pub tab: LauncherTab,
     pub status: Option<StatusMessage>,
+    /// The Kickstart / extended ROM identifications shown on the ROM tab,
+    /// in that order.
+    rom_notes: [RomNote; 2],
     /// The text field being typed into, and the edit buffer, when one has
     /// focus (a plugin string option or a drive volume name).
     editing: Option<EditTarget>,
@@ -5332,14 +5356,59 @@ impl LauncherState {
         // Read the host devices as the screen opens so the pickers show what is
         // connected now.
         setup.refresh_host_devices();
-        Self {
+        let mut state = Self {
             setup,
             workshop: ImageWorkshop::default(),
             tab: LauncherTab::System,
             status: None,
+            rom_notes: Default::default(),
             editing: None,
             edit_buffer: String::new(),
+        };
+        // Name the ROMs the incoming configuration already carries.
+        state.sync_rom_notes();
+        state
+    }
+
+    /// Re-identify the ROM images when the chosen files change.
+    ///
+    /// Identification opens and checksums the image, so it must never happen
+    /// on a redraw: the result is kept against the path it came from and this
+    /// does nothing at all while that path stays put. Call it wherever a
+    /// control may have changed the configuration (browsing to an image,
+    /// clearing a row, resetting to defaults, loading a config file).
+    pub fn sync_rom_notes(&mut self) {
+        for (slot, field) in [(0, F::Rom), (1, F::ExtendedRom)] {
+            let path = self.setup.path(field).map(Path::to_path_buf);
+            if self.rom_notes[slot].path == path {
+                continue;
+            }
+            self.rom_notes[slot].text = path.as_deref().and_then(crate::config::rom_identification);
+            self.rom_notes[slot].path = path;
         }
+    }
+
+    /// What the image on a ROM row was identified as, for its [`RowKind::Note`]
+    /// line. `None` for an image no checksum names, and for every other field.
+    pub fn rom_note(&self, field: LauncherField) -> Option<&str> {
+        let slot = match field {
+            F::Rom => 0,
+            F::ExtendedRom => 1,
+            _ => return None,
+        };
+        self.rom_notes[slot].text.as_deref()
+    }
+
+    /// Stand in for a recognised image, so the ROM tab can be drawn and
+    /// tested without a real Kickstart on the host.
+    #[cfg(test)]
+    pub fn set_rom_note_for_test(&mut self, field: LauncherField, text: &str) {
+        let slot = match field {
+            F::ExtendedRom => 1,
+            _ => 0,
+        };
+        self.rom_notes[slot].path = self.setup.path(field).map(Path::to_path_buf);
+        self.rom_notes[slot].text = Some(text.to_string());
     }
 
     /// The text field currently being edited, if any.
@@ -6995,6 +7064,78 @@ mod tests {
             assert_eq!(setup.path(field), None);
         }
         assert_eq!(setup.to_raw().whdload, crate::config::RawWhdload::default());
+    }
+
+    #[test]
+    fn the_rom_tab_carries_an_identification_line_under_each_path_row() {
+        // Each ROM path row is followed by a note row keyed on the same
+        // field, so the identification is hidden and greyed with its row.
+        let rows = rows(
+            LauncherTab::Rom,
+            ParallelDevice::None,
+            SerialMode::Off,
+            false,
+        );
+        let shape: Vec<(&str, RowKind, LauncherField)> =
+            rows.iter().map(|r| (r.label, r.kind, r.field)).collect();
+        assert_eq!(
+            shape,
+            [
+                ("Kickstart ROM", RowKind::Path, F::Rom),
+                ("", RowKind::Note, F::Rom),
+                ("Extended ROM", RowKind::Path, F::ExtendedRom),
+                ("", RowKind::Note, F::ExtendedRom),
+            ]
+        );
+
+        let mut state = LauncherState::new(MachineSetup::default());
+        // Nothing chosen: the value column says the machine boots the
+        // bundled AROS, and there is no image to identify.
+        assert_eq!(state.setup.value_label(F::Rom), "(bundled AROS)");
+        assert_eq!(state.rom_note(F::Rom), None);
+        assert_eq!(state.rom_note(F::ExtendedRom), None);
+
+        // A file that is not a known ROM (and here does not exist at all)
+        // leaves the line blank rather than claiming anything.
+        state
+            .setup
+            .set_path(F::Rom, PathBuf::from("/roms/mystery.rom"));
+        state.sync_rom_notes();
+        assert_eq!(state.rom_note(F::Rom), None);
+
+        // A recognised image: the note names the Kickstart, and the value
+        // column still shows the file the user picked.
+        state.set_rom_note_for_test(F::Rom, "Kickstart 3.1 (40.68) A1200");
+        assert_eq!(state.setup.value_label(F::Rom), "mystery.rom");
+        assert_eq!(state.rom_note(F::Rom), Some("Kickstart 3.1 (40.68) A1200"));
+        // The identification is cached against the path: syncing again with
+        // the same file in the field must not read (and so re-identify) it.
+        state.sync_rom_notes();
+        assert_eq!(state.rom_note(F::Rom), Some("Kickstart 3.1 (40.68) A1200"));
+        // Choosing another file does re-identify, and clearing the row drops
+        // the note with it.
+        state
+            .setup
+            .set_path(F::Rom, PathBuf::from("/roms/other.rom"));
+        state.sync_rom_notes();
+        assert_eq!(state.rom_note(F::Rom), None);
+        state.set_rom_note_for_test(F::Rom, "Kickstart 1.3 (34.5) A500/A1000/A2000");
+        state.setup.clear_path(F::Rom);
+        state.sync_rom_notes();
+        assert_eq!(state.rom_note(F::Rom), None);
+        // The extended ROM keeps its own line.
+        assert_eq!(state.rom_note(F::ExtendedRom), None);
+        state
+            .setup
+            .set_path(F::ExtendedRom, PathBuf::from("/roms/cd32-ext.rom"));
+        state.set_rom_note_for_test(F::ExtendedRom, "CD32 extended ROM (40.60)");
+        assert_eq!(state.rom_note(F::Rom), None);
+        assert_eq!(
+            state.rom_note(F::ExtendedRom),
+            Some("CD32 extended ROM (40.60)")
+        );
+        // Only the ROM rows have one.
+        assert_eq!(state.rom_note(F::Df0Image), None);
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4988,7 +4988,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             let row_y = launcher_row_y(rect, i) + row_offset;
             match r.kind {
                 // Non-interactive rows.
-                RowKind::SectionHeader | RowKind::BootpriHeader => {}
+                RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::Note => {}
                 RowKind::Text => {
                     if launcher_text_rect(rect, row_y).contains(pos) {
                         return Some(UiControl::LauncherNewImageEdit(r.field));
@@ -5802,6 +5802,25 @@ fn draw_launcher_row(
         );
         return;
     }
+    // The ROM tab's identification line: what the image on the row above
+    // checksums to, greyed and indented under it. Nothing is drawn for an
+    // image no checksum names, or for an empty row.
+    if r.kind == RowKind::Note {
+        if let Some(note) = state.rom_note(r.field) {
+            let x = launcher_pane_x(rect) + 8;
+            let avail = (rect.x + rect.w).saturating_sub(x + LAUNCH_MARGIN);
+            draw_panel_text(
+                frame,
+                x,
+                row_y + 4,
+                &truncate_to_width(note, avail),
+                PANEL_TEXT_DIM,
+                1,
+                scale,
+            );
+        }
+        return;
+    }
     // The greyed column titles above the Boot Priority rows.
     if r.kind == RowKind::BootpriHeader {
         for (x, title) in [
@@ -5871,7 +5890,7 @@ fn draw_launcher_row(
     }
     match r.kind {
         // Drawn above with an early return.
-        RowKind::SectionHeader | RowKind::BootpriHeader => {}
+        RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::Note => {}
         RowKind::Text => {
             draw_launcher_value_box(
                 frame,
@@ -7486,6 +7505,67 @@ mod tests {
             h >= TITLE_H
                 + SHORTCUT_ROWS.len() * SHORTCUT_ROW_H
                 + SHORTCUT_NOTES.len() * SHORTCUT_NOTE_H
+        );
+    }
+
+    /// The ROM tab's identification line is drawn under its path row, in the
+    /// greyed note colour, and only once there is something to say: an image
+    /// no checksum names leaves the line blank rather than an empty box.
+    #[test]
+    fn the_rom_tab_draws_its_identification_line_under_the_path_row() {
+        use super::super::window::{texture_height, texture_width};
+        let scale = 1;
+        let (w, h) = (texture_width(scale), texture_height(scale));
+        // Pixels painted in the note colour on the note row (row 1, under
+        // the Kickstart ROM path row).
+        let note_row_pixels = |frame: &[u8], rect: Rect| {
+            let row_y = launcher_row_y(rect, 1);
+            let mut lit = 0;
+            for y in row_y..row_y + LAUNCH_ROW_H {
+                for x in launcher_pane_x(rect)..rect.x + rect.w - LAUNCH_MARGIN {
+                    let p = (y * w + x) * 4;
+                    if frame[p..p + 4] == PANEL_TEXT_DIM.to_le_bytes() {
+                        lit += 1;
+                    }
+                }
+            }
+            lit
+        };
+        let panel_of = |state: LauncherState| Panel::Launcher(Box::new(state));
+
+        let mut setup = launcher::MachineSetup::default();
+        setup.set_path(
+            LauncherField::Rom,
+            std::path::PathBuf::from("mystery-dump.rom"),
+        );
+        let mut unknown = LauncherState::new(setup.clone());
+        unknown.tab = LauncherTab::Rom;
+        let mut known = LauncherState::new(setup);
+        known.tab = LauncherTab::Rom;
+        known.set_rom_note_for_test(LauncherField::Rom, "Kickstart 3.1 (40.68) A1200");
+
+        let mut blank_frame = vec![0u8; w * h * 4];
+        let ui = UiState {
+            panel: Some(panel_of(unknown)),
+            ..Default::default()
+        };
+        let rect = panel_rect(ui.panel.as_ref().unwrap());
+        draw(&mut blank_frame, scale, &ui, None, None);
+        assert_eq!(
+            note_row_pixels(&blank_frame, rect),
+            0,
+            "an unidentified image must leave the note line empty"
+        );
+
+        let mut frame = vec![0u8; w * h * 4];
+        let ui = UiState {
+            panel: Some(panel_of(known)),
+            ..Default::default()
+        };
+        draw(&mut frame, scale, &ui, None, None);
+        assert!(
+            note_row_pixels(&frame, rect) > 0,
+            "the identification is drawn under the ROM path row"
         );
     }
 
@@ -9372,6 +9452,33 @@ mod tests {
         };
         draw(&mut frame, scale, &ui, None, None);
         save(&frame, "launcher-whdload");
+
+        // The ROM tab: each path row with the identification of the image on
+        // it greyed underneath.
+        let mut frame = vec![0u8; w * h * 4];
+        let mut setup = launcher::MachineSetup::default();
+        setup.select_model(Some(MachineModel::Cd32));
+        setup.set_path(
+            LauncherField::Rom,
+            std::path::PathBuf::from("kick40060.CD32"),
+        );
+        setup.set_path(
+            LauncherField::ExtendedRom,
+            std::path::PathBuf::from("cd32ext.rom"),
+        );
+        let mut state = LauncherState::new(setup);
+        state.tab = LauncherTab::Rom;
+        state.set_rom_note_for_test(LauncherField::Rom, "Kickstart 3.1 (40.60) CD32");
+        state.set_rom_note_for_test(LauncherField::ExtendedRom, "CD32 extended ROM (40.60)");
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: menu::MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None);
+        assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
+        save(&frame, "launcher-rom");
 
         // The Storage tab, whose six sub-page links wrap onto a second row.
         let mut frame = vec![0u8; w * h * 4];

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6126,6 +6126,14 @@ impl App {
                 self.activate_tool_control(ToolPanelKind::FrameAnalyzer, control)
             }
         }
+        // A control may have put a different image in a ROM row (Browse,
+        // Clear, Reset to defaults, Load configuration), so the ROM tab's
+        // identification is brought up to date here, once per click, rather
+        // than on the redraw below: it keys on the path and only opens a file
+        // when a new one is chosen.
+        if let Some(state) = self.launcher_state_mut() {
+            state.sync_rom_notes();
+        }
         self.request_redraw();
     }
 
@@ -7996,7 +8004,10 @@ impl App {
                 .add_filter("Amiga ROM images", &["rom", "bin"])
                 .pick_file();
 
-            let result = (|| -> anyhow::Result<()> {
+            // The identification comes off the bytes already in hand (the
+            // image is handed to the machine straight after), so the OSD and
+            // the log name the Kickstart without re-reading the file.
+            let result = (|| -> anyhow::Result<Option<&'static str>> {
                 let rom = std::fs::read(&main_path)
                     .map_err(|e| anyhow::anyhow!("reading ROM {}: {e}", main_path.display()))?;
                 let ext = match &ext_path {
@@ -8005,17 +8016,28 @@ impl App {
                     })?),
                     None => None,
                 };
-                self.emu.reload_rom(rom, ext)
+                let identified = crate::romdb::describe(&rom).map(|id| id.label());
+                self.emu.reload_rom(rom, ext)?;
+                Ok(identified)
             })();
 
             match result {
-                Ok(()) => {
-                    info!("boot ROM loaded: {}", main_path.display());
+                Ok(identified) => {
+                    let name = display_file_name(&main_path);
+                    match identified {
+                        Some(id) => {
+                            info!("boot ROM loaded: {} ({id})", main_path.display());
+                            self.show_osd(format!("ROM: {name} ({id})"));
+                        }
+                        None => {
+                            info!("boot ROM loaded: {}", main_path.display());
+                            self.show_osd(format!("ROM: {name}"));
+                        }
+                    }
                     self.powered_on = true;
                     self.cpu_halted = false;
                     // The cold reset restarts the frame timeline; force a repaint.
                     self.reset_render_pipeline();
-                    self.show_osd(format!("ROM: {}", display_file_name(&main_path)));
                     self.request_redraw();
                 }
                 Err(e) => {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8024,15 +8024,22 @@ impl App {
             match result {
                 Ok(identified) => {
                     let name = display_file_name(&main_path);
+                    let rom_line = crate::config::about_rom_line(&name, identified);
                     match identified {
-                        Some(id) => {
-                            info!("boot ROM loaded: {} ({id})", main_path.display());
-                            self.show_osd(format!("ROM: {name} ({id})"));
-                        }
-                        None => {
-                            info!("boot ROM loaded: {}", main_path.display());
-                            self.show_osd(format!("ROM: {name}"));
-                        }
+                        Some(id) => info!("boot ROM loaded: {} ({id})", main_path.display()),
+                        None => info!("boot ROM loaded: {}", main_path.display()),
+                    }
+                    self.show_osd(rom_line.clone());
+                    // The About panel's machine lines are cached from the
+                    // configuration; the chip in the machine just changed,
+                    // so its ROM line has to follow the swap.
+                    match self
+                        .about_machine_lines
+                        .iter_mut()
+                        .find(|l| l.starts_with("ROM: "))
+                    {
+                        Some(line) => *line = rom_line,
+                        None => self.about_machine_lines.push(rom_line),
                     }
                     self.powered_on = true;
                     self.cpu_halted = false;

--- a/tests/romdb_assets.rs
+++ b/tests/romdb_assets.rs
@@ -39,7 +39,7 @@ fn asset(name: &str) -> Option<std::path::PathBuf> {
 /// Local ROM dumps and what the table must call them. The file names are the
 /// ones the other ignored suites use (see `tests/README.md`); a collection
 /// keeping the same images under other names simply skips these rows.
-const KNOWN_ROMS: [(&str, &str); 9] = [
+const KNOWN_ROMS: [(&str, &str); 12] = [
     ("kick13.rom", "Kickstart 1.3 (34.5) A500/A1000/A2000"),
     ("KICK13.ROM", "Kickstart 1.3 (34.5) A500/A1000/A2000"),
     ("kickstart205.rom", "Kickstart 2.05 (37.299) A600"),
@@ -61,9 +61,30 @@ const KNOWN_ROMS: [(&str, &str); 9] = [
         "CD32 extended ROM (40.60)",
     ),
     (
+        "CDTV Extended-ROM v1.0 (1991)(Commodore)(CDTV)[!].rom",
+        "CDTV extended ROM v1.0",
+    ),
+    (
+        "CDTV Extended-ROM v2.7 (1992)(Commodore)(CDTV).rom",
+        "CDTV extended ROM v2.7",
+    ),
+    (
+        "CDTV Extended-ROM v2.30 (1992)(Commodore)(A570).rom",
+        "CDTV/A570 extended ROM v2.30",
+    ),
+    (
         "Amiga 1000 ROM Bootstrap (1985)(Commodore)(A1000)[!].rom",
         "A1000 bootstrap ROM",
     ),
+];
+
+/// ROM-shaped images the table must NOT claim to know: diagnostic and test
+/// ROMs a collection keeps beside its Kickstarts. Wrongly identifying one
+/// as a Kickstart would be worse than naming nothing.
+const NOT_KICKSTARTS: [&str; 3] = [
+    "diagrom.rom",
+    "ROMTestProg31.49-262.rom",
+    "ROMTestProg31.49-524.rom",
 ];
 
 #[test]
@@ -87,6 +108,29 @@ fn real_rom_dumps_identify_as_their_kickstart_version() {
     }
     if checked == 0 {
         eprintln!("skipping: no known Kickstart ROM in the asset directory");
+    }
+}
+
+#[test]
+#[ignore = "needs local diagnostic ROM images (see tests/README.md)"]
+fn diagnostic_roms_are_not_mistaken_for_kickstarts() {
+    let mut checked = 0;
+    for name in NOT_KICKSTARTS {
+        let Some(path) = asset(name) else {
+            continue;
+        };
+        let data = std::fs::read(&path).expect("ROM reads");
+        assert_eq!(
+            romdb::describe(&data).map(|id| id.label()),
+            None,
+            "{}: wrongly identified",
+            path.display()
+        );
+        eprintln!("{name}: not identified, as it must be");
+        checked += 1;
+    }
+    if checked == 0 {
+        eprintln!("skipping: no diagnostic ROM in the asset directory");
     }
 }
 

--- a/tests/romdb_assets.rs
+++ b/tests/romdb_assets.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Asset-gated checks of the Kickstart ROM identification table
+//! (`src/romdb.rs`) against real ROM dumps. The unit tests in that module
+//! cover the table's shape and the normalisation with synthetic buffers;
+//! this test proves the transcribed checksums actually name the images a
+//! real collection holds, in the file forms they come in (256 KiB parts,
+//! 512 KiB images, an A1000 bootstrap echoed across its window).
+//!
+//! ROM images are local assets and are never committed, so every file is
+//! optional: absent ones are skipped and the test passes.
+
+use copperline::romdb;
+
+/// The integration-test asset directory (see `tests/README.md`):
+/// `COPPERLINE_TEST_ASSETS`, else `test-assets/` under the repo root,
+/// else the repo root itself.
+fn asset_dir() -> std::path::PathBuf {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match std::env::var_os("COPPERLINE_TEST_ASSETS") {
+        Some(d) => std::path::PathBuf::from(d),
+        None => {
+            let d = root.join("test-assets");
+            if d.is_dir() {
+                d
+            } else {
+                root
+            }
+        }
+    }
+}
+
+/// One asset by name, or `None` when the collection does not hold it.
+fn asset(name: &str) -> Option<std::path::PathBuf> {
+    let path = asset_dir().join(name);
+    path.is_file().then_some(path)
+}
+
+/// Local ROM dumps and what the table must call them. The file names are the
+/// ones the other ignored suites use (see `tests/README.md`); a collection
+/// keeping the same images under other names simply skips these rows.
+const KNOWN_ROMS: [(&str, &str); 9] = [
+    ("kick13.rom", "Kickstart 1.3 (34.5) A500/A1000/A2000"),
+    ("KICK13.ROM", "Kickstart 1.3 (34.5) A500/A1000/A2000"),
+    ("kickstart205.rom", "Kickstart 2.05 (37.299) A600"),
+    ("KICK31.ROM", "Kickstart 3.1 (40.63) A500/A600/A2000"),
+    (
+        "Kickstart v3.1 r40.68 (1993)(Commodore)(A1200)[!].rom",
+        "Kickstart 3.1 (40.68) A1200",
+    ),
+    (
+        "Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom",
+        "Kickstart 3.1 (40.68) A4000",
+    ),
+    (
+        "Kickstart v3.1 r40.060 (1993-05)(Commodore)(CD32)[!].rom",
+        "Kickstart 3.1 (40.60) CD32",
+    ),
+    (
+        "CD32 Extended-ROM r40.60 (1993)(Commodore)(CD32).rom",
+        "CD32 extended ROM (40.60)",
+    ),
+    (
+        "Amiga 1000 ROM Bootstrap (1985)(Commodore)(A1000)[!].rom",
+        "A1000 bootstrap ROM",
+    ),
+];
+
+#[test]
+#[ignore = "needs local Kickstart ROM images (see tests/README.md)"]
+fn real_rom_dumps_identify_as_their_kickstart_version() {
+    let mut checked = 0;
+    for (name, expected) in KNOWN_ROMS {
+        let Some(path) = asset(name) else {
+            continue;
+        };
+        let data = std::fs::read(&path).expect("ROM reads");
+        let identified = romdb::describe(&data);
+        assert_eq!(
+            identified.map(|id| id.label()),
+            Some(expected),
+            "{}: unexpected identification",
+            path.display()
+        );
+        eprintln!("{name}: {expected}");
+        checked += 1;
+    }
+    if checked == 0 {
+        eprintln!("skipping: no known Kickstart ROM in the asset directory");
+    }
+}
+
+/// Every ROM-shaped file in the asset directory, named. Not an assertion
+/// about coverage -- a collection holds plenty of images the table does not
+/// carry (AROS, DiagROM, expansion-board ROMs) -- but a check that reading a
+/// real directory of images never panics and that the ones that do identify
+/// are self-consistent: the reported entry's size is the size the file
+/// normalises to.
+#[test]
+#[ignore = "needs a local ROM collection (see tests/README.md)"]
+fn scanning_a_rom_collection_names_what_it_can() {
+    let Ok(entries) = std::fs::read_dir(asset_dir()) else {
+        eprintln!("skipping: asset directory unreadable");
+        return;
+    };
+    let mut paths: Vec<std::path::PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("rom") || e.eq_ignore_ascii_case("bin"))
+        })
+        .collect();
+    paths.sort();
+    for path in paths {
+        let Some(identified) = romdb::describe_file(&path) else {
+            eprintln!("{}: not identified", path.display());
+            continue;
+        };
+        eprintln!("{}: {}", path.display(), identified.label());
+        if let romdb::Identified::Known(entry) = identified {
+            let len = std::fs::metadata(&path).expect("metadata").len() as usize;
+            assert!(
+                len.is_multiple_of(entry.size),
+                "{}: identified as {} ({} bytes) but the file is {len} bytes",
+                path.display(),
+                entry.label,
+                entry.size
+            );
+        }
+    }
+}


### PR DESCRIPTION
A ROM file's name is whatever its dumper (or collection manager) called it; the image itself is a fixed, known block of bytes. Copperline now identifies the boot ROM by checksum and says which Kickstart it actually is, everywhere the ROM is named.

## What changed

- **New `src/romdb.rs`**: 67 entries keyed on (CRC-32, length) -- every released Kickstart from 1.0 through 3.2.3 (47.115), including the A3000 SK/1.4 betas, both Cloanto re-encodes, Hyperion's 3.1.4-1/-2 and the whole 3.2 line, the Velvet and Walker prototypes, the CD32 Kickstart + extended ROM (and both 1 MiB combined images), the CDTV/A570/CDTV-CR extended ROMs, and the A1000 bootstrap. Checksum data transcribed by script from WinUAE's `rommgr.cpp` (GPL-2.0-or-later, licence-compatible; attributed in the module header). No new dependencies: CRC-32 via `flate2::Crc`, exactly like the existing `RomId`.
- **Normalisation before lookup** mirrors the loader: byte-swapped EPROM-programmer dumps are restored, and whole-image repetition is undone repeatedly (a 256 KiB part stored doubled, the A1000's 8 KiB bootstrap echoed across its 64 KiB window) -- with the whole image tried first, so a 64 KiB bootstrap image identifies as the image you hold, not as its 8 KiB part. Amiga Forever `AMIROMTYPE1` containers are reported as **Cloanto-encrypted** rather than unknown.
- **Surfaces**: the startup `config:` banner (`rom=kick40068.A1200 (Kickstart 3.1 (40.68) A1200)`), the About panel's `ROM:` line, the ROM-load OSD + log, and a greyed identification line under each path row on the machine-configuration screen's ROM tab. The launcher caches the identification against the path -- a redraw never opens the file; it re-identifies once per control activation and only when the path actually changed. The bundled AROS keeps reporting itself as `bundled AROS`; unknown images (DiagROM, home-built ROMs) simply stay unnamed.

## Tests

- Unit: table shape (unique keys, plausible sizes, ASCII labels), well-known `identify_crc` hits, byte-swap/halving/encryption normalisation on synthetic buffers, About-line composition, ROM-tab row shape + cache behaviour, and a pixel-level check that the note line draws only when there is something to say. Full suite green (2356 passed), clippy (`--all-targets --all-features -D warnings`) and fmt clean.
- Asset-gated (`tests/romdb_assets.rs`, skips cleanly without assets): a real local collection identifies correctly -- KS 1.3, 2.05, 3.1 (40.63/40.68 A1200/A4000), CD32 40.60 Kickstart + extended, CDTV extended v1.0/v2.7/v2.30, A1000 bootstrap -- and DiagROM/test ROMs correctly report as not identified.
- Release headless run confirmed the banner: `rom=Kickstart v3.1 r40.68 (1993)(Commodore)(A1200)[!].rom (Kickstart 3.1 (40.68) A1200)`.

## Docs

`docs/guide/configuration.md` (ROM keys section) and `docs/guide/ui.md` (About, Load Kickstart ROM, ROM tab) updated in the same change.

Note: touches neighbouring lines in `ui.rs` to #426, so whichever merges second needs a trivial rebase.
