### PR TITLE
launcher: A-Z shortcuts for WHDLoad games

### DIFF
--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -132,6 +132,10 @@ can be starred without starring the others.
 
 Select a game and press **Run** to play it.
 
+Once there are twenty games or more, a row of letter buttons appears
+above the list. Click one to jump to the first game starting with it;
+letters your collection has no games under are greyed.
+
 ### Where the details come from
 
 **Scan** matches each of your games against the OpenRetro database, mostly

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -132,9 +132,11 @@ can be starred without starring the others.
 
 Select a game and press **Run** to play it.
 
-Once there are twenty games or more, a row of letter buttons appears
-above the list. Click one to jump to the first game starting with it;
-letters your collection has no games under are greyed.
+Once there are twenty games or more, a row of shortcut buttons appears
+above the list: **0-9** for games whose names start with a number, then
+**#** for anything starting with neither a number nor a letter, then A to
+Z. Click one to jump to the first game under it. Buttons your collection
+has nothing under are greyed.
 
 ### Where the details come from
 

--- a/src/gamelib/db.rs
+++ b/src/gamelib/db.rs
@@ -127,6 +127,12 @@ pub struct Database {
     /// so the page can tell the two apart: a store built somewhere else is
     /// not this folder's list, whatever it holds. Absent in stores written
     /// before this was kept, which reads the same as "somewhere else".
+    ///
+    /// Reading is derived; writing is not. [`to_readable_json`] emits this
+    /// file field by field, so a field added here and not added there is
+    /// simply never saved, whatever its serde attribute says -- which for
+    /// this one meant a store that came from nowhere on every launch, and
+    /// a Refresh needed every time to see a list that had not changed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     folder: Option<String>,
     /// Sorted by `file`, which is what makes this store fast to open: the
@@ -950,6 +956,11 @@ pub fn strip_package_name(file_name: &str) -> String {
 fn to_readable_json(db: &Database) -> std::io::Result<String> {
     let mut out = String::from("{\n");
     out.push_str(&format!("  \"format\": {},\n", db.format));
+    if let Some(folder) = &db.folder {
+        out.push_str("  \"folder\": ");
+        out.push_str(&encode(folder)?);
+        out.push_str(",\n");
+    }
     out.push_str("  \"favourites\": ");
     out.push_str(&encode(&db.favourites)?);
     out.push_str(",\n  \"known\": [\n");
@@ -1013,6 +1024,32 @@ fn hex(bytes: &[u8; 16]) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// The folder a store was listed from survives being written and read.
+    ///
+    /// If it did not, every launch would meet a store that claimed to come
+    /// from nowhere and would show no games until Refresh -- which is the
+    /// whole list, every time.
+    #[test]
+    fn the_folder_a_store_lists_survives_a_round_trip() {
+        let at =
+            std::env::temp_dir().join(format!("copperline-db-folder-{}.json", std::process::id()));
+        let mut db = Database::new();
+        db.set_known(vec![Known {
+            file: "Turrican.lha".to_string(),
+            game: None,
+            manual: false,
+            slave_sha1: None,
+        }]);
+        db.set_folder(Path::new("/games/mine"));
+        db.save(&at).unwrap();
+
+        let back = Database::load(&at);
+        assert!(back.lists(Path::new("/games/mine")), "the folder was lost");
+        assert!(!back.lists(Path::new("/games/other")));
+        assert_eq!(back.known().len(), 1);
+        let _ = std::fs::remove_file(&at);
+    }
+
     /// Two packages that differ only in punctuation get different art.
     ///
     /// The key was the path with every separator flattened to `_`, which

--- a/src/gamelib/db.rs
+++ b/src/gamelib/db.rs
@@ -120,6 +120,15 @@ pub struct Database {
     /// a path, which is the state it most needs to be removable from.
     #[serde(default)]
     favourites: std::collections::BTreeMap<String, String>,
+    /// The game folder the known entries were listed from.
+    ///
+    /// Entries are filed by their path under that folder, so pointed at a
+    /// different one they describe packages that are not there. Remembered
+    /// so the page can tell the two apart: a store built somewhere else is
+    /// not this folder's list, whatever it holds. Absent in stores written
+    /// before this was kept, which reads the same as "somewhere else".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    folder: Option<String>,
     /// Sorted by `file`, which is what makes this store fast to open: the
     /// order comes off disk with the parse and lookup is a binary search,
     /// so there is no index to build before the page can draw.
@@ -135,6 +144,7 @@ impl Default for Database {
         Database {
             format: FORMAT,
             favourites: std::collections::BTreeMap::new(),
+            folder: None,
             known: Vec::new(),
         }
     }
@@ -289,6 +299,16 @@ impl Database {
     }
 
     /// Whether a package is a favourite.
+    /// Whether the known entries were listed from `folder`.
+    pub fn lists(&self, folder: &Path) -> bool {
+        self.folder.as_deref() == Some(&*folder.to_string_lossy())
+    }
+
+    /// Record which folder the known entries were listed from.
+    pub fn set_folder(&mut self, folder: &Path) {
+        self.folder = Some(folder.to_string_lossy().into_owned());
+    }
+
     pub fn is_favourite(&self, file: &str) -> bool {
         self.favourites.contains_key(file)
     }

--- a/src/video/font.rs
+++ b/src/video/font.rs
@@ -152,7 +152,7 @@ pub fn renderable(text: &str) -> std::borrow::Cow<'_, str> {
 
 /// One non-ASCII character as printable ASCII. Empty for a combining
 /// mark, which has already been applied to the letter before it.
-fn fold(c: char) -> &'static str {
+pub fn fold(c: char) -> &'static str {
     match c {
         'À'..='Å' | 'à'..='å' | 'Ā' | 'ā' | 'Ă' | 'ă' | 'Ą' | 'ą' => {
             if c.is_uppercase() {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5151,6 +5151,38 @@ impl ScrollRate {
     }
 }
 
+/// The buckets the A-Z shortcut row offers, in the order it draws them.
+///
+/// Digits first, then everything that starts with neither a digit nor a
+/// letter, then the alphabet. A game is filed by the first character of the
+/// name the list shows for it, so what you click matches what you read.
+#[cfg(feature = "game-library")]
+pub const AZ_BUCKETS: usize = 28;
+
+/// The label on bucket `at`.
+#[cfg(feature = "game-library")]
+pub fn az_label(at: usize) -> &'static str {
+    const LETTERS: [&str; 26] = [
+        "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
+        "S", "T", "U", "V", "W", "X", "Y", "Z",
+    ];
+    match at {
+        0 => "0-9",
+        1 => "#",
+        _ => LETTERS.get(at - 2).copied().unwrap_or("#"),
+    }
+}
+
+/// Which bucket a title belongs to.
+#[cfg(feature = "game-library")]
+pub fn az_bucket_of(title: &str) -> usize {
+    match title.chars().next() {
+        Some(c) if c.is_ascii_digit() => 0,
+        Some(c) if c.is_ascii_alphabetic() => 2 + (c.to_ascii_uppercase() as usize - 'A' as usize),
+        _ => 1,
+    }
+}
+
 /// Which way a caret is being stepped.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaretMove {
@@ -6290,6 +6322,35 @@ impl LauncherState {
         let last_start = self.library.games.len().saturating_sub(visible);
         let at = self.library.scroll as isize + delta;
         self.library.scroll = at.clamp(0, last_start as isize) as usize;
+    }
+
+    /// Which buckets the list has games in, so the row can grey the rest.
+    pub fn az_buckets_present(&self) -> [bool; AZ_BUCKETS] {
+        let mut present = [false; AZ_BUCKETS];
+        for entry in self.library.games.entries() {
+            if let Some(slot) = present.get_mut(az_bucket_of(entry.title())) {
+                *slot = true;
+            }
+        }
+        present
+    }
+
+    /// Jump the list to the first game in a bucket, and choose it.
+    pub fn jump_to_bucket(&mut self, bucket: usize, visible: usize) {
+        let Some(at) = self
+            .library
+            .games
+            .entries()
+            .iter()
+            .position(|entry| az_bucket_of(entry.title()) == bucket)
+        else {
+            return;
+        };
+        self.select_library_game(at);
+        // The letter's first game at the top of the box rather than merely
+        // on screen: the point of the jump is to see what is under it.
+        let last_start = self.library.games.len().saturating_sub(visible);
+        self.library.scroll = at.min(last_start);
     }
 
     pub fn scroll_favourites(&mut self, delta: isize, visible: usize) {
@@ -8611,6 +8672,61 @@ mod tests {
         assert_eq!(setup.whdload_machine(), M::Auto);
         setup.cycle(F::WhdloadMachine, false);
         assert_eq!(setup.whdload_machine(), M::Copperline, "and backwards");
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
+    fn the_az_row_files_games_and_jumps_to_them() {
+        use crate::gamelib::{Game, Known, Library};
+        assert_eq!(az_label(0), "0-9");
+        assert_eq!(az_label(1), "#");
+        assert_eq!(az_label(2), "A");
+        assert_eq!(az_label(AZ_BUCKETS - 1), "Z");
+
+        // Filed by the first character of the name shown, whatever case.
+        assert_eq!(az_bucket_of("Turrican"), az_bucket_of("turrican"));
+        assert_eq!(az_bucket_of("Zool"), AZ_BUCKETS - 1);
+        assert_eq!(az_bucket_of("1943"), 0);
+        assert_eq!(az_bucket_of("+4 Bonus"), 1, "neither letter nor digit");
+        assert_eq!(az_bucket_of(""), 1, "nothing to file it under");
+
+        let named = |name: &str| {
+            Some(Game {
+                name: name.to_string(),
+                ..Game::default()
+            })
+        };
+        let known = |file: &str, name: &str| Known {
+            file: file.to_string(),
+            game: named(name),
+            manual: false,
+            slave_sha1: None,
+        };
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.library.db.set_known(vec![
+            known("a.lha", "Alien Breed"),
+            known("t1.lha", "Turrican"),
+            known("t2.lha", "Turrican II"),
+            known("z.lha", "Zool"),
+        ]);
+        state.library.games = Library::known(Path::new("/games"), &state.library.db);
+
+        let present = state.az_buckets_present();
+        assert!(present[az_bucket_of("Alien Breed")]);
+        assert!(present[az_bucket_of("Turrican")]);
+        assert!(!present[0], "no game starts with a digit");
+        assert!(!present[az_bucket_of("Xenon")], "nothing under X");
+
+        // Jumping lands on the first of that letter, and chooses it.
+        state.jump_to_bucket(az_bucket_of("Turrican"), 2);
+        let at = state.library.selected;
+        assert_eq!(state.library.games.entries()[at].title(), "Turrican");
+        assert_eq!(state.library.scroll, at, "it is put at the top of the box");
+
+        // A letter with nothing under it does nothing at all.
+        let before = state.library.selected;
+        state.jump_to_bucket(az_bucket_of("Xenon"), 2);
+        assert_eq!(state.library.selected, before);
     }
 
     #[cfg(feature = "game-library")]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5174,9 +5174,18 @@ pub fn az_label(at: usize) -> &'static str {
 }
 
 /// Which bucket a title belongs to.
+///
+/// The initial is folded to ASCII first, the same way the panel folds it
+/// to draw it: "Élite" is drawn as "Elite" and sorted among the E's, so it
+/// answers to E rather than sitting under `#` where nobody would look for
+/// it.
 #[cfg(feature = "game-library")]
 pub fn az_bucket_of(title: &str) -> usize {
-    match title.chars().next() {
+    let first = title.chars().next().map(|c| match c.is_ascii() {
+        true => c,
+        false => crate::video::font::fold(c).chars().next().unwrap_or(c),
+    });
+    match first {
         Some(c) if c.is_ascii_digit() => 0,
         Some(c) if c.is_ascii_alphabetic() => 2 + (c.to_ascii_uppercase() as usize - 'A' as usize),
         _ => 1,
@@ -5974,6 +5983,13 @@ impl LauncherState {
         // reason to walk a collection of several thousand packages. The
         // Refresh button is.
         match self.library_folder() {
+            // A store built from another folder is not this folder's list:
+            // its entries are paths under somewhere else, and showing them
+            // here offers games that are not there. Refresh is what reads
+            // the folder and makes the store this one's.
+            Some(folder) if !self.library.db.lists(&folder) => {
+                self.library.games = crate::gamelib::Library::default();
+            }
             Some(folder) if !self.library.games.covers(&folder) => {
                 self.library.games = crate::gamelib::Library::known(&folder, &self.library.db);
                 self.select_running_game();
@@ -6288,6 +6304,7 @@ impl LauncherState {
             .library
             .db
             .merge_found(crate::gamelib::scan::packages(&folder));
+        self.library.db.set_folder(&folder);
         self.save_library_database(config_dir);
         self.library.games = crate::gamelib::Library::known(&folder, &self.library.db);
         self.select_running_game();
@@ -8676,6 +8693,43 @@ mod tests {
 
     #[cfg(feature = "game-library")]
     #[test]
+    fn a_store_from_another_folder_is_not_this_folders_list() {
+        use crate::gamelib::Known;
+        // A store carrying a collection listed somewhere else -- which is
+        // what a fresh configuration pointed at a new folder meets.
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.library.db.set_known(
+            (0..40)
+                .map(|at| Known {
+                    file: format!("Old{at}.lha"),
+                    game: None,
+                    manual: false,
+                    slave_sha1: None,
+                })
+                .collect(),
+        );
+        state.library.db.set_folder(Path::new("/games/old"));
+        state.library.db_loaded = true;
+
+        // Pointed at a different folder, the page offers none of them: they
+        // are paths under somewhere else and none of them is here.
+        state
+            .setup
+            .set_path(F::WhdloadGames, PathBuf::from("/games/new"));
+        state.refresh_library(Path::new("/nonexistent"));
+        assert!(
+            state.library.games.is_empty(),
+            "another folder's games were listed as this one's"
+        );
+
+        // Once the store says it lists this folder, they are its list.
+        state.library.db.set_folder(Path::new("/games/new"));
+        state.refresh_library(Path::new("/nonexistent"));
+        assert_eq!(state.library.games.len(), 40);
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
     fn the_az_row_files_games_and_jumps_to_them() {
         use crate::gamelib::{Game, Known, Library};
         assert_eq!(az_label(0), "0-9");
@@ -8688,6 +8742,12 @@ mod tests {
         assert_eq!(az_bucket_of("Zool"), AZ_BUCKETS - 1);
         assert_eq!(az_bucket_of("1943"), 0);
         assert_eq!(az_bucket_of("+4 Bonus"), 1, "neither letter nor digit");
+        // Folded the way the panel draws it: "Élite" reads as "Elite" and
+        // sorts among the E's, so it answers to E.
+        assert_eq!(az_bucket_of("Élite"), az_bucket_of("Elite"));
+        assert_eq!(az_bucket_of("Ätzen"), az_bucket_of("Atzen"));
+        // Something with no ASCII at all still has somewhere to go.
+        assert_eq!(az_bucket_of("中"), 1);
         assert_eq!(az_bucket_of(""), 1, "nothing to file it under");
 
         let named = |name: &str| {

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -792,6 +792,9 @@ pub enum UiControl {
     /// Scroll the favourites list by that many rows.
     #[cfg(feature = "game-library")]
     LauncherLibraryFavouriteScroll(isize),
+    /// Jump the games list to the first game in that A-Z bucket.
+    #[cfg(feature = "game-library")]
+    LauncherLibraryJump(usize),
     /// Open the OpenRetro sign-in dialog.
     #[cfg(feature = "game-library")]
     LauncherOpenRetroLogin,
@@ -5079,6 +5082,101 @@ fn login_button_rects(rect: Rect) -> (Rect, Rect) {
     )
 }
 
+/// One A-Z shortcut button.
+///
+/// Its own drawer rather than [`draw_text_button`], for the hover: the lift
+/// a button's face gets is a couple of shades across seven visible pixels,
+/// which at this size is no answer to the pointer at all. Hovered, the
+/// whole face goes to the blue the chosen list row uses, so there is no
+/// mistaking which letter is under it. A letter with nothing behind it
+/// does not answer.
+#[cfg(feature = "game-library")]
+fn draw_az_button(
+    frame: &mut [u8],
+    rect: Rect,
+    label: &str,
+    live: bool,
+    hovered: bool,
+    scale: usize,
+) {
+    let scaled = scale_rect(rect, scale);
+    fill_rect(
+        frame,
+        scaled,
+        if hovered {
+            MENU_HILIGHT_BG
+        } else {
+            BUTTON_FACE
+        },
+        scale,
+    );
+    draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
+    let colour = match (live, hovered) {
+        (_, true) => MENU_HILIGHT_TEXT,
+        (true, false) => BUTTON_TEXT,
+        (false, false) => BUTTON_TEXT_DISABLED,
+    };
+    let text_w = label.chars().count() * font::GLYPH_W;
+    let x = rect.x + rect.w.saturating_sub(text_w) / 2;
+    let y = rect.y + rect.h.saturating_sub(font::GLYPH_H) / 2;
+    draw_panel_text(frame, x, y, label, colour, 1, scale);
+}
+
+/// The A-Z shortcut buttons, from just after the "Games:" label to the
+/// right edge of the list below them.
+///
+/// Each is barely wider than the character on it -- the row has to hold
+/// twenty-eight of them across the width of the list -- except the digits
+/// bucket, which carries three characters and is given the room for them.
+/// The leftover pixels are spread one apiece from the left, so the last
+/// button ends exactly on the list's right edge rather than a few pixels
+/// short of it.
+#[cfg(feature = "game-library")]
+fn library_az_rects(rect: Rect, whdload_entry: bool) -> Vec<Rect> {
+    use launcher::AZ_BUCKETS;
+    let table = library_table_rect(rect, whdload_entry);
+    let label = "Games:".len() * font::GLYPH_W;
+    let x = table.x + label + LIBRARY_AZ_GAP;
+    let width = (table.x + table.w).saturating_sub(x);
+    let wide = 3 * font::GLYPH_W + 2;
+    let narrow_count = AZ_BUCKETS - 1;
+    let narrow = width.saturating_sub(wide) / narrow_count;
+    // What the division left over, one pixel to each of the first buttons.
+    let mut spare = width.saturating_sub(wide + narrow * narrow_count);
+    let mut at = x;
+    (0..AZ_BUCKETS)
+        .map(|bucket| {
+            let mut w = if bucket == 0 { wide } else { narrow };
+            if spare > 0 {
+                w += 1;
+                spare -= 1;
+            }
+            let r = Rect {
+                x: at,
+                y: table.y.saturating_sub(15),
+                w: w.saturating_sub(1),
+                h: LIBRARY_AZ_H,
+            };
+            at += w;
+            r
+        })
+        .collect()
+}
+
+/// How many games a list needs before the A-Z row appears.
+///
+/// A short list is read rather than navigated: with a screenful or so in
+/// front of you, twenty-eight buttons to reach one of them is in the way.
+#[cfg(feature = "game-library")]
+const LIBRARY_AZ_MIN_GAMES: usize = 20;
+
+/// How far the shortcut row starts after the "Games:" label, and how tall
+/// its buttons are: the label's own line, so the row costs no height.
+#[cfg(feature = "game-library")]
+const LIBRARY_AZ_GAP: usize = 6;
+#[cfg(feature = "game-library")]
+const LIBRARY_AZ_H: usize = 11;
+
 /// The scroll arrows for a list, inside its own frame: up in the top right
 /// corner, down in the bottom right. Both Library lists use it, each with
 /// its own pair of controls.
@@ -5930,6 +6028,16 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                 return Some(control);
             }
         }
+        if state.library.games.len() >= LIBRARY_AZ_MIN_GAMES {
+            for (bucket, at) in library_az_rects(rect, whdload_entry)
+                .into_iter()
+                .enumerate()
+            {
+                if at.contains(pos) {
+                    return Some(UiControl::LauncherLibraryJump(bucket));
+                }
+            }
+        }
         let starred = state.library.db.favourite_count();
         let rows = library_favourite_rows(rect, whdload_entry);
         if starred > rows {
@@ -6028,6 +6136,19 @@ fn draw_library_page(
         state.status.as_ref().map(|s| s.kind),
         Some(launcher::StatusKind::Busy)
     );
+
+    // The shortcut row shares the label's line, so it costs no height.
+    if entries.len() >= LIBRARY_AZ_MIN_GAMES {
+        let present = state.az_buckets_present();
+        for (bucket, at) in library_az_rects(rect, whdload_entry)
+            .into_iter()
+            .enumerate()
+        {
+            let live = present.get(bucket).copied().unwrap_or(false);
+            let hovered = live && hover == Some(UiControl::LauncherLibraryJump(bucket));
+            draw_az_button(frame, at, launcher::az_label(bucket), live, hovered, scale);
+        }
+    }
 
     draw_panel_text(
         frame,
@@ -9164,6 +9285,55 @@ mod tests {
 
     #[cfg(feature = "game-library")]
     #[test]
+    fn the_az_row_appears_only_once_the_list_is_worth_indexing() {
+        use crate::gamelib::{Game, Known, Library};
+        let rect = Rect {
+            x: 0,
+            y: 0,
+            w: 716,
+            h: 581,
+        };
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::WhdloadLibrary;
+        let stock = |n: usize| {
+            (0..n)
+                .map(|at| Known {
+                    file: format!("game{at}.lha"),
+                    game: Some(Game {
+                        name: format!("Game {at}"),
+                        ..Game::default()
+                    }),
+                    manual: false,
+                    slave_sha1: None,
+                })
+                .collect::<Vec<_>>()
+        };
+        let fill = |state: &mut LauncherState, n: usize| {
+            state.library.db.set_known(stock(n));
+            state.library.games = Library::known(std::path::Path::new("/games"), &state.library.db);
+        };
+        let whdload_entry = state.setup.whdload_enabled();
+        let first = library_az_rects(rect, whdload_entry)[0];
+        let hit = |state: &LauncherState| {
+            launcher_control_at(rect, state, (first.x as i32 + 1, first.y as i32 + 1))
+        };
+
+        // A short list is read rather than indexed, so the row is not there
+        // -- and the pixels it would occupy answer to nothing.
+        fill(&mut state, LIBRARY_AZ_MIN_GAMES - 1);
+        assert_eq!(hit(&state), None, "the row is up on a short list");
+
+        // One more game and it appears.
+        fill(&mut state, LIBRARY_AZ_MIN_GAMES);
+        assert_eq!(
+            hit(&state),
+            Some(UiControl::LauncherLibraryJump(0)),
+            "the row is missing on a list long enough for it"
+        );
+    }
+
+    #[cfg(feature = "game-library")]
+    #[test]
     fn the_favourites_arrows_appear_and_its_rows_follow_the_scroll() {
         let rect = Rect {
             x: 0,
@@ -11662,6 +11832,63 @@ mod tests {
         draw(&mut frame, scale, &ui, None, None);
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "launcher-rom");
+
+        // The Library page with the A-Z shortcut row up, since that is the
+        // part whose fit across the width is worth looking at.
+        #[cfg(feature = "game-library")]
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = library_preview_state();
+            // The row appears on the size of the list, so the preview
+            // needs a list that reaches it.
+            let mut more: Vec<crate::gamelib::Known> = state.library.db.known().to_vec();
+            for (at, name) in [
+                "Agony",
+                "Battle Squadron",
+                "Deluxe Galaga",
+                "Elite",
+                "Frontier",
+                "Hired Guns",
+                "It Came from the Desert",
+                "Kick Off 2",
+                "Moonstone",
+                "North & South",
+                "Obitus",
+                "Rick Dangerous",
+                "Utopia",
+                "Walker",
+                "Xenon",
+                "Yo! Joe!",
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                more.push(crate::gamelib::Known {
+                    file: format!("filler{at}.lha"),
+                    game: Some(crate::gamelib::Game {
+                        name: name.to_string(),
+                        ..crate::gamelib::Game::default()
+                    }),
+                    manual: false,
+                    slave_sha1: None,
+                });
+            }
+            state.library.db.set_known(more);
+            state.library.games =
+                crate::gamelib::Library::known(std::path::Path::new("/games"), &state.library.db);
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            // With a letter under the pointer: the hover is the part that
+            // has to read at this size.
+            let over = launcher::az_bucket_of("Golden Axe");
+            let hover = Some(UiControl::LauncherLibraryJump(over));
+            draw(&mut frame, scale, &ui, hover, None);
+            save(&frame, "launcher-whdload-library-az");
+        }
 
         // The Library page, with WHDLoad beside it in the strip and
         // a couple of games standing in for a real folder.

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6336,6 +6336,18 @@ impl App {
                 }
             }
             #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryJump(bucket) => {
+                let whdload_entry = self
+                    .launcher_state()
+                    .is_some_and(|state| state.setup.whdload_enabled());
+                let visible = crate::video::ui::launcher_panel_rect(&self.ui)
+                    .map(|rect| crate::video::ui::library_visible_rows(rect, whdload_entry))
+                    .unwrap_or(1);
+                if let Some(state) = self.launcher_state_mut() {
+                    state.jump_to_bucket(bucket, visible);
+                }
+            }
+            #[cfg(feature = "game-library")]
             UiControl::LauncherLibraryFavouriteScroll(delta) => {
                 let whdload_entry = self
                     .launcher_state()


### PR DESCRIPTION
Off unless asked for: "A-Z shortcuts" on the WHDLoad Settings page puts a row of buttons on the "Games:" line -- a wider 0-9, then # for anything starting with neither a digit nor a letter, then the alphabet. Clicking one jumps the list to the first game filed under it and selects it, so the cover and details follow.

A button is lit only where there is something behind it, so the row says what the collection holds as well as reaching it. Hovered, the whole face goes to the blue the chosen row uses: the couple of shades a button's face normally lifts by are nothing across seven visible pixels, which is also why these have a drawer of their own.

Filed by the first character of the name shown, so what you click matches what you read: a game the scan could not name is filed under its file name, which is what the list shows for it.

<img width="1100" height="859" alt="image" src="https://github.com/user-attachments/assets/8f6da339-ee55-43e0-aeb3-f3e320b65971" />
