### PR TITLE
agnus: BPLxPT is one live counter, never reloaded at vertical blank

### DIFF
--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -39,6 +39,15 @@ raw-DDFSTRT unit rounding to preserve their 40-word rows, and the lo-res
 FMODE=3 landscape needs packed first-eight CCK plane slots instead of
 spreading those slots across the 32-CCK unit.
 
+Like SPRxPT below, each BPLxPT is one live counter: bitplane fetches
+advance it and the end-of-line modulo adds to the full pointer, carrying
+across the 16-bit register boundary, and it is never reloaded at vertical
+blank -- software rewrites the pointers each field. A BPLxPTH/PTL write
+replaces only that half of the DMA-advanced value, which programs exploit
+to flip 8-bitplane double buffers with half the Copper writes: the modulo
+is sized so the end-of-frame carry lands the high half on the next
+buffer, and only the PTL half is rewritten per frame.
+
 Agnus revisions are modelled independently of Denise (machines shipped
 mixed): OCS (8370/8371), ECS 8372A (1M chip RAM reach), ECS 8375 (2M), and
 AGA Alice (2M, HRM IDs $23/$33). VPOSR bits 8-14 report the chipset ID:

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -1205,6 +1205,15 @@ impl Bus {
             off @ 0x0E0..=0x0FF => {
                 let idx = ((off - 0x0E0) / 4) as usize;
                 if idx < if self.aga_enabled() { 8 } else { 6 } {
+                    // BPLxPT is one live counter in Agnus: bitplane DMA and
+                    // the end-of-line modulo adds advance it with carry
+                    // across the 16-bit register boundary, and a half write
+                    // replaces only that half of the advanced value. Merge
+                    // the write into the live DMA pointer, not into the
+                    // last-written latch, so software that rewrites only
+                    // BPLxPTL keeps the DMA-advanced high half (a common
+                    // Copper-bandwidth trick on 8-bitplane AGA screens).
+                    self.denise.bplpt[idx] = self.display_dma_bplpt[idx];
                     if off & 2 == 0 {
                         self.denise.set_bplpt_high(idx, val);
                     } else {

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -140,7 +140,11 @@ impl Bus {
         self.sprite_dma_frame_start_ptr = self.display_dma_sprpt;
         self.current_frame_collision_may_have_dual_playfield =
             self.current_frame_render_base.bplcon0 & 0x0400 != 0;
-        self.display_dma_bplpt = self.denise.bplpt;
+        // BPLxPT carries across the field boundary the same way: real Agnus
+        // never reloads bitplane pointers at vertical blank -- software
+        // rewrites them (fully, or half by half relying on the DMA-advanced
+        // other half) before the next display window starts. The register
+        // write path merges half writes into `display_dma_bplpt` directly.
         self.display_dma_sprpt = self.denise.sprpt;
         self.reset_display_sprite_dma_states();
         self.display_dma_clipped_rows_advanced = false;
@@ -1622,7 +1626,10 @@ impl Bus {
             fmode: self.agnus.fmode(),
             clxcon: self.denise.clxcon,
             clxcon2: self.denise.clxcon2,
-            bplpt: self.denise.bplpt,
+            // The render replay models the live BPLxPT counters, which DMA
+            // and modulo adds keep advancing; `denise.bplpt` is only the
+            // last-written latch for the debugger's register view.
+            bplpt: self.display_dma_bplpt,
             bpldat: self.denise.bpldat,
             sprpt: self.denise.sprpt,
             sprpos: self.denise.sprpos,

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -3244,6 +3244,66 @@ fn ocs_bitplane_dma_capture_extends_equal_ddf_window_to_hard_stop() {
 }
 
 #[test]
+fn bplxptl_half_write_merges_into_dma_advanced_live_pointer() {
+    // BPLxPT is one live counter in Agnus: fetches and the end-of-line
+    // modulo advance it with carry across the 16-bit register boundary,
+    // and a BPLxPTL write replaces only the low half of that advanced
+    // value. Software leans on this to flip 8-bitplane double buffers
+    // with half the Copper writes: the modulo is sized so the carry
+    // lands the high half on the next buffer, then only PTL is rewritten.
+    let mut bus = empty_bus();
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x2C;
+    bus.agnus.hpos = 0x3E;
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x2DC1;
+    bus.denise.ddfstrt = 0x0038;
+    bus.denise.ddfstop = 0x0040;
+    bus.denise.bplcon0 = 0x1000;
+    assert!(!bus.custom_write(0x0E0, 2, 0x0001)); // BPL1PTH
+    assert!(!bus.custom_write(0x0E2, 2, 0xFFF8)); // BPL1PTL
+    assert!(!bus.custom_write(0x108, 2, 0x0010)); // BPL1MOD
+
+    // Two lores words fetched (0x1FFF8 -> 0x1FFFC), then the line-end
+    // modulo add carries into the high word: 0x1FFFC + 0x10 = 0x2000C.
+    bus.advance_chipset(10);
+    assert_eq!(bus.display_dma_bplpt[0], 0x0002_000C);
+
+    // A PTL-only rewrite keeps the DMA-advanced high half, not the high
+    // half of the last register write.
+    assert!(!bus.custom_write(0x0E2, 2, 0x0100));
+    assert_eq!(bus.display_dma_bplpt[0], 0x0002_0100);
+    assert_eq!(bus.denise.bplpt[0], 0x0002_0100);
+}
+
+#[test]
+fn bitplane_pointers_carry_across_vertical_blank_without_reload() {
+    // Real Agnus never reloads BPLxPT at the top of a field: the counter
+    // keeps its end-of-frame value until software rewrites it. Snapping
+    // back to the last-written latch would break PTL-only buffer flips.
+    let mut bus = empty_bus();
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.agnus.vpos = 0x2C;
+    bus.agnus.hpos = 0x3E;
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x2DC1;
+    bus.denise.ddfstrt = 0x0038;
+    bus.denise.ddfstop = 0x0040;
+    bus.denise.bplcon0 = 0x1000;
+    assert!(!bus.custom_write(0x0E0, 2, 0x0000));
+    assert!(!bus.custom_write(0x0E2, 2, 0x0100));
+
+    bus.advance_chipset(10);
+    assert_eq!(bus.display_dma_bplpt[0], 0x0104);
+
+    // Stop bitplane DMA and run past the next vertical blank; the live
+    // pointer must survive the frame boundary untouched.
+    bus.agnus.dmacon = DMACON_DMAEN;
+    bus.advance_chipset(80_000);
+    assert_eq!(bus.display_dma_bplpt[0], 0x0104);
+}
+
+#[test]
 fn aga_lores_eight_plane_dma_capture_fetches_all_eight_streams() {
     // FMODE=0 lo-res with BPLCON0 BPU3 set: Alice schedules all eight
     // plane streams inside the eight-colour-clock fetch unit (plane 8 in
@@ -4345,6 +4405,7 @@ fn beam_timed_bitplane_pointer_changes_later_fallback_fetch_rows() {
     bus.denise.palette.write_ocs(0, 0x0000);
     bus.denise.palette.write_ocs(1, 0x0F00);
     bus.denise.bplpt[0] = 0x0100;
+    bus.display_dma_bplpt[0] = 0x0100;
     write_chip_word(&mut bus, 0x0100, 0x4000);
     write_chip_word(&mut bus, 0x0102, 0x4000);
     write_chip_word(&mut bus, 0x0200, 0x0000);
@@ -4381,6 +4442,7 @@ fn beam_timed_bitplane_pointer_changes_later_fallback_fetch_words() {
     bus.denise.palette.write_ocs(0, 0x0000);
     bus.denise.palette.write_ocs(1, 0x0F00);
     bus.denise.bplpt[0] = 0x0100;
+    bus.display_dma_bplpt[0] = 0x0100;
     write_chip_word(&mut bus, 0x0100, 0x0000);
     write_chip_word(&mut bus, 0x0102, 0x0000);
     write_chip_word(&mut bus, 0x0104, 0x4000);


### PR DESCRIPTION
## What

Real Agnus keeps a single live counter per bitplane pointer: DMA fetches advance it, the end-of-line modulo adds to the full pointer with carry across the 16-bit register boundary, and nothing reloads it at the top of a field -- software rewrites the pointers each frame. A BPLxPTH/PTL write replaces only that half of the DMA-advanced value.

Copperline instead:

1. merged BPLxPTL/PTH half writes into the last-written register latch (stale high half),
2. snapped the live DMA pointers back to that latch at every frame start, and
3. seeded the render snapshot from the latch.

## Why it matters

All three break a common Copper-bandwidth trick on 8-bitplane AGA screens: size the modulo so the end-of-frame carry lands the pointer high half on the next double buffer, then rewrite only the PTL half of each pointer per frame (8 Copper MOVEs instead of 16). Under the old model every plane fetched from a frozen address, showing a corrupted mix of both buffers that flickered as the program drew into them alternately. Regression example: an in-development AGA title doing exactly this renders correctly with the fix, verified frame-for-frame from a save state of the corrupted session.

## How

Follow the existing SPRxPT model (which already advances on fetch and survives the frame boundary): half writes merge into the live `display_dma_bplpt`, `denise.bplpt` remains only the debugger's latch view, the frame-start snap-back is removed, and `capture_render_snapshot` seeds from the live counters. `display_dma_bplpt` was already serialized, so no STATE_VERSION bump and old save states load unchanged.

## Tests

- `bplxptl_half_write_merges_into_dma_advanced_live_pointer`: fetch + modulo carry into the high word, then a PTL-only rewrite keeps the DMA-advanced high half.
- `bitplane_pointers_carry_across_vertical_blank_without_reload`: the live pointer survives the field boundary untouched.
- The two beam-timed render fallback tests now also set the live pointer they render from.
- Full suite green (2471 passed), clippy and fmt clean, all 27 golden probe renders byte-identical (titles that rewrite pointers fully each frame are unaffected).

Docs: `docs/internals/chipset.md` Agnus section documents the live-counter semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012knATf2RzEPMYWfzkJJZTc