### PR TITLE
window: on-screen A600 keyboard strip with a status-bar toggle

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -112,10 +112,13 @@ reflows into it as usual.
 
 It is an **A600** -- the one Amiga keyboard with no numeric keypad, so the
 whole machine fits the window's width at a usable cap size. Clicking a cap
-sends that key's rawkey to the emulated keyboard MCU, exactly as a host
-keystroke does: the same de-duplication, the same authentic serial
-protocol, and the same recording, so on-screen keys are captured by
-`--record-input` and replay from the resulting `--script` file.
+sends that key's rawkey to the emulated keyboard MCU over the same
+authentic serial protocol a host keystroke uses, and is recorded the same
+way, so on-screen keys are captured by `--record-input` and replay from the
+resulting `--script` file. The two keyboards are independent holders of the
+same key: pressing a cap the host keyboard is already holding down changes
+nothing for the machine, and the key comes up only when the last of the two
+lets go.
 
 The keyboard is the way to reach the keys a host keyboard has no
 equivalent of -- Help, both Amiga keys, and the `#`/`~` key beside Return --

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -89,6 +89,9 @@ Status Bar*):
   keyboard icon showing which source drives the joystick port. Click it to
   flip between gamepad-only and keyboard joystick emulation; see
   [](#controller-ports).
+- **Keyboard toggle** (just left of the joystick toggle): a small keyboard
+  icon, lit while the on-screen Amiga keyboard is up. Click it to show or
+  hide it (see [](#on-screen-keyboard)).
 - **Volume slider**: drag, or scroll the mouse wheel over it for 5% steps.
 - **Hamburger menu button**: opens the pop-up menu (below).
 - **Camera button**: saves a screenshot (same as `Cmd+S` on macOS or
@@ -96,6 +99,49 @@ Status Bar*):
 - **Pause / power / reboot buttons.** Pause freezes emulation while staying
   powered; power cold-boots (clears RAM) or powers off back to the test
   screen; reboot is a warm reset.
+
+(on-screen-keyboard)=
+## On-screen keyboard
+
+The keyboard button in the status bar, or *Input Settings > On-Screen
+Keyboard*, draws an Amiga keyboard in a strip between the display and the
+status bar. The window grows to make room for it: the picture keeps its
+size, the canvas gets taller, and hiding the keyboard gives the height
+back. A window you have resized yourself keeps its size, and the display
+reflows into it as usual.
+
+It is an **A600** -- the one Amiga keyboard with no numeric keypad, so the
+whole machine fits the window's width at a usable cap size. Clicking a cap
+sends that key's rawkey to the emulated keyboard MCU, exactly as a host
+keystroke does: the same de-duplication, the same authentic serial
+protocol, and the same recording, so on-screen keys are captured by
+`--record-input` and replay from the resulting `--script` file.
+
+The keyboard is the way to reach the keys a host keyboard has no
+equivalent of -- Help, both Amiga keys, and the `#`/`~` key beside Return --
+and the way to drive a session entirely with the mouse.
+
+- **Qualifiers latch.** A mouse has one button, so Ctrl, both Shifts, both
+  Alts and both Amiga keys stay down when you click them: click one and it
+  is held for the next keystroke, then released with it. Click it twice in
+  quick succession to lock it down until you click it again; click a locked
+  one to let it go. Press and *hold* one instead, and it behaves like the
+  real key, coming up when the button does. A latched qualifier is drawn
+  with an orange ring, a locked one filled orange.
+- **Ctrl+Amiga+Amiga** is typed by latching the three, as any other chord
+  is. The moment the chord completes, the keyboard lets go of all three --
+  the MCU's reset protocol is already running, and qualifiers still held
+  would be reported held again through the power-up stream.
+- **Caps Lock** carries a lamp in the corner of its cap, driven by the
+  keyboard MCU itself rather than by the clicks, so it follows a
+  save-state load or a guest that toggles the key in software.
+- **UK/US legends.** The chip marked UK/US in the cursor notch swaps the
+  five caps a US A600 prints differently (`2`, `3`, `'`, and the two keys a
+  US machine ships blank). It changes what the caps say, not what they
+  send: the guest's own keymap decides that.
+- **The X chip** above it puts the keyboard away, the same as the status
+  bar button. It sits in the slot farthest from the cursor keys, so a
+  missed arrow cannot fold the keyboard away mid-game.
 
 ## Performance overlay
 
@@ -296,6 +342,8 @@ tool window or overlay.
   *held* fire button on live gamepad and keyboard input. Scripted input is
   never gated; see the `[input]` section of
   [Configuration](configuration.md).
+- **On-Screen Keyboard** (also the status-bar keyboard icon): draws an
+  Amiga keyboard under the display; see [](#on-screen-keyboard).
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Input Mapping...**: edits which host keys drive the controller controls,
   for both keyboard mappings; see [](#input-mapping).
@@ -643,8 +691,10 @@ continues.
 
 `Cmd+Shift+R` on macOS or `Alt+Shift+R` on Linux/Windows (or the menu's
 "Record Input") starts logging every input event that reaches the emulated
-machine -- key presses with their hold times, mouse buttons and motion,
-joystick / CD32-pad controls, analogue pot positions, and floppy inserts,
+machine -- key presses with their hold times (typed on the host keyboard
+or clicked on the [on-screen one](#on-screen-keyboard), which reaches the
+machine by the same path), mouse buttons and motion, joystick / CD32-pad
+controls, analogue pot positions, and floppy inserts,
 on whichever port carries each device -- each stamped
 with its emulated time. Pressing it again stops the recording and writes
 `copperline-input-<YYYYMMDDHHmmSS>.clscript` in the working directory: a plain

--- a/src/chipset/keyboard.rs
+++ b/src/chipset/keyboard.rs
@@ -306,9 +306,10 @@ impl KeyboardMcu {
         }
     }
 
-    /// The Caps Lock LED, driven by the keyboard MCU itself. Not yet
-    /// surfaced in the UI; kept as the accessor a status-bar LED needs.
-    #[allow(dead_code)]
+    /// The Caps Lock LED, driven by the keyboard MCU itself. The lamp on
+    /// the on-screen keyboard's Caps cap is this, polled: it moves on a
+    /// save-state load with no key pressed, so it cannot be mirrored from
+    /// keystrokes.
     pub fn caps_lock_led(&self) -> bool {
         self.caps_lock_on
     }

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -54,6 +54,8 @@ pub enum MenuAction {
     SetPortDevice(usize, PortDevice),
     SetJoystickInput(JoystickInputMode),
     SetAutofire(u8),
+    /// Show or hide the on-screen Amiga keyboard.
+    ToggleKeyboardPanel,
 
     // Serial / parallel, present only when something is on the port.
     /// `None` unplugs the cable: a MIDI interface with nothing connected.
@@ -406,6 +408,8 @@ pub struct MenuState<'a> {
     pub input_recording: bool,
     pub autofire_hz: u8,
     pub joystick_input_mode: JoystickInputMode,
+    /// Whether the on-screen Amiga keyboard is up.
+    pub keyboard_panel: bool,
     pub port_devices: [PortDevice; 2],
     pub pixel_aspect: PixelAspect,
     pub scaling: DisplayScaling,
@@ -658,6 +662,13 @@ fn input_rows(s: &MenuState) -> Vec<MenuRow> {
         MenuRow::submenu("Port 2 Device", port(1)),
         MenuRow::submenu("Joystick Input", joystick),
         MenuRow::submenu("Autofire", autofire),
+        // An Amiga keyboard drawn under the display, for the keys a host
+        // keyboard has no equivalent of and for driving a session by mouse.
+        MenuRow::toggle(
+            "On-Screen Keyboard",
+            MenuAction::ToggleKeyboardPanel,
+            s.keyboard_panel,
+        ),
         MenuRow::action("Calibrate Gamepad...", MenuAction::OpenCalibration),
         MenuRow::action("Input Mapping...", MenuAction::OpenInputMapping),
     ]
@@ -1015,6 +1026,7 @@ mod tests {
             input_recording: false,
             autofire_hz: 0,
             joystick_input_mode: JoystickInputMode::Gamepad,
+            keyboard_panel: false,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             pixel_aspect: PixelAspect::Tv,
             scaling: DisplayScaling::Smooth,

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -149,6 +149,27 @@ pub fn status_bar_hidden() -> bool {
     STATUS_BAR_HIDDEN.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+// Per-thread answers for the two strips that take height from the canvas,
+// in test builds only.
+//
+// Both flags have to be process-global in a running window: every draw
+// helper sizes and clips itself from the canvas height they decide, so a
+// parameter would have to be threaded through all of them. That is fine
+// for one window on one thread, but `cargo test` runs its tests in
+// parallel threads inside one process, where a test that put a strip up
+// would move the canvas under another test's buffer -- and the helpers,
+// which clamp against the height as it is *now*, would write past the end
+// of a buffer allocated for the shorter one. Each test thread therefore
+// carries its own answer, and the shared flag stays at its default for any
+// thread that never set one.
+#[cfg(test)]
+thread_local! {
+    static KEYBOARD_PANEL_SHOWN_LOCAL: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+    static MT32_PANEL_SHOWN_LOCAL: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
 /// Whether the on-screen Amiga keyboard is shown under the display
 /// (status-bar button / menu). Main thread only, like [`SQUARE_PIXEL_ASPECT`];
 /// the atomic only satisfies `static` safety.
@@ -156,10 +177,17 @@ static KEYBOARD_PANEL_SHOWN: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 pub fn set_keyboard_panel_shown(shown: bool) {
+    #[cfg(test)]
+    KEYBOARD_PANEL_SHOWN_LOCAL.with(|flag| flag.set(Some(shown)));
+    #[cfg(not(test))]
     KEYBOARD_PANEL_SHOWN.store(shown, std::sync::atomic::Ordering::Relaxed);
 }
 
 pub fn keyboard_panel_shown() -> bool {
+    #[cfg(test)]
+    if let Some(shown) = KEYBOARD_PANEL_SHOWN_LOCAL.with(std::cell::Cell::get) {
+        return shown;
+    }
     KEYBOARD_PANEL_SHOWN.load(std::sync::atomic::Ordering::Relaxed)
 }
 
@@ -169,6 +197,9 @@ pub fn keyboard_panel_shown() -> bool {
 static MT32_PANEL_SHOWN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 pub fn set_mt32_panel_shown(shown: bool) {
+    #[cfg(test)]
+    MT32_PANEL_SHOWN_LOCAL.with(|flag| flag.set(Some(shown)));
+    #[cfg(not(test))]
     MT32_PANEL_SHOWN.store(shown, std::sync::atomic::Ordering::Relaxed);
 }
 
@@ -193,6 +224,10 @@ pub fn mt32_lcd() -> crate::config::Mt32Lcd {
 }
 
 pub fn mt32_panel_shown() -> bool {
+    #[cfg(test)]
+    if let Some(shown) = MT32_PANEL_SHOWN_LOCAL.with(std::cell::Cell::get) {
+        return shown;
+    }
     MT32_PANEL_SHOWN.load(std::sync::atomic::Ordering::Relaxed)
 }
 

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -149,6 +149,20 @@ pub fn status_bar_hidden() -> bool {
     STATUS_BAR_HIDDEN.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Whether the on-screen Amiga keyboard is shown under the display
+/// (status-bar button / menu). Main thread only, like [`SQUARE_PIXEL_ASPECT`];
+/// the atomic only satisfies `static` safety.
+static KEYBOARD_PANEL_SHOWN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_keyboard_panel_shown(shown: bool) {
+    KEYBOARD_PANEL_SHOWN.store(shown, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn keyboard_panel_shown() -> bool {
+    KEYBOARD_PANEL_SHOWN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Whether the MT-32's front panel is shown under the display
 /// (`[serial] mt32_panel`, toggled live from the menu). Main thread only,
 /// like [`SQUARE_PIXEL_ASPECT`]; the atomic only satisfies `static` safety.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -9457,6 +9457,7 @@ mod tests {
             input_recording: false,
             autofire_hz: 0,
             joystick_input_mode: JoystickInputMode::Gamepad,
+            keyboard_panel: false,
             port_devices: [
                 crate::bus::PortDevice::Mouse,
                 crate::bus::PortDevice::Joystick,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -183,7 +183,7 @@ const STATUS_BAR_HEIGHT: usize = 44;
 /// plus the status bar below it unless it is hidden (in which case the display
 /// scales to fill the whole window).
 fn window_present_height() -> usize {
-    present_height() + mt32_panel_height() + status_bar_height()
+    present_height() + mt32_panel_height() + keyboard_panel_height() + status_bar_height()
 }
 
 /// Scanlines the CRT pass draws across the display rect: the emulated field
@@ -231,11 +231,11 @@ fn status_bar_height() -> usize {
     }
 }
 
-/// Where the status bar starts: below the display, and below the MT-32
-/// panel when one is up. The bar sits at the very bottom either way; the
-/// panel takes the strip immediately above it.
+/// Where the status bar starts: below the display and below whichever
+/// strips are up. The bar sits at the very bottom either way; the strips
+/// take the room immediately above it.
 fn status_bar_top() -> usize {
-    present_height() + mt32_panel_height()
+    keyboard_panel_top() + keyboard_panel_height()
 }
 
 /// The MT-32 panel's height, or 0 while it is not shown. It sits between the
@@ -246,6 +246,38 @@ fn mt32_panel_height() -> usize {
         return mt32panel::MT32_PANEL_HEIGHT;
     }
     0
+}
+
+/// Where the on-screen keyboard starts: under the display and under the
+/// MT-32's panel, the way a keyboard sits below whatever is on the desk.
+fn keyboard_panel_top() -> usize {
+    present_height() + mt32_panel_height()
+}
+
+/// Serialises the tests that put one of the canvas-height strips up. The
+/// flags behind them are process-global (they have to be: the draw helpers
+/// size themselves from them), so a test reading `window_present_height`
+/// while another has a strip up would be measuring the other one's canvas.
+#[cfg(test)]
+pub(super) static CANVAS_HEIGHT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Take that lock, ignoring a poisoning left by a test that failed while
+/// holding it -- the flags are reset by each test that takes it, and one
+/// failure should not cascade into every other.
+#[cfg(test)]
+pub(super) fn canvas_height_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    CANVAS_HEIGHT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+/// The on-screen keyboard's height, or 0 while it is not shown.
+fn keyboard_panel_height() -> usize {
+    if super::keyboard_panel_shown() {
+        kbdpanel::KBD_PANEL_HEIGHT
+    } else {
+        0
+    }
 }
 const STATUS_LABEL_X: usize = 18;
 const STATUS_LED_X: usize = 58;
@@ -297,18 +329,26 @@ const SHOT_BUTTON_X: usize = FB_WIDTH - 190;
 const SHOT_BUTTON_W: usize = 22;
 const VOLUME_SLIDER_X: usize = ui::MENU_BUTTON_X - 10 - VOLUME_SLIDER_W;
 const VOLUME_SLIDER_Y: usize = STATUS_CONTROL_Y + 7;
-const VOLUME_SLIDER_W: usize = 72;
+// The slider is as wide as the slot between the media controls and the menu
+// button leaves once the two icon toggles below have taken their 24 pixels
+// each: the bar has one free run of x, and every control on it competes for
+// the same worst case (four floppies plus a CD, ending at x=372).
+const VOLUME_SLIDER_W: usize = 48;
 const VOLUME_SLIDER_H: usize = 8;
 const VOLUME_KNOB_W: usize = 8;
 const VOLUME_KNOB_H: usize = 16;
 const VOLUME_GLYPH_X: usize = VOLUME_SLIDER_X - 16;
-// Joystick input-source toggle: a compact icon button just left of the volume
-// glyph, in the otherwise-free slot before the right-hand control cluster. The
-// widest media layout (four floppies plus a CD) ends at x=372, so a 22px button
-// here clears both the media controls and the speaker glyph; this is verified by
-// `joystick_toggle_clears_worst_case_media`.
+// Joystick input-source and on-screen-keyboard toggles: compact icon buttons
+// just left of the volume glyph, in the otherwise-free slot before the
+// right-hand control cluster. The widest media layout (four floppies plus a
+// CD) ends at x=372, so the pair of 22px buttons here clears both the media
+// controls and the speaker glyph; this is verified by
+// `joystick_toggle_clears_worst_case_media` and
+// `keyboard_toggle_clears_worst_case_media`.
 const JOY_TOGGLE_W: usize = 22;
 const JOY_TOGGLE_X: usize = VOLUME_GLYPH_X - 2 - JOY_TOGGLE_W;
+const KBD_TOGGLE_W: usize = 22;
+const KBD_TOGGLE_X: usize = JOY_TOGGLE_X - 2 - KBD_TOGGLE_W;
 // The standard-window and TV-aperture constants live in
 // `video/present_common.rs` with the presentation helpers they anchor
 // (re-exported through `use present::*` below). Both the live window and
@@ -1095,6 +1135,11 @@ pub struct App {
     /// hardware this is firmware -- so it is kept here.
     #[cfg(feature = "mt32")]
     mt32_panel: mt32panel::Mt32Panel,
+    /// The on-screen Amiga keyboard: which cap the mouse is holding, which
+    /// qualifiers are latched, and which legends the caps wear. Whether the
+    /// strip is up at all is `video::keyboard_panel_shown`, because the
+    /// canvas height is derived from it.
+    kbd_panel: kbdpanel::KbdPanelState,
     /// Mapped host keys currently held for keyboard joystick emulation.
     keyboard_joy_held: [keymap::HeldKeys; keymap::MAPPING_COUNT],
     /// Host-key to controller-control bindings, loaded from the per-user
@@ -1688,6 +1733,7 @@ impl App {
             rewind_armed,
             #[cfg(feature = "mt32")]
             mt32_panel: mt32panel::Mt32Panel::default(),
+            kbd_panel: kbdpanel::KbdPanelState::default(),
             keyboard_joy_held: [keymap::HeldKeys::default(); keymap::MAPPING_COUNT],
             keymap: keymap::KeyMap::load(),
             autofire_hz,
@@ -3161,8 +3207,14 @@ impl ApplicationHandler for App {
                     });
                 #[cfg(not(feature = "mt32"))]
                 let mt32_hover_changed = false;
+                // The keycaps light under the pointer the same way.
+                let kbd_hover_changed = kbdpanel::shown_panel_rect(keyboard_panel_top())
+                    .is_some_and(|panel| {
+                        kbdpanel::hover_changed(panel, previous_cursor_pos, self.cursor_pos)
+                    });
                 if bar_hover_changed(&layout, previous_cursor_pos, self.cursor_pos)
                     || mt32_hover_changed
+                    || kbd_hover_changed
                     || self.main_ui_hover_changed(previous_cursor_pos, self.cursor_pos)
                 {
                     self.request_redraw();
@@ -3216,6 +3268,9 @@ impl ApplicationHandler for App {
                     self.volume_dragging = false;
                     self.analyzer_dragging = false;
                     self.set_mouse_captured(false);
+                    // The button that was holding a keycap will lift over
+                    // some other window, where no MouseInput reaches us.
+                    self.release_keyboard_panel_key();
                 }
             }
             WindowEvent::MouseInput { state, button, .. } => {
@@ -3286,6 +3341,27 @@ impl ApplicationHandler for App {
                             if let Some(control) = mt32panel::control_at(panel, pos) {
                                 let left = button == MouseButton::Left;
                                 self.press_mt32_control(control, left, pos);
+                            }
+                            return;
+                        }
+                    }
+                }
+                // A cap on the on-screen keyboard is let go wherever the
+                // pointer has got to: one mouse button holds one key, so
+                // the lift ends it even if the hand slid off the strip.
+                if !pressed && button == MouseButton::Left && self.release_keyboard_panel_key() {
+                    return;
+                }
+                // The keyboard strip sits between the MT-32's panel and the
+                // status bar and takes its own clicks, as they both do.
+                if pressed && !self.mouse_captured && button == MouseButton::Left {
+                    if let (Some(pos), Some(panel)) = (
+                        self.cursor_pos,
+                        kbdpanel::shown_panel_rect(keyboard_panel_top()),
+                    ) {
+                        if panel.contains(pos) {
+                            if let Some(control) = kbdpanel::control_at(panel, pos) {
+                                self.press_keyboard_panel_control(control);
                             }
                             return;
                         }
@@ -3416,6 +3492,7 @@ impl ApplicationHandler for App {
                     paused: self.paused,
                     media,
                     joystick_input_mode: self.joystick_input_mode,
+                    keyboard_panel_shown: super::keyboard_panel_shown(),
                     hover,
                     control_connected,
                 };
@@ -3428,6 +3505,9 @@ impl ApplicationHandler for App {
                 let mt32_panel = super::mt32_panel_shown()
                     .then(|| self.mt32_panel_view())
                     .flatten();
+                // The Caps Lock lamp is the MCU's, so it is read fresh
+                // every frame rather than mirrored from the clicks.
+                let kbd_panel = super::keyboard_panel_shown().then(|| self.keyboard_panel_view());
                 let ui_data = self.build_panel_view_data();
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
@@ -3516,6 +3596,9 @@ impl ApplicationHandler for App {
                     #[cfg(feature = "mt32")]
                     if let Some(panel) = &mt32_panel {
                         mt32panel::draw(frame, panel, present_height(), r.texture_scale);
+                    }
+                    if let Some(panel) = &kbd_panel {
+                        kbdpanel::draw(frame, panel, keyboard_panel_top(), r.texture_scale);
                     }
                     if !super::status_bar_hidden() {
                         draw_status_bar(frame, &view, r.texture_scale);
@@ -4946,6 +5029,7 @@ impl App {
             mt32_attached,
             mt32_input,
             mt32_panel: crate::video::mt32_panel_shown(),
+            keyboard_panel: crate::video::keyboard_panel_shown(),
             mt32_lcd: crate::video::mt32_lcd(),
             sampler_input: self.sampler.input_device.as_deref().unwrap_or(""),
             sampler_inputs: &sampler_inputs,
@@ -5124,6 +5208,7 @@ impl App {
                 self.show_osd(format!("Autofire: {label}"));
                 self.request_redraw();
             }
+            A::ToggleKeyboardPanel => self.toggle_keyboard_panel(),
 
             #[cfg(feature = "midi")]
             A::SetMidiInput(name) => {
@@ -5329,6 +5414,89 @@ impl App {
             let _ = self.resync_canvas_height();
         }
         self.request_redraw();
+    }
+
+    /// Show or hide the on-screen keyboard, resizing the presentation to
+    /// match. Like the MT-32's panel, the strip takes height from the
+    /// canvas and the draw helpers size themselves from the flag, so the
+    /// two have to move together. Every route in goes through here.
+    fn set_keyboard_panel_shown(&mut self, shown: bool) {
+        if shown == crate::video::keyboard_panel_shown() {
+            return;
+        }
+        if !shown {
+            // The strip is going away with keys still down on it; hand
+            // them back before it does, or the guest is left holding them.
+            let outcome = self.kbd_panel.release_all();
+            self.apply_keyboard_panel_outcome(outcome);
+        }
+        // Decide before the flag flips whether the window still matches the
+        // canvas, so a manual resize survives.
+        let was_canvas_sized = self.window_is_canvas_sized();
+        crate::video::set_keyboard_panel_shown(shown);
+        if self.resync_canvas_height() {
+            self.follow_canvas_change(was_canvas_sized);
+        } else {
+            crate::video::set_keyboard_panel_shown(!shown);
+            let _ = self.resync_canvas_height();
+        }
+        self.request_redraw();
+    }
+
+    fn toggle_keyboard_panel(&mut self) {
+        let shown = !crate::video::keyboard_panel_shown();
+        self.set_keyboard_panel_shown(shown);
+        self.show_osd(if shown {
+            "On-screen keyboard shown"
+        } else {
+            "On-screen keyboard hidden"
+        });
+    }
+
+    /// A click on the on-screen keyboard. The strip works out what it
+    /// means; what comes back is rawkey transitions for the machine.
+    fn press_keyboard_panel_control(&mut self, control: kbdpanel::KbdControl) {
+        let outcome = self.kbd_panel.press(control, Instant::now());
+        let close = outcome.close;
+        self.apply_keyboard_panel_outcome(outcome);
+        if close {
+            self.set_keyboard_panel_shown(false);
+        }
+        self.request_redraw();
+    }
+
+    /// The mouse button lifted. True when it was holding a keycap, in
+    /// which case this click was the keyboard's and nobody else's.
+    fn release_keyboard_panel_key(&mut self) -> bool {
+        if !self.kbd_panel.holding_key() {
+            return false;
+        }
+        let outcome = self.kbd_panel.release(Instant::now());
+        self.apply_keyboard_panel_outcome(outcome);
+        self.request_redraw();
+        true
+    }
+
+    /// Hand the strip's key transitions to the machine. They go through
+    /// the same door as a host keystroke, so an on-screen press is
+    /// de-duplicated, recorded by `--record-input`, and noted for replay
+    /// exactly as a real one is.
+    fn apply_keyboard_panel_outcome(&mut self, outcome: kbdpanel::KbdOutcome) {
+        for (rawkey, pressed) in outcome.keys {
+            self.handle_amiga_key_event(rawkey, pressed);
+        }
+    }
+
+    /// What the strip looks like this frame, with the Caps Lock lamp read
+    /// off the keyboard MCU rather than mirrored from the clicks: a
+    /// save-state load moves that lamp with no key pressed.
+    fn keyboard_panel_view(&mut self) -> kbdpanel::KbdPanelView {
+        let caps_lit = self.emu.bus().keyboard.caps_lock_led();
+        let hover = self
+            .cursor_pos
+            .zip(kbdpanel::shown_panel_rect(keyboard_panel_top()))
+            .and_then(|(pos, panel)| kbdpanel::control_at(panel, pos));
+        self.kbd_panel.view(caps_lit, hover)
     }
 
     /// The synth the panel is driving, when one is fitted and switched on.
@@ -5569,12 +5737,15 @@ impl App {
     /// resized, in which case the caller has to put its flag back: the draw
     /// helpers size themselves from the flag, so a taller canvas over a
     /// shorter buffer would index past it.
-    #[cfg(feature = "mt32")]
+    ///
+    /// Shared by every strip that takes a slice of the canvas -- the MT-32
+    /// panel and the on-screen keyboard -- since what has to follow the
+    /// change is the same in each case.
     fn resync_canvas_height(&mut self) -> bool {
         if let Some(r) = self.render.as_mut() {
             let surface = r.window.inner_size();
             if let Err(e) = sync_main_present_scaling(r, (surface.width, surface.height)) {
-                warn!("resize texture buffer for the MT-32 panel failed: {e}");
+                warn!("resize texture buffer for a canvas-height change failed: {e}");
                 return false;
             }
         }
@@ -5586,7 +5757,7 @@ impl App {
                     texture_width(tool.texture_scale) as u32,
                     texture_height(tool.texture_scale) as u32,
                 ) {
-                    warn!("resize tool texture buffer for the MT-32 panel failed: {e}");
+                    warn!("resize tool texture buffer for a canvas-height change failed: {e}");
                 }
                 tool.window.request_redraw();
             }
@@ -5625,6 +5796,7 @@ impl App {
                 self.cycle_joystick_input_mode();
                 self.request_redraw();
             }
+            BarControl::Keyboard => self.toggle_keyboard_panel(),
             BarControl::Volume => {}
         }
     }
@@ -11374,6 +11546,7 @@ mod console;
 mod control;
 mod crt_shader;
 mod host_input;
+mod kbdpanel;
 #[cfg(feature = "mt32")]
 mod mt32panel;
 mod present;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -254,23 +254,6 @@ fn keyboard_panel_top() -> usize {
     present_height() + mt32_panel_height()
 }
 
-/// Serialises the tests that put one of the canvas-height strips up. The
-/// flags behind them are process-global (they have to be: the draw helpers
-/// size themselves from them), so a test reading `window_present_height`
-/// while another has a strip up would be measuring the other one's canvas.
-#[cfg(test)]
-pub(super) static CANVAS_HEIGHT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Take that lock, ignoring a poisoning left by a test that failed while
-/// holding it -- the flags are reset by each test that takes it, and one
-/// failure should not cascade into every other.
-#[cfg(test)]
-pub(super) fn canvas_height_test_lock() -> std::sync::MutexGuard<'static, ()> {
-    CANVAS_HEIGHT_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-}
-
 /// The on-screen keyboard's height, or 0 while it is not shown.
 fn keyboard_panel_height() -> usize {
     if super::keyboard_panel_shown() {
@@ -685,6 +668,25 @@ fn rawkey_index(rawkey: u8) -> usize {
     (rawkey & 0x7F) as usize
 }
 
+/// Where a rawkey transition came from.
+///
+/// Two things can have a key down at once -- a finger on the host keyboard
+/// and a click on the on-screen keyboard -- and each keeps its own held
+/// table so its own repeats and stale releases are dropped. What the
+/// machine is told is the *aggregate*: the key is down for it while either
+/// source holds it, and only a change in that aggregate is enqueued,
+/// recorded, or noted for replay. Without that, pressing a cap the host is
+/// already holding would be swallowed as a duplicate while its release
+/// still went through, cutting the host's key short -- and the strip would
+/// go on drawing a latch the keyboard MCU never heard about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeySource {
+    /// The host keyboard, both the focused and raw-device paths.
+    Host,
+    /// The on-screen keyboard strip.
+    Panel,
+}
+
 fn rawkey_is_held(held_rawkeys: &[bool; 128], rawkey: u8) -> bool {
     held_rawkeys[rawkey_index(rawkey)]
 }
@@ -961,7 +963,19 @@ pub struct App {
     /// impl catches every exit path, including the headless captures).
     record_input_path: Option<PathBuf>,
     modifiers: ModifiersState,
+    /// Rawkeys the host keyboard is holding down (both the focused
+    /// `KeyboardInput` path and the raw-device qualifier path feed it).
+    /// One of the two sources behind [`App::amiga_rawkey_held`]; see
+    /// [`KeySource`] for why the machine is told about the aggregate
+    /// rather than about either source on its own.
     held_rawkeys: [bool; 128],
+    /// Rawkeys the on-screen keyboard is holding down: the cap under the
+    /// mouse and every latched qualifier. The other source.
+    panel_held_rawkeys: [bool; 128],
+    /// Physical state of the qualifier keys as the raw-device listener
+    /// sees them, which is not a source of its own: it is what stops a
+    /// winit `ModifiersState` update from releasing a qualifier the
+    /// hardware still has down (see `update_host_modifiers`).
     raw_device_held_rawkeys: [bool; 128],
     main_window_focused: bool,
     /// Whether the user has sized the main window themselves, in which case
@@ -1680,6 +1694,7 @@ impl App {
             record_input_path: record_input,
             modifiers: ModifiersState::empty(),
             held_rawkeys: [false; 128],
+            panel_held_rawkeys: [false; 128],
             raw_device_held_rawkeys: [false; 128],
             main_window_focused: false,
             window_manually_sized: false,
@@ -5427,8 +5442,7 @@ impl App {
         if !shown {
             // The strip is going away with keys still down on it; hand
             // them back before it does, or the guest is left holding them.
-            let outcome = self.kbd_panel.release_all();
-            self.apply_keyboard_panel_outcome(outcome);
+            self.release_keyboard_panel_holds();
         }
         // Decide before the flag flips whether the window still matches the
         // canvas, so a manual resize survives.
@@ -5478,13 +5492,26 @@ impl App {
     }
 
     /// Hand the strip's key transitions to the machine. They go through
-    /// the same door as a host keystroke, so an on-screen press is
-    /// de-duplicated, recorded by `--record-input`, and noted for replay
-    /// exactly as a real one is.
+    /// the same door as a host keystroke -- recorded by `--record-input`
+    /// and noted for replay exactly as a real one is -- but as their own
+    /// source, so a cap and a host key can hold the same rawkey without
+    /// either cutting the other short (see [`KeySource`]).
     fn apply_keyboard_panel_outcome(&mut self, outcome: kbdpanel::KbdOutcome) {
         for (rawkey, pressed) in outcome.keys {
-            self.handle_amiga_key_event(rawkey, pressed);
+            self.handle_amiga_key_event_from(KeySource::Panel, rawkey, pressed);
         }
+    }
+
+    /// Let go of everything the on-screen keyboard is holding, through the
+    /// aggregate path, so the machine hears the releases and the drawn
+    /// latches match what it believes.
+    ///
+    /// Called wherever the machine or its keyboard is about to be replaced
+    /// or restarted: a latch is a host-side affordance and has no business
+    /// outliving the machine it was latched against.
+    fn release_keyboard_panel_holds(&mut self) {
+        let outcome = self.kbd_panel.release_all();
+        self.apply_keyboard_panel_outcome(outcome);
     }
 
     /// What the strip looks like this frame, with the Caps Lock lamp read
@@ -7716,6 +7743,11 @@ impl App {
     /// powering it on. The previous (placeholder or running) machine, and its
     /// audio sink, are dropped here.
     fn run_machine(&mut self, emu: Emulator, cfg: &Config, raw: RawConfig) {
+        // Anything the on-screen keyboard is holding belongs to the
+        // machine being replaced, and has to be handed back while that
+        // machine is still here: the new one would otherwise come up with
+        // caps drawn latched that its keyboard MCU never heard of.
+        self.release_keyboard_panel_holds();
         self.emu = emu;
         // Any heat map the analyzer pane armed went with the machine that
         // was just replaced, so the pane owns nothing on this one until it
@@ -8094,6 +8126,12 @@ impl App {
     }
 
     fn load_state_from_path(&mut self, path: &std::path::Path) -> bool {
+        // The restored machine carries its own keyboard state, so the
+        // strip lets go of its holds against the machine that is still
+        // here. Done before the attempt rather than after a success: a
+        // release sent into the restored machine would be a key it never
+        // saw pressed.
+        self.release_keyboard_panel_holds();
         match self.emu.load_state(path) {
             Ok(outcome) => {
                 info!(
@@ -10878,12 +10916,44 @@ impl App {
         }
     }
 
+    /// Whether the machine is being told `rawkey` is down -- by the host
+    /// keyboard, by the on-screen one, or by both.
+    fn amiga_rawkey_held(&self, rawkey: u8) -> bool {
+        rawkey_is_held(&self.held_rawkeys, rawkey)
+            || rawkey_is_held(&self.panel_held_rawkeys, rawkey)
+    }
+
+    /// A transition from the host keyboard.
     fn handle_amiga_key_event(&mut self, rawkey: u8, pressed: bool) {
-        if rawkey_transition_is_duplicate(&self.held_rawkeys, rawkey, pressed) {
+        self.handle_amiga_key_event_from(KeySource::Host, rawkey, pressed);
+    }
+
+    /// A transition from `source`, reaching the machine only when it moves
+    /// the aggregate held state (see [`KeySource`]).
+    fn handle_amiga_key_event_from(&mut self, source: KeySource, rawkey: u8, pressed: bool) {
+        let idx = rawkey_index(rawkey);
+        let held = match source {
+            KeySource::Host => &self.held_rawkeys,
+            KeySource::Panel => &self.panel_held_rawkeys,
+        };
+        // Per-source: a winit auto-repeat re-presses a key this source
+        // already has down, and a source can be told to let go of
+        // something it never took.
+        if rawkey_transition_is_duplicate(held, rawkey, pressed) {
             return;
         }
-        let idx = rawkey_index(rawkey);
-        self.held_rawkeys[idx] = pressed;
+        let was_held = self.amiga_rawkey_held(rawkey);
+        match source {
+            KeySource::Host => self.held_rawkeys[idx] = pressed,
+            KeySource::Panel => self.panel_held_rawkeys[idx] = pressed,
+        }
+        // The other source is holding the same key, so the aggregate did
+        // not move: the machine already believes what this transition
+        // would tell it, and a recorded or replayed copy of it would
+        // reproduce the second holder rather than the keystroke.
+        if was_held == self.amiga_rawkey_held(rawkey) {
+            return;
+        }
 
         // Ctrl+Amiga+Amiga is no longer consumed host-side: the chord
         // travels to the keyboard MCU like every other transition, and
@@ -11179,6 +11249,10 @@ impl App {
     /// Power off: drop into a cold-boot state (RAM cleared) and park the
     /// test screen, so a later power-on comes up as a clean power cycle.
     fn power_off(&mut self) {
+        // A key held on the on-screen keyboard is let go before the power
+        // goes, so the cold-boot machine starts with the caps up and
+        // nothing latched against the machine that just stopped.
+        self.release_keyboard_panel_holds();
         self.powered_on = false;
         self.paused = false;
         self.sync_live_audio_suspension();
@@ -11220,6 +11294,11 @@ impl App {
     }
 
     fn reset_emulator(&mut self, clear_host_keys: bool) {
+        // The strip's latches are a host-side affordance: they must not
+        // ride through a reset and be re-reported by the MCU's power-up
+        // stream, which is what `begin_power_up` does with anything the
+        // matrix still shows held.
+        self.release_keyboard_panel_holds();
         if let Err(e) = self.emu.keyboard_reset() {
             error!("keyboard reset failed: {e:#}");
             self.cpu_halted = true;

--- a/src/video/window/kbdpanel.rs
+++ b/src/video/window/kbdpanel.rs
@@ -749,9 +749,15 @@ impl KbdPanelState {
     }
 
     /// Let go of everything the strip is holding: the cap under the mouse
-    /// and every latched qualifier. Used by the reset chord, by hiding the
-    /// keyboard, and when the machine those keys were pressed on is
-    /// replaced.
+    /// and every latched qualifier.
+    ///
+    /// Used by the reset chord and the close chip here, and by the window
+    /// for every machine-lifecycle change that invalidates a latch --
+    /// hiding the strip, running a new machine, loading a save state,
+    /// powering off, and rebooting (`App::release_keyboard_panel_holds`).
+    /// A latch is a host-side affordance, and one that outlived its
+    /// machine would be drawn down over a keyboard MCU that has never
+    /// heard of it.
     pub fn release_all(&mut self) -> KbdOutcome {
         let mut out = KbdOutcome::default();
         if let Some(rawkey) = self.pressed.take() {
@@ -966,8 +972,8 @@ fn draw_caps_led(frame: &mut [u8], cap: Rect, fill: u32, lit: bool, scale: usize
 /// What is printed on a cap: the main legend, with the shifted one above
 /// it, smaller and dimmer, as the cap prints them.
 fn draw_cap_legends(frame: &mut [u8], cap: Rect, main: Legend, shift: Legend, scale: usize) {
-    let main_px = legend_px(main, cap.w);
-    let main_h = font::GLYPH_H * main_px;
+    let main_px = legend_px(main);
+    let main_h = legend_height(main, main_px);
     if shift == Legend::None {
         let y = cap.y + cap.h.saturating_sub(main_h) / 2;
         draw_legend(frame, cap, y, main, main_px, CAP_INK, scale);
@@ -998,16 +1004,16 @@ fn draw_cap_legends(frame: &mut [u8], cap: Rect, main: Legend, shift: Legend, sc
     );
 }
 
-/// How large a legend is printed: as large as the cap takes, which puts
-/// the character legends at double size and the word legends -- Ctrl,
-/// Shift, Bksp -- at the size a real cap prints them, small.
-fn legend_px(legend: Legend, cap_w: usize) -> usize {
+/// How large a legend is printed.
+///
+/// A cap prints a character legend large and a word legend -- Esc, Ctrl,
+/// Shift, Alt, Bksp -- in a smaller face, and so does this: one character
+/// at double size, anything longer at single. Sizing by what fits the cap
+/// instead would put Alt and Ctrl, two qualifiers of the same width in the
+/// same row, at different sizes, and F10 at a different size from F9.
+fn legend_px(legend: Legend) -> usize {
     match legend {
-        Legend::Text(s) if font::text_width(s, 2) > cap_w => 1,
-        // The Amiga mark is drawn half again as large as a letter: the
-        // left key's is an outline, and an outline of a two-pixel stroke
-        // has nothing left inside it.
-        Legend::Amiga { .. } => 3,
+        Legend::Text(s) if s.chars().count() > 1 => 1,
         _ => 2,
     }
 }
@@ -1017,7 +1023,16 @@ fn legend_width(legend: Legend, px: usize) -> usize {
         Legend::None => 0,
         Legend::Text(s) => font::text_width(s, px),
         Legend::Pound | Legend::Arrow(_) => font::GLYPH_W * px,
-        Legend::Amiga { .. } => amiga_width(px),
+        // Drawn at its own size, in canvas pixels, rather than as a glyph
+        // scaled by whole font pixels.
+        Legend::Amiga { .. } => AMIGA_W,
+    }
+}
+
+fn legend_height(legend: Legend, px: usize) -> usize {
+    match legend {
+        Legend::Amiga { .. } => AMIGA_H,
+        _ => font::GLYPH_H * px,
     }
 }
 
@@ -1048,7 +1063,7 @@ fn draw_legend(
         }
         Legend::Pound => blit_glyph(frame, x, y, &POUND, px, ink, scale),
         Legend::Arrow(dir) => blit_glyph(frame, x, y, arrow_glyph(dir), px, ink, scale),
-        Legend::Amiga { hollow } => draw_amiga_mark(frame, x, y, px, hollow, ink, scale),
+        Legend::Amiga { hollow } => draw_amiga_mark(frame, x, y, hollow, ink, scale),
     }
 }
 
@@ -1104,69 +1119,80 @@ fn blit_glyph(
     }
 }
 
-/// The Amiga key's mark: an A leaning to the right, drawn rather than
-/// typed because the font has no italic and shearing an upright A a pixel
-/// at a time breaks its strokes into steps. Bit 0 of a row is its
-/// leftmost pixel, as in the font.
-static AMIGA_A: [u8; 8] = [0x30, 0x30, 0x78, 0xD8, 0xFC, 0xCC, 0x66, 0x00];
+// The Amiga key's mark: a capital A leaning to the right.
+//
+// Drawn from its own geometry in canvas pixels rather than from a font
+// cell scaled by whole font pixels. The font has no italic, and shearing
+// an upright A by a whole font pixel per row turns each stroke into a
+// staircase of blocks; laid out this way each stroke is a straight line
+// whose lean only ever steps a single pixel at a time.
 
-fn amiga_width(px: usize) -> usize {
-    font::GLYPH_W * px
+/// How tall the mark is, in canvas pixels: half a key, which leaves the
+/// moulding around it on a 1u cap.
+const AMIGA_H: usize = KEY_UNIT / 2;
+/// How far the apex stands right of the foot -- a quarter of the height,
+/// the lean an Amiga keycap's A wears.
+const AMIGA_SHEAR: usize = AMIGA_H / 4;
+/// Half the spread of the legs at the foot.
+const AMIGA_HALF: usize = AMIGA_H * 2 / 5;
+/// Stroke weight. Three rather than two so the left key's outline has
+/// something inside its contour: the outline of a two-pixel stroke is the
+/// whole stroke, and the two marks would come out identical.
+const AMIGA_STROKE: usize = 3;
+/// Where the crossbar sits, measured down the letter.
+const AMIGA_BAR_Y: usize = AMIGA_H * 62 / 100;
+/// The legs reach `AMIGA_HALF` either side of the stem at the foot and
+/// the apex stands `AMIGA_SHEAR` right of it, so the widest row is
+/// whichever of those two is larger.
+const AMIGA_W: usize = AMIGA_HALF
+    + AMIGA_STROKE
+    + if AMIGA_SHEAR > AMIGA_HALF {
+        AMIGA_SHEAR
+    } else {
+        AMIGA_HALF
+    };
+
+/// The letter, as the pixels it covers.
+///
+/// Row by row: the lean runs off linearly from the apex to the foot and
+/// the legs splay the other way, so both strokes are straight lines, and
+/// the crossbar is the run between them at [`AMIGA_BAR_Y`].
+fn amiga_mask() -> [[bool; AMIGA_W]; AMIGA_H] {
+    let mut mask = [[false; AMIGA_W]; AMIGA_H];
+    let last = AMIGA_H - 1;
+    for (y, row) in mask.iter_mut().enumerate() {
+        let lean = AMIGA_SHEAR * (last - y) / last;
+        let span = AMIGA_HALF * y / last;
+        let stem = lean + AMIGA_HALF;
+        let (left, right) = (stem - span, stem + span);
+        for x in left..left + AMIGA_STROKE {
+            row[x] = true;
+        }
+        for x in right..right + AMIGA_STROKE {
+            row[x] = true;
+        }
+        if (AMIGA_BAR_Y..AMIGA_BAR_Y + AMIGA_STROKE).contains(&y) {
+            for cell in row.iter_mut().take(right + AMIGA_STROKE).skip(left) {
+                *cell = true;
+            }
+        }
+    }
+    mask
 }
 
 /// The mark, filled on the right key and outlined on the left, as the
 /// case prints the pair.
-///
-/// The outline is taken after the letter is scaled up, so it is a real
-/// one-pixel edge around a two-pixel stroke rather than the whole stroke
-/// (every pixel of which has an empty neighbour at mark resolution).
-fn draw_amiga_mark(
-    frame: &mut [u8],
-    x: usize,
-    y: usize,
-    px: usize,
-    hollow: bool,
-    ink: u32,
-    scale: usize,
-) {
-    const MAX_W: usize = 8 * 3;
-    const MAX_H: usize = 8 * 3;
-    let (w, h) = (amiga_width(px), font::GLYPH_H * px);
-    if w > MAX_W || h > MAX_H {
-        return;
-    }
-    let mut mask = [[false; MAX_W]; MAX_H];
-    for (row_idx, row) in AMIGA_A.iter().enumerate() {
-        for col in 0..font::GLYPH_W {
-            if row & (1 << col) == 0 {
-                continue;
-            }
-            for dy in 0..px {
-                for dx in 0..px {
-                    mask[row_idx * px + dy][col * px + dx] = true;
-                }
-            }
-        }
-    }
-    for (row, cells) in mask.iter().enumerate().take(h) {
-        for (col, &set) in cells.iter().enumerate().take(w) {
+fn draw_amiga_mark(frame: &mut [u8], x: usize, y: usize, hollow: bool, ink: u32, scale: usize) {
+    let mask = amiga_mask();
+    for (row, cells) in mask.iter().enumerate() {
+        for (col, &set) in cells.iter().enumerate() {
             if !set {
                 continue;
             }
-            if hollow {
-                // An inner pixel is one whose four neighbours are all part
-                // of the letter; the rest are its edge.
-                let inner = row > 0
-                    && col > 0
-                    && row + 1 < h
-                    && col + 1 < w
-                    && mask[row - 1][col]
-                    && mask[row + 1][col]
-                    && mask[row][col - 1]
-                    && mask[row][col + 1];
-                if inner {
-                    continue;
-                }
+            // Outlined: keep only the edge of the letter, which is every
+            // pixel that has a neighbour outside it.
+            if hollow && amiga_interior(&mask, row, col) {
+                continue;
             }
             fill_rect(
                 frame,
@@ -1184,6 +1210,19 @@ fn draw_amiga_mark(
             );
         }
     }
+}
+
+/// Whether the pixel at (`row`, `col`) is surrounded by the letter on all
+/// four sides, and so is inside it rather than on its edge.
+fn amiga_interior(mask: &[[bool; AMIGA_W]; AMIGA_H], row: usize, col: usize) -> bool {
+    row > 0
+        && col > 0
+        && row + 1 < AMIGA_H
+        && col + 1 < AMIGA_W
+        && mask[row - 1][col]
+        && mask[row + 1][col]
+        && mask[row][col - 1]
+        && mask[row][col + 1]
 }
 
 /// A notch chip: the same moulding as the status bar's own buttons, so the
@@ -1278,16 +1317,17 @@ mod tests {
         panel_rect(500)
     }
 
-    /// Holds the canvas-height lock while the strip is up, and takes it
-    /// down again however the test ends: the flag is process-global, and a
-    /// failed assertion must not leave it set for everything after it.
-    struct KeyboardUp(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+    /// Puts the strip up for the length of a test and takes it down again
+    /// however the test ends. The flag is this thread's own in a test
+    /// build (see `crate::video::set_keyboard_panel_shown`), so it costs
+    /// no other test anything -- but a test that left it set would still
+    /// mislead the next one to run on the same thread.
+    struct KeyboardUp;
 
     impl KeyboardUp {
         fn shown() -> Self {
-            let guard = crate::video::window::canvas_height_test_lock();
             crate::video::set_keyboard_panel_shown(true);
-            Self(guard)
+            Self
         }
     }
 

--- a/src/video/window/kbdpanel.rs
+++ b/src/video/window/kbdpanel.rs
@@ -18,7 +18,7 @@
 //! the host has no equivalent for (Help, both Amiga keys, $2B), and a
 //! session driven entirely by the mouse.
 
-use super::statusbar::{draw_rect_bevel, fill_rect};
+use super::statusbar::{blend_pixel, draw_rect_bevel, fill_rect};
 use super::Rect;
 use super::{
     texture_height, texture_width, BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE,
@@ -1121,108 +1121,73 @@ fn blit_glyph(
 
 // The Amiga key's mark: a capital A leaning to the right.
 //
-// Drawn from its own geometry in canvas pixels rather than from a font
-// cell scaled by whole font pixels. The font has no italic, and shearing
-// an upright A by a whole font pixel per row turns each stroke into a
-// staircase of blocks; laid out this way each stroke is a straight line
-// whose lean only ever steps a single pixel at a time.
+// The three strokes are capsules (line segments with a stroke radius) and
+// each pixel is painted with its analytic coverage of them -- distance to
+// the nearest stroke, resolved at the texture's own resolution and blended
+// through an antialiased edge. Whole-pixel masks were tried twice and both
+// read as staircases: the font's A sheared by whole font pixels, and a
+// canvas-pixel mask whose 1 px steps became scale-sized blocks.
 
 /// How tall the mark is, in canvas pixels: half a key, which leaves the
 /// moulding around it on a 1u cap.
 const AMIGA_H: usize = KEY_UNIT / 2;
-/// How far the apex stands right of the foot -- a quarter of the height,
-/// the lean an Amiga keycap's A wears.
-const AMIGA_SHEAR: usize = AMIGA_H / 4;
-/// Half the spread of the legs at the foot.
-const AMIGA_HALF: usize = AMIGA_H * 2 / 5;
-/// Stroke weight. Three rather than two so the left key's outline has
-/// something inside its contour: the outline of a two-pixel stroke is the
-/// whole stroke, and the two marks would come out identical.
+/// Stroke weight, in canvas pixels. Three rather than two so the left
+/// key's outline ring has an interior to be hollow around.
 const AMIGA_STROKE: usize = 3;
-/// Where the crossbar sits, measured down the letter.
-const AMIGA_BAR_Y: usize = AMIGA_H * 62 / 100;
-/// The legs reach `AMIGA_HALF` either side of the stem at the foot and
-/// the apex stands `AMIGA_SHEAR` right of it, so the widest row is
-/// whichever of those two is larger.
-const AMIGA_W: usize = AMIGA_HALF
-    + AMIGA_STROKE
-    + if AMIGA_SHEAR > AMIGA_HALF {
-        AMIGA_SHEAR
-    } else {
-        AMIGA_HALF
-    };
+/// The width of the cell the mark is centred in.
+const AMIGA_W: usize = AMIGA_H * 9 / 10;
+/// Where the crossbar's centreline sits, measured down the letter.
+const AMIGA_BAR_Y: f32 = AMIGA_H as f32 * 0.69;
 
-/// The letter, as the pixels it covers.
-///
-/// Row by row: the lean runs off linearly from the apex to the foot and
-/// the legs splay the other way, so both strokes are straight lines, and
-/// the crossbar is the run between them at [`AMIGA_BAR_Y`].
-fn amiga_mask() -> [[bool; AMIGA_W]; AMIGA_H] {
-    let mut mask = [[false; AMIGA_W]; AMIGA_H];
-    let last = AMIGA_H - 1;
-    for (y, row) in mask.iter_mut().enumerate() {
-        let lean = AMIGA_SHEAR * (last - y) / last;
-        let span = AMIGA_HALF * y / last;
-        let stem = lean + AMIGA_HALF;
-        let (left, right) = (stem - span, stem + span);
-        for x in left..left + AMIGA_STROKE {
-            row[x] = true;
-        }
-        for x in right..right + AMIGA_STROKE {
-            row[x] = true;
-        }
-        if (AMIGA_BAR_Y..AMIGA_BAR_Y + AMIGA_STROKE).contains(&y) {
-            for cell in row.iter_mut().take(right + AMIGA_STROKE).skip(left) {
-                *cell = true;
-            }
-        }
-    }
-    mask
+/// Distance from `p` to the segment `a`..`b`.
+fn segment_distance(p: (f32, f32), a: (f32, f32), b: (f32, f32)) -> f32 {
+    let (px, py) = (p.0 - a.0, p.1 - a.1);
+    let (bx, by) = (b.0 - a.0, b.1 - a.1);
+    let t = ((px * bx + py * by) / (bx * bx + by * by)).clamp(0.0, 1.0);
+    let (dx, dy) = (px - t * bx, py - t * by);
+    (dx * dx + dy * dy).sqrt()
 }
 
 /// The mark, filled on the right key and outlined on the left, as the
 /// case prints the pair.
 fn draw_amiga_mark(frame: &mut [u8], x: usize, y: usize, hollow: bool, ink: u32, scale: usize) {
-    let mask = amiga_mask();
-    for (row, cells) in mask.iter().enumerate() {
-        for (col, &set) in cells.iter().enumerate() {
-            if !set {
-                continue;
+    let h = AMIGA_H as f32;
+    let r = AMIGA_STROKE as f32 / 2.0;
+    // The legs splay to fill the cell at the foot; the apex leans a
+    // quarter of the height right of the letter's midline.
+    let half = (AMIGA_W as f32 - 2.0 * r) / 2.0;
+    let apex = (half + r + h / 4.0, r);
+    let foot_l = (r, h - r);
+    let foot_r = (2.0 * half + r, h - r);
+    // The crossbar runs between the legs' centrelines at its height.
+    let t = (AMIGA_BAR_Y - apex.1) / (foot_l.1 - apex.1);
+    let bar_l = (apex.0 + t * (foot_l.0 - apex.0), AMIGA_BAR_Y);
+    let bar_r = (apex.0 + t * (foot_r.0 - apex.0), AMIGA_BAR_Y);
+    let s = scale as f32;
+    for ty in 0..AMIGA_H * scale {
+        for tx in 0..AMIGA_W * scale {
+            // The pixel's centre, in the letter's own canvas units.
+            let p = ((tx as f32 + 0.5) / s, (ty as f32 + 0.5) / s);
+            let d = segment_distance(p, apex, foot_l)
+                .min(segment_distance(p, apex, foot_r))
+                .min(segment_distance(p, bar_l, bar_r))
+                - r;
+            // Signed distance to the letter's edge, in texture pixels;
+            // coverage fades over one pixel either side of it. The
+            // outlined mark keeps a ring half a stroke wide around the
+            // edge instead of the inside.
+            let d = d * s;
+            let alpha = if hollow {
+                0.5 + r * s / 2.0 - d.abs()
+            } else {
+                0.5 - d
             }
-            // Outlined: keep only the edge of the letter, which is every
-            // pixel that has a neighbour outside it.
-            if hollow && amiga_interior(&mask, row, col) {
-                continue;
+            .clamp(0.0, 1.0);
+            if alpha > 0.0 {
+                blend_pixel(frame, x * scale + tx, y * scale + ty, ink, alpha, scale);
             }
-            fill_rect(
-                frame,
-                scaled(
-                    Rect {
-                        x: x + col,
-                        y: y + row,
-                        w: 1,
-                        h: 1,
-                    },
-                    scale,
-                ),
-                ink,
-                scale,
-            );
         }
     }
-}
-
-/// Whether the pixel at (`row`, `col`) is surrounded by the letter on all
-/// four sides, and so is inside it rather than on its edge.
-fn amiga_interior(mask: &[[bool; AMIGA_W]; AMIGA_H], row: usize, col: usize) -> bool {
-    row > 0
-        && col > 0
-        && row + 1 < AMIGA_H
-        && col + 1 < AMIGA_W
-        && mask[row - 1][col]
-        && mask[row + 1][col]
-        && mask[row][col - 1]
-        && mask[row][col + 1]
 }
 
 /// A notch chip: the same moulding as the status bar's own buttons, so the

--- a/src/video/window/kbdpanel.rs
+++ b/src/video/window/kbdpanel.rs
@@ -1153,21 +1153,33 @@ fn segment_distance(p: (f32, f32), a: (f32, f32), b: (f32, f32)) -> f32 {
 fn draw_amiga_mark(frame: &mut [u8], x: usize, y: usize, hollow: bool, ink: u32, scale: usize) {
     let h = AMIGA_H as f32;
     let r = AMIGA_STROKE as f32 / 2.0;
+    // The outlined mark's ring is centred on the letter's edge, so it
+    // reaches half a stroke beyond it; its geometry is inset by the same
+    // amount so the ring's outer rim lands exactly where the solid mark's
+    // silhouette does, and the two keys print the letter the same size.
+    let ring = if hollow { r / 2.0 } else { 0.0 };
+    let inset = r + ring;
     // The legs splay to fill the cell at the foot; the apex leans a
     // quarter of the height right of the letter's midline.
-    let half = (AMIGA_W as f32 - 2.0 * r) / 2.0;
-    let apex = (half + r + h / 4.0, r);
-    let foot_l = (r, h - r);
-    let foot_r = (2.0 * half + r, h - r);
+    let half = (AMIGA_W as f32 - 2.0 * inset) / 2.0;
+    let apex = (half + inset + h / 4.0, inset);
+    let foot_l = (inset, h - inset);
+    let foot_r = (2.0 * half + inset, h - inset);
     // The crossbar runs between the legs' centrelines at its height.
     let t = (AMIGA_BAR_Y - apex.1) / (foot_l.1 - apex.1);
     let bar_l = (apex.0 + t * (foot_l.0 - apex.0), AMIGA_BAR_Y);
     let bar_r = (apex.0 + t * (foot_r.0 - apex.0), AMIGA_BAR_Y);
     let s = scale as f32;
-    for ty in 0..AMIGA_H * scale {
-        for tx in 0..AMIGA_W * scale {
+    // One canvas pixel of slack around the cell, so the antialiased fade
+    // at the letter's extremes is painted rather than cut off flat.
+    let m = 1usize;
+    for ty in 0..(AMIGA_H + 2 * m) * scale {
+        for tx in 0..(AMIGA_W + 2 * m) * scale {
             // The pixel's centre, in the letter's own canvas units.
-            let p = ((tx as f32 + 0.5) / s, (ty as f32 + 0.5) / s);
+            let p = (
+                (tx as f32 + 0.5) / s - m as f32,
+                (ty as f32 + 0.5) / s - m as f32,
+            );
             let d = segment_distance(p, apex, foot_l)
                 .min(segment_distance(p, apex, foot_r))
                 .min(segment_distance(p, bar_l, bar_r))
@@ -1178,13 +1190,19 @@ fn draw_amiga_mark(frame: &mut [u8], x: usize, y: usize, hollow: bool, ink: u32,
             // edge instead of the inside.
             let d = d * s;
             let alpha = if hollow {
-                0.5 + r * s / 2.0 - d.abs()
+                0.5 + ring * s - d.abs()
             } else {
                 0.5 - d
             }
             .clamp(0.0, 1.0);
             if alpha > 0.0 {
-                blend_pixel(frame, x * scale + tx, y * scale + ty, ink, alpha, scale);
+                let (Some(px), Some(py)) = (
+                    (x * scale + tx).checked_sub(m * scale),
+                    (y * scale + ty).checked_sub(m * scale),
+                ) else {
+                    continue;
+                };
+                blend_pixel(frame, px, py, ink, alpha, scale);
             }
         }
     }

--- a/src/video/window/kbdpanel.rs
+++ b/src/video/window/kbdpanel.rs
@@ -1,0 +1,1689 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The on-screen Amiga keyboard, drawn under the display.
+//!
+//! It is an A600: the one Amiga keyboard with no numeric keypad, so the
+//! whole machine fits the 716-pixel canvas at a usable cap size instead of
+//! spending a third of the width on a keypad. Geometry is the A600's own
+//! 1u grid -- every row 16.5u wide, six rows plus the 0.5u float under the
+//! function row -- and the rawkeys are RKM Libraries table 34-6.
+//!
+//! Clicks go to the keyboard MCU as rawkey transitions, not as host key
+//! codes: $2B, the key beside Return, has no host key on every layout, and
+//! a synthetic host event would also be offered to the keyboard-joystick
+//! mapping first, which would steer a joystick with the cursor keys. An
+//! on-screen Amiga keyboard types.
+//!
+//! The same strip serves the two things a host keyboard cannot do: keys
+//! the host has no equivalent for (Help, both Amiga keys, $2B), and a
+//! session driven entirely by the mouse.
+
+use super::statusbar::{draw_rect_bevel, fill_rect};
+use super::Rect;
+use super::{
+    texture_height, texture_width, BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE,
+    BUTTON_FACE_HOVER, STATUS_BG, STATUS_BOTTOM, STATUS_TEXT, STATUS_TOP,
+};
+use crate::video::font;
+use crate::video::FB_WIDTH;
+use std::time::{Duration, Instant};
+
+/// One grid unit, in canvas pixels. The A600 is 16.5u wide and the canvas
+/// is 716, so 43.4 is the largest unit that fills it; 42 is the whole
+/// number under that, and the 23 pixels it leaves become the side margin
+/// that keeps the outermost caps off the window edge.
+const KEY_UNIT: usize = 42;
+/// The grid, in quarter-units. Everything on an A600 lands on a quarter:
+/// the caps are 1, 1.25, 1.5, 1.75, 2 and 8 units, the gaps 0.5, and only
+/// the ISO Return's stem offset is a quarter. Positions are accumulated in
+/// these integers and converted once, so a row cannot drift.
+const GRID_W_Q: usize = 66; // 16.5u
+const GRID_H_Q: usize = 26; // 6.5u
+/// A quarter-unit position in canvas pixels.
+const fn u_px(q: usize) -> usize {
+    q * KEY_UNIT / 4
+}
+const GRID_W: usize = u_px(GRID_W_Q);
+const GRID_H: usize = u_px(GRID_H_Q);
+/// The margin above and below the keys. The side margin is whatever the
+/// grid leaves of the canvas, so the keyboard is centred on it.
+const PAD_Y: usize = 5;
+const PAD_X: usize = (FB_WIDTH - GRID_W) / 2;
+
+/// How tall the strip is: the six rows plus the margin around them.
+pub const KBD_PANEL_HEIGHT: usize = GRID_H + 2 * PAD_Y;
+
+/// How far the visible cap is inset inside its grid cell. The whole cell
+/// is live, so the gaps between caps still hit the key they belong to.
+const CAP_INSET: usize = 2;
+
+// The fascia is the status bar's, so the strip and the bar read as one
+// piece of chrome rather than two greys that nearly match.
+const PANEL_FACE: u32 = STATUS_BG;
+const PANEL_EDGE_LIGHT: u32 = STATUS_TOP;
+const PANEL_EDGE_DARK: u32 = STATUS_BOTTOM;
+
+// Keycaps. Pale mouldings with near-black legends, the way an A600's caps
+// are, rather than the dark chrome of the fascia they sit on -- a keyboard
+// drawn in the fascia's own greys would read as a grille.
+const CAP_IDLE: u32 = rgba(226, 223, 214);
+const CAP_MOD: u32 = rgba(196, 193, 184);
+const CAP_DOWN: u32 = rgba(168, 164, 152);
+/// A locked qualifier, and the Caps Lock cap while its lamp is lit.
+const CAP_LOCKED: u32 = rgba(232, 145, 84);
+const CAP_INK: u32 = rgba(21, 23, 28);
+/// The Caps Lock lamp in the corner of its own cap, driven by the MCU.
+const CAPS_LED_ON: u32 = rgba(44, 200, 80);
+/// How far a cap lifts under the pointer, matching the status bar's own
+/// buttons so a hover reads the same wherever on the window it happens.
+const HOVER_LIFT: f32 = 16.0;
+/// How the moulding is shaded: the light from the top left, as every
+/// bevel on the window has it.
+const CAP_BEVEL_LIGHT: f32 = 26.0;
+const CAP_BEVEL_DARK: f32 = -64.0;
+/// How far a shifted legend falls back towards its cap, so the two lines
+/// read as the printed pair they are rather than as two legends.
+const SHIFT_DIM: f32 = 0.45;
+
+/// A click on a qualifier shorter than this is a tap, which latches it for
+/// the next keystroke; two taps inside the double window lock it down.
+const TAP: Duration = Duration::from_millis(250);
+const DOUBLE_TAP: Duration = Duration::from_millis(500);
+
+const RAWKEY_CAPS_LOCK: u8 = 0x62;
+const RAWKEY_CTRL: u8 = 0x63;
+const RAWKEY_LEFT_AMIGA: u8 = 0x66;
+const RAWKEY_RIGHT_AMIGA: u8 = 0x67;
+
+/// The seven latching qualifiers, in the order their state is held. Caps
+/// Lock is deliberately not among them: the MCU owns that latch (see
+/// `chipset::keyboard::Keyboard::key_transition`), where the press toggles
+/// the lamp and sends the down code on lock or the up code on unlock, and
+/// the release sends nothing at all.
+const MODIFIERS: [u8; 7] = [
+    RAWKEY_CTRL,
+    0x60, // left shift
+    0x61, // right shift
+    0x64, // left alt
+    0x65, // right alt
+    RAWKEY_LEFT_AMIGA,
+    RAWKEY_RIGHT_AMIGA,
+];
+
+const fn rgba(r: u8, g: u8, b: u8) -> u32 {
+    u32::from_le_bytes([r, g, b, 0xFF])
+}
+
+/// The same colour lifted towards the light (positive) or turned away from
+/// it (negative), which is all the moulding on a cap amounts to.
+fn shade(colour: u32, by: f32) -> u32 {
+    let [r, g, b, a] = colour.to_le_bytes();
+    let step = |c: u8| (f32::from(c) + by).clamp(0.0, 255.0) as u8;
+    u32::from_le_bytes([step(r), step(g), step(b), a])
+}
+
+/// `from` at 0, `to` at 1.
+fn mix(from: u32, to: u32, t: f32) -> u32 {
+    let t = t.clamp(0.0, 1.0);
+    let (a, b) = (from.to_le_bytes(), to.to_le_bytes());
+    let lerp = |i: usize| (f32::from(a[i]) + (f32::from(b[i]) - f32::from(a[i])) * t) as u8;
+    u32::from_le_bytes([lerp(0), lerp(1), lerp(2), a[3]])
+}
+
+// --- the layout ----------------------------------------------------------
+
+/// What is printed on a cap. Most legends are text in the 8x8 font; the
+/// rest are drawn, because they are outside its ASCII range (the pound) or
+/// are marks rather than characters (the cursor arrows, the Amiga key's
+/// leaning A).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Legend {
+    None,
+    Text(&'static str),
+    Pound,
+    Arrow(Arrow),
+    /// The Amiga key's mark: outlined on the left key, filled on the
+    /// right, as the case prints them.
+    Amiga {
+        hollow: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Arrow {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+/// What a cap does beyond sending its rawkey.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Plain,
+    /// A latching qualifier (see [`KbdPanelState::press`]).
+    Modifier,
+    /// Caps Lock, whose latch and lamp belong to the MCU.
+    Caps,
+}
+
+/// One keycap. A row lays out left to right and x accumulates, so a cap
+/// carries only what differs from the default 1u key: `gap_q` is the gap
+/// before it, `w_q` its width, both in quarter-units.
+#[derive(Debug, Clone, Copy)]
+struct KeySpec {
+    gap_q: u8,
+    w_q: u8,
+    raw: u8,
+    main: Legend,
+    shift: Legend,
+    kind: Kind,
+    /// The ISO Return's stem: how far right of the arm's left edge it
+    /// starts, and how wide it is, in quarter-units.
+    stem: Option<(u8, u8)>,
+}
+
+impl KeySpec {
+    const fn new(raw: u8, main: &'static str) -> Self {
+        Self {
+            gap_q: 0,
+            w_q: 4,
+            raw,
+            main: Legend::Text(main),
+            shift: Legend::None,
+            kind: Kind::Plain,
+            stem: None,
+        }
+    }
+
+    /// A cap with nothing printed on it: the space bar.
+    const fn blank(raw: u8) -> Self {
+        Self::glyph(raw, Legend::None)
+    }
+
+    const fn glyph(raw: u8, main: Legend) -> Self {
+        let mut spec = Self::new(raw, "");
+        spec.main = main;
+        spec
+    }
+
+    const fn shifted(mut self, shift: &'static str) -> Self {
+        self.shift = Legend::Text(shift);
+        self
+    }
+
+    const fn shift_glyph(mut self, shift: Legend) -> Self {
+        self.shift = shift;
+        self
+    }
+
+    const fn width(mut self, w_q: u8) -> Self {
+        self.w_q = w_q;
+        self
+    }
+
+    const fn gap(mut self, gap_q: u8) -> Self {
+        self.gap_q = gap_q;
+        self
+    }
+
+    const fn modifier(mut self) -> Self {
+        self.kind = Kind::Modifier;
+        self
+    }
+
+    const fn caps(mut self) -> Self {
+        self.kind = Kind::Caps;
+        self
+    }
+
+    const fn stem(mut self, dx_q: u8, w_q: u8) -> Self {
+        self.stem = Some((dx_q, w_q));
+        self
+    }
+}
+
+struct KeyRow {
+    /// The row's top edge, in quarter-units from the top of the grid.
+    y_q: u8,
+    keys: &'static [KeySpec],
+}
+
+/// The A600's 78 keys.
+///
+/// Rows 2, 3 and 4 stop short of 16.5u. That is not a missing key: it is
+/// the notch the inverted-T cursor cluster sits in, and the two chips at
+/// the end of this file live in it.
+static ROWS: &[KeyRow] = &[
+    KeyRow {
+        y_q: 0,
+        keys: &[
+            KeySpec::new(0x45, "Esc").width(5),
+            KeySpec::new(0x50, "F1").width(5).gap(2),
+            KeySpec::new(0x51, "F2").width(5),
+            KeySpec::new(0x52, "F3").width(5),
+            KeySpec::new(0x53, "F4").width(5),
+            KeySpec::new(0x54, "F5").width(5),
+            KeySpec::new(0x55, "F6").width(5).gap(2),
+            KeySpec::new(0x56, "F7").width(5),
+            KeySpec::new(0x57, "F8").width(5),
+            KeySpec::new(0x58, "F9").width(5),
+            KeySpec::new(0x59, "F10").width(5),
+            KeySpec::new(0x5F, "Help").width(5).gap(2),
+        ],
+    },
+    KeyRow {
+        y_q: 6,
+        keys: &[
+            KeySpec::new(0x00, "`").shifted("~").width(6),
+            KeySpec::new(0x01, "1").shifted("!"),
+            KeySpec::new(0x02, "2").shifted("\""),
+            // The UK cap prints 3 and a pound; the US one 3 and a hash.
+            KeySpec::new(0x03, "3").shift_glyph(Legend::Pound),
+            KeySpec::new(0x04, "4").shifted("$"),
+            KeySpec::new(0x05, "5").shifted("%"),
+            KeySpec::new(0x06, "6").shifted("^"),
+            KeySpec::new(0x07, "7").shifted("&"),
+            KeySpec::new(0x08, "8").shifted("*"),
+            KeySpec::new(0x09, "9").shifted("("),
+            KeySpec::new(0x0A, "0").shifted(")"),
+            KeySpec::new(0x0B, "-").shifted("_"),
+            KeySpec::new(0x0C, "=").shifted("+"),
+            KeySpec::new(0x0D, "\\").shifted("|"),
+            KeySpec::new(0x41, "Bksp"),
+            KeySpec::new(0x46, "Del"),
+        ],
+    },
+    KeyRow {
+        y_q: 10,
+        keys: &[
+            KeySpec::new(0x42, "Tab").width(8),
+            KeySpec::new(0x10, "Q"),
+            KeySpec::new(0x11, "W"),
+            KeySpec::new(0x12, "E"),
+            KeySpec::new(0x13, "R"),
+            KeySpec::new(0x14, "T"),
+            KeySpec::new(0x15, "Y"),
+            KeySpec::new(0x16, "U"),
+            KeySpec::new(0x17, "I"),
+            KeySpec::new(0x18, "O"),
+            KeySpec::new(0x19, "P"),
+            KeySpec::new(0x1A, "[").shifted("{"),
+            KeySpec::new(0x1B, "]").shifted("}"),
+            // The ISO reverse-L Return. This is the wide top arm; the stem
+            // hangs off its bottom edge, inset from the left so the two
+            // right edges line up and the notch is bottom-left. Both end at
+            // 15.5u, where the cursor cluster's notch begins -- the arm
+            // reaches 0.25u further left than the stem, which is the shape
+            // of the key, not a gap before it.
+            KeySpec::new(0x44, "Ret").width(6).stem(1, 5),
+        ],
+    },
+    KeyRow {
+        y_q: 14,
+        keys: &[
+            KeySpec::new(RAWKEY_CTRL, "Ctrl").width(5).modifier(),
+            KeySpec::new(RAWKEY_CAPS_LOCK, "Caps").caps(),
+            KeySpec::new(0x20, "A"),
+            KeySpec::new(0x21, "S"),
+            KeySpec::new(0x22, "D"),
+            KeySpec::new(0x23, "F"),
+            KeySpec::new(0x24, "G"),
+            KeySpec::new(0x25, "H"),
+            KeySpec::new(0x26, "J"),
+            KeySpec::new(0x27, "K"),
+            KeySpec::new(0x28, "L"),
+            KeySpec::new(0x29, ";").shifted(":"),
+            KeySpec::new(0x2A, "'").shifted("@"),
+            KeySpec::new(0x2B, "#").shifted("~"),
+        ],
+    },
+    KeyRow {
+        y_q: 18,
+        keys: &[
+            KeySpec::new(0x60, "Shift").width(7).modifier(),
+            KeySpec::new(0x30, "\\").shifted("|"),
+            KeySpec::new(0x31, "Z"),
+            KeySpec::new(0x32, "X"),
+            KeySpec::new(0x33, "C"),
+            KeySpec::new(0x34, "V"),
+            KeySpec::new(0x35, "B"),
+            KeySpec::new(0x36, "N"),
+            KeySpec::new(0x37, "M"),
+            KeySpec::new(0x38, ",").shifted("<"),
+            KeySpec::new(0x39, ".").shifted(">"),
+            KeySpec::new(0x3A, "/").shifted("?"),
+            KeySpec::new(0x61, "Shift").width(7).modifier(),
+            KeySpec::glyph(0x4C, Legend::Arrow(Arrow::Up)),
+        ],
+    },
+    KeyRow {
+        y_q: 22,
+        keys: &[
+            KeySpec::new(0x64, "Alt").width(5).gap(2).modifier(),
+            KeySpec::glyph(0x66, Legend::Amiga { hollow: true })
+                .width(5)
+                .modifier(),
+            KeySpec::blank(0x40).width(32),
+            KeySpec::glyph(0x67, Legend::Amiga { hollow: false })
+                .width(5)
+                .modifier(),
+            KeySpec::new(0x65, "Alt").width(5).modifier(),
+            KeySpec::glyph(0x4F, Legend::Arrow(Arrow::Left)),
+            KeySpec::glyph(0x4D, Legend::Arrow(Arrow::Down)),
+            KeySpec::glyph(0x4E, Legend::Arrow(Arrow::Right)),
+        ],
+    },
+];
+
+/// The only caps a US A600 prints differently. The shell is the same ISO
+/// 78-key case either way, which is why a US machine ships blank keycaps
+/// in the $2B and $30 positions rather than omitting the switches.
+static US_LEGENDS: &[(u8, Legend, Legend)] = &[
+    (0x02, Legend::Text("2"), Legend::Text("@")),
+    (0x03, Legend::Text("3"), Legend::Text("#")),
+    (0x2A, Legend::Text("'"), Legend::Text("\"")),
+    (0x2B, Legend::None, Legend::None),
+    (0x30, Legend::None, Legend::None),
+];
+
+/// What is printed on `spec`'s cap under the chosen legends.
+fn legends_for(spec: &KeySpec, us: bool) -> (Legend, Legend) {
+    if us {
+        for (raw, main, shift) in US_LEGENDS {
+            if *raw == spec.raw {
+                return (*main, *shift);
+            }
+        }
+    }
+    (spec.main, spec.shift)
+}
+
+// --- geometry ------------------------------------------------------------
+
+/// The strip's rect when it is actually up, and `None` when it is not.
+///
+/// Hit-testing must go through this: with the keyboard hidden its strip is
+/// the status bar's, and testing it anyway swallows every click on the bar.
+pub fn shown_panel_rect(top: usize) -> Option<Rect> {
+    crate::video::keyboard_panel_shown().then(|| panel_rect(top))
+}
+
+/// The strip's rect within the presentation, `top` being the first row
+/// below the display (and below the MT-32's panel, when that is up too).
+pub fn panel_rect(top: usize) -> Rect {
+    Rect {
+        x: 0,
+        y: top,
+        w: FB_WIDTH,
+        h: KBD_PANEL_HEIGHT,
+    }
+}
+
+/// The grid's top-left corner within the strip.
+fn grid_origin(panel: Rect) -> (usize, usize) {
+    (panel.x + PAD_X, panel.y + PAD_Y)
+}
+
+/// The cell a key occupies, from its position and width in quarter-units.
+///
+/// Both edges are converted from the grid position rather than the width
+/// being converted on its own, so neighbouring cells tile exactly: no
+/// rounding can open a seam or overlap one cap onto the next.
+fn cell_rect(panel: Rect, x_q: usize, y_q: usize, w_q: usize) -> Rect {
+    let (ox, oy) = grid_origin(panel);
+    let (x0, x1) = (ox + u_px(x_q), ox + u_px(x_q + w_q));
+    let (y0, y1) = (oy + u_px(y_q), oy + u_px(y_q + 4));
+    Rect {
+        x: x0,
+        y: y0,
+        w: x1 - x0,
+        h: y1 - y0,
+    }
+}
+
+/// The stem of an ISO Return, when the key has one: the cell hanging off
+/// the bottom of its arm.
+fn stem_cell_rect(panel: Rect, x_q: usize, y_q: usize, spec: &KeySpec) -> Option<Rect> {
+    let (dx_q, w_q) = spec.stem?;
+    Some(cell_rect(
+        panel,
+        x_q + usize::from(dx_q),
+        y_q + 4,
+        usize::from(w_q),
+    ))
+}
+
+/// Walk every key, handing each its spec, its grid position in
+/// quarter-units, and the cell it occupies.
+fn each_key(panel: Rect, mut f: impl FnMut(&'static KeySpec, usize, usize, Rect)) {
+    for row in ROWS {
+        let mut x_q = 0usize;
+        for spec in row.keys {
+            x_q += usize::from(spec.gap_q);
+            let y_q = usize::from(row.y_q);
+            f(
+                spec,
+                x_q,
+                y_q,
+                cell_rect(panel, x_q, y_q, usize::from(spec.w_q)),
+            );
+            x_q += usize::from(spec.w_q);
+        }
+    }
+}
+
+/// A chip in the cursor notch. Both are one unit wide less a hair, and
+/// 0.8u tall, sitting in the only part of an A600's outline with no keys
+/// in it.
+fn chip_rect(panel: Rect, tenths_y: usize) -> Rect {
+    let (ox, oy) = grid_origin(panel);
+    Rect {
+        x: ox + u_px(62),
+        y: oy + tenths_y * KEY_UNIT / 10,
+        w: KEY_UNIT - 2 * CAP_INSET,
+        h: 8 * KEY_UNIT / 10,
+    }
+}
+
+/// The UK/US legend switch. It rides on the keyboard rather than in the
+/// menu because it is a property of the caps, and because the notch is
+/// there.
+fn legend_chip_rect(panel: Rect) -> Rect {
+    chip_rect(panel, 36)
+}
+
+/// The chip that puts the keyboard away, in the slot above the legend
+/// switch -- deliberately the one farthest from the cursor keys, so a
+/// missed arrow in a game cannot fold the keyboard mid-play.
+fn close_chip_rect(panel: Rect) -> Rect {
+    chip_rect(panel, 26)
+}
+
+/// Something on the strip the pointer can be over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KbdControl {
+    /// A keycap, by its Amiga rawkey.
+    Key(u8),
+    /// The UK/US legend switch.
+    Legends,
+    /// The chip that hides the keyboard.
+    Close,
+}
+
+/// Which control the pointer is over, if any.
+pub fn control_at(panel: Rect, pos: (i32, i32)) -> Option<KbdControl> {
+    if legend_chip_rect(panel).contains(pos) {
+        return Some(KbdControl::Legends);
+    }
+    if close_chip_rect(panel).contains(pos) {
+        return Some(KbdControl::Close);
+    }
+    let mut found = None;
+    each_key(panel, |spec, x_q, y_q, cell| {
+        if found.is_some() {
+            return;
+        }
+        // The whole L of an ISO Return is one key, arm and stem alike.
+        let hit = cell.contains(pos)
+            || stem_cell_rect(panel, x_q, y_q, spec).is_some_and(|s| s.contains(pos));
+        if hit {
+            found = Some(KbdControl::Key(spec.raw));
+        }
+    });
+    found
+}
+
+/// Whether moving from `previous` to `current` changed which cap is lit
+/// under the pointer, and so needs the strip drawn again.
+pub fn hover_changed(
+    panel: Rect,
+    previous: Option<(i32, i32)>,
+    current: Option<(i32, i32)>,
+) -> bool {
+    previous.and_then(|pos| control_at(panel, pos))
+        != current.and_then(|pos| control_at(panel, pos))
+}
+
+// --- state ---------------------------------------------------------------
+
+/// How far a qualifier is latched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Latch {
+    /// Not latched: it is down only while the mouse holds it.
+    #[default]
+    None,
+    /// Armed for exactly one keystroke, and released with that key.
+    OneShot,
+    /// Held until it is clicked again.
+    Locked,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ModState {
+    /// The machine has been told this qualifier is down.
+    down: bool,
+    latch: Latch,
+    /// The mouse button is on this cap right now, as opposed to the cap
+    /// being latched down with nothing on it.
+    held: bool,
+    down_at: Option<Instant>,
+    /// Another key was pressed while this qualifier was down, which is
+    /// what tells a real chord apart from a bare tap that should latch.
+    used_while_down: bool,
+    last_tap_at: Option<Instant>,
+}
+
+/// What a click on the strip amounts to.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct KbdOutcome {
+    /// Rawkey transitions for the keyboard MCU, in order.
+    pub keys: Vec<(u8, bool)>,
+    /// The close chip was clicked: put the strip away.
+    pub close: bool,
+}
+
+impl KbdOutcome {
+    fn send(&mut self, rawkey: u8, pressed: bool) {
+        self.keys.push((rawkey, pressed));
+    }
+}
+
+/// What the strip is holding down: one cap under the mouse (it is a mouse,
+/// so one at a time) plus whatever qualifiers are latched, and which
+/// legends the caps are wearing.
+#[derive(Debug, Clone, Default)]
+pub struct KbdPanelState {
+    /// The cap the mouse button is holding, if any.
+    pressed: Option<u8>,
+    mods: [ModState; MODIFIERS.len()],
+    us_legends: bool,
+}
+
+fn spec_for(rawkey: u8) -> Option<&'static KeySpec> {
+    ROWS.iter()
+        .flat_map(|row| row.keys)
+        .find(|spec| spec.raw == rawkey)
+}
+
+fn modifier_index(rawkey: u8) -> Option<usize> {
+    MODIFIERS.iter().position(|m| *m == rawkey)
+}
+
+impl KbdPanelState {
+    /// Whether a cap is being held by the mouse.
+    pub fn holding_key(&self) -> bool {
+        self.pressed.is_some()
+    }
+
+    /// The mouse went down on `control`.
+    pub fn press(&mut self, control: KbdControl, now: Instant) -> KbdOutcome {
+        let mut out = KbdOutcome::default();
+        match control {
+            KbdControl::Legends => self.us_legends = !self.us_legends,
+            KbdControl::Close => {
+                // Acting on the press, like every key here: the strip is
+                // gone before the button lifts, so anything it was holding
+                // has to be handed back now.
+                out = self.release_all();
+                out.close = true;
+            }
+            KbdControl::Key(rawkey) => {
+                let Some(spec) = spec_for(rawkey) else {
+                    return out;
+                };
+                self.pressed = Some(rawkey);
+                match spec.kind {
+                    Kind::Modifier => {
+                        let idx = modifier_index(rawkey).expect("qualifier is in MODIFIERS");
+                        let m = &mut self.mods[idx];
+                        m.held = true;
+                        m.down_at = Some(now);
+                        m.used_while_down = false;
+                        if !m.down {
+                            m.down = true;
+                            out.send(rawkey, true);
+                        }
+                    }
+                    // Caps Lock goes the ordinary way: the MCU owns its
+                    // latch (a press flips the lamp and emits the down
+                    // code on lock or the up code on unlock, and the
+                    // release is discarded), so the strip sends the pair a
+                    // real key sends and mirrors nothing.
+                    Kind::Plain | Kind::Caps => {
+                        out.send(rawkey, true);
+                        // Any qualifier now held is being used, which is
+                        // what tells its own release apart from a bare tap.
+                        for m in &mut self.mods {
+                            if m.down {
+                                m.used_while_down = true;
+                            }
+                        }
+                    }
+                }
+                // Checked on the qualifier path as well as the ordinary
+                // one: Ctrl+Amiga+Amiga is made of nothing but qualifiers,
+                // so the press that completes it is always a qualifier's.
+                if self.reset_chord_held() {
+                    out.keys.extend(self.release_all().keys);
+                }
+            }
+        }
+        out
+    }
+
+    /// The mouse button lifted, wherever the pointer had got to. One
+    /// button holds one cap, so this ends whatever the last press began.
+    pub fn release(&mut self, now: Instant) -> KbdOutcome {
+        let mut out = KbdOutcome::default();
+        let Some(rawkey) = self.pressed.take() else {
+            return out;
+        };
+        let Some(spec) = spec_for(rawkey) else {
+            return out;
+        };
+        match spec.kind {
+            Kind::Modifier => {
+                let idx = modifier_index(rawkey).expect("qualifier is in MODIFIERS");
+                self.release_modifier(idx, now, &mut out);
+            }
+            Kind::Plain | Kind::Caps => {
+                out.send(rawkey, false);
+                // One-shots clear on the release, not the press, so the
+                // guest sees the qualifier held across the whole keystroke.
+                for (idx, m) in self.mods.iter_mut().enumerate() {
+                    if m.latch == Latch::OneShot && !m.held {
+                        m.down = false;
+                        m.latch = Latch::None;
+                        out.send(MODIFIERS[idx], false);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// A qualifier clicked on its own stays down for the next keystroke;
+    /// clicked twice it locks until clicked again; held down while another
+    /// key is pressed it behaves like the real key, which is what a chord
+    /// such as Ctrl+Amiga+Amiga wants from a one-button mouse.
+    fn release_modifier(&mut self, idx: usize, now: Instant, out: &mut KbdOutcome) {
+        let rawkey = MODIFIERS[idx];
+        let m = &mut self.mods[idx];
+        m.held = false;
+        let tapped = m
+            .down_at
+            .is_some_and(|at| now.saturating_duration_since(at) < TAP)
+            && !m.used_while_down;
+        let double = m
+            .last_tap_at
+            .is_some_and(|at| now.saturating_duration_since(at) < DOUBLE_TAP);
+        let mut clear = false;
+        if !tapped {
+            clear = true; // a real hold, released
+        } else {
+            match m.latch {
+                Latch::Locked => clear = true, // clicking a locked one unlocks it
+                Latch::OneShot if double => m.latch = Latch::Locked,
+                Latch::OneShot => clear = true, // a second lone click disarms it
+                Latch::None => m.latch = Latch::OneShot,
+            }
+        }
+        if clear {
+            m.down = false;
+            m.latch = Latch::None;
+            out.send(rawkey, false);
+        }
+        m.last_tap_at = Some(now);
+    }
+
+    /// The MCU has just latched Ctrl+Amiga+Amiga and is starting the reset
+    /// flow; a human would now let go. Leaving the qualifiers latched
+    /// would have `begin_power_up` report them still held (`set_held` runs
+    /// before the `in_reset_flow` early return), and the next keystroke
+    /// would reset the machine all over again.
+    fn reset_chord_held(&self) -> bool {
+        [RAWKEY_CTRL, RAWKEY_LEFT_AMIGA, RAWKEY_RIGHT_AMIGA]
+            .into_iter()
+            .all(|raw| modifier_index(raw).is_some_and(|idx| self.mods[idx].down))
+    }
+
+    /// Let go of everything the strip is holding: the cap under the mouse
+    /// and every latched qualifier. Used by the reset chord, by hiding the
+    /// keyboard, and when the machine those keys were pressed on is
+    /// replaced.
+    pub fn release_all(&mut self) -> KbdOutcome {
+        let mut out = KbdOutcome::default();
+        if let Some(rawkey) = self.pressed.take() {
+            // A qualifier's release comes from the loop below instead,
+            // where the latch is cleared with it.
+            if spec_for(rawkey).is_some_and(|s| s.kind != Kind::Modifier) {
+                out.send(rawkey, false);
+            }
+        }
+        for (idx, m) in self.mods.iter_mut().enumerate() {
+            if m.down {
+                out.send(MODIFIERS[idx], false);
+            }
+            *m = ModState::default();
+        }
+        out
+    }
+
+    /// What the strip looks like right now. `caps_lit` is the MCU's own
+    /// lamp, polled rather than mirrored from clicks: a save-state load
+    /// changes it with no key pressed.
+    pub fn view(&self, caps_lit: bool, hover: Option<KbdControl>) -> KbdPanelView {
+        let mut view = KbdPanelView {
+            caps_lit,
+            us_legends: self.us_legends,
+            hover,
+            ..KbdPanelView::default()
+        };
+        if let Some(rawkey) = self.pressed {
+            view.down[usize::from(rawkey & 0x7F)] = true;
+        }
+        for (idx, m) in self.mods.iter().enumerate() {
+            let raw = usize::from(MODIFIERS[idx]);
+            view.latch[raw] = m.latch;
+            // Drawn down while it is genuinely down rather than latched:
+            // a latch has its own mark.
+            if m.down && m.latch == Latch::None {
+                view.down[raw] = true;
+            }
+        }
+        view
+    }
+}
+
+/// What the strip needs to draw itself.
+#[derive(Debug, Clone)]
+pub struct KbdPanelView {
+    /// Caps drawn held down, by rawkey.
+    pub down: [bool; 0x80],
+    /// How far each qualifier is latched, by rawkey.
+    pub latch: [Latch; 0x80],
+    /// The MCU's Caps Lock lamp.
+    pub caps_lit: bool,
+    /// Whether the caps wear US legends instead of UK.
+    pub us_legends: bool,
+    pub hover: Option<KbdControl>,
+}
+
+impl Default for KbdPanelView {
+    fn default() -> Self {
+        Self {
+            down: [false; 0x80],
+            latch: [Latch::None; 0x80],
+            caps_lit: false,
+            us_legends: false,
+            hover: None,
+        }
+    }
+}
+
+// --- drawing -------------------------------------------------------------
+
+/// Draw the keyboard.
+pub fn draw(frame: &mut [u8], view: &KbdPanelView, top: usize, scale: usize) {
+    let panel = panel_rect(top);
+    fill_rect(frame, scaled(panel, scale), PANEL_FACE, scale);
+    draw_rect_bevel(
+        frame,
+        scaled(panel, scale),
+        PANEL_EDGE_LIGHT,
+        PANEL_EDGE_DARK,
+        scale,
+    );
+    each_key(panel, |spec, x_q, y_q, cell| {
+        draw_key(
+            frame,
+            view,
+            spec,
+            cell,
+            stem_cell_rect(panel, x_q, y_q, spec),
+            scale,
+        );
+    });
+    draw_legend_chip(frame, panel, view, scale);
+    draw_close_chip(frame, panel, view, scale);
+}
+
+/// What colour a cap is, before the pointer lifts it.
+fn cap_fill(view: &KbdPanelView, spec: &KeySpec) -> u32 {
+    let raw = usize::from(spec.raw & 0x7F);
+    if spec.kind == Kind::Caps && view.caps_lit {
+        return CAP_LOCKED;
+    }
+    if view.down[raw] {
+        return CAP_DOWN;
+    }
+    if view.latch[raw] == Latch::Locked {
+        return CAP_LOCKED;
+    }
+    if spec.kind == Kind::Modifier {
+        CAP_MOD
+    } else {
+        CAP_IDLE
+    }
+}
+
+fn draw_key(
+    frame: &mut [u8],
+    view: &KbdPanelView,
+    spec: &KeySpec,
+    cell: Rect,
+    stem_cell: Option<Rect>,
+    scale: usize,
+) {
+    let raw = usize::from(spec.raw & 0x7F);
+    let hovered = view.hover == Some(KbdControl::Key(spec.raw));
+    let mut fill = cap_fill(view, spec);
+    if hovered {
+        fill = shade(fill, HOVER_LIFT);
+    }
+    let pressed = view.down[raw];
+    let cap = inset(cell, CAP_INSET);
+    draw_cap(frame, cap, fill, pressed, scale);
+    if let Some(stem_cell) = stem_cell {
+        // The stem starts one pixel inside the arm's bottom edge, so the
+        // two boxes cannot leave a hairline between them, and the seam is
+        // then painted out: what is left is one L-shaped moulding with the
+        // arm's underside bevelled only where it actually overhangs.
+        let stem_top = cap.y + cap.h - 1;
+        let stem = Rect {
+            x: stem_cell.x + CAP_INSET,
+            y: stem_top,
+            w: stem_cell.w - 2 * CAP_INSET,
+            h: (stem_cell.y + stem_cell.h).saturating_sub(CAP_INSET + stem_top),
+        };
+        draw_cap(frame, stem, fill, pressed, scale);
+        fill_rect(
+            frame,
+            scaled(
+                Rect {
+                    x: stem.x + 1,
+                    y: cap.y + cap.h - 2,
+                    w: stem.w.saturating_sub(2),
+                    h: 3,
+                },
+                scale,
+            ),
+            fill,
+            scale,
+        );
+    }
+    // A one-shot qualifier gets a ring rather than a fill: armed for one
+    // keystroke, not held down.
+    if view.latch[raw] == Latch::OneShot {
+        draw_rect_bevel(
+            frame,
+            scaled(inset(cap, 1), scale),
+            CAP_LOCKED,
+            CAP_LOCKED,
+            scale,
+        );
+    }
+    let (main, shift) = legends_for(spec, view.us_legends);
+    draw_cap_legends(frame, cap, main, shift, scale);
+    if spec.kind == Kind::Caps {
+        draw_caps_led(frame, cap, fill, view.caps_lit, scale);
+    }
+}
+
+/// A keycap: a flat moulding with the light on its top and left, turned
+/// over while it is held down.
+fn draw_cap(frame: &mut [u8], rect: Rect, fill: u32, pressed: bool, scale: usize) {
+    let (near, far) = if pressed {
+        (CAP_BEVEL_DARK, CAP_BEVEL_LIGHT)
+    } else {
+        (CAP_BEVEL_LIGHT, CAP_BEVEL_DARK)
+    };
+    let rect = scaled(rect, scale);
+    fill_rect(frame, rect, fill, scale);
+    draw_rect_bevel(frame, rect, shade(fill, near), shade(fill, far), scale);
+}
+
+/// The keycap lamp, in the corner of the cap the way an A600 sets it into
+/// the moulding. Dark it is a hole in the cap rather than a colour of its
+/// own, which is what an unlit LED under tinted plastic looks like.
+fn draw_caps_led(frame: &mut [u8], cap: Rect, fill: u32, lit: bool, scale: usize) {
+    let size = (KEY_UNIT / 7).max(3);
+    let rect = Rect {
+        x: cap.x + cap.w.saturating_sub(size + 4),
+        y: cap.y + 4,
+        w: size,
+        h: size,
+    };
+    let colour = if lit {
+        CAPS_LED_ON
+    } else {
+        mix(fill, rgba(0, 0, 0), 0.25)
+    };
+    fill_rect(frame, scaled(rect, scale), colour, scale);
+}
+
+/// What is printed on a cap: the main legend, with the shifted one above
+/// it, smaller and dimmer, as the cap prints them.
+fn draw_cap_legends(frame: &mut [u8], cap: Rect, main: Legend, shift: Legend, scale: usize) {
+    let main_px = legend_px(main, cap.w);
+    let main_h = font::GLYPH_H * main_px;
+    if shift == Legend::None {
+        let y = cap.y + cap.h.saturating_sub(main_h) / 2;
+        draw_legend(frame, cap, y, main, main_px, CAP_INK, scale);
+        return;
+    }
+    const SHIFT_PX: usize = 1;
+    const LINE_GAP: usize = 2;
+    let shift_h = font::GLYPH_H * SHIFT_PX;
+    let block = shift_h + LINE_GAP + main_h;
+    let top = cap.y + cap.h.saturating_sub(block) / 2;
+    draw_legend(
+        frame,
+        cap,
+        top,
+        shift,
+        SHIFT_PX,
+        mix(CAP_INK, CAP_IDLE, SHIFT_DIM),
+        scale,
+    );
+    draw_legend(
+        frame,
+        cap,
+        top + shift_h + LINE_GAP,
+        main,
+        main_px,
+        CAP_INK,
+        scale,
+    );
+}
+
+/// How large a legend is printed: as large as the cap takes, which puts
+/// the character legends at double size and the word legends -- Ctrl,
+/// Shift, Bksp -- at the size a real cap prints them, small.
+fn legend_px(legend: Legend, cap_w: usize) -> usize {
+    match legend {
+        Legend::Text(s) if font::text_width(s, 2) > cap_w => 1,
+        // The Amiga mark is drawn half again as large as a letter: the
+        // left key's is an outline, and an outline of a two-pixel stroke
+        // has nothing left inside it.
+        Legend::Amiga { .. } => 3,
+        _ => 2,
+    }
+}
+
+fn legend_width(legend: Legend, px: usize) -> usize {
+    match legend {
+        Legend::None => 0,
+        Legend::Text(s) => font::text_width(s, px),
+        Legend::Pound | Legend::Arrow(_) => font::GLYPH_W * px,
+        Legend::Amiga { .. } => amiga_width(px),
+    }
+}
+
+/// One legend line, centred on the cap.
+fn draw_legend(
+    frame: &mut [u8],
+    cap: Rect,
+    y: usize,
+    legend: Legend,
+    px: usize,
+    ink: u32,
+    scale: usize,
+) {
+    let x = cap.x + cap.w.saturating_sub(legend_width(legend, px)) / 2;
+    match legend {
+        Legend::None => {}
+        Legend::Text(s) => {
+            font::draw_text(
+                frame,
+                texture_width(scale),
+                texture_height(scale),
+                x * scale,
+                y * scale,
+                s,
+                ink,
+                px * scale,
+            );
+        }
+        Legend::Pound => blit_glyph(frame, x, y, &POUND, px, ink, scale),
+        Legend::Arrow(dir) => blit_glyph(frame, x, y, arrow_glyph(dir), px, ink, scale),
+        Legend::Amiga { hollow } => draw_amiga_mark(frame, x, y, px, hollow, ink, scale),
+    }
+}
+
+/// The pound sign, which the 8x8 ASCII font has no cell for.
+static POUND: [u8; 8] = [0x1C, 0x26, 0x02, 0x0F, 0x02, 0x02, 0x3F, 0x00];
+
+/// The cursor marks. Bit 0 of a row is its leftmost pixel, as in the font.
+static ARROW_UP: [u8; 8] = [0x18, 0x3C, 0x7E, 0xFF, 0x18, 0x18, 0x18, 0x00];
+static ARROW_DOWN: [u8; 8] = [0x18, 0x18, 0x18, 0xFF, 0x7E, 0x3C, 0x18, 0x00];
+static ARROW_LEFT: [u8; 8] = [0x08, 0x0C, 0xFE, 0xFF, 0xFE, 0x0C, 0x08, 0x00];
+static ARROW_RIGHT: [u8; 8] = [0x10, 0x30, 0x7F, 0xFF, 0x7F, 0x30, 0x10, 0x00];
+
+fn arrow_glyph(dir: Arrow) -> &'static [u8; 8] {
+    match dir {
+        Arrow::Up => &ARROW_UP,
+        Arrow::Down => &ARROW_DOWN,
+        Arrow::Left => &ARROW_LEFT,
+        Arrow::Right => &ARROW_RIGHT,
+    }
+}
+
+/// Blit an 8x8 mark at `px` canvas pixels per mark pixel, in the font's
+/// own bit order.
+fn blit_glyph(
+    frame: &mut [u8],
+    x: usize,
+    y: usize,
+    rows: &[u8; 8],
+    px: usize,
+    ink: u32,
+    scale: usize,
+) {
+    for (row_idx, row) in rows.iter().enumerate() {
+        for col in 0..8 {
+            if row & (1 << col) == 0 {
+                continue;
+            }
+            fill_rect(
+                frame,
+                scaled(
+                    Rect {
+                        x: x + col * px,
+                        y: y + row_idx * px,
+                        w: px,
+                        h: px,
+                    },
+                    scale,
+                ),
+                ink,
+                scale,
+            );
+        }
+    }
+}
+
+/// The Amiga key's mark: an A leaning to the right, drawn rather than
+/// typed because the font has no italic and shearing an upright A a pixel
+/// at a time breaks its strokes into steps. Bit 0 of a row is its
+/// leftmost pixel, as in the font.
+static AMIGA_A: [u8; 8] = [0x30, 0x30, 0x78, 0xD8, 0xFC, 0xCC, 0x66, 0x00];
+
+fn amiga_width(px: usize) -> usize {
+    font::GLYPH_W * px
+}
+
+/// The mark, filled on the right key and outlined on the left, as the
+/// case prints the pair.
+///
+/// The outline is taken after the letter is scaled up, so it is a real
+/// one-pixel edge around a two-pixel stroke rather than the whole stroke
+/// (every pixel of which has an empty neighbour at mark resolution).
+fn draw_amiga_mark(
+    frame: &mut [u8],
+    x: usize,
+    y: usize,
+    px: usize,
+    hollow: bool,
+    ink: u32,
+    scale: usize,
+) {
+    const MAX_W: usize = 8 * 3;
+    const MAX_H: usize = 8 * 3;
+    let (w, h) = (amiga_width(px), font::GLYPH_H * px);
+    if w > MAX_W || h > MAX_H {
+        return;
+    }
+    let mut mask = [[false; MAX_W]; MAX_H];
+    for (row_idx, row) in AMIGA_A.iter().enumerate() {
+        for col in 0..font::GLYPH_W {
+            if row & (1 << col) == 0 {
+                continue;
+            }
+            for dy in 0..px {
+                for dx in 0..px {
+                    mask[row_idx * px + dy][col * px + dx] = true;
+                }
+            }
+        }
+    }
+    for (row, cells) in mask.iter().enumerate().take(h) {
+        for (col, &set) in cells.iter().enumerate().take(w) {
+            if !set {
+                continue;
+            }
+            if hollow {
+                // An inner pixel is one whose four neighbours are all part
+                // of the letter; the rest are its edge.
+                let inner = row > 0
+                    && col > 0
+                    && row + 1 < h
+                    && col + 1 < w
+                    && mask[row - 1][col]
+                    && mask[row + 1][col]
+                    && mask[row][col - 1]
+                    && mask[row][col + 1];
+                if inner {
+                    continue;
+                }
+            }
+            fill_rect(
+                frame,
+                scaled(
+                    Rect {
+                        x: x + col,
+                        y: y + row,
+                        w: 1,
+                        h: 1,
+                    },
+                    scale,
+                ),
+                ink,
+                scale,
+            );
+        }
+    }
+}
+
+/// A notch chip: the same moulding as the status bar's own buttons, so the
+/// two switches on the keyboard read as window furniture rather than as
+/// keys with odd legends.
+fn draw_chip(frame: &mut [u8], rect: Rect, hovered: bool, scale: usize) {
+    let face = if hovered {
+        BUTTON_FACE_HOVER
+    } else {
+        BUTTON_FACE
+    };
+    let scaled_rect = scaled(rect, scale);
+    fill_rect(frame, scaled_rect, face, scale);
+    draw_rect_bevel(
+        frame,
+        scaled_rect,
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+}
+
+fn draw_legend_chip(frame: &mut [u8], panel: Rect, view: &KbdPanelView, scale: usize) {
+    let rect = legend_chip_rect(panel);
+    draw_chip(frame, rect, view.hover == Some(KbdControl::Legends), scale);
+    let label = if view.us_legends { "US" } else { "UK" };
+    let px = 2;
+    let w = font::text_width(label, px);
+    font::draw_text(
+        frame,
+        texture_width(scale),
+        texture_height(scale),
+        (rect.x + rect.w.saturating_sub(w) / 2) * scale,
+        (rect.y + rect.h.saturating_sub(font::GLYPH_H * px) / 2) * scale,
+        label,
+        STATUS_TEXT,
+        px * scale,
+    );
+}
+
+/// The close chip's mark: two strokes crossing, drawn rather than typed so
+/// it is the same weight as the arrows on the cursor caps.
+fn draw_close_chip(frame: &mut [u8], panel: Rect, view: &KbdPanelView, scale: usize) {
+    let rect = close_chip_rect(panel);
+    draw_chip(frame, rect, view.hover == Some(KbdControl::Close), scale);
+    let arm = (rect.h / 3).max(3);
+    let x0 = rect.x + rect.w / 2 - arm / 2;
+    let y0 = rect.y + rect.h / 2 - arm / 2;
+    for step in 0..arm {
+        for (dx, dy) in [(step, step), (step, arm - 1 - step)] {
+            fill_rect(
+                frame,
+                scaled(
+                    Rect {
+                        x: x0 + dx,
+                        y: y0 + dy,
+                        w: 2,
+                        h: 2,
+                    },
+                    scale,
+                ),
+                STATUS_TEXT,
+                scale,
+            );
+        }
+    }
+}
+
+fn inset(rect: Rect, by: usize) -> Rect {
+    Rect {
+        x: rect.x + by,
+        y: rect.y + by,
+        w: rect.w.saturating_sub(2 * by),
+        h: rect.h.saturating_sub(2 * by),
+    }
+}
+
+fn scaled(rect: Rect, scale: usize) -> Rect {
+    Rect {
+        x: rect.x * scale,
+        y: rect.y * scale,
+        w: rect.w * scale,
+        h: rect.h * scale,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn panel() -> Rect {
+        panel_rect(500)
+    }
+
+    /// Holds the canvas-height lock while the strip is up, and takes it
+    /// down again however the test ends: the flag is process-global, and a
+    /// failed assertion must not leave it set for everything after it.
+    struct KeyboardUp(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+    impl KeyboardUp {
+        fn shown() -> Self {
+            let guard = crate::video::window::canvas_height_test_lock();
+            crate::video::set_keyboard_panel_shown(true);
+            Self(guard)
+        }
+    }
+
+    impl Drop for KeyboardUp {
+        fn drop(&mut self) {
+            crate::video::set_keyboard_panel_shown(false);
+        }
+    }
+
+    fn centre(rect: Rect) -> (i32, i32) {
+        ((rect.x + rect.w / 2) as i32, (rect.y + rect.h / 2) as i32)
+    }
+
+    /// The cell of the key carrying `rawkey`.
+    fn cell_of(rawkey: u8) -> Rect {
+        let mut found = None;
+        each_key(panel(), |spec, _, _, cell| {
+            if spec.raw == rawkey {
+                found = Some(cell);
+            }
+        });
+        found.unwrap_or_else(|| panic!("no key {rawkey:#04x}"))
+    }
+
+    /// Every row is laid out on the A600's own grid: three of them run the
+    /// full 16.5u, and the other three stop at the cursor notch.
+    #[test]
+    fn the_rows_end_where_an_a600s_do() {
+        // The home row stops at 14.25u because the ISO Return's stem fills
+        // the rest of it; every other short row ends at the notch itself.
+        let expected = [66usize, 66, 62, 57, 62, 66];
+        for (row, want) in ROWS.iter().zip(expected) {
+            let width: usize = row
+                .keys
+                .iter()
+                .map(|k| usize::from(k.gap_q) + usize::from(k.w_q))
+                .sum();
+            assert_eq!(width, want, "row at y={}q", row.y_q);
+        }
+        // The Return's stem takes the home row out to the notch.
+        let stem = ROWS[2]
+            .keys
+            .iter()
+            .find_map(|k| k.stem)
+            .expect("the home row's Return has a stem");
+        assert_eq!(57 + usize::from(stem.1), 62, "the stem ends at the notch");
+    }
+
+    /// No cap escapes the strip, and none overlaps another.
+    #[test]
+    fn every_cap_fits_the_strip_and_nothing_overlaps() {
+        let panel = panel();
+        let mut cells: Vec<(u8, Rect)> = Vec::new();
+        each_key(panel, |spec, x_q, y_q, cell| {
+            cells.push((spec.raw, cell));
+            if let Some(stem) = stem_cell_rect(panel, x_q, y_q, spec) {
+                cells.push((spec.raw, stem));
+            }
+        });
+        assert_eq!(cells.len(), 79, "78 keys plus the Return's stem");
+        for (raw, cell) in &cells {
+            assert!(cell.x >= panel.x, "key {raw:#04x} runs off the left");
+            assert!(
+                cell.x + cell.w <= panel.x + panel.w,
+                "key {raw:#04x} runs off the right"
+            );
+            assert!(cell.y >= panel.y, "key {raw:#04x} runs off the top");
+            assert!(
+                cell.y + cell.h <= panel.y + panel.h,
+                "key {raw:#04x} runs off the bottom"
+            );
+            assert!(cell.w > 0 && cell.h > 0, "key {raw:#04x} has no size");
+        }
+        for (i, (raw_a, a)) in cells.iter().enumerate() {
+            for (raw_b, b) in &cells[i + 1..] {
+                if raw_a == raw_b {
+                    continue; // the arm and stem of one Return
+                }
+                let apart =
+                    a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y;
+                assert!(apart, "{raw_a:#04x} and {raw_b:#04x} overlap");
+            }
+        }
+        // The chips live in the notch, clear of every cap.
+        for chip in [legend_chip_rect(panel), close_chip_rect(panel)] {
+            assert!(chip.y >= panel.y && chip.y + chip.h <= panel.y + panel.h);
+            for (raw, cell) in &cells {
+                let apart = cell.x + cell.w <= chip.x
+                    || chip.x + chip.w <= cell.x
+                    || cell.y + cell.h <= chip.y
+                    || chip.y + chip.h <= cell.y;
+                assert!(apart, "the notch chip overlaps key {raw:#04x}");
+            }
+        }
+    }
+
+    /// The whole L of an ISO Return is one key: a wide arm with a narrower
+    /// stem hanging off it, both ending at the notch.
+    #[test]
+    fn the_return_is_an_iso_reverse_l() {
+        let panel = panel();
+        let mut arm = None;
+        let mut stem = None;
+        each_key(panel, |spec, x_q, y_q, cell| {
+            if spec.raw == 0x44 {
+                arm = Some(cell);
+                stem = stem_cell_rect(panel, x_q, y_q, spec);
+            }
+        });
+        let (arm, stem) = (arm.unwrap(), stem.unwrap());
+        assert_eq!(arm.x + arm.w, stem.x + stem.w, "right edges line up");
+        assert!(arm.x < stem.x, "the arm reaches further left than the stem");
+        assert_eq!(arm.y + arm.h, stem.y, "the stem hangs off the arm");
+        assert!(stem.w < arm.w, "the stem is the narrower box");
+        // Both halves answer as the same key.
+        assert_eq!(control_at(panel, centre(arm)), Some(KbdControl::Key(0x44)));
+        assert_eq!(control_at(panel, centre(stem)), Some(KbdControl::Key(0x44)));
+    }
+
+    /// Clicking a cap finds the key printed on it, the notch chips answer
+    /// for themselves, and the empty parts of the strip answer for nothing.
+    #[test]
+    fn the_pointer_finds_the_key_it_is_over() {
+        let panel = panel();
+        for raw in [0x45, 0x59, 0x40, 0x62, 0x66, 0x4C, 0x2B, 0x00] {
+            assert_eq!(
+                control_at(panel, centre(cell_of(raw))),
+                Some(KbdControl::Key(raw)),
+                "key {raw:#04x}"
+            );
+        }
+        assert_eq!(
+            control_at(panel, centre(legend_chip_rect(panel))),
+            Some(KbdControl::Legends)
+        );
+        assert_eq!(
+            control_at(panel, centre(close_chip_rect(panel))),
+            Some(KbdControl::Close)
+        );
+        // The notch itself, between the two chips and clear of both.
+        let (ox, oy) = grid_origin(panel);
+        let between = ((ox + u_px(63)) as i32, (oy + u_px(14) + 2) as i32);
+        assert_eq!(control_at(panel, between), None, "the notch is empty");
+        // The margin around the grid, and the strip's own corners.
+        assert_eq!(control_at(panel, (1, panel.y as i32 + 1)), None);
+        assert_eq!(
+            control_at(panel, ((FB_WIDTH - 1) as i32, (panel.y + 1) as i32)),
+            None
+        );
+    }
+
+    /// The gap between two caps still belongs to a key, because the whole
+    /// grid cell is live and only the moulding inside it is inset.
+    #[test]
+    fn the_gaps_between_caps_are_still_live() {
+        let panel = panel();
+        let q = cell_of(0x10); // Q, in the middle of a row of 1u keys
+        let seam = ((q.x + q.w) as i32 - 1, centre(q).1);
+        assert_eq!(control_at(panel, seam), Some(KbdControl::Key(0x10)));
+    }
+
+    /// A US machine prints five caps differently and is otherwise the same
+    /// keyboard.
+    #[test]
+    fn the_legend_switch_only_moves_the_caps_a_us_machine_prints() {
+        let hash = spec_for(0x03).unwrap();
+        assert_eq!(legends_for(hash, false).1, Legend::Pound);
+        assert_eq!(legends_for(hash, true).1, Legend::Text("#"));
+        let blank = spec_for(0x30).unwrap();
+        assert_eq!(legends_for(blank, false).0, Legend::Text("\\"));
+        assert_eq!(legends_for(blank, true).0, Legend::None);
+        // Everything else is the same cap either way.
+        let a = spec_for(0x20).unwrap();
+        assert_eq!(legends_for(a, false), legends_for(a, true));
+    }
+
+    /// A qualifier clicked once arms itself for the next keystroke and
+    /// comes back up with it; clicked twice it locks; clicked while locked
+    /// it lets go.
+    #[test]
+    fn a_qualifier_latches_for_one_keystroke_and_locks_on_a_double_click() {
+        let mut kbd = KbdPanelState::default();
+        let t0 = Instant::now();
+        let shift = KbdControl::Key(0x60);
+
+        // Click: down on the press, still down on the release.
+        assert_eq!(kbd.press(shift, t0).keys, vec![(0x60, true)]);
+        let out = kbd.release(t0 + Duration::from_millis(50));
+        assert!(out.keys.is_empty(), "a tap leaves it down: {out:?}");
+        assert_eq!(kbd.view(false, None).latch[0x60], Latch::OneShot);
+
+        // The next ordinary key takes it with them, on the release.
+        let a = KbdControl::Key(0x20);
+        assert_eq!(
+            kbd.press(a, t0 + Duration::from_secs(1)).keys,
+            vec![(0x20, true)]
+        );
+        assert_eq!(
+            kbd.release(t0 + Duration::from_secs(1)).keys,
+            vec![(0x20, false), (0x60, false)],
+            "the qualifier is released after the key it qualified"
+        );
+        assert_eq!(kbd.view(false, None).latch[0x60], Latch::None);
+
+        // Two clicks inside the double window lock it down.
+        let mut kbd = KbdPanelState::default();
+        kbd.press(shift, t0);
+        kbd.release(t0 + Duration::from_millis(20));
+        kbd.press(shift, t0 + Duration::from_millis(120));
+        let out = kbd.release(t0 + Duration::from_millis(140));
+        assert!(out.keys.is_empty(), "still down: {out:?}");
+        assert_eq!(kbd.view(false, None).latch[0x60], Latch::Locked);
+        // A key now leaves it locked.
+        kbd.press(a, t0 + Duration::from_secs(2));
+        assert_eq!(
+            kbd.release(t0 + Duration::from_secs(2)).keys,
+            vec![(0x20, false)]
+        );
+        assert_eq!(kbd.view(false, None).latch[0x60], Latch::Locked);
+        // Clicking it again lets it go.
+        kbd.press(shift, t0 + Duration::from_secs(3));
+        assert_eq!(
+            kbd.release(t0 + Duration::from_secs(3)).keys,
+            vec![(0x60, false)]
+        );
+        assert_eq!(kbd.view(false, None).latch[0x60], Latch::None);
+    }
+
+    /// Pressed and held rather than clicked, a qualifier behaves like the
+    /// real key: it comes up when the mouse does, with nothing latched.
+    #[test]
+    fn a_qualifier_held_down_comes_up_with_the_mouse() {
+        let mut kbd = KbdPanelState::default();
+        let t0 = Instant::now();
+        assert_eq!(
+            kbd.press(KbdControl::Key(0x60), t0).keys,
+            vec![(0x60, true)]
+        );
+        let out = kbd.release(t0 + TAP + Duration::from_millis(50));
+        assert_eq!(out.keys, vec![(0x60, false)], "a hold is a hold");
+        assert_eq!(kbd.view(false, None).latch[0x60], Latch::None);
+    }
+
+    /// Caps Lock is an ordinary key with a lamp on it: the strip sends the
+    /// pair a real key sends and never mirrors the latch, which is the
+    /// MCU's (the press flips it, the release does nothing at all).
+    #[test]
+    fn caps_lock_is_a_plain_key_whose_lamp_the_mcu_owns() {
+        let mut kbd = KbdPanelState::default();
+        let t0 = Instant::now();
+        let caps = KbdControl::Key(RAWKEY_CAPS_LOCK);
+        assert_eq!(kbd.press(caps, t0).keys, vec![(RAWKEY_CAPS_LOCK, true)]);
+        assert_eq!(kbd.release(t0).keys, vec![(RAWKEY_CAPS_LOCK, false)]);
+        // The lamp comes from the machine, not from the clicks: neither
+        // press moved it here.
+        assert!(!kbd.view(false, None).caps_lit);
+        assert!(kbd.view(true, None).caps_lit);
+        // And a cap left down when the strip goes away is handed back.
+        kbd.press(caps, t0);
+        assert_eq!(kbd.release_all().keys, vec![(RAWKEY_CAPS_LOCK, false)]);
+    }
+
+    /// Ctrl+Amiga+Amiga starts the MCU's reset flow, and the strip lets go
+    /// of all three: latched qualifiers would be reported held through the
+    /// power-up stream and reset the machine again on the next keystroke.
+    #[test]
+    fn the_reset_chord_drops_every_latch() {
+        let mut kbd = KbdPanelState::default();
+        let t0 = Instant::now();
+        // Latched one at a time, as a one-button mouse must.
+        for (n, raw) in [RAWKEY_CTRL, RAWKEY_LEFT_AMIGA].into_iter().enumerate() {
+            let at = t0 + Duration::from_millis(100 * n as u64);
+            kbd.press(KbdControl::Key(raw), at);
+            kbd.release(at + Duration::from_millis(10));
+        }
+        let at = t0 + Duration::from_millis(400);
+        let out = kbd.press(KbdControl::Key(RAWKEY_RIGHT_AMIGA), at);
+        assert_eq!(out.keys.first(), Some(&(RAWKEY_RIGHT_AMIGA, true)));
+        for raw in [RAWKEY_CTRL, RAWKEY_LEFT_AMIGA, RAWKEY_RIGHT_AMIGA] {
+            assert!(
+                out.keys.contains(&(raw, false)),
+                "{raw:#04x} was let go: {out:?}"
+            );
+        }
+        let view = kbd.view(false, None);
+        for raw in MODIFIERS {
+            assert_eq!(view.latch[usize::from(raw)], Latch::None);
+            assert!(!view.down[usize::from(raw)]);
+        }
+        assert!(!kbd.holding_key(), "nothing is left under the mouse");
+    }
+
+    /// The close chip puts the keyboard away and hands back whatever it
+    /// was holding, since the strip is gone before the button lifts.
+    #[test]
+    fn the_close_chip_releases_what_it_was_holding() {
+        let mut kbd = KbdPanelState::default();
+        let t0 = Instant::now();
+        kbd.press(KbdControl::Key(0x60), t0);
+        kbd.release(t0 + Duration::from_millis(10)); // latched
+        let out = kbd.press(KbdControl::Close, t0 + Duration::from_secs(1));
+        assert!(out.close);
+        assert_eq!(out.keys, vec![(0x60, false)]);
+    }
+
+    /// The legend switch changes the caps and nothing else.
+    #[test]
+    fn the_legend_chip_only_swaps_the_legends() {
+        let mut kbd = KbdPanelState::default();
+        assert!(!kbd.view(false, None).us_legends);
+        let out = kbd.press(KbdControl::Legends, Instant::now());
+        assert!(out.keys.is_empty() && !out.close);
+        assert!(kbd.view(false, None).us_legends);
+    }
+
+    /// Renders the keyboard to `target/ui-preview-keyboard-panel.png` under
+    /// COPPERLINE_UI_PREVIEW, for looking at while the design settles.
+    #[test]
+    fn the_keyboard_panel_draws_itself() {
+        use crate::video::window::present_height;
+
+        // The drawing helpers clamp against the presentation texture, so
+        // the strip is drawn where it really sits and cropped out after.
+        let _guard = KeyboardUp::shown();
+        let scale = 2;
+        let (w, h) = (texture_width(scale), texture_height(scale));
+        let top = present_height();
+        let panel = panel_rect(top);
+        let (px, py) = (panel.x * scale, panel.y * scale);
+        let (pw, ph) = (panel.w * scale, panel.h * scale);
+
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = KbdPanelState::default();
+        let t0 = Instant::now();
+        // One qualifier latched for the next keystroke, one locked, and a
+        // cap held down, so the preview shows every state a cap has.
+        state.press(KbdControl::Key(0x60), t0);
+        state.release(t0 + Duration::from_millis(10));
+        state.press(KbdControl::Key(0x63), t0 + Duration::from_millis(20));
+        state.release(t0 + Duration::from_millis(30));
+        state.press(KbdControl::Key(0x63), t0 + Duration::from_millis(40));
+        state.release(t0 + Duration::from_millis(50));
+        state.press(KbdControl::Key(0x24), t0 + Duration::from_secs(1));
+        // Caps lit, and the pointer resting on a cap.
+        let view = state.view(true, Some(KbdControl::Key(0x35)));
+        draw(&mut frame, &view, top, scale);
+
+        let mut strip = Vec::with_capacity(pw * ph * 4);
+        for row in 0..ph {
+            let start = ((py + row) * w + px) * 4;
+            strip.extend_from_slice(&frame[start..start + pw * 4]);
+        }
+        assert_ne!(&strip[0..4], &[0, 0, 0, 0], "the fascia was painted");
+        // A cap in the middle of the strip really got its moulding, read
+        // clear of both its bevel and its centred legend.
+        let a = cell_of(0x20);
+        let cap = pixel_at(&strip, pw, (a.x + 6, a.y + 6 - panel.y), scale);
+        assert_eq!(cap, CAP_IDLE.to_le_bytes(), "the A cap is drawn");
+
+        if crate::envcfg::flag("COPPERLINE_UI_PREVIEW") {
+            let path = "target/ui-preview-keyboard-panel.png";
+            let file = std::fs::File::create(path).unwrap();
+            let mut enc = png::Encoder::new(std::io::BufWriter::new(file), pw as u32, ph as u32);
+            enc.set_color(png::ColorType::Rgba);
+            enc.set_depth(png::BitDepth::Eight);
+            enc.write_header()
+                .unwrap()
+                .write_image_data(&strip)
+                .unwrap();
+            eprintln!("saved {path}");
+        }
+    }
+
+    /// A canvas pixel, in the strip's own coordinates, read out of the
+    /// cropped strip.
+    fn pixel_at(strip: &[u8], strip_w: usize, pos: (usize, usize), scale: usize) -> [u8; 4] {
+        let (x, y) = (pos.0 * scale, pos.1 * scale);
+        strip[(y * strip_w + x) * 4..(y * strip_w + x) * 4 + 4]
+            .try_into()
+            .unwrap()
+    }
+
+    /// It draws at both texture scales without running off the end of a
+    /// correctly sized buffer.
+    #[test]
+    fn it_draws_at_every_texture_scale() {
+        let _guard = KeyboardUp::shown();
+        let top = crate::video::window::present_height();
+        for scale in [1, 2] {
+            let (w, h) = (texture_width(scale), texture_height(scale));
+            let mut frame = vec![0u8; w * h * 4];
+            let view = KbdPanelState::default().view(false, None);
+            draw(&mut frame, &view, top, scale);
+            // The strip was painted rather than left transparent.
+            let row = (top + 1) * scale;
+            assert_ne!(&frame[row * w * 4..row * w * 4 + 4], &[0, 0, 0, 0]);
+        }
+    }
+}

--- a/src/video/window/mt32panel.rs
+++ b/src/video/window/mt32panel.rs
@@ -1145,7 +1145,6 @@ mod tests {
 
         // The drawing helpers clamp against the presentation texture, so the
         // panel is drawn where it really sits and the strip cropped out.
-        let _guard = crate::video::window::canvas_height_test_lock();
         crate::video::set_mt32_panel_shown(true);
         let scale = 2;
         let (w, h) = (texture_width(scale), texture_height(scale));

--- a/src/video/window/mt32panel.rs
+++ b/src/video/window/mt32panel.rs
@@ -1145,6 +1145,7 @@ mod tests {
 
         // The drawing helpers clamp against the presentation texture, so the
         // panel is drawn where it really sits and the strip cropped out.
+        let _guard = crate::video::window::canvas_height_test_lock();
         crate::video::set_mt32_panel_shown(true);
         let scale = 2;
         let (w, h) = (texture_width(scale), texture_height(scale));

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -108,12 +108,19 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
         hover == Some(BarControl::Joystick),
         texture_scale,
     );
+    draw_keyboard_button(
+        frame,
+        scale_rect(keyboard_toggle_rect(), texture_scale),
+        view.keyboard_panel_shown,
+        hover == Some(BarControl::Keyboard),
+        texture_scale,
+    );
     if view.control_connected {
         // A remote control-protocol client is attached; tag the bar so a
         // machine that pauses or steps "by itself" is explicable.
         draw_text(
             frame,
-            (JOY_TOGGLE_X.saturating_sub(44)) * texture_scale,
+            (KBD_TOGGLE_X.saturating_sub(44)) * texture_scale,
             (status_bar_top() + STATUS_CONTROL_Y + 2) * texture_scale,
             "CCP",
             STATUS_TEXT,
@@ -186,6 +193,8 @@ pub(super) struct StatusBarView {
     pub(super) media: MediaBar,
     /// Active host joystick source, shown by the status-bar toggle icon.
     pub(super) joystick_input_mode: JoystickInputMode,
+    /// Whether the on-screen keyboard is up, so its toggle can show it.
+    pub(super) keyboard_panel_shown: bool,
     pub(super) hover: Option<BarControl>,
     /// A control-protocol client is attached (--control-gui).
     pub(super) control_connected: bool,
@@ -200,6 +209,8 @@ pub(super) enum BarControl {
     Screenshot,
     Menu,
     Joystick,
+    /// Show or hide the on-screen Amiga keyboard.
+    Keyboard,
     Volume,
     DriveLoad(usize),
     DriveSwap(usize),
@@ -335,6 +346,9 @@ pub(super) fn control_at(pos: (i32, i32), layout: &BarLayout) -> Option<BarContr
     }
     if joystick_toggle_rect().contains(pos) {
         return Some(BarControl::Joystick);
+    }
+    if keyboard_toggle_rect().contains(pos) {
+        return Some(BarControl::Keyboard);
     }
     if volume_control_hit_rect().contains(pos) {
         return Some(BarControl::Volume);
@@ -487,6 +501,15 @@ pub(super) fn joystick_toggle_rect() -> Rect {
         x: JOY_TOGGLE_X,
         y: status_bar_top() + STATUS_CONTROL_Y,
         w: JOY_TOGGLE_W,
+        h: STATUS_CONTROL_H,
+    }
+}
+
+pub(super) fn keyboard_toggle_rect() -> Rect {
+    Rect {
+        x: KBD_TOGGLE_X,
+        y: status_bar_top() + STATUS_CONTROL_Y,
+        w: KBD_TOGGLE_W,
         h: STATUS_CONTROL_H,
     }
 }
@@ -1383,9 +1406,33 @@ pub(super) fn draw_gamepad_glyph(frame: &mut [u8], rect: Rect, texture_scale: us
     cell(15, 12, 2, 2, BUTTON_EDGE_DARK);
 }
 
+/// The on-screen keyboard's toggle: the same little keyboard the joystick
+/// toggle wears in its key-mapping mode, lit while the strip is up and dark
+/// while it is away, so the button says which it is without a caption.
+pub(super) fn draw_keyboard_button(
+    frame: &mut [u8],
+    rect: Rect,
+    shown: bool,
+    hover: bool,
+    texture_scale: usize,
+) {
+    draw_button_base(frame, rect, hover, texture_scale);
+    let keys = if shown {
+        BUTTON_GLYPH
+    } else {
+        BUTTON_GLYPH_DISABLED
+    };
+    draw_keyboard_glyph_in(frame, rect, keys, texture_scale);
+}
+
 /// A small keyboard: a recessed dark case holding two rows of green keys and a
 /// space bar.
 pub(super) fn draw_keyboard_glyph(frame: &mut [u8], rect: Rect, texture_scale: usize) {
+    draw_keyboard_glyph_in(frame, rect, BUTTON_GLYPH, texture_scale);
+}
+
+/// The same keyboard with its keys in a chosen colour.
+fn draw_keyboard_glyph_in(frame: &mut [u8], rect: Rect, keys: u32, texture_scale: usize) {
     let s = texture_scale;
     let mut cell = |x: usize, y: usize, w: usize, h: usize, color: u32| {
         fill_rect(
@@ -1404,11 +1451,11 @@ pub(super) fn draw_keyboard_glyph(frame: &mut [u8], rect: Rect, texture_scale: u
     cell(3, 6, 16, 11, BUTTON_EDGE_DARK);
     // Two rows of keys.
     for &kx in &[5, 8, 11, 14] {
-        cell(kx, 8, 2, 2, BUTTON_GLYPH);
-        cell(kx, 11, 2, 2, BUTTON_GLYPH);
+        cell(kx, 8, 2, 2, keys);
+        cell(kx, 11, 2, 2, keys);
     }
     // Space bar.
-    cell(7, 14, 8, 2, BUTTON_GLYPH);
+    cell(7, 14, 8, 2, keys);
 }
 
 /// The pause symbol: two short vertical bars flanking the centre.

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11,23 +11,24 @@ use super::{
     control_at, copperline_icon_image, copperline_logo_image, copy_present_frame,
     copy_tv_aperture_to_window, copy_window_present_frame, cursor_position_in_texture,
     draw_status_bar, fdd_track_counter_rect, fdd_track_digit_rect, host_shortcut_modifier_pressed,
-    host_to_amiga_rawkey, joystick_toggle_rect, led_row_rect, mask_present_frame_to_tv,
-    paint_test_screen, parse_amiga_key, pause_button_rect, plan_present_scaling_for,
-    power_button_rect, present_height, presentation_pixels_equal, presentation_source_y_offset,
-    raw_device_qualifier_family_held, raw_device_qualifier_rawkey, rawkey_is_held,
-    rawkey_transition_is_duplicate, reboot_button_rect, repeated_main_key_should_drop, rgba,
-    short_status_error, shorten_status_paths, shot_button_rect, should_render_emulated_frame,
-    standard_window_top_row, status_with_latched_fdd_track, take_integral_mouse_delta,
-    texture_height, texture_width, tint_display_rows, tint_lut, tint_rows_in_place,
-    tv_aperture_source_row, tv_source_h_bounds, volume_percent_from_pos, volume_slider_track_rect,
-    BarControl, DriveBar, JoystickInputMode, MediaBar, PresentationLatch, StatusBarView,
-    ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT, AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT,
-    AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH, BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON,
-    DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL, FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON,
-    POWER_GLYPH_OFF, POWER_GLYPH_ON, POWER_LED_BRIGHT, POWER_LED_DIM, POWER_LED_OFF,
-    STANDARD_PAL_VISIBLE_LINES, STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF,
-    TRACK_SEGMENT_ON, TV_CAPTURED_SOURCE_X, TV_CAPTURED_WIDTH, TV_LIVE_PAD_X,
-    TV_PAL_PRESENT_HEIGHT, TV_PRESENT_SOURCE_Y, VOLUME_FILL, VOLUME_GLYPH_X,
+    host_to_amiga_rawkey, joystick_toggle_rect, kbdpanel, keyboard_toggle_rect, led_row_rect,
+    mask_present_frame_to_tv, paint_test_screen, parse_amiga_key, pause_button_rect,
+    plan_present_scaling_for, power_button_rect, present_height, presentation_pixels_equal,
+    presentation_source_y_offset, raw_device_qualifier_family_held, raw_device_qualifier_rawkey,
+    rawkey_is_held, rawkey_transition_is_duplicate, reboot_button_rect,
+    repeated_main_key_should_drop, rgba, short_status_error, shorten_status_paths,
+    shot_button_rect, should_render_emulated_frame, standard_window_top_row,
+    status_with_latched_fdd_track, take_integral_mouse_delta, texture_height, texture_width,
+    tint_display_rows, tint_lut, tint_rows_in_place, tv_aperture_source_row, tv_source_h_bounds,
+    volume_percent_from_pos, volume_slider_track_rect, BarControl, DriveBar, JoystickInputMode,
+    MediaBar, PresentationLatch, StatusBarView, ToolPanelKind, AMIGA_RAWKEY_LEFT_ALT,
+    AMIGA_RAWKEY_LEFT_SHIFT, AMIGA_RAWKEY_RIGHT_ALT, AMIGA_RAWKEY_RIGHT_SHIFT, BUTTON_GLYPH,
+    BUTTON_GLYPH_DISABLED, CD_BODY, CD_LED_OFF, CD_LED_ON, DISK_BODY, DISK_BODY_SHADOW, DISK_LABEL,
+    FDD_LED_OFF, FDD_LED_ON, HDD_LED_OFF, HDD_LED_ON, POWER_GLYPH_OFF, POWER_GLYPH_ON,
+    POWER_LED_BRIGHT, POWER_LED_DIM, POWER_LED_OFF, STANDARD_PAL_VISIBLE_LINES,
+    STANDARD_PAL_VISIBLE_START_VPOS, STATUS_BG, TRACK_SEGMENT_OFF, TRACK_SEGMENT_ON,
+    TV_CAPTURED_SOURCE_X, TV_CAPTURED_WIDTH, TV_LIVE_PAD_X, TV_PAL_PRESENT_HEIGHT,
+    TV_PRESENT_SOURCE_Y, VOLUME_FILL, VOLUME_GLYPH_X,
 };
 use crate::audio::{AudioSink, NullSink};
 use crate::bus::{FrontPanelStatus, RenderRegisterSnapshot};
@@ -72,6 +73,7 @@ fn view(status: FrontPanelStatus, powered_on: bool, paused: bool) -> StatusBarVi
         paused,
         media: single_drive_media(),
         joystick_input_mode: JoystickInputMode::Gamepad,
+        keyboard_panel_shown: false,
         hover: None,
         control_connected: false,
     }
@@ -1147,6 +1149,237 @@ fn joystick_toggle_clears_worst_case_media() {
 }
 
 #[test]
+fn keyboard_toggle_clears_worst_case_media() {
+    // It shares the joystick toggle's slot, one button further left, so it
+    // is the one the widest media layout (four floppies plus a CD) reaches
+    // first -- and it must not.
+    let toggle = keyboard_toggle_rect();
+    let joystick = joystick_toggle_rect();
+    let layout = bar_layout(&media(4, Some(true)));
+    let media_right = layout
+        .cd_eject
+        .into_iter()
+        .chain(layout.drive_eject.into_iter().flatten())
+        .map(|r| r.x + r.w)
+        .max()
+        .unwrap();
+    assert!(
+        media_right <= toggle.x,
+        "media right edge {media_right} overlaps keyboard toggle at {}",
+        toggle.x
+    );
+    assert!(
+        toggle.x + toggle.w <= joystick.x,
+        "the two toggles overlap each other"
+    );
+    // And it answers to a click in the middle of it.
+    let layout = bar_layout(&single_drive_media());
+    let center = (
+        (toggle.x + toggle.w / 2) as i32,
+        (toggle.y + toggle.h / 2) as i32,
+    );
+    assert_eq!(control_at(center, &layout), Some(BarControl::Keyboard));
+}
+
+/// Holds the canvas-height lock for a test that puts the on-screen
+/// keyboard up, and takes the strip down again however the test ends -- a
+/// failed assertion must not leave the flag set for everything after it.
+struct KeyboardUp(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+impl KeyboardUp {
+    fn shown() -> Self {
+        let guard = super::canvas_height_test_lock();
+        crate::video::set_keyboard_panel_shown(true);
+        Self(guard)
+    }
+
+    /// The same lock without putting the strip up, for a test that does
+    /// its own showing and hiding.
+    fn hidden() -> Self {
+        let guard = super::canvas_height_test_lock();
+        crate::video::set_keyboard_panel_shown(false);
+        Self(guard)
+    }
+}
+
+impl Drop for KeyboardUp {
+    fn drop(&mut self) {
+        crate::video::set_keyboard_panel_shown(false);
+    }
+}
+
+/// The strip's own rect this frame, with the keyboard up.
+fn shown_keyboard_panel() -> super::Rect {
+    kbdpanel::shown_panel_rect(super::keyboard_panel_top()).expect("the keyboard is up")
+}
+
+/// Where on the canvas the cap carrying `rawkey` is, with the keyboard up.
+fn keycap_center(rawkey: u8) -> (i32, i32) {
+    let panel = shown_keyboard_panel();
+    for y in panel.y..panel.y + panel.h {
+        for x in panel.x..panel.x + panel.w {
+            if kbdpanel::control_at(panel, (x as i32, y as i32))
+                == Some(kbdpanel::KbdControl::Key(rawkey))
+            {
+                return (x as i32 + 4, y as i32 + 4);
+            }
+        }
+    }
+    panic!("no cap for rawkey {rawkey:#04x}");
+}
+
+/// Click a cap the way the window event does: press on the way down,
+/// release on the way up.
+fn click_keycap(app: &mut super::App, rawkey: u8) {
+    let panel = shown_keyboard_panel();
+    let control = kbdpanel::control_at(panel, keycap_center(rawkey)).expect("a cap is there");
+    app.press_keyboard_panel_control(control);
+    app.release_keyboard_panel_key();
+}
+
+/// Showing the keyboard grows the canvas by exactly the strip, and hiding
+/// it gives the height back. The picture itself never changes size.
+#[test]
+fn the_keyboard_toggle_grows_and_shrinks_the_canvas() {
+    let _guard = KeyboardUp::hidden();
+    let mut app = test_app();
+    let closed = super::window_present_height();
+    assert!(!crate::video::keyboard_panel_shown());
+
+    app.activate_bar_control(BarControl::Keyboard);
+    assert!(crate::video::keyboard_panel_shown());
+    assert_eq!(
+        super::window_present_height(),
+        closed + kbdpanel::KBD_PANEL_HEIGHT,
+        "the canvas gained exactly the strip"
+    );
+    // The display keeps its own height; the strip came out of the window.
+    assert_eq!(super::status_bar_top(), present_height() + KBD_HEIGHT);
+
+    app.activate_bar_control(BarControl::Keyboard);
+    assert!(!crate::video::keyboard_panel_shown());
+    assert_eq!(super::window_present_height(), closed);
+}
+
+const KBD_HEIGHT: usize = kbdpanel::KBD_PANEL_HEIGHT;
+
+/// Clicking a cap presses the Amiga key on the way down and releases it on
+/// the way up, through the same door a host keystroke uses.
+#[test]
+fn clicking_a_cap_types_its_rawkey() {
+    let _guard = KeyboardUp::shown();
+    let mut app = test_app();
+    let panel = shown_keyboard_panel();
+    let control = kbdpanel::control_at(panel, keycap_center(0x20)).expect("the A cap");
+    assert_eq!(control, kbdpanel::KbdControl::Key(0x20));
+
+    app.press_keyboard_panel_control(control);
+    assert!(rawkey_is_held(&app.held_rawkeys, 0x20), "A went down");
+    assert!(
+        app.emu.bus().keyboard.is_held(0x20),
+        "and the matrix saw it"
+    );
+
+    assert!(app.release_keyboard_panel_key(), "the lift was the strip's");
+    assert!(!rawkey_is_held(&app.held_rawkeys, 0x20), "and came back up");
+    assert!(!app.emu.bus().keyboard.is_held(0x20));
+    // With nothing held, a lift belongs to whoever else wants it.
+    assert!(!app.release_keyboard_panel_key());
+}
+
+/// Caps Lock is the MCU's latch: the strip sends the press and nothing
+/// else, and the lamp on the cap is read back from the MCU.
+#[test]
+fn the_caps_cap_types_and_follows_the_mcus_lamp() {
+    let _guard = KeyboardUp::shown();
+    let mut app = test_app();
+    assert!(!app.emu.bus().keyboard.caps_lock_led());
+
+    click_keycap(&mut app, 0x62);
+    assert!(app.emu.bus().keyboard.caps_lock_led(), "the lamp came on");
+    assert!(app.keyboard_panel_view().caps_lit, "and the cap shows it");
+    // A second click puts it out again: one press per click, never two.
+    click_keycap(&mut app, 0x62);
+    assert!(!app.emu.bus().keyboard.caps_lock_led());
+    assert!(!app.keyboard_panel_view().caps_lit);
+}
+
+/// A qualifier clicked on its own is held for the next keystroke and let
+/// go with it, which is how a one-button mouse types a shifted character.
+#[test]
+fn a_latched_qualifier_is_released_with_the_key_it_qualified() {
+    let _guard = KeyboardUp::shown();
+    let mut app = test_app();
+
+    click_keycap(&mut app, AMIGA_RAWKEY_LEFT_SHIFT);
+    assert!(
+        rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT),
+        "Shift stayed down after the click"
+    );
+
+    let panel = shown_keyboard_panel();
+    let a = kbdpanel::control_at(panel, keycap_center(0x20)).unwrap();
+    app.press_keyboard_panel_control(a);
+    assert!(
+        rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT),
+        "still down across the keystroke"
+    );
+    app.release_keyboard_panel_key();
+    assert!(!rawkey_is_held(&app.held_rawkeys, 0x20));
+    assert!(
+        !rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT),
+        "and came up with it"
+    );
+}
+
+/// Ctrl+Amiga+Amiga starts the MCU's reset flow, and the strip lets go of
+/// all three: latched qualifiers would be reported held through the
+/// power-up stream and reset the machine again on the next keystroke.
+#[test]
+fn the_reset_chord_lets_go_of_every_latched_qualifier() {
+    let _guard = KeyboardUp::shown();
+    let mut app = test_app();
+    const CTRL: u8 = 0x63;
+    const LEFT_AMIGA: u8 = 0x66;
+    const RIGHT_AMIGA: u8 = 0x67;
+
+    click_keycap(&mut app, CTRL);
+    click_keycap(&mut app, LEFT_AMIGA);
+    assert!(rawkey_is_held(&app.held_rawkeys, CTRL));
+    assert!(rawkey_is_held(&app.held_rawkeys, LEFT_AMIGA));
+
+    // The third completes the chord, and the strip comes off the keyboard.
+    let panel = shown_keyboard_panel();
+    let ramiga = kbdpanel::control_at(panel, keycap_center(RIGHT_AMIGA)).unwrap();
+    app.press_keyboard_panel_control(ramiga);
+    for raw in [CTRL, LEFT_AMIGA, RIGHT_AMIGA] {
+        assert!(
+            !rawkey_is_held(&app.held_rawkeys, raw),
+            "{raw:#04x} was let go"
+        );
+    }
+    let view = app.keyboard_panel_view();
+    for raw in [CTRL, LEFT_AMIGA, RIGHT_AMIGA] {
+        assert_eq!(view.latch[usize::from(raw)], kbdpanel::Latch::None);
+        assert!(!view.down[usize::from(raw)]);
+    }
+}
+
+/// Hiding the keyboard with a key still down on it hands that key back:
+/// the strip is gone, so nothing is left to release it.
+#[test]
+fn hiding_the_keyboard_releases_what_it_was_holding() {
+    let _guard = KeyboardUp::shown();
+    let mut app = test_app();
+    click_keycap(&mut app, 0x63); // Ctrl, latched
+    assert!(rawkey_is_held(&app.held_rawkeys, 0x63));
+
+    app.set_keyboard_panel_shown(false);
+    assert!(!rawkey_is_held(&app.held_rawkeys, 0x63), "handed back");
+    assert!(!app.emu.bus().keyboard.is_held(0x63));
+}
+
+#[test]
 fn joystick_toggle_is_hit_tested_and_draws_each_mode() {
     let layout = bar_layout(&single_drive_media());
     let toggle = joystick_toggle_rect();
@@ -1839,6 +2072,7 @@ fn status_bar_draws_cd_buttons_only_on_cd_machines() {
         paused: false,
         media: bar,
         joystick_input_mode: JoystickInputMode::Gamepad,
+        keyboard_panel_shown: false,
         hover: None,
         control_connected: false,
     };

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -1181,24 +1181,24 @@ fn keyboard_toggle_clears_worst_case_media() {
     assert_eq!(control_at(center, &layout), Some(BarControl::Keyboard));
 }
 
-/// Holds the canvas-height lock for a test that puts the on-screen
-/// keyboard up, and takes the strip down again however the test ends -- a
-/// failed assertion must not leave the flag set for everything after it.
-struct KeyboardUp(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+/// Puts the on-screen keyboard up for the length of a test and takes it
+/// down again however the test ends. The flag is this thread's own in a
+/// test build (see `crate::video::set_keyboard_panel_shown`), so it costs
+/// no other test anything -- but a test that left it set would still
+/// mislead the next one to run on the same thread.
+struct KeyboardUp;
 
 impl KeyboardUp {
     fn shown() -> Self {
-        let guard = super::canvas_height_test_lock();
         crate::video::set_keyboard_panel_shown(true);
-        Self(guard)
+        Self
     }
 
-    /// The same lock without putting the strip up, for a test that does
-    /// its own showing and hiding.
+    /// The strip explicitly down, for a test that does its own showing and
+    /// hiding and wants to start from a known state.
     fn hidden() -> Self {
-        let guard = super::canvas_height_test_lock();
         crate::video::set_keyboard_panel_shown(false);
-        Self(guard)
+        Self
     }
 }
 
@@ -1208,14 +1208,16 @@ impl Drop for KeyboardUp {
     }
 }
 
-/// The strip's own rect this frame, with the keyboard up.
-fn shown_keyboard_panel() -> super::Rect {
-    kbdpanel::shown_panel_rect(super::keyboard_panel_top()).expect("the keyboard is up")
+/// Where the strip sits. Its geometry does not depend on the strip being
+/// up, so a test that only clicks caps needs neither the shown flag nor
+/// the lock that serialises it.
+fn keyboard_panel_rect() -> super::Rect {
+    kbdpanel::panel_rect(super::keyboard_panel_top())
 }
 
-/// Where on the canvas the cap carrying `rawkey` is, with the keyboard up.
+/// Where on the canvas the cap carrying `rawkey` is.
 fn keycap_center(rawkey: u8) -> (i32, i32) {
-    let panel = shown_keyboard_panel();
+    let panel = keyboard_panel_rect();
     for y in panel.y..panel.y + panel.h {
         for x in panel.x..panel.x + panel.w {
             if kbdpanel::control_at(panel, (x as i32, y as i32))
@@ -1231,7 +1233,7 @@ fn keycap_center(rawkey: u8) -> (i32, i32) {
 /// Click a cap the way the window event does: press on the way down,
 /// release on the way up.
 fn click_keycap(app: &mut super::App, rawkey: u8) {
-    let panel = shown_keyboard_panel();
+    let panel = keyboard_panel_rect();
     let control = kbdpanel::control_at(panel, keycap_center(rawkey)).expect("a cap is there");
     app.press_keyboard_panel_control(control);
     app.release_keyboard_panel_key();
@@ -1267,38 +1269,41 @@ const KBD_HEIGHT: usize = kbdpanel::KBD_PANEL_HEIGHT;
 /// the way up, through the same door a host keystroke uses.
 #[test]
 fn clicking_a_cap_types_its_rawkey() {
-    let _guard = KeyboardUp::shown();
     let mut app = test_app();
-    let panel = shown_keyboard_panel();
+    let panel = keyboard_panel_rect();
     let control = kbdpanel::control_at(panel, keycap_center(0x20)).expect("the A cap");
     assert_eq!(control, kbdpanel::KbdControl::Key(0x20));
 
     app.press_keyboard_panel_control(control);
-    assert!(rawkey_is_held(&app.held_rawkeys, 0x20), "A went down");
+    assert!(app.amiga_rawkey_held(0x20), "A went down");
     assert!(
         app.emu.bus().keyboard.is_held(0x20),
         "and the matrix saw it"
     );
+    // The host keyboard is not holding it: the strip is its own source.
+    assert!(!rawkey_is_held(&app.held_rawkeys, 0x20));
 
     assert!(app.release_keyboard_panel_key(), "the lift was the strip's");
-    assert!(!rawkey_is_held(&app.held_rawkeys, 0x20), "and came back up");
+    assert!(!app.amiga_rawkey_held(0x20), "and came back up");
     assert!(!app.emu.bus().keyboard.is_held(0x20));
     // With nothing held, a lift belongs to whoever else wants it.
     assert!(!app.release_keyboard_panel_key());
 }
 
-/// Caps Lock is the MCU's latch: the strip sends the press and nothing
-/// else, and the lamp on the cap is read back from the MCU.
+/// Caps Lock is an ordinary key with a lamp: the strip sends the press and
+/// release pair a real cap sends, and the MCU -- which owns the latch --
+/// toggles the lamp on the press and discards the release. The cap reads
+/// the lamp back from the MCU rather than mirroring the clicks.
 #[test]
 fn the_caps_cap_types_and_follows_the_mcus_lamp() {
-    let _guard = KeyboardUp::shown();
     let mut app = test_app();
     assert!(!app.emu.bus().keyboard.caps_lock_led());
 
     click_keycap(&mut app, 0x62);
     assert!(app.emu.bus().keyboard.caps_lock_led(), "the lamp came on");
     assert!(app.keyboard_panel_view().caps_lit, "and the cap shows it");
-    // A second click puts it out again: one press per click, never two.
+    // A second click puts it out again: the release the strip sends in
+    // between changes nothing, so the lamp toggles once per click.
     click_keycap(&mut app, 0x62);
     assert!(!app.emu.bus().keyboard.caps_lock_led());
     assert!(!app.keyboard_panel_view().caps_lit);
@@ -1308,26 +1313,25 @@ fn the_caps_cap_types_and_follows_the_mcus_lamp() {
 /// go with it, which is how a one-button mouse types a shifted character.
 #[test]
 fn a_latched_qualifier_is_released_with_the_key_it_qualified() {
-    let _guard = KeyboardUp::shown();
     let mut app = test_app();
 
     click_keycap(&mut app, AMIGA_RAWKEY_LEFT_SHIFT);
     assert!(
-        rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT),
+        app.amiga_rawkey_held(AMIGA_RAWKEY_LEFT_SHIFT),
         "Shift stayed down after the click"
     );
 
-    let panel = shown_keyboard_panel();
+    let panel = keyboard_panel_rect();
     let a = kbdpanel::control_at(panel, keycap_center(0x20)).unwrap();
     app.press_keyboard_panel_control(a);
     assert!(
-        rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT),
+        app.amiga_rawkey_held(AMIGA_RAWKEY_LEFT_SHIFT),
         "still down across the keystroke"
     );
     app.release_keyboard_panel_key();
-    assert!(!rawkey_is_held(&app.held_rawkeys, 0x20));
+    assert!(!app.amiga_rawkey_held(0x20));
     assert!(
-        !rawkey_is_held(&app.held_rawkeys, AMIGA_RAWKEY_LEFT_SHIFT),
+        !app.amiga_rawkey_held(AMIGA_RAWKEY_LEFT_SHIFT),
         "and came up with it"
     );
 }
@@ -1337,7 +1341,6 @@ fn a_latched_qualifier_is_released_with_the_key_it_qualified() {
 /// power-up stream and reset the machine again on the next keystroke.
 #[test]
 fn the_reset_chord_lets_go_of_every_latched_qualifier() {
-    let _guard = KeyboardUp::shown();
     let mut app = test_app();
     const CTRL: u8 = 0x63;
     const LEFT_AMIGA: u8 = 0x66;
@@ -1345,24 +1348,185 @@ fn the_reset_chord_lets_go_of_every_latched_qualifier() {
 
     click_keycap(&mut app, CTRL);
     click_keycap(&mut app, LEFT_AMIGA);
-    assert!(rawkey_is_held(&app.held_rawkeys, CTRL));
-    assert!(rawkey_is_held(&app.held_rawkeys, LEFT_AMIGA));
+    assert!(app.amiga_rawkey_held(CTRL));
+    assert!(app.amiga_rawkey_held(LEFT_AMIGA));
 
     // The third completes the chord, and the strip comes off the keyboard.
-    let panel = shown_keyboard_panel();
+    let panel = keyboard_panel_rect();
     let ramiga = kbdpanel::control_at(panel, keycap_center(RIGHT_AMIGA)).unwrap();
     app.press_keyboard_panel_control(ramiga);
     for raw in [CTRL, LEFT_AMIGA, RIGHT_AMIGA] {
-        assert!(
-            !rawkey_is_held(&app.held_rawkeys, raw),
-            "{raw:#04x} was let go"
-        );
+        assert!(!app.amiga_rawkey_held(raw), "{raw:#04x} was let go");
     }
     let view = app.keyboard_panel_view();
     for raw in [CTRL, LEFT_AMIGA, RIGHT_AMIGA] {
         assert_eq!(view.latch[usize::from(raw)], kbdpanel::Latch::None);
         assert!(!view.down[usize::from(raw)]);
     }
+}
+
+/// A key the host and the strip are both holding stays down for the
+/// machine until the last of the two lets go. Neither source can cut the
+/// other short, which is what a single de-duplicating table would do: the
+/// second press would be swallowed and the first release believed.
+#[test]
+fn a_key_held_by_both_sources_stays_down_until_both_let_go() {
+    let mut app = test_app();
+
+    // The host takes A first.
+    app.handle_amiga_key_event(0x20, true);
+    assert!(app.emu.bus().keyboard.is_held(0x20));
+
+    // Then the same cap is clicked. The machine already believes A is
+    // down, so nothing new reaches it -- and nothing is recorded either.
+    let panel = keyboard_panel_rect();
+    let a = kbdpanel::control_at(panel, keycap_center(0x20)).unwrap();
+    app.press_keyboard_panel_control(a);
+    assert!(app.emu.bus().keyboard.is_held(0x20));
+
+    // The cap comes up: the host still has it, so the key stays down.
+    app.release_keyboard_panel_key();
+    assert!(
+        app.emu.bus().keyboard.is_held(0x20),
+        "the host is still holding A"
+    );
+    assert!(app.amiga_rawkey_held(0x20));
+
+    // Only the last holder's release reaches the machine.
+    app.handle_amiga_key_event(0x20, false);
+    assert!(!app.emu.bus().keyboard.is_held(0x20), "and now it is up");
+    assert!(!app.amiga_rawkey_held(0x20));
+}
+
+/// The other way round: a qualifier latched on the strip survives a host
+/// tap of the same key, and the machine sees one continuous hold rather
+/// than the host's release cutting the latch short.
+#[test]
+fn a_latched_qualifier_survives_a_host_tap_of_the_same_key() {
+    let mut app = test_app();
+    const SHIFT: u8 = AMIGA_RAWKEY_LEFT_SHIFT;
+
+    click_keycap(&mut app, SHIFT); // latched down by the strip
+    assert!(app.emu.bus().keyboard.is_held(SHIFT));
+
+    // A host press and release of the same qualifier while it is latched.
+    app.handle_amiga_key_event(SHIFT, true);
+    app.handle_amiga_key_event(SHIFT, false);
+    assert!(
+        app.emu.bus().keyboard.is_held(SHIFT),
+        "the strip still has it latched"
+    );
+
+    // And the drawn latch agrees with the machine throughout: the panel
+    // shows it locked down for exactly as long as the machine holds it.
+    assert!(
+        app.keyboard_panel_view().down[usize::from(SHIFT)] || {
+            app.keyboard_panel_view().latch[usize::from(SHIFT)] != kbdpanel::Latch::None
+        }
+    );
+
+    // The keystroke the latch was armed for takes it with it.
+    click_keycap(&mut app, 0x20);
+    assert!(!app.emu.bus().keyboard.is_held(SHIFT), "the latch cleared");
+    assert!(!app.amiga_rawkey_held(SHIFT));
+    let view = app.keyboard_panel_view();
+    assert_eq!(view.latch[usize::from(SHIFT)], kbdpanel::Latch::None);
+    assert!(!view.down[usize::from(SHIFT)]);
+}
+
+/// What the strip draws is what the machine believes, even when the host
+/// had the same key first: the qualifier's press is swallowed as a
+/// duplicate transition, but the strip's own hold is still recorded, so
+/// its latch is not left over a machine that never heard of it.
+#[test]
+fn the_drawn_latch_matches_what_the_machine_holds() {
+    let mut app = test_app();
+    const SHIFT: u8 = AMIGA_RAWKEY_LEFT_SHIFT;
+
+    app.handle_amiga_key_event(SHIFT, true); // the host has it first
+    click_keycap(&mut app, SHIFT); // and the cap latches it
+    let view = app.keyboard_panel_view();
+    assert_eq!(view.latch[usize::from(SHIFT)], kbdpanel::Latch::OneShot);
+    assert!(
+        app.emu.bus().keyboard.is_held(SHIFT),
+        "drawn latched, and really down"
+    );
+
+    // The host lets go. The strip's latch is still there, so the machine
+    // must still have the key -- the host's release is not the last one.
+    app.handle_amiga_key_event(SHIFT, false);
+    assert_eq!(
+        app.keyboard_panel_view().latch[usize::from(SHIFT)],
+        kbdpanel::Latch::OneShot
+    );
+    assert!(
+        app.emu.bus().keyboard.is_held(SHIFT),
+        "the drawn latch is not a lie"
+    );
+
+    // And when the latch goes, so does the key.
+    click_keycap(&mut app, 0x20);
+    assert!(!app.emu.bus().keyboard.is_held(SHIFT));
+    assert_eq!(
+        app.keyboard_panel_view().latch[usize::from(SHIFT)],
+        kbdpanel::Latch::None
+    );
+}
+
+/// Running a new machine (the launcher's Run) lets go of the strip's
+/// holds against the machine being replaced, so neither it nor the new one
+/// is left with a key down that nothing will lift.
+#[test]
+fn running_a_new_machine_lets_go_of_the_strips_keys() {
+    let mut app = test_app();
+    click_keycap(&mut app, 0x63); // Ctrl, latched
+    assert!(app.emu.bus().keyboard.is_held(0x63));
+
+    let raw = crate::config::RawConfig::default();
+    let cfg = crate::config::Config::try_from(raw.clone()).expect("default config");
+    let emu = test_emulator(Box::new(NullSink), crate::config::CpuModel::M68000, &[]);
+    app.run_machine(emu, &cfg, raw);
+
+    assert!(
+        !app.amiga_rawkey_held(0x63),
+        "the latch went with the machine"
+    );
+    assert!(
+        !app.emu.bus().keyboard.is_held(0x63),
+        "and the new machine never saw it"
+    );
+    let view = app.keyboard_panel_view();
+    assert_eq!(view.latch[0x63], kbdpanel::Latch::None);
+    assert!(!view.down[0x63]);
+}
+
+/// Powering off does the same: the cold-boot machine comes up with the
+/// caps drawn up and nothing latched against the machine that stopped.
+#[test]
+fn powering_off_lets_go_of_the_strips_keys() {
+    let mut app = test_app();
+    click_keycap(&mut app, 0x63);
+    assert!(app.emu.bus().keyboard.is_held(0x63));
+
+    app.toggle_power();
+    assert!(!app.powered_on);
+    assert!(!app.amiga_rawkey_held(0x63), "handed back with the power");
+    assert!(!app.emu.bus().keyboard.is_held(0x63));
+    assert_eq!(app.keyboard_panel_view().latch[0x63], kbdpanel::Latch::None);
+}
+
+/// And a reboot: a latch that rode through would be re-reported by the
+/// MCU's power-up stream, which is exactly what starts the reset again.
+#[test]
+fn rebooting_lets_go_of_the_strips_keys() {
+    let mut app = test_app();
+    click_keycap(&mut app, 0x63);
+    assert!(app.emu.bus().keyboard.is_held(0x63));
+
+    app.activate_bar_control(BarControl::Reboot);
+    assert!(!app.amiga_rawkey_held(0x63));
+    assert!(!app.emu.bus().keyboard.is_held(0x63));
+    assert_eq!(app.keyboard_panel_view().latch[0x63], kbdpanel::Latch::None);
 }
 
 /// Hiding the keyboard with a key still down on it hands that key back:
@@ -1372,10 +1536,10 @@ fn hiding_the_keyboard_releases_what_it_was_holding() {
     let _guard = KeyboardUp::shown();
     let mut app = test_app();
     click_keycap(&mut app, 0x63); // Ctrl, latched
-    assert!(rawkey_is_held(&app.held_rawkeys, 0x63));
+    assert!(app.amiga_rawkey_held(0x63));
 
     app.set_keyboard_panel_shown(false);
-    assert!(!rawkey_is_held(&app.held_rawkeys, 0x63), "handed back");
+    assert!(!app.amiga_rawkey_held(0x63), "handed back");
     assert!(!app.emu.bus().keyboard.is_held(0x63));
 }
 
@@ -2126,7 +2290,7 @@ fn status_bar_draws_cd_led_on_cd_machines() {
     v.media = media(1, Some(true));
     draw_status_bar(&mut frame, &v, scale);
     let cd = led_row_rect(3, 4);
-    assert!(cd.y + cd.h <= present_height() + super::STATUS_BAR_HEIGHT);
+    assert!(cd.y + cd.h <= super::status_bar_top() + super::STATUS_BAR_HEIGHT);
     assert_eq!(
         pixel(&frame, cd.x + cd.w / 2, cd.y + cd.h / 2, scale),
         CD_LED_OFF.to_le_bytes()
@@ -3113,11 +3277,15 @@ fn test_app_with_audio_and_cpu(
 /// The same fixture running a guest program: `program` (big-endian 68000
 /// words) is laid down at the reset PC, replacing the head of the NOP
 /// sled. An empty program leaves the plain sled.
-fn test_app_with_audio_cpu_and_program(
+/// The emulator the fixtures run: a NOP-sled ROM with reset vectors
+/// pointing into it, half a meg of chip RAM, unpaced. Built on its own so a
+/// test can make a second machine and hand it to `run_machine`, which is
+/// what the launcher's Run does.
+fn test_emulator(
     audio: Box<dyn AudioSink>,
     cpu: crate::config::CpuModel,
     program: &[u16],
-) -> super::App {
+) -> crate::emulator::Emulator {
     use crate::chipset::paula::Paula;
     use crate::config::PacingBudget;
     use crate::emulator::Emulator;
@@ -3155,7 +3323,7 @@ fn test_app_with_audio_cpu_and_program(
         Paula::new(Box::new(StdoutSink::new()), audio),
         FloppyController::default(),
     );
-    let emu = Emulator::new(
+    Emulator::new(
         bus,
         cpu,
         false,
@@ -3164,7 +3332,15 @@ fn test_app_with_audio_cpu_and_program(
         2,
         false,
     )
-    .expect("test emulator");
+    .expect("test emulator")
+}
+
+fn test_app_with_audio_cpu_and_program(
+    audio: Box<dyn AudioSink>,
+    cpu: crate::config::CpuModel,
+    program: &[u16],
+) -> super::App {
+    let emu = test_emulator(audio, cpu, program);
     super::App::new(
         emu,
         true,


### PR DESCRIPTION
The web build's on-screen A600 keyboard, ported to the desktop window: a full-width strip between the display (or MT-32 panel) and the status bar, with a keyboard-glyph toggle button in the status bar and an **On-Screen Keyboard** row under *Input Settings*.

## What changed

- **New `src/video/window/kbdpanel.rs`**: the 78-key ISO A600 layout (the one Amiga keyboard with no numeric keypad, so the whole machine fits the 716 px canvas at a usable cap size), hit-testing, the qualifier-latch state machine, and drawing. Positions accumulate in integer quarter-units at 42 px/unit, so cells tile with no rounding seams; strip height 283 px. The cursor notch carries the UK/US legend chip and, above it (deliberately the slot farthest from the cursor keys), the X close chip.
- **Strip plumbing** mirrors the MT-32 panel: height folded into `window_present_height()` (display -> MT-32 -> keyboard -> status bar), its own branch in the MouseInput ordering, the full canvas-resize treatment on toggle (re-plan scaling, resize tool-window buffers, follow/rollback). `resync_canvas_height` is un-gated from the `mt32` feature and shared by both strips.
- **Input path**: clicks go through `handle_amiga_key_event`, the same door as a host keystroke -- de-duplicated, **captured by `--record-input`**, and noted for reverse-debug replay. A key releases when the mouse button lifts wherever the pointer got to, and on window focus loss.
- **Qualifiers latch** (one mouse button): click = one-shot, released with the next keystroke; double-click = locked; press-and-hold = a real hold. Completing Ctrl+Amiga+Amiga releases every latch immediately -- the MCU's reset flow re-reports still-held keys through the power-up stream, so leaving them latched would reset again on the next keystroke.
- **Caps Lock** sends the press/release pair a physical key sends (the MCU discards the release itself), and its cap lamp polls `caps_lock_led()` -- the accessor that has been waiting with `#[allow(dead_code)]` for exactly this UI -- so the lamp follows a save-state load or a guest toggling it in software. One deliberate departure from the web build, where press-only was correct: desktop's `handle_amiga_key_event` de-dupes against `held_rawkeys`, so a press-only cap would work exactly once.
- **Status bar**: `BarControl::Keyboard` at the joystick toggle's old slot, drawn with the existing keyboard glyph (green keys while the strip is up, grey when away). To keep the worst-case media cluster (four floppies + CD, ends x=372) clear, the volume slider narrows 72 -> 48 px -- the one pre-existing control that changed size.
- Shown state is runtime-only, matching the status-bar toggle (there is no menu-to-config write-back mechanism to hook into).

## Tests

14 unit tests in kbdpanel.rs (row geometry incl. the 15.5u notch rows and the ISO reverse-L Return, no-overlap sweep, hit-testing incl. live gaps, legend chip scope, the whole latch machine, reset chord, close chip, draw-at-scale, preview PNG) and 7 window tests (toggle grows/shrinks the canvas, cap clicks type through the real path, caps lamp follows the MCU, one-shot release, reset chord, hide-releases-held, status-bar fit). The process-global strip flags raced across tests, so there is now a canvas-height test mutex (the MT-32 preview test takes it too); the full suite was run repeatedly to confirm stability. Full suite green (2366 passed), clippy (`--all-targets`, `--all-features`) and fmt clean.

## Preview

`COPPERLINE_UI_PREVIEW=1 cargo test the_keyboard_panel_draws_itself` renders `target/ui-preview-keyboard-panel.png`: six rows with the F-row breaks, shifted legends printed small above the mains (pound on 3), ISO Return, latched/locked/pressed cap states, the lit caps lamp, and the hollow/filled Amiga marks.

## Docs

`docs/guide/ui.md`: status-bar bullet, a new *On-screen keyboard* section (layout, latching semantics, caps lamp, UK/US chip, close chip, `--record-input`), the Input Settings row, and a note under *Recording input*.
