### PR TITLE
ui: tool windows no longer block main-window Amiga input

### DIFF
--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -6,7 +6,10 @@ tool window alongside the emulated display. Closing it restores the pause
 state from before it opened. The debugger, frame analyzer, and the
 command-line [console](console) are independent tool windows, so all three
 can stay open while you compare CPU/chipset state with the captured bus
-trace.
+trace. Each takes its keys and clicks through its own window, and the main
+window keeps driving the Amiga: press **Run** and you can play the machine
+-- keyboard, mouse, and mouse capture included -- while the tool windows
+watch it.
 Everything the debugger shows comes from
 side-effect-free peeks -- inspecting memory or registers never disturbs the
 emulated machine -- and stepping drives the same cycle-exact core as normal
@@ -236,8 +239,9 @@ bit `$4000` set, after ten earlier qualifying passes.
 | &lt; Step | -- | Step one instruction *backward* (see [](reverse)) |
 | &lt; Run | -- | Run *backward* to the previous breakpoint hit |
 
-The `R`/`S`/`O`/`U`/`F`/`L` keys work whenever the box is unfocused (while it
-is focused they are text input). **Run to $**, **Step Over**, **Step Out**,
+The `R`/`S`/`O`/`U`/`F`/`L` keys act while the debugger window has the focus
+and the box is unfocused (while it is focused they are text input); in the
+main window those keys belong to the Amiga. **Run to $**, **Step Over**, **Step Out**,
 and **Line** are bounded by an instruction budget so a never-returning call
 or never-reached address cannot wedge the UI; if the budget runs out, the
 debugger stays paused. Step Out detects the return by the stack pointer

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -35,7 +35,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off |
 | `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Cmd+Z` | `Alt+Z` | Rewind the machine one step (needs `[emulation] rewind` or *Emulation Settings > Rewind*) |
-| `Esc` | `Esc` | Close an open menu, tool window, or overlay panel; otherwise passed through to the Amiga |
+| `Esc` | `Esc` | Close an open menu or overlay panel (in a tool window, that window); otherwise passed through to the Amiga |
 | `Ctrl+Amiga+Amiga` | `Ctrl+Amiga+Amiga` | Keyboard reset (warm reboot) |
 
 Host modifiers that are passed through to the emulated keyboard map onto
@@ -243,10 +243,14 @@ start-up size is `[display] menu_scale`, `--menu-scale`, or *Menu size* on
 the launcher's A/V & Emu page (Video category).
 
 Tool windows are separate native windows so the emulated display remains visible;
-the debugger and frame analyzer can be open at the same time. Overlay panels
-are drawn over the display. While either kind is open, key presses and display
-clicks stay in the UI instead of reaching the Amiga; `Esc` closes the focused
-tool window or overlay.
+the debugger and frame analyzer can be open at the same time. They take their
+keys and clicks through their own windows, and the main window keeps driving
+the Amiga while they are open -- resume the machine from the debugger and you
+can play on while watching it. Overlay panels are drawn over the display and
+*are* modal: while one is open, key presses and display clicks stay in the UI
+instead of reaching the Amiga. `Esc` in a tool window closes that window;
+`Esc` in the main window closes the menu or overlay panel, and otherwise
+belongs to the Amiga.
 
 ### Tools
 
@@ -816,13 +820,15 @@ the guest is the first one aimed at it -- otherwise a single click on a
 gadget arrives as two, close enough together to read as a double click.
 
 While an overlay panel is open, host cursor motion is not fed to the
-emulated mouse. Tool windows likewise keep the debugger or analyzer
-interaction separate from Amiga mouse input. A panel or tool window
-opened while the mouse was captured borrows the cursor and hands the
-capture back when the last of them closes, so a visit to the debugger
-does not leave the machine uncaptured -- which matters most in
-fullscreen, where there is no desktop to reach for. An explicit
-`Cmd/Alt+G` release settles it the other way: the capture stays off.
+emulated mouse. Tool windows are not modal that way: with the debugger
+or analyzer open, motion and clicks over the main window's display still
+drive the Amiga, and the capture click and shortcut work as usual. A
+panel or tool window opened while the mouse was captured borrows the
+cursor and hands the capture back when the last of them closes, so a
+visit to the debugger does not leave the machine uncaptured -- which
+matters most in fullscreen, where there is no desktop to reach for. An
+explicit `Cmd/Alt+G` release settles it the other way: the capture
+stays off.
 
 Uncaptured, host cursor motion over the display still drives the
 emulated mouse, and `[input] mouse_sensitivity` scales it the same way

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4476,7 +4476,7 @@ impl App {
     }
 
     /// Take the grab if `[input] mouse_capture = "auto"` and the moment is
-    /// right for it: the window holds the focus, nothing modal wants the
+    /// right for it: the window holds the focus, nothing else wants the
     /// cursor, and there is a mouse on a port to drive.
     ///
     /// Deliberately driven by discrete events (focus gain, entering
@@ -4487,7 +4487,7 @@ impl App {
         if self.mouse_capture != crate::config::MouseCapture::Auto
             || self.mouse_captured
             || !self.main_window_focused
-            || self.modal_ui_active()
+            || self.ui_wants_cursor()
             || self.mouse_port().is_none()
         {
             return;
@@ -4504,11 +4504,11 @@ impl App {
         }
     }
 
-    /// Re-take a capture the UI borrowed, once no modal UI still wants the
+    /// Re-take a capture the UI borrowed, once nothing still wants the
     /// cursor. A no-op unless `suspend_mouse_capture_for_ui` recorded one,
     /// so a session that was never captured is never surprised by a grab.
     fn restore_mouse_capture_after_ui(&mut self) {
-        if !self.capture_suspended_by_ui || self.modal_ui_active() {
+        if !self.capture_suspended_by_ui || self.ui_wants_cursor() {
             return;
         }
         // Same guard the click-to-capture path applies: with no mouse left
@@ -4868,9 +4868,6 @@ impl App {
     }
 
     fn main_ui_control_at(&self, pos: (i32, i32)) -> Option<UiControl> {
-        if self.ui.panel.is_none() && self.tool_panel_open() && !self.ui.menu_open {
-            return None;
-        }
         self.ui.control_at(pos)
     }
 
@@ -4883,12 +4880,26 @@ impl App {
             != current.and_then(|pos| self.main_ui_control_at(pos))
     }
 
-    fn tool_panel_open(&self) -> bool {
-        self.debugger_panel.is_some() || self.frame_analyzer_panel.is_some()
+    /// Whether main-window UI is claiming the keyboard and pointer: the
+    /// menu, or an overlay panel drawn over the display. The debugger,
+    /// frame analyzer, and console are separate tool windows with their
+    /// own event routing, so they are deliberately not modal here -- while
+    /// one is open (even mid-run), the main window keeps driving the Amiga.
+    fn modal_ui_active(&self) -> bool {
+        self.ui.active()
     }
 
-    fn modal_ui_active(&self) -> bool {
-        self.ui.active() || self.tool_panel_open()
+    /// Whether any UI surface has a claim on the host cursor: main-window
+    /// UI, or an open tool window. Tool windows are not modal over the
+    /// main window's input, but an automatic grab taken while one is open
+    /// would trap the cursor its controls need, so the auto-capture paths
+    /// wait until the last of them closes. An explicit capture (a display
+    /// click or the shortcut) is always honoured.
+    fn ui_wants_cursor(&self) -> bool {
+        self.ui.active()
+            || ToolPanelKind::ALL
+                .into_iter()
+                .any(|kind| self.tool_panel_is_open(kind))
     }
 
     fn tool_window(&self, kind: ToolPanelKind) -> Option<&ToolWindow> {
@@ -6909,10 +6920,11 @@ impl App {
             if self.library_handle_key(code) {
                 return true;
             }
-            return false;
         }
-        self.default_tool_key_kind()
-            .is_some_and(|kind| self.ui_handle_tool_key(kind, code))
+        // Tool panels (debugger, frame analyzer, console) take their keys
+        // through their own windows' events, never from the main window:
+        // an unclaimed key here belongs to the Amiga.
+        false
     }
 
     /// Type into the sign-in dialog, and answer it.
@@ -7178,16 +7190,6 @@ impl App {
             self.request_redraw();
         }
         handled
-    }
-
-    fn default_tool_key_kind(&self) -> Option<ToolPanelKind> {
-        if self.debugger_panel.is_some() {
-            Some(ToolPanelKind::Debugger)
-        } else if self.frame_analyzer_panel.is_some() {
-            Some(ToolPanelKind::FrameAnalyzer)
-        } else {
-            None
-        }
     }
 
     fn ui_handle_tool_key(&mut self, kind: ToolPanelKind, code: KeyCode) -> bool {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4938,7 +4938,8 @@ fn modal_panel_swallows_amiga_key_presses() {
     assert!(app.ui_handle_key(KeyCode::Escape, None));
     assert!(app.ui.panel.is_none());
 
-    // Hex entry: digits accumulate, Enter commits to the memory view.
+    // Hex entry arrives through the debugger's own tool window: digits
+    // accumulate, Enter commits to the memory view.
     app.open_debugger();
     if let Some(panel) = app.debugger_panel.as_mut() {
         panel.entry_active = true;
@@ -4950,9 +4951,9 @@ fn modal_panel_swallows_amiga_key_presses() {
         KeyCode::Digit0,
         KeyCode::Digit1,
     ] {
-        assert!(app.ui_handle_key(key, None));
+        assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, key));
     }
-    assert!(app.ui_handle_key(KeyCode::Enter, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::Enter));
     match app.debugger_panel.as_ref() {
         Some(panel) => {
             assert_eq!(panel.entry, "C001");
@@ -4961,6 +4962,42 @@ fn modal_panel_swallows_amiga_key_presses() {
         }
         _ => panic!("debugger panel should be open"),
     }
+}
+
+/// The debugger and frame analyzer live in their own tool windows, so an
+/// open one must not swallow the main window's input: keys, pointer
+/// motion, and clicks keep driving the Amiga while the machine runs
+/// under them. Each window's own Escape closes it; a main-window Escape
+/// belongs to the Amiga.
+#[test]
+fn tool_windows_are_not_modal_over_the_main_window() {
+    let mut app = test_app();
+    app.open_debugger();
+    app.open_frame_analyzer();
+    assert!(
+        !app.modal_ui_active(),
+        "tool panels must not gate main-window Amiga input"
+    );
+    assert!(
+        !app.ui_handle_key(KeyCode::KeyS, None),
+        "a main-window key is not claimed by a tool panel"
+    );
+    assert!(
+        !app.ui_handle_key(KeyCode::Escape, None),
+        "a main-window Escape reaches the Amiga"
+    );
+    assert!(app.debugger_panel.is_some());
+    assert!(app.frame_analyzer_panel.is_some());
+
+    // Both windows still borrow the cursor: an automatic re-grab while
+    // one is open would trap the pointer its controls need.
+    assert!(app.ui_wants_cursor());
+
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::Escape));
+    assert!(app.frame_analyzer_panel.is_none());
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::Escape));
+    assert!(app.debugger_panel.is_none());
+    assert!(!app.ui_wants_cursor());
 }
 
 #[test]
@@ -4977,8 +5014,8 @@ fn frame_analyzer_cursor_keys_move_selected_slot() {
         _ => panic!("frame analyzer panel should be open"),
     };
 
-    assert!(app.ui_handle_key(KeyCode::ArrowRight, None));
-    assert!(app.ui_handle_key(KeyCode::ArrowDown, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowRight));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowDown));
     match app.frame_analyzer_panel.as_ref() {
         Some(panel) => {
             assert_eq!(panel.selected_hpos, start_hpos + 1);
@@ -4987,8 +5024,8 @@ fn frame_analyzer_cursor_keys_move_selected_slot() {
         _ => panic!("frame analyzer panel should be open"),
     }
 
-    assert!(app.ui_handle_key(KeyCode::ArrowLeft, None));
-    assert!(app.ui_handle_key(KeyCode::ArrowUp, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowLeft));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowUp));
     match app.frame_analyzer_panel.as_ref() {
         Some(panel) => {
             assert_eq!(panel.selected_hpos, start_hpos);
@@ -5001,8 +5038,8 @@ fn frame_analyzer_cursor_keys_move_selected_slot() {
         panel.selected_hpos = 0;
         panel.selected_vpos = 0;
     }
-    assert!(app.ui_handle_key(KeyCode::ArrowLeft, None));
-    assert!(app.ui_handle_key(KeyCode::ArrowUp, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowLeft));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowUp));
     match app.frame_analyzer_panel.as_ref() {
         Some(panel) => {
             assert_eq!(panel.selected_hpos, 0);
@@ -5026,8 +5063,8 @@ fn frame_analyzer_cursor_keys_move_selected_slot() {
         panel.selected_hpos = max_hpos;
         panel.selected_vpos = max_vpos;
     }
-    assert!(app.ui_handle_key(KeyCode::ArrowRight, None));
-    assert!(app.ui_handle_key(KeyCode::ArrowDown, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowRight));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowDown));
     match app.frame_analyzer_panel.as_ref() {
         Some(panel) => {
             assert_eq!(panel.selected_hpos, max_hpos);
@@ -5051,7 +5088,7 @@ fn frame_analyzer_underlay_toggles_and_renders() {
     assert!(app.build_frame_analyzer_view(&panel).underlay.is_none());
 
     // The U key ticks the checkbox on.
-    assert!(app.ui_handle_key(KeyCode::KeyU, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::KeyU));
     assert!(app
         .frame_analyzer_panel
         .as_ref()
@@ -6289,14 +6326,14 @@ fn debugger_keys_step_and_pin_disassembly() {
 
     // S steps one instruction while the entry box is unfocused.
     let pc_before = app.emu.machine.pc();
-    assert!(app.ui_handle_key(KeyCode::KeyS, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::KeyS));
     assert_eq!(app.emu.machine.pc(), pc_before.wrapping_add(2));
 
     // R toggles run; the explicit choice survives closing the panel.
     assert!(app.paused);
-    assert!(app.ui_handle_key(KeyCode::KeyR, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::KeyR));
     assert!(!app.paused);
-    assert!(app.ui_handle_key(KeyCode::KeyR, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::KeyR));
     assert!(app.paused);
 
     // On the CPU tab, Enter pins the disassembly origin to the typed
@@ -6305,7 +6342,7 @@ fn debugger_keys_step_and_pin_disassembly() {
         panel.entry_active = true;
         panel.entry = "FC0010".to_string();
     }
-    assert!(app.ui_handle_key(KeyCode::Enter, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::Enter));
     match app.debugger_panel.as_ref() {
         Some(panel) => {
             assert_eq!(panel.disasm_addr, Some(0xFC0010));
@@ -6319,7 +6356,7 @@ fn debugger_keys_step_and_pin_disassembly() {
         panel.entry_active = true;
         panel.entry.clear();
     }
-    assert!(app.ui_handle_key(KeyCode::Enter, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::Enter));
     match app.debugger_panel.as_ref() {
         Some(panel) => assert_eq!(panel.disasm_addr, None),
         _ => panic!("debugger panel should be open"),
@@ -6332,7 +6369,7 @@ fn debugger_keys_step_and_pin_disassembly() {
         panel.entry.clear();
     }
     let pc_before = app.emu.machine.pc();
-    assert!(app.ui_handle_key(KeyCode::KeyS, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::Debugger, KeyCode::KeyS));
     assert_eq!(app.emu.machine.pc(), pc_before);
     assert_eq!(
         app.debugger_panel.as_ref().map(|p| p.entry.as_str()),
@@ -7496,14 +7533,14 @@ fn frame_analyzer_m_key_toggles_between_the_beam_and_memory_tabs() {
     let tab = |app: &super::App| app.frame_analyzer_panel.as_ref().map(|panel| panel.tab);
     assert_eq!(tab(&app), Some(AnalyzerTab::Beam));
 
-    assert!(app.ui_handle_key(KeyCode::KeyM, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::KeyM));
     assert_eq!(tab(&app), Some(AnalyzerTab::Memory));
     assert!(
         app.emu.bus().heat_map().is_some(),
         "arriving on the Memory tab arms the map"
     );
 
-    assert!(app.ui_handle_key(KeyCode::KeyM, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::KeyM));
     assert_eq!(tab(&app), Some(AnalyzerTab::Beam));
 }
 
@@ -7528,21 +7565,21 @@ fn frame_analyzer_cursor_keys_move_the_pinned_cell_on_the_memory_tab() {
     // With nothing pinned the first arrow starts from the centre cell, and
     // the beam selection the Beam tab owns is left where it was.
     let centre = heatmap::CELLS / 2 + heatmap::GRID / 2;
-    assert!(app.ui_handle_key(KeyCode::ArrowRight, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowRight));
     assert_eq!(pinned(&app), Some(centre + 1));
-    assert!(app.ui_handle_key(KeyCode::ArrowDown, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowDown));
     assert_eq!(pinned(&app), Some(centre + 1 + heatmap::GRID));
     assert_eq!(beam_slot(&app), slot_before);
 
     // The grid's edges clamp: the selection never wraps into the next row.
     app.activate_ui_control(UiControl::AnalyzerHeatPick { x: 0, y: 0 });
-    assert!(app.ui_handle_key(KeyCode::ArrowLeft, None));
-    assert!(app.ui_handle_key(KeyCode::ArrowUp, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowLeft));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowUp));
     assert_eq!(pinned(&app), Some(0));
     let last = (heatmap::GRID - 1) as u8;
     app.activate_ui_control(UiControl::AnalyzerHeatPick { x: last, y: last });
-    assert!(app.ui_handle_key(KeyCode::ArrowRight, None));
-    assert!(app.ui_handle_key(KeyCode::ArrowDown, None));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowRight));
+    assert!(app.ui_handle_tool_key(ToolPanelKind::FrameAnalyzer, KeyCode::ArrowDown));
     assert_eq!(pinned(&app), Some(heatmap::CELLS - 1));
 }
 


### PR DESCRIPTION
## Problem

With the debugger or frame analyzer open and the machine running, the main window could not control the Amiga: key presses were dropped before reaching the emulated keyboard, uncaptured cursor motion and display clicks were swallowed, and the Cmd/Alt+G capture toggle was refused.

The "open panels are modal" input gating predates the tool-window split: it was correct when these panels rendered as overlays inside the main window, but they have been independent native windows with their own event routing since then. The console was already excluded from the modal gate; the debugger and frame analyzer never got the same treatment.

## Change

Input gating is split into two predicates in `src/video/window.rs`:

- `modal_ui_active()` now covers only genuine main-window UI (the menu and overlay panels) and gates Amiga-bound input. Tool panels are deliberately not counted, so with the debugger or frame analyzer open, keyboard, mouse motion, clicks, and mouse capture all drive the Amiga -- press Run in the debugger and you can play the machine while the tool windows watch it.
- `ui_wants_cursor()` additionally counts open tool windows (console included) and gates only the automatic capture paths (`apply_auto_mouse_capture`, `restore_mouse_capture_after_ui`). A capture borrowed when a tool window opened is still repaid only when the last one closes, and no automatic grab traps the cursor a tool window's controls need. Explicit captures (a display click or the shortcut) always work.

Main-window keys are no longer forwarded into tool panels (`default_tool_key_kind` removed): each tool window takes its keys through its own window events. The debugger's transport keys act when that window has focus, and a main-window Escape goes to the Amiga instead of closing a tool window.

## Tests and docs

- New regression test `tool_windows_are_not_modal_over_the_main_window`.
- Existing debugger/frame-analyzer key tests switched to `ui_handle_tool_key`, the path a tool window's own key events take (matching the existing console tests).
- `docs/guide/ui.md` and `docs/debugger/window.md` updated to describe the non-modal tool windows, the Esc routing, and the capture behaviour.

Full unit suite passes (2472 tests); clippy and rustfmt clean.