### PR TITLE
Feature/whdload game library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,12 +565,15 @@ dependencies = [
  "socket2",
  "thread-priority",
  "toml",
+ "ureq",
  "wasmtime",
  "wat",
  "web-time",
  "windows-sys 0.61.2",
  "winit",
  "zerocopy",
+ "zeroize",
+ "zip",
 ]
 
 [[package]]
@@ -1337,6 +1346,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1571,6 +1591,22 @@ name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
@@ -2951,6 +2987,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ringbuf"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3056,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3295,6 +3380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,6 +3618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "ultraviolet"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,6 +3658,47 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -3599,6 +3737,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -4067,6 +4211,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4879,6 +5032,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4889,3 +5062,15 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +617,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1085,6 +1091,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,12 +1307,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1303,6 +1334,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2054,6 +2091,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2600,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2716,15 @@ dependencies = [
  "pkg-config",
  "regex",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3127,6 +3233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,6 +3264,29 @@ dependencies = [
  "memmap2 0.9.11",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3414,6 +3552,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,13 +3823,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "der",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -3715,6 +3869,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -4211,6 +4371,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,13 +122,9 @@ log = "0.4"
 env_logger = { version = "0.11", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", optional = true }
-# The game library's HTTP client (src/gamelib/openretro.rs). Blocking, which
-# is what a worker thread wants, and rustls rather than the platform's TLS so
-# a build needs no system OpenSSL and the Flatpak carries no extra runtime.
-ureq = { version = "3", default-features = false, features = [
-    "rustls",
-    "gzip",
-], optional = true }
+# The game library's HTTP client (src/gamelib/openretro.rs) is declared per
+# platform, with the other per-target dependencies below: its TLS backend
+# differs by what each host can build without a C toolchain.
 # Wiping the OpenRetro password and auth token from memory once they are
 # done with. Volatile writes with a compiler fence, which a hand-written
 # overwrite of a buffer nothing reads again is entitled to be optimised
@@ -197,6 +193,30 @@ zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 # macOS dock icon: winit's with_window_icon is a no-op on macOS, so the dock
 # icon must be set at runtime via NSApplication. These objc2 versions match the
 # ones rfd already pulls in, so they add no new crate copies to the build.
+# The game library's HTTP client. Blocking, which is what a worker thread
+# wants. The TLS backend differs by platform for build requirements rather
+# than for taste; the trust anchors do not, since both are pointed at the
+# Mozilla root set `webpki-roots` bundles rather than at the host's store.
+#
+# Everywhere but Windows: rustls, so a build needs no system OpenSSL and the
+# Flatpak carries no extra runtime.
+[target.'cfg(not(windows))'.dependencies]
+ureq = { version = "3", default-features = false, features = [
+    "rustls",
+    "gzip",
+], optional = true }
+
+# Windows: schannel, the OS's own TLS, reached through pure-Rust bindings.
+# rustls would do on x86-64, but its crypto provider (`ring`) compiles C and
+# assembly, and on ARM64 Windows `ring` ignores MSVC and demands clang -- see
+# the FIXME in its build.rs -- so a default build fails on a machine carrying
+# exactly the toolchain Rust itself asks for. Nothing here needs a C compiler.
+[target.'cfg(windows)'.dependencies]
+ureq = { version = "3", default-features = false, features = [
+    "native-tls",
+    "gzip",
+], optional = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = ["NSApplication", "NSImage"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,22 @@ default = [
     "mt32",
     "cpu-jit",
     "profile-stats",
+    "game-library",
 ]
 # MT-32 emulation through CopperlineHQ/mt32-rs, reachable as a MIDI-Out
 # target. Off builds carry none of it.
 mt32 = ["dep:mt32-rs"]
+# The WHDLoad game library: the launcher's Library page, the local game
+# database it reads, and the OpenRetro sync that fills it.
+#
+# This is the only part of Copperline that talks to the internet on its own
+# account, so it is the only part that needs an HTTP client and a TLS stack.
+# Off, none of that is linked and none of it is compiled: WHDLoad boots from
+# a path in the configuration exactly as it does with the feature on, the
+# Library page is absent, and `[whdload]` keys that only the library uses
+# are parsed and ignored so a configuration written by a full build still
+# loads. See src/gamelib/.
+game-library = ["dep:ureq", "dep:serde_json", "dep:zeroize"]
 display-plan-trace = []
 # Detailed host-cost counters used by native diagnostics. The browser crate
 # builds the core with `default-features = false`, so its release hot paths do
@@ -110,6 +122,18 @@ log = "0.4"
 env_logger = { version = "0.11", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", optional = true }
+# The game library's HTTP client (src/gamelib/openretro.rs). Blocking, which
+# is what a worker thread wants, and rustls rather than the platform's TLS so
+# a build needs no system OpenSSL and the Flatpak carries no extra runtime.
+ureq = { version = "3", default-features = false, features = [
+    "rustls",
+    "gzip",
+], optional = true }
+# Wiping the OpenRetro password and auth token from memory once they are
+# done with. Volatile writes with a compiler fence, which a hand-written
+# overwrite of a buffer nothing reads again is entitled to be optimised
+# away into nothing at all.
+zeroize = { version = "1", optional = true }
 serde-big-array = "0.5"
 bincode = "1"
 toml = "0.8"
@@ -168,6 +192,7 @@ fluxbridge = { git = "https://github.com/CopperlineHQ/FluxBridge", branch = "mai
 # Rust, so it builds for wasm32 browser targets like the rest of the core.
 chd = "0.3"
 delharc = "0.7.0"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 # macOS dock icon: winit's with_window_icon is a no-op on macOS, so the dock
 # icon must be set at runtime via NSApplication. These objc2 versions match the

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -386,7 +386,8 @@ video = "PAL"
 
 
 # Direct WHDLoad boot (docs/guide/whdload.md): boot straight into a
-# WHDLoad-installed game package. The package is extracted into the game
+# WHDLoad-installed game package -- an .lha, a .zip, or a plain folder
+# holding the installed tree. The package is unpacked into the game
 # library once (savegames persist there), a boot volume is synthesized
 # around the real WHDLoad program (support archives ship with releases, or
 # tools/fetch-whdload.sh), Kickstart images from `kickstarts` are
@@ -394,10 +395,20 @@ video = "PAL"
 # is derived from the slave header (A1200, 8M fast) unless [machine]/rom/
 # [memory] choices above say otherwise. --whdload GAME overrides `game`.
 # [whdload]
-# game = "Turrican.lha"       # .lha archive or a directory holding a .slave
+# game = "Turrican.lha"       # .lha, .zip, or a folder with a .slave
 # library = ""                # game library; default: <config dir>/whdload
 # kickstarts = "/data/amiga/kickstarts"
 # args = "ButtonWait"         # extra WHDLoad command-line options
+# machine_type = "auto"       # or "copperline" to boot on this machine
+# whd_package = ""            # your own WHDLoad_usr.lha
+# skick_package = ""          # your own skick*.lha
+#
+# The launcher's Library page only. `enabled = false` removes the WHDLoad
+# page and everything behind it; a game named above still boots.
+# enabled = true
+# games = ""                  # the folder the Library page lists
+# library_db = ""             # default: <config>/whdload/support/launcher.db
+# library_cache = ""          # default: <config>/whdload/support/cache
 
 
 # Host directories mounted directly as AmigaDOS volumes (HOSTFS0:,

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -396,7 +396,8 @@ video = "PAL"
 # [memory] choices above say otherwise. --whdload GAME overrides `game`.
 # [whdload]
 # game = "Turrican.lha"       # .lha, .zip, or a folder with a .slave
-# library = ""                # game library; default: <config dir>/whdload
+# library = ""                # unpacked games and saves; default:
+#                             # <config dir>/whdload/save
 # kickstarts = "/data/amiga/kickstarts"
 # args = "ButtonWait"         # extra WHDLoad command-line options
 # machine_type = "auto"       # or "copperline" to boot on this machine

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "web-time",
  "windows-sys",
  "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -734,6 +735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,7 +960,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1484,13 +1484,22 @@ hook entirely and never see the mounts.
 
 ```toml
 [whdload]
-game = "Turrican.lha"       # .lha archive or a directory holding a .slave
+game = "Turrican.lha"       # .lha, .zip, or a folder with a .slave
 # library = "..."           # game library; default: <config dir>/whdload
 # kickstarts = "..."        # directory scanned for Kickstart images
 # args = "ButtonWait"       # extra WHDLoad command-line options
+# machine_type = "auto"     # or "copperline" to boot on this machine
+# whd_package = "..."       # your own WHDLoad_usr.lha
+# skick_package = "..."     # your own skick*.lha
+
+# Launcher only.
+# enabled = true            # false removes the WHDLoad page entirely
+# games = "..."             # the folder the Library page lists
+# library_db = "..."        # default: <config>/whdload/support/launcher.db
+# library_cache = "..."     # default: <config>/whdload/support/cache
 ```
 
-Boots straight into a WHDLoad-installed game: the package is extracted
+Boots straight into a WHDLoad-installed game: the package is unpacked
 into the game library (once -- saves the game writes persist there), a
 minimal boot volume is synthesized around the real WHDLoad program, raw
 Kickstart images from `kickstarts` are identified by content and staged

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1485,7 +1485,8 @@ hook entirely and never see the mounts.
 ```toml
 [whdload]
 game = "Turrican.lha"       # .lha, .zip, or a folder with a .slave
-# library = "..."           # game library; default: <config dir>/whdload
+# library = "..."           # unpacked games and saves; default:
+#                           # <config dir>/whdload/save
 # kickstarts = "..."        # directory scanned for Kickstart images
 # args = "ButtonWait"       # extra WHDLoad command-line options
 # machine_type = "auto"     # or "copperline" to boot on this machine

--- a/docs/guide/host-disks.md
+++ b/docs/guide/host-disks.md
@@ -49,6 +49,9 @@ Copperline will not pretend to understand.
 From the launcher: **Storage → Host Disk**, tick the disk, choose where the
 machine should see it, and press **Mount**. Permission is asked for there, at
 the button you pressed, rather than later behind a machine that is starting.
+More disks than the table shows scroll with the arrows in its top and bottom
+right corners, each greyed at its end of the list; held, they work up through
+five speeds, a second at each.
 
 From the command line:
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -540,7 +540,13 @@ The layout is:
   or SCSI drive has an image a small editable box appears next to **Browse**:
   click it and type to set the volume name for a directory mount (left blank, a
   directory mount inherits the host directory's name; the box has no effect on a
-  raw HDF). A setting that does not apply to the chosen machine is greyed and
+  raw HDF).
+  Every box that can be typed into behaves the same way: clicking it starts
+  the edit, a block marks where typing goes, Left/Right and Home/End move
+  it, Backspace and Delete take the character behind and under it, Enter
+  commits and Escape cancels. A value longer than its box scrolls under the
+  block rather than being typed at blind.
+  A setting that does not apply to the chosen machine is greyed and
   shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM
   and the RTG card, "needs 68020+" for the FPU, "needs A600/A1200/A4000" for
   IDE.

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -191,10 +191,10 @@ Disk images can be dropped anywhere on the emulator window:
   multi-selection in the disk dialog.
 - **CD images** (`.cue`/`.iso`/`.chd`) mount in the machine's CD drive
   (CDTV, CD32, or a SCSI CD-ROM unit), with the media-change notification.
-- **WHDLoad packages** (`.lha`, or a bare `.slave`) reboot the machine
-  straight into the game through the [WHDLoad booter](whdload.md), keeping
-  any explicit machine choices; dropped on the configuration screen they
-  fill its **Storage -> WHDLoad** game field instead.
+- **WHDLoad packages** (`.lha`, `.zip`, or a bare `.slave`) reboot the
+  machine straight into the game through the [WHDLoad booter](whdload.md),
+  keeping any explicit machine choices; dropped on the configuration
+  screen they fill the **WHDLoad** page's game field instead.
 - **Hard disk images and Kickstart ROMs** cannot be swapped at runtime; a
   notice points at the machine-configuration screen, which also refuses
   such drops while it is open.
@@ -501,11 +501,12 @@ The layout is:
   the first four); **Host Disk**, for a real disk of this computer's (see
   [](host-disks.md)); **Boot Priority**, which sets each hard-disk drive's
   synthesized-RDB boot priority (see below); **Create Image...**, which
-  makes new ADF and HDF images (see below); **CD** (image, insert delay,
-  CD32 NVRAM); and **WHDLoad**, which picks a WHDLoad game package plus its
-  optional Kickstart-image and game-library directories (see
-  [](whdload.md); Run then boots straight into the game). Each sub-page has
-  a **< Back** button in that block that returns to Storage),
+  makes new ADF and HDF images (see below); and **CD** (image, insert
+  delay, CD32 NVRAM). Each sub-page has a **< Back** button in that block
+  that returns to Storage),
+  *WHDLoad* (the game library, and the settings a package boots with --
+  see [](whdload.md); its entry can be turned off in A/V & Emu ->
+  Emulation),
   *Input* (the controller device in each game port and the joystick input
   source),
   *I/O Ports* (the serial, parallel, and Ethernet ports under **Serial:** /

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -494,7 +494,7 @@ The layout is:
   whatever the chosen interface does not honour. See [](fluxbridge)),
   *Storage* (IDE master/slave, the SCSI controller -- A2091, A4091, or the
   A3000's onboard SCSI -- and its boot ROM and units; a block of buttons at
-  the top links to six sub-pages: **Host Folder**, for host directories
+  the top links to five sub-pages: **Host Folder**, for host directories
   served live as AmigaDOS volumes (up to four mounts, each with a boot
   priority and a read-write/read-only **Access** field -- the config file
   itself takes up to eight `[[filesys]]` mounts, of which the launcher edits
@@ -504,9 +504,8 @@ The layout is:
   makes new ADF and HDF images (see below); and **CD** (image, insert
   delay, CD32 NVRAM). Each sub-page has a **< Back** button in that block
   that returns to Storage),
-  *WHDLoad* (the game library, and the settings a package boots with --
-  see [](whdload.md); its entry can be turned off in A/V & Emu ->
-  Emulation),
+  *WHDLoad* (your game collection, and the settings games boot with -- see
+  [](whdload.md)),
   *Input* (the controller device in each game port and the joystick input
   source),
   *I/O Ports* (the serial, parallel, and Ethernet ports under **Serial:** /

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -504,8 +504,6 @@ The layout is:
   makes new ADF and HDF images (see below); and **CD** (image, insert
   delay, CD32 NVRAM). Each sub-page has a **< Back** button in that block
   that returns to Storage),
-  *WHDLoad* (your game collection, and the settings games boot with -- see
-  [](whdload.md)),
   *Input* (the controller device in each game port and the joystick input
   source),
   *I/O Ports* (the serial, parallel, and Ethernet ports under **Serial:** /
@@ -524,6 +522,8 @@ The layout is:
   input recordings and save-state replays non-reproducible while it flows),
   *Zorro* (extra autoconfig boards by metadata file, with a config panel for a
   WASM plugin board's declared options),
+  *WHDLoad* (your game collection, and the settings games boot with -- see
+  [](whdload.md)),
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
   sounds and volume), **Video** (start fullscreen, status bar, monitor bezel

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -542,9 +542,9 @@ The layout is:
   directory mount inherits the host directory's name; the box has no effect on a
   raw HDF).
   Every box that can be typed into behaves the same way: clicking it starts
-  the edit, a block marks where typing goes, Left/Right and Home/End move
-  it, Backspace and Delete take the character behind and under it, Enter
-  commits and Escape cancels. A value longer than its box scrolls under the
+  the edit, a blinking caret marks where typing goes, Left/Right and
+  Home/End move it, Backspace and Delete take the character behind and
+  under it, Enter commits and Escape cancels. A value longer than its box scrolls under the
   block rather than being typed at blind.
   A setting that does not apply to the chosen machine is greyed and
   shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -541,11 +541,6 @@ The layout is:
   click it and type to set the volume name for a directory mount (left blank, a
   directory mount inherits the host directory's name; the box has no effect on a
   raw HDF).
-  Every box that can be typed into behaves the same way: clicking it starts
-  the edit, a blinking caret marks where typing goes, Left/Right and
-  Home/End move it, Backspace and Delete take the character behind and
-  under it, Enter commits and Escape cancels. A value longer than its box scrolls under the
-  block rather than being typed at blind.
   A setting that does not apply to the chosen machine is greyed and
   shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM
   and the RTG card, "needs 68020+" for the FPU, "needs A600/A1200/A4000" for

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -68,7 +68,7 @@ saves. Delete one and press Refresh and it goes.
   freeware since release 18.2) and the Soft-Kicker package
   (`skick346.lha`) whose `.RTB` relocation tables accompany the raw
   Kickstart images. Building from source, fetch them once with
-  `tools/fetch-whdload.sh`, or press **Download** on the Configuration
+  `tools/fetch-whdload.sh`, or press **Download** on the Settings
   page; `COPPERLINE_WHDBOOT_DIR` points at a directory holding them if
   you keep them elsewhere.
 
@@ -138,7 +138,7 @@ A4000 instead. `machine_type = "copperline"` makes that the rule rather
 than the exception: the package boots on whatever machine the
 configuration describes.
 
-**Machine type** on the Configuration page is the same setting. It cycles
+**Machine type** on the Settings page is the same setting. It cycles
 between `Auto` and `Copperline`, and since neither word says what it does,
 pressing it puts the answer on the status line for a few seconds:
 "WHDLoad uses the Slave file machine type...", or "WHDLoad uses the
@@ -152,7 +152,7 @@ is scriptable and deterministic like any other Copperline run.
 
 The launcher's **WHDLoad** entry opens on the Library: the packages in
 your game folder, with their metadata and cover art, and a second list of
-favourites. **Configuration** is the other half, on the same nav row.
+favourites. **Settings...** is the other half, on the same nav row.
 
 The cover frame is one size for every game, so the writing under it starts
 on the same line each time. Amiga box art is portrait almost without
@@ -210,7 +210,7 @@ metadata editor is for.
 
 ### Signing in to OpenRetro
 
-**Log in** on the Configuration page. An account is free, and it is only
+**Log in** on the Settings page. An account is free, and it is only
 needed to sync the game database -- cover art is public.
 
 Nothing is stored. The password is traded for a token and wiped, the

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -89,8 +89,8 @@ not have, the error names the file, size, and checksum it wants.
 ## What gets staged, and where saves live
 
 Each game gets a directory in the **game library** (by default
-`whdload/` inside the per-user configuration directory, e.g.
-`~/.config/copperline/whdload/`):
+`whdload/save/` inside the per-user configuration directory, e.g.
+`~/.config/copperline/whdload/save/`):
 
 ```text
 <library>/<Game>/
@@ -240,8 +240,8 @@ release it is. Edit it in **Update** to whatever tells them apart --
 
 A game held once, with nothing typed, has no version and no row. Neither
 has one the scan could not name: a file name under a row that says
-nothing else is not the answer to which release it is. Two
-lines is what the column shows and what the field accepts.
+nothing else is not the answer to which release it is. Two lines is what
+the column shows and what the field accepts.
 
 ### Turning it off
 

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -1,7 +1,7 @@
 # WHDLoad games
 
 WHDLoad is the Amiga community's standard for running floppy games from a
-hard disk: a game is "installed" once into a directory with a `.slave`
+hard disk. A game is installed once into a directory holding a `.slave`
 loader beside its data, and the WHDLoad program boots it from AmigaOS,
 taking the machine over the way the original disk would have.
 
@@ -11,11 +11,11 @@ Copperline boots such a package directly:
 copperline --whdload "Turrican.lha"
 ```
 
-No Workbench disk, no hand-built hard-drive image, no startup-sequence of
-your own. Copperline unpacks the package (once), synthesizes a minimal
-boot volume around the real WHDLoad program, derives a suitable machine
-from the slave itself, and boots. The same launch works from a
-configuration file:
+There is no Workbench disk to prepare and no hard-drive image to build.
+Copperline unpacks the package, builds a boot volume around the WHDLoad
+program, works out a suitable machine from the package itself, and boots.
+
+The same launch works from a configuration file:
 
 ```toml
 [whdload]
@@ -23,97 +23,59 @@ game = "Turrican.lha"
 kickstarts = "/data/amiga/kickstarts"
 ```
 
-or from the launcher's **WHDLoad** page, or by dropping a package onto
-the window.
+from the launcher's **WHDLoad** page, or by dropping a package onto the
+window.
 
 ## Package formats
 
-A package is any of three things, and nothing treats them differently:
+A package can be any of three things, and they all work the same way:
 
-- an **`.lha`** archive, which is what the installers publish;
+- an **`.lha`** archive, which is what most installers produce;
 - a **`.zip`**, which is what you get when a browser packs a folder;
-- a **plain folder** holding the installed tree.
+- a **plain folder** holding an installed game.
 
-The `.slave` is what makes any of them a game, and it is searched for
-rather than assumed -- a published `.lha` has it at the archive root, a
-zip made from an unpacked one usually has it a folder or two down. Both
-work.
+Copperline finds the `.slave` wherever it sits, so an archive that keeps
+the game a folder or two down needs no unpacking first. `.lzh` is
+accepted in place of `.lha`, and `.slav` in place of `.slave`.
 
-macOS puts `__MACOSX/` and `._name` stubs in every zip it writes. One of
-those is called `._Something.Slave`, and it would otherwise be found by
-the slave search and booted instead of the real one, so they are ignored
-everywhere.
-
-`.lzh` is accepted as `.lha`, and `.slav` as `.slave`, for packages that
-have been through a filesystem with a short-name limit.
-
-Keeping the same game in two formats is a duplicate, not an error: it
-lists twice and both play, each with its own unpacked copy and its own
-saves. Delete one and press Refresh and it goes.
+The same game kept in two formats is listed twice, and both entries play.
+Each has its own unpacked copy and its own saves.
 
 ## What you need
 
-- **The game package**, in one of the three shapes above.
-- **Kickstart images, from your own collection.** These are copyrighted
-  and never ship with Copperline. Two distinct needs meet here:
-  - The emulated machine itself boots best from a Kickstart 3.1 (40.068
-    A1200) image, the canonical WHDLoad host. Without one the bundled
-    AROS ROM is used instead, and while simple slaves run, many WHDLoad
-    programs need the real Kickstart -- expect reduced compatibility.
-  - Many slaves (OCS/ECS-era games especially) additionally load a raw
-    Kickstart image at run time from `Devs:Kickstarts/` -- typically
-    Kickstart 1.3 -- and refuse to start without it.
-- **The WHDLoad support archives**, which release bundles already
-  include: the unmodified WHDLoad distribution (`WHDLoad_usr.lha`,
-  freeware since release 18.2) and the Soft-Kicker package
-  (`skick346.lha`) whose `.RTB` relocation tables accompany the raw
-  Kickstart images. Building from source, fetch them once with
-  `tools/fetch-whdload.sh`, or press **Download** on the Settings
-  page; `COPPERLINE_WHDBOOT_DIR` points at a directory holding them if
-  you keep them elsewhere.
+**Kickstart images from your own collection.** These are copyrighted and
+do not ship with Copperline. They are wanted for two separate reasons:
 
-  Set `whd_package` or `skick_package` to use your own copies instead.
-  Naming one and leaving the other unset works; the unnamed one still
-  comes from the search.
+- The emulated machine boots best from a Kickstart 3.1 (40.068 A1200)
+  image. Without one Copperline falls back to the bundled AROS ROM; simple
+  games still run, but many WHDLoad titles need the real Kickstart.
+- Many games -- OCS and ECS titles especially -- load a Kickstart image of
+  their own at run time, usually 1.3, and refuse to start without it.
 
-Kickstart images are identified by **content, not filename**: Copperline
-computes the same CRC-16 WHDLoad uses over each candidate file in the
-`kickstarts` directory, after undoing the usual dump variations
-(byte-swapped EPROM images, doubled 256 KiB dumps, Cloanto Amiga Forever
-`rom.key` encryption -- put `rom.key` in the same directory). A file
-called `KICK13.ROM` that is really Kickstart 1.2, or a 3.1 dump that is
-actually the A600 revision, is recognized for what it is and staged under
-its proper `Devs:Kickstarts/` name. If a slave demands an image you do
-not have, the error names the file, size, and checksum it wants.
+Point **Kickstart ROMs** (or `kickstarts`) at the directory holding them.
+The file names do not matter: Copperline identifies each image by its
+contents, so a file called `KICK13.ROM` that is really Kickstart 1.2 is
+recognised for what it is. Encrypted Cloanto Amiga Forever images work if
+`rom.key` sits in the same directory. If a game asks for an image you do
+not have, the error names it.
 
-## What gets staged, and where saves live
+**The WHDLoad support files.** Release builds already include them.
+Building from source, either press **Download** on the Settings page or
+run `tools/fetch-whdload.sh` once. To use copies you already have, set
+`whd_package` and `skick_package`; naming one and leaving the other unset
+is fine.
 
-Each game gets a directory in the **game library** (by default
-`whdload/save/` inside the per-user configuration directory, e.g.
-`~/.config/copperline/whdload/save/`):
+## Saves and unpacked games
 
-```text
-<library>/<Game>/
-  boot/     the synthesized boot volume (WHDBoot:), regenerated each run:
-            C/WHDLoad, S/Startup-Sequence, Devs/Kickstarts/*
-  game/     the unpacked package (WHDGame:), unpacked once, then reused
-```
+Each game gets a directory under `whdload/save/` in your configuration
+directory, for example `~/.config/copperline/whdload/save/Turrican/`.
+Everything the game writes -- savegames, high scores, its own settings --
+lands there and stays across runs.
 
-The library defaults to `whdload/save/`, beside the `whdload/support/`
-the archives live in. An installation that already has games directly
-under `whdload/` -- where this used to be -- carries on using them where
-they are, since that is where its saves are.
+Delete a game's directory to unpack it fresh. Launching a plain folder
+uses that folder directly, so its saves stay with it.
 
-Both are mounted live through the host-directory service
-([`[[filesys]]`](configuration.md)), so everything the game writes --
-savegames, highscores, configuration -- lands in `game/` on the host and
-**persists across runs**. Delete a game's `game/` directory to force a
-fresh unpack; delete a savegame file to undo a save. Passing a folder as
-the game mounts that folder itself, so saves persist there instead.
-
-The generated `Startup-Sequence` runs
-`WHDLoad <slave> Preload SplashDelay=0`. Extra WHDLoad options (see the
-WHDLoad documentation for the full set) can be appended:
+Extra WHDLoad options can be passed through:
 
 ```toml
 [whdload]
@@ -121,183 +83,130 @@ game = "Lotus2.lha"
 args = "ButtonWait NoAutoVec"
 ```
 
-## The derived machine
+See the WHDLoad documentation for the full set.
 
-The slave header declares what the installed program needs: AGA, a 68020,
-chip-memory size, expansion memory. Copperline boots every WHDLoad game
-on the canonical WHDLoad host -- an A1200 (68EC020, AGA, 2 MiB chip) with
-8 MiB of fast RAM -- which satisfies every slave requirement flag;
-OCS/ECS games run under the slave's own hardware bending exactly as they
-do on a real A1200.
+## Which machine a game boots on
 
-Anything you set explicitly wins over the derivation: a `[machine]`
-profile, `rom`, or `[memory]` sizes in the configuration (or their CLI
-equivalents such as `--model` and `--fast`) are left untouched, so
-`copperline --whdload game.lha --model A4000` boots the package on an
-A4000 instead. `machine_type = "copperline"` makes that the rule rather
-than the exception: the package boots on whatever machine the
-configuration describes.
+By default Copperline reads what the game needs from the package and boots
+it on a suitable machine -- an A1200 with 8 MiB of fast RAM, which is what
+WHDLoad games expect. OCS and ECS titles run correctly on it, as they do
+on real hardware.
 
-**Machine type** on the Settings page is the same setting. It cycles
-between `Auto` and `Copperline`, and since neither word says what it does,
-pressing it puts the answer on the status line for a few seconds:
-"WHDLoad uses the Slave file machine type...", or "WHDLoad uses the
-Copperline defined machine type...".
+Anything you set yourself wins. A `[machine]` profile, a `rom`, or
+`[memory]` sizes in your configuration are left alone, so
+`copperline --whdload game.lha --model A4000` boots the game on an A4000.
 
-Everything composes with the rest of the CLI: `--screenshot-after`,
-scripted input, save states, `--record-input` all work, so a WHDLoad game
-is scriptable and deterministic like any other Copperline run.
+**Machine type** on the Settings page chooses between the two:
+
+- **Auto** takes the machine from the game.
+- **Copperline** boots it on the machine your configuration describes.
+
+Pressing it shows which one you have chosen.
+
+Everything else about the run behaves normally: `--screenshot-after`,
+scripted input, save states and `--record-input` all work.
 
 ## The Library page
 
-The launcher's **WHDLoad** entry opens on the Library: the packages in
-your game folder, with their metadata and cover art, and a second list of
-favourites. **Settings...** is the other half, on the same nav row.
+The launcher's **WHDLoad** entry opens on the Library, which lists the
+games in your collection with their cover art and details, and keeps a
+second list of favourites.
 
-The cover frame is one size for every game, so the writing under it starts
-on the same line each time. Amiga box art is portrait almost without
-exception; the rare landscape scan is letterboxed into the frame rather
-than being stretched to fill it.
+Point **Game library** on the Settings page at the folder holding your
+games. Sub-folders are searched too, so a collection filed by letter or by
+genre works, and `.lha` files, zips and folders can be mixed together.
+Clearing this setting empties the list.
 
-Point **Game library** at a folder of packages. It is searched all the
-way down, so a collection filed by letter or by genre works, and it can
-hold `.lha` files, zips and folders mixed together. That setting is the
-whole list: clear it and there are no games, whatever `--whdload` or
-**Launch game** happens to point at.
+Three buttons control the list:
 
-Nothing scans on its own. A folder of several thousand packages takes
-long enough to read that a page which did it whenever you opened a tab
-would be a page that stalls. Three buttons say when:
+- **Refresh** re-reads the folder and picks up games you have added or
+  removed. Details already found are kept.
+- **Scan** looks up each game on [OpenRetro](https://openretro.org) and
+  fills in its name, year, publisher, developer, number of players and
+  cover art. It tells you how many entries it updated.
+- **Update** opens the details editor for the selected game.
 
-- **Refresh** re-reads the folder. Fast: it lists files and reads back
-  what the last scan resolved. Metadata already worked out is kept.
-- **Scan** resolves metadata against [OpenRetro](https://openretro.org).
-  It syncs only what has changed since last time, matches every package,
-  and fetches the cover art it does not already have. It says which of
-  three things happened -- the database was already up to date, *N*
-  entries were updated, or you are not signed in and the cached copy was
-  used.
-- **Update** opens the metadata editor for the selected game.
+Tick **Favourite** to add a game to the favourites list; **Remove** takes
+it off again. Favourites are kept per game file, so one release of a game
+can be starred without starring the others.
 
-Progress and failures appear on the status line at the bottom; the log
-has the detail. A scan can be stopped at any point and keeps what it had
-resolved, and pressing Run stops it.
+Select a game and press **Run** to play it.
 
-Either list scrolls when it holds more than it shows, by the arrows in its
-top and bottom right corners or by the arrow keys -- the same arrows the
-host-disk picker uses, each greyed at its end of the list. Held, either
-works up through five speeds, a second at each, the last of which crosses
-a few thousand games in a second or so. Letting go and pressing again
-starts from the slowest, so nudging the list by one row still does that.
+### Where the details come from
 
-### Matching
+**Scan** matches each of your games against the OpenRetro database, mostly
+by name. Collections name their files in every imaginable way, so the
+match allows for the usual differences: capitals, spaces and underscores,
+version numbers in the file name, and so on. Most games are recognised.
 
-A package is matched to a catalogue entry by the SHA-1 of its slave where
-that works, and by name otherwise. In practice OpenRetro's WHDLoad file
-lists were imported in 2015 and slaves are revised with every release, so
-almost nothing matches by digest today -- the digest is computed anyway
-because it is also how a package is recognised after it has been renamed.
+Some are not, and a few are matched to the wrong game. Use **Update** to
+correct anything the scan got wrong. Once you have edited a game's
+details, later scans leave it alone -- including after you rename the file.
 
-Name matching handles what installers and cataloguers disagree about:
-case, separators, `CamelCase`, the `_v1.5_1234` version stamp, a leading
-or trailing "The", `&` against "and", and roman numerals either way round.
-Failing an exact match it will accept a catalogue title whose words all
-appear in order in the package name, or one within 80% of it by edit
-distance. On a 2252-package library that matches 92%.
+Scanning needs an OpenRetro account, which is free. Sign in with **Log
+in** on the Settings page. Cover art does not need an account.
 
-It is best effort, and it is occasionally wrong. That is what the
-metadata editor is for.
-
-### Signing in to OpenRetro
-
-**Log in** on the Settings page. An account is free, and it is only
-needed to sync the game database -- cover art is public.
-
-Nothing is stored. The password is traded for a token and wiped, the
-token lives as long as the launcher is open, and **Log out** hands it
-back to the service. The connection is HTTPS.
-
-### The metadata editor
+### The details editor
 
 **Update** opens a dialog for the selected game: name, year, publisher,
-developer, players, and the cover art. Clicking the art picks a PNG,
-which is scaled to the size the fetched covers are. The boxes are the
-launcher's, so they are typed into the same way -- Tab or a click moves
-between them, and the caret marking where typing goes is moved with
-Left/Right, which is what amending a title one letter out needs.
+developer, players, version, and the cover art. Click the art to choose a
+PNG of your own; it is scaled to fit.
 
-**Save** marks the entry as yours, and scans leave it alone from then on
--- including after the file is renamed, because the entry is recognised
-by its slave's digest rather than its name. **Clear** empties the fields;
-saving an empty entry hands it back to the scan. **Cancel** changes
-nothing.
+**Save** keeps your changes, **Clear** empties the fields, and **Cancel**
+leaves the game as it was. Clearing a game's details and saving hands it
+back to the scan.
 
 ### Versions
 
-Collections carry the same game several times over -- `1.0`, `1.1`,
-`CD32`, a German release -- and there is no standard to how installers
-name them, so every one of them matches the same catalogue entry and the
-list shows a run of rows that read alike.
+Collections often hold the same game more than once -- different releases,
+an AGA version, a translation. These all match the same database entry, so
+after a scan they appear as identical-looking rows.
 
-**Version** is a metadata field like any other, except that the catalogue
-has no opinion about it. Where the library holds a named game under one
-title more than once, the page shows the package's own file name without
-its extension -- `.lha` against `.zip` is how it was packed, not which
-release it is. Edit it in **Update** to whatever tells them apart --
-"CD32 v1.1" -- and that is shown instead.
-
-A game held once, with nothing typed, has no version and no row. Neither
-has one the scan could not name: a file name under a row that says
-nothing else is not the answer to which release it is. Two lines is what
-the column shows and what the field accepts.
+Where that happens, Copperline fills in a **Version** for each of them
+from the file name, so you can tell them apart. Edit it in **Update** to
+something clearer -- "CD32 v1.1", say -- and that is what the page shows.
+Games your collection holds only once have no version unless you give them
+one.
 
 ### Turning it off
 
-**A/V & Emu -> Emulation -> WHDLoad** is on by default. Off, the
-navigation entry goes and the pages behind it do nothing at all: no
-database read, no cover worker, no scan.
-
-It does not stop a game booting. `--whdload` and `[whdload] game` are
-explicit instructions and still do what they say, so scripts and headless
-runs are unaffected.
+**A/V & Emu -> Emulation -> WHDLoad** removes the WHDLoad entry from the
+launcher. Games still boot from `--whdload` and from `[whdload] game`.
 
 ## Configuration reference
 
 ```toml
 [whdload]
-game = "path/to/Game.lha"   # .lha, .zip, or a folder with a .slave
+game = "path/to/Game.lha"   # .lha, .zip, or a folder holding the game
 library = "..."             # unpacked games and saves; default: <config>/whdload/save
-kickstarts = "..."          # directory scanned for Kickstart images
+kickstarts = "..."          # directory holding your Kickstart images
 args = "..."                # extra WHDLoad command-line options
 machine_type = "auto"       # or "copperline" to boot on this machine
 whd_package = "..."         # your own WHDLoad_usr.lha
 skick_package = "..."       # your own skick*.lha
 
 # Launcher only.
-enabled = true              # false removes the WHDLoad page entirely
+enabled = true              # false removes the WHDLoad page
 games = "..."               # the folder the Library page lists
 library_db = "..."          # default: <config>/whdload/support/launcher.db
 library_cache = "..."       # default: <config>/whdload/support/cache
 ```
 
-When `kickstarts` is not set, the directory of an explicit `rom` and
-`<library>/Kickstarts` are scanned, and a `Kickstarts/` directory next to
-the support archives is always tried last.
+With `kickstarts` unset, Copperline looks beside an explicit `rom`, in
+`<library>/Kickstarts`, and finally beside the support files.
 
-`library_db` is the scanned library: one entry a package, with the
-metadata resolved for it. `library_cache` is what a scan downloaded --
-the snapshot of the online database, and the cover art. Deleting the
-cache costs a download; deleting the library costs a scan.
+`library_db` holds your library: one entry per game, with its details,
+your favourites and any edits you have made. `library_cache` holds what a
+scan downloaded. The cache can be deleted at any time and is rebuilt by
+the next scan; deleting the library loses your favourites and edits.
 
 ## Notes and limitations
 
-- The boot volume runs the real WHDLoad, so WHDLoad's own behaviour
-  applies: its splash window appears briefly, its quit key (default
-  `*` on the numeric pad, or as the slave defines) exits back to the
-  boot shell.
-- Cover art you supply must be a PNG. Copperline carries no JPEG decoder.
-- Per-game tuning beyond the slave header (a title that wants NTSC, or
-  custom controls) is what `args` and the explicit machine overrides are
-  for; Copperline does not ship a per-game settings database.
-- One game boots per run: `--whdload` builds the machine around the
-  package.
+- The boot volume runs the real WHDLoad, so its own behaviour applies: the
+  splash window appears briefly, and its quit key (`*` on the numeric pad
+  unless the game says otherwise) exits back to the boot shell.
+- Cover art you supply must be a PNG.
+- Copperline has no per-game settings database. A game that wants
+  something unusual -- NTSC timing, particular controls -- is handled with
+  `args` and the machine settings.
+- One game boots per run.

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -99,6 +99,11 @@ Each game gets a directory in the **game library** (by default
   game/     the unpacked package (WHDGame:), unpacked once, then reused
 ```
 
+The library defaults to `whdload/save/`, beside the `whdload/support/`
+the archives live in. An installation that already has games directly
+under `whdload/` -- where this used to be -- carries on using them where
+they are, since that is where its saves are.
+
 Both are mounted live through the host-directory service
 ([`[[filesys]]`](configuration.md)), so everything the game writes --
 savegames, highscores, configuration -- lands in `game/` on the host and
@@ -209,6 +214,25 @@ by its slave's digest rather than its name. **Clear** empties the fields;
 saving an empty entry hands it back to the scan. **Cancel** changes
 nothing.
 
+### Versions
+
+Collections carry the same game several times over -- `1.0`, `1.1`,
+`CD32`, a German release -- and there is no standard to how installers
+name them, so every one of them matches the same catalogue entry and the
+list shows a run of rows that read alike.
+
+**Version** is a metadata field like any other, except that the catalogue
+has no opinion about it. Where the library holds a named game under one
+title more than once, the page shows the package's own file name without
+its extension -- `.lha` against `.zip` is how it was packed, not which
+release it is. Edit it in **Update** to whatever tells them apart --
+"CD32 v1.1" -- and that is shown instead.
+
+A game held once, with nothing typed, has no version and no row. Neither
+has one the scan could not name: a file name under a row that says
+nothing else is not the answer to which release it is. Two
+lines is what the column shows and what the field accepts.
+
 ### Turning it off
 
 **A/V & Emu -> Emulation -> WHDLoad** is on by default. Off, the
@@ -224,7 +248,7 @@ runs are unaffected.
 ```toml
 [whdload]
 game = "path/to/Game.lha"   # .lha, .zip, or a folder with a .slave
-library = "..."             # game library; default: <config dir>/whdload
+library = "..."             # unpacked games and saves; default: <config>/whdload/save
 kickstarts = "..."          # directory scanned for Kickstart images
 args = "..."                # extra WHDLoad command-line options
 machine_type = "auto"       # or "copperline" to boot on this machine

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -140,9 +140,9 @@ configuration describes.
 
 **Machine type** on the Configuration page is the same setting. It cycles
 between `Auto` and `Copperline`, and since neither word says what it does,
-pressing it puts the answer on the status line for a few seconds: "WHDLoad
-uses the Slave file machine type", or "WHDLoad uses the Copperline defined
-machine type".
+pressing it puts the answer on the status line for a few seconds:
+"WHDLoad uses the Slave file machine type...", or "WHDLoad uses the
+Copperline defined machine type...".
 
 Everything composes with the rest of the CLI: `--screenshot-after`,
 scripted input, save states, `--record-input` all work, so a WHDLoad game
@@ -221,7 +221,7 @@ back to the service. The connection is HTTPS.
 developer, players, and the cover art. Clicking the art picks a PNG,
 which is scaled to the size the fetched covers are. The boxes are the
 launcher's, so they are typed into the same way -- Tab or a click moves
-between them, and the block marking where typing goes is moved with
+between them, and the caret marking where typing goes is moved with
 Left/Right, which is what amending a title one letter out needs.
 
 **Save** marks the entry as yours, and scans leave it alone from then on

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -175,6 +175,13 @@ Progress and failures appear on the status line at the bottom; the log
 has the detail. A scan can be stopped at any point and keeps what it had
 resolved, and pressing Run stops it.
 
+Either list scrolls when it holds more than it shows, by the arrows in its
+top and bottom right corners or by the arrow keys -- the same arrows the
+host-disk picker uses, each greyed at its end of the list. Held, either
+works up through five speeds, a second at each, the last of which crosses
+a few thousand games in a second or so. Letting go and pressing again
+starts from the slowest, so nudging the list by one row still does that.
+
 ### Matching
 
 A package is matched to a catalogue entry by the SHA-1 of its slave where
@@ -206,7 +213,10 @@ back to the service. The connection is HTTPS.
 
 **Update** opens a dialog for the selected game: name, year, publisher,
 developer, players, and the cover art. Clicking the art picks a PNG,
-which is scaled to the size the fetched covers are.
+which is scaled to the size the fetched covers are. The boxes are the
+launcher's, so they are typed into the same way -- Tab or a click moves
+between them, and the block marking where typing goes is moved with
+Left/Right, which is what amending a title one letter out needs.
 
 **Save** marks the entry as yours, and scans leave it alone from then on
 -- including after the file is renamed, because the entry is recognised

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -161,7 +161,9 @@ than being stretched to fill it.
 
 Point **Game library** at a folder of packages. It is searched all the
 way down, so a collection filed by letter or by genre works, and it can
-hold `.lha` files, zips and folders mixed together.
+hold `.lha` files, zips and folders mixed together. That setting is the
+whole list: clear it and there are no games, whatever `--whdload` or
+**Launch game** happens to point at.
 
 Nothing scans on its own. A folder of several thousand packages takes
 long enough to read that a page which did it whenever you opened a tab

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -138,6 +138,12 @@ A4000 instead. `machine_type = "copperline"` makes that the rule rather
 than the exception: the package boots on whatever machine the
 configuration describes.
 
+**Machine type** on the Configuration page is the same setting. It cycles
+between `Auto` and `Copperline`, and since neither word says what it does,
+pressing it puts the answer on the status line for a few seconds: "WHDLoad
+uses the Slave file machine type", or "WHDLoad uses the Copperline defined
+machine type".
+
 Everything composes with the rest of the CLI: `--screenshot-after`,
 scripted input, save states, `--record-input` all work, so a WHDLoad game
 is scriptable and deterministic like any other Copperline run.

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -3,8 +3,7 @@
 WHDLoad is the Amiga community's standard for running floppy games from a
 hard disk: a game is "installed" once into a directory with a `.slave`
 loader beside its data, and the WHDLoad program boots it from AmigaOS,
-taking the machine over the way the original disk would have. Installed
-games travel as `.lha` archives.
+taking the machine over the way the original disk would have.
 
 Copperline boots such a package directly:
 
@@ -13,7 +12,7 @@ copperline --whdload "Turrican.lha"
 ```
 
 No Workbench disk, no hand-built hard-drive image, no startup-sequence of
-your own. Copperline extracts the archive (once), synthesizes a minimal
+your own. Copperline unpacks the package (once), synthesizes a minimal
 boot volume around the real WHDLoad program, derives a suitable machine
 from the slave itself, and boots. The same launch works from a
 configuration file:
@@ -24,14 +23,37 @@ game = "Turrican.lha"
 kickstarts = "/data/amiga/kickstarts"
 ```
 
-or from the launcher's **Storage -> WHDLoad** page, or by dropping a
-`.lha` file onto the window.
+or from the launcher's **WHDLoad** page, or by dropping a package onto
+the window.
+
+## Package formats
+
+A package is any of three things, and nothing treats them differently:
+
+- an **`.lha`** archive, which is what the installers publish;
+- a **`.zip`**, which is what you get when a browser packs a folder;
+- a **plain folder** holding the installed tree.
+
+The `.slave` is what makes any of them a game, and it is searched for
+rather than assumed -- a published `.lha` has it at the archive root, a
+zip made from an unpacked one usually has it a folder or two down. Both
+work.
+
+macOS puts `__MACOSX/` and `._name` stubs in every zip it writes. One of
+those is called `._Something.Slave`, and it would otherwise be found by
+the slave search and booted instead of the real one, so they are ignored
+everywhere.
+
+`.lzh` is accepted as `.lha`, and `.slav` as `.slave`, for packages that
+have been through a filesystem with a short-name limit.
+
+Keeping the same game in two formats is a duplicate, not an error: it
+lists twice and both play, each with its own unpacked copy and its own
+saves. Delete one and press Refresh and it goes.
 
 ## What you need
 
-- **The game package**: an `.lha` archive holding a `.slave` file and the
-  game data (the shape every WHDLoad install produces). A directory
-  containing the same tree also works and is mounted in place.
+- **The game package**, in one of the three shapes above.
 - **Kickstart images, from your own collection.** These are copyrighted
   and never ship with Copperline. Two distinct needs meet here:
   - The emulated machine itself boots best from a Kickstart 3.1 (40.068
@@ -46,8 +68,13 @@ or from the launcher's **Storage -> WHDLoad** page, or by dropping a
   freeware since release 18.2) and the Soft-Kicker package
   (`skick346.lha`) whose `.RTB` relocation tables accompany the raw
   Kickstart images. Building from source, fetch them once with
-  `tools/fetch-whdload.sh`; `COPPERLINE_WHDBOOT_DIR` points at a
-  directory holding them if you keep them elsewhere.
+  `tools/fetch-whdload.sh`, or press **Download** on the Configuration
+  page; `COPPERLINE_WHDBOOT_DIR` points at a directory holding them if
+  you keep them elsewhere.
+
+  Set `whd_package` or `skick_package` to use your own copies instead.
+  Naming one and leaving the other unset works; the unnamed one still
+  comes from the search.
 
 Kickstart images are identified by **content, not filename**: Copperline
 computes the same CRC-16 WHDLoad uses over each candidate file in the
@@ -69,16 +96,15 @@ Each game gets a directory in the **game library** (by default
 <library>/<Game>/
   boot/     the synthesized boot volume (WHDBoot:), regenerated each run:
             C/WHDLoad, S/Startup-Sequence, Devs/Kickstarts/*
-  game/     the extracted package (WHDGame:), extracted once, then reused
+  game/     the unpacked package (WHDGame:), unpacked once, then reused
 ```
 
 Both are mounted live through the host-directory service
 ([`[[filesys]]`](configuration.md)), so everything the game writes --
 savegames, highscores, configuration -- lands in `game/` on the host and
 **persists across runs**. Delete a game's `game/` directory to force a
-fresh extraction; delete a savegame file to undo a save. Passing a
-directory as the game mounts that directory itself, so saves persist
-there instead.
+fresh unpack; delete a savegame file to undo a save. Passing a folder as
+the game mounts that folder itself, so saves persist there instead.
 
 The generated `Startup-Sequence` runs
 `WHDLoad <slave> Preload SplashDelay=0`. Extra WHDLoad options (see the
@@ -103,25 +129,123 @@ Anything you set explicitly wins over the derivation: a `[machine]`
 profile, `rom`, or `[memory]` sizes in the configuration (or their CLI
 equivalents such as `--model` and `--fast`) are left untouched, so
 `copperline --whdload game.lha --model A4000` boots the package on an
-A4000 instead.
+A4000 instead. `machine_type = "copperline"` makes that the rule rather
+than the exception: the package boots on whatever machine the
+configuration describes.
 
 Everything composes with the rest of the CLI: `--screenshot-after`,
 scripted input, save states, `--record-input` all work, so a WHDLoad game
 is scriptable and deterministic like any other Copperline run.
 
+## The Library page
+
+The launcher's **WHDLoad** entry opens on the Library: the packages in
+your game folder, with their metadata and cover art, and a second list of
+favourites. **Configuration** is the other half, on the same nav row.
+
+The cover frame is one size for every game, so the writing under it starts
+on the same line each time. Amiga box art is portrait almost without
+exception; the rare landscape scan is letterboxed into the frame rather
+than being stretched to fill it.
+
+Point **Game library** at a folder of packages. It is searched all the
+way down, so a collection filed by letter or by genre works, and it can
+hold `.lha` files, zips and folders mixed together.
+
+Nothing scans on its own. A folder of several thousand packages takes
+long enough to read that a page which did it whenever you opened a tab
+would be a page that stalls. Three buttons say when:
+
+- **Refresh** re-reads the folder. Fast: it lists files and reads back
+  what the last scan resolved. Metadata already worked out is kept.
+- **Scan** resolves metadata against [OpenRetro](https://openretro.org).
+  It syncs only what has changed since last time, matches every package,
+  and fetches the cover art it does not already have. It says which of
+  three things happened -- the database was already up to date, *N*
+  entries were updated, or you are not signed in and the cached copy was
+  used.
+- **Update** opens the metadata editor for the selected game.
+
+Progress and failures appear on the status line at the bottom; the log
+has the detail. A scan can be stopped at any point and keeps what it had
+resolved, and pressing Run stops it.
+
+### Matching
+
+A package is matched to a catalogue entry by the SHA-1 of its slave where
+that works, and by name otherwise. In practice OpenRetro's WHDLoad file
+lists were imported in 2015 and slaves are revised with every release, so
+almost nothing matches by digest today -- the digest is computed anyway
+because it is also how a package is recognised after it has been renamed.
+
+Name matching handles what installers and cataloguers disagree about:
+case, separators, `CamelCase`, the `_v1.5_1234` version stamp, a leading
+or trailing "The", `&` against "and", and roman numerals either way round.
+Failing an exact match it will accept a catalogue title whose words all
+appear in order in the package name, or one within 80% of it by edit
+distance. On a 2252-package library that matches 92%.
+
+It is best effort, and it is occasionally wrong. That is what the
+metadata editor is for.
+
+### Signing in to OpenRetro
+
+**Log in** on the Configuration page. An account is free, and it is only
+needed to sync the game database -- cover art is public.
+
+Nothing is stored. The password is traded for a token and wiped, the
+token lives as long as the launcher is open, and **Log out** hands it
+back to the service. The connection is HTTPS.
+
+### The metadata editor
+
+**Update** opens a dialog for the selected game: name, year, publisher,
+developer, players, and the cover art. Clicking the art picks a PNG,
+which is scaled to the size the fetched covers are.
+
+**Save** marks the entry as yours, and scans leave it alone from then on
+-- including after the file is renamed, because the entry is recognised
+by its slave's digest rather than its name. **Clear** empties the fields;
+saving an empty entry hands it back to the scan. **Cancel** changes
+nothing.
+
+### Turning it off
+
+**A/V & Emu -> Emulation -> WHDLoad** is on by default. Off, the
+navigation entry goes and the pages behind it do nothing at all: no
+database read, no cover worker, no scan.
+
+It does not stop a game booting. `--whdload` and `[whdload] game` are
+explicit instructions and still do what they say, so scripts and headless
+runs are unaffected.
+
 ## Configuration reference
 
 ```toml
 [whdload]
-game = "path/to/Game.lha"   # .lha archive or directory with a .slave
+game = "path/to/Game.lha"   # .lha, .zip, or a folder with a .slave
 library = "..."             # game library; default: <config dir>/whdload
 kickstarts = "..."          # directory scanned for Kickstart images
 args = "..."                # extra WHDLoad command-line options
+machine_type = "auto"       # or "copperline" to boot on this machine
+whd_package = "..."         # your own WHDLoad_usr.lha
+skick_package = "..."       # your own skick*.lha
+
+# Launcher only.
+enabled = true              # false removes the WHDLoad page entirely
+games = "..."               # the folder the Library page lists
+library_db = "..."          # default: <config>/whdload/support/launcher.db
+library_cache = "..."       # default: <config>/whdload/support/cache
 ```
 
 When `kickstarts` is not set, the directory of an explicit `rom` and
 `<library>/Kickstarts` are scanned, and a `Kickstarts/` directory next to
 the support archives is always tried last.
+
+`library_db` is the scanned library: one entry a package, with the
+metadata resolved for it. `library_cache` is what a scan downloaded --
+the snapshot of the online database, and the cover art. Deleting the
+cache costs a download; deleting the library costs a scan.
 
 ## Notes and limitations
 
@@ -129,9 +253,9 @@ the support archives is always tried last.
   applies: its splash window appears briefly, its quit key (default
   `*` on the numeric pad, or as the slave defines) exits back to the
   boot shell.
+- Cover art you supply must be a PNG. Copperline carries no JPEG decoder.
 - Per-game tuning beyond the slave header (a title that wants NTSC, or
   custom controls) is what `args` and the explicit machine overrides are
   for; Copperline does not ship a per-game settings database.
 - One game boots per run: `--whdload` builds the machine around the
-  package. To browse a collection, keep packages in a directory and pick
-  from the launcher.
+  package.

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -352,6 +352,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
+        "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+        "dest": "cargo/vendor/base64-0.22.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.22.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64ct/base64ct-1.8.3.crate",
+        "sha256": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06",
+        "dest": "cargo/vendor/base64ct-1.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06\", \"files\": {}}",
+        "dest": "cargo/vendor/base64ct-1.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bincode/bincode-1.3.3.crate",
         "sha256": "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad",
         "dest": "cargo/vendor/bincode-1.3.3"
@@ -1392,6 +1418,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/der/der-0.8.1.crate",
+        "sha256": "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d",
+        "dest": "cargo/vendor/der-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d\", \"files\": {}}",
+        "dest": "cargo/vendor/der-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dispatch/dispatch-0.2.0.crate",
         "sha256": "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b",
         "dest": "cargo/vendor/dispatch-0.2.0"
@@ -1613,6 +1652,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fastrand/fastrand-2.5.0.crate",
+        "sha256": "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223",
+        "dest": "cargo/vendor/fastrand-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223\", \"files\": {}}",
+        "dest": "cargo/vendor/fastrand-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.7.crate",
         "sha256": "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c",
         "dest": "cargo/vendor/fdeflate-0.3.7"
@@ -1722,6 +1774,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.3.2.crate",
+        "sha256": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
+        "dest": "cargo/vendor/foreign-types-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
         "sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
         "dest": "cargo/vendor/foreign-types-0.5.0"
@@ -1743,6 +1808,19 @@
         "type": "inline",
         "contents": "{\"package\": \"ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225\", \"files\": {}}",
         "dest": "cargo/vendor/foreign-types-macros-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.1.1.crate",
+        "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1808,6 +1886,19 @@
         "type": "inline",
         "contents": "{\"package\": \"1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8\", \"files\": {}}",
         "dest": "cargo/vendor/gethostname-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.17.crate",
+        "sha256": "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0",
+        "dest": "cargo/vendor/getrandom-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2107,6 +2198,32 @@
         "type": "inline",
         "contents": "{\"package\": \"62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f\", \"files\": {}}",
         "dest": "cargo/vendor/hound-3.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http/http-1.5.0.crate",
+        "sha256": "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0",
+        "dest": "cargo/vendor/http-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0\", \"files\": {}}",
+        "dest": "cargo/vendor/http-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/httparse/httparse-1.10.1.crate",
+        "sha256": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87",
+        "dest": "cargo/vendor/httparse-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87\", \"files\": {}}",
+        "dest": "cargo/vendor/httparse-1.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2715,6 +2832,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/native-tls/native-tls-0.2.18.crate",
+        "sha256": "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2",
+        "dest": "cargo/vendor/native-tls-0.2.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2\", \"files\": {}}",
+        "dest": "cargo/vendor/native-tls-0.2.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ndk/ndk-0.8.0.crate",
         "sha256": "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7",
         "dest": "cargo/vendor/ndk-0.8.0"
@@ -3287,6 +3417,58 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl/openssl-0.10.81.crate",
+        "sha256": "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45",
+        "dest": "cargo/vendor/openssl-0.10.81"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-0.10.81",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-macros/openssl-macros-0.1.1.crate",
+        "sha256": "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c",
+        "dest": "cargo/vendor/openssl-macros-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-macros-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.2.1.crate",
+        "sha256": "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe",
+        "dest": "cargo/vendor/openssl-probe-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-probe-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.117.crate",
+        "sha256": "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695",
+        "dest": "cargo/vendor/openssl-sys-0.9.117"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-sys-0.9.117",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/orbclient/orbclient-0.3.55.crate",
         "sha256": "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747",
         "dest": "cargo/vendor/orbclient-0.3.55"
@@ -3373,6 +3555,19 @@
         "type": "inline",
         "contents": "{\"package\": \"bbd2eecc2ddc671ec563b5b39f846556aade68a65d1afb14d8fe6b30b0457d75\", \"files\": {}}",
         "dest": "cargo/vendor/pcap-2.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pem-rfc7468/pem-rfc7468-1.0.0.crate",
+        "sha256": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9",
+        "dest": "cargo/vendor/pem-rfc7468-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9\", \"files\": {}}",
+        "dest": "cargo/vendor/pem-rfc7468-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3872,6 +4067,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ring/ring-0.17.14.crate",
+        "sha256": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7",
+        "dest": "cargo/vendor/ring-0.17.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7\", \"files\": {}}",
+        "dest": "cargo/vendor/ring-0.17.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ringbuf/ringbuf-0.4.8.crate",
         "sha256": "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c",
         "dest": "cargo/vendor/ringbuf-0.4.8"
@@ -3950,6 +4158,45 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls/rustls-0.23.43.crate",
+        "sha256": "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06",
+        "dest": "cargo/vendor/rustls-0.23.43"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-0.23.43",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.15.1.crate",
+        "sha256": "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96",
+        "dest": "cargo/vendor/rustls-pki-types-1.15.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-pki-types-1.15.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.103.13.crate",
+        "sha256": "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e",
+        "dest": "cargo/vendor/rustls-webpki-0.103.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-webpki-0.103.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.23.crate",
         "sha256": "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f",
         "dest": "cargo/vendor/rustversion-1.0.23"
@@ -4002,6 +4249,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schannel/schannel-0.1.29.crate",
+        "sha256": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939",
+        "dest": "cargo/vendor/schannel-0.1.29"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939\", \"files\": {}}",
+        "dest": "cargo/vendor/schannel-0.1.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.1.crate",
         "sha256": "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294",
         "dest": "cargo/vendor/scoped-tls-1.0.1"
@@ -4036,6 +4296,32 @@
         "type": "inline",
         "contents": "{\"package\": \"b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec\", \"files\": {}}",
         "dest": "cargo/vendor/sctk-adwaita-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework/security-framework-3.7.0.crate",
+        "sha256": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d",
+        "dest": "cargo/vendor/security-framework-3.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-3.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.17.0.crate",
+        "sha256": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3",
+        "dest": "cargo/vendor/security-framework-sys-2.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-sys-2.17.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4353,6 +4639,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/subtle/subtle-2.6.1.crate",
+        "sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292",
+        "dest": "cargo/vendor/subtle-2.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
+        "dest": "cargo/vendor/subtle-2.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/syn/syn-2.0.119.crate",
         "sha256": "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297",
         "dest": "cargo/vendor/syn-2.0.119"
@@ -4387,6 +4686,19 @@
         "type": "inline",
         "contents": "{\"package\": \"adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca\", \"files\": {}}",
         "dest": "cargo/vendor/target-lexicon-0.13.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tempfile/tempfile-3.27.0.crate",
+        "sha256": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd",
+        "dest": "cargo/vendor/tempfile-3.27.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\", \"files\": {}}",
+        "dest": "cargo/vendor/tempfile-3.27.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4665,6 +4977,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/typed-path/typed-path-0.12.3.crate",
+        "sha256": "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e",
+        "dest": "cargo/vendor/typed-path-0.12.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e\", \"files\": {}}",
+        "dest": "cargo/vendor/typed-path-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ultraviolet/ultraviolet-0.10.0.crate",
         "sha256": "ea519dad475ee0446b8172793c3c327e4fc81dafdaf05aaac510e630000b6296",
         "dest": "cargo/vendor/ultraviolet-0.10.0"
@@ -4730,6 +5055,58 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/untrusted/untrusted-0.9.0.crate",
+        "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+        "dest": "cargo/vendor/untrusted-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1\", \"files\": {}}",
+        "dest": "cargo/vendor/untrusted-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ureq/ureq-3.3.0.crate",
+        "sha256": "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0",
+        "dest": "cargo/vendor/ureq-3.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0\", \"files\": {}}",
+        "dest": "cargo/vendor/ureq-3.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ureq-proto/ureq-proto-0.6.0.crate",
+        "sha256": "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c",
+        "dest": "cargo/vendor/ureq-proto-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c\", \"files\": {}}",
+        "dest": "cargo/vendor/ureq-proto-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8-zero/utf8-zero-0.8.1.crate",
+        "sha256": "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e",
+        "dest": "cargo/vendor/utf8-zero-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8-zero-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.2.crate",
         "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
         "dest": "cargo/vendor/utf8parse-0.2.2"
@@ -4751,6 +5128,19 @@
         "type": "inline",
         "contents": "{\"package\": \"bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239\", \"files\": {}}",
         "dest": "cargo/vendor/uuid-1.24.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vcpkg/vcpkg-0.2.15.crate",
+        "sha256": "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426",
+        "dest": "cargo/vendor/vcpkg-0.2.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426\", \"files\": {}}",
+        "dest": "cargo/vendor/vcpkg-0.2.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4790,6 +5180,19 @@
         "type": "inline",
         "contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
         "dest": "cargo/vendor/walkdir-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasi/wasi-0.11.1+wasi-snapshot-preview1.crate",
+        "sha256": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b",
+        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5271,6 +5674,32 @@
         "type": "inline",
         "contents": "{\"package\": \"5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb\", \"files\": {}}",
         "dest": "cargo/vendor/web-time-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webpki-root-certs/webpki-root-certs-1.0.9.crate",
+        "sha256": "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b",
+        "dest": "cargo/vendor/webpki-root-certs-1.0.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b\", \"files\": {}}",
+        "dest": "cargo/vendor/webpki-root-certs-1.0.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-1.0.9.crate",
+        "sha256": "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a",
+        "dest": "cargo/vendor/webpki-roots-1.0.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a\", \"files\": {}}",
+        "dest": "cargo/vendor/webpki-roots-1.0.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6303,6 +6732,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zeroize/zeroize-1.9.0.crate",
+        "sha256": "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e",
+        "dest": "cargo/vendor/zeroize-1.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e\", \"files\": {}}",
+        "dest": "cargo/vendor/zeroize-1.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zip/zip-8.6.0.crate",
+        "sha256": "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b",
+        "dest": "cargo/vendor/zip-8.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b\", \"files\": {}}",
+        "dest": "cargo/vendor/zip-8.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/zlib-rs/zlib-rs-0.6.7.crate",
         "sha256": "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12",
         "dest": "cargo/vendor/zlib-rs-0.6.7"
@@ -6324,6 +6779,19 @@
         "type": "inline",
         "contents": "{\"package\": \"29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b\", \"files\": {}}",
         "dest": "cargo/vendor/zmij-1.0.23",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zopfli/zopfli-0.8.3.crate",
+        "sha256": "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249",
+        "dest": "cargo/vendor/zopfli-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249\", \"files\": {}}",
+        "dest": "cargo/vendor/zopfli-0.8.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2862,11 +2862,17 @@ pub(crate) struct RawWhdload {
     /// `--whdload` overrides it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) game: Option<String>,
-    /// Game library directory (extracted packages, their saves, and the
-    /// staged boot volumes); defaults to `whdload/` in the per-user
-    /// configuration directory.
+    /// Where extracted packages, their saves and the staged boot volumes
+    /// live; defaults to `whdload/` in the per-user configuration
+    /// directory. The launcher calls it the save directory, which is the
+    /// part of it a person cares about.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) library: Option<String>,
+    /// A directory of WHDLoad packages, searched for games to list. Unlike
+    /// `game` -- one package -- this is a collection, and the launcher's
+    /// Library page lists what is in it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) games: Option<String>,
     /// Directory scanned for Kickstart images to stage into
     /// `Devs:Kickstarts/` (and to boot the machine from). When unset, the
     /// directory of an explicit `rom` and `<library>/Kickstarts` are tried.
@@ -2875,6 +2881,65 @@ pub(crate) struct RawWhdload {
     /// Extra options appended to the generated WHDLoad command line.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) args: Option<String>,
+    /// The WHDLoad distribution archive (`WHDLoad_usr.lha`). When unset the
+    /// copy bundled with the release is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) whd_package: Option<String>,
+    /// The Soft-Kicker archive (`skick*.lha`), whose `.RTB` relocation
+    /// tables accompany raw Kickstart images. When unset the bundled copy
+    /// is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) skick_package: Option<String>,
+    /// Which machine a package boots on: `auto` derives one from the slave
+    /// header, `copperline` uses the machine this configuration describes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) machine_type: Option<WhdloadMachine>,
+    /// Where the scanned library is written: one entry a game, with the
+    /// metadata a scan resolved for it. Defaults to `whdload/library/db.json`
+    /// in the per-user configuration directory.
+    ///
+    /// Configuration-file only, deliberately: it and `library_cache` say
+    /// where the Library page keeps its own working files, which is not
+    /// part of describing a machine and so has no row in the launcher.
+    /// Parsed and ignored in a build without the `game-library` feature, so
+    /// a configuration written by a full build still loads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) library_db: Option<String>,
+    /// Where a scan keeps what it downloaded -- cover art, and the snapshot
+    /// of the online database it matched against. Defaults to
+    /// `whdload/library/cache`. Throwing it away costs a re-download and
+    /// nothing else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) library_cache: Option<String>,
+    /// Whether the launcher offers WHDLoad at all: its entry in the
+    /// left-hand navigation, the Library and Configuration pages behind
+    /// it, and the work those do. Defaults to on.
+    ///
+    /// Off, the launcher does none of it -- no entry, no pages, no game
+    /// database read, no cover worker, no scan. It does not stop a game
+    /// booting: `--whdload` and `[whdload] game` are explicit instructions
+    /// and still do what they say, so scripts and headless runs are
+    /// unaffected.
+    ///
+    /// Library-only, and ignored as the `library_*` keys are without the
+    /// feature.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) enabled: Option<bool>,
+}
+
+/// Which machine a WHDLoad package boots on.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WhdloadMachine {
+    /// Derive it from the slave header: the canonical WHDLoad host, an
+    /// A1200 with 8 MiB of fast RAM, which satisfies every slave flag.
+    #[default]
+    Auto,
+    /// Boot the package on the machine this configuration describes,
+    /// whatever that is. An explicit `[machine]`, `rom` or `[memory]` wins
+    /// under `auto` too; this makes the whole machine the choice rather
+    /// than the parts that were named.
+    Copperline,
 }
 
 /// One `[[filesys]]` entry (experimental): a host directory exported to the

--- a/src/gamelib/cover.rs
+++ b/src/gamelib/cover.rs
@@ -1,0 +1,601 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Cover art, read from the cache a scan filled.
+//!
+//! Nothing here touches the network. A scan downloads the art for the
+//! games in the library -- only for those, since a full catalogue is a few
+//! thousand games and almost all of that would be artwork for games nobody
+//! has -- and this reads what it left behind. Putting a download in the
+//! middle of scrolling a list is how a list becomes slow, and it would
+//! also mean the page behaved differently online and off.
+//!
+//! The reading happens on a worker thread, so nothing here blocks the
+//! launcher: [`Covers::want_around`] says which digests are wanted, and
+//! the pictures appear on a later frame.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, Condvar, Mutex};
+
+/// A decoded cover, ready to draw.
+#[derive(Debug, Clone)]
+pub struct Image {
+    pub width: usize,
+    pub height: usize,
+    /// Straight RGBA, as the panel draws.
+    pub pixels: Vec<u8>,
+}
+
+/// What became of one request, so a game with no art is not asked about
+/// again every frame.
+#[derive(Debug)]
+enum Held {
+    /// On its way.
+    Wanted,
+    /// Here.
+    Have(Image),
+    /// Asked, and there is none -- or it could not be read. Remembered so
+    /// the request is made once rather than on every redraw.
+    None,
+}
+
+/// The covers this session has asked for.
+///
+/// One worker serves them all, newest request first. A thread per request
+/// looked simpler until the arrow keys started repeating: holding one
+/// through a long list asks for a hundred covers in a second, and a
+/// hundred threads racing for the network is slower at delivering the one
+/// you stopped on than a single worker that serves it first.
+pub struct Covers {
+    held: HashMap<String, Held>,
+    /// Insertion order, for capping how much decoded art is kept.
+    order: std::collections::VecDeque<String>,
+    dir: PathBuf,
+    queue: Arc<Queue>,
+    rx: Receiver<(String, Option<Image>)>,
+}
+
+/// How many decoded covers are kept. Only one is ever drawn; the rest are
+/// there so walking back up a list is instant. At a quarter of a megabyte
+/// each this is a few tens of megabytes, which is the right order for a
+/// convenience.
+const KEEP: usize = 96;
+
+/// How far either side of the selection to fetch ahead. Enough that a
+/// steady scroll finds the next one already decoded, small enough that a
+/// fast one does not queue work nobody will look at.
+const AHEAD: usize = 3;
+
+/// How many requests the queue holds. Exactly what one [`Covers::want_around`]
+/// asks for -- the selection and `AHEAD` either side -- and no more: a list
+/// scrolled past leaves a trail of requests nobody is waiting for, and
+/// serving that trail is time taken from what is on screen now.
+const QUEUE_DEPTH: usize = 2 * AHEAD + 1;
+
+/// The work waiting, newest first, and whether anyone is still asking.
+struct Queue {
+    pending: Mutex<Pending>,
+    woken: Condvar,
+}
+
+#[derive(Default)]
+struct Pending {
+    wanted: Vec<String>,
+    /// Cleared when the [`Covers`] that owns this goes away. The worker
+    /// spends its life parked on the condvar waiting for work, so without
+    /// something to wake it and tell it to stop it would park there for
+    /// the life of the process.
+    open: bool,
+}
+
+impl Queue {
+    /// Put one at the front of the queue, which is the back of the vector:
+    /// the worker pops from there, so the most recent ask is served first.
+    fn push(&self, sha1: String) {
+        let Ok(mut pending) = self.pending.lock() else {
+            return;
+        };
+        if !pending.open {
+            return;
+        }
+        pending.wanted.retain(|held| held != &sha1);
+        pending.wanted.push(sha1);
+        let over = pending.wanted.len().saturating_sub(QUEUE_DEPTH);
+        pending.wanted.drain(..over);
+        self.woken.notify_one();
+    }
+
+    /// Wait for work and take the newest. `None` once nobody is waiting for
+    /// an answer, which is the worker's cue to stop.
+    fn take(&self) -> Option<String> {
+        let mut pending = self.pending.lock().ok()?;
+        loop {
+            if !pending.open {
+                return None;
+            }
+            if let Some(next) = pending.wanted.pop() {
+                return Some(next);
+            }
+            pending = self.woken.wait(pending).ok()?;
+        }
+    }
+
+    /// Say that nothing more will be asked for, and wake the worker to
+    /// notice.
+    fn close(&self) {
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.open = false;
+            pending.wanted.clear();
+        }
+        self.woken.notify_all();
+    }
+}
+
+impl std::fmt::Debug for Covers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Covers")
+            .field("held", &self.held.len())
+            .field("dir", &self.dir)
+            .finish()
+    }
+}
+
+impl Clone for Covers {
+    /// A fresh set sharing nothing: the queue and the channel belong to the
+    /// requests in flight, and a clone has none.
+    fn clone(&self) -> Self {
+        Covers::new(self.dir.clone())
+    }
+}
+
+impl Default for Covers {
+    fn default() -> Self {
+        Covers::new(PathBuf::new())
+    }
+}
+
+impl Drop for Covers {
+    /// Let the worker go. It is parked waiting for a request that will
+    /// never come now, and a launcher opened and closed a few times should
+    /// not leave a thread behind each time.
+    fn drop(&mut self) {
+        self.queue.close();
+    }
+}
+
+impl Covers {
+    pub fn new(dir: PathBuf) -> Covers {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let queue = Arc::new(Queue {
+            pending: Mutex::new(Pending {
+                wanted: Vec::new(),
+                open: true,
+            }),
+            woken: Condvar::new(),
+        });
+        let work = Arc::clone(&queue);
+        let at = dir.clone();
+        std::thread::spawn(move || {
+            while let Some(sha1) = work.take() {
+                let image = read_cached(&at, &sha1);
+                // The page has gone: nothing is waiting for this and
+                // nothing will wait for the next one either.
+                if tx.send((sha1, image)).is_err() {
+                    return;
+                }
+            }
+        });
+        Covers {
+            held: HashMap::new(),
+            order: std::collections::VecDeque::new(),
+            dir,
+            queue,
+            rx,
+        }
+    }
+
+    /// Collect anything that has arrived since the last frame, answering
+    /// whether the page should be redrawn.
+    pub fn poll(&mut self) -> bool {
+        let mut arrived = false;
+        while let Ok((sha1, image)) = self.rx.try_recv() {
+            let held = match image {
+                Some(image) => Held::Have(image),
+                None => Held::None,
+            };
+            if self.held.insert(sha1.clone(), held).is_none() {
+                self.order.push_back(sha1);
+            }
+            arrived = true;
+        }
+        // Only decoded pictures are worth capping; a remembered "there is
+        // none" costs a hash entry.
+        while self.order.len() > KEEP {
+            if let Some(oldest) = self.order.pop_front() {
+                self.held.remove(&oldest);
+            }
+        }
+        arrived
+    }
+
+    /// Forget what was asked for, so a game that had no art last time is
+    /// looked for again. A scan has just filled the cache; a "there is
+    /// none" remembered from before it would outlast the answer.
+    pub fn forget(&mut self) {
+        self.held.clear();
+        self.order.clear();
+    }
+
+    /// Forget one, so a picture that has just been replaced is read again
+    /// rather than answered from what it replaced.
+    pub fn forget_one(&mut self, key: &str) {
+        self.held.remove(key);
+        self.order.retain(|held| held != key);
+    }
+
+    /// Forget only the ones that came back empty.
+    ///
+    /// For while a scan is running: art it has just written should be
+    /// picked up, but a picture already decoded should not be thrown away
+    /// and fetched again.
+    pub fn forget_missing(&mut self) {
+        self.held.retain(|_, held| !matches!(held, Held::None));
+        self.order.retain(|sha1| self.held.contains_key(sha1));
+    }
+
+    /// Whether anything is still on its way. The window loop stays awake
+    /// while it is: a picture that lands with nothing watching for it sits
+    /// there unseen until some other event happens to wake the loop, which
+    /// is what "it appears the second time you scroll past" was.
+    pub fn pending(&self) -> bool {
+        self.held.values().any(|held| matches!(held, Held::Wanted))
+    }
+
+    /// The art for a digest if it is here, without asking for it. For the
+    /// draw path, which has no say in what gets fetched.
+    pub fn get(&self, sha1: &str) -> Option<&Image> {
+        match self.held.get(sha1) {
+            Some(Held::Have(image)) => Some(image),
+            _ => None,
+        }
+    }
+
+    /// Ask for a digest, if this is the first time it has been asked for.
+    pub fn want(&mut self, sha1: &str) {
+        if self.held.contains_key(sha1) {
+            return;
+        }
+        self.held.insert(sha1.to_string(), Held::Wanted);
+        self.queue.push(sha1.to_string());
+    }
+
+    /// Ask for what is being looked at, and for its neighbours after it.
+    ///
+    /// The one in the middle goes in last so it is served first. Reading
+    /// ahead is what makes a steady scroll find each cover already
+    /// decoded rather than waiting for it at every step.
+    pub fn want_around<'a>(&mut self, around: impl Iterator<Item = Option<&'a str>>, at: usize) {
+        let window: Vec<Option<&str>> = around.collect();
+        let first = at.saturating_sub(AHEAD);
+        let last = (at + AHEAD).min(window.len().saturating_sub(1));
+        for i in (first..=last).rev() {
+            if i != at {
+                if let Some(Some(sha1)) = window.get(i) {
+                    self.want(sha1);
+                }
+            }
+        }
+        if let Some(Some(sha1)) = window.get(at) {
+            self.want(sha1);
+        }
+    }
+}
+
+/// Where a digest's picture is kept inside the covers directory.
+///
+/// The one place the file name is spelt, so the scan that writes it and
+/// the launcher that reads it cannot drift apart -- which they did, and
+/// the symptom was a library of downloaded art that never appeared.
+pub fn cover_file(dir: &Path, key: &str) -> PathBuf {
+    dir.join(format!("{key}.png"))
+}
+
+/// One cover, read from the cache.
+///
+/// The cache and nothing else: downloading is the scan's job, and a page
+/// that fetched what it was missing would put the network in the middle of
+/// scrolling a list. After a scan every matched game's art is here, so this
+/// is a file read and a decode -- a millisecond or two, which is why it can
+/// keep up with a held arrow key.
+fn read_cached(dir: &Path, sha1: &str) -> Option<Image> {
+    let png = std::fs::read(cover_file(dir, sha1)).ok()?;
+    decode(&png)
+}
+
+/// Take somebody's own picture and make it look like the rest.
+///
+/// The service scales what it serves so the shorter side is
+/// [`super::openretro::COVER_PIXELS`]; measured across a real cache that
+/// is 256 wide by a median 314 tall, a ratio of about 0.82. A picture
+/// chosen by hand is brought to the same bound so the cache holds one kind
+/// of thing -- a phone photograph of a box would otherwise sit in there at
+/// several megabytes and be scaled down on every single frame that drew
+/// it.
+///
+/// Only ever smaller. Blowing a small picture up would spend bytes to add
+/// nothing, and the page scales to its frame at draw time anyway.
+///
+/// Answers the re-encoded PNG, or `None` if the bytes were not a picture.
+pub fn normalise(png: &[u8]) -> Option<Vec<u8>> {
+    let image = decode(png)?;
+    let short = image.width.min(image.height);
+    let bound = super::openretro::COVER_PIXELS as usize;
+    if short <= bound {
+        // Already the right sort of size. Re-encoded anyway rather than
+        // copied, so what lands in the cache is always plain 8-bit RGBA
+        // whatever the file happened to be.
+        return encode(&image);
+    }
+    let (w, h) = (
+        (image.width * bound / short).max(1),
+        (image.height * bound / short).max(1),
+    );
+    encode(&resample(&image, w, h))
+}
+
+/// Scale by averaging the source pixels each destination pixel covers.
+///
+/// A box filter, not the nearest-neighbour the draw path uses: this runs
+/// once and is kept, so it is worth the pass. Picking single pixels out of
+/// a photograph shrunk by a factor of eight is how a cover ends up looking
+/// like it was drawn with a dying pen.
+fn resample(src: &Image, w: usize, h: usize) -> Image {
+    let mut pixels = Vec::with_capacity(w * h * 4);
+    for y in 0..h {
+        let (y0, y1) = (
+            y * src.height / h,
+            ((y + 1) * src.height / h).max(y * src.height / h + 1),
+        );
+        for x in 0..w {
+            let (x0, x1) = (
+                x * src.width / w,
+                ((x + 1) * src.width / w).max(x * src.width / w + 1),
+            );
+            let mut sum = [0u32; 4];
+            let mut n = 0u32;
+            for sy in y0..y1.min(src.height) {
+                for sx in x0..x1.min(src.width) {
+                    let at = (sy * src.width + sx) * 4;
+                    let Some(px) = src.pixels.get(at..at + 4) else {
+                        continue;
+                    };
+                    for (slot, &v) in sum.iter_mut().zip(px) {
+                        *slot += u32::from(v);
+                    }
+                    n += 1;
+                }
+            }
+            let n = n.max(1);
+            pixels.extend(sum.iter().map(|c| (c / n) as u8));
+        }
+    }
+    Image {
+        width: w,
+        height: h,
+        pixels,
+    }
+}
+
+/// An [`Image`] back as PNG bytes.
+fn encode(image: &Image) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut out, image.width as u32, image.height as u32);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().ok()?;
+        writer.write_image_data(&image.pixels).ok()?;
+    }
+    Some(out)
+}
+
+/// Whether these bytes are a PNG that decodes.
+///
+/// Both halves matter: the signature says somebody meant it to be a PNG,
+/// and the decode says it is one. A file that only passes the first would
+/// go into the cache and draw as an empty box for ever after.
+pub fn is_png(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"\x89PNG\r\n\x1a\n") && decode(bytes).is_some()
+}
+
+/// A PNG as RGBA, whatever it was encoded as.
+///
+/// The decoder is asked to do the awkward parts: `EXPAND` turns a palette
+/// into real colours and a sub-byte greyscale into bytes, and `STRIP_16`
+/// brings sixteen-bit samples down to eight. Without them a palette image
+/// could not be drawn at all and a sixteen-bit one would be read as though
+/// every other byte were a pixel, which is a picture of noise rather than
+/// a picture. What arrives here is then one of four shapes, all 8-bit.
+fn decode(png: &[u8]) -> Option<Image> {
+    let mut decoder = png::Decoder::new(png);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let mut buf = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buf).ok()?;
+    let (w, h) = (info.width as usize, info.height as usize);
+    // The buffer belongs to the frame that was read, which may be smaller
+    // than the header claimed; taking a slice of it on trust is how a
+    // truncated file becomes a panic.
+    let take = |n: usize| -> Option<&[u8]> { buf.get(..w.checked_mul(h)?.checked_mul(n)?) };
+    let pixels = match info.color_type {
+        png::ColorType::Rgba => take(4)?.to_vec(),
+        png::ColorType::Rgb => take(3)?
+            .chunks_exact(3)
+            .flat_map(|p| [p[0], p[1], p[2], 0xFF])
+            .collect(),
+        png::ColorType::Grayscale => take(1)?.iter().flat_map(|&v| [v, v, v, 0xFF]).collect(),
+        png::ColorType::GrayscaleAlpha => take(2)?
+            .chunks_exact(2)
+            .flat_map(|p| [p[0], p[0], p[0], p[1]])
+            .collect(),
+        // EXPAND turned any palette into one of the above; nothing else
+        // reaches here.
+        png::ColorType::Indexed => return None,
+    };
+    Some(Image {
+        width: w,
+        height: h,
+        pixels,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode(w: u32, h: u32, colour: png::ColorType, data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut out, w, h);
+            encoder.set_color(colour);
+            encoder.set_depth(png::BitDepth::Eight);
+            let mut writer = encoder.write_header().unwrap();
+            writer.write_image_data(data).unwrap();
+        }
+        out
+    }
+
+    #[test]
+    fn a_cover_decodes_whatever_it_was_encoded_as() {
+        // The service sends RGB; the widening is what makes anything else
+        // draw rather than vanish.
+        let rgb = encode(2, 1, png::ColorType::Rgb, &[1, 2, 3, 4, 5, 6]);
+        let image = decode(&rgb).expect("rgb decodes");
+        assert_eq!((image.width, image.height), (2, 1));
+        assert_eq!(image.pixels, [1, 2, 3, 255, 4, 5, 6, 255]);
+
+        let rgba = encode(1, 1, png::ColorType::Rgba, &[9, 8, 7, 128]);
+        assert_eq!(decode(&rgba).expect("rgba decodes").pixels, [9, 8, 7, 128]);
+
+        let grey = encode(2, 1, png::ColorType::Grayscale, &[40, 200]);
+        assert_eq!(
+            decode(&grey).expect("grey decodes").pixels,
+            [40, 40, 40, 255, 200, 200, 200, 255]
+        );
+
+        // A palette image, which somebody's own cover art may well be: the
+        // decoder expands it rather than the picture being refused.
+        let mut out = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut out, 2, 1);
+            encoder.set_color(png::ColorType::Indexed);
+            encoder.set_depth(png::BitDepth::Eight);
+            encoder.set_palette(vec![1, 2, 3, 9, 8, 7]);
+            let mut writer = encoder.write_header().unwrap();
+            writer.write_image_data(&[0, 1]).unwrap();
+        }
+        assert_eq!(
+            decode(&out).expect("a palette image decodes").pixels,
+            [1, 2, 3, 255, 9, 8, 7, 255]
+        );
+    }
+
+    #[test]
+    fn a_chosen_picture_is_brought_to_the_size_the_rest_are() {
+        // The service bounds the shorter side to 256; a picture somebody
+        // chose is bounded the same way so the cache holds one kind of
+        // thing.
+        let big = super::encode(&Image {
+            width: 1000,
+            height: 1250,
+            pixels: vec![128; 1000 * 1250 * 4],
+        })
+        .unwrap();
+        let out = decode(&normalise(&big).expect("normalises")).unwrap();
+        assert_eq!(out.width.min(out.height), 256);
+        assert_eq!((out.width, out.height), (256, 320), "the shape changed");
+        // The colour survived the averaging.
+        assert!(out.pixels.iter().all(|&v| v == 128));
+
+        // A landscape one is bounded on its height instead.
+        let wide = super::encode(&Image {
+            width: 1000,
+            height: 500,
+            pixels: vec![7; 1000 * 500 * 4],
+        })
+        .unwrap();
+        let out = decode(&normalise(&wide).expect("normalises")).unwrap();
+        assert_eq!((out.width, out.height), (512, 256));
+
+        // One already small enough keeps its size rather than being blown
+        // up to look worse.
+        let small = super::encode(&Image {
+            width: 64,
+            height: 80,
+            pixels: vec![9; 64 * 80 * 4],
+        })
+        .unwrap();
+        let out = decode(&normalise(&small).expect("normalises")).unwrap();
+        assert_eq!((out.width, out.height), (64, 80));
+
+        assert!(normalise(b"not a picture").is_none());
+    }
+
+    #[test]
+    fn something_that_is_not_a_png_is_not_art() {
+        // An error page served with a 200, or a download that stopped
+        // half way, must not be kept as though it were a picture.
+        assert!(decode(b"<html>not found</html>").is_none());
+        assert!(decode(&[]).is_none());
+        let png = encode(1, 1, png::ColorType::Rgb, &[1, 2, 3]);
+        assert!(decode(&png[..png.len() / 2]).is_none());
+    }
+
+    #[test]
+    fn a_dropped_set_lets_its_worker_go() {
+        // The worker spends its life parked waiting for a request. Without
+        // something to wake it and say there will not be another, every
+        // launcher opened would leave a thread behind for the life of the
+        // process.
+        let queue = Arc::new(Queue {
+            pending: Mutex::new(Pending {
+                wanted: Vec::new(),
+                open: true,
+            }),
+            woken: Condvar::new(),
+        });
+        let work = Arc::clone(&queue);
+        let ended = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = Arc::clone(&ended);
+        let worker = std::thread::spawn(move || {
+            while work.take().is_some() {}
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+        // Parked, because nothing has been asked for.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert!(!ended.load(std::sync::atomic::Ordering::SeqCst));
+        queue.close();
+        worker.join().expect("the worker ended");
+        assert!(ended.load(std::sync::atomic::Ordering::SeqCst));
+        // And a closed queue takes nothing further.
+        queue.push("abc".to_string());
+        assert!(queue.take().is_none());
+    }
+
+    #[test]
+    fn a_game_with_no_art_is_asked_about_once() {
+        // Otherwise every redraw starts another request for a picture that
+        // is not there.
+        let mut covers = Covers::new(std::env::temp_dir().join("copperline-covers-test"));
+        covers.want("abc");
+        assert!(covers.get("abc").is_none());
+        // Answer it as the worker would, with nothing.
+        covers.held.insert("abc".to_string(), Held::None);
+        covers.want("abc");
+        assert!(
+            matches!(covers.held.get("abc"), Some(Held::None)),
+            "asking again put it back to wanted"
+        );
+    }
+}

--- a/src/gamelib/cover.rs
+++ b/src/gamelib/cover.rs
@@ -92,18 +92,25 @@ struct Pending {
 impl Queue {
     /// Put one at the front of the queue, which is the back of the vector:
     /// the worker pops from there, so the most recent ask is served first.
-    fn push(&self, sha1: String) {
+    ///
+    /// The queue is bounded, so a fast scroll pushes older asks off the
+    /// back. Those are handed back rather than dropped: the caller marked
+    /// them as on their way, and something that is never coming has to stop
+    /// being marked so, or it can never be asked for again and the window
+    /// loop stays awake waiting for it.
+    fn push(&self, sha1: String) -> Vec<String> {
         let Ok(mut pending) = self.pending.lock() else {
-            return;
+            return vec![sha1];
         };
         if !pending.open {
-            return;
+            return vec![sha1];
         }
         pending.wanted.retain(|held| held != &sha1);
         pending.wanted.push(sha1);
         let over = pending.wanted.len().saturating_sub(QUEUE_DEPTH);
-        pending.wanted.drain(..over);
+        let dropped = pending.wanted.drain(..over).collect();
         self.woken.notify_one();
+        dropped
     }
 
     /// Wait for work and take the newest. `None` once nobody is waiting for
@@ -248,6 +255,12 @@ impl Covers {
     /// while it is: a picture that lands with nothing watching for it sits
     /// there unseen until some other event happens to wake the loop, which
     /// is what "it appears the second time you scroll past" was.
+    /// Whether this digest is still on its way.
+    #[cfg(test)]
+    pub fn is_wanted(&self, sha1: &str) -> bool {
+        matches!(self.held.get(sha1), Some(Held::Wanted))
+    }
+
     pub fn pending(&self) -> bool {
         self.held.values().any(|held| matches!(held, Held::Wanted))
     }
@@ -267,7 +280,11 @@ impl Covers {
             return;
         }
         self.held.insert(sha1.to_string(), Held::Wanted);
-        self.queue.push(sha1.to_string());
+        for dropped in self.queue.push(sha1.to_string()) {
+            // Pushed off the back of the queue: forget it was asked for, so
+            // scrolling back to it asks again.
+            self.held.remove(&dropped);
+        }
     }
 
     /// Ask for what is being looked at, and for its neighbours after it.
@@ -453,6 +470,48 @@ fn decode(png: &[u8]) -> Option<Image> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A cover pushed off the bounded queue is handed back, so the caller
+    /// can stop counting it as on its way.
+    ///
+    /// The queue holds a fixed number and scrolling fast asks for more than
+    /// that, so the oldest asks are dropped. Dropped silently, they would
+    /// stay marked as wanted for ever: the picture could never be asked for
+    /// again -- scrolling back to it would show an empty frame -- and
+    /// `pending` would stay true, holding the window loop awake with
+    /// nothing to wait for.
+    ///
+    /// Tested against the queue rather than through `Covers`, whose worker
+    /// takes entries off concurrently.
+    #[test]
+    fn a_full_queue_hands_back_what_it_pushed_off() {
+        let queue = Queue {
+            pending: Mutex::new(Pending {
+                wanted: Vec::new(),
+                open: true,
+            }),
+            woken: Condvar::new(),
+        };
+        // Fill it exactly: nothing has been pushed off yet.
+        for i in 0..QUEUE_DEPTH {
+            assert!(
+                queue.push(format!("sha{i}")).is_empty(),
+                "dropped something while there was still room"
+            );
+        }
+        // One more, and the oldest comes back.
+        assert_eq!(queue.push("newest".to_string()), vec!["sha0".to_string()]);
+        assert_eq!(queue.push("newer".to_string()), vec!["sha1".to_string()]);
+
+        // Asking again for something already queued moves it rather than
+        // growing the queue, so nothing is pushed off for it.
+        assert!(queue.push("newest".to_string()).is_empty());
+
+        // A closed queue takes nothing, and says so by handing it straight
+        // back -- otherwise it would be marked wanted and never arrive.
+        queue.close();
+        assert_eq!(queue.push("late".to_string()), vec!["late".to_string()]);
+    }
 
     fn encode(w: u32, h: u32, colour: png::ColorType, data: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();

--- a/src/gamelib/db.rs
+++ b/src/gamelib/db.rs
@@ -326,11 +326,10 @@ impl Database {
     /// so it is a name every filesystem accepts, and prefixed so hand-set
     /// art is never mistaken for a catalogue digest.
     pub fn art_key(file: &str) -> String {
-        let safe: String = file
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-            .collect();
-        format!("manual-{safe}")
+        // A digest rather than the path with its punctuation flattened:
+        // mapping every separator to `_` makes `A/B.lha` and `A_B.lha` the
+        // same file name, and the two would overwrite each other's cover.
+        format!("manual-{}", crate::gamelib::sha1::hex(file.as_bytes()))
     }
 
     /// How many are marked, so a page can tell an empty list from a
@@ -994,6 +993,25 @@ fn hex(bytes: &[u8; 16]) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// Two packages that differ only in punctuation get different art.
+    ///
+    /// The key was the path with every separator flattened to `_`, which
+    /// made `A/B.lha` and `A_B.lha` the same file: whichever cover was set
+    /// second replaced the first.
+    #[test]
+    fn art_keys_do_not_collide_on_punctuation() {
+        let a = Database::art_key("A/B.lha");
+        let b = Database::art_key("A_B.lha");
+        assert_ne!(a, b, "two packages share one cover file");
+        assert_eq!(a, Database::art_key("A/B.lha"), "and it is stable");
+        // Still a name every filesystem takes.
+        assert!(a.starts_with("manual-"));
+        assert!(
+            a.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "{a} is not a safe file name"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/gamelib/db.rs
+++ b/src/gamelib/db.rs
@@ -57,6 +57,17 @@ pub struct Game {
     pub developer: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub players: Option<String>,
+    /// Which release of the game this package is.
+    ///
+    /// The one field the catalogue has no opinion about: there is no
+    /// standard to how installers name a release, so
+    /// `CannonFodder2_v1.12_Fr_2578` and `CannonFodder2_v1.11_0104` are
+    /// the same catalogued game and nothing in the record separates them.
+    /// A person can put whatever tells them apart in here -- "CD32 v1.1"
+    /// -- and where a library holds several under one title the page
+    /// offers the file name, which is the only honest answer to hand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     /// The digest of the cover art, to fetch it by.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub front_sha1: Option<String>,
@@ -96,15 +107,17 @@ pub struct Known {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Database {
     format: u32,
-    /// The games marked as favourites: the key their file name reduces to,
-    /// against the name to show for it.
+    /// The packages marked as favourites: the path the store files each
+    /// under, against the name to show for it.
     ///
     /// Kept here rather than in the machine configuration because a
-    /// favourite is not a setting of any machine, and keyed by match key
-    /// rather than by path so moving a collection does not lose them. The
-    /// name is kept with it so a favourite whose game has been deleted
-    /// still reads as a game rather than as the flattened key it is filed
-    /// under -- which is the state it most needs to be removable from.
+    /// favourite is not a setting of any machine. Keyed by the package
+    /// rather than by the game, because a collection holds the same game
+    /// several times over and starring one of them should star that one --
+    /// marking every release of Cannon Fodder 2 because one was picked is
+    /// not what anybody meant. The name is kept with it so a favourite
+    /// whose package has been deleted still reads as a game rather than as
+    /// a path, which is the state it most needs to be removable from.
     #[serde(default)]
     favourites: std::collections::BTreeMap<String, String>,
     /// Sorted by `file`, which is what makes this store fast to open: the
@@ -276,20 +289,18 @@ impl Database {
     }
 
     /// Whether a package is a favourite.
-    pub fn is_favourite(&self, file_name: &str) -> bool {
-        self.favourites
-            .contains_key(&match_key(&strip_package_name(file_name)))
+    pub fn is_favourite(&self, file: &str) -> bool {
+        self.favourites.contains_key(file)
     }
 
     /// Mark or unmark a favourite, answering whether it is one now.
     /// `title` is what to call it in the favourites list, which matters
     /// once the game itself is gone and there is nothing left to ask.
-    pub fn toggle_favourite(&mut self, file_name: &str, title: &str) -> bool {
-        let key = match_key(&strip_package_name(file_name));
-        if self.favourites.remove(&key).is_some() {
+    pub fn toggle_favourite(&mut self, file: &str, title: &str) -> bool {
+        if self.favourites.remove(file).is_some() {
             false
         } else {
-            self.favourites.insert(key, title.to_string());
+            self.favourites.insert(file.to_string(), title.to_string());
             true
         }
     }
@@ -308,10 +319,18 @@ impl Database {
             .map(|(key, name)| (key.as_str(), name.as_str()))
     }
 
-    /// The key a package is filed under, for lining a library entry up
-    /// against the favourites without going through the database.
-    pub fn key_for(file_name: &str) -> String {
-        match_key(&strip_package_name(file_name))
+    /// A file name to keep a package's own cover art under.
+    ///
+    /// Per package rather than per game: two releases of one game are two
+    /// entries and may want two pictures. Reduced to letters and digits
+    /// so it is a name every filesystem accepts, and prefixed so hand-set
+    /// art is never mistaken for a catalogue digest.
+    pub fn art_key(file: &str) -> String {
+        let safe: String = file
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect();
+        format!("manual-{safe}")
     }
 
     /// How many are marked, so a page can tell an empty list from a
@@ -498,6 +517,9 @@ impl Catalogue {
                 publisher: field("publisher"),
                 developer: field("developer"),
                 players: field("players"),
+                // Not a catalogue field: the sync has no opinion about
+                // which release a package is.
+                version: None,
                 front_sha1: field("front_sha1"),
             };
             match self.games.iter_mut().find(|g| g.uuid == uuid) {
@@ -1169,18 +1191,16 @@ mod tests {
         // Survives the session, without anything in the machine's config.
         let back = Database::load(&path);
         assert!(back.is_favourite("GoldenAxe_v1.5_0017.lha"));
-        // Kept by name rather than by path, so a collection that moved --
-        // or a package renamed to a newer install -- keeps its mark.
-        assert!(back.is_favourite("GoldenAxe_v2.0_9999.lha"));
+        // Kept per package: a collection holds the same game several
+        // times over, and starring one of them marks that one rather than
+        // every release of it.
+        assert!(!back.is_favourite("GoldenAxe_v2.0_9999.lha"));
 
         // The title is kept with it, so a favourite whose package has been
         // deleted still has something to show in the list.
         assert_eq!(
             back.favourites().collect::<Vec<_>>(),
-            [(
-                Database::key_for("GoldenAxe_v1.5_0017.lha").as_str(),
-                "Golden Axe"
-            )]
+            [("GoldenAxe_v1.5_0017.lha", "Golden Axe")]
         );
 
         // And it can be taken off again, by the tick beside the game or by
@@ -1189,7 +1209,7 @@ mod tests {
         assert!(!back.toggle_favourite("GoldenAxe_v1.5_0017.lha", "Golden Axe"));
         assert_eq!(back.favourite_count(), 0);
         assert!(back.toggle_favourite("GoldenAxe_v1.5_0017.lha", "Golden Axe"));
-        back.remove_favourite(&Database::key_for("GoldenAxe_v1.5_0017.lha"));
+        back.remove_favourite("GoldenAxe_v1.5_0017.lha");
         assert_eq!(back.favourite_count(), 0);
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1236,6 +1256,50 @@ mod tests {
         );
         let text = to_readable_json(&db).expect("serialises");
         assert_eq!(text.lines().filter(|l| l.starts_with("    {")).count(), 2);
+    }
+
+    #[test]
+    fn a_version_is_kept_and_survives_a_scan() {
+        // Not a catalogue field: a sync has no opinion about which release
+        // a package is, so a version only ever comes from a person -- and
+        // has to survive the scan that would otherwise overwrite it.
+        let mut db = Database::new();
+        db.set_entry(Known {
+            file: "CannonFodder2_v1.11_0104.lha".to_string(),
+            game: Some(Game {
+                name: "Cannon Fodder 2".to_string(),
+                version: Some("CD32 v1.1".to_string()),
+                ..Game::default()
+            }),
+            slave_sha1: Some("aa".to_string()),
+            manual: true,
+        });
+        db.set_known(vec![Known {
+            file: "CannonFodder2_v1.11_0104.lha".to_string(),
+            game: Some(Game {
+                name: "Cannon Fodder 2".to_string(),
+                ..Game::default()
+            }),
+            slave_sha1: Some("aa".to_string()),
+            manual: false,
+        }]);
+        assert_eq!(
+            db.match_file("CannonFodder2_v1.11_0104.lha")
+                .and_then(|g| g.version.as_deref()),
+            Some("CD32 v1.1")
+        );
+
+        // And through the store on disk.
+        let dir = std::env::temp_dir().join(format!("copperline-version-{}", std::process::id()));
+        let at = dir.join("db.json");
+        db.save(&at).unwrap();
+        assert_eq!(
+            Database::load(&at)
+                .match_file("CannonFodder2_v1.11_0104.lha")
+                .and_then(|g| g.version.as_deref()),
+            Some("CD32 v1.1")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/gamelib/db.rs
+++ b/src/gamelib/db.rs
@@ -1,0 +1,1448 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The two stores behind the Library page, and the name matching that ties
+//! a package on disk to a catalogued game.
+//!
+//! **[`Database`]** -- `library_db`, one entry per package that a scan
+//! found, with the metadata it resolved. This is what opening the page
+//! reads, so it is built to be read: entries sorted by file name, looked up
+//! by binary search, and no index rebuilt after parsing. A library of a few
+//! thousand games is a few hundred kilobytes and parses in a few
+//! milliseconds. One entry to a line, so a game that matched wrongly can be
+//! found with a text editor -- the parser does not care where the newlines
+//! are, so that costs nothing to read.
+//!
+//! **[`Catalogue`]** -- the snapshot of the online database a scan matched
+//! against, kept in `library_cache` because it is downloaded and can be
+//! thrown away. Several megabytes, and touched only while a scan runs, so
+//! opening the page never reads it. The sync cursor lives in it, which is
+//! what lets the next scan ask for the changes rather than all of it again.
+//!
+//! Both are written through a temporary and a rename, so a write
+//! interrupted half way leaves the previous file rather than half of a new
+//! one.
+//!
+//! Only *game* records are kept. The sync also carries a variant per
+//! release -- disk images with their SHA1s -- which is how a launcher that
+//! browses ADFs identifies them by content. A WHDLoad package shares no
+//! bytes with those images, so none of that would help here and none of it
+//! is stored; matching is by name, and [`match_key`] is the whole of it.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+/// The scanned library's format. A file written by a different one is
+/// discarded and rescanned rather than read: a wrong guess about an old
+/// layout is a library full of quietly wrong metadata.
+const FORMAT: u32 = 1;
+
+/// The catalogue snapshot's format, which moves independently: it is a
+/// cache, and throwing it away costs only a download.
+const CATALOGUE_FORMAT: u32 = 1;
+
+/// One game, as the Library page needs it.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Game {
+    /// What the entry is, stably: the key a later sync updates in place.
+    /// Empty in a scanned library, where the file name is the key and the
+    /// uuid would be bytes on disk nothing reads.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub uuid: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub year: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub developer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub players: Option<String>,
+    /// The digest of the cover art, to fetch it by.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub front_sha1: Option<String>,
+}
+
+/// One package a scan found, and what it turned out to be.
+///
+/// Flat rather than a flattened `Game`: `#[serde(flatten)]` buffers each
+/// record through an intermediate map, which is exactly the cost this store
+/// is shaped to avoid.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Known {
+    /// The package's file name, with its extension: what the scan saw, and
+    /// the key this store is sorted and searched by.
+    pub file: String,
+    /// What the catalogue said about it. Absent where the scan found no
+    /// match -- kept anyway, so a rescan does not look the same name up
+    /// again and a person can see that it was tried.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub game: Option<Game>,
+    /// The digest of the package's WHDLoad slave, once it has been read.
+    ///
+    /// Kept so a second scan does not open every archive again: reading it
+    /// means decompressing one member out of each package, which is the
+    /// slowest thing a scan does that is not the network.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slave_sha1: Option<String>,
+    /// Set where a person filled this in themselves. A scan leaves those
+    /// alone: somebody who has corrected a wrong match, or given a game
+    /// its own cover, does not want the next scan putting it back. Clearing
+    /// the entry and saving it empty puts it back in the scan's hands.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub manual: bool,
+}
+
+/// The scanned library: what a scan found, and which of it is a favourite.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Database {
+    format: u32,
+    /// The games marked as favourites: the key their file name reduces to,
+    /// against the name to show for it.
+    ///
+    /// Kept here rather than in the machine configuration because a
+    /// favourite is not a setting of any machine, and keyed by match key
+    /// rather than by path so moving a collection does not lose them. The
+    /// name is kept with it so a favourite whose game has been deleted
+    /// still reads as a game rather than as the flattened key it is filed
+    /// under -- which is the state it most needs to be removable from.
+    #[serde(default)]
+    favourites: std::collections::BTreeMap<String, String>,
+    /// Sorted by `file`, which is what makes this store fast to open: the
+    /// order comes off disk with the parse and lookup is a binary search,
+    /// so there is no index to build before the page can draw.
+    #[serde(default)]
+    known: Vec<Known>,
+}
+
+/// An empty library carries this format, not zero: it is about to be
+/// written, and a store that says it came from format 0 would be discarded
+/// the next time it was read.
+impl Default for Database {
+    fn default() -> Database {
+        Database {
+            format: FORMAT,
+            favourites: std::collections::BTreeMap::new(),
+            known: Vec::new(),
+        }
+    }
+}
+
+impl Database {
+    /// An empty library, as though nothing had ever been scanned.
+    pub fn new() -> Database {
+        Database::default()
+    }
+
+    /// Read the store, or start empty.
+    ///
+    /// A file that cannot be read, cannot be parsed, or was written by
+    /// another format is not an error to report: it means there is nothing
+    /// usable held, which is the same position as never having scanned. The
+    /// page lists the folder without metadata, and a scan writes a good one.
+    pub fn load(path: &Path) -> Database {
+        let mut db = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|text| serde_json::from_str::<Database>(&text).ok())
+            .filter(|db| db.format == FORMAT)
+            .unwrap_or_default();
+        // Trusted from the file where it is already right, which is the
+        // usual case, and put right where it is not: a hand-edited store
+        // must not silently stop matching.
+        if !db.known.windows(2).all(|w| w[0].file <= w[1].file) {
+            db.known.sort_by(|a, b| a.file.cmp(&b.file));
+        }
+        db
+    }
+
+    /// Write the store, through a temporary file so an interrupted write
+    /// leaves the previous library rather than half of a new one.
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        write_json(path, &to_readable_json(self)?)
+    }
+
+    /// Replace what is known with the result of a scan.
+    ///
+    /// Entries a person filled in themselves survive it, which is the
+    /// whole point of marking one manual: a scan must not undo a
+    /// correction somebody made because the catalogue had the wrong game.
+    ///
+    /// They survive a rename, too. A package matched by file name alone
+    /// would lose its corrections the moment somebody tidied their
+    /// collection; matched by the digest of its slave, the same game is
+    /// the same game whatever it has been called since. The digest is what
+    /// the scan worked out on the way past -- see
+    /// [`crate::gamelib::scan`] -- so this costs a lookup and no reading.
+    pub fn set_known(&mut self, mut known: Vec<Known>) {
+        known.sort_by(|a, b| a.file.cmp(&b.file));
+        // What was hand-filled, by digest, for the ones whose names have
+        // changed. Built only when there is something to carry across.
+        let renamed: HashMap<&str, &Known> = self
+            .known
+            .iter()
+            .filter(|held| held.manual)
+            .filter_map(|held| Some((held.slave_sha1.as_deref()?, held)))
+            .collect();
+        for entry in &mut known {
+            let held = self
+                .known
+                .binary_search_by(|k| k.file.as_str().cmp(entry.file.as_str()))
+                .ok()
+                .map(|at| &self.known[at])
+                .filter(|held| held.manual)
+                .or_else(|| {
+                    entry
+                        .slave_sha1
+                        .as_deref()
+                        .and_then(|sha1| renamed.get(sha1).copied())
+                });
+            let Some(held) = held else { continue };
+            // The file name is this scan's -- the package really is called
+            // that now -- and everything a person chose comes across.
+            *entry = Known {
+                file: entry.file.clone(),
+                slave_sha1: entry.slave_sha1.clone().or_else(|| held.slave_sha1.clone()),
+                game: held.game.clone(),
+                manual: true,
+            };
+        }
+        self.known = known;
+    }
+
+    /// What the store holds for one package, metadata and manual flag both.
+    pub fn entry(&self, file: &str) -> Option<&Known> {
+        self.known
+            .binary_search_by(|k| k.file.as_str().cmp(file))
+            .ok()
+            .map(|at| &self.known[at])
+    }
+
+    /// Put one entry in, replacing whatever was there.
+    pub fn set_entry(&mut self, entry: Known) {
+        match self.known.binary_search_by(|k| k.file.cmp(&entry.file)) {
+            Ok(at) => self.known[at] = entry,
+            Err(at) => self.known.insert(at, entry),
+        }
+    }
+
+    /// Bring the store into line with what is on disk: `files` is every
+    /// package the folder now holds.
+    ///
+    /// What was already resolved is carried across, so re-reading the
+    /// folder is not a way to lose the metadata a scan spent minutes
+    /// fetching. New packages arrive unresolved, and packages that have
+    /// gone are dropped. Answers how many are new, which is also how much
+    /// work a scan after this has to do.
+    pub fn merge_found(&mut self, files: Vec<String>) -> usize {
+        let mut fresh = 0;
+        let mut known: Vec<Known> = files
+            .into_iter()
+            .map(|file| {
+                let held = self
+                    .known
+                    .binary_search_by(|k| k.file.as_str().cmp(file.as_str()))
+                    .ok()
+                    .map(|at| &self.known[at]);
+                let game = held.and_then(|held| held.game.clone());
+                let manual = held.is_some_and(|held| held.manual);
+                // The digest survives too: it is the expensive thing to
+                // work out, and re-reading a folder has not changed it.
+                let slave_sha1 = held.and_then(|held| held.slave_sha1.clone());
+                fresh += usize::from(game.is_none());
+                Known {
+                    file,
+                    game,
+                    slave_sha1,
+                    manual,
+                }
+            })
+            .collect();
+        known.sort_by(|a, b| a.file.cmp(&b.file));
+        self.known = known;
+        fresh
+    }
+
+    /// How many packages the last scan found.
+    pub fn len(&self) -> usize {
+        self.known.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.known.is_empty()
+    }
+
+    /// Everything the last scan found.
+    pub fn known(&self) -> &[Known] {
+        &self.known
+    }
+
+    /// Whether a package is a favourite.
+    pub fn is_favourite(&self, file_name: &str) -> bool {
+        self.favourites
+            .contains_key(&match_key(&strip_package_name(file_name)))
+    }
+
+    /// Mark or unmark a favourite, answering whether it is one now.
+    /// `title` is what to call it in the favourites list, which matters
+    /// once the game itself is gone and there is nothing left to ask.
+    pub fn toggle_favourite(&mut self, file_name: &str, title: &str) -> bool {
+        let key = match_key(&strip_package_name(file_name));
+        if self.favourites.remove(&key).is_some() {
+            false
+        } else {
+            self.favourites.insert(key, title.to_string());
+            true
+        }
+    }
+
+    /// Drop a favourite by its key, whether or not its game is still
+    /// there. This is how one is taken off after its package has been
+    /// deleted, when there is nothing in the library left to untick.
+    pub fn remove_favourite(&mut self, key: &str) {
+        self.favourites.remove(key);
+    }
+
+    /// The favourites, as (key, name), in the order they are listed.
+    pub fn favourites(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.favourites
+            .iter()
+            .map(|(key, name)| (key.as_str(), name.as_str()))
+    }
+
+    /// The key a package is filed under, for lining a library entry up
+    /// against the favourites without going through the database.
+    pub fn key_for(file_name: &str) -> String {
+        match_key(&strip_package_name(file_name))
+    }
+
+    /// How many are marked, so a page can tell an empty list from a
+    /// database that has never been synced.
+    pub fn favourite_count(&self) -> usize {
+        self.favourites.len()
+    }
+
+    /// What the last scan resolved for a package, by its exact file name.
+    ///
+    /// Exact rather than by match key: the scan already did the matching,
+    /// and this is reading back its answer for the file it answered about.
+    pub fn match_file(&self, file_name: &str) -> Option<&Game> {
+        self.known
+            .binary_search_by(|k| k.file.as_str().cmp(file_name))
+            .ok()
+            .and_then(|at| self.known[at].game.as_ref())
+    }
+}
+
+/// The snapshot of the online database a scan matches against.
+///
+/// Lives in the cache directory: it is downloaded, it is large, and losing
+/// it costs a download and nothing else.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Catalogue {
+    format: u32,
+    /// The digest of a WHDLoad slave against the game it belongs to.
+    ///
+    /// The sync carries a record per release as well as one per game, and
+    /// a WHDLoad release lists its installed files with a SHA-1 each. The
+    /// slave is the one worth keeping: it is small, it is always there,
+    /// and it names the game exactly. Matching a package by it is an
+    /// answer rather than a guess -- see [`Catalogue::match_digest`].
+    #[serde(default)]
+    digests: std::collections::BTreeMap<String, String>,
+    /// The highest sync id taken, which the next sync asks to continue
+    /// after. Zero means nothing has been taken yet.
+    pub cursor: u32,
+    pub games: Vec<Game>,
+    /// Built from `games` on load; never stored, because they are derived
+    /// and a stored index is one more thing that can disagree with the
+    /// data.
+    #[serde(skip)]
+    by_key: HashMap<String, usize>,
+    #[serde(skip)]
+    by_uuid: HashMap<String, usize>,
+    /// Each game's title reduced once, for the two passes that have to
+    /// look at every entry rather than hash straight to one.
+    #[serde(skip)]
+    reduced: Vec<Reduced>,
+}
+
+/// A catalogue title as the matching sees it.
+#[derive(Debug, Clone, Default)]
+struct Reduced {
+    /// The words, normalised, in order.
+    words: Vec<String>,
+    /// Those words run together: the key, and what the edit distance is
+    /// measured across.
+    key: String,
+}
+
+impl Default for Catalogue {
+    fn default() -> Catalogue {
+        Catalogue {
+            format: CATALOGUE_FORMAT,
+            cursor: 0,
+            digests: std::collections::BTreeMap::new(),
+            games: Vec::new(),
+            by_key: HashMap::new(),
+            by_uuid: HashMap::new(),
+            reduced: Vec::new(),
+        }
+    }
+}
+
+impl Catalogue {
+    pub fn new() -> Catalogue {
+        Catalogue::default()
+    }
+
+    /// Read the snapshot, or start empty and re-sync from the beginning.
+    pub fn load(path: &Path) -> Catalogue {
+        let mut cat = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|text| serde_json::from_str::<Catalogue>(&text).ok())
+            .filter(|cat| cat.format == CATALOGUE_FORMAT)
+            .unwrap_or_default();
+        cat.reindex();
+        cat
+    }
+
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        write_json(path, &catalogue_json(self)?)
+    }
+
+    pub fn len(&self) -> usize {
+        self.games.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.games.is_empty()
+    }
+
+    /// The game a slave's digest belongs to.
+    ///
+    /// Exact where it answers: the bytes of that slave are that game's, and
+    /// nothing about the file's name comes into it. Tried before the name
+    /// matching, which is the guess this replaces where it can.
+    pub fn match_digest(&self, sha1: &str) -> Option<&Game> {
+        let uuid = self.digests.get(sha1)?;
+        self.by_uuid.get(uuid).map(|&at| &self.games[at])
+    }
+
+    /// How many slave digests are held, for reporting what a scan has to
+    /// work with.
+    pub fn digest_count(&self) -> usize {
+        self.digests.len()
+    }
+
+    /// The game a package's file name names, if the catalogue knows it.
+    pub fn match_file(&self, file_name: &str) -> Option<&Game> {
+        let title = strip_package_name(file_name);
+        let (plain, folded) = match_keys(&title);
+        let exact = self
+            .by_key
+            .get(&plain)
+            .or_else(|| folded.and_then(|folded| self.by_key.get(&folded)));
+        match exact {
+            Some(&at) => Some(&self.games[at]),
+            // Only what nothing matched exactly walks the catalogue, which
+            // on a real library is a tenth of it.
+            None => self.match_loosely(&title),
+        }
+    }
+
+    /// Fold one page of sync records in, answering how many entries it
+    /// changed. Zero from the first page of a sync is what "already up to
+    /// date" is read from.
+    ///
+    /// Records without a game name are the per-release variants, which
+    /// carry disk-image digests a WHDLoad package cannot match: they are
+    /// skipped rather than stored.
+    pub fn apply(&mut self, records: &[super::openretro::Record]) -> usize {
+        let mut changed = 0;
+        for record in records {
+            self.cursor = self.cursor.max(record.sync_id);
+            let uuid = hex(&record.uuid);
+            let Some(json) = &record.json else {
+                // A deletion: the entry has gone from the database.
+                if let Some(at) = self.games.iter().position(|g| g.uuid == uuid) {
+                    self.games.remove(at);
+                    changed += 1;
+                }
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+                continue;
+            };
+            let Some(name) = value.get("game_name").and_then(|v| v.as_str()) else {
+                // A release rather than a game. Most carry disk images,
+                // which a WHDLoad package shares no bytes with; the
+                // WHDLoad ones carry the installed files, and their slave
+                // digests are what makes an exact match possible.
+                self.take_slave_digests(&value);
+                continue;
+            };
+            if name.trim().is_empty() {
+                continue;
+            }
+            let field = |key: &str| -> Option<String> {
+                value
+                    .get(key)
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+            };
+            let game = Game {
+                uuid: uuid.clone(),
+                name: name.trim().to_string(),
+                year: field("year"),
+                publisher: field("publisher"),
+                developer: field("developer"),
+                players: field("players"),
+                front_sha1: field("front_sha1"),
+            };
+            match self.games.iter_mut().find(|g| g.uuid == uuid) {
+                Some(held) if *held == game => {}
+                Some(held) => {
+                    *held = game;
+                    changed += 1;
+                }
+                None => {
+                    self.games.push(game);
+                    changed += 1;
+                }
+            }
+        }
+        // Only the games are indexed. A page of nothing but release
+        // records has added digests, and those go into a map of their own
+        // -- there is nothing for a rebuild to do, and a rebuild is every
+        // title in the catalogue taken apart again.
+        if changed > 0 {
+            self.reindex();
+        }
+        changed
+    }
+
+    /// Rebuild the name index. The first entry to claim a key keeps it, so
+    /// a later re-import of the same game cannot displace what is matching
+    /// already.
+    /// Note the slave digests a release record carries, against the game
+    /// it is a release of.
+    fn take_slave_digests(&mut self, value: &serde_json::Value) {
+        let Some(parent) = value.get("parent_uuid").and_then(|v| v.as_str()) else {
+            return;
+        };
+        // `file_list` is a JSON array inside a JSON string.
+        let Some(list) = value.get("file_list").and_then(|v| v.as_str()) else {
+            return;
+        };
+        let Ok(files) = serde_json::from_str::<serde_json::Value>(list) else {
+            return;
+        };
+        for file in files.as_array().into_iter().flatten() {
+            let (Some(name), Some(sha1)) = (
+                file.get("name").and_then(|n| n.as_str()),
+                file.get("sha1").and_then(|s| s.as_str()),
+            ) else {
+                continue;
+            };
+            if name.to_ascii_lowercase().ends_with(".slave") && sha1.len() == 40 {
+                self.digests
+                    .insert(sha1.to_ascii_lowercase(), parent.to_string());
+            }
+        }
+    }
+
+    fn reindex(&mut self) {
+        self.games.sort_by(|a, b| a.name.cmp(&b.name));
+        self.by_uuid.clear();
+        self.by_uuid.extend(
+            self.games
+                .iter()
+                .enumerate()
+                .map(|(at, game)| (game.uuid.clone(), at)),
+        );
+        self.by_key.clear();
+        self.reduced.clear();
+        self.reduced.reserve(self.games.len());
+        for (at, game) in self.games.iter().enumerate() {
+            let (plain, folded) = match_keys(&game.name);
+            self.reduced.push(Reduced {
+                words: title_words_full(&game.name),
+                key: plain.clone(),
+            });
+            self.by_key.entry(plain).or_insert(at);
+            if let Some(folded) = folded {
+                self.by_key.entry(folded).or_insert(at);
+            }
+        }
+    }
+
+    /// The game a package's name matches exactly, for telling an exact
+    /// match from a loose one.
+    pub fn matched_exactly(&self, file_name: &str) -> Option<&Game> {
+        let (plain, folded) = match_keys(&strip_package_name(file_name));
+        self.by_key
+            .get(&plain)
+            .or_else(|| folded.and_then(|folded| self.by_key.get(&folded)))
+            .map(|&at| &self.games[at])
+    }
+
+    /// The two passes for a package no key matched exactly.
+    ///
+    /// Both are deliberately stricter than a scraper a person watches
+    /// would be: a wrong match writes a wrong game into somebody's library
+    /// and stays there, where a missing one is visibly missing.
+    ///
+    /// **Words in order.** A catalogue title every one of whose words
+    /// appears, in that order, inside the package's name. This is what
+    /// finds `IndianaJones&TheLastCrusadeAction` -- the package is the
+    /// catalogue title plus a word saying which of the two games it is.
+    /// The longest such title wins, so the more specific entry is
+    /// preferred over one that happens to be a prefix of it. Order is what
+    /// makes it safe: without it, "World Rugby" matches
+    /// `RugbyTheWorldCup`, which is a different game.
+    ///
+    /// **Edit distance.** For the rest -- `RBI2Baseball` against "R.B.I.
+    /// Two Baseball", `UniversalMilitarySimulator` against "UMS (Universal
+    /// Military Simulator)". Skyscraper accepts 65% here; measured against
+    /// a real library that is too loose (it pairs `UltimateGolf` with "The
+    /// Ultimate Quiz" at 66), so this wants 80.
+    fn match_loosely(&self, title: &str) -> Option<&Game> {
+        let words = title_words_full(title);
+        let key: String = title_words(title).concat();
+        if key.len() < MIN_LOOSE_KEY {
+            return None;
+        }
+        let ordered = self
+            .reduced
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| {
+                r.words.len() >= MIN_LOOSE_WORDS
+                    && r.words.iter().map(String::len).sum::<usize>() >= MIN_LOOSE_KEY
+                    && is_subsequence(&r.words, &words)
+            })
+            .max_by_key(|(_, r)| r.words.iter().map(String::len).sum::<usize>());
+        if let Some((at, _)) = ordered {
+            return Some(&self.games[at]);
+        }
+        self.reduced
+            .iter()
+            .enumerate()
+            // The length gate first: it is a comparison, and the distance
+            // it saves is a matrix.
+            .filter(|(_, r)| {
+                r.key.len() >= MIN_LOOSE_KEY && r.key.len().abs_diff(key.len()) <= LOOSE_SLACK
+            })
+            .map(|(at, r)| (similarity(&key, &r.key), at))
+            .filter(|&(score, _)| score >= MIN_SIMILARITY)
+            .max_by_key(|&(score, _)| score)
+            .map(|(_, at)| &self.games[at])
+    }
+}
+
+/// A catalogue title needs at least this many words, and this many
+/// characters, before either loose pass will consider it. Without the
+/// guard a one-word entry is a subsequence of nearly everything: "War"
+/// swallows `UMS2NationsAtWar`, and "1990" swallows
+/// `Italy1990WinnersEdition`.
+const MIN_LOOSE_WORDS: usize = 2;
+const MIN_LOOSE_KEY: usize = 10;
+/// How far apart two keys may be in length and still be worth measuring.
+const LOOSE_SLACK: usize = 6;
+/// How alike they must then be, as a percentage.
+const MIN_SIMILARITY: usize = 80;
+
+/// Whether `needle` appears in `haystack` in order, other words allowed
+/// between and after.
+fn is_subsequence(needle: &[String], haystack: &[String]) -> bool {
+    let mut want = needle.iter();
+    let mut next = want.next();
+    for word in haystack {
+        match next {
+            Some(n) if n == word => next = want.next(),
+            _ => {}
+        }
+    }
+    next.is_none()
+}
+
+/// How alike two keys are, 0 to 100, by Levenshtein distance over the
+/// longer of them.
+fn similarity(a: &str, b: &str) -> usize {
+    let longest = a.len().max(b.len());
+    if longest == 0 {
+        return 0;
+    }
+    100 * (longest - edit_distance(a.as_bytes(), b.as_bytes())) / longest
+}
+
+/// Levenshtein distance, two rows rather than a matrix: the keys are
+/// alphanumeric ASCII by construction, so bytes are characters.
+fn edit_distance(a: &[u8], b: &[u8]) -> usize {
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut row = vec![0usize; b.len() + 1];
+    for (i, &x) in a.iter().enumerate() {
+        row[0] = i + 1;
+        for (j, &y) in b.iter().enumerate() {
+            row[j + 1] = (prev[j] + usize::from(x != y))
+                .min(prev[j + 1] + 1)
+                .min(row[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut row);
+    }
+    prev[b.len()]
+}
+
+/// A game's name reduced to the one thing two spellings of it share.
+///
+/// A WHDLoad package is named by its installer and a database entry by a
+/// cataloguer, so the same game arrives as `JamesPond2_v2.0_AGA_1354` and
+/// as "James Pond II: Robocod". What survives both is the letters and
+/// digits, in order, with the numbering written one way:
+///
+/// - case and every separator go, so `JamesPond2` and "James Pond 2" meet;
+/// - a trailing roman numeral of two letters or more becomes its digits,
+///   so "II" meets `2`;
+/// - an ampersand becomes "and";
+/// - a leading article goes, so "The Settlers" meets `Settlers`;
+/// - anything after a colon goes, since a package name carries the title
+///   and not the subtitle.
+pub fn match_key(name: &str) -> String {
+    keys(name).0
+}
+
+/// Every spelling of a name worth filing it under.
+///
+/// A trailing single letter is the awkward case, and it cannot be decided
+/// from one side alone: "King's Quest V" is the fifth King's Quest, and
+/// `RanX` is a game called Ranx. Rather than guess, a name that ends in
+/// one gets both keys -- the letter as a letter, and the letter as a
+/// number. The catalogue is filed under both and a package is looked up by
+/// both, so whichever way round the two spellings fall, they meet.
+///
+/// The first is the primary: what a favourite is filed under, where one
+/// answer is needed and the letter is the likelier reading.
+pub fn match_keys(name: &str) -> (String, Option<String>) {
+    keys(name)
+}
+
+fn keys(name: &str) -> (String, Option<String>) {
+    let plain = build_key(name, false);
+    let folded = build_key(name, true);
+    (plain.clone(), (folded != plain).then_some(folded))
+}
+
+/// `fold_single` decides whether a trailing single-letter roman numeral
+/// becomes its digits.
+fn build_key(name: &str, fold_single: bool) -> String {
+    let words = title_words(name);
+    let words = words.as_slice();
+    let mut out = String::new();
+    for (i, word) in words.iter().enumerate() {
+        let last = i + 1 == words.len();
+        match roman_to_arabic(word, fold_single && last && i > 0) {
+            Some(n) => out.push_str(&n.to_string()),
+            None => out.push_str(word),
+        }
+    }
+    out
+}
+
+/// A title reduced to its words: the one place a name is taken apart, so
+/// the key and the two loose passes can never disagree about what the
+/// words of a title are.
+///
+/// Everything after a colon goes -- a package name carries the title and
+/// not the subtitle -- an ampersand becomes "and", humps become spaces,
+/// punctuation goes, and a leading or trailing article goes with it.
+fn title_words(name: &str) -> Vec<String> {
+    title_parts(name, true)
+}
+
+/// The same, keeping the subtitle.
+///
+/// The exact key drops it, because a package name carries the title and
+/// not the subtitle. The words-in-order pass wants it: an installer that
+/// ran the two together -- `RobinHoodLegendQuest` for "Robin Hood: Legend
+/// Quest" -- has the subtitle's words right there, and asking for them is
+/// a stricter test rather than a looser one.
+fn title_words_full(name: &str) -> Vec<String> {
+    title_parts(name, false)
+}
+
+fn title_parts(name: &str, cut_subtitle: bool) -> Vec<String> {
+    let title = match cut_subtitle {
+        true => name.split(':').next().unwrap_or(name),
+        false => name,
+    };
+    // An ampersand is a word: installers write `Utopia&NewWorlds` where a
+    // cataloguer writes "Utopia and New Worlds". Dropping it as
+    // punctuation makes those two disagree by three letters.
+    let spaced = split_camel_case(&title.replace('&', " and "));
+    let words: Vec<String> = spaced
+        .split_whitespace()
+        .map(|word| {
+            word.chars()
+                .filter(|c| c.is_alphanumeric())
+                .flat_map(char::to_lowercase)
+                .collect::<String>()
+        })
+        .filter(|word| !word.is_empty())
+        .collect();
+    // A catalogue writes the article at the end -- "Settlers, The" -- and
+    // an installer writes it at the front or not at all, so it is dropped
+    // from either end. Not from a title that is only an article.
+    let article = |w: &String| matches!(w.as_str(), "the" | "a" | "an");
+    match words.as_slice() {
+        [_] => words,
+        [rest @ .., last] if article(last) => rest.to_vec(),
+        [first, rest @ ..] if article(first) => rest.to_vec(),
+        _ => words,
+    }
+}
+
+/// Put a space at each hump, so `JamesPond2` becomes `James Pond 2` and
+/// the words can be looked at one at a time. A run of capitals is one word
+/// (`AGA`), and a digit starts a new one.
+fn split_camel_case(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::new();
+    for (i, &c) in chars.iter().enumerate() {
+        let prev = i.checked_sub(1).map(|p| chars[p]);
+        let next = chars.get(i + 1).copied();
+        let starts_word = match prev {
+            None => false,
+            Some(p) => {
+                // aB, 1a, a1 -- and the last capital of a run before a
+                // lowercase word, as in `AGAVersion`.
+                (p.is_lowercase() && c.is_uppercase())
+                    || (p.is_numeric() != c.is_numeric() && c.is_alphanumeric())
+                    || (p.is_uppercase()
+                        && c.is_uppercase()
+                        && next.is_some_and(char::is_lowercase))
+            }
+        };
+        if starts_word {
+            out.push(' ');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// A roman numeral as its number, so that "II" and `2` are the same word.
+/// Only the small ones a game title uses, and only when the whole word is
+/// one: `mix` and `civ` are words, not numerals.
+///
+/// A single letter is the hard case. "I", "V" and "X" are words as often
+/// as numbers, so one is read as a numeral only in the place a sequel
+/// number goes: the last word of a title that has other words before it.
+/// "King's Quest V" is the fifth; "V" and "I Game" are not.
+fn roman_to_arabic(word: &str, in_numeral_position: bool) -> Option<u32> {
+    const NUMERALS: [(&str, u32); 20] = [
+        ("i", 1),
+        ("ii", 2),
+        ("iii", 3),
+        ("iv", 4),
+        ("v", 5),
+        ("vi", 6),
+        ("vii", 7),
+        ("viii", 8),
+        ("ix", 9),
+        ("x", 10),
+        ("xi", 11),
+        ("xii", 12),
+        ("xiii", 13),
+        ("xiv", 14),
+        ("xv", 15),
+        ("xvi", 16),
+        ("xvii", 17),
+        ("xviii", 18),
+        ("xix", 19),
+        ("xx", 20),
+    ];
+    if word.chars().count() < 2 && !in_numeral_position {
+        return None;
+    }
+    NUMERALS
+        .iter()
+        .find(|(numeral, _)| *numeral == word)
+        .map(|&(_, n)| n)
+}
+
+/// A WHDLoad archive's file name reduced to the game's name.
+///
+/// Installers name a package for the game and then say which install it
+/// is: `GoldenAxe_v1.5_0017.lha`, `JamesPond2_v2.0_AGA_1354.lha`. The
+/// version is where the title stops, and everything after it describes the
+/// install rather than the game.
+pub fn strip_package_name(file_name: &str) -> String {
+    // Only a package extension comes off. A game that arrives as a plain
+    // folder has none, and plenty of Amiga titles have a dot in the name
+    // itself -- `S.W.I.V`, `R.B.I. 2 Baseball` -- so cutting at the last
+    // dot would take letters off the title.
+    let stem = crate::package::stem_of(file_name);
+    // Cut at the first `_v<digit>` -- the version the installer stamped on.
+    let mut cut = stem.len();
+    let bytes: Vec<char> = stem.chars().collect();
+    for i in 0..bytes.len().saturating_sub(2) {
+        if bytes[i] == '_'
+            && (bytes[i + 1] == 'v' || bytes[i + 1] == 'V')
+            && bytes[i + 2].is_ascii_digit()
+        {
+            cut = i;
+            break;
+        }
+    }
+    let title: String = bytes[..cut.min(bytes.len())].iter().collect();
+    title.replace('_', " ")
+}
+
+/// A store as text: the header on its own lines, then one record to a
+/// line, so a person can find a game with a text editor and a search.
+///
+/// Not `to_string_pretty`, which would put every field of every record on
+/// its own line and treble the file for no more readability than this.
+/// Reading is unaffected either way -- the parser does not care where the
+/// newlines are.
+fn to_readable_json(db: &Database) -> std::io::Result<String> {
+    let mut out = String::from("{\n");
+    out.push_str(&format!("  \"format\": {},\n", db.format));
+    out.push_str("  \"favourites\": ");
+    out.push_str(&encode(&db.favourites)?);
+    out.push_str(",\n  \"known\": [\n");
+    lines(&mut out, &db.known)?;
+    out.push_str("  ]\n}\n");
+    Ok(out)
+}
+
+/// The catalogue as text, the same way, with the cursor in the header.
+fn catalogue_json(cat: &Catalogue) -> std::io::Result<String> {
+    let mut out = String::from("{\n");
+    out.push_str(&format!("  \"format\": {},\n", cat.format));
+    out.push_str(&format!("  \"cursor\": {},\n", cat.cursor));
+    out.push_str("  \"digests\": ");
+    out.push_str(&encode(&cat.digests)?);
+    out.push_str(",\n  \"games\": [\n");
+    lines(&mut out, &cat.games)?;
+    out.push_str("  ]\n}\n");
+    Ok(out)
+}
+
+/// One record to a line, indented and comma-separated.
+fn lines<T: serde::Serialize>(out: &mut String, records: &[T]) -> std::io::Result<()> {
+    for (i, record) in records.iter().enumerate() {
+        out.push_str("    ");
+        out.push_str(&encode(record)?);
+        if i + 1 < records.len() {
+            out.push(',');
+        }
+        out.push('\n');
+    }
+    Ok(())
+}
+
+fn encode<T: serde::Serialize>(value: &T) -> std::io::Result<String> {
+    serde_json::to_string(value)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Write a store through a temporary file, so a write interrupted half way
+/// leaves the previous one rather than half of a new one.
+fn write_json(path: &Path, text: &str) -> std::io::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let temp = path.with_extension("json.partial");
+    std::fs::write(&temp, text)?;
+    match std::fs::rename(&temp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp);
+            Err(e)
+        }
+    }
+}
+
+/// Sixteen bytes as the text the store keys on.
+fn hex(bytes: &[u8; 16]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_package_name_reduces_to_the_game_it_names() {
+        // The four in the test library, and the shapes installers use.
+        for (file, want) in [
+            ("GoldenAxe_v1.5_0017.lha", "goldenaxe"),
+            ("JamesPond2_v2.0_AGA_1354.lha", "jamespond2"),
+            ("KingsQuest5_v1.3.lha", "kingsquest5"),
+            ("SimCity_v1.0_2193.lha", "simcity"),
+            // A version written with a capital, and one with no version.
+            ("Lemmings_V2.1_0123.lha", "lemmings"),
+            ("Zool.lha", "zool"),
+        ] {
+            assert_eq!(match_key(&strip_package_name(file)), want, "{file}");
+        }
+    }
+
+    #[test]
+    fn two_spellings_of_a_game_meet_at_the_same_key() {
+        // The package is named by an installer and the entry by a
+        // cataloguer, so this is the whole job.
+        for (package, catalogued) in [
+            ("JamesPond2_v2.0_AGA_1354.lha", "James Pond II: Robocod"),
+            ("GoldenAxe_v1.5_0017.lha", "Golden Axe"),
+            // The trailing single letter, which only meets through the
+            // second key each name is also filed under.
+            ("KingsQuest5_v1.3.lha", "King's Quest V"),
+            ("SimCity_v1.0_2193.lha", "Sim City"),
+            ("TheSettlers_v1.2_0456.lha", "Settlers, The"),
+            ("Turrican2_v1.0.lha", "Turrican II: The Final Fight"),
+            // An installer writes the ampersand a cataloguer writes out.
+            ("Utopia&NewWorlds_v1.3.lha", "Utopia and New Worlds"),
+        ] {
+            let both = |name: &str| {
+                let (plain, folded) = match_keys(name);
+                let mut all = vec![plain];
+                all.extend(folded);
+                all
+            };
+            let from_package = both(&strip_package_name(package));
+            let from_catalogue = both(catalogued);
+            assert!(
+                from_package.iter().any(|k| from_catalogue.contains(k)),
+                "{package} {from_package:?} vs {catalogued} {from_catalogue:?}"
+            );
+        }
+
+        // And two games that are not the same game do not meet: a bare
+        // trailing letter is a letter first and a numeral second.
+        let ranx = match_key(&strip_package_name("RanX_v1.4.lha"));
+        assert_eq!(ranx, match_key("Ranx"), "RanX stopped being Ranx");
+    }
+
+    #[test]
+    fn words_in_order_is_stricter_than_words_in_any_order() {
+        let w = |s: &str| title_words_full(s);
+        // The package is the catalogue title plus a word saying which of
+        // two games it is.
+        assert!(is_subsequence(
+            &w("Indiana Jones and the Last Crusade"),
+            &w("IndianaJones&TheLastCrusadeAction")
+        ));
+        // Same words, different game. Order is the whole guard here.
+        assert!(!is_subsequence(&w("World Rugby"), &w("RugbyTheWorldCup")));
+        // And a title nothing is missing from still matches itself.
+        assert!(is_subsequence(&w("Sim City"), &w("SimCity")));
+    }
+
+    #[test]
+    fn a_loose_match_is_taken_only_when_it_is_close() {
+        // The spellings that should meet, and the pair that should not.
+        assert!(similarity("rbitwobaseball", "rbi2baseball") >= 70);
+        assert_eq!(similarity("simcity", "simcity"), 100);
+        assert!(
+            similarity("ultimategolf", "ultimatequiz") < MIN_SIMILARITY,
+            "two different games were called alike"
+        );
+        assert_eq!(similarity("", ""), 0);
+        assert_eq!(edit_distance(b"kitten", b"sitting"), 3);
+        assert_eq!(edit_distance(b"", b"abc"), 3);
+        assert_eq!(edit_distance(b"abc", b""), 3);
+    }
+
+    #[test]
+    fn a_package_finds_a_game_the_key_alone_would_miss() {
+        use crate::gamelib::openretro::Record;
+        let mut cat = Catalogue::new();
+        let mut id = 0;
+        let mut add = |cat: &mut Catalogue, name: &str| {
+            id += 1;
+            cat.apply(&[Record {
+                sync_id: id,
+                uuid: [id as u8; 16],
+                json: Some(format!(r#"{{"game_name":"{name}"}}"#)),
+            }]);
+        };
+        add(&mut cat, "Indiana Jones and the Last Crusade");
+        add(&mut cat, "Robin Hood: Legend Quest");
+        add(&mut cat, "UMS (Universal Military Simulator)");
+        add(&mut cat, "World Rugby");
+        add(&mut cat, "War");
+
+        let name = |file: &str| cat.match_file(file).map(|g| g.name.as_str());
+        // Words in order, subtitle and all.
+        assert_eq!(
+            name("IndianaJones&TheLastCrusadeAction_v1.2_1619.lha"),
+            Some("Indiana Jones and the Last Crusade")
+        );
+        assert_eq!(
+            name("RobinHoodLegendQuest_v1.1.lha"),
+            Some("Robin Hood: Legend Quest")
+        );
+        // Close enough spelt out.
+        assert_eq!(
+            name("UniversalMilitarySimulator_v1.0_0753.lha"),
+            Some("UMS (Universal Military Simulator)")
+        );
+        // The two that must not be taken: same words in the wrong order,
+        // and a one-word title that is a fragment of everything.
+        assert_eq!(name("RugbyTheWorldCup_v1.2_0258.lha"), None);
+        assert_eq!(name("UMS2NationsAtWar_v1.0_2137.lha"), None);
+    }
+
+    #[test]
+    fn a_numeral_that_is_really_a_word_stays_one() {
+        // "Mix" and "Civ" are not roman numerals, and a single letter is a
+        // word far more often than a number.
+        assert_eq!(match_key("Mix"), "mix");
+        assert_eq!(match_key("Civilization"), "civilization");
+        assert_ne!(match_key("I Game"), "1game");
+    }
+
+    #[test]
+    fn a_later_page_updates_an_entry_rather_than_repeating_it() {
+        use crate::gamelib::openretro::Record;
+        let record = |sync_id: u32, uuid: u8, json: Option<&str>| Record {
+            sync_id,
+            uuid: [uuid; 16],
+            json: json.map(str::to_string),
+        };
+        let mut db = Catalogue::new();
+
+        let added = db.apply(&[
+            record(1, 0xAA, Some(r#"{"game_name":"Turrican","year":"1990"}"#)),
+            // A variant, with no game name: not a game, not stored.
+            record(2, 0xBB, Some(r#"{"variant_name":"Turrican (Disk 1)"}"#)),
+        ]);
+        assert_eq!(added, 1);
+        assert_eq!(db.len(), 1);
+        assert_eq!(db.cursor, 2, "the cursor takes every record, game or not");
+
+        // The same entry again, changed: updated in place.
+        let changed = db.apply(&[record(
+            5,
+            0xAA,
+            Some(r#"{"game_name":"Turrican","year":"1990","publisher":"Rainbow Arts"}"#),
+        )]);
+        assert_eq!(changed, 1);
+        assert_eq!(db.len(), 1);
+        assert_eq!(db.games[0].publisher.as_deref(), Some("Rainbow Arts"));
+
+        // And unchanged: nothing to report, which is what "already up to
+        // date" is read from.
+        let again = db.apply(&[record(
+            6,
+            0xAA,
+            Some(r#"{"game_name":"Turrican","year":"1990","publisher":"Rainbow Arts"}"#),
+        )]);
+        assert_eq!(again, 0);
+
+        // A deletion removes it.
+        assert_eq!(db.apply(&[record(7, 0xAA, None)]), 1);
+        assert!(db.is_empty());
+        assert_eq!(db.cursor, 7);
+    }
+
+    #[test]
+    fn a_favourite_survives_being_written_and_read_back() {
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-favs-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path = dir.join("db.json");
+        let mut db = Database::new();
+        assert!(!db.is_favourite("GoldenAxe_v1.5_0017.lha"));
+        assert!(db.toggle_favourite("GoldenAxe_v1.5_0017.lha", "Golden Axe"));
+        assert!(db.is_favourite("GoldenAxe_v1.5_0017.lha"));
+        assert_eq!(db.favourite_count(), 1);
+        db.save(&path).expect("saved");
+
+        // Survives the session, without anything in the machine's config.
+        let back = Database::load(&path);
+        assert!(back.is_favourite("GoldenAxe_v1.5_0017.lha"));
+        // Kept by name rather than by path, so a collection that moved --
+        // or a package renamed to a newer install -- keeps its mark.
+        assert!(back.is_favourite("GoldenAxe_v2.0_9999.lha"));
+
+        // The title is kept with it, so a favourite whose package has been
+        // deleted still has something to show in the list.
+        assert_eq!(
+            back.favourites().collect::<Vec<_>>(),
+            [(
+                Database::key_for("GoldenAxe_v1.5_0017.lha").as_str(),
+                "Golden Axe"
+            )]
+        );
+
+        // And it can be taken off again, by the tick beside the game or by
+        // the one beside the favourite.
+        let mut back = back;
+        assert!(!back.toggle_favourite("GoldenAxe_v1.5_0017.lha", "Golden Axe"));
+        assert_eq!(back.favourite_count(), 0);
+        assert!(back.toggle_favourite("GoldenAxe_v1.5_0017.lha", "Golden Axe"));
+        back.remove_favourite(&Database::key_for("GoldenAxe_v1.5_0017.lha"));
+        assert_eq!(back.favourite_count(), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_store_is_written_a_record_to_a_line() {
+        use crate::gamelib::openretro::Record;
+        // 676 KiB on one line is unreadable when a game matched wrongly
+        // and you want to look at why.
+        let mut cat = Catalogue::new();
+        for (i, name) in ["Golden Axe", "Sim City", "Turrican"]
+            .into_iter()
+            .enumerate()
+        {
+            cat.apply(&[Record {
+                sync_id: i as u32 + 1,
+                uuid: [i as u8; 16],
+                json: Some(format!(r#"{{"game_name":"{name}"}}"#)),
+            }]);
+        }
+        let text = catalogue_json(&cat).expect("serialises");
+        assert_eq!(
+            text.lines().filter(|l| l.starts_with("    {")).count(),
+            3,
+            "one game to a line"
+        );
+        // Still exactly what serde reads back, newlines or not.
+        let back: Catalogue = serde_json::from_str(&text).expect("parses");
+        assert_eq!(back.games.len(), 3);
+        assert_eq!(back.cursor, cat.cursor);
+
+        // And the scanned library the same way.
+        let mut db = Database::new();
+        db.set_known(
+            ["b.lha", "a.lha"]
+                .into_iter()
+                .map(|file| Known {
+                    file: file.to_string(),
+                    game: None,
+                    manual: false,
+                    slave_sha1: None,
+                })
+                .collect(),
+        );
+        let text = to_readable_json(&db).expect("serialises");
+        assert_eq!(text.lines().filter(|l| l.starts_with("    {")).count(), 2);
+    }
+
+    #[test]
+    fn a_duplicate_lists_twice_and_a_deleted_one_drops_out() {
+        // The same game held as both an .lha and a .zip is a duplicate,
+        // which is the person's business rather than ours: it lists twice
+        // and both play. Deleting one and pressing Refresh takes that one
+        // out and leaves the other alone.
+        let mut db = Database::new();
+        db.merge_found(vec![
+            "GoldenAxe_v1.lha".to_string(),
+            "GoldenAxe_v1.zip".to_string(),
+        ]);
+        assert_eq!(db.len(), 2, "a duplicate should list twice");
+        // Both reduce to the same title, which is what makes them look
+        // like duplicates in the list -- and share a favourites key, so
+        // starring the game stars the game rather than one copy of it.
+        assert_eq!(
+            match_key(&strip_package_name("GoldenAxe_v1.lha")),
+            match_key(&strip_package_name("GoldenAxe_v1.zip"))
+        );
+
+        db.merge_found(vec!["GoldenAxe_v1.zip".to_string()]);
+        assert_eq!(db.len(), 1);
+        assert!(db.entry("GoldenAxe_v1.zip").is_some());
+        assert!(
+            db.entry("GoldenAxe_v1.lha").is_none(),
+            "the deleted one stayed"
+        );
+    }
+
+    #[test]
+    fn a_correction_survives_a_rescan_and_a_rename() {
+        let manual = |file: &str, name: &str, sha1: &str| Known {
+            file: file.to_string(),
+            game: Some(Game {
+                name: name.to_string(),
+                ..Game::default()
+            }),
+            slave_sha1: Some(sha1.to_string()),
+            manual: true,
+        };
+        let scanned = |file: &str, name: &str, sha1: &str| Known {
+            file: file.to_string(),
+            game: Some(Game {
+                name: name.to_string(),
+                ..Game::default()
+            }),
+            slave_sha1: Some(sha1.to_string()),
+            manual: false,
+        };
+        let mut db = Database::new();
+        db.set_known(vec![manual("Axe_v1.lha", "Golden Axe", "aa")]);
+
+        // A rescan matched it to something else. The correction wins: it
+        // was made because the catalogue had it wrong.
+        db.set_known(vec![scanned("Axe_v1.lha", "Golden Axe II", "aa")]);
+        assert_eq!(
+            db.match_file("Axe_v1.lha").map(|g| g.name.as_str()),
+            Some("Golden Axe")
+        );
+        assert!(db.entry("Axe_v1.lha").is_some_and(|k| k.manual));
+
+        // Renamed, and rescanned. Same slave, so the same game: the
+        // correction follows the package rather than the name it had.
+        db.set_known(vec![scanned("A/GoldenAxe.zip", "Golden Axe II", "aa")]);
+        assert_eq!(
+            db.match_file("A/GoldenAxe.zip").map(|g| g.name.as_str()),
+            Some("Golden Axe")
+        );
+        // And it is not left behind under the old name as well.
+        assert_eq!(db.len(), 1);
+        assert!(db.match_file("Axe_v1.lha").is_none());
+
+        // A different package with a different slave is not adopted.
+        db.set_known(vec![
+            scanned("A/GoldenAxe.zip", "Golden Axe II", "aa"),
+            scanned("B/Other.lha", "Something Else", "bb"),
+        ]);
+        assert_eq!(
+            db.match_file("B/Other.lha").map(|g| g.name.as_str()),
+            Some("Something Else")
+        );
+        assert!(db.entry("B/Other.lha").is_some_and(|k| !k.manual));
+    }
+
+    #[test]
+    fn the_scanned_library_is_sorted_and_found_by_exact_file() {
+        // Sorted on the way in, so opening the page is a parse and a
+        // binary search rather than a parse and an index build.
+        let mut db = Database::new();
+        db.set_known(
+            [
+                ("C/Zool_v1.0.lha", "Zool"),
+                ("A/Axe_v1.0.lha", "Golden Axe"),
+            ]
+            .into_iter()
+            .map(|(file, name)| Known {
+                file: file.to_string(),
+                game: Some(Game {
+                    name: name.to_string(),
+                    ..Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            })
+            .collect(),
+        );
+        assert_eq!(
+            db.known()
+                .iter()
+                .map(|k| k.file.as_str())
+                .collect::<Vec<_>>(),
+            ["A/Axe_v1.0.lha", "C/Zool_v1.0.lha"]
+        );
+        assert_eq!(
+            db.match_file("A/Axe_v1.0.lha").map(|g| g.name.as_str()),
+            Some("Golden Axe")
+        );
+        // Exact: the scan already did the matching, and two packages of the
+        // same name in different folders are two packages.
+        assert!(db.match_file("Axe_v1.0.lha").is_none());
+        assert!(db.match_file("B/Axe_v1.0.lha").is_none());
+    }
+
+    #[test]
+    fn a_store_survives_a_round_trip_and_refuses_a_foreign_one() {
+        use crate::gamelib::openretro::Record;
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-gamedb-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        // The catalogue: the cursor comes back, and the index with it.
+        let at = dir.join("openretro.json");
+        let mut cat = Catalogue::new();
+        cat.apply(&[Record {
+            sync_id: 3,
+            uuid: [0xCC; 16],
+            json: Some(r#"{"game_name":"Sim City","front_sha1":"abc"}"#.into()),
+        }]);
+        cat.save(&at).expect("saved");
+        let back = Catalogue::load(&at);
+        assert_eq!(back.cursor, 3);
+        assert_eq!(back.len(), 1);
+        // The index is rebuilt on load, not stored, so matching works.
+        assert_eq!(
+            back.match_file("SimCity_v1.0_2193.lha")
+                .map(|g| g.name.as_str()),
+            Some("Sim City")
+        );
+        assert!(!at.with_extension("json.partial").exists());
+
+        // A file from another format is not read as this one, and neither
+        // is anything that is not the file at all.
+        std::fs::write(&at, r#"{"format":999,"cursor":42,"games":[]}"#).unwrap();
+        assert_eq!(Catalogue::load(&at).cursor, 0, "a foreign format was read");
+        std::fs::write(&at, "not json").unwrap();
+        assert_eq!(Catalogue::load(&at).cursor, 0);
+        assert_eq!(Catalogue::load(&dir.join("nothing.json")).cursor, 0);
+
+        // And the scanned library, which carries the favourites.
+        let path = dir.join("db.json");
+        let mut db = Database::new();
+        db.set_known(vec![Known {
+            file: "SimCity_v1.0_2193.lha".to_string(),
+            game: Some(Game {
+                name: "Sim City".to_string(),
+                front_sha1: Some("abc".to_string()),
+                ..Game::default()
+            }),
+            manual: false,
+            slave_sha1: None,
+        }]);
+        db.toggle_favourite("SimCity_v1.0_2193.lha", "Sim City");
+        db.save(&path).expect("saved");
+        let back = Database::load(&path);
+        assert_eq!(back.len(), 1);
+        assert!(back.is_favourite("SimCity_v1.0_2193.lha"));
+        assert_eq!(
+            back.match_file("SimCity_v1.0_2193.lha")
+                .and_then(|g| g.front_sha1.as_deref()),
+            Some("abc")
+        );
+        std::fs::write(&path, r#"{"format":999,"known":[]}"#).unwrap();
+        assert!(Database::load(&path).is_empty());
+
+        // A store somebody hand-edited out of order still matches: it is
+        // put right on the way in rather than quietly stopping working.
+        std::fs::write(
+            &path,
+            r#"{"format":1,"known":[{"file":"z.lha"},{"file":"a.lha"}]}"#,
+        )
+        .unwrap();
+        let fixed = Database::load(&path);
+        assert_eq!(
+            fixed
+                .known()
+                .iter()
+                .map(|k| k.file.as_str())
+                .collect::<Vec<_>>(),
+            ["a.lha", "z.lha"]
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/gamelib/http.rs
+++ b/src/gamelib/http.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The one place an HTTP client is built.
+//!
+//! Not a wrapper for its own sake: the TLS backend differs by platform, and
+//! ureq will not choose it. `TlsProvider` defaults to Rustls and its own
+//! documentation says of the alternative that "the setting is never picked
+//! up automatically", so a build carrying only native-tls still asks for
+//! Rustls and panics mid-request:
+//!
+//! ```text
+//! uri scheme is https, provider is Rustls but feature is not enabled: rustls
+//! ```
+//!
+//! That is a runtime failure on one platform, in whichever request happens
+//! to run first, and nothing about writing `Agent::config_builder()` warns
+//! you. So there is one constructor, every caller goes through it, and a
+//! test below fails if a second one appears.
+
+use std::time::Duration;
+
+/// An agent for `timeout`, with Copperline's user agent and the platform's
+/// TLS.
+///
+/// The timeout is global rather than per-connect: a transfer that stalls
+/// half way through has to end too, or it holds a worker for ever.
+pub fn agent(timeout: Duration) -> ureq::Agent {
+    let config = ureq::Agent::config_builder()
+        .timeout_global(Some(timeout))
+        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")));
+    // Windows builds link schannel instead of rustls, because rustls's
+    // crypto provider needs a C toolchain that an ARM64 Windows machine
+    // does not have by default (see the two ureq entries in Cargo.toml).
+    // Naming it is not optional -- ureq defaults to Rustls whatever is
+    // compiled in.
+    #[cfg(windows)]
+    let config = config.tls_config(
+        ureq::tls::TlsConfig::builder()
+            .provider(ureq::tls::TlsProvider::NativeTls)
+            .build(),
+    );
+    config.build().into()
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every HTTP client in the game library comes from [`super::agent`].
+    ///
+    /// Reading the sources rather than the behaviour, because the behaviour
+    /// this protects only misbehaves on Windows: a second agent built by
+    /// hand works perfectly on the machine of whoever writes it and panics
+    /// on somebody else's. That is exactly how the first one got in.
+    #[test]
+    fn nothing_else_builds_an_agent() {
+        for (name, source) in [
+            ("openretro.rs", include_str!("openretro.rs")),
+            ("support.rs", include_str!("support.rs")),
+            ("cover.rs", include_str!("cover.rs")),
+            ("scan.rs", include_str!("scan.rs")),
+        ] {
+            assert!(
+                !source.contains("config_builder"),
+                "{name} builds its own ureq agent; call gamelib::http::agent \
+                 instead, or Windows will panic on the first request"
+            );
+        }
+    }
+}

--- a/src/gamelib/library.rs
+++ b/src/gamelib/library.rs
@@ -174,57 +174,6 @@ fn sort_key(title: &str) -> (u8, String) {
     (group, folded)
 }
 
-/// How fast a held scroll runs.
-///
-/// A library is a few hundred games and a wheel notch is one row, so
-/// reaching the far end a row at a time is a lot of turning. Speed builds
-/// while the scrolling continues and falls back to one row as soon as it
-/// pauses, so a short flick still moves by one and a long drag crosses the
-/// list.
-#[derive(Debug, Clone)]
-pub struct ScrollRate {
-    /// When the last movement was, to tell a continued scroll from a fresh
-    /// one.
-    last: Option<std::time::Instant>,
-    /// Rows per notch, which grows while the scrolling keeps up.
-    rate: f32,
-}
-
-impl Default for ScrollRate {
-    fn default() -> Self {
-        Self {
-            last: None,
-            rate: 1.0,
-        }
-    }
-}
-
-impl ScrollRate {
-    /// The gap after which a scroll counts as a new one rather than a
-    /// continuation. About three frames: longer than the gap between
-    /// notches of a turning wheel, shorter than a pause meaning to stop.
-    const CONTINUES_WITHIN: std::time::Duration = std::time::Duration::from_millis(120);
-    /// How much faster each continued notch goes.
-    const GROWTH: f32 = 1.35;
-    /// The ceiling, in rows per notch. Fast enough to cross a long list in
-    /// a second or so, slow enough to stop where you meant to.
-    const FASTEST: f32 = 24.0;
-
-    /// How many rows this notch should move, given when it arrived.
-    pub fn rows_for_notch(&mut self, now: std::time::Instant) -> usize {
-        let continued = self
-            .last
-            .is_some_and(|last| now.duration_since(last) <= Self::CONTINUES_WITHIN);
-        self.rate = if continued {
-            (self.rate * Self::GROWTH).min(Self::FASTEST)
-        } else {
-            1.0
-        };
-        self.last = Some(now);
-        self.rate as usize
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,30 +334,5 @@ mod tests {
         // shows nothing, which is what it would show anyway.
         let library = refreshed(Path::new("/no/such/folder"), &mut Database::new());
         assert!(library.is_empty());
-    }
-
-    #[test]
-    fn scrolling_speeds_up_while_it_continues_and_resets_when_it_stops() {
-        use std::time::{Duration, Instant};
-        let mut rate = ScrollRate::default();
-        let start = Instant::now();
-
-        // The first notch of a scroll always moves one row, so a flick to
-        // nudge the list by one does that and nothing more.
-        assert_eq!(rate.rows_for_notch(start), 1);
-
-        // Kept up, it builds.
-        let mut at = start;
-        let mut rows = 0;
-        for _ in 0..12 {
-            at += Duration::from_millis(30);
-            rows = rate.rows_for_notch(at);
-        }
-        assert!(rows > 1, "a continued scroll did not speed up");
-        assert!(rows <= 24, "a continued scroll ran away: {rows} rows");
-
-        // And a pause puts it back to one.
-        at += Duration::from_millis(400);
-        assert_eq!(rate.rows_for_notch(at), 1);
     }
 }

--- a/src/gamelib/library.rs
+++ b/src/gamelib/library.rs
@@ -28,8 +28,11 @@ pub struct Entry {
     /// it: two `Zool_v1.0.lha` filed under different letters are two
     /// packages, and the bare name cannot tell them apart.
     pub relative: String,
-    /// What the list shows when nothing is known: the file name without
-    /// its extension, which is what a person named it.
+    /// The file name without its extension, which is what a person named
+    /// it. Shown as the title when the scan could not name the package,
+    /// and as the version where a named game is held more than once --
+    /// `.lha` against `.zip` is how it was packed, not which release it
+    /// is, so the extension is no part of either answer.
     pub file_name: String,
     /// What the database says, when the name matched an entry.
     pub game: Option<Game>,
@@ -39,25 +42,15 @@ pub struct Entry {
     /// `CannonFodder2_v1.11_0104`, `_v1.12_Fr_2578`, `_v1.1_De_0241` --
     /// and every one matches the same catalogue entry, so the list shows a
     /// run of rows all reading "Cannon Fodder 2" with nothing to tell them
-    /// apart. Where that happens the page shows a version as well.
+    /// apart. Where that happens to a *named* game the page offers a
+    /// version as well; two packages the scan could not name are two rows
+    /// that say nothing already, and a file name under them adds nothing.
     pub duplicated: bool,
 }
 
 impl Entry {
     /// What to call it: the catalogued name where there is one, and the
     /// file's own otherwise.
-    /// The package's own file name, extension and all.
-    ///
-    /// What tells one version of a game from another: there is no standard
-    /// to how installers name them -- `_v1.12_0104`, `_v1.1_Fr_2578`,
-    /// `_CD32`, `_AGA` -- so the name itself is the only honest answer.
-    pub fn file(&self) -> &str {
-        self.relative
-            .rsplit(['/', '\\'])
-            .next()
-            .unwrap_or(&self.relative)
-    }
-
     pub fn title(&self) -> &str {
         match &self.game {
             Some(game) => &game.name,

--- a/src/gamelib/library.rs
+++ b/src/gamelib/library.rs
@@ -33,11 +33,31 @@ pub struct Entry {
     pub file_name: String,
     /// What the database says, when the name matched an entry.
     pub game: Option<Game>,
+    /// Whether something else in the list is shown under the same title.
+    ///
+    /// Collections carry a game several times over --
+    /// `CannonFodder2_v1.11_0104`, `_v1.12_Fr_2578`, `_v1.1_De_0241` --
+    /// and every one matches the same catalogue entry, so the list shows a
+    /// run of rows all reading "Cannon Fodder 2" with nothing to tell them
+    /// apart. Where that happens the page shows a version as well.
+    pub duplicated: bool,
 }
 
 impl Entry {
     /// What to call it: the catalogued name where there is one, and the
     /// file's own otherwise.
+    /// The package's own file name, extension and all.
+    ///
+    /// What tells one version of a game from another: there is no standard
+    /// to how installers name them -- `_v1.12_0104`, `_v1.1_Fr_2578`,
+    /// `_CD32`, `_AGA` -- so the name itself is the only honest answer.
+    pub fn file(&self) -> &str {
+        self.relative
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(&self.relative)
+    }
+
     pub fn title(&self) -> &str {
         match &self.game {
             Some(game) => &game.name,
@@ -90,16 +110,22 @@ impl Library {
                 let base = relative.rsplit(['/', '\\']).next().unwrap_or(&relative);
                 Entry {
                     game: db.match_file(&relative).cloned(),
-                    file_name: base
-                        .rsplit_once('.')
-                        .map(|(stem, _)| stem.to_string())
-                        .unwrap_or_else(|| base.to_string()),
-                    path: folder.join(&relative),
+                    file_name: crate::package::stem_of(base).to_string(),
+                    path: crate::package::under(folder, &relative),
                     relative,
+                    duplicated: false,
                 }
             })
             .collect();
         entries.sort_by_key(|entry| sort_key(entry.title()));
+        // Sorted by what is shown, so anything sharing a title is adjacent
+        // and one pass settles it.
+        for i in 0..entries.len() {
+            let same = |a: usize, b: usize| entries[a].title() == entries[b].title();
+            let before = i > 0 && same(i - 1, i);
+            let after = i + 1 < entries.len() && same(i + 1, i);
+            entries[i].duplicated = before || after;
+        }
         Library {
             folder: Some(folder.to_path_buf()),
             entries,

--- a/src/gamelib/library.rs
+++ b/src/gamelib/library.rs
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The list the Library page shows: the packages in the game folder, each
+//! with whatever the last scan resolved for it.
+//!
+//! It is built from the store and never from the disk: a collection of
+//! several thousand packages filed a letter deep is a directory walk long
+//! enough to be felt, and nobody asked for one by clicking a tab. Refresh
+//! reads the folder, puts what it finds in the store, and the list follows
+//! from that -- so the same list comes back every time the page is opened,
+//! and comes back after a restart.
+//!
+//! Without a game library set, the folder holding the chosen game stands
+//! in, so pointing at any package still lists its neighbours. There is no
+//! separate setting for it: a second path to keep in step with the first is
+//! a way for the two to disagree.
+
+use std::path::{Path, PathBuf};
+
+use super::db::{Database, Game};
+
+/// One package on disk, and the game it turned out to be.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// The archive itself.
+    pub path: PathBuf,
+    /// Where it sits under the game folder, which is how the store keys
+    /// it: two `Zool_v1.0.lha` filed under different letters are two
+    /// packages, and the bare name cannot tell them apart.
+    pub relative: String,
+    /// What the list shows when nothing is known: the file name without
+    /// its extension, which is what a person named it.
+    pub file_name: String,
+    /// What the database says, when the name matched an entry.
+    pub game: Option<Game>,
+}
+
+impl Entry {
+    /// What to call it: the catalogued name where there is one, and the
+    /// file's own otherwise.
+    pub fn title(&self) -> &str {
+        match &self.game {
+            Some(game) => &game.name,
+            None => &self.file_name,
+        }
+    }
+}
+
+/// The packages in a folder, in the order the list shows them.
+#[derive(Debug, Default, Clone)]
+pub struct Library {
+    /// The folder the entries came from, so a rescan can be skipped when
+    /// nothing has moved.
+    folder: Option<PathBuf>,
+    entries: Vec<Entry>,
+}
+
+impl Library {
+    /// Read a folder of packages, and match each against the database.
+    ///
+    /// Sorted by the name shown rather than by file name, so a list that
+    /// mixes catalogued and uncatalogued games still reads alphabetically.
+    ///
+    /// Searched all the way down, since a collection is usually filed by
+    /// letter or by genre rather than left flat -- but only so far, and
+    /// never through a symbolic link. A library pointed at a home
+    /// directory, or at a tree that links back into itself, must not walk
+    /// the disk or spin forever.
+    /// The list as the store has it.
+    ///
+    /// The store is the only thing the list is ever built from, and
+    /// [`Database::merge_found`] is the only thing that reads the folder.
+    /// One source means the page shows the same thing every time it is
+    /// opened, without walking a collection of several thousand packages
+    /// to find out what that is.
+    ///
+    /// Sorted by the name shown rather than by file name, so a list that
+    /// mixes catalogued and uncatalogued games still reads alphabetically.
+    pub fn known(folder: &Path, db: &Database) -> Library {
+        Library::of(
+            folder,
+            db.known().iter().map(|known| known.file.clone()),
+            db,
+        )
+    }
+
+    fn of(folder: &Path, files: impl Iterator<Item = String>, db: &Database) -> Library {
+        let mut entries: Vec<Entry> = files
+            .map(|relative| {
+                let base = relative.rsplit(['/', '\\']).next().unwrap_or(&relative);
+                Entry {
+                    game: db.match_file(&relative).cloned(),
+                    file_name: base
+                        .rsplit_once('.')
+                        .map(|(stem, _)| stem.to_string())
+                        .unwrap_or_else(|| base.to_string()),
+                    path: folder.join(&relative),
+                    relative,
+                }
+            })
+            .collect();
+        entries.sort_by_key(|entry| sort_key(entry.title()));
+        Library {
+            folder: Some(folder.to_path_buf()),
+            entries,
+        }
+    }
+
+    /// Whether this list already covers `folder`, so a redraw need not
+    /// read the directory again.
+    pub fn covers(&self, folder: &Path) -> bool {
+        self.folder.as_deref() == Some(folder)
+    }
+
+    pub fn entries(&self) -> &[Entry] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Where a package sits in the list, so the game being played can be
+    /// shown as the chosen one.
+    pub fn position(&self, path: &Path) -> Option<usize> {
+        self.entries.iter().position(|e| e.path == path)
+    }
+}
+
+/// A title as the list orders it: digits before letters, case ignored.
+///
+/// Sorting the text directly would put "1942" after "Zool" on any machine
+/// where the locale says so, and would separate "sim city" from "Sim
+/// City". Both are the same shelf to a person looking for a game.
+fn sort_key(title: &str) -> (u8, String) {
+    let folded = title.to_lowercase();
+    let group = match folded.chars().next() {
+        Some(c) if c.is_ascii_digit() => 0,
+        Some(c) if c.is_alphabetic() => 1,
+        // Anything else -- brackets, a leading dot -- after the words
+        // rather than mixed into them.
+        _ => 2,
+    };
+    (group, folded)
+}
+
+/// How fast a held scroll runs.
+///
+/// A library is a few hundred games and a wheel notch is one row, so
+/// reaching the far end a row at a time is a lot of turning. Speed builds
+/// while the scrolling continues and falls back to one row as soon as it
+/// pauses, so a short flick still moves by one and a long drag crosses the
+/// list.
+#[derive(Debug, Clone)]
+pub struct ScrollRate {
+    /// When the last movement was, to tell a continued scroll from a fresh
+    /// one.
+    last: Option<std::time::Instant>,
+    /// Rows per notch, which grows while the scrolling keeps up.
+    rate: f32,
+}
+
+impl Default for ScrollRate {
+    fn default() -> Self {
+        Self {
+            last: None,
+            rate: 1.0,
+        }
+    }
+}
+
+impl ScrollRate {
+    /// The gap after which a scroll counts as a new one rather than a
+    /// continuation. About three frames: longer than the gap between
+    /// notches of a turning wheel, shorter than a pause meaning to stop.
+    const CONTINUES_WITHIN: std::time::Duration = std::time::Duration::from_millis(120);
+    /// How much faster each continued notch goes.
+    const GROWTH: f32 = 1.35;
+    /// The ceiling, in rows per notch. Fast enough to cross a long list in
+    /// a second or so, slow enough to stop where you meant to.
+    const FASTEST: f32 = 24.0;
+
+    /// How many rows this notch should move, given when it arrived.
+    pub fn rows_for_notch(&mut self, now: std::time::Instant) -> usize {
+        let continued = self
+            .last
+            .is_some_and(|last| now.duration_since(last) <= Self::CONTINUES_WITHIN);
+        self.rate = if continued {
+            (self.rate * Self::GROWTH).min(Self::FASTEST)
+        } else {
+            1.0
+        };
+        self.last = Some(now);
+        self.rate as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let at = std::env::temp_dir().join(format!(
+            "copperline-library-{}-{name}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&at).unwrap();
+        at
+    }
+
+    /// What Refresh does: read the folder into the store, then list it.
+    fn refreshed(dir: &Path, db: &mut Database) -> Library {
+        db.merge_found(crate::gamelib::scan::packages(dir));
+        Library::known(dir, db)
+    }
+
+    #[test]
+    fn a_scan_finds_the_packages_and_leaves_everything_else() {
+        let dir = scratch("scan");
+        for name in [
+            "GoldenAxe_v1.5_0017.lha",
+            "SimCity_v1.0_2193.lha",
+            "notes.txt",
+            "Screenshot.png",
+            // Case is the file system's business, not the list's.
+            "Zool_v1.0.LHA",
+        ] {
+            std::fs::write(dir.join(name), b"x").unwrap();
+        }
+        let library = refreshed(&dir, &mut Database::new());
+        let titles: Vec<&str> = library.entries().iter().map(Entry::title).collect();
+        assert_eq!(
+            titles,
+            ["GoldenAxe_v1.5_0017", "SimCity_v1.0_2193", "Zool_v1.0"]
+        );
+        assert!(library.covers(&dir));
+        assert!(!library.covers(Path::new("/somewhere/else")));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_matched_game_is_listed_under_its_catalogued_name() {
+        use crate::gamelib::db::Known;
+        let dir = scratch("named");
+        std::fs::write(dir.join("JamesPond2_v2.0_AGA_1354.lha"), b"x").unwrap();
+        std::fs::write(dir.join("Unknown_v1.0.lha"), b"x").unwrap();
+
+        let mut db = Database::new();
+        db.set_known(vec![Known {
+            file: "JamesPond2_v2.0_AGA_1354.lha".to_string(),
+            game: Some(Game {
+                name: "James Pond 2: Codename RoboCod".to_string(),
+                year: Some("1991".to_string()),
+                ..Game::default()
+            }),
+            manual: false,
+            slave_sha1: None,
+        }]);
+
+        let library = refreshed(&dir, &mut db);
+        // Sorted by what is shown, so the catalogued name decides where it
+        // sits rather than the file name it arrived under.
+        let titles: Vec<&str> = library.entries().iter().map(Entry::title).collect();
+        assert_eq!(titles, ["James Pond 2: Codename RoboCod", "Unknown_v1.0"]);
+        assert_eq!(
+            library.entries()[0]
+                .game
+                .as_ref()
+                .and_then(|g| g.year.as_deref()),
+            Some("1991")
+        );
+        assert!(library.entries()[1].game.is_none());
+
+        // And a package can be found by path, which is how the game being
+        // played stays the chosen one.
+        let at = library.position(&dir.join("Unknown_v1.0.lha"));
+        assert_eq!(at, Some(1));
+        assert_eq!(library.position(Path::new("/nowhere.lha")), None);
+
+        // And the same list without reading the folder again, which is
+        // what opening the page does: the store is the only thing it is
+        // built from, so what Refresh found is what comes back.
+        let listed = Library::known(&dir, &db);
+        let titles: Vec<&str> = listed.entries().iter().map(Entry::title).collect();
+        assert_eq!(titles, ["James Pond 2: Codename RoboCod", "Unknown_v1.0"]);
+        assert_eq!(
+            listed.entries()[0].path,
+            dir.join("JamesPond2_v2.0_AGA_1354.lha")
+        );
+        // Reading the folder again does not lose the metadata: that is
+        // work a scan spent minutes on.
+        let again = refreshed(&dir, &mut db);
+        assert_eq!(
+            again.entries()[0].game.as_ref().map(|g| g.name.as_str()),
+            Some("James Pond 2: Codename RoboCod")
+        );
+
+        // A package that has gone drops out; one that appears arrives
+        // unresolved.
+        std::fs::remove_file(dir.join("Unknown_v1.0.lha")).unwrap();
+        std::fs::write(dir.join("Zool_v1.0.lha"), b"x").unwrap();
+        let after = refreshed(&dir, &mut db);
+        let titles: Vec<&str> = after.entries().iter().map(Entry::title).collect();
+        assert_eq!(titles, ["James Pond 2: Codename RoboCod", "Zool_v1.0"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_collection_is_searched_all_the_way_down() {
+        // Libraries are filed by letter or by genre rather than left flat.
+        let dir = scratch("deep");
+        for sub in ["A", "B/Platformers", "C/1/2/3"] {
+            std::fs::create_dir_all(dir.join(sub)).unwrap();
+        }
+        std::fs::write(dir.join("A/Zool_v1.0.lha"), b"x").unwrap();
+        std::fs::write(dir.join("B/Platformers/JamesPond2_v2.0.lha"), b"x").unwrap();
+        std::fs::write(dir.join("C/1/2/3/SimCity_v1.0.lha"), b"x").unwrap();
+        std::fs::write(dir.join("B/notes.txt"), b"x").unwrap();
+
+        let library = refreshed(&dir, &mut Database::new());
+        let titles: Vec<&str> = library.entries().iter().map(Entry::title).collect();
+        assert_eq!(titles, ["JamesPond2_v2.0", "SimCity_v1.0", "Zool_v1.0"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_search_does_not_follow_a_link_out_of_the_library() {
+        // A link pointing at a parent is a loop, and a link pointing
+        // somewhere else is a search of somebody's whole disk. Neither is
+        // what "list my games" asked for.
+        let dir = scratch("links");
+        std::fs::create_dir_all(dir.join("games")).unwrap();
+        std::fs::write(dir.join("games/Zool_v1.0.lha"), b"x").unwrap();
+        // Outside the library, and reachable only through the link.
+        let outside = scratch("outside");
+        std::fs::write(outside.join("Elsewhere_v1.0.lha"), b"x").unwrap();
+        std::os::unix::fs::symlink(&outside, dir.join("games/away")).unwrap();
+        // And a loop back to the top.
+        std::os::unix::fs::symlink(&dir, dir.join("games/round")).unwrap();
+
+        let library = refreshed(&dir, &mut Database::new());
+        let titles: Vec<&str> = library.entries().iter().map(Entry::title).collect();
+        assert_eq!(titles, ["Zool_v1.0"], "the search left the library");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&outside);
+    }
+
+    #[test]
+    fn a_missing_folder_is_an_empty_list_rather_than_a_failure() {
+        // Nothing has been chosen yet, or the folder went away: the page
+        // shows nothing, which is what it would show anyway.
+        let library = refreshed(Path::new("/no/such/folder"), &mut Database::new());
+        assert!(library.is_empty());
+    }
+
+    #[test]
+    fn scrolling_speeds_up_while_it_continues_and_resets_when_it_stops() {
+        use std::time::{Duration, Instant};
+        let mut rate = ScrollRate::default();
+        let start = Instant::now();
+
+        // The first notch of a scroll always moves one row, so a flick to
+        // nudge the list by one does that and nothing more.
+        assert_eq!(rate.rows_for_notch(start), 1);
+
+        // Kept up, it builds.
+        let mut at = start;
+        let mut rows = 0;
+        for _ in 0..12 {
+            at += Duration::from_millis(30);
+            rows = rate.rows_for_notch(at);
+        }
+        assert!(rows > 1, "a continued scroll did not speed up");
+        assert!(rows <= 24, "a continued scroll ran away: {rows} rows");
+
+        // And a pause puts it back to one.
+        at += Duration::from_millis(400);
+        assert_eq!(rate.rows_for_notch(at), 1);
+    }
+}

--- a/src/gamelib/library.rs
+++ b/src/gamelib/library.rs
@@ -10,10 +10,10 @@
 //! from that -- so the same list comes back every time the page is opened,
 //! and comes back after a restart.
 //!
-//! Without a game library set, the folder holding the chosen game stands
-//! in, so pointing at any package still lists its neighbours. There is no
-//! separate setting for it: a second path to keep in step with the first is
-//! a way for the two to disagree.
+//! With no game library set there is no list: the page says so and says
+//! where to set one. It used to stand in the folder holding the chosen
+//! game, which read as Clear doing nothing -- emptying the setting left
+//! the list full of whatever sat beside the launch game.
 
 use std::path::{Path, PathBuf};
 

--- a/src/gamelib/mod.rs
+++ b/src/gamelib/mod.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The WHDLoad game library: a list of the packages you have, what the
+//! OpenRetro game database says about them, and the sync that fetches it.
+//!
+//! Compiled only with the `game-library` feature. It is the one part of
+//! Copperline that talks to the internet on its own account, and the only
+//! part that needs an HTTP client and a TLS stack, so a build without the
+//! feature links neither and carries none of this. WHDLoad itself does not
+//! depend on any of it: a package still boots from a path in the
+//! configuration exactly the same way.
+//!
+//! Deliberately self-contained. Nothing here reaches into the emulator, and
+//! the rest of Copperline reaches in through a small surface: the launcher
+//! asks for the list, for one game's details, and for a sync to be run.
+
+pub mod cover;
+pub mod db;
+pub mod library;
+pub mod openretro;
+pub mod scan;
+pub mod secret;
+pub mod sha1;
+pub mod support;
+
+pub use cover::Covers;
+pub use db::{Catalogue, Database, Game, Known};
+pub use library::{Entry, Library, ScrollRate};
+pub use scan::{Progress, Scan};
+pub use secret::Secret;

--- a/src/gamelib/mod.rs
+++ b/src/gamelib/mod.rs
@@ -25,6 +25,6 @@ pub mod support;
 
 pub use cover::Covers;
 pub use db::{Catalogue, Database, Game, Known};
-pub use library::{Entry, Library, ScrollRate};
+pub use library::{Entry, Library};
 pub use scan::{Progress, Scan};
 pub use secret::Secret;

--- a/src/gamelib/mod.rs
+++ b/src/gamelib/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod cover;
 pub mod db;
+pub mod http;
 pub mod library;
 pub mod openretro;
 pub mod scan;

--- a/src/gamelib/openretro.rs
+++ b/src/gamelib/openretro.rs
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Talking to openretro.org.
+//!
+//! The service has no published API. What follows was recovered by reading
+//! the FS-UAE launcher, which is the other program that syncs this
+//! database, and then confirmed against the live service; nothing here is
+//! taken from its code, and the storage and matching Copperline does with
+//! the result are its own.
+//!
+//! Three requests, in order:
+//!
+//! 1. `POST /api/auth` -- form-encoded `username`, `password`, `device_id`
+//!    and `device_name`, answering with a short auth token. The password is
+//!    needed for this request and nothing else.
+//! 2. `GET /api/sync/amiga/games?v=3&sync=<cursor>` -- authenticated with
+//!    the token as HTTP Basic. Answers with a run of records rather than
+//!    JSON; see [`Record`]. A page holds up to five hundred, and the next
+//!    page starts from the highest sync id in this one, so a resync asks
+//!    only for what has changed since.
+//! 3. `GET /image/<sha1>?s=<pixels>` -- cover art, as PNG, at whatever size
+//!    is asked for.
+//!
+//! **Over TLS, always.** The FS-UAE client defaults to `http`, which puts a
+//! password on the wire in clear; this one has no such mode.
+
+use std::io::Read;
+use std::time::Duration;
+
+use super::Secret;
+
+/// Where the service lives. Not configurable: a "server" setting is a way
+/// to be talked into sending a password somewhere else.
+const BASE: &str = "https://openretro.org";
+
+/// The platform whose games are synced. OpenRetro carries several; this is
+/// an Amiga emulator.
+const PLATFORM: &str = "amiga";
+
+/// How long any one request may take. A sync page is a couple of hundred
+/// kilobytes, so a slow link is the reason to wait, and a dead service is
+/// the reason not to wait forever.
+const TIMEOUT: Duration = Duration::from_secs(45);
+
+/// The size of cover art fetched, in pixels on the long edge. The list
+/// shows it small, and the service scales server-side, so this is what
+/// travels rather than a megabyte of full-resolution scan.
+pub const COVER_PIXELS: u32 = 256;
+
+/// What this client calls itself when it signs in. The service asks for a
+/// device id so a person can see and revoke their sessions; a fixed one
+/// says "Copperline on this machine" rather than making up a new device on
+/// every login and filling their list with strangers.
+pub const DEVICE_ID: &str = "copperline";
+
+/// What went wrong, in the terms the sync dialog reports.
+#[derive(Debug)]
+pub enum Error {
+    /// The username and password were not accepted.
+    Unauthorized,
+    /// Reached the service, which answered with something else.
+    Http(u16),
+    /// Did not reach the service at all.
+    Offline(String),
+    /// Reached it, and could not make sense of the answer.
+    Malformed(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Unauthorized => write!(f, "Wrong username or password"),
+            Error::Http(code) => write!(f, "Unable to connect to OpenRetro ({code})"),
+            Error::Offline(why) => write!(f, "Unable to connect to OpenRetro ({why})"),
+            Error::Malformed(what) => write!(f, "OpenRetro sent something unexpected ({what})"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// One entry of a sync page.
+///
+/// The stream is not JSON but a run of framed records, which is what makes
+/// a resync cheap: each carries the id the next request resumes from, so
+/// nothing already held is sent again.
+///
+/// ```text
+/// u32be sync_id | 16-byte uuid | u32be length | length bytes
+/// ```
+///
+/// The payload is zlib-compressed JSON. A zero length is not an empty
+/// record but a deletion: the entry with that uuid has gone.
+#[derive(Debug, Clone)]
+pub struct Record {
+    /// Where the next request resumes from.
+    pub sync_id: u32,
+    /// What the entry is, stably, across renames and re-imports.
+    pub uuid: [u8; 16],
+    /// The entry's JSON, or `None` when the entry was deleted.
+    pub json: Option<String>,
+}
+
+/// A session with the service: a token, and the client it was got with.
+///
+/// Holds no password. [`Session::open`] needs one to trade for the token
+/// and does not keep it; the caller is expected to drop theirs as soon as
+/// this returns, which is what [`Secret`] is for.
+pub struct Session {
+    agent: ureq::Agent,
+    token: Secret,
+}
+
+impl std::fmt::Debug for Session {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The token is a credential in its own right: it authenticates
+        // every request until it is handed back.
+        f.write_str("Session { token: <redacted> }")
+    }
+}
+
+impl Session {
+    /// Trade a username and password for a token.
+    pub fn open(username: &str, password: &Secret, device_id: &str) -> Result<Session> {
+        let agent = agent();
+        let body = form(&[
+            ("username", username),
+            ("password", password.expose()),
+            ("device_id", device_id),
+            // What the service lists the token against, so a person can see
+            // which machines hold one.
+            ("device_name", DEVICE_NAME),
+        ]);
+        let reply = agent
+            .post(&format!("{BASE}/api/auth"))
+            .content_type("application/x-www-form-urlencoded")
+            .send(&body);
+        let text = read_reply(reply)?;
+        let json: serde_json::Value =
+            serde_json::from_str(&text).map_err(|e| Error::Malformed(e.to_string()))?;
+        let token = json
+            .get("auth_token")
+            .and_then(|t| t.as_str())
+            .ok_or_else(|| Error::Malformed("no auth_token".into()))?;
+        let mut held = Secret::new();
+        for c in token.chars() {
+            held.push(c);
+        }
+        Ok(Session { agent, token: held })
+    }
+
+    /// Hand the token back, so it stops being usable. Best effort: a token
+    /// left behind expires on its own, and there is nothing a caller could
+    /// usefully do about a failure here.
+    pub fn close(self) {
+        let body = form(&[("auth_token", self.token.expose())]);
+        let _ = self
+            .agent
+            .post(&format!("{BASE}/api/deauth"))
+            .content_type("application/x-www-form-urlencoded")
+            .send(&body);
+    }
+
+    /// Fetch the games changed since `cursor`, as one page.
+    ///
+    /// An empty page means there is nothing further; otherwise the caller
+    /// resumes from the highest [`Record::sync_id`] returned.
+    pub fn games_since(&self, cursor: u32) -> Result<Vec<Record>> {
+        let url = format!("{BASE}/api/sync/{PLATFORM}/games?v=3&sync={cursor}");
+        let reply = self
+            .agent
+            .get(&url)
+            .header(
+                "Authorization",
+                &basic_auth("auth_token", self.token.expose()),
+            )
+            .call();
+        let bytes = read_bytes(reply)?;
+        decode_page(&bytes)
+    }
+}
+
+/// Fetch one piece of cover art, as the PNG bytes the service returns.
+///
+/// Unauthenticated: the images are public, and a sync token is not wanted
+/// on a request that does not need one.
+pub fn cover(sha1: &str, pixels: u32) -> Result<Vec<u8>> {
+    cover_with(&covers_agent(), sha1, pixels)
+}
+
+/// The same, through an agent the caller keeps.
+///
+/// A scan fetches art for every game in the library -- a thousand or more
+/// requests to one host. An agent per request is a TLS handshake per
+/// request; one agent held across them all reuses the connection, which is
+/// most of what makes the difference between a scan that finishes and one
+/// somebody gives up on.
+pub fn cover_with(agent: &ureq::Agent, sha1: &str, pixels: u32) -> Result<Vec<u8>> {
+    // The digest goes into a URL, so it is checked for being one rather
+    // than trusted to be: everything else here is a fixed string.
+    if sha1.len() != 40 || !sha1.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::Malformed("not a sha1".into()));
+    }
+    let url = format!("{BASE}/image/{sha1}?s={pixels}");
+    read_bytes(agent.get(&url).call())
+}
+
+/// An agent for fetching art: no credential goes near it, since the images
+/// are public and a sync token is not wanted on a request that does not
+/// need one.
+pub fn covers_agent() -> ureq::Agent {
+    agent()
+}
+
+/// Cut a sync page into its records.
+///
+/// Deliberately strict: a truncated page is a transfer that went wrong, and
+/// treating the tail as a short record would write a half-read entry into
+/// the database as though it were whole.
+pub fn decode_page(data: &[u8]) -> Result<Vec<Record>> {
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    while at < data.len() {
+        // Checked, because `n` is a length off the wire: on a 32-bit host
+        // a wrapped sum would pass this and panic on the slice.
+        let need = |at: usize, n: usize| -> Result<()> {
+            match at.checked_add(n) {
+                Some(end) if end <= data.len() => Ok(()),
+                _ => Err(Error::Malformed("page ends mid-record".into())),
+            }
+        };
+        need(at, 4)?;
+        let sync_id = u32::from_be_bytes(data[at..at + 4].try_into().expect("4 bytes"));
+        at += 4;
+        need(at, 16)?;
+        let mut uuid = [0u8; 16];
+        uuid.copy_from_slice(&data[at..at + 16]);
+        at += 16;
+        need(at, 4)?;
+        let len = u32::from_be_bytes(data[at..at + 4].try_into().expect("4 bytes")) as usize;
+        at += 4;
+        need(at, len)?;
+        let body = &data[at..at + len];
+        at += len;
+        let json = if body.is_empty() {
+            None
+        } else {
+            Some(inflate(body)?)
+        };
+        out.push(Record {
+            sync_id,
+            uuid,
+            json,
+        });
+    }
+    Ok(out)
+}
+
+/// The most one record's JSON may inflate to.
+///
+/// Compressed data is a ratio, not a size: the page it arrives in is
+/// bounded, but a thousand-to-one stream turns ten megabytes of page into
+/// ten gigabytes of string. A catalogue entry is a few hundred bytes and
+/// the largest seen is a few kilobytes, so this is a hundredfold headroom
+/// and still nowhere near enough to hurt.
+const MAX_RECORD: u64 = 1 << 20;
+
+/// Undo the zlib wrapper a record's JSON arrives in.
+fn inflate(body: &[u8]) -> Result<String> {
+    let mut text = String::new();
+    let read = flate2::read::ZlibDecoder::new(body)
+        .take(MAX_RECORD + 1)
+        .read_to_string(&mut text)
+        .map_err(|e| Error::Malformed(format!("record: {e}")))?;
+    if read as u64 > MAX_RECORD {
+        return Err(Error::Malformed("record is implausibly large".into()));
+    }
+    Ok(text)
+}
+
+/// The client every request goes through.
+///
+/// TLS is rustls against the Mozilla root set `webpki-roots` bundles --
+/// not the platform's store -- so a build needs no system OpenSSL and
+/// behaves the same on every host. The timeout is global, so a connection
+/// that stalls mid-transfer ends rather than holding a worker for ever.
+fn agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(TIMEOUT))
+        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .into()
+}
+
+/// `application/x-www-form-urlencoded`, escaping everything that is not
+/// unreserved -- a password is exactly the kind of string that contains
+/// the characters this is for.
+fn form(fields: &[(&str, &str)]) -> String {
+    let mut out = String::new();
+    for (key, value) in fields {
+        if !out.is_empty() {
+            out.push('&');
+        }
+        out.push_str(key);
+        out.push('=');
+        for byte in value.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    out.push(byte as char)
+                }
+                _ => out.push_str(&format!("%{byte:02X}")),
+            }
+        }
+    }
+    out
+}
+
+/// `Authorization: Basic ...`, which is how the token authenticates a sync
+/// request. Base64 by hand rather than for a dependency's sake.
+fn basic_auth(user: &str, pass: &str) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let raw = format!("{user}:{pass}");
+    let bytes = raw.as_bytes();
+    let mut out = String::from("Basic ");
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = u32::from(b[0]) << 16 | u32::from(b[1]) << 8 | u32::from(b[2]);
+        for i in 0..4 {
+            if i <= chunk.len() {
+                out.push(ALPHABET[(n >> (18 - 6 * i)) as usize & 0x3F] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+/// What the service is told to list this token against.
+///
+/// A fixed string, not the host's name. The name a person gives their
+/// machine is often their own, and there is no reason to hand that to a
+/// third party for a game database lookup.
+const DEVICE_NAME: &str = "copperline";
+
+/// Turn a reply into text, mapping the outcomes the dialog reports.
+fn read_reply(
+    reply: std::result::Result<ureq::http::Response<ureq::Body>, ureq::Error>,
+) -> Result<String> {
+    let bytes = read_bytes(reply)?;
+    String::from_utf8(bytes).map_err(|e| Error::Malformed(e.to_string()))
+}
+
+fn read_bytes(
+    reply: std::result::Result<ureq::http::Response<ureq::Body>, ureq::Error>,
+) -> Result<Vec<u8>> {
+    match reply {
+        Ok(mut response) => response
+            .body_mut()
+            .read_to_vec()
+            .map_err(|e| Error::Offline(e.to_string())),
+        Err(ureq::Error::StatusCode(401)) | Err(ureq::Error::StatusCode(403)) => {
+            Err(Error::Unauthorized)
+        }
+        Err(ureq::Error::StatusCode(code)) => Err(Error::Http(code)),
+        Err(e) => Err(Error::Offline(short(&e.to_string()))),
+    }
+}
+
+/// A connection failure in a few words, for a line in a small dialog.
+fn short(why: &str) -> String {
+    let first = why.split([':', ';']).next().unwrap_or(why).trim();
+    let mut out: String = first.chars().take(48).collect();
+    if first.chars().count() > 48 {
+        out.push_str("...");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn record(sync_id: u32, uuid: u8, json: Option<&str>) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&sync_id.to_be_bytes());
+        out.extend_from_slice(&[uuid; 16]);
+        match json {
+            None => out.extend_from_slice(&0u32.to_be_bytes()),
+            Some(text) => {
+                let mut z =
+                    flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::fast());
+                z.write_all(text.as_bytes()).unwrap();
+                let body = z.finish().unwrap();
+                out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+                out.extend_from_slice(&body);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn a_page_decodes_to_its_records() {
+        let mut page = record(7, 0xAA, Some(r#"{"game_name":"Turrican"}"#));
+        page.extend(record(9, 0xBB, None));
+        let got = decode_page(&page).expect("decodes");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].sync_id, 7);
+        assert_eq!(got[0].uuid, [0xAA; 16]);
+        assert_eq!(got[0].json.as_deref(), Some(r#"{"game_name":"Turrican"}"#));
+        // A zero-length record is a deletion, not an empty entry.
+        assert_eq!(got[1].sync_id, 9);
+        assert_eq!(got[1].json, None);
+    }
+
+    #[test]
+    fn a_truncated_page_is_refused_rather_than_half_read() {
+        // A transfer that stopped early would otherwise write a partial
+        // entry into the database as though it were whole.
+        let page = record(7, 0xAA, Some(r#"{"game_name":"Turrican"}"#));
+        for cut in [1, 4, 20, 24, page.len() - 1] {
+            let err = decode_page(&page[..cut]).expect_err("{cut} bytes should not decode");
+            assert!(matches!(err, Error::Malformed(_)), "{cut}: {err:?}");
+        }
+        assert!(decode_page(&page).is_ok(), "the whole page still decodes");
+    }
+
+    #[test]
+    fn an_empty_page_means_there_is_no_more() {
+        assert!(decode_page(&[]).expect("decodes").is_empty());
+    }
+
+    #[test]
+    fn a_form_escapes_what_a_password_is_made_of() {
+        // The characters a generated passphrase is full of are exactly the
+        // ones that would otherwise end the field or the body.
+        let body = form(&[("password", "a&b=c d+e%f")]);
+        assert_eq!(body, "password=a%26b%3Dc%20d%2Be%25f");
+        assert!(!body[9..].contains('&'), "a value ended the field early");
+    }
+
+    #[test]
+    fn basic_auth_encodes_the_way_the_header_wants() {
+        // Against the worked examples in RFC 4648, including both padding
+        // lengths, since a wrong tail is the classic base64 bug.
+        assert_eq!(basic_auth("", ""), "Basic Og==");
+        assert_eq!(basic_auth("a", "b"), "Basic YTpi");
+        assert_eq!(
+            basic_auth("auth_token", "0123456789abcdef01234567"),
+            "Basic YXV0aF90b2tlbjowMTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc="
+        );
+    }
+
+    /// A real sync against the live service, which is the only thing that
+    /// proves the requests above are the requests it wants. Ignored, and
+    /// reads the account from the environment so that no credential is ever
+    /// written into a source file:
+    ///
+    /// ```sh
+    /// OPENRETRO_USER=you OPENRETRO_PASS=... \
+    ///   cargo test --release --lib openretro_live -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "needs an OpenRetro account in OPENRETRO_USER/OPENRETRO_PASS"]
+    fn openretro_live_sync_and_cover() {
+        let user = std::env::var("OPENRETRO_USER").expect("OPENRETRO_USER");
+        let mut pass = Secret::new();
+        for c in std::env::var("OPENRETRO_PASS")
+            .expect("OPENRETRO_PASS")
+            .chars()
+        {
+            pass.push(c);
+        }
+
+        let session = Session::open(&user, &pass, "copperline-test-device").expect("authorized");
+        drop(pass);
+
+        // Two pages, to exercise the cursor as well as the first request.
+        let mut cursor = 0;
+        let mut seen = 0usize;
+        let mut a_cover: Option<String> = None;
+        for page in 0..2 {
+            let records = session.games_since(cursor).expect("a page of games");
+            assert!(!records.is_empty(), "page {page} was empty");
+            for r in &records {
+                assert!(r.sync_id > cursor, "the cursor did not advance");
+                cursor = r.sync_id;
+                seen += 1;
+                if a_cover.is_none() {
+                    if let Some(json) = &r.json {
+                        let v: serde_json::Value = serde_json::from_str(json).expect("a record");
+                        if let Some(sha1) = v.get("front_sha1").and_then(|s| s.as_str()) {
+                            a_cover = Some(sha1.to_string());
+                        }
+                    }
+                }
+            }
+            eprintln!(
+                "page {page}: {} records, cursor now {cursor}",
+                records.len()
+            );
+        }
+        assert!(seen >= 500, "expected a full page or more, saw {seen}");
+
+        // And the cover art the records point at is really a PNG.
+        let sha1 = a_cover.expect("some game in two pages has cover art");
+        let png = cover(&sha1, COVER_PIXELS).expect("cover art");
+        assert_eq!(&png[..8], b"\x89PNG\r\n\x1a\n", "not a PNG");
+        eprintln!("cover {sha1}: {} bytes", png.len());
+
+        session.close();
+    }
+
+    #[test]
+    fn a_cover_request_checks_the_digest_it_is_given() {
+        // It goes into a URL. Everything else in that URL is a fixed
+        // string, so this is the one part that has to be what it claims.
+        for bad in [
+            "",
+            "../etc/passwd",
+            "zz7b6a3b89d1696e5096aede1b7bd4bf6bf9cb83",
+            &"a".repeat(41),
+        ] {
+            let err = cover(bad, 128).expect_err("{bad:?} is not a sha1");
+            assert!(matches!(err, Error::Malformed(_)), "{bad:?}: {err:?}");
+        }
+    }
+
+    #[test]
+    fn a_session_says_nothing_about_its_token() {
+        // Debug is the easy way for a credential to reach a log line.
+        let shown = format!(
+            "{:?}",
+            Session {
+                agent: agent(),
+                token: Secret::new(),
+            }
+        );
+        assert_eq!(shown, "Session { token: <redacted> }");
+    }
+}

--- a/src/gamelib/openretro.rs
+++ b/src/gamelib/openretro.rs
@@ -283,26 +283,10 @@ fn inflate(body: &[u8]) -> Result<String> {
 /// The client every request goes through.
 ///
 /// TLS is verified against the Mozilla root set `webpki-roots` bundles --
-/// not the platform's store -- so it behaves the same on every host. Which
-/// implementation gets there differs: rustls everywhere but Windows, where
-/// it is the OS's own schannel, because rustls's crypto provider needs a C
-/// toolchain that an ARM64 Windows box does not have by default (see the
-/// two ureq entries in Cargo.toml). ureq never picks native-tls on its own,
-/// so Windows has to name it.
-///
-/// The timeout is global, so a connection that stalls mid-transfer ends
-/// rather than holding a worker for ever.
+/// not the platform's store -- so it behaves the same on every host, and
+/// which implementation gets there is [`http::agent`]'s business.
 fn agent() -> ureq::Agent {
-    let config = ureq::Agent::config_builder()
-        .timeout_global(Some(TIMEOUT))
-        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")));
-    #[cfg(windows)]
-    let config = config.tls_config(
-        ureq::tls::TlsConfig::builder()
-            .provider(ureq::tls::TlsProvider::NativeTls)
-            .build(),
-    );
-    config.build().into()
+    super::http::agent(TIMEOUT)
 }
 
 /// `application/x-www-form-urlencoded`, escaping everything that is not

--- a/src/gamelib/openretro.rs
+++ b/src/gamelib/openretro.rs
@@ -262,10 +262,17 @@ pub fn decode_page(data: &[u8]) -> Result<Vec<Record>> {
 ///
 /// Compressed data is a ratio, not a size: the page it arrives in is
 /// bounded, but a thousand-to-one stream turns ten megabytes of page into
-/// ten gigabytes of string. A catalogue entry is a few hundred bytes and
-/// the largest seen is a few kilobytes, so this is a hundredfold headroom
-/// and still nowhere near enough to hurt.
-const MAX_RECORD: u64 = 1 << 20;
+/// ten gigabytes of string. This is the guard against that, and nothing
+/// else -- it is not a statement about what a sensible record looks like.
+///
+/// Measured over the whole catalogue rather than guessed: 22,420 records
+/// across 45 pages, median 829 bytes, 99th percentile 33 KB -- and exactly
+/// one record of 6.38 MiB, a 2013 import carrying an enormous file list.
+/// The first cap was 1 MiB, written from what an incremental sync happened
+/// to contain, and that one record failed every full sync there has ever
+/// been. This is a little over twice the largest real record, and still
+/// three orders of magnitude short of anything that could hurt.
+const MAX_RECORD: u64 = 16 << 20;
 
 /// Undo the zlib wrapper a record's JSON arrives in.
 fn inflate(body: &[u8]) -> Result<String> {

--- a/src/gamelib/openretro.rs
+++ b/src/gamelib/openretro.rs
@@ -282,16 +282,27 @@ fn inflate(body: &[u8]) -> Result<String> {
 
 /// The client every request goes through.
 ///
-/// TLS is rustls against the Mozilla root set `webpki-roots` bundles --
-/// not the platform's store -- so a build needs no system OpenSSL and
-/// behaves the same on every host. The timeout is global, so a connection
-/// that stalls mid-transfer ends rather than holding a worker for ever.
+/// TLS is verified against the Mozilla root set `webpki-roots` bundles --
+/// not the platform's store -- so it behaves the same on every host. Which
+/// implementation gets there differs: rustls everywhere but Windows, where
+/// it is the OS's own schannel, because rustls's crypto provider needs a C
+/// toolchain that an ARM64 Windows box does not have by default (see the
+/// two ureq entries in Cargo.toml). ureq never picks native-tls on its own,
+/// so Windows has to name it.
+///
+/// The timeout is global, so a connection that stalls mid-transfer ends
+/// rather than holding a worker for ever.
 fn agent() -> ureq::Agent {
-    ureq::Agent::config_builder()
+    let config = ureq::Agent::config_builder()
         .timeout_global(Some(TIMEOUT))
-        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .into()
+        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")));
+    #[cfg(windows)]
+    let config = config.tls_config(
+        ureq::tls::TlsConfig::builder()
+            .provider(ureq::tls::TlsProvider::NativeTls)
+            .build(),
+    );
+    config.build().into()
 }
 
 /// `application/x-www-form-urlencoded`, escaping everything that is not

--- a/src/gamelib/openretro.rs
+++ b/src/gamelib/openretro.rs
@@ -27,6 +27,8 @@
 use std::io::Read;
 use std::time::Duration;
 
+use zeroize::Zeroizing;
+
 use super::Secret;
 
 /// Where the service lives. Not configurable: a "server" setting is a way
@@ -136,7 +138,7 @@ impl Session {
         let reply = agent
             .post(&format!("{BASE}/api/auth"))
             .content_type("application/x-www-form-urlencoded")
-            .send(&body);
+            .send(body.as_str());
         let text = read_reply(reply)?;
         let json: serde_json::Value =
             serde_json::from_str(&text).map_err(|e| Error::Malformed(e.to_string()))?;
@@ -160,7 +162,7 @@ impl Session {
             .agent
             .post(&format!("{BASE}/api/deauth"))
             .content_type("application/x-www-form-urlencoded")
-            .send(&body);
+            .send(body.as_str());
     }
 
     /// Fetch the games changed since `cursor`, as one page.
@@ -299,8 +301,11 @@ fn agent() -> ureq::Agent {
 /// `application/x-www-form-urlencoded`, escaping everything that is not
 /// unreserved -- a password is exactly the kind of string that contains
 /// the characters this is for.
-fn form(fields: &[(&str, &str)]) -> String {
-    let mut out = String::new();
+fn form(fields: &[(&str, &str)]) -> Zeroizing<String> {
+    // Zeroizing, because this is the password again: percent-encoding
+    // leaves every unreserved byte of it verbatim, and a plain String would
+    // hand the whole credential back to the allocator unwiped.
+    let mut out = Zeroizing::new(String::new());
     for (key, value) in fields {
         if !out.is_empty() {
             out.push('&');
@@ -312,7 +317,14 @@ fn form(fields: &[(&str, &str)]) -> String {
                 b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
                     out.push(byte as char)
                 }
-                _ => out.push_str(&format!("%{byte:02X}")),
+                // Written a digit at a time rather than through `format!`,
+                // whose temporary would be one more unwiped copy.
+                _ => {
+                    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                    out.push('%');
+                    out.push(HEX[(byte >> 4) as usize] as char);
+                    out.push(HEX[(byte & 0xf) as usize] as char);
+                }
             }
         }
     }
@@ -444,7 +456,7 @@ mod tests {
         // The characters a generated passphrase is full of are exactly the
         // ones that would otherwise end the field or the body.
         let body = form(&[("password", "a&b=c d+e%f")]);
-        assert_eq!(body, "password=a%26b%3Dc%20d%2Be%25f");
+        assert_eq!(body.as_str(), "password=a%26b%3Dc%20d%2Be%25f");
         assert!(!body[9..].contains('&'), "a value ended the field early");
     }
 

--- a/src/gamelib/scan.rs
+++ b/src/gamelib/scan.rs
@@ -1,0 +1,1172 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Resolving a folder of packages into a library with metadata.
+//!
+//! Nothing here happens on its own. Opening the Library page lists what is
+//! in the game folder and reads what the last scan resolved; it does not
+//! go looking. A folder can hold thousands of packages on a slow disk, and
+//! a page that scanned whenever it was opened would be a page that stalls
+//! for a minute because somebody clicked the wrong tab. The two buttons say
+//! when: Refresh re-reads the folder, and Scan runs this.
+//!
+//! A scan is four pieces of work, in order:
+//!
+//! 1. **The catalogue.** The snapshot in the cache directory is brought up
+//!    to date from the sync cursor, which is a few pages after a first run
+//!    and all of it before one. Without a signed-in session it is used as
+//!    it stands -- local first, always -- and a scan with neither a session
+//!    nor a snapshot is the one case that has nothing to work from.
+//! 2. **Reading.** Enough packages are opened to find out whether the
+//!    catalogue can identify them by the digest of their WHDLoad slave.
+//!    Where it can, every package is read and matched exactly; where it
+//!    cannot, the reading stops after the probe. See [`slave_digests`].
+//! 3. **Matching.** What the digests did not answer is looked up by name.
+//! 4. **Art.** Covers the catalogue points at and the cache has not got are
+//!    fetched. This is the long part of a first scan, and the part a second
+//!    one skips entirely.
+//!
+//! It runs on a worker thread and reports as it goes. It can be stopped at
+//! any point between items -- by the button, or by the machine starting,
+//! since a person who has pressed Run is done with the launcher -- and a
+//! stopped scan keeps what it had resolved rather than throwing it away.
+//! Nothing it meets is fatal: an unreadable folder, a corrupt snapshot, a
+//! service that will not answer or answers with nonsense all end as a short
+//! line on the status bar, because a launcher that panics has lost a
+//! person's session over a file they have never heard of.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::Arc;
+
+use super::db::{Catalogue, Known};
+use super::openretro::Session;
+
+/// What a running scan has to say for itself.
+#[derive(Debug, Clone)]
+pub enum Progress {
+    /// Reading the game folder.
+    Listing,
+    /// Bringing the catalogue snapshot up to date, so far.
+    Syncing { games: usize },
+    /// Reading the packages, to identify them by what is inside.
+    Reading { done: usize, total: usize },
+    /// Looking packages up.
+    Matching { done: usize, total: usize },
+    /// Everything matched, before any art has been fetched. Sent as soon
+    /// as it is known so the page fills in with names, years and
+    /// publishers while the slow part is still running -- a scan of a few
+    /// thousand games that is interrupted at 60% has still done 60% of the
+    /// useful work, and there is no reason to sit on it.
+    Matched { known: Vec<Known>, matched: usize },
+    /// Fetching the art that is missing.
+    Art { done: usize, total: usize },
+    /// Finished. What it resolved came in [`Progress::Matched`], which is
+    /// sent before the art whether the scan finishes or is stopped, so
+    /// this only has to say how it ended.
+    Done {
+        /// Whether it ran to the end rather than being stopped.
+        complete: bool,
+        /// What the online database contributed: how many entries the sync
+        /// brought in, or `None` when it was never asked because nobody is
+        /// signed in. Reported because "scan complete" on its own reads as
+        /// "checked with OpenRetro" whether or not anything did.
+        synced: Option<usize>,
+    },
+    /// Gave up. The string is short enough for the status bar, which is
+    /// perhaps forty characters wide before it starts clipping; whatever
+    /// else is worth knowing has already gone to the log.
+    Failed(String),
+}
+
+impl Progress {
+    /// The line the status bar shows for it.
+    pub fn message(&self) -> String {
+        match self {
+            Progress::Listing => "Reading the game folder...".to_string(),
+            Progress::Syncing { games } => format!("Updating the game database... {games} games"),
+            Progress::Reading { done, total } => format!("Reading packages... {done}/{total}"),
+            Progress::Matching { done, total } => format!("Matching games... {done}/{total}"),
+            Progress::Matched { matched, known } => {
+                format!("Matched {matched} of {} games", known.len())
+            }
+            Progress::Art { done, total } => format!("Fetching cover art... {done}/{total}"),
+            Progress::Done {
+                complete: false, ..
+            } => "Scan stopped -- kept what it had".to_string(),
+            Progress::Done { synced: None, .. } => {
+                "Scan complete -- not logged in, used the cached database".to_string()
+            }
+            Progress::Done {
+                synced: Some(0), ..
+            } => "Scan complete -- database already up to date".to_string(),
+            Progress::Done {
+                synced: Some(n), ..
+            } => format!("Scan complete -- {n} database entries updated"),
+            Progress::Failed(why) => why.clone(),
+        }
+    }
+
+    /// Whether this is the last thing a scan will say.
+    pub fn is_last(&self) -> bool {
+        matches!(self, Progress::Done { .. } | Progress::Failed(_))
+    }
+}
+
+/// A scan in flight.
+pub struct Scan {
+    rx: Receiver<Progress>,
+    stop: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for Scan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Scan { .. }")
+    }
+}
+
+impl Drop for Scan {
+    /// Dropping the handle stops the worker: it checks the flag between
+    /// items, sees it set, and finishes rather than carrying on fetching
+    /// art for a page nobody is looking at.
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+impl Scan {
+    /// Start one. `session` is what a signed-in launcher has; without it
+    /// the scan works from the cached snapshot alone. `held` is the slave
+    /// digest already worked out for each package, so a rescan does not
+    /// open the archives it has read before.
+    pub fn start(
+        folder: PathBuf,
+        cache: PathBuf,
+        session: Option<Arc<Session>>,
+        held: HashMap<String, String>,
+    ) -> Scan {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let stop = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            // Whatever goes wrong in there -- including a panic, which is a
+            // bug rather than a condition, but is still not worth a lost
+            // session over -- comes back as a line rather than as a crash.
+            let sent = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                run(&folder, &cache, session.as_deref(), &held, &flag, &tx)
+            }));
+            if let Err(_panic) = sent {
+                let _ = tx.send(Progress::Failed("Scan failed unexpectedly".to_string()));
+            }
+        });
+        Scan { rx, stop }
+    }
+
+    /// Everything said since the last look, oldest first.
+    pub fn poll(&self) -> Vec<Progress> {
+        self.rx.try_iter().collect()
+    }
+
+    /// Ask it to stop at the next item. It always gets to finish the one it
+    /// is on, so nothing is left half written.
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Where the catalogue snapshot sits inside the cache directory.
+pub fn catalogue_path(cache: &Path) -> PathBuf {
+    cache.join("openretro.json")
+}
+
+/// Where fetched art sits inside the cache directory.
+pub fn covers_path(cache: &Path) -> PathBuf {
+    cache.join("covers")
+}
+
+/// The scan itself, on the worker thread.
+fn run(
+    folder: &Path,
+    cache: &Path,
+    session: Option<&Session>,
+    held: &HashMap<String, String>,
+    stop: &AtomicBool,
+    tx: &Sender<Progress>,
+) {
+    // Stopping keeps what has been resolved: a library half filled in
+    // beats one not filled in at all, and the next scan carries on from a
+    // cache that is further along.
+    let stopped = |tx: &Sender<Progress>, known: Vec<Known>, matched: usize| {
+        let _ = tx.send(Progress::Matched { known, matched });
+        let _ = tx.send(Progress::Done {
+            complete: false,
+            synced: None,
+        });
+    };
+
+    let _ = tx.send(Progress::Listing);
+    if !folder.is_dir() {
+        log::error!("game library: {} is not a directory", folder.display());
+        let _ = tx.send(Progress::Failed("No game library there".to_string()));
+        return;
+    }
+    let files = packages(folder);
+    if files.is_empty() {
+        log::error!("game library: no .lha packages under {}", folder.display());
+        let _ = tx.send(Progress::Failed(
+            "No packages in the game library".to_string(),
+        ));
+        return;
+    }
+
+    // The catalogue, local first: what is cached is used as it stands, and
+    // a session brings it up to date from where it left off.
+    let at = catalogue_path(cache);
+    let mut catalogue = Catalogue::load(&at);
+    let had = catalogue.len();
+    // How many entries the online database contributed, or `None` if it
+    // was never asked. A scan that says nothing about this is a scan a
+    // person reasonably reads as having checked when it has not.
+    let mut synced = None;
+    if let Some(session) = session {
+        let outcome = sync(session, &mut catalogue, stop, tx);
+        synced = Some(*outcome.as_ref().unwrap_or_else(|(_, brought)| brought));
+        // Whatever arrived is kept, cursor and all, whether the sync
+        // finished or the network went away in the middle of it. That is
+        // what makes the next scan resume rather than start again -- and
+        // a connection that drops on page forty of fifty should cost the
+        // last ten pages, not the first forty.
+        if catalogue.len() != had {
+            if let Err(e) = catalogue.save(&at) {
+                log::warn!("game library: could not cache the catalogue: {e}");
+            }
+        }
+        if let Err((why, _)) = outcome {
+            // A sync that failed is not a scan that failed, as long as
+            // there is something to match against.
+            if catalogue.is_empty() {
+                log::error!("game library: {why}, and nothing cached to match against");
+                let _ = tx.send(Progress::Failed("Could not reach OpenRetro".to_string()));
+                return;
+            }
+            log::warn!("game library: {why}; matching against what is cached");
+        }
+    } else if catalogue.is_empty() {
+        log::error!(
+            "game library: no cached game database and no OpenRetro session; \
+             press Log in on the WHDLoad page and scan again"
+        );
+        let _ = tx.send(Progress::Failed("Not logged in to OpenRetro".to_string()));
+        return;
+    }
+    if stop.load(Ordering::Relaxed) {
+        stopped(tx, Vec::new(), 0);
+        return;
+    }
+
+    // Matching, by what is inside a package before what it is called.
+    let total = files.len();
+    let digests = slave_digests(folder, &files, held, stop, tx);
+    if stop.load(Ordering::Relaxed) {
+        stopped(tx, Vec::new(), 0);
+        return;
+    }
+    let mut known = Vec::with_capacity(total);
+    let (mut matched, mut by_digest) = (0, 0);
+    for (done, file) in files.iter().enumerate() {
+        if stop.load(Ordering::Relaxed) {
+            stopped(tx, known, matched);
+            return;
+        }
+        if done % 64 == 0 {
+            let _ = tx.send(Progress::Matching { done, total });
+        }
+        let slave_sha1 = digests[done].clone();
+        // The digest first: where it answers, the bytes of that slave are
+        // that game's and there is nothing to be wrong about. The name is
+        // the fallback, for a package the catalogue has no WHDLoad release
+        // of -- which is most of a third of them.
+        let game = slave_sha1
+            .as_deref()
+            .and_then(|sha1| catalogue.match_digest(sha1))
+            .inspect(|_| by_digest += 1)
+            .or_else(|| catalogue.match_file(file.rsplit('/').next().unwrap_or(file)))
+            .cloned();
+        matched += usize::from(game.is_some());
+        known.push(Known {
+            file: file.clone(),
+            game,
+            slave_sha1,
+            // A scan never claims one as hand-filled; the store keeps
+            // whichever entries already were.
+            manual: false,
+        });
+    }
+    log::info!(
+        "game library: {matched}/{total} matched, {by_digest} of them by slave digest \
+         ({} digests known)",
+        catalogue.digest_count()
+    );
+
+    // The art each match wants, worked out before the result is handed
+    // over -- after it, `known` belongs to the launcher.
+    let covers = covers_path(cache);
+    let wanted: Vec<String> = {
+        let mut seen = std::collections::HashSet::new();
+        known
+            .iter()
+            .filter_map(|k| k.game.as_ref()?.front_sha1.as_deref())
+            .filter(|sha1| seen.insert(*sha1))
+            .filter(|sha1| !super::cover::cover_file(&covers, sha1).exists())
+            .map(str::to_string)
+            .collect()
+    };
+    let _ = tx.send(Progress::Matched { known, matched });
+
+    // Art. The long part of a first scan, and skipped entirely by a second:
+    // only digests the cache has not got are fetched.
+    if !wanted.is_empty() {
+        if std::fs::create_dir_all(&covers).is_err() {
+            log::warn!("game library: cannot write to {}", covers.display());
+        } else {
+            fetch_art(&wanted, &covers, stop, tx);
+        }
+    }
+    let _ = tx.send(Progress::Done {
+        complete: !stop.load(Ordering::Relaxed),
+        synced,
+    });
+}
+
+/// The digest of each package's WHDLoad slave, in the order given.
+///
+/// Two jobs, which is why every package is read rather than a sample.
+///
+/// The first is identity. A slave's bytes belong to exactly one game, so
+/// where the catalogue knows that digest the match is an answer rather
+/// than a guess about a file name. In practice OpenRetro's WHDLoad file
+/// lists were imported in 2015 and slaves are revised with every release,
+/// so a current collection matches almost none of them -- but it costs a
+/// couple of seconds to find out, and the exact path lights up for nothing
+/// if that data is ever refreshed.
+///
+/// The second is what makes it worth doing regardless: a digest is how a
+/// package is recognised after it has been renamed. Metadata somebody
+/// corrected by hand is filed against the package, and without this a
+/// rename would strand it -- see [`Database::set_known`].
+///
+/// `held` supplies what a previous scan worked out, so a rescan opens only
+/// the packages it has not seen. Reading one means decompressing a single
+/// member out of an archive -- a few kilobytes out of tens of megabytes --
+/// and the archives are independent, so they are read several at a time.
+///
+/// An archive that will not open, has no slave, or fails its CRC is not an
+/// error: it is one package matched by name instead. A library assembled
+/// over years has a few of those in it, and a scan that stopped at the
+/// first would never get past it.
+fn slave_digests(
+    folder: &Path,
+    files: &[String],
+    held: &HashMap<String, String>,
+    stop: &AtomicBool,
+    tx: &Sender<Progress>,
+) -> Vec<Option<String>> {
+    let mut out: Vec<Option<String>> = files.iter().map(|file| held.get(file).cloned()).collect();
+    let todo: Vec<usize> = (0..files.len()).filter(|&i| out[i].is_none()).collect();
+    read_digests(folder, files, &todo, &mut out, stop, tx);
+    out
+}
+
+/// Read the slave digest of each package in `todo` into `out`.
+fn read_digests(
+    folder: &Path,
+    files: &[String],
+    todo: &[usize],
+    out: &mut [Option<String>],
+    stop: &AtomicBool,
+    tx: &Sender<Progress>,
+) {
+    if todo.is_empty() {
+        return;
+    }
+    let (found_tx, found_rx) = std::sync::mpsc::channel::<(usize, String)>();
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let done = std::sync::atomic::AtomicUsize::new(0);
+    let total = todo.len();
+    std::thread::scope(|scope| {
+        for _ in 0..READ_WORKERS.min(total) {
+            let (tx, found_tx) = (tx.clone(), found_tx.clone());
+            let (next, done, todo) = (&next, &done, &todo);
+            scope.spawn(move || loop {
+                if stop.load(Ordering::Relaxed) {
+                    return;
+                }
+                let slot = next.fetch_add(1, Ordering::Relaxed);
+                let Some(&at) = todo.get(slot) else { return };
+                if let Some(sha1) = read_slave_digest(&folder.join(&files[at])) {
+                    let _ = found_tx.send((at, sha1));
+                }
+                let n = done.fetch_add(1, Ordering::Relaxed) + 1;
+                if n % 25 == 0 || n == total {
+                    let _ = tx.send(Progress::Reading { done: n, total });
+                }
+            });
+        }
+        // The workers' clones are what hold the channel open; this one
+        // would hold it open for ever.
+        drop(found_tx);
+    });
+    for (at, sha1) in found_rx {
+        out[at] = Some(sha1);
+    }
+}
+
+/// One package's slave digest, or `None` for anything that is not a
+/// readable archive with a slave in it.
+fn read_slave_digest(path: &Path) -> Option<String> {
+    // Nothing in here is trusted: the archive is somebody's download, and
+    // a decoder given a corrupt one may well panic rather than return an
+    // error. That is one bad file in a library, not a scan that dies.
+    let read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::package::read_first(path, |member| {
+            member
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(crate::package::is_slave_name)
+        })
+    }));
+    match read {
+        Ok(Ok(Some(data))) => Some(super::sha1::hex(&data)),
+        Ok(Ok(None)) => None,
+        Ok(Err(e)) => {
+            log::debug!(
+                "game library: {} has no readable slave: {e}",
+                path.display()
+            );
+            None
+        }
+        Err(_) => {
+            log::warn!("game library: {} could not be read at all", path.display());
+            None
+        }
+    }
+}
+
+/// How many archives are opened at once. They are read from disk and
+/// decompressed, so this is bounded by cores rather than by politeness.
+const READ_WORKERS: usize = 6;
+
+/// How many covers are fetched at once.
+///
+/// A library of a couple of thousand games wants nearly as many pictures,
+/// and one at a time over a network round trip is the difference between a
+/// scan that finishes while you wait and one you give up on. Six is enough
+/// to keep the link busy and few enough to be a polite number of
+/// connections to hold open against somebody else's server.
+const ART_WORKERS: usize = 6;
+
+/// Fetch the missing art, several at a time.
+///
+/// Each worker keeps its own agent, so the connection is reused across the
+/// hundreds of requests it makes rather than handshaked afresh for each.
+/// One that will not come is one game without a picture, not a scan that
+/// failed -- and each picture is written as it lands, so a scan stopped
+/// half way leaves half the art on disk rather than none of it.
+fn fetch_art(wanted: &[String], covers: &Path, stop: &AtomicBool, tx: &Sender<Progress>) {
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let done = std::sync::atomic::AtomicUsize::new(0);
+    let total = wanted.len();
+    std::thread::scope(|scope| {
+        for _ in 0..ART_WORKERS.min(total) {
+            let tx = tx.clone();
+            let (next, done) = (&next, &done);
+            scope.spawn(move || {
+                let agent = super::openretro::covers_agent();
+                loop {
+                    if stop.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    let at = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(sha1) = wanted.get(at) else { return };
+                    match super::openretro::cover_with(&agent, sha1, super::openretro::COVER_PIXELS)
+                    {
+                        Ok(png) => write_cover(covers, sha1, &png),
+                        Err(e) => log::debug!("game library: no art for {sha1}: {e}"),
+                    }
+                    // Reported in tens: a message a picture is a message a
+                    // frame, and the number on screen cannot be read that
+                    // fast anyway.
+                    let n = done.fetch_add(1, Ordering::Relaxed) + 1;
+                    if n % 10 == 0 || n == total {
+                        let _ = tx.send(Progress::Art { done: n, total });
+                    }
+                }
+            });
+        }
+    });
+}
+
+/// Write one cover, through a temporary so a download cut off half way
+/// does not leave a broken file the next scan would take for done.
+fn write_cover(covers: &Path, sha1: &str, png: &[u8]) {
+    let at = super::cover::cover_file(covers, sha1);
+    let temp = at.with_extension("png.partial");
+    if std::fs::write(&temp, png).is_ok() && std::fs::rename(&temp, &at).is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+/// Bring the snapshot up to date, a page at a time.
+fn sync(
+    session: &Session,
+    catalogue: &mut Catalogue,
+    stop: &AtomicBool,
+    tx: &Sender<Progress>,
+) -> Result<usize, (String, usize)> {
+    // The cursor is what makes this a check rather than a download: the
+    // service is asked for what has changed since last time, so a library
+    // already up to date costs one empty page.
+    let mut brought = 0;
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return Ok(brought);
+        }
+        let page = match session.games_since(catalogue.cursor) {
+            Ok(page) => page,
+            Err(e) => return Err((format!("Could not reach OpenRetro: {e}"), brought)),
+        };
+        if page.is_empty() {
+            return Ok(brought);
+        }
+        brought += catalogue.apply(&page);
+        let _ = tx.send(Progress::Syncing {
+            games: catalogue.len(),
+        });
+    }
+}
+
+/// Every package in a folder, as paths relative to it.
+///
+/// Relative rather than bare names because a collection filed by letter
+/// has two `Zool_v1.0.lha` in it as often as not, and the store has to be
+/// able to tell them apart.
+pub fn packages(folder: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    walk(folder, folder, 0, &mut 0, &mut out);
+    out
+}
+
+/// How deep the search goes, and how many directories it opens before
+/// giving up. The same limits the list itself uses, and for the same
+/// reasons: a library pointed at a home directory should stop rather than
+/// read somebody's whole disk.
+const MAX_DEPTH: usize = 6;
+const MAX_DIRS: usize = 4000;
+
+fn walk(root: &Path, dir: &Path, depth: usize, walked: &mut usize, out: &mut Vec<String>) {
+    if depth > MAX_DEPTH || *walked >= MAX_DIRS {
+        return;
+    }
+    *walked += 1;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    // Written with forward slashes whatever the host uses, so a store
+    // written on one machine still matches on another.
+    let relative = |path: &Path| -> Option<String> {
+        let under = path.strip_prefix(root).ok()?;
+        let parts: Vec<String> = under
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        (!parts.is_empty()).then(|| parts.join("/"))
+    };
+    for entry in entries.flatten() {
+        // A link is not followed: that is how a search walks out of the
+        // library, and how it goes round in a circle.
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_symlink() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let path = entry.path();
+        if kind.is_dir() {
+            if !crate::package::worth_walking(&name) {
+                continue;
+            }
+            // A directory with a slave under it is one game, and is not
+            // looked inside for more: a game's own data directories are
+            // not each a game of their own.
+            match crate::package::holds_a_slave(&path) {
+                true => out.extend(relative(&path)),
+                false => walk(root, &path, depth + 1, walked, out),
+            }
+            continue;
+        }
+        if crate::package::Kind::of_name(&name).is_some() {
+            out.extend(relative(&path));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        static NEXT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let at = std::env::temp_dir().join(format!(
+            "copperline-scan-{name}-{}",
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&at);
+        std::fs::create_dir_all(&at).unwrap();
+        at
+    }
+
+    /// Everything a scan says, run to a finish.
+    fn drain(scan: &Scan) -> Vec<Progress> {
+        let mut all = Vec::new();
+        for _ in 0..2000 {
+            all.extend(scan.poll());
+            if all.last().is_some_and(Progress::is_last) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        all
+    }
+
+    #[test]
+    fn a_scan_with_nothing_to_match_against_says_so_rather_than_failing_quietly() {
+        // No session and no cached snapshot: the one case a scan cannot do
+        // anything with. It has to name the reason, since "nothing
+        // happened" is what a person would otherwise see.
+        let games = scratch("nothing-games");
+        std::fs::write(games.join("Zool_v1.0.lha"), b"x").unwrap();
+        let cache = scratch("nothing-cache");
+
+        let scan = Scan::start(games.clone(), cache.clone(), None, Default::default());
+        let said = drain(&scan);
+        let last = said.last().expect("a scan says something");
+        assert!(
+            matches!(last, Progress::Failed(why) if why.contains("Not logged in")),
+            "{last:?}"
+        );
+        let _ = std::fs::remove_dir_all(&games);
+        let _ = std::fs::remove_dir_all(&cache);
+    }
+
+    #[test]
+    fn a_scan_matches_against_the_cache_without_a_session() {
+        // Local first: once a catalogue is cached, a scan needs nothing
+        // from the network -- which is also what makes it fast the second
+        // time.
+        use crate::gamelib::openretro::Record;
+        let games = scratch("cached-games");
+        for name in ["GoldenAxe_v1.5_0017.lha", "NoSuchGame_v1.0.lha"] {
+            std::fs::write(games.join(name), b"x").unwrap();
+        }
+        let cache = scratch("cached-cache");
+        let mut catalogue = Catalogue::new();
+        catalogue.apply(&[Record {
+            sync_id: 1,
+            uuid: [1; 16],
+            json: Some(r#"{"game_name":"Golden Axe","year":"1990"}"#.into()),
+        }]);
+        catalogue.save(&catalogue_path(&cache)).unwrap();
+
+        let scan = Scan::start(games.clone(), cache.clone(), None, Default::default());
+        let said = drain(&scan);
+        assert!(
+            matches!(said.last(), Some(Progress::Done { complete: true, .. })),
+            "did not finish: {:?}",
+            said.last()
+        );
+        // The result comes in Matched, before the art, so a scan stopped
+        // after that point has still delivered everything but the
+        // pictures.
+        let Some(Progress::Matched { known, matched }) =
+            said.iter().find(|p| matches!(p, Progress::Matched { .. }))
+        else {
+            panic!("nothing was matched: {said:?}");
+        };
+        assert_eq!(*matched, 1);
+        assert_eq!(known.len(), 2);
+        // Sorted comes later, in the store; here it is whatever the folder
+        // gave, so find rather than index.
+        let axe = known.iter().find(|k| k.file.starts_with("Golden")).unwrap();
+        assert_eq!(
+            axe.game.as_ref().map(|g| g.name.as_str()),
+            Some("Golden Axe")
+        );
+        let other = known.iter().find(|k| k.file.starts_with("NoSuch")).unwrap();
+        assert!(other.game.is_none(), "matched something it should not have");
+        let _ = std::fs::remove_dir_all(&games);
+        let _ = std::fs::remove_dir_all(&cache);
+    }
+
+    #[test]
+    fn a_scan_of_a_folder_that_is_not_there_is_a_message_and_not_a_panic() {
+        let cache = scratch("missing-cache");
+        let scan = Scan::start(
+            PathBuf::from("/no/such/folder"),
+            cache.clone(),
+            None,
+            Default::default(),
+        );
+        let last = drain(&scan).pop().expect("a scan says something");
+        assert!(matches!(last, Progress::Failed(_)), "{last:?}");
+        // And an empty one is not confused with a missing one.
+        let empty = scratch("missing-empty");
+        let scan = Scan::start(empty.clone(), cache.clone(), None, Default::default());
+        let last = drain(&scan).pop().expect("a scan says something");
+        assert!(
+            matches!(&last, Progress::Failed(why) if why.contains("No packages")),
+            "{last:?}"
+        );
+        let _ = std::fs::remove_dir_all(&empty);
+        let _ = std::fs::remove_dir_all(&cache);
+    }
+
+    #[test]
+    fn a_stopped_scan_keeps_what_it_had() {
+        // Pressing Run stops the scan. What it resolved up to then is worth
+        // keeping: a library half filled in beats one not filled in at all,
+        // and the next scan carries on from a cache that is further along.
+        use crate::gamelib::openretro::Record;
+        let games = scratch("stop-games");
+        for i in 0..64 {
+            std::fs::write(games.join(format!("Game{i}_v1.0.lha")), b"x").unwrap();
+        }
+        let cache = scratch("stop-cache");
+        let mut catalogue = Catalogue::new();
+        catalogue.apply(&[Record {
+            sync_id: 1,
+            uuid: [1; 16],
+            json: Some(r#"{"game_name":"Game1"}"#.into()),
+        }]);
+        catalogue.save(&catalogue_path(&cache)).unwrap();
+
+        let scan = Scan::start(games.clone(), cache.clone(), None, Default::default());
+        scan.stop();
+        let last = drain(&scan).pop().expect("a scan says something");
+        // Either it stopped in time or it beat us to the end; both are
+        // finished states, and neither loses anything.
+        assert!(matches!(last, Progress::Done { .. }), "{last:?}");
+        let _ = std::fs::remove_dir_all(&games);
+        let _ = std::fs::remove_dir_all(&cache);
+    }
+
+    #[test]
+    fn a_scan_writes_its_art_where_the_launcher_reads_it() {
+        // These drifted apart once -- the scan wrote cache/covers and the
+        // page read cache -- and the symptom was a whole library of
+        // downloaded art that never appeared. Both go through one
+        // function now, and this is what says so.
+        let cache = scratch("art-paths");
+        let covers = covers_path(&cache);
+        std::fs::create_dir_all(&covers).unwrap();
+        let sha1 = "a".repeat(40);
+        write_cover(&covers, &sha1, b"not really a png");
+
+        let at = crate::gamelib::cover::cover_file(&covers, &sha1);
+        assert!(at.is_file(), "the scan wrote nothing readable");
+        assert!(at.starts_with(&covers), "the art left the covers directory");
+        // And what a scan checks before fetching is the same file it wrote.
+        assert!(!covers.join(format!("{sha1}.png.partial")).exists());
+        let _ = std::fs::remove_dir_all(&cache);
+    }
+
+    #[test]
+    fn the_search_finds_packages_all_the_way_down_but_not_through_a_link() {
+        let dir = scratch("walk");
+        std::fs::create_dir_all(dir.join("A/B")).unwrap();
+        std::fs::write(dir.join("One_v1.0.lha"), b"x").unwrap();
+        std::fs::write(dir.join("A/Two_v1.0.lha"), b"x").unwrap();
+        std::fs::write(dir.join("A/B/Three_v1.0.LHA"), b"x").unwrap();
+        std::fs::write(dir.join("A/notes.txt"), b"x").unwrap();
+        #[cfg(unix)]
+        {
+            let outside = scratch("walk-outside");
+            std::fs::write(outside.join("Away_v1.0.lha"), b"x").unwrap();
+            std::os::unix::fs::symlink(&outside, dir.join("away")).unwrap();
+        }
+        let mut found = packages(&dir);
+        found.sort();
+        // Relative to the library, so two packages of the same name filed
+        // under different letters stay two packages -- and the link is not
+        // followed, so what is outside stays outside.
+        assert_eq!(
+            found,
+            ["A/B/Three_v1.0.LHA", "A/Two_v1.0.lha", "One_v1.0.lha"]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The whole thing against the live service and a real collection:
+    /// sign in, sync, match, fetch the art, write the store, and read it
+    /// back. Ignored; needs an account and somewhere to look.
+    ///
+    /// ```sh
+    /// OPENRETRO_USER=you OPENRETRO_PASS=... WHDLOAD_GAMES=~/Games \
+    ///   cargo test --release --lib scan_live -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "needs an OpenRetro account and a directory of packages"]
+    fn scan_live_end_to_end() {
+        use crate::gamelib::{Database, Secret};
+
+        let user = std::env::var("OPENRETRO_USER").expect("OPENRETRO_USER");
+        let mut pass = Secret::new();
+        for c in std::env::var("OPENRETRO_PASS")
+            .expect("OPENRETRO_PASS")
+            .chars()
+        {
+            pass.push(c);
+        }
+        let session =
+            Session::open(&user, &pass, super::super::openretro::DEVICE_ID).expect("authorized");
+        drop(pass);
+
+        let games = PathBuf::from(std::env::var("WHDLOAD_GAMES").expect("WHDLOAD_GAMES"));
+        let cache = std::env::var("COPPERLINE_SCAN_CACHE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| scratch("live-cache"));
+        let started = std::time::Instant::now();
+        let scan = Scan::start(
+            games.clone(),
+            cache.clone(),
+            Some(Arc::new(session)),
+            Default::default(),
+        );
+        let mut result = None;
+        let mut complete = None;
+        loop {
+            for said in scan.poll() {
+                eprintln!("  {}", said.message());
+                match said {
+                    Progress::Matched { known, matched } => result = Some((known, matched)),
+                    Progress::Done { complete: done, .. } => complete = Some(done),
+                    Progress::Failed(why) => panic!("the scan gave up: {why}"),
+                    _ => {}
+                }
+            }
+            if complete.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert_eq!(complete, Some(true), "the scan stopped early");
+        let (known, matched) = result.expect("the scan matched nothing");
+        eprintln!(
+            "scanned {} packages in {:.1}s, {matched} matched",
+            known.len(),
+            started.elapsed().as_secs_f32()
+        );
+        assert!(!known.is_empty(), "no packages in {}", games.display());
+
+        // What it costs to keep and to open, which is the whole point of
+        // the store's shape. Padded out to the worst case a real
+        // collection reaches, since a few dozen would prove nothing.
+        let mut db = Database::new();
+        let mut padded = known.clone();
+        for i in known.len()..5000 {
+            let mut filler = known[i % known.len()].clone();
+            filler.file = format!("filler/{i:05}_{}", filler.file);
+            padded.push(filler);
+        }
+        db.set_known(padded);
+        let at = cache.join("db.json");
+        db.save(&at).expect("saved");
+        let bytes = std::fs::metadata(&at).unwrap().len();
+        let read = std::time::Instant::now();
+        let back = Database::load(&at);
+        let took = read.elapsed();
+        eprintln!(
+            "store: {} entries, {} KiB, opens in {:.1}ms",
+            back.len(),
+            bytes / 1024,
+            took.as_secs_f32() * 1000.0
+        );
+        assert_eq!(back.len(), 5000);
+        assert!(
+            took < std::time::Duration::from_millis(250),
+            "opening the page would stall: {took:?}"
+        );
+        // And every game still finds its own metadata after the round trip.
+        for k in known.iter().filter(|k| k.game.is_some()) {
+            assert_eq!(
+                back.match_file(&k.file).map(|g| &g.name),
+                k.game.as_ref().map(|g| &g.name),
+                "{} lost its metadata",
+                k.file
+            );
+        }
+
+        // A second scan has nothing to fetch: the catalogue and the art are
+        // both cached, which is what makes it the fast one.
+        let again = std::time::Instant::now();
+        let scan = Scan::start(games.clone(), cache.clone(), None, Default::default());
+        let last = drain(&scan).pop().expect("a second scan finishes");
+        assert!(
+            matches!(last, Progress::Done { complete: true, .. }),
+            "{last:?}"
+        );
+        eprintln!(
+            "second scan, no network: {:.1}s",
+            again.elapsed().as_secs_f32()
+        );
+
+        if std::env::var("COPPERLINE_SCAN_CACHE").is_err() {
+            let _ = std::fs::remove_dir_all(&cache);
+        }
+    }
+
+    /// What the sync actually carries, so matching is not designed from a
+    /// guess about it.
+    #[test]
+    #[ignore = "diagnostic"]
+    fn what_the_sync_carries() {
+        use crate::gamelib::Secret;
+        let user = std::env::var("OPENRETRO_USER").unwrap();
+        let mut pass = Secret::new();
+        for c in std::env::var("OPENRETRO_PASS").unwrap().chars() {
+            pass.push(c);
+        }
+        let session =
+            Session::open(&user, &pass, super::super::openretro::DEVICE_ID).expect("authorized");
+        drop(pass);
+        let mut keys: std::collections::BTreeMap<String, usize> = Default::default();
+        let mut with_name = 0;
+        let mut without = Vec::new();
+        let mut whd: Vec<String> = Vec::new();
+        let mut cursor = 0;
+        for _ in 0..4 {
+            let page = session.games_since(cursor).unwrap();
+            if page.is_empty() {
+                break;
+            }
+            cursor = page.last().unwrap().sync_id;
+            for r in &page {
+                let Some(json) = &r.json else { continue };
+                let v: serde_json::Value = serde_json::from_str(json).unwrap();
+                let Some(obj) = v.as_object() else { continue };
+                for k in obj.keys() {
+                    *keys.entry(k.clone()).or_default() += 1;
+                }
+                if obj.contains_key("whdload_url") && whd.len() < 4 {
+                    whd.push(json.clone());
+                }
+                if obj.contains_key("game_name") {
+                    with_name += 1;
+                } else if without.len() < 3 {
+                    without.push(json.clone());
+                }
+            }
+        }
+        session.close();
+        eprintln!("fields across 4 pages ({with_name} with game_name):");
+        for (k, n) in &keys {
+            eprintln!("   {k}: {n}");
+        }
+        eprintln!("-- whdload records:");
+        for j in &whd {
+            eprintln!("   {}", &j[..j.len().min(700)]);
+        }
+        eprintln!("-- records without a game name:");
+        for j in &without {
+            eprintln!("   {}", &j[..j.len().min(600)]);
+        }
+    }
+
+    /// How much of the catalogue could be matched by content rather than
+    /// by name: the number that decides whether digests can lead.
+    #[test]
+    #[ignore = "diagnostic"]
+    fn whdload_digest_coverage() {
+        use crate::gamelib::Secret;
+        let user = std::env::var("OPENRETRO_USER").unwrap();
+        let mut pass = Secret::new();
+        for c in std::env::var("OPENRETRO_PASS").unwrap().chars() {
+            pass.push(c);
+        }
+        let session =
+            Session::open(&user, &pass, super::super::openretro::DEVICE_ID).expect("authorized");
+        drop(pass);
+        let (mut games, mut variants, mut whd, mut with_dh0) = (0, 0, 0, 0);
+        let mut slaves: std::collections::BTreeMap<String, String> = Default::default();
+        let mut parents: std::collections::BTreeSet<String> = Default::default();
+        let mut cursor = 0;
+        loop {
+            let page = session.games_since(cursor).unwrap();
+            if page.is_empty() {
+                break;
+            }
+            cursor = page.last().unwrap().sync_id;
+            for r in &page {
+                let Some(json) = &r.json else { continue };
+                let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else {
+                    continue;
+                };
+                let Some(obj) = v.as_object() else { continue };
+                if obj.contains_key("game_name") {
+                    games += 1;
+                    continue;
+                }
+                variants += 1;
+                if obj.contains_key("dh0_sha1") {
+                    with_dh0 += 1;
+                }
+                let Some(list) = obj.get("file_list").and_then(|f| f.as_str()) else {
+                    continue;
+                };
+                let Ok(files) = serde_json::from_str::<serde_json::Value>(list) else {
+                    continue;
+                };
+                let mut had_slave = false;
+                for f in files.as_array().into_iter().flatten() {
+                    let (Some(name), Some(sha1)) = (
+                        f.get("name").and_then(|n| n.as_str()),
+                        f.get("sha1").and_then(|s| s.as_str()),
+                    ) else {
+                        continue;
+                    };
+                    if name.to_lowercase().ends_with(".slave") {
+                        had_slave = true;
+                        slaves.insert(sha1.to_string(), name.to_string());
+                    }
+                }
+                if had_slave {
+                    whd += 1;
+                    if let Some(p) = obj.get("parent_uuid").and_then(|p| p.as_str()) {
+                        parents.insert(p.to_string());
+                    }
+                }
+            }
+        }
+        session.close();
+        eprintln!(
+            "catalogue: {games} games, {variants} variants, {whd} WHDLoad variants \
+             ({with_dh0} with dh0_sha1), {} distinct slave digests covering {} games",
+            slaves.len(),
+            parents.len()
+        );
+    }
+
+    /// The match rate and what the loose passes cost, against a real
+    /// library and the cached catalogue.
+    #[test]
+    #[ignore = "needs a scanned cache and a directory of packages"]
+    fn match_rate_on_a_real_library() {
+        let cache = PathBuf::from(std::env::var("COPPERLINE_SCAN_CACHE").unwrap());
+        let catalogue = Catalogue::load(&catalogue_path(&cache));
+        let games = PathBuf::from(std::env::var("WHDLOAD_GAMES").unwrap());
+        let files = packages(&games);
+        let started = std::time::Instant::now();
+        let mut matched = 0;
+        let mut misses = Vec::new();
+        let mut loose = Vec::new();
+        for file in &files {
+            let base = file.rsplit('/').next().unwrap_or(file);
+            match catalogue.match_file(base) {
+                Some(game) => {
+                    matched += 1;
+                    // Only the ones no key matched exactly: the loose
+                    // passes are the ones worth eyeballing.
+                    if catalogue.matched_exactly(base).is_none() {
+                        loose.push(format!("{base}  ->  {}", game.name));
+                    }
+                }
+                None => misses.push(base.to_string()),
+            }
+        }
+        let took = started.elapsed();
+        eprintln!(
+            "{matched}/{} matched ({}%) in {:.0}ms over {} catalogue games",
+            files.len(),
+            matched * 100 / files.len(),
+            took.as_secs_f32() * 1000.0,
+            catalogue.len()
+        );
+        eprintln!("-- {} matched loosely:", loose.len());
+        for l in loose.iter().take(30) {
+            eprintln!("   {l}");
+        }
+        for m in misses.iter().take(4) {
+            eprintln!("   miss {m}");
+        }
+    }
+
+    /// Read back the art a real scan left, through the launcher's own path.
+    #[test]
+    #[ignore = "needs a scanned cache"]
+    fn art_on_disk_is_found_by_the_reader() {
+        let cache = PathBuf::from(std::env::var("COPPERLINE_SCAN_CACHE").unwrap());
+        let db = crate::gamelib::Database::load(&PathBuf::from(
+            std::env::var("COPPERLINE_LIBRARY_DB").unwrap(),
+        ));
+        let mut covers = crate::gamelib::Covers::new(covers_path(&cache));
+        // Only the ones whose file is actually there: a store that has
+        // moved ahead of its cache -- better matching naming art nothing
+        // has fetched yet -- is a scan away from being right, not a bug.
+        let wanted: Vec<String> = db
+            .known()
+            .iter()
+            .filter_map(|k| k.game.as_ref()?.front_sha1.clone())
+            .filter(|sha1| crate::gamelib::cover::cover_file(&covers_path(&cache), sha1).is_file())
+            // As many as the queue holds: it drops stale requests on
+            // purpose, so asking for a hundred at once would prove
+            // nothing about the ones it kept.
+            .take(6)
+            .collect();
+        assert!(!wanted.is_empty(), "no art on disk to read back");
+        for sha1 in &wanted {
+            covers.want(sha1);
+        }
+        let mut have = 0;
+        for _ in 0..200 {
+            covers.poll();
+            have = wanted.iter().filter(|s| covers.get(s).is_some()).count();
+            if have == wanted.len() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        eprintln!(
+            "{have}/{} covers read back from {}",
+            wanted.len(),
+            cache.display()
+        );
+        assert_eq!(have, wanted.len(), "art on disk was not found");
+    }
+
+    /// Refresh against a real folder: a duplicate lists twice, and
+    /// deleting one takes it out.
+    #[test]
+    fn refresh_follows_the_folder() {
+        use crate::gamelib::Database;
+        let dir = scratch("refresh");
+        for name in ["GoldenAxe_v1.lha", "GoldenAxe_v1.zip", "Zool_v1.lha"] {
+            std::fs::write(dir.join(name), b"x").unwrap();
+        }
+        let mut db = Database::new();
+        db.merge_found(packages(&dir));
+        let mut found: Vec<&str> = db.known().iter().map(|k| k.file.as_str()).collect();
+        found.sort();
+        assert_eq!(
+            found,
+            ["GoldenAxe_v1.lha", "GoldenAxe_v1.zip", "Zool_v1.lha"]
+        );
+
+        std::fs::remove_file(dir.join("GoldenAxe_v1.zip")).unwrap();
+        db.merge_found(packages(&dir));
+        let mut found: Vec<&str> = db.known().iter().map(|k| k.file.as_str()).collect();
+        found.sort();
+        assert_eq!(found, ["GoldenAxe_v1.lha", "Zool_v1.lha"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/gamelib/scan.rs
+++ b/src/gamelib/scan.rs
@@ -16,11 +16,12 @@
 //!    and all of it before one. Without a signed-in session it is used as
 //!    it stands -- local first, always -- and a scan with neither a session
 //!    nor a snapshot is the one case that has nothing to work from.
-//! 2. **Reading.** Enough packages are opened to find out whether the
-//!    catalogue can identify them by the digest of their WHDLoad slave.
-//!    Where it can, every package is read and matched exactly; where it
-//!    cannot, the reading stops after the probe. See [`slave_digests`].
-//! 3. **Matching.** What the digests did not answer is looked up by name.
+//! 2. **Reading.** Each package is opened far enough to take the digest
+//!    of its WHDLoad slave, which identifies both the game and the
+//!    package itself across a rename. Only packages not read before.
+//!    See [`slave_digests`].
+//! 3. **Matching.** By that digest where the catalogue knows it, and by
+//!    name otherwise.
 //! 4. **Art.** Covers the catalogue points at and the cache has not got are
 //!    fetched. This is the long part of a first scan, and the part a second
 //!    one skips entirely.
@@ -404,7 +405,8 @@ fn read_digests(
                 }
                 let slot = next.fetch_add(1, Ordering::Relaxed);
                 let Some(&at) = todo.get(slot) else { return };
-                if let Some(sha1) = read_slave_digest(&folder.join(&files[at])) {
+                let at_path = crate::package::under(folder, &files[at]);
+                if let Some(sha1) = read_slave_digest(&at_path) {
                     let _ = found_tx.send((at, sha1));
                 }
                 let n = done.fetch_add(1, Ordering::Relaxed) + 1;

--- a/src/gamelib/scan.rs
+++ b/src/gamelib/scan.rs
@@ -225,7 +225,6 @@ fn run(
     // a session brings it up to date from where it left off.
     let at = catalogue_path(cache);
     let mut catalogue = Catalogue::load(&at);
-    let had = catalogue.len();
     // How many entries the online database contributed, or `None` if it
     // was never asked. A scan that says nothing about this is a scan a
     // person reasonably reads as having checked when it has not.
@@ -238,10 +237,13 @@ fn run(
         // what makes the next scan resume rather than start again -- and
         // a connection that drops on page forty of fifty should cost the
         // last ten pages, not the first forty.
-        if catalogue.len() != had {
-            if let Err(e) = catalogue.save(&at) {
-                log::warn!("game library: could not cache the catalogue: {e}");
-            }
+        // Saved whatever came back, not only when the count moved: a page
+        // can revise entries that already existed, or bring nothing but a
+        // newer cursor, and both leave the length alone. Discarding those
+        // would have the next scan download the same pages again, which is
+        // the opposite of what the cursor is for.
+        if let Err(e) = catalogue.save(&at) {
+            log::warn!("game library: could not cache the catalogue: {e}");
         }
         if let Err((why, _)) = outcome {
             // A sync that failed is not a scan that failed, as long as
@@ -512,6 +514,13 @@ fn fetch_art(wanted: &[String], covers: &Path, stop: &AtomicBool, tx: &Sender<Pr
 /// Write one cover, through a temporary so a download cut off half way
 /// does not leave a broken file the next scan would take for done.
 fn write_cover(covers: &Path, sha1: &str, png: &[u8]) {
+    // A 200 is not a picture: a service having a bad day answers with an
+    // HTML error page, and cached under a .png name it would be "present"
+    // for ever and never fetched again.
+    if !super::cover::is_png(png) {
+        log::warn!("game library: cover {sha1} was not a PNG; not cached");
+        return;
+    }
     let at = super::cover::cover_file(covers, sha1);
     let temp = at.with_extension("png.partial");
     if std::fs::write(&temp, png).is_ok() && std::fs::rename(&temp, &at).is_err() {
@@ -763,6 +772,23 @@ mod tests {
         let _ = std::fs::remove_dir_all(&cache);
     }
 
+    /// The smallest thing `is_png` accepts, for tests that only care that
+    /// the bytes are a picture.
+    fn one_pixel_png() -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut out, 1, 1);
+            encoder.set_color(png::ColorType::Rgb);
+            encoder.set_depth(png::BitDepth::Eight);
+            encoder
+                .write_header()
+                .unwrap()
+                .write_image_data(&[0, 0, 0])
+                .unwrap();
+        }
+        out
+    }
+
     #[test]
     fn a_scan_writes_its_art_where_the_launcher_reads_it() {
         // These drifted apart once -- the scan wrote cache/covers and the
@@ -773,13 +799,23 @@ mod tests {
         let covers = covers_path(&cache);
         std::fs::create_dir_all(&covers).unwrap();
         let sha1 = "a".repeat(40);
-        write_cover(&covers, &sha1, b"not really a png");
+        write_cover(&covers, &sha1, &one_pixel_png());
 
         let at = crate::gamelib::cover::cover_file(&covers, &sha1);
         assert!(at.is_file(), "the scan wrote nothing readable");
         assert!(at.starts_with(&covers), "the art left the covers directory");
         // And what a scan checks before fetching is the same file it wrote.
         assert!(!covers.join(format!("{sha1}.png.partial")).exists());
+
+        // A 200 that is not a picture -- a service answering with an HTML
+        // error page -- is refused rather than cached. Cached, it would be
+        // "present" for ever and the real cover never fetched.
+        let other = "b".repeat(40);
+        write_cover(&covers, &other, b"<html>down for maintenance</html>");
+        assert!(
+            !crate::gamelib::cover::cover_file(&covers, &other).exists(),
+            "a non-PNG body was cached as art"
+        );
         let _ = std::fs::remove_dir_all(&cache);
     }
 

--- a/src/gamelib/secret.rs
+++ b/src/gamelib/secret.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! A password or auth token, held for as long as it is needed and no
+//! longer.
+//!
+//! Copperline stores neither: the sync dialog asks for a password, trades
+//! it for a token, and forgets both when the sync ends. That leaves the
+//! window in which they are in memory, and this type is about keeping that
+//! window small and free of copies.
+//!
+//! Three things a plain `String` would get wrong:
+//!
+//! - **Growing reallocates.** A `String` that outgrows its buffer copies
+//!   itself somewhere new and frees the old one *without* clearing it, so
+//!   typing a long password can leave several prefixes of it lying in freed
+//!   heap. The buffer here is allocated once at its full width and never
+//!   grows, so there is only ever one copy.
+//! - **Dropping does not clear.** Freed memory keeps its contents until
+//!   something else claims it, where a core dump or a later allocation can
+//!   still read it. [`Zeroizing`] overwrites on drop with volatile writes
+//!   the optimiser is not allowed to elide -- which a hand-written
+//!   `buf.fill(0)` on a buffer nothing reads again very much is.
+//! - **`Debug` prints it.** Deriving `Debug` anywhere up the tree would put
+//!   a password in a log line or a panic message. The one here says
+//!   nothing.
+
+use zeroize::Zeroizing;
+
+/// The most characters a credential box accepts. Long enough for any
+/// passphrase, and fixed so the buffer behind it never has to grow.
+pub const MAX_LEN: usize = 128;
+
+/// A credential: kept in one buffer, wiped when dropped, and never printed.
+pub struct Secret {
+    /// Always allocated at [`MAX_LEN`] and never grown, so there is one
+    /// copy of the text and `Zeroizing` clears all of it.
+    text: Zeroizing<String>,
+}
+
+impl Secret {
+    pub fn new() -> Self {
+        Self {
+            text: Zeroizing::new(String::with_capacity(MAX_LEN)),
+        }
+    }
+
+    /// Append a character, up to the width the buffer was made for. Past
+    /// that the character is dropped rather than the buffer grown: growing
+    /// would copy what is already typed somewhere new and leave it there.
+    pub fn push(&mut self, c: char) {
+        if self.text.len() + c.len_utf8() <= MAX_LEN {
+            self.text.push(c);
+        }
+    }
+
+    pub fn pop(&mut self) {
+        self.text.pop();
+    }
+
+    pub fn clear(&mut self) {
+        // Zeroizing clears on drop, not on truncate, so wipe what is there
+        // before shortening: `String::clear` only moves the length.
+        unsafe { self.text.as_mut_vec() }.fill(0);
+        self.text.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    /// How many characters have been typed, for drawing the mask.
+    pub fn chars(&self) -> usize {
+        self.text.chars().count()
+    }
+
+    /// The text itself. Named so that every place a credential leaves this
+    /// type is visible in a grep, and so that nothing reaches for it by
+    /// accident through `Deref` or `Display`.
+    pub fn expose(&self) -> &str {
+        &self.text
+    }
+}
+
+impl Default for Secret {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Says nothing, so that a credential cannot reach a log line or a panic
+/// message through a `Debug` derive somewhere above it.
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Secret(<redacted>)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_secret_never_grows_its_buffer() {
+        // One allocation, made once: a password typed a character at a time
+        // must not leave prefixes of itself in freed heap along the way.
+        let mut s = Secret::new();
+        let at = s.expose().as_ptr();
+        for _ in 0..MAX_LEN {
+            s.push('x');
+        }
+        assert_eq!(s.chars(), MAX_LEN);
+        assert_eq!(s.expose().as_ptr(), at, "the buffer moved while typing");
+
+        // And it stops rather than growing.
+        s.push('y');
+        assert_eq!(s.chars(), MAX_LEN);
+        assert_eq!(s.expose().as_ptr(), at);
+    }
+
+    #[test]
+    fn a_secret_says_nothing_about_itself() {
+        let mut s = Secret::new();
+        for c in "hunter2".chars() {
+            s.push(c);
+        }
+        let shown = format!("{s:?}");
+        assert!(!shown.contains("hunter2"), "Debug printed the secret");
+        assert_eq!(shown, "Secret(<redacted>)");
+    }
+
+    #[test]
+    fn clearing_wipes_rather_than_forgets() {
+        let mut s = Secret::new();
+        for c in "hunter2".chars() {
+            s.push(c);
+        }
+        let at = s.expose().as_ptr();
+        s.clear();
+        assert!(s.is_empty());
+        // The bytes behind it are gone, not merely out of reach: the buffer
+        // is the same one, so this reads what a later `expose` would.
+        let behind = unsafe { std::slice::from_raw_parts(at, "hunter2".len()) };
+        assert!(
+            behind.iter().all(|&b| b == 0),
+            "the old text was still there after clear()"
+        );
+    }
+}

--- a/src/gamelib/secret.rs
+++ b/src/gamelib/secret.rs
@@ -54,8 +54,12 @@ impl Secret {
     }
 
     pub fn pop(&mut self) {
+        let was = self.text.len();
         self.text.pop();
-        self.wipe_tail(1);
+        // As many bytes as the character occupied, not one: a password with
+        // an accent in it would otherwise leave the rest of that character
+        // behind the end of the string.
+        self.wipe_tail(was - self.text.len());
     }
 
     /// Insert at a character index, which is how a caret part-way through
@@ -97,6 +101,19 @@ impl Secret {
     /// length; the characters they dropped are still in the allocation.
     /// `Zeroizing` would get them at drop, but a password deleted mid-typing
     /// should not sit in memory until the dialog closes.
+    /// The whole buffer, live bytes and spare capacity together, so a test
+    /// can see that what was deleted was actually overwritten.
+    ///
+    /// # Safety
+    /// The caller must not write through it: the string's own invariants
+    /// still hold over the first `len` bytes.
+    #[cfg(test)]
+    pub unsafe fn text_for_test(&mut self) -> &[u8] {
+        let vec = unsafe { self.text.as_mut_vec() };
+        let (ptr, cap) = (vec.as_ptr(), vec.capacity());
+        unsafe { std::slice::from_raw_parts(ptr, cap) }
+    }
+
     fn wipe_tail(&mut self, bytes: usize) {
         let vec = unsafe { self.text.as_mut_vec() };
         for byte in vec.spare_capacity_mut().iter_mut().take(bytes) {
@@ -144,6 +161,31 @@ impl std::fmt::Debug for Secret {
 
 #[cfg(test)]
 mod tests {
+    /// Deleting a multi-byte character wipes all of it.
+    ///
+    /// `pop` used to clear one byte whatever it removed, so a password with
+    /// an accent in it left the rest of that character in the spare
+    /// capacity until the whole buffer dropped.
+    #[test]
+    fn popping_a_multibyte_character_wipes_all_of_it() {
+        let mut secret = Secret::new();
+        for c in "aé".chars() {
+            secret.push(c);
+        }
+        assert_eq!(secret.expose(), "aé");
+        let len = secret.expose().len();
+        secret.pop();
+        assert_eq!(secret.expose(), "a");
+        // The two bytes of the character just removed are zero, not just
+        // the last of them.
+        let now = secret.expose().len();
+        let vec = unsafe { secret.text_for_test() };
+        assert!(
+            vec[now..len].iter().all(|&b| b == 0),
+            "part of the deleted character is still there"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/gamelib/secret.rs
+++ b/src/gamelib/secret.rs
@@ -55,6 +55,53 @@ impl Secret {
 
     pub fn pop(&mut self) {
         self.text.pop();
+        self.wipe_tail(1);
+    }
+
+    /// Insert at a character index, which is how a caret part-way through
+    /// the box types. Bounded exactly as [`push`](Self::push) is.
+    ///
+    /// Indices rather than a borrowed `&str`, so the text still leaves this
+    /// type in only one place: [`expose`](Self::expose).
+    pub fn insert_at(&mut self, caret: usize, c: char) {
+        if self.text.len() + c.len_utf8() <= MAX_LEN {
+            let at = self.byte_of(caret);
+            self.text.insert(at, c);
+        }
+    }
+
+    /// Remove the character at an index. False when the index is past the
+    /// end, where there is none.
+    pub fn remove_at(&mut self, caret: usize) -> bool {
+        let at = self.byte_of(caret);
+        if at >= self.text.len() {
+            return false;
+        }
+        let was = self.text.len();
+        self.text.remove(at);
+        self.wipe_tail(was - self.text.len());
+        true
+    }
+
+    /// The byte offset a character index lands on, or the end of the text.
+    fn byte_of(&self, caret: usize) -> usize {
+        self.text
+            .char_indices()
+            .nth(caret)
+            .map_or(self.text.len(), |(at, _)| at)
+    }
+
+    /// Zero the bytes a shortening just left behind the end of the string.
+    ///
+    /// `String::remove` and `String::pop` shift the tail down and move the
+    /// length; the characters they dropped are still in the allocation.
+    /// `Zeroizing` would get them at drop, but a password deleted mid-typing
+    /// should not sit in memory until the dialog closes.
+    fn wipe_tail(&mut self, bytes: usize) {
+        let vec = unsafe { self.text.as_mut_vec() };
+        for byte in vec.spare_capacity_mut().iter_mut().take(bytes) {
+            byte.write(0);
+        }
     }
 
     pub fn clear(&mut self) {

--- a/src/gamelib/sha1.rs
+++ b/src/gamelib/sha1.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! SHA-1, for identifying a WHDLoad package by what is inside it.
+//!
+//! Written out rather than pulled in: it is forty lines of a fully
+//! specified algorithm (FIPS 180-4), it is wanted for exactly one thing,
+//! and a dependency that reaches the network at build time to hash a
+//! kilobyte of slave header is a poor trade. Nothing here is a security
+//! decision -- the digests are catalogue keys, and SHA-1 is what the
+//! catalogue keys on.
+
+/// The digest of `data`, as the forty lowercase hex characters the
+/// catalogue writes.
+pub fn hex(data: &[u8]) -> String {
+    let mut out = String::with_capacity(40);
+    for byte in digest(data) {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+/// The twenty raw bytes.
+pub fn digest(data: &[u8]) -> [u8; 20] {
+    let mut h: [u32; 5] = [
+        0x6745_2301,
+        0xEFCD_AB89,
+        0x98BA_DCFE,
+        0x1032_5476,
+        0xC3D2_E1F0,
+    ];
+    // The message, then a 1 bit, then zeros to 56 mod 64, then the length
+    // in bits as a big-endian u64.
+    let mut block = [0u8; 64];
+    let mut chunks = data.chunks_exact(64);
+    for chunk in &mut chunks {
+        block.copy_from_slice(chunk);
+        compress(&mut h, &block);
+    }
+    let tail = chunks.remainder();
+    let mut last = [0u8; 128];
+    last[..tail.len()].copy_from_slice(tail);
+    last[tail.len()] = 0x80;
+    let bits = (data.len() as u64).wrapping_mul(8);
+    // One final block, or two when the padding will not fit in one.
+    let len = if tail.len() + 1 + 8 <= 64 { 64 } else { 128 };
+    last[len - 8..len].copy_from_slice(&bits.to_be_bytes());
+    for chunk in last[..len].chunks_exact(64) {
+        block.copy_from_slice(chunk);
+        compress(&mut h, &block);
+    }
+    let mut out = [0u8; 20];
+    for (i, word) in h.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+fn compress(h: &mut [u32; 5], block: &[u8; 64]) {
+    let mut w = [0u32; 80];
+    for (i, word) in w.iter_mut().take(16).enumerate() {
+        *word = u32::from_be_bytes([
+            block[i * 4],
+            block[i * 4 + 1],
+            block[i * 4 + 2],
+            block[i * 4 + 3],
+        ]);
+    }
+    for i in 16..80 {
+        w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
+    }
+    let [mut a, mut b, mut c, mut d, mut e] = *h;
+    for (i, &word) in w.iter().enumerate() {
+        let (f, k) = match i {
+            0..=19 => ((b & c) | ((!b) & d), 0x5A82_7999),
+            20..=39 => (b ^ c ^ d, 0x6ED9_EBA1),
+            40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1B_BCDC),
+            _ => (b ^ c ^ d, 0xCA62_C1D6),
+        };
+        let next = a
+            .rotate_left(5)
+            .wrapping_add(f)
+            .wrapping_add(e)
+            .wrapping_add(k)
+            .wrapping_add(word);
+        e = d;
+        d = c;
+        c = b.rotate_left(30);
+        b = a;
+        a = next;
+    }
+    for (slot, value) in h.iter_mut().zip([a, b, c, d, e]) {
+        *slot = slot.wrapping_add(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_published_vectors() {
+        // FIPS 180-2 appendix A, and the two lengths where the padding
+        // needs a second block.
+        assert_eq!(hex(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        assert_eq!(hex(b"abc"), "a9993e364706816aba3e25717850c26c9cd0d89d");
+        assert_eq!(
+            hex(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "84983e441c3bd26ebaae4aa1f95129e5e54670f1"
+        );
+        assert_eq!(
+            hex(&b"a".repeat(1_000_000)),
+            "34aa973cd4c4daa4f61eeb2bdbad27316534016f"
+        );
+        // The block boundaries, which is where padding goes wrong: 55 is
+        // the last length whose padding fits, 56 is the first that needs a
+        // second block, 64 is exactly one block, and 119/120 are the same
+        // pair one block along.
+        for (len, want) in [
+            (55, "c1c8bbdc22796e28c0e15163d20899b65621d65a"),
+            (56, "c2db330f6083854c99d4b5bfb6e8f29f201be699"),
+            (64, "0098ba824b5c16427bd7a1122a5a442a25ec644d"),
+            (119, "ee971065aaa017e0632a8ca6c77bb3bf8b1dfc56"),
+            (120, "f34c1488385346a55709ba056ddd08280dd4c6d6"),
+            (127, "89d95fa32ed44a7c610b7ee38517ddf57e0bb975"),
+            (128, "ad5b3fdbcb526778c2839d2f151ea753995e26a0"),
+        ] {
+            assert_eq!(hex(&b"a".repeat(len)), want, "{len} bytes");
+        }
+    }
+}

--- a/src/gamelib/support.rs
+++ b/src/gamelib/support.rs
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Fetching the two archives WHDLoad staging needs.
+//!
+//! `tools/fetch-whdload.sh` does this at packaging time so a release
+//! carries them; a build from source has neither until someone runs the
+//! script. The Download button does the same work from inside the
+//! launcher, from the same URLs and against the same pinned digests, so
+//! nobody has to find a shell to get started.
+//!
+//! The digests are the point. Both archives are fetched over the network
+//! from hosts nobody here controls, unpacked, and then *run on the
+//! emulated machine*, so a file that is not the file expected is not
+//! written at all. They are pinned in several places -- this module, the
+//! script, the Flatpak manifest, the Homebrew formula -- and
+//! [`tests::the_pinned_digests_match_the_fetch_script`] is what keeps this
+//! copy honest with the script's.
+
+use std::path::{Path, PathBuf};
+
+/// One of the two archives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Archive {
+    /// The WHDLoad distribution itself.
+    Whdload,
+    /// Soft-Kicker, whose `.RTB` relocation tables accompany raw Kickstart
+    /// images.
+    Skick,
+}
+
+impl Archive {
+    pub const ALL: [Archive; 2] = [Archive::Whdload, Archive::Skick];
+
+    /// Where it comes from.
+    pub fn url(self) -> &'static str {
+        match self {
+            // whdload.de publishes this as a rolling "current release"
+            // file, so a new upstream release changes the archive and the
+            // digest below stops matching. That is the signal to review the
+            // release and bump every pin, not to stop checking.
+            Archive::Whdload => "https://whdload.de/whdload/WHDLoad_usr.lha",
+            Archive::Skick => "https://aminet.net/util/boot/skick346.lha",
+        }
+    }
+
+    /// What it must hash to.
+    pub fn sha256(self) -> &'static str {
+        match self {
+            Archive::Whdload => "093333953737528d79c1eda7d21a16a0aa298698722624e7cfb31f588a0a156d",
+            Archive::Skick => "02b4d01852d12ab391c6469064f917221a0f7319fd0b3ba6c359403ec1d59f96",
+        }
+    }
+
+    /// The name it is saved under, which is the name it is published under.
+    pub fn file_name(self) -> &'static str {
+        self.url()
+            .rsplit('/')
+            .next()
+            .expect("a url has a last part")
+    }
+
+    /// What the page calls it.
+    pub fn label(self) -> &'static str {
+        match self {
+            Archive::Whdload => "WHDLoad package",
+            Archive::Skick => "SKick package",
+        }
+    }
+
+    /// Where it lands when nothing says otherwise.
+    pub fn default_path(&self) -> Option<PathBuf> {
+        crate::paths::whdload_support_dir().map(|dir| dir.join(self.file_name()))
+    }
+
+    /// The copy already sitting in the default place, if it is the right
+    /// file. Checked by digest rather than by name: a truncated download or
+    /// a differently-named file put there by hand is not this archive.
+    pub fn found_locally(&self) -> Option<PathBuf> {
+        let at = self.default_path()?;
+        let bytes = std::fs::read(&at).ok()?;
+        (sha256_hex(&bytes) == self.sha256()).then_some(at)
+    }
+}
+
+/// What went wrong, in the words the page shows.
+#[derive(Debug)]
+pub enum Error {
+    /// Could not work out where to put it.
+    NoHome,
+    /// Did not reach the host, or it refused.
+    Fetch(String),
+    /// Arrived, and was not the file expected.
+    Digest,
+    /// Reached the disk and did not stay there.
+    Write(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NoHome => write!(f, "No configuration directory to download into"),
+            Error::Fetch(why) => write!(f, "Download failed ({why})"),
+            Error::Digest => write!(
+                f,
+                "Download did not match its checksum, so it was discarded"
+            ),
+            Error::Write(why) => write!(f, "Could not save the download ({why})"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Fetch an archive into the default place, and answer where it landed.
+///
+/// A copy already there and already right is left alone: this is the same
+/// "up to date" the script reports rather than a fresh download every
+/// press. Nothing is written until the digest matches, and the file only
+/// takes its real name once it has.
+pub fn download(archive: Archive) -> Result<PathBuf, Error> {
+    if let Some(held) = archive.found_locally() {
+        return Ok(held);
+    }
+    let at = archive.default_path().ok_or(Error::NoHome)?;
+    let dir = at.parent().ok_or(Error::NoHome)?;
+    std::fs::create_dir_all(dir).map_err(|e| Error::Write(e.to_string()))?;
+
+    let bytes = fetch(archive.url())?;
+    if sha256_hex(&bytes) != archive.sha256() {
+        return Err(Error::Digest);
+    }
+    // Through a temporary, so an interrupted write cannot leave a partial
+    // archive under the name staging will later trust.
+    let temp = at.with_extension("lha.partial");
+    std::fs::write(&temp, &bytes).map_err(|e| Error::Write(e.to_string()))?;
+    match std::fs::rename(&temp, &at) {
+        Ok(()) => Ok(at),
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp);
+            Err(Error::Write(e.to_string()))
+        }
+    }
+}
+
+/// The most a support archive may be. WHDLoad's is around two megabytes
+/// and Soft-Kicker's a few hundred kilobytes.
+const MAX_ARCHIVE: u64 = 64 << 20;
+
+fn fetch(url: &str) -> Result<Vec<u8>, Error> {
+    use std::io::Read;
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(120)))
+        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .into();
+    let mut response = agent
+        .get(url)
+        .call()
+        .map_err(|e| Error::Fetch(short(&e.to_string())))?;
+    // Bounded, and read through `take` rather than straight off the
+    // reader: the digest is checked afterwards, so a wrong download is
+    // caught either way, but only if there was room to finish reading it.
+    // Both archives are a couple of megabytes; this is room to grow and
+    // still far short of a machine's memory.
+    let mut bytes = Vec::new();
+    response
+        .body_mut()
+        .as_reader()
+        .take(MAX_ARCHIVE + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|e| Error::Fetch(e.to_string()))?;
+    if bytes.len() as u64 > MAX_ARCHIVE {
+        return Err(Error::Fetch("archive is implausibly large".into()));
+    }
+    Ok(bytes)
+}
+
+fn short(why: &str) -> String {
+    let first = why.split([':', ';']).next().unwrap_or(why).trim();
+    first.chars().take(48).collect()
+}
+
+/// SHA-256, as the lower-case hex the pins are written in.
+///
+/// Written out rather than taken from a crate: it is forty lines, it is
+/// used for exactly these two files, and the alternative is a dependency
+/// in the tree of a program that otherwise hashes nothing.
+pub fn sha256_hex(data: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    let mut message = data.to_vec();
+    let bits = (data.len() as u64) * 8;
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bits.to_be_bytes());
+
+    for block in message.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in block.chunks_exact(4).enumerate() {
+            w[i] = u32::from_be_bytes(word.try_into().expect("4 bytes"));
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        for (slot, add) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *slot = slot.wrapping_add(add);
+        }
+    }
+    h.iter().map(|word| format!("{word:08x}")).collect()
+}
+
+/// The Kickstart directory to look in when none is set: WHDLoad's own,
+/// which is where a person who never chose one would have put them.
+pub fn default_kickstart_dir() -> Option<PathBuf> {
+    crate::paths::whdload_dir().map(|dir| dir.join("Kickstarts"))
+}
+
+/// Whether a directory exists and holds anything, so a default worth
+/// adopting can be told from one that is merely named.
+pub fn holds_anything(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_matches_the_published_vectors() {
+        // The three every implementation is checked against, plus the
+        // block-boundary lengths where the padding is easiest to get wrong.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        );
+        // 55, 56 and 64 bytes: either side of the point where the length
+        // no longer fits in the block it padded, and exactly one block.
+        assert_eq!(
+            sha256_hex(&[b'a'; 55]),
+            "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318"
+        );
+        assert_eq!(
+            sha256_hex(&[b'a'; 56]),
+            "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a"
+        );
+        assert_eq!(
+            sha256_hex(&[b'a'; 64]),
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb"
+        );
+    }
+
+    #[test]
+    fn the_pinned_digests_match_the_fetch_script() {
+        // The same two archives are pinned here, in tools/fetch-whdload.sh,
+        // in the Flatpak manifest and in the Homebrew formula. This one is
+        // the copy a running Copperline checks its download against, so it
+        // is the one most worth catching adrift.
+        let script = include_str!("../../tools/fetch-whdload.sh");
+        for archive in Archive::ALL {
+            assert!(
+                script.contains(archive.url()),
+                "{:?}: the script fetches a different URL",
+                archive
+            );
+            assert!(
+                script.contains(archive.sha256()),
+                "{:?}: the script pins a different checksum -- upstream released \\
+                 a new version and this copy was not bumped with it",
+                archive
+            );
+        }
+    }
+
+    #[test]
+    fn an_archive_is_named_by_what_it_is_published_as() {
+        assert_eq!(Archive::Whdload.file_name(), "WHDLoad_usr.lha");
+        assert_eq!(Archive::Skick.file_name(), "skick346.lha");
+    }
+}

--- a/src/gamelib/support.rs
+++ b/src/gamelib/support.rs
@@ -148,11 +148,9 @@ const MAX_ARCHIVE: u64 = 64 << 20;
 
 fn fetch(url: &str) -> Result<Vec<u8>, Error> {
     use std::io::Read;
-    let agent: ureq::Agent = ureq::Agent::config_builder()
-        .timeout_global(Some(std::time::Duration::from_secs(120)))
-        .user_agent(concat!("Copperline/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .into();
+    // Longer than the API's timeout: this is a couple of megabytes over
+    // somebody's home connection, not a request for a record.
+    let agent = super::http::agent(std::time::Duration::from_secs(120));
     let mut response = agent
         .get(url)
         .call()

--- a/src/lha.rs
+++ b/src/lha.rs
@@ -123,6 +123,42 @@ pub fn read_archive(archive: &Path) -> Result<Vec<ArchiveEntry>> {
     Ok(entries)
 }
 
+/// Read the first member whose path satisfies `want`, decompressing only
+/// that one.
+///
+/// [`read_archive`] decompresses everything, which is right when
+/// everything is wanted and wrong when one small file is: a WHDLoad
+/// package is tens of megabytes and its slave is a few kilobytes. Members
+/// that do not match are skipped through the archive rather than decoded.
+pub fn read_first(archive: &Path, want: impl Fn(&Path) -> bool) -> Result<Option<ArchiveEntry>> {
+    let mut reader = delharc::parse_file(archive)
+        .with_context(|| format!("opening LHA archive {}", archive.display()))?;
+    loop {
+        let header = reader.header();
+        let is_dir = header.is_directory();
+        let path = sanitize_member_path(&header.parse_pathname())?;
+        if !is_dir && want(&path) {
+            if !reader.is_decoder_supported() {
+                bail!(
+                    "archive member {} uses an unsupported compression method",
+                    path.display()
+                );
+            }
+            let mut data = Vec::new();
+            reader
+                .read_to_end(&mut data)
+                .with_context(|| format!("decompressing archive member {}", path.display()))?;
+            if !reader.crc_is_ok() {
+                bail!("archive member {} fails its CRC check", path.display());
+            }
+            return Ok(Some(ArchiveEntry { path, data }));
+        }
+        if !reader.next_file()? {
+            return Ok(None);
+        }
+    }
+}
+
 /// List the (normalized, relative) file member paths of an `.lha` archive
 /// without keeping their contents.
 pub fn list_files(archive: &Path) -> Result<Vec<PathBuf>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ pub mod floppy;
 // wasm32 browser build cannot do.
 #[cfg(feature = "fluxbridge")]
 pub mod fluxbridge;
+// The WHDLoad game library: the launcher's Library page, the local game
+// database, and the OpenRetro sync that fills it. Gated because it is the
+// only part of Copperline that makes network requests of its own, and so
+// the only part that needs an HTTP client and a TLS stack.
+#[cfg(feature = "game-library")]
+pub mod gamelib;
 #[cfg(feature = "frontend")]
 pub mod gamepad;
 pub mod gary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub mod midi;
 #[cfg(feature = "mt32")]
 pub mod mt32;
 pub mod net;
+pub mod package;
 pub mod parallel;
 pub mod paths;
 pub mod picasso2;

--- a/src/package.rs
+++ b/src/package.rs
@@ -102,6 +102,19 @@ pub fn stem_of(name: &str) -> &str {
     }
 }
 
+/// A stored relative path resolved under `folder`.
+///
+/// The store writes `/` whatever the host uses, so a library scanned on
+/// one machine still matches on another. Windows takes `/` in a path
+/// happily enough, but joining a component at a time says so outright
+/// rather than relying on it, and what comes out carries the host's own
+/// separator for everything downstream.
+pub fn under(folder: &Path, relative: &str) -> PathBuf {
+    let mut at = folder.to_path_buf();
+    at.extend(relative.split('/').filter(|part| !part.is_empty()));
+    at
+}
+
 /// Whether a name is a WHDLoad slave.
 pub fn is_slave_name(name: &str) -> bool {
     name.rsplit_once('.').is_some_and(|(_, tail)| {
@@ -356,6 +369,13 @@ fn extract_zip(archive: &Path, dest: &Path) -> Result<usize> {
 }
 
 /// Every file under a directory, relative to it, links not followed.
+///
+/// Ordered shallowest first and then by name, which is the order
+/// `whdload::find_slaves` prefers a slave in -- and, more to the point,
+/// an order at all: a directory is read in whatever order the filesystem
+/// feels like, so an unsorted walk would hash a different slave on
+/// different runs and the digest that identifies a package would move
+/// under it.
 fn walk(root: &Path) -> Result<Vec<PathBuf>> {
     fn step(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
         let entries =
@@ -376,6 +396,7 @@ fn walk(root: &Path) -> Result<Vec<PathBuf>> {
     }
     let mut out = Vec::new();
     step(root, root, &mut out)?;
+    out.sort_by_key(|p| (p.components().count(), p.to_string_lossy().to_lowercase()));
     Ok(out)
 }
 
@@ -407,6 +428,23 @@ mod tests {
     }
 
     #[test]
+    fn a_stored_path_resolves_under_the_folder() {
+        // The store keeps `/` whatever the host wrote it on.
+        let at = under(Path::new("/games"), "A/Zool_v1.0.lha");
+        assert_eq!(at, Path::new("/games").join("A").join("Zool_v1.0.lha"));
+        assert_eq!(
+            under(Path::new("/games"), "Zool.lha"),
+            Path::new("/games").join("Zool.lha")
+        );
+        // Nothing odd from an empty or slash-heavy relative.
+        assert_eq!(under(Path::new("/games"), ""), Path::new("/games"));
+        assert_eq!(
+            under(Path::new("/games"), "A//B.lha"),
+            Path::new("/games").join("A").join("B.lha")
+        );
+    }
+
+    #[test]
     fn a_member_never_leaves_the_archive() {
         // A ZIP stores whatever string the writer chose.
         assert_eq!(
@@ -433,6 +471,29 @@ mod tests {
             member_path("/Game/Game.slave").as_deref(),
             Some(Path::new("Game/Game.slave"))
         );
+    }
+
+    #[test]
+    fn a_folder_is_read_in_a_settled_order() {
+        // A directory is read in whatever order the filesystem feels
+        // like. The digest that identifies a package is taken from the
+        // first slave found, so an unsettled order would move it between
+        // runs and a rename would stop being recognisable.
+        let dir = std::env::temp_dir().join(format!("copperline-order-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("data/deep")).unwrap();
+        for at in ["data/deep/Zzz.slave", "data/Bbb.slave", "Aaa.slave"] {
+            std::fs::write(dir.join(at), b"x").unwrap();
+        }
+        // Compared as paths, not as text: `display()` uses the host's
+        // separator, so a string comparison here would pass on Unix and
+        // fail on Windows for no reason anybody cares about.
+        let listed = walk(&dir).unwrap();
+        assert_eq!(
+            listed,
+            ["Aaa.slave", "data/Bbb.slave", "data/deep/Zzz.slave"].map(PathBuf::from)
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! What a WHDLoad game arrives as, and how to get at it.
+//!
+//! Three shapes, and a person should not have to care which they have:
+//!
+//! - **`.lha`**, which is what the packagers publish and what an Amiga
+//!   would have read natively.
+//! - **`.zip`**, which is what a browser hands you when you download a
+//!   folder, and what somebody who has unpacked and repacked one ends up
+//!   with.
+//! - **a plain folder**, which is what you get when you unpack either.
+//!
+//! The `.slave` is what makes any of them a game. Where it sits varies:
+//! straight in the archive root for a published `.lha`, a folder or two
+//! down for a zip made from an unpacked one. Nothing here cares -- the
+//! slave is searched for, not assumed.
+//!
+//! Two kinds of rubbish are ignored throughout. macOS writes `__MACOSX/`
+//! and `._name` AppleDouble stubs into any zip it makes, and one of those
+//! stubs is called `._Something.Slave`: left in, it would be found by the
+//! slave search, sort before the real one, and be booted instead. `.DS_Store`
+//! is harmless but there is no reason to stage it onto a mounted volume.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+use crate::lha;
+
+/// Which of the three a path is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Lha,
+    Zip,
+    Folder,
+}
+
+/// The extensions a package file may carry, lower case.
+///
+/// A closed list, checked case-insensitively, rather than "whatever
+/// follows the last dot". Amiga titles are full of dots -- `S.W.I.V`,
+/// `R.B.I. 2 Baseball`, `Dr.Plummet` -- so treating the tail as an
+/// extension mangles the name of anything that has one and no extension,
+/// which is every game that arrives as a plain folder. Every launcher that
+/// scans a library does it this way for the same reason.
+pub const EXTENSIONS: [&str; 3] = ["lha", "lzh", "zip"];
+
+/// What a slave file is called. `.slav` as well as `.slave`, because a
+/// package that has been through a filesystem with a short name limit
+/// comes out that way and is still a game.
+pub const SLAVE_EXTENSIONS: [&str; 2] = ["slave", "slav"];
+
+/// Directory names never worth walking into: version control, and the two
+/// Copperline itself writes inside a library.
+const SKIP_DIRS: [&str; 5] = [".git", "__MACOSX", "Cache", "Save States", "Saves"];
+
+impl Kind {
+    /// What `path` looks like, by extension for a file and by being one
+    /// for a directory. `None` for anything else, which is how a folder of
+    /// games tells a game from a text file.
+    pub fn of(path: &Path) -> Option<Kind> {
+        if path.is_dir() {
+            return Some(Kind::Folder);
+        }
+        Kind::of_name(path.file_name()?.to_str()?)
+    }
+
+    /// The same from a name alone, for deciding what to list without
+    /// asking the filesystem twice. Never answers `Folder`: a name does
+    /// not say whether it is one.
+    pub fn of_name(name: &str) -> Option<Kind> {
+        match extension_of(name)? {
+            "lha" | "lzh" => Some(Kind::Lha),
+            "zip" => Some(Kind::Zip),
+            _ => None,
+        }
+    }
+}
+
+/// The package extension a name ends in, lower case, or `None`.
+///
+/// Only the ones in [`EXTENSIONS`]: `Aladdin_v1` has no extension, and
+/// `S.W.I.V` has a dot but no extension either.
+fn extension_of(name: &str) -> Option<&'static str> {
+    let (_, tail) = name.rsplit_once('.')?;
+    EXTENSIONS
+        .iter()
+        .find(|ext| tail.eq_ignore_ascii_case(ext))
+        .copied()
+}
+
+/// A package's name without its extension, if it has one this recognises.
+///
+/// `GoldenAxe_v1.5_0017.lha` loses the `.lha`; `S.W.I.V` and `Aladdin_v1`
+/// keep every character, because neither ends in an extension.
+pub fn stem_of(name: &str) -> &str {
+    match extension_of(name) {
+        Some(ext) => &name[..name.len() - ext.len() - 1],
+        None => name,
+    }
+}
+
+/// Whether a name is a WHDLoad slave.
+pub fn is_slave_name(name: &str) -> bool {
+    name.rsplit_once('.').is_some_and(|(_, tail)| {
+        SLAVE_EXTENSIONS
+            .iter()
+            .any(|e| tail.eq_ignore_ascii_case(e))
+    })
+}
+
+/// Whether a directory is worth walking into while looking for games.
+pub fn worth_walking(name: &str) -> bool {
+    !SKIP_DIRS.contains(&name) && !name.starts_with('.')
+}
+
+/// Whether a member path is rubbish an archiver added rather than part of
+/// the game.
+///
+/// `__MACOSX/._Foo.Slave` is the one that matters: it ends in `.Slave`, so
+/// a slave search finds it, and it sorts before the real one often enough
+/// to be booted instead. It is not a slave -- it is a few hundred bytes of
+/// resource fork -- so the game would fail to start with nothing obvious
+/// to blame.
+pub fn is_rubbish(path: &Path) -> bool {
+    path.components().any(|c| {
+        let name = c.as_os_str().to_string_lossy();
+        name == "__MACOSX" || name == ".DS_Store" || name.starts_with("._")
+    })
+}
+
+/// Unpack an archive into `dest`, answering how many files it wrote.
+///
+/// Only for the two archive kinds; a folder is already unpacked and the
+/// caller uses it where it is.
+pub fn extract_to_dir(archive: &Path, dest: &Path) -> Result<usize> {
+    match Kind::of(archive) {
+        Some(Kind::Lha) => lha::extract_to_dir(archive, dest),
+        Some(Kind::Zip) => extract_zip(archive, dest),
+        Some(Kind::Folder) => bail!("{} is a directory, not an archive", archive.display()),
+        None => bail!(
+            "{} is not a WHDLoad package (.lha, .zip or a folder)",
+            archive.display()
+        ),
+    }
+}
+
+/// The relative paths of the members of an archive, or of the files in a
+/// folder, with the rubbish left out.
+pub fn list(path: &Path) -> Result<Vec<PathBuf>> {
+    let all = match Kind::of(path) {
+        Some(Kind::Lha) => lha::list_files(path)?,
+        Some(Kind::Zip) => zip_names(path)?,
+        Some(Kind::Folder) => walk(path)?,
+        None => bail!("{} is not a WHDLoad package", path.display()),
+    };
+    Ok(all.into_iter().filter(|p| !is_rubbish(p)).collect())
+}
+
+/// Read one member out of an archive or folder, by a path `list` returned.
+pub fn read(path: &Path, member: &Path) -> Result<Vec<u8>> {
+    match Kind::of(path) {
+        Some(Kind::Lha) => lha::read_member(path, member),
+        Some(Kind::Zip) => read_zip_member(path, member),
+        Some(Kind::Folder) => std::fs::read(path.join(member))
+            .with_context(|| format!("reading {}", path.join(member).display())),
+        None => bail!("{} is not a WHDLoad package", path.display()),
+    }
+}
+
+/// The first member whose path satisfies `want`, reading only that one.
+///
+/// The point of it is the scan, which wants one small `.slave` out of each
+/// of a few thousand packages and has no use for the rest.
+pub fn read_first(path: &Path, want: impl Fn(&Path) -> bool) -> Result<Option<Vec<u8>>> {
+    let wanted = |p: &Path| !is_rubbish(p) && want(p);
+    match Kind::of(path) {
+        Some(Kind::Lha) => Ok(lha::read_first(path, wanted)?.map(|entry| entry.data)),
+        Some(Kind::Zip) => {
+            let mut zip = open_zip(path)?;
+            let found = (0..zip.len()).find_map(|i| {
+                let file = zip.by_index(i).ok()?;
+                let member = member_path(file.name())?;
+                (!file.is_dir() && wanted(&member)).then_some(i)
+            });
+            match found {
+                Some(i) => {
+                    let mut data = Vec::new();
+                    zip.by_index(i)
+                        .with_context(|| format!("reading a member of {}", path.display()))?
+                        .read_to_end(&mut data)
+                        .with_context(|| format!("decompressing a member of {}", path.display()))?;
+                    Ok(Some(data))
+                }
+                None => Ok(None),
+            }
+        }
+        Some(Kind::Folder) => {
+            for member in walk(path)? {
+                if wanted(&member) {
+                    return Ok(Some(std::fs::read(path.join(&member))?));
+                }
+            }
+            Ok(None)
+        }
+        None => Ok(None),
+    }
+}
+
+/// Whether a `.slave` sits anywhere within `dir`, within a few levels.
+///
+/// This is the test a scan applies to the *children* of a game folder, and
+/// never to the folder itself -- a library holds games, so a slave is
+/// somewhere under it too, and asking of the library would answer yes and
+/// mean nothing. Walking down and stopping at the first child that says
+/// yes is what picks out `Aladdin_v1/` from a folder of a hundred like it.
+///
+/// The depth limit is what stops the question from reading somebody's
+/// whole home directory when the answer is no.
+pub fn holds_a_slave(dir: &Path) -> bool {
+    fn look(dir: &Path, depth: usize) -> bool {
+        if depth > FOLDER_SLAVE_DEPTH {
+            return false;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+        let mut subdirs = Vec::new();
+        for entry in entries.flatten() {
+            let Ok(kind) = entry.file_type() else {
+                continue;
+            };
+            if kind.is_symlink() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("._") {
+                continue;
+            }
+            if kind.is_dir() {
+                if !worth_walking(&name) {
+                    continue;
+                }
+                subdirs.push(entry.path());
+            } else if is_slave_name(&name) {
+                return true;
+            }
+        }
+        subdirs.iter().any(|sub| look(sub, depth + 1))
+    }
+    look(dir, 0)
+}
+
+/// How far under a directory a slave may be for the directory to count as
+/// the game. Two is what the real layouts need -- `Game_v1/Game/Game.slave`
+/// -- and a third is slack for anyone who nested one deeper.
+const FOLDER_SLAVE_DEPTH: usize = 3;
+
+fn open_zip(path: &Path) -> Result<zip::ZipArchive<std::io::BufReader<std::fs::File>>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("opening ZIP archive {}", path.display()))?;
+    zip::ZipArchive::new(std::io::BufReader::new(file))
+        .with_context(|| format!("reading ZIP archive {}", path.display()))
+}
+
+/// A member name as a relative path, or `None` if it tries to leave the
+/// archive.
+///
+/// A ZIP stores whatever string the writer chose, which may be absolute or
+/// full of `..`. Unpacking one of those writes outside the destination,
+/// which is the oldest bug in archive handling and still worth not having.
+fn member_path(name: &str) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for part in name.split(['/', '\\']) {
+        match part {
+            "" | "." => continue,
+            ".." => return None,
+            part if part.contains(':') => return None,
+            part => out.push(part),
+        }
+    }
+    (!out.as_os_str().is_empty()).then_some(out)
+}
+
+fn zip_names(path: &Path) -> Result<Vec<PathBuf>> {
+    let mut zip = open_zip(path)?;
+    let mut out = Vec::new();
+    for i in 0..zip.len() {
+        let file = zip
+            .by_index(i)
+            .with_context(|| format!("reading a member of {}", path.display()))?;
+        if file.is_dir() {
+            continue;
+        }
+        match member_path(file.name()) {
+            Some(member) => out.push(member),
+            None => log::warn!(
+                "whdload: {} has a member named {:?}, which is not a relative path; skipped",
+                path.display(),
+                file.name()
+            ),
+        }
+    }
+    Ok(out)
+}
+
+fn read_zip_member(path: &Path, member: &Path) -> Result<Vec<u8>> {
+    let mut zip = open_zip(path)?;
+    for i in 0..zip.len() {
+        let mut file = zip.by_index(i)?;
+        if member_path(file.name()).as_deref() == Some(member) {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)?;
+            return Ok(data);
+        }
+    }
+    bail!("{} has no member {}", path.display(), member.display())
+}
+
+fn extract_zip(archive: &Path, dest: &Path) -> Result<usize> {
+    let mut zip = open_zip(archive)?;
+    let mut written = 0usize;
+    for i in 0..zip.len() {
+        let mut file = zip
+            .by_index(i)
+            .with_context(|| format!("reading a member of {}", archive.display()))?;
+        if file.is_dir() {
+            continue;
+        }
+        let Some(member) = member_path(file.name()) else {
+            log::warn!(
+                "whdload: {} has a member named {:?}, which is not a relative path; skipped",
+                archive.display(),
+                file.name()
+            );
+            continue;
+        };
+        if is_rubbish(&member) {
+            continue;
+        }
+        let at = dest.join(&member);
+        if let Some(parent) = at.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let mut out =
+            std::fs::File::create(&at).with_context(|| format!("writing {}", at.display()))?;
+        std::io::copy(&mut file, &mut out)
+            .with_context(|| format!("extracting {}", member.display()))?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+/// Every file under a directory, relative to it, links not followed.
+fn walk(root: &Path) -> Result<Vec<PathBuf>> {
+    fn step(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+        let entries =
+            std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))?;
+        for entry in entries.flatten() {
+            let kind = entry.file_type()?;
+            if kind.is_symlink() {
+                continue;
+            }
+            let path = entry.path();
+            if kind.is_dir() {
+                step(root, &path, out)?;
+            } else if let Ok(rel) = path.strip_prefix(root) {
+                out.push(rel.to_path_buf());
+            }
+        }
+        Ok(())
+    }
+    let mut out = Vec::new();
+    step(root, root, &mut out)?;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn what_a_package_looks_like() {
+        assert_eq!(Kind::of_name("Zool_v1.0.lha"), Some(Kind::Lha));
+        assert_eq!(Kind::of_name("Zool_v1.0.LHA"), Some(Kind::Lha));
+        assert_eq!(Kind::of_name("Zool_v1.zip"), Some(Kind::Zip));
+        assert_eq!(Kind::of_name("Zool_v1.ZIP"), Some(Kind::Zip));
+        assert_eq!(Kind::of_name("notes.txt"), None);
+        assert_eq!(Kind::of_name("noextension"), None);
+    }
+
+    #[test]
+    fn a_resource_fork_is_not_a_slave() {
+        // The one that matters: macOS puts `._Foo.Slave` in every zip it
+        // makes, it ends in `.Slave`, and it sorts before the real one. A
+        // game booted from one starts and immediately fails.
+        assert!(is_rubbish(Path::new("__MACOSX/Aladdin/._AladdinAGA.Slave")));
+        assert!(is_rubbish(Path::new("Aladdin/._AladdinAGA.Slave")));
+        assert!(is_rubbish(Path::new("Aladdin/.DS_Store")));
+        assert!(is_rubbish(Path::new("__MACOSX/anything")));
+        assert!(!is_rubbish(Path::new("Aladdin/AladdinAGA.Slave")));
+        assert!(!is_rubbish(Path::new("Aladdin/data/_notes")));
+    }
+
+    #[test]
+    fn a_member_never_leaves_the_archive() {
+        // A ZIP stores whatever string the writer chose.
+        assert_eq!(
+            member_path("Game/Game.slave").as_deref(),
+            Some(Path::new("Game/Game.slave"))
+        );
+        assert_eq!(
+            member_path("Game\\Game.slave").as_deref(),
+            Some(Path::new("Game/Game.slave"))
+        );
+        assert_eq!(
+            member_path("./Game/./Game.slave").as_deref(),
+            Some(Path::new("Game/Game.slave"))
+        );
+        // Absolute, traversing, or an AmigaDOS device name.
+        assert_eq!(member_path("../../etc/passwd"), None);
+        assert_eq!(member_path("Game/../../etc/passwd"), None);
+        assert_eq!(member_path("DH0:Game/Game.slave"), None);
+        assert_eq!(member_path(""), None);
+        assert_eq!(member_path("/"), None);
+        // A leading slash is just an empty first part, which is skipped --
+        // the result is still relative.
+        assert_eq!(
+            member_path("/Game/Game.slave").as_deref(),
+            Some(Path::new("Game/Game.slave"))
+        );
+    }
+
+    #[test]
+    fn a_game_folder_is_picked_out_of_a_library() {
+        let dir = std::env::temp_dir().join(format!("copperline-package-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // The real layout: the library holds game folders, and the slave is
+        // two levels below the game folder.
+        std::fs::create_dir_all(dir.join("Aladdin_v1/AladdinAGA")).unwrap();
+        std::fs::write(dir.join("Aladdin_v1/AladdinAGA/AladdinAGA.Slave"), b"x").unwrap();
+        // The library says yes as well -- which is why it is asked of the
+        // children and the walk stops at the first that agrees.
+        assert!(holds_a_slave(&dir.join("Aladdin_v1")));
+        assert!(holds_a_slave(&dir.join("Aladdin_v1/AladdinAGA")));
+
+        // A folder with no slave under it at all is not a game.
+        std::fs::create_dir_all(dir.join("Screenshots")).unwrap();
+        std::fs::write(dir.join("Screenshots/one.png"), b"x").unwrap();
+        assert!(!holds_a_slave(&dir.join("Screenshots")));
+
+        // A resource fork does not make one, either.
+        std::fs::create_dir_all(dir.join("Junk/__MACOSX")).unwrap();
+        std::fs::write(dir.join("Junk/__MACOSX/._Game.Slave"), b"x").unwrap();
+        assert!(!holds_a_slave(&dir.join("Junk")));
+
+        // Nor does one buried far deeper than a package ever puts it.
+        std::fs::create_dir_all(dir.join("Deep/a/b/c/d")).unwrap();
+        std::fs::write(dir.join("Deep/a/b/c/d/Game.slave"), b"x").unwrap();
+        assert!(!holds_a_slave(&dir.join("Deep")));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -34,6 +34,35 @@ pub fn config_file(name: &str) -> Option<PathBuf> {
     config_dir().map(|dir| dir.join(name))
 }
 
+/// Where WHDLoad keeps everything of its own: the support archives, the
+/// extracted games and their saves, and the game database.
+///
+/// One place, named once. Every WHDLoad setting that says `(default)`
+/// means somewhere under here, so a person who never sets any of them
+/// still knows where to look, and a person who moves one knows what they
+/// are moving it away from.
+pub fn whdload_dir() -> Option<PathBuf> {
+    config_dir().map(|dir| dir.join("whdload"))
+}
+
+/// Where the support archives are looked for and downloaded to.
+pub fn whdload_support_dir() -> Option<PathBuf> {
+    whdload_dir().map(|dir| dir.join("support"))
+}
+
+/// The scanned library, when `[whdload] library_db` does not say otherwise.
+/// Beside the support archives, which is the other thing under `whdload/`
+/// that Copperline rather than the guest put there.
+pub fn whdload_library_db() -> Option<PathBuf> {
+    whdload_support_dir().map(|dir| dir.join("launcher.db"))
+}
+
+/// What a scan downloaded, when `[whdload] library_cache` does not say
+/// otherwise. Safe to delete: it is rebuilt by the next scan.
+pub fn whdload_library_cache() -> Option<PathBuf> {
+    whdload_support_dir().map(|dir| dir.join("cache"))
+}
+
 /// Directory holding the numbered save-state slots.
 pub fn state_slot_dir() -> Option<PathBuf> {
     config_dir().map(|dir| dir.join("states"))

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -50,6 +50,40 @@ pub fn whdload_support_dir() -> Option<PathBuf> {
     whdload_dir().map(|dir| dir.join("support"))
 }
 
+/// Where games are unpacked and their saves kept, when `[whdload] library`
+/// does not say otherwise. Beside the support archives rather than loose
+/// in `whdload/`, so what Copperline downloaded and what the guest wrote
+/// are told apart at a glance.
+///
+/// An installation that already has games directly under `whdload/` --
+/// where this used to be -- carries on using it. The library directory is
+/// where saves live, so moving it would leave somebody's savegames and
+/// highscores behind under a name nothing looks at any more.
+pub fn whdload_save_dir() -> Option<PathBuf> {
+    let whdload = whdload_dir()?;
+    let save = whdload.join("save");
+    if save.is_dir() || !holds_unpacked_games(&whdload) {
+        return Some(save);
+    }
+    log::info!(
+        "whdload: keeping the existing game library in {} (new installations use {})",
+        whdload.display(),
+        save.display()
+    );
+    Some(whdload)
+}
+
+/// Whether a directory holds games unpacked by an earlier version: an
+/// entry with the `.source` marker staging writes beside each one.
+fn holds_unpacked_games(dir: &std::path::Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries
+        .flatten()
+        .any(|entry| entry.path().join(".source").is_file())
+}
+
 /// The scanned library, when `[whdload] library_db` does not say otherwise.
 /// Beside the support archives, which is the other thing under `whdload/`
 /// that Copperline rather than the guest put there.

--- a/src/video/font.rs
+++ b/src/video/font.rs
@@ -124,11 +124,166 @@ pub fn glyph(ch: char) -> &'static [u8; 8] {
     }
 }
 
+/// Text as this font can actually draw it.
+///
+/// The bitmap is printable ASCII, and [`glyph`] answers a blank cell for
+/// anything else -- so "Ishidó" draws as "Ishid " and reads as a spelling
+/// mistake rather than as a missing glyph. The catalogue is full of names
+/// like it, and somebody typing a version of their own may well use one
+/// too, so the nearest ASCII is substituted instead: accents are dropped,
+/// ligatures and sharp s are spelled out, and the typographic quotes and
+/// dashes a database picks up become their ASCII equivalents.
+///
+/// Borrowed and untouched for the ordinary case, which is nearly every
+/// string the panel draws.
+pub fn renderable(text: &str) -> std::borrow::Cow<'_, str> {
+    if text.is_ascii() {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c.is_ascii() {
+            true => out.push(c),
+            false => out.push_str(fold(c)),
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+/// One non-ASCII character as printable ASCII. Empty for a combining
+/// mark, which has already been applied to the letter before it.
+fn fold(c: char) -> &'static str {
+    match c {
+        'À'..='Å' | 'à'..='å' | 'Ā' | 'ā' | 'Ă' | 'ă' | 'Ą' | 'ą' => {
+            if c.is_uppercase() {
+                "A"
+            } else {
+                "a"
+            }
+        }
+        'Æ' => "AE",
+        'æ' => "ae",
+        'Ç' | 'ç' | 'Ć' | 'ć' | 'Č' | 'č' => {
+            if c.is_uppercase() {
+                "C"
+            } else {
+                "c"
+            }
+        }
+        'Ð' | 'ð' | 'Ď' | 'ď' => {
+            if c.is_uppercase() {
+                "D"
+            } else {
+                "d"
+            }
+        }
+        'È'..='Ë' | 'è'..='ë' | 'Ē' | 'ē' | 'Ę' | 'ę' | 'Ě' | 'ě' => {
+            if c.is_uppercase() {
+                "E"
+            } else {
+                "e"
+            }
+        }
+        'Ì'..='Ï' | 'ì'..='ï' | 'Ī' | 'ī' => {
+            if c.is_uppercase() {
+                "I"
+            } else {
+                "i"
+            }
+        }
+        'Ñ' | 'ñ' | 'Ń' | 'ń' | 'Ň' | 'ň' => {
+            if c.is_uppercase() {
+                "N"
+            } else {
+                "n"
+            }
+        }
+        'Ò'..='Ö' | 'Ø' | 'ò'..='ö' | 'ø' | 'Ō' | 'ō' | 'Ő' | 'ő' => {
+            if c.is_uppercase() {
+                "O"
+            } else {
+                "o"
+            }
+        }
+        'Œ' => "OE",
+        'œ' => "oe",
+        'Ř' | 'ř' => {
+            if c.is_uppercase() {
+                "R"
+            } else {
+                "r"
+            }
+        }
+        'Š' | 'š' | 'Ś' | 'ś' | 'Ş' | 'ş' => {
+            if c.is_uppercase() {
+                "S"
+            } else {
+                "s"
+            }
+        }
+        'ß' => "ss",
+        'Ť' | 'ť' | 'Ţ' | 'ţ' => {
+            if c.is_uppercase() {
+                "T"
+            } else {
+                "t"
+            }
+        }
+        'Ù'..='Ü' | 'ù'..='ü' | 'Ū' | 'ū' | 'Ů' | 'ů' | 'Ű' | 'ű' => {
+            if c.is_uppercase() {
+                "U"
+            } else {
+                "u"
+            }
+        }
+        'Ý' | 'ý' | 'ÿ' | 'Ÿ' => {
+            if c.is_uppercase() {
+                "Y"
+            } else {
+                "y"
+            }
+        }
+        'Ž' | 'ž' | 'Ź' | 'ź' | 'Ż' | 'ż' => {
+            if c.is_uppercase() {
+                "Z"
+            } else {
+                "z"
+            }
+        }
+        'Ł' | 'ł' => {
+            if c.is_uppercase() {
+                "L"
+            } else {
+                "l"
+            }
+        }
+        // Punctuation a catalogue picks up from wherever it was typed.
+        '\u{2018}' | '\u{2019}' | '\u{201B}' | '\u{2032}' => "'",
+        '\u{201C}' | '\u{201D}' | '\u{201E}' | '\u{2033}' => "\"",
+        '\u{2013}' | '\u{2014}' | '\u{2212}' => "-",
+        '\u{2026}' => "...",
+        '\u{00D7}' => "x",
+        '\u{00A0}' | '\u{202F}' | '\u{2007}' => " ",
+        '\u{00B0}' => "o",
+        '\u{00A9}' => "(c)",
+        '\u{00AE}' => "(R)",
+        '\u{2122}' => "(TM)",
+        // Combining marks belong to the letter before them, which has
+        // already been folded.
+        '\u{0300}'..='\u{036F}' => "",
+        // Something outside all of it: a visible mark beats a silent gap.
+        _ => "?",
+    }
+}
+
 /// Device-pixel width of `text` rendered at `px` device pixels per font
 /// pixel. Each glyph cell is [`GLYPH_W`] font pixels wide (the cell
 /// already includes inter-character spacing).
 pub fn text_width(text: &str, px: usize) -> usize {
-    text.chars().count() * GLYPH_W * px
+    // Measured as it will be drawn: folding can change the count, and a
+    // width that disagreed with the glyphs would misplace everything
+    // laid out against it.
+    renderable(text).chars().count() * GLYPH_W * px
 }
 
 /// Device-pixel height of one text row at `px` device pixels per font
@@ -155,6 +310,9 @@ pub fn draw_text(
 ) -> usize {
     let bytes = color.to_le_bytes();
     let mut cursor_x = x;
+    // Folded here rather than at every call site, so nothing the panel
+    // draws can quietly lose a letter to a glyph this font has not got.
+    let text = renderable(text);
     for ch in text.chars() {
         let g = glyph(ch);
         for (row_idx, row) in g.iter().enumerate() {
@@ -203,6 +361,32 @@ mod tests {
     fn text_metrics_scale_with_pixel_size() {
         assert_eq!(text_width("AB", 2), 2 * GLYPH_W * 2);
         assert_eq!(text_height(3), GLYPH_H * 3);
+    }
+
+    #[test]
+    fn text_the_font_cannot_draw_is_folded_rather_than_lost() {
+        // The catalogue is full of these -- "Ishido: The Way of Stones" is
+        // spelt with an accent -- and an unmapped glyph draws as a blank,
+        // so the name read as a spelling mistake.
+        assert_eq!(renderable("Ishid\u{f3}"), "Ishido");
+        assert_eq!(renderable("Gr\u{fc}\u{df}e"), "Grusse");
+        assert_eq!(renderable("Fran\u{e7}ais"), "Francais");
+        assert_eq!(renderable("\u{c6}on"), "AEon");
+        assert_eq!(renderable("caf\u{e9} \u{2014} bar"), "cafe - bar");
+        assert_eq!(renderable("don\u{2019}t"), "don't");
+        // Nothing is done to text that needs nothing.
+        assert!(matches!(
+            renderable("Cannon Fodder 2"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        // And the width agrees with what is drawn, or everything laid out
+        // against it lands in the wrong place.
+        assert_eq!(
+            text_width("Gr\u{fc}\u{df}e", 1),
+            "Grusse".chars().count() * GLYPH_W
+        );
+        // Something outside the table is visible rather than a gap.
+        assert_eq!(renderable("\u{4e2d}"), "?");
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -6009,16 +6009,18 @@ impl LauncherState {
     /// pointing at any package still lists its neighbours. The library
     /// wins where both are set: it is the deliberate answer to "where are
     /// my games", and the other is a guess from one of them.
+    /// The folder the Library page lists, which is the one that was set
+    /// and nothing else.
+    ///
+    /// It used to fall back to the folder holding the chosen game, so that
+    /// pointing at a package listed its neighbours. That made Clear look
+    /// broken -- emptying the setting left the list full of whatever sat
+    /// beside the launch game -- and it hid the one thing the empty page
+    /// has to say, which is where to set the folder.
     pub fn library_folder(&self) -> Option<PathBuf> {
         self.setup
             .path(F::WhdloadGames)
             .map(std::path::Path::to_path_buf)
-            .or_else(|| {
-                self.setup
-                    .path(F::WhdloadGame)
-                    .and_then(|game| game.parent())
-                    .map(std::path::Path::to_path_buf)
-            })
     }
 
     pub fn library_selection(&self) -> Option<&crate::gamelib::Entry> {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -3307,6 +3307,12 @@ impl MachineSetup {
                 .is_some_and(crate::config::is_cd_image_path)
     }
 
+    /// Where a WHDLoad game's machine comes from: the slave's own header,
+    /// or this configuration.
+    pub fn whdload_machine(&self) -> crate::config::WhdloadMachine {
+        self.whdload_machine
+    }
+
     pub fn value_label(&self, field: LauncherField) -> String {
         match field {
             F::WhdloadMachine => match self.whdload_machine {
@@ -8584,6 +8590,25 @@ mod tests {
         );
         // Only the ROM rows have one.
         assert_eq!(state.rom_note(F::Df0Image), None);
+    }
+
+    #[test]
+    fn the_machine_type_cycle_reports_which_machine_it_means() {
+        use crate::config::WhdloadMachine as M;
+        let mut setup = MachineSetup::default();
+        // Auto is the default: the slave header says what the game wants.
+        assert_eq!(setup.whdload_machine(), M::Auto);
+        assert_eq!(setup.value_label(F::WhdloadMachine), "Auto");
+
+        // The two settings are one cycle apart either way round, so the
+        // reading after a press is the reading the line describes.
+        setup.cycle(F::WhdloadMachine, true);
+        assert_eq!(setup.whdload_machine(), M::Copperline);
+        assert_eq!(setup.value_label(F::WhdloadMachine), "Copperline");
+        setup.cycle(F::WhdloadMachine, true);
+        assert_eq!(setup.whdload_machine(), M::Auto);
+        setup.cycle(F::WhdloadMachine, false);
+        assert_eq!(setup.whdload_machine(), M::Copperline, "and backwards");
     }
 
     #[cfg(feature = "game-library")]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -7199,6 +7199,7 @@ mod tests {
                 library: Some("/whd/library".to_string()),
                 kickstarts: Some("/roms/kickstarts".to_string()),
                 args: Some("NoVBRMove ButtonWait".to_string()),
+                ..crate::config::RawWhdload::default()
             },
             ..RawConfig::default()
         };

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5402,16 +5402,18 @@ pub enum MetaField {
     Publisher,
     Developer,
     Players,
+    Version,
 }
 
 #[cfg(feature = "game-library")]
 impl MetaField {
-    pub const ALL: [MetaField; 5] = [
+    pub const ALL: [MetaField; 6] = [
         MetaField::Name,
         MetaField::Year,
         MetaField::Publisher,
         MetaField::Developer,
         MetaField::Players,
+        MetaField::Version,
     ];
 
     pub fn label(self) -> &'static str {
@@ -5421,6 +5423,7 @@ impl MetaField {
             MetaField::Publisher => "Publisher",
             MetaField::Developer => "Developer",
             MetaField::Players => "Players",
+            MetaField::Version => "Version",
         }
     }
 
@@ -5440,7 +5443,7 @@ pub struct MetaDialog {
     /// The package being edited, by the name the store files it under.
     pub file: String,
     /// The values, in [`MetaField::ALL`] order.
-    pub values: [String; 5],
+    pub values: [String; 6],
     /// The cache key of the art, which is a catalogue digest for art that
     /// was downloaded and a `manual-` name for art somebody chose.
     pub art: Option<String>,
@@ -5701,7 +5704,7 @@ impl LauncherState {
                     .games
                     .entries()
                     .iter()
-                    .find(|entry| crate::gamelib::Database::key_for(&entry.file_name) == key)
+                    .find(|entry| entry.relative == key)
             }
         }
     }
@@ -5732,8 +5735,10 @@ impl LauncherState {
         };
         // The name is kept with the mark, so the favourite still reads as
         // a game once its package is gone.
-        let (name, title) = (entry.file_name.clone(), entry.title().to_string());
-        self.library.db.toggle_favourite(&name, &title);
+        // The package, not the game: a collection holds the same game
+        // several times over, and starring one of them stars that one.
+        let (file, title) = (entry.relative.clone(), entry.title().to_string());
+        self.library.db.toggle_favourite(&file, &title);
     }
 
     /// Choose a favourite: the game to launch, without also being the row
@@ -5754,7 +5759,7 @@ impl LauncherState {
             .games
             .entries()
             .iter()
-            .find(|entry| crate::gamelib::Database::key_for(&entry.file_name) == key)
+            .find(|entry| entry.relative == key)
             .map(|entry| entry.path.clone());
         if let Some(path) = path {
             self.setup.set_path(F::WhdloadGame, path);
@@ -5766,7 +5771,13 @@ impl LauncherState {
         let Some(entry) = self.library_selection() else {
             return false;
         };
+        // The store keys on the path under the game folder; the version
+        // offered below is the package's own name, which is what tells one
+        // release from another. Without its extension -- `.lha` against
+        // `.zip` is how it was packed, not which release it is.
         let file = entry.relative.clone();
+        let base = entry.file_name.clone();
+        let duplicated = entry.duplicated;
         let game = entry.game.clone();
         let mut dialog = MetaDialog {
             file,
@@ -5781,9 +5792,18 @@ impl LauncherState {
                 (MetaField::Publisher, game.publisher.clone()),
                 (MetaField::Developer, game.developer.clone()),
                 (MetaField::Players, game.players.clone()),
+                (MetaField::Version, game.version.clone()),
             ] {
                 *dialog.value_mut(field) = value.unwrap_or_default();
             }
+        }
+        // Nothing stored, the game has metadata, and the library holds it
+        // more than once: offer the file name, which is the only thing that
+        // separates them. Blank for a game held once, and blank for one the
+        // scan could not name at all -- filling in a version for a package
+        // with nothing else known about it says nothing.
+        if dialog.value(MetaField::Version).is_empty() && duplicated && game.is_some() {
+            *dialog.value_mut(MetaField::Version) = base;
         }
         self.meta = Some(dialog);
         self.status = None;
@@ -5839,6 +5859,7 @@ impl LauncherState {
                     publisher: field(MetaField::Publisher),
                     developer: field(MetaField::Developer),
                     players: field(MetaField::Players),
+                    version: field(MetaField::Version),
                     front_sha1: dialog.art.clone(),
                 }),
                 slave_sha1: held_digest,
@@ -8177,6 +8198,72 @@ mod tests {
         );
         // Only the ROM rows have one.
         assert_eq!(state.rom_note(F::Df0Image), None);
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn a_version_is_offered_only_for_a_named_game_the_library_holds_twice() {
+        use crate::gamelib::{Game, Known, Library};
+        let named = |name: &str| {
+            Some(Game {
+                name: name.to_string(),
+                year: Some("1994".to_string()),
+                ..Game::default()
+            })
+        };
+        let known = |file: &str, game: Option<Game>| Known {
+            file: file.to_string(),
+            game,
+            manual: false,
+            slave_sha1: None,
+        };
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.library.db.set_known(vec![
+            // The same game packed twice, which is what a version is for.
+            known("CannonFodder2_v1.11_0104.lha", named("Cannon Fodder 2")),
+            known("CannonFodder2_v1.12_Fr_2578.zip", named("Cannon Fodder 2")),
+            // Held once: nothing to tell apart.
+            known("Turrican_v1.3_0087.lha", named("Turrican")),
+            // Two the scan could not name. They share a title only because
+            // the title falls back to the file name.
+            known("Mystery/Thing.lha", None),
+            known("Elsewhere/Thing.zip", None),
+        ]);
+        state.library.games = Library::known(Path::new("/games"), &state.library.db);
+        state.library.db_loaded = true;
+
+        let version_of = |state: &mut LauncherState, title: &str| {
+            let at = state
+                .library
+                .games
+                .entries()
+                .iter()
+                .position(|e| e.title() == title)
+                .expect("the entry is in the library");
+            state.select_library_game(at);
+            assert!(state.open_meta_editor(), "the editor opens");
+            let value = state
+                .meta
+                .as_ref()
+                .unwrap()
+                .value(MetaField::Version)
+                .to_string();
+            state.meta = None;
+            value
+        };
+
+        // The package's own name, and not how it was packed: `.lha`
+        // against `.zip` is the same on both and says nothing about which
+        // release either one is.
+        assert_eq!(
+            version_of(&mut state, "Cannon Fodder 2"),
+            "CannonFodder2_v1.11_0104"
+        );
+        // Held once, so there is nothing to separate it from.
+        assert_eq!(version_of(&mut state, "Turrican"), "");
+        // Unnamed by the scan: a file name under a row that already says
+        // nothing is not the answer to which release it is.
+        assert_eq!(version_of(&mut state, "Thing"), "");
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5010,7 +5010,7 @@ impl Caret {
 
     /// Pull the caret back inside a line it may now be off the end of --
     /// the focus moved to a shorter field, or the value was replaced.
-    pub fn clamp(&mut self, text: &str) {
+    fn clamp(&mut self, text: &str) {
         self.0 = self.0.min(text.chars().count());
     }
 
@@ -5042,7 +5042,7 @@ impl Caret {
 
     /// The byte offset the caret sits at, which is the end of the string
     /// when it is past the last character.
-    pub fn byte_in(self, text: &str) -> usize {
+    fn byte_in(self, text: &str) -> usize {
         text.char_indices()
             .nth(self.0)
             .map_or(text.len(), |(at, _)| at)
@@ -6223,7 +6223,7 @@ impl LauncherState {
 
     /// Keep the favourites selection and scroll inside a list that may have
     /// shrunk -- a removal here, or a database re-read that dropped some.
-    pub fn clamp_favourites(&mut self) {
+    fn clamp_favourites(&mut self) {
         let last = self.library.db.favourite_count().saturating_sub(1);
         self.library.favourite_selected = self.library.favourite_selected.min(last);
         self.library.favourite_scroll = self.library.favourite_scroll.min(last);

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -176,9 +176,13 @@ pub enum LauncherTab {
     FluxBridge,
     BootPriority,
     HostFs,
-    /// Direct WHDLoad boot (src/whdload.rs): the game package to boot and
-    /// the staging directories, reached from the Storage tab.
+    /// Direct WHDLoad boot (src/whdload.rs): the game to launch and what
+    /// staging draws on, reached from the Storage tab.
     Whdload,
+    /// The games found beside the one chosen to launch, with what the game
+    /// database says about them. Only in a build with the library.
+    #[cfg(feature = "game-library")]
+    WhdloadLibrary,
     /// Real host storage -- an SD card, a CF card, an Amiga's own hard
     /// drive -- attached in place of a disk image. Drawn as its own layout
     /// rather than a list of settings rows, because choosing a disk is a
@@ -222,6 +226,38 @@ pub const TABS: &[LauncherTab] = &[
     LauncherTab::AvAudio,
 ];
 
+/// The strip with WHDLoad in it, between Storage and Input. This is the
+/// usual one: the entry is there unless somebody has turned WHDLoad off.
+#[cfg(feature = "game-library")]
+const WHDLOAD_TABS: &[LauncherTab] = &[
+    LauncherTab::System,
+    LauncherTab::Cpu,
+    LauncherTab::Memory,
+    LauncherTab::Rom,
+    LauncherTab::Floppy,
+    LauncherTab::Storage,
+    LauncherTab::WhdloadLibrary,
+    LauncherTab::Input,
+    LauncherTab::IoPorts,
+    LauncherTab::Zorro,
+    LauncherTab::AvAudio,
+];
+
+/// The left-hand strip. WHDLoad has an entry of its own unless it has been
+/// turned off in A/V & Emu -> Emulation.
+///
+/// It lands on the Library rather than on the settings behind it: picking
+/// a game is the reason to go there, and the settings are one click away
+/// on the page itself.
+pub fn tabs(whdload_enabled: bool) -> &'static [LauncherTab] {
+    #[cfg(feature = "game-library")]
+    if whdload_enabled {
+        return WHDLOAD_TABS;
+    }
+    let _ = whdload_enabled;
+    TABS
+}
+
 impl LauncherTab {
     pub fn label(self) -> &'static str {
         match self {
@@ -235,6 +271,11 @@ impl LauncherTab {
             LauncherTab::BootPriority => "Boot Priority",
             LauncherTab::HostFs => "Host Folder",
             LauncherTab::Whdload => "WHDLoad",
+            // The strip's own name for it. Inside the WHDLoad pages the
+            // nav chips say Configuration and Library, from their own
+            // labels, so this one is free to say which tab it is.
+            #[cfg(feature = "game-library")]
+            LauncherTab::WhdloadLibrary => "WHDLoad",
             LauncherTab::HostDisk => "Host Disk",
             LauncherTab::Cd => "CD",
             LauncherTab::IoPorts => "I/O Ports",
@@ -254,9 +295,14 @@ impl LauncherTab {
     /// the A/V & Emu one.
     pub fn strip_tab(self) -> LauncherTab {
         match self {
+            // The settings page lights the Library entry: they are two
+            // views of one thing, reached through one strip entry.
+            #[cfg(feature = "game-library")]
+            LauncherTab::Whdload => LauncherTab::WhdloadLibrary,
+            #[cfg(not(feature = "game-library"))]
+            LauncherTab::Whdload => LauncherTab::Storage,
             LauncherTab::Cd
             | LauncherTab::HostFs
-            | LauncherTab::Whdload
             | LauncherTab::HostDisk
             | LauncherTab::BootPriority
             | LauncherTab::CreateFloppy
@@ -273,9 +319,14 @@ impl LauncherTab {
     /// top nav row instead).
     pub fn parent_tab(self) -> Option<LauncherTab> {
         match self {
+            // With the library, WHDLoad is a strip entry of its own and its
+            // two pages switch between each other on the nav row, so there
+            // is nowhere for Back to go. Without it, the one page is still
+            // a Storage sub-page.
+            #[cfg(not(feature = "game-library"))]
+            LauncherTab::Whdload => Some(LauncherTab::Storage),
             LauncherTab::Cd
             | LauncherTab::HostFs
-            | LauncherTab::Whdload
             | LauncherTab::HostDisk
             | LauncherTab::BootPriority
             | LauncherTab::CreateFloppy
@@ -295,6 +346,8 @@ impl LauncherTab {
             LauncherTab::Storage => STORAGE_NAV,
             LauncherTab::AvAudio | LauncherTab::AvVideo | LauncherTab::AvEmulation => AV_NAV,
             LauncherTab::CreateFloppy | LauncherTab::CreateHard => CREATE_NAV,
+            #[cfg(feature = "game-library")]
+            LauncherTab::Whdload | LauncherTab::WhdloadLibrary => WHDLOAD_NAV,
             _ => &[],
         }
     }
@@ -315,14 +368,23 @@ const STORAGE_NAV: &[(&str, LauncherTab)] = &[
     // rather than attaching something: nothing on its pages describes this
     // machine, which is why they are pages of their own.
     ("Create Image...", LauncherTab::CreateFloppy),
-    // Four to a row, so these two wrap onto a second.
+    // Four to a row, so this one wraps onto a second.
     ("CD", LauncherTab::Cd),
-    ("WHDLoad", LauncherTab::Whdload),
 ];
 
 /// The workshop's two pages. Reached from Storage, so they show a Back
 /// button *and* this nav: one says where you came from, the other which of
 /// the two you are on.
+/// WHDLoad's two pages: what a package boots with, and which package.
+/// Only a build with the library has the second, so only that one splits.
+#[cfg(feature = "game-library")]
+const WHDLOAD_NAV: &[(&str, LauncherTab)] = &[
+    // The library first: it is what the strip entry opens on, and what
+    // somebody is there for. The settings behind it are one click away.
+    ("Library", LauncherTab::WhdloadLibrary),
+    ("Configuration", LauncherTab::Whdload),
+];
+
 const CREATE_NAV: &[(&str, LauncherTab)] = &[
     ("Floppy Disk", LauncherTab::CreateFloppy),
     ("Hard Disk", LauncherTab::CreateHard),
@@ -472,6 +534,12 @@ pub enum LauncherField {
     WhdloadGame,
     WhdloadKickstarts,
     WhdloadLibrary,
+    WhdloadWhdPackage,
+    WhdloadSkickPackage,
+    WhdloadMachine,
+    WhdloadOpenRetro,
+    WhdloadEnabled,
+    WhdloadGames,
     // Serial. Present only with the `midi` feature, the only build carrying
     // serial rows at all.
     #[cfg(feature = "midi")]
@@ -602,6 +670,10 @@ pub enum RowKind {
     /// options AmigaDOS's own filesystem carries, greyed for a family that
     /// has none.
     FsVariant,
+    /// An account: whether this session is signed in, with the button that
+    /// signs it in where a Browse would be. Nothing is stored, so the row
+    /// reports the session rather than a setting.
+    Account,
 }
 
 /// One settings row: a label, the field it edits, and how to edit it.
@@ -680,6 +752,31 @@ impl LauncherField {
         matches!(
             self,
             LauncherField::WhdloadKickstarts | LauncherField::WhdloadLibrary
+        ) || cfg!(feature = "game-library") && self.is_whdload_games_field()
+    }
+
+    /// The game library, which is a folder of packages rather than one of
+    /// them. Its own predicate because the field only exists in a build
+    /// with the library, and `matches!` cannot be written conditionally.
+    pub fn is_whdload_games_field(self) -> bool {
+        #[cfg(feature = "game-library")]
+        {
+            self == LauncherField::WhdloadGames
+        }
+        #[cfg(not(feature = "game-library"))]
+        {
+            false
+        }
+    }
+
+    /// Whether this field names a `.lha` archive rather than a directory:
+    /// the game to launch, and the two support packages.
+    pub fn is_whdload_archive_field(self) -> bool {
+        matches!(
+            self,
+            LauncherField::WhdloadGame
+                | LauncherField::WhdloadWhdPackage
+                | LauncherField::WhdloadSkickPackage
         )
     }
 
@@ -690,8 +787,11 @@ impl LauncherField {
         matches!(
             self,
             LauncherField::WhdloadGame
+                | LauncherField::WhdloadGames
                 | LauncherField::WhdloadKickstarts
                 | LauncherField::WhdloadLibrary
+                | LauncherField::WhdloadWhdPackage
+                | LauncherField::WhdloadSkickPackage
         )
     }
 }
@@ -825,14 +925,42 @@ const CD_ROWS: [Row; 3] = [
     row(F::CdInsertDelay, "Insert delay", Cycle),
     row(F::Cd32Nvram, "CD32 NVRAM", PathRow),
 ];
-// The WHDLoad sub-page: the game package to boot, then the two directories
-// staging draws on (src/whdload.rs). Drive rows like the Host FS mounts so
-// the whole host path shows; the staged volumes mount under fixed names
+// The WHDLoad Configuration page: the game to launch, then what staging
+// draws on (src/whdload.rs). Drive rows like the Host FS mounts so the
+// whole host path shows; the staged volumes mount under fixed names
 // (WHDBoot:/WHDGame:), so there is no volume box to fill.
-const WHDLOAD_ROWS: [Row; 3] = [
-    row(F::WhdloadGame, "Game package", Drive),
-    row(F::WhdloadKickstarts, "Kickstart images", Drive),
-    row(F::WhdloadLibrary, "Game library", Drive),
+//
+// Pinning, the account and the game folder belong to the game library, so
+// they are only here in a build that has one. Their settings still
+// round-trip through a save either way -- a configuration written by a full
+// build loads in a slim one without losing them.
+#[cfg(not(feature = "game-library"))]
+const WHDLOAD_ROWS: [Row; 8] = [
+    section_header("WHDLoad Configuration:"),
+    // What to boot, and how: what a person changes per game.
+    row(F::WhdloadGame, "Launch game", Drive),
+    row(F::WhdloadMachine, "Machine type", Cycle),
+    // Then the places things live, set once and left.
+    section_header("Directories:"),
+    row(F::WhdloadWhdPackage, "WHDLoad package", Drive),
+    row(F::WhdloadSkickPackage, "SKick package", Drive),
+    row(F::WhdloadKickstarts, "Kickstart ROMs", Drive),
+    row(F::WhdloadLibrary, "Save data", Drive),
+];
+#[cfg(feature = "game-library")]
+const WHDLOAD_ROWS: [Row; 10] = [
+    section_header("WHDLoad Configuration:"),
+    // What to boot, and how: what a person changes per game.
+    row(F::WhdloadGame, "Launch game", Drive),
+    row(F::WhdloadMachine, "Machine type", Cycle),
+    row(F::WhdloadOpenRetro, "OpenRetro", RowKind::Account),
+    // Then the places things live, set once and left.
+    section_header("Directories:"),
+    row(F::WhdloadWhdPackage, "WHDLoad package", Drive),
+    row(F::WhdloadSkickPackage, "SKick package", Drive),
+    row(F::WhdloadKickstarts, "Kickstart ROMs", Drive),
+    row(F::WhdloadGames, "Game library", Drive),
+    row(F::WhdloadLibrary, "Save data", Drive),
 ];
 // The MIDI endpoint rows appear only when the serial port is in MIDI mode, so
 // the Serial section shows just the Device / Mode selector otherwise. The
@@ -917,11 +1045,22 @@ const AUDIO_ROWS: [Row; 6] = [
     row(F::FloppySounds, "Floppy sounds", Toggle),
     row(F::FloppyVolume, "Floppy volume", Cycle),
 ];
+#[cfg(not(feature = "game-library"))]
 const EMULATION_ROWS: [Row; 4] = [
     row(F::PowerOn, "Power on startup", Toggle),
     row(F::RealtimePriority, "Realtime priority", Toggle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
+];
+#[cfg(feature = "game-library")]
+const EMULATION_ROWS: [Row; 5] = [
+    row(F::PowerOn, "Power on startup", Toggle),
+    row(F::RealtimePriority, "Realtime priority", Toggle),
+    row(F::PacingBudget, "Pacing budget", Cycle),
+    row(F::Warp, "Warp speed", Cycle),
+    // Off, the strip loses its WHDLoad entry and the pages behind it stop
+    // doing anything at all -- no database read, no cover worker, no scan.
+    row(F::WhdloadEnabled, "WHDLoad", Cycle),
 ];
 /// The floppy page. Every option the format carries is on it; nothing on
 /// it reads or writes the machine's configuration.
@@ -1019,6 +1158,9 @@ pub fn rows(
         }
         LauncherTab::HostFs => Cow::Borrowed(&HOSTFS_ROWS),
         LauncherTab::Whdload => Cow::Borrowed(&WHDLOAD_ROWS),
+        // The Library draws a list of games rather than rows of settings.
+        #[cfg(feature = "game-library")]
+        LauncherTab::WhdloadLibrary => Cow::Borrowed(&[]),
         // Drawn as its own layout: a disk table and its buttons, not rows.
         LauncherTab::HostDisk => Cow::Borrowed(&[]),
         LauncherTab::Cd => Cow::Borrowed(&CD_ROWS),
@@ -1692,6 +1834,24 @@ pub struct MachineSetup {
     whdload_kickstarts: Option<PathBuf>,
     whdload_library: Option<PathBuf>,
     whdload_args: Option<String>,
+    /// The WHDLoad distribution and Soft-Kicker archives, when they are not
+    /// the copies the release ships with.
+    whdload_whd_package: Option<PathBuf>,
+    whdload_skick_package: Option<PathBuf>,
+    /// Which machine a package boots on.
+    whdload_machine: crate::config::WhdloadMachine,
+    /// Where the game database lives, and whether WHDLoad has a link of its
+    /// own in the left-hand navigation. Both belong to the library, so a
+    /// build without it carries them through a save untouched rather than
+    /// editing or dropping them.
+    /// Where the Library page keeps its scanned library and its downloads.
+    /// Configuration-file only -- see `RawWhdload::library_db` -- so they
+    /// are held here rather than being launcher fields with rows.
+    whdload_library_db: Option<PathBuf>,
+    whdload_library_cache: Option<PathBuf>,
+    whdload_enabled: bool,
+    /// A directory of packages, which the Library page lists.
+    whdload_games: Option<PathBuf>,
     // Serial port. Carried in every build so a config's `[serial]` block
     // round-trips; only edited in the I/O Ports tab's Serial section, which a
     // `midi` build shows.
@@ -1928,6 +2088,15 @@ impl MachineSetup {
             whdload_kickstarts: raw.whdload.kickstarts.as_deref().map(PathBuf::from),
             whdload_library: raw.whdload.library.as_deref().map(PathBuf::from),
             whdload_args: raw.whdload.args.clone(),
+            whdload_whd_package: raw.whdload.whd_package.as_deref().map(PathBuf::from),
+            whdload_skick_package: raw.whdload.skick_package.as_deref().map(PathBuf::from),
+            whdload_machine: raw.whdload.machine_type.unwrap_or_default(),
+            whdload_library_db: raw.whdload.library_db.as_deref().map(PathBuf::from),
+            whdload_library_cache: raw.whdload.library_cache.as_deref().map(PathBuf::from),
+            // On unless told otherwise: a fresh installation should find
+            // the page there rather than have to be told to show it.
+            whdload_enabled: raw.whdload.enabled.unwrap_or(true),
+            whdload_games: raw.whdload.games.as_deref().map(PathBuf::from),
             serial_mode: cfg.serial.mode,
             midi_out: cfg.serial.midi_out.clone(),
             midi_in: cfg.serial.midi_in.clone(),
@@ -2339,6 +2508,19 @@ impl MachineSetup {
         raw.whdload.kickstarts = self.whdload_kickstarts.as_deref().map(path_string);
         raw.whdload.library = self.whdload_library.as_deref().map(path_string);
         raw.whdload.args = self.whdload_args.clone();
+        raw.whdload.whd_package = self.whdload_whd_package.as_deref().map(path_string);
+        raw.whdload.skick_package = self.whdload_skick_package.as_deref().map(path_string);
+        // Only written when it is not the default, so a saved file stays
+        // the short list of what differs from the profile.
+        raw.whdload.machine_type = (self.whdload_machine
+            != crate::config::WhdloadMachine::default())
+        .then_some(self.whdload_machine);
+        raw.whdload.library_db = self.whdload_library_db.as_deref().map(path_string);
+        raw.whdload.library_cache = self.whdload_library_cache.as_deref().map(path_string);
+        // Only written when it is off, since on is the default and a
+        // configuration file should say what differs from it.
+        raw.whdload.enabled = (!self.whdload_enabled).then_some(false);
+        raw.whdload.games = self.whdload_games.as_deref().map(path_string);
         // A/V and emulation
         if self.overscan != base.overscan {
             raw.display.overscan = Some(overscan_name(self.overscan).to_string());
@@ -2937,6 +3119,11 @@ impl MachineSetup {
     }
 
     /// The current boolean of a toggle field.
+    /// Whether WHDLoad has a link of its own in the left-hand strip.
+    pub fn whdload_enabled(&self) -> bool {
+        self.whdload_enabled
+    }
+
     pub fn toggle_value(&self, field: LauncherField) -> bool {
         match field {
             F::Rtc => self.rtc,
@@ -2993,6 +3180,9 @@ impl MachineSetup {
             F::WhdloadGame => self.whdload_game.as_deref(),
             F::WhdloadKickstarts => self.whdload_kickstarts.as_deref(),
             F::WhdloadLibrary => self.whdload_library.as_deref(),
+            F::WhdloadWhdPackage => self.whdload_whd_package.as_deref(),
+            F::WhdloadSkickPackage => self.whdload_skick_package.as_deref(),
+            F::WhdloadGames => self.whdload_games.as_deref(),
             _ => None,
         }
     }
@@ -3116,6 +3306,16 @@ impl MachineSetup {
 
     pub fn value_label(&self, field: LauncherField) -> String {
         match field {
+            F::WhdloadMachine => match self.whdload_machine {
+                crate::config::WhdloadMachine::Auto => "Auto".to_string(),
+                crate::config::WhdloadMachine::Copperline => "Copperline".to_string(),
+            },
+            F::WhdloadEnabled => if self.whdload_enabled {
+                "Enabled"
+            } else {
+                "Disabled"
+            }
+            .to_string(),
             F::Chipset => chipset_name(self.chipset).to_string(),
             F::Rtg => rtg_card_name(self.rtg).to_string(),
             F::Agnus => match self.agnus {
@@ -3359,10 +3559,15 @@ impl MachineSetup {
                     _ => label,
                 }
             }
-            // The WHDLoad staging directories derive sensible defaults when
-            // unset (see whdload::game_and_options), so their placeholder
-            // says so; the game itself has no default.
-            F::WhdloadKickstarts | F::WhdloadLibrary => self.path_label(field, "(default)"),
+            // The WHDLoad directories all have a place they go when unset,
+            // under the one WHDLoad directory (crate::paths::whdload_dir),
+            // so their placeholder says the setting is doing something
+            // rather than nothing. The game itself has no default, and the
+            // two support archives are either there or not.
+            F::WhdloadKickstarts | F::WhdloadLibrary | F::WhdloadGames => {
+                self.path_label(field, "(default)")
+            }
+            F::WhdloadWhdPackage | F::WhdloadSkickPackage => self.path_label(field, "(none)"),
             // Path/drive fields: the file name, or a placeholder.
             F::Rom => self.path_label(field, "(bundled AROS)"),
             _ if rows_contains_kind(field, RowKind::Path)
@@ -3424,6 +3629,18 @@ impl MachineSetup {
     /// Step a cycle/stepper field forward (`forward`) or backward.
     pub fn cycle(&mut self, field: LauncherField, forward: bool) {
         match field {
+            F::WhdloadEnabled => {
+                self.whdload_enabled = !self.whdload_enabled;
+                let _ = forward;
+            }
+            F::WhdloadMachine => {
+                use crate::config::WhdloadMachine as M;
+                self.whdload_machine = match self.whdload_machine {
+                    M::Auto => M::Copperline,
+                    M::Copperline => M::Auto,
+                };
+                let _ = forward;
+            }
             F::Chipset => self.chipset = cycle_slice(&CHIPSETS, self.chipset, forward),
             F::Rtg => {
                 let cards = if cpu_is_32bit(self.cpu) {
@@ -3822,6 +4039,9 @@ impl MachineSetup {
             F::WhdloadGame => self.whdload_game = Some(path),
             F::WhdloadKickstarts => self.whdload_kickstarts = Some(path),
             F::WhdloadLibrary => self.whdload_library = Some(path),
+            F::WhdloadWhdPackage => self.whdload_whd_package = Some(path),
+            F::WhdloadSkickPackage => self.whdload_skick_package = Some(path),
+            F::WhdloadGames => self.whdload_games = Some(path),
             _ => {
                 if let Some((slot, false)) = filesys_slot(field) {
                     self.filesys_dirs[slot] = Some(path);
@@ -3870,6 +4090,9 @@ impl MachineSetup {
             F::ParallelOutput => self.parallel_output = None,
             F::WhdloadGame => self.whdload_game = None,
             F::WhdloadKickstarts => self.whdload_kickstarts = None,
+            F::WhdloadWhdPackage => self.whdload_whd_package = None,
+            F::WhdloadSkickPackage => self.whdload_skick_package = None,
+            F::WhdloadGames => self.whdload_games = None,
             F::WhdloadLibrary => self.whdload_library = None,
             _ => {
                 if let Some((slot, false)) = filesys_slot(field) {
@@ -5108,6 +5331,610 @@ pub struct LauncherState {
     /// focus (a plugin string option or a drive volume name).
     editing: Option<EditTarget>,
     edit_buffer: String,
+    /// The Library page: the games found, which is chosen, and where the
+    /// list is scrolled to. Held here rather than in the setup for the
+    /// same reason the workshop is -- none of it describes a machine.
+    #[cfg(feature = "game-library")]
+    pub library: LibraryPage,
+    /// The signed-in OpenRetro session, for as long as the launcher is
+    /// open. Shared with a running scan rather than handed over, so the
+    /// row can still say it is signed in while one is going.
+    #[cfg(feature = "game-library")]
+    pub openretro: Option<std::sync::Arc<crate::gamelib::openretro::Session>>,
+    /// The sign-in dialog, when it is up.
+    #[cfg(feature = "game-library")]
+    pub login: Option<LoginDialog>,
+    /// The metadata editor, when it is up.
+    #[cfg(feature = "game-library")]
+    pub meta: Option<MetaDialog>,
+}
+
+/// What the Library page is showing.
+#[cfg(feature = "game-library")]
+#[derive(Debug, Default, Clone)]
+pub struct LibraryPage {
+    /// The game database, read once when the page is first opened.
+    pub db: crate::gamelib::Database,
+    /// Whether the database has been read yet, so an empty one is not
+    /// re-read on every frame.
+    pub db_loaded: bool,
+    /// The games found beside the chosen one.
+    pub games: crate::gamelib::Library,
+    /// Which of the two lists the keyboard is walking, and which row is
+    /// chosen in it. Only the focused list draws a chosen row: a game
+    /// highlighted in both at once reads as two selections.
+    pub focus: LibraryFocus,
+    /// Which entry is chosen, as an index into `games`.
+    pub selected: usize,
+    /// Which row of the favourites list is chosen, as a position in it.
+    pub favourite_selected: usize,
+    /// The first row drawn, for scrolling.
+    pub scroll: usize,
+    /// How fast a continued scroll is running.
+    pub scroll_rate: crate::gamelib::ScrollRate,
+    /// Cover art, fetched for whatever is selected and kept afterwards.
+    pub covers: crate::gamelib::Covers,
+}
+
+/// A package's own name, without the folders above it or its extension.
+#[cfg(feature = "game-library")]
+fn file_stem_of(relative: &str) -> &str {
+    let base = relative.rsplit(['/', '\\']).next().unwrap_or(relative);
+    base.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(base)
+}
+
+/// Which of the Library page's two lists is being walked.
+#[cfg(feature = "game-library")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LibraryFocus {
+    #[default]
+    Games,
+    Favourites,
+}
+
+/// One field of the metadata editor.
+#[cfg(feature = "game-library")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MetaField {
+    #[default]
+    Name,
+    Year,
+    Publisher,
+    Developer,
+    Players,
+}
+
+#[cfg(feature = "game-library")]
+impl MetaField {
+    pub const ALL: [MetaField; 5] = [
+        MetaField::Name,
+        MetaField::Year,
+        MetaField::Publisher,
+        MetaField::Developer,
+        MetaField::Players,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            MetaField::Name => "Name",
+            MetaField::Year => "Year",
+            MetaField::Publisher => "Publisher",
+            MetaField::Developer => "Developer",
+            MetaField::Players => "Players",
+        }
+    }
+
+    fn at(self) -> usize {
+        MetaField::ALL.iter().position(|&f| f == self).unwrap_or(0)
+    }
+}
+
+/// The metadata editor, while it is open.
+///
+/// Everything in it is a copy: nothing reaches the store until Save, so
+/// Cancel really is "leave it as it was", and Clear is something you can
+/// change your mind about.
+#[cfg(feature = "game-library")]
+#[derive(Debug, Clone, Default)]
+pub struct MetaDialog {
+    /// The package being edited, by the name the store files it under.
+    pub file: String,
+    /// The values, in [`MetaField::ALL`] order.
+    pub values: [String; 5],
+    /// The cache key of the art, which is a catalogue digest for art that
+    /// was downloaded and a `manual-` name for art somebody chose.
+    pub art: Option<String>,
+    pub focus: MetaField,
+}
+
+#[cfg(feature = "game-library")]
+impl MetaDialog {
+    pub fn value(&self, field: MetaField) -> &str {
+        &self.values[field.at()]
+    }
+
+    pub fn value_mut(&mut self, field: MetaField) -> &mut String {
+        &mut self.values[field.at()]
+    }
+
+    /// Whether there is anything left to save. An editor emptied and saved
+    /// hands the package back to the scan rather than pinning it empty.
+    pub fn is_empty(&self) -> bool {
+        self.art.is_none() && self.values.iter().all(|v| v.trim().is_empty())
+    }
+}
+
+/// Which box of the sign-in dialog is being typed into.
+#[cfg(feature = "game-library")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoginField {
+    User,
+    Pass,
+}
+
+/// The sign-in dialog, while it is open.
+///
+/// Nothing here is kept: the password is traded for a token when OK is
+/// pressed and wiped on the way out, and the token lives no longer than the
+/// session. See [`crate::gamelib::Secret`] for what that costs to do
+/// properly.
+#[cfg(feature = "game-library")]
+#[derive(Debug)]
+pub struct LoginDialog {
+    pub user: String,
+    pub pass: crate::gamelib::Secret,
+    pub focus: LoginField,
+    /// Set while the sign-in request is in flight, so a second Return does
+    /// not start a second one.
+    pub sending: bool,
+}
+
+/// A cloned launcher state does not carry a half-typed password. That is
+/// the only sensible thing a copy of a credential could be, and it is why
+/// this is written rather than derived.
+#[cfg(feature = "game-library")]
+impl Clone for LoginDialog {
+    fn clone(&self) -> LoginDialog {
+        LoginDialog::default()
+    }
+}
+
+#[cfg(feature = "game-library")]
+impl Default for LoginDialog {
+    fn default() -> LoginDialog {
+        LoginDialog {
+            user: String::new(),
+            pass: crate::gamelib::Secret::new(),
+            focus: LoginField::User,
+            sending: false,
+        }
+    }
+}
+
+/// The support directory under a given configuration directory. The same
+/// place [`crate::paths::whdload_support_dir`] names, spelled from a root
+/// the caller chose so a test can point somewhere else.
+#[cfg(feature = "game-library")]
+fn whdload_support_under(config_dir: &std::path::Path) -> PathBuf {
+    config_dir.join("whdload").join("support")
+}
+
+#[cfg(feature = "game-library")]
+impl MachineSetup {
+    /// Where the scanned library is kept: `[whdload] library_db`, or the
+    /// default under the configuration directory.
+    pub fn library_db(&self, config_dir: &std::path::Path) -> PathBuf {
+        self.whdload_library_db
+            .clone()
+            .unwrap_or_else(|| whdload_support_under(config_dir).join("launcher.db"))
+    }
+
+    /// Where a scan keeps what it downloaded: `[whdload] library_cache`, or
+    /// the default beside the library it belongs to.
+    pub fn library_cache(&self, config_dir: &std::path::Path) -> PathBuf {
+        self.whdload_library_cache
+            .clone()
+            .unwrap_or_else(|| whdload_support_under(config_dir).join("cache"))
+    }
+
+    /// Adopt whatever is already sitting where WHDLoad would have put it.
+    ///
+    /// A person who has run the packaging script, or downloaded once and
+    /// then started a fresh configuration, should not have to point at the
+    /// same files again. Only fills a setting that is empty, so a chosen
+    /// path is never quietly replaced -- and only adopts an archive whose
+    /// digest is right, since a half-finished download in the right place
+    /// with the right name is exactly what should *not* be adopted.
+    pub fn adopt_whdload_defaults(&mut self) {
+        for archive in crate::gamelib::support::Archive::ALL {
+            let field = match archive {
+                crate::gamelib::support::Archive::Whdload => F::WhdloadWhdPackage,
+                crate::gamelib::support::Archive::Skick => F::WhdloadSkickPackage,
+            };
+            if self.path(field).is_none() {
+                if let Some(at) = archive.found_locally() {
+                    self.set_path(field, at);
+                }
+            }
+        }
+        // Kickstart images are somebody's own collection rather than a
+        // known file, so the test is that the directory has anything in it
+        // at all.
+        if self.path(F::WhdloadKickstarts).is_none() {
+            if let Some(dir) = crate::gamelib::support::default_kickstart_dir() {
+                if crate::gamelib::support::holds_anything(&dir) {
+                    self.set_path(F::WhdloadKickstarts, dir);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "game-library")]
+impl LauncherState {
+    /// Bring the Library page up to date with what the configuration says.
+    ///
+    /// Called when the page is drawn or clicked rather than when the
+    /// settings change: the game and the database path are ordinary path
+    /// fields that anything may set -- a Browse, a drop, a loaded config --
+    /// and one place that notices beats a dozen that have to remember to.
+    pub fn refresh_library(&mut self, config_dir: &std::path::Path) {
+        // Turned off, the page does nothing at all: no store read, no
+        // cover worker started, nothing held. Whatever a previous session
+        // left in memory goes with it.
+        if !self.setup.whdload_enabled() {
+            if self.library.db_loaded {
+                self.library = LibraryPage::default();
+            }
+            return;
+        }
+        // No game library means nothing to list -- and nothing to show in
+        // the favourites either. They are kept in the store, so without
+        // this a fresh install with no library set still listed whatever a
+        // previous one had starred.
+        if self.library_folder().is_none() {
+            if self.library.db_loaded {
+                self.library = LibraryPage::default();
+            }
+            return;
+        }
+        if !self.library.db_loaded {
+            self.library.db = crate::gamelib::Database::load(&self.setup.library_db(config_dir));
+            // The covers subdirectory of the cache, not the cache itself:
+            // that is where a scan writes them.
+            self.library.covers = crate::gamelib::Covers::new(crate::gamelib::scan::covers_path(
+                &self.setup.library_cache(config_dir),
+            ));
+            self.library.db_loaded = true;
+        }
+        // From the store, not from the disk: opening a page is not a
+        // reason to walk a collection of several thousand packages. The
+        // Refresh button is.
+        match self.library_folder() {
+            Some(folder) if !self.library.games.covers(&folder) => {
+                self.library.games = crate::gamelib::Library::known(&folder, &self.library.db);
+                self.select_running_game();
+            }
+            None => self.library.games = crate::gamelib::Library::default(),
+            _ => {}
+        }
+        // A list that shrank under the selection must not leave it past the
+        // end, where nothing would be drawn as chosen.
+        self.library.selected = self
+            .library
+            .selected
+            .min(self.library.games.len().saturating_sub(1));
+    }
+
+    /// Put the selection on the game the configuration names, so opening
+    /// the page while one is running shows which.
+    fn select_running_game(&mut self) {
+        if let Some(at) = self
+            .setup
+            .path(F::WhdloadGame)
+            .and_then(|game| self.library.games.position(game))
+        {
+            self.library.selected = at;
+        }
+    }
+
+    /// The entry the list is on, if the list has any.
+    /// Keep the cover art up with the selection: collect anything that has
+    /// arrived, and ask for what is being looked at now. Answers whether
+    /// the page changed and should be drawn again.
+    ///
+    /// Here rather than at each place a game is chosen, because every route
+    /// to a selection -- a click, an arrow key, the favourites list, a
+    /// config that named a game -- has to end up asking.
+    pub fn poll_library_covers(&mut self) -> bool {
+        let arrived = self.library.covers.poll();
+        // The selection and the few either side of it. Reading ahead is
+        // what makes a steady scroll find each cover already decoded
+        // instead of waiting for it at every step.
+        let at = self.library.selected;
+        let entries = self.library.games.entries();
+        let window: Vec<Option<&str>> = entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .game
+                    .as_ref()
+                    .and_then(|game| game.front_sha1.as_deref())
+            })
+            .collect();
+        self.library.covers.want_around(window.into_iter(), at);
+        // And whatever the editor is showing, which after a picture has
+        // been chosen is not the selection's art any more.
+        if let Some(key) = self.meta.as_ref().and_then(|meta| meta.art.clone()) {
+            self.library.covers.want(&key);
+        }
+        arrived
+    }
+
+    /// The folder the list is of.
+    ///
+    /// A game library is a collection and is searched all the way down;
+    /// without one, the folder holding the chosen game stands in, so
+    /// pointing at any package still lists its neighbours. The library
+    /// wins where both are set: it is the deliberate answer to "where are
+    /// my games", and the other is a guess from one of them.
+    pub fn library_folder(&self) -> Option<PathBuf> {
+        self.setup
+            .path(F::WhdloadGames)
+            .map(std::path::Path::to_path_buf)
+            .or_else(|| {
+                self.setup
+                    .path(F::WhdloadGame)
+                    .and_then(|game| game.parent())
+                    .map(std::path::Path::to_path_buf)
+            })
+    }
+
+    pub fn library_selection(&self) -> Option<&crate::gamelib::Entry> {
+        match self.library.focus {
+            LibraryFocus::Games => self.library.games.entries().get(self.library.selected),
+            // A favourite whose package is no longer there has no entry,
+            // and so nothing to show beside it.
+            LibraryFocus::Favourites => {
+                let key = self.favourite_key(self.library.favourite_selected)?;
+                self.library
+                    .games
+                    .entries()
+                    .iter()
+                    .find(|entry| crate::gamelib::Database::key_for(&entry.file_name) == key)
+            }
+        }
+    }
+
+    /// The key of the favourite on that row.
+    pub fn favourite_key(&self, drawn: usize) -> Option<&str> {
+        self.library.db.favourites().nth(drawn).map(|(key, _)| key)
+    }
+
+    /// Choose a game, which is also to say launch it when Run is pressed:
+    /// the selection *is* the configured game rather than something that
+    /// has to be copied across on the way out.
+    pub fn select_library_game(&mut self, index: usize) {
+        let Some(entry) = self.library.games.entries().get(index) else {
+            return;
+        };
+        let path = entry.path.clone();
+        self.library.focus = LibraryFocus::Games;
+        self.library.selected = index;
+        self.setup.set_path(F::WhdloadGame, path);
+        self.status = None;
+    }
+
+    /// Mark or unmark the game at `index` in the list.
+    pub fn toggle_library_favourite(&mut self, index: usize) {
+        let Some(entry) = self.library.games.entries().get(index) else {
+            return;
+        };
+        // The name is kept with the mark, so the favourite still reads as
+        // a game once its package is gone.
+        let (name, title) = (entry.file_name.clone(), entry.title().to_string());
+        self.library.db.toggle_favourite(&name, &title);
+    }
+
+    /// Choose a favourite: the game to launch, without also being the row
+    /// highlighted in the list above. Two highlights for one choice is
+    /// two choices as far as anyone reading the page is concerned.
+    pub fn select_favourite(&mut self, drawn: usize) {
+        let Some(key) = self.favourite_key(drawn).map(str::to_string) else {
+            return;
+        };
+        self.library.focus = LibraryFocus::Favourites;
+        self.library.favourite_selected = drawn;
+        self.status = None;
+        // A favourite whose package has been deleted is still a row worth
+        // landing on -- its Remove tick is the point of it -- but there is
+        // nothing to launch.
+        let path = self
+            .library
+            .games
+            .entries()
+            .iter()
+            .find(|entry| crate::gamelib::Database::key_for(&entry.file_name) == key)
+            .map(|entry| entry.path.clone());
+        if let Some(path) = path {
+            self.setup.set_path(F::WhdloadGame, path);
+        }
+    }
+
+    /// Open the metadata editor on whatever is selected.
+    pub fn open_meta_editor(&mut self) -> bool {
+        let Some(entry) = self.library_selection() else {
+            return false;
+        };
+        let file = entry.relative.clone();
+        let game = entry.game.clone();
+        let mut dialog = MetaDialog {
+            file,
+            focus: MetaField::Name,
+            art: game.as_ref().and_then(|g| g.front_sha1.clone()),
+            ..Default::default()
+        };
+        if let Some(game) = &game {
+            for (field, value) in [
+                (MetaField::Name, Some(game.name.clone())),
+                (MetaField::Year, game.year.clone()),
+                (MetaField::Publisher, game.publisher.clone()),
+                (MetaField::Developer, game.developer.clone()),
+                (MetaField::Players, game.players.clone()),
+            ] {
+                *dialog.value_mut(field) = value.unwrap_or_default();
+            }
+        }
+        self.meta = Some(dialog);
+        self.status = None;
+        true
+    }
+
+    /// Commit the editor into the store, and answer where to save it.
+    ///
+    /// An editor with nothing in it clears the entry and hands it back to
+    /// the scan; anything else is marked as hand-filled, which is what
+    /// stops the next scan overwriting it.
+    pub fn commit_meta_editor(&mut self) {
+        let Some(dialog) = self.meta.take() else {
+            return;
+        };
+        // Keeping the digest means a later scan still recognises the
+        // package without opening it again.
+        let held_digest = self
+            .library
+            .db
+            .entry(&dialog.file)
+            .and_then(|k| k.slave_sha1.clone());
+        let field = |f: MetaField| {
+            let value = dialog.value(f).trim();
+            (!value.is_empty()).then(|| value.to_string())
+        };
+        let entry = if dialog.is_empty() {
+            crate::gamelib::Known {
+                file: dialog.file.clone(),
+                game: None,
+                slave_sha1: held_digest,
+                manual: false,
+            }
+        } else {
+            crate::gamelib::Known {
+                file: dialog.file.clone(),
+                game: Some(crate::gamelib::Game {
+                    // Kept, so a re-sync can still recognise the record
+                    // this started life as.
+                    uuid: self
+                        .library
+                        .db
+                        .entry(&dialog.file)
+                        .and_then(|k| k.game.as_ref())
+                        .map(|g| g.uuid.clone())
+                        .unwrap_or_default(),
+                    // A name left blank falls back to what the list would
+                    // have shown anyway -- the file's own name, without
+                    // the folders it sits in or its extension.
+                    name: field(MetaField::Name)
+                        .unwrap_or_else(|| file_stem_of(&dialog.file).to_string()),
+                    year: field(MetaField::Year),
+                    publisher: field(MetaField::Publisher),
+                    developer: field(MetaField::Developer),
+                    players: field(MetaField::Players),
+                    front_sha1: dialog.art.clone(),
+                }),
+                slave_sha1: held_digest,
+                manual: true,
+            }
+        };
+        self.library.db.set_entry(entry);
+    }
+
+    /// Move the selection in whichever list is focused.
+    pub fn step_library_focus(&mut self, delta: isize, visible: usize) {
+        match self.library.focus {
+            LibraryFocus::Games => self.step_library(delta, visible),
+            LibraryFocus::Favourites => {
+                let len = self.library.db.favourite_count();
+                if len == 0 {
+                    return;
+                }
+                let at = (self.library.favourite_selected as isize + delta)
+                    .clamp(0, len as isize - 1) as usize;
+                self.select_favourite(at);
+            }
+        }
+    }
+
+    /// Take a favourite off from the favourites list itself.
+    pub fn remove_favourite(&mut self, drawn: usize) {
+        if let Some(key) = self.favourite_key(drawn).map(str::to_string) {
+            self.library.db.remove_favourite(&key);
+        }
+    }
+
+    /// Re-read the game folder: the one thing that walks the disk, and the
+    /// only way a package that was not there before gets into the store.
+    ///
+    /// What it finds goes into the store rather than only into the list, so
+    /// the page shows the same thing when it is next opened and after a
+    /// restart. Metadata already resolved is carried across -- reading the
+    /// folder again must not be a way to lose the work a scan did.
+    ///
+    /// Answers how many packages are in the folder, and how many of those
+    /// have nothing known about them yet.
+    pub fn rescan_library(&mut self, config_dir: &std::path::Path) -> (usize, usize) {
+        self.refresh_library(config_dir);
+        let Some(folder) = self.library_folder() else {
+            return (0, 0);
+        };
+        let fresh = self
+            .library
+            .db
+            .merge_found(crate::gamelib::scan::packages(&folder));
+        self.save_library_database(config_dir);
+        self.library.games = crate::gamelib::Library::known(&folder, &self.library.db);
+        self.select_running_game();
+        self.library.selected = self
+            .library
+            .selected
+            .min(self.library.games.len().saturating_sub(1));
+        (self.library.games.len(), fresh)
+    }
+
+    /// Write the database out, so a favourite outlives the session.
+    pub fn save_library_database(&self, config_dir: &std::path::Path) {
+        let at = self.setup.library_db(config_dir);
+        if let Err(e) = self.library.db.save(&at) {
+            log::warn!("game library: could not save {}: {e}", at.display());
+        }
+    }
+
+    /// Move the selection by `delta` rows, keeping it in view.
+    pub fn step_library(&mut self, delta: isize, visible: usize) {
+        let len = self.library.games.len();
+        if len == 0 {
+            return;
+        }
+        let at = (self.library.selected as isize + delta).clamp(0, len as isize - 1) as usize;
+        self.select_library_game(at);
+        self.scroll_library_into_view(visible);
+    }
+
+    /// Scroll the list by `delta` rows without moving the selection.
+    pub fn scroll_library(&mut self, delta: isize, visible: usize) {
+        let last_start = self.library.games.len().saturating_sub(visible);
+        let at = self.library.scroll as isize + delta;
+        self.library.scroll = at.clamp(0, last_start as isize) as usize;
+    }
+
+    /// Bring the selection into the drawn rows, moving as little as will do.
+    fn scroll_library_into_view(&mut self, visible: usize) {
+        let at = self.library.selected;
+        if at < self.library.scroll {
+            self.library.scroll = at;
+        } else if visible > 0 && at >= self.library.scroll + visible {
+            self.library.scroll = at + 1 - visible;
+        }
+    }
 }
 
 impl LauncherState {
@@ -5490,7 +6317,19 @@ impl LauncherState {
         // Read the host devices as the screen opens so the pickers show what is
         // connected now.
         setup.refresh_host_devices();
+        // Likewise the WHDLoad support files: anything already sitting
+        // where they go fills its own row rather than asking again.
+        #[cfg(feature = "game-library")]
+        setup.adopt_whdload_defaults();
         let mut state = Self {
+            #[cfg(feature = "game-library")]
+            library: LibraryPage::default(),
+            #[cfg(feature = "game-library")]
+            openretro: None,
+            #[cfg(feature = "game-library")]
+            login: None,
+            #[cfg(feature = "game-library")]
+            meta: None,
             setup,
             workshop: ImageWorkshop::default(),
             tab: LauncherTab::System,
@@ -7236,9 +8075,32 @@ mod tests {
         assert_eq!(raw.whdload.game.as_deref(), Some("/g/game.lha"));
         assert_eq!(raw.whdload.kickstarts.as_deref(), Some("/k"));
         assert_eq!(raw.whdload.library.as_deref(), Some("/l"));
-        // The WHDLoad volumes have fixed names, so no volume box applies.
-        assert!(!setup.drive_name_applies(F::WhdloadGame));
-        for field in [F::WhdloadGame, F::WhdloadKickstarts, F::WhdloadLibrary] {
+        // The WHDLoad volumes have fixed names, so no path row here ever
+        // grows a volume box -- an editable name with nothing to name.
+        // Every one of them, so a row added later is not left with a box
+        // that cannot be typed into.
+        for field in [
+            F::WhdloadGame,
+            F::WhdloadGames,
+            F::WhdloadKickstarts,
+            F::WhdloadLibrary,
+            F::WhdloadWhdPackage,
+            F::WhdloadSkickPackage,
+        ] {
+            setup.set_path(field, PathBuf::from("/somewhere"));
+            assert!(
+                !setup.drive_name_applies(field),
+                "{field:?} offers a volume box"
+            );
+        }
+        for field in [
+            F::WhdloadGame,
+            F::WhdloadGames,
+            F::WhdloadKickstarts,
+            F::WhdloadLibrary,
+            F::WhdloadWhdPackage,
+            F::WhdloadSkickPackage,
+        ] {
             setup.clear_path(field);
             assert_eq!(setup.path(field), None);
         }
@@ -7318,20 +8180,36 @@ mod tests {
     }
 
     #[test]
-    fn the_whdload_sub_page_hangs_off_the_storage_tab() {
-        // The sub-page keeps the Storage strip entry lit, returns to Storage
-        // via Back, and is reachable from the Storage nav row.
-        assert_eq!(LauncherTab::Whdload.strip_tab(), LauncherTab::Storage);
-        assert_eq!(
-            LauncherTab::Whdload.parent_tab(),
-            Some(LauncherTab::Storage)
-        );
-        assert!(LauncherTab::Storage
+    fn whdload_is_its_own_strip_entry_and_opens_on_the_library() {
+        // It left Storage: the nav row there no longer offers it, and
+        // neither page returns to it.
+        assert!(!LauncherTab::Storage
             .nav_options()
             .iter()
-            .any(|&(label, tab)| label == "WHDLoad" && tab == LauncherTab::Whdload));
-        // The row table: the game package plus the two staging directories,
-        // all path rows with a Browse button.
+            .any(|&(_, tab)| tab == LauncherTab::Whdload));
+        // Both pages light the one entry, which is the Library -- what the
+        // strip opens on, and what the nav row lists first.
+        assert_eq!(
+            LauncherTab::Whdload.strip_tab(),
+            LauncherTab::WhdloadLibrary
+        );
+        assert_eq!(
+            LauncherTab::WhdloadLibrary.strip_tab(),
+            LauncherTab::WhdloadLibrary
+        );
+        assert_eq!(LauncherTab::Whdload.parent_tab(), None);
+        assert_eq!(LauncherTab::WhdloadLibrary.parent_tab(), None);
+        assert_eq!(
+            LauncherTab::WhdloadLibrary.nav_options().first(),
+            Some(&("Library", LauncherTab::WhdloadLibrary))
+        );
+        // And the entry is in the strip when WHDLoad is on, and gone when
+        // it is off.
+        assert!(tabs(true).contains(&LauncherTab::WhdloadLibrary));
+        assert!(!tabs(false).contains(&LauncherTab::WhdloadLibrary));
+        // The row table: the game to launch, then what staging draws on.
+        // The last two belong to the library, so they are only here in a
+        // build that has one.
         let rows = rows(
             LauncherTab::Whdload,
             ParallelDevice::None,
@@ -7339,12 +8217,38 @@ mod tests {
             false,
         );
         let labels: Vec<&str> = rows.iter().map(|r| r.label).collect();
-        assert_eq!(labels, ["Game package", "Kickstart images", "Game library"]);
-        assert!(rows.iter().all(|r| r.kind == RowKind::Drive));
-        // The two directories browse as folders; the package browses as a file.
+        // What to boot and how first, then the places things live.
+        let mut want = vec!["WHDLoad Configuration:", "Launch game", "Machine type"];
+        if cfg!(feature = "game-library") {
+            want.push("OpenRetro");
+        }
+        want.extend([
+            "Directories:",
+            "WHDLoad package",
+            "SKick package",
+            "Kickstart ROMs",
+        ]);
+        if cfg!(feature = "game-library") {
+            want.push("Game library");
+        }
+        want.push("Save data");
+        assert_eq!(labels, want);
+        // Every path row is a Drive row, so the whole host path shows.
+        assert!(rows
+            .iter()
+            .filter(|r| r.field.is_whdload_path_field())
+            .all(|r| r.kind == RowKind::Drive));
+        // Directories browse as folders; the archives browse as files.
         assert!(!F::WhdloadGame.is_whdload_dir_field());
+        assert!(F::WhdloadGame.is_whdload_archive_field());
+        assert!(F::WhdloadWhdPackage.is_whdload_archive_field());
+        assert!(F::WhdloadSkickPackage.is_whdload_archive_field());
         assert!(F::WhdloadKickstarts.is_whdload_dir_field());
         assert!(F::WhdloadLibrary.is_whdload_dir_field());
+        // The game library is a folder of packages, so it browses as one.
+        // Picking it with a file chooser is how it stayed unset.
+        #[cfg(feature = "game-library")]
+        assert!(F::WhdloadGames.is_whdload_dir_field());
     }
 
     #[test]
@@ -8709,7 +9613,6 @@ mod tests {
             LauncherTab::HostFs,
             LauncherTab::HostDisk,
             LauncherTab::BootPriority,
-            LauncherTab::Whdload,
         ] {
             assert!(!TABS.contains(&t));
             // Each keeps the Storage strip tab highlighted and returns to it.
@@ -8735,7 +9638,6 @@ mod tests {
                 LauncherTab::BootPriority,
                 LauncherTab::CreateFloppy,
                 LauncherTab::Cd,
-                LauncherTab::Whdload,
             ]
         );
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1775,6 +1775,8 @@ pub struct MachineSetup {
     /// First row shown in the disk table. The list can be longer than the
     /// box, and a disk that cannot be scrolled to cannot be chosen.
     host_disk_scroll: usize,
+    /// How fast a held scroll over that table is running.
+    host_disk_scroll_rate: ScrollRate,
     /// Why the last tick was refused. Read once by the caller, which puts it
     /// on the status line with every other warning; cleared by the next tick,
     /// because the situation it describes is the one being changed.
@@ -2037,6 +2039,7 @@ impl MachineSetup {
             host_disk_warning: None,
             host_disk_selected: Vec::new(),
             host_disk_scroll: 0,
+            host_disk_scroll_rate: ScrollRate::default(),
             host_disks_attached: raw_host_disks(raw),
             ide_master: cfg.ide.master.as_ref().map(|d| d.path.clone()),
             ide_master_name: cfg.ide.master.as_ref().and_then(|d| d.volume_name.clone()),
@@ -4394,6 +4397,10 @@ impl MachineSetup {
         self.host_disk_scroll
     }
 
+    pub fn host_disk_scroll_rate(&mut self) -> &mut ScrollRate {
+        &mut self.host_disk_scroll_rate
+    }
+
     /// Move the window over the list, stopping at either end. `visible` is
     /// how many rows the box shows, which is the caller's geometry to know.
     pub fn scroll_host_disks(&mut self, delta: isize, visible: usize) {
@@ -4969,6 +4976,184 @@ pub enum EditTarget {
     SerialAddr(LauncherField),
 }
 
+/// Where typing goes in a text field, as a character index into it.
+///
+/// One of these sits beside every editable line in the launcher -- the value
+/// boxes on the configuration pages and the boxes in the WHDLoad dialogs --
+/// so all of them insert, delete and step alike, and all of them draw the
+/// same block over the character the caret is on. Without it a box can only
+/// be typed at the end, which is no way to correct a long path or amend
+/// metadata that is nearly right.
+///
+/// Characters, not bytes: the fields hold whatever a name or a title is
+/// spelt with, and stepping half way into one would split it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Caret(usize);
+
+impl Caret {
+    /// Past the last character, which is where opening a box for editing
+    /// puts it: what is already in there is usually a thing to add to.
+    pub fn end_of(text: &str) -> Self {
+        Self::at_end_of_len(text.chars().count())
+    }
+
+    /// The same for a line whose text is not to be handed out -- a masked
+    /// password, which is counted rather than read.
+    pub fn at_end_of_len(len: usize) -> Self {
+        Self(len)
+    }
+
+    /// Which character the caret is on, for drawing the block.
+    pub fn at(self) -> usize {
+        self.0
+    }
+
+    /// Pull the caret back inside a line it may now be off the end of --
+    /// the focus moved to a shorter field, or the value was replaced.
+    pub fn clamp(&mut self, text: &str) {
+        self.0 = self.0.min(text.chars().count());
+    }
+
+    pub fn left(&mut self) {
+        self.0 = self.0.saturating_sub(1);
+    }
+
+    pub fn right(&mut self, text: &str) {
+        self.right_of(text.chars().count());
+    }
+
+    /// Step right within a line of `len` characters.
+    pub fn right_of(&mut self, len: usize) {
+        self.0 = (self.0 + 1).min(len);
+    }
+
+    pub fn home(&mut self) {
+        self.0 = 0;
+    }
+
+    pub fn end(&mut self, text: &str) {
+        self.0 = text.chars().count();
+    }
+
+    /// The same for a counted line.
+    pub fn end_of_len(&mut self, len: usize) {
+        self.0 = len;
+    }
+
+    /// The byte offset the caret sits at, which is the end of the string
+    /// when it is past the last character.
+    pub fn byte_in(self, text: &str) -> usize {
+        text.char_indices()
+            .nth(self.0)
+            .map_or(text.len(), |(at, _)| at)
+    }
+
+    /// Insert at the caret and step over what was typed.
+    pub fn insert(&mut self, text: &mut String, c: char) {
+        // Against a line that was changed without the caret being told --
+        // a field reset, a value replaced wholesale -- rather than reaching
+        // off the end of it.
+        self.clamp(text);
+        let at = self.byte_in(text);
+        text.insert(at, c);
+        self.0 += 1;
+    }
+
+    /// Delete the character before the caret, as Backspace does. False when
+    /// there is nothing behind it.
+    pub fn backspace(&mut self, text: &mut String) -> bool {
+        self.clamp(text);
+        if self.0 == 0 {
+            return false;
+        }
+        self.left();
+        let at = self.byte_in(text);
+        text.remove(at);
+        true
+    }
+
+    /// Delete the character the caret is on, as Delete does. False at the
+    /// end of the line, where it is on nothing.
+    pub fn delete(&mut self, text: &mut String) -> bool {
+        let at = self.byte_in(text);
+        if at >= text.len() {
+            return false;
+        }
+        text.remove(at);
+        true
+    }
+}
+
+/// How fast a held scroll runs.
+///
+/// A list can be a few hundred rows and a keypress is one of them, so
+/// reaching the far end a row at a time is a lot of pressing. Holding it
+/// instead runs through five speeds, a second at each, and the last one
+/// crosses a library in about a second. Starting slow is the point: most
+/// scrolling is a few rows, and a control that leapt away on the first
+/// repeat would overshoot every time.
+///
+/// Every list in the launcher scrolls through one of these -- the WHDLoad
+/// games and favourites, the host disks -- and both ways of driving them,
+/// a held arrow key and a held scroll-arrow button, go through the same
+/// one, so they run at the same speed as each other.
+///
+/// Letting go and pressing again starts from the bottom: the speed is
+/// measured from when the run of scrolling began, and a gap longer than a
+/// repeat begins a new run.
+#[derive(Debug, Clone, Default)]
+pub struct ScrollRate {
+    /// When the last movement was, to tell a continued scroll from a fresh
+    /// one.
+    last: Option<std::time::Instant>,
+    /// When the run of scrolling this movement belongs to began, which is
+    /// what the speed is worked out from.
+    started: Option<std::time::Instant>,
+}
+
+impl ScrollRate {
+    /// Rows a step, a stage a second. The last is what a long list needs
+    /// and the first is what a short one does.
+    const STAGES: [usize; 5] = [1, 3, 7, 14, 24];
+    /// How long each stage lasts before the next takes over.
+    const STAGE: std::time::Duration = std::time::Duration::from_secs(1);
+    /// The gap after which a movement starts a new run rather than
+    /// continuing one. Longer than the repeat of anything being held --
+    /// the button repeat here, or a host keyboard's -- and shorter than a
+    /// pause that means to stop.
+    const CONTINUES_WITHIN: std::time::Duration = std::time::Duration::from_millis(250);
+
+    /// How many rows this step should move, given when it arrived.
+    pub fn rows_for_step(&mut self, now: std::time::Instant) -> usize {
+        let continued = self
+            .last
+            .is_some_and(|last| now.duration_since(last) <= Self::CONTINUES_WITHIN);
+        let started = match continued {
+            true => self.started.unwrap_or(now),
+            false => now,
+        };
+        self.started = Some(started);
+        self.last = Some(now);
+        let stage = now.duration_since(started).as_millis() / Self::STAGE.as_millis();
+        Self::STAGES[(stage as usize).min(Self::STAGES.len() - 1)]
+    }
+
+    /// Back to the first stage, for a press that is deliberately a new one
+    /// rather than the continuation of an old one.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Which way a caret is being stepped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaretMove {
+    Left,
+    Right,
+    Home,
+    End,
+}
+
 /// The most an address box accepts: a DNS name is up to 253 characters
 /// (254 with a trailing root dot), and ":65535" is six more. Anything
 /// longer cannot be a host:port, so the box stops there.
@@ -5331,6 +5516,8 @@ pub struct LauncherState {
     /// focus (a plugin string option or a drive volume name).
     editing: Option<EditTarget>,
     edit_buffer: String,
+    /// Where typing goes in `edit_buffer`.
+    edit_caret: Caret,
     /// The Library page: the games found, which is chosen, and where the
     /// list is scrolled to. Held here rather than in the setup for the
     /// same reason the workshop is -- none of it describes a machine.
@@ -5370,8 +5557,14 @@ pub struct LibraryPage {
     pub favourite_selected: usize,
     /// The first row drawn, for scrolling.
     pub scroll: usize,
-    /// How fast a continued scroll is running.
-    pub scroll_rate: crate::gamelib::ScrollRate,
+    /// The same for the favourites list, which scrolls on its own: a
+    /// collection can be favourited past the handful of rows the box shows.
+    pub favourite_scroll: usize,
+    /// How fast a continued scroll is running. One per list, so leaving one
+    /// part-way through and picking up the other starts the other at a row
+    /// a notch rather than at whatever speed the first had reached.
+    pub scroll_rate: ScrollRate,
+    pub favourite_scroll_rate: ScrollRate,
     /// Cover art, fetched for whatever is selected and kept afterwards.
     pub covers: crate::gamelib::Covers,
 }
@@ -5448,6 +5641,10 @@ pub struct MetaDialog {
     /// was downloaded and a `manual-` name for art somebody chose.
     pub art: Option<String>,
     pub focus: MetaField,
+    /// Where typing goes in the focused field. Metadata is more often
+    /// amended than typed fresh, so being able to step into what is already
+    /// there is most of the point of the editor.
+    pub caret: Caret,
 }
 
 #[cfg(feature = "game-library")]
@@ -5458,6 +5655,35 @@ impl MetaDialog {
 
     pub fn value_mut(&mut self, field: MetaField) -> &mut String {
         &mut self.values[field.at()]
+    }
+
+    /// Move the focus to another box, putting the caret at the end of what
+    /// that one holds.
+    pub fn focus_on(&mut self, field: MetaField) {
+        self.focus = field;
+        self.caret = Caret::end_of(self.value(field));
+    }
+
+    /// Type into the focused box at the caret, up to what it accepts.
+    pub fn insert(&mut self, c: char, most: usize) {
+        if self.value(self.focus).chars().count() >= most {
+            return;
+        }
+        let focus = self.focus;
+        let mut caret = self.caret;
+        caret.insert(self.value_mut(focus), c);
+        self.caret = caret;
+    }
+
+    /// Step the caret through the focused box.
+    pub fn caret_move(&mut self, to: CaretMove) {
+        let len = self.value(self.focus).chars().count();
+        match to {
+            CaretMove::Left => self.caret.left(),
+            CaretMove::Right => self.caret.right_of(len),
+            CaretMove::Home => self.caret.home(),
+            CaretMove::End => self.caret.end_of_len(len),
+        }
     }
 
     /// Whether there is anything left to save. An editor emptied and saved
@@ -5487,6 +5713,11 @@ pub struct LoginDialog {
     pub user: String,
     pub pass: crate::gamelib::Secret,
     pub focus: LoginField,
+    /// Where typing goes in the focused box, as in the metadata editor: one
+    /// dialog behaving differently from the other is one more thing to
+    /// learn. It steps over the mask in the password box, which is what the
+    /// mask is drawn a character at a time for.
+    pub caret: Caret,
     /// Set while the sign-in request is in flight, so a second Return does
     /// not start a second one.
     pub sending: bool,
@@ -5509,10 +5740,101 @@ impl Default for LoginDialog {
             user: String::new(),
             pass: crate::gamelib::Secret::new(),
             focus: LoginField::User,
+            caret: Caret::default(),
             sending: false,
         }
     }
 }
+
+#[cfg(feature = "game-library")]
+impl LoginDialog {
+    /// How many characters the focused box holds. The password is counted
+    /// rather than read: the caret needs its length, not its text.
+    fn focused_len(&self) -> usize {
+        match self.focus {
+            LoginField::User => self.user.chars().count(),
+            LoginField::Pass => self.pass.chars(),
+        }
+    }
+
+    /// Move to the other box, with the caret at the end of what it holds.
+    pub fn focus_on(&mut self, field: LoginField) {
+        self.focus = field;
+        self.caret = Caret::at_end_of_len(self.focused_len());
+    }
+
+    /// Type at the caret, up to what the box takes.
+    pub fn insert(&mut self, c: char) {
+        match self.focus {
+            LoginField::User if self.user.chars().count() < USER_MAX => {
+                let mut caret = self.caret;
+                caret.insert(&mut self.user, c);
+                self.caret = caret;
+            }
+            // Full: the character is dropped and the caret stays put.
+            LoginField::User => {}
+            // The Secret bounds itself, and says nothing about how full it
+            // is, so the caret follows only a character that went in.
+            LoginField::Pass => {
+                let was = self.pass.chars();
+                self.pass.insert_at(self.caret.at(), c);
+                if self.pass.chars() == was {
+                    return;
+                }
+                self.caret.right_of(self.pass.chars());
+            }
+        }
+    }
+
+    /// Delete backwards from the caret.
+    pub fn backspace(&mut self) {
+        if self.caret.at() == 0 {
+            return;
+        }
+        match self.focus {
+            LoginField::User => {
+                let mut caret = self.caret;
+                caret.backspace(&mut self.user);
+                self.caret = caret;
+            }
+            LoginField::Pass => {
+                self.caret.left();
+                self.pass.remove_at(self.caret.at());
+            }
+        }
+    }
+
+    /// Delete the character the caret is on.
+    pub fn delete(&mut self) {
+        match self.focus {
+            LoginField::User => {
+                let mut caret = self.caret;
+                caret.delete(&mut self.user);
+                self.caret = caret;
+            }
+            LoginField::Pass => {
+                self.pass.remove_at(self.caret.at());
+            }
+        }
+    }
+
+    /// Step the caret through the focused box.
+    pub fn caret_move(&mut self, to: CaretMove) {
+        let len = self.focused_len();
+        match to {
+            CaretMove::Left => self.caret.left(),
+            CaretMove::Right => self.caret.right_of(len),
+            CaretMove::Home => self.caret.home(),
+            CaretMove::End => self.caret.end_of_len(len),
+        }
+    }
+}
+
+/// The longest an OpenRetro user name is taken to be. Nothing documents a
+/// limit; this is a box, not a validator, and a name past it is a paste
+/// that went somewhere it did not belong.
+#[cfg(feature = "game-library")]
+const USER_MAX: usize = 64;
 
 /// The support directory under a given configuration directory. The same
 /// place [`crate::paths::whdload_support_dir`] names, spelled from a root
@@ -5805,6 +6127,9 @@ impl LauncherState {
         if dialog.value(MetaField::Version).is_empty() && duplicated && game.is_some() {
             *dialog.value_mut(MetaField::Version) = base;
         }
+        // The caret goes to the end of the first box, which is where typing
+        // would go anyway and where the block is expected to be.
+        dialog.focus_on(MetaField::Name);
         self.meta = Some(dialog);
         self.status = None;
         true
@@ -5881,15 +6206,27 @@ impl LauncherState {
                 let at = (self.library.favourite_selected as isize + delta)
                     .clamp(0, len as isize - 1) as usize;
                 self.select_favourite(at);
+                self.scroll_favourites_into_view(visible);
             }
         }
     }
 
     /// Take a favourite off from the favourites list itself.
-    pub fn remove_favourite(&mut self, drawn: usize) {
-        if let Some(key) = self.favourite_key(drawn).map(str::to_string) {
+    pub fn remove_favourite(&mut self, at: usize) {
+        if let Some(key) = self.favourite_key(at).map(str::to_string) {
             self.library.db.remove_favourite(&key);
         }
+        // The list just got shorter under both the selection and the scroll,
+        // either of which can now be off the end of it.
+        self.clamp_favourites();
+    }
+
+    /// Keep the favourites selection and scroll inside a list that may have
+    /// shrunk -- a removal here, or a database re-read that dropped some.
+    pub fn clamp_favourites(&mut self) {
+        let last = self.library.db.favourite_count().saturating_sub(1);
+        self.library.favourite_selected = self.library.favourite_selected.min(last);
+        self.library.favourite_scroll = self.library.favourite_scroll.min(last);
     }
 
     /// Re-read the game folder: the one thing that walks the disk, and the
@@ -5945,6 +6282,21 @@ impl LauncherState {
         let last_start = self.library.games.len().saturating_sub(visible);
         let at = self.library.scroll as isize + delta;
         self.library.scroll = at.clamp(0, last_start as isize) as usize;
+    }
+
+    pub fn scroll_favourites(&mut self, delta: isize, visible: usize) {
+        let last_start = self.library.db.favourite_count().saturating_sub(visible);
+        let at = self.library.favourite_scroll as isize + delta;
+        self.library.favourite_scroll = at.clamp(0, last_start as isize) as usize;
+    }
+
+    fn scroll_favourites_into_view(&mut self, visible: usize) {
+        let at = self.library.favourite_selected;
+        if at < self.library.favourite_scroll {
+            self.library.favourite_scroll = at;
+        } else if visible > 0 && at >= self.library.favourite_scroll + visible {
+            self.library.favourite_scroll = at + 1 - visible;
+        }
     }
 
     /// Bring the selection into the drawn rows, moving as little as will do.
@@ -6313,6 +6665,7 @@ impl LauncherState {
         }
         self.edit_buffer = self.workshop_value(field);
         self.editing = Some(EditTarget::NewImageText(field));
+        self.edit_caret = Caret::end_of(&self.edit_buffer);
         self.status = None;
     }
 
@@ -6330,6 +6683,7 @@ impl LauncherState {
             self.edit_buffer.push_str(addr);
         }
         self.editing = Some(EditTarget::SerialAddr(field));
+        self.edit_caret = Caret::end_of(&self.edit_buffer);
         self.status = None;
     }
 
@@ -6358,6 +6712,7 @@ impl LauncherState {
             rom_notes: Default::default(),
             editing: None,
             edit_buffer: String::new(),
+            edit_caret: Caret::default(),
         };
         // Name the ROMs the incoming configuration already carries.
         state.sync_rom_notes();
@@ -6424,6 +6779,7 @@ impl LauncherState {
             .map(|b| b.value(opt))
             .unwrap_or_default();
         self.editing = Some(EditTarget::BoardOption { board, opt });
+        self.edit_caret = Caret::end_of(&self.edit_buffer);
         self.status = None;
     }
 
@@ -6431,6 +6787,7 @@ impl LauncherState {
     pub fn begin_edit_drive_name(&mut self, field: LauncherField) {
         self.edit_buffer = self.setup.drive_name(field).unwrap_or_default().to_string();
         self.editing = Some(EditTarget::DriveName(field));
+        self.edit_caret = Caret::end_of(&self.edit_buffer);
         self.status = None;
     }
 
@@ -6447,6 +6804,7 @@ impl LauncherState {
             None => String::new(),
         };
         self.editing = Some(EditTarget::DriveBootpri(field));
+        self.edit_caret = Caret::end_of(&self.edit_buffer);
         self.status = None;
     }
 
@@ -6457,12 +6815,14 @@ impl LauncherState {
         if let EditTarget::NewImageText(field) = target {
             if let Some(limit) = workshop_digit_limit(field) {
                 // A boot priority is the one signed figure here.
-                let minus_ok =
-                    field == F::NewHardBootPri && c == '-' && self.edit_buffer.is_empty();
+                let minus_ok = field == F::NewHardBootPri
+                    && c == '-'
+                    && self.edit_caret.at() == 0
+                    && !self.edit_buffer.starts_with('-');
                 if (!c.is_ascii_digit() && !minus_ok) || self.edit_buffer.len() >= limit {
                     return;
                 }
-                self.edit_buffer.push(c);
+                self.edit_caret.insert(&mut self.edit_buffer, c);
                 return;
             }
             if let Some(limit) = workshop_text_limit(field) {
@@ -6475,7 +6835,7 @@ impl LauncherState {
                 if self.edit_buffer.chars().count() >= limit {
                     return;
                 }
-                self.edit_buffer.push(c);
+                self.edit_caret.insert(&mut self.edit_buffer, c);
                 return;
             }
         }
@@ -6490,18 +6850,44 @@ impl LauncherState {
         }
         // A boot priority is a signed integer: digits, and a leading minus.
         if let EditTarget::DriveBootpri(_) = target {
-            let minus_ok = c == '-' && self.edit_buffer.is_empty();
+            let minus_ok =
+                c == '-' && self.edit_caret.at() == 0 && !self.edit_buffer.starts_with('-');
             if !(c.is_ascii_digit() || minus_ok) {
                 return;
             }
         }
-        self.edit_buffer.push(c);
+        self.edit_caret.insert(&mut self.edit_buffer, c);
     }
 
     pub fn edit_backspace(&mut self) {
         if self.editing.is_some() {
-            self.edit_buffer.pop();
+            self.edit_caret.backspace(&mut self.edit_buffer);
         }
+    }
+
+    /// Delete forwards, from the character the caret is on.
+    pub fn edit_delete(&mut self) {
+        if self.editing.is_some() {
+            self.edit_caret.delete(&mut self.edit_buffer);
+        }
+    }
+
+    /// Step the caret through the box being typed in.
+    pub fn edit_caret_move(&mut self, to: CaretMove) {
+        if self.editing.is_none() {
+            return;
+        }
+        match to {
+            CaretMove::Left => self.edit_caret.left(),
+            CaretMove::Right => self.edit_caret.right(&self.edit_buffer),
+            CaretMove::Home => self.edit_caret.home(),
+            CaretMove::End => self.edit_caret.end(&self.edit_buffer),
+        }
+    }
+
+    /// Where the caret is in the box being typed in, for drawing it.
+    pub fn edit_caret(&self) -> Caret {
+        self.edit_caret
     }
 
     /// Commit the edit buffer to the focused field. A drive name that would
@@ -8264,6 +8650,229 @@ mod tests {
         // Unnamed by the scan: a file name under a row that already says
         // nothing is not the answer to which release it is.
         assert_eq!(version_of(&mut state, "Thing"), "");
+    }
+
+    #[test]
+    fn a_held_scroll_climbs_five_stages_and_starts_again_when_let_go() {
+        use std::time::{Duration, Instant};
+        // What a held button does: a step every 60 ms, which is what the
+        // stages have to be read against -- they are a second of holding
+        // each, not a count of steps.
+        const EVERY: Duration = Duration::from_millis(60);
+        let start = Instant::now();
+        let mut rate = ScrollRate::default();
+
+        // The first step of a run always moves one row, so a click to nudge
+        // the list by one does that and nothing more.
+        assert_eq!(rate.rows_for_step(start), 1);
+
+        // Held, it works through a stage a second. Sampled just after each
+        // second, which is where the stage that second belongs to shows.
+        let mut at = start;
+        let mut seen = Vec::new();
+        for second in 0..5 {
+            let until = start + Duration::from_millis(second * 1000 + 500);
+            let mut rows = 0;
+            while at < until {
+                rows = rate.rows_for_step(at);
+                at += EVERY;
+            }
+            seen.push(rows);
+        }
+        assert_eq!(seen, vec![1, 3, 7, 14, 24]);
+
+        // The last stage is the ceiling: holding it longer does not keep
+        // making it faster.
+        for _ in 0..100 {
+            assert_eq!(rate.rows_for_step(at), 24, "past the last stage");
+            at += EVERY;
+        }
+
+        // Letting go and pressing again starts from the bottom: a gap
+        // longer than a repeat says the run ended...
+        at += Duration::from_millis(400);
+        assert_eq!(rate.rows_for_step(at), 1, "a pause ended the run");
+
+        // ...and so does a press that says so outright, which is what the
+        // mouse does, since a quick re-click can land inside that gap.
+        for _ in 0..80 {
+            at += EVERY;
+            rate.rows_for_step(at);
+        }
+        assert!(rate.rows_for_step(at) > 1, "mid-run");
+        rate.reset();
+        assert_eq!(rate.rows_for_step(at), 1);
+    }
+
+    #[test]
+    fn a_caret_edits_where_it_stands() {
+        let mut text = "Golden Axe".to_string();
+        let mut caret = Caret::end_of(&text);
+        assert_eq!(caret.at(), 10);
+
+        // Typing goes in at the caret and the caret steps over it.
+        caret.left();
+        caret.left();
+        caret.left();
+        for c in "the ".chars() {
+            caret.insert(&mut text, c);
+        }
+        assert_eq!(text, "Golden the Axe");
+        assert_eq!(caret.at(), 11);
+
+        // Backspace takes what is behind, Delete what is under, and
+        // neither moves the other's way.
+        assert!(caret.backspace(&mut text));
+        assert_eq!(text, "Golden theAxe");
+        assert_eq!(caret.at(), 10);
+        assert!(caret.delete(&mut text));
+        assert_eq!(text, "Golden thexe");
+        assert_eq!(caret.at(), 10, "delete leaves the caret where it was");
+
+        // Neither runs off its end.
+        caret.home();
+        assert!(!caret.backspace(&mut text));
+        caret.end(&text);
+        assert!(!caret.delete(&mut text));
+        assert_eq!(text, "Golden thexe");
+
+        // Stepping stops at both ends rather than wrapping.
+        caret.home();
+        caret.left();
+        assert_eq!(caret.at(), 0);
+        caret.end(&text);
+        caret.right(&text);
+        assert_eq!(caret.at(), text.chars().count());
+        let _ = &text;
+
+        // Characters, not bytes: a title with an accent in it steps one
+        // letter at a time and is never cut in half.
+        let mut text = "Ishido".to_string();
+        let mut caret = Caret::end_of(&text);
+        caret.left();
+        caret.insert(&mut text, 'ó');
+        assert_eq!(text, "Ishidóo");
+        assert_eq!(caret.at(), 6);
+        assert!(caret.backspace(&mut text));
+        assert_eq!(text, "Ishido");
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn the_sign_in_caret_steps_through_the_mask() {
+        let mut login = LoginDialog::default();
+        for c in "hobbo".chars() {
+            login.insert(c);
+        }
+        assert_eq!(login.user, "hobbo");
+        assert_eq!(login.caret.at(), 5);
+
+        // Correcting the middle of a name, without retyping the end.
+        login.caret_move(CaretMove::Left);
+        login.insert('9');
+        login.insert('1');
+        assert_eq!(login.user, "hobb91o");
+        login.delete();
+        assert_eq!(login.user, "hobb91");
+
+        // The password is edited the same way, through the mask: the caret
+        // counts characters, and the text itself never comes back out.
+        login.focus_on(LoginField::Pass);
+        assert_eq!(login.caret.at(), 0, "an empty box starts at the front");
+        for c in "sekrit".chars() {
+            login.insert(c);
+        }
+        assert_eq!(login.pass.chars(), 6);
+        login.caret_move(CaretMove::Home);
+        login.insert('X');
+        assert_eq!(login.pass.expose(), "Xsekrit");
+        assert_eq!(login.caret.at(), 1);
+        login.backspace();
+        assert_eq!(login.pass.expose(), "sekrit");
+        assert_eq!(login.caret.at(), 0);
+        // Backspace at the front does nothing, rather than eating forwards.
+        login.backspace();
+        assert_eq!(login.pass.expose(), "sekrit");
+        login.delete();
+        assert_eq!(login.pass.expose(), "ekrit");
+
+        // Moving between boxes puts the caret at the end of the one moved
+        // to, not wherever it was in the one left behind.
+        login.caret_move(CaretMove::End);
+        login.focus_on(LoginField::User);
+        assert_eq!(login.caret.at(), login.user.chars().count());
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn the_metadata_caret_amends_a_field_in_place() {
+        let mut meta = MetaDialog {
+            file: "Turrican.lha".to_string(),
+            ..Default::default()
+        };
+        *meta.value_mut(MetaField::Name) = "Turican".to_string();
+        *meta.value_mut(MetaField::Year) = "1990".to_string();
+        meta.focus_on(MetaField::Name);
+        assert_eq!(meta.caret.at(), 7);
+
+        // The missing letter goes in where it belongs.
+        for _ in 0..4 {
+            meta.caret_move(CaretMove::Left);
+        }
+        meta.insert('r', 64);
+        assert_eq!(meta.value(MetaField::Name), "Turrican");
+
+        // A full box takes nothing more, wherever the caret is.
+        meta.caret_move(CaretMove::Home);
+        meta.insert('X', 8);
+        assert_eq!(meta.value(MetaField::Name), "Turrican");
+
+        // Moving on lands the caret at the end of the next box, and never
+        // past the end of a shorter one.
+        meta.focus_on(MetaField::Year);
+        assert_eq!(meta.caret.at(), 4);
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn the_favourites_list_scrolls_and_stays_inside_itself() {
+        let mut state = LauncherState::new(MachineSetup::default());
+        for at in 0..10 {
+            state
+                .library
+                .db
+                .toggle_favourite(&format!("Game{at}.lha"), &format!("Game {at}"));
+        }
+        assert_eq!(state.library.db.favourite_count(), 10);
+
+        // Four rows on screen: the scroll stops with the last four in it
+        // rather than running off the end into blank rows.
+        state.scroll_favourites(3, 4);
+        assert_eq!(state.library.favourite_scroll, 3);
+        state.scroll_favourites(100, 4);
+        assert_eq!(state.library.favourite_scroll, 6);
+        state.scroll_favourites(-100, 4);
+        assert_eq!(state.library.favourite_scroll, 0);
+
+        // Walking the list with the keyboard drags the window after it.
+        state.library.focus = LibraryFocus::Favourites;
+        for _ in 0..9 {
+            state.step_library_focus(1, 4);
+        }
+        assert_eq!(state.library.favourite_selected, 9);
+        assert_eq!(state.library.favourite_scroll, 6, "the last row is drawn");
+        state.step_library_focus(-9, 4);
+        assert_eq!(state.library.favourite_selected, 0);
+        assert_eq!(state.library.favourite_scroll, 0);
+
+        // Removing from the end takes the selection and the window with it,
+        // so neither is left pointing past a list that just got shorter.
+        state.library.favourite_selected = 9;
+        state.library.favourite_scroll = 6;
+        state.remove_favourite(9);
+        assert_eq!(state.library.db.favourite_count(), 9);
+        assert_eq!(state.library.favourite_selected, 8);
+        assert_eq!(state.library.favourite_scroll, 6);
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -272,7 +272,7 @@ impl LauncherTab {
             LauncherTab::HostFs => "Host Folder",
             LauncherTab::Whdload => "WHDLoad",
             // The strip's own name for it. Inside the WHDLoad pages the
-            // nav chips say Configuration and Library, from their own
+            // nav chips say Settings... and Library, from their own
             // labels, so this one is free to say which tab it is.
             #[cfg(feature = "game-library")]
             LauncherTab::WhdloadLibrary => "WHDLoad",
@@ -382,7 +382,7 @@ const WHDLOAD_NAV: &[(&str, LauncherTab)] = &[
     // The library first: it is what the strip entry opens on, and what
     // somebody is there for. The settings behind it are one click away.
     ("Library", LauncherTab::WhdloadLibrary),
-    ("Configuration", LauncherTab::Whdload),
+    ("Settings...", LauncherTab::Whdload),
 ];
 
 const CREATE_NAV: &[(&str, LauncherTab)] = &[
@@ -925,7 +925,7 @@ const CD_ROWS: [Row; 3] = [
     row(F::CdInsertDelay, "Insert delay", Cycle),
     row(F::Cd32Nvram, "CD32 NVRAM", PathRow),
 ];
-// The WHDLoad Configuration page: the game to launch, then what staging
+// The WHDLoad Settings page: the game to launch, then what staging
 // draws on (src/whdload.rs). Drive rows like the Host FS mounts so the
 // whole host path shows; the staged volumes mount under fixed names
 // (WHDBoot:/WHDGame:), so there is no volume box to fill.
@@ -936,7 +936,7 @@ const CD_ROWS: [Row; 3] = [
 // build loads in a slim one without losing them.
 #[cfg(not(feature = "game-library"))]
 const WHDLOAD_ROWS: [Row; 8] = [
-    section_header("WHDLoad Configuration:"),
+    section_header("WHDLoad Settings:"),
     // What to boot, and how: what a person changes per game.
     row(F::WhdloadGame, "Launch game", Drive),
     row(F::WhdloadMachine, "Machine type", Cycle),
@@ -949,7 +949,7 @@ const WHDLOAD_ROWS: [Row; 8] = [
 ];
 #[cfg(feature = "game-library")]
 const WHDLOAD_ROWS: [Row; 10] = [
-    section_header("WHDLoad Configuration:"),
+    section_header("WHDLoad Settings:"),
     // What to boot, and how: what a person changes per game.
     row(F::WhdloadGame, "Launch game", Drive),
     row(F::WhdloadMachine, "Machine type", Cycle),
@@ -8941,7 +8941,7 @@ mod tests {
         );
         let labels: Vec<&str> = rows.iter().map(|r| r.label).collect();
         // What to boot and how first, then the places things live.
-        let mut want = vec!["WHDLoad Configuration:", "Launch game", "Machine type"];
+        let mut want = vec!["WHDLoad Settings:", "Launch game", "Machine type"];
         if cfg!(feature = "game-library") {
             want.push("OpenRetro");
         }

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -226,7 +226,7 @@ pub const TABS: &[LauncherTab] = &[
     LauncherTab::AvAudio,
 ];
 
-/// The strip with WHDLoad in it, between Storage and Input. This is the
+/// The strip with WHDLoad in it, between Zorro and A/V & Emu. This is the
 /// usual one: the entry is there unless somebody has turned WHDLoad off.
 #[cfg(feature = "game-library")]
 const WHDLOAD_TABS: &[LauncherTab] = &[
@@ -236,10 +236,10 @@ const WHDLOAD_TABS: &[LauncherTab] = &[
     LauncherTab::Rom,
     LauncherTab::Floppy,
     LauncherTab::Storage,
-    LauncherTab::WhdloadLibrary,
     LauncherTab::Input,
     LauncherTab::IoPorts,
     LauncherTab::Zorro,
+    LauncherTab::WhdloadLibrary,
     LauncherTab::AvAudio,
 ];
 
@@ -8900,6 +8900,28 @@ mod tests {
         assert_eq!(state.library.db.favourite_count(), 9);
         assert_eq!(state.library.favourite_selected, 8);
         assert_eq!(state.library.favourite_scroll, 6);
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn the_whdload_entry_sits_between_zorro_and_av() {
+        // Where it is, and that turning it off takes out that one entry
+        // and leaves every other in place.
+        let with: Vec<LauncherTab> = tabs(true).to_vec();
+        let without: Vec<LauncherTab> = tabs(false).to_vec();
+
+        let at = with
+            .iter()
+            .position(|&t| t == LauncherTab::WhdloadLibrary)
+            .expect("the strip carries WHDLoad");
+        assert_eq!(with[at - 1], LauncherTab::Zorro);
+        assert_eq!(with[at + 1], LauncherTab::AvAudio);
+
+        // Off, it is gone -- and nothing else moved relative to itself.
+        assert!(!without.contains(&LauncherTab::WhdloadLibrary));
+        let mut minus = with.clone();
+        minus.remove(at);
+        assert_eq!(minus, without, "turning it off moved something else");
     }
 
     #[test]

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -149,6 +149,23 @@ pub fn status_bar_hidden() -> bool {
     STATUS_BAR_HIDDEN.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Whether the text caret is in the lit half of its blink.
+///
+/// Set by the window each pass while something is being typed into, and
+/// read at the moment the caret is drawn. A flag rather than a clock in the
+/// drawing code, so a redraw is reproducible: a preview or a test renders
+/// the same pixels whenever it runs, and the caret is lit unless something
+/// deliberately puts it out.
+static CARET_LIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+pub fn set_caret_lit(lit: bool) {
+    CARET_LIT.store(lit, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn caret_lit() -> bool {
+    CARET_LIT.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 // Per-thread answers for the two strips that take height from the canvas,
 // in test builds only.
 //

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4697,10 +4697,11 @@ fn host_disk_row_rect(rect: Rect, index: usize) -> Rect {
 
 // --- the WHDLoad Library page ---------------------------------------------
 
-/// The games list runs from the top of the Memory tab to the bottom of I/O
-/// Ports, and the favourites list fills what is left below it, so both are
-/// worked out from the strip rather than from a row count. These are what
-/// that comes to, and what the scrolling and hit-testing count in.
+/// The games list starts level with the top of the Memory tab and is as
+/// tall as the art frame beside it; the favourites list fills what is left
+/// below, down to the status line. Both are worked out from the panel
+/// rather than from a row count, so these are what that comes to -- and
+/// what the scrolling and hit-testing count in.
 ///
 /// `whdload_entry` is whether the strip carries the WHDLoad entry -- see
 /// [`launcher::tabs`] -- since the strip is a row longer when it does, and

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4725,6 +4725,22 @@ const LIBRARY_COVER_BEZEL: usize = 5;
 /// Between the game list and the row of buttons under it.
 #[cfg(feature = "game-library")]
 const LIBRARY_BUTTON_GAP: usize = 8;
+/// How many lines the version under the cover runs to.
+#[cfg(feature = "game-library")]
+const LIBRARY_VERSION_LINES: usize = 2;
+/// How many lines each catalogue field under the cover runs to. A
+/// developer is sometimes credited to nine people, and without a limit
+/// that one field pushes everything under it off the panel.
+#[cfg(feature = "game-library")]
+const LIBRARY_FIELD_LINES: usize = 2;
+
+/// The most a version may be, in characters: what fits the column it is
+/// drawn in, over [`LIBRARY_VERSION_LINES`] lines. The editor stops there
+/// too, since there is no use in typing what the page cannot show.
+#[cfg(feature = "game-library")]
+pub(in crate::video) fn library_version_max() -> usize {
+    LIBRARY_VERSION_LINES * (LIBRARY_COVER + 2 * LIBRARY_COVER_BEZEL) / font::GLYPH_W
+}
 #[cfg(feature = "game-library")]
 const LIBRARY_COVER_GAP: usize = 12;
 /// Where each column starts, from the inside edge of the box. Two columns:
@@ -6011,7 +6027,7 @@ fn draw_library_page(
             frame,
             tick.x,
             tick.y,
-            state.library.db.is_favourite(&entry.file_name),
+            state.library.db.is_favourite(&entry.relative),
             TICK_GREEN,
             scale,
         );
@@ -6074,7 +6090,7 @@ fn draw_library_page(
         // removable, but there is nothing to launch.
         let present = entries
             .iter()
-            .any(|entry| crate::gamelib::Database::key_for(&entry.file_name) == key);
+            .any(|entry| entry.relative == key);
         let colour = match (chosen, present) {
             (true, _) => MENU_HILIGHT_TEXT,
             (false, true) => PANEL_TEXT,
@@ -6228,22 +6244,88 @@ fn draw_library_cover(frame: &mut [u8], rect: Rect, state: &LauncherState, scale
     // value, and a value too long for the column wrapped rather than cut.
     // Hung off the reserved frame rather than off this cover's, so a short
     // one does not pull the writing up the page.
+    // The block stops above the action bar: a developer credited to nine
+    // people would otherwise run down over the Run button and off the
+    // panel. Each value is held to two lines as well, so one long field
+    // cannot crowd out the ones under it -- what is cut is only what is
+    // drawn, never what is stored.
+    let floor = launcher_action_y(rect).saturating_sub(6);
     let mut y = widest.y + widest.h + 8;
-    let Some(game) = &entry.game else { return };
-    for (label, value) in [
-        ("Year", game.year.as_deref()),
-        ("Publisher", game.publisher.as_deref()),
-        ("Developer", game.developer.as_deref()),
-        ("Players", game.players.as_deref()),
-    ] {
-        let Some(value) = value else { continue };
-        draw_panel_text(frame, widest.x, y, label, PANEL_TEXT_DIM, 1, scale);
+    let game = entry.game.as_ref();
+    let mut show = |label: &str, value: Option<&str>, y: &mut usize| {
+        let Some(value) = value.filter(|v| !v.is_empty()) else {
+            return;
+        };
+        // Label and one line at least, or there is no point starting.
+        if *y + 24 > floor {
+            return;
+        }
+        draw_panel_text(frame, widest.x, *y, label, PANEL_TEXT_DIM, 1, scale);
+        *y += 12;
+        let mut lines = wrap_to_width(value, widest.w);
+        let over = lines.len() > LIBRARY_FIELD_LINES;
+        lines.truncate(LIBRARY_FIELD_LINES);
+        let last = lines.len().saturating_sub(1);
+        for (at, line) in lines.into_iter().enumerate() {
+            if *y + 12 > floor {
+                break;
+            }
+            // The panel marks a cut with a tilde, so a credit that goes
+            // on does not read as one that stopped. Room is made for the
+            // mark rather than hoping the line is short enough.
+            let line = match over && at == last {
+                true => {
+                    let mut cut = line;
+                    while cut.chars().count() * font::GLYPH_W + font::GLYPH_W > widest.w {
+                        cut.pop();
+                    }
+                    format!("{cut}~")
+                }
+                false => line,
+            };
+            draw_panel_text(frame, widest.x, *y, &line, PANEL_TEXT, 1, scale);
+            *y += 12;
+        }
+        *y += 4;
+    };
+    show("Year", game.and_then(|g| g.year.as_deref()), &mut y);
+    show("Publisher", game.and_then(|g| g.publisher.as_deref()), &mut y);
+    show("Developer", game.and_then(|g| g.developer.as_deref()), &mut y);
+    show("Players", game.and_then(|g| g.players.as_deref()), &mut y);
+
+    // Which release this is. Shown only when there is something to say:
+    // what somebody typed, or -- where the library holds this game under
+    // one title more than once -- the package's own name, since nothing
+    // else separates `CannonFodder2_v1.11_0104` from `_v1.12_Fr_2578`.
+    // Without the extension: it is the same on both and says nothing about
+    // which release either is.
+    //
+    // A game held once and never edited has no version and no row, and
+    // neither has one the catalogue has never heard of -- two packages the
+    // scan could not name are two rows that say nothing already, and a
+    // file name under them is not the answer to which release they are.
+    let version = game
+        .and_then(|g| g.version.as_deref())
+        .filter(|v| !v.is_empty())
+        .or_else(|| (entry.duplicated && game.is_some()).then_some(entry.file_name.as_str()));
+    if let Some(version) = version.filter(|_| y + 24 <= floor) {
+        draw_panel_text(frame, widest.x, y, "Version", PANEL_TEXT_DIM, 1, scale);
         y += 12;
-        for line in wrap_to_width(value, widest.w) {
+        // Two lines, because a package name is longer than the column and
+        // both ends of it matter: `CannonFodder2_v1.11_0104.lha` says
+        // which game at the front and which release at the back. Anything
+        // past that is cut, which nothing typed here should reach -- the
+        // editor stops at what these two lines hold.
+        for line in wrap_to_width(version, widest.w)
+            .into_iter()
+            .take(LIBRARY_VERSION_LINES)
+        {
+            if y + 12 > floor {
+                break;
+            }
             draw_panel_text(frame, widest.x, y, &line, PANEL_TEXT, 1, scale);
             y += 12;
         }
-        y += 4;
     }
 }
 
@@ -6311,8 +6393,8 @@ fn fit_within(w: usize, h: usize, into: Rect) -> Option<Rect> {
 }
 
 /// Break text into lines that fit `width`, at spaces where there are any.
-/// A single word longer than the column is cut rather than left to run off
-/// the panel.
+/// A single word longer than the column is broken across lines rather than
+/// left to run off the panel.
 #[cfg(feature = "game-library")]
 fn wrap_to_width(text: &str, width: usize) -> Vec<String> {
     let per_line = (width / font::GLYPH_W).max(1);
@@ -6328,12 +6410,18 @@ fn wrap_to_width(text: &str, width: usize) -> Vec<String> {
             lines.push(std::mem::take(&mut line));
         }
         if word.chars().count() > per_line {
-            // Nothing to break at: take what fits and move on, rather than
-            // drawing past the edge of the box.
+            // Nothing to break at, so it is broken anyway -- across as
+            // many lines as it needs. A package name is one long word and
+            // taking only its first line would drop the part that says
+            // which release it is.
             if !line.is_empty() {
                 lines.push(std::mem::take(&mut line));
             }
-            lines.push(word.chars().take(per_line).collect());
+            let mut rest: Vec<char> = word.chars().collect();
+            while rest.len() > per_line {
+                lines.push(rest.drain(..per_line).collect());
+            }
+            line = rest.into_iter().collect();
             continue;
         }
         if !line.is_empty() {
@@ -9958,7 +10046,13 @@ mod tests {
                     name: "Golden Axe".to_string(),
                     year: Some("1990".to_string()),
                     publisher: Some("Virgin".to_string()),
-                    developer: Some("Probe Software".to_string()),
+                    // Long enough that before the two-line cap it ran down
+                    // over the Run button and off the panel.
+                    developer: Some(
+                        "Adventuresoft UK Ltd - Teoman Irmak, Matt Ellis, Antony M. Scott, \
+                         Graham Lilley, Alan Bridgman, Brian Howarth, Richard Turner"
+                            .to_string(),
+                    ),
                     players: Some("1 - 2 (2)".to_string()),
                     front_sha1: std::env::var("WHDLOAD_COVER_SHA1").ok(),
                     ..crate::gamelib::Game::default()
@@ -9977,9 +10071,27 @@ mod tests {
                 manual: false,
                 slave_sha1: None,
             },
+            // Two releases of one game, which is what the Version row is
+            // for: nothing else tells them apart in the list.
             crate::gamelib::Known {
-                file: "KingsQuest5_v1.3.lha".to_string(),
-                game: None,
+                file: "CannonFodder2_v1.12_Fr_2578.zip".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Cannon Fodder 2".to_string(),
+                    year: Some("1994".to_string()),
+                    publisher: Some("Virgin".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "CannonFodder2_v1.11_0104.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Cannon Fodder 2".to_string(),
+                    year: Some("1994".to_string()),
+                    publisher: Some("Virgin".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
                 manual: false,
                 slave_sha1: None,
             },
@@ -10043,6 +10155,27 @@ mod tests {
             }
         }
         state
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn a_version_runs_to_two_lines_and_no_further() {
+        // A package name is longer than the column and both ends matter:
+        // which game at the front, which release at the back.
+        let name = "CannonFodder2_v1.11_0104.lha";
+        let column = LIBRARY_COVER + 2 * LIBRARY_COVER_BEZEL;
+        let lines = wrap_to_width(name, column);
+        assert!(lines.len() <= LIBRARY_VERSION_LINES, "{lines:?}");
+        assert_eq!(lines.concat(), name, "the whole name should be shown");
+
+        // Two releases stay distinguishable across the wrap, which is the
+        // point of showing it at all.
+        let other = wrap_to_width("CannonFodder2_v1.12_Fr_2578.zip", column);
+        assert_ne!(lines, other);
+
+        // The editor stops where the page stops showing.
+        assert_eq!(library_version_max(), 34);
+        assert!(name.chars().count() <= library_version_max());
     }
 
     #[cfg(feature = "game-library")]
@@ -11140,6 +11273,23 @@ mod tests {
             };
             draw(&mut frame, scale, &ui, None, None);
             save(&frame, "launcher-whdload-library-empty");
+        }
+
+        // One of two releases of the same game: the Version row says which,
+        // since nothing else in the list does.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = library_preview_state();
+            state.select_library_game(0);
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-whdload-library-version");
         }
 
         // The Storage tab, whose six sub-page links wrap onto a second row.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4695,17 +4695,22 @@ fn host_disk_row_rect(rect: Rect, index: usize) -> Rect {
 /// Ports, and the favourites list fills what is left below it, so both are
 /// worked out from the strip rather than from a row count. These are what
 /// that comes to, and what the scrolling and hit-testing count in.
+///
+/// `whdload_entry` is whether the strip carries the WHDLoad entry -- see
+/// [`launcher::tabs`] -- since the strip is a row longer when it does, and
+/// every rect on this page is measured against it. Every layout function
+/// here takes it for the same reason.
 #[cfg(feature = "game-library")]
-pub(in crate::video) fn library_visible_rows(rect: Rect, pinned: bool) -> usize {
-    library_table_rect(rect, pinned)
+pub(in crate::video) fn library_visible_rows(rect: Rect, whdload_entry: bool) -> usize {
+    library_table_rect(rect, whdload_entry)
         .h
         .saturating_sub(LIBRARY_HEADER_H + 4)
         / LIBRARY_ROW_H
 }
 
 #[cfg(feature = "game-library")]
-pub(in crate::video) fn library_favourite_rows(rect: Rect, pinned: bool) -> usize {
-    library_favourites_rect(rect, pinned)
+pub(in crate::video) fn library_favourite_rows(rect: Rect, whdload_entry: bool) -> usize {
+    library_favourites_rect(rect, whdload_entry)
         .h
         .saturating_sub(LIBRARY_HEADER_H + 4)
         / LIBRARY_ROW_H
@@ -4764,8 +4769,8 @@ const LIBRARY_COL_NAME: usize = 6;
 /// heading and the ticks under it stay clear of the scroll arrows inside
 /// the frame -- which they did not when the art column beside them grew.
 #[cfg(feature = "game-library")]
-fn library_col_favourite(rect: Rect, pinned: bool) -> usize {
-    let table = library_table_rect(rect, pinned);
+fn library_col_favourite(rect: Rect, whdload_entry: bool) -> usize {
+    let table = library_table_rect(rect, whdload_entry);
     let heading = "Favourite".len() * font::GLYPH_W;
     table
         .w
@@ -4775,8 +4780,8 @@ fn library_col_favourite(rect: Rect, pinned: bool) -> usize {
 
 /// Where a tab sits in the strip, whichever strip is showing.
 #[cfg(feature = "game-library")]
-fn strip_rect(rect: Rect, tab: launcher::LauncherTab, pinned: bool) -> Rect {
-    let at = launcher::tabs(pinned)
+fn strip_rect(rect: Rect, tab: launcher::LauncherTab, whdload_entry: bool) -> Rect {
+    let at = launcher::tabs(whdload_entry)
         .iter()
         .position(|&t| t == tab)
         .unwrap_or(0);
@@ -4789,8 +4794,8 @@ fn strip_rect(rect: Rect, tab: launcher::LauncherTab, pinned: bool) -> Rect {
 /// deliberate when the strip changes -- which it does, since WHDLoad can
 /// join it.
 #[cfg(feature = "game-library")]
-fn library_table_rect(rect: Rect, pinned: bool) -> Rect {
-    let top = strip_rect(rect, launcher::LauncherTab::Memory, pinned);
+fn library_table_rect(rect: Rect, whdload_entry: bool) -> Rect {
+    let top = strip_rect(rect, launcher::LauncherTab::Memory, whdload_entry);
     let x = launcher_pane_x(rect);
     let right = rect.x + rect.w - 16;
     Rect {
@@ -4810,8 +4815,8 @@ fn library_table_rect(rect: Rect, pinned: bool) -> Rect {
 /// It stops short of the bottom so the panel's own status line, which
 /// reports what just happened, is never drawn over.
 #[cfg(feature = "game-library")]
-fn library_favourites_rect(rect: Rect, pinned: bool) -> Rect {
-    let games = library_table_rect(rect, pinned);
+fn library_favourites_rect(rect: Rect, whdload_entry: bool) -> Rect {
+    let games = library_table_rect(rect, whdload_entry);
     // The gap: the button row, then the "Favourites:" label above the box.
     let y = games.y + games.h + LIBRARY_BUTTON_GAP + LAUNCH_MODEL_H + 10 + 14;
     let bottom = launcher_status_y(rect).saturating_sub(10);
@@ -4824,8 +4829,8 @@ fn library_favourites_rect(rect: Rect, pinned: bool) -> Rect {
 
 /// One row of the favourites list.
 #[cfg(feature = "game-library")]
-fn library_favourite_row_rect(rect: Rect, pinned: bool, drawn: usize) -> Rect {
-    let table = library_favourites_rect(rect, pinned);
+fn library_favourite_row_rect(rect: Rect, whdload_entry: bool, drawn: usize) -> Rect {
+    let table = library_favourites_rect(rect, whdload_entry);
     Rect {
         x: table.x + 2,
         y: table.y + LIBRARY_HEADER_H + drawn * LIBRARY_ROW_H,
@@ -4837,33 +4842,33 @@ fn library_favourite_row_rect(rect: Rect, pinned: bool, drawn: usize) -> Rect {
 /// The Favourite tick on one drawn row: centred under its heading rather
 /// than tucked against the left of the column.
 #[cfg(feature = "game-library")]
-fn library_favourite_box(rect: Rect, pinned: bool, drawn: usize) -> Rect {
+fn library_favourite_box(rect: Rect, whdload_entry: bool, drawn: usize) -> Rect {
     centred_tick(
-        library_row_rect(rect, pinned, drawn),
-        library_col_favourite(rect, pinned),
+        library_row_rect(rect, whdload_entry, drawn),
+        library_col_favourite(rect, whdload_entry),
         "Favourite",
     )
 }
 
 /// The Remove tick on one row of the favourites list.
 #[cfg(feature = "game-library")]
-fn library_remove_box(rect: Rect, pinned: bool, drawn: usize) -> Rect {
+fn library_remove_box(rect: Rect, whdload_entry: bool, drawn: usize) -> Rect {
     // On the same line as the Favourite tick in the list above it, not
     // centred under its own shorter heading: two columns of the same tick
     // that do not line up read as a mistake.
     centred_tick(
-        library_favourite_row_rect(rect, pinned, drawn),
-        library_col_favourite(rect, pinned),
+        library_favourite_row_rect(rect, whdload_entry, drawn),
+        library_col_favourite(rect, whdload_entry),
         "Favourite",
     )
 }
 
 /// Where the "Remove" heading goes: centred over its own ticks.
 #[cfg(feature = "game-library")]
-fn library_remove_heading_x(rect: Rect, pinned: bool) -> usize {
+fn library_remove_heading_x(rect: Rect, whdload_entry: bool) -> usize {
     let tick = centred_tick(
-        library_favourites_rect(rect, pinned),
-        library_col_favourite(rect, pinned),
+        library_favourites_rect(rect, whdload_entry),
+        library_col_favourite(rect, whdload_entry),
         "Favourite",
     );
     (tick.x + 5).saturating_sub("Remove".len() * font::GLYPH_W / 2)
@@ -4885,8 +4890,8 @@ fn centred_tick(row: Rect, column: usize, heading: &str) -> Rect {
 /// One row of the list, by drawn position rather than by index into the
 /// library: the list scrolls, so the two differ.
 #[cfg(feature = "game-library")]
-fn library_row_rect(rect: Rect, pinned: bool, drawn: usize) -> Rect {
-    let table = library_table_rect(rect, pinned);
+fn library_row_rect(rect: Rect, whdload_entry: bool, drawn: usize) -> Rect {
+    let table = library_table_rect(rect, whdload_entry);
     Rect {
         x: table.x + 2,
         y: table.y + LIBRARY_HEADER_H + drawn * LIBRARY_ROW_H,
@@ -4915,12 +4920,13 @@ fn library_cover_size() -> (usize, usize) {
     )
 }
 
-/// The largest the art frame can be: what the layout reserves, and what an
-/// empty one is drawn as. The frame around a picture is this or smaller --
-/// see [`library_mounted_art`].
+/// The art frame: the size the layout reserves, whatever is in it. A
+/// picture that is not this shape is fitted inside and letterboxed, rather
+/// than the frame being cut to the picture -- a frame that changed shape
+/// per game would drag the metadata under it up and down the page.
 #[cfg(feature = "game-library")]
-fn library_cover_rect(rect: Rect, pinned: bool) -> Rect {
-    let table = library_table_rect(rect, pinned);
+fn library_cover_rect(rect: Rect, whdload_entry: bool) -> Rect {
+    let table = library_table_rect(rect, whdload_entry);
     let column = table.x + table.w;
     let right = rect.x + rect.w - 16;
     let (w, h) = library_cover_size();
@@ -4934,8 +4940,8 @@ fn library_cover_rect(rect: Rect, pinned: bool) -> Rect {
 
 /// The most a picture may be, inside the widest frame.
 #[cfg(feature = "game-library")]
-fn library_art_rect(rect: Rect, pinned: bool) -> Rect {
-    let frame = library_cover_rect(rect, pinned);
+fn library_art_rect(rect: Rect, whdload_entry: bool) -> Rect {
+    let frame = library_cover_rect(rect, whdload_entry);
     Rect {
         x: frame.x + LIBRARY_COVER_BEZEL,
         y: frame.y + LIBRARY_COVER_BEZEL,
@@ -4947,8 +4953,8 @@ fn library_art_rect(rect: Rect, pinned: bool) -> Rect {
 /// The three buttons under the game list: as thin as the ones along the
 /// top, and sized so a third fits beside the two there are.
 #[cfg(feature = "game-library")]
-fn library_button_rects(rect: Rect, pinned: bool) -> [Rect; 3] {
-    let table = library_table_rect(rect, pinned);
+fn library_button_rects(rect: Rect, whdload_entry: bool) -> [Rect; 3] {
+    let table = library_table_rect(rect, whdload_entry);
     let gap = 6;
     let w = (table.w + gap) / 3 - gap;
     std::array::from_fn(|i| Rect {
@@ -5085,17 +5091,17 @@ fn library_arrows_in(table: Rect, control: fn(isize) -> UiControl) -> [(UiContro
 }
 
 #[cfg(feature = "game-library")]
-fn library_arrow_rects(rect: Rect, pinned: bool) -> [(UiControl, Rect); 2] {
+fn library_arrow_rects(rect: Rect, whdload_entry: bool) -> [(UiControl, Rect); 2] {
     library_arrows_in(
-        library_table_rect(rect, pinned),
+        library_table_rect(rect, whdload_entry),
         UiControl::LauncherLibraryScroll,
     )
 }
 
 #[cfg(feature = "game-library")]
-fn library_favourite_arrow_rects(rect: Rect, pinned: bool) -> [(UiControl, Rect); 2] {
+fn library_favourite_arrow_rects(rect: Rect, whdload_entry: bool) -> [(UiControl, Rect); 2] {
     library_arrows_in(
-        library_favourites_rect(rect, pinned),
+        library_favourites_rect(rect, whdload_entry),
         UiControl::LauncherLibraryFavouriteScroll,
     )
 }
@@ -5882,24 +5888,24 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
     }
     #[cfg(feature = "game-library")]
     if state.tab == LauncherTab::WhdloadLibrary {
-        let pinned = state.setup.whdload_enabled();
-        if state.library.games.len() > library_visible_rows(rect, pinned) {
-            for (control, arrow) in library_arrow_rects(rect, pinned) {
+        let whdload_entry = state.setup.whdload_enabled();
+        if state.library.games.len() > library_visible_rows(rect, whdload_entry) {
+            for (control, arrow) in library_arrow_rects(rect, whdload_entry) {
                 if arrow.contains(pos) {
                     return Some(control);
                 }
             }
         }
-        for drawn in 0..library_visible_rows(rect, pinned) {
+        for drawn in 0..library_visible_rows(rect, whdload_entry) {
             if state.library.scroll + drawn >= state.library.games.len() {
                 break;
             }
             // The tick first: it sits inside the row, and marking a
             // favourite is not the same as choosing the game.
-            if library_favourite_box(rect, pinned, drawn).contains(pos) {
+            if library_favourite_box(rect, whdload_entry, drawn).contains(pos) {
                 return Some(UiControl::LauncherLibraryFavourite(drawn));
             }
-            if library_row_rect(rect, pinned, drawn).contains(pos) {
+            if library_row_rect(rect, whdload_entry, drawn).contains(pos) {
                 return Some(UiControl::LauncherLibraryPick(drawn));
             }
         }
@@ -5911,16 +5917,16 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
         .into_iter()
         .enumerate()
         {
-            if library_button_rects(rect, pinned)[at].contains(pos)
+            if library_button_rects(rect, whdload_entry)[at].contains(pos)
                 && (at == 0 || !state.library.games.is_empty())
             {
                 return Some(control);
             }
         }
         let starred = state.library.db.favourite_count();
-        let rows = library_favourite_rows(rect, pinned);
+        let rows = library_favourite_rows(rect, whdload_entry);
         if starred > rows {
-            for (control, arrow) in library_favourite_arrow_rects(rect, pinned) {
+            for (control, arrow) in library_favourite_arrow_rects(rect, whdload_entry) {
                 if arrow.contains(pos) {
                     return Some(control);
                 }
@@ -5930,10 +5936,10 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             .saturating_sub(state.library.favourite_scroll)
             .min(rows)
         {
-            if library_remove_box(rect, pinned, drawn).contains(pos) {
+            if library_remove_box(rect, whdload_entry, drawn).contains(pos) {
                 return Some(UiControl::LauncherLibraryFavouriteRemove(drawn));
             }
-            if library_favourite_row_rect(rect, pinned, drawn).contains(pos) {
+            if library_favourite_row_rect(rect, whdload_entry, drawn).contains(pos) {
                 return Some(UiControl::LauncherLibraryFavouritePick(drawn));
             }
         }
@@ -6007,8 +6013,8 @@ fn draw_library_page(
     scale: usize,
 ) {
     let entries = state.library.games.entries();
-    let pinned = state.setup.whdload_enabled();
-    let games = library_table_rect(rect, pinned);
+    let whdload_entry = state.setup.whdload_enabled();
+    let games = library_table_rect(rect, whdload_entry);
     // A scan running greys both buttons: neither of them can start a
     // second one while the first is going.
     let busy = matches!(
@@ -6028,7 +6034,7 @@ fn draw_library_page(
     draw_library_box(frame, games, scale);
     for (at, title) in [
         (LIBRARY_COL_NAME, "Game"),
-        (library_col_favourite(rect, pinned), "Favourite"),
+        (library_col_favourite(rect, whdload_entry), "Favourite"),
     ] {
         draw_panel_text(
             frame,
@@ -6068,11 +6074,11 @@ fn draw_library_page(
         }
     }
 
-    for drawn in 0..library_visible_rows(rect, pinned) {
+    for drawn in 0..library_visible_rows(rect, whdload_entry) {
         let Some(entry) = entries.get(state.library.scroll + drawn) else {
             break;
         };
-        let row = library_row_rect(rect, pinned, drawn);
+        let row = library_row_rect(rect, whdload_entry, drawn);
         let chosen = state.library.focus == launcher::LibraryFocus::Games
             && state.library.scroll + drawn == state.library.selected;
         if chosen {
@@ -6093,13 +6099,13 @@ fn draw_library_page(
             row.y + 3,
             &truncate_to_width(
                 entry.title(),
-                library_col_favourite(rect, pinned).saturating_sub(LIBRARY_COL_NAME + 12),
+                library_col_favourite(rect, whdload_entry).saturating_sub(LIBRARY_COL_NAME + 12),
             ),
             colour,
             1,
             scale,
         );
-        let tick = library_favourite_box(rect, pinned, drawn);
+        let tick = library_favourite_box(rect, whdload_entry, drawn);
         draw_tick_box(
             frame,
             tick.x,
@@ -6113,9 +6119,9 @@ fn draw_library_page(
         }
     }
 
-    let visible = library_visible_rows(rect, pinned);
+    let visible = library_visible_rows(rect, whdload_entry);
     if entries.len() > visible {
-        for (control, at) in library_arrow_rects(rect, pinned) {
+        for (control, at) in library_arrow_rects(rect, whdload_entry) {
             let up = matches!(control, UiControl::LauncherLibraryScroll(d) if d < 0);
             let live = match up {
                 true => state.library.scroll > 0,
@@ -6126,7 +6132,7 @@ fn draw_library_page(
     }
 
     // The favourites, which are the same games under a shorter heading.
-    let favourites = library_favourites_rect(rect, pinned);
+    let favourites = library_favourites_rect(rect, whdload_entry);
     draw_panel_text(
         frame,
         favourites.x,
@@ -6139,14 +6145,14 @@ fn draw_library_page(
     draw_library_box(frame, favourites, scale);
     for (x, title) in [
         (favourites.x + 4 + LIBRARY_COL_NAME, "Game"),
-        (library_remove_heading_x(rect, pinned), "Remove"),
+        (library_remove_heading_x(rect, whdload_entry), "Remove"),
     ] {
         draw_panel_text(frame, x, favourites.y + 5, title, PANEL_TEXT_DIM, 1, scale);
     }
     // From the database rather than from the library, so a favourite whose
     // package has been deleted is still listed -- and can still be taken
     // off, which is most of the reason its Remove tick is there.
-    let favourite_rows = library_favourite_rows(rect, pinned);
+    let favourite_rows = library_favourite_rows(rect, whdload_entry);
     for (drawn, (key, name)) in state
         .library
         .db
@@ -6155,7 +6161,7 @@ fn draw_library_page(
         .take(favourite_rows)
         .enumerate()
     {
-        let row = library_favourite_row_rect(rect, pinned, drawn);
+        let row = library_favourite_row_rect(rect, whdload_entry, drawn);
         let chosen = state.library.focus == launcher::LibraryFocus::Favourites
             && state.library.favourite_scroll + drawn == state.library.favourite_selected;
         if chosen {
@@ -6177,13 +6183,13 @@ fn draw_library_page(
             row.y + 3,
             &truncate_to_width(
                 name,
-                library_col_favourite(rect, pinned).saturating_sub(LIBRARY_COL_NAME + 12),
+                library_col_favourite(rect, whdload_entry).saturating_sub(LIBRARY_COL_NAME + 12),
             ),
             colour,
             1,
             scale,
         );
-        let tick = library_remove_box(rect, pinned, drawn);
+        let tick = library_remove_box(rect, whdload_entry, drawn);
         draw_tick_box(frame, tick.x, tick.y, false, TICK_GREEN, scale);
         if hover == Some(UiControl::LauncherLibraryFavouriteRemove(drawn)) {
             draw_outline(frame, tick, PANEL_TEXT_HILIGHT, scale);
@@ -6192,7 +6198,7 @@ fn draw_library_page(
 
     let starred = state.library.db.favourite_count();
     if starred > favourite_rows {
-        for (control, at) in library_favourite_arrow_rects(rect, pinned) {
+        for (control, at) in library_favourite_arrow_rects(rect, whdload_entry) {
             let up = matches!(control, UiControl::LauncherLibraryFavouriteScroll(d) if d < 0);
             let live = match up {
                 true => state.library.favourite_scroll > 0,
@@ -6207,7 +6213,7 @@ fn draw_library_page(
     // The two buttons that say when work happens, in the gap between the
     // lists. A third slot is left beside them: the row is sized for three
     // so gaining one later does not move the two that are here.
-    let buttons = library_button_rects(rect, pinned);
+    let buttons = library_button_rects(rect, whdload_entry);
     for (at, (label, control, enabled)) in [
         ("Refresh", UiControl::LauncherLibraryRefresh, !busy),
         // Nothing to look up until the folder has been read, so Scan waits
@@ -6263,7 +6269,7 @@ fn draw_library_box(frame: &mut [u8], at: Rect, scale: usize) {
 /// The cover art box, and what the database says under it.
 #[cfg(feature = "game-library")]
 fn draw_library_cover(frame: &mut [u8], rect: Rect, state: &LauncherState, scale: usize) {
-    let pinned = state.setup.whdload_enabled();
+    let whdload_entry = state.setup.whdload_enabled();
     // The frame is the size the layout reserves, whatever shape the picture
     // in it turns out to be: it is where the eye expects the art to be, and
     // the writing under it starts on the same line for every game.
@@ -6271,13 +6277,13 @@ fn draw_library_cover(frame: &mut [u8], rect: Rect, state: &LauncherState, scale
     // cut for that and the rare landscape scan is letterboxed into it --
     // black above and below beats a frame that changes shape and drags the
     // metadata down the page with it.
-    let widest = library_cover_rect(rect, pinned);
+    let widest = library_cover_rect(rect, whdload_entry);
     let entry = state.library_selection();
     let art = entry
         .and_then(|entry| entry.game.as_ref())
         .and_then(|game| game.front_sha1.as_deref())
         .and_then(|sha1| state.library.covers.get(sha1));
-    let (frame_rect, box_rect) = (widest, library_art_rect(rect, pinned));
+    let (frame_rect, box_rect) = (widest, library_art_rect(rect, whdload_entry));
 
     // The mount: a button-faced border raised out of the panel, with the
     // picture recessed into it. Two bevels facing opposite ways is what
@@ -6329,8 +6335,8 @@ fn draw_library_cover(frame: &mut [u8], rect: Rect, state: &LauncherState, scale
 
     // Under the art: what the database knows, each label dimmed above its
     // value, and a value too long for the column wrapped rather than cut.
-    // Hung off the reserved frame rather than off this cover's, so a short
-    // one does not pull the writing up the page.
+    // It starts under the frame, which is one size for every game, so it
+    // starts on the same line each time whatever shape the picture is.
     // The block stops above the action bar: a developer credited to nine
     // people would otherwise run down over the Run button and off the
     // panel. Each value is held to two lines as well, so one long field
@@ -8112,8 +8118,8 @@ fn draw_launcher(
         scale,
     );
     // Vertical category-tab column.
-    let pinned = state.setup.whdload_enabled();
-    let strip = launcher::tabs(pinned);
+    let whdload_entry = state.setup.whdload_enabled();
+    let strip = launcher::tabs(whdload_entry);
     for (i, &tab) in strip.iter().enumerate() {
         draw_launcher_chip(
             frame,
@@ -9122,8 +9128,8 @@ mod tests {
         };
         let mut state = LauncherState::new(launcher::MachineSetup::default());
         state.tab = LauncherTab::WhdloadLibrary;
-        let pinned = state.setup.whdload_enabled();
-        let rows = library_favourite_rows(rect, pinned);
+        let whdload_entry = state.setup.whdload_enabled();
+        let rows = library_favourite_rows(rect, whdload_entry);
         assert!(rows > 1, "the box holds rows to scroll: {rows}");
 
         // A list that fits has no arrows: the corner is a row's, not a
@@ -9134,7 +9140,7 @@ mod tests {
                 .db
                 .toggle_favourite(&format!("Game{at}.lha"), &format!("Game {at}"));
         }
-        let [(up, up_at), (down, down_at)] = library_favourite_arrow_rects(rect, pinned);
+        let [(up, up_at), (down, down_at)] = library_favourite_arrow_rects(rect, whdload_entry);
         let hit = |state: &LauncherState, at: Rect| {
             launcher_control_at(rect, state, (at.x as i32 + 2, at.y as i32 + 2))
         };
@@ -9148,7 +9154,7 @@ mod tests {
 
         // The rows are drawn positions: scrolled down, the top row is the
         // scroll's, so clicking it removes the right favourite.
-        let first = library_favourite_row_rect(rect, pinned, 0);
+        let first = library_favourite_row_rect(rect, whdload_entry, 0);
         let click = (first.x as i32 + 40, first.y as i32 + 2);
         assert_eq!(
             launcher_control_at(rect, &state, click),
@@ -9165,7 +9171,7 @@ mod tests {
         // And the last drawn row is the last one there is: scrolled to the
         // end, the rows below it are not clickable.
         state.scroll_favourites(100, rows);
-        let past = library_favourite_row_rect(rect, pinned, rows - 1);
+        let past = library_favourite_row_rect(rect, whdload_entry, rows - 1);
         assert_eq!(
             launcher_control_at(rect, &state, (past.x as i32 + 40, past.y as i32 + 2)),
             Some(UiControl::LauncherLibraryFavouritePick(rows - 1))
@@ -11660,9 +11666,9 @@ mod tests {
             };
             let rect = launcher_panel_rect(&ui).expect("the launcher is up");
             if let Some(Panel::Launcher(state)) = ui.panel.as_mut() {
-                let pinned = state.setup.whdload_enabled();
-                state.scroll_library(isize::MAX, library_visible_rows(rect, pinned));
-                state.scroll_favourites(isize::MAX, library_favourite_rows(rect, pinned));
+                let whdload_entry = state.setup.whdload_enabled();
+                state.scroll_library(isize::MAX, library_visible_rows(rect, whdload_entry));
+                state.scroll_favourites(isize::MAX, library_favourite_rows(rect, whdload_entry));
             }
             draw(&mut frame, scale, &ui, None, None);
             save(&frame, "launcher-whdload-library-scrolled");

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -484,7 +484,14 @@ impl UiState {
 
 pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
     let rect = panel_rect(panel);
-    if close_button_rect(rect).contains(pos) {
+    // A dialog over the panel answers first, its own close gadget
+    // included; the panel's must not close the launcher out from under it.
+    #[cfg(feature = "game-library")]
+    let modal =
+        matches!(panel, Panel::Launcher(state) if state.login.is_some() || state.meta.is_some());
+    #[cfg(not(feature = "game-library"))]
+    let modal = false;
+    if !modal && close_button_rect(rect).contains(pos) {
         return Some(UiControl::PanelClose);
     }
     match panel {
@@ -764,6 +771,54 @@ pub enum UiControl {
     LauncherNewImageCreate(LauncherField),
     /// The MB/GB written beside the hard-drive size, which swaps on click.
     LauncherNewImageUnit,
+    /// Fetch a WHDLoad support archive into the default place.
+    #[cfg(feature = "game-library")]
+    LauncherWhdloadDownload(LauncherField),
+    /// Scroll the Library list, by rows: negative up, positive down.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryScroll(isize),
+    /// Choose the game on that drawn row of the Library list.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryPick(usize),
+    /// Mark or unmark that drawn row of the Library list.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryFavourite(usize),
+    /// Choose the game on that row of the favourites list.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryFavouritePick(usize),
+    /// Take that row off the favourites list.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryFavouriteRemove(usize),
+    /// Open the OpenRetro sign-in dialog.
+    #[cfg(feature = "game-library")]
+    LauncherOpenRetroLogin,
+    /// Re-read the game folder, without touching metadata.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryRefresh,
+    /// Resolve metadata and art for everything in the game folder.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryUpdate,
+    /// Open the metadata editor on the selected game.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryEdit,
+    /// A field of the metadata editor, its art box, or one of its buttons.
+    #[cfg(feature = "game-library")]
+    MetaField(launcher::MetaField),
+    #[cfg(feature = "game-library")]
+    MetaArt,
+    #[cfg(feature = "game-library")]
+    MetaSave,
+    #[cfg(feature = "game-library")]
+    MetaClear,
+    #[cfg(feature = "game-library")]
+    MetaCancel,
+    /// A field of the sign-in dialog, or one of its two buttons.
+    #[cfg(feature = "game-library")]
+    LoginField(launcher::LoginField),
+    #[cfg(feature = "game-library")]
+    LoginOk,
+    #[cfg(feature = "game-library")]
+    LoginCancel,
     /// A filesystem family tick box on a Create Image page.
     LauncherFsFamily {
         field: LauncherField,
@@ -875,6 +930,16 @@ fn panel_title(panel: &Panel) -> &'static str {
         Panel::Console(_) => "Console",
         Panel::Launcher(_) => "Machine Configuration",
         Panel::DropChooser(_) => "Insert Disk",
+    }
+}
+
+/// The rect the launcher panel occupies, for the parts of the window that
+/// have to measure against it.
+#[cfg(feature = "game-library")]
+pub(in crate::video) fn launcher_panel_rect(ui: &UiState) -> Option<Rect> {
+    match &ui.panel {
+        Some(panel @ Panel::Launcher(_)) => Some(panel_rect(panel)),
+        _ => None,
     }
 }
 
@@ -1766,26 +1831,39 @@ fn draw_panel_chrome(frame: &mut [u8], panel: &Panel, hover: Option<UiControl>, 
     let scaled = scale_rect(rect, scale);
     fill_rect(frame, scaled, PANEL_BG, scale);
     draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
-    // Title bar.
-    let title = Rect {
+    draw_title_bar(
+        frame,
+        rect,
+        panel_title(panel),
+        hover == Some(UiControl::PanelClose),
+        scale,
+    );
+}
+
+/// A panel's blue title bar, with its name and its close gadget.
+fn draw_title_bar(frame: &mut [u8], rect: Rect, title: &str, close_hover: bool, scale: usize) {
+    let bar = Rect {
         x: rect.x + 1,
         y: rect.y + 1,
         w: rect.w - 2,
         h: TITLE_H - 1,
     };
-    fill_rect(frame, scale_rect(title, scale), PANEL_TITLE_BG, scale);
+    fill_rect(frame, scale_rect(bar, scale), PANEL_TITLE_BG, scale);
     draw_panel_text(
         frame,
         rect.x + 10,
         rect.y + (TITLE_H - 16) / 2,
-        panel_title(panel),
+        title,
         PANEL_TITLE_TEXT,
         2,
         scale,
     );
-    // Close gadget: classic square with an inner square.
+    draw_close_gadget(frame, rect, close_hover, scale);
+}
+
+/// The close gadget: a classic square with an inner square.
+fn draw_close_gadget(frame: &mut [u8], rect: Rect, close_hover: bool, scale: usize) {
     let close = close_button_rect(rect);
-    let close_hover = hover == Some(UiControl::PanelClose);
     let face = if close_hover {
         BUTTON_FACE_HOVER
     } else {
@@ -4603,6 +4681,394 @@ fn host_disk_row_rect(rect: Rect, index: usize) -> Rect {
     }
 }
 
+// --- the WHDLoad Library page ---------------------------------------------
+
+/// The games list runs from the top of the Memory tab to the bottom of I/O
+/// Ports, and the favourites list fills what is left below it, so both are
+/// worked out from the strip rather than from a row count. These are what
+/// that comes to, and what the scrolling and hit-testing count in.
+#[cfg(feature = "game-library")]
+pub(in crate::video) fn library_visible_rows(rect: Rect, pinned: bool) -> usize {
+    library_table_rect(rect, pinned)
+        .h
+        .saturating_sub(LIBRARY_HEADER_H + 4)
+        / LIBRARY_ROW_H
+}
+
+#[cfg(feature = "game-library")]
+pub(in crate::video) fn library_favourite_rows(rect: Rect, pinned: bool) -> usize {
+    library_favourites_rect(rect, pinned)
+        .h
+        .saturating_sub(LIBRARY_HEADER_H + 4)
+        / LIBRARY_ROW_H
+}
+#[cfg(feature = "game-library")]
+const LIBRARY_ROW_H: usize = 14;
+#[cfg(feature = "game-library")]
+const LIBRARY_HEADER_H: usize = 16;
+/// The widest a cover is drawn. The gap either side of its frame is
+/// [`LIBRARY_COVER_GAP`], and the frame around it [`LIBRARY_COVER_BEZEL`].
+#[cfg(feature = "game-library")]
+const LIBRARY_COVER: usize = 128;
+/// How much taller than wide the art frame is. Amiga box art is portrait:
+/// measured across the catalogue it runs between 0.75 and 0.82 wide-to-tall
+/// with the odd square compilation, so 4:5 sits in the middle of what is
+/// really there and a picture of any of those shapes only has to give up a
+/// thin margin to fit.
+#[cfg(feature = "game-library")]
+const LIBRARY_COVER_TALL: (usize, usize) = (5, 4);
+/// The frame around the art: thicker than the list's hairline outline and
+/// bevelled, so the picture reads as mounted in the panel rather than
+/// pasted onto it.
+#[cfg(feature = "game-library")]
+const LIBRARY_COVER_BEZEL: usize = 5;
+/// Between the game list and the row of buttons under it.
+#[cfg(feature = "game-library")]
+const LIBRARY_BUTTON_GAP: usize = 8;
+#[cfg(feature = "game-library")]
+const LIBRARY_COVER_GAP: usize = 12;
+/// Where each column starts, from the inside edge of the box. Two columns:
+/// the game, and whether it is a favourite. Year and publisher moved under
+/// the cover art, where there is room to read them.
+#[cfg(feature = "game-library")]
+const LIBRARY_COL_NAME: usize = 6;
+/// The Favourite column, far enough right that a long title clips before
+/// it rather than running into it.
+/// Where the tick column starts, as an offset into the box.
+///
+/// Measured back from the right-hand edge rather than fixed, so the
+/// heading and the ticks under it stay clear of the scroll arrows inside
+/// the frame -- which they did not when the art column beside them grew.
+#[cfg(feature = "game-library")]
+fn library_col_favourite(rect: Rect, pinned: bool) -> usize {
+    let table = library_table_rect(rect, pinned);
+    let heading = "Favourite".len() * font::GLYPH_W;
+    table
+        .w
+        .saturating_sub(HOST_DISK_ARROW + 12 + heading + 6)
+        .max(LIBRARY_COL_NAME + 40)
+}
+
+/// Where a tab sits in the strip, whichever strip is showing.
+#[cfg(feature = "game-library")]
+fn strip_rect(rect: Rect, tab: launcher::LauncherTab, pinned: bool) -> Rect {
+    let at = launcher::tabs(pinned)
+        .iter()
+        .position(|&t| t == tab)
+        .unwrap_or(0);
+    launcher_tab_rect(rect, at)
+}
+
+/// The games list, squared off against the strip beside it: its top level
+/// with the top of Memory, its bottom with the bottom of I/O Ports. Tying
+/// it to the strip rather than to a row count keeps the page looking
+/// deliberate when the strip changes -- which it does, since WHDLoad can
+/// join it.
+#[cfg(feature = "game-library")]
+fn library_table_rect(rect: Rect, pinned: bool) -> Rect {
+    let top = strip_rect(rect, launcher::LauncherTab::Memory, pinned);
+    let x = launcher_pane_x(rect);
+    let right = rect.x + rect.w - 16;
+    Rect {
+        x,
+        y: top.y,
+        w: right
+            .saturating_sub(x)
+            .saturating_sub(library_cover_column()),
+        // The art frame's height, so the two boxes end on one line. Its
+        // top stays level with the top of Memory in the strip; whatever it
+        // no longer reaches down to, the favourites list below it takes.
+        h: library_cover_size().1,
+    }
+}
+
+/// The favourites list, under the games with the button row between them.
+/// It stops short of the bottom so the panel's own status line, which
+/// reports what just happened, is never drawn over.
+#[cfg(feature = "game-library")]
+fn library_favourites_rect(rect: Rect, pinned: bool) -> Rect {
+    let games = library_table_rect(rect, pinned);
+    // The gap: the button row, then the "Favourites:" label above the box.
+    let y = games.y + games.h + LIBRARY_BUTTON_GAP + LAUNCH_MODEL_H + 10 + 14;
+    let bottom = launcher_status_y(rect).saturating_sub(10);
+    Rect {
+        y,
+        h: bottom.saturating_sub(y),
+        ..games
+    }
+}
+
+/// One row of the favourites list.
+#[cfg(feature = "game-library")]
+fn library_favourite_row_rect(rect: Rect, pinned: bool, drawn: usize) -> Rect {
+    let table = library_favourites_rect(rect, pinned);
+    Rect {
+        x: table.x + 2,
+        y: table.y + LIBRARY_HEADER_H + drawn * LIBRARY_ROW_H,
+        w: table.w.saturating_sub(4),
+        h: LIBRARY_ROW_H,
+    }
+}
+
+/// The Favourite tick on one drawn row: centred under its heading rather
+/// than tucked against the left of the column.
+#[cfg(feature = "game-library")]
+fn library_favourite_box(rect: Rect, pinned: bool, drawn: usize) -> Rect {
+    centred_tick(
+        library_row_rect(rect, pinned, drawn),
+        library_col_favourite(rect, pinned),
+        "Favourite",
+    )
+}
+
+/// The Remove tick on one row of the favourites list.
+#[cfg(feature = "game-library")]
+fn library_remove_box(rect: Rect, pinned: bool, drawn: usize) -> Rect {
+    // On the same line as the Favourite tick in the list above it, not
+    // centred under its own shorter heading: two columns of the same tick
+    // that do not line up read as a mistake.
+    centred_tick(
+        library_favourite_row_rect(rect, pinned, drawn),
+        library_col_favourite(rect, pinned),
+        "Favourite",
+    )
+}
+
+/// Where the "Remove" heading goes: centred over its own ticks.
+#[cfg(feature = "game-library")]
+fn library_remove_heading_x(rect: Rect, pinned: bool) -> usize {
+    let tick = centred_tick(
+        library_favourites_rect(rect, pinned),
+        library_col_favourite(rect, pinned),
+        "Favourite",
+    );
+    (tick.x + 5).saturating_sub("Remove".len() * font::GLYPH_W / 2)
+}
+
+/// A tick in the second column, centred under a heading of that width
+/// rather than tucked against the left of the column.
+#[cfg(feature = "game-library")]
+fn centred_tick(row: Rect, column: usize, heading: &str) -> Rect {
+    let width = heading.len() * font::GLYPH_W;
+    Rect {
+        x: row.x + 4 + column + width.saturating_sub(10) / 2,
+        y: row.y + (row.h - 10) / 2,
+        w: 10,
+        h: 10,
+    }
+}
+
+/// One row of the list, by drawn position rather than by index into the
+/// library: the list scrolls, so the two differ.
+#[cfg(feature = "game-library")]
+fn library_row_rect(rect: Rect, pinned: bool, drawn: usize) -> Rect {
+    let table = library_table_rect(rect, pinned);
+    Rect {
+        x: table.x + 2,
+        y: table.y + LIBRARY_HEADER_H + drawn * LIBRARY_ROW_H,
+        w: table.w.saturating_sub(4),
+        h: LIBRARY_ROW_H,
+    }
+}
+
+/// How much of the panel's width the art column takes: the widest frame,
+/// with a gap either side of it, so the frame is centred in a space rather
+/// than pressed against the list.
+#[cfg(feature = "game-library")]
+fn library_cover_column() -> usize {
+    library_cover_size().0 + 2 * LIBRARY_COVER_GAP
+}
+
+/// The art frame at its widest, which is also the game list's height: the
+/// two boxes end on the same line, and it is the frame -- sized from the
+/// shape of a cover -- that decides where that line is. The frame is never
+/// stretched to reach anything.
+#[cfg(feature = "game-library")]
+fn library_cover_size() -> (usize, usize) {
+    (
+        LIBRARY_COVER + 2 * LIBRARY_COVER_BEZEL,
+        LIBRARY_COVER * LIBRARY_COVER_TALL.0 / LIBRARY_COVER_TALL.1 + 2 * LIBRARY_COVER_BEZEL,
+    )
+}
+
+/// The largest the art frame can be: what the layout reserves, and what an
+/// empty one is drawn as. The frame around a picture is this or smaller --
+/// see [`library_mounted_art`].
+#[cfg(feature = "game-library")]
+fn library_cover_rect(rect: Rect, pinned: bool) -> Rect {
+    let table = library_table_rect(rect, pinned);
+    let column = table.x + table.w;
+    let right = rect.x + rect.w - 16;
+    let (w, h) = library_cover_size();
+    Rect {
+        x: column + right.saturating_sub(column).saturating_sub(w) / 2,
+        y: table.y,
+        w,
+        h,
+    }
+}
+
+/// The most a picture may be, inside the widest frame.
+#[cfg(feature = "game-library")]
+fn library_art_rect(rect: Rect, pinned: bool) -> Rect {
+    let frame = library_cover_rect(rect, pinned);
+    Rect {
+        x: frame.x + LIBRARY_COVER_BEZEL,
+        y: frame.y + LIBRARY_COVER_BEZEL,
+        w: frame.w - 2 * LIBRARY_COVER_BEZEL,
+        h: frame.h - 2 * LIBRARY_COVER_BEZEL,
+    }
+}
+
+/// The three buttons under the game list: as thin as the ones along the
+/// top, and sized so a third fits beside the two there are.
+#[cfg(feature = "game-library")]
+fn library_button_rects(rect: Rect, pinned: bool) -> [Rect; 3] {
+    let table = library_table_rect(rect, pinned);
+    let gap = 6;
+    let w = (table.w + gap) / 3 - gap;
+    std::array::from_fn(|i| Rect {
+        x: table.x + i * (w + gap),
+        y: table.y + table.h + LIBRARY_BUTTON_GAP,
+        w,
+        h: LAUNCH_MODEL_H,
+    })
+}
+
+/// The sign-in dialog: a small box in the middle of the panel.
+#[cfg(feature = "game-library")]
+fn login_rect(rect: Rect) -> Rect {
+    // Wide enough that the title clears its own close gadget.
+    let (w, h) = (380, 128 + TITLE_H);
+    Rect {
+        x: rect.x + rect.w.saturating_sub(w) / 2,
+        y: rect.y + rect.h.saturating_sub(h) / 2,
+        w,
+        h,
+    }
+}
+
+/// Its two value boxes, and its two buttons.
+#[cfg(feature = "game-library")]
+fn login_field_rect(rect: Rect, field: launcher::LoginField) -> Rect {
+    let dialog = login_rect(rect);
+    let label = 10 * font::GLYPH_W;
+    Rect {
+        x: dialog.x + 12 + label,
+        y: dialog.y + TITLE_H + 20 + usize::from(field == launcher::LoginField::Pass) * 26,
+        w: dialog.w.saturating_sub(24 + label),
+        h: 18,
+    }
+}
+
+/// The metadata editor: the art on the left at the shape a cover is, the
+/// fields down the right, the buttons along the bottom.
+#[cfg(feature = "game-library")]
+fn meta_rect(rect: Rect) -> Rect {
+    let (w, h) = (440, TITLE_H + META_ART.1 + 56);
+    Rect {
+        x: rect.x + rect.w.saturating_sub(w) / 2,
+        y: rect.y + rect.h.saturating_sub(h) / 2,
+        w,
+        h,
+    }
+}
+
+/// The art box inside it, at the same 4:5 the Library page uses.
+#[cfg(feature = "game-library")]
+const META_ART: (usize, usize) = (112, 140);
+
+#[cfg(feature = "game-library")]
+fn meta_art_rect(rect: Rect) -> Rect {
+    let dialog = meta_rect(rect);
+    Rect {
+        x: dialog.x + 14,
+        y: dialog.y + TITLE_H + 14,
+        w: META_ART.0,
+        h: META_ART.1,
+    }
+}
+
+#[cfg(feature = "game-library")]
+fn meta_field_rect(rect: Rect, field: launcher::MetaField) -> Rect {
+    let dialog = meta_rect(rect);
+    let art = meta_art_rect(rect);
+    let label = 10 * font::GLYPH_W;
+    let x = art.x + art.w + 12 + label;
+    let at = launcher::MetaField::ALL
+        .iter()
+        .position(|&f| f == field)
+        .unwrap_or(0);
+    Rect {
+        x,
+        y: art.y + at * 24,
+        w: (dialog.x + dialog.w).saturating_sub(x + 14),
+        h: 18,
+    }
+}
+
+/// Save, Clear and Cancel, in that order.
+#[cfg(feature = "game-library")]
+fn meta_button_rects(rect: Rect) -> [Rect; 3] {
+    let dialog = meta_rect(rect);
+    let (w, h, gap) = (66, 20, 8);
+    let y = dialog.y + dialog.h - h - 12;
+    std::array::from_fn(|i| Rect {
+        x: dialog.x + dialog.w - 14 - (3 - i) * (w + gap) + gap,
+        y,
+        w,
+        h,
+    })
+}
+
+#[cfg(feature = "game-library")]
+fn login_button_rects(rect: Rect) -> (Rect, Rect) {
+    let dialog = login_rect(rect);
+    let (w, h) = (66, 20);
+    let y = dialog.y + dialog.h - h - 12;
+    (
+        Rect {
+            x: dialog.x + dialog.w - 2 * w - 12 - 8,
+            y,
+            w,
+            h,
+        },
+        Rect {
+            x: dialog.x + dialog.w - w - 12,
+            y,
+            w,
+            h,
+        },
+    )
+}
+
+/// The scroll arrows, inside the list's own frame.
+#[cfg(feature = "game-library")]
+fn library_arrow_rects(rect: Rect, pinned: bool) -> [(UiControl, Rect); 2] {
+    let table = library_table_rect(rect, pinned);
+    let x = table.x + table.w - HOST_DISK_ARROW - 3;
+    [
+        (
+            UiControl::LauncherLibraryScroll(-1),
+            Rect {
+                x,
+                y: table.y + 2,
+                w: HOST_DISK_ARROW,
+                h: HOST_DISK_ARROW,
+            },
+        ),
+        (
+            UiControl::LauncherLibraryScroll(1),
+            Rect {
+                x,
+                y: table.y + table.h - HOST_DISK_ARROW - 2,
+                w: HOST_DISK_ARROW,
+                h: HOST_DISK_ARROW,
+            },
+        ),
+    ]
+}
+
 /// The scroll arrows, up at the top right of the box and down at the bottom
 /// right. Inside the frame rather than beside it, so the box keeps its shape
 /// whether or not the list overflows.
@@ -4805,6 +5271,36 @@ fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
     (browse, clear)
 }
 
+/// The Download button on a support-archive row.
+///
+/// To the *left* of Browse rather than after Clear, where the row's value
+/// would be. There is room because the button and the value are never both
+/// there: it is only offered while nothing has been chosen, and the value
+/// then reads "(none)".
+#[cfg(feature = "game-library")]
+const LAUNCH_DOWNLOAD_W: usize = 78;
+
+#[cfg(feature = "game-library")]
+fn launcher_download_rect(rect: Rect, row_y: usize) -> Rect {
+    let (browse, _) = launcher_path_rects(rect, row_y);
+    Rect {
+        x: browse.x.saturating_sub(LAUNCH_DOWNLOAD_W + 6),
+        w: LAUNCH_DOWNLOAD_W,
+        ..browse
+    }
+}
+
+/// Which archive a row is for, if it is one of the two.
+#[cfg(feature = "game-library")]
+fn row_archive(field: LauncherField) -> Option<crate::gamelib::support::Archive> {
+    use crate::gamelib::support::Archive;
+    match field {
+        LauncherField::WhdloadWhdPackage => Some(Archive::Whdload),
+        LauncherField::WhdloadSkickPackage => Some(Archive::Skick),
+        _ => None,
+    }
+}
+
 /// The editable volume-name box on a drive row: it sits just left of the
 /// Browse button, with the path text filling the space before it.
 fn launcher_drive_name_rect(rect: Rect, row_y: usize) -> Rect {
@@ -4922,12 +5418,62 @@ fn launcher_action_label(control: UiControl) -> &'static str {
 /// Hit-test the configuration panel. Returns the control under `pos`, or `None`
 /// to let the caller swallow the click on the panel body.
 fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Option<UiControl> {
+    // The dialog answers for the whole panel while it is up: nothing
+    // behind it can be clicked, which is what makes it a dialog.
+    #[cfg(feature = "game-library")]
+    if state.meta.is_some() {
+        for (at, control) in [
+            UiControl::MetaSave,
+            UiControl::MetaClear,
+            UiControl::MetaCancel,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if meta_button_rects(rect)[at].contains(pos) {
+                return Some(control);
+            }
+        }
+        if close_button_rect(meta_rect(rect)).contains(pos) {
+            return Some(UiControl::MetaCancel);
+        }
+        if meta_art_rect(rect).contains(pos) {
+            return Some(UiControl::MetaArt);
+        }
+        for field in launcher::MetaField::ALL {
+            if meta_field_rect(rect, field).contains(pos) {
+                return Some(UiControl::MetaField(field));
+            }
+        }
+        return Some(UiControl::PanelBody);
+    }
+    #[cfg(feature = "game-library")]
+    if state.login.is_some() {
+        let (ok, cancel) = login_button_rects(rect);
+        if ok.contains(pos) {
+            return Some(UiControl::LoginOk);
+        }
+        // Its own close gadget, which is Cancel by another name. Checked
+        // before the panel's, which sits behind it.
+        if cancel.contains(pos) || close_button_rect(login_rect(rect)).contains(pos) {
+            return Some(UiControl::LoginCancel);
+        }
+        for field in [launcher::LoginField::User, launcher::LoginField::Pass] {
+            if login_field_rect(rect, field).contains(pos) {
+                return Some(UiControl::LoginField(field));
+            }
+        }
+        return Some(UiControl::PanelBody);
+    }
     for (i, &model) in launcher::MODELS.iter().enumerate() {
         if launcher_model_rect(rect, i).contains(pos) {
             return Some(UiControl::LauncherModel(model));
         }
     }
-    for (i, &tab) in launcher::TABS.iter().enumerate() {
+    for (i, &tab) in launcher::tabs(state.setup.whdload_enabled())
+        .iter()
+        .enumerate()
+    {
         if launcher_tab_rect(rect, i).contains(pos) {
             return Some(UiControl::LauncherTab(tab));
         }
@@ -5164,6 +5710,15 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         return Some(UiControl::LauncherClear(r.field));
                     }
                 }
+                #[cfg(feature = "game-library")]
+                RowKind::Account => {
+                    let (button, _) = launcher_path_rects(rect, row_y);
+                    if button.contains(pos) {
+                        return Some(UiControl::LauncherOpenRetroLogin);
+                    }
+                }
+                #[cfg(not(feature = "game-library"))]
+                RowKind::Account => {}
                 RowKind::FloppyMedia => {
                     let drive = launcher::MachineSetup::drive_image_bay(r.field);
                     if let Some(bay) = drive {
@@ -5220,6 +5775,16 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         if clear.contains(pos) {
                             return Some(UiControl::LauncherClear(r.field));
                         }
+                        // A support archive with nothing chosen can fetch
+                        // its own; once something is chosen there is
+                        // nothing to fetch, and Clear brings it back.
+                        #[cfg(feature = "game-library")]
+                        if row_archive(r.field).is_some()
+                            && state.setup.path(r.field).is_none()
+                            && launcher_download_rect(rect, row_y).contains(pos)
+                        {
+                            return Some(UiControl::LauncherWhdloadDownload(r.field));
+                        }
                     }
                     // The volume name only matters once an image is chosen
                     // (and never for a CD image).
@@ -5230,6 +5795,53 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         return Some(UiControl::LauncherDriveNameEdit(r.field));
                     }
                 }
+            }
+        }
+    }
+    #[cfg(feature = "game-library")]
+    if state.tab == LauncherTab::WhdloadLibrary {
+        let pinned = state.setup.whdload_enabled();
+        if state.library.games.len() > library_visible_rows(rect, pinned) {
+            for (control, arrow) in library_arrow_rects(rect, pinned) {
+                if arrow.contains(pos) {
+                    return Some(control);
+                }
+            }
+        }
+        for drawn in 0..library_visible_rows(rect, pinned) {
+            if state.library.scroll + drawn >= state.library.games.len() {
+                break;
+            }
+            // The tick first: it sits inside the row, and marking a
+            // favourite is not the same as choosing the game.
+            if library_favourite_box(rect, pinned, drawn).contains(pos) {
+                return Some(UiControl::LauncherLibraryFavourite(drawn));
+            }
+            if library_row_rect(rect, pinned, drawn).contains(pos) {
+                return Some(UiControl::LauncherLibraryPick(drawn));
+            }
+        }
+        for (at, control) in [
+            UiControl::LauncherLibraryRefresh,
+            UiControl::LauncherLibraryUpdate,
+            UiControl::LauncherLibraryEdit,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if library_button_rects(rect, pinned)[at].contains(pos)
+                && (at == 0 || !state.library.games.is_empty())
+            {
+                return Some(control);
+            }
+        }
+        let starred = state.library.db.favourite_count();
+        for drawn in 0..starred.min(library_favourite_rows(rect, pinned)) {
+            if library_remove_box(rect, pinned, drawn).contains(pos) {
+                return Some(UiControl::LauncherLibraryFavouriteRemove(drawn));
+            }
+            if library_favourite_row_rect(rect, pinned, drawn).contains(pos) {
+                return Some(UiControl::LauncherLibraryFavouritePick(drawn));
             }
         }
     }
@@ -5291,6 +5903,450 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
 }
 
 /// The Host Disk page: what the host has, and which of it to attach.
+/// The Library page: the games found, which are favourites, and what the
+/// database says about the one picked.
+#[cfg(feature = "game-library")]
+fn draw_library_page(
+    frame: &mut [u8],
+    rect: Rect,
+    state: &LauncherState,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    let entries = state.library.games.entries();
+    let pinned = state.setup.whdload_enabled();
+    let games = library_table_rect(rect, pinned);
+    // A scan running greys both buttons: neither of them can start a
+    // second one while the first is going.
+    let busy = matches!(
+        state.status.as_ref().map(|s| s.kind),
+        Some(launcher::StatusKind::Busy)
+    );
+
+    draw_panel_text(
+        frame,
+        games.x,
+        games.y.saturating_sub(14),
+        "Games:",
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+    draw_library_box(frame, games, scale);
+    for (at, title) in [
+        (LIBRARY_COL_NAME, "Game"),
+        (library_col_favourite(rect, pinned), "Favourite"),
+    ] {
+        draw_panel_text(
+            frame,
+            games.x + 4 + at,
+            games.y + 5,
+            title,
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+    }
+
+    if entries.is_empty() {
+        // What is wrong, then what to do about it, broken where it fits
+        // rather than run off the edge of the box.
+        for (line, text) in [
+            "No games found!",
+            "",
+            "Set \"Game library\" in the WHDLoad",
+            "Configuration menu, then press Refresh.",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if text.is_empty() {
+                continue;
+            }
+            draw_panel_text(
+                frame,
+                games.x + 8,
+                games.y + LIBRARY_HEADER_H + 6 + line * 14,
+                &truncate_to_width(text, games.w.saturating_sub(16)),
+                PANEL_TEXT_DIM,
+                1,
+                scale,
+            );
+        }
+    }
+
+    for drawn in 0..library_visible_rows(rect, pinned) {
+        let Some(entry) = entries.get(state.library.scroll + drawn) else {
+            break;
+        };
+        let row = library_row_rect(rect, pinned, drawn);
+        let chosen = state.library.focus == launcher::LibraryFocus::Games
+            && state.library.scroll + drawn == state.library.selected;
+        if chosen {
+            fill_rect(frame, scale_rect(row, scale), MENU_HILIGHT_BG, scale);
+        } else if hover == Some(UiControl::LauncherLibraryPick(drawn)) {
+            fill_rect(frame, scale_rect(row, scale), BUTTON_FACE_HOVER, scale);
+        }
+        let colour = if chosen {
+            MENU_HILIGHT_TEXT
+        } else {
+            PANEL_TEXT
+        };
+        // Clipped at the Favourite column, so a long title stops rather
+        // than running under the tick.
+        draw_panel_text(
+            frame,
+            row.x + 4 + LIBRARY_COL_NAME,
+            row.y + 3,
+            &truncate_to_width(
+                entry.title(),
+                library_col_favourite(rect, pinned).saturating_sub(LIBRARY_COL_NAME + 12),
+            ),
+            colour,
+            1,
+            scale,
+        );
+        let tick = library_favourite_box(rect, pinned, drawn);
+        draw_tick_box(
+            frame,
+            tick.x,
+            tick.y,
+            state.library.db.is_favourite(&entry.file_name),
+            TICK_GREEN,
+            scale,
+        );
+        if hover == Some(UiControl::LauncherLibraryFavourite(drawn)) {
+            draw_outline(frame, tick, PANEL_TEXT_HILIGHT, scale);
+        }
+    }
+
+    if entries.len() > library_visible_rows(rect, pinned) {
+        for (control, at) in library_arrow_rects(rect, pinned) {
+            let up = matches!(control, UiControl::LauncherLibraryScroll(d) if d < 0);
+            draw_text_button(
+                frame,
+                at,
+                if up { "^" } else { "v" },
+                true,
+                hover == Some(control),
+                scale,
+            );
+        }
+    }
+
+    // The favourites, which are the same games under a shorter heading.
+    let favourites = library_favourites_rect(rect, pinned);
+    draw_panel_text(
+        frame,
+        favourites.x,
+        favourites.y.saturating_sub(14),
+        "Favourites:",
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+    draw_library_box(frame, favourites, scale);
+    for (x, title) in [
+        (favourites.x + 4 + LIBRARY_COL_NAME, "Game"),
+        (library_remove_heading_x(rect, pinned), "Remove"),
+    ] {
+        draw_panel_text(frame, x, favourites.y + 5, title, PANEL_TEXT_DIM, 1, scale);
+    }
+    // From the database rather than from the library, so a favourite whose
+    // package has been deleted is still listed -- and can still be taken
+    // off, which is most of the reason its Remove tick is there.
+    for (drawn, (key, name)) in state
+        .library
+        .db
+        .favourites()
+        .take(library_favourite_rows(rect, pinned))
+        .enumerate()
+    {
+        let row = library_favourite_row_rect(rect, pinned, drawn);
+        let chosen = state.library.focus == launcher::LibraryFocus::Favourites
+            && drawn == state.library.favourite_selected;
+        if chosen {
+            fill_rect(frame, scale_rect(row, scale), MENU_HILIGHT_BG, scale);
+        } else if hover == Some(UiControl::LauncherLibraryFavouritePick(drawn)) {
+            fill_rect(frame, scale_rect(row, scale), BUTTON_FACE_HOVER, scale);
+        }
+        // One no longer in the library is dimmed: still listed, still
+        // removable, but there is nothing to launch.
+        let present = entries
+            .iter()
+            .any(|entry| crate::gamelib::Database::key_for(&entry.file_name) == key);
+        let colour = match (chosen, present) {
+            (true, _) => MENU_HILIGHT_TEXT,
+            (false, true) => PANEL_TEXT,
+            (false, false) => PANEL_TEXT_DIM,
+        };
+        draw_panel_text(
+            frame,
+            row.x + 4 + LIBRARY_COL_NAME,
+            row.y + 3,
+            &truncate_to_width(
+                name,
+                library_col_favourite(rect, pinned).saturating_sub(LIBRARY_COL_NAME + 12),
+            ),
+            colour,
+            1,
+            scale,
+        );
+        let tick = library_remove_box(rect, pinned, drawn);
+        draw_tick_box(frame, tick.x, tick.y, false, TICK_GREEN, scale);
+        if hover == Some(UiControl::LauncherLibraryFavouriteRemove(drawn)) {
+            draw_outline(frame, tick, PANEL_TEXT_HILIGHT, scale);
+        }
+    }
+
+    draw_library_cover(frame, rect, state, scale);
+
+    // The two buttons that say when work happens, in the gap between the
+    // lists. A third slot is left beside them: the row is sized for three
+    // so gaining one later does not move the two that are here.
+    let buttons = library_button_rects(rect, pinned);
+    for (at, (label, control, enabled)) in [
+        ("Refresh", UiControl::LauncherLibraryRefresh, !busy),
+        // Nothing to look up until the folder has been read, so Scan waits
+        // for a Refresh that found something.
+        (
+            "Scan",
+            UiControl::LauncherLibraryUpdate,
+            !busy && !entries.is_empty(),
+        ),
+        (
+            "Update",
+            UiControl::LauncherLibraryEdit,
+            !busy && state.library_selection().is_some(),
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        draw_text_button(
+            frame,
+            buttons[at],
+            label,
+            enabled,
+            hover == Some(control),
+            scale,
+        );
+    }
+}
+
+/// A list box, sunk into the panel like an entry field so it reads as
+/// something to look into rather than a raised control.
+#[cfg(feature = "game-library")]
+fn draw_library_box(frame: &mut [u8], at: Rect, scale: usize) {
+    fill_rect(frame, scale_rect(at, scale), ENTRY_BG, scale);
+    draw_outline(frame, at, BUTTON_EDGE_LIGHT, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(
+            Rect {
+                x: at.x + 1,
+                y: at.y + 1,
+                w: at.w.saturating_sub(2),
+                h: at.h.saturating_sub(2),
+            },
+            scale,
+        ),
+        BUTTON_EDGE_DARK,
+        BUTTON_EDGE_LIGHT,
+        scale,
+    );
+}
+
+/// The cover art box, and what the database says under it.
+#[cfg(feature = "game-library")]
+fn draw_library_cover(frame: &mut [u8], rect: Rect, state: &LauncherState, scale: usize) {
+    let pinned = state.setup.whdload_enabled();
+    // The frame is the size the layout reserves, whatever shape the picture
+    // in it turns out to be: it is where the eye expects the art to be, and
+    // the writing under it starts on the same line for every game.
+    // Amiga box art is portrait almost without exception, so the frame is
+    // cut for that and the rare landscape scan is letterboxed into it --
+    // black above and below beats a frame that changes shape and drags the
+    // metadata down the page with it.
+    let widest = library_cover_rect(rect, pinned);
+    let entry = state.library_selection();
+    let art = entry
+        .and_then(|entry| entry.game.as_ref())
+        .and_then(|game| game.front_sha1.as_deref())
+        .and_then(|sha1| state.library.covers.get(sha1));
+    let (frame_rect, box_rect) = (widest, library_art_rect(rect, pinned));
+
+    // The mount: a button-faced border raised out of the panel, with the
+    // picture recessed into it. Two bevels facing opposite ways is what
+    // makes the frame read as having thickness.
+    fill_rect(frame, scale_rect(frame_rect, scale), BUTTON_FACE, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(frame_rect, scale),
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+    fill_rect(frame, scale_rect(box_rect, scale), ENTRY_BG, scale);
+    if let Some(art) = art {
+        draw_cover_art(frame, box_rect, art, scale);
+    }
+    draw_rect_bevel(
+        frame,
+        scale_rect(box_rect, scale),
+        BUTTON_EDGE_DARK,
+        BUTTON_EDGE_LIGHT,
+        scale,
+    );
+
+    let Some(entry) = entry else {
+        return;
+    };
+    // Two different nothings: a package the catalogue has never heard of,
+    // and one it knows but has no picture for.
+    let missing: &[&str] = match (&entry.game, art.is_some()) {
+        (_, true) => &[],
+        (None, _) => &["not in the", "database"],
+        (Some(_), _) => &["No cover art"],
+    };
+    {
+        for (line, text) in missing.iter().copied().enumerate() {
+            let w = text.chars().count() * font::GLYPH_W;
+            draw_panel_text(
+                frame,
+                box_rect.x + box_rect.w.saturating_sub(w) / 2,
+                box_rect.y + box_rect.h / 2 - 8 * missing.len() + line * 12,
+                text,
+                PANEL_TEXT_DIM,
+                1,
+                scale,
+            );
+        }
+    }
+
+    // Under the art: what the database knows, each label dimmed above its
+    // value, and a value too long for the column wrapped rather than cut.
+    // Hung off the reserved frame rather than off this cover's, so a short
+    // one does not pull the writing up the page.
+    let mut y = widest.y + widest.h + 8;
+    let Some(game) = &entry.game else { return };
+    for (label, value) in [
+        ("Year", game.year.as_deref()),
+        ("Publisher", game.publisher.as_deref()),
+        ("Developer", game.developer.as_deref()),
+        ("Players", game.players.as_deref()),
+    ] {
+        let Some(value) = value else { continue };
+        draw_panel_text(frame, widest.x, y, label, PANEL_TEXT_DIM, 1, scale);
+        y += 12;
+        for line in wrap_to_width(value, widest.w) {
+            draw_panel_text(frame, widest.x, y, &line, PANEL_TEXT, 1, scale);
+            y += 12;
+        }
+        y += 4;
+    }
+}
+
+/// Draw a cover into `into`, scaled to fit and centred, keeping its shape.
+///
+/// Nearest-neighbour, like everything else the panel draws: the launcher
+/// renders at one scale and is blown up whole, so smoothing here would be
+/// undone by the magnification above it anyway.
+#[cfg(feature = "game-library")]
+fn draw_cover_art(frame: &mut [u8], into: Rect, art: &crate::gamelib::cover::Image, scale: usize) {
+    let Some(at) = fit_within(art.width, art.height, into) else {
+        return;
+    };
+    for y in 0..at.h {
+        let from_y = y * art.height / at.h;
+        for x in 0..at.w {
+            let from = (from_y * art.width + x * art.width / at.w) * 4;
+            let Some(px) = art.pixels.get(from..from + 4) else {
+                continue;
+            };
+            // Drawn opaque: cover art has no transparency worth honouring,
+            // and one that does reads better over the box's own fill.
+            let colour = rgba(px[0] as u32, px[1] as u32, px[2] as u32);
+            fill_rect(
+                frame,
+                scale_rect(
+                    Rect {
+                        x: at.x + x,
+                        y: at.y + y,
+                        w: 1,
+                        h: 1,
+                    },
+                    scale,
+                ),
+                colour,
+                scale,
+            );
+        }
+    }
+}
+
+/// The largest rectangle of `w` by `h`'s shape that fits inside `into`,
+/// centred. `None` if either is empty, which is nothing to draw.
+///
+/// Covers are portrait and the box is close to square, so a picture drawn
+/// to the box's own shape would be visibly stretched.
+#[cfg(feature = "game-library")]
+fn fit_within(w: usize, h: usize, into: Rect) -> Option<Rect> {
+    if w == 0 || h == 0 || into.w == 0 || into.h == 0 {
+        return None;
+    }
+    // Whichever side runs out first sets the scale; the other is left a
+    // margin, split evenly.
+    let (fit_w, fit_h) = if w * into.h >= h * into.w {
+        (into.w, (into.w * h / w).clamp(1, into.h))
+    } else {
+        ((into.h * w / h).clamp(1, into.w), into.h)
+    };
+    Some(Rect {
+        x: into.x + (into.w - fit_w) / 2,
+        y: into.y + (into.h - fit_h) / 2,
+        w: fit_w,
+        h: fit_h,
+    })
+}
+
+/// Break text into lines that fit `width`, at spaces where there are any.
+/// A single word longer than the column is cut rather than left to run off
+/// the panel.
+#[cfg(feature = "game-library")]
+fn wrap_to_width(text: &str, width: usize) -> Vec<String> {
+    let per_line = (width / font::GLYPH_W).max(1);
+    let mut lines = Vec::new();
+    let mut line = String::new();
+    for word in text.split_whitespace() {
+        let would_be = if line.is_empty() {
+            word.chars().count()
+        } else {
+            line.chars().count() + 1 + word.chars().count()
+        };
+        if would_be > per_line && !line.is_empty() {
+            lines.push(std::mem::take(&mut line));
+        }
+        if word.chars().count() > per_line {
+            // Nothing to break at: take what fits and move on, rather than
+            // drawing past the edge of the box.
+            if !line.is_empty() {
+                lines.push(std::mem::take(&mut line));
+            }
+            lines.push(word.chars().take(per_line).collect());
+            continue;
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() {
+        lines.push(line);
+    }
+    lines
+}
+
 fn draw_host_disk_page(
     frame: &mut [u8],
     rect: Rect,
@@ -6427,6 +7483,36 @@ fn draw_launcher_row(
                 scale,
             );
         }
+        #[cfg(feature = "game-library")]
+        RowKind::Account => {
+            // Where Browse would be, because it is the same shape of thing:
+            // the button that fills the column in. The column itself says
+            // whether this session is signed in, and is empty when it is
+            // not -- there is no account setting to report, only a session.
+            let (button, _) = launcher_path_rects(rect, row_y);
+            let signed_in = state.openretro.is_some();
+            if signed_in {
+                draw_panel_text(
+                    frame,
+                    launcher_control_x(rect),
+                    button.y + 6,
+                    "logged in",
+                    PANEL_TEXT,
+                    1,
+                    scale,
+                );
+            }
+            draw_text_button(
+                frame,
+                button,
+                if signed_in { "Log out" } else { "Log in" },
+                true,
+                hover == Some(UiControl::LauncherOpenRetroLogin),
+                scale,
+            );
+        }
+        #[cfg(not(feature = "game-library"))]
+        RowKind::Account => {}
         RowKind::Drive => {
             let (browse, clear) = launcher_path_rects(rect, row_y);
             let value_x = launcher_control_x(rect);
@@ -6521,6 +7607,20 @@ fn draw_launcher_row(
                 hover == Some(UiControl::LauncherClear(r.field)),
                 scale,
             );
+            // A support archive with nothing chosen offers to fetch its
+            // own, from the same place and against the same digest the
+            // packaging script uses.
+            #[cfg(feature = "game-library")]
+            if row_archive(r.field).is_some() && setup.path(r.field).is_none() {
+                draw_text_button(
+                    frame,
+                    launcher_download_rect(rect, row_y),
+                    "Download",
+                    true,
+                    hover == Some(UiControl::LauncherWhdloadDownload(r.field)),
+                    scale,
+                );
+            }
         }
     }
 }
@@ -6769,7 +7869,9 @@ fn draw_launcher(
         scale,
     );
     // Vertical category-tab column.
-    for (i, &tab) in launcher::TABS.iter().enumerate() {
+    let pinned = state.setup.whdload_enabled();
+    let strip = launcher::tabs(pinned);
+    for (i, &tab) in strip.iter().enumerate() {
         draw_launcher_chip(
             frame,
             launcher_tab_rect(rect, i),
@@ -6831,6 +7933,10 @@ fn draw_launcher(
             false,
             scale,
         );
+    }
+    #[cfg(feature = "game-library")]
+    if state.tab == LauncherTab::WhdloadLibrary {
+        draw_library_page(frame, rect, state, hover, scale);
     }
     if state.tab == LauncherTab::HostDisk {
         draw_host_disk_page(frame, rect, state, hover, scale);
@@ -6999,10 +8105,10 @@ fn draw_launcher(
     if let Some(status) = &state.status {
         let color = match status.kind {
             launcher::StatusKind::Ok => PANEL_TEXT_HILIGHT,
-            // Neither done nor wrong: the plain panel colour, so a line that
-            // is only reporting progress does not read as either.
-            launcher::StatusKind::Busy => PANEL_TEXT,
-            launcher::StatusKind::Error => PANEL_TEXT_ACCENT,
+            // Work in progress and a failure share the warning colour:
+            // both are "not finished, and worth your attention", and only
+            // a line that says something worked has earned the green.
+            launcher::StatusKind::Busy | launcher::StatusKind::Error => PANEL_TEXT_ACCENT,
         };
         // Kept inside the panel. A failure explains itself at whatever length
         // it needs to, and one long enough to run past the edge is drawn over
@@ -7030,6 +8136,251 @@ fn draw_launcher(
             scale,
         );
     }
+    // Over everything, because it is the only thing being answered while
+    // it is up.
+    #[cfg(feature = "game-library")]
+    if state.login.is_some() {
+        draw_login_dialog(frame, rect, state, hover, scale);
+    }
+    #[cfg(feature = "game-library")]
+    if state.meta.is_some() {
+        draw_meta_dialog(frame, rect, state, hover, scale);
+    }
+}
+
+/// The metadata editor.
+#[cfg(feature = "game-library")]
+fn draw_meta_dialog(
+    frame: &mut [u8],
+    rect: Rect,
+    state: &LauncherState,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    let Some(meta) = &state.meta else { return };
+    fill_rect_blend(frame, scale_rect(rect, scale), SCRIM, SCRIM_ALPHA, scale);
+    let dialog = meta_rect(rect);
+    fill_rect(frame, scale_rect(dialog, scale), PANEL_BG, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(dialog, scale),
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+    draw_title_bar(
+        frame,
+        dialog,
+        "Update metadata",
+        hover == Some(UiControl::MetaCancel),
+        scale,
+    );
+
+    // The art, drawn the way the Library page draws it, and clickable.
+    let art = meta_art_rect(rect);
+    fill_rect(frame, scale_rect(art, scale), BUTTON_FACE, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(art, scale),
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+    let inner = Rect {
+        x: art.x + LIBRARY_COVER_BEZEL,
+        y: art.y + LIBRARY_COVER_BEZEL,
+        w: art.w - 2 * LIBRARY_COVER_BEZEL,
+        h: art.h - 2 * LIBRARY_COVER_BEZEL,
+    };
+    fill_rect(frame, scale_rect(inner, scale), ENTRY_BG, scale);
+    let picture = meta
+        .art
+        .as_deref()
+        .and_then(|key| state.library.covers.get(key));
+    match picture {
+        Some(picture) => draw_cover_art(frame, inner, picture, scale),
+        None => {
+            for (line, text) in ["Click to", "choose art"].into_iter().enumerate() {
+                let w = text.len() * font::GLYPH_W;
+                draw_panel_text(
+                    frame,
+                    inner.x + inner.w.saturating_sub(w) / 2,
+                    inner.y + inner.h / 2 - 12 + line * 12,
+                    text,
+                    PANEL_TEXT_DIM,
+                    1,
+                    scale,
+                );
+            }
+        }
+    }
+    draw_rect_bevel(
+        frame,
+        scale_rect(inner, scale),
+        BUTTON_EDGE_DARK,
+        BUTTON_EDGE_LIGHT,
+        scale,
+    );
+    if hover == Some(UiControl::MetaArt) {
+        draw_outline(frame, art, PANEL_TEXT_HILIGHT, scale);
+    }
+
+    for field in launcher::MetaField::ALL {
+        let box_rect = meta_field_rect(rect, field);
+        draw_panel_text(
+            frame,
+            art.x + art.w + 12,
+            box_rect.y + 5,
+            field.label(),
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+        fill_rect(frame, scale_rect(box_rect, scale), ENTRY_BG, scale);
+        draw_outline(
+            frame,
+            box_rect,
+            if meta.focus == field {
+                PANEL_TEXT_HILIGHT
+            } else {
+                BUTTON_EDGE_DARK
+            },
+            scale,
+        );
+        // The end of what is typed, so a long value shows where the caret
+        // is rather than its own beginning.
+        let value = meta.value(field);
+        let fits = box_rect.w.saturating_sub(10) / font::GLYPH_W;
+        let tail: String = value
+            .chars()
+            .skip(value.chars().count().saturating_sub(fits))
+            .collect();
+        draw_panel_text(
+            frame,
+            box_rect.x + 5,
+            box_rect.y + 5,
+            &tail,
+            PANEL_TEXT,
+            1,
+            scale,
+        );
+    }
+
+    for (at, (label, control)) in [
+        ("Save", UiControl::MetaSave),
+        ("Clear", UiControl::MetaClear),
+        ("Cancel", UiControl::MetaCancel),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        draw_text_button(
+            frame,
+            meta_button_rects(rect)[at],
+            label,
+            true,
+            hover == Some(control),
+            scale,
+        );
+    }
+}
+
+/// The OpenRetro sign-in dialog.
+///
+/// The password is drawn as a run of asterisks, one per character typed:
+/// the [`crate::gamelib::Secret`] behind it is never turned into display
+/// text, so what is on screen cannot be a second copy of it.
+#[cfg(feature = "game-library")]
+fn draw_login_dialog(
+    frame: &mut [u8],
+    rect: Rect,
+    state: &LauncherState,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    use launcher::LoginField;
+    let Some(login) = &state.login else { return };
+    // Everything behind it is dimmed rather than merely covered: a dialog
+    // that only overlaps the page still looks like part of it.
+    fill_rect_blend(frame, scale_rect(rect, scale), SCRIM, SCRIM_ALPHA, scale);
+    let dialog = login_rect(rect);
+    fill_rect(frame, scale_rect(dialog, scale), PANEL_BG, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(dialog, scale),
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+    // Its own title bar, the same as the panel's: a window over a window
+    // should look like one, close gadget included.
+    draw_title_bar(
+        frame,
+        dialog,
+        "Log in to OpenRetro",
+        hover == Some(UiControl::LoginCancel),
+        scale,
+    );
+    for field in [LoginField::User, LoginField::Pass] {
+        let box_rect = login_field_rect(rect, field);
+        let (label, shown) = match field {
+            LoginField::User => ("Username", login.user.clone()),
+            LoginField::Pass => ("Password", "*".repeat(login.pass.chars())),
+        };
+        draw_panel_text(
+            frame,
+            dialog.x + 12,
+            box_rect.y + 5,
+            label,
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+        fill_rect(frame, scale_rect(box_rect, scale), ENTRY_BG, scale);
+        draw_outline(
+            frame,
+            box_rect,
+            if login.focus == field {
+                PANEL_TEXT_HILIGHT
+            } else {
+                BUTTON_EDGE_DARK
+            },
+            scale,
+        );
+        // The end of what has been typed, so a long entry shows the
+        // caret rather than its own beginning.
+        let fits = box_rect.w.saturating_sub(10) / font::GLYPH_W;
+        let tail: String = shown
+            .chars()
+            .skip(shown.chars().count().saturating_sub(fits))
+            .collect();
+        draw_panel_text(
+            frame,
+            box_rect.x + 5,
+            box_rect.y + 5,
+            &tail,
+            ENTRY_TEXT,
+            1,
+            scale,
+        );
+    }
+    let (ok, cancel) = login_button_rects(rect);
+    draw_text_button(
+        frame,
+        ok,
+        "OK",
+        !login.sending,
+        hover == Some(UiControl::LoginOk),
+        scale,
+    );
+    draw_text_button(
+        frame,
+        cancel,
+        "Cancel",
+        true,
+        hover == Some(UiControl::LoginCancel),
+        scale,
+    );
 }
 
 pub fn draw_panel_layer(
@@ -8594,6 +9945,145 @@ mod tests {
         );
     }
 
+    /// A Library page with a few games in it, for the previews.
+    #[cfg(feature = "game-library")]
+    fn library_preview_state() -> LauncherState {
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::WhdloadLibrary;
+
+        state.library.db.set_known(vec![
+            crate::gamelib::Known {
+                file: "GoldenAxe_v1.5_0017.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Golden Axe".to_string(),
+                    year: Some("1990".to_string()),
+                    publisher: Some("Virgin".to_string()),
+                    developer: Some("Probe Software".to_string()),
+                    players: Some("1 - 2 (2)".to_string()),
+                    front_sha1: std::env::var("WHDLOAD_COVER_SHA1").ok(),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "JamesPond2_v2.0_AGA_1354.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "James Pond 2: Codename RoboCod".to_string(),
+                    year: Some("1991".to_string()),
+                    publisher: Some("Millennium".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "KingsQuest5_v1.3.lha".to_string(),
+                game: None,
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "SimCity_v1.0_2193.lha".to_string(),
+                game: None,
+                manual: false,
+                slave_sha1: None,
+            },
+        ]);
+        state
+            .library
+            .db
+            .toggle_favourite("GoldenAxe_v1.5_0017.lha", "Golden Axe");
+        // One whose package is not in the library, which is what the
+        // Remove tick beside it is for.
+        state
+            .library
+            .db
+            .toggle_favourite("Deleted_v1.0_0001.lha", "A Deleted Game");
+        state.library.db_loaded = true;
+        let want_art = std::env::var("WHDLOAD_COVERS").is_ok_and(|covers| {
+            state.library.covers = crate::gamelib::Covers::new(covers.into());
+            true
+        });
+        // A folder of packages, so the list has something in it.
+        if let Ok(games) = std::env::var("WHDLOAD_GAMES") {
+            let first = std::fs::read_dir(&games)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|e| e.path())
+                .find(|p| p.extension().is_some_and(|e| e.eq_ignore_ascii_case("lha")));
+            if let Some(first) = first {
+                state.setup.set_path(LauncherField::WhdloadGame, first);
+                state.refresh_library(std::path::Path::new("/nonexistent"));
+            }
+        }
+        // Land on the game the preview has art and a full set of metadata
+        // for, rather than on whatever sorts first: an empty art frame and
+        // three filled rows is the case the other previews cover.
+        let golden = state
+            .library
+            .games
+            .entries()
+            .iter()
+            .position(|entry| entry.game.as_ref().is_some_and(|g| g.name == "Golden Axe"));
+        if let Some(at) = golden {
+            state.select_library_game(at);
+        }
+        // The window loop asks for the selected game's art each frame
+        // and draws it when it lands; a preview renders once, so it
+        // waits for the picture rather than rendering the empty box.
+        if want_art {
+            state.poll_library_covers();
+            for _ in 0..100 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                if state.poll_library_covers() {
+                    break;
+                }
+            }
+        }
+        state
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn cover_art_keeps_its_shape_inside_the_box() {
+        let box_rect = Rect {
+            x: 100,
+            y: 50,
+            w: 120,
+            h: 130,
+        };
+
+        // A cover is portrait: it fills the height and is centred across.
+        let at = fit_within(600, 800, box_rect).expect("fits");
+        assert_eq!((at.w, at.h), (97, 130));
+        assert_eq!(at.y, 50, "a portrait cover should fill the height");
+        assert!(at.x >= box_rect.x && at.x + at.w <= box_rect.x + box_rect.w);
+        // Centred to the pixel the odd margin allows.
+        let (left, right) = (at.x - box_rect.x, box_rect.w - at.w - (at.x - box_rect.x));
+        assert!(left.abs_diff(right) <= 1, "off centre: {left} and {right}");
+
+        // A landscape one fills the width instead, with the margin above
+        // and below.
+        let at = fit_within(800, 400, box_rect).expect("fits");
+        assert_eq!((at.w, at.h), (120, 60));
+        assert_eq!(at.x, 100);
+        let (top, bottom) = (at.y - box_rect.y, box_rect.h - at.h - (at.y - box_rect.y));
+        assert!(top.abs_diff(bottom) <= 1, "off centre: {top} and {bottom}");
+
+        // Square art in a not-quite-square box still keeps its shape.
+        let at = fit_within(64, 64, box_rect).expect("fits");
+        assert_eq!(at.w, at.h);
+
+        // A picture far wider than it is tall does not collapse to nothing,
+        // and one with no pixels is not drawn at all.
+        assert_eq!(fit_within(4000, 1, box_rect).expect("fits").h, 1);
+        assert!(fit_within(0, 10, box_rect).is_none());
+        assert!(fit_within(10, 0, box_rect).is_none());
+        assert!(fit_within(10, 10, Rect { w: 0, ..box_rect }).is_none());
+    }
+
     #[test]
     fn panels_render_into_their_rects() {
         use super::super::window::{texture_height, texture_width};
@@ -9575,6 +11065,82 @@ mod tests {
         draw(&mut frame, scale, &ui, None, None);
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher-rom");
+
+        // The Library page, with WHDLoad beside it in the strip and
+        // a couple of games standing in for a real folder.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let state = library_preview_state();
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-whdload-library");
+        }
+
+        // The sign-in dialog, over the Configuration page it is opened
+        // from, with something typed into both boxes.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.tab = LauncherTab::Whdload;
+            let mut login = launcher::LoginDialog {
+                user: "hobbo91".to_string(),
+                focus: launcher::LoginField::Pass,
+                ..Default::default()
+            };
+            for c in "not-a-real-password".chars() {
+                login.pass.push(c);
+            }
+            state.login = Some(login);
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-openretro-login");
+        }
+
+        // The metadata editor, over the Library page it is opened from.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = library_preview_state();
+            state.open_meta_editor();
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-meta-editor");
+        }
+
+        // An empty Library page: nothing scanned yet, so Scan is greyed
+        // and the art frame is drawn at the size it reserves.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.tab = LauncherTab::WhdloadLibrary;
+            state.library.db_loaded = true;
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-whdload-library-empty");
+        }
 
         // The Storage tab, whose six sub-page links wrap onto a second row.
         let mut frame = vec![0u8; w * h * 4];

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -789,6 +789,9 @@ pub enum UiControl {
     /// Take that row off the favourites list.
     #[cfg(feature = "game-library")]
     LauncherLibraryFavouriteRemove(usize),
+    /// Scroll the favourites list by that many rows.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryFavouriteScroll(isize),
     /// Open the OpenRetro sign-in dialog.
     #[cfg(feature = "game-library")]
     LauncherOpenRetroLogin,
@@ -4531,23 +4534,28 @@ fn draw_launcher_value_box(
         BUTTON_EDGE_LIGHT,
         scale,
     );
-    let typing = state.typing_in_value_box(field);
-    let (text, color) = if typing {
-        (format!("{}_", state.edit_buffer()), PANEL_TEXT_HILIGHT)
-    } else if disabled {
-        (state.row_value(field), PANEL_TEXT_DIM)
-    } else {
-        (state.row_value(field), PANEL_TEXT)
-    };
     let avail = box_rect.w.saturating_sub(8);
-    // A value that is too long loses its head while it is being typed and
-    // its tail otherwise: what matters when typing is where the caret is,
-    // and it is at the end.
-    let shown = if typing {
-        clip_text_tail(&text, avail)
-    } else {
-        truncate_to_width(&text, avail)
+    if state.typing_in_value_box(field) {
+        draw_edit_line(
+            frame,
+            box_rect.x + 4,
+            box_rect.y + 6,
+            state.edit_buffer(),
+            state.edit_caret().at(),
+            PANEL_TEXT_HILIGHT,
+            PANEL_BG,
+            avail,
+            scale,
+        );
+        return;
+    }
+    let (text, color) = match disabled {
+        true => (state.row_value(field), PANEL_TEXT_DIM),
+        false => (state.row_value(field), PANEL_TEXT),
     };
+    // A value too long for the box loses its tail: the head is the part
+    // that says which of several it is.
+    let shown = truncate_to_width(&text, avail);
     // A short figure between two arrows reads as belonging to them when it
     // is centred, and as a stray left-aligned word when it is not.
     let x = if centred {
@@ -5058,31 +5066,38 @@ fn login_button_rects(rect: Rect) -> (Rect, Rect) {
     )
 }
 
-/// The scroll arrows, inside the list's own frame.
+/// The scroll arrows for a list, inside its own frame: up in the top right
+/// corner, down in the bottom right. Both Library lists use it, each with
+/// its own pair of controls.
+#[cfg(feature = "game-library")]
+fn library_arrows_in(table: Rect, control: fn(isize) -> UiControl) -> [(UiControl, Rect); 2] {
+    let x = table.x + table.w - HOST_DISK_ARROW - 3;
+    let arrow = |y| Rect {
+        x,
+        y,
+        w: HOST_DISK_ARROW,
+        h: HOST_DISK_ARROW,
+    };
+    [
+        (control(-1), arrow(table.y + 2)),
+        (control(1), arrow(table.y + table.h - HOST_DISK_ARROW - 2)),
+    ]
+}
+
 #[cfg(feature = "game-library")]
 fn library_arrow_rects(rect: Rect, pinned: bool) -> [(UiControl, Rect); 2] {
-    let table = library_table_rect(rect, pinned);
-    let x = table.x + table.w - HOST_DISK_ARROW - 3;
-    [
-        (
-            UiControl::LauncherLibraryScroll(-1),
-            Rect {
-                x,
-                y: table.y + 2,
-                w: HOST_DISK_ARROW,
-                h: HOST_DISK_ARROW,
-            },
-        ),
-        (
-            UiControl::LauncherLibraryScroll(1),
-            Rect {
-                x,
-                y: table.y + table.h - HOST_DISK_ARROW - 2,
-                w: HOST_DISK_ARROW,
-                h: HOST_DISK_ARROW,
-            },
-        ),
-    ]
+    library_arrows_in(
+        library_table_rect(rect, pinned),
+        UiControl::LauncherLibraryScroll,
+    )
+}
+
+#[cfg(feature = "game-library")]
+fn library_favourite_arrow_rects(rect: Rect, pinned: bool) -> [(UiControl, Rect); 2] {
+    library_arrows_in(
+        library_favourites_rect(rect, pinned),
+        UiControl::LauncherLibraryFavouriteScroll,
+    )
 }
 
 /// The scroll arrows, up at the top right of the box and down at the bottom
@@ -5113,6 +5128,57 @@ fn host_disk_arrow_rects(rect: Rect) -> [(UiControl, Rect); 2] {
             },
         ),
     ]
+}
+
+/// One scroll arrow: a bevelled button with a triangle on it.
+///
+/// Every scrolling list in the launcher draws its pair with this, so they
+/// look and behave alike -- lit while there is somewhere to go that way and
+/// greyed at the end of the list, brightened under the pointer.
+///
+/// The triangle is stacked runs rather than a glyph: the 8x8 font has no
+/// arrow in it, and a "^" is a caret, which reads as punctuation next to a
+/// list rather than as a direction.
+fn draw_scroll_arrow(
+    frame: &mut [u8],
+    arrow: Rect,
+    up: bool,
+    live: bool,
+    hovered: bool,
+    scale: usize,
+) {
+    let scaled = scale_rect(arrow, scale);
+    fill_rect(frame, scaled, BUTTON_FACE, scale);
+    draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
+    let colour = match (live, hovered) {
+        (false, _) => BUTTON_TEXT_DISABLED,
+        (true, true) => PANEL_TEXT_HILIGHT,
+        (true, false) => BUTTON_TEXT,
+    };
+    // Three rows is enough to read as an arrow at this size. Widening
+    // downwards is an up arrow (narrow tip at the top); widening upwards is
+    // a down arrow.
+    for step in 0..3usize {
+        let width = 1 + step * 2;
+        let y = match up {
+            true => arrow.y + 4 + step,
+            false => arrow.y + 4 + (2 - step),
+        };
+        fill_rect(
+            frame,
+            scale_rect(
+                Rect {
+                    x: arrow.x + HOST_DISK_ARROW / 2 - width / 2 - 1,
+                    y,
+                    w: width,
+                    h: 1,
+                },
+                scale,
+            ),
+            colour,
+            scale,
+        );
+    }
 }
 
 /// The Attach cell of one row: clicked to step through where the machine
@@ -5852,7 +5918,18 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             }
         }
         let starred = state.library.db.favourite_count();
-        for drawn in 0..starred.min(library_favourite_rows(rect, pinned)) {
+        let rows = library_favourite_rows(rect, pinned);
+        if starred > rows {
+            for (control, arrow) in library_favourite_arrow_rects(rect, pinned) {
+                if arrow.contains(pos) {
+                    return Some(control);
+                }
+            }
+        }
+        for drawn in 0..starred
+            .saturating_sub(state.library.favourite_scroll)
+            .min(rows)
+        {
             if library_remove_box(rect, pinned, drawn).contains(pos) {
                 return Some(UiControl::LauncherLibraryFavouriteRemove(drawn));
             }
@@ -6036,17 +6113,15 @@ fn draw_library_page(
         }
     }
 
-    if entries.len() > library_visible_rows(rect, pinned) {
+    let visible = library_visible_rows(rect, pinned);
+    if entries.len() > visible {
         for (control, at) in library_arrow_rects(rect, pinned) {
             let up = matches!(control, UiControl::LauncherLibraryScroll(d) if d < 0);
-            draw_text_button(
-                frame,
-                at,
-                if up { "^" } else { "v" },
-                true,
-                hover == Some(control),
-                scale,
-            );
+            let live = match up {
+                true => state.library.scroll > 0,
+                false => state.library.scroll + visible < entries.len(),
+            };
+            draw_scroll_arrow(frame, at, up, live, hover == Some(control), scale);
         }
     }
 
@@ -6071,16 +6146,18 @@ fn draw_library_page(
     // From the database rather than from the library, so a favourite whose
     // package has been deleted is still listed -- and can still be taken
     // off, which is most of the reason its Remove tick is there.
+    let favourite_rows = library_favourite_rows(rect, pinned);
     for (drawn, (key, name)) in state
         .library
         .db
         .favourites()
-        .take(library_favourite_rows(rect, pinned))
+        .skip(state.library.favourite_scroll)
+        .take(favourite_rows)
         .enumerate()
     {
         let row = library_favourite_row_rect(rect, pinned, drawn);
         let chosen = state.library.focus == launcher::LibraryFocus::Favourites
-            && drawn == state.library.favourite_selected;
+            && state.library.favourite_scroll + drawn == state.library.favourite_selected;
         if chosen {
             fill_rect(frame, scale_rect(row, scale), MENU_HILIGHT_BG, scale);
         } else if hover == Some(UiControl::LauncherLibraryFavouritePick(drawn)) {
@@ -6088,9 +6165,7 @@ fn draw_library_page(
         }
         // One no longer in the library is dimmed: still listed, still
         // removable, but there is nothing to launch.
-        let present = entries
-            .iter()
-            .any(|entry| entry.relative == key);
+        let present = entries.iter().any(|entry| entry.relative == key);
         let colour = match (chosen, present) {
             (true, _) => MENU_HILIGHT_TEXT,
             (false, true) => PANEL_TEXT,
@@ -6112,6 +6187,18 @@ fn draw_library_page(
         draw_tick_box(frame, tick.x, tick.y, false, TICK_GREEN, scale);
         if hover == Some(UiControl::LauncherLibraryFavouriteRemove(drawn)) {
             draw_outline(frame, tick, PANEL_TEXT_HILIGHT, scale);
+        }
+    }
+
+    let starred = state.library.db.favourite_count();
+    if starred > favourite_rows {
+        for (control, at) in library_favourite_arrow_rects(rect, pinned) {
+            let up = matches!(control, UiControl::LauncherLibraryFavouriteScroll(d) if d < 0);
+            let live = match up {
+                true => state.library.favourite_scroll > 0,
+                false => state.library.favourite_scroll + favourite_rows < starred,
+            };
+            draw_scroll_arrow(frame, at, up, live, hover == Some(control), scale);
         }
     }
 
@@ -6289,8 +6376,16 @@ fn draw_library_cover(frame: &mut [u8], rect: Rect, state: &LauncherState, scale
         *y += 4;
     };
     show("Year", game.and_then(|g| g.year.as_deref()), &mut y);
-    show("Publisher", game.and_then(|g| g.publisher.as_deref()), &mut y);
-    show("Developer", game.and_then(|g| g.developer.as_deref()), &mut y);
+    show(
+        "Publisher",
+        game.and_then(|g| g.publisher.as_deref()),
+        &mut y,
+    );
+    show(
+        "Developer",
+        game.and_then(|g| g.developer.as_deref()),
+        &mut y,
+    );
     show("Players", game.and_then(|g| g.players.as_deref()), &mut y);
 
     // Which release this is. Shown only when there is something to say:
@@ -6593,42 +6688,7 @@ fn draw_host_disk_page(
             } else {
                 scroll + HOST_DISK_VISIBLE_ROWS < disks.len()
             };
-            let scaled = scale_rect(arrow, scale);
-            fill_rect(frame, scaled, BUTTON_FACE, scale);
-            draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
-            let colour = if !live {
-                BUTTON_TEXT_DISABLED
-            } else if hover == Some(control) {
-                PANEL_TEXT_HILIGHT
-            } else {
-                BUTTON_TEXT
-            };
-            // A triangle, drawn as stacked runs: three rows is enough to read
-            // as an arrow at this size, and it needs no glyph.
-            for step in 0..3usize {
-                let width = 1 + step * 2;
-                // Widening downwards is an up arrow (narrow tip at the top);
-                // widening upwards is a down arrow.
-                let y = if up {
-                    arrow.y + 4 + step
-                } else {
-                    arrow.y + 4 + (2 - step)
-                };
-                fill_rect(
-                    frame,
-                    scale_rect(
-                        Rect {
-                            x: arrow.x + HOST_DISK_ARROW / 2 - width / 2 - 1,
-                            y,
-                            w: width,
-                            h: 1,
-                        },
-                        scale,
-                    ),
-                    colour,
-                    scale,
-                );
-            }
+            draw_scroll_arrow(frame, arrow, up, live, hover == Some(control), scale);
         }
     }
 
@@ -6788,12 +6848,79 @@ fn truncate_to_width(text: &str, avail_px: usize) -> String {
     format!("{kept}~")
 }
 
+/// Which slice of a line a box shows, and where in it the caret lands.
+///
+/// Answers `(first character shown, cell the caret is on)` for a line of
+/// `len` characters in a box `cells` wide. The caret is kept off the edges
+/// where there is text either side of it -- half a box of lead means
+/// stepping through a long value moves the block, and only shifts the text
+/// once the block reaches an end.
+fn edit_window(len: usize, caret: usize, cells: usize) -> (usize, usize) {
+    let first = caret
+        .saturating_sub(cells / 2)
+        .min(len.saturating_sub(cells));
+    (first, caret - first)
+}
+
+/// Draw a line that is being typed into, with a block over the caret.
+///
+/// Every editable box in the launcher goes through here -- the value boxes
+/// on the configuration pages and both WHDLoad dialogs -- so a caret means
+/// the same thing wherever it is seen. A block rather than a bar: the font
+/// is an 8x8 cell grid with no sub-pixel anywhere in it, and a one-pixel
+/// line between two cells is easy to miss on a scaled-up panel.
+///
+/// The window on the text slides to keep the caret in view, so typing at
+/// the end of something longer than the box pushes the head off the left
+/// and stepping back to the front brings it home. An "..." marks a head
+/// that has been scrolled past, and the caret cell is left free at the
+/// right so a caret past the last character has somewhere to sit.
+#[allow(clippy::too_many_arguments)]
+fn draw_edit_line(
+    frame: &mut [u8],
+    x: usize,
+    y: usize,
+    text: &str,
+    caret: usize,
+    color: u32,
+    bg: u32,
+    avail_px: usize,
+    scale: usize,
+) {
+    let chars: Vec<char> = text.chars().collect();
+    // One cell is the caret's, so a full box still shows where typing goes.
+    let cells = (avail_px / font::GLYPH_W).saturating_sub(1).max(1);
+    let caret = caret.min(chars.len());
+    let (first, cell) = edit_window(chars.len(), caret, cells);
+    let mut shown: Vec<char> = chars.iter().skip(first).take(cells + 1).copied().collect();
+    // Say the head was scrolled past, where the three cells it takes do not
+    // land under the block: a caret sitting on a dot would be a lie about
+    // what deleting there would remove.
+    if first > 0 && cell >= 3 {
+        shown[..3].fill('.');
+    }
+    let shown: String = shown.into_iter().collect();
+    draw_panel_text(frame, x, y, &shown, color, 1, scale);
+    let block = Rect {
+        x: x + cell * font::GLYPH_W,
+        y,
+        w: font::GLYPH_W,
+        h: font::GLYPH_H,
+    };
+    fill_rect(frame, scale_rect(block, scale), color, scale);
+    // The character under the block, drawn in the background so the block
+    // reads as inverse video rather than as a character painted out.
+    if let Some(&c) = chars.get(caret) {
+        draw_panel_text(frame, block.x, y, &c.to_string(), bg, 1, scale);
+    }
+}
+
 /// Clip `text` to `avail_px`, keeping the TAIL and prefixing an ASCII "..."
-/// when it does not fit -- for a host directory the meaningful end (the leaf
-/// dir) stays visible, and for a field being typed into it is the caret. The
-/// bitmap font is ASCII-only, so a real ellipsis glyph cannot be drawn; "..."
-/// is the closest it can render. Mirrors [`truncate_to_width`], which keeps
-/// the head instead.
+/// when it does not fit, so a host directory's meaningful end (the leaf
+/// dir) stays visible. The bitmap font is ASCII-only, so a real ellipsis
+/// glyph cannot be drawn; "..." is the closest it can render. Mirrors
+/// [`truncate_to_width`], which keeps the head instead, and
+/// [`draw_edit_line`], which shows a window around the caret.
 fn clip_text_tail(text: &str, avail_px: usize) -> String {
     let max_chars = avail_px / font::GLYPH_W;
     let len = text.chars().count();
@@ -7337,8 +7464,6 @@ fn draw_launcher_row(
             let editing = state.editing() == Some(EditTarget::DriveBootpri(r.field));
             let text = if let Some(reason) = reason.filter(|_| greyed_shows_reason) {
                 reason.to_string()
-            } else if editing {
-                format!("{}_", state.edit_buffer())
             } else {
                 setup.value_label(r.field)
             };
@@ -7362,7 +7487,21 @@ fn draw_launcher_row(
             } else {
                 PANEL_TEXT
             };
-            draw_panel_text(frame, tx, value.y + 6, &text, color, 1, scale);
+            if editing {
+                draw_edit_line(
+                    frame,
+                    value.x + 4,
+                    value.y + 6,
+                    state.edit_buffer(),
+                    state.edit_caret().at(),
+                    PANEL_TEXT_HILIGHT,
+                    PANEL_BG,
+                    value.w.saturating_sub(8),
+                    scale,
+                );
+            } else {
+                draw_panel_text(frame, tx, value.y + 6, &text, color, 1, scale);
+            }
             // Status column: the "Bootable" label then a tick box, ticked when
             // the drive is bootable.
             let cell = launcher_bootable_rect(rect, row_y);
@@ -7661,23 +7800,35 @@ fn draw_launcher_row(
                     scale,
                 );
                 let editing = state.editing() == Some(EditTarget::DriveName(r.field));
-                let (label, color) = if editing {
-                    (format!("{}_", state.edit_buffer()), PANEL_TEXT_HILIGHT)
-                } else if let Some(name) = setup.drive_name(r.field) {
+                let (label, color) = if let Some(name) = setup.drive_name(r.field) {
                     (name.to_string(), PANEL_TEXT)
                 } else {
                     ("(volume)".to_string(), PANEL_TEXT_DIM)
                 };
-                let shown = truncate_to_width(&label, name_box.w.saturating_sub(8));
-                draw_panel_text(
-                    frame,
-                    name_box.x + 4,
-                    name_box.y + 6,
-                    &shown,
-                    color,
-                    1,
-                    scale,
-                );
+                if editing {
+                    draw_edit_line(
+                        frame,
+                        name_box.x + 4,
+                        name_box.y + 6,
+                        state.edit_buffer(),
+                        state.edit_caret().at(),
+                        PANEL_TEXT_HILIGHT,
+                        PANEL_BG,
+                        name_box.w.saturating_sub(8),
+                        scale,
+                    );
+                } else {
+                    let shown = truncate_to_width(&label, name_box.w.saturating_sub(8));
+                    draw_panel_text(
+                        frame,
+                        name_box.x + 4,
+                        name_box.y + 6,
+                        &shown,
+                        color,
+                        1,
+                        scale,
+                    );
+                }
             }
             draw_text_button(
                 frame,
@@ -7890,18 +8041,22 @@ fn draw_launcher_board_option(
                 BUTTON_EDGE_LIGHT,
                 scale,
             );
-            let text = if editing {
-                format!("{}_", state.edit_buffer())
+            if editing {
+                draw_edit_line(
+                    frame,
+                    vbox.x + 4,
+                    row_y + 8,
+                    state.edit_buffer(),
+                    state.edit_caret().at(),
+                    PANEL_TEXT_HILIGHT,
+                    PANEL_BG,
+                    vbox.w.saturating_sub(8),
+                    scale,
+                );
             } else {
-                value.clone()
-            };
-            let color = if editing {
-                PANEL_TEXT_HILIGHT
-            } else {
-                PANEL_TEXT
-            };
-            let shown = truncate_to_width(&text, vbox.w.saturating_sub(8));
-            draw_panel_text(frame, vbox.x + 4, row_y + 8, &shown, color, 1, scale);
+                let shown = truncate_to_width(&value, vbox.w.saturating_sub(8));
+                draw_panel_text(frame, vbox.x + 4, row_y + 8, &shown, PANEL_TEXT, 1, scale);
+            }
         }
     }
 }
@@ -8335,23 +8490,33 @@ fn draw_meta_dialog(
             },
             scale,
         );
-        // The end of what is typed, so a long value shows where the caret
-        // is rather than its own beginning.
+        // The focused box carries the caret, and the window on the text
+        // follows it: metadata is amended more often than typed fresh, so
+        // the middle of a value has to be reachable.
         let value = meta.value(field);
-        let fits = box_rect.w.saturating_sub(10) / font::GLYPH_W;
-        let tail: String = value
-            .chars()
-            .skip(value.chars().count().saturating_sub(fits))
-            .collect();
-        draw_panel_text(
-            frame,
-            box_rect.x + 5,
-            box_rect.y + 5,
-            &tail,
-            PANEL_TEXT,
-            1,
-            scale,
-        );
+        if meta.focus == field {
+            draw_edit_line(
+                frame,
+                box_rect.x + 5,
+                box_rect.y + 5,
+                value,
+                meta.caret.at(),
+                PANEL_TEXT,
+                ENTRY_BG,
+                box_rect.w.saturating_sub(10),
+                scale,
+            );
+        } else {
+            draw_panel_text(
+                frame,
+                box_rect.x + 5,
+                box_rect.y + 5,
+                &truncate_to_width(value, box_rect.w.saturating_sub(10)),
+                PANEL_TEXT,
+                1,
+                scale,
+            );
+        }
     }
 
     for (at, (label, control)) in [
@@ -8435,22 +8600,32 @@ fn draw_login_dialog(
             },
             scale,
         );
-        // The end of what has been typed, so a long entry shows the
-        // caret rather than its own beginning.
-        let fits = box_rect.w.saturating_sub(10) / font::GLYPH_W;
-        let tail: String = shown
-            .chars()
-            .skip(shown.chars().count().saturating_sub(fits))
-            .collect();
-        draw_panel_text(
-            frame,
-            box_rect.x + 5,
-            box_rect.y + 5,
-            &tail,
-            ENTRY_TEXT,
-            1,
-            scale,
-        );
+        // The focused box carries the caret, and the window on the text
+        // follows it. The mask is one asterisk a character, so the caret
+        // steps through a password exactly as it does through a name.
+        if login.focus == field {
+            draw_edit_line(
+                frame,
+                box_rect.x + 5,
+                box_rect.y + 5,
+                &shown,
+                login.caret.at(),
+                PANEL_TEXT,
+                ENTRY_BG,
+                box_rect.w.saturating_sub(10),
+                scale,
+            );
+        } else {
+            draw_panel_text(
+                frame,
+                box_rect.x + 5,
+                box_rect.y + 5,
+                &truncate_to_width(&shown, box_rect.w.saturating_sub(10)),
+                PANEL_TEXT,
+                1,
+                scale,
+            );
+        }
     }
     let (ok, cancel) = login_button_rects(rect);
     draw_text_button(
@@ -8935,6 +9110,98 @@ pub fn hex_dump_row(addr: u32, bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::config::{JoystickInputMode, PixelAspect, WarpSpeed};
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn the_favourites_arrows_appear_and_its_rows_follow_the_scroll() {
+        let rect = Rect {
+            x: 0,
+            y: 0,
+            w: 716,
+            h: 581,
+        };
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::WhdloadLibrary;
+        let pinned = state.setup.whdload_enabled();
+        let rows = library_favourite_rows(rect, pinned);
+        assert!(rows > 1, "the box holds rows to scroll: {rows}");
+
+        // A list that fits has no arrows: the corner is a row's, not a
+        // button's, so a click there picks the game under it.
+        for at in 0..rows {
+            state
+                .library
+                .db
+                .toggle_favourite(&format!("Game{at}.lha"), &format!("Game {at}"));
+        }
+        let [(up, up_at), (down, down_at)] = library_favourite_arrow_rects(rect, pinned);
+        let hit = |state: &LauncherState, at: Rect| {
+            launcher_control_at(rect, state, (at.x as i32 + 2, at.y as i32 + 2))
+        };
+        assert_ne!(hit(&state, up_at), Some(up));
+        assert_ne!(hit(&state, down_at), Some(down));
+
+        // One more than fits, and they appear.
+        state.library.db.toggle_favourite("GameN.lha", "Game N");
+        assert_eq!(hit(&state, up_at), Some(up));
+        assert_eq!(hit(&state, down_at), Some(down));
+
+        // The rows are drawn positions: scrolled down, the top row is the
+        // scroll's, so clicking it removes the right favourite.
+        let first = library_favourite_row_rect(rect, pinned, 0);
+        let click = (first.x as i32 + 40, first.y as i32 + 2);
+        assert_eq!(
+            launcher_control_at(rect, &state, click),
+            Some(UiControl::LauncherLibraryFavouritePick(0))
+        );
+        state.scroll_favourites(1, rows);
+        assert_eq!(state.library.favourite_scroll, 1);
+        assert_eq!(
+            launcher_control_at(rect, &state, click),
+            Some(UiControl::LauncherLibraryFavouritePick(0)),
+            "still the top drawn row; the window under it moved"
+        );
+
+        // And the last drawn row is the last one there is: scrolled to the
+        // end, the rows below it are not clickable.
+        state.scroll_favourites(100, rows);
+        let past = library_favourite_row_rect(rect, pinned, rows - 1);
+        assert_eq!(
+            launcher_control_at(rect, &state, (past.x as i32 + 40, past.y as i32 + 2)),
+            Some(UiControl::LauncherLibraryFavouritePick(rows - 1))
+        );
+    }
+
+    #[test]
+    fn an_edit_window_keeps_the_caret_in_the_box() {
+        // Short enough to fit: the whole line is shown from the start, and
+        // the caret sits where it is.
+        assert_eq!(edit_window(5, 0, 10), (0, 0));
+        assert_eq!(edit_window(5, 5, 10), (0, 5));
+
+        // Longer than the box. Near the front nothing scrolls yet...
+        assert_eq!(edit_window(40, 0, 10), (0, 0));
+        assert_eq!(edit_window(40, 4, 10), (0, 4));
+        // ...and past half a box the text starts moving under a caret that
+        // stays put, rather than the caret walking into the edge.
+        assert_eq!(edit_window(40, 20, 10), (15, 5));
+        assert_eq!(edit_window(40, 21, 10), (16, 5));
+        // At the end the window stops: the tail is shown and the caret
+        // walks the last cells, which is where typing leaves it.
+        assert_eq!(edit_window(40, 40, 10), (30, 10));
+        assert_eq!(edit_window(40, 38, 10), (30, 8));
+
+        // The caret is always inside the box it is drawn in.
+        for len in 0..40 {
+            for caret in 0..=len {
+                for cells in 1..12 {
+                    let (first, cell) = edit_window(len, caret, cells);
+                    assert!(first <= caret, "{len}/{caret}/{cells}: {first}");
+                    assert!(cell <= cells, "{len}/{caret}/{cells}: {cell}");
+                }
+            }
+        }
+    }
 
     #[test]
     fn clip_path_keeps_the_file_name() {
@@ -10101,6 +10368,116 @@ mod tests {
                 manual: false,
                 slave_sha1: None,
             },
+            crate::gamelib::Known {
+                file: "Lotus2_v1.2_0451.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Lotus Turbo Challenge 2".to_string(),
+                    year: Some("1991".to_string()),
+                    publisher: Some("Gremlin".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "Turrican2_v2.1_1120.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Turrican II".to_string(),
+                    year: Some("1991".to_string()),
+                    publisher: Some("Rainbow Arts".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "SensibleSoccer_v1.1_0788.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Sensible Soccer".to_string(),
+                    year: Some("1992".to_string()),
+                    publisher: Some("Renegade".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "Superfrog_v1.0_0233.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Superfrog".to_string(),
+                    year: Some("1993".to_string()),
+                    publisher: Some("Team17".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "ChaosEngine_v2.0_0912.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "The Chaos Engine".to_string(),
+                    year: Some("1993".to_string()),
+                    publisher: Some("Renegade".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "Xenon2_v1.0_0355.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Xenon 2: Megablast".to_string(),
+                    year: Some("1989".to_string()),
+                    publisher: Some("Image Works".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "Turrican_v1.3_0087.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Turrican".to_string(),
+                    year: Some("1990".to_string()),
+                    publisher: Some("Rainbow Arts".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "Lemmings_v1.1_0621.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Lemmings".to_string(),
+                    year: Some("1991".to_string()),
+                    publisher: Some("Psygnosis".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "Pinball_Dreams_v1.0_0498.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Pinball Dreams".to_string(),
+                    year: Some("1992".to_string()),
+                    publisher: Some("21st Century".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
+            crate::gamelib::Known {
+                file: "SpeedBall2_v1.2_0733.lha".to_string(),
+                game: Some(crate::gamelib::Game {
+                    name: "Speedball 2".to_string(),
+                    year: Some("1990".to_string()),
+                    publisher: Some("Image Works".to_string()),
+                    ..crate::gamelib::Game::default()
+                }),
+                manual: false,
+                slave_sha1: None,
+            },
         ]);
         state
             .library
@@ -10112,23 +10489,30 @@ mod tests {
             .library
             .db
             .toggle_favourite("Deleted_v1.0_0001.lha", "A Deleted Game");
+        // More than the box holds, so the preview covers a favourites list
+        // with its scroll arrows up rather than only the short case.
+        for (file, name) in [
+            ("Lotus2_v1.2_0451.lha", "Lotus Turbo Challenge 2"),
+            ("Turrican2_v2.1_1120.lha", "Turrican II"),
+            ("SensibleSoccer_v1.1_0788.lha", "Sensible Soccer"),
+            ("Superfrog_v1.0_0233.lha", "Superfrog"),
+            ("ChaosEngine_v2.0_0912.lha", "The Chaos Engine"),
+            ("Xenon2_v1.0_0355.lha", "Xenon 2: Megablast"),
+        ] {
+            state.library.db.toggle_favourite(file, name);
+        }
         state.library.db_loaded = true;
         let want_art = std::env::var("WHDLOAD_COVERS").is_ok_and(|covers| {
             state.library.covers = crate::gamelib::Covers::new(covers.into());
             true
         });
-        // A folder of packages, so the list has something in it.
+        // A folder of packages, so the list has something in it. The store
+        // above supplies the metadata; this is only what is on the disk.
         if let Ok(games) = std::env::var("WHDLOAD_GAMES") {
-            let first = std::fs::read_dir(&games)
-                .into_iter()
-                .flatten()
-                .flatten()
-                .map(|e| e.path())
-                .find(|p| p.extension().is_some_and(|e| e.eq_ignore_ascii_case("lha")));
-            if let Some(first) = first {
-                state.setup.set_path(LauncherField::WhdloadGame, first);
-                state.refresh_library(std::path::Path::new("/nonexistent"));
-            }
+            state
+                .setup
+                .set_path(LauncherField::WhdloadGames, games.into());
+            state.refresh_library(std::path::Path::new("/nonexistent"));
         }
         // Land on the game the preview has art and a full set of metadata
         // for, rather than on whatever sorts first: an empty art frame and
@@ -11224,11 +11608,15 @@ mod tests {
             state.tab = LauncherTab::Whdload;
             let mut login = launcher::LoginDialog {
                 user: "hobbo91".to_string(),
-                focus: launcher::LoginField::Pass,
                 ..Default::default()
             };
+            login.focus_on(launcher::LoginField::Pass);
             for c in "not-a-real-password".chars() {
-                login.pass.push(c);
+                login.insert(c);
+            }
+            // Part-way back through it, which is what the caret is for.
+            for _ in 0..8 {
+                login.caret_move(launcher::CaretMove::Left);
             }
             state.login = Some(login);
             let ui = UiState {
@@ -11255,6 +11643,29 @@ mod tests {
             };
             draw(&mut frame, scale, &ui, None, None);
             save(&frame, "launcher-meta-editor");
+        }
+
+        // Both lists run to their far end, where the arrows swap over:
+        // the one pointing back into the list lights and the one pointing
+        // off it greys.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let state = library_preview_state();
+            let mut ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            let rect = launcher_panel_rect(&ui).expect("the launcher is up");
+            if let Some(Panel::Launcher(state)) = ui.panel.as_mut() {
+                let pinned = state.setup.whdload_enabled();
+                state.scroll_library(isize::MAX, library_visible_rows(rect, pinned));
+                state.scroll_favourites(isize::MAX, library_favourite_rows(rect, pinned));
+            }
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-whdload-library-scrolled");
         }
 
         // An empty Library page: nothing scanned yet, so Scan is greyed

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -2814,15 +2814,21 @@ fn draw_console(frame: &mut [u8], rect: Rect, panel: &ConsolePanel, scale: usize
     let scaled = scale_rect(entry, scale);
     fill_rect(frame, scaled, ENTRY_BG, scale);
     draw_rect_bevel(frame, scaled, BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, scale);
-    let mut prompt = format!("> {}_", panel.input);
-    prompt.truncate(84);
-    draw_panel_text(
+    // The same caret every other box in the UI draws, at the end of the
+    // line because that is the only place this one can type: the console
+    // appends and backspaces, and keeps its arrow keys for the history.
+    // (It also clips to the box, where the old fixed truncation could cut
+    // a multi-byte character in half and panic.)
+    let prompt = format!("> {}", panel.input);
+    draw_edit_line(
         frame,
         entry.x + 6,
         entry.y + (CONSOLE_INPUT_H - 8) / 2,
         &prompt,
+        prompt.chars().count(),
         ENTRY_TEXT,
-        1,
+        ENTRY_BG,
+        entry.w.saturating_sub(12),
         scale,
     );
 }
@@ -6907,18 +6913,22 @@ fn draw_edit_line(
     }
     let shown: String = shown.into_iter().collect();
     draw_panel_text(frame, x, y, &shown, color, 1, scale);
+    // Half a cell wide: enough to be seen against the text at any scale,
+    // narrow enough to leave most of the character it stands on legible.
+    // It blinks, so it is also read as a caret rather than as a mark in
+    // the value; out of phase, nothing is drawn and the character shows
+    // whole.
+    if !crate::video::caret_lit() {
+        return;
+    }
     let block = Rect {
         x: x + cell * font::GLYPH_W,
         y,
-        w: font::GLYPH_W,
+        w: (font::GLYPH_W / 2).max(1),
         h: font::GLYPH_H,
     };
     fill_rect(frame, scale_rect(block, scale), color, scale);
-    // The character under the block, drawn in the background so the block
-    // reads as inverse video rather than as a character painted out.
-    if let Some(&c) = chars.get(caret) {
-        draw_panel_text(frame, block.x, y, &c.to_string(), bg, 1, scale);
-    }
+    let _ = bg;
 }
 
 /// Clip `text` to `avail_px`, keeping the TAIL and prefixing an ASCII "..."

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -6054,17 +6054,25 @@ fn draw_library_page(
     }
 
     if entries.is_empty() {
-        // What is wrong, then what to do about it, broken where it fits
-        // rather than run off the edge of the box.
-        for (line, text) in [
+        // What is wrong, then what to do about it, broken where it reads:
+        // the launcher panel is a fixed size, so these lines are the same
+        // lines on every machine. Each is still put through the wrap, which
+        // does nothing while they fit and catches them if the box is ever
+        // made narrower than the words in it.
+        let lines = [
             "No games found!",
             "",
-            "Set \"Game library\" in the WHDLoad",
-            "Configuration menu, then press Refresh.",
-        ]
-        .into_iter()
-        .enumerate()
-        {
+            "Update the \"Game library\" directory",
+            "under WHDLoad -> Settings...",
+        ];
+        let lines: Vec<String> = lines
+            .into_iter()
+            .flat_map(|line| match line.is_empty() {
+                true => vec![String::new()],
+                false => wrap_balanced(line, games.w.saturating_sub(16)),
+            })
+            .collect();
+        for (line, text) in lines.into_iter().enumerate() {
             if text.is_empty() {
                 continue;
             }
@@ -6072,7 +6080,7 @@ fn draw_library_page(
                 frame,
                 games.x + 8,
                 games.y + LIBRARY_HEADER_H + 6 + line * 14,
-                &truncate_to_width(text, games.w.saturating_sub(16)),
+                &text,
                 PANEL_TEXT_DIM,
                 1,
                 scale,
@@ -6497,6 +6505,32 @@ fn fit_within(w: usize, h: usize, into: Rect) -> Option<Rect> {
         w: fit_w,
         h: fit_h,
     })
+}
+
+/// The same as [`wrap_to_width`], but with the lines evened up.
+///
+/// A greedy wrap fills each line to the brim and leaves whatever is left
+/// on the last one, which for a sentence a little wider than its box means
+/// a full line and a single trailing word. It takes the same number of
+/// lines to say it with the break in a sensible place, so the column is
+/// narrowed a character at a time for as long as the line count holds.
+#[cfg(feature = "game-library")]
+fn wrap_balanced(text: &str, width: usize) -> Vec<String> {
+    let mut best = wrap_to_width(text, width);
+    if best.len() < 2 {
+        return best;
+    }
+    let lines = best.len();
+    let mut narrow = width;
+    while narrow > font::GLYPH_W {
+        narrow -= font::GLYPH_W;
+        let tried = wrap_to_width(text, narrow);
+        if tried.len() != lines {
+            break;
+        }
+        best = tried;
+    }
+    best
 }
 
 /// Break text into lines that fit `width`, at spaces where there are any.
@@ -9186,6 +9220,35 @@ mod tests {
             launcher_control_at(rect, &state, (past.x as i32 + 40, past.y as i32 + 2)),
             Some(UiControl::LauncherLibraryFavouritePick(rows - 1))
         );
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn a_balanced_wrap_does_not_leave_one_word_alone() {
+        let g = font::GLYPH_W;
+        let text = "Update the \"Game library\" path in the WHDLoad settings";
+        // Greedy: a full line, then the one word that did not fit.
+        let greedy = wrap_to_width(text, 45 * g);
+        assert_eq!(greedy.len(), 2);
+        assert_eq!(greedy[1], "settings");
+
+        // Balanced: the same two lines, broken where it reads.
+        let even = wrap_balanced(text, 45 * g);
+        assert_eq!(even.len(), 2, "the line count is what it was");
+        assert!(
+            even[1].split_whitespace().count() > 1,
+            "still one word alone: {even:?}"
+        );
+        let longest = even.iter().map(|l| l.chars().count()).max().unwrap();
+        assert!(
+            longest < greedy[0].chars().count(),
+            "no narrower than greedy: {even:?}"
+        );
+        // What is said is still what was passed in.
+        assert_eq!(even.join(" "), text);
+
+        // Text that fits is left alone rather than split for the sake of it.
+        assert_eq!(wrap_balanced("Short", 45 * g), vec!["Short".to_string()]);
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1005,6 +1005,10 @@ pub struct App {
     /// starts the list running after a pause, the way a held key does. Any
     /// of the launcher's scrolling lists can be the one being held.
     scroll_hold: Option<(UiControl, Instant)>,
+    /// When the text caret next changes between lit and dark. `None` when
+    /// nothing is being typed into, which is also what puts it back to lit
+    /// for whichever box opens next.
+    caret_flip_at: Option<Instant>,
     /// True while the frame analyzer selector is following a held left
     /// mouse button.
     analyzer_dragging: bool,
@@ -1569,6 +1573,11 @@ fn clipboard_line() -> String {
 #[cfg(feature = "game-library")]
 const STATUS_LINGER: std::time::Duration = std::time::Duration::from_secs(4);
 
+/// How long the text caret stays lit, and then out. Half a second each way
+/// is about the rate a host's own text cursor blinks at; slower reads as
+/// something still loading, faster as something wrong.
+const CARET_BLINK: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// How long the WHDLoad machine-type line stays. Shorter than
 /// [`STATUS_LINGER`]: it explains a setting that has just been changed, and
 /// is read straight away, rather than reporting the end of something that
@@ -1835,6 +1844,7 @@ impl App {
             last_cursor_phys: None,
             volume_dragging: false,
             scroll_hold: None,
+            caret_flip_at: None,
             analyzer_dragging: false,
             mouse_captured: false,
             capture_suspended_by_ui: false,
@@ -3999,11 +4009,14 @@ impl ApplicationHandler for App {
         // A status line waiting to clear itself keeps the loop awake too,
         // or it would sit there until something else woke it.
         let writing_image = self.image_job.is_some() || downloading || self.status_until.is_some();
+        // Likewise the caret: it has no event of its own either, and a panel
+        // with a box open in it is otherwise perfectly still.
+        let typing = self.blink_caret();
         // A held scroll arrow has no event of its own to wake on: the button
         // went down once and the repeats are this loop's own doing.
         let scrolling = self.scroll_hold.is_some();
         event_loop.set_control_flow(
-            if running || osd_active || calibrating || writing_image || scrolling {
+            if running || osd_active || calibrating || writing_image || scrolling || typing {
                 ControlFlow::Poll
             } else {
                 ControlFlow::Wait
@@ -8456,6 +8469,45 @@ impl App {
         }
     }
 
+    /// Blink the caret in whatever is being typed into, and answer whether
+    /// there is anything.
+    ///
+    /// A redraw is asked for when the phase turns over and not otherwise: a
+    /// caret that changes twice a second is no reason to repaint sixty
+    /// times a second. With nothing being typed into it is left lit, so the
+    /// next box to open starts visible rather than starting dark.
+    fn blink_caret(&mut self) -> bool {
+        let typing = self.launcher_state().is_some_and(|state| {
+            #[cfg(feature = "game-library")]
+            let dialog = state.login.is_some() || state.meta.is_some();
+            #[cfg(not(feature = "game-library"))]
+            let dialog = false;
+            state.editing().is_some() || dialog
+        }) || matches!(self.ui.panel, Some(Panel::Console(_)));
+        let light = |on: bool, at: Option<Instant>, app: &mut Self| {
+            app.caret_flip_at = at;
+            if crate::video::caret_lit() != on {
+                crate::video::set_caret_lit(on);
+                app.request_redraw();
+            }
+        };
+        if !typing {
+            light(true, None, self);
+            return false;
+        }
+        let now = Instant::now();
+        match self.caret_flip_at {
+            // Opening a box starts the phase, lit.
+            None => light(true, Some(now + CARET_BLINK), self),
+            Some(at) if now >= at => {
+                let on = !crate::video::caret_lit();
+                light(on, Some(now + CARET_BLINK), self);
+            }
+            Some(_) => {}
+        }
+        true
+    }
+
     /// Say what the WHDLoad machine-type setting just became.
     ///
     /// The row cycles between two words, "Auto" and "Copperline", and a
@@ -8472,9 +8524,9 @@ impl App {
             return;
         };
         let said = match state.setup.whdload_machine() {
-            crate::config::WhdloadMachine::Auto => "WHDLoad uses the Slave file machine type",
+            crate::config::WhdloadMachine::Auto => "WHDLoad uses the Slave file machine type...",
             crate::config::WhdloadMachine::Copperline => {
-                "WHDLoad uses the Copperline defined machine type"
+                "WHDLoad uses the Copperline defined machine type..."
             }
         };
         state.status = Some(StatusMessage::ok(said));

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6261,11 +6261,11 @@ impl App {
             UiControl::LauncherLibraryScroll(delta) => {
                 // How many rows are on screen comes from the panel's own
                 // size, so the scroll stops where the list does.
-                let pinned = self
+                let whdload_entry = self
                     .launcher_state()
                     .is_some_and(|state| state.setup.whdload_enabled());
                 let visible = crate::video::ui::launcher_panel_rect(&self.ui)
-                    .map(|rect| crate::video::ui::library_visible_rows(rect, pinned))
+                    .map(|rect| crate::video::ui::library_visible_rows(rect, whdload_entry))
                     .unwrap_or(1);
                 if let Some(state) = self.launcher_state_mut() {
                     state.scroll_library(delta, visible);
@@ -6307,11 +6307,11 @@ impl App {
             }
             #[cfg(feature = "game-library")]
             UiControl::LauncherLibraryFavouriteScroll(delta) => {
-                let pinned = self
+                let whdload_entry = self
                     .launcher_state()
                     .is_some_and(|state| state.setup.whdload_enabled());
                 let visible = crate::video::ui::launcher_panel_rect(&self.ui)
-                    .map(|rect| crate::video::ui::library_favourite_rows(rect, pinned))
+                    .map(|rect| crate::video::ui::library_favourite_rows(rect, whdload_entry))
                     .unwrap_or(1);
                 if let Some(state) = self.launcher_state_mut() {
                     state.scroll_favourites(delta, visible);
@@ -7045,11 +7045,11 @@ impl App {
             KeyCode::End => isize::MAX,
             _ => return false,
         };
-        let pinned = self
+        let whdload_entry = self
             .launcher_state()
             .is_some_and(|state| state.setup.whdload_enabled());
         let visible = crate::video::ui::launcher_panel_rect(&self.ui)
-            .map(|rect| crate::video::ui::library_visible_rows(rect, pinned))
+            .map(|rect| crate::video::ui::library_visible_rows(rect, whdload_entry))
             .unwrap_or(1);
         if let Some(state) = self.launcher_state_mut() {
             let rows = match step {
@@ -10496,7 +10496,7 @@ impl App {
                 }
                 if let Some(origin) = panel.disasm_addr {
                     lines.push(ui::DbgLine::plain(format!(
-                        "Disassembly pinned at ${origin:06X} (empty box + Enter follows PC)"
+                        "Disassembly whdload_entry at ${origin:06X} (empty box + Enter follows PC)"
                     )));
                 }
                 let breaks = machine.ui_breaks();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4214,7 +4214,14 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
         Some("cue") | Some("iso") | Some("chd") => DroppedMediaKind::Cd,
         Some("hdf") | Some("hdz") | Some("img") => DroppedMediaKind::HardDisk,
         Some("rom") => DroppedMediaKind::Rom,
-        Some("lha") | Some("slave") => DroppedMediaKind::WhdloadGame,
+        // Every shape `package` accepts, or a dropped zip would be taken
+        // for a disk image and handed to the floppy bay.
+        Some(ext)
+            if crate::package::EXTENSIONS.contains(&ext)
+                || crate::package::SLAVE_EXTENSIONS.contains(&ext) =>
+        {
+            DroppedMediaKind::WhdloadGame
+        }
         _ => DroppedMediaKind::Floppy,
     }
 }
@@ -4225,8 +4232,8 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
 /// as given.
 fn whdload_game_config_path(path: PathBuf) -> PathBuf {
     let is_slave = path
-        .extension()
-        .is_some_and(|e| e.eq_ignore_ascii_case("slave"));
+        .file_name()
+        .is_some_and(|name| crate::package::is_slave_name(&name.to_string_lossy()));
     if is_slave {
         if let Some(dir) = path.parent().filter(|d| !d.as_os_str().is_empty()) {
             return dir.to_path_buf();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1526,11 +1526,22 @@ impl ImageToMake {
 
 /// A WHDLoad support archive being fetched, and the row waiting for it.
 #[cfg(feature = "game-library")]
-/// The most any metadata field takes. Long enough for the longest game
-/// title anyone has, short enough that a paste of a whole document does
-/// not become the name of a game.
+/// The most a metadata field takes.
+///
+/// Long enough for the longest game title anyone has, short enough that a
+/// paste of a whole document does not become the name of a game. The
+/// version is shorter still: the page shows it on two lines under the
+/// cover, and there is no use in typing what it cannot show.
 #[cfg(feature = "game-library")]
 const META_FIELD_MAX: usize = 120;
+
+#[cfg(feature = "game-library")]
+fn meta_field_max(field: crate::video::launcher::MetaField) -> usize {
+    match field {
+        crate::video::launcher::MetaField::Version => crate::video::ui::library_version_max(),
+        _ => META_FIELD_MAX,
+    }
+}
 
 /// The first line of the host clipboard, trimmed.
 ///
@@ -6873,7 +6884,10 @@ impl App {
             let line = clipboard_line();
             if let Some(meta) = self.launcher_meta_mut() {
                 let focus = meta.focus;
-                meta.value_mut(focus).push_str(&line);
+                let most = meta_field_max(focus);
+                let value = meta.value_mut(focus);
+                let room = most.saturating_sub(value.chars().count());
+                value.extend(line.chars().take(room));
             }
             self.request_redraw();
             return true;
@@ -6893,9 +6907,10 @@ impl App {
                 meta.value_mut(focus).pop();
             }
             _ => {
+                let most = meta_field_max(focus);
                 for c in text.unwrap_or_default().chars().filter(|c| !c.is_control()) {
                     let value = meta.value_mut(focus);
-                    if value.chars().count() < META_FIELD_MAX {
+                    if value.chars().count() < most {
                         value.push(c);
                     }
                 }
@@ -8034,7 +8049,7 @@ impl App {
         // Named after the package rather than after the bytes, so choosing
         // a different picture replaces the old one instead of leaving it
         // in the cache with nothing pointing at it.
-        let key = format!("manual-{}", crate::gamelib::Database::key_for(&file));
+        let key = crate::gamelib::Database::art_key(&file);
         let cache = state.setup.library_cache(&config);
         let at =
             crate::gamelib::cover::cover_file(&crate::gamelib::scan::covers_path(&cache), &key);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1569,6 +1569,12 @@ fn clipboard_line() -> String {
 #[cfg(feature = "game-library")]
 const STATUS_LINGER: std::time::Duration = std::time::Duration::from_secs(4);
 
+/// How long the WHDLoad machine-type line stays. Shorter than
+/// [`STATUS_LINGER`]: it explains a setting that has just been changed, and
+/// is read straight away, rather than reporting the end of something that
+/// finished while you were looking elsewhere.
+const WHDLOAD_MACHINE_LINGER: std::time::Duration = std::time::Duration::from_secs(3);
+
 /// How long a scroll arrow must be held before it starts repeating. Long
 /// enough that clicking to move one row never runs on by accident, short
 /// enough that holding it does not feel broken -- the pause a host keyboard
@@ -6212,6 +6218,10 @@ impl App {
                         state.status = None;
                     }
                 }
+                // Which machine a WHDLoad game boots on is the one cycle
+                // here whose two settings look alike from the outside: both
+                // say a word, and neither word says what it does.
+                self.say_whdload_machine(field);
             }
             UiControl::LauncherToggle(field) => {
                 if let Some(state) = self.launcher_state_mut() {
@@ -8446,8 +8456,33 @@ impl App {
         }
     }
 
+    /// Say what the WHDLoad machine-type setting just became.
+    ///
+    /// The row cycles between two words, "Auto" and "Copperline", and a
+    /// word is not an explanation: the first takes the machine from the
+    /// slave's own header, the second from whatever this configuration
+    /// describes. The line says which, and takes itself down again -- it
+    /// answers a press, rather than warning of something to be dealt with.
+    fn say_whdload_machine(&mut self, field: crate::video::launcher::LauncherField) {
+        use crate::video::launcher::LauncherField as F;
+        if field != F::WhdloadMachine {
+            return;
+        }
+        let Some(state) = self.launcher_state_mut() else {
+            return;
+        };
+        let said = match state.setup.whdload_machine() {
+            crate::config::WhdloadMachine::Auto => "WHDLoad uses the Slave file machine type",
+            crate::config::WhdloadMachine::Copperline => {
+                "WHDLoad uses the Copperline defined machine type"
+            }
+        };
+        state.status = Some(StatusMessage::ok(said));
+        self.clear_status_in(WHDLOAD_MACHINE_LINGER);
+        self.request_redraw();
+    }
+
     /// Have the status line clear itself after `linger`.
-    #[cfg(feature = "game-library")]
     fn clear_status_in(&mut self, linger: std::time::Duration) {
         self.status_until = Some(std::time::Instant::now() + linger);
     }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6,6 +6,8 @@
 //! wgpu presentation stay on the main thread.
 
 use super::deinterlace::{Deinterlacer, OUT_HEIGHT};
+#[cfg(feature = "game-library")]
+use super::launcher::StatusKind;
 use super::launcher::{LauncherField, LauncherState, MachineSetup, StatusMessage};
 use super::ui::{self, Panel, UiControl, UiState};
 use super::{
@@ -1034,6 +1036,21 @@ pub struct App {
     /// Files from DroppedFile events, coalesced in about_to_wait: winit
     /// delivers one event per file, and a multi-file drop must act once.
     pending_dropped_files: Vec<PathBuf>,
+    /// A support archive being fetched by the WHDLoad page.
+    #[cfg(feature = "game-library")]
+    whdload_job: Option<WhdloadDownload>,
+    /// A library scan, while one is running. Held here rather than in the
+    /// launcher state for the same reason the other jobs are: it owns a
+    /// worker and a channel, neither of which a cloned state could carry.
+    #[cfg(feature = "game-library")]
+    library_scan: Option<crate::gamelib::Scan>,
+    /// A sign-in in flight.
+    #[cfg(feature = "game-library")]
+    login_job: Option<LoginJob>,
+    /// When a status line that reports something finished should go away.
+    /// A failure stays until something replaces it; only a success has a
+    /// reason to clear itself.
+    status_until: Option<std::time::Instant>,
     /// A disk image being written by the launcher's workshop. A large,
     /// fully-allocated image takes long enough that writing it on this
     /// thread would look like a hang, so it runs on a worker and the loop
@@ -1507,6 +1524,52 @@ impl ImageToMake {
     }
 }
 
+/// A WHDLoad support archive being fetched, and the row waiting for it.
+#[cfg(feature = "game-library")]
+/// The most any metadata field takes. Long enough for the longest game
+/// title anyone has, short enough that a paste of a whole document does
+/// not become the name of a game.
+#[cfg(feature = "game-library")]
+const META_FIELD_MAX: usize = 120;
+
+/// The first line of the host clipboard, trimmed.
+///
+/// One line of it: what these boxes hold is a password or a title, not a
+/// document, and a newline in the middle of one is a paste that went wrong.
+#[cfg(feature = "game-library")]
+fn clipboard_line() -> String {
+    match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
+        Ok(text) => text.lines().next().unwrap_or_default().trim().to_string(),
+        Err(e) => {
+            log::warn!("launcher: clipboard unavailable: {e}");
+            String::new()
+        }
+    }
+}
+
+/// How long a status line that reports something finished stays up. Long
+/// enough to read, short enough that it is gone before it can be mistaken
+/// for the state of things now.
+#[cfg(feature = "game-library")]
+const STATUS_LINGER: std::time::Duration = std::time::Duration::from_secs(4);
+
+/// A sign-in in flight: the request runs on a worker so a slow or
+/// unreachable service cannot freeze the launcher mid-dialog.
+#[cfg(feature = "game-library")]
+struct LoginJob {
+    rx: std::sync::mpsc::Receiver<
+        Result<crate::gamelib::openretro::Session, crate::gamelib::openretro::Error>,
+    >,
+}
+
+/// A WHDLoad support archive being fetched, and the row waiting for it.
+#[cfg(feature = "game-library")]
+struct WhdloadDownload {
+    rx: std::sync::mpsc::Receiver<Result<PathBuf, crate::gamelib::support::Error>>,
+    field: crate::video::launcher::LauncherField,
+    archive: crate::gamelib::support::Archive,
+}
+
 /// An image being written on a worker thread, and what to call it when it
 /// lands.
 struct ImageJob {
@@ -1717,6 +1780,13 @@ impl App {
             osd: None,
             drop_hover: false,
             pending_dropped_files: Vec::new(),
+            #[cfg(feature = "game-library")]
+            library_scan: None,
+            #[cfg(feature = "game-library")]
+            login_job: None,
+            status_until: None,
+            #[cfg(feature = "game-library")]
+            whdload_job: None,
             image_job: None,
             disk_playlists,
             disk_write_protected,
@@ -3811,7 +3881,46 @@ impl ApplicationHandler for App {
         // launcher is up with the machine off -- nothing else would wake
         // the loop to notice it finished.
         self.poll_image_job();
-        let writing_image = self.image_job.is_some();
+        #[cfg(feature = "game-library")]
+        self.poll_whdload_download();
+        #[cfg(feature = "game-library")]
+        self.poll_login();
+        #[cfg(feature = "game-library")]
+        self.poll_library_scan();
+        #[cfg(feature = "game-library")]
+        if self
+            .launcher_state_mut()
+            .is_some_and(|state| state.poll_library_covers())
+        {
+            self.request_redraw();
+        }
+        // A line that reported something finished takes itself down.
+        if self
+            .status_until
+            .is_some_and(|at| std::time::Instant::now() >= at)
+        {
+            self.status_until = None;
+            if let Some(state) = self.launcher_state_mut() {
+                state.status = None;
+            }
+            self.request_redraw();
+        }
+        #[cfg(feature = "game-library")]
+        let downloading = self.whdload_job.is_some()
+            || self.library_scan.is_some()
+            || self.login_job.is_some()
+            // A cover on its way needs the loop awake to collect it. It
+            // arrives on a worker, and nothing else would wake the loop to
+            // notice -- which is a picture that only appears the next time
+            // you happen to press something.
+            || self
+                .launcher_state()
+                .is_some_and(|state| state.library.covers.pending());
+        #[cfg(not(feature = "game-library"))]
+        let downloading = false;
+        // A status line waiting to clear itself keeps the loop awake too,
+        // or it would sit there until something else woke it.
+        let writing_image = self.image_job.is_some() || downloading || self.status_until.is_some();
         event_loop.set_control_flow(if running || osd_active || calibrating || writing_image {
             ControlFlow::Poll
         } else {
@@ -4735,8 +4844,33 @@ impl App {
             ),
             // A command line wants held-key repeat for typing and editing.
             Some(ToolPanelKind::Console) => true,
+            #[cfg(feature = "game-library")]
+            _ => self.launcher_accepts_repeat(code),
+            #[cfg(not(feature = "game-library"))]
             _ => false,
         }
+    }
+
+    /// Whether a held key should keep arriving on a launcher page.
+    ///
+    /// The Library list walks with the arrows and speeds up while they are
+    /// held, which needs the repeats to reach it -- without this, holding
+    /// one does nothing at all. The sign-in dialog is a text field, where
+    /// held Backspace clearing a box is what anyone would expect.
+    #[cfg(feature = "game-library")]
+    fn launcher_accepts_repeat(&self, code: KeyCode) -> bool {
+        use crate::video::launcher::LauncherTab;
+        let Some(state) = self.launcher_state() else {
+            return false;
+        };
+        if state.login.is_some() {
+            return true;
+        }
+        state.tab == LauncherTab::WhdloadLibrary
+            && matches!(
+                code,
+                KeyCode::ArrowUp | KeyCode::ArrowDown | KeyCode::Home | KeyCode::End
+            )
     }
 
     fn should_drop_repeated_main_key(
@@ -5973,6 +6107,15 @@ impl App {
                     if tab == crate::video::launcher::LauncherTab::HostDisk {
                         state.setup.refresh_host_disks();
                     }
+                    // Likewise the Library: a package added since the
+                    // launcher opened should be in the list when the page
+                    // is, and the database may have been synced meanwhile.
+                    #[cfg(feature = "game-library")]
+                    if tab == crate::video::launcher::LauncherTab::WhdloadLibrary {
+                        let at = crate::paths::config_dir().unwrap_or_default();
+                        state.library.games = crate::gamelib::Library::default();
+                        state.refresh_library(&at);
+                    }
                 }
             }
             UiControl::LauncherCycle { field, forward } => {
@@ -6035,6 +6178,106 @@ impl App {
                 }
             }
             UiControl::LauncherNewImageCreate(field) => self.launcher_create_image(field),
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherWhdloadDownload(field) => self.whdload_download(field),
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryScroll(delta) => {
+                // How many rows are on screen comes from the panel's own
+                // size, so the scroll stops where the list does.
+                let pinned = self
+                    .launcher_state()
+                    .is_some_and(|state| state.setup.whdload_enabled());
+                let visible = crate::video::ui::launcher_panel_rect(&self.ui)
+                    .map(|rect| crate::video::ui::library_visible_rows(rect, pinned))
+                    .unwrap_or(1);
+                if let Some(state) = self.launcher_state_mut() {
+                    state.scroll_library(delta, visible);
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryPick(drawn) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    let at = state.library.scroll + drawn;
+                    state.select_library_game(at);
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryFavourite(drawn) => {
+                let config = crate::paths::config_dir().unwrap_or_default();
+                if let Some(state) = self.launcher_state_mut() {
+                    let at = state.library.scroll + drawn;
+                    state.toggle_library_favourite(at);
+                    // Written out as it changes, so a favourite survives a
+                    // session that ends any way at all.
+                    state.save_library_database(&config);
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryFavouritePick(drawn) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.select_favourite(drawn);
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryFavouriteRemove(drawn) => {
+                let config = crate::paths::config_dir().unwrap_or_default();
+                if let Some(state) = self.launcher_state_mut() {
+                    state.remove_favourite(drawn);
+                    state.save_library_database(&config);
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryRefresh => self.library_refresh(),
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryUpdate => self.library_update_metadata(),
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherOpenRetroLogin => self.openretro_login_or_out(),
+            #[cfg(feature = "game-library")]
+            UiControl::LoginField(field) => {
+                if let Some(login) = self.launcher_login_mut() {
+                    login.focus = field;
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryEdit => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.edit_commit();
+                    if !state.open_meta_editor() {
+                        state.status = Some(StatusMessage::err("Choose a game first"));
+                    }
+                }
+                self.request_redraw();
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::MetaField(field) => {
+                if let Some(meta) = self.launcher_meta_mut() {
+                    meta.focus = field;
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::MetaArt => self.meta_choose_art(),
+            #[cfg(feature = "game-library")]
+            UiControl::MetaSave => self.meta_save(),
+            #[cfg(feature = "game-library")]
+            UiControl::MetaClear => {
+                if let Some(meta) = self.launcher_meta_mut() {
+                    // Only in the editor: nothing is lost until Save.
+                    meta.values = Default::default();
+                    meta.art = None;
+                }
+                self.request_redraw();
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::MetaCancel => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.meta = None;
+                }
+                self.request_redraw();
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LoginOk => self.login_submit(),
+            #[cfg(feature = "game-library")]
+            UiControl::LoginCancel => self.login_close(),
             UiControl::LauncherFsFamily { field, family } => {
                 if let Some(state) = self.launcher_state_mut() {
                     state.edit_commit();
@@ -6472,6 +6715,12 @@ impl App {
             if self.input_map_handle_key(code) {
                 return true;
             }
+            // So do the launcher's dialogs: each is the only thing being
+            // answered while it is up, Escape included.
+            #[cfg(feature = "game-library")]
+            if self.login_handle_key(code, text) || self.meta_handle_key(code, text) {
+                return true;
+            }
             if code == KeyCode::Escape {
                 // While typing into a plugin option, Escape cancels the edit
                 // rather than closing the panel.
@@ -6507,10 +6756,223 @@ impl App {
             if self.launcher_handle_edit_key(code, text) {
                 return true;
             }
+            #[cfg(feature = "game-library")]
+            if self.library_handle_key(code) {
+                return true;
+            }
             return false;
         }
         self.default_tool_key_kind()
             .is_some_and(|kind| self.ui_handle_tool_key(kind, code))
+    }
+
+    /// Type into the sign-in dialog, and answer it.
+    ///
+    /// Return is OK and Escape is Cancel, Tab moves between the two boxes,
+    /// and everything else goes into whichever has focus. Characters come
+    /// from the text winit gives rather than from key codes, so a keyboard
+    /// that is not the one this was written on still types what it says.
+    #[cfg(feature = "game-library")]
+    fn login_handle_key(&mut self, code: KeyCode, text: Option<&str>) -> bool {
+        use crate::video::launcher::LoginField;
+        if self
+            .launcher_state()
+            .is_none_or(|state| state.login.is_none())
+        {
+            return false;
+        }
+        match code {
+            KeyCode::Escape => {
+                self.login_close();
+                self.request_redraw();
+                return true;
+            }
+            KeyCode::Enter | KeyCode::NumpadEnter => {
+                self.login_submit();
+                self.request_redraw();
+                return true;
+            }
+            _ => {}
+        }
+        // Cmd+V on macOS, Ctrl+V anywhere: a password long enough to be
+        // worth having is a password worth pasting.
+        if code == KeyCode::KeyV
+            && (host_shortcut_modifier_pressed(self.modifiers) || self.modifiers.control_key())
+        {
+            self.login_paste();
+            return true;
+        }
+        let held = host_shortcut_modifier_pressed(self.modifiers) || self.modifiers.control_key();
+        let Some(login) = self.launcher_login_mut() else {
+            return false;
+        };
+        match code {
+            // Anything else typed with a command modifier held is a
+            // shortcut that is not ours, not text.
+            _ if held && code != KeyCode::Tab && code != KeyCode::Backspace => {}
+            KeyCode::Tab => {
+                login.focus = match login.focus {
+                    LoginField::User => LoginField::Pass,
+                    LoginField::Pass => LoginField::User,
+                };
+            }
+            KeyCode::Backspace => match login.focus {
+                LoginField::User => {
+                    login.user.pop();
+                }
+                LoginField::Pass => login.pass.pop(),
+            },
+            _ => {
+                // Printable characters only: a control code typed into a
+                // password is a character nobody can see and nobody meant.
+                let typed = text.unwrap_or_default();
+                for c in typed.chars().filter(|c| !c.is_control()) {
+                    match login.focus {
+                        LoginField::User if login.user.chars().count() < 64 => login.user.push(c),
+                        LoginField::User => {}
+                        LoginField::Pass => login.pass.push(c),
+                    }
+                }
+            }
+        }
+        self.request_redraw();
+        true
+    }
+
+    /// Type into the metadata editor, and answer it.
+    ///
+    /// Return saves, Escape cancels, Tab walks the fields. The same
+    /// shape as the sign-in dialog, because two dialogs that behave
+    /// differently is two things to learn.
+    #[cfg(feature = "game-library")]
+    fn meta_handle_key(&mut self, code: KeyCode, text: Option<&str>) -> bool {
+        use crate::video::launcher::MetaField;
+        if self
+            .launcher_state()
+            .is_none_or(|state| state.meta.is_none())
+        {
+            return false;
+        }
+        match code {
+            KeyCode::Escape => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.meta = None;
+                }
+                self.request_redraw();
+                return true;
+            }
+            KeyCode::Enter | KeyCode::NumpadEnter => {
+                self.meta_save();
+                return true;
+            }
+            _ => {}
+        }
+        if code == KeyCode::KeyV
+            && (host_shortcut_modifier_pressed(self.modifiers) || self.modifiers.control_key())
+        {
+            let line = clipboard_line();
+            if let Some(meta) = self.launcher_meta_mut() {
+                let focus = meta.focus;
+                meta.value_mut(focus).push_str(&line);
+            }
+            self.request_redraw();
+            return true;
+        }
+        let held = host_shortcut_modifier_pressed(self.modifiers) || self.modifiers.control_key();
+        let Some(meta) = self.launcher_meta_mut() else {
+            return false;
+        };
+        let focus = meta.focus;
+        match code {
+            _ if held && code != KeyCode::Tab && code != KeyCode::Backspace => {}
+            KeyCode::Tab => {
+                let at = MetaField::ALL.iter().position(|&f| f == focus).unwrap_or(0);
+                meta.focus = MetaField::ALL[(at + 1) % MetaField::ALL.len()];
+            }
+            KeyCode::Backspace => {
+                meta.value_mut(focus).pop();
+            }
+            _ => {
+                for c in text.unwrap_or_default().chars().filter(|c| !c.is_control()) {
+                    let value = meta.value_mut(focus);
+                    if value.chars().count() < META_FIELD_MAX {
+                        value.push(c);
+                    }
+                }
+            }
+        }
+        self.request_redraw();
+        true
+    }
+
+    /// Paste the host clipboard into whichever box has focus.
+    ///
+    /// One line of it: a password manager hands over a password, not a
+    /// document, and a newline in the middle of one is a paste that went
+    /// wrong rather than a password with a newline in it.
+    #[cfg(feature = "game-library")]
+    fn login_paste(&mut self) {
+        let line = clipboard_line();
+        if let Some(login) = self.launcher_login_mut() {
+            for c in line.chars().filter(|c| !c.is_control()) {
+                match login.focus {
+                    crate::video::launcher::LoginField::User if login.user.chars().count() < 64 => {
+                        login.user.push(c)
+                    }
+                    crate::video::launcher::LoginField::User => {}
+                    crate::video::launcher::LoginField::Pass => login.pass.push(c),
+                }
+            }
+        }
+        self.request_redraw();
+    }
+
+    /// Walk the Library's lists with the arrow keys, and launch with
+    /// Return.
+    ///
+    /// Held, the arrows accelerate the way the wheel does and through the
+    /// same rate: a key repeating is a scroll continuing, and the two
+    /// should not build up at different speeds.
+    #[cfg(feature = "game-library")]
+    fn library_handle_key(&mut self, code: KeyCode) -> bool {
+        use crate::video::launcher::LauncherTab;
+        if self
+            .launcher_state()
+            .is_none_or(|state| state.tab != LauncherTab::WhdloadLibrary)
+        {
+            return false;
+        }
+        // Return launches what is chosen, which is what Run would do: on
+        // this page the selection is the game, so the two are one action.
+        if matches!(code, KeyCode::Enter | KeyCode::NumpadEnter) {
+            self.launcher_run();
+            return true;
+        }
+        let step = match code {
+            KeyCode::ArrowUp => -1,
+            KeyCode::ArrowDown => 1,
+            KeyCode::Home => isize::MIN,
+            KeyCode::End => isize::MAX,
+            _ => return false,
+        };
+        let pinned = self
+            .launcher_state()
+            .is_some_and(|state| state.setup.whdload_enabled());
+        let visible = crate::video::ui::launcher_panel_rect(&self.ui)
+            .map(|rect| crate::video::ui::library_visible_rows(rect, pinned))
+            .unwrap_or(1);
+        if let Some(state) = self.launcher_state_mut() {
+            let rows = match step {
+                isize::MIN | isize::MAX => step,
+                _ => {
+                    let rate = state.library.scroll_rate.rows_for_notch(Instant::now());
+                    step * rate.max(1) as isize
+                }
+            };
+            state.step_library_focus(rows, visible);
+        }
+        self.request_redraw();
+        true
     }
 
     /// Cancel an in-progress plugin-option text edit, if one is focused.
@@ -7314,13 +7776,17 @@ impl App {
             // or a CHD (a raw .bin is a cue sheet's payload, not loadable
             // alone).
             LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "chd"]),
-            // A WHDLoad package as distributed (.lha), or a bare .slave
-            // picked inside an already-extracted one (stored as its
-            // directory, which is what the stager mounts). Both cases
-            // spelled out like the ROM filters.
-            LauncherField::WhdloadGame => {
-                dialog.add_filter("WHDLoad packages", &["lha", "LHA", "slave", "Slave"])
-            }
+            // A WHDLoad package however it arrived: as distributed
+            // (`.lha`), zipped, or as a bare `.slave` picked inside an
+            // already-extracted one (stored as its directory, which is
+            // what the stager mounts). Spelled in both cases like the ROM
+            // filters, since the dialog matches exactly.
+            LauncherField::WhdloadGame => dialog.add_filter(
+                "WHDLoad packages",
+                &[
+                    "lha", "LHA", "lzh", "LZH", "zip", "ZIP", "slave", "Slave", "slav", "Slav",
+                ],
+            ),
             LauncherField::Cd32Nvram => dialog.add_filter("NVRAM images", &["bin", "nv", "sav"]),
             // SCSI units take hard disks or CD images (a cue/iso/chd
             // attaches a CD-ROM drive at that ID).
@@ -7413,6 +7879,421 @@ impl App {
     ///
     /// The file is chosen first: the save dialog is where a user cancels,
     /// and nothing is written until they have named somewhere to write it.
+    /// Fetch a WHDLoad support archive, and point its row at what landed.
+    ///
+    /// On a worker for the same reason an image write is: the archives are
+    /// a megabyte or two over somebody else's link, and a window that stops
+    /// answering is read as a hung program.
+    #[cfg(feature = "game-library")]
+    fn whdload_download(&mut self, field: crate::video::launcher::LauncherField) {
+        use crate::gamelib::support::Archive;
+        let archive = match field {
+            crate::video::launcher::LauncherField::WhdloadWhdPackage => Archive::Whdload,
+            crate::video::launcher::LauncherField::WhdloadSkickPackage => Archive::Skick,
+            _ => return,
+        };
+        if self.whdload_job.is_some() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(crate::gamelib::support::download(archive));
+        });
+        self.whdload_job = Some(WhdloadDownload { rx, field, archive });
+        self.set_launcher_status(crate::video::launcher::StatusMessage::busy(format!(
+            "Downloading {}...",
+            archive.file_name()
+        )));
+    }
+
+    /// Collect a finished download and point the row at it.
+    #[cfg(feature = "game-library")]
+    fn poll_whdload_download(&mut self) {
+        let Some(job) = &self.whdload_job else { return };
+        let landed = match job.rx.try_recv() {
+            Ok(landed) => landed,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                Err(crate::gamelib::support::Error::Fetch("stopped".into()))
+            }
+        };
+        let job = self.whdload_job.take().expect("checked above");
+        let status = match landed {
+            Ok(at) => {
+                info!(
+                    "whdload: fetched {} to {}",
+                    job.archive.file_name(),
+                    at.display()
+                );
+                let name = job.archive.file_name().to_string();
+                if let Some(state) = self.launcher_state_mut() {
+                    state.setup.set_path(job.field, at);
+                }
+                crate::video::launcher::StatusMessage::ok(format!("Downloaded {name}"))
+            }
+            Err(e) => {
+                warn!("whdload: {} download failed: {e}", job.archive.file_name());
+                crate::video::launcher::StatusMessage::err(e.to_string())
+            }
+        };
+        self.set_launcher_status(status);
+        self.request_redraw();
+    }
+
+    /// The one button: sign in when signed out, and out when in.
+    #[cfg(feature = "game-library")]
+    fn openretro_login_or_out(&mut self) {
+        let signed_in = self
+            .launcher_state()
+            .is_some_and(|state| state.openretro.is_some());
+        if !signed_in {
+            if let Some(state) = self.launcher_state_mut() {
+                state.edit_commit();
+                state.login = Some(crate::video::launcher::LoginDialog::default());
+                state.status = None;
+            }
+            return;
+        }
+        // Signing out hands the token back rather than merely forgetting
+        // it, so the session ends at the service too and not just here.
+        // Whatever the dialog was still holding goes with it.
+        self.login_close();
+        self.login_job = None;
+        if let Some(state) = self.launcher_state_mut() {
+            if let Some(session) = state.openretro.take() {
+                match std::sync::Arc::try_unwrap(session) {
+                    // Handing the token back is a request, and a request
+                    // to a service that is not answering must not be the
+                    // launcher standing still. Nothing waits on it.
+                    Ok(session) => {
+                        std::thread::spawn(move || session.close());
+                    }
+                    // A scan still holds it. Dropping our handle is all
+                    // that is left to do; the scan gives it back when it
+                    // finishes with it.
+                    Err(shared) => drop(shared),
+                }
+            }
+        }
+        // And a scan running on that session has nothing to sync with.
+        self.stop_library_scan();
+        self.set_launcher_status(StatusMessage::ok("Logged out of OpenRetro"));
+        self.clear_status_in(STATUS_LINGER);
+        self.request_redraw();
+    }
+
+    /// The dialog being typed into, if one is up.
+    #[cfg(feature = "game-library")]
+    fn launcher_login_mut(&mut self) -> Option<&mut crate::video::launcher::LoginDialog> {
+        self.launcher_state_mut()?.login.as_mut()
+    }
+
+    #[cfg(feature = "game-library")]
+    fn launcher_meta_mut(&mut self) -> Option<&mut crate::video::launcher::MetaDialog> {
+        self.launcher_state_mut()?.meta.as_mut()
+    }
+
+    /// Choose a picture for the selected game, and put it in the cache
+    /// under a name of its own.
+    ///
+    /// PNG only, because a PNG decoder is all Copperline carries. The file
+    /// is decoded before it is kept, so what goes into the cache is
+    /// something that will draw rather than something that merely has the
+    /// right extension.
+    #[cfg(feature = "game-library")]
+    fn meta_choose_art(&mut self) {
+        let Some(picked) = rfd::FileDialog::new()
+            .set_title("Choose cover art")
+            .add_filter("PNG image", &["png"])
+            .pick_file()
+        else {
+            return;
+        };
+        let config = crate::paths::config_dir().unwrap_or_default();
+        let Some(state) = self.launcher_state_mut() else {
+            return;
+        };
+        let Some(file) = state.meta.as_ref().map(|meta| meta.file.clone()) else {
+            return;
+        };
+        let png = match std::fs::read(&picked) {
+            Ok(png) => png,
+            Err(e) => {
+                log::warn!("game library: cannot read {}: {e}", picked.display());
+                state.status = Some(StatusMessage::err("Could not read that file"));
+                return;
+            }
+        };
+        // Brought to the same bound the fetched covers have, so the cache
+        // holds one kind of thing and a photograph of a box does not sit
+        // in there at several megabytes.
+        let Some(png) = crate::gamelib::cover::normalise(&png) else {
+            state.status = Some(StatusMessage::err("Cover art must be a PNG image"));
+            return;
+        };
+        // Named after the package rather than after the bytes, so choosing
+        // a different picture replaces the old one instead of leaving it
+        // in the cache with nothing pointing at it.
+        let key = format!("manual-{}", crate::gamelib::Database::key_for(&file));
+        let cache = state.setup.library_cache(&config);
+        let at =
+            crate::gamelib::cover::cover_file(&crate::gamelib::scan::covers_path(&cache), &key);
+        if let Err(e) = crate::paths::ensure_parent(&at).and_then(|()| std::fs::write(&at, &png)) {
+            log::warn!("game library: cannot write {}: {e}", at.display());
+            state.status = Some(StatusMessage::err("Could not save that image"));
+            return;
+        }
+        if let Some(meta) = &mut state.meta {
+            meta.art = Some(key.clone());
+        }
+        // Drop whatever was held under that name, so the new picture is
+        // read rather than the one it replaced.
+        state.library.covers.forget_one(&key);
+        state.status = None;
+        self.request_redraw();
+    }
+
+    /// Commit the editor and write the store.
+    #[cfg(feature = "game-library")]
+    fn meta_save(&mut self) {
+        let config = crate::paths::config_dir().unwrap_or_default();
+        if let Some(state) = self.launcher_state_mut() {
+            state.commit_meta_editor();
+            state.save_library_database(&config);
+            // The list is rebuilt so a changed name sorts where it belongs.
+            state.library.games = Default::default();
+            state.refresh_library(&config);
+            state.status = Some(StatusMessage::ok("Metadata saved"));
+        }
+        self.clear_status_in(STATUS_LINGER);
+        self.request_redraw();
+    }
+
+    /// Put the dialog away, wiping what was typed on the way out rather
+    /// than leaving it for the allocator to hand on.
+    #[cfg(feature = "game-library")]
+    fn login_close(&mut self) {
+        if let Some(state) = self.launcher_state_mut() {
+            if let Some(login) = &mut state.login {
+                login.pass.clear();
+            }
+            state.login = None;
+        }
+    }
+
+    /// Trade what was typed for a token, on a worker.
+    #[cfg(feature = "game-library")]
+    fn login_submit(&mut self) {
+        if self.login_job.is_some() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        let Some(state) = self.launcher_state_mut() else {
+            return;
+        };
+        let Some(login) = &mut state.login else {
+            return;
+        };
+        if login.user.trim().is_empty() || login.pass.is_empty() {
+            state.status = Some(StatusMessage::err("Enter a username and a password"));
+            return;
+        }
+        login.sending = true;
+        let user = login.user.trim().to_string();
+        // Moved to the worker rather than copied: `Secret` is not `Clone`
+        // for exactly this reason, and taking it leaves the dialog holding
+        // an empty one.
+        let pass = std::mem::take(&mut login.pass);
+        state.status = Some(StatusMessage::busy("Logging in to OpenRetro..."));
+        std::thread::spawn(move || {
+            let opened = crate::gamelib::openretro::Session::open(
+                &user,
+                &pass,
+                crate::gamelib::openretro::DEVICE_ID,
+            );
+            drop(pass);
+            let _ = tx.send(opened);
+        });
+        self.login_job = Some(LoginJob { rx });
+    }
+
+    /// Collect a finished sign-in.
+    #[cfg(feature = "game-library")]
+    fn poll_login(&mut self) {
+        let Some(job) = &self.login_job else { return };
+        let landed = match job.rx.try_recv() {
+            Ok(landed) => landed,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => Err(
+                crate::gamelib::openretro::Error::Offline("the request stopped".into()),
+            ),
+        };
+        self.login_job = None;
+        let status = match landed {
+            Ok(session) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.openretro = Some(std::sync::Arc::new(session));
+                }
+                StatusMessage::ok("Logged in to OpenRetro")
+            }
+            Err(e) => {
+                // The status bar gets the one thing to do something
+                // about; the log gets the whole of it.
+                log::warn!("openretro: sign-in failed: {e}");
+                StatusMessage::err(match e {
+                    crate::gamelib::openretro::Error::Unauthorized => "Wrong username or password",
+                    _ => "Could not reach OpenRetro",
+                })
+            }
+        };
+        self.login_close();
+        self.set_launcher_status(status);
+        self.clear_status_in(STATUS_LINGER);
+        self.request_redraw();
+    }
+
+    /// Re-read the game folder. Cheap: it lists files and reads back what
+    /// the last scan resolved, and asks the service nothing.
+    #[cfg(feature = "game-library")]
+    fn library_refresh(&mut self) {
+        let config = crate::paths::config_dir().unwrap_or_default();
+        let Some(state) = self.launcher_state_mut() else {
+            return;
+        };
+        let (found, fresh) = state.rescan_library(&config);
+        state.status = Some(match (found, fresh) {
+            (0, _) => StatusMessage::err("No packages found in the game library"),
+            (found, 0) => StatusMessage::ok(format!("Found {found} games")),
+            (found, fresh) => {
+                StatusMessage::ok(format!("Found {found} games, {fresh} without metadata"))
+            }
+        });
+        self.clear_status_in(STATUS_LINGER);
+        self.request_redraw();
+    }
+
+    /// Resolve metadata and art for everything in the game folder.
+    #[cfg(feature = "game-library")]
+    fn library_update_metadata(&mut self) {
+        if self.library_scan.is_some() {
+            return;
+        }
+        let config = crate::paths::config_dir().unwrap_or_default();
+        let Some(state) = self.launcher_state() else {
+            return;
+        };
+        let Some(folder) = state.library_folder() else {
+            self.set_launcher_status(StatusMessage::err("No game library set"));
+            self.clear_status_in(STATUS_LINGER);
+            return;
+        };
+        let cache = state.setup.library_cache(&config);
+        let session = state.openretro.clone();
+        // What the last scan worked out about each package, so this one
+        // opens only the archives it has not seen.
+        let held = state
+            .library
+            .db
+            .known()
+            .iter()
+            .filter_map(|k| Some((k.file.clone(), k.slave_sha1.clone()?)))
+            .collect();
+        self.library_scan = Some(crate::gamelib::Scan::start(folder, cache, session, held));
+        self.set_launcher_status(StatusMessage::busy("Starting the scan..."));
+        self.request_redraw();
+    }
+
+    /// Move a scan along, and take its results as they arrive.
+    ///
+    /// Every message is acted on rather than only the newest: a poll that
+    /// catches up on several at once still carries the one that delivered
+    /// the metadata, and dropping it would lose a whole scan's work. Only
+    /// the last one's wording reaches the status line, which is the part
+    /// that genuinely only wants the newest.
+    #[cfg(feature = "game-library")]
+    fn poll_library_scan(&mut self) {
+        use crate::gamelib::Progress;
+        let Some(scan) = &self.library_scan else {
+            return;
+        };
+        let said = scan.poll();
+        if said.is_empty() {
+            return;
+        }
+        let config = crate::paths::config_dir().unwrap_or_default();
+        let mut status = None;
+        for progress in said {
+            let text = progress.message();
+            let kind = match progress {
+                // The metadata, as soon as it is known: names, years and
+                // publishers fill in while the art is still being
+                // fetched, and a scan interrupted after this point has
+                // still delivered everything but the pictures.
+                Progress::Matched { known, .. } => {
+                    if let Some(state) = self.launcher_state_mut() {
+                        state.library.db.set_known(known);
+                        state.save_library_database(&config);
+                        // Rebuilt against what was just resolved, so a
+                        // changed name sorts where it now belongs.
+                        state.library.games = Default::default();
+                        state.refresh_library(&config);
+                    }
+                    StatusKind::Busy
+                }
+                // Art that has just landed: only the ones that came back
+                // empty are looked for again, so nothing already decoded
+                // is thrown away and read a second time.
+                Progress::Art { .. } => {
+                    if let Some(state) = self.launcher_state_mut() {
+                        state.library.covers.forget_missing();
+                    }
+                    StatusKind::Busy
+                }
+                Progress::Done { complete, .. } => {
+                    if let Some(state) = self.launcher_state_mut() {
+                        state.library.covers.forget();
+                    }
+                    self.library_scan = None;
+                    match complete {
+                        true => StatusKind::Ok,
+                        false => StatusKind::Busy,
+                    }
+                }
+                Progress::Failed(_) => {
+                    self.library_scan = None;
+                    StatusKind::Error
+                }
+                _ => StatusKind::Busy,
+            };
+            status = Some(StatusMessage { text, kind });
+        }
+        if let Some(status) = status {
+            let settled = !matches!(status.kind, StatusKind::Busy);
+            self.set_launcher_status(status);
+            if settled {
+                self.clear_status_in(STATUS_LINGER);
+            }
+        }
+        self.request_redraw();
+    }
+
+    /// Stop a scan and forget it. Pressing Run is the end of the launcher,
+    /// and a worker fetching art for a page nobody is looking at is work
+    /// taken from the machine that was just started.
+    #[cfg(feature = "game-library")]
+    fn stop_library_scan(&mut self) {
+        if let Some(scan) = self.library_scan.take() {
+            scan.stop();
+            log::info!("game library: scan stopped");
+        }
+    }
+
+    /// Have the status line clear itself after `linger`.
+    #[cfg(feature = "game-library")]
+    fn clear_status_in(&mut self, linger: std::time::Duration) {
+        self.status_until = Some(std::time::Instant::now() + linger);
+    }
+
     fn launcher_create_image(&mut self, field: crate::video::launcher::LauncherField) {
         use crate::video::launcher::LauncherField as F;
         // Whatever is half-typed counts: pressing a button is as much an
@@ -7610,6 +8491,13 @@ impl App {
                         // Re-read host device lists so the loaded setup's pickers
                         // are populated, not stuck on "Default"/"None".
                         state.setup.refresh_host_devices();
+                        // The loaded configuration may name a different
+                        // library and a different cache. Everything the
+                        // page held belongs to the one before it.
+                        #[cfg(feature = "game-library")]
+                        {
+                            state.library = Default::default();
+                        }
                         state.status = Some(StatusMessage::ok(format!(
                             "Loaded {}",
                             display_file_name(&path)
@@ -7688,6 +8576,11 @@ impl App {
                 return;
             }
         }
+        // Whoever pressed Run is done with the launcher, and a scan still
+        // fetching art would be taking host time from the machine that is
+        // about to start.
+        #[cfg(feature = "game-library")]
+        self.stop_library_scan();
         let raw = match self.launcher_state().map(|s| s.setup.to_raw()) {
             Some(raw) => raw,
             None => return,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1000,6 +1000,11 @@ pub struct App {
     /// needs the un-mapped coordinate alongside the mapped pixel.
     last_cursor_phys: Option<winit::dpi::PhysicalPosition<f64>>,
     volume_dragging: bool,
+    /// A scroll arrow held down: which control, and when its next repeat is
+    /// due. A click moves one row and lets go; keeping the button down
+    /// starts the list running after a pause, the way a held key does. Any
+    /// of the launcher's scrolling lists can be the one being held.
+    scroll_hold: Option<(UiControl, Instant)>,
     /// True while the frame analyzer selector is following a held left
     /// mouse button.
     analyzer_dragging: bool,
@@ -1564,6 +1569,51 @@ fn clipboard_line() -> String {
 #[cfg(feature = "game-library")]
 const STATUS_LINGER: std::time::Duration = std::time::Duration::from_secs(4);
 
+/// How long a scroll arrow must be held before it starts repeating. Long
+/// enough that clicking to move one row never runs on by accident, short
+/// enough that holding it does not feel broken -- the pause a host keyboard
+/// takes before a held key repeats.
+const SCROLL_HOLD_DELAY: std::time::Duration = std::time::Duration::from_millis(350);
+/// The gap between repeats thereafter. Well inside the window
+/// [`ScrollRate`](crate::video::launcher::ScrollRate) counts as one
+/// continued scroll, so the run builds through its stages while the button
+/// is down rather than restarting under it.
+const SCROLL_HOLD_EVERY: std::time::Duration = std::time::Duration::from_millis(60);
+
+/// Which of the launcher's scrolling lists an arrow belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollList {
+    #[cfg(feature = "game-library")]
+    Games,
+    #[cfg(feature = "game-library")]
+    Favourites,
+    HostDisks,
+}
+
+/// Whether a control is a scroll arrow, and if so which way it goes (`-1`
+/// up, `1` down) and which list it drives.
+fn scroll_arrow_of(control: UiControl) -> Option<(isize, ScrollList)> {
+    match control {
+        #[cfg(feature = "game-library")]
+        UiControl::LauncherLibraryScroll(d) => Some((d.signum(), ScrollList::Games)),
+        #[cfg(feature = "game-library")]
+        UiControl::LauncherLibraryFavouriteScroll(d) => Some((d.signum(), ScrollList::Favourites)),
+        UiControl::LauncherHostDiskScroll(d) => Some((d.signum(), ScrollList::HostDisks)),
+        _ => None,
+    }
+}
+
+/// The control that scrolls `list` by `rows`.
+fn scroll_arrow_for(list: ScrollList, rows: isize) -> UiControl {
+    match list {
+        #[cfg(feature = "game-library")]
+        ScrollList::Games => UiControl::LauncherLibraryScroll(rows),
+        #[cfg(feature = "game-library")]
+        ScrollList::Favourites => UiControl::LauncherLibraryFavouriteScroll(rows),
+        ScrollList::HostDisks => UiControl::LauncherHostDiskScroll(rows),
+    }
+}
+
 /// A sign-in in flight: the request runs on a worker so a slow or
 /// unreachable service cannot freeze the launcher mid-dialog.
 #[cfg(feature = "game-library")]
@@ -1778,6 +1828,7 @@ impl App {
             last_display_cursor_pos: None,
             last_cursor_phys: None,
             volume_dragging: false,
+            scroll_hold: None,
             analyzer_dragging: false,
             mouse_captured: false,
             capture_suspended_by_ui: false,
@@ -3381,6 +3432,7 @@ impl ApplicationHandler for App {
                         let was_volume_dragging = self.volume_dragging;
                         self.volume_dragging = false;
                         self.analyzer_dragging = false;
+                        self.scroll_hold = None;
                         if was_volume_dragging {
                             return;
                         }
@@ -3391,6 +3443,14 @@ impl ApplicationHandler for App {
                         if let Some(control) =
                             self.cursor_pos.and_then(|p| self.main_ui_control_at(p))
                         {
+                            // A scroll arrow keeps running while it is held,
+                            // and a fresh press starts the ramp again rather
+                            // than picking up the speed the last one reached.
+                            if scroll_arrow_of(control).is_some() {
+                                self.scroll_hold =
+                                    Some((control, Instant::now() + SCROLL_HOLD_DELAY));
+                                self.reset_scroll_rate(control);
+                            }
                             self.activate_ui_control_with_event_loop(control, Some(event_loop));
                             self.ensure_tool_windows_for_open_panels(event_loop);
                             return;
@@ -3898,6 +3958,7 @@ impl ApplicationHandler for App {
         self.poll_login();
         #[cfg(feature = "game-library")]
         self.poll_library_scan();
+        self.repeat_held_scroll();
         #[cfg(feature = "game-library")]
         if self
             .launcher_state_mut()
@@ -3932,11 +3993,16 @@ impl ApplicationHandler for App {
         // A status line waiting to clear itself keeps the loop awake too,
         // or it would sit there until something else woke it.
         let writing_image = self.image_job.is_some() || downloading || self.status_until.is_some();
-        event_loop.set_control_flow(if running || osd_active || calibrating || writing_image {
-            ControlFlow::Poll
-        } else {
-            ControlFlow::Wait
-        });
+        // A held scroll arrow has no event of its own to wake on: the button
+        // went down once and the repeats are this loop's own doing.
+        let scrolling = self.scroll_hold.is_some();
+        event_loop.set_control_flow(
+            if running || osd_active || calibrating || writing_image || scrolling {
+                ControlFlow::Poll
+            } else {
+                ControlFlow::Wait
+            },
+        );
         if writing_image && !running {
             // Nothing else paces the loop while the machine is off; check
             // back at a human rate rather than spinning a core on it.
@@ -6226,15 +6292,29 @@ impl App {
             #[cfg(feature = "game-library")]
             UiControl::LauncherLibraryFavouritePick(drawn) => {
                 if let Some(state) = self.launcher_state_mut() {
-                    state.select_favourite(drawn);
+                    let at = state.library.favourite_scroll + drawn;
+                    state.select_favourite(at);
                 }
             }
             #[cfg(feature = "game-library")]
             UiControl::LauncherLibraryFavouriteRemove(drawn) => {
                 let config = crate::paths::config_dir().unwrap_or_default();
                 if let Some(state) = self.launcher_state_mut() {
-                    state.remove_favourite(drawn);
+                    let at = state.library.favourite_scroll + drawn;
+                    state.remove_favourite(at);
                     state.save_library_database(&config);
+                }
+            }
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryFavouriteScroll(delta) => {
+                let pinned = self
+                    .launcher_state()
+                    .is_some_and(|state| state.setup.whdload_enabled());
+                let visible = crate::video::ui::launcher_panel_rect(&self.ui)
+                    .map(|rect| crate::video::ui::library_favourite_rows(rect, pinned))
+                    .unwrap_or(1);
+                if let Some(state) = self.launcher_state_mut() {
+                    state.scroll_favourites(delta, visible);
                 }
             }
             #[cfg(feature = "game-library")]
@@ -6246,7 +6326,7 @@ impl App {
             #[cfg(feature = "game-library")]
             UiControl::LoginField(field) => {
                 if let Some(login) = self.launcher_login_mut() {
-                    login.focus = field;
+                    login.focus_on(field);
                 }
             }
             #[cfg(feature = "game-library")]
@@ -6262,7 +6342,7 @@ impl App {
             #[cfg(feature = "game-library")]
             UiControl::MetaField(field) => {
                 if let Some(meta) = self.launcher_meta_mut() {
-                    meta.focus = field;
+                    meta.focus_on(field);
                 }
             }
             #[cfg(feature = "game-library")]
@@ -6785,7 +6865,7 @@ impl App {
     /// that is not the one this was written on still types what it says.
     #[cfg(feature = "game-library")]
     fn login_handle_key(&mut self, code: KeyCode, text: Option<&str>) -> bool {
-        use crate::video::launcher::LoginField;
+        use crate::video::launcher::{CaretMove, LoginField};
         if self
             .launcher_state()
             .is_none_or(|state| state.login.is_none())
@@ -6821,28 +6901,22 @@ impl App {
             // Anything else typed with a command modifier held is a
             // shortcut that is not ours, not text.
             _ if held && code != KeyCode::Tab && code != KeyCode::Backspace => {}
-            KeyCode::Tab => {
-                login.focus = match login.focus {
-                    LoginField::User => LoginField::Pass,
-                    LoginField::Pass => LoginField::User,
-                };
-            }
-            KeyCode::Backspace => match login.focus {
-                LoginField::User => {
-                    login.user.pop();
-                }
-                LoginField::Pass => login.pass.pop(),
-            },
+            KeyCode::Tab => login.focus_on(match login.focus {
+                LoginField::User => LoginField::Pass,
+                LoginField::Pass => LoginField::User,
+            }),
+            KeyCode::Backspace => login.backspace(),
+            KeyCode::Delete => login.delete(),
+            KeyCode::ArrowLeft => login.caret_move(CaretMove::Left),
+            KeyCode::ArrowRight => login.caret_move(CaretMove::Right),
+            KeyCode::Home => login.caret_move(CaretMove::Home),
+            KeyCode::End => login.caret_move(CaretMove::End),
             _ => {
                 // Printable characters only: a control code typed into a
                 // password is a character nobody can see and nobody meant.
                 let typed = text.unwrap_or_default();
                 for c in typed.chars().filter(|c| !c.is_control()) {
-                    match login.focus {
-                        LoginField::User if login.user.chars().count() < 64 => login.user.push(c),
-                        LoginField::User => {}
-                        LoginField::Pass => login.pass.push(c),
-                    }
+                    login.insert(c);
                 }
             }
         }
@@ -6857,7 +6931,7 @@ impl App {
     /// differently is two things to learn.
     #[cfg(feature = "game-library")]
     fn meta_handle_key(&mut self, code: KeyCode, text: Option<&str>) -> bool {
-        use crate::video::launcher::MetaField;
+        use crate::video::launcher::{CaretMove, MetaField};
         if self
             .launcher_state()
             .is_none_or(|state| state.meta.is_none())
@@ -6883,11 +6957,10 @@ impl App {
         {
             let line = clipboard_line();
             if let Some(meta) = self.launcher_meta_mut() {
-                let focus = meta.focus;
-                let most = meta_field_max(focus);
-                let value = meta.value_mut(focus);
-                let room = most.saturating_sub(value.chars().count());
-                value.extend(line.chars().take(room));
+                let most = meta_field_max(meta.focus);
+                for c in line.chars().filter(|c| !c.is_control()) {
+                    meta.insert(c, most);
+                }
             }
             self.request_redraw();
             return true;
@@ -6901,18 +6974,26 @@ impl App {
             _ if held && code != KeyCode::Tab && code != KeyCode::Backspace => {}
             KeyCode::Tab => {
                 let at = MetaField::ALL.iter().position(|&f| f == focus).unwrap_or(0);
-                meta.focus = MetaField::ALL[(at + 1) % MetaField::ALL.len()];
+                meta.focus_on(MetaField::ALL[(at + 1) % MetaField::ALL.len()]);
             }
             KeyCode::Backspace => {
-                meta.value_mut(focus).pop();
+                let mut caret = meta.caret;
+                caret.backspace(meta.value_mut(focus));
+                meta.caret = caret;
             }
+            KeyCode::Delete => {
+                let mut caret = meta.caret;
+                caret.delete(meta.value_mut(focus));
+                meta.caret = caret;
+            }
+            KeyCode::ArrowLeft => meta.caret_move(CaretMove::Left),
+            KeyCode::ArrowRight => meta.caret_move(CaretMove::Right),
+            KeyCode::Home => meta.caret_move(CaretMove::Home),
+            KeyCode::End => meta.caret_move(CaretMove::End),
             _ => {
                 let most = meta_field_max(focus);
                 for c in text.unwrap_or_default().chars().filter(|c| !c.is_control()) {
-                    let value = meta.value_mut(focus);
-                    if value.chars().count() < most {
-                        value.push(c);
-                    }
+                    meta.insert(c, most);
                 }
             }
         }
@@ -6930,13 +7011,7 @@ impl App {
         let line = clipboard_line();
         if let Some(login) = self.launcher_login_mut() {
             for c in line.chars().filter(|c| !c.is_control()) {
-                match login.focus {
-                    crate::video::launcher::LoginField::User if login.user.chars().count() < 64 => {
-                        login.user.push(c)
-                    }
-                    crate::video::launcher::LoginField::User => {}
-                    crate::video::launcher::LoginField::Pass => login.pass.push(c),
-                }
+                login.insert(c);
             }
         }
         self.request_redraw();
@@ -6945,8 +7020,8 @@ impl App {
     /// Walk the Library's lists with the arrow keys, and launch with
     /// Return.
     ///
-    /// Held, the arrows accelerate the way the wheel does and through the
-    /// same rate: a key repeating is a scroll continuing, and the two
+    /// Held, the arrows accelerate through the same rate the scroll-arrow
+    /// buttons use: a key repeating is a scroll continuing, and the two
     /// should not build up at different speeds.
     #[cfg(feature = "game-library")]
     fn library_handle_key(&mut self, code: KeyCode) -> bool {
@@ -6980,7 +7055,7 @@ impl App {
             let rows = match step {
                 isize::MIN | isize::MAX => step,
                 _ => {
-                    let rate = state.library.scroll_rate.rows_for_notch(Instant::now());
+                    let rate = state.library.scroll_rate.rows_for_step(Instant::now());
                     step * rate.max(1) as isize
                 }
             };
@@ -7008,6 +7083,7 @@ impl App {
     /// Feed a key to a focused plugin-option text field. Returns false (so the
     /// key falls through) when no field is being edited.
     fn launcher_handle_edit_key(&mut self, code: KeyCode, text: Option<&str>) -> bool {
+        use crate::video::launcher::CaretMove;
         let handled = {
             let Some(state) = self.launcher_state_mut() else {
                 return false;
@@ -7017,7 +7093,12 @@ impl App {
             }
             match code {
                 KeyCode::Backspace => state.edit_backspace(),
+                KeyCode::Delete => state.edit_delete(),
                 KeyCode::Enter | KeyCode::NumpadEnter => state.edit_commit(),
+                KeyCode::ArrowLeft => state.edit_caret_move(CaretMove::Left),
+                KeyCode::ArrowRight => state.edit_caret_move(CaretMove::Right),
+                KeyCode::Home => state.edit_caret_move(CaretMove::Home),
+                KeyCode::End => state.edit_caret_move(CaretMove::End),
                 _ => {
                     // Prefer the layout- and shift-aware text the platform
                     // reports, so volume names can contain lowercase letters,
@@ -8226,6 +8307,68 @@ impl App {
     /// the last one's wording reaches the status line, which is the part
     /// that genuinely only wants the newest.
     #[cfg(feature = "game-library")]
+    /// The rate the given list's scrolling runs at.
+    fn scroll_rate_of(
+        &mut self,
+        list: ScrollList,
+    ) -> Option<&mut crate::video::launcher::ScrollRate> {
+        let state = self.launcher_state_mut()?;
+        Some(match list {
+            #[cfg(feature = "game-library")]
+            ScrollList::Games => &mut state.library.scroll_rate,
+            #[cfg(feature = "game-library")]
+            ScrollList::Favourites => &mut state.library.favourite_scroll_rate,
+            ScrollList::HostDisks => state.setup.host_disk_scroll_rate(),
+        })
+    }
+
+    /// Put a list's scrolling back to its first stage, for a press that is
+    /// deliberately a new one.
+    fn reset_scroll_rate(&mut self, control: UiControl) {
+        let Some((_, list)) = scroll_arrow_of(control) else {
+            return;
+        };
+        if let Some(rate) = self.scroll_rate_of(list) {
+            rate.reset();
+        }
+    }
+
+    /// Keep a held scroll arrow running.
+    ///
+    /// The button going down scrolled one row already; this is what happens
+    /// if it is not let go. Nothing moves for [`SCROLL_HOLD_DELAY`], so a
+    /// deliberate single click stays a single row, and after that a repeat
+    /// lands every [`SCROLL_HOLD_EVERY`] -- close enough together that the
+    /// list's [`ScrollRate`](crate::video::launcher::ScrollRate) counts them
+    /// as one run and works through its stages, exactly as it does for a
+    /// held arrow key. Letting go, or sliding off the arrow, stops it.
+    fn repeat_held_scroll(&mut self) {
+        let Some((control, due)) = self.scroll_hold else {
+            return;
+        };
+        let Some((direction, list)) = scroll_arrow_of(control) else {
+            return;
+        };
+        // Sliding off the arrow stops it, the way letting go does: a button
+        // that kept firing from under the pointer would be a button you
+        // cannot get away from.
+        if self.cursor_pos.and_then(|p| self.main_ui_control_at(p)) != Some(control) {
+            self.scroll_hold = None;
+            return;
+        }
+        let now = Instant::now();
+        if now < due {
+            return;
+        }
+        self.scroll_hold = Some((control, now + SCROLL_HOLD_EVERY));
+        let Some(rate) = self.scroll_rate_of(list) else {
+            return;
+        };
+        let rows = direction * rate.rows_for_step(now).max(1) as isize;
+        self.activate_ui_control_with_event_loop(scroll_arrow_for(list, rows), None);
+        self.request_redraw();
+    }
+
     fn poll_library_scan(&mut self) {
         use crate::gamelib::Progress;
         let Some(scan) = &self.library_scan else {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -6281,7 +6281,6 @@ fn dropped_media_classifies_by_extension() {
     assert_eq!(kind("game.dms"), DroppedMediaKind::Floppy);
     assert_eq!(kind("dump.scp"), DroppedMediaKind::Floppy);
     assert_eq!(kind("game.adf.gz"), DroppedMediaKind::Floppy);
-    assert_eq!(kind("game.zip"), DroppedMediaKind::Floppy);
     assert_eq!(kind("mystery"), DroppedMediaKind::Floppy);
     assert_eq!(kind("game.CUE"), DroppedMediaKind::Cd);
     assert_eq!(kind("game.iso"), DroppedMediaKind::Cd);
@@ -6289,9 +6288,16 @@ fn dropped_media_classifies_by_extension() {
     assert_eq!(kind("disk.HDZ"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("disk.img"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("kick31.rom"), DroppedMediaKind::Rom);
+    // Every shape a WHDLoad package comes in, since the launcher and the
+    // CLI take all of them: a dropped zip used to be handed to the floppy
+    // bay as a disk image.
     assert_eq!(kind("game.lha"), DroppedMediaKind::WhdloadGame);
     assert_eq!(kind("Game.LHA"), DroppedMediaKind::WhdloadGame);
+    assert_eq!(kind("game.lzh"), DroppedMediaKind::WhdloadGame);
+    assert_eq!(kind("game.zip"), DroppedMediaKind::WhdloadGame);
+    assert_eq!(kind("game.ZIP"), DroppedMediaKind::WhdloadGame);
     assert_eq!(kind("x.slave"), DroppedMediaKind::WhdloadGame);
+    assert_eq!(kind("x.slav"), DroppedMediaKind::WhdloadGame);
 }
 
 #[test]

--- a/src/whdload.rs
+++ b/src/whdload.rs
@@ -99,6 +99,13 @@ pub fn find_whdboot_assets() -> Option<WhdbootAssets> {
         }
     }
 
+    // Where the launcher's Download button and tools/fetch-whdload.sh put
+    // them. Tried before the development tree so a fetched copy wins over
+    // a stale checked-out one.
+    if let Some(dir) = crate::paths::whdload_support_dir() {
+        dirs.push(dir);
+    }
+
     dirs.push(PathBuf::from("assets").join("whdboot"));
 
     dirs.into_iter().find_map(|dir| {
@@ -478,6 +485,31 @@ pub struct PreparedGame {
     pub staged_kicks: Vec<String>,
 }
 
+/// The library directory a package unpacks into.
+///
+/// An `.lha` keeps the bare stem it has always used, so no existing
+/// library entry moves -- the entry is where saves live, and relocating
+/// one makes a person's savegames look lost.
+///
+/// Anything else keeps its extension. Somebody holding the same game as
+/// both an `.lha` and a `.zip` has a duplicate, which is their business:
+/// it lists twice and both play, with a set of saves each, rather than
+/// the second one refusing to start because the first had taken the name.
+fn library_entry_name(game: &Path) -> String {
+    let name = |part: Option<&std::ffi::OsStr>| {
+        part.map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    };
+    let keeps_stem = matches!(
+        crate::package::Kind::of(game),
+        Some(crate::package::Kind::Lha)
+    );
+    sanitize_game_name(&match keeps_stem {
+        true => name(game.file_stem()),
+        false => name(game.file_name()),
+    })
+}
+
 /// Keep a game's library directory name readable and filesystem-safe.
 fn sanitize_game_name(stem: &str) -> String {
     let name: String = stem
@@ -520,7 +552,12 @@ fn find_slaves(dir: &Path) -> Result<Vec<PathBuf>> {
                 .extension()
                 .is_some_and(|e| e.eq_ignore_ascii_case("slave"))
             {
-                out.push(path.strip_prefix(root).unwrap().to_path_buf());
+                let rel = path.strip_prefix(root).unwrap().to_path_buf();
+                // `__MACOSX/._Foo.Slave` ends in `.Slave` and sorts before
+                // the real one. Booting it starts nothing.
+                if !crate::package::is_rubbish(&rel) {
+                    out.push(rel);
+                }
             }
         }
         Ok(())
@@ -599,13 +636,32 @@ pub fn game_and_options(raw: &RawConfig) -> (Option<PathBuf>, Options) {
             library,
             kickstart_dirs,
             extra_args: raw.whdload.args.clone(),
-            assets: None,
+            assets: configured_assets(raw),
         },
     )
 }
 
-/// Stage `game` (an `.lha` archive or a directory holding a `.slave`) and
-/// return the mountable result.
+/// The support archives the configuration names, if it names either.
+///
+/// `None` leaves [`prepare`] to search, which is what an installation that
+/// has never been told anything wants. Naming one and not the other is
+/// meant to work: the half that was named is used, and the half that was
+/// not still comes from the search.
+fn configured_assets(raw: &RawConfig) -> Option<WhdbootAssets> {
+    let whd = raw.whdload.whd_package.as_ref().map(PathBuf::from);
+    let skick = raw.whdload.skick_package.as_ref().map(PathBuf::from);
+    if whd.is_none() && skick.is_none() {
+        return None;
+    }
+    let found = find_whdboot_assets();
+    Some(WhdbootAssets {
+        whdload_archive: whd.or_else(|| found.as_ref().map(|f| f.whdload_archive.clone()))?,
+        skick_archive: skick.or_else(|| found.and_then(|f| f.skick_archive)),
+    })
+}
+
+/// Stage `game` -- an `.lha` or `.zip` archive, or a directory holding a
+/// `.slave` -- and return the mountable result.
 pub fn prepare(game: &Path, opts: &Options) -> Result<PreparedGame> {
     if !game.exists() {
         bail!("WHDLoad game {} does not exist", game.display());
@@ -616,14 +672,43 @@ pub fn prepare(game: &Path, opts: &Options) -> Result<PreparedGame> {
             whdload_archive: assets.whdload_archive.clone(),
             skick_archive: assets.skick_archive.clone(),
         },
-        None => find_whdboot_assets().with_context(|| {
-            format!(
-                "the WHDLoad support archive {WHDLOAD_USR_ARCHIVE} was not found; \
-                 run tools/fetch-whdload.sh (development) or reinstall Copperline \
-                 (release bundles include it), or point COPPERLINE_WHDBOOT_DIR at \
-                 a directory holding it"
-            )
-        })?,
+        None => match find_whdboot_assets() {
+            Some(assets) => assets,
+            None => {
+                // The status bar gets the one sentence that says what is
+                // wrong; what to do about it goes to the log, where there
+                // is room for it.
+                log::error!(
+                    "whdload: {WHDLOAD_USR_ARCHIVE} was not found. Press Download on \
+                     the WHDLoad page, run tools/fetch-whdload.sh, or point \
+                     COPPERLINE_WHDBOOT_DIR at a directory holding it."
+                );
+                bail!("Missing WHDLoad support archive");
+            }
+        },
+    };
+    // A path that was configured and then moved or deleted fails the same
+    // way as one that was never there, and says the same thing.
+    if !assets.whdload_archive.is_file() {
+        log::error!(
+            "whdload: {} is not there. Set [whdload] whd_package, or clear it and \
+             press Download on the WHDLoad page.",
+            assets.whdload_archive.display()
+        );
+        bail!("Missing WHDLoad support archive");
+    }
+    let assets = WhdbootAssets {
+        skick_archive: assets.skick_archive.filter(|skick| {
+            skick.is_file() || {
+                log::warn!(
+                    "whdload: missing SKick support archive at {}; Kickstart images \
+                     will be staged without .RTB relocation tables",
+                    skick.display()
+                );
+                false
+            }
+        }),
+        ..assets
     };
 
     let library = match &opts.library {
@@ -636,11 +721,7 @@ pub fn prepare(game: &Path, opts: &Options) -> Result<PreparedGame> {
             )?,
     };
 
-    let stem = game
-        .file_stem()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let game_home = library.join(sanitize_game_name(&stem));
+    let game_home = library.join(library_entry_name(game));
 
     // --- Game volume -------------------------------------------------------
     let game_dir = if game.is_dir() {
@@ -689,7 +770,7 @@ pub fn prepare(game: &Path, opts: &Options) -> Result<PreparedGame> {
             }
             std::fs::create_dir_all(&staging)
                 .with_context(|| format!("creating {}", staging.display()))?;
-            let files = lha::extract_to_dir(game, &staging)
+            let files = crate::package::extract_to_dir(game, &staging)
                 .with_context(|| format!("extracting {}", game.display()))?;
             std::fs::rename(&staging, &dest)
                 .with_context(|| format!("promoting extraction into {}", dest.display()))?;
@@ -850,9 +931,8 @@ pub fn prepare(game: &Path, opts: &Options) -> Result<PreparedGame> {
     }
     if assets.skick_archive.is_none() && !staged_kicks.is_empty() {
         log::warn!(
-            "whdload: {SKICK_ARCHIVE} not found next to {}; Kickstart images staged \
-             without .RTB relocation tables",
-            assets.whdload_archive.display()
+            "whdload: missing SKick support archive ({SKICK_ARCHIVE}); Kickstart \
+             images staged without .RTB relocation tables"
         );
     }
 
@@ -927,6 +1007,39 @@ pub fn apply_to_raw(raw: &mut RawConfig, prepared: &PreparedGame) {
 
 #[cfg(test)]
 mod tests {
+    /// Somebody's own WHDLoad and Soft-Kicker archives are used, not
+    /// overridden by the copies Copperline knows how to fetch.
+    ///
+    /// The pinned digests are a convenience for getting started, not a
+    /// requirement: a person testing a new WHDLoad release, or one who
+    /// keeps their own build, points the configuration at it and that is
+    /// what gets staged.
+    #[test]
+    fn a_hand_set_support_archive_is_the_one_used() {
+        use crate::config::RawConfig;
+        let mut raw = RawConfig::default();
+        assert!(
+            super::configured_assets(&raw).is_none(),
+            "an unconfigured build should search rather than insist"
+        );
+
+        raw.whdload.whd_package = Some("/my/WHDLoad_usr.lha".to_string());
+        raw.whdload.skick_package = Some("/my/skick.lha".to_string());
+        let assets = super::configured_assets(&raw).expect("both were named");
+        assert_eq!(assets.whdload_archive, Path::new("/my/WHDLoad_usr.lha"));
+        assert_eq!(
+            assets.skick_archive.as_deref(),
+            Some(Path::new("/my/skick.lha"))
+        );
+
+        // Naming one and not the other works: the half that was named is
+        // used and the other still comes from the search, so somebody
+        // testing a new WHDLoad keeps the Soft-Kicker they already had.
+        raw.whdload.skick_package = None;
+        let assets = super::configured_assets(&raw).expect("one was named");
+        assert_eq!(assets.whdload_archive, Path::new("/my/WHDLoad_usr.lha"));
+    }
+
     use super::*;
     use crate::lha::tests::{build_lha, temp_dir};
 

--- a/src/whdload.rs
+++ b/src/whdload.rs
@@ -496,17 +496,20 @@ pub struct PreparedGame {
 /// it lists twice and both play, with a set of saves each, rather than
 /// the second one refusing to start because the first had taken the name.
 fn library_entry_name(game: &Path) -> String {
-    let name = |part: Option<&std::ffi::OsStr>| {
-        part.map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_default()
-    };
+    let file = game
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    // By name, not by asking the filesystem: the caller has already
+    // established this is a file, and `stem_of` drops only an extension
+    // this recognises -- `S.W.I.V.lha` keeps its dots.
     let keeps_stem = matches!(
-        crate::package::Kind::of(game),
+        crate::package::Kind::of_name(&file),
         Some(crate::package::Kind::Lha)
     );
-    sanitize_game_name(&match keeps_stem {
-        true => name(game.file_stem()),
-        false => name(game.file_name()),
+    sanitize_game_name(match keeps_stem {
+        true => crate::package::stem_of(&file),
+        false => &file,
     })
 }
 
@@ -621,9 +624,7 @@ pub fn game_and_options(raw: &RawConfig) -> (Option<PathBuf>, Options) {
                     }
                 }
             }
-            let lib = library
-                .clone()
-                .or_else(|| crate::paths::config_dir().map(|d| d.join("whdload")));
+            let lib = library.clone().or_else(crate::paths::whdload_save_dir);
             if let Some(lib) = lib {
                 kickstart_dirs.push(lib.join("Kickstarts"));
             }
@@ -713,12 +714,10 @@ pub fn prepare(game: &Path, opts: &Options) -> Result<PreparedGame> {
 
     let library = match &opts.library {
         Some(dir) => dir.clone(),
-        None => crate::paths::config_dir()
-            .map(|dir| dir.join("whdload"))
-            .context(
-                "no per-user directory available for the WHDLoad game library; \
+        None => crate::paths::whdload_save_dir().context(
+            "no per-user directory available for the WHDLoad game library; \
                  set [whdload] library in the configuration",
-            )?,
+        )?,
     };
 
     let game_home = library.join(library_entry_name(game));
@@ -1014,6 +1013,29 @@ mod tests {
     /// requirement: a person testing a new WHDLoad release, or one who
     /// keeps their own build, points the configuration at it and that is
     /// what gets staged.
+    #[test]
+    fn each_package_format_unpacks_somewhere_of_its_own() {
+        // Holding the same game as both an .lha and a .zip is a
+        // duplicate, which is the person's business: both play, with a set
+        // of saves each. The .lha keeps the bare-stem entry it has always
+        // used, so no existing library moves -- that is where saves live.
+        assert_eq!(
+            library_entry_name(Path::new("/g/GoldenAxe_v1.lha")),
+            "GoldenAxe_v1"
+        );
+        assert_eq!(
+            library_entry_name(Path::new("/g/GoldenAxe_v1.zip")),
+            "GoldenAxe_v1.zip"
+        );
+        assert_ne!(
+            library_entry_name(Path::new("/g/GoldenAxe_v1.lha")),
+            library_entry_name(Path::new("/g/GoldenAxe_v1.zip"))
+        );
+        // Only a recognised extension comes off, so a title with dots in
+        // it keeps them.
+        assert_eq!(library_entry_name(Path::new("/g/S.W.I.V.lha")), "S.W.I.V");
+    }
+
     #[test]
     fn a_hand_set_support_archive_is_the_one_used() {
         use crate::config::RawConfig;

--- a/src/whdload.rs
+++ b/src/whdload.rs
@@ -969,18 +969,24 @@ pub fn remember_game(raw: &mut RawConfig, game: &Path) {
 /// configuration (a `[machine]` profile, `rom`, `[memory]` sizes, CLI
 /// overrides, which land in the raw config before this) always wins.
 pub fn apply_to_raw(raw: &mut RawConfig, prepared: &PreparedGame) {
-    if raw.machine.profile.is_none() {
+    // `machine_type = "copperline"` means what it says: boot the package on
+    // the machine this configuration describes, whatever that is. The two
+    // staged volumes below still go on -- without them there is nothing to
+    // boot -- but nothing here decides the machine.
+    let derive =
+        raw.whdload.machine_type.unwrap_or_default() == crate::config::WhdloadMachine::Auto;
+    if derive && raw.machine.profile.is_none() {
         // The canonical WHDLoad host: 68020 + AGA satisfies every slave
         // requirement flag, and OCS/ECS programs run under the slave's own
         // hardware bending, exactly as on a real A1200.
         raw.machine.profile = Some("A1200".to_string());
     }
-    if raw.memory.fast.is_none() {
+    if derive && raw.memory.fast.is_none() {
         // Preload wants room for the whole game on top of ws_ExpMem; the
         // full Zorro II 8 MiB is the canonical WHDLoad recommendation.
         raw.memory.fast = Some("8M".to_string());
     }
-    if raw.rom.is_none() {
+    if derive && raw.rom.is_none() {
         match &prepared.machine_rom {
             Some(rom) => raw.rom = Some(rom.to_string_lossy().into_owned()),
             None => log::warn!(
@@ -1600,5 +1606,47 @@ mod tests {
         assert_eq!(raw.machine.profile.as_deref(), Some("A4000"));
         assert_eq!(raw.memory.fast.as_deref(), Some("2M"));
         assert_eq!(raw.rom.as_deref(), Some("my.rom"));
+    }
+
+    /// `machine_type = "copperline"` boots the package on the machine the
+    /// configuration describes, which includes the parts of it that were
+    /// never named: nothing is derived, not even into empty fields.
+    #[test]
+    fn machine_type_copperline_derives_nothing_but_still_mounts() {
+        let prepared = PreparedGame {
+            boot_dir: PathBuf::from("/lib/game/boot"),
+            game_dir: PathBuf::from("/lib/game/game"),
+            slave_rel: PathBuf::from("Game.Slave"),
+            slave: SlaveInfo::default(),
+            machine_rom: Some(PathBuf::from(
+                "/lib/game/boot/Devs/Kickstarts/kick40068.A1200",
+            )),
+            staged_kicks: vec![],
+        };
+        let mut raw = RawConfig::default();
+        raw.whdload.machine_type = Some(crate::config::WhdloadMachine::Copperline);
+        apply_to_raw(&mut raw, &prepared);
+        assert_eq!(raw.machine.profile, None, "the machine is the config's");
+        assert_eq!(raw.memory.fast, None);
+        assert_eq!(raw.rom, None, "including which ROM it boots");
+
+        // The volumes are not part of the machine: without them the game
+        // has nothing to boot from, whichever setting is chosen.
+        assert_eq!(raw.filesys.len(), 2);
+        assert_eq!(raw.filesys[0].volume.as_deref(), Some(BOOT_VOLUME));
+        assert_eq!(raw.filesys[1].volume.as_deref(), Some(GAME_VOLUME));
+
+        // Auto is the default, and derives as before.
+        let mut raw = RawConfig::default();
+        raw.whdload.machine_type = Some(crate::config::WhdloadMachine::Auto);
+        apply_to_raw(&mut raw, &prepared);
+        assert_eq!(raw.machine.profile.as_deref(), Some("A1200"));
+        let mut raw = RawConfig::default();
+        apply_to_raw(&mut raw, &prepared);
+        assert_eq!(
+            raw.machine.profile.as_deref(),
+            Some("A1200"),
+            "unset = auto"
+        );
     }
 }


### PR DESCRIPTION
# WHDLoad: a game library

_This has turned into a fairly meaty change, but I can't stress enough the time and effort which has gone into making this feel like a more "grown up" emulator experience as far as launching a game library directly using WHDLoad along with automatic cover art and metadata._ 



Boot a WHDLoad game as an `.lha`, a `.zip`, or a plain folder, and browse a
collection of them from the launcher with details and cover art from
OpenRetro.

Based on `main` at 19072d1. Sixteen commits, each building and testing on its
own.

## Packages

Three shapes, treated identically from the CLI and the launcher:

```sh
copperline --whdload Turrican.lha
copperline --whdload Turrican.zip
copperline --whdload Turrican/
```

The `.slave` is searched for rather than assumed — a published `.lha` has it
at the archive root, a zip made from an unpacked one usually a folder or two
down. `.lzh` counts as `.lha` and `.slav` as `.slave`. macOS's `__MACOSX/`
and `._name` stubs are filtered everywhere, including the on-disk search:
one of them is called `._Something.Slave`, it ends in `.Slave`, and it sorts
before the real one.

Keeping the same game as both an `.lha` and a `.zip` is a duplicate, not an
error: it lists twice, both play, each with its own unpacked copy and saves.

**On the `zip` dependency.** Hand-rolling a reader was considered: ~150 lines
against the `flate2` already in the tree, matching how this codebase handles
SHA-1, SHA-256 and base64. The crate won on reliability — real zips carry
zip64, odd encodings and mixed compression methods, and an archive somebody
downloaded is not a format worth being clever about.

## The Library page

WHDLoad moves out of Storage into its own navigation entry, opening on the
**Library**, with **Settings...** the second button on its own nav row.

Nothing scans on its own — a folder of several thousand packages takes long
enough to read that a page which did it on every tab change would stall.
**Refresh** re-reads the folder; **Scan** resolves details against OpenRetro
and fetches missing art; **Update** edits one game's details, including its
cover. Games can be starred into a favourites list, per package rather than
per title, so one release of a game can be marked without marking the others.

**A/V & Emu → Emulation → WHDLoad** is on by default. Off, the entry goes and
the pages behind it do nothing at all: no store read, no cover worker, no
scan. `--whdload` and `[whdload] game` still boot — those are explicit
instructions and scripts depend on them.

Saves default to `whdload/save/`, beside the `whdload/support/` the archives
live in. An installation with games directly under `whdload/` keeps using
them where they are.

## Matching

By the SHA-1 of a package's slave where the catalogue knows it, and by name
otherwise. OpenRetro's WHDLoad file lists were imported in 2015 and slaves
are revised with every release, so almost nothing matches by digest today; it
is computed anyway, because it is also how a package is recognised after it
has been renamed.

Name matching handles what installers and cataloguers disagree about — case,
`CamelCase`, the `_v1.5_1234` stamp, articles, `&` against "and", roman
numerals either way round — then a catalogue title whose words all appear in
order in the package name, then edit distance at 80%. Skyscraper uses 65%
there; measured against a real library that is too loose (it pairs
`UltimateGolf` with "The Ultimate Quiz").

**3753 of 4144 packages (90%) in 148 ms**, on a real collection. Of thirty
loose matches read by hand, twenty-seven are plainly right. A correction made
in the editor survives both a rescan and a rename.

## Versions

A collection carries the same game several times over, and every copy matches
the same catalogue entry. Where the library holds a *named* game under one
title more than once, **Version** is filled in from the package's file name
(without its extension) and can be edited to whatever tells them apart. A
game held once has no version, and neither has one the scan could not name.

## Credentials

An OpenRetro account is only needed to sync the database; cover art is
public. Nothing is stored: the password is traded for a token and both live
in a buffer allocated once at full width so typing cannot leave prefixes in
freed heap, wiped on drop with volatile writes, never printed. Signing out
hands the token back. HTTPS is pinned — fs-uae-launcher's own client defaults
to plain HTTP here.

## Feature gate

`game-library`, on by default. It is the only part of Copperline that makes
network requests of its own, so it is the only part that needs an HTTP client
and a TLS stack. Off: 623 crates → 338, no Library page, and `[whdload]` keys
only it uses are parsed and ignored so a configuration written by a full
build still loads.

## TLS, per platform

`ureq` is declared per target: rustls everywhere but Windows, where it is
native-tls — schannel through pure-Rust bindings.

rustls alone would have been simpler, but its crypto provider is `ring`,
which compiles C and assembly, and ring's `build.rs` hard-switches to clang
on ARM64 Windows:

```rust
// FIXME: On Windows AArch64 we currently must use Clang to compile C code
```

That makes a default build fail on a machine carrying exactly the toolchain
Rust itself asks for. Nothing in the schannel path needs a C compiler, and
Linux keeps the property rustls was chosen for: no system OpenSSL, no extra
Flatpak runtime.

Trust anchors do not vary with the platform. Both backends are pointed at the
Mozilla root set `webpki-roots` bundles rather than the host's own store, so
what is trusted is identical everywhere and only the implementation differs.

Every client comes from one constructor, `gamelib::http::agent`, because ureq
defaults to Rustls whatever is compiled in and never selects native-tls on
its own — a second agent built by hand would work on Linux and macOS and
panic on Windows. A test reads the sibling sources and fails if a second
`config_builder` appears, since that is not a mistake running the code can
catch.

## Sync limits

A record's inflated JSON is capped at 16 MiB, which is a decompression-bomb
guard rather than a statement about the data. Measured across the whole
catalogue: 22,420 records over 45 pages, median 829 bytes, 99th percentile
33 KB, and one record of 6.38 MiB — a 2013 import carrying an enormous file
list. The cap clears the largest real record by two and a half times and
still leaves three orders of magnitude before a page could hurt.

## Two changes outside WHDLoad

Both are in their own commits and either could be split out.

**A caret in every text box.** The launcher's boxes appended: typing went to
the end, Backspace took from the end, so a path one character wrong had to be
retyped from the mistake onwards — worst in the details editor, which exists
to amend what a scan got close to. They now share a caret: Left/Right,
Home/End, Delete, insert at the caret, drawn as a half-cell bar that blinks,
with the window on a long value following it. The same editor serves the
Create Image pages, drive names, boot priorities, the serial Connect/Listen
boxes from #426, and the debugger console's prompt. `Secret` gained indexed
insert and remove so the masked password steps through its asterisks without
the plaintext leaving the type.

**Lists that keep scrolling.** Holding a scroll arrow repeats after the pause
a held key takes, through five speeds a second apart; letting go and pressing
again starts from the slowest. One `ScrollRate` serves the WHDLoad games, the
favourites and the host-disk picker, and the host-disk picker's arrows move
out of that page into one function all three lists draw with. The favourites
list could not scroll at all before.

## Two fixes outside the feature

- **The 8×8 font drew a blank cell for anything outside printable ASCII**, so
  catalogue titles like "Hägar the Horrible" and "Ishidó" read as spelling
  mistakes. Non-ASCII is folded to the nearest ASCII at the drawing stage,
  and measured as it is drawn so nothing laid out against a width moves.
- **The panel's word wrapper truncated a word longer than its column** rather
  than breaking it.

## Verification

- Golden Axe boots from `.lha`, `.zip` and a folder with Kickstart 3.1
  staged; zip and folder produce byte-identical frames. A-10 Tank Killer
  boots to its title screen, staging `kick34005.A500` and `kick40068.A1200`.
  The ROM identification from #427 names the image in the same run's banner:
  the two identification paths compose untouched — `romdb` says what a ROM is
  called, WHDLoad's CRC-16 says which file a slave is asking for.
- 4144-package library: 90% matched in 148 ms. 2252-package library: 1824
  covers fetched in 22 s. Store with 5000 entries: 1.3 MB, opens in 5 ms.
- SHA-1 checked against the published vectors and every block-padding
  boundary.
- Tested end to end on macOS, Windows (arm64) and Linux. On Windows the TLS path is
  schannel: against `aarch64-pc-windows-msvc`, `ring` leaves the dependency
  graph and `schannel` enters it.
- `cargo fmt --check`, `clippy --all-targets`, the full suite (2457 unit
  tests) and the feature-off build are clean.

## Notes for review

- New dependencies: `ureq` with `rustls`/`native-tls` and `zeroize` (behind
  `game-library`), `zip` (unconditional, for package reading).
- `[whdload]` gains `enabled`, `games`, `library_db`, `library_cache`,
  `machine_type`, `whd_package`, `skick_package`.
- Upstream's ROM-note row and value-box generalisation are kept as they are;
  the test asserting WHDLoad hangs off Storage is replaced by one for its own
  strip entry, and `ui.md`'s Storage sub-page count follows it.
- `library_db` holds favourites and hand-edited details and is not
  disposable; `library_cache` is, and is rebuilt by the next scan.
- Cover art you supply must be a PNG; Copperline carries no JPEG decoder.


<img width="719" height="612" alt="Screenshot 2026-08-10 at 19 04 55" src="https://github.com/user-attachments/assets/59109ae7-c0ed-42bb-a9c7-84621fa3a570" />
<img width="719" height="621" alt="Screenshot 2026-08-10 at 19 05 28" src="https://github.com/user-attachments/assets/e6410604-ffd2-4642-80a5-7eb35d55dedf" />
<img width="718" height="615" alt="Screenshot 2026-08-10 at 19 06 46" src="https://github.com/user-attachments/assets/fb11bd20-3c29-4735-ab97-2d75bd2bea3e" />
<img width="718" height="618" alt="Screenshot 2026-08-10 at 19 11 35" src="https://github.com/user-attachments/assets/96ab3069-f980-4d9c-b2e0-5cf804c0f0a4" />
<img width="723" height="579" alt="Screenshot 2026-08-10 at 19 18 47" src="https://github.com/user-attachments/assets/4f05fd6e-abf1-4a03-9ffd-4cca53e6904d" />
